### PR TITLE
feat(elf): add diffusion text runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ add_library(trtmc_core
   src/runtime/models/patchtsmixer/pipeline.cpp
   src/runtime/models/timesfm/pipeline.cpp
   src/runtime/models/chronos_bolt/pipeline.cpp
+  src/runtime/models/elf_flow/pipeline.cpp
   src/runtime/models/segmentation/segment_pipeline.cpp
   src/runtime/models/segmentation/sam_pipeline.cpp
   src/runtime/models/vision_language/pipeline.cpp
@@ -611,6 +612,7 @@ trtmc_add_test(test_text_generation_pipeline REQUIRES_TRT)
 if(TARGET trtmc_backend_trt)
   target_link_libraries(test_text_generation_pipeline PRIVATE trtmc_backend_trt)
 endif()
+trtmc_add_test(test_elf_flow_pipeline)
 trtmc_add_test(test_recurrent_pipeline REQUIRES_TRT)
 if(TARGET trtmc_backend_trt)
   target_link_libraries(test_recurrent_pipeline PRIVATE trtmc_backend_trt)

--- a/cmake/trtmc_pipeline_plugins.cmake
+++ b/cmake/trtmc_pipeline_plugins.cmake
@@ -18,6 +18,7 @@ set(TRTMC_PIPELINE_PLUGINS
   "models/patchtsmixer/plugin.cpp|register_patchtsmixer_plugin"
   "models/timesfm/plugin.cpp|register_timesfm_plugin"
   "models/chronos_bolt/plugin.cpp|register_chronos_bolt_plugin"
+  "models/elf_flow/plugin.cpp|register_elf_flow_plugin"
   "models/segmentation/plugin.cpp|register_segmentation_plugin"
   "models/encoder/object_detection_plugin.cpp|register_object_detection_plugin"
   "models/vision_language/plugin.cpp|register_vl_plugin"

--- a/examples/trtmc_cli.cpp
+++ b/examples/trtmc_cli.cpp
@@ -2,7 +2,11 @@
 //
 // Usage:
 //   trtmc run             <bundle.trtfb> --prompt "text" [--max-new-tokens N] [--benchmark N]
-//                        [--warmup N] [--hf-python PATH]
+//                        [--warmup N] [--num-samples N] [--num-steps N]
+//                        [--guidance-scale S] [--cfg-scale S] [--sde-gamma S]
+//                        [--initial-latents-raw PATH] [--condition-latents-raw PATH]
+//                        [--condition-mask-raw PATH] [--sampling-steps-raw PATH]
+//                        [--sde-noise-raw PATH] [--output samples.jsonl] [--hf-python PATH]
 //   trtmc transcribe      <bundle.trtfb> --audio FILE.wav [--max-new-tokens N] [--hf-python PATH]
 //   trtmc speak           <bundle.trtfb> --audio-in INPUT.wav --audio-out OUTPUT.wav
 //   trtmc generate-video  <bundle.trtfb> --prompt "text" --output DIR [--num-steps N]
@@ -46,6 +50,10 @@ struct CliArgs {
     std::string image_path;
     std::string output_dir;
     std::string initial_latents_raw;
+    std::string condition_latents_raw;
+    std::string condition_mask_raw;
+    std::string sampling_steps_raw;
+    std::string sde_noise_raw;
     std::string document;
     std::string audio_in;
     std::string audio_out;
@@ -57,6 +65,7 @@ struct CliArgs {
     float point_y{0.5F};
     bool is_foreground{true};
     int max_new_tokens{0};
+    int num_samples{1};
     int benchmark{0}; // >0: run N timed iterations after warmup
     int warmup{1};    // number of warmup iterations before timing
     float temperature{1.0F};
@@ -66,6 +75,7 @@ struct CliArgs {
     int seed{-1};
     int num_steps{-1};
     float guidance_scale{-1.0F};
+    float sde_gamma{-1.0F};
     float conf_threshold{-1.0F};
     float cfg_scale{-1.0F};
     bool greedy{false};
@@ -159,7 +169,11 @@ void print_usage() {
            "  trtmc run             <bundle.trtfb> --prompt \"text\" [--image PATH] "
            "[--max-new-tokens N] [--temperature F] [--top-p F] [--min-p F] "
            "[--top-k N] [--seed N] [--benchmark N] [--warmup N] [--hf-python PATH] "
-           "[--kv-cache-size SIZE] [--chat-template] [--no-thinking]\n"
+           "[--kv-cache-size SIZE] [--chat-template] [--no-thinking] "
+           "[--num-samples N] [--num-steps N] [--guidance-scale S] [--cfg-scale S] "
+           "[--sde-gamma S] [--initial-latents-raw PATH] [--condition-latents-raw PATH] "
+           "[--condition-mask-raw PATH] [--sampling-steps-raw PATH] [--sde-noise-raw PATH] "
+           "[--output samples.jsonl]\n"
            "  trtmc encode          <bundle.trtfb> --prompt \"text\" [--hf-python PATH]\n"
            "  trtmc segment         <bundle.trtfb> --image PATH --output PATH [--hf-python PATH]\n"
            "  trtmc segment-sam     <bundle.trtfb> --image PATH --output DIR "
@@ -246,6 +260,10 @@ CliArgs parse_args(int argc, char** argv) {
             args.max_new_tokens = std::atoi(argv[++i]);
             continue;
         }
+        if (arg == "--num-samples" && need_value(arg)) {
+            args.num_samples = std::max(1, std::atoi(argv[++i]));
+            continue;
+        }
         if (arg == "--benchmark" && need_value(arg)) {
             args.benchmark = std::atoi(argv[++i]);
             continue;
@@ -317,12 +335,32 @@ CliArgs parse_args(int argc, char** argv) {
             args.initial_latents_raw = argv[++i];
             continue;
         }
+        if (arg == "--condition-latents-raw" && need_value(arg)) {
+            args.condition_latents_raw = argv[++i];
+            continue;
+        }
+        if (arg == "--condition-mask-raw" && need_value(arg)) {
+            args.condition_mask_raw = argv[++i];
+            continue;
+        }
+        if (arg == "--sampling-steps-raw" && need_value(arg)) {
+            args.sampling_steps_raw = argv[++i];
+            continue;
+        }
+        if (arg == "--sde-noise-raw" && need_value(arg)) {
+            args.sde_noise_raw = argv[++i];
+            continue;
+        }
         if (arg == "--num-steps" && need_value(arg)) {
             args.num_steps = std::atoi(argv[++i]);
             continue;
         }
         if (arg == "--guidance-scale" && need_value(arg)) {
             args.guidance_scale = static_cast<float>(std::atof(argv[++i]));
+            continue;
+        }
+        if (arg == "--sde-gamma" && need_value(arg)) {
+            args.sde_gamma = static_cast<float>(std::atof(argv[++i]));
             continue;
         }
         if ((arg == "--threshold" || arg == "--score-threshold") && need_value(arg)) {
@@ -497,6 +535,55 @@ std::optional<std::vector<float>> read_float32_raw_file(const std::string& path,
     return values;
 }
 
+std::string json_escape(const std::string& text) {
+    std::ostringstream out;
+    for (unsigned char ch : text) {
+        switch (ch) {
+        case '"':
+            out << "\\\"";
+            break;
+        case '\\':
+            out << "\\\\";
+            break;
+        case '\b':
+            out << "\\b";
+            break;
+        case '\f':
+            out << "\\f";
+            break;
+        case '\n':
+            out << "\\n";
+            break;
+        case '\r':
+            out << "\\r";
+            break;
+        case '\t':
+            out << "\\t";
+            break;
+        default:
+            if (ch < 0x20U) {
+                out << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+                    << static_cast<int>(ch) << std::dec << std::setfill(' ');
+            } else {
+                out << static_cast<char>(ch);
+            }
+            break;
+        }
+    }
+    return out.str();
+}
+
+void write_text_sample_jsonl(std::ostream& out, int32_t id, const trtmc::TextResult& result) {
+    out << "{\"id\":" << id << ",\"generated\":\"" << json_escape(result.text)
+        << "\",\"token_ids\":[";
+    for (std::size_t i = 0; i < result.token_ids.size(); ++i) {
+        if (i > 0)
+            out << ',';
+        out << result.token_ids[i];
+    }
+    out << "]}\n";
+}
+
 int cmd_run(const CliArgs& args) {
     if (args.bundle_path.empty()) {
         std::cerr << "Error: run requires a .trtfb bundle file\n";
@@ -509,11 +596,17 @@ int cmd_run(const CliArgs& args) {
         return EXIT_FAILURE;
     }
 
-    const std::string prompt = args.prompt.empty() ? "Hello" : args.prompt;
+    const std::string ptype = pipeline->pipeline_type();
+    const std::string prompt =
+        args.prompt.empty() && ptype != "ElfFlowPipeline" ? "Hello" : args.prompt;
     trtmc::GenerateConfig cfg;
-    cfg.max_new_tokens = args.max_new_tokens > 0 ? args.max_new_tokens : 20;
+    cfg.max_new_tokens =
+        args.max_new_tokens > 0 ? args.max_new_tokens : (ptype == "ElfFlowPipeline" ? 0 : 20);
+    cfg.num_samples = args.num_samples;
     cfg.num_steps = args.num_steps;
     cfg.guidance_scale = args.guidance_scale;
+    cfg.cfg_scale = args.cfg_scale;
+    cfg.sde_gamma = args.sde_gamma;
     cfg.use_chat_template = args.chat_template;
     cfg.enable_thinking = !args.no_thinking;
     cfg.temperature = args.greedy ? 0.0F : args.temperature;
@@ -521,9 +614,53 @@ int cmd_run(const CliArgs& args) {
     cfg.min_p = args.min_p;
     cfg.top_k = args.top_k;
     cfg.seed = args.seed;
+    if (!args.initial_latents_raw.empty()) {
+        std::string error;
+        auto latents = read_float32_raw_file(args.initial_latents_raw, error);
+        if (!latents) {
+            std::cerr << "Error: failed to read --initial-latents-raw: " << error << '\n';
+            return EXIT_FAILURE;
+        }
+        cfg.initial_latents = std::move(*latents);
+    }
+    if (!args.condition_latents_raw.empty()) {
+        std::string error;
+        auto latents = read_float32_raw_file(args.condition_latents_raw, error);
+        if (!latents) {
+            std::cerr << "Error: failed to read --condition-latents-raw: " << error << '\n';
+            return EXIT_FAILURE;
+        }
+        cfg.condition_latents = std::move(*latents);
+    }
+    if (!args.condition_mask_raw.empty()) {
+        std::string error;
+        auto mask = read_float32_raw_file(args.condition_mask_raw, error);
+        if (!mask) {
+            std::cerr << "Error: failed to read --condition-mask-raw: " << error << '\n';
+            return EXIT_FAILURE;
+        }
+        cfg.condition_mask = std::move(*mask);
+    }
+    if (!args.sampling_steps_raw.empty()) {
+        std::string error;
+        auto steps = read_float32_raw_file(args.sampling_steps_raw, error);
+        if (!steps) {
+            std::cerr << "Error: failed to read --sampling-steps-raw: " << error << '\n';
+            return EXIT_FAILURE;
+        }
+        cfg.sampling_steps = std::move(*steps);
+    }
+    if (!args.sde_noise_raw.empty()) {
+        std::string error;
+        auto noise = read_float32_raw_file(args.sde_noise_raw, error);
+        if (!noise) {
+            std::cerr << "Error: failed to read --sde-noise-raw: " << error << '\n';
+            return EXIT_FAILURE;
+        }
+        cfg.sde_noises = std::move(*noise);
+    }
 
     // Detect diffusion pipelines — they use generate_image(), not generate().
-    const std::string ptype = pipeline->pipeline_type();
     const bool is_diffusion =
         (ptype.find("Diffusion") != std::string::npos || ptype.find("Flux") != std::string::npos ||
          ptype.find("Wan") != std::string::npos || ptype.find("ZImage") != std::string::npos ||
@@ -614,9 +751,43 @@ int cmd_run(const CliArgs& args) {
         print_text_timing(result);
         std::cout << result.text << '\n';
     } else {
-        auto result = pipeline->generate(prompt, cfg);
-        print_text_timing(result);
-        std::cout << result.text << '\n';
+        const int samples = std::max(1, cfg.num_samples);
+        if (!cfg.initial_latents.empty() && samples > 1) {
+            std::cerr << "Error: --initial-latents-raw can only be used with one sample\n";
+            return EXIT_FAILURE;
+        }
+
+        std::ofstream jsonl_file;
+        std::ostream* jsonl_out = nullptr;
+        if (!args.output_dir.empty()) {
+            auto out_path = std::filesystem::path(args.output_dir);
+            auto parent = out_path.parent_path();
+            if (!parent.empty())
+                std::filesystem::create_directories(parent);
+            jsonl_file.open(out_path, std::ios::out | std::ios::trunc);
+            if (!jsonl_file) {
+                std::cerr << "Error: failed to open " << args.output_dir << " for writing\n";
+                return EXIT_FAILURE;
+            }
+            jsonl_out = &jsonl_file;
+        } else if (samples > 1) {
+            jsonl_out = &std::cout;
+        }
+
+        for (int i = 0; i < samples; ++i) {
+            trtmc::GenerateConfig sample_cfg = cfg;
+            if (cfg.seed >= 0)
+                sample_cfg.seed = cfg.seed + i;
+            auto result = pipeline->generate(prompt, sample_cfg);
+            print_text_timing(result);
+            if (jsonl_out) {
+                write_text_sample_jsonl(*jsonl_out, i, result);
+            } else {
+                std::cout << result.text << '\n';
+            }
+        }
+        if (jsonl_file.is_open())
+            std::cout << "Saved " << args.output_dir << " (" << samples << " samples)\n";
     }
     return EXIT_SUCCESS;
 }

--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -91,14 +91,21 @@ struct TextEmbedding {
 
 struct GenerateConfig {
     int32_t max_new_tokens{128};
+    int32_t num_samples{1}; // non-AR generators: number of independent samples to emit
     float temperature{1.0f};
     int32_t top_k{1};  // 1 = greedy unless top_p is active; <=0 = no top-k limit
     float top_p{1.0f}; // 1.0 = disabled, 0.0 = greedy, (0,1) = nucleus
     float min_p{0.0f}; // 0.0 = disabled; filters tokens below min_p * max_prob
     int32_t seed{-1};
-    float guidance_scale{-1.0f};        // diffusion
-    int32_t num_steps{-1};              // diffusion
-    std::vector<float> initial_latents; // diffusion: optional packed initial latents
+    float guidance_scale{-1.0f};          // diffusion; ELF uses this as self-conditioning CFG scale
+    float cfg_scale{-1.0f};               // conditional CFG scale; <0 uses model default
+    int32_t num_steps{-1};                // diffusion
+    float sde_gamma{-1.0f};               // diffusion/flow matching; <0 uses model default
+    std::vector<float> initial_latents;   // diffusion: optional packed initial latents
+    std::vector<float> condition_latents; // ELF: [max_length, text_encoder_dim] cond seq
+    std::vector<float> condition_mask;    // ELF: [max_length], >0 marks fixed cond tokens
+    std::vector<float> sampling_steps;    // ELF: optional upstream t_steps [num_steps + 1]
+    std::vector<float> sde_noises;        // ELF: optional scaled eps [num_steps - 1, L, D]
     int32_t eos_token_id{-1};
     int32_t tail_frames{0};           // speech-to-speech: extra frames after input
     bool use_chat_template{false};    ///< Apply chat template before tokenization

--- a/src/runtime/models/elf_flow/MODEL.toml
+++ b/src/runtime/models/elf_flow/MODEL.toml
@@ -1,0 +1,2 @@
+runtime_strategies = ["elf_flow"]
+task_strategy = "diffusion_text_generation"

--- a/src/runtime/models/elf_flow/pipeline.cpp
+++ b/src/runtime/models/elf_flow/pipeline.cpp
@@ -1,0 +1,756 @@
+#include "runtime/models/elf_flow/pipeline.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace trtmc {
+
+namespace {
+
+int32_t infer_static_dim(const TrtModule& module, const std::string& input_name, int32_t axis,
+                         int32_t fallback) {
+    for (const auto& info : module.input_info()) {
+        if (info.name != input_name || axis < 0 || axis >= static_cast<int32_t>(info.shape.size()))
+            continue;
+        const int64_t value = info.shape[static_cast<std::size_t>(axis)];
+        if (value > 0)
+            return static_cast<int32_t>(value);
+    }
+    return fallback;
+}
+
+float trunk_value(const float* trunk_input, int32_t trunk_len, int32_t idx, float fallback) {
+    if (!trunk_input || trunk_len <= idx)
+        return fallback;
+    return trunk_input[idx];
+}
+
+float sigmoid(float value) {
+    return 1.0F / (1.0F + std::exp(-value));
+}
+
+std::uint32_t normalize_seed(int32_t seed) {
+    return seed >= 0 ? static_cast<std::uint32_t>(seed) : 42U;
+}
+
+int32_t argmax_row(const float* row, int32_t width) {
+    int32_t best = 0;
+    float best_value = row[0];
+    for (int32_t i = 1; i < width; ++i) {
+        if (row[i] > best_value) {
+            best_value = row[i];
+            best = i;
+        }
+    }
+    return best;
+}
+
+const Tensor* find_named_output(const TensorMap& outputs, const char* name) {
+    auto it = outputs.find(name);
+    if (it == outputs.end() || !it->second.data || it->second.numel() == 0)
+        return nullptr;
+    return &it->second;
+}
+
+const Tensor* find_any_output(const TensorMap& outputs) {
+    for (const auto& [name, tensor] : outputs) {
+        (void)name;
+        if (tensor.data && tensor.numel() > 0)
+            return &tensor;
+    }
+    return nullptr;
+}
+
+const Tensor* find_text_embedding_output(const TensorMap& outputs) {
+    for (const char* name : {"text_embeddings", "output0", "last_hidden_state"}) {
+        if (const Tensor* output = find_named_output(outputs, name))
+            return output;
+    }
+    return find_any_output(outputs);
+}
+
+std::vector<float> zero_vector_like(const std::vector<float>& values) {
+    return std::vector<float>(values.size(), 0.0F);
+}
+
+int32_t elf_default_num_steps(bool has_condition) {
+    if (has_condition)
+        return 64;
+    return 32;
+}
+
+float elf_default_self_cond_cfg_scale(bool has_condition) {
+    if (has_condition)
+        return 1.0F;
+    return 3.0F;
+}
+
+float elf_default_cfg_scale(bool has_condition) {
+    if (has_condition)
+        return 2.0F;
+    return 1.0F;
+}
+
+float elf_default_sde_gamma(bool has_condition) {
+    if (has_condition)
+        return 0.0F;
+    return 1.5F;
+}
+
+int32_t resolve_positive_int(int32_t value, int32_t fallback) {
+    if (value > 0)
+        return value;
+    return fallback;
+}
+
+float resolve_positive_float(float value, float fallback) {
+    if (value > 0.0F)
+        return value;
+    return fallback;
+}
+
+float resolve_nonnegative_float(float value, float fallback) {
+    if (value >= 0.0F)
+        return value;
+    return fallback;
+}
+
+} // namespace
+
+ElfFlowPipeline::ElfFlowPipeline(std::unique_ptr<TrtModule> model, int32_t max_length,
+                                 int32_t max_input_length, int32_t input_dim, int32_t text_dim,
+                                 int32_t vocab_size, float denoiser_noise_scale,
+                                 float denoiser_p_mean, float denoiser_p_std, float t_eps,
+                                 std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
+                                 std::unique_ptr<TrtModule> text_encoder, float latent_mean,
+                                 float latent_std, int32_t encoder_pad_token_id)
+    : model_(std::move(model)), text_encoder_(std::move(text_encoder)), max_length_(max_length),
+      max_input_length_(max_input_length), input_dim_(input_dim), text_dim_(text_dim),
+      vocab_size_(vocab_size), denoiser_noise_scale_(denoiser_noise_scale),
+      denoiser_p_mean_(denoiser_p_mean), denoiser_p_std_(denoiser_p_std), t_eps_(t_eps),
+      latent_mean_(latent_mean), latent_std_(latent_std),
+      encoder_pad_token_id_(encoder_pad_token_id), tokenizer_(std::move(tokenizer)),
+      model_id_(std::move(model_id_str)) {
+    if (!model_ || !model_->ok())
+        throw std::runtime_error("ElfFlowPipeline: invalid TRT module");
+    configure_model_dimensions();
+    configure_text_encoder();
+}
+
+void ElfFlowPipeline::configure_model_dimensions() {
+    max_length_ = infer_static_dim(*model_, "latent", 0, max_length_);
+    input_dim_ = infer_static_dim(*model_, "latent", 1, input_dim_);
+    if (max_length_ <= 0 || input_dim_ <= 0)
+        throw std::runtime_error("ElfFlowPipeline: invalid latent input shape");
+    if (max_input_length_ < 0)
+        max_input_length_ = 0;
+    if (max_input_length_ >= max_length_)
+        max_input_length_ = 0;
+    if (text_dim_ <= 0)
+        text_dim_ = input_dim_;
+    if (input_dim_ != text_dim_ && input_dim_ != 2 * text_dim_)
+        throw std::runtime_error("ElfFlowPipeline: input_dim must equal text_dim or 2 * text_dim");
+    if (latent_std_ == 0.0F)
+        throw std::runtime_error("ElfFlowPipeline: latent_std must be non-zero");
+}
+
+void ElfFlowPipeline::configure_text_encoder() {
+    encoder_seq_length_ = max_length_;
+    if (!text_encoder_)
+        return;
+    if (!text_encoder_->ok())
+        throw std::runtime_error("ElfFlowPipeline: invalid text encoder TRT module");
+    encoder_seq_length_ = infer_static_dim(*text_encoder_, "input_ids", 1, max_length_);
+    if (encoder_seq_length_ != max_length_) {
+        throw std::runtime_error(
+            "ElfFlowPipeline: text encoder sequence length must match elf_max_length");
+    }
+}
+
+const Tensor* ElfFlowPipeline::select_output(const TensorMap& outputs, bool decoder_mode) {
+    const char* preferred = decoder_mode ? "decoder_logits" : "denoised";
+    if (const Tensor* output = find_named_output(outputs, preferred))
+        return output;
+
+    const char* fallback = decoder_mode ? "denoised" : "decoder_logits";
+    if (const Tensor* output = find_named_output(outputs, fallback))
+        return output;
+    return find_any_output(outputs);
+}
+
+std::vector<float> ElfFlowPipeline::copy_tensor_data(const Tensor& tensor) {
+    std::vector<float> data(tensor.numel());
+    if (!data.empty() && tensor.data)
+        std::memcpy(data.data(), tensor.data, data.size() * sizeof(float));
+    return data;
+}
+
+void ElfFlowPipeline::add_self_cond_cfg_input(TensorMap& inputs, Tensor& tensor) const {
+    if (model_->has_input("self_cond_cfg_scale"))
+        inputs["self_cond_cfg_scale"] = tensor;
+}
+
+int32_t ElfFlowPipeline::resolve_forward_row_dim(const Tensor& tensor, bool decoder_mode) const {
+    int32_t row_dim = tensor.shape.empty() ? static_cast<int32_t>(tensor.numel())
+                                           : static_cast<int32_t>(tensor.shape.back());
+    if (decoder_mode && vocab_size_ > 0)
+        row_dim = vocab_size_;
+    if (!decoder_mode && text_dim_ > 0)
+        row_dim = text_dim_;
+    return row_dim;
+}
+
+ElfFlowPipeline::ForwardOutput ElfFlowPipeline::forward_model(const std::vector<float>& latent,
+                                                              float timestep,
+                                                              float self_cond_cfg_scale,
+                                                              bool decoder_mode) {
+    const int32_t expected = max_length_ * input_dim_;
+    if (static_cast<int32_t>(latent.size()) != expected)
+        throw std::runtime_error("ElfFlowPipeline: latent size does not match engine input shape");
+
+    float decoder_mode_value = decoder_mode ? 1.0F : 0.0F;
+    Tensor latent_t{const_cast<float*>(latent.data()), {max_length_, input_dim_}, DType::kFloat32};
+    Tensor timestep_t{&timestep, {1}, DType::kFloat32};
+    Tensor decoder_mode_t{&decoder_mode_value, {1}, DType::kFloat32};
+    Tensor self_cond_cfg_t{&self_cond_cfg_scale, {1}, DType::kFloat32};
+
+    TensorMap inputs;
+    inputs["latent"] = latent_t;
+    inputs["timestep"] = timestep_t;
+    inputs["decoder_mode"] = decoder_mode_t;
+    add_self_cond_cfg_input(inputs, self_cond_cfg_t);
+
+    auto outputs = model_->forward(inputs);
+    const Tensor* selected = select_output(outputs, decoder_mode);
+    if (!selected)
+        throw std::runtime_error("ElfFlowPipeline: no ELF output found in engine");
+
+    ForwardOutput out;
+    out.data = copy_tensor_data(*selected);
+    out.row_dim = resolve_forward_row_dim(*selected, decoder_mode);
+    return out;
+}
+
+std::vector<float> ElfFlowPipeline::build_model_latent(const std::vector<float>& z,
+                                                       const std::vector<float>& self_cond) const {
+    const std::size_t text_numel =
+        static_cast<std::size_t>(max_length_) * static_cast<std::size_t>(text_dim_);
+    if (z.size() != text_numel || self_cond.size() != text_numel)
+        throw std::runtime_error("ElfFlowPipeline: invalid text latent size");
+
+    if (input_dim_ == text_dim_)
+        return z;
+    if (input_dim_ != 2 * text_dim_)
+        throw std::runtime_error("ElfFlowPipeline: unsupported self-conditioning input shape");
+
+    std::vector<float> model_latent(static_cast<std::size_t>(max_length_) *
+                                    static_cast<std::size_t>(input_dim_));
+    for (int32_t pos = 0; pos < max_length_; ++pos) {
+        const std::size_t src = static_cast<std::size_t>(pos) * static_cast<std::size_t>(text_dim_);
+        const std::size_t dst =
+            static_cast<std::size_t>(pos) * static_cast<std::size_t>(input_dim_);
+        std::copy(z.begin() + static_cast<std::ptrdiff_t>(src),
+                  z.begin() + static_cast<std::ptrdiff_t>(src + text_dim_),
+                  model_latent.begin() + static_cast<std::ptrdiff_t>(dst));
+        std::copy(self_cond.begin() + static_cast<std::ptrdiff_t>(src),
+                  self_cond.begin() + static_cast<std::ptrdiff_t>(src + text_dim_),
+                  model_latent.begin() + static_cast<std::ptrdiff_t>(dst + text_dim_));
+    }
+    return model_latent;
+}
+
+std::vector<float> ElfFlowPipeline::make_sampling_steps(const GenerateConfig& cfg,
+                                                        int32_t num_steps, int32_t seed) const {
+    if (!cfg.sampling_steps.empty()) {
+        if (cfg.sampling_steps.size() < 2U)
+            throw std::runtime_error("ElfFlowPipeline: sampling_steps must contain at least "
+                                     "start and end timesteps");
+        for (std::size_t i = 1; i < cfg.sampling_steps.size(); ++i) {
+            if (cfg.sampling_steps[i] < cfg.sampling_steps[i - 1])
+                throw std::runtime_error("ElfFlowPipeline: sampling_steps must be sorted");
+        }
+        return cfg.sampling_steps;
+    }
+    if (num_steps <= 0)
+        num_steps = 32;
+    std::vector<float> steps;
+    steps.reserve(static_cast<std::size_t>(num_steps) + 1U);
+    steps.push_back(0.0F);
+    if (num_steps > 1) {
+        std::mt19937 rng(normalize_seed(seed) ^ 0x9E3779B9U);
+        std::normal_distribution<float> normal(denoiser_p_mean_, denoiser_p_std_);
+        std::vector<float> middle;
+        middle.reserve(static_cast<std::size_t>(num_steps - 1));
+        for (int32_t i = 0; i < num_steps - 1; ++i)
+            middle.push_back(sigmoid(normal(rng)));
+        std::sort(middle.begin(), middle.end());
+        steps.insert(steps.end(), middle.begin(), middle.end());
+    }
+    steps.push_back(1.0F);
+    return steps;
+}
+
+std::vector<float> ElfFlowPipeline::make_initial_latent(const GenerateConfig& cfg,
+                                                        int32_t seed) const {
+    const std::size_t n =
+        static_cast<std::size_t>(max_length_) * static_cast<std::size_t>(text_dim_);
+    if (!cfg.initial_latents.empty()) {
+        if (cfg.initial_latents.size() != n)
+            throw std::runtime_error("ElfFlowPipeline: initial_latents must have elf_max_length * "
+                                     "elf_text_encoder_dim values");
+        return cfg.initial_latents;
+    }
+    std::vector<float> latent(n);
+    std::mt19937 rng(normalize_seed(seed));
+    std::normal_distribution<float> normal(0.0F, denoiser_noise_scale_);
+    for (float& value : latent)
+        value = normal(rng);
+    return latent;
+}
+
+std::vector<float> ElfFlowPipeline::make_condition_latents(const GenerateConfig& cfg) const {
+    const std::size_t n =
+        static_cast<std::size_t>(max_length_) * static_cast<std::size_t>(text_dim_);
+    if (cfg.condition_latents.empty())
+        return std::vector<float>(n, 0.0F);
+    if (cfg.condition_latents.size() != n)
+        throw std::runtime_error("ElfFlowPipeline: condition_latents must have elf_max_length * "
+                                 "elf_text_encoder_dim values");
+    return cfg.condition_latents;
+}
+
+std::vector<float> ElfFlowPipeline::make_condition_mask(const GenerateConfig& cfg) const {
+    if (cfg.condition_mask.empty())
+        return std::vector<float>(static_cast<std::size_t>(max_length_), 0.0F);
+    if (cfg.condition_mask.size() != static_cast<std::size_t>(max_length_))
+        throw std::runtime_error("ElfFlowPipeline: condition_mask must have elf_max_length values");
+    return cfg.condition_mask;
+}
+
+ElfFlowPipeline::PromptTokenSpan
+ElfFlowPipeline::trim_prompt_tokens(const std::vector<int32_t>& encoded,
+                                    int32_t eos_token_id) const {
+    PromptTokenSpan span;
+    span.end = encoded.size();
+    auto is_generated_special = [&](int32_t id) {
+        return (eos_token_id >= 0 && id == eos_token_id) || id == encoder_pad_token_id_;
+    };
+    while (span.begin < span.end && is_generated_special(encoded[span.begin]))
+        ++span.begin;
+    while (span.end > span.begin && is_generated_special(encoded[span.end - 1]))
+        --span.end;
+
+    const int32_t prompt_limit =
+        max_input_length_ > 0 ? std::min(max_input_length_, max_length_) : max_length_;
+    span.length = std::min(prompt_limit, static_cast<int32_t>(span.end - span.begin));
+    if (span.length <= 0)
+        throw std::runtime_error("ElfFlowPipeline: prompt encoded to no ELF condition tokens");
+    return span;
+}
+
+ElfFlowPipeline::PromptEncoderInputs
+ElfFlowPipeline::make_prompt_encoder_inputs(const std::vector<int32_t>& encoded,
+                                            const PromptTokenSpan& span) const {
+    PromptEncoderInputs inputs;
+    inputs.input_ids.assign(static_cast<std::size_t>(encoder_seq_length_), encoder_pad_token_id_);
+    inputs.attention_mask.assign(static_cast<std::size_t>(encoder_seq_length_), -1e9F);
+    for (int32_t i = 0; i < span.length; ++i) {
+        inputs.input_ids[static_cast<std::size_t>(i)] =
+            encoded[span.begin + static_cast<std::size_t>(i)];
+        inputs.attention_mask[static_cast<std::size_t>(i)] = 0.0F;
+    }
+    return inputs;
+}
+
+std::vector<float> ElfFlowPipeline::normalize_prompt_latents(const Tensor& embeddings) const {
+    const std::size_t expected =
+        static_cast<std::size_t>(max_length_) * static_cast<std::size_t>(text_dim_);
+    if (embeddings.numel() < expected)
+        throw std::runtime_error("ElfFlowPipeline: invalid text encoder output shape");
+
+    std::vector<float> latents(expected, 0.0F);
+    const auto* raw = static_cast<const float*>(embeddings.data);
+    for (std::size_t i = 0; i < expected; ++i)
+        latents[i] = (raw[i] - latent_mean_) / latent_std_;
+    return latents;
+}
+
+std::vector<float>
+ElfFlowPipeline::run_prompt_encoder(const PromptEncoderInputs& prompt_inputs) const {
+    TensorMap inputs;
+    inputs["input_ids"] = Tensor{const_cast<int32_t*>(prompt_inputs.input_ids.data()),
+                                 {1, static_cast<int64_t>(encoder_seq_length_)},
+                                 DType::kInt32};
+    inputs["attention_mask"] = Tensor{const_cast<float*>(prompt_inputs.attention_mask.data()),
+                                      {1, static_cast<int64_t>(encoder_seq_length_)},
+                                      DType::kFloat32};
+
+    auto outputs = text_encoder_->forward(inputs);
+    const Tensor* embeddings = find_text_embedding_output(outputs);
+    if (!embeddings || embeddings->dtype != DType::kFloat32)
+        throw std::runtime_error("ElfFlowPipeline: text encoder must output fp32 text_embeddings");
+    return normalize_prompt_latents(*embeddings);
+}
+
+ElfFlowPipeline::PromptCondition ElfFlowPipeline::make_prompt_condition(const std::string& prompt,
+                                                                        int32_t eos_token_id) {
+    if (!text_encoder_) {
+        throw std::runtime_error(
+            "ElfFlowPipeline: prompt-conditioned generation requires elf_text_encoder_plan in "
+            "the bundle; pass condition_latents/condition_mask for the raw API path");
+    }
+    if (!tokenizer_)
+        throw std::runtime_error(
+            "ElfFlowPipeline: prompt-conditioned generation requires tokenizer.json");
+
+    const auto encoded = tokenizer_->encode(prompt);
+    const auto span = trim_prompt_tokens(encoded, eos_token_id);
+    const auto prompt_inputs = make_prompt_encoder_inputs(encoded, span);
+
+    PromptCondition out;
+    out.latents = run_prompt_encoder(prompt_inputs);
+    out.mask.assign(static_cast<std::size_t>(max_length_), 0.0F);
+    for (int32_t i = 0; i < span.length; ++i)
+        out.mask[static_cast<std::size_t>(i)] = 1.0F;
+    return out;
+}
+
+ElfFlowPipeline::ConditionState ElfFlowPipeline::make_condition_state(const std::string& prompt,
+                                                                      const GenerateConfig& cfg,
+                                                                      int32_t eos_token_id) {
+    if (!cfg.condition_latents.empty())
+        return ConditionState{make_condition_latents(cfg), make_condition_mask(cfg)};
+    if (prompt.empty())
+        return ConditionState{make_condition_latents(cfg), make_condition_mask(cfg)};
+
+    auto prompt_condition = make_prompt_condition(prompt, eos_token_id);
+    return ConditionState{std::move(prompt_condition.latents), std::move(prompt_condition.mask)};
+}
+
+bool ElfFlowPipeline::has_active_condition(const std::vector<float>& cond_mask) const {
+    return std::any_of(cond_mask.begin(), cond_mask.end(),
+                       [](float value) { return value > 0.0F; });
+}
+
+int32_t ElfFlowPipeline::condition_prefix_tokens(const std::vector<float>& cond_mask) const {
+    int32_t count = 0;
+    for (float value : cond_mask) {
+        if (value > 0.0F)
+            ++count;
+    }
+    return count;
+}
+
+void ElfFlowPipeline::restore_condition(std::vector<float>& values,
+                                        const std::vector<float>& cond_seq,
+                                        const std::vector<float>& cond_mask) const {
+    if (cond_mask.empty())
+        return;
+    for (int32_t pos = 0; pos < max_length_; ++pos) {
+        if (cond_mask[static_cast<std::size_t>(pos)] <= 0.0F)
+            continue;
+        const std::size_t base =
+            static_cast<std::size_t>(pos) * static_cast<std::size_t>(text_dim_);
+        std::copy(cond_seq.begin() + static_cast<std::ptrdiff_t>(base),
+                  cond_seq.begin() + static_cast<std::ptrdiff_t>(base + text_dim_),
+                  values.begin() + static_cast<std::ptrdiff_t>(base));
+    }
+}
+
+void ElfFlowPipeline::zero_condition(std::vector<float>& values,
+                                     const std::vector<float>& cond_mask) const {
+    if (cond_mask.empty())
+        return;
+    for (int32_t pos = 0; pos < max_length_; ++pos) {
+        if (cond_mask[static_cast<std::size_t>(pos)] <= 0.0F)
+            continue;
+        const std::size_t base =
+            static_cast<std::size_t>(pos) * static_cast<std::size_t>(text_dim_);
+        std::fill(values.begin() + static_cast<std::ptrdiff_t>(base),
+                  values.begin() + static_cast<std::ptrdiff_t>(base + text_dim_), 0.0F);
+    }
+}
+
+ElfFlowPipeline::DenoiseOutput ElfFlowPipeline::denoise_pass(const std::vector<float>& z,
+                                                             float timestep,
+                                                             const std::vector<float>& x_pred_prev,
+                                                             float self_cond_cfg_scale,
+                                                             const std::vector<float>& cond_seq,
+                                                             const std::vector<float>& cond_mask) {
+    const auto model_latent = build_model_latent(z, x_pred_prev);
+    const auto denoised = forward_model(model_latent, timestep, self_cond_cfg_scale, false);
+    if (denoised.data.size() != z.size())
+        throw std::runtime_error("ElfFlowPipeline: denoised output shape mismatch");
+
+    DenoiseOutput out;
+    out.x = denoised.data;
+    out.v.resize(z.size());
+    const float denom = std::max(1.0F - timestep, t_eps_);
+    for (std::size_t j = 0; j < z.size(); ++j)
+        out.v[j] = (out.x[j] - z[j]) / denom;
+
+    restore_condition(out.x, cond_seq, cond_mask);
+    zero_condition(out.v, cond_mask);
+    return out;
+}
+
+ElfFlowPipeline::DenoiseOutput
+ElfFlowPipeline::denoise_with_cfg(const std::vector<float>& z, float timestep,
+                                  const std::vector<float>& x_pred_prev, float cfg_scale,
+                                  float self_cond_cfg_scale, const std::vector<float>& cond_seq,
+                                  const std::vector<float>& cond_mask) {
+    auto cond = denoise_pass(z, timestep, x_pred_prev, self_cond_cfg_scale, cond_seq, cond_mask);
+    if (cfg_scale == 1.0F)
+        return cond;
+
+    std::vector<float> z_uncond = z;
+    std::vector<float> x_prev_uncond = x_pred_prev;
+    zero_condition(z_uncond, cond_mask);
+    zero_condition(x_prev_uncond, cond_mask);
+    auto uncond = denoise_pass(z_uncond, timestep, x_prev_uncond, self_cond_cfg_scale,
+                               zero_vector_like(cond_seq), cond_mask);
+
+    DenoiseOutput out;
+    out.v.resize(z.size());
+    out.x.resize(z.size());
+    for (std::size_t j = 0; j < z.size(); ++j) {
+        out.v[j] = uncond.v[j] + cfg_scale * (cond.v[j] - uncond.v[j]);
+        out.x[j] = uncond.x[j] + cfg_scale * (cond.x[j] - uncond.x[j]);
+    }
+    restore_condition(out.x, cond_seq, cond_mask);
+    zero_condition(out.v, cond_mask);
+    return out;
+}
+
+int32_t ElfFlowPipeline::resolve_max_output_tokens(const GenerateConfig& cfg,
+                                                   bool has_condition) const {
+    if (cfg.max_new_tokens > 0)
+        return cfg.max_new_tokens;
+    if (has_condition && max_input_length_ > 0)
+        return std::max(1, max_length_ - max_input_length_);
+    return max_length_;
+}
+
+int32_t ElfFlowPipeline::resolve_eos_token_id(const GenerateConfig& cfg) const {
+    if (cfg.eos_token_id >= 0)
+        return cfg.eos_token_id;
+    if (!tokenizer_)
+        return -1;
+    for (std::string_view token :
+         {"</s>", "<eos>", "<|endoftext|>", "<|end_of_text|>", "<|eot_id|>", "[SEP]"}) {
+        const int32_t id = tokenizer_->id_for_token(token);
+        if (id >= 0)
+            return id;
+    }
+    return -1;
+}
+
+std::vector<int32_t> ElfFlowPipeline::decode_tokens(const std::vector<float>& latent,
+                                                    float self_cond_cfg_scale, int32_t eos_token_id,
+                                                    int32_t prefix_tokens_to_drop,
+                                                    int32_t max_output_tokens) {
+    const auto model_latent = build_model_latent(latent, zero_vector_like(latent));
+    const auto logits = forward_model(model_latent, 1.0F, self_cond_cfg_scale, true);
+    if (logits.row_dim <= 0 ||
+        static_cast<int32_t>(logits.data.size()) < max_length_ * logits.row_dim)
+        throw std::runtime_error("ElfFlowPipeline: invalid decoder logits shape");
+
+    std::vector<int32_t> token_ids;
+    token_ids.reserve(static_cast<std::size_t>(max_length_));
+    const int32_t start = std::max(0, std::min(prefix_tokens_to_drop, max_length_));
+    const int32_t limit =
+        max_output_tokens > 0 ? std::min(max_length_, start + max_output_tokens) : max_length_;
+    for (int32_t pos = start; pos < limit; ++pos) {
+        const float* row = logits.data.data() +
+                           static_cast<std::size_t>(pos) * static_cast<std::size_t>(logits.row_dim);
+        const int32_t token_id = argmax_row(row, logits.row_dim);
+        if (eos_token_id >= 0 && token_id == eos_token_id)
+            break;
+        token_ids.push_back(token_id);
+    }
+    return token_ids;
+}
+
+void ElfFlowPipeline::validate_generate_config(const GenerateConfig& cfg) const {
+    if (!model_ || !model_->ok())
+        throw std::runtime_error("ElfFlowPipeline: invalid TRT module");
+    if (!tokenizer_)
+        throw std::runtime_error("ElfFlowPipeline::generate requires tokenizer.json in the bundle");
+    if (cfg.condition_latents.empty() != cfg.condition_mask.empty()) {
+        throw std::runtime_error(
+            "ElfFlowPipeline: conditional generation requires both condition_latents and "
+            "condition_mask");
+    }
+}
+
+ElfFlowPipeline::SamplingOptions
+ElfFlowPipeline::resolve_sampling_options(const GenerateConfig& cfg, bool has_condition) const {
+    SamplingOptions options;
+    options.seed = cfg.seed >= 0 ? cfg.seed : 42;
+    options.num_steps = resolve_positive_int(cfg.num_steps, elf_default_num_steps(has_condition));
+    options.self_cond_cfg_scale =
+        resolve_positive_float(cfg.guidance_scale, elf_default_self_cond_cfg_scale(has_condition));
+    options.cfg_scale = resolve_positive_float(cfg.cfg_scale, elf_default_cfg_scale(has_condition));
+    options.sde_gamma =
+        resolve_nonnegative_float(cfg.sde_gamma, elf_default_sde_gamma(has_condition));
+    return options;
+}
+
+ElfFlowPipeline::SamplingWorkspace
+ElfFlowPipeline::make_sampling_workspace(const GenerateConfig& cfg, const ConditionState& cond,
+                                         int32_t seed) const {
+    SamplingWorkspace workspace;
+    workspace.z = make_initial_latent(cfg, seed);
+    workspace.x_pred.assign(workspace.z.size(), 0.0F);
+    restore_condition(workspace.z, cond.latents, cond.mask);
+    restore_condition(workspace.x_pred, cond.latents, cond.mask);
+    return workspace;
+}
+
+void ElfFlowPipeline::validate_sde_noises(const GenerateConfig& cfg,
+                                          const std::vector<float>& steps) const {
+    const std::size_t latent_numel =
+        static_cast<std::size_t>(max_length_) * static_cast<std::size_t>(text_dim_);
+    const std::size_t sde_step_count = steps.size() > 1U ? steps.size() - 2U : 0U;
+    if (cfg.sde_noises.empty() || cfg.sde_noises.size() == sde_step_count * latent_numel)
+        return;
+    throw std::runtime_error("ElfFlowPipeline: sde_noises must have "
+                             "(sampling_steps.size() - 2) * elf_max_length * "
+                             "elf_text_encoder_dim values");
+}
+
+void ElfFlowPipeline::apply_sde_perturbation(std::vector<float>& z_eval,
+                                             const std::vector<float>& z, const GenerateConfig& cfg,
+                                             const ConditionState& cond, float sde_gamma, float t,
+                                             float t_next, std::size_t step_idx, float& t_eval,
+                                             std::mt19937& rng,
+                                             std::normal_distribution<float>& normal) const {
+    if (sde_gamma <= 0.0F)
+        return;
+    const float h = t_next - t;
+    const float alpha = std::clamp(1.0F - sde_gamma * h, 0.0F, 1.0F);
+    const std::size_t noise_base = step_idx * z.size();
+    t_eval = alpha * t;
+    for (std::size_t j = 0; j < z_eval.size(); ++j) {
+        const float eps = cfg.sde_noises.empty() ? normal(rng) : cfg.sde_noises[noise_base + j];
+        z_eval[j] = alpha * z[j] + (1.0F - alpha) * eps;
+    }
+    restore_condition(z_eval, cond.latents, cond.mask);
+}
+
+void ElfFlowPipeline::run_intermediate_step(SamplingWorkspace& workspace, const GenerateConfig& cfg,
+                                            const ConditionState& cond,
+                                            const SamplingOptions& options,
+                                            const std::vector<float>& steps, std::size_t step_idx,
+                                            std::mt19937& rng,
+                                            std::normal_distribution<float>& normal) {
+    const float t = steps[step_idx];
+    const float t_next = steps[step_idx + 1U];
+    std::vector<float> z_eval = workspace.z;
+    float t_eval = t;
+    apply_sde_perturbation(z_eval, workspace.z, cfg, cond, options.sde_gamma, t, t_next, step_idx,
+                           t_eval, rng, normal);
+
+    const auto denoised = denoise_with_cfg(z_eval, t_eval, workspace.x_pred, options.cfg_scale,
+                                           options.self_cond_cfg_scale, cond.latents, cond.mask);
+    for (std::size_t j = 0; j < workspace.z.size(); ++j)
+        workspace.z[j] = z_eval[j] + (t_next - t_eval) * denoised.v[j];
+    workspace.x_pred = denoised.x;
+}
+
+void ElfFlowPipeline::run_final_step(SamplingWorkspace& workspace, const ConditionState& cond,
+                                     const SamplingOptions& options,
+                                     const std::vector<float>& steps) {
+    const float t = steps[steps.size() - 2U];
+    const float t_next = steps.back();
+    const auto denoised = denoise_with_cfg(workspace.z, t, workspace.x_pred, options.cfg_scale,
+                                           options.self_cond_cfg_scale, cond.latents, cond.mask);
+    for (std::size_t j = 0; j < workspace.z.size(); ++j)
+        workspace.z[j] = workspace.z[j] + (t_next - t) * denoised.v[j];
+    workspace.x_pred = denoised.x;
+}
+
+void ElfFlowPipeline::run_sampling(SamplingWorkspace& workspace, const GenerateConfig& cfg,
+                                   const ConditionState& cond, const SamplingOptions& options,
+                                   const std::vector<float>& steps) {
+    validate_sde_noises(cfg, steps);
+    std::mt19937 step_rng(normalize_seed(options.seed) ^ 0x85EBCA6BU);
+    std::normal_distribution<float> step_normal(0.0F, denoiser_noise_scale_);
+    for (std::size_t i = 0; i + 2U < steps.size(); ++i)
+        run_intermediate_step(workspace, cfg, cond, options, steps, i, step_rng, step_normal);
+    if (steps.size() >= 2U)
+        run_final_step(workspace, cond, options, steps);
+}
+
+TextResult ElfFlowPipeline::make_text_result(const SamplingWorkspace& workspace,
+                                             const GenerateConfig& cfg,
+                                             const SamplingOptions& options, bool has_condition,
+                                             int32_t eos_token_id, int32_t cond_prefix_len,
+                                             double sampling_ms) {
+    auto t_decode_start = std::chrono::steady_clock::now();
+    TextResult result;
+    result.token_ids =
+        decode_tokens(workspace.z, options.self_cond_cfg_scale, eos_token_id, cond_prefix_len,
+                      resolve_max_output_tokens(cfg, has_condition));
+    result.text = tokenizer_->decode(result.token_ids);
+    auto t_decode_end = std::chrono::steady_clock::now();
+    result.prefill_ms = sampling_ms;
+    result.decode_ms =
+        std::chrono::duration<double, std::milli>(t_decode_end - t_decode_start).count();
+    return result;
+}
+
+TextResult ElfFlowPipeline::generate(const std::string& prompt, const GenerateConfig& cfg) {
+    validate_generate_config(cfg);
+    auto t_start = std::chrono::steady_clock::now();
+    const int32_t eos_token_id = resolve_eos_token_id(cfg);
+    auto cond = make_condition_state(prompt, cfg, eos_token_id);
+    const bool has_condition = has_active_condition(cond.mask);
+    const auto options = resolve_sampling_options(cfg, has_condition);
+    auto workspace = make_sampling_workspace(cfg, cond, options.seed);
+    const auto steps = make_sampling_steps(cfg, options.num_steps, options.seed);
+    run_sampling(workspace, cfg, cond, options, steps);
+    auto t_after_sampling = std::chrono::steady_clock::now();
+    const double sampling_ms =
+        std::chrono::duration<double, std::milli>(t_after_sampling - t_start).count();
+    return make_text_result(workspace, cfg, options, has_condition, eos_token_id,
+                            condition_prefix_tokens(cond.mask), sampling_ms);
+}
+
+EmbeddingResult ElfFlowPipeline::solve(const float* branch_input, int32_t branch_len,
+                                       const float* trunk_input, int32_t trunk_len) {
+    if (!model_ || !model_->ok())
+        throw std::runtime_error("ElfFlowPipeline: invalid TRT module");
+    if (!branch_input || branch_len <= 0)
+        throw std::runtime_error("ElfFlowPipeline::solve requires a non-empty latent input");
+
+    const int32_t expected = max_length_ * input_dim_;
+    if (branch_len != expected) {
+        throw std::runtime_error("ElfFlowPipeline::solve expects branch_len == elf_max_length * "
+                                 "elf_input_dim");
+    }
+
+    std::vector<float> latent(branch_input, branch_input + branch_len);
+    const float timestep = trunk_value(trunk_input, trunk_len, 0, 1.0f);
+    const float self_cond_cfg_scale = trunk_value(trunk_input, trunk_len, 1, 1.0f);
+    const float decoder_mode_value = trunk_value(trunk_input, trunk_len, 2, 0.0f);
+    const bool decoder_mode = decoder_mode_value >= 0.5f;
+
+    EmbeddingResult result;
+    const auto output = forward_model(latent, timestep, self_cond_cfg_scale, decoder_mode);
+    result.data = output.data;
+    result.dim = output.row_dim;
+    return result;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/elf_flow/pipeline.h
+++ b/src/runtime/models/elf_flow/pipeline.h
@@ -1,0 +1,157 @@
+#pragma once
+
+// ElfFlowPipeline: numeric API path for GitHub ELF denoiser/decoder bundles.
+
+#include "trtmc/pipeline.h"
+#include "trtmc/runtime/trt_module.h"
+#include "trtmc/tokenizer.h"
+
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+class ElfFlowPipeline final : public IPipeline {
+  public:
+    ElfFlowPipeline(std::unique_ptr<TrtModule> model, int32_t max_length, int32_t max_input_length,
+                    int32_t input_dim, int32_t text_dim, int32_t vocab_size,
+                    float denoiser_noise_scale, float denoiser_p_mean, float denoiser_p_std,
+                    float t_eps, std::shared_ptr<ITokenizer> tokenizer = nullptr,
+                    std::string model_id_str = "",
+                    std::unique_ptr<TrtModule> text_encoder = nullptr, float latent_mean = 0.0F,
+                    float latent_std = 1.0F, int32_t encoder_pad_token_id = 0);
+
+    TextResult generate(const std::string& prompt, const GenerateConfig& cfg = {}) override;
+
+    EmbeddingResult solve(const float* branch_input, int32_t branch_len, const float* trunk_input,
+                          int32_t trunk_len) override;
+
+    const char* model_id() const override { return model_id_.c_str(); }
+    const char* pipeline_type() const override { return "ElfFlowPipeline"; }
+
+  private:
+    struct ForwardOutput {
+        std::vector<float> data;
+        int32_t row_dim{0};
+    };
+    struct DenoiseOutput {
+        std::vector<float> v;
+        std::vector<float> x;
+    };
+    struct PromptCondition {
+        std::vector<float> latents;
+        std::vector<float> mask;
+    };
+    struct PromptTokenSpan {
+        std::size_t begin{0};
+        std::size_t end{0};
+        int32_t length{0};
+    };
+    struct PromptEncoderInputs {
+        std::vector<int32_t> input_ids;
+        std::vector<float> attention_mask;
+    };
+    struct ConditionState {
+        std::vector<float> latents;
+        std::vector<float> mask;
+    };
+    struct SamplingOptions {
+        int32_t seed{42};
+        int32_t num_steps{32};
+        float self_cond_cfg_scale{3.0F};
+        float cfg_scale{1.0F};
+        float sde_gamma{1.5F};
+    };
+    struct SamplingWorkspace {
+        std::vector<float> z;
+        std::vector<float> x_pred;
+    };
+
+    static const Tensor* select_output(const TensorMap& outputs, bool decoder_mode);
+    static std::vector<float> copy_tensor_data(const Tensor& tensor);
+    void configure_model_dimensions();
+    void configure_text_encoder();
+    void validate_generate_config(const GenerateConfig& cfg) const;
+    void add_self_cond_cfg_input(TensorMap& inputs, Tensor& tensor) const;
+    int32_t resolve_forward_row_dim(const Tensor& tensor, bool decoder_mode) const;
+    ForwardOutput forward_model(const std::vector<float>& latent, float timestep,
+                                float self_cond_cfg_scale, bool decoder_mode);
+    DenoiseOutput denoise_pass(const std::vector<float>& z, float timestep,
+                               const std::vector<float>& x_pred_prev, float self_cond_cfg_scale,
+                               const std::vector<float>& cond_seq,
+                               const std::vector<float>& cond_mask);
+    DenoiseOutput denoise_with_cfg(const std::vector<float>& z, float timestep,
+                                   const std::vector<float>& x_pred_prev, float cfg_scale,
+                                   float self_cond_cfg_scale, const std::vector<float>& cond_seq,
+                                   const std::vector<float>& cond_mask);
+    std::vector<float> build_model_latent(const std::vector<float>& z,
+                                          const std::vector<float>& self_cond) const;
+    std::vector<float> make_sampling_steps(const GenerateConfig& cfg, int32_t num_steps,
+                                           int32_t seed) const;
+    std::vector<float> make_initial_latent(const GenerateConfig& cfg, int32_t seed) const;
+    std::vector<int32_t> decode_tokens(const std::vector<float>& latent, float self_cond_cfg_scale,
+                                       int32_t eos_token_id, int32_t prefix_tokens_to_drop,
+                                       int32_t max_output_tokens);
+    std::vector<float> make_condition_latents(const GenerateConfig& cfg) const;
+    std::vector<float> make_condition_mask(const GenerateConfig& cfg) const;
+    PromptCondition make_prompt_condition(const std::string& prompt, int32_t eos_token_id);
+    PromptTokenSpan trim_prompt_tokens(const std::vector<int32_t>& encoded,
+                                       int32_t eos_token_id) const;
+    PromptEncoderInputs make_prompt_encoder_inputs(const std::vector<int32_t>& encoded,
+                                                   const PromptTokenSpan& span) const;
+    std::vector<float> run_prompt_encoder(const PromptEncoderInputs& inputs) const;
+    std::vector<float> normalize_prompt_latents(const Tensor& embeddings) const;
+    ConditionState make_condition_state(const std::string& prompt, const GenerateConfig& cfg,
+                                        int32_t eos_token_id);
+    SamplingOptions resolve_sampling_options(const GenerateConfig& cfg, bool has_condition) const;
+    SamplingWorkspace make_sampling_workspace(const GenerateConfig& cfg, const ConditionState& cond,
+                                              int32_t seed) const;
+    void validate_sde_noises(const GenerateConfig& cfg, const std::vector<float>& steps) const;
+    void apply_sde_perturbation(std::vector<float>& z_eval, const std::vector<float>& z,
+                                const GenerateConfig& cfg, const ConditionState& cond,
+                                float sde_gamma, float t, float t_next, std::size_t step_idx,
+                                float& t_eval, std::mt19937& rng,
+                                std::normal_distribution<float>& normal) const;
+    void run_intermediate_step(SamplingWorkspace& workspace, const GenerateConfig& cfg,
+                               const ConditionState& cond, const SamplingOptions& options,
+                               const std::vector<float>& steps, std::size_t step_idx,
+                               std::mt19937& rng, std::normal_distribution<float>& normal);
+    void run_final_step(SamplingWorkspace& workspace, const ConditionState& cond,
+                        const SamplingOptions& options, const std::vector<float>& steps);
+    void run_sampling(SamplingWorkspace& workspace, const GenerateConfig& cfg,
+                      const ConditionState& cond, const SamplingOptions& options,
+                      const std::vector<float>& steps);
+    TextResult make_text_result(const SamplingWorkspace& workspace, const GenerateConfig& cfg,
+                                const SamplingOptions& options, bool has_condition,
+                                int32_t eos_token_id, int32_t cond_prefix_len, double sampling_ms);
+    int32_t condition_prefix_tokens(const std::vector<float>& cond_mask) const;
+    bool has_active_condition(const std::vector<float>& cond_mask) const;
+    void restore_condition(std::vector<float>& values, const std::vector<float>& cond_seq,
+                           const std::vector<float>& cond_mask) const;
+    void zero_condition(std::vector<float>& values, const std::vector<float>& cond_mask) const;
+    int32_t resolve_max_output_tokens(const GenerateConfig& cfg, bool has_condition) const;
+    int32_t resolve_eos_token_id(const GenerateConfig& cfg) const;
+
+    std::unique_ptr<TrtModule> model_;
+    std::unique_ptr<TrtModule> text_encoder_;
+    int32_t max_length_{0};
+    int32_t max_input_length_{0};
+    int32_t encoder_seq_length_{0};
+    int32_t input_dim_{0};
+    int32_t text_dim_{0};
+    int32_t vocab_size_{0};
+    float denoiser_noise_scale_{1.0F};
+    float denoiser_p_mean_{-1.5F};
+    float denoiser_p_std_{0.8F};
+    float t_eps_{5e-2F};
+    float latent_mean_{0.0F};
+    float latent_std_{1.0F};
+    int32_t encoder_pad_token_id_{0};
+    std::shared_ptr<ITokenizer> tokenizer_;
+    std::string model_id_;
+};
+
+} // namespace trtmc

--- a/src/runtime/models/elf_flow/plugin.cpp
+++ b/src/runtime/models/elf_flow/plugin.cpp
@@ -1,0 +1,59 @@
+// ElfFlowPlugin: loads GitHub ELF denoiser/decoder bundles.
+
+#include "runtime/models/elf_flow/pipeline.h"
+#include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/pipeline_registry.h"
+#include "utils/json_helpers.h"
+
+namespace trtmc {
+
+class ElfFlowPlugin final : public IPipelinePlugin {
+  public:
+    std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
+        ModuleCreateOptions opts;
+        opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
+        opts.cuda_graphs = ctx.cuda_graphs;
+
+        auto loaded = load_trt_module_from_plan(
+            ctx.backend, find_section(ctx.bundle, "engine_plan"), "elf_flow engine", opts);
+        std::unique_ptr<TrtModule> text_encoder;
+        if (const auto* encoder_plan = find_section(ctx.bundle, "elf_text_encoder_plan")) {
+            auto loaded_encoder =
+                load_trt_module_from_plan(ctx.backend, encoder_plan, "elf_text_encoder_plan", opts);
+            text_encoder = std::move(loaded_encoder.module);
+        }
+
+        int32_t max_length = extract_json_int(ctx.config_json, "elf_max_length", 0);
+        if (max_length <= 0)
+            max_length = extract_json_int(ctx.config_json, "max_length", 0);
+        if (max_length <= 0)
+            max_length = extract_json_int(ctx.config_json, "max_position_embeddings", 0);
+        int32_t max_input_length = extract_json_int(ctx.config_json, "elf_max_input_length", 0);
+        if (max_input_length <= 0)
+            max_input_length = extract_json_int(ctx.config_json, "max_input_length", 0);
+
+        int32_t input_dim = extract_json_int(ctx.config_json, "elf_input_dim", 0);
+        int32_t text_dim = extract_json_int(ctx.config_json, "elf_text_encoder_dim", 0);
+        int32_t vocab_size = extract_json_int(ctx.config_json, "vocab_size", 0);
+        float denoiser_noise_scale =
+            extract_json_float(ctx.config_json, "elf_denoiser_noise_scale", 1.0F);
+        float denoiser_p_mean = extract_json_float(ctx.config_json, "elf_denoiser_p_mean", -1.5F);
+        float denoiser_p_std = extract_json_float(ctx.config_json, "elf_denoiser_p_std", 0.8F);
+        float t_eps = extract_json_float(ctx.config_json, "elf_t_eps", 5e-2F);
+        float latent_mean = extract_json_float(ctx.config_json, "elf_latent_mean", 0.0F);
+        float latent_std = extract_json_float(ctx.config_json, "elf_latent_std", 1.0F);
+        int32_t encoder_pad_token_id =
+            extract_json_int(ctx.config_json, "elf_encoder_pad_token_id", 0);
+        auto tokenizer = create_tokenizer_from_bundle(ctx.bundle);
+
+        return std::make_unique<ElfFlowPipeline>(
+            std::move(loaded.module), max_length, max_input_length, input_dim, text_dim, vocab_size,
+            denoiser_noise_scale, denoiser_p_mean, denoiser_p_std, t_eps, std::move(tokenizer),
+            ctx.bundle.info.model_id, std::move(text_encoder), latent_mean, latent_std,
+            encoder_pad_token_id);
+    }
+};
+
+REGISTER_PIPELINE_PLUGIN_WITH_MANIFEST(register_elf_flow_plugin, ElfFlowPlugin, "elf_flow");
+
+} // namespace trtmc

--- a/tensorrt_model_connect/tensorrt_model_connect/config.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/config.py
@@ -7,6 +7,41 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
+_ELF_VARIANTS: dict[str, tuple[int, int, int]] = {
+    "ELF-B": (12, 768, 12),
+    "ELF-M": (24, 1056, 16),
+    "ELF-L": (32, 1280, 16),
+}
+
+
+def _normalize_elf_variant(value: object) -> str:
+    variant = str(value or "ELF-B").upper().replace("_", "-")
+    return variant if variant in _ELF_VARIANTS else "ELF-B"
+
+
+def _elf_yaml_to_config(raw: dict) -> dict:
+    variant = _normalize_elf_variant(raw.get("model"))
+    depth, hidden_size, num_heads = _ELF_VARIANTS[variant]
+    converted = dict(raw)
+    converted.update({
+        "model_type": "elf",
+        "model": variant,
+        "elf_variant": variant,
+        "hidden_size": int(raw.get("hidden_size") or raw.get("elf_hidden_size") or hidden_size),
+        "num_hidden_layers": int(raw.get("depth") or raw.get("num_hidden_layers") or depth),
+        "num_attention_heads": int(raw.get("num_heads") or raw.get("num_attention_heads") or num_heads),
+        "max_position_embeddings": int(raw.get("max_length") or raw.get("max_position_embeddings") or 128),
+        "text_encoder_dim": int(
+            raw.get("text_encoder_dim")
+            or raw.get("encoder_d_model")
+            or raw.get("d_model")
+            or 512
+        ),
+        "vocab_size": int(raw.get("vocab_size") or 0),
+    })
+    return converted
+
+
 @dataclass
 class ModelConfig:
     """Parsed model architecture from HF config.json."""
@@ -202,5 +237,28 @@ class ModelConfig:
 
     @staticmethod
     def from_dir(model_dir: str | Path) -> ModelConfig:
-        config_path = Path(model_dir) / "config.json"
+        model_path = Path(model_dir)
+        config_path = model_path / "config.json"
+        if config_path.exists():
+            return ModelConfig.from_json(config_path.read_text())
+
+        yaml_candidates = [
+            model_path / "config.yaml",
+            model_path / "config.yml",
+            *sorted(model_path.glob("*.yaml")),
+            *sorted(model_path.glob("*.yml")),
+        ]
+        for yaml_path in yaml_candidates:
+            if not yaml_path.exists():
+                continue
+            try:
+                import yaml  # type: ignore[import-untyped]
+            except ImportError as exc:
+                raise RuntimeError("PyYAML is required to load ELF YAML configs") from exc
+            data = yaml.safe_load(yaml_path.read_text()) or {}
+            if not isinstance(data, dict):
+                continue
+            if str(data.get("model", "")).upper().replace("_", "-") in _ELF_VARIANTS:
+                return ModelConfig.from_json(json.dumps(_elf_yaml_to_config(data)))
+
         return ModelConfig.from_json(config_path.read_text())

--- a/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
@@ -73,6 +73,12 @@ _HF_ALLOW_PATTERNS = [
     "model.safetensors-*.safetensors",
     "model.safetensors.index.json",
     "pytorch_model.bin",
+    "*.yml",
+    "*.yaml",
+    "checkpoint_*",
+    "checkpoint_*/**",
+    "model.npz",
+    "elf_params.npz",
     "tokenizer.json",
     "tokenizer_config.json",
     "vocab.json",
@@ -234,6 +240,31 @@ def _is_hf_model_dir(path: Path) -> bool:
     return (path / "config.json").exists() or (path / "model_index.json").exists()
 
 
+def _is_elf_model_dir(path: Path) -> bool:
+    """Return True for the official ELF YAML + checkpoint directory layout."""
+    if not path.is_dir():
+        return False
+    has_checkpoint = any(path.glob("checkpoint_*")) or any(
+        (path / name).exists() for name in ("model.npz", "elf_params.npz")
+    )
+    if not has_checkpoint:
+        return False
+    for yaml_path in [*path.glob("*.yaml"), *path.glob("*.yml")]:
+        try:
+            import yaml  # type: ignore[import-untyped]
+
+            data = yaml.safe_load(yaml_path.read_text()) or {}
+        except Exception:
+            continue
+        if isinstance(data, dict) and str(data.get("model", "")).upper().replace("_", "-") in {
+            "ELF-B",
+            "ELF-M",
+            "ELF-L",
+        }:
+            return True
+    return False
+
+
 def _resolve_model(model_id_or_path: str) -> str:
     """Resolve a HuggingFace repo ID or local path to a local directory.
 
@@ -242,7 +273,7 @@ def _resolve_model(model_id_or_path: str) -> str:
     Handles .nemo archives by extracting config and creating a synthetic dir.
     """
     local = Path(model_id_or_path)
-    if local.is_dir() and _is_hf_model_dir(local):
+    if local.is_dir() and (_is_hf_model_dir(local) or _is_elf_model_dir(local)):
         return str(local)
 
     # Handle .nemo archives (NeMo models like MagpieTTS)
@@ -786,6 +817,8 @@ def build_bundle(
         compile_before_extra = _build_timing_phase(build_timing, "trt_compile_s")
         try:
             build_extra_kwargs = {"verbose": verbose}
+            if _call_supports_kwarg(build_extra, "precision"):
+                build_extra_kwargs["precision"] = precision
             if _call_supports_kwarg(build_extra, "build_timing"):
                 build_extra_kwargs["build_timing"] = build_timing
             extra_engines = build_extra(
@@ -868,8 +901,86 @@ def build_bundle(
         # Use max_cache_length as max_seq_length for encoder
         pass
 
-    # Embed tokenizer + config files.
-    # For config.json, inject runtime_strategy if the plugin provides one.
+    def make_runtime_config_json(source: bytes | None) -> bytes:
+        cfg_dict = json.loads(source) if source is not None else dict(config.raw)
+        runtime_strategy = getattr(plugin, "runtime_strategy", None)
+        if runtime_strategy:
+            cfg_dict["runtime_strategy"] = runtime_strategy
+        elif triattention_cfg is not None:
+            cfg_dict["runtime_strategy"] = "decoder_kv_cache"
+        cfg_dict["engine_backend"] = "trt_rtx" if rtx else "trt"
+        cfg_dict["trt_version"] = trt_version
+        if trt_abi:
+            cfg_dict["trt_abi"] = trt_abi
+        cfg_dict["precision"] = precision
+        cfg_dict["tokenizer_add_special_tokens"] = int(
+            tokenizer_add_special_tokens)
+        if quant_plan is not None:
+            cfg_dict["quantization"] = quant_plan.as_config_dict()
+        elif quantize:
+            cfg_dict["quantization"] = {"format": quantize}
+        if triattention_cfg is not None:
+            cfg_dict["triattention"] = triattention_cfg.to_dict()
+        if enable_dynamic_kv_cache:
+            cfg_dict["dynamic_kv_cache"] = True
+            cfg_dict["dynamic_kv_profile_rows"] = config.raw.get(
+                "_dynamic_kv_profile_rows", [max_cache_length]
+            )
+        embed_input = getattr(plugin, "embed_input", False)
+        if embed_input:
+            cfg_dict["embed_input"] = True
+        if vision_plan is not None:
+            cfg_dict["has_vision_engine"] = True
+        # Inject VL config from plugin (image_token_id, prompt template, etc.)
+        get_vl_config = getattr(plugin, 'get_vl_config', None)
+        if get_vl_config is not None:
+            vl_cfg = get_vl_config(config)
+            if vl_cfg is not None:
+                cfg_dict.update(vl_cfg)
+        # Inject segmentation config from plugin
+        get_seg_config = getattr(plugin, 'get_segmentation_config', None)
+        if get_seg_config is not None:
+            seg_cfg = get_seg_config(config)
+            if seg_cfg is not None:
+                cfg_dict.update(seg_cfg)
+        # Inject detection config from plugin
+        get_det_config = getattr(plugin, 'get_detection_config', None)
+        if get_det_config is not None:
+            det_cfg = get_det_config(config)
+            if det_cfg is not None:
+                cfg_dict.update(det_cfg)
+        # Inject audio config from plugin
+        get_audio_config = getattr(plugin, 'get_audio_config', None)
+        if get_audio_config is not None:
+            audio_cfg = get_audio_config(config)
+            if audio_cfg is not None:
+                cfg_dict.update(audio_cfg)
+        # Inject generic config overrides from plugin.
+        # Build the final dict so overrides appear FIRST in the
+        # serialized JSON.  The C++ fast_path_config parser uses
+        # flat text search (text.find) which picks up the first
+        # occurrence of a key.  For models with nested configs
+        # (e.g. Qwen3-Omni thinker_config.text_config) the nested
+        # copy of "hidden_size" etc. would otherwise shadow the
+        # top-level value.
+        get_overrides = getattr(plugin, 'get_bundle_config_overrides', None)
+        if get_overrides is not None:
+            overrides = get_overrides(config)
+            if overrides is not None:
+                # Put overrides first, then original dict.  Dict
+                # union preserves insertion order; overrides keys
+                # appear before any nested dicts.
+                merged = dict(overrides)
+                merged.update(cfg_dict)
+                # Ensure overrides win for top-level keys.
+                merged.update(overrides)
+                cfg_dict = merged
+        return json.dumps(cfg_dict, indent=2).encode("utf-8")
+
+    # Embed tokenizer + config files. If the source model is a GitHub ELF
+    # directory with only train_*.yml, synthesize config.json for the C++
+    # runtime from the parsed ModelConfig.
+    embedded_config_json = False
     for filename in ("config.json", "tokenizer.json", "tokenizer_config.json",
                      "vocab.json", "merges.txt", "special_tokens_map.json",
                      "tokenizer.model", "preprocessor_config.json"):
@@ -878,81 +989,11 @@ def build_bundle(
             data = file_path.read_bytes()
             # Inject runtime_strategy and VL fields into config.json.
             if filename == "config.json":
-                cfg_dict = json.loads(data)
-                runtime_strategy = getattr(plugin, "runtime_strategy", None)
-                if runtime_strategy:
-                    cfg_dict["runtime_strategy"] = runtime_strategy
-                elif triattention_cfg is not None:
-                    cfg_dict["runtime_strategy"] = "decoder_kv_cache"
-                cfg_dict["engine_backend"] = "trt_rtx" if rtx else "trt"
-                cfg_dict["trt_version"] = trt_version
-                if trt_abi:
-                    cfg_dict["trt_abi"] = trt_abi
-                cfg_dict["precision"] = precision
-                cfg_dict["tokenizer_add_special_tokens"] = int(
-                    tokenizer_add_special_tokens)
-                if quant_plan is not None:
-                    cfg_dict["quantization"] = quant_plan.as_config_dict()
-                elif quantize:
-                    cfg_dict["quantization"] = {"format": quantize}
-                if triattention_cfg is not None:
-                    cfg_dict["triattention"] = triattention_cfg.to_dict()
-                if enable_dynamic_kv_cache:
-                    cfg_dict["dynamic_kv_cache"] = True
-                    cfg_dict["dynamic_kv_profile_rows"] = config.raw.get(
-                        "_dynamic_kv_profile_rows", [max_cache_length]
-                    )
-                embed_input = getattr(plugin, "embed_input", False)
-                if embed_input:
-                    cfg_dict["embed_input"] = True
-                if vision_plan is not None:
-                    cfg_dict["has_vision_engine"] = True
-                # Inject VL config from plugin (image_token_id, prompt template, etc.)
-                get_vl_config = getattr(plugin, 'get_vl_config', None)
-                if get_vl_config is not None:
-                    vl_cfg = get_vl_config(config)
-                    if vl_cfg is not None:
-                        cfg_dict.update(vl_cfg)
-                # Inject segmentation config from plugin
-                get_seg_config = getattr(plugin, 'get_segmentation_config', None)
-                if get_seg_config is not None:
-                    seg_cfg = get_seg_config(config)
-                    if seg_cfg is not None:
-                        cfg_dict.update(seg_cfg)
-                # Inject detection config from plugin
-                get_det_config = getattr(plugin, 'get_detection_config', None)
-                if get_det_config is not None:
-                    det_cfg = get_det_config(config)
-                    if det_cfg is not None:
-                        cfg_dict.update(det_cfg)
-                # Inject audio config from plugin
-                get_audio_config = getattr(plugin, 'get_audio_config', None)
-                if get_audio_config is not None:
-                    audio_cfg = get_audio_config(config)
-                    if audio_cfg is not None:
-                        cfg_dict.update(audio_cfg)
-                # Inject generic config overrides from plugin.
-                # Build the final dict so overrides appear FIRST in the
-                # serialized JSON.  The C++ fast_path_config parser uses
-                # flat text search (text.find) which picks up the first
-                # occurrence of a key.  For models with nested configs
-                # (e.g. Qwen3-Omni thinker_config.text_config) the nested
-                # copy of "hidden_size" etc. would otherwise shadow the
-                # top-level value.
-                get_overrides = getattr(plugin, 'get_bundle_config_overrides', None)
-                if get_overrides is not None:
-                    overrides = get_overrides(config)
-                    if overrides is not None:
-                        # Put overrides first, then original dict.  Dict
-                        # union preserves insertion order; overrides keys
-                        # appear before any nested dicts.
-                        merged = dict(overrides)
-                        merged.update(cfg_dict)
-                        # Ensure overrides win for top-level keys.
-                        merged.update(overrides)
-                        cfg_dict = merged
-                data = json.dumps(cfg_dict, indent=2).encode("utf-8")
+                data = make_runtime_config_json(data)
+                embedded_config_json = True
             sections.append(BundleSection(filename, data))
+    if not embedded_config_json:
+        sections.append(BundleSection("config.json", make_runtime_config_json(None)))
 
     # Package FFI kernel .so files into the bundle
     if kernel_artifacts:

--- a/tensorrt_model_connect/tensorrt_model_connect/families/elf_flow/__init__.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/elf_flow/__init__.py
@@ -1,0 +1,5 @@
+"""ELF flow family plugin and owned builder helpers."""
+
+from .plugin import plugin
+
+__all__ = ["plugin"]

--- a/tensorrt_model_connect/tensorrt_model_connect/families/elf_flow/builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/elf_flow/builder.py
@@ -1,0 +1,299 @@
+"""TensorRT API builder for the GitHub ELF model.
+
+This is a direct TensorRT-API implementation of
+https://github.com/lillian039/ELF, covering the ELF Transformer denoiser and
+factored decoder head from ``src/modules/model.py`` and ``src/modules/layers.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from .config import make_elf_rope_cache, resolve_elf_config
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+
+
+def _storage_dtype(precision: str) -> np.dtype:
+    return np.float16 if precision == "fp16" else np.float32
+
+
+def _dense(
+    network: trt.INetworkDefinition,
+    x: trt.ITensor,
+    lhs_width: int,
+    rhs_width: int,
+    weight: np.ndarray,
+    bias: np.ndarray | None = None,
+    *,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    y = graph_ops.add_matmul_rhs_constant(
+        network, x, lhs_width, rhs_width, weight, dtype=dtype)
+    if bias is not None:
+        y = graph_ops.add_bias_sum(network, y, rhs_width, bias, dtype=dtype)
+    return y
+
+
+def _scalar_2d(network: trt.INetworkDefinition, scalar: trt.ITensor) -> trt.ITensor:
+    reshaped = network.add_shuffle(scalar)
+    reshaped.reshape_dims = (1, 1)
+    return reshaped.get_output(0)
+
+
+def _timestep_mlp(
+    network: trt.INetworkDefinition,
+    scalar: trt.ITensor,
+    hidden_size: int,
+    weights: "WeightDict",
+    prefix: str,
+    *,
+    dtype: np.dtype,
+) -> trt.ITensor:
+    emb = graph_ops.add_timestep_embedding(
+        network, scalar, hidden_size, freq_dim=256, max_period=10000.0, dtype=dtype)
+    emb = _dense(
+        network, emb, 256, hidden_size,
+        weights[f"{prefix}.mlp_0.w"], weights[f"{prefix}.mlp_0.b"], dtype=dtype)
+    emb = graph_ops.add_silu(network, emb)
+    return _dense(
+        network, emb, hidden_size, hidden_size,
+        weights[f"{prefix}.mlp_2.w"], weights[f"{prefix}.mlp_2.b"], dtype=dtype)
+
+
+def _prefix_tokens(
+    network: trt.INetworkDefinition,
+    emb: trt.ITensor,
+    token_weights: np.ndarray,
+    *,
+    dtype: np.dtype,
+) -> trt.ITensor:
+    _, n_tokens, hidden_size = token_weights.shape
+    tokens = graph_ops.add_constant(
+        network, (n_tokens, hidden_size), token_weights.reshape(n_tokens, hidden_size),
+        dtype=dtype)
+    return network.add_elementwise(tokens, emb, trt.ElementWiseOperation.SUM).get_output(0)
+
+
+def _add_transformer_block(
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    weights: "WeightDict",
+    layer_idx: int,
+    cfg: dict,
+    eps_tensor: trt.ITensor,
+    cos_cache: trt.ITensor,
+    sin_cache: trt.ITensor,
+    *,
+    dtype: np.dtype,
+) -> trt.ITensor:
+    hidden_size = cfg["hidden_size"]
+    num_heads = cfg["num_heads"]
+    head_dim = cfg["head_dim"]
+    total_seq = cfg["total_seq"]
+    p = f"layer.{layer_idx}"
+
+    normed = graph_ops.add_rms_norm(
+        network, hidden, hidden_size, weights[f"{p}.norm1"], eps_tensor, dtype=dtype)
+
+    qkv = _dense(
+        network, normed, hidden_size, 3 * hidden_size,
+        weights[f"{p}.attn.qkv.w"], weights[f"{p}.attn.qkv.b"], dtype=dtype)
+    q = network.add_slice(qkv, (0, 0), (total_seq, hidden_size), (1, 1)).get_output(0)
+    k = network.add_slice(qkv, (0, hidden_size), (total_seq, hidden_size), (1, 1)).get_output(0)
+    v = network.add_slice(
+        qkv, (0, 2 * hidden_size), (total_seq, hidden_size), (1, 1)).get_output(0)
+
+    q = graph_ops.add_rms_norm_per_head(
+        network, q, num_heads, head_dim, weights[f"{p}.attn.q_norm"], eps_tensor,
+        dtype=dtype, sequence_length=total_seq)
+    k = graph_ops.add_rms_norm_per_head(
+        network, k, num_heads, head_dim, weights[f"{p}.attn.k_norm"], eps_tensor,
+        dtype=dtype, sequence_length=total_seq)
+
+    q = graph_ops.add_apply_rope_native_sequence(
+        network, q, num_heads, head_dim, cos_cache, sin_cache,
+        rotary_embedding_dim=head_dim, interleaved=True, sequence_length=total_seq)
+    k = graph_ops.add_apply_rope_native_sequence(
+        network, k, num_heads, head_dim, cos_cache, sin_cache,
+        rotary_embedding_dim=head_dim, interleaved=True, sequence_length=total_seq)
+
+    attn = graph_ops.add_attention_from_rows(
+        network, q, k, v, num_heads=num_heads, head_dim=head_dim,
+        q_seq=total_seq, kv_seq=total_seq, causal=False)
+    attn = _dense(
+        network, attn, hidden_size, hidden_size,
+        weights[f"{p}.attn.proj.w"], weights[f"{p}.attn.proj.b"], dtype=dtype)
+    hidden = network.add_elementwise(hidden, attn, trt.ElementWiseOperation.SUM).get_output(0)
+
+    normed = graph_ops.add_rms_norm(
+        network, hidden, hidden_size, weights[f"{p}.norm2"], eps_tensor, dtype=dtype)
+    w12 = weights[f"{p}.mlp.w12.w"]
+    actual_ffn = int(w12.shape[1] // 2)
+    fused = _dense(
+        network, normed, hidden_size, 2 * actual_ffn,
+        weights[f"{p}.mlp.w12.w"], weights[f"{p}.mlp.w12.b"], dtype=dtype)
+    x1 = network.add_slice(fused, (0, 0), (total_seq, actual_ffn), (1, 1)).get_output(0)
+    x2 = network.add_slice(
+        fused, (0, actual_ffn), (total_seq, actual_ffn), (1, 1)).get_output(0)
+    gate = graph_ops.add_silu(network, x1)
+    gated = network.add_elementwise(gate, x2, trt.ElementWiseOperation.PROD).get_output(0)
+    mlp_out = _dense(
+        network, gated, actual_ffn, hidden_size,
+        weights[f"{p}.mlp.w3.w"], weights[f"{p}.mlp.w3.b"], dtype=dtype)
+    return network.add_elementwise(hidden, mlp_out, trt.ElementWiseOperation.SUM).get_output(0)
+
+
+def build_elf_flow_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_seq_length: int | None = None,
+    *,
+    precision: str = "fp32",
+    verbose: bool = False,
+) -> bytes:
+    """Build an ELF denoiser/decoder engine from GitHub ELF weights."""
+    cfg = resolve_elf_config(config, max_seq_length)
+    hidden_size = cfg["hidden_size"]
+    text_dim = cfg["text_encoder_dim"]
+    input_dim = cfg["input_dim"]
+    max_length = cfg["max_length"]
+    config.raw["_elf_engine_max_length"] = max_length
+    dtype = _storage_dtype(precision)
+
+    if cfg["vocab_size"] <= 0:
+        raise ValueError("ELF config must set vocab_size for the decoder head")
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    builder_config = builder.create_builder_config()
+    builder_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 8 << 30)
+    # ELF sampling accumulates small denoising differences across many steps.
+    # Keep the fp32 build in full fp32 rather than TensorRT's default TF32 path
+    # so replay parity against the GitHub JAX implementation stays tight.
+    builder_config.clear_flag(trt.BuilderFlag.TF32)
+
+    latent = network.add_input("latent", trt.float32, (max_length, input_dim))
+    timestep = network.add_input("timestep", trt.float32, (1,))
+    decoder_mode = network.add_input("decoder_mode", trt.float32, (1,))
+    self_cond_cfg = None
+    if cfg["num_self_cond_cfg_tokens"] > 0:
+        self_cond_cfg = network.add_input("self_cond_cfg_scale", trt.float32, (1,))
+
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([cfg["rms_norm_eps"]], dtype=np.float32))
+
+    x = latent
+    if input_dim == 2 * text_dim:
+        x = _dense(
+            network, x, input_dim, text_dim,
+            weights["self_cond_proj.w"], weights["self_cond_proj.b"], dtype=dtype)
+    elif input_dim != text_dim:
+        raise ValueError(
+            f"ELF input_dim={input_dim} must equal text_encoder_dim={text_dim} "
+            f"or 2x that dimension")
+
+    x = _dense(
+        network, x, text_dim, cfg["bottleneck_dim"],
+        weights["text_proj.proj1.w"], None, dtype=dtype)
+    x = _dense(
+        network, x, cfg["bottleneck_dim"], hidden_size,
+        weights["text_proj.proj2.w"], weights["text_proj.proj2.b"], dtype=dtype)
+
+    mode_tokens = 0
+    if cfg["num_model_mode_tokens"] > 0:
+        mode_tokens = cfg["num_model_mode_tokens"]
+        mode = graph_ops.add_constant(
+            network, (mode_tokens, hidden_size),
+            weights["mode_tokens"].reshape(mode_tokens, hidden_size), dtype=dtype)
+        gated = network.add_elementwise(
+            mode, _scalar_2d(network, decoder_mode), trt.ElementWiseOperation.PROD
+        ).get_output(0)
+        cat = network.add_concatenation([gated, x])
+        cat.axis = 0
+        x = cat.get_output(0)
+
+    prefix_parts: list[trt.ITensor] = []
+    time_emb = _timestep_mlp(
+        network, timestep, hidden_size, weights, "t_embedder", dtype=dtype)
+    prefix_parts.append(_prefix_tokens(
+        network, time_emb, weights["t_emb_tokens"], dtype=dtype))
+    if cfg["num_self_cond_cfg_tokens"] > 0:
+        assert self_cond_cfg is not None
+        sc_emb = _timestep_mlp(
+            network, self_cond_cfg, hidden_size, weights,
+            "self_cond_cfg_embedder", dtype=dtype)
+        prefix_parts.append(_prefix_tokens(
+            network, sc_emb, weights["self_cond_cfg_tokens"], dtype=dtype))
+
+    prefix_len = cfg["num_time_tokens"] + cfg["num_self_cond_cfg_tokens"]
+    prefix_cat = network.add_concatenation(prefix_parts)
+    prefix_cat.axis = 0
+    cat = network.add_concatenation([prefix_cat.get_output(0), x])
+    cat.axis = 0
+    hidden = cat.get_output(0)
+
+    total_seq = prefix_len + mode_tokens + max_length
+    cfg = dict(cfg)
+    cfg["total_seq"] = total_seq
+
+    cos_np, sin_np = make_elf_rope_cache(
+        max_length=max_length, head_dim=cfg["head_dim"],
+        prefix_tokens=prefix_len + mode_tokens, theta=cfg["rope_theta"])
+    cos_cache = graph_ops.add_constant(network, cos_np.shape, cos_np, dtype=dtype)
+    sin_cache = graph_ops.add_constant(network, sin_np.shape, sin_np, dtype=dtype)
+
+    for layer_idx in range(cfg["depth"]):
+        hidden = _add_transformer_block(
+            network, hidden, weights, layer_idx, cfg, eps_tensor, cos_cache, sin_cache,
+            dtype=dtype)
+
+    body = network.add_slice(
+        hidden, (prefix_len + mode_tokens, 0), (max_length, hidden_size), (1, 1)
+    ).get_output(0)
+
+    proj = _dense(
+        network, body, hidden_size, text_dim,
+        weights["decoder.proj.w"], weights["decoder.proj.b"], dtype=dtype)
+    proj = graph_ops.add_gelu_new(network, proj, dtype=dtype)
+    logits = _dense(
+        network, proj, text_dim, cfg["vocab_size"],
+        weights["decoder.unembed.w"], weights["decoder.unembed.b"], dtype=dtype)
+    logits = network.add_elementwise(
+        logits, _scalar_2d(network, decoder_mode), trt.ElementWiseOperation.PROD
+    ).get_output(0)
+
+    denoised = graph_ops.add_rms_norm(
+        network, body, hidden_size, weights["final.norm"], eps_tensor, dtype=dtype)
+    denoised = _dense(
+        network, denoised, hidden_size, text_dim,
+        weights["final.linear.w"], weights["final.linear.b"], dtype=dtype)
+
+    denoised = network.add_cast(denoised, trt.float32).get_output(0)
+    denoised.name = "denoised"
+    network.mark_output(denoised)
+    logits = network.add_cast(logits, trt.float32).get_output(0)
+    logits.name = "decoder_logits"
+    network.mark_output(logits)
+
+    print(
+        "[elf-builder] Building ELF TensorRT engine "
+        f"(variant={cfg['variant']}, hidden={hidden_size}, layers={cfg['depth']}, "
+        f"seq={max_length}) ...",
+        file=sys.stderr,
+    )
+    plan = builder.build_serialized_network(network, builder_config)
+    if plan is None:
+        raise RuntimeError("TRT engine serialization failed for ELF")
+    return bytes(plan)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/elf_flow/config.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/elf_flow/config.py
@@ -1,0 +1,122 @@
+"""Configuration helpers for the GitHub ELF model."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from ...config import ModelConfig
+
+
+ELF_VARIANTS: dict[str, tuple[int, int, int]] = {
+    "ELF-B": (12, 768, 12),
+    "ELF-M": (24, 1056, 16),
+    "ELF-L": (32, 1280, 16),
+}
+
+
+def resolve_elf_config(config: "ModelConfig", max_seq_length: int | None = None) -> dict:
+    """Resolve ELF architecture fields from config.json plus upstream defaults."""
+    raw = config.raw or {}
+    variant = str(raw.get("elf_variant") or raw.get("model") or "ELF-B")
+    variant_defaults = ELF_VARIANTS.get(variant.upper(), ELF_VARIANTS["ELF-B"])
+    default_depth, default_hidden, default_heads = variant_defaults
+
+    text_encoder_dim = int(
+        raw.get("text_encoder_dim")
+        or raw.get("encoder_d_model")
+        or raw.get("d_model")
+        or raw.get("text_hidden_size", 0)
+        or 512
+    )
+    hidden_size = int(
+        config.hidden_size
+        or raw.get("hidden_size")
+        or raw.get("elf_hidden_size")
+        or default_hidden
+    )
+    depth = int(
+        config.num_hidden_layers
+        or raw.get("depth")
+        or raw.get("num_hidden_layers")
+        or default_depth
+    )
+    num_heads = int(
+        config.num_attention_heads
+        or raw.get("num_heads")
+        or raw.get("num_attention_heads")
+        or default_heads
+    )
+    if hidden_size % num_heads != 0:
+        raise ValueError(
+            f"ELF hidden_size={hidden_size} must be divisible by num_heads={num_heads}")
+
+    max_length = int(
+        raw.get("_elf_engine_max_length")
+        or max_seq_length
+        or raw.get("max_length")
+        or raw.get("max_position_embeddings")
+        or config.max_position_embeddings
+        or 128
+    )
+    max_input_length = int(raw.get("max_input_length") or raw.get("elf_max_input_length") or 0)
+    self_cond_prob = float(raw.get("self_cond_prob", 0.5))
+    input_dim = int(raw.get("elf_input_dim") or (
+        2 * text_encoder_dim if self_cond_prob > 0.0 else text_encoder_dim))
+
+    num_time_tokens = int(raw.get("num_time_tokens", 4))
+    if num_time_tokens <= 0:
+        raise ValueError("ELF num_time_tokens must be positive")
+
+    return {
+        "variant": variant,
+        "text_encoder_dim": text_encoder_dim,
+        "input_dim": input_dim,
+        "max_length": max_length,
+        "max_input_length": max_input_length,
+        "hidden_size": hidden_size,
+        "depth": depth,
+        "num_heads": num_heads,
+        "head_dim": hidden_size // num_heads,
+        "mlp_ratio": float(raw.get("mlp_ratio", raw.get("elf_mlp_ratio", 4.0))),
+        "bottleneck_dim": int(raw.get("bottleneck_dim", 128)),
+        "num_time_tokens": num_time_tokens,
+        "num_self_cond_cfg_tokens": int(raw.get("num_self_cond_cfg_tokens", 4)),
+        "num_model_mode_tokens": int(raw.get("num_model_mode_tokens", 4)),
+        "vocab_size": int(config.vocab_size or raw.get("vocab_size", 0)),
+        "rope_theta": float(raw.get("rope_theta", 10000.0)),
+        "rms_norm_eps": float(raw.get("rms_norm_eps", 1e-6)),
+        "self_cond_prob": self_cond_prob,
+        "denoiser_noise_scale": float(raw.get("denoiser_noise_scale", 1.0)),
+        "denoiser_p_mean": float(raw.get("denoiser_p_mean", -1.5)),
+        "denoiser_p_std": float(raw.get("denoiser_p_std", 0.8)),
+        "t_eps": float(raw.get("t_eps", 5e-2)),
+    }
+
+
+def make_elf_rope_cache(
+    *,
+    max_length: int,
+    head_dim: int,
+    prefix_tokens: int,
+    theta: float = 10000.0,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return ELF TextRotaryEmbeddingFast caches as [1, S, head_dim / 2]."""
+    head_dim = int(head_dim)
+    if head_dim < 2 or head_dim % 2 != 0:
+        raise ValueError(f"ELF RoPE head_dim must be an even value >= 2; got {head_dim}")
+    half = head_dim // 2
+    total_seq = int(prefix_tokens) + int(max_length)
+    cos = np.ones((total_seq, half), dtype=np.float32)
+    sin = np.zeros((total_seq, half), dtype=np.float32)
+    if max_length <= 0:
+        return cos.reshape(1, total_seq, half), sin.reshape(1, total_seq, half)
+
+    freqs = 1.0 / (theta ** (np.arange(0, head_dim, 2, dtype=np.float32) / head_dim))
+    positions = np.arange(max_length, dtype=np.float32)
+    angles = positions[:, None] * freqs[None, :]
+    cos[prefix_tokens:, :] = np.cos(angles).astype(np.float32)
+    sin[prefix_tokens:, :] = np.sin(angles).astype(np.float32)
+    return cos.reshape(1, total_seq, half), sin.reshape(1, total_seq, half)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/elf_flow/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/elf_flow/plugin.py
@@ -1,0 +1,399 @@
+"""ELF flow family plugin.
+
+ELF is implemented from the GitHub source at https://github.com/lillian039/ELF.
+The weight names below mirror the Flax module tree in ``src/modules/model.py``.
+"""
+
+from __future__ import annotations
+
+import pickle
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from ...checkpoint_mapper import WeightDict
+from ...config import ModelConfig
+from .config import resolve_elf_config
+
+
+class _TensorStore:
+    def __init__(self, model_dir: str | Path):
+        from ...checkpoint_mapper import _has_tensor, _load_tensor, _open_safetensors
+
+        self._has_tensor = _has_tensor
+        self._load_tensor = _load_tensor
+        self._readers = None
+        self._arrays: dict[str, np.ndarray] | None = None
+        model_path = Path(model_dir)
+        try:
+            self._readers = _open_safetensors(model_path)
+        except FileNotFoundError:
+            self._arrays = _load_local_elf_arrays(model_path)
+            if self._arrays is None:
+                raise FileNotFoundError(
+                    f"No ELF safetensors, npz, or local GitHub checkpoint found in {model_path}")
+
+    def has(self, name: str) -> bool:
+        if self._arrays is not None:
+            return name in self._arrays
+        return bool(self._has_tensor(self._readers, name))
+
+    def get(self, name: str) -> np.ndarray:
+        if self._arrays is not None:
+            return np.asarray(self._arrays[name], dtype=np.float32)
+        return self._load_tensor(self._readers, name)
+
+
+def _checkpoint_step(path: Path) -> int:
+    match = re.search(r"(\d+)$", path.name)
+    return int(match.group(1)) if match else -1
+
+
+def _flatten_arrays(value: Any, prefix: str = "") -> dict[str, np.ndarray]:
+    arrays: dict[str, np.ndarray] = {}
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            name = f"{prefix}.{key}" if prefix else str(key)
+            arrays.update(_flatten_arrays(item, name))
+        return arrays
+    if prefix:
+        try:
+            arrays[prefix] = np.asarray(value)
+        except (TypeError, ValueError):
+            pass
+    return arrays
+
+
+def _select_upstream_params(payload: Any) -> Any:
+    if isinstance(payload, Mapping):
+        if "ema_params1" in payload:
+            return payload["ema_params1"]
+        if "params" in payload:
+            return payload["params"]
+    return payload
+
+
+def _load_npz_arrays(path: Path) -> dict[str, np.ndarray] | None:
+    try:
+        loaded = np.load(path, allow_pickle=False)
+    except (OSError, ValueError):
+        return None
+    if not hasattr(loaded, "files"):
+        return None
+    return {key: loaded[key] for key in loaded.files}
+
+
+def _load_pickle_arrays(path: Path) -> dict[str, np.ndarray] | None:
+    try:
+        with path.open("rb") as f:
+            payload = pickle.load(f)
+    except Exception:
+        return None
+    arrays = _flatten_arrays(_select_upstream_params(payload))
+    return arrays or None
+
+
+def _load_flax_arrays(path: Path) -> dict[str, np.ndarray] | None:
+    try:
+        from flax import serialization
+    except ImportError:
+        return None
+
+    if path.is_file():
+        try:
+            payload = serialization.msgpack_restore(path.read_bytes())
+        except Exception:
+            return None
+    else:
+        try:
+            from flax.training import checkpoints
+
+            payload = checkpoints.restore_checkpoint(str(path.resolve()), target=None)
+        except Exception:
+            return None
+    arrays = _flatten_arrays(_select_upstream_params(payload))
+    return arrays or None
+
+
+def _load_checkpoint_arrays(path: Path) -> dict[str, np.ndarray] | None:
+    if path.suffix == ".npz":
+        arrays = _load_npz_arrays(path)
+        if arrays:
+            return arrays
+    arrays = _load_pickle_arrays(path)
+    if arrays:
+        return arrays
+    return _load_flax_arrays(path)
+
+
+def _local_checkpoint_candidates(model_path: Path) -> list[Path]:
+    if model_path.is_file():
+        return [model_path]
+    if not model_path.is_dir():
+        return []
+
+    candidates: list[Path] = []
+    for name in ("model.npz", "elf_params.npz"):
+        candidate = model_path / name
+        if candidate.exists():
+            candidates.append(candidate)
+
+    checkpoints = sorted(
+        model_path.glob("checkpoint_*"),
+        key=lambda item: (_checkpoint_step(item), item.name),
+        reverse=True,
+    )
+    candidates.extend(checkpoints)
+    return candidates
+
+
+def _load_local_elf_arrays(model_path: Path) -> dict[str, np.ndarray] | None:
+    for candidate in _local_checkpoint_candidates(model_path):
+        arrays = _load_checkpoint_arrays(candidate)
+        if arrays:
+            return arrays
+    return None
+
+
+def _target_np_dtype(precision: str) -> np.dtype:
+    return np.float16 if precision in ("fp16", "bf16") else np.float32
+
+
+def _name_variants(name: str) -> list[str]:
+    variants = [name]
+    if "." in name:
+        variants.append(name.replace(".", "/"))
+    if "/" in name:
+        variants.append(name.replace("/", "."))
+    prefixed: list[str] = []
+    for item in variants:
+        prefixed.append(f"params.{item}")
+        prefixed.append(f"params/{item}")
+    out: list[str] = []
+    for item in variants + prefixed:
+        if item not in out:
+            out.append(item)
+    return out
+
+
+def _load(store: _TensorStore, *names: str, dtype: np.dtype = np.float32) -> np.ndarray:
+    for name in names:
+        for candidate in _name_variants(name):
+            if store.has(candidate):
+                return np.ascontiguousarray(store.get(candidate), dtype=dtype)
+    joined = ", ".join(names)
+    raise KeyError(f"ELF tensor not found; tried: {joined}")
+
+
+def _find_encoder_checkpoint(model_dir: str | Path) -> Path | None:
+    model_path = Path(model_dir)
+    for name in (
+        "t5_small_encoder_jax.pkl",
+        "encoder_checkpoint.pkl",
+        "text_encoder.pkl",
+        "t5_encoder.pkl",
+    ):
+        candidate = model_path / name
+        if candidate.exists() and candidate.is_file():
+            return candidate
+    return None
+
+
+def _elf_encoder_pad_token_id(config: ModelConfig) -> int:
+    raw = config.raw or {}
+    explicit = raw.get("elf_encoder_pad_token_id", raw.get("encoder_pad_token_id"))
+    if explicit is not None:
+        return int(explicit)
+    pad_token_id = raw.get("pad_token_id", config.pad_token_id)
+    if isinstance(pad_token_id, int) and pad_token_id >= 0:
+        return int(pad_token_id)
+    if str(raw.get("pad_token", "")).lower() == "eos":
+        eos_token_id = raw.get("eos_token_id", config.eos_token_id)
+        return int(eos_token_id) if isinstance(eos_token_id, int) and eos_token_id >= 0 else 1
+    return 0
+
+
+class ELFPlugin:
+    name = "elf_flow"
+    runtime_strategy = "elf_flow"
+
+    def matches(self, model_type: str) -> bool:
+        mt = (model_type or "").lower()
+        return mt in ("elf", "embedded_language_flow", "embedded-language-flow")
+
+    def load_weights(
+        self,
+        model_dir: str,
+        config: ModelConfig,
+        *,
+        precision: str = "fp32",
+    ) -> WeightDict:
+        cfg = resolve_elf_config(config)
+        store = _TensorStore(model_dir)
+        target_dtype = _target_np_dtype(precision)
+        weights = WeightDict()
+        config.raw["_elf_model_dir"] = str(Path(model_dir).resolve())
+        encoder_checkpoint = _find_encoder_checkpoint(model_dir)
+        if encoder_checkpoint is not None:
+            weights["_elf_encoder_checkpoint"] = str(encoder_checkpoint.resolve())
+            config.raw["_elf_encoder_checkpoint"] = str(encoder_checkpoint.resolve())
+
+        def proj(name: str, *aliases: str) -> np.ndarray:
+            return _load(store, name, *aliases, dtype=target_dtype)
+
+        def vec(name: str, *aliases: str) -> np.ndarray:
+            return _load(store, name, *aliases, dtype=np.float32)
+
+        if cfg["input_dim"] == 2 * cfg["text_encoder_dim"]:
+            weights["self_cond_proj.w"] = proj("self_cond_proj.kernel")
+            weights["self_cond_proj.b"] = proj("self_cond_proj.bias")
+
+        weights["text_proj.proj1.w"] = proj("text_proj.proj1.kernel")
+        weights["text_proj.proj2.w"] = proj("text_proj.proj2.kernel")
+        weights["text_proj.proj2.b"] = proj("text_proj.proj2.bias")
+
+        weights["t_embedder.mlp_0.w"] = proj("t_embedder.mlp_0.kernel")
+        weights["t_embedder.mlp_0.b"] = proj("t_embedder.mlp_0.bias")
+        weights["t_embedder.mlp_2.w"] = proj("t_embedder.mlp_2.kernel")
+        weights["t_embedder.mlp_2.b"] = proj("t_embedder.mlp_2.bias")
+        weights["t_emb_tokens"] = proj("t_emb_tokens")
+
+        if cfg["num_self_cond_cfg_tokens"] > 0:
+            weights["self_cond_cfg_embedder.mlp_0.w"] = proj(
+                "self_cond_cfg_embedder.mlp_0.kernel")
+            weights["self_cond_cfg_embedder.mlp_0.b"] = proj(
+                "self_cond_cfg_embedder.mlp_0.bias")
+            weights["self_cond_cfg_embedder.mlp_2.w"] = proj(
+                "self_cond_cfg_embedder.mlp_2.kernel")
+            weights["self_cond_cfg_embedder.mlp_2.b"] = proj(
+                "self_cond_cfg_embedder.mlp_2.bias")
+            weights["self_cond_cfg_tokens"] = proj("self_cond_cfg_tokens")
+
+        if cfg["num_model_mode_tokens"] > 0:
+            weights["mode_tokens"] = proj("mode_tokens")
+
+        for layer_idx in range(cfg["depth"]):
+            src = f"blocks_{layer_idx}"
+            dst = f"layer.{layer_idx}"
+            weights[f"{dst}.norm1"] = vec(f"{src}.norm1.weight")
+            weights[f"{dst}.attn.qkv.w"] = proj(f"{src}.attn.qkv.kernel")
+            weights[f"{dst}.attn.qkv.b"] = proj(f"{src}.attn.qkv.bias")
+            weights[f"{dst}.attn.q_norm"] = vec(f"{src}.attn.q_norm.weight")
+            weights[f"{dst}.attn.k_norm"] = vec(f"{src}.attn.k_norm.weight")
+            weights[f"{dst}.attn.proj.w"] = proj(f"{src}.attn.proj.kernel")
+            weights[f"{dst}.attn.proj.b"] = proj(f"{src}.attn.proj.bias")
+            weights[f"{dst}.norm2"] = vec(f"{src}.norm2.weight")
+            weights[f"{dst}.mlp.w12.w"] = proj(f"{src}.mlp.w12.kernel")
+            weights[f"{dst}.mlp.w12.b"] = proj(f"{src}.mlp.w12.bias")
+            weights[f"{dst}.mlp.w3.w"] = proj(f"{src}.mlp.w3.kernel")
+            weights[f"{dst}.mlp.w3.b"] = proj(f"{src}.mlp.w3.bias")
+
+        weights["decoder.proj.w"] = proj("proj_kernel")
+        weights["decoder.proj.b"] = proj("proj_bias")
+        weights["decoder.unembed.w"] = proj("unembed_kernel")
+        weights["decoder.unembed.b"] = proj("unembed_bias")
+        if config.vocab_size <= 0 and weights["decoder.unembed.w"].ndim == 2:
+            config.vocab_size = int(weights["decoder.unembed.w"].shape[1])
+            config.raw["vocab_size"] = config.vocab_size
+        weights["final.norm"] = vec("final_layer.norm_final.weight")
+        weights["final.linear.w"] = proj("final_layer.linear.kernel")
+        weights["final.linear.b"] = proj("final_layer.linear.bias")
+        return weights
+
+    def build_engine(
+        self,
+        config: ModelConfig,
+        weights: WeightDict,
+        max_cache_length: int,
+        *,
+        precision: str = "fp32",
+        quant_ctx=None,
+        verbose: bool = False,
+    ) -> bytes:
+        del quant_ctx
+        from .builder import build_elf_flow_engine
+
+        return build_elf_flow_engine(
+            config, weights, max_cache_length, precision=precision, verbose=verbose)
+
+    def build_extra_engines(
+        self,
+        config: ModelConfig,
+        weights: WeightDict,
+        max_cache_length: int,
+        *,
+        precision: str = "fp32",
+        verbose: bool = False,
+        build_timing: dict | None = None,
+    ) -> dict | None:
+        del max_cache_length
+        encoder_checkpoint = weights.get("_elf_encoder_checkpoint")
+        if not encoder_checkpoint:
+            return {}
+
+        from ...build_timing import timed_trt_compile, timed_weight_loading
+        from .t5_encoder_builder import (
+            build_t5_encoder_engine,
+            load_jax_t5_encoder_weights,
+        )
+
+        cfg = resolve_elf_config(config)
+        with timed_weight_loading(build_timing, "elf_t5_encoder"):
+            t5_weights = load_jax_t5_encoder_weights(
+                str(encoder_checkpoint), precision=precision, num_layers=6)
+        with timed_trt_compile(build_timing, "elf_t5_encoder"):
+            t5_plan = build_t5_encoder_engine(
+                t5_weights,
+                d_model=cfg["text_encoder_dim"],
+                num_heads=8,
+                d_kv=64,
+                d_ff=2048,
+                num_layers=6,
+                vocab_size=32128,
+                max_seq_len=cfg["max_length"],
+                eps=1e-6,
+                verbose=verbose,
+            )
+        return {"elf_text_encoder_plan": t5_plan}
+
+    def get_bundle_config_overrides(self, config: ModelConfig) -> dict:
+        cfg = resolve_elf_config(config)
+        raw = config.raw or {}
+        return {
+            "runtime_strategy": self.runtime_strategy,
+            "model_type": "elf",
+            "hidden_size": cfg["hidden_size"],
+            "num_hidden_layers": cfg["depth"],
+            "num_attention_heads": cfg["num_heads"],
+            "head_dim": cfg["head_dim"],
+            "max_position_embeddings": cfg["max_length"],
+            "vocab_size": cfg["vocab_size"],
+            "elf_variant": cfg["variant"],
+            "elf_max_length": cfg["max_length"],
+            "elf_max_input_length": cfg["max_input_length"],
+            "elf_text_encoder_dim": cfg["text_encoder_dim"],
+            "elf_input_dim": cfg["input_dim"],
+            "elf_bottleneck_dim": cfg["bottleneck_dim"],
+            "elf_num_time_tokens": cfg["num_time_tokens"],
+            "elf_num_self_cond_cfg_tokens": cfg["num_self_cond_cfg_tokens"],
+            "elf_num_model_mode_tokens": cfg["num_model_mode_tokens"],
+            "elf_denoiser_noise_scale": cfg["denoiser_noise_scale"],
+            "elf_denoiser_p_mean": cfg["denoiser_p_mean"],
+            "elf_denoiser_p_std": cfg["denoiser_p_std"],
+            "elf_t_eps": cfg["t_eps"],
+            "elf_latent_mean": float(raw.get("latent_mean", 0.0)),
+            "elf_latent_std": float(raw.get("latent_std", 0.2)),
+            "elf_encoder_model_name": raw.get("encoder_model_name", "t5-small"),
+            "elf_encoder_max_length": cfg["max_length"],
+            "elf_encoder_pad_token_id": _elf_encoder_pad_token_id(config),
+            "elf_has_text_encoder": int(bool(raw.get("_elf_encoder_checkpoint"))),
+            "elf_runtime_contract": "api_path_denoise_or_decode_logits",
+            "elf_user_contract": "diffusion_text_generation",
+            "elf_output_schema": "jsonl_id_generated_after_sampler_decode",
+        }
+
+
+plugin = ELFPlugin()

--- a/tensorrt_model_connect/tensorrt_model_connect/families/elf_flow/t5_encoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/elf_flow/t5_encoder_builder.py
@@ -1,0 +1,285 @@
+"""ELF-flow-owned T5-small encoder engine builder.
+
+Builds the original non-gated T5 encoder variant used by the official GitHub
+ELF JAX checkpoint.
+
+Engine I/O:
+    Input:  input_ids [1, max_seq_len] int32
+    Output: text_embeddings [1, max_seq_len, d_model] float32
+
+Single forward pass (no cache), like vision encoder.
+"""
+
+from __future__ import annotations
+
+import pickle
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+
+
+def build_t5_encoder_engine(
+    weights: WeightDict,
+    *,
+    d_model: int = 4096,
+    num_heads: int = 64,
+    d_kv: int = 64,
+    d_ff: int = 10240,
+    num_layers: int = 24,
+    vocab_size: int = 250112,
+    max_seq_len: int = 512,
+    relative_attention_num_buckets: int = 32,
+    relative_attention_max_distance: int = 128,
+    eps: float = 1e-6,
+    verbose: bool = False,
+) -> bytes:
+    """Build the GitHub ELF T5 encoder TRT engine plan.
+
+    Args:
+        weights: Weight dict with T5 encoder weights. Expected keys:
+            - shared.weight: [vocab_size, d_model] embedding
+            - encoder.block.{i}.layer.0.SelfAttention.q/k/v/o.weight
+            - encoder.block.{i}.layer.0.layer_norm.weight
+            - encoder.block.{i}.layer.1.DenseReluDense.wi/wo.weight
+            - encoder.block.{i}.layer.1.layer_norm.weight
+            - encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight
+            - encoder.final_layer_norm.weight
+        d_model: Hidden dimension.
+        num_heads: Number of attention heads.
+        d_kv: Key/value dimension per head.
+        d_ff: Feed-forward inner dimension.
+        num_layers: Number of encoder layers.
+        vocab_size: Vocabulary size.
+        max_seq_len: Maximum sequence length.
+        relative_attention_num_buckets: T5 relative position bias buckets.
+        relative_attention_max_distance: Max distance for relative position.
+        eps: RMSNorm epsilon.
+        verbose: Enable TRT builder verbose logging.
+
+    Returns:
+        Serialized TRT engine plan bytes.
+    """
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    config.clear_flag(trt.BuilderFlag.TF32)
+
+    # --- Inputs ---
+    input_ids = network.add_input(
+        "input_ids", trt.int32, (1, max_seq_len))
+    # Attention mask: [1, max_seq_len] float32, 0.0 for valid, -1e9 for padding
+    attention_mask_input = network.add_input(
+        "attention_mask", trt.float32, (1, max_seq_len))
+
+    # --- Constants ---
+    eps_t = graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+
+    # Embedding table [vocab_size, d_model]
+    embed_table = graph_ops.add_constant(
+        network, (vocab_size, d_model), weights["shared.weight"])
+
+    # --- Embedding lookup ---
+    # Flatten input_ids to [max_seq_len] for gather
+    flatten_ids = network.add_shuffle(input_ids)
+    flatten_ids.reshape_dims = (max_seq_len,)
+
+    gather = network.add_gather(embed_table, flatten_ids.get_output(0), 0)
+    hidden = gather.get_output(0)  # [max_seq_len, d_model]
+
+    # --- Relative position bias ---
+    # Precompute bucket indices [max_seq_len, max_seq_len]
+    bucket_indices = graph_ops.make_t5_relative_position_bias(
+        num_heads, max_seq_len,
+        num_buckets=relative_attention_num_buckets,
+        max_distance=relative_attention_max_distance,
+    )
+
+    # Reshape attention mask: [1, max_seq_len] -> [1, 1, max_seq_len]
+    attn_mask_3d = network.add_shuffle(attention_mask_input)
+    attn_mask_3d.reshape_dims = (1, 1, max_seq_len)
+
+    # UMT5: each layer has its own relative_attention_bias (unlike T5 which shares layer 0's)
+    # Precompute per-layer bias tables as constants
+    per_layer_bias = []
+    for layer_idx in range(num_layers):
+        bias_key = f"encoder.block.{layer_idx}.layer.0.SelfAttention.relative_attention_bias.weight"
+        if bias_key in weights:
+            rel_bias_weight = weights[bias_key]
+        else:
+            # Fallback: use layer 0's bias (vanilla T5 behavior)
+            rel_bias_weight = weights[
+                "encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight"]
+
+        bias_table = np.zeros(
+            (num_heads, max_seq_len, max_seq_len), dtype=np.float32)
+        for q_pos in range(max_seq_len):
+            for k_pos in range(max_seq_len):
+                bucket = bucket_indices[q_pos, k_pos]
+                for h in range(num_heads):
+                    bias_table[h, q_pos, k_pos] = rel_bias_weight[bucket, h]
+
+        rel_bias_const = graph_ops.add_constant(
+            network, (num_heads, max_seq_len, max_seq_len), bias_table)
+
+        # Combine position bias + attention mask
+        position_bias_masked = network.add_elementwise(
+            rel_bias_const, attn_mask_3d.get_output(0),
+            trt.ElementWiseOperation.SUM)
+        per_layer_bias.append(position_bias_masked.get_output(0))
+
+    # --- Encoder layers ---
+    attention_size = num_heads * d_kv
+
+    for layer_idx in range(num_layers):
+        prefix = f"encoder.block.{layer_idx}"
+
+        # === Self-attention sub-layer ===
+        # Pre-norm (RMSNorm)
+        norm1_gamma = weights[f"{prefix}.layer.0.layer_norm.weight"]
+        normed = graph_ops.add_rms_norm(
+            network, hidden, d_model, norm1_gamma, eps_t)
+
+        # Q, K, V projections
+        # T5 uses no bias on Q/K/V/O projections
+        w_q = weights[f"{prefix}.layer.0.SelfAttention.q.weight"]
+        w_k = weights[f"{prefix}.layer.0.SelfAttention.k.weight"]
+        w_v = weights[f"{prefix}.layer.0.SelfAttention.v.weight"]
+        w_o = weights[f"{prefix}.layer.0.SelfAttention.o.weight"]
+
+        # Self-attention with relative position bias
+        q = graph_ops.add_matmul_rhs_constant(
+            network, normed, d_model, attention_size, w_q)
+        k = graph_ops.add_matmul_rhs_constant(
+            network, normed, d_model, attention_size, w_k)
+        v = graph_ops.add_matmul_rhs_constant(
+            network, normed, d_model, attention_size, w_v)
+
+        # T5 attention is intentionally unscaled; relative position bias and
+        # padding mask are folded into the native IAttention additive mask.
+        mask_4d = network.add_shuffle(per_layer_bias[layer_idx])
+        mask_4d.reshape_dims = (1, num_heads, max_seq_len, max_seq_len)
+        context_flat = graph_ops.add_attention_from_rows(
+            network, q, k, v,
+            num_heads=num_heads, head_dim=d_kv,
+            q_seq=max_seq_len, kv_seq=max_seq_len,
+            mask=mask_4d.get_output(0),
+            scale=1.0)
+
+        # Output projection
+        attn_out = graph_ops.add_matmul_rhs_constant(
+            network, context_flat,
+            attention_size, d_model, w_o)
+
+        # Residual
+        hidden = network.add_elementwise(
+            hidden, attn_out,
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === FFN sub-layer ===
+        # Pre-norm (RMSNorm)
+        norm2_gamma = weights[f"{prefix}.layer.1.layer_norm.weight"]
+        ffn_normed = graph_ops.add_rms_norm(
+            network, hidden, d_model, norm2_gamma, eps_t)
+
+        # Original T5 FFN: relu(wi(x)), then wo. ELF's published t5-small
+        # JAX encoder checkpoint uses this non-gated variant.
+        w_fc1 = weights[f"{prefix}.layer.1.DenseReluDense.wi.weight"]
+        w_fc2 = weights[f"{prefix}.layer.1.DenseReluDense.wo.weight"]
+        fc1 = graph_ops.add_matmul_rhs_constant(
+            network, ffn_normed, d_model, d_ff, w_fc1)
+        ffn_input = graph_ops.add_activation(network, fc1, "relu")
+
+        ffn_out = graph_ops.add_matmul_rhs_constant(
+            network, ffn_input, d_ff, d_model, w_fc2)
+
+        # Residual
+        hidden = network.add_elementwise(
+            hidden, ffn_out,
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+    # --- Final norm ---
+    final_norm_gamma = weights["encoder.final_layer_norm.weight"]
+    hidden = graph_ops.add_rms_norm(
+        network, hidden, d_model, final_norm_gamma, eps_t)
+
+    # --- Output ---
+    # Reshape to [1, max_seq_len, d_model]
+    out_reshape = network.add_shuffle(hidden)
+    out_reshape.reshape_dims = (1, max_seq_len, d_model)
+    out_tensor = out_reshape.get_output(0)
+    cast_out = network.add_cast(out_tensor, trt.float32)
+    out_final = cast_out.get_output(0)
+    out_final.name = "text_embeddings"
+    network.mark_output(out_final)
+
+    # --- Build ---
+    print(f"[elf-t5-encoder] Building TRT engine "
+          f"(d_model={d_model}, layers={num_layers}, seq={max_seq_len}) ...",
+          file=sys.stderr)
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError("TRT engine serialization failed for T5 encoder")
+    return bytes(plan)
+
+
+def load_jax_t5_encoder_weights(
+    checkpoint_path: str,
+    *,
+    precision: str = "fp32",
+    num_layers: int = 6,
+) -> WeightDict:
+    """Load the official GitHub ELF JAX T5-small encoder checkpoint.
+
+    The checkpoint published at
+    ``embedded-language-flows/t5_small_encoder_jax/t5_small_encoder_jax.pkl``
+    stores Flax Dense kernels already in ``[in, out]`` layout, which is the
+    layout consumed by ``graph_ops.add_matmul_rhs_constant``.
+    """
+    from ...checkpoint_mapper import WeightDict, _target_np_dtype
+
+    with open(checkpoint_path, "rb") as f:
+        payload = pickle.load(f)
+    params = payload.get("params", payload)
+    target_dtype = _target_np_dtype(precision)
+    weights = WeightDict()
+
+    weights["shared.weight"] = np.ascontiguousarray(
+        params["shared"]["embedding"], dtype=target_dtype)
+    enc = params["encoder"]
+    for i in range(num_layers):
+        src = enc[f"block_{i}"]
+        prefix = f"encoder.block.{i}"
+        attn = src["layer_0"]["SelfAttention"]
+        for proj in ("q", "k", "v", "o"):
+            weights[f"{prefix}.layer.0.SelfAttention.{proj}.weight"] = np.ascontiguousarray(
+                attn[proj]["kernel"], dtype=target_dtype)
+        if i == 0:
+            weights[
+                "encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight"
+            ] = np.ascontiguousarray(
+                attn["relative_attention_bias"]["rel_embedding"], dtype=np.float32)
+        weights[f"{prefix}.layer.0.layer_norm.weight"] = np.ascontiguousarray(
+            src["layer_0"]["layer_norm"]["weight"], dtype=np.float32)
+        dense = src["layer_1"]["DenseReluDense"]
+        weights[f"{prefix}.layer.1.DenseReluDense.wi.weight"] = np.ascontiguousarray(
+            dense["wi"]["kernel"], dtype=target_dtype)
+        weights[f"{prefix}.layer.1.DenseReluDense.wo.weight"] = np.ascontiguousarray(
+            dense["wo"]["kernel"], dtype=target_dtype)
+        weights[f"{prefix}.layer.1.layer_norm.weight"] = np.ascontiguousarray(
+            src["layer_1"]["layer_norm"]["weight"], dtype=np.float32)
+
+    weights["encoder.final_layer_norm.weight"] = np.ascontiguousarray(
+        enc["final_layer_norm"]["weight"], dtype=np.float32)
+    return weights

--- a/tests/builder/test_engine_builder_extended.py
+++ b/tests/builder/test_engine_builder_extended.py
@@ -392,6 +392,69 @@ class TestBuildBundleOrchestration:
                             section_names = [s.name for s in sections]
                             assert "config.json" in section_names
 
+    def test_yaml_only_elf_synthesizes_config_json_section(self, tmp_path):
+        """GitHub ELF YAML-only directories still get runtime config.json."""
+        (tmp_path / "train_owt_ELF-B.yml").write_text(
+            "\n".join([
+                "model: ELF-B",
+                "max_length: 1024",
+                "encoder_model_name: t5-small",
+                "num_time_tokens: 4",
+                "num_self_cond_cfg_tokens: 4",
+                "num_model_mode_tokens: 4",
+                "denoiser_p_mean: -1.5",
+                "denoiser_p_std: 0.8",
+                "denoiser_noise_scale: 2.0",
+                "self_cond_prob: 0.5",
+            ]),
+            encoding="utf-8",
+        )
+        output_path = str(tmp_path / "output.trtfb")
+
+        mock_plugin = MagicMock()
+        mock_plugin.name = "elf"
+        mock_plugin.runtime_strategy = "elf_flow"
+        mock_plugin.load_weights.return_value = {}
+        mock_plugin.build_engine.return_value = b"PLAN"
+        mock_plugin.get_bundle_config_overrides.return_value = {
+            "runtime_strategy": "elf_flow",
+            "model_type": "elf",
+            "elf_max_length": 1024,
+            "elf_max_input_length": 0,
+            "elf_text_encoder_dim": 512,
+            "elf_input_dim": 1024,
+            "elf_denoiser_noise_scale": 2.0,
+        }
+
+        del mock_plugin.build_vision_engine
+        del mock_plugin.build_extra_engines
+        del mock_plugin.embed_input
+        del mock_plugin.get_vl_config
+        del mock_plugin.get_segmentation_config
+        del mock_plugin.get_audio_config
+
+        with patch("tensorrt_model_connect.engine_builder.find_plugin",
+                   return_value=mock_plugin):
+            with patch("tensorrt_model_connect.engine_builder._get_trt_version",
+                       return_value="10.0"):
+                with patch("tensorrt_model_connect.engine_builder._get_gpu_name",
+                           return_value=""):
+                    with patch("tensorrt_model_connect.engine_builder._ensure_tokenizer_json"):
+                        with patch("tensorrt_model_connect.engine_builder.write_bundle") as mock_write:
+                            build_bundle(str(tmp_path), output_path)
+
+        sections = mock_write.call_args[0][2]
+        section_map = {section.name: section.data for section in sections}
+        cfg = json.loads(section_map["config.json"].decode("utf-8"))
+        assert cfg["runtime_strategy"] == "elf_flow"
+        assert cfg["model_type"] == "elf"
+        assert cfg["model"] == "ELF-B"
+        assert cfg["elf_max_length"] == 1024
+        assert cfg["elf_max_input_length"] == 0
+        assert cfg["elf_text_encoder_dim"] == 512
+        assert cfg["elf_input_dim"] == 1024
+        assert cfg["elf_denoiser_noise_scale"] == 2.0
+
     def test_runtime_strategy_injected(self, tmp_path):
         """runtime_strategy from plugin is injected into config.json section."""
         model_dir = self._make_model_dir(tmp_path, model_type="qwen3")

--- a/tests/builder/test_families.py
+++ b/tests/builder/test_families.py
@@ -368,6 +368,9 @@ _POSITIVE_MATCH_CASES = [
     ("pixart", "pixart"),
     ("pixart_sigma", "pixart"),
     ("pixart_alpha", "pixart"),
+    # ELF Flow (diffusion text generation)
+    ("elf", "elf_flow"),
+    ("embedded_language_flow", "elf_flow"),
     # DeepSeek OCR (matches deepseek_vl_v2 model_type)
     ("deepseek_vl_v2", "deepseek_ocr"),
     # MagpieTTS (encoder-decoder TTS)

--- a/tests/builder/test_family_elf.py
+++ b/tests/builder/test_family_elf.py
@@ -1,0 +1,622 @@
+"""Tests for the GitHub ELF family plugin.
+
+These tests validate the exact Flax-style weight naming used by
+https://github.com/lillian039/ELF without depending on Hugging Face loaders.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pickle
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+try:
+    from safetensors.numpy import save_file
+    from tensorrt_model_connect.config import ModelConfig
+    from tensorrt_model_connect.families.elf_flow import plugin
+    from tensorrt_model_connect.families.elf_flow.config import (
+        make_elf_rope_cache,
+        resolve_elf_config,
+    )
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect test dependencies unavailable", allow_module_level=True)
+
+
+RNG = np.random.RandomState(7)
+
+
+def _rand(*shape: int) -> np.ndarray:
+    return RNG.randn(*shape).astype(np.float32)
+
+
+def _cfg(**overrides) -> ModelConfig:
+    data = {
+        "model_type": "elf",
+        "model": "ELF-B",
+        "text_encoder_dim": 6,
+        "hidden_size": 8,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 2,
+        "vocab_size": 11,
+        "max_length": 4,
+        "max_position_embeddings": 4,
+        "bottleneck_dim": 3,
+        "num_time_tokens": 2,
+        "num_self_cond_cfg_tokens": 1,
+        "num_model_mode_tokens": 1,
+        "self_cond_prob": 0.5,
+    }
+    data.update(overrides)
+    return ModelConfig.from_json(json.dumps(data))
+
+
+def _write_model(tmp_path: Path, tensors: dict[str, np.ndarray]) -> None:
+    (tmp_path / "config.json").write_text(json.dumps(_cfg().raw), encoding="utf-8")
+    save_file(tensors, str(tmp_path / "model.safetensors"))
+
+
+def _nest_tensor_tree(tensors: dict[str, np.ndarray]) -> dict:
+    root: dict = {}
+    for name, value in tensors.items():
+        parts = name.split(".")
+        cursor = root
+        for part in parts[:-1]:
+            cursor = cursor.setdefault(part, {})
+        cursor[parts[-1]] = value
+    return root
+
+
+def _find_trtmc_binary() -> Path | None:
+    env_path = os.environ.get("TRTMC_BINARY")
+    candidates = [
+        Path(env_path) if env_path else None,
+        Path(__file__).resolve().parents[2] / "build" / "trtmc",
+        Path("/tmp/trtmc-elf-build/trtmc"),
+    ]
+    for candidate in candidates:
+        if candidate and candidate.exists():
+            return candidate
+    return None
+
+
+def _tiny_unigram_tokenizer_json(vocab_size: int) -> bytes:
+    vocab = [["<unk>", 0.0]]
+    vocab.extend([[f"\u2581{chr(ord('A') + idx - 1)}", -float(idx)] for idx in range(1, vocab_size)])
+    return json.dumps({
+        "model": {"type": "Unigram", "unk_id": 0, "vocab": vocab},
+        "pre_tokenizer": {
+            "type": "Metaspace",
+            "replacement": "\u2581",
+            "add_prefix_space": True,
+        },
+    }).encode("utf-8")
+
+
+def _decode_tiny_unigram(ids: np.ndarray, vocab_size: int) -> str:
+    pieces = ["<unk>"]
+    pieces.extend([f"\u2581{chr(ord('A') + idx - 1)}" for idx in range(1, vocab_size)])
+    joined = "".join(pieces[int(idx)] for idx in ids)
+    return joined.replace("\u2581", " ").lstrip(" ")
+
+
+def _elf_tensors(*, layers: int = 2, scale: float = 1.0) -> dict[str, np.ndarray]:
+    hidden = 8
+    text_dim = 6
+    bottleneck = 3
+    input_dim = 12
+    vocab = 11
+    head_dim = 4
+    actual_ffn = int(int(hidden * 4.0) * 2 / 3)
+    tensors: dict[str, np.ndarray] = {
+        "self_cond_proj.kernel": _rand(input_dim, text_dim),
+        "self_cond_proj.bias": _rand(text_dim),
+        "text_proj.proj1.kernel": _rand(text_dim, bottleneck),
+        "text_proj.proj2.kernel": _rand(bottleneck, hidden),
+        "text_proj.proj2.bias": _rand(hidden),
+        "t_embedder.mlp_0.kernel": _rand(256, hidden),
+        "t_embedder.mlp_0.bias": _rand(hidden),
+        "t_embedder.mlp_2.kernel": _rand(hidden, hidden),
+        "t_embedder.mlp_2.bias": _rand(hidden),
+        "t_emb_tokens": _rand(1, 2, hidden),
+        "self_cond_cfg_embedder.mlp_0.kernel": _rand(256, hidden),
+        "self_cond_cfg_embedder.mlp_0.bias": _rand(hidden),
+        "self_cond_cfg_embedder.mlp_2.kernel": _rand(hidden, hidden),
+        "self_cond_cfg_embedder.mlp_2.bias": _rand(hidden),
+        "self_cond_cfg_tokens": _rand(1, 1, hidden),
+        "mode_tokens": _rand(1, 1, hidden),
+        "proj_kernel": _rand(hidden, text_dim),
+        "proj_bias": _rand(text_dim),
+        "unembed_kernel": _rand(text_dim, vocab),
+        "unembed_bias": _rand(vocab),
+        "final_layer.norm_final.weight": _rand(hidden),
+        "final_layer.linear.kernel": _rand(hidden, text_dim),
+        "final_layer.linear.bias": _rand(text_dim),
+    }
+    if scale != 1.0:
+        tensors = {key: value * scale for key, value in tensors.items()}
+    for i in range(layers):
+        p = f"blocks_{i}"
+        tensors[f"{p}.norm1.weight"] = _rand(hidden)
+        tensors[f"{p}.attn.qkv.kernel"] = _rand(hidden, 3 * hidden) * scale
+        tensors[f"{p}.attn.qkv.bias"] = _rand(3 * hidden) * scale
+        tensors[f"{p}.attn.q_norm.weight"] = _rand(head_dim)
+        tensors[f"{p}.attn.k_norm.weight"] = _rand(head_dim)
+        tensors[f"{p}.attn.proj.kernel"] = _rand(hidden, hidden) * scale
+        tensors[f"{p}.attn.proj.bias"] = _rand(hidden) * scale
+        tensors[f"{p}.norm2.weight"] = _rand(hidden)
+        tensors[f"{p}.mlp.w12.kernel"] = _rand(hidden, 2 * actual_ffn) * scale
+        tensors[f"{p}.mlp.w12.bias"] = _rand(2 * actual_ffn) * scale
+        tensors[f"{p}.mlp.w3.kernel"] = _rand(actual_ffn, hidden) * scale
+        tensors[f"{p}.mlp.w3.bias"] = _rand(hidden) * scale
+    return tensors
+
+
+def _silu(x: np.ndarray) -> np.ndarray:
+    return x / (1.0 + np.exp(-x))
+
+
+def _gelu_tanh(x: np.ndarray) -> np.ndarray:
+    return 0.5 * x * (1.0 + np.tanh(np.sqrt(2.0 / np.pi) * (x + 0.044715 * x**3)))
+
+
+def _rms_norm(x: np.ndarray, weight: np.ndarray, eps: float = 1e-6) -> np.ndarray:
+    return x * (1.0 / np.sqrt(np.mean(x * x, axis=-1, keepdims=True) + eps)) * weight
+
+
+def _timestep_embedding(t: np.ndarray, dim: int = 256) -> np.ndarray:
+    half = dim // 2
+    freqs = np.exp(-np.log(10000.0) * np.arange(0, half, dtype=np.float32) / half)
+    args = t.reshape(-1, 1).astype(np.float32) * freqs.reshape(1, -1)
+    return np.concatenate([np.cos(args), np.sin(args)], axis=-1).astype(np.float32)
+
+
+def _timestep_mlp(t: np.ndarray, weights: dict[str, np.ndarray], prefix: str) -> np.ndarray:
+    emb = _timestep_embedding(t)
+    emb = emb @ weights[f"{prefix}.mlp_0.w"] + weights[f"{prefix}.mlp_0.b"]
+    emb = _silu(emb)
+    return emb @ weights[f"{prefix}.mlp_2.w"] + weights[f"{prefix}.mlp_2.b"]
+
+
+def _apply_github_rope(x: np.ndarray, *, max_length: int, prefix_tokens: int) -> np.ndarray:
+    seq, _, head_dim = x.shape
+    freqs = 1.0 / (10000.0 ** (np.arange(0, head_dim, 2, dtype=np.float32) / head_dim))
+    angles = np.arange(max_length, dtype=np.float32).reshape(-1, 1) * freqs.reshape(1, -1)
+    cos_main = np.repeat(np.cos(angles), 2, axis=-1)
+    sin_main = np.repeat(np.sin(angles), 2, axis=-1)
+    cos = np.concatenate([
+        np.ones((prefix_tokens, head_dim), dtype=np.float32),
+        cos_main,
+    ], axis=0)[:seq]
+    sin = np.concatenate([
+        np.zeros((prefix_tokens, head_dim), dtype=np.float32),
+        sin_main,
+    ], axis=0)[:seq]
+    pairs = x.reshape(seq, x.shape[1], head_dim // 2, 2)
+    rotated = np.stack([-pairs[..., 1], pairs[..., 0]], axis=-1).reshape(x.shape)
+    return x * cos[:, None, :] + rotated * sin[:, None, :]
+
+
+def _softmax(x: np.ndarray, axis: int = -1) -> np.ndarray:
+    shifted = x - np.max(x, axis=axis, keepdims=True)
+    exp = np.exp(shifted)
+    return exp / np.sum(exp, axis=axis, keepdims=True)
+
+
+def _numpy_elf_forward(
+    weights: dict[str, np.ndarray],
+    cfg: dict,
+    latent: np.ndarray,
+    timestep: float,
+    self_cond_cfg_scale: float,
+    decoder_mode: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    hidden_size = cfg["hidden_size"]
+    text_dim = cfg["text_encoder_dim"]
+    max_length = cfg["max_length"]
+    num_heads = cfg["num_heads"]
+    head_dim = cfg["head_dim"]
+    x = latent.astype(np.float32)
+    if x.shape[-1] == 2 * text_dim:
+        x = x @ weights["self_cond_proj.w"] + weights["self_cond_proj.b"]
+
+    x = x @ weights["text_proj.proj1.w"]
+    x = x @ weights["text_proj.proj2.w"] + weights["text_proj.proj2.b"]
+
+    mode_tokens = cfg["num_model_mode_tokens"]
+    if mode_tokens > 0:
+        mode = weights["mode_tokens"].reshape(mode_tokens, hidden_size) * decoder_mode
+        x = np.concatenate([mode, x], axis=0)
+
+    t_emb = _timestep_mlp(np.array([timestep], dtype=np.float32), weights, "t_embedder")
+    prefix_parts = [
+        weights["t_emb_tokens"].reshape(cfg["num_time_tokens"], hidden_size) + t_emb
+    ]
+    if cfg["num_self_cond_cfg_tokens"] > 0:
+        sc_emb = _timestep_mlp(
+            np.array([self_cond_cfg_scale], dtype=np.float32),
+            weights,
+            "self_cond_cfg_embedder",
+        )
+        prefix_parts.append(
+            weights["self_cond_cfg_tokens"].reshape(
+                cfg["num_self_cond_cfg_tokens"], hidden_size) + sc_emb
+        )
+    prefix = np.concatenate(prefix_parts, axis=0)
+    x = np.concatenate([prefix, x], axis=0)
+    empty_tokens = prefix.shape[0] + mode_tokens
+
+    for layer_idx in range(cfg["depth"]):
+        p = f"layer.{layer_idx}"
+        normed = _rms_norm(x, weights[f"{p}.norm1"])
+        qkv = normed @ weights[f"{p}.attn.qkv.w"] + weights[f"{p}.attn.qkv.b"]
+        qkv = qkv.reshape(x.shape[0], 3, num_heads, head_dim)
+        q, k, v = qkv[:, 0], qkv[:, 1], qkv[:, 2]
+        q = _rms_norm(q, weights[f"{p}.attn.q_norm"])
+        k = _rms_norm(k, weights[f"{p}.attn.k_norm"])
+        q = _apply_github_rope(q, max_length=max_length, prefix_tokens=empty_tokens)
+        k = _apply_github_rope(k, max_length=max_length, prefix_tokens=empty_tokens)
+        qh = np.transpose(q, (1, 0, 2))
+        kh = np.transpose(k, (1, 0, 2))
+        vh = np.transpose(v, (1, 0, 2))
+        scores = (qh @ np.swapaxes(kh, -1, -2)) / np.sqrt(head_dim)
+        attn = _softmax(scores, axis=-1) @ vh
+        attn = np.transpose(attn, (1, 0, 2)).reshape(x.shape[0], hidden_size)
+        attn = attn @ weights[f"{p}.attn.proj.w"] + weights[f"{p}.attn.proj.b"]
+        x = x + attn
+
+        normed = _rms_norm(x, weights[f"{p}.norm2"])
+        fused = normed @ weights[f"{p}.mlp.w12.w"] + weights[f"{p}.mlp.w12.b"]
+        x1, x2 = np.split(fused, 2, axis=-1)
+        mlp = (_silu(x1) * x2) @ weights[f"{p}.mlp.w3.w"] + weights[f"{p}.mlp.w3.b"]
+        x = x + mlp
+
+    body = x[empty_tokens:]
+    logits = _gelu_tanh(body @ weights["decoder.proj.w"] + weights["decoder.proj.b"])
+    logits = logits @ weights["decoder.unembed.w"] + weights["decoder.unembed.b"]
+    logits = logits * decoder_mode
+    denoised = _rms_norm(body, weights["final.norm"])
+    denoised = denoised @ weights["final.linear.w"] + weights["final.linear.b"]
+    return denoised.astype(np.float32), logits.astype(np.float32)
+
+
+def test_elf_plugin_matches_and_resolves_config() -> None:
+    assert plugin.matches("elf")
+    assert plugin.matches("embedded-language-flow")
+    assert not plugin.matches("llama")
+
+    cfg = resolve_elf_config(_cfg())
+    assert cfg["hidden_size"] == 8
+    assert cfg["depth"] == 2
+    assert cfg["num_heads"] == 2
+    assert cfg["text_encoder_dim"] == 6
+    assert cfg["input_dim"] == 12
+    assert cfg["max_length"] == 4
+
+
+def test_model_config_from_dir_accepts_github_elf_yaml(tmp_path: Path) -> None:
+    (tmp_path / "train_owt_ELF-B.yml").write_text(
+        "\n".join([
+            "model: ELF-B",
+            "max_length: 1024",
+            "encoder_model_name: t5-small",
+            "denoiser_p_mean: -1.5",
+            "denoiser_p_std: 0.8",
+            "denoiser_noise_scale: 2.0",
+            "self_cond_prob: 0.5",
+            "num_time_tokens: 4",
+            "num_self_cond_cfg_tokens: 4",
+            "num_model_mode_tokens: 4",
+        ]),
+        encoding="utf-8",
+    )
+
+    cfg = ModelConfig.from_dir(tmp_path)
+    resolved = resolve_elf_config(cfg)
+
+    assert cfg.model_type == "elf"
+    assert cfg.hidden_size == 768
+    assert cfg.num_hidden_layers == 12
+    assert cfg.num_attention_heads == 12
+    assert resolved["max_length"] == 1024
+    assert resolved["denoiser_noise_scale"] == 2.0
+
+
+def test_resolve_elf_config_honors_builder_max_length() -> None:
+    cfg = _cfg(max_length=1024, max_position_embeddings=1024)
+
+    resolved = resolve_elf_config(cfg, max_seq_length=128)
+
+    assert resolved["max_length"] == 128
+
+
+def test_load_weights_uses_github_flax_shapes_without_transpose(tmp_path: Path) -> None:
+    tensors = _elf_tensors()
+    qkv = tensors["blocks_0.attn.qkv.kernel"].copy()
+    _write_model(tmp_path, tensors)
+
+    weights = plugin.load_weights(str(tmp_path), _cfg())
+
+    assert weights["self_cond_proj.w"].shape == (12, 6)
+    assert weights["text_proj.proj1.w"].shape == (6, 3)
+    assert weights["layer.0.attn.qkv.w"].shape == (8, 24)
+    np.testing.assert_allclose(weights["layer.0.attn.qkv.w"], qkv)
+    assert weights["layer.0.attn.q_norm"].shape == (4,)
+    assert weights["layer.0.mlp.w12.w"].shape == (8, 42)
+    assert weights["decoder.unembed.w"].shape == (6, 11)
+    assert weights["final.linear.w"].shape == (8, 6)
+
+
+def test_load_weights_accepts_local_github_checkpoint_and_uses_ema_params(tmp_path: Path) -> None:
+    tensors = _elf_tensors()
+    params = {key: value + 100.0 for key, value in tensors.items()}
+    with (tmp_path / "checkpoint_42").open("wb") as f:
+        pickle.dump(
+            {
+                "params": _nest_tensor_tree(params),
+                "ema_params1": _nest_tensor_tree(tensors),
+                "opt_state": {},
+                "step": 42,
+                "epoch": 0,
+                "dropout_rng": np.array([0], dtype=np.uint32),
+            },
+            f,
+        )
+
+    weights = plugin.load_weights(str(tmp_path), _cfg())
+
+    np.testing.assert_allclose(weights["layer.0.attn.qkv.w"], tensors["blocks_0.attn.qkv.kernel"])
+    np.testing.assert_allclose(weights["decoder.unembed.w"], tensors["unembed_kernel"])
+
+
+def test_load_weights_infers_vocab_size_from_unembed_kernel(tmp_path: Path) -> None:
+    tensors = _elf_tensors()
+    _write_model(tmp_path, tensors)
+    cfg = _cfg(vocab_size=0)
+
+    weights = plugin.load_weights(str(tmp_path), cfg)
+
+    assert cfg.vocab_size == tensors["unembed_kernel"].shape[1]
+    assert cfg.raw["vocab_size"] == tensors["unembed_kernel"].shape[1]
+    assert weights["decoder.unembed.w"].shape == tensors["unembed_kernel"].shape
+
+
+def test_bundle_config_overrides_advertise_api_runtime() -> None:
+    overrides = plugin.get_bundle_config_overrides(_cfg())
+    assert overrides["runtime_strategy"] == "elf_flow"
+    assert overrides["model_type"] == "elf"
+    assert overrides["elf_max_length"] == 4
+    assert overrides["elf_text_encoder_dim"] == 6
+    assert overrides["elf_input_dim"] == 12
+    assert overrides["elf_num_time_tokens"] == 2
+    assert overrides["elf_num_self_cond_cfg_tokens"] == 1
+    assert overrides["elf_num_model_mode_tokens"] == 1
+    assert overrides["elf_denoiser_p_mean"] == -1.5
+    assert overrides["elf_denoiser_p_std"] == 0.8
+    assert overrides["elf_latent_mean"] == 0.0
+    assert overrides["elf_latent_std"] == 0.2
+    assert overrides["elf_encoder_model_name"] == "t5-small"
+    assert overrides["elf_encoder_pad_token_id"] == 0
+    assert overrides["elf_has_text_encoder"] == 0
+    assert overrides["elf_runtime_contract"] == "api_path_denoise_or_decode_logits"
+    assert overrides["elf_user_contract"] == "diffusion_text_generation"
+    assert overrides["elf_output_schema"] == "jsonl_id_generated_after_sampler_decode"
+    assert overrides["elf_max_input_length"] == 0
+
+
+def test_load_weights_marks_official_jax_t5_encoder_checkpoint(tmp_path: Path) -> None:
+    tensors = _elf_tensors()
+    _write_model(tmp_path, tensors)
+    (tmp_path / "t5_small_encoder_jax.pkl").write_bytes(b"encoder")
+    cfg = _cfg(pad_token="eos", eos_token_id=1, latent_std=0.25)
+
+    weights = plugin.load_weights(str(tmp_path), cfg)
+    overrides = plugin.get_bundle_config_overrides(cfg)
+
+    assert weights["_elf_encoder_checkpoint"].endswith("t5_small_encoder_jax.pkl")
+    assert overrides["elf_has_text_encoder"] == 1
+    assert overrides["elf_encoder_pad_token_id"] == 1
+    assert overrides["elf_latent_std"] == 0.25
+
+
+def test_build_extra_engines_compiles_official_jax_t5_encoder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: dict[str, object] = {}
+    tensors = _elf_tensors()
+    _write_model(tmp_path, tensors)
+    (tmp_path / "t5_small_encoder_jax.pkl").write_bytes(b"encoder")
+    cfg = _cfg(text_encoder_dim=512)
+    weights = plugin.load_weights(str(tmp_path), cfg)
+
+    def load_jax_t5_encoder_weights(path: str, **kwargs):
+        calls["load"] = {"path": path, **kwargs}
+        return {"shared.weight": np.zeros((32128, 512), dtype=np.float32)}
+
+    def build_t5_encoder_engine(weights_arg, **kwargs):
+        calls["build"] = {"weights": weights_arg, **kwargs}
+        return b"t5-plan"
+
+    fake_t5_builder = types.SimpleNamespace(
+        load_jax_t5_encoder_weights=load_jax_t5_encoder_weights,
+        build_t5_encoder_engine=build_t5_encoder_engine,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.elf_flow.t5_encoder_builder",
+        fake_t5_builder,
+    )
+
+    out = plugin.build_extra_engines(cfg, weights, 128, precision="fp32", verbose=True)
+
+    assert out == {"elf_text_encoder_plan": b"t5-plan"}
+    assert calls["load"]["precision"] == "fp32"
+    assert calls["load"]["num_layers"] == 6
+    assert calls["build"]["d_model"] == 512
+    assert calls["build"]["num_layers"] == 6
+    assert calls["build"]["vocab_size"] == 32128
+    assert calls["build"]["max_seq_len"] == 4
+    assert "is_gated_act" not in calls["build"]
+
+
+def test_elf_rope_cache_matches_github_empty_token_semantics() -> None:
+    cos, sin = make_elf_rope_cache(max_length=3, head_dim=4, prefix_tokens=2)
+    assert cos.shape == (1, 5, 2)
+    assert sin.shape == (1, 5, 2)
+    np.testing.assert_allclose(cos[0, :2], np.ones((2, 2), dtype=np.float32))
+    np.testing.assert_allclose(sin[0, :2], np.zeros((2, 2), dtype=np.float32))
+    np.testing.assert_allclose(cos[0, 2], np.ones(2, dtype=np.float32))
+    np.testing.assert_allclose(sin[0, 2], np.zeros(2, dtype=np.float32))
+
+    freqs = 1.0 / (10000.0 ** (np.arange(0, 4, 2, dtype=np.float32) / 4))
+    np.testing.assert_allclose(cos[0, 3], np.cos(freqs), rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(sin[0, 3], np.sin(freqs), rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.trt
+def test_elf_trt_forward_matches_github_numpy_reference(tmp_path: Path) -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.debug_runner import VisionTrtRunner
+    from tensorrt_model_connect.families.elf_flow.builder import build_elf_flow_engine
+
+    cfg = _cfg(num_hidden_layers=1)
+    tensors = _elf_tensors(layers=1, scale=0.05)
+    _write_model(tmp_path, tensors)
+    weights = plugin.load_weights(str(tmp_path), cfg)
+    resolved = resolve_elf_config(cfg)
+
+    plan = build_elf_flow_engine(cfg, weights, precision="fp32")
+    runner = VisionTrtRunner(plan)
+
+    latent = (np.arange(
+        resolved["max_length"] * resolved["input_dim"], dtype=np.float32
+    ).reshape(resolved["max_length"], resolved["input_dim"]) / 50.0) - 0.2
+    timestep = np.array([0.35], dtype=np.float32)
+    self_cond_cfg_scale = np.array([1.25], dtype=np.float32)
+
+    outputs = runner.encode(
+        latent=latent,
+        timestep=timestep,
+        self_cond_cfg_scale=self_cond_cfg_scale,
+        decoder_mode=np.array([1.0], dtype=np.float32),
+    )
+    ref_denoised, ref_logits = _numpy_elf_forward(
+        weights, resolved, latent, 0.35, 1.25, 1.0)
+    np.testing.assert_allclose(outputs["denoised"], ref_denoised, rtol=2e-3, atol=2e-3)
+    np.testing.assert_allclose(outputs["decoder_logits"], ref_logits, rtol=2e-3, atol=2e-3)
+
+    outputs_off = runner.encode(
+        latent=latent,
+        timestep=timestep,
+        self_cond_cfg_scale=self_cond_cfg_scale,
+        decoder_mode=np.array([0.0], dtype=np.float32),
+    )
+    ref_denoised_off, ref_logits_off = _numpy_elf_forward(
+        weights, resolved, latent, 0.35, 1.25, 0.0)
+    np.testing.assert_allclose(
+        outputs_off["denoised"], ref_denoised_off, rtol=2e-3, atol=2e-3)
+    np.testing.assert_allclose(
+        outputs_off["decoder_logits"], ref_logits_off, rtol=2e-3, atol=2e-3)
+
+
+@pytest.mark.trt
+def test_elf_trtmc_run_generates_text_from_diffusion_decode(tmp_path: Path) -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.bundle_writer import BundleInfo, BundleSection, write_bundle
+    from tensorrt_model_connect.families.elf_flow.builder import build_elf_flow_engine
+
+    trtmc_binary = _find_trtmc_binary()
+    if trtmc_binary is None:
+        pytest.skip("trtmc binary not built")
+    backend_dir = trtmc_binary.parent
+    if not (backend_dir / "libtrtmc_backend_trt.so").exists():
+        pytest.skip("trtmc_backend_trt DSO not built next to trtmc")
+
+    cfg = _cfg(num_hidden_layers=1)
+    tensors = _elf_tensors(layers=1, scale=0.05)
+    _write_model(tmp_path, tensors)
+    weights = plugin.load_weights(str(tmp_path), cfg)
+    resolved = resolve_elf_config(cfg)
+    plan = build_elf_flow_engine(cfg, weights, precision="fp32")
+
+    config_json = {
+        "runtime_strategy": "elf_flow",
+        "engine_backend": "trt",
+        "model_type": "elf",
+        "vocab_size": resolved["vocab_size"],
+        "elf_max_length": resolved["max_length"],
+        "elf_text_encoder_dim": resolved["text_encoder_dim"],
+        "elf_input_dim": resolved["input_dim"],
+        "elf_denoiser_noise_scale": 2.0,
+        "elf_denoiser_p_mean": -1.5,
+        "elf_denoiser_p_std": 0.8,
+        "elf_t_eps": 0.05,
+    }
+    bundle_path = tmp_path / "tiny-elf.trtfb"
+    write_bundle(
+        bundle_path,
+        BundleInfo(
+            model_id="tiny-elf",
+            model_type="elf",
+            family="elf_flow",
+            runtime_strategy="elf_flow",
+            vocab_size=resolved["vocab_size"],
+            hidden_size=resolved["hidden_size"],
+            num_layers=resolved["depth"],
+            num_attention_heads=resolved["num_heads"],
+            tokenizer_add_special_tokens=False,
+        ),
+        [
+            BundleSection("engine_plan", plan),
+            BundleSection("config.json", json.dumps(config_json).encode("utf-8")),
+            BundleSection("tokenizer.json", _tiny_unigram_tokenizer_json(resolved["vocab_size"])),
+        ],
+    )
+
+    z0 = (np.arange(
+        resolved["max_length"] * resolved["text_encoder_dim"], dtype=np.float32
+    ).reshape(resolved["max_length"], resolved["text_encoder_dim"]) / 20.0) - 0.5
+    latents_path = tmp_path / "initial_latents.raw"
+    z0.tofile(latents_path)
+
+    zeros = np.zeros_like(z0)
+    latent0 = np.concatenate([z0, zeros], axis=-1)
+    denoised, _ = _numpy_elf_forward(weights, resolved, latent0, 0.0, 1.0, 0.0)
+    latent1 = np.concatenate([denoised, zeros], axis=-1)
+    _, logits = _numpy_elf_forward(weights, resolved, latent1, 1.0, 1.0, 1.0)
+    expected_ids = np.argmax(logits, axis=-1).astype(np.int32)
+    expected_text = _decode_tiny_unigram(expected_ids, resolved["vocab_size"])
+    assert expected_text
+
+    result = subprocess.run(
+        [
+            str(trtmc_binary),
+            "run",
+            str(bundle_path),
+            "--num-steps",
+            "1",
+            "--guidance-scale",
+            "1",
+            "--sde-gamma",
+            "0",
+            "--seed",
+            "123",
+            "--initial-latents-raw",
+            str(latents_path),
+            "--backend-dir",
+            str(backend_dir),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.rstrip("\n") == expected_text

--- a/tests/cpp/test_cli_args.cpp
+++ b/tests/cpp/test_cli_args.cpp
@@ -70,7 +70,17 @@ struct CliArgs {
     std::uint64_t kv_cache_size_bytes{0};
     std::string image_path;
     std::string output_path;
+    std::string initial_latents_raw;
+    std::string condition_latents_raw;
+    std::string condition_mask_raw;
+    std::string sampling_steps_raw;
+    std::string sde_noise_raw;
     int max_new_tokens{0};
+    int num_samples{1};
+    int num_steps{-1};
+    float guidance_scale{-1.0F};
+    float cfg_scale{-1.0F};
+    float sde_gamma{-1.0F};
     float conf_threshold{-1.0F};
     bool show_help{false};
     bool parse_error{false};
@@ -172,6 +182,51 @@ CliArgs parse_args(int argc, const char** argv) {
             args.max_new_tokens = std::atoi(argv[++i]);
             continue;
         }
+        if (arg == "--num-samples") {
+            if (i + 1 >= argc) {
+                args.parse_error = true;
+                args.error_message = arg + " requires a value";
+                return args;
+            }
+            args.num_samples = std::max(1, std::atoi(argv[++i]));
+            continue;
+        }
+        if (arg == "--num-steps") {
+            if (i + 1 >= argc) {
+                args.parse_error = true;
+                args.error_message = arg + " requires a value";
+                return args;
+            }
+            args.num_steps = std::atoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--guidance-scale") {
+            if (i + 1 >= argc) {
+                args.parse_error = true;
+                args.error_message = arg + " requires a value";
+                return args;
+            }
+            args.guidance_scale = static_cast<float>(std::atof(argv[++i]));
+            continue;
+        }
+        if (arg == "--cfg-scale") {
+            if (i + 1 >= argc) {
+                args.parse_error = true;
+                args.error_message = arg + " requires a value";
+                return args;
+            }
+            args.cfg_scale = static_cast<float>(std::atof(argv[++i]));
+            continue;
+        }
+        if (arg == "--sde-gamma") {
+            if (i + 1 >= argc) {
+                args.parse_error = true;
+                args.error_message = arg + " requires a value";
+                return args;
+            }
+            args.sde_gamma = static_cast<float>(std::atof(argv[++i]));
+            continue;
+        }
         if (arg == "--hf-python") {
             if (i + 1 >= argc) {
                 args.parse_error = true;
@@ -222,6 +277,51 @@ CliArgs parse_args(int argc, const char** argv) {
                 return args;
             }
             args.output_path = argv[++i];
+            continue;
+        }
+        if (arg == "--condition-latents-raw") {
+            if (i + 1 >= argc) {
+                args.parse_error = true;
+                args.error_message = arg + " requires a value";
+                return args;
+            }
+            args.condition_latents_raw = argv[++i];
+            continue;
+        }
+        if (arg == "--initial-latents-raw") {
+            if (i + 1 >= argc) {
+                args.parse_error = true;
+                args.error_message = arg + " requires a value";
+                return args;
+            }
+            args.initial_latents_raw = argv[++i];
+            continue;
+        }
+        if (arg == "--condition-mask-raw") {
+            if (i + 1 >= argc) {
+                args.parse_error = true;
+                args.error_message = arg + " requires a value";
+                return args;
+            }
+            args.condition_mask_raw = argv[++i];
+            continue;
+        }
+        if (arg == "--sampling-steps-raw") {
+            if (i + 1 >= argc) {
+                args.parse_error = true;
+                args.error_message = arg + " requires a value";
+                return args;
+            }
+            args.sampling_steps_raw = argv[++i];
+            continue;
+        }
+        if (arg == "--sde-noise-raw") {
+            if (i + 1 >= argc) {
+                args.parse_error = true;
+                args.error_message = arg + " requires a value";
+                return args;
+            }
+            args.sde_noise_raw = argv[++i];
             continue;
         }
         if (arg == "--threshold" || arg == "--score-threshold") {
@@ -289,8 +389,8 @@ static void test_run_max_tokens() {
 // Mechanism: Calls parse(), checks no parse error and hf_python=="/usr/bin/python3".
 // -----------------------------------------------------------------------------
 static void test_hf_python_flag() {
-    auto args =
-        parse({"trtmc", "run", "bundle.trtfb", "--prompt", "hi", "--hf-python", "/usr/bin/python3"});
+    auto args = parse(
+        {"trtmc", "run", "bundle.trtfb", "--prompt", "hi", "--hf-python", "/usr/bin/python3"});
     check(!args.parse_error, "hf-python no parse error");
     check(args.hf_python == "/usr/bin/python3", "hf-python value");
 }
@@ -373,12 +473,51 @@ static void test_unknown_command_errors() {
 //   and no parse error occurred.
 // -----------------------------------------------------------------------------
 static void test_all_run_flags_combined() {
-    auto args = parse({"trtmc", "run", "bundle.trtfb", "--prompt", "hello", "--max-new-tokens", "10",
-                       "--hf-python", "/usr/bin/python3", "--kv-cache-size", "2GiB"});
+    auto args = parse({"trtmc",
+                       "run",
+                       "bundle.trtfb",
+                       "--prompt",
+                       "hello",
+                       "--max-new-tokens",
+                       "10",
+                       "--num-samples",
+                       "3",
+                       "--num-steps",
+                       "32",
+                       "--guidance-scale",
+                       "3.0",
+                       "--cfg-scale",
+                       "2.0",
+                       "--sde-gamma",
+                       "1.5",
+                       "--initial-latents-raw",
+                       "z.bin",
+                       "--condition-latents-raw",
+                       "cond.bin",
+                       "--condition-mask-raw",
+                       "mask.bin",
+                       "--sampling-steps-raw",
+                       "steps.bin",
+                       "--sde-noise-raw",
+                       "eps.bin",
+                       "--hf-python",
+                       "/usr/bin/python3",
+                       "--kv-cache-size",
+                       "2GiB"});
     check(!args.parse_error, "combined flags no parse error");
     check(args.model_or_bundle == "bundle.trtfb", "combined bundle path");
     check(args.prompt == "hello", "combined prompt");
     check(args.max_new_tokens == 10, "combined max_new_tokens");
+    check(args.num_samples == 3, "combined num_samples");
+    check(args.num_steps == 32, "combined num_steps");
+    check(args.guidance_scale == 3.0F, "combined guidance_scale");
+    check(args.cfg_scale == 2.0F, "combined cfg_scale");
+    check(args.sde_gamma == 1.5F, "combined sde_gamma");
+    check(args.initial_latents_raw == "z.bin", "combined initial_latents_raw");
+    check(args.condition_latents_raw == "cond.bin", "combined condition_latents_raw");
+    check(args.condition_mask_raw == "mask.bin", "combined condition_mask_raw");
+    check(args.sampling_steps_raw == "steps.bin", "combined sampling_steps_raw");
+    check(args.sde_noise_raw == "eps.bin", "combined sde_noise_raw");
     check(args.hf_python == "/usr/bin/python3", "combined hf-python");
     check(args.kv_cache_size_bytes == (2ULL * 1024ULL * 1024ULL * 1024ULL),
           "combined kv-cache-size");

--- a/tests/cpp/test_elf_flow_pipeline.cpp
+++ b/tests/cpp/test_elf_flow_pipeline.cpp
@@ -1,0 +1,611 @@
+// =============================================================================
+// Test suite: ELF flow pipeline generation loop
+// =============================================================================
+//
+// Purpose:
+//   Validates the C++ ELF pipeline's end-to-end generate() path without
+//   requiring a TensorRT SDK. A fake module emulates the GitHub ELF engine
+//   contract: denoise latent embeddings, then decode final embeddings to token
+//   logits.
+//
+// Dependencies:
+//   - runtime/models/elf_flow/pipeline.h
+//   - trtmc/tokenizer.h
+//   - No GPU, TensorRT headers, or model files required.
+// =============================================================================
+
+#include "runtime/models/elf_flow/pipeline.h"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++g_failures;
+    }
+}
+
+bool close_enough(float actual, float expected) {
+    return std::fabs(actual - expected) <= 1e-6F;
+}
+
+float scalar_input(const trtmc::TensorMap& inputs, const std::string& name) {
+    const auto it = inputs.find(name);
+    if (it == inputs.end() || !it->second.data)
+        throw std::runtime_error("missing scalar input: " + name);
+    return *static_cast<float*>(it->second.data);
+}
+
+class FakeTokenizer final : public trtmc::ITokenizer {
+  public:
+    std::vector<int32_t> encode(const std::string& /*text*/) const override { return encoded_ids; }
+
+    std::string decode(const std::vector<int32_t>& ids) const override {
+        std::string out;
+        for (int32_t id : ids)
+            out += token_for_id(id);
+        return out;
+    }
+
+    int32_t id_for_token(std::string_view token) const override {
+        if (token == "</s>")
+            return eos_id;
+        return -1;
+    }
+
+    std::string token_for_id(int32_t id) const override {
+        if (id == 1)
+            return "A";
+        if (id == 2)
+            return "B";
+        if (id == 3)
+            return "C";
+        return "?";
+    }
+
+    int32_t eos_id{-1};
+    std::vector<int32_t> encoded_ids;
+};
+
+class FakeTextEncoderModule final : public trtmc::TrtModule {
+  public:
+    bool ok() const override { return true; }
+
+    std::vector<trtmc::TensorInfo> input_info() const override {
+        return {
+            trtmc::TensorInfo{"input_ids", {1, kMaxLength}, trtmc::DType::kInt32, true},
+            trtmc::TensorInfo{"attention_mask", {1, kMaxLength}, trtmc::DType::kFloat32, true},
+        };
+    }
+
+    std::vector<trtmc::TensorInfo> output_info() const override {
+        return {trtmc::TensorInfo{
+            "text_embeddings", {1, kMaxLength, kTextDim}, trtmc::DType::kFloat32, false}};
+    }
+
+    bool has_input(const std::string& name) const override {
+        return name == "input_ids" || name == "attention_mask";
+    }
+
+    bool has_output(const std::string& name) const override { return name == "text_embeddings"; }
+
+    trtmc::DType tensor_dtype(const std::string& name) const override {
+        if (name == "input_ids")
+            return trtmc::DType::kInt32;
+        return trtmc::DType::kFloat32;
+    }
+
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        if (name == "input_ids" || name == "attention_mask")
+            return {1, kMaxLength};
+        if (name == "text_embeddings")
+            return {1, kMaxLength, kTextDim};
+        return {1};
+    }
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        const auto ids_it = inputs.find("input_ids");
+        const auto mask_it = inputs.find("attention_mask");
+        if (ids_it == inputs.end() || mask_it == inputs.end() || !ids_it->second.data ||
+            !mask_it->second.data) {
+            throw std::runtime_error("missing T5 encoder input");
+        }
+        const auto* ids = static_cast<const int32_t*>(ids_it->second.data);
+        const auto* mask = static_cast<const float*>(mask_it->second.data);
+        saw_prompt_ids = ids[0] == 5 && ids[1] == 1 && ids[2] == 1;
+        saw_prompt_mask = close_enough(mask[0], 0.0F) && mask[1] < -1e8F && mask[2] < -1e8F;
+
+        output_.assign(kMaxLength * kTextDim, 0.0F);
+        output_[0] = 19.0F;
+        output_[1] = 17.0F;
+        trtmc::Tensor tensor;
+        tensor.data = output_.data();
+        tensor.shape = {1, kMaxLength, kTextDim};
+        tensor.dtype = trtmc::DType::kFloat32;
+        return {{"text_embeddings", tensor}};
+    }
+
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap& /*inputs*/) override {
+        return {};
+    }
+    void forward_device_async(const trtmc::DeviceTensorMap& /*inputs*/) override {}
+    void forward_async(const trtmc::TensorMap& /*inputs*/) override {}
+    void sync() override {}
+    cudaStream_t stream() const override { return nullptr; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<int64_t>
+    input_profile_shape(const std::string& name, int32_t /*profile_idx*/,
+                        trtmc::ProfileShapeSelector /*selector*/) const override {
+        return tensor_shape(name);
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string& /*name*/) const override { return nullptr; }
+    void bind_external(const std::string& /*name*/, void* /*ptr*/) override {}
+    void keep_alive(std::shared_ptr<void> resource) override { keep_alive_ = std::move(resource); }
+
+    bool saw_prompt_ids{false};
+    bool saw_prompt_mask{false};
+
+  private:
+    static constexpr int32_t kMaxLength = 3;
+    static constexpr int32_t kTextDim = 2;
+
+    std::vector<float> output_;
+    std::shared_ptr<void> keep_alive_;
+};
+
+class FakeElfModule final : public trtmc::TrtModule {
+  public:
+    bool ok() const override { return true; }
+
+    std::vector<trtmc::TensorInfo> input_info() const override {
+        return {trtmc::TensorInfo{"latent", {kMaxLength, kInputDim}, trtmc::DType::kFloat32, true},
+                trtmc::TensorInfo{"timestep", {1}, trtmc::DType::kFloat32, true},
+                trtmc::TensorInfo{"decoder_mode", {1}, trtmc::DType::kFloat32, true},
+                trtmc::TensorInfo{"self_cond_cfg_scale", {1}, trtmc::DType::kFloat32, true}};
+    }
+
+    std::vector<trtmc::TensorInfo> output_info() const override {
+        return {
+            trtmc::TensorInfo{"denoised", {kMaxLength, kTextDim}, trtmc::DType::kFloat32, false},
+            trtmc::TensorInfo{
+                "decoder_logits", {kMaxLength, kVocabSize}, trtmc::DType::kFloat32, false}};
+    }
+
+    bool has_input(const std::string& name) const override {
+        return name == "latent" || name == "timestep" || name == "decoder_mode" ||
+               name == "self_cond_cfg_scale";
+    }
+
+    bool has_output(const std::string& name) const override {
+        return name == "denoised" || name == "decoder_logits";
+    }
+
+    trtmc::DType tensor_dtype(const std::string& /*name*/) const override {
+        return trtmc::DType::kFloat32;
+    }
+
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        if (name == "latent")
+            return {kMaxLength, kInputDim};
+        if (name == "denoised")
+            return {kMaxLength, kTextDim};
+        if (name == "decoder_logits")
+            return {kMaxLength, kVocabSize};
+        return {1};
+    }
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        const float decoder_mode = scalar_input(inputs, "decoder_mode");
+        const float self_cond_cfg = scalar_input(inputs, "self_cond_cfg_scale");
+        const auto latent_it = inputs.find("latent");
+        if (latent_it == inputs.end() || !latent_it->second.data)
+            throw std::runtime_error("missing latent input");
+        const auto* latent = static_cast<const float*>(latent_it->second.data);
+
+        if (decoder_mode < 0.5F)
+            return forward_denoise(inputs, latent, self_cond_cfg);
+        return forward_decode(inputs, latent, self_cond_cfg);
+    }
+
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap& /*inputs*/) override {
+        return {};
+    }
+    void forward_device_async(const trtmc::DeviceTensorMap& /*inputs*/) override {}
+    void forward_async(const trtmc::TensorMap& /*inputs*/) override {}
+    void sync() override {}
+    cudaStream_t stream() const override { return nullptr; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<int64_t>
+    input_profile_shape(const std::string& name, int32_t /*profile_idx*/,
+                        trtmc::ProfileShapeSelector /*selector*/) const override {
+        return tensor_shape(name);
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string& /*name*/) const override { return nullptr; }
+    void bind_external(const std::string& /*name*/, void* /*ptr*/) override {}
+    void keep_alive(std::shared_ptr<void> resource) override { keep_alive_ = std::move(resource); }
+
+    bool saw_denoise_call{false};
+    bool saw_decode_call{false};
+    bool decode_received_final_latent{false};
+    bool expect_condition{false};
+    bool require_zero_denoise_timestep{true};
+    bool check_first_cond_uses_initial_latent{false};
+    bool saw_cond_cfg_call{false};
+    bool saw_uncond_cfg_call{false};
+    bool saw_first_cond_initial_latent{false};
+    bool check_first_denoise_latent{false};
+    float expected_self_cond_cfg{1.0F};
+    int32_t denoise_calls{0};
+    std::vector<float> expected_initial_latent;
+    std::vector<float> expected_first_denoise_latent;
+    std::vector<float> denoise_timesteps;
+
+  private:
+    trtmc::TensorMap forward_denoise(const trtmc::TensorMap& inputs, const float* latent,
+                                     float self_cond_cfg) {
+        saw_denoise_call = true;
+        ++denoise_calls;
+        denoise_timesteps.push_back(scalar_input(inputs, "timestep"));
+        if (require_zero_denoise_timestep) {
+            check(close_enough(scalar_input(inputs, "timestep"), 0.0F),
+                  "denoise call uses first upstream ODE timestep");
+        }
+        check(close_enough(self_cond_cfg, expected_self_cond_cfg),
+              "denoise call forwards self-cond CFG scale");
+
+        if (expect_condition) {
+            const bool cond_call = close_enough(latent[0], 9.0F) && close_enough(latent[1], 8.0F) &&
+                                   close_enough(latent[2], 9.0F) && close_enough(latent[3], 8.0F);
+            const bool uncond_call = close_enough(latent[0], 0.0F) &&
+                                     close_enough(latent[1], 0.0F) &&
+                                     close_enough(latent[2], 0.0F) && close_enough(latent[3], 0.0F);
+            saw_cond_cfg_call = saw_cond_cfg_call || cond_call;
+            saw_uncond_cfg_call = saw_uncond_cfg_call || uncond_call;
+            check(cond_call || uncond_call,
+                  "conditional denoise receives either cond or zeroed CFG prefix");
+            if (cond_call && check_first_cond_uses_initial_latent &&
+                !saw_first_cond_initial_latent) {
+                bool matches_initial = expected_initial_latent.size() == kMaxLength * kTextDim;
+                for (int32_t row = 1; row < kMaxLength && matches_initial; ++row) {
+                    for (int32_t col = 0; col < kTextDim; ++col) {
+                        const auto latent_idx = row * kInputDim + col;
+                        const auto expected_idx = row * kTextDim + col;
+                        matches_initial =
+                            matches_initial &&
+                            close_enough(latent[latent_idx], expected_initial_latent[expected_idx]);
+                    }
+                }
+                saw_first_cond_initial_latent = matches_initial;
+                check(matches_initial,
+                      "conditional default sampling starts with ODE latent, not SDE backstep");
+            }
+        }
+        if (check_first_denoise_latent && denoise_calls == 1) {
+            bool matches = expected_first_denoise_latent.size() == kMaxLength * kTextDim;
+            for (int32_t row = 0; row < kMaxLength && matches; ++row) {
+                for (int32_t col = 0; col < kTextDim; ++col) {
+                    matches = matches &&
+                              close_enough(latent[row * kInputDim + col],
+                                           expected_first_denoise_latent[row * kTextDim + col]);
+                }
+            }
+            check(matches, "raw SDE noise controls first denoise latent");
+        }
+
+        output_.resize(kMaxLength * kTextDim);
+        last_denoised_.resize(kMaxLength * kTextDim);
+        for (int32_t row = 0; row < kMaxLength; ++row) {
+            for (int32_t col = 0; col < kTextDim; ++col) {
+                const float value = latent[row * kInputDim + col] + 0.25F;
+                output_[row * kTextDim + col] = value;
+                last_denoised_[row * kTextDim + col] = value;
+            }
+            for (int32_t col = kTextDim; col < kInputDim; ++col) {
+                const int32_t first_step_calls = expect_condition ? 2 : 1;
+                if (denoise_calls <= first_step_calls && (!expect_condition || row != 0)) {
+                    check(close_enough(latent[row * kInputDim + col], 0.0F),
+                          "first denoise call receives zero self-conditioning");
+                }
+            }
+        }
+
+        trtmc::Tensor tensor;
+        tensor.data = output_.data();
+        tensor.shape = {kMaxLength, kTextDim};
+        tensor.dtype = trtmc::DType::kFloat32;
+        return {{"denoised", tensor}};
+    }
+
+    trtmc::TensorMap forward_decode(const trtmc::TensorMap& inputs, const float* latent,
+                                    float self_cond_cfg) {
+        saw_decode_call = true;
+        check(close_enough(scalar_input(inputs, "timestep"), 1.0F),
+              "decode call uses upstream final decoder timestep");
+        check(close_enough(self_cond_cfg, 1.0F), "decode call forwards self-cond CFG scale");
+
+        decode_received_final_latent = true;
+        for (int32_t row = 0; row < kMaxLength; ++row) {
+            for (int32_t col = 0; col < kTextDim; ++col) {
+                float expected = last_denoised_[row * kTextDim + col];
+                if (expect_condition && row == 0)
+                    expected = col == 0 ? 9.0F : 8.0F;
+                decode_received_final_latent &=
+                    close_enough(latent[row * kInputDim + col], expected);
+            }
+            for (int32_t col = kTextDim; col < kInputDim; ++col) {
+                decode_received_final_latent &= close_enough(latent[row * kInputDim + col], 0.0F);
+            }
+        }
+
+        output_.assign(kMaxLength * kVocabSize, -100.0F);
+        for (int32_t row = 0; row < kMaxLength; ++row)
+            output_[row * kVocabSize + row + 1] = 100.0F;
+
+        trtmc::Tensor tensor;
+        tensor.data = output_.data();
+        tensor.shape = {kMaxLength, kVocabSize};
+        tensor.dtype = trtmc::DType::kFloat32;
+        return {{"decoder_logits", tensor}};
+    }
+
+    static constexpr int32_t kMaxLength = 3;
+    static constexpr int32_t kTextDim = 2;
+    static constexpr int32_t kInputDim = 4;
+    static constexpr int32_t kVocabSize = 4;
+
+    std::vector<float> output_;
+    std::vector<float> last_denoised_;
+    std::shared_ptr<void> keep_alive_;
+};
+
+void test_generate_runs_upstream_shape_contract() {
+    auto module = std::make_unique<FakeElfModule>();
+    auto* module_ptr = module.get();
+    auto tokenizer = std::make_shared<FakeTokenizer>();
+    trtmc::ElfFlowPipeline pipeline(std::move(module), 3, 0, 4, 2, 4, 2.0F, -1.5F, 0.8F, 0.05F,
+                                    tokenizer, "fake-elf");
+
+    trtmc::GenerateConfig cfg;
+    cfg.num_steps = 1;
+    cfg.guidance_scale = 1.0F;
+    cfg.sde_gamma = 0.0F;
+    cfg.initial_latents = {0.1F, 0.2F, 0.3F, 0.4F, 0.5F, 0.6F};
+
+    const auto result = pipeline.generate("", cfg);
+    check(result.text == "ABC", "ELF generate decodes argmax tokens to text");
+    check((result.token_ids == std::vector<int32_t>{1, 2, 3}),
+          "ELF generate returns decoded token ids");
+    check(module_ptr->saw_denoise_call, "ELF generate runs denoiser");
+    check(module_ptr->saw_decode_call, "ELF generate runs final decoder head");
+    check(module_ptr->decode_received_final_latent,
+          "ELF final decoder receives denoised latent and zero self-conditioning");
+}
+
+void test_conditional_generate_restores_prefix_and_strips_decoded_condition() {
+    auto module = std::make_unique<FakeElfModule>();
+    module->expect_condition = true;
+    auto* module_ptr = module.get();
+    auto tokenizer = std::make_shared<FakeTokenizer>();
+    trtmc::ElfFlowPipeline pipeline(std::move(module), 3, 0, 4, 2, 4, 2.0F, -1.5F, 0.8F, 0.05F,
+                                    tokenizer, "fake-elf");
+
+    trtmc::GenerateConfig cfg;
+    cfg.num_steps = 1;
+    cfg.guidance_scale = 1.0F;
+    cfg.cfg_scale = 2.0F;
+    cfg.sde_gamma = 0.0F;
+    cfg.initial_latents = {0.1F, 0.2F, 0.3F, 0.4F, 0.5F, 0.6F};
+    cfg.condition_latents = {9.0F, 8.0F, 0.0F, 0.0F, 0.0F, 0.0F};
+    cfg.condition_mask = {1.0F, 0.0F, 0.0F};
+
+    const auto result = pipeline.generate("", cfg);
+    check(result.text == "BC", "conditional ELF strips decoded condition prefix");
+    check((result.token_ids == std::vector<int32_t>{2, 3}),
+          "conditional ELF returns only generated token ids");
+    check(module_ptr->denoise_calls == 2, "conditional CFG runs cond and uncond denoise passes");
+    check(module_ptr->saw_cond_cfg_call, "conditional CFG pass receives condition latents");
+    check(module_ptr->saw_uncond_cfg_call, "unconditional CFG pass zeroes condition latents");
+    check(module_ptr->decode_received_final_latent,
+          "conditional final decoder receives restored condition prefix");
+}
+
+void test_conditional_defaults_match_upstream_sampling_config() {
+    auto module = std::make_unique<FakeElfModule>();
+    module->expect_condition = true;
+    module->require_zero_denoise_timestep = false;
+    module->check_first_cond_uses_initial_latent = true;
+    auto* module_ptr = module.get();
+    auto tokenizer = std::make_shared<FakeTokenizer>();
+    trtmc::ElfFlowPipeline pipeline(std::move(module), 3, 1, 4, 2, 4, 2.0F, -1.5F, 0.8F, 0.05F,
+                                    tokenizer, "fake-elf");
+
+    trtmc::GenerateConfig cfg;
+    cfg.initial_latents = {0.1F, 0.2F, 0.3F, 0.4F, 0.5F, 0.6F};
+    cfg.condition_latents = {9.0F, 8.0F, 0.0F, 0.0F, 0.0F, 0.0F};
+    cfg.condition_mask = {1.0F, 0.0F, 0.0F};
+    module_ptr->expected_initial_latent = cfg.initial_latents;
+
+    const auto result = pipeline.generate("", cfg);
+    check(result.text == "BC", "conditional default ELF strips decoded condition prefix");
+    check(module_ptr->denoise_calls == 128,
+          "conditional ELF defaults to upstream 64 ODE steps with CFG scale 2");
+    check(module_ptr->saw_cond_cfg_call, "conditional default CFG receives condition latents");
+    check(module_ptr->saw_uncond_cfg_call, "conditional default CFG zeroes condition latents");
+    check(module_ptr->saw_first_cond_initial_latent,
+          "conditional default uses upstream ODE sampler with no SDE churn");
+}
+
+void test_eos_is_stripped_before_returning_token_ids() {
+    auto module = std::make_unique<FakeElfModule>();
+    auto tokenizer = std::make_shared<FakeTokenizer>();
+    tokenizer->eos_id = 2;
+    trtmc::ElfFlowPipeline pipeline(std::move(module), 3, 0, 4, 2, 4, 2.0F, -1.5F, 0.8F, 0.05F,
+                                    tokenizer, "fake-elf");
+
+    trtmc::GenerateConfig cfg;
+    cfg.num_steps = 1;
+    cfg.guidance_scale = 1.0F;
+    cfg.sde_gamma = 0.0F;
+    cfg.initial_latents = {0.1F, 0.2F, 0.3F, 0.4F, 0.5F, 0.6F};
+
+    const auto result = pipeline.generate("", cfg);
+    check(result.text == "A", "ELF decode stops before EOS text");
+    check((result.token_ids == std::vector<int32_t>{1}),
+          "ELF decode stops before returning EOS token id");
+}
+
+void test_raw_sampling_steps_and_sde_noise_replay_upstream_inputs() {
+    auto module = std::make_unique<FakeElfModule>();
+    module->require_zero_denoise_timestep = false;
+    module->check_first_denoise_latent = true;
+    module->expected_first_denoise_latent = {1.05F, 1.10F, 1.15F, 1.20F, 1.25F, 1.30F};
+    auto* module_ptr = module.get();
+    auto tokenizer = std::make_shared<FakeTokenizer>();
+    trtmc::ElfFlowPipeline pipeline(std::move(module), 3, 0, 4, 2, 4, 2.0F, -1.5F, 0.8F, 0.05F,
+                                    tokenizer, "fake-elf");
+
+    trtmc::GenerateConfig cfg;
+    cfg.guidance_scale = 1.0F;
+    cfg.sde_gamma = 1.0F;
+    cfg.initial_latents = {0.1F, 0.2F, 0.3F, 0.4F, 0.5F, 0.6F};
+    cfg.sampling_steps = {0.0F, 0.5F, 1.0F};
+    cfg.sde_noises = {2.0F, 2.0F, 2.0F, 2.0F, 2.0F, 2.0F};
+
+    const auto result = pipeline.generate("", cfg);
+    check(result.text == "ABC", "raw replay still decodes text");
+    check(module_ptr->denoise_timesteps.size() == 2, "raw replay runs one SDE and final ODE step");
+    check(close_enough(module_ptr->denoise_timesteps[0], 0.0F),
+          "raw replay first timestep uses supplied start");
+    check(close_enough(module_ptr->denoise_timesteps[1], 0.5F),
+          "raw replay final ODE uses supplied penultimate timestep");
+}
+
+void test_prompt_condition_uses_bundled_t5_encoder() {
+    auto module = std::make_unique<FakeElfModule>();
+    module->expect_condition = true;
+    auto* module_ptr = module.get();
+    auto text_encoder = std::make_unique<FakeTextEncoderModule>();
+    auto* text_encoder_ptr = text_encoder.get();
+    auto tokenizer = std::make_shared<FakeTokenizer>();
+    tokenizer->eos_id = 1;
+    tokenizer->encoded_ids = {1, 5, 1};
+    trtmc::ElfFlowPipeline pipeline(std::move(module), 3, 1, 4, 2, 4, 2.0F, -1.5F, 0.8F, 0.05F,
+                                    tokenizer, "fake-elf", std::move(text_encoder), 1.0F, 2.0F, 1);
+
+    trtmc::GenerateConfig cfg;
+    cfg.num_steps = 1;
+    cfg.guidance_scale = 1.0F;
+    cfg.cfg_scale = 2.0F;
+    cfg.sde_gamma = 0.0F;
+    cfg.initial_latents = {0.1F, 0.2F, 0.3F, 0.4F, 0.5F, 0.6F};
+
+    const auto result = pipeline.generate("Quelle", cfg);
+    check(result.text == "BC", "prompt-conditioned ELF strips source-token prefix");
+    check(text_encoder_ptr->saw_prompt_ids,
+          "prompt-conditioned ELF strips tokenizer-added EOS before T5 encoding");
+    check(text_encoder_ptr->saw_prompt_mask,
+          "prompt-conditioned ELF builds additive T5 attention mask");
+    check(module_ptr->saw_cond_cfg_call,
+          "prompt-conditioned ELF normalizes T5 embeddings into condition latents");
+    check(module_ptr->saw_uncond_cfg_call,
+          "prompt-conditioned ELF still runs upstream conditional CFG");
+}
+
+void test_prompt_condition_requires_bundled_t5_encoder() {
+    auto module = std::make_unique<FakeElfModule>();
+    auto tokenizer = std::make_shared<FakeTokenizer>();
+    tokenizer->encoded_ids = {5};
+    trtmc::ElfFlowPipeline pipeline(std::move(module), 3, 1, 4, 2, 4, 2.0F, -1.5F, 0.8F, 0.05F,
+                                    tokenizer, "fake-elf");
+
+    trtmc::GenerateConfig cfg;
+    cfg.num_steps = 1;
+    cfg.guidance_scale = 1.0F;
+    cfg.sde_gamma = 0.0F;
+    cfg.initial_latents = {0.1F, 0.2F, 0.3F, 0.4F, 0.5F, 0.6F};
+
+    bool threw = false;
+    try {
+        (void)pipeline.generate("Quelle", cfg);
+    } catch (const std::runtime_error& e) {
+        threw = std::string(e.what()).find("elf_text_encoder_plan") != std::string::npos;
+    }
+    check(threw, "ELF rejects text prompt when the bundle has no T5 encoder");
+}
+
+void test_condition_api_requires_latents_and_mask() {
+    {
+        auto module = std::make_unique<FakeElfModule>();
+        auto tokenizer = std::make_shared<FakeTokenizer>();
+        trtmc::ElfFlowPipeline pipeline(std::move(module), 3, 0, 4, 2, 4, 2.0F, -1.5F, 0.8F, 0.05F,
+                                        tokenizer, "fake-elf");
+
+        trtmc::GenerateConfig cfg;
+        cfg.num_steps = 1;
+        cfg.guidance_scale = 1.0F;
+        cfg.sde_gamma = 0.0F;
+        cfg.initial_latents = {0.1F, 0.2F, 0.3F, 0.4F, 0.5F, 0.6F};
+        cfg.condition_latents = {9.0F, 8.0F, 0.0F, 0.0F, 0.0F, 0.0F};
+
+        bool threw = false;
+        try {
+            (void)pipeline.generate("ignored", cfg);
+        } catch (const std::runtime_error& e) {
+            threw = std::string(e.what()).find("condition_latents") != std::string::npos;
+        }
+        check(threw, "ELF rejects condition latents without condition mask");
+    }
+    {
+        auto module = std::make_unique<FakeElfModule>();
+        auto tokenizer = std::make_shared<FakeTokenizer>();
+        trtmc::ElfFlowPipeline pipeline(std::move(module), 3, 0, 4, 2, 4, 2.0F, -1.5F, 0.8F, 0.05F,
+                                        tokenizer, "fake-elf");
+
+        trtmc::GenerateConfig cfg;
+        cfg.num_steps = 1;
+        cfg.guidance_scale = 1.0F;
+        cfg.sde_gamma = 0.0F;
+        cfg.initial_latents = {0.1F, 0.2F, 0.3F, 0.4F, 0.5F, 0.6F};
+        cfg.condition_mask = {1.0F, 0.0F, 0.0F};
+
+        bool threw = false;
+        try {
+            (void)pipeline.generate("ignored", cfg);
+        } catch (const std::runtime_error& e) {
+            threw = std::string(e.what()).find("condition_mask") != std::string::npos;
+        }
+        check(threw, "ELF rejects condition mask without condition latents");
+    }
+}
+
+} // namespace
+
+int main() {
+    test_generate_runs_upstream_shape_contract();
+    test_conditional_generate_restores_prefix_and_strips_decoded_condition();
+    test_conditional_defaults_match_upstream_sampling_config();
+    test_eos_is_stripped_before_returning_token_ids();
+    test_raw_sampling_steps_and_sde_noise_replay_upstream_inputs();
+    test_prompt_condition_uses_bundled_t5_encoder();
+    test_prompt_condition_requires_bundled_t5_encoder();
+    test_condition_api_requires_latents_and_mask();
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/e2e/models/elf-b-de-en-l0.json
+++ b/tests/e2e/models/elf-b-de-en-l0.json
@@ -1,0 +1,62 @@
+{
+  "name": "elf-b-de-en-l0",
+  "trace_id": "IT-E2E-ELFB-DEEN-L0-01",
+  "model_id": "github.com/lillian039/ELF:ELF-B-de-en",
+  "bundle": "elf-b-de-en-l0.trtfb",
+  "family": "elf_flow",
+  "runtime_strategy": "elf_flow",
+  "reference_backend": "invariant_only",
+  "oracle_level": "L4_invariants",
+  "reference_family": "elf_conditional_text",
+  "user_contract": "diffusion_text_generation",
+  "ci_tier": "contract_only",
+  "precision": "fp32",
+  "skip": "Contract-only in CI because GitHub ELF checkpoint artifacts are not bundled; local trtmc run supports prompt-conditioned sampling when the bundle includes the official JAX T5 encoder plan, or raw replay when condition latents and mask are supplied.",
+  "inputs": {
+    "generation_mode": "conditional",
+    "task": "wmt14_de_en_translation",
+    "source_text": "Ein kurzer deutscher Satz.",
+    "condition_api": "prompt-conditioned runs may pass --prompt/--source_text when the bundle includes elf_text_encoder_plan; replay runs may instead provide condition_latents_raw/condition_latents_path and condition_mask_raw/condition_mask_path",
+    "expected_output_kind": "English translation",
+    "sampling_method": "ode",
+    "num_sampling_steps": 64,
+    "cfg_scale": 2.0,
+    "self_cond_cfg_scale": 1.0,
+    "output_schema": "jsonl lines with id, generated, and token_ids"
+  },
+  "threshold_overrides": {
+    "contract_min_samples": 1
+  },
+  "stages": [
+    {
+      "name": "condition_encode",
+      "required": true,
+      "artifact_type": "embedding",
+      "comparison_mode": "invariant_check"
+    },
+    {
+      "name": "flow_sampling",
+      "required": true,
+      "artifact_type": "embedding",
+      "comparison_mode": "invariant_check"
+    },
+    {
+      "name": "final_decode",
+      "required": true,
+      "artifact_type": "logits",
+      "comparison_mode": "numeric_tensor"
+    },
+    {
+      "name": "decoded_text",
+      "required": true,
+      "artifact_type": "text_samples",
+      "comparison_mode": "text_quality_metrics"
+    }
+  ],
+  "metadata": {
+    "github_reference": "https://github.com/lillian039/ELF",
+    "upstream_entrypoint": "src/eval.py --config configs/training_configs/train_de-en_ELF-B.yml",
+    "expected_report": "Conditional ELF evaluation reports generated translations and BLEU/ROUGE-style task metrics when online evaluation is enabled.",
+    "notes": "Represents the user-visible ELF conditional translation contract: encode the source prompt with the bundled official JAX T5 encoder plan or accept precomputed source-condition latents through the raw API path, generate English target embeddings with the ELF flow, decode final logits, and emit generated translation text with token_ids."
+  }
+}

--- a/tests/e2e/models/elf-b-owt-l0.json
+++ b/tests/e2e/models/elf-b-owt-l0.json
@@ -1,0 +1,56 @@
+{
+  "name": "elf-b-owt-l0",
+  "trace_id": "IT-E2E-ELFB-OWT-L0-01",
+  "model_id": "github.com/lillian039/ELF:ELF-B-owt",
+  "bundle": "elf-b-owt-l0.trtfb",
+  "family": "elf_flow",
+  "runtime_strategy": "elf_flow",
+  "reference_backend": "invariant_only",
+  "oracle_level": "L4_invariants",
+  "reference_family": "elf_unconditional_text",
+  "user_contract": "diffusion_text_generation",
+  "ci_tier": "contract_only",
+  "precision": "fp32",
+  "skip": "Contract-only in CI because GitHub ELF checkpoint artifacts are not bundled; local trtmc run supports API-path sampling and tokenizer decode when the ELF bundle contains engine_plan and tokenizer.json.",
+  "inputs": {
+    "generation_mode": "unconditional",
+    "dataset_contract": "OpenWebText-style unconditional samples",
+    "num_samples": 1000,
+    "sampling_method": "sde",
+    "num_sampling_steps": 32,
+    "self_cond_cfg_scale": 3.0,
+    "output_schema": "jsonl lines with id, generated, and token_ids"
+  },
+  "threshold_overrides": {
+    "contract_min_samples": 1,
+    "contract_expected_samples": 1000,
+    "contract_max_gen_ppl": 24.5,
+    "contract_min_unigram_entropy": 5.0
+  },
+  "stages": [
+    {
+      "name": "flow_sampling",
+      "required": true,
+      "artifact_type": "embedding",
+      "comparison_mode": "invariant_check"
+    },
+    {
+      "name": "final_decode",
+      "required": true,
+      "artifact_type": "logits",
+      "comparison_mode": "numeric_tensor"
+    },
+    {
+      "name": "decoded_text",
+      "required": true,
+      "artifact_type": "text_samples",
+      "comparison_mode": "text_quality_metrics"
+    }
+  ],
+  "metadata": {
+    "github_reference": "https://github.com/lillian039/ELF",
+    "upstream_entrypoint": "src/eval.py --config configs/training_configs/train_owt_ELF-B.yml",
+    "expected_report": "Gen. PPL around 24 and unigram entropy around 5.15 for ELF-B at 32 SDE steps.",
+    "notes": "Represents the user-visible ELF unconditional contract: generate fixed-length samples from Gaussian embedding noise, decode final logits to token ids, and write JSONL records containing id, generated text, and token_ids."
+  }
+}

--- a/tests/e2e/models/elf-b-xsum-l0.json
+++ b/tests/e2e/models/elf-b-xsum-l0.json
@@ -1,0 +1,62 @@
+{
+  "name": "elf-b-xsum-l0",
+  "trace_id": "IT-E2E-ELFB-XSUM-L0-01",
+  "model_id": "github.com/lillian039/ELF:ELF-B-xsum",
+  "bundle": "elf-b-xsum-l0.trtfb",
+  "family": "elf_flow",
+  "runtime_strategy": "elf_flow",
+  "reference_backend": "invariant_only",
+  "oracle_level": "L4_invariants",
+  "reference_family": "elf_conditional_text",
+  "user_contract": "diffusion_text_generation",
+  "ci_tier": "contract_only",
+  "precision": "fp32",
+  "skip": "Contract-only in CI because GitHub ELF checkpoint artifacts are not bundled; local trtmc run supports prompt-conditioned sampling when the bundle includes the official JAX T5 encoder plan, or raw replay when condition latents and mask are supplied.",
+  "inputs": {
+    "generation_mode": "conditional",
+    "task": "xsum_summarization",
+    "source_text": "A short news article to summarize.",
+    "condition_api": "prompt-conditioned runs may pass --prompt/--source_text when the bundle includes elf_text_encoder_plan; replay runs may instead provide condition_latents_raw/condition_latents_path and condition_mask_raw/condition_mask_path",
+    "expected_output_kind": "abstractive summary",
+    "sampling_method": "ode",
+    "num_sampling_steps": 64,
+    "cfg_scale": 2.0,
+    "self_cond_cfg_scale": 1.0,
+    "output_schema": "jsonl lines with id, generated, and token_ids"
+  },
+  "threshold_overrides": {
+    "contract_min_samples": 1
+  },
+  "stages": [
+    {
+      "name": "condition_encode",
+      "required": true,
+      "artifact_type": "embedding",
+      "comparison_mode": "invariant_check"
+    },
+    {
+      "name": "flow_sampling",
+      "required": true,
+      "artifact_type": "embedding",
+      "comparison_mode": "invariant_check"
+    },
+    {
+      "name": "final_decode",
+      "required": true,
+      "artifact_type": "logits",
+      "comparison_mode": "numeric_tensor"
+    },
+    {
+      "name": "decoded_text",
+      "required": true,
+      "artifact_type": "text_samples",
+      "comparison_mode": "text_quality_metrics"
+    }
+  ],
+  "metadata": {
+    "github_reference": "https://github.com/lillian039/ELF",
+    "upstream_entrypoint": "src/eval.py --config configs/training_configs/train_xsum_ELF-B.yml",
+    "expected_report": "Conditional ELF evaluation reports generated summaries and ROUGE/BLEU-style task metrics when online evaluation is enabled.",
+    "notes": "Represents the user-visible ELF conditional summarization contract: encode the source prompt with the bundled official JAX T5 encoder plan or accept precomputed source-condition latents through the raw API path, generate target embeddings with the ELF flow, decode final logits, and emit generated summary text with token_ids."
+  }
+}

--- a/tests/e2e_harness/comparators/diffusion_text_generation.py
+++ b/tests/e2e_harness/comparators/diffusion_text_generation.py
@@ -1,0 +1,58 @@
+"""Comparator for diffusion text generation outputs.
+
+Most ELF checks are handled by the contract plugin, but this lightweight
+comparator keeps the task strategy covered when no external reference is used.
+"""
+
+from __future__ import annotations
+
+from ..contracts import (
+    CompareResult,
+    MetricResult,
+    StageOutput,
+    StageSpec,
+    StageStatus,
+    ThresholdProfile,
+)
+
+
+class DiffusionTextGenerationComparator:
+    @property
+    def task_strategy(self) -> str:
+        return "diffusion_text_generation"
+
+    def compare(
+        self,
+        trt: StageOutput,
+        ref: StageOutput,
+        threshold: ThresholdProfile,
+        stage: StageSpec,
+    ) -> CompareResult:
+        del ref, threshold
+        if stage.name not in {"decoded_text", "end_to_end", "full_generation"}:
+            return CompareResult(
+                stage_name=stage.name,
+                status=StageStatus.PASSED.value,
+                metrics={"stage_ok": MetricResult(1.0, 1.0, "==", True)},
+                message=f"{stage.name} invariant stage",
+            )
+        samples = trt.data.get("generated_samples", []) if trt.data else []
+        non_empty = 0
+        if isinstance(samples, list):
+            for sample in samples:
+                if isinstance(sample, dict) and str(sample.get("generated", "")).strip():
+                    non_empty += 1
+        passed = non_empty > 0
+        return CompareResult(
+            stage_name=stage.name,
+            status=StageStatus.PASSED.value if passed else StageStatus.FAILED.value,
+            metrics={
+                "non_empty_generated_text": MetricResult(
+                    float(non_empty), 1.0, ">=", passed
+                )
+            },
+            message="diffusion text generation produced text" if passed else "no generated text",
+        )
+
+
+plugin = DiffusionTextGenerationComparator()

--- a/tests/e2e_harness/contracts.py
+++ b/tests/e2e_harness/contracts.py
@@ -118,6 +118,8 @@ class ReferenceFamily(enum.Enum):
     # --- Diffusion ---
     DIFFUSERS_IMAGE_GEN = "diffusers_image_gen"
     DIFFUSERS_VIDEO_GEN = "diffusers_video_gen"
+    ELF_UNCONDITIONAL_TEXT = "elf_unconditional_text"
+    ELF_CONDITIONAL_TEXT = "elf_conditional_text"
 
     # --- Time series ---
     TIME_SERIES_POINT_FORECAST = "time_series_point_forecast"
@@ -143,6 +145,7 @@ class ArtifactType(enum.Enum):
     WAVEFORM = "waveform"
     IMAGE = "image"
     VIDEO_FRAMES = "video_frames"
+    TEXT_SAMPLES = "text_samples"
     LOGITS = "logits"
     SCORE = "score"
     RANKING = "ranking"
@@ -167,6 +170,7 @@ class ComparisonMode(enum.Enum):
     DETECTION_MATCH = "detection_match"
     MEDIA_SIMILARITY = "media_similarity"
     SEMANTIC_JUDGMENT = "semantic_judgment"
+    TEXT_QUALITY_METRICS = "text_quality_metrics"
     INVARIANT_CHECK = "invariant_check"
 
 
@@ -207,6 +211,7 @@ class UserContract(enum.Enum):
     OCR_TEXT = "ocr_text"
     DIFFUSION_IMAGE = "diffusion_image"
     DIFFUSION_VIDEO = "diffusion_video"
+    DIFFUSION_TEXT_GENERATION = "diffusion_text_generation"
 
     # --- Time series ---
     TIME_SERIES_POINT_FORECAST = "time_series_point_forecast"
@@ -795,13 +800,17 @@ MODEL_REFERENCE_FAMILY: Dict[str, str] = {
     "z-image-turbo": ReferenceFamily.DIFFUSERS_IMAGE_GEN.value,
     # 5.26 DIFFUSERS_VIDEO_GEN
     "wan21-t2v-1.3b": ReferenceFamily.DIFFUSERS_VIDEO_GEN.value,
-    # 5.27 TIME_SERIES_POINT_FORECAST
+    # 5.27 ELF diffusion text generation
+    "elf-b-owt-l0": ReferenceFamily.ELF_UNCONDITIONAL_TEXT.value,
+    "elf-b-xsum-l0": ReferenceFamily.ELF_CONDITIONAL_TEXT.value,
+    "elf-b-de-en-l0": ReferenceFamily.ELF_CONDITIONAL_TEXT.value,
+    # 5.28 TIME_SERIES_POINT_FORECAST
     "patchtst-granite-official": ReferenceFamily.TIME_SERIES_POINT_FORECAST.value,
     "patchtsmixer-granite-official": ReferenceFamily.TIME_SERIES_POINT_FORECAST.value,
     "timesfm-2.0-500m-official": ReferenceFamily.TIME_SERIES_POINT_FORECAST.value,
-    # 5.28 TIME_SERIES_QUANTILE_FORECAST
+    # 5.29 TIME_SERIES_QUANTILE_FORECAST
     "chronos-bolt-tiny-official": ReferenceFamily.TIME_SERIES_QUANTILE_FORECAST.value,
-    # 5.29 TIME_SERIES_REGRESSION
+    # 5.30 TIME_SERIES_REGRESSION
     "patchtst-etth1-regression-distribution": ReferenceFamily.TIME_SERIES_REGRESSION.value,
 }
 
@@ -834,6 +843,8 @@ REFERENCE_FAMILY_TO_USER_CONTRACT: Dict[str, str] = {
     ReferenceFamily.PROMPTED_SEGMENTATION_SAM.value: UserContract.PROMPTED_MASK.value,
     ReferenceFamily.DIFFUSERS_IMAGE_GEN.value: UserContract.DIFFUSION_IMAGE.value,
     ReferenceFamily.DIFFUSERS_VIDEO_GEN.value: UserContract.DIFFUSION_VIDEO.value,
+    ReferenceFamily.ELF_UNCONDITIONAL_TEXT.value: UserContract.DIFFUSION_TEXT_GENERATION.value,
+    ReferenceFamily.ELF_CONDITIONAL_TEXT.value: UserContract.DIFFUSION_TEXT_GENERATION.value,
     ReferenceFamily.TIME_SERIES_POINT_FORECAST.value: UserContract.TIME_SERIES_POINT_FORECAST.value,
     ReferenceFamily.TIME_SERIES_QUANTILE_FORECAST.value: UserContract.TIME_SERIES_QUANTILE_FORECAST.value,
     ReferenceFamily.TIME_SERIES_CLASSIFICATION.value: UserContract.TIME_SERIES_CLASSIFICATION.value,
@@ -869,6 +880,8 @@ REFERENCE_FAMILY_TO_COMPARISON_MODE: Dict[str, str] = {
     ReferenceFamily.PROMPTED_SEGMENTATION_SAM.value: ComparisonMode.MASK_OVERLAP.value,
     ReferenceFamily.DIFFUSERS_IMAGE_GEN.value: ComparisonMode.MEDIA_SIMILARITY.value,
     ReferenceFamily.DIFFUSERS_VIDEO_GEN.value: ComparisonMode.MEDIA_SIMILARITY.value,
+    ReferenceFamily.ELF_UNCONDITIONAL_TEXT.value: ComparisonMode.TEXT_QUALITY_METRICS.value,
+    ReferenceFamily.ELF_CONDITIONAL_TEXT.value: ComparisonMode.TEXT_QUALITY_METRICS.value,
     ReferenceFamily.TIME_SERIES_POINT_FORECAST.value: ComparisonMode.NUMERIC_TENSOR.value,
     ReferenceFamily.TIME_SERIES_QUANTILE_FORECAST.value: ComparisonMode.NUMERIC_TENSOR.value,
     ReferenceFamily.TIME_SERIES_CLASSIFICATION.value: ComparisonMode.NUMERIC_TENSOR.value,
@@ -899,6 +912,7 @@ RUNTIME_TO_TASK_STRATEGY: Dict[str, str] = {
     "patchtsmixer_torchtrt": "neural_operator",
     "timesfm_torchtrt": "neural_operator",
     "chronos_bolt_torchtrt": "neural_operator",
+    "elf_flow": "diffusion_text_generation",
     "diffusion": "diffusion_media_generation",      # legacy alias
     "diffusion_flux": "diffusion_media_generation",
     "diffusion_ltx": "diffusion_media_generation",

--- a/tests/e2e_harness/manifest_loader.py
+++ b/tests/e2e_harness/manifest_loader.py
@@ -54,6 +54,7 @@ _DEFAULT_REFERENCE_BACKEND: dict[str, str] = {
     "prompted_segmentation": "hf_transformers",
     "object_detection": "hf_transformers",
     "diffusion_media_generation": "hf_diffusers",
+    "diffusion_text_generation": "invariant_only",
     "torchtrt_diffusion": "torchtrt_diffusers",
     "embedding": "hf_transformers",
     "reranking": "hf_transformers",
@@ -109,6 +110,9 @@ _DEFAULT_STAGES: dict[str, list[dict[str, Any]]] = {
         {"name": "dit_step", "required": False},
         {"name": "vae_decode", "required": False},
         {"name": "end_to_end", "required": True},
+    ],
+    "diffusion_text_generation": [
+        {"name": "decoded_text", "required": True},
     ],
     "embedding": [
         {"name": "full_inference", "required": True},
@@ -532,6 +536,7 @@ _KNOWN_RUNTIME_STRATEGIES = frozenset({
     "patchtsmixer_torchtrt",
     "timesfm_torchtrt",
     "chronos_bolt_torchtrt",
+    "elf_flow",
 })
 
 

--- a/tests/e2e_harness/orchestrator.py
+++ b/tests/e2e_harness/orchestrator.py
@@ -644,7 +644,46 @@ def _build_repro_commands(
         image = (case.inputs.get("image") or case.inputs.get("test_image")
                  or case.inputs.get("image_path"))
         task_strategy = case.task_strategy or ""
-        if task_strategy == "neural_operator":
+        if task_strategy == "diffusion_text_generation":
+            infer_parts = [
+                ctx.binary_path, "run", bundle_path,
+                "--prompt", _shell_quote(
+                    case.inputs.get("prompt")
+                    or case.inputs.get("source_text")
+                    or case.inputs.get("condition_text")
+                    or ""
+                ),
+                "--output", "/tmp/trtmc_elf_samples.jsonl",
+            ]
+            if "max_new_tokens" in case.inputs:
+                infer_parts.extend(["--max-new-tokens", str(case.inputs["max_new_tokens"])])
+            if int(case.inputs.get("num_samples", 1)) > 1:
+                infer_parts.extend(["--num-samples", str(case.inputs["num_samples"])])
+            num_steps = case.inputs.get("num_sampling_steps", case.inputs.get("num_steps"))
+            if num_steps is not None:
+                infer_parts.extend(["--num-steps", str(num_steps)])
+            self_cond = case.inputs.get("self_cond_cfg_scale", case.inputs.get("guidance_scale"))
+            if self_cond is not None:
+                infer_parts.extend(["--guidance-scale", str(self_cond)])
+            if "cfg_scale" in case.inputs:
+                infer_parts.extend(["--cfg-scale", str(case.inputs["cfg_scale"])])
+            if "sde_gamma" in case.inputs:
+                infer_parts.extend(["--sde-gamma", str(case.inputs["sde_gamma"])])
+            if "seed" in case.inputs:
+                infer_parts.extend(["--seed", str(case.inputs["seed"])])
+            condition_latents = (
+                case.inputs.get("condition_latents_raw")
+                or case.inputs.get("condition_latents_path")
+            )
+            condition_mask = (
+                case.inputs.get("condition_mask_raw")
+                or case.inputs.get("condition_mask_path")
+            )
+            if condition_latents:
+                infer_parts.extend(["--condition-latents-raw", str(condition_latents)])
+            if condition_mask:
+                infer_parts.extend(["--condition-mask-raw", str(condition_mask)])
+        elif task_strategy == "neural_operator":
             infer_parts = [ctx.binary_path, "solve", bundle_path]
             branch_input = case.inputs.get("branch_input")
             trunk_input = case.inputs.get("trunk_input")

--- a/tests/e2e_harness/plugins/elf_diffusion_text.py
+++ b/tests/e2e_harness/plugins/elf_diffusion_text.py
@@ -1,0 +1,322 @@
+"""Contract checks for ELF diffusion text generation."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ..contracts import E2ECase, MetricResult, StageOutput, ThresholdProfile
+from .base import make_fail, make_pass, normalize_text
+
+
+def _metric_value(output: StageOutput, *names: str) -> float | None:
+    for name in names:
+        value = output.data.get(name) if output.data else None
+        if value is None:
+            value = output.metadata.get(name) if output.metadata else None
+        if value is None:
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _text_from_sample(sample: Any) -> str:
+    if isinstance(sample, str):
+        return sample
+    if isinstance(sample, dict):
+        for key in ("generated", "generated_text", "text"):
+            value = sample.get(key)
+            if isinstance(value, str):
+                return value
+    return ""
+
+
+def _token_ids_from_sample(sample: Any) -> list[int]:
+    if not isinstance(sample, dict):
+        return []
+    value = sample.get("token_ids")
+    if not isinstance(value, list):
+        return []
+    try:
+        return [int(token) for token in value]
+    except (TypeError, ValueError):
+        return []
+
+
+def _samples_from_jsonl(payload: str) -> list[Any]:
+    samples: list[Any] = []
+    for line in payload.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            samples.append(json.loads(line))
+        except json.JSONDecodeError:
+            samples.append({"generated": line})
+    return samples
+
+
+def _generated_samples(output: StageOutput) -> list[Any]:
+    data = output.data or {}
+    for key in ("generated_samples", "samples", "generated"):
+        value = data.get(key)
+        if isinstance(value, list):
+            return value
+        if isinstance(value, str):
+            return _samples_from_jsonl(value)
+
+    value = data.get("generated_jsonl")
+    if isinstance(value, str):
+        return _samples_from_jsonl(value)
+
+    if output.text:
+        return [{"generated": output.text}]
+    return []
+
+
+def _expected_samples(output: StageOutput) -> list[Any]:
+    data = output.data or {}
+    value = data.get("expected_generated_samples")
+    if isinstance(value, list):
+        return value
+    value = data.get("expected_generated_jsonl")
+    if isinstance(value, str):
+        return _samples_from_jsonl(value)
+    return []
+
+
+def _has_condition_api(case: E2ECase, output: StageOutput) -> bool:
+    resolved = (output.data or {}).get("resolved_inputs", {})
+    inputs = {**(case.inputs or {})}
+    if isinstance(resolved, dict):
+        inputs.update(resolved)
+    if inputs.get("prompt") or inputs.get("source_text") or inputs.get("condition_text"):
+        return True
+    replay_samples = inputs.get("replay_samples")
+    if isinstance(replay_samples, list) and replay_samples:
+        return all(
+            isinstance(sample, dict)
+            and bool(
+                (sample.get("condition_latents_raw") or sample.get("condition_latents_path"))
+                and (sample.get("condition_mask_raw") or sample.get("condition_mask_path"))
+            )
+            for sample in replay_samples
+        )
+    condition_latents = inputs.get("condition_latents_raw") or inputs.get("condition_latents_path")
+    condition_mask = inputs.get("condition_mask_raw") or inputs.get("condition_mask_path")
+    return bool(condition_latents and condition_mask)
+
+
+def _has_condition(case: E2ECase, output: StageOutput) -> bool:
+    if case.reference_family != "elf_conditional_text":
+        return True
+
+    return _has_condition_api(case, output)
+
+
+def _optional_metric(
+    metrics: dict[str, MetricResult],
+    *,
+    name: str,
+    value: float | None,
+    threshold: float | None,
+    operator: str,
+) -> bool:
+    if value is None or threshold is None:
+        return True
+    if operator == "<=":
+        passed = value <= threshold
+    elif operator == ">=":
+        passed = value >= threshold
+    else:
+        raise ValueError(f"Unsupported operator: {operator}")
+    metrics[name] = MetricResult(
+        value=value,
+        threshold=threshold,
+        operator=operator,
+        passed=passed,
+    )
+    return passed
+
+
+class ElfDiffusionTextPlugin:
+    reference_families = ["elf_unconditional_text", "elf_conditional_text"]
+    user_contract = "diffusion_text_generation"
+
+    def configure_reference(self, case: E2ECase) -> dict:
+        return {
+            "implementation": "github_elf",
+            "generation_mode": case.inputs.get("generation_mode", "unconditional"),
+            "output_schema": "jsonl_id_generated_token_ids",
+        }
+
+    def verify(
+        self,
+        trt_output: StageOutput,
+        ref_output: StageOutput,
+        case: E2ECase,
+        threshold: ThresholdProfile,
+    ):
+        del ref_output
+        stage = trt_output.stage_name
+        if stage not in ("full_generation", "decoded_text", "end_to_end"):
+            metrics = {
+                "stage_ok": MetricResult(
+                    value=1.0,
+                    threshold=1.0,
+                    operator="==",
+                    passed=True,
+                    note=f"{stage} completed",
+                )
+            }
+            return make_pass(stage, metrics, f"{stage} invariant check")
+
+        samples = _generated_samples(trt_output)
+        texts = [normalize_text(_text_from_sample(sample)) for sample in samples]
+        expected_samples = _expected_samples(trt_output)
+        expected_texts = [
+            normalize_text(_text_from_sample(sample)) for sample in expected_samples
+        ]
+        generated_token_ids = [_token_ids_from_sample(sample) for sample in samples]
+        expected_token_ids = [
+            _token_ids_from_sample(sample) for sample in expected_samples
+        ]
+        non_empty = sum(1 for text in texts if text)
+        min_samples = int(threshold.metrics.get("contract_min_samples", 1))
+        has_samples = len(samples) >= min_samples
+        non_empty_ok = non_empty == len(samples) and non_empty >= min_samples
+        condition_ok = _has_condition(case, trt_output)
+        expected_sample_count = threshold.metrics.get("contract_expected_samples")
+        expected_sample_count_ok = True
+
+        metrics = {
+            "num_generated_samples": MetricResult(
+                value=float(len(samples)),
+                threshold=float(min_samples),
+                operator=">=",
+                passed=has_samples,
+            ),
+            "non_empty_generated_text": MetricResult(
+                value=float(non_empty),
+                threshold=float(min_samples),
+                operator=">=",
+                passed=non_empty_ok,
+            ),
+            "condition_available": MetricResult(
+                value=1.0 if condition_ok else 0.0,
+                threshold=1.0,
+                operator="==",
+                passed=condition_ok,
+            ),
+        }
+        if expected_sample_count is not None:
+            expected_count = int(expected_sample_count)
+            expected_sample_count_ok = len(samples) == expected_count
+            metrics["expected_generated_sample_count"] = MetricResult(
+                value=float(len(samples)),
+                threshold=float(expected_count),
+                operator="==",
+                passed=expected_sample_count_ok,
+                note="exact sample count required by ELF evaluation contract",
+            )
+
+        max_ppl = threshold.metrics.get("contract_max_gen_ppl")
+        min_entropy = threshold.metrics.get("contract_min_unigram_entropy")
+        min_bleu = threshold.metrics.get("contract_min_bleu")
+        min_rouge_l = threshold.metrics.get("contract_min_rouge_l")
+
+        metric_ok = True
+        metric_ok &= _optional_metric(
+            metrics,
+            name="gen_ppl",
+            value=_metric_value(trt_output, "gen_ppl", "generation_ppl"),
+            threshold=max_ppl,
+            operator="<=",
+        )
+        metric_ok &= _optional_metric(
+            metrics,
+            name="unigram_entropy",
+            value=_metric_value(trt_output, "unigram_entropy", "mean_entropy"),
+            threshold=min_entropy,
+            operator=">=",
+        )
+        metric_ok &= _optional_metric(
+            metrics,
+            name="bleu",
+            value=_metric_value(trt_output, "bleu"),
+            threshold=min_bleu,
+            operator=">=",
+        )
+        metric_ok &= _optional_metric(
+            metrics,
+            name="rouge_l",
+            value=_metric_value(trt_output, "rouge_l", "rougeL"),
+            threshold=min_rouge_l,
+            operator=">=",
+        )
+        if expected_texts:
+            compare_count = min(len(texts), len(expected_texts))
+            matches = sum(
+                1
+                for idx in range(compare_count)
+                if texts[idx] and texts[idx] == expected_texts[idx]
+            )
+            expected_count = len(expected_texts)
+            match_rate = matches / expected_count if expected_count else 0.0
+            threshold_value = threshold.metrics.get(
+                "contract_min_upstream_text_match_rate", 1.0
+            )
+            passed = (
+                len(texts) >= expected_count
+                and match_rate >= threshold_value
+            )
+            metrics["upstream_text_match_rate"] = MetricResult(
+                value=match_rate,
+                threshold=threshold_value,
+                operator=">=",
+                passed=passed,
+                note="exact normalized text match against upstream replay artifact",
+            )
+            metric_ok &= passed
+        expected_token_samples = [
+            token_ids for token_ids in expected_token_ids if token_ids
+        ]
+        if expected_token_samples:
+            compare_count = min(len(generated_token_ids), len(expected_token_ids))
+            matches = sum(
+                1
+                for idx in range(compare_count)
+                if expected_token_ids[idx] and generated_token_ids[idx] == expected_token_ids[idx]
+            )
+            expected_count = len(expected_token_samples)
+            match_rate = matches / expected_count if expected_count else 0.0
+            threshold_value = threshold.metrics.get(
+                "contract_min_upstream_token_match_rate", 1.0
+            )
+            passed = (
+                len(generated_token_ids) >= len(expected_token_ids)
+                and match_rate >= threshold_value
+            )
+            metrics["upstream_token_id_match_rate"] = MetricResult(
+                value=match_rate,
+                threshold=threshold_value,
+                operator=">=",
+                passed=passed,
+                note="exact token-id sequence match against upstream replay artifact",
+            )
+            metric_ok &= passed
+
+        rule = (
+            "num_generated_samples >= contract_min_samples AND "
+            "expected_generated_sample_count_if_configured AND "
+            "non_empty_generated_text AND condition_available AND optional_metrics"
+        )
+        if has_samples and expected_sample_count_ok and non_empty_ok and condition_ok and metric_ok:
+            return make_pass(stage, metrics, rule)
+        return make_fail(stage, metrics, rule, "ELF diffusion text contract failed")
+
+
+plugin = ElfDiffusionTextPlugin()

--- a/tests/e2e_harness/runners/diffusion_text_generation.py
+++ b/tests/e2e_harness/runners/diffusion_text_generation.py
@@ -1,0 +1,463 @@
+"""Diffusion text generation runner for ELF-style non-autoregressive text.
+
+The runtime contract is the C++ ``trtmc run`` path: sample latent text
+embeddings, decode the final ELF logits, and emit JSONL records with ``id``,
+``generated``, and ``token_ids`` fields.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from .. import _case_artifact_dir, save_full_stderr
+from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
+
+logger = logging.getLogger(__name__)
+
+_TEXT_STAGES = {"decoded_text", "end_to_end", "full_generation"}
+_CONDITIONAL_FAMILIES = {"elf_conditional_text"}
+_REPLAY_ARTIFACT_KEYS = ("upstream_replay_artifact", "elf_replay_artifact")
+_REPLAY_FILE_KEYS = (
+    "initial_latents_raw",
+    "initial_latents_path",
+    "condition_latents_raw",
+    "condition_latents_path",
+    "condition_mask_raw",
+    "condition_mask_path",
+    "sampling_steps_raw",
+    "sampling_steps_path",
+    "sde_noise_raw",
+    "sde_noise_path",
+    "expected_generated_jsonl_path",
+    "expected_jsonl_path",
+)
+_TIMING_RE = re.compile(
+    r"^\[trtmc\.timing\]\s+prefill_ms=(?P<prefill_ms>[-+0-9.eE]+)\s+"
+    r"decode_ms=(?P<decode_ms>[-+0-9.eE]+)\s+total_ms=(?P<total_ms>[-+0-9.eE]+)\s*$",
+    re.MULTILINE,
+)
+
+
+def _bundle_path(case: E2ECase, ctx: RunContext) -> str:
+    bundle = case.bundle or f"{case.name}.trtfb"
+    if os.path.isabs(bundle):
+        return bundle
+    return str(Path(ctx.engine_dir) / bundle)
+
+
+def _artifact_path(case: E2ECase, ctx: RunContext, name: str) -> str:
+    base = _case_artifact_dir(ctx.artifacts_dir or "", case.name) if ctx.artifacts_dir else os.getcwd()
+    Path(base).mkdir(parents=True, exist_ok=True)
+    return str(Path(base) / name)
+
+
+def _as_path(value: Any) -> str:
+    return str(value) if isinstance(value, (str, os.PathLike)) and str(value) else ""
+
+
+def _resolve_relative_path(base: Path, value: Any) -> str:
+    path_text = _as_path(value)
+    if not path_text:
+        return ""
+    path = Path(path_text)
+    if not path.is_absolute():
+        path = base.parent / path
+    return str(path)
+
+
+def _load_replay_artifact(inputs: dict[str, Any]) -> dict[str, Any]:
+    replay_path = ""
+    for key in _REPLAY_ARTIFACT_KEYS:
+        replay_path = _as_path(inputs.get(key))
+        if replay_path:
+            break
+    if not replay_path:
+        return {}
+
+    artifact_path = Path(replay_path)
+    try:
+        raw = json.loads(artifact_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RuntimeError(f"Failed to read ELF replay artifact {artifact_path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Invalid ELF replay artifact JSON {artifact_path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise RuntimeError(f"ELF replay artifact {artifact_path} must be a JSON object")
+
+    files = raw.get("files", {})
+    if files is not None and not isinstance(files, dict):
+        raise RuntimeError(f"ELF replay artifact {artifact_path} field 'files' must be an object")
+
+    merged: dict[str, Any] = {}
+    for key in (
+        "max_new_tokens",
+        "num_samples",
+        "num_sampling_steps",
+        "num_steps",
+        "self_cond_cfg_scale",
+        "guidance_scale",
+        "cfg_scale",
+        "sde_gamma",
+        "seed",
+        "generation_mode",
+    ):
+        if key in raw:
+            merged[key] = raw[key]
+
+    source = files or {}
+    for key in _REPLAY_FILE_KEYS:
+        value = raw.get(key, source.get(key))
+        if value:
+            merged[key] = _resolve_relative_path(artifact_path, value)
+
+    replay_samples = raw.get("samples")
+    if replay_samples is not None:
+        if not isinstance(replay_samples, list):
+            raise RuntimeError(
+                f"ELF replay artifact {artifact_path} field 'samples' must be a list"
+            )
+        resolved_samples: list[dict[str, Any]] = []
+        for idx, sample in enumerate(replay_samples):
+            if not isinstance(sample, dict):
+                raise RuntimeError(
+                    f"ELF replay artifact {artifact_path} sample {idx} must be an object"
+                )
+            sample_files = sample.get("files", {})
+            if sample_files is None:
+                sample_files = {}
+            if not isinstance(sample_files, dict):
+                raise RuntimeError(
+                    f"ELF replay artifact {artifact_path} sample {idx} field 'files' "
+                    "must be an object"
+                )
+            resolved_sample = {
+                key: value
+                for key, value in sample.items()
+                if key not in {"files", *_REPLAY_FILE_KEYS}
+            }
+            per_sample_source = {**source, **sample_files}
+            for key in _REPLAY_FILE_KEYS:
+                value = sample.get(key, per_sample_source.get(key))
+                if value:
+                    resolved_sample[key] = _resolve_relative_path(artifact_path, value)
+            resolved_samples.append(resolved_sample)
+        merged["replay_samples"] = resolved_samples
+
+    if isinstance(raw.get("expected_generated_samples"), list):
+        merged["expected_generated_samples"] = raw["expected_generated_samples"]
+    return merged
+
+
+def _merge_replay_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
+    replay_inputs = _load_replay_artifact(inputs)
+    return {**replay_inputs, **inputs}
+
+
+def _is_conditional_elf(case: E2ECase, inputs: dict[str, Any]) -> bool:
+    mode = str(inputs.get("generation_mode", "")).lower()
+    return case.reference_family in _CONDITIONAL_FAMILIES or mode == "conditional"
+
+
+def _has_prompt_condition(inputs: dict[str, Any]) -> bool:
+    return bool(inputs.get("prompt") or inputs.get("source_text") or inputs.get("condition_text"))
+
+
+def _extract_timing(stderr: str) -> dict[str, float]:
+    match = _TIMING_RE.search(stderr or "")
+    if match is None:
+        return {}
+    try:
+        return {
+            "trt_engine_prefill_s": float(match.group("prefill_ms")) / 1000.0,
+            "trt_engine_decode_s": float(match.group("decode_ms")) / 1000.0,
+            "trt_engine_s": float(match.group("total_ms")) / 1000.0,
+        }
+    except ValueError:
+        return {}
+
+
+def _parse_jsonl(payload: str) -> list[dict[str, Any]]:
+    samples: list[dict[str, Any]] = []
+    for idx, line in enumerate(payload.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            sample = json.loads(line)
+            if isinstance(sample, dict):
+                samples.append(sample)
+            else:
+                samples.append({"id": idx, "generated": str(sample)})
+        except json.JSONDecodeError:
+            samples.append({"id": idx, "generated": line})
+    return samples
+
+
+def _make_run_command(
+    case: E2ECase,
+    ctx: RunContext,
+    inputs: dict[str, Any],
+    output_path: str,
+    *,
+    include_num_samples: bool,
+) -> list[str]:
+    prompt = str(
+        inputs.get("prompt")
+        or inputs.get("source_text")
+        or inputs.get("condition_text")
+        or ""
+    )
+    cmd = [ctx.binary_path, "run", _bundle_path(case, ctx), "--prompt", prompt]
+
+    max_new_tokens = inputs.get("max_new_tokens")
+    if max_new_tokens is not None:
+        cmd.extend(["--max-new-tokens", str(max_new_tokens)])
+    num_samples = int(inputs.get("num_samples", 1))
+    if include_num_samples and num_samples > 1:
+        cmd.extend(["--num-samples", str(num_samples)])
+
+    num_steps = inputs.get("num_sampling_steps", inputs.get("num_steps"))
+    if num_steps is not None:
+        cmd.extend(["--num-steps", str(num_steps)])
+    self_cond = inputs.get("self_cond_cfg_scale", inputs.get("guidance_scale"))
+    if self_cond is not None:
+        cmd.extend(["--guidance-scale", str(self_cond)])
+    cfg_scale = inputs.get("cfg_scale")
+    if cfg_scale is not None:
+        cmd.extend(["--cfg-scale", str(cfg_scale)])
+    sde_gamma = inputs.get("sde_gamma")
+    if sde_gamma is not None:
+        cmd.extend(["--sde-gamma", str(sde_gamma)])
+    seed = inputs.get("seed")
+    if seed is not None:
+        cmd.extend(["--seed", str(seed)])
+
+    condition_latents = _as_path(
+        inputs.get("condition_latents_raw") or inputs.get("condition_latents_path")
+    )
+    condition_mask = _as_path(
+        inputs.get("condition_mask_raw") or inputs.get("condition_mask_path")
+    )
+    if (
+        _is_conditional_elf(case, inputs)
+        and (not condition_latents or not condition_mask)
+        and not _has_prompt_condition(inputs)
+    ):
+        raise RuntimeError(
+            "Conditional ELF generation requires either prompt/source_text for the bundled "
+            "T5 encoder path or both condition_latents_raw/condition_latents_path and "
+            "condition_mask_raw/condition_mask_path for raw replay."
+        )
+    if condition_latents:
+        cmd.extend(["--condition-latents-raw", condition_latents])
+    if condition_mask:
+        cmd.extend(["--condition-mask-raw", condition_mask])
+    initial_latents = _as_path(
+        inputs.get("initial_latents_raw") or inputs.get("initial_latents_path")
+    )
+    if initial_latents:
+        cmd.extend(["--initial-latents-raw", initial_latents])
+    sampling_steps = _as_path(
+        inputs.get("sampling_steps_raw") or inputs.get("sampling_steps_path")
+    )
+    if sampling_steps:
+        cmd.extend(["--sampling-steps-raw", sampling_steps])
+    sde_noise = _as_path(inputs.get("sde_noise_raw") or inputs.get("sde_noise_path"))
+    if sde_noise:
+        cmd.extend(["--sde-noise-raw", sde_noise])
+    cmd.extend(["--output", output_path])
+    return cmd
+
+
+def _resolved_input_subset(inputs: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in inputs.items()
+        if key
+        in {
+            "generation_mode",
+            "initial_latents_raw",
+            "initial_latents_path",
+            "condition_latents_raw",
+            "condition_latents_path",
+            "condition_mask_raw",
+            "condition_mask_path",
+            "prompt",
+            "source_text",
+            "condition_text",
+            "sampling_steps_raw",
+            "sampling_steps_path",
+            "sde_noise_raw",
+            "sde_noise_path",
+            "replay_samples",
+        }
+    }
+
+
+class DiffusionTextGenerationRunner:
+    @property
+    def strategy_name(self) -> str:
+        return "diffusion_text_generation"
+
+    def run_stage(
+        self, case: E2ECase, stage: StageSpec, ctx: RunContext
+    ) -> StageOutput:
+        if stage.name not in _TEXT_STAGES:
+            return StageOutput(
+                stage_name=stage.name,
+                data={"stage_ok": True},
+                metadata={
+                    "note": "ELF flow/final-decode invariants are covered by the decoded_text run"
+                },
+            )
+        return self._run_decoded_text(case, stage, ctx)
+
+    def _run_decoded_text(
+        self, case: E2ECase, stage: StageSpec, ctx: RunContext
+    ) -> StageOutput:
+        inputs = _merge_replay_inputs(case.inputs or {})
+        output_path = _artifact_path(case, ctx, "generated_samples.jsonl")
+
+        env = dict(os.environ)
+        if ctx.ld_library_path:
+            env["LD_LIBRARY_PATH"] = ctx.ld_library_path
+
+        t0 = time.monotonic()
+        replay_samples = inputs.get("replay_samples")
+        commands: list[list[str]] = []
+        stdout_parts: list[str] = []
+        stderr_parts: list[str] = []
+        returncodes: list[int] = []
+        if isinstance(replay_samples, list) and replay_samples:
+            all_samples: list[dict[str, Any]] = []
+            payload_lines: list[str] = []
+            for idx, sample_inputs_raw in enumerate(replay_samples):
+                if not isinstance(sample_inputs_raw, dict):
+                    raise RuntimeError(f"ELF replay sample {idx} must be an object")
+                sample_inputs = {**inputs, **sample_inputs_raw, "num_samples": 1}
+                sample_output_path = _artifact_path(
+                    case, ctx, f"generated_sample_{idx:04d}.jsonl"
+                )
+                cmd = _make_run_command(
+                    case,
+                    ctx,
+                    sample_inputs,
+                    sample_output_path,
+                    include_num_samples=False,
+                )
+                logger.info("Running diffusion text replay sample %s: %s", idx, " ".join(cmd))
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, env=env, timeout=600
+                )
+                commands.append(cmd)
+                stdout_parts.append(result.stdout)
+                stderr_parts.append(result.stderr)
+                returncodes.append(result.returncode)
+                if result.returncode != 0:
+                    truncated, log_path = save_full_stderr(
+                        result.stderr,
+                        ctx.artifacts_dir or "",
+                        "diffusion_text_generation",
+                        case.name,
+                    )
+                    message = (
+                        f"ELF diffusion text replay sample {idx} failed "
+                        f"(rc={result.returncode}): {truncated}"
+                    )
+                    if log_path:
+                        message += f" (full stderr: {log_path})"
+                    raise RuntimeError(message)
+                sample_payload = (
+                    Path(sample_output_path).read_text(encoding="utf-8")
+                    if Path(sample_output_path).exists()
+                    else ""
+                )
+                parsed = _parse_jsonl(sample_payload)
+                for parsed_idx, parsed_sample in enumerate(parsed):
+                    sample_id = sample_inputs_raw.get("id", len(all_samples))
+                    if parsed_idx > 0:
+                        sample_id = len(all_samples)
+                    parsed_sample["id"] = sample_id
+                    all_samples.append(parsed_sample)
+                    payload_lines.append(json.dumps(parsed_sample, ensure_ascii=False))
+            payload = "\n".join(payload_lines) + ("\n" if payload_lines else "")
+            Path(output_path).write_text(payload, encoding="utf-8")
+            samples = all_samples
+        else:
+            cmd = _make_run_command(
+                case, ctx, inputs, output_path, include_num_samples=True
+            )
+            logger.info("Running diffusion text generation: %s", " ".join(cmd))
+            result = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=600)
+            commands.append(cmd)
+            stdout_parts.append(result.stdout)
+            stderr_parts.append(result.stderr)
+            returncodes.append(result.returncode)
+            if result.returncode != 0:
+                truncated, log_path = save_full_stderr(
+                    result.stderr, ctx.artifacts_dir or "", "diffusion_text_generation", case.name
+                )
+                message = (
+                    f"ELF diffusion text generation failed (rc={result.returncode}): {truncated}"
+                )
+                if log_path:
+                    message += f" (full stderr: {log_path})"
+                raise RuntimeError(message)
+            payload = (
+                Path(output_path).read_text(encoding="utf-8")
+                if Path(output_path).exists()
+                else ""
+            )
+            samples = _parse_jsonl(payload)
+        elapsed = time.monotonic() - t0
+        generated_text = "\n".join(
+            str(sample.get("generated", "")) for sample in samples if isinstance(sample, dict)
+        )
+        expected_jsonl_path = _as_path(
+            inputs.get("expected_generated_jsonl_path") or inputs.get("expected_jsonl_path")
+        )
+        expected_payload = (
+            Path(expected_jsonl_path).read_text(encoding="utf-8")
+            if expected_jsonl_path and Path(expected_jsonl_path).exists()
+            else ""
+        )
+        expected_samples = (
+            _parse_jsonl(expected_payload)
+            if expected_payload
+            else inputs.get("expected_generated_samples", [])
+        )
+
+        data: dict[str, Any] = {
+            "generated_jsonl": payload,
+            "generated_samples": samples,
+            "output_path": output_path,
+            "resolved_inputs": _resolved_input_subset(inputs),
+        }
+        if expected_payload:
+            data["expected_generated_jsonl"] = expected_payload
+            data["expected_generated_jsonl_path"] = expected_jsonl_path
+        if expected_samples:
+            data["expected_generated_samples"] = expected_samples
+        return StageOutput(
+            stage_name=stage.name,
+            data=data,
+            text=generated_text,
+            timing_s=elapsed,
+            metadata={
+                "command": commands[0] if len(commands) == 1 else commands,
+                "returncode": returncodes[0] if len(returncodes) == 1 else returncodes,
+                "stdout": "\n".join(stdout_parts),
+                "stderr": "\n".join(stderr_parts),
+                **_extract_timing("\n".join(stderr_parts)),
+            },
+        )
+
+
+plugin = DiffusionTextGenerationRunner()

--- a/tests/runtime_strategy_matrix.yaml
+++ b/tests/runtime_strategy_matrix.yaml
@@ -93,6 +93,14 @@
       "diff_framework_check_classes": [],
       "diff_framework_exemption": "No diff_framework check currently registers runtime_strategies=['chronos_bolt_torchtrt']."
     },
+    "elf_flow": {
+      "task_strategy": "diffusion_text_generation",
+      "cli_commands": ["run", "solve"],
+      "runner_class": "tests.e2e_harness.runners.diffusion_text_generation.DiffusionTextGenerationRunner",
+      "comparator_class": "tests.e2e_harness.comparators.diffusion_text_generation.DiffusionTextGenerationComparator",
+      "diff_framework_check_classes": [],
+      "diff_framework_exemption": "No diff_framework check currently registers runtime_strategies=['elf_flow']."
+    },
     "object_detection": {
       "task_strategy": "object_detection",
       "cli_commands": ["detect"],

--- a/tests/tools/test_elf_diffusion_text_contract.py
+++ b/tests/tools/test_elf_diffusion_text_contract.py
@@ -1,0 +1,579 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.e2e_harness.contracts import (
+    E2ECase,
+    RunContext,
+    StageOutput,
+    StageSpec,
+    ThresholdProfile,
+)
+from tests.e2e_harness.manifest_loader import load_manifest
+from tests.e2e_harness.plugins import find_plugin
+from tests.e2e_harness.registry import get_comparator, get_runner
+from tests.e2e_harness.runners import diffusion_text_generation
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _case(reference_family: str, inputs: dict | None = None) -> E2ECase:
+    return E2ECase(
+        name="elf-contract",
+        hf_id="github.com/lillian039/ELF",
+        family="elf_flow",
+        runtime_strategy="elf_flow",
+        reference_backend="invariant_only",
+        reference_family=reference_family,
+        user_contract="diffusion_text_generation",
+        inputs=inputs or {},
+    )
+
+
+def test_elf_contract_plugin_discovers_for_unconditional_and_conditional() -> None:
+    uncond = find_plugin("elf_unconditional_text")
+    cond = find_plugin("elf_conditional_text")
+
+    assert uncond is not None
+    assert cond is uncond
+    assert uncond.user_contract == "diffusion_text_generation"
+    assert (
+        uncond.configure_reference(_case("elf_unconditional_text"))["output_schema"]
+        == "jsonl_id_generated_token_ids"
+    )
+
+
+def test_diffusion_text_generation_runner_and_comparator_are_registered() -> None:
+    runner = get_runner("diffusion_text_generation")
+    comparator = get_comparator("diffusion_text_generation")
+
+    assert runner is not None
+    assert comparator is not None
+
+
+def test_elf_unconditional_contract_accepts_jsonl_samples_and_metrics() -> None:
+    plugin = find_plugin("elf_unconditional_text")
+    assert plugin is not None
+
+    trt = StageOutput(
+        stage_name="decoded_text",
+        data={
+            "generated_jsonl": '{"id": 0, "generated": "A complete generated sentence."}\n',
+            "gen_ppl": 24.0,
+            "unigram_entropy": 5.16,
+        },
+    )
+    threshold = ThresholdProfile(
+        task_strategy="neural_operator",
+        metrics={
+            "contract_min_samples": 1,
+            "contract_max_gen_ppl": 24.5,
+            "contract_min_unigram_entropy": 5.0,
+        },
+    )
+
+    result = plugin.verify(
+        trt,
+        StageOutput("decoded_text"),
+        _case("elf_unconditional_text", {"generation_mode": "unconditional"}),
+        threshold,
+    )
+
+    assert result.passed
+    assert result.metrics["num_generated_samples"].passed
+    assert result.metrics["gen_ppl"].passed
+    assert result.metrics["unigram_entropy"].passed
+
+
+def test_elf_unconditional_contract_enforces_expected_sample_count() -> None:
+    plugin = find_plugin("elf_unconditional_text")
+    assert plugin is not None
+
+    case = _case("elf_unconditional_text", {"generation_mode": "unconditional"})
+    threshold = ThresholdProfile(
+        task_strategy="neural_operator",
+        metrics={"contract_min_samples": 1, "contract_expected_samples": 2},
+    )
+
+    passing = plugin.verify(
+        StageOutput(
+            stage_name="decoded_text",
+            data={
+                "generated_samples": [
+                    {"id": 0, "generated": "First generated sentence."},
+                    {"id": 1, "generated": "Second generated sentence."},
+                ]
+            },
+        ),
+        StageOutput("decoded_text"),
+        case,
+        threshold,
+    )
+    failing = plugin.verify(
+        StageOutput(
+            stage_name="decoded_text",
+            data={
+                "generated_samples": [
+                    {"id": 0, "generated": "Only one generated sentence."}
+                ]
+            },
+        ),
+        StageOutput("decoded_text"),
+        case,
+        threshold,
+    )
+
+    assert passing.passed
+    assert passing.metrics["expected_generated_sample_count"].passed
+    assert not failing.passed
+    assert not failing.metrics["expected_generated_sample_count"].passed
+
+
+def test_elf_conditional_contract_requires_condition_and_generated_text() -> None:
+    plugin = find_plugin("elf_conditional_text")
+    assert plugin is not None
+
+    trt = StageOutput(
+        stage_name="decoded_text",
+        data={
+            "generated_samples": [
+                {
+                    "id": 0,
+                    "source": "Ein kurzer deutscher Satz.",
+                    "generated": "A short German sentence.",
+                }
+            ],
+            "bleu": 32.0,
+            "rougeL": 0.41,
+        },
+    )
+    threshold = ThresholdProfile(
+        task_strategy="neural_operator",
+        metrics={
+            "contract_min_samples": 1,
+            "contract_min_bleu": 1.0,
+            "contract_min_rouge_l": 0.1,
+        },
+    )
+
+    result = plugin.verify(
+        trt,
+        StageOutput("decoded_text"),
+        _case(
+            "elf_conditional_text",
+            {
+                "generation_mode": "conditional",
+                "condition_latents_path": "/tmp/cond.f32",
+                "condition_mask_path": "/tmp/mask.f32",
+            },
+        ),
+        threshold,
+    )
+
+    assert result.passed
+    assert result.metrics["condition_available"].passed
+    assert result.metrics["bleu"].passed
+    assert result.metrics["rouge_l"].passed
+
+
+def test_elf_conditional_contract_accepts_source_text_prompt_condition() -> None:
+    plugin = find_plugin("elf_conditional_text")
+    assert plugin is not None
+
+    result = plugin.verify(
+        StageOutput(
+            stage_name="decoded_text",
+            data={
+                "generated_samples": [
+                    {"id": 0, "source": "Ein kurzer deutscher Satz.", "generated": "A sentence."}
+                ]
+            },
+        ),
+        StageOutput("decoded_text"),
+        _case(
+            "elf_conditional_text",
+            {"generation_mode": "conditional", "source_text": "Ein kurzer deutscher Satz."},
+        ),
+        ThresholdProfile(task_strategy="neural_operator", metrics={"contract_min_samples": 1}),
+    )
+
+    assert result.passed
+    assert result.metrics["condition_available"].passed
+
+
+def test_elf_contract_compares_upstream_replay_expected_text() -> None:
+    plugin = find_plugin("elf_unconditional_text")
+    assert plugin is not None
+
+    result = plugin.verify(
+        StageOutput(
+            stage_name="decoded_text",
+            data={
+                "generated_samples": [
+                    {"id": 0, "generated": "A replayed sentence.", "token_ids": [7, 8, 9]}
+                ],
+                "expected_generated_samples": [
+                    {"id": 0, "generated": "A replayed sentence.", "token_ids": [7, 8, 9]}
+                ],
+            },
+        ),
+        StageOutput("decoded_text"),
+        _case("elf_unconditional_text", {"generation_mode": "unconditional"}),
+        ThresholdProfile(task_strategy="neural_operator", metrics={"contract_min_samples": 1}),
+    )
+
+    assert result.passed
+    assert result.metrics["upstream_text_match_rate"].passed
+    assert result.metrics["upstream_token_id_match_rate"].passed
+
+
+def test_elf_contract_rejects_upstream_replay_text_mismatch() -> None:
+    plugin = find_plugin("elf_unconditional_text")
+    assert plugin is not None
+
+    result = plugin.verify(
+        StageOutput(
+            stage_name="decoded_text",
+            data={
+                "generated_samples": [{"id": 0, "generated": "A C++ sentence."}],
+                "expected_generated_samples": [{"id": 0, "generated": "An upstream sentence."}],
+            },
+        ),
+        StageOutput("decoded_text"),
+        _case("elf_unconditional_text", {"generation_mode": "unconditional"}),
+        ThresholdProfile(task_strategy="neural_operator", metrics={"contract_min_samples": 1}),
+    )
+
+    assert not result.passed
+    assert not result.metrics["upstream_text_match_rate"].passed
+
+
+def test_elf_contract_rejects_upstream_replay_token_mismatch() -> None:
+    plugin = find_plugin("elf_unconditional_text")
+    assert plugin is not None
+
+    result = plugin.verify(
+        StageOutput(
+            stage_name="decoded_text",
+            data={
+                "generated_samples": [
+                    {"id": 0, "generated": "Same text.", "token_ids": [1, 2, 3]}
+                ],
+                "expected_generated_samples": [
+                    {"id": 0, "generated": "Same text.", "token_ids": [1, 2, 4]}
+                ],
+            },
+        ),
+        StageOutput("decoded_text"),
+        _case("elf_unconditional_text", {"generation_mode": "unconditional"}),
+        ThresholdProfile(task_strategy="neural_operator", metrics={"contract_min_samples": 1}),
+    )
+
+    assert not result.passed
+    assert not result.metrics["upstream_token_id_match_rate"].passed
+
+
+def test_diffusion_text_runner_requires_prompt_or_api_condition_for_conditional(
+    tmp_path: Path,
+) -> None:
+    runner = get_runner("diffusion_text_generation")
+    assert runner is not None
+    case = _case(
+        "elf_conditional_text",
+        {"generation_mode": "conditional"},
+    )
+
+    with pytest.raises(RuntimeError, match="requires either prompt/source_text"):
+        runner.run_stage(
+            case,
+            StageSpec(name="decoded_text"),
+            RunContext(
+                case=case,
+                artifacts_dir=str(tmp_path),
+                binary_path="/bin/false",
+                engine_dir=str(tmp_path),
+            ),
+        )
+
+
+def test_diffusion_text_runner_uses_source_text_prompt_condition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    case = _case(
+        "elf_conditional_text",
+        {
+            "generation_mode": "conditional",
+            "source_text": "Ein kurzer deutscher Satz.",
+            "num_sampling_steps": 64,
+        },
+    )
+    captured: dict[str, list[str]] = {}
+
+    def _fake_run(cmd, **kwargs):
+        del kwargs
+        captured["cmd"] = cmd
+        out_path = Path(cmd[cmd.index("--output") + 1])
+        out_path.write_text(
+            '{"id": 0, "generated": "A short German sentence.", "token_ids": [7]}\n',
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(diffusion_text_generation.subprocess, "run", _fake_run)
+    runner = diffusion_text_generation.DiffusionTextGenerationRunner()
+    out = runner.run_stage(
+        case,
+        StageSpec(name="decoded_text"),
+        RunContext(
+            case=case,
+            artifacts_dir=str(tmp_path / "artifacts"),
+            binary_path="/bin/trtmc",
+            engine_dir=str(tmp_path),
+        ),
+    )
+
+    cmd = captured["cmd"]
+    assert "--prompt" in cmd
+    assert cmd[cmd.index("--prompt") + 1] == "Ein kurzer deutscher Satz."
+    assert "--condition-latents-raw" not in cmd
+    assert "--condition-mask-raw" not in cmd
+    assert out.data["generated_samples"][0]["generated"] == "A short German sentence."
+
+
+def test_diffusion_text_runner_consumes_upstream_replay_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in (
+        "initial.f32",
+        "steps.f32",
+        "sde.f32",
+        "cond.f32",
+        "mask.f32",
+    ):
+        (tmp_path / name).write_bytes(b"\0\0\0\0")
+    (tmp_path / "expected.jsonl").write_text(
+        '{"id": 0, "generated": "A replayed sentence.", "token_ids": [7, 8, 9]}\n',
+        encoding="utf-8",
+    )
+    artifact = tmp_path / "elf_replay.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "generation_mode": "conditional",
+                "num_sampling_steps": 64,
+                "self_cond_cfg_scale": 1.0,
+                "cfg_scale": 2.0,
+                "sde_gamma": 0.0,
+                "files": {
+                    "initial_latents_raw": "initial.f32",
+                    "sampling_steps_raw": "steps.f32",
+                    "sde_noise_raw": "sde.f32",
+                    "condition_latents_raw": "cond.f32",
+                    "condition_mask_raw": "mask.f32",
+                    "expected_generated_jsonl_path": "expected.jsonl",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    case = _case(
+        "elf_conditional_text",
+        {"elf_replay_artifact": str(artifact)},
+    )
+    captured: dict[str, list[str]] = {}
+
+    def _fake_run(cmd, **kwargs):
+        del kwargs
+        captured["cmd"] = cmd
+        out_path = Path(cmd[cmd.index("--output") + 1])
+        out_path.write_text(
+            '{"id": 0, "generated": "A replayed sentence.", "token_ids": [7, 8, 9]}\n',
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(diffusion_text_generation.subprocess, "run", _fake_run)
+    runner = diffusion_text_generation.DiffusionTextGenerationRunner()
+    out = runner.run_stage(
+        case,
+        StageSpec(name="decoded_text"),
+        RunContext(
+            case=case,
+            artifacts_dir=str(tmp_path / "artifacts"),
+            binary_path="/bin/trtmc",
+            engine_dir=str(tmp_path),
+        ),
+    )
+
+    cmd = captured["cmd"]
+    assert "--initial-latents-raw" in cmd
+    assert str(tmp_path / "initial.f32") in cmd
+    assert "--sampling-steps-raw" in cmd
+    assert str(tmp_path / "steps.f32") in cmd
+    assert "--sde-noise-raw" in cmd
+    assert str(tmp_path / "sde.f32") in cmd
+    assert "--condition-latents-raw" in cmd
+    assert str(tmp_path / "cond.f32") in cmd
+    assert "--condition-mask-raw" in cmd
+    assert str(tmp_path / "mask.f32") in cmd
+    assert out.data["expected_generated_samples"][0]["generated"] == "A replayed sentence."
+
+    plugin = find_plugin("elf_conditional_text")
+    assert plugin is not None
+    result = plugin.verify(
+        out,
+        StageOutput("decoded_text"),
+        case,
+        ThresholdProfile(task_strategy="neural_operator", metrics={"contract_min_samples": 1}),
+    )
+    assert result.passed
+    assert result.metrics["condition_available"].passed
+    assert result.metrics["upstream_text_match_rate"].passed
+    assert result.metrics["upstream_token_id_match_rate"].passed
+
+
+def test_diffusion_text_runner_consumes_multi_sample_replay_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in (
+        "initial0.f32",
+        "initial1.f32",
+        "steps.f32",
+        "sde0.f32",
+        "sde1.f32",
+    ):
+        (tmp_path / name).write_bytes(b"\0\0\0\0")
+    (tmp_path / "expected.jsonl").write_text(
+        "\n".join(
+            [
+                '{"id": 0, "generated": "Replay zero.", "token_ids": [1]}',
+                '{"id": 1, "generated": "Replay one.", "token_ids": [2]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    artifact = tmp_path / "elf_replay.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "generation_mode": "unconditional",
+                "num_samples": 2,
+                "num_sampling_steps": 32,
+                "files": {
+                    "sampling_steps_raw": "steps.f32",
+                    "expected_generated_jsonl_path": "expected.jsonl",
+                },
+                "samples": [
+                    {
+                        "id": 0,
+                        "files": {
+                            "initial_latents_raw": "initial0.f32",
+                            "sde_noise_raw": "sde0.f32",
+                        },
+                    },
+                    {
+                        "id": 1,
+                        "files": {
+                            "initial_latents_raw": "initial1.f32",
+                            "sde_noise_raw": "sde1.f32",
+                        },
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    case = _case("elf_unconditional_text", {"elf_replay_artifact": str(artifact)})
+    captured: dict[str, list[list[str]]] = {"cmds": []}
+
+    def _fake_run(cmd, **kwargs):
+        del kwargs
+        sample_idx = len(captured["cmds"])
+        captured["cmds"].append(cmd)
+        out_path = Path(cmd[cmd.index("--output") + 1])
+        out_path.write_text(
+            json.dumps(
+                {
+                    "id": 0,
+                    "generated": f"Replay {'zero' if sample_idx == 0 else 'one'}.",
+                    "token_ids": [sample_idx + 1],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(diffusion_text_generation.subprocess, "run", _fake_run)
+    runner = diffusion_text_generation.DiffusionTextGenerationRunner()
+    out = runner.run_stage(
+        case,
+        StageSpec(name="decoded_text"),
+        RunContext(
+            case=case,
+            artifacts_dir=str(tmp_path / "artifacts"),
+            binary_path="/bin/trtmc",
+            engine_dir=str(tmp_path),
+        ),
+    )
+
+    assert len(captured["cmds"]) == 2
+    assert all("--num-samples" not in cmd for cmd in captured["cmds"])
+    assert str(tmp_path / "initial0.f32") in captured["cmds"][0]
+    assert str(tmp_path / "initial1.f32") in captured["cmds"][1]
+    assert [sample["id"] for sample in out.data["generated_samples"]] == [0, 1]
+
+    plugin = find_plugin("elf_unconditional_text")
+    assert plugin is not None
+    result = plugin.verify(
+        out,
+        StageOutput("decoded_text"),
+        case,
+        ThresholdProfile(
+            task_strategy="neural_operator",
+            metrics={"contract_min_samples": 1, "contract_expected_samples": 2},
+        ),
+    )
+    assert result.passed
+    assert result.metrics["expected_generated_sample_count"].passed
+    assert result.metrics["upstream_text_match_rate"].passed
+    assert result.metrics["upstream_token_id_match_rate"].passed
+
+
+def test_elf_contract_rejects_empty_generation() -> None:
+    plugin = find_plugin("elf_unconditional_text")
+    assert plugin is not None
+
+    result = plugin.verify(
+        StageOutput(stage_name="decoded_text", data={"generated_samples": [{"generated": ""}]}),
+        StageOutput("decoded_text"),
+        _case("elf_unconditional_text"),
+        ThresholdProfile(task_strategy="neural_operator", metrics={"contract_min_samples": 1}),
+    )
+
+    assert not result.passed
+    assert not result.metrics["non_empty_generated_text"].passed
+
+
+def test_elf_l0_manifests_record_user_contract_and_skip_reason() -> None:
+    for name, family in (
+        ("elf-b-owt-l0", "elf_unconditional_text"),
+        ("elf-b-xsum-l0", "elf_conditional_text"),
+        ("elf-b-de-en-l0", "elf_conditional_text"),
+    ):
+        case = load_manifest(REPO_ROOT / "tests" / "e2e" / "models" / f"{name}.json")
+
+        assert case.family == "elf_flow"
+        assert case.runtime_strategy == "elf_flow"
+        assert case.task_strategy == "diffusion_text_generation"
+        assert case.reference_family == family
+        assert case.user_contract == "diffusion_text_generation"
+        assert "token_ids" in case.inputs["output_schema"]
+        assert case.metadata["skip_reason"]
+        assert any(stage.artifact_type == "text_samples" for stage in case.stages)

--- a/tests/tools/test_make_elf_replay_artifact.py
+++ b/tests/tools/test_make_elf_replay_artifact.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+from pathlib import Path
+
+from tools.make_elf_replay_artifact import build_artifact
+from tools.validate_elf_replay_artifact import validate_artifact
+
+
+def _write_f32(path: Path, values: list[float]) -> None:
+    path.write_bytes(struct.pack(f"{len(values)}f", *values))
+
+
+def _args(tmp_path: Path, **overrides):
+    values = {
+        "output": str(tmp_path / "elf_replay.json"),
+        "generation_mode": "unconditional",
+        "model_id": "",
+        "variant": "",
+        "max_length": None,
+        "max_input_length": None,
+        "text_encoder_dim": None,
+        "num_samples": None,
+        "num_sampling_steps": None,
+        "self_cond_cfg_scale": None,
+        "cfg_scale": None,
+        "sde_gamma": None,
+        "seed": None,
+        "initial_latents_raw": "",
+        "condition_latents_raw": "",
+        "condition_mask_raw": "",
+        "sampling_steps_raw": "",
+        "sde_noise_raw": "",
+        "expected_generated_jsonl_path": "",
+        "samples_jsonl": "",
+        "sample": None,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_make_single_sample_replay_artifact(tmp_path: Path) -> None:
+    _write_f32(tmp_path / "initial.f32", [0.0, 1.0])
+    _write_f32(tmp_path / "steps.f32", [0.0, 1.0])
+    (tmp_path / "expected.jsonl").write_text(
+        '{"id": 0, "generated": "Replay.", "token_ids": [1]}\n',
+        encoding="utf-8",
+    )
+    artifact_path = tmp_path / "elf_replay.json"
+    artifact = build_artifact(
+        _args(
+            tmp_path,
+            output=str(artifact_path),
+            max_length=1,
+            text_encoder_dim=2,
+            num_samples=1,
+            initial_latents_raw=str(tmp_path / "initial.f32"),
+            sampling_steps_raw=str(tmp_path / "steps.f32"),
+            expected_generated_jsonl_path=str(tmp_path / "expected.jsonl"),
+        )
+    )
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    resolved = validate_artifact(artifact_path)
+
+    assert artifact["files"]["initial_latents_raw"] == "initial.f32"
+    assert artifact["files"]["expected_generated_jsonl_path"] == "expected.jsonl"
+    assert resolved["initial_float_count"] == 2
+    assert resolved["expected_sample_count"] == 1
+
+
+def test_make_multi_sample_replay_artifact_from_samples_jsonl(tmp_path: Path) -> None:
+    _write_f32(tmp_path / "initial0.f32", [0.0])
+    _write_f32(tmp_path / "initial1.f32", [1.0])
+    _write_f32(tmp_path / "steps.f32", [0.0, 1.0])
+    (tmp_path / "expected.jsonl").write_text(
+        "\n".join(
+            [
+                '{"id": 0, "generated": "Replay zero.", "token_ids": [1]}',
+                '{"id": 1, "generated": "Replay one.", "token_ids": [2]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "samples.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"id": 0, "initial": str(tmp_path / "initial0.f32")}),
+                json.dumps({"id": 1, "initial": str(tmp_path / "initial1.f32")}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    artifact_path = tmp_path / "elf_replay.json"
+    artifact = build_artifact(
+        _args(
+            tmp_path,
+            output=str(artifact_path),
+            max_length=1,
+            text_encoder_dim=1,
+            sampling_steps_raw=str(tmp_path / "steps.f32"),
+            expected_generated_jsonl_path=str(tmp_path / "expected.jsonl"),
+            samples_jsonl=str(tmp_path / "samples.jsonl"),
+        )
+    )
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    resolved = validate_artifact(artifact_path)
+
+    assert artifact["num_samples"] == 2
+    assert artifact["samples"][0]["files"]["initial_latents_raw"] == "initial0.f32"
+    assert artifact["samples"][1]["files"]["initial_latents_raw"] == "initial1.f32"
+    assert resolved["replay_sample_count"] == 2
+
+
+def test_make_multi_sample_replay_artifact_from_sample_flags(tmp_path: Path) -> None:
+    _write_f32(tmp_path / "initial0.f32", [0.0])
+    _write_f32(tmp_path / "initial1.f32", [1.0])
+    _write_f32(tmp_path / "steps.f32", [0.0, 1.0])
+    (tmp_path / "expected.jsonl").write_text(
+        "\n".join(
+            [
+                '{"id": 0, "generated": "Replay zero.", "token_ids": [1]}',
+                '{"id": 1, "generated": "Replay one.", "token_ids": [2]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    artifact_path = tmp_path / "elf_replay.json"
+    artifact = build_artifact(
+        _args(
+            tmp_path,
+            output=str(artifact_path),
+            max_length=1,
+            text_encoder_dim=1,
+            sampling_steps_raw=str(tmp_path / "steps.f32"),
+            expected_generated_jsonl_path=str(tmp_path / "expected.jsonl"),
+            sample=[
+                f"id=0,initial={tmp_path / 'initial0.f32'}",
+                f"id=1,initial={tmp_path / 'initial1.f32'}",
+            ],
+        )
+    )
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    resolved = validate_artifact(artifact_path)
+
+    assert artifact["samples"][0]["id"] == 0
+    assert artifact["samples"][1]["id"] == 1
+    assert resolved["replay_sample_count"] == 2

--- a/tests/tools/test_prepare_elf_model_dir.py
+++ b/tests/tools/test_prepare_elf_model_dir.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from tensorrt_model_connect.config import ModelConfig
+from tools.prepare_elf_model_dir import prepare_model_dir
+
+
+def _args(tmp_path: Path, **overrides):
+    values = {
+        "config": str(tmp_path / "train_owt_ELF-B.yml"),
+        "checkpoint_path": str(tmp_path / "ELF-B-owt"),
+        "tokenizer": str(tmp_path / "tokenizer"),
+        "encoder_checkpoint": "",
+        "output": str(tmp_path / "prepared"),
+        "copy": True,
+        "force": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _write_config(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "model: ELF-B",
+                "max_length: 1024",
+                "encoder_model_name: t5-small",
+                "denoiser_noise_scale: 2.0",
+                "self_cond_prob: 0.5",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_prepare_elf_model_dir_combines_config_checkpoint_and_tokenizer(tmp_path: Path) -> None:
+    _write_config(tmp_path / "train_owt_ELF-B.yml")
+    checkpoint_dir = tmp_path / "ELF-B-owt"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "checkpoint_42").write_bytes(b"checkpoint")
+    tokenizer_dir = tmp_path / "tokenizer"
+    tokenizer_dir.mkdir()
+    (tokenizer_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
+    (tokenizer_dir / "tokenizer_config.json").write_text("{}", encoding="utf-8")
+    encoder_checkpoint = tmp_path / "t5_small_encoder_jax.pkl"
+    encoder_checkpoint.write_bytes(b"encoder")
+
+    result = prepare_model_dir(_args(tmp_path, encoder_checkpoint=str(encoder_checkpoint)))
+    output = Path(result["output_dir"])
+    cfg = ModelConfig.from_dir(output)
+
+    assert result["config"] == "train_owt_ELF-B.yml"
+    assert result["checkpoints"] == ["checkpoint_42"]
+    assert result["tokenizer_files"] == ["tokenizer.json", "tokenizer_config.json"]
+    assert result["encoder_checkpoint"] == "t5_small_encoder_jax.pkl"
+    assert (output / "train_owt_ELF-B.yml").exists()
+    assert (output / "checkpoint_42").read_bytes() == b"checkpoint"
+    assert (output / "tokenizer.json").exists()
+    assert (output / "t5_small_encoder_jax.pkl").read_bytes() == b"encoder"
+    assert cfg.model_type == "elf"
+    assert cfg.raw["model"] == "ELF-B"
+
+
+def test_prepare_elf_model_dir_rejects_checkpoint_dir_without_checkpoint(tmp_path: Path) -> None:
+    _write_config(tmp_path / "train_owt_ELF-B.yml")
+    (tmp_path / "ELF-B-owt").mkdir()
+
+    with pytest.raises(FileNotFoundError, match="no ELF checkpoint"):
+        prepare_model_dir(_args(tmp_path, tokenizer=""))
+
+
+def test_prepare_elf_model_dir_rejects_non_empty_output_without_force(tmp_path: Path) -> None:
+    _write_config(tmp_path / "train_owt_ELF-B.yml")
+    checkpoint_dir = tmp_path / "ELF-B-owt"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "checkpoint_42").write_bytes(b"checkpoint")
+    output = tmp_path / "prepared"
+    output.mkdir()
+    (output / "existing.txt").write_text("x", encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="not empty"):
+        prepare_model_dir(_args(tmp_path, tokenizer=""))

--- a/tests/tools/test_validate_elf_replay_artifact.py
+++ b/tests/tools/test_validate_elf_replay_artifact.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+from tools.validate_elf_replay_artifact import validate_artifact
+
+
+def _write_f32(path: Path, values: list[float]) -> None:
+    path.write_bytes(struct.pack(f"{len(values)}f", *values))
+
+
+def test_validate_conditional_replay_artifact_resolves_relative_files(tmp_path: Path) -> None:
+    _write_f32(tmp_path / "initial.f32", [0.0, 1.0, 2.0, 3.0])
+    _write_f32(tmp_path / "steps.f32", [0.0, 0.5, 1.0])
+    _write_f32(tmp_path / "sde.f32", [0.1, 0.2, 0.3, 0.4])
+    _write_f32(tmp_path / "cond.f32", [4.0, 5.0, 0.0, 0.0])
+    _write_f32(tmp_path / "mask.f32", [1.0, 0.0])
+    (tmp_path / "expected.jsonl").write_text(
+        '{"id": 0, "generated": "A replayed sentence.", "token_ids": [7, 8]}\n',
+        encoding="utf-8",
+    )
+    artifact = tmp_path / "elf_replay.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "generation_mode": "conditional",
+                "max_length": 2,
+                "text_encoder_dim": 2,
+                "files": {
+                    "initial_latents_raw": "initial.f32",
+                    "sampling_steps_raw": "steps.f32",
+                    "sde_noise_raw": "sde.f32",
+                    "condition_latents_raw": "cond.f32",
+                    "condition_mask_raw": "mask.f32",
+                    "expected_generated_jsonl_path": "expected.jsonl",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    resolved = validate_artifact(artifact)
+
+    assert resolved["generation_mode"] == "conditional"
+    assert resolved["initial_latents"] == str(tmp_path / "initial.f32")
+    assert resolved["sampling_step_count"] == 3
+    assert resolved["condition_mask_float_count"] == 2
+    assert resolved["sde_noise_float_count"] == 4
+    assert resolved["expected_sample_count"] == 1
+
+
+def test_validate_multi_sample_replay_artifact_resolves_each_sample(tmp_path: Path) -> None:
+    _write_f32(tmp_path / "initial0.f32", [0.0])
+    _write_f32(tmp_path / "initial1.f32", [1.0])
+    _write_f32(tmp_path / "steps.f32", [0.0, 1.0])
+    (tmp_path / "expected.jsonl").write_text(
+        "\n".join(
+            [
+                '{"id": 0, "generated": "Replay zero.", "token_ids": [1]}',
+                '{"id": 1, "generated": "Replay one.", "token_ids": [2]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    artifact = tmp_path / "elf_replay.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "generation_mode": "unconditional",
+                "num_samples": 2,
+                "max_length": 1,
+                "text_encoder_dim": 1,
+                "files": {
+                    "sampling_steps_raw": "steps.f32",
+                    "expected_generated_jsonl_path": "expected.jsonl",
+                },
+                "samples": [
+                    {"files": {"initial_latents_raw": "initial0.f32"}},
+                    {"files": {"initial_latents_raw": "initial1.f32"}},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    resolved = validate_artifact(artifact)
+
+    assert resolved["replay_sample_count"] == 2
+    assert resolved["expected_sample_count"] == 2
+    assert resolved["samples"][0]["initial_latents"] == str(tmp_path / "initial0.f32")
+    assert resolved["samples"][1]["initial_latents"] == str(tmp_path / "initial1.f32")
+
+
+def test_validate_multi_sample_replay_artifact_requires_samples_list(tmp_path: Path) -> None:
+    _write_f32(tmp_path / "initial.f32", [0.0])
+    _write_f32(tmp_path / "steps.f32", [0.0, 1.0])
+    artifact = tmp_path / "elf_replay.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "generation_mode": "unconditional",
+                "num_samples": 2,
+                "files": {
+                    "initial_latents_raw": "initial.f32",
+                    "sampling_steps_raw": "steps.f32",
+                },
+                "expected_generated_samples": [
+                    {"id": 0, "generated": "Replay zero.", "token_ids": [1]},
+                    {"id": 1, "generated": "Replay one.", "token_ids": [2]},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="samples list"):
+        validate_artifact(artifact)
+
+
+def test_validate_replay_artifact_requires_expected_token_ids(tmp_path: Path) -> None:
+    _write_f32(tmp_path / "initial.f32", [0.0])
+    _write_f32(tmp_path / "steps.f32", [0.0, 1.0])
+    artifact = tmp_path / "elf_replay.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "generation_mode": "unconditional",
+                "files": {
+                    "initial_latents_raw": "initial.f32",
+                    "sampling_steps_raw": "steps.f32",
+                },
+                "expected_generated_samples": [{"id": 0, "generated": "Text only"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="token_ids"):
+        validate_artifact(artifact)
+
+
+def test_validate_replay_artifact_checks_declared_latent_shape(tmp_path: Path) -> None:
+    _write_f32(tmp_path / "initial.f32", [0.0, 1.0, 2.0])
+    _write_f32(tmp_path / "steps.f32", [0.0, 1.0])
+    artifact = tmp_path / "elf_replay.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "generation_mode": "unconditional",
+                "max_length": 2,
+                "text_encoder_dim": 2,
+                "files": {
+                    "initial_latents_raw": "initial.f32",
+                    "sampling_steps_raw": "steps.f32",
+                },
+                "expected_generated_samples": [
+                    {"id": 0, "generated": "Shape mismatch", "token_ids": [1]}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="initial latents"):
+        validate_artifact(artifact)

--- a/tools/make_elf_replay_artifact.py
+++ b/tools/make_elf_replay_artifact.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Create ELF replay artifacts for C++ parity runs.
+
+This packages upstream-exported float32 tensors plus upstream generated JSONL
+into the replay schema consumed by the diffusion_text_generation E2E runner.
+It does not generate tensors itself; dump those from the GitHub ELF code path,
+then use this tool to make the artifact portable and validated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from tools.validate_elf_replay_artifact import validate_artifact
+
+
+FILE_ALIASES = {
+    "initial": "initial_latents_raw",
+    "initial_latents": "initial_latents_raw",
+    "initial_latents_raw": "initial_latents_raw",
+    "condition": "condition_latents_raw",
+    "condition_latents": "condition_latents_raw",
+    "condition_latents_raw": "condition_latents_raw",
+    "mask": "condition_mask_raw",
+    "condition_mask": "condition_mask_raw",
+    "condition_mask_raw": "condition_mask_raw",
+    "steps": "sampling_steps_raw",
+    "sampling_steps": "sampling_steps_raw",
+    "sampling_steps_raw": "sampling_steps_raw",
+    "sde": "sde_noise_raw",
+    "sde_noise": "sde_noise_raw",
+    "sde_noise_raw": "sde_noise_raw",
+    "expected": "expected_generated_jsonl_path",
+    "expected_jsonl": "expected_generated_jsonl_path",
+    "expected_generated_jsonl_path": "expected_generated_jsonl_path",
+}
+
+
+def _maybe_add(out: dict[str, Any], key: str, value: Any) -> None:
+    if value is not None and value != "":
+        out[key] = value
+
+
+def _stored_path(path_text: str, artifact_path: Path) -> str:
+    path = Path(path_text)
+    if not path.is_absolute():
+        return path_text
+    try:
+        return os.path.relpath(path, artifact_path.parent)
+    except ValueError:
+        return str(path)
+
+
+def _normalize_file_key(key: str) -> str:
+    normalized = FILE_ALIASES.get(key)
+    if normalized is None:
+        raise ValueError(f"unsupported ELF replay file key: {key}")
+    return normalized
+
+
+def _sample_from_record(record: dict[str, Any], artifact_path: Path) -> dict[str, Any]:
+    files = record.get("files", {})
+    if files is None:
+        files = {}
+    if not isinstance(files, dict):
+        raise ValueError("sample field 'files' must be an object")
+
+    sample: dict[str, Any] = {}
+    file_values: dict[str, str] = {}
+    for key, value in record.items():
+        if key == "files":
+            continue
+        if key in FILE_ALIASES:
+            if isinstance(value, str) and value:
+                file_values[_normalize_file_key(key)] = _stored_path(value, artifact_path)
+        else:
+            sample[key] = value
+    for key, value in files.items():
+        if isinstance(value, str) and value:
+            file_values[_normalize_file_key(str(key))] = _stored_path(value, artifact_path)
+    if file_values:
+        sample["files"] = file_values
+    return sample
+
+
+def _parse_sample_spec(spec: str, artifact_path: Path) -> dict[str, Any]:
+    stripped = spec.strip()
+    if stripped.startswith("{"):
+        raw = json.loads(stripped)
+        if not isinstance(raw, dict):
+            raise ValueError("--sample JSON value must be an object")
+        return _sample_from_record(raw, artifact_path)
+
+    record: dict[str, Any] = {}
+    for part in stripped.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "=" not in part:
+            raise ValueError("--sample entries must be key=value pairs")
+        key, value = part.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if key == "id":
+            record[key] = int(value)
+        else:
+            record[key] = value
+    return _sample_from_record(record, artifact_path)
+
+
+def _load_samples_jsonl(path: Path, artifact_path: Path) -> list[dict[str, Any]]:
+    samples: list[dict[str, Any]] = []
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = line.strip()
+        if not line:
+            continue
+        raw = json.loads(line)
+        if not isinstance(raw, dict):
+            raise ValueError(f"{path}:{line_no}: sample must be a JSON object")
+        samples.append(_sample_from_record(raw, artifact_path))
+    return samples
+
+
+def build_artifact(args: argparse.Namespace) -> dict[str, Any]:
+    artifact_path = Path(args.output).resolve()
+    artifact: dict[str, Any] = {"generation_mode": args.generation_mode}
+    _maybe_add(artifact, "model_id", args.model_id)
+    _maybe_add(artifact, "variant", args.variant)
+    _maybe_add(artifact, "max_length", args.max_length)
+    _maybe_add(artifact, "max_input_length", args.max_input_length)
+    _maybe_add(artifact, "text_encoder_dim", args.text_encoder_dim)
+    _maybe_add(artifact, "num_samples", args.num_samples)
+    _maybe_add(artifact, "num_sampling_steps", args.num_sampling_steps)
+    _maybe_add(artifact, "self_cond_cfg_scale", args.self_cond_cfg_scale)
+    _maybe_add(artifact, "cfg_scale", args.cfg_scale)
+    _maybe_add(artifact, "sde_gamma", args.sde_gamma)
+    _maybe_add(artifact, "seed", args.seed)
+
+    files: dict[str, str] = {}
+    for attr, key in (
+        ("initial_latents_raw", "initial_latents_raw"),
+        ("condition_latents_raw", "condition_latents_raw"),
+        ("condition_mask_raw", "condition_mask_raw"),
+        ("sampling_steps_raw", "sampling_steps_raw"),
+        ("sde_noise_raw", "sde_noise_raw"),
+        ("expected_generated_jsonl_path", "expected_generated_jsonl_path"),
+    ):
+        value = getattr(args, attr)
+        if value:
+            files[key] = _stored_path(value, artifact_path)
+    if files:
+        artifact["files"] = files
+
+    samples: list[dict[str, Any]] = []
+    if args.samples_jsonl:
+        samples.extend(_load_samples_jsonl(Path(args.samples_jsonl), artifact_path))
+    for spec in args.sample or []:
+        samples.append(_parse_sample_spec(spec, artifact_path))
+    if samples:
+        artifact["samples"] = samples
+        artifact["num_samples"] = len(samples)
+    return artifact
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, help="artifact JSON path to write")
+    parser.add_argument(
+        "--generation-mode",
+        choices=["unconditional", "conditional"],
+        default="unconditional",
+    )
+    parser.add_argument("--model-id", default="")
+    parser.add_argument("--variant", default="")
+    parser.add_argument("--max-length", type=int)
+    parser.add_argument("--max-input-length", type=int)
+    parser.add_argument("--text-encoder-dim", type=int)
+    parser.add_argument("--num-samples", type=int)
+    parser.add_argument("--num-sampling-steps", type=int)
+    parser.add_argument("--self-cond-cfg-scale", type=float)
+    parser.add_argument("--cfg-scale", type=float)
+    parser.add_argument("--sde-gamma", type=float)
+    parser.add_argument("--seed", type=int)
+    parser.add_argument("--initial-latents-raw", default="")
+    parser.add_argument("--condition-latents-raw", default="")
+    parser.add_argument("--condition-mask-raw", default="")
+    parser.add_argument("--sampling-steps-raw", default="")
+    parser.add_argument("--sde-noise-raw", default="")
+    parser.add_argument("--expected-generated-jsonl-path", default="")
+    parser.add_argument(
+        "--samples-jsonl",
+        default="",
+        help="JSONL with per-sample files such as initial_latents_raw and sde_noise_raw",
+    )
+    parser.add_argument(
+        "--sample",
+        action="append",
+        help="Per-sample key=value list, e.g. id=0,initial=init0.f32,sde=sde0.f32",
+    )
+    parser.add_argument(
+        "--no-validate",
+        action="store_true",
+        help="write artifact without running validate_elf_replay_artifact",
+    )
+    args = parser.parse_args()
+
+    artifact_path = Path(args.output).resolve()
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact = build_artifact(args)
+    artifact_path.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n",
+                             encoding="utf-8")
+    if not args.no_validate:
+        validate_artifact(artifact_path)
+    print(f"Wrote ELF replay artifact: {artifact_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/prepare_elf_model_dir.py
+++ b/tools/prepare_elf_model_dir.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Prepare a local GitHub ELF checkpoint directory for TRTMC build.
+
+Upstream ELF evaluates with separate ``--config`` and ``--checkpoint_path``
+arguments. TRTMC builds from one model directory, so this tool assembles a
+local directory containing the upstream YAML config, checkpoint files, and
+local tokenizer files without downloading anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+CHECKPOINT_NAMES = ("model.npz", "elf_params.npz")
+TOKENIZER_NAMES = (
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    "spiece.model",
+    "tokenizer.model",
+    "vocab.json",
+)
+ENCODER_CHECKPOINT_NAMES = (
+    "t5_small_encoder_jax.pkl",
+    "encoder_checkpoint.pkl",
+    "text_encoder.pkl",
+    "t5_encoder.pkl",
+)
+
+
+def _install_path(src: Path, dst: Path, *, copy: bool) -> None:
+    if dst.exists() or dst.is_symlink():
+        return
+    if copy:
+        if src.is_dir():
+            shutil.copytree(src, dst)
+        else:
+            shutil.copy2(src, dst)
+    else:
+        dst.symlink_to(src.resolve(), target_is_directory=src.is_dir())
+
+
+def _checkpoint_candidates(path: Path) -> list[Path]:
+    if path.is_file():
+        return [path]
+    if not path.is_dir():
+        raise FileNotFoundError(f"checkpoint path does not exist: {path}")
+    candidates: list[Path] = []
+    for name in CHECKPOINT_NAMES:
+        candidate = path / name
+        if candidate.exists():
+            candidates.append(candidate)
+    candidates.extend(sorted(path.glob("checkpoint_*")))
+    if not candidates:
+        raise FileNotFoundError(
+            f"no ELF checkpoint files found in {path}; expected checkpoint_*, "
+            "model.npz, or elf_params.npz"
+        )
+    return candidates
+
+
+def _install_tokenizer(tokenizer: Path | None, output_dir: Path, *, copy: bool) -> list[str]:
+    if tokenizer is None:
+        return []
+    if not tokenizer.exists():
+        raise FileNotFoundError(f"tokenizer path does not exist: {tokenizer}")
+    installed: list[str] = []
+    if tokenizer.is_file():
+        _install_path(tokenizer, output_dir / tokenizer.name, copy=copy)
+        return [tokenizer.name]
+    for name in TOKENIZER_NAMES:
+        src = tokenizer / name
+        if src.exists():
+            _install_path(src, output_dir / name, copy=copy)
+            installed.append(name)
+    for src in sorted(tokenizer.glob("*.spm")):
+        _install_path(src, output_dir / src.name, copy=copy)
+        installed.append(src.name)
+    return installed
+
+
+def _install_encoder_checkpoint(
+    checkpoint: Path | None, output_dir: Path, *, copy: bool
+) -> str:
+    if checkpoint is None:
+        return ""
+    if not checkpoint.exists() or not checkpoint.is_file():
+        raise FileNotFoundError(f"encoder checkpoint does not exist: {checkpoint}")
+    dst_name = (
+        checkpoint.name
+        if checkpoint.name in ENCODER_CHECKPOINT_NAMES
+        else "t5_small_encoder_jax.pkl"
+    )
+    _install_path(checkpoint, output_dir / dst_name, copy=copy)
+    return dst_name
+
+
+def prepare_model_dir(args: argparse.Namespace) -> dict[str, object]:
+    config = Path(args.config)
+    checkpoint_path = Path(args.checkpoint_path)
+    output_dir = Path(args.output)
+    if not config.exists():
+        raise FileNotFoundError(f"config file does not exist: {config}")
+    if output_dir.exists() and any(output_dir.iterdir()) and not args.force:
+        raise FileExistsError(f"output directory is not empty: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    config_name = config.name if config.suffix in {".yml", ".yaml"} else "config.yml"
+    _install_path(config, output_dir / config_name, copy=args.copy)
+
+    checkpoints = _checkpoint_candidates(checkpoint_path)
+    installed_checkpoints: list[str] = []
+    for src in checkpoints:
+        _install_path(src, output_dir / src.name, copy=args.copy)
+        installed_checkpoints.append(src.name)
+
+    tokenizer = Path(args.tokenizer) if args.tokenizer else None
+    installed_tokenizer = _install_tokenizer(tokenizer, output_dir, copy=args.copy)
+    encoder_checkpoint = Path(args.encoder_checkpoint) if args.encoder_checkpoint else None
+    installed_encoder = _install_encoder_checkpoint(
+        encoder_checkpoint, output_dir, copy=args.copy)
+
+    readme = output_dir / "README.trtmc.txt"
+    readme.write_text(
+        "\n".join(
+            [
+                "TRTMC GitHub ELF build directory",
+                "",
+                f"source_config: {config.resolve()}",
+                f"source_checkpoint_path: {checkpoint_path.resolve()}",
+                f"checkpoint_entries: {', '.join(installed_checkpoints)}",
+                f"tokenizer_entries: {', '.join(installed_tokenizer) or '(none)'}",
+                f"encoder_checkpoint: {installed_encoder or '(none)'}",
+                "",
+                "Build example:",
+                f"python -m tensorrt_model_connect.__main__ build {output_dir} "
+                "-o elf.trtfb --method trt",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "output_dir": str(output_dir),
+        "config": config_name,
+        "checkpoints": installed_checkpoints,
+        "tokenizer_files": installed_tokenizer,
+        "encoder_checkpoint": installed_encoder,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True, help="upstream train_*.yml config")
+    parser.add_argument("--checkpoint-path", required=True,
+                        help="upstream ELF checkpoint file or directory")
+    parser.add_argument("--tokenizer", default="",
+                        help="local tokenizer file/dir, ideally containing tokenizer.json")
+    parser.add_argument("--encoder-checkpoint", default="",
+                        help="official ELF JAX T5 encoder checkpoint .pkl")
+    parser.add_argument("--output", required=True, help="directory to create for TRTMC build")
+    parser.add_argument("--copy", action="store_true",
+                        help="copy files instead of creating symlinks")
+    parser.add_argument("--force", action="store_true",
+                        help="allow reusing a non-empty output directory")
+    args = parser.parse_args()
+
+    result = prepare_model_dir(args)
+    print(f"Prepared ELF model directory: {result['output_dir']}")
+    if not result["tokenizer_files"]:
+        print("Warning: no tokenizer files were installed; runtime text decode needs tokenizer.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -50,6 +50,7 @@ RUNTIME_TO_TASK_STRATEGY: Dict[str, str] = {
     "patchtsmixer_torchtrt": "neural_operator",
     "timesfm_torchtrt": "neural_operator",
     "chronos_bolt_torchtrt": "neural_operator",
+    "elf_flow": "diffusion_text_generation",
     "diffusion": "diffusion_media_generation",
     "diffusion_flux": "diffusion_media_generation",
     "diffusion_ltx": "diffusion_media_generation",
@@ -81,6 +82,8 @@ CPP_PLUGIN_STRATEGIES: Dict[str, List[str]] = {
     "patchtst_plugin": ["patchtst_torchtrt"],
     "patchtsmixer_plugin": ["patchtsmixer_torchtrt"],
     "timesfm_plugin": ["timesfm_torchtrt"],
+    "chronos_bolt_plugin": ["chronos_bolt_torchtrt"],
+    "elf_flow_plugin": ["elf_flow"],
     "segmentation_plugin": ["segmentation", "prompted_segmentation"],
     "object_detection_plugin": ["object_detection"],
     "omni_plugin": ["omni_multimodal"],
@@ -117,6 +120,8 @@ CPP_PIPELINE_STRATEGIES: Dict[str, List[str]] = {
     "patchtst_pipeline": ["patchtst_torchtrt"],
     "patchtsmixer_pipeline": ["patchtsmixer_torchtrt"],
     "timesfm_pipeline": ["timesfm_torchtrt"],
+    "chronos_bolt_pipeline": ["chronos_bolt_torchtrt"],
+    "elf_flow_pipeline": ["elf_flow"],
     "flux_pipeline": ["diffusion_flux"],
     "ltx_video_pipeline": ["diffusion_ltx"],
     "wan_pipeline": ["diffusion_wan"],
@@ -135,6 +140,7 @@ RUNNER_TASK_STRATEGIES: Dict[str, List[str]] = {
     "vision_language": ["vision_language_generation"],
     "audio_speech": ["speech_to_text", "text_to_audio", "speech_to_speech"],
     "diffusion": ["diffusion_media_generation"],
+    "diffusion_text_generation": ["diffusion_text_generation"],
     "segmentation": ["segmentation", "prompted_segmentation", "object_detection"],
     "embedding": ["embedding"],
     "reranking": ["reranking"],
@@ -155,6 +161,7 @@ COMPARATOR_TASK_STRATEGIES: Dict[str, List[str]] = {
     "reranking": ["reranking"],
     "segmentation": ["segmentation", "prompted_segmentation", "object_detection"],
     "diffusion": ["diffusion_media_generation"],
+    "diffusion_text_generation": ["diffusion_text_generation"],
     "omni": ["omni_multimodal"],
     "neural_operator": ["neural_operator"],
 }
@@ -167,6 +174,7 @@ PLUGIN_TASK_STRATEGIES: Dict[str, List[str]] = {
     "time_series_regression": ["neural_operator"],
     "time_series_classification": ["neural_operator"],
     "tts": ["text_to_audio"],
+    "elf_diffusion_text": ["diffusion_text_generation"],
 }
 
 # E2E reference filename (stem) -> task_strategies

--- a/tools/validate_elf_replay_artifact.py
+++ b/tools/validate_elf_replay_artifact.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Validate ELF upstream replay artifacts for C++ parity runs.
+
+The artifact is a JSON object consumed by the ``diffusion_text_generation``
+E2E runner. Paths under ``files`` are resolved relative to the artifact file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+FLOAT32_BYTES = 4
+FILE_KEYS = {
+    "initial_latents_raw",
+    "initial_latents_path",
+    "condition_latents_raw",
+    "condition_latents_path",
+    "condition_mask_raw",
+    "condition_mask_path",
+    "sampling_steps_raw",
+    "sampling_steps_path",
+    "sde_noise_raw",
+    "sde_noise_path",
+    "expected_generated_jsonl_path",
+    "expected_jsonl_path",
+}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"failed to read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ValueError("artifact must be a JSON object")
+    return raw
+
+
+def _artifact_files(raw: dict[str, Any]) -> dict[str, Any]:
+    files = raw.get("files", {})
+    if files is None:
+        files = {}
+    if not isinstance(files, dict):
+        raise ValueError("artifact field 'files' must be an object")
+    out = dict(files)
+    for key in FILE_KEYS:
+        if key in raw:
+            out[key] = raw[key]
+    return out
+
+
+def _sample_files(sample: dict[str, Any], global_files: dict[str, Any], idx: int) -> dict[str, Any]:
+    files = sample.get("files", {})
+    if files is None:
+        files = {}
+    if not isinstance(files, dict):
+        raise ValueError(f"sample {idx} field 'files' must be an object")
+    out = {**global_files, **files}
+    for key in FILE_KEYS:
+        if key in sample:
+            out[key] = sample[key]
+    return out
+
+
+def _path_for(files: dict[str, Any], artifact_path: Path, *keys: str) -> Path | None:
+    for key in keys:
+        value = files.get(key)
+        if isinstance(value, str) and value:
+            path = Path(value)
+            return path if path.is_absolute() else artifact_path.parent / path
+    return None
+
+
+def _float_count(path: Path) -> int:
+    if not path.exists():
+        raise ValueError(f"missing file: {path}")
+    size = path.stat().st_size
+    if size % FLOAT32_BYTES != 0:
+        raise ValueError(f"{path} size is not a multiple of float32")
+    return size // FLOAT32_BYTES
+
+
+def _validate_expected_samples(raw: dict[str, Any], expected_jsonl: Path | None) -> int:
+    if expected_jsonl is not None:
+        if not expected_jsonl.exists():
+            raise ValueError(f"missing expected JSONL: {expected_jsonl}")
+        lines = [line.strip() for line in expected_jsonl.read_text(encoding="utf-8").splitlines()]
+        samples: list[Any] = [json.loads(line) for line in lines if line]
+    else:
+        samples = raw.get("expected_generated_samples", [])
+        if not isinstance(samples, list):
+            raise ValueError("expected_generated_samples must be a list when present")
+
+    if not samples:
+        raise ValueError(
+            "artifact must provide expected_generated_jsonl_path/expected_jsonl_path "
+            "or expected_generated_samples")
+    for idx, sample in enumerate(samples):
+        if not isinstance(sample, dict):
+            raise ValueError(f"expected sample {idx} must be an object")
+        if not isinstance(sample.get("generated"), str):
+            raise ValueError(f"expected sample {idx} must contain generated string")
+        token_ids = sample.get("token_ids")
+        if not isinstance(token_ids, list) or not token_ids:
+            raise ValueError(f"expected sample {idx} must contain non-empty token_ids list")
+        try:
+            [int(token) for token in token_ids]
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"expected sample {idx} token_ids must be integers") from exc
+    return len(samples)
+
+
+def _validate_file_set(
+    path: Path,
+    raw: dict[str, Any],
+    files: dict[str, Any],
+    generation_mode: str,
+    *,
+    label: str,
+) -> dict[str, Any]:
+    initial = _path_for(files, path, "initial_latents_raw", "initial_latents_path")
+    steps = _path_for(files, path, "sampling_steps_raw", "sampling_steps_path")
+    sde_noise = _path_for(files, path, "sde_noise_raw", "sde_noise_path")
+    cond = _path_for(files, path, "condition_latents_raw", "condition_latents_path")
+    mask = _path_for(files, path, "condition_mask_raw", "condition_mask_path")
+
+    if initial is None:
+        raise ValueError(f"{label} must provide initial_latents_raw or initial_latents_path")
+    if steps is None:
+        raise ValueError(f"{label} must provide sampling_steps_raw or sampling_steps_path")
+    if generation_mode == "conditional" and (cond is None or mask is None):
+        raise ValueError(
+            f"conditional replay {label} requires condition_latents_raw/path "
+            "and condition_mask_raw/path")
+
+    initial_count = _float_count(initial)
+    step_count = _float_count(steps)
+    if step_count < 2:
+        raise ValueError("sampling steps must contain at least two float32 values")
+
+    max_length = int(raw.get("max_length", 0) or 0)
+    text_dim = int(raw.get("text_encoder_dim", raw.get("encoder_d_model", 0)) or 0)
+    latent_count = max_length * text_dim
+    if latent_count > 0 and initial_count != latent_count:
+        raise ValueError(
+            f"initial latents contain {initial_count} floats, expected {latent_count}")
+
+    cond_count = _float_count(cond) if cond is not None else 0
+    mask_count = _float_count(mask) if mask is not None else 0
+    if latent_count > 0 and cond is not None and cond_count != latent_count:
+        raise ValueError(
+            f"condition latents contain {cond_count} floats, expected {latent_count}")
+    if max_length > 0 and mask is not None and mask_count != max_length:
+        raise ValueError(f"condition mask contains {mask_count} floats, expected {max_length}")
+
+    sde_noise_count = _float_count(sde_noise) if sde_noise is not None else 0
+    if latent_count > 0 and sde_noise is not None:
+        expected_noise = max(0, step_count - 2) * latent_count
+        if sde_noise_count != expected_noise:
+            raise ValueError(
+                f"sde noise contains {sde_noise_count} floats, expected {expected_noise}")
+
+    resolved = {
+        "generation_mode": generation_mode,
+        "initial_latents": str(initial),
+        "sampling_steps": str(steps),
+        "condition_latents": str(cond) if cond is not None else "",
+        "condition_mask": str(mask) if mask is not None else "",
+        "sde_noise": str(sde_noise) if sde_noise is not None else "",
+        "initial_float_count": initial_count,
+        "sampling_step_count": step_count,
+    }
+    if cond is not None:
+        resolved["condition_latent_float_count"] = cond_count
+    if mask is not None:
+        resolved["condition_mask_float_count"] = mask_count
+    if sde_noise is not None:
+        resolved["sde_noise_float_count"] = sde_noise_count
+    return resolved
+
+
+def validate_artifact(path: Path) -> dict[str, Any]:
+    raw = _load_json(path)
+    files = _artifact_files(raw)
+    generation_mode = str(raw.get("generation_mode", "unconditional")).lower()
+    if generation_mode not in {"unconditional", "conditional"}:
+        raise ValueError("generation_mode must be unconditional or conditional")
+
+    expected_jsonl = _path_for(files, path, "expected_generated_jsonl_path", "expected_jsonl_path")
+    expected_samples = _validate_expected_samples(raw, expected_jsonl)
+    replay_samples = raw.get("samples")
+
+    if replay_samples is not None:
+        if not isinstance(replay_samples, list):
+            raise ValueError("artifact field 'samples' must be a list")
+        if not replay_samples:
+            raise ValueError("artifact field 'samples' must not be empty")
+        declared_samples = int(raw.get("num_samples", len(replay_samples)) or len(replay_samples))
+        if declared_samples != len(replay_samples):
+            raise ValueError(
+                f"num_samples is {declared_samples}, but samples contains "
+                f"{len(replay_samples)} entries")
+        if expected_samples != len(replay_samples):
+            raise ValueError(
+                f"expected sample count is {expected_samples}, but samples contains "
+                f"{len(replay_samples)} entries")
+        sample_summaries = []
+        for idx, sample in enumerate(replay_samples):
+            if not isinstance(sample, dict):
+                raise ValueError(f"sample {idx} must be an object")
+            sample_summaries.append(
+                _validate_file_set(
+                    path,
+                    raw,
+                    _sample_files(sample, files, idx),
+                    generation_mode,
+                    label=f"sample {idx}",
+                )
+            )
+        return {
+            "generation_mode": generation_mode,
+            "expected_jsonl": str(expected_jsonl) if expected_jsonl is not None else "",
+            "expected_sample_count": expected_samples,
+            "replay_sample_count": len(replay_samples),
+            "samples": sample_summaries,
+        }
+
+    declared_samples = int(raw.get("num_samples", 1) or 1)
+    if declared_samples > 1:
+        raise ValueError("multi-sample replay artifacts require a samples list")
+    resolved = _validate_file_set(path, raw, files, generation_mode, label="artifact")
+    if expected_samples != declared_samples:
+        raise ValueError(
+            f"expected sample count is {expected_samples}, but num_samples is {declared_samples}")
+    resolved["expected_jsonl"] = str(expected_jsonl) if expected_jsonl is not None else ""
+    resolved["expected_sample_count"] = expected_samples
+    return resolved
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("artifact", type=Path, help="ELF replay artifact JSON")
+    parser.add_argument("--json", action="store_true", help="print resolved schema as JSON")
+    args = parser.parse_args()
+
+    try:
+        resolved = validate_artifact(args.artifact)
+    except ValueError as exc:
+        print(f"ELF replay artifact invalid: {exc}")
+        return 1
+
+    if args.json:
+        print(json.dumps(resolved, indent=2, sort_keys=True))
+    else:
+        print(f"ELF replay artifact OK: {args.artifact}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Background
ELF generation is not autoregressive prompt continuation. The GitHub implementation samples text embeddings with a flow model, then decodes final embeddings to tokens; conditional models first encode the source text with the published JAX T5 encoder. This PR adds that model family as its own TRTMC plugin and keeps the raw API path available for exact upstream replay.

## Exit Criteria
- Build GitHub ELF checkpoints into a TRTMC bundle with the ELF denoiser/decoder engine.
- Support unconditional generation and conditional prompt generation through the bundled official T5 encoder plan.
- Keep ELF Flow ownership inside `families/elf_flow/`, including its config resolver, denoiser builder, plugin, and duplicated T5 encoder builder.
- Add L0 E2E contract coverage for ELF-B OWT, XSum, and WMT14 De-En.
- Prove parity against the upstream GitHub implementation for a controlled conditional replay.

## Implementation
- Added an `elf_flow` family package under `tensorrt_model_connect/tensorrt_model_connect/families/elf_flow/` with `plugin.py`, `config.py`, `builder.py`, and the family-owned `t5_encoder_builder.py`.
- Kept user-facing model matching on `model_type=elf` while recording the family as `elf_flow` in bundles and E2E manifests, matching the folder-based convention used by other families.
- Added an ELF-flow-owned T5-small encoder builder for the official `t5_small_encoder_jax.pkl` checkpoint and original non-gated T5 ReLU FFN.
- Restored the Flux T5 builder to Flux-owned gated T5 behavior, with no ELF JAX checkpoint loader or ELF-specific FFN switch.
- Added `ElfFlowPipeline` and `elf_flow` plugin wiring for denoise, decode, raw replay tensors, and prompt-to-condition preprocessing via `elf_text_encoder_plan`.
- Added diffusion-text E2E harness runner/comparator/plugin support plus L0 manifests for `elf-b-owt`, `elf-b-xsum`, and `elf-b-de-en`.
- Added local ELF prep/replay artifact tools so upstream-generated latents, timesteps, masks, and expected JSONL can be replayed by the C++ runtime.

## E2E Run Command
To run only the ELF L0 contract manifests locally after building `./build/trtmc`:

```bash
printf '%s\n' \
  elf-b-owt-l0 \
  elf-b-xsum-l0 \
  elf-b-de-en-l0 > /tmp/trtmc-elf-l0-models.txt

env -u HF_HUB_OFFLINE python scripts/warm_hf_cache.py \
  --models-file /tmp/trtmc-elf-l0-models.txt

HF_HUB_OFFLINE=1 ./scripts/run_e2e_parallel.sh \
  --engine-dir "${ENGINE_DIR:-/workspace/users/yifeif/tensorrt-model-connect/engines}" \
  --result-dir e2e_artifacts/elf-l0 \
  --trtmc-binary ./build/trtmc \
  --workers-per-gpu 4 \
  --models-file /tmp/trtmc-elf-l0-models.txt \
  --rebuild-engines
```

The same manifests are selected by PR impact analysis when `elf_flow` runtime/model files or the ELF diffusion-text harness change.

## Validation
- `git diff --check`: passed.
- `git diff --cached --check`: passed before amend.
- `ruff check --config ruff.toml tensorrt_model_connect/tensorrt_model_connect/families/elf_flow tests/builder/test_family_elf.py tests/tools/test_elf_diffusion_text_contract.py tests/builder/test_families.py`: passed.
- `PYTHONPATH=tensorrt_model_connect PYTHONPYCACHEPREFIX=/tmp/trtmc-pycache python3 -m compileall -q tensorrt_model_connect/tensorrt_model_connect/families/elf_flow tests/builder/test_family_elf.py tests/tools/test_elf_diffusion_text_contract.py tests/builder/test_families.py`: passed.
- `PYTHONPATH=tensorrt_model_connect PYTHONPYCACHEPREFIX=/tmp/trtmc-pycache python3 -m pytest tests/builder/test_family_elf.py tests/builder/test_engine_builder_extended.py tests/builder/test_families.py tests/tools/test_elf_diffusion_text_contract.py tests/tools/test_validate_elf_replay_artifact.py tests/tools/test_make_elf_replay_artifact.py tests/tools/test_prepare_elf_model_dir.py tests/tools/test_test_impact.py -q`: passed, 287 passed and 2 skipped.
- `PYTHONPATH=tensorrt_model_connect PYTHONPYCACHEPREFIX=/tmp/trtmc-pycache python3 -m pytest tests/builder/test_family_flux.py tests/builder/test_owned_qwen3_t5_helpers.py tests/builder/test_owned_encoder_builders_coverage.py -q`: passed, 22 passed.
- `docker exec trtmc-dev-gb300-agent-1 bash -lc 'cd /workspace/TensorRT-Model-Connect && cmake --build build-container-trt -j8 >/tmp/trtmc_build_after_rebase.log && ctest --test-dir build-container-trt --output-on-failure -R "test_elf_flow_pipeline|test_cli_args"'`: passed, 2 tests passed.
- Built `artifacts/elf/elf-b-de-en-128-t5.trtfb` from the official `ELF-B-de-en` checkpoint with the official JAX T5-small encoder plan; TensorRT build completed in 42.1s on GB300.
- Controlled upstream replay for `Ein kurzer deutscher Satz.` matched C++ raw condition replay and C++ prompt-conditioned replay exactly after normal EOS truncation: text match true, token ID match true.

## Notes For Future Readers
- L0 manifests are contract-only because the GitHub ELF checkpoints are not committed into the repo; local validation uses downloaded official artifacts and replay files under ignored `artifacts/`.
- Normal seeded sampling is stochastic and does not claim bit-for-bit parity with JAX RNG. Exact parity is proven by replaying upstream initial latents and timesteps through the raw API and prompt-conditioned C++ paths.
- Review order: start with `families/elf_flow/plugin.py`, `families/elf_flow/config.py`, `families/elf_flow/builder.py`, and `families/elf_flow/t5_encoder_builder.py`, then `src/runtime/models/elf_flow/pipeline.cpp`, then the diffusion-text E2E runner/manifests, then the replay tools/tests.
