### PR TITLE
feat(encoder): add tensor parallel support

### DIFF
--- a/python/tensorrt_model_connect/families/bert/plugin.py
+++ b/python/tensorrt_model_connect/families/bert/plugin.py
@@ -23,6 +23,10 @@ from ...checkpoint_mapper import (
     _load_tensor,
     _has_tensor,
 )
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 from .encoder_builder import build_encoder_engine
 
 
@@ -167,7 +171,21 @@ class BertPlugin:
         self, config: ModelConfig, weights: WeightDict,
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="BERT tensor-parallel builds")
+            if quant_ctx is not None:
+                raise ValueError("BERT tensor-parallel builds do not support quantization")
+            from .tp_builder import build_tp_encoder_engine
+            return build_tp_encoder_engine(
+                config, weights,
+                max_seq_length=max_cache_length,
+                verbose=verbose,
+                parallel_config=parallel)
+
         return build_encoder_engine(
             config, weights,
             max_seq_length=max_cache_length,

--- a/python/tensorrt_model_connect/families/bert/tp_builder.py
+++ b/python/tensorrt_model_connect/families/bert/tp_builder.py
@@ -1,0 +1,430 @@
+"""Tensor-parallel encoder-only engine builder (BERT-style).
+
+Builds one rank-local TensorRT engine for an encoder-only transformer. Unlike
+the standard decoder builder, this has:
+  - No KV cache (processes entire sequence at once)
+  - No causal attention mask (full bidirectional attention)
+  - POST-norm architecture (residual + LayerNorm after attention/FFN)
+  - Token type embeddings (segment A/B)
+  - Output: hidden_states [seq_len, hidden_size]
+
+Tensor parallelism only changes the encoder projections:
+  - Q/K/V and FFN fc1 are column-parallel
+  - Attention output and FFN fc2 are row-parallel
+  - Row-parallel outputs are joined with TensorRT distributed ALL_REDUCE
+
+Tensor names for the C++ runtime:
+  Inputs:  input_ids [seq_len], attention_mask [seq_len]
+  Outputs: hidden_states [seq_len, hidden_size]
+
+token_type_ids is baked as constant zeros (single-segment inference).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...config import ModelConfig
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_encoder_tp(
+    config: ModelConfig,
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("BERT tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if config.num_attention_heads % tp != 0:
+        raise ValueError(
+            "BERT tensor parallel requires num_attention_heads divisible by "
+            f"tp_size ({config.num_attention_heads} vs {tp})")
+    if config.intermediate_size % tp != 0:
+        raise ValueError(
+            "BERT tensor parallel requires intermediate_size divisible by "
+            f"tp_size ({config.intermediate_size} vs {tp})")
+
+    for layer_idx in range(config.num_hidden_layers):
+        prefix = f"layer.{layer_idx}"
+        for key in (f"{prefix}.w_q", f"{prefix}.w_k", f"{prefix}.w_v"):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_o"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_o input dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc1"].shape[-1] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc1 output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc2"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc2 input dim must be divisible by tp_size")
+
+    if "relative_position_bias" in weights and weights["relative_position_bias"].shape[0] % tp != 0:
+        raise ValueError(
+            "relative_position_bias head dim must be divisible by tp_size")
+
+
+def shard_encoder_weights(
+    config: ModelConfig,
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local BERT-style encoder weights for the TP builder."""
+    _validate_encoder_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        if key.endswith((".w_q", ".w_k", ".w_v", ".w_fc1")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".q_bias", ".k_bias", ".v_bias", ".fc1_bias")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_o", ".w_fc2")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key == "relative_position_bias":
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_attention_size"] = config.attention_size // parallel.tp_size
+    out["_intermediate_size"] = config.intermediate_size // parallel.tp_size
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def build_tp_encoder_engine(
+    config: ModelConfig,
+    weights: "WeightDict",
+    max_seq_length: int,
+    *,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build a rank-local TRT engine plan for a BERT-style encoder.
+
+    Args:
+        config: Model architecture from config.json.
+        weights: Loaded weight dict from BERT plugin.
+        max_seq_length: Maximum sequence length the engine is compiled for.
+        verbose: Print TRT builder logs.
+
+    Returns:
+        Serialized engine plan bytes.
+    """
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_tp_encoder_engine requires tensor_parallel mode and tp_size > 1")
+    weights = shard_encoder_weights(config, weights, parallel=parallel)
+
+    hidden = config.hidden_size
+    num_layers = config.num_hidden_layers
+    full_num_heads = config.num_attention_heads
+    num_heads = config.num_attention_heads // parallel.tp_size
+    head_dim = hidden // full_num_heads
+    intermediate = config.intermediate_size // parallel.tp_size
+    eps = config.rms_norm_eps  # Actually layer_norm_eps for BERT
+    type_vocab_size = config.raw.get("type_vocab_size", 2)
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
+    # which causes significant accuracy loss across 12+ encoder layers.
+    trt_config.clear_flag(trt.BuilderFlag.TF32)
+
+    # Resolve GELU variant from config
+    hidden_act = config.hidden_act or config.raw.get("activation", "") or "gelu"
+
+    # -------------------------------------------------------------------
+    # Inputs
+    # -------------------------------------------------------------------
+    input_ids = network.add_input("input_ids", trt.int32, (max_seq_length,))
+    attention_mask_input = network.add_input("attention_mask", trt.int32, (max_seq_length,))
+
+    # token_type_ids: constant zeros (all segment-0) — the C++ encoder
+    # pipeline doesn't provide this input, and inference is single-segment.
+    tt_zeros = network.add_constant(
+        (max_seq_length,), trt.Weights(np.zeros(max_seq_length, dtype=np.int32)))
+    token_type_ids = tt_zeros.get_output(0)
+
+    # -------------------------------------------------------------------
+    # Shared constants (support embedding factorization: embedding_size != hidden)
+    # -------------------------------------------------------------------
+    embedding_size = weights["embedding"].shape[1]  # may differ from hidden (e.g. ALBERT 128 vs 768)
+    embedding_table = graph_ops.add_constant(
+        network, weights["embedding"].shape, weights["embedding"])
+    position_embed_table = graph_ops.add_constant(
+        network, weights["position_embedding"].shape, weights["position_embedding"])
+    token_type_table = graph_ops.add_constant(
+        network, (type_vocab_size, embedding_size), weights["token_type_embedding"])
+
+    graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+    attn_scale_tensor = graph_ops.add_constant(
+        network, (1, 1, 1), np.array([1.0 / np.sqrt(max(head_dim, 1))], dtype=np.float32))
+
+    # Build additive attention mask from attention_mask input:
+    # attention_mask is [seq_len] with 1=real, 0=padding.
+    # Convert to [1, 1, seq_len] additive mask: 0.0 for real, -1e10 for padding.
+    mask_float = network.add_cast(attention_mask_input, trt.float32)
+    ones_mask = graph_ops.add_constant(
+        network, (1,), np.array([1.0], dtype=np.float32))
+    neg_large = graph_ops.add_constant(
+        network, (1,), np.array([-1e10], dtype=np.float32))
+    inv_mask = network.add_elementwise(
+        ones_mask, mask_float.get_output(0),
+        trt.ElementWiseOperation.SUB)  # 0 for real, 1 for pad
+    pad_penalty = network.add_elementwise(
+        inv_mask.get_output(0), neg_large,
+        trt.ElementWiseOperation.PROD)  # 0.0 for real, -1e10 for pad
+    # Reshape to [1, 1, seq_len] for broadcasting: [num_heads, seq_len, seq_len]
+    pad_mask_reshape = network.add_shuffle(pad_penalty.get_output(0))
+    pad_mask_reshape.reshape_dims = (1, 1, max_seq_length)
+
+    # Position indices: [0, 1, 2, ..., max_seq_length-1]
+    position_indices = graph_ops.add_constant(
+        network, (max_seq_length,),
+        np.arange(max_seq_length, dtype=np.int32).astype(np.float32))
+    # Cast back to int32 for gather
+    pos_int = network.add_cast(position_indices, trt.int32)
+
+    # -------------------------------------------------------------------
+    # Embedding: word + position + token_type + LayerNorm
+    # -------------------------------------------------------------------
+    word_embed = network.add_gather(embedding_table, input_ids, 0)
+    pos_embed = network.add_gather(position_embed_table, pos_int.get_output(0), 0)
+    tt_embed = network.add_gather(token_type_table, token_type_ids, 0)
+
+    # Sum all three embedding types
+    embed_sum1 = network.add_elementwise(
+        word_embed.get_output(0), pos_embed.get_output(0),
+        trt.ElementWiseOperation.SUM)
+    embed_sum2 = network.add_elementwise(
+        embed_sum1.get_output(0), tt_embed.get_output(0),
+        trt.ElementWiseOperation.SUM)
+
+    # Embedding LayerNorm (over embedding_size, which may differ from hidden)
+    hidden_state = _add_seq_layer_norm(
+        network, embed_sum2.get_output(0), embedding_size, max_seq_length,
+        weights["embed_norm"], weights["embed_norm_beta"], eps)
+
+    # Optional embedding projection: embedding_size -> hidden_size (ALBERT, FNet)
+    if "embed_projection" in weights:
+        hidden_state = graph_ops.add_matmul_rhs_constant(
+            network, hidden_state, embedding_size, hidden,
+            weights["embed_projection"])
+        if "embed_projection_bias" in weights:
+            hidden_state = graph_ops.add_bias_sum(
+                network, hidden_state, hidden,
+                weights["embed_projection_bias"])
+
+    # -------------------------------------------------------------------
+    # Optional relative position bias (MPNet, T5-style)
+    # -------------------------------------------------------------------
+    rel_pos_bias_tensor = None
+    if "relative_position_bias" in weights:
+        # Pre-computed [num_heads, seq_len, seq_len] bias matrix
+        rpb = weights["relative_position_bias"]
+        rel_pos_bias_tensor = graph_ops.add_constant(
+            network, rpb.shape, rpb)
+
+    # -------------------------------------------------------------------
+    # Encoder layers
+    # -------------------------------------------------------------------
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+
+        hidden_state = _add_encoder_layer(
+            network=network,
+            hidden=hidden_state,
+            weights=weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            intermediate_size=intermediate,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            seq_length=max_seq_length,
+            attn_scale_tensor=attn_scale_tensor,
+            attn_mask=pad_mask_reshape.get_output(0),
+            rel_pos_bias=rel_pos_bias_tensor,
+            hidden_act=hidden_act,
+            eps=eps,
+            tp_size=parallel.tp_size,
+        )
+
+    # -------------------------------------------------------------------
+    # Output
+    # -------------------------------------------------------------------
+    hidden_state.name = "hidden_states"
+    network.mark_output(hidden_state)
+
+    # -------------------------------------------------------------------
+    # Build engine
+    # -------------------------------------------------------------------
+    if verbose:
+        print(f"[trtmc build] Building BERT encoder TRT engine "
+              f"({num_layers} layers, hidden={hidden}, tp={parallel.tp_size}, "
+              f"seq_len={max_seq_length}) ...", file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT engine build failed")
+
+    return bytes(plan)
+
+
+def _add_seq_layer_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    seq_length: int,
+    gamma: np.ndarray,
+    beta: np.ndarray,
+    eps: float,
+) -> trt.ITensor:
+    """LayerNorm over sequence of vectors: [seq_len, hidden] -> [seq_len, hidden].
+
+    Uses the shared TRT native normalization helper.
+    """
+    return graph_ops.add_layer_norm_native(
+        network, inp, hidden_size, gamma, beta, eps)
+
+
+def _add_encoder_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    weights: WeightDict,
+    prefix: str,
+    hidden_size: int,
+    intermediate_size: int,
+    num_heads: int,
+    head_dim: int,
+    seq_length: int,
+    attn_scale_tensor: trt.ITensor,
+    attn_mask: trt.ITensor,
+    rel_pos_bias: trt.ITensor | None = None,
+    hidden_act: str = "gelu",
+    eps: float,
+    tp_size: int,
+) -> trt.ITensor:
+    """Add one BERT encoder layer with POST-norm.
+
+    BERT architecture per layer:
+        attn_out = MultiHeadSelfAttention(hidden)
+        hidden = LayerNorm(hidden + attn_out)  # post-norm
+        ffn_out = FFN(hidden)
+        hidden = LayerNorm(hidden + ffn_out)   # post-norm
+    """
+    attention_size = num_heads * head_dim
+
+    # --- Self-attention (no causal mask, bidirectional) ---
+    # QKV projections
+    q = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_q"])
+    k = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_k"])
+    v = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_v"])
+
+    # QKV biases
+    q = graph_ops.add_bias_sum(network, q, attention_size, weights[f"{prefix}.q_bias"])
+    k = graph_ops.add_bias_sum(network, k, attention_size, weights[f"{prefix}.k_bias"])
+    v = graph_ops.add_bias_sum(network, v, attention_size, weights[f"{prefix}.v_bias"])
+
+    # Add relative position bias if present (MPNet/T5-style). IAttention
+    # applies scaling internally through graph_ops.add_attention_from_rows, so
+    # the mask contains only additive bias/masking terms.
+    additive_mask = attn_mask
+    if rel_pos_bias is not None:
+        additive_mask = network.add_elementwise(
+            rel_pos_bias, attn_mask, trt.ElementWiseOperation.SUM).get_output(0)
+
+    mask_4d = network.add_shuffle(additive_mask)
+    mask_4d.reshape_dims = (
+        (1, num_heads, seq_length, seq_length)
+        if rel_pos_bias is not None
+        else (1, 1, 1, seq_length)
+    )
+
+    context_flat = graph_ops.add_attention_from_rows(
+        network, q, k, v,
+        num_heads=num_heads, head_dim=head_dim,
+        q_seq=seq_length, kv_seq=seq_length,
+        mask=mask_4d.get_output(0),
+        tag=prefix + ".attn")
+
+    # Output projection
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, context_flat,
+        attention_size, hidden_size,
+        weights[f"{prefix}.w_o"])
+    attn_out = add_all_reduce_sum(network, attn_out, tp_size)
+    attn_out = graph_ops.add_bias_sum(
+        network, attn_out, hidden_size, weights[f"{prefix}.o_bias"])
+
+    # POST-norm: LayerNorm(hidden + attn_out)
+    residual1 = network.add_elementwise(
+        hidden, attn_out, trt.ElementWiseOperation.SUM)
+    normed1 = _add_seq_layer_norm(
+        network, residual1.get_output(0), hidden_size, seq_length,
+        weights[f"{prefix}.post_attn_norm"],
+        weights[f"{prefix}.post_attn_norm_beta"], eps)
+
+    # --- FFN: fc1 -> GELU -> fc2 ---
+    fc1 = graph_ops.add_matmul_rhs_constant(
+        network, normed1, hidden_size, intermediate_size,
+        weights[f"{prefix}.w_fc1"])
+    fc1 = graph_ops.add_bias_sum(network, fc1, intermediate_size,
+                                  weights[f"{prefix}.fc1_bias"])
+    activated = graph_ops.add_activation(network, fc1, hidden_act)
+    fc2 = graph_ops.add_matmul_rhs_constant(
+        network, activated, intermediate_size, hidden_size,
+        weights[f"{prefix}.w_fc2"])
+    fc2 = add_all_reduce_sum(network, fc2, tp_size)
+    fc2 = graph_ops.add_bias_sum(network, fc2, hidden_size,
+                                  weights[f"{prefix}.fc2_bias"])
+
+    # POST-norm: LayerNorm(normed1 + ffn_out)
+    residual2 = network.add_elementwise(
+        normed1, fc2, trt.ElementWiseOperation.SUM)
+    normed2 = _add_seq_layer_norm(
+        network, residual2.get_output(0), hidden_size, seq_length,
+        weights[f"{prefix}.output_norm"],
+        weights[f"{prefix}.output_norm_beta"], eps)
+
+    return normed2

--- a/python/tensorrt_model_connect/families/convbert/plugin.py
+++ b/python/tensorrt_model_connect/families/convbert/plugin.py
@@ -36,6 +36,10 @@ from ...checkpoint_mapper import (
     _load_tensor,
     _has_tensor,
 )
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 
 
 class ConvBertPlugin:
@@ -187,8 +191,23 @@ class ConvBertPlugin:
 
     def build_engine(
         self, config: ModelConfig, weights: WeightDict,
-        max_cache_length: int, *, verbose: bool = False,
+        max_cache_length: int, *, precision: str = "fp32",
+        quant_ctx=None, verbose: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="ConvBERT tensor-parallel builds")
+            if quant_ctx is not None:
+                raise ValueError("ConvBERT tensor-parallel builds do not support quantization")
+            from .tp_builder import build_tp_convbert_encoder_engine
+            return build_tp_convbert_encoder_engine(
+                config, weights,
+                max_seq_length=max_cache_length,
+                verbose=verbose,
+                parallel_config=parallel)
+
         from .builder import build_convbert_encoder_engine
         return build_convbert_encoder_engine(
             config, weights,

--- a/python/tensorrt_model_connect/families/convbert/tp_builder.py
+++ b/python/tensorrt_model_connect/families/convbert/tp_builder.py
@@ -1,0 +1,631 @@
+"""ConvBERT encoder builder — custom TRT engine builder for ConvBERT.
+
+ConvBERT has a hybrid architecture where each layer uses BOTH:
+  1. Standard multi-head self-attention (on half the head dimensions)
+  2. Span-based dynamic convolution (on the other half)
+
+The two outputs are concatenated and projected back to hidden_size.
+
+Key implementation details:
+  - SeparableConv1D is implemented as depthwise conv1d + pointwise conv1d (1x1)
+  - Unfold (im2col) for sliding windows is implemented via slice+concat on 4D tensors
+  - Dynamic conv kernels are generated per-position, softmaxed, then applied
+  - All operations use static shapes (no dynamic axes)
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...config import ModelConfig
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _slice_convbert_output_rows(
+    arr: np.ndarray,
+    *,
+    rank: int,
+    tp_size: int,
+    all_head_size: int,
+) -> np.ndarray:
+    local_all = all_head_size // tp_size
+    attn_start = rank * local_all
+    conv_start = all_head_size + rank * local_all
+    return np.ascontiguousarray(np.concatenate(
+        [
+            arr[attn_start:attn_start + local_all, :],
+            arr[conv_start:conv_start + local_all, :],
+        ],
+        axis=0,
+    ))
+
+
+def _validate_convbert_tp(
+    config: ModelConfig,
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("ConvBERT tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    new_num_heads = int(weights["_convbert_new_num_heads"][0])
+    all_head_size = int(weights["_convbert_all_head_size"][0])
+    if new_num_heads % tp != 0:
+        raise ValueError(
+            "ConvBERT tensor parallel requires effective attention heads divisible "
+            f"by tp_size ({new_num_heads} vs {tp})")
+    if all_head_size % tp != 0:
+        raise ValueError(
+            "ConvBERT tensor parallel requires all_head_size divisible by "
+            f"tp_size ({all_head_size} vs {tp})")
+    if config.intermediate_size % tp != 0:
+        raise ValueError(
+            "ConvBERT tensor parallel requires intermediate_size divisible by "
+            f"tp_size ({config.intermediate_size} vs {tp})")
+
+    for layer_idx in range(config.num_hidden_layers):
+        prefix = f"layer.{layer_idx}"
+        for key in (f"{prefix}.w_q", f"{prefix}.w_k", f"{prefix}.w_v"):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim must be divisible by tp_size")
+        for key in (f"{prefix}.q_bias", f"{prefix}.k_bias", f"{prefix}.v_bias"):
+            if weights[key].shape[0] % tp != 0:
+                raise ValueError(f"{key} dim must be divisible by tp_size")
+        if weights[f"{prefix}.conv_out_w"].shape[-1] % tp != 0:
+            raise ValueError(f"{prefix}.conv_out_w output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc1"].shape[-1] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc1 output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc2"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc2 input dim must be divisible by tp_size")
+
+
+def shard_convbert_weights(
+    config: ModelConfig,
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local ConvBERT weights for the TP builder."""
+    _validate_convbert_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    full_new_num_heads = int(weights["_convbert_new_num_heads"][0])
+    full_all_head_size = int(weights["_convbert_all_head_size"][0])
+    local_new_num_heads = full_new_num_heads // parallel.tp_size
+    local_all_head_size = full_all_head_size // parallel.tp_size
+
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        if key.endswith((".w_q", ".w_k", ".w_v", ".conv_out_w", ".w_fc1")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((
+            ".q_bias", ".k_bias", ".v_bias", ".sep_conv_pw", ".sep_conv_bias",
+            ".conv_out_bias", ".fc1_bias",
+        )):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".conv_kernel_w"):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".w_o"):
+            out[key] = _slice_convbert_output_rows(
+                value,
+                rank=parallel.rank,
+                tp_size=parallel.tp_size,
+                all_head_size=full_all_head_size)
+        elif key.endswith(".w_fc2"):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_convbert_full_new_num_heads"] = np.array([full_new_num_heads], dtype=np.int32)
+    out["_convbert_full_all_head_size"] = np.array([full_all_head_size], dtype=np.int32)
+    out["_convbert_new_num_heads"] = np.array([local_new_num_heads], dtype=np.int32)
+    out["_convbert_all_head_size"] = np.array([local_all_head_size], dtype=np.int32)
+    out["_intermediate_size"] = config.intermediate_size // parallel.tp_size
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def build_tp_convbert_encoder_engine(
+    config: ModelConfig,
+    weights: WeightDict,
+    max_seq_length: int,
+    *,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build a rank-local TRT engine plan for ConvBERT encoder."""
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_tp_convbert_encoder_engine requires tensor_parallel mode and tp_size > 1")
+    weights = shard_convbert_weights(config, weights, parallel=parallel)
+
+    hidden = config.hidden_size
+    embedding_size = config.raw.get("embedding_size", hidden)
+    vocab = config.vocab_size
+    num_layers = config.num_hidden_layers
+    eps = config.rms_norm_eps  # layer_norm_eps
+    type_vocab_size = config.raw.get("type_vocab_size", 2)
+    hidden_act = config.hidden_act or "gelu"
+    intermediate = config.intermediate_size // parallel.tp_size
+
+    # ConvBERT specific
+    new_num_heads = int(weights["_convbert_new_num_heads"][0])
+    full_new_num_heads = int(weights["_convbert_full_new_num_heads"][0])
+    head_size = int(weights["_convbert_head_size"][0])
+    all_head_size = int(weights["_convbert_all_head_size"][0])
+    conv_kernel_size = int(weights["_convbert_conv_kernel_size"][0])
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    trt_config.clear_flag(trt.BuilderFlag.TF32)
+
+    S = max_seq_length  # alias for brevity
+
+    # -------------------------------------------------------------------
+    # Inputs
+    # -------------------------------------------------------------------
+    input_ids = network.add_input("input_ids", trt.int32, (S,))
+    attention_mask_input = network.add_input("attention_mask", trt.int32, (S,))
+
+    # token_type_ids: constant zeros (all segment-0) — the C++ encoder
+    # pipeline doesn't provide this input, and inference is single-segment.
+    tt_zeros = network.add_constant(
+        (S,), trt.Weights(np.zeros(S, dtype=np.int32)))
+    token_type_ids = tt_zeros.get_output(0)
+
+    # -------------------------------------------------------------------
+    # Shared constants
+    # -------------------------------------------------------------------
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, embedding_size), weights["embedding"])
+    position_embed_table = graph_ops.add_constant(
+        network, weights["position_embedding"].shape, weights["position_embedding"])
+    token_type_table = graph_ops.add_constant(
+        network, (type_vocab_size, embedding_size), weights["token_type_embedding"])
+
+    # Additive attention mask: [1, 1, S]
+    mask_float = network.add_cast(attention_mask_input, trt.float32)
+    ones_mask = graph_ops.add_constant(network, (1,), np.array([1.0], dtype=np.float32))
+    neg_large = graph_ops.add_constant(network, (1,), np.array([-1e10], dtype=np.float32))
+    inv_mask = network.add_elementwise(
+        ones_mask, mask_float.get_output(0), trt.ElementWiseOperation.SUB)
+    pad_penalty = network.add_elementwise(
+        inv_mask.get_output(0), neg_large, trt.ElementWiseOperation.PROD)
+    pad_mask_reshape = network.add_shuffle(pad_penalty.get_output(0))
+    pad_mask_reshape.reshape_dims = (1, 1, S)
+    attn_mask = pad_mask_reshape.get_output(0)
+
+    # Position indices
+    position_indices = graph_ops.add_constant(
+        network, (S,), np.arange(S, dtype=np.int32).astype(np.float32))
+    pos_int = network.add_cast(position_indices, trt.int32)
+
+    # -------------------------------------------------------------------
+    # Embedding: word + position + token_type + LayerNorm
+    # -------------------------------------------------------------------
+    word_embed = network.add_gather(embedding_table, input_ids, 0)
+    pos_embed = network.add_gather(position_embed_table, pos_int.get_output(0), 0)
+    tt_embed = network.add_gather(token_type_table, token_type_ids, 0)
+
+    embed_sum1 = network.add_elementwise(
+        word_embed.get_output(0), pos_embed.get_output(0), trt.ElementWiseOperation.SUM)
+    embed_sum2 = network.add_elementwise(
+        embed_sum1.get_output(0), tt_embed.get_output(0), trt.ElementWiseOperation.SUM)
+
+    hidden_state = _add_seq_layer_norm(
+        network, embed_sum2.get_output(0), embedding_size, S,
+        weights["embed_norm"], weights["embed_norm_beta"], eps)
+
+    # -------------------------------------------------------------------
+    # Encoder layers
+    # -------------------------------------------------------------------
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+
+        hidden_state = _add_convbert_layer(
+            network=network,
+            hidden=hidden_state,
+            weights=weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            intermediate_size=intermediate,
+            new_num_heads=new_num_heads,
+            full_new_num_heads=full_new_num_heads,
+            head_size=head_size,
+            all_head_size=all_head_size,
+            conv_kernel_size=conv_kernel_size,
+            seq_length=S,
+            attn_mask=attn_mask,
+            hidden_act=hidden_act,
+            eps=eps,
+            tp_size=parallel.tp_size,
+            tp_rank=parallel.rank,
+        )
+
+    # -------------------------------------------------------------------
+    # Output
+    # -------------------------------------------------------------------
+    hidden_state.name = "hidden_states"
+    network.mark_output(hidden_state)
+
+    # -------------------------------------------------------------------
+    # Build engine
+    # -------------------------------------------------------------------
+    if verbose:
+        print(f"[trtmc build] Building ConvBERT encoder TRT engine "
+              f"({num_layers} layers, hidden={hidden}, tp={parallel.tp_size}, "
+              f"seq_len={S}, conv_kernel={conv_kernel_size}) ...", file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT engine build failed")
+
+    return bytes(plan)
+
+
+def _add_seq_layer_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    seq_length: int,
+    gamma: np.ndarray,
+    beta: np.ndarray,
+    eps: float,
+) -> trt.ITensor:
+    """LayerNorm over [seq_len, hidden] using TRT native normalization."""
+    return graph_ops.add_layer_norm_native(
+        network, inp, hidden_size, gamma, beta, eps)
+
+
+def _add_separable_conv1d(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    all_head_size: int,
+    conv_kernel_size: int,
+    seq_length: int,
+    dw_weight: np.ndarray,
+    pw_weight: np.ndarray,
+    bias: np.ndarray,
+) -> trt.ITensor:
+    """SeparableConv1D: depthwise conv1d + pointwise conv1d + bias.
+
+    Input: [seq_len, hidden_size] (our 2D layout)
+    Output: [seq_len, all_head_size]
+    """
+    pad = conv_kernel_size // 2
+
+    # Reshape: [seq, hidden] -> [1, hidden, seq, 1] for TRT Conv2d
+    shuf_in = network.add_shuffle(inp)
+    shuf_in.first_transpose = trt.Permutation([1, 0])  # [hidden, seq]
+    shuf_in.reshape_dims = (1, hidden_size, seq_length, 1)
+
+    # Depthwise convolution: kernel [hidden, 1, kernel_size, 1]
+    dw_w_4d = dw_weight.reshape(hidden_size, 1, conv_kernel_size, 1)
+    dw_trt = trt.Weights(np.ascontiguousarray(dw_w_4d, dtype=np.float32))
+    dw_conv = network.add_convolution_nd(
+        shuf_in.get_output(0),
+        num_output_maps=hidden_size,
+        kernel_shape=(conv_kernel_size, 1),
+        kernel=dw_trt,
+    )
+    dw_conv.padding_nd = (pad, 0)
+    dw_conv.num_groups = hidden_size
+
+    # Pointwise conv: kernel [all_head_size, hidden, 1, 1]
+    pw_w_4d = pw_weight.reshape(all_head_size, hidden_size, 1, 1)
+    pw_trt = trt.Weights(np.ascontiguousarray(pw_w_4d, dtype=np.float32))
+    pw_conv = network.add_convolution_nd(
+        dw_conv.get_output(0),
+        num_output_maps=all_head_size,
+        kernel_shape=(1, 1),
+        kernel=pw_trt,
+    )
+
+    # Add bias: [1, all_head_size, 1, 1]
+    bias_4d = graph_ops.add_constant(
+        network, (1, all_head_size, 1, 1), bias.reshape(1, all_head_size, 1, 1))
+    biased = network.add_elementwise(
+        pw_conv.get_output(0), bias_4d, trt.ElementWiseOperation.SUM)
+
+    # Reshape: [1, all_head_size, seq, 1] -> [seq, all_head_size]
+    squeeze = network.add_shuffle(biased.get_output(0))
+    squeeze.reshape_dims = (all_head_size, seq_length)
+    squeeze.second_transpose = trt.Permutation([1, 0])
+
+    return squeeze.get_output(0)
+
+
+def _add_unfold(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    channels: int,
+    seq_length: int,
+    kernel_size: int,
+) -> trt.ITensor:
+    """Unfold (im2col) for 1D signal.
+
+    Input: [channels, seq_length] (channel-first)
+    Output: [channels * kernel_size, seq_length]
+
+    For each position p, gathers values at positions [p-pad, ..., p+pad]
+    for each channel, with zero-padding at boundaries.
+
+    Uses TRT slice layers with zero-fill mode for out-of-bounds positions.
+    """
+    pad = kernel_size // 2
+    shifts = []
+
+    # Expand to 4D: [1, channels, seq_length, 1] for TRT padding (requires 4D)
+    expand = network.add_shuffle(inp)
+    expand.reshape_dims = (1, channels, seq_length, 1)
+    inp_4d = expand.get_output(0)
+
+    for k in range(kernel_size):
+        offset = k - pad  # shift amount: -pad to +pad
+
+        if offset == 0:
+            # No shift needed
+            identity = network.add_shuffle(inp_4d)
+            identity.reshape_dims = (channels, seq_length)
+            shifts.append(identity.get_output(0))
+        elif offset < 0:
+            # Pad left (prepend zeros along H=seq dim), slice from start
+            abs_off = -offset
+            # For 4D [N,C,H,W], padding is 2D: (H_pad, W_pad)
+            pad_layer = network.add_padding_nd(
+                inp_4d,
+                pre_padding=(abs_off, 0),
+                post_padding=(0, 0),
+            )
+            # Slice from start: [1, channels, seq_length, 1]
+            sl = network.add_slice(
+                pad_layer.get_output(0),
+                start=(0, 0, 0, 0),
+                shape=(1, channels, seq_length, 1),
+                stride=(1, 1, 1, 1),
+            )
+            reshape = network.add_shuffle(sl.get_output(0))
+            reshape.reshape_dims = (channels, seq_length)
+            shifts.append(reshape.get_output(0))
+        else:
+            # Pad right (append zeros along H=seq dim), slice from offset
+            pad_layer = network.add_padding_nd(
+                inp_4d,
+                pre_padding=(0, 0),
+                post_padding=(offset, 0),
+            )
+            # Slice from offset: [1, channels, seq_length, 1]
+            sl = network.add_slice(
+                pad_layer.get_output(0),
+                start=(0, 0, offset, 0),
+                shape=(1, channels, seq_length, 1),
+                stride=(1, 1, 1, 1),
+            )
+            reshape = network.add_shuffle(sl.get_output(0))
+            reshape.reshape_dims = (channels, seq_length)
+            shifts.append(reshape.get_output(0))
+
+    # Concatenate along channel dim: [channels * kernel_size, seq_length]
+    if len(shifts) == 1:
+        return shifts[0]
+    cat = network.add_concatenation(shifts)
+    cat.axis = 0  # channel dim
+    return cat.get_output(0)
+
+
+def _add_convbert_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    weights: WeightDict,
+    prefix: str,
+    hidden_size: int,
+    intermediate_size: int,
+    new_num_heads: int,
+    full_new_num_heads: int,
+    head_size: int,
+    all_head_size: int,
+    conv_kernel_size: int,
+    seq_length: int,
+    attn_mask: trt.ITensor,
+    hidden_act: str,
+    eps: float,
+    tp_size: int,
+    tp_rank: int,
+) -> trt.ITensor:
+    """Add one ConvBERT encoder layer with mixed attention + dynamic convolution."""
+    S = seq_length
+
+    # === Branch 1: Standard multi-head self-attention ===
+    q = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, all_head_size, weights[f"{prefix}.w_q"])
+    k = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, all_head_size, weights[f"{prefix}.w_k"])
+    v = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, all_head_size, weights[f"{prefix}.w_v"])
+
+    q = graph_ops.add_bias_sum(network, q, all_head_size, weights[f"{prefix}.q_bias"])
+    k = graph_ops.add_bias_sum(network, k, all_head_size, weights[f"{prefix}.k_bias"])
+    v = graph_ops.add_bias_sum(network, v, all_head_size, weights[f"{prefix}.v_bias"])
+
+    mixed_query = q  # save for conv branch
+
+    # Key padding mask broadcasts across every query row.
+    mask_row = network.add_shuffle(attn_mask)
+    mask_row.reshape_dims = (1, S)
+    zero_col = graph_ops.add_constant(
+        network, (S, 1), np.zeros((S, 1), dtype=np.float32))
+    mask_2d = network.add_elementwise(
+        zero_col, mask_row.get_output(0), trt.ElementWiseOperation.SUM)
+    mask_4d = graph_ops.add_2d_mask_to_4d(network, mask_2d.get_output(0))
+
+    context = graph_ops.add_attention_from_rows(
+        network, q, k, v,
+        num_heads=new_num_heads, head_dim=head_size,
+        q_seq=S, kv_seq=S, mask=mask_4d)
+
+    context_perm = network.add_shuffle(context)
+    context_perm.reshape_dims = (S, new_num_heads, head_size)
+
+    # === Branch 2: Span-based dynamic convolution ===
+
+    # SeparableConv1D on hidden_states
+    key_conv_attn = _add_separable_conv1d(
+        network, hidden,
+        hidden_size, all_head_size, conv_kernel_size, S,
+        weights[f"{prefix}.sep_conv_dw"],
+        weights[f"{prefix}.sep_conv_pw"],
+        weights[f"{prefix}.sep_conv_bias"],
+    )
+
+    # conv_attn = key_conv_attn * query (element-wise)
+    conv_attn = network.add_elementwise(
+        key_conv_attn, mixed_query, trt.ElementWiseOperation.PROD)
+
+    # conv_kernel = linear(conv_attn) -> [seq, num_heads * kernel_size]
+    conv_kernel = graph_ops.add_matmul_rhs_constant(
+        network, conv_attn.get_output(0), all_head_size,
+        full_new_num_heads * conv_kernel_size,
+        weights[f"{prefix}.conv_kernel_w"])
+    conv_kernel = add_all_reduce_sum(network, conv_kernel, tp_size)
+    conv_kernel = graph_ops.add_bias_sum(
+        network, conv_kernel, full_new_num_heads * conv_kernel_size,
+        weights[f"{prefix}.conv_kernel_bias"])
+    local_kernel_start = tp_rank * new_num_heads * conv_kernel_size
+    conv_kernel_slice = network.add_slice(
+        conv_kernel,
+        start=(0, local_kernel_start),
+        shape=(S, new_num_heads * conv_kernel_size),
+        stride=(1, 1),
+    )
+
+    # Reshape to [seq * num_heads, kernel_size, 1], softmax on kernel_size dim
+    ck_reshape = network.add_shuffle(conv_kernel_slice.get_output(0))
+    ck_reshape.reshape_dims = (S * new_num_heads, conv_kernel_size, 1)
+    ck_softmax = network.add_softmax(ck_reshape.get_output(0))
+    ck_softmax.axes = 1 << 1
+
+    # conv_out = linear(hidden) -> [seq, all_head_size]
+    conv_out = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, all_head_size,
+        weights[f"{prefix}.conv_out_w"])
+    conv_out = graph_ops.add_bias_sum(
+        network, conv_out, all_head_size,
+        weights[f"{prefix}.conv_out_bias"])
+
+    # Transpose to [all_head_size, seq] for unfold
+    conv_out_t = network.add_shuffle(conv_out)
+    conv_out_t.first_transpose = trt.Permutation([1, 0])
+
+    # Unfold: [kernel_size * all_head_size, seq] (kernel-major ordering)
+    unfolded = _add_unfold(
+        network, conv_out_t.get_output(0),
+        all_head_size, S, conv_kernel_size)
+
+    # Rearrange from kernel-major [K*C, seq] to channel-major [C*K, seq]
+    # Reshape to [K, C, seq], permute to [C, K, seq], reshape to [C*K, seq]
+    unf_reorder = network.add_shuffle(unfolded)
+    unf_reorder.reshape_dims = (conv_kernel_size, all_head_size, S)
+    unf_reorder.second_transpose = trt.Permutation([1, 0, 2])
+    # Now [all_head_size, kernel_size, seq]
+
+    # Transpose to [seq, all_head_size, kernel_size]
+    unf_to_seq_first = network.add_shuffle(unf_reorder.get_output(0))
+    unf_to_seq_first.first_transpose = trt.Permutation([2, 0, 1])
+    # [seq, all_head_size, kernel_size]
+
+    # Reshape to [seq * num_heads, head_size, kernel_size]
+    unf_reshape = network.add_shuffle(unf_to_seq_first.get_output(0))
+    unf_reshape.reshape_dims = (S * new_num_heads, head_size, conv_kernel_size)
+
+    # Matmul: [S*H, head_size, K] @ [S*H, K, 1] -> [S*H, head_size, 1]
+    conv_result = network.add_matrix_multiply(
+        unf_reshape.get_output(0), trt.MatrixOperation.NONE,
+        ck_softmax.get_output(0), trt.MatrixOperation.NONE)
+
+    # Reshape to [S, new_num_heads, head_size]
+    conv_reshaped = network.add_shuffle(conv_result.get_output(0))
+    conv_reshaped.reshape_dims = (S, new_num_heads, head_size)
+
+    # === Concatenate: [S, 2*num_heads, head_size] ===
+    cat = network.add_concatenation([context_perm.get_output(0), conv_reshaped.get_output(0)])
+    cat.axis = 1
+
+    # Flatten: [S, hidden_size]
+    cat_flat = network.add_shuffle(cat.get_output(0))
+    cat_flat.reshape_dims = (S, 2 * new_num_heads * head_size)
+
+    # === Output projection ===
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, cat_flat.get_output(0), 2 * all_head_size, hidden_size,
+        weights[f"{prefix}.w_o"])
+    attn_out = add_all_reduce_sum(network, attn_out, tp_size)
+    attn_out = graph_ops.add_bias_sum(
+        network, attn_out, hidden_size, weights[f"{prefix}.o_bias"])
+
+    # POST-norm
+    residual1 = network.add_elementwise(
+        hidden, attn_out, trt.ElementWiseOperation.SUM)
+    normed1 = _add_seq_layer_norm(
+        network, residual1.get_output(0), hidden_size, S,
+        weights[f"{prefix}.post_attn_norm"],
+        weights[f"{prefix}.post_attn_norm_beta"], eps)
+
+    # === FFN ===
+    fc1 = graph_ops.add_matmul_rhs_constant(
+        network, normed1, hidden_size, intermediate_size,
+        weights[f"{prefix}.w_fc1"])
+    fc1 = graph_ops.add_bias_sum(
+        network, fc1, intermediate_size, weights[f"{prefix}.fc1_bias"])
+    activated = graph_ops.add_activation(network, fc1, hidden_act)
+    fc2 = graph_ops.add_matmul_rhs_constant(
+        network, activated, intermediate_size, hidden_size,
+        weights[f"{prefix}.w_fc2"])
+    fc2 = add_all_reduce_sum(network, fc2, tp_size)
+    fc2 = graph_ops.add_bias_sum(
+        network, fc2, hidden_size, weights[f"{prefix}.fc2_bias"])
+
+    # POST-norm
+    residual2 = network.add_elementwise(
+        normed1, fc2, trt.ElementWiseOperation.SUM)
+    normed2 = _add_seq_layer_norm(
+        network, residual2.get_output(0), hidden_size, S,
+        weights[f"{prefix}.output_norm"],
+        weights[f"{prefix}.output_norm_beta"], eps)
+
+    return normed2

--- a/python/tensorrt_model_connect/families/deberta/tp_builder.py
+++ b/python/tensorrt_model_connect/families/deberta/tp_builder.py
@@ -31,10 +31,7 @@ from ...checkpoint_mapper import (
     _has_tensor,
 )
 from ... import graph_ops
-from ...parallel_config import (
-    normalize_parallel_config,
-    require_tensorrt_11_for_tensor_parallel,
-)
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
 
 
 trt = trt_compat.get_trt()
@@ -165,30 +162,89 @@ class DebertaPlugin:
 
     def build_engine(
         self, config: ModelConfig, weights: WeightDict,
-        max_cache_length: int, *, precision: str = "fp32",
-        quant_ctx=None, verbose: bool = False,
+        max_cache_length: int, *, verbose: bool = False,
         parallel_config=None,
     ) -> bytes:
-        parallel = normalize_parallel_config(parallel_config)
-        if parallel.enabled:
-            require_tensorrt_11_for_tensor_parallel(
-                parallel, feature="DeBERTa tensor-parallel builds")
-            if quant_ctx is not None:
-                raise ValueError("DeBERTa tensor-parallel builds do not support quantization")
-            from .tp_builder import build_tp_deberta_encoder_engine
-            return build_tp_deberta_encoder_engine(
-                config, weights,
-                max_seq_length=max_cache_length,
-                verbose=verbose,
-                parallel_config=parallel)
-
-        return _build_deberta_encoder_engine(
+        return build_tp_deberta_encoder_engine(
             config, weights,
             max_seq_length=max_cache_length,
-            verbose=verbose)
+            verbose=verbose,
+            parallel_config=parallel_config)
 
 
 plugin = DebertaPlugin()
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_deberta_tp(config, weights, parallel) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("DeBERTa tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if config.num_attention_heads % tp != 0:
+        raise ValueError(
+            "DeBERTa tensor parallel requires num_attention_heads divisible by "
+            f"tp_size ({config.num_attention_heads} vs {tp})")
+    if config.intermediate_size % tp != 0:
+        raise ValueError(
+            "DeBERTa tensor parallel requires intermediate_size divisible by "
+            f"tp_size ({config.intermediate_size} vs {tp})")
+
+    for layer_idx in range(config.num_hidden_layers):
+        prefix = f"layer.{layer_idx}"
+        for key in (
+            f"{prefix}.w_q", f"{prefix}.w_k", f"{prefix}.w_v",
+            f"{prefix}.pos_proj", f"{prefix}.pos_q_proj",
+        ):
+            if key in weights and weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim must be divisible by tp_size")
+        for key in (f"{prefix}.q_bias", f"{prefix}.v_bias", f"{prefix}.pos_q_proj_bias"):
+            if key in weights and weights[key].shape[0] % tp != 0:
+                raise ValueError(f"{key} dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_o"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_o input dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc1"].shape[-1] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc1 output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc2"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc2 input dim must be divisible by tp_size")
+
+
+def shard_deberta_weights(config, weights, *, parallel):
+    """Return rank-local DeBERTa weights for the TP builder."""
+    _validate_deberta_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        if key.endswith((".w_q", ".w_k", ".w_v", ".pos_proj", ".pos_q_proj", ".w_fc1")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".q_bias", ".v_bias", ".pos_q_proj_bias", ".fc1_bias")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_o", ".w_fc2")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_attention_size"] = config.attention_size // parallel.tp_size
+    out["_intermediate_size"] = config.intermediate_size // parallel.tp_size
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
 
 
 def _add_seq_layer_norm(network, inp, hidden_size, gamma, beta, eps):
@@ -196,13 +252,22 @@ def _add_seq_layer_norm(network, inp, hidden_size, gamma, beta, eps):
         network, inp, hidden_size, gamma, beta, eps)
 
 
-def _build_deberta_encoder_engine(config, weights, max_seq_length, *, verbose=False):
+def build_tp_deberta_encoder_engine(
+    config, weights, max_seq_length, *, verbose=False, parallel_config=None,
+):
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_tp_deberta_encoder_engine requires tensor_parallel mode and tp_size > 1")
+    weights = shard_deberta_weights(config, weights, parallel=parallel)
+
     hidden = config.hidden_size
     vocab = config.vocab_size
     num_layers = config.num_hidden_layers
-    num_heads = config.num_attention_heads
-    head_dim = hidden // num_heads
-    intermediate = config.intermediate_size
+    full_num_heads = config.num_attention_heads
+    num_heads = config.num_attention_heads // parallel.tp_size
+    head_dim = hidden // full_num_heads
+    intermediate = config.intermediate_size // parallel.tp_size
     eps = config.rms_norm_eps
 
     deberta_cfg = weights.get("_deberta_config", {})
@@ -289,13 +354,16 @@ def _build_deberta_encoder_engine(config, weights, max_seq_length, *, verbose=Fa
             scale_factor=scale_factor, attn_mask=pad_mask_reshape.get_output(0),
             rel_emb_tensor=rel_emb_tensor, c2p_pos_tensor=c2p_pos_tensor,
             p2c_pos_tensor=p2c_pos_tensor, pos_att_type=pos_att_type,
-            att_span=att_span, hidden_act=hidden_act, eps=eps)
+            att_span=att_span, hidden_act=hidden_act, eps=eps,
+            tp_size=parallel.tp_size)
 
     hidden_state.name = "hidden_states"
     network.mark_output(hidden_state)
 
     if verbose:
-        print(f"[trtmc build] Building DeBERTa encoder ({num_layers} layers, hidden={hidden}, seq={max_seq_length})", file=sys.stderr)
+        print(f"[trtmc build] Building DeBERTa encoder "
+              f"({num_layers} layers, hidden={hidden}, tp={parallel.tp_size}, "
+              f"seq={max_seq_length})", file=sys.stderr)
 
     plan = builder.build_serialized_network(network, trt_config)
     if plan is None:
@@ -306,7 +374,7 @@ def _build_deberta_encoder_engine(config, weights, max_seq_length, *, verbose=Fa
 def _add_deberta_layer(*, network, hidden, weights, prefix, hidden_size, intermediate_size,
                        num_heads, head_dim, seq_length, attn_scale, scale_factor, attn_mask,
                        rel_emb_tensor, c2p_pos_tensor, p2c_pos_tensor, pos_att_type,
-                       att_span, hidden_act, eps):
+                       att_span, hidden_act, eps, tp_size):
     attention_size = num_heads * head_dim
 
     q = graph_ops.add_matmul_rhs_constant(network, hidden, hidden_size, attention_size, weights[f"{prefix}.w_q"])
@@ -378,6 +446,7 @@ def _add_deberta_layer(*, network, hidden, weights, prefix, hidden_size, interme
     context_flat.reshape_dims = (seq_length, attention_size)
 
     attn_out = graph_ops.add_matmul_rhs_constant(network, context_flat.get_output(0), attention_size, hidden_size, weights[f"{prefix}.w_o"])
+    attn_out = add_all_reduce_sum(network, attn_out, tp_size)
     attn_out = graph_ops.add_bias_sum(network, attn_out, hidden_size, weights[f"{prefix}.o_bias"])
 
     residual1 = network.add_elementwise(hidden, attn_out, trt.ElementWiseOperation.SUM)
@@ -387,6 +456,7 @@ def _add_deberta_layer(*, network, hidden, weights, prefix, hidden_size, interme
     fc1 = graph_ops.add_bias_sum(network, fc1, intermediate_size, weights[f"{prefix}.fc1_bias"])
     activated = graph_ops.add_activation(network, fc1, hidden_act)
     fc2 = graph_ops.add_matmul_rhs_constant(network, activated, intermediate_size, hidden_size, weights[f"{prefix}.w_fc2"])
+    fc2 = add_all_reduce_sum(network, fc2, tp_size)
     fc2 = graph_ops.add_bias_sum(network, fc2, hidden_size, weights[f"{prefix}.fc2_bias"])
 
     residual2 = network.add_elementwise(normed1, fc2, trt.ElementWiseOperation.SUM)

--- a/python/tensorrt_model_connect/families/distilbert/plugin.py
+++ b/python/tensorrt_model_connect/families/distilbert/plugin.py
@@ -30,6 +30,10 @@ from ...checkpoint_mapper import (
     _open_safetensors,
     _load_tensor,
 )
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 from .encoder_builder import build_encoder_engine
 
 
@@ -135,8 +139,25 @@ class DistilBertPlugin:
         self, config: ModelConfig, weights: WeightDict,
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
         public_module = sys.modules.get(__package__)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="DistilBERT tensor-parallel builds")
+            if quant_ctx is not None:
+                raise ValueError(
+                    "DistilBERT tensor-parallel builds do not support quantization")
+            from .tp_builder import build_tp_encoder_engine
+            builder = getattr(
+                public_module, "build_tp_encoder_engine", build_tp_encoder_engine)
+            return builder(
+                config, weights,
+                max_seq_length=max_cache_length,
+                verbose=verbose,
+                parallel_config=parallel)
+
         builder = getattr(public_module, "build_encoder_engine", build_encoder_engine)
         return builder(
             config, weights,

--- a/python/tensorrt_model_connect/families/distilbert/tp_builder.py
+++ b/python/tensorrt_model_connect/families/distilbert/tp_builder.py
@@ -1,0 +1,430 @@
+"""Tensor-parallel encoder-only engine builder (DistilDistilBERT-style).
+
+Builds one rank-local TensorRT engine for an encoder-only transformer. Unlike
+the standard decoder builder, this has:
+  - No KV cache (processes entire sequence at once)
+  - No causal attention mask (full bidirectional attention)
+  - POST-norm architecture (residual + LayerNorm after attention/FFN)
+  - Token type embeddings (segment A/B)
+  - Output: hidden_states [seq_len, hidden_size]
+
+Tensor parallelism only changes the encoder projections:
+  - Q/K/V and FFN fc1 are column-parallel
+  - Attention output and FFN fc2 are row-parallel
+  - Row-parallel outputs are joined with TensorRT distributed ALL_REDUCE
+
+Tensor names for the C++ runtime:
+  Inputs:  input_ids [seq_len], attention_mask [seq_len]
+  Outputs: hidden_states [seq_len, hidden_size]
+
+token_type_ids is baked as constant zeros (single-segment inference).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...config import ModelConfig
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_encoder_tp(
+    config: ModelConfig,
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("DistilBERT tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if config.num_attention_heads % tp != 0:
+        raise ValueError(
+            "DistilBERT tensor parallel requires num_attention_heads divisible by "
+            f"tp_size ({config.num_attention_heads} vs {tp})")
+    if config.intermediate_size % tp != 0:
+        raise ValueError(
+            "DistilBERT tensor parallel requires intermediate_size divisible by "
+            f"tp_size ({config.intermediate_size} vs {tp})")
+
+    for layer_idx in range(config.num_hidden_layers):
+        prefix = f"layer.{layer_idx}"
+        for key in (f"{prefix}.w_q", f"{prefix}.w_k", f"{prefix}.w_v"):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_o"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_o input dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc1"].shape[-1] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc1 output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc2"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc2 input dim must be divisible by tp_size")
+
+    if "relative_position_bias" in weights and weights["relative_position_bias"].shape[0] % tp != 0:
+        raise ValueError(
+            "relative_position_bias head dim must be divisible by tp_size")
+
+
+def shard_encoder_weights(
+    config: ModelConfig,
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local DistilDistilBERT-style encoder weights for the TP builder."""
+    _validate_encoder_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        if key.endswith((".w_q", ".w_k", ".w_v", ".w_fc1")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".q_bias", ".k_bias", ".v_bias", ".fc1_bias")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_o", ".w_fc2")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key == "relative_position_bias":
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_attention_size"] = config.attention_size // parallel.tp_size
+    out["_intermediate_size"] = config.intermediate_size // parallel.tp_size
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def build_tp_encoder_engine(
+    config: ModelConfig,
+    weights: "WeightDict",
+    max_seq_length: int,
+    *,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build a rank-local TRT engine plan for a DistilDistilBERT-style encoder.
+
+    Args:
+        config: Model architecture from config.json.
+        weights: Loaded weight dict from DistilBERT plugin.
+        max_seq_length: Maximum sequence length the engine is compiled for.
+        verbose: Print TRT builder logs.
+
+    Returns:
+        Serialized engine plan bytes.
+    """
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_tp_encoder_engine requires tensor_parallel mode and tp_size > 1")
+    weights = shard_encoder_weights(config, weights, parallel=parallel)
+
+    hidden = config.hidden_size
+    num_layers = config.num_hidden_layers
+    full_num_heads = config.num_attention_heads
+    num_heads = config.num_attention_heads // parallel.tp_size
+    head_dim = hidden // full_num_heads
+    intermediate = config.intermediate_size // parallel.tp_size
+    eps = config.rms_norm_eps  # Actually layer_norm_eps for DistilBERT
+    type_vocab_size = config.raw.get("type_vocab_size", 2)
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
+    # which causes significant accuracy loss across 12+ encoder layers.
+    trt_config.clear_flag(trt.BuilderFlag.TF32)
+
+    # Resolve GELU variant from config
+    hidden_act = config.hidden_act or config.raw.get("activation", "") or "gelu"
+
+    # -------------------------------------------------------------------
+    # Inputs
+    # -------------------------------------------------------------------
+    input_ids = network.add_input("input_ids", trt.int32, (max_seq_length,))
+    attention_mask_input = network.add_input("attention_mask", trt.int32, (max_seq_length,))
+
+    # token_type_ids: constant zeros (all segment-0) — the C++ encoder
+    # pipeline doesn't provide this input, and inference is single-segment.
+    tt_zeros = network.add_constant(
+        (max_seq_length,), trt.Weights(np.zeros(max_seq_length, dtype=np.int32)))
+    token_type_ids = tt_zeros.get_output(0)
+
+    # -------------------------------------------------------------------
+    # Shared constants (support embedding factorization: embedding_size != hidden)
+    # -------------------------------------------------------------------
+    embedding_size = weights["embedding"].shape[1]  # may differ from hidden (e.g. ALDistilBERT 128 vs 768)
+    embedding_table = graph_ops.add_constant(
+        network, weights["embedding"].shape, weights["embedding"])
+    position_embed_table = graph_ops.add_constant(
+        network, weights["position_embedding"].shape, weights["position_embedding"])
+    token_type_table = graph_ops.add_constant(
+        network, (type_vocab_size, embedding_size), weights["token_type_embedding"])
+
+    graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+    attn_scale_tensor = graph_ops.add_constant(
+        network, (1, 1, 1), np.array([1.0 / np.sqrt(max(head_dim, 1))], dtype=np.float32))
+
+    # Build additive attention mask from attention_mask input:
+    # attention_mask is [seq_len] with 1=real, 0=padding.
+    # Convert to [1, 1, seq_len] additive mask: 0.0 for real, -1e10 for padding.
+    mask_float = network.add_cast(attention_mask_input, trt.float32)
+    ones_mask = graph_ops.add_constant(
+        network, (1,), np.array([1.0], dtype=np.float32))
+    neg_large = graph_ops.add_constant(
+        network, (1,), np.array([-1e10], dtype=np.float32))
+    inv_mask = network.add_elementwise(
+        ones_mask, mask_float.get_output(0),
+        trt.ElementWiseOperation.SUB)  # 0 for real, 1 for pad
+    pad_penalty = network.add_elementwise(
+        inv_mask.get_output(0), neg_large,
+        trt.ElementWiseOperation.PROD)  # 0.0 for real, -1e10 for pad
+    # Reshape to [1, 1, seq_len] for broadcasting: [num_heads, seq_len, seq_len]
+    pad_mask_reshape = network.add_shuffle(pad_penalty.get_output(0))
+    pad_mask_reshape.reshape_dims = (1, 1, max_seq_length)
+
+    # Position indices: [0, 1, 2, ..., max_seq_length-1]
+    position_indices = graph_ops.add_constant(
+        network, (max_seq_length,),
+        np.arange(max_seq_length, dtype=np.int32).astype(np.float32))
+    # Cast back to int32 for gather
+    pos_int = network.add_cast(position_indices, trt.int32)
+
+    # -------------------------------------------------------------------
+    # Embedding: word + position + token_type + LayerNorm
+    # -------------------------------------------------------------------
+    word_embed = network.add_gather(embedding_table, input_ids, 0)
+    pos_embed = network.add_gather(position_embed_table, pos_int.get_output(0), 0)
+    tt_embed = network.add_gather(token_type_table, token_type_ids, 0)
+
+    # Sum all three embedding types
+    embed_sum1 = network.add_elementwise(
+        word_embed.get_output(0), pos_embed.get_output(0),
+        trt.ElementWiseOperation.SUM)
+    embed_sum2 = network.add_elementwise(
+        embed_sum1.get_output(0), tt_embed.get_output(0),
+        trt.ElementWiseOperation.SUM)
+
+    # Embedding LayerNorm (over embedding_size, which may differ from hidden)
+    hidden_state = _add_seq_layer_norm(
+        network, embed_sum2.get_output(0), embedding_size, max_seq_length,
+        weights["embed_norm"], weights["embed_norm_beta"], eps)
+
+    # Optional embedding projection: embedding_size -> hidden_size (ALDistilBERT, FNet)
+    if "embed_projection" in weights:
+        hidden_state = graph_ops.add_matmul_rhs_constant(
+            network, hidden_state, embedding_size, hidden,
+            weights["embed_projection"])
+        if "embed_projection_bias" in weights:
+            hidden_state = graph_ops.add_bias_sum(
+                network, hidden_state, hidden,
+                weights["embed_projection_bias"])
+
+    # -------------------------------------------------------------------
+    # Optional relative position bias (MPNet, T5-style)
+    # -------------------------------------------------------------------
+    rel_pos_bias_tensor = None
+    if "relative_position_bias" in weights:
+        # Pre-computed [num_heads, seq_len, seq_len] bias matrix
+        rpb = weights["relative_position_bias"]
+        rel_pos_bias_tensor = graph_ops.add_constant(
+            network, rpb.shape, rpb)
+
+    # -------------------------------------------------------------------
+    # Encoder layers
+    # -------------------------------------------------------------------
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+
+        hidden_state = _add_encoder_layer(
+            network=network,
+            hidden=hidden_state,
+            weights=weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            intermediate_size=intermediate,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            seq_length=max_seq_length,
+            attn_scale_tensor=attn_scale_tensor,
+            attn_mask=pad_mask_reshape.get_output(0),
+            rel_pos_bias=rel_pos_bias_tensor,
+            hidden_act=hidden_act,
+            eps=eps,
+            tp_size=parallel.tp_size,
+        )
+
+    # -------------------------------------------------------------------
+    # Output
+    # -------------------------------------------------------------------
+    hidden_state.name = "hidden_states"
+    network.mark_output(hidden_state)
+
+    # -------------------------------------------------------------------
+    # Build engine
+    # -------------------------------------------------------------------
+    if verbose:
+        print(f"[trtmc build] Building DistilBERT encoder TRT engine "
+              f"({num_layers} layers, hidden={hidden}, tp={parallel.tp_size}, "
+              f"seq_len={max_seq_length}) ...", file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT engine build failed")
+
+    return bytes(plan)
+
+
+def _add_seq_layer_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    seq_length: int,
+    gamma: np.ndarray,
+    beta: np.ndarray,
+    eps: float,
+) -> trt.ITensor:
+    """LayerNorm over sequence of vectors: [seq_len, hidden] -> [seq_len, hidden].
+
+    Uses the shared TRT native normalization helper.
+    """
+    return graph_ops.add_layer_norm_native(
+        network, inp, hidden_size, gamma, beta, eps)
+
+
+def _add_encoder_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    weights: WeightDict,
+    prefix: str,
+    hidden_size: int,
+    intermediate_size: int,
+    num_heads: int,
+    head_dim: int,
+    seq_length: int,
+    attn_scale_tensor: trt.ITensor,
+    attn_mask: trt.ITensor,
+    rel_pos_bias: trt.ITensor | None = None,
+    hidden_act: str = "gelu",
+    eps: float,
+    tp_size: int,
+) -> trt.ITensor:
+    """Add one DistilBERT encoder layer with POST-norm.
+
+    DistilBERT architecture per layer:
+        attn_out = MultiHeadSelfAttention(hidden)
+        hidden = LayerNorm(hidden + attn_out)  # post-norm
+        ffn_out = FFN(hidden)
+        hidden = LayerNorm(hidden + ffn_out)   # post-norm
+    """
+    attention_size = num_heads * head_dim
+
+    # --- Self-attention (no causal mask, bidirectional) ---
+    # QKV projections
+    q = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_q"])
+    k = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_k"])
+    v = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_v"])
+
+    # QKV biases
+    q = graph_ops.add_bias_sum(network, q, attention_size, weights[f"{prefix}.q_bias"])
+    k = graph_ops.add_bias_sum(network, k, attention_size, weights[f"{prefix}.k_bias"])
+    v = graph_ops.add_bias_sum(network, v, attention_size, weights[f"{prefix}.v_bias"])
+
+    # Add relative position bias if present (MPNet/T5-style). IAttention
+    # applies scaling internally through graph_ops.add_attention_from_rows, so
+    # the mask contains only additive bias/masking terms.
+    additive_mask = attn_mask
+    if rel_pos_bias is not None:
+        additive_mask = network.add_elementwise(
+            rel_pos_bias, attn_mask, trt.ElementWiseOperation.SUM).get_output(0)
+
+    mask_4d = network.add_shuffle(additive_mask)
+    mask_4d.reshape_dims = (
+        (1, num_heads, seq_length, seq_length)
+        if rel_pos_bias is not None
+        else (1, 1, 1, seq_length)
+    )
+
+    context_flat = graph_ops.add_attention_from_rows(
+        network, q, k, v,
+        num_heads=num_heads, head_dim=head_dim,
+        q_seq=seq_length, kv_seq=seq_length,
+        mask=mask_4d.get_output(0),
+        tag=prefix + ".attn")
+
+    # Output projection
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, context_flat,
+        attention_size, hidden_size,
+        weights[f"{prefix}.w_o"])
+    attn_out = add_all_reduce_sum(network, attn_out, tp_size)
+    attn_out = graph_ops.add_bias_sum(
+        network, attn_out, hidden_size, weights[f"{prefix}.o_bias"])
+
+    # POST-norm: LayerNorm(hidden + attn_out)
+    residual1 = network.add_elementwise(
+        hidden, attn_out, trt.ElementWiseOperation.SUM)
+    normed1 = _add_seq_layer_norm(
+        network, residual1.get_output(0), hidden_size, seq_length,
+        weights[f"{prefix}.post_attn_norm"],
+        weights[f"{prefix}.post_attn_norm_beta"], eps)
+
+    # --- FFN: fc1 -> GELU -> fc2 ---
+    fc1 = graph_ops.add_matmul_rhs_constant(
+        network, normed1, hidden_size, intermediate_size,
+        weights[f"{prefix}.w_fc1"])
+    fc1 = graph_ops.add_bias_sum(network, fc1, intermediate_size,
+                                  weights[f"{prefix}.fc1_bias"])
+    activated = graph_ops.add_activation(network, fc1, hidden_act)
+    fc2 = graph_ops.add_matmul_rhs_constant(
+        network, activated, intermediate_size, hidden_size,
+        weights[f"{prefix}.w_fc2"])
+    fc2 = add_all_reduce_sum(network, fc2, tp_size)
+    fc2 = graph_ops.add_bias_sum(network, fc2, hidden_size,
+                                  weights[f"{prefix}.fc2_bias"])
+
+    # POST-norm: LayerNorm(normed1 + ffn_out)
+    residual2 = network.add_elementwise(
+        normed1, fc2, trt.ElementWiseOperation.SUM)
+    normed2 = _add_seq_layer_norm(
+        network, residual2.get_output(0), hidden_size, seq_length,
+        weights[f"{prefix}.output_norm"],
+        weights[f"{prefix}.output_norm_beta"], eps)
+
+    return normed2

--- a/python/tensorrt_model_connect/families/dpr/plugin.py
+++ b/python/tensorrt_model_connect/families/dpr/plugin.py
@@ -23,6 +23,10 @@ from ...checkpoint_mapper import (
     _load_tensor,
     _has_tensor,
 )
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 from .encoder_builder import build_encoder_engine
 
 
@@ -188,8 +192,23 @@ class DprPlugin:
 
     def build_engine(
         self, config: ModelConfig, weights: WeightDict,
-        max_cache_length: int, *, verbose: bool = False,
+        max_cache_length: int, *, precision: str = "fp32",
+        quant_ctx=None, verbose: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="DPR tensor-parallel builds")
+            if quant_ctx is not None:
+                raise ValueError("DPR tensor-parallel builds do not support quantization")
+            from .tp_builder import build_tp_encoder_engine
+            return build_tp_encoder_engine(
+                config, weights,
+                max_seq_length=max_cache_length,
+                verbose=verbose,
+                parallel_config=parallel)
+
         return build_encoder_engine(
             config, weights,
             max_seq_length=max_cache_length,

--- a/python/tensorrt_model_connect/families/dpr/tp_builder.py
+++ b/python/tensorrt_model_connect/families/dpr/tp_builder.py
@@ -1,0 +1,430 @@
+"""Tensor-parallel encoder-only engine builder (DPR-style).
+
+Builds one rank-local TensorRT engine for an encoder-only transformer. Unlike
+the standard decoder builder, this has:
+  - No KV cache (processes entire sequence at once)
+  - No causal attention mask (full bidirectional attention)
+  - POST-norm architecture (residual + LayerNorm after attention/FFN)
+  - Token type embeddings (segment A/B)
+  - Output: hidden_states [seq_len, hidden_size]
+
+Tensor parallelism only changes the encoder projections:
+  - Q/K/V and FFN fc1 are column-parallel
+  - Attention output and FFN fc2 are row-parallel
+  - Row-parallel outputs are joined with TensorRT distributed ALL_REDUCE
+
+Tensor names for the C++ runtime:
+  Inputs:  input_ids [seq_len], attention_mask [seq_len]
+  Outputs: hidden_states [seq_len, hidden_size]
+
+token_type_ids is baked as constant zeros (single-segment inference).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...config import ModelConfig
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_encoder_tp(
+    config: ModelConfig,
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("DPR tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if config.num_attention_heads % tp != 0:
+        raise ValueError(
+            "DPR tensor parallel requires num_attention_heads divisible by "
+            f"tp_size ({config.num_attention_heads} vs {tp})")
+    if config.intermediate_size % tp != 0:
+        raise ValueError(
+            "DPR tensor parallel requires intermediate_size divisible by "
+            f"tp_size ({config.intermediate_size} vs {tp})")
+
+    for layer_idx in range(config.num_hidden_layers):
+        prefix = f"layer.{layer_idx}"
+        for key in (f"{prefix}.w_q", f"{prefix}.w_k", f"{prefix}.w_v"):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_o"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_o input dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc1"].shape[-1] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc1 output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc2"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc2 input dim must be divisible by tp_size")
+
+    if "relative_position_bias" in weights and weights["relative_position_bias"].shape[0] % tp != 0:
+        raise ValueError(
+            "relative_position_bias head dim must be divisible by tp_size")
+
+
+def shard_encoder_weights(
+    config: ModelConfig,
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local DPR-style encoder weights for the TP builder."""
+    _validate_encoder_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        if key.endswith((".w_q", ".w_k", ".w_v", ".w_fc1")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".q_bias", ".k_bias", ".v_bias", ".fc1_bias")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_o", ".w_fc2")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key == "relative_position_bias":
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_attention_size"] = config.attention_size // parallel.tp_size
+    out["_intermediate_size"] = config.intermediate_size // parallel.tp_size
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def build_tp_encoder_engine(
+    config: ModelConfig,
+    weights: "WeightDict",
+    max_seq_length: int,
+    *,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build a rank-local TRT engine plan for a DPR-style encoder.
+
+    Args:
+        config: Model architecture from config.json.
+        weights: Loaded weight dict from DPR plugin.
+        max_seq_length: Maximum sequence length the engine is compiled for.
+        verbose: Print TRT builder logs.
+
+    Returns:
+        Serialized engine plan bytes.
+    """
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_tp_encoder_engine requires tensor_parallel mode and tp_size > 1")
+    weights = shard_encoder_weights(config, weights, parallel=parallel)
+
+    hidden = config.hidden_size
+    num_layers = config.num_hidden_layers
+    full_num_heads = config.num_attention_heads
+    num_heads = config.num_attention_heads // parallel.tp_size
+    head_dim = hidden // full_num_heads
+    intermediate = config.intermediate_size // parallel.tp_size
+    eps = config.rms_norm_eps  # Actually layer_norm_eps for DPR
+    type_vocab_size = config.raw.get("type_vocab_size", 2)
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
+    # which causes significant accuracy loss across 12+ encoder layers.
+    trt_config.clear_flag(trt.BuilderFlag.TF32)
+
+    # Resolve GELU variant from config
+    hidden_act = config.hidden_act or config.raw.get("activation", "") or "gelu"
+
+    # -------------------------------------------------------------------
+    # Inputs
+    # -------------------------------------------------------------------
+    input_ids = network.add_input("input_ids", trt.int32, (max_seq_length,))
+    attention_mask_input = network.add_input("attention_mask", trt.int32, (max_seq_length,))
+
+    # token_type_ids: constant zeros (all segment-0) — the C++ encoder
+    # pipeline doesn't provide this input, and inference is single-segment.
+    tt_zeros = network.add_constant(
+        (max_seq_length,), trt.Weights(np.zeros(max_seq_length, dtype=np.int32)))
+    token_type_ids = tt_zeros.get_output(0)
+
+    # -------------------------------------------------------------------
+    # Shared constants (support embedding factorization: embedding_size != hidden)
+    # -------------------------------------------------------------------
+    embedding_size = weights["embedding"].shape[1]  # may differ from hidden (e.g. ALDPR 128 vs 768)
+    embedding_table = graph_ops.add_constant(
+        network, weights["embedding"].shape, weights["embedding"])
+    position_embed_table = graph_ops.add_constant(
+        network, weights["position_embedding"].shape, weights["position_embedding"])
+    token_type_table = graph_ops.add_constant(
+        network, (type_vocab_size, embedding_size), weights["token_type_embedding"])
+
+    graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+    attn_scale_tensor = graph_ops.add_constant(
+        network, (1, 1, 1), np.array([1.0 / np.sqrt(max(head_dim, 1))], dtype=np.float32))
+
+    # Build additive attention mask from attention_mask input:
+    # attention_mask is [seq_len] with 1=real, 0=padding.
+    # Convert to [1, 1, seq_len] additive mask: 0.0 for real, -1e10 for padding.
+    mask_float = network.add_cast(attention_mask_input, trt.float32)
+    ones_mask = graph_ops.add_constant(
+        network, (1,), np.array([1.0], dtype=np.float32))
+    neg_large = graph_ops.add_constant(
+        network, (1,), np.array([-1e10], dtype=np.float32))
+    inv_mask = network.add_elementwise(
+        ones_mask, mask_float.get_output(0),
+        trt.ElementWiseOperation.SUB)  # 0 for real, 1 for pad
+    pad_penalty = network.add_elementwise(
+        inv_mask.get_output(0), neg_large,
+        trt.ElementWiseOperation.PROD)  # 0.0 for real, -1e10 for pad
+    # Reshape to [1, 1, seq_len] for broadcasting: [num_heads, seq_len, seq_len]
+    pad_mask_reshape = network.add_shuffle(pad_penalty.get_output(0))
+    pad_mask_reshape.reshape_dims = (1, 1, max_seq_length)
+
+    # Position indices: [0, 1, 2, ..., max_seq_length-1]
+    position_indices = graph_ops.add_constant(
+        network, (max_seq_length,),
+        np.arange(max_seq_length, dtype=np.int32).astype(np.float32))
+    # Cast back to int32 for gather
+    pos_int = network.add_cast(position_indices, trt.int32)
+
+    # -------------------------------------------------------------------
+    # Embedding: word + position + token_type + LayerNorm
+    # -------------------------------------------------------------------
+    word_embed = network.add_gather(embedding_table, input_ids, 0)
+    pos_embed = network.add_gather(position_embed_table, pos_int.get_output(0), 0)
+    tt_embed = network.add_gather(token_type_table, token_type_ids, 0)
+
+    # Sum all three embedding types
+    embed_sum1 = network.add_elementwise(
+        word_embed.get_output(0), pos_embed.get_output(0),
+        trt.ElementWiseOperation.SUM)
+    embed_sum2 = network.add_elementwise(
+        embed_sum1.get_output(0), tt_embed.get_output(0),
+        trt.ElementWiseOperation.SUM)
+
+    # Embedding LayerNorm (over embedding_size, which may differ from hidden)
+    hidden_state = _add_seq_layer_norm(
+        network, embed_sum2.get_output(0), embedding_size, max_seq_length,
+        weights["embed_norm"], weights["embed_norm_beta"], eps)
+
+    # Optional embedding projection: embedding_size -> hidden_size (ALDPR, FNet)
+    if "embed_projection" in weights:
+        hidden_state = graph_ops.add_matmul_rhs_constant(
+            network, hidden_state, embedding_size, hidden,
+            weights["embed_projection"])
+        if "embed_projection_bias" in weights:
+            hidden_state = graph_ops.add_bias_sum(
+                network, hidden_state, hidden,
+                weights["embed_projection_bias"])
+
+    # -------------------------------------------------------------------
+    # Optional relative position bias (MPNet, T5-style)
+    # -------------------------------------------------------------------
+    rel_pos_bias_tensor = None
+    if "relative_position_bias" in weights:
+        # Pre-computed [num_heads, seq_len, seq_len] bias matrix
+        rpb = weights["relative_position_bias"]
+        rel_pos_bias_tensor = graph_ops.add_constant(
+            network, rpb.shape, rpb)
+
+    # -------------------------------------------------------------------
+    # Encoder layers
+    # -------------------------------------------------------------------
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+
+        hidden_state = _add_encoder_layer(
+            network=network,
+            hidden=hidden_state,
+            weights=weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            intermediate_size=intermediate,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            seq_length=max_seq_length,
+            attn_scale_tensor=attn_scale_tensor,
+            attn_mask=pad_mask_reshape.get_output(0),
+            rel_pos_bias=rel_pos_bias_tensor,
+            hidden_act=hidden_act,
+            eps=eps,
+            tp_size=parallel.tp_size,
+        )
+
+    # -------------------------------------------------------------------
+    # Output
+    # -------------------------------------------------------------------
+    hidden_state.name = "hidden_states"
+    network.mark_output(hidden_state)
+
+    # -------------------------------------------------------------------
+    # Build engine
+    # -------------------------------------------------------------------
+    if verbose:
+        print(f"[trtmc build] Building DPR encoder TRT engine "
+              f"({num_layers} layers, hidden={hidden}, tp={parallel.tp_size}, "
+              f"seq_len={max_seq_length}) ...", file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT engine build failed")
+
+    return bytes(plan)
+
+
+def _add_seq_layer_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    seq_length: int,
+    gamma: np.ndarray,
+    beta: np.ndarray,
+    eps: float,
+) -> trt.ITensor:
+    """LayerNorm over sequence of vectors: [seq_len, hidden] -> [seq_len, hidden].
+
+    Uses the shared TRT native normalization helper.
+    """
+    return graph_ops.add_layer_norm_native(
+        network, inp, hidden_size, gamma, beta, eps)
+
+
+def _add_encoder_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    weights: WeightDict,
+    prefix: str,
+    hidden_size: int,
+    intermediate_size: int,
+    num_heads: int,
+    head_dim: int,
+    seq_length: int,
+    attn_scale_tensor: trt.ITensor,
+    attn_mask: trt.ITensor,
+    rel_pos_bias: trt.ITensor | None = None,
+    hidden_act: str = "gelu",
+    eps: float,
+    tp_size: int,
+) -> trt.ITensor:
+    """Add one DPR encoder layer with POST-norm.
+
+    DPR architecture per layer:
+        attn_out = MultiHeadSelfAttention(hidden)
+        hidden = LayerNorm(hidden + attn_out)  # post-norm
+        ffn_out = FFN(hidden)
+        hidden = LayerNorm(hidden + ffn_out)   # post-norm
+    """
+    attention_size = num_heads * head_dim
+
+    # --- Self-attention (no causal mask, bidirectional) ---
+    # QKV projections
+    q = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_q"])
+    k = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_k"])
+    v = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_v"])
+
+    # QKV biases
+    q = graph_ops.add_bias_sum(network, q, attention_size, weights[f"{prefix}.q_bias"])
+    k = graph_ops.add_bias_sum(network, k, attention_size, weights[f"{prefix}.k_bias"])
+    v = graph_ops.add_bias_sum(network, v, attention_size, weights[f"{prefix}.v_bias"])
+
+    # Add relative position bias if present (MPNet/T5-style). IAttention
+    # applies scaling internally through graph_ops.add_attention_from_rows, so
+    # the mask contains only additive bias/masking terms.
+    additive_mask = attn_mask
+    if rel_pos_bias is not None:
+        additive_mask = network.add_elementwise(
+            rel_pos_bias, attn_mask, trt.ElementWiseOperation.SUM).get_output(0)
+
+    mask_4d = network.add_shuffle(additive_mask)
+    mask_4d.reshape_dims = (
+        (1, num_heads, seq_length, seq_length)
+        if rel_pos_bias is not None
+        else (1, 1, 1, seq_length)
+    )
+
+    context_flat = graph_ops.add_attention_from_rows(
+        network, q, k, v,
+        num_heads=num_heads, head_dim=head_dim,
+        q_seq=seq_length, kv_seq=seq_length,
+        mask=mask_4d.get_output(0),
+        tag=prefix + ".attn")
+
+    # Output projection
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, context_flat,
+        attention_size, hidden_size,
+        weights[f"{prefix}.w_o"])
+    attn_out = add_all_reduce_sum(network, attn_out, tp_size)
+    attn_out = graph_ops.add_bias_sum(
+        network, attn_out, hidden_size, weights[f"{prefix}.o_bias"])
+
+    # POST-norm: LayerNorm(hidden + attn_out)
+    residual1 = network.add_elementwise(
+        hidden, attn_out, trt.ElementWiseOperation.SUM)
+    normed1 = _add_seq_layer_norm(
+        network, residual1.get_output(0), hidden_size, seq_length,
+        weights[f"{prefix}.post_attn_norm"],
+        weights[f"{prefix}.post_attn_norm_beta"], eps)
+
+    # --- FFN: fc1 -> GELU -> fc2 ---
+    fc1 = graph_ops.add_matmul_rhs_constant(
+        network, normed1, hidden_size, intermediate_size,
+        weights[f"{prefix}.w_fc1"])
+    fc1 = graph_ops.add_bias_sum(network, fc1, intermediate_size,
+                                  weights[f"{prefix}.fc1_bias"])
+    activated = graph_ops.add_activation(network, fc1, hidden_act)
+    fc2 = graph_ops.add_matmul_rhs_constant(
+        network, activated, intermediate_size, hidden_size,
+        weights[f"{prefix}.w_fc2"])
+    fc2 = add_all_reduce_sum(network, fc2, tp_size)
+    fc2 = graph_ops.add_bias_sum(network, fc2, hidden_size,
+                                  weights[f"{prefix}.fc2_bias"])
+
+    # POST-norm: LayerNorm(normed1 + ffn_out)
+    residual2 = network.add_elementwise(
+        normed1, fc2, trt.ElementWiseOperation.SUM)
+    normed2 = _add_seq_layer_norm(
+        network, residual2.get_output(0), hidden_size, seq_length,
+        weights[f"{prefix}.output_norm"],
+        weights[f"{prefix}.output_norm_beta"], eps)
+
+    return normed2

--- a/python/tensorrt_model_connect/families/fnet/plugin.py
+++ b/python/tensorrt_model_connect/families/fnet/plugin.py
@@ -22,6 +22,10 @@ from ...checkpoint_mapper import (
     _load_tensor,
     _has_tensor,
 )
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 
 
 def _load_ln(readers, prefix):
@@ -131,8 +135,23 @@ class FNetPlugin:
 
     def build_engine(
         self, config: ModelConfig, weights: WeightDict,
-        max_cache_length: int, *, verbose: bool = False,
+        max_cache_length: int, *, precision: str = "fp32",
+        quant_ctx=None, verbose: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="FNet tensor-parallel builds")
+            if quant_ctx is not None:
+                raise ValueError("FNet tensor-parallel builds do not support quantization")
+            from .tp_builder import build_tp_fnet_encoder_engine
+            return build_tp_fnet_encoder_engine(
+                config, weights,
+                max_seq_length=max_cache_length,
+                verbose=verbose,
+                parallel_config=parallel)
+
         from .fnet_encoder_builder import build_fnet_encoder_engine
         return build_fnet_encoder_engine(
             config, weights,

--- a/python/tensorrt_model_connect/families/fnet/tp_builder.py
+++ b/python/tensorrt_model_connect/families/fnet/tp_builder.py
@@ -1,0 +1,287 @@
+"""FNet encoder builder — TRT engine with 2D DFT replacing self-attention.
+
+FNet replaces self-attention with a 2D Discrete Fourier Transform:
+  - DFT2D(X) = DFT_seq @ X @ DFT_hidden (taking real part only)
+  - Implemented via pre-computed cosine/sine matrices as constants
+  - POST-norm: residual + LayerNorm after DFT and FFN
+
+Tensor names for the C++ runtime:
+  Inputs:  input_ids [seq_len], attention_mask [seq_len]
+  Outputs: hidden_states [seq_len, hidden_size]
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...config import ModelConfig
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_fnet_tp(
+    config: ModelConfig,
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("FNet tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if config.intermediate_size % tp != 0:
+        raise ValueError(
+            "FNet tensor parallel requires intermediate_size divisible by "
+            f"tp_size ({config.intermediate_size} vs {tp})")
+
+    for layer_idx in range(config.num_hidden_layers):
+        prefix = f"layer.{layer_idx}"
+        if weights[f"{prefix}.w_fc1"].shape[-1] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc1 output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc2"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc2 input dim must be divisible by tp_size")
+
+
+def shard_fnet_encoder_weights(
+    config: ModelConfig,
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local FNet encoder weights for the TP builder."""
+    _validate_fnet_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        if key.endswith(".w_fc1"):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".fc1_bias"):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".w_fc2"):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_intermediate_size"] = config.intermediate_size // parallel.tp_size
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def _compute_dft_matrices(n: int):
+    """Pre-compute real and imaginary DFT matrices for dimension n.
+
+    Returns (cos_mat, sin_mat) each of shape [n, n].
+    DFT definition: X_k = sum_j x_j * exp(-2pi*i*j*k/n)
+    real part: cos(2*pi*j*k/n), imag part: -sin(2*pi*j*k/n)
+    """
+    j = np.arange(n, dtype=np.float64)
+    k = np.arange(n, dtype=np.float64)
+    jk = np.outer(k, j)  # [n, n]
+    angle = 2.0 * np.pi * jk / n
+    return np.cos(angle).astype(np.float32), np.sin(angle).astype(np.float32)
+
+
+def _add_seq_layer_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    gamma: np.ndarray,
+    beta: np.ndarray,
+    eps: float,
+) -> trt.ITensor:
+    """LayerNorm over [seq_len, hidden] using TRT native normalization."""
+    return graph_ops.add_layer_norm_native(
+        network, inp, hidden_size, gamma, beta, eps)
+
+
+def build_tp_fnet_encoder_engine(
+    config: ModelConfig,
+    weights: WeightDict,
+    max_seq_length: int,
+    *,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build a rank-local TRT engine plan for FNet encoder with 2D DFT."""
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_tp_fnet_encoder_engine requires tensor_parallel mode and tp_size > 1")
+    weights = shard_fnet_encoder_weights(config, weights, parallel=parallel)
+
+    hidden = config.hidden_size
+    num_layers = config.num_hidden_layers
+    intermediate = config.intermediate_size // parallel.tp_size
+    eps = config.rms_norm_eps
+    type_vocab_size = config.raw.get("type_vocab_size", 4)
+    hidden_act = config.hidden_act or config.raw.get("activation", "") or "gelu_new"
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    trt_config.clear_flag(trt.BuilderFlag.TF32)
+
+    S = max_seq_length
+    H = hidden
+
+    # Inputs
+    input_ids = network.add_input("input_ids", trt.int32, (S,))
+    network.add_input("attention_mask", trt.int32, (S,))
+
+    # token_type_ids: constant zeros
+    tt_zeros = network.add_constant(
+        (S,), trt.Weights(np.zeros(S, dtype=np.int32)))
+    token_type_ids = tt_zeros.get_output(0)
+
+    # Embedding tables (may use embedding_size != hidden for factorized embeddings)
+    embedding_size = weights["embedding"].shape[1]
+    embedding_table = graph_ops.add_constant(
+        network, weights["embedding"].shape, weights["embedding"])
+    position_embed_table = graph_ops.add_constant(
+        network, weights["position_embedding"].shape, weights["position_embedding"])
+    token_type_table = graph_ops.add_constant(
+        network, (type_vocab_size, embedding_size), weights["token_type_embedding"])
+
+    # Position indices
+    position_indices = graph_ops.add_constant(
+        network, (S,), np.arange(S, dtype=np.int32).astype(np.float32))
+    pos_int = network.add_cast(position_indices, trt.int32)
+
+    # Embedding: word + position + token_type
+    word_embed = network.add_gather(embedding_table, input_ids, 0)
+    pos_embed = network.add_gather(position_embed_table, pos_int.get_output(0), 0)
+    tt_embed = network.add_gather(token_type_table, token_type_ids, 0)
+
+    embed_sum1 = network.add_elementwise(
+        word_embed.get_output(0), pos_embed.get_output(0),
+        trt.ElementWiseOperation.SUM)
+    embed_sum2 = network.add_elementwise(
+        embed_sum1.get_output(0), tt_embed.get_output(0),
+        trt.ElementWiseOperation.SUM)
+
+    # Embedding LayerNorm (over embedding_size)
+    hidden_state = _add_seq_layer_norm(
+        network, embed_sum2.get_output(0), embedding_size,
+        weights["embed_norm"], weights["embed_norm_beta"], eps)
+
+    # Optional embedding projection: embedding_size -> hidden_size
+    if "embed_projection" in weights:
+        hidden_state = graph_ops.add_matmul_rhs_constant(
+            network, hidden_state, embedding_size, hidden,
+            weights["embed_projection"])
+        if "embed_projection_bias" in weights:
+            hidden_state = graph_ops.add_bias_sum(
+                network, hidden_state, hidden,
+                weights["embed_projection_bias"])
+
+    # Pre-compute 2D DFT matrices as constants
+    # real(DFT2D(X)) = cos_S @ X @ cos_H - sin_S @ X @ sin_H
+    cos_s, sin_s = _compute_dft_matrices(S)
+    cos_h, sin_h = _compute_dft_matrices(H)
+
+    cos_s_const = graph_ops.add_constant(network, (S, S), cos_s)
+    sin_s_const = graph_ops.add_constant(network, (S, S), sin_s)
+    cos_h_const = graph_ops.add_constant(network, (H, H), cos_h)
+    sin_h_const = graph_ops.add_constant(network, (H, H), sin_h)
+
+    # Encoder layers
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+
+        # --- 2D DFT (replaces self-attention) ---
+        # real(DFT2D(X)) = cos_S @ X @ cos_H - sin_S @ X @ sin_H
+        # Term 1: cos_S @ X @ cos_H
+        cx = network.add_matrix_multiply(
+            cos_s_const, trt.MatrixOperation.NONE,
+            hidden_state, trt.MatrixOperation.NONE)
+        cxch = network.add_matrix_multiply(
+            cx.get_output(0), trt.MatrixOperation.NONE,
+            cos_h_const, trt.MatrixOperation.NONE)
+
+        # Term 2: sin_S @ X @ sin_H
+        sx = network.add_matrix_multiply(
+            sin_s_const, trt.MatrixOperation.NONE,
+            hidden_state, trt.MatrixOperation.NONE)
+        sxsh = network.add_matrix_multiply(
+            sx.get_output(0), trt.MatrixOperation.NONE,
+            sin_h_const, trt.MatrixOperation.NONE)
+
+        # real = term1 - term2
+        dft_out = network.add_elementwise(
+            cxch.get_output(0), sxsh.get_output(0),
+            trt.ElementWiseOperation.SUB).get_output(0)
+
+        # POST-norm: residual + LayerNorm after DFT
+        residual1 = network.add_elementwise(
+            hidden_state, dft_out, trt.ElementWiseOperation.SUM)
+        normed1 = _add_seq_layer_norm(
+            network, residual1.get_output(0), hidden,
+            weights[f"{prefix}.post_attn_norm"],
+            weights[f"{prefix}.post_attn_norm_beta"], eps)
+
+        # --- FFN ---
+        fc1 = graph_ops.add_matmul_rhs_constant(
+            network, normed1, hidden, intermediate,
+            weights[f"{prefix}.w_fc1"])
+        fc1 = graph_ops.add_bias_sum(
+            network, fc1, intermediate, weights[f"{prefix}.fc1_bias"])
+        activated = graph_ops.add_activation(network, fc1, hidden_act)
+        fc2 = graph_ops.add_matmul_rhs_constant(
+            network, activated, intermediate, hidden,
+            weights[f"{prefix}.w_fc2"])
+        fc2 = add_all_reduce_sum(network, fc2, parallel.tp_size)
+        fc2 = graph_ops.add_bias_sum(
+            network, fc2, hidden, weights[f"{prefix}.fc2_bias"])
+
+        # POST-norm: residual + LayerNorm after FFN
+        residual2 = network.add_elementwise(
+            normed1, fc2, trt.ElementWiseOperation.SUM)
+        hidden_state = _add_seq_layer_norm(
+            network, residual2.get_output(0), hidden,
+            weights[f"{prefix}.output_norm"],
+            weights[f"{prefix}.output_norm_beta"], eps)
+
+    # Output
+    hidden_state.name = "hidden_states"
+    network.mark_output(hidden_state)
+
+    if verbose:
+        print(f"[trtmc build] Building FNet encoder TRT engine "
+              f"({num_layers} layers, hidden={hidden}, tp={parallel.tp_size}, "
+              f"seq_len={S}) ...", file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT engine build failed")
+
+    return bytes(plan)

--- a/python/tensorrt_model_connect/families/modernbert/plugin.py
+++ b/python/tensorrt_model_connect/families/modernbert/plugin.py
@@ -25,6 +25,10 @@ from ...checkpoint_mapper import (
     _has_tensor,
 )
 from ... import graph_ops
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 
 from tensorrt_model_connect import trt_compat
 
@@ -127,8 +131,23 @@ class ModernbertPlugin:
 
     def build_engine(
         self, config: ModelConfig, weights: WeightDict,
-        max_cache_length: int, *, verbose: bool = False,
+        max_cache_length: int, *, precision: str = "fp32",
+        quant_ctx=None, verbose: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="ModernBERT tensor-parallel builds")
+            if quant_ctx is not None:
+                raise ValueError("ModernBERT tensor-parallel builds do not support quantization")
+            from .tp_builder import build_tp_modernbert_engine
+            return build_tp_modernbert_engine(
+                config, weights,
+                max_seq_length=max_cache_length,
+                verbose=verbose,
+                parallel_config=parallel)
+
         hidden = config.hidden_size
         vocab = config.vocab_size
         num_layers = config.num_hidden_layers

--- a/python/tensorrt_model_connect/families/modernbert/tp_builder.py
+++ b/python/tensorrt_model_connect/families/modernbert/tp_builder.py
@@ -1,0 +1,259 @@
+"""Tensor-parallel ModernBERT encoder builder."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...config import ModelConfig
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...parallel_config import ParallelConfig
+
+
+def _add_layernorm_no_bias(network, inp, hidden_size, gamma, eps):
+    """LayerNorm without bias via TRT native normalization."""
+    beta = np.zeros(hidden_size, dtype=np.float32)
+    return graph_ops.add_layer_norm_native(
+        network, inp, hidden_size, gamma, beta, eps)
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_modernbert_tp(
+    config: ModelConfig,
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("ModernBERT tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if config.num_attention_heads % tp != 0:
+        raise ValueError(
+            "ModernBERT tensor parallel requires num_attention_heads divisible by "
+            f"tp_size ({config.num_attention_heads} vs {tp})")
+    if config.intermediate_size % tp != 0:
+        raise ValueError(
+            "ModernBERT tensor parallel requires intermediate_size divisible by "
+            f"tp_size ({config.intermediate_size} vs {tp})")
+
+    for layer_idx in range(config.num_hidden_layers):
+        prefix = f"layer.{layer_idx}"
+        for key in (f"{prefix}.w_q", f"{prefix}.w_k", f"{prefix}.w_v"):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_o"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_o input dim must be divisible by tp_size")
+        for key in (f"{prefix}.w_mlp_input", f"{prefix}.w_mlp_gate"):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_down"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_down input dim must be divisible by tp_size")
+
+
+def shard_modernbert_weights(
+    config: ModelConfig,
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local ModernBERT weights for the TP builder."""
+    _validate_modernbert_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        if key.endswith((".w_q", ".w_k", ".w_v", ".w_mlp_input", ".w_mlp_gate")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_o", ".w_down")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_attention_size"] = config.attention_size // parallel.tp_size
+    out["_intermediate_size"] = config.intermediate_size // parallel.tp_size
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def build_tp_modernbert_engine(
+    config: ModelConfig,
+    weights: "WeightDict",
+    max_seq_length: int,
+    *,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build a rank-local TensorRT engine plan for ModernBERT."""
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_tp_modernbert_engine requires tensor_parallel mode and tp_size > 1")
+    weights = shard_modernbert_weights(config, weights, parallel=parallel)
+
+    hidden = config.hidden_size
+    vocab = config.vocab_size
+    num_layers = config.num_hidden_layers
+    full_num_heads = config.num_attention_heads
+    num_heads = config.num_attention_heads // parallel.tp_size
+    head_dim = hidden // full_num_heads
+    attention_size = num_heads * head_dim
+    intermediate = config.intermediate_size // parallel.tp_size
+    eps = config.raw.get("norm_eps", config.rms_norm_eps)
+    max_seq = max_seq_length
+
+    layer_types = config.raw.get("layer_types", [])
+    rope_params = config.raw.get("rope_parameters", {})
+    full_theta = 160000.0
+    sliding_theta = 10000.0
+    if rope_params:
+        if "full_attention" in rope_params and rope_params["full_attention"]:
+            full_theta = rope_params["full_attention"].get("rope_theta", 160000.0)
+        if "sliding_attention" in rope_params and rope_params["sliding_attention"]:
+            sliding_theta = rope_params["sliding_attention"].get("rope_theta", 10000.0)
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    trt_config.clear_flag(trt.BuilderFlag.TF32)
+
+    input_ids = network.add_input("input_ids", trt.int32, (max_seq,))
+    attention_mask_input = network.add_input("attention_mask", trt.int32, (max_seq,))
+
+    mask_float = network.add_cast(attention_mask_input, trt.float32)
+    ones_c = graph_ops.add_constant(network, (1,), np.array([1.0], dtype=np.float32))
+    neg_large = graph_ops.add_constant(network, (1,), np.array([-1e10], dtype=np.float32))
+    inv_mask = network.add_elementwise(
+        ones_c, mask_float.get_output(0), trt.ElementWiseOperation.SUB)
+    pad_penalty = network.add_elementwise(
+        inv_mask.get_output(0), neg_large, trt.ElementWiseOperation.PROD)
+    pad_mask_4d = network.add_shuffle(pad_penalty.get_output(0))
+    pad_mask_4d.reshape_dims = (1, 1, 1, max_seq)
+
+    rope_tables = {}
+    for theta in set([full_theta, sliding_theta]):
+        cos = graph_ops.add_constant(
+            network, (max_seq, head_dim // 2),
+            graph_ops.make_rope_table_half_dim(
+                max_seq, head_dim, theta, cosine=True))
+        sin = graph_ops.add_constant(
+            network, (max_seq, head_dim // 2),
+            graph_ops.make_rope_table_half_dim(
+                max_seq, head_dim, theta, cosine=False))
+        rope_tables[theta] = (cos, sin)
+
+    pos_indices = graph_ops.add_constant(
+        network, (max_seq,), np.arange(max_seq, dtype=np.int32),
+        dtype=np.int32)
+
+    embed_table = graph_ops.add_constant(network, (vocab, hidden), weights["embedding"])
+    word_embed = network.add_gather(embed_table, input_ids, 0)
+    hidden_state = _add_layernorm_no_bias(
+        network, word_embed.get_output(0), hidden, weights["embed_norm"], eps)
+
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+
+        if layer_idx < len(layer_types):
+            lt = layer_types[layer_idx]
+            theta = full_theta if lt in ("full_attention", "global_attention") else sliding_theta
+        else:
+            theta = full_theta
+        cos_table, sin_table = rope_tables[theta]
+
+        if f"{prefix}.attn_norm" in weights:
+            attn_input = _add_layernorm_no_bias(
+                network, hidden_state, hidden,
+                weights[f"{prefix}.attn_norm"], eps)
+        else:
+            attn_input = hidden_state
+
+        q = graph_ops.add_matmul_rhs_constant(
+            network, attn_input, hidden, attention_size, weights[f"{prefix}.w_q"])
+        k = graph_ops.add_matmul_rhs_constant(
+            network, attn_input, hidden, attention_size, weights[f"{prefix}.w_k"])
+        v = graph_ops.add_matmul_rhs_constant(
+            network, attn_input, hidden, attention_size, weights[f"{prefix}.w_v"])
+
+        q = graph_ops.add_apply_rope_native(
+            network, q, num_heads, head_dim,
+            cos_table, sin_table, pos_indices, head_dim,
+            sequence_length=max_seq)
+        k = graph_ops.add_apply_rope_native(
+            network, k, num_heads, head_dim,
+            cos_table, sin_table, pos_indices, head_dim,
+            sequence_length=max_seq)
+
+        context_flat = graph_ops.add_attention_from_rows(
+            network, q, k, v,
+            num_heads=num_heads, head_dim=head_dim,
+            q_seq=max_seq, kv_seq=max_seq,
+            mask=pad_mask_4d.get_output(0))
+
+        attn_out = graph_ops.add_matmul_rhs_constant(
+            network, context_flat, attention_size, hidden, weights[f"{prefix}.w_o"])
+        attn_out = add_all_reduce_sum(network, attn_out, parallel.tp_size)
+
+        res1 = network.add_elementwise(hidden_state, attn_out, trt.ElementWiseOperation.SUM)
+        hidden_state = res1.get_output(0)
+
+        mlp_input = _add_layernorm_no_bias(
+            network, hidden_state, hidden, weights[f"{prefix}.mlp_norm"], eps)
+
+        inp_proj = graph_ops.add_matmul_rhs_constant(
+            network, mlp_input, hidden, intermediate, weights[f"{prefix}.w_mlp_input"])
+        gate_proj = graph_ops.add_matmul_rhs_constant(
+            network, mlp_input, hidden, intermediate, weights[f"{prefix}.w_mlp_gate"])
+        inp_act = graph_ops.add_gelu_erf(network, inp_proj)
+        gated = network.add_elementwise(inp_act, gate_proj, trt.ElementWiseOperation.PROD)
+
+        down = graph_ops.add_matmul_rhs_constant(
+            network, gated.get_output(0), intermediate, hidden, weights[f"{prefix}.w_down"])
+        down = add_all_reduce_sum(network, down, parallel.tp_size)
+
+        res2 = network.add_elementwise(hidden_state, down, trt.ElementWiseOperation.SUM)
+        hidden_state = res2.get_output(0)
+
+    hidden_state = _add_layernorm_no_bias(
+        network, hidden_state, hidden, weights["final_norm"], eps)
+
+    hidden_state.name = "hidden_states"
+    network.mark_output(hidden_state)
+
+    if verbose:
+        print(f"[trtmc build] Building ModernBERT encoder TRT engine "
+              f"({num_layers} layers, hidden={hidden}, tp={parallel.tp_size}, "
+              f"seq_len={max_seq}) ...",
+              file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT engine build failed")
+    return bytes(plan)

--- a/python/tensorrt_model_connect/families/mpnet/plugin.py
+++ b/python/tensorrt_model_connect/families/mpnet/plugin.py
@@ -24,6 +24,10 @@ from ...checkpoint_mapper import (
     _load_tensor,
     _has_tensor,
 )
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 from .encoder_builder import build_encoder_engine
 
 
@@ -214,7 +218,9 @@ class MpnetPlugin:
         self, config: ModelConfig, weights: WeightDict,
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
         public_module = sys.modules.get(__package__)
         compute_relative_position_bias = getattr(
             public_module,
@@ -231,6 +237,18 @@ class MpnetPlugin:
             bias_matrix = compute_relative_position_bias(
                 max_cache_length, num_buckets, num_heads, bias_table)
             weights["relative_position_bias"] = bias_matrix
+
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="MPNet tensor-parallel builds")
+            if quant_ctx is not None:
+                raise ValueError("MPNet tensor-parallel builds do not support quantization")
+            from .tp_builder import build_tp_encoder_engine
+            return build_tp_encoder_engine(
+                config, weights,
+                max_seq_length=max_cache_length,
+                verbose=verbose,
+                parallel_config=parallel)
 
         return builder(
             config, weights,

--- a/python/tensorrt_model_connect/families/mpnet/tp_builder.py
+++ b/python/tensorrt_model_connect/families/mpnet/tp_builder.py
@@ -1,0 +1,430 @@
+"""Tensor-parallel encoder-only engine builder (MPNet-style).
+
+Builds one rank-local TensorRT engine for an encoder-only transformer. Unlike
+the standard decoder builder, this has:
+  - No KV cache (processes entire sequence at once)
+  - No causal attention mask (full bidirectional attention)
+  - POST-norm architecture (residual + LayerNorm after attention/FFN)
+  - Token type embeddings (segment A/B)
+  - Output: hidden_states [seq_len, hidden_size]
+
+Tensor parallelism only changes the encoder projections:
+  - Q/K/V and FFN fc1 are column-parallel
+  - Attention output and FFN fc2 are row-parallel
+  - Row-parallel outputs are joined with TensorRT distributed ALL_REDUCE
+
+Tensor names for the C++ runtime:
+  Inputs:  input_ids [seq_len], attention_mask [seq_len]
+  Outputs: hidden_states [seq_len, hidden_size]
+
+token_type_ids is baked as constant zeros (single-segment inference).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...config import ModelConfig
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_encoder_tp(
+    config: ModelConfig,
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("MPNet tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if config.num_attention_heads % tp != 0:
+        raise ValueError(
+            "MPNet tensor parallel requires num_attention_heads divisible by "
+            f"tp_size ({config.num_attention_heads} vs {tp})")
+    if config.intermediate_size % tp != 0:
+        raise ValueError(
+            "MPNet tensor parallel requires intermediate_size divisible by "
+            f"tp_size ({config.intermediate_size} vs {tp})")
+
+    for layer_idx in range(config.num_hidden_layers):
+        prefix = f"layer.{layer_idx}"
+        for key in (f"{prefix}.w_q", f"{prefix}.w_k", f"{prefix}.w_v"):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_o"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_o input dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc1"].shape[-1] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc1 output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc2"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc2 input dim must be divisible by tp_size")
+
+    if "relative_position_bias" in weights and weights["relative_position_bias"].shape[0] % tp != 0:
+        raise ValueError(
+            "relative_position_bias head dim must be divisible by tp_size")
+
+
+def shard_encoder_weights(
+    config: ModelConfig,
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local MPNet-style encoder weights for the TP builder."""
+    _validate_encoder_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        if key.endswith((".w_q", ".w_k", ".w_v", ".w_fc1")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".q_bias", ".k_bias", ".v_bias", ".fc1_bias")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_o", ".w_fc2")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key == "relative_position_bias":
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_attention_size"] = config.attention_size // parallel.tp_size
+    out["_intermediate_size"] = config.intermediate_size // parallel.tp_size
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def build_tp_encoder_engine(
+    config: ModelConfig,
+    weights: "WeightDict",
+    max_seq_length: int,
+    *,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build a rank-local TRT engine plan for a MPNet-style encoder.
+
+    Args:
+        config: Model architecture from config.json.
+        weights: Loaded weight dict from MPNet plugin.
+        max_seq_length: Maximum sequence length the engine is compiled for.
+        verbose: Print TRT builder logs.
+
+    Returns:
+        Serialized engine plan bytes.
+    """
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_tp_encoder_engine requires tensor_parallel mode and tp_size > 1")
+    weights = shard_encoder_weights(config, weights, parallel=parallel)
+
+    hidden = config.hidden_size
+    num_layers = config.num_hidden_layers
+    full_num_heads = config.num_attention_heads
+    num_heads = config.num_attention_heads // parallel.tp_size
+    head_dim = hidden // full_num_heads
+    intermediate = config.intermediate_size // parallel.tp_size
+    eps = config.rms_norm_eps  # Actually layer_norm_eps for MPNet
+    type_vocab_size = config.raw.get("type_vocab_size", 2)
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
+    # which causes significant accuracy loss across 12+ encoder layers.
+    trt_config.clear_flag(trt.BuilderFlag.TF32)
+
+    # Resolve GELU variant from config
+    hidden_act = config.hidden_act or config.raw.get("activation", "") or "gelu"
+
+    # -------------------------------------------------------------------
+    # Inputs
+    # -------------------------------------------------------------------
+    input_ids = network.add_input("input_ids", trt.int32, (max_seq_length,))
+    attention_mask_input = network.add_input("attention_mask", trt.int32, (max_seq_length,))
+
+    # token_type_ids: constant zeros (all segment-0) — the C++ encoder
+    # pipeline doesn't provide this input, and inference is single-segment.
+    tt_zeros = network.add_constant(
+        (max_seq_length,), trt.Weights(np.zeros(max_seq_length, dtype=np.int32)))
+    token_type_ids = tt_zeros.get_output(0)
+
+    # -------------------------------------------------------------------
+    # Shared constants (support embedding factorization: embedding_size != hidden)
+    # -------------------------------------------------------------------
+    embedding_size = weights["embedding"].shape[1]  # may differ from hidden (e.g. ALMPNet 128 vs 768)
+    embedding_table = graph_ops.add_constant(
+        network, weights["embedding"].shape, weights["embedding"])
+    position_embed_table = graph_ops.add_constant(
+        network, weights["position_embedding"].shape, weights["position_embedding"])
+    token_type_table = graph_ops.add_constant(
+        network, (type_vocab_size, embedding_size), weights["token_type_embedding"])
+
+    graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+    attn_scale_tensor = graph_ops.add_constant(
+        network, (1, 1, 1), np.array([1.0 / np.sqrt(max(head_dim, 1))], dtype=np.float32))
+
+    # Build additive attention mask from attention_mask input:
+    # attention_mask is [seq_len] with 1=real, 0=padding.
+    # Convert to [1, 1, seq_len] additive mask: 0.0 for real, -1e10 for padding.
+    mask_float = network.add_cast(attention_mask_input, trt.float32)
+    ones_mask = graph_ops.add_constant(
+        network, (1,), np.array([1.0], dtype=np.float32))
+    neg_large = graph_ops.add_constant(
+        network, (1,), np.array([-1e10], dtype=np.float32))
+    inv_mask = network.add_elementwise(
+        ones_mask, mask_float.get_output(0),
+        trt.ElementWiseOperation.SUB)  # 0 for real, 1 for pad
+    pad_penalty = network.add_elementwise(
+        inv_mask.get_output(0), neg_large,
+        trt.ElementWiseOperation.PROD)  # 0.0 for real, -1e10 for pad
+    # Reshape to [1, 1, seq_len] for broadcasting: [num_heads, seq_len, seq_len]
+    pad_mask_reshape = network.add_shuffle(pad_penalty.get_output(0))
+    pad_mask_reshape.reshape_dims = (1, 1, max_seq_length)
+
+    # Position indices: [0, 1, 2, ..., max_seq_length-1]
+    position_indices = graph_ops.add_constant(
+        network, (max_seq_length,),
+        np.arange(max_seq_length, dtype=np.int32).astype(np.float32))
+    # Cast back to int32 for gather
+    pos_int = network.add_cast(position_indices, trt.int32)
+
+    # -------------------------------------------------------------------
+    # Embedding: word + position + token_type + LayerNorm
+    # -------------------------------------------------------------------
+    word_embed = network.add_gather(embedding_table, input_ids, 0)
+    pos_embed = network.add_gather(position_embed_table, pos_int.get_output(0), 0)
+    tt_embed = network.add_gather(token_type_table, token_type_ids, 0)
+
+    # Sum all three embedding types
+    embed_sum1 = network.add_elementwise(
+        word_embed.get_output(0), pos_embed.get_output(0),
+        trt.ElementWiseOperation.SUM)
+    embed_sum2 = network.add_elementwise(
+        embed_sum1.get_output(0), tt_embed.get_output(0),
+        trt.ElementWiseOperation.SUM)
+
+    # Embedding LayerNorm (over embedding_size, which may differ from hidden)
+    hidden_state = _add_seq_layer_norm(
+        network, embed_sum2.get_output(0), embedding_size, max_seq_length,
+        weights["embed_norm"], weights["embed_norm_beta"], eps)
+
+    # Optional embedding projection: embedding_size -> hidden_size (ALMPNet, FNet)
+    if "embed_projection" in weights:
+        hidden_state = graph_ops.add_matmul_rhs_constant(
+            network, hidden_state, embedding_size, hidden,
+            weights["embed_projection"])
+        if "embed_projection_bias" in weights:
+            hidden_state = graph_ops.add_bias_sum(
+                network, hidden_state, hidden,
+                weights["embed_projection_bias"])
+
+    # -------------------------------------------------------------------
+    # Optional relative position bias (MPNet, T5-style)
+    # -------------------------------------------------------------------
+    rel_pos_bias_tensor = None
+    if "relative_position_bias" in weights:
+        # Pre-computed [num_heads, seq_len, seq_len] bias matrix
+        rpb = weights["relative_position_bias"]
+        rel_pos_bias_tensor = graph_ops.add_constant(
+            network, rpb.shape, rpb)
+
+    # -------------------------------------------------------------------
+    # Encoder layers
+    # -------------------------------------------------------------------
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+
+        hidden_state = _add_encoder_layer(
+            network=network,
+            hidden=hidden_state,
+            weights=weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            intermediate_size=intermediate,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            seq_length=max_seq_length,
+            attn_scale_tensor=attn_scale_tensor,
+            attn_mask=pad_mask_reshape.get_output(0),
+            rel_pos_bias=rel_pos_bias_tensor,
+            hidden_act=hidden_act,
+            eps=eps,
+            tp_size=parallel.tp_size,
+        )
+
+    # -------------------------------------------------------------------
+    # Output
+    # -------------------------------------------------------------------
+    hidden_state.name = "hidden_states"
+    network.mark_output(hidden_state)
+
+    # -------------------------------------------------------------------
+    # Build engine
+    # -------------------------------------------------------------------
+    if verbose:
+        print(f"[trtmc build] Building MPNet encoder TRT engine "
+              f"({num_layers} layers, hidden={hidden}, tp={parallel.tp_size}, "
+              f"seq_len={max_seq_length}) ...", file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT engine build failed")
+
+    return bytes(plan)
+
+
+def _add_seq_layer_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    seq_length: int,
+    gamma: np.ndarray,
+    beta: np.ndarray,
+    eps: float,
+) -> trt.ITensor:
+    """LayerNorm over sequence of vectors: [seq_len, hidden] -> [seq_len, hidden].
+
+    Uses the shared TRT native normalization helper.
+    """
+    return graph_ops.add_layer_norm_native(
+        network, inp, hidden_size, gamma, beta, eps)
+
+
+def _add_encoder_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    weights: WeightDict,
+    prefix: str,
+    hidden_size: int,
+    intermediate_size: int,
+    num_heads: int,
+    head_dim: int,
+    seq_length: int,
+    attn_scale_tensor: trt.ITensor,
+    attn_mask: trt.ITensor,
+    rel_pos_bias: trt.ITensor | None = None,
+    hidden_act: str = "gelu",
+    eps: float,
+    tp_size: int,
+) -> trt.ITensor:
+    """Add one MPNet encoder layer with POST-norm.
+
+    MPNet architecture per layer:
+        attn_out = MultiHeadSelfAttention(hidden)
+        hidden = LayerNorm(hidden + attn_out)  # post-norm
+        ffn_out = FFN(hidden)
+        hidden = LayerNorm(hidden + ffn_out)   # post-norm
+    """
+    attention_size = num_heads * head_dim
+
+    # --- Self-attention (no causal mask, bidirectional) ---
+    # QKV projections
+    q = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_q"])
+    k = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_k"])
+    v = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_v"])
+
+    # QKV biases
+    q = graph_ops.add_bias_sum(network, q, attention_size, weights[f"{prefix}.q_bias"])
+    k = graph_ops.add_bias_sum(network, k, attention_size, weights[f"{prefix}.k_bias"])
+    v = graph_ops.add_bias_sum(network, v, attention_size, weights[f"{prefix}.v_bias"])
+
+    # Add relative position bias if present (MPNet/T5-style). IAttention
+    # applies scaling internally through graph_ops.add_attention_from_rows, so
+    # the mask contains only additive bias/masking terms.
+    additive_mask = attn_mask
+    if rel_pos_bias is not None:
+        additive_mask = network.add_elementwise(
+            rel_pos_bias, attn_mask, trt.ElementWiseOperation.SUM).get_output(0)
+
+    mask_4d = network.add_shuffle(additive_mask)
+    mask_4d.reshape_dims = (
+        (1, num_heads, seq_length, seq_length)
+        if rel_pos_bias is not None
+        else (1, 1, 1, seq_length)
+    )
+
+    context_flat = graph_ops.add_attention_from_rows(
+        network, q, k, v,
+        num_heads=num_heads, head_dim=head_dim,
+        q_seq=seq_length, kv_seq=seq_length,
+        mask=mask_4d.get_output(0),
+        tag=prefix + ".attn")
+
+    # Output projection
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, context_flat,
+        attention_size, hidden_size,
+        weights[f"{prefix}.w_o"])
+    attn_out = add_all_reduce_sum(network, attn_out, tp_size)
+    attn_out = graph_ops.add_bias_sum(
+        network, attn_out, hidden_size, weights[f"{prefix}.o_bias"])
+
+    # POST-norm: LayerNorm(hidden + attn_out)
+    residual1 = network.add_elementwise(
+        hidden, attn_out, trt.ElementWiseOperation.SUM)
+    normed1 = _add_seq_layer_norm(
+        network, residual1.get_output(0), hidden_size, seq_length,
+        weights[f"{prefix}.post_attn_norm"],
+        weights[f"{prefix}.post_attn_norm_beta"], eps)
+
+    # --- FFN: fc1 -> GELU -> fc2 ---
+    fc1 = graph_ops.add_matmul_rhs_constant(
+        network, normed1, hidden_size, intermediate_size,
+        weights[f"{prefix}.w_fc1"])
+    fc1 = graph_ops.add_bias_sum(network, fc1, intermediate_size,
+                                  weights[f"{prefix}.fc1_bias"])
+    activated = graph_ops.add_activation(network, fc1, hidden_act)
+    fc2 = graph_ops.add_matmul_rhs_constant(
+        network, activated, intermediate_size, hidden_size,
+        weights[f"{prefix}.w_fc2"])
+    fc2 = add_all_reduce_sum(network, fc2, tp_size)
+    fc2 = graph_ops.add_bias_sum(network, fc2, hidden_size,
+                                  weights[f"{prefix}.fc2_bias"])
+
+    # POST-norm: LayerNorm(normed1 + ffn_out)
+    residual2 = network.add_elementwise(
+        normed1, fc2, trt.ElementWiseOperation.SUM)
+    normed2 = _add_seq_layer_norm(
+        network, residual2.get_output(0), hidden_size, seq_length,
+        weights[f"{prefix}.output_norm"],
+        weights[f"{prefix}.output_norm_beta"], eps)
+
+    return normed2

--- a/python/tensorrt_model_connect/families/roberta/plugin.py
+++ b/python/tensorrt_model_connect/families/roberta/plugin.py
@@ -29,6 +29,10 @@ from ...checkpoint_mapper import (
     _load_tensor,
     _has_tensor,
 )
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 from .encoder_builder import build_encoder_engine
 
 
@@ -199,8 +203,24 @@ class RobertaPlugin:
         self, config: ModelConfig, weights: WeightDict,
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
         public_module = sys.modules.get(__package__)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="RoBERTa tensor-parallel builds")
+            if quant_ctx is not None:
+                raise ValueError("RoBERTa tensor-parallel builds do not support quantization")
+            from .tp_builder import build_tp_encoder_engine
+            builder = getattr(
+                public_module, "build_tp_encoder_engine", build_tp_encoder_engine)
+            return builder(
+                config, weights,
+                max_seq_length=max_cache_length,
+                verbose=verbose,
+                parallel_config=parallel)
+
         builder = getattr(public_module, "build_encoder_engine", build_encoder_engine)
         return builder(
             config, weights,

--- a/python/tensorrt_model_connect/families/roberta/tp_builder.py
+++ b/python/tensorrt_model_connect/families/roberta/tp_builder.py
@@ -1,0 +1,430 @@
+"""Tensor-parallel encoder-only engine builder (BERT-style).
+
+Builds one rank-local TensorRT engine for an encoder-only transformer. Unlike
+the standard decoder builder, this has:
+  - No KV cache (processes entire sequence at once)
+  - No causal attention mask (full bidirectional attention)
+  - POST-norm architecture (residual + LayerNorm after attention/FFN)
+  - Token type embeddings (segment A/B)
+  - Output: hidden_states [seq_len, hidden_size]
+
+Tensor parallelism only changes the encoder projections:
+  - Q/K/V and FFN fc1 are column-parallel
+  - Attention output and FFN fc2 are row-parallel
+  - Row-parallel outputs are joined with TensorRT distributed ALL_REDUCE
+
+Tensor names for the C++ runtime:
+  Inputs:  input_ids [seq_len], attention_mask [seq_len]
+  Outputs: hidden_states [seq_len, hidden_size]
+
+token_type_ids is baked as constant zeros (single-segment inference).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...config import ModelConfig
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_encoder_tp(
+    config: ModelConfig,
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("RoBERTa tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if config.num_attention_heads % tp != 0:
+        raise ValueError(
+            "RoBERTa tensor parallel requires num_attention_heads divisible by "
+            f"tp_size ({config.num_attention_heads} vs {tp})")
+    if config.intermediate_size % tp != 0:
+        raise ValueError(
+            "RoBERTa tensor parallel requires intermediate_size divisible by "
+            f"tp_size ({config.intermediate_size} vs {tp})")
+
+    for layer_idx in range(config.num_hidden_layers):
+        prefix = f"layer.{layer_idx}"
+        for key in (f"{prefix}.w_q", f"{prefix}.w_k", f"{prefix}.w_v"):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_o"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_o input dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc1"].shape[-1] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc1 output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc2"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc2 input dim must be divisible by tp_size")
+
+    if "relative_position_bias" in weights and weights["relative_position_bias"].shape[0] % tp != 0:
+        raise ValueError(
+            "relative_position_bias head dim must be divisible by tp_size")
+
+
+def shard_encoder_weights(
+    config: ModelConfig,
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local RoBERTa-style encoder weights for the TP builder."""
+    _validate_encoder_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        if key.endswith((".w_q", ".w_k", ".w_v", ".w_fc1")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".q_bias", ".k_bias", ".v_bias", ".fc1_bias")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_o", ".w_fc2")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key == "relative_position_bias":
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_attention_size"] = config.attention_size // parallel.tp_size
+    out["_intermediate_size"] = config.intermediate_size // parallel.tp_size
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def build_tp_encoder_engine(
+    config: ModelConfig,
+    weights: "WeightDict",
+    max_seq_length: int,
+    *,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build a rank-local TRT engine plan for a RoBERTa-style encoder.
+
+    Args:
+        config: Model architecture from config.json.
+        weights: Loaded weight dict from RoBERTa plugin.
+        max_seq_length: Maximum sequence length the engine is compiled for.
+        verbose: Print TRT builder logs.
+
+    Returns:
+        Serialized engine plan bytes.
+    """
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_tp_encoder_engine requires tensor_parallel mode and tp_size > 1")
+    weights = shard_encoder_weights(config, weights, parallel=parallel)
+
+    hidden = config.hidden_size
+    num_layers = config.num_hidden_layers
+    full_num_heads = config.num_attention_heads
+    num_heads = config.num_attention_heads // parallel.tp_size
+    head_dim = hidden // full_num_heads
+    intermediate = config.intermediate_size // parallel.tp_size
+    eps = config.rms_norm_eps  # Actually layer_norm_eps for BERT
+    type_vocab_size = config.raw.get("type_vocab_size", 2)
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    # Disable TF32 to ensure full FP32 precision. TF32 uses 10-bit mantissa
+    # which causes significant accuracy loss across 12+ encoder layers.
+    trt_config.clear_flag(trt.BuilderFlag.TF32)
+
+    # Resolve GELU variant from config
+    hidden_act = config.hidden_act or config.raw.get("activation", "") or "gelu"
+
+    # -------------------------------------------------------------------
+    # Inputs
+    # -------------------------------------------------------------------
+    input_ids = network.add_input("input_ids", trt.int32, (max_seq_length,))
+    attention_mask_input = network.add_input("attention_mask", trt.int32, (max_seq_length,))
+
+    # token_type_ids: constant zeros (all segment-0) — the C++ encoder
+    # pipeline doesn't provide this input, and inference is single-segment.
+    tt_zeros = network.add_constant(
+        (max_seq_length,), trt.Weights(np.zeros(max_seq_length, dtype=np.int32)))
+    token_type_ids = tt_zeros.get_output(0)
+
+    # -------------------------------------------------------------------
+    # Shared constants (support embedding factorization: embedding_size != hidden)
+    # -------------------------------------------------------------------
+    embedding_size = weights["embedding"].shape[1]  # may differ from hidden (e.g. ALBERT 128 vs 768)
+    embedding_table = graph_ops.add_constant(
+        network, weights["embedding"].shape, weights["embedding"])
+    position_embed_table = graph_ops.add_constant(
+        network, weights["position_embedding"].shape, weights["position_embedding"])
+    token_type_table = graph_ops.add_constant(
+        network, (type_vocab_size, embedding_size), weights["token_type_embedding"])
+
+    graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+    attn_scale_tensor = graph_ops.add_constant(
+        network, (1, 1, 1), np.array([1.0 / np.sqrt(max(head_dim, 1))], dtype=np.float32))
+
+    # Build additive attention mask from attention_mask input:
+    # attention_mask is [seq_len] with 1=real, 0=padding.
+    # Convert to [1, 1, seq_len] additive mask: 0.0 for real, -1e10 for padding.
+    mask_float = network.add_cast(attention_mask_input, trt.float32)
+    ones_mask = graph_ops.add_constant(
+        network, (1,), np.array([1.0], dtype=np.float32))
+    neg_large = graph_ops.add_constant(
+        network, (1,), np.array([-1e10], dtype=np.float32))
+    inv_mask = network.add_elementwise(
+        ones_mask, mask_float.get_output(0),
+        trt.ElementWiseOperation.SUB)  # 0 for real, 1 for pad
+    pad_penalty = network.add_elementwise(
+        inv_mask.get_output(0), neg_large,
+        trt.ElementWiseOperation.PROD)  # 0.0 for real, -1e10 for pad
+    # Reshape to [1, 1, seq_len] for broadcasting: [num_heads, seq_len, seq_len]
+    pad_mask_reshape = network.add_shuffle(pad_penalty.get_output(0))
+    pad_mask_reshape.reshape_dims = (1, 1, max_seq_length)
+
+    # Position indices: [0, 1, 2, ..., max_seq_length-1]
+    position_indices = graph_ops.add_constant(
+        network, (max_seq_length,),
+        np.arange(max_seq_length, dtype=np.int32).astype(np.float32))
+    # Cast back to int32 for gather
+    pos_int = network.add_cast(position_indices, trt.int32)
+
+    # -------------------------------------------------------------------
+    # Embedding: word + position + token_type + LayerNorm
+    # -------------------------------------------------------------------
+    word_embed = network.add_gather(embedding_table, input_ids, 0)
+    pos_embed = network.add_gather(position_embed_table, pos_int.get_output(0), 0)
+    tt_embed = network.add_gather(token_type_table, token_type_ids, 0)
+
+    # Sum all three embedding types
+    embed_sum1 = network.add_elementwise(
+        word_embed.get_output(0), pos_embed.get_output(0),
+        trt.ElementWiseOperation.SUM)
+    embed_sum2 = network.add_elementwise(
+        embed_sum1.get_output(0), tt_embed.get_output(0),
+        trt.ElementWiseOperation.SUM)
+
+    # Embedding LayerNorm (over embedding_size, which may differ from hidden)
+    hidden_state = _add_seq_layer_norm(
+        network, embed_sum2.get_output(0), embedding_size, max_seq_length,
+        weights["embed_norm"], weights["embed_norm_beta"], eps)
+
+    # Optional embedding projection: embedding_size -> hidden_size (ALBERT, FNet)
+    if "embed_projection" in weights:
+        hidden_state = graph_ops.add_matmul_rhs_constant(
+            network, hidden_state, embedding_size, hidden,
+            weights["embed_projection"])
+        if "embed_projection_bias" in weights:
+            hidden_state = graph_ops.add_bias_sum(
+                network, hidden_state, hidden,
+                weights["embed_projection_bias"])
+
+    # -------------------------------------------------------------------
+    # Optional relative position bias (MPNet, T5-style)
+    # -------------------------------------------------------------------
+    rel_pos_bias_tensor = None
+    if "relative_position_bias" in weights:
+        # Pre-computed [num_heads, seq_len, seq_len] bias matrix
+        rpb = weights["relative_position_bias"]
+        rel_pos_bias_tensor = graph_ops.add_constant(
+            network, rpb.shape, rpb)
+
+    # -------------------------------------------------------------------
+    # Encoder layers
+    # -------------------------------------------------------------------
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+
+        hidden_state = _add_encoder_layer(
+            network=network,
+            hidden=hidden_state,
+            weights=weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            intermediate_size=intermediate,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            seq_length=max_seq_length,
+            attn_scale_tensor=attn_scale_tensor,
+            attn_mask=pad_mask_reshape.get_output(0),
+            rel_pos_bias=rel_pos_bias_tensor,
+            hidden_act=hidden_act,
+            eps=eps,
+            tp_size=parallel.tp_size,
+        )
+
+    # -------------------------------------------------------------------
+    # Output
+    # -------------------------------------------------------------------
+    hidden_state.name = "hidden_states"
+    network.mark_output(hidden_state)
+
+    # -------------------------------------------------------------------
+    # Build engine
+    # -------------------------------------------------------------------
+    if verbose:
+        print(f"[trtmc build] Building RoBERTa encoder TRT engine "
+              f"({num_layers} layers, hidden={hidden}, tp={parallel.tp_size}, "
+              f"seq_len={max_seq_length}) ...", file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT engine build failed")
+
+    return bytes(plan)
+
+
+def _add_seq_layer_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    seq_length: int,
+    gamma: np.ndarray,
+    beta: np.ndarray,
+    eps: float,
+) -> trt.ITensor:
+    """LayerNorm over sequence of vectors: [seq_len, hidden] -> [seq_len, hidden].
+
+    Uses the shared TRT native normalization helper.
+    """
+    return graph_ops.add_layer_norm_native(
+        network, inp, hidden_size, gamma, beta, eps)
+
+
+def _add_encoder_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    weights: WeightDict,
+    prefix: str,
+    hidden_size: int,
+    intermediate_size: int,
+    num_heads: int,
+    head_dim: int,
+    seq_length: int,
+    attn_scale_tensor: trt.ITensor,
+    attn_mask: trt.ITensor,
+    rel_pos_bias: trt.ITensor | None = None,
+    hidden_act: str = "gelu",
+    eps: float,
+    tp_size: int,
+) -> trt.ITensor:
+    """Add one BERT encoder layer with POST-norm.
+
+    BERT architecture per layer:
+        attn_out = MultiHeadSelfAttention(hidden)
+        hidden = LayerNorm(hidden + attn_out)  # post-norm
+        ffn_out = FFN(hidden)
+        hidden = LayerNorm(hidden + ffn_out)   # post-norm
+    """
+    attention_size = num_heads * head_dim
+
+    # --- Self-attention (no causal mask, bidirectional) ---
+    # QKV projections
+    q = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_q"])
+    k = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_k"])
+    v = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attention_size,
+        weights[f"{prefix}.w_v"])
+
+    # QKV biases
+    q = graph_ops.add_bias_sum(network, q, attention_size, weights[f"{prefix}.q_bias"])
+    k = graph_ops.add_bias_sum(network, k, attention_size, weights[f"{prefix}.k_bias"])
+    v = graph_ops.add_bias_sum(network, v, attention_size, weights[f"{prefix}.v_bias"])
+
+    # Add relative position bias if present (MPNet/T5-style). IAttention
+    # applies scaling internally through graph_ops.add_attention_from_rows, so
+    # the mask contains only additive bias/masking terms.
+    additive_mask = attn_mask
+    if rel_pos_bias is not None:
+        additive_mask = network.add_elementwise(
+            rel_pos_bias, attn_mask, trt.ElementWiseOperation.SUM).get_output(0)
+
+    mask_4d = network.add_shuffle(additive_mask)
+    mask_4d.reshape_dims = (
+        (1, num_heads, seq_length, seq_length)
+        if rel_pos_bias is not None
+        else (1, 1, 1, seq_length)
+    )
+
+    context_flat = graph_ops.add_attention_from_rows(
+        network, q, k, v,
+        num_heads=num_heads, head_dim=head_dim,
+        q_seq=seq_length, kv_seq=seq_length,
+        mask=mask_4d.get_output(0),
+        tag=prefix + ".attn")
+
+    # Output projection
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, context_flat,
+        attention_size, hidden_size,
+        weights[f"{prefix}.w_o"])
+    attn_out = add_all_reduce_sum(network, attn_out, tp_size)
+    attn_out = graph_ops.add_bias_sum(
+        network, attn_out, hidden_size, weights[f"{prefix}.o_bias"])
+
+    # POST-norm: LayerNorm(hidden + attn_out)
+    residual1 = network.add_elementwise(
+        hidden, attn_out, trt.ElementWiseOperation.SUM)
+    normed1 = _add_seq_layer_norm(
+        network, residual1.get_output(0), hidden_size, seq_length,
+        weights[f"{prefix}.post_attn_norm"],
+        weights[f"{prefix}.post_attn_norm_beta"], eps)
+
+    # --- FFN: fc1 -> GELU -> fc2 ---
+    fc1 = graph_ops.add_matmul_rhs_constant(
+        network, normed1, hidden_size, intermediate_size,
+        weights[f"{prefix}.w_fc1"])
+    fc1 = graph_ops.add_bias_sum(network, fc1, intermediate_size,
+                                  weights[f"{prefix}.fc1_bias"])
+    activated = graph_ops.add_activation(network, fc1, hidden_act)
+    fc2 = graph_ops.add_matmul_rhs_constant(
+        network, activated, intermediate_size, hidden_size,
+        weights[f"{prefix}.w_fc2"])
+    fc2 = add_all_reduce_sum(network, fc2, tp_size)
+    fc2 = graph_ops.add_bias_sum(network, fc2, hidden_size,
+                                  weights[f"{prefix}.fc2_bias"])
+
+    # POST-norm: LayerNorm(normed1 + ffn_out)
+    residual2 = network.add_elementwise(
+        normed1, fc2, trt.ElementWiseOperation.SUM)
+    normed2 = _add_seq_layer_norm(
+        network, residual2.get_output(0), hidden_size, seq_length,
+        weights[f"{prefix}.output_norm"],
+        weights[f"{prefix}.output_norm_beta"], eps)
+
+    return normed2

--- a/python/tensorrt_model_connect/families/xlnet/plugin.py
+++ b/python/tensorrt_model_connect/families/xlnet/plugin.py
@@ -26,6 +26,10 @@ from ...checkpoint_mapper import (
     _load_tensor,
     _has_tensor,
 )
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 
 
 def _detect_xlnet_prefix(readers) -> str:
@@ -114,8 +118,23 @@ class XlnetPlugin:
 
     def build_engine(
         self, config: ModelConfig, weights: WeightDict,
-        max_cache_length: int, *, verbose: bool = False,
+        max_cache_length: int, *, precision: str = "fp32",
+        quant_ctx=None, verbose: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="XLNet tensor-parallel builds")
+            if quant_ctx is not None:
+                raise ValueError("XLNet tensor-parallel builds do not support quantization")
+            from .tp_builder import build_tp_xlnet_engine
+            return build_tp_xlnet_engine(
+                config, weights,
+                max_seq_length=max_cache_length,
+                verbose=verbose,
+                parallel_config=parallel)
+
         from .xlnet_builder import build_xlnet_engine
         return build_xlnet_engine(
             config, weights,

--- a/python/tensorrt_model_connect/families/xlnet/tp_builder.py
+++ b/python/tensorrt_model_connect/families/xlnet/tp_builder.py
@@ -1,0 +1,665 @@
+"""XLNet encoder engine builder with relative positional attention.
+
+Builds a TensorRT engine for XLNet's content-stream inference:
+  - Sinusoidal relative positional encoding (computed at build time)
+  - Relative attention: (ac + bd + ef) * scale
+  - Segment-relative encoding with learned seg_embed
+  - POST-norm architecture (same as BERT)
+  - No KV cache (full bidirectional attention)
+
+Tensor names for the C++ runtime:
+  Inputs:  input_ids [seq_len], token_type_ids [seq_len]
+  Outputs: hidden_states [seq_len, hidden_size]
+
+Trace IDs: ARCH-XLNET, UD-XLNET-002
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...config import ModelConfig
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...parallel_config import ParallelConfig
+
+
+def _compute_sinusoidal_pos_emb(seq_len: int, d_model: int) -> np.ndarray:
+    """Compute sinusoidal relative positional embeddings.
+
+    For bidirectional (attn_type="bi"), positions go from klen to -qlen.
+    With no mems, klen=qlen=seq_len, so positions: [seq_len, seq_len-1, ..., 1-seq_len].
+    Total positions: 2*seq_len - 1 (but HF uses 2*seq_len due to range(klen, -qlen, -1)).
+
+    Returns: [2*seq_len, d_model] positional embedding matrix.
+    """
+    # For bi-directional: pos_seq = arange(klen, -qlen, -1) = arange(seq_len, -seq_len, -1)
+    # That gives 2*seq_len positions
+    2 * seq_len
+    pos_seq = np.arange(seq_len, -seq_len, -1, dtype=np.float32)
+
+    freq_seq = np.arange(0, d_model, 2.0, dtype=np.float32)
+    inv_freq = 1.0 / np.power(10000.0, freq_seq / d_model)
+
+    # sinusoid_inp: [n_pos, d_model//2]
+    sinusoid_inp = np.outer(pos_seq, inv_freq)
+
+    # pos_emb: [n_pos, d_model] = [sin, cos] concatenated
+    pos_emb = np.concatenate([np.sin(sinusoid_inp), np.cos(sinusoid_inp)], axis=-1)
+
+    return pos_emb.astype(np.float32)
+
+
+def _compute_seg_mat(seq_len: int) -> np.ndarray:
+    r"""Compute default segment matrix for single-segment input.
+
+    When token_type_ids are all 0 (single segment), seg_mat is all zeros
+    (all tokens in same segment). Returns one-hot: [seq_len, seq_len, 2].
+
+    For seg_mat[i,j] = one_hot(token_type_ids[i] \!= token_type_ids[j]):
+      - If same segment: [1, 0]
+      - If different segment: [0, 1]
+
+    With all zeros token_type_ids: all same segment -> seg_mat[:,:,0]=1, seg_mat[:,:,1]=0.
+    """
+    seg_mat = np.zeros((seq_len, seq_len, 2), dtype=np.float32)
+    seg_mat[:, :, 0] = 1.0  # All same segment
+    return seg_mat
+
+
+def _add_seq_layer_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    gamma: np.ndarray,
+    beta: np.ndarray,
+    eps: float,
+) -> trt.ITensor:
+    """LayerNorm over [seq_len, hidden] using TRT native normalization."""
+    return graph_ops.add_layer_norm_native(
+        network, inp, hidden_size, gamma, beta, eps)
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_xlnet_tp(
+    config: ModelConfig,
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("XLNet tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if config.num_attention_heads % tp != 0:
+        raise ValueError(
+            "XLNet tensor parallel requires num_attention_heads divisible by "
+            f"tp_size ({config.num_attention_heads} vs {tp})")
+    if config.intermediate_size % tp != 0:
+        raise ValueError(
+            "XLNet tensor parallel requires intermediate_size divisible by "
+            f"tp_size ({config.intermediate_size} vs {tp})")
+
+    for layer_idx in range(config.num_hidden_layers):
+        prefix = f"layer.{layer_idx}"
+        for key in (
+            f"{prefix}.w_q", f"{prefix}.w_k", f"{prefix}.w_v",
+            f"{prefix}.w_o", f"{prefix}.w_r", f"{prefix}.w_fc1",
+        ):
+            if weights[key].shape[-1] % tp != 0:
+                raise ValueError(f"{key} output dim must be divisible by tp_size")
+        if weights[f"{prefix}.w_fc2"].shape[0] % tp != 0:
+            raise ValueError(f"{prefix}.w_fc2 input dim must be divisible by tp_size")
+        for key in (f"{prefix}.r_w_bias", f"{prefix}.r_r_bias", f"{prefix}.r_s_bias"):
+            if weights[key].shape[0] % tp != 0:
+                raise ValueError(f"{key} head dim must be divisible by tp_size")
+        if weights[f"{prefix}.seg_embed"].shape[1] % tp != 0:
+            raise ValueError(f"{prefix}.seg_embed head dim must be divisible by tp_size")
+
+
+def shard_xlnet_weights(
+    config: ModelConfig,
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local XLNet weights for the TP builder."""
+    _validate_xlnet_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        if key.endswith((".w_q", ".w_k", ".w_v", ".w_o", ".w_r", ".w_fc1")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".w_fc2"):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".r_w_bias", ".r_r_bias", ".r_s_bias", ".fc1_bias")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".seg_embed"):
+            out[key] = np.ascontiguousarray(
+                np.array_split(value, parallel.tp_size, axis=1)[parallel.rank])
+        else:
+            out[key] = value
+
+    out["_attention_size"] = config.attention_size // parallel.tp_size
+    out["_intermediate_size"] = config.intermediate_size // parallel.tp_size
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def _add_rel_shift(network, bd, num_heads, qlen, klen):
+    """Implement rel_shift_bnij for TRT (no batch dim).
+
+    Input bd: [num_heads, qlen, 2*qlen] (from position attention)
+    Output: [num_heads, qlen, klen]
+
+    Algorithm: reshape to [N, 2*qlen, qlen], remove first row,
+    reshape to [N, qlen, 2*qlen-1], slice to [:, :, :klen].
+    """
+    shuf1 = network.add_shuffle(bd)
+    shuf1.reshape_dims = (num_heads, 2 * qlen, qlen)
+
+    slice_l = network.add_slice(
+        shuf1.get_output(0),
+        start=(0, 1, 0),
+        shape=(num_heads, 2 * qlen - 1, qlen),
+        stride=(1, 1, 1))
+
+    shuf2 = network.add_shuffle(slice_l.get_output(0))
+    shuf2.reshape_dims = (num_heads, qlen, 2 * qlen - 1)
+
+    slice2 = network.add_slice(
+        shuf2.get_output(0),
+        start=(0, 0, 0),
+        shape=(num_heads, qlen, klen),
+        stride=(1, 1, 1))
+
+    return slice2.get_output(0)
+
+
+def build_tp_xlnet_engine(
+    config: ModelConfig,
+    weights: WeightDict,
+    max_seq_length: int,
+    *,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build a rank-local TRT engine plan for XLNet encoder.
+
+    Args:
+        config: Model architecture from config.json.
+        weights: Loaded weight dict from XLNet plugin.
+        max_seq_length: Maximum sequence length the engine is compiled for.
+        verbose: Print TRT builder logs.
+
+    Returns:
+        Serialized engine plan bytes.
+    """
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_tp_xlnet_engine requires tensor_parallel mode and tp_size > 1")
+    weights = shard_xlnet_weights(config, weights, parallel=parallel)
+
+    hidden = config.hidden_size
+    vocab = config.vocab_size
+    num_layers = config.num_hidden_layers
+    full_num_heads = config.num_attention_heads
+    num_heads = config.num_attention_heads // parallel.tp_size
+    d_head = config.raw.get("d_head", hidden // full_num_heads)
+    attn_size = num_heads * d_head
+    intermediate = config.intermediate_size // parallel.tp_size
+    eps = config.rms_norm_eps
+    ff_activation = config.raw.get("ff_activation", "gelu")
+
+    qlen = max_seq_length
+    scale = 1.0 / (d_head ** 0.5)
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    trt_config.clear_flag(trt.BuilderFlag.TF32)
+
+    # -------------------------------------------------------------------
+    # Inputs
+    # -------------------------------------------------------------------
+    input_ids = network.add_input("input_ids", trt.int32, (max_seq_length,))
+    attention_mask_input = network.add_input("attention_mask", trt.int32, (max_seq_length,))
+
+    # token_type_ids: constant zeros (all segment-0) — the C++ encoder
+    # pipeline doesn't provide this input, and inference is single-segment.
+    tt_zeros_layer = network.add_constant(
+        (max_seq_length,), trt.Weights(np.zeros(max_seq_length, dtype=np.int32)))
+    token_type_ids = tt_zeros_layer.get_output(0)
+
+    # -------------------------------------------------------------------
+    # Constants
+    # -------------------------------------------------------------------
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), weights["embedding"])
+    scale_t = graph_ops.add_constant(
+        network, (1, 1, 1), np.array([scale], dtype=np.float32))
+
+    # Precompute sinusoidal relative positional embeddings: [2*qlen, hidden]
+    pos_emb_np = _compute_sinusoidal_pos_emb(qlen, hidden)
+    pos_emb_const = graph_ops.add_constant(
+        network, pos_emb_np.shape, pos_emb_np)
+
+    # Build additive attention mask from attention_mask input
+    mask_float = network.add_cast(attention_mask_input, trt.float32)
+    ones_mask = graph_ops.add_constant(network, (1,), np.array([1.0], dtype=np.float32))
+    neg_large = graph_ops.add_constant(network, (1,), np.array([-1e30], dtype=np.float32))
+    inv_mask = network.add_elementwise(
+        ones_mask, mask_float.get_output(0), trt.ElementWiseOperation.SUB)
+    pad_penalty = network.add_elementwise(
+        inv_mask.get_output(0), neg_large, trt.ElementWiseOperation.PROD)
+    # Reshape to [1, 1, seq_len] for broadcasting
+    pad_mask_reshape = network.add_shuffle(pad_penalty.get_output(0))
+    pad_mask_reshape.reshape_dims = (1, 1, max_seq_length)
+
+    # -------------------------------------------------------------------
+    # Segment matrix computation from token_type_ids
+    # seg_mat[i,j] = one_hot(token_type_ids[i] \!= token_type_ids[j], 2)
+    # Shape: [qlen, klen, 2]  (for segment attention ef term)
+    #
+    # We precompute a default same-segment matrix and compute the actual
+    # one dynamically from token_type_ids.
+    # -------------------------------------------------------------------
+    # Cast token_type_ids to float: [seq_len]
+    tt_float = network.add_cast(token_type_ids, trt.float32)
+
+    # Reshape for broadcasting: [seq_len, 1] and [1, seq_len]
+    tt_col = network.add_shuffle(tt_float.get_output(0))
+    tt_col.reshape_dims = (max_seq_length, 1)
+    tt_row = network.add_shuffle(tt_float.get_output(0))
+    tt_row.reshape_dims = (1, max_seq_length)
+
+    # diff = |tt_col - tt_row| (0 if same segment, >0 if different)
+    tt_diff = network.add_elementwise(
+        tt_col.get_output(0), tt_row.get_output(0),
+        trt.ElementWiseOperation.SUB)
+    tt_abs = network.add_unary(tt_diff.get_output(0), trt.UnaryOperation.ABS)
+
+    # seg_diff: [seq_len, seq_len] with 0=same, 1=different
+    # Clamp to [0,1] (in case of more than 2 segments)
+    one_t = graph_ops.add_constant(network, (1, 1), np.array([1.0], dtype=np.float32))
+    seg_diff_raw = network.add_elementwise(
+        tt_abs.get_output(0), one_t, trt.ElementWiseOperation.MIN)
+
+    # One-hot: seg_mat_same = 1 - seg_diff, seg_mat_diff = seg_diff
+    # Stack to [seq_len, seq_len, 2]: dim0=same, dim1=different
+    seg_same = network.add_elementwise(
+        one_t, seg_diff_raw.get_output(0), trt.ElementWiseOperation.SUB)
+
+    # Reshape both to [seq_len, seq_len, 1] and concat to [seq_len, seq_len, 2]
+    seg_same_3d = network.add_shuffle(seg_same.get_output(0))
+    seg_same_3d.reshape_dims = (max_seq_length, max_seq_length, 1)
+    seg_diff_3d = network.add_shuffle(seg_diff_raw.get_output(0))
+    seg_diff_3d.reshape_dims = (max_seq_length, max_seq_length, 1)
+
+    seg_mat = network.add_concatenation(
+        [seg_same_3d.get_output(0), seg_diff_3d.get_output(0)])
+    seg_mat.axis = 2  # [seq_len, seq_len, 2]
+
+    # -------------------------------------------------------------------
+    # Word embedding
+    # -------------------------------------------------------------------
+    word_embed = network.add_gather(embedding_table, input_ids, 0)
+    # hidden_state: [seq_len, hidden]
+    hidden_state = word_embed.get_output(0)
+
+    # -------------------------------------------------------------------
+    # Encoder layers
+    # -------------------------------------------------------------------
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+
+        hidden_state = _add_xlnet_layer(
+            network=network,
+            hidden=hidden_state,
+            weights=weights,
+            prefix=prefix,
+            pos_emb=pos_emb_const,
+            seg_mat=seg_mat.get_output(0),
+            attn_mask=pad_mask_reshape.get_output(0),
+            hidden_size=hidden,
+            attn_size=attn_size,
+            intermediate_size=intermediate,
+            num_heads=num_heads,
+            d_head=d_head,
+            seq_length=max_seq_length,
+            scale_tensor=scale_t,
+            ff_activation=ff_activation,
+            eps=eps,
+            tp_size=parallel.tp_size,
+        )
+
+    # -------------------------------------------------------------------
+    # Output
+    # -------------------------------------------------------------------
+    hidden_state.name = "hidden_states"
+    network.mark_output(hidden_state)
+
+    if verbose:
+        print(f"[trtmc build] Building XLNet encoder TRT engine "
+              f"({num_layers} layers, hidden={hidden}, tp={parallel.tp_size}, "
+              f"seq_len={max_seq_length}) ...", file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT engine build failed")
+
+    return bytes(plan)
+
+
+def _add_xlnet_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    weights: WeightDict,
+    prefix: str,
+    pos_emb: trt.ITensor,
+    seg_mat: trt.ITensor,
+    attn_mask: trt.ITensor,
+    hidden_size: int,
+    attn_size: int,
+    intermediate_size: int,
+    num_heads: int,
+    d_head: int,
+    seq_length: int,
+    scale_tensor: trt.ITensor,
+    ff_activation: str,
+    eps: float,
+    tp_size: int,
+) -> trt.ITensor:
+    """Add one XLNet encoder layer with relative positional attention.
+
+    XLNet layer (content-stream, bidirectional):
+        q = h @ W_q, k = h @ W_k, v = h @ W_v
+        k_r = pos_emb @ W_r
+        ac = (q + r_w_bias) @ k^T          # content attention
+        bd = (q + r_r_bias) @ k_r^T        # position attention (+ rel_shift)
+        ef = segment attention              # segment-relative
+        attn_score = (ac + bd + ef) * scale
+        attn_out = softmax(attn_score) @ v
+        output = LayerNorm(h + O(attn_out))  # post-norm
+        output = LayerNorm(output + FFN(output))  # post-norm
+    """
+    klen = seq_length  # No mems
+
+    # --- QKV projections: [seq_len, hidden] @ [hidden, attn_size] -> [seq_len, attn_size] ---
+    q = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attn_size,
+        weights[f"{prefix}.w_q"])
+    k = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attn_size,
+        weights[f"{prefix}.w_k"])
+    v = graph_ops.add_matmul_rhs_constant(
+        network, hidden, hidden_size, attn_size,
+        weights[f"{prefix}.w_v"])
+
+    # Position key: [2*qlen, hidden] @ [hidden, attn_size] -> [2*qlen, attn_size]
+    k_r = graph_ops.add_matmul_rhs_constant(
+        network, pos_emb, hidden_size, attn_size,
+        weights[f"{prefix}.w_r"])
+
+    # Reshape QKV to multi-head: [seq_len, attn_size] -> [num_heads, seq_len, d_head]
+    q_heads = network.add_shuffle(q)
+    q_heads.reshape_dims = (seq_length, num_heads, d_head)
+    q_heads.second_transpose = trt.Permutation([1, 0, 2])
+
+    k_heads = network.add_shuffle(k)
+    k_heads.reshape_dims = (seq_length, num_heads, d_head)
+    k_heads.second_transpose = trt.Permutation([1, 0, 2])
+
+    v_heads = network.add_shuffle(v)
+    v_heads.reshape_dims = (seq_length, num_heads, d_head)
+    v_heads.second_transpose = trt.Permutation([1, 0, 2])
+
+    # Position key heads: [2*qlen, attn_size] -> [num_heads, 2*qlen, d_head]
+    kr_heads = network.add_shuffle(k_r)
+    kr_heads.reshape_dims = (2 * seq_length, num_heads, d_head)
+    kr_heads.second_transpose = trt.Permutation([1, 0, 2])
+
+    # --- Content attention: ac = (q + r_w_bias) @ k^T ---
+    # r_w_bias: [num_heads, d_head] -> [num_heads, 1, d_head]
+    r_w_bias = graph_ops.add_constant(
+        network, (num_heads, 1, d_head), weights[f"{prefix}.r_w_bias"].reshape(num_heads, 1, d_head))
+    q_plus_rw = network.add_elementwise(
+        q_heads.get_output(0), r_w_bias,
+        trt.ElementWiseOperation.SUM)
+
+    # ac: [N, qlen, d_head] @ [N, klen, d_head]^T -> [N, qlen, klen]
+    ac = network.add_matrix_multiply(
+        q_plus_rw.get_output(0), trt.MatrixOperation.NONE,
+        k_heads.get_output(0), trt.MatrixOperation.TRANSPOSE)
+
+    # --- Position attention: bd = (q + r_r_bias) @ k_r^T ---
+    r_r_bias = graph_ops.add_constant(
+        network, (num_heads, 1, d_head), weights[f"{prefix}.r_r_bias"].reshape(num_heads, 1, d_head))
+    q_plus_rr = network.add_elementwise(
+        q_heads.get_output(0), r_r_bias,
+        trt.ElementWiseOperation.SUM)
+
+    # bd_raw: [N, qlen, d_head] @ [N, 2*qlen, d_head]^T -> [N, qlen, 2*qlen]
+    bd_raw = network.add_matrix_multiply(
+        q_plus_rr.get_output(0), trt.MatrixOperation.NONE,
+        kr_heads.get_output(0), trt.MatrixOperation.TRANSPOSE)
+
+    # Apply relative shift to bd
+    bd = _add_rel_shift(network, bd_raw.get_output(0), num_heads, seq_length, klen)
+
+    # --- Segment attention: ef ---
+    # ef = einsum("ibnd,snd->ibns", q + r_s_bias, seg_embed)
+    # ef = einsum("ijbs,ibns->bnij", seg_mat, ef)
+    # With batch=1 removed:
+    # q_plus_rs: [N, qlen, d_head], seg_embed: [2, N, d_head]
+    # step 1: for each position i, compute dot of q[i] with seg_embed[s] -> [qlen, N, 2]
+    # step 2: gather from seg_mat and sum -> [N, qlen, klen]
+
+    r_s_bias = graph_ops.add_constant(
+        network, (num_heads, 1, d_head), weights[f"{prefix}.r_s_bias"].reshape(num_heads, 1, d_head))
+    q_plus_rs = network.add_elementwise(
+        q_heads.get_output(0), r_s_bias,
+        trt.ElementWiseOperation.SUM)
+    # q_plus_rs: [N, qlen, d_head]
+
+    # seg_embed: [2, N, d_head]
+    seg_embed = graph_ops.add_constant(
+        network, (2, num_heads, d_head), weights[f"{prefix}.seg_embed"])
+
+    # Compute q_plus_rs @ seg_embed^T for each segment type
+    # seg_embed[0]: [N, d_head] - same segment
+    # seg_embed[1]: [N, d_head] - different segment
+    # Reshape seg_embed to [2, N, d_head]
+    # We need: for each head, for each query position, dot product with seg_embed[s]
+    # = [N, qlen, d_head] @ [N, d_head, 2] -> [N, qlen, 2]
+
+    # Transpose seg_embed: [2, N, d_head] -> [N, d_head, 2]
+    seg_t = network.add_shuffle(seg_embed)
+    seg_t.first_transpose = trt.Permutation([1, 2, 0])  # [N, d_head, 2]
+
+    # ef_per_pos: [N, qlen, 2] = q_plus_rs @ seg_embed_t
+    ef_per_pos = network.add_matrix_multiply(
+        q_plus_rs.get_output(0), trt.MatrixOperation.NONE,
+        seg_t.get_output(0), trt.MatrixOperation.NONE)
+
+    # Now we need to select from ef_per_pos based on seg_mat
+    # seg_mat: [qlen, klen, 2] (one-hot)
+    # For each (i, j), ef[n, i, j] = sum_s(seg_mat[i, j, s] * ef_per_pos[n, i, s])
+    # This is: ef_per_pos: [N, qlen, 2] matmul seg_mat_transposed: [qlen, 2, klen] -> won't work directly
+    # Better: ef_per_pos[n,i,s] * seg_mat[i,j,s] summed over s
+    # = einsum("nis,ijs->nij")
+    # Equivalent to: for each i, ef_per_pos[n,i,:] @ seg_mat[i,:,:]^T
+    # This is a batched matmul over the query dimension.
+    #
+    # Reshape ef_per_pos: [N, qlen, 2] -> [N*qlen, 1, 2]
+    # Reshape seg_mat: [qlen, klen, 2] -> [qlen, 2, klen] -> broadcast to [N*qlen, 2, klen]
+    # Result: [N*qlen, 1, klen] -> reshape to [N, qlen, klen]
+
+    # Alternative: since seg_mat is [qlen, klen, 2], transpose to [qlen, 2, klen]
+    seg_mat_t = network.add_shuffle(seg_mat)
+    seg_mat_t.first_transpose = trt.Permutation([0, 2, 1])  # [qlen, 2, klen]
+
+    # For each head n and position i:
+    # ef[n,i,:] = ef_per_pos[n,i,:] @ seg_mat_t[i,:,:]
+    # = [1, 2] @ [2, klen] -> [1, klen]
+    # This requires a per-position batched matmul which TRT doesn't support directly.
+    # Instead, decompose:
+    # ef = ef_same * seg_mat_same + ef_diff * seg_mat_diff
+    # where seg_mat_same[i,j] = seg_mat[i,j,0] and seg_mat_diff[i,j] = seg_mat[i,j,1]
+
+    # Split ef_per_pos into same/diff: [N, qlen, 2] -> [N, qlen, 1] each
+    ef_same_slice = network.add_slice(
+        ef_per_pos.get_output(0),
+        start=(0, 0, 0),
+        shape=(num_heads, seq_length, 1),
+        stride=(1, 1, 1))
+    ef_diff_slice = network.add_slice(
+        ef_per_pos.get_output(0),
+        start=(0, 0, 1),
+        shape=(num_heads, seq_length, 1),
+        stride=(1, 1, 1))
+
+    # seg_mat_same: seg_mat[:,:,0] -> [qlen, klen]
+    seg_same_slice = network.add_slice(
+        seg_mat,
+        start=(0, 0, 0),
+        shape=(seq_length, seq_length, 1),
+        stride=(1, 1, 1))
+    # Reshape to [1, qlen, klen]
+    seg_same_2d = network.add_shuffle(seg_same_slice.get_output(0))
+    seg_same_2d.reshape_dims = (1, seq_length, seq_length)
+
+    seg_diff_slice = network.add_slice(
+        seg_mat,
+        start=(0, 0, 1),
+        shape=(seq_length, seq_length, 1),
+        stride=(1, 1, 1))
+    seg_diff_2d = network.add_shuffle(seg_diff_slice.get_output(0))
+    seg_diff_2d.reshape_dims = (1, seq_length, seq_length)
+
+    # ef = ef_same * seg_same + ef_diff * seg_diff
+    # ef_same_slice: [N, qlen, 1] broadcasts with seg_same_2d: [1, qlen, klen]
+    ef_same_term = network.add_elementwise(
+        ef_same_slice.get_output(0), seg_same_2d.get_output(0),
+        trt.ElementWiseOperation.PROD)
+    ef_diff_term = network.add_elementwise(
+        ef_diff_slice.get_output(0), seg_diff_2d.get_output(0),
+        trt.ElementWiseOperation.PROD)
+    ef = network.add_elementwise(
+        ef_same_term.get_output(0), ef_diff_term.get_output(0),
+        trt.ElementWiseOperation.SUM)
+
+    # --- Combine attention scores ---
+    # attn_score = (ac + bd + ef) * scale
+    ac_bd = network.add_elementwise(
+        ac.get_output(0), bd,
+        trt.ElementWiseOperation.SUM)
+    ac_bd_ef = network.add_elementwise(
+        ac_bd.get_output(0), ef.get_output(0),
+        trt.ElementWiseOperation.SUM)
+    scaled = network.add_elementwise(
+        ac_bd_ef.get_output(0), scale_tensor,
+        trt.ElementWiseOperation.PROD)
+
+    # Apply attention mask (padding)
+    masked = network.add_elementwise(
+        scaled.get_output(0), attn_mask,
+        trt.ElementWiseOperation.SUM)
+
+    # For bidirectional XLNet, we do NOT apply causal mask (attn_type="bi")
+    # No non_tgt_mask either (that's only used with perm_mask/target_mapping)
+
+    # XLNet adds content, relative-position, and segment logits before
+    # softmax. TRT native IAttention cannot express these extra logits as a
+    # query-independent additive mask, so this attention remains decomposed.
+    softmax = network.add_softmax(masked.get_output(0))
+    softmax.axes = 1 << 2  # last dim (klen)
+
+    # Context: softmax @ V -> [N, qlen, d_head]
+    context_heads = network.add_matrix_multiply(
+        softmax.get_output(0), trt.MatrixOperation.NONE,
+        v_heads.get_output(0), trt.MatrixOperation.NONE)
+
+    # Reshape: [N, qlen, d_head] -> [qlen, N, d_head] -> [qlen, attn_size]
+    context_flat = network.add_shuffle(context_heads.get_output(0))
+    context_flat.first_transpose = trt.Permutation([1, 0, 2])
+    context_flat.reshape_dims = (seq_length, attn_size)
+
+    # Output projection: [qlen, attn_size] @ [attn_size, hidden] -> [qlen, hidden]
+    # Note: XLNet's O weight is [d_model, n_head, d_head] reshaped to [d_model, attn_size]
+    # The einsum is "ibnd,hnd->ibh" which is [qlen, N, d_head] @ [hidden, N, d_head]
+    # This means O^T maps from [attn_size] to [hidden], so we need to transpose our weight.
+    # Our w_o is already [hidden, attn_size] from reshape, so we need [attn_size, hidden]
+    # for context_flat @ w_o^T.
+    # Actually, the einsum "ibnd,hnd->ibh" contracts over n,d producing [i,b,h].
+    # With our flattened version: context_flat @ W_o^T where W_o is [hidden, attn_size]
+    # So we need to use TRANSPOSE on the rhs.
+    w_o = graph_ops.add_constant(
+        network, (hidden_size, attn_size), weights[f"{prefix}.w_o"])
+    attn_out = network.add_matrix_multiply(
+        context_flat.get_output(0), trt.MatrixOperation.NONE,
+        w_o, trt.MatrixOperation.TRANSPOSE)
+    attn_out_sum = add_all_reduce_sum(network, attn_out.get_output(0), tp_size)
+
+    # POST-norm: LayerNorm(h + attn_out)
+    residual1 = network.add_elementwise(
+        hidden, attn_out_sum,
+        trt.ElementWiseOperation.SUM)
+    normed1 = _add_seq_layer_norm(
+        network, residual1.get_output(0), hidden_size,
+        weights[f"{prefix}.attn_norm"],
+        weights[f"{prefix}.attn_norm_beta"], eps)
+
+    # --- FFN ---
+    fc1 = graph_ops.add_matmul_rhs_constant(
+        network, normed1, hidden_size, intermediate_size,
+        weights[f"{prefix}.w_fc1"])
+    fc1 = graph_ops.add_bias_sum(network, fc1, intermediate_size,
+                                  weights[f"{prefix}.fc1_bias"])
+    activated = graph_ops.add_activation(network, fc1, ff_activation)
+    fc2 = graph_ops.add_matmul_rhs_constant(
+        network, activated, intermediate_size, hidden_size,
+        weights[f"{prefix}.w_fc2"])
+    fc2 = add_all_reduce_sum(network, fc2, tp_size)
+    fc2 = graph_ops.add_bias_sum(network, fc2, hidden_size,
+                                  weights[f"{prefix}.fc2_bias"])
+
+    # POST-norm: LayerNorm(normed1 + ffn_out)
+    residual2 = network.add_elementwise(
+        normed1, fc2, trt.ElementWiseOperation.SUM)
+    normed2 = _add_seq_layer_norm(
+        network, residual2.get_output(0), hidden_size,
+        weights[f"{prefix}.ff_norm"],
+        weights[f"{prefix}.ff_norm_beta"], eps)
+
+    return normed2

--- a/src/runtime/models/encoder/plugin.cpp
+++ b/src/runtime/models/encoder/plugin.cpp
@@ -3,9 +3,32 @@
 
 #include "runtime/models/encoder/pipeline.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
+#include "utils/json_helpers.h"
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+} // namespace
 
 class EncoderPlugin final : public IPipelinePlugin {
   public:
@@ -16,8 +39,18 @@ class EncoderPlugin final : public IPipelinePlugin {
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        std::string engine_section = "engine_plan";
+        if (tp_config.enabled) {
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+            opts.distributed_communicator = tp_group.communicator;
+            opts.distributed_owner = tp_group.owner;
+            engine_section = tp_engine_section_name(tp_group.rank);
+        }
+
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "engine_plan", opts);
+            ctx.backend, find_section(ctx.bundle, engine_section), engine_section.c_str(), opts);
         auto tokenizer = create_tokenizer_from_bundle(ctx.bundle);
 
         return std::make_unique<EncoderPipeline>(std::move(loaded.module),

--- a/tests/builder/test_engine_bert_tp.py
+++ b/tests/builder/test_engine_bert_tp.py
@@ -1,0 +1,245 @@
+"""Tensor-parallel tests for BERT encoder support."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "tensorrt_model_connect.config",
+    reason="tensorrt_model_connect requires tensorrt",
+)
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.bert.plugin import BertPlugin
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
+bert_plugin = importlib.import_module(
+    "tensorrt_model_connect.families.bert.plugin")
+
+_LAYERS = 1
+_HIDDEN = 16
+_HEADS = 4
+_MLP = 32
+_VOCAB = 24
+
+
+def _bert_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.bert.tp_builder",
+        reason="TensorRT is required for BERT TP builder tests",
+    )
+
+
+def _make_config(
+    *,
+    hidden: int = _HIDDEN,
+    heads: int = _HEADS,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+) -> ModelConfig:
+    return ModelConfig(
+        model_type="bert",
+        vocab_size=_VOCAB,
+        hidden_size=hidden,
+        intermediate_size=mlp,
+        num_hidden_layers=layers,
+        num_attention_heads=heads,
+        num_key_value_heads=heads,
+        max_position_embeddings=32,
+        rms_norm_eps=1e-5,
+        _head_dim=hidden // heads,
+    )
+
+
+def _matrix(rows: int, cols: int, offset: int = 0) -> np.ndarray:
+    return (np.arange(rows * cols, dtype=np.float32).reshape(rows, cols) + offset)
+
+
+def _make_encoder_weights(
+    *,
+    hidden: int = _HIDDEN,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+    vocab: int = _VOCAB,
+) -> WeightDict:
+    weights = WeightDict({
+        "embedding": _matrix(vocab, hidden),
+        "position_embedding": _matrix(32, hidden, 1000),
+        "token_type_embedding": np.zeros((2, hidden), dtype=np.float32),
+        "embed_norm": np.ones(hidden, dtype=np.float32),
+        "embed_norm_beta": np.zeros(hidden, dtype=np.float32),
+    })
+    for layer_idx in range(layers):
+        prefix = f"layer.{layer_idx}"
+        weights[f"{prefix}.w_q"] = _matrix(hidden, hidden, 10)
+        weights[f"{prefix}.w_k"] = _matrix(hidden, hidden, 20)
+        weights[f"{prefix}.w_v"] = _matrix(hidden, hidden, 30)
+        weights[f"{prefix}.q_bias"] = np.arange(hidden, dtype=np.float32)
+        weights[f"{prefix}.k_bias"] = np.arange(hidden, dtype=np.float32) + 10
+        weights[f"{prefix}.v_bias"] = np.arange(hidden, dtype=np.float32) + 20
+        weights[f"{prefix}.w_o"] = _matrix(hidden, hidden, 40)
+        weights[f"{prefix}.o_bias"] = np.arange(hidden, dtype=np.float32) + 30
+        weights[f"{prefix}.post_attn_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.post_attn_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+        weights[f"{prefix}.w_fc1"] = _matrix(hidden, mlp, 50)
+        weights[f"{prefix}.fc1_bias"] = np.arange(mlp, dtype=np.float32)
+        weights[f"{prefix}.w_fc2"] = _matrix(mlp, hidden, 60)
+        weights[f"{prefix}.fc2_bias"] = np.arange(hidden, dtype=np.float32) + 40
+        weights[f"{prefix}.output_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.output_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+    return weights
+
+
+def test_bert_tp_builder_rejects_single_device_mode():
+    tp_builder = _bert_tp_builder_module()
+
+    with pytest.raises(ValueError, match="requires tensor_parallel mode"):
+        tp_builder.build_tp_encoder_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_seq_length=8,
+            parallel_config=ParallelConfig(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("parallel", "overrides", "message"),
+    [
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1),
+            {},
+            "concrete rank",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"heads": _HEADS + 2},
+            "num_attention_heads divisible",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"mlp": _MLP + 2},
+            "intermediate_size divisible",
+        ),
+    ],
+)
+def test_bert_tp_validation_rejects_bad_config_dimensions(
+    parallel,
+    overrides,
+    message,
+):
+    tp_builder = _bert_tp_builder_module()
+    config_kwargs = {
+        "hidden": _HIDDEN,
+        "heads": _HEADS,
+        "layers": _LAYERS,
+        "mlp": _MLP,
+    }
+    config_kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        tp_builder._validate_encoder_tp(
+            _make_config(**config_kwargs),
+            _make_encoder_weights(mlp=config_kwargs["mlp"]),
+            parallel,
+        )
+
+
+def test_bert_tp_shards_rank_local_encoder_weights():
+    tp_builder = _bert_tp_builder_module()
+    config = _make_config()
+    weights = _make_encoder_weights()
+    shard = tp_builder.shard_encoder_weights(
+        config,
+        weights,
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2),
+    )
+
+    hidden_start = (_HIDDEN // 4) * 2
+    hidden_end = (_HIDDEN // 4) * 3
+    mlp_start = (_MLP // 4) * 2
+    mlp_end = (_MLP // 4) * 3
+
+    assert isinstance(shard, WeightDict)
+    assert shard["_tensor_parallel_size"] == 4
+    assert shard["_tensor_parallel_rank"] == 2
+    assert shard["_attention_size"] == _HIDDEN // 4
+    assert shard["_intermediate_size"] == _MLP // 4
+    assert shard["embedding"] is weights["embedding"]
+
+    np.testing.assert_array_equal(
+        shard["layer.0.w_q"],
+        weights["layer.0.w_q"][:, hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.q_bias"],
+        weights["layer.0.q_bias"][hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_o"],
+        weights["layer.0.w_o"][hidden_start:hidden_end, :],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc1"],
+        weights["layer.0.w_fc1"][:, mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.fc1_bias"],
+        weights["layer.0.fc1_bias"][mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc2"],
+        weights["layer.0.w_fc2"][mlp_start:mlp_end, :],
+    )
+
+
+def test_bert_plugin_routes_tp_build(monkeypatch):
+    tp_builder = _bert_tp_builder_module()
+    captured = {}
+
+    def fake_build(config, weights, max_seq_length, **kwargs):
+        captured["config"] = config
+        captured["weights"] = weights
+        captured["max_seq_length"] = max_seq_length
+        captured["kwargs"] = kwargs
+        return b"bert-tp-plan"
+
+    monkeypatch.setattr(
+        bert_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+    monkeypatch.setattr(tp_builder, "build_tp_encoder_engine", fake_build)
+
+    plan = BertPlugin().build_engine(
+        _make_config(),
+        _make_encoder_weights(),
+        max_cache_length=8,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1),
+    )
+
+    assert plan == b"bert-tp-plan"
+    assert captured["config"].model_type == "bert"
+    assert captured["max_seq_length"] == 8
+    assert captured["kwargs"]["parallel_config"].tp_size == 4
+    assert captured["kwargs"]["parallel_config"].rank == 1
+
+
+def test_bert_plugin_rejects_quantized_tp(monkeypatch):
+    monkeypatch.setattr(
+        bert_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="do not support quantization"):
+        BertPlugin().build_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_cache_length=8,
+            quant_ctx=object(),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )

--- a/tests/builder/test_engine_convbert_tp.py
+++ b/tests/builder/test_engine_convbert_tp.py
@@ -1,0 +1,237 @@
+"""Tensor-parallel tests for ConvBERT encoder support."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "tensorrt_model_connect.config",
+    reason="tensorrt_model_connect requires tensorrt",
+)
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.convbert.plugin import ConvBertPlugin
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
+convbert_plugin = importlib.import_module(
+    "tensorrt_model_connect.families.convbert.plugin")
+
+_LAYERS = 1
+_HIDDEN = 16
+_HEADS = 4
+_EFFECTIVE_HEADS = 2
+_HEAD_SIZE = 4
+_ALL_HEAD = _EFFECTIVE_HEADS * _HEAD_SIZE
+_MLP = 32
+_VOCAB = 24
+_KERNEL = 3
+
+
+def _convbert_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.convbert.tp_builder",
+        reason="TensorRT is required for ConvBERT TP builder tests",
+    )
+
+
+def _make_config(
+    *,
+    hidden: int = _HIDDEN,
+    heads: int = _HEADS,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+) -> ModelConfig:
+    return ModelConfig(
+        model_type="convbert",
+        vocab_size=_VOCAB,
+        hidden_size=hidden,
+        intermediate_size=mlp,
+        num_hidden_layers=layers,
+        num_attention_heads=heads,
+        num_key_value_heads=heads,
+        max_position_embeddings=32,
+        rms_norm_eps=1e-5,
+        _head_dim=hidden // heads,
+        raw={"head_ratio": 2, "conv_kernel_size": _KERNEL},
+    )
+
+
+def _matrix(rows: int, cols: int, offset: int = 0) -> np.ndarray:
+    return np.arange(rows * cols, dtype=np.float32).reshape(rows, cols) + offset
+
+
+def _make_encoder_weights(
+    *,
+    hidden: int = _HIDDEN,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+    vocab: int = _VOCAB,
+) -> WeightDict:
+    weights = WeightDict({
+        "embedding": _matrix(vocab, hidden),
+        "position_embedding": _matrix(32, hidden, 1000),
+        "token_type_embedding": np.zeros((2, hidden), dtype=np.float32),
+        "embed_norm": np.ones(hidden, dtype=np.float32),
+        "embed_norm_beta": np.zeros(hidden, dtype=np.float32),
+        "_convbert_new_num_heads": np.array([_EFFECTIVE_HEADS], dtype=np.int32),
+        "_convbert_head_size": np.array([_HEAD_SIZE], dtype=np.int32),
+        "_convbert_all_head_size": np.array([_ALL_HEAD], dtype=np.int32),
+        "_convbert_conv_kernel_size": np.array([_KERNEL], dtype=np.int32),
+    })
+    for layer_idx in range(layers):
+        prefix = f"layer.{layer_idx}"
+        weights[f"{prefix}.w_q"] = _matrix(hidden, _ALL_HEAD, 10)
+        weights[f"{prefix}.w_k"] = _matrix(hidden, _ALL_HEAD, 20)
+        weights[f"{prefix}.w_v"] = _matrix(hidden, _ALL_HEAD, 30)
+        weights[f"{prefix}.q_bias"] = np.arange(_ALL_HEAD, dtype=np.float32)
+        weights[f"{prefix}.k_bias"] = np.arange(_ALL_HEAD, dtype=np.float32) + 10
+        weights[f"{prefix}.v_bias"] = np.arange(_ALL_HEAD, dtype=np.float32) + 20
+        weights[f"{prefix}.sep_conv_dw"] = _matrix(hidden, _KERNEL, 40)
+        weights[f"{prefix}.sep_conv_pw"] = _matrix(_ALL_HEAD, hidden, 50)
+        weights[f"{prefix}.sep_conv_bias"] = np.arange(_ALL_HEAD, dtype=np.float32)
+        weights[f"{prefix}.conv_kernel_w"] = _matrix(_ALL_HEAD, _EFFECTIVE_HEADS * _KERNEL, 60)
+        weights[f"{prefix}.conv_kernel_bias"] = np.arange(_EFFECTIVE_HEADS * _KERNEL, dtype=np.float32)
+        weights[f"{prefix}.conv_out_w"] = _matrix(hidden, _ALL_HEAD, 70)
+        weights[f"{prefix}.conv_out_bias"] = np.arange(_ALL_HEAD, dtype=np.float32)
+        weights[f"{prefix}.w_o"] = _matrix(2 * _ALL_HEAD, hidden, 80)
+        weights[f"{prefix}.o_bias"] = np.arange(hidden, dtype=np.float32) + 30
+        weights[f"{prefix}.post_attn_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.post_attn_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+        weights[f"{prefix}.w_fc1"] = _matrix(hidden, mlp, 90)
+        weights[f"{prefix}.fc1_bias"] = np.arange(mlp, dtype=np.float32)
+        weights[f"{prefix}.w_fc2"] = _matrix(mlp, hidden, 100)
+        weights[f"{prefix}.fc2_bias"] = np.arange(hidden, dtype=np.float32) + 40
+        weights[f"{prefix}.output_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.output_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+    return weights
+
+
+def test_convbert_tp_builder_rejects_single_device_mode():
+    tp_builder = _convbert_tp_builder_module()
+
+    with pytest.raises(ValueError, match="requires tensor_parallel mode"):
+        tp_builder.build_tp_convbert_encoder_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_seq_length=8,
+            parallel_config=ParallelConfig(),
+        )
+
+
+def test_convbert_tp_validation_rejects_tp4_for_effective_heads():
+    tp_builder = _convbert_tp_builder_module()
+
+    with pytest.raises(ValueError, match="effective attention heads divisible"):
+        tp_builder._validate_convbert_tp(
+            _make_config(),
+            _make_encoder_weights(),
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )
+
+
+def test_convbert_tp_shards_rank_local_encoder_weights():
+    tp_builder = _convbert_tp_builder_module()
+    config = _make_config()
+    weights = _make_encoder_weights()
+    shard = tp_builder.shard_convbert_weights(
+        config,
+        weights,
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=2, rank=1),
+    )
+
+    all_start = _ALL_HEAD // 2
+    all_end = _ALL_HEAD
+    mlp_start = _MLP // 2
+    mlp_end = _MLP
+
+    assert isinstance(shard, WeightDict)
+    assert shard["_tensor_parallel_size"] == 2
+    assert shard["_tensor_parallel_rank"] == 1
+    assert int(shard["_convbert_new_num_heads"][0]) == _EFFECTIVE_HEADS // 2
+    assert int(shard["_convbert_full_new_num_heads"][0]) == _EFFECTIVE_HEADS
+    assert shard["embedding"] is weights["embedding"]
+
+    np.testing.assert_array_equal(
+        shard["layer.0.w_q"],
+        weights["layer.0.w_q"][:, all_start:all_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.sep_conv_pw"],
+        weights["layer.0.sep_conv_pw"][all_start:all_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.conv_kernel_w"],
+        weights["layer.0.conv_kernel_w"][all_start:all_end, :],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.conv_out_w"],
+        weights["layer.0.conv_out_w"][:, all_start:all_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_o"],
+        np.concatenate([
+            weights["layer.0.w_o"][all_start:all_end, :],
+            weights["layer.0.w_o"][_ALL_HEAD + all_start:2 * _ALL_HEAD, :],
+        ], axis=0),
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc1"],
+        weights["layer.0.w_fc1"][:, mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc2"],
+        weights["layer.0.w_fc2"][mlp_start:mlp_end, :],
+    )
+
+
+def test_convbert_plugin_routes_tp_build(monkeypatch):
+    tp_builder = _convbert_tp_builder_module()
+    captured = {}
+
+    def fake_build(config, weights, max_seq_length, **kwargs):
+        captured["config"] = config
+        captured["weights"] = weights
+        captured["max_seq_length"] = max_seq_length
+        captured["kwargs"] = kwargs
+        return b"convbert-tp-plan"
+
+    monkeypatch.setattr(
+        convbert_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+    monkeypatch.setattr(tp_builder, "build_tp_convbert_encoder_engine", fake_build)
+
+    plan = ConvBertPlugin().build_engine(
+        _make_config(),
+        _make_encoder_weights(),
+        max_cache_length=8,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=2, rank=1),
+    )
+
+    assert plan == b"convbert-tp-plan"
+    assert captured["config"].model_type == "convbert"
+    assert captured["max_seq_length"] == 8
+    assert captured["kwargs"]["parallel_config"].tp_size == 2
+    assert captured["kwargs"]["parallel_config"].rank == 1
+
+
+def test_convbert_plugin_rejects_quantized_tp(monkeypatch):
+    monkeypatch.setattr(
+        convbert_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="do not support quantization"):
+        ConvBertPlugin().build_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_cache_length=8,
+            quant_ctx=object(),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=2, rank=0),
+        )

--- a/tests/builder/test_engine_deberta_tp.py
+++ b/tests/builder/test_engine_deberta_tp.py
@@ -1,0 +1,261 @@
+"""Tensor-parallel tests for DeBERTa encoder support."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "tensorrt_model_connect.config",
+    reason="tensorrt_model_connect requires tensorrt",
+)
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.deberta.plugin import DebertaPlugin
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
+deberta_plugin = importlib.import_module(
+    "tensorrt_model_connect.families.deberta.plugin")
+
+_LAYERS = 1
+_HIDDEN = 16
+_HEADS = 4
+_MLP = 32
+_VOCAB = 24
+
+
+def _deberta_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.deberta.tp_builder",
+        reason="TensorRT is required for DeBERTa TP builder tests",
+    )
+
+
+def _make_config(
+    *,
+    hidden: int = _HIDDEN,
+    heads: int = _HEADS,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+) -> ModelConfig:
+    return ModelConfig(
+        model_type="deberta",
+        vocab_size=_VOCAB,
+        hidden_size=hidden,
+        intermediate_size=mlp,
+        num_hidden_layers=layers,
+        num_attention_heads=heads,
+        num_key_value_heads=heads,
+        max_position_embeddings=32,
+        rms_norm_eps=1e-5,
+        _head_dim=hidden // heads,
+        raw={"hidden_act": "gelu"},
+    )
+
+
+def _matrix(rows: int, cols: int, offset: int = 0) -> np.ndarray:
+    return np.arange(rows * cols, dtype=np.float32).reshape(rows, cols) + offset
+
+
+def _make_encoder_weights(
+    *,
+    hidden: int = _HIDDEN,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+    vocab: int = _VOCAB,
+) -> WeightDict:
+    weights = WeightDict({
+        "embedding": _matrix(vocab, hidden),
+        "embed_norm": np.ones(hidden, dtype=np.float32),
+        "embed_norm_beta": np.zeros(hidden, dtype=np.float32),
+        "rel_embeddings": _matrix(64, hidden, 1000),
+        "_deberta_config": {
+            "position_biased_input": False,
+            "type_vocab_size": 0,
+            "max_relative_positions": 32,
+            "pos_att_type": ["c2p", "p2c"],
+        },
+    })
+    for layer_idx in range(layers):
+        prefix = f"layer.{layer_idx}"
+        weights[f"{prefix}.w_q"] = _matrix(hidden, hidden, 10)
+        weights[f"{prefix}.w_k"] = _matrix(hidden, hidden, 20)
+        weights[f"{prefix}.w_v"] = _matrix(hidden, hidden, 30)
+        weights[f"{prefix}.q_bias"] = np.arange(hidden, dtype=np.float32)
+        weights[f"{prefix}.v_bias"] = np.arange(hidden, dtype=np.float32) + 20
+        weights[f"{prefix}.w_o"] = _matrix(hidden, hidden, 40)
+        weights[f"{prefix}.o_bias"] = np.arange(hidden, dtype=np.float32) + 30
+        weights[f"{prefix}.post_attn_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.post_attn_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+        weights[f"{prefix}.pos_proj"] = _matrix(hidden, hidden, 50)
+        weights[f"{prefix}.pos_q_proj"] = _matrix(hidden, hidden, 60)
+        weights[f"{prefix}.pos_q_proj_bias"] = np.arange(hidden, dtype=np.float32) + 40
+        weights[f"{prefix}.w_fc1"] = _matrix(hidden, mlp, 70)
+        weights[f"{prefix}.fc1_bias"] = np.arange(mlp, dtype=np.float32)
+        weights[f"{prefix}.w_fc2"] = _matrix(mlp, hidden, 80)
+        weights[f"{prefix}.fc2_bias"] = np.arange(hidden, dtype=np.float32) + 50
+        weights[f"{prefix}.output_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.output_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+    return weights
+
+
+def test_deberta_tp_builder_rejects_single_device_mode():
+    tp_builder = _deberta_tp_builder_module()
+
+    with pytest.raises(ValueError, match="requires tensor_parallel mode"):
+        tp_builder.build_tp_deberta_encoder_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_seq_length=8,
+            parallel_config=ParallelConfig(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("parallel", "overrides", "message"),
+    [
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1),
+            {},
+            "concrete rank",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"heads": _HEADS + 2},
+            "num_attention_heads divisible",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"mlp": _MLP + 2},
+            "intermediate_size divisible",
+        ),
+    ],
+)
+def test_deberta_tp_validation_rejects_bad_config_dimensions(
+    parallel,
+    overrides,
+    message,
+):
+    tp_builder = _deberta_tp_builder_module()
+    config_kwargs = {
+        "hidden": _HIDDEN,
+        "heads": _HEADS,
+        "layers": _LAYERS,
+        "mlp": _MLP,
+    }
+    config_kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        tp_builder._validate_deberta_tp(
+            _make_config(**config_kwargs),
+            _make_encoder_weights(mlp=config_kwargs["mlp"]),
+            parallel,
+        )
+
+
+def test_deberta_tp_shards_rank_local_encoder_weights():
+    tp_builder = _deberta_tp_builder_module()
+    config = _make_config()
+    weights = _make_encoder_weights()
+    shard = tp_builder.shard_deberta_weights(
+        config,
+        weights,
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2),
+    )
+
+    hidden_start = (_HIDDEN // 4) * 2
+    hidden_end = (_HIDDEN // 4) * 3
+    mlp_start = (_MLP // 4) * 2
+    mlp_end = (_MLP // 4) * 3
+
+    assert isinstance(shard, WeightDict)
+    assert shard["_tensor_parallel_size"] == 4
+    assert shard["_tensor_parallel_rank"] == 2
+    assert shard["_attention_size"] == _HIDDEN // 4
+    assert shard["_intermediate_size"] == _MLP // 4
+    assert shard["embedding"] is weights["embedding"]
+
+    np.testing.assert_array_equal(
+        shard["layer.0.w_q"],
+        weights["layer.0.w_q"][:, hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.q_bias"],
+        weights["layer.0.q_bias"][hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.pos_proj"],
+        weights["layer.0.pos_proj"][:, hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.pos_q_proj_bias"],
+        weights["layer.0.pos_q_proj_bias"][hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_o"],
+        weights["layer.0.w_o"][hidden_start:hidden_end, :],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc1"],
+        weights["layer.0.w_fc1"][:, mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.fc1_bias"],
+        weights["layer.0.fc1_bias"][mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc2"],
+        weights["layer.0.w_fc2"][mlp_start:mlp_end, :],
+    )
+
+
+def test_deberta_plugin_routes_tp_build(monkeypatch):
+    tp_builder = _deberta_tp_builder_module()
+    captured = {}
+
+    def fake_build(config, weights, max_seq_length, **kwargs):
+        captured["config"] = config
+        captured["weights"] = weights
+        captured["max_seq_length"] = max_seq_length
+        captured["kwargs"] = kwargs
+        return b"deberta-tp-plan"
+
+    monkeypatch.setattr(
+        deberta_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+    monkeypatch.setattr(tp_builder, "build_tp_deberta_encoder_engine", fake_build)
+
+    plan = DebertaPlugin().build_engine(
+        _make_config(),
+        _make_encoder_weights(),
+        max_cache_length=8,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1),
+    )
+
+    assert plan == b"deberta-tp-plan"
+    assert captured["config"].model_type == "deberta"
+    assert captured["max_seq_length"] == 8
+    assert captured["kwargs"]["parallel_config"].tp_size == 4
+    assert captured["kwargs"]["parallel_config"].rank == 1
+
+
+def test_deberta_plugin_rejects_quantized_tp(monkeypatch):
+    monkeypatch.setattr(
+        deberta_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="do not support quantization"):
+        DebertaPlugin().build_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_cache_length=8,
+            quant_ctx=object(),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )

--- a/tests/builder/test_engine_distilbert_tp.py
+++ b/tests/builder/test_engine_distilbert_tp.py
@@ -1,0 +1,245 @@
+"""Tensor-parallel tests for DistilBERT encoder support."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "tensorrt_model_connect.config",
+    reason="tensorrt_model_connect requires tensorrt",
+)
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.distilbert.plugin import DistilBertPlugin
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
+distilbert_plugin = importlib.import_module(
+    "tensorrt_model_connect.families.distilbert.plugin")
+
+_LAYERS = 1
+_HIDDEN = 16
+_HEADS = 4
+_MLP = 32
+_VOCAB = 24
+
+
+def _distilbert_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.distilbert.tp_builder",
+        reason="TensorRT is required for DistilBERT TP builder tests",
+    )
+
+
+def _make_config(
+    *,
+    hidden: int = _HIDDEN,
+    heads: int = _HEADS,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+) -> ModelConfig:
+    return ModelConfig(
+        model_type="distilbert",
+        vocab_size=_VOCAB,
+        hidden_size=hidden,
+        intermediate_size=mlp,
+        num_hidden_layers=layers,
+        num_attention_heads=heads,
+        num_key_value_heads=heads,
+        max_position_embeddings=32,
+        rms_norm_eps=1e-5,
+        _head_dim=hidden // heads,
+    )
+
+
+def _matrix(rows: int, cols: int, offset: int = 0) -> np.ndarray:
+    return (np.arange(rows * cols, dtype=np.float32).reshape(rows, cols) + offset)
+
+
+def _make_encoder_weights(
+    *,
+    hidden: int = _HIDDEN,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+    vocab: int = _VOCAB,
+) -> WeightDict:
+    weights = WeightDict({
+        "embedding": _matrix(vocab, hidden),
+        "position_embedding": _matrix(32, hidden, 1000),
+        "token_type_embedding": np.zeros((2, hidden), dtype=np.float32),
+        "embed_norm": np.ones(hidden, dtype=np.float32),
+        "embed_norm_beta": np.zeros(hidden, dtype=np.float32),
+    })
+    for layer_idx in range(layers):
+        prefix = f"layer.{layer_idx}"
+        weights[f"{prefix}.w_q"] = _matrix(hidden, hidden, 10)
+        weights[f"{prefix}.w_k"] = _matrix(hidden, hidden, 20)
+        weights[f"{prefix}.w_v"] = _matrix(hidden, hidden, 30)
+        weights[f"{prefix}.q_bias"] = np.arange(hidden, dtype=np.float32)
+        weights[f"{prefix}.k_bias"] = np.arange(hidden, dtype=np.float32) + 10
+        weights[f"{prefix}.v_bias"] = np.arange(hidden, dtype=np.float32) + 20
+        weights[f"{prefix}.w_o"] = _matrix(hidden, hidden, 40)
+        weights[f"{prefix}.o_bias"] = np.arange(hidden, dtype=np.float32) + 30
+        weights[f"{prefix}.post_attn_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.post_attn_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+        weights[f"{prefix}.w_fc1"] = _matrix(hidden, mlp, 50)
+        weights[f"{prefix}.fc1_bias"] = np.arange(mlp, dtype=np.float32)
+        weights[f"{prefix}.w_fc2"] = _matrix(mlp, hidden, 60)
+        weights[f"{prefix}.fc2_bias"] = np.arange(hidden, dtype=np.float32) + 40
+        weights[f"{prefix}.output_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.output_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+    return weights
+
+
+def test_distilbert_tp_builder_rejects_single_device_mode():
+    tp_builder = _distilbert_tp_builder_module()
+
+    with pytest.raises(ValueError, match="requires tensor_parallel mode"):
+        tp_builder.build_tp_encoder_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_seq_length=8,
+            parallel_config=ParallelConfig(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("parallel", "overrides", "message"),
+    [
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1),
+            {},
+            "concrete rank",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"heads": _HEADS + 2},
+            "num_attention_heads divisible",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"mlp": _MLP + 2},
+            "intermediate_size divisible",
+        ),
+    ],
+)
+def test_distilbert_tp_validation_rejects_bad_config_dimensions(
+    parallel,
+    overrides,
+    message,
+):
+    tp_builder = _distilbert_tp_builder_module()
+    config_kwargs = {
+        "hidden": _HIDDEN,
+        "heads": _HEADS,
+        "layers": _LAYERS,
+        "mlp": _MLP,
+    }
+    config_kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        tp_builder._validate_encoder_tp(
+            _make_config(**config_kwargs),
+            _make_encoder_weights(mlp=config_kwargs["mlp"]),
+            parallel,
+        )
+
+
+def test_distilbert_tp_shards_rank_local_encoder_weights():
+    tp_builder = _distilbert_tp_builder_module()
+    config = _make_config()
+    weights = _make_encoder_weights()
+    shard = tp_builder.shard_encoder_weights(
+        config,
+        weights,
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2),
+    )
+
+    hidden_start = (_HIDDEN // 4) * 2
+    hidden_end = (_HIDDEN // 4) * 3
+    mlp_start = (_MLP // 4) * 2
+    mlp_end = (_MLP // 4) * 3
+
+    assert isinstance(shard, WeightDict)
+    assert shard["_tensor_parallel_size"] == 4
+    assert shard["_tensor_parallel_rank"] == 2
+    assert shard["_attention_size"] == _HIDDEN // 4
+    assert shard["_intermediate_size"] == _MLP // 4
+    assert shard["embedding"] is weights["embedding"]
+
+    np.testing.assert_array_equal(
+        shard["layer.0.w_q"],
+        weights["layer.0.w_q"][:, hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.q_bias"],
+        weights["layer.0.q_bias"][hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_o"],
+        weights["layer.0.w_o"][hidden_start:hidden_end, :],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc1"],
+        weights["layer.0.w_fc1"][:, mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.fc1_bias"],
+        weights["layer.0.fc1_bias"][mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc2"],
+        weights["layer.0.w_fc2"][mlp_start:mlp_end, :],
+    )
+
+
+def test_distilbert_plugin_routes_tp_build(monkeypatch):
+    tp_builder = _distilbert_tp_builder_module()
+    captured = {}
+
+    def fake_build(config, weights, max_seq_length, **kwargs):
+        captured["config"] = config
+        captured["weights"] = weights
+        captured["max_seq_length"] = max_seq_length
+        captured["kwargs"] = kwargs
+        return b"distilbert-tp-plan"
+
+    monkeypatch.setattr(
+        distilbert_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+    monkeypatch.setattr(tp_builder, "build_tp_encoder_engine", fake_build)
+
+    plan = DistilBertPlugin().build_engine(
+        _make_config(),
+        _make_encoder_weights(),
+        max_cache_length=8,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1),
+    )
+
+    assert plan == b"distilbert-tp-plan"
+    assert captured["config"].model_type == "distilbert"
+    assert captured["max_seq_length"] == 8
+    assert captured["kwargs"]["parallel_config"].tp_size == 4
+    assert captured["kwargs"]["parallel_config"].rank == 1
+
+
+def test_distilbert_plugin_rejects_quantized_tp(monkeypatch):
+    monkeypatch.setattr(
+        distilbert_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="do not support quantization"):
+        DistilBertPlugin().build_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_cache_length=8,
+            quant_ctx=object(),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )

--- a/tests/builder/test_engine_dpr_tp.py
+++ b/tests/builder/test_engine_dpr_tp.py
@@ -1,0 +1,245 @@
+"""Tensor-parallel tests for DPR encoder support."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "tensorrt_model_connect.config",
+    reason="tensorrt_model_connect requires tensorrt",
+)
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.dpr.plugin import DprPlugin
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
+dpr_plugin = importlib.import_module(
+    "tensorrt_model_connect.families.dpr.plugin")
+
+_LAYERS = 1
+_HIDDEN = 16
+_HEADS = 4
+_MLP = 32
+_VOCAB = 24
+
+
+def _dpr_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.dpr.tp_builder",
+        reason="TensorRT is required for DPR TP builder tests",
+    )
+
+
+def _make_config(
+    *,
+    hidden: int = _HIDDEN,
+    heads: int = _HEADS,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+) -> ModelConfig:
+    return ModelConfig(
+        model_type="dpr",
+        vocab_size=_VOCAB,
+        hidden_size=hidden,
+        intermediate_size=mlp,
+        num_hidden_layers=layers,
+        num_attention_heads=heads,
+        num_key_value_heads=heads,
+        max_position_embeddings=32,
+        rms_norm_eps=1e-5,
+        _head_dim=hidden // heads,
+    )
+
+
+def _matrix(rows: int, cols: int, offset: int = 0) -> np.ndarray:
+    return (np.arange(rows * cols, dtype=np.float32).reshape(rows, cols) + offset)
+
+
+def _make_encoder_weights(
+    *,
+    hidden: int = _HIDDEN,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+    vocab: int = _VOCAB,
+) -> WeightDict:
+    weights = WeightDict({
+        "embedding": _matrix(vocab, hidden),
+        "position_embedding": _matrix(32, hidden, 1000),
+        "token_type_embedding": np.zeros((2, hidden), dtype=np.float32),
+        "embed_norm": np.ones(hidden, dtype=np.float32),
+        "embed_norm_beta": np.zeros(hidden, dtype=np.float32),
+    })
+    for layer_idx in range(layers):
+        prefix = f"layer.{layer_idx}"
+        weights[f"{prefix}.w_q"] = _matrix(hidden, hidden, 10)
+        weights[f"{prefix}.w_k"] = _matrix(hidden, hidden, 20)
+        weights[f"{prefix}.w_v"] = _matrix(hidden, hidden, 30)
+        weights[f"{prefix}.q_bias"] = np.arange(hidden, dtype=np.float32)
+        weights[f"{prefix}.k_bias"] = np.arange(hidden, dtype=np.float32) + 10
+        weights[f"{prefix}.v_bias"] = np.arange(hidden, dtype=np.float32) + 20
+        weights[f"{prefix}.w_o"] = _matrix(hidden, hidden, 40)
+        weights[f"{prefix}.o_bias"] = np.arange(hidden, dtype=np.float32) + 30
+        weights[f"{prefix}.post_attn_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.post_attn_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+        weights[f"{prefix}.w_fc1"] = _matrix(hidden, mlp, 50)
+        weights[f"{prefix}.fc1_bias"] = np.arange(mlp, dtype=np.float32)
+        weights[f"{prefix}.w_fc2"] = _matrix(mlp, hidden, 60)
+        weights[f"{prefix}.fc2_bias"] = np.arange(hidden, dtype=np.float32) + 40
+        weights[f"{prefix}.output_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.output_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+    return weights
+
+
+def test_dpr_tp_builder_rejects_single_device_mode():
+    tp_builder = _dpr_tp_builder_module()
+
+    with pytest.raises(ValueError, match="requires tensor_parallel mode"):
+        tp_builder.build_tp_encoder_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_seq_length=8,
+            parallel_config=ParallelConfig(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("parallel", "overrides", "message"),
+    [
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1),
+            {},
+            "concrete rank",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"heads": _HEADS + 2},
+            "num_attention_heads divisible",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"mlp": _MLP + 2},
+            "intermediate_size divisible",
+        ),
+    ],
+)
+def test_dpr_tp_validation_rejects_bad_config_dimensions(
+    parallel,
+    overrides,
+    message,
+):
+    tp_builder = _dpr_tp_builder_module()
+    config_kwargs = {
+        "hidden": _HIDDEN,
+        "heads": _HEADS,
+        "layers": _LAYERS,
+        "mlp": _MLP,
+    }
+    config_kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        tp_builder._validate_encoder_tp(
+            _make_config(**config_kwargs),
+            _make_encoder_weights(mlp=config_kwargs["mlp"]),
+            parallel,
+        )
+
+
+def test_dpr_tp_shards_rank_local_encoder_weights():
+    tp_builder = _dpr_tp_builder_module()
+    config = _make_config()
+    weights = _make_encoder_weights()
+    shard = tp_builder.shard_encoder_weights(
+        config,
+        weights,
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2),
+    )
+
+    hidden_start = (_HIDDEN // 4) * 2
+    hidden_end = (_HIDDEN // 4) * 3
+    mlp_start = (_MLP // 4) * 2
+    mlp_end = (_MLP // 4) * 3
+
+    assert isinstance(shard, WeightDict)
+    assert shard["_tensor_parallel_size"] == 4
+    assert shard["_tensor_parallel_rank"] == 2
+    assert shard["_attention_size"] == _HIDDEN // 4
+    assert shard["_intermediate_size"] == _MLP // 4
+    assert shard["embedding"] is weights["embedding"]
+
+    np.testing.assert_array_equal(
+        shard["layer.0.w_q"],
+        weights["layer.0.w_q"][:, hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.q_bias"],
+        weights["layer.0.q_bias"][hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_o"],
+        weights["layer.0.w_o"][hidden_start:hidden_end, :],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc1"],
+        weights["layer.0.w_fc1"][:, mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.fc1_bias"],
+        weights["layer.0.fc1_bias"][mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc2"],
+        weights["layer.0.w_fc2"][mlp_start:mlp_end, :],
+    )
+
+
+def test_dpr_plugin_routes_tp_build(monkeypatch):
+    tp_builder = _dpr_tp_builder_module()
+    captured = {}
+
+    def fake_build(config, weights, max_seq_length, **kwargs):
+        captured["config"] = config
+        captured["weights"] = weights
+        captured["max_seq_length"] = max_seq_length
+        captured["kwargs"] = kwargs
+        return b"dpr-tp-plan"
+
+    monkeypatch.setattr(
+        dpr_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+    monkeypatch.setattr(tp_builder, "build_tp_encoder_engine", fake_build)
+
+    plan = DprPlugin().build_engine(
+        _make_config(),
+        _make_encoder_weights(),
+        max_cache_length=8,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1),
+    )
+
+    assert plan == b"dpr-tp-plan"
+    assert captured["config"].model_type == "dpr"
+    assert captured["max_seq_length"] == 8
+    assert captured["kwargs"]["parallel_config"].tp_size == 4
+    assert captured["kwargs"]["parallel_config"].rank == 1
+
+
+def test_dpr_plugin_rejects_quantized_tp(monkeypatch):
+    monkeypatch.setattr(
+        dpr_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="do not support quantization"):
+        DprPlugin().build_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_cache_length=8,
+            quant_ctx=object(),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )

--- a/tests/builder/test_engine_fnet_tp.py
+++ b/tests/builder/test_engine_fnet_tp.py
@@ -1,0 +1,216 @@
+"""Tensor-parallel tests for FNet encoder support."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "tensorrt_model_connect.config",
+    reason="tensorrt_model_connect requires tensorrt",
+)
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.fnet.plugin import FNetPlugin
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
+fnet_plugin = importlib.import_module(
+    "tensorrt_model_connect.families.fnet.plugin")
+
+_LAYERS = 1
+_HIDDEN = 16
+_MLP = 32
+_VOCAB = 24
+
+
+def _fnet_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.fnet.tp_builder",
+        reason="TensorRT is required for FNet TP builder tests",
+    )
+
+
+def _make_config(
+    *,
+    hidden: int = _HIDDEN,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+) -> ModelConfig:
+    return ModelConfig(
+        model_type="fnet",
+        vocab_size=_VOCAB,
+        hidden_size=hidden,
+        intermediate_size=mlp,
+        num_hidden_layers=layers,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=32,
+        rms_norm_eps=1e-5,
+        _head_dim=hidden // 4,
+    )
+
+
+def _matrix(rows: int, cols: int, offset: int = 0) -> np.ndarray:
+    return np.arange(rows * cols, dtype=np.float32).reshape(rows, cols) + offset
+
+
+def _make_encoder_weights(
+    *,
+    hidden: int = _HIDDEN,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+    vocab: int = _VOCAB,
+) -> WeightDict:
+    weights = WeightDict({
+        "embedding": _matrix(vocab, hidden),
+        "position_embedding": _matrix(32, hidden, 1000),
+        "token_type_embedding": np.zeros((4, hidden), dtype=np.float32),
+        "embed_norm": np.ones(hidden, dtype=np.float32),
+        "embed_norm_beta": np.zeros(hidden, dtype=np.float32),
+        "embed_projection": _matrix(hidden, hidden, 2000),
+        "embed_projection_bias": np.zeros(hidden, dtype=np.float32),
+    })
+    for layer_idx in range(layers):
+        prefix = f"layer.{layer_idx}"
+        weights[f"{prefix}.post_attn_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.post_attn_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+        weights[f"{prefix}.w_fc1"] = _matrix(hidden, mlp, 50)
+        weights[f"{prefix}.fc1_bias"] = np.arange(mlp, dtype=np.float32)
+        weights[f"{prefix}.w_fc2"] = _matrix(mlp, hidden, 60)
+        weights[f"{prefix}.fc2_bias"] = np.arange(hidden, dtype=np.float32) + 40
+        weights[f"{prefix}.output_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.output_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+    return weights
+
+
+def test_fnet_tp_builder_rejects_single_device_mode():
+    tp_builder = _fnet_tp_builder_module()
+
+    with pytest.raises(ValueError, match="requires tensor_parallel mode"):
+        tp_builder.build_tp_fnet_encoder_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_seq_length=8,
+            parallel_config=ParallelConfig(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("parallel", "overrides", "message"),
+    [
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1),
+            {},
+            "concrete rank",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"mlp": _MLP + 2},
+            "intermediate_size divisible",
+        ),
+    ],
+)
+def test_fnet_tp_validation_rejects_bad_config_dimensions(
+    parallel,
+    overrides,
+    message,
+):
+    tp_builder = _fnet_tp_builder_module()
+    config_kwargs = {
+        "hidden": _HIDDEN,
+        "layers": _LAYERS,
+        "mlp": _MLP,
+    }
+    config_kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        tp_builder._validate_fnet_tp(
+            _make_config(**config_kwargs),
+            _make_encoder_weights(mlp=config_kwargs["mlp"]),
+            parallel,
+        )
+
+
+def test_fnet_tp_shards_rank_local_ffn_weights():
+    tp_builder = _fnet_tp_builder_module()
+    config = _make_config()
+    weights = _make_encoder_weights()
+    shard = tp_builder.shard_fnet_encoder_weights(
+        config,
+        weights,
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2),
+    )
+
+    mlp_start = (_MLP // 4) * 2
+    mlp_end = (_MLP // 4) * 3
+
+    assert isinstance(shard, WeightDict)
+    assert shard["_tensor_parallel_size"] == 4
+    assert shard["_tensor_parallel_rank"] == 2
+    assert shard["_intermediate_size"] == _MLP // 4
+    assert shard["embedding"] is weights["embedding"]
+
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc1"],
+        weights["layer.0.w_fc1"][:, mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.fc1_bias"],
+        weights["layer.0.fc1_bias"][mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc2"],
+        weights["layer.0.w_fc2"][mlp_start:mlp_end, :],
+    )
+
+
+def test_fnet_plugin_routes_tp_build(monkeypatch):
+    tp_builder = _fnet_tp_builder_module()
+    captured = {}
+
+    def fake_build(config, weights, max_seq_length, **kwargs):
+        captured["config"] = config
+        captured["weights"] = weights
+        captured["max_seq_length"] = max_seq_length
+        captured["kwargs"] = kwargs
+        return b"fnet-tp-plan"
+
+    monkeypatch.setattr(
+        fnet_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+    monkeypatch.setattr(tp_builder, "build_tp_fnet_encoder_engine", fake_build)
+
+    plan = FNetPlugin().build_engine(
+        _make_config(),
+        _make_encoder_weights(),
+        max_cache_length=8,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1),
+    )
+
+    assert plan == b"fnet-tp-plan"
+    assert captured["config"].model_type == "fnet"
+    assert captured["max_seq_length"] == 8
+    assert captured["kwargs"]["parallel_config"].tp_size == 4
+    assert captured["kwargs"]["parallel_config"].rank == 1
+
+
+def test_fnet_plugin_rejects_quantized_tp(monkeypatch):
+    monkeypatch.setattr(
+        fnet_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="do not support quantization"):
+        FNetPlugin().build_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_cache_length=8,
+            quant_ctx=object(),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )

--- a/tests/builder/test_engine_modernbert_tp.py
+++ b/tests/builder/test_engine_modernbert_tp.py
@@ -1,0 +1,237 @@
+"""Tensor-parallel tests for ModernBERT encoder support."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "tensorrt_model_connect.config",
+    reason="tensorrt_model_connect requires tensorrt",
+)
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.modernbert.plugin import ModernbertPlugin
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
+modernbert_plugin = importlib.import_module(
+    "tensorrt_model_connect.families.modernbert.plugin")
+
+_LAYERS = 1
+_HIDDEN = 16
+_HEADS = 4
+_MLP = 32
+_VOCAB = 24
+
+
+def _modernbert_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.modernbert.tp_builder",
+        reason="TensorRT is required for ModernBERT TP builder tests",
+    )
+
+
+def _make_config(
+    *,
+    hidden: int = _HIDDEN,
+    heads: int = _HEADS,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+) -> ModelConfig:
+    return ModelConfig(
+        model_type="modernbert",
+        vocab_size=_VOCAB,
+        hidden_size=hidden,
+        intermediate_size=mlp,
+        num_hidden_layers=layers,
+        num_attention_heads=heads,
+        num_key_value_heads=heads,
+        max_position_embeddings=32,
+        rms_norm_eps=1e-5,
+        _head_dim=hidden // heads,
+        raw={
+            "norm_eps": 1e-5,
+            "layer_types": ["full_attention"],
+            "rope_parameters": {},
+        },
+    )
+
+
+def _matrix(rows: int, cols: int, offset: int = 0) -> np.ndarray:
+    return np.arange(rows * cols, dtype=np.float32).reshape(rows, cols) + offset
+
+
+def _make_encoder_weights(
+    *,
+    hidden: int = _HIDDEN,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+    vocab: int = _VOCAB,
+) -> WeightDict:
+    weights = WeightDict({
+        "embedding": _matrix(vocab, hidden),
+        "embed_norm": np.ones(hidden, dtype=np.float32),
+        "final_norm": np.ones(hidden, dtype=np.float32),
+    })
+    for layer_idx in range(layers):
+        prefix = f"layer.{layer_idx}"
+        weights[f"{prefix}.attn_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.w_q"] = _matrix(hidden, hidden, 10)
+        weights[f"{prefix}.w_k"] = _matrix(hidden, hidden, 20)
+        weights[f"{prefix}.w_v"] = _matrix(hidden, hidden, 30)
+        weights[f"{prefix}.w_o"] = _matrix(hidden, hidden, 40)
+        weights[f"{prefix}.mlp_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.w_mlp_input"] = _matrix(hidden, mlp, 50)
+        weights[f"{prefix}.w_mlp_gate"] = _matrix(hidden, mlp, 60)
+        weights[f"{prefix}.w_down"] = _matrix(mlp, hidden, 70)
+    return weights
+
+
+def test_modernbert_tp_builder_rejects_single_device_mode():
+    tp_builder = _modernbert_tp_builder_module()
+
+    with pytest.raises(ValueError, match="requires tensor_parallel mode"):
+        tp_builder.build_tp_modernbert_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_seq_length=8,
+            parallel_config=ParallelConfig(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("parallel", "overrides", "message"),
+    [
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1),
+            {},
+            "concrete rank",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"heads": _HEADS + 2},
+            "num_attention_heads divisible",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"mlp": _MLP + 2},
+            "intermediate_size divisible",
+        ),
+    ],
+)
+def test_modernbert_tp_validation_rejects_bad_config_dimensions(
+    parallel,
+    overrides,
+    message,
+):
+    tp_builder = _modernbert_tp_builder_module()
+    config_kwargs = {
+        "hidden": _HIDDEN,
+        "heads": _HEADS,
+        "layers": _LAYERS,
+        "mlp": _MLP,
+    }
+    config_kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        tp_builder._validate_modernbert_tp(
+            _make_config(**config_kwargs),
+            _make_encoder_weights(mlp=config_kwargs["mlp"]),
+            parallel,
+        )
+
+
+def test_modernbert_tp_shards_rank_local_encoder_weights():
+    tp_builder = _modernbert_tp_builder_module()
+    config = _make_config()
+    weights = _make_encoder_weights()
+    shard = tp_builder.shard_modernbert_weights(
+        config,
+        weights,
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2),
+    )
+
+    hidden_start = (_HIDDEN // 4) * 2
+    hidden_end = (_HIDDEN // 4) * 3
+    mlp_start = (_MLP // 4) * 2
+    mlp_end = (_MLP // 4) * 3
+
+    assert isinstance(shard, WeightDict)
+    assert shard["_tensor_parallel_size"] == 4
+    assert shard["_tensor_parallel_rank"] == 2
+    assert shard["_attention_size"] == _HIDDEN // 4
+    assert shard["_intermediate_size"] == _MLP // 4
+    assert shard["embedding"] is weights["embedding"]
+
+    np.testing.assert_array_equal(
+        shard["layer.0.w_q"],
+        weights["layer.0.w_q"][:, hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_o"],
+        weights["layer.0.w_o"][hidden_start:hidden_end, :],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_mlp_input"],
+        weights["layer.0.w_mlp_input"][:, mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_mlp_gate"],
+        weights["layer.0.w_mlp_gate"][:, mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_down"],
+        weights["layer.0.w_down"][mlp_start:mlp_end, :],
+    )
+
+
+def test_modernbert_plugin_routes_tp_build(monkeypatch):
+    tp_builder = _modernbert_tp_builder_module()
+    captured = {}
+
+    def fake_build(config, weights, max_seq_length, **kwargs):
+        captured["config"] = config
+        captured["weights"] = weights
+        captured["max_seq_length"] = max_seq_length
+        captured["kwargs"] = kwargs
+        return b"modernbert-tp-plan"
+
+    monkeypatch.setattr(
+        modernbert_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+    monkeypatch.setattr(tp_builder, "build_tp_modernbert_engine", fake_build)
+
+    plan = ModernbertPlugin().build_engine(
+        _make_config(),
+        _make_encoder_weights(),
+        max_cache_length=8,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1),
+    )
+
+    assert plan == b"modernbert-tp-plan"
+    assert captured["config"].model_type == "modernbert"
+    assert captured["max_seq_length"] == 8
+    assert captured["kwargs"]["parallel_config"].tp_size == 4
+    assert captured["kwargs"]["parallel_config"].rank == 1
+
+
+def test_modernbert_plugin_rejects_quantized_tp(monkeypatch):
+    monkeypatch.setattr(
+        modernbert_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="do not support quantization"):
+        ModernbertPlugin().build_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_cache_length=8,
+            quant_ctx=object(),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )

--- a/tests/builder/test_engine_mpnet_tp.py
+++ b/tests/builder/test_engine_mpnet_tp.py
@@ -1,0 +1,263 @@
+"""Tensor-parallel tests for MPNet encoder support."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "tensorrt_model_connect.config",
+    reason="tensorrt_model_connect requires tensorrt",
+)
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.mpnet.plugin import MpnetPlugin
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
+mpnet_plugin = importlib.import_module(
+    "tensorrt_model_connect.families.mpnet.plugin")
+
+_LAYERS = 1
+_HIDDEN = 16
+_HEADS = 4
+_MLP = 32
+_VOCAB = 24
+
+
+def _mpnet_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.mpnet.tp_builder",
+        reason="TensorRT is required for MPNet TP builder tests",
+    )
+
+
+def _make_config(
+    *,
+    hidden: int = _HIDDEN,
+    heads: int = _HEADS,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+) -> ModelConfig:
+    return ModelConfig(
+        model_type="mpnet",
+        vocab_size=_VOCAB,
+        hidden_size=hidden,
+        intermediate_size=mlp,
+        num_hidden_layers=layers,
+        num_attention_heads=heads,
+        num_key_value_heads=heads,
+        max_position_embeddings=32,
+        rms_norm_eps=1e-5,
+        _head_dim=hidden // heads,
+    )
+
+
+def _matrix(rows: int, cols: int, offset: int = 0) -> np.ndarray:
+    return (np.arange(rows * cols, dtype=np.float32).reshape(rows, cols) + offset)
+
+
+def _make_encoder_weights(
+    *,
+    hidden: int = _HIDDEN,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+    vocab: int = _VOCAB,
+) -> WeightDict:
+    weights = WeightDict({
+        "embedding": _matrix(vocab, hidden),
+        "position_embedding": _matrix(32, hidden, 1000),
+        "token_type_embedding": np.zeros((2, hidden), dtype=np.float32),
+        "embed_norm": np.ones(hidden, dtype=np.float32),
+        "embed_norm_beta": np.zeros(hidden, dtype=np.float32),
+    })
+    for layer_idx in range(layers):
+        prefix = f"layer.{layer_idx}"
+        weights[f"{prefix}.w_q"] = _matrix(hidden, hidden, 10)
+        weights[f"{prefix}.w_k"] = _matrix(hidden, hidden, 20)
+        weights[f"{prefix}.w_v"] = _matrix(hidden, hidden, 30)
+        weights[f"{prefix}.q_bias"] = np.arange(hidden, dtype=np.float32)
+        weights[f"{prefix}.k_bias"] = np.arange(hidden, dtype=np.float32) + 10
+        weights[f"{prefix}.v_bias"] = np.arange(hidden, dtype=np.float32) + 20
+        weights[f"{prefix}.w_o"] = _matrix(hidden, hidden, 40)
+        weights[f"{prefix}.o_bias"] = np.arange(hidden, dtype=np.float32) + 30
+        weights[f"{prefix}.post_attn_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.post_attn_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+        weights[f"{prefix}.w_fc1"] = _matrix(hidden, mlp, 50)
+        weights[f"{prefix}.fc1_bias"] = np.arange(mlp, dtype=np.float32)
+        weights[f"{prefix}.w_fc2"] = _matrix(mlp, hidden, 60)
+        weights[f"{prefix}.fc2_bias"] = np.arange(hidden, dtype=np.float32) + 40
+        weights[f"{prefix}.output_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.output_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+    return weights
+
+
+def test_mpnet_tp_builder_rejects_single_device_mode():
+    tp_builder = _mpnet_tp_builder_module()
+
+    with pytest.raises(ValueError, match="requires tensor_parallel mode"):
+        tp_builder.build_tp_encoder_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_seq_length=8,
+            parallel_config=ParallelConfig(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("parallel", "overrides", "message"),
+    [
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1),
+            {},
+            "concrete rank",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"heads": _HEADS + 2},
+            "num_attention_heads divisible",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"mlp": _MLP + 2},
+            "intermediate_size divisible",
+        ),
+    ],
+)
+def test_mpnet_tp_validation_rejects_bad_config_dimensions(
+    parallel,
+    overrides,
+    message,
+):
+    tp_builder = _mpnet_tp_builder_module()
+    config_kwargs = {
+        "hidden": _HIDDEN,
+        "heads": _HEADS,
+        "layers": _LAYERS,
+        "mlp": _MLP,
+    }
+    config_kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        tp_builder._validate_encoder_tp(
+            _make_config(**config_kwargs),
+            _make_encoder_weights(mlp=config_kwargs["mlp"]),
+            parallel,
+        )
+
+
+def test_mpnet_tp_shards_rank_local_encoder_weights():
+    tp_builder = _mpnet_tp_builder_module()
+    config = _make_config()
+    weights = _make_encoder_weights()
+    shard = tp_builder.shard_encoder_weights(
+        config,
+        weights,
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2),
+    )
+
+    hidden_start = (_HIDDEN // 4) * 2
+    hidden_end = (_HIDDEN // 4) * 3
+    mlp_start = (_MLP // 4) * 2
+    mlp_end = (_MLP // 4) * 3
+
+    assert isinstance(shard, WeightDict)
+    assert shard["_tensor_parallel_size"] == 4
+    assert shard["_tensor_parallel_rank"] == 2
+    assert shard["_attention_size"] == _HIDDEN // 4
+    assert shard["_intermediate_size"] == _MLP // 4
+    assert shard["embedding"] is weights["embedding"]
+
+    np.testing.assert_array_equal(
+        shard["layer.0.w_q"],
+        weights["layer.0.w_q"][:, hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.q_bias"],
+        weights["layer.0.q_bias"][hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_o"],
+        weights["layer.0.w_o"][hidden_start:hidden_end, :],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc1"],
+        weights["layer.0.w_fc1"][:, mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.fc1_bias"],
+        weights["layer.0.fc1_bias"][mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc2"],
+        weights["layer.0.w_fc2"][mlp_start:mlp_end, :],
+    )
+
+
+def test_mpnet_tp_shards_relative_position_bias():
+    tp_builder = _mpnet_tp_builder_module()
+    config = _make_config()
+    weights = _make_encoder_weights()
+    weights["relative_position_bias"] = _matrix(_HEADS, 8, 100).reshape(_HEADS, 2, 4)
+
+    shard = tp_builder.shard_encoder_weights(
+        config,
+        weights,
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=3),
+    )
+
+    np.testing.assert_array_equal(
+        shard["relative_position_bias"],
+        weights["relative_position_bias"][3:4],
+    )
+
+
+def test_mpnet_plugin_routes_tp_build(monkeypatch):
+    tp_builder = _mpnet_tp_builder_module()
+    captured = {}
+
+    def fake_build(config, weights, max_seq_length, **kwargs):
+        captured["config"] = config
+        captured["weights"] = weights
+        captured["max_seq_length"] = max_seq_length
+        captured["kwargs"] = kwargs
+        return b"mpnet-tp-plan"
+
+    monkeypatch.setattr(
+        mpnet_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+    monkeypatch.setattr(tp_builder, "build_tp_encoder_engine", fake_build)
+
+    plan = MpnetPlugin().build_engine(
+        _make_config(),
+        _make_encoder_weights(),
+        max_cache_length=8,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1),
+    )
+
+    assert plan == b"mpnet-tp-plan"
+    assert captured["config"].model_type == "mpnet"
+    assert captured["max_seq_length"] == 8
+    assert captured["kwargs"]["parallel_config"].tp_size == 4
+    assert captured["kwargs"]["parallel_config"].rank == 1
+
+
+def test_mpnet_plugin_rejects_quantized_tp(monkeypatch):
+    monkeypatch.setattr(
+        mpnet_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="do not support quantization"):
+        MpnetPlugin().build_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_cache_length=8,
+            quant_ctx=object(),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )

--- a/tests/builder/test_engine_roberta_tp.py
+++ b/tests/builder/test_engine_roberta_tp.py
@@ -1,0 +1,245 @@
+"""Tensor-parallel tests for RoBERTa encoder support."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "tensorrt_model_connect.config",
+    reason="tensorrt_model_connect requires tensorrt",
+)
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.roberta.plugin import RobertaPlugin
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
+roberta_plugin = importlib.import_module(
+    "tensorrt_model_connect.families.roberta.plugin")
+
+_LAYERS = 1
+_HIDDEN = 16
+_HEADS = 4
+_MLP = 32
+_VOCAB = 24
+
+
+def _roberta_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.roberta.tp_builder",
+        reason="TensorRT is required for RoBERTa TP builder tests",
+    )
+
+
+def _make_config(
+    *,
+    hidden: int = _HIDDEN,
+    heads: int = _HEADS,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+) -> ModelConfig:
+    return ModelConfig(
+        model_type="roberta",
+        vocab_size=_VOCAB,
+        hidden_size=hidden,
+        intermediate_size=mlp,
+        num_hidden_layers=layers,
+        num_attention_heads=heads,
+        num_key_value_heads=heads,
+        max_position_embeddings=32,
+        rms_norm_eps=1e-5,
+        _head_dim=hidden // heads,
+    )
+
+
+def _matrix(rows: int, cols: int, offset: int = 0) -> np.ndarray:
+    return (np.arange(rows * cols, dtype=np.float32).reshape(rows, cols) + offset)
+
+
+def _make_encoder_weights(
+    *,
+    hidden: int = _HIDDEN,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+    vocab: int = _VOCAB,
+) -> WeightDict:
+    weights = WeightDict({
+        "embedding": _matrix(vocab, hidden),
+        "position_embedding": _matrix(32, hidden, 1000),
+        "token_type_embedding": np.zeros((2, hidden), dtype=np.float32),
+        "embed_norm": np.ones(hidden, dtype=np.float32),
+        "embed_norm_beta": np.zeros(hidden, dtype=np.float32),
+    })
+    for layer_idx in range(layers):
+        prefix = f"layer.{layer_idx}"
+        weights[f"{prefix}.w_q"] = _matrix(hidden, hidden, 10)
+        weights[f"{prefix}.w_k"] = _matrix(hidden, hidden, 20)
+        weights[f"{prefix}.w_v"] = _matrix(hidden, hidden, 30)
+        weights[f"{prefix}.q_bias"] = np.arange(hidden, dtype=np.float32)
+        weights[f"{prefix}.k_bias"] = np.arange(hidden, dtype=np.float32) + 10
+        weights[f"{prefix}.v_bias"] = np.arange(hidden, dtype=np.float32) + 20
+        weights[f"{prefix}.w_o"] = _matrix(hidden, hidden, 40)
+        weights[f"{prefix}.o_bias"] = np.arange(hidden, dtype=np.float32) + 30
+        weights[f"{prefix}.post_attn_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.post_attn_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+        weights[f"{prefix}.w_fc1"] = _matrix(hidden, mlp, 50)
+        weights[f"{prefix}.fc1_bias"] = np.arange(mlp, dtype=np.float32)
+        weights[f"{prefix}.w_fc2"] = _matrix(mlp, hidden, 60)
+        weights[f"{prefix}.fc2_bias"] = np.arange(hidden, dtype=np.float32) + 40
+        weights[f"{prefix}.output_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.output_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+    return weights
+
+
+def test_roberta_tp_builder_rejects_single_device_mode():
+    tp_builder = _roberta_tp_builder_module()
+
+    with pytest.raises(ValueError, match="requires tensor_parallel mode"):
+        tp_builder.build_tp_encoder_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_seq_length=8,
+            parallel_config=ParallelConfig(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("parallel", "overrides", "message"),
+    [
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1),
+            {},
+            "concrete rank",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"heads": _HEADS + 2},
+            "num_attention_heads divisible",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"mlp": _MLP + 2},
+            "intermediate_size divisible",
+        ),
+    ],
+)
+def test_roberta_tp_validation_rejects_bad_config_dimensions(
+    parallel,
+    overrides,
+    message,
+):
+    tp_builder = _roberta_tp_builder_module()
+    config_kwargs = {
+        "hidden": _HIDDEN,
+        "heads": _HEADS,
+        "layers": _LAYERS,
+        "mlp": _MLP,
+    }
+    config_kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        tp_builder._validate_encoder_tp(
+            _make_config(**config_kwargs),
+            _make_encoder_weights(mlp=config_kwargs["mlp"]),
+            parallel,
+        )
+
+
+def test_roberta_tp_shards_rank_local_encoder_weights():
+    tp_builder = _roberta_tp_builder_module()
+    config = _make_config()
+    weights = _make_encoder_weights()
+    shard = tp_builder.shard_encoder_weights(
+        config,
+        weights,
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2),
+    )
+
+    hidden_start = (_HIDDEN // 4) * 2
+    hidden_end = (_HIDDEN // 4) * 3
+    mlp_start = (_MLP // 4) * 2
+    mlp_end = (_MLP // 4) * 3
+
+    assert isinstance(shard, WeightDict)
+    assert shard["_tensor_parallel_size"] == 4
+    assert shard["_tensor_parallel_rank"] == 2
+    assert shard["_attention_size"] == _HIDDEN // 4
+    assert shard["_intermediate_size"] == _MLP // 4
+    assert shard["embedding"] is weights["embedding"]
+
+    np.testing.assert_array_equal(
+        shard["layer.0.w_q"],
+        weights["layer.0.w_q"][:, hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.q_bias"],
+        weights["layer.0.q_bias"][hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_o"],
+        weights["layer.0.w_o"][hidden_start:hidden_end, :],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc1"],
+        weights["layer.0.w_fc1"][:, mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.fc1_bias"],
+        weights["layer.0.fc1_bias"][mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc2"],
+        weights["layer.0.w_fc2"][mlp_start:mlp_end, :],
+    )
+
+
+def test_roberta_plugin_routes_tp_build(monkeypatch):
+    tp_builder = _roberta_tp_builder_module()
+    captured = {}
+
+    def fake_build(config, weights, max_seq_length, **kwargs):
+        captured["config"] = config
+        captured["weights"] = weights
+        captured["max_seq_length"] = max_seq_length
+        captured["kwargs"] = kwargs
+        return b"roberta-tp-plan"
+
+    monkeypatch.setattr(
+        roberta_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+    monkeypatch.setattr(tp_builder, "build_tp_encoder_engine", fake_build)
+
+    plan = RobertaPlugin().build_engine(
+        _make_config(),
+        _make_encoder_weights(),
+        max_cache_length=8,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1),
+    )
+
+    assert plan == b"roberta-tp-plan"
+    assert captured["config"].model_type == "roberta"
+    assert captured["max_seq_length"] == 8
+    assert captured["kwargs"]["parallel_config"].tp_size == 4
+    assert captured["kwargs"]["parallel_config"].rank == 1
+
+
+def test_roberta_plugin_rejects_quantized_tp(monkeypatch):
+    monkeypatch.setattr(
+        roberta_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="do not support quantization"):
+        RobertaPlugin().build_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_cache_length=8,
+            quant_ctx=object(),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )

--- a/tests/builder/test_engine_xlnet_tp.py
+++ b/tests/builder/test_engine_xlnet_tp.py
@@ -1,0 +1,249 @@
+"""Tensor-parallel tests for XLNet encoder support."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "tensorrt_model_connect.config",
+    reason="tensorrt_model_connect requires tensorrt",
+)
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.xlnet.plugin import XlnetPlugin
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
+xlnet_plugin = importlib.import_module(
+    "tensorrt_model_connect.families.xlnet.plugin")
+
+_LAYERS = 1
+_HIDDEN = 16
+_HEADS = 4
+_D_HEAD = 4
+_MLP = 32
+_VOCAB = 24
+
+
+def _xlnet_tp_builder_module():
+    return pytest.importorskip(
+        "tensorrt_model_connect.families.xlnet.tp_builder",
+        reason="TensorRT is required for XLNet TP builder tests",
+    )
+
+
+def _make_config(
+    *,
+    hidden: int = _HIDDEN,
+    heads: int = _HEADS,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+) -> ModelConfig:
+    return ModelConfig(
+        model_type="xlnet",
+        vocab_size=_VOCAB,
+        hidden_size=hidden,
+        intermediate_size=mlp,
+        num_hidden_layers=layers,
+        num_attention_heads=heads,
+        num_key_value_heads=heads,
+        max_position_embeddings=32,
+        rms_norm_eps=1e-5,
+        _head_dim=hidden // heads,
+        raw={"d_head": hidden // heads, "ff_activation": "gelu"},
+    )
+
+
+def _matrix(rows: int, cols: int, offset: int = 0) -> np.ndarray:
+    return np.arange(rows * cols, dtype=np.float32).reshape(rows, cols) + offset
+
+
+def _make_encoder_weights(
+    *,
+    hidden: int = _HIDDEN,
+    heads: int = _HEADS,
+    layers: int = _LAYERS,
+    mlp: int = _MLP,
+    vocab: int = _VOCAB,
+) -> WeightDict:
+    d_head = hidden // heads
+    attn = heads * d_head
+    weights = WeightDict({
+        "embedding": _matrix(vocab, hidden),
+    })
+    for layer_idx in range(layers):
+        prefix = f"layer.{layer_idx}"
+        for idx, proj in enumerate(["q", "k", "v", "o", "r"]):
+            weights[f"{prefix}.w_{proj}"] = _matrix(hidden, attn, 10 + idx * 10)
+        weights[f"{prefix}.r_w_bias"] = _matrix(heads, d_head, 100)
+        weights[f"{prefix}.r_r_bias"] = _matrix(heads, d_head, 200)
+        weights[f"{prefix}.r_s_bias"] = _matrix(heads, d_head, 300)
+        weights[f"{prefix}.seg_embed"] = np.arange(
+            2 * heads * d_head, dtype=np.float32).reshape(2, heads, d_head)
+        weights[f"{prefix}.attn_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.attn_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+        weights[f"{prefix}.ff_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{prefix}.ff_norm_beta"] = np.zeros(hidden, dtype=np.float32)
+        weights[f"{prefix}.w_fc1"] = _matrix(hidden, mlp, 400)
+        weights[f"{prefix}.fc1_bias"] = np.arange(mlp, dtype=np.float32)
+        weights[f"{prefix}.w_fc2"] = _matrix(mlp, hidden, 500)
+        weights[f"{prefix}.fc2_bias"] = np.arange(hidden, dtype=np.float32) + 40
+    return weights
+
+
+def test_xlnet_tp_builder_rejects_single_device_mode():
+    tp_builder = _xlnet_tp_builder_module()
+
+    with pytest.raises(ValueError, match="requires tensor_parallel mode"):
+        tp_builder.build_tp_xlnet_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_seq_length=8,
+            parallel_config=ParallelConfig(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("parallel", "overrides", "message"),
+    [
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1),
+            {},
+            "concrete rank",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"heads": _HEADS + 2},
+            "num_attention_heads divisible",
+        ),
+        (
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            {"mlp": _MLP + 2},
+            "intermediate_size divisible",
+        ),
+    ],
+)
+def test_xlnet_tp_validation_rejects_bad_config_dimensions(
+    parallel,
+    overrides,
+    message,
+):
+    tp_builder = _xlnet_tp_builder_module()
+    config_kwargs = {
+        "hidden": _HIDDEN,
+        "heads": _HEADS,
+        "layers": _LAYERS,
+        "mlp": _MLP,
+    }
+    config_kwargs.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        tp_builder._validate_xlnet_tp(
+            _make_config(**config_kwargs),
+            _make_encoder_weights(heads=config_kwargs["heads"], mlp=config_kwargs["mlp"]),
+            parallel,
+        )
+
+
+def test_xlnet_tp_shards_rank_local_encoder_weights():
+    tp_builder = _xlnet_tp_builder_module()
+    config = _make_config()
+    weights = _make_encoder_weights()
+    shard = tp_builder.shard_xlnet_weights(
+        config,
+        weights,
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2),
+    )
+
+    hidden_start = (_HIDDEN // 4) * 2
+    hidden_end = (_HIDDEN // 4) * 3
+    mlp_start = (_MLP // 4) * 2
+    mlp_end = (_MLP // 4) * 3
+
+    assert isinstance(shard, WeightDict)
+    assert shard["_tensor_parallel_size"] == 4
+    assert shard["_tensor_parallel_rank"] == 2
+    assert shard["_attention_size"] == _HIDDEN // 4
+    assert shard["_intermediate_size"] == _MLP // 4
+    assert shard["embedding"] is weights["embedding"]
+
+    np.testing.assert_array_equal(
+        shard["layer.0.w_q"],
+        weights["layer.0.w_q"][:, hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_o"],
+        weights["layer.0.w_o"][:, hidden_start:hidden_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.r_w_bias"],
+        weights["layer.0.r_w_bias"][2:3],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.seg_embed"],
+        weights["layer.0.seg_embed"][:, 2:3, :],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc1"],
+        weights["layer.0.w_fc1"][:, mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.fc1_bias"],
+        weights["layer.0.fc1_bias"][mlp_start:mlp_end],
+    )
+    np.testing.assert_array_equal(
+        shard["layer.0.w_fc2"],
+        weights["layer.0.w_fc2"][mlp_start:mlp_end, :],
+    )
+
+
+def test_xlnet_plugin_routes_tp_build(monkeypatch):
+    tp_builder = _xlnet_tp_builder_module()
+    captured = {}
+
+    def fake_build(config, weights, max_seq_length, **kwargs):
+        captured["config"] = config
+        captured["weights"] = weights
+        captured["max_seq_length"] = max_seq_length
+        captured["kwargs"] = kwargs
+        return b"xlnet-tp-plan"
+
+    monkeypatch.setattr(
+        xlnet_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+    monkeypatch.setattr(tp_builder, "build_tp_xlnet_engine", fake_build)
+
+    plan = XlnetPlugin().build_engine(
+        _make_config(),
+        _make_encoder_weights(),
+        max_cache_length=8,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1),
+    )
+
+    assert plan == b"xlnet-tp-plan"
+    assert captured["config"].model_type == "xlnet"
+    assert captured["max_seq_length"] == 8
+    assert captured["kwargs"]["parallel_config"].tp_size == 4
+    assert captured["kwargs"]["parallel_config"].rank == 1
+
+
+def test_xlnet_plugin_rejects_quantized_tp(monkeypatch):
+    monkeypatch.setattr(
+        xlnet_plugin,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="do not support quantization"):
+        XlnetPlugin().build_engine(
+            _make_config(),
+            _make_encoder_weights(),
+            max_cache_length=8,
+            quant_ctx=object(),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )

--- a/tests/e2e/models/all-mpnet-base-v2-tp4.json
+++ b/tests/e2e/models/all-mpnet-base-v2-tp4.json
@@ -1,0 +1,54 @@
+{
+  "name": "all-mpnet-base-v2-tp4",
+  "trace_id": "IT-E2E-MPNET-TP4-01",
+  "hf_id": "sentence-transformers/all-mpnet-base-v2",
+  "bundle": "all-mpnet-base-v2-tp4.trtfb",
+  "family": "mpnet",
+  "runtime_strategy": "encoder_only",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 384,
+  "prompt": "This is an example sentence for embedding.",
+  "max_new_tokens": 0,
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "MPNet TP4 coverage. Uses the same checkpoint, prompt, cache length, and thresholds as all-mpnet-base-v2."
+}

--- a/tests/e2e/models/bert-base-uncased-tp4.json
+++ b/tests/e2e/models/bert-base-uncased-tp4.json
@@ -1,0 +1,56 @@
+{
+  "name": "bert-base-uncased-tp4",
+  "trace_id": "IT-E2E-BERT-TP4-01",
+  "hf_id": "google-bert/bert-base-uncased",
+  "bundle": "bert-base-uncased-tp4.trtfb",
+  "family": "bert",
+  "runtime_strategy": "encoder_only",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 128,
+  "prompt": "The capital of France is Paris.",
+  "max_new_tokens": 1,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "BERT TP4 coverage. Uses the same checkpoint, prompt, cache length, and thresholds as bert-base-uncased."
+}

--- a/tests/e2e/models/camembert-base-tp4.json
+++ b/tests/e2e/models/camembert-base-tp4.json
@@ -1,0 +1,55 @@
+{
+  "name": "camembert-base-tp4",
+  "trace_id": "IT-E2E-CAMB-TP4-01",
+  "hf_id": "almanach/camembert-base",
+  "bundle": "camembert-base-tp4.trtfb",
+  "family": "roberta",
+  "runtime_strategy": "encoder_only",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 256,
+  "prompt": "Bonjour le monde",
+  "max_new_tokens": 0,
+  "logit_atol": 0.01,
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "CamemBERT base TP4 coverage. Uses the same checkpoint, prompt, cache length, and thresholds as camembert-base."
+}

--- a/tests/e2e/models/convbert-base-tp2.json
+++ b/tests/e2e/models/convbert-base-tp2.json
@@ -1,0 +1,61 @@
+{
+  "name": "convbert-base-tp2",
+  "trace_id": "IT-E2E-CONVBERT-TP2-01",
+  "hf_id": "YituTech/conv-bert-base",
+  "bundle": "convbert-base-tp2.trtfb",
+  "family": "convbert",
+  "runtime_strategy": "encoder_only",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 256,
+  "prompt": "The capital of France is Paris.",
+  "max_new_tokens": 1,
+  "logit_atol": 0.025,
+  "layer_atol": 0.05,
+  "trust_remote_code": false,
+  "notes": "ConvBERT TP2 coverage. TP4 is invalid for conv-bert-base because its 6 effective attention heads are not divisible by 4. Uses the same checkpoint, prompt, cache length, and thresholds as convbert-base.",
+  "core": false,
+  "threshold_overrides": {
+    "cls_embedding_cosine": 0.95,
+    "cls_embedding_l2": 10.0
+  },
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 2
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 2,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 2
+      },
+      "gating": true
+    }
+  ]
+}

--- a/tests/e2e/models/deberta-base-tp4.json
+++ b/tests/e2e/models/deberta-base-tp4.json
@@ -1,0 +1,57 @@
+{
+  "name": "deberta-base-tp4",
+  "trace_id": "IT-E2E-DEBERTA-TP4-01",
+  "hf_id": "microsoft/deberta-base",
+  "bundle": "deberta-base-tp4.trtfb",
+  "family": "deberta",
+  "runtime_strategy": "encoder_only",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 256,
+  "prompt": "The capital of France is Paris.",
+  "max_new_tokens": 1,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "trust_remote_code": false,
+  "notes": "DeBERTa TP4 coverage. Uses the same checkpoint, prompt, cache length, and thresholds as deberta-base.",
+  "core": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ]
+}

--- a/tests/e2e/models/distilbert-base-uncased-tp4.json
+++ b/tests/e2e/models/distilbert-base-uncased-tp4.json
@@ -1,0 +1,54 @@
+{
+  "name": "distilbert-base-uncased-tp4",
+  "trace_id": "IT-E2E-DBERT-TP4-01",
+  "hf_id": "distilbert/distilbert-base-uncased",
+  "bundle": "distilbert-base-uncased-tp4.trtfb",
+  "family": "distilbert",
+  "runtime_strategy": "encoder_only",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 512,
+  "prompt": "The capital of France is Paris.",
+  "max_new_tokens": 0,
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "DistilBERT TP4 coverage. Uses the same checkpoint, prompt, cache length, and thresholds as distilbert-base-uncased."
+}

--- a/tests/e2e/models/dpr-ctx-encoder-tp4.json
+++ b/tests/e2e/models/dpr-ctx-encoder-tp4.json
@@ -1,0 +1,56 @@
+{
+  "name": "dpr-ctx-encoder-tp4",
+  "trace_id": "IT-E2E-DPR-TP4-01",
+  "hf_id": "facebook/dpr-ctx_encoder-single-nq-base",
+  "bundle": "dpr-ctx-encoder-tp4.trtfb",
+  "family": "dpr",
+  "runtime_strategy": "encoder_only",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 256,
+  "prompt": "The capital of France is Paris",
+  "max_new_tokens": 0,
+  "threshold_overrides": {
+    "cls_embedding_cosine": 0.99
+  },
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "DPR TP4 coverage. Uses the same checkpoint, prompt, cache length, and thresholds as dpr-ctx-encoder."
+}

--- a/tests/e2e/models/fnet-base-tp4.json
+++ b/tests/e2e/models/fnet-base-tp4.json
@@ -1,0 +1,61 @@
+{
+  "name": "fnet-base-tp4",
+  "trace_id": "IT-E2E-FNET-TP4-01",
+  "hf_id": "google/fnet-base",
+  "bundle": "fnet-base-tp4.trtfb",
+  "family": "fnet",
+  "runtime_strategy": "encoder_only",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 256,
+  "prompt": "The capital of France is Paris.",
+  "max_new_tokens": 1,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "trust_remote_code": false,
+  "notes": "FNet TP4 coverage. Uses the same checkpoint, prompt, cache length, and thresholds as fnet-base.",
+  "core": false,
+  "threshold_overrides": {
+    "cls_embedding_cosine": 0.6,
+    "cls_embedding_l2": 10.0
+  },
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ]
+}

--- a/tests/e2e/models/modernbert-base-tp4.json
+++ b/tests/e2e/models/modernbert-base-tp4.json
@@ -1,0 +1,57 @@
+{
+  "name": "modernbert-base-tp4",
+  "trace_id": "IT-E2E-MODERNBERT-TP4-01",
+  "hf_id": "answerdotai/ModernBERT-base",
+  "bundle": "modernbert-base-tp4.trtfb",
+  "family": "modernbert",
+  "runtime_strategy": "encoder_only",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 256,
+  "prompt": "The capital of France is Paris.",
+  "max_new_tokens": 1,
+  "threshold_overrides": {
+    "cls_embedding_cosine": 0.995,
+    "cls_embedding_l2": 5.0
+  },
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "ModernBERT TP4 coverage. Uses the same checkpoint, prompt, cache length, and thresholds as modernbert-base."
+}

--- a/tests/e2e/models/roberta-base-tp4.json
+++ b/tests/e2e/models/roberta-base-tp4.json
@@ -1,0 +1,54 @@
+{
+  "name": "roberta-base-tp4",
+  "trace_id": "IT-E2E-ROBBS-TP4-01",
+  "hf_id": "FacebookAI/roberta-base",
+  "bundle": "roberta-base-tp4.trtfb",
+  "family": "roberta",
+  "runtime_strategy": "encoder_only",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 512,
+  "prompt": "The capital of France is Paris.",
+  "max_new_tokens": 0,
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "RoBERTa base TP4 coverage. Uses the same checkpoint, prompt, cache length, and thresholds as roberta-base."
+}

--- a/tests/e2e/models/roberta-large-tp4.json
+++ b/tests/e2e/models/roberta-large-tp4.json
@@ -1,0 +1,54 @@
+{
+  "name": "roberta-large-tp4",
+  "trace_id": "IT-E2E-ROBLG-TP4-01",
+  "hf_id": "FacebookAI/roberta-large",
+  "bundle": "roberta-large-tp4.trtfb",
+  "family": "roberta",
+  "runtime_strategy": "encoder_only",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 512,
+  "prompt": "The capital of France is Paris.",
+  "max_new_tokens": 0,
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "RoBERTa large TP4 coverage. Uses the same checkpoint, prompt, cache length, and thresholds as roberta-large."
+}

--- a/tests/e2e/models/xlm-roberta-base-tp4.json
+++ b/tests/e2e/models/xlm-roberta-base-tp4.json
@@ -1,0 +1,54 @@
+{
+  "name": "xlm-roberta-base-tp4",
+  "trace_id": "IT-E2E-XLMRB-TP4-01",
+  "hf_id": "FacebookAI/xlm-roberta-base",
+  "bundle": "xlm-roberta-base-tp4.trtfb",
+  "family": "roberta",
+  "runtime_strategy": "encoder_only",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 512,
+  "prompt": "The capital of France is Paris.",
+  "max_new_tokens": 0,
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "XLM-RoBERTa base TP4 coverage. Uses the same checkpoint, prompt, cache length, and thresholds as xlm-roberta-base."
+}

--- a/tests/e2e/models/xlnet-base-tp4.json
+++ b/tests/e2e/models/xlnet-base-tp4.json
@@ -1,0 +1,57 @@
+{
+  "name": "xlnet-base-tp4",
+  "trace_id": "IT-E2E-XLNET-TP4-01",
+  "hf_id": "xlnet/xlnet-base-cased",
+  "bundle": "xlnet-base-tp4.trtfb",
+  "family": "xlnet",
+  "runtime_strategy": "encoder_only",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 256,
+  "prompt": "The capital of France is Paris",
+  "max_new_tokens": 0,
+  "threshold_overrides": {
+    "cls_embedding_cosine": 0.95,
+    "cls_embedding_l2": 100.0
+  },
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "XLNet TP4 coverage. Uses the same checkpoint, prompt, cache length, and thresholds as xlnet-base."
+}

--- a/tests/e2e_harness/runners/encoder_only.py
+++ b/tests/e2e_harness/runners/encoder_only.py
@@ -14,6 +14,14 @@ import time
 
 from .. import save_full_stderr
 from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
+from .text_generation import (
+    _distributed_runtime_config,
+    _ensure_distributed_runtime_env,
+    _extract_rank_zero_stdout,
+    _maybe_start_gpu_memory_sampler,
+    _strip_mpi_stream_tags,
+    _wrap_distributed_command,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,12 +53,33 @@ class EncoderOnlyRunner:
         if ctx.ld_library_path:
             env["LD_LIBRARY_PATH"] = ctx.ld_library_path
 
+        distributed_runtime = _distributed_runtime_config(case)
+        if distributed_runtime:
+            _ensure_distributed_runtime_env(case, ctx, env)
+            extra_env = distributed_runtime.get("env", {})
+            if isinstance(extra_env, dict):
+                env.update({str(k): str(v) for k, v in extra_env.items()})
+            cmd = _wrap_distributed_command(cmd, case, env)
+
         logger.info("Running encoder-only: %s", " ".join(cmd))
         t0 = time.monotonic()
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, env=env, timeout=600,
-        )
+        memory_sampler = _maybe_start_gpu_memory_sampler(
+            distributed_runtime, ctx, case, env)
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, env=env, timeout=600,
+            )
+        finally:
+            memory_meta = memory_sampler.stop() if memory_sampler is not None else None
         elapsed = time.monotonic() - t0
+        stdout_for_parse = (
+            _extract_rank_zero_stdout(result.stdout)
+            if distributed_runtime else result.stdout.strip()
+        )
+        stderr_for_display = (
+            _strip_mpi_stream_tags(result.stderr)
+            if distributed_runtime else result.stderr
+        )
 
         if result.returncode != 0:
             truncated, log_path = save_full_stderr(
@@ -62,18 +91,26 @@ class EncoderOnlyRunner:
                 msg += f" (full stderr: {log_path})"
             raise RuntimeError(msg)
 
-        data = _parse_encoder_output(result.stdout.strip())
+        data = _parse_encoder_output(stdout_for_parse)
+
+        metadata = {
+            "command": cmd,
+            "returncode": result.returncode,
+            "stdout": result.stdout or "",
+            "stderr": result.stderr or "",
+        }
+        if distributed_runtime:
+            metadata["distributed_runtime"] = distributed_runtime
+            metadata["rank_zero_stdout"] = stdout_for_parse
+            metadata["stderr_without_mpi_tags"] = stderr_for_display
+        if memory_meta is not None:
+            metadata["gpu_memory"] = memory_meta
 
         return StageOutput(
             stage_name=stage.name,
             data=data,
             timing_s=elapsed,
-            metadata={
-                "command": cmd,
-                "returncode": result.returncode,
-                "stdout": result.stdout or "",
-                "stderr": result.stderr or "",
-            },
+            metadata=metadata,
         )
 
 


### PR DESCRIPTION
## Background
Encoder-only tensor-parallel support started with BERT, but the same runtime and harness changes are shared by closely related encoder families. This PR now intentionally combines the similar encoder-family TP changes so reviewers can review the shared encoder runtime path once instead of across several stacked PRs.

## Exit Criteria
- Add tensor-parallel build support without changing single-device builder behavior.
- Keep TP-specific graph logic in family-local `tp_builder.py` files that follow the corresponding single-device builder structure.
- Add multi-device E2E manifests with the same thresholds and user-facing contracts as the single-device manifests.
- Cover BERT, RoBERTa, DistilBERT, MPNet, DPR, FNet, ModernBERT, DeBERTa, ConvBERT, and XLNet family cases.

## Implementation
- Teach encoder-only C++ runtime loading to initialize the TP group, load `engine_plan_tp_rank{rank}`, and attach the distributed communicator.
- Teach the encoder-only E2E runner to launch `distributed_runtime` cases through `mpirun`, sample distributed GPU memory, and parse rank-0 output.
- Route each family plugin with `parallel.mode=tensor_parallel` through a family-local TP builder.
- Shard attention and FFN projections by TP rank and join row-parallel outputs with distributed all-reduce.
- Add focused builder tests for sharding validation, plugin routing, and unsupported TP shapes.
- Add E2E manifests for `bert-base-uncased-tp4`, `roberta-base-tp4`, `roberta-large-tp4`, `xlm-roberta-base-tp4`, `camembert-base-tp4`, `distilbert-base-uncased-tp4`, `all-mpnet-base-v2-tp4`, `dpr-ctx-encoder-tp4`, `fnet-base-tp4`, `modernbert-base-tp4`, `deberta-base-tp4`, `convbert-base-tp2`, and `xlnet-base-tp4`.

## Validation
- `PYTHONPATH=python:. /opt/venv/bin/python -m pytest -q tests/builder/test_engine_bert_tp.py tests/builder/test_manifest_validation.py`: passed, `33 passed in 0.16s`.
- `cmake -S . -B build-bert-tp4 -G Ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so -DTRTMC_CUDA_INCLUDE_DIR=/usr/local/cuda/include -DTRTMC_CUDART_LIBRARY=/usr/local/cuda/lib64/libcudart.so && cmake --build build-bert-tp4 --target trtmc trtmc_backend_trt -j`: passed in the B200 Docker image.
- `CUDA_VISIBLE_DEVICES=0,1,2,3 PYTHONPATH=python:. /opt/venv/bin/python -m pytest -q "tests/test_e2e.py::test_e2e[bert-base-uncased-tp4]" -v --multi-device-only --engine-dir /tmp/trtmc-storage/bert-tp4/engines --trtmc-binary ./build-bert-tp4/trtmc --hf-python /opt/venv/bin/python --e2e-artifacts-dir /tmp/trtmc-storage/bert-tp4/artifacts --rebuild-engines -s -p no:cacheprovider`: passed, `1 passed in 81.83s`.
- Individual rebuilt single-manifest E2E runs passed in the B200 Docker image for `roberta-base-tp4`, `roberta-large-tp4`, `xlm-roberta-base-tp4`, `camembert-base-tp4`, `distilbert-base-uncased-tp4`, `all-mpnet-base-v2-tp4`, `dpr-ctx-encoder-tp4`, `fnet-base-tp4`, `modernbert-base-tp4`, `deberta-base-tp4`, `convbert-base-tp2`, and `xlnet-base-tp4`.
- `CUDA_VISIBLE_DEVICES=0,1,2,3 PYTHONPATH=python:. /opt/venv/bin/python -m pytest -q tests/builder/test_engine_bert_tp.py tests/builder/test_engine_roberta_tp.py tests/builder/test_engine_distilbert_tp.py tests/builder/test_engine_mpnet_tp.py tests/builder/test_engine_dpr_tp.py tests/builder/test_engine_fnet_tp.py tests/builder/test_engine_modernbert_tp.py tests/builder/test_engine_deberta_tp.py tests/builder/test_engine_convbert_tp.py tests/builder/test_engine_xlnet_tp.py tests/builder/test_manifest_validation.py`: passed in the B200 Docker image, `94 passed, 1 warning in 0.58s`.

## Notes
- ConvBERT uses TP2 because its effective attention-head layout is not divisible by TP4.
- Ruff was not available in the B200 validation image (`ruff: command not found`; `/opt/venv/bin/python: No module named ruff`), so focused lint was not run there.
