### PR TITLE
feat(magpie): add tensor parallel decoder

### DIFF
--- a/python/tensorrt_model_connect/families/magpie_tts/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/magpie_tts/decoder_tp_builder.py
@@ -1,0 +1,475 @@
+"""Tensor-parallel MagpieTTS decoder builder.
+
+This mirrors the decoder graph in ``plugin.py`` and only changes the
+rank-local projection widths. Self-attention Q/K/V and FC1 are
+column-parallel, self-attention output and FC2 are row-parallel and joined
+with TensorRT distributed ALL_REDUCE. Magpie's asymmetric cross-attention has
+one head in the current checkpoint, so it stays replicated on every rank.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import (
+    add_all_reduce_sum,
+    normalize_parallel_config,
+)
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _mark_debug_output(network, tensor, name):
+    identity = network.add_identity(tensor)
+    cast = network.add_cast(identity.get_output(0), trt.float32)
+    out = cast.get_output(0)
+    out.name = name
+    network.mark_output(out)
+
+
+def _slice_first_dim(value: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    if value.shape[0] % tp_size != 0:
+        raise ValueError(f"Cannot shard first dimension {value.shape[0]} over TP{tp_size}")
+    chunk = value.shape[0] // tp_size
+    return np.ascontiguousarray(value[rank * chunk:(rank + 1) * chunk])
+
+
+def _slice_last_dim(value: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    if value.shape[-1] % tp_size != 0:
+        raise ValueError(f"Cannot shard last dimension {value.shape[-1]} over TP{tp_size}")
+    chunk = value.shape[-1] // tp_size
+    slc = [slice(None)] * value.ndim
+    slc[-1] = slice(rank * chunk, (rank + 1) * chunk)
+    return np.ascontiguousarray(value[tuple(slc)])
+
+
+def validate_magpie_decoder_tp(weights: "WeightDict", parallel: "ParallelConfig") -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        raise ValueError("MagpieTTS tensor-parallel builder requires an enabled parallel config")
+    if parallel.rank < 0:
+        raise ValueError("MagpieTTS tensor-parallel engine build requires a concrete rank")
+
+    tp = parallel.tp_size
+    hidden = int(weights["_hidden_size"])
+    dec_heads = int(weights["_dec_heads"])
+    dec_ffn = int(weights["_dec_ffn"])
+    if hidden % tp != 0:
+        raise ValueError(
+            f"MagpieTTS hidden_size={hidden} must be divisible by TP{tp}")
+    if dec_heads % tp != 0:
+        raise ValueError(
+            f"MagpieTTS decoder heads={dec_heads} must be divisible by TP{tp}")
+    if dec_ffn % tp != 0:
+        raise ValueError(
+            f"MagpieTTS decoder FFN size={dec_ffn} must be divisible by TP{tp}")
+
+
+def shard_magpie_decoder_weights(weights: "WeightDict", parallel_config=None) -> "WeightDict":
+    """Return rank-local weights for the Magpie decoder."""
+    parallel = normalize_parallel_config(parallel_config)
+    validate_magpie_decoder_tp(weights, parallel)
+
+    rank = parallel.rank
+    tp = parallel.tp_size
+    dec_layers = int(weights["_dec_layers"])
+    out = type(weights)()
+
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        handled = False
+        for layer_idx in range(dec_layers):
+            pfx = f"layer.{layer_idx}"
+            if key in {f"{pfx}.w_q", f"{pfx}.w_k", f"{pfx}.w_v", f"{pfx}.w_fc1"}:
+                out[key] = _slice_last_dim(value, rank, tp)
+                handled = True
+                break
+            if key in {f"{pfx}.w_o", f"{pfx}.w_fc2"}:
+                out[key] = _slice_first_dim(value, rank, tp)
+                handled = True
+                break
+        if not handled:
+            out[key] = value
+
+    out["_tensor_parallel_size"] = tp
+    out["_tensor_parallel_rank"] = rank
+    return out
+
+
+def build_magpie_tp_decoder_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    parallel_config=None,
+) -> bytes:
+    del config
+    if quant_ctx is not None:
+        raise ValueError("MagpieTTS tensor-parallel builds do not support quantization")
+
+    parallel = normalize_parallel_config(parallel_config)
+    validate_magpie_decoder_tp(weights, parallel)
+
+    dec_layers = int(weights["_dec_layers"])
+    dec_heads = int(weights["_dec_heads"])
+    dec_ffn = int(weights["_dec_ffn"])
+    hidden = int(weights["_hidden_size"])
+    num_codebooks = int(weights["_num_codebooks"])
+    codebook_size = int(weights["_codebook_size"])
+    max_source_positions = int(weights["_max_source_positions"])
+    xa_n_heads = int(weights["_xa_n_heads"])
+    xa_d_head = int(weights["_xa_d_head"])
+    head_dim = hidden // dec_heads
+    local_heads = dec_heads // parallel.tp_size
+    local_attention_size = local_heads * head_dim
+    local_ffn = dec_ffn // parallel.tp_size
+    output_size = num_codebooks * codebook_size
+    rank_weights = shard_magpie_decoder_weights(weights, parallel)
+
+    ctx_len = 1
+    if "baked_context_lengths" in weights:
+        ctx_lengths = np.asarray(weights["baked_context_lengths"], dtype=np.int32)
+        if ctx_lengths.size > 0:
+            ctx_len = max(int(ctx_lengths.max()), 1)
+
+    W = max_cache_length
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    trt_config.clear_flag(trt.BuilderFlag.TF32)
+
+    input_embed = network.add_input("input_embed", trt.float32, (-1, hidden))
+    position_id = network.add_input("position_id", trt.int32, (-1,))
+    attention_mask = network.add_input("attention_mask", trt.float32, (1, -1, -1))
+
+    cache_k_inputs, cache_v_inputs = [], []
+    for i in range(dec_layers):
+        cache_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_k", i),
+            trt.float32, (max_cache_length, local_attention_size)))
+        cache_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_v", i),
+            trt.float32, (max_cache_length, local_attention_size)))
+
+    cross_kv_dtype = trt.float16 if precision == "fp16" else trt.float32
+    cross_k_inputs, cross_v_inputs = [], []
+    for i in range(dec_layers):
+        cross_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cross_k", i),
+            cross_kv_dtype, (max_source_positions, hidden)))
+        cross_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cross_v", i),
+            cross_kv_dtype, (max_source_positions, hidden)))
+
+    cross_attn_prior = network.add_input(
+        "cross_attn_prior", trt.float32, (1, 1, max_source_positions))
+    prior_layers = set(range(3, 10))
+
+    ar_profile = builder.create_optimization_profile()
+    ar_profile.set_shape("input_embed", (1, hidden), (1, hidden), (ctx_len, hidden))
+    ar_profile.set_shape("position_id", (1,), (1,), (ctx_len,))
+    ar_profile.set_shape(
+        "attention_mask", (1, 1, W + 1), (1, 1, W + 1), (1, ctx_len, W + ctx_len))
+    trt_config.add_optimization_profile(ar_profile)
+
+    pf_profile = builder.create_optimization_profile()
+    pf_profile.set_shape("input_embed", (1, hidden), (ctx_len, hidden), (ctx_len, hidden))
+    pf_profile.set_shape("position_id", (1,), (ctx_len,), (ctx_len,))
+    pf_profile.set_shape(
+        "attention_mask",
+        (1, 1, W + 1),
+        (1, ctx_len, W + ctx_len),
+        (1, ctx_len, W + ctx_len),
+    )
+    trt_config.add_optimization_profile(pf_profile)
+
+    dec_pos_np = rank_weights["dec_pos_embedding"]
+    pos_table = graph_ops.add_constant(network, dec_pos_np.shape, dec_pos_np)
+    pos_embed = network.add_gather(pos_table, position_id, 0)
+    hidden_state = network.add_elementwise(
+        input_embed, pos_embed.get_output(0), trt.ElementWiseOperation.SUM).get_output(0)
+
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([1e-5], dtype=np.float32))
+    xa_scale_tensor = graph_ops.add_constant(
+        network, (1, 1, 1), np.array([1.0 / np.sqrt(max(xa_d_head, 1))], dtype=np.float32))
+
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    present_k_outputs, present_v_outputs = [], []
+    alignment_layers = [3, 4, 5, 6]
+    alignment_weights = []
+    for layer_idx in range(dec_layers):
+        prefix = f"layer.{layer_idx}"
+        layer_prior = cross_attn_prior if layer_idx in prior_layers else None
+        result = _add_magpie_tp_decoder_layer(
+            network=network,
+            hidden=hidden_state,
+            cache_k=cache_k_inputs[layer_idx],
+            cache_v=cache_v_inputs[layer_idx],
+            cross_k=cross_k_inputs[layer_idx],
+            cross_v=cross_v_inputs[layer_idx],
+            attention_mask=attention_mask,
+            xa_scale_tensor=xa_scale_tensor,
+            eps_tensor=eps_tensor,
+            weights=rank_weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            local_attention_size=local_attention_size,
+            local_heads=local_heads,
+            head_dim=head_dim,
+            local_ffn=local_ffn,
+            max_source_positions=max_source_positions,
+            xa_n_heads=xa_n_heads,
+            xa_d_head=xa_d_head,
+            tp_size=parallel.tp_size,
+            cross_attn_prior=layer_prior,
+        )
+        hidden_state = result["hidden"]
+        present_k_outputs.append(result["present_k"])
+        present_v_outputs.append(result["present_v"])
+        if layer_idx in alignment_layers:
+            alignment_weights.append(result["cross_attn_weights"])
+        if layer_idx == dec_layers - 1:
+            _mark_debug_output(network, result["cross_attn_weights"], "cross_attn_weights")
+        if debug_layer_outputs:
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    if len(alignment_weights) >= 2:
+        avg = alignment_weights[0]
+        for aw in alignment_weights[1:]:
+            avg = network.add_elementwise(avg, aw, trt.ElementWiseOperation.SUM).get_output(0)
+        n_align = graph_ops.add_constant(
+            network, (1, 1, 1), np.array([1.0 / len(alignment_weights)], dtype=np.float32))
+        avg = network.add_elementwise(avg, n_align, trt.ElementWiseOperation.PROD).get_output(0)
+        avg_over_heads = network.add_reduce(avg, trt.ReduceOperation.AVG, 1 << 0, True)
+        _mark_debug_output(network, avg_over_heads.get_output(0), "alignment_weights")
+
+    hidden_state = graph_ops.add_layer_norm(
+        network,
+        hidden_state,
+        hidden,
+        rank_weights["final_norm"],
+        np.zeros(hidden, dtype=np.float32),
+        eps_tensor,
+    )
+    _mark_debug_output(network, hidden_state, "decoder_hidden")
+
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, output_size, rank_weights["w_out"])
+    logits = graph_ops.add_bias_sum(
+        network, logits, output_size, rank_weights["w_out_bias"])
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for i in range(dec_layers):
+        present_k_outputs[i].name = graph_ops.layer_tensor_name("present_k", i)
+        present_v_outputs[i].name = graph_ops.layer_tensor_name("present_v", i)
+        network.mark_output(present_k_outputs[i])
+        network.mark_output(present_v_outputs[i])
+
+    if verbose:
+        print(
+            f"[trtmc build] Building MagpieTTS TP decoder rank "
+            f"{parallel.rank}/{parallel.tp_size} ({dec_layers}L, h={hidden}, "
+            f"local_sa_heads={local_heads}, local_attn={local_attention_size}, "
+            f"xa_heads={xa_n_heads} d_head={xa_d_head}, local_ffn={local_ffn}, "
+            f"cache={max_cache_length}, output={num_codebooks}x{codebook_size}, "
+            f"prefill_ctx_len={ctx_len})",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT MagpieTTS tensor-parallel decoder engine build failed")
+    return bytes(plan)
+
+
+def _add_magpie_tp_decoder_layer(
+    *,
+    network,
+    hidden,
+    cache_k,
+    cache_v,
+    cross_k,
+    cross_v,
+    attention_mask,
+    xa_scale_tensor,
+    eps_tensor,
+    weights,
+    prefix,
+    hidden_size,
+    local_attention_size,
+    local_heads,
+    head_dim,
+    local_ffn,
+    max_source_positions,
+    xa_n_heads,
+    xa_d_head,
+    tp_size,
+    cross_attn_prior=None,
+):
+    xa_attention_size = xa_n_heads * xa_d_head
+
+    normed = graph_ops.add_layer_norm(
+        network,
+        hidden,
+        hidden_size,
+        weights[f"{prefix}.input_norm"],
+        np.zeros(hidden_size, dtype=np.float32),
+        eps_tensor,
+    )
+
+    q = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, local_attention_size, weights[f"{prefix}.w_q"])
+    k = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, local_attention_size, weights[f"{prefix}.w_k"])
+    v = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, local_attention_size, weights[f"{prefix}.w_v"])
+
+    present_k = k
+    present_v = v
+
+    ak = network.add_concatenation([cache_k, k])
+    ak.axis = 0
+    av = network.add_concatenation([cache_v, v])
+    av.axis = 0
+
+    mask_4d = graph_ops.add_3d_mask_to_4d(network, attention_mask)
+    cf = graph_ops.add_attention_from_rows(
+        network,
+        q,
+        ak.get_output(0),
+        av.get_output(0),
+        num_heads=local_heads,
+        head_dim=head_dim,
+        q_seq=None,
+        kv_seq=None,
+        mask=mask_4d,
+    )
+
+    sa = graph_ops.add_matmul_rhs_constant(
+        network, cf, local_attention_size, hidden_size, weights[f"{prefix}.w_o"])
+    sa = add_all_reduce_sum(network, sa, tp_size)
+    psa = network.add_elementwise(hidden, sa, trt.ElementWiseOperation.SUM).get_output(0)
+
+    cn_query = graph_ops.add_layer_norm(
+        network,
+        psa,
+        hidden_size,
+        weights[f"{prefix}.norm_xattn_query"],
+        np.zeros(hidden_size, dtype=np.float32),
+        eps_tensor,
+    )
+
+    cn_memory = graph_ops.add_layer_norm(
+        network,
+        cross_k,
+        hidden_size,
+        weights[f"{prefix}.norm_xattn_memory"],
+        np.zeros(hidden_size, dtype=np.float32),
+        eps_tensor,
+    )
+
+    cq = graph_ops.add_matmul_rhs_constant(
+        network, cn_query, hidden_size, xa_attention_size, weights[f"{prefix}.cross_w_q"])
+    ck_proj = graph_ops.add_matmul_rhs_constant(
+        network, cn_memory, hidden_size, xa_attention_size, weights[f"{prefix}.cross_w_k"])
+    cv_proj = graph_ops.add_matmul_rhs_constant(
+        network, cn_memory, hidden_size, xa_attention_size, weights[f"{prefix}.cross_w_v"])
+
+    cqh = network.add_shuffle(cq)
+    cqh.reshape_dims = (-1, xa_n_heads, xa_d_head)
+    cqh.second_transpose = trt.Permutation([1, 0, 2])
+    ckh = network.add_shuffle(ck_proj)
+    ckh.reshape_dims = (max_source_positions, xa_n_heads, xa_d_head)
+    ckh.second_transpose = trt.Permutation([1, 0, 2])
+    cvh = network.add_shuffle(cv_proj)
+    cvh.reshape_dims = (max_source_positions, xa_n_heads, xa_d_head)
+    cvh.second_transpose = trt.Permutation([1, 0, 2])
+
+    cs = network.add_elementwise(
+        network.add_matrix_multiply(
+            cqh.get_output(0),
+            trt.MatrixOperation.NONE,
+            ckh.get_output(0),
+            trt.MatrixOperation.TRANSPOSE,
+        ).get_output(0),
+        xa_scale_tensor,
+        trt.ElementWiseOperation.PROD,
+    )
+    csm = network.add_softmax(cs.get_output(0))
+    csm.axes = 1 << 2
+
+    if cross_attn_prior is not None:
+        attn_weighted = network.add_elementwise(
+            csm.get_output(0), cross_attn_prior, trt.ElementWiseOperation.PROD)
+        sum_layer = network.add_reduce(
+            attn_weighted.get_output(0), trt.ReduceOperation.SUM, 1 << 2, True)
+        eps_norm = graph_ops.add_constant(
+            network, (1, 1, 1), np.array([1e-8], dtype=np.float32))
+        sum_safe = network.add_elementwise(
+            sum_layer.get_output(0), eps_norm, trt.ElementWiseOperation.SUM)
+        csm_final = network.add_elementwise(
+            attn_weighted.get_output(0), sum_safe.get_output(0), trt.ElementWiseOperation.DIV)
+    else:
+        csm_final = csm
+
+    cc = network.add_matrix_multiply(
+        csm_final.get_output(0), trt.MatrixOperation.NONE,
+        cvh.get_output(0), trt.MatrixOperation.NONE)
+    ccf = network.add_shuffle(cc.get_output(0))
+    ccf.first_transpose = trt.Permutation([1, 0, 2])
+    ccf.reshape_dims = (-1, xa_attention_size)
+
+    ca = graph_ops.add_matmul_rhs_constant(
+        network, ccf.get_output(0), xa_attention_size, hidden_size,
+        weights[f"{prefix}.cross_w_o"])
+    pca = network.add_elementwise(psa, ca, trt.ElementWiseOperation.SUM).get_output(0)
+
+    fn = graph_ops.add_layer_norm(
+        network,
+        pca,
+        hidden_size,
+        weights[f"{prefix}.post_attn_norm"],
+        np.zeros(hidden_size, dtype=np.float32),
+        eps_tensor,
+    )
+
+    fc1 = graph_ops.add_matmul_rhs_constant(
+        network, fn, hidden_size, local_ffn, weights[f"{prefix}.w_fc1"])
+    act = graph_ops.add_activation(network, fc1, "gelu_new")
+    fc2 = graph_ops.add_matmul_rhs_constant(
+        network, act, local_ffn, hidden_size, weights[f"{prefix}.w_fc2"])
+    fc2 = add_all_reduce_sum(network, fc2, tp_size)
+
+    out = network.add_elementwise(pca, fc2, trt.ElementWiseOperation.SUM).get_output(0)
+
+    return {
+        "hidden": out,
+        "present_k": present_k,
+        "present_v": present_v,
+        "cross_attn_weights": csm.get_output(0),
+    }

--- a/python/tensorrt_model_connect/families/magpie_tts/plugin.py
+++ b/python/tensorrt_model_connect/families/magpie_tts/plugin.py
@@ -64,6 +64,10 @@ from tensorrt_model_connect import trt_compat
 from ...config import ModelConfig
 from ...checkpoint_mapper import WeightDict
 from ...build_timing import timed_trt_compile
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 from ... import graph_ops
 from . import magpie_tokenizer
 
@@ -714,6 +718,7 @@ class MagpieTTSPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
         debug_layer_outputs: bool = False,
+        parallel_config=None,
     ) -> bytes:
         """Build MagpieTTS decoder TRT engine with dynamic seq_len.
 
@@ -722,6 +727,24 @@ class MagpieTTSPlugin:
           - Batched prefill: seq_len=ctx_len (profile 1)
         No separate prefill engine needed — saves ~400MB bundle space.
         """
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="MagpieTTS tensor-parallel decoder builds")
+            if quant_ctx is not None:
+                raise ValueError("MagpieTTS tensor-parallel builds do not support quantization")
+            from .decoder_tp_builder import build_magpie_tp_decoder_engine
+            return build_magpie_tp_decoder_engine(
+                config,
+                weights,
+                max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                parallel_config=parallel,
+            )
+
         dec_layers = weights["_dec_layers"]
         dec_heads = weights["_dec_heads"]
         dec_ffn = weights["_dec_ffn"]

--- a/src/runtime/models/magpie/plugin.cpp
+++ b/src/runtime/models/magpie/plugin.cpp
@@ -5,14 +5,45 @@
 #include "runtime/plugins/shared/audio_helpers.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
 #include "trtmc/config/config_bundle.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
+#include "utils/json_helpers.h"
 
 #include <cstdint>
 #include <exception>
+#include <limits>
+#include <string>
+#include <vector>
 
 namespace trtmc {
 
 namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
+    if (dim < 0 || static_cast<std::size_t>(dim) >= shape.size())
+        return -1;
+    const auto value = shape[static_cast<std::size_t>(dim)];
+    if (value <= 0 || value > std::numeric_limits<int32_t>::max())
+        return -1;
+    return static_cast<int32_t>(value);
+}
 
 int32_t compute_magpie_kv_dim(const BaseConfig& base_cfg, const MagpieTTSConfig& magpie_cfg) {
     if (base_cfg.num_kv_heads > 0 && base_cfg.head_dim > 0)
@@ -20,6 +51,11 @@ int32_t compute_magpie_kv_dim(const BaseConfig& base_cfg, const MagpieTTSConfig&
     if (base_cfg.attention_size > 0)
         return base_cfg.attention_size;
     return magpie_cfg.hidden_size;
+}
+
+int32_t decoder_cache_row_width(const TrtModule& module, int32_t fallback) {
+    const int32_t from_engine = dim_at(module.tensor_shape("cache_k_0"), 1);
+    return from_engine > 0 ? from_engine : fallback;
 }
 
 } // namespace
@@ -57,6 +93,12 @@ class MagpiePlugin final : public IPipelinePlugin {
   public:
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
         load_ffi_kernels_from_bundle(ctx.bundle);
+
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        if (tp_config.enabled)
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+
         auto shared_stream = std::make_shared<CudaStream>();
         if (!shared_stream->ok())
             throw std::runtime_error("MagpiePlugin: failed to create CUDA stream");
@@ -65,11 +107,19 @@ class MagpiePlugin final : public IPipelinePlugin {
         opts.stream = shared_stream->get();
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
+        ModuleCreateOptions decoder_opts = opts;
+        if (tp_config.enabled) {
+            decoder_opts.distributed_communicator = tp_group.communicator;
+            decoder_opts.distributed_owner = tp_group.owner;
+        }
 
         auto enc_loaded = load_trt_module_from_plan(
             ctx.backend, find_section(ctx.bundle, "vision_engine_plan"), "magpie encoder", opts);
+        const std::string decoder_section =
+            tp_config.enabled ? tp_engine_section_name(tp_group.rank) : std::string("engine_plan");
         auto dec_loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "magpie decoder", opts);
+            ctx.backend, find_section(ctx.bundle, decoder_section), "magpie decoder",
+            decoder_opts);
         enc_loaded.module->keep_alive(shared_stream);
         dec_loaded.module->keep_alive(shared_stream);
 
@@ -77,7 +127,8 @@ class MagpiePlugin final : public IPipelinePlugin {
 
         auto magpie_cfg = build_magpie_config(ctx.config_json, ctx.config);
         apply_magpie_registry_overlay(magpie_cfg, ctx.runtime_config);
-        int32_t kv_dim = compute_magpie_kv_dim(ctx.config, magpie_cfg);
+        const int32_t fallback_kv_dim = compute_magpie_kv_dim(ctx.config, magpie_cfg);
+        int32_t kv_dim = decoder_cache_row_width(*dec_loaded.module, fallback_kv_dim);
 
         DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
         std::unique_ptr<IInferenceState> decoder_state = std::make_unique<KvCache>(

--- a/src/runtime/models/magpie/plugin.cpp
+++ b/src/runtime/models/magpie/plugin.cpp
@@ -24,6 +24,12 @@ struct TensorParallelRuntimeConfig {
     int32_t tp_size{1};
 };
 
+struct MagpieDecoderRuntime {
+    DistributedRuntimeGroup tp_group;
+    ModuleCreateOptions opts;
+    std::string section{"engine_plan"};
+};
+
 TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
     TensorParallelRuntimeConfig cfg;
     cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
@@ -56,6 +62,22 @@ int32_t compute_magpie_kv_dim(const BaseConfig& base_cfg, const MagpieTTSConfig&
 int32_t decoder_cache_row_width(const TrtModule& module, int32_t fallback) {
     const int32_t from_engine = dim_at(module.tensor_shape("cache_k_0"), 1);
     return from_engine > 0 ? from_engine : fallback;
+}
+
+MagpieDecoderRuntime make_magpie_decoder_runtime(const PipelineContext& ctx,
+                                                 const ModuleCreateOptions& base_opts) {
+    MagpieDecoderRuntime runtime;
+    runtime.opts = base_opts;
+
+    const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+    if (!tp_config.enabled)
+        return runtime;
+
+    runtime.tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+    runtime.opts.distributed_communicator = runtime.tp_group.communicator;
+    runtime.opts.distributed_owner = runtime.tp_group.owner;
+    runtime.section = tp_engine_section_name(runtime.tp_group.rank);
+    return runtime;
 }
 
 } // namespace
@@ -94,11 +116,6 @@ class MagpiePlugin final : public IPipelinePlugin {
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
         load_ffi_kernels_from_bundle(ctx.bundle);
 
-        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
-        DistributedRuntimeGroup tp_group;
-        if (tp_config.enabled)
-            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
-
         auto shared_stream = std::make_shared<CudaStream>();
         if (!shared_stream->ok())
             throw std::runtime_error("MagpiePlugin: failed to create CUDA stream");
@@ -107,19 +124,13 @@ class MagpiePlugin final : public IPipelinePlugin {
         opts.stream = shared_stream->get();
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
-        ModuleCreateOptions decoder_opts = opts;
-        if (tp_config.enabled) {
-            decoder_opts.distributed_communicator = tp_group.communicator;
-            decoder_opts.distributed_owner = tp_group.owner;
-        }
+        auto decoder_runtime = make_magpie_decoder_runtime(ctx, opts);
 
         auto enc_loaded = load_trt_module_from_plan(
             ctx.backend, find_section(ctx.bundle, "vision_engine_plan"), "magpie encoder", opts);
-        const std::string decoder_section =
-            tp_config.enabled ? tp_engine_section_name(tp_group.rank) : std::string("engine_plan");
         auto dec_loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, decoder_section), "magpie decoder",
-            decoder_opts);
+            ctx.backend, find_section(ctx.bundle, decoder_runtime.section), "magpie decoder",
+            decoder_runtime.opts);
         enc_loaded.module->keep_alive(shared_stream);
         dec_loaded.module->keep_alive(shared_stream);
 

--- a/src/runtime/models/magpie/plugin.cpp
+++ b/src/runtime/models/magpie/plugin.cpp
@@ -26,7 +26,6 @@ struct TensorParallelRuntimeConfig {
 
 struct MagpieDecoderRuntime {
     DistributedRuntimeGroup tp_group;
-    ModuleCreateOptions opts;
     std::string section{"engine_plan"};
 };
 
@@ -64,18 +63,14 @@ int32_t decoder_cache_row_width(const TrtModule& module, int32_t fallback) {
     return from_engine > 0 ? from_engine : fallback;
 }
 
-MagpieDecoderRuntime make_magpie_decoder_runtime(const PipelineContext& ctx,
-                                                 const ModuleCreateOptions& base_opts) {
+MagpieDecoderRuntime make_magpie_decoder_runtime(const PipelineContext& ctx) {
     MagpieDecoderRuntime runtime;
-    runtime.opts = base_opts;
 
     const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
     if (!tp_config.enabled)
         return runtime;
 
     runtime.tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
-    runtime.opts.distributed_communicator = runtime.tp_group.communicator;
-    runtime.opts.distributed_owner = runtime.tp_group.owner;
     runtime.section = tp_engine_section_name(runtime.tp_group.rank);
     return runtime;
 }
@@ -116,6 +111,7 @@ class MagpiePlugin final : public IPipelinePlugin {
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
         load_ffi_kernels_from_bundle(ctx.bundle);
 
+        auto decoder_runtime = make_magpie_decoder_runtime(ctx);
         auto shared_stream = std::make_shared<CudaStream>();
         if (!shared_stream->ok())
             throw std::runtime_error("MagpiePlugin: failed to create CUDA stream");
@@ -124,13 +120,17 @@ class MagpiePlugin final : public IPipelinePlugin {
         opts.stream = shared_stream->get();
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
-        auto decoder_runtime = make_magpie_decoder_runtime(ctx, opts);
+        ModuleCreateOptions decoder_opts = opts;
+        if (decoder_runtime.tp_group.communicator != nullptr) {
+            decoder_opts.distributed_communicator = decoder_runtime.tp_group.communicator;
+            decoder_opts.distributed_owner = decoder_runtime.tp_group.owner;
+        }
 
         auto enc_loaded = load_trt_module_from_plan(
             ctx.backend, find_section(ctx.bundle, "vision_engine_plan"), "magpie encoder", opts);
         auto dec_loaded = load_trt_module_from_plan(
             ctx.backend, find_section(ctx.bundle, decoder_runtime.section), "magpie decoder",
-            decoder_runtime.opts);
+            decoder_opts);
         enc_loaded.module->keep_alive(shared_stream);
         dec_loaded.module->keep_alive(shared_stream);
 

--- a/tests/builder/test_engine_magpie_tts.py
+++ b/tests/builder/test_engine_magpie_tts.py
@@ -1,0 +1,162 @@
+"""Synthetic tests for MagpieTTS tensor-parallel decoder sharding."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "tensorrt_model_connect.config",
+    reason="tensorrt_model_connect requires tensorrt",
+)
+
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
+
+_LAYERS = 2
+_HIDDEN = 16
+_HEADS = 4
+_FFN = 64
+_MAX_SRC = 8
+_XA_HEADS = 1
+_XA_D_HEAD = 4
+_NUM_CODEBOOKS = 2
+_CODEBOOK_SIZE = 8
+
+
+def _magpie_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.magpie_tts.decoder_tp_builder",
+        reason="TensorRT is required for MagpieTTS TP builder tests",
+    )
+
+
+def _make_magpie_weights() -> dict[str, Any]:
+    rng = np.random.RandomState(123)
+
+    def rand(*shape: int) -> np.ndarray:
+        return rng.randn(*shape).astype(np.float32)
+
+    weights = {
+        "_dec_layers": _LAYERS,
+        "_dec_heads": _HEADS,
+        "_dec_ffn": _FFN,
+        "_hidden_size": _HIDDEN,
+        "_num_codebooks": _NUM_CODEBOOKS,
+        "_codebook_size": _CODEBOOK_SIZE,
+        "_max_source_positions": _MAX_SRC,
+        "_xa_n_heads": _XA_HEADS,
+        "_xa_d_head": _XA_D_HEAD,
+        "dec_pos_embedding": rand(16, _HIDDEN),
+        "final_norm": rand(_HIDDEN),
+        "w_out": rand(_HIDDEN, _NUM_CODEBOOKS * _CODEBOOK_SIZE),
+        "w_out_bias": rand(_NUM_CODEBOOKS * _CODEBOOK_SIZE),
+        "baked_context_lengths": np.array([3, 5], dtype=np.int32),
+    }
+    for i in range(_LAYERS):
+        pfx = f"layer.{i}"
+        for key in ("w_q", "w_k", "w_v", "w_o"):
+            weights[f"{pfx}.{key}"] = rand(_HIDDEN, _HIDDEN)
+        weights[f"{pfx}.w_fc1"] = rand(_HIDDEN, _FFN)
+        weights[f"{pfx}.w_fc2"] = rand(_FFN, _HIDDEN)
+        weights[f"{pfx}.input_norm"] = rand(_HIDDEN)
+        weights[f"{pfx}.post_attn_norm"] = rand(_HIDDEN)
+        weights[f"{pfx}.norm_xattn_query"] = rand(_HIDDEN)
+        weights[f"{pfx}.norm_xattn_memory"] = rand(_HIDDEN)
+        weights[f"{pfx}.cross_w_q"] = rand(_HIDDEN, _XA_HEADS * _XA_D_HEAD)
+        weights[f"{pfx}.cross_w_k"] = rand(_HIDDEN, _XA_HEADS * _XA_D_HEAD)
+        weights[f"{pfx}.cross_w_v"] = rand(_HIDDEN, _XA_HEADS * _XA_D_HEAD)
+        weights[f"{pfx}.cross_w_o"] = rand(_XA_HEADS * _XA_D_HEAD, _HIDDEN)
+    return weights
+
+
+def test_magpie_tp_build_rejects_single_device_parallel_config():
+    decoder_tp_builder = _magpie_tp_builder_module()
+
+    with pytest.raises(ValueError, match="enabled parallel config"):
+        decoder_tp_builder.build_magpie_tp_decoder_engine(
+            object(),
+            _make_magpie_weights(),
+            max_cache_length=4,
+            parallel_config=ParallelConfig(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "message"),
+    [
+        ("_hidden_size", _HIDDEN + 1, "hidden_size"),
+        ("_dec_heads", _HEADS + 1, "decoder heads"),
+        ("_dec_ffn", _FFN + 1, "FFN size"),
+    ],
+)
+def test_magpie_tp_validation_rejects_non_divisible_dimensions(key, value, message):
+    decoder_tp_builder = _magpie_tp_builder_module()
+    weights = _make_magpie_weights()
+    weights[key] = value
+
+    with pytest.raises(ValueError, match=message):
+        decoder_tp_builder.validate_magpie_decoder_tp(
+            weights,
+            ParallelConfig(mode="tensor_parallel", tp_size=2, rank=0),
+        )
+
+
+@pytest.mark.parametrize(
+    ("key", "shape", "message"),
+    [
+        ("layer.0.w_q", (_HIDDEN, _HIDDEN - 1), "last dimension"),
+        ("layer.0.w_o", (_HIDDEN - 1, _HIDDEN), "first dimension"),
+    ],
+)
+def test_magpie_tp_sharding_rejects_unshardable_weight_shapes(key, shape, message):
+    decoder_tp_builder = _magpie_tp_builder_module()
+    weights = _make_magpie_weights()
+    weights[key] = np.zeros(shape, dtype=np.float32)
+
+    with pytest.raises(ValueError, match=message):
+        decoder_tp_builder.shard_magpie_decoder_weights(
+            weights,
+            ParallelConfig(mode="tensor_parallel", tp_size=2, rank=0),
+        )
+
+
+def test_magpie_tp_shards_rank_local_decoder_weights():
+    decoder_tp_builder = _magpie_tp_builder_module()
+    weights = _make_magpie_weights()
+    shard = decoder_tp_builder.shard_magpie_decoder_weights(
+        weights,
+        ParallelConfig(mode="tensor_parallel", tp_size=2, rank=1),
+    )
+
+    assert shard["_tensor_parallel_size"] == 2
+    assert shard["_tensor_parallel_rank"] == 1
+    assert shard["dec_pos_embedding"] is weights["dec_pos_embedding"]
+    assert shard["final_norm"] is weights["final_norm"]
+    assert shard["layer.0.cross_w_q"] is weights["layer.0.cross_w_q"]
+    np.testing.assert_array_equal(
+        shard["layer.0.w_q"],
+        weights["layer.0.w_q"][:, _HIDDEN // 2:],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_k"],
+        weights["layer.0.w_k"][:, _HIDDEN // 2:],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_v"],
+        weights["layer.0.w_v"][:, _HIDDEN // 2:],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_o"],
+        weights["layer.0.w_o"][_HIDDEN // 2:, :],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc1"],
+        weights["layer.0.w_fc1"][:, _FFN // 2:],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc2"],
+        weights["layer.0.w_fc2"][_FFN // 2:, :],
+    )

--- a/tests/e2e/models/magpie-tts-357m-tp4.json
+++ b/tests/e2e/models/magpie-tts-357m-tp4.json
@@ -1,0 +1,71 @@
+{
+  "name": "magpie-tts-357m-tp4",
+  "trace_id": "IT-E2E-MGPTTS-TP4-01",
+  "hf_id": "nvidia/magpie_tts_multilingual_357m",
+  "bundle": "magpie-tts-357m-tp4.trtfb",
+  "family": "magpie_tts",
+  "runtime_strategy": "text_to_audio_magpie",
+  "reference_backend": "nemo",
+  "test_type": "audio",
+  "max_cache_length": 512,
+  "prompt": "Ladies and gentlemen, welcome to the annual conference on artificial intelligence and machine learning. Today we will explore the latest advances in natural language processing, computer vision, and reinforcement learning.",
+  "max_new_tokens": 750,
+  "logit_atol": 1e-2,
+  "trust_remote_code": false,
+  "runtime_config": {
+    "audio_magpie": {
+      "cfg_scale": 2.5,
+      "temperature": 0.6,
+      "seed": 42
+    }
+  },
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "python_module_available",
+      "args": {
+        "module": "nemo.collections.tts.g2p.models.i18n_ipa",
+        "timeout_s": 180
+      },
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ]
+}

--- a/tests/e2e_harness/runners/audio_speech.py
+++ b/tests/e2e_harness/runners/audio_speech.py
@@ -293,7 +293,6 @@ class TextToAudioRunner:
             runtime_tokens = runtime_config_set_tokens(case)
             for token in runtime_tokens:
                 cmd.extend(["--set", token])
-            cmd = _wrap_distributed_command(cmd, case)
             # Keep Bark TRT sampling reproducible in CI unless explicitly overridden.
             bark_seed = runtime_config_get(case, "audio_bark.seed")
             if case.family == "bark" and bark_seed is None:
@@ -306,17 +305,17 @@ class TextToAudioRunner:
                 os.path.join(output_root, "rank_0", "bark_dump")
                 if distributed_runtime else os.path.join(tmpdir, "bark_dump")
             )
-            if case.family == "bark":
-                if distributed_runtime:
-                    wrapper = (
-                        'rank="${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${PMIX_RANK:-${RANK:-0}}}}"; '
-                        'out="$1/rank_${rank}"; mkdir -p "$out"; shift; '
-                        'exec "$@" --output "$out/output.wav" '
-                        '--set "audio_bark.dump_path=$out/bark_dump"'
-                    )
-                    cmd = ["bash", "-lc", wrapper, "trtmc_rank_audio", output_root] + cmd
-                else:
-                    cmd.extend(["--set", f"audio_bark.dump_path={bark_dump_prefix}"])
+            if distributed_runtime:
+                wrapper = (
+                    'rank="${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${PMIX_RANK:-${RANK:-0}}}}"; '
+                    'out="$1/rank_${rank}"; mkdir -p "$out"; shift; '
+                    'exec "$@" --output "$out/output.wav"'
+                )
+                if case.family == "bark":
+                    wrapper += ' --set "audio_bark.dump_path=$out/bark_dump"'
+                cmd = ["bash", "-lc", wrapper, "trtmc_rank_audio", output_root] + cmd
+            elif case.family == "bark":
+                cmd.extend(["--set", f"audio_bark.dump_path={bark_dump_prefix}"])
 
             cmd = _wrap_distributed_command(cmd, case)
 


### PR DESCRIPTION
## Background
MagpieTTS had only the single-device decoder path. The recent Whisper, Canary, and Bark TP PRs established the pattern of keeping the original builder untouched and adding a rank-local TP builder for the projection changes.

PR CI also caught a Magpie plugin complexity issue, and B200 E2E exposed a TP runtime ordering bug where the shared CUDA stream was created before the process was bound to its rank-local GPU.

## Exit Criteria
- MagpieTTS can build TP rank-local decoder plans for `parallel.mode=tensor_parallel`.
- A TP4 multi-device e2e manifest exists with the same runtime thresholds as the single-device Magpie case.
- Single-device Magpie behavior remains on the existing builder path.
- TP4 Magpie E2E passes on the B200/TRT11 Docker path before merge.

## Implementation
- Added a MagpieTTS `decoder_tp_builder.py` that mirrors the decoder graph and shards self-attention Q/K/V plus FC1 column-wise, shards self-attention output plus FC2 row-wise, and inserts TensorRT distributed all-reduce joins.
- Kept the asymmetric one-head cross-attention replicated on each rank because that head layout is not divisible across TP4.
- Routed `MagpieTTSPlugin.build_engine` to the TP builder only when the normalized parallel config is enabled.
- Updated the C++ Magpie runtime to initialize the TP group, load `engine_plan_tp_rank{rank}`, attach the TensorRT distributed communicator to the decoder, and size the decoder KV cache from the loaded rank-local engine.
- Fixed the TP runtime setup so `initialize_tensor_parallel_group()` binds the rank GPU before Magpie creates its shared CUDA stream.
- Added a `magpie-tts-357m-tp4` e2e manifest and focused sharding tests.
- Fixed the text-to-audio distributed runner wrapper so distributed audio generation is wrapped once and writes rank-specific output paths for non-Bark text-to-audio cases as well.

## Validation
- `sudo -n docker exec trtmc-b200-trt11-pr49 bash -lc 'cd /workspace/tensorrt-model-connect && python -m pytest -q tests/builder/test_engine_magpie_tts.py'`: passed, 7 tests.
- `sudo -n docker exec trtmc-b200-trt11-pr49 bash -lc 'cd /workspace/tensorrt-model-connect && cmake --build build -j'`: passed.
- `sudo -n docker exec trtmc-b200-trt11-pr49 bash -lc 'cd /workspace/tensorrt-model-connect && PYTHONPATH=python:. python -m pytest -q tests/tools/test_e2e_repro_commands.py tests/tools/test_e2e_runner_cli_alignment.py tests/builder/test_manifest_validation.py tests/builder/test_parallel_config.py'`: passed, 47 tests.
- `sudo -n docker run --rm -v /tmp/trtmc-magpie-pr120-fix:/workspace/tensorrt-model-connect -w /workspace/tensorrt-model-connect trtmc-dev-b200-trt11:latest bash -lc 'python -m pip install -q lizard && python tools/check_cyclomatic_complexity.py src --exclude src/cli --max-ccn 10 --top 20'`: passed, max CCN 10.
- `git diff --check`: passed.
- `sudo -n docker run --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 -v /tmp/trtmc-magpie-pr120-fix:/workspace/tensorrt-model-connect -v /home/scratch.daichu_sw_1/trtmc-storage:/trtmc-storage -w /workspace/tensorrt-model-connect trtmc-dev-b200-trt11:latest bash -lc 'cmake --build build-magpie-e2e --target trtmc -j'`: passed.
- `sudo -n docker run --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 -v /tmp/trtmc-magpie-pr120-fix:/workspace/tensorrt-model-connect -v /home/scratch.daichu_sw_1/trtmc-storage:/trtmc-storage -w /workspace/tensorrt-model-connect trtmc-dev-b200-trt11:latest bash -lc 'timeout 600s mpirun --tag-output -np 4 ... ./build-magpie-e2e/trtmc generate-audio ... --max-new-tokens 750 ...'`: passed, return code 0; all four ranks wrote audio outputs.
- `sudo -n docker run --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 -v /tmp/trtmc-magpie-pr120-fix:/workspace/tensorrt-model-connect -v /home/scratch.daichu_sw_1/trtmc-storage:/trtmc-storage -w /workspace/tensorrt-model-connect trtmc-dev-b200-trt11:latest bash -lc 'python -m pip install -q "nemo_toolkit[tts]==2.7.0" && python -m pip install -q "fsspec==2024.12.0" "setuptools>=80,<82" && python -m pip install -q --upgrade "transformers==5.2.0" && PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py --multi-device-only -k "magpie-tts-357m-tp4" --trtmc-binary ./build-magpie-e2e/trtmc --engine-dir /trtmc-storage/engines-magpie-tp4-trt11d --e2e-artifacts-dir /trtmc-storage/e2e-magpie-tp4-fixed --hf-python /opt/venv/bin/python -s'`: passed, 1 test passed and 12 deselected.

## Notes For Future Readers
- ADR intentionally skipped: this follows the existing per-family TP builder pattern and does not introduce a new runtime strategy, schema, or cross-module architecture.
- Review the Python TP builder first, then the Magpie runtime section selection, then the e2e runner wrapper change.
- Magpie TP runtime must bind the rank-local CUDA device before creating streams or modules; otherwise ranks can desynchronize with TensorRT Myelin CUDA error 400 during generation.
