### PR TITLE
feat(diffusion): add TP lanes for Flux.1, PixArt, Wan, and Z-Image

### DIFF
--- a/src/runtime/models/flux/pipeline.cpp
+++ b/src/runtime/models/flux/pipeline.cpp
@@ -683,11 +683,14 @@ FluxPipeline::FluxPipeline(std::vector<std::unique_ptr<TrtModule>> text_encoders
                            std::unique_ptr<TrtModule> denoiser, std::unique_ptr<TrtModule> vae,
                            DiffusionConfig config, PreprocessorWeights weights,
                            std::shared_ptr<ITokenizer> tokenizer,
-                           std::unique_ptr<ITokenizer> clip_tokenizer, std::string model_id_str)
-    : text_encoders_(std::move(text_encoders)), denoiser_(std::move(denoiser)),
-      vae_(std::move(vae)), config_(std::move(config)), weights_(std::move(weights)),
-      tokenizer_(std::move(tokenizer)), clip_tokenizer_(std::move(clip_tokenizer)),
-      model_id_(std::move(model_id_str)) {
+                           std::unique_ptr<ITokenizer> clip_tokenizer, std::string model_id_str,
+                           std::shared_ptr<void> distributed_owner, int32_t tensor_parallel_rank,
+                           int32_t tensor_parallel_size)
+    : distributed_owner_(std::move(distributed_owner)), tensor_parallel_rank_(tensor_parallel_rank),
+      tensor_parallel_size_(tensor_parallel_size), text_encoders_(std::move(text_encoders)),
+      denoiser_(std::move(denoiser)), vae_(std::move(vae)), config_(std::move(config)),
+      weights_(std::move(weights)), tokenizer_(std::move(tokenizer)),
+      clip_tokenizer_(std::move(clip_tokenizer)), model_id_(std::move(model_id_str)) {
     // Compute FLUX latent layout
     h_latent_ = config_.video_height / config_.scale_factor_spatial;
     w_latent_ = config_.video_width / config_.scale_factor_spatial;
@@ -1235,6 +1238,16 @@ bool FluxPipeline::run_denoising(const diffusion::FluxGenerationPlan& plan,
 // Steps 11-13: VAE decode and convert to ImageResult
 bool FluxPipeline::decode_and_convert(const diffusion::FluxGenerationPlan& plan,
                                       std::vector<float>& latents, ImageResult& result) {
+    if (tensor_parallel_size_ > 1 && tensor_parallel_rank_ != 0) {
+        std::cerr << "[flux] TP rank " << tensor_parallel_rank_
+                  << " skips VAE decode; rank 0 writes image artifacts\n";
+        result.pixels.clear();
+        result.height = 0;
+        result.width = 0;
+        result.num_frames = 0;
+        return true;
+    }
+
     const bool is_flux2 = plan.is_flux2;
     const int32_t z_dim = plan.z_dim;
     const auto& layout = plan.layout;

--- a/src/runtime/models/flux/pipeline.h
+++ b/src/runtime/models/flux/pipeline.h
@@ -22,7 +22,8 @@ class FluxPipeline final : public IPipeline {
                  std::unique_ptr<TrtModule> denoiser, std::unique_ptr<TrtModule> vae,
                  DiffusionConfig config, PreprocessorWeights weights,
                  std::shared_ptr<ITokenizer> tokenizer, std::unique_ptr<ITokenizer> clip_tokenizer,
-                 std::string model_id_str);
+                 std::string model_id_str, std::shared_ptr<void> distributed_owner = nullptr,
+                 int32_t tensor_parallel_rank = 0, int32_t tensor_parallel_size = 1);
 
     ~FluxPipeline() override;
 
@@ -66,6 +67,10 @@ class FluxPipeline final : public IPipeline {
     bool decode_and_convert(const diffusion::FluxGenerationPlan& plan, std::vector<float>& latents,
                             ImageResult& result);
 
+    // Keep TP communicator ownership until after TRT modules are destroyed.
+    std::shared_ptr<void> distributed_owner_;
+    int32_t tensor_parallel_rank_{0};
+    int32_t tensor_parallel_size_{1};
     std::vector<std::unique_ptr<TrtModule>> text_encoders_;
     std::unique_ptr<TrtModule> denoiser_;
     std::unique_ptr<TrtModule> vae_;

--- a/src/runtime/models/flux/plugin.cpp
+++ b/src/runtime/models/flux/plugin.cpp
@@ -4,9 +4,35 @@
 #include "runtime/models/flux/pipeline.h"
 #include "runtime/plugins/shared/diffusion_helpers.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
+#include "utils/json_helpers.h"
+
+#include <cstdint>
+#include <string>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_denoiser_section_name(int32_t rank) {
+    return "denoiser_plan_tp_rank" + std::to_string(rank);
+}
+
+} // namespace
 
 class FluxPlugin final : public IPipelinePlugin {
   public:
@@ -15,7 +41,21 @@ class FluxPlugin final : public IPipelinePlugin {
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
-        auto parts = load_diffusion_parts(ctx.backend, ctx.bundle, ctx.config_json, opts);
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        std::string denoiser_section_name = "denoiser_plan";
+        ModuleCreateOptions denoiser_opts = opts;
+        const ModuleCreateOptions* denoiser_options = nullptr;
+        if (tp_config.enabled) {
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+            denoiser_section_name = tp_denoiser_section_name(tp_group.rank);
+            denoiser_opts.distributed_communicator = tp_group.communicator;
+            denoiser_opts.distributed_owner = tp_group.owner;
+            denoiser_options = &denoiser_opts;
+        }
+
+        auto parts = load_diffusion_parts(ctx.backend, ctx.bundle, ctx.config_json, opts,
+                                          denoiser_section_name, denoiser_options);
 
         // Move text encoder modules into vector
         std::vector<std::unique_ptr<TrtModule>> te_modules;
@@ -28,7 +68,8 @@ class FluxPlugin final : public IPipelinePlugin {
         return std::make_unique<FluxPipeline>(
             std::move(te_modules), std::move(parts.denoiser.module), std::move(parts.vae.module),
             std::move(parts.config), std::move(parts.weights), std::move(parts.tokenizer),
-            std::move(clip_tok), ctx.bundle.info.model_id);
+            std::move(clip_tok), ctx.bundle.info.model_id, tp_group.owner, tp_group.rank,
+            tp_group.tp_size);
     }
 };
 

--- a/src/runtime/models/pixart/pipeline.cpp
+++ b/src/runtime/models/pixart/pipeline.cpp
@@ -500,9 +500,13 @@ ImageResult video_to_image(const VideoResult& vr, int32_t default_h, int32_t def
 PixArtPipeline::PixArtPipeline(std::unique_ptr<TrtModule> text_encoder,
                                std::unique_ptr<TrtModule> denoiser, std::unique_ptr<TrtModule> vae,
                                DiffusionConfig config, PreprocessorWeights weights,
-                               std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str)
-    : text_encoder_(std::move(text_encoder)), denoiser_(std::move(denoiser)), vae_(std::move(vae)),
-      config_(std::move(config)), weights_(std::move(weights)), tokenizer_(std::move(tokenizer)),
+                               std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
+                               std::shared_ptr<void> distributed_owner,
+                               int32_t tensor_parallel_rank, int32_t tensor_parallel_size)
+    : distributed_owner_(std::move(distributed_owner)), tensor_parallel_rank_(tensor_parallel_rank),
+      tensor_parallel_size_(tensor_parallel_size), text_encoder_(std::move(text_encoder)),
+      denoiser_(std::move(denoiser)), vae_(std::move(vae)), config_(std::move(config)),
+      weights_(std::move(weights)), tokenizer_(std::move(tokenizer)),
       model_id_(std::move(model_id_str)) {}
 
 PixArtPipeline::~PixArtPipeline() = default;
@@ -1107,6 +1111,30 @@ bool PixArtPipeline::run_pixart_vae_decode(int32_t z_dim, int32_t t_lat, int32_t
     return true;
 }
 
+ImageResult PixArtPipeline::finish_pixart_generation(int32_t z_dim, int32_t t_lat, int32_t h_lat,
+                                                     int32_t w_lat, std::vector<float>& latents,
+                                                     VideoResult& result) {
+    denormalize_wan_latents(config_, z_dim, t_lat, h_lat, w_lat, latents);
+
+    if (tensor_parallel_size_ > 1 && tensor_parallel_rank_ != 0) {
+        std::cerr << "[pixart] TP rank " << tensor_parallel_rank_
+                  << " skips VAE decode; rank 0 writes image artifacts\n";
+        ImageResult empty;
+        empty.num_frames = 0;
+        return empty;
+    }
+
+    if (!run_pixart_vae_decode(z_dim, t_lat, h_lat, w_lat, latents, result)) {
+        return video_to_image(result, config_.video_height, config_.video_width);
+    }
+
+    result.num_frames = config_.video_num_frames;
+    std::cerr << "[diffusion] Video generation complete: " << result.num_frames << " frames, "
+              << result.height << "x" << result.width << "\n";
+
+    return video_to_image(result, config_.video_height, config_.video_width);
+}
+
 // ---------------------------------------------------------------------------
 // Main generation pipeline
 // ---------------------------------------------------------------------------
@@ -1212,20 +1240,8 @@ ImageResult PixArtPipeline::generate_image(const std::string& prompt, const Gene
         return video_to_image(result, config_.video_height, config_.video_width);
     }
 
-    // Denormalize latents and decode VAE
-    denormalize_wan_latents(config_, layout.z_dim, layout.t_lat, layout.h_lat, layout.w_lat,
-                            latents);
-
-    if (!run_pixart_vae_decode(layout.z_dim, layout.t_lat, layout.h_lat, layout.w_lat, latents,
-                               result)) {
-        return video_to_image(result, config_.video_height, config_.video_width);
-    }
-
-    result.num_frames = config_.video_num_frames;
-    std::cerr << "[diffusion] Video generation complete: " << result.num_frames << " frames, "
-              << result.height << "x" << result.width << "\n";
-
-    return video_to_image(result, config_.video_height, config_.video_width);
+    return finish_pixart_generation(layout.z_dim, layout.t_lat, layout.h_lat, layout.w_lat, latents,
+                                    result);
 }
 
 } // namespace trtmc

--- a/src/runtime/models/pixart/pipeline.h
+++ b/src/runtime/models/pixart/pipeline.h
@@ -22,7 +22,8 @@ class PixArtPipeline final : public IPipeline {
     PixArtPipeline(std::unique_ptr<TrtModule> text_encoder, std::unique_ptr<TrtModule> denoiser,
                    std::unique_ptr<TrtModule> vae, DiffusionConfig config,
                    PreprocessorWeights weights, std::shared_ptr<ITokenizer> tokenizer,
-                   std::string model_id_str);
+                   std::string model_id_str, std::shared_ptr<void> distributed_owner = {},
+                   int32_t tensor_parallel_rank = 0, int32_t tensor_parallel_size = 1);
 
     ~PixArtPipeline() override;
 
@@ -65,7 +66,13 @@ class PixArtPipeline final : public IPipeline {
                                       std::vector<float>& null_text, std::string& error);
     bool run_pixart_vae_decode(int32_t z_dim, int32_t t_lat, int32_t h_lat, int32_t w_lat,
                                std::vector<float>& latents, VideoResult& result);
+    ImageResult finish_pixart_generation(int32_t z_dim, int32_t t_lat, int32_t h_lat, int32_t w_lat,
+                                         std::vector<float>& latents, VideoResult& result);
 
+    // Keep TP communicator ownership until after TRT modules are destroyed.
+    std::shared_ptr<void> distributed_owner_;
+    int32_t tensor_parallel_rank_{0};
+    int32_t tensor_parallel_size_{1};
     std::unique_ptr<TrtModule> text_encoder_;
     std::unique_ptr<TrtModule> denoiser_;
     std::unique_ptr<TrtModule> vae_;

--- a/src/runtime/models/pixart/plugin.cpp
+++ b/src/runtime/models/pixart/plugin.cpp
@@ -6,9 +6,35 @@
 #include "runtime/models/pixart/pipeline.h"
 #include "runtime/plugins/shared/diffusion_helpers.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
+#include "utils/json_helpers.h"
+
+#include <cstdint>
+#include <string>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_denoiser_section_name(int32_t rank) {
+    return "denoiser_plan_tp_rank" + std::to_string(rank);
+}
+
+} // namespace
 
 class PixArtPlugin final : public IPipelinePlugin {
   public:
@@ -17,7 +43,21 @@ class PixArtPlugin final : public IPipelinePlugin {
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
-        auto parts = load_diffusion_parts(ctx.backend, ctx.bundle, ctx.config_json, opts);
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        std::string denoiser_section_name = "denoiser_plan";
+        ModuleCreateOptions denoiser_opts = opts;
+        const ModuleCreateOptions* denoiser_options = nullptr;
+        if (tp_config.enabled) {
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+            denoiser_section_name = tp_denoiser_section_name(tp_group.rank);
+            denoiser_opts.distributed_communicator = tp_group.communicator;
+            denoiser_opts.distributed_owner = tp_group.owner;
+            denoiser_options = &denoiser_opts;
+        }
+
+        auto parts = load_diffusion_parts(ctx.backend, ctx.bundle, ctx.config_json, opts,
+                                          denoiser_section_name, denoiser_options);
 
         // Extract first text encoder
         std::unique_ptr<TrtModule> te_module;
@@ -27,7 +67,7 @@ class PixArtPlugin final : public IPipelinePlugin {
         return std::make_unique<PixArtPipeline>(
             std::move(te_module), std::move(parts.denoiser.module), std::move(parts.vae.module),
             std::move(parts.config), std::move(parts.weights), std::move(parts.tokenizer),
-            ctx.bundle.info.model_id);
+            ctx.bundle.info.model_id, tp_group.owner, tp_group.rank, tp_group.tp_size);
     }
 };
 

--- a/src/runtime/models/wan/pipeline.cpp
+++ b/src/runtime/models/wan/pipeline.cpp
@@ -499,9 +499,13 @@ ImageResult video_to_image(const VideoResult& vr, int32_t default_h, int32_t def
 WanPipeline::WanPipeline(std::unique_ptr<TrtModule> text_encoder,
                          std::unique_ptr<TrtModule> denoiser, std::unique_ptr<TrtModule> vae,
                          DiffusionConfig config, PreprocessorWeights weights,
-                         std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str)
-    : text_encoder_(std::move(text_encoder)), denoiser_(std::move(denoiser)), vae_(std::move(vae)),
-      config_(std::move(config)), weights_(std::move(weights)), tokenizer_(std::move(tokenizer)),
+                         std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
+                         std::shared_ptr<void> distributed_owner, int32_t tensor_parallel_rank,
+                         int32_t tensor_parallel_size)
+    : distributed_owner_(std::move(distributed_owner)), tensor_parallel_rank_(tensor_parallel_rank),
+      tensor_parallel_size_(tensor_parallel_size), text_encoder_(std::move(text_encoder)),
+      denoiser_(std::move(denoiser)), vae_(std::move(vae)), config_(std::move(config)),
+      weights_(std::move(weights)), tokenizer_(std::move(tokenizer)),
       model_id_(std::move(model_id_str)) {}
 
 WanPipeline::~WanPipeline() = default;
@@ -1101,6 +1105,30 @@ bool WanPipeline::run_wan_vae_decode(int32_t z_dim, int32_t t_lat, int32_t h_lat
     return true;
 }
 
+ImageResult WanPipeline::finish_wan_generation(int32_t z_dim, int32_t t_lat, int32_t h_lat,
+                                               int32_t w_lat, std::vector<float>& latents,
+                                               VideoResult& result) {
+    denormalize_wan_latents(config_, z_dim, t_lat, h_lat, w_lat, latents);
+
+    if (tensor_parallel_size_ > 1 && tensor_parallel_rank_ != 0) {
+        std::cerr << "[wan-t2v] TP rank " << tensor_parallel_rank_
+                  << " skips VAE decode; rank 0 writes video artifacts\n";
+        ImageResult empty;
+        empty.num_frames = 0;
+        return empty;
+    }
+
+    if (!run_wan_vae_decode(z_dim, t_lat, h_lat, w_lat, latents, result)) {
+        return video_to_image(result, config_.video_height, config_.video_width);
+    }
+
+    result.num_frames = config_.video_num_frames;
+    std::cerr << "[diffusion] Video generation complete: " << result.num_frames << " frames, "
+              << result.height << "x" << result.width << "\n";
+
+    return video_to_image(result, config_.video_height, config_.video_width);
+}
+
 // ---------------------------------------------------------------------------
 // Main generation pipeline
 // ---------------------------------------------------------------------------
@@ -1205,20 +1233,8 @@ ImageResult WanPipeline::generate_image(const std::string& prompt, const Generat
         return video_to_image(result, config_.video_height, config_.video_width);
     }
 
-    // Denormalize latents and decode VAE
-    denormalize_wan_latents(config_, layout.z_dim, layout.t_lat, layout.h_lat, layout.w_lat,
-                            latents);
-
-    if (!run_wan_vae_decode(layout.z_dim, layout.t_lat, layout.h_lat, layout.w_lat, latents,
-                            result)) {
-        return video_to_image(result, config_.video_height, config_.video_width);
-    }
-
-    result.num_frames = config_.video_num_frames;
-    std::cerr << "[diffusion] Video generation complete: " << result.num_frames << " frames, "
-              << result.height << "x" << result.width << "\n";
-
-    return video_to_image(result, config_.video_height, config_.video_width);
+    return finish_wan_generation(layout.z_dim, layout.t_lat, layout.h_lat, layout.w_lat, latents,
+                                 result);
 }
 
 } // namespace trtmc

--- a/src/runtime/models/wan/pipeline.h
+++ b/src/runtime/models/wan/pipeline.h
@@ -20,7 +20,9 @@ class WanPipeline final : public IPipeline {
   public:
     WanPipeline(std::unique_ptr<TrtModule> text_encoder, std::unique_ptr<TrtModule> denoiser,
                 std::unique_ptr<TrtModule> vae, DiffusionConfig config, PreprocessorWeights weights,
-                std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str);
+                std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
+                std::shared_ptr<void> distributed_owner = {}, int32_t tensor_parallel_rank = 0,
+                int32_t tensor_parallel_size = 1);
 
     ~WanPipeline() override;
 
@@ -63,7 +65,13 @@ class WanPipeline final : public IPipeline {
                                    std::vector<float>& null_text, std::string& error);
     bool run_wan_vae_decode(int32_t z_dim, int32_t t_lat, int32_t h_lat, int32_t w_lat,
                             std::vector<float>& latents, VideoResult& result);
+    ImageResult finish_wan_generation(int32_t z_dim, int32_t t_lat, int32_t h_lat, int32_t w_lat,
+                                      std::vector<float>& latents, VideoResult& result);
 
+    // Keep TP communicator ownership until after TRT modules are destroyed.
+    std::shared_ptr<void> distributed_owner_;
+    int32_t tensor_parallel_rank_{0};
+    int32_t tensor_parallel_size_{1};
     std::unique_ptr<TrtModule> text_encoder_;
     std::unique_ptr<TrtModule> denoiser_;
     std::unique_ptr<TrtModule> vae_;

--- a/src/runtime/models/wan/plugin.cpp
+++ b/src/runtime/models/wan/plugin.cpp
@@ -4,9 +4,35 @@
 #include "runtime/models/wan/pipeline.h"
 #include "runtime/plugins/shared/diffusion_helpers.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
+#include "utils/json_helpers.h"
+
+#include <cstdint>
+#include <string>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_denoiser_section_name(int32_t rank) {
+    return "denoiser_plan_tp_rank" + std::to_string(rank);
+}
+
+} // namespace
 
 class WanPlugin final : public IPipelinePlugin {
   public:
@@ -15,17 +41,31 @@ class WanPlugin final : public IPipelinePlugin {
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
-        auto parts = load_diffusion_parts(ctx.backend, ctx.bundle, ctx.config_json, opts);
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        std::string denoiser_section_name = "denoiser_plan";
+        ModuleCreateOptions denoiser_opts = opts;
+        const ModuleCreateOptions* denoiser_options = nullptr;
+        if (tp_config.enabled) {
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+            denoiser_section_name = tp_denoiser_section_name(tp_group.rank);
+            denoiser_opts.distributed_communicator = tp_group.communicator;
+            denoiser_opts.distributed_owner = tp_group.owner;
+            denoiser_options = &denoiser_opts;
+        }
+
+        auto parts = load_diffusion_parts(ctx.backend, ctx.bundle, ctx.config_json, opts,
+                                          denoiser_section_name, denoiser_options);
 
         // Extract first text encoder
         std::unique_ptr<TrtModule> te_module;
         if (!parts.text_encoders.empty())
             te_module = std::move(parts.text_encoders[0].module);
 
-        return std::make_unique<WanPipeline>(std::move(te_module), std::move(parts.denoiser.module),
-                                             std::move(parts.vae.module), std::move(parts.config),
-                                             std::move(parts.weights), std::move(parts.tokenizer),
-                                             ctx.bundle.info.model_id);
+        return std::make_unique<WanPipeline>(
+            std::move(te_module), std::move(parts.denoiser.module), std::move(parts.vae.module),
+            std::move(parts.config), std::move(parts.weights), std::move(parts.tokenizer),
+            ctx.bundle.info.model_id, tp_group.owner, tp_group.rank, tp_group.tp_size);
     }
 };
 

--- a/src/runtime/models/z_image/pipeline.cpp
+++ b/src/runtime/models/z_image/pipeline.cpp
@@ -197,9 +197,12 @@ ZImagePipeline::ZImagePipeline(std::unique_ptr<TrtModule> text_encoder,
                                DiffusionConfig config, PreprocessorWeights weights,
                                ZImagePreprocessorWeights z_weights,
                                std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
-                               std::string bundle_path)
-    : text_encoder_(std::move(text_encoder)), denoiser_(std::move(denoiser)), vae_(std::move(vae)),
-      config_(std::move(config)), weights_(std::move(weights)), z_weights_(std::move(z_weights)),
+                               std::string bundle_path, std::shared_ptr<void> distributed_owner,
+                               int32_t tensor_parallel_rank, int32_t tensor_parallel_size)
+    : distributed_owner_(std::move(distributed_owner)), tensor_parallel_rank_(tensor_parallel_rank),
+      tensor_parallel_size_(tensor_parallel_size), text_encoder_(std::move(text_encoder)),
+      denoiser_(std::move(denoiser)), vae_(std::move(vae)), config_(std::move(config)),
+      weights_(std::move(weights)), z_weights_(std::move(z_weights)),
       tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
       bundle_path_(std::move(bundle_path)) {
     std::cerr << "[z-image] ZImagePipeline initialized"
@@ -523,6 +526,43 @@ void ZImagePipeline::unpatchify_2d(const std::vector<float>& patches, int32_t c,
     }
 }
 
+ImageResult ZImagePipeline::decode_z_image_result(int32_t z_dim, int32_t h_lat, int32_t w_lat,
+                                                  std::vector<float>& latents, ImageResult result) {
+    denormalize_latents(latents);
+
+    if (tensor_parallel_size_ > 1 && tensor_parallel_rank_ != 0) {
+        std::cerr << "[z-image] TP rank " << tensor_parallel_rank_
+                  << " skips VAE decode; rank 0 writes image artifacts\n";
+        ImageResult empty;
+        empty.num_frames = 0;
+        return empty;
+    }
+
+    std::cerr << "[z-image] Decoding latents via VAE ...\n";
+    if (!vae_) {
+        std::cerr << "[z-image] No VAE decoder module\n";
+        return result;
+    }
+
+    const int32_t h_out = h_lat * 8;
+    const int32_t w_out = w_lat * 8;
+
+    TensorMap vae_inputs;
+    vae_inputs["latent_input"] = Tensor{
+        latents.data(),
+        {1, static_cast<int64_t>(z_dim), static_cast<int64_t>(h_lat), static_cast<int64_t>(w_lat)},
+        DType::kFloat32};
+
+    auto vae_outputs = vae_->forward(vae_inputs);
+
+    const auto& vae_out = vae_outputs["decoder_output"];
+    const auto* raw_pixels = static_cast<const float*>(vae_out.data);
+
+    result = convert_vae_output(raw_pixels, h_out, w_out);
+    std::cerr << "[z-image] Image generated: " << result.width << "x" << result.height << "\n";
+    return result;
+}
+
 // ---------------------------------------------------------------------------
 // generate_image — full Z-Image pipeline
 // ---------------------------------------------------------------------------
@@ -673,37 +713,7 @@ ImageResult ZImagePipeline::generate_image(const std::string& prompt, const Gene
         log_step_stats(step, num_inference_steps, raw_timestep, latents);
     }
 
-    // ── 9. Denormalize latents ──
-    denormalize_latents(latents);
-
-    // ── 10. Run VAE decode via TrtModule::forward() ──
-    std::cerr << "[z-image] Decoding latents via VAE ...\n";
-    if (!vae_) {
-        std::cerr << "[z-image] No VAE decoder module\n";
-        return result;
-    }
-
-    {
-        const int32_t h_out = layout.h_lat * 8;
-        const int32_t w_out = layout.w_lat * 8;
-
-        TensorMap vae_inputs;
-        vae_inputs["latent_input"] =
-            Tensor{latents.data(),
-                   {1, static_cast<int64_t>(layout.z_dim), static_cast<int64_t>(layout.h_lat),
-                    static_cast<int64_t>(layout.w_lat)},
-                   DType::kFloat32};
-
-        auto vae_outputs = vae_->forward(vae_inputs);
-
-        const auto& vae_out = vae_outputs["decoder_output"];
-        const auto* raw_pixels = static_cast<const float*>(vae_out.data);
-
-        result = convert_vae_output(raw_pixels, h_out, w_out);
-    }
-
-    std::cerr << "[z-image] Image generated: " << result.width << "x" << result.height << "\n";
-    return result;
+    return decode_z_image_result(layout.z_dim, layout.h_lat, layout.w_lat, latents, result);
 }
 
 } // namespace trtmc

--- a/src/runtime/models/z_image/pipeline.h
+++ b/src/runtime/models/z_image/pipeline.h
@@ -39,7 +39,8 @@ class ZImagePipeline final : public IPipeline {
                    std::unique_ptr<TrtModule> vae, DiffusionConfig config,
                    PreprocessorWeights weights, ZImagePreprocessorWeights z_weights,
                    std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
-                   std::string bundle_path);
+                   std::string bundle_path, std::shared_ptr<void> distributed_owner = {},
+                   int32_t tensor_parallel_rank = 0, int32_t tensor_parallel_size = 1);
 
     ~ZImagePipeline() override;
 
@@ -63,7 +64,13 @@ class ZImagePipeline final : public IPipeline {
                      std::vector<float>& patches) const;
     void unpatchify_2d(const std::vector<float>& patches, int32_t c, int32_t h, int32_t w,
                        std::vector<float>& output) const;
+    ImageResult decode_z_image_result(int32_t z_dim, int32_t h_lat, int32_t w_lat,
+                                      std::vector<float>& latents, ImageResult result);
 
+    // Keep TP communicator ownership until after TRT modules are destroyed.
+    std::shared_ptr<void> distributed_owner_;
+    int32_t tensor_parallel_rank_{0};
+    int32_t tensor_parallel_size_{1};
     std::unique_ptr<TrtModule> text_encoder_;
     std::unique_ptr<TrtModule> denoiser_;
     std::unique_ptr<TrtModule> vae_;

--- a/src/runtime/models/z_image/plugin.cpp
+++ b/src/runtime/models/z_image/plugin.cpp
@@ -7,14 +7,34 @@
 #include "runtime/models/z_image/pipeline.h"
 #include "runtime/plugins/shared/diffusion_helpers.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
+#include "utils/json_helpers.h"
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>
 
 namespace trtmc {
 namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_denoiser_section_name(int32_t rank) {
+    return "denoiser_plan_tp_rank" + std::to_string(rank);
+}
 
 // Parse Z-Image-specific preprocessor weights from the preprocessor_weights
 // bundle section. These weights are separate from the standard
@@ -74,7 +94,21 @@ class ZImagePlugin final : public IPipelinePlugin {
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
-        auto parts = load_diffusion_parts(ctx.backend, ctx.bundle, ctx.config_json, opts);
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        std::string denoiser_section_name = "denoiser_plan";
+        ModuleCreateOptions denoiser_opts = opts;
+        const ModuleCreateOptions* denoiser_options = nullptr;
+        if (tp_config.enabled) {
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+            denoiser_section_name = tp_denoiser_section_name(tp_group.rank);
+            denoiser_opts.distributed_communicator = tp_group.communicator;
+            denoiser_opts.distributed_owner = tp_group.owner;
+            denoiser_options = &denoiser_opts;
+        }
+
+        auto parts = load_diffusion_parts(ctx.backend, ctx.bundle, ctx.config_json, opts,
+                                          denoiser_section_name, denoiser_options);
 
         // Extract first text encoder
         std::unique_ptr<TrtModule> te_module;
@@ -90,7 +124,8 @@ class ZImagePlugin final : public IPipelinePlugin {
         return std::make_unique<ZImagePipeline>(
             std::move(te_module), std::move(parts.denoiser.module), std::move(parts.vae.module),
             std::move(parts.config), std::move(parts.weights), std::move(z_pw),
-            std::move(parts.tokenizer), ctx.bundle.info.model_id, ctx.bundle_path);
+            std::move(parts.tokenizer), ctx.bundle.info.model_id, ctx.bundle_path, tp_group.owner,
+            tp_group.rank, tp_group.tp_size);
     }
 };
 

--- a/src/runtime/plugins/shared/diffusion_helpers.cpp
+++ b/src/runtime/plugins/shared/diffusion_helpers.cpp
@@ -42,11 +42,16 @@ DiffusionConfig make_diffusion_config(const std::string& json) {
 }
 
 DiffusionParts load_diffusion_parts(IBackend* backend, const BundleFile& bundle,
-                                    const std::string& json, const ModuleCreateOptions& options) {
+                                    const std::string& json, const ModuleCreateOptions& options,
+                                    const std::string& denoiser_section_name,
+                                    const ModuleCreateOptions* denoiser_options) {
     DiffusionParts parts;
 
-    parts.denoiser = load_trt_module_from_plan(backend, find_section(bundle, "denoiser_plan"),
-                                               "denoiser_plan", options);
+    const ModuleCreateOptions& effective_denoiser_options =
+        denoiser_options != nullptr ? *denoiser_options : options;
+    parts.denoiser =
+        load_trt_module_from_plan(backend, find_section(bundle, denoiser_section_name),
+                                  denoiser_section_name.c_str(), effective_denoiser_options);
     parts.vae = load_trt_module_from_plan(backend, find_section(bundle, "vae_decoder_plan"),
                                           "vae_decoder_plan", options);
 

--- a/src/runtime/plugins/shared/diffusion_helpers.h
+++ b/src/runtime/plugins/shared/diffusion_helpers.h
@@ -20,6 +20,8 @@ struct DiffusionParts {
 
 DiffusionParts load_diffusion_parts(IBackend* backend, const BundleFile& bundle,
                                     const std::string& json,
-                                    const ModuleCreateOptions& options = {});
+                                    const ModuleCreateOptions& options = {},
+                                    const std::string& denoiser_section_name = "denoiser_plan",
+                                    const ModuleCreateOptions* denoiser_options = nullptr);
 
 } // namespace trtmc

--- a/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
@@ -26,6 +26,7 @@ from .triattention_export import (
 from .parallel_config import (
     ParallelConfig,
     normalize_parallel_config,
+    rank_denoiser_section,
     rank_engine_section,
     require_tensorrt_11_for_tensor_parallel,
 )
@@ -1244,10 +1245,6 @@ def _build_diffusion_bundle(
     if build_timing is None:
         build_timing = _new_build_timing()
     parallel = normalize_parallel_config(parallel_config)
-    if parallel.enabled:
-        raise NotImplementedError(
-            "Tensor-parallel diffusion builds are not implemented yet; "
-            "decoder TP is the active first target.")
     # Parse model_index.json to determine pipeline type
     model_index = json.loads(
         (model_dir_path / "model_index.json").read_text())
@@ -1268,6 +1265,9 @@ def _build_diffusion_bundle(
             f"Supported: {supported}")
 
     model_type = getattr(plugin, 'name', pipeline_class.lower())
+    if parallel.enabled:
+        require_tensorrt_11_for_tensor_parallel(
+            parallel, feature="Diffusion tensor-parallel builds")
     config = ModelConfig(model_type=model_type, raw=model_index)
     config.raw["max_cache_length"] = max_cache_length
     if diffusion_overrides:
@@ -1344,6 +1344,11 @@ def _build_diffusion_bundle(
             build_components_kwargs["precision"] = precision
         if _call_supports_kwarg(build_components, "build_timing"):
             build_components_kwargs["build_timing"] = build_timing
+        if _call_supports_kwarg(build_components, "parallel_config"):
+            build_components_kwargs["parallel_config"] = parallel
+        elif parallel.enabled:
+            raise NotImplementedError(
+                f"Plugin {plugin.name} does not accept parallel_config for diffusion TP")
         components = build_components(
             str(model_dir_path), config, weights, **build_components_kwargs)
     finally:
@@ -1378,11 +1383,29 @@ def _build_diffusion_bundle(
             file=sys.stderr,
         )
 
-    # Denoiser plan
-    denoiser_plan = components["denoiser"]
-    sections.append(BundleSection("denoiser_plan", denoiser_plan))
-    print(f"  denoiser: {len(denoiser_plan) / (1024 * 1024):.1f} MB",
-          file=sys.stderr)
+    # Denoiser plan(s)
+    if parallel.enabled:
+        denoiser_rank_plans = components.get("denoiser_ranks")
+        if not isinstance(denoiser_rank_plans, dict):
+            raise ValueError(
+                f"Plugin {plugin.name}.build_components() did not return denoiser_ranks")
+        for rank in range(parallel.tp_size):
+            denoiser_plan = denoiser_rank_plans.get(rank)
+            if denoiser_plan is None:
+                denoiser_plan = denoiser_rank_plans.get(str(rank))
+            if denoiser_plan is None:
+                raise ValueError(f"Missing tensor-parallel denoiser plan for rank {rank}")
+            section_name = rank_denoiser_section(rank)
+            sections.append(BundleSection(section_name, denoiser_plan))
+            print(
+                f"  {section_name}: {len(denoiser_plan) / (1024 * 1024):.1f} MB",
+                file=sys.stderr,
+            )
+    else:
+        denoiser_plan = components["denoiser"]
+        sections.append(BundleSection("denoiser_plan", denoiser_plan))
+        print(f"  denoiser: {len(denoiser_plan) / (1024 * 1024):.1f} MB",
+              file=sys.stderr)
 
     # VAE decoder plan
     vae_plan = components["vae_decoder"]
@@ -1442,6 +1465,7 @@ def _build_diffusion_bundle(
             diff_cfg = get_diff_config(config)
             if diff_cfg is not None:
                 cfg_dict.update(diff_cfg)
+        cfg_dict.update(parallel.to_bundle_config_fields())
 
         cfg_data = json.dumps(cfg_dict, indent=2).encode("utf-8")
 

--- a/tensorrt_model_connect/tensorrt_model_connect/families/flux/flux_dit_tp_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/flux/flux_dit_tp_builder.py
@@ -1,0 +1,701 @@
+"""FLUX DiT (Diffusion Transformer) engine builder.
+
+Builds a TensorRT engine for the FLUX-specific transformer denoiser,
+which has two types of blocks:
+  1. Joint transformer blocks (double-stream): image and text attend jointly
+  2. Single transformer blocks (single-stream): operate on concatenated tokens
+
+Engine I/O:
+    Inputs:
+        hidden_states [num_img_tokens, dim] float32 (x_embedder output)
+        encoder_hidden_states [text_seq_len, dim] float32 (context_embedder output)
+        temb [dim] float32  (combined timestep+text+guidance embedding)
+        rotary_cos [total_seq_len, head_dim] float32
+        rotary_sin [total_seq_len, head_dim] float32
+    Outputs:
+        output [num_img_tokens, out_channels] float32
+
+Preprocessor weights (timestep MLP, guidance MLP, text embedder, x_embedder,
+context_embedder, RoPE) are handled externally by the runtime.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import (
+    ParallelConfig,
+    _slice_first_dim,
+    _slice_last_dim,
+    add_all_reduce_sum,
+    normalize_parallel_config,
+    validate_flux_dit_tp,
+)
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+
+
+def build_flux_dit_engine(
+    weights: "WeightDict",
+    *,
+    dim: int = 3072,
+    num_heads: int = 24,
+    num_layers: int = 19,
+    num_single_layers: int = 38,
+    num_img_tokens: int,
+    text_seq_len: int = 512,
+    mlp_ratio: float = 4.0,
+    eps: float = 1e-6,
+    verbose: bool = False,
+    parallel_config: ParallelConfig | None = None,
+) -> bytes:
+    """Build FLUX DiT denoiser TRT engine plan."""
+    head_dim = dim // num_heads
+    ffn_dim = int(dim * mlp_ratio)  # For GELU-approximate FFN
+    total_seq = text_seq_len + num_img_tokens
+    parallel = normalize_parallel_config(parallel_config)
+    validate_flux_dit_tp(
+        dim=dim, num_heads=num_heads, ffn_dim=ffn_dim, parallel=parallel)
+    local_num_heads = num_heads // parallel.tp_size
+    local_dim = dim // parallel.tp_size
+    local_ffn_dim = ffn_dim // parallel.tp_size
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
+
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    # --- Inputs ---
+    hidden_inp = network.add_input(
+        "hidden_states", trt.float32, (num_img_tokens, dim))
+    encoder_inp = network.add_input(
+        "encoder_hidden_states", trt.float32, (text_seq_len, dim))
+    temb_inp = network.add_input(
+        "temb", trt.float32, (dim,))
+    rotary_cos = network.add_input(
+        "rotary_cos", trt.float32, (total_seq, head_dim))
+    rotary_sin = network.add_input(
+        "rotary_sin", trt.float32, (total_seq, head_dim))
+
+    # Constants
+    eps_np = np.array([eps], dtype=np.float32)
+    eps_t = graph_ops.add_constant(network, (1, 1), eps_np)
+
+    # Split RoPE for text and image
+    txt_cos = network.add_slice(rotary_cos, (0, 0), (text_seq_len, head_dim), (1, 1)).get_output(0)
+    txt_sin = network.add_slice(rotary_sin, (0, 0), (text_seq_len, head_dim), (1, 1)).get_output(0)
+    img_cos = network.add_slice(rotary_cos, (text_seq_len, 0), (num_img_tokens, head_dim), (1, 1)).get_output(0)
+    img_sin = network.add_slice(rotary_sin, (text_seq_len, 0), (num_img_tokens, head_dim), (1, 1)).get_output(0)
+
+    hidden = hidden_inp
+    encoder_hidden = encoder_inp
+
+    # ===================== Joint Transformer Blocks =====================
+    for layer_idx in range(num_layers):
+        p = f"transformer_blocks.{layer_idx}"
+
+        # --- AdaLN-Zero for image (norm1) ---
+        # norm1.linear: SiLU(temb) -> Linear(dim, 6*dim) -> chunk(6)
+        norm1_w = weights[f"{p}.norm1.linear.weight"]  # [dim, 6*dim]
+        norm1_b = weights[f"{p}.norm1.linear.bias"]    # [6*dim]
+
+        temb_silu = network.add_activation(temb_inp, trt.ActivationType.SIGMOID)
+        temb_silu_out = network.add_elementwise(
+            temb_inp, temb_silu.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+
+        norm1_proj = _matmul_bias_1d(network, temb_silu_out, dim, 6 * dim, norm1_w, norm1_b)
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = _chunk_6(
+            network, norm1_proj, dim)
+
+        # AdaLN: LayerNorm(x) * (1 + scale) + shift
+        normed_hidden = _adaln_modulate(network, hidden, scale_msa, shift_msa, dim, eps_t, num_img_tokens)
+
+        # --- AdaLN-Zero for text (norm1_context) ---
+        ctx_norm1_w = weights[f"{p}.norm1_context.linear.weight"]
+        ctx_norm1_b = weights[f"{p}.norm1_context.linear.bias"]
+
+        ctx_norm1_proj = _matmul_bias_1d(network, temb_silu_out, dim, 6 * dim, ctx_norm1_w, ctx_norm1_b)
+        c_shift_msa, c_scale_msa, c_gate_msa, c_shift_mlp, c_scale_mlp, c_gate_mlp = _chunk_6(
+            network, ctx_norm1_proj, dim)
+
+        normed_encoder = _adaln_modulate(
+            network, encoder_hidden, c_scale_msa, c_shift_msa, dim, eps_t, text_seq_len)
+
+        # --- Joint Attention ---
+        # Image QKV
+        q_img = _linear_col_parallel(
+            network, normed_hidden, dim, dim, weights, f"{p}.attn.to_q", parallel)
+        k_img = _linear_col_parallel(
+            network, normed_hidden, dim, dim, weights, f"{p}.attn.to_k", parallel)
+        v_img = _linear_col_parallel(
+            network, normed_hidden, dim, dim, weights, f"{p}.attn.to_v", parallel)
+
+        # Text QKV (added projections)
+        q_txt = _linear_col_parallel(
+            network, normed_encoder, dim, dim, weights, f"{p}.attn.add_q_proj", parallel)
+        k_txt = _linear_col_parallel(
+            network, normed_encoder, dim, dim, weights, f"{p}.attn.add_k_proj", parallel)
+        v_txt = _linear_col_parallel(
+            network, normed_encoder, dim, dim, weights, f"{p}.attn.add_v_proj", parallel)
+
+        # QK norm
+        q_img = _rms_norm_per_head_seq(network, q_img, local_num_heads, head_dim, weights[f"{p}.attn.norm_q.weight"], eps_t, num_img_tokens)
+        k_img = _rms_norm_per_head_seq(network, k_img, local_num_heads, head_dim, weights[f"{p}.attn.norm_k.weight"], eps_t, num_img_tokens)
+        q_txt = _rms_norm_per_head_seq(network, q_txt, local_num_heads, head_dim, weights[f"{p}.attn.norm_added_q.weight"], eps_t, text_seq_len)
+        k_txt = _rms_norm_per_head_seq(network, k_txt, local_num_heads, head_dim, weights[f"{p}.attn.norm_added_k.weight"], eps_t, text_seq_len)
+
+        # Apply RoPE to image Q, K
+        q_img = _apply_native_rope_from_full_cache(
+            network, q_img, img_cos, img_sin, local_num_heads, head_dim, num_img_tokens)
+        k_img = _apply_native_rope_from_full_cache(
+            network, k_img, img_cos, img_sin, local_num_heads, head_dim, num_img_tokens)
+
+        # Apply RoPE to text Q, K
+        q_txt = _apply_native_rope_from_full_cache(
+            network, q_txt, txt_cos, txt_sin, local_num_heads, head_dim, text_seq_len)
+        k_txt = _apply_native_rope_from_full_cache(
+            network, k_txt, txt_cos, txt_sin, local_num_heads, head_dim, text_seq_len)
+
+        # Concatenate: [text, image] for joint attention
+        q_cat = network.add_concatenation([q_txt, q_img])
+        q_cat.axis = 0  # [total_seq, dim]
+        k_cat = network.add_concatenation([k_txt, k_img])
+        k_cat.axis = 0
+        v_cat = network.add_concatenation([v_txt, v_img])
+        v_cat.axis = 0
+
+        # Multi-head attention
+        attn_out = _mha(network, q_cat.get_output(0), k_cat.get_output(0),
+                        v_cat.get_output(0), local_num_heads, head_dim, total_seq)
+
+        # Split attention output back into text and image
+        txt_attn = network.add_slice(attn_out, (0, 0), (text_seq_len, local_dim), (1, 1)).get_output(0)
+        img_attn = network.add_slice(attn_out, (text_seq_len, 0), (num_img_tokens, local_dim), (1, 1)).get_output(0)
+
+        # Image output projection + gate + residual
+        img_attn_proj = _linear_row_parallel(
+            network, img_attn, local_dim, dim, weights, f"{p}.attn.to_out.0", parallel)
+        img_attn_gated = _gate_1d(network, img_attn_proj, gate_msa, num_img_tokens)
+        hidden = network.add_elementwise(
+            hidden, img_attn_gated,
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+        # Text output projection + gate + residual
+        txt_attn_proj = _linear_row_parallel(
+            network, txt_attn, local_dim, dim, weights, f"{p}.attn.to_add_out", parallel)
+        txt_attn_gated = _gate_1d(network, txt_attn_proj, c_gate_msa, text_seq_len)
+        encoder_hidden = network.add_elementwise(
+            encoder_hidden, txt_attn_gated,
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+        # --- Image FFN ---
+        normed_ff = _layernorm_modulate(
+            network, hidden, scale_mlp, shift_mlp, dim, eps_t, num_img_tokens)
+        ff_out = _gelu_ffn(network, normed_ff, dim, weights, f"{p}.ff", parallel)
+        ff_gated = _gate_1d(network, ff_out, gate_mlp, num_img_tokens)
+        hidden = network.add_elementwise(
+            hidden, ff_gated,
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+        # --- Text FFN ---
+        normed_ctx_ff = _layernorm_modulate(
+            network, encoder_hidden, c_scale_mlp, c_shift_mlp, dim, eps_t, text_seq_len)
+        ctx_ff_out = _gelu_ffn(network, normed_ctx_ff, dim, weights, f"{p}.ff_context", parallel)
+        ctx_ff_gated = _gate_1d(network, ctx_ff_out, c_gate_mlp, text_seq_len)
+        encoder_hidden = network.add_elementwise(
+            encoder_hidden, ctx_ff_gated,
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+    # ===================== Single Transformer Blocks =====================
+    for layer_idx in range(num_single_layers):
+        p = f"single_transformer_blocks.{layer_idx}"
+
+        # Concatenate text + image
+        cat_hidden = network.add_concatenation([encoder_hidden, hidden])
+        cat_hidden.axis = 0  # [total_seq, dim]
+        residual = cat_hidden.get_output(0)
+
+        # AdaLN-Zero Single: SiLU(temb) -> Linear(dim, 3*dim) -> chunk(3)
+        norm_w = weights[f"{p}.norm.linear.weight"]
+        norm_b = weights[f"{p}.norm.linear.bias"]
+
+        temb_silu2 = network.add_activation(temb_inp, trt.ActivationType.SIGMOID)
+        temb_silu2_out = network.add_elementwise(
+            temb_inp, temb_silu2.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+
+        norm_proj = _matmul_bias_1d(network, temb_silu2_out, dim, 3 * dim, norm_w, norm_b)
+        shift_msa_s, scale_msa_s, gate_msa_s = _chunk_3(network, norm_proj, dim)
+
+        normed_cat = _adaln_modulate(
+            network, residual, scale_msa_s, shift_msa_s, dim, eps_t, total_seq)
+
+        # Parallel MLP: proj_mlp -> GELU_tanh
+        mlp_hidden = _linear_col_parallel(
+            network, normed_cat, dim, ffn_dim, weights, f"{p}.proj_mlp", parallel)
+        mlp_hidden = graph_ops.add_gelu_tanh(network, mlp_hidden)
+
+        # Self-attention on full sequence (text + image)
+        q_s = _linear_col_parallel(
+            network, normed_cat, dim, dim, weights, f"{p}.attn.to_q", parallel)
+        k_s = _linear_col_parallel(
+            network, normed_cat, dim, dim, weights, f"{p}.attn.to_k", parallel)
+        v_s = _linear_col_parallel(
+            network, normed_cat, dim, dim, weights, f"{p}.attn.to_v", parallel)
+
+        # QK norm
+        q_s = _rms_norm_per_head_seq(network, q_s, local_num_heads, head_dim, weights[f"{p}.attn.norm_q.weight"], eps_t, total_seq)
+        k_s = _rms_norm_per_head_seq(network, k_s, local_num_heads, head_dim, weights[f"{p}.attn.norm_k.weight"], eps_t, total_seq)
+
+        # Apply RoPE (full sequence: text + image cos/sin)
+        q_s = _apply_native_rope_from_full_cache(
+            network, q_s, rotary_cos, rotary_sin, local_num_heads, head_dim, total_seq)
+        k_s = _apply_native_rope_from_full_cache(
+            network, k_s, rotary_cos, rotary_sin, local_num_heads, head_dim, total_seq)
+
+        attn_out_s = _mha(network, q_s, k_s, v_s, local_num_heads, head_dim, total_seq)
+
+        # Concatenate attn + mlp -> proj_out
+        cat_attn_mlp = network.add_concatenation([attn_out_s, mlp_hidden])
+        cat_attn_mlp.axis = 1  # [total_seq, dim + ffn_dim]
+
+        combined = _linear_single_block_out_parallel(
+            network, cat_attn_mlp.get_output(0), local_dim, local_ffn_dim,
+            dim, ffn_dim, weights, f"{p}.proj_out", parallel)
+
+        # Gate + residual
+        gated_s = _gate_1d(network, combined, gate_msa_s, total_seq)
+        cat_hidden_out = network.add_elementwise(
+            residual, gated_s,
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+        # Split back
+        encoder_hidden = network.add_slice(
+            cat_hidden_out, (0, 0), (text_seq_len, dim), (1, 1)).get_output(0)
+        hidden = network.add_slice(
+            cat_hidden_out, (text_seq_len, 0), (num_img_tokens, dim), (1, 1)).get_output(0)
+
+    # ===================== Final Output =====================
+    # AdaLayerNormContinuous: SiLU(temb) -> Linear(dim, 2*dim) -> chunk(2) -> scale, shift
+    final_norm_w = weights["norm_out.linear.weight"]
+    final_norm_b = weights["norm_out.linear.bias"]
+
+    temb_silu_f = network.add_activation(temb_inp, trt.ActivationType.SIGMOID)
+    temb_silu_f_out = network.add_elementwise(
+        temb_inp, temb_silu_f.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+
+    final_proj = _matmul_bias_1d(network, temb_silu_f_out, dim, 2 * dim, final_norm_w, final_norm_b)
+    final_scale = network.add_slice(final_proj, (0,), (dim,), (1,)).get_output(0)
+    final_shift = network.add_slice(final_proj, (dim,), (dim,), (1,)).get_output(0)
+
+    output = _adaln_modulate(
+        network, hidden, final_scale, final_shift, dim, eps_t, num_img_tokens)
+
+    # proj_out: [num_img_tokens, dim] -> [num_img_tokens, out_channels]
+    proj_out_w = weights["proj_out.weight"]
+    out_channels = proj_out_w.shape[1]
+    output = graph_ops.add_matmul_rhs_constant(
+        network, output, dim, out_channels, proj_out_w)
+    proj_out_b = weights.get("proj_out.bias")
+    if proj_out_b is not None:
+        output = graph_ops.add_bias_sum(network, output, out_channels, proj_out_b)
+
+    cast_output = network.add_cast(output, trt.float32)
+    output_final = cast_output.get_output(0)
+    output_final.name = "output"
+    network.mark_output(output_final)
+
+    tp_suffix = (
+        f", tp={parallel.tp_size}, rank={parallel.rank}"
+        if parallel.enabled else "")
+    print(f"[flux-dit] Building TRT engine "
+          f"(dim={dim}, joint={num_layers}, single={num_single_layers}, "
+          f"img_tokens={num_img_tokens}, text_seq={text_seq_len}{tp_suffix}) ...",
+          file=sys.stderr)
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError("TRT engine serialization failed for FLUX DiT")
+    return bytes(plan)
+
+
+# ============================================================================
+# Helper functions
+# ============================================================================
+
+def _matmul_bias_1d(network, inp, in_dim, out_dim, weight, bias):
+    """Matmul + bias for 1D input: [in_dim] -> [out_dim]."""
+    inp_2d = network.add_shuffle(inp)
+    inp_2d.reshape_dims = (1, in_dim)
+    out = graph_ops.add_matmul_rhs_constant(
+        network, inp_2d.get_output(0), in_dim, out_dim, weight)
+    out = graph_ops.add_bias_sum(network, out, out_dim, bias)
+    flat = network.add_shuffle(out)
+    flat.reshape_dims = (out_dim,)
+    return flat.get_output(0)
+
+
+def _chunk_6(network, tensor, dim):
+    """Split [6*dim] into 6 x [dim]."""
+    chunks = []
+    for i in range(6):
+        s = network.add_slice(tensor, (i * dim,), (dim,), (1,))
+        chunks.append(s.get_output(0))
+    return chunks
+
+
+def _chunk_3(network, tensor, dim):
+    """Split [3*dim] into 3 x [dim]."""
+    chunks = []
+    for i in range(3):
+        s = network.add_slice(tensor, (i * dim,), (dim,), (1,))
+        chunks.append(s.get_output(0))
+    return chunks
+
+
+def _adaln_modulate(network, x, scale, shift, dim, eps_t, seq_len):
+    """AdaLN: LayerNorm(x) * (1 + scale) + shift.
+    x: [seq_len, dim], scale/shift: [dim] (1D from chunk)."""
+    normed = graph_ops.add_layer_norm_no_affine(network, x, dim, eps_t)
+
+    # Reshape scale/shift from [dim] to [1, dim] for broadcast with [seq_len, dim]
+    scale_2d = network.add_shuffle(scale)
+    scale_2d.reshape_dims = (1, dim)
+    shift_2d = network.add_shuffle(shift)
+    shift_2d.reshape_dims = (1, dim)
+
+    one_const = graph_ops.add_constant(network, (1, 1), np.array([1.0], dtype=np.float32))
+    scale_plus_1 = network.add_elementwise(
+        one_const, scale_2d.get_output(0), trt.ElementWiseOperation.SUM).get_output(0)
+
+    scaled = network.add_elementwise(
+        normed, scale_plus_1, trt.ElementWiseOperation.PROD)
+    shifted = network.add_elementwise(
+        scaled.get_output(0), shift_2d.get_output(0), trt.ElementWiseOperation.SUM)
+    return shifted.get_output(0)
+
+
+def _layernorm_modulate(network, x, scale, shift, dim, eps_t, seq_len):
+    """LayerNorm(x) * (1 + scale) + shift."""
+    return _adaln_modulate(network, x, scale, shift, dim, eps_t, seq_len)
+
+
+def _linear(network, inp, in_dim, out_dim, weights, prefix):
+    """Linear projection with optional bias."""
+    out = graph_ops.add_matmul_rhs_constant(
+        network, inp, in_dim, out_dim, weights[f"{prefix}.weight"])
+    b = weights.get(f"{prefix}.bias")
+    if b is not None:
+        out = graph_ops.add_bias_sum(network, out, out_dim, b)
+    return out
+
+
+def _linear_col_parallel(
+    network,
+    inp,
+    in_dim: int,
+    out_dim: int,
+    weights,
+    prefix: str,
+    parallel: ParallelConfig,
+):
+    """Column-parallel linear: output features are rank-local."""
+    local_out_dim = out_dim // parallel.tp_size
+    weight = weights[f"{prefix}.weight"]
+    if parallel.enabled:
+        weight = _slice_last_dim(weight, parallel.rank, parallel.tp_size)
+    out = graph_ops.add_matmul_rhs_constant(network, inp, in_dim, local_out_dim, weight)
+    bias = weights.get(f"{prefix}.bias")
+    if bias is not None:
+        if parallel.enabled:
+            bias = _slice_first_dim(bias, parallel.rank, parallel.tp_size)
+        out = graph_ops.add_bias_sum(network, out, local_out_dim, bias)
+    return out
+
+
+def _linear_row_parallel(
+    network,
+    inp,
+    in_dim: int,
+    out_dim: int,
+    weights,
+    prefix: str,
+    parallel: ParallelConfig,
+):
+    """Row-parallel linear: partial outputs are all-reduced across TP ranks."""
+    weight = weights[f"{prefix}.weight"]
+    if parallel.enabled:
+        weight = _slice_first_dim(weight, parallel.rank, parallel.tp_size)
+    out = graph_ops.add_matmul_rhs_constant(network, inp, in_dim, out_dim, weight)
+    if parallel.enabled:
+        out = add_all_reduce_sum(network, out, parallel.tp_size)
+    bias = weights.get(f"{prefix}.bias")
+    if bias is not None:
+        out = graph_ops.add_bias_sum(network, out, out_dim, bias)
+    return out
+
+
+def _slice_single_block_proj_out_weight(
+    weight: np.ndarray,
+    *,
+    dim: int,
+    ffn_dim: int,
+    parallel: ParallelConfig,
+) -> np.ndarray:
+    """Shard the single-block proj_out rows across attention and MLP halves."""
+    if not parallel.enabled:
+        return weight
+    attn_weight = _slice_first_dim(weight[:dim, :], parallel.rank, parallel.tp_size)
+    mlp_weight = _slice_first_dim(weight[dim:dim + ffn_dim, :], parallel.rank, parallel.tp_size)
+    return np.ascontiguousarray(np.concatenate([attn_weight, mlp_weight], axis=0))
+
+
+def _linear_single_block_out_parallel(
+    network,
+    inp,
+    local_dim: int,
+    local_ffn_dim: int,
+    dim: int,
+    ffn_dim: int,
+    weights,
+    prefix: str,
+    parallel: ParallelConfig,
+):
+    """Single-block row-parallel projection from local attention+MLP features."""
+    weight = _slice_single_block_proj_out_weight(
+        weights[f"{prefix}.weight"], dim=dim, ffn_dim=ffn_dim, parallel=parallel)
+    in_features = local_dim + local_ffn_dim
+    out = graph_ops.add_matmul_rhs_constant(network, inp, in_features, dim, weight)
+    if parallel.enabled:
+        out = add_all_reduce_sum(network, out, parallel.tp_size)
+    bias = weights.get(f"{prefix}.bias")
+    if bias is not None:
+        out = graph_ops.add_bias_sum(network, out, dim, bias)
+    return out
+
+
+def _rms_norm_per_head_seq(network, x, num_heads, head_dim, weight, eps_t, seq_len):
+    """Per-head RMS norm for [seq_len, dim] tensors with [head_dim] weights.
+
+    Reshapes to [seq_len, num_heads, head_dim], applies RMS norm on head_dim axis,
+    then reshapes back to [seq_len, dim].
+    """
+    return graph_ops.add_rms_norm_per_head(
+        network, x, num_heads, head_dim, weight, eps_t,
+        sequence_length=seq_len)
+
+
+def _apply_native_rope_from_full_cache(
+    network, x, cos_vals, sin_vals, num_heads, head_dim, seq_len,
+):
+    """Apply TRT native RoPE using runtime full-dimension cos/sin rows."""
+    return graph_ops.add_apply_rope_native_from_full_cache(
+        network, x, num_heads, head_dim, cos_vals, sin_vals,
+        seq_len, interleaved=True)
+
+
+def _mha(network, q, k, v, num_heads, head_dim, seq_len):
+    """Multi-head attention: returns [seq_len, dim]."""
+    return graph_ops.add_attention_from_rows(
+        network, q, k, v,
+        num_heads=num_heads, head_dim=head_dim,
+        q_seq=seq_len, kv_seq=seq_len)
+
+
+def _gate_1d(network, x, gate, seq_len):
+    """Gate: x * gate (broadcast gate [dim] over [seq_len, dim]).
+    gate is [dim] (1D), x is [seq_len, dim] (2D). Reshape gate for broadcast."""
+    # Reshape gate from [dim] to [1, dim] for TRT broadcast
+    gate_2d = network.add_shuffle(gate)
+    gate_2d.reshape_dims = (1, -1)
+    return network.add_elementwise(
+        x, gate_2d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def _gelu_ffn(network, inp, dim, weights, prefix, parallel: ParallelConfig):
+    """GELU-approximate FFN: Linear(dim, ffn_dim) -> GELU -> Linear(ffn_dim, dim)."""
+    fc1_w = weights[f"{prefix}.net.0.proj.weight"]
+    ffn_dim = fc1_w.shape[1]
+    local_ffn_dim = ffn_dim // parallel.tp_size
+    if parallel.enabled:
+        fc1_w = _slice_last_dim(fc1_w, parallel.rank, parallel.tp_size)
+
+    fc1 = graph_ops.add_matmul_rhs_constant(network, inp, dim, local_ffn_dim, fc1_w)
+    fc1_b = weights.get(f"{prefix}.net.0.proj.bias")
+    if fc1_b is not None:
+        if parallel.enabled:
+            fc1_b = _slice_first_dim(fc1_b, parallel.rank, parallel.tp_size)
+        fc1 = graph_ops.add_bias_sum(network, fc1, local_ffn_dim, fc1_b)
+
+    act = graph_ops.add_gelu_tanh(network, fc1)
+
+    fc2_w = weights[f"{prefix}.net.2.weight"]
+    if parallel.enabled:
+        fc2_w = _slice_first_dim(fc2_w, parallel.rank, parallel.tp_size)
+    fc2 = graph_ops.add_matmul_rhs_constant(network, act, local_ffn_dim, dim, fc2_w)
+    if parallel.enabled:
+        fc2 = add_all_reduce_sum(network, fc2, parallel.tp_size)
+    fc2_b = weights.get(f"{prefix}.net.2.bias")
+    if fc2_b is not None:
+        fc2 = graph_ops.add_bias_sum(network, fc2, dim, fc2_b)
+    return fc2
+
+
+def load_flux_dit_weights(
+    model_dir: str,
+    *,
+    dim: int = 3072,
+    num_heads: int = 24,
+    num_layers: int = 19,
+    num_single_layers: int = 38,
+) -> "WeightDict":
+    """Load FLUX DiT weights from diffusers-format transformer directory."""
+    from pathlib import Path
+    from ...checkpoint_mapper import WeightDict, _open_safetensors, _load_tensor, _has_tensor
+
+    readers = _open_safetensors(Path(model_dir))
+    weights = WeightDict()
+
+    def _t(name):
+        w = _load_tensor(readers, name)
+        return np.ascontiguousarray(w.T, dtype=np.float32)
+
+    def _f(name):
+        return _load_tensor(readers, name).astype(np.float32)
+
+    def _maybe_f(name):
+        if _has_tensor(readers, name):
+            return _f(name)
+        return None
+
+    def _maybe_t(name):
+        if _has_tensor(readers, name):
+            return _t(name)
+        return None
+
+    # --- Joint transformer blocks ---
+    for i in range(num_layers):
+        p = f"transformer_blocks.{i}"
+        # AdaLN norms
+        weights[f"{p}.norm1.linear.weight"] = _t(f"{p}.norm1.linear.weight")
+        weights[f"{p}.norm1.linear.bias"] = _f(f"{p}.norm1.linear.bias")
+        weights[f"{p}.norm1_context.linear.weight"] = _t(f"{p}.norm1_context.linear.weight")
+        weights[f"{p}.norm1_context.linear.bias"] = _f(f"{p}.norm1_context.linear.bias")
+
+        # Attention projections (image)
+        for proj in ("to_q", "to_k", "to_v"):
+            weights[f"{p}.attn.{proj}.weight"] = _t(f"{p}.attn.{proj}.weight")
+            b = _maybe_f(f"{p}.attn.{proj}.bias")
+            if b is not None:
+                weights[f"{p}.attn.{proj}.bias"] = b
+        weights[f"{p}.attn.to_out.0.weight"] = _t(f"{p}.attn.to_out.0.weight")
+        b = _maybe_f(f"{p}.attn.to_out.0.bias")
+        if b is not None:
+            weights[f"{p}.attn.to_out.0.bias"] = b
+
+        # Attention projections (text "added")
+        for proj in ("add_q_proj", "add_k_proj", "add_v_proj"):
+            weights[f"{p}.attn.{proj}.weight"] = _t(f"{p}.attn.{proj}.weight")
+            b = _maybe_f(f"{p}.attn.{proj}.bias")
+            if b is not None:
+                weights[f"{p}.attn.{proj}.bias"] = b
+        weights[f"{p}.attn.to_add_out.weight"] = _t(f"{p}.attn.to_add_out.weight")
+        b = _maybe_f(f"{p}.attn.to_add_out.bias")
+        if b is not None:
+            weights[f"{p}.attn.to_add_out.bias"] = b
+
+        # QK norms
+        for norm in ("norm_q", "norm_k", "norm_added_q", "norm_added_k"):
+            w = _maybe_f(f"{p}.attn.{norm}.weight")
+            if w is not None:
+                weights[f"{p}.attn.{norm}.weight"] = w
+
+        # FFN (image)
+        weights[f"{p}.ff.net.0.proj.weight"] = _t(f"{p}.ff.net.0.proj.weight")
+        b = _maybe_f(f"{p}.ff.net.0.proj.bias")
+        if b is not None:
+            weights[f"{p}.ff.net.0.proj.bias"] = b
+        weights[f"{p}.ff.net.2.weight"] = _t(f"{p}.ff.net.2.weight")
+        b = _maybe_f(f"{p}.ff.net.2.bias")
+        if b is not None:
+            weights[f"{p}.ff.net.2.bias"] = b
+
+        # FFN (text context)
+        weights[f"{p}.ff_context.net.0.proj.weight"] = _t(f"{p}.ff_context.net.0.proj.weight")
+        b = _maybe_f(f"{p}.ff_context.net.0.proj.bias")
+        if b is not None:
+            weights[f"{p}.ff_context.net.0.proj.bias"] = b
+        weights[f"{p}.ff_context.net.2.weight"] = _t(f"{p}.ff_context.net.2.weight")
+        b = _maybe_f(f"{p}.ff_context.net.2.bias")
+        if b is not None:
+            weights[f"{p}.ff_context.net.2.bias"] = b
+
+    # --- Single transformer blocks ---
+    for i in range(num_single_layers):
+        p = f"single_transformer_blocks.{i}"
+        weights[f"{p}.norm.linear.weight"] = _t(f"{p}.norm.linear.weight")
+        weights[f"{p}.norm.linear.bias"] = _f(f"{p}.norm.linear.bias")
+
+        for proj in ("to_q", "to_k", "to_v"):
+            weights[f"{p}.attn.{proj}.weight"] = _t(f"{p}.attn.{proj}.weight")
+            b = _maybe_f(f"{p}.attn.{proj}.bias")
+            if b is not None:
+                weights[f"{p}.attn.{proj}.bias"] = b
+
+        for norm in ("norm_q", "norm_k"):
+            w = _maybe_f(f"{p}.attn.{norm}.weight")
+            if w is not None:
+                weights[f"{p}.attn.{norm}.weight"] = w
+
+        weights[f"{p}.proj_mlp.weight"] = _t(f"{p}.proj_mlp.weight")
+        b = _maybe_f(f"{p}.proj_mlp.bias")
+        if b is not None:
+            weights[f"{p}.proj_mlp.bias"] = b
+
+        weights[f"{p}.proj_out.weight"] = _t(f"{p}.proj_out.weight")
+        b = _maybe_f(f"{p}.proj_out.bias")
+        if b is not None:
+            weights[f"{p}.proj_out.bias"] = b
+
+    # --- Global ---
+    weights["norm_out.linear.weight"] = _t("norm_out.linear.weight")
+    weights["norm_out.linear.bias"] = _f("norm_out.linear.bias")
+    weights["proj_out.weight"] = _t("proj_out.weight")
+    b = _maybe_f("proj_out.bias")
+    if b is not None:
+        weights["proj_out.bias"] = b
+
+    # Preprocessor weights (external to TRT engine)
+    weights["x_embedder.weight"] = _t("x_embedder.weight")
+    weights["x_embedder.bias"] = _f("x_embedder.bias")
+    weights["context_embedder.weight"] = _t("context_embedder.weight")
+    weights["context_embedder.bias"] = _f("context_embedder.bias")
+
+    # Time-text embedding MLPs
+    for comp in ("timestep_embedder", "text_embedder"):
+        for layer in ("linear_1", "linear_2"):
+            key = f"time_text_embed.{comp}.{layer}"
+            if _has_tensor(readers, f"{key}.weight"):
+                weights[f"{key}.weight"] = _t(f"{key}.weight")
+                b = _maybe_f(f"{key}.bias")
+                if b is not None:
+                    weights[f"{key}.bias"] = b
+
+    # Guidance embedder (optional, only for FLUX.1-dev / guidance_embeds=True)
+    for layer in ("linear_1", "linear_2"):
+        key = f"time_text_embed.guidance_embedder.{layer}"
+        if _has_tensor(readers, f"{key}.weight"):
+            weights[f"{key}.weight"] = _t(f"{key}.weight")
+            b = _maybe_f(f"{key}.bias")
+            if b is not None:
+                weights[f"{key}.bias"] = b
+
+    return weights

--- a/tensorrt_model_connect/tensorrt_model_connect/families/flux/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/flux/plugin.py
@@ -152,6 +152,7 @@ class FluxPlugin:
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
         *, precision: str = "fp32", verbose: bool = False,
         fp8_scales: dict | None = None, build_timing: dict | None = None,
+        parallel_config=None,
     ) -> dict:
         """Build all component engines.
 
@@ -170,24 +171,36 @@ class FluxPlugin:
             return self._build_flux2_components(
                 model_dir, config, weights, tc=tc, verbose=verbose,
                 fp8_scales=fp8_scales, precision=precision,
-                build_timing=build_timing)
+                build_timing=build_timing, parallel_config=parallel_config)
 
         return self._build_flux1_components(
             model_dir, config, weights, tc=tc, verbose=verbose,
-            precision=precision, build_timing=build_timing)
+            precision=precision, build_timing=build_timing,
+            parallel_config=parallel_config)
 
     def _build_flux1_components(
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
         *, tc: dict, precision: str = "fp32", verbose: bool = False,
         build_timing: dict | None = None,
+        parallel_config=None,
     ) -> dict:
         """Build FLUX.1 component engines (CLIP + T5 + DiT + VAE)."""
         from ...build_timing import timed_trt_compile, timed_weight_loading
         from .t5_encoder_builder import build_t5_encoder_engine, load_t5_weights
         from .clip_encoder_builder import build_clip_encoder_engine, load_clip_weights
         from .flux_dit_builder import build_flux_dit_engine, load_flux_dit_weights
+        from .flux_dit_tp_builder import (
+            build_flux_dit_engine as build_flux_dit_tp_engine)
+        from ...parallel_config import (
+            normalize_parallel_config,
+            require_tensorrt_11_for_tensor_parallel,
+        )
         import json
         from pathlib import Path
+
+        parallel = normalize_parallel_config(parallel_config)
+        require_tensorrt_11_for_tensor_parallel(
+            parallel, feature="Flux tensor-parallel builds")
 
         transformer_dir = weights["_transformer_dir"]
         vae_dir = weights["_vae_dir"]
@@ -330,17 +343,36 @@ class FluxPlugin:
                 num_single_layers=num_single_layers,
             )
 
+        dit_plan = None
+        dit_rank_plans = None
         with timed_trt_compile(build_timing, "flux_dit"):
-            dit_plan = build_flux_dit_engine(
-                dit_weights,
-                dim=dit_dim,
-                num_heads=num_heads,
-                num_layers=num_layers,
-                num_single_layers=num_single_layers,
-                num_img_tokens=num_img_tokens,
-                text_seq_len=self._T5_MAX_SEQ_LEN,
-                verbose=verbose,
-            )
+            if parallel.enabled:
+                dit_rank_plans = {}
+                for rank in range(parallel.tp_size):
+                    print(f"[flux] Building FLUX DiT TP rank {rank}/{parallel.tp_size} ...",
+                          file=sys.stderr)
+                    dit_rank_plans[rank] = build_flux_dit_tp_engine(
+                        dit_weights,
+                        dim=dit_dim,
+                        num_heads=num_heads,
+                        num_layers=num_layers,
+                        num_single_layers=num_single_layers,
+                        num_img_tokens=num_img_tokens,
+                        text_seq_len=self._T5_MAX_SEQ_LEN,
+                        verbose=verbose,
+                        parallel_config=parallel.for_rank(rank),
+                    )
+            else:
+                dit_plan = build_flux_dit_engine(
+                    dit_weights,
+                    dim=dit_dim,
+                    num_heads=num_heads,
+                    num_layers=num_layers,
+                    num_single_layers=num_single_layers,
+                    num_img_tokens=num_img_tokens,
+                    text_seq_len=self._T5_MAX_SEQ_LEN,
+                    verbose=verbose,
+                )
 
         # 4. VAE decoder - native TRT engine
         from .flux_vae_builder import build_flux_vae_decoder_engine
@@ -359,18 +391,23 @@ class FluxPlugin:
         # 5. Serialize preprocessor weights
         preprocessor_weights = _serialize_flux_preprocessor(dit_weights, guidance_embeds)
 
-        return {
+        out = {
             "text_encoders": text_encoders,
-            "denoiser": dit_plan,
             "vae_decoder": vae_plan,
             "preprocessor_weights": preprocessor_weights,
         }
+        if parallel.enabled:
+            out["denoiser_ranks"] = dit_rank_plans or {}
+        else:
+            out["denoiser"] = dit_plan
+        return out
 
     def _build_flux2_components(
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
         *, tc: dict, precision: str = "fp32", verbose: bool = False,
         fp8_scales: dict | None = None,
         build_timing: dict | None = None,
+        parallel_config=None,
     ) -> dict:
         """Build FLUX.2 component engines (Mistral + Flux2 DiT + VAE32)."""
         from ...build_timing import timed_trt_compile, timed_weight_loading
@@ -378,6 +415,13 @@ class FluxPlugin:
             build_mistral_encoder_engine, load_mistral_encoder_weights)
         from .flux2_dit_builder import build_flux2_dit_engine, load_flux2_dit_weights
         from .flux_vae_builder import build_flux_vae_decoder_engine
+        from ...parallel_config import normalize_parallel_config
+
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            raise NotImplementedError(
+                "Flux.2 tensor-parallel DiT builds are not implemented yet; "
+                "Flux.1 DiT TP is the supported Flux path.")
 
         transformer_dir = weights["_transformer_dir"]
         vae_dir = weights["_vae_dir"]

--- a/tensorrt_model_connect/tensorrt_model_connect/families/pixart/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/pixart/plugin.py
@@ -110,16 +110,26 @@ class PixArtPlugin:
 
     def build_components(
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
-        *, precision: str = "fp32", verbose: bool = False, **_kwargs,
+        *, precision: str = "fp32", verbose: bool = False,
+        parallel_config=None, **_kwargs,
     ) -> dict:
         """Build all three component engines."""
         from ...build_timing import timed_trt_compile, timed_weight_loading
         from .t5_encoder_builder import build_t5_encoder_engine, load_t5_weights
         from .standard_dit_builder import build_standard_dit_engine
+        from .standard_dit_tp_builder import (
+            build_standard_dit_engine as build_standard_dit_tp_engine)
         from .vae_2d_builder import build_vae_2d_decoder_engine
+        from ...parallel_config import (
+            normalize_parallel_config,
+            require_tensorrt_11_for_tensor_parallel,
+        )
         import json
         from pathlib import Path
         build_timing = _kwargs.get("build_timing")
+        parallel = normalize_parallel_config(parallel_config)
+        require_tensorrt_11_for_tensor_parallel(
+            parallel, feature="PixArt tensor-parallel builds")
 
         text_encoder_dir = weights["_text_encoder_dir"]
         transformer_dir = weights["_transformer_dir"]
@@ -199,22 +209,48 @@ class PixArtPlugin:
                 cross_attn_dim=cross_attn_dim,
             )
 
+        dit_plan = None
+        dit_rank_plans = None
         with timed_trt_compile(build_timing, "pixart_dit"):
-            dit_plan = build_standard_dit_engine(
-                dit_weights,
-                dim=dit_dim,
-                num_heads=num_heads,
-                num_layers=num_layers,
-                ffn_dim=ffn_dim,
-                context_dim=cross_attn_dim,
-                num_patches=num_patches,
-                text_seq_len=self._T5_MAX_SEQ_LEN,
-                qk_norm=False,
-                cross_attn_norm=False,
-                ffn_activation="gelu_approximate",
-                use_rope=False,
-                verbose=verbose,
-            )
+            if parallel.enabled:
+                dit_rank_plans = {}
+                for rank in range(parallel.tp_size):
+                    print(
+                        f"[pixart] Building PixArt DiT TP rank {rank}/{parallel.tp_size} ...",
+                        file=sys.stderr,
+                    )
+                    dit_rank_plans[rank] = build_standard_dit_tp_engine(
+                        dit_weights,
+                        dim=dit_dim,
+                        num_heads=num_heads,
+                        num_layers=num_layers,
+                        ffn_dim=ffn_dim,
+                        context_dim=cross_attn_dim,
+                        num_patches=num_patches,
+                        text_seq_len=self._T5_MAX_SEQ_LEN,
+                        qk_norm=False,
+                        cross_attn_norm=False,
+                        ffn_activation="gelu_approximate",
+                        use_rope=False,
+                        verbose=verbose,
+                        parallel_config=parallel.for_rank(rank),
+                    )
+            else:
+                dit_plan = build_standard_dit_engine(
+                    dit_weights,
+                    dim=dit_dim,
+                    num_heads=num_heads,
+                    num_layers=num_layers,
+                    ffn_dim=ffn_dim,
+                    context_dim=cross_attn_dim,
+                    num_patches=num_patches,
+                    text_seq_len=self._T5_MAX_SEQ_LEN,
+                    qk_norm=False,
+                    cross_attn_norm=False,
+                    ffn_activation="gelu_approximate",
+                    use_rope=False,
+                    verbose=verbose,
+                )
 
         # 3. VAE decoder
         print("[pixart] Building VAE decoder engine ...", file=sys.stderr)
@@ -234,12 +270,16 @@ class PixArtPlugin:
         preprocessor_weights = _serialize_preprocessor_weights(
             dit_weights, t5_d_model, dit_dim)
 
-        return {
+        out = {
             "text_encoders": [("t5", t5_plan)],
-            "denoiser": dit_plan,
             "vae_decoder": vae_plan,
             "preprocessor_weights": preprocessor_weights,
         }
+        if parallel.enabled:
+            out["denoiser_ranks"] = dit_rank_plans or {}
+        else:
+            out["denoiser"] = dit_plan
+        return out
 
     def get_diffusion_config(self, config: ModelConfig) -> dict:
         """Return diffusion pipeline configuration."""

--- a/tensorrt_model_connect/tensorrt_model_connect/families/pixart/standard_dit_tp_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/pixart/standard_dit_tp_builder.py
@@ -1,0 +1,646 @@
+"""Shared DiT (Diffusion Transformer) engine builder.
+
+Builds a TensorRT engine for a DiT-style denoiser. Parameterized for
+variant selection, mirroring how standard_decoder_builder.py works.
+
+Reusable by: Wan2.1, Hunyuan Video, CogVideoX, FLUX (with conditioning_type).
+
+Engine I/O:
+    Inputs:
+        hidden_states [1, num_patches, dim] float32 (patchified latent)
+        timestep_embedding [1, dim * 6] float32 (from external timestep MLP)
+        encoder_hidden_states [1, text_seq_len, context_dim] float32
+        rotary_cos [1, num_patches, 1, head_dim] float32 (precomputed)
+        rotary_sin [1, num_patches, 1, head_dim] float32 (precomputed)
+    Outputs:
+        output [1, num_patches, dim] float32
+
+The timestep embedding, patch embedding, and RoPE are computed externally
+(in the DiffusionRunner / C++ backend) and passed as inputs. This keeps
+the TRT engine focused on the core transformer computation.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import (
+    ParallelConfig,
+    _slice_first_dim,
+    _slice_last_dim,
+    add_all_reduce_sum,
+    normalize_parallel_config,
+    validate_dit_tp,
+)
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+
+
+def build_standard_dit_engine(
+    weights: WeightDict,
+    *,
+    dim: int,
+    num_heads: int,
+    num_layers: int,
+    ffn_dim: int,
+    context_dim: int,
+    num_patches: int,
+    text_seq_len: int = 512,
+    qk_norm: bool = True,
+    cross_attn_norm: bool = True,
+    ffn_activation: str = "gelu_new",
+    use_rope: bool = True,
+    eps: float = 1e-6,
+    verbose: bool = False,
+    parallel_config: ParallelConfig | None = None,
+) -> bytes:
+    """Build DiT denoiser TRT engine plan.
+
+    Args:
+        weights: Weight dict with DiT weights. Expected keys per layer:
+            - blocks.{i}.attn1.to_q/to_k/to_v.weight/bias (self-attn)
+            - blocks.{i}.attn1.to_out.0.weight/bias
+            - blocks.{i}.attn1.norm_q/norm_k.weight (QK norm)
+            - blocks.{i}.norm1 (no weight — elementwise_affine=False)
+            - blocks.{i}.attn2.to_q/to_k/to_v.weight/bias (cross-attn)
+            - blocks.{i}.attn2.to_out.0.weight/bias
+            - blocks.{i}.attn2.norm_q/norm_k.weight
+            - blocks.{i}.attn2.add_k_proj/add_v_proj.weight/bias (if context needs projection)
+            - blocks.{i}.norm2.weight/bias (cross-attn norm, if enabled)
+            - blocks.{i}.ffn.net.0.proj.weight/bias (GELU)
+            - blocks.{i}.ffn.net.2.weight/bias (output proj)
+            - blocks.{i}.norm3 (no weight — elementwise_affine=False)
+            - blocks.{i}.scale_shift_table [1, 6, dim]
+            Global:
+            - norm_out (no weight — elementwise_affine=False)
+            - proj_out.weight/bias
+            - scale_shift_table [1, 2, dim]
+        dim: Hidden dimension of the DiT.
+        num_heads: Number of attention heads.
+        num_layers: Number of DiT blocks.
+        ffn_dim: Feed-forward inner dimension.
+        context_dim: Text encoder output dimension (before projection).
+        num_patches: Total number of patches (T/pt * H/ph * W/pw).
+        text_seq_len: Maximum text sequence length.
+        qk_norm: Apply RMSNorm to Q and K.
+        cross_attn_norm: Apply LayerNorm before cross-attention.
+        ffn_activation: Activation for FFN.
+        use_rope: Apply RoPE to self-attention Q/K. When False, the engine
+            omits rotary_cos/rotary_sin inputs (suitable for models that use
+            fixed position embeddings, e.g. PixArt).
+        eps: LayerNorm epsilon.
+        verbose: Enable TRT builder verbose logging.
+
+    Returns:
+        Serialized TRT engine plan bytes.
+    """
+    parallel = normalize_parallel_config(parallel_config)
+    validate_dit_tp(
+        dim=dim,
+        num_heads=num_heads,
+        ffn_dim=ffn_dim,
+        parallel=parallel,
+        feature="Standard DiT tensor parallel",
+    )
+    head_dim = dim // num_heads
+    local_num_heads = num_heads // parallel.tp_size
+    local_dim = dim // parallel.tp_size
+    local_ffn_dim = ffn_dim // parallel.tp_size
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
+
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    # Inputs
+    hidden_inp = network.add_input(
+        "hidden_states", trt.float32, (num_patches, dim))
+    # Block modulation temb from external embedder: [1, 6 * dim]
+    temb_inp = network.add_input(
+        "timestep_embedding", trt.float32, (1, 6 * dim))
+    # Time embed for final output modulation: [1, dim]
+    time_embed_inp = network.add_input(
+        "time_embed", trt.float32, (1, dim))
+    encoder_hidden = network.add_input(
+        "encoder_hidden_states", trt.float32, (text_seq_len, context_dim))
+
+    # Optional cross-attention mask: [1, 1, text_seq_len] float32.
+    # 0.0 for valid tokens, -10000.0 for padding.
+    # Only added when use_rope=False (PixArt, etc.) since Wan models
+    # don't need it (fixed-length text with no padding).
+    cross_attn_mask = None
+    if not use_rope:
+        cross_attn_mask = network.add_input(
+            "encoder_attention_mask", trt.float32, (1, 1, text_seq_len))
+
+    # Constants
+    eps_t = graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+
+    # RoPE inputs and precomputation (only when use_rope=True)
+    rotary_cos = rotary_sin = None
+    if use_rope:
+        rotary_cos = network.add_input(
+            "rotary_cos", trt.float32, (num_patches, head_dim))
+        rotary_sin = network.add_input(
+            "rotary_sin", trt.float32, (num_patches, head_dim))
+
+    hidden = hidden_inp
+
+    for layer_idx in range(num_layers):
+        prefix = f"blocks.{layer_idx}"
+
+        # --- AdaLN modulation ---
+        # scale_shift_table: [1, 6, dim] -> flatten to [1, 6*dim]
+        sst = weights[f"{prefix}.scale_shift_table"]
+        sst_const = graph_ops.add_constant(
+            network, (1, 6 * dim), sst.reshape(1, 6 * dim))
+
+        # modulation = sst + temb
+        modulation = network.add_elementwise(
+            sst_const, temb_inp, trt.ElementWiseOperation.SUM)
+
+        # Chunk into 6 parts: shift_sa, scale_sa, gate_sa, shift_ff, scale_ff, gate_ff
+        chunks = []
+        for i in range(6):
+            s = network.add_slice(
+                modulation.get_output(0),
+                start=(0, i * dim),
+                shape=(1, dim),
+                stride=(1, 1),
+            )
+            chunks.append(s.get_output(0))
+        shift_sa, scale_sa, gate_sa, shift_ff, scale_ff, gate_ff = chunks
+
+        # === 1. Self-attention with AdaLN + RoPE ===
+        normed = graph_ops.add_adaptive_layernorm(
+            network, hidden, scale_sa, shift_sa, dim, eps)
+
+        # QKV projections
+        q = _linear_col_parallel(
+            network, normed, dim, dim, weights, f"{prefix}.attn1.to_q", parallel)
+        k = _linear_col_parallel(
+            network, normed, dim, dim, weights, f"{prefix}.attn1.to_k", parallel)
+        v = _linear_col_parallel(
+            network, normed, dim, dim, weights, f"{prefix}.attn1.to_v", parallel)
+
+        # QK norm
+        if qk_norm:
+            q_norm_w = weights.get(f"{prefix}.attn1.norm_q.weight")
+            k_norm_w = weights.get(f"{prefix}.attn1.norm_k.weight")
+            if q_norm_w is not None:
+                q = graph_ops.add_rms_norm(
+                    network, q, local_dim,
+                    _tp_norm_weight(q_norm_w, local_num_heads, head_dim, parallel), eps_t)
+            if k_norm_w is not None:
+                k = graph_ops.add_rms_norm(
+                    network, k, local_dim,
+                    _tp_norm_weight(k_norm_w, local_num_heads, head_dim, parallel), eps_t)
+
+        # Apply RoPE to Q and K (skip when use_rope=False)
+        if use_rope:
+            q = graph_ops.add_apply_rope_native_from_full_cache(
+                network, q, local_num_heads, head_dim,
+                rotary_cos, rotary_sin, num_patches,
+                interleaved=True)
+            k = graph_ops.add_apply_rope_native_from_full_cache(
+                network, k, local_num_heads, head_dim,
+                rotary_cos, rotary_sin, num_patches,
+                interleaved=True)
+
+        # Multi-head attention
+        context_flat = graph_ops.add_attention_from_rows(
+            network, q, k, v,
+            num_heads=local_num_heads, head_dim=head_dim,
+            q_seq=num_patches, kv_seq=num_patches,
+            tag=f"{prefix}.attn1")
+
+        # Output projection
+        attn_out = _linear_row_parallel(
+            network, context_flat, local_dim, dim, weights,
+            f"{prefix}.attn1.to_out.0", parallel)
+
+        # Gate + residual
+        gated = network.add_elementwise(
+            attn_out, gate_sa, trt.ElementWiseOperation.PROD)
+        hidden = network.add_elementwise(
+            hidden, gated.get_output(0),
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === 2. Cross-attention ===
+        if cross_attn_norm:
+            cross_norm_w = weights.get(f"{prefix}.norm2.weight")
+            cross_norm_b = weights.get(f"{prefix}.norm2.bias")
+            if cross_norm_w is not None:
+                cross_normed = graph_ops.add_layer_norm(
+                    network, hidden, dim,
+                    cross_norm_w,
+                    cross_norm_b if cross_norm_b is not None else np.zeros(dim, dtype=np.float32),
+                    eps_t)
+            else:
+                cross_normed = hidden
+        else:
+            cross_normed = hidden
+
+        # Cross-attention: Q from hidden, K/V from encoder_hidden
+        cross_q = _linear_col_parallel(
+            network, cross_normed, dim, dim, weights, f"{prefix}.attn2.to_q", parallel)
+
+        # K/V from encoder (may use add_k_proj/add_v_proj for context projection)
+        add_k_proj_w = weights.get(f"{prefix}.attn2.add_k_proj.weight")
+        if add_k_proj_w is not None:
+            # Context needs projection: [text_seq, context_dim] -> [text_seq, dim]
+            cross_k = _linear_col_parallel(
+                network, encoder_hidden, context_dim, dim, weights,
+                f"{prefix}.attn2.add_k_proj", parallel)
+            cross_v = _linear_col_parallel(
+                network, encoder_hidden, context_dim, dim, weights,
+                f"{prefix}.attn2.add_v_proj", parallel)
+        else:
+            # Direct K/V from already-projected context
+            cross_k = _linear_col_parallel(
+                network, encoder_hidden, context_dim, dim, weights,
+                f"{prefix}.attn2.to_k", parallel)
+            cross_v = _linear_col_parallel(
+                network, encoder_hidden, context_dim, dim, weights,
+                f"{prefix}.attn2.to_v", parallel)
+
+        # QK norm for cross-attention
+        if qk_norm:
+            cq_norm = weights.get(f"{prefix}.attn2.norm_q.weight")
+            ck_norm = weights.get(f"{prefix}.attn2.norm_k.weight")
+            if cq_norm is not None:
+                cross_q = graph_ops.add_rms_norm(
+                    network, cross_q, local_dim,
+                    _tp_norm_weight(cq_norm, local_num_heads, head_dim, parallel), eps_t)
+            # For cross-attn with add_k_proj, the K norm is norm_added_k
+            ck_added_norm = weights.get(f"{prefix}.attn2.norm_added_k.weight")
+            if ck_added_norm is not None:
+                cross_k = graph_ops.add_rms_norm(
+                    network, cross_k, local_dim,
+                    _tp_norm_weight(ck_added_norm, local_num_heads, head_dim, parallel), eps_t)
+            elif ck_norm is not None:
+                cross_k = graph_ops.add_rms_norm(
+                    network, cross_k, local_dim,
+                    _tp_norm_weight(ck_norm, local_num_heads, head_dim, parallel), eps_t)
+
+        # Cross multi-head attention (no RoPE)
+        cross_mask_4d = None
+        if cross_attn_mask is not None:
+            cross_mask = network.add_shuffle(cross_attn_mask)
+            cross_mask.reshape_dims = (1, 1, 1, text_seq_len)
+            cross_mask_4d = cross_mask.get_output(0)
+        c_context_flat = graph_ops.add_attention_from_rows(
+            network, cross_q, cross_k, cross_v,
+            num_heads=local_num_heads, head_dim=head_dim,
+            q_seq=num_patches, kv_seq=text_seq_len,
+            mask=cross_mask_4d,
+            tag=f"{prefix}.attn2")
+
+        cross_out = _linear_row_parallel(
+            network, c_context_flat, local_dim, dim, weights,
+            f"{prefix}.attn2.to_out.0", parallel)
+
+        # Cross-attn residual (no gate in Wan)
+        hidden = network.add_elementwise(
+            hidden, cross_out,
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === 3. FFN with AdaLN ===
+        ffn_normed = graph_ops.add_adaptive_layernorm(
+            network, hidden, scale_ff, shift_ff, dim, eps)
+
+        # GELU FFN: Linear(dim, ffn_dim) -> GELU -> Linear(ffn_dim, dim)
+        ffn_fc1 = _linear_col_parallel(
+            network, ffn_normed, dim, ffn_dim, weights,
+            f"{prefix}.ffn.net.0.proj", parallel)
+
+        ffn_act = graph_ops.add_gelu_new(network, ffn_fc1)
+
+        ffn_fc2 = _linear_row_parallel(
+            network, ffn_act, local_ffn_dim, dim, weights,
+            f"{prefix}.ffn.net.2", parallel)
+
+        # Gate + residual
+        gated_ff = network.add_elementwise(
+            ffn_fc2, gate_ff, trt.ElementWiseOperation.PROD)
+        hidden = network.add_elementwise(
+            hidden, gated_ff.get_output(0),
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+    # --- Final output: AdaLN modulation + projection ---
+    # HF: shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
+    # scale_shift_table: [1, 2, dim], time_embed: [1, dim] -> unsqueeze -> [1, 1, dim]
+    # Result after add: [1, 2, dim], chunk -> shift [1, 1, dim], scale [1, 1, dim]
+    final_sst = weights["scale_shift_table"]  # [1, 2, dim]
+    final_sst_const = graph_ops.add_constant(
+        network, (1, 2 * dim), final_sst.reshape(1, 2 * dim))
+
+    # time_embed_inp: [1, dim] -> tile to [1, 2*dim] for broadcast add
+    time_embed_tiled = network.add_concatenation(
+        [time_embed_inp, time_embed_inp])
+    time_embed_tiled.axis = 1  # [1, 2*dim]
+
+    final_modulation = network.add_elementwise(
+        final_sst_const, time_embed_tiled.get_output(0),
+        trt.ElementWiseOperation.SUM)
+
+    final_shift = network.add_slice(
+        final_modulation.get_output(0),
+        start=(0, 0), shape=(1, dim), stride=(1, 1))
+    final_scale = network.add_slice(
+        final_modulation.get_output(0),
+        start=(0, dim), shape=(1, dim), stride=(1, 1))
+
+    # Final LayerNorm + AdaLN modulation
+    hidden = graph_ops.add_adaptive_layernorm(
+        network, hidden, final_scale.get_output(0),
+        final_shift.get_output(0), dim, eps)
+
+    # Final projection: [num_patches, dim] -> [num_patches, out_channels * prod(patch_size)]
+    proj_out_w = weights["proj_out.weight"]
+    out_dim = proj_out_w.shape[1]  # [dim, out_channels * prod(patch_size)]
+    output = graph_ops.add_matmul_rhs_constant(
+        network, hidden, dim, out_dim, proj_out_w)
+    proj_out_b = weights.get("proj_out.bias")
+    if proj_out_b is not None:
+        output = graph_ops.add_bias_sum(network, output, out_dim, proj_out_b)
+
+    # Mark output
+    cast_output = network.add_cast(output, trt.float32)
+    output_final = cast_output.get_output(0)
+    output_final.name = "output"
+    network.mark_output(output_final)
+
+    # --- Build ---
+    tp_suffix = (
+        f", tp={parallel.tp_size}, rank={parallel.rank}"
+        if parallel.enabled else "")
+    print(f"[dit-builder] Building TRT engine "
+          f"(dim={dim}, layers={num_layers}, patches={num_patches}{tp_suffix}) ...",
+          file=sys.stderr)
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError("TRT engine serialization failed for DiT")
+    return bytes(plan)
+
+
+def _linear_col_parallel(
+    network,
+    inp,
+    in_dim: int,
+    out_dim: int,
+    weights,
+    prefix: str,
+    parallel: ParallelConfig,
+):
+    """Column-parallel linear: output features are rank-local."""
+    local_out_dim = out_dim // parallel.tp_size
+    weight = weights[f"{prefix}.weight"]
+    if parallel.enabled:
+        weight = _slice_last_dim(weight, parallel.rank, parallel.tp_size)
+    out = graph_ops.add_matmul_rhs_constant(network, inp, in_dim, local_out_dim, weight)
+    bias = weights.get(f"{prefix}.bias")
+    if bias is not None:
+        if parallel.enabled:
+            bias = _slice_first_dim(bias, parallel.rank, parallel.tp_size)
+        out = graph_ops.add_bias_sum(network, out, local_out_dim, bias)
+    return out
+
+
+def _linear_row_parallel(
+    network,
+    inp,
+    in_dim: int,
+    out_dim: int,
+    weights,
+    prefix: str,
+    parallel: ParallelConfig,
+):
+    """Row-parallel linear: partial outputs are all-reduced across TP ranks."""
+    weight = weights[f"{prefix}.weight"]
+    if parallel.enabled:
+        weight = _slice_first_dim(weight, parallel.rank, parallel.tp_size)
+    out = graph_ops.add_matmul_rhs_constant(network, inp, in_dim, out_dim, weight)
+    if parallel.enabled:
+        out = add_all_reduce_sum(network, out, parallel.tp_size)
+    bias = weights.get(f"{prefix}.bias")
+    if bias is not None:
+        out = graph_ops.add_bias_sum(network, out, out_dim, bias)
+    return out
+
+
+def _tp_norm_weight(
+    weight: np.ndarray,
+    local_num_heads: int,
+    head_dim: int,
+    parallel: ParallelConfig,
+) -> np.ndarray:
+    """Return the rank-local norm vector for sharded attention projections."""
+    if not parallel.enabled:
+        return weight
+    if weight.size == head_dim:
+        return weight
+    return _slice_first_dim(weight.reshape(-1, head_dim), parallel.rank,
+                            parallel.tp_size).reshape(local_num_heads * head_dim)
+
+
+def load_dit_weights(
+    model_dir: str,
+    *,
+    dim: int,
+    num_heads: int,
+    num_layers: int,
+    ffn_dim: int,
+    context_dim: int,
+) -> WeightDict:
+    """Load DiT weights from a diffusers-format transformer directory.
+
+    Expects: model_dir/diffusion_pytorch_model.safetensors (or sharded).
+    Returns WeightDict with transposed projections for TRT matmul.
+    """
+    from pathlib import Path
+    from ...checkpoint_mapper import WeightDict, _open_safetensors, _load_tensor, _has_tensor
+
+    model_path = Path(model_dir)
+    readers = _open_safetensors(model_path)
+    weights = WeightDict()
+
+    def _t(name: str) -> np.ndarray:
+        """Load and transpose [out, in] -> [in, out]."""
+        w = _load_tensor(readers, name)
+        return np.ascontiguousarray(w.T, dtype=np.float32)
+
+    def _f(name: str) -> np.ndarray:
+        """Load flat (1D) weight."""
+        return _load_tensor(readers, name).astype(np.float32)
+
+    def _maybe_t(name: str) -> np.ndarray | None:
+        if _has_tensor(readers, name):
+            return _t(name)
+        return None
+
+    def _maybe_f(name: str) -> np.ndarray | None:
+        if _has_tensor(readers, name):
+            return _f(name)
+        return None
+
+    for i in range(num_layers):
+        p = f"blocks.{i}"
+
+        # Self-attention
+        weights[f"{p}.attn1.to_q.weight"] = _t(f"{p}.attn1.to_q.weight")
+        weights[f"{p}.attn1.to_k.weight"] = _t(f"{p}.attn1.to_k.weight")
+        weights[f"{p}.attn1.to_v.weight"] = _t(f"{p}.attn1.to_v.weight")
+        weights[f"{p}.attn1.to_out.0.weight"] = _t(f"{p}.attn1.to_out.0.weight")
+
+        for proj in ("to_q", "to_k", "to_v"):
+            b = _maybe_f(f"{p}.attn1.{proj}.bias")
+            if b is not None:
+                weights[f"{p}.attn1.{proj}.bias"] = b
+        b = _maybe_f(f"{p}.attn1.to_out.0.bias")
+        if b is not None:
+            weights[f"{p}.attn1.to_out.0.bias"] = b
+
+        # QK norm
+        for norm in ("norm_q", "norm_k"):
+            w = _maybe_f(f"{p}.attn1.{norm}.weight")
+            if w is not None:
+                weights[f"{p}.attn1.{norm}.weight"] = w
+
+        # Cross-attention
+        weights[f"{p}.attn2.to_q.weight"] = _t(f"{p}.attn2.to_q.weight")
+        weights[f"{p}.attn2.to_out.0.weight"] = _t(f"{p}.attn2.to_out.0.weight")
+
+        for proj in ("to_q", "to_k", "to_v"):
+            b = _maybe_f(f"{p}.attn2.{proj}.bias")
+            if b is not None:
+                weights[f"{p}.attn2.{proj}.bias"] = b
+        b = _maybe_f(f"{p}.attn2.to_out.0.bias")
+        if b is not None:
+            weights[f"{p}.attn2.to_out.0.bias"] = b
+
+        # Cross-attn K/V: either to_k/to_v or add_k_proj/add_v_proj
+        if _has_tensor(readers, f"{p}.attn2.add_k_proj.weight"):
+            weights[f"{p}.attn2.add_k_proj.weight"] = _t(f"{p}.attn2.add_k_proj.weight")
+            weights[f"{p}.attn2.add_v_proj.weight"] = _t(f"{p}.attn2.add_v_proj.weight")
+            b = _maybe_f(f"{p}.attn2.add_k_proj.bias")
+            if b is not None:
+                weights[f"{p}.attn2.add_k_proj.bias"] = b
+            b = _maybe_f(f"{p}.attn2.add_v_proj.bias")
+            if b is not None:
+                weights[f"{p}.attn2.add_v_proj.bias"] = b
+        else:
+            weights[f"{p}.attn2.to_k.weight"] = _t(f"{p}.attn2.to_k.weight")
+            weights[f"{p}.attn2.to_v.weight"] = _t(f"{p}.attn2.to_v.weight")
+
+        # Cross-attn QK norm
+        for norm in ("norm_q", "norm_k", "norm_added_k"):
+            w = _maybe_f(f"{p}.attn2.{norm}.weight")
+            if w is not None:
+                weights[f"{p}.attn2.{norm}.weight"] = w
+
+        # Cross-attn norm (LayerNorm)
+        w = _maybe_f(f"{p}.norm2.weight")
+        if w is not None:
+            weights[f"{p}.norm2.weight"] = w
+        b = _maybe_f(f"{p}.norm2.bias")
+        if b is not None:
+            weights[f"{p}.norm2.bias"] = b
+
+        # FFN
+        weights[f"{p}.ffn.net.0.proj.weight"] = _t(f"{p}.ffn.net.0.proj.weight")
+        weights[f"{p}.ffn.net.2.weight"] = _t(f"{p}.ffn.net.2.weight")
+        b = _maybe_f(f"{p}.ffn.net.0.proj.bias")
+        if b is not None:
+            weights[f"{p}.ffn.net.0.proj.bias"] = b
+        b = _maybe_f(f"{p}.ffn.net.2.bias")
+        if b is not None:
+            weights[f"{p}.ffn.net.2.bias"] = b
+
+        # Scale-shift table
+        sst = _load_tensor(readers, f"{p}.scale_shift_table")
+        weights[f"{p}.scale_shift_table"] = sst.astype(np.float32)
+
+    # Final output
+    weights["scale_shift_table"] = _load_tensor(
+        readers, "scale_shift_table").astype(np.float32)
+    weights["proj_out.weight"] = _t("proj_out.weight")
+    b = _maybe_f("proj_out.bias")
+    if b is not None:
+        weights["proj_out.bias"] = b
+
+    # Patch embedding (loaded but used externally, not in the TRT engine)
+    if _has_tensor(readers, "patch_embedding.weight"):
+        weights["patch_embedding.weight"] = _load_tensor(
+            readers, "patch_embedding.weight").astype(np.float32)
+    if _has_tensor(readers, "patch_embedding.bias"):
+        weights["patch_embedding.bias"] = _load_tensor(
+            readers, "patch_embedding.bias").astype(np.float32)
+
+    # Timestep/text embedder weights (used externally)
+    # Map canonical internal names -> possible safetensors names
+    _embedder_aliases = {
+        "condition_embedder.time_embedding.0.weight": [
+            "condition_embedder.time_embedding.0.weight",
+            "condition_embedder.time_embedder.linear_1.weight",
+        ],
+        "condition_embedder.time_embedding.0.bias": [
+            "condition_embedder.time_embedding.0.bias",
+            "condition_embedder.time_embedder.linear_1.bias",
+        ],
+        "condition_embedder.time_embedding.2.weight": [
+            "condition_embedder.time_embedding.2.weight",
+            "condition_embedder.time_embedder.linear_2.weight",
+        ],
+        "condition_embedder.time_embedding.2.bias": [
+            "condition_embedder.time_embedding.2.bias",
+            "condition_embedder.time_embedder.linear_2.bias",
+        ],
+        "condition_embedder.text_embedding.weight": [
+            "condition_embedder.text_embedding.weight",
+            "condition_embedder.text_embedder.linear_1.weight",
+        ],
+        "condition_embedder.text_embedding.bias": [
+            "condition_embedder.text_embedding.bias",
+            "condition_embedder.text_embedder.linear_1.bias",
+        ],
+        "condition_embedder.text_embedding_2.weight": [
+            "condition_embedder.text_embedding_2.weight",
+            "condition_embedder.text_embedder.linear_2.weight",
+        ],
+        "condition_embedder.text_embedding_2.bias": [
+            "condition_embedder.text_embedding_2.bias",
+            "condition_embedder.text_embedder.linear_2.bias",
+        ],
+    }
+    for key in ("condition_embedder.time_proj.weight",
+                "condition_embedder.time_proj.bias"):
+        if _has_tensor(readers, key):
+            w = _load_tensor(readers, key).astype(np.float32)
+            if w.ndim == 2:
+                weights[key] = np.ascontiguousarray(w.T, dtype=np.float32)
+            else:
+                weights[key] = w
+
+    for canonical, aliases in _embedder_aliases.items():
+        for alias in aliases:
+            if _has_tensor(readers, alias):
+                w = _load_tensor(readers, alias).astype(np.float32)
+                if w.ndim == 2:
+                    weights[canonical] = np.ascontiguousarray(w.T, dtype=np.float32)
+                else:
+                    weights[canonical] = w
+                break
+
+    return weights

--- a/tensorrt_model_connect/tensorrt_model_connect/families/wan_t2v/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/wan_t2v/plugin.py
@@ -76,14 +76,33 @@ class WanT2VPlugin:
 
     def build_components(
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
-        *, precision: str = "fp32", verbose: bool = False, **_kwargs,
+        *, precision: str = "fp32", verbose: bool = False,
+        parallel_config=None, **_kwargs,
     ) -> dict:
         """Build all three component engines."""
         from ...build_timing import timed_trt_compile, timed_weight_loading
         from .t5_encoder_builder import build_t5_encoder_engine, load_t5_weights
         from .standard_dit_builder import build_standard_dit_engine, load_dit_weights
+        from .standard_dit_tp_builder import (
+            build_standard_dit_engine as build_standard_dit_tp_engine)
         from .causal_vae_3d_builder import build_causal_vae_3d_engine, load_vae_weights
+        from ...parallel_config import (
+            normalize_parallel_config,
+            require_tensorrt_11_for_tensor_parallel,
+            validate_dit_tp,
+        )
         build_timing = _kwargs.get("build_timing")
+        parallel = normalize_parallel_config(parallel_config)
+        require_tensorrt_11_for_tensor_parallel(
+            parallel, feature="Wan tensor-parallel builds")
+        if parallel.enabled:
+            validate_dit_tp(
+                dim=self._DIT_DIM,
+                num_heads=self._DIT_NUM_HEADS,
+                ffn_dim=self._DIT_FFN_DIM,
+                parallel=parallel.for_rank(0),
+                feature="Wan tensor parallel",
+            )
 
         text_encoder_dir = weights["_text_encoder_dir"]
         transformer_dir = weights["_transformer_dir"]
@@ -141,21 +160,46 @@ class WanT2VPlugin:
         # Note: context_dim=dim (1536) because the text embedding projection
         # (4096->1536) is handled externally in the runner, so cross-attn
         # K/V weights are [dim, dim].
+        dit_plan = None
+        dit_rank_plans = None
         with timed_trt_compile(build_timing, "dit"):
-            dit_plan = build_standard_dit_engine(
-                dit_weights,
-                dim=self._DIT_DIM,
-                num_heads=self._DIT_NUM_HEADS,
-                num_layers=self._DIT_NUM_LAYERS,
-                ffn_dim=self._DIT_FFN_DIM,
-                context_dim=self._DIT_DIM,
-                num_patches=num_patches,
-                text_seq_len=self._T5_MAX_SEQ_LEN,
-                qk_norm=True,
-                cross_attn_norm=True,
-                ffn_activation="gelu_new",
-                verbose=verbose,
-            )
+            if parallel.enabled:
+                dit_rank_plans = {}
+                for rank in range(parallel.tp_size):
+                    print(
+                        f"[wan-t2v] Building DiT TP rank {rank}/{parallel.tp_size} ...",
+                        file=sys.stderr,
+                    )
+                    dit_rank_plans[rank] = build_standard_dit_tp_engine(
+                        dit_weights,
+                        dim=self._DIT_DIM,
+                        num_heads=self._DIT_NUM_HEADS,
+                        num_layers=self._DIT_NUM_LAYERS,
+                        ffn_dim=self._DIT_FFN_DIM,
+                        context_dim=self._DIT_DIM,
+                        num_patches=num_patches,
+                        text_seq_len=self._T5_MAX_SEQ_LEN,
+                        qk_norm=True,
+                        cross_attn_norm=True,
+                        ffn_activation="gelu_new",
+                        verbose=verbose,
+                        parallel_config=parallel.for_rank(rank),
+                    )
+            else:
+                dit_plan = build_standard_dit_engine(
+                    dit_weights,
+                    dim=self._DIT_DIM,
+                    num_heads=self._DIT_NUM_HEADS,
+                    num_layers=self._DIT_NUM_LAYERS,
+                    ffn_dim=self._DIT_FFN_DIM,
+                    context_dim=self._DIT_DIM,
+                    num_patches=num_patches,
+                    text_seq_len=self._T5_MAX_SEQ_LEN,
+                    qk_norm=True,
+                    cross_attn_norm=True,
+                    ffn_activation="gelu_new",
+                    verbose=verbose,
+                )
 
         # 3. Causal 3D VAE decoder
         print("[wan-t2v] Loading VAE decoder weights ...", file=sys.stderr)
@@ -187,12 +231,16 @@ class WanT2VPlugin:
         #    patch embedding, timestep MLP, text projection.
         preprocessor_weights = _serialize_preprocessor_weights(dit_weights)
 
-        return {
+        out = {
             "text_encoders": [("t5", t5_plan)],
-            "denoiser": dit_plan,
             "vae_decoder": vae_plan,
             "preprocessor_weights": preprocessor_weights,
         }
+        if parallel.enabled:
+            out["denoiser_ranks"] = dit_rank_plans or {}
+        else:
+            out["denoiser"] = dit_plan
+        return out
 
     def get_diffusion_config(self, config: ModelConfig) -> dict:
         """Return diffusion pipeline configuration."""

--- a/tensorrt_model_connect/tensorrt_model_connect/families/wan_t2v/standard_dit_tp_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/wan_t2v/standard_dit_tp_builder.py
@@ -1,0 +1,646 @@
+"""Shared DiT (Diffusion Transformer) engine builder.
+
+Builds a TensorRT engine for a DiT-style denoiser. Parameterized for
+variant selection, mirroring how standard_decoder_builder.py works.
+
+Reusable by: Wan2.1, Hunyuan Video, CogVideoX, FLUX (with conditioning_type).
+
+Engine I/O:
+    Inputs:
+        hidden_states [1, num_patches, dim] float32 (patchified latent)
+        timestep_embedding [1, dim * 6] float32 (from external timestep MLP)
+        encoder_hidden_states [1, text_seq_len, context_dim] float32
+        rotary_cos [1, num_patches, 1, head_dim] float32 (precomputed)
+        rotary_sin [1, num_patches, 1, head_dim] float32 (precomputed)
+    Outputs:
+        output [1, num_patches, dim] float32
+
+The timestep embedding, patch embedding, and RoPE are computed externally
+(in the DiffusionRunner / C++ backend) and passed as inputs. This keeps
+the TRT engine focused on the core transformer computation.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import (
+    ParallelConfig,
+    _slice_first_dim,
+    _slice_last_dim,
+    add_all_reduce_sum,
+    normalize_parallel_config,
+    validate_dit_tp,
+)
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+
+
+def build_standard_dit_engine(
+    weights: WeightDict,
+    *,
+    dim: int,
+    num_heads: int,
+    num_layers: int,
+    ffn_dim: int,
+    context_dim: int,
+    num_patches: int,
+    text_seq_len: int = 512,
+    qk_norm: bool = True,
+    cross_attn_norm: bool = True,
+    ffn_activation: str = "gelu_new",
+    use_rope: bool = True,
+    eps: float = 1e-6,
+    verbose: bool = False,
+    parallel_config: ParallelConfig | None = None,
+) -> bytes:
+    """Build DiT denoiser TRT engine plan.
+
+    Args:
+        weights: Weight dict with DiT weights. Expected keys per layer:
+            - blocks.{i}.attn1.to_q/to_k/to_v.weight/bias (self-attn)
+            - blocks.{i}.attn1.to_out.0.weight/bias
+            - blocks.{i}.attn1.norm_q/norm_k.weight (QK norm)
+            - blocks.{i}.norm1 (no weight — elementwise_affine=False)
+            - blocks.{i}.attn2.to_q/to_k/to_v.weight/bias (cross-attn)
+            - blocks.{i}.attn2.to_out.0.weight/bias
+            - blocks.{i}.attn2.norm_q/norm_k.weight
+            - blocks.{i}.attn2.add_k_proj/add_v_proj.weight/bias (if context needs projection)
+            - blocks.{i}.norm2.weight/bias (cross-attn norm, if enabled)
+            - blocks.{i}.ffn.net.0.proj.weight/bias (GELU)
+            - blocks.{i}.ffn.net.2.weight/bias (output proj)
+            - blocks.{i}.norm3 (no weight — elementwise_affine=False)
+            - blocks.{i}.scale_shift_table [1, 6, dim]
+            Global:
+            - norm_out (no weight — elementwise_affine=False)
+            - proj_out.weight/bias
+            - scale_shift_table [1, 2, dim]
+        dim: Hidden dimension of the DiT.
+        num_heads: Number of attention heads.
+        num_layers: Number of DiT blocks.
+        ffn_dim: Feed-forward inner dimension.
+        context_dim: Text encoder output dimension (before projection).
+        num_patches: Total number of patches (T/pt * H/ph * W/pw).
+        text_seq_len: Maximum text sequence length.
+        qk_norm: Apply RMSNorm to Q and K.
+        cross_attn_norm: Apply LayerNorm before cross-attention.
+        ffn_activation: Activation for FFN.
+        use_rope: Apply RoPE to self-attention Q/K. When False, the engine
+            omits rotary_cos/rotary_sin inputs (suitable for models that use
+            fixed position embeddings, e.g. PixArt).
+        eps: LayerNorm epsilon.
+        verbose: Enable TRT builder verbose logging.
+
+    Returns:
+        Serialized TRT engine plan bytes.
+    """
+    parallel = normalize_parallel_config(parallel_config)
+    validate_dit_tp(
+        dim=dim,
+        num_heads=num_heads,
+        ffn_dim=ffn_dim,
+        parallel=parallel,
+        feature="Standard DiT tensor parallel",
+    )
+    head_dim = dim // num_heads
+    local_num_heads = num_heads // parallel.tp_size
+    local_dim = dim // parallel.tp_size
+    local_ffn_dim = ffn_dim // parallel.tp_size
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
+
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    # Inputs
+    hidden_inp = network.add_input(
+        "hidden_states", trt.float32, (num_patches, dim))
+    # Block modulation temb from external embedder: [1, 6 * dim]
+    temb_inp = network.add_input(
+        "timestep_embedding", trt.float32, (1, 6 * dim))
+    # Time embed for final output modulation: [1, dim]
+    time_embed_inp = network.add_input(
+        "time_embed", trt.float32, (1, dim))
+    encoder_hidden = network.add_input(
+        "encoder_hidden_states", trt.float32, (text_seq_len, context_dim))
+
+    # Optional cross-attention mask: [1, 1, text_seq_len] float32.
+    # 0.0 for valid tokens, -10000.0 for padding.
+    # Only added when use_rope=False (PixArt, etc.) since Wan models
+    # don't need it (fixed-length text with no padding).
+    cross_attn_mask = None
+    if not use_rope:
+        cross_attn_mask = network.add_input(
+            "encoder_attention_mask", trt.float32, (1, 1, text_seq_len))
+
+    # Constants
+    eps_t = graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+
+    # RoPE inputs and precomputation (only when use_rope=True)
+    rotary_cos = rotary_sin = None
+    if use_rope:
+        rotary_cos = network.add_input(
+            "rotary_cos", trt.float32, (num_patches, head_dim))
+        rotary_sin = network.add_input(
+            "rotary_sin", trt.float32, (num_patches, head_dim))
+
+    hidden = hidden_inp
+
+    for layer_idx in range(num_layers):
+        prefix = f"blocks.{layer_idx}"
+
+        # --- AdaLN modulation ---
+        # scale_shift_table: [1, 6, dim] -> flatten to [1, 6*dim]
+        sst = weights[f"{prefix}.scale_shift_table"]
+        sst_const = graph_ops.add_constant(
+            network, (1, 6 * dim), sst.reshape(1, 6 * dim))
+
+        # modulation = sst + temb
+        modulation = network.add_elementwise(
+            sst_const, temb_inp, trt.ElementWiseOperation.SUM)
+
+        # Chunk into 6 parts: shift_sa, scale_sa, gate_sa, shift_ff, scale_ff, gate_ff
+        chunks = []
+        for i in range(6):
+            s = network.add_slice(
+                modulation.get_output(0),
+                start=(0, i * dim),
+                shape=(1, dim),
+                stride=(1, 1),
+            )
+            chunks.append(s.get_output(0))
+        shift_sa, scale_sa, gate_sa, shift_ff, scale_ff, gate_ff = chunks
+
+        # === 1. Self-attention with AdaLN + RoPE ===
+        normed = graph_ops.add_adaptive_layernorm(
+            network, hidden, scale_sa, shift_sa, dim, eps)
+
+        # QKV projections
+        q = _linear_col_parallel(
+            network, normed, dim, dim, weights, f"{prefix}.attn1.to_q", parallel)
+        k = _linear_col_parallel(
+            network, normed, dim, dim, weights, f"{prefix}.attn1.to_k", parallel)
+        v = _linear_col_parallel(
+            network, normed, dim, dim, weights, f"{prefix}.attn1.to_v", parallel)
+
+        # QK norm
+        if qk_norm:
+            q_norm_w = weights.get(f"{prefix}.attn1.norm_q.weight")
+            k_norm_w = weights.get(f"{prefix}.attn1.norm_k.weight")
+            if q_norm_w is not None:
+                q = graph_ops.add_rms_norm(
+                    network, q, local_dim,
+                    _tp_norm_weight(q_norm_w, local_num_heads, head_dim, parallel), eps_t)
+            if k_norm_w is not None:
+                k = graph_ops.add_rms_norm(
+                    network, k, local_dim,
+                    _tp_norm_weight(k_norm_w, local_num_heads, head_dim, parallel), eps_t)
+
+        # Apply RoPE to Q and K (skip when use_rope=False)
+        if use_rope:
+            q = graph_ops.add_apply_rope_native_from_full_cache(
+                network, q, local_num_heads, head_dim,
+                rotary_cos, rotary_sin, num_patches,
+                interleaved=True)
+            k = graph_ops.add_apply_rope_native_from_full_cache(
+                network, k, local_num_heads, head_dim,
+                rotary_cos, rotary_sin, num_patches,
+                interleaved=True)
+
+        # Multi-head attention
+        context_flat = graph_ops.add_attention_from_rows(
+            network, q, k, v,
+            num_heads=local_num_heads, head_dim=head_dim,
+            q_seq=num_patches, kv_seq=num_patches,
+            tag=f"{prefix}.attn1")
+
+        # Output projection
+        attn_out = _linear_row_parallel(
+            network, context_flat, local_dim, dim, weights,
+            f"{prefix}.attn1.to_out.0", parallel)
+
+        # Gate + residual
+        gated = network.add_elementwise(
+            attn_out, gate_sa, trt.ElementWiseOperation.PROD)
+        hidden = network.add_elementwise(
+            hidden, gated.get_output(0),
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === 2. Cross-attention ===
+        if cross_attn_norm:
+            cross_norm_w = weights.get(f"{prefix}.norm2.weight")
+            cross_norm_b = weights.get(f"{prefix}.norm2.bias")
+            if cross_norm_w is not None:
+                cross_normed = graph_ops.add_layer_norm(
+                    network, hidden, dim,
+                    cross_norm_w,
+                    cross_norm_b if cross_norm_b is not None else np.zeros(dim, dtype=np.float32),
+                    eps_t)
+            else:
+                cross_normed = hidden
+        else:
+            cross_normed = hidden
+
+        # Cross-attention: Q from hidden, K/V from encoder_hidden
+        cross_q = _linear_col_parallel(
+            network, cross_normed, dim, dim, weights, f"{prefix}.attn2.to_q", parallel)
+
+        # K/V from encoder (may use add_k_proj/add_v_proj for context projection)
+        add_k_proj_w = weights.get(f"{prefix}.attn2.add_k_proj.weight")
+        if add_k_proj_w is not None:
+            # Context needs projection: [text_seq, context_dim] -> [text_seq, dim]
+            cross_k = _linear_col_parallel(
+                network, encoder_hidden, context_dim, dim, weights,
+                f"{prefix}.attn2.add_k_proj", parallel)
+            cross_v = _linear_col_parallel(
+                network, encoder_hidden, context_dim, dim, weights,
+                f"{prefix}.attn2.add_v_proj", parallel)
+        else:
+            # Direct K/V from already-projected context
+            cross_k = _linear_col_parallel(
+                network, encoder_hidden, context_dim, dim, weights,
+                f"{prefix}.attn2.to_k", parallel)
+            cross_v = _linear_col_parallel(
+                network, encoder_hidden, context_dim, dim, weights,
+                f"{prefix}.attn2.to_v", parallel)
+
+        # QK norm for cross-attention
+        if qk_norm:
+            cq_norm = weights.get(f"{prefix}.attn2.norm_q.weight")
+            ck_norm = weights.get(f"{prefix}.attn2.norm_k.weight")
+            if cq_norm is not None:
+                cross_q = graph_ops.add_rms_norm(
+                    network, cross_q, local_dim,
+                    _tp_norm_weight(cq_norm, local_num_heads, head_dim, parallel), eps_t)
+            # For cross-attn with add_k_proj, the K norm is norm_added_k
+            ck_added_norm = weights.get(f"{prefix}.attn2.norm_added_k.weight")
+            if ck_added_norm is not None:
+                cross_k = graph_ops.add_rms_norm(
+                    network, cross_k, local_dim,
+                    _tp_norm_weight(ck_added_norm, local_num_heads, head_dim, parallel), eps_t)
+            elif ck_norm is not None:
+                cross_k = graph_ops.add_rms_norm(
+                    network, cross_k, local_dim,
+                    _tp_norm_weight(ck_norm, local_num_heads, head_dim, parallel), eps_t)
+
+        # Cross multi-head attention (no RoPE)
+        cross_mask_4d = None
+        if cross_attn_mask is not None:
+            cross_mask = network.add_shuffle(cross_attn_mask)
+            cross_mask.reshape_dims = (1, 1, 1, text_seq_len)
+            cross_mask_4d = cross_mask.get_output(0)
+        c_context_flat = graph_ops.add_attention_from_rows(
+            network, cross_q, cross_k, cross_v,
+            num_heads=local_num_heads, head_dim=head_dim,
+            q_seq=num_patches, kv_seq=text_seq_len,
+            mask=cross_mask_4d,
+            tag=f"{prefix}.attn2")
+
+        cross_out = _linear_row_parallel(
+            network, c_context_flat, local_dim, dim, weights,
+            f"{prefix}.attn2.to_out.0", parallel)
+
+        # Cross-attn residual (no gate in Wan)
+        hidden = network.add_elementwise(
+            hidden, cross_out,
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === 3. FFN with AdaLN ===
+        ffn_normed = graph_ops.add_adaptive_layernorm(
+            network, hidden, scale_ff, shift_ff, dim, eps)
+
+        # GELU FFN: Linear(dim, ffn_dim) -> GELU -> Linear(ffn_dim, dim)
+        ffn_fc1 = _linear_col_parallel(
+            network, ffn_normed, dim, ffn_dim, weights,
+            f"{prefix}.ffn.net.0.proj", parallel)
+
+        ffn_act = graph_ops.add_gelu_new(network, ffn_fc1)
+
+        ffn_fc2 = _linear_row_parallel(
+            network, ffn_act, local_ffn_dim, dim, weights,
+            f"{prefix}.ffn.net.2", parallel)
+
+        # Gate + residual
+        gated_ff = network.add_elementwise(
+            ffn_fc2, gate_ff, trt.ElementWiseOperation.PROD)
+        hidden = network.add_elementwise(
+            hidden, gated_ff.get_output(0),
+            trt.ElementWiseOperation.SUM).get_output(0)
+
+    # --- Final output: AdaLN modulation + projection ---
+    # HF: shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
+    # scale_shift_table: [1, 2, dim], time_embed: [1, dim] -> unsqueeze -> [1, 1, dim]
+    # Result after add: [1, 2, dim], chunk -> shift [1, 1, dim], scale [1, 1, dim]
+    final_sst = weights["scale_shift_table"]  # [1, 2, dim]
+    final_sst_const = graph_ops.add_constant(
+        network, (1, 2 * dim), final_sst.reshape(1, 2 * dim))
+
+    # time_embed_inp: [1, dim] -> tile to [1, 2*dim] for broadcast add
+    time_embed_tiled = network.add_concatenation(
+        [time_embed_inp, time_embed_inp])
+    time_embed_tiled.axis = 1  # [1, 2*dim]
+
+    final_modulation = network.add_elementwise(
+        final_sst_const, time_embed_tiled.get_output(0),
+        trt.ElementWiseOperation.SUM)
+
+    final_shift = network.add_slice(
+        final_modulation.get_output(0),
+        start=(0, 0), shape=(1, dim), stride=(1, 1))
+    final_scale = network.add_slice(
+        final_modulation.get_output(0),
+        start=(0, dim), shape=(1, dim), stride=(1, 1))
+
+    # Final LayerNorm + AdaLN modulation
+    hidden = graph_ops.add_adaptive_layernorm(
+        network, hidden, final_scale.get_output(0),
+        final_shift.get_output(0), dim, eps)
+
+    # Final projection: [num_patches, dim] -> [num_patches, out_channels * prod(patch_size)]
+    proj_out_w = weights["proj_out.weight"]
+    out_dim = proj_out_w.shape[1]  # [dim, out_channels * prod(patch_size)]
+    output = graph_ops.add_matmul_rhs_constant(
+        network, hidden, dim, out_dim, proj_out_w)
+    proj_out_b = weights.get("proj_out.bias")
+    if proj_out_b is not None:
+        output = graph_ops.add_bias_sum(network, output, out_dim, proj_out_b)
+
+    # Mark output
+    cast_output = network.add_cast(output, trt.float32)
+    output_final = cast_output.get_output(0)
+    output_final.name = "output"
+    network.mark_output(output_final)
+
+    # --- Build ---
+    tp_suffix = (
+        f", tp={parallel.tp_size}, rank={parallel.rank}"
+        if parallel.enabled else "")
+    print(f"[dit-builder] Building TRT engine "
+          f"(dim={dim}, layers={num_layers}, patches={num_patches}{tp_suffix}) ...",
+          file=sys.stderr)
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError("TRT engine serialization failed for DiT")
+    return bytes(plan)
+
+
+def _linear_col_parallel(
+    network,
+    inp,
+    in_dim: int,
+    out_dim: int,
+    weights,
+    prefix: str,
+    parallel: ParallelConfig,
+):
+    """Column-parallel linear: output features are rank-local."""
+    local_out_dim = out_dim // parallel.tp_size
+    weight = weights[f"{prefix}.weight"]
+    if parallel.enabled:
+        weight = _slice_last_dim(weight, parallel.rank, parallel.tp_size)
+    out = graph_ops.add_matmul_rhs_constant(network, inp, in_dim, local_out_dim, weight)
+    bias = weights.get(f"{prefix}.bias")
+    if bias is not None:
+        if parallel.enabled:
+            bias = _slice_first_dim(bias, parallel.rank, parallel.tp_size)
+        out = graph_ops.add_bias_sum(network, out, local_out_dim, bias)
+    return out
+
+
+def _linear_row_parallel(
+    network,
+    inp,
+    in_dim: int,
+    out_dim: int,
+    weights,
+    prefix: str,
+    parallel: ParallelConfig,
+):
+    """Row-parallel linear: partial outputs are all-reduced across TP ranks."""
+    weight = weights[f"{prefix}.weight"]
+    if parallel.enabled:
+        weight = _slice_first_dim(weight, parallel.rank, parallel.tp_size)
+    out = graph_ops.add_matmul_rhs_constant(network, inp, in_dim, out_dim, weight)
+    if parallel.enabled:
+        out = add_all_reduce_sum(network, out, parallel.tp_size)
+    bias = weights.get(f"{prefix}.bias")
+    if bias is not None:
+        out = graph_ops.add_bias_sum(network, out, out_dim, bias)
+    return out
+
+
+def _tp_norm_weight(
+    weight: np.ndarray,
+    local_num_heads: int,
+    head_dim: int,
+    parallel: ParallelConfig,
+) -> np.ndarray:
+    """Return the rank-local norm vector for sharded attention projections."""
+    if not parallel.enabled:
+        return weight
+    if weight.size == head_dim:
+        return weight
+    return _slice_first_dim(weight.reshape(-1, head_dim), parallel.rank,
+                            parallel.tp_size).reshape(local_num_heads * head_dim)
+
+
+def load_dit_weights(
+    model_dir: str,
+    *,
+    dim: int,
+    num_heads: int,
+    num_layers: int,
+    ffn_dim: int,
+    context_dim: int,
+) -> WeightDict:
+    """Load DiT weights from a diffusers-format transformer directory.
+
+    Expects: model_dir/diffusion_pytorch_model.safetensors (or sharded).
+    Returns WeightDict with transposed projections for TRT matmul.
+    """
+    from pathlib import Path
+    from ...checkpoint_mapper import WeightDict, _open_safetensors, _load_tensor, _has_tensor
+
+    model_path = Path(model_dir)
+    readers = _open_safetensors(model_path)
+    weights = WeightDict()
+
+    def _t(name: str) -> np.ndarray:
+        """Load and transpose [out, in] -> [in, out]."""
+        w = _load_tensor(readers, name)
+        return np.ascontiguousarray(w.T, dtype=np.float32)
+
+    def _f(name: str) -> np.ndarray:
+        """Load flat (1D) weight."""
+        return _load_tensor(readers, name).astype(np.float32)
+
+    def _maybe_t(name: str) -> np.ndarray | None:
+        if _has_tensor(readers, name):
+            return _t(name)
+        return None
+
+    def _maybe_f(name: str) -> np.ndarray | None:
+        if _has_tensor(readers, name):
+            return _f(name)
+        return None
+
+    for i in range(num_layers):
+        p = f"blocks.{i}"
+
+        # Self-attention
+        weights[f"{p}.attn1.to_q.weight"] = _t(f"{p}.attn1.to_q.weight")
+        weights[f"{p}.attn1.to_k.weight"] = _t(f"{p}.attn1.to_k.weight")
+        weights[f"{p}.attn1.to_v.weight"] = _t(f"{p}.attn1.to_v.weight")
+        weights[f"{p}.attn1.to_out.0.weight"] = _t(f"{p}.attn1.to_out.0.weight")
+
+        for proj in ("to_q", "to_k", "to_v"):
+            b = _maybe_f(f"{p}.attn1.{proj}.bias")
+            if b is not None:
+                weights[f"{p}.attn1.{proj}.bias"] = b
+        b = _maybe_f(f"{p}.attn1.to_out.0.bias")
+        if b is not None:
+            weights[f"{p}.attn1.to_out.0.bias"] = b
+
+        # QK norm
+        for norm in ("norm_q", "norm_k"):
+            w = _maybe_f(f"{p}.attn1.{norm}.weight")
+            if w is not None:
+                weights[f"{p}.attn1.{norm}.weight"] = w
+
+        # Cross-attention
+        weights[f"{p}.attn2.to_q.weight"] = _t(f"{p}.attn2.to_q.weight")
+        weights[f"{p}.attn2.to_out.0.weight"] = _t(f"{p}.attn2.to_out.0.weight")
+
+        for proj in ("to_q", "to_k", "to_v"):
+            b = _maybe_f(f"{p}.attn2.{proj}.bias")
+            if b is not None:
+                weights[f"{p}.attn2.{proj}.bias"] = b
+        b = _maybe_f(f"{p}.attn2.to_out.0.bias")
+        if b is not None:
+            weights[f"{p}.attn2.to_out.0.bias"] = b
+
+        # Cross-attn K/V: either to_k/to_v or add_k_proj/add_v_proj
+        if _has_tensor(readers, f"{p}.attn2.add_k_proj.weight"):
+            weights[f"{p}.attn2.add_k_proj.weight"] = _t(f"{p}.attn2.add_k_proj.weight")
+            weights[f"{p}.attn2.add_v_proj.weight"] = _t(f"{p}.attn2.add_v_proj.weight")
+            b = _maybe_f(f"{p}.attn2.add_k_proj.bias")
+            if b is not None:
+                weights[f"{p}.attn2.add_k_proj.bias"] = b
+            b = _maybe_f(f"{p}.attn2.add_v_proj.bias")
+            if b is not None:
+                weights[f"{p}.attn2.add_v_proj.bias"] = b
+        else:
+            weights[f"{p}.attn2.to_k.weight"] = _t(f"{p}.attn2.to_k.weight")
+            weights[f"{p}.attn2.to_v.weight"] = _t(f"{p}.attn2.to_v.weight")
+
+        # Cross-attn QK norm
+        for norm in ("norm_q", "norm_k", "norm_added_k"):
+            w = _maybe_f(f"{p}.attn2.{norm}.weight")
+            if w is not None:
+                weights[f"{p}.attn2.{norm}.weight"] = w
+
+        # Cross-attn norm (LayerNorm)
+        w = _maybe_f(f"{p}.norm2.weight")
+        if w is not None:
+            weights[f"{p}.norm2.weight"] = w
+        b = _maybe_f(f"{p}.norm2.bias")
+        if b is not None:
+            weights[f"{p}.norm2.bias"] = b
+
+        # FFN
+        weights[f"{p}.ffn.net.0.proj.weight"] = _t(f"{p}.ffn.net.0.proj.weight")
+        weights[f"{p}.ffn.net.2.weight"] = _t(f"{p}.ffn.net.2.weight")
+        b = _maybe_f(f"{p}.ffn.net.0.proj.bias")
+        if b is not None:
+            weights[f"{p}.ffn.net.0.proj.bias"] = b
+        b = _maybe_f(f"{p}.ffn.net.2.bias")
+        if b is not None:
+            weights[f"{p}.ffn.net.2.bias"] = b
+
+        # Scale-shift table
+        sst = _load_tensor(readers, f"{p}.scale_shift_table")
+        weights[f"{p}.scale_shift_table"] = sst.astype(np.float32)
+
+    # Final output
+    weights["scale_shift_table"] = _load_tensor(
+        readers, "scale_shift_table").astype(np.float32)
+    weights["proj_out.weight"] = _t("proj_out.weight")
+    b = _maybe_f("proj_out.bias")
+    if b is not None:
+        weights["proj_out.bias"] = b
+
+    # Patch embedding (loaded but used externally, not in the TRT engine)
+    if _has_tensor(readers, "patch_embedding.weight"):
+        weights["patch_embedding.weight"] = _load_tensor(
+            readers, "patch_embedding.weight").astype(np.float32)
+    if _has_tensor(readers, "patch_embedding.bias"):
+        weights["patch_embedding.bias"] = _load_tensor(
+            readers, "patch_embedding.bias").astype(np.float32)
+
+    # Timestep/text embedder weights (used externally)
+    # Map canonical internal names -> possible safetensors names
+    _embedder_aliases = {
+        "condition_embedder.time_embedding.0.weight": [
+            "condition_embedder.time_embedding.0.weight",
+            "condition_embedder.time_embedder.linear_1.weight",
+        ],
+        "condition_embedder.time_embedding.0.bias": [
+            "condition_embedder.time_embedding.0.bias",
+            "condition_embedder.time_embedder.linear_1.bias",
+        ],
+        "condition_embedder.time_embedding.2.weight": [
+            "condition_embedder.time_embedding.2.weight",
+            "condition_embedder.time_embedder.linear_2.weight",
+        ],
+        "condition_embedder.time_embedding.2.bias": [
+            "condition_embedder.time_embedding.2.bias",
+            "condition_embedder.time_embedder.linear_2.bias",
+        ],
+        "condition_embedder.text_embedding.weight": [
+            "condition_embedder.text_embedding.weight",
+            "condition_embedder.text_embedder.linear_1.weight",
+        ],
+        "condition_embedder.text_embedding.bias": [
+            "condition_embedder.text_embedding.bias",
+            "condition_embedder.text_embedder.linear_1.bias",
+        ],
+        "condition_embedder.text_embedding_2.weight": [
+            "condition_embedder.text_embedding_2.weight",
+            "condition_embedder.text_embedder.linear_2.weight",
+        ],
+        "condition_embedder.text_embedding_2.bias": [
+            "condition_embedder.text_embedding_2.bias",
+            "condition_embedder.text_embedder.linear_2.bias",
+        ],
+    }
+    for key in ("condition_embedder.time_proj.weight",
+                "condition_embedder.time_proj.bias"):
+        if _has_tensor(readers, key):
+            w = _load_tensor(readers, key).astype(np.float32)
+            if w.ndim == 2:
+                weights[key] = np.ascontiguousarray(w.T, dtype=np.float32)
+            else:
+                weights[key] = w
+
+    for canonical, aliases in _embedder_aliases.items():
+        for alias in aliases:
+            if _has_tensor(readers, alias):
+                w = _load_tensor(readers, alias).astype(np.float32)
+                if w.ndim == 2:
+                    weights[canonical] = np.ascontiguousarray(w.T, dtype=np.float32)
+                else:
+                    weights[canonical] = w
+                break
+
+    return weights

--- a/tensorrt_model_connect/tensorrt_model_connect/families/z_image/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/z_image/plugin.py
@@ -103,7 +103,8 @@ class ZImagePlugin:
 
     def build_components(
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
-        *, precision: str = "fp32", verbose: bool = False, **_kwargs,
+        *, precision: str = "fp32", verbose: bool = False,
+        parallel_config=None, **_kwargs,
     ) -> dict:
         """Build REAL TRT engines for all Z-Image components."""
         from ...build_timing import timed_trt_compile, timed_weight_loading
@@ -111,8 +112,26 @@ class ZImagePlugin:
             build_qwen3_encoder_engine, load_qwen3_encoder_weights)
         from .z_image_dit_builder import (
             build_z_image_dit_engine, load_z_image_dit_weights)
+        from .z_image_dit_tp_builder import (
+            build_z_image_dit_engine as build_z_image_dit_tp_engine)
         from .vae_2d_builder import build_vae_2d_decoder_engine
+        from ...parallel_config import (
+            normalize_parallel_config,
+            require_tensorrt_11_for_tensor_parallel,
+            validate_dit_tp,
+        )
         build_timing = _kwargs.get("build_timing")
+        parallel = normalize_parallel_config(parallel_config)
+        require_tensorrt_11_for_tensor_parallel(
+            parallel, feature="Z-Image tensor-parallel builds")
+        if parallel.enabled:
+            validate_dit_tp(
+                dim=self._DIT_DIM,
+                num_heads=self._DIT_NUM_HEADS,
+                ffn_dim=self._DIT_FFN_DIM,
+                parallel=parallel.for_rank(0),
+                feature="Z-Image tensor parallel",
+            )
 
         text_encoder_dir = weights["_text_encoder_dir"]
         transformer_dir = weights["_transformer_dir"]
@@ -173,20 +192,44 @@ class ZImagePlugin:
                 num_refiner_layers=self._DIT_NUM_REFINER_LAYERS,
                 ffn_dim=self._DIT_FFN_DIM,
             )
+        dit_plan = None
+        dit_rank_plans = None
         with timed_trt_compile(build_timing, "z_image_dit"):
-            dit_plan = build_z_image_dit_engine(
-                dit_weights,
-                dim=self._DIT_DIM,
-                num_heads=self._DIT_NUM_HEADS,
-                num_layers=self._DIT_NUM_LAYERS,
-                num_refiner_layers=self._DIT_NUM_REFINER_LAYERS,
-                ffn_dim=self._DIT_FFN_DIM,
-                num_patches=num_patches,
-                text_seq_len=self._TEXT_MAX_SEQ_LEN,
-                head_dim=self._DIT_HEAD_DIM,
-                adaln_embed_dim=self._ADALN_EMBED_DIM,
-                verbose=verbose,
-            )
+            if parallel.enabled:
+                dit_rank_plans = {}
+                for rank in range(parallel.tp_size):
+                    print(
+                        f"[z-image] Building DiT TP rank {rank}/{parallel.tp_size} ...",
+                        file=sys.stderr,
+                    )
+                    dit_rank_plans[rank] = build_z_image_dit_tp_engine(
+                        dit_weights,
+                        dim=self._DIT_DIM,
+                        num_heads=self._DIT_NUM_HEADS,
+                        num_layers=self._DIT_NUM_LAYERS,
+                        num_refiner_layers=self._DIT_NUM_REFINER_LAYERS,
+                        ffn_dim=self._DIT_FFN_DIM,
+                        num_patches=num_patches,
+                        text_seq_len=self._TEXT_MAX_SEQ_LEN,
+                        head_dim=self._DIT_HEAD_DIM,
+                        adaln_embed_dim=self._ADALN_EMBED_DIM,
+                        verbose=verbose,
+                        parallel_config=parallel.for_rank(rank),
+                    )
+            else:
+                dit_plan = build_z_image_dit_engine(
+                    dit_weights,
+                    dim=self._DIT_DIM,
+                    num_heads=self._DIT_NUM_HEADS,
+                    num_layers=self._DIT_NUM_LAYERS,
+                    num_refiner_layers=self._DIT_NUM_REFINER_LAYERS,
+                    ffn_dim=self._DIT_FFN_DIM,
+                    num_patches=num_patches,
+                    text_seq_len=self._TEXT_MAX_SEQ_LEN,
+                    head_dim=self._DIT_HEAD_DIM,
+                    adaln_embed_dim=self._ADALN_EMBED_DIM,
+                    verbose=verbose,
+                )
 
         # 3. VAE decoder
         print("[z-image] Building VAE decoder engine ...", file=sys.stderr)
@@ -205,12 +248,16 @@ class ZImagePlugin:
         # 4. Serialize preprocessor weights for C++ runtime
         preprocessor_weights = _serialize_preprocessor_weights(dit_weights)
 
-        return {
+        out = {
             "text_encoders": [("qwen3", te_plan)],
-            "denoiser": dit_plan,
             "vae_decoder": vae_plan,
             "preprocessor_weights": preprocessor_weights,
         }
+        if parallel.enabled:
+            out["denoiser_ranks"] = dit_rank_plans or {}
+        else:
+            out["denoiser"] = dit_plan
+        return out
 
     def get_diffusion_config(self, config: ModelConfig) -> dict:
         image_height = config.raw.get("image_height", 1024)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/z_image/z_image_dit_tp_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/z_image/z_image_dit_tp_builder.py
@@ -1,0 +1,683 @@
+"""Z-Image DiT engine builder.
+
+Builds a TRT engine for the ZImageTransformer2DModel:
+  - 30 main DiT layers (unified single-stream attention + SwiGLU FFN + 4-param AdaLN with tanh gating)
+  - 2 noise_refiner layers (same structure as main layers, operate on noise tokens only)
+  - 2 context_refiner layers (no AdaLN, plain pre-norm attention + SwiGLU FFN, operate on caption tokens)
+  - 3-axis RoPE (time, height, width) with complex-number style
+
+Engine I/O:
+    Inputs:
+        hidden_states [num_patches, dim] float32  (patchified+embedded noise latents)
+        encoder_hidden_states [text_seq_len, dim] float32  (projected caption embeddings)
+        timestep_embedding [1, adaln_embed_dim] float32  (t_embedder MLP output)
+        rotary_cos [total_seq, head_dim] float32  (3-axis RoPE cos)
+        rotary_sin [total_seq, head_dim] float32  (3-axis RoPE sin)
+    Outputs:
+        output [num_patches, out_channels] float32
+
+HF architecture per main layer:
+    # AdaLN modulation: Linear(adaln_dim, 4*dim) -- NO SiLU before per-layer
+    mod = adaLN_modulation(adaln_input)
+    scale_msa, gate_msa, scale_mlp, gate_mlp = chunk(mod, 4)
+    gate_msa, gate_mlp = tanh(gate_msa), tanh(gate_mlp)
+    scale_msa, scale_mlp = 1 + scale_msa, 1 + scale_mlp
+
+    # Pre-norm + self-attention (unified: noise + caption concatenated)
+    x_norm = RMSNorm(x) * scale_msa        # attention_norm1 is pre-norm
+    attn_out = SelfAttention(x_norm, RoPE)
+    x = x + gate_msa * RMSNorm(attn_out)   # attention_norm2 is POST-norm on attn output
+
+    # Pre-norm + SwiGLU FFN
+    x_norm = RMSNorm(x) * scale_mlp        # ffn_norm1 is pre-norm
+    ffn_out = SwiGLU(x_norm)
+    x = x + gate_mlp * RMSNorm(ffn_out)    # ffn_norm2 is POST-norm on ffn output
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...checkpoint_mapper import WeightDict, _open_safetensors, _load_tensor
+from ...parallel_config import (
+    ParallelConfig,
+    _slice_first_dim,
+    _slice_last_dim,
+    add_all_reduce_sum,
+    normalize_parallel_config,
+    validate_dit_tp,
+)
+
+
+trt = trt_compat.get_trt()
+
+def load_z_image_dit_weights(
+    model_dir: str,
+    *,
+    dim: int,
+    num_heads: int,
+    num_layers: int,
+    num_refiner_layers: int,
+    ffn_dim: int,
+) -> WeightDict:
+    """Load Z-Image DiT weights from HF safetensors."""
+    model_path = Path(model_dir)
+    readers = _open_safetensors(model_path)
+    weights = WeightDict()
+
+    def _t(name: str) -> np.ndarray:
+        w = _load_tensor(readers, name)
+        return np.ascontiguousarray(w.T, dtype=np.float32)
+
+    def _f(name: str) -> np.ndarray:
+        return _load_tensor(readers, name).astype(np.float32)
+
+    # Main layers
+    for i in range(num_layers):
+        p = f"layers.{i}"
+        _load_dit_block(weights, readers, p, f"main.{i}", _t, _f, has_adaln=True)
+
+    # Noise refiner layers (same as main, with AdaLN)
+    for i in range(num_refiner_layers):
+        p = f"noise_refiner.{i}"
+        _load_dit_block(weights, readers, p, f"noise_refiner.{i}", _t, _f, has_adaln=True)
+
+    # Context refiner layers (no AdaLN)
+    for i in range(num_refiner_layers):
+        p = f"context_refiner.{i}"
+        _load_dit_block(weights, readers, p, f"context_refiner.{i}", _t, _f, has_adaln=False)
+
+    # Patch embedder: all_x_embedder.2-1 [dim, patch_dim]
+    weights["x_embedder.weight"] = _t("all_x_embedder.2-1.weight")
+    weights["x_embedder.bias"] = _f("all_x_embedder.2-1.bias")
+
+    # Final layer: all_final_layer.2-1
+    # Note: adaLN_modulation is nn.Sequential(SiLU(), Linear(adaln_dim, dim))
+    # So weight index is .1. not .0.
+    weights["final_adaLN.weight"] = _t("all_final_layer.2-1.adaLN_modulation.1.weight")
+    weights["final_adaLN.bias"] = _f("all_final_layer.2-1.adaLN_modulation.1.bias")
+    weights["final_linear.weight"] = _t("all_final_layer.2-1.linear.weight")
+    weights["final_linear.bias"] = _f("all_final_layer.2-1.linear.bias")
+
+    # Caption embedder: cap_embedder.0.weight (RMSNorm gamma), cap_embedder.1 (Linear)
+    weights["cap_norm.weight"] = _f("cap_embedder.0.weight")
+    weights["cap_proj.weight"] = _t("cap_embedder.1.weight")
+    weights["cap_proj.bias"] = _f("cap_embedder.1.bias")
+
+    # Padding tokens
+    weights["cap_pad_token"] = _f("cap_pad_token")
+    weights["x_pad_token"] = _f("x_pad_token")
+
+    # Timestep embedder: t_embedder.mlp.0, t_embedder.mlp.2
+    weights["t_emb.0.weight"] = _t("t_embedder.mlp.0.weight")
+    weights["t_emb.0.bias"] = _f("t_embedder.mlp.0.bias")
+    weights["t_emb.2.weight"] = _t("t_embedder.mlp.2.weight")
+    weights["t_emb.2.bias"] = _f("t_embedder.mlp.2.bias")
+
+    return weights
+
+
+def _load_dit_block(
+    weights: WeightDict,
+    readers,
+    hf_prefix: str,
+    trt_prefix: str,
+    _t,
+    _f,
+    has_adaln: bool,
+):
+    """Load weights for one Z-Image DiT block."""
+    p = hf_prefix
+    tp = trt_prefix
+
+    # Attention (diffusers Attention class uses to_q/to_k/to_v/to_out.0)
+    weights[f"{tp}.to_q"] = _t(f"{p}.attention.to_q.weight")
+    weights[f"{tp}.to_k"] = _t(f"{p}.attention.to_k.weight")
+    weights[f"{tp}.to_v"] = _t(f"{p}.attention.to_v.weight")
+    weights[f"{tp}.to_out"] = _t(f"{p}.attention.to_out.0.weight")
+
+    # QK norm (per-head RMSNorm)
+    weights[f"{tp}.norm_q"] = _f(f"{p}.attention.norm_q.weight")
+    weights[f"{tp}.norm_k"] = _f(f"{p}.attention.norm_k.weight")
+
+    # Pre-attention norm (attention_norm1 = pre-norm)
+    weights[f"{tp}.attn_norm1"] = _f(f"{p}.attention_norm1.weight")
+    # Post-attention norm (attention_norm2 = post-norm on attn output)
+    weights[f"{tp}.attn_norm2"] = _f(f"{p}.attention_norm2.weight")
+
+    # SwiGLU FFN: w1 (gate), w2 (down), w3 (up)
+    weights[f"{tp}.ff_w1"] = _t(f"{p}.feed_forward.w1.weight")
+    weights[f"{tp}.ff_w2"] = _t(f"{p}.feed_forward.w2.weight")
+    weights[f"{tp}.ff_w3"] = _t(f"{p}.feed_forward.w3.weight")
+
+    # FFN norms: ffn_norm1 = pre-norm, ffn_norm2 = post-norm
+    weights[f"{tp}.ffn_norm1"] = _f(f"{p}.ffn_norm1.weight")
+    weights[f"{tp}.ffn_norm2"] = _f(f"{p}.ffn_norm2.weight")
+
+    # AdaLN modulation: nn.Sequential(nn.Linear(adaln_dim, 4*dim))
+    # HF key is adaLN_modulation.0.weight (index 0 in Sequential)
+    if has_adaln:
+        weights[f"{tp}.adaln.weight"] = _t(f"{p}.adaLN_modulation.0.weight")
+        weights[f"{tp}.adaln.bias"] = _f(f"{p}.adaLN_modulation.0.bias")
+
+
+def build_z_image_dit_engine(
+    weights: WeightDict,
+    *,
+    dim: int,
+    num_heads: int,
+    num_layers: int,
+    num_refiner_layers: int,
+    ffn_dim: int,
+    num_patches: int,
+    text_seq_len: int,
+    head_dim: int = 128,
+    adaln_embed_dim: int = 256,
+    eps: float = 1e-5,
+    verbose: bool = False,
+    parallel_config: ParallelConfig | None = None,
+) -> bytes:
+    """Build Z-Image DiT TRT engine."""
+    parallel = normalize_parallel_config(parallel_config)
+    validate_dit_tp(
+        dim=dim,
+        num_heads=num_heads,
+        ffn_dim=ffn_dim,
+        parallel=parallel,
+        feature="Z-Image tensor parallel",
+    )
+    total_seq = num_patches + text_seq_len
+    attn_scale = 1.0 / np.sqrt(max(head_dim, 1))
+    out_channels = weights["final_linear.weight"].shape[1]
+    local_num_heads = num_heads // parallel.tp_size
+    local_dim = dim // parallel.tp_size
+    local_ffn_dim = ffn_dim // parallel.tp_size
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    # Inputs (no batch dim -- static shapes)
+    noise_inp = network.add_input(
+        "hidden_states", trt.float32, (num_patches, dim))
+    caption_inp = network.add_input(
+        "encoder_hidden_states", trt.float32, (text_seq_len, dim))
+    temb_inp = network.add_input(
+        "timestep_embedding", trt.float32, (1, adaln_embed_dim))
+    rope_cos = network.add_input(
+        "rotary_cos", trt.float32, (total_seq, head_dim))
+    rope_sin = network.add_input(
+        "rotary_sin", trt.float32, (total_seq, head_dim))
+
+    # Constants
+    eps_t = graph_ops.add_constant(network, (1, 1), np.array([eps], dtype=np.float32))
+    scale_t = graph_ops.add_constant(
+        network, (1, 1, 1), np.array([attn_scale], dtype=np.float32))
+    ones_t = graph_ops.add_constant(network, (1, 1), np.array([1.0], dtype=np.float32))
+
+    noise = noise_inp
+    caption = caption_inp
+
+    # --- Noise refiner (on noise only, with AdaLN) ---
+    noise_cos = _slice_rope(network, rope_cos, 0, num_patches, head_dim)
+    noise_sin = _slice_rope(network, rope_sin, 0, num_patches, head_dim)
+    for i in range(num_refiner_layers):
+        tp = f"noise_refiner.{i}"
+        noise = _add_adaln_dit_block(
+            network, noise, weights, tp, temb_inp,
+            dim, num_heads, head_dim, ffn_dim, adaln_embed_dim,
+            num_patches, eps_t, scale_t,
+            noise_cos, noise_sin, ones_t, parallel,
+        )
+
+    # --- Context refiner (on caption only, no AdaLN) ---
+    cap_cos = _slice_rope(network, rope_cos, num_patches, text_seq_len, head_dim)
+    cap_sin = _slice_rope(network, rope_sin, num_patches, text_seq_len, head_dim)
+    for i in range(num_refiner_layers):
+        tp = f"context_refiner.{i}"
+        caption = _add_plain_dit_block(
+            network, caption, weights, tp,
+            dim, num_heads, head_dim, ffn_dim, text_seq_len,
+            eps_t, scale_t, cap_cos, cap_sin, parallel,
+        )
+
+    # --- Main layers (unified: noise + caption concatenated) ---
+    for i in range(num_layers):
+        tp = f"main.{i}"
+
+        # AdaLN modulation: Linear(adaln_dim, 4*dim) -- NO SiLU (unlike FinalLayer)
+        adaln_w = weights[f"{tp}.adaln.weight"]
+        adaln_b = weights[f"{tp}.adaln.bias"]
+        modulation = graph_ops.add_matmul_rhs_constant(
+            network, temb_inp, adaln_embed_dim, 4 * dim, adaln_w)
+        modulation = graph_ops.add_bias_sum(network, modulation, 4 * dim, adaln_b)
+
+        # Chunk into 4: scale_msa, gate_msa, scale_mlp, gate_mlp
+        chunks = []
+        for ci in range(4):
+            s = network.add_slice(
+                modulation, start=(0, ci * dim), shape=(1, dim), stride=(1, 1))
+            chunks.append(s.get_output(0))
+        scale_msa, gate_msa_raw, scale_mlp, gate_mlp_raw = chunks
+
+        # Tanh gating (critical for stability)
+        gate_msa_act = network.add_activation(gate_msa_raw, trt.ActivationType.TANH)
+        gate_msa = gate_msa_act.get_output(0)
+        gate_mlp_act = network.add_activation(gate_mlp_raw, trt.ActivationType.TANH)
+        gate_mlp = gate_mlp_act.get_output(0)
+
+        # scale = 1 + scale
+        scale_msa_p1 = network.add_elementwise(
+            scale_msa, ones_t, trt.ElementWiseOperation.SUM).get_output(0)
+        scale_mlp_p1 = network.add_elementwise(
+            scale_mlp, ones_t, trt.ElementWiseOperation.SUM).get_output(0)
+
+        # --- Self-attention with AdaLN ---
+        # Concatenate noise + caption FIRST, then apply SAME attention_norm1
+        unified = network.add_concatenation([noise, caption])
+        unified.axis = 0
+        unified_t = unified.get_output(0)
+
+        # Pre-norm: attention_norm1 on the UNIFIED sequence (both noise and caption)
+        unified_normed = graph_ops.add_rms_norm(
+            network, unified_t, dim, weights[f"{tp}.attn_norm1"], eps_t)
+
+        # Apply scale_msa to unified normed sequence
+        unified_scaled = network.add_elementwise(
+            unified_normed, scale_msa_p1,
+            trt.ElementWiseOperation.PROD).get_output(0)
+
+        # QKV on unified scaled sequence
+        q = _linear_col_parallel(network, unified_scaled, dim, dim, weights, f"{tp}.to_q",
+                                 parallel)
+        k = _linear_col_parallel(network, unified_scaled, dim, dim, weights, f"{tp}.to_k",
+                                 parallel)
+        v = _linear_col_parallel(network, unified_scaled, dim, dim, weights, f"{tp}.to_v",
+                                 parallel)
+
+        # QK norm (per-head)
+        q_norm_w = weights[f"{tp}.norm_q"]
+        k_norm_w = weights[f"{tp}.norm_k"]
+        q_norm_tiled = _tp_per_head_norm_weight(q_norm_w, local_num_heads, head_dim, parallel)
+        k_norm_tiled = _tp_per_head_norm_weight(k_norm_w, local_num_heads, head_dim, parallel)
+        q = _per_head_rms_norm(network, q, local_num_heads, head_dim, q_norm_tiled, eps_t,
+                               total_seq)
+        k = _per_head_rms_norm(network, k, local_num_heads, head_dim, k_norm_tiled, eps_t,
+                               total_seq)
+
+        # Apply RoPE (full unified sequence)
+        q = _apply_native_rope_from_full_cache(
+            network, q, rope_cos, rope_sin, local_num_heads, head_dim, total_seq)
+        k = _apply_native_rope_from_full_cache(
+            network, k, rope_cos, rope_sin, local_num_heads, head_dim, total_seq)
+
+        # Multi-head attention
+        attn_out = _multi_head_attention(network, q, k, v, local_num_heads, head_dim, total_seq,
+                                         total_seq, scale_t)
+
+        # Output projection
+        attn_out = _linear_row_parallel(network, attn_out, local_dim, dim, weights,
+                                        f"{tp}.to_out", parallel)
+
+        # Post-norm: attention_norm2 on attn output (NOT on input)
+        attn_out_normed = graph_ops.add_rms_norm(
+            network, attn_out, dim, weights[f"{tp}.attn_norm2"], eps_t)
+
+        # Gate + residual
+        gated_attn = network.add_elementwise(
+            attn_out_normed, gate_msa, trt.ElementWiseOperation.PROD)
+        unified_t = network.add_elementwise(
+            unified_t, gated_attn.get_output(0), trt.ElementWiseOperation.SUM).get_output(0)
+
+        # --- SwiGLU FFN with AdaLN ---
+        # Pre-norm: ffn_norm1 on unified
+        unified_ffn_normed = graph_ops.add_rms_norm(
+            network, unified_t, dim, weights[f"{tp}.ffn_norm1"], eps_t)
+        unified_ffn_scaled = network.add_elementwise(
+            unified_ffn_normed, scale_mlp_p1,
+            trt.ElementWiseOperation.PROD).get_output(0)
+
+        # SwiGLU: gate = SiLU(x @ w1), up = x @ w3, out = (gate * up) @ w2
+        gate_proj = _linear_col_parallel(network, unified_ffn_scaled, dim, ffn_dim, weights,
+                                         f"{tp}.ff_w1", parallel)
+        up_proj = _linear_col_parallel(network, unified_ffn_scaled, dim, ffn_dim, weights,
+                                       f"{tp}.ff_w3", parallel)
+
+        gate_sigmoid = network.add_activation(gate_proj, trt.ActivationType.SIGMOID)
+        gate_silu = network.add_elementwise(
+            gate_proj, gate_sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+        gated_ffn = network.add_elementwise(
+            gate_silu.get_output(0), up_proj, trt.ElementWiseOperation.PROD)
+
+        down_proj = _linear_row_parallel(network, gated_ffn.get_output(0), local_ffn_dim, dim,
+                                         weights, f"{tp}.ff_w2", parallel)
+
+        # Post-norm: ffn_norm2 on FFN output
+        ffn_out_normed = graph_ops.add_rms_norm(
+            network, down_proj, dim, weights[f"{tp}.ffn_norm2"], eps_t)
+
+        gated_ffn_out = network.add_elementwise(
+            ffn_out_normed, gate_mlp, trt.ElementWiseOperation.PROD)
+        unified_t = network.add_elementwise(
+            unified_t, gated_ffn_out.get_output(0), trt.ElementWiseOperation.SUM).get_output(0)
+
+        # Split unified back into noise and caption
+        noise = network.add_slice(
+            unified_t, start=(0, 0), shape=(num_patches, dim), stride=(1, 1)).get_output(0)
+        caption = network.add_slice(
+            unified_t,
+            start=(num_patches, 0),
+            shape=(text_seq_len, dim),
+            stride=(1, 1),
+        ).get_output(0)
+
+    # --- Final layer ---
+    # FinalLayer: LayerNorm(dim, elementwise_affine=False) * (1 + SiLU(Linear(adaln_dim, dim)))
+    # Then Linear(dim, out_channels)
+
+    # SiLU on temb, then linear
+    temb_silu = network.add_activation(temb_inp, trt.ActivationType.SIGMOID)
+    temb_silu_act = network.add_elementwise(
+        temb_inp, temb_silu.get_output(0), trt.ElementWiseOperation.PROD)
+    final_mod = graph_ops.add_matmul_rhs_constant(
+        network, temb_silu_act.get_output(0), adaln_embed_dim, dim,
+        weights["final_adaLN.weight"])
+    final_mod = graph_ops.add_bias_sum(network, final_mod, dim, weights["final_adaLN.bias"])
+    final_scale = network.add_elementwise(
+        final_mod, ones_t, trt.ElementWiseOperation.SUM).get_output(0)
+
+    # LayerNorm (elementwise_affine=False, eps=1e-6): mean-center then variance-normalize
+    ln_eps = graph_ops.add_constant(network, (1, 1), np.array([1e-6], dtype=np.float32))
+
+    # Compute mean: [num_patches, 1]
+    noise_mean = network.add_reduce(noise, trt.ReduceOperation.AVG, 1 << 1, keep_dims=True)
+    # Subtract mean
+    noise_centered = network.add_elementwise(
+        noise, noise_mean.get_output(0), trt.ElementWiseOperation.SUB).get_output(0)
+    # Compute variance
+    noise_sq = network.add_elementwise(
+        noise_centered, noise_centered, trt.ElementWiseOperation.PROD)
+    noise_var = network.add_reduce(
+        noise_sq.get_output(0), trt.ReduceOperation.AVG, 1 << 1, keep_dims=True)
+    noise_var_eps = network.add_elementwise(
+        noise_var.get_output(0), ln_eps, trt.ElementWiseOperation.SUM)
+    noise_std = network.add_unary(noise_var_eps.get_output(0), trt.UnaryOperation.SQRT)
+    noise_std_recip = network.add_unary(noise_std.get_output(0), trt.UnaryOperation.RECIP)
+    noise_ln = network.add_elementwise(
+        noise_centered, noise_std_recip.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+
+    # Apply scale
+    noise_final = network.add_elementwise(
+        noise_ln, final_scale, trt.ElementWiseOperation.PROD).get_output(0)
+
+    # Final linear projection
+    output = graph_ops.add_matmul_rhs_constant(
+        network, noise_final, dim, out_channels, weights["final_linear.weight"])
+    output = graph_ops.add_bias_sum(
+        network, output, out_channels, weights["final_linear.bias"])
+
+    cast_output = network.add_cast(output, trt.float32)
+    output_final = cast_output.get_output(0)
+    output_final.name = "output"
+    network.mark_output(output_final)
+
+    tp_suffix = (
+        f", tp={parallel.tp_size}, rank={parallel.rank}"
+        if parallel.enabled else "")
+    print(f"[z-image-dit] Building TRT engine "
+          f"(dim={dim}, layers={num_layers}, refiners={num_refiner_layers}, "
+          f"patches={num_patches}, text_seq={text_seq_len}, out_ch={out_channels}"
+          f"{tp_suffix}) ...", file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError("Z-Image DiT TRT engine build failed")
+    return bytes(plan)
+
+
+def _slice_rope(network, rope, start_seq, length, rope_dim):
+    """Slice RoPE along sequence dimension."""
+    s = network.add_slice(rope, start=(start_seq, 0), shape=(length, rope_dim), stride=(1, 1))
+    return s.get_output(0)
+
+
+def _apply_native_rope_from_full_cache(
+    network, x, cos_t, sin_t, num_heads, head_dim, seq_len,
+):
+    """Apply TRT native RoPE using runtime full-dimension cos/sin rows."""
+    return graph_ops.add_apply_rope_native_from_full_cache(
+        network, x, num_heads, head_dim, cos_t, sin_t,
+        seq_len, interleaved=True)
+
+
+def _per_head_rms_norm(network, inp, num_heads, head_dim, gamma, eps_t, seq_len):
+    """Per-head RMSNorm: [seq, num_heads * head_dim] -> reshape -> norm -> reshape."""
+    return graph_ops.add_rms_norm_per_head(
+        network, inp, num_heads, head_dim, gamma, eps_t,
+        sequence_length=seq_len)
+
+
+def _linear_col_parallel(network, inp, in_dim, out_dim, weights, key, parallel):
+    """Column-parallel linear: output features are rank-local."""
+    local_out_dim = out_dim // parallel.tp_size
+    weight = weights[key]
+    if parallel.enabled:
+        weight = _slice_last_dim(weight, parallel.rank, parallel.tp_size)
+    return graph_ops.add_matmul_rhs_constant(network, inp, in_dim, local_out_dim, weight)
+
+
+def _linear_row_parallel(network, inp, in_dim, out_dim, weights, key, parallel):
+    """Row-parallel linear: partial outputs are all-reduced across TP ranks."""
+    weight = weights[key]
+    if parallel.enabled:
+        weight = _slice_first_dim(weight, parallel.rank, parallel.tp_size)
+    out = graph_ops.add_matmul_rhs_constant(network, inp, in_dim, out_dim, weight)
+    if parallel.enabled:
+        out = add_all_reduce_sum(network, out, parallel.tp_size)
+    return out
+
+
+def _tp_per_head_norm_weight(weight, local_num_heads, head_dim, parallel):
+    if weight.size == head_dim:
+        return np.tile(weight.reshape(1, head_dim), (local_num_heads, 1))
+    full = weight.reshape(-1, head_dim)
+    if parallel.enabled:
+        full = _slice_first_dim(full, parallel.rank, parallel.tp_size)
+    return np.ascontiguousarray(full)
+
+
+def _multi_head_attention(network, q, k, v, num_heads, head_dim, q_seq, kv_seq, scale_t):
+    """Standard multi-head attention."""
+    return graph_ops.add_attention_from_rows(
+        network, q, k, v,
+        num_heads=num_heads, head_dim=head_dim,
+        q_seq=q_seq, kv_seq=kv_seq)
+
+
+def _add_plain_dit_block(
+    network, x, weights, prefix,
+    dim, num_heads, head_dim, ffn_dim, seq_len,
+    eps_t, scale_t, cos_t, sin_t, parallel,
+):
+    """Plain DiT block (no AdaLN): pre-norm attention + post-norm + SwiGLU FFN.
+
+    HF architecture (modulation=False):
+        attn_out = attention(attention_norm1(x))
+        x = x + attention_norm2(attn_out)          # norm2 = post-norm
+        x = x + ffn_norm2(feed_forward(ffn_norm1(x)))  # norm2 = post-norm
+    """
+    local_num_heads = num_heads // parallel.tp_size
+    local_dim = dim // parallel.tp_size
+    local_ffn_dim = ffn_dim // parallel.tp_size
+
+    # Pre-attention norm
+    normed = graph_ops.add_rms_norm(network, x, dim, weights[f"{prefix}.attn_norm1"], eps_t)
+
+    # QKV
+    q = _linear_col_parallel(network, normed, dim, dim, weights, f"{prefix}.to_q", parallel)
+    k = _linear_col_parallel(network, normed, dim, dim, weights, f"{prefix}.to_k", parallel)
+    v = _linear_col_parallel(network, normed, dim, dim, weights, f"{prefix}.to_v", parallel)
+
+    # QK norm
+    q_norm = _tp_per_head_norm_weight(
+        weights[f"{prefix}.norm_q"], local_num_heads, head_dim, parallel)
+    k_norm = _tp_per_head_norm_weight(
+        weights[f"{prefix}.norm_k"], local_num_heads, head_dim, parallel)
+    q = _per_head_rms_norm(network, q, local_num_heads, head_dim, q_norm, eps_t, seq_len)
+    k = _per_head_rms_norm(network, k, local_num_heads, head_dim, k_norm, eps_t, seq_len)
+
+    # RoPE
+    q = _apply_native_rope_from_full_cache(
+        network, q, cos_t, sin_t, local_num_heads, head_dim, seq_len)
+    k = _apply_native_rope_from_full_cache(
+        network, k, cos_t, sin_t, local_num_heads, head_dim, seq_len)
+
+    # Attention
+    attn_out = _multi_head_attention(
+        network, q, k, v, local_num_heads, head_dim, seq_len, seq_len, scale_t)
+    attn_out = _linear_row_parallel(
+        network, attn_out, local_dim, dim, weights, f"{prefix}.to_out", parallel)
+
+    # Post-norm on attn output
+    attn_out_normed = graph_ops.add_rms_norm(
+        network, attn_out, dim, weights[f"{prefix}.attn_norm2"], eps_t)
+
+    # Residual
+    x = network.add_elementwise(x, attn_out_normed, trt.ElementWiseOperation.SUM).get_output(0)
+
+    # Pre-FFN norm
+    ffn_normed = graph_ops.add_rms_norm(network, x, dim, weights[f"{prefix}.ffn_norm1"], eps_t)
+
+    # SwiGLU FFN
+    gate_proj = _linear_col_parallel(
+        network, ffn_normed, dim, ffn_dim, weights, f"{prefix}.ff_w1", parallel)
+    up_proj = _linear_col_parallel(
+        network, ffn_normed, dim, ffn_dim, weights, f"{prefix}.ff_w3", parallel)
+    gate_sigmoid = network.add_activation(gate_proj, trt.ActivationType.SIGMOID)
+    gate_silu = network.add_elementwise(
+        gate_proj, gate_sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    gated = network.add_elementwise(gate_silu.get_output(0), up_proj, trt.ElementWiseOperation.PROD)
+    down_proj = _linear_row_parallel(
+        network, gated.get_output(0), local_ffn_dim, dim, weights, f"{prefix}.ff_w2",
+        parallel)
+
+    # Post-norm on FFN output
+    ffn_out_normed = graph_ops.add_rms_norm(
+        network, down_proj, dim, weights[f"{prefix}.ffn_norm2"], eps_t)
+
+    x = network.add_elementwise(x, ffn_out_normed, trt.ElementWiseOperation.SUM).get_output(0)
+    return x
+
+
+def _add_adaln_dit_block(
+    network, x, weights, prefix, temb,
+    dim, num_heads, head_dim, ffn_dim, adaln_embed_dim,
+    seq_len, eps_t, scale_t, cos_t, sin_t, ones_t, parallel,
+):
+    """AdaLN DiT block (noise_refiner): 4-chunk modulation + tanh gating + attention + SwiGLU.
+
+    HF architecture (modulation=True):
+        mod = adaLN_modulation(adaln_input)  # NO SiLU -- just Linear
+        scale_msa, gate_msa, scale_mlp, gate_mlp = chunk(mod, 4)
+        gate_msa, gate_mlp = tanh(gate_msa), tanh(gate_mlp)
+        scale_msa, scale_mlp = 1 + scale_msa, 1 + scale_mlp
+
+        attn_out = attention(attention_norm1(x) * scale_msa)
+        x = x + gate_msa * attention_norm2(attn_out)
+
+        ffn_out = feed_forward(ffn_norm1(x) * scale_mlp)
+        x = x + gate_mlp * ffn_norm2(ffn_out)
+    """
+    local_num_heads = num_heads // parallel.tp_size
+    local_dim = dim // parallel.tp_size
+    local_ffn_dim = ffn_dim // parallel.tp_size
+
+    # AdaLN modulation: just Linear, no SiLU
+    adaln_w = weights[f"{prefix}.adaln.weight"]
+    adaln_b = weights[f"{prefix}.adaln.bias"]
+    mod = graph_ops.add_matmul_rhs_constant(
+        network, temb, adaln_embed_dim, 4 * dim, adaln_w)
+    mod = graph_ops.add_bias_sum(network, mod, 4 * dim, adaln_b)
+
+    chunks = []
+    for ci in range(4):
+        s = network.add_slice(mod, start=(0, ci * dim), shape=(1, dim), stride=(1, 1))
+        chunks.append(s.get_output(0))
+    scale_msa, gate_msa_raw, scale_mlp, gate_mlp_raw = chunks
+
+    # Tanh gating
+    gate_msa = network.add_activation(gate_msa_raw, trt.ActivationType.TANH).get_output(0)
+    gate_mlp = network.add_activation(gate_mlp_raw, trt.ActivationType.TANH).get_output(0)
+
+    scale_msa_p1 = network.add_elementwise(
+        scale_msa, ones_t, trt.ElementWiseOperation.SUM).get_output(0)
+    scale_mlp_p1 = network.add_elementwise(
+        scale_mlp, ones_t, trt.ElementWiseOperation.SUM).get_output(0)
+
+    # Pre-attention norm + AdaLN scale
+    normed = graph_ops.add_rms_norm(network, x, dim, weights[f"{prefix}.attn_norm1"], eps_t)
+    normed = network.add_elementwise(
+        normed, scale_msa_p1, trt.ElementWiseOperation.PROD).get_output(0)
+
+    # QKV
+    q = _linear_col_parallel(network, normed, dim, dim, weights, f"{prefix}.to_q", parallel)
+    k = _linear_col_parallel(network, normed, dim, dim, weights, f"{prefix}.to_k", parallel)
+    v = _linear_col_parallel(network, normed, dim, dim, weights, f"{prefix}.to_v", parallel)
+
+    q_norm = _tp_per_head_norm_weight(
+        weights[f"{prefix}.norm_q"], local_num_heads, head_dim, parallel)
+    k_norm = _tp_per_head_norm_weight(
+        weights[f"{prefix}.norm_k"], local_num_heads, head_dim, parallel)
+    q = _per_head_rms_norm(network, q, local_num_heads, head_dim, q_norm, eps_t, seq_len)
+    k = _per_head_rms_norm(network, k, local_num_heads, head_dim, k_norm, eps_t, seq_len)
+
+    q = _apply_native_rope_from_full_cache(
+        network, q, cos_t, sin_t, local_num_heads, head_dim, seq_len)
+    k = _apply_native_rope_from_full_cache(
+        network, k, cos_t, sin_t, local_num_heads, head_dim, seq_len)
+
+    attn_out = _multi_head_attention(
+        network, q, k, v, local_num_heads, head_dim, seq_len, seq_len, scale_t)
+    attn_out = _linear_row_parallel(
+        network, attn_out, local_dim, dim, weights, f"{prefix}.to_out", parallel)
+
+    # Post-norm on attn output
+    attn_out_normed = graph_ops.add_rms_norm(
+        network, attn_out, dim, weights[f"{prefix}.attn_norm2"], eps_t)
+
+    gated_attn = network.add_elementwise(attn_out_normed, gate_msa, trt.ElementWiseOperation.PROD)
+    x = network.add_elementwise(
+        x, gated_attn.get_output(0), trt.ElementWiseOperation.SUM).get_output(0)
+
+    # FFN
+    ffn_normed = graph_ops.add_rms_norm(network, x, dim, weights[f"{prefix}.ffn_norm1"], eps_t)
+    ffn_normed = network.add_elementwise(
+        ffn_normed, scale_mlp_p1, trt.ElementWiseOperation.PROD).get_output(0)
+
+    gate_proj = _linear_col_parallel(
+        network, ffn_normed, dim, ffn_dim, weights, f"{prefix}.ff_w1", parallel)
+    up_proj = _linear_col_parallel(
+        network, ffn_normed, dim, ffn_dim, weights, f"{prefix}.ff_w3", parallel)
+    gate_sigmoid = network.add_activation(gate_proj, trt.ActivationType.SIGMOID)
+    gate_silu = network.add_elementwise(
+        gate_proj, gate_sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    gated = network.add_elementwise(gate_silu.get_output(0), up_proj, trt.ElementWiseOperation.PROD)
+    down_proj = _linear_row_parallel(
+        network, gated.get_output(0), local_ffn_dim, dim, weights, f"{prefix}.ff_w2",
+        parallel)
+
+    # Post-norm on FFN output
+    ffn_out_normed = graph_ops.add_rms_norm(
+        network, down_proj, dim, weights[f"{prefix}.ffn_norm2"], eps_t)
+
+    gated_ffn = network.add_elementwise(ffn_out_normed, gate_mlp, trt.ElementWiseOperation.PROD)
+    x = network.add_elementwise(
+        x, gated_ffn.get_output(0), trt.ElementWiseOperation.SUM).get_output(0)
+    return x

--- a/tensorrt_model_connect/tensorrt_model_connect/graph_ops.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/graph_ops.py
@@ -2067,7 +2067,8 @@ def add_layer_norm_native(
     Replaces the manual reduce/elementwise chain in add_layer_norm with a
     single fused layer that TRT can optimize end-to-end. In strongly typed
     networks, input/scale/bias must have identical tensor types; compute
-    precision is set to FP32 for numerical stability.
+    precision is set to FP32 for numerical stability when the TensorRT Python
+    layer exposes that control.
 
     Note: INormalizationLayer computes (x - mean) / sqrt(var + eps) * gamma + beta.
     This is LayerNorm, NOT RMSNorm.  Use add_rms_norm for RMSNorm models.
@@ -2094,7 +2095,10 @@ def add_layer_norm_native(
     # hidden dimension is always the last axis for [*, hidden_size] tensors.
     norm = network.add_normalization_v2(inp, gamma_t, beta_t, 1 << (rank - 1))
     norm.epsilon = eps
-    norm.compute_precision = trt.float32
+    # TensorRT 11 removed the Python INormalizationLayer.compute_precision
+    # attribute. Keep the TRT 10 hint, and let TRT 11 infer the precision.
+    if hasattr(norm, "compute_precision"):
+        norm.compute_precision = trt.float32
     return norm.get_output(0)
 
 

--- a/tensorrt_model_connect/tensorrt_model_connect/parallel_config.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/parallel_config.py
@@ -70,6 +70,10 @@ def rank_engine_section(rank: int) -> str:
     return f"engine_plan_tp_rank{int(rank)}"
 
 
+def rank_denoiser_section(rank: int) -> str:
+    return f"denoiser_plan_tp_rank{int(rank)}"
+
+
 def require_tensorrt_11_for_tensor_parallel(
     parallel: ParallelConfig,
     *,
@@ -114,6 +118,50 @@ def validate_standard_decoder_tp(
         raise ValueError(
             f"Standard decoder tensor parallel requires intermediate size divisible by tp_size "
             f"({mlp_size} vs {tp})")
+
+
+def validate_dit_tp(
+    *,
+    dim: int,
+    num_heads: int,
+    ffn_dim: int,
+    parallel: ParallelConfig,
+    feature: str = "DiT tensor parallel",
+) -> None:
+    """Validate common DiT tensor-parallel dimensions."""
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError(f"{feature} engine build requires a concrete rank")
+    tp = parallel.tp_size
+    if dim % tp != 0:
+        raise ValueError(
+            f"{feature} requires hidden dim divisible by tp_size ({dim} vs {tp})")
+    if num_heads % tp != 0:
+        raise ValueError(
+            f"{feature} requires num_attention_heads divisible by tp_size "
+            f"({num_heads} vs {tp})")
+    if ffn_dim % tp != 0:
+        raise ValueError(
+            f"{feature} requires FFN size divisible by tp_size ({ffn_dim} vs {tp})")
+
+
+def validate_flux_dit_tp(
+    *,
+    dim: int,
+    num_heads: int,
+    ffn_dim: int,
+    parallel: ParallelConfig,
+) -> None:
+    """Validate FLUX.1 DiT tensor-parallel dimensions."""
+    validate_dit_tp(
+        dim=dim,
+        num_heads=num_heads,
+        ffn_dim=ffn_dim,
+        parallel=parallel,
+        feature="Flux tensor parallel",
+    )
 
 
 def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
@@ -181,7 +229,7 @@ def add_all_reduce_sum(network, tensor, tp_size: int):
     add_collective = getattr(network, "add_dist_collective", None)
     if add_collective is None:
         raise RuntimeError(
-            "Tensor-parallel decoder builds require TensorRT 11.0+ Python bindings "
+            "Tensor-parallel builds require TensorRT 11.0+ Python bindings "
             "with INetworkDefinition.add_dist_collective")
     layer = add_collective(
         tensor,
@@ -194,7 +242,7 @@ def add_all_reduce_sum(network, tensor, tp_size: int):
         raise RuntimeError("TensorRT failed to add ALL_REDUCE distributed collective")
     if not hasattr(layer, "num_ranks"):
         raise RuntimeError(
-            "Tensor-parallel decoder builds require TensorRT 11.0+ Python bindings "
+            "Tensor-parallel builds require TensorRT 11.0+ Python bindings "
             "with IDistCollectiveLayer.num_ranks")
     layer.num_ranks = tp_size
     return layer.get_output(0)

--- a/tests/builder/test_engine_builder_extended.py
+++ b/tests/builder/test_engine_builder_extended.py
@@ -748,6 +748,98 @@ class TestBuildBundleOrchestration:
             "split-qwen3-h64-l2-bf16-noquant-decode",
         ]
 
+    @pytest.mark.parametrize(
+        ("pipeline_class", "plugin_name", "runtime_strategy"),
+        [
+            ("FluxPipeline", "flux", "diffusion_flux"),
+            ("PixArtSigmaPipeline", "pixart", "diffusion_pixart"),
+            ("WanPipeline", "wan_t2v", "diffusion_wan"),
+        ],
+    )
+    def test_supported_diffusion_tensor_parallel_builds_rank_denoisers(
+        self, tmp_path, pipeline_class, plugin_name, runtime_strategy,
+    ):
+        """Supported diffusion TP families reach build_components and package rank plans."""
+        from tensorrt_model_connect.parallel_config import ParallelConfig
+
+        model_dir = tmp_path / f"{plugin_name}_diffusers"
+        model_dir.mkdir()
+        (model_dir / "model_index.json").write_text(json.dumps({"_class_name": pipeline_class}))
+        output_path = str(tmp_path / f"{plugin_name}.trtfb")
+        seen = {}
+
+        class _DiffusionPlugin:
+            def load_weights(self, model_dir, config):
+                seen["model_type"] = config.model_type
+                return {}
+
+            def build_components(
+                self,
+                model_dir,
+                config,
+                weights,
+                *,
+                parallel_config=None,
+                verbose=False,
+                fp8_scales=None,
+            ):
+                seen["parallel"] = parallel_config
+                return {
+                    "text_encoders": [("t5", b"t5")],
+                    "denoiser_ranks": {
+                        0: b"denoiser0",
+                        1: b"denoiser1",
+                        2: b"denoiser2",
+                        3: b"denoiser3",
+                    },
+                    "vae_decoder": b"vae",
+                }
+
+            def get_diffusion_config(self, config):
+                return {}
+
+        plugin = _DiffusionPlugin()
+        plugin.name = plugin_name
+        plugin.runtime_strategy = runtime_strategy
+
+        with patch("tensorrt_model_connect.engine_builder.find_diffusion_plugin",
+                    return_value=plugin):
+            with patch("tensorrt_model_connect.engine_builder._setup_trt_import"):
+                with patch("tensorrt_model_connect.trt_compat.tensorrt_version",
+                            return_value="11.0.0"):
+                    with patch("tensorrt_model_connect.trt_compat.resolved_summary",
+                                return_value="TensorRT: version=11.0.0"):
+                        with patch("tensorrt_model_connect.engine_builder._get_gpu_name",
+                                    return_value="NVIDIA A100"):
+                            with patch(
+                                "tensorrt_model_connect.engine_builder._detect_diffusion_tokenizer_add_special_tokens",
+                                return_value=False,
+                            ):
+                                with patch("tensorrt_model_connect.engine_builder.write_bundle") as mock_write:
+                                    build_bundle(
+                                        str(model_dir),
+                                        output_path,
+                                        parallel_config=ParallelConfig(
+                                            mode="tensor_parallel",
+                                            tp_size=4,
+                                        ),
+                                    )
+
+        assert seen["model_type"] == plugin_name
+        assert seen["parallel"].enabled
+        assert seen["parallel"].tp_size == 4
+
+        sections = mock_write.call_args[0][2]
+        section_map = {section.name: section.data for section in sections}
+        assert section_map["denoiser_plan_tp_rank0"] == b"denoiser0"
+        assert section_map["denoiser_plan_tp_rank1"] == b"denoiser1"
+        assert section_map["denoiser_plan_tp_rank2"] == b"denoiser2"
+        assert section_map["denoiser_plan_tp_rank3"] == b"denoiser3"
+
+        cfg = json.loads(section_map["config.json"].decode("utf-8"))
+        assert cfg["tensor_parallel_mode"] == "tensor_parallel"
+        assert cfg["tensor_parallel_size"] == 4
+
     def test_load_weights_precision_not_forwarded_when_unsupported(self, tmp_path):
         """build_bundle remains compatible with plugins that do not accept precision."""
         model_dir = self._make_model_dir(tmp_path, model_type="qwen3")

--- a/tests/builder/test_family_flux.py
+++ b/tests/builder/test_family_flux.py
@@ -19,6 +19,7 @@ import pytest
 try:
     from tensorrt_model_connect.config import ModelConfig
     import tensorrt_model_connect.families.flux as flux_mod
+    from tensorrt_model_connect.parallel_config import ParallelConfig
 except (ImportError, ModuleNotFoundError):
     pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
 
@@ -247,6 +248,115 @@ def test_build_components_with_clip_and_second_t5(
     assert calls["build_flux_dit_engine"][1]["num_img_tokens"] == 30
     assert calls["load_flux_dit_weights"][1]["dim"] == 8
     assert calls["serialize"][0][1] is True
+
+
+def test_build_components_builds_rank_local_flux_dit_for_tp(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Intent: verify FLUX.1 TP builds one rank-local DiT plan per rank.
+
+    Preconditions: component builders are replaced by deterministic stubs and TRT version is 11.x.
+    Postconditions: text/VAE stay single-copy while denoiser_ranks carries rank-local plans.
+    """
+    calls: list[ParallelConfig] = []
+    model_dir = tmp_path / "flux_tp"
+    (model_dir / "transformer").mkdir(parents=True)
+    (model_dir / "vae").mkdir(parents=True)
+
+    def load_flux_dit_weights(_path, **_kwargs):
+        return {"dit": np.array([3], dtype=np.float32)}
+
+    def build_flux_dit_engine(_weights, **_kwargs):
+        raise AssertionError("single-device FLUX DiT builder used for TP build")
+
+    def build_flux_dit_tp_engine(_weights, **kwargs):
+        parallel = kwargs["parallel_config"]
+        calls.append(parallel)
+        return f"dit-rank-{parallel.rank}".encode("ascii")
+
+    def build_flux_vae_decoder_engine(_path, **_kwargs):
+        return b"vae-plan"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.flux.t5_encoder_builder",
+        _module(
+            "tensorrt_model_connect.families.flux.t5_encoder_builder",
+            load_t5_weights=lambda *_args, **_kwargs: {},
+            build_t5_encoder_engine=lambda *_args, **_kwargs: b"t5-plan",
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.flux.clip_encoder_builder",
+        _module(
+            "tensorrt_model_connect.families.flux.clip_encoder_builder",
+            load_clip_weights=lambda *_args, **_kwargs: {},
+            build_clip_encoder_engine=lambda *_args, **_kwargs: b"clip-plan",
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.flux.flux_dit_builder",
+        _module(
+            "tensorrt_model_connect.families.flux.flux_dit_builder",
+            load_flux_dit_weights=load_flux_dit_weights,
+            build_flux_dit_engine=build_flux_dit_engine,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.flux.flux_dit_tp_builder",
+        _module(
+            "tensorrt_model_connect.families.flux.flux_dit_tp_builder",
+            build_flux_dit_engine=build_flux_dit_tp_engine,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.flux.flux_vae_builder",
+        _module(
+            "tensorrt_model_connect.families.flux.flux_vae_builder",
+            build_flux_vae_decoder_engine=build_flux_vae_decoder_engine,
+        ),
+    )
+    monkeypatch.setattr(
+        flux_mod,
+        "_serialize_flux_preprocessor",
+        lambda _dit_weights, _guidance_embeds: b"flux-preproc",
+    )
+
+    from tensorrt_model_connect import trt_compat
+    monkeypatch.setattr(trt_compat, "tensorrt_version", lambda: "11.0.0")
+
+    out = flux_mod.plugin.build_components(
+        str(model_dir),
+        _cfg(image_height=80, image_width=96),
+        {
+            "_transformer_dir": str(model_dir / "transformer"),
+            "_vae_dir": str(model_dir / "vae"),
+            "_transformer_config": {
+                "num_attention_heads": 8,
+                "attention_head_dim": 4,
+                "num_layers": 1,
+                "num_single_layers": 1,
+            },
+        },
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4),
+    )
+
+    assert out["text_encoders"] == []
+    assert out["vae_decoder"] == b"vae-plan"
+    assert out["denoiser_ranks"] == {
+        0: b"dit-rank-0",
+        1: b"dit-rank-1",
+        2: b"dit-rank-2",
+        3: b"dit-rank-3",
+    }
+    assert "denoiser" not in out
+    assert [cfg.rank for cfg in calls] == [0, 1, 2, 3]
+    assert all(cfg.tp_size == 4 for cfg in calls)
 
 
 def test_build_components_treats_text_encoder_as_t5_when_not_clip(

--- a/tests/builder/test_family_pixart.py
+++ b/tests/builder/test_family_pixart.py
@@ -271,6 +271,108 @@ def test_build_components_uses_transformer_and_t5_configs(
     assert calls["_serialize_preprocessor_weights"][0][2] == 32
 
 
+def test_build_components_tensor_parallel_uses_tp_dit_builder(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Intent: verify PixArt TP dispatch leaves the single-device DiT builder unused.
+
+    Preconditions: component builders are monkeypatched and TensorRT version is 11.0.
+    Postconditions: denoiser_ranks contains one TP DiT plan per rank from the TP builder.
+    """
+    from tensorrt_model_connect import trt_compat
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+
+    monkeypatch.setattr(trt_compat, "tensorrt_version", lambda: "11.0.0")
+    calls: dict[str, object] = {"dit_ranks": []}
+
+    model_dir = tmp_path / "pixart_tp"
+    (model_dir / "text_encoder").mkdir(parents=True)
+    (model_dir / "transformer").mkdir(parents=True)
+    (model_dir / "vae").mkdir(parents=True)
+
+    def build_standard_dit_engine(_weights, **_kwargs):
+        raise AssertionError("single-device PixArt DiT builder used for TP build")
+
+    def build_standard_dit_tp_engine(_weights, **kwargs):
+        parallel = kwargs["parallel_config"]
+        calls["dit_ranks"].append(parallel.rank)
+        return f"dit-rank-{parallel.rank}".encode()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.pixart.t5_encoder_builder",
+        _module(
+            "tensorrt_model_connect.families.pixart.t5_encoder_builder",
+            load_t5_weights=lambda *_args, **_kwargs: {},
+            build_t5_encoder_engine=lambda *_args, **_kwargs: b"t5-plan",
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.pixart.standard_dit_builder",
+        _module(
+            "tensorrt_model_connect.families.pixart.standard_dit_builder",
+            build_standard_dit_engine=build_standard_dit_engine,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.pixart.standard_dit_tp_builder",
+        _module(
+            "tensorrt_model_connect.families.pixart.standard_dit_tp_builder",
+            build_standard_dit_engine=build_standard_dit_tp_engine,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.pixart.vae_2d_builder",
+        _module(
+            "tensorrt_model_connect.families.pixart.vae_2d_builder",
+            build_vae_2d_decoder_engine=lambda *_args, **_kwargs: b"vae-plan",
+        ),
+    )
+    monkeypatch.setattr(
+        pixart_mod,
+        "_load_pixart_dit_weights",
+        lambda *_args, **_kwargs: {"dit": np.array([1], dtype=np.float32)},
+    )
+    monkeypatch.setattr(
+        pixart_mod,
+        "_serialize_preprocessor_weights",
+        lambda *_args, **_kwargs: b"pixart-pre",
+    )
+
+    out = pixart_mod.plugin.build_components(
+        str(model_dir),
+        _cfg(image_height=256, image_width=384),
+        {
+            "_text_encoder_dir": str(model_dir / "text_encoder"),
+            "_transformer_dir": str(model_dir / "transformer"),
+            "_vae_dir": str(model_dir / "vae"),
+            "_transformer_config": {
+                "num_attention_heads": 4,
+                "attention_head_dim": 8,
+                "num_layers": 1,
+                "patch_size": 4,
+                "cross_attention_dim": 64,
+            },
+        },
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4),
+    )
+
+    assert out["text_encoders"] == [("t5", b"t5-plan")]
+    assert out["denoiser_ranks"] == {
+        0: b"dit-rank-0",
+        1: b"dit-rank-1",
+        2: b"dit-rank-2",
+        3: b"dit-rank-3",
+    }
+    assert "denoiser" not in out
+    assert out["vae_decoder"] == b"vae-plan"
+    assert calls["dit_ranks"] == [0, 1, 2, 3]
+
+
 def test_get_diffusion_config_uses_transformer_overrides() -> None:
     """Intent: verify derived diffusion config values from transformer overrides.
 

--- a/tests/builder/test_family_wan_t2v.py
+++ b/tests/builder/test_family_wan_t2v.py
@@ -180,6 +180,116 @@ def test_build_components_calls_all_subbuilders(monkeypatch: pytest.MonkeyPatch)
     assert calls["build_standard_dit_engine"]["context_dim"] == wan_mod.plugin._DIT_DIM
 
 
+def test_build_components_tensor_parallel_builds_rank_denoisers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Intent: verify Wan TP packaging keeps T5/VAE single-copy and builds rank DiTs.
+
+    Preconditions: builder modules are monkeypatched and TensorRT version is 11.0.
+    Postconditions: denoiser_ranks contains one rank-local plan per requested TP rank.
+    """
+    from tensorrt_model_connect import trt_compat
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+
+    calls: dict[str, object] = {"dit_ranks": []}
+
+    monkeypatch.setattr(trt_compat, "tensorrt_version", lambda: "11.0.0")
+
+    def load_t5_weights(path, **kwargs):
+        calls["load_t5_weights"] = {"path": path, **kwargs}
+        return {"t5.weight": np.array([1], dtype=np.float32)}
+
+    def build_t5_encoder_engine(weights, **kwargs):
+        calls["build_t5_encoder_engine"] = {"weights": weights, **kwargs}
+        return b"t5-plan"
+
+    def load_dit_weights(path, **kwargs):
+        calls["load_dit_weights"] = {"path": path, **kwargs}
+        return {"dit.weight": np.array([2], dtype=np.float32)}
+
+    def build_standard_dit_engine(_weights, **_kwargs):
+        raise AssertionError("single-device Wan DiT builder used for TP build")
+
+    def build_standard_dit_tp_engine(weights, **kwargs):
+        parallel = kwargs["parallel_config"]
+        calls["dit_ranks"].append(parallel.rank)
+        return f"dit-rank-{parallel.rank}".encode()
+
+    def load_vae_weights(path, **kwargs):
+        calls["load_vae_weights"] = {"path": path, **kwargs}
+        return {"vae.weight": np.array([3], dtype=np.float32)}
+
+    def build_causal_vae_3d_engine(weights, **kwargs):
+        calls["build_causal_vae_3d_engine"] = {"weights": weights, **kwargs}
+        return b"vae-plan"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.wan_t2v.t5_encoder_builder",
+        _module(
+            "tensorrt_model_connect.families.wan_t2v.t5_encoder_builder",
+            load_t5_weights=load_t5_weights,
+            build_t5_encoder_engine=build_t5_encoder_engine,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.wan_t2v.standard_dit_builder",
+        _module(
+            "tensorrt_model_connect.families.wan_t2v.standard_dit_builder",
+            load_dit_weights=load_dit_weights,
+            build_standard_dit_engine=build_standard_dit_engine,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.wan_t2v.standard_dit_tp_builder",
+        _module(
+            "tensorrt_model_connect.families.wan_t2v.standard_dit_tp_builder",
+            build_standard_dit_engine=build_standard_dit_tp_engine,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.wan_t2v.causal_vae_3d_builder",
+        _module(
+            "tensorrt_model_connect.families.wan_t2v.causal_vae_3d_builder",
+            load_vae_weights=load_vae_weights,
+            build_causal_vae_3d_engine=build_causal_vae_3d_engine,
+            count_vae_caches=lambda **_kwargs: 0,
+        ),
+    )
+    monkeypatch.setattr(
+        wan_mod,
+        "_serialize_preprocessor_weights",
+        lambda dit_weights: b"wan-preproc",
+    )
+
+    weights = {
+        "_text_encoder_dir": "/model/text_encoder",
+        "_transformer_dir": "/model/transformer",
+        "_vae_dir": "/model/vae",
+    }
+
+    out = wan_mod.plugin.build_components(
+        "/model",
+        _cfg(video_height=64, video_width=80, video_num_frames=9),
+        weights,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4),
+    )
+
+    assert out["text_encoders"] == [("t5", b"t5-plan")]
+    assert out["denoiser_ranks"] == {
+        0: b"dit-rank-0",
+        1: b"dit-rank-1",
+        2: b"dit-rank-2",
+        3: b"dit-rank-3",
+    }
+    assert "denoiser" not in out
+    assert out["vae_decoder"] == b"vae-plan"
+    assert calls["dit_ranks"] == [0, 1, 2, 3]
+
+
 def test_get_diffusion_config_uses_count_vae_caches(monkeypatch: pytest.MonkeyPatch) -> None:
     """Intent: verify diffusion config wiring and imported cache-count helper call.
 

--- a/tests/builder/test_family_z_image.py
+++ b/tests/builder/test_family_z_image.py
@@ -175,6 +175,104 @@ def test_build_components_calls_all_subbuilders(
     assert calls["build_vae_2d_decoder_engine"][1]["w_lat"] == 96
 
 
+def test_build_components_tensor_parallel_builds_rank_denoisers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Intent: verify Z-Image TP packaging builds rank-local DiTs only.
+
+    Preconditions: builder modules are monkeypatched and TensorRT version is 11.0.
+    Postconditions: denoiser_ranks contains TP=2 rank plans while text/VAE remain single-copy.
+    """
+    from tensorrt_model_connect import trt_compat
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+
+    calls: dict[str, object] = {"dit_ranks": []}
+
+    monkeypatch.setattr(trt_compat, "tensorrt_version", lambda: "11.0.0")
+
+    def load_qwen3_encoder_weights(path, **kwargs):
+        calls["load_qwen3_encoder_weights"] = (path, kwargs)
+        return {"te": np.array([1], dtype=np.float32)}
+
+    def build_qwen3_encoder_engine(weights, **kwargs):
+        calls["build_qwen3_encoder_engine"] = (weights, kwargs)
+        return b"te-plan"
+
+    def load_z_image_dit_weights(path, **kwargs):
+        calls["load_z_image_dit_weights"] = (path, kwargs)
+        return {"dit": np.array([2], dtype=np.float32)}
+
+    def build_z_image_dit_engine(_weights, **_kwargs):
+        raise AssertionError("single-device Z-Image DiT builder used for TP build")
+
+    def build_z_image_dit_tp_engine(weights, **kwargs):
+        parallel = kwargs["parallel_config"]
+        calls["dit_ranks"].append(parallel.rank)
+        return f"dit-rank-{parallel.rank}".encode()
+
+    def build_vae_2d_decoder_engine(path, **kwargs):
+        calls["build_vae_2d_decoder_engine"] = (path, kwargs)
+        return b"vae-plan"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.z_image.qwen3_encoder_builder",
+        _module(
+            "tensorrt_model_connect.families.z_image.qwen3_encoder_builder",
+            load_qwen3_encoder_weights=load_qwen3_encoder_weights,
+            build_qwen3_encoder_engine=build_qwen3_encoder_engine,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.z_image.z_image_dit_builder",
+        _module(
+            "tensorrt_model_connect.families.z_image.z_image_dit_builder",
+            load_z_image_dit_weights=load_z_image_dit_weights,
+            build_z_image_dit_engine=build_z_image_dit_engine,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.z_image.z_image_dit_tp_builder",
+        _module(
+            "tensorrt_model_connect.families.z_image.z_image_dit_tp_builder",
+            build_z_image_dit_engine=build_z_image_dit_tp_engine,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.z_image.vae_2d_builder",
+        _module(
+            "tensorrt_model_connect.families.z_image.vae_2d_builder",
+            build_vae_2d_decoder_engine=build_vae_2d_decoder_engine,
+        ),
+    )
+    monkeypatch.setattr(zimg_mod, "_serialize_preprocessor_weights", lambda _w: b"zimg-pre")
+
+    weights = {
+        "_text_encoder_dir": "/model/text_encoder",
+        "_transformer_dir": "/model/transformer",
+        "_vae_dir": "/model/vae",
+    }
+
+    out = zimg_mod.plugin.build_components(
+        "/model",
+        _cfg(image_height=512, image_width=512),
+        weights,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=2),
+    )
+
+    assert out["text_encoders"] == [("qwen3", b"te-plan")]
+    assert out["denoiser_ranks"] == {
+        0: b"dit-rank-0",
+        1: b"dit-rank-1",
+    }
+    assert "denoiser" not in out
+    assert out["vae_decoder"] == b"vae-plan"
+    assert calls["dit_ranks"] == [0, 1]
+
+
 def test_get_diffusion_config_uses_correct_latent_math() -> None:
     """Intent: validate latent-dimension and patch-count wiring in diffusion config.
 

--- a/tests/builder/test_parallel_config.py
+++ b/tests/builder/test_parallel_config.py
@@ -7,8 +7,11 @@ import pytest
 from tensorrt_model_connect.config import ModelConfig
 from tensorrt_model_connect.parallel_config import (
     ParallelConfig,
+    rank_denoiser_section,
     require_tensorrt_11_for_tensor_parallel,
     shard_standard_decoder_weights,
+    validate_dit_tp,
+    validate_flux_dit_tp,
 )
 
 
@@ -50,3 +53,48 @@ def test_tensor_parallel_trt11_guard_ignores_single_device(monkeypatch) -> None:
     monkeypatch.setattr(trt_compat, "tensorrt_version", lambda: "10.13.3")
 
     require_tensorrt_11_for_tensor_parallel(ParallelConfig())
+
+
+def test_rank_denoiser_section_names_flux_tp_sections() -> None:
+    assert rank_denoiser_section(3) == "denoiser_plan_tp_rank3"
+
+
+def test_flux_dit_tp_validation_requires_concrete_rank() -> None:
+    with pytest.raises(ValueError, match="concrete rank"):
+        validate_flux_dit_tp(
+            dim=3072,
+            num_heads=24,
+            ffn_dim=12288,
+            parallel=ParallelConfig(mode="tensor_parallel", tp_size=4),
+        )
+
+
+def test_flux_dit_tp_validation_rejects_undivisible_heads() -> None:
+    with pytest.raises(ValueError, match="num_attention_heads divisible"):
+        validate_flux_dit_tp(
+            dim=3072,
+            num_heads=22,
+            ffn_dim=12288,
+            parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )
+
+
+def test_generic_dit_tp_validation_allows_pixart_tp4() -> None:
+    validate_dit_tp(
+        dim=1152,
+        num_heads=16,
+        ffn_dim=4608,
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        feature="PixArt tensor parallel",
+    )
+
+
+def test_generic_dit_tp_validation_rejects_zimage_tp4_heads() -> None:
+    with pytest.raises(ValueError, match="num_attention_heads divisible"):
+        validate_dit_tp(
+            dim=3840,
+            num_heads=30,
+            ffn_dim=10240,
+            parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            feature="Z-Image tensor parallel",
+        )

--- a/tests/e2e/models/flux-schnell-l0-tp4.json
+++ b/tests/e2e/models/flux-schnell-l0-tp4.json
@@ -1,0 +1,86 @@
+{
+  "name": "flux-schnell-l0-tp4",
+  "trace_id": "IT-E2E-FLXS-L0-TP4-01",
+  "hf_id": "black-forest-labs/FLUX.1-schnell",
+  "bundle": "flux-schnell-l0-tp4.trtfb",
+  "model_type": "flux",
+  "family": "flux",
+  "runtime_strategy": "diffusion_flux",
+  "gated": true,
+  "e2e_parallel_resource": "exclusive_gpu",
+  "ci_tier": "multi_device",
+  "reference_family": "diffusers_image_gen",
+  "user_contract": "diffusion_image",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    },
+    {
+      "kind": "python_module_available",
+      "args": {
+        "module": "diffusers",
+        "phase": "build"
+      },
+      "gating": true
+    },
+    {
+      "kind": "python_module_available",
+      "args": {
+        "module": "ftfy",
+        "phase": "build"
+      },
+      "gating": true
+    },
+    {
+      "kind": "hf_auth_token_present",
+      "args": {},
+      "gating": true
+    }
+  ],
+  "test_prompt": "A photo of a cat sitting on a windowsill at sunset",
+  "test_type": "diffusion",
+  "image_height": 384,
+  "image_width": 384,
+  "video_num_frames": 1,
+  "num_inference_steps": 20,
+  "stages": [
+    {
+      "name": "end_to_end",
+      "required": true
+    }
+  ]
+}

--- a/tests/e2e/models/pixart-sigma-1024-l0-tp4.json
+++ b/tests/e2e/models/pixart-sigma-1024-l0-tp4.json
@@ -1,0 +1,84 @@
+{
+  "name": "pixart-sigma-1024-l0-tp4",
+  "trace_id": "IT-E2E-PXART-L0-TP4-01",
+  "hf_id": "PixArt-alpha/PixArt-Sigma-XL-2-1024-MS",
+  "bundle": "pixart-sigma-1024-l0-tp4.trtfb",
+  "model_type": "pixart",
+  "family": "pixart",
+  "runtime_strategy": "diffusion_pixart",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "ci_tier": "multi_device",
+  "reference_family": "diffusers_image_gen",
+  "user_contract": "diffusion_image",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    },
+    {
+      "kind": "python_module_available",
+      "args": {
+        "module": "diffusers",
+        "phase": "build"
+      },
+      "gating": true
+    },
+    {
+      "kind": "python_module_available",
+      "args": {
+        "module": "ftfy",
+        "phase": "build"
+      },
+      "gating": true
+    }
+  ],
+  "test_prompt": "A photo of a cat sitting on a windowsill at sunset",
+  "test_type": "diffusion",
+  "image_height": 512,
+  "image_width": 512,
+  "video_num_frames": 1,
+  "num_inference_steps": 20,
+  "stages": [
+    {
+      "name": "end_to_end",
+      "required": true
+    }
+  ],
+  "threshold_overrides": {
+    "psnr": 2.0,
+    "ssim": -1.0
+  }
+}

--- a/tests/e2e/models/wan21-t2v-1.3b-l0-tp4.json
+++ b/tests/e2e/models/wan21-t2v-1.3b-l0-tp4.json
@@ -1,0 +1,80 @@
+{
+  "name": "wan21-t2v-1.3b-l0-tp4",
+  "trace_id": "IT-E2E-WAN21-L0-TP4-01",
+  "hf_id": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+  "bundle": "wan21-t2v-1.3b-l0-tp4.trtfb",
+  "model_type": "wan_t2v",
+  "family": "wan_t2v",
+  "runtime_strategy": "diffusion_wan",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "ci_tier": "multi_device",
+  "reference_family": "diffusers_video_gen",
+  "user_contract": "diffusion_video",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    },
+    {
+      "kind": "python_module_available",
+      "args": {
+        "module": "diffusers",
+        "phase": "build"
+      },
+      "gating": true
+    },
+    {
+      "kind": "python_module_available",
+      "args": {
+        "module": "ftfy",
+        "phase": "build"
+      },
+      "gating": true
+    }
+  ],
+  "test_prompt": "A cat sitting on a beach watching the sunset",
+  "test_type": "diffusion",
+  "video_num_frames": 5,
+  "video_height": 384,
+  "video_width": 672,
+  "num_inference_steps": 15,
+  "stages": [
+    {
+      "name": "end_to_end",
+      "required": true
+    }
+  ]
+}

--- a/tests/e2e/models/z-image-turbo-l0-tp2.json
+++ b/tests/e2e/models/z-image-turbo-l0-tp2.json
@@ -1,0 +1,81 @@
+{
+  "name": "z-image-turbo-l0-tp2",
+  "trace_id": "IT-E2E-ZIMG-L0-TP2-01",
+  "hf_id": "Tongyi-MAI/Z-Image-Turbo",
+  "bundle": "z-image-turbo-l0-tp2.trtfb",
+  "model_type": "z_image",
+  "family": "z_image",
+  "runtime_strategy": "diffusion_zimage",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "ci_tier": "multi_device",
+  "reference_family": "diffusers_image_gen",
+  "user_contract": "diffusion_image",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 2
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 2,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 2
+      },
+      "gating": true
+    },
+    {
+      "kind": "python_module_available",
+      "args": {
+        "module": "diffusers",
+        "phase": "build"
+      },
+      "gating": true
+    },
+    {
+      "kind": "python_module_available",
+      "args": {
+        "module": "ftfy",
+        "phase": "build"
+      },
+      "gating": true
+    }
+  ],
+  "test_prompt": "A photo of a cat sitting on a windowsill at sunset",
+  "test_type": "diffusion",
+  "image_height": 512,
+  "image_width": 512,
+  "video_num_frames": 1,
+  "num_inference_steps": 9,
+  "guidance_scale": 0.0,
+  "stages": [
+    {
+      "name": "end_to_end",
+      "required": true
+    }
+  ]
+}

--- a/tests/e2e_harness/runners/diffusion.py
+++ b/tests/e2e_harness/runners/diffusion.py
@@ -27,6 +27,14 @@ from pathlib import Path
 
 from .. import save_full_stderr, _case_artifact_dir
 from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
+from .text_generation import (
+    _distributed_runtime_config,
+    _ensure_distributed_runtime_env,
+    _extract_rank_zero_stdout,
+    _maybe_start_gpu_memory_sampler,
+    _strip_mpi_stream_tags,
+    _wrap_distributed_command,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -456,7 +464,6 @@ class DiffusionMediaRunner:
                 cmd = [
                     binary, "run", bundle_path,
                     "--prompt", prompt,
-                    "--output", output_png,
                     "--num-inference-steps", str(num_steps),
                 ]
                 negative_prompt = case.inputs.get("negative_prompt")
@@ -478,11 +485,11 @@ class DiffusionMediaRunner:
                 if qwen_image_initial_latents_raw:
                     cmd.extend([
                         "--initial-latents-raw", qwen_image_initial_latents_raw])
+                output_target = output_png
             else:
                 cmd = [
                     binary, "generate-video", bundle_path,
                     "--prompt", prompt,
-                    "--output", frame_dir,
                     "--num-steps", str(num_steps),
                 ]
                 if initial_latents_raw:
@@ -492,25 +499,59 @@ class DiffusionMediaRunner:
                     cmd.extend(["--guidance-scale", str(guidance_scale)])
                 if "seed" in case.inputs:
                     cmd.extend(["--seed", str(case.inputs["seed"])])
+                output_target = frame_dir
             runtime_cli_python = ctx.runtime_cli_hf_python()
             if runtime_cli_python:
                 cmd.extend(["--hf-python", runtime_cli_python])
 
             env = {**os.environ, "LD_LIBRARY_PATH": ld_path}
+            distributed_runtime = _distributed_runtime_config(case)
+            output_frame_dir = frame_dir
+            if distributed_runtime:
+                _ensure_distributed_runtime_env(case, ctx, env)
+                extra_env = distributed_runtime.get("env", {})
+                if isinstance(extra_env, dict):
+                    env.update({str(k): str(v) for k, v in extra_env.items()})
+                wrapper = (
+                    'rank="${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${RANK:-0}}}"; '
+                    'out="$1/rank_${rank}"; mkdir -p "$out"; shift; '
+                    'exec "$@" --output "$out"'
+                )
+                cmd = [
+                    "bash", "-lc", wrapper, "trtmc_rank_output", frame_dir,
+                ] + cmd
+                output_frame_dir = os.path.join(frame_dir, "rank_0")
+                cmd = _wrap_distributed_command(cmd, case, env)
+            else:
+                cmd.extend(["--output", output_target])
 
             t0 = time.monotonic()
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=3600, env=env)
+            memory_sampler = _maybe_start_gpu_memory_sampler(
+                distributed_runtime, ctx, case, env)
+            try:
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, timeout=3600, env=env)
+            finally:
+                memory_meta = (
+                    memory_sampler.stop() if memory_sampler is not None else None)
             elapsed = time.monotonic() - t0
+            stdout_text = (
+                _extract_rank_zero_stdout(result.stdout)
+                if distributed_runtime else result.stdout
+            )
+            stderr_text = (
+                _strip_mpi_stream_tags(result.stderr)
+                if distributed_runtime else result.stderr
+            )
 
             # Count frames
-            frame_files = sorted(Path(frame_dir).glob("frame_*.png"))
+            frame_files = sorted(Path(output_frame_dir).glob("frame_*.png"))
             num_frames = len(frame_files)
 
             # Compute frame statistics if frames exist
             frame_stats = {}
             if num_frames > 0:
-                frame_stats = self._compute_frame_stats(frame_dir)
+                frame_stats = self._compute_frame_stats(output_frame_dir)
 
             # Copy frame paths for artifact persistence
             frame_paths = [str(f) for f in frame_files]
@@ -529,7 +570,7 @@ class DiffusionMediaRunner:
                 ]
 
             stderr_truncated, stderr_log = save_full_stderr(
-                result.stderr or "", ctx.artifacts_dir or "",
+                stderr_text or "", ctx.artifacts_dir or "",
                 "end_to_end", case.name)
             e2e_data: dict = {
                 "returncode": result.returncode,
@@ -537,18 +578,27 @@ class DiffusionMediaRunner:
                 "frame_stats": frame_stats,
                 "frames_dir": artifact_frames_dir or frame_dir,
                 "frame_paths": frame_paths,
-                "stdout": result.stdout,
+                "stdout": stdout_text,
                 "stderr": stderr_truncated,
             }
             if stderr_log:
                 e2e_data["stderr_log"] = stderr_log
+            if distributed_runtime:
+                e2e_data["raw_stdout"] = result.stdout
+                e2e_data["distributed_runtime"] = distributed_runtime
+            if memory_meta is not None:
+                e2e_data["gpu_memory"] = memory_meta
 
+            metadata = {"command": cmd}
+            if distributed_runtime:
+                metadata["distributed_runtime"] = distributed_runtime
+                metadata["rank_zero_stdout"] = stdout_text
             return StageOutput(
                 stage_name=stage.name,
                 data=e2e_data,
-                text=result.stdout,
+                text=stdout_text,
                 timing_s=elapsed,
-                metadata={"command": cmd},
+                metadata=metadata,
             )
 
     def _run_frame_quality(


### PR DESCRIPTION
## Background

This PR adds TensorRT 11 tensor-parallel diffusion coverage on top of `main`. The current diff is focused on Flux, PixArt, Wan, and Z-Image DiT/denoiser tensor-parallel lanes; the earlier Qwen TP work is already in `main` and is no longer part of this PR's effective diff.

## Exit Criteria

- Flux, PixArt, Wan, and Z-Image can build rank-local TensorRT DiT/denoiser plans while keeping tokenizers, text encoders, and VAE components replicated where appropriate.
- The C++ runtime can load and execute the new tensor-parallel diffusion bundles under `mpirun`, with rank-zero media artifact collection.
- Representative multi-device E2E manifests cover Flux TP4, PixArt TP4, Wan TP4, and Z-Image TP2.
- Single-device builds and runtime behavior remain the default path unless tensor parallelism is explicitly requested.

## Implementation

- Added shared parallel configuration plumbing, graph helpers, and engine-builder support for rank-local diffusion plans.
- Added TensorRT 11 tensor-parallel builders for Flux, PixArt, Wan, and Z-Image denoiser/DiT components, plus family plugin integration for TP bundle sections.
- Updated Flux, PixArt, Wan, and Z-Image C++ runtime paths to select rank-local plans, coordinate distributed execution, and keep non-sharded components replicated.
- Extended the diffusion E2E runner for distributed launches, rank-zero image/frame collection, GPU memory sampling, and multi-device preflight checks.
- Added focused builder/unit coverage and new E2E model manifests for the representative TP lanes.

## Validation

Validated latest PR head `8db3677` on B200 x8 host `umb-b200-046` with driver `595.58.03`, TensorRT `11.0.0.103`, Transformers `5.2.0`, and GitHub Premerge CI passing.

- `pytest -p no:cacheprovider -q tests/builder/test_parallel_config.py tests/builder/test_family_flux.py tests/builder/test_family_pixart.py tests/builder/test_family_wan_t2v.py tests/builder/test_family_z_image.py tests/builder/test_engine_builder_extended.py::TestBuildBundleOrchestration::test_supported_diffusion_tensor_parallel_builds_rank_denoisers`: passed, `42 passed in 3.05s`.
- `pytest tests/test_e2e.py::test_e2e[flux-schnell-l0-tp4] -v --engine-dir /tmp/trtmc-pr80-e2e-engines --trtmc-binary /workspace/tensorrt-model-connect/build-b200-trt11/trtmc --hf-python /opt/venv/bin/python --multi-device-only --rebuild-engines`: passed. PSNR `7.535083 >= 5.0`, SSIM `0.275888 >= 0.1`, std ratio `0.878884 >= 0.35`.
- `pytest tests/test_e2e.py::test_e2e[pixart-sigma-1024-l0-tp4] -v --engine-dir /tmp/trtmc-pr80-engines-8db3677-pixart-retry --trtmc-binary /workspace/tensorrt-model-connect/build-b200-trt11-local/trtmc --hf-python /opt/venv/bin/python --multi-device-only --rebuild-engines`: passed after rerunning past a transient Hugging Face cache writer failure. PSNR `5.995391 >= 2.0`, SSIM `0.023735 >= -1.0`, std ratio `1.105050 >= 0.35`.
- `pytest tests/test_e2e.py::test_e2e[wan21-t2v-1.3b-l0-tp4] -v --engine-dir /tmp/trtmc-pr80-engines-8db3677-remaining --trtmc-binary /workspace/tensorrt-model-connect/build-b200-trt11-local/trtmc --hf-python /opt/venv/bin/python --multi-device-only --rebuild-engines`: passed. PSNR `18.442767 >= 5.0`, SSIM `0.853740 >= 0.1`, std ratio `0.867268 >= 0.35`.
- `pytest tests/test_e2e.py::test_e2e[z-image-turbo-l0-tp2] -v --engine-dir /tmp/trtmc-pr80-engines-8db3677-remaining --trtmc-binary /workspace/tensorrt-model-connect/build-b200-trt11-local/trtmc --hf-python /opt/venv/bin/python --multi-device-only --rebuild-engines`: passed. PSNR `9.869917 >= 5.0`, SSIM `0.463335 >= 0.1`, std ratio `1.195495 >= 0.35`.
- `GH_CONFIG_DIR=/home/scratch.daichu_sw_1/.config/gh gh pr checks 80`: Premerge CI passed.

## Notes For Future Readers

- Diffusion E2E accuracy is a media-contract gate, not pixel-identical parity. The harness checks generated media presence, pixel mean/std health, TRT/reference std ratio, and configured PSNR/SSIM thresholds.
- PixArt inherits its existing relaxed image comparator thresholds: PSNR `2.0` and SSIM `-1.0`. The SSIM threshold is intentionally non-restrictive for this model, so PixArt pass/fail is driven by image health, std ratio, and PSNR.
- Review order: shared parallel config and engine-builder plumbing first, then family TP builders/plugins, then C++ runtime selection and E2E harness changes.