### PR TITLE
feat(canary): add tensor parallel decoder

### DIFF
--- a/src/runtime/models/whisper/plugin.cpp
+++ b/src/runtime/models/whisper/plugin.cpp
@@ -4,10 +4,50 @@
 #include "runtime/models/whisper/pipeline.h"
 #include "runtime/plugins/shared/audio_helpers.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
 
+#include <limits>
+#include <string>
+#include <vector>
+
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
+    if (dim < 0 || static_cast<std::size_t>(dim) >= shape.size())
+        return -1;
+    const auto value = shape[static_cast<std::size_t>(dim)];
+    if (value <= 0 || value > std::numeric_limits<int32_t>::max())
+        return -1;
+    return static_cast<int32_t>(value);
+}
+
+int32_t decoder_cache_row_width(const TrtModule& module, const BaseConfig& config) {
+    const int32_t from_engine = dim_at(module.tensor_shape("cache_k_0"), 1);
+    return from_engine > 0 ? from_engine : compute_kv_dim(config);
+}
+
+} // namespace
 
 class WhisperPlugin final : public IPipelinePlugin {
   public:
@@ -19,6 +59,10 @@ class WhisperPlugin final : public IPipelinePlugin {
         opts.cuda_graphs = ctx.cuda_graphs;
 
         const auto& json = ctx.config_json;
+        const auto tp_config = parse_tensor_parallel_runtime_config(json);
+        DistributedRuntimeGroup tp_group;
+        if (tp_config.enabled)
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
 
         // Load encoder (stored as vision_engine_plan in Whisper bundles)
         const auto* enc_plan = find_section(ctx.bundle, "vision_engine_plan");
@@ -26,9 +70,16 @@ class WhisperPlugin final : public IPipelinePlugin {
             enc_plan = find_section(ctx.bundle, "coarse_engine_plan");
         auto enc_loaded = load_trt_module_from_plan(ctx.backend, enc_plan, "whisper encoder", opts);
 
-        // Load decoder (main engine_plan)
+        if (tp_config.enabled) {
+            opts.distributed_communicator = tp_group.communicator;
+            opts.distributed_owner = tp_group.owner;
+        }
+
+        // Load decoder (main engine_plan or rank-local TP section)
+        const std::string decoder_section =
+            tp_config.enabled ? tp_engine_section_name(tp_group.rank) : std::string("engine_plan");
         auto dec_loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "whisper decoder", opts);
+            ctx.backend, find_section(ctx.bundle, decoder_section), "whisper decoder", opts);
 
         // Build WhisperConfig
         int32_t encoder_layers = extract_json_int(json, "encoder_layers", ctx.config.num_layers);
@@ -47,7 +98,7 @@ class WhisperPlugin final : public IPipelinePlugin {
 
         // Create KvCache for decoder self-attention
         cudaStream_t stream = dec_loaded.module->stream();
-        int32_t kv_dim = compute_kv_dim(ctx.config);
+        int32_t kv_dim = decoder_cache_row_width(*dec_loaded.module, ctx.config);
         int32_t max_cache = ctx.config.max_cache_length;
         DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
         std::unique_ptr<IInferenceState> state =

--- a/tensorrt_model_connect/tensorrt_model_connect/families/canary/decoder_tp_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/canary/decoder_tp_builder.py
@@ -1,0 +1,468 @@
+"""Tensor-parallel Canary decoder builder.
+
+This intentionally mirrors the single-device Canary decoder graph in
+``plugin.py`` while making the rank-local TP choices explicit:
+
+* self-attention and cross-attention Q/K/V projections are column-sharded,
+* attention output and MLP down projections are row-sharded,
+* row-parallel joins use TensorRT distributed ALL_REDUCE,
+* embeddings, norms, encoder output inputs, and LM head stay replicated.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+import sys
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import (
+    add_all_reduce_sum,
+    normalize_parallel_config,
+)
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_canary_tp(
+    weights: "WeightDict",
+    *,
+    hidden: int,
+    num_heads: int,
+    ffn_dim: int,
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("Canary tensor-parallel engine build requires a concrete rank")
+    tp = parallel.tp_size
+    if hidden % tp != 0:
+        raise ValueError(
+            f"Canary tensor parallel requires hidden size divisible by tp_size "
+            f"({hidden} vs {tp})")
+    if num_heads % tp != 0:
+        raise ValueError(
+            f"Canary tensor parallel requires decoder_attention_heads divisible "
+            f"by tp_size ({num_heads} vs {tp})")
+    if ffn_dim % tp != 0:
+        raise ValueError(
+            f"Canary tensor parallel requires decoder_ffn_dim divisible by tp_size "
+            f"({ffn_dim} vs {tp})")
+    dec_layers = int(weights["_dec_layers"])
+    for i in range(dec_layers):
+        prefix = f"layer.{i}"
+        for key in (f"{prefix}.w_q", f"{prefix}.w_k", f"{prefix}.w_v",
+                    f"{prefix}.xw_q", f"{prefix}.xw_k", f"{prefix}.xw_v"):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim is not divisible by tp_size={tp}")
+        for key in (f"{prefix}.w_o", f"{prefix}.xw_o", f"{prefix}.w_fc2"):
+            if weights[key].shape[0] % tp != 0:
+                raise ValueError(f"{key} input dim is not divisible by tp_size={tp}")
+        if weights[f"{prefix}.w_fc1"].shape[-1] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc1 output dim is not divisible by tp_size={tp}")
+
+
+def shard_canary_decoder_weights(
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local decoder weights for the Canary TP builder."""
+    if not parallel.enabled:
+        return weights
+
+    rank = parallel.rank
+    tp = parallel.tp_size
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+        if key.endswith((
+            ".w_q", ".w_k", ".w_v",
+            ".xw_q", ".xw_k", ".xw_v",
+            ".w_fc1",
+        )):
+            out[key] = _slice_last_dim(value, rank, tp)
+        elif key.endswith((
+            ".q_bias", ".k_bias", ".v_bias",
+            ".xb_q", ".xb_k", ".xb_v",
+            ".fc1_bias",
+        )):
+            out[key] = _slice_first_dim(value, rank, tp)
+        elif key.endswith((".w_o", ".xw_o", ".w_fc2")):
+            out[key] = _slice_first_dim(value, rank, tp)
+        else:
+            out[key] = value
+
+    out["_tensor_parallel_size"] = tp
+    out["_tensor_parallel_rank"] = rank
+    return out
+
+
+def _add_linear_with_bias(
+    network,
+    lhs,
+    in_dim: int,
+    out_dim: int,
+    weight: np.ndarray,
+    bias: np.ndarray | None,
+    *,
+    dtype: np.dtype,
+):
+    out = graph_ops.add_matmul_rhs_constant(
+        network, lhs, in_dim, out_dim, weight, dtype=dtype)
+    if bias is not None:
+        out = graph_ops.add_bias_sum(network, out, out_dim, bias, dtype=dtype)
+    return out
+
+
+def _add_attention_from_rows_manual(
+    network,
+    q,
+    k,
+    v,
+    *,
+    num_heads: int,
+    head_dim: int,
+    q_seq: int,
+    kv_seq: int,
+    mask=None,
+    fp32_accumulation: bool = False,
+):
+    """Primitive scaled-dot-product attention for TP head counts.
+
+    TensorRT native IAttention can be tactic-sensitive for some rank-local
+    head counts, so TP uses explicit batched matmul + softmax + matmul for
+    build stability.
+    """
+    output_dtype = q.dtype
+    q_4d = graph_ops.reshape_rows_to_heads_4d(
+        network, q, num_heads, head_dim, sequence_length=q_seq)
+    k_4d = graph_ops.reshape_rows_to_heads_4d(
+        network, k, num_heads, head_dim, sequence_length=kv_seq)
+    v_4d = graph_ops.reshape_rows_to_heads_4d(
+        network, v, num_heads, head_dim, sequence_length=kv_seq)
+    if fp32_accumulation and output_dtype != trt.float32:
+        q_4d = network.add_cast(q_4d, trt.float32).get_output(0)
+        k_4d = network.add_cast(k_4d, trt.float32).get_output(0)
+        v_4d = network.add_cast(v_4d, trt.float32).get_output(0)
+        if mask is not None and mask.dtype != trt.float32:
+            mask = network.add_cast(mask, trt.float32).get_output(0)
+
+    scale = float(1.0 / np.sqrt(max(head_dim, 1)))
+    scale_np_dtype = np.float16 if q_4d.dtype == trt.float16 else np.float32
+    scale_t = graph_ops.add_constant(
+        network, (1, 1, 1, 1), np.array([[[[scale]]]], dtype=scale_np_dtype),
+        dtype=scale_np_dtype)
+    if q_4d.dtype == trt.bfloat16:
+        scale_t = network.add_cast(scale_t, trt.bfloat16).get_output(0)
+
+    scores = network.add_matrix_multiply(
+        q_4d, trt.MatrixOperation.NONE,
+        k_4d, trt.MatrixOperation.TRANSPOSE).get_output(0)
+    scores = network.add_elementwise(
+        scores, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
+    if mask is not None:
+        scores = network.add_elementwise(
+            scores, mask, trt.ElementWiseOperation.SUM).get_output(0)
+    probs = network.add_softmax(scores)
+    probs.axes = 1 << 3
+    context = network.add_matrix_multiply(
+        probs.get_output(0), trt.MatrixOperation.NONE,
+        v_4d, trt.MatrixOperation.NONE).get_output(0)
+    if context.dtype != output_dtype:
+        context = network.add_cast(context, output_dtype).get_output(0)
+    return graph_ops.reshape_heads_4d_to_rows(
+        network, context, num_heads * head_dim, sequence_length=q_seq)
+
+
+def _add_canary_tp_decoder_layer(
+    *,
+    network,
+    hidden,
+    cache_k,
+    cache_v,
+    cross_k,
+    cross_v,
+    attention_mask,
+    eps_tensor,
+    weights,
+    prefix: str,
+    hidden_size: int,
+    local_attention_size: int,
+    local_heads: int,
+    head_dim: int,
+    local_ffn_dim: int,
+    max_cache_length: int,
+    max_source_positions: int,
+    dtype: np.dtype,
+    work_trt_dtype,
+    tp_size: int,
+):
+    attention_window = max_cache_length + 1
+
+    # Self-attention. Q/K/V are column-parallel, so each rank owns a subset of
+    # heads. The output projection is row-parallel and all-reduced before bias.
+    normed = graph_ops.add_layer_norm(
+        network, hidden, hidden_size, weights[f"{prefix}.input_norm"],
+        weights[f"{prefix}.input_norm_b"], eps_tensor, dtype=dtype)
+    q = _add_linear_with_bias(
+        network, normed, hidden_size, local_attention_size,
+        weights[f"{prefix}.w_q"], weights[f"{prefix}.q_bias"], dtype=dtype)
+    k = _add_linear_with_bias(
+        network, normed, hidden_size, local_attention_size,
+        weights[f"{prefix}.w_k"], weights[f"{prefix}.k_bias"], dtype=dtype)
+    v = _add_linear_with_bias(
+        network, normed, hidden_size, local_attention_size,
+        weights[f"{prefix}.w_v"], weights[f"{prefix}.v_bias"], dtype=dtype)
+    present_k, present_v = k, v
+
+    kr = network.add_shuffle(k)
+    kr.reshape_dims = (1, local_attention_size)
+    vr = network.add_shuffle(v)
+    vr.reshape_dims = (1, local_attention_size)
+    ak = network.add_concatenation([cache_k, kr.get_output(0)])
+    ak.axis = 0
+    av = network.add_concatenation([cache_v, vr.get_output(0)])
+    av.axis = 0
+
+    mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask)
+    context = _add_attention_from_rows_manual(
+        network, q, ak.get_output(0), av.get_output(0),
+        num_heads=local_heads, head_dim=head_dim,
+        q_seq=1, kv_seq=attention_window,
+        mask=mask_4d)
+    sa = graph_ops.add_matmul_rhs_constant(
+        network, context, local_attention_size, hidden_size,
+        weights[f"{prefix}.w_o"], dtype=dtype)
+    sa = add_all_reduce_sum(network, sa, tp_size)
+    sa = graph_ops.add_bias_sum(
+        network, sa, hidden_size, weights[f"{prefix}.o_bias"], dtype=dtype)
+    psa = network.add_elementwise(hidden, sa, trt.ElementWiseOperation.SUM).get_output(0)
+
+    # Cross-attention. Encoder output is replicated; each rank projects K/V
+    # into its local heads, then all-reduces the row-parallel output join.
+    cn = graph_ops.add_layer_norm(
+        network, psa, hidden_size, weights[f"{prefix}.xattn_norm"],
+        weights[f"{prefix}.xattn_norm_b"], eps_tensor, dtype=dtype)
+    cq = _add_linear_with_bias(
+        network, cn, hidden_size, local_attention_size,
+        weights[f"{prefix}.xw_q"], weights[f"{prefix}.xb_q"], dtype=dtype)
+
+    cross_k_typed = cross_k
+    cross_v_typed = cross_v
+    if work_trt_dtype != trt.float32:
+        cross_k_typed = network.add_cast(cross_k, work_trt_dtype).get_output(0)
+        cross_v_typed = network.add_cast(cross_v, work_trt_dtype).get_output(0)
+
+    ck_proj = _add_linear_with_bias(
+        network, cross_k_typed, hidden_size, local_attention_size,
+        weights[f"{prefix}.xw_k"], weights[f"{prefix}.xb_k"], dtype=dtype)
+    cv_proj = _add_linear_with_bias(
+        network, cross_v_typed, hidden_size, local_attention_size,
+        weights[f"{prefix}.xw_v"], weights[f"{prefix}.xb_v"], dtype=dtype)
+    ccf = _add_attention_from_rows_manual(
+        network, cq, ck_proj, cv_proj,
+        num_heads=local_heads, head_dim=head_dim,
+        q_seq=1, kv_seq=max_source_positions,
+        fp32_accumulation=True)
+    ca = graph_ops.add_matmul_rhs_constant(
+        network, ccf, local_attention_size, hidden_size,
+        weights[f"{prefix}.xw_o"], dtype=dtype)
+    ca = add_all_reduce_sum(network, ca, tp_size)
+    ca = graph_ops.add_bias_sum(
+        network, ca, hidden_size, weights[f"{prefix}.xb_o"], dtype=dtype)
+    pca = network.add_elementwise(psa, ca, trt.ElementWiseOperation.SUM).get_output(0)
+
+    # ReLU MLP. FC1 is column-parallel; FC2 is row-parallel and all-reduced
+    # before adding the full FC2 bias.
+    fn = graph_ops.add_layer_norm(
+        network, pca, hidden_size, weights[f"{prefix}.ffn_norm"],
+        weights[f"{prefix}.ffn_norm_b"], eps_tensor, dtype=dtype)
+    fc1 = _add_linear_with_bias(
+        network, fn, hidden_size, local_ffn_dim,
+        weights[f"{prefix}.w_fc1"], weights[f"{prefix}.fc1_bias"], dtype=dtype)
+    act = graph_ops.add_activation(network, fc1, "relu", dtype=dtype)
+    fc2 = graph_ops.add_matmul_rhs_constant(
+        network, act, local_ffn_dim, hidden_size,
+        weights[f"{prefix}.w_fc2"], dtype=dtype)
+    fc2 = add_all_reduce_sum(network, fc2, tp_size)
+    mlp = graph_ops.add_bias_sum(
+        network, fc2, hidden_size, weights[f"{prefix}.fc2_bias"], dtype=dtype)
+    out = network.add_elementwise(pca, mlp, trt.ElementWiseOperation.SUM).get_output(0)
+    return {"hidden": out, "present_k": present_k, "present_v": present_v}
+
+
+def build_canary_tp_decoder_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_canary_tp_decoder_engine requires tensor_parallel mode "
+            "with tp_size > 1")
+    dec_layers = int(weights["_dec_layers"])
+    dec_heads = int(weights["_dec_heads"])
+    dec_ffn = int(weights["_dec_ffn"])
+    max_source_positions = int(weights["_enc_seq"])
+    hidden = int(config.hidden_size)
+    vocab = int(config.vocab_size)
+    head_dim = hidden // dec_heads
+    tp = parallel.tp_size
+
+    _validate_canary_tp(
+        weights, hidden=hidden, num_heads=dec_heads, ffn_dim=dec_ffn,
+        parallel=parallel)
+    rank_weights = shard_canary_decoder_weights(weights, parallel=parallel)
+    local_attention_size = hidden // tp
+    local_heads = dec_heads // tp
+    local_ffn_dim = dec_ffn // tp
+    attention_window = max_cache_length + 1
+
+    if precision == "fp16":
+        work_np_dtype = np.float16
+        work_trt_dtype = trt.float16
+    elif precision == "bf16":
+        work_np_dtype = np.float16
+        work_trt_dtype = trt.bfloat16
+    else:
+        work_np_dtype = np.float32
+        work_trt_dtype = trt.float32
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    position_id = network.add_input("position_id", trt.int32, (1,))
+    attention_mask = network.add_input(
+        "attention_mask", trt.float32, (1, attention_window))
+
+    cache_k_inputs, cache_v_inputs = [], []
+    for i in range(dec_layers):
+        cache_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_k", i),
+            work_trt_dtype, (max_cache_length, local_attention_size)))
+        cache_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_v", i),
+            work_trt_dtype, (max_cache_length, local_attention_size)))
+
+    cross_k_inputs, cross_v_inputs = [], []
+    for i in range(dec_layers):
+        cross_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cross_k", i),
+            trt.float32, (max_source_positions, hidden)))
+        cross_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cross_v", i),
+            trt.float32, (max_source_positions, hidden)))
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), rank_weights["dec_emb"],
+        dtype=work_np_dtype)
+    pos_embed_np = rank_weights["dec_pos"]
+    pos_embedding_table = graph_ops.add_constant(
+        network, pos_embed_np.shape, pos_embed_np, dtype=work_np_dtype)
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([1e-5], dtype=work_np_dtype),
+        dtype=work_np_dtype)
+
+    if work_trt_dtype != trt.float32:
+        attention_mask = network.add_cast(attention_mask, work_trt_dtype).get_output(0)
+
+    hidden_state = network.add_elementwise(
+        network.add_gather(embedding_table, token_id, 0).get_output(0),
+        network.add_gather(pos_embedding_table, position_id, 0).get_output(0),
+        trt.ElementWiseOperation.SUM).get_output(0)
+    hidden_state = graph_ops.add_layer_norm(
+        network, hidden_state, hidden, rank_weights["emb_ln"],
+        rank_weights["emb_ln_b"], eps_tensor, dtype=work_np_dtype)
+
+    present_k_outputs, present_v_outputs = [], []
+    for layer_idx in range(dec_layers):
+        prefix = f"layer.{layer_idx}"
+        result = _add_canary_tp_decoder_layer(
+            network=network,
+            hidden=hidden_state,
+            cache_k=cache_k_inputs[layer_idx],
+            cache_v=cache_v_inputs[layer_idx],
+            cross_k=cross_k_inputs[layer_idx],
+            cross_v=cross_v_inputs[layer_idx],
+            attention_mask=attention_mask,
+            eps_tensor=eps_tensor,
+            weights=rank_weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            local_attention_size=local_attention_size,
+            local_heads=local_heads,
+            head_dim=head_dim,
+            local_ffn_dim=local_ffn_dim,
+            max_cache_length=max_cache_length,
+            max_source_positions=max_source_positions,
+            dtype=work_np_dtype,
+            work_trt_dtype=work_trt_dtype,
+            tp_size=tp,
+        )
+        hidden_state = result["hidden"]
+        present_k_outputs.append(result["present_k"])
+        present_v_outputs.append(result["present_v"])
+
+    hidden_state = graph_ops.add_layer_norm(
+        network, hidden_state, hidden, rank_weights["final_norm"],
+        rank_weights["final_norm_b"], eps_tensor, dtype=work_np_dtype)
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, vocab, rank_weights["w_out"],
+        dtype=work_np_dtype)
+    logits = graph_ops.add_bias_sum(
+        network, logits, vocab, rank_weights["out_bias"],
+        dtype=work_np_dtype)
+
+    if work_trt_dtype != trt.float32:
+        logits = network.add_cast(logits, trt.float32).get_output(0)
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for i in range(dec_layers):
+        present_k_outputs[i].name = graph_ops.layer_tensor_name("present_k", i)
+        present_v_outputs[i].name = graph_ops.layer_tensor_name("present_v", i)
+        network.mark_output(present_k_outputs[i])
+        network.mark_output(present_v_outputs[i])
+
+    if verbose:
+        print(
+            "[trtmc build] Building Canary TP decoder "
+            f"(rank={parallel.rank}/{tp}, {dec_layers}L, h={hidden}, "
+            f"local_heads={local_heads}, cache={max_cache_length}, "
+            f"precision={precision})",
+            file=sys.stderr,
+        )
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT Canary TP decoder engine build failed")
+    return bytes(plan)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/canary/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/canary/plugin.py
@@ -35,6 +35,11 @@ from ...config import ModelConfig
 from ...checkpoint_mapper import WeightDict, _transpose_2d
 from ... import graph_ops
 from ... import graph_blocks
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
+from .decoder_tp_builder import build_canary_tp_decoder_engine
 
 
 trt = trt_compat.get_trt()
@@ -655,7 +660,26 @@ class CanaryPlugin:
     def build_engine(self, config: ModelConfig, weights: WeightDict,
                      max_cache_length: int, *, precision: str = "fp32",
                      quant_ctx=None, verbose: bool = False,
-                     debug_layer_outputs: bool = False) -> bytes:
+                     debug_layer_outputs: bool = False,
+                     parallel_config=None) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="Canary tensor-parallel decoder builds")
+            if quant_ctx is not None:
+                raise ValueError("Canary tensor-parallel builds do not support quantization")
+            if debug_layer_outputs:
+                raise ValueError(
+                    "Canary tensor-parallel builds do not support debug_layer_outputs")
+            return build_canary_tp_decoder_engine(
+                config,
+                weights,
+                max_cache_length,
+                precision=precision,
+                verbose=verbose,
+                parallel_config=parallel,
+            )
+
         dl = weights["_dec_layers"]
         dh = weights["_dec_heads"]
         df = weights["_dec_ffn"]

--- a/tensorrt_model_connect/tensorrt_model_connect/graph_ops.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/graph_ops.py
@@ -2081,7 +2081,8 @@ def add_layer_norm_native(
         eps:         Numerical stability epsilon (scalar, not a tensor).
         dtype:       Storage dtype for gamma/beta constants before TRT cast.
     """
-    rank = len(tuple(inp.shape))
+    inp_shape = getattr(inp, "shape", None)
+    rank = len(tuple(inp_shape)) if inp_shape is not None else 2
     param_shape = (
         (hidden_size,) if rank <= 1 else (1,) * (rank - 1) + (hidden_size,)
     )

--- a/tests/builder/test_family_plugins.py
+++ b/tests/builder/test_family_plugins.py
@@ -27,6 +27,9 @@ try:
 except (ImportError, ModuleNotFoundError):
     pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
 
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
 # ---- helpers shared across all tests ----
 
 RNG = np.random.RandomState(42)
@@ -1918,6 +1921,62 @@ class TestCanaryPlugin:
     MEL_BINS, CONV_KERNEL, SUB_CH = 8, 3, 4
 
     @staticmethod
+    def _make_tp_weights(
+        *,
+        hidden: int = HIDDEN,
+        dec_layers: int = DEC_LAYERS,
+        dec_heads: int = HEADS,
+        ffn: int = FFN,
+    ) -> WeightDict:
+        rng = np.random.RandomState(123)
+
+        def rand(*shape: int) -> np.ndarray:
+            return rng.randn(*shape).astype(np.float32)
+
+        weights = WeightDict({
+            "_dec_layers": dec_layers,
+            "_dec_heads": dec_heads,
+            "_dec_ffn": ffn,
+            "_enc_seq": 16,
+            "dec_emb": rand(TestCanaryPlugin.VOCAB, hidden),
+            "dec_pos": rand(128, hidden),
+            "emb_ln": rand(hidden),
+            "emb_ln_b": rand(hidden),
+            "final_norm": rand(hidden),
+            "final_norm_b": rand(hidden),
+            "w_out": rand(hidden, TestCanaryPlugin.VOCAB),
+            "out_bias": rand(TestCanaryPlugin.VOCAB),
+        })
+        for i in range(dec_layers):
+            pfx = f"layer.{i}"
+            for key in ("w_q", "w_k", "w_v", "xw_q", "xw_k", "xw_v"):
+                weights[f"{pfx}.{key}"] = rand(hidden, hidden)
+            for key in ("q_bias", "k_bias", "v_bias", "xb_q", "xb_k", "xb_v"):
+                weights[f"{pfx}.{key}"] = rand(hidden)
+            for key in ("w_o", "xw_o"):
+                weights[f"{pfx}.{key}"] = rand(hidden, hidden)
+            weights[f"{pfx}.o_bias"] = rand(hidden)
+            weights[f"{pfx}.xb_o"] = rand(hidden)
+            weights[f"{pfx}.w_fc1"] = rand(hidden, ffn)
+            weights[f"{pfx}.fc1_bias"] = rand(ffn)
+            weights[f"{pfx}.w_fc2"] = rand(ffn, hidden)
+            weights[f"{pfx}.fc2_bias"] = rand(hidden)
+            for key in (
+                "input_norm", "input_norm_b",
+                "xattn_norm", "xattn_norm_b",
+                "ffn_norm", "ffn_norm_b",
+            ):
+                weights[f"{pfx}.{key}"] = rand(hidden)
+        return weights
+
+    @staticmethod
+    def _tp_builder_module():
+        return pytest.importorskip(
+            "tensorrt_model_connect.families.canary.decoder_tp_builder",
+            reason="TensorRT is required for Canary TP builder tests",
+        )
+
+    @staticmethod
     def _make_nemo_state_dict(vocab, hidden, enc_layers, dec_layers,
                               heads, head_dim, ffn, mel_bins, conv_kernel,
                               sub_ch):
@@ -2105,3 +2164,165 @@ class TestCanaryPlugin:
         assert weights["_dec_layers"] == self.DEC_LAYERS
         assert weights["_hidden"] == self.HIDDEN
         assert weights["_vocab"] == self.VOCAB
+
+    def test_tp_build_rejects_single_device_mode(self):
+        decoder_tp_builder = self._tp_builder_module()
+
+        with pytest.raises(ValueError, match="requires tensor_parallel mode"):
+            decoder_tp_builder.build_canary_tp_decoder_engine(
+                object(),
+                WeightDict(),
+                max_cache_length=4,
+                parallel_config=ParallelConfig(),
+            )
+
+    def test_tp_validation_ignores_single_device_mode(self):
+        decoder_tp_builder = self._tp_builder_module()
+
+        decoder_tp_builder._validate_canary_tp(
+            WeightDict(),
+            hidden=self.HIDDEN,
+            num_heads=self.HEADS,
+            ffn_dim=self.FFN,
+            parallel=ParallelConfig(),
+        )
+
+    @pytest.mark.parametrize(
+        ("parallel", "overrides", "message"),
+        [
+            (
+                ParallelConfig(mode="tensor_parallel", tp_size=2, rank=-1),
+                {},
+                "concrete rank",
+            ),
+            (
+                ParallelConfig(mode="tensor_parallel", tp_size=2, rank=0),
+                {"hidden": HIDDEN + 1},
+                "hidden size divisible",
+            ),
+            (
+                ParallelConfig(mode="tensor_parallel", tp_size=2, rank=0),
+                {"num_heads": HEADS + 1},
+                "decoder_attention_heads divisible",
+            ),
+            (
+                ParallelConfig(mode="tensor_parallel", tp_size=2, rank=0),
+                {"ffn_dim": FFN + 1},
+                "decoder_ffn_dim divisible",
+            ),
+        ],
+    )
+    def test_tp_validation_rejects_bad_config_dimensions(
+        self,
+        parallel,
+        overrides,
+        message,
+    ):
+        decoder_tp_builder = self._tp_builder_module()
+        kwargs = {
+            "hidden": self.HIDDEN,
+            "num_heads": self.HEADS,
+            "ffn_dim": self.FFN,
+        }
+        kwargs.update(overrides)
+
+        with pytest.raises(ValueError, match=message):
+            decoder_tp_builder._validate_canary_tp(
+                self._make_tp_weights(),
+                parallel=parallel,
+                **kwargs,
+            )
+
+    @pytest.mark.parametrize(
+        ("key", "shape", "message"),
+        [
+            ("layer.0.w_q", (HIDDEN, HIDDEN - 1), "output dim"),
+            ("layer.0.w_o", (HIDDEN - 1, HIDDEN), "input dim"),
+            ("layer.0.w_fc1", (HIDDEN, FFN - 1), "w_fc1 output dim"),
+        ],
+    )
+    def test_tp_validation_rejects_unshardable_weight_shapes(
+        self,
+        key,
+        shape,
+        message,
+    ):
+        decoder_tp_builder = self._tp_builder_module()
+        weights = self._make_tp_weights()
+        weights[key] = np.zeros(shape, dtype=np.float32)
+
+        with pytest.raises(ValueError, match=message):
+            decoder_tp_builder._validate_canary_tp(
+                weights,
+                hidden=self.HIDDEN,
+                num_heads=self.HEADS,
+                ffn_dim=self.FFN,
+                parallel=ParallelConfig(
+                    mode="tensor_parallel",
+                    tp_size=2,
+                    rank=0,
+                ),
+            )
+
+    def test_tp_sharding_returns_original_for_single_device_mode(self):
+        decoder_tp_builder = self._tp_builder_module()
+        weights = self._make_tp_weights()
+        assert decoder_tp_builder.shard_canary_decoder_weights(
+            weights,
+            parallel=ParallelConfig(),
+        ) is weights
+
+    def test_tp_shards_rank_local_decoder_weights(self):
+        decoder_tp_builder = self._tp_builder_module()
+        weights = self._make_tp_weights()
+        shard = decoder_tp_builder.shard_canary_decoder_weights(
+            weights,
+            parallel=ParallelConfig(
+                mode="tensor_parallel",
+                tp_size=2,
+                rank=1,
+            ),
+        )
+
+        assert isinstance(shard, WeightDict)
+        assert shard["_tensor_parallel_size"] == 2
+        assert shard["_tensor_parallel_rank"] == 1
+        assert shard["_dec_layers"] == self.DEC_LAYERS
+
+        np.testing.assert_array_equal(
+            shard["layer.0.w_q"],
+            weights["layer.0.w_q"][:, self.HIDDEN // 2:],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.xw_v"],
+            weights["layer.0.xw_v"][:, self.HIDDEN // 2:],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.q_bias"],
+            weights["layer.0.q_bias"][self.HIDDEN // 2:],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.xb_k"],
+            weights["layer.0.xb_k"][self.HIDDEN // 2:],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.w_o"],
+            weights["layer.0.w_o"][self.HIDDEN // 2:, :],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.xw_o"],
+            weights["layer.0.xw_o"][self.HIDDEN // 2:, :],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.w_fc1"],
+            weights["layer.0.w_fc1"][:, self.FFN // 2:],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.fc1_bias"],
+            weights["layer.0.fc1_bias"][self.FFN // 2:],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.w_fc2"],
+            weights["layer.0.w_fc2"][self.FFN // 2:, :],
+        )
+        assert shard["final_norm"] is weights["final_norm"]

--- a/tests/e2e/models/canary-1b-v2-tp4.json
+++ b/tests/e2e/models/canary-1b-v2-tp4.json
@@ -1,0 +1,61 @@
+{
+  "name": "canary-1b-v2-tp4",
+  "trace_id": "IT-E2E-CANRY-TP4-01",
+  "hf_id": "nvidia/canary-1b-v2",
+  "bundle": "canary-1b-v2-tp4.trtfb",
+  "family": "canary",
+  "runtime_strategy": "speech_to_text",
+  "test_type": "transcription",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 50,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/Recording.wav",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "threshold_overrides": {
+    "wer": 0.3,
+    "cer": 0.2
+  }
+}

--- a/tests/e2e_harness/runners/audio_speech.py
+++ b/tests/e2e_harness/runners/audio_speech.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shutil
 import struct
 import subprocess
@@ -65,6 +66,30 @@ def _resolve_bundle_path(case: E2ECase, ctx: RunContext) -> str:
     if os.path.isabs(bundle_name):
         return bundle_name
     return os.path.join(ctx.engine_dir, bundle_name)
+
+
+def _distributed_runtime_config(case: E2ECase) -> dict:
+    config = case.metadata.get("distributed_runtime", {})
+    return config if isinstance(config, dict) and config.get("enabled") else {}
+
+
+def _wrap_distributed_command(cmd: list[str], case: E2ECase) -> list[str]:
+    config = _distributed_runtime_config(case)
+    if not config:
+        return cmd
+    launcher = str(config.get("launcher", "mpirun") or "mpirun")
+    world_size = int(config.get("world_size", config.get("tp_size", 2)) or 2)
+    launcher_args = config.get("launcher_args")
+    if isinstance(launcher_args, list):
+        return [launcher] + [str(arg) for arg in launcher_args] + cmd
+    return [launcher, "--tag-output", "-np", str(world_size)] + cmd
+
+
+def _strip_mpirun_tags(text: str) -> str:
+    lines = []
+    for line in text.splitlines():
+        lines.append(re.sub(r"^\[[^\]]+\]<std(?:out|err)>:\s?", "", line))
+    return "\n".join(lines)
 
 
 def _read_wav_rms(path: str) -> float:
@@ -157,6 +182,7 @@ class SpeechToTextRunner:
             cmd.extend(["--hf-python", runtime_cli_python])
 
         env = {**os.environ, "LD_LIBRARY_PATH": ld_path}
+        cmd = _wrap_distributed_command(cmd, case)
 
         t0 = time.monotonic()
         result = subprocess.run(
@@ -165,12 +191,16 @@ class SpeechToTextRunner:
 
         # Parse output: expect transcript text on stdout.
         # Strip special tokens like <|notimestamp|>, <|endoftext|>, etc.
-        import re
-        transcript = re.sub(r'<\|[^|]+\|>', '', result.stdout).strip()
+        clean_stdout = _strip_mpirun_tags(result.stdout)
+        transcript_lines = [
+            re.sub(r'<\|[^|]+\|>', '', line).strip()
+            for line in clean_stdout.splitlines()
+        ]
+        transcript = next((line for line in transcript_lines if line), "")
 
         # Try to extract token IDs if the binary outputs them
         token_ids = []
-        for line in result.stderr.splitlines():
+        for line in _strip_mpirun_tags(result.stderr).splitlines():
             if line.startswith("tokens:"):
                 try:
                     token_ids = [int(t) for t in line.split(":", 1)[1].strip().split()]
@@ -257,6 +287,7 @@ class TextToAudioRunner:
             runtime_tokens = runtime_config_set_tokens(case)
             for token in runtime_tokens:
                 cmd.extend(["--set", token])
+            cmd = _wrap_distributed_command(cmd, case)
             # Keep Bark TRT sampling reproducible in CI unless explicitly overridden.
             bark_seed = runtime_config_get(case, "audio_bark.seed")
             if case.family == "bark" and bark_seed is None:


### PR DESCRIPTION
## Background
Canary ASR bundles only had a single-device decoder path. This adds TensorRT 11 tensor-parallel decoder support so Canary can build rank-local decoder engines and run them through the existing ASR runtime path.

## Exit Criteria
- Build Canary TP4 bundles with rank-local decoder engines.
- Run Canary TP4 inference through `mpirun`.
- Keep the existing single-device Canary build path unchanged.
- Add a multi-device E2E manifest for Canary TP4.

## Implementation
- Added a Canary decoder TP builder that shards self-attention, cross-attention, and FFN decoder weights across TP ranks, then uses all-reduce joins for row-parallel outputs.
- Updated the Canary family plugin to accept `parallel_config`, require TensorRT 11 for TP builds, and reject unsupported quantization/debug-layer modes in the TP path.
- Updated the shared ASR runtime loader to select `engine_plan_tp_rankN` sections and initialize the distributed communicator for TP bundles.
- Updated the audio E2E runner to launch distributed ASR cases with `mpirun --tag-output` and strip rank tags before transcript parsing.
- Added `canary-1b-v2-tp4.json` with TP4 build args, distributed runtime metadata, and GPU/mpirun preflight checks.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile tensorrt_model_connect/tensorrt_model_connect/families/canary/decoder_tp_builder.py tensorrt_model_connect/tensorrt_model_connect/families/canary/plugin.py tests/e2e_harness/runners/audio_speech.py`: passed.
- `git diff --check`: passed.
- B200 TRT11 container: `PYTHONPATH=/tmp/trtmc-canary-pr/tensorrt_model_connect PYTHONDONTWRITEBYTECODE=1 HF_HOME=/tmp/trtmc-hf-cache TRANSFORMERS_CACHE=/tmp/trtmc-hf-cache/hub /opt/venv/bin/python -m pytest tests/test_e2e.py::test_e2e[canary-1b-v2-tp4] --multi-device-only --rebuild-engines --engine-dir /tmp/trtmc-engines-canary-tp --trtmc-binary /workspace/tensorrt-model-connect/build-b200-trt11-local/trtmc --hf-python /opt/venv/bin/python --e2e-artifacts-dir /tmp/trtmc-artifacts-canary-tp -p no:cacheprovider -s -q`: build and TP4 TRT inference passed, then the harness failed in the reference stage because this container does not have `nemo` installed and Transformers cannot load `nvidia/canary-1b-v2` as a fallback.
- Canary TP4 standard-audio transcript: `Hello there, how is the weather today?`, matching the known test audio text.
- B200 TRT11 container: built a single-device `canary-1b-v2.trtfb` and ran the same math-domain audio through single-device and TP4 bundles. Both produced `The square root of 49 is 7, and 3 times 8 equals 10.`, so the ad hoc math-audio miss is existing Canary/audio behavior rather than a TP divergence.

## Notes For Future Readers
- Review the shared ASR runtime and E2E runner changes first; they overlap with the Whisper TP PR because Canary uses the same speech-to-text runtime loader.
- Full WER/CER comparison for Canary requires a Python environment with NeMo installed. In this B200 container the formal E2E comparator could not run the Canary reference backend, so the TP validation here covers build, distributed runtime execution, known-audio transcript, and TP-vs-single output parity.
