### PR TITLE
feat(vl): add InternVL and DeepSeek-OCR TP support

### DIFF
--- a/python/tensorrt_model_connect/families/deepseek_ocr/plugin.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/plugin.py
@@ -48,6 +48,10 @@ from ...checkpoint_mapper import (
 )
 from ... import graph_ops
 from ... import graph_blocks
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 from .standard_decoder_builder import _apply_norm, _mark_debug_output
 
 
@@ -94,6 +98,7 @@ class DeepSeekOCRPlugin:
         weights["embedding"] = embedding.astype(np.float32)
 
         attention_size = 0
+        kv_attention_size = 0
 
         for layer_idx in range(num_layers):
             prefix = f"layer.{layer_idx}"
@@ -120,6 +125,8 @@ class DeepSeekOCRPlugin:
 
             if attention_size == 0:
                 attention_size = q_raw.shape[0]
+            if kv_attention_size == 0:
+                kv_attention_size = k_raw.shape[0]
 
             q_t = _transpose_2d(q_raw, "q_proj")
             k_t = _transpose_2d(k_raw, "k_proj")
@@ -213,6 +220,7 @@ class DeepSeekOCRPlugin:
 
         # Store metadata
         weights["_attention_size"] = attention_size  # type: ignore[assignment]
+        weights["_kv_attention_size"] = kv_attention_size  # type: ignore[assignment]
         weights["_n_routed_experts"] = n_routed_experts  # type: ignore[assignment]
         weights["_n_shared_experts"] = n_shared_experts  # type: ignore[assignment]
         weights["_num_experts_per_tok"] = num_experts_per_tok  # type: ignore[assignment]
@@ -229,7 +237,24 @@ class DeepSeekOCRPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
         debug_layer_outputs: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="DeepSeek-OCR tensor-parallel builds")
+            if debug_layer_outputs:
+                raise ValueError(
+                    "DeepSeek-OCR tensor-parallel builds do not support "
+                    "debug layer outputs")
+            from .tp_builder import build_deepseek_ocr_tp_engine
+            return build_deepseek_ocr_tp_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                parallel_config=parallel)
+
         image_prefill_tokens = 257
         if max_cache_length <= image_prefill_tokens:
             print(

--- a/python/tensorrt_model_connect/families/deepseek_ocr/tp_builder.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/tp_builder.py
@@ -1,0 +1,518 @@
+"""Tensor-parallel DeepSeek-OCR text decoder builder."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+from .standard_decoder_builder import _apply_norm
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _slice_last_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=-1)[rank])
+
+
+def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
+
+
+def _validate_deepseek_ocr_tp(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    parallel: "ParallelConfig",
+) -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError(
+            "DeepSeek-OCR tensor-parallel build requires a concrete rank")
+
+    tp = parallel.tp_size
+    if int(config.num_attention_heads) % tp != 0:
+        raise ValueError(
+            "DeepSeek-OCR tensor parallel requires num_attention_heads "
+            f"divisible by tp_size ({config.num_attention_heads} vs {tp})")
+    if int(config.num_key_value_heads) % tp != 0:
+        raise ValueError(
+            "DeepSeek-OCR tensor parallel requires num_key_value_heads "
+            f"divisible by tp_size ({config.num_key_value_heads} vs {tp})")
+
+    checks = {
+        "attention_size": int(weights.get(
+            "_attention_size", config.attention_size)),
+        "kv_attention_size": int(weights.get(
+            "_kv_attention_size", config.num_key_value_heads * config.head_dim)),
+        "dense_intermediate_size": int(config.intermediate_size),
+        "moe_intermediate_size": int(weights["_moe_intermediate_size"]),
+        "shared_intermediate_size": int(weights["_shared_intermediate_size"]),
+    }
+    for name, value in checks.items():
+        if value % tp != 0:
+            raise ValueError(
+                "DeepSeek-OCR tensor parallel requires "
+                f"{name} divisible by tp_size ({value} vs {tp})")
+
+
+def shard_deepseek_ocr_weights(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    *,
+    parallel: "ParallelConfig",
+) -> "WeightDict":
+    """Return rank-local DeepSeek-OCR decoder weights."""
+    _validate_deepseek_ocr_tp(config, weights, parallel)
+    if not parallel.enabled:
+        return weights
+
+    out = type(weights)()
+    for key, value in weights.items():
+        if not isinstance(value, np.ndarray):
+            out[key] = value
+            continue
+
+        if key.endswith((".w_q", ".w_k", ".w_v", ".w_gate", ".w_up")):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_o", ".w_down")):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        else:
+            out[key] = value
+
+    out["_attention_size"] = (
+        int(weights["_attention_size"]) // parallel.tp_size)
+    out["_kv_attention_size"] = (
+        int(weights["_kv_attention_size"]) // parallel.tp_size)
+    out["_moe_intermediate_size"] = (
+        int(weights["_moe_intermediate_size"]) // parallel.tp_size)
+    out["_shared_intermediate_size"] = (
+        int(weights["_shared_intermediate_size"]) // parallel.tp_size)
+    out["_tensor_parallel_size"] = parallel.tp_size
+    out["_tensor_parallel_rank"] = parallel.rank
+    return out
+
+
+def _add_swiglu_local(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    intermediate_size: int,
+    w_gate: np.ndarray,
+    w_up: np.ndarray,
+    w_down: np.ndarray,
+) -> trt.ITensor:
+    gate = graph_ops.add_matmul_rhs_constant(
+        network, inp, hidden_size, intermediate_size, w_gate)
+    up = graph_ops.add_matmul_rhs_constant(
+        network, inp, hidden_size, intermediate_size, w_up)
+    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
+    swish = network.add_elementwise(
+        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    gated = network.add_elementwise(
+        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+    return graph_ops.add_matmul_rhs_constant(
+        network, gated.get_output(0), intermediate_size, hidden_size, w_down)
+
+
+def _add_swiglu_tp(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    intermediate_size: int,
+    w_gate: np.ndarray,
+    w_up: np.ndarray,
+    w_down: np.ndarray,
+    tp_size: int,
+) -> trt.ITensor:
+    local = _add_swiglu_local(
+        network, inp, hidden_size, intermediate_size, w_gate, w_up, w_down)
+    return add_all_reduce_sum(network, local, tp_size)
+
+
+def _add_moe_tp(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    n_routed_experts: int,
+    moe_intermediate: int,
+    num_experts_per_tok: int,
+    shared_intermediate: int,
+    tp_size: int,
+    norm_topk_prob: bool = False,
+    routed_scaling_factor: float = 1.0,
+) -> trt.ITensor:
+    router_logits = graph_ops.add_matmul_rhs_constant(
+        network, inp, hidden_size, n_routed_experts,
+        weights[f"{prefix}.router"])
+    sm = network.add_softmax(router_logits)
+    sm.axes = 1 << 1
+    topk = network.add_topk(
+        sm.get_output(0), trt.TopKOperation.MAX,
+        num_experts_per_tok, 1 << 1)
+    top_values = topk.get_output(0)
+    top_indices = topk.get_output(1)
+
+    if norm_topk_prob:
+        sum_val = network.add_reduce(
+            top_values, trt.ReduceOperation.SUM, 1 << 1, keep_dims=True)
+        scaled_weights = network.add_elementwise(
+            top_values, sum_val.get_output(0), trt.ElementWiseOperation.DIV
+        ).get_output(0)
+    elif routed_scaling_factor != 1.0:
+        scale_c = graph_ops.add_constant(
+            network, (1, 1),
+            np.array([[routed_scaling_factor]], dtype=np.float32))
+        scaled_weights = network.add_elementwise(
+            top_values, scale_c, trt.ElementWiseOperation.PROD).get_output(0)
+    else:
+        scaled_weights = top_values
+
+    expert_outputs = []
+    for expert_idx in range(n_routed_experts):
+        expert_outputs.append(_add_swiglu_local(
+            network, inp, hidden_size, moe_intermediate,
+            weights[f"{prefix}.expert.{expert_idx}.w_gate"],
+            weights[f"{prefix}.expert.{expert_idx}.w_up"],
+            weights[f"{prefix}.expert.{expert_idx}.w_down"],
+        ))
+
+    stacked = network.add_concatenation(expert_outputs)
+    stacked.axis = 0
+    stacked_out = stacked.get_output(0)
+
+    routed_local = None
+    for top_idx in range(num_experts_per_tok):
+        idx_slice = network.add_slice(
+            top_indices, start=(0, top_idx), shape=(1, 1), stride=(1, 1))
+        idx_flat = network.add_shuffle(idx_slice.get_output(0))
+        idx_flat.reshape_dims = (1,)
+        w_slice = network.add_slice(
+            scaled_weights, start=(0, top_idx), shape=(1, 1), stride=(1, 1))
+        expert_out = network.add_gather(stacked_out, idx_flat.get_output(0), 0)
+        scaled = network.add_elementwise(
+            expert_out.get_output(0), w_slice.get_output(0),
+            trt.ElementWiseOperation.PROD)
+        if routed_local is None:
+            routed_local = scaled.get_output(0)
+        else:
+            summed = network.add_elementwise(
+                routed_local, scaled.get_output(0), trt.ElementWiseOperation.SUM)
+            routed_local = summed.get_output(0)
+
+    shared_local = _add_swiglu_local(
+        network, inp, hidden_size, shared_intermediate,
+        weights[f"{prefix}.shared.w_gate"],
+        weights[f"{prefix}.shared.w_up"],
+        weights[f"{prefix}.shared.w_down"],
+    )
+    local_total = network.add_elementwise(
+        routed_local, shared_local, trt.ElementWiseOperation.SUM)
+    return add_all_reduce_sum(network, local_total.get_output(0), tp_size)
+
+
+def _add_decoder_layer_tp(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    cache_k: trt.ITensor,
+    cache_v: trt.ITensor,
+    attention_mask: trt.ITensor,
+    position_id: trt.ITensor,
+    cos_half_tensor: trt.ITensor,
+    sin_half_tensor: trt.ITensor,
+    eps_tensor: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    attention_size: int,
+    kv_attention_size: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    max_cache_length: int,
+    is_moe_layer: bool,
+    n_routed_experts: int,
+    num_experts_per_tok: int,
+    moe_intermediate: int,
+    shared_intermediate: int,
+    dense_intermediate: int,
+    tp_size: int,
+    norm_topk_prob: bool = False,
+    routed_scaling_factor: float = 1.0,
+) -> dict[str, trt.ITensor]:
+    attention_window = max_cache_length + 1
+
+    norm1 = _apply_norm(
+        network, hidden, hidden_size,
+        weights[f"{prefix}.input_norm"], None, eps_tensor, "rmsnorm")
+
+    q = graph_ops.add_matmul_rhs_constant(
+        network, norm1, hidden_size, attention_size,
+        weights[f"{prefix}.w_q"])
+    k = graph_ops.add_matmul_rhs_constant(
+        network, norm1, hidden_size, kv_attention_size,
+        weights[f"{prefix}.w_k"])
+    v = graph_ops.add_matmul_rhs_constant(
+        network, norm1, hidden_size, kv_attention_size,
+        weights[f"{prefix}.w_v"])
+
+    q = graph_ops.add_apply_rope_native(
+        network, q, num_heads, head_dim, cos_half_tensor, sin_half_tensor,
+        position_id, head_dim)
+    k = graph_ops.add_apply_rope_native(
+        network, k, num_kv_heads, head_dim, cos_half_tensor, sin_half_tensor,
+        position_id, head_dim)
+
+    present_k = k
+    present_v = v
+
+    k_reshape = network.add_shuffle(k)
+    k_reshape.reshape_dims = (1, kv_attention_size)
+    v_reshape = network.add_shuffle(v)
+    v_reshape.reshape_dims = (1, kv_attention_size)
+
+    all_k = network.add_concatenation([cache_k, k_reshape.get_output(0)])
+    all_k.axis = 0
+    all_v = network.add_concatenation([cache_v, v_reshape.get_output(0)])
+    all_v.axis = 0
+
+    mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask)
+    context_flat = graph_ops.add_attention_from_rows(
+        network, q, all_k.get_output(0), all_v.get_output(0),
+        num_heads=num_heads, head_dim=head_dim, num_kv_heads=num_kv_heads,
+        q_seq=1, kv_seq=attention_window,
+        mask=mask_4d)
+
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, context_flat, attention_size, hidden_size,
+        weights[f"{prefix}.w_o"])
+    attn_out = add_all_reduce_sum(network, attn_out, tp_size)
+
+    residual1 = network.add_elementwise(
+        hidden, attn_out, trt.ElementWiseOperation.SUM)
+    norm2 = _apply_norm(
+        network, residual1.get_output(0), hidden_size,
+        weights[f"{prefix}.post_attn_norm"], None, eps_tensor, "rmsnorm")
+
+    if is_moe_layer:
+        mlp_out = _add_moe_tp(
+            network, norm2, weights, prefix,
+            hidden_size, n_routed_experts, moe_intermediate,
+            num_experts_per_tok, shared_intermediate, tp_size,
+            norm_topk_prob=norm_topk_prob,
+            routed_scaling_factor=routed_scaling_factor)
+    else:
+        mlp_out = _add_swiglu_tp(
+            network, norm2, hidden_size, dense_intermediate,
+            weights[f"{prefix}.w_gate"],
+            weights[f"{prefix}.w_up"],
+            weights[f"{prefix}.w_down"],
+            tp_size)
+
+    residual2 = network.add_elementwise(
+        residual1.get_output(0), mlp_out, trt.ElementWiseOperation.SUM)
+    return {
+        "hidden": residual2.get_output(0),
+        "present_k": present_k,
+        "present_v": present_v,
+    }
+
+
+def build_deepseek_ocr_tp_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    del precision, quant_ctx
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_deepseek_ocr_tp_engine requires tensor_parallel mode with "
+            "tp_size > 1")
+
+    image_prefill_tokens = 257
+    if max_cache_length <= image_prefill_tokens:
+        print(
+            "[trtmc build] WARNING: DeepSeek-OCR-2 uses 257 image prefill "
+            f"tokens. max_cache_length={max_cache_length} is too small and "
+            "can cause prompt echo / repeated skip-like tokens. Use "
+            "--max-cache-length 4096.",
+            file=sys.stderr,
+        )
+    elif max_cache_length < 4096:
+        print(
+            "[trtmc build] NOTE: DeepSeek-OCR-2 is more stable with "
+            "--max-cache-length 4096.",
+            file=sys.stderr,
+        )
+
+    rank_weights = shard_deepseek_ocr_weights(
+        config, weights, parallel=parallel)
+
+    hidden = int(config.hidden_size)
+    vocab = int(config.vocab_size)
+    num_layers = int(config.num_hidden_layers)
+    num_heads = int(config.num_attention_heads) // parallel.tp_size
+    num_kv_heads = int(config.num_key_value_heads) // parallel.tp_size
+    attention_size = int(rank_weights["_attention_size"])
+    kv_attention_size = int(rank_weights["_kv_attention_size"])
+    head_dim = attention_size // num_heads
+    attention_window = max_cache_length + 1
+
+    n_routed_experts = int(rank_weights["_n_routed_experts"])
+    num_experts_per_tok = int(rank_weights["_num_experts_per_tok"])
+    first_k_dense_replace = int(rank_weights["_first_k_dense_replace"])
+    moe_intermediate = int(rank_weights["_moe_intermediate_size"])
+    shared_intermediate = int(rank_weights["_shared_intermediate_size"])
+    dense_intermediate = int(config.intermediate_size) // parallel.tp_size
+    norm_topk_prob = bool(rank_weights.get("_norm_topk_prob", False))
+    routed_scaling_factor = float(rank_weights.get("_routed_scaling_factor", 1.0))
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    token_id = network.add_input("token_id", trt.int32, (1,))
+    position_id = network.add_input("position_id", trt.int32, (1,))
+    attention_mask = network.add_input(
+        "attention_mask", trt.float32, (1, attention_window))
+    input_embed_tensor = network.add_input(
+        "input_embed", trt.float32, (1, hidden))
+    use_input_embed_tensor = network.add_input(
+        "use_input_embed", trt.float32, (1,))
+
+    cache_k_inputs = []
+    cache_v_inputs = []
+    for layer_idx in range(num_layers):
+        cache_k_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_k", layer_idx),
+            trt.float32, (max_cache_length, kv_attention_size)))
+        cache_v_inputs.append(network.add_input(
+            graph_ops.layer_tensor_name("cache_v", layer_idx),
+            trt.float32, (max_cache_length, kv_attention_size)))
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), rank_weights["embedding"])
+    graph_ops.validate_native_rope_dim(head_dim, field_name="head_dim")
+    cos_half_np = graph_ops.make_rope_table_half_dim(
+        attention_window, head_dim, config.rope_theta, True)
+    sin_half_np = graph_ops.make_rope_table_half_dim(
+        attention_window, head_dim, config.rope_theta, False)
+    cos_half_tensor = graph_ops.add_constant(network, cos_half_np.shape, cos_half_np)
+    sin_half_tensor = graph_ops.add_constant(network, sin_half_np.shape, sin_half_np)
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=np.float32))
+
+    gather = network.add_gather(embedding_table, token_id, 0)
+    token_embed = gather.get_output(0)
+    flag_broadcast = network.add_shuffle(use_input_embed_tensor)
+    flag_broadcast.reshape_dims = (1, 1)
+    one_const = graph_ops.add_constant(
+        network, (1, 1), np.array([1.0], dtype=np.float32))
+    inv_flag = network.add_elementwise(
+        one_const, flag_broadcast.get_output(0), trt.ElementWiseOperation.SUB)
+    tok_part = network.add_elementwise(
+        inv_flag.get_output(0), token_embed, trt.ElementWiseOperation.PROD)
+    embed_part = network.add_elementwise(
+        flag_broadcast.get_output(0), input_embed_tensor,
+        trt.ElementWiseOperation.PROD)
+    hidden_sum = network.add_elementwise(
+        tok_part.get_output(0), embed_part.get_output(0),
+        trt.ElementWiseOperation.SUM)
+    hidden_state = hidden_sum.get_output(0)
+
+    present_k_outputs = []
+    present_v_outputs = []
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        result = _add_decoder_layer_tp(
+            network=network,
+            hidden=hidden_state,
+            cache_k=cache_k_inputs[layer_idx],
+            cache_v=cache_v_inputs[layer_idx],
+            attention_mask=attention_mask,
+            position_id=position_id,
+            cos_half_tensor=cos_half_tensor,
+            sin_half_tensor=sin_half_tensor,
+            eps_tensor=eps_tensor,
+            weights=rank_weights,
+            prefix=prefix,
+            hidden_size=hidden,
+            attention_size=attention_size,
+            kv_attention_size=kv_attention_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            max_cache_length=max_cache_length,
+            is_moe_layer=layer_idx >= first_k_dense_replace,
+            n_routed_experts=n_routed_experts,
+            num_experts_per_tok=num_experts_per_tok,
+            moe_intermediate=moe_intermediate,
+            shared_intermediate=shared_intermediate,
+            dense_intermediate=dense_intermediate,
+            tp_size=parallel.tp_size,
+            norm_topk_prob=norm_topk_prob,
+            routed_scaling_factor=routed_scaling_factor,
+        )
+        hidden_state = result["hidden"]
+        present_k_outputs.append(result["present_k"])
+        present_v_outputs.append(result["present_v"])
+
+    final_norm = rank_weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = _apply_norm(
+            network, hidden_state, hidden, final_norm,
+            None, eps_tensor, "rmsnorm")
+
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, hidden_state, hidden, vocab, rank_weights["w_out"])
+    logits = graph_ops.add_bias_sum(
+        network, logits, vocab, np.zeros(vocab, dtype=np.float32))
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for layer_idx in range(num_layers):
+        pk = present_k_outputs[layer_idx]
+        pv = present_v_outputs[layer_idx]
+        pk.name = graph_ops.layer_tensor_name("present_k", layer_idx)
+        pv.name = graph_ops.layer_tensor_name("present_v", layer_idx)
+        network.mark_output(pk)
+        network.mark_output(pv)
+
+    if verbose:
+        print(
+            "[trtmc build] Building DeepSeek-OCR TP TRT engine "
+            f"(rank={parallel.rank}/{parallel.tp_size}, {num_layers} layers, "
+            f"hidden={hidden}, attn={attention_size}, heads={num_heads}, "
+            f"kv_heads={num_kv_heads}, experts={n_routed_experts}, "
+            f"top_k={num_experts_per_tok}, moe_inter={moe_intermediate}, "
+            f"shared_inter={shared_intermediate}, "
+            f"dense_inter={dense_intermediate}, cache={max_cache_length}) ...",
+            file=sys.stderr,
+        )
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT engine build failed")
+    return bytes(plan)

--- a/python/tensorrt_model_connect/families/internvl/plugin.py
+++ b/python/tensorrt_model_connect/families/internvl/plugin.py
@@ -25,6 +25,10 @@ from ...checkpoint_mapper import (
     _has_tensor,
     _transpose_2d,
 )
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 from .standard_decoder_builder import build_standard_decoder_engine
 
 if TYPE_CHECKING:
@@ -57,8 +61,28 @@ class InternVLPlugin:
         max_cache_length: int, *, precision: str = "fp32",
         quant_ctx=None, verbose: bool = False,
         debug_layer_outputs: bool = False,
+        parallel_config=None,
     ) -> bytes:
         """Build text decoder engine (Qwen2 architecture with embed_input for VL)."""
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="InternVL tensor-parallel builds")
+            if debug_layer_outputs:
+                raise ValueError("InternVL tensor-parallel builds do not support debug layer outputs")
+            from .tp_builder import build_dual_profile_tp_decoder_engine
+            return build_dual_profile_tp_decoder_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                norm_type="rmsnorm",
+                mlp_type="swiglu",
+                position_type="rope",
+                activation="silu",
+                embed_input=True,
+                verbose=verbose,
+                parallel_config=parallel)
+
         return build_standard_decoder_engine(
             config, weights, max_cache_length, verbose=verbose,
             quant_ctx=quant_ctx, embed_input=True,
@@ -166,6 +190,7 @@ def _load_internvl_text_weights(
         raise RuntimeError("Cannot find text decoder layer weights")
 
     attention_size = 0
+    kv_attention_size = 0
     mlp_size = 0
 
     for layer_idx in range(num_layers):
@@ -189,6 +214,8 @@ def _load_internvl_text_weights(
         q_hidden = q_raw.shape[0]
         if attention_size == 0:
             attention_size = q_hidden
+        if kv_attention_size == 0:
+            kv_attention_size = k_raw.shape[0]
 
         q_t = _transpose_2d(q_raw, "q_proj")
         k_t = _transpose_2d(k_raw, "k_proj")
@@ -253,6 +280,7 @@ def _load_internvl_text_weights(
         weights["w_out"] = _transpose_2d(embedding.copy(), "embedding_tied")
 
     weights["_attention_size"] = attention_size
+    weights["_kv_attention_size"] = kv_attention_size
     weights["_mlp_size"] = mlp_size
 
     return weights

--- a/python/tensorrt_model_connect/families/internvl/tp_builder.py
+++ b/python/tensorrt_model_connect/families/internvl/tp_builder.py
@@ -1,0 +1,718 @@
+"""Tensor-parallel dual-profile decoder engine builder.
+
+Produces one rank-local TensorRT engine that handles both prefill
+(multi-token) and decode (single-token) phases by switching between two
+optimization profiles at runtime:
+  * Profile 0 (prefill): Sq ranges over [1, opt=opt_prefill_length, max=max_prefill_length].
+    TensorRT picks batched MHA kernels (e.g. ``_gemm_mha_v2``) at opt Sq.
+  * Profile 1 (decode): Sq fixed to 1. TensorRT picks the GEMV fast-path
+    (``_gemv_mha_v1``).
+
+The build path intentionally duplicates most of the single-device
+dual-profile graph so tensor-parallel shape decisions stay explicit here:
+Q/K/V and MLP expansion projections are column-sharded, output/down
+projections are row-sharded, and each row-parallel join inserts a TensorRT
+distributed ALL_REDUCE collective.
+
+Scope: covers the same architectural variants the legacy
+``standard_decoder_builder`` supports - RMSNorm or LayerNorm; SwiGLU or
+GeluFC MLP; RoPE (full / partial / interleaved), learned absolute, or
+ALiBi position; sequential or parallel residual; optional q/k_norm,
+QKV/output/MLP biases, and a Bloom-style embedding LayerNorm. Quantized
+builds (fp8 / int8 ``quant_ctx``) thread Q/DQ insertion through every
+projection matmul via ``QuantContext.maybe_quantized_matmul``. Per-layer
+Per-layer debug outputs and hidden-state outputs stay on
+``standard_decoder_builder`` for now. The VL ``embed_input`` path is included
+here so InternVL can package rank-local decoder engines.
+
+Tensor contract (matches the C++ runtime KvCache naming):
+  Inputs (dynamic shapes - Sq varies by profile)
+    token_id        int32   (-1,)
+    position_id     int32   (-1,)
+    attention_mask  float32 (-1, -1)                 # (Sq, max_cache + Sq)
+    cache_k_i       fp16/f32 (max_cache, kv_size)    # static
+    cache_v_i       fp16/f32 (max_cache, kv_size)    # static
+  Outputs
+    logits          float32 (1, vocab)               # last-row sliced inside the engine
+    present_k_i     fp16/f32 (-1, kv_size)           # (Sq, kv_size)
+    present_v_i     fp16/f32 (-1, kv_size)           # (Sq, kv_size)
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ... import graph_blocks
+from ...parallel_config import (
+    add_all_reduce_sum,
+    normalize_parallel_config,
+    shard_standard_decoder_weights,
+)
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...config import ModelConfig
+    from ...checkpoint_mapper import WeightDict
+    from ...quantization.context import QuantContext
+
+
+def _const_in_work_dtype(
+    network: trt.INetworkDefinition,
+    shape: tuple,
+    values: np.ndarray,
+    work_np_dtype: np.dtype,
+    work_trt_dtype: trt.DataType,
+) -> trt.ITensor:
+    """Create a constant in work_np_dtype storage and cast it to work_trt_dtype.
+
+    Needed for bf16 builds: the dual-profile builder stores bf16 weights
+    on disk as fp16 (work_np_dtype = np.float16), but the runtime tensor
+    must be bfloat16 to match the rest of the graph. ``add_constant``
+    alone produces an fp16 constant - we need an explicit cast to
+    bfloat16 so layers like IRotaryEmbeddingLayer (which require all
+    inputs to share a dtype) accept it. fp16 / fp32 builds are no-ops
+    because work_np_dtype maps directly to work_trt_dtype.
+    """
+    const = graph_ops.add_constant(network, shape, values, dtype=work_np_dtype)
+    if const.dtype != work_trt_dtype:
+        const = network.add_cast(const, work_trt_dtype).get_output(0)
+    return const
+
+
+def _make_matmul_fn(
+    network: trt.INetworkDefinition,
+    dtype: np.dtype,
+    quant_ctx: "QuantContext | None",
+):
+    """Mirror of ``graph_blocks._make_matmul_fn`` for the dual-profile path.
+
+    Returns a callable ``(lhs, lhs_w, rhs_w, rhs_weights, weight_name) -> ITensor``
+    that routes through ``QuantContext.maybe_quantized_matmul`` when present
+    and falls back to a plain ``add_matmul_rhs_constant`` otherwise. The
+    ``weight_name`` is the dotted weight key (e.g. ``layer.0.w_q``) used by
+    the quantization profile to look up scales and the per-layer exclude
+    pattern.
+    """
+    if quant_ctx is None:
+        def matmul(lhs, lhs_w, rhs_w, rhs_weights, weight_name):
+            return graph_ops.add_matmul_rhs_constant(
+                network, lhs, lhs_w, rhs_w, rhs_weights, dtype=dtype)
+        return matmul
+
+    def matmul(lhs, lhs_w, rhs_w, rhs_weights, weight_name):
+        return quant_ctx.maybe_quantized_matmul(
+            network, lhs, lhs_w, rhs_w, rhs_weights, weight_name,
+            dtype=dtype)
+    return matmul
+
+
+def _validate_tp_quantization(quant_ctx: "QuantContext | None") -> None:
+    if quant_ctx is None:
+        return
+    format_name = getattr(getattr(quant_ctx, "profile", None), "format", None)
+    if getattr(format_name, "name", None) != "fp8":
+        raise ValueError("Tensor-parallel decoder quantization currently supports fp8 only")
+
+
+def _norm_multi(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden: int,
+    gamma: np.ndarray,
+    beta: np.ndarray | None,
+    eps_tensor: trt.ITensor,
+    norm_type: str,
+    dtype: np.dtype,
+) -> trt.ITensor:
+    if norm_type == "layernorm":
+        if beta is None:
+            beta = np.zeros(hidden, dtype=np.float32)
+        return graph_ops.add_layer_norm(
+            network, inp, hidden, gamma, beta, eps_tensor, dtype=dtype)
+    return graph_ops.add_rms_norm(
+        network, inp, hidden, gamma, eps_tensor, dtype=dtype)
+
+
+# ---------------------------------------------------------------------------
+# MLP helpers.
+# ---------------------------------------------------------------------------
+
+
+def _swiglu_mlp(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    *,
+    matmul,
+    weights: "WeightDict",
+    prefix: str,
+    hidden: int,
+    mlp_size: int,
+) -> trt.ITensor:
+    gate = matmul(inp, hidden, mlp_size,
+                  weights[f"{prefix}.w_gate"], f"{prefix}.w_gate")
+    up = matmul(inp, hidden, mlp_size,
+                weights[f"{prefix}.w_up"], f"{prefix}.w_up")
+    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
+    swish = network.add_elementwise(
+        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    gated = network.add_elementwise(
+        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+    mlp_out = matmul(gated.get_output(0), mlp_size, hidden,
+                     weights[f"{prefix}.w_down"], f"{prefix}.w_down")
+    return mlp_out
+
+
+def _gelu_fc_mlp(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    *,
+    matmul,
+    weights: "WeightDict",
+    prefix: str,
+    hidden: int,
+    mlp_size: int,
+    activation: str,
+    work_np_dtype: np.dtype,
+) -> trt.ITensor:
+    fc1 = matmul(inp, hidden, mlp_size,
+                 weights[f"{prefix}.w_fc1"], f"{prefix}.w_fc1")
+    fc1_bias = weights.get(f"{prefix}.fc1_bias")
+    if fc1_bias is not None:
+        fc1 = graph_ops.add_bias_sum(network, fc1, mlp_size, fc1_bias, dtype=work_np_dtype)
+    activated = graph_ops.add_activation(network, fc1, activation, dtype=work_np_dtype)
+    fc2 = matmul(activated, mlp_size, hidden,
+                 weights[f"{prefix}.w_fc2"], f"{prefix}.w_fc2")
+    fc2_bias = weights.get(f"{prefix}.fc2_bias")
+    if fc2_bias is not None:
+        fc2 = graph_ops.add_bias_sum(network, fc2, hidden, fc2_bias, dtype=work_np_dtype)
+    return fc2
+
+
+# ---------------------------------------------------------------------------
+# Config guard.
+# ---------------------------------------------------------------------------
+
+
+def _supports_config(config: "ModelConfig", weights: "WeightDict") -> None:
+    """Reject configs the dual-profile builder cannot handle."""
+    model_type = getattr(config, "model_type", "").lower()
+    if "moe" in model_type or "mamba" in model_type or "rwkv" in model_type:
+        raise NotImplementedError(
+            f"dual_profile_decoder_builder does not support model_type={model_type!r}")
+    if "embedding" not in weights:
+        raise NotImplementedError("missing embedding weight")
+    if "final_norm" not in weights:
+        raise NotImplementedError("missing final_norm weight")
+
+
+# ---------------------------------------------------------------------------
+# Main builder.
+# ---------------------------------------------------------------------------
+
+
+def build_dual_profile_tp_decoder_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp16",
+    opt_prefill_length: int = 64,
+    max_prefill_length: int | None = None,
+    quant_ctx: "QuantContext | None" = None,
+    norm_type: str = "rmsnorm",
+    mlp_type: str = "swiglu",
+    position_type: str = "rope",
+    activation: str = "silu",
+    partial_rotary_factor: float = 1.0,
+    interleaved_rope: bool = False,
+    parallel_residual: bool = False,
+    scale_attn_weights: bool = True,
+    embed_input: bool = False,
+    verbose: bool = False,
+    dynamic_kv_profile_rows: list[int] | None = None,
+    parallel_config=None,
+) -> bytes:
+    """Build a rank-local tensor-parallel engine with prefill/decode profiles.
+
+    ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
+    ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
+    ``scale_attn_weights`` mirror the same parameters on
+    ``build_standard_decoder_engine``.
+
+    The current TP implementation supports tp_size 2, 4, and 8. The caller
+    invokes this builder once per rank and packages the rank-local plans into
+    one bundle.
+
+    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
+    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
+    one per bucket - letting TriAttention pick the smallest active KV cache
+    bucket at runtime while still benefitting from batched prefill on the
+    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
+    can constrain their row count independently.
+    """
+    _supports_config(config, weights)
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "dual_profile_decoder_tp_builder requires "
+            "parallel.mode=tensor_parallel and tp_size > 1")
+    _validate_tp_quantization(quant_ctx)
+    if mlp_type != "swiglu":
+        raise NotImplementedError(
+            "Tensor-parallel decoder builds currently support SwiGLU MLPs only")
+    weights = shard_standard_decoder_weights(config, weights, parallel)
+
+    if max_prefill_length is None:
+        max_prefill_length = max_cache_length
+    max_prefill_length = max(1, min(max_prefill_length, max_cache_length))
+    opt_prefill_length = max(1, min(opt_prefill_length, max_prefill_length))
+
+    multi_bucket_decode = bool(dynamic_kv_profile_rows)
+    if multi_bucket_decode:
+        decode_buckets: list[int] = []
+        seen = set()
+        for raw in dynamic_kv_profile_rows or []:
+            clamped = max(1, min(int(raw), max_cache_length))
+            if clamped not in seen:
+                seen.add(clamped)
+                decode_buckets.append(clamped)
+        decode_buckets.sort()
+        if not decode_buckets:
+            decode_buckets = [max_cache_length]
+            multi_bucket_decode = False
+
+    attention_size = weights.get("_attention_size", config.attention_size)
+    mlp_size = weights.get("_mlp_size", config.intermediate_size)
+    hidden = config.hidden_size
+    vocab = config.vocab_size
+    num_layers = config.num_hidden_layers
+    num_heads = config.num_attention_heads // parallel.tp_size
+    num_kv_heads = config.num_key_value_heads // parallel.tp_size
+    head_dim = attention_size // num_heads
+    kv_attention_size = graph_blocks.infer_kv_attention_size(
+        weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
+    rotary_embedding_dim = int(head_dim * partial_rotary_factor)
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    if precision == "fp16":
+        work_np_dtype, work_trt_dtype = np.float16, trt.float16
+    elif precision == "bf16":
+        work_np_dtype, work_trt_dtype = np.float16, trt.bfloat16
+    else:
+        work_np_dtype, work_trt_dtype = np.float32, trt.float32
+
+    # ---- Inputs (dynamic Sq) ---------------------------------------------
+    token_id = network.add_input("token_id", trt.int32, (-1,))
+    position_id = network.add_input("position_id", trt.int32, (-1,))
+    attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
+    input_embed_tensor = None
+    use_input_embed_tensor = None
+    if embed_input:
+        input_embed_tensor = network.add_input(
+            "input_embed", work_trt_dtype, (1, hidden))
+        use_input_embed_tensor = network.add_input(
+            "use_input_embed", trt.float32, (1,))
+
+    cache_shape: tuple[int, int]
+    if multi_bucket_decode:
+        cache_shape = (-1, kv_attention_size)
+    else:
+        cache_shape = (max_cache_length, kv_attention_size)
+    cache_k_inputs: list[trt.ITensor] = []
+    cache_v_inputs: list[trt.ITensor] = []
+    for i in range(num_layers):
+        ck = network.add_input(
+            graph_ops.layer_tensor_name("cache_k", i),
+            work_trt_dtype, cache_shape)
+        cv = network.add_input(
+            graph_ops.layer_tensor_name("cache_v", i),
+            work_trt_dtype, cache_shape)
+        cache_k_inputs.append(ck)
+        cache_v_inputs.append(cv)
+
+    # Cast mask to compute dtype for elementwise broadcast.
+    if work_trt_dtype != trt.float32:
+        attention_mask_work = network.add_cast(
+            attention_mask, work_trt_dtype).get_output(0)
+    else:
+        attention_mask_work = attention_mask
+
+    # Two (or 1+N) optimization profiles - same graph, different Sq / cache.
+    def _add_profile(opt_sq: int, max_sq: int, *, fixed: bool = False,
+                     cache_rows_min: int | None = None,
+                     cache_rows_opt: int | None = None,
+                     cache_rows_max: int | None = None):
+        prof = builder.create_optimization_profile()
+        min_sq = opt_sq if fixed else 1
+        prof.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
+        prof.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
+        prof.set_shape(
+            "attention_mask",
+            (min_sq, max_cache_length + min_sq),
+            (opt_sq, max_cache_length + opt_sq),
+            (max_sq, max_cache_length + max_sq))
+        if multi_bucket_decode:
+            cmn = cache_rows_min if cache_rows_min is not None else 1
+            cop = cache_rows_opt if cache_rows_opt is not None else max_cache_length
+            cmx = cache_rows_max if cache_rows_max is not None else max_cache_length
+            for i in range(num_layers):
+                for name in (graph_ops.layer_tensor_name("cache_k", i),
+                             graph_ops.layer_tensor_name("cache_v", i)):
+                    prof.set_shape(
+                        name,
+                        (cmn, kv_attention_size),
+                        (cop, kv_attention_size),
+                        (cmx, kv_attention_size))
+        trt_config.add_optimization_profile(prof)
+
+    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                 cache_rows_min=1, cache_rows_opt=max_cache_length,
+                 cache_rows_max=max_cache_length)
+    if multi_bucket_decode:
+        for bucket in decode_buckets:
+            _add_profile(1, 1, fixed=True,
+                         cache_rows_min=1, cache_rows_opt=bucket,
+                         cache_rows_max=bucket)
+    else:
+        _add_profile(1, 1, fixed=True)
+
+    # ---- Shared constants ------------------------------------------------
+    embedding_table = _const_in_work_dtype(
+        network, (vocab, hidden), weights["embedding"],
+        work_np_dtype, work_trt_dtype)
+
+    # RoPE tables (only when position_type == "rope"). Built for the worst
+    # case key length max_cache_length + max_prefill_length, since RoPE is
+    # gathered by position_id at runtime. The half-dim tables feed TRT's
+    # native IRotaryEmbeddingLayer.
+    cos_half_table: trt.ITensor | None = None
+    sin_half_table: trt.ITensor | None = None
+    if position_type == "rope":
+        kmax = max_cache_length + max_prefill_length
+        graph_ops.validate_native_rope_dim(rotary_embedding_dim)
+        cos_half_np = graph_ops.make_rope_table_half_dim(
+            kmax, head_dim, config.rope_theta, True,
+            partial_rotary_factor, interleaved=interleaved_rope)
+        sin_half_np = graph_ops.make_rope_table_half_dim(
+            kmax, head_dim, config.rope_theta, False,
+            partial_rotary_factor, interleaved=interleaved_rope)
+        cos_half_table = _const_in_work_dtype(
+            network, cos_half_np.shape, cos_half_np,
+            work_np_dtype, work_trt_dtype)
+        sin_half_table = _const_in_work_dtype(
+            network, sin_half_np.shape, sin_half_np,
+            work_np_dtype, work_trt_dtype)
+
+    # Learned position embedding (GPT-2 / OPT / GPT-Neo / XGLM).
+    position_embed_table: trt.ITensor | None = None
+    if position_type == "learned":
+        pos_embed_np = weights["position_embedding"]
+        position_embed_table = _const_in_work_dtype(
+            network, pos_embed_np.shape, pos_embed_np,
+            work_np_dtype, work_trt_dtype)
+
+    # ALiBi slopes + cache-slot positions for multi-row mask augmentation.
+    alibi_slopes_tensor: trt.ITensor | None = None
+    alibi_cache_positions_fp32: trt.ITensor | None = None
+    if position_type == "alibi":
+        alibi_slopes_np = graph_ops.compute_alibi_slopes(num_heads)
+        # Slopes live as fp32 so the (key_pos - q_pos) math stays in fp32;
+        # add_alibi_mask_4d casts the final bias to work_trt_dtype before adding
+        # to the additive mask.
+        alibi_slopes_tensor = graph_ops.add_constant(
+            network, (num_heads, 1, 1),
+            alibi_slopes_np.reshape(num_heads, 1, 1), dtype=np.float32)
+        # Cache slot k (for k in [0, max_cache_length)) holds the K/V at
+        # position k. The current step's K/V live in slots
+        # [max_cache_length, max_cache_length + Sq) and their positions come
+        # from position_id at runtime, so we only pre-build the cache half.
+        alibi_cache_positions_fp32 = graph_ops.add_constant(
+            network, (max_cache_length,),
+            np.arange(max_cache_length, dtype=np.float32), dtype=np.float32)
+
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1),
+        np.array([[config.rms_norm_eps]], dtype=np.float32),
+        dtype=np.float32)
+    eps_tensor_per_head = graph_ops.add_constant(
+        network, (1, 1, 1),
+        np.array([[[config.rms_norm_eps]]], dtype=np.float32),
+        dtype=np.float32)
+
+    # Attention scale.
+    attn_scale = (1.0 / np.sqrt(max(head_dim, 1))) if scale_attn_weights else 1.0
+
+    # Quantization-aware matmul (passes weight_name through to QuantContext).
+    matmul = _make_matmul_fn(network, work_np_dtype, quant_ctx)
+
+    # ---- Embedding -------------------------------------------------------
+    emb = network.add_gather(embedding_table, token_id, 0)
+    hidden_state = emb.get_output(0)  # (Sq, hidden)
+
+    if embed_input and input_embed_tensor is not None and use_input_embed_tensor is not None:
+        flag_broadcast = network.add_shuffle(use_input_embed_tensor)
+        flag_broadcast.reshape_dims = (1, 1)
+        flag_for_math = flag_broadcast.get_output(0)
+        if work_trt_dtype != trt.float32:
+            flag_for_math = network.add_cast(flag_for_math, work_trt_dtype).get_output(0)
+        one_const = graph_ops.add_constant(
+            network, (1, 1), np.array([1.0], dtype=work_np_dtype),
+            dtype=work_np_dtype)
+        inv_flag = network.add_elementwise(
+            one_const, flag_for_math,
+            trt.ElementWiseOperation.SUB)
+        tok_part = network.add_elementwise(
+            inv_flag.get_output(0), hidden_state,
+            trt.ElementWiseOperation.PROD)
+        embed_part = network.add_elementwise(
+            flag_for_math, input_embed_tensor,
+            trt.ElementWiseOperation.PROD)
+        hidden_state_sum = network.add_elementwise(
+            tok_part.get_output(0), embed_part.get_output(0),
+            trt.ElementWiseOperation.SUM)
+        hidden_state = hidden_state_sum.get_output(0)
+
+    if position_type == "learned" and position_embed_table is not None:
+        pos_gather = network.add_gather(position_embed_table, position_id, 0)
+        pos_add = network.add_elementwise(
+            hidden_state, pos_gather.get_output(0),
+            trt.ElementWiseOperation.SUM)
+        hidden_state = pos_add.get_output(0)
+
+    # Make sure the main hidden stream is in the requested runtime dtype
+    # before entering the layer stack (BF16 mode stores fp16 constants).
+    if hidden_state.dtype != work_trt_dtype:
+        hidden_state = network.add_cast(hidden_state, work_trt_dtype).get_output(0)
+
+    # Optional embedding LayerNorm (Bloom).
+    embed_norm = weights.get("embedding_norm")
+    if embed_norm is not None:
+        embed_norm_beta = weights.get(
+            "embedding_norm_beta", np.zeros(hidden, dtype=np.float32))
+        hidden_state = _norm_multi(
+            network, hidden_state, hidden, embed_norm, embed_norm_beta,
+            eps_tensor, "layernorm", work_np_dtype)
+
+    # Build the 4D additive mask once - shared across layers. ALiBi
+    # variants augment the mask with per-head linear bias.
+    if position_type == "alibi":
+        mask_4d = graph_ops.add_alibi_mask_4d(
+            network, attention_mask_work, position_id,
+            alibi_slopes_tensor, alibi_cache_positions_fp32,
+            num_heads, target_dtype=work_trt_dtype)
+    else:
+        mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask_work)
+
+    present_k_outs: list[trt.ITensor] = []
+    present_v_outs: list[trt.ITensor] = []
+
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+
+        # Pre-attention norm.
+        normed = _norm_multi(
+            network, hidden_state, hidden,
+            weights[f"{prefix}.input_norm"],
+            weights.get(f"{prefix}.input_norm_beta"),
+            eps_tensor, norm_type, work_np_dtype)
+
+        # Q / K / V projections.
+        q = matmul(normed, hidden, attention_size,
+                   weights[f"{prefix}.w_q"], f"{prefix}.w_q")
+        k = matmul(normed, hidden, kv_attention_size,
+                   weights[f"{prefix}.w_k"], f"{prefix}.w_k")
+        v = matmul(normed, hidden, kv_attention_size,
+                   weights[f"{prefix}.w_v"], f"{prefix}.w_v")
+
+        # Optional QKV biases (Qwen2 / GPT-2 / OPT / Bloom / Falcon / etc.).
+        q_bias = weights.get(f"{prefix}.q_bias")
+        if q_bias is not None:
+            q = graph_ops.add_bias_sum(
+                network, q, attention_size, q_bias, dtype=work_np_dtype)
+        k_bias = weights.get(f"{prefix}.k_bias")
+        if k_bias is not None:
+            k = graph_ops.add_bias_sum(
+                network, k, kv_attention_size, k_bias, dtype=work_np_dtype)
+        v_bias = weights.get(f"{prefix}.v_bias")
+        if v_bias is not None:
+            v = graph_ops.add_bias_sum(
+                network, v, kv_attention_size, v_bias, dtype=work_np_dtype)
+
+        # Optional per-head q/k norm (Qwen3).
+        q_norm = weights.get(f"{prefix}.q_norm")
+        if q_norm is not None:
+            q = graph_ops.add_rms_norm_per_head(
+                network, q, num_heads, head_dim, q_norm,
+                eps_tensor_per_head, dtype=work_np_dtype,
+                sequence_length=None)
+        k_norm = weights.get(f"{prefix}.k_norm")
+        if k_norm is not None:
+            k = graph_ops.add_rms_norm_per_head(
+                network, k, num_kv_heads, head_dim, k_norm,
+                eps_tensor_per_head, dtype=work_np_dtype,
+                sequence_length=None)
+
+        # Position embedding (RoPE only; learned was applied above and ALiBi
+        # is added into the attention mask).
+        if position_type == "rope":
+            q = graph_ops.add_apply_rope_native(
+                network, q, num_heads, head_dim,
+                cos_half_table, sin_half_table, position_id,
+                rotary_embedding_dim, interleaved_rope,
+                sequence_length=None)
+            k = graph_ops.add_apply_rope_native(
+                network, k, num_kv_heads, head_dim,
+                cos_half_table, sin_half_table, position_id,
+                rotary_embedding_dim, interleaved_rope,
+                sequence_length=None)
+
+        # Present K / V (this step's raw K / V), shape (Sq, attn_size).
+        present_k_outs.append(k)
+        present_v_outs.append(v)
+
+        # Concatenate cached + current K / V along the sequence dim.
+        all_k_cat = network.add_concatenation([cache_k_inputs[layer_idx], k])
+        all_k_cat.axis = 0
+        all_v_cat = network.add_concatenation([cache_v_inputs[layer_idx], v])
+        all_v_cat.axis = 0
+
+        context = graph_ops.add_attention_from_rows(
+            network, q, all_k_cat.get_output(0), all_v_cat.get_output(0),
+            num_heads=num_heads, head_dim=head_dim,
+            num_kv_heads=num_kv_heads,
+            q_seq=None, kv_seq=None, causal=False, mask=mask_4d,
+            scale=attn_scale, tag=f"{prefix}.attn")
+
+        attn_out = matmul(context, attention_size, hidden,
+                          weights[f"{prefix}.w_o"], f"{prefix}.w_o")
+        attn_out = add_all_reduce_sum(network, attn_out, parallel.tp_size)
+        o_bias = weights.get(f"{prefix}.o_bias")
+        if o_bias is not None:
+            attn_out = graph_ops.add_bias_sum(
+                network, attn_out, hidden, o_bias, dtype=work_np_dtype)
+
+        # Residual structure: parallel (GPT-NeoX / CodeGen / Falcon-3) vs
+        # sequential (everything else).
+        if parallel_residual:
+            post_attn_norm_w = weights.get(f"{prefix}.post_attn_norm")
+            if post_attn_norm_w is not None:
+                norm2 = _norm_multi(
+                    network, hidden_state, hidden,
+                    post_attn_norm_w,
+                    weights.get(f"{prefix}.post_attn_norm_beta"),
+                    eps_tensor, norm_type, work_np_dtype)
+            else:
+                norm2 = normed
+        else:
+            residual1 = network.add_elementwise(
+                hidden_state, attn_out, trt.ElementWiseOperation.SUM)
+            norm2 = _norm_multi(
+                network, residual1.get_output(0), hidden,
+                weights[f"{prefix}.post_attn_norm"],
+                weights.get(f"{prefix}.post_attn_norm_beta"),
+                eps_tensor, norm_type, work_np_dtype)
+
+        # MLP - SwiGLU (Llama-style) or GeluFC (GPT-2-style).
+        if mlp_type == "gelu_fc":
+            mlp_out = _gelu_fc_mlp(
+                network, norm2,
+                matmul=matmul, weights=weights, prefix=prefix,
+                hidden=hidden, mlp_size=mlp_size,
+                activation=activation, work_np_dtype=work_np_dtype)
+        else:
+            mlp_out = _swiglu_mlp(
+                network, norm2,
+                matmul=matmul, weights=weights, prefix=prefix,
+                hidden=hidden, mlp_size=mlp_size)
+        mlp_out = add_all_reduce_sum(network, mlp_out, parallel.tp_size)
+
+        # Final residual.
+        if parallel_residual:
+            sum_attn = network.add_elementwise(
+                hidden_state, attn_out, trt.ElementWiseOperation.SUM)
+            residual2 = network.add_elementwise(
+                sum_attn.get_output(0), mlp_out, trt.ElementWiseOperation.SUM)
+        else:
+            residual2 = network.add_elementwise(
+                residual1.get_output(0), mlp_out, trt.ElementWiseOperation.SUM)
+        hidden_state = residual2.get_output(0)
+
+    # ---- Final norm + LM head -------------------------------------------
+    final_norm = weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = _norm_multi(
+            network, hidden_state, hidden, final_norm,
+            weights.get("final_norm_beta"),
+            eps_tensor, norm_type, work_np_dtype)
+
+    # Only the LAST prompt token's logits matter for the next-token sample,
+    # so slice hidden_state from (Sq, hidden) to (1, hidden) before the LM
+    # head. This keeps the output contract identical to the single-token
+    # engine (logits shape = (1, vocab)) under both profiles and avoids
+    # computing (Sq - 1) redundant vocab-sized matmul rows during prefill.
+    shape_t = network.add_shape(hidden_state).get_output(0)  # [2] int64
+    one_hidden = graph_ops.add_constant(
+        network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
+    start_sub = network.add_elementwise(
+        shape_t, one_hidden, trt.ElementWiseOperation.SUB)
+    start_t = start_sub.get_output(0)  # [Sq - 1, 0]
+    size_t = graph_ops.add_constant(
+        network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
+    slicer = network.add_slice(hidden_state, start=(0, 0), shape=(0, 0), stride=(1, 1))
+    slicer.set_input(1, start_t)
+    slicer.set_input(2, size_t)
+    last_hidden = slicer.get_output(0)
+
+    out_vocab = (weights["w_out"].shape[1]
+                 if isinstance(weights["w_out"], np.ndarray) else vocab)
+    logits = graph_ops.add_matmul_rhs_constant(
+        network, last_hidden, hidden, out_vocab, weights["w_out"],
+        dtype=work_np_dtype)
+    lm_bias = weights.get("lm_head_bias")
+    if lm_bias is not None:
+        logits = graph_ops.add_bias_sum(
+            network, logits, out_vocab, lm_bias, dtype=work_np_dtype)
+    else:
+        zero_bias = np.zeros(out_vocab, dtype=work_np_dtype)
+        logits = graph_ops.add_bias_sum(
+            network, logits, out_vocab, zero_bias, dtype=work_np_dtype)
+
+    if work_trt_dtype != trt.float32:
+        logits = network.add_cast(logits, trt.float32).get_output(0)
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    for i in range(num_layers):
+        pk = present_k_outs[i]
+        pv = present_v_outs[i]
+        pk.name = graph_ops.layer_tensor_name("present_k", i)
+        pv.name = graph_ops.layer_tensor_name("present_v", i)
+        network.mark_output(pk)
+        network.mark_output(pv)
+
+    if verbose:
+        print(f"[trtmc-build] Building tensor-parallel decoder engine "
+              f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
+              f"kv={kv_attention_size}, "
+              f"mlp={mlp_size}, cache={max_cache_length}, "
+              f"opt_prefill={opt_prefill_length}, max_prefill={max_prefill_length}, "
+              f"norm={norm_type}, mlp_type={mlp_type}, pos={position_type}, "
+              f"precision={precision}, tp={parallel.tp_size}, rank={parallel.rank}) ...",
+              file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("Tensor-parallel decoder engine build failed")
+    return bytes(plan)

--- a/tests/builder/test_engine_deepseek_ocr_tp.py
+++ b/tests/builder/test_engine_deepseek_ocr_tp.py
@@ -1,0 +1,185 @@
+"""Focused tests for DeepSeek-OCR tensor-parallel support."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+try:
+    deepseek_ocr_module = importlib.import_module(
+        "tensorrt_model_connect.families.deepseek_ocr.plugin")
+    from tensorrt_model_connect.checkpoint_mapper import WeightDict
+    from tensorrt_model_connect.families.deepseek_ocr import tp_builder
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _config(num_heads: int = 4, num_kv_heads: int | None = None) -> SimpleNamespace:
+    kv_heads = num_heads if num_kv_heads is None else num_kv_heads
+    return SimpleNamespace(
+        raw={},
+        hidden_size=8,
+        vocab_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=num_heads,
+        num_key_value_heads=kv_heads,
+        head_dim=4,
+        attention_size=num_heads * 4,
+        intermediate_size=16,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+    )
+
+
+def _weights() -> WeightDict:
+    hidden = 8
+    attention = 16
+    kv_attention = 16
+    inter = 16
+    shared = 32
+    weights = WeightDict({
+        "_attention_size": attention,
+        "_kv_attention_size": kv_attention,
+        "_n_routed_experts": 2,
+        "_n_shared_experts": 2,
+        "_num_experts_per_tok": 2,
+        "_first_k_dense_replace": 1,
+        "_moe_intermediate_size": inter,
+        "_shared_intermediate_size": shared,
+        "_norm_topk_prob": False,
+        "_routed_scaling_factor": 1.0,
+        "embedding": np.zeros((32, hidden), dtype=np.float32),
+        "final_norm": np.ones((hidden,), dtype=np.float32),
+        "w_out": np.zeros((hidden, 32), dtype=np.float32),
+    })
+    for layer_idx in range(2):
+        prefix = f"layer.{layer_idx}"
+        weights[f"{prefix}.input_norm"] = np.ones((hidden,), dtype=np.float32)
+        weights[f"{prefix}.post_attn_norm"] = np.ones((hidden,), dtype=np.float32)
+        weights[f"{prefix}.w_q"] = np.arange(
+            hidden * attention, dtype=np.float32).reshape(hidden, attention)
+        weights[f"{prefix}.w_k"] = np.arange(
+            hidden * kv_attention, dtype=np.float32).reshape(hidden, kv_attention)
+        weights[f"{prefix}.w_v"] = np.arange(
+            hidden * kv_attention, dtype=np.float32).reshape(hidden, kv_attention)
+        weights[f"{prefix}.w_o"] = np.arange(
+            attention * hidden, dtype=np.float32).reshape(attention, hidden)
+
+    for key in ("w_gate", "w_up"):
+        weights[f"layer.0.{key}"] = np.arange(
+            hidden * inter, dtype=np.float32).reshape(hidden, inter)
+    weights["layer.0.w_down"] = np.arange(
+        inter * hidden, dtype=np.float32).reshape(inter, hidden)
+
+    weights["layer.1.router"] = np.zeros((hidden, 2), dtype=np.float32)
+    for expert_idx in range(2):
+        prefix = f"layer.1.expert.{expert_idx}"
+        for key in ("w_gate", "w_up"):
+            weights[f"{prefix}.{key}"] = np.arange(
+                hidden * inter, dtype=np.float32).reshape(hidden, inter)
+        weights[f"{prefix}.w_down"] = np.arange(
+            inter * hidden, dtype=np.float32).reshape(inter, hidden)
+    for key in ("w_gate", "w_up"):
+        weights[f"layer.1.shared.{key}"] = np.arange(
+            hidden * shared, dtype=np.float32).reshape(hidden, shared)
+    weights["layer.1.shared.w_down"] = np.arange(
+        shared * hidden, dtype=np.float32).reshape(shared, hidden)
+    return weights
+
+
+def test_deepseek_ocr_tp_slices_attention_and_moe_weights() -> None:
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=2, rank=1)
+    weights = _weights()
+
+    sharded = tp_builder.shard_deepseek_ocr_weights(
+        _config(), weights, parallel=parallel)
+
+    np.testing.assert_array_equal(
+        sharded["layer.0.w_q"], weights["layer.0.w_q"][:, 8:16])
+    np.testing.assert_array_equal(
+        sharded["layer.0.w_k"], weights["layer.0.w_k"][:, 8:16])
+    np.testing.assert_array_equal(
+        sharded["layer.0.w_v"], weights["layer.0.w_v"][:, 8:16])
+    np.testing.assert_array_equal(
+        sharded["layer.0.w_o"], weights["layer.0.w_o"][8:16, :])
+    np.testing.assert_array_equal(
+        sharded["layer.0.w_gate"], weights["layer.0.w_gate"][:, 8:16])
+    np.testing.assert_array_equal(
+        sharded["layer.0.w_down"], weights["layer.0.w_down"][8:16, :])
+    np.testing.assert_array_equal(
+        sharded["layer.1.expert.0.w_up"],
+        weights["layer.1.expert.0.w_up"][:, 8:16])
+    np.testing.assert_array_equal(
+        sharded["layer.1.expert.0.w_down"],
+        weights["layer.1.expert.0.w_down"][8:16, :])
+    np.testing.assert_array_equal(
+        sharded["layer.1.shared.w_gate"],
+        weights["layer.1.shared.w_gate"][:, 16:32])
+    assert sharded["_attention_size"] == 8
+    assert sharded["_kv_attention_size"] == 8
+    assert sharded["_moe_intermediate_size"] == 8
+    assert sharded["_shared_intermediate_size"] == 16
+
+
+def test_deepseek_ocr_tp_validation_rejects_non_divisible_attention_heads() -> None:
+    with pytest.raises(ValueError, match="num_attention_heads"):
+        tp_builder._validate_deepseek_ocr_tp(
+            _config(num_heads=10),
+            _weights(),
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+        )
+
+
+def test_deepseek_ocr_plugin_routes_parallel_builds(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"deepseek-ocr-tp-plan"
+
+    monkeypatch.setattr(
+        deepseek_ocr_module,
+        "require_tensorrt_11_for_tensor_parallel",
+        fake_require,
+    )
+    monkeypatch.setattr(tp_builder, "build_deepseek_ocr_tp_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=2, rank=1)
+    plugin = deepseek_ocr_module.DeepSeekOCRPlugin()
+    result = plugin.build_engine(
+        _config(), _weights(), 4096,
+        verbose=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"deepseek-ocr-tp-plan"
+    assert calls["require"][0] == parallel
+    assert "DeepSeek-OCR tensor-parallel" in calls["require"][1]
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 4096
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["verbose"] is True
+
+
+def test_deepseek_ocr_parallel_build_rejects_debug_outputs(monkeypatch) -> None:
+    monkeypatch.setattr(
+        deepseek_ocr_module,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="debug layer outputs"):
+        deepseek_ocr_module.DeepSeekOCRPlugin().build_engine(
+            _config(),
+            _weights(),
+            max_cache_length=4096,
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=2, rank=0),
+            debug_layer_outputs=True,
+        )

--- a/tests/builder/test_engine_internvl_tp.py
+++ b/tests/builder/test_engine_internvl_tp.py
@@ -1,0 +1,104 @@
+"""Focused tests for InternVL tensor-parallel text decoder support."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
+
+class _Config:
+    model_type = "internvl_chat"
+
+
+def test_internvl_tp_builder_rejects_single_device_mode() -> None:
+    from tensorrt_model_connect.families.internvl import tp_builder
+
+    weights = WeightDict({
+        "embedding": np.zeros((4, 4), dtype=np.float32),
+        "final_norm": np.ones((4,), dtype=np.float32),
+    })
+
+    with pytest.raises(ValueError, match="requires .*tensor_parallel"):
+        tp_builder.build_dual_profile_tp_decoder_engine(
+            _Config(),
+            weights,
+            max_cache_length=4,
+            parallel_config=ParallelConfig(),
+        )
+
+
+def test_internvl_parallel_build_routes_to_tp_builder(monkeypatch) -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.internvl.plugin")
+    from tensorrt_model_connect.families.internvl import tp_builder
+
+    calls = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = {
+            "config": config,
+            "weights": weights,
+            "max_cache_length": max_cache_length,
+            "kwargs": kwargs,
+        }
+        return b"internvl-tp-plan"
+
+    monkeypatch.setattr(
+        plugin_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(
+        tp_builder, "build_dual_profile_tp_decoder_engine", fake_build)
+
+    config = object()
+    weights = WeightDict()
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+
+    result = plugin_module.plugin.build_engine(
+        config,
+        weights,
+        max_cache_length=384,
+        parallel_config=parallel,
+        precision="fp16",
+    )
+
+    assert result == b"internvl-tp-plan"
+    assert calls["require"] == (parallel, "InternVL tensor-parallel builds")
+    assert calls["build"]["config"] is config
+    assert calls["build"]["weights"] is weights
+    assert calls["build"]["max_cache_length"] == 384
+
+    kwargs = calls["build"]["kwargs"]
+    assert kwargs["precision"] == "fp16"
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["embed_input"] is True
+    assert kwargs["norm_type"] == "rmsnorm"
+    assert kwargs["mlp_type"] == "swiglu"
+    assert kwargs["position_type"] == "rope"
+    assert kwargs["activation"] == "silu"
+
+
+def test_internvl_parallel_build_rejects_debug_outputs(monkeypatch) -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.internvl.plugin")
+
+    monkeypatch.setattr(
+        plugin_module,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+
+    with pytest.raises(ValueError, match="debug layer outputs"):
+        plugin_module.plugin.build_engine(
+            object(),
+            WeightDict(),
+            max_cache_length=384,
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+            debug_layer_outputs=True,
+        )

--- a/tests/builder/test_family_plugins.py
+++ b/tests/builder/test_family_plugins.py
@@ -107,6 +107,8 @@ class TestQwenPlugin:
         assert "final_norm" in weights
         assert "w_out" in weights
         assert weights["_attention_size"] == self.HIDDEN
+        assert weights["_kv_attention_size"] == self.KV_HEADS * (
+            self.HIDDEN // self.HEADS)
         assert weights["_mlp_size"] == self.MLP
 
     def test_transpose_applied(self, tmp_path):

--- a/tests/e2e/models/deepseek-ocr-l0-tp2.json
+++ b/tests/e2e/models/deepseek-ocr-l0-tp2.json
@@ -1,0 +1,68 @@
+{
+  "name": "deepseek-ocr-l0-tp2",
+  "trace_id": "IT-E2E-DSOCR-L0-TP2-01",
+  "hf_id": "deepseek-ai/DeepSeek-OCR-2",
+  "bundle": "deepseek-ocr-l0-tp2.trtfb",
+  "family": "deepseek_ocr",
+  "runtime_strategy": "vision_language",
+  "ci_tier": "multi_device",
+  "reference_family": "ocr_markdown",
+  "user_contract": "ocr_text",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 4096,
+  "prompt": "Extract the text from this image.",
+  "max_new_tokens": 80,
+  "logit_atol": 0.001,
+  "test_image": "tests/e2e/data/orc_test_img.jpeg",
+  "trust_remote_code": true,
+  "reference_backend": "golden_snapshot",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 2
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 2,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 2
+      },
+      "gating": true
+    }
+  ],
+  "stages": [
+    {
+      "name": "full_generation",
+      "required": true
+    }
+  ],
+  "metadata": {
+    "golden_snapshot_path": "tests/e2e/data/deepseek_ocr_l0_golden.json"
+  },
+  "notes": "DeepSeek-OCR TP2 coverage. The checkpoint has 10 attention/KV heads, so TP4 is not valid. Uses the same checkpoint, image input, prompt, cache length, golden snapshot, and OCR contract as deepseek-ocr-l0 while running the language decoder through rank-local TP engines."
+}

--- a/tests/e2e/models/internvl3-2b-tp2.json
+++ b/tests/e2e/models/internvl3-2b-tp2.json
@@ -1,0 +1,68 @@
+{
+  "name": "internvl3-2b-tp2",
+  "trace_id": "IT-E2E-IVL3-02-TP2",
+  "hf_id": "OpenGVLab/InternVL3-2B-hf",
+  "bundle": "internvl3-2b-tp2-vl.trtfb",
+  "family": "internvl",
+  "runtime_strategy": "vision_language",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 384,
+  "prompt": "What color is the vehicle in this image? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "test_image": "tests/e2e/data/test_img.jpeg",
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 2
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 2,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 2
+      },
+      "gating": true
+    }
+  ],
+  "stages": [
+    {
+      "name": "full_generation",
+      "required": true
+    }
+  ],
+  "threshold_overrides": {
+    "token_agreement_rate": 0.2,
+    "normalized_text_edit_distance": 0.7,
+    "vision_embedding_cosine": 0.9
+  },
+  "notes": "InternVL3 2B TP2 coverage. The checkpoint has 2 KV heads, so TP4 is not valid. Uses the same checkpoint, prompt, cache length, image, and thresholds as internvl3-2b while running the text decoder through rank-local TP engines."
+}

--- a/tests/e2e/models/internvl3-8b-tp4.json
+++ b/tests/e2e/models/internvl3-8b-tp4.json
@@ -1,0 +1,76 @@
+{
+  "name": "internvl3-8b-tp4",
+  "trace_id": "IT-E2E-IVL3-01-TP4",
+  "hf_id": "OpenGVLab/InternVL3-8B-hf",
+  "bundle": "internvl3-8b-tp4-vl.trtfb",
+  "family": "internvl",
+  "runtime_strategy": "vision_language",
+  "reference_backend": "golden_snapshot",
+  "reference_family": "vl_instruct_qa",
+  "user_contract": "vl_answer",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "internvl3-2b-tp2",
+  "l0_replacement_reason": "InternVL3-8B TP4 is scale coverage; internvl3-2b-tp2 keeps the InternVL3 TP VL path for PR validation because the 2B checkpoint has only 2 KV heads.",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 384,
+  "prompt": "What color is the vehicle in this image? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "test_image": "tests/e2e/data/test_img.jpeg",
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "stages": [
+    {
+      "name": "full_generation",
+      "required": true
+    }
+  ],
+  "metadata": {
+    "golden_snapshot_path": "tests/e2e/data/internvl3_8b_golden.json"
+  },
+  "threshold_overrides": {
+    "token_agreement_rate": 0.2,
+    "normalized_text_edit_distance": 0.7,
+    "vision_embedding_cosine": 0.9
+  },
+  "notes": "InternVL3 8B TP4 scale coverage. Uses the same checkpoint, prompt, cache length, image, thresholds, and golden snapshot as internvl3-8b while running the text decoder through rank-local TP engines."
+}


### PR DESCRIPTION
## Background
InternVL and DeepSeek-OCR both use vision-language runtimes with text decoders that can run through rank-local tensor-parallel engines. InternVL needs coverage for both requested variants, while DeepSeek-OCR needs TP2 because its language decoder has 10 attention/KV heads and TP4 is not valid.

## Exit Criteria
- Add InternVL tensor-parallel support for InternVL3 2B and InternVL3 8B.
- Add DeepSeek-OCR tensor-parallel support without changing the single-device vision engine path.
- Validate all added E2E manifests on B200 GPUs 0-3 before creating this PR.
- Keep the implementation in one PR.

## Implementation
- Add InternVL TP text-decoder routing and a family-local `tp_builder.py`.
- Update the vision-language runtime and E2E runner to handle rank-local text engine sections under distributed runtime.
- Add InternVL3 2B TP2 and InternVL3 8B TP4 E2E manifests.
- Add a DeepSeek-OCR TP2 text-decoder builder that shards Q/K/V, row-parallel output/down projections, dense MLP, routed experts, and shared experts, then all-reduces row-parallel joins.
- Add a DeepSeek-OCR L0 TP2 E2E manifest using the same checkpoint, OCR image, prompt, cache length, golden snapshot, and OCR contract as `deepseek-ocr-l0`.

## Validation
- `CUDA_VISIBLE_DEVICES=0,1,2,3 PYTHONPATH=python:. /opt/venv/bin/python -m pytest -q tests/builder/test_engine_internvl_tp.py tests/builder/test_engine_deepseek_ocr_tp.py tests/builder/test_family_plugins.py::TestInternVLPlugin::test_load_text_weights_keys tests/builder/test_manifest_validation.py`: passed in the B200 Docker container, `34 passed in 1.83s`.
- `cmake -S . -B build-internvl-deepseek-ocr-tp -G Ninja -DCMAKE_BUILD_TYPE=Release -DTRTMC_TRT_INCLUDE_DIR=/opt/trt/include -DTRTMC_TRT_LIBRARY=/opt/trt/lib/libnvinfer.so -DTRTMC_CUDA_INCLUDE_DIR=/usr/local/cuda/include -DTRTMC_CUDART_LIBRARY=/usr/local/cuda/lib64/libcudart.so`: passed in the B200 Docker container.
- `cmake --build build-internvl-deepseek-ocr-tp --target trtmc trtmc_backend_trt -j`: passed in the B200 Docker container.
- `CUDA_VISIBLE_DEVICES=0,1 PYTHONPATH=python:. /opt/venv/bin/python -m pytest -q "tests/test_e2e.py::test_e2e[deepseek-ocr-l0-tp2]" -v --multi-device-only --engine-dir /tmp/trtmc-storage/internvl-deepseek-ocr-tp/engines --trtmc-binary ./build-internvl-deepseek-ocr-tp/trtmc --hf-python /opt/venv/bin/python --e2e-artifacts-dir /tmp/trtmc-storage/internvl-deepseek-ocr-tp/artifacts --rebuild-engines -s -p no:cacheprovider`: passed on B200 GPUs 0-1, `1 passed in 387.43s (0:06:27)`.
- `CUDA_VISIBLE_DEVICES=0,1 PYTHONPATH=python:. /opt/venv/bin/python -m pytest -q "tests/test_e2e.py::test_e2e[internvl3-2b-tp2]" -v --multi-device-only --engine-dir /tmp/trtmc-storage/internvl-deepseek-ocr-tp/engines --trtmc-binary ./build-internvl-deepseek-ocr-tp/trtmc --hf-python /opt/venv/bin/python --e2e-artifacts-dir /tmp/trtmc-storage/internvl-deepseek-ocr-tp/artifacts --rebuild-engines -s -p no:cacheprovider`: passed on B200 GPUs 0-1, `1 passed in 191.25s (0:03:11)`.
- `CUDA_VISIBLE_DEVICES=0,1,2,3 PYTHONPATH=python:. /opt/venv/bin/python -m pytest -q "tests/test_e2e.py::test_e2e[internvl3-8b-tp4]" -v --engine-dir /tmp/trtmc-storage/internvl-deepseek-ocr-tp/engines --trtmc-binary ./build-internvl-deepseek-ocr-tp/trtmc --hf-python /opt/venv/bin/python --e2e-artifacts-dir /tmp/trtmc-storage/internvl-deepseek-ocr-tp/artifacts --rebuild-engines -s -p no:cacheprovider`: passed on B200 GPUs 0-3, `1 passed in 449.31s (0:07:29)`.

## Notes For Future Readers
- InternVL3 2B uses TP2 because it has only 2 KV heads; InternVL3 8B uses TP4.
- DeepSeek-OCR uses TP2 because the checkpoint has 10 attention/KV heads, which is not divisible by TP4.
- The vision engines remain single-copy; tensor parallelism is applied to the text decoder engines loaded by the vision-language runtime.
