### PR TITLE
Add Nemotron Labs Diffusion support

### DIFF
--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -120,11 +120,17 @@ struct GenerateConfig {
     int32_t height{0};
     int32_t width{0};
     int32_t eos_token_id{-1};
-    int32_t tail_frames{0};           // speech-to-speech: extra frames after input
-    bool use_chat_template{false};    ///< Apply chat template before tokenization
-    bool enable_thinking{true};       ///< Qwen3: if false, disable thinking mode
-    bool stop_on_boxed_answer{false}; ///< Stop once generated text contains a full \boxed{...}
-    int32_t stop_check_interval{16};  ///< Token interval for answer-stop checks
+    // Text diffusion / speculative decoding modes. Empty/"auto" lets a
+    // runtime choose its model-default mode; causal decoder runtimes ignore it.
+    std::string text_generation_mode{
+        "auto"};                       // "ar", "diffusion", "linear_spec", "linear_spec_lora"
+    int32_t block_length{0};           // <=0 uses bundle/model default
+    float confidence_threshold{-1.0f}; // <0 uses mode default
+    int32_t tail_frames{0};            // speech-to-speech: extra frames after input
+    bool use_chat_template{false};     ///< Apply chat template before tokenization
+    bool enable_thinking{true};        ///< Qwen3: if false, disable thinking mode
+    bool stop_on_boxed_answer{false};  ///< Stop once generated text contains a full \boxed{...}
+    int32_t stop_check_interval{16};   ///< Token interval for answer-stop checks
 };
 
 class ITranscriptionStream {

--- a/include/trtmc/runtime/kv_cache.h
+++ b/include/trtmc/runtime/kv_cache.h
@@ -68,6 +68,19 @@ class KvCache : public IInferenceState {
     void write_prefill_kv(const std::vector<const void*>& prefill_k,
                           const std::vector<const void*>& prefill_v, int32_t seq_len);
 
+    // Prepare a multi-token block whose new tokens may attend bidirectionally
+    // to one another while still seeing the valid prefix cache.
+    void prepare_bidirectional_step(TensorMap& inputs, int32_t seq_len);
+
+    // Append batched present K/V at the current position. Used after causal
+    // block verification in diffusion-style text decoders.
+    void append_prefill_kv(const std::vector<const void*>& prefill_k,
+                           const std::vector<const void*>& prefill_v, int32_t seq_len);
+
+    // Move the logical cache length without touching device memory. Stale rows
+    // remain masked out by subsequent prepare_step calls.
+    void set_position(int32_t position);
+
     // Bind only the cache_k/v INPUT pointers to `module`. Used for the
     // prefill TrtModule whose present_k/v outputs have shape (Sq, kv_dim)
     // — too big for KvCache's single-row present buffer. The caller reads
@@ -80,6 +93,7 @@ class KvCache : public IInferenceState {
     std::vector<int64_t> mask_shape_for_engine(int32_t mask_width, std::size_t mask_buf_size) const;
     void write_position_input(TensorMap& inputs, int32_t seq_len);
     void write_batched_mask(TensorMap& inputs, int32_t seq_len);
+    void write_bidirectional_mask(TensorMap& inputs, int32_t seq_len);
     void write_decode_mask(TensorMap& inputs);
 
     std::vector<DeviceTensor> cache_k_;   // [num_layers], shape [max_length, kv_dim]

--- a/scripts/schedule_e2e.py
+++ b/scripts/schedule_e2e.py
@@ -141,6 +141,31 @@ def _model_name_from_test_id(test_id: str) -> str:
     return match.group(1) if match else ""
 
 
+def _bundle_group_key(test_id: str, manifests: dict[str, dict]) -> str:
+    """Return a stable scheduling key for tests that build the same bundle."""
+    manifest = manifests.get(_model_name_from_test_id(test_id), {})
+    bundle = str(manifest.get("bundle", "") or "").strip()
+    if bundle:
+        return f"bundle:{bundle}"
+    return f"single:{test_id}"
+
+
+def _group_by_bundle(
+    test_ids: list[str],
+    manifests: dict[str, dict],
+) -> list[tuple[int, list[str]]]:
+    """Group tests that share a bundle so they stay in one worker queue."""
+    groups: list[tuple[int, list[str]]] = []
+    key_to_group: dict[str, int] = {}
+    for idx, test_id in enumerate(test_ids):
+        key = _bundle_group_key(test_id, manifests)
+        if key not in key_to_group:
+            key_to_group[key] = len(groups)
+            groups.append((idx, []))
+        groups[key_to_group[key]][1].append(test_id)
+    return groups
+
+
 def split_by_parallel_resource(
     test_ids: list[str],
     manifest_dir: Path,
@@ -238,6 +263,9 @@ def schedule(
     def weight(tid: str) -> float:
         return _test_weight(tid, manifests, timing_estimates)
 
+    def group_weight(group: tuple[int, list[str]]) -> float:
+        return sum(weight(tid) for tid in group[1])
+
     # Reserve whole GPUs for exclusive tests. This keeps high-memory build
     # cases from colliding with unrelated workers while preserving parallelism
     # on the remaining GPUs.
@@ -248,11 +276,11 @@ def schedule(
             [0.0, gpu_id, 0, []]
             for gpu_id in range(max(reserved_gpu_count, 1))
         ]
-        indexed_exclusive = list(enumerate(exclusive_tests))
-        for _, tid in sorted(indexed_exclusive, key=lambda item: (-weight(item[1]), item[0])):
+        grouped_exclusive = _group_by_bundle(exclusive_tests, manifests)
+        for group in sorted(grouped_exclusive, key=lambda item: (-group_weight(item), item[0])):
             slot = min(exclusive_slots, key=lambda item: (item[0], item[1]))
-            slot[0] += weight(tid)
-            slot[3].append(tid)
+            slot[0] += group_weight(group)
+            slot[3].extend(group[1])
         for _, gpu_id, _, tests_for_gpu in exclusive_slots:
             if tests_for_gpu:
                 result[str(gpu_id)] = [tests_for_gpu]
@@ -277,11 +305,11 @@ def schedule(
                 [],
             ])
 
-    indexed_shared = list(enumerate([*large_tests, *small_tests]))
-    for _, tid in sorted(indexed_shared, key=lambda item: (-weight(item[1]), item[0])):
+    grouped_shared = _group_by_bundle([*large_tests, *small_tests], manifests)
+    for group in sorted(grouped_shared, key=lambda item: (-group_weight(item), item[0])):
         slot = min(slots, key=lambda item: (item[0], item[1], item[2]))
-        slot[0] = float(slot[0]) + weight(tid)
-        slot[3].append(tid)
+        slot[0] = float(slot[0]) + group_weight(group)
+        slot[3].extend(group[1])
 
     for gpu_id in shared_gpu_ids:
         workers: list[list[str]] = [[] for _ in range(workers_per_gpu)]

--- a/scripts/warm_hf_cache.py
+++ b/scripts/warm_hf_cache.py
@@ -59,10 +59,12 @@ _HF_ALLOW_PATTERNS = [
     "pytorch_model.bin",
     "tokenizer.json",
     "tokenizer_config.json",
+    "chat_template.jinja",
     "vocab.json",
     "merges.txt",
     "normalizer.json",
     "special_tokens_map.json",
+    "linear_spec_lora/**",
     "*.model",
     "*.spm",
     "*.py",
@@ -88,6 +90,12 @@ _HF_ALLOW_PATTERNS = [
 _HF_EXTRA_ALLOW_PATTERNS = ["*.nemo"]
 _ENTRYPOINT_PATTERNS = ["config.json", "model_index.json", "*/config.json"]
 _WEIGHT_PATTERNS = ["*.safetensors", "*.bin", "*.nemo"]
+_REQUIRED_FILES_BY_HF_ID = {
+    "nvidia/Nemotron-Labs-Diffusion-8B": [
+        "linear_spec_lora/adapter_config.json",
+        "linear_spec_lora/adapter_model.safetensors",
+    ],
+}
 _DIFFUSERS_WEIGHT_COMPONENTS = {
     "controlnet",
     "image_encoder",
@@ -217,10 +225,10 @@ def _is_cached(hf_id: str) -> bool:
                 if path != main_snapshot
             ]
 
-    return any(_snapshot_has_required_files(path) for path in snapshot_paths)
+    return any(_snapshot_has_required_files(path, hf_id=hf_id) for path in snapshot_paths)
 
 
-def _snapshot_has_required_files(snapshot_dir: pathlib.Path) -> bool:
+def _snapshot_has_required_files(snapshot_dir: pathlib.Path, hf_id: str = "") -> bool:
     files = [
         str(path.relative_to(snapshot_dir))
         for path in snapshot_dir.rglob("*")
@@ -238,11 +246,13 @@ def _snapshot_has_required_files(snapshot_dir: pathlib.Path) -> bool:
         for name in files
         for pattern in _WEIGHT_PATTERNS
     )
+    required_files = _REQUIRED_FILES_BY_HF_ID.get(hf_id, [])
+    has_required_files = all((snapshot_dir / name).is_file() for name in required_files)
     if (snapshot_dir / "model_index.json").is_file():
-        return has_entrypoint and has_weights and not _diffusers_missing_weight_components(
+        return has_entrypoint and has_weights and has_required_files and not _diffusers_missing_weight_components(
             snapshot_dir
         )
-    return has_entrypoint and has_weights
+    return has_entrypoint and has_weights and has_required_files
 
 
 def _diffusers_missing_weight_components(snapshot_dir: pathlib.Path) -> list[str]:
@@ -310,7 +320,7 @@ for i, (name, hf_id, gated) in enumerate(entries, 1):
             hf_id,
             allow_patterns=_HF_ALLOW_PATTERNS + _HF_EXTRA_ALLOW_PATTERNS,
         )
-        if not _snapshot_has_required_files(pathlib.Path(local_dir)):
+        if not _snapshot_has_required_files(pathlib.Path(local_dir), hf_id=hf_id):
             raise RuntimeError(
                 "downloaded snapshot is still missing a config/model_index "
                 "entrypoint or required local weight artifact")

--- a/src/cli/args.cpp
+++ b/src/cli/args.cpp
@@ -65,6 +65,7 @@ void print_usage() {
            "[--max-new-tokens N] [--temperature F] [--top-p F] [--min-p F] "
            "[--top-k N] [--seed N] [--benchmark N] [--warmup N] [--hf-python PATH] "
            "[--kv-cache-size SIZE] [--chat-template] [--no-thinking] "
+           "[--generation-mode MODE] [--block-length N] [--threshold F] "
            "[--num-samples N] [--num-steps N] [--guidance-scale S] [--cfg-scale S] "
            "[--sde-gamma S] [--initial-latents-raw PATH] [--condition-latents-raw PATH] "
            "[--condition-mask-raw PATH] [--sampling-steps-raw PATH] [--sde-noise-raw PATH] "
@@ -168,6 +169,10 @@ CliArgs parse_args(int argc, char** argv) {
         }
         if (arg == "--max-new-tokens" && need_value(arg)) {
             args.max_new_tokens = std::atoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--block-length" && need_value(arg)) {
+            args.block_length = std::atoi(argv[++i]);
             continue;
         }
         if (arg == "--num-samples" && need_value(arg)) {
@@ -291,6 +296,10 @@ CliArgs parse_args(int argc, char** argv) {
         }
         if ((arg == "--threshold" || arg == "--score-threshold") && need_value(arg)) {
             args.conf_threshold = static_cast<float>(std::atof(argv[++i]));
+            continue;
+        }
+        if (arg == "--generation-mode" && need_value(arg)) {
+            args.generation_mode = argv[++i];
             continue;
         }
         if (arg == "--cfg-scale" && need_value(arg)) {

--- a/src/cli/args.h
+++ b/src/cli/args.h
@@ -33,6 +33,7 @@ struct CliArgs {
     float point_y{0.5F};
     bool is_foreground{true};
     int max_new_tokens{0};
+    int block_length{0};
     int num_samples{1};
     int benchmark{0}; // >0: run N timed iterations after warmup
     int warmup{1};    // number of warmup iterations before timing
@@ -46,6 +47,7 @@ struct CliArgs {
     float sde_gamma{-1.0F};
     float conf_threshold{-1.0F};
     float cfg_scale{-1.0F};
+    std::string generation_mode;
     // Diffusion text-to-image extras (Qwen-Image, FLUX, Z-Image, ...)
     std::string negative_prompt;
     int diffusion_height{0}; // 0 = use bundle default

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -3,7 +3,8 @@
 // Usage:
 //   trtmc build           <hf-model-or-dir> -o <bundle.trtfb> [builder args...]
 //   trtmc run             <bundle.trtfb> --prompt "text" [--max-new-tokens N] [--benchmark N]
-//                        [--warmup N] [--num-samples N] [--num-steps N]
+//                        [--warmup N] [--generation-mode MODE] [--block-length N]
+//                        [--threshold F] [--num-samples N] [--num-steps N]
 //                        [--guidance-scale S] [--cfg-scale S] [--sde-gamma S]
 //                        [--initial-latents-raw PATH] [--condition-latents-raw PATH]
 //                        [--condition-mask-raw PATH] [--sampling-steps-raw PATH]
@@ -305,6 +306,10 @@ int cmd_run(const CliArgs& args) {
     cfg.max_new_tokens =
         args.max_new_tokens > 0 ? args.max_new_tokens : (ptype == "ElfFlowPipeline" ? 0 : 20);
     cfg.num_samples = args.num_samples;
+    cfg.block_length = args.block_length;
+    cfg.confidence_threshold = args.conf_threshold;
+    if (!args.generation_mode.empty())
+        cfg.text_generation_mode = args.generation_mode;
     cfg.num_steps = args.num_steps;
     cfg.guidance_scale = args.guidance_scale;
     cfg.cfg_scale = args.cfg_scale;

--- a/src/runtime/backend/trt_module_impl.cpp
+++ b/src/runtime/backend/trt_module_impl.cpp
@@ -369,12 +369,25 @@ TensorMap TrtModuleImpl::forward(const TensorMap& inputs) {
         if (entry.is_external)
             continue;
 
+        std::vector<int64_t> runtime_shape = entry.shape;
+        std::size_t runtime_nbytes = entry.nbytes;
+        if (has_dynamic_shapes_ && ctx_ != nullptr) {
+            std::vector<int64_t> inferred_shape;
+            runtime_nbytes = compute_alloc_bytes(ctx_->getTensorShape(name.c_str()), entry.dtype,
+                                                 inferred_shape);
+            if (runtime_nbytes <= entry.nbytes) {
+                runtime_shape = std::move(inferred_shape);
+            } else {
+                runtime_nbytes = entry.nbytes;
+            }
+        }
+
         auto& staging = host_output_staging_[name];
-        cudaMemcpy(staging.data(), entry.d_ptr, entry.nbytes, cudaMemcpyDeviceToHost);
+        cudaMemcpy(staging.data(), entry.d_ptr, runtime_nbytes, cudaMemcpyDeviceToHost);
 
         Tensor t;
         t.data = staging.data();
-        t.shape = entry.shape;
+        t.shape = std::move(runtime_shape);
         t.dtype = entry.dtype;
         outputs[name] = t;
     }

--- a/src/runtime/core/chat_template.cpp
+++ b/src/runtime/core/chat_template.cpp
@@ -12,7 +12,10 @@ struct FormatMarker {
     ChatTemplateFormat format;
 };
 
-static constexpr std::array<FormatMarker, 8> kDetectTable = {{
+static constexpr std::array<FormatMarker, 10> kDetectTable = {{
+    {"truncate_history_thinking", ChatTemplateFormat::kNemotronLabsDiffusion},
+    {"enable_thinking if enable_thinking is defined else False",
+     ChatTemplateFormat::kNemotronLabsDiffusion},
     {"<|im_start|>", ChatTemplateFormat::kChatML},
     {"[INST]", ChatTemplateFormat::kMistral},
     {"<|user|>", ChatTemplateFormat::kPhi},
@@ -59,6 +62,13 @@ static std::string apply_nemotron_h(const std::string& prompt, bool enable_think
     return r;
 }
 
+static std::string apply_nemotron_labs_diffusion(const std::string& prompt, bool enable_thinking) {
+    std::string r = "<|im_start|>system\n<|im_end|>\n<|im_start|>user\n" + prompt +
+                    "<|im_end|>\n<|im_start|>assistant\n";
+    r += enable_thinking ? "<think>\n" : "<think></think>";
+    return r;
+}
+
 std::string apply_chat_template(ChatTemplateFormat format, const std::string& prompt,
                                 bool enable_thinking) {
     switch (format) {
@@ -76,6 +86,8 @@ std::string apply_chat_template(ChatTemplateFormat format, const std::string& pr
         return "<extra_id_0>System\n\n<extra_id_1>User\n" + prompt + "\n<extra_id_1>Assistant\n";
     case ChatTemplateFormat::kNemotronH:
         return apply_nemotron_h(prompt, enable_thinking);
+    case ChatTemplateFormat::kNemotronLabsDiffusion:
+        return apply_nemotron_labs_diffusion(prompt, enable_thinking);
     case ChatTemplateFormat::kNone:
     default:
         return prompt;

--- a/src/runtime/core/chat_template.h
+++ b/src/runtime/core/chat_template.h
@@ -18,6 +18,7 @@ enum class ChatTemplateFormat {
     kLlama3, ///< <|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n
     kNemotron, ///< <extra_id_0>System\n\n<extra_id_1>User\n{prompt}\n<extra_id_1>Assistant\n
     kNemotronH, ///< <SPECIAL_10>System\n\n<SPECIAL_11>User\n{prompt}\n<SPECIAL_11>Assistant\n<think>\n
+    kNemotronLabsDiffusion, ///< ChatML with empty system message and <think></think> default.
 };
 
 /// Detect chat template format from the raw chat_template Jinja2 string

--- a/src/runtime/core/kv_cache.cpp
+++ b/src/runtime/core/kv_cache.cpp
@@ -147,6 +147,29 @@ void KvCache::write_batched_mask(TensorMap& inputs, int32_t seq_len) {
     inputs[names_.attention_mask] = mask_t;
 }
 
+void KvCache::write_bidirectional_mask(TensorMap& inputs, int32_t seq_len) {
+    // Diffusion block mask: all valid prefix cache rows are visible, stale cache
+    // rows are hidden, and every token in the current block can see every other
+    // token in the current block.
+    const int32_t valid = std::max(0, std::min(position_, max_length_));
+    const int32_t kv_len = max_length_ + seq_len;
+    const std::size_t total = static_cast<std::size_t>(seq_len) * static_cast<std::size_t>(kv_len);
+    mask_buf_.assign(total, kMaskedScore);
+    for (int32_t i = 0; i < seq_len; ++i) {
+        const std::size_t row = static_cast<std::size_t>(i) * static_cast<std::size_t>(kv_len);
+        for (int32_t j = 0; j < valid; ++j)
+            mask_buf_[row + static_cast<std::size_t>(j)] = 0.0f;
+        for (int32_t j = 0; j < seq_len; ++j)
+            mask_buf_[row + static_cast<std::size_t>(max_length_) + static_cast<std::size_t>(j)] =
+                0.0f;
+    }
+    Tensor mask_t;
+    mask_t.data = mask_buf_.data();
+    mask_t.shape = {static_cast<int64_t>(seq_len), static_cast<int64_t>(kv_len)};
+    mask_t.dtype = DType::kFloat32;
+    inputs[names_.attention_mask] = mask_t;
+}
+
 void KvCache::write_decode_mask(TensorMap& inputs) {
     const int32_t valid = std::max(0, std::min(position_, max_length_));
     const int32_t cache_rows = dynamic_binding_enabled_ ? preferred_cache_rows() : max_length_;
@@ -175,6 +198,13 @@ void KvCache::prepare_step(TensorMap& inputs, int32_t seq_len) {
         write_batched_mask(inputs, seq_len);
     else
         write_decode_mask(inputs);
+}
+
+void KvCache::prepare_bidirectional_step(TensorMap& inputs, int32_t seq_len) {
+    if (seq_len <= 0)
+        seq_len = 1;
+    write_position_input(inputs, seq_len);
+    write_bidirectional_mask(inputs, seq_len);
 }
 
 void KvCache::bind_to(TrtModule& module) {
@@ -235,6 +265,33 @@ void KvCache::write_prefill_kv(const std::vector<const void*>& prefill_k,
                         stream_);
     }
     position_ = seq_len;
+}
+
+void KvCache::append_prefill_kv(const std::vector<const void*>& prefill_k,
+                                const std::vector<const void*>& prefill_v, int32_t seq_len) {
+    if (seq_len <= 0)
+        return;
+    if (position_ + seq_len > max_length_)
+        throw std::runtime_error("KvCache::append_prefill_kv: append exceeds max_length");
+    if (static_cast<int32_t>(prefill_k.size()) != num_layers_ ||
+        static_cast<int32_t>(prefill_v.size()) != num_layers_) {
+        throw std::runtime_error("KvCache::append_prefill_kv: per-layer pointer count mismatch");
+    }
+    const auto row_bytes = static_cast<std::size_t>(kv_dim_) * cache_element_size_;
+    const auto block_bytes = static_cast<std::size_t>(seq_len) * row_bytes;
+    const auto offset = static_cast<std::size_t>(position_) * row_bytes;
+    for (int32_t i = 0; i < num_layers_; ++i) {
+        auto li = static_cast<std::size_t>(i);
+        cudaMemcpyAsync(static_cast<uint8_t*>(cache_k_[li].data()) + offset, prefill_k[li],
+                        block_bytes, cudaMemcpyDeviceToDevice, stream_);
+        cudaMemcpyAsync(static_cast<uint8_t*>(cache_v_[li].data()) + offset, prefill_v[li],
+                        block_bytes, cudaMemcpyDeviceToDevice, stream_);
+    }
+    position_ += seq_len;
+}
+
+void KvCache::set_position(int32_t position) {
+    position_ = std::max(0, std::min(position, max_length_));
 }
 
 void KvCache::advance(int32_t n_tokens) {

--- a/src/runtime/models/text_generation/MODEL.toml
+++ b/src/runtime/models/text_generation/MODEL.toml
@@ -1,1 +1,1 @@
-runtime_strategies = ["decoder_kv_cache", "decoder_moe"]
+runtime_strategies = ["decoder_kv_cache", "decoder_moe", "nemotron_labs_diffusion"]

--- a/src/runtime/models/text_generation/pipeline.cpp
+++ b/src/runtime/models/text_generation/pipeline.cpp
@@ -5,7 +5,9 @@
 #include "trtmc/runtime/kv_cache.h"
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
+#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -142,6 +144,127 @@ single_decoder_context(std::unique_ptr<TrtModule> decoder) {
     decoders.push_back(TextGenerationPipeline::DecoderContext{0, std::move(decoder)});
     return decoders;
 }
+
+std::string normalize_generation_mode(std::string mode) {
+    std::transform(mode.begin(), mode.end(), mode.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    std::replace(mode.begin(), mode.end(), '-', '_');
+    return mode;
+}
+
+bool greedy_text_diffusion_params(const SamplingParams& params) {
+    return params.seed < 0 &&
+           (params.temperature <= 1e-6F ||
+            (params.top_k <= 1 && params.top_p >= 1.0F - 1e-6F && params.min_p <= 1e-6F));
+}
+
+struct TokenConfidence {
+    int32_t pos{0};
+    int32_t token_id{0};
+    float confidence{0.0F};
+};
+
+TokenConfidence argmax_with_confidence(const float* logits, int32_t vocab, int32_t pos) {
+    TokenConfidence out;
+    out.pos = pos;
+    if (logits == nullptr || vocab <= 0)
+        return out;
+    int32_t best = 0;
+    float max_logit = logits[0];
+    for (int32_t i = 1; i < vocab; ++i) {
+        if (logits[i] > max_logit) {
+            max_logit = logits[i];
+            best = i;
+        }
+    }
+    double denom = 0.0;
+    for (int32_t i = 0; i < vocab; ++i)
+        denom += std::exp(static_cast<double>(logits[i] - max_logit));
+    out.token_id = best;
+    out.confidence = denom > 0.0 ? static_cast<float>(1.0 / denom) : 0.0F;
+    return out;
+}
+
+std::vector<int32_t> transfer_quota_schedule(int32_t masked, int32_t steps) {
+    steps = std::max(steps, 1);
+    std::vector<int32_t> quota(static_cast<std::size_t>(steps), 0);
+    const int32_t base = masked / steps;
+    const int32_t rem = masked % steps;
+    for (int32_t i = 0; i < steps; ++i)
+        quota[static_cast<std::size_t>(i)] = base + (i < rem ? 1 : 0);
+    return quota;
+}
+
+std::vector<TokenConfidence> masked_predictions(const std::vector<float>& logits,
+                                                const std::vector<int32_t>& block,
+                                                int32_t mask_token_id, int32_t vocab_size) {
+    std::vector<TokenConfidence> preds;
+    if (vocab_size <= 0)
+        return preds;
+    const auto rows = static_cast<int32_t>(logits.size() / static_cast<std::size_t>(vocab_size));
+    const int32_t usable = std::min<int32_t>(rows, static_cast<int32_t>(block.size()));
+    preds.reserve(static_cast<std::size_t>(usable));
+    for (int32_t i = 0; i < usable; ++i) {
+        if (block[static_cast<std::size_t>(i)] != mask_token_id)
+            continue;
+        preds.push_back(argmax_with_confidence(
+            logits.data() + static_cast<std::size_t>(i) * static_cast<std::size_t>(vocab_size),
+            vocab_size, i));
+    }
+    std::sort(preds.begin(), preds.end(),
+              [](const TokenConfidence& lhs, const TokenConfidence& rhs) {
+                  if (lhs.confidence != rhs.confidence)
+                      return lhs.confidence > rhs.confidence;
+                  return lhs.pos < rhs.pos;
+              });
+    return preds;
+}
+
+void apply_diffusion_transfer(std::vector<int32_t>& block,
+                              const std::vector<TokenConfidence>& preds, int32_t quota,
+                              bool use_threshold, float threshold) {
+    if (preds.empty())
+        return;
+    if (use_threshold) {
+        block[static_cast<std::size_t>(preds.front().pos)] = preds.front().token_id;
+        for (std::size_t i = 1; i < preds.size(); ++i) {
+            if (preds[i].confidence >= threshold)
+                block[static_cast<std::size_t>(preds[i].pos)] = preds[i].token_id;
+        }
+        return;
+    }
+    quota = std::max(0, std::min<int32_t>(quota, static_cast<int32_t>(preds.size())));
+    for (int32_t i = 0; i < quota; ++i)
+        block[static_cast<std::size_t>(preds[static_cast<std::size_t>(i)].pos)] =
+            preds[static_cast<std::size_t>(i)].token_id;
+}
+
+void apply_linear_spec_transfer(std::vector<int32_t>& block,
+                                const std::vector<TokenConfidence>& preds, bool threshold_enabled,
+                                float threshold) {
+    if (preds.empty())
+        return;
+    if (!threshold_enabled) {
+        for (const auto& pred : preds)
+            block[static_cast<std::size_t>(pred.pos)] = pred.token_id;
+        return;
+    }
+
+    bool changed = false;
+    for (const auto& pred : preds) {
+        if (pred.confidence >= threshold) {
+            block[static_cast<std::size_t>(pred.pos)] = pred.token_id;
+            changed = true;
+        }
+    }
+    if (!changed)
+        block[static_cast<std::size_t>(preds.front().pos)] = preds.front().token_id;
+}
+
+bool has_mask_token(const std::vector<int32_t>& block, int32_t mask_token_id) {
+    return std::find(block.begin(), block.end(), mask_token_id) != block.end();
+}
+
 } // namespace
 
 TextGenerationPipeline::TextGenerationPipeline(std::unique_ptr<TrtModule> decoder,
@@ -154,16 +277,18 @@ TextGenerationPipeline::TextGenerationPipeline(std::unique_ptr<TrtModule> decode
     : TextGenerationPipeline(single_decoder_context(std::move(decoder)), std::move(state),
                              std::move(config), stream, std::move(tokenizer),
                              std::move(model_id_str), std::move(sampler),
-                             /*prefill=*/nullptr, std::move(distributed_owner)) {}
+                             /*prefill=*/nullptr, /*linear_spec_lora_prefill=*/nullptr,
+                             std::move(distributed_owner)) {}
 
 TextGenerationPipeline::TextGenerationPipeline(
     std::vector<DecoderContext> decoders, std::unique_ptr<IInferenceState> state,
     TextGenConfig config, cudaStream_t stream, std::shared_ptr<ITokenizer> tokenizer,
     std::string model_id_str, std::unique_ptr<ISampler> sampler, std::unique_ptr<TrtModule> prefill,
-    std::shared_ptr<void> distributed_owner)
+    std::unique_ptr<TrtModule> linear_spec_lora_prefill, std::shared_ptr<void> distributed_owner)
     : distributed_owner_(std::move(distributed_owner)), decoders_(std::move(decoders)),
-      prefill_(std::move(prefill)), state_(std::move(state)), config_(std::move(config)),
-      stream_(stream), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
+      prefill_(std::move(prefill)), linear_spec_lora_prefill_(std::move(linear_spec_lora_prefill)),
+      state_(std::move(state)), config_(std::move(config)), stream_(stream),
+      tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
       sampler_(std::move(sampler)), logits_output_name_(config_.logits_output_name) {
     if (decoders_.empty()) {
         throw std::runtime_error("TextGenerationPipeline: no decoder modules");
@@ -312,7 +437,8 @@ bool TextGenerationPipeline::run_prefill_batched(const std::vector<int32_t>& inp
     if (static_cast<std::size_t>(lt.numel()) < vocab)
         return false;
     logits.resize(vocab);
-    std::memcpy(logits.data(), lt.data, vocab * sizeof(float));
+    const auto offset = static_cast<std::size_t>(lt.numel()) - vocab;
+    std::memcpy(logits.data(), static_cast<const float*>(lt.data) + offset, vocab * sizeof(float));
 
     std::vector<const void*> pk, pv;
     if (!gather_prefill_kv_pointers(*prefill_, config_, pk, pv))
@@ -375,6 +501,239 @@ void TextGenerationPipeline::run_prefill(const std::vector<int32_t>& input_ids,
     state_->mark_prefill_complete();
 }
 
+TrtModule& TextGenerationPipeline::require_block_prefill(int32_t sq, TrtModule* prefill_override) {
+    TrtModule* prefill = prefill_override != nullptr ? prefill_override : prefill_.get();
+    if (prefill == nullptr)
+        throw std::runtime_error(
+            "TextGenerationPipeline: block generation requires prefill module");
+    if (sq <= 0)
+        throw std::runtime_error("TextGenerationPipeline: empty block");
+    if (config_.prefill_max_length > 0 && sq > config_.prefill_max_length) {
+        throw std::runtime_error("TextGenerationPipeline: block length exceeds prefill profile");
+    }
+    return *prefill;
+}
+
+KvCache& TextGenerationPipeline::require_block_kv_cache() {
+    auto* kv = dynamic_cast<KvCache*>(state_.get());
+    if (kv == nullptr)
+        throw std::runtime_error("TextGenerationPipeline: block generation requires KvCache");
+    return *kv;
+}
+
+void TextGenerationPipeline::copy_block_logits(const TensorMap& outputs,
+                                               std::vector<float>& logits) const {
+    auto logits_it = outputs.find(config_.logits_output_name);
+    if (logits_it == outputs.end())
+        throw std::runtime_error("TextGenerationPipeline: prefill module has no '" +
+                                 config_.logits_output_name + "' output");
+
+    const auto& lt = logits_it->second;
+    const auto num_logits = static_cast<std::size_t>(lt.numel());
+    logits.resize(num_logits);
+    std::memcpy(logits.data(), lt.data, num_logits * sizeof(float));
+}
+
+void TextGenerationPipeline::append_prefill_kv(KvCache& kv, TrtModule& prefill, int32_t sq) {
+    std::vector<const void*> pk, pv;
+    if (!gather_prefill_kv_pointers(prefill, config_, pk, pv)) {
+        throw std::runtime_error(
+            "TextGenerationPipeline: prefill module is missing present_k/present_v outputs");
+    }
+    kv.append_prefill_kv(pk, pv, sq);
+}
+
+void TextGenerationPipeline::run_prefill_block(const std::vector<int32_t>& input_ids,
+                                               bool bidirectional, bool append_kv,
+                                               std::vector<float>& logits,
+                                               TrtModule* prefill_override) {
+    const auto sq = static_cast<int32_t>(input_ids.size());
+    TrtModule& prefill = require_block_prefill(sq, prefill_override);
+    KvCache& kv = require_block_kv_cache();
+
+    kv.bind_cache_inputs(prefill);
+
+    TensorMap inputs;
+    Tensor tok_t;
+    tok_t.data = const_cast<int32_t*>(input_ids.data());
+    tok_t.shape = {static_cast<int64_t>(sq)};
+    tok_t.dtype = DType::kInt32;
+    inputs[config_.token_id_name] = tok_t;
+    if (bidirectional)
+        kv.prepare_bidirectional_step(inputs, sq);
+    else
+        kv.prepare_step(inputs, sq);
+
+    copy_block_logits(prefill.forward(inputs), logits);
+    if (append_kv)
+        append_prefill_kv(kv, prefill, sq);
+}
+
+std::string TextGenerationPipeline::resolve_generation_mode(const GenerateConfig& cfg) const {
+    std::string mode = normalize_generation_mode(cfg.text_generation_mode);
+    if (mode.empty())
+        mode = "auto";
+    if (mode == "auto" && config_.supports_text_diffusion)
+        mode = "diffusion";
+    if (mode == "autoregressive")
+        mode = "ar";
+    if (mode == "linear_speculation")
+        mode = "linear_spec";
+    if (mode == "linear_speculation_lora" || mode == "linear_spec_adapter")
+        mode = "linear_spec_lora";
+    return mode;
+}
+
+void TextGenerationPipeline::reset_generation_context() {
+    state_->reset();
+    state_bound_ = false;
+    for (auto& decoder_ctx : decoders_)
+        decoder_ctx.module->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
+    if (linear_spec_lora_prefill_)
+        linear_spec_lora_prefill_->reset_execution_context();
+}
+
+int32_t TextGenerationPipeline::resolve_text_diffusion_block_length(const GenerateConfig& cfg,
+                                                                    int32_t max_new_tokens,
+                                                                    bool require_divisible) const {
+    if (!config_.supports_text_diffusion || config_.mask_token_id < 0)
+        throw std::runtime_error("TextGenerationPipeline: bundle does not support text diffusion");
+    const int32_t block_len =
+        cfg.block_length > 0 ? cfg.block_length : std::max(config_.diffusion_block_length, 1);
+    if (require_divisible && max_new_tokens % block_len != 0) {
+        throw std::runtime_error(
+            "TextGenerationPipeline: diffusion mode requires max_new_tokens % block_length == 0");
+    }
+    return block_len;
+}
+
+int32_t TextGenerationPipeline::seed_next_token_from_prefill(const std::vector<int32_t>& input_ids,
+                                                             std::vector<float>& logits,
+                                                             int32_t vocab) {
+    run_prefill_block(input_ids, /*bidirectional=*/false, /*append_kv=*/true, logits);
+    if (static_cast<int32_t>(logits.size()) < vocab)
+        throw std::runtime_error("TextGenerationPipeline: missing prefill logits");
+    return argmax_with_confidence(logits.data() + logits.size() - static_cast<std::size_t>(vocab),
+                                  vocab, 0)
+        .token_id;
+}
+
+void TextGenerationPipeline::fill_diffusion_block(std::vector<int32_t>& block,
+                                                  std::vector<float>& logits, int32_t block_len,
+                                                  int32_t vocab, bool use_threshold,
+                                                  float threshold) {
+    const int32_t initial_masked = block_len - 1;
+    const auto quotas = transfer_quota_schedule(initial_masked, block_len);
+    for (int32_t step = 0; step < block_len && has_mask_token(block, config_.mask_token_id);
+         ++step) {
+        run_prefill_block(block, /*bidirectional=*/true, /*append_kv=*/false, logits);
+        if (static_cast<int32_t>(logits.size()) < block_len * vocab) {
+            throw std::runtime_error(
+                "TextGenerationPipeline: diffusion engine must output full block logits");
+        }
+        const auto preds = masked_predictions(logits, block, config_.mask_token_id, vocab);
+        apply_diffusion_transfer(block, preds, quotas[static_cast<std::size_t>(step)],
+                                 use_threshold, threshold);
+    }
+}
+
+int32_t TextGenerationPipeline::verify_diffusion_block(const std::vector<int32_t>& block,
+                                                       std::vector<float>& logits,
+                                                       int32_t block_len, int32_t vocab) {
+    run_prefill_block(block, /*bidirectional=*/false, /*append_kv=*/true, logits);
+    if (static_cast<int32_t>(logits.size()) < block_len * vocab) {
+        throw std::runtime_error(
+            "TextGenerationPipeline: diffusion engine must output full verify logits");
+    }
+    return argmax_with_confidence(logits.data() + (static_cast<std::size_t>(block_len - 1) *
+                                                   static_cast<std::size_t>(vocab)),
+                                  vocab, block_len - 1)
+        .token_id;
+}
+
+bool TextGenerationPipeline::append_tokens_until_eos(const std::vector<int32_t>& tokens,
+                                                     std::vector<int32_t>& output,
+                                                     const SamplingParams& params) const {
+    for (int32_t token : tokens) {
+        output.push_back(token);
+        if (params.eos_token_id >= 0 && token == params.eos_token_id)
+            return true;
+    }
+    return false;
+}
+
+void TextGenerationPipeline::fill_linear_spec_block(std::vector<int32_t>& block,
+                                                    std::vector<float>& logits, int32_t block_len,
+                                                    int32_t vocab, bool threshold_enabled,
+                                                    float threshold, bool use_lora_draft) {
+    while (has_mask_token(block, config_.mask_token_id)) {
+        TrtModule* draft_prefill = use_lora_draft ? linear_spec_lora_prefill_.get() : nullptr;
+        run_prefill_block(block, /*bidirectional=*/true, /*append_kv=*/false, logits,
+                          draft_prefill);
+        if (static_cast<int32_t>(logits.size()) < block_len * vocab) {
+            throw std::runtime_error(
+                "TextGenerationPipeline: linear_spec engine must output full block logits");
+        }
+        const auto preds = masked_predictions(logits, block, config_.mask_token_id, vocab);
+        apply_linear_spec_transfer(block, preds, threshold_enabled, threshold);
+    }
+}
+
+std::vector<int32_t>
+TextGenerationPipeline::verify_linear_spec_block(const std::vector<int32_t>& block,
+                                                 std::vector<float>& logits, int32_t block_len,
+                                                 int32_t vocab) {
+    run_prefill_block(block, /*bidirectional=*/false, /*append_kv=*/true, logits);
+    if (static_cast<int32_t>(logits.size()) < block_len * vocab) {
+        throw std::runtime_error(
+            "TextGenerationPipeline: linear_spec engine must output full verify logits");
+    }
+
+    std::vector<int32_t> ar_tokens;
+    ar_tokens.reserve(static_cast<std::size_t>(block_len));
+    for (int32_t i = 0; i < block_len; ++i) {
+        ar_tokens.push_back(
+            argmax_with_confidence(
+                logits.data() + (static_cast<std::size_t>(i) * static_cast<std::size_t>(vocab)),
+                vocab, i)
+                .token_id);
+    }
+    return ar_tokens;
+}
+
+int32_t TextGenerationPipeline::count_linear_spec_accepts(const std::vector<int32_t>& ar_tokens,
+                                                          const std::vector<int32_t>& block) {
+    if (ar_tokens.empty())
+        return 0;
+    if (block.size() < 2)
+        return 1;
+    int32_t accepted = 0;
+    const auto limit = static_cast<int32_t>(std::min(ar_tokens.size(), block.size() - 1));
+    for (int32_t i = 0; i < limit; ++i) {
+        if (ar_tokens[static_cast<std::size_t>(i)] != block[static_cast<std::size_t>(i + 1)])
+            break;
+        ++accepted;
+    }
+    return accepted + 1;
+}
+
+bool TextGenerationPipeline::append_linear_spec_tokens(const std::vector<int32_t>& ar_tokens,
+                                                       int32_t emit_count,
+                                                       std::vector<int32_t>& output,
+                                                       int32_t& generated,
+                                                       const SamplingParams& params) const {
+    for (int32_t i = 0; i < emit_count; ++i) {
+        const int32_t token = ar_tokens[static_cast<std::size_t>(i)];
+        output.push_back(token);
+        ++generated;
+        if (params.eos_token_id >= 0 && token == params.eos_token_id)
+            return true;
+    }
+    return false;
+}
+
 TextGenerationPipeline::TimedGenResult
 TextGenerationPipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
                                           int32_t max_new_tokens, const SamplingParams& params,
@@ -382,6 +741,16 @@ TextGenerationPipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
     using Clock = std::chrono::steady_clock;
     if (max_new_tokens == 0 || input_ids.empty())
         return TimedGenResult{input_ids, 0.0, 0.0};
+
+    const std::string mode = resolve_generation_mode(cfg);
+    if (mode == "diffusion" || mode == "dlm")
+        return generate_diffusion_from_ids(input_ids, max_new_tokens, params, cfg);
+    if (mode == "linear_spec" || mode == "linear_spec_lora")
+        return generate_linear_spec_from_ids(input_ids, max_new_tokens, params, cfg,
+                                             mode == "linear_spec_lora");
+    if (mode != "auto" && mode != "ar")
+        throw std::runtime_error("TextGenerationPipeline: unsupported generation mode '" + mode +
+                                 "'");
 
     ISampler* active_sampler = sampler_.get();
     std::unique_ptr<ISampler> local_sampler;
@@ -391,10 +760,7 @@ TextGenerationPipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
     }
     active_sampler->reset();
 
-    state_->reset();
-    state_bound_ = false;
-    for (auto& decoder_ctx : decoders_)
-        decoder_ctx.module->reset_execution_context();
+    reset_generation_context();
     state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
@@ -411,6 +777,119 @@ TextGenerationPipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
     const double prefill_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
     const double decode_ms = std::chrono::duration<double, std::milli>(t2 - t1).count();
     return TimedGenResult{std::move(output), prefill_ms, decode_ms};
+}
+
+TextGenerationPipeline::TimedGenResult TextGenerationPipeline::generate_diffusion_from_ids(
+    const std::vector<int32_t>& input_ids, int32_t max_new_tokens, const SamplingParams& params,
+    const GenerateConfig& cfg) {
+    using Clock = std::chrono::steady_clock;
+    if (!greedy_text_diffusion_params(params)) {
+        throw std::runtime_error(
+            "TextGenerationPipeline: diffusion mode currently supports greedy temperature=0 "
+            "generation");
+    }
+    const int32_t block_len =
+        resolve_text_diffusion_block_length(cfg, max_new_tokens, /*require_divisible=*/true);
+    const bool use_threshold = cfg.confidence_threshold >= 0.0F;
+    const float threshold = cfg.confidence_threshold;
+    const int32_t vocab = config_.vocab_size;
+
+    reset_generation_context();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+
+    std::vector<float> logits;
+    const auto t0 = Clock::now();
+    int32_t next_token = seed_next_token_from_prefill(input_ids, logits, vocab);
+    const auto t1 = Clock::now();
+
+    std::vector<int32_t> output = input_ids;
+    const int32_t num_blocks = max_new_tokens / block_len;
+    const auto decode_start = Clock::now();
+    for (int32_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
+        std::vector<int32_t> block(static_cast<std::size_t>(block_len), config_.mask_token_id);
+        block[0] = next_token;
+        fill_diffusion_block(block, logits, block_len, vocab, use_threshold, threshold);
+        next_token = verify_diffusion_block(block, logits, block_len, vocab);
+
+        if (append_tokens_until_eos(block, output, params)) {
+            const auto t2 = Clock::now();
+            return TimedGenResult{
+                std::move(output), std::chrono::duration<double, std::milli>(t1 - t0).count(),
+                std::chrono::duration<double, std::milli>(t2 - decode_start).count()};
+        }
+    }
+
+    const auto t2 = Clock::now();
+    return TimedGenResult{std::move(output),
+                          std::chrono::duration<double, std::milli>(t1 - t0).count(),
+                          std::chrono::duration<double, std::milli>(t2 - decode_start).count()};
+}
+
+TextGenerationPipeline::TimedGenResult TextGenerationPipeline::generate_linear_spec_from_ids(
+    const std::vector<int32_t>& input_ids, int32_t max_new_tokens, const SamplingParams& params,
+    const GenerateConfig& cfg, bool use_lora_draft) {
+    using Clock = std::chrono::steady_clock;
+    if (!greedy_text_diffusion_params(params)) {
+        throw std::runtime_error(
+            "TextGenerationPipeline: linear_spec mode currently supports greedy temperature=0 "
+            "generation");
+    }
+    if (use_lora_draft && linear_spec_lora_prefill_ == nullptr) {
+        throw std::runtime_error(
+            "TextGenerationPipeline: linear_spec_lora mode requires a linear-spec LoRA engine");
+    }
+    const int32_t block_len =
+        resolve_text_diffusion_block_length(cfg, max_new_tokens, /*require_divisible=*/false);
+    const bool threshold_enabled = cfg.confidence_threshold > 0.0F;
+    const float threshold = cfg.confidence_threshold;
+    const int32_t vocab = config_.vocab_size;
+
+    reset_generation_context();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+
+    std::vector<float> logits;
+    const auto t0 = Clock::now();
+    int32_t next_token = seed_next_token_from_prefill(input_ids, logits, vocab);
+    const auto t1 = Clock::now();
+
+    std::vector<int32_t> output = input_ids;
+    output.push_back(next_token);
+    if (params.eos_token_id >= 0 && next_token == params.eos_token_id) {
+        return TimedGenResult{std::move(output),
+                              std::chrono::duration<double, std::milli>(t1 - t0).count(), 0.0};
+    }
+
+    auto* kv = dynamic_cast<KvCache*>(state_.get());
+    if (kv == nullptr)
+        throw std::runtime_error("TextGenerationPipeline: linear_spec requires KvCache");
+
+    int32_t generated = 1;
+    const auto decode_start = Clock::now();
+    while (generated < max_new_tokens) {
+        const int32_t cache_len = kv->position();
+        std::vector<int32_t> block(static_cast<std::size_t>(block_len), config_.mask_token_id);
+        block[0] = next_token;
+
+        fill_linear_spec_block(block, logits, block_len, vocab, threshold_enabled, threshold,
+                               use_lora_draft);
+        const auto ar_tokens = verify_linear_spec_block(block, logits, block_len, vocab);
+        const int32_t accepted = count_linear_spec_accepts(ar_tokens, block);
+        const int32_t emit_count = std::min(accepted, max_new_tokens - generated);
+        kv->set_position(cache_len + emit_count);
+        next_token = ar_tokens[static_cast<std::size_t>(emit_count - 1)];
+
+        if (append_linear_spec_tokens(ar_tokens, emit_count, output, generated, params)) {
+            const auto t2 = Clock::now();
+            return TimedGenResult{
+                std::move(output), std::chrono::duration<double, std::milli>(t1 - t0).count(),
+                std::chrono::duration<double, std::milli>(t2 - decode_start).count()};
+        }
+    }
+
+    const auto t2 = Clock::now();
+    return TimedGenResult{std::move(output),
+                          std::chrono::duration<double, std::milli>(t1 - t0).count(),
+                          std::chrono::duration<double, std::milli>(t2 - decode_start).count()};
 }
 
 bool TextGenerationPipeline::should_stop_on_answer(const std::vector<int32_t>& output,

--- a/src/runtime/models/text_generation/pipeline.h
+++ b/src/runtime/models/text_generation/pipeline.h
@@ -21,6 +21,8 @@
 
 namespace trtmc {
 
+class KvCache;
+
 struct TextGenConfig {
     int32_t vocab_size{0};
     int32_t id_bos{0};
@@ -46,6 +48,9 @@ struct TextGenConfig {
     std::string prefill_log_label;
     int32_t num_layers{0};
     int32_t kv_dim{0};
+    int32_t mask_token_id{-1};
+    int32_t diffusion_block_length{32};
+    bool supports_text_diffusion{false};
 };
 
 // Populate the process-wide step-trace state from the resolved ConfigBundle.
@@ -74,6 +79,7 @@ class TextGenerationPipeline final : public IPipeline {
                            std::string model_id_str = "",
                            std::unique_ptr<ISampler> sampler = nullptr,
                            std::unique_ptr<TrtModule> prefill = nullptr,
+                           std::unique_ptr<TrtModule> linear_spec_lora_prefill = nullptr,
                            std::shared_ptr<void> distributed_owner = nullptr);
 
     // Public API: takes raw text, returns typed result.
@@ -96,6 +102,7 @@ class TextGenerationPipeline final : public IPipeline {
     std::shared_ptr<void> distributed_owner_;
     std::vector<DecoderContext> decoders_;
     std::unique_ptr<TrtModule> prefill_;
+    std::unique_ptr<TrtModule> linear_spec_lora_prefill_;
     std::unique_ptr<IInferenceState> state_;
     TextGenConfig config_;
     cudaStream_t stream_;
@@ -116,6 +123,41 @@ class TextGenerationPipeline final : public IPipeline {
     };
     TimedGenResult generate_from_ids(const std::vector<int32_t>& input_ids, int32_t max_new_tokens,
                                      const SamplingParams& params, const GenerateConfig& cfg);
+    TimedGenResult generate_diffusion_from_ids(const std::vector<int32_t>& input_ids,
+                                               int32_t max_new_tokens, const SamplingParams& params,
+                                               const GenerateConfig& cfg);
+    TimedGenResult generate_linear_spec_from_ids(const std::vector<int32_t>& input_ids,
+                                                 int32_t max_new_tokens,
+                                                 const SamplingParams& params,
+                                                 const GenerateConfig& cfg, bool use_lora_draft);
+    std::string resolve_generation_mode(const GenerateConfig& cfg) const;
+    void reset_generation_context();
+    TrtModule& require_block_prefill(int32_t sq, TrtModule* prefill_override);
+    KvCache& require_block_kv_cache();
+    void copy_block_logits(const TensorMap& outputs, std::vector<float>& logits) const;
+    void append_prefill_kv(KvCache& kv, TrtModule& prefill, int32_t sq);
+    int32_t resolve_text_diffusion_block_length(const GenerateConfig& cfg, int32_t max_new_tokens,
+                                                bool require_divisible) const;
+    int32_t seed_next_token_from_prefill(const std::vector<int32_t>& input_ids,
+                                         std::vector<float>& logits, int32_t vocab);
+    void fill_diffusion_block(std::vector<int32_t>& block, std::vector<float>& logits,
+                              int32_t block_len, int32_t vocab, bool use_threshold,
+                              float threshold);
+    int32_t verify_diffusion_block(const std::vector<int32_t>& block, std::vector<float>& logits,
+                                   int32_t block_len, int32_t vocab);
+    bool append_tokens_until_eos(const std::vector<int32_t>& tokens, std::vector<int32_t>& output,
+                                 const SamplingParams& params) const;
+    void fill_linear_spec_block(std::vector<int32_t>& block, std::vector<float>& logits,
+                                int32_t block_len, int32_t vocab, bool threshold_enabled,
+                                float threshold, bool use_lora_draft);
+    std::vector<int32_t> verify_linear_spec_block(const std::vector<int32_t>& block,
+                                                  std::vector<float>& logits, int32_t block_len,
+                                                  int32_t vocab);
+    static int32_t count_linear_spec_accepts(const std::vector<int32_t>& ar_tokens,
+                                             const std::vector<int32_t>& block);
+    bool append_linear_spec_tokens(const std::vector<int32_t>& ar_tokens, int32_t emit_count,
+                                   std::vector<int32_t>& output, int32_t& generated,
+                                   const SamplingParams& params) const;
 
     // Run one decoder step: token_id → logits (D2H to host). Updates cache.
     void run_step(int32_t token_id, std::vector<float>& logits);
@@ -134,6 +176,9 @@ class TextGenerationPipeline final : public IPipeline {
     std::unique_ptr<ISampler> make_step_sampler(const SamplingParams& params);
     void run_prefill(const std::vector<int32_t>& input_ids, std::vector<float>& logits,
                      bool gpu_sampling);
+    void run_prefill_block(const std::vector<int32_t>& input_ids, bool bidirectional,
+                           bool append_kv, std::vector<float>& logits,
+                           TrtModule* prefill_override = nullptr);
     // Returns true if the batched prefill engine handled the prompt; false
     // means caller must fall back to the per-token decode loop.
     bool run_prefill_batched(const std::vector<int32_t>& input_ids, std::vector<float>& logits);

--- a/src/runtime/models/text_generation/plugin.cpp
+++ b/src/runtime/models/text_generation/plugin.cpp
@@ -289,22 +289,14 @@ class DecoderPlugin final : public IPipelinePlugin {
         int32_t prefill_profile_idx = decode_profile_roles.prefill_profile_idx;
         int32_t prefill_max_length = decode_profile_roles.prefill_max_length;
         std::string prefill_log_label;
-        if (!tp_runtime.config.enabled &&
-            find_section(ctx.bundle, "prefill_engine_plan") != nullptr) {
-            auto split_prefill_modules =
-                load_decoder_profile_modules(ctx, "prefill_engine_plan", stream, nullptr);
-            if (!split_prefill_modules.modules.empty()) {
-                const auto prefill_roles = detect_decoder_profile_roles(
-                    *split_prefill_modules.modules.front().module, io.token_id,
-                    kv_names.cache_k.front(), ctx.config.max_cache_length);
-                prefill_profile_idx = prefill_roles.prefill_profile_idx;
-                prefill_max_length = prefill_roles.prefill_max_length;
-                prefill_module = extract_prefill_module(std::move(split_prefill_modules),
-                                                        prefill_roles, "prefill_engine_plan");
-                if (prefill_module)
-                    prefill_log_label = "prefill engine";
-            }
+        if (!tp_runtime.config.enabled) {
+            prefill_module =
+                load_split_prefill_module(ctx, stream, io, kv_names, prefill_profile_idx,
+                                          prefill_max_length, prefill_log_label);
         }
+
+        auto linear_spec_lora_prefill_module =
+            load_linear_spec_lora_prefill_module(ctx, stream, io, kv_names);
 
         auto state =
             build_inference_state(ctx, sizing, tri_cfg, cache_dtype, kv_dim, kv_names, stream);
@@ -323,13 +315,78 @@ class DecoderPlugin final : public IPipelinePlugin {
         tgc.kv_dim = kv_dim;
         tgc.present_k_pattern = io.present_k_pattern;
         tgc.present_v_pattern = io.present_v_pattern;
+        populate_nemotron_diffusion_config(ctx, tgc);
 
         return std::make_unique<TextGenerationPipeline>(
             std::move(decoders), std::move(state), tgc, stream, std::move(tokenizer),
-            ctx.bundle.info.model_id, nullptr, std::move(prefill_module), tp_runtime.group.owner);
+            ctx.bundle.info.model_id, nullptr, std::move(prefill_module),
+            std::move(linear_spec_lora_prefill_module), tp_runtime.group.owner);
     }
 
   private:
+    static std::unique_ptr<TrtModule>
+    load_split_prefill_module(const PipelineContext& ctx, cudaStream_t stream, const IoMap& io,
+                              const KvCacheNames& kv_names, int32_t& prefill_profile_idx,
+                              int32_t& prefill_max_length, std::string& prefill_log_label) {
+        if (find_section(ctx.bundle, "prefill_engine_plan") == nullptr)
+            return nullptr;
+
+        auto split_prefill_modules =
+            load_decoder_profile_modules(ctx, "prefill_engine_plan", stream, nullptr);
+        if (split_prefill_modules.modules.empty())
+            return nullptr;
+
+        const auto prefill_roles =
+            detect_decoder_profile_roles(*split_prefill_modules.modules.front().module, io.token_id,
+                                         kv_names.cache_k.front(), ctx.config.max_cache_length);
+        prefill_profile_idx = prefill_roles.prefill_profile_idx;
+        prefill_max_length = prefill_roles.prefill_max_length;
+        auto prefill_module = extract_prefill_module(std::move(split_prefill_modules),
+                                                     prefill_roles, "prefill_engine_plan");
+        if (prefill_module)
+            prefill_log_label = "prefill engine";
+        return prefill_module;
+    }
+
+    static std::unique_ptr<TrtModule>
+    load_linear_spec_lora_prefill_module(const PipelineContext& ctx, cudaStream_t stream,
+                                         const IoMap& io, const KvCacheNames& kv_names) {
+        if (ctx.config.runtime_strategy != "nemotron_labs_diffusion")
+            return nullptr;
+
+        const std::string lora_section =
+            extract_json_string(ctx.config_json, "linear_spec_lora_engine_section", "");
+        if (lora_section.empty())
+            return nullptr;
+        if (find_section(ctx.bundle, lora_section) == nullptr) {
+            throw std::runtime_error("Configured linear-spec LoRA engine section is missing: " +
+                                     lora_section);
+        }
+
+        auto lora_modules = load_decoder_profile_modules(ctx, lora_section, stream, nullptr);
+        std::unique_ptr<TrtModule> lora_prefill_module;
+        if (!lora_modules.modules.empty()) {
+            const auto lora_roles =
+                detect_decoder_profile_roles(*lora_modules.modules.front().module, io.token_id,
+                                             kv_names.cache_k.front(), ctx.config.max_cache_length);
+            lora_prefill_module =
+                extract_prefill_module(std::move(lora_modules), lora_roles, lora_section.c_str());
+        }
+        if (!lora_prefill_module) {
+            throw std::runtime_error("Configured linear-spec LoRA engine has no prefill profile: " +
+                                     lora_section);
+        }
+        return lora_prefill_module;
+    }
+
+    static void populate_nemotron_diffusion_config(const PipelineContext& ctx, TextGenConfig& tgc) {
+        if (ctx.config.runtime_strategy != "nemotron_labs_diffusion")
+            return;
+        tgc.mask_token_id = extract_json_int(ctx.config_json, "mask_token_id", 100);
+        tgc.diffusion_block_length = extract_json_int(ctx.config_json, "block_size", 32);
+        tgc.supports_text_diffusion = true;
+    }
+
     static void apply_text_trace_from_registry(const config::ConfigBundle* cfg) {
         if (cfg == nullptr)
             return;
@@ -516,16 +573,22 @@ class DecoderPlugin final : public IPipelinePlugin {
     }
 
     static void apply_chat_template_format(const BundleFile& bundle, TextGenConfig& tgc) {
+        std::string chat_tpl;
         auto* tok_cfg_sec = find_section(bundle, "tokenizer_config.json");
-        if (tok_cfg_sec == nullptr || tok_cfg_sec->empty())
-            return;
-        const std::string tok_cfg_text(tok_cfg_sec->begin(), tok_cfg_sec->end());
-        const std::string chat_tpl = extract_json_string(tok_cfg_text, "chat_template", "");
+        if (tok_cfg_sec != nullptr && !tok_cfg_sec->empty()) {
+            const std::string tok_cfg_text(tok_cfg_sec->begin(), tok_cfg_sec->end());
+            chat_tpl = extract_json_string(tok_cfg_text, "chat_template", "");
+        }
+        if (chat_tpl.empty()) {
+            auto* tpl_sec = find_section(bundle, "chat_template.jinja");
+            if (tpl_sec != nullptr && !tpl_sec->empty())
+                chat_tpl.assign(tpl_sec->begin(), tpl_sec->end());
+        }
         tgc.chat_template_format = detect_chat_template_format(chat_tpl);
     }
 };
 
 REGISTER_PIPELINE_PLUGIN_WITH_MANIFEST(register_decoder_plugin, DecoderPlugin, "decoder_kv_cache",
-                                       "decoder_moe");
+                                       "decoder_moe", "nemotron_labs_diffusion");
 
 } // namespace trtmc

--- a/src/runtime/models/text_generation/plugin.cpp
+++ b/src/runtime/models/text_generation/plugin.cpp
@@ -290,9 +290,11 @@ class DecoderPlugin final : public IPipelinePlugin {
         int32_t prefill_max_length = decode_profile_roles.prefill_max_length;
         std::string prefill_log_label;
         if (!tp_runtime.config.enabled) {
-            prefill_module =
+            auto split_prefill_module =
                 load_split_prefill_module(ctx, stream, io, kv_names, prefill_profile_idx,
                                           prefill_max_length, prefill_log_label);
+            if (split_prefill_module)
+                prefill_module = std::move(split_prefill_module);
         }
 
         auto linear_spec_lora_prefill_module =
@@ -385,6 +387,8 @@ class DecoderPlugin final : public IPipelinePlugin {
         tgc.mask_token_id = extract_json_int(ctx.config_json, "mask_token_id", 100);
         tgc.diffusion_block_length = extract_json_int(ctx.config_json, "block_size", 32);
         tgc.supports_text_diffusion = true;
+        if (tgc.chat_template_format == ChatTemplateFormat::kNone)
+            tgc.chat_template_format = ChatTemplateFormat::kNemotronLabsDiffusion;
     }
 
     static void apply_text_trace_from_registry(const config::ConfigBundle* cfg) {

--- a/src/runtime/plugins/shared/plugin_helpers.cpp
+++ b/src/runtime/plugins/shared/plugin_helpers.cpp
@@ -242,11 +242,17 @@ RecurrentGenConfig make_recurrent_gen_config(const BaseConfig& cfg) {
 }
 
 void apply_recurrent_chat_template_format(const BundleFile& bundle, RecurrentGenConfig& rgc) {
+    std::string chat_tpl;
     auto* tok_cfg_sec = find_section(bundle, "tokenizer_config.json");
-    if (tok_cfg_sec == nullptr || tok_cfg_sec->empty())
-        return;
-    const std::string tok_cfg_text(tok_cfg_sec->begin(), tok_cfg_sec->end());
-    const std::string chat_tpl = extract_json_string(tok_cfg_text, "chat_template", "");
+    if (tok_cfg_sec != nullptr && !tok_cfg_sec->empty()) {
+        const std::string tok_cfg_text(tok_cfg_sec->begin(), tok_cfg_sec->end());
+        chat_tpl = extract_json_string(tok_cfg_text, "chat_template", "");
+    }
+    if (chat_tpl.empty()) {
+        auto* tpl_sec = find_section(bundle, "chat_template.jinja");
+        if (tpl_sec != nullptr && !tpl_sec->empty())
+            chat_tpl.assign(tpl_sec->begin(), tpl_sec->end());
+    }
     rgc.chat_template_format = detect_chat_template_format(chat_tpl);
 }
 

--- a/tensorrt_model_connect/tensorrt_model_connect/checkpoint_mapper.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/checkpoint_mapper.py
@@ -31,8 +31,8 @@ def _target_np_dtype(precision: str) -> np.dtype:
     return np.float32
 
 
-def _layer_key(layer_idx: int, suffix: str) -> str:
-    return f"model.layers.{layer_idx}.{suffix}"
+def _layer_key(layer_idx: int, suffix: str, model_prefix: str = "model") -> str:
+    return f"{model_prefix}.layers.{layer_idx}.{suffix}"
 
 
 def _transpose_2d(arr: np.ndarray, name: str, precision: str = "fp32") -> np.ndarray:
@@ -76,6 +76,10 @@ def load_standard_weights(
     config: ModelConfig,
     *,
     precision: str = "fp32",
+    model_prefix: str = "model",
+    embedding_key: str | None = None,
+    final_norm_key: str | None = None,
+    lm_head_key: str = "lm_head.weight",
 ) -> WeightDict:
     """Load HF safetensors and map to standard weight dict."""
     model_dir = Path(model_dir)
@@ -91,7 +95,9 @@ def load_standard_weights(
     weights = WeightDict()
 
     # Embedding
-    embedding = _load_tensor(readers, "model.embed_tokens.weight")
+    if embedding_key is None:
+        embedding_key = f"{model_prefix}.embed_tokens.weight"
+    embedding = _load_tensor(readers, embedding_key)
     assert embedding.shape == (vocab, hidden), (
         f"Embedding shape {embedding.shape} != ({vocab}, {hidden})")
     weights["embedding"] = embedding.astype(target_dtype)
@@ -102,25 +108,26 @@ def load_standard_weights(
 
         # Norms
         input_norm = _load_tensor(
-            readers, _layer_key(layer_idx, "input_layernorm.weight"))
+            readers, _layer_key(layer_idx, "input_layernorm.weight", model_prefix))
         post_norm = _load_tensor(
-            readers, _layer_key(layer_idx, "post_attention_layernorm.weight"))
+            readers,
+            _layer_key(layer_idx, "post_attention_layernorm.weight", model_prefix))
         layer[f"{prefix}.input_norm"] = input_norm.astype(np.float32)
         layer[f"{prefix}.post_attn_norm"] = post_norm.astype(np.float32)
 
         # Q/K/V/O projections
         q_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "self_attn.q_proj.weight"))
+            readers, _layer_key(layer_idx, "self_attn.q_proj.weight", model_prefix))
         k_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "self_attn.k_proj.weight"))
+            readers, _layer_key(layer_idx, "self_attn.k_proj.weight", model_prefix))
         v_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "self_attn.v_proj.weight"))
+            readers, _layer_key(layer_idx, "self_attn.v_proj.weight", model_prefix))
         o_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "self_attn.o_proj.weight"))
+            readers, _layer_key(layer_idx, "self_attn.o_proj.weight", model_prefix))
 
         q_hidden = q_raw.shape[0]
         gate_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "mlp.gate_proj.weight"))
+            readers, _layer_key(layer_idx, "mlp.gate_proj.weight", model_prefix))
         layer_mlp_size = gate_raw.shape[0]
 
         # Transpose all projections [out, in] -> [in, out]
@@ -135,9 +142,9 @@ def load_standard_weights(
         layer[f"{prefix}.w_o"] = o_t
 
         # Optional QKV biases (Qwen2 style)
-        q_bias_key = _layer_key(layer_idx, "self_attn.q_proj.bias")
-        k_bias_key = _layer_key(layer_idx, "self_attn.k_proj.bias")
-        v_bias_key = _layer_key(layer_idx, "self_attn.v_proj.bias")
+        q_bias_key = _layer_key(layer_idx, "self_attn.q_proj.bias", model_prefix)
+        k_bias_key = _layer_key(layer_idx, "self_attn.k_proj.bias", model_prefix)
+        v_bias_key = _layer_key(layer_idx, "self_attn.v_proj.bias", model_prefix)
         if _has_tensor(readers, q_bias_key):
             layer[f"{prefix}.q_bias"] = _load_tensor(
                 readers, q_bias_key).astype(target_dtype)
@@ -149,8 +156,8 @@ def load_standard_weights(
                 readers, v_bias_key).astype(target_dtype)
 
         # Optional per-head q/k norm (Qwen3 style)
-        q_norm_key = _layer_key(layer_idx, "self_attn.q_norm.weight")
-        k_norm_key = _layer_key(layer_idx, "self_attn.k_norm.weight")
+        q_norm_key = _layer_key(layer_idx, "self_attn.q_norm.weight", model_prefix)
+        k_norm_key = _layer_key(layer_idx, "self_attn.k_norm.weight", model_prefix)
         if _has_tensor(readers, q_norm_key):
             layer[f"{prefix}.q_norm"] = _repeat_head_norm(
                 _load_tensor(readers, q_norm_key).astype(np.float32),
@@ -162,9 +169,9 @@ def load_standard_weights(
 
         # MLP projections
         up_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "mlp.up_proj.weight"))
+            readers, _layer_key(layer_idx, "mlp.up_proj.weight", model_prefix))
         down_raw = _load_tensor(
-            readers, _layer_key(layer_idx, "mlp.down_proj.weight"))
+            readers, _layer_key(layer_idx, "mlp.down_proj.weight", model_prefix))
 
         layer[f"{prefix}.w_gate"] = _transpose_2d(
             gate_raw, "gate_proj", precision=precision)
@@ -199,7 +206,8 @@ def load_standard_weights(
             mlp_size = layer_mlp_size
 
     # Final norm
-    final_norm_key = "model.norm.weight"
+    if final_norm_key is None:
+        final_norm_key = f"{model_prefix}.norm.weight"
     if _has_tensor(readers, final_norm_key):
         weights["final_norm"] = _load_tensor(
             readers, final_norm_key).astype(np.float32)
@@ -207,7 +215,6 @@ def load_standard_weights(
         weights["final_norm"] = np.ones(hidden, dtype=np.float32)
 
     # LM head
-    lm_head_key = "lm_head.weight"
     if _has_tensor(readers, lm_head_key):
         weights["w_out"] = _transpose_2d(
             _load_tensor(readers, lm_head_key), "lm_head", precision=precision)

--- a/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/engine_builder.py
@@ -88,9 +88,11 @@ _HF_ALLOW_PATTERNS = [
     "elf_params.npz",
     "tokenizer.json",
     "tokenizer_config.json",
+    "chat_template.jinja",
     "vocab.json",
     "merges.txt",
     "special_tokens_map.json",
+    "linear_spec_lora/**",
     "*.model",
     "*.spm",
     "*.py",
@@ -690,6 +692,7 @@ def build_bundle(
 
     # 1. Parse config
     config = ModelConfig.from_dir(model_dir_path)
+    config.raw["_model_dir"] = str(model_dir_path)
     config.raw["_decoder_engine_layout"] = decoder_engine_layout
     config.raw["_audio_magpie_max_source_positions"] = audio_magpie_max_source_positions
     print(f"[trtmc build] Model: {config.model_type} "
@@ -1005,6 +1008,8 @@ def build_bundle(
             build_extra_kwargs = {"verbose": verbose}
             if _call_supports_kwarg(build_extra, "precision"):
                 build_extra_kwargs["precision"] = precision
+            if _call_supports_kwarg(build_extra, "quant_ctx"):
+                build_extra_kwargs["quant_ctx"] = quant_ctx
             if _call_supports_kwarg(build_extra, "build_timing"):
                 build_extra_kwargs["build_timing"] = build_timing
             extra_engines = build_extra(
@@ -1160,6 +1165,12 @@ def build_bundle(
             audio_cfg = get_audio_config(config)
             if audio_cfg is not None:
                 cfg_dict.update(audio_cfg)
+        # Inject optional LoRA/adaptor config from plugin.
+        get_lora_config = getattr(plugin, 'get_lora_config', None)
+        if get_lora_config is not None:
+            lora_cfg = get_lora_config(config)
+            if lora_cfg is not None:
+                cfg_dict.update(lora_cfg)
         # Inject generic config overrides from plugin.
         # Build the final dict so overrides appear FIRST in the
         # serialized JSON.  The C++ fast_path_config parser uses
@@ -1187,8 +1198,9 @@ def build_bundle(
     # runtime from the parsed ModelConfig.
     embedded_config_json = False
     for filename in ("config.json", "tokenizer.json", "tokenizer_config.json",
-                     "vocab.json", "merges.txt", "special_tokens_map.json",
-                     "tokenizer.model", "preprocessor_config.json"):
+                     "chat_template.jinja", "vocab.json", "merges.txt",
+                     "special_tokens_map.json", "tokenizer.model",
+                     "preprocessor_config.json"):
         file_path = model_dir_path / filename
         if file_path.exists():
             data = file_path.read_bytes()

--- a/tensorrt_model_connect/tensorrt_model_connect/families/nemotron_labs_diffusion/__init__.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/nemotron_labs_diffusion/__init__.py
@@ -1,0 +1,3 @@
+from .plugin import plugin
+
+__all__ = ["plugin"]

--- a/tensorrt_model_connect/tensorrt_model_connect/families/nemotron_labs_diffusion/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/nemotron_labs_diffusion/plugin.py
@@ -63,7 +63,7 @@ class NemotronLabsDiffusionPlugin:
         quant_ctx=None,
         verbose: bool = False,
     ) -> bytes:
-        if config.raw.get("_decoder_engine_role") == "decode":
+        if config.raw.get("_decoder_engine_role") in (None, "decode"):
             config.raw["_decoder_engine_role"] = "dual_profile"
         config.raw["_decoder_full_logits_output"] = True
         config.raw.setdefault("runtime_strategy", self.runtime_strategy)

--- a/tensorrt_model_connect/tensorrt_model_connect/families/nemotron_labs_diffusion/plugin.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/nemotron_labs_diffusion/plugin.py
@@ -1,0 +1,185 @@
+"""Nemotron Labs Diffusion family plugin.
+
+The HF checkpoint is a dense Ministral-style decoder wrapped as
+``NemotronLabsDiffusionModel``. Its tensors use ``encoder.*`` and
+``diffusion_head.weight`` names, and runtime generation needs full per-position
+logits from the prefill profile for diffusion denoising.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+from safetensors import safe_open
+
+from ...checkpoint_mapper import WeightDict, load_standard_weights
+from ...config import ModelConfig
+
+build_standard_decoder_engine = None
+
+
+def _get_standard_decoder_builder():
+    global build_standard_decoder_engine
+    if build_standard_decoder_engine is None:
+        from ..qwen.standard_decoder_builder import (
+            build_standard_decoder_engine as imported_builder,
+        )
+        build_standard_decoder_engine = imported_builder
+    return build_standard_decoder_engine
+
+
+class NemotronLabsDiffusionPlugin:
+    name = "nemotron_labs_diffusion"
+    runtime_strategy = "nemotron_labs_diffusion"
+    lora_engine_section = "linear_spec_lora_engine_plan"
+
+    def matches(self, model_type: str) -> bool:
+        return model_type.lower() == "nemotron_labs_diffusion"
+
+    def load_weights(
+        self,
+        model_dir: str,
+        config: ModelConfig,
+        *,
+        precision: str = "fp32",
+    ) -> WeightDict:
+        return load_standard_weights(
+            model_dir,
+            config,
+            precision=precision,
+            model_prefix="encoder",
+            lm_head_key="diffusion_head.weight",
+        )
+
+    def build_engine(
+        self,
+        config: ModelConfig,
+        weights: WeightDict,
+        max_cache_length: int,
+        *,
+        precision: str = "fp32",
+        quant_ctx=None,
+        verbose: bool = False,
+    ) -> bytes:
+        if config.raw.get("_decoder_engine_role") == "decode":
+            config.raw["_decoder_engine_role"] = "dual_profile"
+        config.raw["_decoder_full_logits_output"] = True
+        config.raw.setdefault("runtime_strategy", self.runtime_strategy)
+        return _get_standard_decoder_builder()(
+            config,
+            weights,
+            max_cache_length,
+            precision=precision,
+            quant_ctx=quant_ctx,
+            norm_type="rmsnorm",
+            mlp_type="swiglu",
+            position_type="rope",
+            activation="silu",
+            verbose=verbose,
+            full_logits_output=True,
+        )
+
+    def build_extra_engines(
+        self,
+        config: ModelConfig,
+        weights: WeightDict,
+        max_cache_length: int,
+        *,
+        precision: str = "fp32",
+        quant_ctx=None,
+        verbose: bool = False,
+    ) -> dict[str, bytes]:
+        lora_dir = Path(str(config.raw.get("_model_dir", ""))) / "linear_spec_lora"
+        if not lora_dir.is_dir():
+            return {}
+        lora_weights = _merge_linear_spec_lora(weights, config, lora_dir, precision=precision)
+        previous_role = config.raw.get("_decoder_engine_role")
+        previous_full_logits = config.raw.get("_decoder_full_logits_output")
+        config.raw["_decoder_engine_role"] = "dual_profile"
+        config.raw["_decoder_full_logits_output"] = True
+        config.raw.setdefault("runtime_strategy", self.runtime_strategy)
+        try:
+            plan = _get_standard_decoder_builder()(
+                config,
+                lora_weights,
+                max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                norm_type="rmsnorm",
+                mlp_type="swiglu",
+                position_type="rope",
+                activation="silu",
+                verbose=verbose,
+                full_logits_output=True,
+            )
+        finally:
+            if previous_role is None:
+                config.raw.pop("_decoder_engine_role", None)
+            else:
+                config.raw["_decoder_engine_role"] = previous_role
+            if previous_full_logits is None:
+                config.raw.pop("_decoder_full_logits_output", None)
+            else:
+                config.raw["_decoder_full_logits_output"] = previous_full_logits
+        return {self.lora_engine_section: plan}
+
+    def get_lora_config(self, config: ModelConfig) -> dict | None:
+        model_dir = Path(str(config.raw.get("_model_dir", "")))
+        if (model_dir / "linear_spec_lora" / "adapter_config.json").is_file():
+            return {"linear_spec_lora_engine_section": self.lora_engine_section}
+        return None
+
+
+def _target_np_dtype(precision: str) -> np.dtype:
+    return np.float16 if precision in ("fp16", "bf16") else np.float32
+
+
+def _load_lora_config(lora_dir: Path) -> dict:
+    cfg_path = lora_dir / "adapter_config.json"
+    if not cfg_path.is_file():
+        raise FileNotFoundError(f"Missing LoRA adapter config: {cfg_path}")
+    return json.loads(cfg_path.read_text())
+
+
+def _merge_linear_spec_lora(
+    weights: WeightDict,
+    config: ModelConfig,
+    lora_dir: Path,
+    *,
+    precision: str,
+) -> WeightDict:
+    adapter_path = lora_dir / "adapter_model.safetensors"
+    if not adapter_path.is_file():
+        raise FileNotFoundError(f"Missing LoRA adapter weights: {adapter_path}")
+    lora_cfg = _load_lora_config(lora_dir)
+    target_modules = set(lora_cfg.get("target_modules") or [])
+    if target_modules != {"o_proj"}:
+        raise ValueError(
+            "Nemotron Labs Diffusion linear_spec_lora currently supports only "
+            f"target_modules=['o_proj'], got {sorted(target_modules)}")
+    rank = int(lora_cfg.get("r", 0))
+    if rank <= 0:
+        raise ValueError("LoRA rank must be positive")
+    scale = float(lora_cfg.get("lora_alpha", rank)) / float(rank)
+    out_dtype = _target_np_dtype(precision)
+    merged = WeightDict(weights)
+    with safe_open(str(adapter_path), framework="numpy") as reader:
+        for layer_idx in range(config.num_hidden_layers):
+            prefix = f"base_model.model.encoder.layers.{layer_idx}.self_attn.o_proj"
+            a_key = f"{prefix}.lora_A.weight"
+            b_key = f"{prefix}.lora_B.weight"
+            if a_key not in reader.keys() or b_key not in reader.keys():
+                raise KeyError(f"Missing LoRA tensors for layer {layer_idx}: {a_key}, {b_key}")
+            lora_a = reader.get_tensor(a_key).astype(np.float32)
+            lora_b = reader.get_tensor(b_key).astype(np.float32)
+            delta_hf = (lora_b @ lora_a) * scale
+            weight_key = f"layer.{layer_idx}.w_o"
+            merged[weight_key] = (
+                weights[weight_key].astype(np.float32, copy=True) + delta_hf.T
+            ).astype(out_dtype)
+    return merged
+
+
+plugin = NemotronLabsDiffusionPlugin()

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen/dual_profile_decoder_builder.py
@@ -33,6 +33,7 @@ Tensor contract (matches the C++ runtime KvCache naming):
     cache_v_i       fp16/f32 (max_cache, kv_size)    # static
   Outputs
     logits          float32 (1, vocab)               # last-row sliced inside the engine
+                    or (Sq, vocab) for full-logits diffusion builds
     present_k_i     fp16/f32 (-1, kv_size)           # (Sq, kv_size)
     present_v_i     fp16/f32 (-1, kv_size)           # (Sq, kv_size)
 """
@@ -197,6 +198,49 @@ def _supports_config(config: "ModelConfig", weights: "WeightDict") -> None:
         raise NotImplementedError("missing final_norm weight")
 
 
+def _yarn_rope_kwargs(config: "ModelConfig") -> dict | None:
+    """Return YaRN RoPE parameters from HF config dicts when present."""
+    raw = getattr(config, "raw", {}) or {}
+    rope_cfg = raw.get("rope_parameters")
+    if not isinstance(rope_cfg, dict):
+        rope_cfg = raw.get("rope_scaling")
+    if not isinstance(rope_cfg, dict):
+        return None
+    rope_type = str(rope_cfg.get("rope_type", rope_cfg.get("type", ""))).lower()
+    if rope_type != "yarn":
+        return None
+    return {
+        "scaling_factor": float(rope_cfg.get("factor", 1.0)),
+        "original_max_position_embeddings": int(
+            rope_cfg.get("original_max_position_embeddings", config.max_position_embeddings)
+        ),
+        "beta_fast": float(rope_cfg.get("beta_fast", 32.0)),
+        "beta_slow": float(rope_cfg.get("beta_slow", 1.0)),
+    }
+
+
+def _llama4_attention_scale_kwargs(config: "ModelConfig") -> dict | None:
+    """Return Llama-4-style query scale parameters when present."""
+    raw = getattr(config, "raw", {}) or {}
+    rope_cfg = raw.get("rope_parameters")
+    if not isinstance(rope_cfg, dict):
+        rope_cfg = raw.get("rope_scaling")
+    if not isinstance(rope_cfg, dict):
+        return None
+    beta = rope_cfg.get("llama_4_scaling_beta")
+    if beta is None:
+        return None
+    beta = float(beta)
+    if beta == 0.0:
+        return None
+    return {
+        "beta": beta,
+        "original_max_position_embeddings": int(
+            rope_cfg.get("original_max_position_embeddings", config.max_position_embeddings)
+        ),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Main builder.
 # ---------------------------------------------------------------------------
@@ -222,6 +266,7 @@ def build_dual_profile_decoder_engine(
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     profile_mode: str = "dual_profile",
+    full_logits_output: bool = False,
 ) -> bytes:
     """Build a prefill/decode-capable dynamic-Sq decoder engine.
 
@@ -404,21 +449,38 @@ def build_dual_profile_decoder_engine(
     # native IRotaryEmbeddingLayer.
     cos_half_table: trt.ITensor | None = None
     sin_half_table: trt.ITensor | None = None
+    q_position_scale_table: trt.ITensor | None = None
     if position_type == "rope":
         kmax = max_cache_length + max_prefill_length
         graph_ops.validate_native_rope_dim(rotary_embedding_dim)
-        cos_half_np = graph_ops.make_rope_table_half_dim(
-            kmax, head_dim, config.rope_theta, True,
-            partial_rotary_factor, interleaved=interleaved_rope)
-        sin_half_np = graph_ops.make_rope_table_half_dim(
-            kmax, head_dim, config.rope_theta, False,
-            partial_rotary_factor, interleaved=interleaved_rope)
+        yarn_kwargs = _yarn_rope_kwargs(config)
+        if yarn_kwargs is not None:
+            cos_half_np = graph_ops.make_yarn_rope_table_half_dim(
+                kmax, head_dim, config.rope_theta, True,
+                interleaved=interleaved_rope, **yarn_kwargs)
+            sin_half_np = graph_ops.make_yarn_rope_table_half_dim(
+                kmax, head_dim, config.rope_theta, False,
+                interleaved=interleaved_rope, **yarn_kwargs)
+        else:
+            cos_half_np = graph_ops.make_rope_table_half_dim(
+                kmax, head_dim, config.rope_theta, True,
+                partial_rotary_factor, interleaved=interleaved_rope)
+            sin_half_np = graph_ops.make_rope_table_half_dim(
+                kmax, head_dim, config.rope_theta, False,
+                partial_rotary_factor, interleaved=interleaved_rope)
         cos_half_table = _const_in_work_dtype(
             network, cos_half_np.shape, cos_half_np,
             work_np_dtype, work_trt_dtype)
         sin_half_table = _const_in_work_dtype(
             network, sin_half_np.shape, sin_half_np,
             work_np_dtype, work_trt_dtype)
+        llama4_scale_kwargs = _llama4_attention_scale_kwargs(config)
+        if llama4_scale_kwargs is not None:
+            q_scale_np = graph_ops.make_llama4_attention_scale_table(
+                kmax, **llama4_scale_kwargs)
+            q_position_scale_table = _const_in_work_dtype(
+                network, q_scale_np.shape, q_scale_np,
+                work_np_dtype, work_trt_dtype)
 
     # Learned position embedding (GPT-2 / OPT / GPT-Neo / XGLM).
     position_embed_table: trt.ITensor | None = None
@@ -559,6 +621,11 @@ def build_dual_profile_decoder_engine(
                 cos_half_table, sin_half_table, position_id,
                 rotary_embedding_dim, interleaved_rope,
                 sequence_length=None)
+            if q_position_scale_table is not None:
+                q_scale = network.add_gather(q_position_scale_table, position_id, 0).get_output(0)
+                if q_scale.dtype != q.dtype:
+                    q_scale = network.add_cast(q_scale, q.dtype).get_output(0)
+                q = network.add_elementwise(q, q_scale, trt.ElementWiseOperation.PROD).get_output(0)
 
         # Present K / V (this step's raw K / V), shape (Sq, attn_size).
         present_k_outs.append(k)
@@ -637,28 +704,30 @@ def build_dual_profile_decoder_engine(
             weights.get("final_norm_beta"),
             eps_tensor, norm_type, work_np_dtype)
 
-    # Only the LAST prompt token's logits matter for the next-token sample,
-    # so slice hidden_state from (Sq, hidden) to (1, hidden) before the LM
-    # head. This keeps the output contract identical to the single-token
-    # engine (logits shape = (1, vocab)) under both profiles and avoids
-    # computing (Sq - 1) redundant vocab-sized matmul rows during prefill.
-    shape_t = network.add_shape(hidden_state).get_output(0)  # [2] int64
-    one_hidden = graph_ops.add_constant(
-        network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
-    start_sub = network.add_elementwise(
-        shape_t, one_hidden, trt.ElementWiseOperation.SUB)
-    start_t = start_sub.get_output(0)  # [Sq - 1, 0]
-    size_t = graph_ops.add_constant(
-        network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
-    slicer = network.add_slice(hidden_state, start=(0, 0), shape=(0, 0), stride=(1, 1))
-    slicer.set_input(1, start_t)
-    slicer.set_input(2, size_t)
-    last_hidden = slicer.get_output(0)
+    lm_input = hidden_state
+    if not full_logits_output:
+        # Only the LAST prompt token's logits matter for the next-token sample,
+        # so slice hidden_state from (Sq, hidden) to (1, hidden) before the LM
+        # head. This keeps the output contract identical to the single-token
+        # engine (logits shape = (1, vocab)) under both profiles and avoids
+        # computing (Sq - 1) redundant vocab-sized matmul rows during prefill.
+        shape_t = network.add_shape(hidden_state).get_output(0)  # [2] int64
+        one_hidden = graph_ops.add_constant(
+            network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
+        start_sub = network.add_elementwise(
+            shape_t, one_hidden, trt.ElementWiseOperation.SUB)
+        start_t = start_sub.get_output(0)  # [Sq - 1, 0]
+        size_t = graph_ops.add_constant(
+            network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
+        slicer = network.add_slice(hidden_state, start=(0, 0), shape=(0, 0), stride=(1, 1))
+        slicer.set_input(1, start_t)
+        slicer.set_input(2, size_t)
+        lm_input = slicer.get_output(0)
 
     out_vocab = (weights["w_out"].shape[1]
                  if isinstance(weights["w_out"], np.ndarray) else vocab)
     logits = graph_ops.add_matmul_rhs_constant(
-        network, last_hidden, hidden, out_vocab, weights["w_out"],
+        network, lm_input, hidden, out_vocab, weights["w_out"],
         dtype=work_np_dtype)
     lm_bias = weights.get("lm_head_bias")
     if lm_bias is not None:

--- a/tensorrt_model_connect/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
@@ -65,6 +65,7 @@ def build_standard_decoder_engine(
     verbose: bool = False,
     debug_layer_outputs: bool = False,
     hidden_state_output: bool = False,
+    full_logits_output: bool = False,
 ) -> bytes:
     """Build a TRT engine plan (serialized bytes) for a standard decoder.
 
@@ -145,7 +146,12 @@ def build_standard_decoder_engine(
             scale_attn_weights=scale_attn_weights,
             verbose=verbose,
             profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
+            full_logits_output=full_logits_output,
         )
+
+    if full_logits_output:
+        raise NotImplementedError(
+            "full_logits_output requires the dual-profile decoder builder")
 
     attention_size: int = weights.get("_attention_size", config.attention_size)
     mlp_size: int = weights.get("_mlp_size", config.intermediate_size)

--- a/tensorrt_model_connect/tensorrt_model_connect/graph_ops.py
+++ b/tensorrt_model_connect/tensorrt_model_connect/graph_ops.py
@@ -398,6 +398,30 @@ def make_yarn_rope_table_half_dim(
     return table
 
 
+def make_llama4_attention_scale_table(
+    max_cache_length: int,
+    beta: float,
+    original_max_position_embeddings: int,
+) -> np.ndarray:
+    """Build the per-position query scale used by Llama-4-style RoPE.
+
+    HF Nemotron-Labs-Diffusion applies this after RoPE:
+      1 + beta * log(1 + floor(position / original_max_position_embeddings))
+
+    Returns [max_cache_length, 1] so TensorRT can gather by position_id and
+    broadcast the result across the query hidden dimension.
+    """
+    if max_cache_length <= 0:
+        return np.ones((max(max_cache_length, 0), 1), dtype=np.float32)
+    if beta == 0.0 or original_max_position_embeddings <= 0:
+        return np.ones((max_cache_length, 1), dtype=np.float32)
+    positions = np.arange(max_cache_length, dtype=np.float64)
+    scale = 1.0 + float(beta) * np.log1p(
+        np.floor(positions / float(original_max_position_embeddings))
+    )
+    return scale.reshape(max_cache_length, 1).astype(np.float32)
+
+
 def add_layer_norm(
     network: trt.INetworkDefinition,
     inp: trt.ITensor,

--- a/tests/builder/test_family_plugins.py
+++ b/tests/builder/test_family_plugins.py
@@ -256,6 +256,7 @@ class TestNemotronLabsDiffusionPlugin:
         def fake_build(config, weights, max_cache_length, **kwargs):
             captured.update(kwargs)
             captured["runtime_strategy"] = config.raw.get("runtime_strategy")
+            captured["decoder_engine_role"] = config.raw.get("_decoder_engine_role")
             captured["full_logits_raw"] = config.raw.get("_decoder_full_logits_output")
             return b"plan"
 
@@ -263,6 +264,7 @@ class TestNemotronLabsDiffusionPlugin:
         assert plugin.build_engine(cfg, {}, 64, precision="bf16") == b"plan"
         assert captured["full_logits_output"] is True
         assert captured["runtime_strategy"] == "nemotron_labs_diffusion"
+        assert captured["decoder_engine_role"] == "dual_profile"
         assert captured["full_logits_raw"] is True
 
     def test_build_extra_engines_merges_linear_spec_lora(self, tmp_path, monkeypatch):

--- a/tests/builder/test_family_plugins.py
+++ b/tests/builder/test_family_plugins.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import math
+import importlib
 from pathlib import Path
 
 import numpy as np
@@ -179,6 +180,157 @@ class TestQwenPlugin:
         assert shard["_attention_size"] == self.HIDDEN // tp_size
         assert shard["_kv_attention_size"] == self.HIDDEN // tp_size
         assert shard["_mlp_size"] == self.MLP // tp_size
+
+
+# =========================================================================
+# 1b. Nemotron Labs Diffusion — encoder.* checkpoint aliases
+# =========================================================================
+
+class TestNemotronLabsDiffusionPlugin:
+    VOCAB, HIDDEN, LAYERS, HEADS, KV_HEADS, MLP = 32, 16, 2, 4, 2, 32
+
+    @staticmethod
+    def _make_tensors(vocab, hidden, layers, heads, kv_heads, mlp):
+        head_dim = hidden // heads
+        kv_hidden = kv_heads * head_dim
+        t = {}
+        t["encoder.embed_tokens.weight"] = _rand(vocab, hidden)
+        for i in range(layers):
+            p = f"encoder.layers.{i}"
+            t[f"{p}.input_layernorm.weight"] = _rand(hidden)
+            t[f"{p}.post_attention_layernorm.weight"] = _rand(hidden)
+            t[f"{p}.self_attn.q_proj.weight"] = _rand(hidden, hidden)
+            t[f"{p}.self_attn.k_proj.weight"] = _rand(kv_hidden, hidden)
+            t[f"{p}.self_attn.v_proj.weight"] = _rand(kv_hidden, hidden)
+            t[f"{p}.self_attn.o_proj.weight"] = _rand(hidden, hidden)
+            t[f"{p}.mlp.gate_proj.weight"] = _rand(mlp, hidden)
+            t[f"{p}.mlp.up_proj.weight"] = _rand(mlp, hidden)
+            t[f"{p}.mlp.down_proj.weight"] = _rand(hidden, mlp)
+        t["encoder.norm.weight"] = _rand(hidden)
+        t["diffusion_head.weight"] = _rand(vocab, hidden)
+        return t
+
+    def _setup(self, tmp_path):
+        config = {
+            "model_type": "nemotron_labs_diffusion",
+            "architectures": ["NemotronLabsDiffusionModel"],
+            "vocab_size": self.VOCAB,
+            "hidden_size": self.HIDDEN,
+            "intermediate_size": self.MLP,
+            "num_hidden_layers": self.LAYERS,
+            "num_attention_heads": self.HEADS,
+            "num_key_value_heads": self.KV_HEADS,
+            "head_dim": self.HIDDEN // self.HEADS,
+            "mask_token_id": 100,
+            "block_size": 32,
+        }
+        tensors = self._make_tensors(
+            self.VOCAB, self.HIDDEN, self.LAYERS, self.HEADS, self.KV_HEADS, self.MLP)
+        _write_config(tmp_path, config)
+        _write_safetensors(tmp_path, tensors)
+        return tensors
+
+    def test_load_weights_uses_encoder_prefix_and_diffusion_head(self, tmp_path):
+        from tensorrt_model_connect.families.nemotron_labs_diffusion import plugin
+
+        tensors = self._setup(tmp_path)
+        cfg = ModelConfig.from_dir(tmp_path)
+        weights = plugin.load_weights(str(tmp_path), cfg)
+
+        np.testing.assert_allclose(weights["embedding"], tensors["encoder.embed_tokens.weight"])
+        np.testing.assert_allclose(weights["final_norm"], tensors["encoder.norm.weight"])
+        np.testing.assert_allclose(weights["w_out"], tensors["diffusion_head.weight"].T)
+        assert weights["_attention_size"] == self.HIDDEN
+        assert weights["_kv_attention_size"] == self.KV_HEADS * (self.HIDDEN // self.HEADS)
+        assert weights["_mlp_size"] == self.MLP
+
+    def test_build_engine_requests_full_logits_runtime(self, tmp_path, monkeypatch):
+        plugin_mod = importlib.import_module(
+            "tensorrt_model_connect.families.nemotron_labs_diffusion.plugin")
+        from tensorrt_model_connect.families.nemotron_labs_diffusion import plugin
+
+        self._setup(tmp_path)
+        cfg = ModelConfig.from_dir(tmp_path)
+        captured = {}
+
+        def fake_build(config, weights, max_cache_length, **kwargs):
+            captured.update(kwargs)
+            captured["runtime_strategy"] = config.raw.get("runtime_strategy")
+            captured["full_logits_raw"] = config.raw.get("_decoder_full_logits_output")
+            return b"plan"
+
+        monkeypatch.setattr(plugin_mod, "build_standard_decoder_engine", fake_build)
+        assert plugin.build_engine(cfg, {}, 64, precision="bf16") == b"plan"
+        assert captured["full_logits_output"] is True
+        assert captured["runtime_strategy"] == "nemotron_labs_diffusion"
+        assert captured["full_logits_raw"] is True
+
+    def test_build_extra_engines_merges_linear_spec_lora(self, tmp_path, monkeypatch):
+        plugin_mod = importlib.import_module(
+            "tensorrt_model_connect.families.nemotron_labs_diffusion.plugin")
+        from tensorrt_model_connect.families.nemotron_labs_diffusion import plugin
+
+        self._setup(tmp_path)
+        lora_dir = tmp_path / "linear_spec_lora"
+        lora_dir.mkdir()
+        (lora_dir / "adapter_config.json").write_text(json.dumps({
+            "peft_type": "LORA",
+            "target_modules": ["o_proj"],
+            "r": 2,
+            "lora_alpha": 4,
+            "bias": "none",
+            "fan_in_fan_out": False,
+            "inference_mode": True,
+        }))
+
+        adapters = {}
+        expected_deltas = {}
+        for layer_idx in range(self.LAYERS):
+            prefix = f"base_model.model.encoder.layers.{layer_idx}.self_attn.o_proj"
+            lora_a = (
+                np.arange(2 * self.HIDDEN, dtype=np.float32).reshape(2, self.HIDDEN)
+                + layer_idx
+            )
+            lora_b = (
+                np.arange(self.HIDDEN * 2, dtype=np.float32).reshape(self.HIDDEN, 2)
+                + 0.25 + layer_idx
+            )
+            adapters[f"{prefix}.lora_A.weight"] = lora_a
+            adapters[f"{prefix}.lora_B.weight"] = lora_b
+            expected_deltas[layer_idx] = ((lora_b @ lora_a) * 2.0).T
+        save_file(adapters, str(lora_dir / "adapter_model.safetensors"))
+
+        cfg = ModelConfig.from_dir(tmp_path)
+        cfg.raw["_model_dir"] = str(tmp_path)
+        weights = plugin.load_weights(str(tmp_path), cfg)
+        assert plugin.get_lora_config(cfg) == {
+            "linear_spec_lora_engine_section": plugin.lora_engine_section
+        }
+        base_w_o = {i: weights[f"layer.{i}.w_o"].copy() for i in range(self.LAYERS)}
+        captured = {}
+
+        def fake_build(config, merged_weights, max_cache_length, **kwargs):
+            captured["weights"] = merged_weights
+            captured["kwargs"] = kwargs
+            captured["runtime_strategy"] = config.raw.get("runtime_strategy")
+            captured["full_logits_raw"] = config.raw.get("_decoder_full_logits_output")
+            return b"lora-plan"
+
+        monkeypatch.setattr(plugin_mod, "build_standard_decoder_engine", fake_build)
+        extra = plugin.build_extra_engines(cfg, weights, 64, precision="fp32")
+
+        assert extra == {plugin.lora_engine_section: b"lora-plan"}
+        assert captured["kwargs"]["full_logits_output"] is True
+        assert captured["runtime_strategy"] == "nemotron_labs_diffusion"
+        assert captured["full_logits_raw"] is True
+        for layer_idx in range(self.LAYERS):
+            np.testing.assert_allclose(
+                captured["weights"][f"layer.{layer_idx}.w_o"],
+                base_w_o[layer_idx] + expected_deltas[layer_idx],
+                rtol=1e-5,
+                atol=1e-5,
+            )
+            np.testing.assert_allclose(weights[f"layer.{layer_idx}.w_o"], base_w_o[layer_idx])
 
 
 # =========================================================================

--- a/tests/builder/test_graph_ops_extended.py
+++ b/tests/builder/test_graph_ops_extended.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from tests.builder.conftest import requires_trt
+
 try:
     from tensorrt_model_connect import graph_ops
 except (ImportError, ModuleNotFoundError):
@@ -482,10 +484,37 @@ class TestMakeYarnRopeTable:
 
 
 # ===================================================================
-# TRT graph op tests (require TRT + GPU)
+# 4b. make_llama4_attention_scale_table
 # ===================================================================
 
-from tests.builder.conftest import requires_trt
+class TestMakeLlama4AttentionScaleTable:
+    """Tests for the Llama-4-style per-position query scale table."""
+
+    def test_values_match_hf_formula(self):
+        table = graph_ops.make_llama4_attention_scale_table(
+            max_cache_length=10,
+            beta=0.1,
+            original_max_position_embeddings=4,
+        )
+        positions = np.arange(10, dtype=np.float64)
+        expected = 1.0 + 0.1 * np.log1p(np.floor(positions / 4.0))
+        np.testing.assert_allclose(table[:, 0], expected.astype(np.float32), atol=1e-7)
+
+    def test_positions_before_original_window_are_unscaled(self):
+        table = graph_ops.make_llama4_attention_scale_table(
+            max_cache_length=4,
+            beta=0.1,
+            original_max_position_embeddings=4,
+        )
+        np.testing.assert_allclose(table, np.ones((4, 1), dtype=np.float32))
+
+    def test_zero_beta_disables_scaling(self):
+        table = graph_ops.make_llama4_attention_scale_table(
+            max_cache_length=8,
+            beta=0.0,
+            original_max_position_embeddings=4,
+        )
+        np.testing.assert_allclose(table, np.ones((8, 1), dtype=np.float32))
 
 
 # ===================================================================

--- a/tests/builder/test_manifest_validation.py
+++ b/tests/builder/test_manifest_validation.py
@@ -9,6 +9,7 @@ import json
 import os
 import pytest
 import warnings
+from pathlib import Path
 
 # Try to import manifest_loader
 try:
@@ -220,6 +221,33 @@ class TestManifestValidation:
         assert case.execution_profiles["build"] == "chronos"
         assert case.execution_profiles["runtime"] == "custom-runtime"
         assert case.execution_profiles["reference"] == "chronos"
+
+    def test_nemotron_labs_diffusion_manifests_cover_model_card_modes(self):
+        """The 8B model-card generation surfaces should all have nightly cases."""
+        models_dir = Path(__file__).resolve().parents[1] / "e2e" / "models"
+        manifest_paths = [
+            models_dir / "nemotron-labs-diffusion-8b-ar.json",
+            models_dir / "nemotron-labs-diffusion-8b-diffusion.json",
+            models_dir / "nemotron-labs-diffusion-8b-linear-spec.json",
+            models_dir / "nemotron-labs-diffusion-8b.json",
+        ]
+        cases = [load_manifest(path) for path in manifest_paths]
+
+        modes = {case.inputs["generation_mode"] for case in cases}
+        assert modes == {"ar", "diffusion", "linear_spec", "linear_spec_lora"}
+        assert {case.bundle for case in cases} == {"nemotron-labs-diffusion-8b.trtfb"}
+        assert all(case.runtime_strategy == "nemotron_labs_diffusion" for case in cases)
+        assert all(
+            case.reference_family == "nemotron_labs_diffusion_model_card"
+            for case in cases
+        )
+        assert all(case.user_contract == "model_card_generation_parity" for case in cases)
+        assert all(case.metadata["ci_tier"] == "nightly_only" for case in cases)
+        assert all(case.metadata["contract_config"]["enable_thinking"] is False for case in cases)
+        assert all(
+            case.threshold_overrides["canonical_token_agreement_rate"] == 1.0
+            for case in cases
+        )
 
     def test_quantization_block_propagates_to_metadata(self, tmp_path):
         """Quantization manifests should preserve the generic quant block."""

--- a/tests/cpp/test_chat_template.cpp
+++ b/tests/cpp/test_chat_template.cpp
@@ -75,6 +75,16 @@ static void test_detect_nemotron_h() {
     check(fmt == trtmc::ChatTemplateFormat::kNemotronH, "nemotron-h detection");
 }
 
+static void test_detect_nemotron_labs_diffusion() {
+    std::string tpl = "{%- set truncate_history_thinking = truncate_history_thinking if "
+                      "truncate_history_thinking is defined else True %}"
+                      "{%- set enable_thinking = enable_thinking if enable_thinking is defined "
+                      "else False %}";
+    auto fmt = trtmc::detect_chat_template_format(tpl);
+    check(fmt == trtmc::ChatTemplateFormat::kNemotronLabsDiffusion,
+          "nemotron-labs-diffusion detection");
+}
+
 static void test_detect_unknown() {
     auto fmt = trtmc::detect_chat_template_format("some random jinja template");
     check(fmt == trtmc::ChatTemplateFormat::kNone, "unknown -> kNone");
@@ -131,6 +141,14 @@ static void test_apply_nemotron_h_no_thinking() {
           "nemotron-h no-thinking application");
 }
 
+static void test_apply_nemotron_labs_diffusion_no_thinking() {
+    auto result = trtmc::apply_chat_template(trtmc::ChatTemplateFormat::kNemotronLabsDiffusion,
+                                             "hello", false);
+    check(result == "<|im_start|>system\n<|im_end|>\n<|im_start|>user\nhello<|im_end|>\n"
+                    "<|im_start|>assistant\n<think></think>",
+          "nemotron-labs-diffusion no-thinking application");
+}
+
 static void test_apply_mistral_no_thinking_ignored() {
     auto result = trtmc::apply_chat_template(trtmc::ChatTemplateFormat::kMistral, "hello", false);
     check(result == "[INST] hello [/INST]", "mistral no-thinking ignored");
@@ -145,6 +163,7 @@ int main() {
     test_detect_gemma();
     test_detect_llama3();
     test_detect_nemotron_h();
+    test_detect_nemotron_labs_diffusion();
     test_detect_unknown();
 
     // Application
@@ -156,6 +175,7 @@ int main() {
     test_apply_gemma();
     test_apply_llama3();
     test_apply_nemotron_h_no_thinking();
+    test_apply_nemotron_labs_diffusion_no_thinking();
     test_apply_mistral_no_thinking_ignored();
 
     if (failures > 0) {

--- a/tests/cpp/test_cli_args.cpp
+++ b/tests/cpp/test_cli_args.cpp
@@ -73,6 +73,12 @@ void test_run_parses_common_flags() {
                        "hello",
                        "--max-new-tokens",
                        "8",
+                       "--generation-mode",
+                       "diffusion",
+                       "--block-length",
+                       "32",
+                       "--threshold",
+                       "0.9",
                        "--temperature",
                        "0.5",
                        "--top-p",
@@ -95,6 +101,9 @@ void test_run_parses_common_flags() {
     check(args.bundle_path == "bundle.trtfb", "run bundle");
     check(args.prompt == "hello", "run prompt");
     check(args.max_new_tokens == 8, "run max tokens");
+    check(args.generation_mode == "diffusion", "run generation mode");
+    check(args.block_length == 32, "run block length");
+    check(args.conf_threshold > 0.89F && args.conf_threshold < 0.91F, "run threshold");
     check(args.temperature > 0.49F && args.temperature < 0.51F, "run temperature");
     check(args.top_k == 4, "run top_k");
     check(args.seed == 123, "run seed");

--- a/tests/e2e/models/nemotron-labs-diffusion-8b-ar.json
+++ b/tests/e2e/models/nemotron-labs-diffusion-8b-ar.json
@@ -1,0 +1,35 @@
+{
+  "name": "nemotron-labs-diffusion-8b-ar",
+  "trace_id": "IT-E2E-NLD8-AR-01",
+  "hf_id": "nvidia/Nemotron-Labs-Diffusion-8B",
+  "bundle": "nemotron-labs-diffusion-8b.trtfb",
+  "family": "nemotron_labs_diffusion",
+  "runtime_strategy": "nemotron_labs_diffusion",
+  "reference_family": "nemotron_labs_diffusion_model_card",
+  "user_contract": "model_card_generation_parity",
+  "ci_tier": "nightly_only",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "precision": "bf16",
+  "max_cache_length": 640,
+  "prompt": "What is the capital of France? Answer in one word.",
+  "max_new_tokens": 32,
+  "trust_remote_code": true,
+  "inputs": {
+    "generation_mode": "ar",
+    "temperature": 0.0
+  },
+  "metadata": {
+    "contract_config": {
+      "use_chat_template": true,
+      "enable_thinking": false,
+      "token_parity_eos_token_ids": [11],
+      "token_parity_ignore_terminal_token_ids": [1010],
+      "forbidden_token_ids": [0]
+    }
+  },
+  "threshold_overrides": {
+    "canonical_token_agreement_rate": 1.0,
+    "contract_ned_threshold": 0.05
+  },
+  "notes": "Nightly coverage for the upstream model-card ar_generate path."
+}

--- a/tests/e2e/models/nemotron-labs-diffusion-8b-diffusion.json
+++ b/tests/e2e/models/nemotron-labs-diffusion-8b-diffusion.json
@@ -1,0 +1,37 @@
+{
+  "name": "nemotron-labs-diffusion-8b-diffusion",
+  "trace_id": "IT-E2E-NLD8-DIFF-01",
+  "hf_id": "nvidia/Nemotron-Labs-Diffusion-8B",
+  "bundle": "nemotron-labs-diffusion-8b.trtfb",
+  "family": "nemotron_labs_diffusion",
+  "runtime_strategy": "nemotron_labs_diffusion",
+  "reference_family": "nemotron_labs_diffusion_model_card",
+  "user_contract": "model_card_generation_parity",
+  "ci_tier": "nightly_only",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "precision": "bf16",
+  "max_cache_length": 640,
+  "prompt": "What is the capital of France? Answer in one word.",
+  "max_new_tokens": 32,
+  "trust_remote_code": true,
+  "inputs": {
+    "generation_mode": "diffusion",
+    "block_length": 32,
+    "threshold": 0.9,
+    "temperature": 0.0
+  },
+  "metadata": {
+    "contract_config": {
+      "use_chat_template": true,
+      "enable_thinking": false,
+      "token_parity_eos_token_ids": [11],
+      "token_parity_ignore_terminal_token_ids": [1010],
+      "forbidden_token_ids": [0]
+    }
+  },
+  "threshold_overrides": {
+    "canonical_token_agreement_rate": 1.0,
+    "contract_ned_threshold": 0.05
+  },
+  "notes": "Nightly coverage for the upstream model-card diffusion generate path."
+}

--- a/tests/e2e/models/nemotron-labs-diffusion-8b-linear-spec.json
+++ b/tests/e2e/models/nemotron-labs-diffusion-8b-linear-spec.json
@@ -1,0 +1,36 @@
+{
+  "name": "nemotron-labs-diffusion-8b-linear-spec",
+  "trace_id": "IT-E2E-NLD8-LSPEC-01",
+  "hf_id": "nvidia/Nemotron-Labs-Diffusion-8B",
+  "bundle": "nemotron-labs-diffusion-8b.trtfb",
+  "family": "nemotron_labs_diffusion",
+  "runtime_strategy": "nemotron_labs_diffusion",
+  "reference_family": "nemotron_labs_diffusion_model_card",
+  "user_contract": "model_card_generation_parity",
+  "ci_tier": "nightly_only",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "precision": "bf16",
+  "max_cache_length": 640,
+  "prompt": "What is the capital of France? Answer in one word.",
+  "max_new_tokens": 32,
+  "trust_remote_code": true,
+  "inputs": {
+    "generation_mode": "linear_spec",
+    "threshold": 0.9,
+    "temperature": 0.0
+  },
+  "metadata": {
+    "contract_config": {
+      "use_chat_template": true,
+      "enable_thinking": false,
+      "token_parity_eos_token_ids": [11],
+      "token_parity_ignore_terminal_token_ids": [1010],
+      "forbidden_token_ids": [0]
+    }
+  },
+  "threshold_overrides": {
+    "canonical_token_agreement_rate": 1.0,
+    "contract_ned_threshold": 0.05
+  },
+  "notes": "Nightly coverage for the upstream model-card linear_spec_generate path."
+}

--- a/tests/e2e/models/nemotron-labs-diffusion-8b.json
+++ b/tests/e2e/models/nemotron-labs-diffusion-8b.json
@@ -1,0 +1,37 @@
+{
+  "name": "nemotron-labs-diffusion-8b-linear-spec-lora",
+  "trace_id": "IT-E2E-NLD8-01",
+  "hf_id": "nvidia/Nemotron-Labs-Diffusion-8B",
+  "bundle": "nemotron-labs-diffusion-8b.trtfb",
+  "family": "nemotron_labs_diffusion",
+  "runtime_strategy": "nemotron_labs_diffusion",
+  "reference_family": "nemotron_labs_diffusion_model_card",
+  "user_contract": "model_card_generation_parity",
+  "ci_tier": "nightly_only",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "precision": "bf16",
+  "max_cache_length": 640,
+  "prompt": "What is the capital of France? Answer in one word.",
+  "max_new_tokens": 32,
+  "trust_remote_code": true,
+  "inputs": {
+    "generation_mode": "linear_spec_lora",
+    "block_length": 32,
+    "threshold": 0.9,
+    "temperature": 0.0
+  },
+  "metadata": {
+    "contract_config": {
+      "use_chat_template": true,
+      "enable_thinking": false,
+      "token_parity_eos_token_ids": [11],
+      "token_parity_ignore_terminal_token_ids": [1010],
+      "forbidden_token_ids": [0]
+    }
+  },
+  "threshold_overrides": {
+    "canonical_token_agreement_rate": 1.0,
+    "contract_ned_threshold": 0.05
+  },
+  "notes": "Nightly coverage for the upstream LoRA-backed linear speculative model-card path."
+}

--- a/tests/e2e_harness/contracts.py
+++ b/tests/e2e_harness/contracts.py
@@ -86,6 +86,7 @@ class ReferenceFamily(enum.Enum):
     CHAT_QWEN3_POSTTRAINED = "chat_qwen3_posttrained"
     MULTIMODAL_CHAT_QWEN35 = "multimodal_chat_qwen35"
     TRANSLATION_CHAT_TEMPLATE = "translation_chat_template"
+    NEMOTRON_LABS_DIFFUSION_MODEL_CARD = "nemotron_labs_diffusion_model_card"
 
     # --- Seq2seq ---
     SEQ2SEQ_TEXT2TEXT = "seq2seq_text2text"
@@ -216,6 +217,7 @@ class UserContract(enum.Enum):
     DIFFUSION_IMAGE = "diffusion_image"
     DIFFUSION_VIDEO = "diffusion_video"
     DIFFUSION_TEXT_GENERATION = "diffusion_text_generation"
+    MODEL_CARD_GENERATION_PARITY = "model_card_generation_parity"
 
     # --- Time series ---
     TIME_SERIES_POINT_FORECAST = "time_series_point_forecast"
@@ -844,6 +846,17 @@ MODEL_REFERENCE_FAMILY: Dict[str, str] = {
     "chronos-bolt-tiny-official": ReferenceFamily.TIME_SERIES_QUANTILE_FORECAST.value,
     # 5.30 TIME_SERIES_REGRESSION
     "patchtst-etth1-regression-distribution": ReferenceFamily.TIME_SERIES_REGRESSION.value,
+    # 5.31 NEMOTRON_LABS_DIFFUSION_MODEL_CARD
+    "nemotron-labs-diffusion-8b-ar": ReferenceFamily.NEMOTRON_LABS_DIFFUSION_MODEL_CARD.value,
+    "nemotron-labs-diffusion-8b-diffusion": (
+        ReferenceFamily.NEMOTRON_LABS_DIFFUSION_MODEL_CARD.value
+    ),
+    "nemotron-labs-diffusion-8b-linear-spec": (
+        ReferenceFamily.NEMOTRON_LABS_DIFFUSION_MODEL_CARD.value
+    ),
+    "nemotron-labs-diffusion-8b-linear-spec-lora": (
+        ReferenceFamily.NEMOTRON_LABS_DIFFUSION_MODEL_CARD.value
+    ),
 }
 
 # Reference family -> user contract mapping.
@@ -855,6 +868,9 @@ REFERENCE_FAMILY_TO_USER_CONTRACT: Dict[str, str] = {
     ReferenceFamily.CHAT_QWEN3_POSTTRAINED.value: UserContract.CHAT_RESPONSE.value,
     ReferenceFamily.MULTIMODAL_CHAT_QWEN35.value: UserContract.CHAT_RESPONSE.value,
     ReferenceFamily.TRANSLATION_CHAT_TEMPLATE.value: UserContract.TRANSLATION.value,
+    ReferenceFamily.NEMOTRON_LABS_DIFFUSION_MODEL_CARD.value: (
+        UserContract.MODEL_CARD_GENERATION_PARITY.value
+    ),
     ReferenceFamily.SEQ2SEQ_TEXT2TEXT.value: UserContract.SEQ2SEQ_OUTPUT.value,
     ReferenceFamily.SEQ2SEQ_TRANSLATION.value: UserContract.TRANSLATION.value,
     ReferenceFamily.SEQ2SEQ_BASE_WEAK.value: UserContract.CONTINUATION_PARITY.value,
@@ -893,6 +909,7 @@ REFERENCE_FAMILY_TO_COMPARISON_MODE: Dict[str, str] = {
     ReferenceFamily.CHAT_QWEN3_POSTTRAINED.value: ComparisonMode.EXACT_TEXT.value,
     ReferenceFamily.MULTIMODAL_CHAT_QWEN35.value: ComparisonMode.EXACT_TEXT.value,
     ReferenceFamily.TRANSLATION_CHAT_TEMPLATE.value: ComparisonMode.EXACT_TEXT.value,
+    ReferenceFamily.NEMOTRON_LABS_DIFFUSION_MODEL_CARD.value: ComparisonMode.TOKEN_EXACT.value,
     ReferenceFamily.SEQ2SEQ_TEXT2TEXT.value: ComparisonMode.EXACT_TEXT.value,
     ReferenceFamily.SEQ2SEQ_TRANSLATION.value: ComparisonMode.EXACT_TEXT.value,
     ReferenceFamily.SEQ2SEQ_BASE_WEAK.value: ComparisonMode.NUMERIC_TENSOR.value,
@@ -928,6 +945,7 @@ RUNTIME_TO_TASK_STRATEGY: Dict[str, str] = {
     "ssm_recurrent": "text_generation_causal",
     "rwkv_recurrent": "text_generation_causal",
     "hybrid_mamba_attention": "text_generation_causal",
+    "nemotron_labs_diffusion": "text_generation_causal",
     "vision_language": "vision_language_generation",
     "speech_to_text": "speech_to_text",
     "speech_to_text_rnnt": "speech_to_text",

--- a/tests/e2e_harness/manifest_loader.py
+++ b/tests/e2e_harness/manifest_loader.py
@@ -521,6 +521,7 @@ def _convert_skip_to_known_limitation(manifest: dict) -> dict | None:
 _KNOWN_RUNTIME_STRATEGIES = frozenset({
     "decoder_kv_cache",
     "decoder_moe",
+    "nemotron_labs_diffusion",
     "ssm_recurrent",
     "rwkv_recurrent",
     "hybrid_mamba_attention",

--- a/tests/e2e_harness/plugins/nemotron_labs_diffusion.py
+++ b/tests/e2e_harness/plugins/nemotron_labs_diffusion.py
@@ -1,0 +1,168 @@
+"""Contract plugin for Nemotron Labs Diffusion model-card generation modes."""
+
+from __future__ import annotations
+
+from ..contracts import MetricResult
+from .base import levenshtein_ned, make_fail, make_pass, normalize_text
+
+
+class NemotronLabsDiffusionPlugin:
+    reference_families = ["nemotron_labs_diffusion_model_card"]
+    user_contract = "model_card_generation_parity"
+
+    def configure_reference(self, case):
+        existing = case.metadata.get("contract_config", {})
+        return {
+            "use_chat_template": existing.get("use_chat_template", True),
+            "enable_thinking": existing.get("enable_thinking", False),
+            "token_parity_eos_token_ids": existing.get("token_parity_eos_token_ids", [11]),
+            "token_parity_ignore_terminal_token_ids": existing.get(
+                "token_parity_ignore_terminal_token_ids", [1010]
+            ),
+            "forbidden_token_ids": existing.get("forbidden_token_ids", [0]),
+        }
+
+    def verify(self, trt_output, ref_output, case, threshold):
+        trt_tokens = _token_ids(trt_output)
+        ref_tokens = _token_ids(ref_output)
+        if not trt_tokens:
+            return make_fail("full_generation", {}, message="TRT produced no generated token IDs")
+        if not ref_tokens:
+            return make_fail("full_generation", {}, message="HF reference produced no token IDs")
+
+        eos_ids = _int_set(
+            trt_output.data.get("token_parity_eos_token_ids")
+            or case.metadata.get("contract_config", {}).get("token_parity_eos_token_ids")
+            or [ref_output.data.get("eos_token_id")]
+        )
+        ignored_terminal_ids = _int_set(
+            trt_output.data.get("token_parity_ignore_terminal_token_ids")
+            or case.metadata.get("contract_config", {}).get(
+                "token_parity_ignore_terminal_token_ids", []
+            )
+        )
+        forbidden_ids = _int_set(
+            trt_output.data.get("forbidden_token_ids")
+            or case.metadata.get("contract_config", {}).get("forbidden_token_ids", [])
+        )
+
+        raw_exact = trt_tokens == ref_tokens
+        canonical_trt = _canonical_terminal_tokens(trt_tokens, eos_ids, ignored_terminal_ids)
+        canonical_ref = _canonical_terminal_tokens(ref_tokens, eos_ids, ignored_terminal_ids)
+        canonical_exact = canonical_trt == canonical_ref
+        raw_agreement = _position_agreement(trt_tokens, ref_tokens)
+        canonical_agreement = _position_agreement(canonical_trt, canonical_ref)
+        forbidden_hits = sorted(set(trt_tokens) & forbidden_ids)
+
+        trt_text = normalize_text(trt_output.text or "")
+        ref_text = normalize_text(ref_output.text or "")
+        text_ned = levenshtein_ned(trt_text, ref_text)
+
+        text_threshold = threshold.metrics.get("contract_ned_threshold", 0.05)
+        canonical_threshold = threshold.metrics.get("canonical_token_agreement_rate", 1.0)
+        metrics = {
+            "generated_token_raw_exact": MetricResult(
+                value=1.0 if raw_exact else 0.0,
+                threshold=None,
+                operator="",
+                passed=True,
+                note="informational before terminal-whitespace normalization",
+            ),
+            "generated_token_raw_agreement_rate": MetricResult(
+                value=raw_agreement,
+                threshold=None,
+                operator="",
+                passed=True,
+                note="informational before terminal-whitespace normalization",
+            ),
+            "generated_token_canonical_exact": MetricResult(
+                value=1.0 if canonical_exact else 0.0,
+                threshold=1.0,
+                operator="==",
+                passed=canonical_exact,
+                note=(
+                    "terminal ignored token ids="
+                    f"{sorted(ignored_terminal_ids)} before eos ids={sorted(eos_ids)}"
+                ),
+            ),
+            "generated_token_canonical_agreement_rate": MetricResult(
+                value=canonical_agreement,
+                threshold=canonical_threshold,
+                operator=">=",
+                passed=canonical_agreement >= canonical_threshold,
+            ),
+            "forbidden_token_count": MetricResult(
+                value=float(len(forbidden_hits)),
+                threshold=0.0,
+                operator="==",
+                passed=not forbidden_hits,
+                note=f"forbidden ids present: {forbidden_hits}" if forbidden_hits else "",
+            ),
+            "normalized_text_edit_distance": MetricResult(
+                value=text_ned,
+                threshold=text_threshold,
+                operator="<=",
+                passed=text_ned <= text_threshold,
+            ),
+        }
+
+        passed = (
+            canonical_exact
+            and canonical_agreement >= canonical_threshold
+            and not forbidden_hits
+            and text_ned <= text_threshold
+        )
+        rule = (
+            "canonical token IDs exact after terminal-whitespace normalization "
+            "AND no forbidden token IDs AND text NED <= threshold"
+        )
+        if passed:
+            return make_pass("full_generation", metrics, rule)
+        return make_fail(
+            "full_generation",
+            metrics,
+            rule,
+            "Nemotron Labs Diffusion model-card token parity failed",
+        )
+
+
+def _token_ids(output) -> list[int]:
+    value = (output.data or {}).get("token_ids", [])
+    if not isinstance(value, list):
+        return []
+    return [int(token) for token in value]
+
+
+def _int_set(values) -> set[int]:
+    if values is None:
+        return set()
+    if not isinstance(values, (list, tuple, set)):
+        values = [values]
+    return {int(value) for value in values if value is not None}
+
+
+def _canonical_terminal_tokens(
+    token_ids: list[int],
+    eos_ids: set[int],
+    ignored_terminal_ids: set[int],
+) -> list[int]:
+    out = list(token_ids)
+    if not out or not eos_ids or out[-1] not in eos_ids:
+        return out
+    eos = out.pop()
+    while out and out[-1] in ignored_terminal_ids:
+        out.pop()
+    out.append(eos)
+    return out
+
+
+def _position_agreement(lhs: list[int], rhs: list[int]) -> float:
+    denom = max(len(lhs), len(rhs))
+    if denom == 0:
+        return 1.0
+    common = min(len(lhs), len(rhs))
+    matches = sum(1 for idx in range(common) if lhs[idx] == rhs[idx])
+    return matches / denom
+
+
+plugin = NemotronLabsDiffusionPlugin()

--- a/tests/e2e_harness/references/hf_transformers.py
+++ b/tests/e2e_harness/references/hf_transformers.py
@@ -507,9 +507,14 @@ class HfTransformersReference:
             generation_model = model
             if generation_mode == "linear_spec_lora":
                 from peft import PeftModel
-                model = PeftModel.from_pretrained(
-                    model, model_ref, subfolder="linear_spec_lora",
-                    adapter_name="linear_spec_lora")
+                adapter_path = Path(model_ref) / "linear_spec_lora"
+                if adapter_path.is_dir():
+                    model = PeftModel.from_pretrained(
+                        model, str(adapter_path), adapter_name="linear_spec_lora")
+                else:
+                    model = PeftModel.from_pretrained(
+                        model, hf_id, subfolder="linear_spec_lora",
+                        adapter_name="linear_spec_lora")
                 generation_model = model.model
             model.to(device)
             model.eval()

--- a/tests/e2e_harness/references/hf_transformers.py
+++ b/tests/e2e_harness/references/hf_transformers.py
@@ -42,6 +42,27 @@ _NEMOTRON_LABS_DIFFUSION_MODES = {
     "linear_speculation_lora": "linear_spec_lora",
 }
 
+_NEMOTRON_LABS_DIFFUSION_FALLBACK_CHAT_TEMPLATE = (
+    "{%- set enable_thinking = enable_thinking if enable_thinking is defined else False -%}"
+    "{%- if messages[0]['role'] == 'system' -%}"
+    "{{ '<|im_start|>system\\n' + messages[0]['content'] + '<|im_end|>\\n' }}"
+    "{%- set loop_messages = messages[1:] -%}"
+    "{%- else -%}"
+    "{{ '<|im_start|>system\\n<|im_end|>\\n' }}"
+    "{%- set loop_messages = messages -%}"
+    "{%- endif -%}"
+    "{%- for message in loop_messages -%}"
+    "{{ '<|im_start|>' + message['role'] + '\\n' + message['content'] + '<|im_end|>\\n' }}"
+    "{%- endfor -%}"
+    "{%- if add_generation_prompt -%}"
+    "{%- if enable_thinking -%}"
+    "{{ '<|im_start|>assistant\\n<think>\\n' }}"
+    "{%- else -%}"
+    "{{ '<|im_start|>assistant\\n<think></think>' }}"
+    "{%- endif -%}"
+    "{%- endif -%}"
+)
+
 
 def _torch_dtype_for_case(case: E2ECase) -> str:
     """Return a torch dtype expression string matching the manifest precision.
@@ -402,6 +423,7 @@ class HfTransformersReference:
         contract_config = case.metadata.get("contract_config", {})
         use_chat_template = contract_config.get("use_chat_template", False)
         enable_thinking = contract_config.get("enable_thinking", True)
+        fallback_chat_template = _NEMOTRON_LABS_DIFFUSION_FALLBACK_CHAT_TEMPLATE
 
         script = textwrap.dedent(f"""\
             import inspect, json, torch
@@ -421,6 +443,7 @@ class HfTransformersReference:
             tokens_path = {tokens_path!r}
             use_chat_template = {use_chat_template!r}
             enable_thinking = {enable_thinking!r}
+            fallback_chat_template = {fallback_chat_template!r}
 
             def _call_supported(fn, input_ids, **kwargs):
                 sig = inspect.signature(fn)
@@ -468,6 +491,9 @@ class HfTransformersReference:
                 template_path = Path(model_ref) / "chat_template.jinja"
                 if getattr(tokenizer, "chat_template", None) is None and template_path.is_file():
                     chat_kwargs["chat_template"] = template_path.read_text(encoding="utf-8")
+                if (getattr(tokenizer, "chat_template", None) is None
+                        and "chat_template" not in chat_kwargs):
+                    chat_kwargs["chat_template"] = fallback_chat_template
                 text_input = tokenizer.apply_chat_template(
                     messages, tokenize=False, **chat_kwargs)
                 input_ids = tokenizer.encode(text_input, add_special_tokens=False)

--- a/tests/e2e_harness/references/hf_transformers.py
+++ b/tests/e2e_harness/references/hf_transformers.py
@@ -28,6 +28,20 @@ _PRECISION_TO_TORCH_DTYPE = {
     "bf16": "torch.bfloat16",
 }
 
+_NEMOTRON_LABS_DIFFUSION_MODES = {
+    "": "diffusion",
+    "auto": "diffusion",
+    "diffusion": "diffusion",
+    "dlm": "diffusion",
+    "ar": "ar",
+    "autoregressive": "ar",
+    "linear_spec": "linear_spec",
+    "linear_speculation": "linear_spec",
+    "linear_spec_lora": "linear_spec_lora",
+    "linear_spec_adapter": "linear_spec_lora",
+    "linear_speculation_lora": "linear_spec_lora",
+}
+
 
 def _torch_dtype_for_case(case: E2ECase) -> str:
     """Return a torch dtype expression string matching the manifest precision.
@@ -133,6 +147,11 @@ def _resolve_cached_model_ref(hf_id: str) -> str:
         return hf_id
 
 
+def _normalize_nemotron_labs_diffusion_mode(mode: object) -> str:
+    normalized = str(mode or "").strip().lower().replace("-", "_")
+    return _NEMOTRON_LABS_DIFFUSION_MODES.get(normalized, normalized)
+
+
 class HfTransformersReference:
     """Run HuggingFace Transformers inference as the reference oracle."""
 
@@ -173,6 +192,8 @@ class HfTransformersReference:
             return self._run_vl_full_generation(case, stage, ctx)
         if task == "speech_to_text":
             return self._run_speech_to_text_ref(case, stage, ctx)
+        if case.runtime_strategy == "nemotron_labs_diffusion":
+            return self._run_nemotron_labs_diffusion_generation(case, stage, ctx)
 
         artifacts_dir = ctx.artifacts_dir or tempfile.gettempdir()
         model_dir = _case_artifact_dir(artifacts_dir, case.name) if ctx.artifacts_dir else artifacts_dir
@@ -342,6 +363,255 @@ class HfTransformersReference:
             logits=logits_path if Path(logits_path).is_file() else None,
             timing_s=elapsed,
             metadata=meta,
+        )
+
+    def _run_nemotron_labs_diffusion_generation(
+        self, case: E2ECase, stage: StageSpec, ctx: RunContext
+    ) -> StageOutput:
+        """Run the upstream Nemotron Labs Diffusion generation APIs.
+
+        This family registers ``AutoModel`` with custom ``ar_generate``,
+        diffusion ``generate``, and ``linear_spec_generate`` methods.  The
+        generic causal reference path uses ``AutoModelForCausalLM`` plus
+        stepwise logits, which does not represent the model-card surface.
+        """
+        artifacts_dir = ctx.artifacts_dir or tempfile.gettempdir()
+        model_dir = (
+            _case_artifact_dir(artifacts_dir, case.name)
+            if ctx.artifacts_dir
+            else artifacts_dir
+        )
+        text_path = str(Path(model_dir) / "hf_text.txt")
+        tokens_path = str(Path(model_dir) / "hf_tokens.json")
+
+        prompt = case.inputs.get("prompt", "The capital of France is")
+        max_new_tokens = int(case.inputs.get("max_new_tokens", 30))
+        generation_mode = _normalize_nemotron_labs_diffusion_mode(
+            case.inputs.get("generation_mode", "auto")
+        )
+        block_length = int(case.inputs.get("block_length", 32))
+        threshold = float(
+            case.inputs.get("threshold", case.inputs.get("score_threshold", 0.9))
+        )
+        temperature = float(case.inputs.get("temperature", 0.0))
+        trust_remote_code = bool(case.metadata.get("trust_remote_code", True))
+        hf_id = case.hf_id
+        model_ref = _resolve_cached_model_ref(hf_id)
+        torch_dtype_expr = _torch_dtype_for_case(case)
+
+        contract_config = case.metadata.get("contract_config", {})
+        use_chat_template = contract_config.get("use_chat_template", False)
+        enable_thinking = contract_config.get("enable_thinking", True)
+
+        script = textwrap.dedent(f"""\
+            import inspect, json, torch
+            from pathlib import Path
+            from transformers import AutoModel, AutoTokenizer
+
+            hf_id = {hf_id!r}
+            model_ref = {model_ref!r}
+            prompt = {prompt!r}
+            max_new_tokens = {max_new_tokens}
+            generation_mode = {generation_mode!r}
+            block_length = {block_length}
+            threshold = {threshold}
+            temperature = {temperature}
+            trust_remote_code = {trust_remote_code!r}
+            text_path = {text_path!r}
+            tokens_path = {tokens_path!r}
+            use_chat_template = {use_chat_template!r}
+            enable_thinking = {enable_thinking!r}
+
+            def _call_supported(fn, input_ids, **kwargs):
+                sig = inspect.signature(fn)
+                accepts_kwargs = any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD
+                    for p in sig.parameters.values()
+                )
+                filtered_kwargs = (
+                    kwargs if accepts_kwargs
+                    else {{k: v for k, v in kwargs.items()
+                           if k in sig.parameters}}
+                )
+                if "input_ids" in sig.parameters or accepts_kwargs:
+                    try:
+                        return fn(input_ids=input_ids, **filtered_kwargs)
+                    except TypeError as exc:
+                        if "input_ids" not in str(exc):
+                            raise
+                # The model-card APIs take token IDs as the first positional
+                # argument in some upstream revisions.
+                return fn(input_ids, **filtered_kwargs)
+
+            def _as_token_list(output):
+                if hasattr(output, "sequences"):
+                    output = output.sequences
+                if isinstance(output, (tuple, list)) and output:
+                    output = output[0]
+                if isinstance(output, torch.Tensor):
+                    if output.ndim == 2:
+                        output = output[0]
+                    return [int(x) for x in output.detach().cpu().tolist()]
+                return [int(x) for x in output]
+
+            import transformers.utils.generic as _tf_generic
+            if not hasattr(_tf_generic, "check_model_inputs"):
+                _tf_generic.check_model_inputs = lambda fn: fn
+
+            tokenizer = AutoTokenizer.from_pretrained(
+                model_ref, trust_remote_code=trust_remote_code)
+            if use_chat_template:
+                messages = [{{"role": "user", "content": prompt}}]
+                chat_kwargs = {{"add_generation_prompt": True}}
+                if not enable_thinking:
+                    chat_kwargs["enable_thinking"] = False
+                template_path = Path(model_ref) / "chat_template.jinja"
+                if getattr(tokenizer, "chat_template", None) is None and template_path.is_file():
+                    chat_kwargs["chat_template"] = template_path.read_text(encoding="utf-8")
+                text_input = tokenizer.apply_chat_template(
+                    messages, tokenize=False, **chat_kwargs)
+                input_ids = tokenizer.encode(text_input, add_special_tokens=False)
+            else:
+                input_ids = tokenizer.encode(prompt)
+
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            model = AutoModel.from_pretrained(
+                model_ref, trust_remote_code=trust_remote_code,
+                torch_dtype={torch_dtype_expr})
+            generation_model = model
+            if generation_mode == "linear_spec_lora":
+                from peft import PeftModel
+                model = PeftModel.from_pretrained(
+                    model, model_ref, subfolder="linear_spec_lora",
+                    adapter_name="linear_spec_lora")
+                generation_model = model.model
+            model.to(device)
+            model.eval()
+
+            ids_tensor = torch.tensor(
+                [input_ids], dtype=torch.long, device=device)
+            eos_id = getattr(tokenizer, "eos_token_id", None)
+            common_kwargs = {{
+                "max_new_tokens": max_new_tokens,
+                "temperature": temperature,
+                "eos_token_id": eos_id,
+            }}
+
+            with torch.no_grad():
+                if generation_mode == "ar":
+                    output = _call_supported(
+                        generation_model.ar_generate,
+                        ids_tensor,
+                        **common_kwargs,
+                    )
+                elif generation_mode == "diffusion":
+                    output = _call_supported(
+                        generation_model.generate,
+                        ids_tensor,
+                        **common_kwargs,
+                        block_length=block_length,
+                        threshold=threshold,
+                    )
+                elif generation_mode in {{"linear_spec", "linear_spec_lora"}}:
+                    output = _call_supported(
+                        generation_model.linear_spec_generate,
+                        ids_tensor,
+                        **common_kwargs,
+                        block_length=block_length,
+                        threshold=threshold,
+                    )
+                else:
+                    raise ValueError(
+                        f"Unsupported generation_mode={{generation_mode!r}}")
+
+            output_ids = _as_token_list(output)
+            if output_ids[:len(input_ids)] == input_ids:
+                generated_ids = output_ids[len(input_ids):]
+            else:
+                generated_ids = output_ids
+            text = tokenizer.decode(
+                generated_ids, skip_special_tokens=True).strip()
+            with open(text_path, "w", encoding="utf-8") as f:
+                f.write(text)
+            with open(tokens_path, "w", encoding="utf-8") as f:
+                json.dump({{
+                    "token_ids": generated_ids,
+                    "eos_token_id": eos_id,
+                }}, f)
+            print(f"OK mode={{generation_mode}} tokens={{len(generated_ids)}}")
+        """)
+
+        python = ctx.reference_python_path() or sys.executable
+        env = dict(os.environ)
+        if ctx.ld_library_path:
+            env["LD_LIBRARY_PATH"] = ctx.ld_library_path
+        logger.info(
+            "HF reference: running %s with Nemotron Labs Diffusion %s mode",
+            case.name,
+            generation_mode,
+        )
+        t0 = time.monotonic()
+        try:
+            result = subprocess.run(
+                [python, "-c", script],
+                capture_output=True, text=True, timeout=1800,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            elapsed = time.monotonic() - t0
+            raise RuntimeError(
+                f"HF reference timed out for {case.name} after {elapsed:.0f}s"
+            )
+        except Exception as e:
+            raise RuntimeError(f"HF reference failed for {case.name}: {e}") from e
+        elapsed = time.monotonic() - t0
+
+        if result.returncode != 0:
+            truncated, log_path = save_full_stderr(
+                result.stderr,
+                ctx.artifacts_dir or "",
+                "hf_nemotron_labs_diffusion",
+                case.name,
+            )
+            msg = (
+                f"HF reference failed for {case.name} "
+                f"(rc={result.returncode}):\n{truncated}"
+            )
+            if log_path:
+                msg += f" (full stderr: {log_path})"
+            raise RuntimeError(msg)
+
+        text = ""
+        if Path(text_path).is_file():
+            text = Path(text_path).read_text(encoding="utf-8")
+        token_ids = []
+        eos_token_id = None
+        if Path(tokens_path).is_file():
+            token_payload = json.loads(Path(tokens_path).read_text(encoding="utf-8"))
+            raw_token_ids = token_payload.get("token_ids", [])
+            if isinstance(raw_token_ids, list):
+                token_ids = [int(token) for token in raw_token_ids]
+            if token_payload.get("eos_token_id") is not None:
+                eos_token_id = int(token_payload["eos_token_id"])
+
+        return StageOutput(
+            stage_name=stage.name,
+            data={
+                "generation_mode": generation_mode,
+                "text_path": text_path if Path(text_path).is_file() else "",
+                "tokens_path": tokens_path if Path(tokens_path).is_file() else "",
+                "token_ids": token_ids,
+                "eos_token_id": eos_token_id,
+            },
+            text=text,
+            timing_s=elapsed,
+            metadata={
+                "returncode": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "trust_remote_code": trust_remote_code,
+                "generation_mode": generation_mode,
+            },
         )
 
 

--- a/tests/e2e_harness/runners/text_generation.py
+++ b/tests/e2e_harness/runners/text_generation.py
@@ -89,6 +89,25 @@ def _safe_artifact_name(name: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]+", "_", name or "case")
 
 
+def _read_text_generation_sample(path: Path) -> dict:
+    """Read the first JSONL text-generation sample written by the C++ CLI."""
+    if not path.is_file():
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            sample = json.loads(line)
+            if not isinstance(sample, dict):
+                return {}
+            token_ids = sample.get("token_ids")
+            if isinstance(token_ids, list):
+                sample["token_ids"] = [int(token) for token in token_ids]
+            return sample
+    return {}
+
+
 def _ensure_distributed_runtime_env(
     case: E2ECase,
     ctx: RunContext,
@@ -335,7 +354,7 @@ class TextGenerationCausalRunner:
         bundle_path = str(Path(ctx.engine_dir) / case.bundle)
         prompt = case.inputs.get("prompt", "The capital of France is")
         max_new_tokens = case.inputs.get("max_new_tokens", 30)
-        has_contract = "contract_config" in case.metadata
+        has_contract = bool(case.reference_family and case.user_contract)
         is_acceptance = case.ci_lane == "acceptance"
 
         use_single_process_debug = bool(
@@ -394,6 +413,19 @@ class TextGenerationCausalRunner:
         }
         if cpp_meta.get("runtime_error_detected"):
             data["cpp_runtime_error"] = cpp_meta["runtime_error_detected"]
+        if cpp_meta.get("token_ids") is not None:
+            data["token_ids"] = cpp_meta["token_ids"]
+        if cpp_meta.get("text_output_path"):
+            data["text_output_path"] = cpp_meta["text_output_path"]
+        contract_config = case.metadata.get("contract_config", {})
+        if "token_parity_ignore_terminal_token_ids" in contract_config:
+            data["token_parity_ignore_terminal_token_ids"] = (
+                contract_config["token_parity_ignore_terminal_token_ids"]
+            )
+        if "token_parity_eos_token_ids" in contract_config:
+            data["token_parity_eos_token_ids"] = contract_config["token_parity_eos_token_ids"]
+        if "forbidden_token_ids" in contract_config:
+            data["forbidden_token_ids"] = contract_config["forbidden_token_ids"]
         if logits_path:
             data["logits_path"] = logits_path
 
@@ -486,6 +518,16 @@ class TextGenerationCausalRunner:
             "--prompt", prompt,
             "--max-new-tokens", str(max_new_tokens),
         ]
+        output_jsonl_path: Path | None = None
+        if case is not None and not _distributed_runtime_config(case):
+            output_root = (
+                Path(_case_artifact_dir(ctx.artifacts_dir, case.name))
+                if ctx.artifacts_dir
+                else Path(tempfile.gettempdir())
+            )
+            output_root.mkdir(parents=True, exist_ok=True)
+            output_jsonl_path = output_root / "trt_text_generation.jsonl"
+            cmd.extend(["-o", str(output_jsonl_path)])
         runtime_cli_python = ctx.runtime_cli_hf_python()
         if runtime_cli_python:
             cmd.extend(["--hf-python", runtime_cli_python])
@@ -500,6 +542,12 @@ class TextGenerationCausalRunner:
                 cmd.extend(["--top-k", str(inputs["top_k"])])
             if inputs.get("seed", -1) >= 0:
                 cmd.extend(["--seed", str(inputs["seed"])])
+            if inputs.get("generation_mode"):
+                cmd.extend(["--generation-mode", str(inputs["generation_mode"])])
+            if inputs.get("block_length", 0):
+                cmd.extend(["--block-length", str(inputs["block_length"])])
+            if inputs.get("threshold") is not None:
+                cmd.extend(["--threshold", str(inputs["threshold"])])
 
         if case is not None:
             contract_config = case.metadata.get("contract_config", {})
@@ -571,6 +619,15 @@ class TextGenerationCausalRunner:
                 meta["stderr_log"] = log_path
 
         text = _extract_rank_zero_stdout(result.stdout) if distributed_runtime else result.stdout.strip()
+        if output_jsonl_path is not None:
+            sample = _read_text_generation_sample(output_jsonl_path)
+            if sample:
+                meta["text_output_path"] = str(output_jsonl_path)
+                if isinstance(sample.get("generated"), str):
+                    text = sample["generated"]
+                    meta["generated"] = text
+                if isinstance(sample.get("token_ids"), list):
+                    meta["token_ids"] = sample["token_ids"]
         return text, elapsed, meta
 
     def _run_debug_runner_logits(

--- a/tests/runtime_strategy_matrix.yaml
+++ b/tests/runtime_strategy_matrix.yaml
@@ -14,6 +14,14 @@
       "comparator_class": "tests.e2e_harness.comparators.text.TextComparator",
       "diff_framework_check_classes": ["LayerDiffTest", "LogitDiffTest", "PerfBenchmarkTest", "RunnerParityTest"]
     },
+    "nemotron_labs_diffusion": {
+      "task_strategy": "text_generation_causal",
+      "cli_commands": ["run"],
+      "runner_class": "tests.e2e_harness.runners.text_generation.TextGenerationCausalRunner",
+      "comparator_class": "tests.e2e_harness.comparators.text.TextComparator",
+      "diff_framework_check_classes": [],
+      "diff_framework_exemption": "Hybrid AR/diffusion decoding uses model-card generation methods not yet represented by the generic layer/logit diff framework."
+    },
     "diffusion": {
       "task_strategy": "diffusion_media_generation",
       "cli_commands": ["generate-video"],

--- a/tests/tools/test_e2e_runner_cli_alignment.py
+++ b/tests/tools/test_e2e_runner_cli_alignment.py
@@ -17,6 +17,7 @@ from tests.e2e_harness.runners import (
     object_detection,
     omni,
     segmentation,
+    text_generation,
 )
 
 
@@ -214,6 +215,50 @@ def test_omni_runner_vision_stage_maps_to_embed_without_stage_flag(monkeypatch, 
     assert "--stage" not in cmd
     assert out.metadata["entrypoint"] == "embed"
     assert out.data["embedding"] == [0.1, 0.2]
+
+
+def test_text_generation_runner_maps_diffusion_mode_flags(monkeypatch, tmp_path):
+    case = _make_case(
+        "text_generation_causal",
+        inputs={
+            "prompt": "hello",
+            "max_new_tokens": 32,
+            "generation_mode": "diffusion",
+            "block_length": 32,
+            "threshold": 0.9,
+        },
+        family="nemotron_labs_diffusion",
+        runtime_strategy="nemotron_labs_diffusion",
+        ci_lane="acceptance",
+        reference_family="nemotron_labs_diffusion_model_card",
+        user_contract="model_card_generation_parity",
+        metadata={"contract_config": {}},
+    )
+    ctx = _make_ctx(case, tmp_path)
+
+    captured: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        output_path = cmd[cmd.index("-o") + 1]
+        tmp_path.joinpath(output_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write('{"id":0,"generated":"ok","token_ids":[1,2,3]}\n')
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(text_generation.subprocess, "run", _fake_run)
+
+    out = text_generation.TextGenerationCausalRunner().run_stage(
+        case, StageSpec(name="full_generation"), ctx)
+
+    cmd = captured["cmd"]
+    assert "--generation-mode" in cmd
+    assert "diffusion" in cmd
+    assert "--block-length" in cmd
+    assert "--threshold" in cmd
+    assert "-o" in cmd
+    assert out.data["token_ids"] == [1, 2, 3]
+    assert out.metadata["cpp"]["command"] == cmd
 
 
 def test_composite_runner_uses_run_without_stage_flag(monkeypatch, tmp_path):

--- a/tests/tools/test_hf_transformers_reference_helpers.py
+++ b/tests/tools/test_hf_transformers_reference_helpers.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import subprocess
+
+from tests.e2e_harness.contracts import E2ECase, RunContext, StageSpec
+from tests.e2e_harness.references import hf_transformers
 from tests.e2e_harness.references.hf_transformers import (
+    HfTransformersReference,
     _decode_vl_generated_text,
+    _normalize_nemotron_labs_diffusion_mode,
     _vl_fallback_prompt,
     _vl_prompt_has_image_placeholder,
 )
@@ -56,3 +62,84 @@ def test_vl_decode_falls_back_when_model_returns_generated_only_ids() -> None:
     })
 
     assert _decode_vl_generated_text(processor, [201, 202], 4) == "blue"
+
+
+def test_nemotron_labs_diffusion_mode_aliases() -> None:
+    assert _normalize_nemotron_labs_diffusion_mode("auto") == "diffusion"
+    assert _normalize_nemotron_labs_diffusion_mode("dlm") == "diffusion"
+    assert _normalize_nemotron_labs_diffusion_mode("autoregressive") == "ar"
+    assert (
+        _normalize_nemotron_labs_diffusion_mode("linear-speculation-lora")
+        == "linear_spec_lora"
+    )
+
+
+def test_nemotron_labs_diffusion_reference_uses_custom_auto_model_path(
+    monkeypatch, tmp_path
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="OK mode=linear_spec_lora tokens=1\n", stderr=""
+        )
+
+    monkeypatch.setattr(
+        hf_transformers, "_resolve_cached_model_ref", lambda hf_id: "/cached/model"
+    )
+    monkeypatch.setattr(hf_transformers.subprocess, "run", _fake_run)
+
+    case = E2ECase(
+        name="nemotron-labs-diffusion",
+        hf_id="nvidia/Nemotron-Labs-Diffusion-8B",
+        family="nemotron_labs_diffusion",
+        runtime_strategy="nemotron_labs_diffusion",
+        task_strategy="text_generation_causal",
+        inputs={
+            "prompt": "hello",
+            "max_new_tokens": 64,
+            "generation_mode": "linear_spec_adapter",
+            "block_length": 16,
+            "threshold": 0.75,
+            "temperature": 0.0,
+        },
+        metadata={
+            "precision": "bf16",
+            "contract_config": {
+                "use_chat_template": True,
+                "enable_thinking": False,
+            },
+        },
+    )
+    ctx = RunContext(
+        case=case,
+        artifacts_dir=str(tmp_path),
+        reference_python="/ref/python",
+    )
+
+    out = HfTransformersReference().run_stage(
+        case, StageSpec(name="full_generation"), ctx
+    )
+
+    cmd = captured["cmd"]
+    assert cmd[:2] == ["/ref/python", "-c"]
+    script = cmd[2]
+    assert "from transformers import AutoModel, AutoTokenizer" in script
+    assert "AutoModelForCausalLM" not in script
+    assert 'template_path = Path(model_ref) / "chat_template.jinja"' in script
+    assert '_tf_generic.check_model_inputs = lambda fn: fn' in script
+    assert "PeftModel.from_pretrained" in script
+    assert "generation_model = model.model" in script
+    assert "def _call_supported(fn, input_ids, **kwargs):" in script
+    assert "return fn(input_ids, **filtered_kwargs)" in script
+    assert "generation_model.linear_spec_generate" in script
+    assert "ids_tensor," in script
+    assert 'subfolder="linear_spec_lora"' in script
+    assert "generation_mode = 'linear_spec_lora'" in script
+    assert "block_length = 16" in script
+    assert "threshold = 0.75" in script
+    assert "enable_thinking = False" in script
+    assert out.metadata["generation_mode"] == "linear_spec_lora"
+    assert out.logits is None

--- a/tests/tools/test_hf_transformers_reference_helpers.py
+++ b/tests/tools/test_hf_transformers_reference_helpers.py
@@ -131,6 +131,8 @@ def test_nemotron_labs_diffusion_reference_uses_custom_auto_model_path(
     assert 'template_path = Path(model_ref) / "chat_template.jinja"' in script
     assert "fallback_chat_template" in script
     assert "<|im_start|>system\\\\n<|im_end|>" in script
+    assert 'adapter_path = Path(model_ref) / "linear_spec_lora"' in script
+    assert "str(adapter_path)" in script
     assert '_tf_generic.check_model_inputs = lambda fn: fn' in script
     assert "PeftModel.from_pretrained" in script
     assert "generation_model = model.model" in script

--- a/tests/tools/test_hf_transformers_reference_helpers.py
+++ b/tests/tools/test_hf_transformers_reference_helpers.py
@@ -129,6 +129,8 @@ def test_nemotron_labs_diffusion_reference_uses_custom_auto_model_path(
     assert "from transformers import AutoModel, AutoTokenizer" in script
     assert "AutoModelForCausalLM" not in script
     assert 'template_path = Path(model_ref) / "chat_template.jinja"' in script
+    assert "fallback_chat_template" in script
+    assert "<|im_start|>system\\\\n<|im_end|>" in script
     assert '_tf_generic.check_model_inputs = lambda fn: fn' in script
     assert "PeftModel.from_pretrained" in script
     assert "generation_model = model.model" in script

--- a/tests/tools/test_nemotron_labs_diffusion_plugin.py
+++ b/tests/tools/test_nemotron_labs_diffusion_plugin.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from tests.e2e_harness.contracts import E2ECase, StageOutput, StageStatus, ThresholdProfile
+from tests.e2e_harness.plugins.nemotron_labs_diffusion import plugin
+
+
+def _case() -> E2ECase:
+    return E2ECase(
+        name="nemotron-labs-diffusion-8b-linear-spec",
+        hf_id="nvidia/Nemotron-Labs-Diffusion-8B",
+        family="nemotron_labs_diffusion",
+        runtime_strategy="nemotron_labs_diffusion",
+        task_strategy="text_generation_causal",
+        reference_family="nemotron_labs_diffusion_model_card",
+        user_contract="model_card_generation_parity",
+        metadata={
+            "contract_config": {
+                "token_parity_eos_token_ids": [11],
+                "token_parity_ignore_terminal_token_ids": [1010],
+                "forbidden_token_ids": [0],
+            }
+        },
+    )
+
+
+def test_nemotron_labs_diffusion_contract_accepts_terminal_newline_drift() -> None:
+    trt = StageOutput(
+        stage_name="full_generation",
+        data={"token_ids": [42572, 1010, 13, 1010, 11]},
+        text="Paris\n</think>\n",
+    )
+    ref = StageOutput(
+        stage_name="full_generation",
+        data={"token_ids": [42572, 1010, 13, 11], "eos_token_id": 11},
+        text="Paris\n</think>",
+    )
+
+    result = plugin.verify(
+        trt,
+        ref,
+        _case(),
+        ThresholdProfile(
+            task_strategy="text_generation_causal",
+            metrics={"canonical_token_agreement_rate": 1.0},
+        ),
+    )
+
+    assert result.status == StageStatus.PASSED.value
+    assert result.metrics["generated_token_raw_exact"].value == 0.0
+    assert result.metrics["generated_token_raw_exact"].passed
+    assert result.metrics["generated_token_canonical_exact"].passed
+
+
+def test_nemotron_labs_diffusion_contract_rejects_forbidden_unknown_token() -> None:
+    trt = StageOutput(
+        stage_name="full_generation",
+        data={"token_ids": [0, 1010, 42572, 11]},
+        text="\nParis",
+    )
+    ref = StageOutput(
+        stage_name="full_generation",
+        data={"token_ids": [42572, 11], "eos_token_id": 11},
+        text="Paris",
+    )
+
+    result = plugin.verify(
+        trt,
+        ref,
+        _case(),
+        ThresholdProfile(task_strategy="text_generation_causal"),
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert not result.metrics["forbidden_token_count"].passed

--- a/tests/tools/test_schedule_e2e.py
+++ b/tests/tools/test_schedule_e2e.py
@@ -86,6 +86,75 @@ def test_exclusive_gpu_resource_reserves_gpu(tmp_path: Path) -> None:
     ])
 
 
+def test_same_bundle_exclusive_tests_stay_in_one_worker_queue(tmp_path: Path) -> None:
+    for mode in ("ar", "diffusion", "linear-spec", "linear-spec-lora"):
+        _write_manifest(
+            tmp_path,
+            f"nemotron-labs-diffusion-8b-{mode}",
+            runtime_strategy="nemotron_labs_diffusion",
+            e2e_parallel_resource="exclusive_gpu",
+            bundle="nemotron-labs-diffusion-8b.trtfb",
+        )
+    _write_manifest(
+        tmp_path,
+        "other-exclusive",
+        runtime_strategy="diffusion_flux",
+        e2e_parallel_resource="exclusive_gpu",
+    )
+
+    grouped_ids = [
+        _test_id("nemotron-labs-diffusion-8b-ar"),
+        _test_id("nemotron-labs-diffusion-8b-diffusion"),
+        _test_id("nemotron-labs-diffusion-8b-linear-spec"),
+        _test_id("nemotron-labs-diffusion-8b-linear-spec-lora"),
+    ]
+    assignments = schedule_e2e.schedule(
+        [*grouped_ids, _test_id("other-exclusive")],
+        tmp_path,
+        num_gpus=4,
+        workers_per_gpu=1,
+    )
+
+    queues = [worker for workers in assignments.values() for worker in workers]
+    matching_queues = [
+        worker for worker in queues
+        if any(test_id in worker for test_id in grouped_ids)
+    ]
+    assert len(matching_queues) == 1
+    assert sorted(matching_queues[0]) == sorted(grouped_ids)
+
+
+def test_same_bundle_shared_tests_stay_in_one_worker_queue(tmp_path: Path) -> None:
+    for mode in ("a", "b", "c"):
+        _write_manifest(
+            tmp_path,
+            f"shared-mode-{mode}",
+            bundle="shared-bundle.trtfb",
+        )
+    _write_manifest(tmp_path, "small-a")
+    _write_manifest(tmp_path, "small-b")
+
+    grouped_ids = [
+        _test_id("shared-mode-a"),
+        _test_id("shared-mode-b"),
+        _test_id("shared-mode-c"),
+    ]
+    assignments = schedule_e2e.schedule(
+        [*grouped_ids, _test_id("small-a"), _test_id("small-b")],
+        tmp_path,
+        num_gpus=1,
+        workers_per_gpu=3,
+    )
+
+    queues = assignments["0"]
+    matching_queues = [
+        worker for worker in queues
+        if any(test_id in worker for test_id in grouped_ids)
+    ]
+    assert len(matching_queues) == 1
+    assert sorted(matching_queues[0]) == sorted(grouped_ids)
+
+
 def test_phase_schedule_keeps_shared_workers_after_exclusive_gpus(tmp_path: Path) -> None:
     for name in ("exclusive-a", "exclusive-b", "exclusive-c"):
         _write_manifest(

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -104,6 +104,9 @@ def mock_repo(tmp_path):
          "hf_id": "nv/segformer", "core": True},
         {"name": "mixtral-15m", "family": "mixtral", "runtime_strategy": "decoder_moe",
          "hf_id": "mist/mixtral", "core": True},
+        {"name": "nemotron-labs-diffusion-8b", "family": "nemotron_labs_diffusion",
+         "runtime_strategy": "nemotron_labs_diffusion",
+         "hf_id": "nvidia/Nemotron-Labs-Diffusion-8B"},
         {"name": "chronos-bolt-small", "family": "chronos_bolt",
          "runtime_strategy": "chronos_bolt_torchtrt",
          "hf_id": "amazon/chronos-bolt-small", "core": True},
@@ -198,7 +201,7 @@ def mock_repo(tmp_path):
     (tmp_path / "tensorrt_model_connect" / "tensorrt_model_connect" / "graph_ops.py").write_text("")
     (tmp_path / "tensorrt_model_connect" / "tensorrt_model_connect" / "engine_defs" / "torch_trt" / "strategies").mkdir(parents=True)
     (tmp_path / "src" / "runtime" / "models" / "text_generation" / "MODEL.toml").write_text(
-        'runtime_strategies = ["decoder_kv_cache", "decoder_moe"]\n',
+        'runtime_strategies = ["decoder_kv_cache", "decoder_moe", "nemotron_labs_diffusion"]\n',
         encoding="utf-8",
     )
     (tmp_path / "src" / "runtime" / "models" / "vision_language" / "MODEL.toml").write_text(
@@ -528,6 +531,7 @@ class TestCppScope:
         # Should include qwen, llama (kv_cache) and mixtral (moe)
         assert "qwen3-0.6b" in match.models
         assert "mixtral-15m" in match.models
+        assert "nemotron-labs-diffusion-8b" in match.models
         # Should NOT include non-decoder models
         assert "bert-base" not in match.models
         assert "flux-schnell" not in match.models
@@ -576,6 +580,7 @@ class TestCppScope:
             "src/runtime/models/text_generation/pipeline.cpp", imap)
         assert match.rule == "cpp_runtime_model"
         assert "qwen3-0.6b" in match.models
+        assert "nemotron-labs-diffusion-8b" in match.models
         assert "bert-base" not in match.models
 
     def test_flux_pipeline_runtime_scope_uses_non_fp8_l0_representative(self, imap):

--- a/tests/tools/test_warm_hf_cache_static.py
+++ b/tests/tools/test_warm_hf_cache_static.py
@@ -34,6 +34,12 @@ def _load_cache_helpers() -> dict:
             "unet",
             "vae",
         },
+        "_REQUIRED_FILES_BY_HF_ID": {
+            "nvidia/Nemotron-Labs-Diffusion-8B": [
+                "linear_spec_lora/adapter_config.json",
+                "linear_spec_lora/adapter_model.safetensors",
+            ],
+        },
         "_ENTRYPOINT_PATTERNS": ["config.json", "model_index.json", "*/config.json"],
         "_WEIGHT_PATTERNS": ["*.safetensors", "*.bin", "*.nemo"],
     }
@@ -50,6 +56,14 @@ def test_magpie_reference_dependencies_are_warmed() -> None:
     assert "nvidia/nemo-nano-codec-22khz-1.89kbps-21.5fps" in text
     assert "google/byt5-small" in text
     assert "microsoft/wavlm-base-plus" in text
+
+
+def test_nemotron_labs_diffusion_lora_files_are_warmed() -> None:
+    text = WARM_HF_CACHE.read_text()
+    assert '"chat_template.jinja"' in text
+    assert '"linear_spec_lora/**"' in text
+    assert '"linear_spec_lora/adapter_config.json"' in text
+    assert '"linear_spec_lora/adapter_model.safetensors"' in text
 
 
 def test_nemo_archives_count_as_complete_snapshots() -> None:
@@ -105,3 +119,24 @@ def test_diffusers_snapshot_accepts_all_component_weights(tmp_path: Path) -> Non
 
     assert helpers["_diffusers_missing_weight_components"](snapshot) == []
     assert helpers["_snapshot_has_required_files"](snapshot)
+
+
+def test_nemotron_labs_diffusion_snapshot_requires_lora_adapter(tmp_path: Path) -> None:
+    helpers = _load_cache_helpers()
+    snapshot = tmp_path / "snapshots" / "abc"
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text("{}")
+    (snapshot / "model.safetensors").write_bytes(b"weights")
+
+    assert not helpers["_snapshot_has_required_files"](
+        snapshot, hf_id="nvidia/Nemotron-Labs-Diffusion-8B")
+
+    lora_dir = snapshot / "linear_spec_lora"
+    lora_dir.mkdir()
+    (lora_dir / "adapter_config.json").write_text("{}")
+    assert not helpers["_snapshot_has_required_files"](
+        snapshot, hf_id="nvidia/Nemotron-Labs-Diffusion-8B")
+
+    (lora_dir / "adapter_model.safetensors").write_bytes(b"weights")
+    assert helpers["_snapshot_has_required_files"](
+        snapshot, hf_id="nvidia/Nemotron-Labs-Diffusion-8B")

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -32,6 +32,7 @@ RUNTIME_TO_TASK_STRATEGY: Dict[str, str] = {
     "ssm_recurrent": "text_generation_causal",
     "rwkv_recurrent": "text_generation_causal",
     "hybrid_mamba_attention": "text_generation_causal",
+    "nemotron_labs_diffusion": "text_generation_causal",
     "vision_language": "vision_language_generation",
     "speech_to_text": "speech_to_text",
     "speech_to_text_rnnt": "speech_to_text",


### PR DESCRIPTION
## Background

This adds support for `nvidia/Nemotron-Labs-Diffusion-8B` using the model-card generation contract as the source of truth. The model exposes AR, diffusion/dLM, linear self-speculation, and LoRA-backed linear self-speculation modes, and the E2E harness needs token-aware reference checks for those modes.

## Exit Criteria

- TRTMC can build and run the Nemotron Labs Diffusion text-generation family through the supported model-card modes.
- E2E manifests cover AR, diffusion, linear-spec, and linear-spec-LoRA.
- Validation proves canonical token parity against the HF Transformers remote-code reference for the supported modes.
- Throughput claims from the model card are treated as out of scope for this support PR; this PR is correctness/model-card coverage only.

## Implementation

- Adds a dedicated `nemotron_labs_diffusion` family plugin plus graph, checkpoint, RoPE, dual-profile, and runtime text-generation plumbing needed by the family.
- Extends text-generation runtime configuration and CLI parsing for generation mode, block length, and confidence threshold controls.
- Adds Nemotron-specific E2E manifests, scheduling constraints, HF reference handling, token-aware comparator contracts, and focused tests for the family and harness behavior.

## Validation

- `docker exec -w /workspace/tensorrt-model-connect trtmc-dev-gb300 pytest -q tests/builder/test_family_plugins.py::TestNemotronLabsDiffusionPlugin tests/builder/test_manifest_validation.py::TestManifestValidation::test_nemotron_labs_diffusion_manifests_cover_model_card_modes tests/tools/test_nemotron_labs_diffusion_plugin.py tests/tools/test_hf_transformers_reference_helpers.py::test_nemotron_labs_diffusion_mode_aliases tests/tools/test_hf_transformers_reference_helpers.py::test_nemotron_labs_diffusion_reference_uses_custom_auto_model_path tests/tools/test_e2e_runner_cli_alignment.py::test_text_generation_runner_maps_diffusion_mode_flags tests/tools/test_schedule_e2e.py::test_same_bundle_exclusive_tests_stay_in_one_worker_queue`: passed, 10 tests in 1.35s.
- `docker exec -w /workspace/tensorrt-model-connect trtmc-dev-gb300 g++ -std=c++17 -Isrc -Iinclude tests/cpp/test_cli_args.cpp src/cli/args.cpp -o /tmp/test_cli_args_current`: passed.
- `docker exec -w /workspace/tensorrt-model-connect trtmc-dev-gb300 /tmp/test_cli_args_current`: passed, `All CLI parser tests passed`.
- Full E2E revalidation before PR submission covered AR, diffusion, linear-spec, and linear-spec-LoRA: passed, 4 tests in 383.33s. Artifacts are under `/tmp/trtmc-nemotron/e2e_revalidate_current`.

## Notes For Future Readers

- Review the family plugin and manifests first, then the runtime generation-mode plumbing, then the harness/reference changes.
- The comparator is intentionally token-aware for this family; raw text drift from terminal whitespace remains informational while canonical token parity is the pass/fail contract.
