### PR TITLE
docs(skills): forbid merging before CI passes

### DIFF
--- a/plugins/trtmc-agent-skills/skills/pr-babysitter/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/pr-babysitter/SKILL.md
@@ -26,6 +26,9 @@ branch, and push updated commits. Work sequentially and report every PR state.
   `gh pr merge --auto` or any equivalent API flag.
 - When merge authority is granted, merge only after the latest CI for the
   current PR head has completed successfully and the PR is mergeable.
+- Treat GitHub branch protection and rulesets as insufficient evidence of CI
+  safety. The repository may allow a squash or rebase merge while checks are
+  still queued, pending, running, or absent; that is still forbidden here.
 - If a fix needs unavailable hardware, product judgment, or broad scope, stop
   and report the blocker.
 
@@ -90,8 +93,11 @@ gh pr checks <number> --repo NVIDIA/TensorRT-Model-Connect
 ## Merge After CI
 
 Only merge when the user has explicitly authorized merging. Never treat
-auto-merge as a way to wait for CI. GitHub auto-merge has previously accepted a
-merge request while a check was still queued, so it is forbidden for this skill.
+auto-merge as a way to wait for CI. A `gh pr merge --auto` invocation has
+previously merged immediately while a check was still queued because the
+repository ruleset did not require status checks. Auto-merge is forbidden for
+this skill. This is an agent-side hard gate: if GitHub would allow the merge
+before CI is green, do not merge anyway.
 
 Before merging, verify all of the following against the latest PR head:
 
@@ -101,11 +107,21 @@ Before merging, verify all of the following against the latest PR head:
   shows the same head SHA whose checks passed.
 - `mergeable` is `MERGEABLE` and `mergeStateStatus` is clean enough for the
   repository ruleset, such as `CLEAN`.
-- No required check is pending, queued, running, skipped unexpectedly, or
-  failing.
+- Every expected CI check in `statusCheckRollup` has completed with conclusion
+  `SUCCESS`. Treat `QUEUED`, `PENDING`, `IN_PROGRESS`, `WAITING`,
+  `REQUESTED`, empty conclusion, missing check rollup, skipped unexpectedly,
+  or failing as a merge blocker.
+- The same completed successful check set belongs to the current `headRefOid`.
+  If a new commit lands after checks pass, restart the wait.
 
-If any check is pending or queued, wait and poll. If any check fails, diagnose
-and fix it. Do not merge.
+If `gh pr checks` exits nonzero, including exit code 8 for pending checks, do
+not merge. If any check is pending or queued, wait and poll. If any check fails,
+diagnose and fix it. If no CI checks are reported for the head SHA, report a
+human blocker instead of merging.
+
+Do not infer safety from `mergeable=MERGEABLE`, an allowed merge button, a
+ruleset that lacks required status checks, or successful local tests. Those are
+not substitutes for completed successful GitHub CI.
 
 Use an explicit merge command only after those checks pass. Do not include
 `--auto`:

--- a/plugins/trtmc-agent-skills/skills/submit-github-pr/SKILL.md
+++ b/plugins/trtmc-agent-skills/skills/submit-github-pr/SKILL.md
@@ -17,6 +17,8 @@ description: >-
 - Use `gh` for GitHub PR operations.
 - Use `$write-git-messages` to draft the PR title/body and any commit or squash
   message.
+- This skill opens PRs only. Do not merge from this skill. If the user asks to
+  babysit or merge the PR, switch to `$pr-babysitter` and follow its CI gate.
 
 ## Quick Flow
 
@@ -135,6 +137,7 @@ gh pr view --repo NVIDIA/TensorRT-Model-Connect --web
 gh pr checks --repo NVIDIA/TensorRT-Model-Connect <pr-number>
 ```
 
-Wait for GitHub CI before merging. Merge only when asked or when the task
-explicitly includes merge authority; follow repository rules for squash or
-rebase merge.
+Do not merge from this skill, even if the task includes merge authority. Use
+`$pr-babysitter` for monitoring and merging. It has the required hard CI gate
+and explicitly forbids `gh pr merge --auto` and any merge while checks are
+queued, pending, running, missing, skipped unexpectedly, or failing.


### PR DESCRIPTION
## Background
PR #170 was squash-merged while its Premerge CI job was still queued. Investigation showed GitHub allowed that because the active `main` branch rulesets require PR-based squash/rebase merges but do not require status checks. The branch protection endpoint returns 404 for classic protection, and the repository rulesets for `main` do not include a required status check rule.

## Exit Criteria
- PR workflow skills explicitly forbid merging while GitHub CI is queued, pending, running, missing, skipped unexpectedly, or failing.
- Skills do not rely on GitHub mergeability, branch rulesets, local validation, or an allowed merge button as substitutes for completed successful CI.
- PR creation guidance delegates all merge/babysit behavior to the PR babysitter skill.

## Implementation
- Updated `pr-babysitter` to make completed successful GitHub CI an agent-side hard gate before any merge command.
- Documented the exact failure mode: `gh pr merge --auto` can merge immediately when branch rules do not require status checks, so auto-merge remains forbidden.
- Updated `submit-github-pr` to be creation-only and require `$pr-babysitter` for monitoring or merging.

## Validation
- `git diff --check`: passed.

## Notes For Future Readers
- This does not change GitHub repository rules. It makes the agent workflow stricter than GitHub when GitHub would permit a merge before CI passes.
