### PR TITLE
test(bark): add large tensor parallel e2e

### DIFF
--- a/tests/e2e/models/bark-large-tp4.json
+++ b/tests/e2e/models/bark-large-tp4.json
@@ -1,0 +1,68 @@
+{
+  "name": "bark-large-tp4",
+  "trace_id": "IT-E2E-BARKL-TP4-01",
+  "hf_id": "suno/bark",
+  "bundle": "bark-large-tp4.trtfb",
+  "family": "bark",
+  "runtime_strategy": "text_to_audio_bark",
+  "ci_tier": "multi_device",
+  "l0_replacement": "bark-small-tp4",
+  "l0_replacement_reason": "Bark large TP4 is scale coverage; bark-small-tp4 keeps the Bark tensor-parallel TTS path for PR multi-device coverage.",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "test_type": "audio",
+  "max_cache_length": 1024,
+  "prompt": "Hello, this is a test of the text to speech system.",
+  "max_new_tokens": 0,
+  "logit_atol": 0.01,
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "determinism": {
+    "seed": 42
+  },
+  "threshold_overrides": {
+    "duration_ratio_min": 0.2,
+    "duration_ratio_max": 2.5,
+    "log_spectral_distance": 12.0,
+    "mel_spectrogram_distance": 10.0,
+    "min_semantic_tokens": 30,
+    "rms_min": 0.005
+  }
+}

--- a/tests/e2e_harness/runners/audio_speech.py
+++ b/tests/e2e_harness/runners/audio_speech.py
@@ -293,7 +293,6 @@ class TextToAudioRunner:
             runtime_tokens = runtime_config_set_tokens(case)
             for token in runtime_tokens:
                 cmd.extend(["--set", token])
-            cmd = _wrap_distributed_command(cmd, case)
             # Keep Bark TRT sampling reproducible in CI unless explicitly overridden.
             bark_seed = runtime_config_get(case, "audio_bark.seed")
             if case.family == "bark" and bark_seed is None:

--- a/tests/tools/test_e2e_runner_cli_alignment.py
+++ b/tests/tools/test_e2e_runner_cli_alignment.py
@@ -164,6 +164,42 @@ def test_audio_runner_maps_runtime_config_to_set_flags(monkeypatch, tmp_path):
     assert out.metadata["command"] == cmd
 
 
+def test_bark_distributed_audio_runner_wraps_mpirun_once(monkeypatch, tmp_path):
+    case = _make_case(
+        "text_to_audio",
+        inputs={"prompt": "hello"},
+        family="bark",
+        runtime_strategy="text_to_audio_bark",
+        metadata={
+            "distributed_runtime": {
+                "enabled": True,
+                "launcher": "mpirun",
+                "world_size": 4,
+            },
+        },
+        determinism={"seed": 42},
+    )
+    ctx = _make_ctx(case, tmp_path)
+
+    captured: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(audio_speech.subprocess, "run", _fake_run)
+
+    out = audio_speech.TextToAudioRunner().run_stage(
+        case, StageSpec(name="generate"), ctx)
+
+    cmd = captured["cmd"]
+    assert cmd[:4] == ["mpirun", "--tag-output", "-np", "4"]
+    assert cmd.count("mpirun") == 1
+    assert "trtmc_rank_audio" in cmd
+    assert "audio_bark.seed=42" in cmd
+    assert out.metadata["command"] == cmd
+
+
 def test_omni_runner_thinker_stage_drops_unsupported_stage_flag(monkeypatch, tmp_path):
     case = _make_case(
         "omni_multimodal",


### PR DESCRIPTION
## Background
PR #110 added Bark small TP4 coverage. Bark large was still only covered by the single-device E2E manifest, so this adds the matching TP4 scale-coverage case for `suno/bark`.

## Exit Criteria
- Add a Bark large TP4 E2E manifest.
- Preserve the single-device Bark large thresholds and deterministic seed.
- Verify the Bark large TP4 E2E path on the B200 Docker image before relying on CI.

## Implementation
- Added `bark-large-tp4.json` with TP4 build metadata, 4-rank distributed runtime metadata, and the same audio thresholds used by `bark-large.json`.
- Kept `bark-small-tp4` as the L0 replacement so PR multi-device coverage can stay on the smaller Bark case.
- Fixed the text-to-audio E2E runner so distributed Bark commands are wrapped in `mpirun` once. The previous command construction wrapped before and after adding the Bark per-rank output wrapper, which produced a recursive `mpirun` runtime failure.

## Validation
- `PYTHONPATH=python:. python -m pytest -q tests/tools/test_e2e_runner_cli_alignment.py -k "bark_distributed_audio_runner or audio_runner_maps_runtime_config"`: passed, `2 passed, 8 deselected`.
- `PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py --multi-device-only -k "bark-large-tp4" --trtmc-binary ./build/trtmc --engine-dir /trtmc-storage/engines-bark-large-tp4 --e2e-artifacts-dir /trtmc-storage/e2e-bark-large-tp4-rerun -s`: passed, `1 passed, 12 deselected in 132.29s` on B200.
- `git diff --check`: passed.

## Notes For Future Readers
- The first Bark large TP4 run built the bundle successfully but failed with nested `mpirun`; the amended runner fix is what made the E2E runtime pass.
