### PR TITLE
fix(builder): generate PixArt tokenizer JSON

### DIFF
--- a/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
@@ -520,6 +520,26 @@ def _detect_diffusion_tokenizer_add_special_tokens(model_dir: Path) -> bool:
     return _detect_tokenizer_add_special_tokens(model_dir)
 
 
+def _find_sentencepiece_model(model_dir: Path) -> Path | None:
+    """Return the best SentencePiece model file for tokenizer.json conversion."""
+    preferred = (
+        model_dir / "source.spm",
+        model_dir / "spiece.model",
+        model_dir / "tokenizer.model",
+    )
+    for path in preferred:
+        if path.exists():
+            return path
+
+    candidates = sorted(
+        {
+            *model_dir.glob("*.spm"),
+            *model_dir.glob("*.model"),
+        }
+    )
+    return candidates[0] if candidates else None
+
+
 def _ensure_tokenizer_json(model_dir: Path) -> None:
     """If the model directory lacks tokenizer.json, generate it from the
     slow tokenizer using HF transformers. This ensures the C++ runtime can
@@ -544,15 +564,16 @@ def _ensure_tokenizer_json(model_dir: Path) -> None:
     except Exception:
         pass
 
-    # --- Attempt 2: build from SentencePiece .spm + vocab.json ---
+    # --- Attempt 2: build from SentencePiece model + optional vocab.json ---
     # Marian/NLLB models have source.spm (encoder-side SentencePiece) and
     # vocab.json (combined source+target vocabulary with IDs).  We build a
     # Unigram tokenizer.json using the full combined vocab (so IDs match the
     # TRT engine) with scores from the SPM model for source tokens and a
     # default low score for target-only tokens.
-    spm_candidates = list(model_dir.glob("*.spm"))
-    source_spm = model_dir / "source.spm"
-    spm_path = source_spm if source_spm.exists() else (spm_candidates[0] if spm_candidates else None)
+    #
+    # Diffusers T5 tokenizers, including PixArt, commonly ship spiece.model
+    # instead of a .spm file.
+    spm_path = _find_sentencepiece_model(model_dir)
     vocab_json_path = model_dir / "vocab.json"
     if spm_path is not None:
         try:

--- a/tests/builder/test_engine_builder_extended.py
+++ b/tests/builder/test_engine_builder_extended.py
@@ -23,6 +23,7 @@ try:
     from tensorrt_model_connect.engine_builder import (
         _get_trt_version,
         _get_gpu_name,
+        _find_sentencepiece_model,
         _ensure_tokenizer_json,
         build_bundle,
     )
@@ -116,6 +117,30 @@ class TestGetGpuName:
 # ---------------------------------------------------------------------------
 # _ensure_tokenizer_json
 # ---------------------------------------------------------------------------
+
+
+class TestFindSentencePieceModel:
+    def test_prefers_source_spm(self, tmp_path):
+        """source.spm remains the preferred encoder-side SentencePiece file."""
+        source = tmp_path / "source.spm"
+        spiece = tmp_path / "spiece.model"
+        source.write_bytes(b"source")
+        spiece.write_bytes(b"spiece")
+
+        assert _find_sentencepiece_model(tmp_path) == source
+
+    def test_falls_back_to_spiece_model(self, tmp_path):
+        """PixArt/T5 tokenizer directories commonly ship spiece.model."""
+        spiece = tmp_path / "spiece.model"
+        spiece.write_bytes(b"spiece")
+
+        assert _find_sentencepiece_model(tmp_path) == spiece
+
+    def test_falls_back_to_any_model_extension(self, tmp_path):
+        custom = tmp_path / "custom.model"
+        custom.write_bytes(b"custom")
+
+        assert _find_sentencepiece_model(tmp_path) == custom
 
 
 class TestEnsureTokenizerJson:

--- a/tests/e2e/models/pixart-sigma-1024-tp4.json
+++ b/tests/e2e/models/pixart-sigma-1024-tp4.json
@@ -1,8 +1,8 @@
 {
-  "name": "pixart-sigma-1024-l0-tp4",
-  "trace_id": "IT-E2E-PXART-L0-TP4-01",
+  "name": "pixart-sigma-1024-tp4",
+  "trace_id": "IT-E2E-PXART-TP4-01",
   "hf_id": "PixArt-alpha/PixArt-Sigma-XL-2-1024-MS",
-  "bundle": "pixart-sigma-1024-l0-tp4.trtfb",
+  "bundle": "pixart-sigma-1024-tp4.trtfb",
   "model_type": "pixart",
   "family": "pixart",
   "runtime_strategy": "diffusion_pixart",
@@ -67,8 +67,8 @@
   ],
   "test_prompt": "A photo of a cat sitting on a windowsill at sunset",
   "test_type": "diffusion",
-  "image_height": 512,
-  "image_width": 512,
+  "image_height": 1024,
+  "image_width": 1024,
   "video_num_frames": 1,
   "num_inference_steps": 20,
   "stages": [
@@ -78,7 +78,8 @@
     }
   ],
   "threshold_overrides": {
-    "psnr": 2.0,
-    "ssim": -1.0
+    "min_pixel_mean": 0.15,
+    "max_pixel_mean": 0.85,
+    "min_pixel_std": 0.05
   }
 }


### PR DESCRIPTION
## Background
PixArt runtime prompt conditioning depends on the native C++ tokenizer embedded in the `.trtfb` bundle. SentencePiece-only tokenizer directories can lack `tokenizer.json`; before this change the fallback conversion only looked for `source.spm` or other `*.spm` files, while PixArt/T5 tokenizer directories commonly ship `spiece.model`.

The tokenizer fix is generic, not tensor-parallel specific. The TP4 manifest gives the distributed PixArt path native 1024x1024 coverage so tokenizer or sharding regressions show up in an end-to-end image comparison.

## Exit Criteria
- SentencePiece tokenizers that use `spiece.model` can generate and embed a native `tokenizer.json`.
- PixArt TP4 builds and runs at 1024x1024 against the HF Diffusers reference.
- TRT output is visually coherent and passes image-health gates, not just process-level success.

## Implementation
- Add SentencePiece model discovery that prefers `source.spm`, then `spiece.model`, then `tokenizer.model`, with fallback to any `*.spm` or `*.model` file.
- Use that discovery in `_ensure_tokenizer_json()` so diffusion bundles can embed `tokenizer.json` for PixArt/T5-style tokenizers.
- Promote the PixArt TP4 e2e manifest from the 512px L0 variant to native 1024x1024 coverage and use image-health thresholds for mean/std instead of the old loose similarity-only gates.

## Validation
- `pytest tests/builder/test_engine_builder_extended.py::TestFindSentencePieceModel -q`: passed, 3 passed.
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so && cmake --build build -j 32`: passed in the B200 TRT11 container, with `libtrtmc_backend_trt.so` enabled.
- `HF_HOME=/workspace/tensorrt-model-connect/artifacts/pr107-pixart-b200/hf_home pytest tests/test_e2e.py::test_e2e[pixart-sigma-1024-tp4] --multi-device-only --e2e-platform B200 --e2e-artifacts-dir /workspace/tensorrt-model-connect/artifacts/pr107-pixart-b200 --engine-dir /workspace/tensorrt-model-connect/artifacts/pr107-pixart-b200/engines --trtmc-binary ./build/trtmc --hf-python /opt/venv/bin/python --rebuild-engines -s -vv`: passed, 1 passed in 624.81s.
- `python3 -m tensorrt_model_connect.__main__ inspect /workspace/tensorrt-model-connect/artifacts/pr107-pixart-b200/engines/pixart-sigma-1024-tp4.trtfb`: confirmed the bundle includes `tokenizer.json`, `tokenizer_config.json`, `special_tokens_map.json`, and `spiece.model`.
- New B200 image metrics: TRT mean/std `0.2778 / 0.3216`, reference mean/std `0.2953 / 0.3392`, std ratio `0.948`, PSNR `8.998`, SSIM `0.426`; all gates passed.

## Notes For Future Readers
- Single-device PixArt uses the same tokenizer generation path; the core fix is not TP-specific.
- TP4 remains useful coverage because it exercises rank-specific DiT plans, `mpirun -np 4`, distributed communicator setup, and rank-0 image artifact writing.
- In the latest B200 run, `tokenizer.json` generation succeeded through the existing slow-tokenizer conversion path; the `spiece.model` discovery is the fallback that prevents this class of failure when that conversion is unavailable.
