### PR TITLE
feat(sam): add encoder tp4 support

### DIFF
--- a/python/tensorrt_model_connect/families/sam/plugin.py
+++ b/python/tensorrt_model_connect/families/sam/plugin.py
@@ -49,6 +49,10 @@ from ...checkpoint_mapper import (
     _transpose_2d,
 )
 from ... import graph_ops
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 
 
 trt = trt_compat.get_trt()
@@ -399,12 +403,28 @@ class SamPlugin:
         self, config: ModelConfig, weights: WeightDict,
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
+        parallel_config=None,
     ) -> bytes:
         """Build TRT engine for SAM image encoder.
 
         Input:  pixel_values [1, 3, 1024, 1024]
         Output: image_embeddings [1, 256, 64, 64]
         """
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="SAM encoder tensor-parallel MLP builds")
+            if quant_ctx is not None:
+                raise ValueError("SAM tensor-parallel builds do not support quantization")
+            from .sam_tp_builder import build_sam_tp_encoder_engine
+            return build_sam_tp_encoder_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                parallel_config=parallel,
+            )
+
         sam_cfg = config.raw.get("_sam_config", _resolve_sam_config(config.raw))
         hidden = sam_cfg["hidden_size"]
         num_layers = sam_cfg["num_hidden_layers"]

--- a/python/tensorrt_model_connect/families/sam/sam_tp_builder.py
+++ b/python/tensorrt_model_connect/families/sam/sam_tp_builder.py
@@ -1,0 +1,242 @@
+"""Tensor-parallel SAM image encoder builder.
+
+SAM ViT attention and the mask decoder remain replicated. The encoder MLPs are
+tensor-parallel: FC1 columns are sharded, FC2 rows are sharded, and a TensorRT
+distributed ALL_REDUCE restores the full residual before the next layer.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+import sys
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+from .plugin import SamPlugin, _resolve_sam_config
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _validate_sam_encoder_tp(config: "ModelConfig", parallel: "ParallelConfig") -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("SAM tensor-parallel build requires a concrete rank")
+    sam_cfg = config.raw.get("_sam_config", _resolve_sam_config(config.raw))
+    mlp_dim = int(sam_cfg["mlp_dim"])
+    if mlp_dim % parallel.tp_size != 0:
+        raise ValueError(
+            "SAM tensor-parallel encoder requires mlp_dim divisible by tp_size "
+            f"({mlp_dim} vs {parallel.tp_size})")
+
+
+def _slice_mlp_columns(arr: np.ndarray, mlp_dim: int, parallel: "ParallelConfig") -> np.ndarray:
+    local = mlp_dim // parallel.tp_size
+    start = parallel.rank * local
+    end = start + local
+    return np.ascontiguousarray(arr[..., start:end])
+
+
+def _slice_mlp_rows(arr: np.ndarray, mlp_dim: int, parallel: "ParallelConfig") -> np.ndarray:
+    local = mlp_dim // parallel.tp_size
+    start = parallel.rank * local
+    end = start + local
+    return np.ascontiguousarray(arr[start:end, ...])
+
+
+def build_sam_tp_encoder_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build one rank-local SAM image encoder with tensor-parallel MLPs."""
+    del max_cache_length, precision
+    if quant_ctx is not None:
+        raise ValueError("SAM tensor-parallel builds do not support quantization")
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError("SAM tensor-parallel builder requires an enabled parallel config")
+    _validate_sam_encoder_tp(config, parallel)
+
+    sam_cfg = config.raw.get("_sam_config", _resolve_sam_config(config.raw))
+    hidden = sam_cfg["hidden_size"]
+    num_layers = sam_cfg["num_hidden_layers"]
+    num_heads = sam_cfg["num_attention_heads"]
+    head_dim = hidden // num_heads
+    mlp_dim = sam_cfg["mlp_dim"]
+    local_mlp_dim = mlp_dim // parallel.tp_size
+    image_size = sam_cfg["image_size"]
+    patch_size = sam_cfg["patch_size"]
+    window_size = sam_cfg["window_size"]
+    global_attn_indexes = set(sam_cfg["global_attn_indexes"])
+    decoder_hidden = sam_cfg["decoder_hidden_size"]
+
+    grid_size = image_size // patch_size
+    seq_len = grid_size * grid_size
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 2 << 30)
+
+    eps_t = graph_ops.add_constant(
+        network, (1, 1), np.array([1e-6], dtype=np.float32))
+
+    pixel_values = network.add_input(
+        "pixel_values", trt.float32, (1, 3, image_size, image_size))
+
+    pe_w = weights["encoder.patch_embed.weight"]
+    pe_b = weights["encoder.patch_embed.bias"]
+    patch_conv = network.add_convolution_nd(
+        pixel_values, num_output_maps=hidden,
+        kernel_shape=(patch_size, patch_size),
+        kernel=trt.Weights(np.ascontiguousarray(pe_w)),
+        bias=trt.Weights(np.ascontiguousarray(pe_b)))
+    patch_conv.stride_nd = (patch_size, patch_size)
+
+    to_nhwc = network.add_shuffle(patch_conv.get_output(0))
+    to_nhwc.first_transpose = trt.Permutation([0, 2, 3, 1])
+
+    pos_embed = weights["encoder.pos_embed"]
+    pos_c = graph_ops.add_constant(
+        network, (1, grid_size, grid_size, hidden), pos_embed)
+    pos_sum = network.add_elementwise(
+        to_nhwc.get_output(0), pos_c, trt.ElementWiseOperation.SUM)
+    hidden_state = pos_sum.get_output(0)
+
+    for layer_idx in range(num_layers):
+        w_prefix = f"encoder.layer{layer_idx}"
+        use_global_attn = layer_idx in global_attn_indexes
+
+        norm1_w = weights[f"{w_prefix}.norm1.weight"]
+        norm1_b = weights[f"{w_prefix}.norm1.bias"]
+
+        reshape_2d = network.add_shuffle(hidden_state)
+        reshape_2d.reshape_dims = (seq_len, hidden)
+
+        normed = graph_ops.add_layer_norm(
+            network, reshape_2d.get_output(0), hidden,
+            norm1_w, norm1_b, eps_t)
+
+        normed_4d = network.add_shuffle(normed)
+        normed_4d.reshape_dims = (1, grid_size, grid_size, hidden)
+
+        if use_global_attn:
+            attn_out_4d = SamPlugin._build_global_attention(
+                network, normed_4d.get_output(0), weights, w_prefix,
+                grid_size, hidden, num_heads, head_dim, seq_len)
+        else:
+            attn_out_4d = SamPlugin._build_windowed_attention(
+                network, normed_4d.get_output(0), weights, w_prefix,
+                grid_size, hidden, num_heads, head_dim, window_size)
+
+        res1 = network.add_elementwise(
+            hidden_state, attn_out_4d, trt.ElementWiseOperation.SUM)
+
+        norm2_w = weights[f"{w_prefix}.norm2.weight"]
+        norm2_b = weights[f"{w_prefix}.norm2.bias"]
+
+        res1_2d = network.add_shuffle(res1.get_output(0))
+        res1_2d.reshape_dims = (seq_len, hidden)
+
+        normed2 = graph_ops.add_layer_norm(
+            network, res1_2d.get_output(0), hidden,
+            norm2_w, norm2_b, eps_t)
+
+        fc1_w = _slice_mlp_columns(weights[f"{w_prefix}.mlp.fc1.weight"], mlp_dim, parallel)
+        fc1_b = _slice_mlp_columns(weights[f"{w_prefix}.mlp.fc1.bias"], mlp_dim, parallel)
+        fc1 = graph_ops.add_matmul_rhs_constant(
+            network, normed2, hidden, local_mlp_dim, fc1_w)
+        fc1 = graph_ops.add_bias_sum(network, fc1, local_mlp_dim, fc1_b)
+        gelu = graph_ops.add_gelu_new(network, fc1)
+
+        fc2_w = _slice_mlp_rows(weights[f"{w_prefix}.mlp.fc2.weight"], mlp_dim, parallel)
+        fc2 = graph_ops.add_matmul_rhs_constant(
+            network, gelu, local_mlp_dim, hidden, fc2_w)
+        fc2 = add_all_reduce_sum(network, fc2, parallel.tp_size)
+        fc2 = graph_ops.add_bias_sum(
+            network, fc2, hidden, weights[f"{w_prefix}.mlp.fc2.bias"])
+
+        fc2_4d = network.add_shuffle(fc2)
+        fc2_4d.reshape_dims = (1, grid_size, grid_size, hidden)
+
+        res2 = network.add_elementwise(
+            res1.get_output(0), fc2_4d.get_output(0), trt.ElementWiseOperation.SUM)
+        hidden_state = res2.get_output(0)
+
+    to_nchw = network.add_shuffle(hidden_state)
+    to_nchw.first_transpose = trt.Permutation([0, 3, 1, 2])
+
+    neck_c1_w = weights["encoder.neck.conv1.weight"]
+    neck_c1_b = weights.get("encoder.neck.conv1.bias",
+                            np.zeros(decoder_hidden, dtype=np.float32))
+    neck_conv1 = network.add_convolution_nd(
+        to_nchw.get_output(0), num_output_maps=decoder_hidden,
+        kernel_shape=(1, 1),
+        kernel=trt.Weights(np.ascontiguousarray(neck_c1_w)),
+        bias=trt.Weights(np.ascontiguousarray(neck_c1_b)))
+
+    to_nhwc_n1 = network.add_shuffle(neck_conv1.get_output(0))
+    to_nhwc_n1.first_transpose = trt.Permutation([0, 2, 3, 1])
+    flat_n1 = network.add_shuffle(to_nhwc_n1.get_output(0))
+    flat_n1.reshape_dims = (seq_len, decoder_hidden)
+    ln1_out = graph_ops.add_layer_norm(
+        network, flat_n1.get_output(0), decoder_hidden,
+        weights["encoder.neck.ln1.weight"], weights["encoder.neck.ln1.bias"], eps_t)
+    unflat_n1 = network.add_shuffle(ln1_out)
+    unflat_n1.reshape_dims = (1, grid_size, grid_size, decoder_hidden)
+    to_nchw_n1 = network.add_shuffle(unflat_n1.get_output(0))
+    to_nchw_n1.first_transpose = trt.Permutation([0, 3, 1, 2])
+
+    neck_c2_w = weights["encoder.neck.conv2.weight"]
+    neck_c2_b = weights.get("encoder.neck.conv2.bias",
+                            np.zeros(decoder_hidden, dtype=np.float32))
+    neck_conv2 = network.add_convolution_nd(
+        to_nchw_n1.get_output(0), num_output_maps=decoder_hidden,
+        kernel_shape=(3, 3),
+        kernel=trt.Weights(np.ascontiguousarray(neck_c2_w)),
+        bias=trt.Weights(np.ascontiguousarray(neck_c2_b)))
+    neck_conv2.padding_nd = (1, 1)
+
+    to_nhwc_n2 = network.add_shuffle(neck_conv2.get_output(0))
+    to_nhwc_n2.first_transpose = trt.Permutation([0, 2, 3, 1])
+    flat_n2 = network.add_shuffle(to_nhwc_n2.get_output(0))
+    flat_n2.reshape_dims = (seq_len, decoder_hidden)
+    ln2_out = graph_ops.add_layer_norm(
+        network, flat_n2.get_output(0), decoder_hidden,
+        weights["encoder.neck.ln2.weight"], weights["encoder.neck.ln2.bias"], eps_t)
+    unflat_n2 = network.add_shuffle(ln2_out)
+    unflat_n2.reshape_dims = (1, grid_size, grid_size, decoder_hidden)
+    to_nchw_n2 = network.add_shuffle(unflat_n2.get_output(0))
+    to_nchw_n2.first_transpose = trt.Permutation([0, 3, 1, 2])
+
+    output = to_nchw_n2.get_output(0)
+    output.name = "image_embeddings"
+    network.mark_output(output)
+
+    if verbose:
+        print(
+            f"[trtmc build] Building SAM encoder TP rank {parallel.rank}/{parallel.tp_size} "
+            f"(image={image_size}x{image_size}, hidden={hidden}, layers={num_layers}) ...",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT engine build failed for SAM tensor-parallel encoder")
+    return bytes(plan)

--- a/src/runtime/models/segmentation/plugin.cpp
+++ b/src/runtime/models/segmentation/plugin.cpp
@@ -4,14 +4,34 @@
 #include "runtime/models/segmentation/sam_pipeline.h"
 #include "runtime/models/segmentation/segment_pipeline.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
 
+#include <cstdint>
+#include <string>
 #include <utility>
 
 namespace trtmc {
 
 namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
 
 SamConfig make_sam_config(const std::string& json) {
     SamConfig cfg;
@@ -54,8 +74,19 @@ class SegmentationPlugin final : public IPipelinePlugin {
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        ModuleCreateOptions encoder_opts = opts;
+        std::string encoder_section = "engine_plan";
+        if (tp_config.enabled) {
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+            encoder_opts.distributed_communicator = tp_group.communicator;
+            encoder_opts.distributed_owner = tp_group.owner;
+            encoder_section = tp_engine_section_name(tp_group.rank);
+        }
+
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "engine_plan", opts);
+            ctx.backend, find_section(ctx.bundle, encoder_section), "engine_plan", encoder_opts);
 
         if (ctx.config.runtime_strategy == "prompted_segmentation") {
             auto decoder = try_load_trt_module_from_plan(

--- a/tests/builder/test_engine_sam_tp.py
+++ b/tests/builder/test_engine_sam_tp.py
@@ -1,0 +1,119 @@
+"""Focused tests for SAM tensor-parallel encoder support."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+try:
+    sam_plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.sam.plugin")
+    from tensorrt_model_connect.families.sam import sam_tp_builder
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _raw_config(mlp_dim: int = 64) -> dict:
+    return {
+        "model_type": "sam",
+        "vision_config": {
+            "hidden_size": 32,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "image_size": 64,
+            "patch_size": 16,
+            "mlp_dim": mlp_dim,
+            "window_size": 2,
+            "global_attn_indexes": [1],
+        },
+        "prompt_encoder_config": {
+            "hidden_size": 16,
+            "image_embedding_size": 4,
+        },
+        "mask_decoder_config": {
+            "hidden_size": 16,
+            "num_multimask_outputs": 3,
+            "num_attention_heads": 4,
+            "depth": 2,
+        },
+    }
+
+
+def _model_config(mlp_dim: int = 64) -> SimpleNamespace:
+    return SimpleNamespace(raw=_raw_config(mlp_dim))
+
+
+def test_sam_tp_slices_encoder_mlp_columns_and_rows():
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+    columns = np.arange(32 * 64, dtype=np.float32).reshape(32, 64)
+    rows = np.arange(64 * 32, dtype=np.float32).reshape(64, 32)
+
+    np.testing.assert_array_equal(
+        sam_tp_builder._slice_mlp_columns(columns, 64, parallel),
+        columns[:, 32:48],
+    )
+    np.testing.assert_array_equal(
+        sam_tp_builder._slice_mlp_rows(rows, 64, parallel),
+        rows[32:48, :],
+    )
+
+
+def test_sam_tp_validation_rejects_non_divisible_mlp_dim():
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0)
+    with pytest.raises(ValueError, match="mlp_dim divisible"):
+        sam_tp_builder._validate_sam_encoder_tp(_model_config(66), parallel)
+
+
+def test_sam_tp_validation_requires_concrete_rank():
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1)
+    with pytest.raises(ValueError, match="concrete rank"):
+        sam_tp_builder._validate_sam_encoder_tp(_model_config(), parallel)
+
+
+def test_sam_plugin_routes_parallel_builds(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"sam-tp-plan"
+
+    monkeypatch.setattr(
+        sam_plugin_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(sam_tp_builder, "build_sam_tp_encoder_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1)
+    result = sam_plugin_module.SamPlugin().build_engine(
+        _model_config(), {"encoder.layer0.mlp.fc1.weight": np.zeros((32, 64))}, 7,
+        verbose=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"sam-tp-plan"
+    assert calls["require"][0] == parallel
+    assert "SAM encoder tensor-parallel" in calls["require"][1]
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 7
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["verbose"] is True
+
+
+def test_sam_plugin_rejects_parallel_quantization(monkeypatch):
+    monkeypatch.setattr(
+        sam_plugin_module,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="quantization"):
+        sam_plugin_module.SamPlugin().build_engine(
+            _model_config(), {}, 1,
+            quant_ctx=object(),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )

--- a/tests/e2e/models/sam-vit-base-tp4.json
+++ b/tests/e2e/models/sam-vit-base-tp4.json
@@ -1,0 +1,60 @@
+{
+  "name": "sam-vit-base-tp4",
+  "trace_id": "IT-E2E-SAM-TP4-01",
+  "hf_id": "facebook/sam-vit-base",
+  "bundle": "sam-vit-base-tp4.trtfb",
+  "family": "sam",
+  "runtime_strategy": "prompted_segmentation",
+  "test_type": "prompted_segmentation",
+  "max_cache_length": 1,
+  "prompt": "",
+  "max_new_tokens": 0,
+  "logit_atol": 0.5,
+  "trust_remote_code": false,
+  "test_image": "data/test_img.jpeg",
+  "point_x": 0.5,
+  "point_y": 0.5,
+  "num_expected_masks": 3,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "SAM ViT-base TP4 repro. Uses the same checkpoint, image, prompted segmentation comparator, logit tolerance, and mask-count threshold as sam-vit-base."
+}

--- a/tests/e2e_harness/runners/segmentation.py
+++ b/tests/e2e_harness/runners/segmentation.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -26,6 +27,30 @@ from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
 logger = logging.getLogger(__name__)
 
 PROJECT_DIR = Path(__file__).resolve().parents[3]
+
+
+def _distributed_runtime_config(case: E2ECase) -> dict:
+    config = case.metadata.get("distributed_runtime", {})
+    return config if isinstance(config, dict) and config.get("enabled") else {}
+
+
+def _wrap_distributed_command(cmd: list[str], case: E2ECase) -> list[str]:
+    config = _distributed_runtime_config(case)
+    if not config:
+        return cmd
+    launcher = str(config.get("launcher", "mpirun") or "mpirun")
+    world_size = int(config.get("world_size", config.get("tp_size", 2)) or 2)
+    launcher_args = config.get("launcher_args")
+    if isinstance(launcher_args, list):
+        return [launcher] + [str(arg) for arg in launcher_args] + cmd
+    return [launcher, "--tag-output", "-np", str(world_size)] + cmd
+
+
+def _strip_mpirun_tags(text: str) -> str:
+    lines = []
+    for line in text.splitlines():
+        lines.append(re.sub(r"^\[[^\]]+\]<std(?:out|err)>:\s?", "", line))
+    return "\n".join(lines)
 
 
 class SegmentationRunner:
@@ -88,16 +113,30 @@ class SegmentationRunner:
             )
 
         _model_dir = _case_artifact_dir(ctx.artifacts_dir or "/tmp/claude", case.name)
-        output_path = os.path.join(_model_dir, "seg_output.png")
+        distributed_runtime = _distributed_runtime_config(case)
+        output_root = os.path.join(_model_dir, "rank_outputs")
+        output_path = (
+            os.path.join(output_root, "rank_0", "seg_output.png")
+            if distributed_runtime else os.path.join(_model_dir, "seg_output.png")
+        )
 
         cmd = [
             str(ctx.binary_path), "segment", str(bundle_path),
             "--image", str(image_path),
-            "--output", str(output_path),
         ]
+        if distributed_runtime:
+            wrapper = (
+                'rank="${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${PMIX_RANK:-${RANK:-0}}}}"; '
+                'out="$1/rank_${rank}"; mkdir -p "$out"; shift; '
+                'exec "$@" --output "$out/seg_output.png"'
+            )
+            cmd = ["bash", "-lc", wrapper, "trtmc_rank_segment", output_root] + cmd
+        else:
+            cmd.extend(["--output", str(output_path)])
         runtime_cli_python = ctx.runtime_cli_hf_python()
         if runtime_cli_python:
             cmd.extend(["--hf-python", str(runtime_cli_python)])
+        cmd = _wrap_distributed_command(cmd, case)
 
         env = dict(os.environ)
         if ctx.ld_library_path:
@@ -133,7 +172,8 @@ class SegmentationRunner:
         seg_meta: dict = {
             "command": cmd,
             "returncode": result.returncode,
-            "stderr": stderr_truncated,
+            "stdout": _strip_mpirun_tags(result.stdout),
+            "stderr": _strip_mpirun_tags(stderr_truncated),
         }
         if stderr_log:
             seg_meta["stderr_log"] = stderr_log
@@ -216,23 +256,35 @@ class PromptedSegmentationRunner:
         is_foreground = case.inputs.get("is_foreground", True)
         num_expected_masks = case.inputs.get("num_expected_masks", 4)
 
-        output_dir = os.path.join(
-            _case_artifact_dir(ctx.artifacts_dir or "/tmp/claude", case.name),
-            "masks",
+        _model_dir = _case_artifact_dir(ctx.artifacts_dir or "/tmp/claude", case.name)
+        distributed_runtime = _distributed_runtime_config(case)
+        output_root = os.path.join(_model_dir, "rank_outputs")
+        output_dir = (
+            os.path.join(output_root, "rank_0", "masks")
+            if distributed_runtime else os.path.join(_model_dir, "masks")
         )
 
         cmd = [
             str(ctx.binary_path), "segment-sam", str(bundle_path),
             "--image", str(image_path),
-            "--output", str(output_dir),
             "--point-x", str(point_x),
             "--point-y", str(point_y),
         ]
         if not is_foreground:
             cmd.append("--background")
+        if distributed_runtime:
+            wrapper = (
+                'rank="${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${PMIX_RANK:-${RANK:-0}}}}"; '
+                'out="$1/rank_${rank}/masks"; mkdir -p "$out"; shift; '
+                'exec "$@" --output "$out"'
+            )
+            cmd = ["bash", "-lc", wrapper, "trtmc_rank_sam", output_root] + cmd
+        else:
+            cmd.extend(["--output", str(output_dir)])
         runtime_cli_python = ctx.runtime_cli_hf_python()
         if runtime_cli_python:
             cmd.extend(["--hf-python", str(runtime_cli_python)])
+        cmd = _wrap_distributed_command(cmd, case)
 
         env = dict(os.environ)
         if ctx.ld_library_path:
@@ -268,8 +320,8 @@ class PromptedSegmentationRunner:
         pseg_meta: dict = {
             "command": cmd,
             "returncode": result.returncode,
-            "stdout": result.stdout[-2000:] if result.stdout else "",
-            "stderr": stderr_truncated,
+            "stdout": _strip_mpirun_tags(result.stdout)[-2000:] if result.stdout else "",
+            "stderr": _strip_mpirun_tags(stderr_truncated),
         }
         if stderr_log:
             pseg_meta["stderr_log"] = stderr_log


### PR DESCRIPTION
## Background
SAM ViT-base did not have a multi-device E2E coverage path. The goal is to add TP4 support using the repo's existing pattern: keep the single-device builder intact, duplicate only the rank-local builder pieces that are specific to tensor parallelism, and keep the E2E thresholds aligned with the single-device manifest.

## Exit Criteria
- SAM ViT-base has a TP4 bundle manifest that uses the same checkpoint, prompted segmentation input, and comparison thresholds as `sam-vit-base`.
- The TP path builds and runs correctly on the B200 multi-GPU environment before opening the PR.
- The change stays limited to SAM TP build/runtime wiring and the shared segmentation runner support needed by the new manifest.

## Implementation
- Added `sam_tp_builder.py`, which duplicates the SAM image encoder builder and shards only the ViT MLP inner dimension: FC1 columns and FC2 rows are rank-local, then TensorRT distributed all-reduce restores the full residual. Attention, the neck, prompt encoding, and mask decoding remain replicated.
- Routed `SamPlugin.build_engine(..., parallel_config=...)` to the TP builder only when tensor parallel mode is enabled, with TensorRT 11 and quantization guards.
- Updated the segmentation runtime plugin to load `engine_plan_tp_rankN` sections and initialize the TensorRT distributed communicator when the bundle config requests tensor parallelism.
- Updated the segmentation E2E runner to launch distributed semantic and prompted segmentation runs with rank-local output directories, while comparisons read rank 0 outputs.
- Added `sam-vit-base-tp4.json` plus focused builder tests for SAM MLP slicing, validation, and plugin routing.

## Validation
- `PYTHONPATH=python:. python -m pytest -q tests/builder/test_engine_sam_tp.py tests/builder/test_manifest_validation.py`: passed, `31 passed in 0.14s`.
- `git diff --check`: passed.
- `cmake -S . -B build-sam-e2e -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so`: passed in `trtmc-dev-b200-trt11:latest`.
- `cmake --build build-sam-e2e --target trtmc trtmc_backend_trt -j`: passed.
- `python -m pip install --disable-pip-version-check --quiet ruff clang-format && ruff check --config ruff.toml python/tensorrt_model_connect/families/sam/plugin.py python/tensorrt_model_connect/families/sam/sam_tp_builder.py tests/e2e_harness/runners/segmentation.py tests/builder/test_engine_sam_tp.py && clang-format --dry-run --Werror src/runtime/models/segmentation/plugin.cpp`: passed.
- `PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py --multi-device-only -k "sam-vit-base-tp4" --trtmc-binary ./build-sam-e2e/trtmc --engine-dir /trtmc-storage/engines-sam-tp4 --e2e-artifacts-dir /trtmc-storage/e2e-sam-tp4 --hf-python /opt/venv/bin/python -s`: passed, `1 passed, 12 deselected in 135.56s`.

## Notes For Future Readers
- Review `sam_tp_builder.py` first, then the small `SamPlugin` route, then the runtime/runner wiring.
- This intentionally does not shard SAM attention or mask decoder. The TP boundary is limited to encoder MLPs so the output remains exact after all-reduce and the prompted segmentation comparator can reuse the single-device thresholds.
