### PR TITLE
feat(nemotron): add speech streaming tp support

### DIFF
--- a/python/tensorrt_model_connect/families/nemotron_speech_streaming/plugin.py
+++ b/python/tensorrt_model_connect/families/nemotron_speech_streaming/plugin.py
@@ -23,6 +23,10 @@ from tensorrt_model_connect import trt_compat
 from ... import graph_ops
 from ...checkpoint_mapper import WeightDict, _transpose_2d
 from ...config import ModelConfig
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 from ..canary import (
     _add_conv_norm,
     _add_half_ffn,
@@ -35,6 +39,7 @@ from ..canary import (
     _relative_pe,
     _to_np,
 )
+from .predictor_tp_builder import build_nemotron_streaming_tp_predictor
 
 
 trt = trt_compat.get_trt()
@@ -683,8 +688,21 @@ class NemotronSpeechStreamingPlugin:
 
     def build_engine(self, config: ModelConfig, weights: WeightDict, max_cache_length: int,
                      *, precision: str = "fp32", quant_ctx=None, verbose: bool = False,
-                     debug_layer_outputs: bool = False) -> bytes:
-        del config, max_cache_length, precision, quant_ctx, debug_layer_outputs
+                     debug_layer_outputs: bool = False, parallel_config=None) -> bytes:
+        del config, max_cache_length, precision
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="Nemotron Speech Streaming TP predictor builds")
+            if quant_ctx is not None:
+                raise ValueError(
+                    "Nemotron Speech Streaming tensor-parallel builds do not support quantization")
+            if debug_layer_outputs:
+                raise ValueError(
+                    "Nemotron Speech Streaming tensor-parallel builds do not support "
+                    "debug_layer_outputs")
+            return build_nemotron_streaming_tp_predictor(
+                weights, verbose=verbose, parallel_config=parallel)
         return _build_predictor(weights, verbose=verbose)
 
     def build_vision_engine(self, model_dir: str, config: ModelConfig, weights: WeightDict,

--- a/python/tensorrt_model_connect/families/nemotron_speech_streaming/predictor_tp_builder.py
+++ b/python/tensorrt_model_connect/families/nemotron_speech_streaming/predictor_tp_builder.py
@@ -1,0 +1,188 @@
+"""Tensor-parallel Nemotron Speech Streaming RNNT predictor builder.
+
+This mirrors the single-device predictor graph in ``plugin.py`` while keeping
+the RNNT runtime contract unchanged:
+
+* predictor embeddings stay replicated,
+* each LSTM gate projection is column-sharded across the hidden dimension,
+* rank-local hidden/cell slices are zero-padded back to full hidden size,
+* TensorRT distributed ALL_REDUCE sums the padded slices so every rank produces
+  the same full predictor state and ``pred_output`` tensors.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+import sys
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_lstm_gate_columns(arr: np.ndarray, hidden: int, parallel: "ParallelConfig") -> np.ndarray:
+    """Slice i/f/g/o gate columns for this rank while preserving gate order."""
+    rank = parallel.rank
+    tp = parallel.tp_size
+    local_hidden = hidden // tp
+    start = rank * local_hidden
+    end = start + local_hidden
+    parts = [
+        arr[..., start:end],
+        arr[..., hidden + start:hidden + end],
+        arr[..., 2 * hidden + start:2 * hidden + end],
+        arr[..., 3 * hidden + start:3 * hidden + end],
+    ]
+    return np.ascontiguousarray(np.concatenate(parts, axis=-1))
+
+
+def _validate_predictor_tp(weights: "WeightDict", parallel: "ParallelConfig") -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("Nemotron Speech Streaming TP predictor requires a concrete rank")
+    hidden = int(weights["_pred_hidden"])
+    if hidden % parallel.tp_size != 0:
+        raise ValueError(
+            "Nemotron Speech Streaming TP predictor requires pred_hidden divisible by "
+            f"tp_size ({hidden} vs {parallel.tp_size})")
+    for layer in range(int(weights["_pred_layers"])):
+        pfx = f"pred.{layer}"
+        expected = (hidden, 4 * hidden)
+        for key in (f"{pfx}.w_ih_t", f"{pfx}.w_hh_t"):
+            if tuple(weights[key].shape) != expected:
+                raise ValueError(f"{key} shape must be {expected}; got {weights[key].shape}")
+        if tuple(weights[f"{pfx}.bias"].shape) != (1, 4 * hidden):
+            raise ValueError(
+                f"{pfx}.bias shape must be {(1, 4 * hidden)}; "
+                f"got {weights[f'{pfx}.bias'].shape}")
+
+
+def _add_rank_full_state(network, local, hidden: int, parallel: "ParallelConfig"):
+    local_hidden = hidden // parallel.tp_size
+    start = parallel.rank * local_hidden
+    end = start + local_hidden
+    parts = []
+    if start > 0:
+        parts.append(graph_ops.add_constant(
+            network, (1, start), np.zeros((1, start), dtype=np.float32)))
+    parts.append(local)
+    if end < hidden:
+        suffix = hidden - end
+        parts.append(graph_ops.add_constant(
+            network, (1, suffix), np.zeros((1, suffix), dtype=np.float32)))
+    cat = network.add_concatenation(parts)
+    cat.axis = 1
+    return add_all_reduce_sum(network, cat.get_output(0), parallel.tp_size)
+
+
+def _add_lstm_cell_tp(network, x, h_prev, c_prev, weights, pfx: str, hidden: int,
+                      parallel: "ParallelConfig"):
+    local_hidden = hidden // parallel.tp_size
+    w_ih = graph_ops.add_constant(
+        network, (hidden, 4 * local_hidden),
+        _slice_lstm_gate_columns(weights[f"{pfx}.w_ih_t"], hidden, parallel))
+    w_hh = graph_ops.add_constant(
+        network, (hidden, 4 * local_hidden),
+        _slice_lstm_gate_columns(weights[f"{pfx}.w_hh_t"], hidden, parallel))
+    bias = graph_ops.add_constant(
+        network, (1, 4 * local_hidden),
+        _slice_lstm_gate_columns(weights[f"{pfx}.bias"], hidden, parallel))
+
+    xw = network.add_matrix_multiply(x, trt.MatrixOperation.NONE, w_ih, trt.MatrixOperation.NONE)
+    hw = network.add_matrix_multiply(h_prev, trt.MatrixOperation.NONE, w_hh, trt.MatrixOperation.NONE)
+    gates = network.add_elementwise(xw.get_output(0), hw.get_output(0), trt.ElementWiseOperation.SUM)
+    gates = network.add_elementwise(gates.get_output(0), bias, trt.ElementWiseOperation.SUM)
+
+    gate_i = network.add_slice(gates.get_output(0), start=(0, 0), shape=(1, local_hidden), stride=(1, 1))
+    gate_f = network.add_slice(
+        gates.get_output(0), start=(0, local_hidden), shape=(1, local_hidden), stride=(1, 1))
+    gate_g = network.add_slice(
+        gates.get_output(0), start=(0, 2 * local_hidden), shape=(1, local_hidden), stride=(1, 1))
+    gate_o = network.add_slice(
+        gates.get_output(0), start=(0, 3 * local_hidden), shape=(1, local_hidden), stride=(1, 1))
+
+    i_t = network.add_activation(gate_i.get_output(0), trt.ActivationType.SIGMOID).get_output(0)
+    f_t = network.add_activation(gate_f.get_output(0), trt.ActivationType.SIGMOID).get_output(0)
+    g_t = network.add_activation(gate_g.get_output(0), trt.ActivationType.TANH).get_output(0)
+    o_t = network.add_activation(gate_o.get_output(0), trt.ActivationType.SIGMOID).get_output(0)
+
+    c_local = network.add_slice(
+        c_prev, start=(0, parallel.rank * local_hidden), shape=(1, local_hidden), stride=(1, 1))
+    forget = network.add_elementwise(
+        f_t, c_local.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    update = network.add_elementwise(i_t, g_t, trt.ElementWiseOperation.PROD).get_output(0)
+    c_local_new = network.add_elementwise(forget, update, trt.ElementWiseOperation.SUM).get_output(0)
+    tanh_c = network.add_activation(c_local_new, trt.ActivationType.TANH).get_output(0)
+    h_local_new = network.add_elementwise(o_t, tanh_c, trt.ElementWiseOperation.PROD).get_output(0)
+
+    h_new = _add_rank_full_state(network, h_local_new, hidden, parallel)
+    c_new = _add_rank_full_state(network, c_local_new, hidden, parallel)
+    return h_new, c_new
+
+
+def build_nemotron_streaming_tp_predictor(
+    weights: "WeightDict",
+    *,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_nemotron_streaming_tp_predictor requires parallel.mode=tensor_parallel "
+            "and tp_size > 1")
+    _validate_predictor_tp(weights, parallel)
+
+    pred_hidden = int(weights["_pred_hidden"])
+    pred_layers = int(weights["_pred_layers"])
+    vocab_total = int(weights["_vocab_total"])
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 256 << 20)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    embedding = graph_ops.add_constant(network, (vocab_total, pred_hidden), weights["pred_embedding"])
+    hidden = network.add_gather(embedding, token_id, 0).get_output(0)
+
+    next_h = []
+    next_c = []
+    for layer in range(pred_layers):
+        h_in = network.add_input(f"state_h_{layer}", trt.float32, (1, pred_hidden))
+        c_in = network.add_input(f"state_c_{layer}", trt.float32, (1, pred_hidden))
+        hidden, c_new = _add_lstm_cell_tp(
+            network, hidden, h_in, c_in, weights, f"pred.{layer}", pred_hidden, parallel)
+        next_h.append(hidden)
+        next_c.append(c_new)
+
+    pred_output = network.add_identity(hidden).get_output(0)
+    pred_output.name = "pred_output"
+    network.mark_output(pred_output)
+    for layer in range(pred_layers):
+        next_h[layer].name = f"next_h_{layer}"
+        next_c[layer].name = f"next_c_{layer}"
+        network.mark_output(next_h[layer])
+        network.mark_output(next_c[layer])
+
+    if verbose:
+        print(
+            "[trtmc build] Building RNNT TP predictor "
+            f"({pred_layers}L, h={pred_hidden}, tp={parallel.tp_size}, rank={parallel.rank})",
+            file=sys.stderr,
+        )
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError("RNNT TP predictor build failed")
+    return bytes(plan)

--- a/src/runtime/models/rnnt/plugin.cpp
+++ b/src/runtime/models/rnnt/plugin.cpp
@@ -3,15 +3,38 @@
 #include "runtime/models/rnnt/pipeline.h"
 #include "runtime/plugins/shared/audio_helpers.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <utility>
 #include <vector>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+} // namespace
 
 class RnntPlugin final : public IPipelinePlugin {
   public:
@@ -22,10 +45,21 @@ class RnntPlugin final : public IPipelinePlugin {
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        ModuleCreateOptions pred_opts = opts;
+        std::string pred_section = "engine_plan";
+        if (tp_config.enabled) {
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+            pred_opts.distributed_communicator = tp_group.communicator;
+            pred_opts.distributed_owner = tp_group.owner;
+            pred_section = tp_engine_section_name(tp_group.rank);
+        }
+
         auto enc_loaded = load_trt_module_from_plan(
             ctx.backend, find_section(ctx.bundle, "vision_engine_plan"), "rnnt encoder", opts);
         auto pred_loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "rnnt predictor", opts);
+            ctx.backend, find_section(ctx.bundle, pred_section), "rnnt predictor", pred_opts);
         auto joint_loaded = load_trt_module_from_plan(
             ctx.backend, find_section(ctx.bundle, "joint_engine_plan"), "rnnt joint", opts);
         std::map<int32_t, std::string> streaming_encoder_sections;

--- a/tests/builder/test_engine_nemotron_speech_streaming_tp.py
+++ b/tests/builder/test_engine_nemotron_speech_streaming_tp.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+import importlib
+
+import numpy as np
+import pytest
+
+from tensorrt_model_connect.parallel_config import ParallelConfig
+from tensorrt_model_connect.families.nemotron_speech_streaming.predictor_tp_builder import (
+    _slice_lstm_gate_columns,
+    _validate_predictor_tp,
+)
+
+nss = importlib.import_module("tensorrt_model_connect.families.nemotron_speech_streaming.plugin")
+
+
+def _weights(hidden: int = 8) -> dict:
+    weights = {
+        "_pred_hidden": hidden,
+        "_pred_layers": 1,
+        "_vocab_total": 16,
+        "pred_embedding": np.zeros((16, hidden), dtype=np.float32),
+        "pred.0.w_ih_t": np.zeros((hidden, 4 * hidden), dtype=np.float32),
+        "pred.0.w_hh_t": np.zeros((hidden, 4 * hidden), dtype=np.float32),
+        "pred.0.bias": np.zeros((1, 4 * hidden), dtype=np.float32),
+    }
+    return weights
+
+
+def test_slice_lstm_gate_columns_preserves_ifgo_gate_order() -> None:
+    hidden = 8
+    arr = np.arange(hidden * 4 * hidden, dtype=np.float32).reshape(hidden, 4 * hidden)
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+
+    sliced = _slice_lstm_gate_columns(arr, hidden, parallel)
+
+    expected = np.concatenate(
+        [
+            arr[:, 4:6],
+            arr[:, 12:14],
+            arr[:, 20:22],
+            arr[:, 28:30],
+        ],
+        axis=-1,
+    )
+    np.testing.assert_array_equal(sliced, expected)
+    assert sliced.flags.c_contiguous
+
+
+def test_validate_predictor_tp_rejects_non_divisible_hidden() -> None:
+    weights = _weights(hidden=10)
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0)
+
+    with pytest.raises(ValueError, match="pred_hidden divisible"):
+        _validate_predictor_tp(weights, parallel)
+
+
+def test_plugin_routes_parallel_builds_to_tp_predictor(monkeypatch) -> None:
+    calls = {}
+
+    def fake_require(parallel, *, feature):
+        calls["feature"] = feature
+        assert parallel.tp_size == 4
+
+    def fake_build(weights, *, verbose, parallel_config):
+        calls["rank"] = parallel_config.rank
+        calls["weights"] = weights
+        calls["verbose"] = verbose
+        return b"tp-predictor"
+
+    monkeypatch.setattr(nss, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(nss, "build_nemotron_streaming_tp_predictor", fake_build)
+
+    out = nss.plugin.build_engine(
+        SimpleNamespace(),
+        _weights(),
+        128,
+        verbose=True,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=3),
+    )
+
+    assert out == b"tp-predictor"
+    assert calls["feature"] == "Nemotron Speech Streaming TP predictor builds"
+    assert calls["rank"] == 3
+    assert calls["weights"]["_pred_hidden"] == 8
+    assert calls["verbose"] is True
+
+
+def test_plugin_rejects_tp_quantization(monkeypatch) -> None:
+    monkeypatch.setattr(nss, "require_tensorrt_11_for_tensor_parallel", lambda *_, **__: None)
+
+    with pytest.raises(ValueError, match="do not support quantization"):
+        nss.plugin.build_engine(
+            SimpleNamespace(),
+            _weights(),
+            128,
+            quant_ctx=object(),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )

--- a/tests/e2e/models/nemotron-speech-streaming-en-0.6b-tp4.json
+++ b/tests/e2e/models/nemotron-speech-streaming-en-0.6b-tp4.json
@@ -1,0 +1,61 @@
+{
+  "name": "nemotron-speech-streaming-en-0.6b-tp4",
+  "trace_id": "IT-E2E-NEMO-RNNT-TP4-01",
+  "hf_id": "nvidia/nemotron-speech-streaming-en-0.6b",
+  "bundle": "nemotron-speech-streaming-en-0.6b-tp4.trtfb",
+  "family": "nemotron_speech_streaming",
+  "runtime_strategy": "speech_to_text_rnnt",
+  "test_type": "transcription",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 80,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/Recording.wav",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "threshold_overrides": {
+    "wer": 0.35,
+    "cer": 0.25
+  }
+}


### PR DESCRIPTION
## Background
Nemotron speech streaming needed tensor-parallel coverage using the existing pattern of duplicating the single-device builder and only changing the multi-device pieces. This adds TP support for the RNNT predictor path and a TP4 E2E manifest for the 0.6B streaming model.

## Exit Criteria
- Build rank-local TP predictor plans while preserving the existing RNNT runtime tensor contract.
- Load the rank-specific predictor plan under mpirun and keep encoder, joint, and streaming encoder plans replicated.
- Verify the TP4 E2E transcription case with the same WER/CER thresholds as the single-device manifest.

## Implementation
- Added a Nemotron speech streaming predictor TP builder that shards LSTM gate columns per rank, pads rank-local hidden/cell slices back to full width, and all-reduces the full predictor outputs so every rank stays in sync.
- Routed `parallel_config` through the Nemotron speech streaming plugin with TRT 11 and unsupported-option checks.
- Updated the RNNT runtime plugin to initialize the tensor-parallel group and load `engine_plan_tp_rankN` for the predictor while leaving non-TP sections unchanged.
- Added focused builder tests and a `nemotron-speech-streaming-en-0.6b-tp4` multi-device E2E manifest.

## Validation
- `git diff --check`: passed.
- `sudo -n docker run --rm -v /tmp/trtmc-nemotron-speech-streaming-tp4:/workspace/tensorrt-model-connect -w /workspace/tensorrt-model-connect trtmc-dev-b200-trt11:latest bash -lc 'PYTHONPATH=python:. python -m pytest -q tests/builder/test_engine_nemotron_speech_streaming_tp.py tests/builder/test_manifest_validation.py -q'`: passed, 30 tests.
- `sudo -n docker run --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 -v /tmp/trtmc-nemotron-speech-streaming-tp4:/workspace/tensorrt-model-connect -w /workspace/tensorrt-model-connect trtmc-dev-b200-trt11:latest bash -lc 'cmake --build build-nemotron-e2e --target trtmc_backend_trt -j'`: passed.
- `sudo -n docker run --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 -v /tmp/trtmc-nemotron-speech-streaming-tp4:/workspace/tensorrt-model-connect -v /home/scratch.daichu_sw_1/trtmc-storage:/trtmc-storage -w /workspace/tensorrt-model-connect trtmc-dev-b200-trt11:latest bash -lc 'python -m pip install -q "nemo_toolkit[asr]==2.7.0" && python -m pip install -q "fsspec==2024.12.0" "setuptools>=80,<82" && python -m pip install -q --upgrade "transformers==5.2.0" && PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py --multi-device-only -k "nemotron-speech-streaming-en-0.6b-tp4" --trtmc-binary ./build-nemotron-e2e/trtmc --engine-dir /trtmc-storage/engines-nemotron-speech-streaming-tp4 --e2e-artifacts-dir /trtmc-storage/e2e-nemotron-speech-streaming-tp4-backend --hf-python /opt/venv/bin/python -s'`: passed, 1 test in 238.67s.

## Notes For Future Readers
- Review the TP builder first, then the RNNT runtime loader. The runtime contract intentionally keeps predictor state tensors full-width, which avoids broader RNNT pipeline changes.