### PR TITLE
feat(eagle-vlm): add tensor parallel support

### DIFF
--- a/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/plugin.py
@@ -30,6 +30,10 @@ from ...checkpoint_mapper import (
     _has_tensor,
     _transpose_2d,
 )
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
 
 if TYPE_CHECKING:
     pass
@@ -69,11 +73,21 @@ class EagleVLMPlugin:
     def build_engine(
         self, config: ModelConfig, weights: WeightDict,
         max_cache_length: int, *, precision: str = "fp32",
-        quant_ctx=None, verbose: bool = False,
+        quant_ctx=None, verbose: bool = False, parallel_config=None,
     ) -> bytes:
         is_rerank = _is_reranker(config)
         # Store for runtime_strategy property
         self._runtime_strategy = "reranking" if is_rerank else "embedding"
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="Eagle VLM tensor-parallel builds")
+            from .tp_builder import build_eagle_vlm_tp_engine
+            return build_eagle_vlm_tp_engine(
+                config, weights, max_cache_length,
+                is_reranker=is_rerank,
+                verbose=verbose,
+                parallel_config=parallel)
         return _build_eagle_engine(
             config, weights, max_cache_length,
             is_reranker=is_rerank, verbose=verbose)

--- a/python/tensorrt_model_connect/families/eagle_vlm/tp_builder.py
+++ b/python/tensorrt_model_connect/families/eagle_vlm/tp_builder.py
@@ -1,0 +1,253 @@
+"""Tensor-parallel Eagle VLM text-backbone builder."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ...checkpoint_mapper import WeightDict
+from ...parallel_config import (
+    add_all_reduce_sum,
+    normalize_parallel_config,
+    shard_standard_decoder_weights,
+)
+from .plugin import _make_llama3_rope_table_half_dim
+
+if TYPE_CHECKING:
+    from ...config import ModelConfig
+    from ...parallel_config import ParallelConfig
+
+
+def shard_eagle_vlm_weights(
+    config: "ModelConfig",
+    weights: WeightDict,
+    *,
+    parallel: "ParallelConfig",
+) -> WeightDict:
+    """Return rank-local Eagle VLM text weights for TP builds."""
+    return shard_standard_decoder_weights(config, weights, parallel)
+
+
+def build_eagle_vlm_tp_engine(
+    config: "ModelConfig",
+    weights: WeightDict,
+    max_cache_length: int,
+    *,
+    is_reranker: bool = False,
+    precision: str = "fp32",
+    quant_ctx=None,
+    verbose: bool = False,
+    parallel_config=None,
+) -> bytes:
+    """Build a rank-local tensor-parallel Eagle VLM text engine.
+
+    This mirrors the single-device Eagle text builder. The only graph changes
+    are rank-local Q/K/V and MLP inner projections plus all-reduce joins after
+    row-parallel attention and MLP output projections.
+    """
+    del precision, quant_ctx
+
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError(
+            "build_eagle_vlm_tp_engine requires tensor_parallel mode with "
+            "tp_size > 1")
+    rank_weights = shard_eagle_vlm_weights(
+        config, weights, parallel=parallel)
+
+    from tensorrt_model_connect import trt_compat
+    trt = trt_compat.get_trt()
+    from ... import graph_ops
+    from ... import graph_blocks
+
+    attention_size = int(rank_weights.get(
+        "_attention_size", config.attention_size // parallel.tp_size))
+    mlp_size = int(rank_weights.get(
+        "_mlp_size", config.intermediate_size // parallel.tp_size))
+    hidden = config.hidden_size
+    vocab = config.vocab_size
+    num_layers = config.num_hidden_layers
+    num_heads = config.num_attention_heads // parallel.tp_size
+    num_kv_heads = config.num_key_value_heads // parallel.tp_size
+    head_dim = attention_size // num_heads
+    kv_attention_size = graph_blocks.infer_kv_attention_size(
+        rank_weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
+    seq_length = max_cache_length
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    trt_config = builder.create_builder_config()
+    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    input_ids = network.add_input("input_ids", trt.int32, (seq_length,))
+    attention_mask_input = network.add_input("attention_mask", trt.int32, (seq_length,))
+    input_embed = network.add_input("input_embed", trt.float32, (seq_length, hidden))
+    use_input_embed = network.add_input("use_input_embed", trt.float32, (seq_length,))
+
+    embedding_table = graph_ops.add_constant(
+        network, (vocab, hidden), rank_weights["embedding"])
+    gather = network.add_gather(embedding_table, input_ids, 0)
+    token_embed = gather.get_output(0)
+
+    use_reshape = network.add_shuffle(use_input_embed)
+    use_reshape.reshape_dims = (seq_length, 1)
+    ones_bcast = graph_ops.add_constant(
+        network, (1, 1), np.array([1.0], dtype=np.float32))
+    inv_use = network.add_elementwise(
+        ones_bcast, use_reshape.get_output(0),
+        trt.ElementWiseOperation.SUB)
+    embed_part = network.add_elementwise(
+        input_embed, use_reshape.get_output(0),
+        trt.ElementWiseOperation.PROD)
+    token_part = network.add_elementwise(
+        token_embed, inv_use.get_output(0),
+        trt.ElementWiseOperation.PROD)
+    merged = network.add_elementwise(
+        embed_part.get_output(0), token_part.get_output(0),
+        trt.ElementWiseOperation.SUM)
+    hidden_state = merged.get_output(0)
+
+    graph_ops.validate_native_rope_dim(head_dim, field_name="head_dim")
+    rope_params = config.raw.get("llm_config", {}).get("rope_parameters", {})
+    rope_type = rope_params.get("rope_type", "")
+    if rope_type == "llama3":
+        cos_half_np = _make_llama3_rope_table_half_dim(
+            seq_length, head_dim, config.rope_theta, True,
+            factor=rope_params.get("factor", 1.0),
+            low_freq_factor=rope_params.get("low_freq_factor", 1.0),
+            high_freq_factor=rope_params.get("high_freq_factor", 1.0),
+            original_max_position_embeddings=rope_params.get(
+                "original_max_position_embeddings", 8192))
+        sin_half_np = _make_llama3_rope_table_half_dim(
+            seq_length, head_dim, config.rope_theta, False,
+            factor=rope_params.get("factor", 1.0),
+            low_freq_factor=rope_params.get("low_freq_factor", 1.0),
+            high_freq_factor=rope_params.get("high_freq_factor", 1.0),
+            original_max_position_embeddings=rope_params.get(
+                "original_max_position_embeddings", 8192))
+    else:
+        cos_half_np = graph_ops.make_rope_table_half_dim(
+            seq_length, head_dim, config.rope_theta, True)
+        sin_half_np = graph_ops.make_rope_table_half_dim(
+            seq_length, head_dim, config.rope_theta, False)
+    cos_half_tensor = graph_ops.add_constant(
+        network, cos_half_np.shape, cos_half_np)
+    sin_half_tensor = graph_ops.add_constant(
+        network, sin_half_np.shape, sin_half_np)
+    rope_position_ids = graph_ops.add_constant(
+        network, (seq_length,), np.arange(seq_length, dtype=np.int32),
+        dtype=np.int32)
+    eps_tensor = graph_ops.add_constant(
+        network, (1, 1), np.array([config.rms_norm_eps], dtype=np.float32))
+    attn_scale = 1.0 / np.sqrt(max(head_dim, 1))
+
+    mask_float = network.add_cast(attention_mask_input, trt.float32)
+    ones_const = graph_ops.add_constant(
+        network, (1,), np.array([1.0], dtype=np.float32))
+    neg_large = graph_ops.add_constant(
+        network, (1,), np.array([-1e10], dtype=np.float32))
+    inv_mask = network.add_elementwise(
+        ones_const, mask_float.get_output(0), trt.ElementWiseOperation.SUB)
+    pad_penalty = network.add_elementwise(
+        inv_mask.get_output(0), neg_large, trt.ElementWiseOperation.PROD)
+    pad_mask_row = network.add_shuffle(pad_penalty.get_output(0))
+    pad_mask_row.reshape_dims = (1, seq_length)
+    query_zeros = graph_ops.add_constant(
+        network, (seq_length, 1), np.zeros((seq_length, 1), dtype=np.float32))
+    pad_mask_2d = network.add_elementwise(
+        query_zeros, pad_mask_row.get_output(0), trt.ElementWiseOperation.SUM)
+    pad_mask_4d = graph_ops.add_2d_mask_to_4d(network, pad_mask_2d.get_output(0))
+
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+
+        norm1 = graph_blocks.apply_norm(
+            network, hidden_state, hidden,
+            rank_weights[f"{prefix}.input_norm"],
+            None, eps_tensor, "rmsnorm")
+
+        q = graph_ops.add_matmul_rhs_constant(
+            network, norm1, hidden, attention_size, rank_weights[f"{prefix}.w_q"])
+        k = graph_ops.add_matmul_rhs_constant(
+            network, norm1, hidden, kv_attention_size, rank_weights[f"{prefix}.w_k"])
+        v = graph_ops.add_matmul_rhs_constant(
+            network, norm1, hidden, kv_attention_size, rank_weights[f"{prefix}.w_v"])
+
+        q_rope = graph_ops.add_apply_rope_native(
+            network, q, num_heads, head_dim,
+            cos_half_tensor, sin_half_tensor, rope_position_ids,
+            head_dim, sequence_length=seq_length)
+        k_rope = graph_ops.add_apply_rope_native(
+            network, k, num_kv_heads, head_dim,
+            cos_half_tensor, sin_half_tensor, rope_position_ids,
+            head_dim, sequence_length=seq_length)
+
+        attn_concat = graph_ops.add_attention_from_rows(
+            network, q_rope, k_rope, v,
+            num_heads=num_heads, head_dim=head_dim,
+            num_kv_heads=num_kv_heads,
+            q_seq=seq_length, kv_seq=seq_length,
+            mask=pad_mask_4d,
+            scale=attn_scale)
+
+        proj_out = graph_ops.add_matmul_rhs_constant(
+            network, attn_concat, attention_size, hidden,
+            rank_weights[f"{prefix}.w_o"])
+        proj_out = add_all_reduce_sum(network, proj_out, parallel.tp_size)
+
+        residual1 = network.add_elementwise(
+            hidden_state, proj_out, trt.ElementWiseOperation.SUM)
+
+        norm2 = graph_blocks.apply_norm(
+            network, residual1.get_output(0), hidden,
+            rank_weights[f"{prefix}.post_attn_norm"],
+            None, eps_tensor, "rmsnorm")
+
+        mlp_out = graph_blocks.add_swiglu_mlp(
+            network, norm2, weights=rank_weights, prefix=prefix,
+            hidden_size=hidden, mlp_size=mlp_size)
+        mlp_out = add_all_reduce_sum(network, mlp_out, parallel.tp_size)
+
+        residual2 = network.add_elementwise(
+            residual1.get_output(0), mlp_out,
+            trt.ElementWiseOperation.SUM)
+        hidden_state = residual2.get_output(0)
+
+    final_norm = rank_weights.get("final_norm")
+    if final_norm is not None and len(final_norm) > 0:
+        hidden_state = graph_blocks.apply_norm(
+            network, hidden_state, hidden, final_norm, None,
+            eps_tensor, "rmsnorm")
+
+    if is_reranker and "score_weight" in rank_weights:
+        score = graph_ops.add_matmul_rhs_constant(
+            network, hidden_state, hidden,
+            rank_weights["score_weight"].shape[1],
+            rank_weights["score_weight"])
+        if "score_bias" in rank_weights:
+            score = graph_ops.add_bias_sum(
+                network, score, rank_weights["score_weight"].shape[1],
+                rank_weights["score_bias"])
+        score.name = "score"
+        network.mark_output(score)
+    else:
+        hidden_state.name = "hidden_states"
+        network.mark_output(hidden_state)
+
+    mode_str = "reranking" if is_reranker else "embedding"
+    if verbose:
+        print(f"[trtmc build] Building Eagle {mode_str} TP engine "
+              f"(rank={parallel.rank}/{parallel.tp_size}, "
+              f"{num_layers} layers, hidden={hidden}, "
+              f"attn={attention_size}, mlp={mlp_size}, "
+              f"seq_len={seq_length}) ...",
+              file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, trt_config)
+    if plan is None:
+        raise RuntimeError("Eagle VLM tensor-parallel engine build failed")
+
+    return bytes(plan)

--- a/src/runtime/models/encoder/plugin.cpp
+++ b/src/runtime/models/encoder/plugin.cpp
@@ -3,9 +3,35 @@
 
 #include "runtime/models/encoder/pipeline.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
+#include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
+#include "utils/json_helpers.h"
+
+#include <cstdint>
+#include <string>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+} // namespace
 
 class EncoderPlugin final : public IPipelinePlugin {
   public:
@@ -16,8 +42,18 @@ class EncoderPlugin final : public IPipelinePlugin {
         opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
         opts.cuda_graphs = ctx.cuda_graphs;
 
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        DistributedRuntimeGroup tp_group;
+        std::string engine_section = "engine_plan";
+        if (tp_config.enabled) {
+            tp_group = initialize_tensor_parallel_group(tp_config.tp_size);
+            opts.distributed_communicator = tp_group.communicator;
+            opts.distributed_owner = tp_group.owner;
+            engine_section = tp_engine_section_name(tp_group.rank);
+        }
+
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "engine_plan", opts);
+            ctx.backend, find_section(ctx.bundle, engine_section), "engine_plan", opts);
         auto tokenizer = create_tokenizer_from_bundle(ctx.bundle);
 
         return std::make_unique<EncoderPipeline>(std::move(loaded.module),

--- a/tests/builder/test_engine_eagle_vlm_tp.py
+++ b/tests/builder/test_engine_eagle_vlm_tp.py
@@ -1,0 +1,155 @@
+"""Focused tests for Eagle VLM tensor-parallel text-backbone support."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.parallel_config import ParallelConfig
+
+
+class _Config:
+    raw = {}
+    model_type = "llama_nemotron_vl"
+    vocab_size = 32
+    hidden_size = 16
+    num_hidden_layers = 1
+    num_attention_heads = 4
+    num_key_value_heads = 4
+    head_dim = 4
+    attention_size = 16
+    intermediate_size = 32
+
+
+def _weights() -> WeightDict:
+    hidden = _Config.hidden_size
+    attention = _Config.attention_size
+    mlp = _Config.intermediate_size
+    return WeightDict({
+        "embedding": np.zeros((_Config.vocab_size, hidden), dtype=np.float32),
+        "layer.0.input_norm": np.ones((hidden,), dtype=np.float32),
+        "layer.0.post_attn_norm": np.ones((hidden,), dtype=np.float32),
+        "layer.0.w_q": np.zeros((hidden, attention), dtype=np.float32),
+        "layer.0.w_k": np.zeros((hidden, attention), dtype=np.float32),
+        "layer.0.w_v": np.zeros((hidden, attention), dtype=np.float32),
+        "layer.0.w_o": np.zeros((attention, hidden), dtype=np.float32),
+        "layer.0.w_gate": np.zeros((hidden, mlp), dtype=np.float32),
+        "layer.0.w_up": np.zeros((hidden, mlp), dtype=np.float32),
+        "layer.0.w_down": np.zeros((mlp, hidden), dtype=np.float32),
+        "final_norm": np.ones((hidden,), dtype=np.float32),
+        "score_weight": np.zeros((hidden, 1), dtype=np.float32),
+        "score_bias": np.zeros((1,), dtype=np.float32),
+        "w_out": np.zeros((hidden, 1), dtype=np.float32),
+        "_attention_size": attention,
+        "_kv_attention_size": attention,
+        "_mlp_size": mlp,
+    })
+
+
+def test_eagle_vlm_tp_shards_text_backbone_weights() -> None:
+    from tensorrt_model_connect.families.eagle_vlm import tp_builder
+
+    sharded = tp_builder.shard_eagle_vlm_weights(
+        _Config(),
+        _weights(),
+        parallel=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=2),
+    )
+
+    assert sharded["layer.0.w_q"].shape == (16, 4)
+    assert sharded["layer.0.w_k"].shape == (16, 4)
+    assert sharded["layer.0.w_v"].shape == (16, 4)
+    assert sharded["layer.0.w_o"].shape == (4, 16)
+    assert sharded["layer.0.w_gate"].shape == (16, 8)
+    assert sharded["layer.0.w_up"].shape == (16, 8)
+    assert sharded["layer.0.w_down"].shape == (8, 16)
+    assert sharded["score_weight"].shape == (16, 1)
+    assert sharded["_attention_size"] == 4
+    assert sharded["_kv_attention_size"] == 4
+    assert sharded["_mlp_size"] == 8
+    assert sharded["_tensor_parallel_size"] == 4
+    assert sharded["_tensor_parallel_rank"] == 2
+
+
+def test_eagle_vlm_tp_builder_rejects_single_device_mode() -> None:
+    from tensorrt_model_connect.families.eagle_vlm import tp_builder
+
+    with pytest.raises(ValueError, match="requires tensor_parallel"):
+        tp_builder.build_eagle_vlm_tp_engine(
+            _Config(),
+            _weights(),
+            max_cache_length=4,
+            parallel_config=ParallelConfig(),
+        )
+
+
+def test_eagle_vlm_parallel_build_routes_to_tp_builder(monkeypatch) -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.eagle_vlm.plugin")
+    from tensorrt_model_connect.families.eagle_vlm import tp_builder
+
+    calls = {}
+
+    def fake_require(parallel, *, feature):
+        calls["require"] = (parallel, feature)
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = {
+            "config": config,
+            "weights": weights,
+            "max_cache_length": max_cache_length,
+            "kwargs": kwargs,
+        }
+        return b"eagle-vlm-tp-plan"
+
+    monkeypatch.setattr(
+        plugin_module, "require_tensorrt_11_for_tensor_parallel", fake_require)
+    monkeypatch.setattr(tp_builder, "build_eagle_vlm_tp_engine", fake_build)
+
+    parallel = ParallelConfig(mode="tensor_parallel", tp_size=4, rank=1)
+    result = plugin_module.plugin.build_engine(
+        _Config(),
+        _weights(),
+        max_cache_length=512,
+        parallel_config=parallel,
+    )
+
+    assert result == b"eagle-vlm-tp-plan"
+    assert calls["require"] == (parallel, "Eagle VLM tensor-parallel builds")
+    assert calls["build"]["max_cache_length"] == 512
+    assert calls["build"]["kwargs"]["parallel_config"] == parallel
+    assert calls["build"]["kwargs"]["is_reranker"] is False
+
+
+def test_eagle_vlm_parallel_build_preserves_reranking_mode(monkeypatch) -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.eagle_vlm.plugin")
+    from tensorrt_model_connect.families.eagle_vlm import tp_builder
+
+    calls = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["kwargs"] = kwargs
+        return b"eagle-rerank-tp-plan"
+
+    monkeypatch.setattr(
+        plugin_module,
+        "require_tensorrt_11_for_tensor_parallel",
+        lambda parallel, *, feature: None,
+    )
+    monkeypatch.setattr(tp_builder, "build_eagle_vlm_tp_engine", fake_build)
+
+    class RerankConfig(_Config):
+        raw = {"is_reranker": True}
+
+    result = plugin_module.plugin.build_engine(
+        RerankConfig(),
+        _weights(),
+        max_cache_length=256,
+        parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+    )
+
+    assert result == b"eagle-rerank-tp-plan"
+    assert calls["kwargs"]["is_reranker"] is True

--- a/tests/e2e/models/nemotron-embed-vl-1b-v2-tp4.json
+++ b/tests/e2e/models/nemotron-embed-vl-1b-v2-tp4.json
@@ -1,0 +1,59 @@
+{
+  "name": "nemotron-embed-vl-1b-v2-tp4",
+  "trace_id": "IT-E2E-NMEMB-TP4-01",
+  "hf_id": "nvidia/llama-nemotron-embed-vl-1b-v2",
+  "bundle": "nemotron-embed-vl-1b-v2-tp4.trtfb",
+  "family": "eagle_vlm",
+  "runtime_strategy": "embedding",
+  "reference_family": "vl_embed_retrieval",
+  "user_contract": "embedding_vector",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 512,
+  "prompt": "What is machine learning?",
+  "trust_remote_code": true,
+  "metadata": {
+    "trust_remote_code": true,
+    "modality": "text"
+  },
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "Eagle VLM/Nemotron embed TP4 coverage. Uses the same checkpoint, prompt, cache length, metadata, and default embedding thresholds as nemotron-embed-vl-1b-v2 while running the Llama text backbone through rank-local TP engines."
+}

--- a/tests/e2e/models/nemotron-rerank-vl-1b-v2-tp4.json
+++ b/tests/e2e/models/nemotron-rerank-vl-1b-v2-tp4.json
@@ -1,0 +1,72 @@
+{
+  "name": "nemotron-rerank-vl-1b-v2-tp4",
+  "trace_id": "IT-E2E-EGRK-TP4-01",
+  "hf_id": "nvidia/llama-nemotron-rerank-vl-1b-v2",
+  "bundle": "nemotron-rerank-vl-1b-v2-tp4.trtfb",
+  "family": "eagle_vlm",
+  "runtime_strategy": "reranking",
+  "reference_family": "vl_rerank",
+  "user_contract": "ranking_order",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 256,
+  "inputs": {
+    "prompt": "Which planet is known as the Red Planet?",
+    "documents": [
+      "Venus is often called Earth's twin because of its similar size and proximity.",
+      "Mars, known for its reddish appearance, is often referred to as the Red Planet.",
+      "Jupiter, the largest planet in our solar system, has a prominent red spot.",
+      "Saturn, famous for its rings, is sometimes mistaken for the Red Planet."
+    ]
+  },
+  "max_new_tokens": 1,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "trust_remote_code": true,
+  "threshold_overrides": {
+    "contract_ranking_agreement": 1.0,
+    "pairwise_ordering_agreement": 1.0,
+    "kendall_tau": 1.0,
+    "spearman_rho": 1.0
+  },
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "notes": "Eagle VLM/Nemotron rerank TP4 coverage. Uses the same checkpoint, prompt, documents, cache length, and strict ranking thresholds as nemotron-rerank-vl-1b-v2 while running the Llama text backbone through rank-local TP engines."
+}

--- a/tests/e2e_harness/runners/embedding.py
+++ b/tests/e2e_harness/runners/embedding.py
@@ -11,8 +11,16 @@ import os
 import subprocess
 import time
 
-from .. import save_full_stderr
+from .. import _case_artifact_dir, save_full_stderr
 from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
+from .text_generation import (
+    _distributed_runtime_config,
+    _ensure_distributed_runtime_env,
+    _extract_rank_zero_stdout,
+    _maybe_start_gpu_memory_sampler,
+    _strip_mpi_stream_tags,
+    _wrap_distributed_command,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,17 +53,57 @@ class EmbeddingRunner:
         env = dict(os.environ)
         if ctx.ld_library_path:
             env["LD_LIBRARY_PATH"] = ctx.ld_library_path
+        distributed_runtime = _distributed_runtime_config(case)
+        embedding_stdout_path = ""
+        if distributed_runtime:
+            _ensure_distributed_runtime_env(case, ctx, env)
+            extra_env = distributed_runtime.get("env", {})
+            if isinstance(extra_env, dict):
+                env.update({str(k): str(v) for k, v in extra_env.items()})
+            if ctx.artifacts_dir:
+                artifact_dir = _case_artifact_dir(ctx.artifacts_dir, case.name)
+                embedding_stdout_path = os.path.join(
+                    artifact_dir, "embedding_rank0_stdout.json")
+                try:
+                    os.unlink(embedding_stdout_path)
+                except FileNotFoundError:
+                    pass
+                env["TRTMC_EMBEDDING_STDOUT"] = embedding_stdout_path
+                cmd = _wrap_rank0_stdout_capture(cmd)
+                export_env = distributed_runtime.get("export_env", [])
+                if isinstance(export_env, list):
+                    export_names = [str(name) for name in export_env]
+                    if "TRTMC_EMBEDDING_STDOUT" not in export_names:
+                        distributed_runtime = dict(distributed_runtime)
+                        distributed_runtime["export_env"] = (
+                            export_names + ["TRTMC_EMBEDDING_STDOUT"])
+            cmd = _wrap_distributed_command(cmd, case, env)
 
         logger.info("Running embedding: %s", " ".join(cmd))
         t0 = time.monotonic()
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, env=env, timeout=600,
-        )
+        memory_sampler = _maybe_start_gpu_memory_sampler(
+            distributed_runtime, ctx, case, env)
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, env=env, timeout=600,
+            )
+        finally:
+            memory_meta = (
+                memory_sampler.stop() if memory_sampler is not None else None)
         elapsed = time.monotonic() - t0
+        parse_stdout = (
+            _extract_rank_zero_stdout(result.stdout)
+            if distributed_runtime else result.stdout.strip())
+        if embedding_stdout_path and os.path.isfile(embedding_stdout_path):
+            with open(embedding_stdout_path, encoding="utf-8") as f:
+                parse_stdout = f.read().strip()
+        parse_stderr = (
+            _strip_mpi_stream_tags(result.stderr)
+            if distributed_runtime else result.stderr)
 
         if result.returncode != 0:
             truncated, log_path = save_full_stderr(
-                result.stderr, ctx.artifacts_dir or "",
+                parse_stderr, ctx.artifacts_dir or "",
                 "embedding", case.name)
             msg = (f"Embedding inference failed (rc={result.returncode}): "
                    f"{truncated}")
@@ -64,19 +112,24 @@ class EmbeddingRunner:
             raise RuntimeError(msg)
 
         # Parse embedding vector from stdout (JSON array or whitespace-separated floats)
-        stdout = result.stdout.strip()
-        embedding = _parse_embedding(stdout)
+        embedding = _parse_embedding(parse_stdout)
+
+        metadata = {
+            "command": cmd,
+            "returncode": result.returncode,
+            "stdout": result.stdout or "",
+            "stderr": parse_stderr or "",
+        }
+        if distributed_runtime:
+            metadata["distributed_runtime"] = distributed_runtime
+        if memory_meta is not None:
+            metadata["gpu_memory"] = memory_meta
 
         return StageOutput(
             stage_name=stage.name,
             data={"embedding": embedding},
             timing_s=elapsed,
-            metadata={
-                "command": cmd,
-                "returncode": result.returncode,
-                "stdout": result.stdout or "",
-                "stderr": result.stderr or "",
-            },
+            metadata=metadata,
         )
 
 
@@ -92,19 +145,42 @@ def _parse_embedding(stdout: str) -> list[float]:
     except (json.JSONDecodeError, ValueError):
         pass
 
+    # OpenMPI --tag-output can split long rank-0 JSON lines into tagged
+    # chunks. The distributed stdout extractor rejoins those chunks with
+    # newlines, which may land inside JSON numbers.
+    try:
+        compact = "".join(stdout.splitlines())
+        data = json.loads(compact)
+        if isinstance(data, list):
+            return [float(x) for x in data]
+        if isinstance(data, dict) and "embedding" in data:
+            return [float(x) for x in data["embedding"]]
+    except (json.JSONDecodeError, ValueError):
+        pass
+
     # Try whitespace-separated floats (last line may be the embedding)
     for line in reversed(stdout.splitlines()):
         line = line.strip()
         if not line:
             continue
         try:
-            values = [float(x) for x in line.split()]
+            values = [float(x) for x in line.replace(",", " ").split()]
             if len(values) > 1:
                 return values
         except ValueError:
             continue
 
     raise ValueError(f"Could not parse embedding from output: {stdout[:500]}")
+
+
+def _wrap_rank0_stdout_capture(cmd: list[str]) -> list[str]:
+    script = (
+        'rank="${OMPI_COMM_WORLD_RANK:-${PMI_RANK:-${PMIX_RANK:-${RANK:-0}}}}"; '
+        'if [ "$rank" = "0" ] && [ -n "${TRTMC_EMBEDDING_STDOUT:-}" ]; then '
+        'exec "$@" > "$TRTMC_EMBEDDING_STDOUT"; '
+        'else exec "$@" >/dev/null; fi'
+    )
+    return ["bash", "-lc", script, "trtmc-embed-rank-wrapper"] + cmd
 
 
 plugin = EmbeddingRunner()

--- a/tests/e2e_harness/runners/reranking.py
+++ b/tests/e2e_harness/runners/reranking.py
@@ -16,6 +16,14 @@ from typing import Any
 
 from .. import save_full_stderr
 from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
+from .text_generation import (
+    _distributed_runtime_config,
+    _ensure_distributed_runtime_env,
+    _extract_rank_zero_stdout,
+    _maybe_start_gpu_memory_sampler,
+    _strip_mpi_stream_tags,
+    _wrap_distributed_command,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +55,10 @@ class RerankingRunner:
         env = dict(os.environ)
         if ctx.ld_library_path:
             env["LD_LIBRARY_PATH"] = ctx.ld_library_path
+        distributed_runtime = _distributed_runtime_config(case)
+        extra_env = distributed_runtime.get("env", {}) if distributed_runtime else {}
+        if distributed_runtime and isinstance(extra_env, dict):
+            env.update({str(k): str(v) for k, v in extra_env.items()})
 
         scores: list[float] = []
         commands: list[list[str]] = []
@@ -63,24 +75,46 @@ class RerankingRunner:
             ]
             if runtime_cli_python:
                 cmd.extend(["--hf-python", runtime_cli_python])
+            run_env = dict(env)
+            if distributed_runtime:
+                _ensure_distributed_runtime_env(
+                    case, ctx, run_env, rendezvous_suffix=f"-doc{index}")
+                cmd = _wrap_distributed_command(cmd, case, run_env)
 
             logger.info("Running reranking document %d: %s", index, " ".join(cmd))
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, env=env, timeout=600,
-            )
+            memory_sampler = _maybe_start_gpu_memory_sampler(
+                distributed_runtime, ctx, case, run_env)
+            try:
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, env=run_env, timeout=600,
+                )
+            finally:
+                memory_meta = (
+                    memory_sampler.stop() if memory_sampler is not None else None)
+            parse_stdout = (
+                _extract_rank_zero_stdout(result.stdout)
+                if distributed_runtime else result.stdout)
+            parse_stderr = (
+                _strip_mpi_stream_tags(result.stderr)
+                if distributed_runtime else result.stderr)
             commands.append(cmd)
-            stdout_by_document.append(result.stdout or "")
-            stderr_by_document.append(result.stderr or "")
-            command_metadata.append({
+            stdout_by_document.append(parse_stdout or "")
+            stderr_by_document.append(parse_stderr or "")
+            doc_meta: dict[str, Any] = {
                 "command": cmd,
                 "returncode": result.returncode,
                 "stdout": result.stdout or "",
-                "stderr": result.stderr or "",
-            })
+                "stderr": parse_stderr or "",
+            }
+            if distributed_runtime:
+                doc_meta["distributed_runtime"] = distributed_runtime
+            if memory_meta is not None:
+                doc_meta["gpu_memory"] = memory_meta
+            command_metadata.append(doc_meta)
 
             if result.returncode != 0:
                 truncated, log_path = save_full_stderr(
-                    result.stderr, ctx.artifacts_dir or "",
+                    parse_stderr, ctx.artifacts_dir or "",
                     f"reranking_doc_{index}", case.name)
                 msg = (
                     f"Reranking inference failed for document {index} "
@@ -90,7 +124,7 @@ class RerankingRunner:
                     msg += f" (full stderr: {log_path})"
                 raise RuntimeError(msg)
 
-            scores.append(_parse_score(result.stdout))
+            scores.append(_parse_score(parse_stdout))
 
         elapsed = time.monotonic() - t0
         metadata: dict[str, Any] = {
@@ -103,6 +137,8 @@ class RerankingRunner:
             metadata[f"document_{index}"] = doc_meta
         if len(commands) == 1:
             metadata.update(command_metadata[0])
+        if distributed_runtime:
+            metadata["distributed_runtime"] = distributed_runtime
 
         return StageOutput(
             stage_name=stage.name,

--- a/tests/e2e_harness/runners/text_generation.py
+++ b/tests/e2e_harness/runners/text_generation.py
@@ -150,8 +150,9 @@ def _wrap_distributed_command(
     export_env = config.get("export_env", ["LD_LIBRARY_PATH", "CUDA_VISIBLE_DEVICES"])
     if isinstance(export_env, list) and Path(launcher).name == "mpirun":
         export_names = [str(name) for name in export_env]
-        if "TRTMC_NCCL_RENDEZVOUS" in env and "TRTMC_NCCL_RENDEZVOUS" not in export_names:
-            export_names.append("TRTMC_NCCL_RENDEZVOUS")
+        for name in ("TRTMC_NCCL_RENDEZVOUS", "TRTMC_EMBEDDING_STDOUT"):
+            if name in env and name not in export_names:
+                export_names.append(name)
         for name in export_names:
             if name in env:
                 prefix.extend(["-x", name])

--- a/tests/tools/test_e2e_runner_cli_alignment.py
+++ b/tests/tools/test_e2e_runner_cli_alignment.py
@@ -13,6 +13,7 @@ import subprocess
 from tests.e2e_harness.contracts import E2ECase, RunContext, StageSpec
 from tests.e2e_harness.runners import (
     audio_speech,
+    embedding,
     neural_operator,
     object_detection,
     omni,
@@ -251,6 +252,12 @@ def test_omni_runner_vision_stage_maps_to_embed_without_stage_flag(monkeypatch, 
     assert "--stage" not in cmd
     assert out.metadata["entrypoint"] == "embed"
     assert out.data["embedding"] == [0.1, 0.2]
+
+
+def test_embedding_parser_accepts_fragmented_json_from_mpirun() -> None:
+    stdout = '{"embedding": [0.1, 0.2,\n 0.3], "dim": 3}\n'
+
+    assert embedding._parse_embedding(stdout) == [0.1, 0.2, 0.3]
 
 
 def test_text_generation_runner_maps_diffusion_mode_flags(monkeypatch, tmp_path):


### PR DESCRIPTION
## Background
Eagle VLM already supported single-device embedding and reranking builds, but the text backbone could not be emitted as rank-local tensor-parallel plans. This adds TP4 coverage for the Nemotron Eagle VLM embedding and reranking variants using the same thresholds and inputs as the single-device E2E cases.

## Exit Criteria
- Eagle VLM embedding and reranking builds produce rank-local `engine_plan_tp_rank*` sections for `tp_size=4`.
- Runtime embedding and reranking flows launch under `mpirun` and select the rank-local section for each process.
- Both new TP4 E2E manifests pass on B200 GPUs 0-3 with rebuilt engines.

## Implementation
- Route `eagle_vlm` builds through a new TP builder when `parallel_config` enables tensor parallelism.
- Add an Eagle VLM TP builder that mirrors the single-device text-backbone builder, shards standard decoder weights, and inserts all-reduce joins after row-parallel attention and MLP output projections.
- Teach the encoder runtime plugin to initialize the distributed runtime group and load `engine_plan_tp_rank{rank}` for TP encoder-style strategies.
- Extend embedding and reranking E2E runners to use the shared distributed launch helpers. Embedding rank 0 writes stdout to an artifact file so long JSON embedding vectors are not fragmented by OpenMPI tag output.
- Add focused builder/parser tests and TP4 manifests for `nvidia/llama-nemotron-embed-vl-1b-v2` and `nvidia/llama-nemotron-rerank-vl-1b-v2`.

## Validation
- `sudo docker run --rm --gpus '"device=0,1,2,3"' ... pytest tests/builder/test_engine_eagle_vlm_tp.py tests/tools/test_e2e_runner_cli_alignment.py::test_embedding_parser_accepts_fragmented_json_from_mpirun`: passed, 5 tests.
- `sudo docker run --rm --name trtmc-eagle-vlm-tp4-validation --gpus '"device=0,1,2,3"' ... /opt/venv/bin/python -m pytest tests/test_e2e.py::test_e2e[nemotron-embed-vl-1b-v2-tp4] tests/test_e2e.py::test_e2e[nemotron-rerank-vl-1b-v2-tp4] -v --multi-device-only --engine-dir /engines --trtmc-binary ./build/trtmc --hf-python /opt/venv/bin/python --e2e-artifacts-dir /artifacts --rebuild-engines`: passed, 2 tests in 359.97s.

## Notes For Future Readers
- Review the TP builder first, then the encoder runtime change, then the E2E runner changes. The embedding stdout capture is intentionally rank-0 only because OpenMPI can split long JSON embedding vectors into tagged chunks.