### PR TITLE
feat(cosmos): scaffold Cosmos-Reason1-7B + Cosmos-Reason2-2B dense lanes (XFAIL)

### DIFF
--- a/tests/e2e/models/cosmos-reason1-7b.json
+++ b/tests/e2e/models/cosmos-reason1-7b.json
@@ -1,0 +1,15 @@
+{
+  "name": "cosmos-reason1-7b",
+  "trace_id": "IT-E2E-COSMOSR1-7B-01",
+  "hf_id": "nvidia/Cosmos-Reason1-7B",
+  "bundle": "cosmos-reason1-7b.trtfb",
+  "family": "qwen_vl",
+  "runtime_strategy": "vision_language",
+  "max_cache_length": 384,
+  "prompt": "What color is the vehicle in this image? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "test_image": "tests/e2e/data/test_img.jpeg",
+  "trust_remote_code": false
+}

--- a/tests/e2e/models/cosmos-reason2-2b.json
+++ b/tests/e2e/models/cosmos-reason2-2b.json
@@ -1,0 +1,15 @@
+{
+  "name": "cosmos-reason2-2b",
+  "trace_id": "IT-E2E-COSMOSR2-2B-01",
+  "hf_id": "nvidia/Cosmos-Reason2-2B",
+  "bundle": "cosmos-reason2-2b.trtfb",
+  "family": "qwen_vl",
+  "runtime_strategy": "vision_language",
+  "max_cache_length": 256,
+  "prompt": "What color is the vehicle in this image? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "test_image": "tests/e2e/data/test_img.jpeg",
+  "trust_remote_code": false
+}

--- a/tests/e2e/waives.txt
+++ b/tests/e2e/waives.txt
@@ -8,3 +8,5 @@ internlm2-1.8b           SKIP   (DynamicCache.from_legacy_cache removed in trans
 phi4-multimodal           SKIP   (phi4-multimodal remote code incompatible with transformers 5.x)
 eagle-embed-vl-1b-v2     SKIP   (HF repo 404)
 eagle-rerank-vl-1b-v2    SKIP   (HF repo 404)
+cosmos-reason1-7b         XFAIL  (qwen2_5_vl-based but bundle build fails on Cosmos-specific weight layout differences from vanilla Qwen2.5-VL; needs qwen_vl plugin extension)
+cosmos-reason2-2b         XFAIL  (qwen3_vl-based; HF reference fails with "Image features and image tokens do not match" — prompt format needs image placeholder tokens not yet handled by the harness)


### PR DESCRIPTION
## Summary

Scaffolds dense single-device E2E lanes for the two Cosmos-Reason models the user requested. Both are currently XFAIL with diagnostic reasons committed in `waives.txt`:

- **cosmos-reason1-7b** (`nvidia/Cosmos-Reason1-7B`, `qwen2_5_vl`): bundle `build_fail`. Cosmos-specific weight-layout differences from the vanilla Qwen2.5-VL base; the `qwen_vl` plugin's `load_weights` doesn't yet handle them.
- **cosmos-reason2-2b** (`nvidia/Cosmos-Reason2-2B`, `qwen3_vl`): HF reference fails with `Image features and image tokens do not match, tokens: 0, features: 240` — the harness's VL prompt path doesn't currently emit the `<|image_pad|>` placeholders that `qwen3_vl` expects.

Both lanes need targeted VL-family debugging that is separate from the TP work, so they ship as scaffolds + waives — the lanes auto-unwaive once the underlying issues are fixed.

TP variants are not in this PR — they depend on **qwen_vl family TP** being enabled (similar pattern to phi4_multimodal TP in PR #103). That's a separate piece of work; the VL+TP C++ runtime from PR #103 is reusable, but the qwen_vl plugin needs its own sibling TP builder.

## Verified on

- Host: 2× NVIDIA A30 24 GB (`ipp1-1940`)
- Stack: TRT 11.0.0.107 + NCCL 2.30.4

Both lanes ran via the standard harness; failures are reproducible and documented above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)