### PR TITLE
fix(gemma): use gelu_pytorch_tanh in MLP gate path

### DIFF
--- a/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_builder.py
@@ -139,16 +139,18 @@ def _swiglu_mlp(
     prefix: str,
     hidden: int,
     mlp_size: int,
+    work_np_dtype: np.dtype,
 ) -> trt.ITensor:
+    # Gemma 1 / Gemma 2 both use hidden_activation="gelu_pytorch_tanh" — the
+    # gate path is gelu_tanh(gate), not silu(gate). HF GemmaMLP applies
+    # ACT2FN["gelu_pytorch_tanh"] = nn.GELU(approximate="tanh") to gate_proj.
     gate = matmul(inp, hidden, mlp_size,
                   weights[f"{prefix}.w_gate"], f"{prefix}.w_gate")
     up = matmul(inp, hidden, mlp_size,
                 weights[f"{prefix}.w_up"], f"{prefix}.w_up")
-    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
-    swish = network.add_elementwise(
-        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    activated = graph_ops.add_gelu_new(network, gate, dtype=work_np_dtype)
     gated = network.add_elementwise(
-        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+        activated, up, trt.ElementWiseOperation.PROD)
     mlp_out = matmul(gated.get_output(0), mlp_size, hidden,
                      weights[f"{prefix}.w_down"], f"{prefix}.w_down")
     return mlp_out
@@ -637,7 +639,8 @@ def build_dual_profile_decoder_engine(
             mlp_out = _swiglu_mlp(
                 network, norm2,
                 matmul=matmul, weights=weights, prefix=prefix,
-                hidden=hidden, mlp_size=mlp_size)
+                hidden=hidden, mlp_size=mlp_size,
+                work_np_dtype=work_np_dtype)
 
         # Final residual.
         if gemma2_norms:

--- a/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/gemma/dual_profile_decoder_tp_builder.py
@@ -153,16 +153,17 @@ def _swiglu_mlp(
     prefix: str,
     hidden: int,
     mlp_size: int,
+    work_np_dtype: np.dtype,
 ) -> trt.ITensor:
+    # Gemma uses hidden_activation="gelu_pytorch_tanh"; gate path is
+    # gelu_tanh(gate), not silu(gate). See dense builder for context.
     gate = matmul(inp, hidden, mlp_size,
                   weights[f"{prefix}.w_gate"], f"{prefix}.w_gate")
     up = matmul(inp, hidden, mlp_size,
                 weights[f"{prefix}.w_up"], f"{prefix}.w_up")
-    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
-    swish = network.add_elementwise(
-        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+    activated = graph_ops.add_gelu_new(network, gate, dtype=work_np_dtype)
     gated = network.add_elementwise(
-        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+        activated, up, trt.ElementWiseOperation.PROD)
     mlp_out = matmul(gated.get_output(0), mlp_size, hidden,
                      weights[f"{prefix}.w_down"], f"{prefix}.w_down")
     return mlp_out
@@ -625,7 +626,8 @@ def build_dual_profile_tp_decoder_engine(
             mlp_out = _swiglu_mlp(
                 network, norm2,
                 matmul=matmul, weights=weights, prefix=prefix,
-                hidden=hidden, mlp_size=mlp_size)
+                hidden=hidden, mlp_size=mlp_size,
+                work_np_dtype=work_np_dtype)
         mlp_out = add_all_reduce_sum(network, mlp_out, parallel.tp_size)
 
         # Final residual.

--- a/tests/builder/test_owned_builder_mocked_paths.py
+++ b/tests/builder/test_owned_builder_mocked_paths.py
@@ -292,15 +292,31 @@ def test_onnx_builder_success_and_plan_none_branches() -> None:
     )
     mod = _import_with_fake_trt("tensorrt_model_connect.families.qwen_vl.onnx_vision_builder", fake_trt=fake_trt)
 
-    plan = mod.build_vision_engine_from_onnx(b"good-onnx", verbose=True)
-    assert plan == b"engine-plan"
-    # EXPLICIT_BATCH (1 << 0) | STRONGLY_TYPED (1 << 1) = 3
-    assert _FakeBuilder.last_instance.flags == 3
-    assert _FakeBuilder.last_instance.config.calls == [("workspace", 1 << 30)]
+    # Keep the fake patched during the call: trt_compat.network_creation_flags()
+    # reads sys.modules["tensorrt"] at call time, not at import time.
+    previous_trt = sys.modules.get("tensorrt")
+    previous_trt_compat_module = None
+    try:
+        from tensorrt_model_connect import trt_compat as _tc
+        previous_trt_compat_module = _tc._module
+        _tc._module = fake_trt
+        sys.modules["tensorrt"] = fake_trt
+        plan = mod.build_vision_engine_from_onnx(b"good-onnx", verbose=True)
+        assert plan == b"engine-plan"
+        # EXPLICIT_BATCH (1 << 0) | STRONGLY_TYPED (1 << 1) = 3
+        assert _FakeBuilder.last_instance.flags == 3
+        assert _FakeBuilder.last_instance.config.calls == [("workspace", 1 << 30)]
 
-    _FakeBuilder.plan_to_return = None
-    with pytest.raises(RuntimeError, match="TensorRT vision engine build failed"):
-        mod.build_vision_engine_from_onnx(b"good-onnx")
+        _FakeBuilder.plan_to_return = None
+        with pytest.raises(RuntimeError, match="TensorRT vision engine build failed"):
+            mod.build_vision_engine_from_onnx(b"good-onnx")
+    finally:
+        if previous_trt is None:
+            sys.modules.pop("tensorrt", None)
+        else:
+            sys.modules["tensorrt"] = previous_trt
+        from tensorrt_model_connect import trt_compat as _tc
+        _tc._module = previous_trt_compat_module
 
 
 @pytest.mark.unit

--- a/tests/e2e/models/gemma-2-2b.json
+++ b/tests/e2e/models/gemma-2-2b.json
@@ -5,6 +5,7 @@
   "bundle": "gemma-2-2b.trtfb",
   "family": "gemma",
   "runtime_strategy": "decoder_kv_cache",
+  "precision": "bf16",
   "max_cache_length": 256,
   "prompt": "What is 2 + 2? Answer with just the number.",
   "max_new_tokens": 10,


### PR DESCRIPTION
## Summary

Gemma 1 and Gemma 2 both ship `hidden_activation: \"gelu_pytorch_tanh\"` in config.json. HF \`GemmaMLP.forward\` applies \`ACT2FN[\"gelu_pytorch_tanh\"]\` = \`nn.GELU(approximate=\"tanh\")\` to the gate projection, then multiplies by the up projection:

\`\`\`
down_proj(gelu_tanh(gate_proj(x)) * up_proj(x))
\`\`\`

The gemma family's \`_swiglu_mlp\` helper in both \`dual_profile_decoder_builder.py\` and \`dual_profile_decoder_tp_builder.py\` was applying SiLU (sigmoid * gate) — the standard SwiGLU activation used by Llama / Qwen / Mistral etc.

The wrong activation manifested as 'empty response' at runtime for \`gemma-2-2b-it\` (the model sampled EOS as the first generated token, even though build / weight-load succeeded).

After the fix, \`gemma-2-2b-it\` at \`precision: bf16\` produces the expected output for the lane prompt \"What is 2 + 2? Answer with just the number.\" → \`4\`. \`tests/e2e/models/gemma-2-2b.json\` is updated to set \`precision: bf16\` (fp32 builds a 12.8 GB engine plan that doesn't deserialize on A30 24 GB alongside the HF transformers reference load).

## Test plan

- [x] Verified on ipp1-1940 (2× A30, TRT 11.0.0.114) — built bf16 bundle, ran \`trtmc run gemma-2-2b.trtfb --prompt 'What is 2 + 2? Answer with just the number.' --max-new-tokens 10 --chat-template\`. Output: \`4 \`. Timing: prefill_ms=50.5, decode_ms=36.7, total_ms=87.2.
- [ ] Re-run \`tests/test_e2e.py::test_e2e[gemma-2-2b]\` in CI with HF_TOKEN (lane is gated)
- [ ] Spot-check that Llama / Qwen / Mistral / Phi-3 / Granite lanes still pass (helper is family-local — change is isolated to gemma)

🤖 Generated with [Claude Code](https://claude.com/claude-code)