### PR TITLE
Run SAM E2E without waive

### DIFF
--- a/tests/e2e/waives.txt
+++ b/tests/e2e/waives.txt
@@ -15,6 +15,5 @@ phi4-multimodal           SKIP   (phi4-multimodal remote code incompatible with 
 qwen2.5-0.5b-torchtrt    XFAIL  (Torch-TensorRT bundle build depends on TRT-LLM plugins not supported by the CUDA 13 CI image)
 eagle-embed-vl-1b-v2     SKIP   (HF repo 404)
 eagle-rerank-vl-1b-v2    SKIP   (HF repo 404)
-sam-vit-base             XFAIL  (prompted segmentation parity gap in TRT SAM runtime; refactor-specific CLI/runtime-guard failures fixed, mask semantics still require dedicated runtime follow-up)
 z-image-turbo            XFAIL  (HF diffusion reference is stylized/silhouette for a photo prompt; VLM gate should surface the reference quality gap)
 z-image-turbo-l0         XFAIL  (HF diffusion reference is stylized/silhouette for a photo prompt; VLM gate should surface the reference quality gap)


### PR DESCRIPTION
Removes the sam-vit-base XFAIL so selective E2E runs the current prompted-segmentation SAM path against the HF SAM reference.

Validation:
- PYTHONPYCACHEPREFIX=/tmp/trtmc-pycache python3 tools/test_impact.py --base github/main --head HEAD --json
- PYTHONPYCACHEPREFIX=/tmp/trtmc-pycache python3 -m pytest tests/tools/test_test_impact.py::TestHarness::test_waives_diff_can_be_refined_to_named_model -q
- PYTHONPYCACHEPREFIX=/tmp/trtmc-pycache python3 tools/test_impact.py --validate
- git diff --check github/main..HEAD

Local C++/GPU E2E not run because trtf-dev-gb300-agent-4 is not running.