### PR TITLE
feat(deepseek-v2): add tp2 support

### DIFF
--- a/python/tensorrt_model_connect/families/deepseek_v2/plugin.py
+++ b/python/tensorrt_model_connect/families/deepseek_v2/plugin.py
@@ -51,6 +51,10 @@ from ...checkpoint_mapper import (
 )
 from ... import graph_ops
 from ... import graph_blocks
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 from .standard_decoder_builder import _apply_norm, _mark_debug_output
 
 
@@ -293,7 +297,22 @@ class DeepSeekV2Plugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
         debug_layer_outputs: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="DeepSeek-V2 tensor-parallel builds")
+            from .tp_builder import build_deepseek_v2_tp_engine
+            return build_deepseek_v2_tp_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                parallel_config=parallel,
+            )
+
         hidden = config.hidden_size
         vocab = config.vocab_size
         num_layers = config.num_hidden_layers

--- a/python/tensorrt_model_connect/families/deepseek_v2/tp_builder.py
+++ b/python/tensorrt_model_connect/families/deepseek_v2/tp_builder.py
@@ -1,0 +1,651 @@
+"""Tensor-parallel DeepSeek-V2 builder."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+from .standard_decoder_builder import _apply_norm, _mark_debug_output
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _is_moe_layer(weights: "WeightDict", layer_idx: int) -> bool:
+    first = int(weights["_first_k_dense_replace"])
+    freq = int(weights["_moe_layer_freq"])
+    return layer_idx >= first and (layer_idx - first) % freq == 0
+
+
+def _validate_deepseek_v2_tp(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError(
+            "DeepSeek-V2 tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if int(config.num_attention_heads) % tp != 0:
+        raise ValueError(
+            "DeepSeek-V2 tensor parallel requires num_attention_heads "
+            f"divisible by tp_size ({config.num_attention_heads} vs {tp})")
+
+    checks = {
+        "moe_intermediate_size": int(weights["_moe_intermediate_size"]),
+        "shared_intermediate_size": int(weights["_shared_intermediate_size"]),
+        "dense_intermediate_size": int(config.intermediate_size),
+    }
+    for name, value in checks.items():
+        if value % tp != 0:
+            raise ValueError(
+                f"DeepSeek-V2 tensor parallel requires {name} divisible by "
+                f"tp_size ({value} vs {tp})")
+
+
+def shard_deepseek_v2_weights(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local DeepSeek-V2 weights for the TP builder."""
+    _validate_deepseek_v2_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        if key.endswith((".w_q", ".w_q_b", ".w_kv_b", ".w_gate", ".w_up")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_o", ".w_down")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_attention_size"] = int(weights["_attention_size"]) // parallel.tp_size
+    out["_moe_intermediate_size"] = (
+        int(weights["_moe_intermediate_size"]) // parallel.tp_size)
+    out["_shared_intermediate_size"] = (
+        int(weights["_shared_intermediate_size"]) // parallel.tp_size)
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def _add_swiglu_local(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    intermediate_size: int,
+    w_gate: np.ndarray,
+    w_up: np.ndarray,
+    w_down: np.ndarray,
+) -> trt.ITensor:
+    gate = graph_ops.add_matmul_rhs_constant(
+        network, inp, hidden_size, intermediate_size, w_gate)
+    up = graph_ops.add_matmul_rhs_constant(
+        network, inp, hidden_size, intermediate_size, w_up)
+    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
+    swish = network.add_elementwise(
+        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    gated = network.add_elementwise(
+        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+    return graph_ops.add_matmul_rhs_constant(
+        network, gated.get_output(0), intermediate_size, hidden_size, w_down)
+
+
+def _add_swiglu_tp(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    intermediate_size: int,
+    w_gate: np.ndarray,
+    w_up: np.ndarray,
+    w_down: np.ndarray,
+    tp_size: int,
+) -> trt.ITensor:
+    local = _add_swiglu_local(
+        network, inp, hidden_size, intermediate_size, w_gate, w_up, w_down)
+    return add_all_reduce_sum(network, local, tp_size)
+
+
+def _add_deepseek_tp_moe_block(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    n_routed_experts: int,
+    moe_intermediate: int,
+    num_experts_per_tok: int,
+    shared_intermediate: int,
+    tp_size: int,
+    norm_topk_prob: bool = False,
+    routed_scaling_factor: float = 1.0,
+) -> trt.ITensor:
+    router_logits = graph_ops.add_matmul_rhs_constant(
+        network, inp, hidden_size, n_routed_experts,
+        weights[f"{prefix}.router"])
+    sm = network.add_softmax(router_logits)
+    sm.axes = 1 << 1
+    topk = network.add_topk(
+        sm.get_output(0), trt.TopKOperation.MAX,
+        num_experts_per_tok, 1 << 1)
+    top_values = topk.get_output(0)
+    top_indices = topk.get_output(1)
+
+    if norm_topk_prob:
+        sum_val = network.add_reduce(
+            top_values, trt.ReduceOperation.SUM, 1 << 1, keep_dims=True)
+        scaled_weights = network.add_elementwise(
+            top_values, sum_val.get_output(0), trt.ElementWiseOperation.DIV
+        ).get_output(0)
+    elif routed_scaling_factor != 1.0:
+        scale_c = graph_ops.add_constant(
+            network, (1, 1),
+            np.array([[routed_scaling_factor]], dtype=np.float32))
+        scaled_weights = network.add_elementwise(
+            top_values, scale_c, trt.ElementWiseOperation.PROD).get_output(0)
+    else:
+        scaled_weights = top_values
+
+    expert_outputs = []
+    for expert_idx in range(n_routed_experts):
+        expert_outputs.append(_add_swiglu_local(
+            network, inp, hidden_size, moe_intermediate,
+            weights[f"{prefix}.expert.{expert_idx}.w_gate"],
+            weights[f"{prefix}.expert.{expert_idx}.w_up"],
+            weights[f"{prefix}.expert.{expert_idx}.w_down"],
+        ))
+
+    stacked = network.add_concatenation(expert_outputs)
+    stacked.axis = 0
+    stacked_out = stacked.get_output(0)
+
+    routed_local = None
+    for top_idx in range(num_experts_per_tok):
+        idx_slice = network.add_slice(
+            top_indices, start=(0, top_idx), shape=(1, 1), stride=(1, 1))
+        idx_flat = network.add_shuffle(idx_slice.get_output(0))
+        idx_flat.reshape_dims = (1,)
+        w_slice = network.add_slice(
+            scaled_weights, start=(0, top_idx), shape=(1, 1), stride=(1, 1))
+        expert_out = network.add_gather(stacked_out, idx_flat.get_output(0), 0)
+        scaled = network.add_elementwise(
+            expert_out.get_output(0), w_slice.get_output(0),
+            trt.ElementWiseOperation.PROD)
+        if routed_local is None:
+            routed_local = scaled.get_output(0)
+        else:
+            summed = network.add_elementwise(
+                routed_local, scaled.get_output(0), trt.ElementWiseOperation.SUM)
+            routed_local = summed.get_output(0)
+
+    shared_local = _add_swiglu_local(
+        network, inp, hidden_size, shared_intermediate,
+        weights[f"{prefix}.shared.w_gate"],
+        weights[f"{prefix}.shared.w_up"],
+        weights[f"{prefix}.shared.w_down"],
+    )
+    local_total = network.add_elementwise(
+        routed_local, shared_local, trt.ElementWiseOperation.SUM)
+    return add_all_reduce_sum(network, local_total.get_output(0), tp_size)
+
+
+def _add_mla_attention_tp(
+    *,
+    network: trt.INetworkDefinition,
+    normed: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    attention_mask: trt.ITensor,
+    position_id: trt.ITensor,
+    cos_half_tensor: trt.ITensor,
+    sin_half_tensor: trt.ITensor,
+    attn_scale: float,
+    eps_tensor: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    num_heads: int,
+    qk_nope_head_dim: int,
+    qk_rope_head_dim: int,
+    v_head_dim: int,
+    kv_lora_rank: int,
+    q_lora_rank,
+    attention_size: int,
+    max_cache_length: int,
+    tp_size: int,
+) -> dict[str, trt.ITensor]:
+    attention_window = max_cache_length + 1
+    k_head_dim = qk_nope_head_dim + qk_rope_head_dim
+    q_total = num_heads * k_head_dim
+    rope_total = num_heads * qk_rope_head_dim
+
+    if q_lora_rank is not None and q_lora_rank > 0:
+        q_compressed = graph_ops.add_matmul_rhs_constant(
+            network, normed, hidden_size, q_lora_rank,
+            weights[f"{prefix}.w_q_a"])
+        q_compressed = graph_ops.add_rms_norm(
+            network, q_compressed, q_lora_rank,
+            weights[f"{prefix}.q_a_norm"], eps_tensor)
+        q = graph_ops.add_matmul_rhs_constant(
+            network, q_compressed, q_lora_rank, q_total,
+            weights[f"{prefix}.w_q_b"])
+    else:
+        q = graph_ops.add_matmul_rhs_constant(
+            network, normed, hidden_size, q_total,
+            weights[f"{prefix}.w_q"])
+
+    q_reshaped = network.add_shuffle(q)
+    q_reshaped.reshape_dims = (num_heads, k_head_dim)
+    q_nope = network.add_slice(
+        q_reshaped.get_output(0), start=(0, 0),
+        shape=(num_heads, qk_nope_head_dim), stride=(1, 1)).get_output(0)
+    q_rope_slice = network.add_slice(
+        q_reshaped.get_output(0), start=(0, qk_nope_head_dim),
+        shape=(num_heads, qk_rope_head_dim), stride=(1, 1))
+    q_rope_flat = network.add_shuffle(q_rope_slice.get_output(0))
+    q_rope_flat.reshape_dims = (1, rope_total)
+    q_rope_roped = graph_ops.add_apply_rope_native(
+        network, q_rope_flat.get_output(0), num_heads, qk_rope_head_dim,
+        cos_half_tensor, sin_half_tensor, position_id,
+        qk_rope_head_dim, interleaved=True)
+    q_rope_heads = network.add_shuffle(q_rope_roped)
+    q_rope_heads.reshape_dims = (num_heads, qk_rope_head_dim)
+    q_full_cat = network.add_concatenation([q_nope, q_rope_heads.get_output(0)])
+    q_full_cat.axis = 1
+
+    kv_a_dim = kv_lora_rank + qk_rope_head_dim
+    c_kv = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, kv_a_dim,
+        weights[f"{prefix}.w_kv_a"])
+    c_kv_latent = network.add_slice(
+        c_kv, start=(0, 0), shape=(1, kv_lora_rank), stride=(1, 1)
+    ).get_output(0)
+    k_rope_pass = network.add_slice(
+        c_kv, start=(0, kv_lora_rank), shape=(1, qk_rope_head_dim),
+        stride=(1, 1)).get_output(0)
+    c_kv_normed = graph_ops.add_rms_norm(
+        network, c_kv_latent, kv_lora_rank,
+        weights[f"{prefix}.kv_a_norm"], eps_tensor)
+
+    kv_b_out_dim = num_heads * (qk_nope_head_dim + v_head_dim)
+    kv_expanded = graph_ops.add_matmul_rhs_constant(
+        network, c_kv_normed, kv_lora_rank, kv_b_out_dim,
+        weights[f"{prefix}.w_kv_b"])
+    kv_per_head = network.add_shuffle(kv_expanded)
+    kv_per_head.reshape_dims = (num_heads, qk_nope_head_dim + v_head_dim)
+    k_nope = network.add_slice(
+        kv_per_head.get_output(0), start=(0, 0),
+        shape=(num_heads, qk_nope_head_dim), stride=(1, 1)).get_output(0)
+    v_heads = network.add_slice(
+        kv_per_head.get_output(0), start=(0, qk_nope_head_dim),
+        shape=(num_heads, v_head_dim), stride=(1, 1)).get_output(0)
+
+    k_rope_roped = graph_ops.add_apply_rope_native(
+        network, k_rope_pass, 1, qk_rope_head_dim,
+        cos_half_tensor, sin_half_tensor, position_id,
+        qk_rope_head_dim, interleaved=True)
+    k_rope_copies = [k_rope_roped for _ in range(num_heads)]
+    k_rope_broadcast = network.add_concatenation(k_rope_copies)
+    k_rope_broadcast.axis = 0
+    k_full_cat = network.add_concatenation([k_nope, k_rope_broadcast.get_output(0)])
+    k_full_cat.axis = 1
+
+    pad_size = k_head_dim - v_head_dim
+    if pad_size > 0:
+        zero_pad = graph_ops.add_constant(
+            network, (num_heads, pad_size),
+            np.zeros((num_heads, pad_size), dtype=np.float32))
+        v_padded_cat = network.add_concatenation([v_heads, zero_pad])
+        v_padded_cat.axis = 1
+        v_padded = v_padded_cat.get_output(0)
+    else:
+        v_padded = v_heads
+
+    k_flat = network.add_shuffle(k_full_cat.get_output(0))
+    k_flat.reshape_dims = (1, attention_size)
+    v_flat = network.add_shuffle(v_padded)
+    v_flat.reshape_dims = (1, attention_size)
+    present_k = k_flat.get_output(0)
+    present_v = v_flat.get_output(0)
+
+    all_k = network.add_concatenation([cache_k, present_k])
+    all_k.axis = 0
+    all_v = network.add_concatenation([cache_v, present_v])
+    all_v.axis = 0
+    q_flat = network.add_shuffle(q_full_cat.get_output(0))
+    q_flat.reshape_dims = (1, attention_size)
+    mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask)
+    attn_context = graph_ops.add_attention_from_rows(
+        network, q_flat.get_output(0), all_k.get_output(0), all_v.get_output(0),
+        num_heads=num_heads, head_dim=k_head_dim, q_seq=1,
+        kv_seq=attention_window, mask=mask_4d, scale=attn_scale)
+
+    if pad_size > 0:
+        context_heads = network.add_shuffle(attn_context)
+        context_heads.reshape_dims = (num_heads, k_head_dim)
+        context_sliced = network.add_slice(
+            context_heads.get_output(0), start=(0, 0),
+            shape=(num_heads, v_head_dim), stride=(1, 1))
+        context_flat = network.add_shuffle(context_sliced.get_output(0))
+        context_flat.reshape_dims = (1, num_heads * v_head_dim)
+        attn_context = context_flat.get_output(0)
+
+    v_total = num_heads * v_head_dim
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, attn_context, v_total, hidden_size,
+        weights[f"{prefix}.w_o"])
+    attn_out = add_all_reduce_sum(network, attn_out, tp_size)
+
+    return {
+        "attn_out": attn_out,
+        "present_k": present_k,
+        "present_v": present_v,
+    }
+
+
+def _add_decoder_layer_tp(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    attention_mask: trt.ITensor,
+    position_id: trt.ITensor,
+    cos_half_tensor: trt.ITensor,
+    sin_half_tensor: trt.ITensor,
+    attn_scale: float,
+    eps_tensor: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    num_heads: int,
+    qk_nope_head_dim: int,
+    qk_rope_head_dim: int,
+    v_head_dim: int,
+    kv_lora_rank: int,
+    q_lora_rank,
+    attention_size: int,
+    max_cache_length: int,
+    is_moe_layer: bool,
+    n_routed_experts: int,
+    num_experts_per_tok: int,
+    moe_intermediate: int,
+    shared_intermediate: int,
+    dense_intermediate: int,
+    tp_size: int,
+    norm_topk_prob: bool = False,
+    routed_scaling_factor: float = 1.0,
+) -> dict[str, trt.ITensor]:
+    norm1 = _apply_norm(
+        network, hidden, hidden_size,
+        weights[f"{prefix}.input_norm"], None, eps_tensor, "rmsnorm")
+    attn = _add_mla_attention_tp(
+        network=network,
+        normed=norm1,
+        cache_k=cache_k,
+        cache_v=cache_v,
+        attention_mask=attention_mask,
+        position_id=position_id,
+        cos_half_tensor=cos_half_tensor,
+        sin_half_tensor=sin_half_tensor,
+        attn_scale=attn_scale,
+        eps_tensor=eps_tensor,
+        weights=weights,
+        prefix=prefix,
+        hidden_size=hidden_size,
+        num_heads=num_heads,
+        qk_nope_head_dim=qk_nope_head_dim,
+        qk_rope_head_dim=qk_rope_head_dim,
+        v_head_dim=v_head_dim,
+        kv_lora_rank=kv_lora_rank,
+        q_lora_rank=q_lora_rank,
+        attention_size=attention_size,
+        max_cache_length=max_cache_length,
+        tp_size=tp_size,
+    )
+    residual1 = network.add_elementwise(
+        hidden, attn["attn_out"], trt.ElementWiseOperation.SUM)
+    norm2 = _apply_norm(
+        network, residual1.get_output(0), hidden_size,
+        weights[f"{prefix}.post_attn_norm"], None, eps_tensor, "rmsnorm")
+
+    if is_moe_layer:
+        mlp_out = _add_deepseek_tp_moe_block(
+            network, norm2, weights, prefix,
+            hidden_size, n_routed_experts, moe_intermediate,
+            num_experts_per_tok, shared_intermediate, tp_size,
+            norm_topk_prob=norm_topk_prob,
+            routed_scaling_factor=routed_scaling_factor)
+    else:
+        mlp_out = _add_swiglu_tp(
+            network, norm2, hidden_size, dense_intermediate,
+            weights[f"{prefix}.w_gate"],
+            weights[f"{prefix}.w_up"],
+            weights[f"{prefix}.w_down"],
+            tp_size,
+        )
+
+    residual2 = network.add_elementwise(
+        residual1.get_output(0), mlp_out, trt.ElementWiseOperation.SUM)
+    return {
+        "hidden": residual2.get_output(0),
+        "post_attn": residual1.get_output(0),
+        "present_k": attn["present_k"],
+        "present_v": attn["present_v"],
+    }
+
+
+def _make_rope_tables(
+    config: "ModelConfig",
+    attention_window: int,
+    qk_rope_head_dim: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    rope_scaling = config.raw.get("rope_scaling")
+    if rope_scaling and rope_scaling.get("type") == "yarn":
+        yarn_kwargs = dict(
+            scaling_factor=rope_scaling["factor"],
+            original_max_position_embeddings=rope_scaling[
+                "original_max_position_embeddings"],
+            beta_fast=rope_scaling["beta_fast"],
+            beta_slow=rope_scaling["beta_slow"],
+        )
+        return (
+            graph_ops.make_yarn_rope_table_half_dim(
+                attention_window, qk_rope_head_dim, config.rope_theta,
+                True, **yarn_kwargs, interleaved=True),
+            graph_ops.make_yarn_rope_table_half_dim(
+                attention_window, qk_rope_head_dim, config.rope_theta,
+                False, **yarn_kwargs, interleaved=True),
+        )
+    return (
+        graph_ops.make_rope_table_half_dim(
+            attention_window, qk_rope_head_dim,
+            config.rope_theta, True, interleaved=True),
+        graph_ops.make_rope_table_half_dim(
+            attention_window, qk_rope_head_dim,
+            config.rope_theta, False, interleaved=True),
+    )
+
+
+def build_deepseek_v2_tp_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    parallel_config=None,
+) -> bytes:
+    del precision, quant_ctx
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_deepseek_v2_tp_engine requires tensor_parallel mode with "
+            "tp_size > 1")
+
+    rank_weights = shard_deepseek_v2_weights(config, weights, parallel=parallel)
+    hidden = int(config.hidden_size)
+    vocab = int(config.vocab_size)
+    num_layers = int(config.num_hidden_layers)
+    num_heads = int(config.num_attention_heads) // parallel.tp_size
+    qk_nope_head_dim = int(rank_weights["_qk_nope_head_dim"])
+    qk_rope_head_dim = int(rank_weights["_qk_rope_head_dim"])
+    v_head_dim = int(rank_weights["_v_head_dim"])
+    kv_lora_rank = int(rank_weights["_kv_lora_rank"])
+    q_lora_rank = rank_weights["_q_lora_rank"]
+    n_routed_experts = int(rank_weights["_n_routed_experts"])
+    num_experts_per_tok = int(rank_weights["_num_experts_per_tok"])
+    moe_intermediate = int(rank_weights["_moe_intermediate_size"])
+    shared_intermediate = int(rank_weights["_shared_intermediate_size"])
+    dense_intermediate = int(config.intermediate_size) // parallel.tp_size
+    norm_topk_prob = bool(rank_weights["_norm_topk_prob"])
+    routed_scaling_factor = float(rank_weights["_routed_scaling_factor"])
+
+    k_head_dim = qk_nope_head_dim + qk_rope_head_dim
+    attention_size = num_heads * k_head_dim
+    attention_window = max_cache_length + 1
+    attn_scale = 1.0 / np.sqrt(max(k_head_dim, 1))
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    position_id = network.add_input("position_id", trt.int32, (1,))
+    attention_mask = network.add_input(
+        "attention_mask", trt.float32, (1, attention_window))
+    cache_k_inputs = []
+    cache_v_inputs = []
+    for layer_idx in range(num_layers):
+        cache_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_k", layer_idx),
+            trt.float32, (max_cache_length, attention_size)))
+        cache_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_v", layer_idx),
+            trt.float32, (max_cache_length, attention_size)))
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), rank_weights["embedding"])
+    cos_half_np, sin_half_np = _make_rope_tables(
+        config, attention_window, qk_rope_head_dim)
+    cos_half_tensor = graph_ops.add_constant(network, cos_half_np.shape, cos_half_np)
+    sin_half_tensor = graph_ops.add_constant(network, sin_half_np.shape, sin_half_np)
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=np.float32))
+
+    hidden_state = network.add_gather(embedding_table, token_id, 0).get_output(0)
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    present_k_outputs = []
+    present_v_outputs = []
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        result = _add_decoder_layer_tp(
+            network=network,
+            hidden=hidden_state,
+            cache_k=cache_k_inputs[layer_idx],
+            cache_v=cache_v_inputs[layer_idx],
+            attention_mask=attention_mask,
+            position_id=position_id,
+            cos_half_tensor=cos_half_tensor,
+            sin_half_tensor=sin_half_tensor,
+            attn_scale=attn_scale,
+            eps_tensor=eps_tensor,
+            weights=rank_weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            num_heads=num_heads,
+            qk_nope_head_dim=qk_nope_head_dim,
+            qk_rope_head_dim=qk_rope_head_dim,
+            v_head_dim=v_head_dim,
+            kv_lora_rank=kv_lora_rank,
+            q_lora_rank=q_lora_rank,
+            attention_size=attention_size,
+            max_cache_length=max_cache_length,
+            is_moe_layer=_is_moe_layer(rank_weights, layer_idx),
+            n_routed_experts=n_routed_experts,
+            num_experts_per_tok=num_experts_per_tok,
+            moe_intermediate=moe_intermediate,
+            shared_intermediate=shared_intermediate,
+            dense_intermediate=dense_intermediate,
+            tp_size=parallel.tp_size,
+            norm_topk_prob=norm_topk_prob,
+            routed_scaling_factor=routed_scaling_factor,
+        )
+        hidden_state = result["hidden"]
+        present_k_outputs.append(result["present_k"])
+        present_v_outputs.append(result["present_v"])
+        if debug_layer_outputs:
+            _mark_debug_output(
+                network, result["post_attn"], f"debug_post_attn_{layer_idx}")
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    final_norm = rank_weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = _apply_norm(
+            network, hidden_state, hidden, final_norm, None,
+            eps_tensor, "rmsnorm")
+
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, vocab, rank_weights["w_out"])
+    logits = graph_ops.add_bias_sum(
+        network, logits, vocab, np.zeros(vocab, dtype=np.float32))
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for layer_idx in range(num_layers):
+        present_k_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_k", layer_idx)
+        present_v_outputs[layer_idx].name = graph_ops.layer_tensor_name(
+            "present_v", layer_idx)
+        network.mark_output(present_k_outputs[layer_idx])
+        network.mark_output(present_v_outputs[layer_idx])
+
+    if verbose:
+        print(
+            "[trtmc build] DeepSeek-V2 TP engine "
+            f"(rank={parallel.rank}/{parallel.tp_size}, {num_layers}L, "
+            f"local_heads={num_heads}, local_attn={attention_size}, "
+            f"local_moe={moe_intermediate})",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT DeepSeek-V2 TP engine build failed")
+    return bytes(plan)

--- a/tests/builder/test_engine_deepseek_v2_tp.py
+++ b/tests/builder/test_engine_deepseek_v2_tp.py
@@ -1,0 +1,176 @@
+"""Focused tests for DeepSeek-V2 tensor-parallel support."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+try:
+    deepseek_module = importlib.import_module(
+        "tensorrt_model_connect.families.deepseek_v2.plugin")
+    from tensorrt_model_connect.families.deepseek_v2 import tp_builder
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _config(num_heads: int = 4) -> SimpleNamespace:
+    return SimpleNamespace(
+        raw={},
+        hidden_size=8,
+        vocab_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=num_heads,
+        num_key_value_heads=num_heads,
+        head_dim=4,
+        attention_size=16,
+        intermediate_size=16,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+    )
+
+
+def _weights() -> dict:
+    hidden = 8
+    q_lora = 8
+    kv_lora = 8
+    heads = 4
+    nope = 2
+    rope = 2
+    v_dim = 2
+    inter = 16
+    shared = 32
+    weights: dict[str, object] = {
+        "_attention_size": heads * (nope + rope),
+        "_qk_nope_head_dim": nope,
+        "_qk_rope_head_dim": rope,
+        "_v_head_dim": v_dim,
+        "_kv_lora_rank": kv_lora,
+        "_q_lora_rank": q_lora,
+        "_n_routed_experts": 2,
+        "_n_shared_experts": 2,
+        "_num_experts_per_tok": 2,
+        "_first_k_dense_replace": 1,
+        "_moe_layer_freq": 1,
+        "_moe_intermediate_size": inter,
+        "_shared_intermediate_size": shared,
+        "_norm_topk_prob": False,
+        "_routed_scaling_factor": 1.0,
+        "embedding": np.zeros((32, hidden), dtype=np.float32),
+        "final_norm": np.ones((hidden,), dtype=np.float32),
+        "w_out": np.zeros((hidden, 32), dtype=np.float32),
+    }
+    for layer_idx in range(2):
+        prefix = f"layer.{layer_idx}"
+        weights[f"{prefix}.input_norm"] = np.ones((hidden,), dtype=np.float32)
+        weights[f"{prefix}.post_attn_norm"] = np.ones((hidden,), dtype=np.float32)
+        weights[f"{prefix}.w_q_a"] = np.arange(
+            hidden * q_lora, dtype=np.float32).reshape(hidden, q_lora)
+        weights[f"{prefix}.q_a_norm"] = np.ones((q_lora,), dtype=np.float32)
+        weights[f"{prefix}.w_q_b"] = np.arange(
+            q_lora * heads * (nope + rope), dtype=np.float32
+        ).reshape(q_lora, heads * (nope + rope))
+        weights[f"{prefix}.w_kv_a"] = np.arange(
+            hidden * (kv_lora + rope), dtype=np.float32
+        ).reshape(hidden, kv_lora + rope)
+        weights[f"{prefix}.kv_a_norm"] = np.ones((kv_lora,), dtype=np.float32)
+        weights[f"{prefix}.w_kv_b"] = np.arange(
+            kv_lora * heads * (nope + v_dim), dtype=np.float32
+        ).reshape(kv_lora, heads * (nope + v_dim))
+        weights[f"{prefix}.w_o"] = np.arange(
+            heads * v_dim * hidden, dtype=np.float32).reshape(heads * v_dim, hidden)
+
+    for key in ("w_gate", "w_up"):
+        weights[f"layer.0.{key}"] = np.arange(
+            hidden * inter, dtype=np.float32).reshape(hidden, inter)
+    weights["layer.0.w_down"] = np.arange(
+        inter * hidden, dtype=np.float32).reshape(inter, hidden)
+
+    weights["layer.1.router"] = np.zeros((hidden, 2), dtype=np.float32)
+    for expert_idx in range(2):
+        prefix = f"layer.1.expert.{expert_idx}"
+        for key in ("w_gate", "w_up"):
+            weights[f"{prefix}.{key}"] = np.arange(
+                hidden * inter, dtype=np.float32).reshape(hidden, inter)
+        weights[f"{prefix}.w_down"] = np.arange(
+            inter * hidden, dtype=np.float32).reshape(inter, hidden)
+    for key in ("w_gate", "w_up"):
+        weights[f"layer.1.shared.{key}"] = np.arange(
+            hidden * shared, dtype=np.float32).reshape(hidden, shared)
+    weights["layer.1.shared.w_down"] = np.arange(
+        shared * hidden, dtype=np.float32).reshape(shared, hidden)
+    return weights
+
+
+def test_deepseek_v2_tp_slices_mla_and_mlp_weights():
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+    weights = _weights()
+
+    sharded = tp_builder.shard_deepseek_v2_weights(
+        _config(), weights, parallel=parallel)
+
+    np.testing.assert_array_equal(
+        sharded["layer.0.w_q_b"], weights["layer.0.w_q_b"][:, 8:12])
+    np.testing.assert_array_equal(
+        sharded["layer.0.w_kv_b"], weights["layer.0.w_kv_b"][:, 8:12])
+    np.testing.assert_array_equal(
+        sharded["layer.0.w_kv_a"], weights["layer.0.w_kv_a"])
+    np.testing.assert_array_equal(
+        sharded["layer.0.w_o"], weights["layer.0.w_o"][4:6, :])
+    np.testing.assert_array_equal(
+        sharded["layer.0.w_gate"], weights["layer.0.w_gate"][:, 8:12])
+    np.testing.assert_array_equal(
+        sharded["layer.1.expert.0.w_down"],
+        weights["layer.1.expert.0.w_down"][8:12, :],
+    )
+    np.testing.assert_array_equal(
+        sharded["layer.1.shared.w_gate"],
+        weights["layer.1.shared.w_gate"][:, 16:24],
+    )
+    assert sharded["_attention_size"] == 4
+    assert sharded["_moe_intermediate_size"] == 4
+    assert sharded["_shared_intermediate_size"] == 8
+
+
+def test_deepseek_v2_tp_validation_rejects_non_divisible_attention_heads():
+    with pytest.raises(ValueError, match="num_attention_heads"):
+        tp_builder._validate_deepseek_v2_tp(
+            _config(num_heads=3),
+            _weights(),
+            ParallelConfig(mode="tensor_parallel", tp_size=2, rank=0),
+        )
+
+
+def test_deepseek_v2_plugin_routes_parallel_builds(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"deepseek-v2-tp-plan"
+
+    monkeypatch.setattr(
+        deepseek_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(tp_builder, "build_deepseek_v2_tp_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=2, rank=1)
+    result = deepseek_module.DeepSeekV2Plugin().build_engine(
+        _config(), _weights(), 17,
+        verbose=True,
+        debug_layer_outputs=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"deepseek-v2-tp-plan"
+    assert calls["require"][0] == parallel
+    assert "DeepSeek-V2 tensor-parallel" in calls["require"][1]
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 17
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["verbose"] is True
+    assert kwargs["debug_layer_outputs"] is True

--- a/tests/e2e/models/deepseek-v2-tiny-tp2.json
+++ b/tests/e2e/models/deepseek-v2-tiny-tp2.json
@@ -1,0 +1,57 @@
+{
+  "name": "deepseek-v2-tiny-tp2",
+  "trace_id": "IT-E2E-DSV2T-TP2-01",
+  "hf_id": "yujiepan/deepseek-v3-tiny-random",
+  "bundle": "deepseek-v2-tiny-tp2.trtfb",
+  "family": "deepseek_v2",
+  "runtime_strategy": "decoder_kv_cache",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 64,
+  "prompt": "The capital of France is",
+  "max_new_tokens": 10,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 2
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 2,
+    "debug_logits": true,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 2
+      },
+      "gating": true
+    }
+  ],
+  "notes": "DeepSeek-V2 tiny TP2 repro using the same checkpoint, prompt, generation length, and thresholds as deepseek-v2-tiny. TP4 is invalid because this checkpoint has 2 attention heads."
+}


### PR DESCRIPTION
## Background
DeepSeek-V2 needed a tensor-parallel E2E path following the repo pattern of keeping TP-specific logic in a separate builder. The available tiny DeepSeek-V2/V3 checkpoint has 2 attention heads, so TP4 is not valid for this model and the test uses TP2.

## Exit Criteria
- Add DeepSeek-V2 tensor-parallel build support without changing the single-device builder behavior.
- Add a multi-device E2E manifest that keeps the single-device prompt, generation length, and accuracy thresholds.
- Verify the focused unit coverage, lint, C++ build, and DeepSeek-V2 TP2 E2E test before opening the PR.

## Implementation
- Route DeepSeek-V2 builds with `parallel.mode=tensor_parallel` through a new `tp_builder.py`.
- Shard MLA head projections and dense, routed, and shared MoE inner dimensions by TP rank, then join local attention/MLP outputs with distributed all-reduce.
- Add focused builder tests for sharding validation and plugin routing.
- Add `deepseek-v2-tiny-tp2.json` as a multi-device E2E manifest with `world_size=2`.

## Validation
- `PYTHONPATH=python:. python -m pytest -q tests/builder/test_engine_deepseek_v2_tp.py tests/builder/test_manifest_validation.py`: passed, `29 passed in 0.24s`.
- `ruff check --config ruff.toml python/tensorrt_model_connect/families/deepseek_v2/plugin.py python/tensorrt_model_connect/families/deepseek_v2/tp_builder.py tests/builder/test_engine_deepseek_v2_tp.py`: passed.
- `cmake -S . -B build-deepseek-v2-e2e -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so && cmake --build build-deepseek-v2-e2e --target trtmc trtmc_backend_trt -j`: passed in the B200 Docker image.
- `HF_HOME=/hf-cache PYTHONPATH=python:. python -m pytest -q tests/test_e2e.py --multi-device-only -k "deepseek-v2-tiny-tp2" --trtmc-binary ./build-deepseek-v2-e2e/trtmc --engine-dir /trtmc-local-storage/engines-deepseek-v2-tp2 --e2e-artifacts-dir /trtmc-local-storage/e2e-deepseek-v2-tp2 --hf-python /opt/venv/bin/python -s`: passed, `1 passed, 12 deselected in 64.23s`.

## Notes For Future Readers
- Review `tp_builder.py` first; `plugin.py` only dispatches parallel builds into that implementation.
- TP4 should not be enabled for this tiny checkpoint unless a different checkpoint with attention heads divisible by 4 is used.
