### PR TITLE
test(deepseek-v2): add Lite TP4 e2e

### DIFF
--- a/tests/e2e/models/deepseek-v2-lite-tp4.json
+++ b/tests/e2e/models/deepseek-v2-lite-tp4.json
@@ -1,0 +1,57 @@
+{
+  "name": "deepseek-v2-lite-tp4",
+  "trace_id": "IT-E2E-DSV2L-TP4-01",
+  "hf_id": "deepseek-ai/DeepSeek-V2-Lite",
+  "bundle": "deepseek-v2-lite-tp4.trtfb",
+  "family": "deepseek_v2",
+  "runtime_strategy": "decoder_kv_cache",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 128,
+  "prompt": "The capital of France is",
+  "max_new_tokens": 10,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "debug_logits": true,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "DeepSeek-V2 Lite TP4 repro using the same checkpoint, prompt, generation length, and thresholds as deepseek-v2-lite."
+}


### PR DESCRIPTION
## Background
PR #137 added DeepSeek-V2 tensor-parallel coverage using the tiny checkpoint. DeepSeek-V2 Lite already has single-device nightly coverage, but did not have a full Lite tensor-parallel E2E manifest.

## Exit Criteria
- Add a DeepSeek-V2 Lite multi-device E2E manifest using TP4.
- Keep thresholds, prompt, generation length, and cache length aligned with the single-device `deepseek-v2-lite` manifest.
- Validate the new case on the B200 host using host GPUs 4-7 before opening the PR.

## Implementation
- Added `deepseek-v2-lite-tp4` as a `multi_device` E2E manifest for the existing `deepseek_v2` family.
- The manifest uses the existing DeepSeek-V2 TP builder through `build_args.parallel.tp_size = 4`, `mpirun` world size 4, and the same logit/layer thresholds as `deepseek-v2-lite`.
- ADR intentionally skipped because this is a new manifest for an existing family and runtime path.

## Validation
- `pytest tests/builder/test_manifest_validation.py -q`: passed, 26 tests.
- `cmake --build build-b200-trt11-local-trt --target trtmc -j 16`: passed inside fresh `b200` container.
- `pytest -p no:cacheprovider -s "tests/test_e2e.py::test_e2e[deepseek-v2-lite-tp4]" --multi-device-only --engine-dir /tmp/trtmc-deepseek-v2-lite-tp4/engines --e2e-artifacts-dir /tmp/trtmc-deepseek-v2-lite-tp4/artifacts-rerun --trtmc-binary build-b200-trt11-local-trt/trtmc --hf-python /opt/venv/bin/python`: passed, 1 test in 107.56s, using the bundle built in the same fresh B200 container.

## Notes For Future Readers
- Validation ran in `trtmc-b200-deepseek-lite-tp4`, a fresh `b200` Docker container attached to host GPU UUIDs for GPUs 4-7. Inside Docker those appear as GPU indices 0-3.
- The first E2E run completed the full bundle build in 1477.49s and wrote a 64 GB bundle, then hit a container-only `getpwuid()` failure because it was launched as an unmapped numeric UID. The rerun used the same bundle as root in the same fresh container and passed.
