### PR TITLE
Remove stale Eagle E2E waives

### DIFF
--- a/tests/e2e/waives.txt
+++ b/tests/e2e/waives.txt
@@ -13,8 +13,6 @@ internlm2-1.8b           SKIP   (DynamicCache.from_legacy_cache removed in trans
 nemotron-h-nano-9b       XFAIL  (TRT-only: HF reference needs mamba-ssm which is not installed; build+inference verified, no parity comparison)
 phi4-multimodal           SKIP   (phi4-multimodal remote code incompatible with transformers 5.x)
 qwen2.5-0.5b-torchtrt    XFAIL  (Torch-TensorRT bundle build depends on TRT-LLM plugins not supported by the CUDA 13 CI image)
-eagle-embed-vl-1b-v2     SKIP   (HF repo 404)
-eagle-rerank-vl-1b-v2    SKIP   (HF repo 404)
 sam-vit-base             XFAIL  (prompted segmentation parity gap in TRT SAM runtime; refactor-specific CLI/runtime-guard failures fixed, mask semantics still require dedicated runtime follow-up)
 z-image-turbo            XFAIL  (HF diffusion reference is stylized/silhouette for a photo prompt; VLM gate should surface the reference quality gap)
 z-image-turbo-l0         XFAIL  (HF diffusion reference is stylized/silhouette for a photo prompt; VLM gate should surface the reference quality gap)

--- a/tests/tools/test_e2e_waives.py
+++ b/tests/tools/test_e2e_waives.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from tests import test_e2e
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_load_waives_filters_with_explicit_platform(monkeypatch, tmp_path) -> None:
@@ -42,3 +48,14 @@ def test_load_waives_without_platform_ignores_prefixed_entries(monkeypatch, tmp_
     waives = test_e2e._load_waives()
 
     assert waives == {"model-shared": ("XFAIL", "shared waive")}
+
+
+def test_repo_waives_reference_existing_e2e_cases() -> None:
+    manifest_names = set()
+    for manifest_path in (REPO_ROOT / "tests/e2e/models").glob("*.json"):
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest_names.add(raw["name"])
+
+    waives = test_e2e._load_waives()
+
+    assert set(waives).issubset(manifest_names)

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -647,6 +647,20 @@ diff --git a/tests/e2e/waives.txt b/tests/e2e/waives.txt
         assert refined.rule == "e2e_waives_model_lines"
         assert refined.models == ["flux-schnell"]
 
+    def test_stale_waives_diff_has_no_e2e_impact(self, imap):
+        """Removing a waive for a non-existent case should not fan out E2E."""
+        diff_text = """
+diff --git a/tests/e2e/waives.txt b/tests/e2e/waives.txt
+@@ -1 +1 @@
+-eagle-embed-vl-1b-v2 SKIP (stale HF repo 404 waive)
+-eagle-rerank-vl-1b-v2 SKIP (stale HF repo 404 waive)
+"""
+        broad = test_impact.classify_file("tests/e2e/waives.txt", imap)
+        refined = test_impact.maybe_refine_match_with_diff(
+            "tests/e2e/waives.txt", broad, diff_text, imap)
+        assert refined.rule == "e2e_waives_stale_lines"
+        assert refined.models == []
+
 
 class TestDiffAwareBuilderRefinement:
     def test_cli_fp8_diff_can_be_refined(self, imap):

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1080,10 +1080,13 @@ def maybe_refine_match_with_diff(
 
     if path == "tests/e2e/waives.txt":
         models = []
+        stale_waive_lines = []
         for line in lines:
             fields = line.split()
             if fields and fields[0] in imap.all_model_names_set:
                 models.append(fields[0])
+            elif len(fields) >= 2 and fields[1].upper() in {"SKIP", "XFAIL"}:
+                stale_waive_lines.append(fields[0])
         if models:
             return RuleMatch(
                 "e2e_waives_model_lines",
@@ -1091,6 +1094,8 @@ def maybe_refine_match_with_diff(
                 match.unit_tiers,
                 match.rebuild_cpp,
             )
+        if stale_waive_lines and len(stale_waive_lines) == len(lines):
+            return RuleMatch("e2e_waives_stale_lines", [], [], False)
 
     return match
 


### PR DESCRIPTION
## Summary

- remove stale `eagle-embed-vl-1b-v2` and `eagle-rerank-vl-1b-v2` E2E waive entries; those names do not correspond to current manifests
- add a tools test requiring every repo waive to reference an existing E2E case
- refine impact analysis so removing stale waive lines does not fan out to the whole E2E matrix

## Validation

- `PYTHONPATH=tensorrt_model_connect python3 -m pytest tests/tools/test_e2e_waives.py tests/tools/test_test_impact.py::TestHarness::test_stale_waives_diff_has_no_e2e_impact -q`
- `python3 tools/test_impact.py --base github/main --json`
- changed-files `ruff check --config ruff.toml`
- `PYTHONPYCACHEPREFIX=/tmp/trtmc-pycache PYTHONPATH=tensorrt_model_connect python3 -m py_compile ...`
- `git diff --check github/main...HEAD`
