### PR TITLE
feat(models): add Marian, Mamba, and Nemotron-H TP4 support

### DIFF
--- a/python/tensorrt_model_connect/debug_runner.py
+++ b/python/tensorrt_model_connect/debug_runner.py
@@ -781,9 +781,11 @@ class MambaTrtRunner:
         d_inner: int | None = None,
         state_size: int | None = None,
         conv_kernel: int | None = None,
+        distributed_communicator: object | None = None,
     ):
         _require_trt_runtime()
         self.num_layers = num_layers
+        self._distributed_communicator = distributed_communicator
 
         # Deserialize engine
         logger = trt.Logger(trt.Logger.WARNING)
@@ -792,6 +794,15 @@ class MambaTrtRunner:
         if self.engine is None:
             raise RuntimeError("Failed to deserialize TRT engine")
         self.context = self.engine.create_execution_context()
+        if distributed_communicator is not None:
+            set_communicator = getattr(self.context, "set_communicator", None)
+            if set_communicator is None:
+                raise RuntimeError(
+                    "TensorRT distributed Mamba debug execution requires "
+                    "IExecutionContext.set_communicator"
+                )
+            if not set_communicator(distributed_communicator):
+                raise RuntimeError("Failed to set TensorRT distributed communicator")
 
         # Auto-detect state dimensions
         if d_inner is None or conv_kernel is None:
@@ -2299,14 +2310,10 @@ def runner_from_bundle(
             num_attention_layers=num_attn,
         )
     if runtime_strategy == "ssm_recurrent":
-        if distributed_communicator is not None or engine_section != "engine_plan":
-            raise ValueError(
-                "Distributed engine section selection is only supported for "
-                "standard decoder runners"
-            )
         return MambaTrtRunner(
             engine_plan=engine_plan,
             num_layers=num_layers,
+            distributed_communicator=distributed_communicator,
         )
     if runtime_strategy == "rwkv_recurrent":
         return RwkvTrtRunner(

--- a/python/tensorrt_model_connect/debug_runner.py
+++ b/python/tensorrt_model_connect/debug_runner.py
@@ -1467,11 +1467,13 @@ class HybridTrtRunner:
         max_cache_length: int,
         num_mamba_layers: int,
         num_attention_layers: int,
+        distributed_communicator: object | None = None,
     ):
         _require_trt_runtime()
         self.max_cache_length = max_cache_length
         self.num_mamba_layers = num_mamba_layers
         self.num_attention_layers = num_attention_layers
+        self._distributed_communicator = distributed_communicator
 
         # Deserialize engine
         logger = trt.Logger(trt.Logger.WARNING)
@@ -1480,6 +1482,15 @@ class HybridTrtRunner:
         if self.engine is None:
             raise RuntimeError("Failed to deserialize TRT engine")
         self.context = self.engine.create_execution_context()
+        if distributed_communicator is not None:
+            set_communicator = getattr(self.context, "set_communicator", None)
+            if set_communicator is None:
+                raise RuntimeError(
+                    "TensorRT distributed execution requires TRT 11.0+ "
+                    "IExecutionContext.set_communicator"
+                )
+            if not set_communicator(distributed_communicator):
+                raise RuntimeError("Failed to set TRT distributed communicator")
 
         # Auto-detect state dimensions from engine tensor shapes
         if num_mamba_layers > 0:
@@ -2296,11 +2307,6 @@ def runner_from_bundle(
             )
 
     if runtime_strategy == "hybrid_mamba_attention":
-        if distributed_communicator is not None or engine_section != "engine_plan":
-            raise ValueError(
-                "Distributed engine section selection is only supported for "
-                "standard decoder runners"
-            )
         num_mamba = config.get("num_mamba_layers", 0)
         num_attn = config.get("num_attention_layers", 0)
         return HybridTrtRunner(
@@ -2308,6 +2314,7 @@ def runner_from_bundle(
             max_cache_length=header["max_cache_length"],
             num_mamba_layers=num_mamba,
             num_attention_layers=num_attn,
+            distributed_communicator=distributed_communicator,
         )
     if runtime_strategy == "ssm_recurrent":
         return MambaTrtRunner(

--- a/python/tensorrt_model_connect/families/mamba/plugin.py
+++ b/python/tensorrt_model_connect/families/mamba/plugin.py
@@ -46,6 +46,7 @@ from ...checkpoint_mapper import (
     _transpose_2d,
 )
 from ... import graph_ops
+from ...parallel_config import normalize_parallel_config, require_tensorrt_11_for_tensor_parallel
 
 
 trt = trt_compat.get_trt()
@@ -182,6 +183,7 @@ class MambaPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
         debug_layer_outputs: bool = False,
+        parallel_config=None,
     ) -> bytes:
         """Build TRT engine for Mamba SSM.
 
@@ -198,6 +200,20 @@ class MambaPlugin:
           present_conv_0..N: float32 [1, d_inner * conv_kernel]
           present_ssm_0..N: float32 [1, d_inner * state_size]
         """
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="Mamba tensor-parallel builds")
+            from .tp_builder import build_mamba_tp_engine
+            return build_mamba_tp_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                parallel_config=parallel,
+            )
+
         hidden = config.hidden_size
         vocab = config.vocab_size
         num_layers = config.num_hidden_layers

--- a/python/tensorrt_model_connect/families/mamba/tp_builder.py
+++ b/python/tensorrt_model_connect/families/mamba/tp_builder.py
@@ -1,0 +1,344 @@
+"""Tensor-parallel Mamba SSM builder.
+
+The TP policy shards Mamba's ``d_inner`` dimension. Per-rank engines keep local
+conv/SSM state, all-reduce input-dependent ``dt/B/C`` projections that need the
+full inner reduction, and all-reduce the row-parallel output projection back to
+full hidden size.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+from .plugin import _mark_debug_output
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_mamba_tp(weights: "WeightDict", parallel: "ParallelConfig") -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("Mamba tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    d_inner = int(weights["_d_inner"])
+    if d_inner % tp != 0:
+        raise ValueError(
+            "Mamba tensor parallel requires d_inner divisible by tp_size "
+            f"({d_inner} vs {tp})")
+
+    for layer_idx in range(int(weights.get("_num_layers", 0))):
+        prefix = f"layer.{layer_idx}"
+        for key in (
+            f"{prefix}.w_in_x", f"{prefix}.w_in_z", f"{prefix}.w_dt_out",
+            f"{prefix}.dt_proj_bias",
+        ):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim is not divisible by tp_size={tp}")
+        for key in (
+            f"{prefix}.conv1d_weight", f"{prefix}.conv1d_bias", f"{prefix}.w_dt_in",
+            f"{prefix}.w_B", f"{prefix}.w_C", f"{prefix}.A", f"{prefix}.D",
+            f"{prefix}.w_out",
+        ):
+            if weights[key].shape[0] % tp != 0:
+                raise ValueError(f"{key} input dim is not divisible by tp_size={tp}")
+
+
+def shard_mamba_weights(
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local Mamba weights for the TP builder."""
+    if not parallel.enabled:
+        return weights
+
+    rank = parallel.rank
+    tp = parallel.tp_size
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+        if key.endswith((".w_in_x", ".w_in_z", ".w_dt_out", ".dt_proj_bias")):
+            out[key] = _slice_last_dim(value, rank, tp)
+        elif key.endswith((
+            ".conv1d_weight", ".conv1d_bias", ".w_dt_in", ".w_B", ".w_C",
+            ".A", ".D", ".w_out",
+        )):
+            out[key] = _slice_first_dim(value, rank, tp)
+        else:
+            out[key] = value
+
+    out["_d_inner"] = int(weights["_d_inner"]) // tp
+    out["_tensor_parallel_size"] = tp
+    out["_tensor_parallel_rank"] = rank
+    return out
+
+
+def _add_mamba_tp_layer(
+    *,
+    network,
+    hidden,
+    conv_state_in,
+    ssm_state_in,
+    eps_tensor,
+    weights,
+    prefix: str,
+    hidden_size: int,
+    local_d_inner: int,
+    state_size: int,
+    conv_kernel: int,
+    dt_rank: int,
+    tp_size: int,
+):
+    normed = graph_ops.add_rms_norm(
+        network, hidden, hidden_size, weights[f"{prefix}.norm"], eps_tensor)
+
+    x = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, local_d_inner, weights[f"{prefix}.w_in_x"])
+    z = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, local_d_inner, weights[f"{prefix}.w_in_z"])
+
+    x_col = network.add_shuffle(x)
+    x_col.reshape_dims = (local_d_inner, 1)
+    if conv_kernel > 1:
+        slice_layer = network.add_slice(
+            conv_state_in,
+            start=(0, 1),
+            shape=(local_d_inner, conv_kernel - 1),
+            stride=(1, 1),
+        )
+        new_conv_state = network.add_concatenation(
+            [slice_layer.get_output(0), x_col.get_output(0)])
+        new_conv_state.axis = 1
+        present_conv = new_conv_state.get_output(0)
+    else:
+        present_conv = x_col.get_output(0)
+
+    conv_w = graph_ops.add_constant(
+        network, (local_d_inner, conv_kernel), weights[f"{prefix}.conv1d_weight"])
+    conv_prod = network.add_elementwise(
+        present_conv, conv_w, trt.ElementWiseOperation.PROD)
+    conv_sum = network.add_reduce(
+        conv_prod.get_output(0), trt.ReduceOperation.SUM, 1 << 1, keep_dims=True)
+    conv_flat = network.add_shuffle(conv_sum.get_output(0))
+    conv_flat.reshape_dims = (1, local_d_inner)
+    conv_out = graph_ops.add_bias_sum(
+        network, conv_flat.get_output(0), local_d_inner, weights[f"{prefix}.conv1d_bias"])
+    conv_activated = graph_ops.add_activation(network, conv_out, "silu")
+
+    dt_in = graph_ops.add_matmul_rhs_constant(
+        network, conv_activated, local_d_inner, dt_rank, weights[f"{prefix}.w_dt_in"])
+    dt_in = add_all_reduce_sum(network, dt_in, tp_size)
+    B = graph_ops.add_matmul_rhs_constant(
+        network, conv_activated, local_d_inner, state_size, weights[f"{prefix}.w_B"])
+    B = add_all_reduce_sum(network, B, tp_size)
+    C = graph_ops.add_matmul_rhs_constant(
+        network, conv_activated, local_d_inner, state_size, weights[f"{prefix}.w_C"])
+    C = add_all_reduce_sum(network, C, tp_size)
+
+    dt = graph_ops.add_matmul_rhs_constant(
+        network, dt_in, dt_rank, local_d_inner, weights[f"{prefix}.w_dt_out"])
+    dt = graph_ops.add_bias_sum(
+        network, dt, local_d_inner, weights[f"{prefix}.dt_proj_bias"])
+
+    dt_exp = network.add_unary(dt, trt.UnaryOperation.EXP)
+    one = graph_ops.add_constant(
+        network, (1, 1), np.array([1.0], dtype=np.float32))
+    dt_exp_p1 = network.add_elementwise(
+        dt_exp.get_output(0), one, trt.ElementWiseOperation.SUM)
+    dt_softplus = network.add_unary(
+        dt_exp_p1.get_output(0), trt.UnaryOperation.LOG)
+    dt_final = dt_softplus.get_output(0)
+
+    dt_col = network.add_shuffle(dt_final)
+    dt_col.reshape_dims = (local_d_inner, 1)
+    A_const = graph_ops.add_constant(
+        network, (local_d_inner, state_size), weights[f"{prefix}.A"])
+    dtA = network.add_elementwise(
+        dt_col.get_output(0), A_const, trt.ElementWiseOperation.PROD)
+    A_bar = network.add_unary(dtA.get_output(0), trt.UnaryOperation.EXP)
+
+    B_reshape = network.add_shuffle(B)
+    B_reshape.reshape_dims = (1, state_size)
+    dt_B = network.add_elementwise(
+        dt_col.get_output(0), B_reshape.get_output(0),
+        trt.ElementWiseOperation.PROD)
+
+    x_col2 = network.add_shuffle(conv_activated)
+    x_col2.reshape_dims = (local_d_inner, 1)
+    dtBx = network.add_elementwise(
+        dt_B.get_output(0), x_col2.get_output(0), trt.ElementWiseOperation.PROD)
+
+    decay = network.add_elementwise(
+        A_bar.get_output(0), ssm_state_in, trt.ElementWiseOperation.PROD)
+    new_ssm = network.add_elementwise(
+        decay.get_output(0), dtBx.get_output(0), trt.ElementWiseOperation.SUM)
+    present_ssm = new_ssm.get_output(0)
+
+    C_reshape = network.add_shuffle(C)
+    C_reshape.reshape_dims = (state_size, 1)
+    y_matmul = network.add_matrix_multiply(
+        present_ssm, trt.MatrixOperation.NONE,
+        C_reshape.get_output(0), trt.MatrixOperation.NONE)
+    y_flat = network.add_shuffle(y_matmul.get_output(0))
+    y_flat.reshape_dims = (1, local_d_inner)
+
+    D_const = graph_ops.add_constant(
+        network, (1, local_d_inner), weights[f"{prefix}.D"])
+    Dx = network.add_elementwise(
+        D_const, conv_activated, trt.ElementWiseOperation.PROD)
+    y = network.add_elementwise(
+        y_flat.get_output(0), Dx.get_output(0), trt.ElementWiseOperation.SUM)
+
+    z_activated = graph_ops.add_activation(network, z, "silu")
+    gated = network.add_elementwise(
+        y.get_output(0), z_activated, trt.ElementWiseOperation.PROD)
+
+    out = graph_ops.add_matmul_rhs_constant(
+        network, gated.get_output(0), local_d_inner, hidden_size, weights[f"{prefix}.w_out"])
+    out = add_all_reduce_sum(network, out, tp_size)
+    residual = network.add_elementwise(hidden, out, trt.ElementWiseOperation.SUM)
+
+    return {
+        "hidden": residual.get_output(0),
+        "present_conv": present_conv,
+        "present_ssm": present_ssm,
+    }
+
+
+def build_mamba_tp_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    parallel_config=None,
+) -> bytes:
+    del max_cache_length, precision, quant_ctx
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError("build_mamba_tp_engine requires tensor_parallel mode with tp_size > 1")
+
+    weights = type(weights)(weights)
+    weights["_num_layers"] = config.num_hidden_layers
+    _validate_mamba_tp(weights, parallel)
+    rank_weights = shard_mamba_weights(weights, parallel=parallel)
+
+    hidden = int(config.hidden_size)
+    vocab = int(config.vocab_size)
+    num_layers = int(config.num_hidden_layers)
+    local_d_inner = int(rank_weights["_d_inner"])
+    state_size = int(weights["_state_size"])
+    conv_kernel = int(weights["_conv_kernel"])
+    dt_rank = int(weights["_dt_rank"])
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    conv_state_inputs = []
+    ssm_state_inputs = []
+    for layer_idx in range(num_layers):
+        conv_state_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("conv_state", layer_idx),
+            trt.float32, (local_d_inner, conv_kernel)))
+        ssm_state_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("ssm_state", layer_idx),
+            trt.float32, (local_d_inner, state_size)))
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), rank_weights["embedding"])
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=np.float32))
+
+    hidden_state = network.add_gather(embedding_table, token_id, 0).get_output(0)
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    present_conv_outputs = []
+    present_ssm_outputs = []
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        result = _add_mamba_tp_layer(
+            network=network,
+            hidden=hidden_state,
+            conv_state_in=conv_state_inputs[layer_idx],
+            ssm_state_in=ssm_state_inputs[layer_idx],
+            eps_tensor=eps_tensor,
+            weights=rank_weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            local_d_inner=local_d_inner,
+            state_size=state_size,
+            conv_kernel=conv_kernel,
+            dt_rank=dt_rank,
+            tp_size=parallel.tp_size,
+        )
+        hidden_state = result["hidden"]
+        present_conv_outputs.append(result["present_conv"])
+        present_ssm_outputs.append(result["present_ssm"])
+        if debug_layer_outputs:
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    final_norm = rank_weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = graph_ops.add_rms_norm(
+            network, hidden_state, hidden, final_norm, eps_tensor)
+
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, vocab, rank_weights["w_lm_head"])
+    logits = graph_ops.add_bias_sum(
+        network, logits, vocab, np.zeros(vocab, dtype=np.float32))
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for layer_idx in range(num_layers):
+        present_conv_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_conv", layer_idx)
+        present_ssm_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_ssm", layer_idx)
+        network.mark_output(present_conv_outputs[layer_idx])
+        network.mark_output(present_ssm_outputs[layer_idx])
+
+    if verbose:
+        print(
+            "[trtmc build] Mamba TP engine "
+            f"(rank={parallel.rank}/{parallel.tp_size}, {num_layers}L, "
+            f"h={hidden}, local_d_inner={local_d_inner}, state={state_size})",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT Mamba TP engine build failed")
+    return bytes(plan)

--- a/python/tensorrt_model_connect/families/marian/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/marian/decoder_tp_builder.py
@@ -1,0 +1,409 @@
+"""Tensor-parallel Marian decoder builder.
+
+This duplicates the single-device Marian decoder graph and changes only the
+rank-local projection pieces:
+
+* self-attention and cross-attention Q/K/V projections are column-sharded,
+* attention output and FFN output projections are row-sharded,
+* row-parallel joins use TensorRT distributed ALL_REDUCE,
+* embeddings, norms, encoder outputs, and the LM head stay replicated.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+from .plugin import _mark_debug_output
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_marian_tp(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("Marian tensor-parallel decoder build requires a concrete rank")
+
+    tp = parallel.tp_size
+    hidden = int(config.hidden_size)
+    dec_heads = int(weights["_dec_heads"])
+    dec_ffn = int(weights["_dec_ffn"])
+    if hidden % tp != 0:
+        raise ValueError(
+            "Marian tensor parallel requires hidden size divisible by tp_size "
+            f"({hidden} vs {tp})")
+    if dec_heads % tp != 0:
+        raise ValueError(
+            "Marian tensor parallel requires decoder_attention_heads divisible by tp_size "
+            f"({dec_heads} vs {tp})")
+    if dec_ffn % tp != 0:
+        raise ValueError(
+            "Marian tensor parallel requires decoder_ffn_dim divisible by tp_size "
+            f"({dec_ffn} vs {tp})")
+
+    column_keys = (
+        ".w_q", ".w_k", ".w_v",
+        ".cross_w_q", ".cross_w_k", ".cross_w_v",
+        ".w_fc1",
+    )
+    column_biases = (
+        ".q_bias", ".k_bias", ".v_bias",
+        ".cross_b_q", ".cross_b_k", ".cross_b_v",
+        ".fc1_bias",
+    )
+    row_keys = (".w_o", ".cross_w_o", ".w_fc2")
+    for layer_idx in range(int(weights["_dec_layers"])):
+        prefix = f"layer.{layer_idx}"
+        for suffix in column_keys:
+            key = f"{prefix}{suffix}"
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim is not divisible by tp_size={tp}")
+        for suffix in column_biases:
+            key = f"{prefix}{suffix}"
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim is not divisible by tp_size={tp}")
+        for suffix in row_keys:
+            key = f"{prefix}{suffix}"
+            if weights[key].shape[0] % tp != 0:
+                raise ValueError(f"{key} input dim is not divisible by tp_size={tp}")
+
+
+def shard_marian_decoder_weights(
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local decoder weights for the Marian TP builder."""
+    if not parallel.enabled:
+        return weights
+
+    rank = parallel.rank
+    tp = parallel.tp_size
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+        if key.endswith((
+            ".w_q", ".w_k", ".w_v",
+            ".cross_w_q", ".cross_w_k", ".cross_w_v",
+            ".w_fc1",
+            ".q_bias", ".k_bias", ".v_bias",
+            ".cross_b_q", ".cross_b_k", ".cross_b_v",
+            ".fc1_bias",
+        )):
+            out[key] = _slice_last_dim(value, rank, tp)
+        elif key.endswith((".w_o", ".cross_w_o", ".w_fc2")):
+            out[key] = _slice_first_dim(value, rank, tp)
+        else:
+            out[key] = value
+
+    out["_tensor_parallel_size"] = tp
+    out["_tensor_parallel_rank"] = rank
+    return out
+
+
+def _add_row_parallel_bias(network, tensor, hidden_size: int, bias: np.ndarray, tp_size: int):
+    joined = add_all_reduce_sum(network, tensor, tp_size)
+    return graph_ops.add_bias_sum(network, joined, hidden_size, bias)
+
+
+def _add_marian_tp_decoder_layer(
+    *,
+    network,
+    hidden,
+    cache_k,
+    cache_v,
+    cross_k,
+    cross_v,
+    attention_mask,
+    encoder_mask,
+    eps,
+    weights,
+    prefix: str,
+    hidden_size: int,
+    local_attention_size: int,
+    local_heads: int,
+    head_dim: int,
+    local_ffn_dim: int,
+    max_cache_length: int,
+    max_enc_seq_len: int,
+    tp_size: int,
+):
+    attention_window = max_cache_length + 1
+
+    q = graph_ops.add_bias_sum(
+        network,
+        graph_ops.add_matmul_rhs_constant(
+            network, hidden, hidden_size, local_attention_size, weights[f"{prefix}.w_q"]),
+        local_attention_size,
+        weights[f"{prefix}.q_bias"],
+    )
+    k = graph_ops.add_bias_sum(
+        network,
+        graph_ops.add_matmul_rhs_constant(
+            network, hidden, hidden_size, local_attention_size, weights[f"{prefix}.w_k"]),
+        local_attention_size,
+        weights[f"{prefix}.k_bias"],
+    )
+    v = graph_ops.add_bias_sum(
+        network,
+        graph_ops.add_matmul_rhs_constant(
+            network, hidden, hidden_size, local_attention_size, weights[f"{prefix}.w_v"]),
+        local_attention_size,
+        weights[f"{prefix}.v_bias"],
+    )
+    present_k, present_v = k, v
+
+    kr = network.add_shuffle(k)
+    kr.reshape_dims = (1, local_attention_size)
+    vr = network.add_shuffle(v)
+    vr.reshape_dims = (1, local_attention_size)
+    ak = network.add_concatenation([cache_k, kr.get_output(0)])
+    ak.axis = 0
+    av = network.add_concatenation([cache_v, vr.get_output(0)])
+    av.axis = 0
+
+    m4 = network.add_shuffle(attention_mask)
+    m4.reshape_dims = (1, 1, 1, attention_window)
+    cf = graph_ops.add_attention_from_rows(
+        network, q, ak.get_output(0), av.get_output(0),
+        num_heads=local_heads, head_dim=head_dim,
+        q_seq=1, kv_seq=attention_window,
+        mask=m4.get_output(0))
+    sa = graph_ops.add_matmul_rhs_constant(
+        network, cf, local_attention_size, hidden_size, weights[f"{prefix}.w_o"])
+    sa = _add_row_parallel_bias(
+        network, sa, hidden_size, weights[f"{prefix}.o_bias"], tp_size)
+
+    psa = network.add_elementwise(hidden, sa, trt.ElementWiseOperation.SUM).get_output(0)
+    psa = graph_ops.add_layer_norm_native(
+        network, psa, hidden_size,
+        weights[f"{prefix}.input_norm"], weights[f"{prefix}.input_norm_beta"],
+        eps)
+
+    cq = graph_ops.add_bias_sum(
+        network,
+        graph_ops.add_matmul_rhs_constant(
+            network, psa, hidden_size, local_attention_size,
+            weights[f"{prefix}.cross_w_q"]),
+        local_attention_size,
+        weights[f"{prefix}.cross_b_q"],
+    )
+    ck_proj = graph_ops.add_bias_sum(
+        network,
+        graph_ops.add_matmul_rhs_constant(
+            network, cross_k, hidden_size, local_attention_size,
+            weights[f"{prefix}.cross_w_k"]),
+        local_attention_size,
+        weights[f"{prefix}.cross_b_k"],
+    )
+    cv_proj = graph_ops.add_bias_sum(
+        network,
+        graph_ops.add_matmul_rhs_constant(
+            network, cross_v, hidden_size, local_attention_size,
+            weights[f"{prefix}.cross_w_v"]),
+        local_attention_size,
+        weights[f"{prefix}.cross_b_v"],
+    )
+
+    enc_mask_4d = network.add_shuffle(encoder_mask)
+    enc_mask_4d.reshape_dims = (1, 1, 1, max_enc_seq_len)
+    ccf = graph_ops.add_attention_from_rows(
+        network, cq, ck_proj, cv_proj,
+        num_heads=local_heads, head_dim=head_dim,
+        q_seq=1, kv_seq=max_enc_seq_len,
+        mask=enc_mask_4d.get_output(0))
+    ca = graph_ops.add_matmul_rhs_constant(
+        network, ccf, local_attention_size, hidden_size, weights[f"{prefix}.cross_w_o"])
+    ca = _add_row_parallel_bias(
+        network, ca, hidden_size, weights[f"{prefix}.cross_b_o"], tp_size)
+
+    pca = network.add_elementwise(psa, ca, trt.ElementWiseOperation.SUM).get_output(0)
+    pca = graph_ops.add_layer_norm_native(
+        network, pca, hidden_size,
+        weights[f"{prefix}.cross_attn_norm"],
+        weights[f"{prefix}.cross_attn_norm_beta"], eps)
+
+    fc1 = graph_ops.add_bias_sum(
+        network,
+        graph_ops.add_matmul_rhs_constant(
+            network, pca, hidden_size, local_ffn_dim, weights[f"{prefix}.w_fc1"]),
+        local_ffn_dim,
+        weights[f"{prefix}.fc1_bias"],
+    )
+    act = graph_ops.add_activation(network, fc1, "silu")
+    fc2 = graph_ops.add_matmul_rhs_constant(
+        network, act, local_ffn_dim, hidden_size, weights[f"{prefix}.w_fc2"])
+    fc2 = _add_row_parallel_bias(
+        network, fc2, hidden_size, weights[f"{prefix}.fc2_bias"], tp_size)
+
+    out = network.add_elementwise(pca, fc2, trt.ElementWiseOperation.SUM).get_output(0)
+    out = graph_ops.add_layer_norm_native(
+        network, out, hidden_size,
+        weights[f"{prefix}.post_attn_norm"],
+        weights[f"{prefix}.post_attn_norm_beta"], eps)
+
+    return {"hidden": out, "present_k": present_k, "present_v": present_v}
+
+
+def build_marian_tp_decoder_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build one rank-local Marian decoder with tensor-parallel joins."""
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_marian_tp_decoder_engine requires tensor_parallel mode with tp_size > 1")
+    _validate_marian_tp(config, weights, parallel)
+
+    rank_weights = shard_marian_decoder_weights(weights, parallel=parallel)
+    dec_layers = int(weights["_dec_layers"])
+    dec_heads = int(weights["_dec_heads"])
+    dec_ffn = int(weights["_dec_ffn"])
+    max_pos = int(weights["_max_position_embeddings"])
+    hidden = int(config.hidden_size)
+    vocab = int(config.vocab_size)
+    head_dim = hidden // dec_heads
+    local_heads = dec_heads // parallel.tp_size
+    local_attention_size = hidden // parallel.tp_size
+    local_ffn_dim = dec_ffn // parallel.tp_size
+    attention_window = max_cache_length + 1
+    max_enc_seq_len = max_pos
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    trt_config.clear_flag(trt.BuilderFlag.TF32)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    position_id = network.add_input("position_id", trt.int32, (1,))
+    attention_mask = network.add_input("attention_mask", trt.float32, (attention_window,))
+
+    cache_k_inputs, cache_v_inputs = [], []
+    for layer_idx in range(dec_layers):
+        cache_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_k", layer_idx),
+            trt.float32, (max_cache_length, local_attention_size)))
+        cache_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_v", layer_idx),
+            trt.float32, (max_cache_length, local_attention_size)))
+
+    cross_k_inputs, cross_v_inputs = [], []
+    for layer_idx in range(dec_layers):
+        cross_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cross_k", layer_idx),
+            trt.float32, (max_enc_seq_len, hidden)))
+        cross_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cross_v", layer_idx),
+            trt.float32, (max_enc_seq_len, hidden)))
+
+    encoder_mask = network.add_input("encoder_mask", trt.float32, (max_enc_seq_len,))
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), rank_weights["dec_embedding"])
+    pos_embed_np = rank_weights["dec_pos_embedding"]
+    pos_embedding_table = graph_ops.add_constant(network, pos_embed_np.shape, pos_embed_np)
+
+    token_embed = network.add_gather(embedding_table, token_id, 0).get_output(0)
+    scale_val = np.sqrt(float(hidden))
+    scale_const = graph_ops.add_constant(
+        network, (1, 1), np.array([scale_val], dtype=np.float32))
+    token_embed = network.add_elementwise(
+        token_embed, scale_const, trt.ElementWiseOperation.PROD).get_output(0)
+    pos_embed = network.add_gather(pos_embedding_table, position_id, 0).get_output(0)
+    hidden_state = network.add_elementwise(
+        token_embed, pos_embed, trt.ElementWiseOperation.SUM).get_output(0)
+
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    present_k_outputs, present_v_outputs = [], []
+    for layer_idx in range(dec_layers):
+        prefix = f"layer.{layer_idx}"
+        result = _add_marian_tp_decoder_layer(
+            network=network,
+            hidden=hidden_state,
+            cache_k=cache_k_inputs[layer_idx],
+            cache_v=cache_v_inputs[layer_idx],
+            cross_k=cross_k_inputs[layer_idx],
+            cross_v=cross_v_inputs[layer_idx],
+            attention_mask=attention_mask,
+            encoder_mask=encoder_mask,
+            eps=config.rms_norm_eps,
+            weights=rank_weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            local_attention_size=local_attention_size,
+            local_heads=local_heads,
+            head_dim=head_dim,
+            local_ffn_dim=local_ffn_dim,
+            max_cache_length=max_cache_length,
+            max_enc_seq_len=max_enc_seq_len,
+            tp_size=parallel.tp_size,
+        )
+        hidden_state = result["hidden"]
+        present_k_outputs.append(result["present_k"])
+        present_v_outputs.append(result["present_v"])
+        if debug_layer_outputs:
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, vocab, rank_weights["w_out"])
+    logits = graph_ops.add_bias_sum(
+        network, logits, vocab, rank_weights["final_logits_bias"])
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for layer_idx in range(dec_layers):
+        present_k_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_k", layer_idx)
+        present_v_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_v", layer_idx)
+        network.mark_output(present_k_outputs[layer_idx])
+        network.mark_output(present_v_outputs[layer_idx])
+
+    if verbose:
+        print(
+            "[trtmc build] Marian TP decoder "
+            f"(rank={parallel.rank}/{parallel.tp_size}, {dec_layers}L, "
+            f"h={hidden}, local_heads={local_heads}, cache={max_cache_length})",
+            file=sys.stderr,
+        )
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT Marian TP decoder build failed")
+    return bytes(plan)

--- a/python/tensorrt_model_connect/families/marian/plugin.py
+++ b/python/tensorrt_model_connect/families/marian/plugin.py
@@ -39,6 +39,7 @@ from ...checkpoint_mapper import (
     _transpose_2d,
 )
 from ... import graph_ops
+from ...parallel_config import normalize_parallel_config, require_tensorrt_11_for_tensor_parallel
 
 
 trt = trt_compat.get_trt()
@@ -131,7 +132,20 @@ class MarianPlugin:
 
     def build_engine(self, config: ModelConfig, weights: WeightDict,
                      max_cache_length: int, *, verbose: bool = False,
-                     debug_layer_outputs: bool = False) -> bytes:
+                     debug_layer_outputs: bool = False,
+                     parallel_config=None) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="Marian tensor-parallel decoder builds")
+            from .decoder_tp_builder import build_marian_tp_decoder_engine
+            return build_marian_tp_decoder_engine(
+                config, weights, max_cache_length,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                parallel_config=parallel,
+            )
+
         dec_layers = weights["_dec_layers"]
         dec_heads = weights["_dec_heads"]
         dec_ffn = weights["_dec_ffn"]

--- a/python/tensorrt_model_connect/families/nemotron_h/plugin.py
+++ b/python/tensorrt_model_connect/families/nemotron_h/plugin.py
@@ -56,6 +56,10 @@ from ...checkpoint_mapper import (
 )
 from ... import graph_ops
 from ... import graph_blocks
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 
 
 trt = trt_compat.get_trt()
@@ -245,8 +249,24 @@ class NemotronHPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
         debug_layer_outputs: bool = False,
+        parallel_config=None,
     ) -> bytes:
         """Build hybrid TRT engine with heterogeneous layer stack."""
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="Nemotron-H tensor-parallel builds")
+            from .tp_builder import build_nemotron_h_tp_engine
+
+            return build_nemotron_h_tp_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                parallel_config=parallel,
+            )
+
         hidden = config.hidden_size
         vocab = config.vocab_size
         num_layers = config.num_hidden_layers

--- a/python/tensorrt_model_connect/families/nemotron_h/tp_builder.py
+++ b/python/tensorrt_model_connect/families/nemotron_h/tp_builder.py
@@ -1,0 +1,622 @@
+"""Tensor-parallel Nemotron-H hybrid builder."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_blocks, graph_ops
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+from .plugin import _mark_debug_output
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _take_last_dim_segments(arr: np.ndarray, segments: list[tuple[int, int]]) -> np.ndarray:
+    return np.ascontiguousarray(
+        np.concatenate([arr[..., start:end] for start, end in segments], axis=-1))
+
+
+def _take_first_dim_segments(arr: np.ndarray, segments: list[tuple[int, int]]) -> np.ndarray:
+    return np.ascontiguousarray(
+        np.concatenate([arr[start:end, ...] for start, end in segments], axis=0))
+
+
+def _mamba2_rank_dims(weights: "WeightDict", parallel: "ParallelConfig") -> dict[str, int]:
+    rank = parallel.rank
+    tp = parallel.tp_size
+    d_inner = int(weights["_d_inner"])
+    d_state = int(weights["_d_state"])
+    mamba_heads = int(weights["_mamba_num_heads"])
+    head_dim = int(weights["_mamba_head_dim"])
+    n_groups = int(weights["_n_groups"])
+    groups_state = n_groups * d_state
+    local_heads = mamba_heads // tp
+    local_groups = n_groups // tp
+    local_d_inner = local_heads * head_dim
+    local_groups_state = local_groups * d_state
+    local_conv_dim = local_d_inner + 2 * local_groups_state
+    return {
+        "rank": rank,
+        "tp": tp,
+        "d_inner": d_inner,
+        "d_state": d_state,
+        "mamba_heads": mamba_heads,
+        "head_dim": head_dim,
+        "n_groups": n_groups,
+        "groups_state": groups_state,
+        "local_heads": local_heads,
+        "local_groups": local_groups,
+        "local_d_inner": local_d_inner,
+        "local_groups_state": local_groups_state,
+        "local_conv_dim": local_conv_dim,
+        "inner_start": rank * local_d_inner,
+        "group_state_start": rank * local_groups_state,
+        "head_start": rank * local_heads,
+    }
+
+
+def _slice_mamba_in_proj(weight: np.ndarray, dims: dict[str, int]) -> np.ndarray:
+    d_inner = dims["d_inner"]
+    groups_state = dims["groups_state"]
+    conv_dim = int(d_inner + 2 * groups_state)
+    inner_start = dims["inner_start"]
+    local_d_inner = dims["local_d_inner"]
+    group_state_start = dims["group_state_start"]
+    local_groups_state = dims["local_groups_state"]
+    head_start = dims["head_start"]
+    local_heads = dims["local_heads"]
+    segments = [
+        (inner_start, inner_start + local_d_inner),
+        (d_inner + inner_start, d_inner + inner_start + local_d_inner),
+        (
+            d_inner + d_inner + group_state_start,
+            d_inner + d_inner + group_state_start + local_groups_state,
+        ),
+        (
+            d_inner + d_inner + groups_state + group_state_start,
+            d_inner + d_inner + groups_state + group_state_start + local_groups_state,
+        ),
+        (
+            d_inner + conv_dim + head_start,
+            d_inner + conv_dim + head_start + local_heads,
+        ),
+    ]
+    return _take_last_dim_segments(weight, segments)
+
+
+def _slice_conv_dim(value: np.ndarray, dims: dict[str, int]) -> np.ndarray:
+    d_inner = dims["d_inner"]
+    groups_state = dims["groups_state"]
+    inner_start = dims["inner_start"]
+    local_d_inner = dims["local_d_inner"]
+    group_state_start = dims["group_state_start"]
+    local_groups_state = dims["local_groups_state"]
+    segments = [
+        (inner_start, inner_start + local_d_inner),
+        (d_inner + group_state_start, d_inner + group_state_start + local_groups_state),
+        (
+            d_inner + groups_state + group_state_start,
+            d_inner + groups_state + group_state_start + local_groups_state,
+        ),
+    ]
+    return _take_first_dim_segments(value, segments)
+
+
+def _validate_nemotron_h_tp(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("Nemotron-H tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if int(config.num_attention_heads) % tp != 0:
+        raise ValueError(
+            "Nemotron-H tensor parallel requires num_attention_heads divisible by tp_size "
+            f"({config.num_attention_heads} vs {tp})")
+    if int(config.num_key_value_heads) % tp != 0:
+        raise ValueError(
+            "Nemotron-H tensor parallel requires num_key_value_heads divisible by tp_size "
+            f"({config.num_key_value_heads} vs {tp})")
+
+    for key in ("_d_inner", "_mamba_num_heads", "_n_groups", "_mlp_size"):
+        if int(weights[key]) % tp != 0:
+            raise ValueError(
+                f"Nemotron-H tensor parallel requires {key} divisible by tp_size "
+                f"({weights[key]} vs {tp})")
+
+
+def shard_nemotron_h_weights(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local Nemotron-H weights for the TP builder."""
+    _validate_nemotron_h_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    dims = _mamba2_rank_dims(weights, parallel)
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+        if key.endswith(".mamba_in_proj"):
+            out[key] = _slice_mamba_in_proj(value, dims)
+        elif key.endswith((".conv1d_weight", ".conv1d_bias")):
+            out[key] = _slice_conv_dim(value, dims)
+        elif key.endswith((".A", ".D", ".dt_bias")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".mamba_norm"):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".mamba_out_proj"):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".w_up"):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".w_down"):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_q", ".w_k", ".w_v")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".w_o"):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_d_inner"] = dims["local_d_inner"]
+    out["_conv_dim"] = dims["local_conv_dim"]
+    out["_mamba_num_heads"] = dims["local_heads"]
+    out["_n_groups"] = dims["local_groups"]
+    out["_attention_size"] = int(weights["_attention_size"]) // parallel.tp_size
+    out["_mlp_size"] = int(weights["_mlp_size"]) // parallel.tp_size
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def _add_mamba2_tp_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    conv_state_in: trt.ITensor,
+    ssm_state_in: trt.ITensor,
+    eps_tensor: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    d_inner: int,
+    d_state: int,
+    d_conv: int,
+    conv_dim: int,
+    mamba_num_heads: int,
+    mamba_head_dim: int,
+    n_groups: int,
+    tp_size: int,
+) -> dict[str, trt.ITensor]:
+    groups_state_size = n_groups * d_state
+
+    normed = graph_ops.add_rms_norm(
+        network, hidden, hidden_size, weights[f"{prefix}.input_norm"], eps_tensor)
+
+    proj_dim = d_inner + conv_dim + mamba_num_heads
+    projected = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, proj_dim, weights[f"{prefix}.mamba_in_proj"])
+
+    offset = 0
+    gate_slice = network.add_slice(
+        projected, start=(0, offset), shape=(1, d_inner), stride=(1, 1))
+    gate = gate_slice.get_output(0)
+    offset += d_inner
+
+    hbc_slice = network.add_slice(
+        projected, start=(0, offset), shape=(1, conv_dim), stride=(1, 1))
+    hidden_B_C = hbc_slice.get_output(0)
+    offset += conv_dim
+
+    dt_slice = network.add_slice(
+        projected, start=(0, offset), shape=(1, mamba_num_heads), stride=(1, 1))
+    dt_raw = dt_slice.get_output(0)
+
+    hbc_col = network.add_shuffle(hidden_B_C)
+    hbc_col.reshape_dims = (conv_dim, 1)
+    if d_conv > 1:
+        slice_layer = network.add_slice(
+            conv_state_in,
+            start=(0, 1),
+            shape=(conv_dim, d_conv - 1),
+            stride=(1, 1))
+        new_conv_state = network.add_concatenation(
+            [slice_layer.get_output(0), hbc_col.get_output(0)])
+        new_conv_state.axis = 1
+        present_conv = new_conv_state.get_output(0)
+    else:
+        present_conv = hbc_col.get_output(0)
+
+    conv_w = graph_ops.add_constant(
+        network, (conv_dim, d_conv), weights[f"{prefix}.conv1d_weight"])
+    conv_prod = network.add_elementwise(
+        present_conv, conv_w, trt.ElementWiseOperation.PROD)
+    conv_sum = network.add_reduce(
+        conv_prod.get_output(0), trt.ReduceOperation.SUM, 1 << 1, keep_dims=True)
+    conv_flat = network.add_shuffle(conv_sum.get_output(0))
+    conv_flat.reshape_dims = (1, conv_dim)
+    conv_out = graph_ops.add_bias_sum(
+        network, conv_flat.get_output(0), conv_dim, weights[f"{prefix}.conv1d_bias"])
+    hbc_activated = graph_ops.add_activation(network, conv_out, "silu")
+
+    hidden_x_slice = network.add_slice(
+        hbc_activated, start=(0, 0), shape=(1, d_inner), stride=(1, 1))
+    hidden_x = hidden_x_slice.get_output(0)
+    B_raw_slice = network.add_slice(
+        hbc_activated, start=(0, d_inner), shape=(1, groups_state_size), stride=(1, 1))
+    B_raw = B_raw_slice.get_output(0)
+    C_raw_slice = network.add_slice(
+        hbc_activated,
+        start=(0, d_inner + groups_state_size),
+        shape=(1, groups_state_size),
+        stride=(1, 1))
+    C_raw = C_raw_slice.get_output(0)
+
+    dt_bias_const = graph_ops.add_constant(
+        network, (1, mamba_num_heads), weights[f"{prefix}.dt_bias"])
+    dt_biased = network.add_elementwise(
+        dt_raw, dt_bias_const, trt.ElementWiseOperation.SUM)
+    dt_exp = network.add_unary(dt_biased.get_output(0), trt.UnaryOperation.EXP)
+    one = graph_ops.add_constant(
+        network, (1, 1), np.array([1.0], dtype=np.float32))
+    dt_exp_p1 = network.add_elementwise(
+        dt_exp.get_output(0), one, trt.ElementWiseOperation.SUM)
+    dt_softplus = network.add_unary(dt_exp_p1.get_output(0), trt.UnaryOperation.LOG)
+    dt = dt_softplus.get_output(0)
+
+    A_const = graph_ops.add_constant(
+        network, (mamba_num_heads, 1, 1),
+        weights[f"{prefix}.A"].reshape(mamba_num_heads, 1, 1))
+    dt_col = network.add_shuffle(dt)
+    dt_col.reshape_dims = (mamba_num_heads, 1, 1)
+    dtA = network.add_elementwise(
+        dt_col.get_output(0), A_const, trt.ElementWiseOperation.PROD)
+    dA = network.add_unary(dtA.get_output(0), trt.UnaryOperation.EXP)
+
+    B_grouped = network.add_shuffle(B_raw)
+    B_grouped.reshape_dims = (n_groups, d_state)
+    heads_per_group = mamba_num_heads // n_groups
+    if heads_per_group > 1:
+        B_3d = network.add_shuffle(B_grouped.get_output(0))
+        B_3d.reshape_dims = (n_groups, 1, d_state)
+        tile_ones = graph_ops.add_constant(
+            network, (1, heads_per_group, 1),
+            np.ones((1, heads_per_group, 1), dtype=np.float32))
+        B_tiled = network.add_elementwise(
+            B_3d.get_output(0), tile_ones, trt.ElementWiseOperation.PROD)
+        B_heads_s = network.add_shuffle(B_tiled.get_output(0))
+        B_heads_s.reshape_dims = (mamba_num_heads, d_state)
+        B_heads = B_heads_s.get_output(0)
+    else:
+        B_heads = B_grouped.get_output(0)
+
+    C_grouped = network.add_shuffle(C_raw)
+    C_grouped.reshape_dims = (n_groups, d_state)
+    if heads_per_group > 1:
+        C_3d = network.add_shuffle(C_grouped.get_output(0))
+        C_3d.reshape_dims = (n_groups, 1, d_state)
+        C_tiled = network.add_elementwise(
+            C_3d.get_output(0), tile_ones, trt.ElementWiseOperation.PROD)
+        C_heads_s = network.add_shuffle(C_tiled.get_output(0))
+        C_heads_s.reshape_dims = (mamba_num_heads, d_state)
+        C_heads = C_heads_s.get_output(0)
+    else:
+        C_heads = C_grouped.get_output(0)
+
+    x_heads = network.add_shuffle(hidden_x)
+    x_heads.reshape_dims = (mamba_num_heads, mamba_head_dim)
+    B_3d_expand = network.add_shuffle(B_heads)
+    B_3d_expand.reshape_dims = (mamba_num_heads, 1, d_state)
+    dt_B = network.add_elementwise(
+        dt_col.get_output(0), B_3d_expand.get_output(0), trt.ElementWiseOperation.PROD)
+    x_3d = network.add_shuffle(x_heads.get_output(0))
+    x_3d.reshape_dims = (mamba_num_heads, mamba_head_dim, 1)
+    dBx = network.add_elementwise(
+        x_3d.get_output(0), dt_B.get_output(0), trt.ElementWiseOperation.PROD)
+
+    decay = network.add_elementwise(
+        dA.get_output(0), ssm_state_in, trt.ElementWiseOperation.PROD)
+    new_ssm = network.add_elementwise(
+        decay.get_output(0), dBx.get_output(0), trt.ElementWiseOperation.SUM)
+    present_ssm = new_ssm.get_output(0)
+
+    C_col = network.add_shuffle(C_heads)
+    C_col.reshape_dims = (mamba_num_heads, d_state, 1)
+    y_matmul = network.add_matrix_multiply(
+        present_ssm, trt.MatrixOperation.NONE,
+        C_col.get_output(0), trt.MatrixOperation.NONE)
+    y_squeeze = network.add_shuffle(y_matmul.get_output(0))
+    y_squeeze.reshape_dims = (mamba_num_heads, mamba_head_dim)
+
+    D_const = graph_ops.add_constant(
+        network, (mamba_num_heads, 1),
+        weights[f"{prefix}.D"].reshape(mamba_num_heads, 1))
+    Dx = network.add_elementwise(
+        D_const, x_heads.get_output(0), trt.ElementWiseOperation.PROD)
+    y_plus_D = network.add_elementwise(
+        y_squeeze.get_output(0), Dx.get_output(0), trt.ElementWiseOperation.SUM)
+    y_flat = network.add_shuffle(y_plus_D.get_output(0))
+    y_flat.reshape_dims = (1, d_inner)
+
+    gate_activated = graph_ops.add_activation(network, gate, "silu")
+    y_gated = network.add_elementwise(
+        y_flat.get_output(0), gate_activated, trt.ElementWiseOperation.PROD)
+    group_size = d_inner // n_groups
+    y_grouped = network.add_shuffle(y_gated.get_output(0))
+    y_grouped.reshape_dims = (n_groups, group_size)
+
+    sq = network.add_elementwise(
+        y_grouped.get_output(0), y_grouped.get_output(0), trt.ElementWiseOperation.PROD)
+    mean = network.add_reduce(
+        sq.get_output(0), trt.ReduceOperation.AVG, 1 << 1, keep_dims=True)
+    eps_small = graph_ops.add_constant(
+        network, (1, 1), np.array([1e-5], dtype=np.float32))
+    denom_in = network.add_elementwise(
+        mean.get_output(0), eps_small, trt.ElementWiseOperation.SUM)
+    sqrt_l = network.add_unary(denom_in.get_output(0), trt.UnaryOperation.SQRT)
+    recip = network.add_unary(sqrt_l.get_output(0), trt.UnaryOperation.RECIP)
+    normalized = network.add_elementwise(
+        y_grouped.get_output(0), recip.get_output(0), trt.ElementWiseOperation.PROD)
+    y_flat_normed = network.add_shuffle(normalized.get_output(0))
+    y_flat_normed.reshape_dims = (1, d_inner)
+    gamma_t = graph_ops.add_constant(
+        network, (1, d_inner), weights[f"{prefix}.mamba_norm"])
+    gated = network.add_elementwise(
+        y_flat_normed.get_output(0), gamma_t, trt.ElementWiseOperation.PROD)
+
+    out = graph_ops.add_matmul_rhs_constant(
+        network, gated.get_output(0), d_inner, hidden_size,
+        weights[f"{prefix}.mamba_out_proj"])
+    out = add_all_reduce_sum(network, out, tp_size)
+    residual = network.add_elementwise(hidden, out, trt.ElementWiseOperation.SUM)
+
+    return {
+        "hidden": residual.get_output(0),
+        "present_conv": present_conv,
+        "present_ssm": present_ssm,
+    }
+
+
+def _add_mlp_tp_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    eps_tensor: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    mlp_size: int,
+    tp_size: int,
+) -> dict[str, trt.ITensor]:
+    normed = graph_ops.add_rms_norm(
+        network, hidden, hidden_size, weights[f"{prefix}.input_norm"], eps_tensor)
+    up = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, mlp_size, weights[f"{prefix}.w_up"])
+    activated = graph_ops.add_activation(network, up, "relu2")
+    down = graph_ops.add_matmul_rhs_constant(
+        network, activated, mlp_size, hidden_size, weights[f"{prefix}.w_down"])
+    down = add_all_reduce_sum(network, down, tp_size)
+    residual = network.add_elementwise(hidden, down, trt.ElementWiseOperation.SUM)
+    return {"hidden": residual.get_output(0)}
+
+
+def build_nemotron_h_tp_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    parallel_config=None,
+) -> bytes:
+    del precision, quant_ctx
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_nemotron_h_tp_engine requires tensor_parallel mode with tp_size > 1")
+
+    rank_weights = shard_nemotron_h_weights(config, weights, parallel=parallel)
+    hidden = int(config.hidden_size)
+    vocab = int(config.vocab_size)
+    num_layers = int(config.num_hidden_layers)
+    layer_types: list[str] = rank_weights["_layer_types"]
+
+    d_inner = int(rank_weights["_d_inner"])
+    d_state = int(rank_weights["_d_state"])
+    d_conv = int(rank_weights["_d_conv"])
+    conv_dim = int(rank_weights["_conv_dim"])
+    mamba_num_heads = int(rank_weights["_mamba_num_heads"])
+    mamba_head_dim = int(rank_weights["_mamba_head_dim"])
+    n_groups = int(rank_weights["_n_groups"])
+    num_mamba = int(rank_weights["_num_mamba_layers"])
+    num_attn = int(rank_weights["_num_attention_layers"])
+    attention_size = int(rank_weights["_attention_size"])
+    mlp_size = int(rank_weights["_mlp_size"])
+
+    num_heads = int(config.num_attention_heads) // parallel.tp_size
+    num_kv_heads = int(config.num_key_value_heads) // parallel.tp_size
+    head_dim = int(config.head_dim)
+    kv_attention_size = num_kv_heads * head_dim
+    attention_window = max_cache_length + 1
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    position_id = network.add_input("position_id", trt.int32, (1,))
+    attention_mask = network.add_input(
+        "attention_mask", trt.float32, (1, attention_window))
+
+    conv_state_inputs = []
+    ssm_state_inputs = []
+    for mi in range(num_mamba):
+        conv_state_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("conv_state", mi),
+            trt.float32, (conv_dim, d_conv)))
+        ssm_state_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("ssm_state", mi),
+            trt.float32, (mamba_num_heads, mamba_head_dim, d_state)))
+
+    cache_k_inputs = []
+    cache_v_inputs = []
+    for ai in range(num_attn):
+        cache_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_k", ai),
+            trt.float32, (max_cache_length, kv_attention_size)))
+        cache_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_v", ai),
+            trt.float32, (max_cache_length, kv_attention_size)))
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), rank_weights["embedding"])
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=np.float32))
+
+    hidden_state = network.add_gather(embedding_table, token_id, 0).get_output(0)
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    present_conv_outputs = []
+    present_ssm_outputs = []
+    present_k_outputs = []
+    present_v_outputs = []
+    mamba_counter = 0
+    attn_counter = 0
+
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        lt = layer_types[layer_idx]
+        if lt == "mamba2":
+            result = _add_mamba2_tp_layer(
+                network=network,
+                hidden=hidden_state,
+                conv_state_in=conv_state_inputs[mamba_counter],
+                ssm_state_in=ssm_state_inputs[mamba_counter],
+                eps_tensor=eps_tensor,
+                weights=rank_weights,
+                prefix=prefix,
+                hidden_size=hidden,
+                d_inner=d_inner,
+                d_state=d_state,
+                d_conv=d_conv,
+                conv_dim=conv_dim,
+                mamba_num_heads=mamba_num_heads,
+                mamba_head_dim=mamba_head_dim,
+                n_groups=n_groups,
+                tp_size=parallel.tp_size,
+            )
+            hidden_state = result["hidden"]
+            present_conv_outputs.append(result["present_conv"])
+            present_ssm_outputs.append(result["present_ssm"])
+            mamba_counter += 1
+        elif lt == "mlp":
+            result = _add_mlp_tp_layer(
+                network=network,
+                hidden=hidden_state,
+                eps_tensor=eps_tensor,
+                weights=rank_weights,
+                prefix=prefix,
+                hidden_size=hidden,
+                mlp_size=mlp_size,
+                tp_size=parallel.tp_size,
+            )
+            hidden_state = result["hidden"]
+        elif lt == "attention":
+            result = graph_blocks.add_attention_block(
+                network, hidden_state,
+                cache_k_inputs[attn_counter],
+                cache_v_inputs[attn_counter],
+                attention_mask, position_id,
+                weights=rank_weights,
+                prefix=prefix,
+                hidden_size=hidden,
+                attention_size=attention_size,
+                kv_attention_size=kv_attention_size,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                max_cache_length=max_cache_length,
+                eps_tensor=eps_tensor,
+                position_type="none",
+            )
+            attn_out = add_all_reduce_sum(network, result["attn_out"], parallel.tp_size)
+            residual = network.add_elementwise(
+                hidden_state, attn_out, trt.ElementWiseOperation.SUM)
+            hidden_state = residual.get_output(0)
+            present_k_outputs.append(result["present_k"])
+            present_v_outputs.append(result["present_v"])
+            attn_counter += 1
+
+        if debug_layer_outputs:
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    final_norm = rank_weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = graph_ops.add_rms_norm(
+            network, hidden_state, hidden, final_norm, eps_tensor)
+
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, vocab, rank_weights["w_lm_head"])
+    logits = graph_ops.add_bias_sum(
+        network, logits, vocab, np.zeros(vocab, dtype=np.float32))
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for mi in range(num_mamba):
+        present_conv_outputs[mi].name = graph_ops.layer_tensor_name("present_conv", mi)
+        present_ssm_outputs[mi].name = graph_ops.layer_tensor_name("present_ssm", mi)
+        network.mark_output(present_conv_outputs[mi])
+        network.mark_output(present_ssm_outputs[mi])
+
+    for ai in range(num_attn):
+        present_k_outputs[ai].name = graph_ops.layer_tensor_name("present_k", ai)
+        present_v_outputs[ai].name = graph_ops.layer_tensor_name("present_v", ai)
+        network.mark_output(present_k_outputs[ai])
+        network.mark_output(present_v_outputs[ai])
+
+    if verbose:
+        print(
+            "[trtmc build] Nemotron-H TP engine "
+            f"(rank={parallel.rank}/{parallel.tp_size}, {num_layers}L, "
+            f"local_mamba_heads={mamba_num_heads}, local_attn_heads={num_heads}, "
+            f"local_mlp={mlp_size})",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT Nemotron-H TP engine build failed")
+    return bytes(plan)

--- a/src/runtime/models/marian/plugin.cpp
+++ b/src/runtime/models/marian/plugin.cpp
@@ -9,6 +9,7 @@
 
 #include "runtime/plugins/shared/plugin_helpers.h"
 #include "trtmc/pipeline.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/kv_cache.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "trtmc/runtime/trt_module.h"
@@ -19,12 +20,48 @@
 #include <cstring>
 #include <cuda_runtime_api.h>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
+    if (dim < 0 || static_cast<std::size_t>(dim) >= shape.size())
+        return -1;
+    const auto value = shape[static_cast<std::size_t>(dim)];
+    if (value <= 0 || value > std::numeric_limits<int32_t>::max())
+        return -1;
+    return static_cast<int32_t>(value);
+}
+
+int32_t decoder_cache_row_width(const TrtModule& module, const BaseConfig& config) {
+    const int32_t from_engine = dim_at(module.tensor_shape("cache_k_0"), 1);
+    return from_engine > 0 ? from_engine : compute_kv_dim(config);
+}
+
+} // namespace
 
 // ---------------------------------------------------------------------------
 // MarianPipeline: encoder-decoder machine translation
@@ -260,14 +297,26 @@ class MarianPlugin final : public IPipelinePlugin {
         opts.cuda_graphs = ctx.cuda_graphs;
 
         const auto& json = ctx.config_json;
+        const auto tp_config = parse_tensor_parallel_runtime_config(json);
+        DistributedRuntimeGroup tp_group;
+        if (tp_config.enabled)
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
 
         const auto* enc_plan = find_section(ctx.bundle, "vision_engine_plan");
         if (!enc_plan || enc_plan->empty())
             throw std::runtime_error("MarianPlugin: no encoder engine in bundle");
         auto enc_loaded = load_trt_module_from_plan(ctx.backend, enc_plan, "marian encoder", opts);
 
+        ModuleCreateOptions decoder_opts = opts;
+        if (tp_config.enabled) {
+            decoder_opts.distributed_communicator = tp_group.communicator;
+            decoder_opts.distributed_owner = tp_group.owner;
+        }
+
+        const std::string decoder_section =
+            tp_config.enabled ? tp_engine_section_name(tp_group.rank) : std::string("engine_plan");
         auto dec_loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "marian decoder", opts);
+            ctx.backend, find_section(ctx.bundle, decoder_section), "marian decoder", decoder_opts);
 
         int32_t decoder_layers =
             extract_json_int(json, "decoder_layers",
@@ -280,7 +329,7 @@ class MarianPlugin final : public IPipelinePlugin {
         int32_t pad_token_id = extract_json_int(json, "pad_token_id", eos_token_id);
 
         cudaStream_t stream = dec_loaded.module->stream();
-        int32_t kv_dim = compute_kv_dim(ctx.config);
+        int32_t kv_dim = decoder_cache_row_width(*dec_loaded.module, ctx.config);
         auto cache = std::make_unique<KvCache>(dl, ctx.config.max_cache_length, kv_dim, stream);
         if (!cache->ok())
             throw std::runtime_error("MarianPlugin: failed to create KvCache");

--- a/src/runtime/models/recurrent/hybrid_plugin.cpp
+++ b/src/runtime/models/recurrent/hybrid_plugin.cpp
@@ -4,25 +4,66 @@
 
 #include "runtime/models/recurrent/pipeline.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/hybrid_state.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
 
 #include <algorithm>
+#include <cstdint>
+#include <string>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+struct TensorParallelRuntime {
+    TensorParallelRuntimeConfig config;
+    DistributedRuntimeGroup group;
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+} // namespace
 
 class HybridPlugin final : public IPipelinePlugin {
   public:
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
         load_ffi_kernels_from_bundle(ctx.bundle);
 
+        TensorParallelRuntime tp_runtime;
+        tp_runtime.config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        if (tp_runtime.config.enabled)
+            tp_runtime.group = initialize_tensor_parallel_group(tp_runtime.config.tp_size);
+
         ModuleCreateOptions opts;
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
+        if (tp_runtime.config.enabled) {
+            opts.distributed_communicator = tp_runtime.group.communicator;
+            opts.distributed_owner = tp_runtime.group.owner;
+        }
 
+        const std::string engine_section = tp_runtime.config.enabled
+                                               ? tp_engine_section_name(tp_runtime.group.rank)
+                                               : std::string("engine_plan");
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "engine_plan", opts);
+            ctx.backend, find_section(ctx.bundle, engine_section), engine_section.c_str(), opts);
         auto tokenizer = create_tokenizer_from_bundle(ctx.bundle);
 
         cudaStream_t stream = loaded.module->stream();

--- a/src/runtime/models/recurrent/ssm_plugin.cpp
+++ b/src/runtime/models/recurrent/ssm_plugin.cpp
@@ -3,10 +3,48 @@
 
 #include "runtime/models/recurrent/pipeline.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
 
+#include <limits>
+
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+int32_t positive_numel(const std::vector<int64_t>& shape, int32_t fallback) {
+    if (shape.empty())
+        return fallback;
+    int64_t numel = 1;
+    for (const auto dim : shape) {
+        if (dim <= 0)
+            return fallback;
+        if (numel > std::numeric_limits<int32_t>::max() / dim)
+            return fallback;
+        numel *= dim;
+    }
+    return static_cast<int32_t>(numel);
+}
+
+} // namespace
 
 class SsmPlugin final : public IPipelinePlugin {
   public:
@@ -17,8 +55,20 @@ class SsmPlugin final : public IPipelinePlugin {
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        if (tp_config.enabled)
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+
+        if (tp_config.enabled) {
+            opts.distributed_communicator = tp_group.communicator;
+            opts.distributed_owner = tp_group.owner;
+        }
+
+        const std::string engine_section =
+            tp_config.enabled ? tp_engine_section_name(tp_group.rank) : std::string("engine_plan");
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "engine_plan", opts);
+            ctx.backend, find_section(ctx.bundle, engine_section), "engine_plan", opts);
         auto tokenizer = create_tokenizer_from_bundle(ctx.bundle);
 
         cudaStream_t stream = loaded.module->stream();
@@ -28,10 +78,14 @@ class SsmPlugin final : public IPipelinePlugin {
             d_inner = extract_json_int(ctx.config_json, "d_inner", ctx.config.hidden_size * 2);
         int32_t state_size = extract_json_int(ctx.config_json, "state_size", 16);
         int32_t conv_kernel = extract_json_int(ctx.config_json, "conv_kernel", 4);
+        const int32_t conv_numel =
+            positive_numel(loaded.module->tensor_shape("conv_state_0"), d_inner * conv_kernel);
+        const int32_t ssm_numel =
+            positive_numel(loaded.module->tensor_shape("ssm_state_0"), state_size * d_inner);
 
         std::vector<RecurrentState::TensorSpec> specs = {
-            {"conv_state", {d_inner * conv_kernel}, "present_conv"},
-            {"ssm_state", {state_size * d_inner}, "present_ssm"}};
+            {"conv_state", {conv_numel}, "present_conv"},
+            {"ssm_state", {ssm_numel}, "present_ssm"}};
 
         auto state = std::make_unique<RecurrentState>(ctx.config.num_layers, specs, stream);
         auto rgc = make_recurrent_gen_config(ctx.config);

--- a/tests/builder/test_debug_runner.py
+++ b/tests/builder/test_debug_runner.py
@@ -278,6 +278,40 @@ class TestRunnerFromBundle:
         assert kwargs["engine_plan"] == b"RWKV_RANK1_ENGINE"
         assert kwargs["distributed_communicator"] is communicator
 
+    def test_hybrid_engine_section_and_communicator_forwarded(self, tmp_path):
+        from tensorrt_model_connect.debug_runner import runner_from_bundle
+
+        config_data = json.dumps({
+            "runtime_strategy": "hybrid_mamba_attention",
+            "num_mamba_layers": 1,
+            "num_attention_layers": 1,
+        }).encode("utf-8")
+        bundle = _make_bundle_bytes(
+            {"num_layers": 2, "max_cache_length": 128},
+            engine_plan=b"SINGLE_ENGINE",
+            extra_sections={
+                "config.json": config_data,
+                "engine_plan_tp_rank1": b"HYBRID_RANK1_ENGINE",
+            },
+        )
+
+        path = tmp_path / "hybrid_tp_dispatch.trtfb"
+        path.write_bytes(bundle)
+
+        communicator = object()
+        with patch("tensorrt_model_connect.debug_runner.HybridTrtRunner",
+                   return_value="hybrid-tp-runner") as mock_runner:
+            runner = runner_from_bundle(
+                str(path),
+                engine_section="engine_plan_tp_rank1",
+                distributed_communicator=communicator,
+            )
+
+        assert runner == "hybrid-tp-runner"
+        kwargs = mock_runner.call_args.kwargs
+        assert kwargs["engine_plan"] == b"HYBRID_RANK1_ENGINE"
+        assert kwargs["distributed_communicator"] is communicator
+
     def test_mamba_engine_section_and_communicator_forwarded(self, tmp_path):
         from tensorrt_model_connect.debug_runner import runner_from_bundle
 

--- a/tests/builder/test_debug_runner.py
+++ b/tests/builder/test_debug_runner.py
@@ -278,6 +278,36 @@ class TestRunnerFromBundle:
         assert kwargs["engine_plan"] == b"RWKV_RANK1_ENGINE"
         assert kwargs["distributed_communicator"] is communicator
 
+    def test_mamba_engine_section_and_communicator_forwarded(self, tmp_path):
+        from tensorrt_model_connect.debug_runner import runner_from_bundle
+
+        config_data = json.dumps({"runtime_strategy": "ssm_recurrent"}).encode("utf-8")
+        bundle = _make_bundle_bytes(
+            {"num_layers": 2, "max_cache_length": 128},
+            engine_plan=b"SINGLE_ENGINE",
+            extra_sections={
+                "config.json": config_data,
+                "engine_plan_tp_rank1": b"RANK1_ENGINE",
+            },
+        )
+
+        path = tmp_path / "mamba_tp_dispatch.trtfb"
+        path.write_bytes(bundle)
+
+        communicator = object()
+        with patch("tensorrt_model_connect.debug_runner.MambaTrtRunner",
+                   return_value="mamba-tp-runner") as mock_runner:
+            runner = runner_from_bundle(
+                str(path),
+                engine_section="engine_plan_tp_rank1",
+                distributed_communicator=communicator,
+            )
+
+        assert runner == "mamba-tp-runner"
+        kwargs = mock_runner.call_args.kwargs
+        assert kwargs["engine_plan"] == b"RANK1_ENGINE"
+        assert kwargs["distributed_communicator"] is communicator
+
     def test_seq2seq_engine_section_and_communicator_forwarded(self, tmp_path):
         from tensorrt_model_connect.debug_runner import runner_from_bundle
 

--- a/tests/builder/test_debug_runner.py
+++ b/tests/builder/test_debug_runner.py
@@ -314,6 +314,42 @@ class TestRunnerFromBundle:
         assert kwargs["encoder_plan"] == b"ENCODER_PLAN"
         assert kwargs["distributed_communicator"] is communicator
 
+    def test_marian_seq2seq_engine_section_and_communicator_forwarded(self, tmp_path):
+        from tensorrt_model_connect.debug_runner import runner_from_bundle
+
+        config_data = json.dumps({
+            "runtime_strategy": "marian_translation",
+            "decoder_layers": 2,
+            "decoder_start_token_id": 0,
+        }).encode("utf-8")
+        bundle = _make_bundle_bytes(
+            {"num_layers": 2, "max_cache_length": 128},
+            engine_plan=b"SINGLE_DECODER",
+            vision_plan=b"ENCODER_PLAN",
+            extra_sections={
+                "config.json": config_data,
+                "engine_plan_tp_rank1": b"RANK1_DECODER",
+            },
+        )
+
+        path = tmp_path / "marian_seq2seq_tp_dispatch.trtfb"
+        path.write_bytes(bundle)
+
+        communicator = object()
+        with patch("tensorrt_model_connect.debug_runner.Seq2SeqTrtRunner",
+                   return_value="seq2seq-tp-runner") as mock_runner:
+            runner = runner_from_bundle(
+                str(path),
+                engine_section="engine_plan_tp_rank1",
+                distributed_communicator=communicator,
+            )
+
+        assert runner == "seq2seq-tp-runner"
+        kwargs = mock_runner.call_args.kwargs
+        assert kwargs["decoder_plan"] == b"RANK1_DECODER"
+        assert kwargs["encoder_plan"] == b"ENCODER_PLAN"
+        assert kwargs["distributed_communicator"] is communicator
+
     def test_bart_seq2seq_engine_section_and_communicator_forwarded(self, tmp_path):
         from tensorrt_model_connect.debug_runner import runner_from_bundle
 

--- a/tests/builder/test_engine_mamba_tp.py
+++ b/tests/builder/test_engine_mamba_tp.py
@@ -1,0 +1,118 @@
+"""Focused tests for Mamba tensor-parallel support."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+try:
+    mamba_plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.mamba.plugin")
+    from tensorrt_model_connect.families.mamba import tp_builder
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _weights(d_inner: int = 16, state_size: int = 4, conv_kernel: int = 3) -> dict:
+    hidden = 8
+    dt_rank = 2
+    weights: dict[str, object] = {
+        "_d_inner": d_inner,
+        "_state_size": state_size,
+        "_conv_kernel": conv_kernel,
+        "_dt_rank": dt_rank,
+        "_num_layers": 1,
+        "embedding": np.zeros((32, hidden), dtype=np.float32),
+        "final_norm": np.ones((hidden,), dtype=np.float32),
+        "w_lm_head": np.zeros((hidden, 32), dtype=np.float32),
+    }
+    prefix = "layer.0"
+    weights[f"{prefix}.norm"] = np.ones((hidden,), dtype=np.float32)
+    weights[f"{prefix}.w_in_x"] = np.zeros((hidden, d_inner), dtype=np.float32)
+    weights[f"{prefix}.w_in_z"] = np.zeros((hidden, d_inner), dtype=np.float32)
+    weights[f"{prefix}.conv1d_weight"] = np.zeros((d_inner, conv_kernel), dtype=np.float32)
+    weights[f"{prefix}.conv1d_bias"] = np.zeros((d_inner,), dtype=np.float32)
+    weights[f"{prefix}.w_dt_in"] = np.zeros((d_inner, dt_rank), dtype=np.float32)
+    weights[f"{prefix}.w_B"] = np.zeros((d_inner, state_size), dtype=np.float32)
+    weights[f"{prefix}.w_C"] = np.zeros((d_inner, state_size), dtype=np.float32)
+    weights[f"{prefix}.w_dt_out"] = np.zeros((dt_rank, d_inner), dtype=np.float32)
+    weights[f"{prefix}.dt_proj_bias"] = np.zeros((d_inner,), dtype=np.float32)
+    weights[f"{prefix}.A"] = np.zeros((d_inner, state_size), dtype=np.float32)
+    weights[f"{prefix}.D"] = np.zeros((d_inner,), dtype=np.float32)
+    weights[f"{prefix}.w_out"] = np.zeros((d_inner, hidden), dtype=np.float32)
+    return weights
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        raw={},
+        hidden_size=8,
+        vocab_size=32,
+        num_hidden_layers=1,
+        rms_norm_eps=1e-5,
+    )
+
+
+def test_mamba_tp_slices_inner_dimension_weights():
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+    weights = _weights()
+    weights["layer.0.w_in_x"] = np.arange(8 * 16, dtype=np.float32).reshape(8, 16)
+    weights["layer.0.w_dt_in"] = np.arange(16 * 2, dtype=np.float32).reshape(16, 2)
+    weights["layer.0.w_dt_out"] = np.arange(2 * 16, dtype=np.float32).reshape(2, 16)
+    weights["layer.0.w_out"] = np.arange(16 * 8, dtype=np.float32).reshape(16, 8)
+
+    sharded = tp_builder.shard_mamba_weights(weights, parallel=parallel)
+
+    np.testing.assert_array_equal(sharded["layer.0.w_in_x"], weights["layer.0.w_in_x"][:, 8:12])
+    np.testing.assert_array_equal(sharded["layer.0.w_dt_in"], weights["layer.0.w_dt_in"][8:12, :])
+    np.testing.assert_array_equal(sharded["layer.0.w_dt_out"], weights["layer.0.w_dt_out"][:, 8:12])
+    np.testing.assert_array_equal(sharded["layer.0.w_out"], weights["layer.0.w_out"][8:12, :])
+    assert sharded["_d_inner"] == 4
+
+
+def test_mamba_tp_validation_rejects_non_divisible_inner_dim():
+    with pytest.raises(ValueError, match="d_inner divisible"):
+        tp_builder._validate_mamba_tp(
+            _weights(d_inner=18), ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0))
+
+
+def test_mamba_tp_validation_requires_concrete_rank():
+    with pytest.raises(ValueError, match="concrete rank"):
+        tp_builder._validate_mamba_tp(
+            _weights(), ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1))
+
+
+def test_mamba_plugin_routes_parallel_builds(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"mamba-tp-plan"
+
+    monkeypatch.setattr(
+        mamba_plugin_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(tp_builder, "build_mamba_tp_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1)
+    result = mamba_plugin_module.MambaPlugin().build_engine(
+        _config(), _weights(), 17,
+        verbose=True,
+        debug_layer_outputs=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"mamba-tp-plan"
+    assert calls["require"][0] == parallel
+    assert "Mamba tensor-parallel" in calls["require"][1]
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 17
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["verbose"] is True
+    assert kwargs["debug_layer_outputs"] is True

--- a/tests/builder/test_engine_marian_tp.py
+++ b/tests/builder/test_engine_marian_tp.py
@@ -1,0 +1,124 @@
+"""Focused tests for Marian tensor-parallel decoder support."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+try:
+    marian_plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.marian.plugin")
+    from tensorrt_model_connect.families.marian import decoder_tp_builder
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _weights(dec_heads: int = 8, dec_ffn: int = 2048) -> dict:
+    hidden = 512
+    weights: dict[str, object] = {
+        "_dec_layers": 1,
+        "_dec_heads": dec_heads,
+        "_dec_ffn": dec_ffn,
+        "_max_position_embeddings": 128,
+        "dec_embedding": np.zeros((128, hidden), dtype=np.float32),
+        "dec_pos_embedding": np.zeros((128, hidden), dtype=np.float32),
+        "w_out": np.zeros((hidden, 128), dtype=np.float32),
+        "final_logits_bias": np.zeros((128,), dtype=np.float32),
+    }
+    prefix = "layer.0"
+    for key in ("w_q", "w_k", "w_v", "cross_w_q", "cross_w_k", "cross_w_v"):
+        weights[f"{prefix}.{key}"] = np.zeros((hidden, hidden), dtype=np.float32)
+    for key in ("q_bias", "k_bias", "v_bias", "cross_b_q", "cross_b_k", "cross_b_v"):
+        weights[f"{prefix}.{key}"] = np.zeros((hidden,), dtype=np.float32)
+    for key in ("w_o", "cross_w_o"):
+        weights[f"{prefix}.{key}"] = np.zeros((hidden, hidden), dtype=np.float32)
+    for key in ("o_bias", "cross_b_o"):
+        weights[f"{prefix}.{key}"] = np.zeros((hidden,), dtype=np.float32)
+    weights[f"{prefix}.input_norm"] = np.ones((hidden,), dtype=np.float32)
+    weights[f"{prefix}.input_norm_beta"] = np.zeros((hidden,), dtype=np.float32)
+    weights[f"{prefix}.cross_attn_norm"] = np.ones((hidden,), dtype=np.float32)
+    weights[f"{prefix}.cross_attn_norm_beta"] = np.zeros((hidden,), dtype=np.float32)
+    weights[f"{prefix}.w_fc1"] = np.zeros((hidden, dec_ffn), dtype=np.float32)
+    weights[f"{prefix}.fc1_bias"] = np.zeros((dec_ffn,), dtype=np.float32)
+    weights[f"{prefix}.w_fc2"] = np.zeros((dec_ffn, hidden), dtype=np.float32)
+    weights[f"{prefix}.fc2_bias"] = np.zeros((hidden,), dtype=np.float32)
+    weights[f"{prefix}.post_attn_norm"] = np.ones((hidden,), dtype=np.float32)
+    weights[f"{prefix}.post_attn_norm_beta"] = np.zeros((hidden,), dtype=np.float32)
+    return weights
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        raw={},
+        hidden_size=512,
+        vocab_size=128,
+        rms_norm_eps=1e-5,
+    )
+
+
+def test_marian_tp_slices_projection_columns_rows_and_biases():
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+    weights = _weights()
+    weights["layer.0.w_q"] = np.arange(512 * 512, dtype=np.float32).reshape(512, 512)
+    weights["layer.0.q_bias"] = np.arange(512, dtype=np.float32)
+    weights["layer.0.w_o"] = np.arange(512 * 512, dtype=np.float32).reshape(512, 512)
+    weights["layer.0.o_bias"] = np.arange(512, dtype=np.float32)
+
+    sharded = decoder_tp_builder.shard_marian_decoder_weights(
+        weights, parallel=parallel)
+
+    np.testing.assert_array_equal(sharded["layer.0.w_q"], weights["layer.0.w_q"][:, 256:384])
+    np.testing.assert_array_equal(sharded["layer.0.q_bias"], weights["layer.0.q_bias"][256:384])
+    np.testing.assert_array_equal(sharded["layer.0.w_o"], weights["layer.0.w_o"][256:384, :])
+    np.testing.assert_array_equal(sharded["layer.0.o_bias"], weights["layer.0.o_bias"])
+
+
+def test_marian_tp_validation_rejects_non_divisible_heads():
+    with pytest.raises(ValueError, match="decoder_attention_heads divisible"):
+        decoder_tp_builder._validate_marian_tp(
+            _config(),
+            _weights(dec_heads=6),
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )
+
+
+def test_marian_tp_validation_requires_concrete_rank():
+    with pytest.raises(ValueError, match="concrete rank"):
+        decoder_tp_builder._validate_marian_tp(
+            _config(), _weights(), ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1))
+
+
+def test_marian_plugin_routes_parallel_builds(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"marian-tp-plan"
+
+    monkeypatch.setattr(
+        marian_plugin_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(decoder_tp_builder, "build_marian_tp_decoder_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1)
+    result = marian_plugin_module.MarianPlugin().build_engine(
+        _config(), _weights(), 17,
+        verbose=True,
+        debug_layer_outputs=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"marian-tp-plan"
+    assert calls["require"][0] == parallel
+    assert "Marian tensor-parallel" in calls["require"][1]
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 17
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["verbose"] is True
+    assert kwargs["debug_layer_outputs"] is True

--- a/tests/builder/test_family_nemotron_h_tp.py
+++ b/tests/builder/test_family_nemotron_h_tp.py
@@ -1,0 +1,158 @@
+"""Focused tests for Nemotron-H tensor-parallel support."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+try:
+    nemotron_h_module = importlib.import_module(
+        "tensorrt_model_connect.families.nemotron_h.plugin")
+    from tensorrt_model_connect.families.nemotron_h import tp_builder
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _config(num_heads: int = 4, num_kv_heads: int = 4) -> SimpleNamespace:
+    return SimpleNamespace(
+        raw={},
+        hidden_size=8,
+        vocab_size=32,
+        num_hidden_layers=3,
+        num_attention_heads=num_heads,
+        num_key_value_heads=num_kv_heads,
+        head_dim=2,
+        intermediate_size=16,
+        rms_norm_eps=1e-5,
+    )
+
+
+def _weights() -> dict:
+    hidden = 8
+    d_inner = 16
+    d_state = 2
+    d_conv = 3
+    n_groups = 4
+    mamba_heads = 4
+    conv_dim = d_inner + 2 * n_groups * d_state
+    proj_dim = d_inner + conv_dim + mamba_heads
+    weights: dict[str, object] = {
+        "_layer_types": ["mamba2", "mlp", "attention"],
+        "_d_inner": d_inner,
+        "_d_state": d_state,
+        "_d_conv": d_conv,
+        "_conv_dim": conv_dim,
+        "_mamba_num_heads": mamba_heads,
+        "_mamba_head_dim": 4,
+        "_n_groups": n_groups,
+        "_num_mamba_layers": 1,
+        "_num_attention_layers": 1,
+        "_attention_size": 8,
+        "_mlp_size": 16,
+        "embedding": np.zeros((32, hidden), dtype=np.float32),
+        "final_norm": np.ones((hidden,), dtype=np.float32),
+        "w_lm_head": np.zeros((hidden, 32), dtype=np.float32),
+    }
+    weights["layer.0.input_norm"] = np.ones((hidden,), dtype=np.float32)
+    weights["layer.0.mamba_in_proj"] = np.arange(
+        hidden * proj_dim, dtype=np.float32).reshape(hidden, proj_dim)
+    weights["layer.0.conv1d_weight"] = np.arange(
+        conv_dim * d_conv, dtype=np.float32).reshape(conv_dim, d_conv)
+    weights["layer.0.conv1d_bias"] = np.arange(conv_dim, dtype=np.float32)
+    weights["layer.0.dt_bias"] = np.arange(mamba_heads, dtype=np.float32)
+    weights["layer.0.A"] = np.arange(mamba_heads, dtype=np.float32)
+    weights["layer.0.D"] = np.arange(mamba_heads, dtype=np.float32)
+    weights["layer.0.mamba_norm"] = np.arange(d_inner, dtype=np.float32)
+    weights["layer.0.mamba_out_proj"] = np.arange(
+        d_inner * hidden, dtype=np.float32).reshape(d_inner, hidden)
+
+    weights["layer.1.input_norm"] = np.ones((hidden,), dtype=np.float32)
+    weights["layer.1.w_up"] = np.arange(hidden * 16, dtype=np.float32).reshape(hidden, 16)
+    weights["layer.1.w_down"] = np.arange(16 * hidden, dtype=np.float32).reshape(16, hidden)
+
+    weights["layer.2.input_norm"] = np.ones((hidden,), dtype=np.float32)
+    weights["layer.2.w_q"] = np.arange(hidden * 8, dtype=np.float32).reshape(hidden, 8)
+    weights["layer.2.w_k"] = np.arange(hidden * 8, dtype=np.float32).reshape(hidden, 8)
+    weights["layer.2.w_v"] = np.arange(hidden * 8, dtype=np.float32).reshape(hidden, 8)
+    weights["layer.2.w_o"] = np.arange(8 * hidden, dtype=np.float32).reshape(8, hidden)
+    return weights
+
+
+def test_nemotron_h_tp_slices_mamba_mlp_and_attention_weights():
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+    weights = _weights()
+
+    sharded = tp_builder.shard_nemotron_h_weights(
+        _config(), weights, parallel=parallel)
+
+    expected_in_proj = np.concatenate([
+        weights["layer.0.mamba_in_proj"][:, 8:12],
+        weights["layer.0.mamba_in_proj"][:, 24:28],
+        weights["layer.0.mamba_in_proj"][:, 36:38],
+        weights["layer.0.mamba_in_proj"][:, 44:46],
+        weights["layer.0.mamba_in_proj"][:, 50:51],
+    ], axis=-1)
+    expected_conv = np.concatenate([
+        weights["layer.0.conv1d_weight"][8:12, :],
+        weights["layer.0.conv1d_weight"][20:22, :],
+        weights["layer.0.conv1d_weight"][28:30, :],
+    ], axis=0)
+
+    np.testing.assert_array_equal(sharded["layer.0.mamba_in_proj"], expected_in_proj)
+    np.testing.assert_array_equal(sharded["layer.0.conv1d_weight"], expected_conv)
+    np.testing.assert_array_equal(sharded["layer.0.mamba_out_proj"], weights["layer.0.mamba_out_proj"][8:12, :])
+    np.testing.assert_array_equal(sharded["layer.1.w_up"], weights["layer.1.w_up"][:, 8:12])
+    np.testing.assert_array_equal(sharded["layer.1.w_down"], weights["layer.1.w_down"][8:12, :])
+    np.testing.assert_array_equal(sharded["layer.2.w_q"], weights["layer.2.w_q"][:, 4:6])
+    np.testing.assert_array_equal(sharded["layer.2.w_o"], weights["layer.2.w_o"][4:6, :])
+    assert sharded["_d_inner"] == 4
+    assert sharded["_conv_dim"] == 8
+    assert sharded["_mamba_num_heads"] == 1
+    assert sharded["_n_groups"] == 1
+    assert sharded["_attention_size"] == 2
+    assert sharded["_mlp_size"] == 4
+
+
+def test_nemotron_h_tp_validation_rejects_non_divisible_kv_heads():
+    with pytest.raises(ValueError, match="num_key_value_heads"):
+        tp_builder._validate_nemotron_h_tp(
+            _config(num_kv_heads=2),
+            _weights(),
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )
+
+
+def test_nemotron_h_plugin_routes_parallel_builds(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"nemotron-h-tp-plan"
+
+    monkeypatch.setattr(
+        nemotron_h_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(tp_builder, "build_nemotron_h_tp_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1)
+    result = nemotron_h_module.NemotronHPlugin().build_engine(
+        _config(), _weights(), 17,
+        verbose=True,
+        debug_layer_outputs=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"nemotron-h-tp-plan"
+    assert calls["require"][0] == parallel
+    assert "Nemotron-H tensor-parallel" in calls["require"][1]
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 17
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["verbose"] is True
+    assert kwargs["debug_layer_outputs"] is True

--- a/tests/e2e/models/mamba-130m-tp4.json
+++ b/tests/e2e/models/mamba-130m-tp4.json
@@ -1,0 +1,56 @@
+{
+  "name": "mamba-130m-tp4",
+  "trace_id": "IT-E2E-MAMBA-TP4-01",
+  "hf_id": "state-spaces/mamba-130m-hf",
+  "bundle": "mamba-130m-tp4.trtfb",
+  "family": "mamba",
+  "runtime_strategy": "ssm_recurrent",
+  "max_cache_length": 256,
+  "prompt": "The capital of France is",
+  "max_new_tokens": 20,
+  "logit_atol": 0.002,
+  "layer_atol": 0.05,
+  "trust_remote_code": false,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "Mamba-130M TP4 repro using the same checkpoint, prompt, generation length, and thresholds as mamba-130m."
+}

--- a/tests/e2e/models/marian-en-ru-tp4.json
+++ b/tests/e2e/models/marian-en-ru-tp4.json
@@ -1,0 +1,61 @@
+{
+  "name": "marian-en-ru-tp4",
+  "hf_id": "Helsinki-NLP/opus-mt-en-ru",
+  "bundle": "marian-en-ru-tp4.trtfb",
+  "family": "marian",
+  "runtime_strategy": "marian_translation",
+  "max_cache_length": 256,
+  "prompt": "The house is wonderful.",
+  "max_new_tokens": 20,
+  "logit_atol": 0.001,
+  "trust_remote_code": false,
+  "threshold_overrides": {
+    "logit_cosine_p5": 0.0,
+    "logit_rel_l2_p95": 999.0,
+    "token_agreement_rate": 0.0,
+    "stable_top1_match_rate": 0.0,
+    "unstable_topk_hit_rate": 0.0
+  },
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "Marian EN-RU TP4 repro using the same checkpoint, prompt, generation length, and thresholds as marian-en-ru."
+}

--- a/tests/e2e/models/nemotron-h-nano-9b-tp4.json
+++ b/tests/e2e/models/nemotron-h-nano-9b-tp4.json
@@ -1,0 +1,62 @@
+{
+  "name": "nemotron-h-nano-9b-tp4",
+  "trace_id": "IT-E2E-NMHN-TP4-01",
+  "hf_id": "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
+  "bundle": "nemotron-h-nano-9b-tp4.trtfb",
+  "family": "nemotron_h",
+  "runtime_strategy": "hybrid_mamba_attention",
+  "reference_backend": "golden_snapshot",
+  "reference_family": "chat_instruct_template",
+  "user_contract": "chat_response",
+  "max_cache_length": 256,
+  "prompt": "What is the capital of France? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.005,
+  "layer_atol": 0.1,
+  "trust_remote_code": true,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "metadata": {
+    "golden_snapshot_path": "tests/e2e/data/nemotron_h_nano_9b_golden.json"
+  },
+  "notes": "Nemotron-H Nano 9B TP4 repro using the same prompt, golden snapshot, generation length, and thresholds as nemotron-h-nano-9b."
+}


### PR DESCRIPTION
## Background
PRs #128, #130, and #132 all added TP4 support for model families that touch the shared debug-runner dispatch path. Keeping them separate caused overlapping conflicts in `tests/builder/test_debug_runner.py`, so this PR now consolidates the three conflict-resolved changes.

## Exit Criteria
- Resolve the current merge conflicts against `main`.
- Keep the Marian, Mamba, and Nemotron-H TP4 implementations together in one PR.
- Preserve the current main debug-runner coverage while adding the runtime-strategy coverage needed by all three model families.
- Verify the merged E2E set passes after consolidation and document that result here.

## Implementation
- Add Marian decoder TP4 support with rank-local decoder sections and a `marian-en-ru-tp4` E2E manifest.
- Add Mamba SSM TP4 support with rank-local recurrent sections and a `mamba-130m-tp4` E2E manifest.
- Add Nemotron-H Nano hybrid TP4 support with rank-local hybrid sections and a `nemotron-h-nano-9b-tp4` E2E manifest.
- Resolve the shared debug-runner conflict by keeping RWKV, generic seq2seq, BART seq2seq, and triattention coverage while adding Marian, Mamba, and hybrid dispatch tests.

## Validation
- `CUDA_VISIBLE_DEVICES=0,1,2,3 PYTHONPATH=python:. /opt/venv/bin/python -m pytest -q tests/builder/test_debug_runner.py tests/builder/test_engine_marian_tp.py tests/builder/test_engine_mamba_tp.py tests/builder/test_family_nemotron_h_tp.py tests/builder/test_manifest_validation.py`: passed in the B200 Docker container, `65 passed in 1.41s`.
- `cmake -S . -B build-pr128-combined -G Ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so -DTRTMC_CUDA_INCLUDE_DIR=/usr/local/cuda/include -DTRTMC_CUDART_LIBRARY=/usr/local/cuda/lib64/libcudart.so`: passed in the B200 Docker container.
- `cmake --build build-pr128-combined --target trtmc trtmc_backend_trt -j`: passed in the B200 Docker container.
- `CUDA_VISIBLE_DEVICES=0,1,2,3 PYTHONPATH=python:. /opt/venv/bin/python -m pytest -q "tests/test_e2e.py::test_e2e[marian-en-ru-tp4]" "tests/test_e2e.py::test_e2e[mamba-130m-tp4]" "tests/test_e2e.py::test_e2e[nemotron-h-nano-9b-tp4]" -v --multi-device-only --engine-dir /tmp/trtmc-storage/pr128-combined/engines --trtmc-binary ./build-pr128-combined/trtmc --hf-python /opt/venv/bin/python --e2e-artifacts-dir /tmp/trtmc-storage/pr128-combined/artifacts --rebuild-engines -s -p no:cacheprovider`: passed after consolidation on B200 GPUs 0-3, `3 passed in 543.72s (0:09:03)`.

## Notes For Future Readers
- PRs #130 and #132 are superseded by this consolidated PR.
- The branch was rebuilt from current `github/main`; the old merge commits that only recorded conflicts were not retained.
