### PR TITLE
feat(mamba): add ssm tp4 support

### DIFF
--- a/python/tensorrt_model_connect/debug_runner.py
+++ b/python/tensorrt_model_connect/debug_runner.py
@@ -781,9 +781,11 @@ class MambaTrtRunner:
         d_inner: int | None = None,
         state_size: int | None = None,
         conv_kernel: int | None = None,
+        distributed_communicator: object | None = None,
     ):
         _require_trt_runtime()
         self.num_layers = num_layers
+        self._distributed_communicator = distributed_communicator
 
         # Deserialize engine
         logger = trt.Logger(trt.Logger.WARNING)
@@ -792,6 +794,15 @@ class MambaTrtRunner:
         if self.engine is None:
             raise RuntimeError("Failed to deserialize TRT engine")
         self.context = self.engine.create_execution_context()
+        if distributed_communicator is not None:
+            set_communicator = getattr(self.context, "set_communicator", None)
+            if set_communicator is None:
+                raise RuntimeError(
+                    "TensorRT distributed Mamba debug execution requires "
+                    "IExecutionContext.set_communicator"
+                )
+            if not set_communicator(distributed_communicator):
+                raise RuntimeError("Failed to set TensorRT distributed communicator")
 
         # Auto-detect state dimensions
         if d_inner is None or conv_kernel is None:
@@ -2271,14 +2282,10 @@ def runner_from_bundle(
             num_attention_layers=num_attn,
         )
     if runtime_strategy == "ssm_recurrent":
-        if distributed_communicator is not None or engine_section != "engine_plan":
-            raise ValueError(
-                "Distributed engine section selection is only supported for "
-                "standard decoder runners"
-            )
         return MambaTrtRunner(
             engine_plan=engine_plan,
             num_layers=num_layers,
+            distributed_communicator=distributed_communicator,
         )
     if runtime_strategy == "rwkv_recurrent":
         if distributed_communicator is not None or engine_section != "engine_plan":

--- a/python/tensorrt_model_connect/families/mamba/plugin.py
+++ b/python/tensorrt_model_connect/families/mamba/plugin.py
@@ -46,6 +46,7 @@ from ...checkpoint_mapper import (
     _transpose_2d,
 )
 from ... import graph_ops
+from ...parallel_config import normalize_parallel_config, require_tensorrt_11_for_tensor_parallel
 
 
 trt = trt_compat.get_trt()
@@ -182,6 +183,7 @@ class MambaPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
         debug_layer_outputs: bool = False,
+        parallel_config=None,
     ) -> bytes:
         """Build TRT engine for Mamba SSM.
 
@@ -198,6 +200,20 @@ class MambaPlugin:
           present_conv_0..N: float32 [1, d_inner * conv_kernel]
           present_ssm_0..N: float32 [1, d_inner * state_size]
         """
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="Mamba tensor-parallel builds")
+            from .tp_builder import build_mamba_tp_engine
+            return build_mamba_tp_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                parallel_config=parallel,
+            )
+
         hidden = config.hidden_size
         vocab = config.vocab_size
         num_layers = config.num_hidden_layers

--- a/python/tensorrt_model_connect/families/mamba/tp_builder.py
+++ b/python/tensorrt_model_connect/families/mamba/tp_builder.py
@@ -1,0 +1,344 @@
+"""Tensor-parallel Mamba SSM builder.
+
+The TP policy shards Mamba's ``d_inner`` dimension. Per-rank engines keep local
+conv/SSM state, all-reduce input-dependent ``dt/B/C`` projections that need the
+full inner reduction, and all-reduce the row-parallel output projection back to
+full hidden size.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+from .plugin import _mark_debug_output
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_mamba_tp(weights: "WeightDict", parallel: "ParallelConfig") -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("Mamba tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    d_inner = int(weights["_d_inner"])
+    if d_inner % tp != 0:
+        raise ValueError(
+            "Mamba tensor parallel requires d_inner divisible by tp_size "
+            f"({d_inner} vs {tp})")
+
+    for layer_idx in range(int(weights.get("_num_layers", 0))):
+        prefix = f"layer.{layer_idx}"
+        for key in (
+            f"{prefix}.w_in_x", f"{prefix}.w_in_z", f"{prefix}.w_dt_out",
+            f"{prefix}.dt_proj_bias",
+        ):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim is not divisible by tp_size={tp}")
+        for key in (
+            f"{prefix}.conv1d_weight", f"{prefix}.conv1d_bias", f"{prefix}.w_dt_in",
+            f"{prefix}.w_B", f"{prefix}.w_C", f"{prefix}.A", f"{prefix}.D",
+            f"{prefix}.w_out",
+        ):
+            if weights[key].shape[0] % tp != 0:
+                raise ValueError(f"{key} input dim is not divisible by tp_size={tp}")
+
+
+def shard_mamba_weights(
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local Mamba weights for the TP builder."""
+    if not parallel.enabled:
+        return weights
+
+    rank = parallel.rank
+    tp = parallel.tp_size
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+        if key.endswith((".w_in_x", ".w_in_z", ".w_dt_out", ".dt_proj_bias")):
+            out[key] = _slice_last_dim(value, rank, tp)
+        elif key.endswith((
+            ".conv1d_weight", ".conv1d_bias", ".w_dt_in", ".w_B", ".w_C",
+            ".A", ".D", ".w_out",
+        )):
+            out[key] = _slice_first_dim(value, rank, tp)
+        else:
+            out[key] = value
+
+    out["_d_inner"] = int(weights["_d_inner"]) // tp
+    out["_tensor_parallel_size"] = tp
+    out["_tensor_parallel_rank"] = rank
+    return out
+
+
+def _add_mamba_tp_layer(
+    *,
+    network,
+    hidden,
+    conv_state_in,
+    ssm_state_in,
+    eps_tensor,
+    weights,
+    prefix: str,
+    hidden_size: int,
+    local_d_inner: int,
+    state_size: int,
+    conv_kernel: int,
+    dt_rank: int,
+    tp_size: int,
+):
+    normed = graph_ops.add_rms_norm(
+        network, hidden, hidden_size, weights[f"{prefix}.norm"], eps_tensor)
+
+    x = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, local_d_inner, weights[f"{prefix}.w_in_x"])
+    z = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, local_d_inner, weights[f"{prefix}.w_in_z"])
+
+    x_col = network.add_shuffle(x)
+    x_col.reshape_dims = (local_d_inner, 1)
+    if conv_kernel > 1:
+        slice_layer = network.add_slice(
+            conv_state_in,
+            start=(0, 1),
+            shape=(local_d_inner, conv_kernel - 1),
+            stride=(1, 1),
+        )
+        new_conv_state = network.add_concatenation(
+            [slice_layer.get_output(0), x_col.get_output(0)])
+        new_conv_state.axis = 1
+        present_conv = new_conv_state.get_output(0)
+    else:
+        present_conv = x_col.get_output(0)
+
+    conv_w = graph_ops.add_constant(
+        network, (local_d_inner, conv_kernel), weights[f"{prefix}.conv1d_weight"])
+    conv_prod = network.add_elementwise(
+        present_conv, conv_w, trt.ElementWiseOperation.PROD)
+    conv_sum = network.add_reduce(
+        conv_prod.get_output(0), trt.ReduceOperation.SUM, 1 << 1, keep_dims=True)
+    conv_flat = network.add_shuffle(conv_sum.get_output(0))
+    conv_flat.reshape_dims = (1, local_d_inner)
+    conv_out = graph_ops.add_bias_sum(
+        network, conv_flat.get_output(0), local_d_inner, weights[f"{prefix}.conv1d_bias"])
+    conv_activated = graph_ops.add_activation(network, conv_out, "silu")
+
+    dt_in = graph_ops.add_matmul_rhs_constant(
+        network, conv_activated, local_d_inner, dt_rank, weights[f"{prefix}.w_dt_in"])
+    dt_in = add_all_reduce_sum(network, dt_in, tp_size)
+    B = graph_ops.add_matmul_rhs_constant(
+        network, conv_activated, local_d_inner, state_size, weights[f"{prefix}.w_B"])
+    B = add_all_reduce_sum(network, B, tp_size)
+    C = graph_ops.add_matmul_rhs_constant(
+        network, conv_activated, local_d_inner, state_size, weights[f"{prefix}.w_C"])
+    C = add_all_reduce_sum(network, C, tp_size)
+
+    dt = graph_ops.add_matmul_rhs_constant(
+        network, dt_in, dt_rank, local_d_inner, weights[f"{prefix}.w_dt_out"])
+    dt = graph_ops.add_bias_sum(
+        network, dt, local_d_inner, weights[f"{prefix}.dt_proj_bias"])
+
+    dt_exp = network.add_unary(dt, trt.UnaryOperation.EXP)
+    one = graph_ops.add_constant(
+        network, (1, 1), np.array([1.0], dtype=np.float32))
+    dt_exp_p1 = network.add_elementwise(
+        dt_exp.get_output(0), one, trt.ElementWiseOperation.SUM)
+    dt_softplus = network.add_unary(
+        dt_exp_p1.get_output(0), trt.UnaryOperation.LOG)
+    dt_final = dt_softplus.get_output(0)
+
+    dt_col = network.add_shuffle(dt_final)
+    dt_col.reshape_dims = (local_d_inner, 1)
+    A_const = graph_ops.add_constant(
+        network, (local_d_inner, state_size), weights[f"{prefix}.A"])
+    dtA = network.add_elementwise(
+        dt_col.get_output(0), A_const, trt.ElementWiseOperation.PROD)
+    A_bar = network.add_unary(dtA.get_output(0), trt.UnaryOperation.EXP)
+
+    B_reshape = network.add_shuffle(B)
+    B_reshape.reshape_dims = (1, state_size)
+    dt_B = network.add_elementwise(
+        dt_col.get_output(0), B_reshape.get_output(0),
+        trt.ElementWiseOperation.PROD)
+
+    x_col2 = network.add_shuffle(conv_activated)
+    x_col2.reshape_dims = (local_d_inner, 1)
+    dtBx = network.add_elementwise(
+        dt_B.get_output(0), x_col2.get_output(0), trt.ElementWiseOperation.PROD)
+
+    decay = network.add_elementwise(
+        A_bar.get_output(0), ssm_state_in, trt.ElementWiseOperation.PROD)
+    new_ssm = network.add_elementwise(
+        decay.get_output(0), dtBx.get_output(0), trt.ElementWiseOperation.SUM)
+    present_ssm = new_ssm.get_output(0)
+
+    C_reshape = network.add_shuffle(C)
+    C_reshape.reshape_dims = (state_size, 1)
+    y_matmul = network.add_matrix_multiply(
+        present_ssm, trt.MatrixOperation.NONE,
+        C_reshape.get_output(0), trt.MatrixOperation.NONE)
+    y_flat = network.add_shuffle(y_matmul.get_output(0))
+    y_flat.reshape_dims = (1, local_d_inner)
+
+    D_const = graph_ops.add_constant(
+        network, (1, local_d_inner), weights[f"{prefix}.D"])
+    Dx = network.add_elementwise(
+        D_const, conv_activated, trt.ElementWiseOperation.PROD)
+    y = network.add_elementwise(
+        y_flat.get_output(0), Dx.get_output(0), trt.ElementWiseOperation.SUM)
+
+    z_activated = graph_ops.add_activation(network, z, "silu")
+    gated = network.add_elementwise(
+        y.get_output(0), z_activated, trt.ElementWiseOperation.PROD)
+
+    out = graph_ops.add_matmul_rhs_constant(
+        network, gated.get_output(0), local_d_inner, hidden_size, weights[f"{prefix}.w_out"])
+    out = add_all_reduce_sum(network, out, tp_size)
+    residual = network.add_elementwise(hidden, out, trt.ElementWiseOperation.SUM)
+
+    return {
+        "hidden": residual.get_output(0),
+        "present_conv": present_conv,
+        "present_ssm": present_ssm,
+    }
+
+
+def build_mamba_tp_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    parallel_config=None,
+) -> bytes:
+    del max_cache_length, precision, quant_ctx
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError("build_mamba_tp_engine requires tensor_parallel mode with tp_size > 1")
+
+    weights = type(weights)(weights)
+    weights["_num_layers"] = config.num_hidden_layers
+    _validate_mamba_tp(weights, parallel)
+    rank_weights = shard_mamba_weights(weights, parallel=parallel)
+
+    hidden = int(config.hidden_size)
+    vocab = int(config.vocab_size)
+    num_layers = int(config.num_hidden_layers)
+    local_d_inner = int(rank_weights["_d_inner"])
+    state_size = int(weights["_state_size"])
+    conv_kernel = int(weights["_conv_kernel"])
+    dt_rank = int(weights["_dt_rank"])
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    conv_state_inputs = []
+    ssm_state_inputs = []
+    for layer_idx in range(num_layers):
+        conv_state_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("conv_state", layer_idx),
+            trt.float32, (local_d_inner, conv_kernel)))
+        ssm_state_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("ssm_state", layer_idx),
+            trt.float32, (local_d_inner, state_size)))
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), rank_weights["embedding"])
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=np.float32))
+
+    hidden_state = network.add_gather(embedding_table, token_id, 0).get_output(0)
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    present_conv_outputs = []
+    present_ssm_outputs = []
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        result = _add_mamba_tp_layer(
+            network=network,
+            hidden=hidden_state,
+            conv_state_in=conv_state_inputs[layer_idx],
+            ssm_state_in=ssm_state_inputs[layer_idx],
+            eps_tensor=eps_tensor,
+            weights=rank_weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            local_d_inner=local_d_inner,
+            state_size=state_size,
+            conv_kernel=conv_kernel,
+            dt_rank=dt_rank,
+            tp_size=parallel.tp_size,
+        )
+        hidden_state = result["hidden"]
+        present_conv_outputs.append(result["present_conv"])
+        present_ssm_outputs.append(result["present_ssm"])
+        if debug_layer_outputs:
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    final_norm = rank_weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = graph_ops.add_rms_norm(
+            network, hidden_state, hidden, final_norm, eps_tensor)
+
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, vocab, rank_weights["w_lm_head"])
+    logits = graph_ops.add_bias_sum(
+        network, logits, vocab, np.zeros(vocab, dtype=np.float32))
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for layer_idx in range(num_layers):
+        present_conv_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_conv", layer_idx)
+        present_ssm_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_ssm", layer_idx)
+        network.mark_output(present_conv_outputs[layer_idx])
+        network.mark_output(present_ssm_outputs[layer_idx])
+
+    if verbose:
+        print(
+            "[trtmc build] Mamba TP engine "
+            f"(rank={parallel.rank}/{parallel.tp_size}, {num_layers}L, "
+            f"h={hidden}, local_d_inner={local_d_inner}, state={state_size})",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT Mamba TP engine build failed")
+    return bytes(plan)

--- a/src/runtime/models/recurrent/ssm_plugin.cpp
+++ b/src/runtime/models/recurrent/ssm_plugin.cpp
@@ -3,10 +3,48 @@
 
 #include "runtime/models/recurrent/pipeline.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
 
+#include <limits>
+
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+int32_t positive_numel(const std::vector<int64_t>& shape, int32_t fallback) {
+    if (shape.empty())
+        return fallback;
+    int64_t numel = 1;
+    for (const auto dim : shape) {
+        if (dim <= 0)
+            return fallback;
+        if (numel > std::numeric_limits<int32_t>::max() / dim)
+            return fallback;
+        numel *= dim;
+    }
+    return static_cast<int32_t>(numel);
+}
+
+} // namespace
 
 class SsmPlugin final : public IPipelinePlugin {
   public:
@@ -17,8 +55,20 @@ class SsmPlugin final : public IPipelinePlugin {
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        if (tp_config.enabled)
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+
+        if (tp_config.enabled) {
+            opts.distributed_communicator = tp_group.communicator;
+            opts.distributed_owner = tp_group.owner;
+        }
+
+        const std::string engine_section =
+            tp_config.enabled ? tp_engine_section_name(tp_group.rank) : std::string("engine_plan");
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "engine_plan", opts);
+            ctx.backend, find_section(ctx.bundle, engine_section), "engine_plan", opts);
         auto tokenizer = create_tokenizer_from_bundle(ctx.bundle);
 
         cudaStream_t stream = loaded.module->stream();
@@ -28,10 +78,14 @@ class SsmPlugin final : public IPipelinePlugin {
             d_inner = extract_json_int(ctx.config_json, "d_inner", ctx.config.hidden_size * 2);
         int32_t state_size = extract_json_int(ctx.config_json, "state_size", 16);
         int32_t conv_kernel = extract_json_int(ctx.config_json, "conv_kernel", 4);
+        const int32_t conv_numel =
+            positive_numel(loaded.module->tensor_shape("conv_state_0"), d_inner * conv_kernel);
+        const int32_t ssm_numel =
+            positive_numel(loaded.module->tensor_shape("ssm_state_0"), state_size * d_inner);
 
         std::vector<RecurrentState::TensorSpec> specs = {
-            {"conv_state", {d_inner * conv_kernel}, "present_conv"},
-            {"ssm_state", {state_size * d_inner}, "present_ssm"}};
+            {"conv_state", {conv_numel}, "present_conv"},
+            {"ssm_state", {ssm_numel}, "present_ssm"}};
 
         auto state = std::make_unique<RecurrentState>(ctx.config.num_layers, specs, stream);
         auto rgc = make_recurrent_gen_config(ctx.config);

--- a/tests/builder/test_debug_runner.py
+++ b/tests/builder/test_debug_runner.py
@@ -248,6 +248,36 @@ class TestRunnerFromBundle:
         assert kwargs["engine_plan"] == b"RANK1_ENGINE"
         assert kwargs["distributed_communicator"] is communicator
 
+    def test_mamba_engine_section_and_communicator_forwarded(self, tmp_path):
+        from tensorrt_model_connect.debug_runner import runner_from_bundle
+
+        config_data = json.dumps({"runtime_strategy": "ssm_recurrent"}).encode("utf-8")
+        bundle = _make_bundle_bytes(
+            {"num_layers": 2, "max_cache_length": 128},
+            engine_plan=b"SINGLE_ENGINE",
+            extra_sections={
+                "config.json": config_data,
+                "engine_plan_tp_rank1": b"RANK1_ENGINE",
+            },
+        )
+
+        path = tmp_path / "mamba_tp_dispatch.trtfb"
+        path.write_bytes(bundle)
+
+        communicator = object()
+        with patch("tensorrt_model_connect.debug_runner.MambaTrtRunner",
+                   return_value="mamba-tp-runner") as mock_runner:
+            runner = runner_from_bundle(
+                str(path),
+                engine_section="engine_plan_tp_rank1",
+                distributed_communicator=communicator,
+            )
+
+        assert runner == "mamba-tp-runner"
+        kwargs = mock_runner.call_args.kwargs
+        assert kwargs["engine_plan"] == b"RANK1_ENGINE"
+        assert kwargs["distributed_communicator"] is communicator
+
     def test_mpi_rank_info_uses_single_node_rank(self, monkeypatch):
         from tensorrt_model_connect.debug_runner import _mpi_rank_info_from_env
 

--- a/tests/builder/test_engine_mamba_tp.py
+++ b/tests/builder/test_engine_mamba_tp.py
@@ -1,0 +1,118 @@
+"""Focused tests for Mamba tensor-parallel support."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+try:
+    mamba_plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.mamba.plugin")
+    from tensorrt_model_connect.families.mamba import tp_builder
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _weights(d_inner: int = 16, state_size: int = 4, conv_kernel: int = 3) -> dict:
+    hidden = 8
+    dt_rank = 2
+    weights: dict[str, object] = {
+        "_d_inner": d_inner,
+        "_state_size": state_size,
+        "_conv_kernel": conv_kernel,
+        "_dt_rank": dt_rank,
+        "_num_layers": 1,
+        "embedding": np.zeros((32, hidden), dtype=np.float32),
+        "final_norm": np.ones((hidden,), dtype=np.float32),
+        "w_lm_head": np.zeros((hidden, 32), dtype=np.float32),
+    }
+    prefix = "layer.0"
+    weights[f"{prefix}.norm"] = np.ones((hidden,), dtype=np.float32)
+    weights[f"{prefix}.w_in_x"] = np.zeros((hidden, d_inner), dtype=np.float32)
+    weights[f"{prefix}.w_in_z"] = np.zeros((hidden, d_inner), dtype=np.float32)
+    weights[f"{prefix}.conv1d_weight"] = np.zeros((d_inner, conv_kernel), dtype=np.float32)
+    weights[f"{prefix}.conv1d_bias"] = np.zeros((d_inner,), dtype=np.float32)
+    weights[f"{prefix}.w_dt_in"] = np.zeros((d_inner, dt_rank), dtype=np.float32)
+    weights[f"{prefix}.w_B"] = np.zeros((d_inner, state_size), dtype=np.float32)
+    weights[f"{prefix}.w_C"] = np.zeros((d_inner, state_size), dtype=np.float32)
+    weights[f"{prefix}.w_dt_out"] = np.zeros((dt_rank, d_inner), dtype=np.float32)
+    weights[f"{prefix}.dt_proj_bias"] = np.zeros((d_inner,), dtype=np.float32)
+    weights[f"{prefix}.A"] = np.zeros((d_inner, state_size), dtype=np.float32)
+    weights[f"{prefix}.D"] = np.zeros((d_inner,), dtype=np.float32)
+    weights[f"{prefix}.w_out"] = np.zeros((d_inner, hidden), dtype=np.float32)
+    return weights
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        raw={},
+        hidden_size=8,
+        vocab_size=32,
+        num_hidden_layers=1,
+        rms_norm_eps=1e-5,
+    )
+
+
+def test_mamba_tp_slices_inner_dimension_weights():
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+    weights = _weights()
+    weights["layer.0.w_in_x"] = np.arange(8 * 16, dtype=np.float32).reshape(8, 16)
+    weights["layer.0.w_dt_in"] = np.arange(16 * 2, dtype=np.float32).reshape(16, 2)
+    weights["layer.0.w_dt_out"] = np.arange(2 * 16, dtype=np.float32).reshape(2, 16)
+    weights["layer.0.w_out"] = np.arange(16 * 8, dtype=np.float32).reshape(16, 8)
+
+    sharded = tp_builder.shard_mamba_weights(weights, parallel=parallel)
+
+    np.testing.assert_array_equal(sharded["layer.0.w_in_x"], weights["layer.0.w_in_x"][:, 8:12])
+    np.testing.assert_array_equal(sharded["layer.0.w_dt_in"], weights["layer.0.w_dt_in"][8:12, :])
+    np.testing.assert_array_equal(sharded["layer.0.w_dt_out"], weights["layer.0.w_dt_out"][:, 8:12])
+    np.testing.assert_array_equal(sharded["layer.0.w_out"], weights["layer.0.w_out"][8:12, :])
+    assert sharded["_d_inner"] == 4
+
+
+def test_mamba_tp_validation_rejects_non_divisible_inner_dim():
+    with pytest.raises(ValueError, match="d_inner divisible"):
+        tp_builder._validate_mamba_tp(
+            _weights(d_inner=18), ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0))
+
+
+def test_mamba_tp_validation_requires_concrete_rank():
+    with pytest.raises(ValueError, match="concrete rank"):
+        tp_builder._validate_mamba_tp(
+            _weights(), ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1))
+
+
+def test_mamba_plugin_routes_parallel_builds(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"mamba-tp-plan"
+
+    monkeypatch.setattr(
+        mamba_plugin_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(tp_builder, "build_mamba_tp_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1)
+    result = mamba_plugin_module.MambaPlugin().build_engine(
+        _config(), _weights(), 17,
+        verbose=True,
+        debug_layer_outputs=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"mamba-tp-plan"
+    assert calls["require"][0] == parallel
+    assert "Mamba tensor-parallel" in calls["require"][1]
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 17
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["verbose"] is True
+    assert kwargs["debug_layer_outputs"] is True

--- a/tests/e2e/models/mamba-130m-tp4.json
+++ b/tests/e2e/models/mamba-130m-tp4.json
@@ -1,0 +1,56 @@
+{
+  "name": "mamba-130m-tp4",
+  "trace_id": "IT-E2E-MAMBA-TP4-01",
+  "hf_id": "state-spaces/mamba-130m-hf",
+  "bundle": "mamba-130m-tp4.trtfb",
+  "family": "mamba",
+  "runtime_strategy": "ssm_recurrent",
+  "max_cache_length": 256,
+  "prompt": "The capital of France is",
+  "max_new_tokens": 20,
+  "logit_atol": 0.002,
+  "layer_atol": 0.05,
+  "trust_remote_code": false,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "Mamba-130M TP4 repro using the same checkpoint, prompt, generation length, and thresholds as mamba-130m."
+}


### PR DESCRIPTION
## Background
Mamba only had a single-device recurrent SSM path. This adds the tensor-parallel path needed for Mamba-130M TP4 while keeping the E2E threshold aligned with the existing single-device manifest.

## Exit Criteria
- Build a rank-local Mamba TensorRT engine for each TP rank.
- Load rank-specific recurrent engine sections at runtime with a distributed communicator.
- Add and pass a Mamba-130M TP4 E2E test without relaxing the single-device logit or layer thresholds.

## Implementation
- Added a Mamba TP builder that shards the `d_inner` dimension, keeps per-rank conv/SSM state local, and all-reduces the input-dependent `dt/B/C` projections and row-parallel output projection.
- Routed parallel Mamba builds through the TP builder with TensorRT 11 gating.
- Updated the recurrent SSM runtime and debug runner to select `engine_plan_tp_rank*` sections and size recurrent state buffers from the rank-local engine bindings.
- Added focused builder/debug-runner tests and `mamba-130m-tp4.json` using the same checkpoint, prompt, generation length, `logit_atol`, and `layer_atol` as `mamba-130m`.

## Validation
- `PYTHONPATH=python:. python -m pytest -q tests/builder/test_engine_mamba_tp.py tests/builder/test_manifest_validation.py tests/builder/test_debug_runner.py`: passed, 53 tests.
- `python -m pip install --disable-pip-version-check --quiet ruff clang-format && ruff check --config ruff.toml python/tensorrt_model_connect/debug_runner.py python/tensorrt_model_connect/families/mamba/plugin.py python/tensorrt_model_connect/families/mamba/tp_builder.py tests/builder/test_engine_mamba_tp.py tests/builder/test_debug_runner.py && clang-format --dry-run --Werror src/runtime/models/recurrent/ssm_plugin.cpp`: passed.
- `cmake -S . -B build-mamba-e2e -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so && cmake --build build-mamba-e2e --target trtmc trtmc_backend_trt -j`: passed.
- `PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py --multi-device-only -k "mamba-130m-tp4" --trtmc-binary ./build-mamba-e2e/trtmc --engine-dir /trtmc-local-storage/engines-mamba-tp4-final --e2e-artifacts-dir /trtmc-local-storage/e2e-mamba-tp4-final --hf-python /opt/venv/bin/python -s`: passed, 1 test selected.
- `git diff --check`: passed.

## Notes For Future Readers
- Review the TP builder first, then the recurrent runtime changes. The debug runner changes are only there to mirror the runtime section and communicator behavior during E2E.
- The E2E run used `/tmp`-backed storage mounted at `/trtmc-local-storage` to avoid the shared scratch quota.
