### PR TITLE
Fix DPR context encoder E2E contract

### DIFF
--- a/tensorrt_model_connect/tensorrt_model_connect/encoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/encoder_builder.py
@@ -37,6 +37,7 @@ def build_encoder_engine(
     weights: WeightDict,
     max_seq_length: int,
     *,
+    output_pooler: bool = False,
     verbose: bool = False,
 ) -> bytes:
     """Build a TRT engine plan for a BERT-style encoder.
@@ -45,6 +46,9 @@ def build_encoder_engine(
         config: Model architecture from config.json.
         weights: Loaded weight dict from BERT plugin.
         max_seq_length: Maximum sequence length the engine is compiled for.
+        output_pooler: Mark the BERT-style pooler output instead of the full
+            hidden-state matrix. This matches DPRContextEncoder's public
+            embedding contract.
         verbose: Print TRT builder logs.
 
     Returns:
@@ -189,7 +193,12 @@ def build_encoder_engine(
     # -------------------------------------------------------------------
     # Output
     # -------------------------------------------------------------------
-    hidden_state.name = "hidden_states"
+    if output_pooler:
+        hidden_state = _add_pooler_output(
+            network, hidden_state, hidden, weights)
+        hidden_state.name = "pooler_output"
+    else:
+        hidden_state.name = "hidden_states"
     network.mark_output(hidden_state)
 
     # -------------------------------------------------------------------
@@ -222,6 +231,27 @@ def _add_seq_layer_norm(
     """
     return graph_ops.add_layer_norm_native(
         network, inp, hidden_size, gamma, beta, eps)
+
+
+def _add_pooler_output(
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    hidden_size: int,
+    weights: WeightDict,
+) -> trt.ITensor:
+    """Apply HF BertPooler: tanh(Dense(hidden_states[0]))."""
+    if "pooler_w" not in weights or "pooler_bias" not in weights:
+        raise ValueError("Pooler output requested but pooler weights are missing")
+
+    cls_slice = network.add_slice(
+        hidden, start=(0, 0), shape=(1, hidden_size), stride=(1, 1))
+    pooled = graph_ops.add_matmul_rhs_constant(
+        network, cls_slice.get_output(0), hidden_size, hidden_size,
+        weights["pooler_w"])
+    pooled = graph_ops.add_bias_sum(
+        network, pooled, hidden_size, weights["pooler_bias"])
+    return network.add_activation(
+        pooled, trt.ActivationType.TANH).get_output(0)
 
 
 def _add_encoder_layer(

--- a/tensorrt_model_connect/tensorrt_model_connect/families/dpr.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/dpr.py
@@ -76,8 +76,6 @@ class DprPlugin:
         hidden = config.hidden_size
         vocab = config.vocab_size
         num_layers = config.num_hidden_layers
-        num_heads = config.num_attention_heads
-        intermediate = config.intermediate_size
         max_pos = config.max_position_embeddings
         type_vocab_size = config.raw.get("type_vocab_size", 2)
 
@@ -193,6 +191,7 @@ class DprPlugin:
         return build_encoder_engine(
             config, weights,
             max_seq_length=max_cache_length,
+            output_pooler=True,
             verbose=verbose)
 
 

--- a/tests/builder/test_build_engine_decoders.py
+++ b/tests/builder/test_build_engine_decoders.py
@@ -256,6 +256,8 @@ class TestDPRBuildEngine:
             t[f"{p}.output.dense.bias"] = _rand(hidden)
             t[f"{p}.output.LayerNorm.weight"] = _rand(hidden)
             t[f"{p}.output.LayerNorm.bias"] = _rand(hidden)
+        t["ctx_encoder.bert_model.pooler.dense.weight"] = _rand(hidden, hidden)
+        t["ctx_encoder.bert_model.pooler.dense.bias"] = _rand(hidden)
         return t
 
     def test_build_engine_returns_bytes(self, tmp_path):

--- a/tests/builder/test_family_plugins_extended.py
+++ b/tests/builder/test_family_plugins_extended.py
@@ -512,7 +512,6 @@ class TestDebertaPlugin:
 
     @staticmethod
     def _make_tensors(vocab, hidden, layers, heads, intermediate, max_pos):
-        head_dim = hidden // heads
         t = {}
         t["deberta.embeddings.word_embeddings.weight"] = _rand(vocab, hidden)
         t["deberta.embeddings.LayerNorm.weight"] = _rand(hidden)
@@ -782,6 +781,8 @@ class TestDPRPlugin:
             t[f"{p}.output.LayerNorm.weight"] = _rand(hidden)
             t[f"{p}.output.LayerNorm.bias"] = _rand(hidden)
 
+        t["ctx_encoder.bert_model.pooler.dense.weight"] = _rand(hidden, hidden)
+        t["ctx_encoder.bert_model.pooler.dense.bias"] = _rand(hidden)
         return t
 
     def test_load_weights_keys(self, tmp_path):
@@ -807,6 +808,8 @@ class TestDPRPlugin:
         assert "embedding" in weights
         assert "position_embedding" in weights
         assert "embed_norm" in weights
+        assert "pooler_w" in weights
+        assert "pooler_bias" in weights
 
         for i in range(self.LAYERS):
             for key in ("w_q", "w_k", "w_v"):

--- a/tests/builder/test_owned_encoder_builders_coverage.py
+++ b/tests/builder/test_owned_encoder_builders_coverage.py
@@ -183,7 +183,7 @@ def _make_fake_trt() -> types.SimpleNamespace:
         ReduceOperation=types.SimpleNamespace(AVG="avg"),
         UnaryOperation=types.SimpleNamespace(SQRT="sqrt", RECIP="recip"),
         MatrixOperation=types.SimpleNamespace(NONE="none", TRANSPOSE="transpose"),
-        ActivationType=types.SimpleNamespace(SIGMOID="sigmoid"),
+        ActivationType=types.SimpleNamespace(SIGMOID="sigmoid", TANH="tanh"),
         AttentionNormalizationOp=types.SimpleNamespace(SOFTMAX="softmax"),
         MemoryPoolType=types.SimpleNamespace(WORKSPACE="workspace"),
         BuilderFlag=types.SimpleNamespace(TF32="tf32"),
@@ -619,6 +619,48 @@ def test_build_encoder_engine_success_passes_rel_pos_bias_and_activation(monkeyp
     assert builder.config.pool_limits == [("workspace", 1 << 30)]
     assert builder.config.cleared_flags == ["tf32"]
     assert [t.name for t in builder.network.outputs] == ["hidden_states"]
+
+
+@pytest.mark.unit
+def test_build_encoder_engine_can_mark_pooler_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Intent: verify DPR-style pooler output is exposed as the engine output."""
+    fake_trt = _make_fake_trt()
+    mod = _import_with_fake_trt("tensorrt_model_connect.encoder_builder", fake_trt)
+
+    monkeypatch.setattr(mod.graph_ops, "add_constant", _fake_tensor_fn("const"))
+    monkeypatch.setattr(mod.graph_ops, "add_matmul_rhs_constant", _fake_tensor_fn("pool_mm"))
+    monkeypatch.setattr(mod.graph_ops, "add_bias_sum", _fake_tensor_fn("pool_bias"))
+    monkeypatch.setattr(mod, "_add_seq_layer_norm", _fake_tensor_fn("embed_ln"))
+    monkeypatch.setattr(mod, "_add_encoder_layer", _fake_tensor_fn("layer"))
+
+    config = types.SimpleNamespace(
+        hidden_size=4,
+        vocab_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        intermediate_size=6,
+        rms_norm_eps=1e-5,
+        hidden_act="gelu",
+        raw={"type_vocab_size": 2},
+    )
+    weights = {
+        "embedding": np.zeros((8, 4), dtype=np.float32),
+        "position_embedding": np.zeros((4, 4), dtype=np.float32),
+        "token_type_embedding": np.zeros((2, 4), dtype=np.float32),
+        "embed_norm": np.ones((4,), dtype=np.float32),
+        "embed_norm_beta": np.zeros((4,), dtype=np.float32),
+        "pooler_w": np.zeros((4, 4), dtype=np.float32),
+        "pooler_bias": np.zeros((4,), dtype=np.float32),
+    }
+
+    plan = mod.build_encoder_engine(
+        config, weights, max_seq_length=4, output_pooler=True)
+
+    assert plan == b"engine-plan"
+    builder = fake_trt.Builder.last_instance
+    assert [t.name for t in builder.network.outputs] == ["pooler_output"]
+    assert any(call[0] == "add_slice" for call in builder.network.calls)
+    assert any(call[0] == "add_activation" for call in builder.network.calls)
 
 
 @pytest.mark.unit

--- a/tests/e2e/models/dpr-ctx-encoder.json
+++ b/tests/e2e/models/dpr-ctx-encoder.json
@@ -8,8 +8,7 @@
   "prompt": "The capital of France is Paris",
   "max_new_tokens": 0,
   "threshold_overrides": {
-    "cls_embedding_cosine": -0.1,
-    "cls_embedding_l2": 35.0
+    "cls_embedding_cosine": 0.95
   },
-  "notes": "DPR CLS cosine=-0.05; DPR plugin weight prefix mapping produces fundamentally different hidden states from BertModel reference. Needs layer-by-layer debug."
+  "notes": "Matches the model card contract: DPRContextEncoderTokenizer + DPRContextEncoder(...).pooler_output passage embedding."
 }

--- a/tests/e2e_harness/references/hf_transformers.py
+++ b/tests/e2e_harness/references/hf_transformers.py
@@ -315,6 +315,8 @@ class HfTransformersReference:
         hf_id = case.hf_id
         model_ref = _resolve_cached_model_ref(hf_id)
         torch_dtype_expr = _torch_dtype_for_case(case)
+        contract_config = case.metadata.get("contract_config", {})
+        auto_class = contract_config.get("auto_class", "AutoModel")
 
         script = textwrap.dedent(f"""\
             import json, torch, numpy as np
@@ -325,9 +327,15 @@ class HfTransformersReference:
             prompt = {prompt!r}
             trust_remote_code = {trust_remote_code!r}
             output_path = {output_path!r}
+            auto_class = {auto_class!r}
 
-            tokenizer = AutoTokenizer.from_pretrained(
-                model_ref, trust_remote_code=trust_remote_code)
+            if auto_class == 'DPRContextEncoder':
+                from transformers import DPRContextEncoderTokenizer
+                tokenizer = DPRContextEncoderTokenizer.from_pretrained(
+                    model_ref, trust_remote_code=trust_remote_code)
+            else:
+                tokenizer = AutoTokenizer.from_pretrained(
+                    model_ref, trust_remote_code=trust_remote_code)
 
             # Load model — try AutoModel first, fall back to base model
             # for specialized wrappers (DPR, etc.) that don't return
@@ -337,16 +345,22 @@ class HfTransformersReference:
                 model_ref, trust_remote_code=trust_remote_code)
             model_type = getattr(config, 'model_type', '')
 
-            if model_type == 'dpr':
-                # DPR wraps BERT under ctx_encoder.bert_model or
-                # question_encoder.bert_model prefix.  AutoModel loads
-                # the wrong class (DPRQuestionEncoder) with missing weights.
-                # Load as DPRContextEncoder and extract the inner BERT.
+            use_dpr_pooler = False
+            if auto_class == 'DPRContextEncoder':
+                # Match the model card: DPRContextEncoder returns the passage
+                # embedding through pooler_output.
                 from transformers import DPRContextEncoder
-                _dpr = DPRContextEncoder.from_pretrained(
+                model = DPRContextEncoder.from_pretrained(
                     model_ref, trust_remote_code=trust_remote_code,
                     torch_dtype={torch_dtype_expr})
-                model = _dpr.ctx_encoder.bert_model
+                use_dpr_pooler = True
+            elif model_type == 'dpr':
+                # Fallback for legacy DPR manifests without contract metadata.
+                from transformers import DPRContextEncoder
+                model = DPRContextEncoder.from_pretrained(
+                    model_ref, trust_remote_code=trust_remote_code,
+                    torch_dtype={torch_dtype_expr})
+                use_dpr_pooler = True
             else:
                 model = AutoModel.from_pretrained(
                     model_ref, trust_remote_code=trust_remote_code,
@@ -355,10 +369,15 @@ class HfTransformersReference:
 
             inputs = tokenizer(prompt, return_tensors="pt")
             with torch.no_grad():
-                outputs = model(**inputs)
+                outputs = (
+                    model(input_ids=inputs["input_ids"])
+                    if use_dpr_pooler else model(**inputs)
+                )
 
             # CLS token embedding from last_hidden_state
-            if hasattr(outputs, 'last_hidden_state') and outputs.last_hidden_state is not None:
+            if use_dpr_pooler and hasattr(outputs, 'pooler_output') and outputs.pooler_output is not None:
+                cls_embedding = outputs.pooler_output[0].float().cpu().numpy().tolist()
+            elif hasattr(outputs, 'last_hidden_state') and outputs.last_hidden_state is not None:
                 cls_embedding = outputs.last_hidden_state[0, 0].float().cpu().numpy().tolist()
             else:
                 first_out = outputs[0]


### PR DESCRIPTION
## Summary
- align DPR E2E with the model card path: DPRContextEncoderTokenizer plus DPRContextEncoder pooler_output
- expose optional BERT-style pooler output from the TRT encoder builder and enable it for the DPR family
- replace the waived DPR threshold with a 0.95 cosine gate and add mocked builder coverage for pooler output

## Validation
- PYTHONPATH=tensorrt_model_connect python3 -m pytest tests/builder/test_owned_encoder_builders_coverage.py::test_build_encoder_engine_can_mark_pooler_output tests/tools/test_embedding_contract_plugins.py -q
- RUFF_CACHE_DIR=/tmp/ruff-cache-trtmc python3 -m ruff check tensorrt_model_connect/tensorrt_model_connect/encoder_builder.py tensorrt_model_connect/tensorrt_model_connect/families/dpr.py tests/e2e_harness/references/hf_transformers.py tests/builder/test_owned_encoder_builders_coverage.py tests/builder/test_family_plugins_extended.py tests/builder/test_build_engine_decoders.py
- python3 -m json.tool tests/e2e/models/dpr-ctx-encoder.json >/tmp/dpr-ctx-encoder-jsoncheck.out

Note: local agent-4 TRT container is not running, so real GPU E2E validation is left to GitHub CI.