### PR TITLE
feat(qwen-vl): add TP decoder support

### DIFF
--- a/python/tensorrt_model_connect/families/qwen_vl/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/decoder_tp_builder.py
@@ -1,0 +1,419 @@
+"""Tensor-parallel Qwen-VL text decoder builder.
+
+This mirrors the single-device Qwen-VL decoder paths while adding only tensor
+parallel projection sharding and distributed ALL_REDUCE joins. It keeps the VL
+``input_embed`` override used by Qwen2.5-VL and optionally injects Qwen3-VL
+DeepStack features after attention residuals.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_blocks
+from ... import graph_ops
+from ...parallel_config import (
+    add_all_reduce_sum,
+    normalize_parallel_config,
+    shard_standard_decoder_weights,
+)
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+
+
+def _mark_debug_output(network: trt.INetworkDefinition, tensor: trt.ITensor, name: str) -> None:
+    cast = network.add_cast(tensor, trt.float32)
+    out = cast.get_output(0)
+    out.name = name
+    network.mark_output(out)
+
+
+def _ensure_tp_metadata(config: "ModelConfig", weights: "WeightDict") -> "WeightDict":
+    if "_kv_attention_size" in weights:
+        return weights
+    copied = type(weights)(weights)
+    copied["_kv_attention_size"] = int(weights.get("_attention_size", config.attention_size))
+    return copied
+
+
+def _apply_norm(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    gamma: np.ndarray,
+    beta: np.ndarray | None,
+    eps_tensor: trt.ITensor,
+    norm_type: str,
+    dtype: np.dtype = np.float32,
+    eps: float | None = None,
+) -> trt.ITensor:
+    return graph_blocks.apply_norm(
+        network, inp, hidden_size, gamma, beta, eps_tensor, norm_type,
+        dtype=dtype, eps=eps)
+
+
+def build_qwen_vl_tp_decoder_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    norm_type: str = "rmsnorm",
+    mlp_type: str = "swiglu",
+    position_type: str = "rope",
+    activation: str = "silu",
+    partial_rotary_factor: float = 1.0,
+    interleaved_rope: bool = False,
+    parallel_residual: bool = False,
+    scale_attn_weights: bool = True,
+    embed_input: bool = True,
+    deepstack_num_levels: int = 0,
+    verbose: bool = False,
+    debug_layer_outputs: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build one rank-local Qwen-VL text decoder engine."""
+    if mlp_type != "swiglu":
+        raise NotImplementedError("Qwen-VL tensor-parallel builds support SwiGLU MLPs only")
+
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError("Qwen-VL tensor-parallel builder requires an enabled parallel config")
+    if parallel.rank < 0:
+        raise ValueError("Qwen-VL tensor-parallel engine build requires a concrete rank")
+
+    weights = _ensure_tp_metadata(config, weights)
+    weights = shard_standard_decoder_weights(config, weights, parallel)
+
+    attention_size = int(weights.get("_attention_size", config.attention_size))
+    mlp_size = int(weights.get("_mlp_size", config.intermediate_size))
+    hidden = config.hidden_size
+    vocab = config.vocab_size
+    num_layers = config.num_hidden_layers
+    num_heads = config.num_attention_heads // parallel.tp_size
+    num_kv_heads = config.num_key_value_heads // parallel.tp_size
+    head_dim = attention_size // num_heads
+    kv_attention_size = graph_blocks.infer_kv_attention_size(
+        weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
+    attention_window = max_cache_length + 1
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    if precision == "fp16":
+        work_np_dtype = np.float16
+        work_trt_dtype = trt.float16
+    elif precision == "bf16":
+        work_np_dtype = np.float16
+        work_trt_dtype = trt.bfloat16
+    else:
+        work_np_dtype = np.float32
+        work_trt_dtype = trt.float32
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    position_id = network.add_input("position_id", trt.int32, (1,))
+    attention_mask = network.add_input("attention_mask", trt.float32, (1, attention_window))
+
+    input_embed_tensor = None
+    use_input_embed_tensor = None
+    if embed_input:
+        input_embed_tensor = network.add_input("input_embed", work_trt_dtype, (1, hidden))
+        use_input_embed_tensor = network.add_input("use_input_embed", trt.float32, (1,))
+
+    deepstack_embed_inputs: list[trt.ITensor] = []
+    deepstack_active_tensor = None
+    if deepstack_num_levels > 0:
+        for level in range(deepstack_num_levels):
+            deepstack_embed_inputs.append(network.add_input(
+                f"deepstack_embed_{level}", work_trt_dtype, (1, hidden)))
+        deepstack_active_tensor = network.add_input(
+            "deepstack_active", trt.float32, (1,))
+
+    cache_k_inputs = []
+    cache_v_inputs = []
+    for i in range(num_layers):
+        cache_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_k", i),
+            work_trt_dtype,
+            (max_cache_length, kv_attention_size),
+        ))
+        cache_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_v", i),
+            work_trt_dtype,
+            (max_cache_length, kv_attention_size),
+        ))
+
+    if work_trt_dtype != trt.float32:
+        attention_mask = network.add_cast(attention_mask, work_trt_dtype).get_output(0)
+
+    def _cast_work_dtype(tensor: trt.ITensor) -> trt.ITensor:
+        if tensor.dtype == work_trt_dtype:
+            return tensor
+        return network.add_cast(tensor, work_trt_dtype).get_output(0)
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), weights["embedding"], dtype=work_np_dtype)
+
+    cos_half_tensor = None
+    sin_half_tensor = None
+    rotary_embedding_dim = int(head_dim * partial_rotary_factor)
+    if position_type == "rope":
+        graph_ops.validate_native_rope_dim(rotary_embedding_dim)
+        cos_half_np = graph_ops.make_rope_table_half_dim(
+            attention_window, head_dim, config.rope_theta, True,
+            partial_rotary_factor, interleaved=interleaved_rope)
+        sin_half_np = graph_ops.make_rope_table_half_dim(
+            attention_window, head_dim, config.rope_theta, False,
+            partial_rotary_factor, interleaved=interleaved_rope)
+        cos_half_tensor = _cast_work_dtype(
+            graph_ops.add_constant(network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype))
+        sin_half_tensor = _cast_work_dtype(
+            graph_ops.add_constant(network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype))
+    else:
+        raise NotImplementedError("Qwen-VL tensor-parallel builds require RoPE")
+
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=work_np_dtype),
+        dtype=work_np_dtype)
+    attn_scale = (1.0 / np.sqrt(max(head_dim, 1))) if scale_attn_weights else 1.0
+
+    token_embed = network.add_gather(embedding_table, token_id, 0).get_output(0)
+    if embed_input and input_embed_tensor is not None and use_input_embed_tensor is not None:
+        flag_broadcast = network.add_shuffle(use_input_embed_tensor)
+        flag_broadcast.reshape_dims = (1, 1)
+        flag_for_math = flag_broadcast.get_output(0)
+        if work_trt_dtype != trt.float32:
+            flag_for_math = network.add_cast(flag_for_math, work_trt_dtype).get_output(0)
+        one_const = graph_ops.add_constant(
+            network, (1, 1), np.array([1.0], dtype=work_np_dtype),
+            dtype=work_np_dtype)
+        inv_flag = network.add_elementwise(
+            one_const, flag_for_math, trt.ElementWiseOperation.SUB).get_output(0)
+        tok_part = network.add_elementwise(
+            inv_flag, token_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        embed_part = network.add_elementwise(
+            flag_for_math, input_embed_tensor, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden_state = network.add_elementwise(
+            tok_part, embed_part, trt.ElementWiseOperation.SUM).get_output(0)
+    else:
+        hidden_state = token_embed
+
+    if hidden_state.dtype != work_trt_dtype:
+        hidden_state = network.add_cast(hidden_state, work_trt_dtype).get_output(0)
+
+    if debug_layer_outputs:
+        _mark_debug_output(network, hidden_state, "debug_embed")
+
+    present_k_outputs = []
+    present_v_outputs = []
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        result = _add_tp_decoder_layer(
+            network=network,
+            hidden=hidden_state,
+            cache_k=cache_k_inputs[layer_idx],
+            cache_v=cache_v_inputs[layer_idx],
+            attention_mask=attention_mask,
+            position_id=position_id,
+            attention_scale=attn_scale,
+            eps_tensor=eps_tensor,
+            eps=config.rms_norm_eps,
+            weights=weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            attention_size=attention_size,
+            kv_attention_size=kv_attention_size,
+            mlp_size=mlp_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            max_cache_length=max_cache_length,
+            norm_type=norm_type,
+            activation=activation,
+            parallel_residual=parallel_residual,
+            dtype=work_np_dtype,
+            quant_ctx=quant_ctx,
+            cos_half_tensor=cos_half_tensor,
+            sin_half_tensor=sin_half_tensor,
+            rotary_embedding_dim=rotary_embedding_dim,
+            interleaved_rope=interleaved_rope,
+            tp_size=parallel.tp_size,
+            deepstack_embed=(
+                deepstack_embed_inputs[layer_idx]
+                if layer_idx < len(deepstack_embed_inputs)
+                else None
+            ),
+            deepstack_active=deepstack_active_tensor,
+        )
+        hidden_state = result["hidden"]
+        present_k_outputs.append(result["present_k"])
+        present_v_outputs.append(result["present_v"])
+        if debug_layer_outputs:
+            _mark_debug_output(network, result["post_attn"], f"debug_post_attn_{layer_idx}")
+            _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
+
+    final_norm = weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = _apply_norm(
+            network, hidden_state, hidden, final_norm,
+            weights.get("final_norm_beta"), eps_tensor, norm_type,
+            dtype=work_np_dtype, eps=config.rms_norm_eps)
+
+    out_vocab = weights["w_out"].shape[1] if isinstance(weights["w_out"], np.ndarray) else vocab
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, out_vocab, weights["w_out"], dtype=work_np_dtype)
+    lm_bias = weights.get("lm_head_bias")
+    if lm_bias is not None:
+        logits = graph_ops.add_bias_sum(network, logits, out_vocab, lm_bias, dtype=work_np_dtype)
+    else:
+        logits = graph_ops.add_bias_sum(
+            network, logits, out_vocab, np.zeros(out_vocab, dtype=work_np_dtype),
+            dtype=work_np_dtype)
+    if work_trt_dtype != trt.float32:
+        logits = network.add_cast(logits, trt.float32).get_output(0)
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for i in range(num_layers):
+        present_k_outputs[i].name = graph_ops.layer_tensor_name("present_k", i)
+        present_v_outputs[i].name = graph_ops.layer_tensor_name("present_v", i)
+        network.mark_output(present_k_outputs[i])
+        network.mark_output(present_v_outputs[i])
+
+    if verbose:
+        print(
+            f"[trtmc build] Building Qwen-VL TP rank "
+            f"{parallel.rank}/{parallel.tp_size} ({num_layers}L, h={hidden}, "
+            f"local_heads={num_heads}, local_attn={attention_size}, "
+            f"local_mlp={mlp_size}, cache={max_cache_length}, precision={precision}) ...",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT Qwen-VL tensor-parallel decoder build failed")
+    return bytes(plan)
+
+
+def _add_tp_decoder_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    attention_mask: trt.ITensor,
+    position_id: trt.ITensor,
+    attention_scale: float | None,
+    eps_tensor: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    attention_size: int,
+    kv_attention_size: int,
+    mlp_size: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    max_cache_length: int,
+    norm_type: str,
+    activation: str,
+    parallel_residual: bool,
+    dtype: np.dtype,
+    quant_ctx,
+    cos_half_tensor: trt.ITensor,
+    sin_half_tensor: trt.ITensor,
+    rotary_embedding_dim: int,
+    interleaved_rope: bool,
+    tp_size: int,
+    deepstack_embed: trt.ITensor | None = None,
+    deepstack_active: trt.ITensor | None = None,
+    eps: float | None = None,
+) -> dict[str, trt.ITensor]:
+    attn = graph_blocks.add_attention_block(
+        network, hidden, cache_k, cache_v, attention_mask, position_id,
+        weights=weights, prefix=prefix,
+        hidden_size=hidden_size, attention_size=attention_size,
+        kv_attention_size=kv_attention_size,
+        num_heads=num_heads, num_kv_heads=num_kv_heads, head_dim=head_dim,
+        max_cache_length=max_cache_length,
+        attention_scale=attention_scale,
+        eps_tensor=eps_tensor, eps=eps,
+        norm_type=norm_type, position_type="rope",
+        alibi_slopes_tensor=None,
+        alibi_indices_tensor=None,
+        dtype=dtype,
+        quant_ctx=quant_ctx,
+        layer_prefix=prefix,
+        cos_half_tensor=cos_half_tensor,
+        sin_half_tensor=sin_half_tensor,
+        rotary_embedding_dim=rotary_embedding_dim,
+        interleaved_rope=interleaved_rope,
+        ffi_attention_kernel=None,
+        dynamic_kv_cache=False,
+    )
+    attn_out = add_all_reduce_sum(network, attn["attn_out"], tp_size)
+
+    if parallel_residual:
+        post_attn_norm_w = weights.get(f"{prefix}.post_attn_norm")
+        if post_attn_norm_w is not None:
+            norm2 = _apply_norm(
+                network, hidden, hidden_size,
+                post_attn_norm_w,
+                weights.get(f"{prefix}.post_attn_norm_beta"),
+                eps_tensor, norm_type, dtype=dtype, eps=eps)
+        else:
+            norm2 = attn["normed"]
+    else:
+        residual1 = network.add_elementwise(
+            hidden, attn_out, trt.ElementWiseOperation.SUM).get_output(0)
+        if deepstack_embed is not None and deepstack_active is not None:
+            ds_active_broadcast = network.add_shuffle(deepstack_active)
+            ds_active_broadcast.reshape_dims = (1, 1)
+            active = ds_active_broadcast.get_output(0)
+            if active.dtype != deepstack_embed.dtype:
+                active = network.add_cast(active, deepstack_embed.dtype).get_output(0)
+            ds_scaled = network.add_elementwise(
+                deepstack_embed, active, trt.ElementWiseOperation.PROD).get_output(0)
+            residual1 = network.add_elementwise(
+                residual1, ds_scaled, trt.ElementWiseOperation.SUM).get_output(0)
+        norm2 = _apply_norm(
+            network, residual1, hidden_size,
+            weights[f"{prefix}.post_attn_norm"],
+            weights.get(f"{prefix}.post_attn_norm_beta"),
+            eps_tensor, norm_type, dtype=dtype, eps=eps)
+
+    mlp_out = graph_blocks.add_swiglu_mlp(
+        network, norm2, weights=weights, prefix=prefix,
+        hidden_size=hidden_size, mlp_size=mlp_size, dtype=dtype,
+        quant_ctx=quant_ctx, layer_prefix=prefix)
+    mlp_out = add_all_reduce_sum(network, mlp_out, tp_size)
+
+    if parallel_residual:
+        sum_attn = network.add_elementwise(
+            hidden, attn_out, trt.ElementWiseOperation.SUM).get_output(0)
+        residual2 = network.add_elementwise(
+            sum_attn, mlp_out, trt.ElementWiseOperation.SUM).get_output(0)
+        post_attn_tensor = sum_attn
+    else:
+        residual2 = network.add_elementwise(
+            residual1, mlp_out, trt.ElementWiseOperation.SUM).get_output(0)
+        post_attn_tensor = residual1
+
+    return {
+        "hidden": residual2,
+        "post_attn": post_attn_tensor,
+        "present_k": attn["present_k"],
+        "present_v": attn["present_v"],
+    }

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -29,6 +29,8 @@ from ...checkpoint_mapper import (
     _has_tensor,
     _transpose_2d,
 )
+from ...parallel_config import normalize_parallel_config
+from .decoder_tp_builder import build_qwen_vl_tp_decoder_engine
 from .standard_decoder_builder import build_standard_decoder_engine
 from ... import graph_ops
 from ... import graph_blocks
@@ -69,15 +71,37 @@ class QwenVLPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
         debug_layer_outputs: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
         if _is_qwen3_vl(config):
             vc = config.raw.get("vision_config", {})
             deepstack_indexes = vc.get("deepstack_visual_indexes", [])
+            if parallel.enabled:
+                return build_qwen_vl_tp_decoder_engine(
+                    config, weights, max_cache_length,
+                    precision=precision,
+                    quant_ctx=quant_ctx,
+                    embed_input=True,
+                    deepstack_num_levels=len(deepstack_indexes),
+                    verbose=verbose,
+                    debug_layer_outputs=debug_layer_outputs,
+                    parallel_config=parallel)
             return _build_qwen3_vl_decoder(
                 config, weights, max_cache_length,
                 deepstack_num_levels=len(deepstack_indexes),
                 quant_ctx=quant_ctx, verbose=verbose,
                 debug_layer_outputs=debug_layer_outputs)
+        if parallel.enabled:
+            return build_qwen_vl_tp_decoder_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                embed_input=True,
+                deepstack_num_levels=0,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                parallel_config=parallel)
         return build_standard_decoder_engine(
             config, weights, max_cache_length, verbose=verbose,
             quant_ctx=quant_ctx, embed_input=True,
@@ -203,6 +227,7 @@ def _load_qwen3_vl_weights(model_dir: str, config: ModelConfig) -> WeightDict:
 
     attention_size = 0
     mlp_size = 0
+    kv_attention_size = 0
 
     for layer_idx in range(num_layers):
         prefix = f"layer.{layer_idx}"
@@ -238,6 +263,8 @@ def _load_qwen3_vl_weights(model_dir: str, config: ModelConfig) -> WeightDict:
         weights[f"{prefix}.w_k"] = k_t
         weights[f"{prefix}.w_v"] = v_t
         weights[f"{prefix}.w_o"] = o_t
+        if kv_attention_size == 0:
+            kv_attention_size = k_t.shape[1]
 
         # Optional per-head q/k norms (Qwen3)
         q_norm_key = f"{hf_prefix}.self_attn.q_norm.weight"
@@ -278,6 +305,7 @@ def _load_qwen3_vl_weights(model_dir: str, config: ModelConfig) -> WeightDict:
         weights["w_out"] = _transpose_2d(embedding.copy(), "embedding_tied")
 
     weights["_attention_size"] = attention_size
+    weights["_kv_attention_size"] = kv_attention_size
     weights["_mlp_size"] = mlp_size
 
     return weights

--- a/src/runtime/models/vision_language/pipeline.cpp
+++ b/src/runtime/models/vision_language/pipeline.cpp
@@ -74,6 +74,22 @@ int32_t infer_feature_dim(const TrtModule& encoder, int32_t configured_dim) {
     return 0;
 }
 
+std::vector<const float*>
+select_deepstack_feature_pointers(const std::vector<std::vector<float>>& deepstack_features,
+                                  int32_t feature_index, int32_t feature_dim) {
+    std::vector<const float*> embeds;
+    embeds.reserve(deepstack_features.size());
+    for (const auto& deepstack : deepstack_features) {
+        const int32_t count =
+            static_cast<int32_t>(deepstack.size() / static_cast<std::size_t>(feature_dim));
+        embeds.push_back(feature_index < count
+                             ? deepstack.data() +
+                                   static_cast<std::size_t>(feature_index) * feature_dim
+                             : nullptr);
+    }
+    return embeds;
+}
+
 } // namespace
 
 std::pair<int32_t, int32_t> VLPipeline::resolve_gen_limits(const GenerateConfig& cfg) const {
@@ -113,8 +129,8 @@ TextResult VLPipeline::generate(const std::string& prompt, const float* image_pi
     auto input_ids = tokenizer_->encode(format_vl_prompt(prompt, vl_preprocess_));
     auto [max_new, eos] = resolve_gen_limits(cfg);
     auto sp_vl = sampling_params_from_config(cfg, eos);
-    auto out = generate_vl_from_ids(input_ids, features, deepstack_features, nf, dim, max_new,
-                                    sp_vl);
+    auto out =
+        generate_vl_from_ids(input_ids, features, deepstack_features, nf, dim, max_new, sp_vl);
 
     std::vector<int32_t> new_tokens(out.begin() + static_cast<std::ptrdiff_t>(input_ids.size()),
                                     out.end());
@@ -168,13 +184,10 @@ std::vector<int32_t> VLPipeline::generate_from_ids(const std::vector<int32_t>& i
     return output;
 }
 
-std::vector<int32_t> VLPipeline::generate_vl_from_ids(const std::vector<int32_t>& input_ids,
-                                                      const std::vector<float>& image_features,
-                                                      const std::vector<std::vector<float>>&
-                                                          deepstack_features,
-                                                      int32_t num_features, int32_t feature_dim,
-                                                      int32_t max_new_tokens,
-                                                      const SamplingParams& params) {
+std::vector<int32_t> VLPipeline::generate_vl_from_ids(
+    const std::vector<int32_t>& input_ids, const std::vector<float>& image_features,
+    const std::vector<std::vector<float>>& deepstack_features, int32_t num_features,
+    int32_t feature_dim, int32_t max_new_tokens, const SamplingParams& params) {
     if (max_new_tokens == 0 || input_ids.empty())
         return input_ids;
 
@@ -192,48 +205,46 @@ std::vector<int32_t> VLPipeline::generate_vl_from_ids(const std::vector<int32_t>
 
     std::vector<float> logits;
     int32_t feature_index = 0;
-    int32_t image_token = config_.image_token_id;
-
-    // Prefill: run each token with vision embedding injection at image tokens.
-    auto prefill_one = [&](int32_t tid) {
-        if (tid == image_token && feature_index < num_features) {
-            const int32_t used_feature_index = feature_index;
-            const float* embed =
-                image_features.data() + static_cast<std::size_t>(feature_index) * feature_dim;
-            std::vector<const float*> deepstack_embeds;
-            deepstack_embeds.reserve(deepstack_features.size());
-            for (const auto& deepstack : deepstack_features) {
-                const int32_t deepstack_count =
-                    static_cast<int32_t>(deepstack.size() / static_cast<std::size_t>(feature_dim));
-                deepstack_embeds.push_back(
-                    used_feature_index < deepstack_count
-                        ? deepstack.data() +
-                              static_cast<std::size_t>(used_feature_index) * feature_dim
-                        : nullptr);
-            }
-            run_text_step_with_embed(tid, embed, 1.0F, deepstack_embeds,
-                                     deepstack_embeds.empty() ? 0.0F : 1.0F, logits);
-            ++feature_index;
-        } else {
-            run_text_step_with_embed(tid, nullptr, 0.0F, {}, 0.0F, logits);
-        }
-    };
 
     for (const auto& tid : input_ids)
-        prefill_one(tid);
+        run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
+                             feature_index, logits);
 
-    // Autoregressive decode
     std::vector<int32_t> output = input_ids;
+    run_vl_decode_loop(active_sampler, params, output, logits, max_new_tokens);
+    return output;
+}
+
+void VLPipeline::run_vl_prefill_token(int32_t token_id, const std::vector<float>& image_features,
+                                      const std::vector<std::vector<float>>& deepstack_features,
+                                      int32_t num_features, int32_t feature_dim,
+                                      int32_t& feature_index, std::vector<float>& logits) {
+    const bool use_image_embed = token_id == config_.image_token_id && feature_index < num_features;
+    if (!use_image_embed) {
+        run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, logits);
+        return;
+    }
+
+    const float* embed =
+        image_features.data() + static_cast<std::size_t>(feature_index) * feature_dim;
+    const auto deepstack_embeds =
+        select_deepstack_feature_pointers(deepstack_features, feature_index, feature_dim);
+    run_text_step_with_embed(token_id, embed, 1.0F, deepstack_embeds,
+                             deepstack_embeds.empty() ? 0.0F : 1.0F, logits);
+    ++feature_index;
+}
+
+void VLPipeline::run_vl_decode_loop(ISampler* sampler, const SamplingParams& params,
+                                    std::vector<int32_t>& output, std::vector<float>& logits,
+                                    int32_t max_new_tokens) {
     const int32_t vocab_size = static_cast<int32_t>(logits.size());
     for (int32_t step = 0; step < max_new_tokens; ++step) {
-        SampleResult result = active_sampler->sample(logits.data(), vocab_size, params);
+        SampleResult result = sampler->sample(logits.data(), vocab_size, params);
         output.push_back(result.token_id);
         if (result.is_eos)
             break;
         run_text_step(result.token_id, logits);
     }
-
-    return output;
 }
 
 void VLPipeline::run_text_step(int32_t token_id, std::vector<float>& logits) {
@@ -263,8 +274,7 @@ void VLPipeline::run_text_step(int32_t token_id, std::vector<float>& logits) {
 void VLPipeline::run_text_step_with_embed(int32_t token_id, const float* input_embed,
                                           float use_input_embed,
                                           const std::vector<const float*>& deepstack_embeds,
-                                          float deepstack_active,
-                                          std::vector<float>& logits) {
+                                          float deepstack_active, std::vector<float>& logits) {
     if (!text_decoder_->has_input("input_embed")) {
         run_text_step(token_id, logits);
         return;

--- a/src/runtime/models/vision_language/pipeline.cpp
+++ b/src/runtime/models/vision_language/pipeline.cpp
@@ -99,8 +99,9 @@ TextResult VLPipeline::generate(const std::string& prompt, const float* image_pi
         throw std::runtime_error("VLPipeline: image preprocessing failed");
 
     std::vector<float> features;
+    std::vector<std::vector<float>> deepstack_features;
     if (!run_vision_encoder(preprocessed.pixel_values.data(), preprocessed.pixel_values.size(),
-                            features))
+                            features, &deepstack_features))
         throw std::runtime_error("VLPipeline: vision encoder failed");
 
     int32_t dim = infer_feature_dim(*vision_encoder_, config_.vision_output_dim);
@@ -112,7 +113,8 @@ TextResult VLPipeline::generate(const std::string& prompt, const float* image_pi
     auto input_ids = tokenizer_->encode(format_vl_prompt(prompt, vl_preprocess_));
     auto [max_new, eos] = resolve_gen_limits(cfg);
     auto sp_vl = sampling_params_from_config(cfg, eos);
-    auto out = generate_vl_from_ids(input_ids, features, nf, dim, max_new, sp_vl);
+    auto out = generate_vl_from_ids(input_ids, features, deepstack_features, nf, dim, max_new,
+                                    sp_vl);
 
     std::vector<int32_t> new_tokens(out.begin() + static_cast<std::ptrdiff_t>(input_ids.size()),
                                     out.end());
@@ -168,6 +170,8 @@ std::vector<int32_t> VLPipeline::generate_from_ids(const std::vector<int32_t>& i
 
 std::vector<int32_t> VLPipeline::generate_vl_from_ids(const std::vector<int32_t>& input_ids,
                                                       const std::vector<float>& image_features,
+                                                      const std::vector<std::vector<float>>&
+                                                          deepstack_features,
                                                       int32_t num_features, int32_t feature_dim,
                                                       int32_t max_new_tokens,
                                                       const SamplingParams& params) {
@@ -193,12 +197,25 @@ std::vector<int32_t> VLPipeline::generate_vl_from_ids(const std::vector<int32_t>
     // Prefill: run each token with vision embedding injection at image tokens.
     auto prefill_one = [&](int32_t tid) {
         if (tid == image_token && feature_index < num_features) {
+            const int32_t used_feature_index = feature_index;
             const float* embed =
                 image_features.data() + static_cast<std::size_t>(feature_index) * feature_dim;
-            run_text_step_with_embed(tid, embed, 1.0F, logits);
+            std::vector<const float*> deepstack_embeds;
+            deepstack_embeds.reserve(deepstack_features.size());
+            for (const auto& deepstack : deepstack_features) {
+                const int32_t deepstack_count =
+                    static_cast<int32_t>(deepstack.size() / static_cast<std::size_t>(feature_dim));
+                deepstack_embeds.push_back(
+                    used_feature_index < deepstack_count
+                        ? deepstack.data() +
+                              static_cast<std::size_t>(used_feature_index) * feature_dim
+                        : nullptr);
+            }
+            run_text_step_with_embed(tid, embed, 1.0F, deepstack_embeds,
+                                     deepstack_embeds.empty() ? 0.0F : 1.0F, logits);
             ++feature_index;
         } else {
-            run_text_step_with_embed(tid, nullptr, 0.0F, logits);
+            run_text_step_with_embed(tid, nullptr, 0.0F, {}, 0.0F, logits);
         }
     };
 
@@ -244,7 +261,10 @@ void VLPipeline::run_text_step(int32_t token_id, std::vector<float>& logits) {
 }
 
 void VLPipeline::run_text_step_with_embed(int32_t token_id, const float* input_embed,
-                                          float use_input_embed, std::vector<float>& logits) {
+                                          float use_input_embed,
+                                          const std::vector<const float*>& deepstack_embeds,
+                                          float deepstack_active,
+                                          std::vector<float>& logits) {
     if (!text_decoder_->has_input("input_embed")) {
         run_text_step(token_id, logits);
         return;
@@ -283,12 +303,32 @@ void VLPipeline::run_text_step_with_embed(int32_t token_id, const float* input_e
 
     // DeepStack: if the engine has deepstack inputs, provide inactive zeros.
     if (text_decoder_->has_input("deepstack_active")) {
-        float ds_active = 0.0F;
         Tensor ds_active_t;
-        ds_active_t.data = &ds_active;
+        ds_active_t.data = &deepstack_active;
         ds_active_t.shape = {1};
         ds_active_t.dtype = DType::kFloat32;
         inputs["deepstack_active"] = ds_active_t;
+
+        std::vector<float> zero_deepstack;
+        for (std::size_t i = 0;; ++i) {
+            const std::string name = "deepstack_embed_" + std::to_string(i);
+            if (!text_decoder_->has_input(name))
+                break;
+
+            const float* deepstack_embed =
+                i < deepstack_embeds.size() ? deepstack_embeds[i] : nullptr;
+            if (deepstack_embed == nullptr) {
+                if (zero_deepstack.empty())
+                    zero_deepstack.resize(static_cast<std::size_t>(embed_dim), 0.0F);
+                deepstack_embed = zero_deepstack.data();
+            }
+
+            Tensor ds_embed_t;
+            ds_embed_t.data = const_cast<float*>(deepstack_embed);
+            ds_embed_t.shape = {1, static_cast<int64_t>(embed_dim)};
+            ds_embed_t.dtype = DType::kFloat32;
+            inputs[name] = ds_embed_t;
+        }
     }
 
     auto outputs = text_decoder_->forward(inputs);
@@ -305,7 +345,8 @@ void VLPipeline::run_text_step_with_embed(int32_t token_id, const float* input_e
 }
 
 bool VLPipeline::run_vision_encoder(const float* pixel_values, std::size_t pixel_count,
-                                    std::vector<float>& image_features) {
+                                    std::vector<float>& image_features,
+                                    std::vector<std::vector<float>>* deepstack_features) {
     if (!vision_encoder_ || !vision_encoder_->ok())
         return false;
 
@@ -341,6 +382,20 @@ bool VLPipeline::run_vision_encoder(const float* pixel_values, std::size_t pixel
     auto n = it->second.numel();
     image_features.resize(static_cast<std::size_t>(n));
     std::memcpy(image_features.data(), it->second.data, n * sizeof(float));
+
+    if (deepstack_features != nullptr) {
+        deepstack_features->clear();
+        for (std::size_t i = 0;; ++i) {
+            const std::string name = "deepstack_features_" + std::to_string(i);
+            auto ds_it = outputs.find(name);
+            if (ds_it == outputs.end())
+                break;
+            auto ds_n = ds_it->second.numel();
+            deepstack_features->emplace_back(static_cast<std::size_t>(ds_n));
+            std::memcpy(deepstack_features->back().data(), ds_it->second.data,
+                        ds_n * sizeof(float));
+        }
+    }
 
     return true;
 }

--- a/src/runtime/models/vision_language/pipeline.h
+++ b/src/runtime/models/vision_language/pipeline.h
@@ -71,22 +71,28 @@ class VLPipeline final : public IPipeline {
                                            int32_t max_new_tokens, const SamplingParams& params);
 
     // VL generation with vision features injected at image token positions.
-    std::vector<int32_t> generate_vl_from_ids(const std::vector<int32_t>& input_ids,
-                                              const std::vector<float>& image_features,
-                                              const std::vector<std::vector<float>>&
-                                                  deepstack_features,
-                                              int32_t num_features, int32_t feature_dim,
-                                              int32_t max_new_tokens, const SamplingParams& params);
+    std::vector<int32_t> generate_vl_from_ids(
+        const std::vector<int32_t>& input_ids, const std::vector<float>& image_features,
+        const std::vector<std::vector<float>>& deepstack_features, int32_t num_features,
+        int32_t feature_dim, int32_t max_new_tokens, const SamplingParams& params);
 
     std::pair<int32_t, int32_t> resolve_gen_limits(const GenerateConfig& cfg) const;
+
+    void run_vl_prefill_token(int32_t token_id, const std::vector<float>& image_features,
+                              const std::vector<std::vector<float>>& deepstack_features,
+                              int32_t num_features, int32_t feature_dim, int32_t& feature_index,
+                              std::vector<float>& logits);
+
+    void run_vl_decode_loop(ISampler* sampler, const SamplingParams& params,
+                            std::vector<int32_t>& output, std::vector<float>& logits,
+                            int32_t max_new_tokens);
 
     void run_text_step(int32_t token_id, std::vector<float>& logits);
 
     // Run a text step with optional vision embedding override.
     void run_text_step_with_embed(int32_t token_id, const float* input_embed, float use_input_embed,
                                   const std::vector<const float*>& deepstack_embeds,
-                                  float deepstack_active,
-                                  std::vector<float>& logits);
+                                  float deepstack_active, std::vector<float>& logits);
 
     // Run vision encoder on preprocessed pixel values.
     bool run_vision_encoder(const float* pixel_values, std::size_t pixel_count,

--- a/src/runtime/models/vision_language/pipeline.h
+++ b/src/runtime/models/vision_language/pipeline.h
@@ -73,6 +73,8 @@ class VLPipeline final : public IPipeline {
     // VL generation with vision features injected at image token positions.
     std::vector<int32_t> generate_vl_from_ids(const std::vector<int32_t>& input_ids,
                                               const std::vector<float>& image_features,
+                                              const std::vector<std::vector<float>>&
+                                                  deepstack_features,
                                               int32_t num_features, int32_t feature_dim,
                                               int32_t max_new_tokens, const SamplingParams& params);
 
@@ -82,11 +84,14 @@ class VLPipeline final : public IPipeline {
 
     // Run a text step with optional vision embedding override.
     void run_text_step_with_embed(int32_t token_id, const float* input_embed, float use_input_embed,
+                                  const std::vector<const float*>& deepstack_embeds,
+                                  float deepstack_active,
                                   std::vector<float>& logits);
 
     // Run vision encoder on preprocessed pixel values.
     bool run_vision_encoder(const float* pixel_values, std::size_t pixel_count,
-                            std::vector<float>& image_features);
+                            std::vector<float>& image_features,
+                            std::vector<std::vector<float>>* deepstack_features = nullptr);
 };
 
 } // namespace trtmc

--- a/src/runtime/models/vision_language/plugin.cpp
+++ b/src/runtime/models/vision_language/plugin.cpp
@@ -5,17 +5,56 @@
 #include "runtime/domains/multimodal/image_preprocessor.h"
 #include "runtime/models/vision_language/pipeline.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
 
+#include <cstddef>
 #include <iostream>
+#include <string>
+#include <vector>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+int32_t dim_at(const std::vector<int64_t>& shape, std::size_t idx) {
+    return shape.size() > idx ? static_cast<int32_t>(shape[idx]) : 0;
+}
+
+int32_t decoder_cache_row_width(const TrtModule& module, const BaseConfig& config) {
+    const int32_t from_engine = dim_at(module.tensor_shape("cache_k_0"), 1);
+    return from_engine > 0 ? from_engine : compute_kv_dim(config);
+}
+
+} // namespace
 
 class VLPlugin final : public IPipelinePlugin {
   public:
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
         load_ffi_kernels_from_bundle(ctx.bundle);
+
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        if (tp_config.enabled)
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
 
         auto shared_stream = std::make_shared<CudaStream>();
         if (!shared_stream->ok())
@@ -25,6 +64,12 @@ class VLPlugin final : public IPipelinePlugin {
         opts.stream = shared_stream->get();
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
+
+        auto decoder_opts = opts;
+        if (tp_config.enabled) {
+            decoder_opts.distributed_communicator = tp_group.communicator;
+            decoder_opts.distributed_owner = tp_group.owner;
+        }
 
         // Build KvCacheNames from IoMap patterns.
         const auto& io = ctx.config.io_map;
@@ -36,12 +81,15 @@ class VLPlugin final : public IPipelinePlugin {
             kv_names.present_v.push_back(expand_layer_name(io.present_v_pattern, i));
         }
 
+        const std::string engine_section =
+            tp_config.enabled ? tp_engine_section_name(tp_group.rank) : std::string("engine_plan");
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "engine_plan", opts);
+            ctx.backend, find_section(ctx.bundle, engine_section), engine_section.c_str(),
+            decoder_opts);
         loaded.module->keep_alive(shared_stream);
 
         cudaStream_t stream = loaded.module->stream();
-        int32_t kv_dim = compute_kv_dim(ctx.config);
+        int32_t kv_dim = decoder_cache_row_width(*loaded.module, ctx.config);
         DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
         std::unique_ptr<IInferenceState> state =
             std::make_unique<KvCache>(ctx.config.num_layers, ctx.config.max_cache_length, kv_dim,

--- a/src/runtime/models/vision_language/plugin.cpp
+++ b/src/runtime/models/vision_language/plugin.cpp
@@ -10,7 +10,9 @@
 #include "utils/json_helpers.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -21,6 +23,12 @@ namespace {
 struct TensorParallelRuntimeConfig {
     bool enabled{false};
     int32_t tp_size{1};
+};
+
+struct TextModuleRuntime {
+    ModuleCreateOptions options;
+    DistributedRuntimeGroup tp_group;
+    std::string engine_section{"engine_plan"};
 };
 
 TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
@@ -39,9 +47,80 @@ int32_t dim_at(const std::vector<int64_t>& shape, std::size_t idx) {
     return shape.size() > idx ? static_cast<int32_t>(shape[idx]) : 0;
 }
 
-int32_t decoder_cache_row_width(const TrtModule& module, const BaseConfig& config) {
-    const int32_t from_engine = dim_at(module.tensor_shape("cache_k_0"), 1);
+int32_t decoder_cache_row_width(const TrtModule& module, const std::string& tensor_name,
+                                const BaseConfig& config) {
+    const int32_t from_engine = dim_at(module.tensor_shape(tensor_name), 1);
     return from_engine > 0 ? from_engine : compute_kv_dim(config);
+}
+
+TextModuleRuntime initialize_text_module_runtime(const TensorParallelRuntimeConfig& tp_config) {
+    TextModuleRuntime runtime;
+    if (!tp_config.enabled)
+        return runtime;
+
+    runtime.tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+    runtime.engine_section = tp_engine_section_name(runtime.tp_group.rank);
+    return runtime;
+}
+
+void configure_text_module_options(TextModuleRuntime& runtime,
+                                   const ModuleCreateOptions& base_options,
+                                   const TensorParallelRuntimeConfig& tp_config) {
+    runtime.options = base_options;
+    if (!tp_config.enabled)
+        return;
+
+    runtime.options.distributed_communicator = runtime.tp_group.communicator;
+    runtime.options.distributed_owner = runtime.tp_group.owner;
+}
+
+KvCacheNames build_kv_cache_names(const BaseConfig& config) {
+    const auto& io = config.io_map;
+    KvCacheNames kv_names;
+    for (int32_t i = 0; i < config.num_layers; ++i) {
+        kv_names.cache_k.push_back(expand_layer_name(io.cache_k_pattern, i));
+        kv_names.cache_v.push_back(expand_layer_name(io.cache_v_pattern, i));
+        kv_names.present_k.push_back(expand_layer_name(io.present_k_pattern, i));
+        kv_names.present_v.push_back(expand_layer_name(io.present_v_pattern, i));
+    }
+    return kv_names;
+}
+
+LoadedModule load_text_module(const PipelineContext& ctx, TextModuleRuntime& runtime,
+                              const std::shared_ptr<CudaStream>& stream) {
+    auto loaded =
+        load_trt_module_from_plan(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
+                                  runtime.engine_section.c_str(), runtime.options);
+    loaded.module->keep_alive(stream);
+    if (runtime.tp_group.owner)
+        loaded.module->keep_alive(runtime.tp_group.owner);
+    return loaded;
+}
+
+std::unique_ptr<TrtModule> load_vision_module(IBackend* backend, const BundleFile& bundle,
+                                              const ModuleCreateOptions& options,
+                                              const std::shared_ptr<CudaStream>& stream,
+                                              bool declared_in_config) {
+    auto loaded = try_load_trt_module_from_plan(backend, find_section(bundle, "vision_engine_plan"),
+                                                "vision_engine_plan", options);
+    if (loaded.module && loaded.module->ok()) {
+        loaded.module->keep_alive(stream);
+        std::cerr << "[trtmc] Vision encoder loaded" << std::endl;
+        return std::move(loaded.module);
+    }
+    if (declared_in_config) {
+        std::cerr << "[trtmc] WARNING: Bundle declares vision engine but "
+                     "deserialization failed"
+                  << std::endl;
+    }
+    return nullptr;
+}
+
+std::string bundle_section_text(const BundleFile& bundle, const std::string& section_name) {
+    const auto* section = find_section(bundle, section_name);
+    if (section && !section->empty())
+        return std::string(section->begin(), section->end());
+    return {};
 }
 
 } // namespace
@@ -52,9 +131,7 @@ class VLPlugin final : public IPipelinePlugin {
         load_ffi_kernels_from_bundle(ctx.bundle);
 
         const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
-        DistributedRuntimeGroup tp_group;
-        if (tp_config.enabled)
-            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+        auto text_runtime = initialize_text_module_runtime(tp_config);
 
         auto shared_stream = std::make_shared<CudaStream>();
         if (!shared_stream->ok())
@@ -65,31 +142,16 @@ class VLPlugin final : public IPipelinePlugin {
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
-        auto decoder_opts = opts;
-        if (tp_config.enabled) {
-            decoder_opts.distributed_communicator = tp_group.communicator;
-            decoder_opts.distributed_owner = tp_group.owner;
-        }
+        configure_text_module_options(text_runtime, opts, tp_config);
 
-        // Build KvCacheNames from IoMap patterns.
-        const auto& io = ctx.config.io_map;
-        KvCacheNames kv_names;
-        for (int32_t i = 0; i < ctx.config.num_layers; ++i) {
-            kv_names.cache_k.push_back(expand_layer_name(io.cache_k_pattern, i));
-            kv_names.cache_v.push_back(expand_layer_name(io.cache_v_pattern, i));
-            kv_names.present_k.push_back(expand_layer_name(io.present_k_pattern, i));
-            kv_names.present_v.push_back(expand_layer_name(io.present_v_pattern, i));
-        }
+        KvCacheNames kv_names = build_kv_cache_names(ctx.config);
 
-        const std::string engine_section =
-            tp_config.enabled ? tp_engine_section_name(tp_group.rank) : std::string("engine_plan");
-        auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, engine_section), engine_section.c_str(),
-            decoder_opts);
-        loaded.module->keep_alive(shared_stream);
+        auto loaded = load_text_module(ctx, text_runtime, shared_stream);
 
         cudaStream_t stream = loaded.module->stream();
-        int32_t kv_dim = decoder_cache_row_width(*loaded.module, ctx.config);
+        const std::string cache_k_name =
+            kv_names.cache_k.empty() ? std::string("cache_k_0") : kv_names.cache_k.front();
+        int32_t kv_dim = decoder_cache_row_width(*loaded.module, cache_k_name, ctx.config);
         DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
         std::unique_ptr<IInferenceState> state =
             std::make_unique<KvCache>(ctx.config.num_layers, ctx.config.max_cache_length, kv_dim,
@@ -108,29 +170,14 @@ class VLPlugin final : public IPipelinePlugin {
         bool has_vision_engine = extract_json_int(ctx.config_json, "has_vision_engine", 0) != 0;
 
         // Try to load the vision encoder engine from the bundle.
-        std::unique_ptr<TrtModule> vision_module;
-        auto vision_loaded = try_load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "vision_engine_plan"), "vision_engine_plan",
-            opts);
-        if (vision_loaded.module && vision_loaded.module->ok()) {
-            vision_loaded.module->keep_alive(shared_stream);
-            vision_module = std::move(vision_loaded.module);
-            std::cerr << "[trtmc] Vision encoder loaded" << std::endl;
-        } else if (has_vision_engine) {
-            std::cerr << "[trtmc] WARNING: Bundle declares vision engine but "
-                         "deserialization failed"
-                      << std::endl;
-        }
+        std::unique_ptr<TrtModule> vision_module =
+            load_vision_module(ctx.backend, ctx.bundle, opts, shared_stream, has_vision_engine);
 
         // Build VL preprocessing config from bundle's config.json +
         // preprocessor_config.json sections.
-        std::string config_text, preproc_text;
-        const auto* config_sec = find_section(ctx.bundle, "config.json");
-        if (config_sec && !config_sec->empty())
-            config_text.assign(config_sec->begin(), config_sec->end());
-        const auto* preproc_sec = find_section(ctx.bundle, "preprocessor_config.json");
-        if (preproc_sec && !preproc_sec->empty())
-            preproc_text.assign(preproc_sec->begin(), preproc_sec->end());
+        const std::string config_text = bundle_section_text(ctx.bundle, "config.json");
+        const std::string preproc_text =
+            bundle_section_text(ctx.bundle, "preprocessor_config.json");
         auto vl_preprocess = parse_vl_preprocess_config(config_text, preproc_text);
 
         return std::make_unique<VLPipeline>(std::move(loaded.module), std::move(vision_module),

--- a/tests/builder/test_engine_qwen_vl_tp.py
+++ b/tests/builder/test_engine_qwen_vl_tp.py
@@ -1,0 +1,68 @@
+"""Focused tests for Qwen-VL tensor-parallel dispatch."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+try:
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _config(*, qwen3: bool = False) -> SimpleNamespace:
+    raw = {"vision_config": {"deepstack_visual_indexes": [5, 11, 17]}} if qwen3 else {}
+    return SimpleNamespace(
+        raw=raw,
+        hidden_size=16,
+        vocab_size=32,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=4,
+        attention_size=16,
+        intermediate_size=32,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("qwen3", "tp_size", "deepstack_num_levels"),
+    [
+        (False, 2, 0),
+        (True, 4, 3),
+    ],
+)
+def test_qwen_vl_plugin_routes_parallel_builds(
+    monkeypatch, qwen3: bool, tp_size: int, deepstack_num_levels: int
+) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen_vl.plugin")
+    calls: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"qwen-vl-tp-plan"
+
+    monkeypatch.setattr(module, "build_qwen_vl_tp_decoder_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=tp_size, rank=1)
+    result = module.QwenVLPlugin().build_engine(
+        _config(qwen3=qwen3),
+        {"_attention_size": 16, "_kv_attention_size": 16, "_mlp_size": 32},
+        23,
+        verbose=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"qwen-vl-tp-plan"
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 23
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["embed_input"] is True
+    assert kwargs["deepstack_num_levels"] == deepstack_num_levels
+    assert kwargs["verbose"] is True

--- a/tests/e2e/models/qwen25vl-3b-tp2.json
+++ b/tests/e2e/models/qwen25vl-3b-tp2.json
@@ -1,0 +1,59 @@
+{
+  "name": "qwen25vl-3b-tp2",
+  "trace_id": "IT-E2E-Q25VL-TP2-01",
+  "hf_id": "Qwen/Qwen2.5-VL-3B-Instruct",
+  "bundle": "qwen25vl-3b-vl-tp2.trtfb",
+  "family": "qwen_vl",
+  "runtime_strategy": "vision_language",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 384,
+  "prompt": "What color is the vehicle in this image? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "test_image": "tests/e2e/data/test_img.jpeg",
+  "trust_remote_code": false,
+  "core": true,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 2
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 2,
+    "debug_logits": true,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 2
+      },
+      "gating": true
+    }
+  ],
+  "notes": "Tensor-parallel TP=2 Qwen2.5-VL coverage; TP4 is not valid because the model has two KV heads."
+}

--- a/tests/e2e/models/qwen3-vl-2b-tp4.json
+++ b/tests/e2e/models/qwen3-vl-2b-tp4.json
@@ -1,0 +1,58 @@
+{
+  "name": "qwen3-vl-2b-tp4",
+  "trace_id": "IT-E2E-Q3VL-TP4-01",
+  "hf_id": "Qwen/Qwen3-VL-2B-Instruct",
+  "bundle": "qwen3-vl-2b-tp4.trtfb",
+  "family": "qwen_vl",
+  "runtime_strategy": "vision_language",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 256,
+  "prompt": "What color is the vehicle in this image? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "test_image": "tests/e2e/data/test_img.jpeg",
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "debug_logits": true,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "Tensor-parallel TP=4 Qwen3-VL coverage on four GPUs."
+}

--- a/tests/e2e_harness/runners/vision_language.py
+++ b/tests/e2e_harness/runners/vision_language.py
@@ -23,6 +23,17 @@ from pathlib import Path
 
 from .. import save_full_stderr, _case_artifact_dir
 from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
+from .text_generation import (
+    _detect_trt_runtime_error,
+    _distributed_runtime_config,
+    _ensure_distributed_runtime_env,
+    _extract_rank_zero_stdout,
+    _extract_trtmc_load_timing,
+    _extract_trtmc_timing,
+    _maybe_start_gpu_memory_sampler,
+    _strip_mpi_stream_tags,
+    _wrap_distributed_command,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -287,21 +298,43 @@ class VisionLanguageRunner:
         env = dict(os.environ)
         if ctx.ld_library_path:
             env["LD_LIBRARY_PATH"] = ctx.ld_library_path
+        distributed_runtime = _distributed_runtime_config(case)
+        if distributed_runtime:
+            _ensure_distributed_runtime_env(case, ctx, env)
+            extra_env = distributed_runtime.get("env", {})
+            if isinstance(extra_env, dict):
+                env.update({str(k): str(v) for k, v in extra_env.items()})
+            cmd = _wrap_distributed_command(cmd, case, env)
 
         t0 = time.monotonic()
+        memory_sampler = _maybe_start_gpu_memory_sampler(
+            distributed_runtime, ctx, case, env)
         try:
             result = subprocess.run(
                 cmd, capture_output=True, text=True, timeout=600, env=env)
         except subprocess.TimeoutExpired:
+            meta: dict = {
+                "error": "C++ VL generation timed out",
+                "command": cmd,
+            }
+            if memory_sampler is not None:
+                meta["gpu_memory"] = memory_sampler.stop()
             return StageOutput(
                 stage_name="full_generation",
                 timing_s=time.monotonic() - t0,
-                metadata={"error": "C++ VL generation timed out",
-                          "command": cmd},
+                metadata=meta,
             )
         elapsed = time.monotonic() - t0
+        memory_meta = memory_sampler.stop() if memory_sampler is not None else None
 
-        raw_text = result.stdout.strip()
+        parse_stderr = (
+            _strip_mpi_stream_tags(result.stderr)
+            if distributed_runtime else result.stderr
+        )
+        raw_text = (
+            _extract_rank_zero_stdout(result.stdout)
+            if distributed_runtime else result.stdout.strip()
+        )
 
         # Strip chat template / prompt prefix from C++ binary output.
         # The C++ binary may output the full conversation including the
@@ -332,6 +365,20 @@ class VisionLanguageRunner:
             "stdout": result.stdout or "",
             "stderr": result.stderr or "",
         }
+        if distributed_runtime:
+            meta_fg["distributed_runtime"] = distributed_runtime
+            meta_fg["rank_zero_stdout"] = raw_text
+            meta_fg["stderr_without_mpi_tags"] = parse_stderr
+        if memory_meta is not None:
+            meta_fg["gpu_memory"] = memory_meta
+        meta_fg.update(_extract_trtmc_timing(parse_stderr))
+        meta_fg.update(_extract_trtmc_load_timing(parse_stderr))
+        runtime_error = _detect_trt_runtime_error(parse_stderr)
+        if runtime_error:
+            meta_fg["runtime_error_detected"] = runtime_error
+            if result.returncode == 0:
+                meta_fg["effective_returncode"] = -1
+                meta_fg["error"] = "TensorRT runtime error detected in stderr"
         if stderr_log:
             meta_fg["stderr_log"] = stderr_log
 

--- a/tools/diff_vl.py
+++ b/tools/diff_vl.py
@@ -73,7 +73,7 @@ def _get_hf_vision_features_qwen(
 
     if is_qwen3:
         print(f"[diff_vl] Loading HF Qwen3 VL model {model_id} ...", file=sys.stderr)
-        from transformers import Qwen3VLForConditionalGeneration, AutoProcessor
+        from transformers import Qwen3VLForConditionalGeneration
         model_cls = Qwen3VLForConditionalGeneration
     else:
         print(f"[diff_vl] Loading HF Qwen2.5 VL model {model_id} ...", file=sys.stderr)
@@ -135,9 +135,7 @@ def _get_hf_vision_features_qwen(
     trt_pixel_values = np.tile(img_chw, (temporal, 1, 1)).astype(np.float32)
 
     del model
-    import gc; gc.collect()
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
+    _free_gpu()
     return hf_features_np, trt_pixel_values
 
 
@@ -210,9 +208,7 @@ def _get_hf_vision_features_generic(
     trt_pixel_values = img_np.transpose(2, 0, 1).astype(np.float32)
 
     del model
-    import gc; gc.collect()
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
+    _free_gpu()
     return hf_features_np, trt_pixel_values
 
 
@@ -306,22 +302,25 @@ def test_vision_features(
     # Basic sanity checks
     if np.all(trt_features == 0):
         print("[diff_vl] FAIL: TRT vision output is all zeros", file=sys.stderr)
-        del runner; _free_gpu()
+        del runner
+        _free_gpu()
         return False
 
     if np.any(np.isnan(trt_features)):
         print("[diff_vl] FAIL: TRT vision output contains NaN", file=sys.stderr)
-        del runner; _free_gpu()
+        del runner
+        _free_gpu()
         return False
 
     if np.any(np.isinf(trt_features)):
         print("[diff_vl] FAIL: TRT vision output contains Inf", file=sys.stderr)
-        del runner; _free_gpu()
+        del runner
+        _free_gpu()
         return False
 
     # Numerical comparison against HF reference
     if model_id is not None:
-        print(f"[diff_vl] Comparing against HF reference ...", file=sys.stderr)
+        print("[diff_vl] Comparing against HF reference ...", file=sys.stderr)
 
         # Warn if HF processor's image_mean/std differ from bundle values
         try:
@@ -373,7 +372,7 @@ def test_vision_features(
             print(f"[diff_vl] WARN: Max diff {max_diff:.6f} > atol {atol}",
                   file=sys.stderr)
             # Not a hard failure — print diagnostics
-            print(f"[diff_vl] Per-row max diff (first 10 features):",
+            print("[diff_vl] Per-row max diff (first 10 features):",
                   file=sys.stderr)
             for i in range(min(10, trt_sub.shape[0])):
                 row_diff = np.abs(trt_sub[i] - hf_sub[i]).max()
@@ -388,7 +387,7 @@ def test_vision_features(
             _free_gpu()
             return False
 
-    print(f"[diff_vl] Vision encoder: PASS", file=sys.stderr)
+    print("[diff_vl] Vision encoder: PASS", file=sys.stderr)
     # Ensure GPU is free for next test (runner may already be deleted by HF path)
     try:
         del runner
@@ -418,13 +417,15 @@ def test_embed_input(bundle_path: str) -> bool:
     if not runner.has_embed_input:
         print("[diff_vl] Text decoder has no embed_input — skipping",
               file=sys.stderr)
-        del runner; _free_gpu()
+        del runner
+        _free_gpu()
         return True
 
     result1 = runner.step(1, use_input_embed=0.0)
     if "logits" not in result1:
         print("[diff_vl] FAIL: no logits from text decoder", file=sys.stderr)
-        del runner; _free_gpu()
+        del runner
+        _free_gpu()
         return False
 
     embed_shape = tuple(runner.engine.get_tensor_shape("input_embed"))
@@ -433,12 +434,14 @@ def test_embed_input(bundle_path: str) -> bool:
     result2 = runner.step(0, input_embed=dummy_embed, use_input_embed=1.0)
     if "logits" not in result2:
         print("[diff_vl] FAIL: no logits from embed_input step", file=sys.stderr)
-        del runner; _free_gpu()
+        del runner
+        _free_gpu()
         return False
 
     print(f"[diff_vl] Text decoder embed_input: PASS "
           f"(hidden={embed_hidden})", file=sys.stderr)
-    del runner; _free_gpu()
+    del runner
+    _free_gpu()
     return True
 
 
@@ -448,7 +451,10 @@ def test_vl_generation(
     max_new_tokens: int = 20,
 ) -> bool:
     """Run full VL generation in Python using VLTrtRunner."""
-    from tensorrt_model_connect.debug_runner import VLTrtRunner
+    from tensorrt_model_connect.debug_runner import (
+        load_section_from_bundle,
+        VLTrtRunner,
+    )
 
     print("[diff_vl] Loading VL runner from bundle ...", file=sys.stderr)
     runner = VLTrtRunner(bundle_path)
@@ -476,7 +482,7 @@ def test_vl_generation(
         tok_data = load_section_from_bundle(bundle_path, "tokenizer.json")
         if tok_data:
             # Write tokenizer to temp dir and load
-            import tempfile, json
+            import tempfile
             with tempfile.TemporaryDirectory() as tmpdir:
                 for name in ["tokenizer.json", "tokenizer_config.json",
                              "special_tokens_map.json"]:
@@ -508,7 +514,8 @@ def test_vl_generation(
         print("[diff_vl] WARN: Empty generation output", file=sys.stderr)
 
     print("[diff_vl] VL generation: PASS", file=sys.stderr)
-    del runner; _free_gpu()
+    del runner
+    _free_gpu()
     return True
 
 
@@ -547,10 +554,6 @@ def test_cpp_binary(
     print(f"[diff_vl] C++ output: {output[:200]!r}", file=sys.stderr)
     print("[diff_vl] C++ binary: PASS", file=sys.stderr)
     return True
-
-
-# Need this import at module level for test_vl_generation
-from tensorrt_model_connect.debug_runner import load_section_from_bundle
 
 
 def test_debug_layers(
@@ -679,9 +682,7 @@ def test_debug_layers(
                   file=sys.stderr)
 
     del model
-    import gc; gc.collect()
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
+    _free_gpu()
 
     print("[diff_vl] Debug layers: DONE", file=sys.stderr)
     return True

--- a/tools/diff_vl.py
+++ b/tools/diff_vl.py
@@ -400,7 +400,19 @@ def test_vision_features(
 
 def test_embed_input(bundle_path: str) -> bool:
     """Verify the text decoder accepts embed_input mode."""
-    from tensorrt_model_connect.debug_runner import runner_from_bundle
+    from tensorrt_model_connect.debug_runner import (
+        load_section_from_bundle,
+        runner_from_bundle,
+    )
+
+    if (
+        load_section_from_bundle(bundle_path, "engine_plan") is None
+        and load_section_from_bundle(bundle_path, "engine_plan_tp_rank0") is not None
+    ):
+        print("[diff_vl] Text decoder embed_input: SKIP "
+              "(tensor-parallel decoder requires distributed runtime)",
+              file=sys.stderr)
+        return True
 
     runner = runner_from_bundle(bundle_path)
     if not runner.has_embed_input:


### PR DESCRIPTION
## Background
Qwen-VL did not have tensor-parallel decoder coverage. Qwen2.5-VL also cannot use TP4 on the 3B test model because it has two KV heads, so this PR uses TP2 for Qwen2.5-VL and TP4 for Qwen3-VL.

## Exit Criteria
- Build Qwen2.5-VL and Qwen3-VL decoder bundles with tensor-parallel rank engines.
- Run native VL generation under distributed runtime for multi-device e2e tests.
- Pass Qwen2.5-VL TP2 and Qwen3-VL TP4 e2e tests on B200 GPUs.

## Implementation
- Add a Qwen-VL TP decoder builder that mirrors the single-device decoder path and adds rank-local projection sharding plus all-reduce joins.
- Route Qwen2.5-VL and Qwen3-VL parallel builds through the TP builder, including Qwen3 DeepStack decoder inputs.
- Update the VL runtime to load rank-specific engine sections, attach the TensorRT distributed communicator, size KV cache rows from the rank-local engine binding, and pass DeepStack vision features through prefill.
- Teach the VL e2e runner to wrap full generation with the distributed launcher and add TP manifests for Qwen2.5-VL TP2 and Qwen3-VL TP4.

## Validation
- `pytest -p no:cacheprovider -q tests/builder/test_engine_qwen_vl_tp.py tests/builder/test_manifest_validation.py`: passed, 28 tests.
- `ctest -R "test_vl_pipeline|test_image_preprocessor|test_vl_decode_policy|test_vision_execution_plan" --output-on-failure`: passed, 4 tests.
- `pytest -p no:cacheprovider -s tests/test_e2e.py::test_e2e[qwen25vl-3b-tp2] --multi-device-only --engine-dir /tmp/trtmc-qwen25vl-tp2/engines --e2e-artifacts-dir /tmp/trtmc-qwen25vl-tp2/artifacts-final --trtmc-binary build-b200-trt11-local-trt/trtmc --hf-python /opt/venv/bin/python`: passed on B200 container-visible GPUs 0-1, mapping to host GPUs 4-5.
- `pytest -p no:cacheprovider -s tests/test_e2e.py::test_e2e[qwen3-vl-2b-tp4] --multi-device-only --engine-dir /tmp/trtmc-qwen3vl-tp4/engines --e2e-artifacts-dir /tmp/trtmc-qwen3vl-tp4/artifacts --trtmc-binary build-b200-trt11-local-trt/trtmc --hf-python /opt/venv/bin/python`: passed on B200 container-visible GPUs 0-3, mapping to host GPUs 4-7.

## Notes For Future Readers
- Review the runtime plugin and pipeline changes before the builder: the C++ runtime must use the engine-local cache row width for TP rank engines.
- Qwen2.5-VL TP4 is intentionally not included for the 3B manifest because the model has only two KV heads.