### PR TITLE
feat(gemma): add TP4 Gemma2 e2e support

### DIFF
--- a/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_tp_builder.py
@@ -1,20 +1,21 @@
-"""Dual-profile decoder engine builder — single engine, two optimization profiles.
+"""Tensor-parallel dual-profile decoder engine builder.
 
-Produces one TensorRT engine that handles both prefill (multi-token) and
-decode (single-token) phases by switching between two optimization profiles
-at runtime:
+Produces one rank-local TensorRT engine that handles both prefill
+(multi-token) and decode (single-token) phases by switching between two
+optimization profiles at runtime:
   * Profile 0 (prefill): Sq ranges over [1, opt=opt_prefill_length, max=max_prefill_length].
     TensorRT picks batched MHA kernels (e.g. ``_gemm_mha_v2``) at opt Sq.
   * Profile 1 (decode): Sq fixed to 1. TensorRT picks the GEMV fast-path
     (``_gemv_mha_v1``).
 
-Both profiles use the same graph and weights — only the optimization
-profile differs, so the engine's weights live once in GPU memory and the
-C++ runtime creates two ``IExecutionContext``s (one per profile) that
-share the engine.
+The build path intentionally duplicates most of the single-device
+dual-profile graph so tensor-parallel shape decisions stay explicit here:
+Q/K/V and MLP expansion projections are column-sharded, output/down
+projections are row-sharded, and each row-parallel join inserts a TensorRT
+distributed ALL_REDUCE collective.
 
 Scope: covers the same architectural variants the legacy
-``standard_decoder_builder`` supports — RMSNorm or LayerNorm; SwiGLU or
+``standard_decoder_builder`` supports - RMSNorm or LayerNorm; SwiGLU or
 GeluFC MLP; RoPE (full / partial / interleaved), learned absolute, or
 ALiBi position; sequential or parallel residual; optional q/k_norm,
 QKV/output/MLP biases, and a Bloom-style embedding LayerNorm. Quantized
@@ -25,7 +26,7 @@ on ``standard_decoder_builder`` for now and are dispatched there from
 inside ``build_standard_decoder_engine``.
 
 Tensor contract (matches the C++ runtime KvCache naming):
-  Inputs (dynamic shapes — Sq varies by profile)
+  Inputs (dynamic shapes - Sq varies by profile)
     token_id        int32   (-1,)
     position_id     int32   (-1,)
     attention_mask  float32 (-1, -1)                 # (Sq, max_cache + Sq)
@@ -47,6 +48,11 @@ from tensorrt_model_connect import trt_compat
 
 from ... import graph_ops
 from ... import graph_blocks
+from ...parallel_config import (
+    add_all_reduce_sum,
+    normalize_parallel_config,
+    shard_standard_decoder_weights,
+)
 
 trt = trt_compat.get_trt()
 
@@ -68,7 +74,7 @@ def _const_in_work_dtype(
     Needed for bf16 builds: the dual-profile builder stores bf16 weights
     on disk as fp16 (work_np_dtype = np.float16), but the runtime tensor
     must be bfloat16 to match the rest of the graph. ``add_constant``
-    alone produces an fp16 constant — we need an explicit cast to
+    alone produces an fp16 constant - we need an explicit cast to
     bfloat16 so layers like IRotaryEmbeddingLayer (which require all
     inputs to share a dtype) accept it. fp16 / fp32 builds are no-ops
     because work_np_dtype maps directly to work_trt_dtype.
@@ -104,6 +110,14 @@ def _make_matmul_fn(
             network, lhs, lhs_w, rhs_w, rhs_weights, weight_name,
             dtype=dtype)
     return matmul
+
+
+def _validate_tp_quantization(quant_ctx: "QuantContext | None") -> None:
+    if quant_ctx is None:
+        return
+    format_name = getattr(getattr(quant_ctx, "profile", None), "format", None)
+    if getattr(format_name, "name", None) != "fp8":
+        raise ValueError("Tensor-parallel decoder quantization currently supports fp8 only")
 
 
 def _norm_multi(
@@ -202,7 +216,7 @@ def _supports_config(config: "ModelConfig", weights: "WeightDict") -> None:
 # ---------------------------------------------------------------------------
 
 
-def build_dual_profile_decoder_engine(
+def build_dual_profile_tp_decoder_engine(
     config: "ModelConfig",
     weights: "WeightDict",
     max_cache_length: int,
@@ -221,38 +235,37 @@ def build_dual_profile_decoder_engine(
     scale_attn_weights: bool = True,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
-    profile_mode: str = "dual_profile",
+    parallel_config=None,
 ) -> bytes:
-    """Build a prefill/decode-capable dynamic-Sq decoder engine.
+    """Build a rank-local tensor-parallel engine with prefill/decode profiles.
 
     ``norm_type`` / ``mlp_type`` / ``position_type`` / ``activation`` /
     ``partial_rotary_factor`` / ``interleaved_rope`` / ``parallel_residual`` /
     ``scale_attn_weights`` mirror the same parameters on
     ``build_standard_decoder_engine``.
 
-    ``quant_ctx`` (optional) routes every projection matmul through
-    ``QuantContext.maybe_quantized_matmul`` for fp8 / int8 Q/DQ insertion;
-    when ``None`` the matmuls are plain fp16 / bf16 / fp32.
+    The current TP implementation supports tp_size 2, 4, and 8. The caller
+    invokes this builder once per rank and packages the rank-local plans into
+    one bundle.
 
-    ``profile_mode`` controls which optimization profiles are emitted:
-
-    * ``"dual_profile"``: one prefill profile followed by one or more decode
-      profiles. When ``dynamic_kv_profile_rows`` is provided, the decode side
-      gets one profile per bucket — letting TriAttention pick the smallest
-      active KV cache bucket at runtime while still benefitting from batched
-      prefill on the prompt.
-    * ``"prefill"``: one prefill profile only. This is used by split-engine
-      bundles, where decode is served by a separate fixed-Sq=1 engine.
-
-    Dynamic-KV cache bucket profiles are only meaningful in ``dual_profile``
-    mode. In either mode, cache_k/cache_v inputs are declared dynamic when
-    bucket profiles are requested so each profile can constrain their row count.
+    When ``dynamic_kv_profile_rows`` is provided, the engine carries one
+    prefill profile (profile 0) followed by N decode profiles (profile 1..N),
+    one per bucket - letting TriAttention pick the smallest active KV cache
+    bucket at runtime while still benefitting from batched prefill on the
+    prompt. The cache_k/cache_v inputs are declared dynamic so each profile
+    can constrain their row count independently.
     """
     _supports_config(config, weights)
-    if profile_mode not in ("dual_profile", "prefill"):
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
         raise ValueError(
-            "profile_mode must be 'dual_profile' or 'prefill', "
-            f"got {profile_mode!r}")
+            "dual_profile_decoder_tp_builder requires "
+            "parallel.mode=tensor_parallel and tp_size > 1")
+    _validate_tp_quantization(quant_ctx)
+    if mlp_type != "swiglu":
+        raise NotImplementedError(
+            "Tensor-parallel decoder builds currently support SwiGLU MLPs only")
+    weights = shard_standard_decoder_weights(config, weights, parallel)
 
     if max_prefill_length is None:
         max_prefill_length = max_cache_length
@@ -278,8 +291,8 @@ def build_dual_profile_decoder_engine(
     hidden = config.hidden_size
     vocab = config.vocab_size
     num_layers = config.num_hidden_layers
-    num_heads = config.num_attention_heads
-    num_kv_heads = config.num_key_value_heads
+    num_heads = config.num_attention_heads // parallel.tp_size
+    num_kv_heads = config.num_key_value_heads // parallel.tp_size
     head_dim = attention_size // num_heads
     kv_attention_size = graph_blocks.infer_kv_attention_size(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
@@ -328,7 +341,7 @@ def build_dual_profile_decoder_engine(
     else:
         attention_mask_work = attention_mask
 
-    # Two (or 1+N) optimization profiles — same graph, different Sq / cache.
+    # Two (or 1+N) optimization profiles - same graph, different Sq / cache.
     def _add_profile(opt_sq: int, max_sq: int, *, fixed: bool = False,
                      cache_rows_min: int | None = None,
                      cache_rows_opt: int | None = None,
@@ -356,42 +369,16 @@ def build_dual_profile_decoder_engine(
                         (cmx, kv_attention_size))
         trt_config.add_optimization_profile(prof)
 
-    import os as _os_dbg
-    if profile_mode == "prefill":
-        _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                     cache_rows_min=1, cache_rows_opt=max_cache_length,
-                     cache_rows_max=max_cache_length)
-    elif _os_dbg.environ.get("TRTMC_DECODE_ONLY_DEBUG") == "1":
-        # Diagnostic: build a one-profile engine with dynamic-shape inputs
-        # but Sq pinned to 1. Lets us isolate dynamic-shape enqueueV3
-        # overhead from per-profile kernel specialisation.
-        _add_profile(1, 1, fixed=True)
+    _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
+                 cache_rows_min=1, cache_rows_opt=max_cache_length,
+                 cache_rows_max=max_cache_length)
+    if multi_bucket_decode:
+        for bucket in decode_buckets:
+            _add_profile(1, 1, fixed=True,
+                         cache_rows_min=1, cache_rows_opt=bucket,
+                         cache_rows_max=bucket)
     else:
-        _reverse = _os_dbg.environ.get("TRTMC_REVERSE_PROFILE_ORDER", "0") == "1"
-        if _reverse:
-            # Decode profile registered first so it commits its preferred
-            # weight layout before the prefill profile compiles.
-            if multi_bucket_decode:
-                for bucket in decode_buckets:
-                    _add_profile(1, 1, fixed=True,
-                                 cache_rows_min=1, cache_rows_opt=bucket,
-                                 cache_rows_max=bucket)
-            else:
-                _add_profile(1, 1, fixed=True)
-            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                         cache_rows_min=1, cache_rows_opt=max_cache_length,
-                         cache_rows_max=max_cache_length)
-        else:
-            _add_profile(opt_prefill_length, max_prefill_length, fixed=False,
-                         cache_rows_min=1, cache_rows_opt=max_cache_length,
-                         cache_rows_max=max_cache_length)
-            if multi_bucket_decode:
-                for bucket in decode_buckets:
-                    _add_profile(1, 1, fixed=True,
-                                 cache_rows_min=1, cache_rows_opt=bucket,
-                                 cache_rows_max=bucket)
-            else:
-                _add_profile(1, 1, fixed=True)
+        _add_profile(1, 1, fixed=True)
 
     # ---- Shared constants ------------------------------------------------
     embedding_table = _const_in_work_dtype(
@@ -489,7 +476,7 @@ def build_dual_profile_decoder_engine(
             network, hidden_state, hidden, embed_norm, embed_norm_beta,
             eps_tensor, "layernorm", work_np_dtype)
 
-    # Build the 4D additive mask once — shared across layers. ALiBi
+    # Build the 4D additive mask once - shared across layers. ALiBi
     # variants augment the mask with per-head linear bias.
     if position_type == "alibi":
         mask_4d = graph_ops.add_alibi_mask_4d(
@@ -582,6 +569,7 @@ def build_dual_profile_decoder_engine(
 
         attn_out = matmul(context, attention_size, hidden,
                           weights[f"{prefix}.w_o"], f"{prefix}.w_o")
+        attn_out = add_all_reduce_sum(network, attn_out, parallel.tp_size)
         o_bias = weights.get(f"{prefix}.o_bias")
         if o_bias is not None:
             attn_out = graph_ops.add_bias_sum(
@@ -626,7 +614,7 @@ def build_dual_profile_decoder_engine(
                 weights.get(f"{prefix}.post_attn_norm_beta"),
                 eps_tensor, norm_type, work_np_dtype)
 
-        # MLP — SwiGLU (Llama-style) or GeluFC (GPT-2-style).
+        # MLP - SwiGLU (Llama-style) or GeluFC (GPT-2-style).
         if mlp_type == "gelu_fc":
             mlp_out = _gelu_fc_mlp(
                 network, norm2,
@@ -638,6 +626,7 @@ def build_dual_profile_decoder_engine(
                 network, norm2,
                 matmul=matmul, weights=weights, prefix=prefix,
                 hidden=hidden, mlp_size=mlp_size)
+        mlp_out = add_all_reduce_sum(network, mlp_out, parallel.tp_size)
 
         # Final residual.
         if gemma2_norms:
@@ -716,17 +705,16 @@ def build_dual_profile_decoder_engine(
         network.mark_output(pv)
 
     if verbose:
-        mode_label = "prefill-profile" if profile_mode == "prefill" else "dual-profile"
-        print(f"[trtmc build] Building {mode_label} engine "
+        print(f"[trtmc-build] Building tensor-parallel decoder engine "
               f"(layers={num_layers}, hidden={hidden}, attn={attention_size}, "
               f"kv={kv_attention_size}, "
               f"mlp={mlp_size}, cache={max_cache_length}, "
               f"opt_prefill={opt_prefill_length}, max_prefill={max_prefill_length}, "
               f"norm={norm_type}, mlp_type={mlp_type}, pos={position_type}, "
-              f"precision={precision}) ...",
+              f"precision={precision}, tp={parallel.tp_size}, rank={parallel.rank}) ...",
               file=sys.stderr)
 
     plan = builder.build_serialized_network(network, trt_config)
     if plan is None:
-        raise RuntimeError("dual-profile decoder engine build failed")
+        raise RuntimeError("Tensor-parallel decoder engine build failed")
     return bytes(plan)

--- a/python/tensorrt_model_connect/families/gemma/plugin.py
+++ b/python/tensorrt_model_connect/families/gemma/plugin.py
@@ -3,9 +3,18 @@
 from __future__ import annotations
 
 import math
+from pathlib import Path
 
 from ...config import ModelConfig
-from ...checkpoint_mapper import WeightDict, load_standard_weights
+from ...checkpoint_mapper import (
+    WeightDict,
+    _has_tensor,
+    _load_tensor,
+    _open_safetensors,
+    load_standard_weights,
+)
+from ...parallel_config import normalize_parallel_config
+from .dual_profile_decoder_tp_builder import build_dual_profile_tp_decoder_engine
 from .standard_decoder_builder import build_standard_decoder_engine
 
 
@@ -20,12 +29,22 @@ class GemmaPlugin:
         *, precision: str = "fp32",
     ) -> WeightDict:
         weights = load_standard_weights(model_dir, config, precision=precision)
+        readers = _open_safetensors(Path(model_dir))
 
         # Fix 1: Gemma uses (1 + gamma) * normalized instead of gamma * normalized.
         for layer_idx in range(config.num_hidden_layers):
             prefix = f"layer.{layer_idx}"
+            hf_prefix = f"model.layers.{layer_idx}"
             weights[f"{prefix}.input_norm"] = weights[f"{prefix}.input_norm"] + 1.0
             weights[f"{prefix}.post_attn_norm"] = weights[f"{prefix}.post_attn_norm"] + 1.0
+            pre_ffn_key = f"{hf_prefix}.pre_feedforward_layernorm.weight"
+            if _has_tensor(readers, pre_ffn_key):
+                weights[f"{prefix}.pre_ffn_norm"] = (
+                    _load_tensor(readers, pre_ffn_key).astype("float32") + 1.0)
+            post_ffn_key = f"{hf_prefix}.post_feedforward_layernorm.weight"
+            if _has_tensor(readers, post_ffn_key):
+                weights[f"{prefix}.post_ffn_norm"] = (
+                    _load_tensor(readers, post_ffn_key).astype("float32") + 1.0)
         weights["final_norm"] = weights["final_norm"] + 1.0
 
         # Fix 2: Gemma scales embedding by sqrt(hidden_size).
@@ -37,8 +56,17 @@ class GemmaPlugin:
     def build_engine(
         self, config: ModelConfig, weights: WeightDict,
         max_cache_length: int, *, precision: str = "fp32",
-        quant_ctx=None, verbose: bool = False,
+        quant_ctx=None, verbose: bool = False, parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            return build_dual_profile_tp_decoder_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                parallel_config=parallel)
+
         return build_standard_decoder_engine(
             config, weights, max_cache_length, precision=precision,
             quant_ctx=quant_ctx, verbose=verbose)

--- a/python/tensorrt_model_connect/families/gemma/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/gemma/standard_decoder_builder.py
@@ -323,6 +323,7 @@ def build_standard_decoder_engine(
         network, (1, 1), np.array([config.rms_norm_eps], dtype=work_np_dtype),
         dtype=work_np_dtype)
     attn_scale = (1.0 / np.sqrt(max(head_dim, 1))) if scale_attn_weights else 1.0
+    final_logit_softcap = config.raw.get("final_logit_softcapping")
     # ---------------------------------------------------------------
     # Embedding lookup (with optional embed_input override for VL)
     # ---------------------------------------------------------------
@@ -480,6 +481,10 @@ def build_standard_decoder_engine(
         logits = graph_ops.add_bias_sum(network, logits, out_vocab, b_out,
                                         dtype=work_np_dtype)
 
+    if final_logit_softcap is not None and float(final_logit_softcap) > 0.0:
+        logits = graph_ops.add_tanh_softcap(
+            network, logits, float(final_logit_softcap), scalar_shape=(1, 1))
+
     # Logits output: always FP32 for accurate argmax/sampling
     if work_trt_dtype != trt.float32:
         logits_cast = network.add_cast(logits, trt.float32)
@@ -599,7 +604,25 @@ def _add_decoder_layer(
     present_v = attn["present_v"]
 
     # --- Parallel vs sequential residual ---
-    if parallel_residual:
+    gemma2_norms = (
+        weights.get(f"{prefix}.pre_ffn_norm") is not None
+        and weights.get(f"{prefix}.post_ffn_norm") is not None
+    )
+
+    if gemma2_norms:
+        attn_out = _apply_norm(
+            network, attn_out, hidden_size,
+            weights[f"{prefix}.post_attn_norm"],
+            weights.get(f"{prefix}.post_attn_norm_beta"),
+            eps_tensor, norm_type, dtype=dtype, eps=eps)
+        residual1 = network.add_elementwise(
+            hidden, attn_out, trt.ElementWiseOperation.SUM)
+        norm2 = _apply_norm(
+            network, residual1.get_output(0), hidden_size,
+            weights[f"{prefix}.pre_ffn_norm"],
+            weights.get(f"{prefix}.pre_ffn_norm_beta"),
+            eps_tensor, norm_type, dtype=dtype, eps=eps)
+    elif parallel_residual:
         post_attn_norm_w = weights.get(f"{prefix}.post_attn_norm")
         if post_attn_norm_w is not None:
             norm2 = _apply_norm(
@@ -632,7 +655,16 @@ def _add_decoder_layer(
             quant_ctx=quant_ctx, layer_prefix=prefix)
 
     # Final residual connection
-    if parallel_residual:
+    if gemma2_norms:
+        mlp_out = _apply_norm(
+            network, mlp_out, hidden_size,
+            weights[f"{prefix}.post_ffn_norm"],
+            weights.get(f"{prefix}.post_ffn_norm_beta"),
+            eps_tensor, norm_type, dtype=dtype, eps=eps)
+        residual2 = network.add_elementwise(
+            residual1.get_output(0), mlp_out, trt.ElementWiseOperation.SUM)
+        post_attn_tensor = residual1.get_output(0)
+    elif parallel_residual:
         sum_attn = network.add_elementwise(
             hidden, attn_out, trt.ElementWiseOperation.SUM)
         residual2 = network.add_elementwise(

--- a/python/tensorrt_model_connect/graph_ops.py
+++ b/python/tensorrt_model_connect/graph_ops.py
@@ -2602,6 +2602,139 @@ def add_attention_core(
     return _cast_back_to_trt_dtype(network, attn.get_output(0), output_dtype)
 
 
+def _scalar_constant_for_trt_dtype(
+    network: trt.INetworkDefinition,
+    shape: tuple[int, ...],
+    value: float,
+    dtype: trt.DataType,
+) -> trt.ITensor:
+    np_dtype = np.float16 if dtype == trt.float16 else np.float32
+    const = add_constant(
+        network, shape, np.full(shape, value, dtype=np_dtype),
+        dtype=np_dtype)
+    if dtype == trt.bfloat16:
+        const = network.add_cast(const, trt.bfloat16).get_output(0)
+    return const
+
+
+def add_tanh_softcap(
+    network: trt.INetworkDefinition,
+    tensor: trt.ITensor,
+    cap: float,
+    *,
+    scalar_shape: tuple[int, ...],
+) -> trt.ITensor:
+    """Apply ``tanh(tensor / cap) * cap`` using scalar broadcasting."""
+    cap_t = _scalar_constant_for_trt_dtype(
+        network, scalar_shape, float(cap), tensor.dtype)
+    scaled = network.add_elementwise(
+        tensor, cap_t, trt.ElementWiseOperation.DIV).get_output(0)
+    capped = network.add_activation(
+        scaled, trt.ActivationType.TANH).get_output(0)
+    return network.add_elementwise(
+        capped, cap_t, trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def _repeat_kv_heads_4d(
+    network: trt.INetworkDefinition,
+    x_4d: trt.ITensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+) -> trt.ITensor:
+    if num_kv_heads == num_heads:
+        return x_4d
+    if num_kv_heads <= 0 or num_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"num_heads={num_heads} must be divisible by "
+            f"num_kv_heads={num_kv_heads}")
+
+    repeat = num_heads // num_kv_heads
+    if num_kv_heads == 1:
+        concat = network.add_concatenation([x_4d] * repeat)
+        concat.axis = 1
+        return concat.get_output(0)
+
+    x_shape = network.add_shape(x_4d).get_output(0)
+    one = add_constant(
+        network, (1,), np.array([1], dtype=np.int64), dtype=np.int64)
+    seq = network.add_slice(x_shape, start=(2,), shape=(1,), stride=(1,))
+    dim = add_constant(
+        network, (1,), np.array([head_dim], dtype=np.int64), dtype=np.int64)
+    slice_shape = network.add_concatenation([one, one, seq.get_output(0), dim])
+    slice_shape.axis = 0
+
+    repeated = []
+    for head_idx in range(num_kv_heads):
+        head_slice = network.add_slice(
+            x_4d, start=(0, head_idx, 0, 0),
+            shape=(1, 1, 1, head_dim), stride=(1, 1, 1, 1))
+        head_slice.set_input(2, slice_shape.get_output(0))
+        repeated.extend([head_slice.get_output(0)] * repeat)
+
+    concat = network.add_concatenation(repeated)
+    concat.axis = 1
+    return concat.get_output(0)
+
+
+def _add_attention_core_with_logit_softcap(
+    network: trt.INetworkDefinition,
+    q_4d: trt.ITensor,
+    k_4d: trt.ITensor,
+    v_4d: trt.ITensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    mask: trt.ITensor | None,
+    scale: float,
+    logit_softcap: float,
+) -> trt.ITensor:
+    output_dtype = q_4d.dtype
+    k_4d = _repeat_kv_heads_4d(
+        network, k_4d, num_heads=num_heads, num_kv_heads=num_kv_heads,
+        head_dim=head_dim)
+    v_4d = _repeat_kv_heads_4d(
+        network, v_4d, num_heads=num_heads, num_kv_heads=num_kv_heads,
+        head_dim=head_dim)
+
+    score_q = q_4d
+    score_k = k_4d
+    score_mask = mask
+    if output_dtype != trt.float32:
+        score_q = network.add_cast(score_q, trt.float32).get_output(0)
+        score_k = network.add_cast(score_k, trt.float32).get_output(0)
+        if score_mask is not None and score_mask.dtype != trt.float32:
+            score_mask = network.add_cast(score_mask, trt.float32).get_output(0)
+
+    scale_t = _scalar_constant_for_trt_dtype(
+        network, (1, 1, 1, 1), scale, score_q.dtype)
+    scores = network.add_matrix_multiply(
+        score_q, trt.MatrixOperation.NONE,
+        score_k, trt.MatrixOperation.TRANSPOSE).get_output(0)
+    scores = network.add_elementwise(
+        scores, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
+
+    scores = add_tanh_softcap(
+        network, scores, logit_softcap, scalar_shape=(1, 1, 1, 1))
+
+    if score_mask is not None:
+        scores = network.add_elementwise(
+            scores, score_mask, trt.ElementWiseOperation.SUM).get_output(0)
+
+    probs = network.add_softmax(scores)
+    probs.axes = 1 << 3
+    probs_t = probs.get_output(0)
+    if probs_t.dtype != output_dtype:
+        probs_t = network.add_cast(probs_t, output_dtype).get_output(0)
+
+    context = network.add_matrix_multiply(
+        probs_t, trt.MatrixOperation.NONE,
+        v_4d, trt.MatrixOperation.NONE).get_output(0)
+    return _cast_back_to_trt_dtype(network, context, output_dtype)
+
+
 def add_attention_from_rows(
     network: trt.INetworkDefinition,
     q: trt.ITensor,
@@ -2616,6 +2749,7 @@ def add_attention_from_rows(
     causal: bool = False,
     mask: trt.ITensor | None = None,
     scale: float | None = None,
+    logit_softcap: float | None = None,
     fp32_accumulation: bool = False,
     tag: str | None = None,
 ) -> trt.ITensor:
@@ -2638,9 +2772,18 @@ def add_attention_from_rows(
         tag=None if tag is None else tag + ".v")
     if scale is None:
         scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
-    ctx_4d = add_attention_core(
-        network, q_4d, k_4d, v_4d, causal=causal, mask=mask, scale=scale,
-        fp32_accumulation=fp32_accumulation)
+    if logit_softcap is not None and float(logit_softcap) > 0.0:
+        if causal:
+            raise NotImplementedError(
+                "logit_softcap attention requires an explicit additive mask")
+        ctx_4d = _add_attention_core_with_logit_softcap(
+            network, q_4d, k_4d, v_4d,
+            num_heads=num_heads, num_kv_heads=kv_heads, head_dim=head_dim,
+            mask=mask, scale=scale, logit_softcap=float(logit_softcap))
+    else:
+        ctx_4d = add_attention_core(
+            network, q_4d, k_4d, v_4d, causal=causal, mask=mask, scale=scale,
+            fp32_accumulation=fp32_accumulation)
     return reshape_heads_4d_to_rows(
         network, ctx_4d, attention_size, sequence_length=q_seq,
         tag=None if tag is None else tag + ".ctx")

--- a/src/tokenizer/bpe_tokenizer.cpp
+++ b/src/tokenizer/bpe_tokenizer.cpp
@@ -754,7 +754,8 @@ class BpeTokenizer final : public ITokenizer {
             out += (c == ' ') ? sp : std::string(1, c);
         }
         // Metaspace prepend_scheme=first: prepend if not already starting with ▁
-        if (!mSentencePiecePrependAlways && (out.empty() || out.compare(0, sp.size(), sp) != 0)) {
+        if (!mSentencePiecePrependAlways && mSentencePiecePrependIfMissing &&
+            (out.empty() || out.compare(0, sp.size(), sp) != 0)) {
             out = sp + out;
         }
         return out;
@@ -1186,6 +1187,12 @@ class BpeTokenizer final : public ITokenizer {
             int digit_group = 0;
             mPreTokenizerVariant = detect_split_variant(pt, digit_group);
             mPreTokenizerDigitGroup = digit_group;
+        } else if (pt_type == "Split" && pt.contains("pattern") &&
+                   pt["pattern"].contains("String") &&
+                   pt["pattern"]["String"].get<std::string>() == " ") {
+            // Gemma SentencePiece-BPE tokenizers use a direct Split(" ")
+            // pre-tokenizer with spaces already normalized to U+2581.
+            mUsePreTokenizer = false;
         } else if (pt_type == "Metaspace") {
             mIsMetaspace = true;
             mUsePreTokenizer = false;
@@ -1296,6 +1303,14 @@ class BpeTokenizer final : public ITokenizer {
                     mSentencePiecePrependAlways = true;
                 }
             }
+        } else if (norm_type == "Replace" && norm.contains("pattern") &&
+                   norm["pattern"].contains("String") &&
+                   norm["pattern"]["String"].get<std::string>() == " " &&
+                   norm.value("content", "") == "\xe2\x96\x81") {
+            // Gemma replaces spaces with ▁ but does not prepend ▁ to the
+            // first token. Preserve the old prepend-if-missing behavior for
+            // Metaspace-style SentencePiece models.
+            mSentencePiecePrependIfMissing = false;
         }
     }
 
@@ -1398,6 +1413,7 @@ class BpeTokenizer final : public ITokenizer {
     bool mIsSentencePiece = false;
     bool mSentencePiecePrependAlways =
         false; // true for Normalizer Prepend, false for Metaspace first
+    bool mSentencePiecePrependIfMissing = true;
     bool mByteFallback = false;
 
     // Post-processor: BOS/EOS token IDs to add when add_special_tokens=true

--- a/src/tokenizer/bpe_tokenizer.cpp
+++ b/src/tokenizer/bpe_tokenizer.cpp
@@ -1172,8 +1172,7 @@ class BpeTokenizer final : public ITokenizer {
         return pretok::Variant::kGpt2;
     }
 
-    static bool is_space_split_pre_tokenizer(const nlohmann::json& pt,
-                                             const std::string& pt_type) {
+    static bool is_space_split_pre_tokenizer(const nlohmann::json& pt, const std::string& pt_type) {
         if (pt_type != "Split")
             return false;
         if (!pt.contains("pattern") || !pt["pattern"].contains("String"))

--- a/src/tokenizer/bpe_tokenizer.cpp
+++ b/src/tokenizer/bpe_tokenizer.cpp
@@ -1172,6 +1172,15 @@ class BpeTokenizer final : public ITokenizer {
         return pretok::Variant::kGpt2;
     }
 
+    static bool is_space_split_pre_tokenizer(const nlohmann::json& pt,
+                                             const std::string& pt_type) {
+        if (pt_type != "Split")
+            return false;
+        if (!pt.contains("pattern") || !pt["pattern"].contains("String"))
+            return false;
+        return pt["pattern"]["String"].get<std::string>() == " ";
+    }
+
     void detect_pre_tokenizer(const nlohmann::json& j) {
         mUsePreTokenizer = true;
         mPreTokenizerVariant = pretok::Variant::kGpt2;
@@ -1187,9 +1196,7 @@ class BpeTokenizer final : public ITokenizer {
             int digit_group = 0;
             mPreTokenizerVariant = detect_split_variant(pt, digit_group);
             mPreTokenizerDigitGroup = digit_group;
-        } else if (pt_type == "Split" && pt.contains("pattern") &&
-                   pt["pattern"].contains("String") &&
-                   pt["pattern"]["String"].get<std::string>() == " ") {
+        } else if (is_space_split_pre_tokenizer(pt, pt_type)) {
             // Gemma SentencePiece-BPE tokenizers use a direct Split(" ")
             // pre-tokenizer with spaces already normalized to U+2581.
             mUsePreTokenizer = false;
@@ -1292,21 +1299,36 @@ class BpeTokenizer final : public ITokenizer {
     }
 
     // Detect normalizer: check for Prepend (always prepend ▁) vs none
+    static bool normalizer_sequence_prepends(const nlohmann::json& norm,
+                                             const std::string& norm_type) {
+        if (norm_type != "Sequence" || !norm.contains("normalizers"))
+            return false;
+        for (auto& sub : norm["normalizers"]) {
+            if (sub.value("type", "") == "Prepend")
+                return true;
+        }
+        return false;
+    }
+
+    static bool normalizer_replaces_space_with_sentence_piece(const nlohmann::json& norm,
+                                                              const std::string& norm_type) {
+        if (norm_type != "Replace")
+            return false;
+        if (!norm.contains("pattern") || !norm["pattern"].contains("String"))
+            return false;
+        if (norm["pattern"]["String"].get<std::string>() != " ")
+            return false;
+        return norm.value("content", "") == "\xe2\x96\x81";
+    }
+
     void detect_normalizer(const nlohmann::json& j) {
         if (!j.contains("normalizer") || j["normalizer"].is_null())
             return;
         auto& norm = j["normalizer"];
         std::string norm_type = norm.value("type", "");
-        if (norm_type == "Sequence" && norm.contains("normalizers")) {
-            for (auto& sub : norm["normalizers"]) {
-                if (sub.value("type", "") == "Prepend") {
-                    mSentencePiecePrependAlways = true;
-                }
-            }
-        } else if (norm_type == "Replace" && norm.contains("pattern") &&
-                   norm["pattern"].contains("String") &&
-                   norm["pattern"]["String"].get<std::string>() == " " &&
-                   norm.value("content", "") == "\xe2\x96\x81") {
+        if (normalizer_sequence_prepends(norm, norm_type)) {
+            mSentencePiecePrependAlways = true;
+        } else if (normalizer_replaces_space_with_sentence_piece(norm, norm_type)) {
             // Gemma replaces spaces with ▁ but does not prepend ▁ to the
             // first token. Preserve the old prepend-if-missing behavior for
             // Metaspace-style SentencePiece models.

--- a/tests/builder/test_engine_gemma_tp.py
+++ b/tests/builder/test_engine_gemma_tp.py
@@ -1,0 +1,56 @@
+"""Focused tests for Gemma tensor-parallel dispatch."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+try:
+    from tensorrt_model_connect.parallel_config import ParallelConfig
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        raw={},
+        hidden_size=16,
+        vocab_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=4,
+        attention_size=16,
+        intermediate_size=32,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+    )
+
+
+def test_gemma_plugin_routes_parallel_builds(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.gemma.plugin")
+    calls: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"gemma-tp-plan"
+
+    monkeypatch.setattr(module, "build_dual_profile_tp_decoder_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+    result = module.GemmaPlugin().build_engine(
+        _config(),
+        {"_attention_size": 16, "_kv_attention_size": 16, "_mlp_size": 32},
+        23,
+        verbose=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"gemma-tp-plan"
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 23
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["verbose"] is True

--- a/tests/cpp/test_bpe_tokenizer.cpp
+++ b/tests/cpp/test_bpe_tokenizer.cpp
@@ -1648,6 +1648,88 @@ int main() {
         }
     }
 
+    // === 37. Gemma Split pre-tokenizer with SentencePiece-BPE normalizer ===
+    {
+        std::cerr << "\n=== Gemma Split SentencePiece-BPE ===\n";
+
+        std::string gemma_json = R"({
+          "model": {
+            "type": "BPE",
+            "vocab": {
+              "<bos>": 0,
+              "\u2581": 1,
+              "i": 2,
+              "s": 3,
+              "is": 4,
+              "\u2581is": 5,
+              "2": 6,
+              "+": 7,
+              "\u2581+": 8,
+              "?": 9,
+              "W": 10,
+              "h": 11,
+              "a": 12,
+              "t": 13,
+              "Wh": 14,
+              "Wha": 15,
+              "What": 16
+            },
+            "merges": [
+              "W h",
+              "Wh a",
+              "Wha t",
+              "i s",
+              "\u2581 is",
+              "\u2581 +"
+            ]
+          },
+          "added_tokens": [
+            {"id": 0, "content": "<bos>", "special": true}
+          ],
+          "normalizer": {
+            "type": "Replace",
+            "pattern": {"String": " "},
+            "content": "\u2581"
+          },
+          "pre_tokenizer": {
+            "type": "Split",
+            "pattern": {"String": " "},
+            "behavior": "MergedWithPrevious",
+            "invert": false
+          },
+          "decoder": {
+            "type": "Sequence",
+            "decoders": [
+              {"type": "Replace", "pattern": {"String": "\u2581"}, "content": " "},
+              {"type": "ByteFallback"},
+              {"type": "Fuse"}
+            ]
+          },
+          "post_processor": {
+            "type": "TemplateProcessing",
+            "single": [
+              {"SpecialToken": {"id": "<bos>", "type_id": 0}},
+              {"Sequence": {"id": "A", "type_id": 0}}
+            ],
+            "special_tokens": {
+              "<bos>": {"id": "<bos>", "ids": [0], "tokens": ["<bos>"]}
+            }
+          }
+        })";
+
+        auto tok = trtmc::CreateBpeTokenizer(gemma_json.data(), gemma_json.size(), true);
+        check(tok != nullptr, "gemma_split_create");
+        {
+            auto ids = tok->encode("What is 2 + 2?");
+            std::vector<int32_t> expected = {0, 16, 5, 1, 6, 8, 1, 6, 9};
+            check(ids == expected, "gemma_split_encode_no_leading_space");
+        }
+        {
+            auto text = tok->decode({0, 16, 5, 1, 6, 8, 1, 6, 9});
+            check(text == "What is 2 + 2?", "gemma_split_decode");
+        }
+    }
+
     if (failures > 0) {
         std::cerr << "\n" << failures << " test(s) failed\n";
         return 1;

--- a/tests/cpp/test_bpe_tokenizer.cpp
+++ b/tests/cpp/test_bpe_tokenizer.cpp
@@ -1524,7 +1524,8 @@ int main() {
         }
 
         // Without special tokens: no BOS/EOS
-        auto tok_ns = trtmc::CreateBpeTokenizer(multi_bos_json.data(), multi_bos_json.size(), false);
+        auto tok_ns =
+            trtmc::CreateBpeTokenizer(multi_bos_json.data(), multi_bos_json.size(), false);
         {
             auto ids = tok_ns->encode("hello");
             check(!ids.empty() && ids[0] != 200 && ids.back() != 202,

--- a/tests/e2e/models/gemma-2-2b-tp4.json
+++ b/tests/e2e/models/gemma-2-2b-tp4.json
@@ -1,0 +1,58 @@
+{
+  "name": "gemma-2-2b-tp4",
+  "trace_id": "IT-E2E-GMA2-TP4-01",
+  "hf_id": "google/gemma-2-2b-it",
+  "bundle": "gemma-2-2b-tp4.trtfb",
+  "family": "gemma",
+  "runtime_strategy": "decoder_kv_cache",
+  "reference_family": "chat_instruct_template",
+  "max_cache_length": 256,
+  "prompt": "What is 2 + 2? Answer with just the number.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "trust_remote_code": false,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "debug_logits": true,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "Tensor-parallel TP=4 Gemma decoder coverage on four GPUs."
+}


### PR DESCRIPTION
## Background
Gemma2 TP4 coverage was blocked on three issues: no Gemma tensor-parallel builder, Gemma2-specific decoder semantics were not modeled, and the native tokenizer could not handle Gemma's Split/SentencePiece-BPE tokenizer JSON. The new TP4 e2e manifest also needs to use the same chat/instruct reference contract as the existing single-device Gemma case.

## Exit Criteria
- Gemma2 TP4 builds and runs on four B200 GPUs.
- The Gemma2 TP4 e2e case passes before opening the PR.
- Changes stay scoped to Gemma TP support, Gemma2 graph correctness, and the tokenizer support required by Gemma runtime.

## Implementation
- Adds a Gemma tensor-parallel dual-profile decoder builder, routed from the Gemma plugin when tensor parallelism is enabled.
- Loads Gemma2 pre/post feed-forward norms and applies the Gemma2 residual order, attention logit softcap, and final logit softcap in the Gemma builders.
- Extends the shared attention helper with an opt-in softcap path; existing callers keep the native attention path unless they pass a softcap.
- Updates the native BPE tokenizer for Gemma Split/SentencePiece-BPE handling.
- Adds a TP4 Gemma2 e2e manifest using distributed runtime and the chat/instruct reference family.

## Validation
- `pytest -p no:cacheprovider -q tests/builder/test_engine_gemma.py tests/builder/test_engine_gemma_tp.py tests/builder/test_manifest_validation.py`: passed, 42 tests.
- `cd build-b200-trt11-local-trt && ./test_bpe_tokenizer`: passed, all native BPE tokenizer tests.
- `pytest -p no:cacheprovider -s "tests/test_e2e.py::test_e2e[gemma-2-2b-tp4]" --multi-device-only --engine-dir /tmp/trtmc-gemma-tp4-gemma2norms/engines --e2e-artifacts-dir /tmp/trtmc-gemma-tp4-chat/artifacts --trtmc-binary build-b200-trt11-local-trt/trtmc --hf-python /opt/venv/bin/python`: passed on B200 GPUs 4-7 via the Docker container, 1 test in 50.26s.

## Notes For Future Readers
- Review the Gemma plugin and builder changes before the TP builder; the TP builder intentionally mirrors the single-device dual-profile graph and only adds TP sharding/all-reduce behavior.
- The existing single-device Gemma manifest remains waived as gated; this PR adds the new TP4 manifest and validates it with authenticated local access.