### PR TITLE
fix(falcon): scale ALiBi bias for RW parity

### DIFF
--- a/tensorrt_model_connect/tensorrt_model_connect/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/dual_profile_decoder_builder.py
@@ -219,6 +219,7 @@ def build_dual_profile_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    alibi_bias_scale: float = 1.0,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
 ) -> bytes:
@@ -228,6 +229,8 @@ def build_dual_profile_decoder_engine(
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
     ``scale_attn_weights`` mirror the same parameters on
     ``build_standard_decoder_engine``.
+    ``alibi_bias_scale`` is multiplied into ALiBi slopes before they are added
+    through the native attention mask.
 
     ``quant_ctx`` (optional) routes every projection matmul through
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
@@ -394,7 +397,7 @@ def build_dual_profile_decoder_engine(
     alibi_slopes_tensor: trt.ITensor | None = None
     alibi_cache_positions_fp32: trt.ITensor | None = None
     if position_type == "alibi":
-        alibi_slopes_np = graph_ops.compute_alibi_slopes(num_heads)
+        alibi_slopes_np = graph_ops.compute_alibi_slopes(num_heads) * float(alibi_bias_scale)
         # Slopes live as fp32 so the (key_pos - q_pos) math stays in fp32;
         # add_alibi_mask_4d casts the final bias to work_trt_dtype before adding
         # to the additive mask.

--- a/tensorrt_model_connect/tensorrt_model_connect/families/falcon.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/falcon.py
@@ -235,6 +235,12 @@ class FalconPlugin:
         # Falcon-RW models use ALiBi; Falcon-3 uses RoPE
         use_alibi = config.raw.get("alibi", False)
         position_type = "alibi" if use_alibi else "rope"
+        alibi_bias_scale = (
+            float(1.0 / np.sqrt(max(config.head_dim, 1)))
+            if use_alibi
+            else 1.0
+        )
+        activation = config.raw.get("activation") or config.hidden_act or "gelu"
 
         return build_standard_decoder_engine(
             config, weights, max_cache_length,
@@ -242,7 +248,8 @@ class FalconPlugin:
             norm_type="layernorm",
             mlp_type="gelu_fc",
             position_type=position_type,
-            activation="gelu_new",
+            activation=activation,
+            alibi_bias_scale=alibi_bias_scale,
             verbose=verbose,
             debug_layer_outputs=debug_layer_outputs)
 

--- a/tensorrt_model_connect/tensorrt_model_connect/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/standard_decoder_builder.py
@@ -61,6 +61,7 @@ def build_standard_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    alibi_bias_scale: float = 1.0,
     embed_input: bool = False,
     verbose: bool = False,
     debug_layer_outputs: bool = False,
@@ -85,6 +86,9 @@ def build_standard_decoder_engine(
             rotated-half (LLaMA/Qwen) where (d, d+half) share frequencies.
         scale_attn_weights: Whether to scale attention scores by 1/sqrt(head_dim).
             Most models use this (True, default). GPT-Neo does NOT scale (False).
+        alibi_bias_scale: Extra scale applied to ALiBi slopes before building
+            the additive attention mask. BLOOM leaves ALiBi unscaled while
+            Falcon scales ALiBi with the same factor as QK scores.
         embed_input: If True, add input_embed [1, hidden] and use_input_embed [1]
             engine inputs. When use_input_embed==1, the decoder uses input_embed
             directly instead of the embedding lookup. Used for VL models where
@@ -134,6 +138,7 @@ def build_standard_decoder_engine(
             interleaved_rope=interleaved_rope,
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
+            alibi_bias_scale=alibi_bias_scale,
             verbose=verbose,
         )
 
@@ -298,7 +303,7 @@ def build_standard_decoder_engine(
         position_embed_table = graph_ops.add_constant(
             network, pos_embed_np.shape, pos_embed_np, dtype=work_np_dtype)
     elif position_type == "alibi":
-        alibi_slopes_np = graph_ops.compute_alibi_slopes(num_heads)
+        alibi_slopes_np = graph_ops.compute_alibi_slopes(num_heads) * float(alibi_bias_scale)
         alibi_slopes_tensor = graph_ops.add_constant(
             network, (num_heads, 1, 1),
             alibi_slopes_np.reshape(num_heads, 1, 1), dtype=np.float32)

--- a/tests/builder/test_engine_falcon.py
+++ b/tests/builder/test_engine_falcon.py
@@ -20,7 +20,7 @@ import numpy as np
 import pytest
 
 from tensorrt_model_connect.config import ModelConfig
-from tests.builder.family_plugin_tester import FamilyPluginTester, TinyModelSpec
+from tests.builder.family_plugin_tester import FamilyPluginTester
 from tests.builder.family_plugin_test_mixin import FamilyPluginTestMixin
 
 

--- a/tests/builder/test_engine_falcon.py
+++ b/tests/builder/test_engine_falcon.py
@@ -13,8 +13,13 @@ Intent: Validate the Falcon family plugin weight loading including LayerNorm wit
 Preconditions: safetensors and tensorrt_model_connect are importable; TRT+GPU required for engine build tests.
 Postconditions: All weight keys map correctly from Falcon's HF layout, LayerNorm biases are loaded, and FC MLP keys (dense_h_to_4h/dense_4h_to_h) resolve to fc1/fc2.
 """
-import numpy as np
+import sys
+import types
 
+import numpy as np
+import pytest
+
+from tensorrt_model_connect.config import ModelConfig
 from tests.builder.family_plugin_tester import FamilyPluginTester, TinyModelSpec
 from tests.builder.family_plugin_test_mixin import FamilyPluginTestMixin
 
@@ -128,6 +133,52 @@ class FalconPluginTester(FamilyPluginTester):
 
 class TestFalconEngine(FamilyPluginTestMixin):
     tester_class = FalconPluginTester
+
+    def test_rw_alibi_bias_uses_falcon_logit_scale(self, monkeypatch):
+        """Validate Falcon-RW ALiBi is scaled like HF Falcon attention logits.
+
+        Intention:
+            HF Falcon adds ALiBi to raw QK attention scores and then scales the
+            combined logits by 1/sqrt(head_dim). TRT native attention scales QK
+            before applying the additive mask, so the Falcon plugin must
+            pre-scale ALiBi slopes to keep the same logit contract.
+
+        Setup:
+            Monkeypatch the shared decoder builder, build a tiny ALiBi Falcon
+            config, and verify the plugin forwards the expected ALiBi scale and
+            exact GELU activation.
+        """
+        fake_trt = types.ModuleType("tensorrt")
+        monkeypatch.setitem(sys.modules, "tensorrt", fake_trt)
+        from tensorrt_model_connect import trt_compat
+        monkeypatch.setattr(trt_compat, "_module", None)
+        from tensorrt_model_connect.families import falcon as falcon_module
+
+        captured = {}
+
+        def fake_build_standard_decoder_engine(*args, **kwargs):
+            captured.update(kwargs)
+            return b"plan"
+
+        monkeypatch.setattr(
+            falcon_module,
+            "build_standard_decoder_engine",
+            fake_build_standard_decoder_engine,
+        )
+        config = ModelConfig.create_tiny(
+            "falcon",
+            hidden_size=16,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            alibi=True,
+        )
+
+        plan = falcon_module.plugin.build_engine(config, {}, 8)
+
+        assert plan == b"plan"
+        assert captured["position_type"] == "alibi"
+        assert captured["activation"] == "gelu"
+        assert captured["alibi_bias_scale"] == pytest.approx(0.5)
 
     def test_layernorm_beta_present(self, tester, tmp_path):
         """Validate that Falcon includes LayerNorm bias (beta) weights.

--- a/tests/e2e/waives.txt
+++ b/tests/e2e/waives.txt
@@ -5,7 +5,6 @@
 albert-base               XFAIL  (encoder representation parity below minimum contract floor; threshold override no longer counts as green validation)
 bart-base                 XFAIL  (seq2seq-base weak contract produced empty TRT continuation against non-empty HF output)
 dpr-ctx-encoder           XFAIL  (DPR embedding cosine below minimum contract floor; old negative threshold masked the parity gap)
-falcon-rw-1b             XFAIL  (ALiBi attention numerical divergence — TRT logit rel_l2 1.7x, needs investigation)
 fnet-base                 XFAIL  (encoder representation parity below minimum contract floor; DFT approximation gap needs validation follow-up)
 gemma-2-2b               SKIP   (gated model, needs HF_TOKEN)
 internlm2-1.8b           SKIP   (DynamicCache.from_legacy_cache removed in transformers 5.x)


### PR DESCRIPTION
## Background
Nightly run 25747071012 left `falcon-rw-1b` xfailed because the TRT path repeated `time` while HF produced a normal continuation. The saved logits diverged during prompt stepping once ALiBi affected attention scores.

Root cause: HF Falcon adds ALiBi to raw QK attention scores and then scales the combined logits by `1/sqrt(head_dim)`. The TRT native attention path scales QK before applying the additive mask, so Falcon ALiBi was too large by `sqrt(head_dim)` when folded into the mask.

## Exit Criteria
- `falcon-rw-1b` passes continuation parity without an XFAIL.
- Falcon ALiBi/logit scaling is covered by focused builder coverage.
- Shared ALiBi behavior remains opt-in so BLOOM keeps its existing unscaled contract.

## Implementation
- Added an `alibi_bias_scale` parameter to the shared decoder builders, defaulting to `1.0`.
- Set Falcon ALiBi scale to `1/sqrt(head_dim)`, matching HF Falcon's add-then-scale logit order.
- Resolved Falcon activation from config with the HF RW default `gelu`.
- Removed the `falcon-rw-1b` E2E XFAIL after the native continuation parity check passed.

## Validation
- `PYTHONPATH=tensorrt_model_connect python3 -m pytest tests/builder/test_engine_falcon.py -q`: passed, `3 passed, 13 skipped`.
- `docker exec trtmc-dev-gb300-agent-1 bash -lc 'cd /tmp/trtmc-falcon-rw-1b-worktree && PYTHONPATH=tensorrt_model_connect python -m pytest tests/builder/test_engine_falcon.py -q'`: passed, `16 passed`.
- `docker exec trtmc-dev-gb300-agent-1 bash -lc 'cd /tmp/trtmc-falcon-rw-1b-worktree && PYTHONPATH=tensorrt_model_connect python -m pytest tests/builder/test_standard_decoder.py::TestTensorNamingContract::test_alibi_positions -q'`: passed, `1 passed`.
- `docker exec trtmc-dev-gb300-agent-1 bash -lc 'cd /tmp/trtmc-falcon-rw-1b-worktree && PYTHONPATH=tensorrt_model_connect python -m pytest tests/builder/test_graph_ops.py::TestComputeAlibiSlopes -q'`: passed, `11 passed`.
- `docker exec trtmc-dev-gb300-agent-1 cmake --build /tmp/trtmc-falcon-rw-1b-cppbuild --target trtmc_backend_trt -j 8`: passed, built the missing local backend DSO needed by the container's stock `trtmc` binary.
- `docker exec trtmc-dev-gb300-agent-1 bash -lc 'cd /tmp/trtmc-falcon-rw-1b-worktree && LD_LIBRARY_PATH=/tmp/trtmc-falcon-rw-1b-cppbuild:${LD_LIBRARY_PATH:-} PYTHONPATH=tensorrt_model_connect HF_HOME=/tmp/hf-cache HF_HUB_CACHE=/tmp/hf-cache/hub TRANSFORMERS_OFFLINE=1 HF_HUB_OFFLINE=1 TRTMC_E2E_EXCLUDE_GPU0=1 ./scripts/run_e2e_parallel.sh --models-file /tmp/trtmc-models-falcon-rw-1b.txt --engine-dir /tmp/trtmc-falcon-rw-1b-engines-fix --result-dir /tmp/trtmc-falcon-rw-1b-e2e-final --trtmc-binary /workspace/TensorRT-Model-Connect/build/trtmc --hf-python /opt/venv/bin/python --num-gpus 2 --workers-per-gpu 1 --progress-interval 30'`: passed, `1 passed in 42.43s`; final artifact has status `pass`, NED `0.0`, and the C++ continuation matches HF.
- `git diff --check`: passed.

## Notes For Future Readers
- Keep the Falcon ALiBi scale in the Falcon plugin. BLOOM uses the same shared builder surface but has a different HF ALiBi scaling contract.
- The agent-1 container's prebuilt `/workspace/TensorRT-Model-Connect/build/trtmc` did not include `libtrtmc_backend_trt*.so`, so local native E2E validation built that DSO under `/tmp` against the installed TensorRT wheel. No repository build artifact is included in this PR.
