### PR TITLE
docs(agents): add CI criteria guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,12 @@
 - Do not publish CI reports to GitHub Pages unless the user explicitly changes
   that decision.
 
+## Dos And Don'ts
+
+- Do keep validation criteria meaningful and aligned with the behavior under
+  test.
+- Never change the test passing criteria for the purpose of passing CI.
+
 ## Repo Skills
 
 - Codex skills packaged for this repo are registered through

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
 
 - Do keep validation criteria meaningful and aligned with the behavior under
   test.
-- Never change the test passing criteria for the purpose of passing CI.
+- Never change the test passing criteria for the purpose of passing CI. If you believe the test is faulty, escalate to a human
 
 ## Repo Skills
 


### PR DESCRIPTION
## Background
Agents need an explicit repository-level guardrail against weakening validation just to make a pipeline green. This documents the policy directly in `AGENTS.md`.

## Exit Criteria
- `AGENTS.md` has a dedicated Dos And Don'ts section.
- The section says agents must never change test passing criteria for the purpose of passing CI.

## Implementation
- Added a `Dos And Don'ts` section near the existing repository workflow guidance.
- Added a positive validation guideline and the requested CI passing-criteria prohibition.

## Validation
- `git diff --check`: passed.

## Notes For Future Readers
- This is a docs-only policy change; no runtime tests were run because no code paths changed.
