### PR TITLE
feat(mixtral): add moe tp2 support

### DIFF
--- a/python/tensorrt_model_connect/families/mixtral/plugin.py
+++ b/python/tensorrt_model_connect/families/mixtral/plugin.py
@@ -38,6 +38,10 @@ from ...checkpoint_mapper import (
 )
 from ... import graph_ops
 from ... import graph_blocks
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 from .standard_decoder_builder import _apply_norm, _mark_debug_output
 
 
@@ -160,7 +164,23 @@ class MixtralPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
         debug_layer_outputs: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="Mixtral tensor-parallel builds")
+            from .tp_builder import build_mixtral_tp_engine
+
+            return build_mixtral_tp_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                parallel_config=parallel,
+            )
+
         attention_size: int = weights.get("_attention_size", config.attention_size)
         num_experts: int = weights["_num_experts"]
         moe_intermediate: int = weights["_moe_intermediate_size"]

--- a/python/tensorrt_model_connect/families/mixtral/tp_builder.py
+++ b/python/tensorrt_model_connect/families/mixtral/tp_builder.py
@@ -1,0 +1,398 @@
+"""Tensor-parallel Mixtral MoE builder."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_blocks, graph_ops
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+from .standard_decoder_builder import _apply_norm, _mark_debug_output
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_mixtral_tp(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("Mixtral tensor-parallel build requires a concrete rank")
+    tp = parallel.tp_size
+    if int(config.num_attention_heads) % tp != 0:
+        raise ValueError(
+            "Mixtral tensor parallel requires num_attention_heads divisible by tp_size "
+            f"({config.num_attention_heads} vs {tp})")
+    if int(config.num_key_value_heads) % tp != 0:
+        raise ValueError(
+            "Mixtral tensor parallel requires num_key_value_heads divisible by tp_size "
+            f"({config.num_key_value_heads} vs {tp})")
+
+    attention_size = int(weights.get("_attention_size", config.attention_size))
+    kv_attention_size = graph_blocks.infer_kv_attention_size(
+        weights,
+        num_kv_heads=int(config.num_key_value_heads),
+        head_dim=attention_size // int(config.num_attention_heads),
+    )
+    moe_intermediate = int(weights["_moe_intermediate_size"])
+    checks = {
+        "attention_size": attention_size,
+        "kv_attention_size": kv_attention_size,
+        "moe_intermediate_size": moe_intermediate,
+    }
+    for name, value in checks.items():
+        if value % tp != 0:
+            raise ValueError(
+                f"Mixtral tensor parallel requires {name} divisible by tp_size "
+                f"({value} vs {tp})")
+
+
+def shard_mixtral_weights(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local Mixtral weights for the TP builder."""
+    _validate_mixtral_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+        if key.endswith((".w_q", ".w_k", ".w_v", ".w_gate", ".w_up")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_o", ".w_down")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_attention_size"] = int(weights["_attention_size"]) // parallel.tp_size
+    out["_moe_intermediate_size"] = (
+        int(weights["_moe_intermediate_size"]) // parallel.tp_size)
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def _add_swiglu_expert_tp(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    intermediate_size: int,
+    w_gate: np.ndarray,
+    w_up: np.ndarray,
+    w_down: np.ndarray,
+) -> trt.ITensor:
+    gate = graph_ops.add_matmul_rhs_constant(
+        network, inp, hidden_size, intermediate_size, w_gate)
+    up = graph_ops.add_matmul_rhs_constant(
+        network, inp, hidden_size, intermediate_size, w_up)
+    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
+    swish = network.add_elementwise(
+        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    gated = network.add_elementwise(
+        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+    return graph_ops.add_matmul_rhs_constant(
+        network, gated.get_output(0), intermediate_size, hidden_size, w_down)
+
+
+def _add_mixtral_moe_tp_block(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    num_experts: int,
+    moe_intermediate: int,
+    tp_size: int,
+    top_k: int = 2,
+) -> trt.ITensor:
+    router_logits = graph_ops.add_matmul_rhs_constant(
+        network, inp, hidden_size, num_experts, weights[f"{prefix}.router"])
+    sm = network.add_softmax(router_logits)
+    sm.axes = 1 << 1
+    topk = network.add_topk(sm.get_output(0), trt.TopKOperation.MAX, top_k, 1 << 1)
+    top_values = topk.get_output(0)
+    top_indices = topk.get_output(1)
+    sum_val = network.add_reduce(
+        top_values, trt.ReduceOperation.SUM, 1 << 1, keep_dims=True)
+    norm_weights = network.add_elementwise(
+        top_values, sum_val.get_output(0), trt.ElementWiseOperation.DIV)
+
+    expert_outputs = []
+    for expert_idx in range(num_experts):
+        expert_outputs.append(_add_swiglu_expert_tp(
+            network, inp, hidden_size, moe_intermediate,
+            weights[f"{prefix}.expert.{expert_idx}.w_gate"],
+            weights[f"{prefix}.expert.{expert_idx}.w_up"],
+            weights[f"{prefix}.expert.{expert_idx}.w_down"],
+        ))
+
+    stacked = network.add_concatenation(expert_outputs)
+    stacked.axis = 0
+    stacked_out = stacked.get_output(0)
+    result = None
+    for top_idx in range(top_k):
+        idx_slice = network.add_slice(
+            top_indices, start=(0, top_idx), shape=(1, 1), stride=(1, 1))
+        idx_flat = network.add_shuffle(idx_slice.get_output(0))
+        idx_flat.reshape_dims = (1,)
+        w_slice = network.add_slice(
+            norm_weights.get_output(0),
+            start=(0, top_idx), shape=(1, 1), stride=(1, 1))
+        expert_out = network.add_gather(stacked_out, idx_flat.get_output(0), 0)
+        scaled = network.add_elementwise(
+            expert_out.get_output(0), w_slice.get_output(0),
+            trt.ElementWiseOperation.PROD)
+        if result is None:
+            result = scaled.get_output(0)
+        else:
+            summed = network.add_elementwise(
+                result, scaled.get_output(0), trt.ElementWiseOperation.SUM)
+            result = summed.get_output(0)
+
+    return add_all_reduce_sum(network, result, tp_size)
+
+
+def _add_mixtral_tp_decoder_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    attention_mask: trt.ITensor,
+    position_id: trt.ITensor,
+    cos_half_tensor: trt.ITensor,
+    sin_half_tensor: trt.ITensor,
+    eps_tensor: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    attention_size: int,
+    kv_attention_size: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    max_cache_length: int,
+    num_experts: int,
+    moe_intermediate: int,
+    tp_size: int,
+    top_k: int = 2,
+) -> dict[str, trt.ITensor]:
+    attention_window = max_cache_length + 1
+    norm1 = _apply_norm(
+        network, hidden, hidden_size,
+        weights[f"{prefix}.input_norm"], None, eps_tensor, "rmsnorm")
+
+    q = graph_ops.add_matmul_rhs_constant(
+        network, norm1, hidden_size, attention_size, weights[f"{prefix}.w_q"])
+    k = graph_ops.add_matmul_rhs_constant(
+        network, norm1, hidden_size, kv_attention_size, weights[f"{prefix}.w_k"])
+    v = graph_ops.add_matmul_rhs_constant(
+        network, norm1, hidden_size, kv_attention_size, weights[f"{prefix}.w_v"])
+
+    q = graph_ops.add_apply_rope_native(
+        network, q, num_heads, head_dim, cos_half_tensor, sin_half_tensor,
+        position_id, head_dim)
+    k = graph_ops.add_apply_rope_native(
+        network, k, num_kv_heads, head_dim, cos_half_tensor, sin_half_tensor,
+        position_id, head_dim)
+
+    present_k = k
+    present_v = v
+    k_reshape = network.add_shuffle(k)
+    k_reshape.reshape_dims = (1, kv_attention_size)
+    v_reshape = network.add_shuffle(v)
+    v_reshape.reshape_dims = (1, kv_attention_size)
+    all_k = network.add_concatenation([cache_k, k_reshape.get_output(0)])
+    all_k.axis = 0
+    all_v = network.add_concatenation([cache_v, v_reshape.get_output(0)])
+    all_v.axis = 0
+
+    mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask)
+    context_flat = graph_ops.add_attention_from_rows(
+        network, q, all_k.get_output(0), all_v.get_output(0),
+        num_heads=num_heads, head_dim=head_dim, num_kv_heads=num_kv_heads,
+        q_seq=1, kv_seq=attention_window, mask=mask_4d)
+
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, context_flat, attention_size, hidden_size, weights[f"{prefix}.w_o"])
+    attn_out = add_all_reduce_sum(network, attn_out, tp_size)
+    residual1 = network.add_elementwise(
+        hidden, attn_out, trt.ElementWiseOperation.SUM)
+
+    norm2 = _apply_norm(
+        network, residual1.get_output(0), hidden_size,
+        weights[f"{prefix}.post_attn_norm"], None, eps_tensor, "rmsnorm")
+    moe_out = _add_mixtral_moe_tp_block(
+        network, norm2, weights, prefix,
+        hidden_size, num_experts, moe_intermediate, tp_size, top_k)
+    residual2 = network.add_elementwise(
+        residual1.get_output(0), moe_out, trt.ElementWiseOperation.SUM)
+
+    return {
+        "hidden": residual2.get_output(0),
+        "post_attn": residual1.get_output(0),
+        "present_k": present_k,
+        "present_v": present_v,
+    }
+
+
+def build_mixtral_tp_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    parallel_config=None,
+) -> bytes:
+    del precision, quant_ctx
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError("build_mixtral_tp_engine requires tensor_parallel mode with tp_size > 1")
+
+    rank_weights = shard_mixtral_weights(config, weights, parallel=parallel)
+    attention_size = int(rank_weights["_attention_size"])
+    num_experts = int(rank_weights["_num_experts"])
+    moe_intermediate = int(rank_weights["_moe_intermediate_size"])
+    top_k = int(rank_weights["_num_experts_per_tok"])
+    hidden = int(config.hidden_size)
+    vocab = int(config.vocab_size)
+    num_layers = int(config.num_hidden_layers)
+    num_heads = int(config.num_attention_heads) // parallel.tp_size
+    num_kv_heads = int(config.num_key_value_heads) // parallel.tp_size
+    head_dim = int(config.head_dim)
+    kv_attention_size = num_kv_heads * head_dim
+    attention_window = max_cache_length + 1
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    position_id = network.add_input("position_id", trt.int32, (1,))
+    attention_mask = network.add_input(
+        "attention_mask", trt.float32, (1, attention_window))
+    cache_k_inputs = []
+    cache_v_inputs = []
+    for layer_idx in range(num_layers):
+        cache_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_k", layer_idx),
+            trt.float32, (max_cache_length, kv_attention_size)))
+        cache_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_v", layer_idx),
+            trt.float32, (max_cache_length, kv_attention_size)))
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), rank_weights["embedding"])
+    graph_ops.validate_native_rope_dim(head_dim, field_name="head_dim")
+    cos_half_np = graph_ops.make_rope_table_half_dim(
+        attention_window, head_dim, config.rope_theta, True)
+    sin_half_np = graph_ops.make_rope_table_half_dim(
+        attention_window, head_dim, config.rope_theta, False)
+    cos_half_tensor = graph_ops.add_constant(network, cos_half_np.shape, cos_half_np)
+    sin_half_tensor = graph_ops.add_constant(network, sin_half_np.shape, sin_half_np)
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=np.float32))
+
+    hidden_state = network.add_gather(embedding_table, token_id, 0).get_output(0)
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    present_k_outputs = []
+    present_v_outputs = []
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        result = _add_mixtral_tp_decoder_layer(
+            network=network,
+            hidden=hidden_state,
+            cache_k=cache_k_inputs[layer_idx],
+            cache_v=cache_v_inputs[layer_idx],
+            attention_mask=attention_mask,
+            position_id=position_id,
+            cos_half_tensor=cos_half_tensor,
+            sin_half_tensor=sin_half_tensor,
+            eps_tensor=eps_tensor,
+            weights=rank_weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            attention_size=attention_size,
+            kv_attention_size=kv_attention_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            max_cache_length=max_cache_length,
+            num_experts=num_experts,
+            moe_intermediate=moe_intermediate,
+            tp_size=parallel.tp_size,
+            top_k=top_k,
+        )
+        hidden_state = result["hidden"]
+        present_k_outputs.append(result["present_k"])
+        present_v_outputs.append(result["present_v"])
+        if debug_layer_outputs:
+            _mark_debug_output(network, result["post_attn"], f"debug_post_attn_{layer_idx}")
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    final_norm = rank_weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = _apply_norm(
+            network, hidden_state, hidden, final_norm, None, eps_tensor, "rmsnorm")
+
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, vocab, rank_weights["w_out"])
+    logits = graph_ops.add_bias_sum(
+        network, logits, vocab, np.zeros(vocab, dtype=np.float32))
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for layer_idx in range(num_layers):
+        present_k_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_k", layer_idx)
+        present_v_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_v", layer_idx)
+        network.mark_output(present_k_outputs[layer_idx])
+        network.mark_output(present_v_outputs[layer_idx])
+
+    if verbose:
+        print(
+            "[trtmc build] Mixtral TP engine "
+            f"(rank={parallel.rank}/{parallel.tp_size}, {num_layers}L, "
+            f"local_attn={attention_size}, local_moe={moe_intermediate})",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT Mixtral TP engine build failed")
+    return bytes(plan)

--- a/tests/builder/test_engine_mixtral_tp.py
+++ b/tests/builder/test_engine_mixtral_tp.py
@@ -1,0 +1,124 @@
+"""Focused tests for Mixtral tensor-parallel support."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+try:
+    mixtral_module = importlib.import_module(
+        "tensorrt_model_connect.families.mixtral.plugin")
+    from tensorrt_model_connect.families.mixtral import tp_builder
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _config(num_kv_heads: int = 4) -> SimpleNamespace:
+    return SimpleNamespace(
+        raw={},
+        hidden_size=8,
+        vocab_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=num_kv_heads,
+        head_dim=2,
+        attention_size=8,
+        intermediate_size=16,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+    )
+
+
+def _weights() -> dict:
+    hidden = 8
+    inter = 16
+    weights: dict[str, object] = {
+        "_attention_size": 8,
+        "_num_experts": 2,
+        "_moe_intermediate_size": inter,
+        "_num_experts_per_tok": 2,
+        "embedding": np.zeros((32, hidden), dtype=np.float32),
+        "final_norm": np.ones((hidden,), dtype=np.float32),
+        "w_out": np.zeros((hidden, 32), dtype=np.float32),
+        "layer.0.input_norm": np.ones((hidden,), dtype=np.float32),
+        "layer.0.post_attn_norm": np.ones((hidden,), dtype=np.float32),
+        "layer.0.router": np.zeros((hidden, 2), dtype=np.float32),
+    }
+    for key in ("w_q", "w_k", "w_v"):
+        weights[f"layer.0.{key}"] = np.arange(
+            hidden * 8, dtype=np.float32).reshape(hidden, 8)
+    weights["layer.0.w_o"] = np.arange(8 * hidden, dtype=np.float32).reshape(8, hidden)
+    for expert_idx in range(2):
+        prefix = f"layer.0.expert.{expert_idx}"
+        weights[f"{prefix}.w_gate"] = np.arange(
+            hidden * inter, dtype=np.float32).reshape(hidden, inter)
+        weights[f"{prefix}.w_up"] = np.arange(
+            hidden * inter, dtype=np.float32).reshape(hidden, inter)
+        weights[f"{prefix}.w_down"] = np.arange(
+            inter * hidden, dtype=np.float32).reshape(inter, hidden)
+    return weights
+
+
+def test_mixtral_tp_slices_attention_and_expert_weights():
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+    weights = _weights()
+
+    sharded = tp_builder.shard_mixtral_weights(_config(), weights, parallel=parallel)
+
+    np.testing.assert_array_equal(sharded["layer.0.w_q"], weights["layer.0.w_q"][:, 4:6])
+    np.testing.assert_array_equal(sharded["layer.0.w_o"], weights["layer.0.w_o"][4:6, :])
+    np.testing.assert_array_equal(
+        sharded["layer.0.expert.0.w_gate"],
+        weights["layer.0.expert.0.w_gate"][:, 8:12],
+    )
+    np.testing.assert_array_equal(
+        sharded["layer.0.expert.0.w_down"],
+        weights["layer.0.expert.0.w_down"][8:12, :],
+    )
+    assert sharded["_attention_size"] == 2
+    assert sharded["_moe_intermediate_size"] == 4
+
+
+def test_mixtral_tp_validation_rejects_non_divisible_kv_heads():
+    with pytest.raises(ValueError, match="num_key_value_heads"):
+        tp_builder._validate_mixtral_tp(
+            _config(num_kv_heads=2),
+            _weights(),
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )
+
+
+def test_mixtral_plugin_routes_parallel_builds(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"mixtral-tp-plan"
+
+    monkeypatch.setattr(
+        mixtral_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(tp_builder, "build_mixtral_tp_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1)
+    result = mixtral_module.MixtralPlugin().build_engine(
+        _config(), _weights(), 17,
+        verbose=True,
+        debug_layer_outputs=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"mixtral-tp-plan"
+    assert calls["require"][0] == parallel
+    assert "Mixtral tensor-parallel" in calls["require"][1]
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 17
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["verbose"] is True
+    assert kwargs["debug_layer_outputs"] is True

--- a/tests/e2e/models/mixtral-stories-15m-tp2.json
+++ b/tests/e2e/models/mixtral-stories-15m-tp2.json
@@ -1,0 +1,56 @@
+{
+  "name": "mixtral-stories-15m-tp2",
+  "trace_id": "IT-E2E-MXTRL-TP2-01",
+  "hf_id": "ggml-org/stories15M_MOE",
+  "bundle": "mixtral-stories-15m-tp2.trtfb",
+  "family": "mixtral",
+  "runtime_strategy": "decoder_moe",
+  "max_cache_length": 256,
+  "prompt": "Once upon a time there was a little",
+  "max_new_tokens": 20,
+  "logit_atol": 0.002,
+  "layer_atol": 0.05,
+  "trust_remote_code": false,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 2
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 2,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 2
+      },
+      "gating": true
+    }
+  ],
+  "notes": "Mixtral Stories 15M TP2 repro using the same checkpoint, prompt, generation length, and thresholds as mixtral-stories-15m. TP4 is not valid because this checkpoint has 6 attention heads."
+}


### PR DESCRIPTION
## Summary

- add a Mixtral tensor-parallel builder for the decoder MoE path
- shard Q/K/V and expert gate/up projections by output dimension, shard O and expert down projections by input dimension
- add `mixtral-stories-15m-tp2` E2E coverage with the same correctness thresholds as the single-device manifest

## Validation

- `PYTHONPATH=python:. python -m pytest -q tests/builder/test_engine_mixtral_tp.py tests/builder/test_manifest_validation.py`
- `python -m pip install --disable-pip-version-check --quiet ruff clang-format && ruff check --config ruff.toml python/tensorrt_model_connect/families/mixtral/plugin.py python/tensorrt_model_connect/families/mixtral/tp_builder.py tests/builder/test_engine_mixtral_tp.py`
- `cmake -S . -B build-mixtral-e2e -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so && cmake --build build-mixtral-e2e --target trtmc trtmc_backend_trt -j`
- `PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py --multi-device-only -k "mixtral-stories-15m-tp2" --trtmc-binary ./build-mixtral-e2e/trtmc --engine-dir /trtmc-local-storage/engines-mixtral-tp2 --e2e-artifacts-dir /trtmc-local-storage/e2e-mixtral-tp2 --hf-python /opt/venv/bin/python -s`

Note: TP4 is not valid for the Mixtral Stories 15M checkpoint because it has 6 attention heads, so this PR adds TP2 per the existing TP-size fallback guidance.
