### PR TITLE
feat(e2e): pass typed plugin runtime context

### DIFF
--- a/tests/e2e_harness/contracts.py
+++ b/tests/e2e_harness/contracts.py
@@ -560,6 +560,32 @@ class RunContext:
         return self.runtime_python_path()
 
 
+@dataclass(frozen=True)
+class PluginRuntimeContext:
+    """Resolved runtime paths made available to contract plugins.
+
+    This context is intentionally narrower than :class:`RunContext`: it contains
+    only paths that contract plugins may need for validation helpers. Empty
+    strings mean the corresponding path was not configured for this run.
+
+    Attributes:
+        engine_dir: Directory containing resolved TensorRT engine bundles.
+        binary_path: Path to the TensorRT-Model-Connect CLI binary.
+        hf_python: Optional Python interpreter value passed as ``--hf-python``
+            to compatible runtime commands.
+        runtime_python: Python interpreter for TRT-side helper subprocesses.
+        reference_python: Python interpreter for reference/validation tools.
+        artifacts_dir: Directory where this case writes E2E artifacts.
+    """
+
+    engine_dir: str = ""
+    binary_path: str = ""
+    hf_python: str = ""
+    runtime_python: str = ""
+    reference_python: str = ""
+    artifacts_dir: str = ""
+
+
 # ---------------------------------------------------------------------------
 # Protocols
 # ---------------------------------------------------------------------------

--- a/tests/e2e_harness/orchestrator.py
+++ b/tests/e2e_harness/orchestrator.py
@@ -21,6 +21,7 @@ Lifecycle per case:
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import os
@@ -40,6 +41,7 @@ from .contracts import (
     E2EResult,
     E2EStatus,
     FailureType,
+    PluginRuntimeContext,
     PreflightRequirement,
     RunContext,
     StageOutput,
@@ -937,6 +939,54 @@ def _collect_trt_stage_timing(output: StageOutput, stage_name: str) -> dict[str,
     return timings
 
 
+def _build_plugin_runtime_context(ctx: RunContext) -> PluginRuntimeContext:
+    """Create the typed runtime context exposed to contract plugins."""
+    return PluginRuntimeContext(
+        engine_dir=ctx.engine_dir,
+        binary_path=ctx.binary_path,
+        hf_python=ctx.runtime_cli_hf_python(),
+        runtime_python=ctx.runtime_python_path(),
+        reference_python=ctx.reference_python_path(),
+        artifacts_dir=ctx.artifacts_dir,
+    )
+
+
+def _plugin_accepts_runtime_context(contract_plugin: Any) -> bool:
+    """Return True when a contract plugin opts into PluginRuntimeContext."""
+    try:
+        parameters = inspect.signature(contract_plugin.verify).parameters
+    except (TypeError, ValueError):
+        return False
+
+    return (
+        "runtime_context" in parameters
+        or any(
+            param.kind == inspect.Parameter.VAR_KEYWORD
+            for param in parameters.values()
+        )
+    )
+
+
+def _verify_contract_plugin(
+    contract_plugin: Any,
+    trt_output: StageOutput,
+    ref_output: StageOutput,
+    case: E2ECase,
+    threshold: ThresholdProfile,
+    runtime_context: PluginRuntimeContext,
+) -> CompareResult:
+    """Call a contract plugin while preserving legacy verify signatures."""
+    if _plugin_accepts_runtime_context(contract_plugin):
+        return contract_plugin.verify(
+            trt_output,
+            ref_output,
+            case,
+            threshold,
+            runtime_context=runtime_context,
+        )
+    return contract_plugin.verify(trt_output, ref_output, case, threshold)
+
+
 def _extract_trt_engine_time_s(output: StageOutput) -> float | None:
     metadata = output.metadata or {}
     candidates: list[Any] = [
@@ -1146,6 +1196,7 @@ class E2EOrchestrator:
             rebuild=ctx.rebuild,
             verbose=ctx.verbose,
         )
+        plugin_runtime_context = _build_plugin_runtime_context(ctx_with_bundle)
 
         # Resolve runner, reference, comparator, and contract plugin
         runner = get_runner(case.task_strategy)
@@ -1162,17 +1213,6 @@ class E2EOrchestrator:
                     case.metadata["contract_config"] = ref_config
             except Exception as e:
                 logger.warning("Contract plugin configure_reference failed: %s", e)
-
-            # Expose runtime paths so plugins can invoke auxiliary binaries
-            # and reference Python tools for contract checks.
-            case.metadata["_ctx"] = {
-                "engine_dir": ctx.engine_dir,
-                "binary_path": ctx.binary_path,
-                "hf_python": ctx.runtime_cli_hf_python(),
-                "runtime_python": ctx.runtime_python_path(),
-                "reference_python": ctx.reference_python_path(),
-                "artifacts_dir": artifacts_dir,
-            }
 
         # 3. Execute stages
         stage_results: dict[str, CompareResult] = {}
@@ -1289,8 +1329,14 @@ class E2EOrchestrator:
                 if contract_plugin is not None:
                     t0 = time.monotonic()
                     try:
-                        compare_result = contract_plugin.verify(
-                            trt_output, ref_output, case, threshold)
+                        compare_result = _verify_contract_plugin(
+                            contract_plugin,
+                            trt_output,
+                            ref_output,
+                            case,
+                            threshold,
+                            plugin_runtime_context,
+                        )
                         timing[f"contract_{stage_name}_s"] = time.monotonic() - t0
                     except Exception as e:
                         timing[f"contract_{stage_name}_s"] = time.monotonic() - t0

--- a/tests/e2e_harness/plugins/base.py
+++ b/tests/e2e_harness/plugins/base.py
@@ -21,6 +21,7 @@ from ..contracts import (
     CompareResult,
     E2ECase,
     MetricResult,
+    PluginRuntimeContext,
     StageOutput,
     StageStatus,
     ThresholdProfile,
@@ -70,12 +71,19 @@ class ContractTestPlugin(Protocol):
         ref_output: StageOutput,
         case: E2ECase,
         threshold: ThresholdProfile,
+        *,
+        runtime_context: PluginRuntimeContext | None = None,
     ) -> CompareResult:
         """Verify the user-facing contract.
 
         Called in the acceptance CI lane.  Should check user-visible behavior
         (exact text match, correct ranking, valid transcript, etc.) rather
         than numeric tensor parity.
+
+        Migrated plugins may accept ``runtime_context`` for resolved runtime
+        paths such as engine directories, binaries, and Python interpreters.
+        The orchestrator omits this keyword for legacy plugins that have not
+        declared it yet.
 
         Returns a CompareResult with contract-level metrics.
         """

--- a/tests/e2e_harness/plugins/tts.py
+++ b/tests/e2e_harness/plugins/tts.py
@@ -16,7 +16,12 @@ import sys
 import textwrap
 
 from ..contracts import (
-    CompareResult, E2ECase, MetricResult, StageOutput, ThresholdProfile,
+    CompareResult,
+    E2ECase,
+    MetricResult,
+    PluginRuntimeContext,
+    StageOutput,
+    ThresholdProfile,
 )
 from .base import (
     normalize_text, levenshtein_ned, make_pass, make_fail,
@@ -150,6 +155,8 @@ class TTSPlugin:
         ref_output: StageOutput,
         case: E2ECase,
         threshold: ThresholdProfile,
+        *,
+        runtime_context: PluginRuntimeContext | None = None,
     ) -> CompareResult:
         trt_wav = trt_output.data.get("wav_path")
         trt_rms = trt_output.data.get("rms")
@@ -191,12 +198,10 @@ class TTSPlugin:
         )
 
         if has_wav and input_prompt:
-            # Runtime paths injected by the orchestrator
-            ctx = case.metadata.get("_ctx", {})
             asr_python = (
-                ctx.get("reference_python")
-                or ctx.get("hf_python")
-                or ctx.get("runtime_python")
+                (runtime_context.reference_python if runtime_context else "")
+                or (runtime_context.hf_python if runtime_context else "")
+                or (runtime_context.runtime_python if runtime_context else "")
                 or sys.executable
             )
 

--- a/tests/tools/test_plugin_runtime_context.py
+++ b/tests/tools/test_plugin_runtime_context.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.e2e_harness import artifact_sink
+from tests.e2e_harness import orchestrator as orchestrator_module
+from tests.e2e_harness.contracts import (
+    CompareResult,
+    E2ECase,
+    PluginRuntimeContext,
+    RunContext,
+    StageOutput,
+    StageSpec,
+    StageStatus,
+    ThresholdProfile,
+)
+
+
+class _Runner:
+    @property
+    def strategy_name(self) -> str:
+        return "fake_task"
+
+    def run_stage(
+        self, case: E2ECase, stage: StageSpec, ctx: RunContext
+    ) -> StageOutput:
+        return StageOutput(stage_name=stage.name, text="trt")
+
+
+class _Reference:
+    @property
+    def backend_name(self) -> str:
+        return "fake_reference"
+
+    def run_stage(
+        self, case: E2ECase, stage: StageSpec, ctx: RunContext
+    ) -> StageOutput:
+        return StageOutput(stage_name=stage.name, text="ref")
+
+
+class _RuntimeContextPlugin:
+    reference_families = ["fake_family"]
+    user_contract = "fake_contract"
+
+    def __init__(self) -> None:
+        self.runtime_context: PluginRuntimeContext | None = None
+
+    def configure_reference(self, case: E2ECase) -> dict[str, str]:
+        return {"configured": "yes"}
+
+    def verify(
+        self,
+        trt_output: StageOutput,
+        ref_output: StageOutput,
+        case: E2ECase,
+        threshold: ThresholdProfile,
+        *,
+        runtime_context: PluginRuntimeContext | None = None,
+    ) -> CompareResult:
+        self.runtime_context = runtime_context
+        return CompareResult(
+            stage_name=trt_output.stage_name,
+            status=StageStatus.PASSED.value,
+            message="ok",
+        )
+
+
+def _case() -> E2ECase:
+    return E2ECase(
+        name="plugin-runtime-context",
+        hf_id="fake/model",
+        family="fake",
+        runtime_strategy="speech_to_speech",
+        task_strategy="fake_task",
+        reference_backend="fake_reference",
+        reference_family="fake_family",
+        bundle="plugin-runtime-context.trtfb",
+        stages=[StageSpec(name="generate")],
+    )
+
+
+def test_orchestrator_passes_typed_runtime_context_to_contract_plugin(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    case = _case()
+    plugin = _RuntimeContextPlugin()
+    artifacts_dir = tmp_path / "artifacts"
+    engine_dir = tmp_path / "engines"
+    engine_dir.mkdir()
+    ctx = RunContext(
+        case=case,
+        artifacts_dir=str(artifacts_dir),
+        binary_path="/opt/trtmc/bin/trtmc",
+        hf_python="/venvs/base/bin/python",
+        runtime_python="/venvs/runtime/bin/python",
+        reference_python="/venvs/reference/bin/python",
+        runtime_profile="runtime-profile",
+        reference_profile="reference-profile",
+        engine_dir=str(engine_dir),
+    )
+
+    monkeypatch.setattr(
+        artifact_sink, "_collect_env_fingerprint", lambda ctx=None: {})
+    monkeypatch.setattr(
+        orchestrator_module,
+        "_resolve_bundle",
+        lambda case, ctx: (str(engine_dir / case.bundle), None, "", {}),
+    )
+    monkeypatch.setattr(orchestrator_module, "get_runner", lambda name: _Runner())
+    monkeypatch.setattr(orchestrator_module, "get_reference", lambda name: _Reference())
+    monkeypatch.setattr(orchestrator_module, "get_comparator", lambda name: None)
+    monkeypatch.setattr(
+        orchestrator_module, "get_contract_plugin", lambda family: plugin)
+
+    result = orchestrator_module.E2EOrchestrator().run(case, ctx)
+
+    assert result.status == "pass"
+    assert case.metadata["contract_config"] == {"configured": "yes"}
+    assert "_ctx" not in case.metadata
+    assert plugin.runtime_context == PluginRuntimeContext(
+        engine_dir=str(engine_dir),
+        binary_path="/opt/trtmc/bin/trtmc",
+        hf_python="/venvs/runtime/bin/python",
+        runtime_python="/venvs/runtime/bin/python",
+        reference_python="/venvs/reference/bin/python",
+        artifacts_dir=str(artifacts_dir),
+    )
+
+
+def test_legacy_contract_plugin_verify_signature_still_supported() -> None:
+    class LegacyPlugin:
+        def verify(self, trt_output, ref_output, case, threshold):
+            return CompareResult(
+                stage_name=trt_output.stage_name,
+                status=StageStatus.PASSED.value,
+                message="legacy ok",
+            )
+
+    result = orchestrator_module._verify_contract_plugin(
+        LegacyPlugin(),
+        StageOutput(stage_name="generate"),
+        StageOutput(stage_name="generate"),
+        _case(),
+        ThresholdProfile(task_strategy="fake_task"),
+        PluginRuntimeContext(reference_python="/venvs/reference/bin/python"),
+    )
+
+    assert result.status == StageStatus.PASSED.value


### PR DESCRIPTION
## Background
Contract plugins used a private `case.metadata["_ctx"]` dictionary for runtime paths, making the available fields implicit and failures late when a key was missing or renamed.

Closes #61.

## Exit Criteria
- No plugin reads `case.metadata["_ctx"]` directly.
- Runtime context fields are typed and documented.
- Tests cover a plugin receiving expected context values.
- Legacy plugin verify signatures continue to work.

## Implementation
- Adds `PluginRuntimeContext` to the harness contracts with documented runtime path fields.
- Builds the typed context in the orchestrator and passes it only to plugins that declare `runtime_context` or accept `**kwargs`.
- Migrates the TTS plugin to use the typed context while preserving legacy plugin compatibility.

## Validation
- `PYTHONPATH="$PWD/tensorrt_model_connect" /tmp/trtmc-pytest-venv/bin/python -m pytest tests/tools/test_plugin_runtime_context.py -q`: passed, 2 tests.

## Notes For Future Readers
- Existing plugins can keep their current `verify(trt_output, ref_output, case, threshold)` signature. New plugins that need runtime paths should opt into `runtime_context` explicitly.
