### PR TITLE
Fix nightly impact classification

### DIFF
--- a/.github/scripts/run-trtmc-ci.sh
+++ b/.github/scripts/run-trtmc-ci.sh
@@ -277,7 +277,7 @@ for test in tests:
       -n auto "${cov_args[@]}"
   else
     echo "Running all builder + tools tests"
-    run_with_timeout "${PYTHON_BUILDER_TIMEOUT:-40m}" python -m pytest tests/builder/ tests/tools/ tests/engine_defs/torch_trt/ -v \
+    run_with_timeout "${PYTHON_BUILDER_TIMEOUT:-40m}" python -m pytest tests/builder/ tests/tools/ tests/engine_defs/torch_trt/ tests/e2e_harness/test_*.py -v \
       --ignore=tests/builder/test_cli.py \
       --ignore=tests/engine_defs/torch_trt/test_pixart_vs_hf.py \
       -n auto "${cov_args[@]}"

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -60,6 +60,11 @@ def test_diffusion_vlm_pair_count_uses_helper() -> None:
     assert "python3 -c" not in vlm_block
 
 
+def test_full_python_builder_runs_e2e_harness_unit_tests() -> None:
+    text = (REPO_ROOT / ".github" / "scripts" / "run-trtmc-ci.sh").read_text()
+    assert "tests/e2e_harness/test_*.py" in text
+
+
 def test_shared_setup_action_creates_hf_cache_dirs() -> None:
     text = (REPO_ROOT / ".github" / "actions" / "setup-trtmc" / "action.yml").read_text()
     assert '"${HF_HOME:-}"' in text

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -308,7 +308,9 @@ class TestDeclarativeClassificationRules:
                 "tests/e2e_harness/thresholds/defaults/custom.json",
                 "harness_threshold_unknown",
             ),
+            ("tests/e2e_harness/test_orchestrator_phases.py", "harness_unit_test"),
             ("scripts/_gen_fp8_bf16.py", "fp8_gen_script"),
+            ("tools/make_elf_replay_artifact.py", "elf_replay_tool"),
         ],
     )
     def test_representative_rule_paths(self, imap, path, rule_name):
@@ -798,6 +800,18 @@ class TestUnitTiers:
         assert match.models == []
         assert "tools" in match.unit_tiers
 
+    def test_elf_replay_tools_trigger_tools_tier(self, imap):
+        """ELF helper tool edits run tools-tier tests without E2E."""
+        for path in (
+            "tools/make_elf_replay_artifact.py",
+            "tools/prepare_elf_model_dir.py",
+            "tools/validate_elf_replay_artifact.py",
+        ):
+            match = test_impact.classify_file(path, imap)
+            assert match.rule == "elf_replay_tool"
+            assert match.models == []
+            assert match.unit_tiers == ["tools"]
+
     def test_unit_tier_torchtrt_engine_defs(self, imap):
         """Torch-TRT engine-def tests run as builder tests without E2E."""
         match = test_impact.classify_file(
@@ -874,6 +888,14 @@ class TestHarness:
             "tests/e2e_harness/orchestrator.py", imap)
         assert match.rule == "harness_shared"
         assert len(match.models) == len(imap.all_model_names)
+
+    def test_harness_unit_test_file(self, imap):
+        """e2e_harness/test_*.py -> direct tools-tier test only."""
+        match = test_impact.classify_file(
+            "tests/e2e_harness/test_orchestrator_phases.py", imap)
+        assert match.rule == "harness_unit_test"
+        assert match.models == []
+        assert match.unit_tiers == ["tools"]
 
     def test_torch_reference_includes_neural_operator_models(self, mock_repo):
         """torch_reference.py includes neural_operator-backed time-series manifests."""
@@ -1473,6 +1495,17 @@ class TestCoverageMapIntegration:
         )
 
         assert result.tools_tests == ["tests/tools/test_z_image_model_card_contract.py"]
+        assert "tools" not in result.fallback_tiers
+
+    def test_changed_e2e_harness_unit_test_selected_directly(self, imap):
+        """Changed e2e_harness test files run directly without broad E2E impact."""
+        result = test_impact.analyze_impact(
+            ["tests/e2e_harness/test_orchestrator_phases.py"], imap,
+            coverage_map={},
+        )
+
+        assert result.e2e_models == []
+        assert result.tools_tests == ["tests/e2e_harness/test_orchestrator_phases.py"]
         assert "tools" not in result.fallback_tiers
 
     def test_json_output_includes_test_lists(self, imap):

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -596,7 +596,7 @@ def _infer_unit_tiers(path: str) -> List[str]:
         tiers.append("builder")
     if path.startswith("tests/cpp/"):
         tiers.append("cpp")
-    if path.startswith("tests/tools/"):
+    if path.startswith("tests/tools/") or path.startswith("tests/e2e_harness/test_"):
         tiers.append("tools")
     return sorted(set(tiers))
 
@@ -1312,6 +1312,13 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
         ),
         ClassificationRule(
             priority=380,
+            name="harness_unit_test",
+            matcher=_regex_rule(r"tests/e2e_harness/test_[\w_]+\.py$"),
+            resolver=_match_result("harness_unit_test", _no_models, ["tools"], False),
+            covered_by=("TestHarness.test_harness_unit_test_file",),
+        ),
+        ClassificationRule(
+            priority=385,
             name="harness_shared",
             matcher=_path_startswith("tests/e2e_harness/"),
             resolver=_match_result("harness_shared", _all_models),
@@ -1404,6 +1411,17 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             covered_by=("TestDeclarativeClassificationRules.test_representative_rule_paths",),
         ),
         ClassificationRule(
+            priority=485,
+            name="elf_replay_tool",
+            matcher=_path_in({
+                "tools/make_elf_replay_artifact.py",
+                "tools/prepare_elf_model_dir.py",
+                "tools/validate_elf_replay_artifact.py",
+            }),
+            resolver=_match_result("elf_replay_tool", _no_models, ["tools"], False),
+            covered_by=("TestUnitTiers.test_elf_replay_tools_trigger_tools_tier",),
+        ),
+        ClassificationRule(
             priority=490,
             name="no_impact",
             matcher=_no_impact_matcher,
@@ -1455,7 +1473,7 @@ def _direct_python_test_targets(changed_files: List[str]) -> tuple[List[str], Li
             continue
         if path.startswith("tests/builder/") or path.startswith("tests/engine_defs/torch_trt/"):
             builder_tests.add(path)
-        elif path.startswith("tests/tools/"):
+        elif path.startswith("tests/tools/") or path.startswith("tests/e2e_harness/test_"):
             tools_tests.add(path)
     return sorted(builder_tests), sorted(tools_tests)
 


### PR DESCRIPTION
## Summary
- classify e2e_harness/test_*.py files as direct tools-tier tests instead of broad harness_shared E2E impact
- classify ELF replay helper tools as tools-tier changes instead of reviewed no-impact fallback
- include e2e_harness/test_*.py in the full python-builder pytest set

## Validation
- PYTHONPATH=tensorrt_model_connect:. python3 tools/test_impact.py --validate --json
- PYTHONPATH=tensorrt_model_connect:. python3 -m pytest tests/tools/test_test_impact.py -q
- PYTHONPATH=tensorrt_model_connect:. python3 -m pytest tests/tools/test_github_actions_ci.py -q
- PYTHONPATH=tensorrt_model_connect:. python3 -m pytest tests/e2e_harness/test_orchestrator_phases.py -q