### PR TITLE
feat(bark): add tensor parallel decoders

### DIFF
--- a/src/runtime/models/bark/plugin.cpp
+++ b/src/runtime/models/bark/plugin.cpp
@@ -54,10 +54,8 @@ int32_t decoder_cache_row_width(const TrtModule& module, int32_t fallback) {
     return from_engine > 0 ? from_engine : fallback;
 }
 
-std::unique_ptr<KvCache> make_bark_coarse_kv_cache(const std::string& json,
-                                                   const BaseConfig& base,
-                                                   const TrtModule& module,
-                                                   cudaStream_t stream,
+std::unique_ptr<KvCache> make_bark_coarse_kv_cache(const std::string& json, const BaseConfig& base,
+                                                   const TrtModule& module, cudaStream_t stream,
                                                    DType cache_dtype) {
     int32_t hidden = extract_json_int(json, "coarse_hidden_size", base.hidden_size);
     int32_t layers = extract_json_int(json, "coarse_num_layers", base.num_layers);
@@ -66,6 +64,63 @@ std::unique_ptr<KvCache> make_bark_coarse_kv_cache(const std::string& json,
     int32_t max_cache = extract_json_int(json, "coarse_max_cache_length", base.max_cache_length);
     const int32_t row_width = decoder_cache_row_width(module, heads * hd);
     return std::make_unique<KvCache>(layers, max_cache, row_width, stream, cache_dtype);
+}
+
+BarkConfig make_bark_config(const PipelineContext& ctx) {
+    const auto& json = ctx.config_json;
+    BarkConfig bark_cfg;
+    bark_cfg.sample_rate = extract_json_int(json, "sample_rate", 24000);
+    bark_cfg.hidden_size = ctx.config.hidden_size;
+    bark_cfg.semantic_input_vocab = extract_json_int(json, "semantic_input_vocab", 129600);
+    bark_cfg.semantic_output_vocab = ctx.config.vocab_size;
+    bark_cfg.text_encoding_offset = extract_json_int(json, "text_encoding_offset", 10048);
+    bark_cfg.text_pad_token = extract_json_int(json, "text_pad_token", 129595);
+    bark_cfg.semantic_pad_token = extract_json_int(json, "semantic_pad_token", 10000);
+    bark_cfg.semantic_infer_token = extract_json_int(json, "semantic_infer_token", 129599);
+    bark_cfg.semantic_vocab_size = extract_json_int(json, "semantic_vocab_size", 10000);
+    bark_cfg.coarse_input_vocab = extract_json_int(json, "coarse_input_vocab", 12096);
+    bark_cfg.coarse_semantic_pad_token = extract_json_int(json, "coarse_semantic_pad_token", 12048);
+    bark_cfg.coarse_infer_token = extract_json_int(json, "coarse_infer_token", 12050);
+    bark_cfg.n_coarse_codebooks = extract_json_int(json, "n_coarse_codebooks", 2);
+    bark_cfg.codebook_size = extract_json_int(json, "codebook_size", 1024);
+    bark_cfg.codec_seq_length = extract_json_int(json, "codec_seq_length", 0);
+    bark_cfg.codec_upsample_factor = extract_json_int(json, "codec_upsample_factor", 320);
+    bark_cfg.codec_n_codebooks = extract_json_int(json, "codec_n_codebooks", 8);
+    bark_cfg.fine_hidden_size = extract_json_int(json, "fine_hidden_size", ctx.config.hidden_size);
+    bark_cfg.fine_n_lm_heads = extract_json_int(json, "fine_n_lm_heads", 7);
+    bark_cfg.fine_codebook_size = extract_json_int(json, "fine_codebook_size", 1056);
+    bark_cfg.fine_seq_length = extract_json_int(json, "fine_seq_length", 0);
+
+    // audio_bark.* namespace (replaces TRTMC_BARK_{DUMP,GREEDY,SEED}).
+    if (ctx.runtime_config != nullptr) {
+        try {
+            bark_cfg.dump_path = ctx.runtime_config->get<std::string>("audio_bark", "dump_path");
+            bark_cfg.greedy = ctx.runtime_config->get<bool>("audio_bark", "greedy");
+            bark_cfg.seed = ctx.runtime_config->get<std::int64_t>("audio_bark", "seed");
+        } catch (const std::exception&) {
+            // Schema not registered or type mismatch: stay at defaults.
+        }
+    }
+
+    return bark_cfg;
+}
+
+void attach_optional_bark_modules(BarkPipeline& pipeline, const PipelineContext& ctx,
+                                  const ModuleCreateOptions& opts) {
+    auto codec_loaded = try_load_trt_module_from_plan(
+        ctx.backend, find_section(ctx.bundle, "codec_engine_plan"), "bark codec", opts);
+    if (codec_loaded.module && codec_loaded.module->ok())
+        pipeline.set_codec_module(std::move(codec_loaded.module));
+
+    auto fine_loaded = try_load_trt_module_from_plan(
+        ctx.backend, find_section(ctx.bundle, "fine_engine_plan"), "bark fine", opts);
+    if (fine_loaded.module && fine_loaded.module->ok()) {
+        pipeline.set_fine_module(std::move(fine_loaded.module));
+        auto fe = section_to_floats(find_section(ctx.bundle, "fine_embed"));
+        auto fp = section_to_floats(find_section(ctx.bundle, "fine_position_embed"));
+        if (!fe.empty())
+            pipeline.set_fine_embeddings(std::move(fe), std::move(fp));
+    }
 }
 
 } // namespace
@@ -103,54 +158,18 @@ class BarkPlugin final : public IPipelinePlugin {
             ctx.backend, find_section(ctx.bundle, coarse_section), "bark coarse", decoder_opts);
 
         cudaStream_t stream = sem_loaded.module->stream();
-
-        // Build BarkConfig
-        BarkConfig bark_cfg;
-        bark_cfg.sample_rate = extract_json_int(json, "sample_rate", 24000);
-        bark_cfg.hidden_size = ctx.config.hidden_size;
-        bark_cfg.semantic_input_vocab = extract_json_int(json, "semantic_input_vocab", 129600);
-        bark_cfg.semantic_output_vocab = ctx.config.vocab_size;
-        bark_cfg.text_encoding_offset = extract_json_int(json, "text_encoding_offset", 10048);
-        bark_cfg.text_pad_token = extract_json_int(json, "text_pad_token", 129595);
-        bark_cfg.semantic_pad_token = extract_json_int(json, "semantic_pad_token", 10000);
-        bark_cfg.semantic_infer_token = extract_json_int(json, "semantic_infer_token", 129599);
-        bark_cfg.semantic_vocab_size = extract_json_int(json, "semantic_vocab_size", 10000);
-        bark_cfg.coarse_input_vocab = extract_json_int(json, "coarse_input_vocab", 12096);
-        bark_cfg.coarse_semantic_pad_token =
-            extract_json_int(json, "coarse_semantic_pad_token", 12048);
-        bark_cfg.coarse_infer_token = extract_json_int(json, "coarse_infer_token", 12050);
-        bark_cfg.n_coarse_codebooks = extract_json_int(json, "n_coarse_codebooks", 2);
-        bark_cfg.codebook_size = extract_json_int(json, "codebook_size", 1024);
-        bark_cfg.codec_seq_length = extract_json_int(json, "codec_seq_length", 0);
-        bark_cfg.codec_upsample_factor = extract_json_int(json, "codec_upsample_factor", 320);
-        bark_cfg.codec_n_codebooks = extract_json_int(json, "codec_n_codebooks", 8);
-        bark_cfg.fine_hidden_size =
-            extract_json_int(json, "fine_hidden_size", ctx.config.hidden_size);
-        bark_cfg.fine_n_lm_heads = extract_json_int(json, "fine_n_lm_heads", 7);
-        bark_cfg.fine_codebook_size = extract_json_int(json, "fine_codebook_size", 1056);
-        bark_cfg.fine_seq_length = extract_json_int(json, "fine_seq_length", 0);
-
-        // audio_bark.* namespace (replaces TRTMC_BARK_{DUMP,GREEDY,SEED}).
-        if (ctx.runtime_config != nullptr) {
-            try {
-                bark_cfg.dump_path =
-                    ctx.runtime_config->get<std::string>("audio_bark", "dump_path");
-                bark_cfg.greedy = ctx.runtime_config->get<bool>("audio_bark", "greedy");
-                bark_cfg.seed = ctx.runtime_config->get<std::int64_t>("audio_bark", "seed");
-            } catch (const std::exception&) {
-                // Schema not registered or type mismatch — stay at defaults.
-            }
-        }
+        BarkConfig bark_cfg = make_bark_config(ctx);
 
         // Create KvCaches for semantic and coarse stages
-        int32_t sem_kv_dim = decoder_cache_row_width(*sem_loaded.module, compute_kv_dim(ctx.config));
+        int32_t sem_kv_dim =
+            decoder_cache_row_width(*sem_loaded.module, compute_kv_dim(ctx.config));
         DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
         std::unique_ptr<IInferenceState> sem_state = std::make_unique<KvCache>(
             ctx.config.num_layers, ctx.config.max_cache_length, sem_kv_dim, stream, cache_dtype);
 
         // Coarse engine may have different dimensions -- resolve with semantic fallbacks
-        std::unique_ptr<IInferenceState> coarse_state(
-            make_bark_coarse_kv_cache(json, ctx.config, *coarse_loaded.module, stream, cache_dtype));
+        std::unique_ptr<IInferenceState> coarse_state(make_bark_coarse_kv_cache(
+            json, ctx.config, *coarse_loaded.module, stream, cache_dtype));
 
         // Load embeddings
         auto sem_embed = section_to_floats(find_section(ctx.bundle, "semantic_embed"));
@@ -166,22 +185,7 @@ class BarkPlugin final : public IPipelinePlugin {
             std::move(coarse_state), std::move(sem_embed), std::move(coarse_embed),
             std::move(bark_cfg), stream, std::move(bark_tokenizer), ctx.bundle.info.model_id);
 
-        // Optional codec engine
-        auto codec_loaded = try_load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "codec_engine_plan"), "bark codec", opts);
-        if (codec_loaded.module && codec_loaded.module->ok())
-            pipeline->set_codec_module(std::move(codec_loaded.module));
-
-        // Optional fine engine
-        auto fine_loaded = try_load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "fine_engine_plan"), "bark fine", opts);
-        if (fine_loaded.module && fine_loaded.module->ok()) {
-            pipeline->set_fine_module(std::move(fine_loaded.module));
-            auto fe = section_to_floats(find_section(ctx.bundle, "fine_embed"));
-            auto fp = section_to_floats(find_section(ctx.bundle, "fine_position_embed"));
-            if (!fe.empty())
-                pipeline->set_fine_embeddings(std::move(fe), std::move(fp));
-        }
+        attach_optional_bark_modules(*pipeline, ctx, opts);
 
         return pipeline;
     }

--- a/src/runtime/models/bark/plugin.cpp
+++ b/src/runtime/models/bark/plugin.cpp
@@ -5,14 +5,70 @@
 #include "runtime/plugins/shared/audio_helpers.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
 #include "trtmc/config/config_bundle.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
 
 #include <cstdint>
 #include <exception>
+#include <limits>
 #include <string>
+#include <vector>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+std::string coarse_tp_engine_section_name(int32_t rank) {
+    return "coarse_engine_plan_tp_rank" + std::to_string(rank);
+}
+
+int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
+    if (dim < 0 || static_cast<std::size_t>(dim) >= shape.size())
+        return -1;
+    const auto value = shape[static_cast<std::size_t>(dim)];
+    if (value <= 0 || value > std::numeric_limits<int32_t>::max())
+        return -1;
+    return static_cast<int32_t>(value);
+}
+
+int32_t decoder_cache_row_width(const TrtModule& module, int32_t fallback) {
+    const int32_t from_engine = dim_at(module.tensor_shape("cache_k_0"), 1);
+    return from_engine > 0 ? from_engine : fallback;
+}
+
+std::unique_ptr<KvCache> make_bark_coarse_kv_cache(const std::string& json,
+                                                   const BaseConfig& base,
+                                                   const TrtModule& module,
+                                                   cudaStream_t stream,
+                                                   DType cache_dtype) {
+    int32_t hidden = extract_json_int(json, "coarse_hidden_size", base.hidden_size);
+    int32_t layers = extract_json_int(json, "coarse_num_layers", base.num_layers);
+    int32_t heads = extract_json_int(json, "coarse_num_heads", base.num_heads);
+    int32_t hd = (heads > 0) ? hidden / heads : 128;
+    int32_t max_cache = extract_json_int(json, "coarse_max_cache_length", base.max_cache_length);
+    const int32_t row_width = decoder_cache_row_width(module, heads * hd);
+    return std::make_unique<KvCache>(layers, max_cache, row_width, stream, cache_dtype);
+}
+
+} // namespace
 
 class BarkPlugin final : public IPipelinePlugin {
   public:
@@ -24,14 +80,27 @@ class BarkPlugin final : public IPipelinePlugin {
         opts.cuda_graphs = ctx.cuda_graphs;
 
         const auto& json = ctx.config_json;
+        const auto tp_config = parse_tensor_parallel_runtime_config(json);
+        DistributedRuntimeGroup tp_group;
+        ModuleCreateOptions decoder_opts = opts;
+        if (tp_config.enabled) {
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+            decoder_opts.distributed_communicator = tp_group.communicator;
+            decoder_opts.distributed_owner = tp_group.owner;
+        }
 
-        // Load semantic engine (main plan)
+        // Load semantic engine (main plan or rank-local TP section)
+        const std::string semantic_section =
+            tp_config.enabled ? tp_engine_section_name(tp_group.rank) : std::string("engine_plan");
         auto sem_loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "bark semantic", opts);
+            ctx.backend, find_section(ctx.bundle, semantic_section), "bark semantic", decoder_opts);
 
-        // Load coarse engine
+        // Load coarse engine (single plan or rank-local TP section)
+        const std::string coarse_section = tp_config.enabled
+                                               ? coarse_tp_engine_section_name(tp_group.rank)
+                                               : std::string("coarse_engine_plan");
         auto coarse_loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "coarse_engine_plan"), "bark coarse", opts);
+            ctx.backend, find_section(ctx.bundle, coarse_section), "bark coarse", decoder_opts);
 
         cudaStream_t stream = sem_loaded.module->stream();
 
@@ -74,14 +143,14 @@ class BarkPlugin final : public IPipelinePlugin {
         }
 
         // Create KvCaches for semantic and coarse stages
-        int32_t sem_kv_dim = compute_kv_dim(ctx.config);
+        int32_t sem_kv_dim = decoder_cache_row_width(*sem_loaded.module, compute_kv_dim(ctx.config));
         DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
         std::unique_ptr<IInferenceState> sem_state = std::make_unique<KvCache>(
             ctx.config.num_layers, ctx.config.max_cache_length, sem_kv_dim, stream, cache_dtype);
 
         // Coarse engine may have different dimensions -- resolve with semantic fallbacks
         std::unique_ptr<IInferenceState> coarse_state(
-            make_coarse_kv_cache(json, ctx.config, stream, cache_dtype));
+            make_bark_coarse_kv_cache(json, ctx.config, *coarse_loaded.module, stream, cache_dtype));
 
         // Load embeddings
         auto sem_embed = section_to_floats(find_section(ctx.bundle, "semantic_embed"));

--- a/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
@@ -1007,6 +1007,8 @@ def build_bundle(
                 build_extra_kwargs["precision"] = precision
             if _call_supports_kwarg(build_extra, "build_timing"):
                 build_extra_kwargs["build_timing"] = build_timing
+            if _call_supports_kwarg(build_extra, "parallel_config"):
+                build_extra_kwargs["parallel_config"] = parallel
             extra_engines = build_extra(
                 config, weights, max_cache_length, **build_extra_kwargs) or {}
         finally:

--- a/tensorrt_model_connect/tensorrt_model_connect/families/bark/decoder_tp_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/bark/decoder_tp_builder.py
@@ -1,0 +1,419 @@
+"""Tensor-parallel Bark semantic/coarse decoder builder.
+
+This mirrors Bark's single-device ``standard_decoder_builder`` for the
+autoregressive semantic and coarse GPT blocks. Tensor parallelism only changes
+the decoder projections: Q/K/V and FC1 are column-parallel, output/FC2 are
+row-parallel and joined with a TensorRT distributed all-reduce.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...checkpoint_mapper import WeightDict
+from ...config import ModelConfig
+from ...parallel_config import (
+    add_all_reduce_sum,
+    normalize_parallel_config,
+)
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_first_dim(value: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    if value.shape[0] % tp_size != 0:
+        raise ValueError(f"Cannot shard first dimension {value.shape[0]} over TP{tp_size}")
+    chunk = value.shape[0] // tp_size
+    return np.ascontiguousarray(value[rank * chunk:(rank + 1) * chunk])
+
+
+def _slice_last_dim(value: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    if value.shape[-1] % tp_size != 0:
+        raise ValueError(f"Cannot shard last dimension {value.shape[-1]} over TP{tp_size}")
+    chunk = value.shape[-1] // tp_size
+    slc = [slice(None)] * value.ndim
+    slc[-1] = slice(rank * chunk, (rank + 1) * chunk)
+    return np.ascontiguousarray(value[tuple(slc)])
+
+
+def _validate_bark_tp(
+    *,
+    sub_model: str,
+    hidden: int,
+    num_heads: int,
+    mlp_size: int,
+    parallel: "ParallelConfig",
+) -> None:
+    if not parallel.enabled:
+        raise ValueError("Bark tensor-parallel builder requires an enabled parallel config")
+    if hidden % parallel.tp_size != 0:
+        raise ValueError(
+            f"{sub_model} hidden_size={hidden} must be divisible by TP{parallel.tp_size}")
+    if num_heads % parallel.tp_size != 0:
+        raise ValueError(
+            f"{sub_model} num_heads={num_heads} must be divisible by TP{parallel.tp_size}")
+    if mlp_size % parallel.tp_size != 0:
+        raise ValueError(
+            f"{sub_model} mlp_size={mlp_size} must be divisible by TP{parallel.tp_size}")
+
+
+def shard_bark_decoder_weights(
+    weights: WeightDict,
+    *,
+    sub_model: str,
+    sub_cfg: dict,
+    parallel_config=None,
+) -> WeightDict:
+    """Return rank-local weights for a Bark semantic/coarse decoder."""
+    parallel = normalize_parallel_config(parallel_config)
+    hidden = int(sub_cfg["hidden_size"])
+    num_heads = int(sub_cfg["num_heads"])
+    num_layers = int(sub_cfg["num_layers"])
+    mlp_size = int(sub_cfg.get("intermediate_size", hidden * 4))
+    _validate_bark_tp(
+        sub_model=sub_model,
+        hidden=hidden,
+        num_heads=num_heads,
+        mlp_size=mlp_size,
+        parallel=parallel,
+    )
+
+    sharded = WeightDict()
+    for key, value in weights.items():
+        if key.startswith("_"):
+            continue
+        if not isinstance(value, np.ndarray):
+            sharded[key] = value
+            continue
+
+        if key in {"embedding", "position_embedding", "final_norm", "final_norm_beta", "w_out"}:
+            sharded[key] = value
+            continue
+
+        handled = False
+        for layer_idx in range(num_layers):
+            lp = f"layer.{layer_idx}"
+            if key in {f"{lp}.w_q", f"{lp}.w_k", f"{lp}.w_v", f"{lp}.w_fc1"}:
+                sharded[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+                handled = True
+                break
+            if key in {f"{lp}.q_bias", f"{lp}.k_bias", f"{lp}.v_bias", f"{lp}.fc1_bias"}:
+                sharded[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+                handled = True
+                break
+            if key in {f"{lp}.w_o", f"{lp}.w_fc2"}:
+                sharded[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+                handled = True
+                break
+            if key in {
+                f"{lp}.input_norm",
+                f"{lp}.input_norm_beta",
+                f"{lp}.post_attn_norm",
+                f"{lp}.post_attn_norm_beta",
+                f"{lp}.o_bias",
+                f"{lp}.fc2_bias",
+            }:
+                sharded[key] = value
+                handled = True
+                break
+        if not handled:
+            sharded[key] = value
+
+    return sharded
+
+
+def _row_parallel_linear(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    in_width: int,
+    out_width: int,
+    weight: np.ndarray,
+    *,
+    tp_size: int,
+    bias: np.ndarray | None = None,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    out = graph_ops.add_matmul_rhs_constant(
+        network, inp, in_width, out_width, weight, dtype=dtype)
+    out = add_all_reduce_sum(network, out, tp_size)
+    if bias is not None:
+        out = graph_ops.add_bias_sum(network, out, out_width, bias, dtype=dtype)
+    return out
+
+
+def _add_bark_tp_decoder_layer(
+    network: trt.INetworkDefinition,
+    hidden_state: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    attention_mask: trt.ITensor,
+    *,
+    layer_idx: int,
+    weights: WeightDict,
+    hidden: int,
+    local_attention_size: int,
+    local_heads: int,
+    head_dim: int,
+    local_mlp_size: int,
+    attention_window: int,
+    eps_tensor: trt.ITensor,
+    tp_size: int,
+    dtype: np.dtype = np.float32,
+) -> tuple[trt.ITensor, trt.ITensor, trt.ITensor]:
+    lp = f"layer.{layer_idx}"
+
+    normed = graph_ops.add_layer_norm(
+        network,
+        hidden_state,
+        hidden,
+        weights[f"{lp}.input_norm"],
+        weights[f"{lp}.input_norm_beta"],
+        eps_tensor,
+        dtype=dtype,
+    )
+
+    q = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden, local_attention_size, weights[f"{lp}.w_q"], dtype=dtype)
+    k = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden, local_attention_size, weights[f"{lp}.w_k"], dtype=dtype)
+    v = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden, local_attention_size, weights[f"{lp}.w_v"], dtype=dtype)
+    for name, width in (("q", local_attention_size), ("k", local_attention_size),
+                        ("v", local_attention_size)):
+        bias = weights.get(f"{lp}.{name}_bias")
+        if bias is None:
+            continue
+        tensor = {"q": q, "k": k, "v": v}[name]
+        tensor = graph_ops.add_bias_sum(network, tensor, width, bias, dtype=dtype)
+        if name == "q":
+            q = tensor
+        elif name == "k":
+            k = tensor
+        else:
+            v = tensor
+
+    present_k = k
+    present_v = v
+
+    k_row = network.add_shuffle(k)
+    k_row.reshape_dims = (1, local_attention_size)
+    v_row = network.add_shuffle(v)
+    v_row.reshape_dims = (1, local_attention_size)
+
+    all_k = network.add_concatenation([cache_k, k_row.get_output(0)])
+    all_k.axis = 0
+    all_v = network.add_concatenation([cache_v, v_row.get_output(0)])
+    all_v.axis = 0
+
+    mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask)
+    ctx = graph_ops.add_attention_from_rows(
+        network,
+        q,
+        all_k.get_output(0),
+        all_v.get_output(0),
+        num_heads=local_heads,
+        head_dim=head_dim,
+        q_seq=1,
+        kv_seq=attention_window,
+        mask=mask_4d,
+        scale=1.0 / np.sqrt(head_dim),
+    )
+
+    attn_out = _row_parallel_linear(
+        network,
+        ctx,
+        local_attention_size,
+        hidden,
+        weights[f"{lp}.w_o"],
+        tp_size=tp_size,
+        bias=weights.get(f"{lp}.o_bias"),
+        dtype=dtype,
+    )
+    hidden_state = network.add_elementwise(
+        hidden_state, attn_out, trt.ElementWiseOperation.SUM).get_output(0)
+
+    normed2 = graph_ops.add_layer_norm(
+        network,
+        hidden_state,
+        hidden,
+        weights[f"{lp}.post_attn_norm"],
+        weights[f"{lp}.post_attn_norm_beta"],
+        eps_tensor,
+        dtype=dtype,
+    )
+    fc1 = graph_ops.add_matmul_rhs_constant(
+        network, normed2, hidden, local_mlp_size, weights[f"{lp}.w_fc1"], dtype=dtype)
+    fc1_bias = weights.get(f"{lp}.fc1_bias")
+    if fc1_bias is not None:
+        fc1 = graph_ops.add_bias_sum(network, fc1, local_mlp_size, fc1_bias, dtype=dtype)
+    gelu = graph_ops.add_gelu_new(network, fc1, dtype=dtype)
+    fc2 = _row_parallel_linear(
+        network,
+        gelu,
+        local_mlp_size,
+        hidden,
+        weights[f"{lp}.w_fc2"],
+        tp_size=tp_size,
+        bias=weights.get(f"{lp}.fc2_bias"),
+        dtype=dtype,
+    )
+    hidden_state = network.add_elementwise(
+        hidden_state, fc2, trt.ElementWiseOperation.SUM).get_output(0)
+
+    return hidden_state, present_k, present_v
+
+
+def build_bark_tp_decoder_engine(
+    config: ModelConfig,
+    weights: WeightDict,
+    max_cache_length: int,
+    *,
+    sub_model: str,
+    sub_cfg: dict,
+    precision: str = "fp32",
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build one rank-local TP engine for a Bark semantic/coarse decoder."""
+    del precision  # Bark decoder engines currently use fp32, matching the existing path.
+    parallel = normalize_parallel_config(parallel_config)
+    hidden = int(sub_cfg["hidden_size"])
+    num_heads = int(sub_cfg["num_heads"])
+    num_layers = int(sub_cfg["num_layers"])
+    vocab = int(sub_cfg["vocab_size"])
+    output_vocab = int(sub_cfg.get("output_vocab", vocab))
+    max_position = int(sub_cfg.get("max_position", 1024))
+    mlp_size = int(sub_cfg.get("intermediate_size", hidden * 4))
+    _validate_bark_tp(
+        sub_model=sub_model,
+        hidden=hidden,
+        num_heads=num_heads,
+        mlp_size=mlp_size,
+        parallel=parallel,
+    )
+
+    local_heads = num_heads // parallel.tp_size
+    head_dim = hidden // num_heads
+    local_attention_size = local_heads * head_dim
+    local_mlp_size = mlp_size // parallel.tp_size
+    attention_window = max_cache_length + 1
+    rank_weights = shard_bark_decoder_weights(
+        weights, sub_model=sub_model, sub_cfg=sub_cfg, parallel_config=parallel)
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    position_id = network.add_input("position_id", trt.int32, (1,))
+    attention_mask = network.add_input("attention_mask", trt.float32, (1, attention_window))
+    input_embed = network.add_input("input_embed", trt.float32, (1, hidden))
+    use_input_embed = network.add_input("use_input_embed", trt.float32, (1,))
+
+    cache_k_inputs = []
+    cache_v_inputs = []
+    for i in range(num_layers):
+        ck = network.add_input(
+            graph_ops.layer_tensor_name("cache_k", i),
+            trt.float32,
+            (max_cache_length, local_attention_size),
+        )
+        cv = network.add_input(
+            graph_ops.layer_tensor_name("cache_v", i),
+            trt.float32,
+            (max_cache_length, local_attention_size),
+        )
+        cache_k_inputs.append(ck)
+        cache_v_inputs.append(cv)
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), rank_weights["embedding"])
+    position_table = graph_ops.add_constant(
+        network, (max_position, hidden), rank_weights["position_embedding"])
+    token_embed = network.add_gather(embedding_table, token_id, 0).get_output(0)
+
+    flag = network.add_shuffle(use_input_embed)
+    flag.reshape_dims = (1, 1)
+    one = graph_ops.add_constant(network, (1, 1), np.array([1.0], dtype=np.float32))
+    inv_flag = network.add_elementwise(
+        one, flag.get_output(0), trt.ElementWiseOperation.SUB).get_output(0)
+    token_part = network.add_elementwise(
+        token_embed, inv_flag, trt.ElementWiseOperation.PROD).get_output(0)
+    embed_part = network.add_elementwise(
+        input_embed, flag.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    hidden_state = network.add_elementwise(
+        token_part, embed_part, trt.ElementWiseOperation.SUM).get_output(0)
+    pos_embed = network.add_gather(position_table, position_id, 0).get_output(0)
+    hidden_state = network.add_elementwise(
+        hidden_state, pos_embed, trt.ElementWiseOperation.SUM).get_output(0)
+
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=np.float32))
+    present_k_outputs = []
+    present_v_outputs = []
+    for layer_idx in range(num_layers):
+        hidden_state, present_k, present_v = _add_bark_tp_decoder_layer(
+            network,
+            hidden_state,
+            cache_k_inputs[layer_idx],
+            cache_v_inputs[layer_idx],
+            attention_mask,
+            layer_idx=layer_idx,
+            weights=rank_weights,
+            hidden=hidden,
+            local_attention_size=local_attention_size,
+            local_heads=local_heads,
+            head_dim=head_dim,
+            local_mlp_size=local_mlp_size,
+            attention_window=attention_window,
+            eps_tensor=eps_tensor,
+            tp_size=parallel.tp_size,
+        )
+        present_k_outputs.append(present_k)
+        present_v_outputs.append(present_v)
+
+    hidden_state = graph_ops.add_layer_norm(
+        network,
+        hidden_state,
+        hidden,
+        rank_weights["final_norm"],
+        rank_weights["final_norm_beta"],
+        eps_tensor,
+    )
+
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, output_vocab, rank_weights["w_out"])
+    logits = graph_ops.add_bias_sum(
+        network, logits, output_vocab, np.zeros(output_vocab, dtype=np.float32))
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for i, (present_k, present_v) in enumerate(zip(present_k_outputs, present_v_outputs)):
+        present_k.name = graph_ops.layer_tensor_name("present_k", i)
+        present_v.name = graph_ops.layer_tensor_name("present_v", i)
+        network.mark_output(present_k)
+        network.mark_output(present_v)
+
+    if verbose:
+        print(
+            f"[trtmc build] Building Bark {sub_model} TP rank {parallel.rank}/"
+            f"{parallel.tp_size}: layers={num_layers}, hidden={hidden}, "
+            f"local_heads={local_heads}, local_attn={local_attention_size}, "
+            f"cache={max_cache_length}",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError(f"TensorRT engine build failed for Bark {sub_model} TP rank")
+    return bytes(plan)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/bark/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/bark/plugin.py
@@ -33,6 +33,11 @@ from ...config import ModelConfig
 from ...checkpoint_mapper import WeightDict
 from ...build_timing import timed_trt_compile
 from ... import graph_ops
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
+from .decoder_tp_builder import build_bark_tp_decoder_engine
 
 
 trt = trt_compat.get_trt()
@@ -453,9 +458,27 @@ class BarkPlugin:
         self, config: ModelConfig, weights: WeightDict,
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
+        parallel_config=None,
     ) -> bytes:
         """Build TRT engine for semantic decoder (primary engine)."""
         sem_cfg = weights["_semantic_cfg"]
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="Bark semantic tensor-parallel decoder builds")
+            if quant_ctx is not None:
+                raise ValueError("Bark tensor-parallel builds do not support quantization")
+            sem_weights = _extract_bark_sub_weights(weights, "semantic")
+            return build_bark_tp_decoder_engine(
+                config,
+                sem_weights,
+                max_cache_length,
+                sub_model="semantic",
+                sub_cfg=sem_cfg,
+                precision=precision,
+                verbose=verbose,
+                parallel_config=parallel,
+            )
         return _build_bark_standard_engine(
             weights, "semantic", sem_cfg, max_cache_length,
             embed_input=True, verbose=verbose)
@@ -465,19 +488,45 @@ class BarkPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         verbose: bool = False,
         build_timing: dict | None = None,
+        parallel_config=None,
     ) -> dict:
         """Build coarse, fine, codec engines + embedding tables for C++ runtime."""
         coarse_cfg = weights["_coarse_cfg"]
         fine_cfg = weights["_fine_cfg"]
+        parallel = normalize_parallel_config(parallel_config)
 
-        with timed_trt_compile(build_timing, "extra_bark_coarse_decoder"):
-            coarse_plan = _build_bark_standard_engine(
-                weights, "coarse", coarse_cfg, max_cache_length,
-                embed_input=True, verbose=verbose)
-
-        result = {
-            "coarse_engine_plan": coarse_plan,
-        }
+        result = {}
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="Bark coarse tensor-parallel decoder builds")
+            coarse_weights = _extract_bark_sub_weights(weights, "coarse")
+            with timed_trt_compile(build_timing, "extra_bark_coarse_decoder"):
+                for rank in range(parallel.tp_size):
+                    rank_parallel = parallel.for_rank(rank)
+                    if verbose:
+                        print(
+                            f"[trtmc build]   Building coarse TP rank "
+                            f"{rank}/{parallel.tp_size} ...",
+                            file=sys.stderr,
+                        )
+                    result[f"coarse_engine_plan_tp_rank{rank}"] = (
+                        build_bark_tp_decoder_engine(
+                            config,
+                            coarse_weights,
+                            max_cache_length,
+                            sub_model="coarse",
+                            sub_cfg=coarse_cfg,
+                            precision=precision,
+                            verbose=verbose,
+                            parallel_config=rank_parallel,
+                        )
+                    )
+        else:
+            with timed_trt_compile(build_timing, "extra_bark_coarse_decoder"):
+                coarse_plan = _build_bark_standard_engine(
+                    weights, "coarse", coarse_cfg, max_cache_length,
+                    embed_input=True, verbose=verbose)
+            result["coarse_engine_plan"] = coarse_plan
 
         # Add embedding tables as raw bundle sections.
         # The C++ runtime does host-side embedding lookup for embed_input mode.
@@ -606,6 +655,15 @@ class BarkPlugin:
         return cfg
 
 
+def _extract_bark_sub_weights(weights: WeightDict, sub_model: str) -> WeightDict:
+    """Extract semantic/coarse weights and strip the stored sub-model prefix."""
+    prefix = f"{sub_model}."
+    sub_weights = WeightDict()
+    for k, v in weights.items():
+        if k.startswith(prefix) and not k.startswith("_"):
+            sub_weights[k[len(prefix):]] = v
+    return sub_weights
+
 
 def _build_bark_standard_engine(
     weights: WeightDict,
@@ -619,11 +677,7 @@ def _build_bark_standard_engine(
     from .standard_decoder_builder import build_standard_decoder_engine
 
     # Extract sub-model weights (strip prefix)
-    prefix = f"{sub_model}."
-    sub_weights = WeightDict()
-    for k, v in weights.items():
-        if k.startswith(prefix) and not k.startswith("_"):
-            sub_weights[k[len(prefix):]] = v
+    sub_weights = _extract_bark_sub_weights(weights, sub_model)
 
     # Also need _attention_size and _mlp_size for the builder
     hidden = sub_cfg["hidden_size"]

--- a/tensorrt_model_connect/tensorrt_model_connect/graph_ops.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/graph_ops.py
@@ -2081,7 +2081,8 @@ def add_layer_norm_native(
         eps:         Numerical stability epsilon (scalar, not a tensor).
         dtype:       Storage dtype for gamma/beta constants before TRT cast.
     """
-    rank = len(tuple(inp.shape))
+    inp_shape = getattr(inp, "shape", None)
+    rank = len(tuple(inp_shape)) if inp_shape is not None else 2
     param_shape = (
         (hidden_size,) if rank <= 1 else (1,) * (rank - 1) + (hidden_size,)
     )

--- a/tests/builder/test_engine_bark.py
+++ b/tests/builder/test_engine_bark.py
@@ -34,16 +34,14 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-try:
-    from safetensors.numpy import save_file
-except (ImportError, ModuleNotFoundError):
-    pytest.skip("safetensors not available", allow_module_level=True)
+pytest.importorskip("safetensors.numpy", reason="safetensors not available")
+pytest.importorskip(
+    "tensorrt_model_connect.config",
+    reason="tensorrt_model_connect requires tensorrt",
+)
 
-try:
-    from tensorrt_model_connect.config import ModelConfig
-except (ImportError, ModuleNotFoundError):
-    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
-
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.parallel_config import ParallelConfig
 from tests.builder.family_plugin_tester import FamilyPluginTester, TinyModelSpec
 from tests.builder.family_plugin_test_mixin import FamilyPluginTestMixin
 
@@ -70,6 +68,55 @@ _FINE_MAX_POS = 32
 _FINE_N_EMBED_TABLES = 8
 _FINE_N_LM_HEADS = 7
 _FINE_CODEBOOK_SIZE = 16
+
+
+def _make_bark_tp_weights(
+    *,
+    hidden: int = _SEM_HIDDEN,
+    num_layers: int = _SEM_LAYERS,
+    mlp_size: int | None = None,
+) -> WeightDict:
+    rng = np.random.RandomState(123)
+    mlp_size = mlp_size or hidden * 4
+
+    def rand(*shape: int) -> np.ndarray:
+        return rng.randn(*shape).astype(np.float32)
+
+    weights = WeightDict({
+        "_attention_size": hidden,
+        "metadata": "kept",
+        "embedding": rand(_SEM_VOCAB, hidden),
+        "position_embedding": rand(_SEM_MAX_POS, hidden),
+        "final_norm": rand(hidden),
+        "final_norm_beta": rand(hidden),
+        "w_out": rand(hidden, _SEM_OUTPUT_VOCAB),
+        "extra_tensor": rand(3, 3),
+    })
+    for i in range(num_layers):
+        lp = f"layer.{i}"
+        for key in ("w_q", "w_k", "w_v"):
+            weights[f"{lp}.{key}"] = rand(hidden, hidden)
+        for key in ("q_bias", "k_bias", "v_bias"):
+            weights[f"{lp}.{key}"] = rand(hidden)
+        weights[f"{lp}.w_o"] = rand(hidden, hidden)
+        weights[f"{lp}.o_bias"] = rand(hidden)
+        weights[f"{lp}.w_fc1"] = rand(hidden, mlp_size)
+        weights[f"{lp}.fc1_bias"] = rand(mlp_size)
+        weights[f"{lp}.w_fc2"] = rand(mlp_size, hidden)
+        weights[f"{lp}.fc2_bias"] = rand(hidden)
+        for key in (
+            "input_norm", "input_norm_beta",
+            "post_attn_norm", "post_attn_norm_beta",
+        ):
+            weights[f"{lp}.{key}"] = rand(hidden)
+    return weights
+
+
+def _bark_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.bark.decoder_tp_builder",
+        reason="TensorRT is required for Bark TP builder tests",
+    )
 
 
 class BarkPluginTester(FamilyPluginTester):
@@ -231,7 +278,6 @@ class BarkPluginTester(FamilyPluginTester):
 
         # Semantic sub-model
         for prefix in ("semantic", "coarse"):
-            h = _SEM_HIDDEN if prefix == "semantic" else _COARSE_HIDDEN
             n_layers = _SEM_LAYERS if prefix == "semantic" else _COARSE_LAYERS
             keys.update({
                 f"{prefix}.embedding",
@@ -462,3 +508,140 @@ class TestBarkEngine(FamilyPluginTestMixin):
             f"w_q shape[0] = {w_q.shape[0]}, expected {_SEM_HIDDEN} "
             f"(projection should be transposed from HF [out, in] to [in, out])"
         )
+
+    def test_bark_tp_build_rejects_single_device_parallel_config(self):
+        decoder_tp_builder = _bark_tp_builder_module()
+
+        with pytest.raises(ValueError, match="enabled parallel config"):
+            decoder_tp_builder.build_bark_tp_decoder_engine(
+                object(),
+                _make_bark_tp_weights(),
+                max_cache_length=4,
+                sub_model="semantic",
+                sub_cfg={
+                    "hidden_size": _SEM_HIDDEN,
+                    "num_heads": _SEM_HEADS,
+                    "num_layers": _SEM_LAYERS,
+                    "vocab_size": _SEM_VOCAB,
+                    "output_vocab": _SEM_OUTPUT_VOCAB,
+                    "intermediate_size": _SEM_HIDDEN * 4,
+                },
+                parallel_config=ParallelConfig(),
+            )
+
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            ({"hidden": _SEM_HIDDEN + 1}, "hidden_size"),
+            ({"num_heads": _SEM_HEADS + 1}, "num_heads"),
+            ({"mlp_size": _SEM_HIDDEN * 4 + 1}, "mlp_size"),
+        ],
+    )
+    def test_bark_tp_validation_rejects_non_divisible_dimensions(
+        self,
+        kwargs,
+        message,
+    ):
+        decoder_tp_builder = _bark_tp_builder_module()
+        params = {
+            "sub_model": "semantic",
+            "hidden": _SEM_HIDDEN,
+            "num_heads": _SEM_HEADS,
+            "mlp_size": _SEM_HIDDEN * 4,
+            "parallel": ParallelConfig(
+                mode="tensor_parallel",
+                tp_size=2,
+                rank=0,
+            ),
+        }
+        params.update(kwargs)
+
+        with pytest.raises(ValueError, match=message):
+            decoder_tp_builder._validate_bark_tp(**params)
+
+    @pytest.mark.parametrize(
+        ("key", "shape", "message"),
+        [
+            ("layer.0.w_q", (_SEM_HIDDEN, _SEM_HIDDEN - 1), "last dimension"),
+            ("layer.0.w_o", (_SEM_HIDDEN - 1, _SEM_HIDDEN), "first dimension"),
+        ],
+    )
+    def test_bark_tp_sharding_rejects_unshardable_weight_shapes(
+        self,
+        key,
+        shape,
+        message,
+    ):
+        decoder_tp_builder = _bark_tp_builder_module()
+        weights = _make_bark_tp_weights()
+        weights[key] = np.zeros(shape, dtype=np.float32)
+
+        with pytest.raises(ValueError, match=message):
+            decoder_tp_builder.shard_bark_decoder_weights(
+                weights,
+                sub_model="semantic",
+                sub_cfg={
+                    "hidden_size": _SEM_HIDDEN,
+                    "num_heads": _SEM_HEADS,
+                    "num_layers": _SEM_LAYERS,
+                    "intermediate_size": _SEM_HIDDEN * 4,
+                },
+                parallel_config=ParallelConfig(
+                    mode="tensor_parallel",
+                    tp_size=2,
+                    rank=0,
+                ),
+            )
+
+    def test_bark_tp_shards_rank_local_decoder_weights(self):
+        decoder_tp_builder = _bark_tp_builder_module()
+        weights = _make_bark_tp_weights()
+        shard = decoder_tp_builder.shard_bark_decoder_weights(
+            weights,
+            sub_model="semantic",
+            sub_cfg={
+                "hidden_size": _SEM_HIDDEN,
+                "num_heads": _SEM_HEADS,
+                "num_layers": _SEM_LAYERS,
+                "intermediate_size": _SEM_HIDDEN * 4,
+            },
+            parallel_config=ParallelConfig(
+                mode="tensor_parallel",
+                tp_size=2,
+                rank=1,
+            ),
+        )
+
+        assert "_attention_size" not in shard
+        assert shard["metadata"] == "kept"
+        assert shard["embedding"] is weights["embedding"]
+        assert shard["final_norm"] is weights["final_norm"]
+        np.testing.assert_array_equal(
+            shard["extra_tensor"],
+            weights["extra_tensor"],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.w_q"],
+            weights["layer.0.w_q"][:, _SEM_HIDDEN // 2:],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.q_bias"],
+            weights["layer.0.q_bias"][_SEM_HIDDEN // 2:],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.w_o"],
+            weights["layer.0.w_o"][_SEM_HIDDEN // 2:, :],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.w_fc1"],
+            weights["layer.0.w_fc1"][:, (_SEM_HIDDEN * 4) // 2:],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.fc1_bias"],
+            weights["layer.0.fc1_bias"][(_SEM_HIDDEN * 4) // 2:],
+        )
+        np.testing.assert_array_equal(
+            shard["layer.0.w_fc2"],
+            weights["layer.0.w_fc2"][(_SEM_HIDDEN * 4) // 2:, :],
+        )
+        assert shard["layer.0.o_bias"] is weights["layer.0.o_bias"]

--- a/tests/e2e/models/bark-small-tp4.json
+++ b/tests/e2e/models/bark-small-tp4.json
@@ -1,0 +1,68 @@
+{
+  "name": "bark-small-tp4",
+  "trace_id": "IT-E2E-BARKS-TP4-01",
+  "hf_id": "suno/bark-small",
+  "bundle": "bark-small-tp4.trtfb",
+  "family": "bark",
+  "runtime_strategy": "text_to_audio_bark",
+  "test_type": "audio",
+  "max_cache_length": 1024,
+  "prompt": "Hello, this is a test of the audio generation system.",
+  "max_new_tokens": 0,
+  "logit_atol": 0.01,
+  "trust_remote_code": false,
+  "core": true,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "determinism": {
+    "seed": 0
+  },
+  "threshold_overrides": {
+    "duration_ratio_min": 0.3,
+    "log_spectral_distance": 10.0,
+    "mel_spectrogram_distance": 8.0,
+    "min_semantic_tokens": 50,
+    "rms_min": 0.01,
+    "golden_semantic_tokens": [41, 215, 548, 6961, 602, 602, 2586, 8385, 1311, 602, 5109, 3051, 1136, 8343, 8909, 292, 3318, 6362, 6362, 4401],
+    "golden_coarse_tokens": [10062, 11937, 10062, 11448, 10408, 11568, 10062, 11448, 10062, 11448, 10408, 11568, 10408, 11542, 10408, 11937, 10408, 11568, 10062, 11448]
+  }
+}

--- a/tests/e2e_harness/runners/audio_speech.py
+++ b/tests/e2e_harness/runners/audio_speech.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shutil
 import struct
 import subprocess
@@ -65,6 +66,30 @@ def _resolve_bundle_path(case: E2ECase, ctx: RunContext) -> str:
     if os.path.isabs(bundle_name):
         return bundle_name
     return os.path.join(ctx.engine_dir, bundle_name)
+
+
+def _distributed_runtime_config(case: E2ECase) -> dict:
+    config = case.metadata.get("distributed_runtime", {})
+    return config if isinstance(config, dict) and config.get("enabled") else {}
+
+
+def _wrap_distributed_command(cmd: list[str], case: E2ECase) -> list[str]:
+    config = _distributed_runtime_config(case)
+    if not config:
+        return cmd
+    launcher = str(config.get("launcher", "mpirun") or "mpirun")
+    world_size = int(config.get("world_size", config.get("tp_size", 2)) or 2)
+    launcher_args = config.get("launcher_args")
+    if isinstance(launcher_args, list):
+        return [launcher] + [str(arg) for arg in launcher_args] + cmd
+    return [launcher, "--tag-output", "-np", str(world_size)] + cmd
+
+
+def _strip_mpirun_tags(text: str) -> str:
+    lines = []
+    for line in text.splitlines():
+        lines.append(re.sub(r"^\[[^\]]+\]<std(?:out|err)>:\s?", "", line))
+    return "\n".join(lines)
 
 
 def _read_wav_rms(path: str) -> float:
@@ -157,6 +182,7 @@ class SpeechToTextRunner:
             cmd.extend(["--hf-python", runtime_cli_python])
 
         env = {**os.environ, "LD_LIBRARY_PATH": ld_path}
+        cmd = _wrap_distributed_command(cmd, case)
 
         t0 = time.monotonic()
         result = subprocess.run(
@@ -165,12 +191,16 @@ class SpeechToTextRunner:
 
         # Parse output: expect transcript text on stdout.
         # Strip special tokens like <|notimestamp|>, <|endoftext|>, etc.
-        import re
-        transcript = re.sub(r'<\|[^|]+\|>', '', result.stdout).strip()
+        clean_stdout = _strip_mpirun_tags(result.stdout)
+        transcript_lines = [
+            re.sub(r'<\|[^|]+\|>', '', line).strip()
+            for line in clean_stdout.splitlines()
+        ]
+        transcript = next((line for line in transcript_lines if line), "")
 
         # Try to extract token IDs if the binary outputs them
         token_ids = []
-        for line in result.stderr.splitlines():
+        for line in _strip_mpirun_tags(result.stderr).splitlines():
             if line.startswith("tokens:"):
                 try:
                     token_ids = [int(t) for t in line.split(":", 1)[1].strip().split()]
@@ -238,13 +268,19 @@ class TextToAudioRunner:
         ld_path = _build_ld_library_path(ctx)
 
         with tempfile.TemporaryDirectory(prefix="trtmc_audio_") as tmpdir:
-            wav_path = os.path.join(tmpdir, "output.wav")
+            distributed_runtime = _distributed_runtime_config(case)
+            output_root = os.path.join(tmpdir, "rank_outputs")
+            wav_path = (
+                os.path.join(output_root, "rank_0", "output.wav")
+                if distributed_runtime else os.path.join(tmpdir, "output.wav")
+            )
 
             cmd = [
                 binary, "generate-audio", bundle_path,
                 "--prompt", prompt,
-                "--output", wav_path,
             ]
+            if not distributed_runtime:
+                cmd.extend(["--output", wav_path])
             runtime_cli_python = ctx.runtime_cli_hf_python()
             if runtime_cli_python:
                 cmd.extend(["--hf-python", runtime_cli_python])
@@ -265,9 +301,23 @@ class TextToAudioRunner:
                     bark_seed = int(seed)
                     cmd.extend(["--set", f"audio_bark.seed={int(seed)}"])
             # Dump intermediate tokens for diversity/degeneration checks.
-            bark_dump_prefix = os.path.join(tmpdir, "bark_dump")
+            bark_dump_prefix = (
+                os.path.join(output_root, "rank_0", "bark_dump")
+                if distributed_runtime else os.path.join(tmpdir, "bark_dump")
+            )
             if case.family == "bark":
-                cmd.extend(["--set", f"audio_bark.dump_path={bark_dump_prefix}"])
+                if distributed_runtime:
+                    wrapper = (
+                        'rank="${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${PMIX_RANK:-${RANK:-0}}}}"; '
+                        'out="$1/rank_${rank}"; mkdir -p "$out"; shift; '
+                        'exec "$@" --output "$out/output.wav" '
+                        '--set "audio_bark.dump_path=$out/bark_dump"'
+                    )
+                    cmd = ["bash", "-lc", wrapper, "trtmc_rank_audio", output_root] + cmd
+                else:
+                    cmd.extend(["--set", f"audio_bark.dump_path={bark_dump_prefix}"])
+
+            cmd = _wrap_distributed_command(cmd, case)
 
             t0 = time.monotonic()
             result = subprocess.run(
@@ -279,8 +329,8 @@ class TextToAudioRunner:
                 "text_to_audio", case.name)
             data: dict = {
                 "returncode": result.returncode,
-                "stdout": result.stdout,
-                "stderr": stderr_truncated,
+                "stdout": _strip_mpirun_tags(result.stdout),
+                "stderr": _strip_mpirun_tags(stderr_truncated),
             }
             if case.family == "bark" and bark_seed is not None:
                 data["trt_seed"] = str(bark_seed)


### PR DESCRIPTION
## Background
Bark has separate autoregressive semantic and coarse decoder engines, but both were single-device only. This adds TensorRT 11 tensor-parallel builds for those decoder stages while leaving the fine and codec engines replicated.

## Exit Criteria
- Build Bark semantic and coarse TP4 decoder engines.
- Run Bark TP4 generation through `mpirun`.
- Preserve the existing single-device Bark build path.
- Add multi-device E2E coverage for `suno/bark-small`.

## Implementation
- Added a Bark semantic/coarse TP decoder builder that mirrors the existing single-device decoder graph, shards Q/K/V and FC1 by output dimension, shards output/FC2 by input dimension, and joins row-parallel outputs with TensorRT distributed all-reduce.
- Updated Bark’s family plugin to accept `parallel_config`, build rank-local semantic engines through the generic bundle path, and build rank-local coarse engine sections from `build_extra_engines`.
- Updated the Bark runtime plugin to initialize the TP group, load `engine_plan_tp_rankN` and `coarse_engine_plan_tp_rankN`, and size semantic/coarse KV caches from the loaded engine tensors.
- Passed `parallel_config` into generic extra engine builders when a plugin supports it.
- Updated the audio E2E runner for distributed audio/speech commands, including per-rank Bark output directories so rank 0 artifacts are compared without output-file races.
- Added `bark-small-tp4.json` with TP4 build args, distributed runtime metadata, and GPU/mpirun preflight checks.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile tensorrt_model_connect/tensorrt_model_connect/families/bark/decoder_tp_builder.py tensorrt_model_connect/tensorrt_model_connect/families/bark/plugin.py tensorrt_model_connect/tensorrt_model_connect/engine_builder.py tests/e2e_harness/runners/audio_speech.py`: passed.
- `git diff --check`: passed.
- B200 TRT11 container: `cmake -S /tmp/trtmc-bark-pr -B /tmp/trtmc-build-bark -G Ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_BUILD_BACKEND_TRT=ON -DTRTMC_ENABLE_TRT=ON -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so`: passed.
- B200 TRT11 container: `cmake --build /tmp/trtmc-build-bark --target trtmc -j 16`: passed.
- B200 TRT11 container: `cmake --build /tmp/trtmc-build-bark --target trtmc_backend_trt -j 16`: passed.
- B200 TRT11 container: `PYTHONPATH=/tmp/trtmc-bark-pr/tensorrt_model_connect PYTHONDONTWRITEBYTECODE=1 HF_HOME=/tmp/trtmc-hf-cache TRANSFORMERS_CACHE=/tmp/trtmc-hf-cache/hub LD_LIBRARY_PATH=/tmp/trtmc-build-bark:$LD_LIBRARY_PATH /opt/venv/bin/python -m pytest tests/test_e2e.py::test_e2e[bark-small-tp4] --multi-device-only --rebuild-engines --engine-dir /tmp/trtmc-engines-bark-tp-fixed --trtmc-binary /tmp/trtmc-build-bark/trtmc --hf-python /opt/venv/bin/python --e2e-artifacts-dir /tmp/trtmc-artifacts-bark-tp-fixed -p no:cacheprovider -s -q`: passed, 1 test in 210.38s.
- Bark TP4 E2E metrics: 7/7 passed; RMS 0.03146, duration ratio 1.0187, mel distance 5.303 <= 8.0, log spectral distance 6.341 <= 10.0, semantic diversity 0.954, first 20 semantic golden tokens 20/20, and first 20 coarse golden tokens 20/20.

## Notes For Future Readers
- The shared audio runner distributed helpers overlap with the Whisper and Canary TP PRs; review that once and then focus on the Bark-specific rank-output handling.
- Fine and codec engines remain replicated because they are not the autoregressive TP bottleneck and do not use decoder KV-cache collectives.
