### PR TITLE
refactor(ci): extract diffusion frame pair counting

### DIFF
--- a/.github/scripts/run-trtmc-ci.sh
+++ b/.github/scripts/run-trtmc-ci.sh
@@ -447,28 +447,7 @@ run_diffusion_vlm_assessment() {
   fi
 
   local pair_count
-  pair_count=$(python3 -c '
-import json
-import sys
-from pathlib import Path
-
-root = Path(sys.argv[1])
-count = 0
-for result_path in root.glob("*/result.json"):
-    try:
-        result = json.loads(result_path.read_text(encoding="utf-8"))
-    except Exception:
-        continue
-    case = result.get("case_config", {})
-    if case.get("task_strategy") != "diffusion_media_generation":
-        continue
-    model_dir = result_path.parent
-    has_trt = (model_dir / "frames").is_dir()
-    has_ref = (model_dir / "hf_frames").is_dir() or (model_dir / "ref_frames").is_dir()
-    if has_trt and has_ref:
-        count += 1
-print(count)
-' e2e_artifacts/artifacts)
+  pair_count=$(python3 tools/count_diffusion_frame_pairs.py e2e_artifacts/artifacts)
   if [ "${pair_count:-0}" -eq 0 ]; then
     echo "Skipping: no TRT/HF diffusion frame pairs for VLM assessment"
     return 0

--- a/tests/tools/test_count_diffusion_frame_pairs.py
+++ b/tests/tools/test_count_diffusion_frame_pairs.py
@@ -1,0 +1,95 @@
+"""Tests for tools/count_diffusion_frame_pairs.py."""
+
+from __future__ import annotations
+
+import json
+
+from tools.count_diffusion_frame_pairs import (
+    count_diffusion_frame_pairs,
+    discover_diffusion_frame_pairs,
+    main,
+)
+
+
+def _write_result(
+    model_dir,
+    task_strategy: str = "diffusion_media_generation",
+    case_name: str = "model-diff",
+) -> None:
+    model_dir.mkdir(parents=True, exist_ok=True)
+    (model_dir / "result.json").write_text(
+        json.dumps({
+            "case_name": case_name,
+            "case_config": {
+                "name": case_name,
+                "task_strategy": task_strategy,
+                "inputs": {"prompt": "a cat"},
+            },
+        }),
+        encoding="utf-8",
+    )
+
+
+def _write_frame_pair(model_dir, reference_dir: str) -> None:
+    (model_dir / "frames").mkdir(parents=True, exist_ok=True)
+    (model_dir / reference_dir).mkdir(parents=True, exist_ok=True)
+    (model_dir / "frames" / "frame_0000.png").write_bytes(b"trt")
+    (model_dir / reference_dir / "frame_0000.png").write_bytes(b"ref")
+
+
+def test_counts_frames_plus_hf_frames(tmp_path) -> None:
+    model_dir = tmp_path / "artifacts" / "wan"
+    _write_result(model_dir, case_name="wan")
+    _write_frame_pair(model_dir, "hf_frames")
+
+    pairs = discover_diffusion_frame_pairs(tmp_path / "artifacts")
+
+    assert count_diffusion_frame_pairs(tmp_path / "artifacts") == 1
+    assert pairs[0]["case_name"] == "wan"
+    assert pairs[0]["trt_image"].endswith("frames/frame_0000.png")
+    assert pairs[0]["hf_image"].endswith("hf_frames/frame_0000.png")
+
+
+def test_counts_frames_plus_ref_frames(tmp_path) -> None:
+    model_dir = tmp_path / "artifacts" / "pixart"
+    _write_result(model_dir, case_name="pixart")
+    _write_frame_pair(model_dir, "ref_frames")
+
+    pairs = discover_diffusion_frame_pairs(tmp_path / "artifacts")
+
+    assert count_diffusion_frame_pairs(tmp_path / "artifacts") == 1
+    assert pairs[0]["hf_image"].endswith("ref_frames/frame_0000.png")
+
+
+def test_malformed_result_json_is_ignored(tmp_path) -> None:
+    model_dir = tmp_path / "artifacts" / "broken"
+    model_dir.mkdir(parents=True)
+    _write_frame_pair(model_dir, "hf_frames")
+    (model_dir / "result.json").write_text("{not-json", encoding="utf-8")
+
+    assert discover_diffusion_frame_pairs(tmp_path / "artifacts") == []
+    assert count_diffusion_frame_pairs(tmp_path / "artifacts") == 0
+
+
+def test_non_diffusion_result_is_ignored(tmp_path) -> None:
+    model_dir = tmp_path / "artifacts" / "qwen"
+    _write_result(model_dir, task_strategy="text_generation_causal", case_name="qwen")
+    _write_frame_pair(model_dir, "hf_frames")
+
+    assert discover_diffusion_frame_pairs(tmp_path / "artifacts") == []
+    assert count_diffusion_frame_pairs(tmp_path / "artifacts") == 0
+
+
+def test_zero_pair_count_and_json_output(tmp_path, capsys) -> None:
+    artifacts_dir = tmp_path / "artifacts"
+    model_dir = artifacts_dir / "missing-reference"
+    _write_result(model_dir)
+    (model_dir / "frames").mkdir(parents=True)
+    (model_dir / "frames" / "frame_0000.png").write_bytes(b"trt")
+
+    assert main([str(artifacts_dir)]) == 0
+    assert capsys.readouterr().out.strip() == "0"
+
+    assert main([str(artifacts_dir), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"count": 0, "pairs": []}

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -50,6 +50,16 @@ def test_diffusion_vlm_gate_failures_are_not_waived() -> None:
     assert "--waives" not in text
 
 
+def test_diffusion_vlm_pair_count_uses_helper() -> None:
+    text = (REPO_ROOT / ".github" / "scripts" / "run-trtmc-ci.sh").read_text()
+    vlm_block = text.split("run_diffusion_vlm_assessment() {", maxsplit=1)[1].split(
+        "\ngenerate_coverage_map() {",
+        maxsplit=1,
+    )[0]
+    assert "tools/count_diffusion_frame_pairs.py e2e_artifacts/artifacts" in vlm_block
+    assert "python3 -c" not in vlm_block
+
+
 def test_shared_setup_action_creates_hf_cache_dirs() -> None:
     text = (REPO_ROOT / ".github" / "actions" / "setup-trtmc" / "action.yml").read_text()
     assert '"${HF_HOME:-}"' in text

--- a/tools/count_diffusion_frame_pairs.py
+++ b/tools/count_diffusion_frame_pairs.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Count diffusion TRT/reference frame pairs in E2E artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _frames_in(path: Path) -> list[Path]:
+    if not path.is_dir():
+        return []
+    frames = sorted(path.glob("frame_*.png"))
+    if frames:
+        return frames
+    return sorted(path.glob("*.png"))
+
+
+def _select_frame(frames: list[Path]) -> Path | None:
+    if not frames:
+        return None
+    return frames[(len(frames) - 1) // 2]
+
+
+def _load_result(path: Path) -> dict[str, Any] | None:
+    try:
+        result = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return result if isinstance(result, dict) else None
+
+
+def discover_diffusion_frame_pairs(artifacts_dir: Path) -> list[dict[str, Any]]:
+    """Return paired TRT/reference diffusion frames discovered under artifacts."""
+    pairs: list[dict[str, Any]] = []
+    for result_path in sorted(artifacts_dir.glob("*/result.json")):
+        result = _load_result(result_path)
+        if result is None:
+            continue
+
+        case = result.get("case_config", {})
+        if not isinstance(case, dict):
+            continue
+        if case.get("task_strategy") != "diffusion_media_generation":
+            continue
+
+        model_dir = result_path.parent
+        trt_frame = _select_frame(_frames_in(model_dir / "frames"))
+        hf_frame = _select_frame(_frames_in(model_dir / "hf_frames"))
+        if hf_frame is None:
+            hf_frame = _select_frame(_frames_in(model_dir / "ref_frames"))
+        if trt_frame is None or hf_frame is None:
+            continue
+
+        inputs = case.get("inputs", {})
+        if not isinstance(inputs, dict):
+            inputs = {}
+        pairs.append({
+            "case_name": result.get("case_name") or case.get("name") or model_dir.name,
+            "prompt": inputs.get("prompt", ""),
+            "trt_image": str(trt_frame),
+            "hf_image": str(hf_frame),
+        })
+    return pairs
+
+
+def count_diffusion_frame_pairs(artifacts_dir: Path) -> int:
+    """Return the number of discoverable diffusion frame pairs."""
+    return len(discover_diffusion_frame_pairs(artifacts_dir))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Count diffusion TRT/reference frame pairs in E2E artifacts."
+    )
+    parser.add_argument("artifacts_dir", type=Path)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="print JSON details instead of only the pair count",
+    )
+    args = parser.parse_args(argv)
+
+    pairs = discover_diffusion_frame_pairs(args.artifacts_dir)
+    if args.json_output:
+        print(json.dumps({"count": len(pairs), "pairs": pairs}, indent=2))
+    else:
+        print(len(pairs))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/evaluate_diffusion_vlm_similarity.py
+++ b/tools/evaluate_diffusion_vlm_similarity.py
@@ -14,6 +14,11 @@ import re
 from pathlib import Path
 from typing import Any
 
+try:
+    from tools.count_diffusion_frame_pairs import discover_diffusion_frame_pairs
+except ModuleNotFoundError:
+    from count_diffusion_frame_pairs import discover_diffusion_frame_pairs
+
 
 DEFAULT_MODEL_ID = "Qwen/Qwen2.5-VL-3B-Instruct"
 _JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
@@ -55,45 +60,8 @@ def _load_image(path: Path, max_side: int) -> Any:
     return image
 
 
-def _frames_in(path: Path) -> list[Path]:
-    if not path.is_dir():
-        return []
-    frames = sorted(path.glob("frame_*.png"))
-    if frames:
-        return frames
-    return sorted(path.glob("*.png"))
-
-
-def _select_frame(frames: list[Path]) -> Path | None:
-    if not frames:
-        return None
-    return frames[(len(frames) - 1) // 2]
-
-
 def _discover_pairs(artifacts_dir: Path) -> list[dict[str, Any]]:
-    pairs: list[dict[str, Any]] = []
-    for result_path in sorted(artifacts_dir.glob("*/result.json")):
-        result = json.loads(result_path.read_text(encoding="utf-8"))
-        case = result.get("case_config", {})
-        if case.get("task_strategy") != "diffusion_media_generation":
-            continue
-
-        model_dir = result_path.parent
-        trt_frame = _select_frame(_frames_in(model_dir / "frames"))
-        hf_frame = _select_frame(_frames_in(model_dir / "hf_frames"))
-        if hf_frame is None:
-            hf_frame = _select_frame(_frames_in(model_dir / "ref_frames"))
-        if trt_frame is None or hf_frame is None:
-            continue
-
-        inputs = case.get("inputs", {})
-        pairs.append({
-            "case_name": result.get("case_name") or case.get("name") or model_dir.name,
-            "prompt": inputs.get("prompt", ""),
-            "trt_image": str(trt_frame),
-            "hf_image": str(hf_frame),
-        })
-    return pairs
+    return discover_diffusion_frame_pairs(artifacts_dir)
 
 
 def _parse_json(text: str) -> dict[str, Any]:


### PR DESCRIPTION
## Background

Closes #56. The diffusion VLM stage in `.github/scripts/run-trtmc-ci.sh` counted TRT/reference frame pairs with inline Python, which mixed shell orchestration with artifact schema parsing and made pair discovery hard to test directly.

## Exit Criteria

- Remove embedded Python pair discovery from `run-trtmc-ci.sh`.
- Add a helper that reports diffusion frame-pair counts and JSON details.
- Cover `frames` with `hf_frames`, `frames` with `ref_frames`, malformed `result.json`, non-diffusion results, and zero-pair behavior.
- Keep CI skipping VLM assessment only when the helper reports zero pairs.

## Implementation

- Added `tools/count_diffusion_frame_pairs.py` with reusable discovery, count output, and `--json` details.
- Updated `run-trtmc-ci.sh` to call the helper for `pair_count` instead of embedding Python.
- Reused the helper from `tools/evaluate_diffusion_vlm_similarity.py` so the CI gate and VLM assessment tool discover pairs consistently.
- Added focused helper tests and a CI wiring assertion for the diffusion VLM block.

## Validation

- `bash -n .github/scripts/run-trtmc-ci.sh`: passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/trtmc-issue55-venv/bin/python -m pytest tests/tools/test_count_diffusion_frame_pairs.py tests/tools/test_diffusion_vlm_similarity_tool.py tests/tools/test_github_actions_ci.py -q`: `25 passed in 0.07s`
- `/tmp/trtmc-issue55-venv/bin/python -m ruff check --config ruff.toml tools/count_diffusion_frame_pairs.py tools/evaluate_diffusion_vlm_similarity.py tests/tools/test_count_diffusion_frame_pairs.py tests/tools/test_github_actions_ci.py`: `All checks passed!`

## Notes For Future Readers

Review the helper first, then the shell change. The helper intentionally keeps the VLM tool's selected-frame behavior so a positive CI pair count means the VLM evaluator can discover the same pair.
