### PR TITLE
feat(rwkv): add recurrent tp4 support

### DIFF
--- a/python/tensorrt_model_connect/debug_runner.py
+++ b/python/tensorrt_model_connect/debug_runner.py
@@ -1027,9 +1027,15 @@ class RwkvTrtRunner:
     Only transfers token_id (H2D) and logits (D2H) per step.
     """
 
-    def __init__(self, engine_plan: bytes, num_layers: int):
+    def __init__(
+        self,
+        engine_plan: bytes,
+        num_layers: int,
+        distributed_communicator: object | None = None,
+    ):
         _require_trt_runtime()
         self.num_layers = num_layers
+        self._distributed_communicator = distributed_communicator
 
         logger = trt.Logger(trt.Logger.WARNING)
         runtime = trt.Runtime(logger)
@@ -1037,6 +1043,15 @@ class RwkvTrtRunner:
         if self.engine is None:
             raise RuntimeError("Failed to deserialize TRT engine")
         self.context = self.engine.create_execution_context()
+        if distributed_communicator is not None:
+            set_communicator = getattr(self.context, "set_communicator", None)
+            if set_communicator is None:
+                raise RuntimeError(
+                    "TensorRT distributed execution requires TRT 11.0+ "
+                    "IExecutionContext.set_communicator"
+                )
+            if not set_communicator(distributed_communicator):
+                raise RuntimeError("Failed to set TRT distributed communicator")
 
         # Auto-detect hidden_size from attn_state_0 shape [1, hidden]
         state_shape = tuple(self.engine.get_tensor_shape("attn_state_0"))
@@ -2281,14 +2296,10 @@ def runner_from_bundle(
             num_layers=num_layers,
         )
     if runtime_strategy == "rwkv_recurrent":
-        if distributed_communicator is not None or engine_section != "engine_plan":
-            raise ValueError(
-                "Distributed engine section selection is only supported for "
-                "standard decoder runners"
-            )
         return RwkvTrtRunner(
             engine_plan=engine_plan,
             num_layers=num_layers,
+            distributed_communicator=distributed_communicator,
         )
     if tri_cfg.get("enabled") and runtime_strategy in ("decoder_kv_cache", "decoder_moe"):
         tri_stats = load_triattention_stats_from_bundle(

--- a/python/tensorrt_model_connect/families/rwkv/plugin.py
+++ b/python/tensorrt_model_connect/families/rwkv/plugin.py
@@ -59,6 +59,10 @@ from ...checkpoint_mapper import (
     _transpose_2d,
 )
 from ... import graph_ops
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 
 
 trt = trt_compat.get_trt()
@@ -212,6 +216,7 @@ class RwkvPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
         debug_layer_outputs: bool = False,
+        parallel_config=None,
     ) -> bytes:
         """Build TRT engine for RWKV linear attention.
 
@@ -234,6 +239,21 @@ class RwkvPlugin:
           present_den_0..N: float32 [1, hidden_size]
           present_max_0..N: float32 [1, hidden_size]
         """
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="RWKV tensor-parallel builds")
+            from .tp_builder import build_rwkv_tp_engine
+
+            return build_rwkv_tp_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                parallel_config=parallel,
+            )
+
         hidden = config.hidden_size
         vocab = config.vocab_size
         num_layers = config.num_hidden_layers

--- a/python/tensorrt_model_connect/families/rwkv/tp_builder.py
+++ b/python/tensorrt_model_connect/families/rwkv/tp_builder.py
@@ -1,0 +1,409 @@
+"""Tensor-parallel RWKV recurrent builder."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+from .plugin import _mark_debug_output
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_rwkv_tp(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("RWKV tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    hidden = int(config.hidden_size)
+    intermediate = int(weights.get("_intermediate_size", config.intermediate_size))
+    if hidden % tp != 0:
+        raise ValueError(
+            "RWKV tensor parallel requires hidden_size divisible by tp_size "
+            f"({hidden} vs {tp})")
+    if intermediate % tp != 0:
+        raise ValueError(
+            "RWKV tensor parallel requires intermediate_size divisible by tp_size "
+            f"({intermediate} vs {tp})")
+
+    for layer_idx in range(int(config.num_hidden_layers)):
+        prefix = f"layer.{layer_idx}"
+        for key in (
+            f"{prefix}.time_decay",
+            f"{prefix}.time_first",
+            f"{prefix}.w_attn_k",
+            f"{prefix}.w_attn_v",
+            f"{prefix}.w_attn_r",
+            f"{prefix}.w_ffn_k",
+        ):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim is not divisible by tp_size={tp}")
+        for key in (f"{prefix}.w_attn_o", f"{prefix}.w_ffn_v"):
+            if weights[key].shape[0] % tp != 0:
+                raise ValueError(f"{key} input dim is not divisible by tp_size={tp}")
+
+
+def shard_rwkv_weights(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local RWKV weights for the TP builder."""
+    _validate_rwkv_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    rank = parallel.rank
+    tp = parallel.tp_size
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+        if key.endswith((
+            ".time_decay",
+            ".time_first",
+            ".w_attn_k",
+            ".w_attn_v",
+            ".w_attn_r",
+            ".w_ffn_k",
+        )):
+            out[key] = _slice_last_dim(value, rank, tp)
+        elif key.endswith((".w_attn_o", ".w_ffn_v")):
+            out[key] = _slice_first_dim(value, rank, tp)
+        else:
+            out[key] = value
+
+    out["_intermediate_size"] = int(weights["_intermediate_size"]) // tp
+    out["_tensor_parallel_size"] = tp
+    out["_tensor_parallel_rank"] = rank
+    return out
+
+
+def _add_rwkv_tp_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    attn_state_in: trt.ITensor,
+    ff_state_in: trt.ITensor,
+    num_state_in: trt.ITensor,
+    den_state_in: trt.ITensor,
+    max_state_in: trt.ITensor,
+    eps_tensor: trt.ITensor,
+    one_const: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    local_hidden: int,
+    local_intermediate: int,
+    tp_size: int,
+) -> dict[str, trt.ITensor]:
+    normed_attn = graph_ops.add_layer_norm(
+        network, hidden, hidden_size,
+        weights[f"{prefix}.attn_norm"],
+        weights[f"{prefix}.attn_norm_beta"],
+        eps_tensor)
+    present_attn = normed_attn
+
+    def _time_shift_blend(normed, prev_state, mix_weights_key):
+        mix = graph_ops.add_constant(
+            network, (1, hidden_size), weights[mix_weights_key])
+        one_minus_mix = network.add_elementwise(
+            one_const, mix, trt.ElementWiseOperation.SUB)
+        cur_part = network.add_elementwise(
+            normed, mix, trt.ElementWiseOperation.PROD)
+        prev_part = network.add_elementwise(
+            prev_state, one_minus_mix.get_output(0),
+            trt.ElementWiseOperation.PROD)
+        blended = network.add_elementwise(
+            cur_part.get_output(0), prev_part.get_output(0),
+            trt.ElementWiseOperation.SUM)
+        return blended.get_output(0)
+
+    xk = _time_shift_blend(
+        normed_attn, attn_state_in, f"{prefix}.time_mix_key")
+    xv = _time_shift_blend(
+        normed_attn, attn_state_in, f"{prefix}.time_mix_value")
+    xr = _time_shift_blend(
+        normed_attn, attn_state_in, f"{prefix}.time_mix_receptance")
+
+    r_proj = graph_ops.add_matmul_rhs_constant(
+        network, xr, hidden_size, local_hidden, weights[f"{prefix}.w_attn_r"])
+    r_gate = network.add_activation(r_proj, trt.ActivationType.SIGMOID)
+    k_proj = graph_ops.add_matmul_rhs_constant(
+        network, xk, hidden_size, local_hidden, weights[f"{prefix}.w_attn_k"])
+    v_proj = graph_ops.add_matmul_rhs_constant(
+        network, xv, hidden_size, local_hidden, weights[f"{prefix}.w_attn_v"])
+
+    time_decay = graph_ops.add_constant(
+        network, (1, local_hidden), weights[f"{prefix}.time_decay"])
+    time_first = graph_ops.add_constant(
+        network, (1, local_hidden), weights[f"{prefix}.time_first"])
+
+    decay_plus_max = network.add_elementwise(
+        max_state_in, time_decay, trt.ElementWiseOperation.SUM)
+    tf_plus_k = network.add_elementwise(
+        time_first, k_proj, trt.ElementWiseOperation.SUM)
+
+    q_out = network.add_elementwise(
+        tf_plus_k.get_output(0), max_state_in, trt.ElementWiseOperation.MAX)
+    tf_k_minus_q = network.add_elementwise(
+        tf_plus_k.get_output(0), q_out.get_output(0), trt.ElementWiseOperation.SUB)
+    exp_tf_k = network.add_unary(
+        tf_k_minus_q.get_output(0), trt.UnaryOperation.EXP)
+    ms_minus_q = network.add_elementwise(
+        max_state_in, q_out.get_output(0), trt.ElementWiseOperation.SUB)
+    exp_dpm = network.add_unary(
+        ms_minus_q.get_output(0), trt.UnaryOperation.EXP)
+
+    term1_num = network.add_elementwise(
+        exp_tf_k.get_output(0), v_proj, trt.ElementWiseOperation.PROD)
+    term2_num = network.add_elementwise(
+        exp_dpm.get_output(0), num_state_in, trt.ElementWiseOperation.PROD)
+    wkv_num = network.add_elementwise(
+        term1_num.get_output(0), term2_num.get_output(0), trt.ElementWiseOperation.SUM)
+
+    term2_den = network.add_elementwise(
+        exp_dpm.get_output(0), den_state_in, trt.ElementWiseOperation.PROD)
+    wkv_den = network.add_elementwise(
+        exp_tf_k.get_output(0), term2_den.get_output(0), trt.ElementWiseOperation.SUM)
+    wkv = network.add_elementwise(
+        wkv_num.get_output(0), wkv_den.get_output(0), trt.ElementWiseOperation.DIV)
+
+    q2 = network.add_elementwise(
+        k_proj, decay_plus_max.get_output(0), trt.ElementWiseOperation.MAX)
+    k_minus_q2 = network.add_elementwise(
+        k_proj, q2.get_output(0), trt.ElementWiseOperation.SUB)
+    exp_k_q2 = network.add_unary(
+        k_minus_q2.get_output(0), trt.UnaryOperation.EXP)
+    dpm_minus_q2 = network.add_elementwise(
+        decay_plus_max.get_output(0), q2.get_output(0), trt.ElementWiseOperation.SUB)
+    exp_dpm_q2 = network.add_unary(
+        dpm_minus_q2.get_output(0), trt.UnaryOperation.EXP)
+
+    st_term1 = network.add_elementwise(
+        exp_k_q2.get_output(0), v_proj, trt.ElementWiseOperation.PROD)
+    st_term2 = network.add_elementwise(
+        exp_dpm_q2.get_output(0), num_state_in, trt.ElementWiseOperation.PROD)
+    present_num = network.add_elementwise(
+        st_term1.get_output(0), st_term2.get_output(0), trt.ElementWiseOperation.SUM)
+    st_den_term2 = network.add_elementwise(
+        exp_dpm_q2.get_output(0), den_state_in, trt.ElementWiseOperation.PROD)
+    present_den = network.add_elementwise(
+        exp_k_q2.get_output(0), st_den_term2.get_output(0), trt.ElementWiseOperation.SUM)
+    present_max = q2.get_output(0)
+
+    gated = network.add_elementwise(
+        r_gate.get_output(0), wkv.get_output(0), trt.ElementWiseOperation.PROD)
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, gated.get_output(0), local_hidden, hidden_size,
+        weights[f"{prefix}.w_attn_o"])
+    attn_out = add_all_reduce_sum(network, attn_out, tp_size)
+    residual_attn = network.add_elementwise(
+        hidden, attn_out, trt.ElementWiseOperation.SUM)
+    hidden_after_attn = residual_attn.get_output(0)
+
+    normed_ffn = graph_ops.add_layer_norm(
+        network, hidden_after_attn, hidden_size,
+        weights[f"{prefix}.ffn_norm"],
+        weights[f"{prefix}.ffn_norm_beta"],
+        eps_tensor)
+    present_ff = normed_ffn
+
+    xk_ffn = _time_shift_blend(
+        normed_ffn, ff_state_in, f"{prefix}.time_mix_ffn_key")
+    xr_ffn = _time_shift_blend(
+        normed_ffn, ff_state_in, f"{prefix}.time_mix_ffn_receptance")
+
+    k_ffn = graph_ops.add_matmul_rhs_constant(
+        network, xk_ffn, hidden_size, local_intermediate,
+        weights[f"{prefix}.w_ffn_k"])
+    k_activated = graph_ops.add_activation(network, k_ffn, "squared_relu")
+    r_ffn = graph_ops.add_matmul_rhs_constant(
+        network, xr_ffn, hidden_size, hidden_size, weights[f"{prefix}.w_ffn_r"])
+    r_ffn_gate = network.add_activation(r_ffn, trt.ActivationType.SIGMOID)
+    kv_ffn = graph_ops.add_matmul_rhs_constant(
+        network, k_activated, local_intermediate, hidden_size,
+        weights[f"{prefix}.w_ffn_v"])
+    kv_ffn = add_all_reduce_sum(network, kv_ffn, tp_size)
+    gated_ffn = network.add_elementwise(
+        r_ffn_gate.get_output(0), kv_ffn, trt.ElementWiseOperation.PROD)
+    residual_ffn = network.add_elementwise(
+        hidden_after_attn, gated_ffn.get_output(0), trt.ElementWiseOperation.SUM)
+
+    return {
+        "hidden": residual_ffn.get_output(0),
+        "present_attn": present_attn,
+        "present_ff": present_ff,
+        "present_num": present_num.get_output(0),
+        "present_den": present_den.get_output(0),
+        "present_max": present_max,
+    }
+
+
+def build_rwkv_tp_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    parallel_config=None,
+) -> bytes:
+    del max_cache_length, precision, quant_ctx
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError("build_rwkv_tp_engine requires tensor_parallel mode with tp_size > 1")
+
+    rank_weights = shard_rwkv_weights(config, weights, parallel=parallel)
+    hidden = int(config.hidden_size)
+    vocab = int(config.vocab_size)
+    num_layers = int(config.num_hidden_layers)
+    local_hidden = hidden // parallel.tp_size
+    local_intermediate = int(rank_weights["_intermediate_size"])
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    attn_state_inputs = []
+    ff_state_inputs = []
+    num_state_inputs = []
+    den_state_inputs = []
+    max_state_inputs = []
+    for layer_idx in range(num_layers):
+        attn_state_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("attn_state", layer_idx),
+            trt.float32, (1, hidden)))
+        ff_state_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("ff_state", layer_idx),
+            trt.float32, (1, hidden)))
+        num_state_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("num_state", layer_idx),
+            trt.float32, (1, local_hidden)))
+        den_state_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("den_state", layer_idx),
+            trt.float32, (1, local_hidden)))
+        max_state_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("max_state", layer_idx),
+            trt.float32, (1, local_hidden)))
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), rank_weights["embedding"])
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=np.float32))
+    one_const = graph_ops.add_constant(
+        network, (1, 1), np.array([1.0], dtype=np.float32))
+
+    hidden_state = network.add_gather(embedding_table, token_id, 0).get_output(0)
+    if "pre_ln_weight" in rank_weights:
+        hidden_state = graph_ops.add_layer_norm(
+            network, hidden_state, hidden,
+            rank_weights["pre_ln_weight"],
+            rank_weights["pre_ln_bias"],
+            eps_tensor)
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    present_attn_outputs = []
+    present_ff_outputs = []
+    present_num_outputs = []
+    present_den_outputs = []
+    present_max_outputs = []
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        result = _add_rwkv_tp_layer(
+            network=network,
+            hidden=hidden_state,
+            attn_state_in=attn_state_inputs[layer_idx],
+            ff_state_in=ff_state_inputs[layer_idx],
+            num_state_in=num_state_inputs[layer_idx],
+            den_state_in=den_state_inputs[layer_idx],
+            max_state_in=max_state_inputs[layer_idx],
+            eps_tensor=eps_tensor,
+            one_const=one_const,
+            weights=rank_weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            local_hidden=local_hidden,
+            local_intermediate=local_intermediate,
+            tp_size=parallel.tp_size,
+        )
+        hidden_state = result["hidden"]
+        present_attn_outputs.append(result["present_attn"])
+        present_ff_outputs.append(result["present_ff"])
+        present_num_outputs.append(result["present_num"])
+        present_den_outputs.append(result["present_den"])
+        present_max_outputs.append(result["present_max"])
+        if debug_layer_outputs:
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    hidden_state = graph_ops.add_layer_norm(
+        network, hidden_state, hidden,
+        rank_weights["final_norm"], rank_weights["final_norm_beta"], eps_tensor)
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, vocab, rank_weights["w_lm_head"])
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for layer_idx in range(num_layers):
+        present_attn_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_attn", layer_idx)
+        present_ff_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_ff", layer_idx)
+        present_num_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_num", layer_idx)
+        present_den_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_den", layer_idx)
+        present_max_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_max", layer_idx)
+        network.mark_output(present_attn_outputs[layer_idx])
+        network.mark_output(present_ff_outputs[layer_idx])
+        network.mark_output(present_num_outputs[layer_idx])
+        network.mark_output(present_den_outputs[layer_idx])
+        network.mark_output(present_max_outputs[layer_idx])
+
+    if verbose:
+        print(
+            "[trtmc build] RWKV TP engine "
+            f"(rank={parallel.rank}/{parallel.tp_size}, {num_layers}L, "
+            f"h={hidden}, local_h={local_hidden}, local_i={local_intermediate})",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT RWKV TP engine build failed")
+    return bytes(plan)

--- a/src/runtime/models/recurrent/rwkv_plugin.cpp
+++ b/src/runtime/models/recurrent/rwkv_plugin.cpp
@@ -3,21 +3,64 @@
 
 #include "runtime/models/recurrent/pipeline.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
+#include "utils/json_helpers.h"
+
+#include <cstdint>
+#include <string>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+struct TensorParallelRuntime {
+    TensorParallelRuntimeConfig config;
+    DistributedRuntimeGroup group;
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+} // namespace
 
 class RwkvPlugin final : public IPipelinePlugin {
   public:
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
         load_ffi_kernels_from_bundle(ctx.bundle);
 
+        TensorParallelRuntime tp_runtime;
+        tp_runtime.config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        if (tp_runtime.config.enabled)
+            tp_runtime.group = initialize_tensor_parallel_group(tp_runtime.config.tp_size);
+
         ModuleCreateOptions opts;
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
+        if (tp_runtime.config.enabled) {
+            opts.distributed_communicator = tp_runtime.group.communicator;
+            opts.distributed_owner = tp_runtime.group.owner;
+        }
 
+        const std::string engine_section = tp_runtime.config.enabled
+                                               ? tp_engine_section_name(tp_runtime.group.rank)
+                                               : std::string("engine_plan");
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "engine_plan", opts);
+            ctx.backend, find_section(ctx.bundle, engine_section), engine_section.c_str(), opts);
         auto tokenizer = create_tokenizer_from_bundle(ctx.bundle);
 
         cudaStream_t stream = loaded.module->stream();

--- a/tests/builder/test_debug_runner.py
+++ b/tests/builder/test_debug_runner.py
@@ -248,6 +248,36 @@ class TestRunnerFromBundle:
         assert kwargs["engine_plan"] == b"RANK1_ENGINE"
         assert kwargs["distributed_communicator"] is communicator
 
+    def test_rwkv_engine_section_and_communicator_forwarded(self, tmp_path):
+        from tensorrt_model_connect.debug_runner import runner_from_bundle
+
+        config_data = json.dumps({"runtime_strategy": "rwkv_recurrent"}).encode("utf-8")
+        bundle = _make_bundle_bytes(
+            {"num_layers": 2, "max_cache_length": 128},
+            engine_plan=b"SINGLE_ENGINE",
+            extra_sections={
+                "config.json": config_data,
+                "engine_plan_tp_rank1": b"RWKV_RANK1_ENGINE",
+            },
+        )
+
+        path = tmp_path / "rwkv_tp_dispatch.trtfb"
+        path.write_bytes(bundle)
+
+        communicator = object()
+        with patch("tensorrt_model_connect.debug_runner.RwkvTrtRunner",
+                   return_value="rwkv-tp-runner") as mock_runner:
+            runner = runner_from_bundle(
+                str(path),
+                engine_section="engine_plan_tp_rank1",
+                distributed_communicator=communicator,
+            )
+
+        assert runner == "rwkv-tp-runner"
+        kwargs = mock_runner.call_args.kwargs
+        assert kwargs["engine_plan"] == b"RWKV_RANK1_ENGINE"
+        assert kwargs["distributed_communicator"] is communicator
+
     def test_mpi_rank_info_uses_single_node_rank(self, monkeypatch):
         from tensorrt_model_connect.debug_runner import _mpi_rank_info_from_env
 

--- a/tests/builder/test_engine_rwkv_tp.py
+++ b/tests/builder/test_engine_rwkv_tp.py
@@ -1,0 +1,128 @@
+"""Focused tests for RWKV tensor-parallel support."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+try:
+    rwkv_plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.rwkv.plugin")
+    from tensorrt_model_connect.families.rwkv import tp_builder
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _config(hidden: int = 8, intermediate: int = 16) -> SimpleNamespace:
+    return SimpleNamespace(
+        raw={},
+        hidden_size=hidden,
+        vocab_size=32,
+        num_hidden_layers=1,
+        intermediate_size=intermediate,
+        rms_norm_eps=1e-5,
+    )
+
+
+def _weights(hidden: int = 8, intermediate: int = 16) -> dict:
+    weights: dict[str, object] = {
+        "_intermediate_size": intermediate,
+        "embedding": np.zeros((32, hidden), dtype=np.float32),
+        "final_norm": np.ones((hidden,), dtype=np.float32),
+        "final_norm_beta": np.zeros((hidden,), dtype=np.float32),
+        "w_lm_head": np.zeros((hidden, 32), dtype=np.float32),
+    }
+    prefix = "layer.0"
+    weights[f"{prefix}.attn_norm"] = np.ones((hidden,), dtype=np.float32)
+    weights[f"{prefix}.attn_norm_beta"] = np.zeros((hidden,), dtype=np.float32)
+    weights[f"{prefix}.ffn_norm"] = np.ones((hidden,), dtype=np.float32)
+    weights[f"{prefix}.ffn_norm_beta"] = np.zeros((hidden,), dtype=np.float32)
+    weights[f"{prefix}.time_decay"] = np.zeros((hidden,), dtype=np.float32)
+    weights[f"{prefix}.time_first"] = np.zeros((hidden,), dtype=np.float32)
+    weights[f"{prefix}.time_mix_key"] = np.zeros((hidden,), dtype=np.float32)
+    weights[f"{prefix}.time_mix_value"] = np.zeros((hidden,), dtype=np.float32)
+    weights[f"{prefix}.time_mix_receptance"] = np.zeros((hidden,), dtype=np.float32)
+    weights[f"{prefix}.w_attn_k"] = np.zeros((hidden, hidden), dtype=np.float32)
+    weights[f"{prefix}.w_attn_v"] = np.zeros((hidden, hidden), dtype=np.float32)
+    weights[f"{prefix}.w_attn_r"] = np.zeros((hidden, hidden), dtype=np.float32)
+    weights[f"{prefix}.w_attn_o"] = np.zeros((hidden, hidden), dtype=np.float32)
+    weights[f"{prefix}.time_mix_ffn_key"] = np.zeros((hidden,), dtype=np.float32)
+    weights[f"{prefix}.time_mix_ffn_receptance"] = np.zeros((hidden,), dtype=np.float32)
+    weights[f"{prefix}.w_ffn_k"] = np.zeros((hidden, intermediate), dtype=np.float32)
+    weights[f"{prefix}.w_ffn_v"] = np.zeros((intermediate, hidden), dtype=np.float32)
+    weights[f"{prefix}.w_ffn_r"] = np.zeros((hidden, hidden), dtype=np.float32)
+    return weights
+
+
+def test_rwkv_tp_slices_hidden_and_intermediate_weights():
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+    config = _config()
+    weights = _weights()
+    weights["layer.0.time_decay"] = np.arange(8, dtype=np.float32)
+    weights["layer.0.w_attn_k"] = np.arange(8 * 8, dtype=np.float32).reshape(8, 8)
+    weights["layer.0.w_attn_o"] = np.arange(8 * 8, dtype=np.float32).reshape(8, 8)
+    weights["layer.0.w_ffn_k"] = np.arange(8 * 16, dtype=np.float32).reshape(8, 16)
+    weights["layer.0.w_ffn_v"] = np.arange(16 * 8, dtype=np.float32).reshape(16, 8)
+
+    sharded = tp_builder.shard_rwkv_weights(config, weights, parallel=parallel)
+
+    np.testing.assert_array_equal(sharded["layer.0.time_decay"], weights["layer.0.time_decay"][4:6])
+    np.testing.assert_array_equal(sharded["layer.0.w_attn_k"], weights["layer.0.w_attn_k"][:, 4:6])
+    np.testing.assert_array_equal(sharded["layer.0.w_attn_o"], weights["layer.0.w_attn_o"][4:6, :])
+    np.testing.assert_array_equal(sharded["layer.0.w_ffn_k"], weights["layer.0.w_ffn_k"][:, 8:12])
+    np.testing.assert_array_equal(sharded["layer.0.w_ffn_v"], weights["layer.0.w_ffn_v"][8:12, :])
+    assert sharded["_intermediate_size"] == 4
+
+
+def test_rwkv_tp_validation_rejects_non_divisible_hidden_dim():
+    with pytest.raises(ValueError, match="hidden_size divisible"):
+        tp_builder._validate_rwkv_tp(
+            _config(hidden=10),
+            _weights(hidden=10),
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )
+
+
+def test_rwkv_tp_validation_requires_concrete_rank():
+    with pytest.raises(ValueError, match="concrete rank"):
+        tp_builder._validate_rwkv_tp(
+            _config(),
+            _weights(),
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1),
+        )
+
+
+def test_rwkv_plugin_routes_parallel_builds(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"rwkv-tp-plan"
+
+    monkeypatch.setattr(
+        rwkv_plugin_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(tp_builder, "build_rwkv_tp_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1)
+    result = rwkv_plugin_module.RwkvPlugin().build_engine(
+        _config(), _weights(), 17,
+        verbose=True,
+        debug_layer_outputs=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"rwkv-tp-plan"
+    assert calls["require"][0] == parallel
+    assert "RWKV tensor-parallel" in calls["require"][1]
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 17
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["verbose"] is True
+    assert kwargs["debug_layer_outputs"] is True

--- a/tests/e2e/models/rwkv-169m-tp4.json
+++ b/tests/e2e/models/rwkv-169m-tp4.json
@@ -1,0 +1,56 @@
+{
+  "name": "rwkv-169m-tp4",
+  "trace_id": "IT-E2E-RWKV-TP4-01",
+  "hf_id": "RWKV/rwkv-4-169m-pile",
+  "bundle": "rwkv-169m-tp4.trtfb",
+  "family": "rwkv",
+  "runtime_strategy": "rwkv_recurrent",
+  "max_cache_length": 32,
+  "prompt": "The capital of France is",
+  "max_new_tokens": 10,
+  "logit_atol": 0.002,
+  "layer_atol": 0.05,
+  "trust_remote_code": false,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "RWKV-169M TP4 repro using the same checkpoint, prompt, generation length, and thresholds as rwkv-169m."
+}


### PR DESCRIPTION
## Background
RWKV only had a single-device recurrent runtime path. This adds the tensor-parallel path needed for RWKV-169M TP4 while keeping the E2E thresholds aligned with the existing single-device manifest.

## Exit Criteria
- Build a rank-local RWKV TensorRT engine for each TP rank.
- Load rank-specific recurrent engine sections at runtime with a distributed communicator.
- Add and pass a RWKV-169M TP4 E2E test without relaxing the single-device logit or layer thresholds.

## Implementation
- Added a RWKV TP builder that shards the hidden WKV lanes and FFN intermediate work, keeps embeddings/norms/LM head replicated, and all-reduces row-parallel attention/FFN outputs back to full hidden state.
- Routed parallel RWKV builds through the TP builder with TensorRT 11 gating.
- Updated the RWKV recurrent runtime and debug runner to select `engine_plan_tp_rank*` sections and pass TensorRT distributed communicators.
- Added focused builder/debug-runner tests and `rwkv-169m-tp4.json` using the same checkpoint, prompt, generation length, `logit_atol`, and `layer_atol` as `rwkv-169m`.

## Validation
- `PYTHONPATH=python:. python -m pytest -q tests/builder/test_engine_rwkv_tp.py tests/builder/test_manifest_validation.py tests/builder/test_debug_runner.py`: passed, 53 tests.
- `python -m pip install --disable-pip-version-check --quiet ruff clang-format && ruff check --config ruff.toml python/tensorrt_model_connect/debug_runner.py python/tensorrt_model_connect/families/rwkv/plugin.py python/tensorrt_model_connect/families/rwkv/tp_builder.py tests/builder/test_engine_rwkv_tp.py tests/builder/test_debug_runner.py && clang-format --dry-run --Werror src/runtime/models/recurrent/rwkv_plugin.cpp`: passed.
- `cmake -S . -B build-rwkv-e2e -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so && cmake --build build-rwkv-e2e --target trtmc trtmc_backend_trt -j`: passed after fixing the section-label type.
- `PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py --multi-device-only -k "rwkv-169m-tp4" --trtmc-binary ./build-rwkv-e2e/trtmc --engine-dir /trtmc-local-storage/engines-rwkv-tp4 --e2e-artifacts-dir /trtmc-local-storage/e2e-rwkv-tp4 --hf-python /opt/venv/bin/python -s`: passed, 1 test selected.
- `git diff --check`: passed.

## Notes For Future Readers
- Review the TP builder first, then the RWKV runtime section selection. The debug-runner change mirrors runtime rank-section and communicator behavior for E2E logit comparison.
- The E2E run used `/tmp`-backed storage mounted at `/trtmc-local-storage` to avoid the shared scratch quota.
