### PR TITLE
feat(qwen-moe): add tp4 support

### DIFF
--- a/python/tensorrt_model_connect/families/qwen_moe/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_moe/plugin.py
@@ -47,6 +47,10 @@ from ...checkpoint_mapper import (
 )
 from ... import graph_ops
 from ... import graph_blocks
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 from .standard_decoder_builder import _apply_norm, _mark_debug_output
 
 
@@ -277,7 +281,22 @@ class Qwen3MoePlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
         debug_layer_outputs: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="Qwen-MoE tensor-parallel builds")
+            from .tp_builder import build_qwen_moe_tp_engine
+            return build_qwen_moe_tp_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                parallel_config=parallel,
+            )
+
         attention_size: int = weights.get(
             "_attention_size", config.attention_size)
         num_experts: int = weights["_num_experts"]

--- a/python/tensorrt_model_connect/families/qwen_moe/tp_builder.py
+++ b/python/tensorrt_model_connect/families/qwen_moe/tp_builder.py
@@ -1,0 +1,614 @@
+"""Tensor-parallel Qwen-MoE builder."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_blocks, graph_ops
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+from .standard_decoder_builder import _apply_norm, _mark_debug_output
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _slice_middle_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=1)[rank])
+
+
+def _validate_qwen_moe_tp(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("Qwen-MoE tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if int(config.num_attention_heads) % tp != 0:
+        raise ValueError(
+            "Qwen-MoE tensor parallel requires num_attention_heads divisible by "
+            f"tp_size ({config.num_attention_heads} vs {tp})")
+    attention_size = int(weights.get("_attention_size", config.attention_size))
+    kv_attention_size = graph_blocks.infer_kv_attention_size(
+        weights,
+        num_kv_heads=int(config.num_key_value_heads),
+        head_dim=attention_size // int(config.num_attention_heads),
+    )
+    checks = {
+        "attention_size": attention_size,
+        "moe_intermediate_size": int(weights["_moe_intermediate_size"]),
+    }
+    if int(config.num_key_value_heads) % tp == 0:
+        checks["kv_attention_size"] = kv_attention_size
+    dense_intermediate = int(weights.get("_dense_intermediate_size", 0))
+    if dense_intermediate:
+        checks["dense_intermediate_size"] = dense_intermediate
+    shared_intermediate = int(weights.get("_shared_expert_intermediate_size", 0))
+    if shared_intermediate:
+        checks["shared_expert_intermediate_size"] = shared_intermediate
+
+    for name, value in checks.items():
+        if value % tp != 0:
+            raise ValueError(
+                f"Qwen-MoE tensor parallel requires {name} divisible by "
+                f"tp_size ({value} vs {tp})")
+
+
+def shard_qwen_moe_weights(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local Qwen-MoE weights for the TP builder."""
+    _validate_qwen_moe_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    out = type(weights)()
+    head_dim = int(config.head_dim)
+    shard_kv = int(config.num_key_value_heads) % parallel.tp_size == 0
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        if key.endswith(".experts.w_gate") or key.endswith(".experts.w_up"):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".experts.w_down"):
+            out[key] = _slice_middle_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".w_q"):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_k", ".w_v")):
+            if shard_kv:
+                out[key] = _slice_last_dim(
+                    value, parallel.rank, parallel.tp_size)
+            else:
+                out[key] = value
+        elif key.endswith((".w_gate", ".w_up")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_o", ".w_down")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".q_norm") and value.size > head_dim:
+            reshaped = value.reshape(-1, head_dim)
+            out[key] = _slice_first_dim(
+                reshaped, parallel.rank, parallel.tp_size).reshape(-1)
+        elif key.endswith(".k_norm") and value.size > head_dim:
+            if shard_kv:
+                reshaped = value.reshape(-1, head_dim)
+                out[key] = _slice_first_dim(
+                    reshaped, parallel.rank, parallel.tp_size).reshape(-1)
+            else:
+                out[key] = value
+        else:
+            out[key] = value
+
+    attention_size = int(weights["_attention_size"])
+    kv_attention_size = graph_blocks.infer_kv_attention_size(
+        weights,
+        num_kv_heads=int(config.num_key_value_heads),
+        head_dim=attention_size // int(config.num_attention_heads),
+    )
+    out["_attention_size"] = int(weights["_attention_size"]) // parallel.tp_size
+    out["_kv_attention_size"] = (
+        kv_attention_size // parallel.tp_size if shard_kv else kv_attention_size)
+    out["_num_key_value_heads"] = (
+        int(config.num_key_value_heads) // parallel.tp_size
+        if shard_kv
+        else int(config.num_key_value_heads)
+    )
+    out["_moe_intermediate_size"] = (
+        int(weights["_moe_intermediate_size"]) // parallel.tp_size)
+    if int(weights.get("_dense_intermediate_size", 0)):
+        out["_dense_intermediate_size"] = (
+            int(weights["_dense_intermediate_size"]) // parallel.tp_size)
+    if int(weights.get("_shared_expert_intermediate_size", 0)):
+        out["_shared_expert_intermediate_size"] = (
+            int(weights["_shared_expert_intermediate_size"]) // parallel.tp_size)
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def _add_swiglu_local(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    intermediate_size: int,
+    w_gate: np.ndarray,
+    w_up: np.ndarray,
+    w_down: np.ndarray,
+    *,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    gate = graph_ops.add_matmul_rhs_constant(
+        network, inp, hidden_size, intermediate_size, w_gate, dtype=dtype)
+    up = graph_ops.add_matmul_rhs_constant(
+        network, inp, hidden_size, intermediate_size, w_up, dtype=dtype)
+    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
+    swish = network.add_elementwise(
+        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    gated = network.add_elementwise(
+        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+    down = graph_ops.add_matmul_rhs_constant(
+        network, gated.get_output(0), intermediate_size, hidden_size, w_down,
+        dtype=dtype)
+    return down
+
+
+def _add_swiglu_tp(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    intermediate_size: int,
+    w_gate: np.ndarray,
+    w_up: np.ndarray,
+    w_down: np.ndarray,
+    tp_size: int,
+    *,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    down = _add_swiglu_local(
+        network, inp, hidden_size, intermediate_size, w_gate, w_up, w_down,
+        dtype=dtype)
+    return add_all_reduce_sum(network, down, tp_size)
+
+
+def _add_packed_swiglu_experts_tp(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    w_gate: np.ndarray,
+    w_up: np.ndarray,
+    w_down: np.ndarray,
+    *,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """Compute all rank-local expert outputs with packed batched matmuls."""
+    num_experts, _, _ = w_gate.shape
+
+    inp_3d = network.add_shuffle(inp)
+    inp_3d.reshape_dims = (1, 1, hidden_size)
+    expert_scale = graph_ops.add_constant(
+        network, (num_experts, 1, 1),
+        np.ones((num_experts, 1, 1), dtype=dtype),
+        dtype=dtype,
+    )
+    batched_inp = network.add_elementwise(
+        inp_3d.get_output(0), expert_scale, trt.ElementWiseOperation.PROD)
+
+    gate_w = graph_ops.add_constant(network, w_gate.shape, w_gate, dtype=dtype)
+    up_w = graph_ops.add_constant(network, w_up.shape, w_up, dtype=dtype)
+    down_w = graph_ops.add_constant(network, w_down.shape, w_down, dtype=dtype)
+
+    gate = network.add_matrix_multiply(
+        batched_inp.get_output(0), trt.MatrixOperation.NONE,
+        gate_w, trt.MatrixOperation.NONE)
+    up = network.add_matrix_multiply(
+        batched_inp.get_output(0), trt.MatrixOperation.NONE,
+        up_w, trt.MatrixOperation.NONE)
+    sigmoid = network.add_activation(gate.get_output(0), trt.ActivationType.SIGMOID)
+    swish = network.add_elementwise(
+        gate.get_output(0), sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    gated = network.add_elementwise(
+        swish.get_output(0), up.get_output(0), trt.ElementWiseOperation.PROD)
+    down = network.add_matrix_multiply(
+        gated.get_output(0), trt.MatrixOperation.NONE,
+        down_w, trt.MatrixOperation.NONE)
+    return down.get_output(0)
+
+
+def _add_qwen_moe_tp_block(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    num_experts: int,
+    shared_expert_intermediate: int,
+    top_k: int,
+    tp_size: int,
+    has_shared_expert: bool = True,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    router_logits = graph_ops.add_matmul_rhs_constant(
+        network, inp, hidden_size, num_experts,
+        weights[f"{prefix}.router"], dtype=dtype)
+    sm = network.add_softmax(router_logits)
+    sm.axes = 1 << 1
+    topk = network.add_topk(
+        sm.get_output(0), trt.TopKOperation.MAX, top_k, 1 << 1)
+    top_values = topk.get_output(0)
+    top_indices = topk.get_output(1)
+    sum_val = network.add_reduce(
+        top_values, trt.ReduceOperation.SUM, 1 << 1, keep_dims=True)
+    norm_weights = network.add_elementwise(
+        top_values, sum_val.get_output(0), trt.ElementWiseOperation.DIV)
+
+    expert_outputs = _add_packed_swiglu_experts_tp(
+        network, inp, hidden_size,
+        weights[f"{prefix}.experts.w_gate"],
+        weights[f"{prefix}.experts.w_up"],
+        weights[f"{prefix}.experts.w_down"],
+        dtype=dtype,
+    )
+
+    routed_result = None
+    for top_idx in range(top_k):
+        idx_slice = network.add_slice(
+            top_indices, start=(0, top_idx), shape=(1, 1), stride=(1, 1))
+        idx_flat = network.add_shuffle(idx_slice.get_output(0))
+        idx_flat.reshape_dims = (1,)
+        w_slice = network.add_slice(
+            norm_weights.get_output(0),
+            start=(0, top_idx), shape=(1, 1), stride=(1, 1))
+        w_reshape = network.add_shuffle(w_slice.get_output(0))
+        w_reshape.reshape_dims = (1, 1, 1)
+
+        expert_out = network.add_gather(
+            expert_outputs, idx_flat.get_output(0), 0)
+        scaled = network.add_elementwise(
+            expert_out.get_output(0), w_reshape.get_output(0),
+            trt.ElementWiseOperation.PROD)
+        scaled_flat = network.add_shuffle(scaled.get_output(0))
+        scaled_flat.reshape_dims = (1, hidden_size)
+
+        if routed_result is None:
+            routed_result = scaled_flat.get_output(0)
+        else:
+            summed = network.add_elementwise(
+                routed_result, scaled_flat.get_output(0),
+                trt.ElementWiseOperation.SUM)
+            routed_result = summed.get_output(0)
+
+    local_result = routed_result
+    if has_shared_expert:
+        shared_out = _add_swiglu_local(
+            network, inp, hidden_size, shared_expert_intermediate,
+            weights[f"{prefix}.shared_expert.w_gate"],
+            weights[f"{prefix}.shared_expert.w_up"],
+            weights[f"{prefix}.shared_expert.w_down"],
+            dtype=dtype,
+        )
+        shared_gate_w = weights.get(f"{prefix}.shared_expert_gate")
+        if shared_gate_w is not None:
+            gate_score = graph_ops.add_matmul_rhs_constant(
+                network, inp, hidden_size, 1, shared_gate_w.reshape(-1, 1),
+                dtype=dtype)
+            gate_sigmoid = network.add_activation(
+                gate_score, trt.ActivationType.SIGMOID)
+            gated = network.add_elementwise(
+                shared_out, gate_sigmoid.get_output(0),
+                trt.ElementWiseOperation.PROD)
+            shared_out = gated.get_output(0)
+        combined = network.add_elementwise(
+            local_result, shared_out, trt.ElementWiseOperation.SUM)
+        local_result = combined.get_output(0)
+
+    return add_all_reduce_sum(network, local_result, tp_size)
+
+
+def _add_qwen_moe_tp_decoder_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    attention_mask: trt.ITensor,
+    position_id: trt.ITensor,
+    cos_half_tensor: trt.ITensor,
+    sin_half_tensor: trt.ITensor,
+    eps_tensor: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    attention_size: int,
+    kv_attention_size: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    max_cache_length: int,
+    is_dense: bool,
+    num_experts: int,
+    shared_expert_intermediate: int,
+    dense_intermediate: int,
+    top_k: int,
+    tp_size: int,
+    has_shared_expert: bool = True,
+    dtype: np.dtype = np.float32,
+) -> dict[str, trt.ITensor]:
+    attention_window = max_cache_length + 1
+    norm1 = _apply_norm(
+        network, hidden, hidden_size,
+        weights[f"{prefix}.input_norm"], None, eps_tensor, "rmsnorm",
+        dtype=dtype)
+
+    q = graph_ops.add_matmul_rhs_constant(
+        network, norm1, hidden_size, attention_size,
+        weights[f"{prefix}.w_q"], dtype=dtype)
+    k = graph_ops.add_matmul_rhs_constant(
+        network, norm1, hidden_size, kv_attention_size,
+        weights[f"{prefix}.w_k"], dtype=dtype)
+    v = graph_ops.add_matmul_rhs_constant(
+        network, norm1, hidden_size, kv_attention_size,
+        weights[f"{prefix}.w_v"], dtype=dtype)
+
+    q_norm = weights.get(f"{prefix}.q_norm")
+    if q_norm is not None:
+        q = graph_ops.add_rms_norm_per_head(
+            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype)
+    k_norm = weights.get(f"{prefix}.k_norm")
+    if k_norm is not None:
+        k = graph_ops.add_rms_norm_per_head(
+            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype)
+
+    q = graph_ops.add_apply_rope_native(
+        network, q, num_heads, head_dim, cos_half_tensor, sin_half_tensor,
+        position_id, head_dim)
+    k = graph_ops.add_apply_rope_native(
+        network, k, num_kv_heads, head_dim, cos_half_tensor, sin_half_tensor,
+        position_id, head_dim)
+
+    present_k = k
+    present_v = v
+    k_reshape = network.add_shuffle(k)
+    k_reshape.reshape_dims = (1, kv_attention_size)
+    v_reshape = network.add_shuffle(v)
+    v_reshape.reshape_dims = (1, kv_attention_size)
+    all_k = network.add_concatenation([cache_k, k_reshape.get_output(0)])
+    all_k.axis = 0
+    all_v = network.add_concatenation([cache_v, v_reshape.get_output(0)])
+    all_v.axis = 0
+
+    mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask)
+    context = graph_ops.add_attention_from_rows(
+        network, q, all_k.get_output(0), all_v.get_output(0),
+        num_heads=num_heads, head_dim=head_dim, num_kv_heads=num_kv_heads,
+        q_seq=1, kv_seq=attention_window, causal=False, mask=mask_4d)
+
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, context, attention_size, hidden_size,
+        weights[f"{prefix}.w_o"], dtype=dtype)
+    attn_out = add_all_reduce_sum(network, attn_out, tp_size)
+    residual1 = network.add_elementwise(
+        hidden, attn_out, trt.ElementWiseOperation.SUM)
+
+    norm2 = _apply_norm(
+        network, residual1.get_output(0), hidden_size,
+        weights[f"{prefix}.post_attn_norm"], None, eps_tensor, "rmsnorm",
+        dtype=dtype)
+
+    if is_dense:
+        mlp_out = _add_swiglu_tp(
+            network, norm2, hidden_size, dense_intermediate,
+            weights[f"{prefix}.w_gate"], weights[f"{prefix}.w_up"],
+            weights[f"{prefix}.w_down"], tp_size, dtype=dtype)
+    else:
+        mlp_out = _add_qwen_moe_tp_block(
+            network, norm2, weights, prefix,
+            hidden_size, num_experts, shared_expert_intermediate, top_k,
+            tp_size, has_shared_expert=has_shared_expert, dtype=dtype)
+
+    residual2 = network.add_elementwise(
+        residual1.get_output(0), mlp_out, trt.ElementWiseOperation.SUM)
+
+    return {
+        "hidden": residual2.get_output(0),
+        "post_attn": residual1.get_output(0),
+        "present_k": present_k,
+        "present_v": present_v,
+    }
+
+
+def build_qwen_moe_tp_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    parallel_config=None,
+) -> bytes:
+    del quant_ctx
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_qwen_moe_tp_engine requires tensor_parallel mode with "
+            "tp_size > 1")
+
+    rank_weights = shard_qwen_moe_weights(config, weights, parallel=parallel)
+    attention_size = int(rank_weights["_attention_size"])
+    num_experts = int(rank_weights["_num_experts"])
+    shared_expert_intermediate = int(rank_weights[
+        "_shared_expert_intermediate_size"])
+    dense_intermediate = int(rank_weights["_dense_intermediate_size"])
+    top_k = int(rank_weights["_num_experts_per_tok"])
+    mlp_only_set = set(rank_weights.get("_mlp_only_layers", []))
+    has_shared_expert = bool(rank_weights.get("_has_shared_expert", True))
+
+    hidden = int(config.hidden_size)
+    vocab = int(config.vocab_size)
+    num_layers = int(config.num_hidden_layers)
+    num_heads = int(config.num_attention_heads) // parallel.tp_size
+    num_kv_heads = int(rank_weights["_num_key_value_heads"])
+    head_dim = attention_size // num_heads
+    kv_attention_size = int(rank_weights["_kv_attention_size"])
+    attention_window = max_cache_length + 1
+
+    if precision == "fp16":
+        work_np_dtype = np.float16
+        work_trt_dtype = trt.float16
+    elif precision == "bf16":
+        work_np_dtype = np.float16
+        work_trt_dtype = trt.bfloat16
+    else:
+        work_np_dtype = np.float32
+        work_trt_dtype = trt.float32
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    position_id = network.add_input("position_id", trt.int32, (1,))
+    attention_mask = network.add_input(
+        "attention_mask", trt.float32, (1, attention_window))
+    cache_k_inputs = []
+    cache_v_inputs = []
+    for layer_idx in range(num_layers):
+        cache_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_k", layer_idx),
+            work_trt_dtype, (max_cache_length, kv_attention_size)))
+        cache_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_v", layer_idx),
+            work_trt_dtype, (max_cache_length, kv_attention_size)))
+
+    if work_trt_dtype != trt.float32:
+        attention_mask = network.add_cast(
+            attention_mask, work_trt_dtype).get_output(0)
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), rank_weights["embedding"],
+        dtype=work_np_dtype)
+    graph_ops.validate_native_rope_dim(head_dim, field_name="head_dim")
+    cos_half_np = graph_ops.make_rope_table_half_dim(
+        attention_window, head_dim, config.rope_theta, True)
+    sin_half_np = graph_ops.make_rope_table_half_dim(
+        attention_window, head_dim, config.rope_theta, False)
+    cos_half_tensor = graph_ops.add_constant(
+        network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype)
+    sin_half_tensor = graph_ops.add_constant(
+        network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype)
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1),
+        np.array([config.rms_norm_eps], dtype=work_np_dtype),
+        dtype=work_np_dtype)
+
+    hidden_state = network.add_gather(embedding_table, token_id, 0).get_output(0)
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    present_k_outputs = []
+    present_v_outputs = []
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        result = _add_qwen_moe_tp_decoder_layer(
+            network=network,
+            hidden=hidden_state,
+            cache_k=cache_k_inputs[layer_idx],
+            cache_v=cache_v_inputs[layer_idx],
+            attention_mask=attention_mask,
+            position_id=position_id,
+            cos_half_tensor=cos_half_tensor,
+            sin_half_tensor=sin_half_tensor,
+            eps_tensor=eps_tensor,
+            weights=rank_weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            attention_size=attention_size,
+            kv_attention_size=kv_attention_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            max_cache_length=max_cache_length,
+            is_dense=layer_idx in mlp_only_set,
+            num_experts=num_experts,
+            shared_expert_intermediate=shared_expert_intermediate,
+            dense_intermediate=dense_intermediate,
+            top_k=top_k,
+            tp_size=parallel.tp_size,
+            has_shared_expert=has_shared_expert,
+            dtype=work_np_dtype,
+        )
+        hidden_state = result["hidden"]
+        present_k_outputs.append(result["present_k"])
+        present_v_outputs.append(result["present_v"])
+        if debug_layer_outputs:
+            _mark_debug_output(
+                network, result["post_attn"], f"debug_post_attn_{layer_idx}")
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    final_norm = rank_weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = _apply_norm(
+            network, hidden_state, hidden, final_norm, None, eps_tensor,
+            "rmsnorm", dtype=work_np_dtype)
+
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, vocab, rank_weights["w_out"],
+        dtype=work_np_dtype)
+    logits = graph_ops.add_bias_sum(
+        network, logits, vocab, np.zeros(vocab, dtype=work_np_dtype),
+        dtype=work_np_dtype)
+    if work_trt_dtype != trt.float32:
+        logits = network.add_cast(logits, trt.float32).get_output(0)
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for layer_idx in range(num_layers):
+        present_k_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_k", layer_idx)
+        present_v_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_v", layer_idx)
+        network.mark_output(present_k_outputs[layer_idx])
+        network.mark_output(present_v_outputs[layer_idx])
+
+    if verbose:
+        print(
+            "[trtmc build] Qwen-MoE TP engine "
+            f"(rank={parallel.rank}/{parallel.tp_size}, {num_layers}L, "
+            f"local_attn={attention_size}, local_heads={num_heads}, "
+            f"top_k={top_k}, shared_expert={has_shared_expert}, "
+            f"dense_layers={sorted(mlp_only_set)}, precision={precision})",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT Qwen-MoE TP engine build failed")
+    return bytes(plan)

--- a/tests/builder/test_engine_qwen_moe_tp.py
+++ b/tests/builder/test_engine_qwen_moe_tp.py
@@ -1,0 +1,185 @@
+"""Focused tests for Qwen-MoE tensor-parallel support."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+try:
+    qwen_moe_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen_moe.plugin")
+    from tensorrt_model_connect.families.qwen_moe import tp_builder
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _config(num_kv_heads: int = 4) -> SimpleNamespace:
+    return SimpleNamespace(
+        raw={},
+        hidden_size=8,
+        vocab_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=num_kv_heads,
+        head_dim=2,
+        attention_size=8,
+        intermediate_size=16,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+    )
+
+
+def _weights() -> dict:
+    hidden = 8
+    inter = 16
+    weights: dict[str, object] = {
+        "_attention_size": 8,
+        "_num_experts": 2,
+        "_num_experts_per_tok": 2,
+        "_moe_intermediate_size": inter,
+        "_shared_expert_intermediate_size": inter,
+        "_dense_intermediate_size": inter,
+        "_mlp_only_layers": [1],
+        "_has_shared_expert": True,
+        "embedding": np.zeros((32, hidden), dtype=np.float32),
+        "final_norm": np.ones((hidden,), dtype=np.float32),
+        "w_out": np.zeros((hidden, 32), dtype=np.float32),
+    }
+    for layer_idx in range(2):
+        prefix = f"layer.{layer_idx}"
+        weights[f"{prefix}.input_norm"] = np.ones((hidden,), dtype=np.float32)
+        weights[f"{prefix}.post_attn_norm"] = np.ones((hidden,), dtype=np.float32)
+        weights[f"{prefix}.q_norm"] = np.arange(8, dtype=np.float32)
+        weights[f"{prefix}.k_norm"] = np.arange(8, dtype=np.float32)
+        for key in ("w_q", "w_k", "w_v"):
+            weights[f"{prefix}.{key}"] = np.arange(
+                hidden * 8, dtype=np.float32).reshape(hidden, 8)
+        weights[f"{prefix}.w_o"] = np.arange(
+            8 * hidden, dtype=np.float32).reshape(8, hidden)
+
+    weights["layer.0.router"] = np.zeros((hidden, 2), dtype=np.float32)
+    weights["layer.0.experts.w_gate"] = np.arange(
+        2 * hidden * inter, dtype=np.float32).reshape(2, hidden, inter)
+    weights["layer.0.experts.w_up"] = np.arange(
+        2 * hidden * inter, dtype=np.float32).reshape(2, hidden, inter)
+    weights["layer.0.experts.w_down"] = np.arange(
+        2 * inter * hidden, dtype=np.float32).reshape(2, inter, hidden)
+    for key in ("w_gate", "w_up"):
+        weights[f"layer.0.shared_expert.{key}"] = np.arange(
+            hidden * inter, dtype=np.float32).reshape(hidden, inter)
+    weights["layer.0.shared_expert.w_down"] = np.arange(
+        inter * hidden, dtype=np.float32).reshape(inter, hidden)
+    weights["layer.0.shared_expert_gate"] = np.zeros((1, hidden), dtype=np.float32)
+
+    for key in ("w_gate", "w_up"):
+        weights[f"layer.1.{key}"] = np.arange(
+            hidden * inter, dtype=np.float32).reshape(hidden, inter)
+    weights["layer.1.w_down"] = np.arange(
+        inter * hidden, dtype=np.float32).reshape(inter, hidden)
+    return weights
+
+
+def test_qwen_moe_tp_slices_attention_norms_dense_and_packed_experts():
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+    weights = _weights()
+
+    sharded = tp_builder.shard_qwen_moe_weights(
+        _config(), weights, parallel=parallel)
+
+    np.testing.assert_array_equal(
+        sharded["layer.0.w_q"], weights["layer.0.w_q"][:, 4:6])
+    np.testing.assert_array_equal(
+        sharded["layer.0.w_o"], weights["layer.0.w_o"][4:6, :])
+    np.testing.assert_array_equal(
+        sharded["layer.0.q_norm"], weights["layer.0.q_norm"][4:6])
+    np.testing.assert_array_equal(
+        sharded["layer.0.experts.w_gate"],
+        weights["layer.0.experts.w_gate"][:, :, 8:12],
+    )
+    np.testing.assert_array_equal(
+        sharded["layer.0.experts.w_down"],
+        weights["layer.0.experts.w_down"][:, 8:12, :],
+    )
+    np.testing.assert_array_equal(
+        sharded["layer.0.shared_expert.w_gate"],
+        weights["layer.0.shared_expert.w_gate"][:, 8:12],
+    )
+    np.testing.assert_array_equal(
+        sharded["layer.1.w_down"], weights["layer.1.w_down"][8:12, :])
+    assert sharded["_attention_size"] == 2
+    assert sharded["_moe_intermediate_size"] == 4
+    assert sharded["_dense_intermediate_size"] == 4
+    assert sharded["_shared_expert_intermediate_size"] == 4
+
+
+def test_qwen_moe_tp_validation_rejects_non_divisible_attention_heads():
+    cfg = _config()
+    cfg.num_attention_heads = 3
+    with pytest.raises(ValueError, match="num_attention_heads"):
+        tp_builder._validate_qwen_moe_tp(
+            cfg,
+            _weights(),
+            ParallelConfig(mode="tensor_parallel", tp_size=2, rank=0),
+        )
+
+
+def test_qwen_moe_tp_replicates_non_divisible_kv_heads():
+    weights = _weights()
+    for layer_idx in range(2):
+        prefix = f"layer.{layer_idx}"
+        weights[f"{prefix}.w_k"] = np.arange(
+            8 * 2, dtype=np.float32).reshape(8, 2)
+        weights[f"{prefix}.w_v"] = np.arange(
+            8 * 2, dtype=np.float32).reshape(8, 2)
+        weights[f"{prefix}.k_norm"] = np.arange(2, dtype=np.float32)
+
+    sharded = tp_builder.shard_qwen_moe_weights(
+        _config(num_kv_heads=1),
+        weights,
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=2, rank=1),
+    )
+
+    np.testing.assert_array_equal(sharded["layer.0.w_k"], weights["layer.0.w_k"])
+    np.testing.assert_array_equal(
+        sharded["layer.0.k_norm"], weights["layer.0.k_norm"])
+    assert sharded["_attention_size"] == 4
+    assert sharded["_kv_attention_size"] == 2
+    assert sharded["_num_key_value_heads"] == 1
+
+
+def test_qwen_moe_plugin_routes_parallel_builds(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"qwen-moe-tp-plan"
+
+    monkeypatch.setattr(
+        qwen_moe_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(tp_builder, "build_qwen_moe_tp_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1)
+    result = qwen_moe_module.Qwen3MoePlugin().build_engine(
+        _config(), _weights(), 17,
+        precision="fp16",
+        verbose=True,
+        debug_layer_outputs=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"qwen-moe-tp-plan"
+    assert calls["require"][0] == parallel
+    assert "Qwen-MoE tensor-parallel" in calls["require"][1]
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 17
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["precision"] == "fp16"
+    assert kwargs["verbose"] is True
+    assert kwargs["debug_layer_outputs"] is True

--- a/tests/e2e/models/qwen3-moe-30b-a3b-tp4.json
+++ b/tests/e2e/models/qwen3-moe-30b-a3b-tp4.json
@@ -1,0 +1,61 @@
+{
+  "name": "qwen3-moe-30b-a3b-tp4",
+  "trace_id": "IT-E2E-Q3MOE-TP4-01",
+  "hf_id": "Qwen/Qwen3-30B-A3B",
+  "bundle": "qwen3-moe-30b-a3b-tp4.trtfb",
+  "family": "qwen_moe",
+  "runtime_strategy": "decoder_moe",
+  "ci_tier": "nightly_only",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "precision": "fp16",
+  "max_cache_length": 128,
+  "prompt": "What is the largest planet in our solar system? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.01,
+  "layer_atol": 0.05,
+  "trust_remote_code": false,
+  "metadata": {
+    "single_process_debug_generation": true
+  },
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "debug_logits": true,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "Qwen3-MoE 30B A3B TP4 repro using the same checkpoint, prompt, generation length, and thresholds as qwen3-moe-30b-a3b."
+}


### PR DESCRIPTION
## Summary

- add a Qwen-MoE tensor-parallel builder for dense, routed, and shared-expert layers
- shard Q/O and expert inner dimensions, and replicate K/V when KV heads are not divisible for MQA-style checkpoints
- add `qwen3-moe-30b-a3b-tp4` E2E coverage with the same prompt, generation length, and thresholds as `qwen3-moe-30b-a3b`

## Validation

- `PYTHONPATH=python:. python -m pytest -q tests/builder/test_engine_qwen_moe_tp.py tests/builder/test_manifest_validation.py`
- `python -m pip install --disable-pip-version-check --quiet ruff clang-format && ruff check --config ruff.toml python/tensorrt_model_connect/families/qwen_moe/plugin.py python/tensorrt_model_connect/families/qwen_moe/tp_builder.py tests/builder/test_engine_qwen_moe_tp.py`
- `cmake -S . -B build-qwen-moe-e2e -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so && cmake --build build-qwen-moe-e2e --target trtmc trtmc_backend_trt -j`
- `HF_HOME=/hf-cache PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py -k "qwen3-moe-30b-a3b-tp4" --trtmc-binary ./build-qwen-moe-e2e/trtmc --engine-dir /trtmc-local-storage/engines-qwen-moe-30b-tp4 --e2e-artifacts-dir /trtmc-local-storage/e2e-qwen-moe-30b-tp4 --hf-python /opt/venv/bin/python -s`

Note: the tiny Qwen3-MoE L0 checkpoint has 2 attention heads and 1 KV head. TP4 is invalid for it, and TP2 requires replicated K/V; that path was exercised as a smoke run, but the PR E2E case uses the full 30B A3B model so the harness performs the normal comparison.
