### PR TITLE
feat(qwen): add tp4 top-p and fp8 coverage

### DIFF
--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -230,6 +230,18 @@ def _call_supports_kwarg(func, name: str) -> bool:
     )
 
 
+def _quant_format_name(quant_ctx) -> str | None:
+    quant_format = getattr(getattr(quant_ctx, "profile", None), "format", None)
+    return getattr(quant_format, "name", None)
+
+
+def _plugin_supports_parallel_quantization(plugin, quant_ctx) -> bool:
+    supports = getattr(plugin, "supports_parallel_quantization", None)
+    if not callable(supports):
+        return False
+    return bool(supports(_quant_format_name(quant_ctx)))
+
+
 def _plugin_uses_standard_decoder_builder(plugin) -> bool:
     """Best-effort check for family plugins routed through the standard decoder."""
     try:
@@ -861,7 +873,9 @@ def build_bundle(
 
     if parallel.enabled:
         require_tensorrt_11_for_tensor_parallel(parallel)
-        if quant_ctx is not None:
+        if quant_ctx is not None and not _plugin_supports_parallel_quantization(
+            plugin, quant_ctx
+        ):
             raise ValueError("Tensor-parallel decoder builds do not support quantization yet")
         if enable_dynamic_kv_cache:
             raise NotImplementedError(

--- a/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/dual_profile_decoder_tp_builder.py
@@ -112,6 +112,14 @@ def _make_matmul_fn(
     return matmul
 
 
+def _validate_tp_quantization(quant_ctx: "QuantContext | None") -> None:
+    if quant_ctx is None:
+        return
+    format_name = getattr(getattr(quant_ctx, "profile", None), "format", None)
+    if getattr(format_name, "name", None) != "fp8":
+        raise ValueError("Tensor-parallel decoder quantization currently supports fp8 only")
+
+
 def _norm_multi(
     network: trt.INetworkDefinition,
     inp: trt.ITensor,
@@ -253,8 +261,7 @@ def build_dual_profile_tp_decoder_engine(
         raise ValueError(
             "dual_profile_decoder_tp_builder requires "
             "parallel.mode=tensor_parallel and tp_size > 1")
-    if quant_ctx is not None:
-        raise ValueError("Tensor-parallel decoder builds do not support quantization yet")
+    _validate_tp_quantization(quant_ctx)
     if mlp_type != "swiglu":
         raise NotImplementedError(
             "Tensor-parallel decoder builds currently support SwiGLU MLPs only")

--- a/python/tensorrt_model_connect/families/qwen/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen/plugin.py
@@ -116,6 +116,9 @@ class QwenPlugin:
             ])
         return patterns
 
+    def supports_parallel_quantization(self, format_name: str | None) -> bool:
+        return format_name == "fp8"
+
     def quant_adapter(self, format_name: str) -> StandardDecoderCalibrationAdapter:
         return StandardDecoderCalibrationAdapter(family=self.name)
 

--- a/tests/builder/test_engine_qwen.py
+++ b/tests/builder/test_engine_qwen.py
@@ -5,6 +5,8 @@ Intent: Validate the Qwen family plugin weight loading and standard decoder key 
 Preconditions: safetensors and tensorrt_model_connect are importable; TRT+GPU required for engine build tests.
 Postconditions: All standard decoder weight keys are present with correct shapes and the engine builds successfully.
 """
+import pytest
+
 from tests.builder.family_plugin_tester import FamilyPluginTester
 from tests.builder.family_plugin_test_mixin import FamilyPluginTestMixin
 
@@ -16,3 +18,67 @@ class QwenPluginTester(FamilyPluginTester):
 
 class TestQwenEngine(FamilyPluginTestMixin):
     tester_class = QwenPluginTester
+
+
+def _qwen_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.qwen.dual_profile_decoder_tp_builder",
+        reason="TensorRT is required for Qwen TP builder tests",
+    )
+
+
+def _quant_ctx(format_name: str):
+    from tensorrt_model_connect.quantization import get_format, QuantScaleMap
+    from tensorrt_model_connect.quantization.context import QuantContext
+    from tensorrt_model_connect.quantization.profile import QuantProfile
+
+    return QuantContext(
+        profile=QuantProfile(
+            format=get_format(format_name),
+            scale_map=QuantScaleMap(dynamic=True),
+        )
+    )
+
+
+def test_qwen_tp_quantization_allows_fp8():
+    qwen_tp_builder = _qwen_tp_builder_module()
+
+    qwen_tp_builder._validate_tp_quantization(_quant_ctx("fp8"))
+
+
+def test_qwen_tp_quantization_rejects_non_fp8():
+    qwen_tp_builder = _qwen_tp_builder_module()
+
+    with pytest.raises(ValueError, match="supports fp8 only"):
+        qwen_tp_builder._validate_tp_quantization(_quant_ctx("int8_sq"))
+
+
+def test_qwen_plugin_advertises_fp8_parallel_quantization_only():
+    from tensorrt_model_connect.families.qwen import plugin
+
+    assert plugin.supports_parallel_quantization("fp8")
+    assert not plugin.supports_parallel_quantization("int8_sq")
+    assert not plugin.supports_parallel_quantization(None)
+
+
+def test_engine_builder_parallel_quantization_gate_allows_qwen_fp8():
+    from tensorrt_model_connect.engine_builder import (
+        _plugin_supports_parallel_quantization,
+    )
+    from tensorrt_model_connect.families.qwen import plugin
+
+    assert _plugin_supports_parallel_quantization(plugin, _quant_ctx("fp8"))
+
+
+def test_engine_builder_parallel_quantization_gate_rejects_default_plugin():
+    from tensorrt_model_connect.engine_builder import (
+        _plugin_supports_parallel_quantization,
+    )
+
+    class PluginWithoutParallelQuantization:
+        pass
+
+    assert not _plugin_supports_parallel_quantization(
+        PluginWithoutParallelQuantization(),
+        _quant_ctx("fp8"),
+    )

--- a/tests/e2e/models/qwen3-0.6b-fp8-tp4.json
+++ b/tests/e2e/models/qwen3-0.6b-fp8-tp4.json
@@ -1,0 +1,65 @@
+{
+  "name": "qwen3-0.6b-fp8-tp4",
+  "trace_id": "IT-E2E-QWN3-FP8-TP4-01",
+  "hf_id": "Qwen/Qwen3-0.6B",
+  "bundle": "qwen3-0.6b-fp8-bf16base-tp4.trtfb",
+  "family": "qwen",
+  "runtime_strategy": "decoder_kv_cache",
+  "precision": "bf16",
+  "quantization": {
+    "format": "fp8",
+    "scale_source": "modelopt",
+    "calibration_samples": 64
+  },
+  "max_cache_length": 256,
+  "prompt": "What is the capital of France? Answer in one word.",
+  "max_new_tokens": 10,
+  "trust_remote_code": false,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "debug_logits": true,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "threshold_overrides": {
+    "logit_cosine_p5": 0.2,
+    "logit_rel_l2_p95": 1.5
+  },
+  "notes": "FP8 TP4 quantization can perturb raw logit distributions while preserving decoded output agreement. Keep the same token agreement and normalized edit distance gates as qwen3-0.6b-fp8 for output confidence."
+}

--- a/tests/e2e/models/qwen3-0.6b-topp-tp4.json
+++ b/tests/e2e/models/qwen3-0.6b-topp-tp4.json
@@ -1,0 +1,63 @@
+{
+  "name": "qwen3-0.6b-topp-tp4",
+  "trace_id": "IT-E2E-TOPP-TP4-001",
+  "hf_id": "Qwen/Qwen3-0.6B",
+  "bundle": "qwen3-0.6b-topp-fp16-tp4.trtfb",
+  "family": "qwen",
+  "runtime_strategy": "decoder_kv_cache",
+  "precision": "fp16",
+  "reference_backend": "invariant_only",
+  "reference_family": "sampling_top_p",
+  "user_contract": "sampling",
+  "max_cache_length": 256,
+  "prompt": "What is the capital of France? Answer in one word.",
+  "max_new_tokens": 20,
+  "temperature": 0.7,
+  "top_p": 0.9,
+  "top_k": 50,
+  "seed": 42,
+  "determinism_reruns": 1,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "debug_logits": true,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "test_note": "Validates host-side top-p nucleus sampling on an fp16 Qwen3 TP4 bundle: with temperature=0.7/top_p=0.9/top_k=50/seed=42, the distributed runtime CLI must forward sampling flags, produce non-empty output, and reproduce the same seeded output on rerun. Device placement is not asserted by this E2E contract; top-p filtering is implemented on CPU via HOST sampler logits."
+}


### PR DESCRIPTION
## Background
Qwen3 already had TP4 E2E coverage for the base 0.6B and 4B manifests. This adds the same tensor-parallel coverage for the Qwen3 0.6B top-p and FP8 variants, including the missing build-path allowance for Qwen FP8 TP quantization.

## Exit Criteria
- Add TP4 E2E manifests for `qwen3-0.6b-topp` and `qwen3-0.6b-fp8`.
- Preserve the single-device generation and comparison thresholds.
- Keep tensor-parallel quantization rejected unless a family explicitly supports the requested quantization format.

## Implementation
- Added TP4 manifests for the top-p and FP8 Qwen3 0.6B cases with distributed runtime metadata and existing single-device thresholds/settings.
- Let `engine_builder.py` defer TP quantization support to an explicit plugin capability instead of rejecting all quantized TP builds globally.
- Declared Qwen TP quantization support for FP8 only, while keeping the Qwen TP builder validation that rejects non-FP8 quantization.
- Added focused builder tests for the Qwen FP8 capability and the default rejection path.

## Validation
- `PYTHONPATH=python:. python -m pytest -q tests/builder/test_engine_qwen.py tests/builder/test_manifest_validation.py tests/builder/test_quantization.py`: passed, `60 passed in 39.75s` on the B200 GPU Docker image.
- `PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py --multi-device-only -k "qwen3-0.6b-fp8-tp4" --trtmc-binary ./build/trtmc --engine-dir /trtmc-storage/engines-qwen-tp4-rerun2 --e2e-artifacts-dir /trtmc-storage/e2e-qwen-tp4-runtime-rerun -s`: passed, `1 passed, 13 deselected in 51.61s` on B200.
- `PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py --multi-device-only -k "qwen3-0.6b-topp-tp4" --trtmc-binary ./build/trtmc --engine-dir /trtmc-storage/engines-qwen-tp4 --e2e-artifacts-dir /trtmc-storage/e2e-qwen-topp-runtime-rerun -s`: passed, `1 passed, 13 deselected in 62.82s` on B200.
- `git diff --check`: passed.

## Notes For Future Readers
- Review the manifests first, then the small `engine_builder.py` capability gate. The gate intentionally remains opt-in so other families do not inherit TP quantization support by accident.
