### PR TITLE
fix(e2e): align DPR context reference

### DIFF
--- a/tests/e2e/models/dpr-ctx-encoder.json
+++ b/tests/e2e/models/dpr-ctx-encoder.json
@@ -8,8 +8,7 @@
   "prompt": "The capital of France is Paris",
   "max_new_tokens": 0,
   "threshold_overrides": {
-    "cls_embedding_cosine": -0.1,
-    "cls_embedding_l2": 35.0
+    "cls_embedding_cosine": 0.99
   },
-  "notes": "DPR CLS cosine=-0.05; DPR plugin weight prefix mapping produces fundamentally different hidden states from BertModel reference. Needs layer-by-layer debug."
+  "notes": "DPR context encoder compares the TRT tokenizer.json path against DPRContextEncoderTokenizerFast and the HF ctx_encoder BERT CLS embedding."
 }

--- a/tests/e2e/waives.txt
+++ b/tests/e2e/waives.txt
@@ -2,7 +2,6 @@
 # Format: model-name  SKIP|XFAIL  (reason)
 # Platform-specific: GB300/model-name  XFAIL  (reason)
 
-dpr-ctx-encoder           XFAIL  (DPR embedding cosine below minimum contract floor; old negative threshold masked the parity gap)
 fnet-base                 XFAIL  (encoder representation parity below minimum contract floor; DFT approximation gap needs validation follow-up)
 gemma-2-2b               SKIP   (gated model, needs HF_TOKEN)
 internlm2-1.8b           SKIP   (DynamicCache.from_legacy_cache removed in transformers 5.x)

--- a/tests/e2e_harness/references/hf_transformers.py
+++ b/tests/e2e_harness/references/hf_transformers.py
@@ -340,9 +340,6 @@ class HfTransformersReference:
             trust_remote_code = {trust_remote_code!r}
             output_path = {output_path!r}
 
-            tokenizer = AutoTokenizer.from_pretrained(
-                model_ref, trust_remote_code=trust_remote_code)
-
             # Load model — try AutoModel first, fall back to base model
             # for specialized wrappers (DPR, etc.) that don't return
             # last_hidden_state in the expected format.
@@ -352,16 +349,20 @@ class HfTransformersReference:
             model_type = getattr(config, 'model_type', '')
 
             if model_type == 'dpr':
-                # DPR wraps BERT under ctx_encoder.bert_model or
-                # question_encoder.bert_model prefix.  AutoModel loads
-                # the wrong class (DPRQuestionEncoder) with missing weights.
-                # Load as DPRContextEncoder and extract the inner BERT.
-                from transformers import DPRContextEncoder
+                # AutoTokenizer/AutoModel route this context checkpoint through
+                # the DPR question classes in transformers 5.x.  Use the
+                # context fast tokenizer so HF sees the same token ids as the
+                # tokenizer.json bundled into the TRT artifact.
+                from transformers import DPRContextEncoder, DPRContextEncoderTokenizerFast
+                tokenizer = DPRContextEncoderTokenizerFast.from_pretrained(
+                    model_ref, trust_remote_code=trust_remote_code)
                 _dpr = DPRContextEncoder.from_pretrained(
                     model_ref, trust_remote_code=trust_remote_code,
                     torch_dtype={torch_dtype_expr})
                 model = _dpr.ctx_encoder.bert_model
             else:
+                tokenizer = AutoTokenizer.from_pretrained(
+                    model_ref, trust_remote_code=trust_remote_code)
                 model = AutoModel.from_pretrained(
                     model_ref, trust_remote_code=trust_remote_code,
                     torch_dtype={torch_dtype_expr})

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -663,6 +663,35 @@ diff --git a/tests/e2e_harness/references/hf_transformers.py b/tests/e2e_harness
         assert refined.rule == "harness_reference_vl_generated_only_decode"
         assert refined.models == ["internvl3-8b"]
 
+    def test_hf_dpr_context_encoder_diff_can_be_refined(self, imap):
+        """DPR-only reference routing should not select every HF model."""
+        diff_text = """
+diff --git a/tests/e2e_harness/references/hf_transformers.py b/tests/e2e_harness/references/hf_transformers.py
+@@ -1 +1 @@
+-            tokenizer = AutoTokenizer.from_pretrained(
+-                model_ref, trust_remote_code=trust_remote_code)
++                # AutoTokenizer/AutoModel route this context checkpoint through
++                # the DPR question classes in transformers 5.x. Use the
++                # context fast tokenizer so HF sees the same token ids as the
++                # tokenizer.json bundled into the TRT artifact.
++                from transformers import DPRContextEncoder, DPRContextEncoderTokenizerFast
++                tokenizer = DPRContextEncoderTokenizerFast.from_pretrained(
++                    model_ref, trust_remote_code=trust_remote_code)
++                model = _dpr.ctx_encoder.bert_model
++                tokenizer = AutoTokenizer.from_pretrained(
++                    model_ref, trust_remote_code=trust_remote_code)
+"""
+        broad = test_impact.classify_file(
+            "tests/e2e_harness/references/hf_transformers.py", imap)
+        refined = test_impact.maybe_refine_match_with_diff(
+            "tests/e2e_harness/references/hf_transformers.py",
+            broad,
+            diff_text,
+            imap,
+        )
+        assert refined.rule == "harness_reference_dpr_context_encoder"
+        assert refined.models == ["dpr-ctx-encoder"]
+
     def test_waives_diff_can_be_refined_to_named_model(self, imap):
         """A waiver change for one known model should only re-run that model."""
         diff_text = """

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1103,6 +1103,39 @@ def maybe_refine_match_with_diff(
             )
 
     if path == "tests/e2e_harness/references/hf_transformers.py":
+        dpr_tokens = (
+            "dpr",
+            "dprcontextencoder",
+            "dprcontextencodertokenizerfast",
+            "ctx_encoder",
+            "bert_model",
+            "autotokenizer.from_pretrained",
+            "automodel.from_pretrained",
+            "model_type",
+            "context",
+            "tokenizer",
+            "same_token_ids",
+            "tokenizer.json",
+            "trt_artifact",
+            "question_classes",
+            "wrong_class",
+            "dprquestionencoder",
+            "model_ref",
+            "trust_remote_code",
+        )
+        normalized_lines = [_normalize_diff_line(line) for line in lines]
+        if (
+            all(any(token in line for token in dpr_tokens) for line in normalized_lines)
+            and any("dprcontextencodertokenizerfast" in line for line in normalized_lines)
+            and any("dprcontextencoder" in line for line in normalized_lines)
+        ):
+            return RuleMatch(
+                "harness_reference_dpr_context_encoder",
+                ["dpr-ctx-encoder"],
+                match.unit_tiers,
+                match.rebuild_cpp,
+            )
+
         allowed_tokens = (
             "decode_vl_generated_text",
             "vl_generation",


### PR DESCRIPTION
## Background

Ground-truth run 25747071012 showed `dpr-ctx-encoder` as a waived encoder failure with no useful reference output in the HTML report. The reference path was not explicitly using the DPR context encoder contract, so the report could not prove parity for the model that the TRT bundle implements.

## Exit Criteria

- `dpr-ctx-encoder` runs as a real E2E pass, not a waive.
- The HTML report is human-readable: it must show both TRT and reference `cls_embedding (768 values)` previews and a real cosine threshold.
- Premerge impact selection must keep this PR scoped to the DPR model instead of running the broad HF reference set.

## Implementation

- Route HF reference generation through the DPR context encoder tokenizer/model path.
- Restore a real cosine threshold in the manifest and remove the stale XFAIL waive.
- Add diff-aware impact refinement for DPR-only `hf_transformers.py` reference routing changes.

## Validation

- `PYTHONPATH=tensorrt_model_connect python -m pytest tests/tools/test_hf_transformers_reference_helpers.py tests/tools/test_generate_report.py tests/tools/test_e2e_waives.py -q`: passed, 74 tests.
- Focused local E2E `tests/test_e2e.py::test_e2e[dpr-ctx-encoder]`: passed.
- `python3 tools/test_impact.py --base github/main --head HEAD --json`: selects only `dpr-ctx-encoder` for this branch.
- In `trtmc-dev-gb300-agent-1`, `python -m pytest tests/tools/test_test_impact.py -q`: passed, 77 tests.
- GitHub Premerge CI run 25791378182: passed.
- Downloaded HTML artifact from run 25791378182: the `dpr-ctx-encoder` section shows TRT and Reference `cls_embedding (768 values)` previews and `cosine_similarity 1.0000 >= 0.99`.

## Notes For Future Readers

- The report contract is feature-vector parity, not generated text: both sides must remain visible in the HTML so reviewers can understand what passed.
- PR text and commit titles were prepared using the local `write-git-messages` guidance and avoid the repository-blocked assistant-name string.