### PR TITLE
fix(e2e): remove stale Qwen TorchTRT waive

### DIFF
--- a/tests/e2e/waives.txt
+++ b/tests/e2e/waives.txt
@@ -7,7 +7,6 @@ fnet-base                 XFAIL  (encoder representation parity below minimum co
 gemma-2-2b               SKIP   (gated model, needs HF_TOKEN)
 internlm2-1.8b           SKIP   (DynamicCache.from_legacy_cache removed in transformers 5.x)
 phi4-multimodal           SKIP   (phi4-multimodal remote code incompatible with transformers 5.x)
-qwen2.5-0.5b-torchtrt    XFAIL  (Torch-TensorRT bundle build depends on TRT-LLM plugins not supported by the CUDA 13 CI image)
 eagle-embed-vl-1b-v2     SKIP   (HF repo 404)
 eagle-rerank-vl-1b-v2    SKIP   (HF repo 404)
 z-image-turbo            XFAIL  (HF diffusion reference is stylized/silhouette for a photo prompt; VLM gate should surface the reference quality gap)

--- a/tests/tools/test_e2e_waives.py
+++ b/tests/tools/test_e2e_waives.py
@@ -42,3 +42,9 @@ def test_load_waives_without_platform_ignores_prefixed_entries(monkeypatch, tmp_
     waives = test_e2e._load_waives()
 
     assert waives == {"model-shared": ("XFAIL", "shared waive")}
+
+
+def test_qwen25_torchtrt_is_not_globally_waived() -> None:
+    waives = test_e2e._load_waives()
+
+    assert "qwen2.5-0.5b-torchtrt" not in waives


### PR DESCRIPTION
## Root Cause

Ground-truth run 25747071012 passed `qwen2.5-0.5b-torchtrt` with normalized text edit distance `0.0000`, but `tests/e2e/waives.txt` still marked it XFAIL for an older CUDA 13 / Torch-TensorRT dependency issue. That produced a stale XPASS instead of a normal human-readable text-generation pass.

## Fix

- Removed the stale `qwen2.5-0.5b-torchtrt` XFAIL from `tests/e2e/waives.txt`.
- Added a targeted waive guard so the stale global waive is not reintroduced without an explicit test update.

## Validation

- `PYTHONPATH=tensorrt_model_connect python -m pytest tests/tools/test_e2e_waives.py tests/tools/test_generate_ci_summary.py tests/tools/test_generate_report.py -q`: passed, 74 tests.
- Human report replay: `/tmp/qwen25-torchtrt-human-contract-1778656551/e2e_report.html` shows `PASS qwen2.5-0.5b-torchtrt`, visible TRT output, visible Reference output, and `normalized_text_edit_distance=0.0000`.
- Focused local E2E in agent-1 skipped before model execution because this local container lacks `torch_tensorrt`; the ground-truth CI image had that dependency and passed.
- PR-style local preflight in `trtmc-dev-gb300-agent-1`:
  - `bash .github/scripts/run-trtmc-ci.sh impact`: passed.
  - `bash .github/scripts/run-trtmc-ci.sh lint`: passed.
  - `bash .github/scripts/run-trtmc-ci.sh python-builder`: passed, 3 tests.

## CI

- PR: https://github.com/NVIDIA/TensorRT-Model-Connect/pull/40
- Current run: https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/25784415913
- Status as of 2026-05-13: queued because the only self-hosted runner, `gb300-nvl-019-compute01`, is offline.

## Remaining Risk

- The official GitHub check must confirm the current runner image still has the Torch-TensorRT dependency before this PR is green by the plan definition.
- The ground-truth artifact also had a debug-runner logits probe failure for `cache_k_0`; this PR only removes the stale text-generation XFAIL.
- PR text and commit title were prepared using the local `write-git-messages` guidance; no message contains `disallowed assistant-name string`.