### PR TITLE
feat(audio): add scoped VoxCPM2 detection support

### DIFF
--- a/cmake/trtmc_config_schemas.cmake
+++ b/cmake/trtmc_config_schemas.cmake
@@ -14,6 +14,7 @@ set(TRTMC_CONFIG_SCHEMAS
   "runtime.cpp|register_runtime_schema"
   "audio_bark.cpp|register_audio_bark_schema"
   "audio_magpie.cpp|register_audio_magpie_schema"
+  "audio_voxcpm2.cpp|register_audio_voxcpm2_schema"
   "platform.cpp|register_platform_schema"
 )
 

--- a/include/trtmc/config/schemas/audio_voxcpm2.h
+++ b/include/trtmc/config/schemas/audio_voxcpm2.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "trtmc/config/schema_registry.h"
+
+namespace trtmc::config::schemas {
+
+Schema make_audio_voxcpm2_schema();
+
+} // namespace trtmc::config::schemas

--- a/python/tensorrt_model_connect/families/voxcpm2/__init__.py
+++ b/python/tensorrt_model_connect/families/voxcpm2/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .plugin import VoxCPM2Plugin, plugin
+
+__all__ = ["VoxCPM2Plugin", "plugin"]

--- a/python/tensorrt_model_connect/families/voxcpm2/plugin.py
+++ b/python/tensorrt_model_connect/families/voxcpm2/plugin.py
@@ -1,0 +1,95 @@
+"""VoxCPM2 family detection and metadata.
+
+VoxCPM2 is not a Bark or Magpie variant. The upstream checkpoint combines a
+MiniCPM-style language model, residual autoregressive modeling, LocDiT
+diffusion, and AudioVAE. This plugin intentionally stops before weight loading
+so users get an explicit unsupported-runtime error instead of a misleading
+decoder or text-to-audio build attempt.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...checkpoint_mapper import WeightDict
+from ...config import ModelConfig
+
+
+_UNSUPPORTED_MESSAGE = (
+    "VoxCPM2 is detected, but TensorRT runtime support is not implemented yet. "
+    "The upstream openbmb/VoxCPM2 architecture requires LocEnc, TSLM/RALM, "
+    "LocDiT diffusion, and AudioVAE support; the existing Bark and Magpie TTS "
+    "pipelines do not match this checkpoint."
+)
+
+
+def _as_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+class VoxCPM2Plugin:
+    name = "voxcpm2"
+    runtime_strategy = "text_to_audio_voxcpm2"
+    runtime_config_namespace = "audio_voxcpm2"
+
+    def matches(self, model_type: str) -> bool:
+        return str(model_type or "").lower().replace("-", "_") in {
+            "voxcpm2",
+            "vox_cpm2",
+        }
+
+    def load_weights(
+        self,
+        model_dir: str,
+        config: ModelConfig,
+        *,
+        precision: str = "fp32",
+    ) -> WeightDict:
+        raise NotImplementedError(_UNSUPPORTED_MESSAGE)
+
+    def build_engine(
+        self,
+        config: ModelConfig,
+        weights: WeightDict,
+        max_cache_length: int,
+        *,
+        precision: str = "fp32",
+        quant_ctx=None,
+        verbose: bool = False,
+        parallel_config=None,
+    ) -> bytes:
+        raise NotImplementedError(_UNSUPPORTED_MESSAGE)
+
+    def get_audio_config(self, config: ModelConfig) -> dict:
+        raw = config.raw or {}
+        lm_config = raw.get("lm_config") if isinstance(raw.get("lm_config"), dict) else {}
+        audio_vae = (
+            raw.get("audio_vae_config")
+            if isinstance(raw.get("audio_vae_config"), dict)
+            else {}
+        )
+        dit_config = raw.get("dit_config") if isinstance(raw.get("dit_config"), dict) else {}
+
+        return {
+            "voxcpm2": True,
+            "voxcpm2_runtime_supported": False,
+            "voxcpm2_architecture": str(raw.get("architecture") or config.model_type),
+            "voxcpm2_reference_sample_rate": _as_int(audio_vae.get("sample_rate"), 16000),
+            "sample_rate": _as_int(audio_vae.get("out_sample_rate"), 48000),
+            "voxcpm2_max_length": _as_int(raw.get("max_length"), 8192),
+            "voxcpm2_dtype": str(raw.get("dtype") or "bfloat16"),
+            "voxcpm2_lm_hidden_size": _as_int(
+                lm_config.get("hidden_size"), config.hidden_size
+            ),
+            "voxcpm2_lm_layers": _as_int(
+                lm_config.get("num_hidden_layers"), config.num_hidden_layers
+            ),
+            "voxcpm2_dit_hidden_dim": _as_int(dit_config.get("hidden_dim"), 1024),
+            "voxcpm2_dit_layers": _as_int(dit_config.get("num_layers"), 12),
+        }
+
+
+plugin = VoxCPM2Plugin()

--- a/python/tensorrt_model_connect/runtime_config/schemas/audio_voxcpm2.py
+++ b/python/tensorrt_model_connect/runtime_config/schemas/audio_voxcpm2.py
@@ -1,0 +1,80 @@
+"""Schema for the ``audio_voxcpm2`` namespace.
+
+Session knobs mirror the upstream ``voxcpm`` generation API. The current
+family plugin is detection-only; these fields reserve the runtime surface for a
+future TensorRT implementation without overloading Bark or Magpie settings.
+"""
+
+from __future__ import annotations
+
+from tensorrt_model_connect.runtime_config import (
+    ConfigField,
+    Layer,
+    Schema,
+    register_schema,
+)
+
+
+_SESSION = frozenset({Layer.SESSION_REQUEST, Layer.PLATFORM_PROFILE})
+
+
+SCHEMA = Schema(
+    namespace="audio_voxcpm2",
+    fields=(
+        ConfigField(
+            name="cfg_value",
+            type_tag="float",
+            default=2.0,
+            allowed_layers=_SESSION,
+            validator=lambda v: isinstance(v, (int, float)) and v >= 0.0,
+        ),
+        ConfigField(
+            name="inference_timesteps",
+            type_tag="int32",
+            default=10,
+            allowed_layers=_SESSION,
+            validator=lambda v: isinstance(v, int) and v > 0,
+        ),
+        ConfigField(
+            name="normalize",
+            type_tag="bool",
+            default=True,
+            allowed_layers=_SESSION,
+        ),
+        ConfigField(
+            name="denoise",
+            type_tag="bool",
+            default=True,
+            allowed_layers=_SESSION,
+        ),
+        ConfigField(
+            name="retry_badcase",
+            type_tag="bool",
+            default=True,
+            allowed_layers=_SESSION,
+        ),
+        ConfigField(
+            name="retry_badcase_max_times",
+            type_tag="int32",
+            default=3,
+            allowed_layers=_SESSION,
+            validator=lambda v: isinstance(v, int) and v >= 0,
+        ),
+        ConfigField(
+            name="retry_badcase_ratio_threshold",
+            type_tag="float",
+            default=6.0,
+            allowed_layers=_SESSION,
+            validator=lambda v: isinstance(v, (int, float)) and v > 0.0,
+        ),
+        ConfigField(
+            name="seed",
+            type_tag="int64",
+            default=-1,
+            allowed_layers=_SESSION,
+        ),
+    ),
+)
+
+
+register_schema(SCHEMA)

--- a/src/runtime/config/schemas/audio_voxcpm2.cpp
+++ b/src/runtime/config/schemas/audio_voxcpm2.cpp
@@ -1,0 +1,64 @@
+// Registration for the "audio_voxcpm2" namespace schema.
+// Mirrors python/tensorrt_model_connect/runtime_config/schemas/audio_voxcpm2.py.
+
+#include "trtmc/config/schemas/audio_voxcpm2.h"
+
+#include <any>
+#include <cstdint>
+#include <set>
+
+namespace trtmc::config::schemas {
+
+namespace {
+bool is_nonneg_float(const std::any& v) {
+    if (v.type() == typeid(float))
+        return std::any_cast<float>(v) >= 0.0F;
+    if (v.type() == typeid(double))
+        return std::any_cast<double>(v) >= 0.0;
+    return false;
+}
+
+bool is_positive_float(const std::any& v) {
+    if (v.type() == typeid(float))
+        return std::any_cast<float>(v) > 0.0F;
+    if (v.type() == typeid(double))
+        return std::any_cast<double>(v) > 0.0;
+    return false;
+}
+
+bool is_positive_int32(const std::any& v) {
+    if (v.type() != typeid(std::int32_t))
+        return false;
+    return std::any_cast<std::int32_t>(v) > 0;
+}
+
+bool is_nonneg_int32(const std::any& v) {
+    if (v.type() != typeid(std::int32_t))
+        return false;
+    return std::any_cast<std::int32_t>(v) >= 0;
+}
+} // namespace
+
+Schema make_audio_voxcpm2_schema() {
+    const std::set<Layer> session = {Layer::SessionRequest, Layer::PlatformProfile};
+    return Schema{
+        "audio_voxcpm2",
+        {
+            ConfigField{"cfg_value", "float", std::any{2.0F}, session, is_nonneg_float},
+            ConfigField{"inference_timesteps", "int32", std::any{std::int32_t{10}}, session,
+                        is_positive_int32},
+            ConfigField{"normalize", "bool", std::any{true}, session, nullptr},
+            ConfigField{"denoise", "bool", std::any{true}, session, nullptr},
+            ConfigField{"retry_badcase", "bool", std::any{true}, session, nullptr},
+            ConfigField{"retry_badcase_max_times", "int32", std::any{std::int32_t{3}}, session,
+                        is_nonneg_int32},
+            ConfigField{"retry_badcase_ratio_threshold", "float", std::any{6.0F}, session,
+                        is_positive_float},
+            ConfigField{"seed", "int64", std::any{std::int64_t{-1}}, session, nullptr},
+        },
+    };
+}
+
+REGISTER_CONFIG_SCHEMA_FACTORY_WITH_MANIFEST(register_audio_voxcpm2_schema,
+                                             make_audio_voxcpm2_schema);
+} // namespace trtmc::config::schemas

--- a/tests/builder/test_config_schema_voxcpm2.py
+++ b/tests/builder/test_config_schema_voxcpm2.py
@@ -1,0 +1,68 @@
+"""Tests for the VoxCPM2 runtime config schema."""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    from tensorrt_model_connect.runtime_config import (
+        ConfigBundle,
+        Layer,
+        LayerContribution,
+        clear_for_testing,
+        lookup,
+    )
+    from tensorrt_model_connect.runtime_config.schemas import load_all
+except ImportError:  # pragma: no cover
+    pytest.skip("tensorrt_model_connect.runtime_config not importable", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    clear_for_testing()
+    yield
+    clear_for_testing()
+
+
+def test_audio_voxcpm2_schema_defaults_and_session_values():
+    load_all()
+    schema = lookup("audio_voxcpm2")
+    assert schema is not None
+
+    by_name = {field.name: field for field in schema.fields}
+    assert by_name["cfg_value"].default == 2.0
+    assert by_name["inference_timesteps"].default == 10
+    assert by_name["normalize"].default is True
+    assert by_name["denoise"].default is True
+    assert by_name["retry_badcase"].default is True
+    assert by_name["retry_badcase_max_times"].default == 3
+    assert by_name["retry_badcase_ratio_threshold"].default == 6.0
+    assert by_name["seed"].default == -1
+
+    bundle = ConfigBundle.build([
+        LayerContribution(
+            layer=Layer.SESSION_REQUEST,
+            values={
+                "audio_voxcpm2": {
+                    "cfg_value": 1.5,
+                    "inference_timesteps": 4,
+                    "seed": 123,
+                },
+            },
+        ),
+    ])
+
+    assert bundle.get("audio_voxcpm2", "cfg_value") == 1.5
+    assert bundle.get("audio_voxcpm2", "inference_timesteps") == 4
+    assert bundle.get("audio_voxcpm2", "seed") == 123
+
+
+def test_audio_voxcpm2_schema_rejects_invalid_timesteps():
+    load_all()
+    with pytest.raises(ValueError, match="audio_voxcpm2.inference_timesteps"):
+        ConfigBundle.build([
+            LayerContribution(
+                layer=Layer.SESSION_REQUEST,
+                values={"audio_voxcpm2": {"inference_timesteps": 0}},
+            ),
+        ])

--- a/tests/builder/test_families.py
+++ b/tests/builder/test_families.py
@@ -389,6 +389,9 @@ _POSITIVE_MATCH_CASES = [
     # MagpieTTS (encoder-decoder TTS)
     ("magpie_tts", "magpie_tts"),
     ("decoder_ce", "magpie_tts"),
+    # VoxCPM2 (detected TTS family, TensorRT runtime pending)
+    ("voxcpm2", "voxcpm2"),
+    ("vox_cpm2", "voxcpm2"),
     # Qwen3.5 (hybrid DeltaNet + Attention)
     ("qwen3_5", "qwen3_5"),
     ("qwen3.5", "qwen3_5"),
@@ -568,6 +571,10 @@ class TestRuntimeStrategy:
     def test_nemotron_speech_streaming_strategy(self):
         plugin = find_plugin("nemotron_speech_streaming")
         assert getattr(plugin, "runtime_strategy", None) == "speech_to_text_rnnt"
+
+    def test_voxcpm2_strategy(self):
+        plugin = find_plugin("voxcpm2")
+        assert getattr(plugin, "runtime_strategy", None) == "text_to_audio_voxcpm2"
 
     def test_standard_decoder_no_strategy(self):
         """Standard decoder plugins have no runtime_strategy (defaults to decoder_kv_cache)."""

--- a/tests/builder/test_family_voxcpm2.py
+++ b/tests/builder/test_family_voxcpm2.py
@@ -1,0 +1,86 @@
+"""Tests for VoxCPM2 detection-only family support."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("tensorrt_model_connect", reason="tensorrt_model_connect requires tensorrt")
+
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families import find_plugin
+from tests.e2e_harness.manifest_loader import load_manifest
+
+
+def _voxcpm2_config() -> ModelConfig:
+    return ModelConfig.from_json(json.dumps({
+        "architecture": "voxcpm2",
+        "lm_config": {
+            "hidden_size": 2048,
+            "intermediate_size": 6144,
+            "max_position_embeddings": 32768,
+            "num_attention_heads": 16,
+            "num_hidden_layers": 28,
+            "num_key_value_heads": 2,
+            "vocab_size": 73448,
+        },
+        "dit_config": {
+            "hidden_dim": 1024,
+            "num_layers": 12,
+        },
+        "audio_vae_config": {
+            "sample_rate": 16000,
+            "out_sample_rate": 48000,
+        },
+        "max_length": 8192,
+        "dtype": "bfloat16",
+    }))
+
+
+def test_voxcpm2_plugin_matches_config_model_type():
+    plugin = find_plugin("voxcpm2")
+    assert plugin is not None
+    assert plugin.name == "voxcpm2"
+    assert plugin.matches("voxcpm2")
+    assert plugin.matches("vox-cpm2")
+    assert not plugin.matches("bark")
+
+
+def test_voxcpm2_audio_config_records_upstream_shape():
+    plugin = find_plugin("voxcpm2")
+    cfg = _voxcpm2_config()
+
+    audio_cfg = plugin.get_audio_config(cfg)
+
+    assert audio_cfg["voxcpm2"] is True
+    assert audio_cfg["voxcpm2_runtime_supported"] is False
+    assert audio_cfg["voxcpm2_architecture"] == "voxcpm2"
+    assert audio_cfg["voxcpm2_reference_sample_rate"] == 16000
+    assert audio_cfg["sample_rate"] == 48000
+    assert audio_cfg["voxcpm2_lm_hidden_size"] == 2048
+    assert audio_cfg["voxcpm2_lm_layers"] == 28
+    assert audio_cfg["voxcpm2_dit_hidden_dim"] == 1024
+    assert audio_cfg["voxcpm2_dit_layers"] == 12
+
+
+def test_voxcpm2_build_fails_before_misrouting_to_bark_or_magpie(tmp_path):
+    plugin = find_plugin("voxcpm2")
+    cfg = _voxcpm2_config()
+
+    with pytest.raises(NotImplementedError, match="LocEnc"):
+        plugin.load_weights(str(tmp_path), cfg, precision="bf16")
+
+
+def test_voxcpm2_manifest_routes_to_text_to_audio_and_documents_skip():
+    manifest = Path(__file__).resolve().parents[1] / "e2e" / "models" / "voxcpm2.json"
+
+    with pytest.warns(UserWarning, match="unknown runtime_strategy"):
+        case = load_manifest(manifest)
+
+    assert case.runtime_strategy == "text_to_audio_voxcpm2"
+    assert case.task_strategy == "text_to_audio"
+    assert case.reference_backend == "custom_python"
+    assert "skip_reason" in case.metadata
+    assert "voxcpm-based reference runner" in case.metadata["reference_note"]

--- a/tests/e2e/models/voxcpm2.json
+++ b/tests/e2e/models/voxcpm2.json
@@ -1,0 +1,32 @@
+{
+  "name": "voxcpm2",
+  "trace_id": "IT-E2E-VOXCPM2-01",
+  "hf_id": "openbmb/VoxCPM2",
+  "bundle": "voxcpm2.trtfb",
+  "family": "voxcpm2",
+  "runtime_strategy": "text_to_audio_voxcpm2",
+  "task_strategy": "text_to_audio",
+  "reference_backend": "custom_python",
+  "oracle_level": "L1_external_reference",
+  "test_type": "audio",
+  "max_cache_length": 8192,
+  "prompt": "VoxCPM2 brings multilingual text to speech to TensorRT Model Connect.",
+  "max_new_tokens": 0,
+  "trust_remote_code": true,
+  "runtime_config": {
+    "audio_voxcpm2": {
+      "cfg_value": 2.0,
+      "inference_timesteps": 10,
+      "normalize": true,
+      "denoise": true,
+      "retry_badcase": true,
+      "retry_badcase_max_times": 3,
+      "retry_badcase_ratio_threshold": 6.0,
+      "seed": 42
+    }
+  },
+  "metadata": {
+    "reference_note": "Full E2E validation needs a voxcpm-based reference runner; the HF Transformers Bark reference path is not valid for VoxCPM2."
+  },
+  "skip": "Detection-only coverage: VoxCPM2 is not a Bark or Magpie variant, and TensorRT runtime support still needs LocEnc, TSLM/RALM, LocDiT diffusion, and AudioVAE implementation."
+}

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -99,6 +99,8 @@ def mock_repo(tmp_path):
          "hf_id": "Q/Q25VL", "test_image": "data/test_img.jpeg", "core": True},
         {"name": "bark-small", "family": "bark", "runtime_strategy": "text_to_audio_bark",
          "hf_id": "suno/bark", "core": True},
+        {"name": "voxcpm2", "family": "voxcpm2", "runtime_strategy": "text_to_audio_voxcpm2",
+         "hf_id": "openbmb/VoxCPM2", "runtime_config": {"audio_voxcpm2": {}}},
         {"name": "sam-vit", "family": "sam", "runtime_strategy": "prompted_segmentation",
          "hf_id": "fb/sam", "core": True},
         {"name": "segformer-b0", "family": "segformer", "runtime_strategy": "segmentation",
@@ -274,6 +276,8 @@ class TestDeclarativeClassificationRules:
         }
 
         assert priorities["cpp_scoped_helper"] < priorities["cpp_source"]
+        assert priorities["cpp_config_schema"] < priorities["cpp_source"]
+        assert priorities["runtime_config_schema"] < priorities["shared_builder_module"]
 
     @pytest.mark.parametrize(
         "path,rule_name",
@@ -494,6 +498,36 @@ class TestSharedModules:
             "python/tensorrt_model_connect/config.py", imap)
         assert match.rule == "shared_builder_module"
         assert len(match.models) == len(imap.all_model_names)
+
+
+class TestRuntimeConfigSchemaScope:
+    def test_python_audio_schema_scope(self, imap):
+        """audio runtime config schema changes route to the matching TTS model."""
+        match = test_impact.classify_file(
+            "python/tensorrt_model_connect/runtime_config/schemas/audio_voxcpm2.py",
+            imap,
+        )
+
+        assert match.rule == "runtime_config_schema"
+        assert match.models == ["voxcpm2"]
+        assert match.unit_tiers == ["builder"]
+        assert match.rebuild_cpp is False
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "src/runtime/config/schemas/audio_voxcpm2.cpp",
+            "include/trtmc/config/schemas/audio_voxcpm2.h",
+        ],
+    )
+    def test_cpp_audio_schema_scope(self, imap, path):
+        """C++ audio schema changes route to the matching TTS model."""
+        match = test_impact.classify_file(path, imap)
+
+        assert match.rule == "cpp_config_schema"
+        assert match.models == ["voxcpm2"]
+        assert match.unit_tiers == ["cpp"]
+        assert match.rebuild_cpp is True
 
 
 # ---------------------------------------------------------------------------
@@ -869,6 +903,14 @@ class TestHarness:
         assert match.rule == "harness_runner"
         assert "qwen3-0.6b" in match.models
         assert "bert-base" not in match.models
+
+    def test_text_to_audio_runner_includes_voxcpm2_strategy(self, imap):
+        """text_to_audio_voxcpm2 maps onto the text_to_audio task strategy."""
+        match = test_impact.classify_file(
+            "tests/e2e_harness/runners/audio_speech.py", imap)
+        assert match.rule == "harness_runner"
+        assert "bark-small" in match.models
+        assert "voxcpm2" in match.models
 
     def test_harness_comparator(self, imap):
         """comparators/diffusion.py -> diffusion models."""

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -39,6 +39,7 @@ RUNTIME_TO_TASK_STRATEGY: Dict[str, str] = {
     "text_to_audio": "text_to_audio",
     "text_to_audio_bark": "text_to_audio",
     "text_to_audio_magpie": "text_to_audio",
+    "text_to_audio_voxcpm2": "text_to_audio",
     "speech_to_speech": "speech_to_speech",
     "segmentation": "segmentation",
     "prompted_segmentation": "prompted_segmentation",
@@ -911,6 +912,21 @@ def _task_strategy_models_from_group(
     return _resolver
 
 
+def _runtime_config_schema_models(context: RuleContext, imap: ImpactMap) -> List[str]:
+    namespace = _group(context)
+    models: Set[str] = set()
+    for model, metadata in imap.model_metadata.items():
+        runtime_config = metadata.get("runtime_config")
+        if isinstance(runtime_config, dict) and namespace in runtime_config:
+            models.add(model)
+
+    if namespace.startswith("audio_"):
+        suffix = namespace.removeprefix("audio_")
+        models.update(imap.strategy_to_models.get(f"text_to_audio_{suffix}", []))
+
+    return sorted(models)
+
+
 def _no_impact_resolver(
     context: RuleContext,
     imap: ImpactMap,
@@ -1030,6 +1046,18 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             ),
             resolver=_match_result("specialized_builder", _specialized_builder_models),
             covered_by=("TestDeclarativeClassificationRules.test_specialized_builder_rule",),
+        ),
+        ClassificationRule(
+            priority=95,
+            name="runtime_config_schema",
+            matcher=_regex_rule(
+                r"python/tensorrt_model_connect/runtime_config/schemas/(audio_\w+)\.py$"
+            ),
+            resolver=_match_result(
+                "runtime_config_schema",
+                _runtime_config_schema_models,
+            ),
+            covered_by=("TestRuntimeConfigSchemaScope.test_python_audio_schema_scope",),
         ),
         ClassificationRule(
             priority=100,
@@ -1171,6 +1199,15 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
                 "TestCppScope.test_scoped_cpp_helper_gpu_matmul",
                 "TestCppScope.test_scoped_cpp_helper_diffusion_seam",
             ),
+        ),
+        ClassificationRule(
+            priority=225,
+            name="cpp_config_schema",
+            matcher=_regex_rule(
+                r"(?:src/runtime/config/schemas|include/trtmc/config/schemas)/(audio_\w+)\.(?:cpp|h)$"
+            ),
+            resolver=_match_result("cpp_config_schema", _runtime_config_schema_models),
+            covered_by=("TestRuntimeConfigSchemaScope.test_cpp_audio_schema_scope",),
         ),
         ClassificationRule(
             priority=230,

--- a/tools/test_impact_fallback_allowlist.txt
+++ b/tools/test_impact_fallback_allowlist.txt
@@ -228,8 +228,6 @@ shared_builder_module python/tensorrt_model_connect/runtime_config/cli_support.p
 shared_builder_module python/tensorrt_model_connect/runtime_config/config_bundle.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/runtime_config/schema_registry.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/runtime_config/schemas/__init__.py # shared Python builder surface; broad builder impact is intentional
-shared_builder_module python/tensorrt_model_connect/runtime_config/schemas/audio_bark.py # shared Python builder surface; broad builder impact is intentional
-shared_builder_module python/tensorrt_model_connect/runtime_config/schemas/audio_magpie.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/runtime_config/schemas/platform.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/runtime_config/schemas/runtime.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/runtime_config/schemas/text_trace.py # shared Python builder surface; broad builder impact is intentional

--- a/website/docs/getting-started/model-support.md
+++ b/website/docs/getting-started/model-support.md
@@ -7,7 +7,8 @@ Model support is defined by two source-of-truth surfaces:
 - Python family plugins under `python/tensorrt_model_connect/families/`.
 - E2E manifests under `tests/e2e/models/`.
 
-The current checkout contains 68 Python family plugins and 122 E2E model manifests.
+The current checkout contains Python family plugins and E2E model manifests for
+the supported and experimental surfaces below.
 
 ## Support Levels
 
@@ -19,6 +20,7 @@ Use these terms when reading the tables:
 | Builder support | A Python family plugin can create bundle artifacts, but runtime or E2E coverage may be narrower. |
 | Runtime strategy support | A C++ plugin and pipeline shape exist for bundles that carry the strategy. Specific families still need builder and manifest coverage. |
 | Experimental support | The path exists but may have stricter environment, model-size, precision, or parity limits. Read the manifest and tutorial caveats before relying on it. |
+| Detection-only support | The model family is recognized and documented, but bundle/runtime construction stops with an explicit unsupported message. |
 | Not supported by listing alone | A HuggingFace model name that resembles a family is not automatically supported. The family plugin and runtime strategy must match the model's config and request-time behavior. |
 
 The E2E manifests are the most concrete proof because they name the model ID, runtime strategy, prompt/input shape, verifier, and tolerances.
@@ -49,9 +51,18 @@ internlm, internvl, llama, m2m_100, magpie_tts, mamba, marian, mistral,
 mixtral, modernbert, mpnet, nemotron, nemotron_h, nemotron_speech_streaming,
 olmo, olmo2, opt, personaplex, phi, phi4_multimodal, phi_moe, pixart,
 qwen, qwen3_5, qwen3_omni, qwen_moe, qwen_vl, roberta, rwkv, sam,
-segformer, stablelm, starcoder2, t5, wan_t2v, whisper, xglm, xlnet,
-z_image
+segformer, stablelm, starcoder2, t5, voxcpm2, wan_t2v, whisper, xglm,
+xlnet, z_image
 ```
+
+:::caution VoxCPM2 status
+`openbmb/VoxCPM2` is detection-only in this checkout. The `voxcpm2` family
+plugin recognizes `architecture: "voxcpm2"` configs and the `audio_voxcpm2`
+schema reserves generation knobs from the upstream `voxcpm` API, but the
+TensorRT builder/runtime is not implemented yet. This model is not routed
+through Bark or Magpie because VoxCPM2 uses LocEnc, TSLM/RALM, LocDiT, and
+AudioVAE components that need dedicated support.
+:::
 
 ## How support is resolved
 

--- a/website/docs/tutorials/intermediate/multimodal-and-speech.md
+++ b/website/docs/tutorials/intermediate/multimodal-and-speech.md
@@ -132,6 +132,12 @@ Streaming adds two concerns that offline transcription does not have:
 
 Magpie supports chunked audio callbacks in the C++ API and `trtmc serve-audio` in the CLI.
 
+VoxCPM2 is currently recognized as a detection-only family. Its upstream
+`voxcpm` workflow uses LocEnc, TSLM/RALM, LocDiT diffusion, and AudioVAE rather
+than the Bark or Magpie acoustic/codec layout, so TensorRT bundle construction
+stops with an explicit unsupported message until those components have native
+builder and runtime support.
+
 ```mermaid
 flowchart LR
   Prompt["Text prompt"] --> TextTok["Text or phoneme tokens"]


### PR DESCRIPTION
## Background
GH-174 asks for support for `openbmb/VoxCPM2`. The upstream model card describes VoxCPM2 as an Apache-2.0 multilingual text-to-speech model with about 2B BF16 parameters, tokenizer-free diffusion autoregressive architecture (`LocEnc -> TSLM -> RALM -> LocDiT`), 48 kHz output, 16 kHz reference-audio cloning input, and a `voxcpm` API entry point via `VoxCPM.from_pretrained("openbmb/VoxCPM2")`.

## Exit Criteria
- The repo recognizes VoxCPM2 configs and does not misroute them through Bark or Magpie.
- Runtime/config/manifest surfaces clearly document that full TensorRT execution is not implemented in this pass.
- The skipped E2E manifest records the intended runtime strategy and follow-up blocker without weakening audio/TTS pass criteria.

## Implementation
- Added a `voxcpm2` family plugin with `text_to_audio_voxcpm2` strategy metadata, upstream audio-shape metadata extraction, and an explicit `NotImplementedError` before weight loading/building.
- Added Python and C++ `audio_voxcpm2` config schemas for upstream `voxcpm` generation knobs.
- Added a skipped `tests/e2e/models/voxcpm2.json` manifest using a future custom `voxcpm` reference path rather than the Bark/HF Transformers reference path.
- Updated docs to list VoxCPM2 as detection-only and explain why Bark/Magpie cannot be reused.
- Scoped impact analysis for audio runtime-config schemas so this detection-only addition selects `voxcpm2` instead of forcing unrelated all-model E2E coverage.

## Validation
- `python3 -m pytest -q tests/builder/test_config_schema_voxcpm2.py tests/builder/test_family_voxcpm2.py tests/builder/test_families.py::TestRuntimeStrategy::test_voxcpm2_strategy`: passed, 7 tests.
- `python3 -m pytest -q tests/tools/test_test_impact.py`: passed, 133 tests.
- `python3 tools/test_impact.py --validate`: passed. Existing repository warnings remain for `qwen3_omni/`, core task-strategy coverage, and unrelated stale fallback-allowlist entries.
- `python3 tools/test_impact.py --files cmake/trtmc_config_schemas.cmake,include/trtmc/config/schemas/audio_voxcpm2.h,python/tensorrt_model_connect/families/voxcpm2/__init__.py,python/tensorrt_model_connect/families/voxcpm2/plugin.py,python/tensorrt_model_connect/runtime_config/schemas/audio_voxcpm2.py,src/runtime/config/schemas/audio_voxcpm2.cpp,tests/builder/test_config_schema_voxcpm2.py,tests/builder/test_families.py,tests/builder/test_family_voxcpm2.py,tests/e2e/models/voxcpm2.json,tests/tools/test_test_impact.py,tools/test_impact.py,tools/test_impact_fallback_allowlist.txt,website/docs/getting-started/model-support.md,website/docs/tutorials/intermediate/multimodal-and-speech.md --json`: passed; selected only `voxcpm2` for E2E and builder/cpp/tools unit tiers.
- `python3 -m ruff check python/tensorrt_model_connect/families/voxcpm2 python/tensorrt_model_connect/runtime_config/schemas/audio_voxcpm2.py tests/builder/test_config_schema_voxcpm2.py tests/builder/test_family_voxcpm2.py tests/tools/test_test_impact.py tools/test_impact.py`: passed.
- `python3 -m json.tool tests/e2e/models/voxcpm2.json`: passed.
- `git diff --check`: passed.
- GitHub Premerge CI for `d3b4b6a2f72def1c182d964f7319e91983023291`: passed in run `26775979355`. Impact analysis selected one E2E model, `voxcpm2`; selective E2E ran `tests/test_e2e.py::test_e2e[voxcpm2]` and skipped it with the detection-only reason.

## Notes For Future Readers
- This is intentionally detection-only. Full TensorRT runtime support still needs dedicated LocEnc, TSLM/RALM, LocDiT diffusion, AudioVAE, and `voxcpm` reference-runner work.
- The manifest is skipped so CI records the target surface without claiming runtime parity.
- `text_to_audio_voxcpm2` is intentionally mapped for impact analysis, while the skipped manifest carries an explicit `task_strategy` until a real E2E runner/runtime path exists.

Refs #174
