### PR TITLE
docs(skills): add git message plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "trtmc-agent-skills",
+  "interface": {
+    "displayName": "TensorRT-Model-Connect Skills"
+  },
+  "plugins": [
+    {
+      "name": "trtmc-agent-skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/trtmc-agent-skills"
+      },
+      "policy": {
+        "installation": "INSTALLED_BY_DEFAULT",
+        "authentication": "ON_USE"
+      },
+      "category": "Development"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,11 @@ tests/torchtrt_e2e/models/*.json
 !.gitignore
 !.gitlab-ci.yml
 !.dockerignore
+!.agents/
+!.agents/plugins/
+!.agents/plugins/marketplace.json
+!plugins/trtmc-agent-skills/.codex-plugin/
+!plugins/trtmc-agent-skills/.codex-plugin/**
 config
 HEAD
 hooks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,15 @@
 - Keep GitHub Pages dedicated to the documentation website.
 - Do not publish CI reports to GitHub Pages unless the user explicitly changes
   that decision.
+
+## Repo Skills
+
+- Codex skills packaged for this repo are registered through
+  `.agents/plugins/marketplace.json`.
+- The `trtmc-agent-skills` plugin is marked `INSTALLED_BY_DEFAULT` and exposes
+  repo-local skills from `plugins/trtmc-agent-skills/skills/`.
+- Use `$write-git-messages` when drafting or reviewing commit messages, PR
+  titles, PR descriptions, squash merge messages, or rebase message text.
+- If `$write-git-messages` is not listed in the active runtime skills, load
+  `plugins/trtmc-agent-skills/skills/write-git-messages/SKILL.md` directly and
+  follow it.

--- a/plugins/trtmc-agent-skills/.codex-plugin/plugin.json
+++ b/plugins/trtmc-agent-skills/.codex-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "trtmc-agent-skills",
+  "version": "0.1.0",
+  "description": "Repo-local Codex skills for TensorRT-Model-Connect developer workflows.",
+  "repository": "https://github.com/NVIDIA/TensorRT-Model-Connect",
+  "keywords": [
+    "codex",
+    "skills",
+    "git",
+    "pull-requests",
+    "developer-workflow"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "TensorRT-Model-Connect Skills",
+    "shortDescription": "Repo skills for commit and PR workflows",
+    "longDescription": "Installs TensorRT-Model-Connect Codex skills that help developers operate consistently in this repository.",
+    "developerName": "NVIDIA",
+    "category": "Development",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Use $write-git-messages to draft a PR message from my diff."
+    ],
+    "brandColor": "#76B900"
+  }
+}

--- a/plugins/trtmc-agent-skills/skills/write-git-messages/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/write-git-messages/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: write-git-messages
+description: Draft, revise, or review Git commit messages, PR titles, PR descriptions, and squash or rebase merge messages. Use when Codex needs to summarize a diff for reviewers, convert rough notes into a commit or PR message, check a message against Git and Conventional Commits style, or prepare repository contribution text before pushing/opening a PR.
+---
+
+# Write Git Messages
+
+## Workflow
+
+1. Inspect the actual change before writing: use `git diff --stat`, `git diff --name-only`, and focused diffs for changed files. If only a user summary is available, state that the message is based on the provided summary.
+2. Match the requested artifact: commit message, PR title/body, squash merge message, rebase todo wording, or review response.
+3. Follow the repository's existing convention first. If the repo has no clear convention, default to Conventional Commits for commit titles and PR titles.
+4. Keep claims evidence-based. Do not invent issue numbers, benchmark results, tests, generated artifacts, or reviewer decisions.
+5. Prefer ready-to-use text. Return the final message in a fenced `text` or `markdown` block, followed by short notes only if tradeoffs matter.
+
+For source rationale, read `references/source-notes.md` only when you need to explain or adjust the standard.
+
+## Commit Messages
+
+Use this default shape:
+
+```text
+type(scope): imperative summary
+
+Why this change is needed and what behavior changes.
+Mention important constraints, migrations, or risk.
+
+Refs: #123
+BREAKING CHANGE: explain incompatible behavior
+```
+
+Guidelines:
+
+- Keep the first line short and self-contained; aim for 50 characters when practical.
+- Separate the title from the body with a blank line.
+- Use imperative mood in the summary: `add`, `fix`, `document`, `remove`.
+- Use a meaningful type: `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `build`, `ci`, `chore`, or `revert`.
+- Add a scope only when it helps route ownership or understand impact.
+- Put the "why" and user-visible behavior in the body; do not restate every file changed.
+- Use footers for issue links, co-authors, and breaking changes.
+- Split unrelated work into separate commits when possible. If not possible, choose the dominant type and explain the combined scope in the body.
+- Avoid vague titles such as `update files`, `misc fixes`, `work in progress`, or `fix stuff`.
+- In this repo, never include `Claude` in commit messages because the GitHub ruleset rejects it.
+
+## PR Messages
+
+Write PR bodies as a one-minute review brief in plain English. A reviewer should be able to understand why the PR exists, what done means, how it works, how it was validated, and what future readers should know without reconstructing the task from the diff.
+
+Use this default PR body:
+
+```markdown
+## Background
+<Why this task exists. Include the problem, prior failure, user request, policy,
+or workflow gap that motivated the change.>
+
+## Exit Criteria
+- <objective condition that means this task is done>
+- <any explicit non-goal or boundary if useful>
+
+## Implementation
+- <what changed, grouped by behavior or component rather than every file>
+- <how the design works and why this approach was chosen>
+
+## Validation
+- `<command>`: <result>
+- `<command>`: <result>
+
+## Notes For Future Readers
+- <follow-up, limitation, reviewer order, operational note, or reason a future
+  maintainer should not remove or duplicate this change>
+```
+
+For tiny PRs, keep all sections but make each one one or two sentences. For larger PRs, use bullets inside sections. Omit only sections that are truly inapplicable, not just inconvenient to fill.
+
+When reporting validation:
+
+- Include exact commands and whether they passed, failed, or were not run.
+- Include the result in plain English, not only the command.
+- If validation was not run, say why and describe the residual risk.
+
+Guidelines:
+
+- Make the PR title mirror the expected squash or merge commit title.
+- Keep the PR focused on one purpose. If the diff is broad, say why it could not be split.
+- In the body, include purpose, done criteria, change overview, relevant issue links or prior discussions, and any requested feedback.
+- For multi-file or multi-layer changes, tell reviewers where to start and what order to review in the future-reader notes.
+- Call out security, dependency, migration, compatibility, and rollback concerns when present.
+- Omit empty sections rather than leaving placeholders.
+
+## Review Checklist
+
+Before returning a message, verify:
+
+- The title says what changed without relying on the body.
+- The body explains why the change exists when the reason is not obvious.
+- The body defines exit criteria clearly enough that a reviewer can tell whether the task is complete.
+- The implementation section explains the approach in human terms, not just filenames.
+- The type and scope match the diff.
+- Test claims match commands actually run or user-provided evidence.
+- Validation includes both commands and pass/fail results.
+- Future-reader notes capture any review order, limitation, or maintenance warning that is not obvious from the diff.

--- a/plugins/trtmc-agent-skills/skills/write-git-messages/agents/openai.yaml
+++ b/plugins/trtmc-agent-skills/skills/write-git-messages/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Write Git Messages"
+  short_description: "Draft clear commit and PR messages"
+  default_prompt: "Use $write-git-messages to draft a commit message and PR description from this diff."

--- a/plugins/trtmc-agent-skills/skills/write-git-messages/references/source-notes.md
+++ b/plugins/trtmc-agent-skills/skills/write-git-messages/references/source-notes.md
@@ -1,0 +1,19 @@
+# Source Notes
+
+Use these notes when a user asks why the skill recommends a format or when local repository convention conflicts with a default.
+
+## Primary Sources Researched
+
+- Git user manual, "Creating good commit messages": recommends a short first line, blank line, then a fuller description; Git treats text before the first blank line as the commit title.
+  - https://git-scm.com/docs/user-manual
+- Conventional Commits 1.0.0: defines `<type>[optional scope]: <description>`, optional body, and optional footer structure; uses `fix`, `feat`, and `BREAKING CHANGE` to communicate semantic intent, while allowing other types.
+  - https://www.conventionalcommits.org/en/v1.0.0/
+- GitHub Docs, "Helping others review your changes": recommends small focused PRs, clear titles/descriptions, purpose, change overview, links to context, requested feedback, review order for multi-file PRs, and self-review/build/test before submitting.
+  - https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/helping-others-review-your-changes
+
+## Practical Interpretation
+
+- Commit messages optimize long-term history search and release automation.
+- PR messages optimize review speed, reviewer confidence, and collaboration.
+- A good PR title often becomes the squash merge title, so it should be written with the same care as a commit summary.
+- Local repository convention wins over generic style unless it is unclear, missing, or explicitly being replaced.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,11 @@
 # Skills
 
-Project-specific Claude Code skills. Each skill is a `SKILL.md` file in its own subdirectory.
+Project-specific agent skills. Each skill is a `SKILL.md` file in its own
+subdirectory.
+
+Codex-discoverable skills are packaged in
+`plugins/trtmc-agent-skills/skills/` and registered by
+`.agents/plugins/marketplace.json`.
 
 | Skill | Purpose |
 |-------|---------|


### PR DESCRIPTION
## Background
This task started because the repo did not have a reusable Codex skill for writing useful commit and PR messages. The first pass also exposed an important discovery problem: putting a skill under the top-level `skills/` directory made it visible as a file, but did not make it available as a Codex-discoverable repo skill for developers who pull the repo and start a fresh Codex session.

The goal of this PR is to turn the researched commit/PR-message guidance into a repo-local Codex skill and register it through the Codex plugin marketplace path, so future developers can find and use it consistently.

## Exit Criteria
- A fresh checkout contains a Codex marketplace entry for the repo skill plugin.
- The `write-git-messages` skill is packaged in one place, without duplicate top-level skill copies.
- The skill tells agents to write PR bodies with enough context for a reviewer to understand the task in about one minute.
- The PR itself uses that richer format so reviewers can evaluate the change without reconstructing the history from comments.

## Implementation
- Added `.agents/plugins/marketplace.json` to register the repo-local `trtmc-agent-skills` plugin with `INSTALLED_BY_DEFAULT`.
- Added `plugins/trtmc-agent-skills/.codex-plugin/plugin.json` as the plugin manifest. It points Codex at `./skills/` inside the plugin.
- Added `plugins/trtmc-agent-skills/skills/write-git-messages/` as the single source of truth for the new skill, including UI metadata and researched source notes.
- Updated the skill so PR bodies include background, exit criteria, implementation details, validation results, and notes for future readers.
- Updated `.gitignore` so the required `.agents` marketplace file and plugin manifest are tracked even though dot-directories are generally ignored.
- Updated `AGENTS.md` and `skills/README.md` to document the plugin discovery path and the fallback file path if a running session has not populated the skill list yet.

## Validation
- `python3 /workspace/users/yifeif/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/trtmc-agent-skills/skills/write-git-messages`: passed; the packaged skill has valid frontmatter and naming.
- `python3 -m json.tool .agents/plugins/marketplace.json`: passed; the marketplace JSON parses correctly.
- `python3 -m json.tool plugins/trtmc-agent-skills/.codex-plugin/plugin.json`: passed; the plugin manifest JSON parses correctly.
- `git diff --check`: passed; no whitespace errors were reported.
- `CODEX_HOME=/tmp/trtmc-codex-plugin-validate codex plugin marketplace add /workspace/users/yifeif/workspaces/agent-3/TensorRT-Model-Connect`: passed; Codex accepted the repo as marketplace `trtmc-agent-skills` and reported the installed marketplace root as this checkout.

## Notes For Future Readers
- The skill intentionally lives only under `plugins/trtmc-agent-skills/skills/write-git-messages/`. Do not add a second copy under top-level `skills/`; that creates drift and makes reviews noisier.
- Active Codex sessions do not hot-load skills that are added mid-session. After this PR lands, start a fresh Codex session from the checkout to pick up the marketplace/plugin path. If `$write-git-messages` is still not listed, follow the fallback path documented in `AGENTS.md`.
- The source notes cite Git, Conventional Commits, and GitHub reviewer guidance. The skill keeps those details in `references/source-notes.md` so the main workflow stays compact.
