### PR TITLE
feat(personaplex): add temporal tp support

### DIFF
--- a/python/tensorrt_model_connect/families/personaplex/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/personaplex/decoder_tp_builder.py
@@ -1,0 +1,399 @@
+"""Tensor-parallel PersonaPlex temporal decoder builder.
+
+This mirrors the single-device standard decoder path used by PersonaPlex's
+temporal transformer. Tensor parallelism only changes the decoder projections:
+Q/K/V and SwiGLU gate/up are column-parallel, output/down are row-parallel and
+joined with TensorRT distributed ALL_REDUCE.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_blocks
+from ... import graph_ops
+from ...parallel_config import (
+    add_all_reduce_sum,
+    normalize_parallel_config,
+    shard_standard_decoder_weights,
+)
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+
+
+def _mark_debug_output(network: trt.INetworkDefinition, tensor: trt.ITensor, name: str) -> None:
+    cast = network.add_cast(tensor, trt.float32)
+    out = cast.get_output(0)
+    out.name = name
+    network.mark_output(out)
+
+
+def _ensure_tp_metadata(config: "ModelConfig", weights: "WeightDict") -> "WeightDict":
+    if "_kv_attention_size" in weights:
+        return weights
+    copied = type(weights)(weights)
+    copied["_kv_attention_size"] = int(weights.get("_attention_size", config.attention_size))
+    return copied
+
+
+def _apply_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    gamma: np.ndarray,
+    beta: np.ndarray | None,
+    eps_tensor: trt.ITensor,
+    norm_type: str,
+    dtype: np.dtype = np.float32,
+    eps: float | None = None,
+) -> trt.ITensor:
+    return graph_blocks.apply_norm(
+        network, inp, hidden_size, gamma, beta, eps_tensor, norm_type,
+        dtype=dtype, eps=eps)
+
+
+def build_personaplex_tp_decoder_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    norm_type: str = "rmsnorm",
+    mlp_type: str = "swiglu",
+    position_type: str = "rope",
+    activation: str = "silu",
+    partial_rotary_factor: float = 1.0,
+    interleaved_rope: bool = True,
+    parallel_residual: bool = False,
+    scale_attn_weights: bool = True,
+    embed_input: bool = True,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    hidden_state_output: bool = True,
+    parallel_config=None,
+) -> bytes:
+    """Build one rank-local PersonaPlex temporal decoder engine."""
+    if quant_ctx is not None:
+        raise ValueError("PersonaPlex tensor-parallel builds do not support quantization")
+    if mlp_type != "swiglu":
+        raise NotImplementedError("PersonaPlex tensor-parallel builds support SwiGLU MLPs only")
+
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError("PersonaPlex tensor-parallel builder requires an enabled parallel config")
+    if parallel.rank < 0:
+        raise ValueError("PersonaPlex tensor-parallel engine build requires a concrete rank")
+
+    weights = _ensure_tp_metadata(config, weights)
+    weights = shard_standard_decoder_weights(config, weights, parallel)
+
+    attention_size = int(weights.get("_attention_size", config.attention_size))
+    mlp_size = int(weights.get("_mlp_size", config.intermediate_size))
+    hidden = config.hidden_size
+    vocab = config.vocab_size
+    num_layers = config.num_hidden_layers
+    num_heads = config.num_attention_heads // parallel.tp_size
+    num_kv_heads = config.num_key_value_heads // parallel.tp_size
+    head_dim = attention_size // num_heads
+    kv_attention_size = graph_blocks.infer_kv_attention_size(
+        weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
+    attention_window = max_cache_length + 1
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    if precision == "fp16":
+        work_np_dtype = np.float16
+        work_trt_dtype = trt.float16
+    elif precision == "bf16":
+        work_np_dtype = np.float16
+        work_trt_dtype = trt.bfloat16
+    else:
+        work_np_dtype = np.float32
+        work_trt_dtype = trt.float32
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    position_id = network.add_input("position_id", trt.int32, (1,))
+    attention_mask = network.add_input("attention_mask", trt.float32, (1, attention_window))
+
+    input_embed_tensor = None
+    use_input_embed_tensor = None
+    if embed_input:
+        input_embed_tensor = network.add_input("input_embed", work_trt_dtype, (1, hidden))
+        use_input_embed_tensor = network.add_input("use_input_embed", trt.float32, (1,))
+
+    cache_k_inputs = []
+    cache_v_inputs = []
+    for i in range(num_layers):
+        cache_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_k", i),
+            work_trt_dtype,
+            (max_cache_length, kv_attention_size),
+        ))
+        cache_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_v", i),
+            work_trt_dtype,
+            (max_cache_length, kv_attention_size),
+        ))
+
+    if work_trt_dtype != trt.float32:
+        attention_mask = network.add_cast(attention_mask, work_trt_dtype).get_output(0)
+
+    def _cast_work_dtype(tensor: trt.ITensor) -> trt.ITensor:
+        if tensor.dtype == work_trt_dtype:
+            return tensor
+        return network.add_cast(tensor, work_trt_dtype).get_output(0)
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), weights["embedding"], dtype=work_np_dtype)
+
+    cos_half_tensor = None
+    sin_half_tensor = None
+    rotary_embedding_dim = int(head_dim * partial_rotary_factor)
+    if position_type == "rope":
+        graph_ops.validate_native_rope_dim(rotary_embedding_dim)
+        cos_half_np = graph_ops.make_rope_table_half_dim(
+            attention_window, head_dim, config.rope_theta, True,
+            partial_rotary_factor, interleaved=interleaved_rope)
+        sin_half_np = graph_ops.make_rope_table_half_dim(
+            attention_window, head_dim, config.rope_theta, False,
+            partial_rotary_factor, interleaved=interleaved_rope)
+        cos_half_tensor = _cast_work_dtype(
+            graph_ops.add_constant(network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype))
+        sin_half_tensor = _cast_work_dtype(
+            graph_ops.add_constant(network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype))
+    else:
+        raise NotImplementedError("PersonaPlex tensor-parallel builds require RoPE")
+
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=work_np_dtype),
+        dtype=work_np_dtype)
+    attn_scale = (1.0 / np.sqrt(max(head_dim, 1))) if scale_attn_weights else 1.0
+
+    token_embed = network.add_gather(embedding_table, token_id, 0).get_output(0)
+    if embed_input and input_embed_tensor is not None and use_input_embed_tensor is not None:
+        flag_broadcast = network.add_shuffle(use_input_embed_tensor)
+        flag_broadcast.reshape_dims = (1, 1)
+        flag_for_math = flag_broadcast.get_output(0)
+        if work_trt_dtype != trt.float32:
+            flag_for_math = network.add_cast(flag_for_math, work_trt_dtype).get_output(0)
+        one_const = graph_ops.add_constant(
+            network, (1, 1), np.array([1.0], dtype=work_np_dtype),
+            dtype=work_np_dtype)
+        inv_flag = network.add_elementwise(
+            one_const, flag_for_math, trt.ElementWiseOperation.SUB).get_output(0)
+        tok_part = network.add_elementwise(
+            inv_flag, token_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        embed_part = network.add_elementwise(
+            flag_for_math, input_embed_tensor, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden_state = network.add_elementwise(
+            tok_part, embed_part, trt.ElementWiseOperation.SUM).get_output(0)
+    else:
+        hidden_state = token_embed
+
+    if hidden_state.dtype != work_trt_dtype:
+        hidden_state = network.add_cast(hidden_state, work_trt_dtype).get_output(0)
+
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    present_k_outputs = []
+    present_v_outputs = []
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        result = _add_tp_decoder_layer(
+            network=network,
+            hidden=hidden_state,
+            cache_k=cache_k_inputs[layer_idx],
+            cache_v=cache_v_inputs[layer_idx],
+            attention_mask=attention_mask,
+            position_id=position_id,
+            attention_scale=attn_scale,
+            eps_tensor=eps_tensor,
+            eps=config.rms_norm_eps,
+            weights=weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            attention_size=attention_size,
+            kv_attention_size=kv_attention_size,
+            mlp_size=mlp_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            max_cache_length=max_cache_length,
+            norm_type=norm_type,
+            activation=activation,
+            parallel_residual=parallel_residual,
+            dtype=work_np_dtype,
+            quant_ctx=quant_ctx,
+            cos_half_tensor=cos_half_tensor,
+            sin_half_tensor=sin_half_tensor,
+            rotary_embedding_dim=rotary_embedding_dim,
+            interleaved_rope=interleaved_rope,
+            tp_size=parallel.tp_size,
+        )
+        hidden_state = result["hidden"]
+        present_k_outputs.append(result["present_k"])
+        present_v_outputs.append(result["present_v"])
+        if debug_layer_outputs:
+            _mark_debug_output(network, result["post_attn"], f"debug_post_attn_{layer_idx}")
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    final_norm = weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = _apply_norm(
+            network, hidden_state, hidden, final_norm,
+            weights.get("final_norm_beta"), eps_tensor, norm_type,
+            dtype=work_np_dtype, eps=config.rms_norm_eps)
+
+    if hidden_state_output:
+        hs_out = network.add_identity(hidden_state).get_output(0)
+        hs_out.name = "hidden_state"
+        network.mark_output(hs_out)
+
+    out_vocab = weights["w_out"].shape[1] if isinstance(weights["w_out"], np.ndarray) else vocab
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, out_vocab, weights["w_out"], dtype=work_np_dtype)
+    lm_bias = weights.get("lm_head_bias")
+    if lm_bias is not None:
+        logits = graph_ops.add_bias_sum(network, logits, out_vocab, lm_bias, dtype=work_np_dtype)
+    else:
+        logits = graph_ops.add_bias_sum(
+            network, logits, out_vocab, np.zeros(out_vocab, dtype=work_np_dtype),
+            dtype=work_np_dtype)
+    if work_trt_dtype != trt.float32:
+        logits = network.add_cast(logits, trt.float32).get_output(0)
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for i in range(num_layers):
+        present_k_outputs[i].name = graph_ops.layer_tensor_name("present_k", i)
+        present_v_outputs[i].name = graph_ops.layer_tensor_name("present_v", i)
+        network.mark_output(present_k_outputs[i])
+        network.mark_output(present_v_outputs[i])
+
+    if verbose:
+        print(
+            f"[trtmc build] Building PersonaPlex temporal TP rank "
+            f"{parallel.rank}/{parallel.tp_size} ({num_layers}L, h={hidden}, "
+            f"local_heads={num_heads}, local_attn={attention_size}, "
+            f"local_mlp={mlp_size}, cache={max_cache_length}, precision={precision}) ...",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT PersonaPlex tensor-parallel temporal build failed")
+    return bytes(plan)
+
+
+def _add_tp_decoder_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    attention_mask: trt.ITensor,
+    position_id: trt.ITensor,
+    attention_scale: float | None,
+    eps_tensor: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    attention_size: int,
+    kv_attention_size: int,
+    mlp_size: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    max_cache_length: int,
+    norm_type: str,
+    activation: str,
+    parallel_residual: bool,
+    dtype: np.dtype,
+    quant_ctx,
+    cos_half_tensor: trt.ITensor,
+    sin_half_tensor: trt.ITensor,
+    rotary_embedding_dim: int,
+    interleaved_rope: bool,
+    tp_size: int,
+    eps: float | None = None,
+) -> dict[str, trt.ITensor]:
+    attn = graph_blocks.add_attention_block(
+        network, hidden, cache_k, cache_v, attention_mask, position_id,
+        weights=weights, prefix=prefix,
+        hidden_size=hidden_size, attention_size=attention_size,
+        kv_attention_size=kv_attention_size,
+        num_heads=num_heads, num_kv_heads=num_kv_heads, head_dim=head_dim,
+        max_cache_length=max_cache_length,
+        attention_scale=attention_scale,
+        eps_tensor=eps_tensor, eps=eps,
+        norm_type=norm_type, position_type="rope",
+        alibi_slopes_tensor=None,
+        alibi_indices_tensor=None,
+        dtype=dtype,
+        quant_ctx=quant_ctx,
+        layer_prefix=prefix,
+        cos_half_tensor=cos_half_tensor,
+        sin_half_tensor=sin_half_tensor,
+        rotary_embedding_dim=rotary_embedding_dim,
+        interleaved_rope=interleaved_rope,
+        ffi_attention_kernel=None,
+        dynamic_kv_cache=False,
+    )
+    attn_out = add_all_reduce_sum(network, attn["attn_out"], tp_size)
+
+    if parallel_residual:
+        post_attn_norm_w = weights.get(f"{prefix}.post_attn_norm")
+        if post_attn_norm_w is not None:
+            norm2 = _apply_norm(
+                network, hidden, hidden_size,
+                post_attn_norm_w,
+                weights.get(f"{prefix}.post_attn_norm_beta"),
+                eps_tensor, norm_type, dtype=dtype, eps=eps)
+        else:
+            norm2 = attn["normed"]
+    else:
+        residual1 = network.add_elementwise(
+            hidden, attn_out, trt.ElementWiseOperation.SUM).get_output(0)
+        norm2 = _apply_norm(
+            network, residual1, hidden_size,
+            weights[f"{prefix}.post_attn_norm"],
+            weights.get(f"{prefix}.post_attn_norm_beta"),
+            eps_tensor, norm_type, dtype=dtype, eps=eps)
+
+    mlp_out = graph_blocks.add_swiglu_mlp(
+        network, norm2, weights=weights, prefix=prefix,
+        hidden_size=hidden_size, mlp_size=mlp_size, dtype=dtype,
+        quant_ctx=quant_ctx, layer_prefix=prefix)
+    mlp_out = add_all_reduce_sum(network, mlp_out, tp_size)
+
+    if parallel_residual:
+        sum_attn = network.add_elementwise(
+            hidden, attn_out, trt.ElementWiseOperation.SUM).get_output(0)
+        residual2 = network.add_elementwise(
+            sum_attn, mlp_out, trt.ElementWiseOperation.SUM).get_output(0)
+        post_attn_tensor = sum_attn
+    else:
+        residual2 = network.add_elementwise(
+            residual1, mlp_out, trt.ElementWiseOperation.SUM).get_output(0)
+        post_attn_tensor = residual1
+
+    return {
+        "hidden": residual2,
+        "post_attn": post_attn_tensor,
+        "present_k": attn["present_k"],
+        "present_v": attn["present_v"],
+    }

--- a/python/tensorrt_model_connect/families/personaplex/plugin.py
+++ b/python/tensorrt_model_connect/families/personaplex/plugin.py
@@ -68,6 +68,10 @@ from ...checkpoint_mapper import (
     _transpose_2d,
 )
 from ...build_timing import timed_trt_compile
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 
 trt = trt_compat.get_trt() if trt_compat.is_available() else None
 
@@ -243,6 +247,7 @@ class PersonaPlexPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
         debug_layer_outputs: bool = False,
+        parallel_config=None,
     ) -> bytes:
         """Build TRT engine for the Temporal Transformer.
 
@@ -280,6 +285,31 @@ class PersonaPlexPlugin:
         for key, val in weights.items():
             if key.startswith("temporal."):
                 decoder_weights[key[len("temporal."):]] = val
+        decoder_weights["_kv_attention_size"] = hidden
+
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="PersonaPlex temporal tensor-parallel builds")
+            if quant_ctx is not None:
+                raise ValueError("PersonaPlex tensor-parallel builds do not support quantization")
+            from .decoder_tp_builder import build_personaplex_tp_decoder_engine
+            return build_personaplex_tp_decoder_engine(
+                temporal_config,
+                decoder_weights,
+                max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                norm_type="rmsnorm",
+                mlp_type="swiglu",
+                position_type="rope",
+                interleaved_rope=True,
+                embed_input=True,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                hidden_state_output=True,
+                parallel_config=parallel,
+            )
 
         return build_standard_decoder_engine(
             temporal_config, decoder_weights, max_cache_length,

--- a/src/runtime/models/speech/plugin.cpp
+++ b/src/runtime/models/speech/plugin.cpp
@@ -4,9 +4,51 @@
 #include "runtime/models/speech/pipeline.h"
 #include "runtime/plugins/shared/audio_helpers.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
+#include "utils/json_helpers.h"
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
+    if (dim < 0 || static_cast<std::size_t>(dim) >= shape.size())
+        return -1;
+    const auto value = shape[static_cast<std::size_t>(dim)];
+    if (value <= 0 || value > std::numeric_limits<int32_t>::max())
+        return -1;
+    return static_cast<int32_t>(value);
+}
+
+int32_t decoder_cache_row_width(const TrtModule& module, int32_t fallback) {
+    const int32_t from_engine = dim_at(module.tensor_shape("cache_k_0"), 1);
+    return from_engine > 0 ? from_engine : fallback;
+}
+
+} // namespace
 
 class SpeechPlugin final : public IPipelinePlugin {
   public:
@@ -21,12 +63,27 @@ class SpeechPlugin final : public IPipelinePlugin {
             build_speech_config_from_bundle(ctx.bundle, ctx.config_json, ctx.config, ctx.hf_python);
         infer_speech_vocab_sizes(speech_cfg, ctx.config_json, ctx.config);
 
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        ModuleCreateOptions temporal_opts = opts;
+        if (tp_config.enabled) {
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+            temporal_opts.distributed_communicator = tp_group.communicator;
+            temporal_opts.distributed_owner = tp_group.owner;
+        }
+
+        const std::string temporal_section =
+            tp_config.enabled ? tp_engine_section_name(tp_group.rank) : std::string("engine_plan");
         auto temporal_loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "speech temporal", opts);
+            ctx.backend, find_section(ctx.bundle, temporal_section), "speech temporal",
+            temporal_opts);
 
         cudaStream_t stream = temporal_loaded.module->stream();
 
-        int32_t temporal_kv_dim = compute_kv_dim_kv_heads(ctx.config, ctx.config.hidden_size);
+        const int32_t temporal_kv_fallback =
+            compute_kv_dim_kv_heads(ctx.config, ctx.config.hidden_size);
+        int32_t temporal_kv_dim =
+            decoder_cache_row_width(*temporal_loaded.module, temporal_kv_fallback);
 
         DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
         std::unique_ptr<IInferenceState> temporal_state =

--- a/src/runtime/models/speech/plugin.cpp
+++ b/src/runtime/models/speech/plugin.cpp
@@ -74,9 +74,9 @@ class SpeechPlugin final : public IPipelinePlugin {
 
         const std::string temporal_section =
             tp_config.enabled ? tp_engine_section_name(tp_group.rank) : std::string("engine_plan");
-        auto temporal_loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, temporal_section), "speech temporal",
-            temporal_opts);
+        auto temporal_loaded =
+            load_trt_module_from_plan(ctx.backend, find_section(ctx.bundle, temporal_section),
+                                      "speech temporal", temporal_opts);
 
         cudaStream_t stream = temporal_loaded.module->stream();
 

--- a/tests/builder/test_engine_personaplex_tp.py
+++ b/tests/builder/test_engine_personaplex_tp.py
@@ -1,0 +1,245 @@
+"""Tensor-parallel tests for PersonaPlex temporal decoder support."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "tensorrt_model_connect.config",
+    reason="tensorrt_model_connect requires tensorrt",
+)
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.personaplex.plugin import PersonaPlexPlugin
+from tensorrt_model_connect.parallel_config import ParallelConfig, shard_standard_decoder_weights
+
+personaplex_plugin = importlib.import_module(
+    "tensorrt_model_connect.families.personaplex.plugin")
+
+
+_LAYERS = 2
+_HIDDEN = 16
+_HEADS = 4
+_MLP = 64
+_VOCAB = 32
+
+
+def _personaplex_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.personaplex.decoder_tp_builder",
+        reason="TensorRT is required for PersonaPlex TP builder tests",
+    )
+
+
+def _make_config(
+    *,
+    hidden: int = _HIDDEN,
+    heads: int = _HEADS,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+) -> ModelConfig:
+    return ModelConfig(
+        model_type="personaplex",
+        vocab_size=_VOCAB,
+        hidden_size=hidden,
+        intermediate_size=mlp,
+        num_hidden_layers=layers,
+        num_attention_heads=heads,
+        num_key_value_heads=heads,
+        rms_norm_eps=1e-8,
+        _head_dim=hidden // heads,
+    )
+
+
+def _make_temporal_weights(
+    *,
+    hidden: int = _HIDDEN,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+    vocab: int = _VOCAB,
+) -> WeightDict:
+    rng = np.random.RandomState(123)
+
+    def rand(*shape: int) -> np.ndarray:
+        return rng.randn(*shape).astype(np.float32)
+
+    weights = WeightDict({
+        "_attention_size": hidden,
+        "_mlp_size": mlp,
+        "embedding": rand(vocab, hidden),
+        "position_embedding": np.zeros((128, hidden), dtype=np.float32),
+        "final_norm": rand(hidden),
+        "w_out": rand(hidden, vocab),
+    })
+    for i in range(layers):
+        prefix = f"layer.{i}"
+        weights[f"{prefix}.input_norm"] = rand(hidden)
+        weights[f"{prefix}.post_attn_norm"] = rand(hidden)
+        weights[f"{prefix}.w_q"] = rand(hidden, hidden)
+        weights[f"{prefix}.w_k"] = rand(hidden, hidden)
+        weights[f"{prefix}.w_v"] = rand(hidden, hidden)
+        weights[f"{prefix}.w_o"] = rand(hidden, hidden)
+        weights[f"{prefix}.w_gate"] = rand(hidden, mlp)
+        weights[f"{prefix}.w_up"] = rand(hidden, mlp)
+        weights[f"{prefix}.w_down"] = rand(mlp, hidden)
+    return weights
+
+
+def test_personaplex_tp_builder_rejects_single_device_mode():
+    decoder_tp_builder = _personaplex_tp_builder_module()
+
+    with pytest.raises(ValueError, match="requires an enabled parallel config"):
+        decoder_tp_builder.build_personaplex_tp_decoder_engine(
+            _make_config(),
+            _make_temporal_weights(),
+            max_cache_length=4,
+            parallel_config=ParallelConfig(),
+        )
+
+
+def test_personaplex_tp_metadata_defaults_to_attention_size():
+    decoder_tp_builder = _personaplex_tp_builder_module()
+    config = _make_config()
+    weights = _make_temporal_weights()
+
+    with_metadata = decoder_tp_builder._ensure_tp_metadata(config, weights)
+
+    assert with_metadata is not weights
+    assert with_metadata["_kv_attention_size"] == _HIDDEN
+    assert "_kv_attention_size" not in weights
+
+
+def test_personaplex_tp_preserves_existing_kv_metadata():
+    decoder_tp_builder = _personaplex_tp_builder_module()
+    config = _make_config()
+    weights = _make_temporal_weights()
+    weights["_kv_attention_size"] = _HIDDEN
+
+    assert decoder_tp_builder._ensure_tp_metadata(config, weights) is weights
+
+
+def test_personaplex_tp_shards_rank_local_temporal_weights():
+    decoder_tp_builder = _personaplex_tp_builder_module()
+    weights = decoder_tp_builder._ensure_tp_metadata(
+        _make_config(), _make_temporal_weights())
+
+    shard = shard_standard_decoder_weights(
+        _make_config(),
+        weights,
+        ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2),
+    )
+
+    assert isinstance(shard, WeightDict)
+    assert shard["_tensor_parallel_size"] == 4
+    assert shard["_tensor_parallel_rank"] == 2
+    assert shard["_attention_size"] == _HIDDEN // 4
+    assert shard["_kv_attention_size"] == _HIDDEN // 4
+    assert shard["_mlp_size"] == _MLP // 4
+    assert shard["embedding"] is weights["embedding"]
+    assert shard["final_norm"] is weights["final_norm"]
+
+    q_start = (_HIDDEN // 4) * 2
+    q_end = (_HIDDEN // 4) * 3
+    mlp_start = (_MLP // 4) * 2
+    mlp_end = (_MLP // 4) * 3
+    np.testing.assert_array_equal(
+        shard["layer.0.w_q"],
+        weights["layer.0.w_q"][:, q_start:q_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_k"],
+        weights["layer.0.w_k"][:, q_start:q_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_o"],
+        weights["layer.0.w_o"][q_start:q_end, :],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_gate"],
+        weights["layer.0.w_gate"][:, mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_down"],
+        weights["layer.0.w_down"][mlp_start:mlp_end, :],
+    )
+
+
+def test_personaplex_plugin_routes_temporal_tp_build(monkeypatch):
+    decoder_tp_builder = _personaplex_tp_builder_module()
+    captured = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        captured["config"] = config
+        captured["weights"] = weights
+        captured["max_cache_length"] = max_cache_length
+        captured["kwargs"] = kwargs
+        return b"tp-plan"
+
+    monkeypatch.setattr(
+        personaplex_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+    monkeypatch.setattr(
+        decoder_tp_builder,
+        "build_personaplex_tp_decoder_engine",
+        fake_build,
+    )
+
+    weights = WeightDict({
+        "_hidden_size": _HIDDEN,
+        "_num_hidden_layers": _LAYERS,
+        "_num_attention_heads": _HEADS,
+        "_head_dim": _HIDDEN // _HEADS,
+        "_intermediate_size": _MLP,
+        "_text_vocab": _VOCAB,
+        "temporal._attention_size": _HIDDEN,
+        "temporal._mlp_size": _MLP,
+        "temporal.embedding": np.zeros((_VOCAB, _HIDDEN), dtype=np.float32),
+        "temporal.w_out": np.zeros((_HIDDEN, _VOCAB), dtype=np.float32),
+    })
+
+    plan = PersonaPlexPlugin().build_engine(
+        _make_config(),
+        weights,
+        max_cache_length=8,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1),
+    )
+
+    assert plan == b"tp-plan"
+    assert captured["config"].num_attention_heads == _HEADS
+    assert captured["weights"]["_kv_attention_size"] == _HIDDEN
+    assert captured["max_cache_length"] == 8
+    assert captured["kwargs"]["mlp_type"] == "swiglu"
+    assert captured["kwargs"]["position_type"] == "rope"
+    assert captured["kwargs"]["embed_input"] is True
+    assert captured["kwargs"]["hidden_state_output"] is True
+    assert captured["kwargs"]["parallel_config"].tp_size == 4
+
+
+def test_personaplex_plugin_rejects_quantized_tp(monkeypatch):
+    monkeypatch.setattr(
+        personaplex_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="do not support quantization"):
+        PersonaPlexPlugin().build_engine(
+            _make_config(),
+            WeightDict({
+                "_hidden_size": _HIDDEN,
+                "_num_hidden_layers": _LAYERS,
+                "_num_attention_heads": _HEADS,
+                "_head_dim": _HIDDEN // _HEADS,
+                "_intermediate_size": _MLP,
+                "_text_vocab": _VOCAB,
+            }),
+            max_cache_length=8,
+            quant_ctx=object(),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )

--- a/tests/e2e/models/personaplex-7b-l0-tp4.json
+++ b/tests/e2e/models/personaplex-7b-l0-tp4.json
@@ -1,0 +1,65 @@
+{
+  "name": "personaplex-7b-l0-tp4",
+  "trace_id": "IT-E2E-PPLX-L0-TP4-01",
+  "hf_id": "nvidia/personaplex-7b-v1",
+  "bundle": "personaplex-7b-l0-tp4.trtfb",
+  "family": "personaplex",
+  "runtime_strategy": "speech_to_speech",
+  "gated": true,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "reference_family": "s2s_personaplex",
+  "user_contract": "speech_response",
+  "test_type": "audio",
+  "max_cache_length": 512,
+  "test_input_audio": "data/Recording.wav",
+  "speech_reference_tokens": "data/personaplex_recording_official_tokens_greedy.npy",
+  "speech_test_max_frames": 100,
+  "speech_min_token_match": 0.8,
+  "speech_min_frame_exact": 0.7,
+  "speech_min_rms": 0.001,
+  "prompt": "",
+  "max_new_tokens": 300,
+  "logit_atol": 0.01,
+  "trust_remote_code": true,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "PersonaPlex L0 tensor-parallel repro. Uses the same checkpoint, speech_to_speech runtime, official token snapshot, runner, comparator, speech artifact contract, cache budget, tail-frame budget, and thresholds as personaplex-7b-l0."
+}

--- a/tests/e2e_harness/runners/audio_speech.py
+++ b/tests/e2e_harness/runners/audio_speech.py
@@ -92,6 +92,17 @@ def _strip_mpirun_tags(text: str) -> str:
     return "\n".join(lines)
 
 
+def _untag_ranked_mpirun_line(line: str) -> tuple[int | None, str]:
+    match = re.match(r"^\[([^\]]+)\]<std(?:out|err)>:\s?(.*)$", line)
+    if not match:
+        return None, line
+    rank_text = match.group(1).split(",")[-1]
+    try:
+        return int(rank_text), match.group(2)
+    except ValueError:
+        return None, match.group(2)
+
+
 def _read_wav_rms(path: str) -> float:
     """Read a WAV file and return its RMS energy."""
     import numpy as np
@@ -466,15 +477,32 @@ class SpeechToSpeechRunner:
         )
 
         with tempfile.TemporaryDirectory(prefix="trtmc_s2s_") as tmpdir:
-            wav_path = os.path.join(tmpdir, "output.wav")
-            tokens_path = os.path.join(tmpdir, "output_tokens.npy")
+            distributed_runtime = _distributed_runtime_config(case)
+            output_root = os.path.join(tmpdir, "rank_outputs")
+            wav_path = (
+                os.path.join(output_root, "rank_0", "output.wav")
+                if distributed_runtime else os.path.join(tmpdir, "output.wav")
+            )
+            tokens_path = (
+                os.path.join(output_root, "rank_0", "output_tokens.npy")
+                if distributed_runtime else os.path.join(tmpdir, "output_tokens.npy")
+            )
 
             cmd = [
                 binary, "speak", bundle_path,
                 "--audio-in", audio_input,
-                "--audio-out", wav_path,
                 "--tail-frames", str(max_frames),
             ]
+            if distributed_runtime:
+                wrapper = (
+                    'rank="${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${PMIX_RANK:-${RANK:-0}}}}"; '
+                    'out="$1/rank_${rank}"; mkdir -p "$out"; shift; '
+                    'exec "$@" --audio-out "$out/output.wav"'
+                )
+                cmd = ["bash", "-lc", wrapper, "trtmc_rank_speech", output_root] + cmd
+            else:
+                cmd.extend(["--audio-out", wav_path])
+            cmd = _wrap_distributed_command(cmd, case)
 
             env = {
                 **os.environ,
@@ -491,8 +519,8 @@ class SpeechToSpeechRunner:
                 "speech_to_speech", case.name)
             data: dict = {
                 "returncode": result.returncode,
-                "stdout": result.stdout,
-                "stderr": stderr_truncated,
+                "stdout": _strip_mpirun_tags(result.stdout),
+                "stderr": _strip_mpirun_tags(stderr_truncated),
             }
             if stderr_log:
                 data["stderr_log"] = stderr_log
@@ -544,7 +572,10 @@ class SpeechToSpeechRunner:
         """Try to parse frame tokens from C++ stderr output."""
         import numpy as np
         frames = []
-        for line in (stderr or "").splitlines():
+        for raw_line in (stderr or "").splitlines():
+            rank, line = _untag_ranked_mpirun_line(raw_line)
+            if rank not in (None, 0):
+                continue
             if line.startswith("frame["):
                 try:
                     # format: frame[N]: depth=X audio=Y,Z,...
@@ -558,6 +589,16 @@ class SpeechToSpeechRunner:
                     if token_strs:
                         frames.append(token_strs)
                 except (ValueError, IndexError):
+                    pass
+                continue
+
+            match = re.search(r"\[speech\]\s+Output frame\s+\d+:\s*(.*)$", line)
+            if match:
+                try:
+                    token_strs = [int(t) for t in match.group(1).split()]
+                    if token_strs:
+                        frames.append(token_strs)
+                except ValueError:
                     pass
         if frames:
             data["output_tokens"] = np.array(frames, dtype=np.int32)


### PR DESCRIPTION
## Background
PersonaPlex needed tensor-parallel coverage following the repo pattern of duplicating the single-device builder and only changing the multi-device pieces. This adds TP support for the temporal decoder and verifies the L0 speech-to-speech path with TP4.

## Exit Criteria
- Build rank-local PersonaPlex temporal decoder plans for TP4.
- Load the rank-specific temporal plan at speech runtime while keeping depth/codebook engines unchanged.
- Verify the TP4 L0 E2E case with the same token/audio thresholds as `personaplex-7b-l0`.

## Implementation
- Added a PersonaPlex temporal TP builder that shards standard decoder projections and all-reduces the row-parallel attention/MLP outputs.
- Routed `parallel_config` through the PersonaPlex plugin with TRT 11 and unsupported-option checks.
- Updated the speech runtime plugin to initialize the tensor-parallel group and load `engine_plan_tp_rankN`, sizing the temporal KV cache from the loaded rank-local engine.
- Updated the speech-to-speech E2E runner to write per-rank outputs under distributed execution and compare rank 0 output/tokens.
- Added focused builder tests and a `personaplex-7b-l0-tp4` multi-device E2E manifest.

## Validation
- `git diff --check`: passed.
- `sudo -n docker run --rm -v /home/scratch.daichu_sw_1/TensorRT-Model-Connect:/workspace/tensorrt-model-connect -w /workspace/tensorrt-model-connect trtmc-dev-b200-trt11:latest bash -lc 'PYTHONPATH=python:. python -m pytest -q tests/builder/test_engine_personaplex_tp.py tests/builder/test_manifest_validation.py -q'`: passed, 32 tests.
- `sudo -n docker run --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 -v /home/scratch.daichu_sw_1/TensorRT-Model-Connect:/workspace/tensorrt-model-connect -w /workspace/tensorrt-model-connect trtmc-dev-b200-trt11:latest bash -lc 'git config --global --add safe.directory /workspace/tensorrt-model-connect/build-personaplex-e2e/_deps/nlohmann_json-src && cmake -S . -B build-personaplex-e2e -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so && cmake --build build-personaplex-e2e --target trtmc trtmc_backend_trt -j'`: passed.
- `sudo -n docker run --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 -e HF_TOKEN=<redacted> -e HUGGINGFACE_HUB_TOKEN=<redacted> -v /home/scratch.daichu_sw_1/TensorRT-Model-Connect:/workspace/tensorrt-model-connect -v /home/scratch.daichu_sw_1/trtmc-storage:/trtmc-storage -w /workspace/tensorrt-model-connect trtmc-dev-b200-trt11:latest bash -lc 'PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py --multi-device-only -k "personaplex-7b-l0-tp4" --trtmc-binary ./build-personaplex-e2e/trtmc --engine-dir /trtmc-storage/engines-personaplex-tp4 --e2e-artifacts-dir /trtmc-storage/e2e-personaplex-tp4 --hf-python /opt/venv/bin/python -s'`: passed, 1 test in 996.48s.

## Notes For Future Readers
- Review the temporal TP builder first, then the speech runtime loader and runner changes. The runner change is needed because distributed speech-to-speech runs must avoid every rank writing the same output path.