### PR TITLE
feat(onboarding): scaffold expanded model list (Qwen2-VL, Qwen-Image-TP, Qwen35-9B-TP, Gemma 4) (XFAIL)

### DIFF
--- a/tests/e2e/models/gemma-4-e4b.json
+++ b/tests/e2e/models/gemma-4-e4b.json
@@ -1,0 +1,15 @@
+{
+  "name": "gemma-4-e4b",
+  "trace_id": "IT-E2E-GMA4-E4B-01",
+  "hf_id": "google/gemma-4-E4B-it",
+  "bundle": "gemma-4-e4b.trtfb",
+  "family": "gemma",
+  "runtime_strategy": "vision_language",
+  "max_cache_length": 256,
+  "prompt": "What is 2 + 2? Answer with just the number.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "trust_remote_code": false,
+  "notes": "Gemma 4 E4B (multimodal: audio + vision + text). model_type=gemma4, Gemma4ForConditionalGeneration. Config nests audio_config (gemma4_audio: 12-layer conv-subsampling encoder) + vision_config + text decoder, plus boa/boi/eoa special tokens. Existing gemma family only handles Gemma 1/2 text-only — new family work needed to add multimodal heads. Scaffolded to mark the gap."
+}

--- a/tests/e2e/models/qwen-image-tp4.json
+++ b/tests/e2e/models/qwen-image-tp4.json
@@ -1,0 +1,50 @@
+{
+  "name": "qwen-image-tp4",
+  "trace_id": "IT-E2E-QIMG-TP4-01",
+  "hf_id": "Qwen/Qwen-Image",
+  "bundle": "qwen-image-tp4.trtfb",
+  "model_type": "qwen_image",
+  "family": "qwen_image",
+  "runtime_strategy": "diffusion_qwen_image",
+  "task_strategy": "diffusion_media_generation",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "description": "Qwen-Image base text-to-image TP=4 lane (text encoder + DiT + VAE sharded across 4 GPUs)",
+  "build_args": {
+    "max_cache_length": 256,
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 4
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 4,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    { "kind": "binary_exists", "args": {}, "gating": true },
+    { "kind": "command_available", "args": { "command": "mpirun" }, "gating": true },
+    { "kind": "gpu_count_min", "args": { "count": 4 }, "gating": true }
+  ],
+  "prompt": "A cat holding a sign that says hello world",
+  "negative_prompt": " ",
+  "test_type": "diffusion",
+  "image_height": 1024,
+  "image_width": 1024,
+  "height": 1024,
+  "width": 1024,
+  "video_num_frames": 1,
+  "num_inference_steps": 20,
+  "cfg_scale": 4.0,
+  "seed": 42,
+  "skip_text_comparison": true,
+  "notes": "Qwen-Image TP=4 scaffold. qwen_image family currently lacks TP infra (DiT TP, VAE TP, text-encoder TP). Lane parked as XFAIL until qwen_image family TP is implemented (similar shape to wan_t2v / flux diffusion TP work)."
+}

--- a/tests/e2e/models/qwen2-vl-7b-tp2.json
+++ b/tests/e2e/models/qwen2-vl-7b-tp2.json
@@ -1,0 +1,42 @@
+{
+  "name": "qwen2-vl-7b-tp2",
+  "trace_id": "IT-E2E-Q2VL-7B-TP2-01",
+  "hf_id": "Qwen/Qwen2-VL-7B-Instruct",
+  "bundle": "qwen2-vl-7b-tp2.trtfb",
+  "family": "qwen_vl",
+  "runtime_strategy": "vision_language",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 384,
+  "prompt": "What color is the vehicle in this image? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "test_image": "tests/e2e/data/test_img.jpeg",
+  "trust_remote_code": false,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 2
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 2,
+    "debug_logits": true,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    { "kind": "binary_exists", "args": {}, "gating": true },
+    { "kind": "command_available", "args": { "command": "mpirun" }, "gating": true },
+    { "kind": "gpu_count_min", "args": { "count": 2 }, "gating": true }
+  ],
+  "notes": "Qwen2-VL-7B-Instruct TP=2 lane. num_kv_heads=4 -> TP=2 is the upper bound (TP=4 would shard kv_heads to 1 per rank). model_type=qwen2_vl routes through qwen_vl family TP path."
+}

--- a/tests/e2e/models/qwen2-vl-7b.json
+++ b/tests/e2e/models/qwen2-vl-7b.json
@@ -1,0 +1,16 @@
+{
+  "name": "qwen2-vl-7b",
+  "trace_id": "IT-E2E-Q2VL-7B-01",
+  "hf_id": "Qwen/Qwen2-VL-7B-Instruct",
+  "bundle": "qwen2-vl-7b.trtfb",
+  "family": "qwen_vl",
+  "runtime_strategy": "vision_language",
+  "max_cache_length": 384,
+  "prompt": "What color is the vehicle in this image? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "test_image": "tests/e2e/data/test_img.jpeg",
+  "trust_remote_code": false,
+  "notes": "Qwen2-VL-7B-Instruct dense (single-device) lane. model_type=qwen2_vl, routes to qwen_vl family (matcher accepts qwen+vl)."
+}

--- a/tests/e2e/models/qwen35-9b-tp2.json
+++ b/tests/e2e/models/qwen35-9b-tp2.json
@@ -1,0 +1,39 @@
+{
+  "name": "qwen35-9b-tp2",
+  "trace_id": "IT-E2E-Q35-TP2-01",
+  "hf_id": "Qwen/Qwen3.5-9B",
+  "bundle": "qwen35-9b-tp2.trtfb",
+  "family": "qwen3_5",
+  "runtime_strategy": "hybrid_mamba_attention",
+  "ci_tier": "multi_device",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "max_cache_length": 256,
+  "prompt": "What is the capital of France? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.005,
+  "trust_remote_code": true,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 2
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 2,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    { "kind": "binary_exists", "args": {}, "gating": true },
+    { "kind": "command_available", "args": { "command": "mpirun" }, "gating": true },
+    { "kind": "gpu_count_min", "args": { "count": 2 }, "gating": true }
+  ],
+  "notes": "Qwen3.5-9B TP=2 lane. qwen3_5 family is hybrid Mamba+attention; current TP infra targets dense/MoE decoders. Lane scaffolded to mark the gap — needs Mamba SSM-aware TP sharding in qwen3_5 family (similar to nemotron_h hybrid TP from PR #128)."
+}

--- a/tests/e2e/waives.txt
+++ b/tests/e2e/waives.txt
@@ -8,3 +8,8 @@ internlm2-1.8b           SKIP   (DynamicCache.from_legacy_cache removed in trans
 phi4-multimodal           SKIP   (phi4-multimodal remote code incompatible with transformers 5.x)
 eagle-embed-vl-1b-v2     SKIP   (HF repo 404)
 eagle-rerank-vl-1b-v2    SKIP   (HF repo 404)
+qwen2-vl-7b               XFAIL  (qwen_vl family matcher accepts model_type=qwen2_vl but generation diverges from HF reference: trtmc emits 10 tokens, ref 5 tokens, NED=1.0, token_agreement=0. Plugin assumes Qwen2.5-VL / Qwen3-VL semantics; Qwen2-VL needs family-side compatibility audit.)
+qwen2-vl-7b-tp2           XFAIL  (Same root cause as qwen2-vl-7b dense lane — qwen_vl family needs Qwen2-VL compatibility.)
+qwen35-9b-tp2             XFAIL  (qwen3_5 family is hybrid Mamba+attention; no TP infra yet. Same shape of gap as nemotron_h MoE — needs Mamba SSM-aware sharding.)
+qwen-image-tp4            XFAIL  (qwen_image family lacks TP infra; needs DiT TP + VAE TP + text-encoder TP, similar to wan_t2v / flux TP work.)
+gemma-4-e4b               XFAIL  (Gemma 4 is multimodal: audio + vision + text. Gemma4ForConditionalGeneration. Existing gemma family only handles text decoder; multimodal heads need new family work.)


### PR DESCRIPTION
## Summary

Adds manifest scaffolds for models in the expanded onboarding list that did not yet have lane coverage. All are XFAIL with documented blockers.

| Lane | Blocker |
|---|---|
| \`qwen2-vl-7b\` / \`qwen2-vl-7b-tp2\` | qwen_vl family matcher accepts \`qwen2_vl\` but generation diverges (NED=1.0, token_agreement=0). Family was tested against Qwen2.5-VL / Qwen3-VL; Qwen2-VL needs a family-side compatibility audit. |
| \`qwen35-9b-tp2\` | qwen3_5 family is hybrid Mamba+attention with no TP infra. Same shape of gap as the nemotron_h MoE work. |
| \`qwen-image-tp4\` | qwen_image diffusion family has no TP (needs DiT TP + VAE TP + text-encoder TP, similar to wan_t2v / flux). |
| \`gemma-4-e4b\` | Gemma 4 is multimodal (audio + vision + text, \`Gemma4ForConditionalGeneration\`). Existing gemma family only handles text decoder. |

Verified on umb-b200-138 (8× B200 180GB, TRT 11.0.0.114):
- qwen2-vl-7b dense + TP=2 both rebuild cleanly; compare fails with NED=1.0 and trtmc emitting 10-11 tokens vs ref's 5

**Note:** Gemini 3 from the user's expanded list is NOT included — Google does not publish Gemini weights on Hugging Face (API-only model).

## Test plan

- [ ] CI: All five lanes XFAIL via waives.txt entries
- [ ] Follow-up: family-side investigations to convert each XFAIL to PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)