### PR TITLE
Remove root builder compatibility shims

### DIFF
--- a/tensorrt_model_connect/tensorrt_model_connect/causal_vae_3d_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/causal_vae_3d_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the wan_t2v family-owned causal_vae_3d_builder implementation."""
-
-import sys as _sys
-
-from .families.wan_t2v import causal_vae_3d_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/clip_encoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/clip_encoder_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the flux family-owned clip_encoder_builder implementation."""
-
-import sys as _sys
-
-from .families.flux import clip_encoder_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/convbert_encoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/convbert_encoder_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the ConvBERT family-owned builder."""
-
-import sys as _sys
-
-from .families.convbert import builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/dual_profile_decoder_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the llama family-owned dual_profile_decoder_builder implementation."""
-
-import sys as _sys
-
-from .families.llama import dual_profile_decoder_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/encodec_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/encodec_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the bark family-owned encodec_builder implementation."""
-
-import sys as _sys
-
-from .families.bark import encodec_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/encoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/encoder_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the bert family-owned encoder_builder implementation."""
-
-import sys as _sys
-
-from .families.bert import encoder_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/flux2_dit_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/flux2_dit_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the flux family-owned flux2_dit_builder implementation."""
-
-import sys as _sys
-
-from .families.flux import flux2_dit_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/flux_dit_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/flux_dit_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the flux family-owned flux_dit_builder implementation."""
-
-import sys as _sys
-
-from .families.flux import flux_dit_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/flux_vae_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/flux_vae_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the flux family-owned flux_vae_builder implementation."""
-
-import sys as _sys
-
-from .families.flux import flux_vae_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/fnet_encoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/fnet_encoder_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the fnet family-owned fnet_encoder_builder implementation."""
-
-import sys as _sys
-
-from .families.fnet import fnet_encoder_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/internvit_vision_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/internvit_vision_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the internvl family-owned internvit_vision_builder implementation."""
-
-import sys as _sys
-
-from .families.internvl import internvit_vision_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/ltx_dit_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/ltx_dit_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the ltx_video family-owned ltx_dit_builder implementation."""
-
-import sys as _sys
-
-from .families.ltx_video import ltx_dit_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/ltx_vae_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/ltx_vae_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the ltx_video family-owned ltx_vae_builder implementation."""
-
-import sys as _sys
-
-from .families.ltx_video import ltx_vae_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/mistral_encoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/mistral_encoder_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the flux family-owned mistral_encoder_builder implementation."""
-
-import sys as _sys
-
-from .families.flux import mistral_encoder_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/nanocodec_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/nanocodec_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the magpie_tts family-owned nanocodec_builder implementation."""
-
-import sys as _sys
-
-from .families.magpie_tts import nanocodec_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/onnx_vision_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/onnx_vision_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the qwen_vl family-owned onnx_vision_builder implementation."""
-
-import sys as _sys
-
-from .families.qwen_vl import onnx_vision_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/phi4mm_vision_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/phi4mm_vision_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the phi4_multimodal family-owned phi4mm_vision_builder implementation."""
-
-import sys as _sys
-
-from .families.phi4_multimodal import phi4mm_vision_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/qwen3_encoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/qwen3_encoder_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the z_image family-owned qwen3_encoder_builder implementation."""
-
-import sys as _sys
-
-from .families.z_image import qwen3_encoder_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/qwen_vl_vision_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/qwen_vl_vision_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the qwen_vl family-owned qwen_vl_vision_builder implementation."""
-
-import sys as _sys
-
-from .families.qwen_vl import qwen_vl_vision_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/standard_decoder_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the llama family-owned standard_decoder_builder implementation."""
-
-import sys as _sys
-
-from .families.llama import standard_decoder_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/standard_dit_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/standard_dit_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the pixart family-owned standard_dit_builder implementation."""
-
-import sys as _sys
-
-from .families.pixart import standard_dit_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/t5_encoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/t5_encoder_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the flux family-owned t5_encoder_builder implementation."""
-
-import sys as _sys
-
-from .families.flux import t5_encoder_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/vae_2d_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/vae_2d_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the pixart family-owned vae_2d_builder implementation."""
-
-import sys as _sys
-
-from .families.pixart import vae_2d_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/vision_encoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/vision_encoder_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the Qwen-VL family-owned vision encoder builder."""
-
-import sys as _sys
-
-from . import qwen_vl_vision_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/xlnet_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/xlnet_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the xlnet family-owned xlnet_builder implementation."""
-
-import sys as _sys
-
-from .families.xlnet import xlnet_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tensorrt_model_connect/tensorrt_model_connect/z_image_dit_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/z_image_dit_builder.py
@@ -1,7 +1,0 @@
-"""Compatibility shim for the z_image family-owned z_image_dit_builder implementation."""
-
-import sys as _sys
-
-from .families.z_image import z_image_dit_builder as _impl
-
-_sys.modules[__name__] = _impl

--- a/tests/builder/test_owned_builder_mocked_paths.py
+++ b/tests/builder/test_owned_builder_mocked_paths.py
@@ -52,19 +52,6 @@ def _make_fake_trt_base() -> types.SimpleNamespace:
     )
 
 
-_SHARED_BUILDER_MODULES = {
-    "tensorrt_model_connect.encodec_builder": (
-        "tensorrt_model_connect.families.bark.encodec_builder"
-    ),
-    "tensorrt_model_connect.encoder_builder": (
-        "tensorrt_model_connect.families.bert.encoder_builder"
-    ),
-    "tensorrt_model_connect.onnx_vision_builder": (
-        "tensorrt_model_connect.families.qwen_vl.onnx_vision_builder"
-    ),
-}
-
-
 def _drop_imported_module(module_name: str) -> None:
     sys.modules.pop(module_name, None)
     package_name, _, attribute_name = module_name.rpartition(".")
@@ -78,9 +65,6 @@ def _import_with_fake_trt(module_name: str, fake_trt: types.SimpleNamespace | No
         fake_trt = _make_fake_trt_base()
     # Remove cached modules that may have imported with a different trt object.
     _drop_imported_module(module_name)
-    shared_module_name = _SHARED_BUILDER_MODULES.get(module_name)
-    if shared_module_name is not None:
-        _drop_imported_module(shared_module_name)
     if module_name.endswith("encoder_builder"):
         _drop_imported_module("tensorrt_model_connect.graph_ops")
         _drop_imported_module("tensorrt_model_connect.graph_blocks")
@@ -95,7 +79,7 @@ def test_encodec_fuse_weight_norm_matches_manual_formula() -> None:
     Preconditions: `g` and `v` arrays have compatible output-channel shapes.
     Postconditions: Fused weights equal g*v/||v|| with float32 output dtype.
     """
-    mod = _import_with_fake_trt("tensorrt_model_connect.encodec_builder")
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.bark.encodec_builder")
 
     g = np.array([[[2.0]], [[4.0]]], dtype=np.float32)
     v = np.array(
@@ -121,7 +105,7 @@ def test_encoder_seq_layer_norm_uses_native_normalization() -> None:
     Postconditions: Function returns tensor from native normalization layer
         with correct epsilon and axis mask.
     """
-    mod = _import_with_fake_trt("tensorrt_model_connect.encoder_builder")
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.bert.encoder_builder")
 
     class _FakeTensor:
         def __init__(self, name: str, dtype=np.float32):
@@ -225,7 +209,7 @@ def test_onnx_builder_raises_parser_error_with_details() -> None:
         NetworkDefinitionCreationFlag=types.SimpleNamespace(EXPLICIT_BATCH=0, STRONGLY_TYPED=1),
         MemoryPoolType=types.SimpleNamespace(WORKSPACE="workspace"),
     )
-    mod = _import_with_fake_trt("tensorrt_model_connect.onnx_vision_builder", fake_trt=fake_trt)
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.qwen_vl.onnx_vision_builder", fake_trt=fake_trt)
 
     with pytest.raises(RuntimeError, match="ONNX parsing failed"):
         mod.build_vision_engine_from_onnx(b"bad-onnx")
@@ -298,7 +282,7 @@ def test_onnx_builder_success_and_plan_none_branches() -> None:
         NetworkDefinitionCreationFlag=types.SimpleNamespace(EXPLICIT_BATCH=0, STRONGLY_TYPED=1),
         MemoryPoolType=types.SimpleNamespace(WORKSPACE="workspace"),
     )
-    mod = _import_with_fake_trt("tensorrt_model_connect.onnx_vision_builder", fake_trt=fake_trt)
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.qwen_vl.onnx_vision_builder", fake_trt=fake_trt)
 
     plan = mod.build_vision_engine_from_onnx(b"good-onnx", verbose=True)
     assert plan == b"engine-plan"
@@ -318,7 +302,7 @@ def test_trace_hf_vision_encoder_import_and_missing_encoder_branches() -> None:
     Preconditions: torch and transformers modules are replaced by deterministic fakes.
     Postconditions: Missing dependency raises ImportError; missing vision attr raises RuntimeError.
     """
-    mod = _import_with_fake_trt("tensorrt_model_connect.onnx_vision_builder")
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.qwen_vl.onnx_vision_builder")
 
     class _NoGrad:
         def __enter__(self):
@@ -363,7 +347,7 @@ def test_trace_hf_vision_encoder_success_path_with_mocked_export() -> None:
     Preconditions: Fake torch exporter writes deterministic ONNX bytes; fake transformers returns vision model.
     Postconditions: Returned engine bytes come from `build_vision_engine_from_onnx` call.
     """
-    mod = _import_with_fake_trt("tensorrt_model_connect.onnx_vision_builder")
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.qwen_vl.onnx_vision_builder")
 
     class _NoGrad:
         def __enter__(self):
@@ -420,21 +404,3 @@ def test_trace_hf_vision_encoder_success_path_with_mocked_export() -> None:
     assert _AutoModel.called == ("model-dir", False)
     assert vision_model.eval_called is True
     assert export_calls and export_calls[0]["opset_version"] == 17
-
-
-@pytest.mark.unit
-def test_vision_encoder_builder_reexports_from_qwen_vl_module(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Intent: verify compatibility shim re-exports symbols from qwen_vl_vision_builder.
-
-    Preconditions: Source module is pre-injected in sys.modules with explicit __all__.
-    Postconditions: Imported shim exposes the source marker symbol.
-    """
-    fake_src = types.ModuleType("tensorrt_model_connect.qwen_vl_vision_builder")
-    fake_src.__all__ = ["MARKER"]  # type: ignore[attr-defined]
-    fake_src.MARKER = object()  # type: ignore[attr-defined]
-
-    monkeypatch.setitem(sys.modules, "tensorrt_model_connect.qwen_vl_vision_builder", fake_src)
-    sys.modules.pop("tensorrt_model_connect.vision_encoder_builder", None)
-
-    shim = importlib.import_module("tensorrt_model_connect.vision_encoder_builder")
-    assert shim.MARKER is fake_src.MARKER

--- a/tests/builder/test_owned_encoder_builders_coverage.py
+++ b/tests/builder/test_owned_encoder_builders_coverage.py
@@ -196,22 +196,6 @@ def _make_fake_trt() -> types.SimpleNamespace:
     )
 
 
-_SHARED_BUILDER_MODULES = {
-    "tensorrt_model_connect.clip_encoder_builder": (
-        "tensorrt_model_connect.families.flux.clip_encoder_builder"
-    ),
-    "tensorrt_model_connect.encoder_builder": (
-        "tensorrt_model_connect.families.bert.encoder_builder"
-    ),
-    "tensorrt_model_connect.qwen3_encoder_builder": (
-        "tensorrt_model_connect.families.z_image.qwen3_encoder_builder"
-    ),
-    "tensorrt_model_connect.t5_encoder_builder": (
-        "tensorrt_model_connect.families.flux.t5_encoder_builder"
-    ),
-}
-
-
 def _drop_imported_module(module_name: str) -> None:
     sys.modules.pop(module_name, None)
     package_name, _, attribute_name = module_name.rpartition(".")
@@ -224,7 +208,6 @@ def _import_with_fake_trt(module_name: str, fake_trt: types.SimpleNamespace):
     """Import a tensorrt_model_connect module while tensorrt is mocked."""
     for mod_name in (
         module_name,
-        _SHARED_BUILDER_MODULES.get(module_name),
         "tensorrt_model_connect.graph_ops",
         "tensorrt_model_connect.graph_blocks",
     ):
@@ -247,15 +230,14 @@ def _import_qwen3_with_fake_trt(fake_trt: types.SimpleNamespace):
     fake_cm._has_tensor = lambda _readers, _name: False  # type: ignore[attr-defined]
 
     for mod_name in (
-        "tensorrt_model_connect.qwen3_encoder_builder",
-        _SHARED_BUILDER_MODULES["tensorrt_model_connect.qwen3_encoder_builder"],
+        "tensorrt_model_connect.families.z_image.qwen3_encoder_builder",
         "tensorrt_model_connect.checkpoint_mapper",
         "tensorrt_model_connect.graph_ops",
         "tensorrt_model_connect.graph_blocks",
     ):
         _drop_imported_module(mod_name)
     with patch.dict(sys.modules, {"tensorrt": fake_trt, "tensorrt_model_connect.checkpoint_mapper": fake_cm}):
-        return importlib.import_module("tensorrt_model_connect.qwen3_encoder_builder")
+        return importlib.import_module("tensorrt_model_connect.families.z_image.qwen3_encoder_builder")
 
 
 def _fake_tensor_fn(prefix: str):
@@ -379,7 +361,7 @@ def test_build_clip_encoder_engine_success_uses_fake_builder_and_marks_outputs(m
     Postconditions: Engine bytes are returned, config flags are set, and both outputs are marked.
     """
     fake_trt = _make_fake_trt()
-    mod = _import_with_fake_trt("tensorrt_model_connect.clip_encoder_builder", fake_trt)
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.flux.clip_encoder_builder", fake_trt)
 
     constant_payloads: list[tuple[tuple[int, ...], np.ndarray]] = []
 
@@ -421,7 +403,7 @@ def test_build_clip_encoder_engine_raises_when_builder_returns_none(monkeypatch:
     """
     fake_trt = _make_fake_trt()
     fake_trt.Builder.plan_to_return = None
-    mod = _import_with_fake_trt("tensorrt_model_connect.clip_encoder_builder", fake_trt)
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.flux.clip_encoder_builder", fake_trt)
 
     monkeypatch.setattr(mod.graph_ops, "add_constant", _fake_tensor_fn("const"))
     monkeypatch.setattr(mod.graph_ops, "add_layer_norm", _fake_tensor_fn("ln"))
@@ -448,7 +430,7 @@ def test_load_clip_weights_transposes_projection_matrices_and_keeps_biases() -> 
     Postconditions: Projection matrices are transposed while scalar/vector tensors remain untransformed float32.
     """
     fake_trt = _make_fake_trt()
-    mod = _import_with_fake_trt("tensorrt_model_connect.clip_encoder_builder", fake_trt)
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.flux.clip_encoder_builder", fake_trt)
 
     tensors: dict[str, np.ndarray] = {
         "text_model.embeddings.token_embedding.weight": np.arange(32, dtype=np.float32).reshape(8, 4),
@@ -508,7 +490,7 @@ def test_build_t5_encoder_engine_success_exercises_relative_bias_fallback(monkey
     Postconditions: Engine bytes are returned and each layer emits the expected derived bias constant.
     """
     fake_trt = _make_fake_trt()
-    mod = _import_with_fake_trt("tensorrt_model_connect.t5_encoder_builder", fake_trt)
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.flux.t5_encoder_builder", fake_trt)
 
     bucket_indices = np.array([[0, 1], [2, 3]], dtype=np.int32)
     constant_payloads: list[tuple[tuple[int, ...], np.ndarray]] = []
@@ -573,7 +555,7 @@ def test_build_t5_encoder_engine_raises_when_builder_returns_none(monkeypatch: p
     """
     fake_trt = _make_fake_trt()
     fake_trt.Builder.plan_to_return = None
-    mod = _import_with_fake_trt("tensorrt_model_connect.t5_encoder_builder", fake_trt)
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.flux.t5_encoder_builder", fake_trt)
 
     monkeypatch.setattr(mod.graph_ops, "add_constant", _fake_tensor_fn("const"))
     monkeypatch.setattr(mod.graph_ops, "make_t5_relative_position_bias", lambda *_a, **_k: np.zeros((2, 2), dtype=np.int32))
@@ -603,7 +585,7 @@ def test_build_encoder_engine_success_passes_rel_pos_bias_and_activation(monkeyp
     Postconditions: Layer helper receives expected hidden-act/rel-bias values and engine bytes are returned.
     """
     fake_trt = _make_fake_trt()
-    mod = _import_with_fake_trt("tensorrt_model_connect.encoder_builder", fake_trt)
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.bert.encoder_builder", fake_trt)
 
     monkeypatch.setattr(mod.graph_ops, "add_constant", _fake_tensor_fn("const"))
     monkeypatch.setattr(mod, "_add_seq_layer_norm", _fake_tensor_fn("embed_ln"))
@@ -657,7 +639,7 @@ def test_build_encoder_engine_raises_when_builder_returns_none(monkeypatch: pyte
     """
     fake_trt = _make_fake_trt()
     fake_trt.Builder.plan_to_return = None
-    mod = _import_with_fake_trt("tensorrt_model_connect.encoder_builder", fake_trt)
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.bert.encoder_builder", fake_trt)
 
     monkeypatch.setattr(mod.graph_ops, "add_constant", _fake_tensor_fn("const"))
     monkeypatch.setattr(mod, "_add_seq_layer_norm", _fake_tensor_fn("embed_ln"))

--- a/tests/builder/test_owned_qwen3_t5_helpers.py
+++ b/tests/builder/test_owned_qwen3_t5_helpers.py
@@ -50,16 +50,6 @@ def _make_fake_trt() -> types.SimpleNamespace:
     )
 
 
-_SHARED_BUILDER_MODULES = {
-    "tensorrt_model_connect.qwen3_encoder_builder": (
-        "tensorrt_model_connect.families.z_image.qwen3_encoder_builder"
-    ),
-    "tensorrt_model_connect.t5_encoder_builder": (
-        "tensorrt_model_connect.families.flux.t5_encoder_builder"
-    ),
-}
-
-
 def _drop_imported_module(module_name: str) -> None:
     sys.modules.pop(module_name, None)
     package_name, _, attribute_name = module_name.rpartition(".")
@@ -73,9 +63,6 @@ def _import_with_fake_trt(module_name: str):
     sentinel = object()
     old_trt = sys.modules.get("tensorrt", sentinel)
     _drop_imported_module(module_name)
-    shared_module_name = _SHARED_BUILDER_MODULES.get(module_name)
-    if shared_module_name is not None:
-        _drop_imported_module(shared_module_name)
     sys.modules["tensorrt"] = _make_fake_trt()
     try:
         return importlib.import_module(module_name)
@@ -93,7 +80,7 @@ def test_qwen3_native_rope_table_has_expected_identities() -> None:
     Preconditions: Qwen3 helper module is importable with fake trt.
     Postconditions: half-dim cos/sin tables satisfy position-0 identity and trig invariants.
     """
-    mod = _import_with_fake_trt("tensorrt_model_connect.qwen3_encoder_builder")
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.z_image.qwen3_encoder_builder")
 
     cos = mod.graph_ops.make_rope_table_half_dim(
         max_cache_length=3,
@@ -124,7 +111,7 @@ def test_load_qwen3_encoder_weights_transposes_and_optional_norm() -> None:
     Preconditions: Safetensors reader helpers are mocked with deterministic arrays.
     Postconditions: Returned WeightDict has expected keys and transformed values.
     """
-    mod = _import_with_fake_trt("tensorrt_model_connect.qwen3_encoder_builder")
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.z_image.qwen3_encoder_builder")
 
     tensors = {
         "model.embed_tokens.weight": np.arange(20, dtype=np.float32).reshape(5, 4),
@@ -192,7 +179,7 @@ def test_load_t5_weights_transposes_and_bias_fallback() -> None:
     Preconditions: checkpoint_mapper helpers are replaced by a fake deterministic module.
     Postconditions: Returned weights are float32 and include expected optional keys.
     """
-    mod = _import_with_fake_trt("tensorrt_model_connect.t5_encoder_builder")
+    mod = _import_with_fake_trt("tensorrt_model_connect.families.flux.t5_encoder_builder")
 
     tensors: dict[str, np.ndarray] = {
         "shared.weight": np.arange(28, dtype=np.float32).reshape(7, 4),

--- a/tests/builder/test_standard_decoder.py
+++ b/tests/builder/test_standard_decoder.py
@@ -88,7 +88,7 @@ class TestTensorNamingContract:
 
     def _build_engine(self, **kwargs):
         from tensorrt_model_connect.config import ModelConfig
-        from tensorrt_model_connect.standard_decoder_builder import build_standard_decoder_engine
+        from tensorrt_model_connect.families.llama.standard_decoder_builder import build_standard_decoder_engine
 
         hidden, vocab, num_layers = 16, 32, 2
         num_heads = 4
@@ -195,7 +195,7 @@ class TestTensorNamingContract:
 
     def test_dynamic_kv_cache_shapes(self):
         from tensorrt_model_connect.config import ModelConfig
-        from tensorrt_model_connect.standard_decoder_builder import build_standard_decoder_engine
+        from tensorrt_model_connect.families.llama.standard_decoder_builder import build_standard_decoder_engine
 
         hidden, vocab, num_layers = 16, 32, 2
         num_heads = 4
@@ -227,7 +227,7 @@ class TestTensorNamingContract:
 
     def test_dynamic_kv_cache_multiple_profiles(self):
         from tensorrt_model_connect.config import ModelConfig
-        from tensorrt_model_connect.standard_decoder_builder import build_standard_decoder_engine
+        from tensorrt_model_connect.families.llama.standard_decoder_builder import build_standard_decoder_engine
 
         hidden, vocab, num_layers = 16, 32, 2
         num_heads = 4
@@ -268,7 +268,7 @@ class TestTensorNamingContract:
 
     def test_dynamic_kv_cache_rejects_alibi(self):
         from tensorrt_model_connect.config import ModelConfig
-        from tensorrt_model_connect.standard_decoder_builder import build_standard_decoder_engine
+        from tensorrt_model_connect.families.llama.standard_decoder_builder import build_standard_decoder_engine
 
         hidden, vocab, num_layers = 16, 32, 2
         num_heads = 4

--- a/tests/builder/test_vision_compute.py
+++ b/tests/builder/test_vision_compute.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-pytest.importorskip("tensorrt_model_connect", reason="tensorrt_model_connect requires tensorrt")
-from tensorrt_model_connect.qwen_vl_vision_builder import _compute_vision_rope_tables
+try:
+    from tensorrt_model_connect.families.qwen_vl.qwen_vl_vision_builder import _compute_vision_rope_tables
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
 
 
 class TestComputeVisionRopeTables:

--- a/tests/builder/test_vision_compute_extended.py
+++ b/tests/builder/test_vision_compute_extended.py
@@ -18,7 +18,7 @@ import pytest
 
 try:
     from tensorrt_model_connect import graph_ops
-    from tensorrt_model_connect.qwen_vl_vision_builder import (
+    from tensorrt_model_connect.families.qwen_vl.qwen_vl_vision_builder import (
         _compute_vision_rope_tables,
         build_qwen3_vl_vision_engine,
         build_qwen_vl_vision_engine,
@@ -26,7 +26,7 @@ try:
 except (ImportError, ModuleNotFoundError):
     pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
 
-from tests.builder.conftest import requires_trt, run_trt_graph
+from tests.builder.conftest import requires_trt
 
 
 # ===================================================================
@@ -177,7 +177,6 @@ class TestSpatialMerge:
         norm_gamma = np.ones(input_dim, dtype=np.float32)
 
         def build_fn(network, trt_inputs):
-            import tensorrt as trt
             eps_tensor = graph_ops.add_constant(
                 network, (1, 1), np.array([1e-6], dtype=np.float32))
             out = graph_ops.add_spatial_merge(
@@ -299,8 +298,6 @@ class TestVisionEncoderGraphConstruction:
     @requires_trt
     def test_qwen25_vl_graph_builds(self):
         """Qwen2.5-VL vision encoder builds without errors on tiny dims."""
-        import tensorrt as trt
-
         # Tiny config: 2 layers, 4x4 grid, embed=32
         embed_dim = 32
         num_heads = 2
@@ -311,9 +308,6 @@ class TestVisionEncoderGraphConstruction:
         in_channels = 3
         temporal_patch_size = 2
         fixed_image_size = 16  # 16/4 = 4x4 grid
-        grid = fixed_image_size // patch_size
-        num_patches = grid * grid  # 16
-        num_merged = num_patches // (merge_size * merge_size)  # 4
         text_hidden = 32
         input_channels = temporal_patch_size * in_channels
         merged_dim = embed_dim * merge_size * merge_size
@@ -395,8 +389,6 @@ class TestVisionEncoderGraphConstruction:
         temporal_patch_size = 2
         fixed_image_size = 16
         grid = fixed_image_size // patch_size
-        num_patches = grid * grid  # 16
-        num_merged = num_patches // (merge_size * merge_size)  # 4
         text_hidden = 32
         input_channels = temporal_patch_size * in_channels
         merge_unit = merge_size * merge_size

--- a/tools/diff_layers.py
+++ b/tools/diff_layers.py
@@ -25,7 +25,7 @@ def build_debug_engine(model_id_or_path, max_cache_length, verbose):
     from tensorrt_model_connect.engine_builder import _resolve_model
     from tensorrt_model_connect.config import ModelConfig
     from tensorrt_model_connect.families import find_plugin
-    from tensorrt_model_connect.standard_decoder_builder import build_standard_decoder_engine
+    from tensorrt_model_connect.families.llama.standard_decoder_builder import build_standard_decoder_engine
 
     model_dir = _resolve_model(model_id_or_path)
     config = ModelConfig.from_dir(model_dir)
@@ -37,7 +37,7 @@ def build_debug_engine(model_id_or_path, max_cache_length, verbose):
           f"(layers={config.num_hidden_layers}, hidden={config.hidden_size})",
           file=sys.stderr)
 
-    print(f"[diff-layers] Loading weights ...", file=sys.stderr)
+    print("[diff-layers] Loading weights ...", file=sys.stderr)
     weights = plugin.load_weights(model_dir, config)
 
     # Build with debug outputs — call the builder directly with the flag
@@ -117,12 +117,12 @@ def main():
           f"text={tokenizer.decode([token_id])!r}")
 
     # Run TRT (single step at position 0)
-    print(f"[diff-layers] Running TRT ...", file=sys.stderr)
+    print("[diff-layers] Running TRT ...", file=sys.stderr)
     trt_results = run_trt_single_step(
         engine_plan, config, token_id, args.max_cache_length)
 
     # Run HF (single token forward pass)
-    print(f"[diff-layers] Running HF ...", file=sys.stderr)
+    print("[diff-layers] Running HF ...", file=sys.stderr)
     hf_hidden, hf_logits = run_hf_single_step(
         model_dir, token_id, trust_remote_code=args.trust_remote_code)
 
@@ -235,82 +235,6 @@ def main():
     print(f"  Tolerance: {args.atol}")
     print(f"  {'PASS' if all_passed else 'FAIL'}")
     sys.exit(0 if all_passed else 1)
-
-
-def run_as_diff_test(ctx):
-    """Framework entry point. Returns DiffResult."""
-    from diff_framework.protocol import DiffResult
-    import time as _time
-
-    t0 = _time.monotonic()
-    try:
-        engine_plan, config, model_dir = build_debug_engine(
-            ctx.model, ctx.max_cache_length, ctx.verbose)
-
-        from transformers import AutoTokenizer
-        tokenizer = AutoTokenizer.from_pretrained(
-            model_dir, trust_remote_code=ctx.trust_remote_code)
-        input_ids = tokenizer.encode("Hello")
-        token_id = input_ids[0]
-
-        trt_results = run_trt_single_step(
-            engine_plan, config, token_id, ctx.max_cache_length)
-        hf_hidden, hf_logits = run_hf_single_step(
-            model_dir, token_id, trust_remote_code=ctx.trust_remote_code)
-
-        max_overall = 0.0
-        all_passed = True
-        layer_diffs = {}
-
-        # Embedding
-        if "debug_embed" in trt_results:
-            trt_embed = trt_results["debug_embed"].flatten()
-            hf_embed = hf_hidden[0]
-            md = float(np.abs(trt_embed - hf_embed).max())
-            max_overall = max(max_overall, md)
-            layer_diffs["embed"] = md
-            if md > ctx.layer_atol:
-                all_passed = False
-
-        # Per-layer hidden states
-        num_layers = config.num_hidden_layers
-        for i in range(num_layers):
-            hidden_key = f"debug_hidden_{i}"
-            if hidden_key not in trt_results:
-                continue
-            trt_h = trt_results[hidden_key].flatten()
-            is_last = (i == num_layers - 1)
-            if is_last and len(hf_hidden) == num_layers + 1:
-                continue
-            hf_h = hf_hidden[i + 1] if (i + 1) < len(hf_hidden) else None
-            if hf_h is None:
-                continue
-            md = float(np.abs(trt_h - hf_h).max())
-            max_overall = max(max_overall, md)
-            layer_diffs[f"layer.{i}"] = md
-            if md > ctx.layer_atol:
-                all_passed = False
-
-        # Logits
-        trt_logits_arr = trt_results["logits"].flatten()
-        md = float(np.abs(trt_logits_arr - hf_logits).max())
-        max_overall = max(max_overall, md)
-        layer_diffs["logits"] = md
-        if md > ctx.layer_atol:
-            all_passed = False
-
-        return DiffResult(
-            test_name="layer_diff", model=ctx.model,
-            runtime_strategy=ctx.runtime_strategy,
-            passed=all_passed,
-            status="PASS" if all_passed else "FAIL",
-            message=f"max_overall_diff={max_overall:.6f} (atol={ctx.layer_atol})",
-            metrics={"max_overall_diff": max_overall, "atol": ctx.layer_atol,
-                     "layer_diffs": layer_diffs},
-            duration_s=_time.monotonic() - t0)
-    except Exception as e:
-        return DiffResult.error(
-            "layer_diff", ctx.model, ctx.runtime_strategy, str(e))
 
 
 def run_as_diff_test(ctx):

--- a/tools/diff_t5.py
+++ b/tools/diff_t5.py
@@ -66,7 +66,7 @@ def main():
 
     # 4. Build TRT engine
     print("[diff-t5] Building TRT T5 engine ...", file=sys.stderr)
-    from tensorrt_model_connect.t5_encoder_builder import build_t5_encoder_engine, load_t5_weights
+    from tensorrt_model_connect.families.flux.t5_encoder_builder import build_t5_encoder_engine, load_t5_weights
 
     config = hf_model.config
     t5_weights = load_t5_weights(

--- a/tools/validate_dit.py
+++ b/tools/validate_dit.py
@@ -33,7 +33,6 @@ def main():
 
     DIM = 1536
     NUM_HEADS = 12
-    HEAD_DIM = DIM // NUM_HEADS
     NUM_LAYERS = 30
     FFN_DIM = 8960
     TEXT_SEQ = 16
@@ -65,7 +64,7 @@ def main():
     hf_model.norm_out.register_forward_hook(hook_after_patch)
 
     with torch.no_grad():
-        hf_out = hf_model(
+        hf_model(
             hidden_states=latent,
             timestep=timestep,
             encoder_hidden_states=text_hidden,
@@ -96,7 +95,7 @@ def main():
     cos_np = rope_cos[0, :, 0, :].numpy()  # [num_patches, head_dim]
     sin_np = rope_sin[0, :, 0, :].numpy()  # [num_patches, head_dim]
 
-    print(f"[validate-dit] Extracted intermediates:", file=sys.stderr)
+    print("[validate-dit] Extracted intermediates:", file=sys.stderr)
     print(f"  hidden: {hidden_np.shape}", file=sys.stderr)
     print(f"  block_temb: {temb_np.shape}", file=sys.stderr)
     print(f"  time_embed: {time_embed_np.shape}", file=sys.stderr)
@@ -126,7 +125,7 @@ def main():
     print("[validate-dit] Loading DiT weights & building TRT engine ...",
           file=sys.stderr)
     sys.path.insert(0, str(Path(__file__).parent.parent / "tensorrt_model_connect"))
-    from tensorrt_model_connect.standard_dit_builder import build_standard_dit_engine, load_dit_weights
+    from tensorrt_model_connect.families.pixart.standard_dit_builder import build_standard_dit_engine, load_dit_weights
 
     t0 = time.time()
     weights = load_dit_weights(dit_dir, dim=DIM, num_heads=NUM_HEADS,
@@ -163,7 +162,7 @@ def main():
     cos_sim = np.sum(hf_final * trt_final) / (
         np.linalg.norm(hf_final) * np.linalg.norm(trt_final) + 1e-8)
 
-    print(f"\n=== DiT Denoiser Validation ===")
+    print("\n=== DiT Denoiser Validation ===")
     print(f"Patches: {NUM_PATCHES}, Layers: {NUM_LAYERS}")
     print(f"Max abs diff: {max_diff:.6f}")
     print(f"Mean abs diff: {mean_diff:.6f}")

--- a/tools/validate_t5.py
+++ b/tools/validate_t5.py
@@ -64,7 +64,7 @@ def main():
     # --- TRT ---
     print("[validate] Loading T5 weights ...", file=sys.stderr)
     sys.path.insert(0, str(Path(__file__).parent.parent / "tensorrt_model_connect"))
-    from tensorrt_model_connect.t5_encoder_builder import build_t5_encoder_engine, load_t5_weights
+    from tensorrt_model_connect.families.flux.t5_encoder_builder import build_t5_encoder_engine, load_t5_weights
 
     cfg = hf_model.config
     t0 = time.time()
@@ -115,7 +115,7 @@ def main():
     cos_sim = np.sum(hf_valid * trt_valid) / (
         np.linalg.norm(hf_valid) * np.linalg.norm(trt_valid) + 1e-8)
 
-    print(f"\n=== T5 Encoder Validation ===")
+    print("\n=== T5 Encoder Validation ===")
     print(f"Prompt: {args.prompt!r}")
     print(f"Seq len: {args.max_seq_len} (valid: {valid_len})")
     print(f"Max abs diff: {max_diff:.6f}")


### PR DESCRIPTION
## Background
The family-owned builder layout is now in place, but the package root still kept 26 seven-line compatibility shim modules for old builder import paths. Those root files duplicated the family ownership surface and kept future builder ownership ambiguous.

## Exit Criteria
- Package-root builder modules are removed except `engine_builder.py`.
- In-repo tests and tools import the family-owned builder modules directly.
- Builder ownership tests continue to exercise the family modules without relying on root aliases.

## Implementation
- Deleted the root `*_builder.py` compatibility shims under `tensorrt_model_connect/tensorrt_model_connect/`.
- Repointed validation/diff tools and builder tests to explicit `tensorrt_model_connect.families.<family>.<builder>` imports.
- Removed shim-specific test scaffolding and one dead duplicate `run_as_diff_test` definition that changed-file lint would reject.

## Validation
- `PYTHONPATH=tensorrt_model_connect python -m pytest tests/builder/test_owned_qwen3_t5_helpers.py tests/builder/test_owned_encoder_builders_coverage.py tests/builder/test_owned_builder_mocked_paths.py tests/builder/test_vision_compute.py tests/builder/test_vision_compute_extended.py tests/builder/test_standard_decoder.py tests/tools/test_test_impact.py -q` -> 104 passed, 13 skipped.
- `python -m ruff check --config ruff.toml ...changed files...` -> passed.
- `git diff --check` -> passed.
- `PYTHONPATH=tensorrt_model_connect python scripts/check_family_coverage.py` -> all non-exempt plugins covered.
- `PYTHONPATH=tensorrt_model_connect python3 tools/test_impact.py --validate` -> passed.

## Notes For Future Readers
The remaining package-root builder file is `engine_builder.py`; model-specific builders now live under their owning family folder. Full TRT-backed CI remains the source of truth for GPU/TensorRT collection paths.
