### PR TITLE
Prepare Phi-4 multimodal E2E contract

### DIFF
--- a/tests/e2e/models/phi4-multimodal.json
+++ b/tests/e2e/models/phi4-multimodal.json
@@ -6,10 +6,11 @@
   "family": "phi4_multimodal",
   "runtime_strategy": "vision_language",
   "max_cache_length": 384,
-  "prompt": "Describe this image.",
+  "prompt": "What is shown in this image?",
   "max_new_tokens": 30,
   "logit_atol": 0.01,
   "layer_atol": 0.1,
   "trust_remote_code": true,
-  "test_image": "tests/e2e/data/test_img.jpeg"
+  "test_image": "tests/e2e/data/test_img.jpeg",
+  "notes": "Model card uses AutoProcessor with prompt '<|user|><|image_1|>What is shown in this image?<|end|><|assistant|>'. The centralized waive remains until TRTMC implements Phi-4 dynamic-HD vision preprocessing, vision LoRA merging, and a wired vision engine."
 }

--- a/tests/e2e/waives.txt
+++ b/tests/e2e/waives.txt
@@ -10,7 +10,7 @@ fnet-base                 XFAIL  (encoder representation parity below minimum co
 gemma-2-2b               SKIP   (gated model, needs HF_TOKEN)
 internlm2-1.8b           SKIP   (DynamicCache.from_legacy_cache removed in transformers 5.x)
 nemotron-h-nano-9b       XFAIL  (TRT-only: HF reference needs mamba-ssm which is not installed; build+inference verified, no parity comparison)
-phi4-multimodal           SKIP   (phi4-multimodal remote code incompatible with transformers 5.x)
+phi4-multimodal           SKIP   (Phi-4 model-card vision path requires dynamic-HD preprocessing, vision LoRA merging, and a wired vision engine)
 qwen2.5-0.5b-torchtrt    XFAIL  (Torch-TensorRT bundle build depends on TRT-LLM plugins not supported by the CUDA 13 CI image)
 eagle-embed-vl-1b-v2     SKIP   (HF repo 404)
 eagle-rerank-vl-1b-v2    SKIP   (HF repo 404)

--- a/tests/e2e_harness/references/hf_transformers.py
+++ b/tests/e2e_harness/references/hf_transformers.py
@@ -46,6 +46,8 @@ def _vl_fallback_prompt(hf_id: str, prompt: str) -> str:
         return f"<|vision_start|><|image_pad|><|vision_end|>{prompt}"
     if "internvl" in lower_id:
         return f"<IMG_CONTEXT>\n{prompt}"
+    if "phi-4" in lower_id and "multimodal" in lower_id:
+        return f"<|user|><|image_1|>{prompt}<|end|><|assistant|>"
     return prompt
 
 
@@ -1199,7 +1201,8 @@ class HfTransformersReference:
                 if not isinstance(text_input, str):
                     raise TypeError("processor.apply_chat_template did not return text")
                 if not any(marker in text_input for marker in (
-                    "<|image_pad|>", "<|vision_start|>", "<image>"
+                    "<|image_pad|>", "<|vision_start|>", "<image>",
+                    "<|image_1|>", "<|endoftext10|>"
                 )):
                     raise ValueError("chat template produced no image placeholder")
                 inputs = processor(

--- a/tests/tools/test_phi4_multimodal_model_card_contract.py
+++ b/tests/tools/test_phi4_multimodal_model_card_contract.py
@@ -1,0 +1,34 @@
+"""Tests for Phi-4-multimodal model-card reference setup."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests.e2e_harness.references.hf_transformers import _vl_fallback_prompt
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "tests/e2e/models/phi4-multimodal.json"
+
+
+def test_phi4_manifest_uses_model_card_vision_prompt() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert manifest["hf_id"] == "microsoft/Phi-4-multimodal-instruct"
+    assert manifest["runtime_strategy"] == "vision_language"
+    assert manifest["trust_remote_code"] is True
+    assert manifest["prompt"] == "What is shown in this image?"
+    assert manifest["test_image"] == "tests/e2e/data/test_img.jpeg"
+
+
+def test_phi4_hf_reference_fallback_uses_processor_image_marker() -> None:
+    prompt = "What is shown in this image?"
+
+    rendered = _vl_fallback_prompt(
+        "microsoft/Phi-4-multimodal-instruct", prompt)
+
+    assert rendered == (
+        "<|user|><|image_1|>What is shown in this image?"
+        "<|end|><|assistant|>"
+    )

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -676,6 +676,28 @@ diff --git a/tests/e2e/waives.txt b/tests/e2e/waives.txt
         assert refined.rule == "e2e_waives_model_lines"
         assert refined.models == ["flux-schnell"]
 
+    def test_hf_transformers_phi4_prompt_diff_can_be_refined(self, imap):
+        """Phi-4-only HF reference prompt fallback narrows to Phi-4."""
+        diff_text = """
+diff --git a/tests/e2e_harness/references/hf_transformers.py b/tests/e2e_harness/references/hf_transformers.py
+@@ -1 +1 @@
++    if "phi-4" in lower_id and "multimodal" in lower_id:
++        return f"<|user|><|image_1|>{prompt}<|end|><|assistant|>"
+-                    "<|image_pad|>", "<|vision_start|>", "<image>"
++                    "<|image_pad|>", "<|vision_start|>", "<image>",
++                    "<|image_1|>", "<|endoftext10|>"
+"""
+        broad = test_impact.classify_file(
+            "tests/e2e_harness/references/hf_transformers.py", imap)
+        refined = test_impact.maybe_refine_match_with_diff(
+            "tests/e2e_harness/references/hf_transformers.py",
+            broad,
+            diff_text,
+            imap,
+        )
+        assert refined.rule == "harness_reference_phi4_multimodal"
+        assert refined.models == ["phi4-multimodal"]
+
 
 class TestDiffAwareBuilderRefinement:
     def test_cli_fp8_diff_can_be_refined(self, imap):

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -957,6 +957,31 @@ def maybe_refine_match_with_diff(
                 match.unit_tiers, match.rebuild_cpp,
             )
 
+    if path == "tests/e2e_harness/references/hf_transformers.py":
+        allowed_tokens = (
+            "phi-4",
+            "multimodal",
+            "image_1",
+            "endoftext10",
+            "image_pad",
+            "vision_start",
+            "image",
+            "assistant",
+            "vl_fallback_prompt",
+            "image_placeholder",
+            "marker",
+        )
+        if all(
+            any(token in _normalize_diff_line(line) for token in allowed_tokens)
+            for line in lines
+        ):
+            return RuleMatch(
+                "harness_reference_phi4_multimodal",
+                ["phi4-multimodal"],
+                match.unit_tiers,
+                match.rebuild_cpp,
+            )
+
     if path == "tensorrt_model_connect/tensorrt_model_connect/cli.py":
         allowed_tokens = ("fp8_scales", "save_fp8_scales")
         if all(


### PR DESCRIPTION
## Summary
- align the Phi-4 multimodal E2E prompt/reference fallback with the model-card AutoProcessor form
- narrow test-impact selection for the Phi-4-only HF reference prompt change
- document the remaining runtime blocker: Dynamic-HD preprocessing, vision LoRA merging, and a wired vision engine are still required before the centralized skip can be removed

## Validation
- python3 -m pytest tests/tools/test_phi4_multimodal_model_card_contract.py tests/tools/test_test_impact.py -q
- python3 -m json.tool tests/e2e/models/phi4-multimodal.json
- PYTHONPATH=tensorrt_model_connect:. python3 tools/test_impact.py --base github/main --head HEAD --json
- git diff --check