### PR TITLE
feat(timm_vit): add TP4 e2e support

### DIFF
--- a/python/tensorrt_model_connect/families/timm_vit/plugin.py
+++ b/python/tensorrt_model_connect/families/timm_vit/plugin.py
@@ -25,6 +25,10 @@ from ...checkpoint_mapper import (
     _transpose_2d,
 )
 from ...config import ModelConfig
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 
 
 trt = trt_compat.get_trt()
@@ -144,7 +148,23 @@ class TimmVitPlugin:
         precision: str = "fp32",
         quant_ctx=None,
         verbose: bool = False,
+        parallel_config=None,
     ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="timm_vit tensor-parallel MLP builds")
+            if quant_ctx is not None:
+                raise ValueError("timm_vit tensor-parallel builds do not support quantization")
+            from .timm_vit_tp_builder import build_timm_vit_tp_engine
+            return build_timm_vit_tp_engine(
+                config, weights, max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                verbose=verbose,
+                parallel_config=parallel,
+            )
+
         del max_cache_length, quant_ctx
         if precision not in ("fp32",):
             raise ValueError("timm_vit raw TRT path currently supports precision='fp32'")

--- a/python/tensorrt_model_connect/families/timm_vit/timm_vit_tp_builder.py
+++ b/python/tensorrt_model_connect/families/timm_vit/timm_vit_tp_builder.py
@@ -1,0 +1,346 @@
+"""Tensor-parallel timm ViT image-classification builder.
+
+timm ViT attention remains replicated. The MLP path is tensor-parallel:
+FC1 columns are sharded, FC2 rows are sharded, and a TensorRT distributed
+ALL_REDUCE restores the full residual before the next layer.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+import sys
+
+import numpy as np
+from tensorrt_model_connect import graph_ops, trt_compat
+
+from ...checkpoint_mapper import _transpose_2d
+from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
+from .plugin import _resolve_vit_config
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def _validate_timm_vit_tp(config: "ModelConfig", parallel: "ParallelConfig") -> None:
+    parallel.validate()
+    if not parallel.enabled:
+        return
+    if parallel.rank < 0:
+        raise ValueError("timm_vit tensor-parallel build requires a concrete rank")
+    vit_cfg = config.raw.get("_timm_vit_config") or _resolve_vit_config(config.raw)
+    mlp_hidden = int(vit_cfg["mlp_hidden"])
+    if mlp_hidden % parallel.tp_size != 0:
+        raise ValueError(
+            "timm_vit tensor-parallel MLP requires mlp_hidden divisible by tp_size "
+            f"({mlp_hidden} vs {parallel.tp_size})")
+
+
+def _slice_mlp_columns(
+    arr: np.ndarray,
+    mlp_hidden: int,
+    parallel: "ParallelConfig",
+) -> np.ndarray:
+    local = mlp_hidden // parallel.tp_size
+    start = parallel.rank * local
+    end = start + local
+    return np.ascontiguousarray(arr[..., start:end])
+
+
+def _slice_mlp_rows(
+    arr: np.ndarray,
+    mlp_hidden: int,
+    parallel: "ParallelConfig",
+) -> np.ndarray:
+    local = mlp_hidden // parallel.tp_size
+    start = parallel.rank * local
+    end = start + local
+    return np.ascontiguousarray(arr[start:end, ...])
+
+
+def build_timm_vit_tp_engine(
+    config: "ModelConfig",
+    weights: "WeightDict",
+    max_cache_length: int,
+    *,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build one rank-local timm ViT engine with tensor-parallel MLPs."""
+    del max_cache_length
+    if quant_ctx is not None:
+        raise ValueError("timm_vit tensor-parallel builds do not support quantization")
+    if precision not in ("fp32",):
+        raise ValueError("timm_vit tensor-parallel path currently supports precision='fp32'")
+
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError("timm_vit tensor-parallel builder requires an enabled parallel config")
+    _validate_timm_vit_tp(config, parallel)
+
+    vit_cfg = config.raw.get("_timm_vit_config") or _resolve_vit_config(config.raw)
+    image_h = vit_cfg["image_size_h"]
+    image_w = vit_cfg["image_size_w"]
+    patch_h = vit_cfg["patch_h"]
+    patch_w = vit_cfg["patch_w"]
+    hidden_size = vit_cfg["hidden"]
+    depth = vit_cfg["depth"]
+    num_heads = vit_cfg["heads"]
+    mlp_hidden = vit_cfg["mlp_hidden"]
+    local_mlp_hidden = mlp_hidden // parallel.tp_size
+    num_classes = vit_cfg["num_classes"]
+    eps_val = vit_cfg["eps"]
+
+    if image_h % patch_h != 0 or image_w % patch_w != 0:
+        raise ValueError(
+            f"image_size {image_h}x{image_w} must be divisible by patch "
+            f"{patch_h}x{patch_w}"
+        )
+
+    grid_h = image_h // patch_h
+    grid_w = image_w // patch_w
+    num_patches = grid_h * grid_w
+    seq_len = num_patches + 1
+
+    if verbose:
+        print(
+            "[trtmc build] timm_vit TP: "
+            f"rank={parallel.rank}/{parallel.tp_size}, image={image_h}x{image_w}, "
+            f"patch={patch_h}x{patch_w}, tokens={seq_len}, hidden={hidden_size}, "
+            f"layers={depth}, heads={num_heads}, mlp_local={local_mlp_hidden}, "
+            f"classes={num_classes}",
+            file=sys.stderr,
+        )
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        trt_compat.network_creation_flags(
+            strongly_typed=True,
+            explicit_batch=True,
+        )
+    )
+    trt_config = builder.create_builder_config()
+    trt_config.avg_timing_iterations = 8
+    trt_config.max_aux_streams = 0
+    trt_config.set_flag(trt.BuilderFlag.DISABLE_TIMING_CACHE)
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 4 << 30)
+
+    pixel_values = network.add_input(
+        "pixel_values", trt.float32, (1, 3, image_h, image_w))
+
+    patch = network.add_convolution_nd(
+        pixel_values,
+        num_output_maps=hidden_size,
+        kernel_shape=(patch_h, patch_w),
+        kernel=trt.Weights(np.ascontiguousarray(
+            weights["patch_embed.proj.weight"], dtype=np.float32)),
+        bias=trt.Weights(np.ascontiguousarray(
+            weights["patch_embed.proj.bias"], dtype=np.float32)),
+    )
+    patch.stride_nd = (patch_h, patch_w)
+
+    patches_nhwc = network.add_shuffle(patch.get_output(0))
+    patches_nhwc.first_transpose = (0, 2, 3, 1)
+    patches_nhwc.reshape_dims = (1, num_patches, hidden_size)
+    hidden = patches_nhwc.get_output(0)
+
+    cls_token = np.ascontiguousarray(
+        weights["cls_token"].reshape(1, 1, hidden_size), dtype=np.float32)
+    cls_const = graph_ops.add_constant(
+        network, (1, 1, hidden_size), cls_token, dtype=np.float32)
+    cat = network.add_concatenation([cls_const, hidden])
+    cat.axis = 1
+    hidden = cat.get_output(0)
+
+    pos_embed = np.ascontiguousarray(
+        weights["pos_embed"].reshape(1, seq_len, hidden_size), dtype=np.float32)
+    pos_const = graph_ops.add_constant(
+        network, (1, seq_len, hidden_size), pos_embed, dtype=np.float32)
+    hidden = network.add_elementwise(
+        hidden, pos_const, trt.ElementWiseOperation.SUM).get_output(0)
+
+    for layer_idx in range(depth):
+        prefix = f"blocks.{layer_idx}"
+        norm1 = graph_ops.add_layer_norm_native(
+            network,
+            hidden,
+            hidden_size,
+            weights[f"{prefix}.norm1.weight"].astype(np.float32),
+            weights[f"{prefix}.norm1.bias"].astype(np.float32),
+            eps_val,
+        )
+
+        qkv_w = weights[f"{prefix}.attn.qkv.weight"].astype(np.float32)
+        q_w, k_w, v_w = np.split(qkv_w, 3, axis=1)
+        qkv_b = weights.get(f"{prefix}.attn.qkv.bias")
+        q_b = k_b = v_b = None
+        if qkv_b is not None:
+            q_b, k_b, v_b = np.split(qkv_b.astype(np.float32), 3)
+
+        q = graph_ops.add_matmul_rhs_constant(
+            network,
+            norm1,
+            hidden_size,
+            hidden_size,
+            q_w,
+        )
+        k = graph_ops.add_matmul_rhs_constant(
+            network,
+            norm1,
+            hidden_size,
+            hidden_size,
+            k_w,
+        )
+        v = graph_ops.add_matmul_rhs_constant(
+            network,
+            norm1,
+            hidden_size,
+            hidden_size,
+            v_w,
+        )
+        if q_b is not None:
+            q = graph_ops.add_bias_sum(network, q, hidden_size, q_b)
+            k = graph_ops.add_bias_sum(network, k, hidden_size, k_b)
+            v = graph_ops.add_bias_sum(network, v, hidden_size, v_b)
+
+        head_dim = hidden_size // num_heads
+
+        def to_heads(x: trt.ITensor) -> trt.ITensor:
+            heads = network.add_shuffle(x)
+            heads.reshape_dims = (1, seq_len, num_heads, head_dim)
+            heads.second_transpose = trt.Permutation([0, 2, 1, 3])
+            return heads.get_output(0)
+
+        q = to_heads(q)
+        k = to_heads(k)
+        v = to_heads(v)
+        scale = graph_ops.add_constant(
+            network,
+            (1, 1, 1, 1),
+            np.array([[[[1.0 / np.sqrt(head_dim)]]]], dtype=np.float32),
+            dtype=np.float32,
+        )
+        q_scaled = network.add_elementwise(
+            q, scale, trt.ElementWiseOperation.PROD).get_output(0)
+        scores = network.add_matrix_multiply(
+            q_scaled,
+            trt.MatrixOperation.NONE,
+            k,
+            trt.MatrixOperation.TRANSPOSE,
+        )
+        probs = network.add_softmax(scores.get_output(0))
+        probs.axes = 1 << 3
+        context = network.add_matrix_multiply(
+            probs.get_output(0),
+            trt.MatrixOperation.NONE,
+            v,
+            trt.MatrixOperation.NONE,
+        )
+        attn_context = network.add_shuffle(context.get_output(0))
+        attn_context.first_transpose = trt.Permutation([0, 2, 1, 3])
+        attn_context.reshape_dims = (1, seq_len, hidden_size)
+        attn = graph_ops.add_matmul_rhs_constant(
+            network,
+            attn_context.get_output(0),
+            hidden_size,
+            hidden_size,
+            weights[f"{prefix}.attn.proj.weight"].astype(np.float32),
+        )
+        attn = graph_ops.add_bias_sum(
+            network,
+            attn,
+            hidden_size,
+            weights[f"{prefix}.attn.proj.bias"].astype(np.float32),
+        )
+        hidden = network.add_elementwise(
+            hidden, attn, trt.ElementWiseOperation.SUM).get_output(0)
+
+        norm2 = graph_ops.add_layer_norm_native(
+            network,
+            hidden,
+            hidden_size,
+            weights[f"{prefix}.norm2.weight"].astype(np.float32),
+            weights[f"{prefix}.norm2.bias"].astype(np.float32),
+            eps_val,
+        )
+        fc1_w = _slice_mlp_columns(
+            weights[f"{prefix}.mlp.fc1.weight"].astype(np.float32),
+            mlp_hidden,
+            parallel,
+        )
+        fc1_b = _slice_mlp_columns(
+            weights[f"{prefix}.mlp.fc1.bias"].astype(np.float32),
+            mlp_hidden,
+            parallel,
+        )
+        fc1 = graph_ops.add_matmul_rhs_constant(
+            network,
+            norm2,
+            hidden_size,
+            local_mlp_hidden,
+            fc1_w,
+        )
+        fc1 = graph_ops.add_bias_sum(network, fc1, local_mlp_hidden, fc1_b)
+        act = graph_ops.add_gelu_erf(network, fc1)
+        fc2_w = _slice_mlp_rows(
+            weights[f"{prefix}.mlp.fc2.weight"].astype(np.float32),
+            mlp_hidden,
+            parallel,
+        )
+        fc2 = graph_ops.add_matmul_rhs_constant(
+            network,
+            act,
+            local_mlp_hidden,
+            hidden_size,
+            fc2_w,
+        )
+        fc2 = add_all_reduce_sum(network, fc2, parallel.tp_size)
+        fc2 = graph_ops.add_bias_sum(
+            network,
+            fc2,
+            hidden_size,
+            weights[f"{prefix}.mlp.fc2.bias"].astype(np.float32),
+        )
+        hidden = network.add_elementwise(
+            hidden, fc2, trt.ElementWiseOperation.SUM).get_output(0)
+
+    hidden = graph_ops.add_layer_norm_native(
+        network,
+        hidden,
+        hidden_size,
+        weights["norm.weight"].astype(np.float32),
+        weights["norm.bias"].astype(np.float32),
+        eps_val,
+    )
+    cls = network.add_slice(
+        hidden, start=(0, 0, 0), shape=(1, 1, hidden_size), stride=(1, 1, 1)
+    ).get_output(0)
+
+    logits = graph_ops.add_matmul_rhs_constant(
+        network,
+        cls,
+        hidden_size,
+        num_classes,
+        _transpose_2d(
+            weights["head.weight"].astype(np.float32),
+            "head.weight",
+        ),
+    )
+    logits = graph_ops.add_bias_sum(
+        network, logits, num_classes, weights["head.bias"].astype(np.float32))
+    flatten_logits = network.add_shuffle(logits)
+    flatten_logits.reshape_dims = (1, num_classes)
+    logits = flatten_logits.get_output(0)
+    logits.name = "logits"
+    network.mark_output(logits)
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("TensorRT timm_vit tensor-parallel engine build failed")
+    return bytes(plan)

--- a/src/runtime/models/timm_vit/plugin.cpp
+++ b/src/runtime/models/timm_vit/plugin.cpp
@@ -2,9 +2,35 @@
 
 #include "runtime/models/timm_vit/pipeline.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
+#include "utils/json_helpers.h"
+
+#include <cstdint>
+#include <string>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+} // namespace
 
 class TimmVitPlugin final : public IPipelinePlugin {
   public:
@@ -13,8 +39,18 @@ class TimmVitPlugin final : public IPipelinePlugin {
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        std::string engine_section = "engine_plan";
+        if (tp_config.enabled) {
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+            opts.distributed_communicator = tp_group.communicator;
+            opts.distributed_owner = tp_group.owner;
+            engine_section = tp_engine_section_name(tp_group.rank);
+        }
+
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "engine_plan", opts);
+            ctx.backend, find_section(ctx.bundle, engine_section), "engine_plan", opts);
         return std::make_unique<ImageClassificationPipeline>(std::move(loaded.module),
                                                              ctx.bundle.info.model_id);
     }

--- a/tests/builder/test_family_timm_vit.py
+++ b/tests/builder/test_family_timm_vit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import importlib
 from pathlib import Path
 
 import numpy as np
@@ -12,8 +13,13 @@ try:
     from safetensors.numpy import save_file
     from tensorrt_model_connect.config import ModelConfig
     from tensorrt_model_connect.families.timm_vit import plugin
+    from tensorrt_model_connect.families.timm_vit import timm_vit_tp_builder as tp_builder
+    from tensorrt_model_connect.parallel_config import ParallelConfig
 except (ImportError, ModuleNotFoundError):
     pytest.skip("tensorrt_model_connect requires TensorRT", allow_module_level=True)
+
+timm_vit_plugin_module = importlib.import_module(
+    "tensorrt_model_connect.families.timm_vit.plugin")
 
 
 def _rand(*shape: int) -> np.ndarray:
@@ -87,3 +93,70 @@ def test_load_weights_maps_timm_vit_shapes(tmp_path: Path):
         weights["blocks.0.attn.qkv.weight"],
         raw["blocks.0.attn.qkv.weight"].T,
     )
+
+
+def test_timm_vit_tp_slices_mlp_weights_by_rank(tmp_path: Path):
+    raw = _write_tiny_vit(tmp_path)
+    cfg = ModelConfig.from_dir(tmp_path)
+    weights = plugin.load_weights(str(tmp_path), cfg)
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2)
+
+    fc1 = tp_builder._slice_mlp_columns(
+        weights["blocks.0.mlp.fc1.weight"], 16, parallel)
+    fc1_bias = tp_builder._slice_mlp_columns(
+        weights["blocks.0.mlp.fc1.bias"], 16, parallel)
+    fc2 = tp_builder._slice_mlp_rows(
+        weights["blocks.0.mlp.fc2.weight"], 16, parallel)
+
+    assert fc1.shape == (8, 4)
+    assert fc1_bias.shape == (4,)
+    assert fc2.shape == (4, 8)
+    np.testing.assert_allclose(fc1, raw["blocks.0.mlp.fc1.weight"].T[:, 8:12])
+    np.testing.assert_allclose(fc1_bias, raw["blocks.0.mlp.fc1.bias"][8:12])
+    np.testing.assert_allclose(fc2, raw["blocks.0.mlp.fc2.weight"].T[8:12, :])
+
+
+def test_timm_vit_tp_validation_requires_concrete_rank(tmp_path: Path):
+    _write_tiny_vit(tmp_path)
+    cfg = ModelConfig.from_dir(tmp_path)
+
+    with pytest.raises(ValueError, match="concrete rank"):
+        tp_builder._validate_timm_vit_tp(
+            cfg,
+            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=-1),
+        )
+
+
+def test_timm_vit_plugin_routes_parallel_builds(monkeypatch, tmp_path: Path):
+    _write_tiny_vit(tmp_path)
+    cfg = ModelConfig.from_dir(tmp_path)
+    weights = plugin.load_weights(str(tmp_path), cfg)
+    calls: dict[str, object] = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"timm-vit-tp-plan"
+
+    monkeypatch.setattr(
+        timm_vit_plugin_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(tp_builder, "build_timm_vit_tp_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1)
+    result = timm_vit_plugin_module.TimmVitPlugin().build_engine(
+        cfg,
+        weights,
+        1,
+        verbose=True,
+        parallel_config=parallel,
+    )
+
+    assert result == b"timm-vit-tp-plan"
+    assert calls["require"][0] == parallel
+    assert "timm_vit tensor-parallel" in calls["require"][1]
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 1
+    assert kwargs["parallel_config"] == parallel
+    assert kwargs["verbose"] is True

--- a/tests/e2e/models/timm-vit-base-p16-224-augreg-in21k-ft-in1k-tp4.json
+++ b/tests/e2e/models/timm-vit-base-p16-224-augreg-in21k-ft-in1k-tp4.json
@@ -1,0 +1,60 @@
+{
+  "name": "timm-vit-base-p16-224-augreg-in21k-ft-in1k-tp4",
+  "trace_id": "IT-E2E-TIMM-VIT-TP4-01",
+  "hf_id": "timm/vit_base_patch16_224.augreg_in21k_ft_in1k",
+  "bundle": "timm-vit-base-p16-224-augreg-in21k-ft-in1k-tp4.trtfb",
+  "family": "timm_vit",
+  "runtime_strategy": "image_classification",
+  "task_strategy": "image_classification",
+  "reference_family": "image_classification",
+  "user_contract": "image_classification",
+  "test_type": "image_classification",
+  "max_cache_length": 1,
+  "prompt": "",
+  "max_new_tokens": 0,
+  "precision": "fp32",
+  "trust_remote_code": false,
+  "test_image": "data/test_img.jpeg",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "timm ViT-base TP4 repro. Uses the same checkpoint, image, image-classification comparator, and thresholds as timm-vit-base-p16-224-augreg-in21k-ft-in1k."
+}

--- a/tests/e2e_harness/references/hf_transformers.py
+++ b/tests/e2e_harness/references/hf_transformers.py
@@ -916,13 +916,18 @@ class HfTransformersReference:
                 resized_w = resize_short
                 resized_h = max(1, int(height * resize_short / width + 0.5))
 
-            image = image.resize((resized_w, resized_h), Image.Resampling.NEAREST)
-            left = max(0, (resized_w - target) // 2)
-            top = max(0, (resized_h - target) // 2)
-            image = image.crop((left, top, left + target, top + target))
-            arr = np.asarray(image, dtype=np.float32) / 255.0
-            arr = (arr - 0.5) / 0.5
-            chw = np.transpose(arr, (2, 0, 1))[None, ...].copy()
+            source = np.asarray(image, dtype=np.float32) / 255.0
+            crop_x = max(0, (resized_w - target) // 2)
+            crop_y = max(0, (resized_h - target) // 2)
+            chw = np.empty((3, target, target), dtype=np.float32)
+            for y in range(target):
+                ry = crop_y + y
+                src_y = min(height - 1, int(float(ry) * height / resized_h))
+                for x in range(target):
+                    rx = crop_x + x
+                    src_x = min(width - 1, int(float(rx) * width / resized_w))
+                    chw[:, y, x] = (source[src_y, src_x, :] - 0.5) / 0.5
+            chw = chw[None, ...].copy()
 
             model_ref = f"hf-hub:{{hf_id}}"
             try:

--- a/tests/e2e_harness/runners/image_classification.py
+++ b/tests/e2e_harness/runners/image_classification.py
@@ -5,15 +5,92 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import subprocess
+import tempfile
 import time
 from pathlib import Path
 
-from .. import save_full_stderr
+from .. import save_full_stderr, _case_artifact_dir
 from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
 
 logger = logging.getLogger(__name__)
 PROJECT_DIR = Path(__file__).resolve().parents[3]
+_MPI_TAGGED_STDOUT_RE = re.compile(
+    r"^\[[^\]]+,(?P<rank>\d+)\]<stdout>:\s?(?P<text>.*)$")
+_MPI_STREAM_TAG_RE = re.compile(r"\[[^\]]+,\d+\]<(?:stdout|stderr)>:\s?")
+
+
+def _distributed_runtime_config(case: E2ECase) -> dict:
+    config = case.metadata.get("distributed_runtime", {})
+    return config if isinstance(config, dict) and config.get("enabled") else {}
+
+
+def _extract_rank_zero_stdout(stdout: str) -> str:
+    rank0_lines: list[str] = []
+    saw_tagged = False
+    for line in (stdout or "").splitlines():
+        match = _MPI_TAGGED_STDOUT_RE.match(line)
+        if match is None:
+            continue
+        saw_tagged = True
+        if int(match.group("rank")) == 0:
+            rank0_lines.append(match.group("text"))
+    if saw_tagged:
+        return "\n".join(rank0_lines).strip()
+    return (stdout or "").strip()
+
+
+def _strip_mpi_stream_tags(text: str) -> str:
+    return _MPI_STREAM_TAG_RE.sub("", text or "")
+
+
+def _ensure_distributed_runtime_env(
+    case: E2ECase,
+    ctx: RunContext,
+    env: dict[str, str],
+) -> None:
+    if not _distributed_runtime_config(case) or env.get("TRTMC_NCCL_RENDEZVOUS"):
+        return
+    root = (
+        Path(_case_artifact_dir(ctx.artifacts_dir, case.name))
+        if ctx.artifacts_dir else Path(tempfile.gettempdir())
+    )
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / f"{case.name}.nccl_rendezvous.bin"
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    env["TRTMC_NCCL_RENDEZVOUS"] = str(path)
+
+
+def _wrap_distributed_command(
+    cmd: list[str],
+    case: E2ECase,
+    env: dict[str, str],
+) -> list[str]:
+    config = _distributed_runtime_config(case)
+    if not config:
+        return cmd
+    launcher = str(config.get("launcher", "mpirun") or "mpirun")
+    world_size = int(config.get("world_size", config.get("tp_size", 2)) or 2)
+    launcher_args = config.get("launcher_args")
+    if isinstance(launcher_args, list):
+        prefix = [launcher] + [str(arg) for arg in launcher_args]
+    else:
+        prefix = [launcher, "--tag-output", "-np", str(world_size)]
+
+    export_env = config.get("export_env", ["LD_LIBRARY_PATH", "CUDA_VISIBLE_DEVICES"])
+    if isinstance(export_env, list) and Path(launcher).name == "mpirun":
+        export_names = [str(name) for name in export_env]
+        if "TRTMC_NCCL_RENDEZVOUS" in env and "TRTMC_NCCL_RENDEZVOUS" not in export_names:
+            export_names.append("TRTMC_NCCL_RENDEZVOUS")
+        for name in export_names:
+            if name in env:
+                prefix.extend(["-x", name])
+
+    return prefix + cmd
 
 
 class ImageClassificationRunner:
@@ -43,6 +120,8 @@ class ImageClassificationRunner:
         env = dict(os.environ)
         if ctx.ld_library_path:
             env["LD_LIBRARY_PATH"] = ctx.ld_library_path
+        _ensure_distributed_runtime_env(case, ctx, env)
+        cmd = _wrap_distributed_command(cmd, case, env)
 
         logger.info("Running image classification: %s", " ".join(cmd))
         t0 = time.monotonic()
@@ -62,21 +141,29 @@ class ImageClassificationRunner:
                 msg += f" (full stderr: {log_path})"
             raise RuntimeError(msg)
 
+        stdout = _extract_rank_zero_stdout(result.stdout)
         try:
-            data = json.loads(result.stdout.strip())
+            data = json.loads(stdout)
         except json.JSONDecodeError:
-            data = {"raw_output": result.stdout.strip()}
+            data = {"raw_output": stdout}
+
+        stderr_truncated, stderr_log = save_full_stderr(
+            result.stderr or "", ctx.artifacts_dir or "",
+            "image_classification", case.name)
+        metadata = {
+            "command": cmd,
+            "returncode": result.returncode,
+            "stdout": _strip_mpi_stream_tags(result.stdout or ""),
+            "stderr": _strip_mpi_stream_tags(stderr_truncated),
+        }
+        if stderr_log:
+            metadata["stderr_log"] = stderr_log
 
         return StageOutput(
             stage_name=stage.name,
             data=data,
             timing_s=elapsed,
-            metadata={
-                "command": cmd,
-                "returncode": result.returncode,
-                "stdout": result.stdout or "",
-                "stderr": result.stderr or "",
-            },
+            metadata=metadata,
         )
 
     def _resolve_image_path(self, case: E2ECase, ctx: RunContext) -> str | None:


### PR DESCRIPTION
## Background
The timm ViT family had only a single-device e2e manifest. This adds TP4 coverage following the existing vision TP pattern: keep attention replicated, shard the MLP projections, and join the residual path with TensorRT distributed all-reduce.

## Exit Criteria
- Add timm ViT TP4 build/runtime support without changing the image-classification comparator threshold.
- Add a TP4 e2e manifest for `timm/vit_base_patch16_224.augreg_in21k_ft_in1k`.
- Verify the existing single-device timm ViT e2e and the new TP4 e2e on the B200 container using four visible GPUs mapped from host GPUs 4-7.

## Implementation
- Added `timm_vit_tp_builder.py`, a duplicated rank-local TRT builder that keeps attention, embeddings, norms, and classifier replicated while tensor-parallelizing the block MLP FC1/FC2 path.
- Routed `timm_vit` plugin builds through the TP builder when `parallel.mode=tensor_parallel`, and updated the C++ runtime plugin to load rank-specific `engine_plan_tp_rankN` sections with a distributed communicator.
- Added distributed launch support to the image-classification e2e runner so TP classify runs use `mpirun` and parse rank-0 JSON output.
- Aligned the HF image-classification reference preprocessing with the C++ runtime sampling path; the existing single-device timm ViT e2e was otherwise comparing against a different resized input.
- Added the `timm-vit-base-p16-224-augreg-in21k-ft-in1k-tp4` manifest with the same comparator behavior as the single-device case.

## Validation
- `sudo -n docker exec trtmc-b200-qwen-vl-tp bash -lc 'cd /workspace/tensorrt-model-connect && export PYTHONPATH=/workspace/tensorrt-model-connect/python:/workspace/tensorrt-model-connect && export PYTHONDONTWRITEBYTECODE=1 && pytest -p no:cacheprovider -q tests/builder/test_family_timm_vit.py tests/builder/test_manifest_validation.py'`: passed, `31 passed`.
- `sudo -n docker exec -u 47239:30 trtmc-b200-qwen-vl-tp bash -lc 'cd /workspace/tensorrt-model-connect && cmake --build build-b200-trt11-local-trt --target trtmc -j 8'`: passed.
- `sudo -n docker exec trtmc-b200-qwen-vl-tp bash -lc 'cd /workspace/tensorrt-model-connect && export PYTHONPATH=/workspace/tensorrt-model-connect/python:/workspace/tensorrt-model-connect && export PYTHONDONTWRITEBYTECODE=1 && export CUDA_VISIBLE_DEVICES=0 && pytest -p no:cacheprovider -s "tests/test_e2e.py::test_e2e[timm-vit-base-p16-224-augreg-in21k-ft-in1k]" --engine-dir /tmp/trtmc-timm-vit-single-check/engines --e2e-artifacts-dir /tmp/trtmc-timm-vit-single-check/artifacts --trtmc-binary build-b200-trt11-local-trt/trtmc --hf-python /opt/venv/bin/python'`: passed, `1 passed in 26.39s`.
- `sudo -n docker exec trtmc-b200-qwen-vl-tp bash -lc 'cd /workspace/tensorrt-model-connect && export PYTHONPATH=/workspace/tensorrt-model-connect/python:/workspace/tensorrt-model-connect && export PYTHONDONTWRITEBYTECODE=1 && export CUDA_VISIBLE_DEVICES=0,1,2,3 && export TRTMC_NCCL_LIB_DIR=/opt/venv/lib/python3.12/site-packages/nvidia/nccl/lib && export LD_LIBRARY_PATH=/opt/venv/lib/python3.12/site-packages/nvidia/nccl/lib:${LD_LIBRARY_PATH} && export OMPI_ALLOW_RUN_AS_ROOT=1 && export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 && pytest -p no:cacheprovider -s "tests/test_e2e.py::test_e2e[timm-vit-base-p16-224-augreg-in21k-ft-in1k-tp4]" --multi-device-only --engine-dir /tmp/trtmc-timm-vit-tp4-e2e/engines --e2e-artifacts-dir /tmp/trtmc-timm-vit-tp4-e2e/artifacts --trtmc-binary build-b200-trt11-local-trt/trtmc --hf-python /opt/venv/bin/python'`: passed, `1 passed in 27.71s`; result artifact reports `TRT top=479, reference top=479`.

## Notes For Future Readers
- The TP builder intentionally mirrors the SAM/SegFormer vision TP approach by sharding only the MLP path; attention remains replicated.
- The B200 container venv needed `timm` installed so the existing image-classification reference runner could execute.
