### PR TITLE
Fix Nemotron rerank E2E comparison

### DIFF
--- a/src/runtime/pipelines/encoder_pipeline.cpp
+++ b/src/runtime/pipelines/encoder_pipeline.cpp
@@ -100,7 +100,9 @@ EmbeddingResult EncoderPipeline::encode(const std::string& text) {
 float EncoderPipeline::rerank(const std::string& query, const std::string& document) {
     if (!tokenizer_)
         throw std::runtime_error("EncoderPipeline: no tokenizer configured");
-    std::string combined = query + " [SEP] " + document;
+    // Match the text-only reranking template documented by the supported
+    // Nemotron rerank cross-encoder model card.
+    std::string combined = "question:" + query + "   passage:" + document;
     auto ids = tokenizer_->encode(combined);
     auto result = encode_ids(ids);
     return result.data.empty() ? 0.0f : result.data[0];

--- a/tests/cpp/test_encoder_pipeline.cpp
+++ b/tests/cpp/test_encoder_pipeline.cpp
@@ -441,7 +441,7 @@ static void test_encoder_rerank() {
     auto tokenizer = std::make_shared<FixedTokenizer>();
     trtmc::EncoderPipeline pipeline(std::move(module), "rerank", tokenizer);
 
-    // rerank() concatenates query + " [SEP] " + document, encodes, returns data[0]
+    // rerank() applies the supported cross-encoder text template and returns data[0]
     float score = pipeline.rerank("query", "doc");
     // Score is a float (from engine constant output = 0.1f at index 0)
     check(score >= -1e6f && score <= 1e6f, "rerank: returns a finite float");

--- a/tests/e2e/models/nemotron-rerank-vl-1b-v2.json
+++ b/tests/e2e/models/nemotron-rerank-vl-1b-v2.json
@@ -5,15 +5,26 @@
   "bundle": "nemotron-rerank-vl-1b-v2.trtfb",
   "family": "eagle_vlm",
   "runtime_strategy": "reranking",
+  "reference_family": "vl_rerank",
+  "user_contract": "ranking_order",
   "max_cache_length": 256,
   "inputs": {
-    "prompt": "What is the capital of France?",
-    "document": "Paris is the capital and most populous city of France."
+    "prompt": "Which planet is known as the Red Planet?",
+    "documents": [
+      "Venus is often called Earth's twin because of its similar size and proximity.",
+      "Mars, known for its reddish appearance, is often referred to as the Red Planet.",
+      "Jupiter, the largest planet in our solar system, has a prominent red spot.",
+      "Saturn, famous for its rings, is sometimes mistaken for the Red Planet."
+    ]
   },
-  "prompt": "What is the capital of France?",
   "max_new_tokens": 1,
   "logit_atol": 0.001,
   "layer_atol": 0.05,
   "trust_remote_code": true,
-  "skip_comparison": "trtmc rerank returns a single (prompt, document) relevance score while the HF AutoModelForSequenceClassification reference returns a logits list — the harness has no comparator for that shape yet, so TRT runs but comparison is skipped"
+  "threshold_overrides": {
+    "contract_ranking_agreement": 1.0,
+    "pairwise_ordering_agreement": 1.0,
+    "kendall_tau": 1.0,
+    "spearman_rho": 1.0
+  }
 }

--- a/tests/e2e_harness/references/hf_transformers.py
+++ b/tests/e2e_harness/references/hf_transformers.py
@@ -606,37 +606,76 @@ class HfTransformersReference:
     def _run_reranking_ref(
         self, case: E2ECase, stage: StageSpec, ctx: RunContext
     ) -> StageOutput:
-        """Run HF model for reranking and return scores."""
+        """Run HF cross-encoder reranking and return one score per document."""
         artifacts_dir = ctx.artifacts_dir or tempfile.gettempdir()
         model_dir = _case_artifact_dir(artifacts_dir, case.name) if ctx.artifacts_dir else artifacts_dir
         output_path = str(Path(model_dir) / "hf_rerank.json")
 
         prompt = case.inputs.get("prompt", "query: test")
+        documents = case.inputs.get("documents")
+        if documents is None:
+            document = case.inputs.get("document", "")
+            documents = [document] if document else []
         trust_remote_code = case.metadata.get("trust_remote_code", False)
         hf_id = case.hf_id
+        model_ref = _resolve_cached_model_ref(hf_id)
         torch_dtype_expr = _torch_dtype_for_case(case)
 
         script = textwrap.dedent(f"""\
             import json, torch
-            from transformers import AutoModelForSequenceClassification, AutoTokenizer
+            from transformers import AutoModelForSequenceClassification, AutoProcessor, AutoTokenizer
 
             hf_id = {hf_id!r}
+            model_ref = {model_ref!r}
             prompt = {prompt!r}
+            documents = {documents!r}
             trust_remote_code = {trust_remote_code!r}
             output_path = {output_path!r}
+            torch_dtype = {torch_dtype_expr}
 
-            tokenizer = AutoTokenizer.from_pretrained(
-                hf_id, trust_remote_code=trust_remote_code)
             model = AutoModelForSequenceClassification.from_pretrained(
-                hf_id, trust_remote_code=trust_remote_code,
-                torch_dtype={torch_dtype_expr})
+                model_ref, trust_remote_code=trust_remote_code,
+                torch_dtype=torch_dtype)
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            model.to(device)
             model.eval()
 
-            inputs = tokenizer(prompt, return_tensors="pt", padding=True,
-                               truncation=True)
+            examples = [
+                {{"question": prompt, "doc_text": doc, "doc_image": ""}}
+                for doc in documents
+            ]
+
+            try:
+                processor = AutoProcessor.from_pretrained(
+                    model_ref, trust_remote_code=trust_remote_code,
+                    max_input_tiles=6, use_thumbnail=True,
+                    rerank_max_length=8192)
+                if not hasattr(processor, "process_queries_documents_crossencoder"):
+                    raise AttributeError("processor has no cross-encoder helper")
+                inputs = processor.process_queries_documents_crossencoder(examples)
+            except Exception:
+                tokenizer = AutoTokenizer.from_pretrained(
+                    model_ref, trust_remote_code=trust_remote_code)
+                texts = [
+                    f"question:{{prompt}}   passage:{{doc}}"
+                    for doc in documents
+                ]
+                inputs = tokenizer(
+                    texts, return_tensors="pt", padding=True, truncation=True)
+
+            inputs = {{
+                key: value.to(device) if hasattr(value, "to") else value
+                for key, value in inputs.items()
+            }}
             with torch.no_grad():
                 outputs = model(**inputs)
-            scores = outputs.logits[0].float().cpu().tolist()
+            logits = outputs.logits.detach().float().cpu()
+            if logits.ndim == 2 and logits.shape[-1] == 1:
+                scores = logits[:, 0].tolist()
+            elif logits.ndim == 2:
+                scores = logits[:, -1].tolist()
+            else:
+                scores = logits.reshape(-1).tolist()
             result = {{"scores": scores}}
             with open(output_path, "w") as f:
                 json.dump(result, f)

--- a/tests/e2e_harness/runners/reranking.py
+++ b/tests/e2e_harness/runners/reranking.py
@@ -1,9 +1,8 @@
 """Reranking strategy runner — TRT inference for reranking models.
 
-Runs the C++ binary with ``trtmc rerank`` to produce a relevance score for a
-single (prompt, document) pair. The binary prints ``Relevance score: <float>``
-on stdout; this runner parses that single score and wraps it as a one-element
-``scores`` list so the reranking comparator contract is satisfied.
+Runs the C++ binary with ``trtmc rerank`` to produce relevance scores for one
+or more query/document pairs. The binary prints ``Relevance score: <float>``
+on stdout; this runner parses each score and returns them in manifest order.
 """
 
 from __future__ import annotations
@@ -13,6 +12,7 @@ import os
 import re
 import subprocess
 import time
+from typing import Any
 
 from .. import save_full_stderr
 from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
@@ -34,57 +34,81 @@ class RerankingRunner:
     ) -> StageOutput:
         bundle_path = os.path.join(ctx.engine_dir, case.bundle)
         prompt = case.inputs.get("prompt", "")
-        document = case.inputs.get("document", "")
+        documents = _documents_from_inputs(case.inputs)
 
-        if not prompt or not document:
+        if not prompt or not documents:
             raise ValueError(
-                "Reranking requires both 'prompt' and 'document' in "
+                "Reranking requires 'prompt' and at least one document in "
                 f"manifest inputs (case={case.name!r})"
             )
 
-        cmd = [
-            ctx.binary_path, "rerank", bundle_path,
-            "--prompt", prompt,
-            "--document", document,
-        ]
-
         runtime_cli_python = ctx.runtime_cli_hf_python()
-        if runtime_cli_python:
-            cmd.extend(["--hf-python", runtime_cli_python])
 
         env = dict(os.environ)
         if ctx.ld_library_path:
             env["LD_LIBRARY_PATH"] = ctx.ld_library_path
 
-        logger.info("Running reranking: %s", " ".join(cmd))
+        scores: list[float] = []
+        commands: list[list[str]] = []
+        stdout_by_document: list[str] = []
+        stderr_by_document: list[str] = []
+        command_metadata: list[dict[str, Any]] = []
         t0 = time.monotonic()
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, env=env, timeout=600,
-        )
-        elapsed = time.monotonic() - t0
 
-        if result.returncode != 0:
-            truncated, log_path = save_full_stderr(
-                result.stderr, ctx.artifacts_dir or "",
-                "reranking", case.name)
-            msg = (f"Reranking inference failed (rc={result.returncode}): "
-                   f"{truncated}")
-            if log_path:
-                msg += f" (full stderr: {log_path})"
-            raise RuntimeError(msg)
+        for index, document in enumerate(documents):
+            cmd = [
+                ctx.binary_path, "rerank", bundle_path,
+                "--prompt", prompt,
+                "--document", document,
+            ]
+            if runtime_cli_python:
+                cmd.extend(["--hf-python", runtime_cli_python])
 
-        score = _parse_score(result.stdout)
-
-        return StageOutput(
-            stage_name=stage.name,
-            data={"scores": [score]},
-            timing_s=elapsed,
-            metadata={
+            logger.info("Running reranking document %d: %s", index, " ".join(cmd))
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, env=env, timeout=600,
+            )
+            commands.append(cmd)
+            stdout_by_document.append(result.stdout or "")
+            stderr_by_document.append(result.stderr or "")
+            command_metadata.append({
                 "command": cmd,
                 "returncode": result.returncode,
                 "stdout": result.stdout or "",
                 "stderr": result.stderr or "",
-            },
+            })
+
+            if result.returncode != 0:
+                truncated, log_path = save_full_stderr(
+                    result.stderr, ctx.artifacts_dir or "",
+                    f"reranking_doc_{index}", case.name)
+                msg = (
+                    f"Reranking inference failed for document {index} "
+                    f"(rc={result.returncode}): {truncated}"
+                )
+                if log_path:
+                    msg += f" (full stderr: {log_path})"
+                raise RuntimeError(msg)
+
+            scores.append(_parse_score(result.stdout))
+
+        elapsed = time.monotonic() - t0
+        metadata: dict[str, Any] = {
+            "commands": commands,
+            "stdout_by_document": stdout_by_document,
+            "stderr_by_document": stderr_by_document,
+            "document_count": len(documents),
+        }
+        for index, doc_meta in enumerate(command_metadata):
+            metadata[f"document_{index}"] = doc_meta
+        if len(commands) == 1:
+            metadata.update(command_metadata[0])
+
+        return StageOutput(
+            stage_name=stage.name,
+            data={"scores": scores, "documents": documents},
+            timing_s=elapsed,
+            metadata=metadata,
         )
 
 
@@ -104,6 +128,17 @@ def _parse_score(stdout: str) -> float:
             continue
 
     raise ValueError(f"Could not parse relevance score from output: {stdout[:500]}")
+
+
+def _documents_from_inputs(inputs: dict[str, Any]) -> list[str]:
+    documents = inputs.get("documents")
+    if documents is not None:
+        if not isinstance(documents, list):
+            raise TypeError("Reranking 'documents' input must be a list")
+        return [str(doc) for doc in documents if str(doc)]
+
+    document = inputs.get("document", "")
+    return [str(document)] if str(document) else []
 
 
 plugin = RerankingRunner()

--- a/tests/tools/test_reranking_runner.py
+++ b/tests/tools/test_reranking_runner.py
@@ -1,0 +1,68 @@
+"""Tests for the E2E reranking runner."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tests.e2e_harness.contracts import E2ECase, RunContext, StageSpec
+from tests.e2e_harness.runners.reranking import (
+    RerankingRunner,
+    _documents_from_inputs,
+)
+
+
+def _case(inputs: dict) -> E2ECase:
+    return E2ECase(
+        name="rerank-test",
+        hf_id="org/reranker",
+        family="eagle_vlm",
+        runtime_strategy="reranking",
+        bundle="rerank.trtfb",
+        inputs=inputs,
+    )
+
+
+def test_documents_from_inputs_prefers_document_list() -> None:
+    docs = _documents_from_inputs({
+        "document": "legacy",
+        "documents": ["first", "second"],
+    })
+
+    assert docs == ["first", "second"]
+
+
+def test_documents_from_inputs_rejects_non_list_documents() -> None:
+    with pytest.raises(TypeError, match="documents"):
+        _documents_from_inputs({"documents": "not-a-list"})
+
+
+def test_runner_scores_each_manifest_document(monkeypatch, tmp_path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **_kwargs):  # noqa: ANN001
+        calls.append(cmd)
+        idx = len(calls)
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout=f"Relevance score: {idx * 0.25}", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    case = _case({
+        "prompt": "Which planet is known as the Red Planet?",
+        "documents": ["Venus text", "Mars text", "Jupiter text"],
+    })
+    ctx = RunContext(
+        case=case,
+        binary_path="/bin/trtmc",
+        engine_dir=str(tmp_path),
+    )
+
+    output = RerankingRunner().run_stage(case, StageSpec("full_inference"), ctx)
+
+    assert output.data["scores"] == [0.25, 0.5, 0.75]
+    assert output.data["documents"] == ["Venus text", "Mars text", "Jupiter text"]
+    assert [cmd[6] for cmd in calls] == ["Venus text", "Mars text", "Jupiter text"]
+    assert output.metadata["document_count"] == 3
+    assert output.metadata["document_1"]["stdout"] == "Relevance score: 0.5"


### PR DESCRIPTION
## Summary
- replace the Nemotron rerank skip-comparison path with the model-card query/passages and a real HF cross-encoder reference
- run TRT rerank over each document and compare the resulting score ordering
- align the runtime text template with the supported text-only rerank template and add focused runner coverage

## Validation
- python3 -m pytest tests/tools/test_reranking_runner.py -q
- RUFF_CACHE_DIR=/tmp/ruff-cache-trtmc python3 -m ruff check tests/e2e_harness/runners/reranking.py tests/e2e_harness/references/hf_transformers.py tests/tools/test_reranking_runner.py
- PYTHONPATH=tensorrt_model_connect python3 - <<'PY'
from tests.e2e_harness.manifest_loader import load_manifest
case = load_manifest('tests/e2e/models/nemotron-rerank-vl-1b-v2.json')
print(case.name, case.task_strategy, case.reference_backend, case.reference_family, case.user_contract)
print(len(case.inputs['documents']), case.metadata.get('skip_comparison_reason'))
PY

Local C++/focused E2E validation is blocked in this workspace because trtf-dev-gb300-agent-4 is not running and the existing build tree is not writable by this user.