### PR TITLE
refactor(report): extract VLM assessment renderer

### DIFF
--- a/scripts/generate_e2e_report.py
+++ b/scripts/generate_e2e_report.py
@@ -25,6 +25,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 import xml.etree.ElementTree as ET
 
+from reporting.vlm_assessment import render_diffusion_vlm_assessment as _render_diffusion_vlm_assessment
+
 # Maximum file size to embed inline (10 MB).
 _MAX_EMBED_BYTES = 10 * 1024 * 1024
 
@@ -1220,77 +1222,6 @@ def render_diffusion_model(result: Dict[str, Any]) -> str:
     parts.append(_render_repro_commands(result.get("repro_commands", {})))
     parts.append(_render_timing_sections(result))
     return "\n".join(parts)
-
-
-def _render_diffusion_vlm_assessment(result: Dict[str, Any]) -> str:
-    assessment = result.get("vlm_assessment")
-    if not isinstance(assessment, dict):
-        return (
-            "<h4>VLM Semantic Assessment</h4>"
-            "<p><em>No VLM assessment artifact was found for this model.</em></p>"
-        )
-
-    judgment = assessment.get("vlm_judgment", {})
-    if not isinstance(judgment, dict):
-        judgment = {}
-    gate = judgment.get("vlm_gate", {})
-    if not isinstance(gate, dict):
-        gate = {}
-
-    gate_failed = bool(gate.get("failed", False))
-    if gate_failed:
-        gate_label = "FAIL"
-        gate_cls = "vlm-fail"
-    else:
-        gate_label = "PASS"
-        gate_cls = "vlm-pass"
-    reasons = gate.get("reasons") or []
-    if isinstance(reasons, list):
-        reason_text = (
-            "; ".join(str(r) for r in reasons)
-            or str(judgment.get("reason", ""))
-        )
-    else:
-        reason_text = str(reasons)
-
-    rows = [
-        ("Judge model", assessment.get("model_id", "")),
-        ("Semantic similarity", judgment.get("semantic_similarity_0_to_5", "")),
-        ("TRT prompt alignment", judgment.get("trt_prompt_alignment_0_to_5", "")),
-        ("HF prompt alignment", judgment.get("hf_prompt_alignment_0_to_5", "")),
-        ("TRT visual quality", judgment.get("trt_visual_quality_0_to_5", "")),
-        ("HF visual quality", judgment.get("hf_visual_quality_0_to_5", "")),
-        ("TRT relative to HF", judgment.get("trt_relative_to_hf", "")),
-        ("Regression", judgment.get("is_regression", "")),
-        ("Gate", gate_label),
-        ("Reason", reason_text or judgment.get("reason", "")),
-    ]
-    table_rows = "\n".join(
-        f"<tr><td>{_esc(name)}</td><td>{_format_value(value)}</td></tr>"
-        for name, value in rows
-        if value not in ("", None)
-    )
-
-    descriptions = []
-    trt_description = judgment.get("trt_description")
-    hf_description = judgment.get("hf_description")
-    if trt_description:
-        descriptions.append(
-            f"<p><strong>TRT description:</strong> {_esc(trt_description)}</p>")
-    if hf_description:
-        descriptions.append(
-            f"<p><strong>HF description:</strong> {_esc(hf_description)}</p>")
-
-    return (
-        '<section class="vlm-assessment">'
-        '<h4>VLM Semantic Assessment</h4>'
-        f'<p class="{gate_cls}"><strong>Gate:</strong> {gate_label}</p>'
-        '<table class="vlm-table"><tbody>'
-        f"{table_rows}"
-        "</tbody></table>"
-        + "".join(descriptions)
-        + "</section>"
-    )
 
 
 def _stage_output_returncode(stage: Dict[str, Any]) -> Any:

--- a/scripts/reporting/__init__.py
+++ b/scripts/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Report rendering components for script-generated HTML reports."""

--- a/scripts/reporting/vlm_assessment.py
+++ b/scripts/reporting/vlm_assessment.py
@@ -1,0 +1,130 @@
+"""Diffusion VLM semantic assessment report component."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import html
+from typing import Any
+
+
+@dataclass(frozen=True)
+class VlmGate:
+    """Normalized VLM gate state."""
+
+    failed: bool
+    label: str
+    css_class: str
+    reason_text: str
+
+
+@dataclass(frozen=True)
+class VlmAssessment:
+    """Normalized fields rendered in the VLM assessment block."""
+
+    model_id: Any
+    judgment: Mapping[str, Any]
+    gate: VlmGate
+
+
+def _esc(text: Any) -> str:
+    return html.escape(str(text)) if text is not None else ""
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, float):
+        if abs(value) < 0.001 and value != 0:
+            return f"{value:.2e}"
+        return f"{value:.4f}"
+    return _esc(value)
+
+
+def _reason_text(reasons: Any, judgment: Mapping[str, Any]) -> str:
+    if isinstance(reasons, list):
+        return "; ".join(str(reason) for reason in reasons) or str(
+            judgment.get("reason", "")
+        )
+    if reasons:
+        return str(reasons)
+    return str(judgment.get("reason", ""))
+
+
+def normalize_assessment(raw: Any) -> VlmAssessment | None:
+    """Normalize a raw result-level VLM assessment payload for rendering."""
+    if not isinstance(raw, Mapping):
+        return None
+
+    raw_judgment = raw.get("vlm_judgment", {})
+    judgment: Mapping[str, Any] = (
+        raw_judgment if isinstance(raw_judgment, Mapping) else {}
+    )
+
+    raw_gate = judgment.get("vlm_gate", {})
+    gate_data: Mapping[str, Any] = raw_gate if isinstance(raw_gate, Mapping) else {}
+    failed = bool(gate_data.get("failed", False))
+    label = "FAIL" if failed else "PASS"
+    css_class = "vlm-fail" if failed else "vlm-pass"
+
+    return VlmAssessment(
+        model_id=raw.get("model_id", ""),
+        judgment=judgment,
+        gate=VlmGate(
+            failed=failed,
+            label=label,
+            css_class=css_class,
+            reason_text=_reason_text(gate_data.get("reasons"), judgment),
+        ),
+    )
+
+
+def render_diffusion_vlm_assessment(result: Mapping[str, Any]) -> str:
+    """Render the diffusion VLM semantic assessment section for a model result."""
+    assessment = normalize_assessment(result.get("vlm_assessment"))
+    if assessment is None:
+        return (
+            "<h4>VLM Semantic Assessment</h4>"
+            "<p><em>No VLM assessment artifact was found for this model.</em></p>"
+        )
+
+    judgment = assessment.judgment
+    rows = [
+        ("Judge model", assessment.model_id),
+        ("Semantic similarity", judgment.get("semantic_similarity_0_to_5", "")),
+        ("TRT prompt alignment", judgment.get("trt_prompt_alignment_0_to_5", "")),
+        ("HF prompt alignment", judgment.get("hf_prompt_alignment_0_to_5", "")),
+        ("TRT visual quality", judgment.get("trt_visual_quality_0_to_5", "")),
+        ("HF visual quality", judgment.get("hf_visual_quality_0_to_5", "")),
+        ("TRT relative to HF", judgment.get("trt_relative_to_hf", "")),
+        ("Regression", judgment.get("is_regression", "")),
+        ("Gate", assessment.gate.label),
+        ("Reason", assessment.gate.reason_text or judgment.get("reason", "")),
+    ]
+    table_rows = "\n".join(
+        f"<tr><td>{_esc(name)}</td><td>{_format_value(value)}</td></tr>"
+        for name, value in rows
+        if value not in ("", None)
+    )
+
+    descriptions = []
+    trt_description = judgment.get("trt_description")
+    hf_description = judgment.get("hf_description")
+    if trt_description:
+        descriptions.append(
+            f"<p><strong>TRT description:</strong> {_esc(trt_description)}</p>"
+        )
+    if hf_description:
+        descriptions.append(
+            f"<p><strong>HF description:</strong> {_esc(hf_description)}</p>"
+        )
+
+    return (
+        '<section class="vlm-assessment">'
+        "<h4>VLM Semantic Assessment</h4>"
+        f'<p class="{assessment.gate.css_class}"><strong>Gate:</strong> '
+        f"{assessment.gate.label}</p>"
+        '<table class="vlm-table"><tbody>'
+        f"{table_rows}"
+        "</tbody></table>"
+        + "".join(descriptions)
+        + "</section>"
+    )

--- a/tests/tools/test_generate_report.py
+++ b/tests/tools/test_generate_report.py
@@ -32,6 +32,14 @@ def _import_report():
     return importlib.import_module("generate_e2e_report")
 
 
+def _import_vlm_assessment():
+    """Import the VLM assessment report component from scripts/."""
+    scripts_dir = str(Path(__file__).resolve().parents[2] / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    return importlib.import_module("reporting.vlm_assessment")
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -844,6 +852,23 @@ class TestRenderVlModel:
 
 class TestRenderDiffusionModel:
     """Tests for render_diffusion_model()."""
+
+    def test_vlm_assessment_missing_artifact_message(self):
+        mod = _import_vlm_assessment()
+        html = mod.render_diffusion_vlm_assessment({})
+        assert "No VLM assessment artifact was found for this model" in html
+
+    def test_vlm_assessment_malformed_judgment_defaults_to_pass(self):
+        mod = _import_vlm_assessment()
+        html = mod.render_diffusion_vlm_assessment({
+            "vlm_assessment": {
+                "model_id": "Judge <model>",
+                "vlm_judgment": "not a structured judgment",
+            }
+        })
+        assert "Judge &lt;model&gt;" in html
+        assert "<strong>Gate:</strong> PASS" in html
+        assert "Semantic similarity" not in html
 
     def test_frame_gallery(self, tmp_path):
         mod = _import_report()


### PR DESCRIPTION
## Background

Closes #55. VLM semantic assessment HTML was embedded in `generate_e2e_report.py`, coupling gate normalization, row selection, escaping, and rendering to the main report generator.

## Exit Criteria

- Isolates VLM assessment normalization and rendering in `scripts/reporting/vlm_assessment.py`.
- Keeps `generate_e2e_report.py` as the orchestration layer.
- Covers pass and fail gates through existing report tests, with added coverage for missing artifacts and malformed judgments.
- Preserves the legacy artifact waive-field behavior tested by the synthetic report suite.

## Implementation

- Added a focused `reporting.vlm_assessment` component with normalized dataclasses and HTML rendering.
- Replaced the inline diffusion VLM renderer in `generate_e2e_report.py` with the new component import.
- Extended `tests/tools/test_generate_report.py` with direct component coverage for missing and malformed VLM artifacts.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /tmp/trtmc-issue55-venv/bin/python -m pytest tests/tools/test_generate_report.py -q` -> `73 passed in 0.16s`
- `/tmp/trtmc-issue55-venv/bin/python -m ruff check --config ruff.toml scripts/generate_e2e_report.py scripts/reporting/__init__.py scripts/reporting/vlm_assessment.py tests/tools/test_generate_report.py` -> `All checks passed!`

## Notes For Future Readers

The new component intentionally keeps the existing VLM table fields, gate labels, CSS classes, and missing-artifact message stable so existing report output remains compatible.
