### PR TITLE
feat(diffusion): add batch inference 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ add_library(trtmc_core
   src/runtime/domains/audio/audio_types.cpp
   src/runtime/domains/audio/mel_spectrogram.cpp
   src/runtime/domains/audio/audio_bundle_validation.cpp
+  src/runtime/domains/diffusion/batch_utils.cpp
   src/runtime/domains/diffusion/diffusion_preprocessor.cpp
   src/runtime/domains/diffusion/qwen_image_types.cpp
   src/tokenizer/vocab_tokenizer.cpp
@@ -657,6 +658,7 @@ trtmc_add_test(test_vision_execution_plan)
 
 # Diffusion
 trtmc_add_test(test_diffusion_generation_plan)
+trtmc_add_test(test_diffusion_batch_utils)
 trtmc_add_test(test_diffusion_denoising_step_seam)
 trtmc_add_test(test_flow_match_scheduler)
 trtmc_add_test(test_diffusion_math)

--- a/examples/trtmc_cli.cpp
+++ b/examples/trtmc_cli.cpp
@@ -1631,7 +1631,7 @@ int cmd_inspect(const CliArgs& args) {
                                     info.max_batch_size.text_encoder != 1 ||
                                     info.max_batch_size.vae != 1;
         const bool is_diffusion_bundle =
-            info.runtime_strategy == "diffusion" ||
+            info.runtime_strategy.rfind("diffusion", 0) == 0 ||
             info.family.find("diffusion") != std::string::npos;
         if (is_diffusion_bundle || has_batch_caps) {
             std::cout << "Max batch size:     dit=" << info.max_batch_size.dit

--- a/examples/trtmc_cli.cpp
+++ b/examples/trtmc_cli.cpp
@@ -18,6 +18,7 @@
 //   trtmc version
 
 #include "stb_image_write.h"
+#include "runtime/domains/diffusion/batch_utils.h"
 #include "trtmc/bundle.h"
 #include "trtmc/config/cli_support.h"
 #include "trtmc/config/schema_registry.h"
@@ -49,6 +50,7 @@ struct CliArgs {
     std::string command;
     std::string bundle_path;
     std::string prompt;
+    std::string prompts_file;
     std::string hf_python;
     std::uint64_t kv_cache_size_bytes{0};
     std::string image_path;
@@ -77,6 +79,9 @@ struct CliArgs {
     float min_p{0.0F};
     int top_k{1};
     int seed{-1};
+    bool seed_was_set{false};
+    std::vector<std::uint64_t> seed_list;
+    int num_images{1};
     int num_steps{-1};
     float guidance_scale{-1.0F};
     float sde_gamma{-1.0F};
@@ -171,6 +176,63 @@ trtmc::LoadOptions make_load_options(const CliArgs& args) {
     return options;
 }
 
+std::optional<std::vector<std::uint64_t>> parse_seed_csv(const std::string& text) {
+    std::vector<std::uint64_t> seeds;
+    std::size_t start = 0;
+    while (start <= text.size()) {
+        const auto comma = text.find(',', start);
+        const auto end = (comma == std::string::npos) ? text.size() : comma;
+        const std::string token = text.substr(start, end - start);
+        if (token.empty())
+            return std::nullopt;
+        try {
+            std::size_t consumed = 0;
+            const auto value = std::stoull(token, &consumed, 10);
+            if (consumed != token.size())
+                return std::nullopt;
+            seeds.push_back(value);
+        } catch (...) {
+            return std::nullopt;
+        }
+        if (comma == std::string::npos)
+            break;
+        start = comma + 1;
+    }
+    return seeds;
+}
+
+std::vector<std::string> read_prompts_file(const std::string& path, std::string& error) {
+    std::ifstream in(path);
+    if (!in) {
+        error = "failed to open " + path;
+        return {};
+    }
+    std::vector<std::string> prompts;
+    std::string line;
+    while (std::getline(in, line)) {
+        if (!line.empty() && line.back() == '\r')
+            line.pop_back();
+        if (!line.empty())
+            prompts.push_back(line);
+    }
+    if (prompts.empty())
+        error = path + " contains no prompts";
+    return prompts;
+}
+
+std::string format_output_path(const std::string& path, int index, int total) {
+    if (total == 1)
+        return path;
+    const auto sep = path.find_last_of("/\\");
+    const auto dot = path.find_last_of('.');
+    const bool has_extension = dot != std::string::npos &&
+                               (sep == std::string::npos || dot > sep);
+    const std::string suffix = "_" + std::to_string(index);
+    if (!has_extension)
+        return path + suffix;
+    return path.substr(0, dot) + suffix + path.substr(dot);
+}
+
 void print_usage() {
     std::cerr
         << "Usage:\n"
@@ -184,7 +246,8 @@ void print_usage() {
            "[--output samples.jsonl]\n"
            "                        Diffusion text-to-image extras (Qwen-Image, FLUX, "
            "Z-Image): [--negative-prompt \"text\"] "
-           "[--num-inference-steps N] [--height N] [--width N]\n"
+           "[--num-inference-steps N] [--height N] [--width N] "
+           "[--num-images N] [--prompts-file PATH] [--seed N|N,N,...]\n"
            "  trtmc encode          <bundle.trtfb> --prompt \"text\" [--hf-python PATH]\n"
            "  trtmc segment         <bundle.trtfb> --image PATH --output PATH [--hf-python PATH]\n"
            "  trtmc segment-sam     <bundle.trtfb> --image PATH --output DIR "
@@ -301,7 +364,33 @@ CliArgs parse_args(int argc, char** argv) {
             continue;
         }
         if (arg == "--seed" && need_value(arg)) {
-            args.seed = std::atoi(argv[++i]);
+            const std::string value = argv[++i];
+            args.seed_was_set = true;
+            if (value.find(',') != std::string::npos) {
+                auto seeds = parse_seed_csv(value);
+                if (!seeds) {
+                    args.parse_error = true;
+                    args.error_message = "--seed expects an integer or comma-separated integers";
+                    return args;
+                }
+                args.seed_list = std::move(*seeds);
+                args.seed = args.seed_list.empty() ? -1 : static_cast<int>(args.seed_list[0]);
+            } else {
+                args.seed = std::atoi(value.c_str());
+            }
+            continue;
+        }
+        if (arg == "--num-images" && need_value(arg)) {
+            args.num_images = std::atoi(argv[++i]);
+            if (args.num_images < 1) {
+                args.parse_error = true;
+                args.error_message = "--num-images must be >= 1";
+                return args;
+            }
+            continue;
+        }
+        if (arg == "--prompts-file" && need_value(arg)) {
+            args.prompts_file = argv[++i];
             continue;
         }
         if (arg == "--tail-frames" && need_value(arg)) {
@@ -512,6 +601,12 @@ CliArgs parse_args(int argc, char** argv) {
             args.error_message = "Unexpected positional argument: " + arg;
             return args;
         }
+    }
+
+    if (!args.prompt.empty() && !args.prompts_file.empty()) {
+        args.parse_error = true;
+        args.error_message = "--prompt and --prompts-file are mutually exclusive";
+        return args;
     }
 
     return args;
@@ -747,35 +842,88 @@ int cmd_run(const CliArgs& args) {
         auto last = pipeline->generate(prompt, trtmc::GenerateConfig{cfg});
         std::cout << last.text << '\n';
     } else if (is_diffusion) {
-        auto result = pipeline->generate_image(prompt, cfg);
-        if (result.pixels.empty()) {
-            std::cerr << "Error: image generation failed\n";
+        std::vector<std::string> base_prompts;
+        if (!args.prompts_file.empty()) {
+            std::string error;
+            base_prompts = read_prompts_file(args.prompts_file, error);
+            if (!error.empty()) {
+                std::cerr << "Error: " << error << '\n';
+                return EXIT_FAILURE;
+            }
+        } else {
+            base_prompts.push_back(prompt);
+        }
+
+        std::vector<std::string> prompts;
+        prompts.reserve(base_prompts.size() * static_cast<std::size_t>(args.num_images));
+        for (const auto& base_prompt : base_prompts) {
+            for (int i = 0; i < args.num_images; ++i)
+                prompts.push_back(base_prompt);
+        }
+        const int total = static_cast<int>(prompts.size());
+        if (!cfg.initial_latents.empty() && total > 1) {
+            std::cerr << "Error: --initial-latents-raw can only be used with one image\n";
+            return EXIT_FAILURE;
+        }
+
+        std::vector<int32_t> per_sample_seeds;
+        try {
+            if (!args.seed_list.empty()) {
+                per_sample_seeds = trtmc::diffusion::derive_per_sample_seeds(
+                    args.seed_list, total);
+            } else if (args.seed_was_set && total == 1) {
+                per_sample_seeds = {args.seed};
+            } else if (total > 1 || args.seed_was_set) {
+                const std::uint64_t global_seed =
+                    args.seed >= 0 ? static_cast<std::uint64_t>(args.seed) : 42ULL;
+                per_sample_seeds =
+                    trtmc::diffusion::derive_per_sample_seeds(global_seed, total);
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "Error: " << e.what() << '\n';
+            return EXIT_FAILURE;
+        }
+
+        auto results = pipeline->generate_images(prompts, per_sample_seeds, cfg);
+        if (results.size() != prompts.size()) {
+            std::cerr << "Error: image generation returned " << results.size()
+                      << " results for " << prompts.size() << " prompts\n";
             return EXIT_FAILURE;
         }
 
         // Save as PNG. If -o ends with .png, use as file path; otherwise
-        // treat as directory and write output.png inside it.
-        std::string out_path;
+        // treat as directory and write output.png inside it. Multiple images
+        // get _<i> before the extension.
+        std::string base_out_path;
         if (!args.output_dir.empty() && args.output_dir.size() > 4 &&
             args.output_dir.substr(args.output_dir.size() - 4) == ".png") {
-            out_path = args.output_dir;
-            auto parent = std::filesystem::path(out_path).parent_path();
+            base_out_path = args.output_dir;
+            auto parent = std::filesystem::path(base_out_path).parent_path();
             if (!parent.empty())
                 std::filesystem::create_directories(parent);
         } else {
             const std::string out_dir =
                 args.output_dir.empty() ? "/tmp/trtmc_run_output" : args.output_dir;
             std::filesystem::create_directories(out_dir);
-            out_path = out_dir + "/output.png";
+            base_out_path = out_dir + "/output.png";
         }
 
-        try {
-            trtmc::io::save_png(result, out_path);
-        } catch (const std::exception& e) {
-            std::cerr << "Error: " << e.what() << '\n';
-            return EXIT_FAILURE;
+        for (int i = 0; i < total; ++i) {
+            const auto& result = results[static_cast<std::size_t>(i)];
+            if (result.pixels.empty()) {
+                std::cerr << "Error: image generation failed for sample " << i << '\n';
+                return EXIT_FAILURE;
+            }
+            const std::string out_path = format_output_path(base_out_path, i, total);
+            try {
+                trtmc::io::save_png(result, out_path);
+            } catch (const std::exception& e) {
+                std::cerr << "Error: " << e.what() << '\n';
+                return EXIT_FAILURE;
+            }
+            std::cout << "Saved " << out_path << " (" << result.width << "x"
+                      << result.height << ")\n";
         }
-        std::cout << "Saved " << out_path << " (" << result.width << "x" << result.height << ")\n";
     } else if (!args.image_path.empty()) {
         // Load image using trtmc_io
         auto image = trtmc::io::read_image(args.image_path);
@@ -1479,6 +1627,17 @@ int cmd_inspect(const CliArgs& args) {
         std::cout << "Max cache length:   " << info.max_cache_length << '\n';
         if (!info.runtime_strategy.empty())
             std::cout << "Runtime strategy:   " << info.runtime_strategy << '\n';
+        const bool has_batch_caps = info.max_batch_size.dit != 1 ||
+                                    info.max_batch_size.text_encoder != 1 ||
+                                    info.max_batch_size.vae != 1;
+        const bool is_diffusion_bundle =
+            info.runtime_strategy == "diffusion" ||
+            info.family.find("diffusion") != std::string::npos;
+        if (is_diffusion_bundle || has_batch_caps) {
+            std::cout << "Max batch size:     dit=" << info.max_batch_size.dit
+                      << " text_encoder=" << info.max_batch_size.text_encoder
+                      << " vae=" << info.max_batch_size.vae << '\n';
+        }
         return EXIT_SUCCESS;
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << '\n';

--- a/include/trtmc/bundle.h
+++ b/include/trtmc/bundle.h
@@ -5,6 +5,12 @@
 
 namespace trtmc {
 
+struct MaxBatchSize {
+    int32_t dit{1};
+    int32_t text_encoder{1};
+    int32_t vae{1};
+};
+
 struct BundleInfo {
     std::string model_id;
     std::string model_type;
@@ -23,6 +29,7 @@ struct BundleInfo {
     std::string runtime_strategy; // e.g. "decoder_kv_cache", "diffusion", etc.
     bool tokenizer_add_special_tokens{false};
     bool tokenizer_add_special_tokens_present{false};
+    MaxBatchSize max_batch_size{};
 };
 
 // Read metadata without loading the engine.

--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -182,6 +182,24 @@ class IPipeline {
                                  " does not support generate_image()");
     }
 
+    virtual std::vector<ImageResult> generate_images(
+        const std::vector<std::string>& prompts,
+        const std::vector<int32_t>& per_sample_seeds,
+        const GenerateConfig& cfg = {}) {
+        if (!per_sample_seeds.empty() && per_sample_seeds.size() != prompts.size()) {
+            throw std::invalid_argument("per_sample_seeds size must match prompts size");
+        }
+        std::vector<ImageResult> results;
+        results.reserve(prompts.size());
+        for (std::size_t i = 0; i < prompts.size(); ++i) {
+            GenerateConfig sample_cfg = cfg;
+            if (!per_sample_seeds.empty())
+                sample_cfg.seed = per_sample_seeds[i];
+            results.push_back(generate_image(prompts[i], sample_cfg));
+        }
+        return results;
+    }
+
     virtual ImageResult generate_image(const TextEmbedding& emb, const GenerateConfig& cfg = {}) {
         (void)emb;
         (void)cfg;

--- a/src/bundle/bundle_format.cpp
+++ b/src/bundle/bundle_format.cpp
@@ -146,6 +146,13 @@ BundleInfo BundleInfoFromJson(const std::string& json, BundleSectionTable& secti
         info.tokenizer_add_special_tokens = (tokenizer_add_special != 0);
         info.tokenizer_add_special_tokens_present = true;
     }
+    const std::string max_batch_json = extract_json_object_text(json, "max_batch_size");
+    if (!max_batch_json.empty()) {
+        info.max_batch_size.dit = extract_json_int(max_batch_json, "dit", 1);
+        info.max_batch_size.text_encoder =
+            extract_json_int(max_batch_json, "text_encoder", 1);
+        info.max_batch_size.vae = extract_json_int(max_batch_json, "vae", 1);
+    }
 
     sections_out.clear();
     parse_sections_table(json, sections_out);

--- a/src/runtime/domains/diffusion/batch_utils.cpp
+++ b/src/runtime/domains/diffusion/batch_utils.cpp
@@ -1,0 +1,69 @@
+#include "runtime/domains/diffusion/batch_utils.h"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <random>
+#include <stdexcept>
+
+namespace trtmc::diffusion {
+
+namespace {
+
+std::int32_t normalize_public_seed(std::uint32_t seed) {
+    return static_cast<std::int32_t>(seed & 0x7FFFFFFFU);
+}
+
+} // namespace
+
+std::vector<std::int32_t> derive_per_sample_seeds(std::uint64_t global_seed, int count) {
+    if (count < 1)
+        throw std::invalid_argument("count must be >= 1");
+
+    std::vector<std::int32_t> out(static_cast<std::size_t>(count));
+    for (int i = 0; i < count; ++i) {
+        std::seed_seq seq{
+            static_cast<std::uint32_t>(global_seed & 0xFFFFFFFFULL),
+            static_cast<std::uint32_t>(global_seed >> 32U),
+            static_cast<std::uint32_t>(i),
+        };
+        std::array<std::uint32_t, 1> buf{};
+        seq.generate(buf.begin(), buf.end());
+        out[static_cast<std::size_t>(i)] = normalize_public_seed(buf[0]);
+    }
+    return out;
+}
+
+std::vector<std::int32_t> derive_per_sample_seeds(
+    const std::vector<std::uint64_t>& explicit_list, int count) {
+    if (count < 1)
+        throw std::invalid_argument("count must be >= 1");
+    if (static_cast<int>(explicit_list.size()) != count)
+        throw std::invalid_argument("--seed list length must equal total batch count");
+
+    std::vector<std::int32_t> out;
+    out.reserve(explicit_list.size());
+    for (std::uint64_t seed : explicit_list) {
+        if (seed > static_cast<std::uint64_t>(std::numeric_limits<std::int32_t>::max()))
+            throw std::invalid_argument("--seed values must fit in int32");
+        out.push_back(static_cast<std::int32_t>(seed));
+    }
+    return out;
+}
+
+std::vector<int> plan_chunks(int total, int cap) {
+    if (total < 1)
+        throw std::invalid_argument("total must be >= 1");
+    if (cap < 1)
+        throw std::invalid_argument("cap must be >= 1");
+
+    std::vector<int> plan;
+    while (total > 0) {
+        const int n = std::min(total, cap);
+        plan.push_back(n);
+        total -= n;
+    }
+    return plan;
+}
+
+} // namespace trtmc::diffusion

--- a/src/runtime/domains/diffusion/batch_utils.h
+++ b/src/runtime/domains/diffusion/batch_utils.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace trtmc::diffusion {
+
+std::vector<std::int32_t> derive_per_sample_seeds(std::uint64_t global_seed, int count);
+
+std::vector<std::int32_t> derive_per_sample_seeds(
+    const std::vector<std::uint64_t>& explicit_list, int count);
+
+std::vector<int> plan_chunks(int total, int cap);
+
+} // namespace trtmc::diffusion

--- a/src/runtime/domains/diffusion/diffusion_types.h
+++ b/src/runtime/domains/diffusion/diffusion_types.h
@@ -21,6 +21,16 @@ struct DiffusionConfig {
     int32_t max_image_seq_len{4096};
     float shift_terminal{0.0F};
 
+    // Per-call requested batch size. Defaults to 1 to preserve existing
+    // single-image behavior for old call sites.
+    int32_t batch_size{1};
+
+    struct {
+        int32_t dit{1};
+        int32_t text_encoder{1};
+        int32_t vae{1};
+    } max_batch_size;
+
     int32_t video_height{480};
     int32_t video_width{832};
     int32_t video_num_frames{81};

--- a/src/runtime/models/flux/pipeline.cpp
+++ b/src/runtime/models/flux/pipeline.cpp
@@ -1376,9 +1376,6 @@ std::vector<ImageResult> FluxPipeline::generate_images(
     std::size_t prompt_offset = 0;
     for (int32_t chunk_size : chunks) {
         const int32_t batch = chunk_size;
-        std::cerr << "[flux] Batched DiT chunk B=" << batch << "/" << cap << ", prompts "
-                  << prompt_offset << ".."
-                  << (prompt_offset + static_cast<std::size_t>(batch) - 1U) << "\n";
 
         diffusion::FluxGenerationPlan plan;
         bool have_plan = false;

--- a/src/runtime/models/flux/pipeline.cpp
+++ b/src/runtime/models/flux/pipeline.cpp
@@ -9,6 +9,7 @@
 #include "runtime/models/flux/pipeline.h"
 
 #include "runtime/core/gpu_matmul.h"
+#include "runtime/domains/diffusion/batch_utils.h"
 #include "runtime/domains/diffusion/diffusion_denoising_step_seam.h"
 #include "runtime/domains/diffusion/diffusion_generation_plan.h"
 #include "runtime/domains/diffusion/diffusion_scheduler_helpers.h"
@@ -23,6 +24,7 @@
 #include <iostream>
 #include <numeric>
 #include <random>
+#include <stdexcept>
 
 namespace trtmc {
 
@@ -859,6 +861,59 @@ bool FluxPipeline::run_flux_denoiser(const std::vector<float>& hidden,
     return true;
 }
 
+bool FluxPipeline::run_flux_denoiser_batched(const std::vector<float>& hidden,
+                                             const std::vector<float>& encoder_hidden,
+                                             const std::vector<float>& temb,
+                                             const std::vector<float>& cos_vals,
+                                             const std::vector<float>& sin_vals, int32_t batch,
+                                             int32_t hidden_cols,
+                                             int32_t expected_output_cols,
+                                             std::vector<float>& output) {
+    const int32_t dit_dim = config_.dit_dim;
+    const int32_t text_seq = config_.text_seq_len;
+    const int32_t head_dim = dit_dim / std::max(config_.dit_num_heads, 1);
+    const int32_t total_seq = text_seq + num_img_tokens_;
+
+    TensorMap inputs;
+    inputs["hidden_states"] =
+        Tensor{const_cast<float*>(hidden.data()),
+               {static_cast<int64_t>(batch), static_cast<int64_t>(num_img_tokens_),
+                static_cast<int64_t>(hidden_cols)},
+               DType::kFloat32};
+    inputs["encoder_hidden_states"] =
+        Tensor{const_cast<float*>(encoder_hidden.data()),
+               {static_cast<int64_t>(batch), static_cast<int64_t>(text_seq),
+                static_cast<int64_t>(dit_dim)},
+               DType::kFloat32};
+    inputs["temb"] =
+        Tensor{const_cast<float*>(temb.data()),
+               {static_cast<int64_t>(batch), static_cast<int64_t>(dit_dim)}, DType::kFloat32};
+    inputs["rotary_cos"] =
+        Tensor{const_cast<float*>(cos_vals.data()),
+               {static_cast<int64_t>(batch), static_cast<int64_t>(total_seq),
+                static_cast<int64_t>(head_dim)},
+               DType::kFloat32};
+    inputs["rotary_sin"] =
+        Tensor{const_cast<float*>(sin_vals.data()),
+               {static_cast<int64_t>(batch), static_cast<int64_t>(total_seq),
+                static_cast<int64_t>(head_dim)},
+               DType::kFloat32};
+
+    auto outputs = denoiser_->forward(inputs);
+    auto& out_tensor = outputs.at("output");
+    const auto expected = static_cast<std::size_t>(batch) *
+                          static_cast<std::size_t>(num_img_tokens_) *
+                          static_cast<std::size_t>(expected_output_cols);
+    if (out_tensor.numel() < expected) {
+        std::cerr << "[flux] Batched DiT output too small: got " << out_tensor.numel()
+                  << ", expected at least " << expected << "\n";
+        return false;
+    }
+    const auto* out_data = static_cast<const float*>(out_tensor.data);
+    output.assign(out_data, out_data + expected);
+    return true;
+}
+
 // FLUX.2 denoiser: takes raw timestep/guidance scalars + raw T5 embeddings.
 // Context embedder and temb MLP are baked into the TRT engine.
 bool FluxPipeline::run_flux2_denoiser(const std::vector<float>& hidden,
@@ -1272,6 +1327,225 @@ bool FluxPipeline::decode_and_convert(const diffusion::FluxGenerationPlan& plan,
 // ===========================================================================
 // generate_image — Full FLUX pipeline
 // ===========================================================================
+
+std::vector<ImageResult> FluxPipeline::generate_images(
+    const std::vector<std::string>& prompts, const std::vector<int32_t>& per_sample_seeds,
+    const GenerateConfig& cfg) {
+    if (prompts.empty())
+        return {};
+    if (!per_sample_seeds.empty() && per_sample_seeds.size() != prompts.size()) {
+        throw std::invalid_argument("per_sample_seeds size must match prompts size");
+    }
+
+    std::vector<int32_t> resolved_seeds;
+    if (!per_sample_seeds.empty()) {
+        resolved_seeds = per_sample_seeds;
+    } else if (prompts.size() == 1U) {
+        resolved_seeds = {cfg.seed};
+    } else {
+        const std::uint64_t global_seed =
+            cfg.seed >= 0 ? static_cast<std::uint64_t>(cfg.seed) : 42ULL;
+        resolved_seeds =
+            diffusion::derive_per_sample_seeds(global_seed, static_cast<int>(prompts.size()));
+    }
+
+    if (!denoiser_ || config_.max_batch_size.dit <= 1 ||
+        denoiser_->input_rank("hidden_states") != 3 || !denoiser_->has_input("temb")) {
+        return IPipeline::generate_images(prompts, resolved_seeds, cfg);
+    }
+
+    int32_t cap = std::max(config_.max_batch_size.dit, 1);
+    const auto profile_max = denoiser_->input_profile_shape(
+        "hidden_states", denoiser_->profile_idx(), ProfileShapeSelector::kMax);
+    if (!profile_max.empty() && profile_max[0] > 0) {
+        cap = std::min(cap, static_cast<int32_t>(profile_max[0]));
+    }
+    if (cap <= 1) {
+        return IPipeline::generate_images(prompts, resolved_seeds, cfg);
+    }
+
+    const int32_t num_inference_steps =
+        diffusion::resolve_requested_steps(cfg.num_steps, config_.num_inference_steps, true);
+    const float guidance_scale =
+        diffusion::resolve_requested_guidance(cfg.guidance_scale, config_.guidance_scale);
+
+    const auto chunks = diffusion::plan_chunks(static_cast<int>(prompts.size()), cap);
+    std::vector<ImageResult> results;
+    results.reserve(prompts.size());
+
+    std::size_t prompt_offset = 0;
+    for (int32_t chunk_size : chunks) {
+        const int32_t batch = chunk_size;
+        std::cerr << "[flux] Batched DiT chunk B=" << batch << "/" << cap << ", prompts "
+                  << prompt_offset << ".."
+                  << (prompt_offset + static_cast<std::size_t>(batch) - 1U) << "\n";
+
+        diffusion::FluxGenerationPlan plan;
+        bool have_plan = false;
+        std::vector<std::vector<float>> pooled_by_sample(static_cast<std::size_t>(batch));
+
+        std::vector<float> encoder_hidden_batched;
+        std::vector<float> rope_cos_batched;
+        std::vector<float> rope_sin_batched;
+        std::vector<float> latents;
+
+        std::size_t latent_size = 0;
+        std::size_t encoder_hidden_size = 0;
+        std::size_t rope_size = 0;
+        int32_t total_seq = 0;
+        int32_t head_dim = 0;
+
+        for (int32_t b = 0; b < batch; ++b) {
+            const std::size_t sample_idx = prompt_offset + static_cast<std::size_t>(b);
+
+            diffusion::FluxGenerationPlan sample_plan;
+            std::vector<float> text_embeddings;
+            if (!prepare_conditioning(
+                    prompts[sample_idx], cfg, sample_plan, pooled_by_sample[static_cast<std::size_t>(b)],
+                    text_embeddings)) {
+                return {};
+            }
+            if (sample_plan.is_flux2) {
+                return IPipeline::generate_images(prompts, resolved_seeds, cfg);
+            }
+            if (!have_plan) {
+                plan = sample_plan;
+                plan.num_inference_steps = num_inference_steps;
+                plan.guidance_scale = guidance_scale;
+
+                latent_size = static_cast<std::size_t>(plan.latent_size);
+                encoder_hidden_size = static_cast<std::size_t>(plan.text_seq) *
+                                      static_cast<std::size_t>(plan.dit_dim);
+                head_dim = plan.dit_dim / std::max(config_.dit_num_heads, 1);
+                total_seq = plan.text_seq + num_img_tokens_;
+                rope_size =
+                    static_cast<std::size_t>(total_seq) * static_cast<std::size_t>(head_dim);
+
+                encoder_hidden_batched.resize(
+                    static_cast<std::size_t>(batch) * encoder_hidden_size);
+                rope_cos_batched.resize(static_cast<std::size_t>(batch) * rope_size);
+                rope_sin_batched.resize(static_cast<std::size_t>(batch) * rope_size);
+                latents.resize(static_cast<std::size_t>(batch) * latent_size);
+                have_plan = true;
+            }
+
+            std::vector<float> encoder_hidden;
+            std::vector<float> cos_vals, sin_vals;
+            std::vector<float> sample_latents;
+            prepare_denoising_state(
+                plan, text_embeddings, encoder_hidden, cos_vals, sin_vals, sample_latents,
+                resolved_seeds[sample_idx]);
+
+            std::copy(encoder_hidden.begin(), encoder_hidden.end(),
+                      encoder_hidden_batched.begin() +
+                          static_cast<std::ptrdiff_t>(b) *
+                              static_cast<std::ptrdiff_t>(encoder_hidden_size));
+            std::copy(cos_vals.begin(), cos_vals.end(),
+                      rope_cos_batched.begin() +
+                          static_cast<std::ptrdiff_t>(b) * static_cast<std::ptrdiff_t>(rope_size));
+            std::copy(sin_vals.begin(), sin_vals.end(),
+                      rope_sin_batched.begin() +
+                          static_cast<std::ptrdiff_t>(b) * static_cast<std::ptrdiff_t>(rope_size));
+            std::copy(sample_latents.begin(), sample_latents.end(),
+                      latents.begin() +
+                          static_cast<std::ptrdiff_t>(b) *
+                              static_cast<std::ptrdiff_t>(latent_size));
+        }
+
+        const int32_t dit_dim = plan.dit_dim;
+        const int32_t z_dim = plan.z_dim;
+        const auto& layout = plan.layout;
+        const int32_t hidden_dim = dit_dim;
+        const auto hidden_size = static_cast<std::size_t>(num_img_tokens_) *
+                                 static_cast<std::size_t>(hidden_dim);
+        const auto packed_size = static_cast<std::size_t>(num_img_tokens_) *
+                                 static_cast<std::size_t>(layout.packed_channels);
+
+        auto pack_latents_fn = make_flux_pack_fn(false, z_dim, h_latent_, w_latent_, layout);
+        auto unpack_velocity_fn = make_flux_unpack_fn(false, z_dim, h_latent_, w_latent_, layout);
+        auto embed_hidden =
+            make_flux_hidden_embedder(weights_.patch_embed_weight, weights_.patch_embed_bias,
+                                      num_img_tokens_, layout, dit_dim);
+
+        FlowMatchEulerState scheduler = diffusion::make_flux_scheduler_state(plan);
+        log_flux_dynamic_shift(scheduler);
+
+        std::vector<float> hidden(static_cast<std::size_t>(batch) * hidden_size);
+        std::vector<float> temb_batched(static_cast<std::size_t>(batch) *
+                                        static_cast<std::size_t>(dit_dim));
+        std::vector<float> denoiser_output;
+        std::vector<float> velocity(static_cast<std::size_t>(batch) * latent_size);
+        std::vector<float> sample_latents;
+        std::vector<float> packed;
+        std::vector<float> sample_hidden(hidden_size);
+        std::vector<float> temb;
+        std::vector<float> sample_output;
+        std::vector<float> sample_velocity;
+
+        for (int32_t step = 0; step < num_inference_steps; ++step) {
+            const float raw_timestep = scheduler.timesteps[static_cast<std::size_t>(step)];
+            const float t_for_embedding = raw_timestep / 1000.0F;
+
+            for (int32_t b = 0; b < batch; ++b) {
+                const auto sample_offset = static_cast<std::size_t>(b) * latent_size;
+                const auto* sample_latents_ptr = latents.data() + sample_offset;
+                sample_latents.assign(sample_latents_ptr, sample_latents_ptr + latent_size);
+
+                pack_latents_fn(sample_latents, packed);
+                embed_hidden(packed, sample_hidden);
+                std::copy(sample_hidden.begin(), sample_hidden.end(),
+                          hidden.begin() +
+                              static_cast<std::ptrdiff_t>(b) *
+                                  static_cast<std::ptrdiff_t>(hidden_size));
+
+                compute_flux_timestep_embedding(
+                    t_for_embedding, guidance_scale, pooled_by_sample[static_cast<std::size_t>(b)],
+                    temb);
+                std::copy(temb.begin(), temb.end(),
+                          temb_batched.begin() +
+                              static_cast<std::ptrdiff_t>(b) *
+                                  static_cast<std::ptrdiff_t>(dit_dim));
+            }
+
+            if (!run_flux_denoiser_batched(
+                    hidden, encoder_hidden_batched, temb_batched, rope_cos_batched,
+                    rope_sin_batched, batch, hidden_dim, layout.packed_channels,
+                    denoiser_output)) {
+                std::cerr << "[flux] Batched DiT failed at step " << step << "\n";
+                return {};
+            }
+
+            for (int32_t b = 0; b < batch; ++b) {
+                const auto* sample_output_ptr =
+                    denoiser_output.data() + static_cast<std::size_t>(b) * packed_size;
+                sample_output.assign(sample_output_ptr, sample_output_ptr + packed_size);
+                unpack_velocity_fn(sample_output, sample_velocity);
+                std::copy(sample_velocity.begin(), sample_velocity.end(),
+                          velocity.begin() +
+                              static_cast<std::ptrdiff_t>(b) *
+                                  static_cast<std::ptrdiff_t>(latent_size));
+            }
+
+            scheduler.step(velocity.data(), latents.data(), latents.data(), latents.size(), step);
+            log_flux_step_stats(step, num_inference_steps, scheduler, latents, velocity, hidden);
+        }
+
+        for (int32_t b = 0; b < batch; ++b) {
+            const auto* sample_latents_ptr =
+                latents.data() + static_cast<std::size_t>(b) * latent_size;
+            sample_latents.assign(sample_latents_ptr, sample_latents_ptr + latent_size);
+            ImageResult result;
+            if (!decode_and_convert(plan, sample_latents, result)) {
+                return {};
+            }
+            results.push_back(std::move(result));
+        }
+
+        prompt_offset += static_cast<std::size_t>(batch);
+    }
+
+    return results;
+}
 
 ImageResult FluxPipeline::generate_image(const std::string& prompt, const GenerateConfig& cfg) {
     using Clock = std::chrono::steady_clock;

--- a/src/runtime/models/flux/pipeline.cpp
+++ b/src/runtime/models/flux/pipeline.cpp
@@ -168,8 +168,9 @@ bool prepare_flux_t5_conditioning(const std::vector<int32_t>& input_ids, int32_t
 // Latent initialization
 // ---------------------------------------------------------------------------
 
-void initialize_flux_latents(std::vector<float>& latents) {
-    std::mt19937 gen(42);
+void initialize_flux_latents(std::vector<float>& latents, int32_t seed) {
+    const auto normalized_seed = static_cast<std::mt19937::result_type>(seed >= 0 ? seed : 42);
+    std::mt19937 gen(normalized_seed);
     std::normal_distribution<float> dist(0.0F, 1.0F);
     for (auto& v : latents) {
         v = dist(gen);
@@ -1116,7 +1117,7 @@ void FluxPipeline::prepare_denoising_state(const diffusion::FluxGenerationPlan& 
                                            std::vector<float>& encoder_hidden,
                                            std::vector<float>& cos_vals,
                                            std::vector<float>& sin_vals,
-                                           std::vector<float>& latents) {
+                                           std::vector<float>& latents, int32_t seed) {
     using Clock = std::chrono::steady_clock;
     const int32_t dit_dim = plan.dit_dim;
     const int32_t text_seq = plan.text_seq;
@@ -1145,7 +1146,7 @@ void FluxPipeline::prepare_denoising_state(const diffusion::FluxGenerationPlan& 
 
     // 8. Initialize random latents
     latents.resize(plan.latent_size);
-    initialize_flux_latents(latents);
+    initialize_flux_latents(latents, seed);
     auto tp3 = Clock::now();
 
     auto ms = [](auto a, auto b) {
@@ -1291,7 +1292,8 @@ ImageResult FluxPipeline::generate_image(const std::string& prompt, const Genera
     std::vector<float> encoder_hidden;
     std::vector<float> cos_vals, sin_vals;
     std::vector<float> latents;
-    prepare_denoising_state(plan, text_embeddings, encoder_hidden, cos_vals, sin_vals, latents);
+    prepare_denoising_state(
+        plan, text_embeddings, encoder_hidden, cos_vals, sin_vals, latents, cfg.seed);
     const auto t_prep = Clock::now();
 
     // Step 10: Denoising loop

--- a/src/runtime/models/flux/pipeline.h
+++ b/src/runtime/models/flux/pipeline.h
@@ -27,6 +27,10 @@ class FluxPipeline final : public IPipeline {
     ~FluxPipeline() override;
 
     ImageResult generate_image(const std::string& prompt, const GenerateConfig& cfg = {}) override;
+    std::vector<ImageResult> generate_images(
+        const std::vector<std::string>& prompts,
+        const std::vector<int32_t>& per_sample_seeds = {},
+        const GenerateConfig& cfg = {}) override;
 
     const char* model_id() const override { return model_id_.c_str(); }
     const char* pipeline_type() const override { return "FluxPipeline"; }
@@ -39,6 +43,13 @@ class FluxPipeline final : public IPipeline {
                            const std::vector<float>& encoder_hidden, const std::vector<float>& temb,
                            const std::vector<float>& cos_vals, const std::vector<float>& sin_vals,
                            std::vector<float>& output);
+    bool run_flux_denoiser_batched(const std::vector<float>& hidden,
+                                   const std::vector<float>& encoder_hidden,
+                                   const std::vector<float>& temb,
+                                   const std::vector<float>& cos_vals,
+                                   const std::vector<float>& sin_vals, int32_t batch,
+                                   int32_t hidden_cols, int32_t expected_output_cols,
+                                   std::vector<float>& output);
     // FLUX.2: denoiser with baked temb MLP + context embedder
     bool run_flux2_denoiser(const std::vector<float>& hidden,
                             const std::vector<float>& encoder_hidden, float timestep,

--- a/src/runtime/models/flux/pipeline.h
+++ b/src/runtime/models/flux/pipeline.h
@@ -58,7 +58,8 @@ class FluxPipeline final : public IPipeline {
     void prepare_denoising_state(const diffusion::FluxGenerationPlan& plan,
                                  const std::vector<float>& text_embeddings,
                                  std::vector<float>& encoder_hidden, std::vector<float>& cos_vals,
-                                 std::vector<float>& sin_vals, std::vector<float>& latents);
+                                 std::vector<float>& sin_vals, std::vector<float>& latents,
+                                 int32_t seed);
     bool run_denoising(const diffusion::FluxGenerationPlan& plan,
                        const std::vector<float>& pooled_output, std::vector<float>& encoder_hidden,
                        std::vector<float>& cos_vals, std::vector<float>& sin_vals,

--- a/src/runtime/models/qwen_image/pipeline.cpp
+++ b/src/runtime/models/qwen_image/pipeline.cpp
@@ -7,6 +7,7 @@
 
 #include "runtime/models/qwen_image/pipeline.h"
 
+#include "runtime/domains/diffusion/batch_utils.h"
 #include "runtime/domains/diffusion/diffusion_scheduler_helpers.h"
 #include "trtmc/runtime/scheduler.h"
 
@@ -41,6 +42,7 @@ QwenImagePipeline::QwenImagePipeline(Construction c)
       vision_engine_(std::move(c.vision_engine)),
       vae_encoder_engine_(std::move(c.vae_encoder_engine)), tokenizer_(std::move(c.tokenizer)),
       config_(std::move(c.config)), preprocessor_(std::move(c.preprocessor)),
+      max_dit_batch_size_(std::max(c.max_dit_batch_size, 1)),
       model_id_(std::move(c.model_id)), bundle_path_(std::move(c.bundle_path)) {}
 
 QwenImagePipeline::~QwenImagePipeline() = default;
@@ -113,6 +115,12 @@ void validate_caller_initial_latents(const std::vector<float>& initial_latents, 
     }
 }
 
+FlowMatchEulerScheduler build_scheduler(const QwenImageDiffusionConfig& dc, int num_steps,
+                                        int n_img);
+void combine_cfg_with_renorm(const std::vector<float>& noise_pos,
+                             const std::vector<float>& noise_neg, float cfg_scale, int n_img,
+                             std::size_t channels, std::vector<float>& out);
+
 } // namespace
 
 ImageResult QwenImagePipeline::generate_image(const std::string& prompt,
@@ -164,6 +172,163 @@ ImageResult QwenImagePipeline::generate_image(const std::string& prompt,
     result.num_frames = 1;
     result.pixels = std::move(image.pixels);
     return result;
+}
+
+std::vector<ImageResult> QwenImagePipeline::generate_images(
+    const std::vector<std::string>& prompts, const std::vector<int32_t>& per_sample_seeds,
+    const GenerateConfig& cfg) {
+    if (prompts.empty())
+        return {};
+    if (!per_sample_seeds.empty() && per_sample_seeds.size() != prompts.size()) {
+        throw std::invalid_argument("per_sample_seeds size must match prompts size");
+    }
+
+    validate_generate_image_engines(text_engine_ != nullptr, denoiser_engine_ != nullptr,
+                                    vae_decoder_engine_ != nullptr);
+    const GenerateKnobs k = resolve_generate_knobs(cfg, config_);
+
+    std::vector<int32_t> resolved_seeds;
+    if (!per_sample_seeds.empty()) {
+        resolved_seeds = per_sample_seeds;
+    } else if (prompts.size() == 1U) {
+        resolved_seeds = {cfg.seed};
+    } else {
+        resolved_seeds =
+            diffusion::derive_per_sample_seeds(k.seed, static_cast<int>(prompts.size()));
+    }
+
+    if (!cfg.initial_latents.empty() || max_dit_batch_size_ <= 1 ||
+        denoiser_engine_->input_rank("img_patched") != 3) {
+        return IPipeline::generate_images(prompts, resolved_seeds, cfg);
+    }
+
+    int32_t cap = std::max(max_dit_batch_size_, 1);
+    const auto profile_max = denoiser_engine_->input_profile_shape(
+        "img_patched", denoiser_engine_->profile_idx(), ProfileShapeSelector::kMax);
+    if (!profile_max.empty() && profile_max[0] > 0) {
+        cap = std::min(cap, static_cast<int32_t>(profile_max[0]));
+    }
+    if (cap <= 1) {
+        return IPipeline::generate_images(prompts, resolved_seeds, cfg);
+    }
+
+    auto shape = compute_latent_shape(k.height, k.width);
+    validate_generate_image_shape(shape.latent_h, shape.latent_w, shape.n_img_tokens);
+    const int latent_channels = config_.vae.latent_channels;
+    const int in_channels = config_.denoiser.in_channels;
+    const int max_text_tokens = config_.denoiser.max_text_tokens;
+    const int text_embed_dim = config_.denoiser.text_embed_dim;
+    const std::size_t packed_size = static_cast<std::size_t>(shape.n_img_tokens) *
+                                    static_cast<std::size_t>(in_channels);
+    const std::size_t hidden_size = static_cast<std::size_t>(max_text_tokens) *
+                                    static_cast<std::size_t>(text_embed_dim);
+
+    const EncodedPrompt neg = encode_text(k.negative);
+    const bool do_cfg = k.cfg_scale > 1.0F;
+    const auto chunks = diffusion::plan_chunks(static_cast<int>(prompts.size()), cap);
+    std::vector<ImageResult> results;
+    results.reserve(prompts.size());
+
+    auto run_denoiser_batched = [&](const std::vector<float>& latents_packed,
+                                    const std::vector<float>& hidden_states, float normalized_t,
+                                    int32_t batch) {
+        std::vector<float> timestep_buf(static_cast<std::size_t>(batch), normalized_t);
+        TensorMap inputs;
+        inputs["img_patched"] =
+            Tensor{const_cast<float*>(latents_packed.data()),
+                   {static_cast<int64_t>(batch), static_cast<int64_t>(shape.n_img_tokens),
+                    static_cast<int64_t>(in_channels)},
+                   DType::kFloat32};
+        inputs["txt_hidden"] =
+            Tensor{const_cast<float*>(hidden_states.data()),
+                   {static_cast<int64_t>(batch), static_cast<int64_t>(max_text_tokens),
+                    static_cast<int64_t>(text_embed_dim)},
+                   DType::kFloat32};
+        inputs["timestep"] = Tensor{timestep_buf.data(), {static_cast<int64_t>(batch)},
+                                    DType::kFloat32};
+
+        auto outputs = denoiser_engine_->forward(inputs);
+        const auto& noise = outputs["noise_patched"];
+        const std::size_t expected = static_cast<std::size_t>(batch) * packed_size;
+        if (noise.numel() != expected) {
+            throw std::runtime_error(
+                "QwenImagePipeline::generate_images: batched denoiser output size " +
+                std::to_string(noise.numel()) + " does not match expected " +
+                std::to_string(expected));
+        }
+        std::vector<float> out(expected);
+        std::memcpy(out.data(), noise.data, out.size() * sizeof(float));
+        return out;
+    };
+
+    std::size_t prompt_offset = 0;
+    for (int32_t chunk_size : chunks) {
+        const int32_t batch = chunk_size;
+        std::vector<float> latents_packed(static_cast<std::size_t>(batch) * packed_size);
+        std::vector<float> pos_hidden(static_cast<std::size_t>(batch) * hidden_size);
+        std::vector<float> neg_hidden(static_cast<std::size_t>(batch) * hidden_size);
+
+        for (int32_t b = 0; b < batch; ++b) {
+            const std::size_t sample_idx = prompt_offset + static_cast<std::size_t>(b);
+            const auto pos = encode_text(prompts[sample_idx]);
+            std::copy(pos.hidden_states.begin(), pos.hidden_states.end(),
+                      pos_hidden.begin() +
+                          static_cast<std::ptrdiff_t>(b) *
+                              static_cast<std::ptrdiff_t>(hidden_size));
+            std::copy(neg.hidden_states.begin(), neg.hidden_states.end(),
+                      neg_hidden.begin() +
+                          static_cast<std::ptrdiff_t>(b) *
+                              static_cast<std::ptrdiff_t>(hidden_size));
+
+            const uint64_t seed = resolved_seeds[sample_idx] >= 0
+                                      ? static_cast<uint64_t>(resolved_seeds[sample_idx])
+                                      : 42ULL;
+            auto latents =
+                prepare_initial_latents(shape.latent_h, shape.latent_w, latent_channels, seed);
+            auto packed = patchify_latents(latents, latent_channels, shape.latent_h,
+                                           shape.latent_w, config_.denoiser.patch_size);
+            std::copy(packed.begin(), packed.end(),
+                      latents_packed.begin() +
+                          static_cast<std::ptrdiff_t>(b) *
+                              static_cast<std::ptrdiff_t>(packed_size));
+        }
+
+        auto scheduler = build_scheduler(config_.diffusion, k.num_steps, shape.n_img_tokens);
+        const auto& timesteps = scheduler.timesteps();
+        std::vector<float> noise_pred(static_cast<std::size_t>(batch) * packed_size);
+
+        for (int step = 0; step < k.num_steps; ++step) {
+            const float norm_t = normalize_timestep(timesteps[static_cast<std::size_t>(step)]);
+            auto noise_pos = run_denoiser_batched(latents_packed, pos_hidden, norm_t, batch);
+            if (do_cfg) {
+                auto noise_neg = run_denoiser_batched(latents_packed, neg_hidden, norm_t, batch);
+                combine_cfg_with_renorm(noise_pos, noise_neg, k.cfg_scale,
+                                        batch * shape.n_img_tokens,
+                                        static_cast<std::size_t>(in_channels), noise_pred);
+            } else {
+                noise_pred = std::move(noise_pos);
+            }
+            scheduler.step(latents_packed.data(), noise_pred.data(),
+                           static_cast<int32_t>(latents_packed.size()), step);
+        }
+
+        for (int32_t b = 0; b < batch; ++b) {
+            const auto* sample_ptr = latents_packed.data() + static_cast<std::size_t>(b) * packed_size;
+            std::vector<float> sample(sample_ptr, sample_ptr + packed_size);
+            auto image = vae_decode(sample, shape.n_img_tokens, shape.latent_h, shape.latent_w);
+            ImageResult result;
+            result.height = image.height;
+            result.width = image.width;
+            result.channels = 3;
+            result.num_frames = 1;
+            result.pixels = std::move(image.pixels);
+            results.push_back(std::move(result));
+        }
+
+        prompt_offset += static_cast<std::size_t>(batch);
+    }
+
+    return results;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/runtime/models/qwen_image/pipeline.cpp
+++ b/src/runtime/models/qwen_image/pipeline.cpp
@@ -224,14 +224,20 @@ std::vector<ImageResult> QwenImagePipeline::generate_images(
                                     static_cast<std::size_t>(text_embed_dim);
 
     const EncodedPrompt neg = encode_text(k.negative);
+    std::vector<float> neg_mask(static_cast<std::size_t>(max_text_tokens));
+    for (int i = 0; i < max_text_tokens; ++i) {
+        neg_mask[static_cast<std::size_t>(i)] =
+            neg.attention_mask[static_cast<std::size_t>(i)] != 0 ? 1.0F : 0.0F;
+    }
     const bool do_cfg = k.cfg_scale > 1.0F;
     const auto chunks = diffusion::plan_chunks(static_cast<int>(prompts.size()), cap);
     std::vector<ImageResult> results;
     results.reserve(prompts.size());
 
     auto run_denoiser_batched = [&](const std::vector<float>& latents_packed,
-                                    const std::vector<float>& hidden_states, float normalized_t,
-                                    int32_t batch) {
+                                    const std::vector<float>& hidden_states,
+                                    const std::vector<float>& text_mask,
+                                    float normalized_t, int32_t batch) {
         std::vector<float> timestep_buf(static_cast<std::size_t>(batch), normalized_t);
         TensorMap inputs;
         inputs["img_patched"] =
@@ -244,20 +250,26 @@ std::vector<ImageResult> QwenImagePipeline::generate_images(
                    {static_cast<int64_t>(batch), static_cast<int64_t>(max_text_tokens),
                     static_cast<int64_t>(text_embed_dim)},
                    DType::kFloat32};
+        if (denoiser_engine_->has_input("encoder_hidden_states_mask")) {
+            inputs["encoder_hidden_states_mask"] =
+                Tensor{const_cast<float*>(text_mask.data()),
+                       {static_cast<int64_t>(batch), static_cast<int64_t>(max_text_tokens)},
+                       DType::kFloat32};
+        }
         inputs["timestep"] = Tensor{timestep_buf.data(), {static_cast<int64_t>(batch)},
                                     DType::kFloat32};
 
         auto outputs = denoiser_engine_->forward(inputs);
         const auto& noise = outputs["noise_patched"];
         const std::size_t expected = static_cast<std::size_t>(batch) * packed_size;
-        if (noise.numel() != expected) {
+        if (noise.numel() < expected) {
             throw std::runtime_error(
                 "QwenImagePipeline::generate_images: batched denoiser output size " +
                 std::to_string(noise.numel()) + " does not match expected " +
                 std::to_string(expected));
         }
         std::vector<float> out(expected);
-        std::memcpy(out.data(), noise.data, out.size() * sizeof(float));
+        std::memcpy(out.data(), noise.data, expected * sizeof(float));
         return out;
     };
 
@@ -267,10 +279,16 @@ std::vector<ImageResult> QwenImagePipeline::generate_images(
         std::vector<float> latents_packed(static_cast<std::size_t>(batch) * packed_size);
         std::vector<float> pos_hidden(static_cast<std::size_t>(batch) * hidden_size);
         std::vector<float> neg_hidden(static_cast<std::size_t>(batch) * hidden_size);
+        std::vector<float> pos_mask(static_cast<std::size_t>(batch) *
+                                    static_cast<std::size_t>(max_text_tokens));
+        std::vector<float> neg_mask_batched(static_cast<std::size_t>(batch) *
+                                            static_cast<std::size_t>(max_text_tokens));
 
         for (int32_t b = 0; b < batch; ++b) {
             const std::size_t sample_idx = prompt_offset + static_cast<std::size_t>(b);
             const auto pos = encode_text(prompts[sample_idx]);
+            const auto mask_offset = static_cast<std::size_t>(b) *
+                                     static_cast<std::size_t>(max_text_tokens);
             std::copy(pos.hidden_states.begin(), pos.hidden_states.end(),
                       pos_hidden.begin() +
                           static_cast<std::ptrdiff_t>(b) *
@@ -279,6 +297,12 @@ std::vector<ImageResult> QwenImagePipeline::generate_images(
                       neg_hidden.begin() +
                           static_cast<std::ptrdiff_t>(b) *
                               static_cast<std::ptrdiff_t>(hidden_size));
+            for (int i = 0; i < max_text_tokens; ++i) {
+                pos_mask[mask_offset + static_cast<std::size_t>(i)] =
+                    pos.attention_mask[static_cast<std::size_t>(i)] != 0 ? 1.0F : 0.0F;
+            }
+            std::copy(neg_mask.begin(), neg_mask.end(),
+                      neg_mask_batched.begin() + static_cast<std::ptrdiff_t>(mask_offset));
 
             const uint64_t seed = resolved_seeds[sample_idx] >= 0
                                       ? static_cast<uint64_t>(resolved_seeds[sample_idx])
@@ -299,9 +323,12 @@ std::vector<ImageResult> QwenImagePipeline::generate_images(
 
         for (int step = 0; step < k.num_steps; ++step) {
             const float norm_t = normalize_timestep(timesteps[static_cast<std::size_t>(step)]);
-            auto noise_pos = run_denoiser_batched(latents_packed, pos_hidden, norm_t, batch);
+            auto noise_pos =
+                run_denoiser_batched(latents_packed, pos_hidden, pos_mask, norm_t, batch);
             if (do_cfg) {
-                auto noise_neg = run_denoiser_batched(latents_packed, neg_hidden, norm_t, batch);
+                auto noise_neg =
+                    run_denoiser_batched(latents_packed, neg_hidden, neg_mask_batched, norm_t,
+                                         batch);
                 combine_cfg_with_renorm(noise_pos, noise_neg, k.cfg_scale,
                                         batch * shape.n_img_tokens,
                                         static_cast<std::size_t>(in_channels), noise_pred);
@@ -504,10 +531,21 @@ QwenImagePipeline::run_denoiser_once(const std::vector<float>& latents_packed, f
                                  " does not match max_text_tokens * text_embed_dim = " +
                                  std::to_string(expected_hidden_size));
     }
+    if (attention_mask.size() != static_cast<std::size_t>(max_text_tokens)) {
+        throw std::runtime_error("QwenImagePipeline::run_denoiser_once: attention_mask size " +
+                                 std::to_string(attention_mask.size()) +
+                                 " does not match max_text_tokens = " +
+                                 std::to_string(max_text_tokens));
+    }
 
     const int64_t n_img =
         static_cast<int64_t>(latents_packed.size() / static_cast<std::size_t>(in_channels));
     float timestep_buf = normalized_t;
+    std::vector<float> encoder_mask(static_cast<std::size_t>(max_text_tokens));
+    for (int i = 0; i < max_text_tokens; ++i) {
+        encoder_mask[static_cast<std::size_t>(i)] =
+            attention_mask[static_cast<std::size_t>(i)] != 0 ? 1.0F : 0.0F;
+    }
 
     TensorMap inputs;
     inputs["img_patched"] = Tensor{const_cast<float*>(latents_packed.data()),
@@ -517,12 +555,23 @@ QwenImagePipeline::run_denoiser_once(const std::vector<float>& latents_packed, f
         Tensor{const_cast<float*>(hidden_states.data()),
                {1, static_cast<int64_t>(max_text_tokens), static_cast<int64_t>(text_embed_dim)},
                DType::kFloat32};
+    if (denoiser_engine_->has_input("encoder_hidden_states_mask")) {
+        inputs["encoder_hidden_states_mask"] =
+            Tensor{encoder_mask.data(), {1, static_cast<int64_t>(max_text_tokens)},
+                   DType::kFloat32};
+    }
     inputs["timestep"] = Tensor{&timestep_buf, {1}, DType::kFloat32};
 
     auto outputs = denoiser_engine_->forward(inputs);
     const auto& noise = outputs["noise_patched"];
-    std::vector<float> result(noise.numel());
-    std::memcpy(result.data(), noise.data, result.size() * sizeof(float));
+    const std::size_t expected = latents_packed.size();
+    if (noise.numel() < expected) {
+        throw std::runtime_error("QwenImagePipeline::run_denoiser_once: denoiser output size " +
+                                 std::to_string(noise.numel()) + " does not match expected " +
+                                 std::to_string(expected));
+    }
+    std::vector<float> result(expected);
+    std::memcpy(result.data(), noise.data, expected * sizeof(float));
     return result;
 }
 

--- a/src/runtime/models/qwen_image/pipeline.h
+++ b/src/runtime/models/qwen_image/pipeline.h
@@ -125,10 +125,9 @@ class QwenImagePipeline final : public IPipeline {
     // already-divided-by-1000 scalar. Returns the predicted noise as
     // [1, n_img, out_channels * patch_size^2 = 64] row-major fp32.
     //
-    // attention_mask is accepted for API parity with the Python runner but
-    // currently unused: the denoiser engine was baked WITHOUT an
-    // encoder_hidden_states_mask input so zero-padded text positions
-    // participate in attention (documented deviation).
+    // attention_mask is 1 for valid text tokens and 0 for padded text tokens.
+    // Newer denoiser engines consume it as encoder_hidden_states_mask; older
+    // bundles without that input still run without masking for compatibility.
     std::vector<float> run_denoiser_once(const std::vector<float>& latents_packed,
                                          float normalized_t,
                                          const std::vector<float>& hidden_states,

--- a/src/runtime/models/qwen_image/pipeline.h
+++ b/src/runtime/models/qwen_image/pipeline.h
@@ -43,6 +43,7 @@ class QwenImagePipeline final : public IPipeline {
         std::shared_ptr<ITokenizer> tokenizer;
         QwenImageConfig config;
         QwenImagePreprocessorWeights preprocessor;
+        int32_t max_dit_batch_size{1};
         std::string model_id;
         std::string bundle_path;
     };
@@ -51,6 +52,10 @@ class QwenImagePipeline final : public IPipeline {
     ~QwenImagePipeline() override;
 
     ImageResult generate_image(const std::string& prompt, const GenerateConfig& cfg = {}) override;
+    std::vector<ImageResult> generate_images(
+        const std::vector<std::string>& prompts,
+        const std::vector<int32_t>& per_sample_seeds = {},
+        const GenerateConfig& cfg = {}) override;
 
     const char* model_id() const override { return model_id_.c_str(); }
     const char* pipeline_type() const override { return "QwenImagePipeline"; }
@@ -190,6 +195,7 @@ class QwenImagePipeline final : public IPipeline {
     std::shared_ptr<ITokenizer> tokenizer_;
     QwenImageConfig config_;
     QwenImagePreprocessorWeights preprocessor_;
+    int32_t max_dit_batch_size_{1};
     std::string model_id_;
     std::string bundle_path_;
 };

--- a/src/runtime/models/qwen_image/plugin.cpp
+++ b/src/runtime/models/qwen_image/plugin.cpp
@@ -58,6 +58,7 @@ class QwenImagePlugin final : public IPipelinePlugin {
         c.tokenizer = std::move(parts.tokenizer);
         c.config = std::move(qi_config);
         c.preprocessor = std::move(qi_preprocessor);
+        c.max_dit_batch_size = ctx.bundle.info.max_batch_size.dit;
         c.model_id = ctx.bundle.info.model_id;
         c.bundle_path = ctx.bundle_path;
         return std::make_unique<QwenImagePipeline>(std::move(c));

--- a/src/runtime/models/z_image/pipeline.cpp
+++ b/src/runtime/models/z_image/pipeline.cpp
@@ -271,6 +271,99 @@ bool ZImagePipeline::run_text_encoder(const std::vector<int32_t>& input_ids,
     return true;
 }
 
+bool ZImagePipeline::run_text_encoder_batched(
+    const std::vector<std::vector<int32_t>>& input_ids_batch,
+    std::vector<float>& text_embeddings) {
+    if (input_ids_batch.empty()) {
+        text_embeddings.clear();
+        return true;
+    }
+    if (!text_encoder_) {
+        std::cerr << "[z-image] No text encoder module\n";
+        return false;
+    }
+
+    const int32_t batch = static_cast<int32_t>(input_ids_batch.size());
+    const int32_t seq_len = config_.text_seq_len;
+    const int32_t te_dim = config_.text_encoder_dim;
+    const auto emb_size = static_cast<std::size_t>(seq_len) * static_cast<std::size_t>(te_dim);
+
+    auto run_serial = [&]() {
+        text_embeddings.resize(static_cast<std::size_t>(batch) * emb_size);
+        std::vector<float> sample_embeddings;
+        for (int32_t b = 0; b < batch; ++b) {
+            if (!run_text_encoder(input_ids_batch[static_cast<std::size_t>(b)], sample_embeddings))
+                return false;
+            std::copy(sample_embeddings.begin(), sample_embeddings.end(),
+                      text_embeddings.begin() +
+                          static_cast<std::ptrdiff_t>(b) *
+                              static_cast<std::ptrdiff_t>(emb_size));
+        }
+        return true;
+    };
+
+    if (text_encoder_->input_rank("input_ids") != 2)
+        return run_serial();
+
+    int32_t cap = std::max(config_.max_batch_size.text_encoder, 1);
+    const auto profile_max = text_encoder_->input_profile_shape(
+        "input_ids", text_encoder_->profile_idx(), ProfileShapeSelector::kMax);
+    if (!profile_max.empty() && profile_max[0] > 0)
+        cap = std::min(cap, static_cast<int32_t>(profile_max[0]));
+    if (batch > cap)
+        return run_serial();
+
+    std::vector<int32_t> padded_ids(static_cast<std::size_t>(batch) *
+                                    static_cast<std::size_t>(seq_len), 0);
+    std::vector<float> mask(static_cast<std::size_t>(batch) *
+                            static_cast<std::size_t>(seq_len), -1e9F);
+
+    for (int32_t b = 0; b < batch; ++b) {
+        const auto& ids = input_ids_batch[static_cast<std::size_t>(b)];
+        const auto copy_len = std::min(static_cast<std::size_t>(seq_len), ids.size());
+        auto row = static_cast<std::size_t>(b) * static_cast<std::size_t>(seq_len);
+        std::copy_n(ids.begin(), copy_len, padded_ids.begin() + static_cast<std::ptrdiff_t>(row));
+        for (int32_t i = 0; i < seq_len; ++i) {
+            if (padded_ids[row + static_cast<std::size_t>(i)] != 0)
+                mask[row + static_cast<std::size_t>(i)] = 0.0F;
+        }
+    }
+
+    TensorMap inputs;
+    inputs["input_ids"] =
+        Tensor{padded_ids.data(),
+               {static_cast<int64_t>(batch), static_cast<int64_t>(seq_len)}, DType::kInt32};
+    inputs["attention_mask"] =
+        Tensor{mask.data(),
+               {static_cast<int64_t>(batch), static_cast<int64_t>(seq_len)}, DType::kFloat32};
+
+    auto outputs = text_encoder_->forward(inputs);
+    const auto& te_out = outputs["text_embeddings"];
+    const auto expected = static_cast<std::size_t>(batch) * emb_size;
+    if (te_out.numel() != expected) {
+        std::cerr << "[z-image] Batched text encoder output size " << te_out.numel()
+                  << " does not match expected " << expected << "\n";
+        return false;
+    }
+
+    text_embeddings.resize(expected);
+    std::memcpy(text_embeddings.data(), te_out.data, expected * sizeof(float));
+
+    for (int32_t b = 0; b < batch; ++b) {
+        const auto row = static_cast<std::size_t>(b) * static_cast<std::size_t>(seq_len);
+        for (int32_t i = 0; i < seq_len; ++i) {
+            if (padded_ids[row + static_cast<std::size_t>(i)] == 0) {
+                float* emb_row = text_embeddings.data() +
+                                 (row + static_cast<std::size_t>(i)) *
+                                     static_cast<std::size_t>(te_dim);
+                std::fill_n(emb_row, static_cast<std::size_t>(te_dim), 0.0F);
+            }
+        }
+    }
+
+    return true;
+}
+
 // ---------------------------------------------------------------------------
 // Denoiser: Z-Image DiT (unified attention)
 // ---------------------------------------------------------------------------
@@ -657,6 +750,8 @@ std::vector<ImageResult> ZImagePipeline::generate_images(
                              static_cast<std::size_t>(layout.dit_dim);
     const auto caption_size = static_cast<std::size_t>(layout.text_seq) *
                               static_cast<std::size_t>(layout.dit_dim);
+    const auto text_embedding_size = static_cast<std::size_t>(layout.text_seq) *
+                                     static_cast<std::size_t>(config_.text_encoder_dim);
     const auto rope_size =
         static_cast<std::size_t>(layout.num_patches + layout.text_seq) *
         static_cast<std::size_t>(layout.head_dim);
@@ -665,9 +760,6 @@ std::vector<ImageResult> ZImagePipeline::generate_images(
     std::size_t prompt_offset = 0;
     for (int32_t chunk_size : chunks) {
         const int32_t batch = chunk_size;
-        std::cerr << "[z-image] Batched DiT chunk B=" << batch << "/" << cap
-                  << ", prompts " << prompt_offset << ".."
-                  << (prompt_offset + static_cast<std::size_t>(batch) - 1U) << "\n";
 
         std::vector<float> caption_projected_batched(
             static_cast<std::size_t>(batch) * caption_size);
@@ -675,22 +767,39 @@ std::vector<ImageResult> ZImagePipeline::generate_images(
         std::vector<float> rope_sin_batched(static_cast<std::size_t>(batch) * rope_size);
         std::vector<float> latents(static_cast<std::size_t>(batch) * latent_size);
 
+        std::vector<std::vector<int32_t>> input_ids_batch(static_cast<std::size_t>(batch));
+        std::vector<int32_t> cap_ori_lens(static_cast<std::size_t>(batch));
+        std::vector<int32_t> cap_padded_lens(static_cast<std::size_t>(batch));
         for (int32_t b = 0; b < batch; ++b) {
             const std::size_t sample_idx = prompt_offset + static_cast<std::size_t>(b);
             const std::string prepared = apply_chat_template(prompts[sample_idx]);
-            const std::vector<int32_t> input_ids = tokenizer_->encode(prepared);
+            input_ids_batch[static_cast<std::size_t>(b)] = tokenizer_->encode(prepared);
+            cap_ori_lens[static_cast<std::size_t>(b)] =
+                count_non_pad_tokens(input_ids_batch[static_cast<std::size_t>(b)]);
+            cap_padded_lens[static_cast<std::size_t>(b)] =
+                pad_to_next_multiple(cap_ori_lens[static_cast<std::size_t>(b)], kSeqMultipleOf);
+        }
 
-            std::vector<float> text_embeddings;
-            if (!run_text_encoder(input_ids, text_embeddings)) {
-                std::cerr << "[z-image] Text encoder failed for sample " << sample_idx << "\n";
-                return {};
-            }
+        std::vector<float> text_embeddings_batched;
+        if (!run_text_encoder_batched(input_ids_batch, text_embeddings_batched)) {
+            std::cerr << "[z-image] Text encoder failed for chunk at prompt " << prompt_offset
+                      << "\n";
+            return {};
+        }
 
-            const int32_t cap_ori_len = count_non_pad_tokens(input_ids);
-            const int32_t cap_padded_len = pad_to_next_multiple(cap_ori_len, kSeqMultipleOf);
-
+        for (int32_t b = 0; b < batch; ++b) {
+            const std::size_t sample_idx = prompt_offset + static_cast<std::size_t>(b);
+            const auto text_offset = static_cast<std::size_t>(b) * text_embedding_size;
+            std::vector<float> text_embeddings(
+                text_embeddings_batched.begin() + static_cast<std::ptrdiff_t>(text_offset),
+                text_embeddings_batched.begin() +
+                    static_cast<std::ptrdiff_t>(text_offset + text_embedding_size));
             std::vector<float> caption_projected;
-            project_caption(text_embeddings, cap_ori_len, cap_padded_len, caption_projected);
+            project_caption(
+                text_embeddings,
+                cap_ori_lens[static_cast<std::size_t>(b)],
+                cap_padded_lens[static_cast<std::size_t>(b)],
+                caption_projected);
             std::copy(caption_projected.begin(), caption_projected.end(),
                       caption_projected_batched.begin() +
                           static_cast<std::ptrdiff_t>(b) *
@@ -698,7 +807,8 @@ std::vector<ImageResult> ZImagePipeline::generate_images(
 
             std::vector<float> rope_cos, rope_sin;
             compute_3d_rope(
-                cap_padded_len, layout.num_patches, layout.nh, layout.nw, rope_cos, rope_sin);
+                cap_padded_lens[static_cast<std::size_t>(b)], layout.num_patches,
+                layout.nh, layout.nw, rope_cos, rope_sin);
             std::copy(rope_cos.begin(), rope_cos.end(),
                       rope_cos_batched.begin() +
                           static_cast<std::ptrdiff_t>(b) *

--- a/src/runtime/models/z_image/pipeline.cpp
+++ b/src/runtime/models/z_image/pipeline.cpp
@@ -1,13 +1,16 @@
 #include "runtime/models/z_image/pipeline.h"
 
+#include "runtime/domains/diffusion/batch_utils.h"
 #include "runtime/domains/diffusion/diffusion_math.h"
 #include "runtime/domains/diffusion/diffusion_scheduler_helpers.h"
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstring>
 #include <iostream>
 #include <random>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -109,13 +112,17 @@ int32_t pad_to_next_multiple(int32_t value, int32_t multiple) {
 // Latent initialization
 // ---------------------------------------------------------------------------
 
-void initialize_latents(std::vector<float>& latents, int32_t seed) {
+void initialize_latents_data(float* data, std::size_t count, int32_t seed) {
     const auto normalized_seed = static_cast<std::mt19937::result_type>(seed >= 0 ? seed : 42);
     std::mt19937 gen(normalized_seed);
     std::normal_distribution<float> dist(0.0F, 1.0F);
-    for (auto& v : latents) {
-        v = dist(gen);
+    for (std::size_t i = 0; i < count; ++i) {
+        data[i] = dist(gen);
     }
+}
+
+void initialize_latents(std::vector<float>& latents, int32_t seed) {
+    initialize_latents_data(latents.data(), latents.size(), seed);
 }
 
 // ---------------------------------------------------------------------------
@@ -301,6 +308,64 @@ bool ZImagePipeline::run_denoiser(const std::vector<float>& hidden,
     const auto out_numel = dit_out.numel();
     output.resize(out_numel);
     std::memcpy(output.data(), dit_out.data, out_numel * sizeof(float));
+
+    return true;
+}
+
+bool ZImagePipeline::run_denoiser_batched(
+    const std::vector<float>& hidden, const std::vector<float>& encoder_hidden,
+    const std::vector<float>& temb, const std::vector<float>& cos_vals,
+    const std::vector<float>& sin_vals, int32_t batch_size, int32_t num_patches,
+    int32_t dit_dim, int32_t text_seq, int32_t freq_dim, int32_t total_seq,
+    int32_t head_dim, int32_t patch_dim, std::vector<float>& output) {
+    if (!denoiser_) {
+        std::cerr << "[z-image] No denoiser module\n";
+        return false;
+    }
+    if (batch_size < 1) {
+        std::cerr << "[z-image] Invalid denoiser batch size: " << batch_size << "\n";
+        return false;
+    }
+
+    TensorMap inputs;
+    inputs["hidden_states"] =
+        Tensor{const_cast<float*>(hidden.data()),
+               {static_cast<int64_t>(batch_size), static_cast<int64_t>(num_patches),
+                static_cast<int64_t>(dit_dim)},
+               DType::kFloat32};
+    inputs["encoder_hidden_states"] =
+        Tensor{const_cast<float*>(encoder_hidden.data()),
+               {static_cast<int64_t>(batch_size), static_cast<int64_t>(text_seq),
+                static_cast<int64_t>(dit_dim)},
+               DType::kFloat32};
+    inputs["timestep_embedding"] =
+        Tensor{const_cast<float*>(temb.data()),
+               {static_cast<int64_t>(batch_size), 1, static_cast<int64_t>(freq_dim)},
+               DType::kFloat32};
+    inputs["rotary_cos"] =
+        Tensor{const_cast<float*>(cos_vals.data()),
+               {static_cast<int64_t>(batch_size), static_cast<int64_t>(total_seq),
+                static_cast<int64_t>(head_dim)},
+               DType::kFloat32};
+    inputs["rotary_sin"] =
+        Tensor{const_cast<float*>(sin_vals.data()),
+               {static_cast<int64_t>(batch_size), static_cast<int64_t>(total_seq),
+                static_cast<int64_t>(head_dim)},
+               DType::kFloat32};
+
+    auto outputs = denoiser_->forward(inputs);
+
+    const auto& dit_out = outputs["output"];
+    const auto expected = static_cast<std::size_t>(batch_size) *
+                          static_cast<std::size_t>(num_patches) *
+                          static_cast<std::size_t>(patch_dim);
+    if (dit_out.numel() < expected) {
+        std::cerr << "[z-image] DiT output too small: got " << dit_out.numel()
+                  << " floats, expected at least " << expected << "\n";
+        return false;
+    }
+    output.resize(expected);
+    std::memcpy(output.data(), dit_out.data, expected * sizeof(float));
 
     return true;
 }
@@ -522,6 +587,246 @@ void ZImagePipeline::unpatchify_2d(const std::vector<float>& patches, int32_t c,
             }
         }
     }
+}
+
+std::vector<ImageResult> ZImagePipeline::generate_images(
+    const std::vector<std::string>& prompts, const std::vector<int32_t>& per_sample_seeds,
+    const GenerateConfig& cfg) {
+    if (prompts.empty())
+        return {};
+    if (!per_sample_seeds.empty() && per_sample_seeds.size() != prompts.size()) {
+        throw std::invalid_argument("per_sample_seeds size must match prompts size");
+    }
+
+    std::vector<int32_t> resolved_seeds;
+    if (!per_sample_seeds.empty()) {
+        resolved_seeds = per_sample_seeds;
+    } else if (prompts.size() == 1U) {
+        resolved_seeds = {cfg.seed};
+    } else {
+        const std::uint64_t global_seed =
+            cfg.seed >= 0 ? static_cast<std::uint64_t>(cfg.seed) : 42ULL;
+        resolved_seeds = diffusion::derive_per_sample_seeds(
+            global_seed, static_cast<int>(prompts.size()));
+    }
+
+    if (!denoiser_ || config_.max_batch_size.dit <= 1 ||
+        denoiser_->input_rank("hidden_states") != 3) {
+        return IPipeline::generate_images(prompts, resolved_seeds, cfg);
+    }
+
+    int32_t cap = std::max(config_.max_batch_size.dit, 1);
+    const auto profile_max = denoiser_->input_profile_shape(
+        "hidden_states", denoiser_->profile_idx(), ProfileShapeSelector::kMax);
+    if (!profile_max.empty() && profile_max[0] > 0) {
+        cap = std::min(cap, static_cast<int32_t>(profile_max[0]));
+    }
+    if (cap <= 1)
+        return IPipeline::generate_images(prompts, resolved_seeds, cfg);
+
+    const int32_t num_inference_steps =
+        resolve_requested_steps(cfg.num_steps, config_.num_inference_steps, true);
+    const float guidance_scale =
+        resolve_requested_guidance(cfg.guidance_scale, config_.guidance_scale);
+    (void)guidance_scale; // Z-Image does not use CFG
+
+    const ZImageLayout layout = make_layout(config_);
+    if (!z_weights_.valid) {
+        std::cerr << "[z-image] WARNING: Z-Image preprocessor weights not loaded.\n";
+        return {};
+    }
+    if (!tokenizer_) {
+        std::cerr << "[z-image] No tokenizer available\n";
+        return {};
+    }
+    if (!vae_) {
+        std::cerr << "[z-image] No VAE decoder module\n";
+        return {};
+    }
+
+    const auto chunks = diffusion::plan_chunks(static_cast<int>(prompts.size()), cap);
+    std::vector<ImageResult> results;
+    results.reserve(prompts.size());
+
+    const auto latent_size = static_cast<std::size_t>(layout.z_dim) *
+                             static_cast<std::size_t>(layout.h_lat) *
+                             static_cast<std::size_t>(layout.w_lat);
+    const auto patch_size = static_cast<std::size_t>(layout.num_patches) *
+                            static_cast<std::size_t>(layout.patch_dim);
+    const auto hidden_size = static_cast<std::size_t>(layout.num_patches) *
+                             static_cast<std::size_t>(layout.dit_dim);
+    const auto caption_size = static_cast<std::size_t>(layout.text_seq) *
+                              static_cast<std::size_t>(layout.dit_dim);
+    const auto rope_size =
+        static_cast<std::size_t>(layout.num_patches + layout.text_seq) *
+        static_cast<std::size_t>(layout.head_dim);
+    const int32_t total_seq = layout.num_patches + layout.text_seq;
+
+    std::size_t prompt_offset = 0;
+    for (int32_t chunk_size : chunks) {
+        const int32_t batch = chunk_size;
+        std::cerr << "[z-image] Batched DiT chunk B=" << batch << "/" << cap
+                  << ", prompts " << prompt_offset << ".."
+                  << (prompt_offset + static_cast<std::size_t>(batch) - 1U) << "\n";
+
+        std::vector<float> caption_projected_batched(
+            static_cast<std::size_t>(batch) * caption_size);
+        std::vector<float> rope_cos_batched(static_cast<std::size_t>(batch) * rope_size);
+        std::vector<float> rope_sin_batched(static_cast<std::size_t>(batch) * rope_size);
+        std::vector<float> latents(static_cast<std::size_t>(batch) * latent_size);
+
+        for (int32_t b = 0; b < batch; ++b) {
+            const std::size_t sample_idx = prompt_offset + static_cast<std::size_t>(b);
+            const std::string prepared = apply_chat_template(prompts[sample_idx]);
+            const std::vector<int32_t> input_ids = tokenizer_->encode(prepared);
+
+            std::vector<float> text_embeddings;
+            if (!run_text_encoder(input_ids, text_embeddings)) {
+                std::cerr << "[z-image] Text encoder failed for sample " << sample_idx << "\n";
+                return {};
+            }
+
+            const int32_t cap_ori_len = count_non_pad_tokens(input_ids);
+            const int32_t cap_padded_len = pad_to_next_multiple(cap_ori_len, kSeqMultipleOf);
+
+            std::vector<float> caption_projected;
+            project_caption(text_embeddings, cap_ori_len, cap_padded_len, caption_projected);
+            std::copy(caption_projected.begin(), caption_projected.end(),
+                      caption_projected_batched.begin() +
+                          static_cast<std::ptrdiff_t>(b) *
+                              static_cast<std::ptrdiff_t>(caption_size));
+
+            std::vector<float> rope_cos, rope_sin;
+            compute_3d_rope(
+                cap_padded_len, layout.num_patches, layout.nh, layout.nw, rope_cos, rope_sin);
+            std::copy(rope_cos.begin(), rope_cos.end(),
+                      rope_cos_batched.begin() +
+                          static_cast<std::ptrdiff_t>(b) *
+                              static_cast<std::ptrdiff_t>(rope_size));
+            std::copy(rope_sin.begin(), rope_sin.end(),
+                      rope_sin_batched.begin() +
+                          static_cast<std::ptrdiff_t>(b) *
+                              static_cast<std::ptrdiff_t>(rope_size));
+
+            initialize_latents_data(
+                latents.data() + static_cast<std::size_t>(b) * latent_size,
+                latent_size, resolved_seeds[sample_idx]);
+        }
+
+        FlowMatchEulerState scheduler;
+        scheduler.shift = config_.flow_shift;
+        scheduler.use_zero_sigma_min = true;
+        scheduler.set_timesteps(num_inference_steps);
+
+        std::vector<float> temb_one;
+        std::vector<float> temb_batched(static_cast<std::size_t>(batch) *
+                                        static_cast<std::size_t>(config_.freq_dim));
+        std::vector<float> sample_latents;
+        std::vector<float> patches;
+        std::vector<float> hidden(static_cast<std::size_t>(batch) * hidden_size);
+        std::vector<float> denoiser_output;
+        std::vector<float> sample_noise_pred;
+        std::vector<float> noise_pred(static_cast<std::size_t>(batch) * latent_size);
+
+        for (int32_t step = 0; step < num_inference_steps; ++step) {
+            const float raw_timestep = scheduler.timesteps[static_cast<std::size_t>(step)];
+            const float t_for_embedding = 1000.0F - raw_timestep;
+
+            const int32_t half = config_.freq_dim / 2;
+            std::vector<float> sinusoidal(static_cast<std::size_t>(config_.freq_dim));
+            for (int32_t i = 0; i < half; ++i) {
+                const float freq = std::exp(-std::log(10000.0F) * static_cast<float>(i) /
+                                            static_cast<float>(half));
+                sinusoidal[static_cast<std::size_t>(i)] = std::cos(t_for_embedding * freq);
+                sinusoidal[static_cast<std::size_t>(i + half)] = std::sin(t_for_embedding * freq);
+            }
+
+            const int32_t mid_dim =
+                static_cast<int32_t>(z_weights_.t_embedder_mlp_0_bias.size());
+            std::vector<float> h1(static_cast<std::size_t>(mid_dim));
+            cpu_matmul_bias(sinusoidal.data(), z_weights_.t_embedder_mlp_0_weight.data(),
+                            z_weights_.t_embedder_mlp_0_bias.data(), h1.data(), 1,
+                            config_.freq_dim, mid_dim);
+            cpu_silu_inplace(h1.data(), static_cast<std::size_t>(mid_dim));
+
+            temb_one.resize(static_cast<std::size_t>(config_.freq_dim));
+            cpu_matmul_bias(h1.data(), z_weights_.t_embedder_mlp_2_weight.data(),
+                            z_weights_.t_embedder_mlp_2_bias.data(), temb_one.data(), 1,
+                            mid_dim, config_.freq_dim);
+            for (int32_t b = 0; b < batch; ++b) {
+                std::copy(temb_one.begin(), temb_one.end(),
+                          temb_batched.begin() +
+                              static_cast<std::ptrdiff_t>(b) *
+                                  static_cast<std::ptrdiff_t>(config_.freq_dim));
+            }
+
+            for (int32_t b = 0; b < batch; ++b) {
+                const auto* sample_latents_ptr =
+                    latents.data() + static_cast<std::size_t>(b) * latent_size;
+                sample_latents.assign(sample_latents_ptr, sample_latents_ptr + latent_size);
+                patchify_2d(sample_latents, layout.z_dim, layout.h_lat, layout.w_lat, patches);
+
+                cpu_matmul_bias(patches.data(), z_weights_.x_embed_weight.data(),
+                                z_weights_.x_embed_bias.data(),
+                                hidden.data() + static_cast<std::size_t>(b) * hidden_size,
+                                layout.num_patches, layout.patch_dim, layout.dit_dim);
+            }
+
+            if (!run_denoiser_batched(
+                    hidden, caption_projected_batched, temb_batched, rope_cos_batched,
+                    rope_sin_batched, batch, layout.num_patches, layout.dit_dim,
+                    layout.text_seq, config_.freq_dim, total_seq, layout.head_dim,
+                    layout.patch_dim, denoiser_output)) {
+                std::cerr << "[z-image] Batched DiT failed at step " << step << "\n";
+                return {};
+            }
+
+            for (int32_t b = 0; b < batch; ++b) {
+                const auto* sample_patches_ptr =
+                    denoiser_output.data() + static_cast<std::size_t>(b) * patch_size;
+                std::vector<float> sample_patches(sample_patches_ptr,
+                                                  sample_patches_ptr + patch_size);
+                unpatchify_2d(
+                    sample_patches, layout.z_dim, layout.h_lat, layout.w_lat,
+                    sample_noise_pred);
+                std::copy(sample_noise_pred.begin(), sample_noise_pred.end(),
+                          noise_pred.begin() +
+                              static_cast<std::ptrdiff_t>(b) *
+                                  static_cast<std::ptrdiff_t>(latent_size));
+            }
+
+            negate_inplace(noise_pred);
+            scheduler.step(noise_pred.data(), latents.data(), latents.data(), latents.size(), step);
+            log_step_stats(step, num_inference_steps, raw_timestep, latents);
+        }
+
+        for (int32_t b = 0; b < batch; ++b) {
+            const auto* sample_latents_ptr =
+                latents.data() + static_cast<std::size_t>(b) * latent_size;
+            sample_latents.assign(sample_latents_ptr, sample_latents_ptr + latent_size);
+            denormalize_latents(sample_latents);
+
+            const int32_t h_out = layout.h_lat * 8;
+            const int32_t w_out = layout.w_lat * 8;
+
+            TensorMap vae_inputs;
+            vae_inputs["latent_input"] =
+                Tensor{sample_latents.data(),
+                       {1, static_cast<int64_t>(layout.z_dim),
+                        static_cast<int64_t>(layout.h_lat),
+                        static_cast<int64_t>(layout.w_lat)},
+                       DType::kFloat32};
+
+            auto vae_outputs = vae_->forward(vae_inputs);
+            const auto& vae_out = vae_outputs["decoder_output"];
+            const auto* raw_pixels = static_cast<const float*>(vae_out.data);
+            results.push_back(convert_vae_output(raw_pixels, h_out, w_out));
+        }
+
+        prompt_offset += static_cast<std::size_t>(batch);
+    }
+
+    return results;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/runtime/models/z_image/pipeline.cpp
+++ b/src/runtime/models/z_image/pipeline.cpp
@@ -109,8 +109,9 @@ int32_t pad_to_next_multiple(int32_t value, int32_t multiple) {
 // Latent initialization
 // ---------------------------------------------------------------------------
 
-void initialize_latents(std::vector<float>& latents) {
-    std::mt19937 gen(42);
+void initialize_latents(std::vector<float>& latents, int32_t seed) {
+    const auto normalized_seed = static_cast<std::mt19937::result_type>(seed >= 0 ? seed : 42);
+    std::mt19937 gen(normalized_seed);
     std::normal_distribution<float> dist(0.0F, 1.0F);
     for (auto& v : latents) {
         v = dist(gen);
@@ -587,7 +588,7 @@ ImageResult ZImagePipeline::generate_image(const std::string& prompt, const Gene
                              static_cast<std::size_t>(layout.h_lat) *
                              static_cast<std::size_t>(layout.w_lat);
     std::vector<float> latents(latent_size);
-    initialize_latents(latents);
+    initialize_latents(latents, cfg.seed);
 
     // ── 7. Create FlowMatchEuler scheduler ──
     FlowMatchEulerState scheduler;

--- a/src/runtime/models/z_image/pipeline.h
+++ b/src/runtime/models/z_image/pipeline.h
@@ -44,6 +44,10 @@ class ZImagePipeline final : public IPipeline {
     ~ZImagePipeline() override;
 
     ImageResult generate_image(const std::string& prompt, const GenerateConfig& cfg = {}) override;
+    std::vector<ImageResult> generate_images(
+        const std::vector<std::string>& prompts,
+        const std::vector<int32_t>& per_sample_seeds,
+        const GenerateConfig& cfg = {}) override;
 
     const char* model_id() const override { return model_id_.c_str(); }
     const char* pipeline_type() const override { return "ZImagePipeline"; }
@@ -54,6 +58,16 @@ class ZImagePipeline final : public IPipeline {
     bool run_denoiser(const std::vector<float>& hidden, const std::vector<float>& encoder_hidden,
                       const std::vector<float>& temb, const std::vector<float>& cos_vals,
                       const std::vector<float>& sin_vals, std::vector<float>& output);
+    bool run_denoiser_batched(const std::vector<float>& hidden,
+                              const std::vector<float>& encoder_hidden,
+                              const std::vector<float>& temb,
+                              const std::vector<float>& cos_vals,
+                              const std::vector<float>& sin_vals,
+                              int32_t batch_size, int32_t num_patches,
+                              int32_t dit_dim, int32_t text_seq,
+                              int32_t freq_dim, int32_t total_seq,
+                              int32_t head_dim, int32_t patch_dim,
+                              std::vector<float>& output);
 
     void project_caption(const std::vector<float>& text_emb, int32_t actual_len, int32_t padded_len,
                          std::vector<float>& projected) const;

--- a/src/runtime/models/z_image/pipeline.h
+++ b/src/runtime/models/z_image/pipeline.h
@@ -55,6 +55,8 @@ class ZImagePipeline final : public IPipeline {
   private:
     bool run_text_encoder(const std::vector<int32_t>& input_ids,
                           std::vector<float>& text_embeddings);
+    bool run_text_encoder_batched(const std::vector<std::vector<int32_t>>& input_ids_batch,
+                                  std::vector<float>& text_embeddings);
     bool run_denoiser(const std::vector<float>& hidden, const std::vector<float>& encoder_hidden,
                       const std::vector<float>& temb, const std::vector<float>& cos_vals,
                       const std::vector<float>& sin_vals, std::vector<float>& output);

--- a/src/runtime/plugins/shared/diffusion_helpers.cpp
+++ b/src/runtime/plugins/shared/diffusion_helpers.cpp
@@ -70,6 +70,10 @@ DiffusionParts load_diffusion_parts(IBackend* backend, const BundleFile& bundle,
     if (pw && !pw->empty())
         parts.weights = parse_preprocessor_weights(*pw);
 
+    parts.config.max_batch_size.dit = bundle.info.max_batch_size.dit;
+    parts.config.max_batch_size.text_encoder = bundle.info.max_batch_size.text_encoder;
+    parts.config.max_batch_size.vae = bundle.info.max_batch_size.vae;
+
     parts.tokenizer = create_tokenizer_from_bundle(bundle);
     return parts;
 }

--- a/tensorrt_model_connect/tensorrt_model_connect/bundle_writer.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/bundle_writer.py
@@ -48,6 +48,9 @@ class BundleInfo:
     quantization: str = "none"
     tokenizer_add_special_tokens: bool = False
     io_map: dict | None = None  # tensor name mapping; None = TRT API defaults
+    # Optional diffusion batch caps. Missing means old-bundle behavior: every
+    # component is treated as batch-cap 1 by the runtime.
+    max_batch_size: dict[str, int] | None = None
     # Namespaced defaults produced at build time. When non-empty, serialized
     # into the header as `defaults: {namespace: {field: value, ...}}` and
     # read back at runtime as the BUNDLE_DEFAULT layer — the lowest-priority
@@ -101,6 +104,8 @@ def write_bundle(
            if info.quantization != "none" else {}),
         "tokenizer_add_special_tokens": int(info.tokenizer_add_special_tokens),
         **({"io_map": info.io_map} if info.io_map else {}),
+        **({"max_batch_size": dict(info.max_batch_size)}
+           if info.max_batch_size is not None else {}),
         **({"defaults": info.defaults} if info.defaults else {}),
         "sections": {
             s["name"]: {"offset": s["offset"], "size": s["size"]}
@@ -115,3 +120,19 @@ def write_bundle(
         f.write(header_json)
         for s in sections:
             f.write(s.data)
+
+
+def read_bundle_header(path: str | Path) -> dict[str, Any]:
+    """Read only the JSON header from a .trtfb bundle."""
+    with open(path, "rb") as f:
+        magic = f.read(8)
+        if magic != BUNDLE_MAGIC:
+            raise ValueError(f"Bad bundle magic: {magic!r}")
+        header_len_data = f.read(8)
+        if len(header_len_data) != 8:
+            raise ValueError("Bundle truncated before header length")
+        header_len = struct.unpack("<Q", header_len_data)[0]
+        header_data = f.read(header_len)
+        if len(header_data) != header_len:
+            raise ValueError("Bundle truncated before full header")
+    return json.loads(header_data.decode("utf-8"))

--- a/tensorrt_model_connect/tensorrt_model_connect/cli.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/cli.py
@@ -157,6 +157,7 @@ def _cmd_build(args: argparse.Namespace) -> int:
             max_cache_length=args.max_cache_length,
             dynamic_kv_cache=getattr(args, "dynamic_kv_cache", False),
             dynamic_kv_profile_rows_override=getattr(args, "dynamic_kv_profile_rows", None),
+            max_batch_size=getattr(args, "max_batch_size", 1),
             precision=args.precision,
             quantize=quantize,
             quant_scales=args.quant_scales,
@@ -546,6 +547,10 @@ def main() -> None:
                          help="KV cache length (default: 256)")
     build_p.add_argument("--dynamic-kv-cache", action="store_true",
                          help="Build decoder bundles with runtime-resizable KV cache support")
+    build_p.add_argument(
+        "--max-batch-size", type=int, default=1,
+        help="Reserved diffusion engine batch cap. Only 1 is accepted until "
+             "dynamic-batch component builders are enabled. Default: 1.")
     build_p.add_argument(
         "--dynamic-kv-profile-rows",
         type=_parse_profile_rows,

--- a/tensorrt_model_connect/tensorrt_model_connect/cli.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/cli.py
@@ -469,9 +469,26 @@ def _cmd_inspect(args: argparse.Namespace) -> int:
             ("Precision", "precision"),
             ("Quantization", "quantization"),
             ("Engine backend", "engine_backend"),
+            ("Runtime strategy", "runtime_strategy"),
         ]
         for label, key in fields:
             print(f"{label + ':':<20} {header.get(key, '')}")
+
+        max_batch = header.get("max_batch_size")
+        runtime_strategy = str(header.get("runtime_strategy", "") or "")
+        family = str(header.get("family", "") or "")
+        is_diffusion = (
+            runtime_strategy.startswith("diffusion") or "diffusion" in family
+        )
+        if max_batch is not None or is_diffusion:
+            max_batch = max_batch or {}
+            dit = int(max_batch.get("dit", 1))
+            text_encoder = int(max_batch.get("text_encoder", 1))
+            vae = int(max_batch.get("vae", 1))
+            print(
+                f"{'Max batch size:':<20} "
+                f"dit={dit} text_encoder={text_encoder} vae={vae}"
+            )
 
         sections = header.get("sections", {})
         if sections:
@@ -549,8 +566,9 @@ def main() -> None:
                          help="Build decoder bundles with runtime-resizable KV cache support")
     build_p.add_argument(
         "--max-batch-size", type=int, default=1,
-        help="Reserved diffusion engine batch cap. Only 1 is accepted until "
-             "dynamic-batch component builders are enabled. Default: 1.")
+        help="Diffusion DiT engine batch cap for families that support "
+             "dynamic-batch DiT engines. Text encoders and VAE decode remain "
+             "sliced at batch 1. Default: 1.")
     build_p.add_argument(
         "--dynamic-kv-profile-rows",
         type=_parse_profile_rows,

--- a/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
@@ -1121,14 +1121,16 @@ def _build_diffusion_bundle(
         raise ValueError(f"--max-batch-size must be >= 1 (got {max_batch_size})")
     supports_dynamic_batch_dit = bool(
         getattr(plugin, "supports_dynamic_batch_dit", False))
+    supports_dynamic_batch_text_encoder = bool(
+        getattr(plugin, "supports_dynamic_batch_text_encoder", False))
     if max_batch_size != 1 and not supports_dynamic_batch_dit:
         raise NotImplementedError(
             "--max-batch-size > 1 requires dynamic-batch diffusion component "
-            "builders, which are not enabled in this implementation slice yet"
+            f"builders, which are not supported for {plugin.name}"
         )
     diffusion_max_batch_size = {
         "dit": int(max_batch_size if supports_dynamic_batch_dit else 1),
-        "text_encoder": 1,
+        "text_encoder": int(max_batch_size if supports_dynamic_batch_text_encoder else 1),
         "vae": 1,
     }
 

--- a/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
@@ -1119,16 +1119,16 @@ def _build_diffusion_bundle(
     print(f"[trtmc-build] Family: {plugin.name}", file=sys.stderr)
     if max_batch_size < 1:
         raise ValueError(f"--max-batch-size must be >= 1 (got {max_batch_size})")
-    if max_batch_size != 1:
+    supports_dynamic_batch_dit = bool(
+        getattr(plugin, "supports_dynamic_batch_dit", False))
+    if max_batch_size != 1 and not supports_dynamic_batch_dit:
         raise NotImplementedError(
             "--max-batch-size > 1 requires dynamic-batch diffusion component "
             "builders, which are not enabled in this implementation slice yet"
         )
     diffusion_max_batch_size = {
-        "dit": int(max_batch_size),
-        "text_encoder": int(
-            max_batch_size if max_batch_size == 1 else min(max_batch_size * 2, 8)
-        ),
+        "dit": int(max_batch_size if supports_dynamic_batch_dit else 1),
+        "text_encoder": 1,
         "vae": 1,
     }
 
@@ -1198,6 +1198,8 @@ def _build_diffusion_bundle(
             build_components_kwargs["precision"] = precision
         if _call_supports_kwarg(build_components, "build_timing"):
             build_components_kwargs["build_timing"] = build_timing
+        if _call_supports_kwarg(build_components, "max_batch_size"):
+            build_components_kwargs["max_batch_size"] = max_batch_size
         components = build_components(
             str(model_dir_path), config, weights, **build_components_kwargs)
     finally:

--- a/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
@@ -166,6 +166,47 @@ def _sanitize_dynamic_kv_profile_rows(
     return sanitized
 
 
+def add_dynamic_batch_profile(
+    builder,
+    config,
+    network,
+    *,
+    input_names: list[str],
+    max_batch: int,
+    opt_batch: int,
+    static_shape: dict[str, tuple[int, ...]],
+) -> None:
+    """Attach one TensorRT profile with a dynamic leading batch dimension.
+
+    ``static_shape`` stores each input's shape without the leading batch dim.
+    The attached profile uses ``kMIN=1``, ``kOPT=opt_batch``, and
+    ``kMAX=max_batch`` for every named input.
+    """
+    del network  # The profile API is name-based; keep the arg for call-site clarity.
+    if max_batch < 1:
+        raise ValueError(f"max_batch must be >= 1 (got {max_batch})")
+    if not (1 <= opt_batch <= max_batch):
+        raise ValueError(
+            "opt_batch must satisfy 1 <= opt_batch <= max_batch "
+            f"(got opt_batch={opt_batch}, max_batch={max_batch})"
+        )
+
+    missing = [name for name in input_names if name not in static_shape]
+    if missing:
+        raise KeyError(f"static_shape missing entries for: {', '.join(missing)}")
+
+    profile = builder.create_optimization_profile()
+    for name in input_names:
+        tail = tuple(static_shape[name])
+        profile.set_shape(
+            name,
+            min=(1, *tail),
+            opt=(opt_batch, *tail),
+            max=(max_batch, *tail),
+        )
+    config.add_optimization_profile(profile)
+
+
 def _raise_friendly_download_error(model_id: str, exc: Exception) -> None:
     """Re-raise HF download errors with clear, actionable messages."""
     exc_type = type(exc).__name__
@@ -577,6 +618,7 @@ def build_bundle(
     # config.raw, same passthrough pattern.
     audio_magpie_max_source_positions: int = 0,
     diffusion_overrides: dict | None = None,
+    max_batch_size: int = 1,
     build_timing_path: str | None = None,
 ) -> None:
     """Full pipeline: load HF model → build TRT engine → write .trtfb bundle.
@@ -617,6 +659,7 @@ def build_bundle(
             fp8_scales=fp8_scales, save_fp8_scales=save_fp8_scales,
             rtx=rtx,
             diffusion_overrides=diffusion_overrides,
+            max_batch_size=max_batch_size,
             build_timing=build_timing)
         return
 
@@ -1039,6 +1082,7 @@ def _build_diffusion_bundle(
     save_fp8_scales: str | None = None,
     rtx: bool = False,
     diffusion_overrides: dict | None = None,
+    max_batch_size: int = 1,
     build_timing: dict | None = None,
 ) -> None:
     """Build a diffusion model bundle from a diffusers-format directory."""
@@ -1073,6 +1117,20 @@ def _build_diffusion_bundle(
     )
 
     print(f"[trtmc-build] Family: {plugin.name}", file=sys.stderr)
+    if max_batch_size < 1:
+        raise ValueError(f"--max-batch-size must be >= 1 (got {max_batch_size})")
+    if max_batch_size != 1:
+        raise NotImplementedError(
+            "--max-batch-size > 1 requires dynamic-batch diffusion component "
+            "builders, which are not enabled in this implementation slice yet"
+        )
+    diffusion_max_batch_size = {
+        "dit": int(max_batch_size),
+        "text_encoder": int(
+            max_batch_size if max_batch_size == 1 else min(max_batch_size * 2, 8)
+        ),
+        "vae": 1,
+    }
 
     # Load weights (lightweight — just paths for diffusion)
     t1 = time.monotonic()
@@ -1308,6 +1366,7 @@ def _build_diffusion_bundle(
         precision=precision,
         max_cache_length=max_cache_length,
         tokenizer_add_special_tokens=tokenizer_add_special_tokens,
+        max_batch_size=diffusion_max_batch_size,
     )
 
     write_t0 = time.monotonic()
@@ -1346,6 +1405,7 @@ def build(
     triattention_disable_trig: bool = False,
     audio_magpie_max_source_positions: int = 0,
     diffusion_overrides: dict | None = None,
+    max_batch_size: int = 1,
     build_timing_path: str | None = None,
 ) -> None:
     """Build a .trtfb bundle from a HuggingFace model ID or local path.
@@ -1386,4 +1446,5 @@ def build(
                  triattention_disable_trig=triattention_disable_trig,
                  audio_magpie_max_source_positions=audio_magpie_max_source_positions,
                  diffusion_overrides=diffusion_overrides,
+                 max_batch_size=max_batch_size,
                  build_timing_path=build_timing_path)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/flux/flux_dit_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/flux/flux_dit_builder.py
@@ -46,9 +46,27 @@ def build_flux_dit_engine(
     text_seq_len: int = 512,
     mlp_ratio: float = 4.0,
     eps: float = 1e-6,
+    max_batch_size: int = 1,
+    opt_batch_size: int | None = None,
     verbose: bool = False,
 ) -> bytes:
     """Build FLUX DiT denoiser TRT engine plan."""
+    if max_batch_size > 1:
+        return _build_flux_dit_engine_batched(
+            weights,
+            dim=dim,
+            num_heads=num_heads,
+            num_layers=num_layers,
+            num_single_layers=num_single_layers,
+            num_img_tokens=num_img_tokens,
+            text_seq_len=text_seq_len,
+            mlp_ratio=mlp_ratio,
+            eps=eps,
+            max_batch_size=max_batch_size,
+            opt_batch_size=opt_batch_size,
+            verbose=verbose,
+        )
+
     head_dim = dim // num_heads
     ffn_dim = int(dim * mlp_ratio)  # For GELU-approximate FFN
     total_seq = text_seq_len + num_img_tokens
@@ -433,6 +451,457 @@ def _gelu_ffn(network, inp, dim, weights, prefix):
     if fc2_b is not None:
         fc2 = graph_ops.add_bias_sum(network, fc2, dim, fc2_b)
     return fc2
+
+
+def _dynamic_batch_shape(network, reference, tail: tuple[int, ...]):
+    """Shape tensor [B, *tail] using dim 0 from a dynamic-batch tensor."""
+    ref_shape = network.add_shape(reference).get_output(0)
+    batch = network.add_slice(ref_shape, start=(0,), shape=(1,), stride=(1,))
+    tail_t = graph_ops.add_constant(
+        network, (len(tail),), np.asarray(tail, dtype=np.int64), dtype=np.int64)
+    target = network.add_concatenation([batch.get_output(0), tail_t])
+    target.axis = 0
+    return target.get_output(0)
+
+
+def _slice_batched_vector(network, x, start_width: int, width: int):
+    """Slice [B, D] along D while preserving runtime-dynamic B."""
+    s = network.add_slice(
+        x, start=(0, start_width), shape=(0, 0), stride=(1, 1))
+    s.set_input(2, _dynamic_batch_shape(network, x, (width,)))
+    return s.get_output(0)
+
+
+def _slice_batched_sequence(network, x, start_seq: int, length: int, width: int):
+    """Slice [B, S, D] along S while preserving runtime-dynamic B."""
+    s = network.add_slice(
+        x, start=(0, start_seq, 0), shape=(0, 0, 0), stride=(1, 1, 1))
+    s.set_input(2, _dynamic_batch_shape(network, x, (length, width)))
+    return s.get_output(0)
+
+
+def _slice_batched_rope_half(network, rope, seq_len: int, half: int):
+    """Slice interleaved full-dim RoPE cache [B, S, D] to [B, S, D/2]."""
+    s = network.add_slice(
+        rope, start=(0, 0, 0), shape=(0, 0, 0), stride=(1, 1, 2))
+    s.set_input(2, _dynamic_batch_shape(network, rope, (seq_len, half)))
+    return s.get_output(0)
+
+
+def _slice_batched_complex_part(network, x, seq_len: int, num_heads: int,
+                                half: int, complex_index: int):
+    """Slice real/imag part from [B, S, H, D/2, 2] to [B, S, H, D/2]."""
+    s = network.add_slice(
+        x, start=(0, 0, 0, 0, complex_index), shape=(0, 0, 0, 0, 0),
+        stride=(1, 1, 1, 1, 1))
+    s.set_input(2, _dynamic_batch_shape(network, x, (seq_len, num_heads, half, 1)))
+    r = network.add_shuffle(s.get_output(0))
+    r.reshape_dims = (-1, seq_len, num_heads, half)
+    return r.get_output(0)
+
+
+def _reshape_batched_rows_to_heads_4d(network, x, num_heads: int, head_dim: int,
+                                      seq_len: int):
+    """[B, S, H*D] -> [B, H, S, D]."""
+    r = network.add_shuffle(x)
+    r.reshape_dims = (-1, seq_len, num_heads, head_dim)
+    r.second_transpose = trt.Permutation([0, 2, 1, 3])
+    return r.get_output(0)
+
+
+def _reshape_heads_4d_to_batched_rows(network, x, num_heads: int, head_dim: int,
+                                      seq_len: int):
+    """[B, H, S, D] -> [B, S, H*D]."""
+    r = network.add_shuffle(x)
+    r.first_transpose = trt.Permutation([0, 2, 1, 3])
+    r.reshape_dims = (-1, seq_len, num_heads * head_dim)
+    return r.get_output(0)
+
+
+def _mha_batched(network, q, k, v, num_heads: int, head_dim: int, seq_len: int):
+    """Multi-head attention for [B, S, H*D] tensors."""
+    q_4d = _reshape_batched_rows_to_heads_4d(network, q, num_heads, head_dim, seq_len)
+    k_4d = _reshape_batched_rows_to_heads_4d(network, k, num_heads, head_dim, seq_len)
+    v_4d = _reshape_batched_rows_to_heads_4d(network, v, num_heads, head_dim, seq_len)
+    ctx_4d = graph_ops.add_attention_core(
+        network, q_4d, k_4d, v_4d, causal=False, mask=None,
+        scale=float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0)
+    return _reshape_heads_4d_to_batched_rows(network, ctx_4d, num_heads, head_dim, seq_len)
+
+
+def _apply_rope_batched_from_full_cache(network, x, cos_t, sin_t, num_heads: int,
+                                        head_dim: int, seq_len: int):
+    """Apply interleaved RoPE to [B, S, H*D] with [B, S, D] caches."""
+    half = head_dim // 2
+    x_pairs_r = network.add_shuffle(x)
+    x_pairs_r.reshape_dims = (-1, seq_len, num_heads, half, 2)
+    x_pairs = x_pairs_r.get_output(0)
+
+    x_real = _slice_batched_complex_part(network, x_pairs, seq_len, num_heads, half, 0)
+    x_imag = _slice_batched_complex_part(network, x_pairs, seq_len, num_heads, half, 1)
+
+    cos_half = _slice_batched_rope_half(network, cos_t, seq_len, half)
+    sin_half = _slice_batched_rope_half(network, sin_t, seq_len, half)
+    cos_4d = network.add_shuffle(cos_half)
+    cos_4d.reshape_dims = (-1, seq_len, 1, half)
+    sin_4d = network.add_shuffle(sin_half)
+    sin_4d.reshape_dims = (-1, seq_len, 1, half)
+
+    r_cos = network.add_elementwise(
+        x_real, cos_4d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    i_sin = network.add_elementwise(
+        x_imag, sin_4d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    new_real = network.add_elementwise(
+        r_cos, i_sin, trt.ElementWiseOperation.SUB).get_output(0)
+
+    r_sin = network.add_elementwise(
+        x_real, sin_4d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    i_cos = network.add_elementwise(
+        x_imag, cos_4d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    new_imag = network.add_elementwise(
+        r_sin, i_cos, trt.ElementWiseOperation.SUM).get_output(0)
+
+    nr = network.add_shuffle(new_real)
+    nr.reshape_dims = (-1, seq_len, num_heads, half, 1)
+    ni = network.add_shuffle(new_imag)
+    ni.reshape_dims = (-1, seq_len, num_heads, half, 1)
+    cat = network.add_concatenation([nr.get_output(0), ni.get_output(0)])
+    cat.axis = 4
+
+    flat = network.add_shuffle(cat.get_output(0))
+    flat.reshape_dims = (-1, seq_len, num_heads * head_dim)
+    return flat.get_output(0)
+
+
+def _layer_norm_last_dim_no_affine_batched(network, x, eps_t):
+    """LayerNorm without affine over final dim for [B, S, D]."""
+    mean = network.add_reduce(x, trt.ReduceOperation.AVG, 1 << 2, keep_dims=True)
+    centered = network.add_elementwise(
+        x, mean.get_output(0), trt.ElementWiseOperation.SUB).get_output(0)
+    sq = network.add_elementwise(centered, centered, trt.ElementWiseOperation.PROD)
+    var = network.add_reduce(sq.get_output(0), trt.ReduceOperation.AVG, 1 << 2,
+                             keep_dims=True)
+    var_eps = network.add_elementwise(var.get_output(0), eps_t, trt.ElementWiseOperation.SUM)
+    std = network.add_unary(var_eps.get_output(0), trt.UnaryOperation.SQRT)
+    inv_std = network.add_unary(std.get_output(0), trt.UnaryOperation.RECIP)
+    return network.add_elementwise(
+        centered, inv_std.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def _matmul_bias_batched(network, inp, in_dim, out_dim, weight, bias):
+    """Matmul + bias for [B, in_dim] -> [B, out_dim]."""
+    out = graph_ops.add_matmul_rhs_constant(network, inp, in_dim, out_dim, weight)
+    return graph_ops.add_bias_sum(network, out, out_dim, bias)
+
+
+def _chunk_batched(network, tensor, chunks: int, dim: int):
+    """Split [B, chunks*dim] into ``chunks`` tensors of [B, dim]."""
+    out = []
+    for i in range(chunks):
+        out.append(_slice_batched_vector(network, tensor, i * dim, dim))
+    return out
+
+
+def _adaln_modulate_batched(network, x, scale, shift, dim, eps_t):
+    """AdaLN: LayerNorm(x) * (1 + scale) + shift for [B, S, D]."""
+    normed = _layer_norm_last_dim_no_affine_batched(network, x, eps_t)
+
+    scale_3d = network.add_shuffle(scale)
+    scale_3d.reshape_dims = (-1, 1, dim)
+    shift_3d = network.add_shuffle(shift)
+    shift_3d.reshape_dims = (-1, 1, dim)
+
+    one_const = graph_ops.add_constant(network, (1, 1, 1), np.array([1.0], dtype=np.float32))
+    scale_plus_1 = network.add_elementwise(
+        one_const, scale_3d.get_output(0), trt.ElementWiseOperation.SUM).get_output(0)
+
+    scaled = network.add_elementwise(normed, scale_plus_1, trt.ElementWiseOperation.PROD)
+    shifted = network.add_elementwise(
+        scaled.get_output(0), shift_3d.get_output(0), trt.ElementWiseOperation.SUM)
+    return shifted.get_output(0)
+
+
+def _layernorm_modulate_batched(network, x, scale, shift, dim, eps_t):
+    """LayerNorm(x) * (1 + scale) + shift for [B, S, D]."""
+    return _adaln_modulate_batched(network, x, scale, shift, dim, eps_t)
+
+
+def _gate_batched(network, x, gate, dim: int):
+    """Gate [B, S, D] with per-sample gate [B, D]."""
+    gate_3d = network.add_shuffle(gate)
+    gate_3d.reshape_dims = (-1, 1, dim)
+    return network.add_elementwise(
+        x, gate_3d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def _build_flux_dit_engine_batched(
+    weights: "WeightDict",
+    *,
+    dim: int,
+    num_heads: int,
+    num_layers: int,
+    num_single_layers: int,
+    num_img_tokens: int,
+    text_seq_len: int,
+    mlp_ratio: float,
+    eps: float,
+    max_batch_size: int,
+    opt_batch_size: int | None,
+    verbose: bool,
+) -> bytes:
+    """Build a dynamic-leading-batch FLUX.1 DiT TRT engine."""
+    from ...engine_builder import add_dynamic_batch_profile
+
+    if max_batch_size < 1:
+        raise ValueError(f"max_batch_size must be >= 1 (got {max_batch_size})")
+    opt_batch = min(max_batch_size, 4) if opt_batch_size is None else opt_batch_size
+
+    head_dim = dim // num_heads
+    ffn_dim = int(dim * mlp_ratio)
+    total_seq = text_seq_len + num_img_tokens
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
+
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    hidden_inp = network.add_input(
+        "hidden_states", trt.float32, (-1, num_img_tokens, dim))
+    encoder_inp = network.add_input(
+        "encoder_hidden_states", trt.float32, (-1, text_seq_len, dim))
+    temb_inp = network.add_input("temb", trt.float32, (-1, dim))
+    rotary_cos = network.add_input("rotary_cos", trt.float32, (-1, total_seq, head_dim))
+    rotary_sin = network.add_input("rotary_sin", trt.float32, (-1, total_seq, head_dim))
+
+    add_dynamic_batch_profile(
+        builder,
+        config,
+        network,
+        input_names=[
+            "hidden_states",
+            "encoder_hidden_states",
+            "temb",
+            "rotary_cos",
+            "rotary_sin",
+        ],
+        max_batch=max_batch_size,
+        opt_batch=opt_batch,
+        static_shape={
+            "hidden_states": (num_img_tokens, dim),
+            "encoder_hidden_states": (text_seq_len, dim),
+            "temb": (dim,),
+            "rotary_cos": (total_seq, head_dim),
+            "rotary_sin": (total_seq, head_dim),
+        },
+    )
+
+    eps_t = graph_ops.add_constant(network, (1, 1, 1), np.array([eps], dtype=np.float32))
+
+    txt_cos = _slice_batched_sequence(network, rotary_cos, 0, text_seq_len, head_dim)
+    txt_sin = _slice_batched_sequence(network, rotary_sin, 0, text_seq_len, head_dim)
+    img_cos = _slice_batched_sequence(network, rotary_cos, text_seq_len, num_img_tokens, head_dim)
+    img_sin = _slice_batched_sequence(network, rotary_sin, text_seq_len, num_img_tokens, head_dim)
+
+    hidden = hidden_inp
+    encoder_hidden = encoder_inp
+
+    for layer_idx in range(num_layers):
+        p = f"transformer_blocks.{layer_idx}"
+
+        norm1_w = weights[f"{p}.norm1.linear.weight"]
+        norm1_b = weights[f"{p}.norm1.linear.bias"]
+        temb_silu = network.add_activation(temb_inp, trt.ActivationType.SIGMOID)
+        temb_silu_out = network.add_elementwise(
+            temb_inp, temb_silu.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+
+        norm1_proj = _matmul_bias_batched(network, temb_silu_out, dim, 6 * dim,
+                                          norm1_w, norm1_b)
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = _chunk_batched(
+            network, norm1_proj, 6, dim)
+        normed_hidden = _adaln_modulate_batched(network, hidden, scale_msa, shift_msa,
+                                                dim, eps_t)
+
+        ctx_norm1_w = weights[f"{p}.norm1_context.linear.weight"]
+        ctx_norm1_b = weights[f"{p}.norm1_context.linear.bias"]
+        ctx_norm1_proj = _matmul_bias_batched(
+            network, temb_silu_out, dim, 6 * dim, ctx_norm1_w, ctx_norm1_b)
+        c_shift_msa, c_scale_msa, c_gate_msa, c_shift_mlp, c_scale_mlp, c_gate_mlp = (
+            _chunk_batched(network, ctx_norm1_proj, 6, dim))
+        normed_encoder = _adaln_modulate_batched(
+            network, encoder_hidden, c_scale_msa, c_shift_msa, dim, eps_t)
+
+        q_img = _linear(network, normed_hidden, dim, dim, weights, f"{p}.attn.to_q")
+        k_img = _linear(network, normed_hidden, dim, dim, weights, f"{p}.attn.to_k")
+        v_img = _linear(network, normed_hidden, dim, dim, weights, f"{p}.attn.to_v")
+
+        q_txt = _linear(network, normed_encoder, dim, dim, weights, f"{p}.attn.add_q_proj")
+        k_txt = _linear(network, normed_encoder, dim, dim, weights, f"{p}.attn.add_k_proj")
+        v_txt = _linear(network, normed_encoder, dim, dim, weights, f"{p}.attn.add_v_proj")
+
+        q_img = graph_ops.add_rms_norm_per_head_batched(
+            network, q_img, num_heads, head_dim, weights[f"{p}.attn.norm_q.weight"],
+            eps_t, sequence_length=num_img_tokens)
+        k_img = graph_ops.add_rms_norm_per_head_batched(
+            network, k_img, num_heads, head_dim, weights[f"{p}.attn.norm_k.weight"],
+            eps_t, sequence_length=num_img_tokens)
+        q_txt = graph_ops.add_rms_norm_per_head_batched(
+            network, q_txt, num_heads, head_dim, weights[f"{p}.attn.norm_added_q.weight"],
+            eps_t, sequence_length=text_seq_len)
+        k_txt = graph_ops.add_rms_norm_per_head_batched(
+            network, k_txt, num_heads, head_dim, weights[f"{p}.attn.norm_added_k.weight"],
+            eps_t, sequence_length=text_seq_len)
+
+        q_img = _apply_rope_batched_from_full_cache(
+            network, q_img, img_cos, img_sin, num_heads, head_dim, num_img_tokens)
+        k_img = _apply_rope_batched_from_full_cache(
+            network, k_img, img_cos, img_sin, num_heads, head_dim, num_img_tokens)
+        q_txt = _apply_rope_batched_from_full_cache(
+            network, q_txt, txt_cos, txt_sin, num_heads, head_dim, text_seq_len)
+        k_txt = _apply_rope_batched_from_full_cache(
+            network, k_txt, txt_cos, txt_sin, num_heads, head_dim, text_seq_len)
+
+        q_cat = network.add_concatenation([q_txt, q_img])
+        q_cat.axis = 1
+        k_cat = network.add_concatenation([k_txt, k_img])
+        k_cat.axis = 1
+        v_cat = network.add_concatenation([v_txt, v_img])
+        v_cat.axis = 1
+
+        attn_out = _mha_batched(
+            network, q_cat.get_output(0), k_cat.get_output(0), v_cat.get_output(0),
+            num_heads, head_dim, total_seq)
+
+        txt_attn = _slice_batched_sequence(network, attn_out, 0, text_seq_len, dim)
+        img_attn = _slice_batched_sequence(network, attn_out, text_seq_len,
+                                           num_img_tokens, dim)
+
+        img_attn_proj = _linear(network, img_attn, dim, dim, weights, f"{p}.attn.to_out.0")
+        img_attn_gated = _gate_batched(network, img_attn_proj, gate_msa, dim)
+        hidden = network.add_elementwise(
+            hidden, img_attn_gated, trt.ElementWiseOperation.SUM).get_output(0)
+
+        txt_attn_proj = _linear(network, txt_attn, dim, dim, weights, f"{p}.attn.to_add_out")
+        txt_attn_gated = _gate_batched(network, txt_attn_proj, c_gate_msa, dim)
+        encoder_hidden = network.add_elementwise(
+            encoder_hidden, txt_attn_gated, trt.ElementWiseOperation.SUM).get_output(0)
+
+        normed_ff = _layernorm_modulate_batched(
+            network, hidden, scale_mlp, shift_mlp, dim, eps_t)
+        ff_out = _gelu_ffn(network, normed_ff, dim, weights, f"{p}.ff")
+        ff_gated = _gate_batched(network, ff_out, gate_mlp, dim)
+        hidden = network.add_elementwise(
+            hidden, ff_gated, trt.ElementWiseOperation.SUM).get_output(0)
+
+        normed_ctx_ff = _layernorm_modulate_batched(
+            network, encoder_hidden, c_scale_mlp, c_shift_mlp, dim, eps_t)
+        ctx_ff_out = _gelu_ffn(network, normed_ctx_ff, dim, weights, f"{p}.ff_context")
+        ctx_ff_gated = _gate_batched(network, ctx_ff_out, c_gate_mlp, dim)
+        encoder_hidden = network.add_elementwise(
+            encoder_hidden, ctx_ff_gated, trt.ElementWiseOperation.SUM).get_output(0)
+
+    for layer_idx in range(num_single_layers):
+        p = f"single_transformer_blocks.{layer_idx}"
+
+        cat_hidden = network.add_concatenation([encoder_hidden, hidden])
+        cat_hidden.axis = 1
+        residual = cat_hidden.get_output(0)
+
+        norm_w = weights[f"{p}.norm.linear.weight"]
+        norm_b = weights[f"{p}.norm.linear.bias"]
+        temb_silu2 = network.add_activation(temb_inp, trt.ActivationType.SIGMOID)
+        temb_silu2_out = network.add_elementwise(
+            temb_inp, temb_silu2.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+
+        norm_proj = _matmul_bias_batched(network, temb_silu2_out, dim, 3 * dim,
+                                         norm_w, norm_b)
+        shift_msa_s, scale_msa_s, gate_msa_s = _chunk_batched(network, norm_proj, 3, dim)
+        normed_cat = _adaln_modulate_batched(
+            network, residual, scale_msa_s, shift_msa_s, dim, eps_t)
+
+        mlp_hidden = graph_ops.add_matmul_rhs_constant(
+            network, normed_cat, dim, ffn_dim, weights[f"{p}.proj_mlp.weight"])
+        mlp_b = weights.get(f"{p}.proj_mlp.bias")
+        if mlp_b is not None:
+            mlp_hidden = graph_ops.add_bias_sum(network, mlp_hidden, ffn_dim, mlp_b)
+        mlp_hidden = graph_ops.add_gelu_tanh(network, mlp_hidden)
+
+        q_s = _linear(network, normed_cat, dim, dim, weights, f"{p}.attn.to_q")
+        k_s = _linear(network, normed_cat, dim, dim, weights, f"{p}.attn.to_k")
+        v_s = _linear(network, normed_cat, dim, dim, weights, f"{p}.attn.to_v")
+
+        q_s = graph_ops.add_rms_norm_per_head_batched(
+            network, q_s, num_heads, head_dim, weights[f"{p}.attn.norm_q.weight"],
+            eps_t, sequence_length=total_seq)
+        k_s = graph_ops.add_rms_norm_per_head_batched(
+            network, k_s, num_heads, head_dim, weights[f"{p}.attn.norm_k.weight"],
+            eps_t, sequence_length=total_seq)
+
+        q_s = _apply_rope_batched_from_full_cache(
+            network, q_s, rotary_cos, rotary_sin, num_heads, head_dim, total_seq)
+        k_s = _apply_rope_batched_from_full_cache(
+            network, k_s, rotary_cos, rotary_sin, num_heads, head_dim, total_seq)
+
+        attn_out_s = _mha_batched(network, q_s, k_s, v_s, num_heads, head_dim, total_seq)
+
+        cat_attn_mlp = network.add_concatenation([attn_out_s, mlp_hidden])
+        cat_attn_mlp.axis = 2
+
+        proj_out_w = weights[f"{p}.proj_out.weight"]
+        in_features = dim + ffn_dim
+        combined = graph_ops.add_matmul_rhs_constant(
+            network, cat_attn_mlp.get_output(0), in_features, dim, proj_out_w)
+        proj_out_b = weights.get(f"{p}.proj_out.bias")
+        if proj_out_b is not None:
+            combined = graph_ops.add_bias_sum(network, combined, dim, proj_out_b)
+
+        gated_s = _gate_batched(network, combined, gate_msa_s, dim)
+        cat_hidden_out = network.add_elementwise(
+            residual, gated_s, trt.ElementWiseOperation.SUM).get_output(0)
+
+        encoder_hidden = _slice_batched_sequence(network, cat_hidden_out, 0,
+                                                 text_seq_len, dim)
+        hidden = _slice_batched_sequence(network, cat_hidden_out, text_seq_len,
+                                         num_img_tokens, dim)
+
+    final_norm_w = weights["norm_out.linear.weight"]
+    final_norm_b = weights["norm_out.linear.bias"]
+
+    temb_silu_f = network.add_activation(temb_inp, trt.ActivationType.SIGMOID)
+    temb_silu_f_out = network.add_elementwise(
+        temb_inp, temb_silu_f.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+
+    final_proj = _matmul_bias_batched(network, temb_silu_f_out, dim, 2 * dim,
+                                      final_norm_w, final_norm_b)
+    final_scale = _slice_batched_vector(network, final_proj, 0, dim)
+    final_shift = _slice_batched_vector(network, final_proj, dim, dim)
+
+    output = _adaln_modulate_batched(network, hidden, final_scale, final_shift, dim, eps_t)
+
+    proj_out_w = weights["proj_out.weight"]
+    out_channels = proj_out_w.shape[1]
+    output = graph_ops.add_matmul_rhs_constant(
+        network, output, dim, out_channels, proj_out_w)
+    proj_out_b = weights.get("proj_out.bias")
+    if proj_out_b is not None:
+        output = graph_ops.add_bias_sum(network, output, out_channels, proj_out_b)
+
+    cast_output = network.add_cast(output, trt.float32)
+    output_final = cast_output.get_output(0)
+    output_final.name = "output"
+    network.mark_output(output_final)
+
+    print(f"[flux-dit] Building dynamic-batch TRT engine "
+          f"(B=1..{max_batch_size}, opt={opt_batch}, dim={dim}, "
+          f"joint={num_layers}, single={num_single_layers}, "
+          f"img_tokens={num_img_tokens}, text_seq={text_seq_len}) ...",
+          file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError("TRT engine serialization failed for dynamic-batch FLUX DiT")
+    return bytes(plan)
 
 
 def load_flux_dit_weights(

--- a/tensorrt_model_connect/tensorrt_model_connect/families/flux/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/flux/plugin.py
@@ -29,6 +29,7 @@ class FluxPlugin:
     name = "flux"
     runtime_strategy = "diffusion_flux"
     pipeline_classes = ["FluxPipeline", "Flux2Pipeline"]
+    supports_dynamic_batch_dit = True
 
     # Default FLUX.1-dev architecture params
     _CLIP_HIDDEN = 768
@@ -152,6 +153,7 @@ class FluxPlugin:
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
         *, precision: str = "fp32", verbose: bool = False,
         fp8_scales: dict | None = None, build_timing: dict | None = None,
+        max_batch_size: int = 1,
     ) -> dict:
         """Build all component engines.
 
@@ -167,6 +169,11 @@ class FluxPlugin:
 
         # Detect FLUX.2 via transformer config
         if _is_flux2(tc):
+            if max_batch_size > 1:
+                raise NotImplementedError(
+                    "FLUX.2 dynamic-batch DiT build is not implemented yet; "
+                    "use --max-batch-size 1 for FLUX.2 models"
+                )
             return self._build_flux2_components(
                 model_dir, config, weights, tc=tc, verbose=verbose,
                 fp8_scales=fp8_scales, precision=precision,
@@ -174,12 +181,14 @@ class FluxPlugin:
 
         return self._build_flux1_components(
             model_dir, config, weights, tc=tc, verbose=verbose,
-            precision=precision, build_timing=build_timing)
+            precision=precision, build_timing=build_timing,
+            max_batch_size=max_batch_size)
 
     def _build_flux1_components(
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
         *, tc: dict, precision: str = "fp32", verbose: bool = False,
         build_timing: dict | None = None,
+        max_batch_size: int = 1,
     ) -> dict:
         """Build FLUX.1 component engines (CLIP + T5 + DiT + VAE)."""
         from ...build_timing import timed_trt_compile, timed_weight_loading
@@ -339,6 +348,7 @@ class FluxPlugin:
                 num_single_layers=num_single_layers,
                 num_img_tokens=num_img_tokens,
                 text_seq_len=self._T5_MAX_SEQ_LEN,
+                max_batch_size=max_batch_size,
                 verbose=verbose,
             )
 

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/plugin.py
@@ -26,6 +26,7 @@ from ...checkpoint_mapper import WeightDict
 class QwenImagePlugin:
     name = "qwen_image"
     runtime_strategy = "diffusion_qwen_image"
+    supports_dynamic_batch_dit = True
     pipeline_classes = [
         "QwenImagePipeline",
         "QwenImageEditPipeline",
@@ -80,7 +81,8 @@ class QwenImagePlugin:
 
     def build_components(
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
-        *, precision: str = "bf16", verbose: bool = False, **_kwargs,
+        *, precision: str = "bf16", verbose: bool = False,
+        max_batch_size: int = 1, **_kwargs,
     ) -> dict:
         """Build TRT engines and bundle blobs for a Qwen-Image T2I checkpoint.
 
@@ -207,6 +209,7 @@ class QwenImagePlugin:
             build_qwen_image_dit_engine(
                 dit_cfg, dit_w, dit_plan_path,
                 h_lat=h_lat, w_lat=w_lat, n_text=n_text,
+                batch_size=max_batch_size,
                 verbose=verbose,
             )
             dit_engine_bytes = dit_plan_path.read_bytes()

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/plugin.py
@@ -23,6 +23,16 @@ from ...config import ModelConfig
 from ...checkpoint_mapper import WeightDict
 
 
+def _apply_build_overrides(bundle_cfg: dict, config: ModelConfig) -> None:
+    if "image_height" in config.raw:
+        bundle_cfg["image"]["default_height"] = int(config.raw["image_height"])
+    if "image_width" in config.raw:
+        bundle_cfg["image"]["default_width"] = int(config.raw["image_width"])
+    if "num_inference_steps" in config.raw:
+        bundle_cfg["diffusion"]["default_num_inference_steps"] = int(
+            config.raw["num_inference_steps"])
+
+
 class QwenImagePlugin:
     name = "qwen_image"
     runtime_strategy = "diffusion_qwen_image"
@@ -135,7 +145,7 @@ class QwenImagePlugin:
         # 1. Bundle config.json blob -- pure file-IO transform, fast.
         print("[qwen-image] Building bundle config ...", file=sys.stderr)
         bundle_cfg = build_bundle_config(repo)
-        config_json_bytes = json.dumps(bundle_cfg, indent=2).encode("utf-8")
+        _apply_build_overrides(bundle_cfg, config)
 
         # Derive engine build-time shape constants from the bundle config so
         # the static plans agree with the C++ runtime contract.
@@ -152,6 +162,7 @@ class QwenImagePlugin:
         latent_w = default_w // vae_scale
         h_lat = latent_h // patch_size
         w_lat = latent_w // patch_size
+        config_json_bytes = json.dumps(bundle_cfg, indent=2).encode("utf-8")
 
         # 2. Qwen2.5-VL LM text encoder.
         print(

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen_image_dit_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen_image_dit_builder.py
@@ -1001,6 +1001,7 @@ def _add_joint_attention(
     network, q_img_3d, k_img_3d, v_img_3d,
     q_txt_3d, k_txt_3d, v_txt_3d,
     num_heads: int, head_dim: int, n_img: int, n_txt: int, batch_size: int = 1,
+    attention_mask=None,
 ):
     """Joint attention with concat order [txt, img].
 
@@ -1026,9 +1027,11 @@ def _add_joint_attention(
     q_4d = to_4d(q.get_output(0))
     k_4d = to_4d(k.get_output(0))
     v_4d = to_4d(v.get_output(0))
+    if attention_mask is not None and attention_mask.dtype != q_4d.dtype:
+        attention_mask = network.add_cast(attention_mask, q_4d.dtype).get_output(0)
 
     ctx_4d = graph_ops.add_attention_core(
-        network, q_4d, k_4d, v_4d, causal=False, mask=None,
+        network, q_4d, k_4d, v_4d, causal=False, mask=attention_mask,
         scale=float(1.0 / math.sqrt(head_dim)),
     )
 
@@ -1044,6 +1047,50 @@ def _add_joint_attention(
     img = _slice_batch_sequence(network, out_3d, n_txt, n_img, num_heads * head_dim,
                                 batch_size)
     return txt, img
+
+
+def _add_joint_attention_mask(
+    network,
+    encoder_hidden_states_mask,
+    *,
+    n_txt: int,
+    n_img: int,
+    batch_size: int,
+):
+    """Build additive joint attention mask [B, 1, 1, N_txt + N_img].
+
+    Diffusers passes a boolean mask with 1/True for valid text tokens and
+    concatenates all-valid image tokens. TRT IAttention uses an additive mask,
+    so invalid text key positions become -1e9 and valid text/image keys are 0.
+    """
+    if encoder_hidden_states_mask.dtype != trt.float32:
+        encoder_hidden_states_mask = network.add_cast(
+            encoder_hidden_states_mask, trt.float32).get_output(0)
+
+    ones = graph_ops.add_constant(
+        network, (1, n_txt), np.ones((1, n_txt), dtype=np.float32))
+    invalid = network.add_elementwise(
+        ones, encoder_hidden_states_mask, trt.ElementWiseOperation.SUB)
+    neg_large = graph_ops.add_constant(
+        network, (1, n_txt), np.full((1, n_txt), -1.0e9, dtype=np.float32))
+    txt_additive = network.add_elementwise(
+        invalid.get_output(0), neg_large, trt.ElementWiseOperation.PROD)
+
+    first_col = _slice_batch_vector(
+        network, encoder_hidden_states_mask, 0, 1, batch_size)
+    img_zero_rhs = graph_ops.add_constant(
+        network, (1, n_img), np.zeros((1, n_img), dtype=np.float32))
+    img_additive = network.add_matrix_multiply(
+        first_col, trt.MatrixOperation.NONE,
+        img_zero_rhs, trt.MatrixOperation.NONE,
+    )
+
+    joint = network.add_concatenation(
+        [txt_additive.get_output(0), img_additive.get_output(0)])
+    joint.axis = 1
+    mask_4d = network.add_shuffle(joint.get_output(0))
+    mask_4d.reshape_dims = (-1, 1, 1, n_txt + n_img)
+    return mask_4d.get_output(0)
 
 
 def _add_mlp_block(network, x_3d, hidden_size: int, intermediate_size: int,
@@ -1146,6 +1193,7 @@ def _add_joint_block_graph(
     n_img: int,
     n_text: int,
     batch_size: int = 1,
+    attention_mask=None,
 ):
     """Build the math of one Qwen-Image MMDiT joint block.
 
@@ -1237,7 +1285,7 @@ def _add_joint_block_graph(
     attn_txt_3d, attn_img_3d = _add_joint_attention(
         network, img_q, img_k, img_v, txt_q, txt_k, txt_v,
         num_heads=H, head_dim=D, n_img=n_img, n_txt=n_text,
-        batch_size=batch_size,
+        batch_size=batch_size, attention_mask=attention_mask,
     )
 
     # ----- output projections (separate for each stream).
@@ -1752,6 +1800,9 @@ def build_qwen_image_dit_engine(
           the 2x2 packing).
       ``txt_hidden`` [B, N_txt = n_text, text_embed_dim]
           text encoder hidden states (Qwen2.5-VL hidden = 3584).
+      ``encoder_hidden_states_mask`` [B, N_txt = n_text]
+          1.0 for valid text tokens, 0.0 for padded text tokens. The image
+          side is always treated as valid when constructing joint attention.
       ``timestep``  [B]
           diffusion timestep (fp32; will be cast/multiplied by ``scale=1000``
           inside the sinusoidal embedding, matching diffusers).
@@ -1816,6 +1867,9 @@ def build_qwen_image_dit_engine(
     txt_hidden = network.add_input(
         "txt_hidden", trt.float32, (input_batch, n_text, txt_d),
     )
+    encoder_hidden_states_mask = network.add_input(
+        "encoder_hidden_states_mask", trt.float32, (input_batch, n_text),
+    )
     timestep = network.add_input("timestep", trt.float32, (input_batch,))
 
     if dynamic_batch:
@@ -1826,12 +1880,18 @@ def build_qwen_image_dit_engine(
             builder,
             config,
             network,
-            input_names=["img_patched", "txt_hidden", "timestep"],
+            input_names=[
+                "img_patched",
+                "txt_hidden",
+                "encoder_hidden_states_mask",
+                "timestep",
+            ],
             max_batch=batch_size,
             opt_batch=opt_batch,
             static_shape={
                 "img_patched": (n_img, in_ch),
                 "txt_hidden": (n_text, txt_d),
+                "encoder_hidden_states_mask": (n_text,),
                 "timestep": (),
             },
         )
@@ -1878,6 +1938,13 @@ def build_qwen_image_dit_engine(
                                    shape=(n_text, head_dim), stride=(1, 1))
     sin_txt_sl = network.add_slice(sin_const, start=(n_img, 0),
                                    shape=(n_text, head_dim), stride=(1, 1))
+    joint_attention_mask = _add_joint_attention_mask(
+        network,
+        encoder_hidden_states_mask,
+        n_txt=n_text,
+        n_img=n_img,
+        batch_size=batch_size,
+    )
 
     # ----- Joint blocks loop.
     jb_cfg = _joint_block_cfg_from(cfg)
@@ -1900,6 +1967,7 @@ def build_qwen_image_dit_engine(
             n_img=n_img,
             n_text=n_text,
             batch_size=batch_size,
+            attention_mask=joint_attention_mask,
         )
 
     # ----- AdaLayerNormContinuous(elementwise_affine=False) -> proj_out.

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen_image_dit_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen_image/qwen_image_dit_builder.py
@@ -374,6 +374,59 @@ def _add_linear(network, x, weight_np: np.ndarray, bias_np: np.ndarray):
     return y
 
 
+def _dynamic_batch_shape(network, reference, tail: tuple[int, ...]):
+    """Shape tensor [B, *tail] using dim 0 from a dynamic-batch tensor."""
+    ref_shape = network.add_shape(reference).get_output(0)
+    batch = network.add_slice(ref_shape, start=(0,), shape=(1,), stride=(1,))
+    tail_t = graph_ops.add_constant(
+        network, (len(tail),), np.asarray(tail, dtype=np.int64), dtype=np.int64)
+    target = network.add_concatenation([batch.get_output(0), tail_t])
+    target.axis = 0
+    return target.get_output(0)
+
+
+def _slice_batch_vector(network, x, start_width: int, width: int, batch_size: int):
+    """Slice [B, D] along D, preserving dynamic B when present."""
+    if batch_size == 1:
+        return network.add_slice(
+            x, start=(0, start_width), shape=(1, width), stride=(1, 1)).get_output(0)
+    s = network.add_slice(
+        x, start=(0, start_width), shape=(0, 0), stride=(1, 1))
+    s.set_input(2, _dynamic_batch_shape(network, x, (width,)))
+    return s.get_output(0)
+
+
+def _slice_batch_sequence(network, x, start_seq: int, length: int, width: int,
+                          batch_size: int):
+    """Slice [B, S, D] along S, preserving dynamic B when present."""
+    if batch_size == 1:
+        return network.add_slice(
+            x, start=(0, start_seq, 0), shape=(1, length, width),
+            stride=(1, 1, 1)).get_output(0)
+    s = network.add_slice(
+        x, start=(0, start_seq, 0), shape=(0, 0, 0), stride=(1, 1, 1))
+    s.set_input(2, _dynamic_batch_shape(network, x, (length, width)))
+    return s.get_output(0)
+
+
+def _slice_batch_complex_part(network, x, seq_len: int, num_heads: int, half: int,
+                              complex_index: int, batch_size: int):
+    """Slice real/imag part from [B, S, H, D/2, 2] to [B, S, H, D/2]."""
+    if batch_size == 1:
+        s = network.add_slice(
+            x, start=(0, 0, 0, 0, complex_index),
+            shape=(1, seq_len, num_heads, half, 1),
+            stride=(1, 1, 1, 1, 1))
+    else:
+        s = network.add_slice(
+            x, start=(0, 0, 0, 0, complex_index), shape=(0, 0, 0, 0, 0),
+            stride=(1, 1, 1, 1, 1))
+        s.set_input(2, _dynamic_batch_shape(network, x, (seq_len, num_heads, half, 1)))
+    r = network.add_shuffle(s.get_output(0))
+    r.reshape_dims = (-1, seq_len, num_heads, half)
+    return r.get_output(0)
+
+
 def build_timestep_embed_engine(
     out_path: PathLike,
     *,
@@ -852,33 +905,19 @@ def _add_gate_residual(network, residual_3d, gate_2d, branch_3d, hidden_size: in
 
 def _add_rms_norm_per_head(network, x_3d, num_heads: int, head_dim: int,
                            gamma: np.ndarray, eps: float, seq_len: int):
-    """RMSNorm over head_dim for [B, S, H*D] (B is fixed in static engine).
-
-    Reuses graph_ops.add_rms_norm_per_head, which auto-casts to fp32 for
-    numerical stability when its ``dtype`` parameter is non-fp32 and casts
-    back to the input dtype afterwards. The bf16 storage path is selected
-    here so the in/out tensor dtype stays bf16 while the reduction runs in
-    fp32 -- matches the QK-norm precision pattern of flux2/Qwen-VL.
-    """
-    # [B, S, H*D] -> [S, H*D] (B=1).
-    sq = network.add_shuffle(x_3d)
-    sq.reshape_dims = (seq_len, num_heads * head_dim)
+    """RMSNorm over head_dim for [B, S, H*D]."""
     eps_t = _add_2d_constant(network, np.array([eps], dtype=np.float32))
     eps_scalar = network.add_shuffle(eps_t)
     eps_scalar.reshape_dims = ()
-    out_2d = graph_ops.add_rms_norm_per_head(
-        network, sq.get_output(0), num_heads, head_dim, gamma,
+    return graph_ops.add_rms_norm_per_head_batched(
+        network, x_3d, num_heads, head_dim, gamma,
         eps_scalar.get_output(0), sequence_length=seq_len,
         dtype=np.float16,  # signal "non-fp32 in/out, fp32 compute internally"
     )
-    # [S, H*D] -> [B=1, S, H*D].
-    out_3d = network.add_shuffle(out_2d)
-    out_3d.reshape_dims = (1, seq_len, num_heads * head_dim)
-    return out_3d.get_output(0)
 
 
 def _add_rope_pair(network, x_3d, cos_2d, sin_2d, num_heads: int,
-                   head_dim: int, seq_len: int):
+                   head_dim: int, seq_len: int, batch_size: int = 1):
     """Apply Qwen pair-based RoPE.
 
     x_3d:    [B=1, S, H*D]
@@ -891,24 +930,17 @@ def _add_rope_pair(network, x_3d, cos_2d, sin_2d, num_heads: int,
 
     Returns [B=1, S, H*D].
     """
-    # [B=1, S, H*D] -> [S, H*D] -> [S, H, D] -> [S, H, D/2, 2]
+    # [B, S, H*D] -> [B, S, H, D/2, 2]
     rb = network.add_shuffle(x_3d)
-    rb.reshape_dims = (seq_len, num_heads, head_dim // 2, 2)
+    rb.reshape_dims = (-1, seq_len, num_heads, head_dim // 2, 2)
     x_pairs = rb.get_output(0)
 
     # x_real = x[..., 0], x_imag = x[..., 1]  (along last axis).
-    x_real_sl = network.add_slice(
-        x_pairs, start=(0, 0, 0, 0),
-        shape=(seq_len, num_heads, head_dim // 2, 1), stride=(1, 1, 1, 1),
-    )
-    x_imag_sl = network.add_slice(
-        x_pairs, start=(0, 0, 0, 1),
-        shape=(seq_len, num_heads, head_dim // 2, 1), stride=(1, 1, 1, 1),
-    )
-    x_real = network.add_shuffle(x_real_sl.get_output(0))
-    x_real.reshape_dims = (seq_len, num_heads, head_dim // 2)
-    x_imag = network.add_shuffle(x_imag_sl.get_output(0))
-    x_imag.reshape_dims = (seq_len, num_heads, head_dim // 2)
+    half = head_dim // 2
+    x_real = _slice_batch_complex_part(network, x_pairs, seq_len, num_heads, half, 0,
+                                       batch_size)
+    x_imag = _slice_batch_complex_part(network, x_pairs, seq_len, num_heads, half, 1,
+                                       batch_size)
 
     # cos_pair / sin_pair: take every-other element from cos/sin (they are
     # interleaved-duplicated, so cos_pair[..., j] = cos[..., 2j]).
@@ -925,16 +957,16 @@ def _add_rope_pair(network, x_3d, cos_2d, sin_2d, num_heads: int,
     sin_pair_c = _to_compute_dtype(network, sin_pair_sl.get_output(0))
     # Reshape cos/sin to [S, 1, D/2] for broadcast across heads.
     cos_3d = network.add_shuffle(cos_pair_c)
-    cos_3d.reshape_dims = (seq_len, 1, head_dim // 2)
+    cos_3d.reshape_dims = (1, seq_len, 1, head_dim // 2)
     sin_3d = network.add_shuffle(sin_pair_c)
-    sin_3d.reshape_dims = (seq_len, 1, head_dim // 2)
+    sin_3d.reshape_dims = (1, seq_len, 1, head_dim // 2)
 
     # new_real = x_real * cos - x_imag * sin
     r_cos = network.add_elementwise(
-        x_real.get_output(0), cos_3d.get_output(0), trt.ElementWiseOperation.PROD,
+        x_real, cos_3d.get_output(0), trt.ElementWiseOperation.PROD,
     ).get_output(0)
     i_sin = network.add_elementwise(
-        x_imag.get_output(0), sin_3d.get_output(0), trt.ElementWiseOperation.PROD,
+        x_imag, sin_3d.get_output(0), trt.ElementWiseOperation.PROD,
     ).get_output(0)
     new_real = network.add_elementwise(
         r_cos, i_sin, trt.ElementWiseOperation.SUB,
@@ -942,10 +974,10 @@ def _add_rope_pair(network, x_3d, cos_2d, sin_2d, num_heads: int,
 
     # new_imag = x_real * sin + x_imag * cos
     r_sin = network.add_elementwise(
-        x_real.get_output(0), sin_3d.get_output(0), trt.ElementWiseOperation.PROD,
+        x_real, sin_3d.get_output(0), trt.ElementWiseOperation.PROD,
     ).get_output(0)
     i_cos = network.add_elementwise(
-        x_imag.get_output(0), cos_3d.get_output(0), trt.ElementWiseOperation.PROD,
+        x_imag, cos_3d.get_output(0), trt.ElementWiseOperation.PROD,
     ).get_output(0)
     new_imag = network.add_elementwise(
         r_sin, i_cos, trt.ElementWiseOperation.SUM,
@@ -953,22 +985,22 @@ def _add_rope_pair(network, x_3d, cos_2d, sin_2d, num_heads: int,
 
     # Stack along the last dim: [S, H, D/2] + [S, H, D/2] -> [S, H, D/2, 2]
     nr_4d = network.add_shuffle(new_real)
-    nr_4d.reshape_dims = (seq_len, num_heads, head_dim // 2, 1)
+    nr_4d.reshape_dims = (-1, seq_len, num_heads, head_dim // 2, 1)
     ni_4d = network.add_shuffle(new_imag)
-    ni_4d.reshape_dims = (seq_len, num_heads, head_dim // 2, 1)
+    ni_4d.reshape_dims = (-1, seq_len, num_heads, head_dim // 2, 1)
     cat = network.add_concatenation([nr_4d.get_output(0), ni_4d.get_output(0)])
-    cat.axis = 3
+    cat.axis = 4
 
-    # [S, H, D/2, 2] -> [B=1, S, H*D]
+    # [B, S, H, D/2, 2] -> [B, S, H*D]
     flat = network.add_shuffle(cat.get_output(0))
-    flat.reshape_dims = (1, seq_len, num_heads * head_dim)
+    flat.reshape_dims = (-1, seq_len, num_heads * head_dim)
     return flat.get_output(0)
 
 
 def _add_joint_attention(
     network, q_img_3d, k_img_3d, v_img_3d,
     q_txt_3d, k_txt_3d, v_txt_3d,
-    num_heads: int, head_dim: int, n_img: int, n_txt: int,
+    num_heads: int, head_dim: int, n_img: int, n_txt: int, batch_size: int = 1,
 ):
     """Joint attention with concat order [txt, img].
 
@@ -987,7 +1019,7 @@ def _add_joint_attention(
     # Reshape [B=1, S, H*D] -> [B=1, S, H, D] -> [B=1, H, S, D].
     def to_4d(x_3d):
         r1 = network.add_shuffle(x_3d)
-        r1.reshape_dims = (1, seq_total, num_heads, head_dim)
+        r1.reshape_dims = (-1, seq_total, num_heads, head_dim)
         r1.second_transpose = trt.Permutation([0, 2, 1, 3])
         return r1.get_output(0)
 
@@ -1003,24 +1035,20 @@ def _add_joint_attention(
     # [B=1, H, S, D] -> [B=1, S, H, D] -> [B=1, S, H*D]
     out_shuffle = network.add_shuffle(ctx_4d)
     out_shuffle.first_transpose = trt.Permutation([0, 2, 1, 3])
-    out_shuffle.reshape_dims = (1, seq_total, num_heads * head_dim)
+    out_shuffle.reshape_dims = (-1, seq_total, num_heads * head_dim)
     out_3d = out_shuffle.get_output(0)
 
     # Split back into [B, N_txt, H*D] and [B, N_img, H*D].
-    txt_sl = network.add_slice(
-        out_3d, start=(0, 0, 0),
-        shape=(1, n_txt, num_heads * head_dim), stride=(1, 1, 1),
-    )
-    img_sl = network.add_slice(
-        out_3d, start=(0, n_txt, 0),
-        shape=(1, n_img, num_heads * head_dim), stride=(1, 1, 1),
-    )
-    return txt_sl.get_output(0), img_sl.get_output(0)
+    txt = _slice_batch_sequence(network, out_3d, 0, n_txt, num_heads * head_dim,
+                                batch_size)
+    img = _slice_batch_sequence(network, out_3d, n_txt, n_img, num_heads * head_dim,
+                                batch_size)
+    return txt, img
 
 
 def _add_mlp_block(network, x_3d, hidden_size: int, intermediate_size: int,
                    weights: Mapping[str, np.ndarray], prefix: str,
-                   seq_len: int):
+                   seq_len: int, batch_size: int = 1):
     """FeedForward block: Linear -> GELU(tanh) -> Linear.
 
     Diffusers FeedForward (gelu-approximate, mult=4, bias=True):
@@ -1035,15 +1063,13 @@ def _add_mlp_block(network, x_3d, hidden_size: int, intermediate_size: int,
     w2 = np.asarray(weights[f"{prefix}.net.2.weight"], dtype=np.float32)        # [hidden, inner]
     b2 = np.asarray(weights[f"{prefix}.net.2.bias"], dtype=np.float32)
 
-    # Flatten to [S, D] for matmul, then back to [B=1, S, D'].
-    flat = network.add_shuffle(x_3d)
-    flat.reshape_dims = (seq_len, hidden_size)
-    h = _add_linear_2d(network, flat.get_output(0), hidden_size, intermediate_size, w1, b1)
+    h = _add_linear_3d(
+        network, x_3d, hidden_size, intermediate_size, w1, b1,
+        seq_len=seq_len, batch_size=batch_size)
     h = graph_ops.add_gelu_tanh(network, h)
-    h = _add_linear_2d(network, h, intermediate_size, hidden_size, w2, b2)
-    unflat = network.add_shuffle(h)
-    unflat.reshape_dims = (1, seq_len, hidden_size)
-    return unflat.get_output(0)
+    return _add_linear_3d(
+        network, h, intermediate_size, hidden_size, w2, b2,
+        seq_len=seq_len, batch_size=batch_size)
 
 
 def _add_qkv_with_norm_and_rope(
@@ -1052,53 +1078,43 @@ def _add_qkv_with_norm_and_rope(
     q_key: str, k_key: str, v_key: str,
     norm_q_key: str | None, norm_k_key: str | None,
     rms_eps: float,
-    cos_2d, sin_2d,
+    cos_2d, sin_2d, batch_size: int = 1,
 ):
     """Compute QKV for one stream with q-norm/k-norm + RoPE.
 
     Inputs are [B=1, S, D]. Returns (q_3d, k_3d, v_3d) each [B=1, S, H*D].
     Q and K get q-norm/k-norm + RoPE applied. V is passed through.
     """
-    flat = network.add_shuffle(x_3d)
-    flat.reshape_dims = (seq_len, hidden_size)
-    x_flat = flat.get_output(0)
-
     def _proj(weight_key: str):
         w_hf = np.asarray(weights[f"{weight_key}.weight"], dtype=np.float32)
         b_hf = weights.get(f"{weight_key}.bias")
         b = np.asarray(b_hf, dtype=np.float32) if b_hf is not None else None
-        return _add_linear_2d(network, x_flat, hidden_size, hidden_size, w_hf, b)
+        return _add_linear_3d(
+            network, x_3d, hidden_size, hidden_size, w_hf, b,
+            seq_len=seq_len, batch_size=batch_size)
 
     q = _proj(q_key)
     k = _proj(k_key)
     v = _proj(v_key)
 
-    # Reshape to [B=1, S, H*D] for downstream helpers.
-    def to_3d(t):
-        s = network.add_shuffle(t)
-        s.reshape_dims = (1, seq_len, num_heads * head_dim)
-        return s.get_output(0)
-
-    q_3d = to_3d(q)
-    k_3d = to_3d(k)
-    v_3d = to_3d(v)
-
     # qk-norm: RMSNorm over head_dim with weight [head_dim].
     if norm_q_key is not None and f"{norm_q_key}.weight" in weights:
         gamma = np.asarray(weights[f"{norm_q_key}.weight"], dtype=np.float32)
-        q_3d = _add_rms_norm_per_head(
-            network, q_3d, num_heads, head_dim, gamma, rms_eps, seq_len,
+        q = _add_rms_norm_per_head(
+            network, q, num_heads, head_dim, gamma, rms_eps, seq_len,
         )
     if norm_k_key is not None and f"{norm_k_key}.weight" in weights:
         gamma = np.asarray(weights[f"{norm_k_key}.weight"], dtype=np.float32)
-        k_3d = _add_rms_norm_per_head(
-            network, k_3d, num_heads, head_dim, gamma, rms_eps, seq_len,
+        k = _add_rms_norm_per_head(
+            network, k, num_heads, head_dim, gamma, rms_eps, seq_len,
         )
 
     # RoPE on Q and K (V untouched).
-    q_3d = _add_rope_pair(network, q_3d, cos_2d, sin_2d, num_heads, head_dim, seq_len)
-    k_3d = _add_rope_pair(network, k_3d, cos_2d, sin_2d, num_heads, head_dim, seq_len)
-    return q_3d, k_3d, v_3d
+    q = _add_rope_pair(network, q, cos_2d, sin_2d, num_heads, head_dim, seq_len,
+                       batch_size)
+    k = _add_rope_pair(network, k, cos_2d, sin_2d, num_heads, head_dim, seq_len,
+                       batch_size)
+    return q, k, v
 
 
 # ---------------------------------------------------------------------------
@@ -1139,10 +1155,6 @@ def _add_joint_block_graph(
 
     Returns ``(img_out_3d, txt_out_3d)``, both [B, S_*, hidden].
     """
-    if batch_size != 1:
-        raise NotImplementedError(
-            "_add_joint_block_graph currently supports batch_size=1 only"
-        )
     H = cfg.num_attention_heads
     D = cfg.attention_head_dim
     dim = cfg.hidden_size
@@ -1189,11 +1201,7 @@ def _add_joint_block_graph(
     def _six_chunks(mod_params):
         chunks = []
         for i in range(6):
-            sl = network.add_slice(
-                mod_params, start=(0, i * dim),
-                shape=(batch_size, dim), stride=(1, 1),
-            )
-            chunks.append(sl.get_output(0))
+            chunks.append(_slice_batch_vector(network, mod_params, i * dim, dim, batch_size))
         return chunks
 
     img_shift_msa, img_scale_msa, img_gate_msa, \
@@ -1214,6 +1222,7 @@ def _add_joint_block_graph(
         q_key="attn.to_q", k_key="attn.to_k", v_key="attn.to_v",
         norm_q_key="attn.norm_q", norm_k_key="attn.norm_k",
         rms_eps=cfg.rms_norm_eps, cos_2d=cos_img, sin_2d=sin_img,
+        batch_size=batch_size,
     )
     txt_q, txt_k, txt_v = _add_qkv_with_norm_and_rope(
         network, txt_modulated, prefixed,
@@ -1221,24 +1230,22 @@ def _add_joint_block_graph(
         q_key="attn.add_q_proj", k_key="attn.add_k_proj", v_key="attn.add_v_proj",
         norm_q_key="attn.norm_added_q", norm_k_key="attn.norm_added_k",
         rms_eps=cfg.rms_norm_eps, cos_2d=cos_txt, sin_2d=sin_txt,
+        batch_size=batch_size,
     )
 
     # ----- joint attention; concat order [txt, img].
     attn_txt_3d, attn_img_3d = _add_joint_attention(
         network, img_q, img_k, img_v, txt_q, txt_k, txt_v,
         num_heads=H, head_dim=D, n_img=n_img, n_txt=n_text,
+        batch_size=batch_size,
     )
 
     # ----- output projections (separate for each stream).
     def _out_proj(x_3d, key_suffix: str, seq_len: int):
         w = _w(f"{key_suffix}.weight")
         b = _w_opt(f"{key_suffix}.bias")
-        flat = network.add_shuffle(x_3d)
-        flat.reshape_dims = (seq_len, dim)
-        proj = _add_linear_2d(network, flat.get_output(0), dim, dim, w, b)
-        unflat = network.add_shuffle(proj)
-        unflat.reshape_dims = (1, seq_len, dim)
-        return unflat.get_output(0)
+        return _add_linear_3d(network, x_3d, dim, dim, w, b,
+                              seq_len=seq_len, batch_size=batch_size)
 
     img_attn_out = _out_proj(attn_img_3d, "attn.to_out.0", n_img)
     txt_attn_out = _out_proj(attn_txt_3d, "attn.to_add_out", n_text)
@@ -1252,6 +1259,7 @@ def _add_joint_block_graph(
     img_mod2_out = _add_modulate(network, img_n2, img_shift_mlp, img_scale_mlp, dim)
     img_mlp_out = _add_mlp_block(
         network, img_mod2_out, dim, cfg.intermediate_size, prefixed, "img_mlp", n_img,
+        batch_size=batch_size,
     )
     img_out = _add_gate_residual(network, hs_img, img_gate_mlp, img_mlp_out, dim)
 
@@ -1259,6 +1267,7 @@ def _add_joint_block_graph(
     txt_mod2_out = _add_modulate(network, txt_n2, txt_shift_mlp, txt_scale_mlp, dim)
     txt_mlp_out = _add_mlp_block(
         network, txt_mod2_out, dim, cfg.intermediate_size, prefixed, "txt_mlp", n_text,
+        batch_size=batch_size,
     )
     txt_out = _add_gate_residual(network, hs_txt, txt_gate_mlp, txt_mlp_out, dim)
     return img_out, txt_out
@@ -1537,15 +1546,19 @@ def _add_linear_3d(network, x_3d, in_dim: int, out_dim: int, w_hf: np.ndarray,
                    b_hf: "np.ndarray | None", seq_len: int, batch_size: int = 1):
     """Linear on a [B, S, in_dim] tensor -> [B, S, out_dim].
 
-    Flattens to [B*S, in_dim], applies the existing _add_linear_2d helper,
-    then reshapes back. ``batch_size`` is bound statically.
+    Uses a rank-3 matmul so the leading batch dimension can be dynamic.
     """
-    flat = network.add_shuffle(x_3d)
-    flat.reshape_dims = (batch_size * seq_len, in_dim)
-    y = _add_linear_2d(network, flat.get_output(0), in_dim, out_dim, w_hf, b_hf)
-    unflat = network.add_shuffle(y)
-    unflat.reshape_dims = (batch_size, seq_len, out_dim)
-    return unflat.get_output(0)
+    x_c = _to_compute_dtype(network, x_3d)
+    w_t = np.ascontiguousarray(w_hf.T, dtype=np.float32)
+    w_const = _add_constant_reduced(network, (1, in_dim, out_dim), w_t.reshape(1, in_dim, out_dim))
+    mm = network.add_matrix_multiply(
+        x_c, trt.MatrixOperation.NONE, w_const, trt.MatrixOperation.NONE)
+    y = mm.get_output(0)
+    if b_hf is not None:
+        b_const = _add_constant_reduced(
+            network, (1, 1, out_dim), np.asarray(b_hf, dtype=np.float32).reshape(1, 1, out_dim))
+        y = network.add_elementwise(y, b_const, trt.ElementWiseOperation.SUM).get_output(0)
+    return y
 
 
 def _add_rms_norm_last_dim_3d(network, x_3d, hidden_size: int, gamma: np.ndarray,
@@ -1646,16 +1659,8 @@ def _add_norm_out_3d(
     temb_silu = graph_ops.add_silu(network, temb_2d)
     emb = _add_linear_2d(network, temb_silu, hidden_size, 2 * hidden_size, w, b)
     # chunk(2, dim=1) -> (scale, shift).  diffusers convention is scale-first.
-    scale_sl = network.add_slice(
-        emb, start=(0, 0),
-        shape=(batch_size, hidden_size), stride=(1, 1),
-    )
-    shift_sl = network.add_slice(
-        emb, start=(0, hidden_size),
-        shape=(batch_size, hidden_size), stride=(1, 1),
-    )
-    scale = scale_sl.get_output(0)
-    shift = shift_sl.get_output(0)
+    scale = _slice_batch_vector(network, emb, 0, hidden_size, batch_size)
+    shift = _slice_batch_vector(network, emb, hidden_size, hidden_size, batch_size)
 
     # LayerNorm(x), no affine.
     x_normed = _add_layernorm_no_affine_3d(network, x_3d, hidden_size, eps)
@@ -1728,6 +1733,7 @@ def build_qwen_image_dit_engine(
     w_lat: int,
     n_text: int,
     batch_size: int = 1,
+    opt_batch_size: int | None = None,
     verbose: bool = False,
 ) -> Path:
     """Build the full Qwen-Image MMDiT denoiser as a single TRT engine.
@@ -1764,10 +1770,8 @@ def build_qwen_image_dit_engine(
 
     Returns the path to the written serialised plan.
     """
-    if batch_size != 1:
-        raise NotImplementedError(
-            "build_qwen_image_dit_engine currently supports batch_size=1 only"
-        )
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1 (got {batch_size})")
     if cfg.num_attention_heads * cfg.attention_head_dim != cfg.hidden_size:
         raise ValueError(
             f"hidden_size ({cfg.hidden_size}) != num_heads ({cfg.num_attention_heads}) "
@@ -1803,14 +1807,34 @@ def build_qwen_image_dit_engine(
     )
 
     builder, config, network = _make_builder(verbose)
+    dynamic_batch = batch_size > 1
+    input_batch = -1 if dynamic_batch else batch_size
 
     img_patched = network.add_input(
-        "img_patched", trt.float32, (batch_size, n_img, in_ch),
+        "img_patched", trt.float32, (input_batch, n_img, in_ch),
     )
     txt_hidden = network.add_input(
-        "txt_hidden", trt.float32, (batch_size, n_text, txt_d),
+        "txt_hidden", trt.float32, (input_batch, n_text, txt_d),
     )
-    timestep = network.add_input("timestep", trt.float32, (batch_size,))
+    timestep = network.add_input("timestep", trt.float32, (input_batch,))
+
+    if dynamic_batch:
+        from ...engine_builder import add_dynamic_batch_profile
+
+        opt_batch = min(batch_size, 4) if opt_batch_size is None else opt_batch_size
+        add_dynamic_batch_profile(
+            builder,
+            config,
+            network,
+            input_names=["img_patched", "txt_hidden", "timestep"],
+            max_batch=batch_size,
+            opt_batch=opt_batch,
+            static_shape={
+                "img_patched": (n_img, in_ch),
+                "txt_hidden": (n_text, txt_d),
+                "timestep": (),
+            },
+        )
 
     # ----- img_in: Linear(in_ch -> hidden) over [B, N_img, in_ch].
     img_in_w = np.asarray(weights["img_in.weight"], dtype=np.float32)
@@ -1898,7 +1922,8 @@ def build_qwen_image_dit_engine(
 
     print(
         f"[qwen-image-dit] Building full denoiser engine "
-        f"(B={batch_size}, n_img={n_img}, n_text={n_text}, "
+        f"(B={'1..' + str(batch_size) if dynamic_batch else str(batch_size)}, "
+        f"n_img={n_img}, n_text={n_text}, "
         f"blocks={cfg.num_joint_blocks}, hidden={H_dim}, "
         f"heads={cfg.num_attention_heads}, head_dim={head_dim}, "
         f"text_d={txt_d}, in_ch={in_ch}, out_ch={out_ch}, p={p}) "

--- a/tensorrt_model_connect/tensorrt_model_connect/families/z_image/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/z_image/plugin.py
@@ -35,6 +35,7 @@ class ZImagePlugin:
     name = "z_image"
     runtime_strategy = "diffusion_zimage"
     supports_dynamic_batch_dit = True
+    supports_dynamic_batch_text_encoder = True
     pipeline_classes = ["ZImagePipeline"]
 
     # Z-Image Turbo architecture params
@@ -161,6 +162,7 @@ class ZImagePlugin:
                 max_seq_len=self._TEXT_MAX_SEQ_LEN,
                 rope_theta=self._TEXT_ROPE_THETA,
                 output_layer=self._TEXT_OUTPUT_LAYER,
+                max_batch_size=max_batch_size,
                 verbose=verbose,
             )
 
@@ -227,7 +229,7 @@ class ZImagePlugin:
         return {
             "diffusion_backend_type": "z_image_2d",
             "scheduler": "flow_match_euler",
-            "num_inference_steps": 9,
+            "num_inference_steps": config.raw.get("num_inference_steps", 9),
             "guidance_scale": 0.0,
             "flow_shift": 3.0,  # HF scheduler shift=3.0 (use_dynamic_shifting=False)
             "video_height": image_height,

--- a/tensorrt_model_connect/tensorrt_model_connect/families/z_image/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/z_image/plugin.py
@@ -34,6 +34,7 @@ from ...checkpoint_mapper import WeightDict
 class ZImagePlugin:
     name = "z_image"
     runtime_strategy = "diffusion_zimage"
+    supports_dynamic_batch_dit = True
     pipeline_classes = ["ZImagePipeline"]
 
     # Z-Image Turbo architecture params
@@ -103,7 +104,8 @@ class ZImagePlugin:
 
     def build_components(
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
-        *, precision: str = "fp32", verbose: bool = False, **_kwargs,
+        *, precision: str = "fp32", verbose: bool = False,
+        max_batch_size: int = 1, **_kwargs,
     ) -> dict:
         """Build REAL TRT engines for all Z-Image components."""
         from ...build_timing import timed_trt_compile, timed_weight_loading
@@ -185,6 +187,7 @@ class ZImagePlugin:
                 text_seq_len=self._TEXT_MAX_SEQ_LEN,
                 head_dim=self._DIT_HEAD_DIM,
                 adaln_embed_dim=self._ADALN_EMBED_DIM,
+                max_batch_size=max_batch_size,
                 verbose=verbose,
             )
 

--- a/tensorrt_model_connect/tensorrt_model_connect/families/z_image/qwen3_encoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/z_image/qwen3_encoder_builder.py
@@ -7,8 +7,9 @@ Unlike the standard decoder builder, this:
   - Returns hidden_states from a configurable layer (default: layer -2)
 
 Engine I/O:
-    Inputs:  input_ids [seq_len] int32, attention_mask [seq_len] float32
-    Outputs: text_embeddings [seq_len, hidden_size] float32
+    Inputs:  input_ids [seq_len] or [B, seq_len] int32,
+             attention_mask [seq_len] or [B, seq_len] float32
+    Outputs: text_embeddings [seq_len, hidden_size] or [B, seq_len, hidden_size] float32
 """
 
 from __future__ import annotations
@@ -93,6 +94,8 @@ def build_qwen3_encoder_engine(
     rope_theta: float = 1000000.0,
     eps: float = 1e-6,
     output_layer: int = -2,
+    max_batch_size: int = 1,
+    opt_batch_size: int | None = None,
     verbose: bool = False,
 ) -> bytes:
     """Build Qwen3 text encoder TRT engine.
@@ -103,8 +106,12 @@ def build_qwen3_encoder_engine(
     """
     if output_layer < 0:
         output_layer = num_layers + output_layer  # e.g., 36 + (-2) = 34
+    if max_batch_size < 1:
+        raise ValueError(f"max_batch_size must be >= 1 (got {max_batch_size})")
 
     kv_dim = num_kv_heads * head_dim
+    use_batch = max_batch_size > 1
+    opt_batch = min(max_batch_size, 4) if opt_batch_size is None else opt_batch_size
 
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
@@ -114,11 +121,30 @@ def build_qwen3_encoder_engine(
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
 
     # Inputs
-    input_ids = network.add_input("input_ids", trt.int32, (max_seq_len,))
-    attn_mask = network.add_input("attention_mask", trt.float32, (max_seq_len,))
+    if use_batch:
+        from ...engine_builder import add_dynamic_batch_profile
+
+        input_ids = network.add_input("input_ids", trt.int32, (-1, max_seq_len))
+        attn_mask = network.add_input("attention_mask", trt.float32, (-1, max_seq_len))
+        add_dynamic_batch_profile(
+            builder,
+            config,
+            network,
+            input_names=["input_ids", "attention_mask"],
+            max_batch=max_batch_size,
+            opt_batch=opt_batch,
+            static_shape={
+                "input_ids": (max_seq_len,),
+                "attention_mask": (max_seq_len,),
+            },
+        )
+    else:
+        input_ids = network.add_input("input_ids", trt.int32, (max_seq_len,))
+        attn_mask = network.add_input("attention_mask", trt.float32, (max_seq_len,))
 
     # Constants
-    eps_t = graph_ops.add_constant(network, (1, 1), np.array([eps], dtype=np.float32))
+    eps_shape = (1, 1, 1) if use_batch else (1, 1)
+    eps_t = graph_ops.add_constant(network, eps_shape, np.array([eps], dtype=np.float32))
 
     # Embedding
     embed_table = graph_ops.add_constant(
@@ -143,7 +169,7 @@ def build_qwen3_encoder_engine(
     # and query positions.
     # We mask padded positions with -1e9
     mask_reshape = network.add_shuffle(attn_mask)
-    mask_reshape.reshape_dims = (1, 1, 1, max_seq_len)
+    mask_reshape.reshape_dims = (-1, 1, 1, max_seq_len) if use_batch else (1, 1, 1, max_seq_len)
 
     for layer_idx in range(num_layers):
         if layer_idx == output_layer:
@@ -151,9 +177,14 @@ def build_qwen3_encoder_engine(
             output_hidden = hidden
 
         # RMSNorm
-        normed = graph_ops.add_rms_norm(
-            network, hidden, hidden_size,
-            weights[f"layer.{layer_idx}.input_layernorm"], eps_t)
+        if use_batch:
+            normed = graph_ops.add_rms_norm_last_dim(
+                network, hidden, hidden_size,
+                weights[f"layer.{layer_idx}.input_layernorm"], eps_t)
+        else:
+            normed = graph_ops.add_rms_norm(
+                network, hidden, hidden_size,
+                weights[f"layer.{layer_idx}.input_layernorm"], eps_t)
 
         # QKV projections
         q = graph_ops.add_matmul_rhs_constant(
@@ -173,26 +204,48 @@ def build_qwen3_encoder_engine(
         q_norm_tiled = np.tile(q_norm_w.reshape(1, head_dim), (num_heads, 1))
         k_norm_tiled = np.tile(k_norm_w.reshape(1, head_dim), (num_kv_heads, 1))
 
-        q = _add_per_head_rms_norm(network, q, num_heads, head_dim, q_norm_tiled, eps_t, max_seq_len)
-        k = _add_per_head_rms_norm(network, k, num_kv_heads, head_dim, k_norm_tiled, eps_t, max_seq_len)
+        if use_batch:
+            q = graph_ops.add_rms_norm_per_head_batched(
+                network, q, num_heads, head_dim, q_norm_tiled, eps_t,
+                sequence_length=max_seq_len)
+            k = graph_ops.add_rms_norm_per_head_batched(
+                network, k, num_kv_heads, head_dim, k_norm_tiled, eps_t,
+                sequence_length=max_seq_len)
+            q = _add_apply_rope_native_batched(
+                network, q, rope_cos_half, rope_sin_half,
+                num_heads, head_dim, max_seq_len)
+            k = _add_apply_rope_native_batched(
+                network, k, rope_cos_half, rope_sin_half,
+                num_kv_heads, head_dim, max_seq_len)
+            ctx_flat = _add_attention_from_batched_rows(
+                network, q, k, v,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                q_seq=max_seq_len,
+                kv_seq=max_seq_len,
+                mask=mask_reshape.get_output(0))
+        else:
+            q = _add_per_head_rms_norm(network, q, num_heads, head_dim, q_norm_tiled, eps_t, max_seq_len)
+            k = _add_per_head_rms_norm(network, k, num_kv_heads, head_dim, k_norm_tiled, eps_t, max_seq_len)
 
-        q = graph_ops.add_apply_rope_native(
-            network, q, num_heads, head_dim,
-            rope_cos_half, rope_sin_half, rope_position_ids,
-            head_dim, sequence_length=max_seq_len)
-        k = graph_ops.add_apply_rope_native(
-            network, k, num_kv_heads, head_dim,
-            rope_cos_half, rope_sin_half, rope_position_ids,
-            head_dim, sequence_length=max_seq_len)
+            q = graph_ops.add_apply_rope_native(
+                network, q, num_heads, head_dim,
+                rope_cos_half, rope_sin_half, rope_position_ids,
+                head_dim, sequence_length=max_seq_len)
+            k = graph_ops.add_apply_rope_native(
+                network, k, num_kv_heads, head_dim,
+                rope_cos_half, rope_sin_half, rope_position_ids,
+                head_dim, sequence_length=max_seq_len)
 
-        ctx_flat = graph_ops.add_attention_from_rows(
-            network, q, k, v,
-            num_heads=num_heads,
-            num_kv_heads=num_kv_heads,
-            head_dim=head_dim,
-            q_seq=max_seq_len, kv_seq=max_seq_len,
-            mask=mask_reshape.get_output(0),
-            tag=f"layer.{layer_idx}.attn")
+            ctx_flat = graph_ops.add_attention_from_rows(
+                network, q, k, v,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                q_seq=max_seq_len, kv_seq=max_seq_len,
+                mask=mask_reshape.get_output(0),
+                tag=f"layer.{layer_idx}.attn")
 
         # Output projection
         attn_out = graph_ops.add_matmul_rhs_constant(
@@ -204,9 +257,14 @@ def build_qwen3_encoder_engine(
             hidden, attn_out, trt.ElementWiseOperation.SUM).get_output(0)
 
         # Post-attention RMSNorm
-        normed2 = graph_ops.add_rms_norm(
-            network, hidden, hidden_size,
-            weights[f"layer.{layer_idx}.post_attn_norm"], eps_t)
+        if use_batch:
+            normed2 = graph_ops.add_rms_norm_last_dim(
+                network, hidden, hidden_size,
+                weights[f"layer.{layer_idx}.post_attn_norm"], eps_t)
+        else:
+            normed2 = graph_ops.add_rms_norm(
+                network, hidden, hidden_size,
+                weights[f"layer.{layer_idx}.post_attn_norm"], eps_t)
 
         # SwiGLU MLP
         gate = graph_ops.add_matmul_rhs_constant(
@@ -244,7 +302,7 @@ def build_qwen3_encoder_engine(
 
     print(f"[qwen3-encoder] Building TRT engine "
           f"(layers={num_layers}, hidden={hidden_size}, output_layer={output_layer}, "
-          f"seq_len={max_seq_len}) ...", file=sys.stderr)
+          f"seq_len={max_seq_len}, max_batch={max_batch_size}) ...", file=sys.stderr)
 
     plan = builder.build_serialized_network(network, config)
     if plan is None:
@@ -265,3 +323,133 @@ def _add_per_head_rms_norm(
     return graph_ops.add_rms_norm_per_head(
         network, inp, num_heads, head_dim, gamma, eps_t,
         sequence_length=seq_len)
+
+
+def _reshape_batched_rows_to_heads_4d(
+    network: trt.INetworkDefinition,
+    x: trt.ITensor,
+    num_heads: int,
+    head_dim: int,
+    seq_len: int,
+) -> trt.ITensor:
+    """[B, S, H*D] -> [B, H, S, D]."""
+    r = network.add_shuffle(x)
+    r.reshape_dims = (-1, seq_len, num_heads, head_dim)
+    r.second_transpose = trt.Permutation([0, 2, 1, 3])
+    return r.get_output(0)
+
+
+def _reshape_heads_4d_to_batched_rows(
+    network: trt.INetworkDefinition,
+    x: trt.ITensor,
+    num_heads: int,
+    head_dim: int,
+    seq_len: int,
+) -> trt.ITensor:
+    """[B, H, S, D] -> [B, S, H*D]."""
+    r = network.add_shuffle(x)
+    r.first_transpose = trt.Permutation([0, 2, 1, 3])
+    r.reshape_dims = (-1, seq_len, num_heads * head_dim)
+    return r.get_output(0)
+
+
+def _dynamic_batch_shape(
+    network: trt.INetworkDefinition,
+    reference: trt.ITensor,
+    tail: tuple[int, ...],
+) -> trt.ITensor:
+    ref_shape = network.add_shape(reference).get_output(0)
+    batch_dim = network.add_slice(ref_shape, start=(0,), shape=(1,), stride=(1,))
+    tail_t = graph_ops.add_constant(
+        network,
+        (len(tail),),
+        np.asarray(tail, dtype=np.int64),
+        dtype=np.int64,
+    )
+    target = network.add_concatenation([batch_dim.get_output(0), tail_t])
+    target.axis = 0
+    return target.get_output(0)
+
+
+def _slice_batched_last_dim(
+    network: trt.INetworkDefinition,
+    x: trt.ITensor,
+    seq_len: int,
+    num_heads: int,
+    start: int,
+    width: int,
+) -> trt.ITensor:
+    s = network.add_slice(
+        x, start=(0, 0, 0, start), shape=(0, 0, 0, 0), stride=(1, 1, 1, 1))
+    s.set_input(2, _dynamic_batch_shape(network, x, (seq_len, num_heads, width)))
+    return s.get_output(0)
+
+
+def _add_apply_rope_native_batched(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    cos_cache_2d: trt.ITensor,
+    sin_cache_2d: trt.ITensor,
+    num_heads: int,
+    head_dim: int,
+    seq_len: int,
+) -> trt.ITensor:
+    """Apply rotate-half RoPE to [B, S, H*D] using a static per-position cache."""
+    half = head_dim // 2
+    x = network.add_shuffle(inp)
+    x.reshape_dims = (-1, seq_len, num_heads, head_dim)
+    x_4d = x.get_output(0)
+
+    x1 = _slice_batched_last_dim(network, x_4d, seq_len, num_heads, 0, half)
+    x2 = _slice_batched_last_dim(network, x_4d, seq_len, num_heads, half, half)
+
+    cos = network.add_shuffle(cos_cache_2d)
+    cos.reshape_dims = (1, seq_len, 1, half)
+    sin = network.add_shuffle(sin_cache_2d)
+    sin.reshape_dims = (1, seq_len, 1, half)
+
+    x1_cos = network.add_elementwise(x1, cos.get_output(0), trt.ElementWiseOperation.PROD)
+    x2_sin = network.add_elementwise(x2, sin.get_output(0), trt.ElementWiseOperation.PROD)
+    first = network.add_elementwise(
+        x1_cos.get_output(0), x2_sin.get_output(0), trt.ElementWiseOperation.SUB)
+
+    x2_cos = network.add_elementwise(x2, cos.get_output(0), trt.ElementWiseOperation.PROD)
+    x1_sin = network.add_elementwise(x1, sin.get_output(0), trt.ElementWiseOperation.PROD)
+    second = network.add_elementwise(
+        x2_cos.get_output(0), x1_sin.get_output(0), trt.ElementWiseOperation.SUM)
+
+    rope = network.add_concatenation([first.get_output(0), second.get_output(0)])
+    rope.axis = 3
+    out = network.add_shuffle(rope.get_output(0))
+    out.reshape_dims = (-1, seq_len, num_heads * head_dim)
+    return out.get_output(0)
+
+
+def _add_attention_from_batched_rows(
+    network: trt.INetworkDefinition,
+    q: trt.ITensor,
+    k: trt.ITensor,
+    v: trt.ITensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    q_seq: int,
+    kv_seq: int,
+    mask: trt.ITensor | None,
+) -> trt.ITensor:
+    """Native IAttention for [B, S, H*D] Q and [B, S, KVH*D] K/V."""
+    q_4d = _reshape_batched_rows_to_heads_4d(network, q, num_heads, head_dim, q_seq)
+    k_4d = _reshape_batched_rows_to_heads_4d(network, k, num_kv_heads, head_dim, kv_seq)
+    v_4d = _reshape_batched_rows_to_heads_4d(network, v, num_kv_heads, head_dim, kv_seq)
+    ctx_4d = graph_ops.add_attention_core(
+        network,
+        q_4d,
+        k_4d,
+        v_4d,
+        causal=False,
+        mask=mask,
+        scale=float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0,
+    )
+    return _reshape_heads_4d_to_batched_rows(
+        network, ctx_4d, num_heads, head_dim, q_seq)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/z_image/z_image_dit_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/z_image/z_image_dit_builder.py
@@ -171,9 +171,29 @@ def build_z_image_dit_engine(
     head_dim: int = 128,
     adaln_embed_dim: int = 256,
     eps: float = 1e-5,
+    max_batch_size: int = 1,
+    opt_batch_size: int | None = None,
     verbose: bool = False,
 ) -> bytes:
     """Build Z-Image DiT TRT engine."""
+    if max_batch_size > 1:
+        return _build_z_image_dit_engine_batched(
+            weights,
+            dim=dim,
+            num_heads=num_heads,
+            num_layers=num_layers,
+            num_refiner_layers=num_refiner_layers,
+            ffn_dim=ffn_dim,
+            num_patches=num_patches,
+            text_seq_len=text_seq_len,
+            head_dim=head_dim,
+            adaln_embed_dim=adaln_embed_dim,
+            eps=eps,
+            max_batch_size=max_batch_size,
+            opt_batch_size=opt_batch_size,
+            verbose=verbose,
+        )
+
     total_seq = num_patches + text_seq_len
     attn_scale = 1.0 / np.sqrt(max(head_dim, 1))
     out_channels = weights["final_linear.weight"].shape[1]
@@ -412,6 +432,355 @@ def build_z_image_dit_engine(
     return bytes(plan)
 
 
+def _dynamic_batch_shape(network, reference, tail: tuple[int, ...]):
+    """Shape tensor [B, *tail] using dim 0 from a dynamic-batch tensor."""
+    ref_shape = network.add_shape(reference).get_output(0)
+    batch = network.add_slice(ref_shape, start=(0,), shape=(1,), stride=(1,))
+    tail_t = graph_ops.add_constant(
+        network, (len(tail),), np.asarray(tail, dtype=np.int64), dtype=np.int64)
+    target = network.add_concatenation([batch.get_output(0), tail_t])
+    target.axis = 0
+    return target.get_output(0)
+
+
+def _slice_batched_sequence(network, x, start_seq: int, length: int, width: int):
+    """Slice [B, S, D] along S while preserving runtime-dynamic B."""
+    s = network.add_slice(
+        x, start=(0, start_seq, 0), shape=(0, 0, 0), stride=(1, 1, 1))
+    s.set_input(2, _dynamic_batch_shape(network, x, (length, width)))
+    return s.get_output(0)
+
+
+def _slice_batched_rope_half(network, rope, seq_len: int, half: int):
+    """Slice interleaved full-dim RoPE cache [B, S, D] to [B, S, D/2]."""
+    s = network.add_slice(
+        rope, start=(0, 0, 0), shape=(0, 0, 0), stride=(1, 1, 2))
+    s.set_input(2, _dynamic_batch_shape(network, rope, (seq_len, half)))
+    return s.get_output(0)
+
+
+def _slice_batched_complex_part(network, x, seq_len: int, num_heads: int,
+                                half: int, complex_index: int):
+    """Slice real/imag part from [B, S, H, D/2, 2] to [B, S, H, D/2]."""
+    s = network.add_slice(
+        x, start=(0, 0, 0, 0, complex_index), shape=(0, 0, 0, 0, 0),
+        stride=(1, 1, 1, 1, 1))
+    s.set_input(2, _dynamic_batch_shape(network, x, (seq_len, num_heads, half, 1)))
+    r = network.add_shuffle(s.get_output(0))
+    r.reshape_dims = (-1, seq_len, num_heads, half)
+    return r.get_output(0)
+
+
+def _reshape_batched_rows_to_heads_4d(network, x, num_heads: int, head_dim: int,
+                                      seq_len: int):
+    """[B, S, H*D] -> [B, H, S, D]."""
+    r = network.add_shuffle(x)
+    r.reshape_dims = (-1, seq_len, num_heads, head_dim)
+    r.second_transpose = trt.Permutation([0, 2, 1, 3])
+    return r.get_output(0)
+
+
+def _reshape_heads_4d_to_batched_rows(network, x, num_heads: int, head_dim: int,
+                                      seq_len: int):
+    """[B, H, S, D] -> [B, S, H*D]."""
+    r = network.add_shuffle(x)
+    r.first_transpose = trt.Permutation([0, 2, 1, 3])
+    r.reshape_dims = (-1, seq_len, num_heads * head_dim)
+    return r.get_output(0)
+
+
+def _multi_head_attention_batched(network, q, k, v, num_heads: int, head_dim: int,
+                                  q_seq: int, kv_seq: int, scale_t):
+    """Standard multi-head attention for [B, S, H*D] tensors."""
+    q_4d = _reshape_batched_rows_to_heads_4d(network, q, num_heads, head_dim, q_seq)
+    k_4d = _reshape_batched_rows_to_heads_4d(network, k, num_heads, head_dim, kv_seq)
+    v_4d = _reshape_batched_rows_to_heads_4d(network, v, num_heads, head_dim, kv_seq)
+    ctx_4d = graph_ops.add_attention_core(
+        network, q_4d, k_4d, v_4d, causal=False, mask=None,
+        scale=float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0)
+    return _reshape_heads_4d_to_batched_rows(network, ctx_4d, num_heads, head_dim, q_seq)
+
+
+def _apply_rope_batched_from_full_cache(network, x, cos_t, sin_t, num_heads: int,
+                                        head_dim: int, seq_len: int):
+    """Apply Z-Image interleaved RoPE to [B, S, H*D] with [B, S, D] caches."""
+    half = head_dim // 2
+    x_pairs_r = network.add_shuffle(x)
+    x_pairs_r.reshape_dims = (-1, seq_len, num_heads, half, 2)
+    x_pairs = x_pairs_r.get_output(0)
+
+    x_real = _slice_batched_complex_part(network, x_pairs, seq_len, num_heads, half, 0)
+    x_imag = _slice_batched_complex_part(network, x_pairs, seq_len, num_heads, half, 1)
+
+    cos_half = _slice_batched_rope_half(network, cos_t, seq_len, half)
+    sin_half = _slice_batched_rope_half(network, sin_t, seq_len, half)
+    cos_4d = network.add_shuffle(cos_half)
+    cos_4d.reshape_dims = (-1, seq_len, 1, half)
+    sin_4d = network.add_shuffle(sin_half)
+    sin_4d.reshape_dims = (-1, seq_len, 1, half)
+
+    r_cos = network.add_elementwise(
+        x_real, cos_4d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    i_sin = network.add_elementwise(
+        x_imag, sin_4d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    new_real = network.add_elementwise(
+        r_cos, i_sin, trt.ElementWiseOperation.SUB).get_output(0)
+
+    r_sin = network.add_elementwise(
+        x_real, sin_4d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    i_cos = network.add_elementwise(
+        x_imag, cos_4d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    new_imag = network.add_elementwise(
+        r_sin, i_cos, trt.ElementWiseOperation.SUM).get_output(0)
+
+    nr = network.add_shuffle(new_real)
+    nr.reshape_dims = (-1, seq_len, num_heads, half, 1)
+    ni = network.add_shuffle(new_imag)
+    ni.reshape_dims = (-1, seq_len, num_heads, half, 1)
+    cat = network.add_concatenation([nr.get_output(0), ni.get_output(0)])
+    cat.axis = 4
+
+    flat = network.add_shuffle(cat.get_output(0))
+    flat.reshape_dims = (-1, seq_len, num_heads * head_dim)
+    return flat.get_output(0)
+
+
+def _layer_norm_last_dim_no_affine_batched(network, x, hidden_size: int, eps: float = 1e-6):
+    """LayerNorm without affine over final dim for [B, S, D]."""
+    eps_t = graph_ops.add_constant(network, (1, 1, 1), np.array([eps], dtype=np.float32))
+    mean = network.add_reduce(x, trt.ReduceOperation.AVG, 1 << 2, keep_dims=True)
+    centered = network.add_elementwise(
+        x, mean.get_output(0), trt.ElementWiseOperation.SUB).get_output(0)
+    sq = network.add_elementwise(centered, centered, trt.ElementWiseOperation.PROD)
+    var = network.add_reduce(sq.get_output(0), trt.ReduceOperation.AVG, 1 << 2, keep_dims=True)
+    var_eps = network.add_elementwise(
+        var.get_output(0), eps_t, trt.ElementWiseOperation.SUM)
+    std = network.add_unary(var_eps.get_output(0), trt.UnaryOperation.SQRT)
+    inv_std = network.add_unary(std.get_output(0), trt.UnaryOperation.RECIP)
+    return network.add_elementwise(
+        centered, inv_std.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def _build_z_image_dit_engine_batched(
+    weights: WeightDict,
+    *,
+    dim: int,
+    num_heads: int,
+    num_layers: int,
+    num_refiner_layers: int,
+    ffn_dim: int,
+    num_patches: int,
+    text_seq_len: int,
+    head_dim: int,
+    adaln_embed_dim: int,
+    eps: float,
+    max_batch_size: int,
+    opt_batch_size: int | None,
+    verbose: bool,
+) -> bytes:
+    """Build a dynamic-leading-batch Z-Image DiT TRT engine."""
+    from ...engine_builder import add_dynamic_batch_profile
+
+    if max_batch_size < 1:
+        raise ValueError(f"max_batch_size must be >= 1 (got {max_batch_size})")
+    opt_batch = min(max_batch_size, 4) if opt_batch_size is None else opt_batch_size
+    total_seq = num_patches + text_seq_len
+    out_channels = weights["final_linear.weight"].shape[1]
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    noise_inp = network.add_input("hidden_states", trt.float32, (-1, num_patches, dim))
+    caption_inp = network.add_input(
+        "encoder_hidden_states", trt.float32, (-1, text_seq_len, dim))
+    temb_inp = network.add_input(
+        "timestep_embedding", trt.float32, (-1, 1, adaln_embed_dim))
+    rope_cos = network.add_input("rotary_cos", trt.float32, (-1, total_seq, head_dim))
+    rope_sin = network.add_input("rotary_sin", trt.float32, (-1, total_seq, head_dim))
+
+    add_dynamic_batch_profile(
+        builder,
+        config,
+        network,
+        input_names=[
+            "hidden_states",
+            "encoder_hidden_states",
+            "timestep_embedding",
+            "rotary_cos",
+            "rotary_sin",
+        ],
+        max_batch=max_batch_size,
+        opt_batch=opt_batch,
+        static_shape={
+            "hidden_states": (num_patches, dim),
+            "encoder_hidden_states": (text_seq_len, dim),
+            "timestep_embedding": (1, adaln_embed_dim),
+            "rotary_cos": (total_seq, head_dim),
+            "rotary_sin": (total_seq, head_dim),
+        },
+    )
+
+    eps_t = graph_ops.add_constant(network, (1, 1, 1), np.array([eps], dtype=np.float32))
+    scale_t = graph_ops.add_constant(
+        network, (1, 1, 1, 1), np.array([1.0 / np.sqrt(max(head_dim, 1))], dtype=np.float32))
+    ones_t = graph_ops.add_constant(network, (1, 1, 1), np.array([1.0], dtype=np.float32))
+
+    noise = noise_inp
+    caption = caption_inp
+
+    noise_cos = _slice_batched_sequence(network, rope_cos, 0, num_patches, head_dim)
+    noise_sin = _slice_batched_sequence(network, rope_sin, 0, num_patches, head_dim)
+    for i in range(num_refiner_layers):
+        tp = f"noise_refiner.{i}"
+        noise = _add_adaln_dit_block_batched(
+            network, noise, weights, tp, temb_inp,
+            dim, num_heads, head_dim, ffn_dim, adaln_embed_dim,
+            num_patches, eps_t, scale_t, noise_cos, noise_sin, ones_t,
+        )
+
+    cap_cos = _slice_batched_sequence(network, rope_cos, num_patches, text_seq_len, head_dim)
+    cap_sin = _slice_batched_sequence(network, rope_sin, num_patches, text_seq_len, head_dim)
+    for i in range(num_refiner_layers):
+        tp = f"context_refiner.{i}"
+        caption = _add_plain_dit_block_batched(
+            network, caption, weights, tp,
+            dim, num_heads, head_dim, ffn_dim, text_seq_len,
+            eps_t, scale_t, cap_cos, cap_sin,
+        )
+
+    for i in range(num_layers):
+        tp = f"main.{i}"
+
+        adaln_w = weights[f"{tp}.adaln.weight"]
+        adaln_b = weights[f"{tp}.adaln.bias"]
+        modulation = graph_ops.add_matmul_rhs_constant(
+            network, temb_inp, adaln_embed_dim, 4 * dim, adaln_w)
+        modulation = graph_ops.add_bias_sum(network, modulation, 4 * dim, adaln_b)
+
+        chunks = []
+        for ci in range(4):
+            s = network.add_slice(
+                modulation, start=(0, 0, ci * dim), shape=(0, 0, 0),
+                stride=(1, 1, 1))
+            s.set_input(2, _dynamic_batch_shape(network, modulation, (1, dim)))
+            chunks.append(s.get_output(0))
+        scale_msa, gate_msa_raw, scale_mlp, gate_mlp_raw = chunks
+
+        gate_msa = network.add_activation(gate_msa_raw, trt.ActivationType.TANH).get_output(0)
+        gate_mlp = network.add_activation(gate_mlp_raw, trt.ActivationType.TANH).get_output(0)
+        scale_msa_p1 = network.add_elementwise(
+            scale_msa, ones_t, trt.ElementWiseOperation.SUM).get_output(0)
+        scale_mlp_p1 = network.add_elementwise(
+            scale_mlp, ones_t, trt.ElementWiseOperation.SUM).get_output(0)
+
+        unified = network.add_concatenation([noise, caption])
+        unified.axis = 1
+        unified_t = unified.get_output(0)
+
+        unified_normed = graph_ops.add_rms_norm_last_dim(
+            network, unified_t, dim, weights[f"{tp}.attn_norm1"], eps_t)
+        unified_scaled = network.add_elementwise(
+            unified_normed, scale_msa_p1, trt.ElementWiseOperation.PROD).get_output(0)
+
+        q = graph_ops.add_matmul_rhs_constant(
+            network, unified_scaled, dim, dim, weights[f"{tp}.to_q"])
+        k = graph_ops.add_matmul_rhs_constant(
+            network, unified_scaled, dim, dim, weights[f"{tp}.to_k"])
+        v = graph_ops.add_matmul_rhs_constant(
+            network, unified_scaled, dim, dim, weights[f"{tp}.to_v"])
+
+        q_norm_tiled = np.tile(weights[f"{tp}.norm_q"].reshape(1, head_dim), (num_heads, 1))
+        k_norm_tiled = np.tile(weights[f"{tp}.norm_k"].reshape(1, head_dim), (num_heads, 1))
+        q = graph_ops.add_rms_norm_per_head_batched(
+            network, q, num_heads, head_dim, q_norm_tiled, eps_t,
+            sequence_length=total_seq)
+        k = graph_ops.add_rms_norm_per_head_batched(
+            network, k, num_heads, head_dim, k_norm_tiled, eps_t,
+            sequence_length=total_seq)
+
+        q = _apply_rope_batched_from_full_cache(
+            network, q, rope_cos, rope_sin, num_heads, head_dim, total_seq)
+        k = _apply_rope_batched_from_full_cache(
+            network, k, rope_cos, rope_sin, num_heads, head_dim, total_seq)
+
+        attn_out = _multi_head_attention_batched(
+            network, q, k, v, num_heads, head_dim, total_seq, total_seq, scale_t)
+        attn_out = graph_ops.add_matmul_rhs_constant(
+            network, attn_out, dim, dim, weights[f"{tp}.to_out"])
+        attn_out_normed = graph_ops.add_rms_norm_last_dim(
+            network, attn_out, dim, weights[f"{tp}.attn_norm2"], eps_t)
+
+        gated_attn = network.add_elementwise(
+            attn_out_normed, gate_msa, trt.ElementWiseOperation.PROD)
+        unified_t = network.add_elementwise(
+            unified_t, gated_attn.get_output(0), trt.ElementWiseOperation.SUM).get_output(0)
+
+        unified_ffn_normed = graph_ops.add_rms_norm_last_dim(
+            network, unified_t, dim, weights[f"{tp}.ffn_norm1"], eps_t)
+        unified_ffn_scaled = network.add_elementwise(
+            unified_ffn_normed, scale_mlp_p1, trt.ElementWiseOperation.PROD).get_output(0)
+
+        gate_proj = graph_ops.add_matmul_rhs_constant(
+            network, unified_ffn_scaled, dim, ffn_dim, weights[f"{tp}.ff_w1"])
+        up_proj = graph_ops.add_matmul_rhs_constant(
+            network, unified_ffn_scaled, dim, ffn_dim, weights[f"{tp}.ff_w3"])
+        gate_sigmoid = network.add_activation(gate_proj, trt.ActivationType.SIGMOID)
+        gate_silu = network.add_elementwise(
+            gate_proj, gate_sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+        gated_ffn = network.add_elementwise(
+            gate_silu.get_output(0), up_proj, trt.ElementWiseOperation.PROD)
+        down_proj = graph_ops.add_matmul_rhs_constant(
+            network, gated_ffn.get_output(0), ffn_dim, dim, weights[f"{tp}.ff_w2"])
+
+        ffn_out_normed = graph_ops.add_rms_norm_last_dim(
+            network, down_proj, dim, weights[f"{tp}.ffn_norm2"], eps_t)
+        gated_ffn_out = network.add_elementwise(
+            ffn_out_normed, gate_mlp, trt.ElementWiseOperation.PROD)
+        unified_t = network.add_elementwise(
+            unified_t, gated_ffn_out.get_output(0), trt.ElementWiseOperation.SUM).get_output(0)
+
+        noise = _slice_batched_sequence(network, unified_t, 0, num_patches, dim)
+        caption = _slice_batched_sequence(network, unified_t, num_patches, text_seq_len, dim)
+
+    temb_silu = network.add_activation(temb_inp, trt.ActivationType.SIGMOID)
+    temb_silu_act = network.add_elementwise(
+        temb_inp, temb_silu.get_output(0), trt.ElementWiseOperation.PROD)
+    final_mod = graph_ops.add_matmul_rhs_constant(
+        network, temb_silu_act.get_output(0), adaln_embed_dim, dim,
+        weights["final_adaLN.weight"])
+    final_mod = graph_ops.add_bias_sum(network, final_mod, dim, weights["final_adaLN.bias"])
+    final_scale = network.add_elementwise(
+        final_mod, ones_t, trt.ElementWiseOperation.SUM).get_output(0)
+
+    noise_ln = _layer_norm_last_dim_no_affine_batched(network, noise, dim, eps=1e-6)
+    noise_final = network.add_elementwise(
+        noise_ln, final_scale, trt.ElementWiseOperation.PROD).get_output(0)
+
+    output = graph_ops.add_matmul_rhs_constant(
+        network, noise_final, dim, out_channels, weights["final_linear.weight"])
+    output = graph_ops.add_bias_sum(
+        network, output, out_channels, weights["final_linear.bias"])
+
+    cast_output = network.add_cast(output, trt.float32)
+    output_final = cast_output.get_output(0)
+    output_final.name = "output"
+    network.mark_output(output_final)
+
+    print(f"[z-image-dit] Building dynamic-batch TRT engine "
+          f"(B=1..{max_batch_size}, opt={opt_batch}, dim={dim}, layers={num_layers}, "
+          f"refiners={num_refiner_layers}, patches={num_patches}, "
+          f"text_seq={text_seq_len}, out_ch={out_channels}) ...",
+          file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError("Z-Image dynamic-batch DiT TRT engine build failed")
+    return bytes(plan)
+
+
 def _slice_rope(network, rope, start_seq, length, rope_dim):
     """Slice RoPE along sequence dimension."""
     s = network.add_slice(rope, start=(start_seq, 0), shape=(length, rope_dim), stride=(1, 1))
@@ -587,4 +956,144 @@ def _add_adaln_dit_block(
 
     gated_ffn = network.add_elementwise(ffn_out_normed, gate_mlp, trt.ElementWiseOperation.PROD)
     x = network.add_elementwise(x, gated_ffn.get_output(0), trt.ElementWiseOperation.SUM).get_output(0)
+    return x
+
+
+def _add_plain_dit_block_batched(
+    network, x, weights, prefix,
+    dim, num_heads, head_dim, ffn_dim, seq_len,
+    eps_t, scale_t, cos_t, sin_t,
+):
+    """Plain DiT block for [B, S, D] tensors."""
+    normed = graph_ops.add_rms_norm_last_dim(
+        network, x, dim, weights[f"{prefix}.attn_norm1"], eps_t)
+
+    q = graph_ops.add_matmul_rhs_constant(network, normed, dim, dim, weights[f"{prefix}.to_q"])
+    k = graph_ops.add_matmul_rhs_constant(network, normed, dim, dim, weights[f"{prefix}.to_k"])
+    v = graph_ops.add_matmul_rhs_constant(network, normed, dim, dim, weights[f"{prefix}.to_v"])
+
+    q_norm = np.tile(weights[f"{prefix}.norm_q"].reshape(1, head_dim), (num_heads, 1))
+    k_norm = np.tile(weights[f"{prefix}.norm_k"].reshape(1, head_dim), (num_heads, 1))
+    q = graph_ops.add_rms_norm_per_head_batched(
+        network, q, num_heads, head_dim, q_norm, eps_t, sequence_length=seq_len)
+    k = graph_ops.add_rms_norm_per_head_batched(
+        network, k, num_heads, head_dim, k_norm, eps_t, sequence_length=seq_len)
+
+    q = _apply_rope_batched_from_full_cache(
+        network, q, cos_t, sin_t, num_heads, head_dim, seq_len)
+    k = _apply_rope_batched_from_full_cache(
+        network, k, cos_t, sin_t, num_heads, head_dim, seq_len)
+
+    attn_out = _multi_head_attention_batched(
+        network, q, k, v, num_heads, head_dim, seq_len, seq_len, scale_t)
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, attn_out, dim, dim, weights[f"{prefix}.to_out"])
+    attn_out_normed = graph_ops.add_rms_norm_last_dim(
+        network, attn_out, dim, weights[f"{prefix}.attn_norm2"], eps_t)
+
+    x = network.add_elementwise(x, attn_out_normed, trt.ElementWiseOperation.SUM).get_output(0)
+
+    ffn_normed = graph_ops.add_rms_norm_last_dim(
+        network, x, dim, weights[f"{prefix}.ffn_norm1"], eps_t)
+    gate_proj = graph_ops.add_matmul_rhs_constant(
+        network, ffn_normed, dim, ffn_dim, weights[f"{prefix}.ff_w1"])
+    up_proj = graph_ops.add_matmul_rhs_constant(
+        network, ffn_normed, dim, ffn_dim, weights[f"{prefix}.ff_w3"])
+    gate_sigmoid = network.add_activation(gate_proj, trt.ActivationType.SIGMOID)
+    gate_silu = network.add_elementwise(
+        gate_proj, gate_sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    gated = network.add_elementwise(
+        gate_silu.get_output(0), up_proj, trt.ElementWiseOperation.PROD)
+    down_proj = graph_ops.add_matmul_rhs_constant(
+        network, gated.get_output(0), ffn_dim, dim, weights[f"{prefix}.ff_w2"])
+
+    ffn_out_normed = graph_ops.add_rms_norm_last_dim(
+        network, down_proj, dim, weights[f"{prefix}.ffn_norm2"], eps_t)
+    x = network.add_elementwise(x, ffn_out_normed, trt.ElementWiseOperation.SUM).get_output(0)
+    return x
+
+
+def _add_adaln_dit_block_batched(
+    network, x, weights, prefix, temb,
+    dim, num_heads, head_dim, ffn_dim, adaln_embed_dim,
+    seq_len, eps_t, scale_t, cos_t, sin_t, ones_t,
+):
+    """AdaLN DiT block for [B, S, D] tensors."""
+    adaln_w = weights[f"{prefix}.adaln.weight"]
+    adaln_b = weights[f"{prefix}.adaln.bias"]
+    mod = graph_ops.add_matmul_rhs_constant(
+        network, temb, adaln_embed_dim, 4 * dim, adaln_w)
+    mod = graph_ops.add_bias_sum(network, mod, 4 * dim, adaln_b)
+
+    chunks = []
+    for ci in range(4):
+        s = network.add_slice(
+            mod, start=(0, 0, ci * dim), shape=(0, 0, 0), stride=(1, 1, 1))
+        s.set_input(2, _dynamic_batch_shape(network, mod, (1, dim)))
+        chunks.append(s.get_output(0))
+    scale_msa, gate_msa_raw, scale_mlp, gate_mlp_raw = chunks
+
+    gate_msa = network.add_activation(gate_msa_raw, trt.ActivationType.TANH).get_output(0)
+    gate_mlp = network.add_activation(gate_mlp_raw, trt.ActivationType.TANH).get_output(0)
+    scale_msa_p1 = network.add_elementwise(
+        scale_msa, ones_t, trt.ElementWiseOperation.SUM).get_output(0)
+    scale_mlp_p1 = network.add_elementwise(
+        scale_mlp, ones_t, trt.ElementWiseOperation.SUM).get_output(0)
+
+    normed = graph_ops.add_rms_norm_last_dim(
+        network, x, dim, weights[f"{prefix}.attn_norm1"], eps_t)
+    normed = network.add_elementwise(
+        normed, scale_msa_p1, trt.ElementWiseOperation.PROD).get_output(0)
+
+    q = graph_ops.add_matmul_rhs_constant(network, normed, dim, dim, weights[f"{prefix}.to_q"])
+    k = graph_ops.add_matmul_rhs_constant(network, normed, dim, dim, weights[f"{prefix}.to_k"])
+    v = graph_ops.add_matmul_rhs_constant(network, normed, dim, dim, weights[f"{prefix}.to_v"])
+
+    q_norm = np.tile(weights[f"{prefix}.norm_q"].reshape(1, head_dim), (num_heads, 1))
+    k_norm = np.tile(weights[f"{prefix}.norm_k"].reshape(1, head_dim), (num_heads, 1))
+    q = graph_ops.add_rms_norm_per_head_batched(
+        network, q, num_heads, head_dim, q_norm, eps_t, sequence_length=seq_len)
+    k = graph_ops.add_rms_norm_per_head_batched(
+        network, k, num_heads, head_dim, k_norm, eps_t, sequence_length=seq_len)
+
+    q = _apply_rope_batched_from_full_cache(
+        network, q, cos_t, sin_t, num_heads, head_dim, seq_len)
+    k = _apply_rope_batched_from_full_cache(
+        network, k, cos_t, sin_t, num_heads, head_dim, seq_len)
+
+    attn_out = _multi_head_attention_batched(
+        network, q, k, v, num_heads, head_dim, seq_len, seq_len, scale_t)
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, attn_out, dim, dim, weights[f"{prefix}.to_out"])
+    attn_out_normed = graph_ops.add_rms_norm_last_dim(
+        network, attn_out, dim, weights[f"{prefix}.attn_norm2"], eps_t)
+
+    gated_attn = network.add_elementwise(
+        attn_out_normed, gate_msa, trt.ElementWiseOperation.PROD)
+    x = network.add_elementwise(
+        x, gated_attn.get_output(0), trt.ElementWiseOperation.SUM).get_output(0)
+
+    ffn_normed = graph_ops.add_rms_norm_last_dim(
+        network, x, dim, weights[f"{prefix}.ffn_norm1"], eps_t)
+    ffn_normed = network.add_elementwise(
+        ffn_normed, scale_mlp_p1, trt.ElementWiseOperation.PROD).get_output(0)
+
+    gate_proj = graph_ops.add_matmul_rhs_constant(
+        network, ffn_normed, dim, ffn_dim, weights[f"{prefix}.ff_w1"])
+    up_proj = graph_ops.add_matmul_rhs_constant(
+        network, ffn_normed, dim, ffn_dim, weights[f"{prefix}.ff_w3"])
+    gate_sigmoid = network.add_activation(gate_proj, trt.ActivationType.SIGMOID)
+    gate_silu = network.add_elementwise(
+        gate_proj, gate_sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    gated = network.add_elementwise(
+        gate_silu.get_output(0), up_proj, trt.ElementWiseOperation.PROD)
+    down_proj = graph_ops.add_matmul_rhs_constant(
+        network, gated.get_output(0), ffn_dim, dim, weights[f"{prefix}.ff_w2"])
+
+    ffn_out_normed = graph_ops.add_rms_norm_last_dim(
+        network, down_proj, dim, weights[f"{prefix}.ffn_norm2"], eps_t)
+    gated_ffn = network.add_elementwise(
+        ffn_out_normed, gate_mlp, trt.ElementWiseOperation.PROD)
+    x = network.add_elementwise(
+        x, gated_ffn.get_output(0), trt.ElementWiseOperation.SUM).get_output(0)
     return x

--- a/tensorrt_model_connect/tensorrt_model_connect/graph_ops.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/graph_ops.py
@@ -192,6 +192,117 @@ def add_rms_norm_per_head(
     return reshape_out.get_output(0)
 
 
+def _dynamic_batch_shape(
+    network: trt.INetworkDefinition,
+    reference: trt.ITensor,
+    tail: tuple[int, ...],
+) -> trt.ITensor:
+    """Return a shape tensor [B, *tail] using dim 0 from ``reference``."""
+    ref_shape = network.add_shape(reference).get_output(0)
+    batch_dim = network.add_slice(ref_shape, start=(0,), shape=(1,), stride=(1,))
+    tail_t = add_constant(
+        network,
+        (len(tail),),
+        np.asarray(tail, dtype=np.int64),
+        dtype=np.int64,
+    )
+    target = network.add_concatenation([batch_dim.get_output(0), tail_t])
+    target.axis = 0
+    return target.get_output(0)
+
+
+def add_rms_norm_last_dim(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    gamma: np.ndarray,
+    eps_tensor: trt.ITensor,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """RMSNorm over the final dimension for rank-2/rank-3 tensors."""
+    rank = len(tuple(inp.shape))
+    if rank < 2:
+        raise ValueError("add_rms_norm_last_dim expects rank >= 2")
+
+    need_cast = (dtype != np.float32)
+    output_dtype = inp.dtype
+    if need_cast:
+        inp = network.add_cast(inp, trt.float32).get_output(0)
+        eps_tensor = network.add_cast(eps_tensor, trt.float32).get_output(0)
+
+    sq = network.add_elementwise(inp, inp, trt.ElementWiseOperation.PROD)
+    mean = network.add_reduce(
+        sq.get_output(0), trt.ReduceOperation.AVG, 1 << (rank - 1), keep_dims=True)
+    denom_in = network.add_elementwise(
+        mean.get_output(0), eps_tensor, trt.ElementWiseOperation.SUM)
+    sqrt_l = network.add_unary(denom_in.get_output(0), trt.UnaryOperation.SQRT)
+    recip = network.add_unary(sqrt_l.get_output(0), trt.UnaryOperation.RECIP)
+    normalized = network.add_elementwise(
+        inp, recip.get_output(0), trt.ElementWiseOperation.PROD)
+    gamma_shape = (1,) * (rank - 1) + (hidden_size,)
+    gamma_t = add_constant(
+        network, gamma_shape, np.asarray(gamma).reshape(gamma_shape), dtype=np.float32)
+    scaled = network.add_elementwise(
+        normalized.get_output(0), gamma_t, trt.ElementWiseOperation.PROD)
+    result = scaled.get_output(0)
+    if need_cast:
+        result = _cast_back_to_trt_dtype(network, result, output_dtype)
+    return result
+
+
+def add_rms_norm_per_head_batched(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    num_heads: int,
+    head_dim: int,
+    gamma: np.ndarray,
+    eps_tensor: trt.ITensor,
+    dtype: np.dtype = np.float32,
+    sequence_length: int | None = None,
+) -> trt.ITensor:
+    """Per-head RMSNorm for [B, S, num_heads * head_dim] tensors."""
+    seq_dim = -1 if sequence_length is None else sequence_length
+    need_cast = (dtype != np.float32)
+    output_dtype = inp.dtype
+
+    reshape_in = network.add_shuffle(inp)
+    reshape_in.reshape_dims = (-1, seq_dim, num_heads, head_dim)
+    reshaped = reshape_in.get_output(0)
+    if need_cast:
+        reshaped = network.add_cast(reshaped, trt.float32).get_output(0)
+        eps_tensor = network.add_cast(eps_tensor, trt.float32).get_output(0)
+
+    eps_4d = network.add_shuffle(eps_tensor)
+    eps_4d.reshape_dims = (1, 1, 1, 1)
+    sq = network.add_elementwise(reshaped, reshaped, trt.ElementWiseOperation.PROD)
+    mean = network.add_reduce(
+        sq.get_output(0), trt.ReduceOperation.AVG, 1 << 3, keep_dims=True)
+    denom_in = network.add_elementwise(
+        mean.get_output(0), eps_4d.get_output(0), trt.ElementWiseOperation.SUM)
+    sqrt_l = network.add_unary(denom_in.get_output(0), trt.UnaryOperation.SQRT)
+    recip = network.add_unary(sqrt_l.get_output(0), trt.UnaryOperation.RECIP)
+    normalized = network.add_elementwise(
+        reshaped, recip.get_output(0), trt.ElementWiseOperation.PROD)
+
+    gamma_arr = np.asarray(gamma, dtype=np.float32)
+    if gamma_arr.size == head_dim:
+        gamma_shape = (1, 1, 1, head_dim)
+        gamma_arr = gamma_arr.reshape(gamma_shape)
+    else:
+        gamma_shape = (1, 1, num_heads, head_dim)
+        gamma_arr = gamma_arr.reshape(gamma_shape)
+    gamma_t = add_constant(network, gamma_shape, gamma_arr, dtype=np.float32)
+    scaled = network.add_elementwise(
+        normalized.get_output(0), gamma_t, trt.ElementWiseOperation.PROD)
+
+    result = scaled.get_output(0)
+    if need_cast:
+        result = _cast_back_to_trt_dtype(network, result, output_dtype)
+    reshape_out = network.add_shuffle(result)
+    reshape_out.reshape_dims = (-1, seq_dim, num_heads * head_dim)
+    return reshape_out.get_output(0)
+
+
 def add_l2_norm(
     network: trt.INetworkDefinition,
     inp: trt.ITensor,

--- a/tests/builder/test_bundle_writer.py
+++ b/tests/builder/test_bundle_writer.py
@@ -160,6 +160,26 @@ class TestWriteBundle:
         assert header["num_attention_heads"] == 32
         assert header["num_key_value_heads"] == 8
 
+    def test_max_batch_size_roundtrip(self, tmp_path):
+        info = BundleInfo(
+            model_id="batch-test",
+            family="diffusion_flux",
+            max_batch_size={"dit": 4, "text_encoder": 8, "vae": 1},
+        )
+        out_path = str(tmp_path / "batch.trtfb")
+        write_bundle(out_path, info, [])
+
+        header, _ = self._read_bundle(out_path)
+        assert header["max_batch_size"] == {"dit": 4, "text_encoder": 8, "vae": 1}
+
+    def test_max_batch_size_omitted_when_unset(self, tmp_path):
+        info = BundleInfo(model_id="batch-default")
+        out_path = str(tmp_path / "batch-default.trtfb")
+        write_bundle(out_path, info, [])
+
+        header, _ = self._read_bundle(out_path)
+        assert "max_batch_size" not in header
+
 
 def _read_bundle_from_bytes(data: bytes) -> tuple[dict, dict[str, bytes]]:
     """Parse a .trtfb bundle from raw bytes. Raises on any format error."""

--- a/tests/builder/test_cli.py
+++ b/tests/builder/test_cli.py
@@ -144,6 +144,8 @@ class TestCmdInspect:
             "num_attention_heads": 16,
             "num_key_value_heads": 4,
             "max_cache_length": 256,
+            "runtime_strategy": "diffusion_qwen_image",
+            "max_batch_size": {"dit": 4, "text_encoder": 1, "vae": 1},
             "sections": {
                 "engine_plan": {"offset": 0, "size": 100},
             },
@@ -164,6 +166,7 @@ class TestCmdInspect:
         assert "qwen3" in captured.out
         assert "test-model" in captured.out
         assert "qwen" in captured.out
+        assert "dit=4 text_encoder=1 vae=1" in captured.out
         assert "engine_plan" in captured.out
 
     def test_inspect_nonexistent_file(self):

--- a/tests/builder/test_dynamic_batch_profile.py
+++ b/tests/builder/test_dynamic_batch_profile.py
@@ -1,0 +1,163 @@
+"""Tests for the diffusion dynamic-batch optimization-profile helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import requires_trt
+
+
+def test_add_dynamic_batch_profile_rejects_max_zero():
+    from tensorrt_model_connect.engine_builder import add_dynamic_batch_profile
+
+    class _FakeProfile:
+        def set_shape(self, *args, **kwargs):
+            pass
+
+    class _FakeBuilder:
+        def create_optimization_profile(self):
+            return _FakeProfile()
+
+    class _FakeConfig:
+        def add_optimization_profile(self, profile):
+            pass
+
+    with pytest.raises(ValueError, match="max_batch must be >= 1"):
+        add_dynamic_batch_profile(
+            _FakeBuilder(), _FakeConfig(), object(),
+            input_names=["x"],
+            max_batch=0,
+            opt_batch=1,
+            static_shape={"x": (8,)},
+        )
+
+
+def test_add_dynamic_batch_profile_rejects_opt_above_max():
+    from tensorrt_model_connect.engine_builder import add_dynamic_batch_profile
+
+    class _FakeProfile:
+        def set_shape(self, *args, **kwargs):
+            pass
+
+    class _FakeBuilder:
+        def create_optimization_profile(self):
+            return _FakeProfile()
+
+    class _FakeConfig:
+        def add_optimization_profile(self, profile):
+            pass
+
+    with pytest.raises(ValueError, match="opt_batch must satisfy"):
+        add_dynamic_batch_profile(
+            _FakeBuilder(), _FakeConfig(), object(),
+            input_names=["x"],
+            max_batch=4,
+            opt_batch=8,
+            static_shape={"x": (8,)},
+        )
+
+
+def test_add_dynamic_batch_profile_rejects_missing_static_shape():
+    from tensorrt_model_connect.engine_builder import add_dynamic_batch_profile
+
+    class _FakeProfile:
+        def set_shape(self, *args, **kwargs):
+            pass
+
+    class _FakeBuilder:
+        def create_optimization_profile(self):
+            return _FakeProfile()
+
+    class _FakeConfig:
+        def add_optimization_profile(self, profile):
+            pass
+
+    with pytest.raises(KeyError, match="static_shape missing"):
+        add_dynamic_batch_profile(
+            _FakeBuilder(), _FakeConfig(), object(),
+            input_names=["hidden_states", "encoder_hidden_states"],
+            max_batch=4,
+            opt_batch=4,
+            static_shape={"hidden_states": (64, 128)},
+        )
+
+
+def test_add_dynamic_batch_profile_sets_min_opt_max_shapes():
+    from tensorrt_model_connect.engine_builder import add_dynamic_batch_profile
+
+    class _Profile:
+        def __init__(self):
+            self.shapes: dict[str, tuple] = {}
+
+        def set_shape(self, name, *, min, opt, max):
+            self.shapes[name] = (tuple(min), tuple(opt), tuple(max))
+
+    class _Builder:
+        def __init__(self):
+            self.profile = _Profile()
+
+        def create_optimization_profile(self):
+            return self.profile
+
+    class _Config:
+        def __init__(self):
+            self.added = []
+
+        def add_optimization_profile(self, profile):
+            self.added.append(profile)
+
+    builder = _Builder()
+    config = _Config()
+
+    add_dynamic_batch_profile(
+        builder, config, object(),
+        input_names=["hidden_states", "encoder_hidden_states", "temb"],
+        max_batch=4,
+        opt_batch=4,
+        static_shape={
+            "hidden_states": (64, 128),
+            "encoder_hidden_states": (32, 256),
+            "temb": (768,),
+        },
+    )
+
+    assert len(config.added) == 1
+    assert builder.profile.shapes["hidden_states"] == (
+        (1, 64, 128), (4, 64, 128), (4, 64, 128)
+    )
+    assert builder.profile.shapes["encoder_hidden_states"] == (
+        (1, 32, 256), (4, 32, 256), (4, 32, 256)
+    )
+    assert builder.profile.shapes["temb"] == ((1, 768), (4, 768), (4, 768))
+
+
+@requires_trt
+def test_add_dynamic_batch_profile_builds_a_trivial_engine(tmp_path):
+    import tensorrt as trt
+    from tensorrt_model_connect.engine_builder import add_dynamic_batch_profile
+
+    logger = trt.Logger(trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(0)
+    x = network.add_input("x", trt.float32, (-1, 8))
+    identity = network.add_identity(x)
+    network.mark_output(identity.get_output(0))
+    config = builder.create_builder_config()
+
+    add_dynamic_batch_profile(
+        builder, config, network,
+        input_names=["x"],
+        max_batch=4,
+        opt_batch=4,
+        static_shape={"x": (8,)},
+    )
+
+    serialized = builder.build_serialized_network(network, config)
+    assert serialized is not None
+
+    runtime = trt.Runtime(logger)
+    engine = runtime.deserialize_cuda_engine(bytes(serialized))
+    ctx = engine.create_execution_context()
+    for batch in (1, 2, 3, 4):
+        assert ctx.set_input_shape("x", (batch, 8))
+    assert ctx.set_input_shape("x", (5, 8)) is False

--- a/tests/builder/test_family_flux.py
+++ b/tests/builder/test_family_flux.py
@@ -235,6 +235,7 @@ def test_build_components_with_clip_and_second_t5(
         str(model_dir),
         _cfg(image_height=80, image_width=96),
         weights,
+        max_batch_size=3,
         verbose=False,
     )
 
@@ -245,8 +246,22 @@ def test_build_components_with_clip_and_second_t5(
 
     # h_lat=10, w_lat=12, pack_size=2 -> num_img_tokens=30
     assert calls["build_flux_dit_engine"][1]["num_img_tokens"] == 30
+    assert calls["build_flux_dit_engine"][1]["max_batch_size"] == 3
     assert calls["load_flux_dit_weights"][1]["dim"] == 8
     assert calls["serialize"][0][1] is True
+
+
+def test_build_components_rejects_flux2_dynamic_batch(tmp_path) -> None:
+    """Intent: ensure FLUX.2 does not advertise DiT batching before its builder is converted."""
+    weights = {
+        "_transformer_dir": str(tmp_path / "transformer"),
+        "_vae_dir": str(tmp_path / "vae"),
+        "_transformer_config": {"_class_name": "Flux2Transformer2DModel"},
+    }
+
+    with pytest.raises(NotImplementedError, match="FLUX.2 dynamic-batch DiT"):
+        flux_mod.plugin.build_components(
+            str(tmp_path), _cfg(), weights, max_batch_size=2, verbose=False)
 
 
 def test_build_components_treats_text_encoder_as_t5_when_not_clip(

--- a/tests/builder/test_family_z_image.py
+++ b/tests/builder/test_family_z_image.py
@@ -161,6 +161,7 @@ def test_build_components_calls_all_subbuilders(
         "/model",
         _cfg(image_height=1024, image_width=768),
         weights,
+        max_batch_size=4,
         verbose=True,
     )
 
@@ -171,6 +172,7 @@ def test_build_components_calls_all_subbuilders(
 
     # h_lat=128, w_lat=96, patch=2x2 -> 3072 patches.
     assert calls["build_z_image_dit_engine"][1]["num_patches"] == 3072
+    assert calls["build_z_image_dit_engine"][1]["max_batch_size"] == 4
     assert calls["build_vae_2d_decoder_engine"][1]["h_lat"] == 128
     assert calls["build_vae_2d_decoder_engine"][1]["w_lat"] == 96
 

--- a/tests/builder/test_family_z_image.py
+++ b/tests/builder/test_family_z_image.py
@@ -171,6 +171,7 @@ def test_build_components_calls_all_subbuilders(
     assert out["preprocessor_weights"] == b"zimg-pre"
 
     # h_lat=128, w_lat=96, patch=2x2 -> 3072 patches.
+    assert calls["build_qwen3_encoder_engine"][1]["max_batch_size"] == 4
     assert calls["build_z_image_dit_engine"][1]["num_patches"] == 3072
     assert calls["build_z_image_dit_engine"][1]["max_batch_size"] == 4
     assert calls["build_vae_2d_decoder_engine"][1]["h_lat"] == 128

--- a/tests/builder/test_flux_dit_dynamic_batch.py
+++ b/tests/builder/test_flux_dit_dynamic_batch.py
@@ -1,0 +1,104 @@
+"""Smoke tests for the FLUX.1 dynamic-batch DiT builder path."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .conftest import requires_trt
+
+
+def _rng_for(prefix: str) -> np.random.Generator:
+    seed = sum((i + 1) * ord(ch) for i, ch in enumerate(prefix)) % (2**32)
+    return np.random.default_rng(seed)
+
+
+def _linear(weights: dict[str, np.ndarray], key: str, in_dim: int, out_dim: int) -> None:
+    rng = _rng_for(key)
+    weights[f"{key}.weight"] = rng.normal(0.0, 0.01, (in_dim, out_dim)).astype(np.float32)
+    weights[f"{key}.bias"] = np.zeros((out_dim,), dtype=np.float32)
+
+
+def _joint_block_weights(prefix: str, *, dim: int, head_dim: int, ffn_dim: int) -> dict[str, np.ndarray]:
+    weights: dict[str, np.ndarray] = {}
+    _linear(weights, f"{prefix}.norm1.linear", dim, 6 * dim)
+    _linear(weights, f"{prefix}.norm1_context.linear", dim, 6 * dim)
+
+    for name in ("to_q", "to_k", "to_v"):
+        _linear(weights, f"{prefix}.attn.{name}", dim, dim)
+    _linear(weights, f"{prefix}.attn.to_out.0", dim, dim)
+
+    for name in ("add_q_proj", "add_k_proj", "add_v_proj"):
+        _linear(weights, f"{prefix}.attn.{name}", dim, dim)
+    _linear(weights, f"{prefix}.attn.to_add_out", dim, dim)
+
+    for name in ("norm_q", "norm_k", "norm_added_q", "norm_added_k"):
+        weights[f"{prefix}.attn.{name}.weight"] = np.ones((head_dim,), dtype=np.float32)
+
+    _linear(weights, f"{prefix}.ff.net.0.proj", dim, ffn_dim)
+    _linear(weights, f"{prefix}.ff.net.2", ffn_dim, dim)
+    _linear(weights, f"{prefix}.ff_context.net.0.proj", dim, ffn_dim)
+    _linear(weights, f"{prefix}.ff_context.net.2", ffn_dim, dim)
+    return weights
+
+
+def _single_block_weights(prefix: str, *, dim: int, head_dim: int, ffn_dim: int) -> dict[str, np.ndarray]:
+    weights: dict[str, np.ndarray] = {}
+    _linear(weights, f"{prefix}.norm.linear", dim, 3 * dim)
+    for name in ("to_q", "to_k", "to_v"):
+        _linear(weights, f"{prefix}.attn.{name}", dim, dim)
+    for name in ("norm_q", "norm_k"):
+        weights[f"{prefix}.attn.{name}.weight"] = np.ones((head_dim,), dtype=np.float32)
+    _linear(weights, f"{prefix}.proj_mlp", dim, ffn_dim)
+    _linear(weights, f"{prefix}.proj_out", dim + ffn_dim, dim)
+    return weights
+
+
+def _tiny_weights() -> dict[str, np.ndarray]:
+    dim = 8
+    head_dim = 4
+    ffn_dim = 16
+    out_channels = 4
+    weights: dict[str, np.ndarray] = {}
+    weights.update(_joint_block_weights(
+        "transformer_blocks.0", dim=dim, head_dim=head_dim, ffn_dim=ffn_dim))
+    weights.update(_single_block_weights(
+        "single_transformer_blocks.0", dim=dim, head_dim=head_dim, ffn_dim=ffn_dim))
+    _linear(weights, "norm_out.linear", dim, 2 * dim)
+    _linear(weights, "proj_out", dim, out_channels)
+    return weights
+
+
+@requires_trt
+def test_flux_dit_dynamic_batch_engine_builds_tiny_network():
+    import tensorrt as trt
+    from tensorrt_model_connect.families.flux.flux_dit_builder import (
+        build_flux_dit_engine,
+    )
+
+    plan = build_flux_dit_engine(
+        _tiny_weights(),
+        dim=8,
+        num_heads=2,
+        num_layers=1,
+        num_single_layers=1,
+        num_img_tokens=2,
+        text_seq_len=3,
+        mlp_ratio=2.0,
+        max_batch_size=2,
+        verbose=False,
+    )
+
+    logger = trt.Logger(trt.Logger.WARNING)
+    runtime = trt.Runtime(logger)
+    engine = runtime.deserialize_cuda_engine(plan)
+    ctx = engine.create_execution_context()
+
+    for batch in (1, 2):
+        assert ctx.set_input_shape("hidden_states", (batch, 2, 8))
+        assert ctx.set_input_shape("encoder_hidden_states", (batch, 3, 8))
+        assert ctx.set_input_shape("temb", (batch, 8))
+        assert ctx.set_input_shape("rotary_cos", (batch, 5, 4))
+        assert ctx.set_input_shape("rotary_sin", (batch, 5, 4))
+        assert tuple(ctx.get_tensor_shape("output")) == (batch, 2, 4)
+
+    assert ctx.set_input_shape("hidden_states", (3, 2, 8)) is False

--- a/tests/builder/test_qwen_image_dit_dynamic_batch.py
+++ b/tests/builder/test_qwen_image_dit_dynamic_batch.py
@@ -106,6 +106,7 @@ def test_qwen_image_dit_dynamic_batch_engine_builds_tiny_network(tmp_path):
     for batch in (1, 2):
         assert ctx.set_input_shape("img_patched", (batch, 2, 4))
         assert ctx.set_input_shape("txt_hidden", (batch, 3, 6))
+        assert ctx.set_input_shape("encoder_hidden_states_mask", (batch, 3))
         assert ctx.set_input_shape("timestep", (batch,))
         assert tuple(ctx.get_tensor_shape("noise_patched")) == (batch, 2, 4)
 

--- a/tests/builder/test_qwen_image_dit_dynamic_batch.py
+++ b/tests/builder/test_qwen_image_dit_dynamic_batch.py
@@ -1,0 +1,112 @@
+"""Smoke tests for the Qwen-Image dynamic-batch DiT builder path."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .conftest import requires_trt
+
+
+def _rng_for(key: str) -> np.random.Generator:
+    seed = sum((i + 1) * ord(ch) for i, ch in enumerate(key)) % (2**32)
+    return np.random.default_rng(seed)
+
+
+def _linear(weights: dict[str, np.ndarray], key: str, out_dim: int, in_dim: int) -> None:
+    rng = _rng_for(key)
+    weights[f"{key}.weight"] = rng.normal(0.0, 0.01, (out_dim, in_dim)).astype(np.float32)
+    weights[f"{key}.bias"] = np.zeros((out_dim,), dtype=np.float32)
+
+
+def _block_weights(prefix: str, *, hidden: int, head_dim: int, intermediate: int) -> dict[str, np.ndarray]:
+    weights: dict[str, np.ndarray] = {}
+    _linear(weights, f"{prefix}.img_mod.1", 6 * hidden, hidden)
+    _linear(weights, f"{prefix}.txt_mod.1", 6 * hidden, hidden)
+
+    for name in ("to_q", "to_k", "to_v"):
+        _linear(weights, f"{prefix}.attn.{name}", hidden, hidden)
+    for name in ("add_q_proj", "add_k_proj", "add_v_proj"):
+        _linear(weights, f"{prefix}.attn.{name}", hidden, hidden)
+    _linear(weights, f"{prefix}.attn.to_out.0", hidden, hidden)
+    _linear(weights, f"{prefix}.attn.to_add_out", hidden, hidden)
+
+    for name in ("norm_q", "norm_k", "norm_added_q", "norm_added_k"):
+        weights[f"{prefix}.attn.{name}.weight"] = np.ones((head_dim,), dtype=np.float32)
+
+    _linear(weights, f"{prefix}.img_mlp.net.0.proj", intermediate, hidden)
+    _linear(weights, f"{prefix}.img_mlp.net.2", hidden, intermediate)
+    _linear(weights, f"{prefix}.txt_mlp.net.0.proj", intermediate, hidden)
+    _linear(weights, f"{prefix}.txt_mlp.net.2", hidden, intermediate)
+    return weights
+
+
+def _tiny_weights() -> dict[str, np.ndarray]:
+    hidden = 12
+    text_dim = 6
+    in_channels = 4
+    out_channels = 1
+    patch = 2
+    timestep_dim = 4
+    intermediate = 24
+
+    weights: dict[str, np.ndarray] = {}
+    _linear(weights, "img_in", hidden, in_channels)
+    weights["txt_norm.weight"] = np.ones((text_dim,), dtype=np.float32)
+    _linear(weights, "txt_in", hidden, text_dim)
+    _linear(weights, "time_text_embed.timestep_embedder.linear_1", hidden, timestep_dim)
+    _linear(weights, "time_text_embed.timestep_embedder.linear_2", hidden, hidden)
+    weights.update(_block_weights(
+        "transformer_blocks.0", hidden=hidden, head_dim=6, intermediate=intermediate))
+    _linear(weights, "norm_out.linear", 2 * hidden, hidden)
+    _linear(weights, "proj_out", out_channels * patch * patch, hidden)
+    return weights
+
+
+@requires_trt
+def test_qwen_image_dit_dynamic_batch_engine_builds_tiny_network(tmp_path):
+    import tensorrt as trt
+    from tensorrt_model_connect.families.qwen_image.qwen_image_dit_builder import (
+        QwenImageDiTConfig,
+        build_qwen_image_dit_engine,
+    )
+
+    cfg = QwenImageDiTConfig(
+        in_channels=4,
+        out_channels=1,
+        patch_size=2,
+        hidden_size=12,
+        num_joint_blocks=1,
+        num_attention_heads=2,
+        attention_head_dim=6,
+        intermediate_size=24,
+        text_embed_dim=6,
+        rope_axes_dim=[2, 2, 2],
+        timestep_embed_dim=4,
+        max_image_tokens=2,
+        max_text_tokens=3,
+    )
+    out_path = tmp_path / "qwen_image_dit.plan"
+
+    build_qwen_image_dit_engine(
+        cfg,
+        _tiny_weights(),
+        out_path,
+        h_lat=1,
+        w_lat=2,
+        n_text=3,
+        batch_size=2,
+        verbose=False,
+    )
+
+    logger = trt.Logger(trt.Logger.WARNING)
+    runtime = trt.Runtime(logger)
+    engine = runtime.deserialize_cuda_engine(out_path.read_bytes())
+    ctx = engine.create_execution_context()
+
+    for batch in (1, 2):
+        assert ctx.set_input_shape("img_patched", (batch, 2, 4))
+        assert ctx.set_input_shape("txt_hidden", (batch, 3, 6))
+        assert ctx.set_input_shape("timestep", (batch,))
+        assert tuple(ctx.get_tensor_shape("noise_patched")) == (batch, 2, 4)
+
+    assert ctx.set_input_shape("img_patched", (3, 2, 4)) is False

--- a/tests/cpp/test_bundle_format.cpp
+++ b/tests/cpp/test_bundle_format.cpp
@@ -230,6 +230,41 @@ static void test_tokenizer_add_special_tokens_header() {
     trtmc_test::remove_all_safe(tmp);
 }
 
+static void test_max_batch_size_header() {
+    const auto tmp = make_temp_dir();
+    const auto path = (tmp / "batch_caps.trtfb").string();
+
+    const std::string json = R"({
+  "model_id": "batch-caps",
+  "family": "diffusion_flux",
+  "max_batch_size": {"dit": 4, "text_encoder": 8, "vae": 1},
+  "sections": {}
+})";
+    write_minimal_bundle(path, json);
+
+    const auto loaded = trtmc::ReadBundleFile(path);
+    check(loaded.info.max_batch_size.dit == 4, "max_batch_size dit");
+    check(loaded.info.max_batch_size.text_encoder == 8, "max_batch_size text_encoder");
+    check(loaded.info.max_batch_size.vae == 1, "max_batch_size vae");
+
+    trtmc_test::remove_all_safe(tmp);
+}
+
+static void test_max_batch_size_defaults_to_one() {
+    const auto tmp = make_temp_dir();
+    const auto path = (tmp / "batch_caps_default.trtfb").string();
+
+    write_minimal_bundle(path, R"({"model_id": "batch-default", "sections": {}})");
+
+    const auto loaded = trtmc::ReadBundleFile(path);
+    check(loaded.info.max_batch_size.dit == 1, "default max_batch_size dit");
+    check(loaded.info.max_batch_size.text_encoder == 1,
+          "default max_batch_size text_encoder");
+    check(loaded.info.max_batch_size.vae == 1, "default max_batch_size vae");
+
+    trtmc_test::remove_all_safe(tmp);
+}
+
 static void test_truncated_bundle_throws() {
     const auto tmp = make_temp_dir();
     const auto path = (tmp / "truncated.trtfb").string();
@@ -264,6 +299,8 @@ int main() {
     test_is_bundle_invalid();
     test_inspect_returns_metadata();
     test_tokenizer_add_special_tokens_header();
+    test_max_batch_size_header();
+    test_max_batch_size_defaults_to_one();
     test_truncated_bundle_throws();
 
     if (failures > 0) {

--- a/tests/cpp/test_cli_args.cpp
+++ b/tests/cpp/test_cli_args.cpp
@@ -66,6 +66,7 @@ struct CliArgs {
     std::string command;
     std::string model_or_bundle;
     std::string prompt;
+    std::string prompts_file;
     std::string hf_python;
     std::uint64_t kv_cache_size_bytes{0};
     std::string image_path;
@@ -82,6 +83,10 @@ struct CliArgs {
     float cfg_scale{-1.0F};
     float sde_gamma{-1.0F};
     float conf_threshold{-1.0F};
+    bool seed_was_set{false};
+    std::vector<std::uint64_t> seed_list;
+    int seed{-1};
+    int num_images{1};
     bool show_help{false};
     bool parse_error{false};
     std::string error_message;
@@ -133,6 +138,31 @@ std::optional<std::uint64_t> parse_byte_size(const std::string& text) {
         bytes > static_cast<long double>(std::numeric_limits<std::uint64_t>::max()))
         return std::nullopt;
     return static_cast<std::uint64_t>(bytes + 0.5L);
+}
+
+std::optional<std::vector<std::uint64_t>> parse_seed_csv(const std::string& text) {
+    std::vector<std::uint64_t> seeds;
+    std::size_t start = 0;
+    while (start <= text.size()) {
+        const auto comma = text.find(',', start);
+        const auto end = (comma == std::string::npos) ? text.size() : comma;
+        const std::string token = text.substr(start, end - start);
+        if (token.empty())
+            return std::nullopt;
+        try {
+            std::size_t consumed = 0;
+            const auto value = std::stoull(token, &consumed, 10);
+            if (consumed != token.size())
+                return std::nullopt;
+            seeds.push_back(value);
+        } catch (...) {
+            return std::nullopt;
+        }
+        if (comma == std::string::npos)
+            break;
+        start = comma + 1;
+    }
+    return seeds;
 }
 
 CliArgs parse_args(int argc, const char** argv) {
@@ -225,6 +255,51 @@ CliArgs parse_args(int argc, const char** argv) {
                 return args;
             }
             args.sde_gamma = static_cast<float>(std::atof(argv[++i]));
+            continue;
+        }
+        if (arg == "--seed") {
+            if (i + 1 >= argc) {
+                args.parse_error = true;
+                args.error_message = arg + " requires a value";
+                return args;
+            }
+            const std::string value = argv[++i];
+            args.seed_was_set = true;
+            if (value.find(',') != std::string::npos) {
+                auto seeds = parse_seed_csv(value);
+                if (!seeds) {
+                    args.parse_error = true;
+                    args.error_message = "--seed expects an integer or comma-separated integers";
+                    return args;
+                }
+                args.seed_list = std::move(*seeds);
+                args.seed = args.seed_list.empty() ? -1 : static_cast<int>(args.seed_list[0]);
+            } else {
+                args.seed = std::atoi(value.c_str());
+            }
+            continue;
+        }
+        if (arg == "--num-images") {
+            if (i + 1 >= argc) {
+                args.parse_error = true;
+                args.error_message = arg + " requires a value";
+                return args;
+            }
+            args.num_images = std::atoi(argv[++i]);
+            if (args.num_images < 1) {
+                args.parse_error = true;
+                args.error_message = "--num-images must be >= 1";
+                return args;
+            }
+            continue;
+        }
+        if (arg == "--prompts-file") {
+            if (i + 1 >= argc) {
+                args.parse_error = true;
+                args.error_message = arg + " requires a value";
+                return args;
+            }
+            args.prompts_file = argv[++i];
             continue;
         }
         if (arg == "--hf-python") {
@@ -346,6 +421,12 @@ CliArgs parse_args(int argc, const char** argv) {
             args.error_message = "Unexpected positional argument: " + arg;
             return args;
         }
+    }
+
+    if (!args.prompt.empty() && !args.prompts_file.empty()) {
+        args.parse_error = true;
+        args.error_message = "--prompt and --prompts-file are mutually exclusive";
+        return args;
     }
 
     return args;
@@ -541,6 +622,30 @@ static void test_kv_cache_size_equals_flag() {
     check(args.kv_cache_size_bytes == 90000000000ULL, "kv-cache-size equals parsed");
 }
 
+static void test_diffusion_batch_flags() {
+    auto args = parse({"trtmc", "run", "bundle.trtfb", "--prompt", "x", "--num-images", "4",
+                       "--seed", "0,1,2,3"});
+    check(!args.parse_error, "diffusion batch flags no parse error");
+    check(args.num_images == 4, "num-images parsed");
+    check(args.seed_was_set, "seed marked set");
+    check(args.seed_list == std::vector<std::uint64_t>({0, 1, 2, 3}), "seed csv parsed");
+}
+
+static void test_num_images_zero_errors() {
+    auto args = parse({"trtmc", "run", "bundle.trtfb", "--prompt", "x", "--num-images", "0"});
+    check(args.parse_error, "num-images zero errors");
+    check(args.error_message.find("--num-images must be >= 1") != std::string::npos,
+          "num-images zero message");
+}
+
+static void test_prompt_and_prompts_file_mutually_exclusive() {
+    auto args = parse(
+        {"trtmc", "run", "bundle.trtfb", "--prompt", "x", "--prompts-file", "p.txt"});
+    check(args.parse_error, "prompt/prompts-file mutually exclusive");
+    check(args.error_message.find("mutually exclusive") != std::string::npos,
+          "prompt/prompts-file error message");
+}
+
 // -----------------------------------------------------------------------------
 // Intention: Verify detect alias flags parse exactly like canonical names.
 // Setup: Simulated argv with detect + --output-json + --score-threshold.
@@ -584,6 +689,9 @@ int main() {
     test_kv_cache_size_flag();
     test_kv_cache_size_alias_flag();
     test_kv_cache_size_equals_flag();
+    test_diffusion_batch_flags();
+    test_num_images_zero_errors();
+    test_prompt_and_prompts_file_mutually_exclusive();
     test_detect_alias_flags();
     test_detect_unknown_flag_still_errors();
 

--- a/tests/cpp/test_diffusion_batch_utils.cpp
+++ b/tests/cpp/test_diffusion_batch_utils.cpp
@@ -1,0 +1,70 @@
+#include "runtime/domains/diffusion/batch_utils.h"
+
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+static int failures = 0;
+
+static void check(bool condition, const char* test_name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << test_name << '\n';
+        ++failures;
+    }
+}
+
+static void test_per_sample_seed_from_global() {
+    const auto seeds = trtmc::diffusion::derive_per_sample_seeds(42, 4);
+    check(seeds.size() == 4U, "seed count");
+    check(seeds[1] != seeds[0], "seed 1 differs");
+    check(seeds[2] != seeds[0], "seed 2 differs");
+    check(seeds == trtmc::diffusion::derive_per_sample_seeds(42, 4),
+          "seed derivation deterministic");
+}
+
+static void test_explicit_seed_list_must_match_count() {
+    bool threw = false;
+    try {
+        (void)trtmc::diffusion::derive_per_sample_seeds(
+            std::vector<std::uint64_t>{1, 2, 3}, 4);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check(threw, "explicit seed count mismatch throws");
+}
+
+static void test_chunking_divides_evenly() {
+    const auto plan = trtmc::diffusion::plan_chunks(8, 4);
+    check(plan == std::vector<int>({4, 4}), "chunking divides evenly");
+}
+
+static void test_chunking_handles_remainder() {
+    const auto plan = trtmc::diffusion::plan_chunks(9, 4);
+    check(plan == std::vector<int>({4, 4, 1}), "chunking handles remainder");
+}
+
+static void test_chunking_rejects_invalid_cap() {
+    bool threw = false;
+    try {
+        (void)trtmc::diffusion::plan_chunks(4, 0);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check(threw, "chunking rejects invalid cap");
+}
+
+int main() {
+    test_per_sample_seed_from_global();
+    test_explicit_seed_list_must_match_count();
+    test_chunking_divides_evenly();
+    test_chunking_handles_remainder();
+    test_chunking_rejects_invalid_cap();
+
+    if (failures > 0) {
+        std::cerr << failures << " test(s) FAILED\n";
+        return 1;
+    }
+    std::cerr << "All diffusion_batch_utils tests passed.\n";
+    return 0;
+}

--- a/tests/cpp/test_diffusion_pipeline_new.cpp
+++ b/tests/cpp/test_diffusion_pipeline_new.cpp
@@ -26,12 +26,17 @@
 // =============================================================================
 
 #include "runtime/models/flux/pipeline.h"
+#include "runtime/models/qwen_image/pipeline.h"
 #include "runtime/models/wan/pipeline.h"
 #include "runtime/models/z_image/pipeline.h"
 
 #include <cstdint>
 #include <iostream>
+#include <memory>
 #include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 static int failures = 0;
@@ -40,6 +45,224 @@ static void check(bool c, const char* n) {
         std::cerr << "FAIL: " << n << '\n';
         ++failures;
     }
+}
+
+class FakeTokenizer final : public trtmc::ITokenizer {
+  public:
+    std::vector<int32_t> encode(const std::string& text) const override {
+        (void)text;
+        return {1, 2};
+    }
+    std::string decode(const std::vector<int32_t>& ids) const override {
+        (void)ids;
+        return {};
+    }
+    int32_t id_for_token(std::string_view token) const override {
+        (void)token;
+        return 0;
+    }
+    std::string token_for_id(int32_t id) const override {
+        (void)id;
+        return {};
+    }
+};
+
+class FakeModule final : public trtmc::TrtModule {
+  public:
+    enum class Kind { TextEncoder, Denoiser, Vae };
+
+    explicit FakeModule(Kind kind) : kind_(kind) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        ++forward_calls;
+        if (kind_ == Kind::Denoiser) {
+            if (inputs.count("img_patched") != 0U) {
+                denoiser_hidden_shapes.push_back(inputs.at("img_patched").shape);
+                denoiser_encoder_shapes.push_back(inputs.at("txt_hidden").shape);
+                denoiser_timestep_shapes.push_back(inputs.at("timestep").shape);
+                const auto& hidden_shape = inputs.at("img_patched").shape;
+                const int64_t batch = hidden_shape[0];
+                const int64_t patches = hidden_shape[1];
+                const int64_t channels = hidden_shape[2];
+                output_.assign(static_cast<std::size_t>(batch * patches * channels), 0.0F);
+                return {{"noise_patched",
+                         trtmc::Tensor{output_.data(), {batch, patches, channels},
+                                       trtmc::DType::kFloat32}}};
+            }
+
+            denoiser_hidden_shapes.push_back(inputs.at("hidden_states").shape);
+            denoiser_encoder_shapes.push_back(inputs.at("encoder_hidden_states").shape);
+            if (inputs.count("timestep_embedding") != 0U) {
+                denoiser_timestep_shapes.push_back(inputs.at("timestep_embedding").shape);
+            } else {
+                denoiser_timestep_shapes.push_back(inputs.at("temb").shape);
+            }
+            denoiser_rope_shapes.push_back(inputs.at("rotary_cos").shape);
+
+            const auto& hidden_shape = inputs.at("hidden_states").shape;
+            const int64_t batch = hidden_shape[0];
+            const int64_t patches = hidden_shape[1];
+            output_.assign(static_cast<std::size_t>(batch * patches * patch_dim), 0.0F);
+            return {{"output",
+                     trtmc::Tensor{output_.data(), {batch, patches, patch_dim},
+                                   trtmc::DType::kFloat32}}};
+        }
+
+        if (kind_ == Kind::TextEncoder) {
+            text_input_shapes.push_back(inputs.at("input_ids").shape);
+            output_.assign(static_cast<std::size_t>(text_seq * text_dim), 0.25F);
+            return {{"text_embeddings",
+                     trtmc::Tensor{output_.data(), {text_seq, text_dim},
+                                   trtmc::DType::kFloat32}},
+                    {"last_hidden_state",
+                     trtmc::Tensor{output_.data(), {text_seq, text_dim},
+                                   trtmc::DType::kFloat32}}};
+        }
+
+        if (inputs.count("latent_input") != 0U) {
+            vae_input_shapes.push_back(inputs.at("latent_input").shape);
+            output_.assign(static_cast<std::size_t>(3 * vae_h * vae_w), 0.0F);
+            return {{"decoder_output",
+                     trtmc::Tensor{output_.data(), {1, 3, vae_h, vae_w},
+                                   trtmc::DType::kFloat32}}};
+        }
+        if (inputs.count("latent") != 0U) {
+            vae_input_shapes.push_back(inputs.at("latent").shape);
+            const auto& shape = inputs.at("latent").shape;
+            const int64_t h = shape[3];
+            const int64_t w = shape[4];
+            output_.assign(static_cast<std::size_t>(3 * h * w), 0.0F);
+            return {{"image",
+                     trtmc::Tensor{output_.data(), {1, 3, 1, h, w},
+                                   trtmc::DType::kFloat32}}};
+        }
+
+        vae_input_shapes.push_back(inputs.at("latents").shape);
+        output_.assign(static_cast<std::size_t>(3 * vae_h * vae_w), 0.0F);
+        return {{"image",
+                 trtmc::Tensor{output_.data(), {3, vae_h, vae_w}, trtmc::DType::kFloat32}}};
+    }
+
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap& inputs) override {
+        (void)inputs;
+        return {};
+    }
+    void forward_device_async(const trtmc::DeviceTensorMap& inputs) override { (void)inputs; }
+    void forward_async(const trtmc::TensorMap& inputs) override { (void)forward(inputs); }
+    void sync() override {}
+
+    cudaStream_t stream() const override { return nullptr; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return {}; }
+    std::vector<trtmc::TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override {
+        (void)name;
+        return true;
+    }
+    bool has_output(const std::string& name) const override {
+        (void)name;
+        return true;
+    }
+    trtmc::DType tensor_dtype(const std::string& name) const override {
+        (void)name;
+        return trtmc::DType::kFloat32;
+    }
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        (void)name;
+        return {};
+    }
+    std::vector<int64_t> input_profile_shape(
+        const std::string& name, int32_t profile_idx,
+        trtmc::ProfileShapeSelector selector) const override {
+        (void)profile_idx;
+        if (kind_ == Kind::Denoiser && name == "hidden_states" &&
+            selector == trtmc::ProfileShapeSelector::kMax) {
+            return {2, 1, 128};
+        }
+        if (kind_ == Kind::Denoiser && name == "img_patched" &&
+            selector == trtmc::ProfileShapeSelector::kMax) {
+            return {2, 1, 4};
+        }
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string& name) const override {
+        (void)name;
+        return nullptr;
+    }
+    void bind_external(const std::string& name, void* ptr) override {
+        (void)name;
+        (void)ptr;
+    }
+    int32_t input_rank(const std::string& name) const override {
+        if (kind_ == Kind::Denoiser && name == "hidden_states")
+            return 3;
+        if (kind_ == Kind::Denoiser && name == "img_patched")
+            return 3;
+        return 0;
+    }
+    bool input_is_dynamic(const std::string& name) const override {
+        return kind_ == Kind::Denoiser && name == "hidden_states";
+    }
+    bool ok() const override { return true; }
+    void keep_alive(std::shared_ptr<void> resource) override { (void)resource; }
+
+    int32_t forward_calls{0};
+    std::vector<std::vector<int64_t>> text_input_shapes;
+    std::vector<std::vector<int64_t>> denoiser_hidden_shapes;
+    std::vector<std::vector<int64_t>> denoiser_encoder_shapes;
+    std::vector<std::vector<int64_t>> denoiser_timestep_shapes;
+    std::vector<std::vector<int64_t>> denoiser_rope_shapes;
+    std::vector<std::vector<int64_t>> vae_input_shapes;
+
+    static constexpr int64_t text_seq = 32;
+    static constexpr int64_t text_dim = 2;
+    static constexpr int64_t patch_dim = 4;
+    static constexpr int64_t vae_h = 16;
+    static constexpr int64_t vae_w = 16;
+
+  private:
+    Kind kind_;
+    std::vector<float> output_;
+};
+
+static trtmc::ZImagePreprocessorWeights tiny_zimage_weights() {
+    trtmc::ZImagePreprocessorWeights weights;
+    weights.cap_dim = 2;
+    weights.dit_dim = 128;
+    weights.freq_dim = 4;
+    weights.valid = true;
+    weights.cap_norm_weight = {1.0F, 1.0F};
+    weights.cap_proj_weight.assign(static_cast<std::size_t>(2 * 128), 0.0F);
+    weights.cap_proj_bias.assign(128, 0.0F);
+    weights.cap_pad_token.assign(128, 0.0F);
+    weights.x_embed_weight.assign(static_cast<std::size_t>(4 * 128), 0.0F);
+    weights.x_embed_bias.assign(128, 0.0F);
+    weights.t_embedder_mlp_0_weight.assign(static_cast<std::size_t>(4 * 4), 0.0F);
+    weights.t_embedder_mlp_0_bias.assign(4, 0.0F);
+    weights.t_embedder_mlp_2_weight.assign(static_cast<std::size_t>(4 * 4), 0.0F);
+    weights.t_embedder_mlp_2_bias.assign(4, 0.0F);
+    return weights;
+}
+
+static trtmc::PreprocessorWeights tiny_flux_weights() {
+    trtmc::PreprocessorWeights weights;
+    constexpr int32_t freq_dim = 4;
+    constexpr int32_t dit_dim = 8;
+    constexpr int32_t text_dim = 2;
+    constexpr int32_t packed_channels = 4;
+
+    weights.time_emb_0_weight.assign(static_cast<std::size_t>(freq_dim * dit_dim), 0.0F);
+    weights.time_emb_0_bias.assign(dit_dim, 0.0F);
+    weights.time_emb_2_weight.assign(static_cast<std::size_t>(dit_dim * dit_dim), 0.0F);
+    weights.time_emb_2_bias.assign(dit_dim, 0.0F);
+    weights.context_embed_weight.assign(static_cast<std::size_t>(text_dim * dit_dim), 0.0F);
+    weights.context_embed_bias.assign(dit_dim, 0.0F);
+    weights.patch_embed_weight.assign(static_cast<std::size_t>(packed_channels * dit_dim), 0.0F);
+    weights.patch_embed_bias.assign(dit_dim, 0.0F);
+    return weights;
 }
 
 static void test_flux_construction() {
@@ -95,6 +318,187 @@ static void test_zimage_construction() {
     check(std::string(pipeline.model_id()) == "test-zimage", "ZImagePipeline model_id");
 }
 
+static void test_zimage_generate_images_uses_batched_dit_shapes() {
+    trtmc::DiffusionConfig cfg;
+    cfg.video_height = 2;
+    cfg.video_width = 2;
+    cfg.num_inference_steps = 1;
+    cfg.flow_shift = 3.0F;
+    cfg.dit_dim = 128;
+    cfg.dit_num_heads = 1;
+    cfg.z_dim = 1;
+    cfg.scale_factor_spatial = 1;
+    cfg.patch_size = {1, 2, 2};
+    cfg.freq_dim = 4;
+    cfg.text_seq_len = 32;
+    cfg.text_encoder_dim = 2;
+    cfg.max_batch_size.dit = 2;
+
+    auto text_encoder = std::make_unique<FakeModule>(FakeModule::Kind::TextEncoder);
+    auto denoiser = std::make_unique<FakeModule>(FakeModule::Kind::Denoiser);
+    auto vae = std::make_unique<FakeModule>(FakeModule::Kind::Vae);
+    auto* text_encoder_ptr = text_encoder.get();
+    auto* denoiser_ptr = denoiser.get();
+    auto* vae_ptr = vae.get();
+
+    trtmc::ZImagePipeline pipeline(
+        std::move(text_encoder), std::move(denoiser), std::move(vae), cfg,
+        trtmc::PreprocessorWeights{}, tiny_zimage_weights(),
+        std::make_shared<FakeTokenizer>(),
+        /*model_id_str=*/"test-zimage-batch",
+        /*bundle_path=*/"/tmp/test.trtfb");
+
+    trtmc::GenerateConfig generate_cfg;
+    generate_cfg.num_steps = 1;
+    generate_cfg.seed = 123;
+    const auto images = pipeline.generate_images({"a", "b", "c"}, {11, 12, 13}, generate_cfg);
+
+    check(images.size() == 3U, "ZImagePipeline batched result count");
+    check(text_encoder_ptr->forward_calls == 3, "ZImagePipeline text encoder remains serial");
+    check(denoiser_ptr->forward_calls == 2, "ZImagePipeline denoiser chunks by cap");
+    check(vae_ptr->forward_calls == 3, "ZImagePipeline VAE remains sliced");
+
+    check(denoiser_ptr->denoiser_hidden_shapes.size() == 2U, "denoiser captured two chunks");
+    if (denoiser_ptr->denoiser_hidden_shapes.size() == 2U) {
+        check(denoiser_ptr->denoiser_hidden_shapes[0] == std::vector<int64_t>({2, 1, 128}),
+              "first denoiser hidden shape");
+        check(denoiser_ptr->denoiser_hidden_shapes[1] == std::vector<int64_t>({1, 1, 128}),
+              "second denoiser hidden shape");
+        check(denoiser_ptr->denoiser_encoder_shapes[0] ==
+                  std::vector<int64_t>({2, 32, 128}),
+              "first denoiser encoder shape");
+        check(denoiser_ptr->denoiser_timestep_shapes[0] ==
+                  std::vector<int64_t>({2, 1, 4}),
+              "first denoiser timestep shape");
+        check(denoiser_ptr->denoiser_rope_shapes[0] ==
+                  std::vector<int64_t>({2, 33, 128}),
+              "first denoiser rope shape");
+    }
+}
+
+static void test_flux_generate_images_uses_batched_dit_shapes() {
+    trtmc::DiffusionConfig cfg;
+    cfg.video_height = 2;
+    cfg.video_width = 2;
+    cfg.num_inference_steps = 1;
+    cfg.flow_shift = 3.0F;
+    cfg.dit_dim = 8;
+    cfg.dit_num_heads = 1;
+    cfg.z_dim = 1;
+    cfg.scale_factor_spatial = 1;
+    cfg.patch_size = {1, 2, 2};
+    cfg.freq_dim = 4;
+    cfg.text_seq_len = 32;
+    cfg.text_encoder_dim = 2;
+    cfg.axes_dims_rope = {2, 2, 4};
+    cfg.max_batch_size.dit = 2;
+
+    std::vector<std::unique_ptr<trtmc::TrtModule>> text_encoders;
+    auto text_encoder = std::make_unique<FakeModule>(FakeModule::Kind::TextEncoder);
+    auto denoiser = std::make_unique<FakeModule>(FakeModule::Kind::Denoiser);
+    auto vae = std::make_unique<FakeModule>(FakeModule::Kind::Vae);
+    auto* text_encoder_ptr = text_encoder.get();
+    auto* denoiser_ptr = denoiser.get();
+    auto* vae_ptr = vae.get();
+    text_encoders.push_back(std::move(text_encoder));
+
+    trtmc::FluxPipeline pipeline(
+        std::move(text_encoders), std::move(denoiser), std::move(vae), cfg,
+        tiny_flux_weights(), std::make_shared<FakeTokenizer>(),
+        /*clip_tokenizer=*/nullptr,
+        /*model_id_str=*/"test-flux-batch");
+
+    trtmc::GenerateConfig generate_cfg;
+    generate_cfg.num_steps = 1;
+    generate_cfg.seed = 123;
+    const auto images = pipeline.generate_images({"a", "b", "c"}, {11, 12, 13}, generate_cfg);
+
+    check(images.size() == 3U, "FluxPipeline batched result count");
+    check(text_encoder_ptr->forward_calls == 3, "FluxPipeline text encoder remains serial");
+    check(denoiser_ptr->forward_calls == 2, "FluxPipeline denoiser chunks by cap");
+    check(vae_ptr->forward_calls == 3, "FluxPipeline VAE remains sliced");
+
+    check(denoiser_ptr->denoiser_hidden_shapes.size() == 2U,
+          "FluxPipeline denoiser captured two chunks");
+    if (denoiser_ptr->denoiser_hidden_shapes.size() == 2U) {
+        check(denoiser_ptr->denoiser_hidden_shapes[0] == std::vector<int64_t>({2, 1, 8}),
+              "FluxPipeline first denoiser hidden shape");
+        check(denoiser_ptr->denoiser_hidden_shapes[1] == std::vector<int64_t>({1, 1, 8}),
+              "FluxPipeline second denoiser hidden shape");
+        check(denoiser_ptr->denoiser_encoder_shapes[0] == std::vector<int64_t>({2, 32, 8}),
+              "FluxPipeline first denoiser encoder shape");
+        check(denoiser_ptr->denoiser_timestep_shapes[0] == std::vector<int64_t>({2, 8}),
+              "FluxPipeline first denoiser temb shape");
+        check(denoiser_ptr->denoiser_rope_shapes[0] == std::vector<int64_t>({2, 33, 8}),
+              "FluxPipeline first denoiser rope shape");
+    }
+}
+
+static void test_qwen_image_generate_images_uses_batched_dit_shapes() {
+    trtmc::QwenImageConfig cfg;
+    cfg.image.default_height = 2;
+    cfg.image.default_width = 2;
+    cfg.diffusion.default_num_inference_steps = 1;
+    cfg.diffusion.default_cfg_scale = 4.0F;
+    cfg.diffusion.default_negative_prompt = " ";
+    cfg.text_encoder.max_seq_len = 32;
+    cfg.denoiser.max_text_tokens = 32;
+    cfg.denoiser.text_embed_dim = 2;
+    cfg.denoiser.in_channels = 4;
+    cfg.denoiser.out_channels = 1;
+    cfg.denoiser.patch_size = 2;
+    cfg.vae.latent_channels = 1;
+    cfg.vae.spatial_scale_factor = 1;
+
+    trtmc::QwenImagePreprocessorWeights preprocessor;
+    preprocessor.latents_mean = {0.0F};
+    preprocessor.latents_std = {1.0F};
+    preprocessor.valid = true;
+
+    auto text_encoder = std::make_unique<FakeModule>(FakeModule::Kind::TextEncoder);
+    auto denoiser = std::make_unique<FakeModule>(FakeModule::Kind::Denoiser);
+    auto vae = std::make_unique<FakeModule>(FakeModule::Kind::Vae);
+    auto* text_encoder_ptr = text_encoder.get();
+    auto* denoiser_ptr = denoiser.get();
+    auto* vae_ptr = vae.get();
+
+    trtmc::QwenImagePipeline::Construction c;
+    c.text_engine = std::move(text_encoder);
+    c.denoiser_engine = std::move(denoiser);
+    c.vae_decoder_engine = std::move(vae);
+    c.tokenizer = std::make_shared<FakeTokenizer>();
+    c.config = cfg;
+    c.preprocessor = preprocessor;
+    c.max_dit_batch_size = 2;
+    c.model_id = "test-qwen-image-batch";
+    trtmc::QwenImagePipeline pipeline(std::move(c));
+
+    trtmc::GenerateConfig generate_cfg;
+    generate_cfg.num_steps = 1;
+    generate_cfg.seed = 123;
+    const auto images = pipeline.generate_images({"a", "b", "c"}, {11, 12, 13}, generate_cfg);
+
+    check(images.size() == 3U, "QwenImagePipeline batched result count");
+    check(text_encoder_ptr->forward_calls == 4,
+          "QwenImagePipeline text encoder runs positives plus shared negative");
+    check(denoiser_ptr->forward_calls == 4,
+          "QwenImagePipeline denoiser runs cond/uncond per chunk");
+    check(vae_ptr->forward_calls == 3, "QwenImagePipeline VAE remains sliced");
+
+    check(denoiser_ptr->denoiser_hidden_shapes.size() == 4U,
+          "QwenImagePipeline denoiser captured CFG chunk calls");
+    if (denoiser_ptr->denoiser_hidden_shapes.size() == 4U) {
+        check(denoiser_ptr->denoiser_hidden_shapes[0] == std::vector<int64_t>({2, 1, 4}),
+              "QwenImagePipeline first denoiser image shape");
+        check(denoiser_ptr->denoiser_hidden_shapes[2] == std::vector<int64_t>({1, 1, 4}),
+              "QwenImagePipeline second denoiser image shape");
+        check(denoiser_ptr->denoiser_encoder_shapes[0] == std::vector<int64_t>({2, 32, 2}),
+              "QwenImagePipeline first denoiser text shape");
+        check(denoiser_ptr->denoiser_timestep_shapes[0] == std::vector<int64_t>({2}),
+              "QwenImagePipeline first denoiser timestep shape");
+    }
+}
+
 static void test_flux_with_custom_config() {
     // Test FluxPipeline with non-default config to exercise the latent layout
     // computation path with patch_size override.
@@ -115,6 +519,9 @@ int main() {
     test_flux_construction();
     test_wan_construction();
     test_zimage_construction();
+    test_zimage_generate_images_uses_batched_dit_shapes();
+    test_flux_generate_images_uses_batched_dit_shapes();
+    test_qwen_image_generate_images_uses_batched_dit_shapes();
     test_flux_with_custom_config();
     if (failures > 0)
         std::cerr << failures << " test(s) FAILED\n";

--- a/tests/cpp/test_pipeline_api.cpp
+++ b/tests/cpp/test_pipeline_api.cpp
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 static int failures = 0;
 
@@ -46,6 +47,27 @@ class DummyPipeline final : public trtmc::IPipeline {
   public:
     const char* model_id() const override { return "dummy-model"; }
     const char* pipeline_type() const override { return "DummyPipeline"; }
+};
+
+class DummyImagePipeline final : public trtmc::IPipeline {
+  public:
+    const char* model_id() const override { return "dummy-image-model"; }
+    const char* pipeline_type() const override { return "DummyImagePipeline"; }
+
+    trtmc::ImageResult generate_image(const std::string& prompt,
+                                      const trtmc::GenerateConfig& cfg = {}) override {
+        prompts += prompt + ";";
+        seeds.push_back(cfg.seed);
+        trtmc::ImageResult result;
+        result.width = 1;
+        result.height = 1;
+        result.channels = 3;
+        result.pixels = {static_cast<float>(cfg.seed), 0.0F, 0.0F};
+        return result;
+    }
+
+    std::string prompts;
+    std::vector<int32_t> seeds;
 };
 
 static void test_null_input_returns_null() {
@@ -217,6 +239,19 @@ static void test_ipipeline_default_virtuals() {
     check(threw, "default detect throws");
 }
 
+static void test_generate_images_default_loops_generate_image() {
+    DummyImagePipeline pipeline;
+    trtmc::GenerateConfig cfg;
+    cfg.seed = 999;
+    const auto results = pipeline.generate_images({"a", "b"}, {7, 8}, cfg);
+
+    check(results.size() == 2U, "generate_images result count");
+    check(pipeline.prompts == "a;b;", "generate_images prompt order");
+    check(pipeline.seeds == std::vector<int32_t>({7, 8}), "generate_images seeds");
+    check(results[0].pixels[0] == 7.0F, "generate_images first result");
+    check(results[1].pixels[0] == 8.0F, "generate_images second result");
+}
+
 int main() {
     test_null_input_returns_null();
     test_invalid_path_returns_null();
@@ -225,6 +260,7 @@ int main() {
     test_sizeof_ipipeline_is_vtable();
     test_delete_null_safe();
     test_ipipeline_default_virtuals();
+    test_generate_images_default_loops_generate_image();
 
     if (failures > 0) {
         std::cerr << failures << " test(s) FAILED\n";


### PR DESCRIPTION
## Background
  This PR adds batch inference support for diffusion pipelines to improve throughput when generating multiple images. The initial target is batching DiT denoising, with Z-Image also supporting batched Qwen3 text encoding.

  ## Exit Criteria
  - FLUX, Qwen Image, and Z-Image can build diffusion bundles with `--max-batch-size > 1` for supported batched DiT engines.
  - Runtime generation chunks prompts by component batch capacity and preserves batch-1 fallback behavior for text/VAE stages.
  - Qwen Image batched output remains prompt-aligned by masking padded text tokens in joint attention.
  - Bundle inspection reports diffusion component batch caps.

  ## Implementation
  - Added dynamic-batch TensorRT profiles for diffusion DiT builders and runtime chunking across FLUX, Qwen Image, and Z-Image.
  - Added `encoder_hidden_states_mask` to the Qwen Image DiT engine and runtime inputs to match diffusers’ padded-token masking behavior.
  - Added Z-Image Qwen3 text encoder dynamic-batch support and fixed batched RoPE/layout handling.
  - Extended bundle metadata and CLI/native inspect output to show `dit`, `text_encoder`, and `vae` batch caps.
  - Kept compatibility with older Qwen bundles by only passing the new mask input when the engine exposes it.
