### PR TITLE
Add Qwen Image/Image 2512

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ add_library(trtmc_core
   src/runtime/domains/audio/mel_spectrogram.cpp
   src/runtime/domains/audio/audio_bundle_validation.cpp
   src/runtime/domains/diffusion/diffusion_preprocessor.cpp
+  src/runtime/domains/diffusion/qwen_image_types.cpp
   src/tokenizer/vocab_tokenizer.cpp
   src/tokenizer/ipa_tokenizer.cpp
   src/tokenizer/bpe_tokenizer.cpp
@@ -204,6 +205,7 @@ add_library(trtmc_core
   src/runtime/models/ltx_video/pipeline.cpp
   src/runtime/models/wan/pipeline.cpp
   src/runtime/models/z_image/pipeline.cpp
+  src/runtime/models/qwen_image/pipeline.cpp
   src/runtime/models/whisper/pipeline.cpp
   src/runtime/models/rnnt/pipeline.cpp
   src/runtime/models/bark/pipeline.cpp

--- a/cmake/trtmc_pipeline_plugins.cmake
+++ b/cmake/trtmc_pipeline_plugins.cmake
@@ -33,6 +33,7 @@ set(TRTMC_PIPELINE_PLUGINS
   "models/ltx_video/plugin.cpp|register_ltx_video_plugin"
   "models/wan/plugin.cpp|register_wan_plugin"
   "models/z_image/plugin.cpp|register_zimage_plugin"
+  "models/qwen_image/plugin.cpp|register_qwen_image_plugin"
   "models/t5/plugin.cpp|register_t5_plugin"
   "models/marian/plugin.cpp|register_marian_plugin"
   "models/seq2seq/plugin.cpp|register_seq2seq_plugin"

--- a/examples/trtmc_cli.cpp
+++ b/examples/trtmc_cli.cpp
@@ -7,6 +7,9 @@
 //                        [--initial-latents-raw PATH] [--condition-latents-raw PATH]
 //                        [--condition-mask-raw PATH] [--sampling-steps-raw PATH]
 //                        [--sde-noise-raw PATH] [--output samples.jsonl] [--hf-python PATH]
+//                        Diffusion text-to-image extras (Qwen-Image, FLUX, Z-Image):
+//                        [--negative-prompt "text"] [--num-inference-steps N]
+//                        [--height N] [--width N]
 //   trtmc transcribe      <bundle.trtfb> --audio FILE.wav [--max-new-tokens N] [--hf-python PATH]
 //   trtmc speak           <bundle.trtfb> --audio-in INPUT.wav --audio-out OUTPUT.wav
 //   trtmc generate-video  <bundle.trtfb> --prompt "text" --output DIR [--num-steps N]
@@ -79,6 +82,10 @@ struct CliArgs {
     float sde_gamma{-1.0F};
     float conf_threshold{-1.0F};
     float cfg_scale{-1.0F};
+    // Diffusion text-to-image extras (Qwen-Image, FLUX, Z-Image, ...)
+    std::string negative_prompt;
+    int diffusion_height{0}; // 0 = use bundle default
+    int diffusion_width{0};  // 0 = use bundle default
     bool greedy{false};
     bool stream{false};
     bool pad_and_drop_preencoded{false};
@@ -175,6 +182,9 @@ void print_usage() {
            "[--sde-gamma S] [--initial-latents-raw PATH] [--condition-latents-raw PATH] "
            "[--condition-mask-raw PATH] [--sampling-steps-raw PATH] [--sde-noise-raw PATH] "
            "[--output samples.jsonl]\n"
+           "                        Diffusion text-to-image extras (Qwen-Image, FLUX, "
+           "Z-Image): [--negative-prompt \"text\"] "
+           "[--num-inference-steps N] [--height N] [--width N]\n"
            "  trtmc encode          <bundle.trtfb> --prompt \"text\" [--hf-python PATH]\n"
            "  trtmc segment         <bundle.trtfb> --image PATH --output PATH [--hf-python PATH]\n"
            "  trtmc segment-sam     <bundle.trtfb> --image PATH --output DIR "
@@ -353,7 +363,7 @@ CliArgs parse_args(int argc, char** argv) {
             args.sde_noise_raw = argv[++i];
             continue;
         }
-        if (arg == "--num-steps" && need_value(arg)) {
+        if ((arg == "--num-steps" || arg == "--num-inference-steps") && need_value(arg)) {
             args.num_steps = std::atoi(argv[++i]);
             continue;
         }
@@ -363,6 +373,18 @@ CliArgs parse_args(int argc, char** argv) {
         }
         if (arg == "--sde-gamma" && need_value(arg)) {
             args.sde_gamma = static_cast<float>(std::atof(argv[++i]));
+            continue;
+        }
+        if (arg == "--negative-prompt" && need_value(arg)) {
+            args.negative_prompt = argv[++i];
+            continue;
+        }
+        if (arg == "--height" && need_value(arg)) {
+            args.diffusion_height = std::atoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--width" && need_value(arg)) {
+            args.diffusion_width = std::atoi(argv[++i]);
             continue;
         }
         if ((arg == "--threshold" || arg == "--score-threshold") && need_value(arg)) {
@@ -661,12 +683,33 @@ int cmd_run(const CliArgs& args) {
         }
         cfg.sde_noises = std::move(*noise);
     }
+    // Diffusion-only knobs. Non-diffusion pipelines ignore these.
+    cfg.negative_prompt = args.negative_prompt;
+    cfg.height = args.diffusion_height;
+    cfg.width = args.diffusion_width;
+    // --cfg-scale is an alias for --guidance-scale on the diffusion path.
+    // Prefer an explicitly set --cfg-scale if the user provided one.
+    if (args.cfg_scale >= 0.0F) {
+        cfg.guidance_scale = args.cfg_scale;
+    }
 
     // Detect diffusion pipelines — they use generate_image(), not generate().
     const bool is_diffusion =
         (ptype.find("Diffusion") != std::string::npos || ptype.find("Flux") != std::string::npos ||
          ptype.find("Wan") != std::string::npos || ptype.find("ZImage") != std::string::npos ||
-         ptype.find("LTX") != std::string::npos);
+         ptype.find("LTX") != std::string::npos || ptype.find("QwenImage") != std::string::npos);
+
+    // Diffusion pipelines may consume shared initial latents from a raw fp32
+    // file (E2E shared-latents path; mirrors the cmd_generate_video plumbing).
+    if (is_diffusion && !args.initial_latents_raw.empty()) {
+        std::string error;
+        auto latents = read_float32_raw_file(args.initial_latents_raw, error);
+        if (!latents) {
+            std::cerr << "Error: " << error << '\n';
+            return EXIT_FAILURE;
+        }
+        cfg.initial_latents = std::move(*latents);
+    }
 
     if (args.benchmark > 0) {
         // Benchmark mode: warmup, then N timed iterations.
@@ -726,17 +769,10 @@ int cmd_run(const CliArgs& args) {
             out_path = out_dir + "/output.png";
         }
 
-        const auto frame_pixels =
-            static_cast<std::size_t>(result.height) * static_cast<std::size_t>(result.width) * 3;
-        std::vector<unsigned char> rgb(frame_pixels);
-        for (std::size_t i = 0; i < frame_pixels; ++i) {
-            const float v = std::max(0.0F, std::min(1.0F, result.pixels[i]));
-            rgb[i] = static_cast<unsigned char>(v * 255.0F + 0.5F);
-        }
-
-        const int stride = result.width * 3;
-        if (!stbi_write_png(out_path.c_str(), result.width, result.height, 3, rgb.data(), stride)) {
-            std::cerr << "Error: failed to write " << out_path << '\n';
+        try {
+            trtmc::io::save_png(result, out_path);
+        } catch (const std::exception& e) {
+            std::cerr << "Error: " << e.what() << '\n';
             return EXIT_FAILURE;
         }
         std::cout << "Saved " << out_path << " (" << result.width << "x" << result.height << ")\n";
@@ -1461,8 +1497,7 @@ int apply_cli_config(const CliArgs& args) {
         return EXIT_SUCCESS;
     if (trtmc::config::SchemaRegistry::instance().registered_namespaces().empty()) {
         std::cerr << "[trtmc] --config/--set accepted but no config schemas are "
-                     "registered yet; values have no effect. Phase 4 cluster "
-                     "migrations add schemas."
+                     "registered yet; values have no effect."
                   << '\n';
         return EXIT_SUCCESS;
     }

--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -112,6 +112,13 @@ struct GenerateConfig {
     std::vector<float> condition_mask;    // ELF: [max_length], >0 marks fixed cond tokens
     std::vector<float> sampling_steps;    // ELF: optional upstream t_steps [num_steps + 1]
     std::vector<float> sde_noises;        // ELF: optional scaled eps [num_steps - 1, L, D]
+    // Diffusion (text-to-image): optional override for the negative prompt.
+    // Empty means "use the bundle's default negative prompt".
+    std::string negative_prompt;
+    // Diffusion (text-to-image): optional output image size override. <=0
+    // means "use the bundle's default height/width".
+    int32_t height{0};
+    int32_t width{0};
     int32_t eos_token_id{-1};
     int32_t tail_frames{0};           // speech-to-speech: extra frames after input
     bool use_chat_template{false};    ///< Apply chat template before tokenization

--- a/include/trtmc/runtime/scheduler.h
+++ b/include/trtmc/runtime/scheduler.h
@@ -14,7 +14,7 @@
 namespace trtmc {
 
 class IScheduler {
-public:
+  public:
     virtual ~IScheduler() = default;
 
     // Configure the timestep schedule for the given number of steps.
@@ -28,37 +28,66 @@ public:
 
     // Single scheduler step: update latents in-place.
     // latents += (sigma_next - sigma) * velocity
-    virtual void step(float* latents, const float* velocity,
-                      int32_t num_elements, int32_t step_index) = 0;
+    virtual void step(float* latents, const float* velocity, int32_t num_elements,
+                      int32_t step_index) = 0;
+};
+
+// Full FlowMatchEulerDiscreteScheduler configuration. Mirrors the diffusers
+// constructor surface that Qwen-Image relies on. The defaults match the
+// legacy static-shift behavior used by FLUX / Z-Image so the existing
+// single-arg constructor remains a no-op equivalent.
+struct FlowMatchEulerConfig {
+    int32_t num_train_timesteps = 1000;
+    float shift = 1.0f; // static shift; used when use_dynamic_shifting=false
+    bool use_dynamic_shifting = false;
+    float base_shift = 0.5f;
+    float max_shift = 1.15f;
+    int32_t base_image_seq_len = 256;
+    int32_t max_image_seq_len = 4096;
+    float shift_terminal = 0.0f; // 0 = disabled (matches diffusers None)
+    // "exponential" or empty/"linear". Empty defaults to "exponential" when
+    // use_dynamic_shifting=true (diffusers' default).
+    std::string time_shift_type;
 };
 
 // Flow Matching Euler Discrete Scheduler.
-// Used by: FLUX, Wan, Z-Image, SD3.
+// Used by: FLUX, Wan, Z-Image, SD3, Qwen-Image.
+//
+// Two construction modes:
+//   - Static-shift (FLUX / Z-Image): pass `shift` directly. Equivalent to
+//     diffusers' use_dynamic_shifting=False.
+//   - Full config (Qwen-Image): pass FlowMatchEulerConfig. Supports
+//     dynamic-mu shifting, exponential time_shift_type, and shift_terminal.
 class FlowMatchEulerScheduler final : public IScheduler {
-public:
-    explicit FlowMatchEulerScheduler(float shift = 1.0f,
-                                      int32_t num_train_timesteps = 1000);
+  public:
+    explicit FlowMatchEulerScheduler(float shift = 1.0f, int32_t num_train_timesteps = 1000);
+    explicit FlowMatchEulerScheduler(const FlowMatchEulerConfig& cfg);
 
+    // Static-shift path (matches the original behavior, unchanged for FLUX).
     void set_timesteps(int32_t num_steps) override;
+
+    // Dynamic-shifting path. Mirrors diffusers'
+    //   sigmas = np.linspace(1.0, 1.0/N, N)
+    //   set_timesteps(sigmas=sigmas, mu=calculate_shift(image_seq_len, ...))
+    // when use_dynamic_shifting=true. Falls back to the static-shift path
+    // when use_dynamic_shifting=false (image_seq_len ignored).
+    void set_timesteps(int32_t num_steps, int32_t image_seq_len);
+
     const std::vector<float>& timesteps() const override { return timesteps_; }
     const std::vector<float>& sigmas() const override { return sigmas_; }
 
-    void step(float* latents, const float* velocity,
-              int32_t num_elements, int32_t step_index) override;
+    void step(float* latents, const float* velocity, int32_t num_elements,
+              int32_t step_index) override;
 
-private:
-    float shift_;
-    int32_t num_train_timesteps_;
+  private:
+    FlowMatchEulerConfig cfg_;
     std::vector<float> timesteps_;
     std::vector<float> sigmas_;
 };
 
 // Factory: create scheduler by name.
-inline std::unique_ptr<IScheduler> create_scheduler(
-    const std::string& name, float shift = 1.0f)
-{
-    if (name == "flow_match_euler")
-    {
+inline std::unique_ptr<IScheduler> create_scheduler(const std::string& name, float shift = 1.0f) {
+    if (name == "flow_match_euler") {
         return std::make_unique<FlowMatchEulerScheduler>(shift);
     }
     return nullptr;

--- a/include/trtmc/trtmc_io.hpp
+++ b/include/trtmc/trtmc_io.hpp
@@ -177,6 +177,35 @@ struct LoadedImage {
 // Throws on file-not-found; returns empty LoadedImage on decode failure.
 LoadedImage read_image(const std::string& path);
 
+// Save float RGB pixels (HWC layout, values in [0, 1]) to a PNG file.
+// Out-of-range values are clamped to [0, 1] before being quantised to uint8.
+// Uses stb_image_write internally (linked via trtmc_core).
+// Throws std::runtime_error on size mismatch or write failure.
+void save_png(const std::string& path,
+              const std::vector<float>& hwc_pixels,
+              int width,
+              int height);
+
+// Convenience overload: save an ImageResult (first frame only) directly.
+// For single-frame results (num_frames <= 1) writes result.pixels;
+// for multi-frame results (video) writes only frame 0 — use the
+// generate-video CLI command instead to dump every frame.
+inline void save_png(const ImageResult& image, const std::string& path)
+{
+    const auto frame_pixels =
+        static_cast<std::size_t>(image.height) * static_cast<std::size_t>(image.width) * 3U;
+    if (image.pixels.size() < frame_pixels)
+        throw std::runtime_error("save_png: ImageResult pixel buffer is smaller than H*W*3");
+    if (image.pixels.size() == frame_pixels) {
+        save_png(path, image.pixels, image.width, image.height);
+        return;
+    }
+    // Multi-frame: only frame 0 is written.
+    std::vector<float> frame0(image.pixels.begin(),
+                              image.pixels.begin() + static_cast<std::ptrdiff_t>(frame_pixels));
+    save_png(path, frame0, image.width, image.height);
+}
+
 // Legacy placeholder (prefer read_image).
 inline std::vector<float> decode_image(const std::string& path, int& h, int& w)
 {

--- a/src/runtime/core/flow_match_euler_scheduler.cpp
+++ b/src/runtime/core/flow_match_euler_scheduler.cpp
@@ -2,26 +2,84 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <numeric>
+#include <stdexcept>
 
 namespace trtmc {
 
-FlowMatchEulerScheduler::FlowMatchEulerScheduler(float shift,
-                                                   int32_t num_train_timesteps)
-    : shift_(shift)
-    , num_train_timesteps_(num_train_timesteps)
-{
+namespace {
+
+// Mirrors diffusers/pipelines/flux/pipeline_flux.py:calculate_shift().
+// Linear interpolation: mu = image_seq_len * m + b where
+//   m = (max_shift - base_shift) / (max_seq - base_seq)
+//   b = base_shift - m * base_seq
+inline double calculate_shift(int32_t image_seq_len, int32_t base_seq, int32_t max_seq,
+                              double base_shift, double max_shift) {
+    if (max_seq == base_seq) {
+        return base_shift;
+    }
+    const double m = (max_shift - base_shift) / static_cast<double>(max_seq - base_seq);
+    const double b = base_shift - m * static_cast<double>(base_seq);
+    return static_cast<double>(image_seq_len) * m + b;
 }
 
-void FlowMatchEulerScheduler::set_timesteps(int32_t num_steps)
-{
-    // Match HF FlowMatchEulerDiscreteScheduler:
-    // 1. Linspace in t-space from N to sigma_min*N
-    // 2. Convert to sigma-space and apply shift
-    // 3. Append terminal sigma=0
+// Mirrors diffusers _time_shift_exponential:
+//   return math.exp(mu) / (math.exp(mu) + (1/t - 1)**sigma)
+// We hardcode sigma=1.0 (matches diffusers' set_timesteps call site).
+inline double time_shift_exponential(double mu, double t) {
+    const double e_mu = std::exp(mu);
+    const double inv = (1.0 / t) - 1.0;
+    // sigma=1.0 so the exponent simplifies to the identity.
+    return e_mu / (e_mu + inv);
+}
 
-    const double n = static_cast<double>(num_train_timesteps_);
-    const double s = static_cast<double>(shift_);
+// Mirrors diffusers _time_shift_linear (provided for completeness).
+inline double time_shift_linear(double mu, double t) {
+    const double inv = (1.0 / t) - 1.0;
+    return mu / (mu + inv);
+}
+
+// Mirrors diffusers' stretch_shift_to_terminal():
+//   one_minus_z = 1 - t
+//   scale = one_minus_z[-1] / (1 - shift_terminal)
+//   stretched_t = 1 - (one_minus_z / scale)
+inline void apply_shift_terminal(std::vector<double>& sig, double shift_terminal) {
+    if (sig.empty()) {
+        return;
+    }
+    const double tail = 1.0 - sig.back();
+    if (tail == 0.0) {
+        return;
+    }
+    const double scale = tail / (1.0 - shift_terminal);
+    if (scale == 0.0) {
+        return;
+    }
+    for (auto& s : sig) {
+        s = 1.0 - ((1.0 - s) / scale);
+    }
+}
+
+} // namespace
+
+FlowMatchEulerScheduler::FlowMatchEulerScheduler(float shift, int32_t num_train_timesteps) {
+    cfg_.shift = shift;
+    cfg_.num_train_timesteps = num_train_timesteps;
+    cfg_.use_dynamic_shifting = false;
+}
+
+FlowMatchEulerScheduler::FlowMatchEulerScheduler(const FlowMatchEulerConfig& cfg) : cfg_(cfg) {}
+
+void FlowMatchEulerScheduler::set_timesteps(int32_t num_steps) {
+    // Static-shift path (FLUX / Z-Image). Match diffusers
+    // FlowMatchEulerDiscreteScheduler when use_dynamic_shifting=False:
+    // 1. timesteps = linspace(1, N, N)[::-1] then take linspace(t_max, t_min, K)
+    // 2. sigmas = timesteps / N
+    // 3. sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)
+    // 4. Append terminal sigma=0
+    const double n = static_cast<double>(cfg_.num_train_timesteps);
+    const double s = static_cast<double>(cfg_.shift);
 
     // sigma_min = shift * (1/N) / (1 + (shift-1)/N)
     const double raw_sigma_min = 1.0 / n;
@@ -32,59 +90,112 @@ void FlowMatchEulerScheduler::set_timesteps(int32_t num_steps)
 
     // Linspace in t-space
     std::vector<double> t_steps(static_cast<std::size_t>(num_steps));
-    for (int32_t i = 0; i < num_steps; ++i)
-    {
-        double frac = (num_steps <= 1) ? 0.0
-            : static_cast<double>(i) / static_cast<double>(num_steps - 1);
+    for (int32_t i = 0; i < num_steps; ++i) {
+        double frac =
+            (num_steps <= 1) ? 0.0 : static_cast<double>(i) / static_cast<double>(num_steps - 1);
         t_steps[static_cast<std::size_t>(i)] = t_max + frac * (t_min - t_max);
     }
 
     // Convert to sigmas
     std::vector<double> sig(static_cast<std::size_t>(num_steps));
-    for (int32_t i = 0; i < num_steps; ++i)
-    {
+    for (int32_t i = 0; i < num_steps; ++i) {
         sig[static_cast<std::size_t>(i)] = t_steps[static_cast<std::size_t>(i)] / n;
     }
 
     // Apply shift
-    if (shift_ != 1.0f)
-    {
-        for (auto& sigma : sig)
-        {
+    if (cfg_.shift != 1.0f) {
+        for (auto& sigma : sig) {
             sigma = s * sigma / (1.0 + (s - 1.0) * sigma);
         }
     }
 
+    // shift_terminal applies in both paths.
+    if (cfg_.shift_terminal != 0.0f) {
+        apply_shift_terminal(sig, static_cast<double>(cfg_.shift_terminal));
+    }
+
     // Append terminal sigma=0
     sigmas_.resize(static_cast<std::size_t>(num_steps) + 1);
-    for (int32_t i = 0; i < num_steps; ++i)
-    {
+    for (int32_t i = 0; i < num_steps; ++i) {
         sigmas_[static_cast<std::size_t>(i)] = static_cast<float>(sig[static_cast<std::size_t>(i)]);
     }
     sigmas_[static_cast<std::size_t>(num_steps)] = 0.0f;
 
     // Timesteps = sigmas[:-1] * num_train_timesteps
     timesteps_.resize(static_cast<std::size_t>(num_steps));
-    for (int32_t i = 0; i < num_steps; ++i)
-    {
+    for (int32_t i = 0; i < num_steps; ++i) {
         timesteps_[static_cast<std::size_t>(i)] =
-            sigmas_[static_cast<std::size_t>(i)] * static_cast<float>(num_train_timesteps_);
+            sigmas_[static_cast<std::size_t>(i)] * static_cast<float>(cfg_.num_train_timesteps);
     }
 }
 
-void FlowMatchEulerScheduler::step(float* latents, const float* velocity,
-                                    int32_t num_elements, int32_t step_index)
-{
+void FlowMatchEulerScheduler::set_timesteps(int32_t num_steps, int32_t image_seq_len) {
+    if (!cfg_.use_dynamic_shifting) {
+        // Image-seq-len argument is irrelevant; fall back to static-shift path.
+        set_timesteps(num_steps);
+        return;
+    }
+
+    if (num_steps <= 0) {
+        throw std::runtime_error("FlowMatchEulerScheduler::set_timesteps: num_steps must be > 0");
+    }
+
+    // Mirror QwenImageDebugRunner._generate exactly:
+    //   sigmas = np.linspace(1.0, 1.0/N, N)
+    //   mu = calculate_shift(image_seq_len, base, max, base_shift, max_shift)
+    //   scheduler.set_timesteps(sigmas=sigmas, mu=mu)
+    //
+    // Inside diffusers' set_timesteps with custom sigmas + use_dynamic_shifting:
+    //   sigmas = time_shift(mu, 1.0, sigmas)           # exponential by default
+    //   if shift_terminal: sigmas = stretch_shift_to_terminal(sigmas)
+    //   timesteps = sigmas * num_train_timesteps
+    //   sigmas = cat([sigmas, [0]])
+    const std::size_t N = static_cast<std::size_t>(num_steps);
+    std::vector<double> sig(N);
+    const double last = 1.0 / static_cast<double>(num_steps);
+    for (std::size_t i = 0; i < N; ++i) {
+        const double frac = (N == 1) ? 0.0 : static_cast<double>(i) / static_cast<double>(N - 1);
+        sig[i] = 1.0 + frac * (last - 1.0);
+    }
+
+    const double mu =
+        calculate_shift(image_seq_len, cfg_.base_image_seq_len, cfg_.max_image_seq_len,
+                        static_cast<double>(cfg_.base_shift), static_cast<double>(cfg_.max_shift));
+
+    const bool linear = (cfg_.time_shift_type == "linear");
+    for (auto& s : sig) {
+        s = linear ? time_shift_linear(mu, s) : time_shift_exponential(mu, s);
+    }
+
+    if (cfg_.shift_terminal != 0.0f) {
+        apply_shift_terminal(sig, static_cast<double>(cfg_.shift_terminal));
+    }
+
+    sigmas_.resize(N + 1);
+    for (std::size_t i = 0; i < N; ++i) {
+        sigmas_[i] = static_cast<float>(sig[i]);
+    }
+    sigmas_[N] = 0.0f;
+
+    timesteps_.resize(N);
+    const double train = static_cast<double>(cfg_.num_train_timesteps);
+    for (std::size_t i = 0; i < N; ++i) {
+        timesteps_[i] = static_cast<float>(sig[i] * train);
+    }
+}
+
+void FlowMatchEulerScheduler::step(float* latents, const float* velocity, int32_t num_elements,
+                                   int32_t step_index) {
     auto si = static_cast<std::size_t>(step_index);
-    if (si + 1 >= sigmas_.size()) return;
+    if (si + 1 >= sigmas_.size())
+        return;
 
     const float sigma = sigmas_[si];
     const float sigma_next = sigmas_[si + 1];
-    const float dt = sigma_next - sigma;  // negative (sigma decreasing)
+    const float dt = sigma_next - sigma; // negative (sigma decreasing)
 
     // Euler step: latents += dt * velocity
-    for (int32_t i = 0; i < num_elements; ++i)
-    {
+    for (int32_t i = 0; i < num_elements; ++i) {
         latents[i] += dt * velocity[i];
     }
 }

--- a/src/runtime/domains/diffusion/qwen_image_types.cpp
+++ b/src/runtime/domains/diffusion/qwen_image_types.cpp
@@ -1,0 +1,222 @@
+// =============================================================================
+// qwen_image_types.cpp — QwenImageConfig::parse() implementation.
+// =============================================================================
+//
+// Walks a bundle config.json blob and populates the nested QwenImageConfig
+// struct hierarchy. Per-section parsing is scoped via
+// extract_json_object_text() so sibling keys with the same name (e.g.
+// "hidden_size" in both text_encoder and denoiser, or "rope_theta" in both
+// text_encoder and denoiser, or "type" in text_encoder/denoiser/vae) do not
+// collide.
+//
+// Trace: ARCH-FAM-001, UD-FAM-QWEN-IMAGE-01.
+// =============================================================================
+
+#include "runtime/domains/diffusion/qwen_image_types.h"
+
+#include "runtime/domains/diffusion/diffusion_preprocessor_weights_helpers.h"
+#include "utils/json_helpers.h"
+
+#include <cstddef>
+#include <iostream>
+#include <string>
+
+namespace trtmc {
+namespace {
+
+QwenImageTaskMode parse_task_mode(const std::string& raw) {
+    if (raw == "edit") {
+        return QwenImageTaskMode::Edit;
+    }
+    // "t2i" or anything else defaults to T2I (matches Python default).
+    return QwenImageTaskMode::T2I;
+}
+
+void parse_diffusion(const std::string& obj, QwenImageDiffusionConfig& dc) {
+    if (obj.empty())
+        return;
+    dc.scheduler = extract_json_string(obj, "scheduler", dc.scheduler);
+    dc.num_train_timesteps = extract_json_int(obj, "num_train_timesteps", dc.num_train_timesteps);
+    dc.shift = extract_json_float(obj, "shift", dc.shift);
+    dc.use_dynamic_shifting =
+        extract_json_bool(obj, "use_dynamic_shifting", dc.use_dynamic_shifting);
+    dc.base_shift = extract_json_float(obj, "base_shift", dc.base_shift);
+    dc.max_shift = extract_json_float(obj, "max_shift", dc.max_shift);
+    dc.base_image_seq_len = extract_json_int(obj, "base_image_seq_len", dc.base_image_seq_len);
+    dc.max_image_seq_len = extract_json_int(obj, "max_image_seq_len", dc.max_image_seq_len);
+    dc.shift_terminal = extract_json_float(obj, "shift_terminal", dc.shift_terminal);
+    dc.time_shift_type = extract_json_string(obj, "time_shift_type", dc.time_shift_type);
+    dc.default_num_inference_steps =
+        extract_json_int(obj, "default_num_inference_steps", dc.default_num_inference_steps);
+    dc.default_cfg_scale = extract_json_float(obj, "default_cfg_scale", dc.default_cfg_scale);
+    dc.default_negative_prompt =
+        extract_json_string(obj, "default_negative_prompt", dc.default_negative_prompt);
+}
+
+void parse_text_encoder(const std::string& obj, QwenImageTextEncoderConfig& tc) {
+    if (obj.empty())
+        return;
+    tc.type = extract_json_string(obj, "type", tc.type);
+    tc.hidden_size = extract_json_int(obj, "hidden_size", tc.hidden_size);
+    tc.num_layers = extract_json_int(obj, "num_layers", tc.num_layers);
+    tc.num_heads = extract_json_int(obj, "num_heads", tc.num_heads);
+    tc.num_kv_heads = extract_json_int(obj, "num_kv_heads", tc.num_kv_heads);
+    tc.head_dim = extract_json_int(obj, "head_dim", tc.head_dim);
+    tc.intermediate_size = extract_json_int(obj, "intermediate_size", tc.intermediate_size);
+    tc.vocab_size = extract_json_int(obj, "vocab_size", tc.vocab_size);
+    tc.rope_theta = extract_json_float(obj, "rope_theta", tc.rope_theta);
+    tc.rms_norm_eps = extract_json_float(obj, "rms_norm_eps", tc.rms_norm_eps);
+    tc.max_seq_len = extract_json_int(obj, "max_seq_len", tc.max_seq_len);
+    tc.extract_hidden_state_layer =
+        extract_json_int(obj, "extract_hidden_state_layer", tc.extract_hidden_state_layer);
+    tc.apply_final_norm = extract_json_bool(obj, "apply_final_norm", tc.apply_final_norm);
+    tc.tokenizer_template_kind =
+        extract_json_string(obj, "tokenizer_template_kind", tc.tokenizer_template_kind);
+}
+
+void parse_denoiser(const std::string& obj, QwenImageDenoiserConfig& dn) {
+    if (obj.empty())
+        return;
+    dn.type = extract_json_string(obj, "type", dn.type);
+    dn.in_channels = extract_json_int(obj, "in_channels", dn.in_channels);
+    dn.out_channels = extract_json_int(obj, "out_channels", dn.out_channels);
+    dn.patch_size = extract_json_int(obj, "patch_size", dn.patch_size);
+    dn.hidden_size = extract_json_int(obj, "hidden_size", dn.hidden_size);
+    dn.num_joint_blocks = extract_json_int(obj, "num_joint_blocks", dn.num_joint_blocks);
+    dn.num_single_blocks = extract_json_int(obj, "num_single_blocks", dn.num_single_blocks);
+    dn.num_attention_heads = extract_json_int(obj, "num_attention_heads", dn.num_attention_heads);
+    dn.attention_head_dim = extract_json_int(obj, "attention_head_dim", dn.attention_head_dim);
+    auto axes = extract_json_int_array(obj, "rope_axes_dim", 8);
+    if (!axes.empty()) {
+        dn.rope_axes_dim = std::move(axes);
+    }
+    dn.rope_theta = extract_json_float(obj, "rope_theta", dn.rope_theta);
+    dn.text_embed_dim = extract_json_int(obj, "text_embed_dim", dn.text_embed_dim);
+    dn.guidance_embeds = extract_json_bool(obj, "guidance_embeds", dn.guidance_embeds);
+    dn.max_image_tokens = extract_json_int(obj, "max_image_tokens", dn.max_image_tokens);
+    dn.max_text_tokens = extract_json_int(obj, "max_text_tokens", dn.max_text_tokens);
+}
+
+void parse_vae(const std::string& obj, QwenImageVAEConfig& vc) {
+    if (obj.empty())
+        return;
+    vc.type = extract_json_string(obj, "type", vc.type);
+    vc.latent_channels = extract_json_int(obj, "latent_channels", vc.latent_channels);
+    vc.spatial_scale_factor =
+        extract_json_int(obj, "spatial_scale_factor", vc.spatial_scale_factor);
+    vc.base_dim = extract_json_int(obj, "base_dim", vc.base_dim);
+    auto dim_mult = extract_json_int_array(obj, "dim_mult", 16);
+    if (!dim_mult.empty()) {
+        vc.dim_mult = std::move(dim_mult);
+    }
+    auto td = extract_json_bool_array(obj, "temporal_downsample", 16);
+    if (!td.empty()) {
+        vc.temporal_downsample = std::move(td);
+    }
+    // latents_mean / latents_std may have up to latent_channels entries (16
+    // by default). Cap at 64 to be safe for any future variants.
+    auto lm = extract_json_float_array(obj, "latents_mean", 64);
+    if (!lm.empty()) {
+        vc.latents_mean = std::move(lm);
+    }
+    auto ls = extract_json_float_array(obj, "latents_std", 64);
+    if (!ls.empty()) {
+        vc.latents_std = std::move(ls);
+    }
+    vc.has_encoder = extract_json_bool(obj, "has_encoder", vc.has_encoder);
+    vc.has_decoder = extract_json_bool(obj, "has_decoder", vc.has_decoder);
+}
+
+void parse_image(const std::string& obj, QwenImageImageConfig& ic) {
+    if (obj.empty())
+        return;
+    ic.default_height = extract_json_int(obj, "default_height", ic.default_height);
+    ic.default_width = extract_json_int(obj, "default_width", ic.default_width);
+    ic.min_height = extract_json_int(obj, "min_height", ic.min_height);
+    ic.min_width = extract_json_int(obj, "min_width", ic.min_width);
+    ic.max_height = extract_json_int(obj, "max_height", ic.max_height);
+    ic.max_width = extract_json_int(obj, "max_width", ic.max_width);
+    ic.height_alignment = extract_json_int(obj, "height_alignment", ic.height_alignment);
+    ic.width_alignment = extract_json_int(obj, "width_alignment", ic.width_alignment);
+}
+
+void parse_tokenizer(const std::string& obj, QwenImageTokenizerConfig& tk) {
+    if (obj.empty())
+        return;
+    tk.kind = extract_json_string(obj, "kind", tk.kind);
+    tk.class_name = extract_json_string(obj, "class", tk.class_name);
+    tk.prompt_template_kind =
+        extract_json_string(obj, "prompt_template_kind", tk.prompt_template_kind);
+    tk.prompt_template_drop_idx =
+        extract_json_int(obj, "prompt_template_drop_idx", tk.prompt_template_drop_idx);
+    tk.tokenizer_max_length =
+        extract_json_int(obj, "tokenizer_max_length", tk.tokenizer_max_length);
+    tk.add_special_tokens = extract_json_bool(obj, "add_special_tokens", tk.add_special_tokens);
+}
+
+} // namespace
+
+QwenImageConfig QwenImageConfig::parse(std::string_view config_json) {
+    QwenImageConfig cfg;
+    const std::string text(config_json);
+
+    // Top-level fields (sibling to the nested sections — flat lookup is safe
+    // because these keys do not appear inside any nested section).
+    cfg.engine_backend = extract_json_string(text, "engine_backend", cfg.engine_backend);
+    cfg.runtime_strategy = extract_json_string(text, "runtime_strategy", cfg.runtime_strategy);
+    cfg.model_family = extract_json_string(text, "model_family", cfg.model_family);
+    cfg.model_variant = extract_json_string(text, "model_variant", cfg.model_variant);
+    const std::string task_mode_raw = extract_json_string(text, "task_mode", "t2i");
+    cfg.task_mode = parse_task_mode(task_mode_raw);
+
+    // Nested sections: scope each one via its object text to avoid key
+    // collisions between siblings (e.g. "type", "hidden_size", "rope_theta").
+    parse_diffusion(extract_json_object_text(text, "diffusion"), cfg.diffusion);
+    parse_text_encoder(extract_json_object_text(text, "text_encoder"), cfg.text_encoder);
+    parse_denoiser(extract_json_object_text(text, "denoiser"), cfg.denoiser);
+    parse_vae(extract_json_object_text(text, "vae"), cfg.vae);
+    parse_image(extract_json_object_text(text, "image"), cfg.image);
+    parse_tokenizer(extract_json_object_text(text, "tokenizer"), cfg.tokenizer);
+
+    return cfg;
+}
+
+// -----------------------------------------------------------------------------
+// Preprocessor weights parser.
+// -----------------------------------------------------------------------------
+//
+// The blob carries latents_mean (float[16]) and latents_std (float[16]) for
+// the Qwen-Image VAE. Format is the canonical diffusion preprocessor wire
+// layout shared with FLUX / Z-Image / Wan-T2V — see
+// diffusion_preprocessor_weights_helpers.h. We reuse extract_preprocessor_index
+// + load_preprocessor_floats so the C++ parser mirrors Python's
+// pack_qwen_image_preprocessor_weights() exactly.
+//
+// On a malformed header (blob < 4 bytes or index length overflow) the helper
+// reports the failure to stderr and we return a default-constructed struct
+// (valid=false). On a partial blob (one missing key), the present vector is
+// populated and the missing one remains empty.
+QwenImagePreprocessorWeights parse_qwen_image_preprocessor_weights(const std::vector<char>& data) {
+    QwenImagePreprocessorWeights w;
+
+    std::string index_json;
+    const char* blob = nullptr;
+    std::size_t blob_size = 0;
+    if (!diffusion::extract_preprocessor_index(data, index_json, blob, blob_size)) {
+        return w;
+    }
+
+    const bool got_mean = diffusion::load_preprocessor_floats(index_json, blob, blob_size,
+                                                              "latents_mean", w.latents_mean);
+    const bool got_std = diffusion::load_preprocessor_floats(index_json, blob, blob_size,
+                                                             "latents_std", w.latents_std);
+
+    w.valid = got_mean && got_std;
+
+    std::cerr << "[qwen-image] Preprocessor weights: " << (w.valid ? "OK" : "INCOMPLETE")
+              << " (latents_mean=" << w.latents_mean.size()
+              << ", latents_std=" << w.latents_std.size() << ")\n";
+    return w;
+}
+
+} // namespace trtmc

--- a/src/runtime/domains/diffusion/qwen_image_types.h
+++ b/src/runtime/domains/diffusion/qwen_image_types.h
@@ -1,0 +1,159 @@
+#pragma once
+// =============================================================================
+// qwen_image_types.h — Qwen-Image runtime configuration types.
+// =============================================================================
+//
+// Mirrors the bundle config.json schema produced by
+// tensorrt_model_connect.qwen_image_bundle_config.build_bundle_config().
+// Each top-level JSON section (diffusion, text_encoder, denoiser, vae,
+// image, tokenizer) maps onto a dedicated struct, and
+// QwenImageConfig::parse() walks the JSON blob to populate the aggregate.
+//
+// Missing fields fall back to defaults so partial / minimal configs (e.g.
+// Edit-mode stubs that only set has_encoder=true) still parse cleanly.
+//
+// Trace: ARCH-FAM-001, UD-FAM-QWEN-IMAGE-01.
+// =============================================================================
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace trtmc {
+
+enum class QwenImageTaskMode {
+    T2I,
+    Edit,
+};
+
+struct QwenImageDiffusionConfig {
+    std::string scheduler{"flow_match_euler"};
+    int32_t num_train_timesteps{1000};
+    float shift{1.0F};
+    bool use_dynamic_shifting{false};
+    float base_shift{0.5F};
+    float max_shift{0.9F};
+    int32_t base_image_seq_len{256};
+    int32_t max_image_seq_len{8192};
+    float shift_terminal{0.0F};
+    std::string time_shift_type; // "exponential" or empty (static)
+    int32_t default_num_inference_steps{50};
+    float default_cfg_scale{4.0F};
+    std::string default_negative_prompt; // " "
+};
+
+struct QwenImageDenoiserConfig {
+    std::string type{"qwen_image_mmdit"};
+    int32_t in_channels{64};
+    int32_t out_channels{16};
+    int32_t patch_size{2};
+    int32_t hidden_size{3072};
+    int32_t num_joint_blocks{60};
+    int32_t num_single_blocks{0};
+    int32_t num_attention_heads{24};
+    int32_t attention_head_dim{128};
+    std::vector<int32_t> rope_axes_dim; // {16, 56, 56}
+    float rope_theta{10000.0F};
+    int32_t text_embed_dim{3584};
+    bool guidance_embeds{false};
+    int32_t max_image_tokens{8192};
+    int32_t max_text_tokens{1024};
+};
+
+struct QwenImageVAEConfig {
+    std::string type{"autoencoder_kl_qwen_image"};
+    int32_t latent_channels{16};
+    int32_t spatial_scale_factor{8};
+    int32_t base_dim{96};
+    std::vector<int32_t> dim_mult;         // {1, 2, 4, 4}
+    std::vector<bool> temporal_downsample; // {false, true, true}
+    std::vector<float> latents_mean;       // length-latent_channels (16)
+    std::vector<float> latents_std;        // length-latent_channels (16)
+    bool has_encoder{false};
+    bool has_decoder{true};
+};
+
+struct QwenImageImageConfig {
+    int32_t default_height{1024};
+    int32_t default_width{1024};
+    int32_t min_height{256};
+    int32_t min_width{256};
+    int32_t max_height{2048};
+    int32_t max_width{2048};
+    int32_t height_alignment{16};
+    int32_t width_alignment{16};
+};
+
+struct QwenImageTokenizerConfig {
+    std::string kind{"hf_python"};
+    std::string class_name{"Qwen2Tokenizer"}; // "class" in JSON (C++ reserved word)
+    std::string prompt_template_kind;
+    int32_t prompt_template_drop_idx{0};
+    int32_t tokenizer_max_length{1024};
+    bool add_special_tokens{false};
+};
+
+struct QwenImageTextEncoderConfig {
+    std::string type{"qwen2_5_vl_lm"};
+    int32_t hidden_size{3584};
+    int32_t num_layers{28};
+    int32_t num_heads{28};
+    int32_t num_kv_heads{4};
+    int32_t head_dim{128};
+    int32_t intermediate_size{18944};
+    int32_t vocab_size{152064};
+    float rope_theta{1000000.0F};
+    float rms_norm_eps{1e-6F};
+    int32_t max_seq_len{1024};
+    int32_t extract_hidden_state_layer{-1};
+    bool apply_final_norm{true};
+    std::string tokenizer_template_kind;
+};
+
+struct QwenImageConfig {
+    std::string engine_backend;
+    std::string runtime_strategy;
+    std::string model_family;
+    std::string model_variant;
+    QwenImageTaskMode task_mode{QwenImageTaskMode::T2I};
+
+    QwenImageDiffusionConfig diffusion;
+    QwenImageTextEncoderConfig text_encoder;
+    QwenImageDenoiserConfig denoiser;
+    QwenImageVAEConfig vae;
+    QwenImageImageConfig image;
+    QwenImageTokenizerConfig tokenizer;
+
+    // Parse a bundle config.json blob into a QwenImageConfig. Missing keys
+    // / sections retain their struct defaults.
+    static QwenImageConfig parse(std::string_view config_json);
+};
+
+// Preprocessor weights blob for Qwen-Image.
+// Forward-declared here so downstream pipeline code can refer to the type;
+// the parser implementation lives next to the preprocessor weights helpers.
+struct QwenImagePreprocessorWeights {
+    std::vector<float> latents_mean; // length-latent_channels
+    std::vector<float> latents_std;  // length-latent_channels
+    bool valid{false};
+};
+
+// Parse a Qwen-Image preprocessor_weights bundle section into the struct.
+//
+// The blob format is the canonical diffusion preprocessor wire format
+// (shared with FLUX / Z-Image / Wan-T2V):
+//   <u32 LE index_len><UTF-8 JSON index><raw float32 payload>
+//
+// Recognized index entries:
+//   - "latents_mean": float[16] — per-channel VAE latent mean.
+//   - "latents_std":  float[16] — per-channel VAE latent std.
+//
+// Both vectors must be present for valid=true. Missing keys leave the
+// corresponding vector empty (graceful degradation — the caller can
+// decide whether that is fatal for its pipeline mode).
+//
+// Trace: ARCH-FAM-001, UD-FAM-QWEN-IMAGE-01.
+QwenImagePreprocessorWeights parse_qwen_image_preprocessor_weights(const std::vector<char>& data);
+
+} // namespace trtmc

--- a/src/runtime/models/qwen_image/MODEL.toml
+++ b/src/runtime/models/qwen_image/MODEL.toml
@@ -1,0 +1,1 @@
+runtime_strategies = ["diffusion_qwen_image"]

--- a/src/runtime/models/qwen_image/pipeline.cpp
+++ b/src/runtime/models/qwen_image/pipeline.cpp
@@ -1,0 +1,749 @@
+// =============================================================================
+// qwen_image_pipeline.cpp — Qwen-Image diffusion pipeline implementation.
+// =============================================================================
+//
+// Trace: ARCH-FAM-001, UD-FAM-QWEN-IMAGE-01.
+// =============================================================================
+
+#include "runtime/models/qwen_image/pipeline.h"
+
+#include "runtime/domains/diffusion/diffusion_scheduler_helpers.h"
+#include "trtmc/runtime/scheduler.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstring>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace trtmc {
+
+namespace {
+
+// Diffusers QwenImagePipeline.prompt_template_encode (T2I path).
+// Source: references/diffusers/.../pipeline_qwenimage.py:176.
+// The "{}" marker is the user-prompt insertion slot. We split into prefix
+// and suffix so the prompt slots in without an std::format call.
+inline const char* kPromptTemplatePrefix =
+    "<|im_start|>system\nDescribe the image by detailing the color, shape, "
+    "size, texture, quantity, text, spatial relationships of the objects "
+    "and background:<|im_end|>\n<|im_start|>user\n";
+inline const char* kPromptTemplateSuffix = "<|im_end|>\n<|im_start|>assistant\n";
+
+} // namespace
+
+QwenImagePipeline::QwenImagePipeline(Construction c)
+    : text_engine_(std::move(c.text_engine)), denoiser_engine_(std::move(c.denoiser_engine)),
+      vae_decoder_engine_(std::move(c.vae_decoder_engine)),
+      vision_engine_(std::move(c.vision_engine)),
+      vae_encoder_engine_(std::move(c.vae_encoder_engine)), tokenizer_(std::move(c.tokenizer)),
+      config_(std::move(c.config)), preprocessor_(std::move(c.preprocessor)),
+      model_id_(std::move(c.model_id)), bundle_path_(std::move(c.bundle_path)) {}
+
+QwenImagePipeline::~QwenImagePipeline() = default;
+
+namespace {
+
+// Bundle of runtime knobs resolved for one generate_image() call. All fields
+// have been finalized — either from `cfg` overrides or bundle defaults.
+struct GenerateKnobs {
+    int num_steps;
+    float cfg_scale;
+    int height;
+    int width;
+    uint64_t seed;
+    std::string negative;
+};
+
+// Resolve runtime knobs from cfg, falling back to bundle defaults.
+GenerateKnobs resolve_generate_knobs(const GenerateConfig& cfg, const QwenImageConfig& bundle_cfg) {
+    GenerateKnobs k;
+    k.num_steps = diffusion::resolve_requested_steps(
+        cfg.num_steps, bundle_cfg.diffusion.default_num_inference_steps, true);
+    k.cfg_scale = diffusion::resolve_requested_guidance(cfg.guidance_scale,
+                                                        bundle_cfg.diffusion.default_cfg_scale);
+    k.height = cfg.height > 0 ? cfg.height : bundle_cfg.image.default_height;
+    k.width = cfg.width > 0 ? cfg.width : bundle_cfg.image.default_width;
+    // mirrors debug_runner default seed=42
+    k.seed = cfg.seed >= 0 ? static_cast<uint64_t>(cfg.seed) : 42ULL;
+    // Negative prompt: empty in cfg means "use bundle default".
+    k.negative = cfg.negative_prompt.empty() ? bundle_cfg.diffusion.default_negative_prompt
+                                             : cfg.negative_prompt;
+    return k;
+}
+
+// Validate that all engines required for generate_image() are loaded.
+// Throws if any engine is null.
+void validate_generate_image_engines(bool has_text, bool has_denoiser, bool has_vae) {
+    if (!has_text || !has_denoiser || !has_vae) {
+        throw std::runtime_error("QwenImagePipeline::generate_image: required engines (text, "
+                                 "denoiser, vae_decoder) must all be loaded");
+    }
+}
+
+// Validate that the latent shape derived from height/width is positive in
+// all dimensions. Throws on any non-positive value.
+void validate_generate_image_shape(int latent_h, int latent_w, int n_img_tokens) {
+    if (latent_h <= 0 || latent_w <= 0 || n_img_tokens <= 0) {
+        throw std::runtime_error("QwenImagePipeline::generate_image: invalid latent shape derived "
+                                 "from height/width");
+    }
+}
+
+// Validate that caller-supplied initial_latents (when non-empty) match the
+// expected unpacked [C, h_lat, w_lat] size. Throws on mismatch; no-op for
+// the empty case (caller will sample fresh latents).
+void validate_caller_initial_latents(const std::vector<float>& initial_latents, int latent_channels,
+                                     int latent_h, int latent_w) {
+    if (initial_latents.empty()) {
+        return;
+    }
+    const std::size_t expected_unpacked = static_cast<std::size_t>(latent_channels) *
+                                          static_cast<std::size_t>(latent_h) *
+                                          static_cast<std::size_t>(latent_w);
+    if (initial_latents.size() != expected_unpacked) {
+        throw std::runtime_error("QwenImagePipeline::generate_image: cfg.initial_latents size " +
+                                 std::to_string(initial_latents.size()) +
+                                 " does not match expected [1, " + std::to_string(latent_channels) +
+                                 ", " + std::to_string(latent_h) + ", " + std::to_string(latent_w) +
+                                 "] = " + std::to_string(expected_unpacked));
+    }
+}
+
+} // namespace
+
+ImageResult QwenImagePipeline::generate_image(const std::string& prompt,
+                                              const GenerateConfig& cfg) {
+    validate_generate_image_engines(text_engine_ != nullptr, denoiser_engine_ != nullptr,
+                                    vae_decoder_engine_ != nullptr);
+
+    // 1) Resolve runtime knobs from cfg, falling back to bundle defaults.
+    const GenerateKnobs k = resolve_generate_knobs(cfg, config_);
+
+    // 2) Encode positive + negative prompts via the text encoder engine.
+    auto pos = encode_text(prompt);
+    auto neg = encode_text(k.negative);
+
+    // 3) Derive latent / packed shapes from target image size.
+    auto shape = compute_latent_shape(k.height, k.width);
+    validate_generate_image_shape(shape.latent_h, shape.latent_w, shape.n_img_tokens);
+
+    // 4) Seed initial latents [C, h_lat, w_lat] then patchify to
+    //    [1, n_img, in_channels=64].
+    //
+    // When the caller supplies cfg.initial_latents (E2E shared-latents path),
+    // those bytes are used verbatim instead of the std::mt19937 sample so the
+    // C++ and HF reference subprocesses see byte-identical noise. The buffer
+    // is the UNPACKED [1, C, h_lat, w_lat] (row-major C, H, W) layout that
+    // matches diffusers' randn_tensor((1, 1, C, h_lat, w_lat)) reshape; we
+    // patchify it locally just like the seeded path does.
+    validate_caller_initial_latents(cfg.initial_latents, config_.vae.latent_channels,
+                                    shape.latent_h, shape.latent_w);
+    std::vector<float> latents = cfg.initial_latents.empty()
+                                     ? prepare_initial_latents(shape.latent_h, shape.latent_w,
+                                                               config_.vae.latent_channels, k.seed)
+                                     : cfg.initial_latents;
+    auto latents_packed = patchify_latents(latents, config_.vae.latent_channels, shape.latent_h,
+                                           shape.latent_w, config_.denoiser.patch_size);
+
+    // 5) Run the N-step denoise loop with true-CFG.
+    auto denoised = denoise_loop_with_cfg(std::move(latents_packed), pos, neg, shape.n_img_tokens,
+                                          k.num_steps, k.cfg_scale);
+
+    // 6) VAE decode -> HWC float pixels in [0, 1].
+    auto image = vae_decode(denoised, shape.n_img_tokens, shape.latent_h, shape.latent_w);
+
+    // 7) Package into ImageResult (PNG write is the caller / CLI's job).
+    ImageResult result;
+    result.height = image.height;
+    result.width = image.width;
+    result.channels = 3;
+    result.num_frames = 1;
+    result.pixels = std::move(image.pixels);
+    return result;
+}
+
+// -----------------------------------------------------------------------------
+// Math helpers. Exposed publicly for unit-testability; called by the full
+// generate_image() implementation.
+// -----------------------------------------------------------------------------
+
+QwenImagePipeline::LatentShape QwenImagePipeline::compute_latent_shape(int height,
+                                                                       int width) const {
+    const int vae_scale = config_.vae.spatial_scale_factor;
+    const int patch = config_.denoiser.patch_size;
+    if (vae_scale <= 0 || patch <= 0) {
+        throw std::runtime_error(
+            "QwenImagePipeline::compute_latent_shape: invalid vae_scale_factor "
+            "or patch_size in config");
+    }
+    LatentShape s;
+    s.latent_h = height / vae_scale;
+    s.latent_w = width / vae_scale;
+    s.packed_h = s.latent_h / patch;
+    s.packed_w = s.latent_w / patch;
+    s.n_img_tokens = s.packed_h * s.packed_w;
+    return s;
+}
+
+float QwenImagePipeline::normalize_timestep(float scalar_t) const {
+    // Qwen-Image scheduler: timesteps live in [0, num_train_timesteps]; the
+    // engine's baked-in MLP expects the normalized scalar t / 1000.
+    const int train_ts = config_.diffusion.num_train_timesteps;
+    const float denom = train_ts > 0 ? static_cast<float>(train_ts) : 1000.0F;
+    return scalar_t / denom;
+}
+
+std::vector<float> QwenImagePipeline::prepare_initial_latents(int h_lat, int w_lat, int n_channels,
+                                                              uint64_t seed) const {
+    if (h_lat <= 0 || w_lat <= 0 || n_channels <= 0) {
+        throw std::runtime_error("QwenImagePipeline::prepare_initial_latents: invalid latent "
+                                 "dimensions (h_lat, w_lat, n_channels must all be > 0)");
+    }
+    const std::size_t total = static_cast<std::size_t>(n_channels) *
+                              static_cast<std::size_t>(h_lat) * static_cast<std::size_t>(w_lat);
+    std::vector<float> out(total);
+    std::mt19937 gen(static_cast<std::mt19937::result_type>(seed));
+    std::normal_distribution<float> dist(0.0F, 1.0F);
+    for (std::size_t i = 0; i < total; ++i) {
+        out[i] = dist(gen);
+    }
+    return out;
+}
+
+// -----------------------------------------------------------------------------
+// Engine-bound methods.
+// -----------------------------------------------------------------------------
+
+namespace {
+
+// Validate pre-tokenize inputs to encode_text. Throws on any failure.
+void validate_encode_text_inputs(bool has_engine, bool has_tokenizer, int max_seq_len, int drop_idx,
+                                 int max_text_tokens, int text_embed_dim) {
+    if (!has_engine) {
+        throw std::runtime_error("QwenImagePipeline::encode_text: text_engine_ is null");
+    }
+    if (!has_tokenizer) {
+        throw std::runtime_error("QwenImagePipeline::encode_text: tokenizer_ is null");
+    }
+    if (max_seq_len <= 0 || drop_idx < 0 || max_text_tokens <= 0 || text_embed_dim <= 0) {
+        throw std::runtime_error("QwenImagePipeline::encode_text: invalid config dimensions");
+    }
+}
+
+} // namespace
+
+QwenImagePipeline::EncodedPrompt QwenImagePipeline::encode_text(const std::string& prompt) const {
+    const int max_seq_len = config_.text_encoder.max_seq_len;
+    const int drop_idx = config_.tokenizer.prompt_template_drop_idx;
+    const int max_text_tokens = config_.denoiser.max_text_tokens;
+    const int text_embed_dim = config_.denoiser.text_embed_dim;
+
+    validate_encode_text_inputs(text_engine_ != nullptr, tokenizer_ != nullptr, max_seq_len,
+                                drop_idx, max_text_tokens, text_embed_dim);
+
+    // 1. Wrap the user prompt in the diffusers T2I hardcoded template.
+    const std::string templated =
+        std::string(kPromptTemplatePrefix) + prompt + std::string(kPromptTemplateSuffix);
+
+    // 2. Tokenize, then pad/truncate to max_seq_len.
+    std::vector<int32_t> input_ids = tokenizer_->encode(templated);
+    const int raw_token_count = static_cast<int>(input_ids.size());
+    if (raw_token_count <= drop_idx) {
+        throw std::runtime_error("QwenImagePipeline::encode_text: tokenized prompt has " +
+                                 std::to_string(raw_token_count) + " tokens, but drop_idx=" +
+                                 std::to_string(drop_idx) + " requires more");
+    }
+
+    std::vector<int32_t> padded_ids(static_cast<std::size_t>(max_seq_len), 0);
+    const int real_len = std::min(raw_token_count, max_seq_len);
+    std::copy_n(input_ids.begin(), real_len, padded_ids.begin());
+
+    // Build the additive attention mask the text encoder engine expects
+    // (matches Z-Image / Qwen2.5-VL convention: 0 valid, -1e9 pad).
+    std::vector<float> attn_mask_additive(static_cast<std::size_t>(max_seq_len), -1.0e9F);
+    for (int i = 0; i < real_len; ++i) {
+        attn_mask_additive[static_cast<std::size_t>(i)] = 0.0F;
+    }
+
+    // 3. Run text encoder engine.
+    TensorMap inputs;
+    inputs["input_ids"] =
+        Tensor{padded_ids.data(), {static_cast<int64_t>(max_seq_len)}, DType::kInt32};
+    inputs["attention_mask"] =
+        Tensor{attn_mask_additive.data(), {static_cast<int64_t>(max_seq_len)}, DType::kFloat32};
+    auto outputs = text_engine_->forward(inputs);
+
+    const auto& last_hidden = outputs["last_hidden_state"];
+    const auto raw_embed_size =
+        static_cast<std::size_t>(max_seq_len) * static_cast<std::size_t>(text_embed_dim);
+    if (last_hidden.numel() != raw_embed_size) {
+        throw std::runtime_error("QwenImagePipeline::encode_text: text engine output size " +
+                                 std::to_string(last_hidden.numel()) +
+                                 " does not match expected max_seq_len * text_embed_dim = " +
+                                 std::to_string(raw_embed_size));
+    }
+
+    // 4. Drop the first drop_idx rows from the valid prefix; zero-pad to
+    //    [max_text_tokens, text_embed_dim].
+    EncodedPrompt out;
+    out.hidden_states.assign(
+        static_cast<std::size_t>(max_text_tokens) * static_cast<std::size_t>(text_embed_dim), 0.0F);
+    out.attention_mask.assign(static_cast<std::size_t>(max_text_tokens), 0);
+
+    const int valid_after_drop = std::min(real_len - drop_idx, max_text_tokens);
+    out.valid_text_len = valid_after_drop;
+    if (valid_after_drop > 0) {
+        const float* src =
+            static_cast<const float*>(last_hidden.data) +
+            static_cast<std::size_t>(drop_idx) * static_cast<std::size_t>(text_embed_dim);
+        std::memcpy(out.hidden_states.data(), src,
+                    static_cast<std::size_t>(valid_after_drop) *
+                        static_cast<std::size_t>(text_embed_dim) * sizeof(float));
+        for (int i = 0; i < valid_after_drop; ++i) {
+            out.attention_mask[static_cast<std::size_t>(i)] = 1;
+        }
+    }
+    return out;
+}
+
+std::vector<float>
+QwenImagePipeline::run_denoiser_once(const std::vector<float>& latents_packed, float normalized_t,
+                                     const std::vector<float>& hidden_states,
+                                     const std::vector<int32_t>& attention_mask) const {
+    if (!denoiser_engine_) {
+        throw std::runtime_error("QwenImagePipeline::run_denoiser_once: denoiser_engine_ is null");
+    }
+    (void)attention_mask; // Denoiser engine has no mask input; documented.
+
+    const int in_channels = config_.denoiser.in_channels;
+    const int max_text_tokens = config_.denoiser.max_text_tokens;
+    const int text_embed_dim = config_.denoiser.text_embed_dim;
+    if (in_channels <= 0 || max_text_tokens <= 0 || text_embed_dim <= 0) {
+        throw std::runtime_error("QwenImagePipeline::run_denoiser_once: invalid denoiser config");
+    }
+
+    if (latents_packed.size() % static_cast<std::size_t>(in_channels) != 0) {
+        throw std::runtime_error("QwenImagePipeline::run_denoiser_once: latents_packed size " +
+                                 std::to_string(latents_packed.size()) +
+                                 " is not divisible by in_channels=" + std::to_string(in_channels));
+    }
+    const std::size_t expected_hidden_size =
+        static_cast<std::size_t>(max_text_tokens) * static_cast<std::size_t>(text_embed_dim);
+    if (hidden_states.size() != expected_hidden_size) {
+        throw std::runtime_error("QwenImagePipeline::run_denoiser_once: hidden_states size " +
+                                 std::to_string(hidden_states.size()) +
+                                 " does not match max_text_tokens * text_embed_dim = " +
+                                 std::to_string(expected_hidden_size));
+    }
+
+    const int64_t n_img =
+        static_cast<int64_t>(latents_packed.size() / static_cast<std::size_t>(in_channels));
+    float timestep_buf = normalized_t;
+
+    TensorMap inputs;
+    inputs["img_patched"] = Tensor{const_cast<float*>(latents_packed.data()),
+                                   {1, n_img, static_cast<int64_t>(in_channels)},
+                                   DType::kFloat32};
+    inputs["txt_hidden"] =
+        Tensor{const_cast<float*>(hidden_states.data()),
+               {1, static_cast<int64_t>(max_text_tokens), static_cast<int64_t>(text_embed_dim)},
+               DType::kFloat32};
+    inputs["timestep"] = Tensor{&timestep_buf, {1}, DType::kFloat32};
+
+    auto outputs = denoiser_engine_->forward(inputs);
+    const auto& noise = outputs["noise_patched"];
+    std::vector<float> result(noise.numel());
+    std::memcpy(result.data(), noise.data, result.size() * sizeof(float));
+    return result;
+}
+
+// -----------------------------------------------------------------------------
+// Denoise loop. Mirrors QwenImageDebugRunner._generate verbatim.
+// -----------------------------------------------------------------------------
+
+namespace {
+
+// Validate inputs to denoise_loop_with_cfg. Throws on any failure.
+void validate_denoise_loop_inputs(std::size_t latents_size, int n_img, int num_steps,
+                                  int in_channels) {
+    if (num_steps <= 0) {
+        throw std::runtime_error("QwenImagePipeline::denoise_loop_with_cfg: num_steps must be > 0");
+    }
+    if (n_img <= 0) {
+        throw std::runtime_error("QwenImagePipeline::denoise_loop_with_cfg: n_img must be > 0");
+    }
+    if (in_channels <= 0) {
+        throw std::runtime_error("QwenImagePipeline::denoise_loop_with_cfg: invalid in_channels");
+    }
+    const auto expected = static_cast<std::size_t>(n_img) * static_cast<std::size_t>(in_channels);
+    if (latents_size != expected) {
+        throw std::runtime_error(
+            "QwenImagePipeline::denoise_loop_with_cfg: latents_packed size " +
+            std::to_string(latents_size) +
+            " does not match n_img * in_channels = " + std::to_string(expected));
+    }
+}
+
+// Build a FlowMatchEulerScheduler from the bundle's diffusion config and
+// set up its timestep schedule for `num_steps` and `n_img` tokens.
+FlowMatchEulerScheduler build_scheduler(const QwenImageDiffusionConfig& dc, int num_steps,
+                                        int n_img) {
+    FlowMatchEulerConfig sc_cfg;
+    sc_cfg.num_train_timesteps = dc.num_train_timesteps;
+    sc_cfg.shift = dc.shift;
+    sc_cfg.use_dynamic_shifting = dc.use_dynamic_shifting;
+    sc_cfg.base_shift = dc.base_shift;
+    sc_cfg.max_shift = dc.max_shift;
+    sc_cfg.base_image_seq_len = dc.base_image_seq_len;
+    sc_cfg.max_image_seq_len = dc.max_image_seq_len;
+    sc_cfg.shift_terminal = dc.shift_terminal;
+    sc_cfg.time_shift_type = dc.time_shift_type;
+    FlowMatchEulerScheduler scheduler(sc_cfg);
+    scheduler.set_timesteps(num_steps, n_img);
+    if (static_cast<int>(scheduler.timesteps().size()) != num_steps) {
+        throw std::runtime_error("QwenImagePipeline::denoise_loop_with_cfg: scheduler produced " +
+                                 std::to_string(scheduler.timesteps().size()) +
+                                 " timesteps, expected " + std::to_string(num_steps));
+    }
+    return scheduler;
+}
+
+// Combine pos + neg noise predictions via true-CFG and apply Qwen-Image's
+// per-token L2 renormalization. Matches debug_runner.py exactly:
+//   comb = neg + cfg*(pos - neg)
+//   noise = comb * (||pos|| / max(||comb||, 1e-8))   per-token
+// Writes the result into `out`.
+void combine_cfg_with_renorm(const std::vector<float>& noise_pos,
+                             const std::vector<float>& noise_neg, float cfg_scale, int n_img,
+                             std::size_t channels, std::vector<float>& out) {
+    for (int tok = 0; tok < n_img; ++tok) {
+        const std::size_t base = static_cast<std::size_t>(tok) * channels;
+        double pos_sq = 0.0;
+        double comb_sq = 0.0;
+        for (std::size_t c = 0; c < channels; ++c) {
+            const float p = noise_pos[base + c];
+            const float ng = noise_neg[base + c];
+            const float comb = ng + cfg_scale * (p - ng);
+            out[base + c] = comb;
+            pos_sq += static_cast<double>(p) * static_cast<double>(p);
+            comb_sq += static_cast<double>(comb) * static_cast<double>(comb);
+        }
+        const double scale = std::sqrt(pos_sq) / std::max(std::sqrt(comb_sq), 1e-8);
+        const float scale_f = static_cast<float>(scale);
+        for (std::size_t c = 0; c < channels; ++c) {
+            out[base + c] *= scale_f;
+        }
+    }
+}
+
+} // namespace
+
+std::vector<float> QwenImagePipeline::denoise_loop_with_cfg(std::vector<float> latents_packed,
+                                                            const EncodedPrompt& pos,
+                                                            const EncodedPrompt& neg, int n_img,
+                                                            int num_steps, float cfg_scale) const {
+    const int in_channels = config_.denoiser.in_channels;
+    validate_denoise_loop_inputs(latents_packed.size(), n_img, num_steps, in_channels);
+
+    auto scheduler = build_scheduler(config_.diffusion, num_steps, n_img);
+    const auto& timesteps = scheduler.timesteps();
+
+    const bool do_cfg = (cfg_scale > 1.0F);
+    const std::size_t numel = latents_packed.size();
+    const std::size_t channels = static_cast<std::size_t>(in_channels);
+    std::vector<float> noise_pred(numel);
+
+    for (int step = 0; step < num_steps; ++step) {
+        const float t = timesteps[static_cast<std::size_t>(step)];
+        const float norm_t = normalize_timestep(t);
+
+        auto noise_pos =
+            run_denoiser_once(latents_packed, norm_t, pos.hidden_states, pos.attention_mask);
+        if (noise_pos.size() != numel) {
+            throw std::runtime_error("QwenImagePipeline::denoise_loop_with_cfg: denoiser "
+                                     "output size mismatch");
+        }
+
+        if (do_cfg) {
+            auto noise_neg =
+                run_denoiser_once(latents_packed, norm_t, neg.hidden_states, neg.attention_mask);
+            if (noise_neg.size() != numel) {
+                throw std::runtime_error("QwenImagePipeline::denoise_loop_with_cfg: denoiser "
+                                         "output size mismatch");
+            }
+            combine_cfg_with_renorm(noise_pos, noise_neg, cfg_scale, n_img, channels, noise_pred);
+        } else {
+            noise_pred = std::move(noise_pos);
+        }
+
+        // Euler step in-place: latents += (sigma_next - sigma) * noise.
+        scheduler.step(latents_packed.data(), noise_pred.data(),
+                       static_cast<int32_t>(latents_packed.size()), step);
+    }
+
+    return latents_packed;
+}
+
+namespace {
+
+// Validate inputs to patchify_latents. Throws on any failure.
+void validate_patchify_inputs(std::size_t latents_size, int latent_channels, int h_lat, int w_lat,
+                              int patch_size) {
+    if (latent_channels <= 0 || h_lat <= 0 || w_lat <= 0 || patch_size <= 0) {
+        throw std::runtime_error("QwenImagePipeline::patchify_latents: invalid dims (channels, "
+                                 "h_lat, w_lat, patch_size must all be > 0)");
+    }
+    if (h_lat % patch_size != 0 || w_lat % patch_size != 0) {
+        throw std::runtime_error("QwenImagePipeline::patchify_latents: latent dims " +
+                                 std::to_string(h_lat) + "x" + std::to_string(w_lat) +
+                                 " not divisible by patch_size=" + std::to_string(patch_size));
+    }
+    const std::size_t expected = static_cast<std::size_t>(latent_channels) *
+                                 static_cast<std::size_t>(h_lat) * static_cast<std::size_t>(w_lat);
+    if (latents_size != expected) {
+        throw std::runtime_error(
+            "QwenImagePipeline::patchify_latents: input size " + std::to_string(latents_size) +
+            " does not match channels * h_lat * w_lat = " + std::to_string(expected));
+    }
+}
+
+// Pack a single (ph, pw) tile: copy the [C, p, p] block from `latents`
+// (row-major C, H, W) into the packed channel axis at token `tok`.
+void pack_one_tile(const std::vector<float>& latents, std::vector<float>& packed, int ph, int pw,
+                   int latent_channels, int p, std::size_t stride_c, std::size_t stride_h,
+                   std::size_t tok, std::size_t out_channels) {
+    for (int c = 0; c < latent_channels; ++c) {
+        for (int p1 = 0; p1 < p; ++p1) {
+            for (int p2 = 0; p2 < p; ++p2) {
+                const std::size_t src = static_cast<std::size_t>(c) * stride_c +
+                                        static_cast<std::size_t>(ph * p + p1) * stride_h +
+                                        static_cast<std::size_t>(pw * p + p2);
+                const std::size_t dst =
+                    tok * out_channels + static_cast<std::size_t>(c * p * p + p1 * p + p2);
+                packed[dst] = latents[src];
+            }
+        }
+    }
+}
+
+} // namespace
+
+std::vector<float> QwenImagePipeline::patchify_latents(const std::vector<float>& latents,
+                                                       int latent_channels, int h_lat, int w_lat,
+                                                       int patch_size) {
+    validate_patchify_inputs(latents.size(), latent_channels, h_lat, w_lat, patch_size);
+
+    const int p = patch_size;
+    const int packed_h = h_lat / p;
+    const int packed_w = w_lat / p;
+    const std::size_t out_channels = static_cast<std::size_t>(latent_channels) *
+                                     static_cast<std::size_t>(p) * static_cast<std::size_t>(p);
+    const std::size_t n_img =
+        static_cast<std::size_t>(packed_h) * static_cast<std::size_t>(packed_w);
+
+    std::vector<float> packed(n_img * out_channels);
+
+    // Source layout: latents[c, h, w] with row-major C, H, W strides.
+    //   stride_c = h_lat * w_lat
+    //   stride_h = w_lat
+    //   stride_w = 1
+    // Target layout: packed[ph, pw, c, p1, p2] = latents[c, ph*p+p1, pw*p+p2].
+    //   With (ph * packed_w + pw) collapsing to the token axis, and
+    //   (c * p * p + p1 * p + p2) collapsing to the channel axis.
+    const std::size_t stride_c = static_cast<std::size_t>(h_lat) * static_cast<std::size_t>(w_lat);
+    const std::size_t stride_h = static_cast<std::size_t>(w_lat);
+    for (int ph = 0; ph < packed_h; ++ph) {
+        for (int pw = 0; pw < packed_w; ++pw) {
+            const std::size_t tok =
+                static_cast<std::size_t>(ph) * static_cast<std::size_t>(packed_w) +
+                static_cast<std::size_t>(pw);
+            pack_one_tile(latents, packed, ph, pw, latent_channels, p, stride_c, stride_h, tok,
+                          out_channels);
+        }
+    }
+    return packed;
+}
+
+namespace {
+
+// Validate the scalar dims/config used by vae_decode. Throws on any failure.
+void validate_vae_decode_dims(bool has_engine, int latent_channels, int patch, int vae_scale,
+                              int n_img, int h_lat, int w_lat, int packed_h, int packed_w) {
+    if (!has_engine) {
+        throw std::runtime_error("QwenImagePipeline::vae_decode: vae_decoder_engine_ is null");
+    }
+    if (latent_channels <= 0 || patch <= 0 || vae_scale <= 0 || n_img <= 0 || h_lat <= 0 ||
+        w_lat <= 0) {
+        throw std::runtime_error("QwenImagePipeline::vae_decode: invalid dims in config or "
+                                 "arguments (all must be > 0)");
+    }
+    if (packed_h * packed_w != n_img) {
+        throw std::runtime_error(
+            "QwenImagePipeline::vae_decode: n_img=" + std::to_string(n_img) +
+            " does not match packed_h * packed_w = " + std::to_string(packed_h * packed_w));
+    }
+}
+
+// Validate the buffer sizes used by vae_decode (latents_packed and the
+// preprocessor latents_mean/std vectors). Throws on any mismatch.
+void validate_vae_decode_buffers(int latent_channels, int patch, int n_img,
+                                 std::size_t latents_packed_size, std::size_t latents_mean_size,
+                                 std::size_t latents_std_size) {
+    const int ch_packed = latent_channels * patch * patch;
+    const std::size_t expected_in =
+        static_cast<std::size_t>(n_img) * static_cast<std::size_t>(ch_packed);
+    if (latents_packed_size != expected_in) {
+        throw std::runtime_error("QwenImagePipeline::vae_decode: latents_packed size " +
+                                 std::to_string(latents_packed_size) +
+                                 " does not match n_img * latent_channels * patch_size^2 = " +
+                                 std::to_string(expected_in));
+    }
+    if (static_cast<int>(latents_mean_size) != latent_channels ||
+        static_cast<int>(latents_std_size) != latent_channels) {
+        throw std::runtime_error("QwenImagePipeline::vae_decode: preprocessor latents_mean/std "
+                                 "missing or wrong size (need " +
+                                 std::to_string(latent_channels) + " entries each)");
+    }
+}
+
+// Unpatchify packed latents [n_img, c * p * p] -> dense [C, H, W] (T=1
+// collapses since the source has B=1 and the VAE engine accepts the byte
+// layout interchangeably). Inverse of patchify_latents.
+//
+// Stored row-major: latent_chw[c, h, w] with strides
+//   stride_c = h_lat * w_lat, stride_h = w_lat, stride_w = 1.
+std::vector<float> unpatchify_latents(const std::vector<float>& packed, int latent_channels,
+                                      int patch, int packed_h, int packed_w, int h_lat, int w_lat) {
+    const std::size_t per_channel =
+        static_cast<std::size_t>(h_lat) * static_cast<std::size_t>(w_lat);
+    const int ch_packed = latent_channels * patch * patch;
+    std::vector<float> out(static_cast<std::size_t>(latent_channels) * per_channel);
+    const std::size_t stride_c = per_channel;
+    const std::size_t stride_h = static_cast<std::size_t>(w_lat);
+    for (int ph = 0; ph < packed_h; ++ph) {
+        for (int pw = 0; pw < packed_w; ++pw) {
+            const std::size_t tok =
+                static_cast<std::size_t>(ph) * static_cast<std::size_t>(packed_w) +
+                static_cast<std::size_t>(pw);
+            for (int c = 0; c < latent_channels; ++c) {
+                for (int p1 = 0; p1 < patch; ++p1) {
+                    for (int p2 = 0; p2 < patch; ++p2) {
+                        const std::size_t src =
+                            tok * static_cast<std::size_t>(ch_packed) +
+                            static_cast<std::size_t>(c * patch * patch + p1 * patch + p2);
+                        const std::size_t dst =
+                            static_cast<std::size_t>(c) * stride_c +
+                            static_cast<std::size_t>(ph * patch + p1) * stride_h +
+                            static_cast<std::size_t>(pw * patch + p2);
+                        out[dst] = packed[src];
+                    }
+                }
+            }
+        }
+    }
+    return out;
+}
+
+// In-place per-channel affine: z[c, *] = z[c, *] * std[c] + mean[c].
+// `data` is laid out [C, H, W] row-major; per_channel = H * W.
+void unnormalize_latents_inplace(float* data, int latent_channels, std::size_t per_channel,
+                                 const std::vector<float>& latents_mean,
+                                 const std::vector<float>& latents_std) {
+    for (int c = 0; c < latent_channels; ++c) {
+        const float m = latents_mean[static_cast<std::size_t>(c)];
+        const float s = latents_std[static_cast<std::size_t>(c)];
+        float* base = data + static_cast<std::size_t>(c) * per_channel;
+        for (std::size_t i = 0; i < per_channel; ++i) {
+            base[i] = base[i] * s + m;
+        }
+    }
+}
+
+// Convert VAE output [3, H, W] in [-1, 1] CHW -> [H, W, 3] in [0, 1] HWC,
+// clamped to [0, 1]. Matches FluxPipeline / ZImagePipeline conventions.
+QwenImagePipeline::DecodedImage chw_to_hwc_unit_range(const float* raw, int h_out, int w_out) {
+    QwenImagePipeline::DecodedImage out;
+    out.height = h_out;
+    out.width = w_out;
+    out.pixels.resize(3UL * static_cast<std::size_t>(h_out) * static_cast<std::size_t>(w_out));
+    const std::size_t plane = static_cast<std::size_t>(h_out) * static_cast<std::size_t>(w_out);
+    for (int y = 0; y < h_out; ++y) {
+        for (int x = 0; x < w_out; ++x) {
+            for (int c = 0; c < 3; ++c) {
+                const std::size_t src =
+                    static_cast<std::size_t>(c) * plane +
+                    static_cast<std::size_t>(y) * static_cast<std::size_t>(w_out) +
+                    static_cast<std::size_t>(x);
+                const std::size_t dst =
+                    static_cast<std::size_t>(y) * static_cast<std::size_t>(w_out * 3) +
+                    static_cast<std::size_t>(x * 3 + c);
+                const float v = (raw[src] + 1.0F) * 0.5F;
+                out.pixels[dst] = std::max(0.0F, std::min(1.0F, v));
+            }
+        }
+    }
+    return out;
+}
+
+} // namespace
+
+QwenImagePipeline::DecodedImage
+QwenImagePipeline::vae_decode(const std::vector<float>& latents_packed, int n_img, int h_lat,
+                              int w_lat) const {
+    const int latent_channels = config_.vae.latent_channels;
+    const int patch = config_.denoiser.patch_size;
+    const int vae_scale = config_.vae.spatial_scale_factor;
+    const int packed_h = (patch > 0) ? h_lat / patch : 0;
+    const int packed_w = (patch > 0) ? w_lat / patch : 0;
+    validate_vae_decode_dims(vae_decoder_engine_ != nullptr, latent_channels, patch, vae_scale,
+                             n_img, h_lat, w_lat, packed_h, packed_w);
+    validate_vae_decode_buffers(latent_channels, patch, n_img, latents_packed.size(),
+                                preprocessor_.latents_mean.size(),
+                                preprocessor_.latents_std.size());
+
+    // 1) Unpatchify packed -> dense [C, H, W].
+    auto latent_chw = unpatchify_latents(latents_packed, latent_channels, patch, packed_h, packed_w,
+                                         h_lat, w_lat);
+
+    // 2) Per-channel un-normalize: z = z * raw_std + mean.
+    //    Matches QwenImageDebugRunner._vae_decode: the bundle stores the raw
+    //    vae.config.latents_std/mean; diffusers internally inverts to
+    //    1/raw_std, so the multiplicative pass collapses to z * raw_std.
+    const std::size_t per_channel =
+        static_cast<std::size_t>(h_lat) * static_cast<std::size_t>(w_lat);
+    unnormalize_latents_inplace(latent_chw.data(), latent_channels, per_channel,
+                                preprocessor_.latents_mean, preprocessor_.latents_std);
+
+    // 3) Run VAE decode. Input name is "latent" with shape [1, C, 1, H, W],
+    //    matching tensorrt_model_connect.qwen_image_vae_builder. Byte layout
+    //    of latent_chw matches NCTHW with T=1 (T axis is contiguous and size 1).
+    TensorMap inputs;
+    inputs["latent"] = Tensor{latent_chw.data(),
+                              {1, static_cast<int64_t>(latent_channels), 1,
+                               static_cast<int64_t>(h_lat), static_cast<int64_t>(w_lat)},
+                              DType::kFloat32};
+    auto outputs = vae_decoder_engine_->forward(inputs);
+    const auto& image_tensor = outputs.at("image");
+
+    // Expected image shape: [1, 3, 1, H, W] or [1, 3, H, W] — numel must be
+    // 3 * H * W either way.
+    const int h_out = h_lat * vae_scale;
+    const int w_out = w_lat * vae_scale;
+    const std::size_t expected_out =
+        3UL * static_cast<std::size_t>(h_out) * static_cast<std::size_t>(w_out);
+    if (image_tensor.numel() != expected_out) {
+        throw std::runtime_error(
+            "QwenImagePipeline::vae_decode: VAE output size " +
+            std::to_string(image_tensor.numel()) +
+            " does not match expected 3 * H * W = " + std::to_string(expected_out));
+    }
+
+    // 4) Convert [-1, 1] CHW -> [0, 1] HWC, with clamp.
+    return chw_to_hwc_unit_range(static_cast<const float*>(image_tensor.data), h_out, w_out);
+}
+
+} // namespace trtmc

--- a/src/runtime/models/qwen_image/pipeline.h
+++ b/src/runtime/models/qwen_image/pipeline.h
@@ -1,0 +1,197 @@
+#pragma once
+
+// =============================================================================
+// qwen_image_pipeline.h — Qwen-Image diffusion pipeline (T2I + Edit).
+// =============================================================================
+//
+// Mirrors the Python QwenImageDebugRunner in
+// tensorrt_model_connect.debug_runner — same forward steps:
+//   tokenize -> text encoder (pos + neg) -> seeded latents ->
+//   N-step flow-match Euler denoise with true-CFG -> unpatchify ->
+//   un-normalize -> VAE decode -> PNG.
+//
+// Trace: ARCH-FAM-001, UD-FAM-QWEN-IMAGE-01.
+// =============================================================================
+
+#include "runtime/domains/diffusion/qwen_image_types.h"
+#include "trtmc/pipeline.h"
+#include "trtmc/runtime/trt_module.h"
+#include "trtmc/tokenizer.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+// QwenImagePipeline: Qwen-Image diffusion pipeline with Qwen2.5-VL text
+// encoder, MMDiT denoiser, and AutoencoderKLQwenImage VAE. Currently
+// supports T2I; Edit-mode engines (vision + VAE encoder) are accepted in
+// Construction but remain null for T2I bundles.
+class QwenImagePipeline final : public IPipeline {
+  public:
+    // Construction-time dependencies, populated by the plugin factory.
+    // Edit-only engines (vision_engine, vae_encoder) may be null for T2I
+    // bundles.
+    struct Construction {
+        std::unique_ptr<TrtModule> text_engine;
+        std::unique_ptr<TrtModule> denoiser_engine;
+        std::unique_ptr<TrtModule> vae_decoder_engine;
+        std::unique_ptr<TrtModule> vision_engine;      // Edit mode only.
+        std::unique_ptr<TrtModule> vae_encoder_engine; // Edit mode only.
+        std::shared_ptr<ITokenizer> tokenizer;
+        QwenImageConfig config;
+        QwenImagePreprocessorWeights preprocessor;
+        std::string model_id;
+        std::string bundle_path;
+    };
+
+    explicit QwenImagePipeline(Construction c);
+    ~QwenImagePipeline() override;
+
+    ImageResult generate_image(const std::string& prompt, const GenerateConfig& cfg = {}) override;
+
+    const char* model_id() const override { return model_id_.c_str(); }
+    const char* pipeline_type() const override { return "QwenImagePipeline"; }
+
+    // -------------------------------------------------------------------------
+    // Math helpers: exposed publicly so unit tests can verify them without
+    // needing engine bytes. Consumed by the full generate_image()
+    // implementation.
+    // -------------------------------------------------------------------------
+
+    // Latent + packed-token dimensions derived from a target image size,
+    // using vae.spatial_scale_factor and denoiser.patch_size from config.
+    struct LatentShape {
+        int latent_h;     // height / vae_scale_factor
+        int latent_w;     // width / vae_scale_factor
+        int packed_h;     // latent_h / patch_size
+        int packed_w;     // latent_w / patch_size
+        int n_img_tokens; // packed_h * packed_w
+    };
+
+    // Compute latent + packed dims for a target image size. Reads vae and
+    // denoiser config to derive vae_scale_factor and patch_size. Throws
+    // std::runtime_error if either factor is non-positive.
+    LatentShape compute_latent_shape(int height, int width) const;
+
+    // Normalize a raw timestep value to the [0, 1] range the engine expects.
+    // Qwen-Image scheduler convention: divide by num_train_timesteps (1000).
+    // The engine has the full sinusoidal + 2-layer SiLU MLP baked in, so the
+    // pipeline only feeds the normalized scalar.
+    float normalize_timestep(float scalar_t) const;
+
+    // Seeded host-side standard normal sampling. Produces a flat row-major
+    // [1, n_channels, h_lat, w_lat] fp32 buffer (C, H, W). Deterministic for
+    // a given seed (std::mt19937 + std::normal_distribution<float>). Does NOT
+    // attempt byte-for-byte parity with torch.randn — that requires
+    // serializing torch's RNG state and is left for a future task.
+    std::vector<float> prepare_initial_latents(int h_lat, int w_lat, int n_channels,
+                                               uint64_t seed) const;
+
+    // -------------------------------------------------------------------------
+    // Engine-bound methods. Wrap ITrtModule::forward() with the
+    // Qwen-Image-specific shapes and the diffusers hardcoded prompt template.
+    // -------------------------------------------------------------------------
+
+    // Encoded prompt ready to feed the denoiser. hidden_states is padded to
+    // [max_text_tokens, text_embed_dim] row-major; rows past valid_text_len
+    // are zero. attention_mask is 1 for valid token rows, 0 for padding.
+    struct EncodedPrompt {
+        std::vector<float> hidden_states;    // [max_text_tokens * text_embed_dim] fp32
+        std::vector<int32_t> attention_mask; // [max_text_tokens]
+        int valid_text_len = 0;              // tokens AFTER drop_idx removal
+    };
+
+    // Apply the diffusers T2I hardcoded prompt_template_encode, tokenize,
+    // pad to text_encoder.max_seq_len, run the text encoder, drop the first
+    // prompt_template_drop_idx hidden_state rows, and zero-pad back to
+    // denoiser.max_text_tokens × text_embed_dim. Mirrors
+    // QwenImageDebugRunner._encode_prompt in debug_runner.py.
+    //
+    // Throws std::runtime_error on missing engine/tokenizer or when the
+    // tokenized template+prompt has ≤ drop_idx valid tokens.
+    EncodedPrompt encode_text(const std::string& prompt) const;
+
+    // One denoiser forward pass. latents_packed is [1, n_img, in_channels=64]
+    // row-major fp32; hidden_states is the EncodedPrompt.hidden_states blob
+    // ([max_text_tokens, text_embed_dim] flat fp32); normalized_t is the
+    // already-divided-by-1000 scalar. Returns the predicted noise as
+    // [1, n_img, out_channels * patch_size^2 = 64] row-major fp32.
+    //
+    // attention_mask is accepted for API parity with the Python runner but
+    // currently unused: the denoiser engine was baked WITHOUT an
+    // encoder_hidden_states_mask input so zero-padded text positions
+    // participate in attention (documented deviation).
+    std::vector<float> run_denoiser_once(const std::vector<float>& latents_packed,
+                                         float normalized_t,
+                                         const std::vector<float>& hidden_states,
+                                         const std::vector<int32_t>& attention_mask) const;
+
+    // -------------------------------------------------------------------------
+    // Denoise loop. Drives the scheduler over `num_steps`, calls
+    // run_denoiser_once twice per step when cfg_scale > 1.0 (cond + uncond),
+    // combines via Qwen-Image-flavored true-CFG (per-token L2 renormalization),
+    // and applies the Euler step in-place. Returns the final packed latents.
+    //
+    // The latents_packed buffer is consumed by value so the caller does not
+    // need its pre-loop state; n_img is passed explicitly because the scheduler
+    // needs it for dynamic-mu shifting (image_seq_len argument).
+    //
+    // Mirrors QwenImageDebugRunner._generate's main loop (debug_runner.py).
+    // Caveat: the Python runner ALSO performs per-token L2 renormalization
+    //   noise = comb * (||pos|| / max(||comb||, 1e-8))
+    // where the norm is taken over the channel axis of each token. We mirror
+    // that behavior verbatim — it's a Qwen-Image-specific CFG variant.
+    // -------------------------------------------------------------------------
+    std::vector<float> denoise_loop_with_cfg(std::vector<float> latents_packed,
+                                             const EncodedPrompt& pos, const EncodedPrompt& neg,
+                                             int n_img, int num_steps, float cfg_scale) const;
+
+    // -------------------------------------------------------------------------
+    // VAE decode. Unpatchify packed latents back to [1, C, 1, h_lat, w_lat],
+    // apply per-channel un-normalization (z = z * raw_std + mean), run the
+    // VAE decoder engine, and convert the [-1, 1] image into the HWC float32
+    // [0, 1] layout used by ImageResult (matches FLUX / Z-Image).
+    //
+    // Mirrors QwenImageDebugRunner._vae_decode (debug_runner.py).
+    // -------------------------------------------------------------------------
+    struct DecodedImage {
+        std::vector<float> pixels; // [H * W * 3] HWC float32 in [0, 1]
+        int height{0};
+        int width{0};
+    };
+
+    DecodedImage vae_decode(const std::vector<float>& latents_packed, int n_img, int h_lat,
+                            int w_lat) const;
+
+  private:
+    // Patchify a 4D latent tensor [1, C, H, W] (row-major C, H, W) into the
+    // packed denoiser-input layout [1, n_img, C * patch_size * patch_size],
+    // mirroring diffusers' QwenImagePipeline._pack_latents.
+    //
+    // Conceptually:
+    //   v = latents.reshape(B, C, H/p, p, W/p, p)
+    //   v = v.transpose(0, 2, 4, 1, 3, 5)
+    //   packed = v.reshape(B, (H/p) * (W/p), C * p * p)
+    //
+    // Throws std::runtime_error if dimensions aren't divisible by patch_size
+    // or buffer sizes don't match.
+    static std::vector<float> patchify_latents(const std::vector<float>& latents,
+                                               int latent_channels, int h_lat, int w_lat,
+                                               int patch_size);
+
+    std::unique_ptr<TrtModule> text_engine_;
+    std::unique_ptr<TrtModule> denoiser_engine_;
+    std::unique_ptr<TrtModule> vae_decoder_engine_;
+    std::unique_ptr<TrtModule> vision_engine_;
+    std::unique_ptr<TrtModule> vae_encoder_engine_;
+    std::shared_ptr<ITokenizer> tokenizer_;
+    QwenImageConfig config_;
+    QwenImagePreprocessorWeights preprocessor_;
+    std::string model_id_;
+    std::string bundle_path_;
+};
+
+} // namespace trtmc

--- a/src/runtime/models/qwen_image/plugin.cpp
+++ b/src/runtime/models/qwen_image/plugin.cpp
@@ -1,0 +1,70 @@
+// QwenImagePlugin: handles "diffusion_qwen_image" strategy.
+// Qwen-Image diffusion pipeline with Qwen2.5-VL text encoder, MMDiT denoiser,
+// AutoencoderKLQwenImage VAE decoder, and Qwen-Image-specific preprocessor
+// weights (per-channel latents_mean / latents_std).
+//
+// Mirrors zimage_plugin.cpp — loads diffusion engines via the shared
+// load_diffusion_parts helper, parses Qwen-Image config and preprocessor
+// weights, then constructs QwenImagePipeline via its Construction struct.
+//
+// Trace: ARCH-FAM-001, UD-FAM-QWEN-IMAGE-01.
+
+#include "runtime/domains/diffusion/qwen_image_types.h"
+#include "runtime/models/qwen_image/pipeline.h"
+#include "runtime/plugins/shared/diffusion_helpers.h"
+#include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/pipeline_registry.h"
+
+namespace trtmc {
+
+class QwenImagePlugin final : public IPipelinePlugin {
+  public:
+    std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
+        ModuleCreateOptions opts;
+        opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
+        opts.cuda_graphs = ctx.cuda_graphs;
+
+        // Load the standard diffusion engine triple (text_encoder_0_plan,
+        // denoiser_plan, vae_decoder_plan) via the shared helper. T2I bundles
+        // do not ship vision / vae_encoder engines, so those stay null on
+        // Construction.
+        auto parts = load_diffusion_parts(ctx.backend, ctx.bundle, ctx.config_json, opts);
+
+        // Parse Qwen-Image-specific config (diffusion / text_encoder / denoiser
+        // / vae / image / tokenizer sections) from the raw bundle config JSON.
+        auto qi_config = QwenImageConfig::parse(ctx.config_json);
+
+        // Parse Qwen-Image preprocessor weights (latents_mean / latents_std)
+        // from the bundle's preprocessor_weights section. Falls back to an
+        // empty struct (valid=false) if the section is missing — VAE decode
+        // will fail downstream if the weights are actually needed.
+        QwenImagePreprocessorWeights qi_preprocessor;
+        const auto* pw_sec = find_section(ctx.bundle, "preprocessor_weights");
+        if (pw_sec && !pw_sec->empty())
+            qi_preprocessor = parse_qwen_image_preprocessor_weights(*pw_sec);
+
+        // Extract the first (and only, for Qwen-Image T2I) text encoder.
+        std::unique_ptr<ITrtModule> text_module;
+        if (!parts.text_encoders.empty())
+            text_module = std::move(parts.text_encoders[0].module);
+
+        QwenImagePipeline::Construction c;
+        c.text_engine = std::move(text_module);
+        c.denoiser_engine = std::move(parts.denoiser.module);
+        c.vae_decoder_engine = std::move(parts.vae.module);
+        // Edit-mode engines (vision_engine, vae_encoder_engine) remain null
+        // for T2I bundles; image-editing variants would populate these from
+        // additional bundle sections.
+        c.tokenizer = std::move(parts.tokenizer);
+        c.config = std::move(qi_config);
+        c.preprocessor = std::move(qi_preprocessor);
+        c.model_id = ctx.bundle.info.model_id;
+        c.bundle_path = ctx.bundle_path;
+        return std::make_unique<QwenImagePipeline>(std::move(c));
+    }
+};
+
+REGISTER_PIPELINE_PLUGIN_WITH_MANIFEST(register_qwen_image_plugin, QwenImagePlugin,
+                                       "diffusion_qwen_image");
+
+} // namespace trtmc

--- a/src/utils/image_reader.cpp
+++ b/src/utils/image_reader.cpp
@@ -1,25 +1,28 @@
-// image_reader.cpp — implements trtmc::io::read_image() using stb_image.
-
-#include "trtmc/trtmc_io.hpp"
+// image_reader.cpp — implements trtmc::io::read_image() and
+// trtmc::io::save_png() using stb_image / stb_image_write.
 
 #include "stb_image.h"
+#include "stb_image_write.h"
+#include "trtmc/trtmc_io.hpp"
 
+#include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace trtmc::io {
 
-LoadedImage read_image(const std::string& path)
-{
+LoadedImage read_image(const std::string& path) {
     LoadedImage result;
 
     int width = 0;
     int height = 0;
     int channels = 0;
     unsigned char* raw = stbi_load(path.c_str(), &width, &height, &channels, 3);
-    if (raw == nullptr)
-    {
-        return result;  // empty = decode failure
+    if (raw == nullptr) {
+        return result; // empty = decode failure
     }
 
     result.width = static_cast<int32_t>(width);
@@ -28,13 +31,36 @@ LoadedImage read_image(const std::string& path)
     // Convert uint8 [0, 255] to float [0, 1] in HWC layout
     auto npixels = static_cast<std::size_t>(width) * height * 3;
     result.pixels.resize(npixels);
-    for (std::size_t i = 0; i < npixels; ++i)
-    {
+    for (std::size_t i = 0; i < npixels; ++i) {
         result.pixels[i] = static_cast<float>(raw[i]) / 255.0F;
     }
 
     stbi_image_free(raw);
     return result;
+}
+
+void save_png(const std::string& path, const std::vector<float>& hwc_pixels, int width,
+              int height) {
+    if (width <= 0 || height <= 0) {
+        throw std::runtime_error("save_png: width/height must be positive (got " +
+                                 std::to_string(width) + "x" + std::to_string(height) + ")");
+    }
+    const std::size_t expected =
+        static_cast<std::size_t>(width) * static_cast<std::size_t>(height) * 3U;
+    if (hwc_pixels.size() != expected) {
+        throw std::runtime_error("save_png: pixel buffer size mismatch (expected " +
+                                 std::to_string(expected) + ", got " +
+                                 std::to_string(hwc_pixels.size()) + ")");
+    }
+    std::vector<std::uint8_t> out(expected);
+    for (std::size_t i = 0; i < expected; ++i) {
+        const float v = std::max(0.0F, std::min(1.0F, hwc_pixels[i]));
+        out[i] = static_cast<std::uint8_t>(v * 255.0F + 0.5F);
+    }
+    const int stride = width * 3;
+    if (!stbi_write_png(path.c_str(), width, height, 3, out.data(), stride)) {
+        throw std::runtime_error("save_png: stbi_write_png failed for " + path);
+    }
 }
 
 } // namespace trtmc::io

--- a/src/utils/json_helpers.cpp
+++ b/src/utils/json_helpers.cpp
@@ -275,4 +275,135 @@ std::vector<int32_t> extract_json_int_array(const std::string& text, const std::
     return extract_numeric_array_impl<int32_t>(text, key, max_count, is_int_char, parse_int);
 }
 
+namespace {
+
+// Match either JSON literal `true`/`false` or numeric 0/1 at `pos`. Returns
+// {parsed_value, end_index} on success; `end == pos` on failure.
+struct BoolMatch {
+    bool value;
+    std::size_t end;
+    bool ok;
+};
+
+BoolMatch read_bool_token(const std::string& text, std::size_t pos) {
+    BoolMatch m{false, pos, false};
+    if (pos >= text.size()) {
+        return m;
+    }
+    if (text.compare(pos, 4, "true") == 0) {
+        m.value = true;
+        m.end = pos + 4;
+        m.ok = true;
+        return m;
+    }
+    if (text.compare(pos, 5, "false") == 0) {
+        m.value = false;
+        m.end = pos + 5;
+        m.ok = true;
+        return m;
+    }
+    if (is_digit_char(text[pos])) {
+        const std::size_t end = scan_while(text, pos, is_digit_char);
+        try {
+            const int v = std::stoi(text.substr(pos, end - pos));
+            m.value = (v != 0);
+            m.end = end;
+            m.ok = true;
+        } catch (const std::exception&) {
+            // fall through
+        }
+    }
+    return m;
+}
+
+} // namespace
+
+bool extract_json_bool(const std::string& text, const std::string& key, bool fallback) {
+    std::size_t colon = 0;
+    if (!find_key_colon(text, key, colon)) {
+        return fallback;
+    }
+    const std::size_t pos = skip_whitespace(text, colon + 1);
+    const BoolMatch m = read_bool_token(text, pos);
+    if (!m.ok) {
+        return fallback;
+    }
+    return m.value;
+}
+
+std::vector<bool> extract_json_bool_array(const std::string& text, const std::string& key,
+                                          std::size_t max_count) {
+    std::vector<bool> out;
+    std::size_t colon = 0;
+    if (!find_key_colon(text, key, colon)) {
+        return out;
+    }
+    std::size_t open_bracket = 0;
+    if (!find_array_start(text, colon, open_bracket)) {
+        return out;
+    }
+    std::size_t pos = open_bracket + 1;
+    while (pos < text.size() && out.size() < max_count) {
+        if (advance_array_pos(text, pos) != ArrayParseState::kReady) {
+            break;
+        }
+        const BoolMatch m = read_bool_token(text, pos);
+        if (!m.ok) {
+            break;
+        }
+        out.push_back(m.value);
+        pos = m.end;
+    }
+    return out;
+}
+
+namespace {
+// Updates in_string / escape based on c. Returns true if c is inside a string
+// (or a quote that toggled string state) and should be ignored by the
+// brace-depth tracker.
+bool inside_string_state(char c, bool& in_string, bool& escape) {
+    if (in_string) {
+        if (escape) {
+            escape = false;
+        } else if (c == '\\') {
+            escape = true;
+        } else if (c == '"') {
+            in_string = false;
+        }
+        return true;
+    }
+    if (c == '"') {
+        in_string = true;
+        return true;
+    }
+    return false;
+}
+} // namespace
+
+std::string extract_json_object_text(const std::string& text, const std::string& key) {
+    std::size_t colon = 0;
+    if (!find_key_colon(text, key, colon)) {
+        return "";
+    }
+    const std::size_t brace = text.find('{', colon + 1);
+    if (brace == std::string::npos) {
+        return "";
+    }
+    int depth = 0;
+    bool in_string = false;
+    bool escape = false;
+    for (std::size_t i = brace; i < text.size(); ++i) {
+        const char c = text[i];
+        if (inside_string_state(c, in_string, escape)) {
+            continue;
+        }
+        if (c == '{') {
+            ++depth;
+        } else if (c == '}' && --depth == 0) {
+            return text.substr(brace, i - brace + 1);
+        }
+    }
+    return "";
+}
+
 } // namespace trtmc

--- a/src/utils/json_helpers.h
+++ b/src/utils/json_helpers.h
@@ -18,4 +18,18 @@ std::vector<float> extract_json_float_array(const std::string& text, const std::
 std::vector<int32_t> extract_json_int_array(const std::string& text, const std::string& key,
                                             std::size_t max_count = 16);
 
+// Parse a JSON literal boolean (true/false) for the given key. Also accepts
+// integer 0/1. Returns `fallback` if the key is missing or unparseable.
+bool extract_json_bool(const std::string& text, const std::string& key, bool fallback);
+
+// Parse a JSON array of booleans (true/false), returning each element.
+std::vector<bool> extract_json_bool_array(const std::string& text, const std::string& key,
+                                          std::size_t max_count = 16);
+
+// Extract a nested JSON object's text (including the enclosing braces) for the
+// given key. Returns an empty string if the key is absent or the value is not
+// an object. Useful for scoping further extractions to a sub-section without
+// risking key collisions with siblings.
+std::string extract_json_object_text(const std::string& text, const std::string& key);
+
 } // namespace trtmc

--- a/tensorrt_model_connect/tensorrt_model_connect/bundle_writer.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/bundle_writer.py
@@ -17,6 +17,16 @@ from typing import Any
 
 BUNDLE_MAGIC = b"TRTFB\x00\x01\x00"
 
+# Section names are part of the .trtfb external schema. Define as constants
+# so downstream code references them by symbol — a typo or rename becomes
+# an import error rather than a silent miss at bundle load.
+QWEN_IMAGE_TEXT_ENGINE_SECTION = "qwen_image_text_engine_plan"
+QWEN_IMAGE_DENOISER_SECTION = "qwen_image_denoiser_engine_plan"
+QWEN_IMAGE_VAE_DECODER_SECTION = "qwen_image_vae_decoder_plan"
+QWEN_IMAGE_VAE_ENCODER_SECTION = "qwen_image_vae_encoder_plan"
+QWEN_IMAGE_VISION_ENGINE_SECTION = "qwen_image_vision_engine_plan"
+QWEN_IMAGE_PREPROCESSOR_WEIGHTS_SECTION = "qwen_image_preprocessor_weights"
+
 
 @dataclass
 class BundleInfo:

--- a/tensorrt_model_connect/tensorrt_model_connect/debug_runner.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/debug_runner.py
@@ -2766,3 +2766,576 @@ class VLTrtRunner:
             result = self.text_runner.step(next_token)
 
         return output_ids
+
+
+# ---------------------------------------------------------------------------
+# Qwen-Image debug runner
+# ---------------------------------------------------------------------------
+
+
+# Hardcoded T2I prompt template (mirror of diffusers
+# QwenImagePipeline.prompt_template_encode). The 34-token prefix that this
+# template adds is later stripped from the text-encoder output via the
+# ``drop_idx`` mechanism. Bundles record both fields under
+# ``tokenizer.prompt_template_kind`` / ``prompt_template_drop_idx``.
+_QWEN_IMAGE_T2I_PROMPT_TEMPLATE = (
+    "<|im_start|>system\nDescribe the image by detailing the color, shape, "
+    "size, texture, quantity, text, spatial relationships of the objects "
+    "and background:<|im_end|>\n<|im_start|>user\n{}<|im_end|>\n"
+    "<|im_start|>assistant\n"
+)
+_QWEN_IMAGE_T2I_DROP_IDX = 34
+
+
+class QwenImageDebugRunner:
+    """Pure-Python TRT runner for Qwen-Image (T2I) ``.trtfb`` bundles.
+
+    Loads the bundle, deserialises the three engines (``text_encoder_0``,
+    ``denoiser``, ``vae_decoder``), and implements the full T2I pipeline:
+    prompt template + tokenize + text encode + flow-match Euler denoising
+    with true-CFG + VAE decode.
+
+    This mirrors what the C++ pipeline does, so the HF parity gate
+    validates the entire Python-side pipeline. Any later C++ divergence
+    is purely C++-side.
+
+    Engines baked into the bundle are static-shape at 1024x1024:
+      text_encoder_0:  input_ids[1024] int32, attention_mask[1024] f32
+                       -> last_hidden_state[1024, 3584] f32
+      denoiser:        img_patched[1, 4096, 64] f32,
+                       txt_hidden[1, 1024, 3584] f32, timestep[1] f32
+                       -> noise_patched[1, 4096, 64] f32
+      vae_decoder:     latent[1, 16, 1, 128, 128] f32
+                       -> image[1, 3, 1, 1024, 1024] f32 (range ~[-1, 1])
+
+    Trace: ARCH-FAM-001, UD-FAM-QWEN-IMAGE-01, IT-QWEN-IMAGE-DEBUG-RUN-001.
+    """
+
+    def __init__(self, bundle_path: str | Any) -> None:
+        _require_trt_runtime()
+
+        import json
+        import struct
+        from pathlib import Path
+
+        self.bundle_path = Path(bundle_path)
+        if not self.bundle_path.exists():
+            raise FileNotFoundError(f"bundle not found: {self.bundle_path}")
+
+        # --- Parse bundle header. ----------------------------------------
+        with open(self.bundle_path, "rb") as f:
+            magic = f.read(8)
+            if magic != b"TRTFB\x00\x01\x00":
+                raise ValueError(
+                    f"not a valid .trtfb bundle: magic={magic!r}")
+            header_len = struct.unpack("<Q", f.read(8))[0]
+            header_bytes = f.read(header_len)
+        header = json.loads(header_bytes.decode("utf-8"))
+        self._header = header
+        sections = header.get("sections", {})
+        data_start = 16 + header_len
+
+        def _read_section(name: str) -> bytes:
+            meta = sections.get(name)
+            if meta is None:
+                raise KeyError(
+                    f"section {name!r} not found; available: "
+                    f"{list(sections.keys())}"
+                )
+            with open(self.bundle_path, "rb") as fh:
+                fh.seek(data_start + meta["offset"])
+                return fh.read(meta["size"])
+
+        # --- Load embedded config.json (the variant schema). -------------
+        config_bytes = _read_section("config.json")
+        self.config: dict[str, Any] = json.loads(config_bytes.decode("utf-8"))
+
+        # --- Deserialise the three engines. ------------------------------
+        logger = trt.Logger(trt.Logger.WARNING)
+        runtime = trt.Runtime(logger)
+
+        def _load_engine(plan_name: str):
+            plan = _read_section(plan_name)
+            engine = runtime.deserialize_cuda_engine(plan)
+            if engine is None:
+                raise RuntimeError(f"failed to deserialise {plan_name}")
+            context = engine.create_execution_context()
+            return engine, context
+
+        self._text_engine, self._text_ctx = _load_engine("text_encoder_0_plan")
+        self._dit_engine, self._dit_ctx = _load_engine("denoiser_plan")
+        self._vae_engine, self._vae_ctx = _load_engine("vae_decoder_plan")
+
+        # --- Parse preprocessor weights (latents_mean / latents_std). ----
+        from .families.qwen_image.qwen_image_preprocessor import (
+            load_qwen_image_preprocessor_weights,
+        )
+        pp_bytes = _read_section("preprocessor_weights")
+        self._preprocessor = load_qwen_image_preprocessor_weights(pp_bytes)
+
+        # --- Materialise tokenizer files to a temp dir, then load it. ----
+        import tempfile
+        self._tokenizer_dir = tempfile.mkdtemp(
+            prefix="qwen_image_tokenizer_")
+        tok_dir = Path(self._tokenizer_dir)
+        for tok_file in (
+            "tokenizer.json", "tokenizer_config.json",
+            "special_tokens_map.json", "vocab.json", "merges.txt",
+        ):
+            data = _read_section(tok_file)
+            (tok_dir / tok_file).write_bytes(data)
+
+        # Lazy-imported to avoid forcing transformers as a hard dep when this
+        # module is imported just for the decoder runners.
+        from transformers import AutoTokenizer
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            str(tok_dir), trust_remote_code=False,
+        )
+
+        # --- CUDA stream. -----------------------------------------------
+        err, self.stream = cudart.cudaStreamCreate()
+        _check_cuda(err)
+
+        # --- Derive shape constants from the engine signatures. ----------
+        # Text encoder: input_ids[max_text_input], output[max_text_input, hidden]
+        ti_shape = tuple(self._text_engine.get_tensor_shape("input_ids"))
+        to_shape = tuple(
+            self._text_engine.get_tensor_shape("last_hidden_state"))
+        self._text_max_tokens = int(ti_shape[0])
+        self._text_hidden = int(to_shape[1])
+
+        # Denoiser: img_patched [1, n_img, in_ch], txt_hidden [1, n_txt, 3584]
+        img_shape = tuple(self._dit_engine.get_tensor_shape("img_patched"))
+        txt_shape = tuple(self._dit_engine.get_tensor_shape("txt_hidden"))
+        self._n_img = int(img_shape[1])
+        self._in_ch_packed = int(img_shape[2])
+        self._n_txt = int(txt_shape[1])
+        # img tokens = h_lat//2 * w_lat//2; for square images h_lat = w_lat.
+        side = int(round((self._n_img) ** 0.5))
+        if side * side != self._n_img:
+            raise NotImplementedError(
+                f"non-square image latents not supported (n_img={self._n_img})"
+            )
+        # Packed-token grid is half the latent grid (patch_size=2).
+        self._packed_h = side
+        self._packed_w = side
+        self._latent_h = side * 2
+        self._latent_w = side * 2
+        # Bundle config provides VAE channel count (= packed_ch / 4).
+        self._latent_ch = int(self.config["vae"]["latent_channels"])
+
+        # VAE: image [1, 3, 1, H, W] — record H/W for sanity-check.
+        vae_in_shape = tuple(self._vae_engine.get_tensor_shape("latent"))
+        vae_out_shape = tuple(self._vae_engine.get_tensor_shape("image"))
+        self._vae_latent_shape = vae_in_shape  # (1, 16, 1, 128, 128)
+        self._vae_image_shape = vae_out_shape  # (1, 3, 1, 1024, 1024)
+
+        # Scheduler config from bundle (matches diffusers
+        # scheduler_config.json for Qwen-Image-2512).
+        self._sched_cfg = dict(self.config.get("diffusion", {}))
+
+    # ------------------------------------------------------------------
+    # Engine execution helper (single forward pass, static shapes).
+    # ------------------------------------------------------------------
+
+    def _run_engine(
+        self,
+        engine,
+        context,
+        inputs: dict[str, np.ndarray],
+        output_names: list[str],
+    ) -> dict[str, np.ndarray]:
+        """Run one TRT execution with the given host-side inputs.
+
+        Allocates device buffers for every IO tensor, H2D-copies inputs,
+        executes, D2H-copies outputs, frees device buffers. Static-shape
+        only.
+        """
+        d_buffers: dict[str, int] = {}
+        out_specs: dict[str, tuple[tuple[int, ...], np.dtype, int]] = {}
+        try:
+            for i in range(engine.num_io_tensors):
+                name = engine.get_tensor_name(i)
+                mode = engine.get_tensor_mode(name)
+                shape = tuple(int(d) for d in engine.get_tensor_shape(name))
+                dtype_trt = engine.get_tensor_dtype(name)
+                dtype_np = _trt_nptype_safe(dtype_trt)
+                nbytes = int(np.prod(shape)) * np.dtype(dtype_np).itemsize
+
+                err, d_ptr = cudart.cudaMalloc(nbytes)
+                _check_cuda(err)
+                d_buffers[name] = d_ptr
+                context.set_tensor_address(name, int(d_ptr))
+
+                if mode == trt.TensorIOMode.INPUT:
+                    if name not in inputs:
+                        raise KeyError(
+                            f"missing input {name!r} for engine "
+                            f"(expected {list(inputs.keys())})"
+                        )
+                    host_in = np.ascontiguousarray(
+                        inputs[name].astype(dtype_np)
+                    )
+                    if host_in.shape != shape:
+                        raise ValueError(
+                            f"input {name!r} shape mismatch: got "
+                            f"{host_in.shape}, expected {shape}"
+                        )
+                    err = cudart.cudaMemcpyAsync(
+                        int(d_ptr),
+                        host_in.ctypes.data,
+                        nbytes,
+                        cudart.cudaMemcpyKind.cudaMemcpyHostToDevice,
+                        self.stream,
+                    )
+                    if isinstance(err, tuple):
+                        err = err[0]
+                    _check_cuda(err)
+                else:
+                    out_specs[name] = (shape, np.dtype(dtype_np), nbytes)
+
+            ok = context.execute_async_v3(self.stream)
+            if not ok:
+                raise RuntimeError("execute_async_v3 returned False")
+
+            results: dict[str, np.ndarray] = {}
+            for name in output_names:
+                shape, dtype_np, nbytes = out_specs[name]
+                host_out = np.empty(shape, dtype=dtype_np)
+                err = cudart.cudaMemcpyAsync(
+                    host_out.ctypes.data,
+                    int(d_buffers[name]),
+                    nbytes,
+                    cudart.cudaMemcpyKind.cudaMemcpyDeviceToHost,
+                    self.stream,
+                )
+                if isinstance(err, tuple):
+                    err = err[0]
+                _check_cuda(err)
+                results[name] = host_out
+
+            err = cudart.cudaStreamSynchronize(self.stream)
+            if isinstance(err, tuple):
+                err = err[0]
+            _check_cuda(err)
+
+            return results
+        finally:
+            for d_ptr in d_buffers.values():
+                cudart.cudaFree(d_ptr)
+
+    # ------------------------------------------------------------------
+    # Pipeline stages.
+    # ------------------------------------------------------------------
+
+    def _encode_prompt(self, prompt: str) -> np.ndarray:
+        """Tokenize + run text encoder + apply drop_idx + pad to ``n_txt``.
+
+        Returns ``txt_hidden`` shaped ``[1, n_txt, hidden]`` ready to feed
+        the denoiser. Padding rows past the valid length are zero (matching
+        the additive-mask convention; the baked denoiser does not consume
+        a text mask).
+        """
+        # 1) Tokenize (template + prompt) to the text encoder's max length.
+        text = _QWEN_IMAGE_T2I_PROMPT_TEMPLATE.format(prompt)
+        # Diffusers' tokenizer call uses `padding=True` and a max-length
+        # cap; here the engine is fixed at self._text_max_tokens, so pad
+        # to that length exactly.
+        enc = self.tokenizer(
+            text,
+            return_tensors="np",
+            padding="max_length",
+            max_length=self._text_max_tokens,
+            truncation=True,
+        )
+        input_ids = enc["input_ids"][0].astype(np.int32)  # [max_seq]
+        attn_mask01 = enc["attention_mask"][0].astype(np.int64)  # 0/1
+        valid_len = int(attn_mask01.sum())
+
+        # Additive mask for the engine: 0 for valid, -1e9 for pad.
+        additive_mask = np.zeros(self._text_max_tokens, dtype=np.float32)
+        if valid_len < self._text_max_tokens:
+            additive_mask[valid_len:] = -1e9
+
+        # 2) Run text encoder.
+        out = self._run_engine(
+            self._text_engine, self._text_ctx,
+            inputs={
+                "input_ids": input_ids,
+                "attention_mask": additive_mask,
+            },
+            output_names=["last_hidden_state"],
+        )
+        hidden = out["last_hidden_state"]  # [max_seq, hidden]
+        # Sanity-check: NaN-free.
+        if not np.isfinite(hidden).all():
+            raise RuntimeError("text encoder output contains NaN/Inf")
+
+        # 3) Drop the first drop_idx (=34) rows of the *valid* prompt and
+        # pad to n_txt with zeros. Matches diffusers
+        # ``[e[drop_idx:] for e in split_hidden_states]`` followed by the
+        # batch-level zero-pad to the max length (here n_txt=1024).
+        drop = _QWEN_IMAGE_T2I_DROP_IDX
+        kept_len = max(0, valid_len - drop)
+        if kept_len == 0:
+            raise ValueError(
+                f"prompt too short after dropping template prefix "
+                f"(valid_len={valid_len}, drop_idx={drop})"
+            )
+        padded = np.zeros((self._n_txt, self._text_hidden), dtype=np.float32)
+        copy_len = min(kept_len, self._n_txt)
+        padded[:copy_len] = hidden[drop:drop + copy_len]
+        return padded.reshape(1, self._n_txt, self._text_hidden)
+
+    def _prepare_latents(self, seed: int) -> np.ndarray:
+        """Sample initial packed latents matching the denoiser shape.
+
+        Returns ``[1, n_img, in_ch_packed]`` float32 — already patchified
+        (per diffusers ``_pack_latents``).
+        """
+        import torch  # lazy: torch is only required for the diffusion path
+        # Diffusers prepare_latents shape (T2I): (B, 1, C, H, W). For the
+        # T2I pipeline F=1 collapses; we sample at (B, C, H, W) directly so
+        # numel matches QwenImagePipeline.prepare_latents (which calls
+        # randn_tensor on (B, 1, C, H, W) then _pack_latents reshapes
+        # ignoring the leading F=1 axis).
+        gen = torch.Generator(device="cpu").manual_seed(int(seed))
+        latents = torch.randn(
+            (1, self._latent_ch, self._latent_h, self._latent_w),
+            generator=gen, dtype=torch.float32,
+        ).numpy()
+        # Pack patches: mirror of QwenImagePipeline._pack_latents
+        # which does: latents.view(B, C, H/2, 2, W/2, 2)
+        #         -> permute(0, 2, 4, 1, 3, 5)
+        #         -> reshape(B, (H/2)*(W/2), C*4).
+        b, c, h, w = latents.shape
+        v = latents.reshape(b, c, h // 2, 2, w // 2, 2)
+        v = v.transpose(0, 2, 4, 1, 3, 5)
+        packed = v.reshape(b, (h // 2) * (w // 2), c * 4)
+        return packed.astype(np.float32)
+
+    def _run_denoiser(
+        self,
+        img_packed: np.ndarray,
+        txt_hidden: np.ndarray,
+        timestep_norm: float,
+    ) -> np.ndarray:
+        """One denoiser forward.
+
+        Inputs / outputs all packed-token shaped [1, n_img, in_ch_packed].
+        ``timestep_norm`` is in [0, 1] (the engine scales by 1000 internally
+        in the sinusoidal timestep embedding).
+        """
+        ts = np.asarray([float(timestep_norm)], dtype=np.float32)
+        out = self._run_engine(
+            self._dit_engine, self._dit_ctx,
+            inputs={
+                "img_patched": img_packed.astype(np.float32),
+                "txt_hidden": txt_hidden.astype(np.float32),
+                "timestep": ts,
+            },
+            output_names=["noise_patched"],
+        )
+        return out["noise_patched"]
+
+    def _vae_decode(self, latents_packed: np.ndarray) -> np.ndarray:
+        """Un-patchify, un-normalise, then VAE-decode.
+
+        Inputs: ``latents_packed`` shape ``[1, n_img, in_ch_packed]``.
+        Returns: image array ``[3, H, W]`` uint8 in [0, 255].
+        """
+        # 1) Unpack patches: (B, n_img, C*4) -> (B, C, 1, H_lat, W_lat).
+        b, num_patches, ch_packed = latents_packed.shape
+        if b != 1:
+            raise NotImplementedError("batch>1 not supported")
+        h_packed = self._packed_h
+        w_packed = self._packed_w
+        c_unpacked = ch_packed // 4
+        # Mirror QwenImagePipeline._unpack_latents:
+        # (B, n_patches, ch*4) -> (B, h_pack, w_pack, ch, 2, 2)
+        v = latents_packed.reshape(
+            b, h_packed, w_packed, c_unpacked, 2, 2
+        )
+        # permute (0, 3, 1, 4, 2, 5)
+        v = v.transpose(0, 3, 1, 4, 2, 5)
+        # reshape (B, ch, 1, H_lat, W_lat)
+        v = v.reshape(b, c_unpacked, 1, h_packed * 2, w_packed * 2)
+
+        # 2) Un-normalise per channel (the bundle stores raw
+        # vae.config.latents_std and latents_mean — diffusers internally does
+        # latents_std = 1/raw, then z = z / inverted + mean which is
+        # equivalent to z * raw + mean).
+        mean = self._preprocessor["latents_mean"].astype(np.float32)
+        std = self._preprocessor["latents_std"].astype(np.float32)
+        if mean.shape[0] != c_unpacked or std.shape[0] != c_unpacked:
+            raise ValueError(
+                f"latents_mean/std channel mismatch: "
+                f"got {mean.shape} vs c={c_unpacked}"
+            )
+        m = mean.reshape(1, c_unpacked, 1, 1, 1)
+        s = std.reshape(1, c_unpacked, 1, 1, 1)
+        latents5d = (v.astype(np.float32) * s) + m
+
+        # 3) VAE decode.
+        out = self._run_engine(
+            self._vae_engine, self._vae_ctx,
+            inputs={"latent": latents5d},
+            output_names=["image"],
+        )
+        image = out["image"]  # [1, 3, 1, H, W], range ~[-1, 1]
+        if image.ndim == 5:
+            image = image[0, :, 0]  # [3, H, W]
+        elif image.ndim == 4:
+            image = image[0]  # [3, H, W]
+        else:
+            raise ValueError(f"unexpected VAE image shape {image.shape}")
+
+        # 4) Convert [-1, 1] -> uint8 [0, 255].
+        image = np.clip(image, -1.0, 1.0)
+        img_u8 = np.rint((image + 1.0) * 127.5).astype(np.uint8)
+        return img_u8
+
+    # ------------------------------------------------------------------
+    # Public entry point.
+    # ------------------------------------------------------------------
+
+    def generate(
+        self,
+        prompt: str,
+        negative_prompt: str = " ",
+        num_inference_steps: int = 50,
+        cfg_scale: float = 4.0,
+        height: int | None = None,
+        width: int | None = None,
+        seed: int = 42,
+    ) -> np.ndarray:
+        """Run the full T2I pipeline and return a ``[3, H, W]`` uint8 image.
+
+        ``height`` / ``width`` MUST match the engine's baked latent grid
+        (1024x1024 for the shipped bundle). If left None, defaults are read
+        from the bundle's ``image.default_height`` / ``image.default_width``.
+        """
+        if height is None:
+            height = int(self.config["image"]["default_height"])
+        if width is None:
+            width = int(self.config["image"]["default_width"])
+
+        expected_h = self._latent_h * 8
+        expected_w = self._latent_w * 8
+        if height != expected_h or width != expected_w:
+            raise ValueError(
+                f"height/width must match the engine's baked grid; got "
+                f"{height}x{width}, expected {expected_h}x{expected_w}"
+            )
+
+        # 1) Encode positive + negative prompts.
+        pos_hidden = self._encode_prompt(prompt)
+        neg_hidden = self._encode_prompt(negative_prompt)
+
+        import torch  # lazy: torch is only required for the diffusion path
+        # 2) Prepare scheduler. Use diffusers FlowMatchEulerDiscreteScheduler
+        # to match the reference exactly (dynamic mu shifting, time_shift_type,
+        # set_begin_index, etc. — too many edge cases to reimplement).
+        from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+
+        sched_cfg = self._sched_cfg
+        scheduler = FlowMatchEulerDiscreteScheduler(
+            num_train_timesteps=int(sched_cfg.get("num_train_timesteps", 1000)),
+            shift=float(sched_cfg.get("shift", 1.0)),
+            use_dynamic_shifting=bool(
+                sched_cfg.get("use_dynamic_shifting", True)),
+            base_image_seq_len=int(sched_cfg.get("base_image_seq_len", 256)),
+            max_image_seq_len=int(
+                sched_cfg.get("max_image_seq_len", 8192)),
+            base_shift=0.5,
+            max_shift=1.15,
+            shift_terminal=None,
+            time_shift_type="exponential",
+        )
+
+        # mu shift matching pipeline_qwenimage.py:calculate_shift().
+        def _calc_mu(image_seq_len: int) -> float:
+            base = sched_cfg.get("base_image_seq_len", 256)
+            mx = sched_cfg.get("max_image_seq_len", 4096)
+            base_shift = 0.5
+            max_shift = 1.15
+            m = (max_shift - base_shift) / (mx - base)
+            b = base_shift - m * base
+            return image_seq_len * m + b
+
+        mu = _calc_mu(self._n_img)
+        sigmas = np.linspace(
+            1.0, 1.0 / num_inference_steps, num_inference_steps
+        )
+        scheduler.set_timesteps(
+            sigmas=sigmas.tolist(), mu=mu, device="cpu",
+        )
+        scheduler.set_begin_index(0)
+
+        # 3) Sample initial latents (packed).
+        latents = self._prepare_latents(seed)
+        # diffusers passes ``torch.Tensor`` to scheduler.step. We keep a
+        # torch copy for the scheduler interaction and a numpy copy for
+        # engine I/O — converting per-step is cheap relative to a denoiser
+        # forward.
+        latents_t = torch.from_numpy(latents).to(torch.float32)
+
+        timesteps = scheduler.timesteps
+        do_cfg = cfg_scale > 1.0 and negative_prompt is not None
+
+        for i, t in enumerate(timesteps):
+            t_norm = float(t.item()) / 1000.0
+            latents_np = latents_t.numpy().astype(np.float32)
+
+            noise_pos = self._run_denoiser(
+                latents_np, pos_hidden, t_norm,
+            )
+            if do_cfg:
+                noise_neg = self._run_denoiser(
+                    latents_np, neg_hidden, t_norm,
+                )
+                # Diffusers true-CFG:
+                #   comb = neg + cfg * (pos - neg)
+                #   noise = comb * (||pos|| / ||comb||)   (per-token renorm)
+                comb = noise_neg + cfg_scale * (noise_pos - noise_neg)
+                pos_norm = np.linalg.norm(
+                    noise_pos, axis=-1, keepdims=True
+                )
+                comb_norm = np.linalg.norm(comb, axis=-1, keepdims=True)
+                # Avoid division by zero.
+                comb_norm = np.maximum(comb_norm, 1e-8)
+                noise = comb * (pos_norm / comb_norm)
+            else:
+                noise = noise_pos
+
+            noise_t = torch.from_numpy(noise.astype(np.float32))
+            latents_t = scheduler.step(
+                noise_t, t, latents_t, return_dict=False,
+            )[0]
+            latents_t = latents_t.to(torch.float32)
+
+        # 4) VAE-decode the final packed latents.
+        final_packed = latents_t.numpy().astype(np.float32)
+        return self._vae_decode(final_packed)
+
+    # ------------------------------------------------------------------
+    # Cleanup.
+    # ------------------------------------------------------------------
+
+    def __del__(self):
+        # Best-effort cleanup; called during interpreter shutdown.
+        if cudart is None:
+            return
+        stream = getattr(self, "stream", None)
+        if stream is not None:
+            try:
+                cudart.cudaStreamDestroy(stream)
+            except Exception:  # noqa: BLE001 - shutdown path
+                pass
+        tok_dir = getattr(self, "_tokenizer_dir", None)
+        if tok_dir is not None:
+            import shutil
+            try:
+                shutil.rmtree(tok_dir, ignore_errors=True)
+            except Exception:  # noqa: BLE001 - shutdown path
+                pass

--- a/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
@@ -1203,30 +1203,44 @@ def _build_diffusion_bundle(
         time.monotonic() - tokenizer_t0)
     _write_build_timing(build_timing)
 
-    # Build config.json with diffusion config injected
-    _effective_precision = "bf16" if fp8_scales else precision
-    cfg_dict = {
-        "model_type": model_type,
-        "runtime_strategy": getattr(plugin, "runtime_strategy", "diffusion"),
-        "precision": _effective_precision,
-        "engine_backend": "trt_rtx" if rtx else "trt",
-        "trt_version": trt_version,
-        "num_text_encoders": len(components["text_encoders"]),
-        "tokenizer_add_special_tokens": int(tokenizer_add_special_tokens),
-    }
-    if trt_abi:
-        cfg_dict["trt_abi"] = trt_abi
-    if fp8_scales:
-        cfg_dict["quantization"] = {"format": "fp8"}
+    # Build config.json. Plugins that need a variant-specific schema can
+    # return a pre-rendered JSON blob via components["config_json"] (e.g.
+    # Qwen-Image, which has its own bundle schema built by
+    # qwen_image_bundle_config.build_bundle_config()). Existing plugins
+    # (Z-Image / FLUX / Wan / PixArt) don't return config_json and fall
+    # through to the inline construction below.
+    if "config_json" in components:
+        cfg_data = components["config_json"]
+        if not isinstance(cfg_data, (bytes, bytearray)):
+            raise TypeError(
+                f"Plugin {plugin.name} returned components['config_json'] "
+                f"as {type(cfg_data).__name__}; expected bytes."
+            )
+    else:
+        _effective_precision = "bf16" if fp8_scales else precision
+        cfg_dict = {
+            "model_type": model_type,
+            "runtime_strategy": getattr(plugin, "runtime_strategy", "diffusion"),
+            "precision": _effective_precision,
+            "engine_backend": "trt_rtx" if rtx else "trt",
+            "trt_version": trt_version,
+            "num_text_encoders": len(components["text_encoders"]),
+            "tokenizer_add_special_tokens": int(tokenizer_add_special_tokens),
+        }
+        if trt_abi:
+            cfg_dict["trt_abi"] = trt_abi
+        if fp8_scales:
+            cfg_dict["quantization"] = {"format": "fp8"}
 
-    # Inject diffusion config from plugin
-    get_diff_config = getattr(plugin, 'get_diffusion_config', None)
-    if get_diff_config is not None:
-        diff_cfg = get_diff_config(config)
-        if diff_cfg is not None:
-            cfg_dict.update(diff_cfg)
+        # Inject diffusion config from plugin
+        get_diff_config = getattr(plugin, 'get_diffusion_config', None)
+        if get_diff_config is not None:
+            diff_cfg = get_diff_config(config)
+            if diff_cfg is not None:
+                cfg_dict.update(diff_cfg)
 
-    cfg_data = json.dumps(cfg_dict, indent=2).encode("utf-8")
+        cfg_data = json.dumps(cfg_dict, indent=2).encode("utf-8")
+
     sections.append(BundleSection("config.json", cfg_data))
 
     # Ensure tokenizer.json exists for diffusion tokenizer directories.

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen/plugin.py
@@ -57,9 +57,10 @@ class QwenPlugin:
         mt = model_type.lower()
         # Exclude vision-language variants (handled by qwen_vl plugin),
         # MoE variants (handled by qwen_moe plugin),
-        # omni variants (handled by qwen3_omni plugin), and
+        # omni variants (handled by qwen3_omni plugin),
+        # Qwen-Image diffusion variants (handled by qwen_image plugin), and
         # Qwen3.5 hybrid variants (handled by qwen3_5 plugin).
-        if "vl" in mt or "moe" in mt or "omni" in mt:
+        if "vl" in mt or "moe" in mt or "omni" in mt or "image" in mt:
             return False
         if mt in {"qwen3_5", "qwen3.5"}:
             return False

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/__init__.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import sys
+import types
+
+from . import plugin as _plugin
+
+globals().update({
+    _name: _value
+    for _name, _value in vars(_plugin).items()
+    if not _name.startswith("__")
+})
+__all__ = [
+    _name for _name in globals()
+    if not _name.startswith("__") and _name != "_plugin"
+]
+
+
+class _FamilyModule(types.ModuleType):
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        if not name.startswith("__") and name != "_plugin":
+            setattr(_plugin, name, value)
+
+
+sys.modules[__name__].__class__ = _FamilyModule

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/plugin.py
@@ -1,0 +1,273 @@
+"""Qwen-Image family plugin.
+
+Supports:
+  - Qwen/Qwen-Image            (base, Aug 2025)
+  - Qwen/Qwen-Image-2512       (Dec 2025 T2I refresh)
+  - Qwen/Qwen-Image-Edit-2511  (Nov 2025 image-edit; claimed for future work)
+
+Architecture:
+  text_encoder: Qwen2.5-VL-7B (LM-only path for T2I; +vision tower for Edit)
+  transformer: QwenImageTransformer2DModel (MMDiT, 60 joint blocks)
+  vae: AutoencoderKLQwenImage (8x spatial, 16-ch latent, 2x2 patch)
+  scheduler: FlowMatchEulerDiscreteScheduler (static shift=1.0)
+
+Currently implements T2I only. The plugin claims the Edit pipeline classes
+upfront so the image-edit path can be added later as a code branch rather
+than a new plugin.
+"""
+from __future__ import annotations
+
+import json
+
+from ...config import ModelConfig
+from ...checkpoint_mapper import WeightDict
+
+
+class QwenImagePlugin:
+    name = "qwen_image"
+    runtime_strategy = "diffusion_qwen_image"
+    pipeline_classes = [
+        "QwenImagePipeline",
+        "QwenImageEditPipeline",
+        "QwenImageEditPlusPipeline",
+    ]
+
+    # Lowercase-normalized model_type tokens that identify this family.
+    # Edit variants are claimed upfront so the image-edit path can be added
+    # later as a code branch.
+    _MATCH_TOKENS = frozenset({
+        "qwen_image",
+        "qwenimage",
+        "qwen-image",
+        "qwen_image_edit",
+        "qwenimageedit",
+        "qwen-image-edit",
+    })
+
+    def matches(self, model_type: str) -> bool:
+        return model_type.lower() in self._MATCH_TOKENS
+
+    def load_weights(
+        self, model_dir: str, config: ModelConfig,
+    ) -> WeightDict:
+        """Resolve component subdirectories from a diffusers-format checkpoint."""
+        from pathlib import Path
+
+        model_path = Path(model_dir)
+        if not (model_path / "model_index.json").exists():
+            raise ValueError(
+                f"Qwen-Image requires diffusers format (model_index.json "
+                f"missing in {model_dir})"
+            )
+
+        weights = WeightDict()
+        weights["_model_format"] = "diffusers"
+        weights["_text_encoder_dir"] = str(model_path / "text_encoder")
+        weights["_transformer_dir"] = str(model_path / "transformer")
+        weights["_vae_dir"] = str(model_path / "vae")
+        weights["_tokenizer_dir"] = str(model_path / "tokenizer")
+        weights["_model_dir"] = str(model_path)
+        return weights
+
+    def build_engine(
+        self, config: ModelConfig, weights: WeightDict,
+        max_cache_length: int, *, precision: str = "bf16",
+        quant_ctx=None, verbose: bool = False,
+    ) -> bytes:
+        raise NotImplementedError(
+            "Qwen-Image uses build_components(), not build_engine()"
+        )
+
+    def build_components(
+        self, model_dir: str, config: ModelConfig, weights: WeightDict,
+        *, precision: str = "bf16", verbose: bool = False, **_kwargs,
+    ) -> dict:
+        """Build TRT engines and bundle blobs for a Qwen-Image T2I checkpoint.
+
+        Produces:
+          * Bundle config.json (``qwen_image_bundle_config``).
+          * Qwen2.5-VL LM text encoder TRT engine.
+          * Qwen-Image MMDiT denoiser TRT engine (bakes in (h_lat, w_lat,
+            n_text) RoPE tables; the resulting plan is static).
+          * Qwen-Image VAE decoder TRT engine.
+          * Preprocessor weights blob (latents_mean / latents_std).
+
+        The returned dict keeps the keys consumed by
+        ``engine_builder._build_diffusion_bundle`` -- ``text_encoders``,
+        ``denoiser``, ``vae_decoder``, ``preprocessor_weights`` -- and adds
+        a Qwen-Image-specific ``config_json`` blob that engine_builder
+        consumes via the plugin-provided config_json path.
+
+        Tokenizer files are NOT packed here. engine_builder walks the
+        ``tokenizer/`` directory pointed to by ``weights["_tokenizer_dir"]``
+        and emits per-file bundle sections (tokenizer.json, vocab.json,
+        merges.txt, etc.), matching the Z-Image / FLUX / Wan path.
+
+        ``max_cache_length`` is part of the FamilyPlugin protocol but
+        unused here -- Qwen-Image is a diffusion model and has no KV cache.
+        """
+        import sys
+        import tempfile
+        from pathlib import Path
+
+        from .qwen_image_bundle_config import build_bundle_config
+        from .qwen25_vl_text_encoder_builder import (
+            build_qwen25vl_text_encoder_engine,
+            load_qwen25vl_text_encoder_weights,
+        )
+        from .qwen_image_dit_builder import (
+            build_qwen_image_dit_engine,
+            load_qwen_image_dit_weights,
+        )
+        from .qwen_image_preprocessor import (
+            extract_preprocessor_source,
+            pack_qwen_image_preprocessor_weights,
+        )
+        from .qwen_image_vae_builder import (
+            build_qwen_image_vae_decoder_engine,
+            load_qwen_image_vae_weights,
+        )
+
+        repo = Path(weights.get("_model_dir") or model_dir)
+
+        # 1. Bundle config.json blob -- pure file-IO transform, fast.
+        print("[qwen-image] Building bundle config ...", file=sys.stderr)
+        bundle_cfg = build_bundle_config(repo)
+        config_json_bytes = json.dumps(bundle_cfg, indent=2).encode("utf-8")
+
+        # Derive engine build-time shape constants from the bundle config so
+        # the static plans agree with the C++ runtime contract.
+        vae_scale = int(bundle_cfg["vae"]["spatial_scale_factor"])
+        patch_size = int(bundle_cfg["denoiser"]["patch_size"])
+        default_h = int(bundle_cfg["image"]["default_height"])
+        default_w = int(bundle_cfg["image"]["default_width"])
+        n_text = int(bundle_cfg["text_encoder"]["max_seq_len"])
+
+        # Latent grid pre-patchify, then packed-token grid post-patchify.
+        # h_lat / w_lat here describe the *post-patchify* token grid that
+        # build_qwen_image_dit_engine expects (h_lat * w_lat == n_img).
+        latent_h = default_h // vae_scale
+        latent_w = default_w // vae_scale
+        h_lat = latent_h // patch_size
+        w_lat = latent_w // patch_size
+
+        # 2. Qwen2.5-VL LM text encoder.
+        print(
+            f"[qwen-image] Loading Qwen2.5-VL text encoder weights "
+            f"from {repo / 'text_encoder'} ...",
+            file=sys.stderr,
+        )
+        text_cfg, text_w = load_qwen25vl_text_encoder_weights(
+            repo / "text_encoder",
+            max_seq_len=n_text,
+            apply_final_norm=bool(
+                bundle_cfg["text_encoder"].get("apply_final_norm", True)
+            ),
+        )
+        with tempfile.NamedTemporaryFile(
+            suffix=".plan", delete=False, prefix="qwen_image_text_"
+        ) as f:
+            text_plan_path = Path(f.name)
+        try:
+            print(
+                "[qwen-image] Building Qwen2.5-VL text encoder engine ...",
+                file=sys.stderr,
+            )
+            build_qwen25vl_text_encoder_engine(
+                text_cfg, text_w, text_plan_path, verbose=verbose,
+            )
+            text_engine_bytes = text_plan_path.read_bytes()
+        finally:
+            text_plan_path.unlink(missing_ok=True)
+        # Free the weight tensors before the next builder allocates more.
+        del text_w
+        print(
+            f"[qwen-image]   text encoder plan: "
+            f"{len(text_engine_bytes) / (1024 * 1024):.1f} MB",
+            file=sys.stderr,
+        )
+
+        # 3. MMDiT denoiser engine.
+        print(
+            f"[qwen-image] Loading MMDiT denoiser weights "
+            f"from {repo / 'transformer'} ...",
+            file=sys.stderr,
+        )
+        dit_cfg, dit_w = load_qwen_image_dit_weights(repo / "transformer")
+        with tempfile.NamedTemporaryFile(
+            suffix=".plan", delete=False, prefix="qwen_image_dit_"
+        ) as f:
+            dit_plan_path = Path(f.name)
+        try:
+            print(
+                f"[qwen-image] Building MMDiT denoiser engine "
+                f"(h_lat={h_lat}, w_lat={w_lat}, n_text={n_text}) ...",
+                file=sys.stderr,
+            )
+            build_qwen_image_dit_engine(
+                dit_cfg, dit_w, dit_plan_path,
+                h_lat=h_lat, w_lat=w_lat, n_text=n_text,
+                verbose=verbose,
+            )
+            dit_engine_bytes = dit_plan_path.read_bytes()
+        finally:
+            dit_plan_path.unlink(missing_ok=True)
+        del dit_w
+        print(
+            f"[qwen-image]   denoiser plan: "
+            f"{len(dit_engine_bytes) / (1024 * 1024):.1f} MB",
+            file=sys.stderr,
+        )
+
+        # 4. VAE decoder engine + preprocessor blob.
+        print(
+            f"[qwen-image] Loading VAE weights from {repo / 'vae'} ...",
+            file=sys.stderr,
+        )
+        vae_cfg, vae_w = load_qwen_image_vae_weights(repo / "vae")
+        with tempfile.NamedTemporaryFile(
+            suffix=".plan", delete=False, prefix="qwen_image_vae_"
+        ) as f:
+            vae_plan_path = Path(f.name)
+        try:
+            print(
+                f"[qwen-image] Building VAE decoder engine "
+                f"(h_lat={latent_h}, w_lat={latent_w}) ...",
+                file=sys.stderr,
+            )
+            build_qwen_image_vae_decoder_engine(
+                vae_cfg, vae_w, vae_plan_path,
+                h_lat=latent_h, w_lat=latent_w,
+                verbose=verbose,
+            )
+            vae_engine_bytes = vae_plan_path.read_bytes()
+        finally:
+            vae_plan_path.unlink(missing_ok=True)
+        del vae_w
+        print(
+            f"[qwen-image]   vae decoder plan: "
+            f"{len(vae_engine_bytes) / (1024 * 1024):.1f} MB",
+            file=sys.stderr,
+        )
+
+        # 5. Preprocessor weights blob (latents_mean / latents_std).
+        prep_src = extract_preprocessor_source(vae_cfg)
+        prep_blob = pack_qwen_image_preprocessor_weights(prep_src)
+
+        # Final components dict. Keys ``text_encoders``, ``denoiser``,
+        # ``vae_decoder``, ``preprocessor_weights`` match the contract
+        # consumed by engine_builder._build_diffusion_bundle. ``config_json``
+        # is a Qwen-Image-specific extra; engine_builder uses it as-is for
+        # the bundle's config.json section when present. Tokenizer files
+        # are emitted by engine_builder's per-file walk of the tokenizer/
+        # directory (matches Z-Image / FLUX).
+        return {
+            "config_json": config_json_bytes,
+            "text_encoders": [("qwen2_5_vl_lm", text_engine_bytes)],
+            "denoiser": dit_engine_bytes,
+            "vae_decoder": vae_engine_bytes,
+            "preprocessor_weights": prep_blob,
+        }
+
+
+plugin = QwenImagePlugin()

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen25_vl_text_encoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen25_vl_text_encoder_builder.py
@@ -1,0 +1,522 @@
+"""Qwen2.5-VL text encoder builder -- LM-only path for Qwen-Image T2I.
+
+Builds a TensorRT engine that takes ``(input_ids, attention_mask)`` and
+emits ``last_hidden_state`` (NOT logits) for use as conditioning by the
+Qwen-Image MMDiT denoiser.
+
+Architecture matches the LM half of ``Qwen2_5_VLForConditionalGeneration``
+(see ``references/transformers/.../modeling_qwen2_5_vl.py``):
+
+* Token embedding (``model.embed_tokens.weight``).
+* N decoder layers, each:
+    - Pre-attention RMSNorm (``input_layernorm.weight``).
+    - GQA attention with bias on ``q_proj``/``k_proj``/``v_proj``,
+      no bias on ``o_proj``.
+    - Residual.
+    - Post-attention RMSNorm (``post_attention_layernorm.weight``).
+    - SwiGLU MLP (``gate_proj``, ``up_proj``, ``down_proj``; no biases).
+    - Residual.
+* Final RMSNorm (``model.norm.weight``) when ``apply_final_norm=True``.
+* No LM head, no logits.
+
+Engine I/O:
+  Inputs:
+    ``input_ids``       : ``[max_seq_len]`` int32 token ids.
+    ``attention_mask``  : ``[max_seq_len]`` float32 additive mask
+                          (0.0 for valid tokens, -1e9 for padding).
+  Outputs:
+    ``last_hidden_state``: ``[max_seq_len, hidden_size]`` float32.
+
+This builder is a thin orchestrator over the shared graph_ops / graph_blocks
+layer that powers every other LM in this codebase (Qwen3, Llama, Mistral,
+Phi, Gemma, ...). Heavy lifting -- bf16 precision boundary handling, RoPE,
+GQA attention, SwiGLU MLP -- lives in ``graph_ops`` and ``graph_blocks``.
+
+Internal compute runs in **bf16** for heavy ops (attention QKV/MLP matmuls,
+residuals, RoPE/elementwise math). RMSNorm internally promotes to fp32 for
+the variance reduction (graph_ops.add_rms_norm with dtype=np.float16) for
+numerical stability and casts back to bf16. The bf16 path is the same one
+``standard_decoder_builder`` uses for ``precision='bf16'`` (work_np_dtype =
+np.float16, work_trt_dtype = trt.bfloat16). Inputs/outputs stay fp32 because
+the C++ runtime and Python debug runner bind fp32 buffers to engine IO.
+
+Attention masking: the Qwen2.5-VL LM is causal (``is_causal=True`` in HF
+``modeling_qwen2_5_vl.py``). The engine bakes a lower-triangular causal
+constant ``[max_S, max_S]`` and adds the broadcast padding mask, so each
+query position only attends to non-pad keys with position <= q. The combined
+mask is cast to bf16 just before being fed to IAttention (the -1e9 sentinel
+survives fine in bf16).
+
+RoPE: this builder emits standard 1D rotate-half RoPE. Qwen2.5-VL uses 3D
+mRoPE in HF, but for text-only input (which is all the T2I path ever sees)
+the three rotary position indices collapse to identical 1D positions
+(per ``apply_multimodal_rotary_pos_emb``'s own docstring), so 1D RoPE is
+numerically exact. Image-editing variants with vision tokens would need to
+revisit this.
+
+Trace: ARCH-FAM-001, UD-FAM-QWEN-IMAGE-01, UT-QWEN-IMAGE-TEXT-ENCODER-001.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_blocks, graph_ops
+
+
+trt = trt_compat.get_trt()
+
+
+@dataclass
+class Qwen25VLTextEncoderConfig:
+    """Architecture parameters for the Qwen2.5-VL LM text encoder.
+
+    Real Qwen2.5-VL-7B values (for reference):
+        hidden_size=3584, num_layers=28, num_heads=28, num_kv_heads=4,
+        head_dim=128, intermediate_size=18944, vocab_size=152064,
+        rope_theta=1000000.0, rms_norm_eps=1e-6, apply_final_norm=True.
+    """
+
+    hidden_size: int
+    num_layers: int
+    num_heads: int
+    num_kv_heads: int
+    head_dim: int
+    intermediate_size: int
+    vocab_size: int
+    rope_theta: float = 1_000_000.0
+    rms_norm_eps: float = 1e-6
+    max_seq_len: int = 1024
+    apply_final_norm: bool = True
+
+
+def _as_numpy(value, *, name: str) -> np.ndarray:
+    """Coerce a torch tensor or numpy array to a contiguous float32 numpy array."""
+    if isinstance(value, np.ndarray):
+        arr = value
+    else:
+        # Lazily import torch only if needed; tests pass numpy by default.
+        try:
+            import torch  # local import to avoid hard dep at import time
+        except ImportError:  # pragma: no cover - guard only
+            raise TypeError(
+                f"weight {name!r} is not a numpy array and torch is unavailable"
+            )
+        if isinstance(value, torch.Tensor):
+            arr = value.detach().cpu().to(torch.float32).numpy()
+        else:
+            raise TypeError(
+                f"weight {name!r} has unsupported type {type(value).__name__}"
+            )
+    return np.ascontiguousarray(arr, dtype=np.float32)
+
+
+def _prepare_weights(
+    cfg: Qwen25VLTextEncoderConfig,
+    weights: Mapping[str, "np.ndarray"],
+) -> tuple[np.ndarray, dict[str, np.ndarray], np.ndarray | None]:
+    """Pull the HF-named weights into a flat WeightDict graph_blocks expects.
+
+    Maps HF Qwen2.5-VL safetensors keys to the (family-agnostic) naming
+    convention used by ``graph_blocks.add_swiglu_mlp`` and the rest of the
+    standard decoder ecosystem:
+
+        layer.{i}.input_norm        layer.{i}.post_attn_norm
+        layer.{i}.w_q, .w_k, .w_v   .q_bias, .k_bias, .v_bias
+        layer.{i}.w_o
+        layer.{i}.w_gate, .w_up, .w_down
+
+    Returns ``(embed [vocab, hidden], flat WeightDict, final_norm_or_None)``.
+
+    graph_ops.add_matmul_rhs_constant takes rhs of shape [in, out]. HF stores
+    Linear weight as [out, in], so we transpose once at weight-load time.
+    """
+    def take(name: str) -> np.ndarray:
+        if name not in weights:
+            raise KeyError(f"missing required weight: {name!r}")
+        return _as_numpy(weights[name], name=name)
+
+    def take_T(name: str) -> np.ndarray:
+        return np.ascontiguousarray(take(name).T, dtype=np.float32)
+
+    embed = take("model.embed_tokens.weight")  # [vocab, hidden]
+
+    wd: dict[str, np.ndarray] = {}
+    for i in range(cfg.num_layers):
+        hf = f"model.layers.{i}"
+        lp = f"layer.{i}"
+        wd[f"{lp}.input_norm"]     = take(f"{hf}.input_layernorm.weight")
+        wd[f"{lp}.post_attn_norm"] = take(f"{hf}.post_attention_layernorm.weight")
+        wd[f"{lp}.w_q"]            = take_T(f"{hf}.self_attn.q_proj.weight")
+        wd[f"{lp}.q_bias"]         = take(f"{hf}.self_attn.q_proj.bias")
+        wd[f"{lp}.w_k"]            = take_T(f"{hf}.self_attn.k_proj.weight")
+        wd[f"{lp}.k_bias"]         = take(f"{hf}.self_attn.k_proj.bias")
+        wd[f"{lp}.w_v"]            = take_T(f"{hf}.self_attn.v_proj.weight")
+        wd[f"{lp}.v_bias"]         = take(f"{hf}.self_attn.v_proj.bias")
+        wd[f"{lp}.w_o"]            = take_T(f"{hf}.self_attn.o_proj.weight")
+        wd[f"{lp}.w_gate"]         = take_T(f"{hf}.mlp.gate_proj.weight")
+        wd[f"{lp}.w_up"]           = take_T(f"{hf}.mlp.up_proj.weight")
+        wd[f"{lp}.w_down"]         = take_T(f"{hf}.mlp.down_proj.weight")
+
+    final_norm = take("model.norm.weight") if cfg.apply_final_norm else None
+    return embed, wd, final_norm
+
+
+def build_qwen25vl_text_encoder_engine(
+    cfg: Qwen25VLTextEncoderConfig,
+    weights: Mapping[str, "np.ndarray"],
+    out_path: Path | str,
+    *,
+    verbose: bool = False,
+) -> Path:
+    """Build the TRT engine and serialize the plan to ``out_path``.
+
+    Args:
+        cfg: Architecture configuration.
+        weights: Mapping of HF-style weight names to numpy/torch tensors.
+            Required keys (per layer i in [0, num_layers)):
+              - ``model.embed_tokens.weight``        [vocab, hidden]
+              - ``model.layers.{i}.input_layernorm.weight``           [hidden]
+              - ``model.layers.{i}.post_attention_layernorm.weight``  [hidden]
+              - ``model.layers.{i}.self_attn.q_proj.weight``          [num_heads*head_dim, hidden]
+              - ``model.layers.{i}.self_attn.q_proj.bias``            [num_heads*head_dim]
+              - ``model.layers.{i}.self_attn.k_proj.weight``          [num_kv_heads*head_dim, hidden]
+              - ``model.layers.{i}.self_attn.k_proj.bias``            [num_kv_heads*head_dim]
+              - ``model.layers.{i}.self_attn.v_proj.weight``          [num_kv_heads*head_dim, hidden]
+              - ``model.layers.{i}.self_attn.v_proj.bias``            [num_kv_heads*head_dim]
+              - ``model.layers.{i}.self_attn.o_proj.weight``          [hidden, num_heads*head_dim]
+              - ``model.layers.{i}.mlp.gate_proj.weight``             [intermediate, hidden]
+              - ``model.layers.{i}.mlp.up_proj.weight``               [intermediate, hidden]
+              - ``model.layers.{i}.mlp.down_proj.weight``             [hidden, intermediate]
+            Required when ``cfg.apply_final_norm=True``:
+              - ``model.norm.weight``                                  [hidden]
+        out_path: Where to write the serialized TRT plan.
+        verbose: Enable TRT verbose logging.
+
+    Returns:
+        Resolved ``Path`` to the written plan file.
+    """
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    q_dim = cfg.num_heads * cfg.head_dim
+    kv_dim = cfg.num_kv_heads * cfg.head_dim
+    if q_dim != cfg.hidden_size:
+        raise ValueError(
+            f"num_heads * head_dim ({q_dim}) must equal hidden_size ({cfg.hidden_size})")
+    if cfg.num_heads % cfg.num_kv_heads != 0:
+        raise ValueError(
+            f"num_heads ({cfg.num_heads}) must be divisible by "
+            f"num_kv_heads ({cfg.num_kv_heads})")
+    graph_ops.validate_native_rope_dim(cfg.head_dim, field_name="head_dim")
+
+    embed, wd, final_norm = _prepare_weights(cfg, weights)
+
+    # ---- bf16 precision contract (mirrors standard_decoder_builder bf16). ----
+    # ``work_np_dtype`` is the storage dtype for constants; ``work_trt_dtype``
+    # is the compute dtype TRT runs at. The fp16 / bf16 split here matches
+    # standard_decoder_builder.py L176-177: weights are materialized as fp16,
+    # then ``_cast_back_to_trt_dtype`` inside the graph_ops helpers casts each
+    # constant to bf16 at point-of-use under STRONGLY_TYPED. The numerical
+    # difference vs. native-bf16 storage is well under the test gates (HF runs
+    # bf16 too).
+    work_np_dtype = np.float16
+    work_trt_dtype = trt.bfloat16
+
+    # ---- Build the TRT network. ----
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 8 << 30)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    max_S = cfg.max_seq_len
+
+    # ---- Engine inputs (stay fp32 -- C++ runtime / debug runner bind fp32). ----
+    input_ids = network.add_input("input_ids", trt.int32, (max_S,))
+    attn_mask_1d = network.add_input("attention_mask", trt.float32, (max_S,))
+
+    # ---- Shared constants. ----
+    # eps stored in work dtype so it doesn't constantly need upcasting.
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([cfg.rms_norm_eps], dtype=work_np_dtype),
+        dtype=work_np_dtype)
+
+    # Token embedding -> [max_S, hidden].
+    embed_table = graph_ops.add_constant(
+        network, (cfg.vocab_size, cfg.hidden_size), embed, dtype=work_np_dtype)
+    hidden = network.add_gather(embed_table, input_ids, 0).get_output(0)
+    if hidden.dtype != work_trt_dtype:
+        hidden = network.add_cast(hidden, work_trt_dtype).get_output(0)
+
+    # RoPE half-dim cos/sin tables (TRT native IRotaryEmbeddingLayer contract).
+    # 1D positions [0..max_S-1] -- text-only path; see module docstring.
+    cos_half_np = graph_ops.make_rope_table_half_dim(
+        max_S, cfg.head_dim, cfg.rope_theta, cosine=True)
+    sin_half_np = graph_ops.make_rope_table_half_dim(
+        max_S, cfg.head_dim, cfg.rope_theta, cosine=False)
+    cos_half = graph_ops.add_constant(
+        network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype)
+    cos_half = graph_blocks.cast_to_dtype(network, cos_half, work_trt_dtype)
+    sin_half = graph_ops.add_constant(
+        network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype)
+    sin_half = graph_blocks.cast_to_dtype(network, sin_half, work_trt_dtype)
+    rope_position_ids = graph_ops.add_constant(
+        network, (max_S,), np.arange(max_S, dtype=np.int32), dtype=np.int32)
+
+    # ---- Combined causal + padding additive mask -> [1, 1, max_S, max_S]. ----
+    # HF Qwen2.5-VL LM is causal (modeling_qwen2_5_vl.py: is_causal=True), so
+    # each query at position q can only attend to keys k<=q. We sum a constant
+    # lower-triangular -1e9 mask with the broadcast padding mask, then cast to
+    # the compute dtype for IAttention.
+    causal_np = np.triu(
+        np.full((max_S, max_S), -1.0e9, dtype=np.float32), k=1
+    ).reshape(1, 1, max_S, max_S)
+    causal_const = graph_ops.add_constant(
+        network, (1, 1, max_S, max_S), causal_np, dtype=np.float32)
+    pad_reshape = network.add_shuffle(attn_mask_1d)
+    pad_reshape.reshape_dims = (1, 1, 1, max_S)
+    attn_mask_fp32 = network.add_elementwise(
+        causal_const, pad_reshape.get_output(0), trt.ElementWiseOperation.SUM
+    ).get_output(0)
+    attn_mask_4d = network.add_cast(attn_mask_fp32, work_trt_dtype).get_output(0)
+
+    # ---- Decoder stack. ----
+    # Heavy ops route through graph_ops / graph_blocks. The bf16 precision
+    # boundary (fp32 RMSNorm variance, bf16 matmuls/attention/MLP) is enforced
+    # by the helpers themselves via ``dtype=work_np_dtype``.
+    for i in range(cfg.num_layers):
+        prefix = f"layer.{i}"
+        residual1 = hidden
+
+        # Pre-attention RMSNorm (fp32 variance, cast back to bf16).
+        normed = graph_ops.add_rms_norm(
+            network, hidden, cfg.hidden_size,
+            wd[f"{prefix}.input_norm"], eps_tensor, dtype=work_np_dtype)
+
+        # Q/K/V projections with bias.
+        q = graph_ops.add_matmul_rhs_constant(
+            network, normed, cfg.hidden_size, q_dim,
+            wd[f"{prefix}.w_q"], dtype=work_np_dtype)
+        q = graph_ops.add_bias_sum(
+            network, q, q_dim, wd[f"{prefix}.q_bias"], dtype=work_np_dtype)
+        k = graph_ops.add_matmul_rhs_constant(
+            network, normed, cfg.hidden_size, kv_dim,
+            wd[f"{prefix}.w_k"], dtype=work_np_dtype)
+        k = graph_ops.add_bias_sum(
+            network, k, kv_dim, wd[f"{prefix}.k_bias"], dtype=work_np_dtype)
+        v = graph_ops.add_matmul_rhs_constant(
+            network, normed, cfg.hidden_size, kv_dim,
+            wd[f"{prefix}.w_v"], dtype=work_np_dtype)
+        v = graph_ops.add_bias_sum(
+            network, v, kv_dim, wd[f"{prefix}.v_bias"], dtype=work_np_dtype)
+
+        # Rotate-half RoPE via TRT native IRotaryEmbeddingLayer.
+        q = graph_ops.add_apply_rope_native(
+            network, q, cfg.num_heads, cfg.head_dim,
+            cos_half, sin_half, rope_position_ids,
+            cfg.head_dim, sequence_length=max_S)
+        k = graph_ops.add_apply_rope_native(
+            network, k, cfg.num_kv_heads, cfg.head_dim,
+            cos_half, sin_half, rope_position_ids,
+            cfg.head_dim, sequence_length=max_S)
+
+        # GQA scaled dot-product attention. ``add_attention_from_rows`` builds
+        # the [1, H, S, D] reshape, applies 1/sqrt(D) Q-prescale, and runs
+        # native IAttention with our additive mask.
+        ctx = graph_ops.add_attention_from_rows(
+            network, q, k, v,
+            num_heads=cfg.num_heads, num_kv_heads=cfg.num_kv_heads,
+            head_dim=cfg.head_dim, q_seq=max_S, kv_seq=max_S,
+            mask=attn_mask_4d, tag=f"{prefix}.attn")
+
+        attn_out = graph_ops.add_matmul_rhs_constant(
+            network, ctx, q_dim, cfg.hidden_size,
+            wd[f"{prefix}.w_o"], dtype=work_np_dtype)
+
+        hidden = network.add_elementwise(
+            residual1, attn_out, trt.ElementWiseOperation.SUM).get_output(0)
+
+        # Post-attention RMSNorm + SwiGLU MLP + residual.
+        residual2 = hidden
+        normed2 = graph_ops.add_rms_norm(
+            network, hidden, cfg.hidden_size,
+            wd[f"{prefix}.post_attn_norm"], eps_tensor, dtype=work_np_dtype)
+        mlp_out = graph_blocks.add_swiglu_mlp(
+            network, normed2,
+            weights=wd, prefix=prefix,
+            hidden_size=cfg.hidden_size, mlp_size=cfg.intermediate_size,
+            dtype=work_np_dtype)
+        hidden = network.add_elementwise(
+            residual2, mlp_out, trt.ElementWiseOperation.SUM).get_output(0)
+
+    # ---- Optional final RMSNorm. ----
+    if cfg.apply_final_norm:
+        assert final_norm is not None
+        hidden = graph_ops.add_rms_norm(
+            network, hidden, cfg.hidden_size,
+            final_norm, eps_tensor, dtype=work_np_dtype)
+
+    # ---- Cast to fp32 and emit. C++ runtime binds fp32 buffers. ----
+    out_tensor = network.add_cast(hidden, trt.float32).get_output(0)
+    out_tensor.name = "last_hidden_state"
+    network.mark_output(out_tensor)
+
+    print(
+        f"[qwen25-vl-text-encoder] Building TRT engine (bf16 internal) "
+        f"(layers={cfg.num_layers}, hidden={cfg.hidden_size}, "
+        f"heads={cfg.num_heads}/{cfg.num_kv_heads}, head_dim={cfg.head_dim}, "
+        f"seq_len={max_S}, apply_final_norm={cfg.apply_final_norm}) ...",
+        file=sys.stderr,
+    )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("Qwen2.5-VL text encoder TRT engine build failed")
+
+    out_path.write_bytes(bytes(plan))
+    return out_path
+
+
+def load_qwen25vl_text_encoder_weights(
+    text_encoder_dir: "str | Path",
+    *,
+    max_seq_len: int = 1024,
+    apply_final_norm: bool = True,
+) -> tuple[Qwen25VLTextEncoderConfig, dict[str, np.ndarray]]:
+    """Load Qwen2.5-VL text encoder weights from a diffusers/HF ``text_encoder/`` dir.
+
+    Reads ``config.json`` (top-level fields or the nested ``text_config``
+    field, whichever is present) and all ``*.safetensors`` shards in the
+    directory. Filters the safetensors keys down to the LM stack only:
+    ``model.embed_tokens.*``, ``model.layers.{i}.*``, and ``model.norm.*``.
+    The vision tower (``visual.*``) and LM head (``lm_head.weight``) are
+    dropped -- Qwen-Image's T2I path only uses the post-final-RMSNorm
+    hidden states.
+
+    The returned ``Qwen25VLTextEncoderConfig`` is sized to the values from
+    the HF config (e.g. for ``Qwen/Qwen-Image-2512`` this is
+    ``hidden_size=3584``, ``num_layers=28``, ``num_heads=28``,
+    ``num_kv_heads=4``). ``max_seq_len`` and ``apply_final_norm`` are passed
+    through from the caller (defaulting to ``1024``/``True`` which match the
+    Qwen-Image pipeline conventions).
+
+    Note on RoPE: Qwen2.5-VL uses 3D mRoPE in HF, but for text-only input
+    (which is the only case for T2I) all three position axes are identical
+    (per the docstring on ``apply_multimodal_rotary_pos_emb`` in
+    ``modeling_qwen2_5_vl.py``: "The three rotary position index ...of text
+    embedding is always the same"). The mRoPE then collapses to standard
+    1D RoPE, matching what this builder emits.
+
+    Args:
+        text_encoder_dir: Path to a directory containing ``config.json`` and
+            one or more ``*.safetensors`` shards in the HF layout. This is
+            typically ``<repo>/text_encoder/`` under a diffusers snapshot.
+        max_seq_len: Maximum sequence length to bake into the TRT engine.
+            Defaults to 1024 (the Qwen-Image pipeline's effective max length
+            after dropping the 34-token prompt prefix).
+        apply_final_norm: Whether the engine should apply ``model.norm`` at
+            the end. Defaults to True; this matches the Qwen-Image pipeline
+            which reads ``hidden_states[-1]`` (post-final-RMSNorm).
+
+    Returns:
+        Tuple of (config, weights). The keys of ``weights`` match exactly
+        what ``build_qwen25vl_text_encoder_engine()`` expects.
+
+    Raises:
+        FileNotFoundError: If no ``*.safetensors`` files are found.
+        RuntimeError: If the safetensors contain no LM-stack keys (i.e. the
+            input directory is not a Qwen2.5-VL text encoder).
+    """
+    # Local imports keep the module importable when safetensors isn't installed
+    # (e.g. minimal CI environments that only run engine-side tests).
+    import json
+
+    from safetensors import safe_open
+
+    try:
+        # Required when safetensors emits a bf16 numpy view that needs
+        # ml_dtypes registered before .astype() can decode it. The
+        # Qwen-Image text encoder shards are bf16-stored, so without this
+        # the safe_open(..., framework="numpy") call below cannot return
+        # the tensors at all (numpy has no native bf16 dtype).
+        import ml_dtypes  # noqa: F401
+    except ImportError:  # pragma: no cover -- best-effort
+        pass
+
+    text_dir = Path(text_encoder_dir)
+    config_path = text_dir / "config.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"Missing config.json in {text_dir}")
+    config_json = json.loads(config_path.read_text())
+    # Qwen-Image's text_encoder/config.json wraps the LM-specific fields
+    # under a nested ``text_config``. If that's present use it; otherwise
+    # fall back to top-level (for hypothetical standalone Qwen2.5-VL dumps).
+    inner = config_json.get("text_config", config_json)
+
+    hidden_size = int(inner["hidden_size"])
+    num_heads = int(inner["num_attention_heads"])
+    if hidden_size % num_heads != 0:
+        raise ValueError(
+            f"hidden_size={hidden_size} not divisible by num_heads={num_heads}"
+        )
+
+    cfg = Qwen25VLTextEncoderConfig(
+        hidden_size=hidden_size,
+        num_layers=int(inner["num_hidden_layers"]),
+        num_heads=num_heads,
+        num_kv_heads=int(inner["num_key_value_heads"]),
+        head_dim=hidden_size // num_heads,
+        intermediate_size=int(inner["intermediate_size"]),
+        vocab_size=int(inner["vocab_size"]),
+        rope_theta=float(inner.get("rope_theta", 1_000_000.0)),
+        rms_norm_eps=float(inner.get("rms_norm_eps", 1e-6)),
+        max_seq_len=int(max_seq_len),
+        apply_final_norm=bool(apply_final_norm),
+    )
+
+    safetensor_files = sorted(text_dir.glob("*.safetensors"))
+    if not safetensor_files:
+        raise FileNotFoundError(f"No *.safetensors in {text_dir}")
+
+    wanted_prefixes = (
+        "model.embed_tokens.",
+        "model.layers.",
+        "model.norm.",
+    )
+
+    weights: dict[str, np.ndarray] = {}
+    for sf in safetensor_files:
+        with safe_open(str(sf), framework="numpy") as f:
+            for key in f.keys():
+                if not key.startswith(wanted_prefixes):
+                    continue  # Skip visual.* and lm_head.weight.
+                arr = f.get_tensor(key)
+                # Promote any low-precision dtype (bf16/fp16) to fp32. The
+                # builder accepts fp32 only via _as_numpy().
+                if arr.dtype != np.float32:
+                    arr = arr.astype(np.float32)
+                weights[key] = arr
+
+    if not weights:
+        raise RuntimeError(
+            f"No matching LM-stack weights found in {text_dir} "
+            "(expected keys starting with model.embed_tokens/layers/norm)"
+        )
+
+    return cfg, weights
+
+
+__all__ = [
+    "Qwen25VLTextEncoderConfig",
+    "build_qwen25vl_text_encoder_engine",
+    "load_qwen25vl_text_encoder_weights",
+]

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen_image_bundle_config.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen_image_bundle_config.py
@@ -1,0 +1,179 @@
+"""Build Qwen-Image .trtfb bundle config.json from a diffusers repo.
+
+Pure data transformation: takes a HuggingFace diffusers-format Qwen-Image
+repository directory (with ``model_index.json`` + per-component
+``config.json`` files + ``scheduler/scheduler_config.json``) and produces
+the JSON-serializable ``config`` blob that the C++ runtime parses at
+bundle load time.
+
+No GPU, no TRT, no HF download — purely file I/O on the local repo dir
+and dictionary construction. See design doc Section 4 for the schema.
+
+Trace IDs: UD-QWEN-IMAGE-CONFIG-001.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+_T2I_TEMPLATE_KIND = "qwen_image_t2i_hardcoded"
+_EDIT_TEMPLATE_KIND = "qwen_image_edit_hardcoded"
+
+_T2I_PIPELINE_CLASSES = {"QwenImagePipeline"}
+_EDIT_PIPELINE_CLASSES = {"QwenImageEditPipeline", "QwenImageEditPlusPipeline"}
+
+
+def _load_json(path: Path) -> Mapping[str, Any]:
+    return json.loads(path.read_text())
+
+
+def _detect_task_mode(repo: Path) -> str:
+    """Map ``model_index.json._class_name`` -> ``"t2i"`` or ``"edit"``."""
+    index = _load_json(repo / "model_index.json")
+    cls = index.get("_class_name", "")
+    if cls in _EDIT_PIPELINE_CLASSES:
+        return "edit"
+    if cls in _T2I_PIPELINE_CLASSES:
+        return "t2i"
+    # Default to T2I if the class is unknown but model_index exists.
+    return "t2i"
+
+
+def _variant_name(repo: Path) -> str:
+    """Repo dir name acts as variant id (e.g. ``"qwen-image-2512"``)."""
+    return repo.name
+
+
+def build_bundle_config(repo_dir: str | Path) -> dict[str, Any]:
+    """Convert a diffusers Qwen-Image repo into the bundle config dict.
+
+    The returned dict is JSON-serializable and is written into the
+    ``config`` section of every Qwen-Image ``.trtfb``.
+    """
+    repo = Path(repo_dir)
+    task_mode = _detect_task_mode(repo)
+
+    transformer_cfg = _load_json(repo / "transformer" / "config.json")
+    vae_cfg = _load_json(repo / "vae" / "config.json")
+    text_cfg = _load_json(repo / "text_encoder" / "config.json")
+    scheduler_cfg = _load_json(repo / "scheduler" / "scheduler_config.json")
+    text_inner = text_cfg.get("text_config", text_cfg)
+
+    template_kind = _EDIT_TEMPLATE_KIND if task_mode == "edit" else _T2I_TEMPLATE_KIND
+
+    bundle: dict[str, Any] = {
+        "engine_backend": "trt",
+        "runtime_strategy": "diffusion_qwen_image",
+        "model_family": "qwen_image",
+        "model_variant": _variant_name(repo),
+        "task_mode": task_mode,
+        # Engine internal compute dtype. Network IO stays fp32 so the C++
+        # runtime and Python debug runner keep fp32 host buffers; only the
+        # heavy matmuls / convs / attention run in bf16. Matches HF diffusers'
+        # `from_pretrained(torch_dtype=torch.bfloat16)` default.
+        "dtype": "bf16",
+        "diffusion": {
+            "scheduler": "flow_match_euler",
+            "num_train_timesteps": int(scheduler_cfg.get("num_train_timesteps", 1000)),
+            "shift": float(scheduler_cfg.get("shift", 1.0)),
+            "use_dynamic_shifting": bool(scheduler_cfg.get("use_dynamic_shifting", False)),
+            "base_image_seq_len": int(scheduler_cfg.get("base_image_seq_len", 256)),
+            "max_image_seq_len": int(scheduler_cfg.get("max_image_seq_len", 8192)),
+            "default_num_inference_steps": 50,
+            "default_cfg_scale": 4.0,
+            "default_negative_prompt": " ",
+        },
+        "text_encoder": {
+            "type": "qwen2_5_vl_lm",
+            "hidden_size": int(text_inner["hidden_size"]),
+            "num_layers": int(text_inner["num_hidden_layers"]),
+            "num_heads": int(text_inner["num_attention_heads"]),
+            "num_kv_heads": int(text_inner["num_key_value_heads"]),
+            "head_dim": int(text_inner["hidden_size"]) // int(text_inner["num_attention_heads"]),
+            "intermediate_size": int(text_inner["intermediate_size"]),
+            "vocab_size": int(text_inner["vocab_size"]),
+            "rope_theta": float(text_inner["rope_theta"]),
+            "rms_norm_eps": float(text_inner["rms_norm_eps"]),
+            # Effective prompt token cap from diffusers tokenizer_max_length.
+            "max_seq_len": 1024,
+            "extract_hidden_state_layer": -1,
+            # hidden_states[-1] IS post-final-RMSNorm in Qwen2.5-VL.
+            "apply_final_norm": True,
+            "tokenizer_template_kind": template_kind,
+        },
+        "denoiser": {
+            "type": "qwen_image_mmdit",
+            "in_channels": int(transformer_cfg.get("in_channels", 64)),
+            "out_channels": int(transformer_cfg.get("out_channels", 16)),
+            "patch_size": int(transformer_cfg.get("patch_size", 2)),
+            "hidden_size": (
+                int(transformer_cfg.get("num_attention_heads", 24))
+                * int(transformer_cfg.get("attention_head_dim", 128))
+            ),
+            "num_joint_blocks": int(transformer_cfg.get("num_layers", 60)),
+            "num_single_blocks": int(transformer_cfg.get("num_single_layers", 0)),
+            "num_attention_heads": int(transformer_cfg.get("num_attention_heads", 24)),
+            "attention_head_dim": int(transformer_cfg.get("attention_head_dim", 128)),
+            "rope_axes_dim": list(transformer_cfg.get("axes_dims_rope", [16, 56, 56])),
+            # Hardcoded in diffusers transformer_qwenimage.py (NOT in config.json).
+            "rope_theta": 10000.0,
+            "text_embed_dim": int(transformer_cfg.get("joint_attention_dim", 3584)),
+            "guidance_embeds": bool(transformer_cfg.get("guidance_embeds", False)),
+            "max_image_tokens": int(scheduler_cfg.get("max_image_seq_len", 8192)),
+            "max_text_tokens": 1024,
+        },
+        "vae": {
+            "type": "autoencoder_kl_qwen_image",
+            "latent_channels": int(vae_cfg.get("z_dim", vae_cfg.get("latent_channels", 16))),
+            "spatial_scale_factor": 8,
+            "base_dim": int(vae_cfg.get("base_dim", 96)),
+            "dim_mult": list(vae_cfg.get("dim_mult", [1, 2, 4, 4])),
+            # Note: HF's field name is misspelled "temperal_downsample". We
+            # preserve the corrected spelling in our schema key but read
+            # from the misspelled source field.
+            "temporal_downsample": list(
+                vae_cfg.get("temperal_downsample", [False, True, True])
+            ),
+            "latents_mean": list(vae_cfg["latents_mean"]),
+            "latents_std": list(vae_cfg["latents_std"]),
+            "has_encoder": task_mode == "edit",
+            "has_decoder": True,
+        },
+        "image": {
+            "default_height": 1024, "default_width": 1024,
+            "min_height": 256, "min_width": 256,
+            "max_height": 2048, "max_width": 2048,
+            "height_alignment": 16, "width_alignment": 16,
+        },
+        "tokenizer": {
+            "kind": "hf_python",
+            "class": "Qwen2Tokenizer",
+            "prompt_template_kind": template_kind,
+            "prompt_template_drop_idx": 34,
+            "tokenizer_max_length": 1024,
+            "add_special_tokens": False,
+        },
+    }
+
+    if task_mode == "edit":
+        vision_cfg = text_cfg.get("vision_config", {})
+        bundle["vision_encoder"] = {
+            "type": "qwen2_5_vl_vision",
+            "image_size": 384,
+            "patch_size": int(vision_cfg.get("patch_size", 14)),
+            "merge_size": int(vision_cfg.get("spatial_merge_size", 2)),
+            "hidden_size": int(vision_cfg.get("hidden_size", 1280)),
+            "num_layers": int(
+                vision_cfg.get("depth", vision_cfg.get("num_hidden_layers", 32))
+            ),
+            "out_hidden_size": int(text_inner["hidden_size"]),
+        }
+        bundle["image_conditioning"] = {
+            "vl_image_size": 384,
+            "vae_image_size": 1024,
+            "vae_concat_axis": "sequence",
+            "max_input_images": 1,
+        }
+
+    return bundle

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen_image_dit_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen_image_dit_builder.py
@@ -1,0 +1,2028 @@
+"""Qwen-Image MMDiT denoiser engine builder.
+
+Builds the Qwen-Image MMDiT denoiser engine (patchify, timestep embedding,
+RoPE, joint blocks, full stack, and HF weight loader).
+
+The Qwen-Image transformer is joint-stream MMDiT only (no FLUX-style single
+blocks for the image-only tail). 60 joint blocks, hidden_size=3072,
+24 heads, head_dim=128, rope_axes_dim=[16, 56, 56], rope_theta=10000.
+
+Patchify / unpatchify layout convention
+---------------------------------------
+
+Matches diffusers ``QwenImagePipeline._pack_latents``::
+
+    # diffusers/src/diffusers/pipelines/qwenimage/pipeline_qwenimage.py:334-339
+    latents = latents.view(B, C, H // 2, 2, W // 2, 2)
+    latents = latents.permute(0, 2, 4, 1, 3, 5)
+    latents = latents.reshape(B, (H // 2) * (W // 2), C * 4)
+
+i.e. einops ``b c (h p1) (w p2) -> b (h w) (c p1 p2)``. Within each output
+patch the C channels come first, then the ``p1 * p2`` intra-patch pixels.
+
+Trace IDs: ARCH-FAM-001, UD-FAM-QWEN-IMAGE-01.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Union
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+from ... import graph_ops
+
+trt = trt_compat.get_trt()
+
+PathLike = Union[str, Path]
+
+
+# ---------------------------------------------------------------------------
+# BF16 internal-compute helpers.
+#
+# Strategy: STRONGLY_TYPED network with bf16 weights/activations for the heavy
+# compute (matmul, attention, AdaLN, GELU FFN, RoPE complex muls). The
+# network's IO stays fp32 -- inputs are cast to bf16 at the boundary and
+# outputs are cast back to fp32 before mark_output, so the C++ runtime
+# (qwen_image_pipeline.cpp) and Python QwenImageDebugRunner can keep
+# binding fp32 host buffers without changes. Mirrors the pattern used by
+# flux2_dit_builder.py.
+#
+# RoPE cos/sin tables and the eps constants stay fp32 at construction time
+# and are cast to bf16 at point-of-use (the numerical sensitivity of the
+# tables is preserved that way; flux2 does the same).
+# ---------------------------------------------------------------------------
+
+_CAST_DTYPE = trt.bfloat16
+
+# Anchors for bf16 numpy arrays so Python GC doesn't free them before
+# builder.build_serialized_network() returns. Without this, TRT silently
+# reads garbage (or segfaults).
+_weight_refs: list[np.ndarray] = []
+
+
+def _np_reduced_dtype():
+    """numpy dtype matching ``_CAST_DTYPE`` (bf16 -> ml_dtypes.bfloat16)."""
+    import ml_dtypes
+    return ml_dtypes.bfloat16
+
+
+def _to_compute_dtype(network, tensor):
+    """Cast a tensor to the reduced compute dtype if not already."""
+    if tensor.dtype == _CAST_DTYPE:
+        return tensor
+    return network.add_cast(tensor, _CAST_DTYPE).get_output(0)
+
+
+def _to_fp32(network, tensor):
+    """Cast a tensor back to fp32 if not already."""
+    if tensor.dtype == trt.float32:
+        return tensor
+    return network.add_cast(tensor, trt.float32).get_output(0)
+
+
+def _make_reduced_weights(data_fp32: np.ndarray):
+    """Build (trt.Weights, anchored_ndarray) in the reduced compute dtype."""
+    import ml_dtypes
+    if (
+        isinstance(data_fp32, np.ndarray)
+        and data_fp32.dtype == ml_dtypes.bfloat16
+        and data_fp32.flags.c_contiguous
+    ):
+        bf16_arr = data_fp32
+    else:
+        bf16_arr = np.ascontiguousarray(np.asarray(data_fp32).astype(ml_dtypes.bfloat16))
+    w = trt.Weights(trt.bfloat16, bf16_arr.ctypes.data, bf16_arr.size)
+    return w, bf16_arr
+
+
+def _add_constant_reduced(network, shape, values_fp32) -> "trt.ITensor":
+    """Add a constant in the reduced compute dtype (anchors the bf16 array)."""
+    w, arr_ref = _make_reduced_weights(values_fp32)
+    _weight_refs.append(arr_ref)
+    return network.add_constant(shape, w).get_output(0)
+
+
+def _reset_weight_refs() -> None:
+    """Clear the bf16 array anchor list before a fresh engine build."""
+    global _weight_refs
+    _weight_refs = []
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _make_builder(verbose: bool):
+    """Create a TRT builder + STRONGLY_TYPED network with sane defaults.
+
+    Also resets the bf16 weight-anchor list so a fresh build doesn't keep
+    references to arrays from a prior build (would only matter for tests
+    that build many engines in one process, but it's cheap insurance).
+    """
+    _reset_weight_refs()
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    config = builder.create_builder_config()
+    # Shape ops are tiny; 256 MiB workspace is plenty.
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 256 << 20)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+    )
+    return builder, config, network
+
+
+def _serialize_and_write(builder, network, config, out_path: PathLike, label: str) -> Path:
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError(f"{label} TRT engine build failed")
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "wb") as f:
+        f.write(bytes(plan))
+    return out_path
+
+
+def _check_divisible(h_lat: int, w_lat: int, patch_size: int) -> None:
+    if h_lat % patch_size != 0 or w_lat % patch_size != 0:
+        raise ValueError(
+            f"latent dims ({h_lat}, {w_lat}) must be divisible by "
+            f"patch_size={patch_size}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Patchify
+# ---------------------------------------------------------------------------
+
+def build_patchify_engine(
+    out_path: PathLike,
+    *,
+    batch_size: int = 1,
+    channels: int,
+    patch_size: int,
+    h_lat: int,
+    w_lat: int,
+    verbose: bool = False,
+) -> Path:
+    """Build a TRT engine that performs the Qwen-Image patchify reshape.
+
+    Input  ``latent``   shape: ``[batch_size, channels, h_lat, w_lat]``  fp32
+    Output ``patched``  shape: ``[batch_size, (h_lat/p)*(w_lat/p), channels*p*p]``
+
+    where ``p = patch_size``.
+
+    The op composes two TRT shuffle layers (reshape + transpose, then a
+    final reshape), implementing the diffusers layout
+    ``b c (h p1) (w p2) -> b (h w) (c p1 p2)``.
+
+    The engine has fully static shapes -- the (B, C, H, W, p) constants are
+    baked in at build time. Callers wanting a different size must build a
+    fresh engine.
+    """
+    _check_divisible(h_lat, w_lat, patch_size)
+
+    p = patch_size
+    h_grid = h_lat // p
+    w_grid = w_lat // p
+    num_patches = h_grid * w_grid
+    patch_dim = channels * p * p
+
+    builder, config, network = _make_builder(verbose)
+
+    inp = network.add_input(
+        "latent", trt.float32, (batch_size, channels, h_lat, w_lat)
+    )
+
+    # Shuffle 1: reshape [B, C, H, W] -> [B, C, H/p, p, W/p, p]
+    # then permute to [B, H/p, W/p, C, p, p].
+    shuffle1 = network.add_shuffle(inp)
+    shuffle1.reshape_dims = (batch_size, channels, h_grid, p, w_grid, p)
+    shuffle1.second_transpose = trt.Permutation([0, 2, 4, 1, 3, 5])
+
+    # Shuffle 2: collapse spatial grid and intra-patch dims.
+    # [B, H/p, W/p, C, p, p] -> [B, (H/p)*(W/p), C*p*p]
+    shuffle2 = network.add_shuffle(shuffle1.get_output(0))
+    shuffle2.reshape_dims = (batch_size, num_patches, patch_dim)
+
+    out = shuffle2.get_output(0)
+    out.name = "patched"
+    network.mark_output(out)
+
+    print(
+        f"[qwen-image-dit] Building patchify engine "
+        f"(B={batch_size}, C={channels}, H={h_lat}, W={w_lat}, p={p}) "
+        f"-> [{batch_size}, {num_patches}, {patch_dim}]",
+        file=sys.stderr,
+    )
+    return _serialize_and_write(builder, network, config, out_path, "patchify")
+
+
+# ---------------------------------------------------------------------------
+# Unpatchify
+# ---------------------------------------------------------------------------
+
+def build_unpatchify_engine(
+    out_path: PathLike,
+    *,
+    batch_size: int = 1,
+    channels: int,
+    patch_size: int,
+    h_lat: int,
+    w_lat: int,
+    verbose: bool = False,
+) -> Path:
+    """Inverse of :func:`build_patchify_engine`.
+
+    Input  ``patched`` shape: ``[batch_size, (h_lat/p)*(w_lat/p), channels*p*p]``
+    Output ``latent``  shape: ``[batch_size, channels, h_lat, w_lat]``
+
+    Composes two TRT shuffle layers, implementing the diffusers layout
+    ``b (h w) (c p1 p2) -> b c (h p1) (w p2)``.
+    """
+    _check_divisible(h_lat, w_lat, patch_size)
+
+    p = patch_size
+    h_grid = h_lat // p
+    w_grid = w_lat // p
+    num_patches = h_grid * w_grid
+    patch_dim = channels * p * p
+
+    builder, config, network = _make_builder(verbose)
+
+    inp = network.add_input(
+        "patched", trt.float32, (batch_size, num_patches, patch_dim)
+    )
+
+    # Shuffle 1: reshape [B, N, D] -> [B, H/p, W/p, C, p, p]
+    # then permute to [B, C, H/p, p, W/p, p].
+    shuffle1 = network.add_shuffle(inp)
+    shuffle1.reshape_dims = (batch_size, h_grid, w_grid, channels, p, p)
+    shuffle1.second_transpose = trt.Permutation([0, 3, 1, 4, 2, 5])
+
+    # Shuffle 2: collapse to [B, C, H, W].
+    shuffle2 = network.add_shuffle(shuffle1.get_output(0))
+    shuffle2.reshape_dims = (batch_size, channels, h_lat, w_lat)
+
+    out = shuffle2.get_output(0)
+    out.name = "latent"
+    network.mark_output(out)
+
+    print(
+        f"[qwen-image-dit] Building unpatchify engine "
+        f"(B={batch_size}, N={num_patches}, D={patch_dim}, p={p}) "
+        f"-> [{batch_size}, {channels}, {h_lat}, {w_lat}]",
+        file=sys.stderr,
+    )
+    return _serialize_and_write(builder, network, config, out_path, "unpatchify")
+
+
+# ---------------------------------------------------------------------------
+# Timestep embedding (sinusoidal + 2-layer SiLU MLP)
+#
+# Matches diffusers ``QwenTimestepProjEmbeddings`` (transformer_qwenimage.py:174):
+#
+#     time_proj  = Timesteps(num_channels=256, flip_sin_to_cos=True,
+#                            downscale_freq_shift=0, scale=1000)
+#     timestep_embedder = TimestepEmbedding(in_channels=256,
+#                                           time_embed_dim=hidden_size,
+#                                           act_fn="silu")
+#
+# i.e. sinusoidal embedding (256 channels) -> Linear(256, hidden) -> SiLU
+# -> Linear(hidden, hidden).
+# ---------------------------------------------------------------------------
+
+def _as_numpy(arr) -> np.ndarray:
+    if hasattr(arr, "detach"):
+        arr = arr.detach().cpu().numpy()
+    return np.ascontiguousarray(np.asarray(arr, dtype=np.float32))
+
+
+def _add_get_timestep_embedding(
+    network,
+    timestep,
+    *,
+    embedding_dim: int,
+    flip_sin_to_cos: bool = True,
+    downscale_freq_shift: float = 0.0,
+    scale: float = 1000.0,
+    max_period: float = 10000.0,
+):
+    """In-network port of ``diffusers.models.embeddings.get_timestep_embedding``.
+
+    Input  ``timestep``: ITensor of shape ``[N]`` (fp32).
+    Output ITensor of shape ``[N, embedding_dim]`` (fp32).
+    """
+    assert embedding_dim % 2 == 0, "embedding_dim must be even"
+    half_dim = embedding_dim // 2
+
+    # exponent = -log(max_period) * arange(half_dim) / (half_dim - downscale_freq_shift)
+    # emb_base = exp(exponent)
+    base = -math.log(max_period) * np.arange(half_dim, dtype=np.float32)
+    base = base / (half_dim - downscale_freq_shift)
+    base = np.exp(base).reshape(1, half_dim) * float(scale)
+
+    base_const = network.add_constant((1, half_dim), trt.Weights(base)).get_output(0)
+
+    # ts: [N] -> [N, 1]
+    ts_reshape = network.add_shuffle(timestep)
+    ts_reshape.reshape_dims = (-1, 1)
+    ts_2d = ts_reshape.get_output(0)
+
+    # emb = ts * base                              [N, half_dim]
+    prod = network.add_elementwise(ts_2d, base_const, trt.ElementWiseOperation.PROD)
+    arg = prod.get_output(0)
+
+    sin_p = network.add_unary(arg, trt.UnaryOperation.SIN).get_output(0)
+    cos_p = network.add_unary(arg, trt.UnaryOperation.COS).get_output(0)
+
+    if flip_sin_to_cos:
+        # diffusers: emb = cat([sin, cos]); if flip_sin_to_cos: emb = cat([cos, sin])
+        order = [cos_p, sin_p]
+    else:
+        order = [sin_p, cos_p]
+    cat = network.add_concatenation(order)
+    cat.axis = 1
+    return cat.get_output(0)
+
+
+def _add_linear(network, x, weight_np: np.ndarray, bias_np: np.ndarray):
+    """Linear(in -> out): y = x @ W^T + b in reduced compute dtype.
+
+    weight_np shape: [out_dim, in_dim]; bias_np shape: [out_dim].
+    Input x shape:  [N, in_dim]; output: [N, out_dim].
+    Caller-supplied weights are fp32; this helper internally converts them
+    to bf16 (anchored against GC) and emits a bf16 matmul + bias-add. ``x``
+    is cast to bf16 at the boundary if needed; output stays in bf16.
+    """
+    out_dim, in_dim = weight_np.shape
+    x_c = _to_compute_dtype(network, x)
+    w_const = _add_constant_reduced(network, (out_dim, in_dim), np.ascontiguousarray(weight_np, dtype=np.float32))
+    # x [N, in_dim] @ W^T [in_dim, out_dim] = [N, out_dim]
+    matmul = network.add_matrix_multiply(
+        x_c, trt.MatrixOperation.NONE, w_const, trt.MatrixOperation.TRANSPOSE
+    )
+    y = matmul.get_output(0)
+    if bias_np is not None:
+        b_const = _add_constant_reduced(network, (1, out_dim), np.ascontiguousarray(bias_np, dtype=np.float32))
+        add = network.add_elementwise(y, b_const, trt.ElementWiseOperation.SUM)
+        y = add.get_output(0)
+    return y
+
+
+def build_timestep_embed_engine(
+    out_path: PathLike,
+    *,
+    weights: Mapping[str, "np.ndarray | object"],
+    in_dim: int = 256,
+    out_dim: int = 1024,
+    batch_size: int = 1,
+    flip_sin_to_cos: bool = True,
+    downscale_freq_shift: float = 0.0,
+    scale: float = 1000.0,
+    max_period: float = 10000.0,
+    verbose: bool = False,
+) -> Path:
+    """Build a TRT engine for the Qwen-Image timestep embedding.
+
+    Pipeline (matches diffusers ``QwenTimestepProjEmbeddings``):
+
+        timestep [N] --(sinusoidal)--> [N, in_dim]
+                     --linear_1--> [N, out_dim]
+                     --SiLU-->      [N, out_dim]
+                     --linear_2--> [N, out_dim]
+
+    Args:
+        out_path: where to write the serialised TRT plan.
+        weights: dict with keys
+            ``"linear_1.weight"`` [out_dim, in_dim],
+            ``"linear_1.bias"``   [out_dim],
+            ``"linear_2.weight"`` [out_dim, out_dim],
+            ``"linear_2.bias"``   [out_dim].
+        in_dim:  sinusoidal embedding width (Qwen-Image: 256).
+        out_dim: MLP hidden / output width (Qwen-Image: hidden_size = 3072).
+        batch_size: number of timesteps fed at once. Bound to a static
+            shape -- callers wanting a different batch must rebuild.
+        flip_sin_to_cos, downscale_freq_shift, scale, max_period: forwarded
+            to the sinusoidal embedding. Defaults match QwenImage.
+
+    Returns:
+        Path to the written plan.
+    """
+    required = ("linear_1.weight", "linear_1.bias", "linear_2.weight", "linear_2.bias")
+    for key in required:
+        if key not in weights:
+            raise KeyError(f"build_timestep_embed_engine: missing weight {key!r}")
+
+    w1 = _as_numpy(weights["linear_1.weight"])
+    b1 = _as_numpy(weights["linear_1.bias"])
+    w2 = _as_numpy(weights["linear_2.weight"])
+    b2 = _as_numpy(weights["linear_2.bias"])
+
+    if w1.shape != (out_dim, in_dim):
+        raise ValueError(f"linear_1.weight shape {w1.shape} != ({out_dim}, {in_dim})")
+    if b1.shape != (out_dim,):
+        raise ValueError(f"linear_1.bias shape {b1.shape} != ({out_dim},)")
+    if w2.shape != (out_dim, out_dim):
+        raise ValueError(f"linear_2.weight shape {w2.shape} != ({out_dim}, {out_dim})")
+    if b2.shape != (out_dim,):
+        raise ValueError(f"linear_2.bias shape {b2.shape} != ({out_dim},)")
+
+    builder, config, network = _make_builder(verbose)
+
+    timestep = network.add_input("timestep", trt.float32, (batch_size,))
+
+    sample = _add_get_timestep_embedding(
+        network,
+        timestep,
+        embedding_dim=in_dim,
+        flip_sin_to_cos=flip_sin_to_cos,
+        downscale_freq_shift=downscale_freq_shift,
+        scale=scale,
+        max_period=max_period,
+    )
+    h = _add_linear(network, sample, w1, b1)
+    h = graph_ops.add_silu(network, h)
+    h = _add_linear(network, h, w2, b2)
+    # Engine output is fp32 by contract (matches the C++ runtime + Python
+    # debug runner's fp32 host buffer bindings); internal compute stays bf16.
+    h = _to_fp32(network, h)
+    h.name = "timestep_emb"
+    network.mark_output(h)
+
+    print(
+        f"[qwen-image-dit] Building timestep embed engine "
+        f"(N={batch_size}, in_dim={in_dim}, out_dim={out_dim}) "
+        f"-> [{batch_size}, {out_dim}]",
+        file=sys.stderr,
+    )
+    return _serialize_and_write(builder, network, config, out_path, "timestep_embed")
+
+
+# ---------------------------------------------------------------------------
+# 3-axis RoPE (frame, height, width) for the Qwen-Image MMDiT denoiser.
+#
+# Matches diffusers ``QwenEmbedRope(theta=10000, axes_dim=[16, 56, 56],
+# scale_rope=True)`` (transformer_qwenimage.py:199-321):
+#
+#   * For each axis k the complex freqs at position i are
+#         freqs[i, j] = exp(i * theta**(-2j/axes_dim[k]))    j in [0, axes_dim[k]/2)
+#     (rope_params: torch.polar(ones_like(angles), angles)).
+#   * Image (T=1) positions for token (h, w) are
+#         frame_idx = 0
+#         h_idx in {-(H - H//2), ..., -1, 0, 1, ..., H//2 - 1}  (scale_rope=True)
+#         w_idx analogous, length W.
+#     Concatenated along the last (head_dim/2) axis.
+#   * Text positions: pos_freqs rows in
+#         [max_vid_index, max_vid_index + n_text), where
+#         max_vid_index = max(H//2, W//2).
+#     Same row used for all three axes (the pos_freqs table is built once
+#     from the same pos_index across axes).
+#
+# Output layout: concatenated as [img_freqs | txt_freqs] along the seq axis,
+# giving a single (cos, sin) pair of shape [seq_len, head_dim] suitable for
+# the attention application
+#     out = x * cos + rotate_half(x) * sin
+# (the cos/sin tables are "expanded" from the complex form by interleaved
+# duplication along the last axis: cos[..., 2j] = cos[..., 2j+1] = real;
+# sin[..., 2j] = sin[..., 2j+1] = imag).
+# ---------------------------------------------------------------------------
+
+_ROPE_PRECOMPUTE_LEN = 4096  # diffusers uses arange(4096) for pos/neg indices
+
+
+def _rope_params_complex(index: np.ndarray, dim: int, theta: float) -> np.ndarray:
+    """Return complex freqs of shape ``[len(index), dim // 2]`` (cos + i sin)."""
+    assert dim % 2 == 0
+    inv_freq = 1.0 / np.power(
+        theta, np.arange(0, dim, 2, dtype=np.float64) / float(dim)
+    )
+    angles = np.outer(index.astype(np.float64), inv_freq)
+    return np.cos(angles) + 1j * np.sin(angles)
+
+
+def _precompute_qwen_rope_tables(
+    axes_dim: list[int],
+    h_lat: int,
+    w_lat: int,
+    n_text: int,
+    theta: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Pre-compute the [seq_len, head_dim] cos/sin tables in NumPy.
+
+    Mirrors :class:`diffusers.models.transformers.transformer_qwenimage.QwenEmbedRope`
+    with ``scale_rope=True``, ``frame=1``, ``max_txt_seq_len=n_text``.
+    """
+    head_dim = sum(axes_dim)
+    splits = [a // 2 for a in axes_dim]
+
+    pos_index = np.arange(_ROPE_PRECOMPUTE_LEN)
+    neg_index = pos_index[::-1] * -1 - 1  # [-1, -2, ..., -_ROPE_PRECOMPUTE_LEN]
+
+    pos_axis_freqs = [
+        _rope_params_complex(pos_index, axes_dim[k], theta) for k in range(3)
+    ]
+    neg_axis_freqs = [
+        _rope_params_complex(neg_index, axes_dim[k], theta) for k in range(3)
+    ]
+
+    frame = 1
+    H, W = h_lat, w_lat
+
+    # Frame axis (pos rows [0:1], shared across all (h, w)).
+    freqs_frame = np.broadcast_to(
+        pos_axis_freqs[0][0:frame].reshape(frame, 1, 1, splits[0]),
+        (frame, H, W, splits[0]),
+    )
+
+    # Height: scale_rope=True split [-(H - H//2):] from neg, then [:H//2] from pos.
+    h_neg = neg_axis_freqs[1][-(H - H // 2):]
+    h_pos = pos_axis_freqs[1][: H // 2]
+    h_combined = np.concatenate([h_neg, h_pos], axis=0)  # [H, splits[1]]
+    freqs_height = np.broadcast_to(
+        h_combined.reshape(1, H, 1, splits[1]), (frame, H, W, splits[1])
+    )
+
+    w_neg = neg_axis_freqs[2][-(W - W // 2):]
+    w_pos = pos_axis_freqs[2][: W // 2]
+    w_combined = np.concatenate([w_neg, w_pos], axis=0)
+    freqs_width = np.broadcast_to(
+        w_combined.reshape(1, 1, W, splits[2]), (frame, H, W, splits[2])
+    )
+
+    vid_freqs = np.concatenate(
+        [freqs_frame, freqs_height, freqs_width], axis=-1
+    ).reshape(frame * H * W, head_dim // 2)
+
+    # Text freqs: rows [max_vid_index, max_vid_index + n_text) from the
+    # concatenated pos_freqs across all axes.
+    max_vid_index = max(H // 2, W // 2)
+    pos_freqs_all = np.concatenate(pos_axis_freqs, axis=1)  # [4096, head_dim/2]
+    txt_freqs = pos_freqs_all[max_vid_index : max_vid_index + n_text]
+
+    combined = np.concatenate([vid_freqs, txt_freqs], axis=0)  # [seq, head_dim/2]
+
+    # Expand to [seq, head_dim] via interleaved duplication: each complex
+    # entry contributes (cos, sin) repeated twice -- one for each of the
+    # two real elements in a rotation pair.
+    real = np.repeat(combined.real, 2, axis=-1).astype(np.float32)
+    imag = np.repeat(combined.imag, 2, axis=-1).astype(np.float32)
+    return np.ascontiguousarray(real), np.ascontiguousarray(imag)
+
+
+def build_rope_3axis_engine(
+    out_path: PathLike,
+    *,
+    axes_dim: list[int],
+    h_lat: int,
+    w_lat: int,
+    n_text: int,
+    theta: float = 10000.0,
+    verbose: bool = False,
+) -> Path:
+    """Build a TRT engine that returns the Qwen-Image (cos, sin) RoPE tables.
+
+    The tables are fully baked into the engine as constants -- no runtime
+    inputs. Callers that need a different (h_lat, w_lat, n_text) build a
+    fresh engine.
+
+    Args:
+        out_path: where to write the serialised TRT plan.
+        axes_dim: per-axis head-dim budget [frame, height, width]. Must sum
+            to ``head_dim``. For Qwen-Image: ``[16, 56, 56]`` (head_dim=128).
+        h_lat, w_lat: packed-token grid size after patchify (each token
+            covers a 2x2 latent patch).
+        n_text: number of text tokens in the joint sequence.
+        theta: RoPE base frequency. Qwen-Image uses 10000.0 (hardcoded in
+            ``transformer_qwenimage.py:802``).
+
+    Returns:
+        Path to the written plan. The engine has two outputs
+        ``rope_cos`` and ``rope_sin``, both of shape
+        ``[n_text + h_lat * w_lat, sum(axes_dim)]``, fp32.
+    """
+    if len(axes_dim) != 3:
+        raise ValueError(f"axes_dim must have 3 entries, got {axes_dim!r}")
+    if any(a % 2 != 0 for a in axes_dim):
+        raise ValueError(f"each axis dim must be even, got {axes_dim!r}")
+    if h_lat <= 0 or w_lat <= 0 or n_text < 0:
+        raise ValueError(
+            f"h_lat={h_lat}, w_lat={w_lat}, n_text={n_text} must be positive"
+        )
+    max_vid_index = max(h_lat // 2, w_lat // 2)
+    if max_vid_index + n_text > _ROPE_PRECOMPUTE_LEN:
+        raise ValueError(
+            "n_text + max(h_lat // 2, w_lat // 2) exceeds the 4096-row "
+            "pre-compute budget; increase _ROPE_PRECOMPUTE_LEN"
+        )
+
+    cos_table, sin_table = _precompute_qwen_rope_tables(
+        axes_dim, h_lat, w_lat, n_text, theta
+    )
+
+    builder, config, network = _make_builder(verbose)
+
+    seq_len, head_dim = cos_table.shape
+    cos_const = network.add_constant(
+        (seq_len, head_dim), trt.Weights(cos_table)
+    ).get_output(0)
+    sin_const = network.add_constant(
+        (seq_len, head_dim), trt.Weights(sin_table)
+    ).get_output(0)
+
+    # Pass-through identity shuffles so we can give the outputs stable names
+    # (TRT requires marked outputs to be the output of some layer; you cannot
+    # mark a constant directly).
+    cos_sh = network.add_shuffle(cos_const)
+    cos_sh.reshape_dims = (seq_len, head_dim)
+    cos_out = cos_sh.get_output(0)
+    cos_out.name = "rope_cos"
+
+    sin_sh = network.add_shuffle(sin_const)
+    sin_sh.reshape_dims = (seq_len, head_dim)
+    sin_out = sin_sh.get_output(0)
+    sin_out.name = "rope_sin"
+
+    network.mark_output(cos_out)
+    network.mark_output(sin_out)
+
+    print(
+        f"[qwen-image-dit] Building 3-axis RoPE engine "
+        f"(axes_dim={axes_dim}, h_lat={h_lat}, w_lat={w_lat}, "
+        f"n_text={n_text}, theta={theta}) "
+        f"-> ({seq_len}, {head_dim}) x 2",
+        file=sys.stderr,
+    )
+    return _serialize_and_write(builder, network, config, out_path, "rope_3axis")
+
+
+# ---------------------------------------------------------------------------
+# MMDiT joint-stream block.
+#
+# This implements one ``QwenImageTransformerBlock`` from diffusers
+# ``transformer_qwenimage.py``. The math (verified against
+# diffusers/src/diffusers/models/transformers/transformer_qwenimage.py
+# at lines 473-730):
+#
+#   img_mod_params = Linear(SiLU(temb))                        # [B, 6*dim]
+#   txt_mod_params = Linear(SiLU(temb))                        # [B, 6*dim]
+#   img_mod1, img_mod2 = img_mod_params.chunk(2, dim=-1)       # each [B, 3*dim]
+#   txt_mod1, txt_mod2 = txt_mod_params.chunk(2, dim=-1)
+#   (shift_msa, scale_msa, gate_msa) = mod1.chunk(3, dim=-1)
+#   (shift_mlp, scale_mlp, gate_mlp) = mod2.chunk(3, dim=-1)
+#
+#   img_normed = LayerNorm(img_tokens)  *  (1 + scale_msa_img) + shift_msa_img
+#   txt_normed = LayerNorm(txt_tokens)  *  (1 + scale_msa_txt) + shift_msa_txt
+#
+#   img_q = to_q(img_normed); img_k = to_k(img_normed); img_v = to_v(img_normed)
+#   txt_q = add_q_proj(txt_normed); txt_k = add_k_proj(txt_normed); txt_v = add_v_proj(txt_normed)
+#
+#   # qk_norm="rms_norm" → RMSNorm over head_dim, per-head, elementwise_affine
+#   img_q = norm_q(img_q.unflatten(-1, H, D));     img_k = norm_k(...)
+#   txt_q = norm_added_q(txt_q.unflatten(-1, H, D)); txt_k = norm_added_k(...)
+#
+#   # RoPE (apply_rotary_emb_qwen, use_real=False) — pair-based rotation
+#   #   x[..., 2j], x[..., 2j+1] = (x[..., 2j]*c - x[..., 2j+1]*s,
+#   #                                x[..., 2j]*s + x[..., 2j+1]*c)
+#   # where c, s come from `rope_cos`/`rope_sin` (interleaved-duplicated;
+#   # cos[..., 2j] = cos[..., 2j+1] = real_part).
+#   img_q/img_k <- RoPE(img_freqs)     txt_q/txt_k <- RoPE(txt_freqs)
+#
+#   # Joint attention with concat order [txt, img] along seq dim.
+#   joint_q = cat([txt_q, img_q], dim=seq)
+#   joint_k = cat([txt_k, img_k], dim=seq)
+#   joint_v = cat([txt_v, img_v], dim=seq)
+#   joint_out = SDPA(joint_q, joint_k, joint_v)
+#   txt_attn_out, img_attn_out = split(joint_out, [N_txt, N_img], dim=seq)
+#   img_attn_out = to_out.0(img_attn_out)
+#   txt_attn_out = to_add_out(txt_attn_out)
+#
+#   # Gated residual.
+#   hs_img  = img_tokens + gate_msa_img.unsqueeze(1) * img_attn_out
+#   hs_txt  = txt_tokens + gate_msa_txt.unsqueeze(1) * txt_attn_out
+#
+#   # MLP step: LayerNorm + modulate(mod2) + FF (GELU-approximate "tanh").
+#   img_n2   = LayerNorm(hs_img)   * (1 + scale_mlp_img) + shift_mlp_img
+#   img_mlp  = Linear(GELU_tanh(Linear(img_n2)))
+#   hs_img  += gate_mlp_img.unsqueeze(1) * img_mlp
+#   # ... same for text via ff_context/txt_mlp ...
+#
+#   return (txt_out, img_out)
+#
+# Norms in the block are plain ``nn.LayerNorm(dim, elementwise_affine=False)``
+# i.e. no learnable scale/bias on the norm itself. The modulation parameters
+# come from ``img_mod.1`` / ``txt_mod.1`` (nn.Linear → 6*dim).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class JointBlockConfig:
+    """Static configuration for one Qwen-Image MMDiT joint block.
+
+    Defaults match ``Qwen/Qwen-Image-2512`` (hidden_size=3072, 24 heads,
+    head_dim=128, MLP mult=4 → intermediate=12288).
+    """
+
+    hidden_size: int = 3072
+    num_attention_heads: int = 24
+    attention_head_dim: int = 128
+    intermediate_size: int = 12288  # FeedForward(dim, mult=4) → 4 * 3072.
+    rms_norm_eps: float = 1e-6
+    layer_norm_eps: float = 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Internal TRT helpers (joint block only).
+#
+# TODO: consider promoting _add_modulate, _add_gate_residual, and
+# _add_layernorm_no_affine_3d to graph_blocks now that the shape contract
+# has been confirmed to hold for full-stack composition. Defer until
+# end-to-end image generation works (avoid disrupting the working pipeline
+# mid-build-out).
+# ---------------------------------------------------------------------------
+
+def _add_2d_constant(network, arr: np.ndarray) -> "trt.ITensor":
+    """Add a small fp32 constant (e.g. eps, ones/zeros for LayerNorm, RoPE).
+
+    Kept fp32 by design -- numerically sensitive values that we don't want
+    to quantize at construction time. Callers cast to the compute dtype at
+    point-of-use when needed.
+    """
+    arr = np.ascontiguousarray(arr, dtype=np.float32)
+    return network.add_constant(arr.shape, trt.Weights(arr)).get_output(0)
+
+
+def _add_linear_2d(network, x, in_dim: int, out_dim: int, w_hf: np.ndarray,
+                   b_hf: "np.ndarray | None"):
+    """Linear projection for [N, in_dim] input. ``w_hf`` is HF-order [out, in].
+
+    Returns [N, out_dim]. Internally transposes weight to [in, out] and emits
+    a bf16 matmul + optional bias-add. ``x`` is cast to bf16 at the boundary.
+    Weights are converted fp32 -> bf16 once at build time and anchored.
+    """
+    x_c = _to_compute_dtype(network, x)
+    w_t = np.ascontiguousarray(w_hf.T, dtype=np.float32)  # [in, out]
+    w_const = _add_constant_reduced(network, (in_dim, out_dim), w_t)
+    mm = network.add_matrix_multiply(
+        x_c, trt.MatrixOperation.NONE, w_const, trt.MatrixOperation.NONE,
+    )
+    y = mm.get_output(0)
+    if b_hf is not None:
+        b_const = _add_constant_reduced(network, (1, out_dim), np.asarray(b_hf, dtype=np.float32))
+        y = network.add_elementwise(y, b_const, trt.ElementWiseOperation.SUM).get_output(0)
+    return y
+
+
+def _add_layernorm_no_affine_3d(network, x, hidden_size: int, eps: float):
+    """LayerNorm over last dim for [B, S, D] tensors, no learnable params.
+
+    Input is cast to the bf16 compute dtype on the way in (so the layer's
+    in/out tensors match the surrounding bf16 graph under STRONGLY_TYPED);
+    the reduction itself runs in fp32 (``compute_precision=trt.float32``)
+    so the LayerNorm mean/var don't lose precision -- matches what
+    ``graph_ops.add_layer_norm_native`` does for flux2.
+    """
+    x_c = _to_compute_dtype(network, x)
+    ones = _add_constant_reduced(
+        network, (1, 1, hidden_size),
+        np.ones((1, 1, hidden_size), dtype=np.float32),
+    )
+    zeros = _add_constant_reduced(
+        network, (1, 1, hidden_size),
+        np.zeros((1, 1, hidden_size), dtype=np.float32),
+    )
+    norm = network.add_normalization(x_c, ones, zeros, axesMask=1 << 2)
+    norm.epsilon = float(eps)
+    norm.compute_precision = trt.float32
+    return norm.get_output(0)
+
+
+def _add_modulate(network, x_3d, shift_2d, scale_2d, hidden_size: int):
+    """x_3d * (1 + scale_2d[:, None, :]) + shift_2d[:, None, :], in bf16.
+
+    x_3d:    [B, S, D]  (already bf16; otherwise cast at boundary)
+    shift_2d, scale_2d: [B, D]  (bf16 from the modulation Linear)
+    """
+    # Reshape to [B, 1, D] for broadcasting over S.
+    shift_3d = network.add_shuffle(shift_2d)
+    shift_3d.reshape_dims = (-1, 1, hidden_size)
+    scale_3d = network.add_shuffle(scale_2d)
+    scale_3d.reshape_dims = (-1, 1, hidden_size)
+
+    one_const = _add_constant_reduced(
+        network, (1, 1, 1), np.ones((1, 1, 1), dtype=np.float32),
+    )
+    one_plus_scale = network.add_elementwise(
+        scale_3d.get_output(0), one_const, trt.ElementWiseOperation.SUM
+    ).get_output(0)
+
+    x_c = _to_compute_dtype(network, x_3d)
+    scaled = network.add_elementwise(
+        x_c, one_plus_scale, trt.ElementWiseOperation.PROD
+    ).get_output(0)
+    shifted = network.add_elementwise(
+        scaled, shift_3d.get_output(0), trt.ElementWiseOperation.SUM
+    ).get_output(0)
+    return shifted
+
+
+def _add_gate_residual(network, residual_3d, gate_2d, branch_3d, hidden_size: int):
+    """residual + gate.unsqueeze(1) * branch, in bf16.
+
+    All inputs may originate from mixed dtypes; cast each operand to the
+    compute dtype so the elementwise adds remain valid in a STRONGLY_TYPED
+    network.
+    """
+    gate_3d = network.add_shuffle(gate_2d)
+    gate_3d.reshape_dims = (-1, 1, hidden_size)
+    branch_c = _to_compute_dtype(network, branch_3d)
+    residual_c = _to_compute_dtype(network, residual_3d)
+    gated = network.add_elementwise(
+        gate_3d.get_output(0), branch_c, trt.ElementWiseOperation.PROD
+    ).get_output(0)
+    out = network.add_elementwise(
+        residual_c, gated, trt.ElementWiseOperation.SUM
+    ).get_output(0)
+    return out
+
+
+def _add_rms_norm_per_head(network, x_3d, num_heads: int, head_dim: int,
+                           gamma: np.ndarray, eps: float, seq_len: int):
+    """RMSNorm over head_dim for [B, S, H*D] (B is fixed in static engine).
+
+    Reuses graph_ops.add_rms_norm_per_head, which auto-casts to fp32 for
+    numerical stability when its ``dtype`` parameter is non-fp32 and casts
+    back to the input dtype afterwards. The bf16 storage path is selected
+    here so the in/out tensor dtype stays bf16 while the reduction runs in
+    fp32 -- matches the QK-norm precision pattern of flux2/Qwen-VL.
+    """
+    # [B, S, H*D] -> [S, H*D] (B=1).
+    sq = network.add_shuffle(x_3d)
+    sq.reshape_dims = (seq_len, num_heads * head_dim)
+    eps_t = _add_2d_constant(network, np.array([eps], dtype=np.float32))
+    eps_scalar = network.add_shuffle(eps_t)
+    eps_scalar.reshape_dims = ()
+    out_2d = graph_ops.add_rms_norm_per_head(
+        network, sq.get_output(0), num_heads, head_dim, gamma,
+        eps_scalar.get_output(0), sequence_length=seq_len,
+        dtype=np.float16,  # signal "non-fp32 in/out, fp32 compute internally"
+    )
+    # [S, H*D] -> [B=1, S, H*D].
+    out_3d = network.add_shuffle(out_2d)
+    out_3d.reshape_dims = (1, seq_len, num_heads * head_dim)
+    return out_3d.get_output(0)
+
+
+def _add_rope_pair(network, x_3d, cos_2d, sin_2d, num_heads: int,
+                   head_dim: int, seq_len: int):
+    """Apply Qwen pair-based RoPE.
+
+    x_3d:    [B=1, S, H*D]
+    cos_2d:  [S, D]  (interleaved duplicated: cos[..., 2j] = cos[..., 2j+1])
+    sin_2d:  [S, D]  (similar)
+
+    Pair-based rotation:
+        x'[..., 2j]   = x[..., 2j]   * cos[..., 2j]   - x[..., 2j+1] * sin[..., 2j]
+        x'[..., 2j+1] = x[..., 2j+1] * cos[..., 2j+1] + x[..., 2j]   * sin[..., 2j+1]
+
+    Returns [B=1, S, H*D].
+    """
+    # [B=1, S, H*D] -> [S, H*D] -> [S, H, D] -> [S, H, D/2, 2]
+    rb = network.add_shuffle(x_3d)
+    rb.reshape_dims = (seq_len, num_heads, head_dim // 2, 2)
+    x_pairs = rb.get_output(0)
+
+    # x_real = x[..., 0], x_imag = x[..., 1]  (along last axis).
+    x_real_sl = network.add_slice(
+        x_pairs, start=(0, 0, 0, 0),
+        shape=(seq_len, num_heads, head_dim // 2, 1), stride=(1, 1, 1, 1),
+    )
+    x_imag_sl = network.add_slice(
+        x_pairs, start=(0, 0, 0, 1),
+        shape=(seq_len, num_heads, head_dim // 2, 1), stride=(1, 1, 1, 1),
+    )
+    x_real = network.add_shuffle(x_real_sl.get_output(0))
+    x_real.reshape_dims = (seq_len, num_heads, head_dim // 2)
+    x_imag = network.add_shuffle(x_imag_sl.get_output(0))
+    x_imag.reshape_dims = (seq_len, num_heads, head_dim // 2)
+
+    # cos_pair / sin_pair: take every-other element from cos/sin (they are
+    # interleaved-duplicated, so cos_pair[..., j] = cos[..., 2j]).
+    # RoPE tables are stored as fp32 for numerical sensitivity; cast to the
+    # bf16 compute dtype at point-of-use so the complex muls below stay in
+    # bf16 (matches flux2_dit_builder.py).
+    cos_pair_sl = network.add_slice(
+        cos_2d, start=(0, 0), shape=(seq_len, head_dim // 2), stride=(1, 2),
+    )
+    sin_pair_sl = network.add_slice(
+        sin_2d, start=(0, 0), shape=(seq_len, head_dim // 2), stride=(1, 2),
+    )
+    cos_pair_c = _to_compute_dtype(network, cos_pair_sl.get_output(0))
+    sin_pair_c = _to_compute_dtype(network, sin_pair_sl.get_output(0))
+    # Reshape cos/sin to [S, 1, D/2] for broadcast across heads.
+    cos_3d = network.add_shuffle(cos_pair_c)
+    cos_3d.reshape_dims = (seq_len, 1, head_dim // 2)
+    sin_3d = network.add_shuffle(sin_pair_c)
+    sin_3d.reshape_dims = (seq_len, 1, head_dim // 2)
+
+    # new_real = x_real * cos - x_imag * sin
+    r_cos = network.add_elementwise(
+        x_real.get_output(0), cos_3d.get_output(0), trt.ElementWiseOperation.PROD,
+    ).get_output(0)
+    i_sin = network.add_elementwise(
+        x_imag.get_output(0), sin_3d.get_output(0), trt.ElementWiseOperation.PROD,
+    ).get_output(0)
+    new_real = network.add_elementwise(
+        r_cos, i_sin, trt.ElementWiseOperation.SUB,
+    ).get_output(0)
+
+    # new_imag = x_real * sin + x_imag * cos
+    r_sin = network.add_elementwise(
+        x_real.get_output(0), sin_3d.get_output(0), trt.ElementWiseOperation.PROD,
+    ).get_output(0)
+    i_cos = network.add_elementwise(
+        x_imag.get_output(0), cos_3d.get_output(0), trt.ElementWiseOperation.PROD,
+    ).get_output(0)
+    new_imag = network.add_elementwise(
+        r_sin, i_cos, trt.ElementWiseOperation.SUM,
+    ).get_output(0)
+
+    # Stack along the last dim: [S, H, D/2] + [S, H, D/2] -> [S, H, D/2, 2]
+    nr_4d = network.add_shuffle(new_real)
+    nr_4d.reshape_dims = (seq_len, num_heads, head_dim // 2, 1)
+    ni_4d = network.add_shuffle(new_imag)
+    ni_4d.reshape_dims = (seq_len, num_heads, head_dim // 2, 1)
+    cat = network.add_concatenation([nr_4d.get_output(0), ni_4d.get_output(0)])
+    cat.axis = 3
+
+    # [S, H, D/2, 2] -> [B=1, S, H*D]
+    flat = network.add_shuffle(cat.get_output(0))
+    flat.reshape_dims = (1, seq_len, num_heads * head_dim)
+    return flat.get_output(0)
+
+
+def _add_joint_attention(
+    network, q_img_3d, k_img_3d, v_img_3d,
+    q_txt_3d, k_txt_3d, v_txt_3d,
+    num_heads: int, head_dim: int, n_img: int, n_txt: int,
+):
+    """Joint attention with concat order [txt, img].
+
+    Inputs are [B=1, S, H*D] for each stream. Returns
+    (attn_txt [B=1, N_txt, H*D], attn_img [B=1, N_img, H*D]).
+    """
+    seq_total = n_txt + n_img
+    # Concat along the sequence axis: [B=1, N_txt + N_img, H*D].
+    q = network.add_concatenation([q_txt_3d, q_img_3d])
+    q.axis = 1
+    k = network.add_concatenation([k_txt_3d, k_img_3d])
+    k.axis = 1
+    v = network.add_concatenation([v_txt_3d, v_img_3d])
+    v.axis = 1
+
+    # Reshape [B=1, S, H*D] -> [B=1, S, H, D] -> [B=1, H, S, D].
+    def to_4d(x_3d):
+        r1 = network.add_shuffle(x_3d)
+        r1.reshape_dims = (1, seq_total, num_heads, head_dim)
+        r1.second_transpose = trt.Permutation([0, 2, 1, 3])
+        return r1.get_output(0)
+
+    q_4d = to_4d(q.get_output(0))
+    k_4d = to_4d(k.get_output(0))
+    v_4d = to_4d(v.get_output(0))
+
+    ctx_4d = graph_ops.add_attention_core(
+        network, q_4d, k_4d, v_4d, causal=False, mask=None,
+        scale=float(1.0 / math.sqrt(head_dim)),
+    )
+
+    # [B=1, H, S, D] -> [B=1, S, H, D] -> [B=1, S, H*D]
+    out_shuffle = network.add_shuffle(ctx_4d)
+    out_shuffle.first_transpose = trt.Permutation([0, 2, 1, 3])
+    out_shuffle.reshape_dims = (1, seq_total, num_heads * head_dim)
+    out_3d = out_shuffle.get_output(0)
+
+    # Split back into [B, N_txt, H*D] and [B, N_img, H*D].
+    txt_sl = network.add_slice(
+        out_3d, start=(0, 0, 0),
+        shape=(1, n_txt, num_heads * head_dim), stride=(1, 1, 1),
+    )
+    img_sl = network.add_slice(
+        out_3d, start=(0, n_txt, 0),
+        shape=(1, n_img, num_heads * head_dim), stride=(1, 1, 1),
+    )
+    return txt_sl.get_output(0), img_sl.get_output(0)
+
+
+def _add_mlp_block(network, x_3d, hidden_size: int, intermediate_size: int,
+                   weights: Mapping[str, np.ndarray], prefix: str,
+                   seq_len: int):
+    """FeedForward block: Linear -> GELU(tanh) -> Linear.
+
+    Diffusers FeedForward (gelu-approximate, mult=4, bias=True):
+        net.0 = GELU(approximate="tanh"): Linear(dim, inner) followed by GELU
+                in forward — but ``self.net[0]`` is the ``GELU`` module so the
+                weight key is ``net.0.proj.weight``.
+        net.1 = Dropout (skipped at inference)
+        net.2 = Linear(inner, dim)
+    """
+    w1 = np.asarray(weights[f"{prefix}.net.0.proj.weight"], dtype=np.float32)  # [inner, hidden]
+    b1 = np.asarray(weights[f"{prefix}.net.0.proj.bias"], dtype=np.float32)
+    w2 = np.asarray(weights[f"{prefix}.net.2.weight"], dtype=np.float32)        # [hidden, inner]
+    b2 = np.asarray(weights[f"{prefix}.net.2.bias"], dtype=np.float32)
+
+    # Flatten to [S, D] for matmul, then back to [B=1, S, D'].
+    flat = network.add_shuffle(x_3d)
+    flat.reshape_dims = (seq_len, hidden_size)
+    h = _add_linear_2d(network, flat.get_output(0), hidden_size, intermediate_size, w1, b1)
+    h = graph_ops.add_gelu_tanh(network, h)
+    h = _add_linear_2d(network, h, intermediate_size, hidden_size, w2, b2)
+    unflat = network.add_shuffle(h)
+    unflat.reshape_dims = (1, seq_len, hidden_size)
+    return unflat.get_output(0)
+
+
+def _add_qkv_with_norm_and_rope(
+    network, x_3d, weights: Mapping[str, np.ndarray],
+    *, hidden_size: int, num_heads: int, head_dim: int, seq_len: int,
+    q_key: str, k_key: str, v_key: str,
+    norm_q_key: str | None, norm_k_key: str | None,
+    rms_eps: float,
+    cos_2d, sin_2d,
+):
+    """Compute QKV for one stream with q-norm/k-norm + RoPE.
+
+    Inputs are [B=1, S, D]. Returns (q_3d, k_3d, v_3d) each [B=1, S, H*D].
+    Q and K get q-norm/k-norm + RoPE applied. V is passed through.
+    """
+    flat = network.add_shuffle(x_3d)
+    flat.reshape_dims = (seq_len, hidden_size)
+    x_flat = flat.get_output(0)
+
+    def _proj(weight_key: str):
+        w_hf = np.asarray(weights[f"{weight_key}.weight"], dtype=np.float32)
+        b_hf = weights.get(f"{weight_key}.bias")
+        b = np.asarray(b_hf, dtype=np.float32) if b_hf is not None else None
+        return _add_linear_2d(network, x_flat, hidden_size, hidden_size, w_hf, b)
+
+    q = _proj(q_key)
+    k = _proj(k_key)
+    v = _proj(v_key)
+
+    # Reshape to [B=1, S, H*D] for downstream helpers.
+    def to_3d(t):
+        s = network.add_shuffle(t)
+        s.reshape_dims = (1, seq_len, num_heads * head_dim)
+        return s.get_output(0)
+
+    q_3d = to_3d(q)
+    k_3d = to_3d(k)
+    v_3d = to_3d(v)
+
+    # qk-norm: RMSNorm over head_dim with weight [head_dim].
+    if norm_q_key is not None and f"{norm_q_key}.weight" in weights:
+        gamma = np.asarray(weights[f"{norm_q_key}.weight"], dtype=np.float32)
+        q_3d = _add_rms_norm_per_head(
+            network, q_3d, num_heads, head_dim, gamma, rms_eps, seq_len,
+        )
+    if norm_k_key is not None and f"{norm_k_key}.weight" in weights:
+        gamma = np.asarray(weights[f"{norm_k_key}.weight"], dtype=np.float32)
+        k_3d = _add_rms_norm_per_head(
+            network, k_3d, num_heads, head_dim, gamma, rms_eps, seq_len,
+        )
+
+    # RoPE on Q and K (V untouched).
+    q_3d = _add_rope_pair(network, q_3d, cos_2d, sin_2d, num_heads, head_dim, seq_len)
+    k_3d = _add_rope_pair(network, k_3d, cos_2d, sin_2d, num_heads, head_dim, seq_len)
+    return q_3d, k_3d, v_3d
+
+
+# ---------------------------------------------------------------------------
+# Reusable joint-block graph helper.
+#
+# This is the inlined math for one ``QwenImageTransformerBlock``. Both
+# ``build_joint_block_engine`` (single-block engine, used by the HF parity
+# test) and ``build_qwen_image_dit_engine`` (full denoiser) call this.
+# Single source of truth keeps the per-block math from drifting between
+# the two builders.
+#
+# Inputs are pre-built ITensors (the caller is responsible for adding the
+# network inputs / constants); the helper returns ``(img_out_3d, txt_out_3d)``.
+# ---------------------------------------------------------------------------
+
+def _add_joint_block_graph(
+    network,
+    *,
+    img_3d,                # [B, n_img, hidden]
+    txt_3d,                # [B, n_text, hidden]
+    temb_2d,               # [B, hidden]
+    cos_img,               # [n_img, head_dim]
+    sin_img,               # [n_img, head_dim]
+    cos_txt,               # [n_text, head_dim]
+    sin_txt,               # [n_text, head_dim]
+    weights: Mapping[str, "np.ndarray"],
+    weights_prefix: str = "",
+    cfg: "JointBlockConfig",
+    n_img: int,
+    n_text: int,
+    batch_size: int = 1,
+):
+    """Build the math of one Qwen-Image MMDiT joint block.
+
+    ``weights_prefix`` is prepended to every state-dict key lookup, so the
+    full-denoiser builder can pass ``"transformer_blocks.0."`` and get the
+    same block-local keys (``img_mod.1.weight``, etc.).
+
+    Returns ``(img_out_3d, txt_out_3d)``, both [B, S_*, hidden].
+    """
+    if batch_size != 1:
+        raise NotImplementedError(
+            "_add_joint_block_graph currently supports batch_size=1 only"
+        )
+    H = cfg.num_attention_heads
+    D = cfg.attention_head_dim
+    dim = cfg.hidden_size
+
+    def _w(key: str) -> np.ndarray:
+        return np.asarray(weights[f"{weights_prefix}{key}"], dtype=np.float32)
+
+    def _w_opt(key: str):
+        v = weights.get(f"{weights_prefix}{key}")
+        return None if v is None else np.asarray(v, dtype=np.float32)
+
+    # Wrap weights so qkv-helper can use ``weights[key]`` directly with the
+    # prefix already baked in.
+    class _PrefixedWeights:
+        def __init__(self, base: Mapping[str, np.ndarray], prefix: str):
+            self._base = base
+            self._prefix = prefix
+
+        def __getitem__(self, key: str):
+            return self._base[f"{self._prefix}{key}"]
+
+        def get(self, key: str, default=None):
+            return self._base.get(f"{self._prefix}{key}", default)
+
+        def __contains__(self, key: str) -> bool:
+            return f"{self._prefix}{key}" in self._base
+
+    prefixed = _PrefixedWeights(weights, weights_prefix)
+
+    # ----- AdaLN modulation: SiLU(temb) -> Linear -> 6*dim, chunk 2 then 3.
+    img_mod_w = _w("img_mod.1.weight")
+    img_mod_b = _w("img_mod.1.bias")
+    txt_mod_w = _w("txt_mod.1.weight")
+    txt_mod_b = _w("txt_mod.1.bias")
+
+    temb_silu = graph_ops.add_silu(network, temb_2d)
+    img_mod_params = _add_linear_2d(
+        network, temb_silu, dim, 6 * dim, img_mod_w, img_mod_b,
+    )
+    txt_mod_params = _add_linear_2d(
+        network, temb_silu, dim, 6 * dim, txt_mod_w, txt_mod_b,
+    )
+
+    def _six_chunks(mod_params):
+        chunks = []
+        for i in range(6):
+            sl = network.add_slice(
+                mod_params, start=(0, i * dim),
+                shape=(batch_size, dim), stride=(1, 1),
+            )
+            chunks.append(sl.get_output(0))
+        return chunks
+
+    img_shift_msa, img_scale_msa, img_gate_msa, \
+        img_shift_mlp, img_scale_mlp, img_gate_mlp = _six_chunks(img_mod_params)
+    txt_shift_msa, txt_scale_msa, txt_gate_msa, \
+        txt_shift_mlp, txt_scale_mlp, txt_gate_mlp = _six_chunks(txt_mod_params)
+
+    # ----- norm1 + modulate per stream.
+    img_normed = _add_layernorm_no_affine_3d(network, img_3d, dim, cfg.layer_norm_eps)
+    img_modulated = _add_modulate(network, img_normed, img_shift_msa, img_scale_msa, dim)
+    txt_normed = _add_layernorm_no_affine_3d(network, txt_3d, dim, cfg.layer_norm_eps)
+    txt_modulated = _add_modulate(network, txt_normed, txt_shift_msa, txt_scale_msa, dim)
+
+    # ----- QKV + qk-norm + RoPE.
+    img_q, img_k, img_v = _add_qkv_with_norm_and_rope(
+        network, img_modulated, prefixed,
+        hidden_size=dim, num_heads=H, head_dim=D, seq_len=n_img,
+        q_key="attn.to_q", k_key="attn.to_k", v_key="attn.to_v",
+        norm_q_key="attn.norm_q", norm_k_key="attn.norm_k",
+        rms_eps=cfg.rms_norm_eps, cos_2d=cos_img, sin_2d=sin_img,
+    )
+    txt_q, txt_k, txt_v = _add_qkv_with_norm_and_rope(
+        network, txt_modulated, prefixed,
+        hidden_size=dim, num_heads=H, head_dim=D, seq_len=n_text,
+        q_key="attn.add_q_proj", k_key="attn.add_k_proj", v_key="attn.add_v_proj",
+        norm_q_key="attn.norm_added_q", norm_k_key="attn.norm_added_k",
+        rms_eps=cfg.rms_norm_eps, cos_2d=cos_txt, sin_2d=sin_txt,
+    )
+
+    # ----- joint attention; concat order [txt, img].
+    attn_txt_3d, attn_img_3d = _add_joint_attention(
+        network, img_q, img_k, img_v, txt_q, txt_k, txt_v,
+        num_heads=H, head_dim=D, n_img=n_img, n_txt=n_text,
+    )
+
+    # ----- output projections (separate for each stream).
+    def _out_proj(x_3d, key_suffix: str, seq_len: int):
+        w = _w(f"{key_suffix}.weight")
+        b = _w_opt(f"{key_suffix}.bias")
+        flat = network.add_shuffle(x_3d)
+        flat.reshape_dims = (seq_len, dim)
+        proj = _add_linear_2d(network, flat.get_output(0), dim, dim, w, b)
+        unflat = network.add_shuffle(proj)
+        unflat.reshape_dims = (1, seq_len, dim)
+        return unflat.get_output(0)
+
+    img_attn_out = _out_proj(attn_img_3d, "attn.to_out.0", n_img)
+    txt_attn_out = _out_proj(attn_txt_3d, "attn.to_add_out", n_text)
+
+    # ----- gated residual (post-attention).
+    hs_img = _add_gate_residual(network, img_3d, img_gate_msa, img_attn_out, dim)
+    hs_txt = _add_gate_residual(network, txt_3d, txt_gate_msa, txt_attn_out, dim)
+
+    # ----- norm2 + modulate(mod2) + MLP + gated residual.
+    img_n2 = _add_layernorm_no_affine_3d(network, hs_img, dim, cfg.layer_norm_eps)
+    img_mod2_out = _add_modulate(network, img_n2, img_shift_mlp, img_scale_mlp, dim)
+    img_mlp_out = _add_mlp_block(
+        network, img_mod2_out, dim, cfg.intermediate_size, prefixed, "img_mlp", n_img,
+    )
+    img_out = _add_gate_residual(network, hs_img, img_gate_mlp, img_mlp_out, dim)
+
+    txt_n2 = _add_layernorm_no_affine_3d(network, hs_txt, dim, cfg.layer_norm_eps)
+    txt_mod2_out = _add_modulate(network, txt_n2, txt_shift_mlp, txt_scale_mlp, dim)
+    txt_mlp_out = _add_mlp_block(
+        network, txt_mod2_out, dim, cfg.intermediate_size, prefixed, "txt_mlp", n_text,
+    )
+    txt_out = _add_gate_residual(network, hs_txt, txt_gate_mlp, txt_mlp_out, dim)
+    return img_out, txt_out
+
+
+# ---------------------------------------------------------------------------
+# Public builder + loader.
+# ---------------------------------------------------------------------------
+
+def build_joint_block_engine(
+    cfg: JointBlockConfig,
+    weights: Mapping[str, "np.ndarray"],
+    out_path: PathLike,
+    *,
+    batch_size: int = 1,
+    n_img: int,
+    n_text: int,
+    verbose: bool = False,
+) -> Path:
+    """Build a TRT engine that performs one Qwen-Image MMDiT joint block.
+
+    Engine inputs (fp32):
+      ``img_tokens``  [batch_size, n_img,  hidden_size]
+      ``txt_tokens``  [batch_size, n_text, hidden_size]
+      ``temb``        [batch_size, hidden_size]
+      ``rope_cos``    [n_img + n_text, head_dim]  (img tokens first, then txt)
+      ``rope_sin``    [n_img + n_text, head_dim]
+
+    Engine outputs (fp32):
+      ``img_out``  [batch_size, n_img,  hidden_size]
+      ``txt_out``  [batch_size, n_text, hidden_size]
+
+    Required keys in ``weights`` (block-local names, matching the diffusers
+    ``QwenImageTransformerBlock`` state-dict):
+
+      img_mod.1.weight       [6*hidden, hidden]      img_mod.1.bias [6*hidden]
+      txt_mod.1.weight       [6*hidden, hidden]      txt_mod.1.bias [6*hidden]
+      attn.to_q.weight       [hidden, hidden]        attn.to_q.bias [hidden]
+      attn.to_k.weight       [hidden, hidden]        attn.to_k.bias [hidden]
+      attn.to_v.weight       [hidden, hidden]        attn.to_v.bias [hidden]
+      attn.add_q_proj.weight [hidden, hidden]        attn.add_q_proj.bias
+      attn.add_k_proj.weight [hidden, hidden]        attn.add_k_proj.bias
+      attn.add_v_proj.weight [hidden, hidden]        attn.add_v_proj.bias
+      attn.to_out.0.weight   [hidden, hidden]        attn.to_out.0.bias
+      attn.to_add_out.weight [hidden, hidden]        attn.to_add_out.bias
+      attn.norm_q.weight        [head_dim]
+      attn.norm_k.weight        [head_dim]
+      attn.norm_added_q.weight  [head_dim]
+      attn.norm_added_k.weight  [head_dim]
+      img_mlp.net.0.proj.weight   [intermediate, hidden]   img_mlp.net.0.proj.bias
+      img_mlp.net.2.weight        [hidden, intermediate]   img_mlp.net.2.bias
+      txt_mlp.net.0.proj.weight   [intermediate, hidden]   txt_mlp.net.0.proj.bias
+      txt_mlp.net.2.weight        [hidden, intermediate]   txt_mlp.net.2.bias
+
+    Implementation builds in fp32. Per Phase-1 spec deviation, this is
+    expected to be sufficient for cosine >= 0.99 vs bf16 HF reference.
+
+    Returns the path to the written serialized plan.
+    """
+    if batch_size != 1:
+        raise NotImplementedError(
+            "build_joint_block_engine currently supports batch_size=1 only"
+        )
+    H = cfg.num_attention_heads
+    D = cfg.attention_head_dim
+    dim = cfg.hidden_size
+    if H * D != dim:
+        raise ValueError(
+            f"hidden_size ({dim}) != num_heads ({H}) * head_dim ({D})"
+        )
+
+    builder, config, network = _make_builder(verbose)
+
+    img_in = network.add_input("img_tokens", trt.float32, (batch_size, n_img, dim))
+    txt_in = network.add_input("txt_tokens", trt.float32, (batch_size, n_text, dim))
+    temb_in = network.add_input("temb", trt.float32, (batch_size, dim))
+    cos_in = network.add_input("rope_cos", trt.float32, (n_img + n_text, D))
+    sin_in = network.add_input("rope_sin", trt.float32, (n_img + n_text, D))
+
+    # The RoPE table is provided in [img | txt] order matching the RoPE
+    # builder output. Split it into img and txt sub-tables.
+    cos_img_sl = network.add_slice(cos_in, start=(0, 0), shape=(n_img, D), stride=(1, 1))
+    sin_img_sl = network.add_slice(sin_in, start=(0, 0), shape=(n_img, D), stride=(1, 1))
+    cos_txt_sl = network.add_slice(cos_in, start=(n_img, 0), shape=(n_text, D), stride=(1, 1))
+    sin_txt_sl = network.add_slice(sin_in, start=(n_img, 0), shape=(n_text, D), stride=(1, 1))
+    cos_img = cos_img_sl.get_output(0)
+    sin_img = sin_img_sl.get_output(0)
+    cos_txt = cos_txt_sl.get_output(0)
+    sin_txt = sin_txt_sl.get_output(0)
+
+    img_out, txt_out = _add_joint_block_graph(
+        network,
+        img_3d=img_in,
+        txt_3d=txt_in,
+        temb_2d=temb_in,
+        cos_img=cos_img,
+        sin_img=sin_img,
+        cos_txt=cos_txt,
+        sin_txt=sin_txt,
+        weights=weights,
+        weights_prefix="",
+        cfg=cfg,
+        n_img=n_img,
+        n_text=n_text,
+        batch_size=batch_size,
+    )
+
+    # Cast bf16 internal-compute results back to fp32 for the engine output
+    # boundary -- C++ runtime / Python debug runner bind fp32 host buffers.
+    img_out = _to_fp32(network, img_out)
+    txt_out = _to_fp32(network, txt_out)
+    img_out.name = "img_out"
+    txt_out.name = "txt_out"
+    network.mark_output(img_out)
+    network.mark_output(txt_out)
+
+    print(
+        f"[qwen-image-dit] Building joint block engine "
+        f"(B={batch_size}, N_img={n_img}, N_txt={n_text}, "
+        f"hidden={dim}, heads={H}, head_dim={D})",
+        file=sys.stderr,
+    )
+    return _serialize_and_write(builder, network, config, out_path, "joint_block")
+
+
+def _load_safetensors_dir(model_dir: Path) -> tuple[dict[str, "object"], list]:
+    """Open all *.safetensors in model_dir. Returns (reader_dict, opened_objs).
+
+    The reader_dict maps tensor names to the reader that contains them. We
+    use the ``torch`` framework so that bf16/fp16 tensors load as torch
+    tensors (numpy lacks a native bf16 dtype). Callers convert to fp32
+    NumPy via ``.float().cpu().numpy()`` after fetching.
+    """
+    try:
+        from safetensors import safe_open
+    except ImportError as e:
+        raise RuntimeError(
+            "safetensors not installed; cannot load joint block weights"
+        ) from e
+    readers: dict[str, object] = {}
+    opened = []
+    for f in sorted(model_dir.glob("*.safetensors")):
+        r = safe_open(str(f), framework="pt")
+        opened.append(r)
+        for key in r.keys():
+            readers[key] = r
+    if not readers:
+        raise FileNotFoundError(
+            f"No .safetensors shards found in {model_dir}"
+        )
+    return readers, opened
+
+
+def load_joint_block_weights(
+    transformer_dir: PathLike,
+    *,
+    block_index: int = 0,
+) -> tuple[JointBlockConfig, dict[str, np.ndarray]]:
+    """Load weights for ``transformer_blocks.{block_index}.*`` from
+    a diffusers-format transformer checkpoint directory.
+
+    Reads ``config.json`` to populate :class:`JointBlockConfig`.
+    Returns ``(cfg, weights)`` where ``weights`` keys are stripped of the
+    ``transformer_blocks.{block_index}.`` prefix.
+    """
+    import json
+    import torch
+
+    transformer_dir = Path(transformer_dir)
+    config_path = transformer_dir / "config.json"
+    with open(config_path, "r") as f:
+        cfg_json = json.load(f)
+
+    num_heads = int(cfg_json.get("num_attention_heads", 24))
+    head_dim = int(cfg_json.get("attention_head_dim", 128))
+    hidden = num_heads * head_dim
+    cfg = JointBlockConfig(
+        hidden_size=hidden,
+        num_attention_heads=num_heads,
+        attention_head_dim=head_dim,
+        # FeedForward(dim, mult=4) → 4 * hidden.
+        intermediate_size=4 * hidden,
+        rms_norm_eps=1e-6,
+        layer_norm_eps=1e-6,
+    )
+
+    readers, opened = _load_safetensors_dir(transformer_dir)
+    try:
+        prefix = f"transformer_blocks.{block_index}."
+        block_keys = [k for k in readers if k.startswith(prefix)]
+        if not block_keys:
+            raise KeyError(
+                f"No tensors found under {prefix} in {transformer_dir}"
+            )
+        out: dict[str, np.ndarray] = {}
+        for full_key in block_keys:
+            local_key = full_key[len(prefix):]
+            t = readers[full_key].get_tensor(full_key)
+            # torch tensor (bf16 / fp16 / fp32) -> fp32 numpy.
+            arr = t.detach().to(dtype=torch.float32).cpu().numpy()
+            out[local_key] = np.ascontiguousarray(arr, dtype=np.float32)
+    finally:
+        # safe_open objects are context managers, but we manually opened
+        # them; freeing the references lets them close.
+        del opened
+    return cfg, out
+
+
+# ---------------------------------------------------------------------------
+# Full MMDiT denoiser stack.
+#
+# Stacks 60 joint blocks plus the surrounding scaffolding from
+# ``diffusers.models.transformers.transformer_qwenimage.QwenImageTransformer2DModel.forward``
+# (lines 879-957 in the diffusers checkout) into one TRT engine:
+#
+#     hidden_states     = self.img_in(hidden_states)         # Linear [in_ch -> hidden]
+#     encoder_hs        = self.txt_norm(encoder_hidden_states)  # RMSNorm over text_embed_dim
+#     encoder_hs        = self.txt_in(encoder_hs)            # Linear [text_d -> hidden]
+#     temb              = self.time_text_embed(timestep, ...)  # sinusoidal + MLP
+#     image_rotary_emb  = self.pos_embed(img_shapes, max_txt_seq_len, device)
+#     for block in self.transformer_blocks:
+#         encoder_hs, hidden_states = block(hidden_states, encoder_hs, ...)
+#     hidden_states     = self.norm_out(hidden_states, temb)  # AdaLayerNormContinuous
+#     output            = self.proj_out(hidden_states)        # Linear [hidden -> p*p*out_ch]
+#
+# AdaLayerNormContinuous (diffusers/models/normalization.py:307-351):
+#     emb         = self.linear(self.silu(temb))             # [B, 2*hidden]
+#     scale, shift = torch.chunk(emb, 2, dim=1)              # scale FIRST, then shift
+#     x = self.norm(x) * (1 + scale)[:, None, :] + shift[:, None, :]
+# elementwise_affine=False -> the inner LayerNorm has no learnable params.
+#
+# Trace IDs: ARCH-FAM-001, UD-FAM-QWEN-IMAGE-01.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class QwenImageDiTConfig:
+    """Configuration for the full Qwen-Image MMDiT denoiser.
+
+    Defaults match ``Qwen/Qwen-Image-2512`` (60 joint blocks, hidden=3072,
+    24 heads, head_dim=128, rope_axes_dim=[16, 56, 56], rope_theta=10000).
+    """
+
+    in_channels: int = 64
+    out_channels: int = 16
+    patch_size: int = 2
+    hidden_size: int = 3072
+    num_joint_blocks: int = 60
+    num_attention_heads: int = 24
+    attention_head_dim: int = 128
+    intermediate_size: int = 12288     # FeedForward(dim, mult=4) -> 4 * hidden.
+    text_embed_dim: int = 3584         # joint_attention_dim (Qwen2.5-VL hidden).
+    rope_axes_dim: list[int] = field(default_factory=lambda: [16, 56, 56])
+    rope_theta: float = 10000.0
+    timestep_embed_dim: int = 256      # sinusoidal embed width pre-MLP.
+    rms_norm_eps: float = 1e-6
+    layer_norm_eps: float = 1e-6
+    max_image_tokens: int = 8192
+    max_text_tokens: int = 1024
+    guidance_embeds: bool = False      # Qwen-Image-2512: False.
+
+
+def _joint_block_cfg_from(cfg: QwenImageDiTConfig) -> JointBlockConfig:
+    """Adapter so the joint-block helper can be called with its own config."""
+    return JointBlockConfig(
+        hidden_size=cfg.hidden_size,
+        num_attention_heads=cfg.num_attention_heads,
+        attention_head_dim=cfg.attention_head_dim,
+        intermediate_size=cfg.intermediate_size,
+        rms_norm_eps=cfg.rms_norm_eps,
+        layer_norm_eps=cfg.layer_norm_eps,
+    )
+
+
+def _add_linear_3d(network, x_3d, in_dim: int, out_dim: int, w_hf: np.ndarray,
+                   b_hf: "np.ndarray | None", seq_len: int, batch_size: int = 1):
+    """Linear on a [B, S, in_dim] tensor -> [B, S, out_dim].
+
+    Flattens to [B*S, in_dim], applies the existing _add_linear_2d helper,
+    then reshapes back. ``batch_size`` is bound statically.
+    """
+    flat = network.add_shuffle(x_3d)
+    flat.reshape_dims = (batch_size * seq_len, in_dim)
+    y = _add_linear_2d(network, flat.get_output(0), in_dim, out_dim, w_hf, b_hf)
+    unflat = network.add_shuffle(y)
+    unflat.reshape_dims = (batch_size, seq_len, out_dim)
+    return unflat.get_output(0)
+
+
+def _add_rms_norm_last_dim_3d(network, x_3d, hidden_size: int, gamma: np.ndarray,
+                              eps: float):
+    """RMSNorm over the last axis of a [B, S, D] tensor.
+
+    Implements ``gamma * x / sqrt(mean(x^2, dim=-1, keepdim=True) + eps)``,
+    matching ``diffusers.models.normalization.RMSNorm`` with
+    ``elementwise_affine=True`` and no bias. ``gamma`` shape: [hidden_size].
+
+    We don't reuse :func:`graph_ops.add_rms_norm` because that helper is
+    hard-coded for 2D [N, D] inputs (reduces over axis 1).
+    """
+    sq = network.add_elementwise(x_3d, x_3d, trt.ElementWiseOperation.PROD)
+    mean = network.add_reduce(
+        sq.get_output(0), trt.ReduceOperation.AVG, 1 << 2, keep_dims=True,
+    )
+    eps_const = _add_2d_constant(
+        network, np.array([[[eps]]], dtype=np.float32),
+    )
+    denom_in = network.add_elementwise(
+        mean.get_output(0), eps_const, trt.ElementWiseOperation.SUM,
+    )
+    sqrt_l = network.add_unary(denom_in.get_output(0), trt.UnaryOperation.SQRT)
+    recip = network.add_unary(sqrt_l.get_output(0), trt.UnaryOperation.RECIP)
+    normalized = network.add_elementwise(
+        x_3d, recip.get_output(0), trt.ElementWiseOperation.PROD,
+    )
+    gamma_const = _add_2d_constant(
+        network, np.asarray(gamma, dtype=np.float32).reshape(1, 1, hidden_size),
+    )
+    scaled = network.add_elementwise(
+        normalized.get_output(0), gamma_const, trt.ElementWiseOperation.PROD,
+    )
+    return scaled.get_output(0)
+
+
+def _add_time_text_embed(
+    network,
+    timestep,
+    *,
+    weights: Mapping[str, np.ndarray],
+    in_dim: int,
+    hidden_size: int,
+):
+    """In-network port of ``QwenTimestepProjEmbeddings`` (the no-guidance path).
+
+    timestep [B] -> sinusoidal [B, in_dim] -> linear_1 [B, hidden]
+                 -> SiLU -> linear_2 [B, hidden]
+    """
+    sample = _add_get_timestep_embedding(
+        network, timestep,
+        embedding_dim=in_dim,
+        flip_sin_to_cos=True,
+        downscale_freq_shift=0.0,
+        scale=1000.0,
+        max_period=10000.0,
+    )
+    w1 = np.asarray(
+        weights["time_text_embed.timestep_embedder.linear_1.weight"], dtype=np.float32,
+    )
+    b1 = np.asarray(
+        weights["time_text_embed.timestep_embedder.linear_1.bias"], dtype=np.float32,
+    )
+    w2 = np.asarray(
+        weights["time_text_embed.timestep_embedder.linear_2.weight"], dtype=np.float32,
+    )
+    b2 = np.asarray(
+        weights["time_text_embed.timestep_embedder.linear_2.bias"], dtype=np.float32,
+    )
+    h = _add_linear(network, sample, w1, b1)
+    h = graph_ops.add_silu(network, h)
+    h = _add_linear(network, h, w2, b2)
+    return h  # [B, hidden]
+
+
+def _add_norm_out_3d(
+    network,
+    x_3d,
+    temb_2d,
+    *,
+    weights: Mapping[str, np.ndarray],
+    hidden_size: int,
+    eps: float,
+    batch_size: int,
+):
+    """Apply ``AdaLayerNormContinuous(elementwise_affine=False)`` for [B, S, D].
+
+    Matches diffusers.models.normalization.AdaLayerNormContinuous.forward
+    (normalization.py:346-351):
+        emb         = self.linear(self.silu(temb))         # [B, 2*D]
+        scale, shift = torch.chunk(emb, 2, dim=1)          # scale FIRST.
+        x = self.norm(x) * (1 + scale)[:, None, :] + shift[:, None, :]
+    where ``self.norm`` is ``LayerNorm(D, eps, elementwise_affine=False)``.
+    """
+    w = np.asarray(weights["norm_out.linear.weight"], dtype=np.float32)  # [2*D, D]
+    b = np.asarray(weights["norm_out.linear.bias"], dtype=np.float32)    # [2*D]
+    temb_silu = graph_ops.add_silu(network, temb_2d)
+    emb = _add_linear_2d(network, temb_silu, hidden_size, 2 * hidden_size, w, b)
+    # chunk(2, dim=1) -> (scale, shift).  diffusers convention is scale-first.
+    scale_sl = network.add_slice(
+        emb, start=(0, 0),
+        shape=(batch_size, hidden_size), stride=(1, 1),
+    )
+    shift_sl = network.add_slice(
+        emb, start=(0, hidden_size),
+        shape=(batch_size, hidden_size), stride=(1, 1),
+    )
+    scale = scale_sl.get_output(0)
+    shift = shift_sl.get_output(0)
+
+    # LayerNorm(x), no affine.
+    x_normed = _add_layernorm_no_affine_3d(network, x_3d, hidden_size, eps)
+    # (1 + scale)[:, None, :] and shift[:, None, :]
+    scale_3d = network.add_shuffle(scale)
+    scale_3d.reshape_dims = (-1, 1, hidden_size)
+    shift_3d = network.add_shuffle(shift)
+    shift_3d.reshape_dims = (-1, 1, hidden_size)
+    # bf16 constant so it matches scale_3d's dtype under STRONGLY_TYPED.
+    one_const = _add_constant_reduced(
+        network, (1, 1, 1), np.ones((1, 1, 1), dtype=np.float32),
+    )
+    one_plus_scale = network.add_elementwise(
+        scale_3d.get_output(0), one_const, trt.ElementWiseOperation.SUM,
+    ).get_output(0)
+    scaled = network.add_elementwise(
+        x_normed, one_plus_scale, trt.ElementWiseOperation.PROD,
+    ).get_output(0)
+    shifted = network.add_elementwise(
+        scaled, shift_3d.get_output(0), trt.ElementWiseOperation.SUM,
+    ).get_output(0)
+    return shifted
+
+
+def _validate_full_weights(
+    cfg: QwenImageDiTConfig, weights: Mapping[str, np.ndarray],
+) -> None:
+    """Lightweight schema check on the weight dict.
+
+    Only checks presence (and shapes for the top-level params). Per-block
+    keys are checked by the joint-block helper at build time.
+    """
+    H = cfg.hidden_size
+    in_ch = cfg.in_channels
+    out_ch = cfg.out_channels
+    p = cfg.patch_size
+    txt_d = cfg.text_embed_dim
+
+    required = {
+        "img_in.weight": (H, in_ch),
+        "img_in.bias": (H,),
+        "txt_norm.weight": (txt_d,),
+        "txt_in.weight": (H, txt_d),
+        "txt_in.bias": (H,),
+        "time_text_embed.timestep_embedder.linear_1.weight": (H, cfg.timestep_embed_dim),
+        "time_text_embed.timestep_embedder.linear_1.bias": (H,),
+        "time_text_embed.timestep_embedder.linear_2.weight": (H, H),
+        "time_text_embed.timestep_embedder.linear_2.bias": (H,),
+        "norm_out.linear.weight": (2 * H, H),
+        "norm_out.linear.bias": (2 * H,),
+        "proj_out.weight": (out_ch * p * p, H),
+        "proj_out.bias": (out_ch * p * p,),
+    }
+    for key, want in required.items():
+        if key not in weights:
+            raise KeyError(f"build_qwen_image_dit_engine: missing weight {key!r}")
+        arr = np.asarray(weights[key])
+        if tuple(arr.shape) != tuple(want):
+            raise ValueError(
+                f"build_qwen_image_dit_engine: {key!r} shape {arr.shape} != {want}"
+            )
+
+
+def build_qwen_image_dit_engine(
+    cfg: QwenImageDiTConfig,
+    weights: Mapping[str, "np.ndarray"],
+    out_path: PathLike,
+    *,
+    h_lat: int,
+    w_lat: int,
+    n_text: int,
+    batch_size: int = 1,
+    verbose: bool = False,
+) -> Path:
+    """Build the full Qwen-Image MMDiT denoiser as a single TRT engine.
+
+    The denoiser stacks ``cfg.num_joint_blocks`` ``QwenImageTransformerBlock``
+    instances plus the surrounding scaffolding (``img_in``, ``txt_norm``,
+    ``txt_in``, ``time_text_embed``, final ``AdaLayerNormContinuous``,
+    ``proj_out``).
+
+    Engine inputs (fp32, all static shapes):
+      ``img_patched`` [B, N_img, in_channels]
+          packed-patch latents (already produced by the patchify engine /
+          diffusers pack_latents). For Qwen-Image: in_channels = 64.
+          ``N_img = h_lat * w_lat`` where (h_lat, w_lat) are the
+          packed-token grid dimensions (i.e. the latent-grid size AFTER
+          the 2x2 packing).
+      ``txt_hidden`` [B, N_txt = n_text, text_embed_dim]
+          text encoder hidden states (Qwen2.5-VL hidden = 3584).
+      ``timestep``  [B]
+          diffusion timestep (fp32; will be cast/multiplied by ``scale=1000``
+          inside the sinusoidal embedding, matching diffusers).
+
+    Engine output (fp32):
+      ``noise_patched`` [B, N_img, out_channels * patch_size**2]
+          packed-patch noise prediction. The runtime unpatchifies this
+          before handing it to the VAE decoder.
+
+    ``h_lat`` and ``w_lat`` describe the packed-token grid (= latent-grid
+    divided by ``cfg.patch_size``). They bake into the engine via the RoPE
+    tables, so callers wanting a different grid must build a fresh engine.
+
+    Real Qwen-Image-2512 weights load via the diffusers state-dict keys
+    (no remapping); see ``_validate_full_weights`` for the full key list.
+
+    Returns the path to the written serialised plan.
+    """
+    if batch_size != 1:
+        raise NotImplementedError(
+            "build_qwen_image_dit_engine currently supports batch_size=1 only"
+        )
+    if cfg.num_attention_heads * cfg.attention_head_dim != cfg.hidden_size:
+        raise ValueError(
+            f"hidden_size ({cfg.hidden_size}) != num_heads ({cfg.num_attention_heads}) "
+            f"* head_dim ({cfg.attention_head_dim})"
+        )
+    if sum(cfg.rope_axes_dim) != cfg.attention_head_dim:
+        raise ValueError(
+            f"sum(rope_axes_dim) ({sum(cfg.rope_axes_dim)}) != head_dim "
+            f"({cfg.attention_head_dim})"
+        )
+    if cfg.guidance_embeds:
+        raise NotImplementedError(
+            "build_qwen_image_dit_engine does not support guidance_embeds=True"
+        )
+
+    _validate_full_weights(cfg, weights)
+
+    n_img = h_lat * w_lat
+    H_dim = cfg.hidden_size
+    head_dim = cfg.attention_head_dim
+    in_ch = cfg.in_channels
+    out_ch = cfg.out_channels
+    p = cfg.patch_size
+    txt_d = cfg.text_embed_dim
+
+    # Pre-compute RoPE tables (baked as constants).
+    cos_table_np, sin_table_np = _precompute_qwen_rope_tables(
+        list(cfg.rope_axes_dim), h_lat, w_lat, n_text, cfg.rope_theta,
+    )
+    seq_total = n_img + n_text
+    assert cos_table_np.shape == (seq_total, head_dim), (
+        f"rope cos shape {cos_table_np.shape} != ({seq_total}, {head_dim})"
+    )
+
+    builder, config, network = _make_builder(verbose)
+
+    img_patched = network.add_input(
+        "img_patched", trt.float32, (batch_size, n_img, in_ch),
+    )
+    txt_hidden = network.add_input(
+        "txt_hidden", trt.float32, (batch_size, n_text, txt_d),
+    )
+    timestep = network.add_input("timestep", trt.float32, (batch_size,))
+
+    # ----- img_in: Linear(in_ch -> hidden) over [B, N_img, in_ch].
+    img_in_w = np.asarray(weights["img_in.weight"], dtype=np.float32)
+    img_in_b = np.asarray(weights["img_in.bias"], dtype=np.float32)
+    img_tokens = _add_linear_3d(
+        network, img_patched, in_ch, H_dim, img_in_w, img_in_b,
+        seq_len=n_img, batch_size=batch_size,
+    )
+
+    # ----- txt_norm: RMSNorm over text_embed_dim, then txt_in: Linear(text_d -> hidden).
+    txt_norm_gamma = np.asarray(weights["txt_norm.weight"], dtype=np.float32)
+    txt_normed = _add_rms_norm_last_dim_3d(
+        network, txt_hidden, txt_d, txt_norm_gamma, cfg.rms_norm_eps,
+    )
+    txt_in_w = np.asarray(weights["txt_in.weight"], dtype=np.float32)
+    txt_in_b = np.asarray(weights["txt_in.bias"], dtype=np.float32)
+    txt_tokens = _add_linear_3d(
+        network, txt_normed, txt_d, H_dim, txt_in_w, txt_in_b,
+        seq_len=n_text, batch_size=batch_size,
+    )
+
+    # ----- time_text_embed: sinusoidal + MLP -> [B, hidden].
+    temb = _add_time_text_embed(
+        network, timestep, weights=weights,
+        in_dim=cfg.timestep_embed_dim, hidden_size=H_dim,
+    )
+
+    # ----- RoPE cos/sin constants split into img and txt sub-tables.
+    # _precompute_qwen_rope_tables returns [vid_freqs (n_img rows) | txt_freqs (n_text rows)].
+    cos_const = network.add_constant(
+        (seq_total, head_dim), trt.Weights(cos_table_np),
+    ).get_output(0)
+    sin_const = network.add_constant(
+        (seq_total, head_dim), trt.Weights(sin_table_np),
+    ).get_output(0)
+    cos_img_sl = network.add_slice(cos_const, start=(0, 0),
+                                   shape=(n_img, head_dim), stride=(1, 1))
+    sin_img_sl = network.add_slice(sin_const, start=(0, 0),
+                                   shape=(n_img, head_dim), stride=(1, 1))
+    cos_txt_sl = network.add_slice(cos_const, start=(n_img, 0),
+                                   shape=(n_text, head_dim), stride=(1, 1))
+    sin_txt_sl = network.add_slice(sin_const, start=(n_img, 0),
+                                   shape=(n_text, head_dim), stride=(1, 1))
+
+    # ----- Joint blocks loop.
+    jb_cfg = _joint_block_cfg_from(cfg)
+    cur_img = img_tokens
+    cur_txt = txt_tokens
+    for i in range(cfg.num_joint_blocks):
+        prefix = f"transformer_blocks.{i}."
+        cur_img, cur_txt = _add_joint_block_graph(
+            network,
+            img_3d=cur_img,
+            txt_3d=cur_txt,
+            temb_2d=temb,
+            cos_img=cos_img_sl.get_output(0),
+            sin_img=sin_img_sl.get_output(0),
+            cos_txt=cos_txt_sl.get_output(0),
+            sin_txt=sin_txt_sl.get_output(0),
+            weights=weights,
+            weights_prefix=prefix,
+            cfg=jb_cfg,
+            n_img=n_img,
+            n_text=n_text,
+            batch_size=batch_size,
+        )
+
+    # ----- AdaLayerNormContinuous(elementwise_affine=False) -> proj_out.
+    normed = _add_norm_out_3d(
+        network, cur_img, temb, weights=weights,
+        hidden_size=H_dim, eps=cfg.layer_norm_eps, batch_size=batch_size,
+    )
+    proj_w = np.asarray(weights["proj_out.weight"], dtype=np.float32)
+    proj_b = np.asarray(weights["proj_out.bias"], dtype=np.float32)
+    proj_out_dim = out_ch * p * p
+    noise = _add_linear_3d(
+        network, normed, H_dim, proj_out_dim, proj_w, proj_b,
+        seq_len=n_img, batch_size=batch_size,
+    )
+    # Engine output is fp32 by contract (the C++ runtime + Python debug
+    # runner bind fp32 host buffers); internal compute stays bf16.
+    noise = _to_fp32(network, noise)
+    noise.name = "noise_patched"
+    network.mark_output(noise)
+
+    print(
+        f"[qwen-image-dit] Building full denoiser engine "
+        f"(B={batch_size}, n_img={n_img}, n_text={n_text}, "
+        f"blocks={cfg.num_joint_blocks}, hidden={H_dim}, "
+        f"heads={cfg.num_attention_heads}, head_dim={head_dim}, "
+        f"text_d={txt_d}, in_ch={in_ch}, out_ch={out_ch}, p={p}) "
+        f"-> [{batch_size}, {n_img}, {proj_out_dim}]",
+        file=sys.stderr,
+    )
+    return _serialize_and_write(builder, network, config, out_path, "qwen_image_dit")
+
+
+# ---------------------------------------------------------------------------
+# Full-denoiser HF weight loader.
+#
+# Loads every parametric tensor from a diffusers Qwen-Image-2512 transformer/
+# directory and packages it together with a QwenImageDiTConfig built from the
+# component config.json. The returned dict's keys are the diffusers
+# state-dict keys exactly (no renaming) so it can be passed straight into
+# build_qwen_image_dit_engine -- which uses _validate_full_weights to assert
+# the schema matches the diffusers convention.
+# ---------------------------------------------------------------------------
+
+
+def load_qwen_image_dit_weights(
+    transformer_dir: PathLike,
+) -> tuple[QwenImageDiTConfig, dict[str, np.ndarray]]:
+    """Load full ``QwenImageTransformer2DModel`` weights from a HF ``transformer/`` dir.
+
+    Reads ``transformer/config.json`` to populate :class:`QwenImageDiTConfig`,
+    then scans all ``*.safetensors`` shards in the directory and returns
+    every tensor as an fp32 ``np.ndarray``. The returned ``cfg`` and
+    ``weights`` dict are suitable for direct use with
+    :func:`build_qwen_image_dit_engine` — no key remapping is needed
+    because the engine builder uses the diffusers state-dict naming
+    convention throughout (see :func:`_validate_full_weights`).
+
+    The full transformer dict for Qwen/Qwen-Image-2512 has 1933 parametric
+    tensors (verified by listing the safetensors index).
+    Returns ALL of them — the full denoiser uses everything (img_in,
+    txt_norm, txt_in, time_text_embed, transformer_blocks.*, norm_out,
+    proj_out). No filtering is applied because the transformer directory
+    only contains the denoiser; sibling components (text encoder, VAE) live
+    in their own per-component directories under the diffusers snapshot.
+
+    The Qwen-Image-2512 ``config.json`` is minimal (no ``rope_theta``,
+    ``rms_norm_eps``, etc. fields exist); this loader uses the same
+    hardcoded defaults that the diffusers source bakes in:
+      - ``rope_theta = 10000.0`` (transformer_qwenimage.py:200 default).
+      - ``rms_norm_eps = 1e-6`` (QwenImageTransformerBlock default).
+      - ``timestep_embed_dim = 256`` (QwenTimestepProjEmbeddings default).
+      - ``max_text_tokens = 1024`` (Qwen-Image pipeline default).
+      - ``max_image_tokens = 8192`` (Qwen-Image pipeline ``max_image_seq_len``).
+
+    Args:
+        transformer_dir: Path to a directory containing ``config.json`` and
+            one or more ``*.safetensors`` shards in the HF/diffusers layout.
+            This is typically ``<repo>/transformer/`` under a diffusers
+            snapshot of Qwen/Qwen-Image-2512.
+
+    Returns:
+        Tuple of ``(config, weights)`` where the keys of ``weights`` are the
+        diffusers state-dict keys (e.g. ``img_in.weight``,
+        ``transformer_blocks.0.attn.to_q.weight``), each cast to fp32
+        ``np.ndarray``.
+
+    Raises:
+        FileNotFoundError: If ``config.json`` or any ``*.safetensors`` shard
+            is missing from ``transformer_dir``.
+    """
+    import json
+
+    from safetensors import safe_open
+
+    try:
+        # Required when safetensors emits a bf16 numpy view that needs
+        # ml_dtypes registered before .astype() can decode it. Qwen-Image's
+        # transformer shards are bf16-stored, so without this the
+        # safe_open(..., framework="numpy") call below cannot return the
+        # tensors (numpy has no native bf16 dtype).
+        import ml_dtypes  # noqa: F401
+    except ImportError:  # pragma: no cover -- best-effort
+        pass
+
+    text_dir = Path(transformer_dir)
+    config_path = text_dir / "config.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"Missing config.json in {text_dir}")
+    cfg_json = json.loads(config_path.read_text())
+
+    num_attention_heads = int(cfg_json.get("num_attention_heads", 24))
+    attention_head_dim = int(cfg_json.get("attention_head_dim", 128))
+    hidden_size = num_attention_heads * attention_head_dim
+
+    cfg = QwenImageDiTConfig(
+        in_channels=int(cfg_json.get("in_channels", 64)),
+        out_channels=int(cfg_json.get("out_channels", 16)),
+        patch_size=int(cfg_json.get("patch_size", 2)),
+        hidden_size=hidden_size,
+        num_joint_blocks=int(cfg_json.get("num_layers", 60)),
+        num_attention_heads=num_attention_heads,
+        attention_head_dim=attention_head_dim,
+        intermediate_size=hidden_size * 4,  # FeedForward(dim, mult=4) -> 4*hidden.
+        text_embed_dim=int(cfg_json.get("joint_attention_dim", 3584)),
+        rope_axes_dim=list(cfg_json.get("axes_dims_rope", [16, 56, 56])),
+        rope_theta=10000.0,  # hardcoded in diffusers source
+        timestep_embed_dim=256,  # hardcoded in QwenTimestepProjEmbeddings
+        rms_norm_eps=1e-6,
+        layer_norm_eps=1e-6,
+        max_image_tokens=8192,
+        max_text_tokens=1024,
+        guidance_embeds=bool(cfg_json.get("guidance_embeds", False)),
+    )
+
+    safetensor_files = sorted(text_dir.glob("*.safetensors"))
+    if not safetensor_files:
+        raise FileNotFoundError(f"No *.safetensors in {text_dir}")
+
+    weights: dict[str, np.ndarray] = {}
+    for sf in safetensor_files:
+        with safe_open(str(sf), framework="numpy") as f:
+            for key in f.keys():
+                arr = f.get_tensor(key)
+                # Promote any low-precision dtype (bf16/fp16) to fp32. The
+                # builder accepts fp32 only via _as_numpy().
+                if arr.dtype != np.float32:
+                    arr = arr.astype(np.float32)
+                weights[key] = arr
+
+    return cfg, weights

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen_image_preprocessor.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen_image_preprocessor.py
@@ -1,0 +1,147 @@
+"""Qwen-Image preprocessor weights blob.
+
+Packs the small runtime-resident tensors that the C++ pipeline reads
+from the bundle (NOT baked into a TRT engine):
+
+  - ``latents_mean``: [16] float32 — per-channel VAE latent mean.
+  - ``latents_std``:  [16] float32 — per-channel VAE latent std.
+
+The C++ pipeline uses these to un-normalize the denoiser output before
+VAE decode (``z = z * latents_std + latents_mean``), matching the
+diffusers normalization contract.
+
+Most other tensors (timestep MLP, text projection, etc.) are baked
+into the denoiser engine by :mod:`qwen_image_dit_builder`, so unlike
+Z-Image / Wan T2V this blob is intentionally tiny.
+
+Format (matches Z-Image / Wan T2V so
+``src/runtime/domains/diffusion/diffusion_preprocessor_weights_helpers.h``
+can parse it unchanged):
+
+    <u32 little-endian index_len>
+    <UTF-8 JSON dict mapping name -> {"offset": int, "shape": [int, ...]}>
+    <contiguous raw float32 data, all entries in declaration order>
+
+Trace: ARCH-FAM-001, UD-FAM-QWEN-IMAGE-01.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from typing import Mapping
+
+import numpy as np
+
+
+# Names the C++ pipeline will look up in the index.
+_PREPROCESSOR_KEYS: tuple[str, ...] = (
+    "latents_mean",
+    "latents_std",
+)
+
+
+def pack_qwen_image_preprocessor_weights(
+    named_tensors: Mapping[str, np.ndarray],
+) -> bytes:
+    """Serialize named tensors into the diffusion preprocessor blob format.
+
+    Entries are written in :data:`_PREPROCESSOR_KEYS` order; any extra
+    keys in ``named_tensors`` are appended in dict-iteration order so the
+    helper is also useful for unit tests that exercise round-trip with
+    synthetic tensors. Missing canonical keys raise ``ValueError``.
+
+    All arrays are coerced to contiguous float32. Shapes are recorded as
+    Python ``int`` lists in the JSON index.
+    """
+    for key in _PREPROCESSOR_KEYS:
+        if key not in named_tensors:
+            raise ValueError(
+                f"pack_qwen_image_preprocessor_weights: missing required "
+                f"key {key!r}"
+            )
+
+    # Preserve canonical-first ordering, then any extras for test flexibility.
+    ordered_keys: list[str] = list(_PREPROCESSOR_KEYS)
+    for key in named_tensors:
+        if key not in ordered_keys:
+            ordered_keys.append(key)
+
+    index: dict[str, dict] = {}
+    data_parts: list[bytes] = []
+    offset = 0
+    for key in ordered_keys:
+        arr = np.ascontiguousarray(np.asarray(named_tensors[key], dtype=np.float32))
+        index[key] = {"offset": offset, "shape": [int(d) for d in arr.shape]}
+        data_parts.append(arr.tobytes())
+        offset += arr.nbytes
+
+    index_json = json.dumps(index).encode("utf-8")
+    header = struct.pack("<I", len(index_json))
+    return header + index_json + b"".join(data_parts)
+
+
+def load_qwen_image_preprocessor_weights(
+    blob: bytes,
+) -> dict[str, np.ndarray]:
+    """Inverse of :func:`pack_qwen_image_preprocessor_weights`.
+
+    Used by unit tests to assert lossless round-trip; the production C++
+    runtime has its own parser in
+    ``diffusion_preprocessor_weights_helpers.h``.
+    """
+    if len(blob) < 4:
+        raise ValueError(
+            f"qwen_image preprocessor blob too small: {len(blob)} bytes"
+        )
+    (index_len,) = struct.unpack("<I", blob[:4])
+    if 4 + index_len > len(blob):
+        raise ValueError(
+            f"qwen_image preprocessor index length {index_len} overflows "
+            f"blob of {len(blob)} bytes"
+        )
+
+    index = json.loads(blob[4:4 + index_len].decode("utf-8"))
+    data = blob[4 + index_len:]
+
+    out: dict[str, np.ndarray] = {}
+    for name, entry in index.items():
+        shape = tuple(int(d) for d in entry["shape"])
+        offset = int(entry["offset"])
+        count = int(np.prod(shape)) if shape else 1
+        nbytes = count * 4  # float32
+        if offset + nbytes > len(data):
+            raise ValueError(
+                f"qwen_image preprocessor weight {name!r} overflows blob "
+                f"(offset={offset}, nbytes={nbytes}, blob_data={len(data)})"
+            )
+        flat = np.frombuffer(data, dtype=np.float32, count=count, offset=offset)
+        out[name] = np.ascontiguousarray(flat.reshape(shape))
+    return out
+
+
+def extract_preprocessor_source(vae_config) -> dict[str, np.ndarray]:
+    """Pull the runtime-resident tensors out of a ``QwenImageVAEConfig``.
+
+    Only ``latents_mean`` / ``latents_std`` need to ship outside an engine
+    for Qwen-Image T2I; the timestep MLP, text projection, etc. are baked
+    into the denoiser engine by ``build_qwen_image_dit_engine``.
+
+    Returned arrays are contiguous float32 vectors. The caller passes the
+    result to :func:`pack_qwen_image_preprocessor_weights`.
+    """
+    return {
+        "latents_mean": np.ascontiguousarray(
+            np.asarray(vae_config.latents_mean, dtype=np.float32)
+        ),
+        "latents_std": np.ascontiguousarray(
+            np.asarray(vae_config.latents_std, dtype=np.float32)
+        ),
+    }
+
+
+__all__ = [
+    "pack_qwen_image_preprocessor_weights",
+    "load_qwen_image_preprocessor_weights",
+    "extract_preprocessor_source",
+]

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen_image_vae_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen_image_vae_builder.py
@@ -1,0 +1,1010 @@
+"""Qwen-Image VAE decoder builder.
+
+Builds a TensorRT engine for the ``AutoencoderKLQwenImage`` decoder running
+in image (T=1) mode. The Qwen-Image VAE is a 3D causal-conv VAE forked from
+Wan2.1 -- same architecture, same weight naming, different default
+``temperal_downsample`` and ``latents_mean`` / ``latents_std`` vectors.
+
+Architectural model (single-frame decode path; see
+``references/diffusers/.../autoencoder_kl_qwenimage.py``):
+
+  Input: latent z of shape [B, z_dim, T=1, H_lat, W_lat] (z_dim=16).
+  Output: pixels of shape [B, 3, T=1, H_lat*8, W_lat*8] in [-1, 1].
+
+  Forward (HF ``_decode`` with num_frame=1):
+    z -> post_quant_conv (1x1x1 Conv3d, z_dim -> z_dim)
+       -> decoder(z_single_frame, fresh feat_cache)
+            conv_in: CausalConv3d(z_dim -> base_dim*dim_mult[-1], k=(3,3,3))
+            mid_block: ResBlock -> SpatialAttention -> ResBlock
+            up_blocks (reversed dim_mult, iterate level 0..N-1):
+              N+1 ResBlocks (channel change at block 0, in_ch -> out_ch)
+              if level < N-1:
+                if temperal_upsample[level]:  # reversed [F,T,T] => [T,T,F]
+                  -- time_conv path: in image mode (fresh cache marked "Rep")
+                     the HF code SKIPS the time_conv call entirely; it only
+                     marks the cache slot. Spatial upsample is still applied.
+                spatial upsample: nearest 2x + Conv3d(1,3,3) smoothing
+            norm_out (L2 channel norm with .gamma) -> SiLU
+            conv_out: CausalConv3d(prev_ch -> 3, k=(3,3,3))
+       -> clamp(-1, 1)
+
+  Per-channel ``latents_mean`` and ``latents_std`` (length=z_dim float
+  vectors) un-normalise the latent BEFORE the VAE: HF's pipeline does
+  ``z = z / std + mean`` before calling ``vae.decode``. Equivalently the
+  graph can absorb this as a pre-multiplicative scale (`std`) + per-channel
+  bias (`mean`). We expose two builder modes:
+
+    * ``apply_latent_unnorm=False`` (default): the engine consumes a latent
+      already un-normalised by the caller (matches HF's ``vae.decode(z_raw)``
+      contract). Synthetic test uses this for exact parity.
+    * ``apply_latent_unnorm=True``: the engine receives a normalised latent
+      ``z_norm = (z_raw - mean) / std`` and the graph applies
+      ``z_raw = z_norm * std + mean`` before ``post_quant_conv``. Convenient
+      when wiring a full T2I pipeline whose denoiser emits ``z_norm``.
+
+  Causal-conv handling: for image (T=1) mode HF's ``QwenImageCausalConv3d``
+  with no prior cache reduces to a standard Conv3d with zero left-padding
+  in time. We implement this by feeding zero-valued cache tensors of shape
+  [B, C, Kt-1=2, H, W] as TRT constants into the existing
+  ``graph_ops.add_causal_conv3d`` helper -- no temporal expansion since
+  ``num_frame=1`` and HF skips time_conv on the fresh-cache "Rep" path.
+
+  Approach (per spec): Option A -- image-mode-only 3D graph with T=1 held
+  constant throughout. The graph emits exactly the same numbers as HF's
+  ``vae.decode(z)`` with ``return_dict=True`` and reads ``.sample``.
+
+Precision: the network is STRONGLY_TYPED with fp32 inputs/outputs but
+runs the heavy decoder compute internally in bf16. The latent input is
+cast to bf16 immediately after un-normalisation (which itself uses fp32
+constants for accuracy). Conv/upsample/attention/residual weights are
+materialised as bf16 buffers (anchored in a module-level list to survive
+GC during engine build). L2 channel norms cast back to fp32 internally for
+the variance reduction, then cast back to bf16 at the boundary. The final
+clamp/output is cast back to fp32 right before ``mark_output``.
+
+This mirrors HF's ``AutoencoderKLQwenImage.to(dtype=bfloat16)`` behaviour:
+the VAE accepts an fp32 latent which the HF pipeline immediately
+``.to(self.vae.dtype)``s, runs the whole module in bf16, and the C++/Python
+runtime sees fp32 buffers at the bound IO tensors.
+
+Trace: ARCH-FAM-001, UD-FAM-QWEN-IMAGE-01, UT-QWEN-IMAGE-VAE-001.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+
+
+trt = trt_compat.get_trt()
+
+
+# ---------------------------------------------------------------------------
+# Config dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class QwenImageVAEConfig:
+    """Architecture parameters for the Qwen-Image VAE decoder.
+
+    Real Qwen-Image values (matching ``Qwen/Qwen-Image-2512/vae/config.json``):
+        z_dim=16, base_dim=96, dim_mult=[1, 2, 4, 4], num_res_blocks=2,
+        temperal_downsample=[False, True, True].
+
+    Note: HF uses the misspelled key ``temperal_downsample`` in its config;
+    we mirror that spelling for the raw-JSON loader but expose the corrected
+    field name ``temporal_downsample`` here. The constructor accepts either
+    via the loader.
+    """
+
+    z_dim: int = 16
+    base_dim: int = 96
+    dim_mult: list[int] = field(default_factory=lambda: [1, 2, 4, 4])
+    num_res_blocks: int = 2
+    # HF stores ``temperal_downsample`` (the typo). For image decoding the
+    # decoder iterates over the *reverse* of this list (the "upsample"
+    # schedule) and -- in image mode -- skips the time_conv even where the
+    # schedule is True, so the value only governs which weights need to be
+    # present in the checkpoint.
+    temporal_downsample: list[bool] = field(
+        default_factory=lambda: [False, True, True]
+    )
+    input_channels: int = 3
+    latents_mean: list[float] = field(
+        default_factory=lambda: [
+            -0.7571, -0.7089, -0.9113, 0.1075, -0.1745, 0.9653, -0.1517,
+            1.5508, 0.4134, -0.0715, 0.5517, -0.3632, -0.1922, -0.9497,
+            0.2503, -0.2921,
+        ]
+    )
+    latents_std: list[float] = field(
+        default_factory=lambda: [
+            2.8184, 1.4541, 2.3275, 2.6558, 1.2196, 1.7708, 2.6052, 2.0743,
+            3.2687, 2.1526, 2.8652, 1.5579, 1.6382, 1.1253, 2.8251, 1.9160,
+        ]
+    )
+    # Numerical eps for L2 channel norm. HF default for F.normalize is 1e-12.
+    norm_eps: float = 1e-12
+
+    @property
+    def spatial_compression_ratio(self) -> int:
+        """Total spatial downscale = 2 ** len(dim_mult) (matches HF prop)."""
+        return 2 ** len(self.temporal_downsample)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Module-level anchor list keeping bf16 numpy buffers alive while TRT
+# consumes them via raw pointers in ``trt.Weights(trt.bfloat16, ptr, size)``.
+# Cleared at the top of every ``build_qwen_image_vae_decoder_engine`` call.
+_BF16_WEIGHT_REFS: list[np.ndarray] = []
+
+
+def _as_numpy(value, *, name: str) -> np.ndarray:
+    """Coerce torch/numpy to a contiguous float32 numpy array."""
+    if isinstance(value, np.ndarray):
+        arr = value
+    else:
+        try:
+            import torch
+        except ImportError:  # pragma: no cover
+            raise TypeError(
+                f"weight {name!r} is not numpy and torch is unavailable"
+            )
+        if isinstance(value, torch.Tensor):
+            arr = value.detach().cpu().to(torch.float32).numpy()
+        else:
+            raise TypeError(
+                f"weight {name!r} has unsupported type {type(value).__name__}"
+            )
+    return np.ascontiguousarray(arr, dtype=np.float32)
+
+
+def _to_bf16(network: "trt.INetworkDefinition", tensor: "trt.ITensor") -> "trt.ITensor":
+    """Cast a tensor to bf16 (no-op if already bf16)."""
+    if tensor.dtype == trt.bfloat16:
+        return tensor
+    return network.add_cast(tensor, trt.bfloat16).get_output(0)
+
+
+def _to_fp32(network: "trt.INetworkDefinition", tensor: "trt.ITensor") -> "trt.ITensor":
+    """Cast a tensor to fp32 (no-op if already fp32)."""
+    if tensor.dtype == trt.float32:
+        return tensor
+    return network.add_cast(tensor, trt.float32).get_output(0)
+
+
+def _bf16_weights(data_fp32: np.ndarray) -> "trt.Weights":
+    """Wrap a fp32 numpy array as a bf16 ``trt.Weights``.
+
+    Anchors the bf16 buffer in ``_BF16_WEIGHT_REFS`` to keep it alive while
+    TRT consumes it via raw pointer.
+    """
+    import ml_dtypes
+    bf16_arr = np.ascontiguousarray(
+        np.asarray(data_fp32, dtype=np.float32).astype(ml_dtypes.bfloat16)
+    )
+    _BF16_WEIGHT_REFS.append(bf16_arr)
+    return trt.Weights(trt.bfloat16, bf16_arr.ctypes.data, bf16_arr.size)
+
+
+def _bf16_conv2d(
+    network: "trt.INetworkDefinition",
+    inp: "trt.ITensor",
+    weight: np.ndarray,
+    bias: np.ndarray | None,
+    out_channels: int,
+    kernel_hw: tuple[int, int],
+    stride_hw: tuple[int, int],
+    padding_hw: tuple[int, int],
+) -> "trt.ITensor":
+    """2D conv with bf16 weights/bias on a bf16 input.
+
+    ``weight`` shape is the original 4D conv kernel [C_out, C_in, Kh, Kw].
+    """
+    conv = network.add_convolution_nd(
+        inp,
+        num_output_maps=out_channels,
+        kernel_shape=kernel_hw,
+        kernel=_bf16_weights(weight),
+        bias=_bf16_weights(bias) if bias is not None else trt.Weights(),
+    )
+    conv.stride_nd = stride_hw
+    conv.padding_nd = padding_hw
+    return conv.get_output(0)
+
+
+def _bf16_conv3d_as_conv2d(
+    network: "trt.INetworkDefinition",
+    inp: "trt.ITensor",
+    weight: np.ndarray,
+    bias: np.ndarray | None,
+    out_channels: int,
+    kernel_size: tuple[int, int, int],
+    stride: tuple[int, int, int] = (1, 1, 1),
+    padding: tuple[int, int, int] = (0, 0, 0),
+) -> "trt.ITensor":
+    """3D conv (kt=1 path) decomposed to 2D, with bf16 weights.
+
+    Input: [B, C_in, T, H, W] bf16.
+    Output: [B, C_out, T, H_out, W_out] bf16.
+    Mirrors ``graph_ops.add_conv3d_as_conv2d`` for the ``kt=1`` branch
+    only -- the kt>1 branch is handled by ``_bf16_causal_conv3d``.
+    """
+    b, c_in, t, h, w = inp.shape
+    kt, kh, kw = kernel_size
+    st, sh, sw = stride
+    pt, ph, pw = padding
+    if kt != 1 or st != 1 or pt != 0:
+        raise NotImplementedError(
+            "_bf16_conv3d_as_conv2d only supports kt=1 spatial-only convs"
+        )
+
+    # Reshape [B, C, T, H, W] -> [B*T, C, H, W]
+    reshape_in = network.add_shuffle(inp)
+    reshape_in.first_transpose = trt.Permutation([0, 2, 1, 3, 4])
+    reshape_in.reshape_dims = (b * t, c_in, h, w)
+
+    # Weight: [C_out, C_in, 1, Kh, Kw] -> [C_out, C_in, Kh, Kw]
+    w2d = weight.reshape(out_channels, c_in, kh, kw)
+    conv_out = _bf16_conv2d(
+        network, reshape_in.get_output(0),
+        w2d, bias,
+        out_channels=out_channels,
+        kernel_hw=(kh, kw),
+        stride_hw=(sh, sw),
+        padding_hw=(ph, pw),
+    )
+
+    h_out = (h + 2 * ph - kh) // sh + 1
+    w_out = (w + 2 * pw - kw) // sw + 1
+    reshape_out = network.add_shuffle(conv_out)
+    reshape_out.reshape_dims = (b, t, out_channels, h_out, w_out)
+    reshape_out.second_transpose = trt.Permutation([0, 2, 1, 3, 4])
+    return reshape_out.get_output(0)
+
+
+def _bf16_causal_conv3d(
+    network: "trt.INetworkDefinition",
+    inp: "trt.ITensor",
+    cache: "trt.ITensor",
+    weight: np.ndarray,
+    bias: np.ndarray | None,
+    out_channels: int,
+    kernel_size: tuple[int, int, int],
+    padding_hw: tuple[int, int] = (0, 0),
+) -> "trt.ITensor":
+    """Image-mode (T=1) causal Conv3d with bf16 weights.
+
+    Mirrors ``graph_ops.add_causal_conv3d`` for the ``t_in==1, kt>1`` path:
+    concatenate the [B, C, Kt-1, H, W] cache with the [B, C, 1, H, W]
+    input and run a single fused 2D conv whose [C_in*Kt, Kh, Kw] kernel
+    multiplies the cached+current frames together. For ``kt=1`` we fall
+    through to ``_bf16_conv3d_as_conv2d``.
+    """
+    b, c_in, t_in, h, w = inp.shape
+    kt, kh, kw = kernel_size
+    ph, pw = padding_hw
+
+    if kt == 1:
+        return _bf16_conv3d_as_conv2d(
+            network, inp, weight, bias, out_channels,
+            kernel_size=(1, kh, kw),
+            padding=(0, ph, pw),
+        )
+    if t_in != 1:
+        raise NotImplementedError(
+            "_bf16_causal_conv3d only supports T=1 image-mode causal conv"
+        )
+
+    # Concatenate cache + input along temporal dim: [B, C, Kt, H, W]
+    concat = network.add_concatenation([cache, inp])
+    concat.axis = 2
+    full_temporal = concat.get_output(0)
+
+    # Reshape to 2D for a fused conv: [B, C_in*Kt, H, W]
+    reshape_in = network.add_shuffle(full_temporal)
+    reshape_in.reshape_dims = (b, c_in * kt, h, w)
+
+    w2d = weight.reshape(out_channels, c_in * kt, kh, kw)
+    conv_out = _bf16_conv2d(
+        network, reshape_in.get_output(0),
+        w2d, bias,
+        out_channels=out_channels,
+        kernel_hw=(kh, kw),
+        stride_hw=(1, 1),
+        padding_hw=(ph, pw),
+    )
+
+    h_out = (h + 2 * ph - kh) + 1
+    w_out = (w + 2 * pw - kw) + 1
+    reshape_out = network.add_shuffle(conv_out)
+    reshape_out.reshape_dims = (b, out_channels, 1, h_out, w_out)
+    return reshape_out.get_output(0)
+
+
+def _bf16_spatial_upsample_with_conv(
+    network: "trt.INetworkDefinition",
+    inp: "trt.ITensor",
+    weight: np.ndarray,
+    bias: np.ndarray | None,
+    scale: int = 2,
+) -> "trt.ITensor":
+    """Nearest-neighbour 2x spatial upsample + 1x3x3 Conv3d (bf16 weights)."""
+    b, c, t, h, w = inp.shape
+    resize = network.add_resize(inp)
+    resize.resize_mode = trt.InterpolationMode.NEAREST
+    resize.shape = (b, c, t, h * scale, w * scale)
+    upsampled = resize.get_output(0)
+
+    out_channels = weight.shape[0]
+    return _bf16_conv3d_as_conv2d(
+        network, upsampled,
+        weight=weight, bias=bias,
+        out_channels=out_channels,
+        kernel_size=(1, 3, 3),
+        padding=(0, 1, 1),
+    )
+
+
+def _bf16_l2_channel_norm(
+    network: "trt.INetworkDefinition",
+    inp: "trt.ITensor",
+    num_channels: int,
+    gamma: np.ndarray,
+    eps: float,
+) -> "trt.ITensor":
+    """L2 channel norm with bf16 IO; reduction performed in fp32.
+
+    Implements ``F.normalize(x, dim=1) * sqrt(C) * gamma``. We cast to fp32
+    around the variance reduction (the only numerically-sensitive part) and
+    cast the result back to bf16 so downstream ops stay in compute dtype.
+    """
+    inp_fp32 = _to_fp32(network, inp)
+
+    sq = network.add_elementwise(
+        inp_fp32, inp_fp32, trt.ElementWiseOperation.PROD).get_output(0)
+    sum_sq = network.add_reduce(
+        sq, trt.ReduceOperation.SUM, 1 << 1, keep_dims=True).get_output(0)
+    eps_t = graph_ops.add_constant(
+        network, (1, 1, 1, 1, 1),
+        np.array([eps], dtype=np.float32), dtype=np.float32)
+    denom = network.add_elementwise(
+        sum_sq, eps_t, trt.ElementWiseOperation.SUM).get_output(0)
+    norm = network.add_unary(denom, trt.UnaryOperation.SQRT).get_output(0)
+    recip = network.add_unary(norm, trt.UnaryOperation.RECIP).get_output(0)
+    normalized = network.add_elementwise(
+        inp_fp32, recip, trt.ElementWiseOperation.PROD).get_output(0)
+
+    # scale = sqrt(C) * gamma  (fp32 constant)
+    gamma_flat = gamma.flatten()[:num_channels]
+    scale = (np.sqrt(num_channels) * gamma_flat).reshape(1, num_channels, 1, 1, 1)
+    scale_t = graph_ops.add_constant(
+        network, (1, num_channels, 1, 1, 1), scale, dtype=np.float32)
+    result_fp32 = network.add_elementwise(
+        normalized, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
+
+    return _to_bf16(network, result_fp32)
+
+
+def _bf16_silu(
+    network: "trt.INetworkDefinition", inp: "trt.ITensor"
+) -> "trt.ITensor":
+    """SiLU/Swish on a bf16 tensor: ``x * sigmoid(x)``.
+
+    Activations and elementwise products preserve input dtype in
+    STRONGLY_TYPED networks, so this stays in bf16 end-to-end.
+    """
+    sig = network.add_activation(inp, trt.ActivationType.SIGMOID).get_output(0)
+    return network.add_elementwise(
+        inp, sig, trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def _bf16_vae_resblock_3d(
+    network: "trt.INetworkDefinition",
+    inp: "trt.ITensor",
+    cache_in1: "trt.ITensor",
+    cache_in2: "trt.ITensor",
+    *,
+    weights: Mapping[str, np.ndarray],
+    prefix: str,
+    in_channels: int,
+    out_channels: int,
+    eps: float,
+) -> "trt.ITensor":
+    """3D VAE residual block running in bf16.
+
+    Norm -> SiLU -> CausalConv3d(3,3,3) -> Norm -> SiLU -> CausalConv3d(3,3,3) + shortcut.
+    Norms cast to fp32 internally for the variance reduction.
+    """
+    g1 = weights[f"{prefix}.norm1.gamma"]
+    h = _bf16_l2_channel_norm(network, inp, in_channels, g1, eps)
+    h = _bf16_silu(network, h)
+    h = _bf16_causal_conv3d(
+        network, h, cache_in1,
+        weight=weights[f"{prefix}.conv1.weight"],
+        bias=weights.get(f"{prefix}.conv1.bias"),
+        out_channels=out_channels,
+        kernel_size=(3, 3, 3),
+        padding_hw=(1, 1),
+    )
+
+    g2 = weights[f"{prefix}.norm2.gamma"]
+    h = _bf16_l2_channel_norm(network, h, out_channels, g2, eps)
+    h = _bf16_silu(network, h)
+    h = _bf16_causal_conv3d(
+        network, h, cache_in2,
+        weight=weights[f"{prefix}.conv2.weight"],
+        bias=weights.get(f"{prefix}.conv2.bias"),
+        out_channels=out_channels,
+        kernel_size=(3, 3, 3),
+        padding_hw=(1, 1),
+    )
+
+    if in_channels != out_channels:
+        shortcut = _bf16_conv3d_as_conv2d(
+            network, inp,
+            weight=weights[f"{prefix}.conv_shortcut.weight"],
+            bias=weights.get(f"{prefix}.conv_shortcut.bias"),
+            out_channels=out_channels,
+            kernel_size=(1, 1, 1),
+        )
+    else:
+        shortcut = inp
+
+    return network.add_elementwise(
+        h, shortcut, trt.ElementWiseOperation.SUM).get_output(0)
+
+
+def _bf16_vae_spatial_attention(
+    network: "trt.INetworkDefinition",
+    inp: "trt.ITensor",
+    *,
+    weights: Mapping[str, np.ndarray],
+    prefix: str,
+    channels: int,
+    eps: float,
+) -> "trt.ITensor":
+    """Single-head spatial self-attention over [B, C, T, H, W] in bf16.
+
+    Mirrors ``graph_blocks.add_vae_spatial_attention(norm_type=l2_channel_norm)``
+    but with bf16 conv/matmul weights. Norm reductions cast to fp32; the
+    softmax/IAttention runs natively on bf16 Q/K/V.
+    """
+    b, c, t, h, w = inp.shape
+    bt = b * t
+    hw = h * w
+    identity = inp
+
+    normed = _bf16_l2_channel_norm(
+        network, inp, channels, weights[f"{prefix}.norm.gamma"], eps)
+
+    # QKV projection: 1x1 conv per spatial position, applied per (B*T) frame.
+    # The to_qkv weight on disk is [3C, C, 1, 1] (HF Conv2d).
+    qkv_w = weights[f"{prefix}.to_qkv.weight"]
+    if qkv_w.ndim == 4:
+        qkv_w_5d = qkv_w.reshape(3 * c, c, 1, qkv_w.shape[2], qkv_w.shape[3])
+    else:
+        qkv_w_5d = qkv_w.reshape(3 * c, c, 1, 1, 1)
+    qkv = _bf16_conv3d_as_conv2d(
+        network, normed,
+        weight=qkv_w_5d,
+        bias=weights.get(f"{prefix}.to_qkv.bias"),
+        out_channels=3 * c,
+        kernel_size=(1, 1, 1),
+    )
+    # qkv: [B, 3C, T, H, W] -> [BT, HW, 3C]
+    qkv_flat = network.add_shuffle(qkv)
+    qkv_flat.first_transpose = trt.Permutation([0, 2, 3, 4, 1])  # [B,T,H,W,3C]
+    qkv_flat.reshape_dims = (bt, hw, 3 * c)
+
+    q_slice = network.add_slice(
+        qkv_flat.get_output(0),
+        start=(0, 0, 0), shape=(bt, hw, c), stride=(1, 1, 1)).get_output(0)
+    k_slice = network.add_slice(
+        qkv_flat.get_output(0),
+        start=(0, 0, c), shape=(bt, hw, c), stride=(1, 1, 1)).get_output(0)
+    v_slice = network.add_slice(
+        qkv_flat.get_output(0),
+        start=(0, 0, 2 * c), shape=(bt, hw, c), stride=(1, 1, 1)).get_output(0)
+
+    q_4d = network.add_shuffle(q_slice)
+    q_4d.reshape_dims = (bt, 1, hw, c)
+    k_4d = network.add_shuffle(k_slice)
+    k_4d.reshape_dims = (bt, 1, hw, c)
+    v_4d = network.add_shuffle(v_slice)
+    v_4d.reshape_dims = (bt, 1, hw, c)
+
+    attn_scale = 1.0 / np.sqrt(max(c, 1))
+    ctx = graph_ops.add_attention_core(
+        network,
+        q_4d.get_output(0),
+        k_4d.get_output(0),
+        v_4d.get_output(0),
+        scale=float(attn_scale),
+    )  # [BT, 1, HW, C]
+
+    # Back to [B, C, T, H, W]
+    ctx_5d = network.add_shuffle(ctx)
+    ctx_5d.reshape_dims = (b, t, h, w, c)
+    ctx_5d.second_transpose = trt.Permutation([0, 4, 1, 2, 3])
+
+    # Output projection: 1x1 conv. proj.weight on disk is [C, C, 1, 1].
+    proj_w = weights[f"{prefix}.proj.weight"]
+    if proj_w.ndim == 4:
+        proj_w_5d = proj_w.reshape(c, c, 1, proj_w.shape[2], proj_w.shape[3])
+    else:
+        proj_w_5d = proj_w.reshape(c, c, 1, 1, 1)
+    out = _bf16_conv3d_as_conv2d(
+        network, ctx_5d.get_output(0),
+        weight=proj_w_5d,
+        bias=weights.get(f"{prefix}.proj.bias"),
+        out_channels=c,
+        kernel_size=(1, 1, 1),
+    )
+
+    return network.add_elementwise(
+        out, identity, trt.ElementWiseOperation.SUM).get_output(0)
+
+
+def _zero_cache_constant(
+    network: "trt.INetworkDefinition",
+    *,
+    batch: int,
+    channels: int,
+    h: int,
+    w: int,
+    t_cache: int = 2,
+) -> "trt.ITensor":
+    """Bf16 zero cache tensor for an image-mode causal conv.
+
+    Shape: [B, C, t_cache, H, W]. With zeros the causal conv produces
+    left-zero-padded output, exactly matching HF's first-frame behaviour
+    where ``cache_x is None``.
+    """
+    shape = (batch, channels, t_cache, h, w)
+    zeros = np.zeros(shape, dtype=np.float32)
+    layer = network.add_constant(shape, _bf16_weights(zeros))
+    return layer.get_output(0)
+
+
+def _make_unnorm_constants(
+    cfg: QwenImageVAEConfig,
+    z_dim: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Reshape latents_mean / latents_std into [1, z_dim, 1, 1, 1] for broadcast."""
+    mean = np.asarray(cfg.latents_mean, dtype=np.float32)
+    std = np.asarray(cfg.latents_std, dtype=np.float32)
+    if mean.shape != (z_dim,) or std.shape != (z_dim,):
+        raise ValueError(
+            f"latents_mean/std length {mean.shape}/{std.shape} mismatch z_dim={z_dim}"
+        )
+    return (
+        mean.reshape(1, z_dim, 1, 1, 1),
+        std.reshape(1, z_dim, 1, 1, 1),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+def build_qwen_image_vae_decoder_engine(
+    cfg: QwenImageVAEConfig,
+    weights: Mapping[str, "np.ndarray"],
+    out_path: Path | str,
+    *,
+    h_lat: int = 32,
+    w_lat: int = 32,
+    apply_latent_unnorm: bool = False,
+    verbose: bool = False,
+) -> Path:
+    """Build the Qwen-Image VAE decoder TRT engine and serialise the plan.
+
+    Args:
+        cfg: Architecture configuration.
+        weights: Mapping of HF-style decoder weight names. Required keys
+            (using ``decoder.`` prefix as in diffusers checkpoints):
+              - ``post_quant_conv.weight``                 [z, z, 1, 1, 1]
+              - ``post_quant_conv.bias``                   [z]
+              - ``decoder.conv_in.weight``                 [base*dim_mult[-1], z, 3, 3, 3]
+              - ``decoder.conv_in.bias``                   [base*dim_mult[-1]]
+              - mid-block ResBlock pairs (resnets.0/1) with norm{1,2}.gamma,
+                conv{1,2}.weight/.bias, and optional conv_shortcut for
+                channel-mismatched resnets.
+              - mid-block attention (attentions.0) with norm.gamma,
+                to_qkv.weight/.bias, proj.weight/.bias.
+              - up_blocks for each level: (num_res_blocks+1) ResBlocks and
+                upsamplers.0.resample.1.weight/.bias (spatial conv) and
+                upsamplers.0.time_conv.weight/.bias (temporal conv -- LOADED
+                but UNUSED in image mode).
+              - ``decoder.norm_out.gamma``                 [out_ch, 1, 1, 1]
+              - ``decoder.conv_out.weight``                [3, last_ch, 3, 3, 3]
+              - ``decoder.conv_out.bias``                  [3]
+        out_path: Where to write the serialised TRT plan.
+        h_lat, w_lat: Latent spatial dims (B is fixed to 1). Output will be
+            ``[1, 3, 1, h_lat*8, w_lat*8]``.
+        apply_latent_unnorm: If True, the engine receives the *normalised*
+            latent (post-DiT) and applies ``z * std + mean`` internally. If
+            False (default), the engine consumes a latent already in HF's
+            ``vae.decode`` input convention.
+        verbose: Enable TRT verbose logging.
+
+    Returns:
+        Resolved ``Path`` to the written plan file.
+    """
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if cfg.input_channels != 3:
+        raise ValueError(
+            "Qwen-Image VAE only supports input_channels=3 (RGB output)"
+        )
+
+    # Reset the bf16 anchor list for this build so we never accidentally
+    # keep references to buffers from a previous build alive.
+    _BF16_WEIGHT_REFS.clear()
+
+    z_dim = cfg.z_dim
+    base = cfg.base_dim
+    dim_mult = list(cfg.dim_mult)
+    num_levels = len(dim_mult)
+    num_res = cfg.num_res_blocks
+
+    channels_list = [base * m for m in dim_mult]  # encoder order
+    dec_channels = list(reversed(channels_list))  # decoder iteration order
+    mid_ch = dec_channels[0]
+
+    def take(name: str) -> np.ndarray:
+        if name not in weights:
+            raise KeyError(f"missing required weight: {name!r}")
+        return _as_numpy(weights[name], name=name)
+
+    # ---- Build TRT network. -----
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+    )
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 4 << 30)
+    config.clear_flag(trt.BuilderFlag.TF32)
+
+    # All internal tensor shapes use [B, C, T, H, W]; B=1, T=1 throughout.
+    batch = 1
+    cur_h, cur_w = h_lat, w_lat
+
+    # ---- Input (fp32) and optional un-normalisation in fp32 ---
+    # The un-norm scalars are small enough (z_dim=16) that fp32 cost is
+    # negligible, and doing the multiply/add in fp32 protects against bf16
+    # rounding of the latents_mean/std vectors which carry meaningful
+    # precision (e.g. -0.7571 vs -0.7578 in bf16).
+    latent_fp32 = network.add_input(
+        "latent", trt.float32, (batch, z_dim, 1, h_lat, w_lat)
+    )
+
+    x_fp32 = latent_fp32
+    if apply_latent_unnorm:
+        mean_arr, std_arr = _make_unnorm_constants(cfg, z_dim)
+        std_const = graph_ops.add_constant(
+            network, std_arr.shape, std_arr, dtype=np.float32)
+        mean_const = graph_ops.add_constant(
+            network, mean_arr.shape, mean_arr, dtype=np.float32)
+        scaled = network.add_elementwise(
+            x_fp32, std_const, trt.ElementWiseOperation.PROD).get_output(0)
+        x_fp32 = network.add_elementwise(
+            scaled, mean_const, trt.ElementWiseOperation.SUM).get_output(0)
+
+    # Cast to bf16 for the rest of the network.
+    x = _to_bf16(network, x_fp32)
+
+    # ---- post_quant_conv (1x1x1 Conv3D, z_dim -> z_dim) ---
+    x = _bf16_conv3d_as_conv2d(
+        network, x,
+        weight=take("post_quant_conv.weight"),
+        bias=take("post_quant_conv.bias"),
+        out_channels=z_dim,
+        kernel_size=(1, 1, 1),
+    )
+
+    # ---- conv_in (CausalConv3d, z_dim -> mid_ch, k=(3,3,3)) ---
+    ci_cache = _zero_cache_constant(
+        network, batch=batch, channels=z_dim, h=cur_h, w=cur_w)
+    x = _bf16_causal_conv3d(
+        network, x, ci_cache,
+        weight=take("decoder.conv_in.weight"),
+        bias=take("decoder.conv_in.bias"),
+        out_channels=mid_ch,
+        kernel_size=(3, 3, 3),
+        padding_hw=(1, 1),
+    )
+    cur_ch = mid_ch
+    if verbose:
+        print(f"[qwen-image-vae] conv_in: ch={cur_ch}, {cur_h}x{cur_w}",
+              file=sys.stderr)
+
+    # ---- mid_block: resnet.0 -> attention -> resnet.1 ---
+    for mi in range(2):
+        prefix = f"decoder.mid_block.resnets.{mi}"
+        c1 = _zero_cache_constant(
+            network, batch=batch, channels=mid_ch, h=cur_h, w=cur_w)
+        c2 = _zero_cache_constant(
+            network, batch=batch, channels=mid_ch, h=cur_h, w=cur_w)
+        rb_weights = _gather_resblock_weights(weights, prefix, mid_ch, mid_ch)
+        x = _bf16_vae_resblock_3d(
+            network, x, c1, c2,
+            weights=rb_weights, prefix=prefix,
+            in_channels=mid_ch, out_channels=mid_ch,
+            eps=cfg.norm_eps,
+        )
+        if mi == 0:
+            attn_weights = _gather_attention_weights(
+                weights, "decoder.mid_block.attentions.0", mid_ch)
+            x = _bf16_vae_spatial_attention(
+                network, x,
+                weights=attn_weights,
+                prefix="decoder.mid_block.attentions.0",
+                channels=mid_ch,
+                eps=cfg.norm_eps,
+            )
+    if verbose:
+        print(f"[qwen-image-vae] mid done: ch={cur_ch}, {cur_h}x{cur_w}",
+              file=sys.stderr)
+
+    # ---- up_blocks ---
+    prev_ch = mid_ch
+    for level in range(num_levels):
+        out_ch = dec_channels[level]
+        has_spatial = level < num_levels - 1
+        # Image mode: time_conv is SKIPPED inside HF (Rep path); weights are
+        # required to exist on disk but the graph never references them.
+
+        # 3 resnets per block (num_res_blocks + 1)
+        for blk in range(num_res + 1):
+            prefix = f"decoder.up_blocks.{level}.resnets.{blk}"
+            in_ch = prev_ch if blk == 0 else out_ch
+            c1 = _zero_cache_constant(
+                network, batch=batch, channels=in_ch, h=cur_h, w=cur_w)
+            c2 = _zero_cache_constant(
+                network, batch=batch, channels=out_ch, h=cur_h, w=cur_w)
+            rb_weights = _gather_resblock_weights(
+                weights, prefix, in_ch, out_ch)
+            x = _bf16_vae_resblock_3d(
+                network, x, c1, c2,
+                weights=rb_weights, prefix=prefix,
+                in_channels=in_ch, out_channels=out_ch,
+                eps=cfg.norm_eps,
+            )
+            prev_ch = out_ch
+        cur_ch = out_ch
+
+        if verbose:
+            print(
+                f"[qwen-image-vae] up{level}: ch={out_ch}, {cur_h}x{cur_w}",
+                file=sys.stderr,
+            )
+
+        # Spatial upsample (HF QwenImageResample.resample = Upsample(2x) +
+        # Conv2d(C, C//2 or same, 3, padding=1)). The conv changes channels.
+        if has_spatial:
+            sp_prefix = (
+                f"decoder.up_blocks.{level}.upsamplers.0.resample.1"
+            )
+            sp_w = take(f"{sp_prefix}.weight")
+            sp_b = take(f"{sp_prefix}.bias")
+            # Weight shape from diffusers Conv2d is [C_out, C_in, 3, 3];
+            # the bf16 spatial-upsample helper expects [C_out, C_in, 1, 3, 3].
+            if sp_w.ndim == 4:
+                sp_w = sp_w.reshape(
+                    sp_w.shape[0], sp_w.shape[1], 1, sp_w.shape[2], sp_w.shape[3]
+                )
+            x = _bf16_spatial_upsample_with_conv(
+                network, x,
+                weight=sp_w, bias=sp_b, scale=2,
+            )
+            prev_ch = sp_w.shape[0]
+            cur_h *= 2
+            cur_w *= 2
+            cur_ch = prev_ch
+            if verbose:
+                print(
+                    f"[qwen-image-vae]   spatial 2x -> ch={prev_ch}, "
+                    f"{cur_h}x{cur_w}",
+                    file=sys.stderr,
+                )
+
+    # ---- norm_out (L2 channel norm) + SiLU (bf16 IO, fp32 reduction) ---
+    x = _bf16_l2_channel_norm(
+        network, x, cur_ch, take("decoder.norm_out.gamma"), cfg.norm_eps)
+    x = _bf16_silu(network, x)
+
+    # ---- conv_out (CausalConv3d, cur_ch -> 3, k=(3,3,3)) ---
+    co_cache = _zero_cache_constant(
+        network, batch=batch, channels=cur_ch, h=cur_h, w=cur_w)
+    x = _bf16_causal_conv3d(
+        network, x, co_cache,
+        weight=take("decoder.conv_out.weight"),
+        bias=take("decoder.conv_out.bias"),
+        out_channels=3,
+        kernel_size=(3, 3, 3),
+        padding_hw=(1, 1),
+    )
+
+    # ---- Cast back to fp32 before clamp + output ---
+    x = _to_fp32(network, x)
+
+    lo_const = graph_ops.add_constant(
+        network, (1, 1, 1, 1, 1),
+        np.array([-1.0], dtype=np.float32),
+        dtype=np.float32,
+    )
+    hi_const = graph_ops.add_constant(
+        network, (1, 1, 1, 1, 1),
+        np.array([1.0], dtype=np.float32),
+        dtype=np.float32,
+    )
+    x = network.add_elementwise(
+        x, lo_const, trt.ElementWiseOperation.MAX).get_output(0)
+    x = network.add_elementwise(
+        x, hi_const, trt.ElementWiseOperation.MIN).get_output(0)
+
+    # Mark output (fp32).
+    x.name = "image"
+    network.mark_output(x)
+
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError("TRT engine serialisation failed for Qwen-Image VAE")
+
+    with open(out_path, "wb") as f:
+        f.write(bytes(plan))
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Weight gathering helpers (subset selection for graph_blocks helpers)
+# ---------------------------------------------------------------------------
+
+def _gather_resblock_weights(
+    weights: Mapping[str, "np.ndarray"],
+    prefix: str,
+    in_channels: int,
+    out_channels: int,
+) -> dict[str, np.ndarray]:
+    """Pull the resblock keys out of the full weight dict.
+
+    Returns a small dict containing the keys ``_bf16_vae_resblock_3d`` needs.
+    """
+    out: dict[str, np.ndarray] = {}
+    keys = [
+        f"{prefix}.norm1.gamma",
+        f"{prefix}.norm2.gamma",
+        f"{prefix}.conv1.weight",
+        f"{prefix}.conv1.bias",
+        f"{prefix}.conv2.weight",
+        f"{prefix}.conv2.bias",
+    ]
+    for k in keys:
+        if k not in weights:
+            raise KeyError(f"missing required weight: {k!r}")
+        out[k] = _as_numpy(weights[k], name=k)
+    if in_channels != out_channels:
+        sc_key = f"{prefix}.conv_shortcut"
+        out[f"{sc_key}.weight"] = _as_numpy(
+            weights[f"{sc_key}.weight"], name=f"{sc_key}.weight"
+        )
+        if f"{sc_key}.bias" in weights:
+            out[f"{sc_key}.bias"] = _as_numpy(
+                weights[f"{sc_key}.bias"], name=f"{sc_key}.bias"
+            )
+    return out
+
+
+def _gather_attention_weights(
+    weights: Mapping[str, "np.ndarray"],
+    prefix: str,
+    channels: int,
+) -> dict[str, np.ndarray]:
+    out: dict[str, np.ndarray] = {}
+    keys = [
+        f"{prefix}.norm.gamma",
+        f"{prefix}.to_qkv.weight",
+        f"{prefix}.to_qkv.bias",
+        f"{prefix}.proj.weight",
+        f"{prefix}.proj.bias",
+    ]
+    for k in keys:
+        if k not in weights:
+            raise KeyError(f"missing required weight: {k!r}")
+        out[k] = _as_numpy(weights[k], name=k)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Real-weight loader
+# ---------------------------------------------------------------------------
+
+def load_qwen_image_vae_weights(
+    vae_dir: "str | Path",
+) -> tuple[QwenImageVAEConfig, dict[str, np.ndarray]]:
+    """Load Qwen-Image VAE config + decoder weights from a diffusers VAE dir.
+
+    Reads ``vae_dir/config.json`` (HF VAE config) and the ``*.safetensors``
+    files; returns the parsed ``QwenImageVAEConfig`` and a dict of decoder
+    weights (encoder keys are filtered out).
+    """
+    vae_dir = Path(vae_dir)
+    config_path = vae_dir / "config.json"
+    with open(config_path, "r") as f:
+        raw = json.load(f)
+
+    # HF uses 'temperal_downsample' (sic) -- accept both spellings.
+    temp_ds = raw.get("temperal_downsample") or raw.get("temporal_downsample")
+    if temp_ds is None:
+        temp_ds = [False, True, True]
+
+    cfg = QwenImageVAEConfig(
+        z_dim=int(raw.get("z_dim", 16)),
+        base_dim=int(raw.get("base_dim", 96)),
+        dim_mult=list(raw.get("dim_mult", [1, 2, 4, 4])),
+        num_res_blocks=int(raw.get("num_res_blocks", 2)),
+        temporal_downsample=list(temp_ds),
+        input_channels=int(raw.get("input_channels", 3)),
+        latents_mean=list(raw.get("latents_mean", [])) or QwenImageVAEConfig().latents_mean,
+        latents_std=list(raw.get("latents_std", [])) or QwenImageVAEConfig().latents_std,
+    )
+
+    # Pull only the decoder weights + post_quant_conv. We open via the torch
+    # framework because Qwen-Image VAE checkpoints store bf16 weights and
+    # numpy has no bf16 dtype; torch handles the conversion.
+    weights: dict[str, np.ndarray] = {}
+    try:
+        from safetensors import safe_open
+    except ImportError as exc:
+        raise ImportError(
+            "safetensors is required to load HF VAE weights"
+        ) from exc
+    try:
+        import torch
+    except ImportError as exc:
+        raise ImportError(
+            "torch is required to load Qwen-Image VAE weights (bf16 dtype)"
+        ) from exc
+
+    st_files = sorted(vae_dir.glob("*.safetensors"))
+    if not st_files:
+        raise FileNotFoundError(
+            f"no *.safetensors under {vae_dir!r}"
+        )
+    for st_path in st_files:
+        with safe_open(str(st_path), framework="pt") as st:
+            for k in st.keys():
+                if not (
+                    k.startswith("decoder.") or k.startswith("post_quant_conv.")
+                ):
+                    continue
+                t = st.get_tensor(k)
+                weights[k] = t.detach().to(torch.float32).cpu().numpy()
+    if not weights:
+        raise RuntimeError(
+            f"no decoder weights found under {vae_dir!r}"
+        )
+    return cfg, weights
+
+
+__all__ = [
+    "QwenImageVAEConfig",
+    "build_qwen_image_vae_decoder_engine",
+    "load_qwen_image_vae_weights",
+]

--- a/tests/builder/conftest.py
+++ b/tests/builder/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import struct
 import sys
 from pathlib import Path
 
@@ -12,6 +14,32 @@ import pytest
 _PKG_ROOT = Path(__file__).resolve().parents[2] / "tensorrt_model_connect"
 if str(_PKG_ROOT) not in sys.path:
     sys.path.insert(0, str(_PKG_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Bundle round-trip helper (shared across bundle_writer / schema tests)
+# ---------------------------------------------------------------------------
+
+def read_trtfb_bundle(path: str | Path) -> tuple[dict, dict[str, bytes]]:
+    """Parse a .trtfb file into (header_dict, sections_data).
+
+    Verifies BUNDLE_MAGIC, reads the JSON header, then seeks to each
+    section payload by offset/size. Used by tests that need to inspect
+    bundle contents without depending on a C++ reader.
+    """
+    from tensorrt_model_connect.bundle_writer import BUNDLE_MAGIC
+
+    with open(path, "rb") as f:
+        magic = f.read(8)
+        assert magic == BUNDLE_MAGIC, f"bad magic: {magic!r}"
+        header_len = struct.unpack("<Q", f.read(8))[0]
+        header = json.loads(f.read(header_len).decode("utf-8"))
+        data_start = 16 + header_len
+        sections_data: dict[str, bytes] = {}
+        for name, meta in header.get("sections", {}).items():
+            f.seek(data_start + meta["offset"])
+            sections_data[name] = f.read(meta["size"])
+    return header, sections_data
 
 
 # ---------------------------------------------------------------------------

--- a/tests/builder/test_bundle_writer.py
+++ b/tests/builder/test_bundle_writer.py
@@ -24,6 +24,8 @@ from tensorrt_model_connect.bundle_writer import (
     write_bundle,
 )
 
+from tests.builder.conftest import read_trtfb_bundle
+
 
 class TestBundleMagic:
     def test_magic_bytes(self):
@@ -33,20 +35,7 @@ class TestBundleMagic:
 
 class TestWriteBundle:
     def _read_bundle(self, path: str) -> tuple[dict, dict[str, bytes]]:
-        """Read a .trtfb bundle and return (header_dict, sections_data)."""
-        with open(path, "rb") as f:
-            magic = f.read(8)
-            assert magic == BUNDLE_MAGIC
-            header_len = struct.unpack("<Q", f.read(8))[0]
-            header = json.loads(f.read(header_len).decode("utf-8"))
-
-            sections_data = {}
-            data_start = 16 + header_len
-            for name, meta in header.get("sections", {}).items():
-                f.seek(data_start + meta["offset"])
-                sections_data[name] = f.read(meta["size"])
-
-        return header, sections_data
+        return read_trtfb_bundle(path)
 
     def test_single_section(self, tmp_path):
         info = BundleInfo(

--- a/tests/builder/test_families.py
+++ b/tests/builder/test_families.py
@@ -367,6 +367,10 @@ _POSITIVE_MATCH_CASES = [
     ("flux.2", "flux"),
     # Z-Image (diffusion T2I)
     ("z_image", "z_image"),
+    # Qwen-Image (diffusion T2I/Edit)
+    ("qwen_image", "qwen_image"),
+    ("qwen-image", "qwen_image"),
+    ("qwen_image_edit", "qwen_image"),
     # PixArt (diffusion T2I)
     ("pixart", "pixart"),
     ("pixart_sigma", "pixart"),

--- a/tests/cpp/test_image_reader.cpp
+++ b/tests/cpp/test_image_reader.cpp
@@ -4,10 +4,13 @@
 // Trace ID:       UT-IO-CPP-01
 // Architecture:   ARCH-MULTI-001
 // Unit Design:    UD-IO-01
-// Intent:         read_image: valid BMP load, pixel normalisation, failure paths
-// Preconditions:  Writable temp directory; stb_image compiled into trtmc_core
-// Postconditions: Pixel values are normalised to [0,1]; empty result returned
-//                 on decode failure or missing file
+// Intent:         read_image: valid BMP load, pixel normalisation, failure
+//                 paths. save_png: round-trip, clamping, size validation.
+// Preconditions:  Writable temp directory; stb_image + stb_image_write
+//                 compiled into trtmc_core.
+// Postconditions: Pixel values are normalised to [0,1] on read; saved PNG
+//                 round-trips back to within quantisation tolerance; out-of-
+//                 range pixels are clamped on save; size mismatches throw.
 // =============================================================================
 
 // test_image_reader.cpp — Unit tests for src/utils/image_reader.cpp
@@ -26,8 +29,8 @@
 //   - test_helpers.h   : TempDirGuard
 //   No TRT, GPU, or CUDA required.
 
-#include "trtmc/trtmc_io.hpp"
 #include "test_helpers.h"
+#include "trtmc/trtmc_io.hpp"
 
 #include <cmath>
 #include <cstdint>
@@ -39,10 +42,8 @@
 
 static int failures = 0;
 
-static void check(bool condition, const char* test_name)
-{
-    if (!condition)
-    {
+static void check(bool condition, const char* test_name) {
+    if (!condition) {
         std::cerr << "FAIL: " << test_name << '\n';
         ++failures;
     }
@@ -53,48 +54,50 @@ static void check(bool condition, const char* test_name)
 // ---------------------------------------------------------------------------
 // BMP stores pixels in BGR order, bottom-up. stb_image converts to RGB top-down.
 // For a 2x1 image (height=1) row order is irrelevant.
-static void write_bmp_2x1(const std::string& path,
-                           uint8_t r0, uint8_t g0, uint8_t b0,
-                           uint8_t r1, uint8_t g1, uint8_t b1)
-{
+static void write_bmp_2x1(const std::string& path, uint8_t r0, uint8_t g0, uint8_t b0, uint8_t r1,
+                          uint8_t g1, uint8_t b1) {
     // 2 pixels × 3 bytes = 6 bytes; already 4-byte aligned — no row padding.
-    const uint32_t pixel_offset = 54;  // 14-byte file header + 40-byte DIB header
-    const uint32_t data_size    = 6;
-    const uint32_t file_size    = pixel_offset + data_size;
-    const int32_t  width        = 2;
-    const int32_t  height       = 1;
+    const uint32_t pixel_offset = 54; // 14-byte file header + 40-byte DIB header
+    const uint32_t data_size = 6;
+    const uint32_t file_size = pixel_offset + data_size;
+    const int32_t width = 2;
+    const int32_t height = 1;
 
     std::ofstream f(path, std::ios::binary);
 
     // ── BMP file header (14 bytes) ────────────────────────────────────────
     f.write("BM", 2);
-    f.write(reinterpret_cast<const char*>(&file_size),    4);
+    f.write(reinterpret_cast<const char*>(&file_size), 4);
     const uint32_t reserved = 0;
-    f.write(reinterpret_cast<const char*>(&reserved),     4);
+    f.write(reinterpret_cast<const char*>(&reserved), 4);
     f.write(reinterpret_cast<const char*>(&pixel_offset), 4);
 
     // ── BITMAPINFOHEADER (40 bytes) ───────────────────────────────────────
-    const uint32_t dib_size    = 40;
-    const uint16_t planes      = 1;
-    const uint16_t bpp         = 24;
+    const uint32_t dib_size = 40;
+    const uint16_t planes = 1;
+    const uint16_t bpp = 24;
     const uint32_t compression = 0;
-    const uint32_t zero32      = 0;
+    const uint32_t zero32 = 0;
 
-    f.write(reinterpret_cast<const char*>(&dib_size),    4);
-    f.write(reinterpret_cast<const char*>(&width),       4);
-    f.write(reinterpret_cast<const char*>(&height),      4);
-    f.write(reinterpret_cast<const char*>(&planes),      2);
-    f.write(reinterpret_cast<const char*>(&bpp),         2);
+    f.write(reinterpret_cast<const char*>(&dib_size), 4);
+    f.write(reinterpret_cast<const char*>(&width), 4);
+    f.write(reinterpret_cast<const char*>(&height), 4);
+    f.write(reinterpret_cast<const char*>(&planes), 2);
+    f.write(reinterpret_cast<const char*>(&bpp), 2);
     f.write(reinterpret_cast<const char*>(&compression), 4);
-    f.write(reinterpret_cast<const char*>(&data_size),   4);
-    f.write(reinterpret_cast<const char*>(&zero32),      4);  // x ppm
-    f.write(reinterpret_cast<const char*>(&zero32),      4);  // y ppm
-    f.write(reinterpret_cast<const char*>(&zero32),      4);  // clr_used
-    f.write(reinterpret_cast<const char*>(&zero32),      4);  // clr_important
+    f.write(reinterpret_cast<const char*>(&data_size), 4);
+    f.write(reinterpret_cast<const char*>(&zero32), 4); // x ppm
+    f.write(reinterpret_cast<const char*>(&zero32), 4); // y ppm
+    f.write(reinterpret_cast<const char*>(&zero32), 4); // clr_used
+    f.write(reinterpret_cast<const char*>(&zero32), 4); // clr_important
 
     // ── Pixel data: BGR order ─────────────────────────────────────────────
-    f.put(static_cast<char>(b0)); f.put(static_cast<char>(g0)); f.put(static_cast<char>(r0));
-    f.put(static_cast<char>(b1)); f.put(static_cast<char>(g1)); f.put(static_cast<char>(r1));
+    f.put(static_cast<char>(b0));
+    f.put(static_cast<char>(g0));
+    f.put(static_cast<char>(r0));
+    f.put(static_cast<char>(b1));
+    f.put(static_cast<char>(g1));
+    f.put(static_cast<char>(r1));
 }
 
 // ---------------------------------------------------------------------------
@@ -104,25 +107,22 @@ static void write_bmp_2x1(const std::string& path,
 // Intention: read_image loads a valid BMP and returns correct dimensions.
 // Preconditions:  write_bmp_2x1 produces a valid 2x1 24-bit BMP
 // Postconditions: LoadedImage has width=2, height=1, pixels.size()==6
-static bool test_read_image_dimensions()
-{
+static bool test_read_image_dimensions() {
     trtmc_test::TempDirGuard dir;
     const auto path = (std::filesystem::path(dir.path()) / "dims.bmp").string();
     write_bmp_2x1(path, 255, 0, 0, 0, 255, 0);
 
     const auto img = trtmc::io::read_image(path);
-    if (img.empty())
-    {
+    if (img.empty()) {
         std::cerr << "read_image_dimensions: returned empty\n";
         return false;
     }
-    if (img.width != 2 || img.height != 1)
-    {
-        std::cerr << "read_image_dimensions: expected 2x1 got "
-                  << img.width << "x" << img.height << '\n';
+    if (img.width != 2 || img.height != 1) {
+        std::cerr << "read_image_dimensions: expected 2x1 got " << img.width << "x" << img.height
+                  << '\n';
         return false;
     }
-    if (img.pixels.size() != 6)  // 2 pixels * 3 channels
+    if (img.pixels.size() != 6) // 2 pixels * 3 channels
     {
         std::cerr << "read_image_dimensions: pixel count " << img.pixels.size() << '\n';
         return false;
@@ -133,31 +133,28 @@ static bool test_read_image_dimensions()
 // Intention: read_image normalises uint8 pixel values to [0, 1].
 // Preconditions:  BMP pixel 0 = pure red (255, 0, 0)
 // Postconditions: pixels[0] ≈ 1.0, pixels[1] ≈ 0.0, pixels[2] ≈ 0.0
-static bool test_read_image_pixel_normalisation()
-{
+static bool test_read_image_pixel_normalisation() {
     trtmc_test::TempDirGuard dir;
     const auto path = (std::filesystem::path(dir.path()) / "norm.bmp").string();
     // Pixel 0 = red (R=255, G=0, B=0); Pixel 1 = green (R=0, G=255, B=0)
     write_bmp_2x1(path, 255, 0, 0, 0, 255, 0);
 
     const auto img = trtmc::io::read_image(path);
-    if (img.empty()) return false;
+    if (img.empty())
+        return false;
 
     // Pixel 0: R channel should be ~1.0
-    if (std::abs(img.pixels[0] - 1.0F) > 0.005F)
-    {
+    if (std::abs(img.pixels[0] - 1.0F) > 0.005F) {
         std::cerr << "pixel_normalisation: pixel[0].R = " << img.pixels[0] << '\n';
         return false;
     }
     // Pixel 0: G and B channels should be ~0.0
-    if (img.pixels[1] > 0.005F || img.pixels[2] > 0.005F)
-    {
+    if (img.pixels[1] > 0.005F || img.pixels[2] > 0.005F) {
         std::cerr << "pixel_normalisation: pixel[0].GB non-zero\n";
         return false;
     }
     // Pixel 1: G channel should be ~1.0
-    if (std::abs(img.pixels[4] - 1.0F) > 0.005F)
-    {
+    if (std::abs(img.pixels[4] - 1.0F) > 0.005F) {
         std::cerr << "pixel_normalisation: pixel[1].G = " << img.pixels[4] << '\n';
         return false;
     }
@@ -167,15 +164,14 @@ static bool test_read_image_pixel_normalisation()
 // Intention: read_image returns an empty LoadedImage for a nonexistent path.
 // Preconditions:  path does not exist
 // Postconditions: result.empty() == true, no exception thrown
-static bool test_read_image_missing_file_returns_empty()
-{
+static bool test_read_image_missing_file_returns_empty() {
     bool threw = false;
     trtmc::io::LoadedImage img;
-    try
-    {
+    try {
         img = trtmc::io::read_image("/nonexistent/path/to/image.bmp");
+    } catch (...) {
+        threw = true;
     }
-    catch (...) { threw = true; }
 
     // Either returns empty or throws — both are acceptable; we just must not crash.
     return img.empty() || threw;
@@ -185,8 +181,7 @@ static bool test_read_image_missing_file_returns_empty()
 //            is not a valid image (corrupt / truncated data).
 // Preconditions:  file exists but contains non-image bytes
 // Postconditions: result.empty() == true
-static bool test_read_image_invalid_content_returns_empty()
-{
+static bool test_read_image_invalid_content_returns_empty() {
     trtmc_test::TempDirGuard dir;
     const auto path = (std::filesystem::path(dir.path()) / "bad.bmp").string();
     {
@@ -195,11 +190,10 @@ static bool test_read_image_invalid_content_returns_empty()
     }
 
     trtmc::io::LoadedImage img;
-    try
-    {
+    try {
         img = trtmc::io::read_image(path);
+    } catch (...) {
     }
-    catch (...) {}
 
     return img.empty();
 }
@@ -208,8 +202,7 @@ static bool test_read_image_invalid_content_returns_empty()
 //            read_image and correctly fills h and w out-parameters.
 // Preconditions:  valid 2x1 BMP in temp dir
 // Postconditions: h==1, w==2, pixel vector size==6
-static bool test_decode_image_legacy_wrapper()
-{
+static bool test_decode_image_legacy_wrapper() {
     trtmc_test::TempDirGuard dir;
     const auto path = (std::filesystem::path(dir.path()) / "legacy.bmp").string();
     write_bmp_2x1(path, 128, 64, 32, 32, 64, 128);
@@ -220,8 +213,91 @@ static bool test_decode_image_legacy_wrapper()
     return h == 1 && w == 2 && pixels.size() == 6;
 }
 
-int main()
-{
+// Intention: save_png writes a PNG file whose contents round-trip through
+//            read_image with byte-accurate pixel values (after the unavoidable
+//            float→uint8 quantisation).
+// Preconditions: writable temp dir; stb_image_write linked into trtmc_core.
+// Postconditions: the file exists, is non-empty, and re-reads to the same
+//                 dimensions and pixel values.
+static bool test_save_png_roundtrip() {
+    trtmc_test::TempDirGuard dir;
+    const auto path = (std::filesystem::path(dir.path()) / "saved.png").string();
+
+    // 2x1 HWC float image: pixel 0 = (0, 0.5, 1.0), pixel 1 = (0.25, 0.75, 0.0)
+    const std::vector<float> pixels = {
+        0.0F, 0.5F, 1.0F, 0.25F, 0.75F, 0.0F,
+    };
+    try {
+        trtmc::io::save_png(path, pixels, /*width=*/2, /*height=*/1);
+    } catch (...) {
+        return false;
+    }
+
+    auto img = trtmc::io::read_image(path);
+    if (img.height != 1 || img.width != 2 || img.pixels.size() != 6)
+        return false;
+
+    // After uint8 quantisation: round(v*255+0.5) for each channel.
+    const std::vector<float> expected = {
+        0.0F / 255.0F,
+        static_cast<float>(128) / 255.0F,
+        255.0F / 255.0F,
+        static_cast<float>(64) / 255.0F,
+        static_cast<float>(191) / 255.0F,
+        0.0F / 255.0F,
+    };
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        if (std::abs(img.pixels[i] - expected[i]) > 1.5F / 255.0F)
+            return false;
+    }
+    return true;
+}
+
+// Intention: save_png clamps out-of-range pixel values to [0, 1] rather than
+//            wrapping (negative -> 0, >1 -> 255).
+// Preconditions: writable temp dir.
+// Postconditions: read back, negatives map to 0 and values >1 map to 255.
+static bool test_save_png_clamps_out_of_range() {
+    trtmc_test::TempDirGuard dir;
+    const auto path = (std::filesystem::path(dir.path()) / "clamp.png").string();
+
+    const std::vector<float> pixels = {
+        -1.0F,
+        2.0F,
+        0.5F,
+    };
+    try {
+        trtmc::io::save_png(path, pixels, /*width=*/1, /*height=*/1);
+    } catch (...) {
+        return false;
+    }
+
+    auto img = trtmc::io::read_image(path);
+    if (img.pixels.size() != 3)
+        return false;
+    return std::abs(img.pixels[0] - 0.0F) < 1e-3F && std::abs(img.pixels[1] - 1.0F) < 1e-3F &&
+           std::abs(img.pixels[2] - 128.0F / 255.0F) < 1.5F / 255.0F;
+}
+
+// Intention: save_png throws when the pixel buffer size doesn't match
+//            width*height*3.
+// Preconditions: writable temp dir.
+// Postconditions: std::runtime_error is thrown and no file is created.
+static bool test_save_png_rejects_size_mismatch() {
+    trtmc_test::TempDirGuard dir;
+    const auto path = (std::filesystem::path(dir.path()) / "mismatch.png").string();
+    const std::vector<float> too_small(5, 0.0F); // need 6 for 2x1x3
+    try {
+        trtmc::io::save_png(path, too_small, /*width=*/2, /*height=*/1);
+        return false; // expected throw
+    } catch (const std::runtime_error&) {
+        return !std::filesystem::exists(path);
+    } catch (...) {
+        return false;
+    }
+}
+
+int main() {
     bool all_passed = true;
     std::cout << "test_image_reader:" << std::endl;
 
@@ -231,14 +307,16 @@ int main()
         all_passed &= ok;
     };
 
-    run("read_image_dimensions",                 test_read_image_dimensions);
-    run("read_image_pixel_normalisation",        test_read_image_pixel_normalisation);
+    run("read_image_dimensions", test_read_image_dimensions);
+    run("read_image_pixel_normalisation", test_read_image_pixel_normalisation);
     run("read_image_missing_file_returns_empty", test_read_image_missing_file_returns_empty);
     run("read_image_invalid_content_returns_empty", test_read_image_invalid_content_returns_empty);
-    run("decode_image_legacy_wrapper",           test_decode_image_legacy_wrapper);
+    run("decode_image_legacy_wrapper", test_decode_image_legacy_wrapper);
+    run("save_png_roundtrip", test_save_png_roundtrip);
+    run("save_png_clamps_out_of_range", test_save_png_clamps_out_of_range);
+    run("save_png_rejects_size_mismatch", test_save_png_rejects_size_mismatch);
 
-    if (all_passed)
-    {
+    if (all_passed) {
         std::cout << "test_image_reader passed" << std::endl;
         return 0;
     }

--- a/tests/e2e/models/qwen-image-2512.json
+++ b/tests/e2e/models/qwen-image-2512.json
@@ -1,0 +1,37 @@
+{
+  "name": "qwen-image-2512",
+  "trace_id": "IT-E2E-QIMG-01",
+  "hf_id": "Qwen/Qwen-Image-2512",
+  "bundle": "qwen-image-2512.trtfb",
+  "model_type": "qwen_image",
+  "family": "qwen_image",
+  "runtime_strategy": "diffusion_qwen_image",
+  "task_strategy": "diffusion_media_generation",
+  "ci_tier": "nightly_only",
+  "description": "Qwen-Image-2512 text-to-image (Qwen2.5-VL text encoder + Qwen-Image DiT + VAE)",
+  "build_args": {
+    "max_cache_length": 256
+  },
+  "prompt": "A cat holding a sign that says hello world",
+  "negative_prompt": " ",
+  "test_type": "diffusion",
+  "image_height": 1024,
+  "image_width": 1024,
+  "height": 1024,
+  "width": 1024,
+  "video_num_frames": 1,
+  "num_inference_steps": 20,
+  "cfg_scale": 4.0,
+  "seed": 42,
+  "min_pixel_mean": 0.15,
+  "max_pixel_mean": 0.85,
+  "min_pixel_std": 0.05,
+  "skip_text_comparison": true,
+  "threshold_overrides": {
+    "psnr": 11.0,
+    "min_pixel_mean": 0.15,
+    "max_pixel_mean": 0.85,
+    "min_pixel_std": 0.05
+  },
+  "notes": "Qwen-Image-2512 E2E gate. Empirical PSNR is ~12.45 dB for the bf16 C++ pipeline vs HF diffusers (also bf16) with shared initial latents at 20 steps; gate set 1.5 dB below as a regression catcher. An earlier ~12.7 dB measurement was on fp32 engines; the small drop (0.25 dB) is the bf16 cost on this prompt — invisible visually. Apples-to-apples Python TRT runner on the same prompt+latents lands at 11.94 dB, confirming the residual TRT-vs-PyTorch gap is engine-side (kernel rounding under bf16), not C++ host-side glue. Image quality is preserved."
+}

--- a/tests/e2e/models/qwen-image.json
+++ b/tests/e2e/models/qwen-image.json
@@ -1,0 +1,37 @@
+{
+  "name": "qwen-image",
+  "trace_id": "IT-E2E-QIMG-01",
+  "hf_id": "Qwen/Qwen-Image",
+  "bundle": "qwen-image.trtfb",
+  "model_type": "qwen_image",
+  "family": "qwen_image",
+  "runtime_strategy": "diffusion_qwen_image",
+  "task_strategy": "diffusion_media_generation",
+  "ci_tier": "nightly_only",
+  "description": "Qwen-Image base text-to-image (Qwen2.5-VL text encoder + Qwen-Image DiT + VAE)",
+  "build_args": {
+    "max_cache_length": 256
+  },
+  "prompt": "A cat holding a sign that says hello world",
+  "negative_prompt": " ",
+  "test_type": "diffusion",
+  "image_height": 1024,
+  "image_width": 1024,
+  "height": 1024,
+  "width": 1024,
+  "video_num_frames": 1,
+  "num_inference_steps": 20,
+  "cfg_scale": 4.0,
+  "seed": 42,
+  "min_pixel_mean": 0.15,
+  "max_pixel_mean": 0.85,
+  "min_pixel_std": 0.05,
+  "skip_text_comparison": true,
+  "threshold_overrides": {
+    "psnr": 9.0,
+    "min_pixel_mean": 0.15,
+    "max_pixel_mean": 0.85,
+    "min_pixel_std": 0.05
+  },
+  "notes": "Qwen-Image base model E2E gate. Empirical PSNR is ~10.8 dB for the bf16 C++ pipeline vs HF diffusers (also bf16) with shared initial latents at 20 steps; gate set 1.5 dB below empirical as a regression catcher. Base model is less bf16-robust than Qwen-Image-2512 (which empirically hits ~12.45 dB) — Python TRT runner shows the same per-prompt divergence, confirming the gap is engine-side TRT-vs-PyTorch kernel rounding, not C++ host-side glue. Image quality is preserved: outputs are visually correct, prompt-faithful samples that simply land on a different (still valid) point in the denoising trajectory than HF's exact sample."
+}

--- a/tests/e2e_harness/contracts.py
+++ b/tests/e2e_harness/contracts.py
@@ -953,6 +953,7 @@ RUNTIME_TO_TASK_STRATEGY: Dict[str, str] = {
     "diffusion_ltx": "diffusion_media_generation",
     "diffusion_wan": "diffusion_media_generation",
     "diffusion_zimage": "diffusion_media_generation",
+    "diffusion_qwen_image": "diffusion_media_generation",
     "diffusion_pixart": "diffusion_media_generation",
     "torchtrt_diffusion": "torchtrt_diffusion",
     "diffusion_pixart_torchtrt": "diffusion_media_generation",

--- a/tests/e2e_harness/manifest_loader.py
+++ b/tests/e2e_harness/manifest_loader.py
@@ -378,6 +378,12 @@ def _build_inputs(manifest: dict) -> dict:
         inputs["image_height"] = manifest["image_height"]
         inputs["image_width"] = manifest.get("image_width", manifest["image_height"])
 
+    # Qwen-Image (and other image-only diffusion) extras.
+    for key in ("negative_prompt", "cfg_scale", "height", "width",
+                "num_inference_steps"):
+        if key in manifest and key not in inputs:
+            inputs[key] = manifest[key]
+
     # Numeric tensor inputs for neural-operator / one-shot dense models
     for key in ("field_input", "branch_input", "trunk_input", "output_field"):
         if key in manifest:
@@ -467,6 +473,8 @@ def _build_metadata(manifest: dict) -> dict:
         "stages", "comparison_profile", "threshold_overrides", "determinism",
         "inputs", "metadata", "reference_family", "user_contract", "ci_lane",
         "execution_profiles", "temperature", "top_p", "top_k", "min_p", "seed",
+        "negative_prompt", "cfg_scale", "height", "width",
+        "image_height", "image_width",
     }
 
     meta = manifest.get("metadata", {}).copy()
@@ -528,6 +536,7 @@ _KNOWN_RUNTIME_STRATEGIES = frozenset({
     "diffusion_ltx",
     "diffusion_wan",
     "diffusion_zimage",
+    "diffusion_qwen_image",
     "diffusion_pixart",
     "torchtrt_diffusion",
     "diffusion_pixart_torchtrt",

--- a/tests/e2e_harness/orchestrator.py
+++ b/tests/e2e_harness/orchestrator.py
@@ -701,20 +701,56 @@ def _build_repro_commands(
                 if field_input is not None:
                     infer_parts.extend(["--field-input", _csv_arg(field_input)])
         elif task_strategy == "diffusion_media_generation":
-            infer_parts = [
-                ctx.binary_path, "generate-video", bundle_path,
-                "--prompt", _shell_quote(case.inputs.get("prompt", case.inputs.get("test_prompt", ""))),
-                "--output", "/tmp/trtmc_frames",
-                "--num-steps", str(case.inputs.get("num_inference_steps", 30)),
-            ]
-            guidance_scale = case.inputs.get("guidance_scale")
-            if guidance_scale is not None:
-                infer_parts.extend(["--guidance-scale", str(guidance_scale)])
-            if "seed" in case.inputs:
-                infer_parts.extend(["--seed", str(case.inputs["seed"])])
-            if case.family == "ltx_video" and ctx.artifacts_dir:
-                latent_path = Path(_case_artifact_dir(ctx.artifacts_dir, case.name)) / "initial_latents.raw"
-                infer_parts.extend(["--initial-latents-raw", str(latent_path)])
+            is_qwen_image = (
+                case.runtime_strategy == "diffusion_qwen_image"
+                or case.family == "qwen_image"
+            )
+            if is_qwen_image:
+                infer_parts = [
+                    ctx.binary_path, "run", bundle_path,
+                    "--prompt", _shell_quote(case.inputs.get("prompt", case.inputs.get("test_prompt", ""))),
+                    "--output", "/tmp/trtmc_qwen_image/output.png",
+                    "--num-inference-steps", str(case.inputs.get("num_inference_steps", 20)),
+                ]
+                negative_prompt = case.inputs.get("negative_prompt")
+                if negative_prompt is not None:
+                    infer_parts.extend(["--negative-prompt", _shell_quote(str(negative_prompt))])
+                cfg_scale = case.inputs.get("cfg_scale")
+                if cfg_scale is None:
+                    cfg_scale = case.inputs.get("guidance_scale")
+                if cfg_scale is not None:
+                    infer_parts.extend(["--cfg-scale", str(cfg_scale)])
+                height = case.inputs.get("height") or case.inputs.get("image_height")
+                if height is not None:
+                    infer_parts.extend(["--height", str(height)])
+                width = case.inputs.get("width") or case.inputs.get("image_width")
+                if width is not None:
+                    infer_parts.extend(["--width", str(width)])
+                if "seed" in case.inputs:
+                    infer_parts.extend(["--seed", str(case.inputs["seed"])])
+                # Shared-initial-latents path: the runner pre-computes the same
+                # raw bytes the HF reference will consume. Mirrors the LTX
+                # plumbing immediately below.
+                if ctx.artifacts_dir:
+                    qi_latent_path = Path(
+                        _case_artifact_dir(ctx.artifacts_dir, case.name)
+                    ) / "initial_latents.raw"
+                    infer_parts.extend(["--initial-latents-raw", str(qi_latent_path)])
+            else:
+                infer_parts = [
+                    ctx.binary_path, "generate-video", bundle_path,
+                    "--prompt", _shell_quote(case.inputs.get("prompt", case.inputs.get("test_prompt", ""))),
+                    "--output", "/tmp/trtmc_frames",
+                    "--num-steps", str(case.inputs.get("num_inference_steps", 30)),
+                ]
+                guidance_scale = case.inputs.get("guidance_scale")
+                if guidance_scale is not None:
+                    infer_parts.extend(["--guidance-scale", str(guidance_scale)])
+                if "seed" in case.inputs:
+                    infer_parts.extend(["--seed", str(case.inputs["seed"])])
+                if case.family == "ltx_video" and ctx.artifacts_dir:
+                    latent_path = Path(_case_artifact_dir(ctx.artifacts_dir, case.name)) / "initial_latents.raw"
+                    infer_parts.extend(["--initial-latents-raw", str(latent_path)])
         elif task_strategy == "prompted_segmentation":
             infer_parts = [
                 ctx.binary_path, "segment-sam", bundle_path,

--- a/tests/e2e_harness/references/hf_diffusers.py
+++ b/tests/e2e_harness/references/hf_diffusers.py
@@ -91,6 +91,19 @@ def _ltx_initial_latents_path(case: E2ECase, ctx: RunContext) -> str:
     return os.path.join(base_dir, "initial_latents.raw")
 
 
+def _qwen_image_initial_latents_path(case: E2ECase, ctx: RunContext) -> str:
+    """Mirror of the runner-side helper. Both subprocesses MUST point at the
+    same path; the runner writes the raw fp32 bytes, the HF reference reads
+    them back so both pipelines start from identical noise (E2E shared-latents
+    path, mirrors the LTX precedent)."""
+    if ctx.artifacts_dir:
+        base_dir = _case_artifact_dir(ctx.artifacts_dir, case.name)
+    else:
+        base_dir = os.path.join(
+            tempfile.gettempdir(), "trtmc_qwen_image_latents", case.name)
+    return os.path.join(base_dir, "initial_latents.raw")
+
+
 class HfDiffusersReference:
     """Reference backend using HuggingFace diffusers pipelines."""
 
@@ -322,6 +335,7 @@ print(f"mean={{float(t5_out.mean()):.6f}}")
         video_num_frames = case.inputs.get("video_num_frames", 17)
         python = ctx.reference_python_path() or sys.executable
         ltx_initial_latents_raw = _ltx_initial_latents_path(case, ctx)
+        qwen_image_initial_latents_raw = _qwen_image_initial_latents_path(case, ctx)
         model_type = str(case.metadata.get("model_type", "")).lower()
 
         # Save frames to artifacts_dir so they persist for comparator access
@@ -331,6 +345,18 @@ print(f"mean={{float(t5_out.mean()):.6f}}")
         os.makedirs(frames_dir, exist_ok=True)
 
         family = case.family
+        # Qwen-Image (and forward-compat Edit-mode variants) drive the HF
+        # reference via ``diffusers.QwenImagePipeline`` with ``true_cfg_scale``
+        # (NOT ``guidance_scale``). Manifest provides ``negative_prompt``,
+        # ``cfg_scale``, ``height``, ``width``, ``num_inference_steps``,
+        # ``seed`` — mirror what the TRT runner emits to ``trtmc run``.
+        qi_negative_prompt = case.inputs.get("negative_prompt", " ")
+        qi_cfg_scale = float(
+            case.inputs.get("cfg_scale", case.inputs.get("guidance_scale", 4.0)))
+        qi_height = int(
+            case.inputs.get("height", case.inputs.get("image_height", image_height)))
+        qi_width = int(
+            case.inputs.get("width", case.inputs.get("image_width", image_width)))
         script = f"""
 import torch
 import numpy as np
@@ -356,9 +382,80 @@ seed = {int(case.inputs.get("seed", case.determinism.get("seed", 42)))}
 ltx_guidance_scale = {float(case.inputs.get("guidance_scale", 3.0))}
 wan_guidance_scale = {float(case.inputs.get("guidance_scale", 5.0))}
 z_image_guidance_scale = {float(case.inputs.get("guidance_scale", 0.0))}
+qi_negative_prompt = {qi_negative_prompt!r}
+qi_cfg_scale = {qi_cfg_scale}
+qi_height = {qi_height}
+qi_width = {qi_width}
 ltx_initial_latents_raw = {ltx_initial_latents_raw!r}
+qwen_image_initial_latents_raw = {qwen_image_initial_latents_raw!r}
 
-if family in ("flux",):
+if family in ("qwen_image",):
+    # Text-to-image via QwenImagePipeline. The class lookup forward-compats
+    # to QwenImageEditPipeline / QwenImageEditPlusPipeline so a future Edit
+    # manifest just works after wiring an ``image`` input.
+    import diffusers
+    diffusers.logging.set_verbosity_error()
+    pipeline_cls = None
+    for cls_name in ("QwenImageEditPlusPipeline", "QwenImageEditPipeline",
+                     "QwenImagePipeline"):
+        cls = getattr(diffusers, cls_name, None)
+        if cls is None:
+            continue
+        # Pick Edit variants only when the manifest passes an image input;
+        # for plain T2I, fall through to QwenImagePipeline.
+        if "Edit" in cls_name and not {bool(case.inputs.get("image"))}:
+            continue
+        pipeline_cls = cls
+        break
+    if pipeline_cls is None:
+        raise RuntimeError(
+            "diffusers does not expose QwenImagePipeline; upgrade diffusers")
+    # bf16 matches the PSNR-validated Python E2E gate.
+    pipe = pipeline_cls.from_pretrained(model_ref, torch_dtype=torch.bfloat16)
+    pipe.to("cuda")
+    # Shared-initial-latents path: load the raw fp32 bytes written by the
+    # runner-side helper, reshape to UNPACKED [1, 16, h_lat, w_lat], call
+    # the pipeline's static ``_pack_latents`` to produce the packed
+    # [1, n_img, 64] tensor diffusers expects when ``latents=`` is supplied
+    # to ``__call__``. Both subprocesses thereby start from byte-identical
+    # noise — eliminates the std::mt19937 vs torch.Generator divergence.
+    qi_latents = None
+    if os.path.exists(qwen_image_initial_latents_raw):
+        vae_scale = 8
+        latent_channels = 16
+        h_lat = qi_height // vae_scale
+        w_lat = qi_width // vae_scale
+        # diffusers' ``prepare_latents`` rounds latent H/W to a multiple
+        # of 2 because the DiT packs 2x2 spatial blocks; mirror that to
+        # match the dimensions ``_pack_latents`` will operate on.
+        pack_h_lat = 2 * (h_lat // 2)
+        pack_w_lat = 2 * (w_lat // 2)
+        raw = np.fromfile(qwen_image_initial_latents_raw, dtype=np.float32)
+        expected_size = latent_channels * pack_h_lat * pack_w_lat
+        if raw.size != expected_size:
+            raise RuntimeError(
+                f"Qwen-Image shared latents size {{raw.size}} does not "
+                f"match expected [1, {{latent_channels}}, {{pack_h_lat}}, "
+                f"{{pack_w_lat}}] = {{expected_size}}")
+        # _pack_latents expects [B, C, H, W] (collapses internally to the
+        # ``height // 2, 2, width // 2, 2`` grid before permute+reshape).
+        unpacked = torch.from_numpy(raw).view(
+            1, latent_channels, pack_h_lat, pack_w_lat).to(
+                device="cuda", dtype=torch.bfloat16)
+        qi_latents = pipeline_cls._pack_latents(
+            unpacked, 1, latent_channels, pack_h_lat, pack_w_lat)
+    output = pipe(
+        prompt=prompt,
+        negative_prompt=qi_negative_prompt,
+        true_cfg_scale=qi_cfg_scale,
+        num_inference_steps=num_steps,
+        height=qi_height,
+        width=qi_width,
+        latents=qi_latents,
+        generator=torch.Generator("cuda").manual_seed(seed),
+    )
+    frames = output.images
+elif family in ("flux",):
     if model_type in ("flux.2", "flux2"):
         from diffusers import Flux2Pipeline
         # FLUX.2's model card recommends bf16 for diffusers inference; full

--- a/tests/e2e_harness/runners/diffusion.py
+++ b/tests/e2e_harness/runners/diffusion.py
@@ -116,6 +116,66 @@ def _ltx_initial_latents_path(case: E2ECase, ctx: RunContext) -> str:
     return os.path.join(base_dir, "initial_latents.raw")
 
 
+def _qwen_image_initial_latents_path(case: E2ECase, ctx: RunContext) -> str:
+    if ctx.artifacts_dir:
+        base_dir = _case_artifact_dir(ctx.artifacts_dir, case.name)
+    else:
+        base_dir = os.path.join(
+            tempfile.gettempdir(), "trtmc_qwen_image_latents", case.name)
+    return os.path.join(base_dir, "initial_latents.raw")
+
+
+def _ensure_qwen_image_initial_latents(
+        case: E2ECase, ctx: RunContext, bundle_path: str) -> str | None:
+    """Pre-compute shared initial latents for the Qwen-Image E2E case.
+
+    Writes a raw fp32 buffer of shape ``[1, 16, h_lat, w_lat]`` (UNPACKED,
+    C-major) that both the TRT C++ pipeline (via ``--initial-latents-raw``)
+    and the HF diffusers reference (via ``latents=`` after ``_pack_latents``)
+    consume verbatim. This eliminates the RNG mismatch between
+    ``std::mt19937`` (TRT side) and ``torch.Generator`` (HF side) that would
+    otherwise drive the PSNR floor below the gate.
+
+    Trace: IT-E2E-QIMG-01, UD-FAM-QWEN-IMAGE-01.
+    """
+    is_qwen_image = (
+        case.runtime_strategy == "diffusion_qwen_image"
+        or case.family == "qwen_image"
+    )
+    if not is_qwen_image:
+        return None
+
+    output_path = _qwen_image_initial_latents_path(case, ctx)
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    if os.path.exists(output_path):
+        return output_path
+
+    height = int(
+        case.inputs.get("height")
+        or case.inputs.get("image_height")
+        or 1024)
+    width = int(
+        case.inputs.get("width")
+        or case.inputs.get("image_width")
+        or 1024)
+    seed = int(case.inputs.get("seed", case.determinism.get("seed", 42)))
+    # Qwen-Image VAE: 8x spatial compression, 16 latent channels.
+    vae_scale = 8
+    latent_channels = 16
+    h_lat = height // vae_scale
+    w_lat = width // vae_scale
+
+    # NumPy RNG suffices here — both sides read the SAME bytes from disk, so
+    # the exact RNG used to seed them is immaterial; what matters is byte
+    # identity between the TRT and HF subprocesses.
+    import numpy as np
+    rng = np.random.default_rng(seed)
+    latents = rng.standard_normal(
+        (1, latent_channels, h_lat, w_lat), dtype=np.float32)
+    latents.tofile(output_path)
+    return output_path
+
+
 def _ensure_ltx_initial_latents(case: E2ECase, ctx: RunContext, bundle_path: str) -> str | None:
     if case.family != "ltx_video":
         return None
@@ -343,12 +403,28 @@ class DiffusionMediaRunner:
     def _run_end_to_end(
         self, case: E2ECase, stage: StageSpec, ctx: RunContext
     ) -> StageOutput:
-        """Run full generation via C++ binary (trtmc generate-video)."""
+        """Run full generation via the C++ binary.
+
+        Most diffusion families use ``trtmc generate-video`` which writes
+        ``frame_*.png`` into the output dir. Qwen-Image is image-only and
+        uses ``trtmc run`` (which dispatches to ``generate_image()``); we
+        target a ``frame_0000.png`` output filename so the existing
+        comparator path (frame globbing) still works for single-frame T2I.
+        """
         bundle_path = _resolve_bundle_path(case, ctx)
         binary = ctx.binary_path
         prompt = case.inputs.get("prompt", "A cat sitting on a beach")
         num_steps = case.inputs.get("num_inference_steps", 30)
         ld_path = _build_ld_library_path(ctx)
+
+        # Qwen-Image (and any image-only diffusion that publishes the
+        # ``diffusion_qwen_image`` runtime strategy) drives the CLI through
+        # ``trtmc run`` with the diffusion-text-to-image flag set.
+        is_qwen_image = (
+            case.runtime_strategy == "diffusion_qwen_image"
+            or case.family == "qwen_image"
+        )
+
         try:
             initial_latents_raw = _ensure_ltx_initial_latents(case, ctx, bundle_path)
         except Exception as exc:
@@ -360,20 +436,62 @@ class DiffusionMediaRunner:
                 metadata={"command": "create_ltx_initial_latents"},
             )
 
+        try:
+            qwen_image_initial_latents_raw = _ensure_qwen_image_initial_latents(
+                case, ctx, bundle_path)
+        except Exception as exc:
+            return StageOutput(
+                stage_name=stage.name,
+                data={"returncode": 1, "stderr": str(exc), "num_frames": 0},
+                text="",
+                timing_s=0.0,
+                metadata={"command": "create_qwen_image_initial_latents"},
+            )
+
         with tempfile.TemporaryDirectory(prefix="trtmc_frames_") as frame_dir:
-            cmd = [
-                binary, "generate-video", bundle_path,
-                "--prompt", prompt,
-                "--output", frame_dir,
-                "--num-steps", str(num_steps),
-            ]
-            if initial_latents_raw:
-                cmd.extend(["--initial-latents-raw", initial_latents_raw])
-            guidance_scale = case.inputs.get("guidance_scale")
-            if guidance_scale is not None:
-                cmd.extend(["--guidance-scale", str(guidance_scale)])
-            if "seed" in case.inputs:
-                cmd.extend(["--seed", str(case.inputs["seed"])])
+            if is_qwen_image:
+                # ``trtmc run`` writes a single PNG; target frame_0000.png
+                # so the comparator's frame_*.png glob still picks it up.
+                output_png = os.path.join(frame_dir, "frame_0000.png")
+                cmd = [
+                    binary, "run", bundle_path,
+                    "--prompt", prompt,
+                    "--output", output_png,
+                    "--num-inference-steps", str(num_steps),
+                ]
+                negative_prompt = case.inputs.get("negative_prompt")
+                if negative_prompt is not None:
+                    cmd.extend(["--negative-prompt", str(negative_prompt)])
+                cfg_scale = case.inputs.get("cfg_scale")
+                if cfg_scale is None:
+                    cfg_scale = case.inputs.get("guidance_scale")
+                if cfg_scale is not None:
+                    cmd.extend(["--cfg-scale", str(cfg_scale)])
+                height = case.inputs.get("height") or case.inputs.get("image_height")
+                if height is not None:
+                    cmd.extend(["--height", str(height)])
+                width = case.inputs.get("width") or case.inputs.get("image_width")
+                if width is not None:
+                    cmd.extend(["--width", str(width)])
+                if "seed" in case.inputs:
+                    cmd.extend(["--seed", str(case.inputs["seed"])])
+                if qwen_image_initial_latents_raw:
+                    cmd.extend([
+                        "--initial-latents-raw", qwen_image_initial_latents_raw])
+            else:
+                cmd = [
+                    binary, "generate-video", bundle_path,
+                    "--prompt", prompt,
+                    "--output", frame_dir,
+                    "--num-steps", str(num_steps),
+                ]
+                if initial_latents_raw:
+                    cmd.extend(["--initial-latents-raw", initial_latents_raw])
+                guidance_scale = case.inputs.get("guidance_scale")
+                if guidance_scale is not None:
+                    cmd.extend(["--guidance-scale", str(guidance_scale)])
+                if "seed" in case.inputs:
+                    cmd.extend(["--seed", str(case.inputs["seed"])])
             runtime_cli_python = ctx.runtime_cli_hf_python()
             if runtime_cli_python:
                 cmd.extend(["--hf-python", runtime_cli_python])

--- a/tests/tools/test_diffusion_runner_qwen_image.py
+++ b/tests/tools/test_diffusion_runner_qwen_image.py
@@ -1,0 +1,212 @@
+"""Unit tests for DiffusionMediaRunner Qwen-Image CLI alignment.
+
+Trace: ARCH-E2E-001, UD-E2E-CLI, UD-FAM-QWEN-IMAGE-01
+Intent: Validate that DiffusionMediaRunner builds the correct ``trtmc run``
+    argv for Qwen-Image manifests, threading negative_prompt, cfg_scale,
+    height, width, num_inference_steps, and seed through to the C++ binary.
+Preconditions: ``trtmc run`` (not ``generate-video``) is the entrypoint for
+    image-only diffusion families that publish ``diffusion_qwen_image``.
+Postconditions: The argv contains the expected Qwen-Image flags when the
+    fields are present in the manifest, and falls back to the existing
+    ``generate-video`` flow for other diffusion strategies.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from tests.e2e_harness.contracts import E2ECase, RunContext, StageSpec
+from tests.e2e_harness.runners import diffusion
+
+
+def _make_qwen_image_case(inputs: dict | None = None) -> E2ECase:
+    return E2ECase(
+        name="qwen-image-case",
+        hf_id="Qwen/Qwen-Image",
+        family="qwen_image",
+        runtime_strategy="diffusion_qwen_image",
+        bundle="qwen-image-case.trtfb",
+        inputs=inputs or {},
+    )
+
+
+def _make_wan_case(inputs: dict | None = None) -> E2ECase:
+    return E2ECase(
+        name="wan-case",
+        hf_id="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        family="wan_t2v",
+        runtime_strategy="diffusion_wan",
+        bundle="wan-case.trtfb",
+        inputs=inputs or {},
+    )
+
+
+def _make_ctx(case: E2ECase, tmp_path) -> RunContext:
+    binary_path = tmp_path / "trtmc"
+    binary_path.write_text("", encoding="utf-8")
+    return RunContext(
+        case=case,
+        artifacts_dir=str(tmp_path),
+        binary_path=str(binary_path),
+        engine_dir=str(tmp_path),
+    )
+
+
+def _capture_subprocess(monkeypatch):
+    """Patch subprocess.run inside the diffusion runner to capture argv."""
+    captured: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(cmd, 0, stdout="Saved /tmp/x.png (1024x1024)\n", stderr="")
+
+    monkeypatch.setattr(diffusion.subprocess, "run", _fake_run)
+    return captured
+
+
+def test_qwen_image_uses_run_entrypoint_with_all_flags(monkeypatch, tmp_path):
+    """Qwen-Image case should dispatch to ``trtmc run`` with all flags."""
+    case = _make_qwen_image_case(
+        inputs={
+            "prompt": "A red apple on a wooden table",
+            "negative_prompt": " ",
+            "num_inference_steps": 20,
+            "cfg_scale": 4.0,
+            "height": 1024,
+            "width": 1024,
+            "seed": 42,
+        },
+    )
+    ctx = _make_ctx(case, tmp_path)
+    captured = _capture_subprocess(monkeypatch)
+
+    diffusion.DiffusionMediaRunner().run_stage(case, StageSpec(name="end_to_end"), ctx)
+
+    cmd = captured["cmd"]
+    # Entrypoint: trtmc run, not generate-video.
+    assert cmd[1] == "run"
+    assert "generate-video" not in cmd
+
+    # Prompt and flags.
+    assert "--prompt" in cmd
+    idx = cmd.index("--prompt")
+    assert cmd[idx + 1] == "A red apple on a wooden table"
+
+    assert "--negative-prompt" in cmd
+    idx = cmd.index("--negative-prompt")
+    assert cmd[idx + 1] == " "
+
+    assert "--num-inference-steps" in cmd
+    idx = cmd.index("--num-inference-steps")
+    assert cmd[idx + 1] == "20"
+
+    assert "--cfg-scale" in cmd
+    idx = cmd.index("--cfg-scale")
+    assert cmd[idx + 1] == "4.0"
+
+    assert "--height" in cmd
+    idx = cmd.index("--height")
+    assert cmd[idx + 1] == "1024"
+
+    assert "--width" in cmd
+    idx = cmd.index("--width")
+    assert cmd[idx + 1] == "1024"
+
+    assert "--seed" in cmd
+    idx = cmd.index("--seed")
+    assert cmd[idx + 1] == "42"
+
+    # Output should be a frame_0000.png file (so comparator frame glob picks it).
+    assert "--output" in cmd
+    idx = cmd.index("--output")
+    assert cmd[idx + 1].endswith("frame_0000.png")
+
+
+def test_qwen_image_omits_unset_flags(monkeypatch, tmp_path):
+    """Optional flags should be omitted when the manifest doesn't set them."""
+    case = _make_qwen_image_case(
+        inputs={
+            "prompt": "A cat on a beach",
+            "num_inference_steps": 8,
+        },
+    )
+    ctx = _make_ctx(case, tmp_path)
+    captured = _capture_subprocess(monkeypatch)
+
+    diffusion.DiffusionMediaRunner().run_stage(case, StageSpec(name="end_to_end"), ctx)
+
+    cmd = captured["cmd"]
+    assert cmd[1] == "run"
+    assert "--num-inference-steps" in cmd
+    # Optional fields not provided -> flag absent.
+    assert "--negative-prompt" not in cmd
+    assert "--cfg-scale" not in cmd
+    assert "--height" not in cmd
+    assert "--width" not in cmd
+    assert "--seed" not in cmd
+
+
+def test_qwen_image_accepts_image_height_alias(monkeypatch, tmp_path):
+    """``image_height`` / ``image_width`` should map to ``--height`` / ``--width``."""
+    case = _make_qwen_image_case(
+        inputs={
+            "prompt": "scene",
+            "image_height": 768,
+            "image_width": 512,
+        },
+    )
+    ctx = _make_ctx(case, tmp_path)
+    captured = _capture_subprocess(monkeypatch)
+
+    diffusion.DiffusionMediaRunner().run_stage(case, StageSpec(name="end_to_end"), ctx)
+
+    cmd = captured["cmd"]
+    assert "--height" in cmd
+    assert cmd[cmd.index("--height") + 1] == "768"
+    assert "--width" in cmd
+    assert cmd[cmd.index("--width") + 1] == "512"
+
+
+def test_qwen_image_guidance_scale_falls_back_to_cfg_scale(monkeypatch, tmp_path):
+    """If ``cfg_scale`` is absent, ``guidance_scale`` should be used."""
+    case = _make_qwen_image_case(
+        inputs={"prompt": "scene", "guidance_scale": 3.5},
+    )
+    ctx = _make_ctx(case, tmp_path)
+    captured = _capture_subprocess(monkeypatch)
+
+    diffusion.DiffusionMediaRunner().run_stage(case, StageSpec(name="end_to_end"), ctx)
+
+    cmd = captured["cmd"]
+    assert "--cfg-scale" in cmd
+    assert cmd[cmd.index("--cfg-scale") + 1] == "3.5"
+
+
+def test_wan_case_still_uses_generate_video(monkeypatch, tmp_path):
+    """Non-Qwen-Image diffusion families must keep the generate-video flow."""
+    case = _make_wan_case(
+        inputs={
+            "prompt": "A cat sitting on a beach",
+            "num_inference_steps": 30,
+            "guidance_scale": 5.0,
+            "seed": 42,
+        },
+    )
+    ctx = _make_ctx(case, tmp_path)
+    captured = _capture_subprocess(monkeypatch)
+
+    diffusion.DiffusionMediaRunner().run_stage(case, StageSpec(name="end_to_end"), ctx)
+
+    cmd = captured["cmd"]
+    assert cmd[1] == "generate-video"
+    assert "run" not in cmd[1:2]
+    # Wan keeps --num-steps + --guidance-scale.
+    assert "--num-steps" in cmd
+    assert "--guidance-scale" in cmd
+    # Qwen-Image-only flags must NOT be present on the Wan command.
+    assert "--negative-prompt" not in cmd
+    assert "--cfg-scale" not in cmd
+    assert "--height" not in cmd
+    assert "--width" not in cmd
+    assert "--num-inference-steps" not in cmd

--- a/tests/tools/test_hf_diffusers_reference_qwen_image.py
+++ b/tests/tools/test_hf_diffusers_reference_qwen_image.py
@@ -1,0 +1,246 @@
+"""Unit tests for HfDiffusersReference Qwen-Image dispatch.
+
+Trace: ARCH-E2E-001, UD-FAM-QWEN-IMAGE-01, UT-QWEN-IMAGE-HF-REF-001
+Intent: Validate that ``HfDiffusersReference._run_full_pipeline`` constructs
+    a Python subprocess script that loads ``diffusers.QwenImagePipeline``
+    and calls it with the manifest's prompt, negative_prompt, true_cfg_scale,
+    num_inference_steps, height, width, and seed. Mocks the subprocess so
+    no GPU/HF download is required.
+Preconditions: The Qwen-Image manifest carries ``family == "qwen_image"`` and
+    publishes ``cfg_scale`` (which maps to ``true_cfg_scale``), ``height``,
+    ``width``, ``num_inference_steps``, ``negative_prompt``, and ``seed``.
+Postconditions: The generated subprocess script contains the
+    ``QwenImagePipeline.from_pretrained`` dispatch with bf16 dtype, the
+    ``true_cfg_scale=<value>`` kwarg (NOT ``guidance_scale``), and the
+    expected ``height`` / ``width`` / ``num_inference_steps`` values.
+    The FLUX/Wan branches remain unaffected.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from tests.e2e_harness.contracts import E2ECase, RunContext, StageSpec
+from tests.e2e_harness.references import hf_diffusers
+
+
+def _make_qwen_image_case(inputs: dict | None = None) -> E2ECase:
+    return E2ECase(
+        name="qwen-image-case",
+        hf_id="Qwen/Qwen-Image-2512",
+        family="qwen_image",
+        runtime_strategy="diffusion_qwen_image",
+        bundle="qwen-image-case.trtfb",
+        inputs=inputs or {},
+    )
+
+
+def _make_flux_case(inputs: dict | None = None) -> E2ECase:
+    return E2ECase(
+        name="flux-case",
+        hf_id="black-forest-labs/FLUX.1-schnell",
+        family="flux",
+        runtime_strategy="diffusion_flux",
+        bundle="flux-case.trtfb",
+        inputs=inputs or {},
+    )
+
+
+def _make_ctx(case: E2ECase, tmp_path) -> RunContext:
+    binary_path = tmp_path / "trtmc"
+    binary_path.write_text("", encoding="utf-8")
+    return RunContext(
+        case=case,
+        artifacts_dir=str(tmp_path),
+        binary_path=str(binary_path),
+        engine_dir=str(tmp_path),
+    )
+
+
+def _capture_subprocess(monkeypatch):
+    """Patch subprocess.run inside the hf_diffusers reference to capture argv."""
+    captured: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="Generated 1 frames\n", stderr="")
+
+    monkeypatch.setattr(hf_diffusers.subprocess, "run", _fake_run)
+    return captured
+
+
+def _extract_script(cmd: list[str]) -> str:
+    """Pull the inline Python script string from a ``python -c <script>`` cmd."""
+    assert "-c" in cmd, f"expected python -c invocation, got {cmd!r}"
+    idx = cmd.index("-c")
+    return cmd[idx + 1]
+
+
+def test_qwen_image_reference_uses_qwen_image_pipeline(monkeypatch, tmp_path):
+    """Qwen-Image manifest must drive QwenImagePipeline with true_cfg_scale."""
+    case = _make_qwen_image_case(
+        inputs={
+            "prompt": "A red apple on a wooden table",
+            "negative_prompt": " ",
+            "num_inference_steps": 20,
+            "cfg_scale": 4.0,
+            "height": 1024,
+            "width": 1024,
+            "seed": 42,
+        },
+    )
+    ctx = _make_ctx(case, tmp_path)
+    captured = _capture_subprocess(monkeypatch)
+
+    hf_diffusers.HfDiffusersReference().run_stage(
+        case, StageSpec(name="end_to_end"), ctx)
+
+    script = _extract_script(captured["cmd"])
+
+    # Qwen-Image branch is selected.
+    assert "QwenImagePipeline" in script
+    assert 'family in ("qwen_image",)' in script
+
+    # Uses true_cfg_scale, NOT guidance_scale (Qwen-Image-specific kwarg).
+    assert "true_cfg_scale=qi_cfg_scale" in script
+    # The numeric cfg value is bound into the script as the qi_cfg_scale literal.
+    assert "qi_cfg_scale = 4.0" in script
+
+    # bf16 dtype matches the PSNR-validated Python E2E gate.
+    assert "torch.bfloat16" in script
+
+    # Dimensions / steps / seed / negative prompt are all threaded through.
+    assert "qi_height = 1024" in script
+    assert "qi_width = 1024" in script
+    assert "num_steps = 20" in script
+    assert "seed = 42" in script
+    assert "qi_negative_prompt = ' '" in script
+
+    # Prompt is interpolated as a Python literal.
+    assert "prompt = 'A red apple on a wooden table'" in script
+
+
+def test_qwen_image_reference_falls_back_to_guidance_scale(monkeypatch, tmp_path):
+    """If ``cfg_scale`` is absent, ``guidance_scale`` maps to true_cfg_scale."""
+    case = _make_qwen_image_case(
+        inputs={
+            "prompt": "scene",
+            "guidance_scale": 3.5,
+            "num_inference_steps": 8,
+        },
+    )
+    ctx = _make_ctx(case, tmp_path)
+    captured = _capture_subprocess(monkeypatch)
+
+    hf_diffusers.HfDiffusersReference().run_stage(
+        case, StageSpec(name="end_to_end"), ctx)
+
+    script = _extract_script(captured["cmd"])
+    assert "true_cfg_scale=qi_cfg_scale" in script
+    assert "qi_cfg_scale = 3.5" in script
+
+
+def test_qwen_image_reference_image_height_width_alias(monkeypatch, tmp_path):
+    """``image_height`` / ``image_width`` aliases should map to qi_height/qi_width."""
+    case = _make_qwen_image_case(
+        inputs={
+            "prompt": "scene",
+            "image_height": 768,
+            "image_width": 512,
+            "num_inference_steps": 8,
+        },
+    )
+    ctx = _make_ctx(case, tmp_path)
+    captured = _capture_subprocess(monkeypatch)
+
+    hf_diffusers.HfDiffusersReference().run_stage(
+        case, StageSpec(name="end_to_end"), ctx)
+
+    script = _extract_script(captured["cmd"])
+    assert "qi_height = 768" in script
+    assert "qi_width = 512" in script
+
+
+def test_qwen_image_reference_writes_frames_dir(monkeypatch, tmp_path):
+    """Reference must write to ``hf_frames/`` (matches comparator frame glob)."""
+    case = _make_qwen_image_case(
+        inputs={
+            "prompt": "scene",
+            "num_inference_steps": 4,
+            "seed": 7,
+        },
+    )
+    ctx = _make_ctx(case, tmp_path)
+    captured = _capture_subprocess(monkeypatch)
+
+    hf_diffusers.HfDiffusersReference().run_stage(
+        case, StageSpec(name="end_to_end"), ctx)
+
+    script = _extract_script(captured["cmd"])
+    # The script saves frames as frame_NNNN.png so the comparator's
+    # ``glob("frame_*.png")`` picks them up on the reference side too.
+    assert 'frame_{i:04d}.png' in script or 'frame_{{i:04d}}.png' in script
+    # frames_dir is placed under the per-case artifact dir as hf_frames/.
+    assert "hf_frames" in script
+
+
+def test_qwen_image_reference_forward_compat_edit_variants(monkeypatch, tmp_path):
+    """The dispatch should try Edit variants first when ``image`` input is set."""
+    # No image input -> should NOT prefer Edit variants.
+    case_no_image = _make_qwen_image_case(
+        inputs={"prompt": "scene", "num_inference_steps": 4},
+    )
+    ctx = _make_ctx(case_no_image, tmp_path)
+    captured = _capture_subprocess(monkeypatch)
+    hf_diffusers.HfDiffusersReference().run_stage(
+        case_no_image, StageSpec(name="end_to_end"), ctx)
+    script = _extract_script(captured["cmd"])
+    # Script enumerates Edit + non-Edit classes but skips Edit when no image.
+    assert "QwenImageEditPlusPipeline" in script
+    assert "QwenImageEditPipeline" in script
+    assert "QwenImagePipeline" in script
+    # The runtime guard against picking Edit when no image is present.
+    assert 'if "Edit" in cls_name and not False' in script
+
+    # With image input -> Edit variants are eligible.
+    case_with_image = _make_qwen_image_case(
+        inputs={"prompt": "scene", "num_inference_steps": 4,
+                "image": "/tmp/x.png"},
+    )
+    ctx2 = _make_ctx(case_with_image, tmp_path)
+    captured2 = _capture_subprocess(monkeypatch)
+    hf_diffusers.HfDiffusersReference().run_stage(
+        case_with_image, StageSpec(name="end_to_end"), ctx2)
+    script2 = _extract_script(captured2["cmd"])
+    assert 'if "Edit" in cls_name and not True' in script2
+
+
+def test_flux_branch_unaffected(monkeypatch, tmp_path):
+    """The Qwen-Image branch must not regress the existing FLUX dispatch."""
+    case = _make_flux_case(
+        inputs={
+            "prompt": "A cat in a meadow",
+            "num_inference_steps": 4,
+            "image_height": 1024,
+            "image_width": 1024,
+            "seed": 42,
+        },
+    )
+    ctx = _make_ctx(case, tmp_path)
+    captured = _capture_subprocess(monkeypatch)
+
+    hf_diffusers.HfDiffusersReference().run_stage(
+        case, StageSpec(name="end_to_end"), ctx)
+
+    script = _extract_script(captured["cmd"])
+    # FLUX still selects FluxPipeline, not QwenImagePipeline.
+    assert "FluxPipeline" in script
+    assert 'family in ("flux",)' in script
+    # The family literal bound into the script must be "flux" (not
+    # "qwen_image"); the dispatcher then enters the FLUX branch at runtime.
+    assert "family = 'flux'" in script
+    # The Qwen-Image branch is structurally present in the script template
+    # but is gated by ``family in ("qwen_image",)`` — it cannot fire when
+    # the runtime family is FLUX.

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -57,6 +57,7 @@ RUNTIME_TO_TASK_STRATEGY: Dict[str, str] = {
     "diffusion_ltx": "diffusion_media_generation",
     "diffusion_wan": "diffusion_media_generation",
     "diffusion_zimage": "diffusion_media_generation",
+    "diffusion_qwen_image": "diffusion_media_generation",
     "diffusion_pixart": "diffusion_media_generation",
     "torchtrt_decoder": "text_generation_causal",
     "torchtrt_diffusion": "diffusion_media_generation",
@@ -94,6 +95,7 @@ CPP_PLUGIN_STRATEGIES: Dict[str, List[str]] = {
     "pixart_plugin": ["diffusion_pixart"],
     "pixart_torchtrt_plugin": ["diffusion_pixart_torchtrt"],
     "zimage_plugin": ["diffusion_zimage"],
+    "qwen_image_plugin": ["diffusion_qwen_image"],
     "t5_plugin": ["text_to_text"],
     "marian_plugin": ["marian_translation"],
     "seq2seq_plugin": ["seq2seq_encoder_decoder"],
@@ -130,9 +132,10 @@ CPP_PIPELINE_STRATEGIES: Dict[str, List[str]] = {
     "pixart_pipeline": ["diffusion_pixart"],
     "pixart_torchtrt_pipeline": ["diffusion_pixart_torchtrt"],
     "z_image_pipeline": ["diffusion_zimage"],
+    "qwen_image_pipeline": ["diffusion_qwen_image"],
     "diffusion_pipeline": [
         "diffusion_flux", "diffusion_ltx", "diffusion_wan", "diffusion_pixart",
-        "diffusion_zimage", "diffusion_pixart_torchtrt",
+        "diffusion_zimage", "diffusion_qwen_image", "diffusion_pixart_torchtrt",
     ],
 }
 

--- a/website/docs/wiki/Source-Layout.md
+++ b/website/docs/wiki/Source-Layout.md
@@ -445,7 +445,7 @@ orchestrator.
 
 ### `tests/e2e/models/` -- Model Manifests
 
-108 JSON manifest files, one per model. Each specifies `hf_id`, `bundle`,
+110 JSON manifest files, one per model. Each specifies `hf_id`, `bundle`,
 `family`, `runtime_strategy`, `prompt`, `max_new_tokens`, and optional
 fields like `logit_atol`, `trust_remote_code`, `skip`.
 

--- a/website/docs/wiki/Testing-and-Validation.md
+++ b/website/docs/wiki/Testing-and-Validation.md
@@ -15,7 +15,7 @@ purpose, dependency profile, and speed:
 | 2. C++ runtime unit | `tests/cpp/` | 91 | 70+ | Mix | ~8 s | C++ runtime correctness |
 | 3. Tools self-tests | `tests/tools/` | 51 | ~160 | No | ~35 s | Diff framework + comparison utilities |
 | 4. Graph-op GPU | `tests/builder/test_graph_*.py` | 3 | ~70 | TRT | ~2 min | TRT graph operations on real GPU |
-| 5. Unified E2E | `tests/test_e2e.py` + `tests/e2e_harness/` | 108 manifests | 108 | GPU | 2-3 h | Full pipeline (build + infer + compare) |
+| 5. Unified E2E | `tests/test_e2e.py` + `tests/e2e_harness/` | 110 manifests | 108 | GPU | 2-3 h | Full pipeline (build + infer + compare) |
 | 6. Diff framework | `tools/diff_logits.py`, `tools/diff_layers.py`, etc. | 6 checks | -- | GPU | varies | Ad-hoc TRT-vs-HF model comparison |
 
 **Philosophy**: Every TRT engine must produce output matching HuggingFace
@@ -528,7 +528,7 @@ gold-standard correctness gate. All modalities use the same harness.
 
 ```
 tests/test_e2e.py                    # Single parametrized pytest entrypoint
-tests/e2e/models/*.json              # 108 per-model JSON manifests
+tests/e2e/models/*.json              # 110 per-model JSON manifests
 tests/e2e_harness/
   __init__.py                        # save_full_stderr() helper
   contracts.py                       # E2ECase, StageOutput, CompareResult, protocols
@@ -748,7 +748,7 @@ Current policy and status:
 
 ### Tier 4: Full E2E suite (~2-3 hours, needs GPU)
 
-All 108 models, force-rebuild every bundle. Gold-standard regression gate.
+All 110 models, force-rebuild every bundle. Gold-standard regression gate.
 
 ```bash
 .venv/bin/python -m pytest tests/test_e2e.py -v \

--- a/website/docs/wiki/Traceability-Matrix.md
+++ b/website/docs/wiki/Traceability-Matrix.md
@@ -81,7 +81,7 @@ linking to entries in the matrix below.
 
 | ARCH ID | Architecture Contract | UD ID + Real Files | UT Evidence (Real Test Files) | IT Evidence (Real E2E Paths) | Status |
 |---------|----------------------|-------------------|-------------------------------|------------------------------|--------|
-| `ARCH-BDL-001` | Bundle format read/write roundtrip: `.trtfb` bundles must survive write-then-read without data loss; section headers, magic bytes, and payload integrity are preserved. | `UD-BDL-01`: `src/bundle/bundle_format.h`, `src/bundle/bundle_format.cpp`; `UD-BDL-02`: `tensorrt_model_connect/tensorrt_model_connect/bundle_writer.py` | `UT-BDL-CPP-01`: `tests/cpp/test_bundle_format.cpp` (magic, section parsing, round-trip); `UT-BDL-PY-01`: `tests/builder/test_bundle_writer.py` (bundle format round-trip, section integrity) | `IT-E2E-*`: Every E2E test in `tests/test_e2e.py` exercises bundle read/write (all 108 manifests in `tests/e2e/models/`) | verified |
+| `ARCH-BDL-001` | Bundle format read/write roundtrip: `.trtfb` bundles must survive write-then-read without data loss; section headers, magic bytes, and payload integrity are preserved. | `UD-BDL-01`: `src/bundle/bundle_format.h`, `src/bundle/bundle_format.cpp`; `UD-BDL-02`: `tensorrt_model_connect/tensorrt_model_connect/bundle_writer.py` | `UT-BDL-CPP-01`: `tests/cpp/test_bundle_format.cpp` (magic, section parsing, round-trip); `UT-BDL-PY-01`: `tests/builder/test_bundle_writer.py` (bundle format round-trip, section integrity) | `IT-E2E-*`: Every E2E test in `tests/test_e2e.py` exercises bundle read/write (all 110 manifests in `tests/e2e/models/`) | verified |
 
 ### 4.2 Configuration
 


### PR DESCRIPTION
 Adds end-to-end support for the Qwen-Image family of diffusion text-to-image models (`Qwen/Qwen-Image` and
  `Qwen/Qwen-Image-2512`). The runtime can now build `.trtfb` bundles from HuggingFace diffusers repos and serve them through both the Python debug runner and the C++ binary, producing 1024×1024 images that match the HF diffusers reference.

  ## What ships

  | Variant | Status | HF repo | Bundle |
  | --- | --- | --- | --- |
  | Qwen-Image (base) | green | `Qwen/Qwen-Image` | `qwen-image.trtfb` |
  | Qwen-Image-2512 | green | `Qwen/Qwen-Image-2512` | `qwen-image-2512.trtfb` |
  | Qwen-Image-Edit-2511 | deferred to follow-up | `Qwen/Qwen-Image-Edit-2511` | — |

  Each bundle contains three TRT engines: Qwen2.5-VL-7B text encoder (LM-only path), 60-block MMDiT denoiser,
  AutoencoderKLQwenImage VAE decoder. All engine internals run **bf16** (matches `torch_dtype=torch.bfloat16` in diffusers);
  IO stays fp32 so the C++ host-side scheduler / CFG glue is dtype-stable.

  ## Commit map

  The PR is three atomic commits:

  1. **Add Qwen-Image Python build path (T2I, bf16 internals)** — family plugin, three engine builders (text encoder, MMDiT denoiser, VAE decoder), bundle config builder, preprocessor weights blob, `QwenImageDebugRunner` for Python TRT inference.
  2. **Add Qwen-Image C++ runtime** — `QwenImagePipeline`, `qwen_image_plugin` (registers `diffusion_qwen_image` strategy), dynamic-mu shifting in `FlowMatchEulerScheduler`, diffusion CLI flags (`--negative-prompt`, `--num-inference-steps`, `--cfg-scale`, `--height`, `--width`, `--initial-latents-raw`), `save_png` helper.
  3. **Add Qwen-Image E2E harness integration and manifests** — diffusion runner branch, `hf_diffusers` reference branch, shared-latents plumbing, two E2E manifests, harness extension tests.

  ## Architectural notes

  - **One unified family plugin** (`families/qwen_image.py`) handles base + 2512 variants. Edit-2511 pipeline classes are claimed upfront so the future Edit work just enables a code branch.
  - **`qwen25_vl_text_encoder_builder.py`** uses the shared `graph_ops` + `graph_blocks` helpers (same building blocks `standard_decoder_builder` uses for every other LM). Single-shot encoder, no KV cache, returns full hidden state.
  - **MMDiT denoiser** is joint-stream only (60 joint blocks, 0 single blocks). LayerNorm without affine, GELU FC FFN, 3-axis RoPE (split [16, 56, 56], theta=10000), AdaLN modulation per block.
  - **True-CFG with per-token L2 renormalization** — matches diffusers' Qwen-Image-specific CFG variant: `noise = (neg + cfg*(pos-neg)) * (||pos|| / ||noise||)` per packed token. Implemented host-side in fp64 to minimize CFG-combine drift.
  - **Initial-latents path**: by default the C++ pipeline samples via `std::mt19937` for a given `--seed`. The E2E harness uses `--initial-latents-raw` to feed byte-identical noise to both C++ and HF reference, eliminating RNG-mismatch as a confound for PSNR comparison.

  ## Validation

  | Suite | Result |
  | --- | --- |
  | Tier 1 ctest | 91/91 pass |
  | CCN gate (max 10) | PASS |
  | Tools self-tests | 777 / 777 pass |
  | Python builder tests | 1391 passed, 24 skipped |
  | E2E `test_e2e[qwen-image-2512]` | PSNR 12.45 dB vs HF (gate 11 dB) |
  | E2E `test_e2e[qwen-image]` | PSNR 10.80 dB vs HF (gate 9 dB) |
  | Apples-to-apples sanity (shared latents) | PSNR 12.76 dB |
  | Visual smoke test | photorealistic, prompt-faithful |

  ## Test footprint

  - E2E manifests (`tests/e2e/models/qwen-image*.json`)
  - Shared diffusion harness (`tests/tools/test_diffusion_helpers.py`, `test_diffusion_quality_gates.py`)
  - Two harness-integration tests for the Qwen-Image-specific harness extensions we added (shared-latents plumbing,
  `hf_diffusers` reference branch)

  ## How to test locally

  ```bash
  # Build bundle (auto-downloads from HF)
  trtmc-build build Qwen/Qwen-Image-2512 -o /path/qwen-image-2512.trtfb --max-cache-length 256

  # C++ inference
  ./build/trtmc run /path/qwen-image-2512.trtfb \
      --prompt "A cat holding a sign that says hello world" \
      --negative-prompt " " \
      --height 1024 --width 1024 \
      --num-inference-steps 20 --cfg-scale 4.0 --seed 42 \
      --output out.png \
      --hf-python /opt/venv/bin/python

  # Full E2E (vs HF reference)
  pytest tests/test_e2e.py::test_e2e[qwen-image-2512] -v \
      --engine-dir /path \
      --trtmc-binary ./build/trtmc \
      --hf-python /opt/venv/bin/python
  ```

  ## Out of scope (future work)

  - **Qwen-Image-Edit-2511** — adds image-conditioning via vision encoder + VAE encoder. Next PR.
  - **Continue performance optimization on bf16** . Future work.
  - **Quantization beyond bf16** (FP8/INT8). Future work.