### PR TITLE
ci: run premerge only on pull requests

### DIFF
--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -1,12 +1,6 @@
 name: TensorRT-Model-Connect Premerge CI
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "website/**"
-      - ".github/workflows/pages.yml"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Background
The premerge workflow currently runs once for pull requests and again after the PR is merged because it is also subscribed to `push` events on `main`. The post-merge run is lighter than the PR run, but it still consumes runner time after the PR has already passed validation.

## Exit Criteria
- Pull requests targeting `main` still run the premerge workflow automatically.
- Merges to `main` no longer trigger this premerge workflow automatically.
- Manual `workflow_dispatch` remains available for ad hoc runs.

## Implementation
- Removed the `push` trigger from `.github/workflows/trtmc-ci.yml`.
- Left the existing `pull_request` trigger and workflow body unchanged.

## Validation
- `git diff --check -- .github/workflows/trtmc-ci.yml`: passed with no whitespace errors.

## Notes For Future Readers
- The docs Pages workflow is unchanged and still owns website publication behavior.
