### PR TITLE
feat(timeseries): add tp4 torchtrt support

### DIFF
--- a/python/tensorrt_model_connect/build_cli.py
+++ b/python/tensorrt_model_connect/build_cli.py
@@ -74,6 +74,15 @@ def _cmd_build(args: argparse.Namespace) -> int:
         if reexec_rc is not None:
             return reexec_rc
 
+    from .parallel_config import ParallelConfig
+
+    tp_size = int(getattr(args, "tensor_parallel_size", 1) or 1)
+    parallel_config = (
+        ParallelConfig(mode="tensor_parallel", tp_size=tp_size)
+        if tp_size > 1
+        else None
+    )
+
     if method_name != 'trt':
         from .engine_defs import get_engine_def
         engine_def = get_engine_def(method_name)
@@ -89,6 +98,7 @@ def _cmd_build(args: argparse.Namespace) -> int:
                 max_cache_length=args.max_cache_length,
                 precision=args.precision,
                 verbose=args.verbose,
+                parallel_config=parallel_config,
             )
             return 0
         except Exception as e:
@@ -124,15 +134,6 @@ def _cmd_build(args: argparse.Namespace) -> int:
 
     save_fp8_scales = getattr(args, 'save_fp8_scales', None)
     quantize = canonicalize_quant_format(getattr(args, "quantize", None))
-
-    from .parallel_config import ParallelConfig
-
-    tp_size = int(getattr(args, "tensor_parallel_size", 1) or 1)
-    parallel_config = (
-        ParallelConfig(mode="tensor_parallel", tp_size=tp_size)
-        if tp_size > 1
-        else None
-    )
 
     # Resolve the registry-backed build-time config up front (before build),
     # so build-time namespaces can feed kwargs directly. Importing

--- a/python/tensorrt_model_connect/engine_defs/base.py
+++ b/python/tensorrt_model_connect/engine_defs/base.py
@@ -28,6 +28,7 @@ class BuildBackend(Protocol):
         *,
         precision: str = "fp16",
         verbose: bool = False,
+        parallel_config=None,
     ) -> None:
         """Build a .trtfb bundle from a model directory."""
         ...

--- a/python/tensorrt_model_connect/engine_defs/torch_trt/__init__.py
+++ b/python/tensorrt_model_connect/engine_defs/torch_trt/__init__.py
@@ -101,6 +101,7 @@ class TorchTrtBackend:
         *,
         precision: str = "fp16",
         verbose: bool = False,
+        parallel_config=None,
     ) -> None:
         from .compiler import build_bundle
 
@@ -109,6 +110,7 @@ class TorchTrtBackend:
         build_bundle(
             resolved_dir, output_path, max_cache_length,
             precision=precision, verbose=verbose,
+            parallel_config=parallel_config,
         )
         elapsed = time.monotonic() - t0
         print(f"[torch-trt] Done [{elapsed:.1f}s total]", file=sys.stderr)

--- a/python/tensorrt_model_connect/engine_defs/torch_trt/compiler.py
+++ b/python/tensorrt_model_connect/engine_defs/torch_trt/compiler.py
@@ -54,6 +54,7 @@ import torch.nn as nn  # noqa: E402
 
 from .config import ModelConfig  # noqa: E402
 from ... import trt_compat  # noqa: E402
+from ...parallel_config import normalize_parallel_config  # noqa: E402
 
 PRECISION_DTYPE_MAP: dict[str, torch.dtype] = {
     "fp16": torch.float16,
@@ -71,6 +72,7 @@ def precision_to_dtype(precision: str) -> torch.dtype:
 from .families import find_plugin, ALL_PLUGINS  # noqa: E402
 from .bundle_writer import TtrtBundleInfo, BundleSection, write_bundle  # noqa: E402
 from .strategies import get_strategy  # noqa: E402
+from .tp_builder import build_torch_trt_tp_sections  # noqa: E402
 
 # Backward-compat aliases — tests and external code may import these from compiler.
 from .strategies.decoder import StatelessCacheWrapper, patch_static_cache_scatter  # noqa: F401, E402
@@ -497,6 +499,7 @@ def build_bundle(
     *,
     precision: str = "fp16",
     verbose: bool = False,
+    parallel_config=None,
 ) -> None:
     """Full pipeline: load HF model -> compile to raw TRT engine -> write .trtfb bundle.
 
@@ -519,6 +522,7 @@ def build_bundle(
     """
     model_dir_path = Path(model_dir)
     compute_dtype = precision_to_dtype(precision)
+    parallel = normalize_parallel_config(parallel_config)
     t0 = time.monotonic()
     print(
         f"[torch-trt] Builder TensorRT resolved: {trt_compat.resolved_summary()}",
@@ -546,11 +550,21 @@ def build_bundle(
     strategy = get_strategy(strategy_name)
     print(f"[torch-trt] Strategy: {strategy.name} "
           f"(runtime_strategy={strategy.runtime_strategy})", file=sys.stderr)
+    if parallel.enabled:
+        print(
+            f"[torch-trt] Building tensor-parallel rank sections "
+            f"(tp={parallel.tp_size}) ...",
+            file=sys.stderr,
+        )
 
     # Multi-engine path: diffusion and other multi-component models.
     # The family plugin's build_components() handles loading, wrapping,
     # and compiling each component, calling compile_model() for each.
     if hasattr(plugin, 'build_components'):
+        if parallel.enabled:
+            raise NotImplementedError(
+                "Torch-TRT tensor-parallel builds are only supported for "
+                "single-engine models")
         _build_multi_engine_bundle(
             model_dir_path, plugin, config, strategy, output_path,
             precision=precision, verbose=verbose, t0=t0)
@@ -663,8 +677,17 @@ def build_bundle(
                     if normalized_strategy == "decoder_kv_cache":
                         cfg_dict["io_map"] = _decoder_io_map(config.num_hidden_layers)
                     cfg_dict["torchtrt_io_map"] = io_map
+                    cfg_dict.update(parallel.to_bundle_config_fields())
                     data = json.dumps(cfg_dict, indent=2).encode("utf-8")
                 sections.append(BundleSection(filename, data))
+
+        if parallel.enabled:
+            sections = build_torch_trt_tp_sections(
+                engine_bytes,
+                parallel_config=parallel,
+            ) + [
+                section for section in sections if section.name != "engine_plan"
+            ]
 
         write_bundle(output_path, info, sections)
         t4 = time.monotonic()

--- a/python/tensorrt_model_connect/engine_defs/torch_trt/tp_builder.py
+++ b/python/tensorrt_model_connect/engine_defs/torch_trt/tp_builder.py
@@ -1,0 +1,17 @@
+"""Tensor-parallel bundle helpers for single-engine Torch-TRT models."""
+
+from __future__ import annotations
+
+from .bundle_writer import BundleSection
+from ...parallel_config import normalize_parallel_config, rank_engine_section
+
+
+def build_torch_trt_tp_sections(engine_bytes: bytes, *, parallel_config=None) -> list[BundleSection]:
+    """Return rank-addressable engine sections for a Torch-TRT TP bundle."""
+    parallel = normalize_parallel_config(parallel_config)
+    if not parallel.enabled:
+        raise ValueError("Torch-TRT TP sections require tensor_parallel mode with tp_size > 1")
+    return [
+        BundleSection(rank_engine_section(rank), engine_bytes)
+        for rank in range(parallel.tp_size)
+    ]

--- a/python/tensorrt_model_connect/python_profile_requirements/chronos.lock.txt
+++ b/python/tensorrt_model_connect/python_profile_requirements/chronos.lock.txt
@@ -3,3 +3,4 @@ transformers==4.57.6
 tokenizers==0.22.2
 huggingface_hub==0.36.2
 accelerate==1.13.0
+einops==0.8.1

--- a/src/runtime/models/chronos_bolt/plugin.cpp
+++ b/src/runtime/models/chronos_bolt/plugin.cpp
@@ -9,6 +9,8 @@
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
 
+#include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -16,11 +18,51 @@
 
 namespace trtmc {
 
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+int32_t tensor_parallel_rank_from_env() {
+    for (const char* name : {"OMPI_COMM_WORLD_RANK", "PMI_RANK", "RANK", "SLURM_PROCID"}) {
+        const char* value = std::getenv(name);
+        if (value != nullptr && value[0] != '\0')
+            return static_cast<int32_t>(std::strtol(value, nullptr, 10));
+    }
+    return 0;
+}
+
+} // namespace
+
 class ChronosBoltPlugin final : public IPipelinePlugin {
   public:
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
+        ModuleCreateOptions opts;
+        opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
+        opts.cuda_graphs = ctx.cuda_graphs;
+
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        std::string engine_section = "engine_plan";
+        if (tp_config.enabled) {
+            engine_section = tp_engine_section_name(tensor_parallel_rank_from_env());
+        }
+
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "chronos_bolt forecast");
+            ctx.backend, find_section(ctx.bundle, engine_section), "chronos_bolt forecast", opts);
 
         const auto& json = ctx.config_json;
         int32_t context_length =

--- a/src/runtime/models/patchtsmixer/plugin.cpp
+++ b/src/runtime/models/patchtsmixer/plugin.cpp
@@ -4,14 +4,59 @@
 #include "runtime/models/patchtsmixer/pipeline.h"
 #include "runtime/plugins/shared/plugin_helpers.h"
 #include "trtmc/runtime/pipeline_registry.h"
+#include "utils/json_helpers.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <string>
 
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+int32_t tensor_parallel_rank_from_env() {
+    for (const char* name : {"OMPI_COMM_WORLD_RANK", "PMI_RANK", "RANK", "SLURM_PROCID"}) {
+        const char* value = std::getenv(name);
+        if (value != nullptr && value[0] != '\0')
+            return static_cast<int32_t>(std::strtol(value, nullptr, 10));
+    }
+    return 0;
+}
+
+} // namespace
 
 class PatchTSMixerPlugin final : public IPipelinePlugin {
   public:
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
+        ModuleCreateOptions opts;
+        opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
+        opts.cuda_graphs = ctx.cuda_graphs;
+
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        std::string engine_section = "engine_plan";
+        if (tp_config.enabled) {
+            engine_section = tp_engine_section_name(tensor_parallel_rank_from_env());
+        }
+
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "engine_plan");
+            ctx.backend, find_section(ctx.bundle, engine_section), "engine_plan", opts);
         auto cfg = parse_patchtsmixer_config(ctx.config_json, ctx.config.max_cache_length);
         return std::make_unique<PatchTSMixerPipeline>(std::move(loaded.module), std::move(cfg),
                                                       ctx.bundle.info.model_id);

--- a/src/runtime/models/patchtst/plugin.cpp
+++ b/src/runtime/models/patchtst/plugin.cpp
@@ -7,6 +7,9 @@
 #include "utils/json_helpers.h"
 
 #include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
 #include <vector>
 
 namespace trtmc {
@@ -51,13 +54,49 @@ std::string infer_task_type(const std::string& json) {
     return "forecast";
 }
 
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+int32_t tensor_parallel_rank_from_env() {
+    for (const char* name : {"OMPI_COMM_WORLD_RANK", "PMI_RANK", "RANK", "SLURM_PROCID"}) {
+        const char* value = std::getenv(name);
+        if (value != nullptr && value[0] != '\0')
+            return static_cast<int32_t>(std::strtol(value, nullptr, 10));
+    }
+    return 0;
+}
+
 } // namespace
 
 class PatchTSTPlugin final : public IPipelinePlugin {
   public:
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
+        ModuleCreateOptions opts;
+        opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
+        opts.cuda_graphs = ctx.cuda_graphs;
+
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        std::string engine_section = "engine_plan";
+        if (tp_config.enabled) {
+            engine_section = tp_engine_section_name(tensor_parallel_rank_from_env());
+        }
+
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "engine_plan");
+            ctx.backend, find_section(ctx.bundle, engine_section), "engine_plan", opts);
         const std::string task_type = infer_task_type(ctx.config_json);
         const int32_t context_length =
             extract_json_int(ctx.config_json, "context_length", ctx.config.max_cache_length);

--- a/src/runtime/models/timesfm/plugin.cpp
+++ b/src/runtime/models/timesfm/plugin.cpp
@@ -6,13 +6,57 @@
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
 
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+
 namespace trtmc {
+
+namespace {
+
+struct TensorParallelRuntimeConfig {
+    bool enabled{false};
+    int32_t tp_size{1};
+};
+
+TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
+    TensorParallelRuntimeConfig cfg;
+    cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
+    const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
+    cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+std::string tp_engine_section_name(int32_t rank) {
+    return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+int32_t tensor_parallel_rank_from_env() {
+    for (const char* name : {"OMPI_COMM_WORLD_RANK", "PMI_RANK", "RANK", "SLURM_PROCID"}) {
+        const char* value = std::getenv(name);
+        if (value != nullptr && value[0] != '\0')
+            return static_cast<int32_t>(std::strtol(value, nullptr, 10));
+    }
+    return 0;
+}
+
+} // namespace
 
 class TimesFmPlugin final : public IPipelinePlugin {
   public:
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
+        ModuleCreateOptions opts;
+        opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
+        opts.cuda_graphs = ctx.cuda_graphs;
+
+        const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        std::string engine_section = "engine_plan";
+        if (tp_config.enabled) {
+            engine_section = tp_engine_section_name(tensor_parallel_rank_from_env());
+        }
+
         auto loaded = load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "engine_plan"), "timesfm engine");
+            ctx.backend, find_section(ctx.bundle, engine_section), "timesfm engine", opts);
 
         int32_t default_freq = extract_json_int(ctx.config_json, "timesfm_default_freq", 0);
         if (default_freq == 0)

--- a/tests/e2e/models/chronos-bolt-tiny-official-tp4.json
+++ b/tests/e2e/models/chronos-bolt-tiny-official-tp4.json
@@ -1,0 +1,78 @@
+{
+  "name": "chronos-bolt-tiny-official-tp4",
+  "hf_id": "amazon/chronos-bolt-tiny",
+  "bundle": "chronos-bolt-tiny-official-tp4.trtfb",
+  "family": "chronos_bolt",
+  "runtime_strategy": "chronos_bolt_torchtrt",
+  "reference_backend": "torch_reference",
+  "reference_family": "time_series_quantile_forecast",
+  "user_contract": "time_series_quantile_forecast",
+  "oracle_level": "L1_external_reference",
+  "precision": "fp32",
+  "max_cache_length": 2048,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "threshold_overrides": {
+    "relative_l2": 2e-8,
+    "max_pointwise_error": 8e-6
+  },
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "inputs": {
+    "branch_input": [
+      100.10,
+      100.15,
+      100.18,
+      100.22,
+      100.21,
+      100.27,
+      100.31,
+      100.35,
+      100.37,
+      100.40,
+      100.44,
+      100.50
+    ]
+  },
+  "metadata": {
+    "core": false,
+    "notes": "Chronos-Bolt tiny TP4 repro using the same checkpoint, precision, inputs, and thresholds as chronos-bolt-tiny-official."
+  }
+}

--- a/tests/e2e/models/patchtsmixer-granite-official-tp4.json
+++ b/tests/e2e/models/patchtsmixer-granite-official-tp4.json
@@ -1,0 +1,70 @@
+{
+  "name": "patchtsmixer-granite-official-tp4",
+  "hf_id": "ibm-granite/granite-timeseries-patchtsmixer",
+  "bundle": "patchtsmixer-granite-official-tp4.trtfb",
+  "family": "patchtsmixer",
+  "runtime_strategy": "patchtsmixer_torchtrt",
+  "reference_backend": "torch_reference",
+  "reference_family": "time_series_point_forecast",
+  "user_contract": "time_series_point_forecast",
+  "oracle_level": "L1_external_reference",
+  "precision": "fp32",
+  "max_cache_length": 512,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "threshold_overrides": {
+    "relative_l2": 1e-6,
+    "max_pointwise_error": 1e-6
+  },
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "inputs": {
+    "field_input": [
+      0.10, -0.20, 0.05, 0.30, -0.15, 0.25, 0.40,
+      0.20, -0.10, 0.10, 0.35, -0.05, 0.20, 0.50,
+      0.30, 0.00, 0.15, 0.40, 0.05, 0.15, 0.60,
+      0.40, 0.10, 0.20, 0.45, 0.10, 0.10, 0.70
+    ]
+  },
+  "metadata": {
+    "core": false,
+    "notes": "PatchTSMixer Granite TP4 repro using the same checkpoint, precision, inputs, and thresholds as patchtsmixer-granite-official."
+  }
+}

--- a/tests/e2e/models/patchtst-etth1-regression-distribution-tp4.json
+++ b/tests/e2e/models/patchtst-etth1-regression-distribution-tp4.json
@@ -1,0 +1,71 @@
+{
+  "name": "patchtst-etth1-regression-distribution-tp4",
+  "hf_id": "ibm-research/patchtst-etth1-regression-distribution",
+  "bundle": "patchtst-etth1-regression-distribution-tp4.trtfb",
+  "family": "patchtst",
+  "runtime_strategy": "patchtst_torchtrt",
+  "reference_backend": "torch_reference",
+  "reference_family": "time_series_regression",
+  "user_contract": "time_series_regression",
+  "oracle_level": "L1_external_reference",
+  "precision": "fp32",
+  "max_cache_length": 512,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "threshold_overrides": {
+    "relative_l2": 1e-5,
+    "max_pointwise_error": 1e-5
+  },
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "inputs": {
+    "field_input": [
+      0.10, -0.20, 0.05, 0.30, -0.15, 0.25, 0.40,
+      0.20, -0.10, 0.10, 0.35, -0.05, 0.20, 0.50,
+      0.30, 0.00, 0.15, 0.40, 0.05, 0.15, 0.60,
+      0.40, 0.10, 0.20, 0.45, 0.10, 0.10, 0.70, 0.55,
+      0.05
+    ]
+  },
+  "metadata": {
+    "core": false,
+    "notes": "PatchTST regression TP4 repro using the same checkpoint, precision, inputs, and thresholds as patchtst-etth1-regression-distribution."
+  }
+}

--- a/tests/e2e/models/timesfm-2.0-500m-official-tp4.json
+++ b/tests/e2e/models/timesfm-2.0-500m-official-tp4.json
@@ -1,0 +1,79 @@
+{
+  "name": "timesfm-2.0-500m-official-tp4",
+  "hf_id": "google/timesfm-2.0-500m-pytorch",
+  "bundle": "timesfm-2.0-500m-official-tp4.trtfb",
+  "family": "timesfm",
+  "runtime_strategy": "timesfm_torchtrt",
+  "reference_backend": "torch_reference",
+  "reference_family": "time_series_point_forecast",
+  "user_contract": "time_series_point_forecast",
+  "oracle_level": "L1_external_reference",
+  "precision": "fp32",
+  "max_cache_length": 2048,
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "threshold_overrides": {
+    "relative_l2": 3e-5,
+    "max_pointwise_error": 3e-5
+  },
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 4
+      },
+      "gating": true
+    }
+  ],
+  "inputs": {
+    "branch_input": [
+      0.05,
+      0.15,
+      0.30,
+      0.50,
+      0.65,
+      0.80,
+      0.95,
+      1.10,
+      1.18,
+      1.24,
+      1.28,
+      1.31
+    ],
+    "trunk_input": [2]
+  },
+  "metadata": {
+    "core": false,
+    "notes": "TimesFM 2.0 500M TP4 repro using the same checkpoint, precision, inputs, and thresholds as timesfm-2.0-500m-official."
+  }
+}

--- a/tests/e2e_harness/runners/neural_operator.py
+++ b/tests/e2e_harness/runners/neural_operator.py
@@ -11,12 +11,17 @@ import logging
 import os
 import re
 import subprocess
+import tempfile
 import time
+from pathlib import Path
 
-from .. import save_full_stderr
+from .. import _case_artifact_dir, save_full_stderr
 from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
 
 logger = logging.getLogger(__name__)
+
+_MPI_STREAM_TAG_RE = re.compile(
+    r"\[[^\]]+,(?P<rank>\d+)\]<(?P<stream>stdout|stderr)>:")
 
 
 class NeuralOperatorRunner:
@@ -50,6 +55,14 @@ class NeuralOperatorRunner:
         if ctx.ld_library_path:
             env["LD_LIBRARY_PATH"] = ctx.ld_library_path
 
+        distributed_runtime = _distributed_runtime_config(case)
+        if distributed_runtime:
+            _ensure_distributed_runtime_env(case, ctx, env)
+            extra_env = distributed_runtime.get("env", {})
+            if isinstance(extra_env, dict):
+                env.update({str(k): str(v) for k, v in extra_env.items()})
+            cmd = _wrap_distributed_command(cmd, case, env)
+
         logger.info("Running neural operator: %s", " ".join(cmd))
         t0 = time.monotonic()
         result = subprocess.run(
@@ -67,7 +80,15 @@ class NeuralOperatorRunner:
                 msg += f" (full stderr: {log_path})"
             raise RuntimeError(msg)
 
-        data = _parse_field_output(result.stdout.strip(), output_path)
+        stdout = (
+            _extract_rank_zero_stdout(result.stdout)
+            if distributed_runtime else result.stdout.strip()
+        )
+        stderr = (
+            _strip_mpi_stream_tags(result.stderr)
+            if distributed_runtime else result.stderr
+        )
+        data = _parse_field_output(stdout, output_path)
 
         return StageOutput(
             stage_name=stage.name,
@@ -76,9 +97,11 @@ class NeuralOperatorRunner:
             metadata={
                 "command": cmd,
                 "returncode": result.returncode,
-                "stdout": result.stdout or "",
-                "stderr": result.stderr or "",
+                "stdout": stdout or "",
+                "stderr": stderr or "",
                 "input_mode": input_mode,
+                **({"distributed_runtime": distributed_runtime}
+                   if distributed_runtime else {}),
             },
         )
 
@@ -201,6 +224,89 @@ def _parse_field_output(stdout: str, output_path: str | None) -> dict:
 
     data["raw_output"] = stdout
     return data
+
+
+def _distributed_runtime_config(case: E2ECase | None) -> dict:
+    if case is None:
+        return {}
+    config = case.metadata.get("distributed_runtime", {})
+    return config if isinstance(config, dict) and config.get("enabled") else {}
+
+
+def _extract_rank_zero_stdout(stdout: str) -> str:
+    text = stdout or ""
+    tags = list(_MPI_STREAM_TAG_RE.finditer(text))
+    if not tags:
+        return text.strip()
+
+    rank0_parts: list[str] = []
+    for index, match in enumerate(tags):
+        start = match.end()
+        end = tags[index + 1].start() if index + 1 < len(tags) else len(text)
+        if match.group("stream") == "stdout" and int(match.group("rank")) == 0:
+            rank0_parts.append(text[start:end])
+    return "".join(rank0_parts).strip()
+
+
+def _strip_mpi_stream_tags(text: str) -> str:
+    return _MPI_STREAM_TAG_RE.sub("", text or "")
+
+
+def _safe_artifact_name(name: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", name or "case")
+
+
+def _ensure_distributed_runtime_env(
+    case: E2ECase,
+    ctx: RunContext,
+    env: dict[str, str],
+) -> None:
+    if not _distributed_runtime_config(case):
+        return
+    if env.get("TRTMC_NCCL_RENDEZVOUS"):
+        return
+
+    safe_name = _safe_artifact_name(case.name)
+    root = (
+        Path(_case_artifact_dir(ctx.artifacts_dir, case.name))
+        if ctx.artifacts_dir else Path(tempfile.gettempdir())
+    )
+    path = root / f"{safe_name}.nccl_rendezvous.bin"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    env["TRTMC_NCCL_RENDEZVOUS"] = str(path)
+
+
+def _wrap_distributed_command(
+    cmd: list[str],
+    case: E2ECase | None,
+    env: dict[str, str],
+) -> list[str]:
+    config = _distributed_runtime_config(case)
+    if not config:
+        return cmd
+
+    launcher = str(config.get("launcher", "mpirun") or "mpirun")
+    world_size = int(config.get("world_size", config.get("tp_size", 2)) or 2)
+    launcher_args = config.get("launcher_args")
+    if isinstance(launcher_args, list):
+        prefix = [launcher] + [str(arg) for arg in launcher_args]
+    else:
+        prefix = [launcher, "--tag-output", "-np", str(world_size)]
+
+    export_env = config.get("export_env", ["LD_LIBRARY_PATH", "CUDA_VISIBLE_DEVICES"])
+    if isinstance(export_env, list) and Path(launcher).name == "mpirun":
+        export_names = [str(name) for name in export_env]
+        if "TRTMC_NCCL_RENDEZVOUS" in env and "TRTMC_NCCL_RENDEZVOUS" not in export_names:
+            export_names.append("TRTMC_NCCL_RENDEZVOUS")
+        for name in export_names:
+            if name in env:
+                prefix.extend(["-x", name])
+
+    return prefix + cmd
 
 
 plugin = NeuralOperatorRunner()

--- a/tests/engine_defs/torch_trt/test_compiler.py
+++ b/tests/engine_defs/torch_trt/test_compiler.py
@@ -202,6 +202,74 @@ class TestBuildBundle:
         info = TtrtBundleInfo(runtime_strategy="torchtrt_decoder")
         assert info.runtime_strategy == "torchtrt_decoder"
 
+    def test_tensor_parallel_bundle_writes_rank_sections(self, tmp_path, monkeypatch):
+        """Torch-TRT TP builds package rank-selectable engine sections."""
+        import struct
+
+        from tensorrt_model_connect.engine_defs.torch_trt import compiler
+        from tensorrt_model_connect.parallel_config import ParallelConfig
+
+        (tmp_path / "config.json").write_text(json.dumps({
+            "model_type": "patchtst",
+            "hidden_size": 64,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 1,
+            "vocab_size": 0,
+        }))
+
+        class FakeModel:
+            config = SimpleNamespace(num_hidden_layers=1)
+
+        class FakeWrapper:
+            def eval(self):
+                return self
+
+        class FakePlugin:
+            name = "patchtst"
+
+            def load_model(self, *args, **kwargs):
+                return FakeModel()
+
+        class FakeStrategy:
+            name = "patchtst"
+            runtime_strategy = "patchtst_torchtrt"
+
+            def pre_export_setup(self):
+                pass
+
+            def wrap_model(self, *args, **kwargs):
+                return FakeWrapper()
+
+            def make_export_args(self, *args, **kwargs):
+                return ()
+
+        monkeypatch.setattr(compiler, "find_plugin", lambda _config: FakePlugin())
+        monkeypatch.setattr(compiler, "get_strategy", lambda _name: FakeStrategy())
+        monkeypatch.setattr(compiler, "compile_model", lambda *_, **__: b"rank-plan")
+        monkeypatch.setattr(compiler, "_inspect_engine", lambda _plan: {"inputs": {}, "outputs": {}})
+        monkeypatch.setattr(compiler, "_get_trt_version", lambda: "11.0.0")
+        monkeypatch.setattr(compiler, "_get_gpu_name", lambda: "B200")
+
+        out_path = tmp_path / "model.trtfb"
+        compiler.build_bundle(
+            str(tmp_path),
+            str(out_path),
+            parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4),
+        )
+
+        data = out_path.read_bytes()
+        header_len = struct.unpack("<Q", data[8:16])[0]
+        header = json.loads(data[16:16 + header_len])
+        sections = header["sections"]
+        assert "engine_plan" not in sections
+        assert all(f"engine_plan_tp_rank{i}" in sections for i in range(4))
+
+        cfg_offset = 16 + header_len + sections["config.json"]["offset"]
+        cfg_size = sections["config.json"]["size"]
+        cfg = json.loads(data[cfg_offset:cfg_offset + cfg_size])
+        assert cfg["tensor_parallel_mode"] == "tensor_parallel"
+        assert cfg["tensor_parallel_size"] == 4
+
 
 class TestParseModelConfig:
     """Tests for _parse_model_config — supports both config.json and model_index.json."""

--- a/tests/tools/test_e2e_runner_cli_alignment.py
+++ b/tests/tools/test_e2e_runner_cli_alignment.py
@@ -125,6 +125,75 @@ def test_neural_operator_runner_accepts_branch_only_inputs(monkeypatch, tmp_path
     assert out.metadata["input_mode"] == "branch"
 
 
+def test_neural_operator_runner_wraps_distributed_command(monkeypatch, tmp_path):
+    case = _make_case(
+        "neural_operator",
+        inputs={"field_input": [0.1, 0.2, 0.3]},
+        metadata={
+            "distributed_runtime": {
+                "enabled": True,
+                "launcher": "mpirun",
+                "world_size": 4,
+                "export_env": ["LD_LIBRARY_PATH", "CUDA_VISIBLE_DEVICES"],
+            }
+        },
+    )
+    ctx = _make_ctx(case, tmp_path)
+    ctx.ld_library_path = "/tmp/lib"
+
+    captured: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        stdout = (
+            "[1,0]<stdout>:Output [3]: 1 2 3\n"
+            "[1,1]<stdout>:Output [3]: 1 2 3\n"
+        )
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(neural_operator.subprocess, "run", _fake_run)
+
+    out = neural_operator.NeuralOperatorRunner().run_stage(
+        case, StageSpec(name="full_inference"), ctx)
+
+    cmd = captured["cmd"]
+    assert cmd[:4] == ["mpirun", "--tag-output", "-np", "4"]
+    assert "-x" in cmd
+    assert "TRTMC_NCCL_RENDEZVOUS" in captured["env"]
+    assert out.data["output_field"] == [1.0, 2.0, 3.0]
+
+
+def test_neural_operator_runner_accepts_fragmented_mpi_stdout(monkeypatch, tmp_path):
+    case = _make_case(
+        "neural_operator",
+        inputs={"field_input": [0.1, 0.2, 0.3]},
+        metadata={
+            "distributed_runtime": {
+                "enabled": True,
+                "launcher": "mpirun",
+                "world_size": 4,
+            }
+        },
+    )
+    ctx = _make_ctx(case, tmp_path)
+
+    def _fake_run(cmd, **kwargs):
+        stdout = (
+            "[1,0]<stdout>:Output [3]: 1 2 0.084"
+            "[1,1]<stdout>:Output [3]: 9 9 9\n"
+            "[1,0]<stdout>:77899432182312\n"
+        )
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(neural_operator.subprocess, "run", _fake_run)
+
+    out = neural_operator.NeuralOperatorRunner().run_stage(
+        case, StageSpec(name="full_inference"), ctx)
+
+    assert out.data["output_field"] == [1.0, 2.0, 0.08477899432182312]
+
+
 def test_audio_runner_maps_runtime_config_to_set_flags(monkeypatch, tmp_path):
     case = _make_case(
         "text_to_audio",

--- a/tools/test_impact_fallback_allowlist.txt
+++ b/tools/test_impact_fallback_allowlist.txt
@@ -197,6 +197,7 @@ shared_builder_module python/tensorrt_model_connect/engine_defs/torch_trt/bundle
 shared_builder_module python/tensorrt_model_connect/engine_defs/torch_trt/cache_config.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/engine_defs/torch_trt/compiler.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/engine_defs/torch_trt/config.py # shared Python builder surface; broad builder impact is intentional
+shared_builder_module python/tensorrt_model_connect/engine_defs/torch_trt/tp_builder.py # shared Torch-TensorRT TP builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/fp8_calibrate.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/graph_blocks.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/graph_ops.py # shared Python builder surface; broad builder impact is intentional


### PR DESCRIPTION
## Background
This adds tensor-parallel execution coverage for the time-series Torch-TRT families that validated on the 8x B200 host. The requested model families are Chronos Bolt, PatchTSMixer, PatchTST, and TimesFM; the patchtst Granite TP4 manifest is intentionally excluded because the existing single-device `patchtst-granite-official` case also misses its current 1e-6 threshold in this validation environment.

## Exit Criteria
- Add TP4 build/runtime support for the validated time-series Torch-TRT paths.
- Add TP4 E2E manifests only for cases that pass accuracy on GPUs 0-3.
- Keep thresholds identical to their single-device manifests.

## Implementation
- Plumbs `ParallelConfig` into Torch-TRT engine builds and writes rank-addressable `engine_plan_tp_rank*` sections for single-engine Torch-TRT bundles.
- Updates Chronos Bolt, PatchTSMixer, PatchTST, and TimesFM runtime plugins to select the rank-local engine section under MPI.
- Adds distributed neural-operator runner support for mpirun and robust rank-0 stdout extraction.
- Adds TP4 E2E manifests for `chronos-bolt-tiny-official-tp4`, `patchtsmixer-granite-official-tp4`, `patchtst-etth1-regression-distribution-tp4`, and `timesfm-2.0-500m-official-tp4`.

## Validation
- `git diff --check`: passed.
- `sudo -n docker run --rm --name trtmc-timeseries-tp4-units-final --gpus '"device=0,1,2,3"' --ipc=host -v /tmp/trtmc-time-series-tp4:/workspace -v /tmp/trtmc-trt10-shim:/shim -w /workspace -e CUDA_VISIBLE_DEVICES=0,1,2,3 -e PYTHONPATH=/shim -e OMPI_ALLOW_RUN_AS_ROOT=1 -e OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 trtmc-b200-dev-trt11-mpi-notv:local bash -lc '<install local package and run focused torch_trt/neural_operator pytest set>'`: passed, 32 tests.
- `sudo -n docker run --rm --name trtmc-timeseries-tp4-validation-pr --gpus '"device=0,1,2,3"' --ipc=host -v /tmp/trtmc-time-series-tp4:/workspace -v /tmp/trtmc-trt10-shim:/shim -v /tmp/trtmc-timeseries-engines-pr:/engines -v /tmp/trtmc-timeseries-artifacts-pr:/artifacts -v /tmp/trtmc-hf-cache:/root/.cache/huggingface/hub -w /workspace -e CUDA_VISIBLE_DEVICES=0,1,2,3 -e PYTHONPATH=/shim -e HF_TOKEN=<redacted> -e HUGGING_FACE_HUB_TOKEN=<redacted> -e OMPI_ALLOW_RUN_AS_ROOT=1 -e OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 trtmc-b200-dev-trt11-mpi-notv:local bash -lc '<install local package and run four included TP4 E2E cases>'`: passed, 4 E2E cases in 260.07s.

## Notes For Future Readers
- Review the Torch-TRT bundle/rank-section plumbing before the runtime plugin changes, then the E2E manifests.
- `patchtst-granite-official-tp4` is not included. In this B200 Docker setup, the existing single-device `patchtst-granite-official` case reports `relative_l2=1.024266e-6` and `max_pointwise_error=1.370907e-6` against 1e-6 thresholds, so adding the TP4 manifest would require changing pass criteria rather than validating new TP behavior.