### PR TITLE
ci: reuse wheel build for C++ tests

### DIFF
--- a/.github/scripts/run-gha-stage.sh
+++ b/.github/scripts/run-gha-stage.sh
@@ -3,43 +3,14 @@ set -euo pipefail
 
 stage="${1:?usage: run-gha-stage.sh <stage>}"
 
-docker image inspect "$TRTMC_CI_IMAGE" >/dev/null || {
-  echo "::error::Docker image '$TRTMC_CI_IMAGE' is not present on the self-hosted runner. Set repository variable TRTMC_MANYLINUX_CI_IMAGE if the runner uses a different local manylinux image tag."
+container_name="${TRTMC_CI_CONTAINER_NAME:-trtmc-ci-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}}"
+
+if [ "$(docker inspect -f '{{.State.Running}}' "$container_name" 2>/dev/null || true)" != "true" ]; then
+  echo "::error::CI container '$container_name' is not running. Start it with .github/scripts/start-gha-container.sh before running stages."
   exit 1
-}
-
-extra_mounts=()
-if [ -d /workspace/users/yifeif ]; then
-  extra_mounts+=(-v /workspace/users/yifeif:/workspace/users/yifeif)
 fi
 
-mkdir_if_set() {
-  local path="${1:-}"
-  if [ -n "$path" ]; then
-    mkdir -p "$path" 2>/dev/null || {
-      echo "::warning::Could not create '$path' on the host; the CI container will try through mounted storage."
-    }
-  fi
-}
-
-mkdir_if_set "${TRTMC_STORAGE_ROOT:-}"
-mkdir_if_set "${ENGINE_DIR:-}"
-mkdir_if_set "${HF_HOME:-}"
-mkdir_if_set "${HF_HUB_CACHE:-}"
-mkdir_if_set "${HUGGINGFACE_HUB_CACHE:-}"
-mkdir_if_set "${HF_MODULES_CACHE:-}"
-
-if [ -n "${GITHUB_WORKSPACE:-}" ] && [ -d "$GITHUB_WORKSPACE" ]; then
-  chmod -R a+rwX "$GITHUB_WORKSPACE" 2>/dev/null || {
-    echo "::warning::Could not normalize workspace permissions before entering the CI container."
-  }
-fi
-
-# shellcheck disable=SC2086
-docker run --rm \
-  $TRTMC_CONTAINER_OPTIONS \
-  "${extra_mounts[@]}" \
-  -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+docker exec \
   -w "$GITHUB_WORKSPACE" \
   -e CI_BASE_REF \
   -e ENGINE_DIR \
@@ -54,6 +25,8 @@ docker run --rm \
   -e GITHUB_EVENT_NAME \
   -e GITHUB_REF_NAME \
   -e GITHUB_RUN_ID \
+  -e GITHUB_RUN_ATTEMPT \
+  -e TRTMC_CI_STATE_DIR \
   -e TRTMC_E2E_EXCLUDE_GPU0 \
   -e TRTMC_E2E_DEPRIORITIZE_GPU0 \
   -e TRTMC_TRT_TIMING_CACHE_PATH \
@@ -72,6 +45,7 @@ docker run --rm \
   -e CPP_UNIT_TIMEOUT \
   -e PYTHON_BUILDER_TIMEOUT \
   -e CPP_COVERAGE_TIMEOUT \
+  -e CPP_COVERAGE_BUILD_DIR \
   -e GRAPH_OP_TIMEOUT \
   -e SELECTIVE_E2E_TIMEOUT \
   -e FULL_E2E_TIMEOUT \
@@ -92,5 +66,5 @@ docker run --rm \
   -e DIFFUSION_VLM_TIMEOUT \
   -e HF_TOKEN \
   -e HUGGING_FACE_HUB_TOKEN \
-  "$TRTMC_CI_IMAGE" \
+  "$container_name" \
   bash .github/scripts/run-trtmc-ci.sh "$stage"

--- a/.github/scripts/run-trtmc-ci.sh
+++ b/.github/scripts/run-trtmc-ci.sh
@@ -59,6 +59,28 @@ prepare_shared_directories() {
 
 prepare_shared_directories
 
+ci_state_dir() {
+  printf '%s\n' "${TRTMC_CI_STATE_DIR:-.ci}"
+}
+
+ensure_ci_state_dir() {
+  mkdir -p "$(ci_state_dir)"
+}
+
+wheel_build_metadata_file() {
+  printf '%s/trtmc-wheel-build.env\n' "$(ci_state_dir)"
+}
+
+wheel_install_metadata_file() {
+  printf '%s/wheel-installed.env\n' "$(ci_state_dir)"
+}
+
+write_shell_var() {
+  local name="$1"
+  local value="$2"
+  printf '%s=%q\n' "$name" "$value"
+}
+
 configure_e2e_timing_cache() {
   local cache_root="${TRTMC_STORAGE_ROOT:-${ENGINE_DIR:-.}}"
   local opt_level="${TRTMC_BUILDER_OPTIMIZATION_LEVEL:-default}"
@@ -146,13 +168,85 @@ for backend in backends:
 PY
 }
 
-setup_environment() {
-  verify_environment
+install_built_wheel_once() {
+  ensure_ci_state_dir
+  local sentinel
+  sentinel="$(wheel_install_metadata_file)"
+  if [ -f "$sentinel" ]; then
+    echo "Built wheel already installed in this CI container:"
+    cat "$sentinel"
+    return 0
+  fi
+  local install_wheel
+  install_wheel="$(select_compatible_wheel dist)"
   install_built_wheel
+  {
+    write_shell_var TRTMC_INSTALLED_WHEEL "$install_wheel"
+    write_shell_var TRTMC_WHEEL_INSTALLED_AT "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  } > "$sentinel"
+}
+
+verify_built_wheel_installed() {
+  local sentinel
+  sentinel="$(wheel_install_metadata_file)"
+  if [ ! -f "$sentinel" ]; then
+    echo "ERROR: built wheel has not been installed in this CI container; missing $sentinel" >&2
+    exit 1
+  fi
+  # shellcheck disable=SC1090
+  source "$sentinel"
+  python - "${TRTMC_INSTALLED_WHEEL:-}" <<'PY'
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import tensorrt_model_connect
+
+wheel = Path(sys.argv[1])
+repo = Path.cwd().resolve()
+package_file = Path(tensorrt_model_connect.__file__).resolve()
+try:
+    package_file.relative_to(repo)
+except ValueError:
+    pass
+else:
+    raise SystemExit(
+        f"tensorrt_model_connect imported from source tree after wheel install: {package_file}"
+    )
+
+installed_script = shutil.which("trtmc")
+if installed_script is None:
+    raise SystemExit("installed trtmc was not found on PATH")
+installed_script_path = Path(installed_script)
+if installed_script_path.read_bytes()[:4] != b"\x7fELF":
+    raise SystemExit(f"{installed_script_path} is not the native ELF trtmc executable")
+
+print(f"installed_wheel={wheel}")
+print(f"imported_package={package_file}")
+print(f"installed_trtmc={installed_script_path}")
+PY
+}
+
+setup_source_check_environment() {
+  verify_environment
+}
+
+setup_wheel_runtime_environment() {
+  verify_environment
+  verify_built_wheel_installed
 }
 
 setup_package_build_environment() {
   verify_environment
+}
+
+ensure_conan_cli() {
+  if command -v conan >/dev/null 2>&1; then
+    return 0
+  fi
+  python -m pip install --disable-pip-version-check --quiet "conan-py-build==0.4.3"
 }
 
 impact_analysis() {
@@ -173,49 +267,71 @@ impact_analysis() {
   python3 tools/test_impact.py "${impact_args[@]}" --verbose
 }
 
-build_all() {
-  local trt_include="${TRTMC_TRT_INCLUDE_DIR:-${TRT_INC_DIR:-}}"
-  local trt_library="${TRTMC_TRT_LIBRARY:-}"
-  if [ -z "$trt_library" ] && [ -n "${TRT_LIB_DIR:-}" ]; then
-    trt_library="${TRT_LIB_DIR%/}/libnvinfer.so"
+load_wheel_build_metadata() {
+  local metadata
+  metadata="$(wheel_build_metadata_file)"
+  if [ ! -f "$metadata" ]; then
+    echo "ERROR: reusable wheel build metadata is missing: $metadata" >&2
+    exit 1
   fi
-  if [ -z "$trt_library" ]; then
-    for candidate in \
-      /opt/venv/lib/python*/site-packages/tensorrt_libs/libnvinfer.so \
-      /usr/lib/aarch64-linux-gnu/libnvinfer.so \
-      /usr/lib/x86_64-linux-gnu/libnvinfer.so \
-      /usr/local/tensorrt/lib/libnvinfer.so; do
-      if [ -f "$candidate" ]; then
-        trt_library="$candidate"
-        break
-      fi
-    done
-  fi
-  if [ -z "$trt_include" ]; then
-    for candidate in /usr/local/tensorrt/include /usr/include/aarch64-linux-gnu /usr/include/x86_64-linux-gnu /usr/include; do
-      if [ -f "$candidate/NvInfer.h" ]; then
-        trt_include="$candidate"
-        break
-      fi
-    done
+  # shellcheck disable=SC1090
+  source "$metadata"
+  : "${TRTMC_REUSE_CONAN_OUT_DIR:?TRTMC_REUSE_CONAN_OUT_DIR missing from $metadata}"
+  : "${TRTMC_REUSE_CMAKE_BUILD_DIR:?TRTMC_REUSE_CMAKE_BUILD_DIR missing from $metadata}"
+}
+
+select_cpp_build_targets() {
+  if [ "${FULL_E2E:-false}" = "true" ]; then
+    printf '%s\n' "trtmc_cpp_tests"
+    return 0
   fi
 
-  local cuda_include="${TRTMC_CUDA_INCLUDE_DIR:-/usr/local/cuda/include}"
-  local cudart_library="${TRTMC_CUDART_LIBRARY:-/usr/local/cuda/lib64/libcudart.so}"
-  local enable_libtorch_multinomial="${TRTMC_ENABLE_LIBTORCH_MULTINOMIAL:-OFF}"
+  python3 - <<'PY'
+import json
+from pathlib import Path
 
-  : "${trt_include:?TensorRT include directory was not found}"
-  : "${trt_library:?TensorRT libnvinfer.so was not found}"
-  : "${cuda_include:?CUDA include directory was not found}"
-  : "${cudart_library:?CUDA runtime library was not found}"
+impact = Path("impact.json")
+if not impact.exists():
+    print("trtmc_cpp_tests")
+    raise SystemExit(0)
 
-  run_with_timeout "${BUILD_ALL_TIMEOUT:-15m}" cmake -S . -B build -G Ninja \
-    -DTRTMC_TRT_INCLUDE_DIR="$trt_include" \
-    -DTRTMC_TRT_LIBRARY="$trt_library" \
-    -DTRTMC_CUDA_INCLUDE_DIR="$cuda_include" \
-    -DTRTMC_CUDART_LIBRARY="$cudart_library" \
-    -DTRTMC_ENABLE_LIBTORCH_MULTINOMIAL="$enable_libtorch_multinomial"
-  run_with_timeout "${BUILD_ALL_TIMEOUT:-15m}" cmake --build build -j
+d = json.loads(impact.read_text())
+if "cpp" not in d.get("unit_tiers", []):
+    raise SystemExit(0)
+
+tests = d.get("cpp_tests", [])
+fallback = d.get("fallback_tiers", [])
+if "cpp" in fallback or not tests:
+    print("trtmc_cpp_tests")
+else:
+    print(" ".join(tests))
+PY
+}
+
+build_cpp_test_executables() {
+  local targets
+  targets="$(select_cpp_build_targets)"
+  if [ -z "$targets" ]; then
+    echo "Skipping: no C++ test targets selected"
+    return 0
+  fi
+
+  load_wheel_build_metadata
+  ensure_conan_cli
+  local conan_profile="${CONAN_PY_BUILD_PROFILE:-$PWD/conan-py-build.profile}"
+  local conan_profile_args=()
+  if [ -f "$conan_profile" ]; then
+    conan_profile_args=(-pr:h "$conan_profile" -pr:b "$conan_profile")
+  fi
+  echo "Building C++ test target(s) via Conan: $targets"
+  run_with_timeout "${BUILD_ALL_TIMEOUT:-15m}" env \
+    TRTMC_CONAN_ENABLE_TEST_TARGETS=1 \
+    TRTMC_CONAN_BUILD_TARGETS="$targets" \
+    TRTMC_TRT_INCLUDE_DIR="${TRTMC_TRT_INCLUDE_DIR:-}" \
+    TRTMC_TRT_LIBRARY="${TRTMC_TRT_LIBRARY:-}" \
+    TRTMC_CUDA_INCLUDE_DIR="${TRTMC_CUDA_INCLUDE_DIR:-}" \
+    TRTMC_CUDART_LIBRARY="${TRTMC_CUDART_LIBRARY:-}" \
+    conan build . -of "$TRTMC_REUSE_CONAN_OUT_DIR" "${conan_profile_args[@]}"
 }
 
 check_family_coverage() {
@@ -275,12 +391,13 @@ print('|'.join(tests))
 " 2>/dev/null) || true
   fi
 
+  load_wheel_build_metadata
   if [ -n "$cpp_tests" ]; then
     echo "Selective C++ tests: $cpp_tests"
-    run_with_timeout "${CPP_UNIT_TIMEOUT:-20m}" ctest --test-dir build -R "$cpp_tests" --output-on-failure
+    run_with_timeout "${CPP_UNIT_TIMEOUT:-20m}" ctest --test-dir "$TRTMC_REUSE_CMAKE_BUILD_DIR" -R "$cpp_tests" --output-on-failure
   else
     echo "Running all C++ tests"
-    run_with_timeout "${CPP_UNIT_TIMEOUT:-20m}" ctest --test-dir build --output-on-failure
+    run_with_timeout "${CPP_UNIT_TIMEOUT:-20m}" ctest --test-dir "$TRTMC_REUSE_CMAKE_BUILD_DIR" --output-on-failure
   fi
 }
 
@@ -536,7 +653,8 @@ generate_coverage_map() {
   fi
 
   python -m pip install --disable-pip-version-check --quiet "coverage[toml]==7.6.10" "pytest-cov>=6.0" "gcovr==8.2"
-  run_with_timeout "${COVERAGE_MAP_TIMEOUT:-90m}" python -m tools.coverage_map.generate --output coverage_map.json --python-bin python --build-dir build
+  local cpp_coverage_build_dir="${CPP_COVERAGE_BUILD_DIR:-$PWD/build-cov}"
+  run_with_timeout "${COVERAGE_MAP_TIMEOUT:-90m}" python -m tools.coverage_map.generate --output coverage_map.json --python-bin python --build-dir "$cpp_coverage_build_dir"
   python -m tools.coverage_map.generate --validate coverage_map.json
   python -c "import json; d=json.load(open('coverage_map.json')); m=d['meta']; print('Python tests: %s, C++ tests: %s, Source files: %d' % (m['python_tests'], m['cpp_tests'], len(d['source_to_tests'])))"
 }
@@ -618,6 +736,20 @@ validate_manylinux_build_environment() {
   fi
 }
 
+locate_conan_cmake_build_dir() {
+  local conan_out="$1"
+  mapfile -t cmake_caches < <(
+    find "$conan_out/build" -mindepth 2 -maxdepth 2 -name CMakeCache.txt -type f | sort
+  )
+  if [ "${#cmake_caches[@]}" -ne 1 ]; then
+    printf 'ERROR: expected exactly one reusable CMakeCache.txt under %s, found %d\n' \
+      "$conan_out" "${#cmake_caches[@]}" >&2
+    printf '  %s\n' "${cmake_caches[@]:-}" >&2
+    exit 1
+  fi
+  dirname "${cmake_caches[0]}"
+}
+
 build_pip_package() {
   local trt_include="${TRTMC_TRT_INCLUDE_DIR:-${TRT_INC_DIR:-}}"
   local trt_library="${TRTMC_TRT_LIBRARY:-}"
@@ -654,14 +786,21 @@ build_pip_package() {
   : "${cudart_library:?CUDA runtime library was not found}"
 
   python -m pip install --disable-pip-version-check --quiet "auditwheel>=6.2" "build>=1.2"
-  local package_build_root="${TRTMC_PACKAGE_BUILD_ROOT:-/tmp/trtmc-conan-py-wheel-${GITHUB_RUN_ID:-local}}"
-  rm -rf dist "$package_build_root" python/tensorrt_model_connect/build python/tensorrt_model_connect/*.egg-info
+  ensure_ci_state_dir
+  local package_build_root="${TRTMC_PACKAGE_BUILD_ROOT:-$PWD/.ci/conan-py-wheel-${GITHUB_RUN_ID:-local}}"
+  rm -rf dist "$package_build_root" "$(wheel_build_metadata_file)" "$(wheel_install_metadata_file)" \
+    python/tensorrt_model_connect/build python/tensorrt_model_connect/*.egg-info
   find python/tensorrt_model_connect -type d -name __pycache__ -prune -exec rm -rf {} +
   mkdir -p dist
 
   local python_tags="${TRTMC_PACKAGE_PYTHON_TAGS:-py310 py312}"
   local wheel_arch="${TRTMC_PACKAGE_WHEEL_ARCH:-manylinux_2_39_aarch64}"
   validate_manylinux_build_environment "$wheel_arch"
+  local current_tag
+  current_tag="$(current_python_wheel_tag)"
+  local reuse_tag=""
+  local reuse_conan_out=""
+  local reuse_cmake_build_dir=""
   local expected_wheels=0
   local tag
   for tag in $python_tags; do
@@ -673,12 +812,21 @@ build_pip_package() {
       TRTMC_TRT_LIBRARY="$trt_library" \
       TRTMC_CUDA_INCLUDE_DIR="$cuda_include" \
       TRTMC_CUDART_LIBRARY="$cudart_library" \
+      TRTMC_CONAN_ENABLE_TEST_TARGETS=1 \
       WHEEL_PYVER="$tag" \
       WHEEL_ABI=none \
       WHEEL_ARCH="$wheel_arch" \
       python -m build --wheel --outdir "$PWD/dist" \
         -C "build-dir=$package_build_root/$tag" \
         .
+    local tag_conan_out="$package_build_root/$tag/conan_out"
+    local tag_cmake_build_dir
+    tag_cmake_build_dir="$(locate_conan_cmake_build_dir "$tag_conan_out")"
+    if [ -z "$reuse_tag" ] || [ "$tag" = "$current_tag" ]; then
+      reuse_tag="$tag"
+      reuse_conan_out="$tag_conan_out"
+      reuse_cmake_build_dir="$tag_cmake_build_dir"
+    fi
   done
 
   mapfile -t wheels < <(find dist -maxdepth 1 -type f -name '*.whl' | sort)
@@ -760,6 +908,18 @@ for wheel in sys.argv[1:]:
     for entry in sorted([*bin_entries, *script_entries, *backend_entries]):
         print(f"  {entry}")
 PY
+
+  {
+    write_shell_var TRTMC_REUSE_WHEEL_TAG "$reuse_tag"
+    write_shell_var TRTMC_REUSE_CONAN_OUT_DIR "$reuse_conan_out"
+    write_shell_var TRTMC_REUSE_CMAKE_BUILD_DIR "$reuse_cmake_build_dir"
+    write_shell_var TRTMC_TRT_INCLUDE_DIR "$trt_include"
+    write_shell_var TRTMC_TRT_LIBRARY "$trt_library"
+    write_shell_var TRTMC_CUDA_INCLUDE_DIR "$cuda_include"
+    write_shell_var TRTMC_CUDART_LIBRARY "$cudart_library"
+  } > "$(wheel_build_metadata_file)"
+  echo "Reusable wheel build metadata:"
+  cat "$(wheel_build_metadata_file)"
 
   local install_wheel
   install_wheel="$(select_compatible_wheel dist)"
@@ -862,62 +1022,63 @@ run_stage() {
   local stage="$1"
   case "$stage" in
     setup)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
+      run_step "Install trtmc pip package" install_built_wheel_once
       ;;
     impact)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
+      run_step "Setup TensorRT-Model-Connect source checks" setup_source_check_environment
       run_step "Impact analysis" impact_analysis
       ;;
     build)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
-      run_step "Build all" build_all
+      run_step "Setup TensorRT-Model-Connect source checks" setup_source_check_environment
+      run_step "Build C++ test executables" build_cpp_test_executables
       ;;
     family-coverage)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
+      run_step "Setup TensorRT-Model-Connect source checks" setup_source_check_environment
       run_step "Check family coverage" check_family_coverage
       ;;
     complexity)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
+      run_step "Setup TensorRT-Model-Connect source checks" setup_source_check_environment
       run_step "Check cyclomatic complexity" check_cyclomatic_complexity
       ;;
     lint)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
+      run_step "Setup TensorRT-Model-Connect source checks" setup_source_check_environment
       run_step "Lint changed files" lint_changed_files
       ;;
     cpp-unit)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
+      run_step "Setup TensorRT-Model-Connect source checks" setup_source_check_environment
       run_step "C++ unit tests" run_cpp_unit_tests
       ;;
     python-builder)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
+      run_step "Setup TensorRT-Model-Connect wheel runtime" setup_wheel_runtime_environment
       run_step "Python builder and tools tests" run_python_builder_tests
       ;;
     cpp-coverage)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
+      run_step "Setup TensorRT-Model-Connect source checks" setup_source_check_environment
       run_step "C++ coverage" run_cpp_coverage
       ;;
     graph-ops)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
+      run_step "Setup TensorRT-Model-Connect wheel runtime" setup_wheel_runtime_environment
       run_step "Graph-op GPU tests" run_graph_op_tests
       ;;
     selective-e2e)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
+      run_step "Setup TensorRT-Model-Connect wheel runtime" setup_wheel_runtime_environment
       run_step "Selective E2E tests" run_selective_e2e
       ;;
     full-e2e)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
+      run_step "Setup TensorRT-Model-Connect wheel runtime" setup_wheel_runtime_environment
       run_step "Full E2E tests" run_full_e2e
       ;;
     coverage-map)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
+      run_step "Setup TensorRT-Model-Connect wheel runtime" setup_wheel_runtime_environment
       run_step "Generate coverage map" generate_coverage_map
       ;;
     package)
       run_step "Setup TensorRT-Model-Connect package build environment" setup_package_build_environment
       run_step "Build trtmc pip package" build_pip_package
+      run_step "Install trtmc pip package" install_built_wheel_once
       ;;
     wheel-qwen-smoke)
-      run_step "Setup TensorRT-Model-Connect" setup_environment
+      run_step "Setup TensorRT-Model-Connect source checks" setup_source_check_environment
       run_step "Qwen smoke test from trtmc pip package" run_wheel_qwen_smoke
       ;;
     *)
@@ -934,9 +1095,9 @@ fi
 
 run_step "Setup TensorRT-Model-Connect package build environment" setup_package_build_environment
 run_step "Build trtmc pip package" build_pip_package
-run_step "Setup TensorRT-Model-Connect" setup_environment
+run_step "Install trtmc pip package" install_built_wheel_once
 run_step "Impact analysis" impact_analysis
-run_step "Build all" build_all
+run_step "Build C++ test executables" build_cpp_test_executables
 run_step "Check family coverage" check_family_coverage
 run_step "Check cyclomatic complexity" check_cyclomatic_complexity
 run_step "Lint changed files" lint_changed_files

--- a/.github/scripts/start-gha-container.sh
+++ b/.github/scripts/start-gha-container.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+container_name="${TRTMC_CI_CONTAINER_NAME:-trtmc-ci-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}}"
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "TRTMC_CI_CONTAINER_NAME=${container_name}" >> "$GITHUB_ENV"
+fi
+
+docker image inspect "$TRTMC_CI_IMAGE" >/dev/null || {
+  echo "::error::Docker image '$TRTMC_CI_IMAGE' is not present on the self-hosted runner. Set repository variable TRTMC_MANYLINUX_CI_IMAGE if the runner uses a different local manylinux image tag."
+  exit 1
+}
+
+docker rm -f "$container_name" >/dev/null 2>&1 || true
+
+extra_mounts=()
+if [ -d /workspace/users/yifeif ]; then
+  extra_mounts+=(-v /workspace/users/yifeif:/workspace/users/yifeif)
+fi
+
+mkdir_if_set() {
+  local path="${1:-}"
+  if [ -n "$path" ]; then
+    mkdir -p "$path" 2>/dev/null || {
+      echo "::warning::Could not create '$path' on the host; the CI container will try through mounted storage."
+    }
+  fi
+}
+
+mkdir_if_set "${TRTMC_STORAGE_ROOT:-}"
+mkdir_if_set "${ENGINE_DIR:-}"
+mkdir_if_set "${HF_HOME:-}"
+mkdir_if_set "${HF_HUB_CACHE:-}"
+mkdir_if_set "${HUGGINGFACE_HUB_CACHE:-}"
+mkdir_if_set "${HF_MODULES_CACHE:-}"
+
+if [ -n "${GITHUB_WORKSPACE:-}" ] && [ -d "$GITHUB_WORKSPACE" ]; then
+  chmod -R a+rwX "$GITHUB_WORKSPACE" 2>/dev/null || {
+    echo "::warning::Could not normalize workspace permissions before entering the CI container."
+  }
+fi
+
+env_args=()
+add_env() {
+  local name="$1"
+  env_args+=(-e "${name}=${!name-}")
+}
+
+for name in \
+  CI_BASE_REF \
+  ENGINE_DIR \
+  TRTMC_STORAGE_ROOT \
+  HF_HOME \
+  HF_HUB_CACHE \
+  HUGGINGFACE_HUB_CACHE \
+  HF_MODULES_CACHE \
+  FULL_E2E \
+  RUN_COVERAGE_MAP \
+  REBUILD_ENGINES \
+  GITHUB_EVENT_NAME \
+  GITHUB_REF_NAME \
+  GITHUB_RUN_ID \
+  GITHUB_RUN_ATTEMPT \
+  TRTMC_CI_STATE_DIR \
+  TRTMC_E2E_EXCLUDE_GPU0 \
+  TRTMC_E2E_DEPRIORITIZE_GPU0 \
+  TRTMC_TRT_TIMING_CACHE_PATH \
+  TRTMC_TRT_TIMING_CACHE_DIR \
+  TRTMC_BUILDER_OPTIMIZATION_LEVEL \
+  TRTMC_MAX_NUM_TACTICS \
+  TRTMC_AVG_TIMING_ITERATIONS \
+  TRTMC_ENABLE_LIBTORCH_MULTINOMIAL \
+  PYTHONHASHSEED \
+  PYTHON_COVERAGE_MIN_LINE \
+  PYTHON_COVERAGE_MIN_BRANCH \
+  CPP_COVERAGE_MIN_LINE \
+  CPP_COVERAGE_MIN_FUNCTION \
+  CPP_COVERAGE_MIN_BRANCH \
+  BUILD_ALL_TIMEOUT \
+  CPP_UNIT_TIMEOUT \
+  PYTHON_BUILDER_TIMEOUT \
+  CPP_COVERAGE_TIMEOUT \
+  CPP_COVERAGE_BUILD_DIR \
+  GRAPH_OP_TIMEOUT \
+  SELECTIVE_E2E_TIMEOUT \
+  FULL_E2E_TIMEOUT \
+  COVERAGE_MAP_TIMEOUT \
+  TRTMC_PACKAGE_PYTHON_TAGS \
+  TRTMC_PACKAGE_WHEEL_ARCH \
+  TRTMC_PACKAGE_BUILD_ROOT \
+  TRTMC_WHEEL_QWEN_MODEL_ID \
+  TRTMC_WHEEL_QWEN_MAX_CACHE \
+  TRTMC_WHEEL_QWEN_MAX_NEW_TOKENS \
+  TRTMC_WHEEL_QWEN_OPTIMIZATION_LEVEL \
+  TRTMC_WHEEL_QWEN_BUILD_TIMEOUT \
+  TRTMC_WHEEL_QWEN_RUN_TIMEOUT \
+  DIFFUSION_VLM_ASSESSMENT \
+  DIFFUSION_VLM_MODEL_ID \
+  DIFFUSION_VLM_MAX_SIDE \
+  DIFFUSION_VLM_MAX_NEW_TOKENS \
+  DIFFUSION_VLM_TIMEOUT \
+  HF_TOKEN \
+  HUGGING_FACE_HUB_TOKEN; do
+  add_env "$name"
+done
+
+# shellcheck disable=SC2086
+docker run -d \
+  --name "$container_name" \
+  $TRTMC_CONTAINER_OPTIONS \
+  "${extra_mounts[@]}" \
+  -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+  -w "$GITHUB_WORKSPACE" \
+  "${env_args[@]}" \
+  "$TRTMC_CI_IMAGE" \
+  bash -lc 'trap "exit 0" TERM INT; sleep infinity & wait'
+
+echo "Started CI container: $container_name"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,6 +25,7 @@ env:
   HUGGINGFACE_HUB_CACHE: ${{ vars.TRTMC_HF_HUB_CACHE || '/workspace/users/yifeif/tensorrt-model-connect/hf-cache/hub' }}
   HF_MODULES_CACHE: ${{ vars.TRTMC_HF_MODULES_CACHE || '/workspace/users/yifeif/tensorrt-model-connect/hf-cache/modules' }}
   TRTMC_CI_IMAGE: ${{ vars.TRTMC_MANYLINUX_CI_IMAGE || 'trtmc-dev-gb300:manylinux_2_39' }}
+  TRTMC_CI_CONTAINER_NAME: trtmc-ci-${{ github.run_id }}-${{ github.run_attempt }}
   TRTMC_CONTAINER_OPTIONS: ${{ vars.TRTMC_CONTAINER_OPTIONS || '--gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864' }}
   TRTMC_PACKAGE_PYTHON_TAGS: ${{ vars.TRTMC_PACKAGE_PYTHON_TAGS || 'py310 py312' }}
   TRTMC_PACKAGE_WHEEL_ARCH: ${{ vars.TRTMC_PACKAGE_WHEEL_ARCH || 'manylinux_2_39_aarch64' }}
@@ -62,6 +63,7 @@ jobs:
           set -euo pipefail
           if [ -d "$GITHUB_WORKSPACE" ]; then
             chmod -R a+rwX "$GITHUB_WORKSPACE" 2>/dev/null || true
+            docker rm -f "$TRTMC_CI_CONTAINER_NAME" >/dev/null 2>&1 || true
             docker image inspect "$TRTMC_CI_IMAGE" >/dev/null || {
               echo "::error::Docker image '$TRTMC_CI_IMAGE' is not present on the self-hosted runner. Set repository variable TRTMC_MANYLINUX_CI_IMAGE if the runner uses a different local manylinux image tag."
               exit 1
@@ -112,20 +114,20 @@ jobs:
           echo "RUN_COVERAGE_MAP=$RUN_COVERAGE_MAP"
           echo "REBUILD_ENGINES=$REBUILD_ENGINES"
 
+      - name: Start CI container
+        timeout-minutes: 5
+        run: bash .github/scripts/start-gha-container.sh
+
       - name: Build trtmc pip package
         timeout-minutes: 30
         run: bash .github/scripts/run-gha-stage.sh package
-
-      - name: Setup TensorRT-Model-Connect
-        timeout-minutes: 5
-        run: bash .github/scripts/run-gha-stage.sh setup
 
       - name: Impact analysis
         if: ${{ always() }}
         timeout-minutes: 5
         run: bash .github/scripts/run-gha-stage.sh impact
 
-      - name: Build all
+      - name: Build C++ test executables
         if: ${{ always() }}
         timeout-minutes: 15
         run: bash .github/scripts/run-gha-stage.sh build
@@ -274,3 +276,7 @@ jobs:
             coverage_map.json
             coverage/
             e2e_artifacts/
+
+      - name: Stop CI container
+        if: always()
+        run: docker rm -f "$TRTMC_CI_CONTAINER_NAME" >/dev/null 2>&1 || true

--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -24,6 +24,7 @@ env:
   HUGGINGFACE_HUB_CACHE: ${{ vars.TRTMC_HF_HUB_CACHE || '/workspace/users/yifeif/tensorrt-model-connect/hf-cache/hub' }}
   HF_MODULES_CACHE: ${{ vars.TRTMC_HF_MODULES_CACHE || '/workspace/users/yifeif/tensorrt-model-connect/hf-cache/modules' }}
   TRTMC_CI_IMAGE: ${{ vars.TRTMC_MANYLINUX_CI_IMAGE || 'trtmc-dev-gb300:manylinux_2_39' }}
+  TRTMC_CI_CONTAINER_NAME: trtmc-ci-${{ github.run_id }}-${{ github.run_attempt }}
   TRTMC_CONTAINER_OPTIONS: ${{ vars.TRTMC_CONTAINER_OPTIONS || '--gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864' }}
   TRTMC_PACKAGE_PYTHON_TAGS: ${{ vars.TRTMC_PACKAGE_PYTHON_TAGS || 'py312' }}
   TRTMC_PACKAGE_WHEEL_ARCH: ${{ vars.TRTMC_PACKAGE_WHEEL_ARCH || 'manylinux_2_39_aarch64' }}
@@ -60,6 +61,7 @@ jobs:
           set -euo pipefail
           if [ -d "$GITHUB_WORKSPACE" ]; then
             chmod -R a+rwX "$GITHUB_WORKSPACE" 2>/dev/null || true
+            docker rm -f "$TRTMC_CI_CONTAINER_NAME" >/dev/null 2>&1 || true
             docker image inspect "$TRTMC_CI_IMAGE" >/dev/null || {
               echo "::error::Docker image '$TRTMC_CI_IMAGE' is not present on the self-hosted runner. Set repository variable TRTMC_MANYLINUX_CI_IMAGE if the runner uses a different local manylinux image tag."
               exit 1
@@ -129,19 +131,19 @@ jobs:
             echo "CI mode: branch/manual unit gates"
           fi
 
+      - name: Start CI container
+        timeout-minutes: 5
+        run: bash .github/scripts/start-gha-container.sh
+
       - name: Build trtmc pip package
         timeout-minutes: 30
         run: bash .github/scripts/run-gha-stage.sh package
-
-      - name: Setup TensorRT-Model-Connect
-        timeout-minutes: 5
-        run: bash .github/scripts/run-gha-stage.sh setup
 
       - name: Impact analysis
         timeout-minutes: 5
         run: bash .github/scripts/run-gha-stage.sh impact
 
-      - name: Build all
+      - name: Build C++ test executables
         timeout-minutes: 15
         run: bash .github/scripts/run-gha-stage.sh build
 
@@ -214,3 +216,7 @@ jobs:
             coverage/
             e2e_artifacts/
             dist/*.whl
+
+      - name: Stop CI container
+        if: always()
+        run: docker rm -f "$TRTMC_CI_CONTAINER_NAME" >/dev/null 2>&1 || true

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 cmake-build-*/
 
 # Local coverage and investigation output
+/.ci/
 /coverage/
 /artifacts/
 
@@ -26,6 +27,7 @@ cmake-build-*/
 # CMake/Ninja generated files
 CMakeFiles/
 CMakeCache.txt
+CMakeUserPresets.json
 cmake_install.cmake
 install_manifest.txt
 Makefile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,22 @@ add_library(trtmc_core
   src/runtime/models/pixart_torchtrt/pipeline.cpp
 )
 
+# Keep warning policy strict for project code, but avoid CI log spam from
+# vendored STB implementation headers and known GCC 13/libstdc++ false
+# positives from inlined std::vector assignment helpers.
+set_source_files_properties(src/runtime/core/stb_impl.cpp
+  PROPERTIES
+    COMPILE_OPTIONS "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-pedantic>;$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-missing-field-initializers>"
+)
+set_source_files_properties(
+  src/runtime/models/magpie/pipeline.cpp
+  src/runtime/models/pixart/pipeline.cpp
+  src/runtime/models/speech/pipeline.cpp
+  src/runtime/models/wan/pipeline.cpp
+  PROPERTIES
+    COMPILE_OPTIONS "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-nonnull>;$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-free-nonheap-object>"
+)
+
 # Add CUDA kernel sources when CUDA compiler is available
 if(CMAKE_CUDA_COMPILER)
   target_sources(trtmc_core PRIVATE
@@ -253,7 +269,9 @@ target_include_directories(trtmc_core
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE
     ${PROJECT_SOURCE_DIR}/src
-    ${PROJECT_SOURCE_DIR}/third_party/stb
+)
+target_include_directories(trtmc_core SYSTEM PRIVATE
+  ${PROJECT_SOURCE_DIR}/third_party/stb
 )
 
 target_compile_definitions(trtmc_core
@@ -264,9 +282,8 @@ target_compile_definitions(trtmc_core
 
 target_compile_options(trtmc_core
   PRIVATE
-    -Wall
-    -Wextra
-    -Wpedantic
+    "$<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Wpedantic>"
+    "$<$<COMPILE_LANGUAGE:CUDA>:-Wall;-Wextra>"
 )
 
 # nlohmann/json: use include-only (header-only lib) to avoid export-set issues
@@ -529,18 +546,20 @@ add_executable(trtmc
   src/cli/main.cpp
 )
 target_link_libraries(trtmc PRIVATE trtmc_core)
-target_include_directories(trtmc PRIVATE ${PROJECT_SOURCE_DIR}/third_party/stb ${PROJECT_SOURCE_DIR}/src)
+target_include_directories(trtmc PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_include_directories(trtmc SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/third_party/stb)
 
 if(TRTMC_BUILD_BENCHMARKS)
   add_executable(trtmc_dataset_benchmark examples/trtmc_dataset_benchmark.cpp)
   target_link_libraries(trtmc_dataset_benchmark PRIVATE trtmc_core)
-  target_include_directories(trtmc_dataset_benchmark PRIVATE
+  target_include_directories(trtmc_dataset_benchmark SYSTEM PRIVATE
     ${PROJECT_SOURCE_DIR}/third_party/stb
   )
 endif()
 
 if(TRTMC_BUILD_TESTS)
 enable_testing()
+add_custom_target(trtmc_cpp_tests)
 
 # --- Test helper function ---
 # Usage:
@@ -552,7 +571,8 @@ function(trtmc_add_test TEST_NAME)
     message(STATUS "Skipping ${TEST_NAME}: TensorRT SDK not available")
     return()
   endif()
-  add_executable(${TEST_NAME} tests/cpp/${TEST_NAME}.cpp)
+  add_executable(${TEST_NAME} EXCLUDE_FROM_ALL tests/cpp/${TEST_NAME}.cpp)
+  add_dependencies(trtmc_cpp_tests ${TEST_NAME})
   target_link_libraries(${TEST_NAME} PRIVATE trtmc_core)
   if(NOT ARG_NO_SRC_INCLUDE)
     target_include_directories(${TEST_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,6 +10,10 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy
 
 
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 class TensorRTModelConnectConan(ConanFile):
     name = "tensorrt-model-connect"
     version = "0.1.0"
@@ -28,7 +32,9 @@ class TensorRTModelConnectConan(ConanFile):
         deps.generate()
 
         toolchain = CMakeToolchain(self)
-        toolchain.cache_variables["TRTMC_BUILD_TESTS"] = False
+        toolchain.cache_variables["TRTMC_BUILD_TESTS"] = _env_flag(
+            "TRTMC_CONAN_ENABLE_TEST_TARGETS"
+        )
         toolchain.cache_variables["TRTMC_BUILD_BENCHMARKS"] = False
         toolchain.cache_variables["TRTMC_ENABLE_LIBTORCH_MULTINOMIAL"] = False
 
@@ -47,7 +53,12 @@ class TensorRTModelConnectConan(ConanFile):
     def build(self) -> None:
         cmake = CMake(self)
         cmake.configure()
-        cmake.build()
+        targets = os.environ.get("TRTMC_CONAN_BUILD_TARGETS", "").split()
+        if targets:
+            for target in targets:
+                cmake.build(target=target)
+        else:
+            cmake.build()
 
     def package(self) -> None:
         package_bin = Path(self.package_folder) / "tensorrt_model_connect" / "bin"

--- a/src/runtime/core/sampler.cpp
+++ b/src/runtime/core/sampler.cpp
@@ -423,7 +423,7 @@ SamplingParams sampling_params_from_config(const GenerateConfig& cfg, int32_t de
 }
 
 std::unique_ptr<ISampler> create_sampler(const SamplingParams& params,
-                                         const SamplerFactoryOptions& options) {
+                                         [[maybe_unused]] const SamplerFactoryOptions& options) {
     // Greedy when sampling is fully disabled and no explicit random seed is set.
     const float top_p = sanitized_top_p(params.top_p);
     const float min_p = sanitized_min_p(params.min_p);

--- a/src/runtime/models/flux/pipeline.cpp
+++ b/src/runtime/models/flux/pipeline.cpp
@@ -328,8 +328,8 @@ void unpack_flux_velocity(const std::vector<float>& denoiser_output, int32_t z_d
 // Step logging
 // ---------------------------------------------------------------------------
 
-void compute_vector_stats(const std::vector<float>& values, float& min_out, float& max_out,
-                          double& mean_out) {
+[[maybe_unused]] void compute_vector_stats(const std::vector<float>& values, float& min_out,
+                                           float& max_out, double& mean_out) {
     min_out = values[0];
     max_out = values[0];
     double sum = 0.0;

--- a/src/runtime/models/magpie/pipeline.cpp
+++ b/src/runtime/models/magpie/pipeline.cpp
@@ -102,7 +102,6 @@ MagpiePipeline::MagpiePipeline(
     cudaStream_t stream, std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str)
     : encoder_(std::move(encoder)), decoder_(std::move(decoder)),
       decoder_state_(std::move(decoder_state)), codec_(std::move(codec)),
-      lt_module_(std::move(lt_module)), prefill_module_(std::move(prefill_module)),
       decoder_state_uncond_(std::move(decoder_state_uncond)), cross_k_(std::move(cross_k)),
       cross_v_(std::move(cross_v)), cross_k_uncond_(std::move(cross_k_uncond)),
       cross_v_uncond_(std::move(cross_v_uncond)), encoder_output_(std::move(encoder_output)),
@@ -117,8 +116,9 @@ MagpiePipeline::MagpiePipeline(
       device_all_codes_(static_cast<std::size_t>(512) * config.num_codebooks * sizeof(int32_t)),
       device_logits_cond_(0), device_logits_uncond_(0),
       device_rand_vals_(static_cast<std::size_t>(config.num_codebooks) * sizeof(float)),
-      stream_(stream), config_(config), tokenizer_(std::move(tokenizer)),
-      model_id_(std::move(model_id_str)), rng_(std::random_device{}()) {
+      prefill_module_(std::move(prefill_module)), lt_module_(std::move(lt_module)), stream_(stream),
+      config_(config), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
+      rng_(std::random_device{}()) {
     if (!decoder_ || !decoder_->ok())
         throw std::runtime_error("MagpiePipeline: invalid decoder module");
     if (!decoder_state_ || !decoder_state_->ok())
@@ -579,6 +579,7 @@ bool MagpiePipeline::prefill_context_sequential(DecoderLoopState& state, int32_t
 // ---------------------------------------------------------------------------
 
 bool MagpiePipeline::run_cfg_uncond_pass_gpu(DecoderLoopState& state, int32_t frame) {
+    (void)frame;
 #if TRTMC_HAS_CUDA_KERNELS
     // Save conditioned logits
     void* cond_logits_ptr = decoder_->device_ptr("logits");
@@ -617,7 +618,6 @@ bool MagpiePipeline::run_cfg_uncond_pass_gpu(DecoderLoopState& state, int32_t fr
     return true;
 #else
     (void)state;
-    (void)frame;
     return false;
 #endif
 }

--- a/src/runtime/models/magpie/pipeline.h
+++ b/src/runtime/models/magpie/pipeline.h
@@ -42,6 +42,7 @@ class MagpiePipeline final : public IPipeline {
 
     const char* model_id() const override { return model_id_.c_str(); }
     const char* pipeline_type() const override { return "MagpiePipeline"; }
+    using IPipeline::generate_audio_streaming;
 
   private:
     struct DecoderLoopState {

--- a/src/tokenizer/unigram_tokenizer.cpp
+++ b/src/tokenizer/unigram_tokenizer.cpp
@@ -165,7 +165,8 @@ std::vector<std::string> whitespace_split(const std::string& text) {
     return words;
 }
 
-std::string metaspace_pre_tokenize(const std::string& text, bool add_prefix_space) {
+[[maybe_unused]] std::string metaspace_pre_tokenize(const std::string& text,
+                                                    bool add_prefix_space) {
     std::string result;
     result.reserve(text.size() + 8);
     if (add_prefix_space && !text.empty() && text[0] != ' ') {

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -20,7 +20,8 @@ def test_workflows_define_shared_hf_cache_env() -> None:
 
 
 def test_github_stage_wrapper_mounts_and_exports_hf_cache_env() -> None:
-    text = (REPO_ROOT / ".github" / "scripts" / "run-gha-stage.sh").read_text()
+    stage_text = (REPO_ROOT / ".github" / "scripts" / "run-gha-stage.sh").read_text()
+    start_text = (REPO_ROOT / ".github" / "scripts" / "start-gha-container.sh").read_text()
     for name in (
         "TRTMC_STORAGE_ROOT",
         "HF_HOME",
@@ -28,9 +29,11 @@ def test_github_stage_wrapper_mounts_and_exports_hf_cache_env() -> None:
         "HUGGINGFACE_HUB_CACHE",
         "HF_MODULES_CACHE",
     ):
-        assert f'mkdir_if_set "${{{name}:-}}"' in text
-        assert f"-e {name}" in text
-    assert "/workspace/users/yifeif:/workspace/users/yifeif" in text
+        assert f'mkdir_if_set "${{{name}:-}}"' in start_text
+        assert name in start_text
+        assert f"-e {name}" in stage_text
+    assert "/workspace/users/yifeif:/workspace/users/yifeif" in start_text
+    assert "docker exec" in stage_text
 
 
 def test_github_stage_wrapper_exports_e2e_gpu_controls() -> None:
@@ -125,7 +128,7 @@ def test_nightly_attempts_all_test_stages_after_failures() -> None:
     text = (REPO_ROOT / ".github" / "workflows" / "nightly.yml").read_text()
     required_steps = (
         "Impact analysis",
-        "Build all",
+        "Build C++ test executables",
         "Check family coverage",
         "Check cyclomatic complexity",
         "Lint changed files",
@@ -169,9 +172,9 @@ def test_github_ci_uses_manylinux_image_and_builds_wheel_first() -> None:
         assert "TRTMC_PACKAGE_WHEEL_ARCH:" in text
         assert "manylinux_2_39_aarch64" in text
         assert "TRTMC_PACKAGE_CI_IMAGE" not in text
-        assert text.index("Build trtmc pip package") < text.index(
-            "Setup TensorRT-Model-Connect"
-        )
+        assert text.index("Start CI container") < text.index("Build trtmc pip package")
+        assert text.index("Build trtmc pip package") < text.index("Impact analysis")
+        assert "Setup TensorRT-Model-Connect" not in text
 
 
 def test_package_stage_builds_py310_and_py312_wheels() -> None:
@@ -214,14 +217,27 @@ def test_release_wheel_build_disables_libtorch_linkage() -> None:
 
 
 def test_ci_source_build_defaults_to_packaged_libtorch_mode() -> None:
-    script = (REPO_ROOT / ".github" / "scripts" / "run-trtmc-ci.sh").read_text()
+    conanfile = (REPO_ROOT / "conanfile.py").read_text()
     wrapper = (REPO_ROOT / ".github" / "scripts" / "run-gha-stage.sh").read_text()
     coverage = (REPO_ROOT / "tools" / "coverage" / "cpp_coverage.sh").read_text()
-    assert 'TRTMC_ENABLE_LIBTORCH_MULTINOMIAL:-OFF' in script
-    assert '-DTRTMC_ENABLE_LIBTORCH_MULTINOMIAL="$enable_libtorch_multinomial"' in script
+    assert 'toolchain.cache_variables["TRTMC_ENABLE_LIBTORCH_MULTINOMIAL"] = False' in conanfile
     assert 'TRTMC_ENABLE_LIBTORCH_MULTINOMIAL="${TRTMC_ENABLE_LIBTORCH_MULTINOMIAL:-OFF}"' in coverage
     assert '-DTRTMC_ENABLE_LIBTORCH_MULTINOMIAL="${TRTMC_ENABLE_LIBTORCH_MULTINOMIAL}"' in coverage
     assert "-e TRTMC_ENABLE_LIBTORCH_MULTINOMIAL" in wrapper
+
+
+def test_ci_cpp_test_build_reuses_wheel_conan_tree() -> None:
+    script = (REPO_ROOT / ".github" / "scripts" / "run-trtmc-ci.sh").read_text()
+    assert "TRTMC_CONAN_ENABLE_TEST_TARGETS=1" in script
+    assert 'TRTMC_CONAN_BUILD_TARGETS="$targets"' in script
+    assert 'conan build . -of "$TRTMC_REUSE_CONAN_OUT_DIR"' in script
+    assert 'ctest --test-dir "$TRTMC_REUSE_CMAKE_BUILD_DIR"' in script
+    assert "wheel_build_metadata_file" in script
+
+
+def test_cpp_coverage_builds_excluded_test_target() -> None:
+    coverage = (REPO_ROOT / "tools" / "coverage" / "cpp_coverage.sh").read_text()
+    assert "--target trtmc_cpp_tests" in coverage
 
 
 def test_root_pyproject_configures_conan_py_build_wheel() -> None:

--- a/tools/coverage/cpp_coverage.sh
+++ b/tools/coverage/cpp_coverage.sh
@@ -142,11 +142,15 @@ echo "[cpp-coverage] Gate thresholds: line>=${CPP_COVERAGE_MIN_LINE}% function>=
 
 cmake "${cmake_args[@]}"
 
+build_parallel_args=(--parallel)
 if [[ -n "${BUILD_PARALLEL}" ]]; then
-  cmake --build "${BUILD_DIR}" --parallel "${BUILD_PARALLEL}"
-else
-  cmake --build "${BUILD_DIR}" --parallel
+  build_parallel_args=(--parallel "${BUILD_PARALLEL}")
 fi
+
+cmake --build "${BUILD_DIR}" "${build_parallel_args[@]}"
+# C++ unit test executables are excluded from the default wheel build, so
+# coverage must request the aggregate test target explicitly before ctest.
+cmake --build "${BUILD_DIR}" --target trtmc_cpp_tests "${build_parallel_args[@]}"
 
 # Remove stale runtime coverage data from previous runs.
 find "${BUILD_DIR}" -name "*.gcda" -delete || true


### PR DESCRIPTION
## Background
CI currently builds the native runtime once through `conan-py-build` for the wheel, then configures a second CMake build just to compile and run C++ unit tests. Downstream stages also start fresh containers, which repeats setup and loses the wheel install state.

## Exit Criteria
- Keep wheel-first CI behavior and wheel artifact semantics unchanged.
- Reuse the wheel package stage's Conan/CMake tree to build C++ test executables.
- Install the built wheel once per CI job container, then have runtime stages verify that install instead of reinstalling.
- Preserve source-only and coverage stage behavior without weakening gates.

## Implementation
- Added a job-scoped CI container startup script and changed stage execution from per-stage `docker run --rm` to `docker exec`.
- The package stage now enables C++ test target configuration, writes reusable wheel build metadata under `.ci/`, and installs the built wheel once into the shared container.
- `conanfile.py` now supports CI-only test target configuration and target-specific `conan build` calls via environment variables.
- CMake now creates an aggregate `trtmc_cpp_tests` target while keeping individual tests out of the default wheel build.
- C++ unit tests now run from the reused Conan CMake build directory, and C++ coverage explicitly builds the excluded test target before CTest.
- Narrow warning cleanup handles STB, CUDA pedantic noise, and known GCC/libstdc++ false positives without relaxing global warning policy.

## Validation
- `bash -n .github/scripts/run-trtmc-ci.sh .github/scripts/run-gha-stage.sh .github/scripts/start-gha-container.sh tools/coverage/cpp_coverage.sh`: passed.
- `python -m py_compile conanfile.py`: passed.
- `python -m ruff check --config ruff.toml tests/tools/test_github_actions_ci.py conanfile.py`: passed.
- YAML parse for `.github/workflows/trtmc-ci.yml` and `.github/workflows/nightly.yml`: passed.
- `git diff --check`: passed.
- Docker CI lint stage, `bash .github/scripts/run-gha-stage.sh lint`: passed against `github/main...HEAD`.
- Docker pytest, `python -m pytest tests/tools/test_github_actions_ci.py -q`: passed, 26 tests.
- Docker C++ build stage, `FULL_E2E=true bash .github/scripts/run-gha-stage.sh build`: passed and built `trtmc_cpp_tests` through Conan from the reusable wheel build directory.
- Docker C++ unit stage, `FULL_E2E=true bash .github/scripts/run-gha-stage.sh cpp-unit`: passed, 92/92 tests.
- Docker setup stage, `bash .github/scripts/run-gha-stage.sh setup`: passed and verified the installed wheel imports from site-packages with native `trtmc` and backend DSOs.
- Docker package stage was run until the local runner hit host disk exhaustion during the existing dependency-heavy isolated smoke install; before that point it completed the native wheel build, auditwheel validation, and reusable metadata write.

## Notes For Future Readers
- Review the workflow/scripts first, then `conanfile.py`/CMake. The small C++ source edits are warning cleanup needed to keep the stricter build logs readable.
- The plan markdown used during review is intentionally not included in this PR.
