### PR TITLE
ci: harden selective and nightly testing

### DIFF
--- a/.github/scripts/run-trtmc-ci.sh
+++ b/.github/scripts/run-trtmc-ci.sh
@@ -173,7 +173,7 @@ lint_changed_files() {
 
   local base_ref="$CI_BASE_REF"
   if [ "${GITHUB_EVENT_NAME:-}" = "workflow_dispatch" ] || [ "${GITHUB_EVENT_NAME:-}" = "schedule" ]; then
-    base_ref="origin/${GITHUB_REF_NAME:-main}"
+    base_ref="${CI_BASE_REF:-origin/${GITHUB_REF_NAME:-main}}"
   fi
 
   local changed_py

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 10 * * *"
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to test with the full nightly workflow"
+        required: false
+        default: "main"
 
 permissions:
   contents: read
@@ -35,12 +40,13 @@ env:
   DIFFUSION_VLM_MAX_SIDE: "512"
   DIFFUSION_VLM_MAX_NEW_TOKENS: "384"
   DIFFUSION_VLM_TIMEOUT: "45m"
+  NIGHTLY_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || 'main' }}
   HF_TOKEN: ${{ secrets.HF_TOKEN }}
   HUGGING_FACE_HUB_TOKEN: ${{ secrets.HF_TOKEN }}
 
 jobs:
   nightly-ci:
-    name: Nightly Full CI on GitHub main
+    name: Nightly Full CI
     runs-on: ${{ fromJSON(vars.TRTMC_RUNNER_LABELS || '["self-hosted"]') }}
     timeout-minutes: 720
 
@@ -76,10 +82,10 @@ jobs:
               '
           fi
 
-      - name: Check out GitHub main tip
+      - name: Check out nightly ref
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ env.NIGHTLY_REF }}
           fetch-depth: 0
           clean: false
           lfs: false
@@ -88,13 +94,18 @@ jobs:
         run: |
           set -euo pipefail
           git fetch origin main --quiet
-          echo "CI_BASE_REF=HEAD~1" >> "$GITHUB_ENV"
-          echo "Running nightly on GitHub main tip: $(git rev-parse HEAD)"
+          if [ "$NIGHTLY_REF" = "main" ]; then
+            base="HEAD~1"
+          else
+            base="origin/main"
+          fi
+          echo "CI_BASE_REF=$base" >> "$GITHUB_ENV"
+          echo "Running nightly on GitHub ref '$NIGHTLY_REF': $(git rev-parse HEAD)"
 
       - name: Report CI mode
         run: |
           set -euo pipefail
-          echo "CI mode: nightly/full E2E on GitHub main"
+          echo "CI mode: nightly/full E2E on GitHub ref '$NIGHTLY_REF'"
           echo "FULL_E2E=$FULL_E2E"
           echo "RUN_COVERAGE_MAP=$RUN_COVERAGE_MAP"
           echo "REBUILD_ENGINES=$REBUILD_ENGINES"
@@ -104,46 +115,57 @@ jobs:
         run: bash .github/scripts/run-gha-stage.sh setup
 
       - name: Impact analysis
+        if: ${{ always() }}
         timeout-minutes: 5
         run: bash .github/scripts/run-gha-stage.sh impact
 
       - name: Build all
+        if: ${{ always() }}
         timeout-minutes: 15
         run: bash .github/scripts/run-gha-stage.sh build
 
       - name: Check family coverage
+        if: ${{ always() }}
         timeout-minutes: 15
         run: bash .github/scripts/run-gha-stage.sh family-coverage
 
       - name: Check cyclomatic complexity
+        if: ${{ always() }}
         timeout-minutes: 15
         run: bash .github/scripts/run-gha-stage.sh complexity
 
       - name: Lint changed files
+        if: ${{ always() }}
         timeout-minutes: 5
         run: bash .github/scripts/run-gha-stage.sh lint
 
       - name: C++ unit tests
+        if: ${{ always() }}
         timeout-minutes: 20
         run: bash .github/scripts/run-gha-stage.sh cpp-unit
 
       - name: Python builder and tools tests
+        if: ${{ always() }}
         timeout-minutes: 40
         run: bash .github/scripts/run-gha-stage.sh python-builder
 
       - name: C++ coverage
+        if: ${{ always() }}
         timeout-minutes: 40
         run: bash .github/scripts/run-gha-stage.sh cpp-coverage
 
       - name: Graph-op GPU tests
+        if: ${{ always() }}
         timeout-minutes: 20
         run: bash .github/scripts/run-gha-stage.sh graph-ops
 
       - name: Full E2E tests
+        if: ${{ always() }}
         timeout-minutes: 360
         run: bash .github/scripts/run-gha-stage.sh full-e2e
 
       - name: Generate coverage map
+        if: ${{ always() }}
         timeout-minutes: 90
         run: bash .github/scripts/run-gha-stage.sh coverage-map
 

--- a/tests/builder/test_owned_builder_mocked_paths.py
+++ b/tests/builder/test_owned_builder_mocked_paths.py
@@ -68,8 +68,15 @@ def _import_with_fake_trt(module_name: str, fake_trt: types.SimpleNamespace | No
     if module_name.endswith("encoder_builder"):
         _drop_imported_module("tensorrt_model_connect.graph_ops")
         _drop_imported_module("tensorrt_model_connect.graph_blocks")
-    with patch.dict(sys.modules, {"tensorrt": fake_trt}):
+    previous_trt = sys.modules.get("tensorrt")
+    sys.modules["tensorrt"] = fake_trt
+    try:
         return importlib.import_module(module_name)
+    finally:
+        if previous_trt is None:
+            sys.modules.pop("tensorrt", None)
+        else:
+            sys.modules["tensorrt"] = previous_trt
 
 
 @pytest.mark.unit
@@ -108,9 +115,10 @@ def test_encoder_seq_layer_norm_uses_native_normalization() -> None:
     mod = _import_with_fake_trt("tensorrt_model_connect.families.bert.encoder_builder")
 
     class _FakeTensor:
-        def __init__(self, name: str, dtype=np.float32):
+        def __init__(self, name: str, dtype=np.float32, shape: tuple[int, ...] = (3, 4)):
             self.name = name
             self.dtype = dtype
+            self.shape = shape
 
     class _FakeNormLayer:
         def __init__(self):

--- a/tests/builder/test_owned_encoder_builders_coverage.py
+++ b/tests/builder/test_owned_encoder_builders_coverage.py
@@ -30,17 +30,19 @@ if str(_PKG_ROOT) not in sys.path:
 class _FakeTensor:
     _next_id = 0
 
-    def __init__(self, name: str | None = None):
+    def __init__(self, name: str | None = None, shape: tuple[int, ...] = (1, 4)):
         if name is None:
             type(self)._next_id += 1
             name = f"t{type(self)._next_id}"
         self.name = name
         self.dtype = None
+        self.shape = shape
 
 
 class _FakeLayer:
-    def __init__(self, output: _FakeTensor | None = None):
+    def __init__(self, output: _FakeTensor | None = None, shape: tuple[int, ...] = (1, 4)):
         self._output = output or _FakeTensor()
+        self._output.shape = shape
         self.reshape_dims = None
         self.second_transpose = None
         self.first_transpose = None
@@ -67,17 +69,19 @@ class _FakeNetwork:
 
     def _record(self, op: str, *args, **kwargs) -> _FakeLayer:
         self.calls.append((op, args, kwargs))
-        return _FakeLayer()
+        shape = next((tuple(arg.shape) for arg in args if hasattr(arg, "shape")), (1, 4))
+        return _FakeLayer(shape=shape)
 
     def add_input(self, name: str, dtype: object, shape: tuple[int, ...]) -> _FakeTensor:
         self.inputs.append((name, dtype, shape))
-        out = _FakeTensor(name)
+        out = _FakeTensor(name, shape=shape)
         out.dtype = dtype
         self.calls.append(("add_input", (name, dtype, shape), {}))
         return out
 
     def add_constant(self, shape: tuple[int, ...], weights: object) -> _FakeLayer:
-        return self._record("add_constant", shape, weights)
+        self.calls.append(("add_constant", (shape, weights), {}))
+        return _FakeLayer(shape=tuple(shape))
 
     def add_cast(self, tensor, target_dtype, **kwargs) -> _FakeLayer:
         layer = self._record("add_cast", tensor, target_dtype, **kwargs)
@@ -213,8 +217,15 @@ def _import_with_fake_trt(module_name: str, fake_trt: types.SimpleNamespace):
     ):
         if mod_name is not None:
             _drop_imported_module(mod_name)
-    with patch.dict(sys.modules, {"tensorrt": fake_trt}):
+    previous_trt = sys.modules.get("tensorrt")
+    sys.modules["tensorrt"] = fake_trt
+    try:
         return importlib.import_module(module_name)
+    finally:
+        if previous_trt is None:
+            sys.modules.pop("tensorrt", None)
+        else:
+            sys.modules["tensorrt"] = previous_trt
 
 
 def _import_qwen3_with_fake_trt(fake_trt: types.SimpleNamespace):

--- a/tests/tools/test_coverage_map.py
+++ b/tests/tools/test_coverage_map.py
@@ -280,6 +280,21 @@ class TestSelectTests:
         assert "builder" in result.fallback_tiers
         assert result.builder_tests == []
 
+    def test_direct_python_test_file_runs_directly_without_fallback(self, sample_map):
+        """Changed Python tests should run directly without forcing full-tier fallback."""
+        result = select_tests([
+            "tests/builder/test_family_timm_vit.py",
+            "tests/tools/test_test_impact.py",
+            "tests/e2e_harness/test_orchestrator_phases.py",
+        ], sample_map)
+
+        assert result.builder_tests == ["tests/builder/test_family_timm_vit.py"]
+        assert result.tools_tests == [
+            "tests/e2e_harness/test_orchestrator_phases.py",
+            "tests/tools/test_test_impact.py",
+        ]
+        assert result.fallback_tiers == []
+
     def test_multiple_files_union(self, sample_map):
         """Multiple changed files produce union of tests."""
         result = select_tests([

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -100,6 +100,39 @@ def test_github_workflows_keep_html_report_in_full_artifacts() -> None:
         assert "!e2e_artifacts/e2e_report.html" not in text
 
 
+def test_nightly_workflow_dispatch_can_validate_requested_ref() -> None:
+    text = (REPO_ROOT / ".github" / "workflows" / "nightly.yml").read_text()
+    assert "workflow_dispatch:" in text
+    assert "NIGHTLY_REF:" in text
+    assert "ref: ${{ env.NIGHTLY_REF }}" in text
+    assert 'base="origin/main"' in text
+
+
+def test_workflow_dispatch_lint_uses_resolved_ci_base_ref() -> None:
+    text = (REPO_ROOT / ".github" / "scripts" / "run-trtmc-ci.sh").read_text()
+    assert 'base_ref="${CI_BASE_REF:-origin/${GITHUB_REF_NAME:-main}}"' in text
+
+
+def test_nightly_attempts_all_test_stages_after_failures() -> None:
+    text = (REPO_ROOT / ".github" / "workflows" / "nightly.yml").read_text()
+    required_steps = (
+        "Impact analysis",
+        "Build all",
+        "Check family coverage",
+        "Check cyclomatic complexity",
+        "Lint changed files",
+        "C++ unit tests",
+        "Python builder and tools tests",
+        "C++ coverage",
+        "Graph-op GPU tests",
+        "Full E2E tests",
+        "Generate coverage map",
+    )
+    for step_name in required_steps:
+        block = text.split(f"- name: {step_name}", maxsplit=1)[1].split("\n\n", maxsplit=1)[0]
+        assert "if: ${{ always() }}" in block
+
+
 def test_github_workflows_write_e2e_markdown_summary() -> None:
     for workflow in ("trtmc-ci.yml", "nightly.yml"):
         text = (REPO_ROOT / ".github" / "workflows" / workflow).read_text()

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1537,6 +1537,20 @@ class TestCoverageMapIntegration:
         assert result.tools_tests == ["tests/tools/test_z_image_model_card_contract.py"]
         assert "tools" not in result.fallback_tiers
 
+    def test_direct_builder_test_does_not_suppress_shared_source_fallback(self, imap):
+        """Direct tests must not hide fallback required by changed shared builder code."""
+        result = test_impact.analyze_impact(
+            [
+                "tensorrt_model_connect/tensorrt_model_connect/graph_ops.py",
+                "tests/builder/test_family_timm_vit.py",
+            ],
+            imap,
+            coverage_map={},
+        )
+
+        assert result.builder_tests == ["tests/builder/test_family_timm_vit.py"]
+        assert "builder" in result.fallback_tiers
+
     def test_changed_e2e_harness_unit_test_selected_directly(self, imap):
         """Changed e2e_harness test files run directly without broad E2E impact."""
         result = test_impact.analyze_impact(

--- a/tools/coverage_map/select_tests.py
+++ b/tools/coverage_map/select_tests.py
@@ -71,6 +71,15 @@ def _classify_tier(path: str) -> Optional[str]:
     return None
 
 
+def _direct_python_test_tier(path: str) -> Optional[str]:
+    """Return the tier for Python test files that pytest can run directly."""
+    if path.startswith("tests/builder/") or path.startswith("tests/engine_defs/torch_trt/"):
+        return "builder"
+    if path.startswith("tests/tools/") or path.startswith("tests/e2e_harness/test_"):
+        return "tools"
+    return None
+
+
 def select_tests(
     changed_files: List[str],
     source_to_tests: Dict[str, List[str]],
@@ -90,6 +99,14 @@ def select_tests(
 
     for path in changed_files:
         path = path.replace("\\", "/").strip("/")
+
+        direct_tier = _direct_python_test_tier(path)
+        if direct_tier == "builder":
+            builder_tests.add(path)
+            continue
+        if direct_tier == "tools":
+            tools_tests.add(path)
+            continue
 
         if _is_no_impact(path):
             continue

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1574,10 +1574,8 @@ def analyze_impact(
     direct_builder_tests, direct_tools_tests = _direct_python_test_targets(changed_files)
     if direct_builder_tests:
         builder_tests = sorted(set(builder_tests).union(direct_builder_tests))
-        fallback_tiers = [tier for tier in fallback_tiers if tier != "builder"]
     if direct_tools_tests:
         tools_tests = sorted(set(tools_tests).union(direct_tools_tests))
-        fallback_tiers = [tier for tier in fallback_tiers if tier != "tools"]
 
     return ImpactResult(
         e2e_models=e2e_models,


### PR DESCRIPTION
## Background
The latest nightly exposed a premerge false negative: a shared builder helper changed, selective CI ran only direct family tests, and the full builder suite caught the missed mocked encoder paths later in nightly. This PR tightens selective test fallback and changes nightly so one failed stage does not prevent later stages from running.

## Exit Criteria
- Shared builder/source changes cannot have their full-tier fallback suppressed by directly changed tests in the same PR.
- Directly changed Python test files still run directly without forcing a full-tier fallback by themselves.
- Nightly can be manually dispatched against a PR branch and attempts all major validation stages even if an earlier stage fails.
- The builder mock tests that caught the latest failure pass with TensorRT-like shape metadata.

## Implementation
- Keep coverage-map fallback tiers when changed shared source still requires full-tier execution; direct tests are unioned into the selected set but no longer hide source fallback.
- Teach coverage-map selection to recognize direct Python test files before no-impact filtering.
- Add a `nightly.yml` workflow-dispatch `ref` input and compare non-main manual nightlies against `origin/main`.
- Add `if: always()` to nightly validation stages so later stages still run and produce evidence after an earlier failure.
- Update fake TRT tensors in the affected mocked builder tests to carry `.shape`, matching the contract used by native layer norm.

## Validation
- `env PYTHONPATH=tensorrt_model_connect:. python3 -m pytest tests/tools/test_github_actions_ci.py tests/tools/test_test_impact.py tests/tools/test_coverage_map.py -q -p no:cacheprovider`: passed, 170 tests.
- `env PYTHONPATH=tensorrt_model_connect:. python3 -m pytest tests/builder/test_owned_builder_mocked_paths.py tests/builder/test_owned_encoder_builders_coverage.py -q -p no:cacheprovider`: passed, 16 tests.
- `env PYTHONPATH=tensorrt_model_connect:. python3 tools/test_impact.py --validate --json`: passed.
- `ruff check tools/coverage_map/select_tests.py tools/test_impact.py tests/tools/test_coverage_map.py tests/tools/test_test_impact.py tests/tools/test_github_actions_ci.py tests/builder/test_owned_builder_mocked_paths.py tests/builder/test_owned_encoder_builders_coverage.py`: passed.
- `bash -n .github/scripts/run-trtmc-ci.sh`: passed.
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/nightly.yml').read_text()); yaml.safe_load(pathlib.Path('.github/workflows/trtmc-ci.yml').read_text()); print('yaml ok')"`: passed.

## Notes For Future Readers
Review `tools/test_impact.py` and `tools/coverage_map/select_tests.py` first; the workflow changes are there to prove this policy in GitHub Actions and to make branch-level nightly validation possible.
