### PR TITLE
feat(nemotron-h): add nano tp4 support

### DIFF
--- a/python/tensorrt_model_connect/debug_runner.py
+++ b/python/tensorrt_model_connect/debug_runner.py
@@ -1441,11 +1441,13 @@ class HybridTrtRunner:
         max_cache_length: int,
         num_mamba_layers: int,
         num_attention_layers: int,
+        distributed_communicator: object | None = None,
     ):
         _require_trt_runtime()
         self.max_cache_length = max_cache_length
         self.num_mamba_layers = num_mamba_layers
         self.num_attention_layers = num_attention_layers
+        self._distributed_communicator = distributed_communicator
 
         # Deserialize engine
         logger = trt.Logger(trt.Logger.WARNING)
@@ -1454,6 +1456,15 @@ class HybridTrtRunner:
         if self.engine is None:
             raise RuntimeError("Failed to deserialize TRT engine")
         self.context = self.engine.create_execution_context()
+        if distributed_communicator is not None:
+            set_communicator = getattr(self.context, "set_communicator", None)
+            if set_communicator is None:
+                raise RuntimeError(
+                    "TensorRT distributed execution requires TRT 11.0+ "
+                    "IExecutionContext.set_communicator"
+                )
+            if not set_communicator(distributed_communicator):
+                raise RuntimeError("Failed to set TRT distributed communicator")
 
         # Auto-detect state dimensions from engine tensor shapes
         if num_mamba_layers > 0:
@@ -2257,11 +2268,6 @@ def runner_from_bundle(
             )
 
     if runtime_strategy == "hybrid_mamba_attention":
-        if distributed_communicator is not None or engine_section != "engine_plan":
-            raise ValueError(
-                "Distributed engine section selection is only supported for "
-                "standard decoder runners"
-            )
         num_mamba = config.get("num_mamba_layers", 0)
         num_attn = config.get("num_attention_layers", 0)
         return HybridTrtRunner(
@@ -2269,6 +2275,7 @@ def runner_from_bundle(
             max_cache_length=header["max_cache_length"],
             num_mamba_layers=num_mamba,
             num_attention_layers=num_attn,
+            distributed_communicator=distributed_communicator,
         )
     if runtime_strategy == "ssm_recurrent":
         if distributed_communicator is not None or engine_section != "engine_plan":

--- a/python/tensorrt_model_connect/families/nemotron_h/plugin.py
+++ b/python/tensorrt_model_connect/families/nemotron_h/plugin.py
@@ -56,6 +56,10 @@ from ...checkpoint_mapper import (
 )
 from ... import graph_ops
 from ... import graph_blocks
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 
 
 trt = trt_compat.get_trt()
@@ -245,8 +249,24 @@ class NemotronHPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
         debug_layer_outputs: bool = False,
+        parallel_config=None,
     ) -> bytes:
         """Build hybrid TRT engine with heterogeneous layer stack."""
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="Nemotron-H tensor-parallel builds")
+            from .tp_builder import build_nemotron_h_tp_engine
+
+            return build_nemotron_h_tp_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                parallel_config=parallel,
+            )
+
         hidden = config.hidden_size
         vocab = config.vocab_size
         num_layers = config.num_hidden_layers

--- a/python/tensorrt_model_connect/families/nemotron_h/tp_builder.py
+++ b/python/tensorrt_model_connect/families/nemotron_h/tp_builder.py
@@ -1,0 +1,622 @@
+"""Tensor-parallel Nemotron-H hybrid builder."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_blocks, graph_ops
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+from .plugin import _mark_debug_output
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _take_last_dim_segments(arr: np.ndarray, segments: list[tuple[int, int]]) -> np.ndarray:
+    return np.ascontiguousarray(
+        np.concatenate([arr[..., start:end] for start, end in segments], axis=-1))
+
+
+def _take_first_dim_segments(arr: np.ndarray, segments: list[tuple[int, int]]) -> np.ndarray:
+    return np.ascontiguousarray(
+        np.concatenate([arr[start:end, ...] for start, end in segments], axis=0))
+
+
+def _mamba2_rank_dims(weights: "WeightDict", parallel: "ParallelConfig") -> dict[str, int]:
+    rank = parallel.rank
+    tp = parallel.tp_size
+    d_inner = int(weights["_d_inner"])
+    d_state = int(weights["_d_state"])
+    mamba_heads = int(weights["_mamba_num_heads"])
+    head_dim = int(weights["_mamba_head_dim"])
+    n_groups = int(weights["_n_groups"])
+    groups_state = n_groups * d_state
+    local_heads = mamba_heads // tp
+    local_groups = n_groups // tp
+    local_d_inner = local_heads * head_dim
+    local_groups_state = local_groups * d_state
+    local_conv_dim = local_d_inner + 2 * local_groups_state
+    return {
+        "rank": rank,
+        "tp": tp,
+        "d_inner": d_inner,
+        "d_state": d_state,
+        "mamba_heads": mamba_heads,
+        "head_dim": head_dim,
+        "n_groups": n_groups,
+        "groups_state": groups_state,
+        "local_heads": local_heads,
+        "local_groups": local_groups,
+        "local_d_inner": local_d_inner,
+        "local_groups_state": local_groups_state,
+        "local_conv_dim": local_conv_dim,
+        "inner_start": rank * local_d_inner,
+        "group_state_start": rank * local_groups_state,
+        "head_start": rank * local_heads,
+    }
+
+
+def _slice_mamba_in_proj(weight: np.ndarray, dims: dict[str, int]) -> np.ndarray:
+    d_inner = dims["d_inner"]
+    groups_state = dims["groups_state"]
+    conv_dim = int(d_inner + 2 * groups_state)
+    inner_start = dims["inner_start"]
+    local_d_inner = dims["local_d_inner"]
+    group_state_start = dims["group_state_start"]
+    local_groups_state = dims["local_groups_state"]
+    head_start = dims["head_start"]
+    local_heads = dims["local_heads"]
+    segments = [
+        (inner_start, inner_start + local_d_inner),
+        (d_inner + inner_start, d_inner + inner_start + local_d_inner),
+        (
+            d_inner + d_inner + group_state_start,
+            d_inner + d_inner + group_state_start + local_groups_state,
+        ),
+        (
+            d_inner + d_inner + groups_state + group_state_start,
+            d_inner + d_inner + groups_state + group_state_start + local_groups_state,
+        ),
+        (
+            d_inner + conv_dim + head_start,
+            d_inner + conv_dim + head_start + local_heads,
+        ),
+    ]
+    return _take_last_dim_segments(weight, segments)
+
+
+def _slice_conv_dim(value: np.ndarray, dims: dict[str, int]) -> np.ndarray:
+    d_inner = dims["d_inner"]
+    groups_state = dims["groups_state"]
+    inner_start = dims["inner_start"]
+    local_d_inner = dims["local_d_inner"]
+    group_state_start = dims["group_state_start"]
+    local_groups_state = dims["local_groups_state"]
+    segments = [
+        (inner_start, inner_start + local_d_inner),
+        (d_inner + group_state_start, d_inner + group_state_start + local_groups_state),
+        (
+            d_inner + groups_state + group_state_start,
+            d_inner + groups_state + group_state_start + local_groups_state,
+        ),
+    ]
+    return _take_first_dim_segments(value, segments)
+
+
+def _validate_nemotron_h_tp(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("Nemotron-H tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if int(config.num_attention_heads) % tp != 0:
+        raise ValueError(
+            "Nemotron-H tensor parallel requires num_attention_heads divisible by tp_size "
+            f"({config.num_attention_heads} vs {tp})")
+    if int(config.num_key_value_heads) % tp != 0:
+        raise ValueError(
+            "Nemotron-H tensor parallel requires num_key_value_heads divisible by tp_size "
+            f"({config.num_key_value_heads} vs {tp})")
+
+    for key in ("_d_inner", "_mamba_num_heads", "_n_groups", "_mlp_size"):
+        if int(weights[key]) % tp != 0:
+            raise ValueError(
+                f"Nemotron-H tensor parallel requires {key} divisible by tp_size "
+                f"({weights[key]} vs {tp})")
+
+
+def shard_nemotron_h_weights(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local Nemotron-H weights for the TP builder."""
+    _validate_nemotron_h_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    dims = _mamba2_rank_dims(weights, parallel)
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+        if key.endswith(".mamba_in_proj"):
+            out[key] = _slice_mamba_in_proj(value, dims)
+        elif key.endswith((".conv1d_weight", ".conv1d_bias")):
+            out[key] = _slice_conv_dim(value, dims)
+        elif key.endswith((".A", ".D", ".dt_bias")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".mamba_norm"):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".mamba_out_proj"):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".w_up"):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".w_down"):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_q", ".w_k", ".w_v")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".w_o"):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_d_inner"] = dims["local_d_inner"]
+    out["_conv_dim"] = dims["local_conv_dim"]
+    out["_mamba_num_heads"] = dims["local_heads"]
+    out["_n_groups"] = dims["local_groups"]
+    out["_attention_size"] = int(weights["_attention_size"]) // parallel.tp_size
+    out["_mlp_size"] = int(weights["_mlp_size"]) // parallel.tp_size
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def _add_mamba2_tp_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    conv_state_in: trt.ITensor,
+    ssm_state_in: trt.ITensor,
+    eps_tensor: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    d_inner: int,
+    d_state: int,
+    d_conv: int,
+    conv_dim: int,
+    mamba_num_heads: int,
+    mamba_head_dim: int,
+    n_groups: int,
+    tp_size: int,
+) -> dict[str, trt.ITensor]:
+    groups_state_size = n_groups * d_state
+
+    normed = graph_ops.add_rms_norm(
+        network, hidden, hidden_size, weights[f"{prefix}.input_norm"], eps_tensor)
+
+    proj_dim = d_inner + conv_dim + mamba_num_heads
+    projected = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, proj_dim, weights[f"{prefix}.mamba_in_proj"])
+
+    offset = 0
+    gate_slice = network.add_slice(
+        projected, start=(0, offset), shape=(1, d_inner), stride=(1, 1))
+    gate = gate_slice.get_output(0)
+    offset += d_inner
+
+    hbc_slice = network.add_slice(
+        projected, start=(0, offset), shape=(1, conv_dim), stride=(1, 1))
+    hidden_B_C = hbc_slice.get_output(0)
+    offset += conv_dim
+
+    dt_slice = network.add_slice(
+        projected, start=(0, offset), shape=(1, mamba_num_heads), stride=(1, 1))
+    dt_raw = dt_slice.get_output(0)
+
+    hbc_col = network.add_shuffle(hidden_B_C)
+    hbc_col.reshape_dims = (conv_dim, 1)
+    if d_conv > 1:
+        slice_layer = network.add_slice(
+            conv_state_in,
+            start=(0, 1),
+            shape=(conv_dim, d_conv - 1),
+            stride=(1, 1))
+        new_conv_state = network.add_concatenation(
+            [slice_layer.get_output(0), hbc_col.get_output(0)])
+        new_conv_state.axis = 1
+        present_conv = new_conv_state.get_output(0)
+    else:
+        present_conv = hbc_col.get_output(0)
+
+    conv_w = graph_ops.add_constant(
+        network, (conv_dim, d_conv), weights[f"{prefix}.conv1d_weight"])
+    conv_prod = network.add_elementwise(
+        present_conv, conv_w, trt.ElementWiseOperation.PROD)
+    conv_sum = network.add_reduce(
+        conv_prod.get_output(0), trt.ReduceOperation.SUM, 1 << 1, keep_dims=True)
+    conv_flat = network.add_shuffle(conv_sum.get_output(0))
+    conv_flat.reshape_dims = (1, conv_dim)
+    conv_out = graph_ops.add_bias_sum(
+        network, conv_flat.get_output(0), conv_dim, weights[f"{prefix}.conv1d_bias"])
+    hbc_activated = graph_ops.add_activation(network, conv_out, "silu")
+
+    hidden_x_slice = network.add_slice(
+        hbc_activated, start=(0, 0), shape=(1, d_inner), stride=(1, 1))
+    hidden_x = hidden_x_slice.get_output(0)
+    B_raw_slice = network.add_slice(
+        hbc_activated, start=(0, d_inner), shape=(1, groups_state_size), stride=(1, 1))
+    B_raw = B_raw_slice.get_output(0)
+    C_raw_slice = network.add_slice(
+        hbc_activated,
+        start=(0, d_inner + groups_state_size),
+        shape=(1, groups_state_size),
+        stride=(1, 1))
+    C_raw = C_raw_slice.get_output(0)
+
+    dt_bias_const = graph_ops.add_constant(
+        network, (1, mamba_num_heads), weights[f"{prefix}.dt_bias"])
+    dt_biased = network.add_elementwise(
+        dt_raw, dt_bias_const, trt.ElementWiseOperation.SUM)
+    dt_exp = network.add_unary(dt_biased.get_output(0), trt.UnaryOperation.EXP)
+    one = graph_ops.add_constant(
+        network, (1, 1), np.array([1.0], dtype=np.float32))
+    dt_exp_p1 = network.add_elementwise(
+        dt_exp.get_output(0), one, trt.ElementWiseOperation.SUM)
+    dt_softplus = network.add_unary(dt_exp_p1.get_output(0), trt.UnaryOperation.LOG)
+    dt = dt_softplus.get_output(0)
+
+    A_const = graph_ops.add_constant(
+        network, (mamba_num_heads, 1, 1),
+        weights[f"{prefix}.A"].reshape(mamba_num_heads, 1, 1))
+    dt_col = network.add_shuffle(dt)
+    dt_col.reshape_dims = (mamba_num_heads, 1, 1)
+    dtA = network.add_elementwise(
+        dt_col.get_output(0), A_const, trt.ElementWiseOperation.PROD)
+    dA = network.add_unary(dtA.get_output(0), trt.UnaryOperation.EXP)
+
+    B_grouped = network.add_shuffle(B_raw)
+    B_grouped.reshape_dims = (n_groups, d_state)
+    heads_per_group = mamba_num_heads // n_groups
+    if heads_per_group > 1:
+        B_3d = network.add_shuffle(B_grouped.get_output(0))
+        B_3d.reshape_dims = (n_groups, 1, d_state)
+        tile_ones = graph_ops.add_constant(
+            network, (1, heads_per_group, 1),
+            np.ones((1, heads_per_group, 1), dtype=np.float32))
+        B_tiled = network.add_elementwise(
+            B_3d.get_output(0), tile_ones, trt.ElementWiseOperation.PROD)
+        B_heads_s = network.add_shuffle(B_tiled.get_output(0))
+        B_heads_s.reshape_dims = (mamba_num_heads, d_state)
+        B_heads = B_heads_s.get_output(0)
+    else:
+        B_heads = B_grouped.get_output(0)
+
+    C_grouped = network.add_shuffle(C_raw)
+    C_grouped.reshape_dims = (n_groups, d_state)
+    if heads_per_group > 1:
+        C_3d = network.add_shuffle(C_grouped.get_output(0))
+        C_3d.reshape_dims = (n_groups, 1, d_state)
+        C_tiled = network.add_elementwise(
+            C_3d.get_output(0), tile_ones, trt.ElementWiseOperation.PROD)
+        C_heads_s = network.add_shuffle(C_tiled.get_output(0))
+        C_heads_s.reshape_dims = (mamba_num_heads, d_state)
+        C_heads = C_heads_s.get_output(0)
+    else:
+        C_heads = C_grouped.get_output(0)
+
+    x_heads = network.add_shuffle(hidden_x)
+    x_heads.reshape_dims = (mamba_num_heads, mamba_head_dim)
+    B_3d_expand = network.add_shuffle(B_heads)
+    B_3d_expand.reshape_dims = (mamba_num_heads, 1, d_state)
+    dt_B = network.add_elementwise(
+        dt_col.get_output(0), B_3d_expand.get_output(0), trt.ElementWiseOperation.PROD)
+    x_3d = network.add_shuffle(x_heads.get_output(0))
+    x_3d.reshape_dims = (mamba_num_heads, mamba_head_dim, 1)
+    dBx = network.add_elementwise(
+        x_3d.get_output(0), dt_B.get_output(0), trt.ElementWiseOperation.PROD)
+
+    decay = network.add_elementwise(
+        dA.get_output(0), ssm_state_in, trt.ElementWiseOperation.PROD)
+    new_ssm = network.add_elementwise(
+        decay.get_output(0), dBx.get_output(0), trt.ElementWiseOperation.SUM)
+    present_ssm = new_ssm.get_output(0)
+
+    C_col = network.add_shuffle(C_heads)
+    C_col.reshape_dims = (mamba_num_heads, d_state, 1)
+    y_matmul = network.add_matrix_multiply(
+        present_ssm, trt.MatrixOperation.NONE,
+        C_col.get_output(0), trt.MatrixOperation.NONE)
+    y_squeeze = network.add_shuffle(y_matmul.get_output(0))
+    y_squeeze.reshape_dims = (mamba_num_heads, mamba_head_dim)
+
+    D_const = graph_ops.add_constant(
+        network, (mamba_num_heads, 1),
+        weights[f"{prefix}.D"].reshape(mamba_num_heads, 1))
+    Dx = network.add_elementwise(
+        D_const, x_heads.get_output(0), trt.ElementWiseOperation.PROD)
+    y_plus_D = network.add_elementwise(
+        y_squeeze.get_output(0), Dx.get_output(0), trt.ElementWiseOperation.SUM)
+    y_flat = network.add_shuffle(y_plus_D.get_output(0))
+    y_flat.reshape_dims = (1, d_inner)
+
+    gate_activated = graph_ops.add_activation(network, gate, "silu")
+    y_gated = network.add_elementwise(
+        y_flat.get_output(0), gate_activated, trt.ElementWiseOperation.PROD)
+    group_size = d_inner // n_groups
+    y_grouped = network.add_shuffle(y_gated.get_output(0))
+    y_grouped.reshape_dims = (n_groups, group_size)
+
+    sq = network.add_elementwise(
+        y_grouped.get_output(0), y_grouped.get_output(0), trt.ElementWiseOperation.PROD)
+    mean = network.add_reduce(
+        sq.get_output(0), trt.ReduceOperation.AVG, 1 << 1, keep_dims=True)
+    eps_small = graph_ops.add_constant(
+        network, (1, 1), np.array([1e-5], dtype=np.float32))
+    denom_in = network.add_elementwise(
+        mean.get_output(0), eps_small, trt.ElementWiseOperation.SUM)
+    sqrt_l = network.add_unary(denom_in.get_output(0), trt.UnaryOperation.SQRT)
+    recip = network.add_unary(sqrt_l.get_output(0), trt.UnaryOperation.RECIP)
+    normalized = network.add_elementwise(
+        y_grouped.get_output(0), recip.get_output(0), trt.ElementWiseOperation.PROD)
+    y_flat_normed = network.add_shuffle(normalized.get_output(0))
+    y_flat_normed.reshape_dims = (1, d_inner)
+    gamma_t = graph_ops.add_constant(
+        network, (1, d_inner), weights[f"{prefix}.mamba_norm"])
+    gated = network.add_elementwise(
+        y_flat_normed.get_output(0), gamma_t, trt.ElementWiseOperation.PROD)
+
+    out = graph_ops.add_matmul_rhs_constant(
+        network, gated.get_output(0), d_inner, hidden_size,
+        weights[f"{prefix}.mamba_out_proj"])
+    out = add_all_reduce_sum(network, out, tp_size)
+    residual = network.add_elementwise(hidden, out, trt.ElementWiseOperation.SUM)
+
+    return {
+        "hidden": residual.get_output(0),
+        "present_conv": present_conv,
+        "present_ssm": present_ssm,
+    }
+
+
+def _add_mlp_tp_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    eps_tensor: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    mlp_size: int,
+    tp_size: int,
+) -> dict[str, trt.ITensor]:
+    normed = graph_ops.add_rms_norm(
+        network, hidden, hidden_size, weights[f"{prefix}.input_norm"], eps_tensor)
+    up = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, mlp_size, weights[f"{prefix}.w_up"])
+    activated = graph_ops.add_activation(network, up, "relu2")
+    down = graph_ops.add_matmul_rhs_constant(
+        network, activated, mlp_size, hidden_size, weights[f"{prefix}.w_down"])
+    down = add_all_reduce_sum(network, down, tp_size)
+    residual = network.add_elementwise(hidden, down, trt.ElementWiseOperation.SUM)
+    return {"hidden": residual.get_output(0)}
+
+
+def build_nemotron_h_tp_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    parallel_config=None,
+) -> bytes:
+    del precision, quant_ctx
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_nemotron_h_tp_engine requires tensor_parallel mode with tp_size > 1")
+
+    rank_weights = shard_nemotron_h_weights(config, weights, parallel=parallel)
+    hidden = int(config.hidden_size)
+    vocab = int(config.vocab_size)
+    num_layers = int(config.num_hidden_layers)
+    layer_types: list[str] = rank_weights["_layer_types"]
+
+    d_inner = int(rank_weights["_d_inner"])
+    d_state = int(rank_weights["_d_state"])
+    d_conv = int(rank_weights["_d_conv"])
+    conv_dim = int(rank_weights["_conv_dim"])
+    mamba_num_heads = int(rank_weights["_mamba_num_heads"])
+    mamba_head_dim = int(rank_weights["_mamba_head_dim"])
+    n_groups = int(rank_weights["_n_groups"])
+    num_mamba = int(rank_weights["_num_mamba_layers"])
+    num_attn = int(rank_weights["_num_attention_layers"])
+    attention_size = int(rank_weights["_attention_size"])
+    mlp_size = int(rank_weights["_mlp_size"])
+
+    num_heads = int(config.num_attention_heads) // parallel.tp_size
+    num_kv_heads = int(config.num_key_value_heads) // parallel.tp_size
+    head_dim = int(config.head_dim)
+    kv_attention_size = num_kv_heads * head_dim
+    attention_window = max_cache_length + 1
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    position_id = network.add_input("position_id", trt.int32, (1,))
+    attention_mask = network.add_input(
+        "attention_mask", trt.float32, (1, attention_window))
+
+    conv_state_inputs = []
+    ssm_state_inputs = []
+    for mi in range(num_mamba):
+        conv_state_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("conv_state", mi),
+            trt.float32, (conv_dim, d_conv)))
+        ssm_state_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("ssm_state", mi),
+            trt.float32, (mamba_num_heads, mamba_head_dim, d_state)))
+
+    cache_k_inputs = []
+    cache_v_inputs = []
+    for ai in range(num_attn):
+        cache_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_k", ai),
+            trt.float32, (max_cache_length, kv_attention_size)))
+        cache_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_v", ai),
+            trt.float32, (max_cache_length, kv_attention_size)))
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), rank_weights["embedding"])
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=np.float32))
+
+    hidden_state = network.add_gather(embedding_table, token_id, 0).get_output(0)
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    present_conv_outputs = []
+    present_ssm_outputs = []
+    present_k_outputs = []
+    present_v_outputs = []
+    mamba_counter = 0
+    attn_counter = 0
+
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        lt = layer_types[layer_idx]
+        if lt == "mamba2":
+            result = _add_mamba2_tp_layer(
+                network=network,
+                hidden=hidden_state,
+                conv_state_in=conv_state_inputs[mamba_counter],
+                ssm_state_in=ssm_state_inputs[mamba_counter],
+                eps_tensor=eps_tensor,
+                weights=rank_weights,
+                prefix=prefix,
+                hidden_size=hidden,
+                d_inner=d_inner,
+                d_state=d_state,
+                d_conv=d_conv,
+                conv_dim=conv_dim,
+                mamba_num_heads=mamba_num_heads,
+                mamba_head_dim=mamba_head_dim,
+                n_groups=n_groups,
+                tp_size=parallel.tp_size,
+            )
+            hidden_state = result["hidden"]
+            present_conv_outputs.append(result["present_conv"])
+            present_ssm_outputs.append(result["present_ssm"])
+            mamba_counter += 1
+        elif lt == "mlp":
+            result = _add_mlp_tp_layer(
+                network=network,
+                hidden=hidden_state,
+                eps_tensor=eps_tensor,
+                weights=rank_weights,
+                prefix=prefix,
+                hidden_size=hidden,
+                mlp_size=mlp_size,
+                tp_size=parallel.tp_size,
+            )
+            hidden_state = result["hidden"]
+        elif lt == "attention":
+            result = graph_blocks.add_attention_block(
+                network, hidden_state,
+                cache_k_inputs[attn_counter],
+                cache_v_inputs[attn_counter],
+                attention_mask, position_id,
+                weights=rank_weights,
+                prefix=prefix,
+                hidden_size=hidden,
+                attention_size=attention_size,
+                kv_attention_size=kv_attention_size,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                max_cache_length=max_cache_length,
+                eps_tensor=eps_tensor,
+                position_type="none",
+            )
+            attn_out = add_all_reduce_sum(network, result["attn_out"], parallel.tp_size)
+            residual = network.add_elementwise(
+                hidden_state, attn_out, trt.ElementWiseOperation.SUM)
+            hidden_state = residual.get_output(0)
+            present_k_outputs.append(result["present_k"])
+            present_v_outputs.append(result["present_v"])
+            attn_counter += 1
+
+        if debug_layer_outputs:
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    final_norm = rank_weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = graph_ops.add_rms_norm(
+            network, hidden_state, hidden, final_norm, eps_tensor)
+
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, vocab, rank_weights["w_lm_head"])
+    logits = graph_ops.add_bias_sum(
+        network, logits, vocab, np.zeros(vocab, dtype=np.float32))
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for mi in range(num_mamba):
+        present_conv_outputs[mi].name = graph_ops.layer_tensor_name("present_conv", mi)
+        present_ssm_outputs[mi].name = graph_ops.layer_tensor_name("present_ssm", mi)
+        network.mark_output(present_conv_outputs[mi])
+        network.mark_output(present_ssm_outputs[mi])
+
+    for ai in range(num_attn):
+        present_k_outputs[ai].name = graph_ops.layer_tensor_name("present_k", ai)
+        present_v_outputs[ai].name = graph_ops.layer_tensor_name("present_v", ai)
+        network.mark_output(present_k_outputs[ai])
+        network.mark_output(present_v_outputs[ai])
+
+    if verbose:
+        print(
+            "[trtmc build] Nemotron-H TP engine "
+            f"(rank={parallel.rank}/{parallel.tp_size}, {num_layers}L, "
+            f"local_mamba_heads={mamba_num_heads}, local_attn_heads={num_heads}, "
+            f"local_mlp={mlp_size})",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT Nemotron-H TP engine build failed")
+    return bytes(plan)

--- a/src/runtime/models/recurrent/hybrid_plugin.cpp
+++ b/src/runtime/models/recurrent/hybrid_plugin.cpp
@@ -4,25 +4,66 @@
 
 #include "runtime/models/recurrent/pipeline.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/hybrid_state.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
 
 #include <algorithm>
+#include <cstdint>
+#include <string>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+struct TensorParallelRuntime {
+    TensorParallelRuntimeConfig config;
+    DistributedRuntimeGroup group;
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+} // namespace
 
 class HybridPlugin final : public IPipelinePlugin {
   public:
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
         load_ffi_kernels_from_bundle(ctx.bundle);
 
+        TensorParallelRuntime tp_runtime;
+        tp_runtime.config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        if (tp_runtime.config.enabled)
+            tp_runtime.group = initialize_tensor_parallel_group(tp_runtime.config.tp_size);
+
         ModuleCreateOptions opts;
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
+        if (tp_runtime.config.enabled) {
+            opts.distributed_communicator = tp_runtime.group.communicator;
+            opts.distributed_owner = tp_runtime.group.owner;
+        }
 
+        const std::string engine_section = tp_runtime.config.enabled
+                                               ? tp_engine_section_name(tp_runtime.group.rank)
+                                               : std::string("engine_plan");
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "engine_plan", opts);
+            ctx.backend, find_section(ctx.bundle, engine_section), engine_section.c_str(), opts);
         auto tokenizer = create_tokenizer_from_bundle(ctx.bundle);
 
         cudaStream_t stream = loaded.module->stream();

--- a/tests/builder/test_debug_runner.py
+++ b/tests/builder/test_debug_runner.py
@@ -248,6 +248,40 @@ class TestRunnerFromBundle:
         assert kwargs["engine_plan"] == b"RANK1_ENGINE"
         assert kwargs["distributed_communicator"] is communicator
 
+    def test_hybrid_engine_section_and_communicator_forwarded(self, tmp_path):
+        from tensorrt_model_connect.debug_runner import runner_from_bundle
+
+        config_data = json.dumps({
+            "runtime_strategy": "hybrid_mamba_attention",
+            "num_mamba_layers": 1,
+            "num_attention_layers": 1,
+        }).encode("utf-8")
+        bundle = _make_bundle_bytes(
+            {"num_layers": 2, "max_cache_length": 128},
+            engine_plan=b"SINGLE_ENGINE",
+            extra_sections={
+                "config.json": config_data,
+                "engine_plan_tp_rank1": b"HYBRID_RANK1_ENGINE",
+            },
+        )
+
+        path = tmp_path / "hybrid_tp_dispatch.trtfb"
+        path.write_bytes(bundle)
+
+        communicator = object()
+        with patch("tensorrt_model_connect.debug_runner.HybridTrtRunner",
+                   return_value="hybrid-tp-runner") as mock_runner:
+            runner = runner_from_bundle(
+                str(path),
+                engine_section="engine_plan_tp_rank1",
+                distributed_communicator=communicator,
+            )
+
+        assert runner == "hybrid-tp-runner"
+        kwargs = mock_runner.call_args.kwargs
+        assert kwargs["engine_plan"] == b"HYBRID_RANK1_ENGINE"
+        assert kwargs["distributed_communicator"] is communicator
+
     def test_mpi_rank_info_uses_single_node_rank(self, monkeypatch):
         from tensorrt_model_connect.debug_runner import _mpi_rank_info_from_env
 

--- a/tests/builder/test_family_nemotron_h_tp.py
+++ b/tests/builder/test_family_nemotron_h_tp.py
@@ -1,0 +1,158 @@
+"""Focused tests for Nemotron-H tensor-parallel support."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+try:
+    nemotron_h_module = importlib.import_module(
+        "tensorrt_model_connect.families.nemotron_h.plugin")
+    from tensorrt_model_connect.families.nemotron_h import tp_builder
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _config(num_heads: int = 4, num_kv_heads: int = 4) -> SimpleNamespace:
+    return SimpleNamespace(
+        raw={},
+        hidden_size=8,
+        vocab_size=32,
+        num_hidden_layers=3,
+        num_attention_heads=num_heads,
+        num_key_value_heads=num_kv_heads,
+        head_dim=2,
+        intermediate_size=16,
+        rms_norm_eps=1e-5,
+    )
+
+
+def _weights() -> dict:
+    hidden = 8
+    d_inner = 16
+    d_state = 2
+    d_conv = 3
+    n_groups = 4
+    mamba_heads = 4
+    conv_dim = d_inner + 2 * n_groups * d_state
+    proj_dim = d_inner + conv_dim + mamba_heads
+    weights: dict[str, object] = {
+        "_layer_types": ["mamba2", "mlp", "attention"],
+        "_d_inner": d_inner,
+        "_d_state": d_state,
+        "_d_conv": d_conv,
+        "_conv_dim": conv_dim,
+        "_mamba_num_heads": mamba_heads,
+        "_mamba_head_dim": 4,
+        "_n_groups": n_groups,
+        "_num_mamba_layers": 1,
+        "_num_attention_layers": 1,
+        "_attention_size": 8,
+        "_mlp_size": 16,
+        "embedding": np.zeros((32, hidden), dtype=np.float32),
+        "final_norm": np.ones((hidden,), dtype=np.float32),
+        "w_lm_head": np.zeros((hidden, 32), dtype=np.float32),
+    }
+    weights["layer.0.input_norm"] = np.ones((hidden,), dtype=np.float32)
+    weights["layer.0.mamba_in_proj"] = np.arange(
+        hidden * proj_dim, dtype=np.float32).reshape(hidden, proj_dim)
+    weights["layer.0.conv1d_weight"] = np.arange(
+        conv_dim * d_conv, dtype=np.float32).reshape(conv_dim, d_conv)
+    weights["layer.0.conv1d_bias"] = np.arange(conv_dim, dtype=np.float32)
+    weights["layer.0.dt_bias"] = np.arange(mamba_heads, dtype=np.float32)
+    weights["layer.0.A"] = np.arange(mamba_heads, dtype=np.float32)
+    weights["layer.0.D"] = np.arange(mamba_heads, dtype=np.float32)
+    weights["layer.0.mamba_norm"] = np.arange(d_inner, dtype=np.float32)
+    weights["layer.0.mamba_out_proj"] = np.arange(
+        d_inner * hidden, dtype=np.float32).reshape(d_inner, hidden)
+
+    weights["layer.1.input_norm"] = np.ones((hidden,), dtype=np.float32)
+    weights["layer.1.w_up"] = np.arange(hidden * 16, dtype=np.float32).reshape(hidden, 16)
+    weights["layer.1.w_down"] = np.arange(16 * hidden, dtype=np.float32).reshape(16, hidden)
+
+    weights["layer.2.input_norm"] = np.ones((hidden,), dtype=np.float32)
+    weights["layer.2.w_q"] = np.arange(hidden * 8, dtype=np.float32).reshape(hidden, 8)
+    weights["layer.2.w_k"] = np.arange(hidden * 8, dtype=np.float32).reshape(hidden, 8)
+    weights["layer.2.w_v"] = np.arange(hidden * 8, dtype=np.float32).reshape(hidden, 8)
+    weights["layer.2.w_o"] = np.arange(8 * hidden, dtype=np.float32).reshape(8, hidden)
+    return weights
+
+
+def test_nemotron_h_tp_slices_mamba_mlp_and_attention_weights():
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+    weights = _weights()
+
+    sharded = tp_builder.shard_nemotron_h_weights(
+        _config(), weights, parallel=parallel)
+
+    expected_in_proj = np.concatenate([
+        weights["layer.0.mamba_in_proj"][:, 8:12],
+        weights["layer.0.mamba_in_proj"][:, 24:28],
+        weights["layer.0.mamba_in_proj"][:, 36:38],
+        weights["layer.0.mamba_in_proj"][:, 44:46],
+        weights["layer.0.mamba_in_proj"][:, 50:51],
+    ], axis=-1)
+    expected_conv = np.concatenate([
+        weights["layer.0.conv1d_weight"][8:12, :],
+        weights["layer.0.conv1d_weight"][20:22, :],
+        weights["layer.0.conv1d_weight"][28:30, :],
+    ], axis=0)
+
+    np.testing.assert_array_equal(sharded["layer.0.mamba_in_proj"], expected_in_proj)
+    np.testing.assert_array_equal(sharded["layer.0.conv1d_weight"], expected_conv)
+    np.testing.assert_array_equal(sharded["layer.0.mamba_out_proj"], weights["layer.0.mamba_out_proj"][8:12, :])
+    np.testing.assert_array_equal(sharded["layer.1.w_up"], weights["layer.1.w_up"][:, 8:12])
+    np.testing.assert_array_equal(sharded["layer.1.w_down"], weights["layer.1.w_down"][8:12, :])
+    np.testing.assert_array_equal(sharded["layer.2.w_q"], weights["layer.2.w_q"][:, 4:6])
+    np.testing.assert_array_equal(sharded["layer.2.w_o"], weights["layer.2.w_o"][4:6, :])
+    assert sharded["_d_inner"] == 4
+    assert sharded["_conv_dim"] == 8
+    assert sharded["_mamba_num_heads"] == 1
+    assert sharded["_n_groups"] == 1
+    assert sharded["_attention_size"] == 2
+    assert sharded["_mlp_size"] == 4
+
+
+def test_nemotron_h_tp_validation_rejects_non_divisible_kv_heads():
+    with pytest.raises(ValueError, match="num_key_value_heads"):
+        tp_builder._validate_nemotron_h_tp(
+            _config(num_kv_heads=2),
+            _weights(),
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )
+
+
+def test_nemotron_h_plugin_routes_parallel_builds(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"nemotron-h-tp-plan"
+
+    monkeypatch.setattr(
+        nemotron_h_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(tp_builder, "build_nemotron_h_tp_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1)
+    result = nemotron_h_module.NemotronHPlugin().build_engine(
+        _config(), _weights(), 17,
+        verbose=True,
+        debug_layer_outputs=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"nemotron-h-tp-plan"
+    assert calls["require"][0] == parallel
+    assert "Nemotron-H tensor-parallel" in calls["require"][1]
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 17
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["verbose"] is True
+    assert kwargs["debug_layer_outputs"] is True

--- a/tests/e2e/models/nemotron-h-nano-9b-tp4.json
+++ b/tests/e2e/models/nemotron-h-nano-9b-tp4.json
@@ -1,0 +1,62 @@
+{
+  "name": "nemotron-h-nano-9b-tp4",
+  "trace_id": "IT-E2E-NMHN-TP4-01",
+  "hf_id": "nvidia/NVIDIA-Nemotron-Nano-9B-v2",
+  "bundle": "nemotron-h-nano-9b-tp4.trtfb",
+  "family": "nemotron_h",
+  "runtime_strategy": "hybrid_mamba_attention",
+  "reference_backend": "golden_snapshot",
+  "reference_family": "chat_instruct_template",
+  "user_contract": "chat_response",
+  "max_cache_length": 256,
+  "prompt": "What is the capital of France? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.005,
+  "layer_atol": 0.1,
+  "trust_remote_code": true,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "metadata": {
+    "golden_snapshot_path": "tests/e2e/data/nemotron_h_nano_9b_golden.json"
+  },
+  "notes": "Nemotron-H Nano 9B TP4 repro using the same prompt, golden snapshot, generation length, and thresholds as nemotron-h-nano-9b."
+}


### PR DESCRIPTION
## Background
Nemotron-H Nano 9B only had a single-device hybrid Mamba-2 + attention runtime path. This adds TP4 coverage for the hybrid model while keeping the same golden snapshot and thresholds as the existing single-device manifest.

## Exit Criteria
- Build a rank-local Nemotron-H hybrid TensorRT engine for each TP rank.
- Load rank-specific hybrid engine sections at runtime with a distributed communicator.
- Add and pass a Nemotron-H Nano 9B TP4 E2E test without changing the single-device golden answer or thresholds.

## Implementation
- Added a Nemotron-H TP builder that shards Mamba-2 heads/groups, attention heads/KV heads, and MLP intermediate dimensions, then all-reduces row-parallel joins back to full hidden state.
- Routed parallel Nemotron-H builds through the TP builder with TensorRT 11 gating.
- Updated the hybrid recurrent runtime and debug runner to select `engine_plan_tp_rank*` sections and pass TensorRT distributed communicators.
- Added focused sharding/routing tests and `nemotron-h-nano-9b-tp4.json` using the same prompt, golden snapshot, generation length, `logit_atol`, and `layer_atol` as `nemotron-h-nano-9b`.

## Validation
- `PYTHONPATH=python:. python -m pytest -q tests/builder/test_family_nemotron_h_tp.py tests/builder/test_family_nemotron_h.py tests/builder/test_manifest_validation.py tests/builder/test_debug_runner.py`: passed, 56 tests.
- `python -m pip install --disable-pip-version-check --quiet ruff clang-format && ruff check --config ruff.toml python/tensorrt_model_connect/debug_runner.py python/tensorrt_model_connect/families/nemotron_h/plugin.py python/tensorrt_model_connect/families/nemotron_h/tp_builder.py tests/builder/test_family_nemotron_h_tp.py tests/builder/test_debug_runner.py && clang-format --dry-run --Werror src/runtime/models/recurrent/hybrid_plugin.cpp`: passed.
- `cmake -S . -B build-nemotron-h-e2e -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so && cmake --build build-nemotron-h-e2e --target trtmc trtmc_backend_trt -j`: passed.
- `PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py --multi-device-only -k "nemotron-h-nano-9b-tp4" --trtmc-binary ./build-nemotron-h-e2e/trtmc --engine-dir /trtmc-local-storage/engines-nemotron-h-tp4 --e2e-artifacts-dir /trtmc-local-storage/e2e-nemotron-h-tp4 --hf-python /opt/venv/bin/python -s`: passed, 1 test selected.
- `git diff --check`: passed.

## Notes For Future Readers
- Review the TP builder first, especially the Mamba-2 projection slicing. The runtime/debug-runner changes only enable rank-section selection and communicator setup for hybrid bundles.
- The E2E run used `/tmp`-backed storage mounted at `/trtmc-local-storage` to avoid the shared scratch quota.
