### PR TITLE
feat(t5): add decoder tp4 support

### DIFF
--- a/python/tensorrt_model_connect/debug_runner.py
+++ b/python/tensorrt_model_connect/debug_runner.py
@@ -1756,12 +1756,14 @@ class Seq2SeqTrtRunner:
         max_source_positions: int,
         hidden_size: int | None = None,
         decoder_start_token_id: int = 2,
+        distributed_communicator: object | None = None,
     ):
         _require_trt_runtime()
         self.num_layers = num_layers
         self.max_cache_length = max_cache_length
         self.max_source_positions = max_source_positions
         self.decoder_start_token_id = decoder_start_token_id
+        self._distributed_communicator = distributed_communicator
 
         logger = trt.Logger(trt.Logger.WARNING)
         runtime = trt.Runtime(logger)
@@ -1771,6 +1773,15 @@ class Seq2SeqTrtRunner:
         if self.dec_engine is None:
             raise RuntimeError("Failed to deserialize seq2seq decoder TRT engine")
         self.dec_context = self.dec_engine.create_execution_context()
+        if distributed_communicator is not None:
+            set_communicator = getattr(self.dec_context, "set_communicator", None)
+            if set_communicator is None:
+                raise RuntimeError(
+                    "TensorRT distributed seq2seq debug execution requires "
+                    "IExecutionContext.set_communicator"
+                )
+            if not set_communicator(distributed_communicator):
+                raise RuntimeError("Failed to set TensorRT distributed communicator")
 
         # Encoder engine
         self.enc_engine = runtime.deserialize_cuda_engine(encoder_plan)
@@ -1781,6 +1792,10 @@ class Seq2SeqTrtRunner:
         # Auto-detect dimensions from decoder engine
         cache_shape = tuple(self.dec_engine.get_tensor_shape("cache_k_0"))
         self.attention_size = cache_shape[1]
+        self._decoder_has_encoder_mask = any(
+            self.dec_engine.get_tensor_name(i) == "encoder_mask"
+            for i in range(self.dec_engine.num_io_tensors)
+        )
         if hidden_size is None:
             cross_shape = tuple(self.dec_engine.get_tensor_shape("cross_k_0"))
             hidden_size = cross_shape[1]
@@ -1930,6 +1945,8 @@ class Seq2SeqTrtRunner:
             self.dec_context.set_tensor_address(f"present_v_{i}", self._d_present_v[i])
             self.dec_context.set_tensor_address(f"cross_k_{i}", self._d_cross_k[i])
             self.dec_context.set_tensor_address(f"cross_v_{i}", self._d_cross_v[i])
+        if self._decoder_has_encoder_mask:
+            self.dec_context.set_tensor_address("encoder_mask", self._d_enc_mask)
 
         self.dec_context.execute_async_v3(stream)
 
@@ -2238,11 +2255,6 @@ def runner_from_bundle(
     tri_cfg = config.get("triattention", {}) or {}
 
     if runtime_strategy in ("seq2seq_encoder_decoder", "text_to_text", "marian_translation"):
-        if distributed_communicator is not None or engine_section != "engine_plan":
-            raise ValueError(
-                "Distributed engine section selection is only supported for "
-                "single-engine decoder runners"
-            )
         encoder_plan, _ = load_vision_engine_from_bundle(bundle_path)
         if encoder_plan is not None:
             dec_layers = config.get("decoder_layers", num_layers)
@@ -2254,6 +2266,7 @@ def runner_from_bundle(
                 max_cache_length=header["max_cache_length"],
                 max_source_positions=header["max_cache_length"],
                 decoder_start_token_id=decoder_start,
+                distributed_communicator=distributed_communicator,
             )
 
     if runtime_strategy == "hybrid_mamba_attention":

--- a/python/tensorrt_model_connect/families/t5/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/t5/decoder_tp_builder.py
@@ -1,0 +1,388 @@
+"""Tensor-parallel T5 decoder builder.
+
+This mirrors the single-device decoder graph in ``plugin.py`` while applying
+tensor parallelism only to the decoder projections:
+
+* self-attention and cross-attention Q/K/V projections are column-sharded,
+* attention output and FFN output projections are row-sharded,
+* TensorRT distributed ALL_REDUCE restores full hidden states after row joins,
+* embeddings, norms, encoder outputs, and the LM head stay replicated.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+import sys
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+from .plugin import _make_t5_causal_buckets, _make_t5_cross_buckets, _mark_debug_output
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_t5_tp(weights: "WeightDict", parallel: "ParallelConfig") -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("T5 tensor-parallel decoder build requires a concrete rank")
+
+    tp = parallel.tp_size
+    num_heads = int(weights["_num_heads"])
+    attention_size = num_heads * int(weights["_d_kv"])
+    ffn_dim = int(weights["_d_ff"])
+    if num_heads % tp != 0:
+        raise ValueError(
+            "T5 tensor parallel requires num_heads divisible by tp_size "
+            f"({num_heads} vs {tp})")
+    if attention_size % tp != 0:
+        raise ValueError(
+            "T5 tensor parallel requires attention size divisible by tp_size "
+            f"({attention_size} vs {tp})")
+    if ffn_dim % tp != 0:
+        raise ValueError(
+            "T5 tensor parallel requires d_ff divisible by tp_size "
+            f"({ffn_dim} vs {tp})")
+
+    for layer_idx in range(int(weights["_dec_layers"])):
+        prefix = f"layer.{layer_idx}"
+        for key in (
+            f"{prefix}.w_q", f"{prefix}.w_k", f"{prefix}.w_v",
+            f"{prefix}.cross_w_q", f"{prefix}.cross_w_k",
+            f"{prefix}.cross_w_v", f"{prefix}.w_fc1",
+        ):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim is not divisible by tp_size={tp}")
+        for key in (f"{prefix}.w_o", f"{prefix}.cross_w_o", f"{prefix}.w_fc2"):
+            if weights[key].shape[0] % tp != 0:
+                raise ValueError(f"{key} input dim is not divisible by tp_size={tp}")
+
+
+def shard_t5_decoder_weights(
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local decoder weights for the T5 TP builder."""
+    if not parallel.enabled:
+        return weights
+
+    rank = parallel.rank
+    tp = parallel.tp_size
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+        if key.endswith((
+            ".w_q", ".w_k", ".w_v",
+            ".cross_w_q", ".cross_w_k", ".cross_w_v",
+            ".w_fc1",
+        )):
+            out[key] = _slice_last_dim(value, rank, tp)
+        elif key.endswith((".w_o", ".cross_w_o", ".w_fc2")):
+            out[key] = _slice_first_dim(value, rank, tp)
+        elif key in {"dec_self_rel_attn_bias", "dec_cross_rel_attn_bias"}:
+            out[key] = _slice_last_dim(value, rank, tp)
+        else:
+            out[key] = value
+
+    out["_tensor_parallel_size"] = tp
+    out["_tensor_parallel_rank"] = rank
+    return out
+
+
+def _add_t5_tp_decoder_layer(
+    *,
+    network,
+    hidden,
+    cache_k,
+    cache_v,
+    cross_k,
+    cross_v,
+    attention_mask,
+    position_id,
+    eps_tensor,
+    weights,
+    prefix: str,
+    hidden_size: int,
+    local_attention_size: int,
+    local_heads: int,
+    head_dim: int,
+    local_ffn_dim: int,
+    max_cache_length: int,
+    max_source_positions: int,
+    dec_self_rel_bias,
+    dec_cross_rel_bias,
+    num_buckets: int,
+    max_distance: int,
+    enc_mask=None,
+    tp_size: int = 1,
+):
+    attention_window = max_cache_length + 1
+
+    normed = graph_ops.add_rms_norm(
+        network, hidden, hidden_size, weights[f"{prefix}.input_norm"], eps_tensor)
+    q = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, local_attention_size, weights[f"{prefix}.w_q"])
+    k = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, local_attention_size, weights[f"{prefix}.w_k"])
+    v = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, local_attention_size, weights[f"{prefix}.w_v"])
+    present_k, present_v = k, v
+
+    kr = network.add_shuffle(k)
+    kr.reshape_dims = (1, local_attention_size)
+    vr = network.add_shuffle(v)
+    vr.reshape_dims = (1, local_attention_size)
+    ak = network.add_concatenation([cache_k, kr.get_output(0)])
+    ak.axis = 0
+    av = network.add_concatenation([cache_v, vr.get_output(0)])
+    av.axis = 0
+
+    if dec_self_rel_bias is not None:
+        bucket_indices = _make_t5_causal_buckets(
+            attention_window, num_buckets, max_distance)
+        bias = dec_self_rel_bias[bucket_indices.flatten()].reshape(
+            attention_window, attention_window, local_heads).transpose(2, 0, 1)
+        bias_const = graph_ops.add_constant(
+            network, bias.shape, bias.astype(np.float32))
+        bias_row = network.add_gather(bias_const, position_id, 1)
+        mask_3d = network.add_shuffle(attention_mask)
+        mask_3d.reshape_dims = (1, 1, attention_window)
+        self_mask_3d = network.add_elementwise(
+            bias_row.get_output(0), mask_3d.get_output(0),
+            trt.ElementWiseOperation.SUM)
+        self_mask_4d = network.add_shuffle(self_mask_3d.get_output(0))
+        self_mask_4d.reshape_dims = (1, local_heads, 1, attention_window)
+        self_mask = self_mask_4d.get_output(0)
+    else:
+        self_mask = graph_ops.add_2d_mask_to_4d(network, attention_mask)
+
+    context = graph_ops.add_attention_from_rows(
+        network, q, ak.get_output(0), av.get_output(0),
+        num_heads=local_heads, head_dim=head_dim,
+        q_seq=1, kv_seq=attention_window,
+        mask=self_mask,
+        scale=1.0)
+    sa = graph_ops.add_matmul_rhs_constant(
+        network, context, local_attention_size, hidden_size,
+        weights[f"{prefix}.w_o"])
+    sa = add_all_reduce_sum(network, sa, tp_size)
+    psa = network.add_elementwise(hidden, sa, trt.ElementWiseOperation.SUM).get_output(0)
+
+    cross_normed = graph_ops.add_rms_norm(
+        network, psa, hidden_size, weights[f"{prefix}.cross_attn_norm"], eps_tensor)
+    cross_q = graph_ops.add_matmul_rhs_constant(
+        network, cross_normed, hidden_size, local_attention_size,
+        weights[f"{prefix}.cross_w_q"])
+    cross_k_proj = graph_ops.add_matmul_rhs_constant(
+        network, cross_k, hidden_size, local_attention_size,
+        weights[f"{prefix}.cross_w_k"])
+    cross_v_proj = graph_ops.add_matmul_rhs_constant(
+        network, cross_v, hidden_size, local_attention_size,
+        weights[f"{prefix}.cross_w_v"])
+
+    if dec_cross_rel_bias is not None:
+        cross_buckets = _make_t5_cross_buckets(
+            attention_window, max_source_positions, num_buckets, max_distance)
+        cross_bias = dec_cross_rel_bias[cross_buckets.flatten()].reshape(
+            attention_window, max_source_positions, local_heads).transpose(2, 0, 1)
+        cross_bias_const = graph_ops.add_constant(
+            network, cross_bias.shape, cross_bias.astype(np.float32))
+        cross_bias_row = network.add_gather(cross_bias_const, position_id, 1)
+        cross_mask = cross_bias_row.get_output(0)
+        if enc_mask is not None:
+            cross_mask = network.add_elementwise(
+                cross_mask, enc_mask, trt.ElementWiseOperation.SUM).get_output(0)
+        cross_mask_4d = network.add_shuffle(cross_mask)
+        cross_mask_4d.reshape_dims = (1, local_heads, 1, max_source_positions)
+        cross_mask = cross_mask_4d.get_output(0)
+    elif enc_mask is not None:
+        cross_mask_4d = network.add_shuffle(enc_mask)
+        cross_mask_4d.reshape_dims = (1, 1, 1, max_source_positions)
+        cross_mask = cross_mask_4d.get_output(0)
+    else:
+        cross_mask = None
+
+    cross_context = graph_ops.add_attention_from_rows(
+        network, cross_q, cross_k_proj, cross_v_proj,
+        num_heads=local_heads, head_dim=head_dim,
+        q_seq=1, kv_seq=max_source_positions,
+        mask=cross_mask,
+        scale=1.0)
+    cross_out = graph_ops.add_matmul_rhs_constant(
+        network, cross_context, local_attention_size, hidden_size,
+        weights[f"{prefix}.cross_w_o"])
+    cross_out = add_all_reduce_sum(network, cross_out, tp_size)
+    pca = network.add_elementwise(
+        psa, cross_out, trt.ElementWiseOperation.SUM).get_output(0)
+
+    ffn_normed = graph_ops.add_rms_norm(
+        network, pca, hidden_size, weights[f"{prefix}.post_attn_norm"], eps_tensor)
+    fc1 = graph_ops.add_matmul_rhs_constant(
+        network, ffn_normed, hidden_size, local_ffn_dim, weights[f"{prefix}.w_fc1"])
+    relu = network.add_activation(fc1, trt.ActivationType.RELU)
+    fc2 = graph_ops.add_matmul_rhs_constant(
+        network, relu.get_output(0), local_ffn_dim, hidden_size,
+        weights[f"{prefix}.w_fc2"])
+    fc2 = add_all_reduce_sum(network, fc2, tp_size)
+    out = network.add_elementwise(pca, fc2, trt.ElementWiseOperation.SUM).get_output(0)
+    return {"hidden": out, "present_k": present_k, "present_v": present_v}
+
+
+def build_t5_tp_decoder_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build one rank-local T5 decoder with tensor-parallel projection joins."""
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_t5_tp_decoder_engine requires tensor_parallel mode with tp_size > 1")
+    _validate_t5_tp(weights, parallel)
+
+    rank_weights = shard_t5_decoder_weights(weights, parallel=parallel)
+    decoder_layers = int(weights["_dec_layers"])
+    num_heads = int(weights["_num_heads"])
+    head_dim = int(weights["_d_kv"])
+    ffn_dim = int(weights["_d_ff"])
+    hidden_size = int(weights["_hidden"])
+    vocab_size = int(weights["_vocab_size"])
+    num_buckets = int(weights["_num_buckets"])
+    max_distance = int(weights["_max_distance"])
+    eps = float(weights["_layer_norm_eps"])
+    attention_size = num_heads * head_dim
+    local_heads = num_heads // parallel.tp_size
+    local_attention_size = attention_size // parallel.tp_size
+    local_ffn_dim = ffn_dim // parallel.tp_size
+    attention_window = max_cache_length + 1
+    max_source_positions = max_cache_length
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    trt_config.clear_flag(trt.BuilderFlag.TF32)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    position_id = network.add_input("position_id", trt.int32, (1,))
+    attention_mask = network.add_input("attention_mask", trt.float32, (1, attention_window))
+    cache_k_inputs, cache_v_inputs = [], []
+    for layer_idx in range(decoder_layers):
+        cache_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_k", layer_idx),
+            trt.float32, (max_cache_length, local_attention_size)))
+        cache_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_v", layer_idx),
+            trt.float32, (max_cache_length, local_attention_size)))
+
+    cross_k_inputs, cross_v_inputs = [], []
+    for layer_idx in range(decoder_layers):
+        cross_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cross_k", layer_idx),
+            trt.float32, (max_source_positions, hidden_size)))
+        cross_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cross_v", layer_idx),
+            trt.float32, (max_source_positions, hidden_size)))
+
+    encoder_mask = network.add_input("encoder_mask", trt.float32, (max_source_positions,))
+    encoder_mask_3d = network.add_shuffle(encoder_mask)
+    encoder_mask_3d.reshape_dims = (1, 1, max_source_positions)
+    encoder_mask = encoder_mask_3d.get_output(0)
+
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+    embedding = graph_ops.add_constant(
+        network, (vocab_size, hidden_size), rank_weights["shared_embedding"])
+    hidden_state = network.add_gather(embedding, token_id, 0).get_output(0)
+    self_rel_bias = rank_weights.get("dec_self_rel_attn_bias")
+    cross_rel_bias = rank_weights.get("dec_cross_rel_attn_bias")
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    present_k_outputs, present_v_outputs = [], []
+    for layer_idx in range(decoder_layers):
+        prefix = f"layer.{layer_idx}"
+        result = _add_t5_tp_decoder_layer(
+            network=network,
+            hidden=hidden_state,
+            cache_k=cache_k_inputs[layer_idx],
+            cache_v=cache_v_inputs[layer_idx],
+            cross_k=cross_k_inputs[layer_idx],
+            cross_v=cross_v_inputs[layer_idx],
+            attention_mask=attention_mask,
+            position_id=position_id,
+            eps_tensor=eps_tensor,
+            weights=rank_weights,
+            prefix=prefix,
+            hidden_size=hidden_size,
+            local_attention_size=local_attention_size,
+            local_heads=local_heads,
+            head_dim=head_dim,
+            local_ffn_dim=local_ffn_dim,
+            max_cache_length=max_cache_length,
+            max_source_positions=max_source_positions,
+            dec_self_rel_bias=self_rel_bias,
+            dec_cross_rel_bias=cross_rel_bias,
+            num_buckets=num_buckets,
+            max_distance=max_distance,
+            enc_mask=encoder_mask,
+            tp_size=parallel.tp_size,
+        )
+        hidden_state = result["hidden"]
+        present_k_outputs.append(result["present_k"])
+        present_v_outputs.append(result["present_v"])
+        if debug_layer_outputs:
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    hidden_state = graph_ops.add_rms_norm(
+        network, hidden_state, hidden_size, rank_weights["final_norm"], eps_tensor)
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden_size, vocab_size, rank_weights["w_out"])
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for layer_idx in range(decoder_layers):
+        present_k_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_k", layer_idx)
+        present_v_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_v", layer_idx)
+        network.mark_output(present_k_outputs[layer_idx])
+        network.mark_output(present_v_outputs[layer_idx])
+
+    if verbose:
+        print(
+            "[trtmc build] T5 TP decoder "
+            f"(rank={parallel.rank}/{parallel.tp_size}, {decoder_layers}L, "
+            f"h={hidden_size}, local_heads={local_heads}, cache={max_cache_length})",
+            file=sys.stderr,
+        )
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT T5 TP decoder build failed")
+    return bytes(plan)

--- a/python/tensorrt_model_connect/families/t5/plugin.py
+++ b/python/tensorrt_model_connect/families/t5/plugin.py
@@ -7,6 +7,7 @@ import numpy as np
 from tensorrt_model_connect import trt_compat
 from ...checkpoint_mapper import WeightDict, _open_safetensors, _load_tensor, _has_tensor, _transpose_2d
 from ... import graph_ops
+from ...parallel_config import normalize_parallel_config, require_tensorrt_11_for_tensor_parallel
 
 trt = trt_compat.get_trt()
 
@@ -95,7 +96,22 @@ class T5Plugin:
             weights["w_out"] = _transpose_2d(shared_embed.copy(), "embedding_tied")
         return weights
 
-    def build_engine(self, config, weights, max_cache_length, *, verbose=False, debug_layer_outputs=False):
+    def build_engine(
+        self, config, weights, max_cache_length, *, verbose=False,
+        debug_layer_outputs=False, parallel_config=None,
+    ):
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="T5 tensor-parallel decoder builds")
+            from .decoder_tp_builder import build_t5_tp_decoder_engine
+            return build_t5_tp_decoder_engine(
+                config, weights, max_cache_length,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                parallel_config=parallel,
+            )
+
         weights['_max_cache_length'] = max_cache_length
         dl = weights["_dec_layers"]
         nh = weights["_num_heads"]

--- a/src/runtime/models/t5/plugin.cpp
+++ b/src/runtime/models/t5/plugin.cpp
@@ -9,6 +9,7 @@
 
 #include "runtime/plugins/shared/plugin_helpers.h"
 #include "trtmc/pipeline.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/kv_cache.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "trtmc/runtime/trt_module.h"
@@ -18,12 +19,48 @@
 #include <algorithm>
 #include <cstring>
 #include <cuda_runtime_api.h>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
+    if (dim < 0 || static_cast<std::size_t>(dim) >= shape.size())
+        return -1;
+    const auto value = shape[static_cast<std::size_t>(dim)];
+    if (value <= 0 || value > std::numeric_limits<int32_t>::max())
+        return -1;
+    return static_cast<int32_t>(value);
+}
+
+int32_t decoder_cache_row_width(const TrtModule& module, const BaseConfig& config) {
+    const int32_t from_engine = dim_at(module.tensor_shape("cache_k_0"), 1);
+    return from_engine > 0 ? from_engine : compute_kv_dim(config);
+}
+
+} // namespace
 
 // ---------------------------------------------------------------------------
 // T5Pipeline: encoder-decoder text generation
@@ -280,6 +317,10 @@ class T5Plugin final : public IPipelinePlugin {
         opts.cuda_graphs = ctx.cuda_graphs;
 
         const auto& json = ctx.config_json;
+        const auto tp_config = parse_tensor_parallel_runtime_config(json);
+        DistributedRuntimeGroup tp_group;
+        if (tp_config.enabled)
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
 
         // Load encoder (stored as vision_engine_plan in T5 bundles)
         const auto* enc_plan = find_section(ctx.bundle, "vision_engine_plan");
@@ -287,9 +328,17 @@ class T5Plugin final : public IPipelinePlugin {
             throw std::runtime_error("T5Plugin: no encoder engine in bundle");
         auto enc_loaded = load_trt_module_from_plan(ctx.backend, enc_plan, "t5 encoder", opts);
 
-        // Load decoder (main engine_plan)
+        ModuleCreateOptions decoder_opts = opts;
+        if (tp_config.enabled) {
+            decoder_opts.distributed_communicator = tp_group.communicator;
+            decoder_opts.distributed_owner = tp_group.owner;
+        }
+
+        // Load decoder (main engine_plan or rank-local TP section)
+        const std::string decoder_section =
+            tp_config.enabled ? tp_engine_section_name(tp_group.rank) : std::string("engine_plan");
         auto dec_loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "t5 decoder", opts);
+            ctx.backend, find_section(ctx.bundle, decoder_section), "t5 decoder", decoder_opts);
 
         // Config
         int32_t decoder_layers =
@@ -301,7 +350,7 @@ class T5Plugin final : public IPipelinePlugin {
 
         // Create KvCache for decoder self-attention
         cudaStream_t stream = dec_loaded.module->stream();
-        int32_t kv_dim = compute_kv_dim(ctx.config);
+        int32_t kv_dim = decoder_cache_row_width(*dec_loaded.module, ctx.config);
         auto cache = std::make_unique<KvCache>(dl, ctx.config.max_cache_length, kv_dim, stream);
         if (!cache->ok())
             throw std::runtime_error("T5Plugin: failed to create KvCache");

--- a/tests/builder/test_debug_runner.py
+++ b/tests/builder/test_debug_runner.py
@@ -248,6 +248,42 @@ class TestRunnerFromBundle:
         assert kwargs["engine_plan"] == b"RANK1_ENGINE"
         assert kwargs["distributed_communicator"] is communicator
 
+    def test_seq2seq_engine_section_and_communicator_forwarded(self, tmp_path):
+        from tensorrt_model_connect.debug_runner import runner_from_bundle
+
+        config_data = json.dumps({
+            "runtime_strategy": "text_to_text",
+            "decoder_layers": 2,
+            "decoder_start_token_id": 0,
+        }).encode("utf-8")
+        bundle = _make_bundle_bytes(
+            {"num_layers": 2, "max_cache_length": 128},
+            engine_plan=b"SINGLE_DECODER",
+            vision_plan=b"ENCODER_PLAN",
+            extra_sections={
+                "config.json": config_data,
+                "engine_plan_tp_rank1": b"RANK1_DECODER",
+            },
+        )
+
+        path = tmp_path / "seq2seq_tp_dispatch.trtfb"
+        path.write_bytes(bundle)
+
+        communicator = object()
+        with patch("tensorrt_model_connect.debug_runner.Seq2SeqTrtRunner",
+                   return_value="seq2seq-tp-runner") as mock_runner:
+            runner = runner_from_bundle(
+                str(path),
+                engine_section="engine_plan_tp_rank1",
+                distributed_communicator=communicator,
+            )
+
+        assert runner == "seq2seq-tp-runner"
+        kwargs = mock_runner.call_args.kwargs
+        assert kwargs["decoder_plan"] == b"RANK1_DECODER"
+        assert kwargs["encoder_plan"] == b"ENCODER_PLAN"
+        assert kwargs["distributed_communicator"] is communicator
+
     def test_mpi_rank_info_uses_single_node_rank(self, monkeypatch):
         from tensorrt_model_connect.debug_runner import _mpi_rank_info_from_env
 

--- a/tests/builder/test_engine_t5_tp.py
+++ b/tests/builder/test_engine_t5_tp.py
@@ -1,0 +1,108 @@
+"""Focused tests for T5 tensor-parallel decoder support."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+try:
+    t5_plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.t5.plugin")
+    from tensorrt_model_connect.families.t5 import decoder_tp_builder
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _weights(num_heads: int = 8, d_kv: int = 64, d_ff: int = 2048) -> dict:
+    hidden = num_heads * d_kv
+    weights: dict[str, object] = {
+        "_dec_layers": 1,
+        "_num_heads": num_heads,
+        "_d_kv": d_kv,
+        "_d_ff": d_ff,
+        "_hidden": hidden,
+        "_vocab_size": 128,
+        "_num_buckets": 32,
+        "_max_distance": 128,
+        "_layer_norm_eps": 1e-6,
+        "dec_self_rel_attn_bias": np.arange(32 * num_heads, dtype=np.float32).reshape(
+            32, num_heads),
+        "dec_cross_rel_attn_bias": np.arange(32 * num_heads, dtype=np.float32).reshape(
+            32, num_heads),
+    }
+    prefix = "layer.0"
+    attention = num_heads * d_kv
+    for key in ("w_q", "w_k", "w_v", "cross_w_q", "cross_w_k", "cross_w_v"):
+        weights[f"{prefix}.{key}"] = np.zeros((hidden, attention), dtype=np.float32)
+    for key in ("w_o", "cross_w_o"):
+        weights[f"{prefix}.{key}"] = np.zeros((attention, hidden), dtype=np.float32)
+    weights[f"{prefix}.w_fc1"] = np.zeros((hidden, d_ff), dtype=np.float32)
+    weights[f"{prefix}.w_fc2"] = np.zeros((d_ff, hidden), dtype=np.float32)
+    return weights
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(raw={}, hidden_size=512, vocab_size=128)
+
+
+def test_t5_tp_slices_projection_columns_rows_and_bias_heads():
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+    weights = _weights()
+    weights["layer.0.w_q"] = np.arange(512 * 512, dtype=np.float32).reshape(512, 512)
+    weights["layer.0.w_o"] = np.arange(512 * 512, dtype=np.float32).reshape(512, 512)
+
+    sharded = decoder_tp_builder.shard_t5_decoder_weights(
+        weights, parallel=parallel)
+
+    np.testing.assert_array_equal(sharded["layer.0.w_q"], weights["layer.0.w_q"][:, 256:384])
+    np.testing.assert_array_equal(sharded["layer.0.w_o"], weights["layer.0.w_o"][256:384, :])
+    np.testing.assert_array_equal(
+        sharded["dec_self_rel_attn_bias"], weights["dec_self_rel_attn_bias"][:, 4:6])
+
+
+def test_t5_tp_validation_rejects_non_divisible_heads():
+    with pytest.raises(ValueError, match="num_heads divisible"):
+        decoder_tp_builder._validate_t5_tp(
+            _weights(num_heads=6), ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0))
+
+
+def test_t5_tp_validation_requires_concrete_rank():
+    with pytest.raises(ValueError, match="concrete rank"):
+        decoder_tp_builder._validate_t5_tp(
+            _weights(), ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1))
+
+
+def test_t5_plugin_routes_parallel_builds(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"t5-tp-plan"
+
+    monkeypatch.setattr(
+        t5_plugin_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(decoder_tp_builder, "build_t5_tp_decoder_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1)
+    result = t5_plugin_module.T5Plugin().build_engine(
+        _config(), _weights(), 17,
+        verbose=True,
+        debug_layer_outputs=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"t5-tp-plan"
+    assert calls["require"][0] == parallel
+    assert "T5 tensor-parallel" in calls["require"][1]
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 17
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["verbose"] is True
+    assert kwargs["debug_layer_outputs"] is True

--- a/tests/e2e/models/t5-small-tp4.json
+++ b/tests/e2e/models/t5-small-tp4.json
@@ -1,0 +1,52 @@
+{
+  "name": "t5-small-tp4",
+  "hf_id": "google-t5/t5-small",
+  "bundle": "t5-small-tp4.trtfb",
+  "family": "t5",
+  "runtime_strategy": "text_to_text",
+  "max_cache_length": 256,
+  "prompt": "translate English to German: The house is wonderful.",
+  "max_new_tokens": 20,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "T5-small TP4 repro using the same checkpoint, prompt, and generation length as t5-small."
+}

--- a/tests/e2e_harness/runners/text_generation.py
+++ b/tests/e2e_harness/runners/text_generation.py
@@ -696,9 +696,10 @@ class TextGenerationCausalRunner:
 
                 # Run full generate (we always need prefill internally)
                 results = runner.generate(input_ids, max_new_tokens)
+                is_seq2seq = runner.__class__.__name__ == "Seq2SeqTrtRunner"
                 generated_tokens = []
                 if len(results) > 0 and max_new_tokens > 0:
-                    start = max(len(input_ids) - 1, 0)
+                    start = 0 if is_seq2seq else max(len(input_ids) - 1, 0)
                     for i in range(max_new_tokens):
                         idx = start + i
                         if idx >= len(results):


### PR DESCRIPTION
## Background
T5 needs the same tensor-parallel E2E coverage pattern as the other model families being added to the multi-device suite. The decoder can be sharded while the encoder remains single-copy, but the seq2seq debug runner also needs to support rank-local decoder sections when a distributed communicator is active.

## Exit Criteria
- Add a T5-small TP4 E2E manifest using the same checkpoint, prompt, generation length, and default correctness thresholds as the single-device case.
- Build rank-local T5 decoder engines from the existing single-device builder structure, changing only the tensor-parallel decoder pieces.
- Verify the TP4 E2E test passes before opening the PR.

## Implementation
- Added a T5 decoder TP builder that column-shards self-attention, cross-attention, and FFN input projections; row-shards output projections; and restores full hidden states with TensorRT distributed all-reduce.
- Kept embeddings, norms, encoder outputs, and the LM head replicated so the encoder path remains unchanged.
- Updated the T5 runtime to initialize tensor-parallel groups, load the rank-local decoder section, and size the KV cache from the rank-local engine.
- Updated the seq2seq debug runner and generated E2E script path so rank-local decoder sections work with a communicator and seq2seq generated-token comparisons use decoder-step results.
- Added focused builder and debug-runner dispatch tests.

## Validation
- `PYTHONPATH=python:. python -m pytest -q tests/builder/test_engine_t5_tp.py tests/builder/test_manifest_validation.py tests/builder/test_debug_runner.py`: passed, `53 passed in 0.23s`.
- `git diff --check`: passed.
- `python -m pip install --disable-pip-version-check --quiet ruff clang-format && ruff check --config ruff.toml python/tensorrt_model_connect/debug_runner.py python/tensorrt_model_connect/families/t5/plugin.py python/tensorrt_model_connect/families/t5/decoder_tp_builder.py tests/e2e_harness/runners/text_generation.py tests/builder/test_engine_t5_tp.py tests/builder/test_debug_runner.py && clang-format --dry-run --Werror src/runtime/models/t5/plugin.cpp`: passed.
- `cmake -S . -B build-t5-e2e -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so && cmake --build build-t5-e2e --target trtmc trtmc_backend_trt -j`: passed.
- `PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py --multi-device-only -k "t5-small-tp4" --trtmc-binary ./build-t5-e2e/trtmc --engine-dir /trtmc-storage/engines-t5-tp4-final --e2e-artifacts-dir /trtmc-storage/e2e-t5-tp4-final --hf-python /opt/venv/bin/python -s`: passed, `1 passed, 12 deselected in 102.68s`.

## Notes For Future Readers
- The TP4 manifest intentionally does not add relaxed threshold overrides; the E2E passes with the default criteria.
- Review the new decoder TP builder first, then the runtime/debug-runner changes that select rank-local decoder sections.
