### PR TITLE
Fix Z-Image Turbo E2E contract

### DIFF
--- a/tests/e2e/models/z-image-turbo.json
+++ b/tests/e2e/models/z-image-turbo.json
@@ -9,19 +9,23 @@
   "ci_tier": "nightly_only",
   "l0_replacement": "z-image-turbo-l0",
   "l0_replacement_reason": "Z-Image-Turbo scale stays nightly; z-image-turbo-l0 keeps the Z-Image path at 512px for MR L0.",
-  "description": "Z-Image-Turbo text-to-image (Qwen3 encoder + ZImage DiT + VAE)",
+  "reference_family": "diffusers_image_gen",
+  "user_contract": "diffusion_image",
+  "description": "Z-Image-Turbo text-to-image using the model-card Diffusers prompt",
   "build_args": {
     "max_cache_length": 256
   },
-  "test_prompt": "A photo of a cat sitting on a windowsill at sunset",
+  "test_prompt": "Astronaut in a jungle, cold color palette, muted colors, detailed, 8k",
   "test_type": "diffusion",
   "image_height": 1024,
   "image_width": 1024,
   "video_num_frames": 1,
-  "num_inference_steps": 4,
+  "num_inference_steps": 9,
+  "guidance_scale": 0.0,
+  "seed": 42,
   "min_pixel_mean": 0.15,
   "max_pixel_mean": 0.85,
   "min_pixel_std": 0.05,
   "skip_text_comparison": true,
-  "notes": "Z-Image-Turbo: Qwen3 text encoder + ZImage DiT (unified attention, tanh-gated AdaLN) + AutoencoderKL VAE. Flow matching scheduler with shift=3.0."
+  "notes": "Z-Image-Turbo: Qwen3 text encoder + ZImage DiT (unified attention, tanh-gated AdaLN) + AutoencoderKL VAE. Uses the model-card Diffusers prompt, 1024x1024 image size, guidance_scale=0.0, seed=42, and num_inference_steps=9 (8 DiT forwards). Flow matching scheduler with shift=3.0."
 }

--- a/tests/e2e/waives.txt
+++ b/tests/e2e/waives.txt
@@ -16,5 +16,4 @@ qwen2.5-0.5b-torchtrt    XFAIL  (Torch-TensorRT bundle build depends on TRT-LLM 
 eagle-embed-vl-1b-v2     SKIP   (HF repo 404)
 eagle-rerank-vl-1b-v2    SKIP   (HF repo 404)
 sam-vit-base             XFAIL  (prompted segmentation parity gap in TRT SAM runtime; refactor-specific CLI/runtime-guard failures fixed, mask semantics still require dedicated runtime follow-up)
-z-image-turbo            XFAIL  (HF diffusion reference is stylized/silhouette for a photo prompt; VLM gate should surface the reference quality gap)
 z-image-turbo-l0         XFAIL  (HF diffusion reference is stylized/silhouette for a photo prompt; VLM gate should surface the reference quality gap)

--- a/tests/tools/test_z_image_turbo_model_card_contract.py
+++ b/tests/tools/test_z_image_turbo_model_card_contract.py
@@ -1,0 +1,48 @@
+"""Tests for the full Z-Image Turbo model-card E2E contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests import test_e2e
+from tools.evaluate_diffusion_vlm_similarity import _apply_gate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "tests/e2e/models/z-image-turbo.json"
+MODEL_CARD_PROMPT = "Astronaut in a jungle, cold color palette, muted colors, detailed, 8k"
+
+
+def test_z_image_turbo_uses_model_card_prompt_and_generation_settings() -> None:
+    raw = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert raw["hf_id"] == "Tongyi-MAI/Z-Image-Turbo"
+    assert raw["reference_family"] == "diffusers_image_gen"
+    assert raw["user_contract"] == "diffusion_image"
+    assert raw["test_prompt"] == MODEL_CARD_PROMPT
+    assert raw["image_height"] == 1024
+    assert raw["image_width"] == 1024
+    assert raw["num_inference_steps"] == 9
+    assert raw["guidance_scale"] == 0.0
+    assert raw["seed"] == 42
+
+
+def test_z_image_turbo_prompt_does_not_trigger_photo_reference_waive_path() -> None:
+    gate = _apply_gate({
+        "semantic_similarity_0_to_5": 4.0,
+        "trt_prompt_alignment_0_to_5": 4.0,
+        "trt_visual_quality_0_to_5": 4.0,
+        "hf_prompt_alignment_0_to_5": 4.0,
+        "hf_visual_quality_0_to_5": 4.0,
+        "is_regression": False,
+        "hf_description": "A stylized astronaut in a lush jungle.",
+    }, prompt=MODEL_CARD_PROMPT)
+
+    assert not gate["failed"]
+
+
+def test_z_image_turbo_is_not_globally_waived() -> None:
+    waives = test_e2e._load_waives()
+
+    assert "z-image-turbo" not in waives


### PR DESCRIPTION
## Summary
- align full/nightly z-image-turbo with the Z-Image-Turbo model-card Diffusers prompt
- use the model-card 1024px generation settings: 9 inference steps, guidance_scale 0.0, seed 42
- remove the full z-image-turbo waive and add a tools contract test

## Validation
- PYTHONPATH=tensorrt_model_connect python3 -m pytest tests/tools/test_z_image_turbo_model_card_contract.py -q
- PYTHONPYCACHEPREFIX=/tmp/trtmc-pycache PYTHONPATH=tensorrt_model_connect python3 -m py_compile tests/tools/test_z_image_turbo_model_card_contract.py
- RUFF_CACHE_DIR=/tmp/ruff-cache-trtmc python3 -m ruff check --config ruff.toml tests/tools/test_z_image_turbo_model_card_contract.py
- git diff --check
- python3 tools/test_impact.py --base github/main --json
- python3 tools/test_impact.py --base github/main --json --e2e-suite nightly

## Impact
- PR L0 selective E2E: z-image-turbo-l0 replacement
- Nightly E2E: z-image-turbo
