### PR TITLE
fix(e2e): validate ALBERT encoder outputs

### DIFF
--- a/scripts/generate_e2e_report.py
+++ b/scripts/generate_e2e_report.py
@@ -939,6 +939,60 @@ def _get_stage_text(stage_outputs: Dict[str, Any], prefix: str) -> Optional[str]
     return None
 
 
+def _flatten_numeric_preview(value: Any, limit: int = 16) -> Tuple[List[float], int, float]:
+    """Return the first numeric leaves, total numeric leaf count, and L2 sum."""
+    preview: List[float] = []
+    total = 0
+    sumsq = 0.0
+    stack = [value]
+    while stack:
+        cur = stack.pop()
+        if isinstance(cur, (int, float)):
+            total += 1
+            sumsq += float(cur) * float(cur)
+            if len(preview) < limit:
+                preview.append(float(cur))
+        elif isinstance(cur, list):
+            stack.extend(reversed(cur))
+    return preview, total, sumsq
+
+
+def _get_stage_feature_output(
+    stage_outputs: Dict[str, Any], prefix: str
+) -> Optional[Tuple[str, Any]]:
+    """Extract a structured numeric feature output from a matching stage."""
+    feature_keys = ("cls_embedding", "embedding")
+    for key, val in stage_outputs.items():
+        if not key.startswith(prefix) or not isinstance(val, dict):
+            continue
+        data = val.get("data")
+        if not isinstance(data, dict):
+            continue
+        for feature_key in feature_keys:
+            if feature_key in data:
+                return feature_key, data[feature_key]
+    return None
+
+
+def _format_feature_output(feature: Optional[Tuple[str, Any]]) -> Optional[str]:
+    """Format an embedding/feature vector so generic reports show references."""
+    if feature is None:
+        return None
+    name, value = feature
+    preview, total, sumsq = _flatten_numeric_preview(value)
+    if total <= 0:
+        return f"{name}: (no numeric values)"
+
+    norm = sumsq ** 0.5
+    suffix = " ..." if total > len(preview) else ""
+    preview_text = ", ".join(f"{x:.6g}" for x in preview)
+    return (
+        f"{name} ({total} values)\n"
+        f"preview[0:{len(preview)}]: [{preview_text}{suffix}]\n"
+        f"l2_norm: {norm:.6g}"
+    )
+
+
 def render_text_model(result: Dict[str, Any]) -> str:
     """Render detail section for a text-generation model."""
     cc = result.get("case_config", {})
@@ -1314,12 +1368,18 @@ def render_generic_model(result: Dict[str, Any]) -> str:
     stage_outputs = result.get("stage_outputs", {})
     trt_text = _get_stage_text(stage_outputs, "trt_")
     ref_text = _get_stage_text(stage_outputs, "ref_")
+    trt_feature = _format_feature_output(
+        _get_stage_feature_output(stage_outputs, "trt_"))
+    ref_feature = _format_feature_output(
+        _get_stage_feature_output(stage_outputs, "ref_"))
 
     parts = []
     if prompt:
         parts.append(f"<p><strong>Prompt:</strong> {_esc(prompt)}</p>")
     if trt_text or ref_text:
         parts.append(_render_text_comparison(trt_text, ref_text))
+    elif trt_feature or ref_feature:
+        parts.append(_render_text_comparison(trt_feature, ref_feature))
     parts.append(_render_metrics_table(result.get("stages", {})))
     parts.append(_render_repro_commands(result.get("repro_commands", {})))
     parts.append(_render_timing_sections(result))

--- a/src/tokenizer/unigram_tokenizer.cpp
+++ b/src/tokenizer/unigram_tokenizer.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cctype>
 #include <cmath>
 #include <cstring>
 #include <limits>
@@ -10,6 +11,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace trtmc {
@@ -17,33 +19,38 @@ namespace {
 
 // ─── UTF-8 helpers ───
 
-inline char32_t utf8_to_char32(const std::string& s, size_t& pos)
-{
+inline char32_t utf8_to_char32(const std::string& s, size_t& pos) {
     unsigned char c = static_cast<unsigned char>(s[pos]);
-    if (c < 0x80) { ++pos; return static_cast<char32_t>(c); }
+    if (c < 0x80) {
+        ++pos;
+        return static_cast<char32_t>(c);
+    }
     if ((c & 0xE0) == 0xC0 && pos + 1 < s.size()) {
         char32_t cp = (static_cast<char32_t>(c & 0x1F) << 6) |
                       static_cast<char32_t>(static_cast<unsigned char>(s[pos + 1]) & 0x3F);
-        pos += 2; return cp;
+        pos += 2;
+        return cp;
     }
     if ((c & 0xF0) == 0xE0 && pos + 2 < s.size()) {
         char32_t cp = (static_cast<char32_t>(c & 0x0F) << 12) |
                       (static_cast<char32_t>(static_cast<unsigned char>(s[pos + 1]) & 0x3F) << 6) |
                       static_cast<char32_t>(static_cast<unsigned char>(s[pos + 2]) & 0x3F);
-        pos += 3; return cp;
+        pos += 3;
+        return cp;
     }
     if ((c & 0xF8) == 0xF0 && pos + 3 < s.size()) {
         char32_t cp = (static_cast<char32_t>(c & 0x07) << 18) |
                       (static_cast<char32_t>(static_cast<unsigned char>(s[pos + 1]) & 0x3F) << 12) |
                       (static_cast<char32_t>(static_cast<unsigned char>(s[pos + 2]) & 0x3F) << 6) |
                       static_cast<char32_t>(static_cast<unsigned char>(s[pos + 3]) & 0x3F);
-        pos += 4; return cp;
+        pos += 4;
+        return cp;
     }
-    ++pos; return 0xFFFD;
+    ++pos;
+    return 0xFFFD;
 }
 
-inline std::string char32_to_utf8(char32_t cp)
-{
+inline std::string char32_to_utf8(char32_t cp) {
     std::string r;
     if (cp <= 0x7F) {
         r.push_back(static_cast<char>(cp));
@@ -64,13 +71,16 @@ inline std::string char32_to_utf8(char32_t cp)
 }
 
 // Return the byte length of the UTF-8 codepoint starting at s[pos].
-inline size_t utf8_char_len(const std::string& s, size_t pos)
-{
+inline size_t utf8_char_len(const std::string& s, size_t pos) {
     unsigned char c = static_cast<unsigned char>(s[pos]);
-    if (c < 0x80) return 1;
-    if ((c & 0xE0) == 0xC0) return 2;
-    if ((c & 0xF0) == 0xE0) return 3;
-    if ((c & 0xF8) == 0xF0) return 4;
+    if (c < 0x80)
+        return 1;
+    if ((c & 0xE0) == 0xC0)
+        return 2;
+    if ((c & 0xF0) == 0xE0)
+        return 3;
+    if ((c & 0xF8) == 0xF0)
+        return 4;
     return 1;
 }
 
@@ -86,37 +96,48 @@ inline size_t utf8_char_len(const std::string& s, size_t pos)
 // 2. Whitespace normalization (various Unicode spaces → regular space)
 // This is sufficient for most practical text inputs.
 
-inline bool is_control(char32_t cp)
-{
-    if (cp == '\t' || cp == '\n' || cp == '\r') return false;
+inline bool is_control(char32_t cp) {
+    if (cp == '\t' || cp == '\n' || cp == '\r')
+        return false;
     return (cp < 0x20) || cp == 0x7F || (cp >= 0x80 && cp <= 0x9F);
 }
 
-struct UnicodeRange { char32_t lo, hi; };
+struct UnicodeRange {
+    char32_t lo, hi;
+};
 constexpr UnicodeRange kUnicodeSpaces[] = {
-    {0x00A0, 0x00A0}, {0x1680, 0x1680}, {0x2000, 0x200A},
-    {0x2028, 0x2029}, {0x202F, 0x202F}, {0x205F, 0x205F}, {0x3000, 0x3000},
+    {0x00A0, 0x00A0}, {0x1680, 0x1680}, {0x2000, 0x200A}, {0x2028, 0x2029},
+    {0x202F, 0x202F}, {0x205F, 0x205F}, {0x3000, 0x3000},
 };
 
-inline bool is_unicode_space(char32_t cp)
-{
+inline bool is_unicode_space(char32_t cp) {
     for (const auto& r : kUnicodeSpaces)
-        if (cp >= r.lo && cp <= r.hi) return true;
+        if (cp >= r.lo && cp <= r.hi)
+            return true;
     return false;
 }
 
-std::string precompiled_normalize(const std::string& text)
-{
+std::string precompiled_normalize(const std::string& text) {
     std::string result;
     result.reserve(text.size());
     size_t pos = 0;
     while (pos < text.size()) {
         char32_t cp = utf8_to_char32(text, pos);
-        if (is_control(cp)) continue;
-        if (is_unicode_space(cp)) { result += ' '; continue; }
+        if (is_control(cp))
+            continue;
+        if (is_unicode_space(cp)) {
+            result += ' ';
+            continue;
+        }
         result += char32_to_utf8(cp);
     }
     return result;
+}
+
+std::string lowercase_ascii(std::string text) {
+    std::transform(text.begin(), text.end(), text.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return text;
 }
 
 // ─── Metaspace Pre-tokenizer ───
@@ -124,27 +145,27 @@ std::string precompiled_normalize(const std::string& text)
 
 static const std::string kMetaspaceChar = "\xe2\x96\x81"; // ▁ U+2581
 
-inline bool is_ws(char c)
-{
+inline bool is_ws(char c) {
     return c == ' ' || c == '\t' || c == '\n' || c == '\r';
 }
 
-std::vector<std::string> whitespace_split(const std::string& text)
-{
+std::vector<std::string> whitespace_split(const std::string& text) {
     std::vector<std::string> words;
     size_t i = 0;
     while (i < text.size()) {
-        while (i < text.size() && is_ws(text[i])) ++i;
-        if (i >= text.size()) break;
+        while (i < text.size() && is_ws(text[i]))
+            ++i;
+        if (i >= text.size())
+            break;
         size_t start = i;
-        while (i < text.size() && !is_ws(text[i])) ++i;
+        while (i < text.size() && !is_ws(text[i]))
+            ++i;
         words.push_back(text.substr(start, i - start));
     }
     return words;
 }
 
-std::string metaspace_pre_tokenize(const std::string& text, bool add_prefix_space)
-{
+std::string metaspace_pre_tokenize(const std::string& text, bool add_prefix_space) {
     std::string result;
     result.reserve(text.size() + 8);
     if (add_prefix_space && !text.empty() && text[0] != ' ') {
@@ -164,16 +185,15 @@ std::string metaspace_pre_tokenize(const std::string& text, bool add_prefix_spac
 
 struct TrieNode {
     std::unordered_map<char, int> children;
-    int token_id = -1;   // -1 = not a token end
+    int token_id = -1; // -1 = not a token end
     float score = 0.0f;
 };
 
 class Trie {
-public:
+  public:
     Trie() { mNodes.emplace_back(); } // root node
 
-    void insert(const std::string& token, int id, float score)
-    {
+    void insert(const std::string& token, int id, float score) {
         int node = 0;
         for (char c : token) {
             auto it = mNodes[node].children.find(c);
@@ -192,27 +212,28 @@ public:
 
     // Find all tokens that match a prefix of text starting at offset.
     // Returns vector of (token_id, byte_length, score).
-    struct Match { int token_id; size_t length; float score; };
+    struct Match {
+        int token_id;
+        size_t length;
+        float score;
+    };
 
-    void find_prefixes(const std::string& text, size_t offset,
-                       std::vector<Match>& out) const
-    {
+    void find_prefixes(const std::string& text, size_t offset, std::vector<Match>& out) const {
         out.clear();
         int node = 0;
         for (size_t i = offset; i < text.size(); ++i) {
             char c = text[i];
             auto it = mNodes[node].children.find(c);
-            if (it == mNodes[node].children.end()) break;
+            if (it == mNodes[node].children.end())
+                break;
             node = it->second;
             if (mNodes[node].token_id >= 0) {
-                out.push_back({mNodes[node].token_id,
-                               i - offset + 1,
-                               mNodes[node].score});
+                out.push_back({mNodes[node].token_id, i - offset + 1, mNodes[node].score});
             }
         }
     }
 
-private:
+  private:
     std::vector<TrieNode> mNodes;
 };
 
@@ -224,13 +245,10 @@ struct ViterbiNode {
     size_t prev_pos; // byte position of previous node
 };
 
-std::vector<int32_t> viterbi_encode(
-    const std::string& text,
-    const Trie& trie,
-    int32_t unk_id,
-    float unk_score)
-{
-    if (text.empty()) return {};
+std::vector<int32_t> viterbi_encode(const std::string& text, const Trie& trie, int32_t unk_id,
+                                    float unk_score) {
+    if (text.empty())
+        return {};
 
     size_t n = text.size();
     // best[i] = best path score to reach byte position i
@@ -240,7 +258,8 @@ std::vector<int32_t> viterbi_encode(
     std::vector<Trie::Match> matches;
 
     for (size_t i = 0; i < n; ++i) {
-        if (best[i].score == -std::numeric_limits<float>::infinity()) continue;
+        if (best[i].score == -std::numeric_limits<float>::infinity())
+            continue;
 
         trie.find_prefixes(text, i, matches);
 
@@ -287,24 +306,24 @@ std::vector<int32_t> viterbi_encode(
 // ─── UnigramTokenizer ───
 
 class UnigramTokenizer final : public ITokenizer {
-public:
-    static std::unique_ptr<UnigramTokenizer> Create(
-        const char* json_data, std::size_t json_size, bool add_special_tokens)
-    {
+  public:
+    static std::unique_ptr<UnigramTokenizer> Create(const char* json_data, std::size_t json_size,
+                                                    bool add_special_tokens) {
         auto tok = std::unique_ptr<UnigramTokenizer>(new UnigramTokenizer());
         tok->mAddSpecialTokens = add_special_tokens;
         tok->parse_tokenizer_json(json_data, json_size);
         return tok;
     }
 
-    std::vector<int32_t> encode(const std::string& text) const override
-    {
+    std::vector<int32_t> encode(const std::string& text) const override {
         if (text.empty()) {
             return mAddSpecialTokens ? make_special_frame({}) : std::vector<int32_t>{};
         }
 
         // Normalize
         std::string normalized = mUsePrecompiled ? precompiled_normalize(text) : text;
+        if (mLowercase)
+            normalized = lowercase_ascii(std::move(normalized));
 
         // Pre-tokenize: WhitespaceSplit → Metaspace
         auto words = whitespace_split(normalized);
@@ -316,15 +335,16 @@ public:
             ids.insert(ids.end(), word_ids.begin(), word_ids.end());
         }
 
-        if (mAddSpecialTokens) ids = make_special_frame(ids);
+        if (mAddSpecialTokens)
+            ids = make_special_frame(ids);
         return ids;
     }
 
-    std::string decode(const std::vector<int32_t>& ids) const override
-    {
+    std::string decode(const std::vector<int32_t>& ids) const override {
         std::string result;
         for (int32_t id : ids) {
-            if (mDecodeSkipIds.count(id)) continue;
+            if (mDecodeSkipIds.count(id))
+                continue;
             std::string token = token_for_id(id);
             result += token;
         }
@@ -332,31 +352,29 @@ public:
         return decode_metaspace(result);
     }
 
-    int32_t id_for_token(std::string_view token) const override
-    {
+    int32_t id_for_token(std::string_view token) const override {
         auto it = mTokenToId.find(std::string(token));
         return it != mTokenToId.end() ? it->second : -1;
     }
 
-    std::string token_for_id(int32_t id) const override
-    {
+    std::string token_for_id(int32_t id) const override {
         if (id >= 0 && static_cast<size_t>(id) < mIdToToken.size()) {
             return mIdToToken[id];
         }
         return "";
     }
 
-private:
+  private:
     UnigramTokenizer() = default;
 
-    static std::string decode_metaspace(const std::string& text)
-    {
+    static std::string decode_metaspace(const std::string& text) {
         std::string result;
         size_t pos = 0;
         while (pos < text.size()) {
-            if (pos + kMetaspaceChar.size() <= text.size()
-                && text.compare(pos, kMetaspaceChar.size(), kMetaspaceChar) == 0) {
-                if (!result.empty()) result += ' ';
+            if (pos + kMetaspaceChar.size() <= text.size() &&
+                text.compare(pos, kMetaspaceChar.size(), kMetaspaceChar) == 0) {
+                if (!result.empty())
+                    result += ' ';
                 pos += kMetaspaceChar.size();
             } else {
                 result += text[pos];
@@ -366,25 +384,24 @@ private:
         return result;
     }
 
-    std::vector<int32_t> make_special_frame(std::vector<int32_t> ids) const
-    {
+    std::vector<int32_t> make_special_frame(std::vector<int32_t> ids) const {
         std::vector<int32_t> result;
-        if (mBosId >= 0) result.push_back(mBosId);
+        if (mBosId >= 0)
+            result.push_back(mBosId);
         result.insert(result.end(), ids.begin(), ids.end());
-        if (mEosId >= 0) result.push_back(mEosId);
+        if (mEosId >= 0)
+            result.push_back(mEosId);
         return result;
     }
 
     // ─── JSON parsing ───
 
-    void parse_tokenizer_json(const char* json_data, std::size_t json_size)
-    {
+    void parse_tokenizer_json(const char* json_data, std::size_t json_size) {
         nlohmann::json j;
         try {
             j = nlohmann::json::parse(json_data, json_data + json_size);
         } catch (const std::exception& e) {
-            throw std::runtime_error(
-                std::string("Failed to parse tokenizer.json: ") + e.what());
+            throw std::runtime_error(std::string("Failed to parse tokenizer.json: ") + e.what());
         }
 
         validate_model(j);
@@ -397,8 +414,7 @@ private:
         resolve_special_ids();
     }
 
-    static void validate_model(const nlohmann::json& j)
-    {
+    static void validate_model(const nlohmann::json& j) {
         if (!j.contains("model"))
             throw std::runtime_error("Invalid tokenizer.json: missing model");
 
@@ -425,8 +441,7 @@ private:
             throw std::runtime_error("Invalid tokenizer.json: missing model.vocab");
     }
 
-    void parse_vocab(const nlohmann::json& j)
-    {
+    void parse_vocab(const nlohmann::json& j) {
         auto& vocab = j["model"]["vocab"];
         mIdToToken.resize(vocab.size());
         mUnkId = j["model"].value("unk_id", 0);
@@ -444,13 +459,13 @@ private:
         // UNK score: must be worse than ANY real vocab token for Viterbi
         float min_score = 0.0f;
         for (float s : mScores) {
-            if (s < min_score) min_score = s;
+            if (s < min_score)
+                min_score = s;
         }
         mUnkScore = min_score - 10.0f;
     }
 
-    void build_trie()
-    {
+    void build_trie() {
         for (size_t i = 0; i < mIdToToken.size(); ++i) {
             const auto& token = mIdToToken[i];
             if (!token.empty()) {
@@ -459,31 +474,37 @@ private:
         }
     }
 
-    void parse_normalizer(const nlohmann::json& j)
-    {
-        if (!j.contains("normalizer") || j["normalizer"].is_null()) return;
-        auto& norm = j["normalizer"];
-        std::string ntype = norm.value("type", "");
+    void apply_normalizer_config(const nlohmann::json& norm) {
+        const std::string ntype = norm.value("type", "");
         if (ntype == "Precompiled") {
             mUsePrecompiled = true;
-        } else if (ntype == "Prepend") {
+            return;
+        }
+        if (ntype == "Lowercase") {
+            mLowercase = true;
+            return;
+        }
+        if (ntype == "Prepend") {
             // Marian-style: prepend a string (e.g., "▁") to input
             mAddPrefixSpace = true;
-        } else if (ntype == "Sequence" && norm.contains("normalizers")) {
-            for (auto& sub : norm["normalizers"]) {
-                std::string stype = sub.value("type", "");
-                if (stype == "Precompiled") {
-                    mUsePrecompiled = true;
-                } else if (stype == "Prepend") {
-                    mAddPrefixSpace = true;
-                }
-            }
         }
     }
 
-    void parse_pre_tokenizer(const nlohmann::json& j)
-    {
-        if (!j.contains("pre_tokenizer") || j["pre_tokenizer"].is_null()) return;
+    void parse_normalizer(const nlohmann::json& j) {
+        if (!j.contains("normalizer") || j["normalizer"].is_null())
+            return;
+        const auto& norm = j["normalizer"];
+        if (norm.value("type", "") == "Sequence" && norm.contains("normalizers")) {
+            for (const auto& sub : norm["normalizers"])
+                apply_normalizer_config(sub);
+            return;
+        }
+        apply_normalizer_config(norm);
+    }
+
+    void parse_pre_tokenizer(const nlohmann::json& j) {
+        if (!j.contains("pre_tokenizer") || j["pre_tokenizer"].is_null())
+            return;
         auto& pt = j["pre_tokenizer"];
         std::string ptype = pt.value("type", "");
 
@@ -502,9 +523,9 @@ private:
         }
     }
 
-    void parse_added_tokens(const nlohmann::json& j)
-    {
-        if (!j.contains("added_tokens")) return;
+    void parse_added_tokens(const nlohmann::json& j) {
+        if (!j.contains("added_tokens"))
+            return;
         for (auto& tok : j["added_tokens"]) {
             int32_t tok_id = tok.value("id", -1);
             std::string content = tok.value("content", "");
@@ -520,57 +541,64 @@ private:
     }
 
     // Extract BOS/EOS from TemplateProcessing "single" array
-    void extract_template_bos_eos(const nlohmann::json& pp)
-    {
-        if (!pp.contains("single") || !pp["single"].is_array()) return;
+    void extract_template_bos_eos(const nlohmann::json& pp) {
+        if (!pp.contains("single") || !pp["single"].is_array())
+            return;
         for (auto& item : pp["single"]) {
-            if (!item.contains("SpecialToken")) continue;
+            if (!item.contains("SpecialToken"))
+                continue;
             std::string tok_str = item["SpecialToken"].value("id", "");
             auto it = mTokenToId.find(tok_str);
-            if (it == mTokenToId.end()) continue;
-            if (mBosId < 0) mBosId = it->second;
-            else mEosId = it->second;
+            if (it == mTokenToId.end())
+                continue;
+            if (mBosId < 0)
+                mBosId = it->second;
+            else
+                mEosId = it->second;
         }
     }
 
     // Extract BOS/EOS from RobertaProcessing cls/sep arrays
-    static int32_t extract_pp_id(const nlohmann::json& pp, const char* key)
-    {
+    static int32_t extract_pp_id(const nlohmann::json& pp, const char* key) {
         if (pp.contains(key) && pp[key].is_array() && pp[key].size() >= 2)
             return pp[key][1].get<int32_t>();
         return -1;
     }
 
-    void parse_post_processor(const nlohmann::json& j)
-    {
-        if (!j.contains("post_processor") || j["post_processor"].is_null()) return;
+    void parse_post_processor(const nlohmann::json& j) {
+        if (!j.contains("post_processor") || j["post_processor"].is_null())
+            return;
         auto& pp = j["post_processor"];
         std::string ptype = pp.value("type", "");
 
-        if (ptype == "TemplateProcessing") extract_template_bos_eos(pp);
+        if (ptype == "TemplateProcessing")
+            extract_template_bos_eos(pp);
         if (ptype == "RobertaProcessing") {
             mBosId = extract_pp_id(pp, "cls");
             mEosId = extract_pp_id(pp, "sep");
         }
     }
 
-    void resolve_special_ids()
-    {
+    void resolve_special_ids() {
         // Fallback: try common token names
         auto find_id = [this](const std::string& a, const std::string& b) -> int32_t {
             auto it = mTokenToId.find(a);
-            if (it != mTokenToId.end()) return it->second;
+            if (it != mTokenToId.end())
+                return it->second;
             it = mTokenToId.find(b);
             return it != mTokenToId.end() ? it->second : -1;
         };
 
-        if (mBosId < 0) mBosId = find_id("<s>", "[CLS]");
-        if (mEosId < 0) mEosId = find_id("</s>", "[SEP]");
+        if (mBosId < 0)
+            mBosId = find_id("<s>", "[CLS]");
+        if (mEosId < 0)
+            mEosId = find_id("</s>", "[SEP]");
         int32_t padId = find_id("<pad>", "[PAD]");
 
         // Build decode skip set
         for (int32_t id : {mBosId, mEosId, padId}) {
-            if (id >= 0) mDecodeSkipIds.insert(id);
+            if (id >= 0)
+                mDecodeSkipIds.insert(id);
         }
     }
 
@@ -586,6 +614,7 @@ private:
     float mUnkScore = -100.0f;
     bool mAddSpecialTokens = true;
     bool mUsePrecompiled = false;
+    bool mLowercase = false;
     bool mAddPrefixSpace = true;
 
     int32_t mBosId = -1;
@@ -594,13 +623,10 @@ private:
 
 } // namespace
 
-std::unique_ptr<ITokenizer> CreateUnigramTokenizer(
-    const char* tokenizer_json_data,
-    std::size_t tokenizer_json_size,
-    bool add_special_tokens)
-{
-    return UnigramTokenizer::Create(
-        tokenizer_json_data, tokenizer_json_size, add_special_tokens);
+std::unique_ptr<ITokenizer> CreateUnigramTokenizer(const char* tokenizer_json_data,
+                                                   std::size_t tokenizer_json_size,
+                                                   bool add_special_tokens) {
+    return UnigramTokenizer::Create(tokenizer_json_data, tokenizer_json_size, add_special_tokens);
 }
 
 } // namespace trtmc

--- a/tests/cpp/test_tokenizer_edge_cases.cpp
+++ b/tests/cpp/test_tokenizer_edge_cases.cpp
@@ -105,6 +105,29 @@ static const char* kUnigramJson = R"({
   }
 })";
 
+static const char* kUnigramLowercaseSequenceJson = R"({
+  "model": {
+    "type": "Unigram",
+    "unk_id": 0,
+    "vocab": [
+      ["<unk>", 0.0],
+      ["\u2581the", -1.0]
+    ]
+  },
+  "normalizer": {
+    "type": "Sequence",
+    "normalizers": [
+      {"type": "Precompiled", "precompiled_charsmap": "unused"},
+      {"type": "Lowercase"}
+    ]
+  },
+  "pre_tokenizer": {
+    "type": "Metaspace",
+    "replacement": "\u2581",
+    "add_prefix_space": true
+  }
+})";
+
 // ─── Helper: build a string with specific bytes ───
 static std::string bytes(std::initializer_list<unsigned char> bs) {
     std::string s;
@@ -470,6 +493,14 @@ static void test_valid_multibyte_utf8() {
     }
 }
 
+static void test_unigram_sequence_lowercase_normalizer() {
+    std::string json(kUnigramLowercaseSequenceJson);
+    auto tok = trtmc::CreateUnigramTokenizer(json.data(), json.size(), false);
+
+    auto ids = tok->encode("The");
+    check(ids.size() == 1 && ids[0] == 1, "uni_sequence_lowercase_normalizer");
+}
+
 int main() {
     // Malformed UTF-8
     test_bpe_malformed_utf8();
@@ -488,6 +519,9 @@ int main() {
 
     // Valid multi-byte UTF-8 (regression)
     test_valid_multibyte_utf8();
+
+    // Normalizer sequences
+    test_unigram_sequence_lowercase_normalizer();
 
     if (failures > 0) {
         std::cerr << failures << " test(s) FAILED\n";

--- a/tests/e2e/models/albert-base.json
+++ b/tests/e2e/models/albert-base.json
@@ -8,8 +8,7 @@
   "prompt": "The capital of France is Paris.",
   "max_new_tokens": 0,
   "threshold_overrides": {
-    "cls_embedding_cosine": 0.6,
-    "cls_embedding_l2": 30.0
+    "cls_embedding_cosine": 0.99
   },
-  "notes": "ALBERT cross-layer sharing + embedding factorization causes larger TRT-HF delta than standard BERT"
+  "notes": "ALBERT cross-layer sharing and embedding factorization; C++ Unigram tokenization must match HF lowercasing"
 }

--- a/tests/e2e/waives.txt
+++ b/tests/e2e/waives.txt
@@ -2,7 +2,6 @@
 # Format: model-name  SKIP|XFAIL  (reason)
 # Platform-specific: GB300/model-name  XFAIL  (reason)
 
-albert-base               XFAIL  (encoder representation parity below minimum contract floor; threshold override no longer counts as green validation)
 dpr-ctx-encoder           XFAIL  (DPR embedding cosine below minimum contract floor; old negative threshold masked the parity gap)
 fnet-base                 XFAIL  (encoder representation parity below minimum contract floor; DFT approximation gap needs validation follow-up)
 gemma-2-2b               SKIP   (gated model, needs HF_TOKEN)

--- a/tests/tools/test_generate_report.py
+++ b/tests/tools/test_generate_report.py
@@ -723,6 +723,35 @@ class TestRenderTextModel:
         assert "Paris" in html
 
 
+class TestRenderGenericModel:
+    """Tests for render_generic_model()."""
+
+    def test_shows_encoder_reference_feature_output(self):
+        mod = _import_report()
+        r = _make_result(
+            task_strategy="encoder_only_nlp",
+            family="albert",
+            stage_outputs={
+                "trt_full_inference": {
+                    "stage_name": "full_inference",
+                    "data": {"cls_embedding": [1.0, 2.0, 3.0]},
+                    "metadata": {},
+                },
+                "ref_full_inference": {
+                    "stage_name": "full_inference",
+                    "data": {"cls_embedding": [1.0, 2.0, 3.0]},
+                    "metadata": {},
+                },
+            },
+        )
+        html = mod.render_generic_model(r)
+        assert "TRT Output" in html
+        assert "Reference Output" in html
+        assert "cls_embedding (3 values)" in html
+        assert "preview[0:3]" in html
+        assert "l2_norm" in html
+
+
 class TestRenderVlModel:
     """Tests for render_vl_model()."""
 


### PR DESCRIPTION
## Background
ALBERT was XFAIL in the nightly because the encoder representation comparison reported a low cosine score. The source/log audit showed the model graph and HF reference both ran, but the native C++ Unigram tokenizer skipped the `Lowercase` step in the ALBERT tokenizer normalizer sequence, so TRT encoded a different prompt than the HF reference. The HTML report also hid structured encoder outputs, which made the reference-output contract hard to audit by eye.

## Exit Criteria
- `albert-base` runs as a normal passing E2E test, not an XFAIL.
- The HTML report shows human-readable TRT and reference encoder feature outputs.
- The tokenizer behavior is covered by a focused C++ regression test.

## Implementation
- Honor `Lowercase` entries inside Unigram normalizer sequences after the precompiled normalizer shim.
- Add a tokenizer edge-case test for a `Sequence(Precompiled, Lowercase)` Unigram tokenizer.
- Render `cls_embedding` and `embedding` previews for generic E2E models so the report includes visible TRT and Reference Output sections.
- Remove the `albert-base` waive and tighten its cosine threshold to `0.99`.

## Validation
- `python -m pytest tests/tools/test_generate_report.py -q`: passed, 67 tests.
- `docker exec trtmc-dev-gb300-agent-1 bash -lc "/tmp/trtmc-build-agent1/test_tokenizer_edge_cases"`: passed.
- `docker exec trtmc-dev-gb300-agent-1 bash -lc "cd /workspace/TensorRT-Model-Connect && printf \"%s\\n\" albert-base > /tmp/trtmc-models-albert.txt && PYTHONPATH=/workspace/TensorRT-Model-Connect/tensorrt_model_connect ./scripts/run_e2e_parallel.sh --models-file /tmp/trtmc-models-albert.txt --engine-dir /tmp/trtmc-engines-albert-minimal --result-dir /tmp/trtmc-albert-minimal --trtmc-binary /tmp/trtmc-build-agent1/trtmc --hf-python /opt/venv/bin/python --num-gpus 1 --workers-per-gpu 1 --progress-interval 20 --rebuild-engines"`: passed, `tests/test_e2e.py::test_e2e[albert-base]`.
- Generated `/tmp/trtmc-albert-minimal/e2e_report.html`: contains `TRT Output`, `Reference Output`, `cls_embedding (768 values)`, no `(none)` placeholder.

## Notes For Future Readers
- The Unigram precompiled normalizer support is still a lightweight shim; this change handles the ALBERT/HF lowercase contract without claiming full Unicode NFKD or accent-stripping parity.