### PR TITLE
Add timm ViT image classification support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ add_library(trtmc_core
   src/runtime/models/elf_flow/pipeline.cpp
   src/runtime/models/segmentation/segment_pipeline.cpp
   src/runtime/models/segmentation/sam_pipeline.cpp
+  src/runtime/models/timm_vit/pipeline.cpp
   src/runtime/models/vision_language/pipeline.cpp
   src/runtime/models/flux/pipeline.cpp
   src/runtime/models/ltx_video/pipeline.cpp

--- a/cmake/trtmc_pipeline_plugins.cmake
+++ b/cmake/trtmc_pipeline_plugins.cmake
@@ -20,6 +20,7 @@ set(TRTMC_PIPELINE_PLUGINS
   "models/chronos_bolt/plugin.cpp|register_chronos_bolt_plugin"
   "models/elf_flow/plugin.cpp|register_elf_flow_plugin"
   "models/segmentation/plugin.cpp|register_segmentation_plugin"
+  "models/timm_vit/plugin.cpp|register_timm_vit_plugin"
   "models/encoder/object_detection_plugin.cpp|register_object_detection_plugin"
   "models/vision_language/plugin.cpp|register_vl_plugin"
   "models/whisper/plugin.cpp|register_whisper_plugin"

--- a/examples/trtmc_cli.cpp
+++ b/examples/trtmc_cli.cpp
@@ -10,6 +10,7 @@
 //   trtmc transcribe      <bundle.trtfb> --audio FILE.wav [--max-new-tokens N] [--hf-python PATH]
 //   trtmc speak           <bundle.trtfb> --audio-in INPUT.wav --audio-out OUTPUT.wav
 //   trtmc generate-video  <bundle.trtfb> --prompt "text" --output DIR [--num-steps N]
+//   trtmc classify        <bundle.trtfb> --image PATH [--benchmark N] [--warmup N]
 //   trtmc inspect         <bundle.trtfb>
 //   trtmc version
 
@@ -178,6 +179,7 @@ void print_usage() {
            "  trtmc segment         <bundle.trtfb> --image PATH --output PATH [--hf-python PATH]\n"
            "  trtmc segment-sam     <bundle.trtfb> --image PATH --output DIR "
            "[--point-x F] [--point-y F] [--background] [--hf-python PATH]\n"
+           "  trtmc classify        <bundle.trtfb> --image PATH [--benchmark N] [--warmup N]\n"
            "  trtmc generate-audio  <bundle.trtfb> --prompt \"text\" --output PATH "
            "[--max-new-tokens N] [--hf-python PATH]\n"
            "  trtmc serve-audio     <bundle.trtfb> [--chunk-frames N] [--max-new-tokens N] "
@@ -224,10 +226,10 @@ CliArgs parse_args(int argc, char** argv) {
         return args;
     }
 
-    static const char* known_cmds[] = {"run",         "inspect",        "generate-video", "segment",
-                                       "segment-sam", "generate-audio", "serve-audio",    "encode",
-                                       "embed",       "rerank",         "solve",          "speak",
-                                       "transcribe",  nullptr};
+    static const char* known_cmds[] = {"run",         "inspect",    "generate-video", "segment",
+                                       "segment-sam", "classify",   "generate-audio", "serve-audio",
+                                       "encode",      "embed",      "rerank",         "solve",
+                                       "speak",       "transcribe", nullptr};
     bool valid = false;
     for (const char** p = known_cmds; *p; ++p)
         if (args.command == *p) {
@@ -914,6 +916,98 @@ int cmd_segment(const CliArgs& args) {
     return EXIT_SUCCESS;
 }
 
+std::vector<float> preprocess_classification_image(const trtmc::io::LoadedImage& image) {
+    constexpr int32_t target = 224;
+    constexpr float crop_pct = 0.9F;
+    const int32_t resize_short = static_cast<int32_t>(static_cast<float>(target) / crop_pct + 0.5F);
+    const float mean[3] = {0.5F, 0.5F, 0.5F};
+    const float stdv[3] = {0.5F, 0.5F, 0.5F};
+
+    int32_t resized_h = resize_short;
+    int32_t resized_w = resize_short;
+    if (image.height <= image.width) {
+        resized_h = resize_short;
+        resized_w =
+            std::max(1, static_cast<int32_t>(
+                            static_cast<float>(image.width) * resize_short / image.height + 0.5F));
+    } else {
+        resized_w = resize_short;
+        resized_h =
+            std::max(1, static_cast<int32_t>(
+                            static_cast<float>(image.height) * resize_short / image.width + 0.5F));
+    }
+
+    const int32_t crop_y = std::max(0, (resized_h - target) / 2);
+    const int32_t crop_x = std::max(0, (resized_w - target) / 2);
+    std::vector<float> chw(static_cast<std::size_t>(3) * target * target);
+
+    for (int32_t y = 0; y < target; ++y) {
+        const int32_t ry = crop_y + y;
+        const int32_t src_y =
+            std::min(image.height - 1,
+                     static_cast<int32_t>(static_cast<float>(ry) * image.height / resized_h));
+        for (int32_t x = 0; x < target; ++x) {
+            const int32_t rx = crop_x + x;
+            const int32_t src_x =
+                std::min(image.width - 1,
+                         static_cast<int32_t>(static_cast<float>(rx) * image.width / resized_w));
+            const auto src_idx = static_cast<std::size_t>((src_y * image.width + src_x) * 3);
+            for (int32_t c = 0; c < 3; ++c) {
+                const float val = (image.pixels[src_idx + c] - mean[c]) / stdv[c];
+                chw[static_cast<std::size_t>(c) * target * target +
+                    static_cast<std::size_t>(y) * target + x] = val;
+            }
+        }
+    }
+    return chw;
+}
+
+int cmd_classify(const CliArgs& args) {
+    if (args.bundle_path.empty() || args.image_path.empty()) {
+        std::cerr << "Error: classify requires bundle + --image\n";
+        return EXIT_FAILURE;
+    }
+
+    auto pipeline = trtmc::load(args.bundle_path, make_load_options(args));
+    auto image = trtmc::io::read_image(args.image_path);
+    if (image.empty()) {
+        std::cerr << "Error: failed to load image: " << args.image_path << '\n';
+        return EXIT_FAILURE;
+    }
+
+    auto chw_pixels = preprocess_classification_image(image);
+    constexpr int32_t target = 224;
+
+    trtmc::ClassificationResult result;
+    if (args.benchmark > 0) {
+        const int warmup_n = std::max(0, args.warmup);
+        const int bench_n = args.benchmark;
+        for (int i = 0; i < warmup_n; ++i)
+            result = pipeline->classify(chw_pixels.data(), target, target);
+
+        std::vector<double> times;
+        times.reserve(static_cast<std::size_t>(bench_n));
+        for (int i = 0; i < bench_n; ++i) {
+            const auto t0 = std::chrono::steady_clock::now();
+            result = pipeline->classify(chw_pixels.data(), target, target);
+            const auto t1 = std::chrono::steady_clock::now();
+            times.push_back(std::chrono::duration<double, std::milli>(t1 - t0).count());
+        }
+        const double mean = std::accumulate(times.begin(), times.end(), 0.0) /
+                            static_cast<double>(std::max(1, bench_n));
+        std::cerr << std::fixed << std::setprecision(6) << "[trtmc.benchmark] classify_ms=" << mean
+                  << " iterations=" << bench_n << " warmup=" << warmup_n << '\n';
+    } else {
+        result = pipeline->classify(chw_pixels.data(), target, target);
+    }
+
+    std::cout << "{"
+              << "\"top_class\":" << result.top_class << ","
+              << "\"top_score\":" << std::setprecision(8) << result.top_score << ","
+              << "\"num_classes\":" << result.logits.size() << "}\n";
+    return EXIT_SUCCESS;
+}
+
 int write_sam_overlay(const trtmc::PromptedSegmentationResult& result,
                       const trtmc::io::LoadedImage& image, const std::string& path) {
     if (result.num_masks <= 0 || result.height <= 0 || result.width <= 0 || result.masks.empty() ||
@@ -1412,6 +1506,8 @@ int main(int argc, char** argv) {
             return cmd_segment(args);
         if (args.command == "segment-sam")
             return cmd_segment_sam(args);
+        if (args.command == "classify")
+            return cmd_classify(args);
         if (args.command == "generate-audio")
             return cmd_generate_audio(args);
         if (args.command == "serve-audio")

--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -84,6 +84,12 @@ struct PromptedSegmentationResult {
     int32_t width{0};
 };
 
+struct ClassificationResult {
+    std::vector<float> logits; // [num_classes]
+    int32_t top_class{-1};
+    float top_score{0.0F};
+};
+
 struct TextEmbedding {
     std::vector<float> data;
     std::vector<int64_t> shape;
@@ -278,6 +284,14 @@ class IPipeline {
         (void)is_foreground;
         throw std::runtime_error(std::string(pipeline_type()) +
                                  " does not support segment_prompted()");
+    }
+
+    // -- Image classification --
+    virtual ClassificationResult classify(const float* pixels, int32_t height, int32_t width) {
+        (void)pixels;
+        (void)height;
+        (void)width;
+        throw std::runtime_error(std::string(pipeline_type()) + " does not support classify()");
     }
 
     // -- Encoder-only hidden states (BERT) --

--- a/src/runtime/models/timm_vit/MODEL.toml
+++ b/src/runtime/models/timm_vit/MODEL.toml
@@ -1,0 +1,1 @@
+runtime_strategies = ["image_classification"]

--- a/src/runtime/models/timm_vit/pipeline.cpp
+++ b/src/runtime/models/timm_vit/pipeline.cpp
@@ -1,0 +1,56 @@
+#include "runtime/models/timm_vit/pipeline.h"
+
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
+
+namespace trtmc {
+
+namespace {
+
+const Tensor* find_logits_output(const TensorMap& outputs) {
+    for (const auto& [name, tensor] : outputs) {
+        if (name.find("logits") != std::string::npos || outputs.size() == 1)
+            return &tensor;
+    }
+    return nullptr;
+}
+
+} // namespace
+
+ImageClassificationPipeline::ImageClassificationPipeline(std::unique_ptr<TrtModule> model,
+                                                         std::string model_id_str)
+    : model_(std::move(model)), model_id_(std::move(model_id_str)) {
+    if (!model_ || !model_->ok())
+        throw std::runtime_error("ImageClassificationPipeline: invalid model");
+}
+
+ClassificationResult ImageClassificationPipeline::classify(const float* pixels, int32_t height,
+                                                           int32_t width) {
+    Tensor img_t;
+    img_t.data = const_cast<float*>(pixels);
+    img_t.shape = {1, 3, height, width};
+    img_t.dtype = DType::kFloat32;
+
+    auto outputs = model_->forward({{"pixel_values", img_t}});
+    ClassificationResult result;
+
+    const Tensor* logits_tensor = find_logits_output(outputs);
+    if (!logits_tensor)
+        return result;
+
+    const auto n = logits_tensor->numel();
+    if (n <= 0)
+        return result;
+
+    result.logits.resize(static_cast<std::size_t>(n));
+    std::memcpy(result.logits.data(), logits_tensor->data,
+                static_cast<std::size_t>(n) * sizeof(float));
+
+    auto best = std::max_element(result.logits.begin(), result.logits.end());
+    result.top_class = static_cast<int32_t>(std::distance(result.logits.begin(), best));
+    result.top_score = (best == result.logits.end()) ? 0.0F : *best;
+    return result;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/timm_vit/pipeline.h
+++ b/src/runtime/models/timm_vit/pipeline.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "trtmc/pipeline.h"
+#include "trtmc/runtime/trt_module.h"
+
+#include <memory>
+#include <string>
+
+namespace trtmc {
+
+class ImageClassificationPipeline final : public IPipeline {
+  public:
+    explicit ImageClassificationPipeline(std::unique_ptr<TrtModule> model,
+                                         std::string model_id_str = "");
+
+    ClassificationResult classify(const float* pixels, int32_t height, int32_t width) override;
+
+    const char* model_id() const override { return model_id_.c_str(); }
+    const char* pipeline_type() const override { return "ImageClassificationPipeline"; }
+
+  private:
+    std::unique_ptr<TrtModule> model_;
+    std::string model_id_;
+};
+
+} // namespace trtmc

--- a/src/runtime/models/timm_vit/plugin.cpp
+++ b/src/runtime/models/timm_vit/plugin.cpp
@@ -1,0 +1,26 @@
+// TimmVitPlugin: handles timm ViT image-classification bundles.
+
+#include "runtime/models/timm_vit/pipeline.h"
+#include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/pipeline_registry.h"
+
+namespace trtmc {
+
+class TimmVitPlugin final : public IPipelinePlugin {
+  public:
+    std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
+        ModuleCreateOptions opts;
+        opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
+        opts.cuda_graphs = ctx.cuda_graphs;
+
+        auto loaded = load_trt_module_from_plan(
+            ctx.backend, find_section(ctx.bundle, "engine_plan"), "engine_plan", opts);
+        return std::make_unique<ImageClassificationPipeline>(std::move(loaded.module),
+                                                             ctx.bundle.info.model_id);
+    }
+};
+
+REGISTER_PIPELINE_PLUGIN_WITH_MANIFEST(register_timm_vit_plugin, TimmVitPlugin,
+                                       "image_classification");
+
+} // namespace trtmc

--- a/tensorrt_model_connect/tensorrt_model_connect/config.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/config.py
@@ -200,11 +200,16 @@ class ModelConfig:
                     rope_theta = 10000.0
         rope_theta = float(rope_theta)
 
+        architecture = d.get("architecture", "")
+        architectures = d.get("architectures", [])
+        if not architectures and architecture:
+            architectures = [architecture]
+
         return ModelConfig(
-            model_type=d.get("model_type", ""),
-            architectures=d.get("architectures", []),
+            model_type=d.get("model_type", "") or architecture,
+            architectures=architectures,
             vocab_size=d.get("vocab_size", 0),
-            hidden_size=hidden_size,
+            hidden_size=hidden_size or d.get("num_features", 0),
             intermediate_size=intermediate,
             num_hidden_layers=num_layers,
             num_attention_heads=num_heads,

--- a/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
@@ -888,7 +888,13 @@ def build_bundle(
     # slow tokenizer so the C++ runtime can always load via AutoTokenizer.
     # Skip for non-text models (segmentation, audio) that don't use tokenizers.
     runtime_strategy = getattr(plugin, "runtime_strategy", "")
-    if runtime_strategy not in ("segmentation", "neural_operator", "object_detection", "prompted_segmentation"):
+    if runtime_strategy not in (
+        "segmentation",
+        "neural_operator",
+        "object_detection",
+        "prompted_segmentation",
+        "image_classification",
+    ):
         tokenizer_json_t0 = time.monotonic()
         _ensure_tokenizer_json(model_dir_path)
         _add_build_timing(

--- a/tensorrt_model_connect/tensorrt_model_connect/families/timm_vit/__init__.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/timm_vit/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import sys
+import types
+
+from . import plugin as _plugin
+
+globals().update({
+    _name: _value
+    for _name, _value in vars(_plugin).items()
+    if not _name.startswith("__")
+})
+__all__ = [
+    _name for _name in globals()
+    if not _name.startswith("__") and _name != "_plugin"
+]
+
+
+class _FamilyModule(types.ModuleType):
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        if not name.startswith("__") and name != "_plugin":
+            setattr(_plugin, name, value)
+
+
+sys.modules[__name__].__class__ = _FamilyModule

--- a/tensorrt_model_connect/tensorrt_model_connect/families/timm_vit/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/timm_vit/plugin.py
@@ -1,0 +1,414 @@
+"""timm ViT image-classification family plugin.
+
+Supports fixed-size timm Vision Transformer classifiers stored in HF Hub
+format. The initial target is:
+  timm/vit_base_patch16_224.augreg_in21k_ft_in1k
+
+The builder constructs the classifier with TensorRT Network API calls rather
+than routing through ONNX.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+from tensorrt_model_connect import graph_ops, trt_compat
+
+from ...checkpoint_mapper import (
+    WeightDict,
+    _has_tensor,
+    _load_tensor,
+    _open_safetensors,
+    _target_np_dtype,
+    _transpose_2d,
+)
+from ...config import ModelConfig
+
+
+trt = trt_compat.get_trt()
+
+
+def _as_tuple2(value, default: int) -> tuple[int, int]:
+    if isinstance(value, (list, tuple)) and len(value) >= 2:
+        return int(value[0]), int(value[1])
+    if isinstance(value, int):
+        return value, value
+    return default, default
+
+
+def _resolve_vit_config(raw: dict) -> dict:
+    input_size = raw.get("input_size", [3, 224, 224])
+    if isinstance(input_size, int):
+        image_size_h, image_size_w = _as_tuple2(input_size, 224)
+    else:
+        image_size_h, image_size_w = _as_tuple2(input_size[-2:], 224)
+    patch_h, patch_w = _as_tuple2(raw.get("patch_size", 16), 16)
+    hidden = int(raw.get("embed_dim", raw.get("num_features", 768)))
+    depth = int(raw.get("depth", raw.get("num_hidden_layers", 12)))
+    heads = int(raw.get("num_heads", raw.get("num_attention_heads", 12)))
+    mlp_hidden = int(float(raw.get("mlp_ratio", 4.0)) * hidden)
+    return {
+        "image_size_h": image_size_h,
+        "image_size_w": image_size_w,
+        "patch_h": patch_h,
+        "patch_w": patch_w,
+        "hidden": hidden,
+        "depth": depth,
+        "heads": heads,
+        "mlp_hidden": int(raw.get("intermediate_size", mlp_hidden)),
+        "num_classes": int(raw.get("num_classes", 1000)),
+        "eps": float(raw.get("layer_norm_eps", raw.get("norm_eps", 1.0e-6))),
+    }
+
+
+class TimmVitPlugin:
+    name = "timm_vit"
+    runtime_strategy = "image_classification"
+
+    def matches(self, model_type: str) -> bool:
+        mt = (model_type or "").lower()
+        return mt.startswith("vit_") or mt in {"timm_vit", "vision_transformer"}
+
+    def load_weights(
+        self,
+        model_dir: str,
+        config: ModelConfig,
+        *,
+        precision: str = "fp32",
+    ) -> WeightDict:
+        readers = _open_safetensors(Path(model_dir))
+        raw = config.raw
+        vit_cfg = _resolve_vit_config(raw)
+        raw["_timm_vit_config"] = vit_cfg
+        target_dtype = _target_np_dtype(precision)
+
+        weights = WeightDict()
+        for key in (
+            "patch_embed.proj.weight",
+            "patch_embed.proj.bias",
+            "cls_token",
+            "pos_embed",
+            "norm.weight",
+            "norm.bias",
+            "head.weight",
+            "head.bias",
+        ):
+            if _has_tensor(readers, key):
+                weights[key] = _load_tensor(readers, key).astype(
+                    np.float32 if key.endswith(("bias", "weight")) and key.startswith("norm")
+                    else target_dtype
+                )
+
+        if "head.weight" not in weights:
+            raise KeyError("Tensor not found: head.weight")
+        if "head.bias" not in weights:
+            weights["head.bias"] = np.zeros(
+                int(weights["head.weight"].shape[0]), dtype=target_dtype)
+
+        depth = vit_cfg["depth"]
+        for layer_idx in range(depth):
+            prefix = f"blocks.{layer_idx}"
+            for key in (
+                "norm1.weight",
+                "norm1.bias",
+                "attn.qkv.weight",
+                "attn.qkv.bias",
+                "attn.proj.weight",
+                "attn.proj.bias",
+                "norm2.weight",
+                "norm2.bias",
+                "mlp.fc1.weight",
+                "mlp.fc1.bias",
+                "mlp.fc2.weight",
+                "mlp.fc2.bias",
+            ):
+                full_key = f"{prefix}.{key}"
+                arr = _load_tensor(readers, full_key)
+                if key.endswith("weight") and arr.ndim == 2:
+                    weights[full_key] = _transpose_2d(
+                        arr, full_key, precision=precision)
+                else:
+                    weights[full_key] = arr.astype(
+                        np.float32 if key.startswith("norm") else target_dtype)
+
+        return weights
+
+    def build_engine(
+        self,
+        config: ModelConfig,
+        weights: WeightDict,
+        max_cache_length: int,
+        *,
+        precision: str = "fp32",
+        quant_ctx=None,
+        verbose: bool = False,
+    ) -> bytes:
+        del max_cache_length, quant_ctx
+        if precision not in ("fp32",):
+            raise ValueError("timm_vit raw TRT path currently supports precision='fp32'")
+
+        vit_cfg = config.raw.get("_timm_vit_config") or _resolve_vit_config(config.raw)
+        image_h = vit_cfg["image_size_h"]
+        image_w = vit_cfg["image_size_w"]
+        patch_h = vit_cfg["patch_h"]
+        patch_w = vit_cfg["patch_w"]
+        hidden_size = vit_cfg["hidden"]
+        depth = vit_cfg["depth"]
+        num_heads = vit_cfg["heads"]
+        mlp_hidden = vit_cfg["mlp_hidden"]
+        num_classes = vit_cfg["num_classes"]
+        eps_val = vit_cfg["eps"]
+
+        if image_h % patch_h != 0 or image_w % patch_w != 0:
+            raise ValueError(
+                f"image_size {image_h}x{image_w} must be divisible by patch "
+                f"{patch_h}x{patch_w}"
+            )
+
+        grid_h = image_h // patch_h
+        grid_w = image_w // patch_w
+        num_patches = grid_h * grid_w
+        seq_len = num_patches + 1
+
+        if verbose:
+            print(
+                "[trtmc-build] timm_vit: "
+                f"image={image_h}x{image_w}, patch={patch_h}x{patch_w}, "
+                f"tokens={seq_len}, hidden={hidden_size}, layers={depth}, "
+                f"heads={num_heads}, classes={num_classes}",
+                file=sys.stderr,
+            )
+
+        logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+        builder = trt.Builder(logger)
+        network = builder.create_network(
+            trt_compat.network_creation_flags(
+                strongly_typed=True,
+                explicit_batch=True,
+            )
+        )
+        trt_config = builder.create_builder_config()
+        trt_config.avg_timing_iterations = 8
+        trt_config.max_aux_streams = 0
+        trt_config.set_flag(trt.BuilderFlag.DISABLE_TIMING_CACHE)
+        trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 4 << 30)
+
+        pixel_values = network.add_input(
+            "pixel_values", trt.float32, (1, 3, image_h, image_w))
+
+        patch = network.add_convolution_nd(
+            pixel_values,
+            num_output_maps=hidden_size,
+            kernel_shape=(patch_h, patch_w),
+            kernel=trt.Weights(np.ascontiguousarray(
+                weights["patch_embed.proj.weight"], dtype=np.float32)),
+            bias=trt.Weights(np.ascontiguousarray(
+                weights["patch_embed.proj.bias"], dtype=np.float32)),
+        )
+        patch.stride_nd = (patch_h, patch_w)
+
+        patches_nhwc = network.add_shuffle(patch.get_output(0))
+        patches_nhwc.first_transpose = (0, 2, 3, 1)
+        patches_nhwc.reshape_dims = (1, num_patches, hidden_size)
+        hidden = patches_nhwc.get_output(0)
+
+        cls_token = np.ascontiguousarray(
+            weights["cls_token"].reshape(1, 1, hidden_size), dtype=np.float32)
+        cls_const = graph_ops.add_constant(
+            network, (1, 1, hidden_size), cls_token, dtype=np.float32)
+        cat = network.add_concatenation([cls_const, hidden])
+        cat.axis = 1
+        hidden = cat.get_output(0)
+
+        pos_embed = np.ascontiguousarray(
+            weights["pos_embed"].reshape(1, seq_len, hidden_size), dtype=np.float32)
+        pos_const = graph_ops.add_constant(
+            network, (1, seq_len, hidden_size), pos_embed, dtype=np.float32)
+        hidden = network.add_elementwise(
+            hidden, pos_const, trt.ElementWiseOperation.SUM).get_output(0)
+
+        for layer_idx in range(depth):
+            prefix = f"blocks.{layer_idx}"
+            norm1 = graph_ops.add_layer_norm_native(
+                network,
+                hidden,
+                hidden_size,
+                weights[f"{prefix}.norm1.weight"].astype(np.float32),
+                weights[f"{prefix}.norm1.bias"].astype(np.float32),
+                eps_val,
+            )
+
+            qkv_w = weights[f"{prefix}.attn.qkv.weight"].astype(np.float32)
+            q_w, k_w, v_w = np.split(qkv_w, 3, axis=1)
+            qkv_b = weights.get(f"{prefix}.attn.qkv.bias")
+            q_b = k_b = v_b = None
+            if qkv_b is not None:
+                q_b, k_b, v_b = np.split(qkv_b.astype(np.float32), 3)
+
+            q = graph_ops.add_matmul_rhs_constant(
+                network,
+                norm1,
+                hidden_size,
+                hidden_size,
+                q_w,
+            )
+            k = graph_ops.add_matmul_rhs_constant(
+                network,
+                norm1,
+                hidden_size,
+                hidden_size,
+                k_w,
+            )
+            v = graph_ops.add_matmul_rhs_constant(
+                network,
+                norm1,
+                hidden_size,
+                hidden_size,
+                v_w,
+            )
+            if q_b is not None:
+                q = graph_ops.add_bias_sum(network, q, hidden_size, q_b)
+                k = graph_ops.add_bias_sum(network, k, hidden_size, k_b)
+                v = graph_ops.add_bias_sum(network, v, hidden_size, v_b)
+
+            head_dim = hidden_size // num_heads
+
+            def to_heads(x: trt.ITensor) -> trt.ITensor:
+                heads = network.add_shuffle(x)
+                heads.reshape_dims = (1, seq_len, num_heads, head_dim)
+                heads.second_transpose = trt.Permutation([0, 2, 1, 3])
+                return heads.get_output(0)
+
+            q = to_heads(q)
+            k = to_heads(k)
+            v = to_heads(v)
+            scale = graph_ops.add_constant(
+                network,
+                (1, 1, 1, 1),
+                np.array([[[[1.0 / np.sqrt(head_dim)]]]], dtype=np.float32),
+                dtype=np.float32,
+            )
+            q_scaled = network.add_elementwise(
+                q, scale, trt.ElementWiseOperation.PROD).get_output(0)
+            scores = network.add_matrix_multiply(
+                q_scaled,
+                trt.MatrixOperation.NONE,
+                k,
+                trt.MatrixOperation.TRANSPOSE,
+            )
+            probs = network.add_softmax(scores.get_output(0))
+            probs.axes = 1 << 3
+            context = network.add_matrix_multiply(
+                probs.get_output(0),
+                trt.MatrixOperation.NONE,
+                v,
+                trt.MatrixOperation.NONE,
+            )
+            attn_context = network.add_shuffle(context.get_output(0))
+            attn_context.first_transpose = trt.Permutation([0, 2, 1, 3])
+            attn_context.reshape_dims = (1, seq_len, hidden_size)
+            attn = graph_ops.add_matmul_rhs_constant(
+                network,
+                attn_context.get_output(0),
+                hidden_size,
+                hidden_size,
+                weights[f"{prefix}.attn.proj.weight"].astype(np.float32),
+            )
+            attn = graph_ops.add_bias_sum(
+                network,
+                attn,
+                hidden_size,
+                weights[f"{prefix}.attn.proj.bias"].astype(np.float32),
+            )
+            hidden = network.add_elementwise(
+                hidden, attn, trt.ElementWiseOperation.SUM).get_output(0)
+
+            norm2 = graph_ops.add_layer_norm_native(
+                network,
+                hidden,
+                hidden_size,
+                weights[f"{prefix}.norm2.weight"].astype(np.float32),
+                weights[f"{prefix}.norm2.bias"].astype(np.float32),
+                eps_val,
+            )
+            fc1 = graph_ops.add_matmul_rhs_constant(
+                network,
+                norm2,
+                hidden_size,
+                mlp_hidden,
+                weights[f"{prefix}.mlp.fc1.weight"].astype(np.float32),
+            )
+            fc1 = graph_ops.add_bias_sum(
+                network, fc1, mlp_hidden,
+                weights[f"{prefix}.mlp.fc1.bias"].astype(np.float32))
+            act = graph_ops.add_gelu_erf(network, fc1)
+            fc2 = graph_ops.add_matmul_rhs_constant(
+                network,
+                act,
+                mlp_hidden,
+                hidden_size,
+                weights[f"{prefix}.mlp.fc2.weight"].astype(np.float32),
+            )
+            fc2 = graph_ops.add_bias_sum(
+                network, fc2, hidden_size,
+                weights[f"{prefix}.mlp.fc2.bias"].astype(np.float32))
+            hidden = network.add_elementwise(
+                hidden, fc2, trt.ElementWiseOperation.SUM).get_output(0)
+
+        hidden = graph_ops.add_layer_norm_native(
+            network,
+            hidden,
+            hidden_size,
+            weights["norm.weight"].astype(np.float32),
+            weights["norm.bias"].astype(np.float32),
+            eps_val,
+        )
+        cls = network.add_slice(
+            hidden, start=(0, 0, 0), shape=(1, 1, hidden_size), stride=(1, 1, 1)
+        ).get_output(0)
+
+        logits = graph_ops.add_matmul_rhs_constant(
+            network,
+            cls,
+            hidden_size,
+            num_classes,
+            _transpose_2d(
+                weights["head.weight"].astype(np.float32),
+                "head.weight",
+            ),
+        )
+        logits = graph_ops.add_bias_sum(
+            network, logits, num_classes, weights["head.bias"].astype(np.float32))
+        flatten_logits = network.add_shuffle(logits)
+        flatten_logits.reshape_dims = (1, num_classes)
+        logits = flatten_logits.get_output(0)
+        logits.name = "logits"
+        network.mark_output(logits)
+
+        plan = builder.build_serialized_network(network, trt_config)
+        if plan is None:
+            raise RuntimeError("TensorRT timm_vit engine build failed")
+        return bytes(plan)
+
+    def get_bundle_config_overrides(self, config: ModelConfig) -> dict:
+        vit_cfg = config.raw.get("_timm_vit_config") or _resolve_vit_config(config.raw)
+        mean = config.raw.get("mean", [0.5, 0.5, 0.5])
+        std = config.raw.get("std", [0.5, 0.5, 0.5])
+        return {
+            "model_type": config.model_type,
+            "runtime_strategy": self.runtime_strategy,
+            "hidden_size": vit_cfg["hidden"],
+            "num_hidden_layers": vit_cfg["depth"],
+            "num_attention_heads": vit_cfg["heads"],
+            "input_image_h": vit_cfg["image_size_h"],
+            "input_image_w": vit_cfg["image_size_w"],
+            "num_classes": vit_cfg["num_classes"],
+            "image_mean": mean,
+            "image_std": std,
+            "crop_pct": float(config.raw.get("crop_pct", 0.9)),
+        }
+
+
+plugin = TimmVitPlugin()

--- a/tensorrt_model_connect/tensorrt_model_connect/graph_ops.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/graph_ops.py
@@ -58,7 +58,18 @@ def add_matmul_rhs_constant(
     dtype: np.dtype = np.float32,
 ) -> trt.ITensor:
     """Matrix multiply: lhs @ rhs_constant.  rhs is [lhs_width, rhs_width]."""
-    rhs = add_constant(network, (lhs_width, rhs_width), rhs_weights, dtype=dtype)
+    rank = len(tuple(lhs.shape))
+    rhs_shape = (
+        (lhs_width, rhs_width)
+        if rank <= 2
+        else (1,) * (rank - 2) + (lhs_width, rhs_width)
+    )
+    rhs = add_constant(
+        network,
+        rhs_shape,
+        np.asarray(rhs_weights).reshape(rhs_shape),
+        dtype=dtype,
+    )
     rhs = _cast_back_to_trt_dtype(network, rhs, lhs.dtype)
     mm = network.add_matrix_multiply(
         lhs, trt.MatrixOperation.NONE,
@@ -74,8 +85,11 @@ def add_bias_sum(
     bias: np.ndarray,
     dtype: np.dtype = np.float32,
 ) -> trt.ITensor:
-    """Element-wise add a [1, width] bias."""
-    bias_t = add_constant(network, (1, width), bias, dtype=dtype)
+    """Element-wise add a bias broadcast over all non-feature axes."""
+    rank = len(tuple(inp.shape))
+    bias_shape = (width,) if rank <= 1 else (1,) * (rank - 1) + (width,)
+    bias_t = add_constant(
+        network, bias_shape, np.asarray(bias).reshape(bias_shape), dtype=dtype)
     bias_t = _cast_back_to_trt_dtype(network, bias_t, inp.dtype)
     s = network.add_elementwise(inp, bias_t, trt.ElementWiseOperation.SUM)
     return _cast_back_to_trt_dtype(network, s.get_output(0), inp.dtype)
@@ -449,9 +463,11 @@ def add_gelu_new(
     fp16, runtime trt_dtype is bfloat16) or any other non-matching combo.
     """
     target_dtype = inp.dtype
+    const_shape = (1,) * max(1, len(tuple(inp.shape)))
 
     def _const(name, value):
-        c = add_constant(network, (1, 1), np.array([value], dtype=np.float32), dtype=dtype)
+        c = add_constant(
+            network, const_shape, np.array([value], dtype=np.float32), dtype=dtype)
         return _cast_back_to_trt_dtype(network, c, target_dtype)
 
     # x^3
@@ -499,9 +515,11 @@ def add_gelu_erf(
     documented on ``add_gelu_new``.
     """
     target_dtype = inp.dtype
+    const_shape = (1,) * max(1, len(tuple(inp.shape)))
 
     def _const(value):
-        c = add_constant(network, (1, 1), np.array([value], dtype=np.float32), dtype=dtype)
+        c = add_constant(
+            network, const_shape, np.array([value], dtype=np.float32), dtype=dtype)
         return _cast_back_to_trt_dtype(network, c, target_dtype)
 
     inv_sqrt2 = _const(1.0 / np.sqrt(2.0))
@@ -2062,14 +2080,19 @@ def add_layer_norm_native(
         eps:         Numerical stability epsilon (scalar, not a tensor).
         dtype:       Storage dtype for gamma/beta constants before TRT cast.
     """
-    gamma_t = add_constant(network, (1, hidden_size), gamma, dtype=dtype)
-    beta_t = add_constant(network, (1, hidden_size), beta, dtype=dtype)
+    rank = len(tuple(inp.shape))
+    param_shape = (
+        (hidden_size,) if rank <= 1 else (1,) * (rank - 1) + (hidden_size,)
+    )
+    gamma_t = add_constant(
+        network, param_shape, np.asarray(gamma).reshape(param_shape), dtype=dtype)
+    beta_t = add_constant(
+        network, param_shape, np.asarray(beta).reshape(param_shape), dtype=dtype)
     gamma_t = _cast_back_to_trt_dtype(network, gamma_t, inp.dtype)
     beta_t = _cast_back_to_trt_dtype(network, beta_t, inp.dtype)
-    # axesMask bit i selects axis i as a reduction axis.
-    # For a [..., H] tensor the hidden dim is the last axis.
-    # With rank-2 input [1, H], axis 1 → mask = 1 << 1 = 2.
-    norm = network.add_normalization_v2(inp, gamma_t, beta_t, 1 << 1)
+    # axesMask bit i selects axis i as a reduction axis. The normalized
+    # hidden dimension is always the last axis for [*, hidden_size] tensors.
+    norm = network.add_normalization_v2(inp, gamma_t, beta_t, 1 << (rank - 1))
     norm.epsilon = eps
     norm.compute_precision = trt.float32
     return norm.get_output(0)

--- a/tests/builder/test_families.py
+++ b/tests/builder/test_families.py
@@ -357,6 +357,9 @@ _POSITIVE_MATCH_CASES = [
     ("nemotron_hybrid", "nemotron_h"),
     # SAM (prompted segmentation)
     ("sam", "sam"),
+    # timm Vision Transformer (image classification)
+    ("vit_base_patch16_224", "timm_vit"),
+    ("timm_vit", "timm_vit"),
     # Phi-4 Multimodal
     ("phi4_multimodal", "phi4_multimodal"),
     # FLUX (diffusion T2I)

--- a/tests/builder/test_family_timm_vit.py
+++ b/tests/builder/test_family_timm_vit.py
@@ -1,0 +1,89 @@
+"""Tests for the timm ViT image-classification family plugin."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+try:
+    from safetensors.numpy import save_file
+    from tensorrt_model_connect.config import ModelConfig
+    from tensorrt_model_connect.families.timm_vit import plugin
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires TensorRT", allow_module_level=True)
+
+
+def _rand(*shape: int) -> np.ndarray:
+    return np.random.RandomState(7).randn(*shape).astype(np.float32)
+
+
+def _write_tiny_vit(tmp_path: Path) -> dict[str, np.ndarray]:
+    hidden = 8
+    mlp = 16
+    classes = 5
+    config = {
+        "architecture": "vit_base_patch16_224",
+        "input_size": [3, 224, 224],
+        "patch_size": 16,
+        "num_features": hidden,
+        "depth": 1,
+        "num_heads": 2,
+        "mlp_ratio": 2.0,
+        "num_classes": classes,
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    tensors = {
+        "patch_embed.proj.weight": _rand(hidden, 3, 16, 16),
+        "patch_embed.proj.bias": _rand(hidden),
+        "cls_token": _rand(1, 1, hidden),
+        "pos_embed": _rand(1, 197, hidden),
+        "blocks.0.norm1.weight": _rand(hidden),
+        "blocks.0.norm1.bias": _rand(hidden),
+        "blocks.0.attn.qkv.weight": _rand(3 * hidden, hidden),
+        "blocks.0.attn.qkv.bias": _rand(3 * hidden),
+        "blocks.0.attn.proj.weight": _rand(hidden, hidden),
+        "blocks.0.attn.proj.bias": _rand(hidden),
+        "blocks.0.norm2.weight": _rand(hidden),
+        "blocks.0.norm2.bias": _rand(hidden),
+        "blocks.0.mlp.fc1.weight": _rand(mlp, hidden),
+        "blocks.0.mlp.fc1.bias": _rand(mlp),
+        "blocks.0.mlp.fc2.weight": _rand(hidden, mlp),
+        "blocks.0.mlp.fc2.bias": _rand(hidden),
+        "norm.weight": _rand(hidden),
+        "norm.bias": _rand(hidden),
+        "head.weight": _rand(classes, hidden),
+        "head.bias": _rand(classes),
+    }
+    save_file(tensors, str(tmp_path / "model.safetensors"))
+    return tensors
+
+
+def test_model_config_uses_timm_architecture_when_model_type_absent(tmp_path: Path):
+    _write_tiny_vit(tmp_path)
+    cfg = ModelConfig.from_dir(tmp_path)
+
+    assert cfg.model_type == "vit_base_patch16_224"
+    assert cfg.hidden_size == 8
+    assert cfg.architectures == ["vit_base_patch16_224"]
+    assert plugin.matches(cfg.model_type)
+
+
+def test_load_weights_maps_timm_vit_shapes(tmp_path: Path):
+    raw = _write_tiny_vit(tmp_path)
+    cfg = ModelConfig.from_dir(tmp_path)
+
+    weights = plugin.load_weights(str(tmp_path), cfg)
+
+    assert weights["patch_embed.proj.weight"].shape == (8, 3, 16, 16)
+    assert weights["cls_token"].shape == (1, 1, 8)
+    assert weights["pos_embed"].shape == (1, 197, 8)
+    assert weights["blocks.0.attn.qkv.weight"].shape == (8, 24)
+    assert weights["blocks.0.mlp.fc1.weight"].shape == (8, 16)
+    assert weights["blocks.0.mlp.fc2.weight"].shape == (16, 8)
+    np.testing.assert_allclose(
+        weights["blocks.0.attn.qkv.weight"],
+        raw["blocks.0.attn.qkv.weight"].T,
+    )

--- a/tests/e2e/models/timm-vit-base-p16-224-augreg-in21k-ft-in1k.json
+++ b/tests/e2e/models/timm-vit-base-p16-224-augreg-in21k-ft-in1k.json
@@ -1,0 +1,19 @@
+{
+  "name": "timm-vit-base-p16-224-augreg-in21k-ft-in1k",
+  "trace_id": "IT-E2E-TIMM-VIT-01",
+  "hf_id": "timm/vit_base_patch16_224.augreg_in21k_ft_in1k",
+  "bundle": "timm-vit-base-p16-224-augreg-in21k-ft-in1k.trtfb",
+  "family": "timm_vit",
+  "runtime_strategy": "image_classification",
+  "task_strategy": "image_classification",
+  "reference_family": "image_classification",
+  "user_contract": "image_classification",
+  "test_type": "image_classification",
+  "max_cache_length": 1,
+  "prompt": "",
+  "max_new_tokens": 0,
+  "precision": "fp32",
+  "trust_remote_code": false,
+  "test_image": "data/test_img.jpeg",
+  "core": true
+}

--- a/tests/e2e_harness/comparators/image_classification.py
+++ b/tests/e2e_harness/comparators/image_classification.py
@@ -1,0 +1,77 @@
+"""Image-classification comparator."""
+
+from __future__ import annotations
+
+from ..contracts import (
+    CompareResult,
+    MetricResult,
+    StageOutput,
+    StageSpec,
+    StageStatus,
+    ThresholdProfile,
+)
+
+
+class ImageClassificationComparator:
+    @property
+    def task_strategy(self) -> str:
+        return "image_classification"
+
+    def compare(
+        self,
+        trt: StageOutput,
+        ref: StageOutput,
+        threshold: ThresholdProfile,
+        stage: StageSpec,
+    ) -> CompareResult:
+        metrics: dict[str, MetricResult] = {}
+
+        trt_top = trt.data.get("top_class")
+        ref_top = ref.data.get("top_class")
+        if trt_top is None:
+            return CompareResult(
+                stage_name=stage.name,
+                status=StageStatus.ERROR.value,
+                metrics=metrics,
+                message="TRT classification output missing top_class",
+            )
+        if ref_top is None:
+            return CompareResult(
+                stage_name=stage.name,
+                status=StageStatus.ERROR.value,
+                metrics=metrics,
+                message="Reference classification output missing top_class",
+            )
+
+        top1_match = int(trt_top) == int(ref_top)
+        metrics["top1_match"] = MetricResult(
+            value=1.0 if top1_match else 0.0,
+            threshold=1.0,
+            operator="==",
+            passed=top1_match,
+        )
+
+        if "top_score" in trt.data and "top_score" in ref.data:
+            diff = abs(float(trt.data["top_score"]) - float(ref.data["top_score"]))
+            score_atol = threshold.metrics.get("top_score_atol")
+            metrics["top_score_abs_diff"] = MetricResult(
+                value=diff,
+                threshold=score_atol,
+                operator="<=" if score_atol is not None else "informational",
+                passed=True if score_atol is None else diff <= score_atol,
+            )
+
+        passed = all(metric.passed for metric in metrics.values())
+        return CompareResult(
+            stage_name=stage.name,
+            status=StageStatus.PASSED.value if passed else StageStatus.FAILED.value,
+            metrics=metrics,
+            composite_rule="top-1 class must match",
+            message=(
+                f"Image classification: TRT top={int(trt_top)}, "
+                f"reference top={int(ref_top)}"
+            ),
+        )
+
+
+plugin = ImageClassificationComparator()

--- a/tests/e2e_harness/contracts.py
+++ b/tests/e2e_harness/contracts.py
@@ -115,6 +115,9 @@ class ReferenceFamily(enum.Enum):
     SEGMENTATION_SEGFORMER = "segmentation_segformer"
     PROMPTED_SEGMENTATION_SAM = "prompted_segmentation_sam"
 
+    # --- Image classification ---
+    IMAGE_CLASSIFICATION = "image_classification"
+
     # --- Diffusion ---
     DIFFUSERS_IMAGE_GEN = "diffusers_image_gen"
     DIFFUSERS_VIDEO_GEN = "diffusers_video_gen"
@@ -205,6 +208,7 @@ class UserContract(enum.Enum):
     SPEECH_RESPONSE = "speech_response"
     SEGMENTATION_MASK = "segmentation_mask"
     PROMPTED_MASK = "prompted_mask"
+    IMAGE_CLASSIFICATION = "image_classification"
     EMBEDDING_VECTOR = "embedding_vector"
     RANKING_ORDER = "ranking_order"
     VL_ANSWER = "vl_answer"
@@ -819,6 +823,8 @@ MODEL_REFERENCE_FAMILY: Dict[str, str] = {
     "segformer-b0-ade": ReferenceFamily.SEGMENTATION_SEGFORMER.value,
     # 5.24 PROMPTED_SEGMENTATION_SAM
     "sam-vit-base": ReferenceFamily.PROMPTED_SEGMENTATION_SAM.value,
+    # 5.24a IMAGE_CLASSIFICATION
+    "timm-vit-base-p16-224-augreg-in21k-ft-in1k": ReferenceFamily.IMAGE_CLASSIFICATION.value,
     # 5.25 DIFFUSERS_IMAGE_GEN
     "flux-schnell": ReferenceFamily.DIFFUSERS_IMAGE_GEN.value,
     "flux-2-dev": ReferenceFamily.DIFFUSERS_IMAGE_GEN.value,
@@ -867,6 +873,7 @@ REFERENCE_FAMILY_TO_USER_CONTRACT: Dict[str, str] = {
     ReferenceFamily.S2S_PERSONAPLEX.value: UserContract.SPEECH_RESPONSE.value,
     ReferenceFamily.SEGMENTATION_SEGFORMER.value: UserContract.SEGMENTATION_MASK.value,
     ReferenceFamily.PROMPTED_SEGMENTATION_SAM.value: UserContract.PROMPTED_MASK.value,
+    ReferenceFamily.IMAGE_CLASSIFICATION.value: UserContract.IMAGE_CLASSIFICATION.value,
     ReferenceFamily.DIFFUSERS_IMAGE_GEN.value: UserContract.DIFFUSION_IMAGE.value,
     ReferenceFamily.DIFFUSERS_VIDEO_GEN.value: UserContract.DIFFUSION_VIDEO.value,
     ReferenceFamily.ELF_UNCONDITIONAL_TEXT.value: UserContract.DIFFUSION_TEXT_GENERATION.value,
@@ -904,6 +911,7 @@ REFERENCE_FAMILY_TO_COMPARISON_MODE: Dict[str, str] = {
     ReferenceFamily.S2S_PERSONAPLEX.value: ComparisonMode.SEMANTIC_JUDGMENT.value,
     ReferenceFamily.SEGMENTATION_SEGFORMER.value: ComparisonMode.MASK_OVERLAP.value,
     ReferenceFamily.PROMPTED_SEGMENTATION_SAM.value: ComparisonMode.MASK_OVERLAP.value,
+    ReferenceFamily.IMAGE_CLASSIFICATION.value: ComparisonMode.NUMERIC_TENSOR.value,
     ReferenceFamily.DIFFUSERS_IMAGE_GEN.value: ComparisonMode.MEDIA_SIMILARITY.value,
     ReferenceFamily.DIFFUSERS_VIDEO_GEN.value: ComparisonMode.MEDIA_SIMILARITY.value,
     ReferenceFamily.ELF_UNCONDITIONAL_TEXT.value: ComparisonMode.TEXT_QUALITY_METRICS.value,
@@ -929,6 +937,7 @@ RUNTIME_TO_TASK_STRATEGY: Dict[str, str] = {
     "speech_to_speech": "speech_to_speech",
     "segmentation": "segmentation",
     "prompted_segmentation": "prompted_segmentation",
+    "image_classification": "image_classification",
     "object_detection": "object_detection",
     "embedding": "embedding",
     "reranking": "reranking",

--- a/tests/e2e_harness/manifest_loader.py
+++ b/tests/e2e_harness/manifest_loader.py
@@ -52,6 +52,7 @@ _DEFAULT_REFERENCE_BACKEND: dict[str, str] = {
     "speech_to_speech": "torch_reference",
     "segmentation": "hf_transformers",
     "prompted_segmentation": "hf_transformers",
+    "image_classification": "hf_transformers",
     "object_detection": "hf_transformers",
     "diffusion_media_generation": "hf_diffusers",
     "diffusion_text_generation": "invariant_only",
@@ -100,6 +101,9 @@ _DEFAULT_STAGES: dict[str, list[dict[str, Any]]] = {
         {"name": "full_inference", "required": True},
     ],
     "prompted_segmentation": [
+        {"name": "full_inference", "required": True},
+    ],
+    "image_classification": [
         {"name": "full_inference", "required": True},
     ],
     "object_detection": [
@@ -270,6 +274,13 @@ def _build_preflight(manifest: dict, task_strategy: str) -> list[PreflightRequir
         reqs.append(PreflightRequirement(
             kind="python_module_available",
             args={"module": "chronos", "phase": "build"},
+            gating=True,
+        ))
+
+    if task_strategy == "image_classification":
+        reqs.append(PreflightRequirement(
+            kind="python_module_available",
+            args={"module": "timm", "phase": "reference"},
             gating=True,
         ))
 
@@ -522,6 +533,7 @@ _KNOWN_RUNTIME_STRATEGIES = frozenset({
     "diffusion_pixart_torchtrt",
     "segmentation",
     "prompted_segmentation",
+    "image_classification",
     "encoder_only",
     "embedding",
     "reranking",

--- a/tests/e2e_harness/orchestrator.py
+++ b/tests/e2e_harness/orchestrator.py
@@ -85,6 +85,7 @@ _MIGRATED_RUNTIME_STRATEGIES = frozenset({
     "vision_language",
     "segmentation",
     "prompted_segmentation",
+    "image_classification",
     "object_detection",
     "neural_operator",
     "text_to_audio",
@@ -729,6 +730,11 @@ def _build_repro_commands(
                 ctx.binary_path, "segment", bundle_path,
                 "--image", str(image or ""),
                 "--output", "/tmp/trtmc_segmentation.png",
+            ]
+        elif task_strategy == "image_classification":
+            infer_parts = [
+                ctx.binary_path, "classify", bundle_path,
+                "--image", str(image or ""),
             ]
         else:
             infer_parts = [

--- a/tests/e2e_harness/references/hf_transformers.py
+++ b/tests/e2e_harness/references/hf_transformers.py
@@ -367,6 +367,8 @@ class HfTransformersReference:
             return self._run_speech_to_text_ref(case, stage, ctx)
         if task == "object_detection":
             return self._run_object_detection_ref(case, stage, ctx)
+        if task == "image_classification":
+            return self._run_image_classification_ref(case, stage, ctx)
         raise ValueError(
             f"full_inference not implemented for task_strategy={task!r}")
 
@@ -576,6 +578,114 @@ class HfTransformersReference:
         return StageOutput(
             stage_name=stage.name, data=data, timing_s=elapsed,
             metadata={"returncode": result.returncode})
+
+    def _run_image_classification_ref(
+        self, case: E2ECase, stage: StageSpec, ctx: RunContext
+    ) -> StageOutput:
+        """Run timm image classification as the reference oracle."""
+        artifacts_dir = ctx.artifacts_dir or tempfile.gettempdir()
+        model_dir = _case_artifact_dir(artifacts_dir, case.name) if ctx.artifacts_dir else artifacts_dir
+        output_path = str(Path(model_dir) / "hf_image_classification.json")
+
+        image_path = self._resolve_image_path(case.inputs.get("image", ""))
+        hf_id = case.hf_id
+
+        script = textwrap.dedent(f"""\
+            import json
+            from pathlib import Path
+
+            import numpy as np
+            import timm
+            import torch
+            from PIL import Image
+
+            hf_id = {hf_id!r}
+            image_path = {image_path!r}
+            output_path = {output_path!r}
+
+            target = 224
+            crop_pct = 0.9
+            resize_short = int(target / crop_pct + 0.5)
+            image = Image.open(image_path).convert("RGB")
+            width, height = image.size
+            if height <= width:
+                resized_h = resize_short
+                resized_w = max(1, int(width * resize_short / height + 0.5))
+            else:
+                resized_w = resize_short
+                resized_h = max(1, int(height * resize_short / width + 0.5))
+
+            image = image.resize((resized_w, resized_h), Image.Resampling.NEAREST)
+            left = max(0, (resized_w - target) // 2)
+            top = max(0, (resized_h - target) // 2)
+            image = image.crop((left, top, left + target, top + target))
+            arr = np.asarray(image, dtype=np.float32) / 255.0
+            arr = (arr - 0.5) / 0.5
+            chw = np.transpose(arr, (2, 0, 1))[None, ...].copy()
+
+            model_ref = f"hf-hub:{{hf_id}}"
+            try:
+                model = timm.create_model(model_ref, pretrained=True)
+            except Exception:
+                model = timm.create_model(f"hf_hub:{{hf_id}}", pretrained=True)
+            model.eval()
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            model.to(device)
+
+            with torch.no_grad():
+                tensor = torch.from_numpy(chw).to(device)
+                logits = model(tensor)[0].float().cpu().numpy()
+
+            top_class = int(np.argmax(logits))
+            result = {{
+                "top_class": top_class,
+                "top_score": float(logits[top_class]),
+                "num_classes": int(logits.shape[0]),
+            }}
+            Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+            with open(output_path, "w") as f:
+                json.dump(result, f)
+            print("OK")
+        """)
+
+        python = ctx.reference_python_path() or sys.executable
+        env = dict(os.environ)
+        if ctx.ld_library_path:
+            env["LD_LIBRARY_PATH"] = ctx.ld_library_path
+
+        t0 = time.monotonic()
+        result = subprocess.run(
+            [python, "-c", script],
+            capture_output=True, text=True, timeout=900, env=env,
+        )
+        elapsed = time.monotonic() - t0
+
+        if result.returncode != 0:
+            truncated, log_path = save_full_stderr(
+                result.stderr, ctx.artifacts_dir or "",
+                "hf_image_classification", case.name)
+            msg = (
+                f"HF image classification failed for {case.name} "
+                f"(rc={result.returncode}):\n{truncated}"
+            )
+            if log_path:
+                msg += f" (full stderr: {log_path})"
+            raise RuntimeError(msg)
+
+        data = {}
+        if Path(output_path).is_file():
+            data = json.loads(Path(output_path).read_text())
+
+        return StageOutput(
+            stage_name=stage.name,
+            data=data,
+            timing_s=elapsed,
+            metadata={
+                "returncode": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            },
+        )
 
     def _run_segmentation_ref(
         self, case: E2ECase, stage: StageSpec, ctx: RunContext

--- a/tests/e2e_harness/runners/image_classification.py
+++ b/tests/e2e_harness/runners/image_classification.py
@@ -1,0 +1,99 @@
+"""Image-classification strategy runner."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+
+from .. import save_full_stderr
+from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
+
+logger = logging.getLogger(__name__)
+PROJECT_DIR = Path(__file__).resolve().parents[3]
+
+
+class ImageClassificationRunner:
+    @property
+    def strategy_name(self) -> str:
+        return "image_classification"
+
+    def run_stage(
+        self,
+        case: E2ECase,
+        stage: StageSpec,
+        ctx: RunContext,
+    ) -> StageOutput:
+        bundle_path = os.path.join(ctx.engine_dir, case.bundle)
+        image_path = self._resolve_image_path(case, ctx)
+        cmd = [
+            ctx.binary_path,
+            "classify",
+            bundle_path,
+            "--image",
+            image_path or "",
+        ]
+        runtime_cli_python = ctx.runtime_cli_hf_python()
+        if runtime_cli_python:
+            cmd.extend(["--hf-python", runtime_cli_python])
+
+        env = dict(os.environ)
+        if ctx.ld_library_path:
+            env["LD_LIBRARY_PATH"] = ctx.ld_library_path
+
+        logger.info("Running image classification: %s", " ".join(cmd))
+        t0 = time.monotonic()
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, env=env, timeout=600)
+        elapsed = time.monotonic() - t0
+
+        if result.returncode != 0:
+            truncated, log_path = save_full_stderr(
+                result.stderr, ctx.artifacts_dir or "",
+                "image_classification", case.name)
+            msg = (
+                f"Image classification failed (rc={result.returncode}): "
+                f"{truncated}"
+            )
+            if log_path:
+                msg += f" (full stderr: {log_path})"
+            raise RuntimeError(msg)
+
+        try:
+            data = json.loads(result.stdout.strip())
+        except json.JSONDecodeError:
+            data = {"raw_output": result.stdout.strip()}
+
+        return StageOutput(
+            stage_name=stage.name,
+            data=data,
+            timing_s=elapsed,
+            metadata={
+                "command": cmd,
+                "returncode": result.returncode,
+                "stdout": result.stdout or "",
+                "stderr": result.stderr or "",
+            },
+        )
+
+    def _resolve_image_path(self, case: E2ECase, ctx: RunContext) -> str | None:
+        image = (
+            case.inputs.get("image") or case.inputs.get("test_image")
+            or case.inputs.get("image_path")
+        )
+        if not image:
+            return None
+        path = Path(image)
+        if path.is_absolute():
+            return str(path)
+        for base in (ctx.engine_dir, str(PROJECT_DIR), str(PROJECT_DIR / "tests" / "e2e")):
+            candidate = Path(base) / image
+            if candidate.is_file():
+                return str(candidate)
+        return str(path)
+
+
+plugin = ImageClassificationRunner()

--- a/tests/runtime_strategy_matrix.yaml
+++ b/tests/runtime_strategy_matrix.yaml
@@ -125,6 +125,14 @@
       "diff_framework_check_classes": [],
       "diff_framework_exemption": "No diff_framework check currently registers runtime_strategies=['prompted_segmentation']."
     },
+    "image_classification": {
+      "task_strategy": "image_classification",
+      "cli_commands": ["classify"],
+      "runner_class": "tests.e2e_harness.runners.image_classification.ImageClassificationRunner",
+      "comparator_class": "tests.e2e_harness.comparators.image_classification.ImageClassificationComparator",
+      "diff_framework_check_classes": [],
+      "diff_framework_exemption": "No diff_framework check currently registers runtime_strategies=['image_classification']."
+    },
     "reranking": {
       "task_strategy": "reranking",
       "cli_commands": ["rerank"],

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -41,6 +41,7 @@ RUNTIME_TO_TASK_STRATEGY: Dict[str, str] = {
     "speech_to_speech": "speech_to_speech",
     "segmentation": "segmentation",
     "prompted_segmentation": "prompted_segmentation",
+    "image_classification": "image_classification",
     "object_detection": "object_detection",
     "embedding": "embedding",
     "reranking": "reranking",
@@ -113,6 +114,7 @@ CPP_PIPELINE_STRATEGIES: Dict[str, List[str]] = {
     # Segmentation pipelines — separate files, not part of encoder_pipeline:
     "segment_pipeline": ["segmentation"],
     "sam_pipeline": ["prompted_segmentation"],
+    "image_classification_pipeline": ["image_classification"],
     "encoder_pipeline": [
         "encoder_only", "embedding", "reranking", "neural_operator",
         "object_detection",
@@ -141,6 +143,7 @@ RUNNER_TASK_STRATEGIES: Dict[str, List[str]] = {
     "audio_speech": ["speech_to_text", "text_to_audio", "speech_to_speech"],
     "diffusion": ["diffusion_media_generation"],
     "diffusion_text_generation": ["diffusion_text_generation"],
+    "image_classification": ["image_classification"],
     "segmentation": ["segmentation", "prompted_segmentation", "object_detection"],
     "embedding": ["embedding"],
     "reranking": ["reranking"],
@@ -160,6 +163,7 @@ COMPARATOR_TASK_STRATEGIES: Dict[str, List[str]] = {
     "embedding": ["embedding"],
     "reranking": ["reranking"],
     "segmentation": ["segmentation", "prompted_segmentation", "object_detection"],
+    "image_classification": ["image_classification"],
     "diffusion": ["diffusion_media_generation"],
     "diffusion_text_generation": ["diffusion_text_generation"],
     "omni": ["omni_multimodal"],
@@ -182,7 +186,8 @@ REFERENCE_TASK_STRATEGIES: Dict[str, List[str]] = {
     "hf_transformers": [
         "text_generation_causal", "vision_language_generation", "text_to_audio",
         "speech_to_text", "encoder_only_nlp", "embedding", "reranking",
-        "segmentation", "prompted_segmentation", "object_detection",
+        "segmentation", "prompted_segmentation", "image_classification",
+        "object_detection",
     ],
     "hf_diffusers": ["diffusion_media_generation"],
     "torch_reference": ["speech_to_speech", "omni_multimodal", "neural_operator"],

--- a/tools/test_impact_fallback_allowlist.txt
+++ b/tools/test_impact_fallback_allowlist.txt
@@ -70,6 +70,7 @@ harness_shared tests/e2e_harness/registry.py # shared E2E harness surface; broad
 harness_shared tests/e2e_harness/result_schema.py # shared E2E harness surface; broad E2E impact is intentional
 harness_shared tests/e2e_harness/runtime_config.py # shared E2E harness surface; broad E2E impact is intentional
 harness_shared tests/e2e_harness/thresholds/__init__.py # shared E2E harness surface; broad E2E impact is intentional
+harness_shared tests/e2e_harness/test_orchestrator_phases.py # shared E2E harness surface; broad E2E impact is intentional
 no_impact scripts/_build_fp8_onnx_monolithic.py # developer utility script; no CI test impact is intentional
 no_impact scripts/_inject_fp8_qdq_proto.py # developer utility script; no CI test impact is intentional
 no_impact scripts/_mk_fp8_bf16_bundle.py # developer utility script; no CI test impact is intentional
@@ -157,6 +158,7 @@ no_impact tools/diff_vl.py # developer utility script; no CI test impact is inte
 no_impact tools/diffusion_helpers.py # developer utility script; no CI test impact is intentional
 no_impact tools/evaluate_diffusion_vlm_similarity.py # developer utility script; no CI test impact is intentional
 no_impact tools/layer_profiler.py # developer utility script; no CI test impact is intentional
+no_impact tools/make_elf_replay_artifact.py # developer utility script; no CI test impact is intentional
 no_impact tools/nsys_to_layer_timing.py # developer utility script; no CI test impact is intentional
 no_impact tools/perf_compare.py # developer utility script; no CI test impact is intentional
 no_impact tools/perf_compare_all.py # developer utility script; no CI test impact is intentional
@@ -165,6 +167,7 @@ no_impact tools/perf_compare_torchtrt.py # developer utility script; no CI test 
 no_impact tools/perf_utils.py # developer utility script; no CI test impact is intentional
 no_impact tools/perfdb.py # developer utility script; no CI test impact is intentional
 no_impact tools/profile_report.py # developer utility script; no CI test impact is intentional
+no_impact tools/prepare_elf_model_dir.py # developer utility script; no CI test impact is intentional
 no_impact tools/sol_estimate.py # developer utility script; no CI test impact is intentional
 no_impact tools/test_graph_ops.py # developer utility script; no CI test impact is intentional
 no_impact tools/test_impact.py # developer utility script; no CI test impact is intentional
@@ -172,8 +175,10 @@ no_impact tools/test_impact_fallback_allowlist.txt # validation metadata; no CI 
 no_impact tools/test_runner_parity.py # developer utility script; no CI test impact is intentional
 no_impact tools/tool_helpers.py # developer utility script; no CI test impact is intentional
 no_impact tools/trtmc_profile.py # developer utility script; no CI test impact is intentional
+no_impact tools/validate_elf_replay_artifact.py # developer utility script; no CI test impact is intentional
 no_impact tools/validate_dit.py # developer utility script; no CI test impact is intentional
 no_impact tools/validate_t5.py # developer utility script; no CI test impact is intentional
+no_impact tools/validation/timm_vit/benchmark_trt_paths.py # developer validation helper; no CI test impact is intentional
 shared_builder_module tensorrt_model_connect/pyproject.toml # shared Python builder surface; broad builder impact is intentional
 shared_builder_module tensorrt_model_connect/tensorrt_model_connect/__init__.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module tensorrt_model_connect/tensorrt_model_connect/__main__.py # shared Python builder surface; broad builder impact is intentional

--- a/tools/validation/timm_vit/benchmark_trt_paths.py
+++ b/tools/validation/timm_vit/benchmark_trt_paths.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Compare raw TensorRT API and ONNX->trtexec engines for timm ViT.
+
+The raw API path uses TensorRT-Model-Connect's timm_vit family plugin.  The
+ONNX path exports the same timm PyTorch model, builds an engine with trtexec,
+and benchmarks both plans with identical input tensors via TensorRT Python.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+DEFAULT_MODEL_ID = "timm/vit_base_patch16_224.augreg_in21k_ft_in1k"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _find_trtexec(explicit: str | None) -> str:
+    candidates = []
+    if explicit:
+        candidates.append(explicit)
+    which = shutil.which("trtexec")
+    if which:
+        candidates.append(which)
+    candidates.extend([
+        "/usr/src/tensorrt/bin/trtexec",
+        "/opt/tensorrt/bin/trtexec",
+        "/usr/local/tensorrt/bin/trtexec",
+    ])
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file():
+            return candidate
+    raise FileNotFoundError(
+        "trtexec not found; pass --trtexec or add TensorRT's bin directory to PATH"
+    )
+
+
+def _create_timm_model(model_id: str):
+    import timm
+
+    try:
+        return timm.create_model(f"hf-hub:{model_id}", pretrained=True)
+    except Exception:
+        return timm.create_model(f"hf_hub:{model_id}", pretrained=True)
+
+
+def _build_api_engine(model_id: str, plan_path: Path, *, verbose: bool) -> None:
+    from tensorrt_model_connect.config import ModelConfig
+    from tensorrt_model_connect.engine_builder import _resolve_model
+    from tensorrt_model_connect.families import find_plugin
+
+    model_dir = Path(_resolve_model(model_id))
+    config = ModelConfig.from_dir(model_dir)
+    plugin = find_plugin(config.model_type)
+    if plugin is None or plugin.name != "timm_vit":
+        raise RuntimeError(
+            f"Expected timm_vit plugin for {config.model_type!r}, got {plugin}"
+        )
+
+    weights = plugin.load_weights(str(model_dir), config, precision="fp32")
+    plan = plugin.build_engine(
+        config,
+        weights,
+        max_cache_length=1,
+        precision="fp32",
+        verbose=verbose,
+    )
+    plan_path.write_bytes(plan)
+
+
+def _export_onnx(model_id: str, onnx_path: Path) -> None:
+    import torch
+
+    model = _create_timm_model(model_id)
+    model.eval()
+    dummy = torch.randn(1, 3, 224, 224, dtype=torch.float32)
+    torch.onnx.export(
+        model,
+        dummy,
+        str(onnx_path),
+        input_names=["pixel_values"],
+        output_names=["logits"],
+        opset_version=17,
+        do_constant_folding=True,
+        dynamo=False,
+    )
+
+
+def _build_trtexec_engine(
+    trtexec: str,
+    onnx_path: Path,
+    plan_path: Path,
+    log_path: Path,
+) -> None:
+    cmd = [
+        trtexec,
+        f"--onnx={onnx_path}",
+        f"--saveEngine={plan_path}",
+        "--skipInference",
+    ]
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, timeout=1800)
+    log_path.write_text(
+        "COMMAND: " + " ".join(cmd) + "\n\nSTDOUT:\n" + result.stdout +
+        "\n\nSTDERR:\n" + result.stderr,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"trtexec failed with rc={result.returncode}; see {log_path}")
+
+
+_TRTEXEC_TIMING_RE = re.compile(
+    r"GPU Compute Time: min = (?P<min>[0-9.]+) ms, max = (?P<max>[0-9.]+) ms, "
+    r"mean = (?P<mean>[0-9.]+) ms, median = (?P<median>[0-9.]+) ms"
+)
+
+
+def _benchmark_plan_with_trtexec(
+    trtexec: str,
+    plan_path: Path,
+    log_path: Path,
+    *,
+    warmup: int,
+    iterations: int,
+) -> dict[str, Any]:
+    cmd = [
+        trtexec,
+        f"--loadEngine={plan_path}",
+        f"--warmUp={max(200, warmup)}",
+        "--duration=0",
+        f"--iterations={iterations}",
+        "--noDataTransfers",
+    ]
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, timeout=1800)
+    log_path.write_text(
+        "COMMAND: " + " ".join(cmd) + "\n\nSTDOUT:\n" + result.stdout +
+        "\n\nSTDERR:\n" + result.stderr,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"trtexec benchmark failed with rc={result.returncode}; see {log_path}")
+    matches = list(_TRTEXEC_TIMING_RE.finditer(result.stdout + "\n" + result.stderr))
+    if not matches:
+        raise RuntimeError(f"Could not parse trtexec GPU timing from {log_path}")
+    timing = matches[-1].groupdict()
+    return {
+        "mean_ms": float(timing["mean"]),
+        "median_ms": float(timing["median"]),
+        "stdev_ms": None,
+        "min_ms": float(timing["min"]),
+        "max_ms": float(timing["max"]),
+        "iterations": iterations,
+        "warmup": max(200, warmup),
+        "log": str(log_path),
+    }
+
+
+def _input_from_image(image_path: Path) -> np.ndarray:
+    from PIL import Image
+
+    target = 224
+    crop_pct = 0.9
+    resize_short = int(target / crop_pct + 0.5)
+    image = Image.open(image_path).convert("RGB")
+    width, height = image.size
+    if height <= width:
+        resized_h = resize_short
+        resized_w = max(1, int(width * resize_short / height + 0.5))
+    else:
+        resized_w = resize_short
+        resized_h = max(1, int(height * resize_short / width + 0.5))
+    image = image.resize((resized_w, resized_h), Image.Resampling.NEAREST)
+    left = max(0, (resized_w - target) // 2)
+    top = max(0, (resized_h - target) // 2)
+    image = image.crop((left, top, left + target, top + target))
+    arr = np.asarray(image, dtype=np.float32) / 255.0
+    arr = (arr - 0.5) / 0.5
+    return np.transpose(arr, (2, 0, 1))[None, ...].copy()
+
+
+def _make_input(seed: int, image: str | None) -> np.ndarray:
+    if image:
+        return _input_from_image(Path(image))
+    rng = np.random.default_rng(seed)
+    return rng.normal(0.0, 1.0, size=(1, 3, 224, 224)).astype(np.float32)
+
+
+def _torch_dtype_for_trt(trt_dtype):
+    import tensorrt as trt
+    import torch
+
+    mapping = {
+        trt.float32: torch.float32,
+        trt.float16: torch.float16,
+        trt.int32: torch.int32,
+        trt.bool: torch.bool,
+    }
+    if hasattr(trt, "bfloat16"):
+        mapping[trt.bfloat16] = torch.bfloat16
+    if hasattr(trt, "int64"):
+        mapping[trt.int64] = torch.int64
+    return mapping[trt_dtype]
+
+
+def _load_engine(plan_path: Path):
+    import tensorrt as trt
+
+    logger = trt.Logger(trt.Logger.WARNING)
+    runtime = trt.Runtime(logger)
+    engine = runtime.deserialize_cuda_engine(plan_path.read_bytes())
+    if engine is None:
+        raise RuntimeError(f"Failed to deserialize {plan_path}")
+    return engine
+
+
+def _prepare_context(plan_path: Path, input_np: np.ndarray):
+    import tensorrt as trt
+    import torch
+
+    engine = _load_engine(plan_path)
+    context = engine.create_execution_context()
+    tensors: dict[str, Any] = {}
+    outputs: dict[str, Any] = {}
+
+    for idx in range(engine.num_io_tensors):
+        name = engine.get_tensor_name(idx)
+        mode = engine.get_tensor_mode(name)
+        if mode == trt.TensorIOMode.INPUT:
+            if hasattr(context, "set_input_shape"):
+                context.set_input_shape(name, tuple(input_np.shape))
+            tensor = torch.as_tensor(input_np, device="cuda").contiguous()
+        else:
+            shape = tuple(int(dim) for dim in context.get_tensor_shape(name))
+            dtype = _torch_dtype_for_trt(engine.get_tensor_dtype(name))
+            tensor = torch.empty(shape, dtype=dtype, device="cuda")
+            outputs[name] = tensor
+        tensors[name] = tensor
+        context.set_tensor_address(name, int(tensor.data_ptr()))
+
+    return engine, context, tensors, outputs
+
+
+def _run_once(context, outputs: dict[str, Any], stream) -> np.ndarray:
+    import torch
+
+    with torch.cuda.stream(stream):
+        context.execute_async_v3(stream_handle=stream.cuda_stream)
+    torch.cuda.synchronize()
+    if "logits" in outputs:
+        out = outputs["logits"]
+    else:
+        out = next(iter(outputs.values()))
+    return out.detach().float().cpu().numpy().reshape(-1)
+
+
+def _benchmark_plan(
+    plan_path: Path,
+    input_np: np.ndarray,
+    *,
+    warmup: int,
+    iterations: int,
+) -> dict[str, Any]:
+    import torch
+
+    _engine, context, _tensors, outputs = _prepare_context(plan_path, input_np)
+    stream = torch.cuda.Stream()
+    for _ in range(warmup):
+        with torch.cuda.stream(stream):
+            context.execute_async_v3(stream_handle=stream.cuda_stream)
+    torch.cuda.synchronize()
+
+    times_ms: list[float] = []
+    for _ in range(iterations):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        with torch.cuda.stream(stream):
+            start.record(stream)
+            context.execute_async_v3(stream_handle=stream.cuda_stream)
+            end.record(stream)
+        torch.cuda.synchronize()
+        times_ms.append(float(start.elapsed_time(end)))
+
+    logits = _run_once(context, outputs, stream)
+    return {
+        "mean_ms": float(statistics.fmean(times_ms)),
+        "median_ms": float(statistics.median(times_ms)),
+        "stdev_ms": float(statistics.pstdev(times_ms)),
+        "min_ms": float(min(times_ms)),
+        "max_ms": float(max(times_ms)),
+        "iterations": iterations,
+        "warmup": warmup,
+        "logits": logits,
+    }
+
+
+def _summarize(
+    api: dict[str, Any],
+    onnx: dict[str, Any],
+    *,
+    max_ratio: float,
+    max_abs_diff: float,
+) -> dict[str, Any]:
+    api_logits = api.pop("logits")
+    onnx_logits = onnx.pop("logits")
+    abs_diff = np.abs(api_logits - onnx_logits)
+    top_api = int(np.argmax(api_logits))
+    top_onnx = int(np.argmax(onnx_logits))
+    api_over_onnx = api["mean_ms"] / onnx["mean_ms"]
+    symmetric_ratio = (
+        max(api["mean_ms"], onnx["mean_ms"]) / min(api["mean_ms"], onnx["mean_ms"])
+    )
+    return {
+        "api_engine": api,
+        "onnx_trtexec_engine": onnx,
+        "api_over_onnx_ratio": float(api_over_onnx),
+        "perf_ratio_max_over_min": float(symmetric_ratio),
+        "perf_within_threshold": bool(api_over_onnx <= max_ratio),
+        "max_allowed_perf_ratio": max_ratio,
+        "output": {
+            "max_abs_diff": float(abs_diff.max()),
+            "mean_abs_diff": float(abs_diff.mean()),
+            "top1_api": top_api,
+            "top1_onnx_trtexec": top_onnx,
+            "top1_match": top_api == top_onnx,
+            "max_allowed_abs_diff": max_abs_diff,
+            "within_threshold": bool(abs_diff.max() <= max_abs_diff),
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-id", default=DEFAULT_MODEL_ID)
+    parser.add_argument(
+        "--out-dir",
+        default=str(_repo_root() / "artifacts" / "timm_vit_trt_path_comparison"),
+    )
+    parser.add_argument("--trtexec", default=None)
+    parser.add_argument("--image", default=None)
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--max-ratio", type=float, default=1.05)
+    parser.add_argument("--max-abs-diff", type=float, default=0.05)
+    parser.add_argument(
+        "--perf-runner",
+        choices=("trtexec", "python"),
+        default="trtexec",
+        help=(
+            "Use direct trtexec GPU Compute Time for the performance gate "
+            "or Python CUDA events. Python is still used for correctness."
+        ),
+    )
+    parser.add_argument("--rebuild", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    api_plan = out_dir / "api.plan"
+    onnx_path = out_dir / "model.onnx"
+    onnx_plan = out_dir / "onnx_trtexec.plan"
+    trtexec_log = out_dir / "trtexec.log"
+    result_path = out_dir / "result.json"
+
+    trtexec = _find_trtexec(args.trtexec)
+
+    t0 = time.monotonic()
+    if args.rebuild or not api_plan.is_file():
+        _build_api_engine(args.model_id, api_plan, verbose=args.verbose)
+    if args.rebuild or not onnx_path.is_file():
+        _export_onnx(args.model_id, onnx_path)
+    if args.rebuild or not onnx_plan.is_file():
+        _build_trtexec_engine(trtexec, onnx_path, onnx_plan, trtexec_log)
+
+    input_np = _make_input(args.seed, args.image)
+    api_python = _benchmark_plan(
+        api_plan, input_np, warmup=args.warmup, iterations=args.iterations)
+    onnx_python = _benchmark_plan(
+        onnx_plan, input_np, warmup=args.warmup, iterations=args.iterations)
+    if args.perf_runner == "trtexec":
+        api_perf = _benchmark_plan_with_trtexec(
+            trtexec,
+            api_plan,
+            out_dir / "trtexec_api_bench.log",
+            warmup=args.warmup,
+            iterations=args.iterations,
+        )
+        onnx_perf = _benchmark_plan_with_trtexec(
+            trtexec,
+            onnx_plan,
+            out_dir / "trtexec_onnx_bench.log",
+            warmup=args.warmup,
+            iterations=args.iterations,
+        )
+        api = {**api_perf, "logits": api_python["logits"]}
+        onnx = {**onnx_perf, "logits": onnx_python["logits"]}
+    else:
+        api = api_python.copy()
+        onnx = onnx_python.copy()
+    summary = _summarize(
+        api, onnx, max_ratio=args.max_ratio, max_abs_diff=args.max_abs_diff)
+    summary["perf_runner"] = args.perf_runner
+    summary["python_api_engine"] = {
+        key: value for key, value in api_python.items() if key != "logits"}
+    summary["python_onnx_trtexec_engine"] = {
+        key: value for key, value in onnx_python.items() if key != "logits"}
+    summary.update({
+        "model_id": args.model_id,
+        "api_plan": str(api_plan),
+        "onnx_path": str(onnx_path),
+        "onnx_trtexec_plan": str(onnx_plan),
+        "trtexec": trtexec,
+        "trtexec_log": str(trtexec_log),
+        "input": {"image": args.image, "seed": args.seed},
+        "total_elapsed_s": time.monotonic() - t0,
+    })
+    result_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    print(
+        "api_mean_ms={api:.6f} onnx_trtexec_mean_ms={onnx:.6f} "
+        "api_over_onnx={ratio:.6f} top1_match={top1} max_abs_diff={diff:.6g} "
+        "result={result}".format(
+            api=summary["api_engine"]["mean_ms"],
+            onnx=summary["onnx_trtexec_engine"]["mean_ms"],
+            ratio=summary["api_over_onnx_ratio"],
+            top1=summary["output"]["top1_match"],
+            diff=summary["output"]["max_abs_diff"],
+            result=result_path,
+        )
+    )
+    if not summary["perf_within_threshold"]:
+        return 2
+    if not summary["output"]["top1_match"] or not summary["output"]["within_threshold"]:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add a `timm_vit` family package for `timm/vit_base_patch16_224.augreg_in21k_ft_in1k` using raw TensorRT Network API construction.
- Add a dedicated `src/runtime/models/timm_vit/` runtime model plugin and pipeline for image classification.
- Add image-classification CLI, E2E harness runner/comparator/reference support, and focused builder coverage.
- Keep the ViT API-vs-ONNX TensorRT benchmark under `tools/validation/timm_vit/`.

## Validation
- `python3 tools/test_impact.py --validate`: validation passed.
- Host direct lint: `ruff check --config ruff.toml ...` on changed Python files: passed.
- Host direct format: `clang-format --dry-run --Werror ...` on changed C++ files: passed.
- `python3 -m py_compile tensorrt_model_connect/tensorrt_model_connect/families/timm_vit/__init__.py tensorrt_model_connect/tensorrt_model_connect/families/timm_vit/plugin.py tools/validation/timm_vit/benchmark_trt_paths.py tools/test_impact.py`: passed.
- Agent-2 container: `ruff check --config ruff.toml ...` on changed Python files: passed.
- Agent-2 container: `clang-format --dry-run --Werror ...` on changed C++ files: passed.
- Agent-2 container: `bash .github/scripts/run-trtmc-ci.sh build`: passed.
- Agent-2 container: `python -m pytest tests/builder/test_families.py tests/builder/test_family_timm_vit.py -v -n auto`: `141 passed`.
- Agent-2 container: `ctest --test-dir build --output-on-failure`: `91/91` tests passed.
- Prior strict perf gate for the same ViT API path: `CUDA_VISIBLE_DEVICES=0 PYTHONPATH=tensorrt_model_connect:. python tools/validation/timm_vit/benchmark_trt_paths.py --out-dir artifacts/timm_vit_strict_final_trtexec_gate --iterations 1000 --warmup 200 --max-ratio 1.0 --max-abs-diff 0.05 --rebuild`: `api_mean_ms=0.859343`, `onnx_trtexec_mean_ms=0.867429`, `api_over_onnx=0.990678`, `top1_match=True`, `max_abs_diff=0.00152111`.
