### PR TITLE
perf(decoder): split prefill and decode engines

### DIFF
--- a/src/runtime/models/text_generation/pipeline.cpp
+++ b/src/runtime/models/text_generation/pipeline.cpp
@@ -315,9 +315,38 @@ bool TextGenerationPipeline::run_prefill_batched(const std::vector<int32_t>& inp
     if (!gather_prefill_kv_pointers(*prefill_, config_, pk, pv))
         return false;
     kv->write_prefill_kv(pk, pv, sq);
-    if (trt_log_to_stderr_enabled())
-        std::cerr << "[trtmc] Batched prefill (profile 0): " << sq << " tokens in one call\n";
+    if (trt_log_to_stderr_enabled()) {
+        std::cerr << "[trtmc] Batched prefill (";
+        if (!config_.prefill_log_label.empty()) {
+            std::cerr << config_.prefill_log_label;
+        } else {
+            std::cerr << "profile " << config_.prefill_profile_index;
+        }
+        std::cerr << "): " << sq << " tokens in one call\n";
+    }
     return true;
+}
+
+void TextGenerationPipeline::prime_decoder_after_batched_prefill(
+    const std::vector<int32_t>& input_ids) {
+    if (input_ids.empty())
+        return;
+
+    TrtModule& decoder = bind_decoder_for_step();
+    if (!decoder.cuda_graph_active())
+        return;
+
+    int32_t token_id = input_ids.back();
+    TensorMap inputs;
+    Tensor token_tensor;
+    token_tensor.data = &token_id;
+    token_tensor.shape = {1};
+    token_tensor.dtype = DType::kInt32;
+    inputs[config_.token_id_name] = token_tensor;
+
+    state_->prepare_step(inputs);
+    decoder.forward_async(inputs);
+    decoder.sync();
 }
 
 void TextGenerationPipeline::run_prefill(const std::vector<int32_t>& input_ids,
@@ -325,6 +354,7 @@ void TextGenerationPipeline::run_prefill(const std::vector<int32_t>& input_ids,
     // Fast path: batched prefill engine writes K/V for the whole prompt in
     // one forward and returns last-token logits on host.
     if (!gpu_sampling && run_prefill_batched(input_ids, logits)) {
+        prime_decoder_after_batched_prefill(input_ids);
         state_->mark_prefill_complete();
         return;
     }

--- a/src/runtime/models/text_generation/pipeline.h
+++ b/src/runtime/models/text_generation/pipeline.h
@@ -42,6 +42,8 @@ struct TextGenConfig {
     std::string present_k_pattern{"present_k_{i}"};
     std::string present_v_pattern{"present_v_{i}"};
     int32_t prefill_max_length{0};
+    int32_t prefill_profile_index{-1};
+    std::string prefill_log_label;
     int32_t num_layers{0};
     int32_t kv_dim{0};
 };
@@ -131,6 +133,7 @@ class TextGenerationPipeline final : public IPipeline {
     // Returns true if the batched prefill engine handled the prompt; false
     // means caller must fall back to the per-token decode loop.
     bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits);
+    void prime_decoder_after_batched_prefill(const std::vector<int32_t>& input_ids);
     bool should_stop_on_answer(const std::vector<int32_t>& output, int32_t prompt_token_count,
                                const GenerateConfig& cfg, int32_t steps, int32_t stop_interval,
                                bool is_eos) const;

--- a/src/runtime/models/text_generation/plugin.cpp
+++ b/src/runtime/models/text_generation/plugin.cpp
@@ -31,6 +31,17 @@ struct KvCacheRuntimeSizing {
     bool clamped_to_bundle_max{false};
 };
 
+struct DecoderProfileInfo {
+    int32_t profile_idx{0};
+    int32_t kv_rows{0};
+};
+
+struct DecoderProfileRoles {
+    int32_t prefill_profile_idx{-1};
+    int32_t prefill_max_length{0};
+    std::vector<DecoderProfileInfo> decode_profiles;
+};
+
 int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
     if (dim < 0 || static_cast<std::size_t>(dim) >= shape.size())
         return -1;
@@ -75,6 +86,63 @@ bool cache_input_supports_runtime_rows(const TrtModule& module, const std::strin
             return true;
     }
     return false;
+}
+
+int32_t profile_token_max_length(const TrtModule& module, const std::string& token_id_name,
+                                 int32_t profile_idx) {
+    return dim_at(
+        module.input_profile_shape(token_id_name, profile_idx, ProfileShapeSelector::kMax), 0);
+}
+
+int32_t profile_cache_rows(const TrtModule& module, const std::string& cache_name,
+                           int32_t profile_idx, int32_t fallback_rows) {
+    const int32_t static_rows = dim_at(module.tensor_shape(cache_name), 0);
+    if (static_rows > 0)
+        return static_rows;
+
+    if (profile_idx >= 0 && profile_idx < module.optimization_profile_count()) {
+        const int32_t max_rows = dim_at(
+            module.input_profile_shape(cache_name, profile_idx, ProfileShapeSelector::kMax), 0);
+        if (max_rows > 0)
+            return max_rows;
+    }
+    return fallback_rows;
+}
+
+DecoderProfileRoles detect_decoder_profile_roles(const TrtModule& module,
+                                                 const std::string& token_id_name,
+                                                 const std::string& cache_k_name,
+                                                 int32_t fallback_rows) {
+    DecoderProfileRoles roles;
+    const int32_t num_profiles = module.optimization_profile_count();
+    if (num_profiles <= 0) {
+        roles.decode_profiles.push_back(DecoderProfileInfo{0, fallback_rows});
+        return roles;
+    }
+
+    for (int32_t profile_idx = 0; profile_idx < num_profiles; ++profile_idx) {
+        const int32_t token_max = profile_token_max_length(module, token_id_name, profile_idx);
+        if (token_max > 1) {
+            if (token_max > roles.prefill_max_length) {
+                roles.prefill_profile_idx = profile_idx;
+                roles.prefill_max_length = token_max;
+            }
+            continue;
+        }
+
+        roles.decode_profiles.push_back(DecoderProfileInfo{
+            profile_idx, profile_cache_rows(module, cache_k_name, profile_idx, fallback_rows)});
+    }
+
+    if (roles.decode_profiles.empty()) {
+        const int32_t fallback_profile =
+            roles.prefill_profile_idx >= 0 ? roles.prefill_profile_idx : 0;
+        roles.decode_profiles.push_back(DecoderProfileInfo{
+            fallback_profile,
+            profile_cache_rows(module, cache_k_name, fallback_profile, fallback_rows)});
+    }
+
+    return roles;
 }
 
 std::string format_bytes(std::uint64_t bytes) {
@@ -168,7 +236,7 @@ class DecoderPlugin final : public IPipelinePlugin {
         TriAttentionConfig tri_cfg = parse_triattention_bundle_config(
             ctx.config_json, ctx.config.max_cache_length, ctx.runtime_config);
 
-        auto profile_modules = load_decoder_profile_modules(ctx);
+        auto profile_modules = load_decoder_profile_modules(ctx, "engine_plan", nullptr);
         if (profile_modules.modules.empty())
             throw std::runtime_error("No decoder engine profiles were loaded");
         TrtModule& metadata_module = *profile_modules.modules.front().module;
@@ -177,13 +245,33 @@ class DecoderPlugin final : public IPipelinePlugin {
         const auto sizing = resolve_kv_cache_runtime_sizing(ctx, metadata_module, kv_names,
                                                             cache_dtype, tri_cfg, kv_dim);
 
-        const int32_t prefill_max_length = detect_prefill_max_length(metadata_module, io.token_id);
-        const int32_t first_decode_profile = prefill_max_length > 0 ? 1 : 0;
+        const auto decode_profile_roles = detect_decoder_profile_roles(
+            metadata_module, io.token_id, kv_names.cache_k.front(), ctx.config.max_cache_length);
 
         std::unique_ptr<TrtModule> prefill_module;
-        auto decoders = build_decoder_contexts(ctx, std::move(profile_modules), sizing.runtime_rows,
-                                               first_decode_profile, prefill_module);
+        auto decoders = build_decoder_contexts(std::move(profile_modules), sizing.runtime_rows,
+                                               decode_profile_roles, prefill_module);
         cudaStream_t stream = decoders.front().module->stream();
+
+        int32_t prefill_profile_idx = decode_profile_roles.prefill_profile_idx;
+        int32_t prefill_max_length = decode_profile_roles.prefill_max_length;
+        std::string prefill_log_label;
+        if (find_section(ctx.bundle, "prefill_engine_plan") != nullptr) {
+            auto split_prefill_modules =
+                load_decoder_profile_modules(ctx, "prefill_engine_plan", stream);
+            if (!split_prefill_modules.modules.empty()) {
+                const auto prefill_roles = detect_decoder_profile_roles(
+                    *split_prefill_modules.modules.front().module, io.token_id,
+                    kv_names.cache_k.front(), ctx.config.max_cache_length);
+                prefill_profile_idx = prefill_roles.prefill_profile_idx;
+                prefill_max_length = prefill_roles.prefill_max_length;
+                prefill_module = extract_prefill_module(std::move(split_prefill_modules),
+                                                        prefill_roles, "prefill_engine_plan");
+                if (prefill_module)
+                    prefill_log_label = "prefill engine";
+            }
+        }
+
         auto state =
             build_inference_state(ctx, sizing, tri_cfg, cache_dtype, kv_dim, kv_names, stream);
         log_kv_cache_sizing(ctx, sizing, state.get());
@@ -195,6 +283,8 @@ class DecoderPlugin final : public IPipelinePlugin {
         // through `prefill_module` (TRT optimization profile 0) and copies
         // per-layer K/V into the shared cache via write_prefill_kv.
         tgc.prefill_max_length = prefill_max_length;
+        tgc.prefill_profile_index = prefill_profile_idx;
+        tgc.prefill_log_label = std::move(prefill_log_label);
         tgc.num_layers = ctx.config.num_layers;
         tgc.kv_dim = kv_dim;
         tgc.present_k_pattern = io.present_k_pattern;
@@ -220,10 +310,12 @@ class DecoderPlugin final : public IPipelinePlugin {
         }
     }
 
-    static BackendProfileModules load_decoder_profile_modules(const PipelineContext& ctx) {
-        auto* plan = find_section(ctx.bundle, "engine_plan");
+    static BackendProfileModules load_decoder_profile_modules(const PipelineContext& ctx,
+                                                              const char* section_name,
+                                                              cudaStream_t stream) {
+        auto* plan = find_section(ctx.bundle, section_name);
         if (plan == nullptr || plan->empty())
-            throw std::runtime_error("engine_plan section is missing");
+            throw std::runtime_error(std::string(section_name) + " section is missing");
         if (ctx.backend == nullptr)
             throw std::runtime_error("No backend loaded");
 
@@ -236,6 +328,7 @@ class DecoderPlugin final : public IPipelinePlugin {
             profile_indices.push_back(i);
 
         ModuleCreateOptions opts;
+        opts.stream = stream;
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
@@ -244,10 +337,10 @@ class DecoderPlugin final : public IPipelinePlugin {
             ctx.backend->create_profile_modules(plan->data(), plan->size(), opts, profile_indices);
         const auto t1 = std::chrono::steady_clock::now();
         const double load_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
-        log_trt_load_timing("engine_plan", load_ms, plan->size());
+        log_trt_load_timing(section_name, load_ms, plan->size());
         for (auto& entry : modules.modules) {
-            entry.module->set_timing_label(entry.profile_idx == 0 ? "engine_plan:profile0"
-                                                                  : "engine_plan:decode");
+            entry.module->set_timing_label(std::string(section_name) +
+                                           (entry.profile_idx == 0 ? ":profile0" : ":decode"));
         }
         return modules;
     }
@@ -264,47 +357,61 @@ class DecoderPlugin final : public IPipelinePlugin {
         }
     }
 
-    // Returns the prefill optimization profile's MAX seq-len if the engine
-    // ships with a "prefill" profile (i.e. profile 0 lets `token_id` be
-    // multi-row); 0 otherwise. Bundles built by the dual-profile decoder
-    // builder put prefill at profile 0; legacy bundles only have single-
-    // token decode profiles (Sq=1 across all profiles).
-    static int32_t detect_prefill_max_length(const TrtModule& module,
-                                             const std::string& token_id_name) {
-        if (module.optimization_profile_count() <= 0)
-            return 0;
-        const int32_t max_tokens =
-            dim_at(module.input_profile_shape(token_id_name, 0, ProfileShapeSelector::kMax), 0);
-        return max_tokens > 1 ? max_tokens : 0;
+    static std::unique_ptr<TrtModule>
+    extract_prefill_module(BackendProfileModules profile_modules,
+                           const DecoderProfileRoles& profile_roles, const char* section_name) {
+        if (profile_roles.prefill_profile_idx < 0)
+            return nullptr;
+        for (auto& entry : profile_modules.modules) {
+            if (entry.profile_idx != profile_roles.prefill_profile_idx)
+                continue;
+            entry.module->set_timing_label(std::string(section_name) + ":prefill");
+            return std::move(entry.module);
+        }
+        return nullptr;
+    }
+
+    static BackendProfileModule* find_profile_module(BackendProfileModules& profile_modules,
+                                                     int32_t profile_idx) {
+        auto found = std::find_if(
+            profile_modules.modules.begin(), profile_modules.modules.end(),
+            [&](const BackendProfileModule& entry) { return entry.profile_idx == profile_idx; });
+        if (found == profile_modules.modules.end())
+            return nullptr;
+        return &*found;
+    }
+
+    static void extract_engine_plan_prefill_module(BackendProfileModules& profile_modules,
+                                                   const DecoderProfileRoles& profile_roles,
+                                                   std::unique_ptr<TrtModule>& prefill_module) {
+        if (profile_roles.prefill_profile_idx < 0)
+            return;
+        auto* entry = find_profile_module(profile_modules, profile_roles.prefill_profile_idx);
+        if (entry == nullptr || !entry->module)
+            return;
+        entry->module->set_timing_label("engine_plan:prefill");
+        prefill_module = std::move(entry->module);
     }
 
     static std::vector<TextGenerationPipeline::DecoderContext>
-    build_decoder_contexts(const PipelineContext& ctx, BackendProfileModules profile_modules,
-                           int32_t runtime_rows, int32_t first_decode_profile,
+    build_decoder_contexts(BackendProfileModules profile_modules, int32_t runtime_rows,
+                           const DecoderProfileRoles& profile_roles,
                            std::unique_ptr<TrtModule>& prefill_module) {
-        auto profile_rows = extract_json_int_array(ctx.config_json, "dynamic_kv_profile_rows", 16);
-        if (profile_rows.empty())
-            profile_rows.push_back(ctx.config.max_cache_length);
         std::vector<TextGenerationPipeline::DecoderContext> decoders;
         decoders.reserve(profile_modules.modules.size());
-        for (auto& entry : profile_modules.modules) {
-            if (entry.profile_idx == 0 && first_decode_profile == 1) {
-                entry.module->set_timing_label("engine_plan:prefill");
-                prefill_module = std::move(entry.module);
-                continue;
-            }
-            if (entry.profile_idx < first_decode_profile)
-                continue;
-            const int32_t row_idx = entry.profile_idx - first_decode_profile;
-            if (row_idx >= static_cast<int32_t>(profile_rows.size()))
-                continue;
-            const int32_t profile_max_rows = profile_rows[static_cast<std::size_t>(row_idx)];
-            if (row_idx > 0 && profile_max_rows > runtime_rows)
+        for (const auto& profile : profile_roles.decode_profiles) {
+            if (profile.kv_rows > runtime_rows && !decoders.empty())
                 break;
-            entry.module->set_timing_label("engine_plan:decode");
+            auto* found = find_profile_module(profile_modules, profile.profile_idx);
+            if (found == nullptr || !found->module)
+                continue;
+            found->module->set_timing_label("engine_plan:decode");
             decoders.push_back(
-                TextGenerationPipeline::DecoderContext{profile_max_rows, std::move(entry.module)});
+                TextGenerationPipeline::DecoderContext{profile.kv_rows, std::move(found->module)});
         }
+
+        extract_engine_plan_prefill_module(profile_modules, profile_roles, prefill_module);
+
         if (decoders.empty())
             throw std::runtime_error("No decoder profile available for engine_plan");
         return decoders;

--- a/src/runtime/plugins/shared/plugin_helpers.h
+++ b/src/runtime/plugins/shared/plugin_helpers.h
@@ -54,8 +54,8 @@ std::unique_ptr<ITrtModule> extract_optional_module(IBackend* backend,
 // and both modules share the CUDA stream. Use `decode->stream()` to obtain
 // the shared stream.
 struct DualProfileModules {
-    std::unique_ptr<ITrtModule> prefill; // profile 0 — batched Sq (null if single-profile)
-    std::unique_ptr<ITrtModule> decode;  // profile 1, or the only profile if single-profile
+    std::unique_ptr<ITrtModule> prefill; // batched Sq profile (null if single-profile)
+    std::unique_ptr<ITrtModule> decode;  // Sq=1 profile, or the only profile if single-profile
 };
 
 // Load an engine from a serialized plan via the backend and create two

--- a/tensorrt_model_connect/tensorrt_model_connect/cli.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/cli.py
@@ -155,6 +155,7 @@ def _cmd_build(args: argparse.Namespace) -> int:
             model_id_or_path=build_model_ref,
             output_path=args.output,
             max_cache_length=args.max_cache_length,
+            decoder_engine_layout=getattr(args, "decoder_engine_layout", "split"),
             dynamic_kv_cache=getattr(args, "dynamic_kv_cache", False),
             dynamic_kv_profile_rows_override=getattr(args, "dynamic_kv_profile_rows", None),
             precision=args.precision,
@@ -406,7 +407,9 @@ def list_engine_sections(bundle_path: str) -> list[dict]:
 
         # Infer role from section name
         if name == "engine_plan":
-            role = "primary"
+            role = "decode" if "prefill_engine_plan" in sections else "primary"
+        elif name == "prefill_engine_plan":
+            role = "prefill"
         elif "vision" in name:
             role = "vision"
         elif "text_encoder" in name:
@@ -544,6 +547,14 @@ def main() -> None:
                          help="Output .trtfb file path")
     build_p.add_argument("--max-cache-length", type=int, default=256,
                          help="KV cache length (default: 256)")
+    build_p.add_argument(
+        "--decoder-engine-layout",
+        choices=["split", "dual_profile"],
+        default="split",
+        help="Decoder engine layout for supported LLMs: split builds separate "
+             "prefill/decode engines (default); dual_profile keeps one "
+             "low-VRAM engine with multiple optimization profiles",
+    )
     build_p.add_argument("--dynamic-kv-cache", action="store_true",
                          help="Build decoder bundles with runtime-resizable KV cache support")
     build_p.add_argument(

--- a/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
@@ -221,6 +221,56 @@ def _call_supports_kwarg(func, name: str) -> bool:
     )
 
 
+def _plugin_uses_standard_decoder_builder(plugin) -> bool:
+    """Best-effort check for family plugins routed through the standard decoder."""
+    try:
+        source = inspect.getsource(plugin.build_engine)
+    except (OSError, TypeError):
+        return False
+    return "build_standard_decoder_engine" in source
+
+
+def _plugin_supports_split_decoder_roles(plugin) -> bool:
+    """Return True when the family's standard builder honors split roles."""
+    if not _plugin_uses_standard_decoder_builder(plugin):
+        return False
+    build_globals = getattr(plugin.build_engine, "__globals__", {})
+    standard_builder = build_globals.get("build_standard_decoder_engine")
+    if standard_builder is None:
+        return False
+    try:
+        source = inspect.getsource(standard_builder)
+    except (OSError, TypeError):
+        return False
+    return (
+        "_decoder_engine_role" in source
+        and "profile_mode" in source
+    )
+
+
+def _can_build_split_decoder_engines(
+    plugin,
+    runtime_strategy: str,
+    *,
+    dynamic_kv_cache: bool,
+    triattention_enabled: bool,
+) -> bool:
+    """Return True when split prefill/decode engines are supported.
+
+    The split layout relies on ``standard_decoder_builder`` honoring the
+    internal ``_decoder_engine_role`` passthrough. Custom MoE, recurrent,
+    VL/embed-input, TriAttention, and dynamic-KV runtimes keep their existing
+    single-engine behavior until they opt into the same contract.
+    """
+    if runtime_strategy not in ("decoder_kv_cache", "decoder_moe"):
+        return False
+    if dynamic_kv_cache or triattention_enabled:
+        return False
+    if bool(getattr(plugin, "embed_input", False)):
+        return False
+    return _plugin_supports_split_decoder_roles(plugin)
+
+
 def _load_plugin_weights(
     plugin,
     model_dir: str,
@@ -554,6 +604,7 @@ def build_bundle(
     output_path: str,
     max_cache_length: int = 256,
     *,
+    decoder_engine_layout: str = "split",
     dynamic_kv_cache: bool = False,
     dynamic_kv_profile_rows_override: list[int] | None = None,
     precision: str = "fp32",
@@ -585,8 +636,15 @@ def build_bundle(
         model_dir: Path to HF model directory with config.json + safetensors.
         output_path: Where to write the .trtfb bundle.
         max_cache_length: KV cache length for the engine.
+        decoder_engine_layout: ``"split"`` builds separate prefill/decode
+            engines for supported decoder LLMs. ``"dual_profile"`` keeps the
+            low-VRAM single-engine/multi-profile layout.
         verbose: Print detailed logs.
     """
+    if decoder_engine_layout not in ("split", "dual_profile"):
+        raise ValueError(
+            "decoder_engine_layout must be 'split' or 'dual_profile', "
+            f"got {decoder_engine_layout!r}")
     _setup_trt_import(rtx)
     try:
         print(
@@ -622,6 +680,7 @@ def build_bundle(
 
     # 1. Parse config
     config = ModelConfig.from_dir(model_dir_path)
+    config.raw["_decoder_engine_layout"] = decoder_engine_layout
     config.raw["_audio_magpie_max_source_positions"] = audio_magpie_max_source_positions
     print(f"[trtmc-build] Model: {config.model_type} "
           f"(layers={config.num_hidden_layers}, hidden={config.hidden_size}, "
@@ -766,26 +825,107 @@ def build_bundle(
         config.raw["_dynamic_kv_opt_length"] = max_cache_length
         config.raw["_dynamic_kv_profile_rows"] = dynamic_kv_profile_rows
 
-    print(f"[trtmc-build] Building TRT engine (cache={max_cache_length}) ...",
-          file=sys.stderr)
     # Pass precision/quant_ctx only if the plugin accepts them (not all do).
     extra_kwargs = {}
     if _call_supports_kwarg(plugin.build_engine, 'precision'):
         extra_kwargs['precision'] = precision
     if _call_supports_kwarg(plugin.build_engine, 'quant_ctx'):
         extra_kwargs['quant_ctx'] = quant_ctx
+
+    def _split_timing_cache_scope(role: str) -> str:
+        quant_label = quantize or "noquant"
+        return (
+            f"split-{config.model_type}-h{config.hidden_size}"
+            f"-l{config.num_hidden_layers}-{precision}-{quant_label}-{role}"
+        )
+
+    def _build_plugin_engine_with_role(role: str) -> bytes:
+        previous_role = config.raw.get("_decoder_engine_role")
+        config.raw["_decoder_engine_role"] = role
+        try:
+            return plugin.build_engine(
+                config, weights, max_cache_length, verbose=verbose,
+                **extra_kwargs)
+        finally:
+            if previous_role is None:
+                config.raw.pop("_decoder_engine_role", None)
+            else:
+                config.raw["_decoder_engine_role"] = previous_role
+
+    def _build_split_plugin_engine_with_role(role: str) -> bytes:
+        with trt_compat.scoped_timing_cache(_split_timing_cache_scope(role)):
+            return _build_plugin_engine_with_role(role)
+
+    split_supported = (
+        decoder_engine_layout == "split" and
+        _can_build_split_decoder_engines(
+            plugin,
+            runtime_strategy,
+            dynamic_kv_cache=enable_dynamic_kv_cache,
+            triattention_enabled=triattention_cfg is not None,
+        )
+    )
+
+    engine_plan: bytes
+    prefill_engine_plan: bytes | None = None
+    actual_decoder_engine_layout = "single"
     engine_t0 = time.monotonic()
     try:
-        engine_plan = plugin.build_engine(
-            config, weights, max_cache_length, verbose=verbose,
-            **extra_kwargs)
+        if split_supported:
+            print(
+                f"[trtmc-build] Building split decoder engines "
+                f"(cache={max_cache_length}) ...",
+                file=sys.stderr,
+            )
+            prefill_t0 = time.monotonic()
+            prefill_engine_plan = _build_split_plugin_engine_with_role("prefill")
+            prefill_elapsed = time.monotonic() - prefill_t0
+            _add_build_timing(
+                build_timing, "trt_compile_prefill_engine_s", prefill_elapsed)
+            print(
+                f"[trtmc-build] Prefill engine built [{prefill_elapsed:.1f}s] "
+                f"({len(prefill_engine_plan) / (1024 * 1024):.1f} MB)",
+                file=sys.stderr,
+            )
+
+            decode_t0 = time.monotonic()
+            engine_plan = _build_split_plugin_engine_with_role("decode")
+            decode_elapsed = time.monotonic() - decode_t0
+            _add_build_timing(
+                build_timing, "trt_compile_decode_engine_s", decode_elapsed)
+            print(
+                f"[trtmc-build] Decode engine built [{decode_elapsed:.1f}s] "
+                f"({len(engine_plan) / (1024 * 1024):.1f} MB)",
+                file=sys.stderr,
+            )
+            actual_decoder_engine_layout = "split"
+        else:
+            if decoder_engine_layout == "split" and runtime_strategy in (
+                "decoder_kv_cache", "decoder_moe"
+            ):
+                print(
+                    "[trtmc-build] Split decoder layout is not supported for "
+                    f"family={plugin.name}; using existing single-engine path",
+                    file=sys.stderr,
+                )
+            print(f"[trtmc-build] Building TRT engine (cache={max_cache_length}) ...",
+                  file=sys.stderr)
+            role = "dual_profile" if decoder_engine_layout == "dual_profile" else "decode"
+            engine_plan = _build_plugin_engine_with_role(role)
+            if decoder_engine_layout == "dual_profile":
+                actual_decoder_engine_layout = "dual_profile"
     finally:
         engine_elapsed = time.monotonic() - engine_t0
         _add_build_timing(build_timing, "trt_compile_s", engine_elapsed)
         _add_build_timing(build_timing, "trt_compile_main_engine_s", engine_elapsed)
         _write_build_timing(build_timing)
-    print(f"[trtmc-build] Engine built [{engine_elapsed:.1f}s] "
-          f"({len(engine_plan) / (1024 * 1024):.1f} MB)", file=sys.stderr)
+    if actual_decoder_engine_layout == "split":
+        total_mb = (len(engine_plan) + len(prefill_engine_plan or b"")) / (1024 * 1024)
+        print(f"[trtmc-build] Split engines built [{engine_elapsed:.1f}s] "
+              f"({total_mb:.1f} MB total)", file=sys.stderr)
+    else:
+        print(f"[trtmc-build] Engine built [{engine_elapsed:.1f}s] "
+              f"({len(engine_plan) / (1024 * 1024):.1f} MB)", file=sys.stderr)
 
     # 4b. Build vision engine (optional, VL models only)
     vision_plan = None
@@ -869,7 +1009,12 @@ def build_bundle(
         tokenizer_add_special_tokens=tokenizer_add_special_tokens,
     )
 
+    # For split decoder bundles, keep ``engine_plan`` as the decode-only
+    # engine for compatibility with existing tools and add the prefill engine
+    # under a role-specific section.
     sections = [BundleSection("engine_plan", engine_plan)]
+    if prefill_engine_plan is not None:
+        sections.append(BundleSection("prefill_engine_plan", prefill_engine_plan))
 
     # Add vision engine section if present
     if vision_plan is not None:
@@ -921,6 +1066,7 @@ def build_bundle(
         cfg_dict["precision"] = precision
         cfg_dict["tokenizer_add_special_tokens"] = int(
             tokenizer_add_special_tokens)
+        cfg_dict["decoder_engine_layout"] = actual_decoder_engine_layout
         if quant_plan is not None:
             cfg_dict["quantization"] = quant_plan.as_config_dict()
         elif quantize:
@@ -1311,6 +1457,7 @@ def build(
     output_path: str,
     max_cache_length: int = 256,
     *,
+    decoder_engine_layout: str = "split",
     dynamic_kv_cache: bool = False,
     dynamic_kv_profile_rows_override: list[int] | None = None,
     precision: str = "fp32",
@@ -1344,6 +1491,7 @@ def build(
         model_id_or_path: HF repo ID or local directory with config.json + safetensors.
         output_path: Where to write the .trtfb bundle.
         max_cache_length: KV cache length for the engine.
+        decoder_engine_layout: ``"split"`` or ``"dual_profile"``.
         verbose: Print detailed TRT builder logs.
         fp8_scales: Per-layer FP8 scales dict, or ``"auto"`` for auto-calibration.
         save_fp8_scales: Path to save calibrated FP8 scales JSON.
@@ -1353,6 +1501,7 @@ def build(
     build_bundle._fp8_scales = fp8_scales
     build_bundle._save_fp8_scales = save_fp8_scales
     build_bundle(model_dir, output_path, max_cache_length,
+                 decoder_engine_layout=decoder_engine_layout,
                  dynamic_kv_cache=dynamic_kv_cache,
                  dynamic_kv_profile_rows_override=dynamic_kv_profile_rows_override,
                  precision=precision,

--- a/tensorrt_model_connect/tensorrt_model_connect/families/bark/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/bark/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/bark/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/bark/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/bloom/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/bloom/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/bloom/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/bloom/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/codegen/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/codegen/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/codegen/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/codegen/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/deepseek_ocr/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/deepseek_ocr/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/deepseek_ocr/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/deepseek_ocr/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/deepseek_v2/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/deepseek_v2/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/deepseek_v2/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/deepseek_v2/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/falcon/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/falcon/dual_profile_decoder_builder.py
@@ -222,8 +222,9 @@ def build_dual_profile_decoder_engine(
     alibi_bias_scale: float = 1.0,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -236,14 +237,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -282,6 +294,9 @@ def build_dual_profile_decoder_engine(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    import os as _os_pv
+    if _os_pv.environ.get("TRTMC_TRT_DETAILED_VERBOSITY") == "1":
+        trt_config.profiling_verbosity = trt.ProfilingVerbosity.DETAILED
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16
@@ -347,16 +362,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -648,7 +689,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/falcon/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/falcon/standard_decoder_builder.py
@@ -101,10 +101,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -125,7 +130,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -140,6 +149,7 @@ def build_standard_decoder_engine(
             scale_attn_weights=scale_attn_weights,
             alibi_bias_scale=alibi_bias_scale,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)
@@ -172,6 +182,9 @@ def build_standard_decoder_engine(
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    import os as _os_pv
+    if _os_pv.environ.get("TRTMC_TRT_DETAILED_VERBOSITY") == "1":
+        trt_config.profiling_verbosity = trt.ProfilingVerbosity.DETAILED
 
     # Precision configuration
     if precision == "fp16":
@@ -272,6 +285,7 @@ def build_standard_decoder_engine(
     # ---------------------------------------------------------------
     embedding_table = graph_ops.add_constant(
         network, (vocab, hidden), weights["embedding"], dtype=work_np_dtype)
+    embedding_table = _cast_work_dtype(embedding_table)
 
     # RoPE tables (only needed when position_type == "rope")
     position_embed_table = None
@@ -302,21 +316,25 @@ def build_standard_decoder_engine(
         pos_embed_np = weights["position_embedding"]
         position_embed_table = graph_ops.add_constant(
             network, pos_embed_np.shape, pos_embed_np, dtype=work_np_dtype)
+        position_embed_table = _cast_work_dtype(position_embed_table)
     elif position_type == "alibi":
         alibi_slopes_np = graph_ops.compute_alibi_slopes(num_heads) * float(alibi_bias_scale)
         alibi_slopes_tensor = graph_ops.add_constant(
             network, (num_heads, 1, 1),
             alibi_slopes_np.reshape(num_heads, 1, 1), dtype=np.float32)
+        alibi_slopes_tensor = _cast_work_dtype(alibi_slopes_tensor)
         # Cache position indices [0, 1, ..., max_cache_length-1].
         # The current token's position (position_id) is appended at runtime.
         alibi_indices_tensor = graph_ops.add_constant(
             network, (max_cache_length,),
             np.arange(max_cache_length, dtype=np.float32),
             dtype=np.float32)
+        alibi_indices_tensor = _cast_work_dtype(alibi_indices_tensor)
 
     eps_tensor = graph_ops.add_constant(
         network, (1, 1), np.array([config.rms_norm_eps], dtype=work_np_dtype),
         dtype=work_np_dtype)
+    eps_tensor = _cast_work_dtype(eps_tensor)
     attn_scale = (1.0 / np.sqrt(max(head_dim, 1))) if scale_attn_weights else 1.0
     # ---------------------------------------------------------------
     # Embedding lookup (with optional embed_input override for VL)
@@ -336,6 +354,7 @@ def build_standard_decoder_engine(
         one_const = graph_ops.add_constant(
             network, (1, 1), np.array([1.0], dtype=work_np_dtype),
             dtype=work_np_dtype)
+        one_const = _cast_work_dtype(one_const)
         inv_flag = network.add_elementwise(
             one_const, flag_for_math,
             trt.ElementWiseOperation.SUB)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/gemma/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/gemma/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/gemma/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/gemma/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/glm/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/glm/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/glm/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/glm/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/gpt2/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/gpt2/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/gpt2/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/gpt2/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/gpt_neo/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/gpt_neo/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/gpt_neo/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/gpt_neo/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/gpt_neox/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/gpt_neox/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/gpt_neox/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/gpt_neox/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/gpt_oss/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/gpt_oss/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/gpt_oss/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/gpt_oss/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/granite/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/granite/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/granite/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/granite/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/internlm/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/internlm/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/internlm/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/internlm/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/internvl/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/internvl/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/internvl/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/internvl/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/llama/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/llama/dual_profile_decoder_builder.py
@@ -222,8 +222,9 @@ def build_dual_profile_decoder_engine(
     alibi_bias_scale: float = 1.0,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -236,14 +237,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -347,16 +359,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -648,7 +686,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/llama/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/llama/standard_decoder_builder.py
@@ -101,10 +101,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -125,7 +130,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -140,6 +149,7 @@ def build_standard_decoder_engine(
             scale_attn_weights=scale_attn_weights,
             alibi_bias_scale=alibi_bias_scale,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/mistral/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/mistral/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/mistral/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/mistral/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/mixtral/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/mixtral/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/mixtral/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/mixtral/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/nemotron/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/nemotron/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/nemotron/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/nemotron/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/olmo/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/olmo/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/olmo/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/olmo/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/opt/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/opt/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/opt/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/opt/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/personaplex/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/personaplex/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/personaplex/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/personaplex/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/phi/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/phi/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/phi/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/phi/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/phi4_multimodal/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/phi4_multimodal/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/phi4_multimodal/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/phi4_multimodal/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/phi_moe/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/phi_moe/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/phi_moe/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/phi_moe/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen3_omni/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen3_omni/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen3_omni/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen3_omni/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_moe/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_moe/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_moe/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_moe/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_vl/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_vl/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_vl/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_vl/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/stablelm/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/stablelm/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/stablelm/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/stablelm/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/starcoder2/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/starcoder2/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/starcoder2/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/starcoder2/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/xglm/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/xglm/dual_profile_decoder_builder.py
@@ -221,8 +221,9 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
+    profile_mode: str = "dual_profile",
 ) -> bytes:
-    """Build a dual-profile prefill+decode engine with two optimization profiles.
+    """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
@@ -233,14 +234,25 @@ def build_dual_profile_decoder_engine(
     ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
     when ``None`` the matmuls are plain fp16 / bf16 / fp32.
 
-    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
-    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
-    one per bucket — letting TriAttention pick the smallest active KV cache
-    bucket at runtime while still benefitting from batched prefill on the
-    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
-    can constrain their row count independently.
+    ``profile_mode`` controls which optimization profiles are emitted:
+
+    * ``"dual_profile"``: one prefill profile followed by one or more decode
+      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
+      gets one profile per bucket — letting TriAttention pick the smallest
+      active KV cache bucket at runtime while still benefitting from batched
+      prefill on the prompt.
+    * ``"prefill"``: one prefill profile only. This is used by split-engine
+      bundles, where decode is served by a separate fixed-Sq=1 engine.
+
+    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
+    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
+    bucket profiles are requested so each profile can constrain their row count.
     """
     _supports_config(config, weights)
+    if profile_mode not in ("dual_profile", "prefill"):
+        raise ValueError(
+            "profile_mode must be 'dual_profile' or 'prefill', "
+            f"got {profile_mode!r}")
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -344,16 +356,42 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                 cache_rows_min=1, cache_rows_opt=max_cache_length,
-                 cache_rows_max=max_cache_length)
-    if multi_bucket_decode:
-        for bucket in decode_buckets:
-            _add_profile(1, 1, fixed=True,
-                         cache_rows_min=1, cache_rows_opt=bucket,
-                         cache_rows_max=bucket)
-    else:
+    import os as _os_dbg
+    if profile_mode == "prefill":
+        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                     cache_rows_min=1, cache_rows_opt=max_cache_length,
+                     cache_rows_max=max_cache_length)
+    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
+        # Diagnostic: build a one-profile engine with dynamic-shape inputs
+        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
+        # overhead from per-profile kernel specialisation.
         _add_profile(1, 1, fixed=True)
+    else:
+        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
+        if _reverse:
+            # Decode profile registered first so it commits its preferred
+            # weight layout before the prefill profile compiles.
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+        else:
+            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                         cache_rows_min=1, cache_rows_opt=max_cache_length,
+                         cache_rows_max=max_cache_length)
+            if multi_bucket_decode:
+                for bucket in decode_buckets:
+                    _add_profile(1, 1, fixed=True,
+                                 cache_rows_min=1, cache_rows_opt=bucket,
+                                 cache_rows_max=bucket)
+            else:
+                _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -645,7 +683,8 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        print(f"[trtmc-build] Building dual-profile engine "
+        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
+        print(f"[trtmc-build] Building {mode_label} engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/xglm/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/xglm/standard_decoder_builder.py
@@ -97,10 +97,15 @@ def build_standard_decoder_engine(
         Serialized engine plan bytes.
     """
     import os as _os
-    # Dispatch to the dual-profile builder by default (one engine, two
-    # optimization profiles — Profile 0 = batched prefill, Profile 1 =
-    # single-token decode). Quantized builds (``quant_ctx``) thread Q/DQ
-    # insertion through every projection matmul via
+    # Mark the graph as honoring the internal decoder role contract. This is
+    # embedded in the mutable config for family helpers that need to branch on
+    # the active engine layout while building.
+    config.raw["_decoder_engine_layout_supported"] = True
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+
+    # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
+    # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
+    # every projection matmul via
     # ``QuantContext.maybe_quantized_matmul``, so they share the dispatch.
     #
     # The legacy single-profile graph below stays in place for paths the
@@ -121,7 +126,11 @@ def build_standard_decoder_engine(
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
     )
-    if not _dual_profile_disabled_for:
+    if decoder_engine_role == "prefill" and _dual_profile_disabled_for:
+        raise NotImplementedError(
+            "split prefill engine is not supported for this standard decoder "
+            "configuration")
+    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -135,6 +144,7 @@ def build_standard_decoder_engine(
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
+            profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )
 
     attention_size: int = weights.get("_attention_size", config.attention_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/trt_compat.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/trt_compat.py
@@ -245,6 +245,34 @@ def _timing_cache_path() -> Path | None:
     return Path(cache_dir) / f"{_backend_module_name}-{version}-opt{opt_level}.cache"
 
 
+def _scope_cache_path(path: Path, scope: str) -> Path:
+    scoped_name = _sanitize_cache_name(scope)
+    return path.with_name(f"{path.stem}.{scoped_name}{path.suffix}")
+
+
+@contextmanager
+def scoped_timing_cache(scope: str | None):
+    """Temporarily route TensorRT timing-cache IO to a scoped cache file."""
+    if not scope:
+        yield
+        return
+
+    path = _timing_cache_path()
+    if path is None:
+        yield
+        return
+
+    previous = os.environ.get(_TIMING_CACHE_PATH_ENV)
+    os.environ[_TIMING_CACHE_PATH_ENV] = str(_scope_cache_path(path, scope))
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(_TIMING_CACHE_PATH_ENV, None)
+        else:
+            os.environ[_TIMING_CACHE_PATH_ENV] = previous
+
+
 @contextmanager
 def _locked_cache(path: Path):
     lock_path = path.with_name(f"{path.name}.lock")

--- a/tests/builder/test_cli.py
+++ b/tests/builder/test_cli.py
@@ -166,6 +166,44 @@ class TestCmdInspect:
         assert "qwen" in captured.out
         assert "engine_plan" in captured.out
 
+    def test_list_engine_sections_marks_split_decoder_roles(self, tmp_path):
+        """Split decoder bundles should label decode and prefill plans distinctly."""
+        import json
+        import struct
+
+        bundle_path = tmp_path / "split.trtfb"
+        header = {
+            "model_id": "test-model",
+            "model_type": "qwen3",
+            "family": "qwen",
+            "trt_version": "10.0.0",
+            "gpu_name": "A100",
+            "created_at": "2025-01-01T00:00:00Z",
+            "vocab_size": 32000,
+            "hidden_size": 1024,
+            "num_layers": 24,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 4,
+            "max_cache_length": 256,
+            "sections": {
+                "engine_plan": {"offset": 0, "size": 100},
+                "prefill_engine_plan": {"offset": 100, "size": 200},
+            },
+        }
+        header_json = json.dumps(header).encode("utf-8")
+
+        with open(bundle_path, "wb") as f:
+            f.write(b"TRTFB\x00\x01\x00")
+            f.write(struct.pack("<Q", len(header_json)))
+            f.write(header_json)
+            f.write(b"\x00" * 300)
+
+        from tensorrt_model_connect.cli import list_engine_sections
+
+        roles = {entry["name"]: entry["role"] for entry in list_engine_sections(str(bundle_path))}
+        assert roles["engine_plan"] == "decode"
+        assert roles["prefill_engine_plan"] == "prefill"
+
     def test_inspect_nonexistent_file(self):
         """_cmd_inspect returns 1 for non-existent file."""
         from tensorrt_model_connect.cli import _cmd_inspect
@@ -368,6 +406,52 @@ class TestCmdBuildMocked:
             )
             _cmd_build(args)
             assert received == [[32, 64, 128]]
+        finally:
+            eb.build = original_build
+
+    def test_decoder_engine_layout_propagated(self, tmp_path):
+        """Verify --decoder-engine-layout is forwarded to engine_builder.build()."""
+        from tensorrt_model_connect.cli import _cmd_build
+        import tensorrt_model_connect.engine_builder as eb
+
+        received = []
+
+        def mock_build(model_id_or_path, output_path, max_cache_length, *,
+                       decoder_engine_layout="split", **kwargs):
+            received.append(decoder_engine_layout)
+
+        original_build = eb.build
+        eb.build = mock_build
+        try:
+            args = argparse.Namespace(
+                model="some-model",
+                output=str(tmp_path / "out.trtfb"),
+                max_cache_length=256,
+                decoder_engine_layout="dual_profile",
+                dynamic_kv_cache=False,
+                dynamic_kv_profile_rows=None,
+                precision="fp32",
+                quantize=None,
+                quant_scales=None,
+                quant_calibration_samples=512,
+                verbose=False,
+                fp8=False,
+                fp8_scales=None,
+                save_fp8_scales=None,
+                triattention_stats=None,
+                triattention_kv_budget=None,
+                triattention_divide_length=128,
+                triattention_recent_window=128,
+                triattention_score_aggregation="mean",
+                triattention_count_prompt_tokens=True,
+                triattention_protect_prefill=True,
+                triattention_disable_mlr=False,
+                triattention_disable_trig=False,
+                method="trt",
+                _skip_profile_resolution=True,
+            )
+            _cmd_build(args)
+            assert received == ["dual_profile"]
         finally:
             eb.build = original_build
 

--- a/tests/builder/test_engine_builder_extended.py
+++ b/tests/builder/test_engine_builder_extended.py
@@ -12,12 +12,14 @@ from __future__ import annotations
 
 import json
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 try:
+    import tensorrt_model_connect.engine_builder as engine_builder
     from tensorrt_model_connect.engine_builder import (
         _get_trt_version,
         _get_gpu_name,
@@ -198,6 +200,36 @@ class TestEnsureTokenizerJson:
 # ---------------------------------------------------------------------------
 # build_bundle orchestration
 # ---------------------------------------------------------------------------
+
+
+def build_standard_decoder_engine(config, weights, max_cache_length, *, verbose=False):
+    _decoder_engine_role = config.raw.get("_decoder_engine_role")
+    profile_mode = "prefill" if _decoder_engine_role == "prefill" else "dual_profile"
+    return f"{_decoder_engine_role}:{profile_mode}".encode()
+
+
+class _SplitDecoderPlugin:
+    name = "qwen"
+    runtime_strategy = "decoder_kv_cache"
+
+    def load_weights(self, model_dir, config, *, precision="fp32"):
+        return {}
+
+    def build_engine(
+        self,
+        config,
+        weights,
+        max_cache_length,
+        *,
+        precision="fp32",
+        verbose=False,
+    ):
+        return build_standard_decoder_engine(
+            config,
+            weights,
+            max_cache_length,
+            verbose=verbose,
+        )
 
 
 class TestBuildBundleOrchestration:
@@ -672,6 +704,49 @@ class TestBuildBundleOrchestration:
                             )
 
         assert seen["precision"] == "fp16"
+
+    def test_split_decoder_builds_use_role_scoped_timing_caches(self, tmp_path, monkeypatch):
+        """Split prefill/decode builds should not share the global timing cache."""
+        model_dir = self._make_model_dir(tmp_path, model_type="qwen3")
+        output_path = str(tmp_path / "output.trtfb")
+        scopes = []
+
+        @contextmanager
+        def fake_scoped_timing_cache(scope):
+            scopes.append(scope)
+            yield
+
+        monkeypatch.setattr(
+            engine_builder.trt_compat,
+            "scoped_timing_cache",
+            fake_scoped_timing_cache,
+        )
+
+        with patch("tensorrt_model_connect.engine_builder.find_plugin",
+                   return_value=_SplitDecoderPlugin()):
+            with patch("tensorrt_model_connect.engine_builder._get_trt_version",
+                       return_value="10.0"):
+                with patch("tensorrt_model_connect.engine_builder._get_gpu_name",
+                           return_value=""):
+                    with patch("tensorrt_model_connect.engine_builder._ensure_tokenizer_json"):
+                        with patch("tensorrt_model_connect.engine_builder.write_bundle") as mock_write:
+                            build_bundle(
+                                str(model_dir),
+                                output_path,
+                                precision="bf16",
+                            )
+
+        sections = mock_write.call_args[0][2]
+        assert [section.name for section in sections[:2]] == [
+            "engine_plan",
+            "prefill_engine_plan",
+        ]
+        assert sections[0].data == b"decode:dual_profile"
+        assert sections[1].data == b"prefill:prefill"
+        assert scopes == [
+            "split-qwen3-h64-l2-bf16-noquant-prefill",
+            "split-qwen3-h64-l2-bf16-noquant-decode",
+        ]
 
     def test_load_weights_precision_not_forwarded_when_unsupported(self, tmp_path):
         """build_bundle remains compatible with plugins that do not accept precision."""

--- a/tests/builder/test_split_decoder_builder_contract.py
+++ b/tests/builder/test_split_decoder_builder_contract.py
@@ -1,0 +1,45 @@
+"""Regression coverage for copied standard decoder builders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FAMILIES_DIR = (
+    ROOT / "tensorrt_model_connect" / "tensorrt_model_connect" / "families"
+)
+
+
+def _family_files(name: str) -> list[Path]:
+    return sorted(FAMILIES_DIR.glob(f"*/{name}"))
+
+
+def test_standard_decoder_builder_copies_honor_split_roles():
+    """Each copied standard builder must route split prefill by role."""
+    missing: list[str] = []
+    for path in _family_files("standard_decoder_builder.py"):
+        text = path.read_text(encoding="utf-8")
+        if (
+            "_decoder_engine_role" not in text
+            or "_decoder_engine_layout_supported" not in text
+            or "profile_mode=(" not in text
+        ):
+            missing.append(str(path.relative_to(ROOT)))
+
+    assert not missing
+
+
+def test_dual_profile_builder_copies_support_prefill_only_mode():
+    """Each copied dual-profile builder must be able to emit prefill only."""
+    missing: list[str] = []
+    for path in _family_files("dual_profile_decoder_builder.py"):
+        text = path.read_text(encoding="utf-8")
+        if (
+            'profile_mode: str = "dual_profile"' not in text
+            or 'profile_mode == "prefill"' not in text
+            or "TRTMC_REVERSE_PROFILE_ORDER" not in text
+        ):
+            missing.append(str(path.relative_to(ROOT)))
+
+    assert not missing

--- a/tests/builder/test_trt_compat_boundary.py
+++ b/tests/builder/test_trt_compat_boundary.py
@@ -253,3 +253,16 @@ def test_trt_compat_applies_builder_env_and_persists_timing_cache(monkeypatch, t
     assert ("create_timing_cache", b"") in calls
     assert ("set_timing_cache", True) in calls
     assert ("get_timing_cache",) in calls
+
+
+def test_trt_compat_scoped_timing_cache_uses_separate_path(monkeypatch, tmp_path):
+    cache_path = tmp_path / "tensorrt-opt1.cache"
+    monkeypatch.setenv("TRTMC_TRT_TIMING_CACHE_PATH", str(cache_path))
+
+    with trt_compat.scoped_timing_cache("split qwen/decode"):
+        assert (
+            trt_compat._timing_cache_path()
+            == tmp_path / "tensorrt-opt1.split_qwen_decode.cache"
+        )
+
+    assert trt_compat._timing_cache_path() == cache_path


### PR DESCRIPTION
Port of the split prefill and decode engine work.

## Summary

This change keeps the fast batched-prefill path from the dual-profile decoder builder while recovering decode specialization by defaulting supported decoder LLMs to separate prefill and decode engines.

- Adds `--decoder-engine-layout={split,dual_profile}`.
- Uses `split` as the default for supported standard decoder LLMs.
- Keeps `dual_profile` as the explicit low-VRAM option.
- Stores the decode-only engine in `engine_plan` and the batched prefill engine in `prefill_engine_plan`.
- Updates runtime loading so split bundles use one prefill module and one decode-specialized module sharing the same CUDA stream/KV cache.
- Keeps unsupported/custom runtimes on their existing single-engine path.
- Includes BF16 constant/type fixes needed by non-Qwen families after the split path is enabled.

## Performance Summary

Full verification was run on `gb300-nvl-019-compute02.nvidia.com` in `trtf-dev-gb300-yihengz`.

Representative BF16 tiny-family matrix vs ToT:

| Family | Split tok/s | ToT tok/s | Delta | Split decode ms | ToT decode ms |
|---|---:|---:|---:|---:|---:|
| llama | 867.45 | 844.56 | +2.7% | 36.89 | 37.89 |
| mistral | 861.67 | 847.48 | +1.7% | 37.14 | 37.76 |
| gemma | 591.24 | 578.76 | +2.2% | 54.12 | 55.29 |
| phi4_multimodal | 642.33 | 633.07 | +1.5% | 49.82 | 50.55 |
| opt | 774.60 | 749.51 | +3.3% | 41.31 | 42.69 |
| bloom | 961.82 | 845.29 | +13.8% | 33.27 | 37.86 |
| gpt_neo | 959.31 | 889.71 | +7.8% | 33.36 | 35.97 |
| gpt_neox | 888.98 | 846.92 | +5.0% | 36.00 | 37.78 |
| codegen | 912.49 | 842.19 | +8.3% | 35.07 | 38.00 |

Split-specific BF16 fixes were validated for:

- OPT: `prefill_ms=9.16`, `decode_ms=41.31`, `tokens_per_sec=774.60`
- Bloom: `prefill_ms=8.88`, `decode_ms=33.27`, `tokens_per_sec=961.82`
- GPT-Neo: `prefill_ms=7.90`, `decode_ms=33.36`, `tokens_per_sec=959.31`

Qwen3-0.6B common settings, max cache 2048:

| Precision | ISL/OSL | Split tok/s | Dual-profile tok/s | Split decode ms | Dual decode ms | Split memory | Dual memory |
|---|---:|---:|---:|---:|---:|---:|---:|
| FP8-like | 16/32 | 322.36 | 319.76 | 99.27 | 100.08 | - | - |
| FP8-like | 128/128 | 319.36 | 321.63 | 400.80 | 397.97 | - | - |
| FP8-like | 512/128 | 320.76 | 321.09 | 399.05 | 398.64 | - | - |
| FP8-like | 1024/256 | 320.41 | 319.51 | 798.99 | 801.22 | 5348 MB | 4280 MB |
| BF16 | 16/32 | 315.46 | 311.95 | 101.44 | 102.58 | - | - |
| BF16 | 128/128 | 313.59 | 315.53 | 408.18 | 405.67 | - | - |
| BF16 | 512/128 | 306.97 | 315.75 | 416.98 | 405.39 | - | - |
| BF16 | 1024/256 | 313.67 | 315.31 | 816.14 | 811.89 | 5702 MB | 4476 MB |

Kernel inspection:

- Qwen split BF16: decode engine recovered `_gemv_mha_v1=28`; prefill engine used `_gemm_mha_v2=28`.
- Qwen split FP8-like: decode engine recovered GEMV count `56`; prefill engine used GEMM count `56`.
- Bloom/GPT-Neo split builds also recovered GEMV/GEMM separation where tiny dimensions exposed kernels.

Interpretation: split recovers decode-specialized kernels and improves representative decode throughput across the tested LLM families. Qwen E2E throughput is mixed by ISL/OSL because memory and prefill/decode balance differ by setting; split consumes more memory, so `dual_profile` remains available as the explicit low-VRAM mode.

## GitHub Port Verification

Rebased/cherry-picked onto `NVIDIA/TensorRT-Model-Connect` `main` at `a5a3363e8f21424801208da89deedd4e1e629265`.

Local:

- `git diff --check upstream/main..HEAD`
- `python3 -m py_compile tensorrt_model_connect/tensorrt_model_connect/cli.py tensorrt_model_connect/tensorrt_model_connect/engine_builder.py tensorrt_model_connect/tensorrt_model_connect/standard_decoder_builder.py tensorrt_model_connect/tensorrt_model_connect/dual_profile_decoder_builder.py tensorrt_model_connect/tensorrt_model_connect/graph_ops.py`
- `PYTHONPATH=tensorrt_model_connect python3 -m pytest tests/builder/test_cli.py -q` -> `31 passed`

GB300 container `trtf-dev-gb300-yihengz`:

- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j 16 --target trtmc trtmc_backend_trt test_text_generation_pipeline test_trt_runtime_lifetime test_decode_runtime`
- `ctest --test-dir build -R '(text_generation_pipeline|trt_runtime_lifetime|decode_runtime)' --output-on-failure` -> `3/3 passed`
- `PYTHONPATH=tensorrt_model_connect python3 -m pytest tests/builder/test_cli.py -q` -> `31 passed`, with existing ConvBERT invalid-escape warnings
