### PR TITLE
ci(e2e): refine impact selection

### DIFF
--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -82,7 +82,8 @@ def mock_repo(tmp_path):
         {"name": "bert-base", "family": "bert", "runtime_strategy": "encoder_only",
          "hf_id": "bert-base", "core": True},
         {"name": "whisper-tiny-fp16", "family": "whisper", "runtime_strategy": "speech_to_text",
-         "hf_id": "openai/whisper-tiny", "precision": "fp16", "core": True},
+         "hf_id": "openai/whisper-tiny", "precision": "fp16", "core": True,
+         "test_input_audio": "tests/e2e/data/Recording.wav"},
         {"name": "flux-schnell", "family": "flux", "runtime_strategy": "diffusion_flux",
          "hf_id": "bf/FLUX", "core": True},
         {"name": "z-image-turbo", "family": "z_image", "runtime_strategy": "diffusion_zimage",
@@ -94,7 +95,7 @@ def mock_repo(tmp_path):
         {"name": "mamba-130m", "family": "mamba", "runtime_strategy": "ssm_recurrent",
          "hf_id": "ss/mamba", "core": True},
         {"name": "qwen25vl-3b", "family": "qwen_vl", "runtime_strategy": "vision_language",
-         "hf_id": "Q/Q25VL", "core": True},
+         "hf_id": "Q/Q25VL", "test_image": "data/test_img.jpeg", "core": True},
         {"name": "bark-small", "family": "bark", "runtime_strategy": "text_to_audio_bark",
          "hf_id": "suno/bark", "core": True},
         {"name": "sam-vit", "family": "sam", "runtime_strategy": "prompted_segmentation",
@@ -603,6 +604,37 @@ class TestNoImpact:
         assert match.rule == "no_impact"
         assert match.models == []
 
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".agents/plugins/marketplace.json",
+            "plugins/trtmc-agent-skills/.codex-plugin/plugin.json",
+            "plugins/trtmc-agent-skills/skills/fp16-trt-network/agents/openai.yaml",
+        ],
+    )
+    def test_agent_plugin_metadata_no_impact(self, imap, path):
+        """Codex agent/plugin metadata should not trigger E2E selection."""
+        match = test_impact.classify_file(path, imap)
+        assert match.rule == "no_impact"
+        assert match.models == []
+        assert match.unit_tiers == []
+        assert match.rebuild_cpp is False
+
+    def test_agent_plugin_metadata_aggregate_no_e2e(self, imap):
+        """Agent-only plugin edits should aggregate to no selected E2E models."""
+        result = test_impact.analyze_impact(
+            [
+                ".agents/plugins/marketplace.json",
+                "plugins/trtmc-agent-skills/.codex-plugin/plugin.json",
+                "plugins/trtmc-agent-skills/skills/debug-trt-mismatch/SKILL.md",
+                "plugins/trtmc-agent-skills/skills/debug-trt-mismatch/agents/openai.yaml",
+            ],
+            imap,
+        )
+        assert result.e2e_models == []
+        assert result.unit_tiers == []
+        assert result.rebuild_cpp is False
+
 
 class TestE2EDataFiles:
     def test_data_file_maps_to_manifest_users(self, imap):
@@ -611,6 +643,20 @@ class TestE2EDataFiles:
             "tests/e2e/data/flux2-fp8-scales.json", imap)
         assert match.rule == "e2e_data_file"
         assert match.models == ["flux-2-dev-fp8"]
+
+    def test_repo_relative_data_file_maps_to_manifest_users(self, imap):
+        """Manifest tests/e2e/data references should select only their users."""
+        match = test_impact.classify_file(
+            "tests/e2e/data/Recording.wav", imap)
+        assert match.rule == "e2e_data_file"
+        assert match.models == ["whisper-tiny-fp16"]
+
+    def test_manifest_relative_data_file_maps_to_manifest_users(self, imap):
+        """Manifest data/ references resolve relative to tests/e2e/."""
+        match = test_impact.classify_file(
+            "tests/e2e/data/test_img.jpeg", imap)
+        assert match.rule == "e2e_data_file"
+        assert match.models == ["qwen25vl-3b"]
 
 
 # ---------------------------------------------------------------------------
@@ -642,6 +688,14 @@ class TestUnitTiers:
         assert match.rule == "unit_tools"
         assert match.models == []
         assert "tools" in match.unit_tiers
+
+    def test_unit_tier_torchtrt_engine_defs(self, imap):
+        """Torch-TRT engine-def tests run as builder tests without E2E."""
+        match = test_impact.classify_file(
+            "tests/engine_defs/torch_trt/test_config.py", imap)
+        assert match.rule == "unit_torchtrt_builder"
+        assert match.models == []
+        assert "builder" in match.unit_tiers
 
     def test_source_implies_unit_tier(self, imap):
         """C++ source change implies 'cpp' unit tier alongside E2E."""

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -218,6 +218,8 @@ _NO_IMPACT_PATTERNS = [
     r"^\.gitlab-ci\.yml$",
     r"^\.gitlab/",
     r"^\.claude/",
+    r"^\.agents/",
+    r"^plugins/trtmc-agent-skills/",
     r"^LICENSE",
     r"^CLAUDE\.md$",
     r"^recovery-",
@@ -348,6 +350,24 @@ def _scan_cpp_runtime_model_manifests(models_dir: Path) -> Dict[str, List[str]]:
     return scoped
 
 
+def _iter_manifest_data_paths(value: object) -> List[str]:
+    """Return repo-relative tests/e2e/data paths referenced by a manifest."""
+    paths: Set[str] = set()
+    if isinstance(value, dict):
+        for child in value.values():
+            paths.update(_iter_manifest_data_paths(child))
+    elif isinstance(value, list):
+        for child in value:
+            paths.update(_iter_manifest_data_paths(child))
+    elif isinstance(value, str):
+        normalized = value.strip().replace("\\", "/")
+        if normalized.startswith("tests/e2e/data/"):
+            paths.add(normalized)
+        elif normalized.startswith("data/"):
+            paths.add(f"tests/e2e/{normalized}")
+    return sorted(paths)
+
+
 def build_impact_map(repo_root: Path) -> ImpactMap:
     """Build the impact map by scanning manifests and family plugins."""
     models_dir = repo_root / "tests" / "e2e" / "models"
@@ -396,6 +416,8 @@ def build_impact_map(repo_root: Path) -> ImpactMap:
             manifest_field_to_models_sets.setdefault("fp8_scales", set()).add(name)
             e2e_data_file_to_models_sets.setdefault(
                 f"tests/e2e/data/{fp8_scales}", set()).add(name)
+        for data_path in _iter_manifest_data_paths(data):
+            e2e_data_file_to_models_sets.setdefault(data_path, set()).add(name)
 
     builder_to_families = _scan_family_imports(families_dir) if families_dir.is_dir() else {}
     cpp_runtime_model_strategies = _scan_cpp_runtime_model_manifests(runtime_models_dir)
@@ -555,7 +577,9 @@ def _infer_unit_tiers(path: str) -> List[str]:
     if (path.startswith("src/") or path.startswith("include/")
             or path == "CMakeLists.txt" or path.startswith("cmake/")):
         tiers.append("cpp")
-    if path.startswith("tests/builder/") or path.startswith("tests/torchtrt_builder/"):
+    if (path.startswith("tests/builder/")
+            or path.startswith("tests/torchtrt_builder/")
+            or path.startswith("tests/engine_defs/torch_trt/")):
         tiers.append("builder")
     if path.startswith("tests/cpp/"):
         tiers.append("cpp")
@@ -838,6 +862,8 @@ def classify_file(path: str, imap: ImpactMap) -> RuleMatch:
     if path.startswith("tests/tools/"):
         return RuleMatch("unit_tools", [], unit_tiers, rebuild)
     if path.startswith("tests/torchtrt_builder/"):
+        return RuleMatch("unit_torchtrt_builder", [], unit_tiers, rebuild)
+    if path.startswith("tests/engine_defs/torch_trt/"):
         return RuleMatch("unit_torchtrt_builder", [], unit_tiers, rebuild)
 
     # Rule 12: CMake / build system — triggers C++ rebuild + unit tests


### PR DESCRIPTION
## Background
PR #76 selected the broad L0 E2E set because repo-local Codex plugin metadata and skill agent YAML files fell through to the impact selector catch-all rule. While tracing that path, two adjacent over-selection cases were also clear: Torch-TRT engine-def unit tests were treated as unknown files, and checked-in E2E fixture files were not scoped to the manifests that reference them.

## Exit Criteria
- Agent-only Codex plugin edits do not select E2E models.
- Torch-TRT engine-def test edits run as builder tests without selecting E2E.
- E2E data fixture edits select only manifests that reference the changed fixture.

## Implementation
- Mark `.agents/` and `plugins/trtmc-agent-skills/` as no-impact paths for E2E and unit tier selection.
- Index manifest-referenced `data/...` and `tests/e2e/data/...` strings into the E2E data-file impact map.
- Classify `tests/engine_defs/torch_trt/` as Torch-TRT builder unit tests, matching the direct-test selection logic that already existed.
- Add regression coverage for the agent metadata paths, fixture scoping, and Torch-TRT engine-def unit-test classification.

## Validation
- `/workspace/users/yizhuoz/venv/bin/python -m pytest tests/tools/test_test_impact.py -q`: passed, 92 tests.
- `python3 tools/test_impact.py --validate`: passed; existing validation warnings were unchanged.
- `python3 -m py_compile tools/test_impact.py tests/tools/test_test_impact.py && git diff --check`: passed.
- `python3 tools/test_impact.py --files <PR #76 agent plugin JSON/YAML paths plus .agents marketplace> --json`: passed; selected zero E2E models.
- `python3 tools/test_impact.py --base github/main --head HEAD --json`: passed; selected no E2E models and only `tests/tools/test_test_impact.py` as a tools test.

## Notes For Future Readers
- Remaining `catch_all` paths still include environment, package, bundled model, and legacy E2E-test files where broad validation may still be defensible. This PR only narrows paths with clear ownership and low false-negative risk.