### PR TITLE
feat(diffusion): batch-inference foundation PR1 — builders, bundle, helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ add_library(trtmc_core
   src/runtime/domains/audio/audio_types.cpp
   src/runtime/domains/audio/mel_spectrogram.cpp
   src/runtime/domains/audio/audio_bundle_validation.cpp
+  src/runtime/domains/diffusion/batch_utils.cpp
   src/runtime/domains/diffusion/diffusion_preprocessor.cpp
   src/runtime/domains/diffusion/qwen_image_types.cpp
   src/tokenizer/vocab_tokenizer.cpp
@@ -704,6 +705,7 @@ trtmc_add_test(test_diffusion_generation_plan)
 trtmc_add_test(test_diffusion_denoising_step_seam)
 trtmc_add_test(test_flow_match_scheduler)
 trtmc_add_test(test_diffusion_math)
+trtmc_add_test(test_diffusion_batch_utils)
 trtmc_add_test(test_ltx_video_pipeline)
 
 # Recurrent (Mamba / RWKV)

--- a/include/trtmc/bundle.h
+++ b/include/trtmc/bundle.h
@@ -12,6 +12,14 @@ struct BundleSectionInfo {
     std::uint64_t size{0};
 };
 
+// Per-component batch-size envelope baked into a diffusion bundle.
+// Absent in the bundle JSON => all caps default to 1 (today's behavior).
+struct MaxBatchSize {
+    int32_t dit{1};
+    int32_t text_encoder{1};
+    int32_t vae{1};
+};
+
 struct BundleInfo {
     std::string model_id;
     std::string model_type;
@@ -31,6 +39,7 @@ struct BundleInfo {
     bool tokenizer_add_special_tokens{false};
     bool tokenizer_add_special_tokens_present{false};
     std::vector<BundleSectionInfo> sections;
+    MaxBatchSize max_batch_size{};
 };
 
 // Read metadata without loading the engine.

--- a/python/tensorrt_model_connect/bundle_writer.py
+++ b/python/tensorrt_model_connect/bundle_writer.py
@@ -54,6 +54,11 @@ class BundleInfo:
     # input to the config registry merge. None/empty → no block emitted, so
     # old readers continue to work untouched.
     defaults: dict | None = None
+    # Per-component batch-size envelope for diffusion bundles. Shape:
+    # `{"dit": N, "text_encoder": N, "vae": N}`. None → field is omitted from
+    # the JSON header so older runtimes still load the bundle and treat the
+    # engine as B=1. See design doc Decision C.
+    max_batch_size: dict[str, int] | None = None
 
 
 @dataclass
@@ -102,6 +107,8 @@ def write_bundle(
         "tokenizer_add_special_tokens": int(info.tokenizer_add_special_tokens),
         **({"io_map": info.io_map} if info.io_map else {}),
         **({"defaults": info.defaults} if info.defaults else {}),
+        **({"max_batch_size": dict(info.max_batch_size)}
+           if info.max_batch_size else {}),
         "sections": {
             s["name"]: {"offset": s["offset"], "size": s["size"]}
             for s in section_meta

--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -175,6 +175,48 @@ def _sanitize_dynamic_kv_profile_rows(
     return sanitized
 
 
+def add_dynamic_batch_profile(
+    builder,
+    config,
+    network,
+    *,
+    input_names: list[str],
+    max_batch: int,
+    opt_batch: int,
+    static_shape: dict[str, tuple[int, ...]],
+) -> None:
+    """Attach one TensorRT profile with a dynamic leading batch dimension.
+
+    Used by every diffusion engine builder so the leading dim of each named
+    input is dynamic in the range ``[1, max_batch]`` with kOPT=``opt_batch``.
+    ``static_shape[name]`` is the per-input shape *without* the batch dim
+    (e.g. ``(num_patches, hidden_dim)``).
+    """
+    del network  # The profile API is name-based; arg kept for call-site clarity.
+    if max_batch < 1:
+        raise ValueError(f"max_batch must be >= 1 (got {max_batch})")
+    if not (1 <= opt_batch <= max_batch):
+        raise ValueError(
+            "opt_batch must satisfy 1 <= opt_batch <= max_batch "
+            f"(got opt_batch={opt_batch}, max_batch={max_batch})"
+        )
+    missing = [name for name in input_names if name not in static_shape]
+    if missing:
+        raise KeyError(
+            f"static_shape missing entries for: {', '.join(missing)}"
+        )
+    profile = builder.create_optimization_profile()
+    for name in input_names:
+        tail = tuple(static_shape[name])
+        profile.set_shape(
+            name,
+            min=(1, *tail),
+            opt=(opt_batch, *tail),
+            max=(max_batch, *tail),
+        )
+    config.add_optimization_profile(profile)
+
+
 def _raise_friendly_download_error(model_id: str, exc: Exception) -> None:
     """Re-raise HF download errors with clear, actionable messages."""
     exc_type = type(exc).__name__

--- a/python/tensorrt_model_connect/families/flux/flux_dit_builder.py
+++ b/python/tensorrt_model_connect/families/flux/flux_dit_builder.py
@@ -46,9 +46,36 @@ def build_flux_dit_engine(
     text_seq_len: int = 512,
     mlp_ratio: float = 4.0,
     eps: float = 1e-6,
+    max_batch_size: int = 1,
+    opt_batch_size: int | None = None,
     verbose: bool = False,
 ) -> bytes:
-    """Build FLUX DiT denoiser TRT engine plan."""
+    """Build FLUX.1 DiT denoiser TRT engine plan.
+
+    When ``max_batch_size > 1`` the engine gains a dynamic leading batch
+    dimension via a single TRT optimization profile spanning ``[1,
+    max_batch_size]`` with ``kOPT = min(max_batch_size, 4)`` (or the
+    caller-supplied ``opt_batch_size``). ``max_batch_size == 1`` preserves
+    the legacy static-shape engine byte-for-byte.
+    """
+    if max_batch_size < 1:
+        raise ValueError(f"max_batch_size must be >= 1 (got {max_batch_size})")
+    if max_batch_size > 1:
+        return _build_flux_dit_engine_batched(
+            weights,
+            dim=dim,
+            num_heads=num_heads,
+            num_layers=num_layers,
+            num_single_layers=num_single_layers,
+            num_img_tokens=num_img_tokens,
+            text_seq_len=text_seq_len,
+            mlp_ratio=mlp_ratio,
+            eps=eps,
+            max_batch_size=max_batch_size,
+            opt_batch_size=opt_batch_size,
+            verbose=verbose,
+        )
+
     head_dim = dim // num_heads
     ffn_dim = int(dim * mlp_ratio)  # For GELU-approximate FFN
     total_seq = text_seq_len + num_img_tokens
@@ -433,6 +460,482 @@ def _gelu_ffn(network, inp, dim, weights, prefix):
     if fc2_b is not None:
         fc2 = graph_ops.add_bias_sum(network, fc2, dim, fc2_b)
     return fc2
+
+
+# ============================================================================
+# Dynamic-batch path
+# ============================================================================
+#
+# When ``max_batch_size > 1`` we build a separate engine where every input
+# carries a leading dynamic dim and a single :class:`IOptimizationProfile`
+# spans ``[1, max_batch_size]`` with ``kOPT = min(max_batch_size, 4)``
+# (design Decisions A and C). The legacy static-shape path above is left
+# untouched so ``max_batch_size == 1`` stays byte-for-byte identical.
+
+def _dynamic_batch_shape(network, reference, tail: tuple[int, ...]):
+    """Shape tensor ``[B, *tail]`` using dim 0 from a dynamic-batch tensor."""
+    ref_shape = network.add_shape(reference).get_output(0)
+    batch = network.add_slice(ref_shape, start=(0,), shape=(1,), stride=(1,))
+    tail_t = graph_ops.add_constant(
+        network, (len(tail),), np.asarray(tail, dtype=np.int64), dtype=np.int64)
+    target = network.add_concatenation([batch.get_output(0), tail_t])
+    target.axis = 0
+    return target.get_output(0)
+
+
+def _slice_batched_vector(network, x, start_width: int, width: int):
+    """Slice ``[B, D]`` along D while preserving runtime-dynamic B."""
+    s = network.add_slice(
+        x, start=(0, start_width), shape=(0, 0), stride=(1, 1))
+    s.set_input(2, _dynamic_batch_shape(network, x, (width,)))
+    return s.get_output(0)
+
+
+def _slice_batched_sequence(network, x, start_seq: int, length: int, width: int):
+    """Slice ``[B, S, D]`` along S while preserving runtime-dynamic B."""
+    s = network.add_slice(
+        x, start=(0, start_seq, 0), shape=(0, 0, 0), stride=(1, 1, 1))
+    s.set_input(2, _dynamic_batch_shape(network, x, (length, width)))
+    return s.get_output(0)
+
+
+def _slice_batched_rope_half(network, rope, seq_len: int, half: int):
+    """Slice interleaved full-dim RoPE cache ``[B, S, D]`` to ``[B, S, D/2]``."""
+    s = network.add_slice(
+        rope, start=(0, 0, 0), shape=(0, 0, 0), stride=(1, 1, 2))
+    s.set_input(2, _dynamic_batch_shape(network, rope, (seq_len, half)))
+    return s.get_output(0)
+
+
+def _slice_batched_complex_part(network, x, seq_len: int, num_heads: int,
+                                half: int, complex_index: int):
+    """Slice real/imag part from ``[B, S, H, D/2, 2]`` to ``[B, S, H, D/2]``."""
+    s = network.add_slice(
+        x, start=(0, 0, 0, 0, complex_index), shape=(0, 0, 0, 0, 0),
+        stride=(1, 1, 1, 1, 1))
+    s.set_input(2, _dynamic_batch_shape(network, x, (seq_len, num_heads, half, 1)))
+    r = network.add_shuffle(s.get_output(0))
+    r.reshape_dims = (-1, seq_len, num_heads, half)
+    return r.get_output(0)
+
+
+def _reshape_batched_rows_to_heads_4d(network, x, num_heads: int, head_dim: int,
+                                      seq_len: int):
+    """``[B, S, H*D]`` -> ``[B, H, S, D]``."""
+    r = network.add_shuffle(x)
+    r.reshape_dims = (-1, seq_len, num_heads, head_dim)
+    r.second_transpose = trt.Permutation([0, 2, 1, 3])
+    return r.get_output(0)
+
+
+def _reshape_heads_4d_to_batched_rows(network, x, num_heads: int, head_dim: int,
+                                      seq_len: int):
+    """``[B, H, S, D]`` -> ``[B, S, H*D]``."""
+    r = network.add_shuffle(x)
+    r.first_transpose = trt.Permutation([0, 2, 1, 3])
+    r.reshape_dims = (-1, seq_len, num_heads * head_dim)
+    return r.get_output(0)
+
+
+def _mha_batched(network, q, k, v, num_heads: int, head_dim: int, seq_len: int):
+    """Multi-head attention for ``[B, S, H*D]`` tensors."""
+    q_4d = _reshape_batched_rows_to_heads_4d(network, q, num_heads, head_dim, seq_len)
+    k_4d = _reshape_batched_rows_to_heads_4d(network, k, num_heads, head_dim, seq_len)
+    v_4d = _reshape_batched_rows_to_heads_4d(network, v, num_heads, head_dim, seq_len)
+    ctx_4d = graph_ops.add_attention_core(
+        network, q_4d, k_4d, v_4d, causal=False, mask=None,
+        scale=float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0)
+    return _reshape_heads_4d_to_batched_rows(network, ctx_4d, num_heads, head_dim, seq_len)
+
+
+def _apply_rope_batched_from_full_cache(network, x, cos_t, sin_t, num_heads: int,
+                                        head_dim: int, seq_len: int):
+    """Apply interleaved RoPE to ``[B, S, H*D]`` with ``[B, S, D]`` caches."""
+    half = head_dim // 2
+    x_pairs_r = network.add_shuffle(x)
+    x_pairs_r.reshape_dims = (-1, seq_len, num_heads, half, 2)
+    x_pairs = x_pairs_r.get_output(0)
+
+    x_real = _slice_batched_complex_part(network, x_pairs, seq_len, num_heads, half, 0)
+    x_imag = _slice_batched_complex_part(network, x_pairs, seq_len, num_heads, half, 1)
+
+    cos_half = _slice_batched_rope_half(network, cos_t, seq_len, half)
+    sin_half = _slice_batched_rope_half(network, sin_t, seq_len, half)
+    cos_4d = network.add_shuffle(cos_half)
+    cos_4d.reshape_dims = (-1, seq_len, 1, half)
+    sin_4d = network.add_shuffle(sin_half)
+    sin_4d.reshape_dims = (-1, seq_len, 1, half)
+
+    r_cos = network.add_elementwise(
+        x_real, cos_4d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    i_sin = network.add_elementwise(
+        x_imag, sin_4d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    new_real = network.add_elementwise(
+        r_cos, i_sin, trt.ElementWiseOperation.SUB).get_output(0)
+
+    r_sin = network.add_elementwise(
+        x_real, sin_4d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    i_cos = network.add_elementwise(
+        x_imag, cos_4d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+    new_imag = network.add_elementwise(
+        r_sin, i_cos, trt.ElementWiseOperation.SUM).get_output(0)
+
+    nr = network.add_shuffle(new_real)
+    nr.reshape_dims = (-1, seq_len, num_heads, half, 1)
+    ni = network.add_shuffle(new_imag)
+    ni.reshape_dims = (-1, seq_len, num_heads, half, 1)
+    cat = network.add_concatenation([nr.get_output(0), ni.get_output(0)])
+    cat.axis = 4
+
+    flat = network.add_shuffle(cat.get_output(0))
+    flat.reshape_dims = (-1, seq_len, num_heads * head_dim)
+    return flat.get_output(0)
+
+
+def _layer_norm_last_dim_no_affine_batched(network, x, eps_t):
+    """LayerNorm without affine over final dim for ``[B, S, D]``."""
+    mean = network.add_reduce(x, trt.ReduceOperation.AVG, 1 << 2, keep_dims=True)
+    centered = network.add_elementwise(
+        x, mean.get_output(0), trt.ElementWiseOperation.SUB).get_output(0)
+    sq = network.add_elementwise(centered, centered, trt.ElementWiseOperation.PROD)
+    var = network.add_reduce(sq.get_output(0), trt.ReduceOperation.AVG, 1 << 2,
+                             keep_dims=True)
+    var_eps = network.add_elementwise(var.get_output(0), eps_t,
+                                      trt.ElementWiseOperation.SUM)
+    std = network.add_unary(var_eps.get_output(0), trt.UnaryOperation.SQRT)
+    inv_std = network.add_unary(std.get_output(0), trt.UnaryOperation.RECIP)
+    return network.add_elementwise(
+        centered, inv_std.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def _matmul_bias_batched(network, inp, in_dim, out_dim, weight, bias):
+    """Matmul + bias for ``[B, in_dim]`` -> ``[B, out_dim]``."""
+    out = graph_ops.add_matmul_rhs_constant(network, inp, in_dim, out_dim, weight)
+    return graph_ops.add_bias_sum(network, out, out_dim, bias)
+
+
+def _chunk_batched(network, tensor, chunks: int, dim: int):
+    """Split ``[B, chunks*dim]`` into ``chunks`` tensors of ``[B, dim]``."""
+    return [_slice_batched_vector(network, tensor, i * dim, dim) for i in range(chunks)]
+
+
+def _adaln_modulate_batched(network, x, scale, shift, dim, eps_t):
+    """AdaLN: ``LayerNorm(x) * (1 + scale) + shift`` for ``[B, S, D]``."""
+    normed = _layer_norm_last_dim_no_affine_batched(network, x, eps_t)
+
+    scale_3d = network.add_shuffle(scale)
+    scale_3d.reshape_dims = (-1, 1, dim)
+    shift_3d = network.add_shuffle(shift)
+    shift_3d.reshape_dims = (-1, 1, dim)
+
+    one_const = graph_ops.add_constant(network, (1, 1, 1),
+                                       np.array([1.0], dtype=np.float32))
+    scale_plus_1 = network.add_elementwise(
+        one_const, scale_3d.get_output(0),
+        trt.ElementWiseOperation.SUM).get_output(0)
+
+    scaled = network.add_elementwise(normed, scale_plus_1, trt.ElementWiseOperation.PROD)
+    shifted = network.add_elementwise(
+        scaled.get_output(0), shift_3d.get_output(0), trt.ElementWiseOperation.SUM)
+    return shifted.get_output(0)
+
+
+def _layernorm_modulate_batched(network, x, scale, shift, dim, eps_t):
+    """LayerNorm(x) * (1 + scale) + shift for ``[B, S, D]``."""
+    return _adaln_modulate_batched(network, x, scale, shift, dim, eps_t)
+
+
+def _gate_batched(network, x, gate, dim: int):
+    """Gate ``[B, S, D]`` with per-sample gate ``[B, D]``."""
+    gate_3d = network.add_shuffle(gate)
+    gate_3d.reshape_dims = (-1, 1, dim)
+    return network.add_elementwise(
+        x, gate_3d.get_output(0), trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def _build_flux_dit_engine_batched(
+    weights: "WeightDict",
+    *,
+    dim: int,
+    num_heads: int,
+    num_layers: int,
+    num_single_layers: int,
+    num_img_tokens: int,
+    text_seq_len: int,
+    mlp_ratio: float,
+    eps: float,
+    max_batch_size: int,
+    opt_batch_size: int | None,
+    verbose: bool,
+) -> bytes:
+    """Build a dynamic-leading-batch FLUX.1 DiT TRT engine."""
+    from ...engine_builder import add_dynamic_batch_profile
+
+    if max_batch_size < 1:
+        raise ValueError(f"max_batch_size must be >= 1 (got {max_batch_size})")
+    opt_batch = min(max_batch_size, 4) if opt_batch_size is None else opt_batch_size
+
+    head_dim = dim // num_heads
+    ffn_dim = int(dim * mlp_ratio)
+    total_seq = text_seq_len + num_img_tokens
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
+
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    hidden_inp = network.add_input(
+        "hidden_states", trt.float32, (-1, num_img_tokens, dim))
+    encoder_inp = network.add_input(
+        "encoder_hidden_states", trt.float32, (-1, text_seq_len, dim))
+    temb_inp = network.add_input("temb", trt.float32, (-1, dim))
+    rotary_cos = network.add_input("rotary_cos", trt.float32, (-1, total_seq, head_dim))
+    rotary_sin = network.add_input("rotary_sin", trt.float32, (-1, total_seq, head_dim))
+
+    add_dynamic_batch_profile(
+        builder,
+        config,
+        network,
+        input_names=[
+            "hidden_states",
+            "encoder_hidden_states",
+            "temb",
+            "rotary_cos",
+            "rotary_sin",
+        ],
+        max_batch=max_batch_size,
+        opt_batch=opt_batch,
+        static_shape={
+            "hidden_states": (num_img_tokens, dim),
+            "encoder_hidden_states": (text_seq_len, dim),
+            "temb": (dim,),
+            "rotary_cos": (total_seq, head_dim),
+            "rotary_sin": (total_seq, head_dim),
+        },
+    )
+
+    eps_t = graph_ops.add_constant(
+        network, (1, 1, 1), np.array([eps], dtype=np.float32))
+
+    txt_cos = _slice_batched_sequence(network, rotary_cos, 0, text_seq_len, head_dim)
+    txt_sin = _slice_batched_sequence(network, rotary_sin, 0, text_seq_len, head_dim)
+    img_cos = _slice_batched_sequence(network, rotary_cos, text_seq_len,
+                                      num_img_tokens, head_dim)
+    img_sin = _slice_batched_sequence(network, rotary_sin, text_seq_len,
+                                      num_img_tokens, head_dim)
+
+    hidden = hidden_inp
+    encoder_hidden = encoder_inp
+
+    for layer_idx in range(num_layers):
+        p = f"transformer_blocks.{layer_idx}"
+
+        norm1_w = weights[f"{p}.norm1.linear.weight"]
+        norm1_b = weights[f"{p}.norm1.linear.bias"]
+        temb_silu = network.add_activation(temb_inp, trt.ActivationType.SIGMOID)
+        temb_silu_out = network.add_elementwise(
+            temb_inp, temb_silu.get_output(0),
+            trt.ElementWiseOperation.PROD).get_output(0)
+
+        norm1_proj = _matmul_bias_batched(
+            network, temb_silu_out, dim, 6 * dim, norm1_w, norm1_b)
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
+            _chunk_batched(network, norm1_proj, 6, dim))
+        normed_hidden = _adaln_modulate_batched(
+            network, hidden, scale_msa, shift_msa, dim, eps_t)
+
+        ctx_norm1_w = weights[f"{p}.norm1_context.linear.weight"]
+        ctx_norm1_b = weights[f"{p}.norm1_context.linear.bias"]
+        ctx_norm1_proj = _matmul_bias_batched(
+            network, temb_silu_out, dim, 6 * dim, ctx_norm1_w, ctx_norm1_b)
+        c_shift_msa, c_scale_msa, c_gate_msa, c_shift_mlp, c_scale_mlp, c_gate_mlp = (
+            _chunk_batched(network, ctx_norm1_proj, 6, dim))
+        normed_encoder = _adaln_modulate_batched(
+            network, encoder_hidden, c_scale_msa, c_shift_msa, dim, eps_t)
+
+        q_img = _linear(network, normed_hidden, dim, dim, weights, f"{p}.attn.to_q")
+        k_img = _linear(network, normed_hidden, dim, dim, weights, f"{p}.attn.to_k")
+        v_img = _linear(network, normed_hidden, dim, dim, weights, f"{p}.attn.to_v")
+
+        q_txt = _linear(network, normed_encoder, dim, dim, weights, f"{p}.attn.add_q_proj")
+        k_txt = _linear(network, normed_encoder, dim, dim, weights, f"{p}.attn.add_k_proj")
+        v_txt = _linear(network, normed_encoder, dim, dim, weights, f"{p}.attn.add_v_proj")
+
+        q_img = graph_ops.add_rms_norm_per_head_batched(
+            network, q_img, num_heads, head_dim,
+            weights[f"{p}.attn.norm_q.weight"], eps_t,
+            sequence_length=num_img_tokens)
+        k_img = graph_ops.add_rms_norm_per_head_batched(
+            network, k_img, num_heads, head_dim,
+            weights[f"{p}.attn.norm_k.weight"], eps_t,
+            sequence_length=num_img_tokens)
+        q_txt = graph_ops.add_rms_norm_per_head_batched(
+            network, q_txt, num_heads, head_dim,
+            weights[f"{p}.attn.norm_added_q.weight"], eps_t,
+            sequence_length=text_seq_len)
+        k_txt = graph_ops.add_rms_norm_per_head_batched(
+            network, k_txt, num_heads, head_dim,
+            weights[f"{p}.attn.norm_added_k.weight"], eps_t,
+            sequence_length=text_seq_len)
+
+        q_img = _apply_rope_batched_from_full_cache(
+            network, q_img, img_cos, img_sin, num_heads, head_dim, num_img_tokens)
+        k_img = _apply_rope_batched_from_full_cache(
+            network, k_img, img_cos, img_sin, num_heads, head_dim, num_img_tokens)
+        q_txt = _apply_rope_batched_from_full_cache(
+            network, q_txt, txt_cos, txt_sin, num_heads, head_dim, text_seq_len)
+        k_txt = _apply_rope_batched_from_full_cache(
+            network, k_txt, txt_cos, txt_sin, num_heads, head_dim, text_seq_len)
+
+        q_cat = network.add_concatenation([q_txt, q_img])
+        q_cat.axis = 1
+        k_cat = network.add_concatenation([k_txt, k_img])
+        k_cat.axis = 1
+        v_cat = network.add_concatenation([v_txt, v_img])
+        v_cat.axis = 1
+
+        attn_out = _mha_batched(
+            network, q_cat.get_output(0), k_cat.get_output(0), v_cat.get_output(0),
+            num_heads, head_dim, total_seq)
+
+        txt_attn = _slice_batched_sequence(network, attn_out, 0, text_seq_len, dim)
+        img_attn = _slice_batched_sequence(network, attn_out, text_seq_len,
+                                           num_img_tokens, dim)
+
+        img_attn_proj = _linear(network, img_attn, dim, dim, weights, f"{p}.attn.to_out.0")
+        img_attn_gated = _gate_batched(network, img_attn_proj, gate_msa, dim)
+        hidden = network.add_elementwise(
+            hidden, img_attn_gated, trt.ElementWiseOperation.SUM).get_output(0)
+
+        txt_attn_proj = _linear(network, txt_attn, dim, dim, weights,
+                                f"{p}.attn.to_add_out")
+        txt_attn_gated = _gate_batched(network, txt_attn_proj, c_gate_msa, dim)
+        encoder_hidden = network.add_elementwise(
+            encoder_hidden, txt_attn_gated, trt.ElementWiseOperation.SUM).get_output(0)
+
+        normed_ff = _layernorm_modulate_batched(
+            network, hidden, scale_mlp, shift_mlp, dim, eps_t)
+        ff_out = _gelu_ffn(network, normed_ff, dim, weights, f"{p}.ff")
+        ff_gated = _gate_batched(network, ff_out, gate_mlp, dim)
+        hidden = network.add_elementwise(
+            hidden, ff_gated, trt.ElementWiseOperation.SUM).get_output(0)
+
+        normed_ctx_ff = _layernorm_modulate_batched(
+            network, encoder_hidden, c_scale_mlp, c_shift_mlp, dim, eps_t)
+        ctx_ff_out = _gelu_ffn(network, normed_ctx_ff, dim, weights, f"{p}.ff_context")
+        ctx_ff_gated = _gate_batched(network, ctx_ff_out, c_gate_mlp, dim)
+        encoder_hidden = network.add_elementwise(
+            encoder_hidden, ctx_ff_gated, trt.ElementWiseOperation.SUM).get_output(0)
+
+    for layer_idx in range(num_single_layers):
+        p = f"single_transformer_blocks.{layer_idx}"
+
+        cat_hidden = network.add_concatenation([encoder_hidden, hidden])
+        cat_hidden.axis = 1
+        residual = cat_hidden.get_output(0)
+
+        norm_w = weights[f"{p}.norm.linear.weight"]
+        norm_b = weights[f"{p}.norm.linear.bias"]
+        temb_silu2 = network.add_activation(temb_inp, trt.ActivationType.SIGMOID)
+        temb_silu2_out = network.add_elementwise(
+            temb_inp, temb_silu2.get_output(0),
+            trt.ElementWiseOperation.PROD).get_output(0)
+
+        norm_proj = _matmul_bias_batched(
+            network, temb_silu2_out, dim, 3 * dim, norm_w, norm_b)
+        shift_msa_s, scale_msa_s, gate_msa_s = _chunk_batched(network, norm_proj, 3, dim)
+        normed_cat = _adaln_modulate_batched(
+            network, residual, scale_msa_s, shift_msa_s, dim, eps_t)
+
+        mlp_hidden = graph_ops.add_matmul_rhs_constant(
+            network, normed_cat, dim, ffn_dim, weights[f"{p}.proj_mlp.weight"])
+        mlp_b = weights.get(f"{p}.proj_mlp.bias")
+        if mlp_b is not None:
+            mlp_hidden = graph_ops.add_bias_sum(network, mlp_hidden, ffn_dim, mlp_b)
+        mlp_hidden = graph_ops.add_gelu_tanh(network, mlp_hidden)
+
+        q_s = _linear(network, normed_cat, dim, dim, weights, f"{p}.attn.to_q")
+        k_s = _linear(network, normed_cat, dim, dim, weights, f"{p}.attn.to_k")
+        v_s = _linear(network, normed_cat, dim, dim, weights, f"{p}.attn.to_v")
+
+        q_s = graph_ops.add_rms_norm_per_head_batched(
+            network, q_s, num_heads, head_dim,
+            weights[f"{p}.attn.norm_q.weight"], eps_t,
+            sequence_length=total_seq)
+        k_s = graph_ops.add_rms_norm_per_head_batched(
+            network, k_s, num_heads, head_dim,
+            weights[f"{p}.attn.norm_k.weight"], eps_t,
+            sequence_length=total_seq)
+
+        q_s = _apply_rope_batched_from_full_cache(
+            network, q_s, rotary_cos, rotary_sin, num_heads, head_dim, total_seq)
+        k_s = _apply_rope_batched_from_full_cache(
+            network, k_s, rotary_cos, rotary_sin, num_heads, head_dim, total_seq)
+
+        attn_out_s = _mha_batched(network, q_s, k_s, v_s, num_heads, head_dim, total_seq)
+
+        cat_attn_mlp = network.add_concatenation([attn_out_s, mlp_hidden])
+        cat_attn_mlp.axis = 2
+
+        proj_out_w = weights[f"{p}.proj_out.weight"]
+        in_features = dim + ffn_dim
+        combined = graph_ops.add_matmul_rhs_constant(
+            network, cat_attn_mlp.get_output(0), in_features, dim, proj_out_w)
+        proj_out_b = weights.get(f"{p}.proj_out.bias")
+        if proj_out_b is not None:
+            combined = graph_ops.add_bias_sum(network, combined, dim, proj_out_b)
+
+        gated_s = _gate_batched(network, combined, gate_msa_s, dim)
+        cat_hidden_out = network.add_elementwise(
+            residual, gated_s, trt.ElementWiseOperation.SUM).get_output(0)
+
+        encoder_hidden = _slice_batched_sequence(
+            network, cat_hidden_out, 0, text_seq_len, dim)
+        hidden = _slice_batched_sequence(
+            network, cat_hidden_out, text_seq_len, num_img_tokens, dim)
+
+    final_norm_w = weights["norm_out.linear.weight"]
+    final_norm_b = weights["norm_out.linear.bias"]
+
+    temb_silu_f = network.add_activation(temb_inp, trt.ActivationType.SIGMOID)
+    temb_silu_f_out = network.add_elementwise(
+        temb_inp, temb_silu_f.get_output(0),
+        trt.ElementWiseOperation.PROD).get_output(0)
+
+    final_proj = _matmul_bias_batched(
+        network, temb_silu_f_out, dim, 2 * dim, final_norm_w, final_norm_b)
+    final_scale = _slice_batched_vector(network, final_proj, 0, dim)
+    final_shift = _slice_batched_vector(network, final_proj, dim, dim)
+
+    output = _adaln_modulate_batched(
+        network, hidden, final_scale, final_shift, dim, eps_t)
+
+    proj_out_w = weights["proj_out.weight"]
+    out_channels = proj_out_w.shape[1]
+    output = graph_ops.add_matmul_rhs_constant(
+        network, output, dim, out_channels, proj_out_w)
+    proj_out_b = weights.get("proj_out.bias")
+    if proj_out_b is not None:
+        output = graph_ops.add_bias_sum(network, output, out_channels, proj_out_b)
+
+    cast_output = network.add_cast(output, trt.float32)
+    output_final = cast_output.get_output(0)
+    output_final.name = "output"
+    network.mark_output(output_final)
+
+    print(f"[flux-dit] Building dynamic-batch TRT engine "
+          f"(B=1..{max_batch_size}, opt={opt_batch}, dim={dim}, "
+          f"joint={num_layers}, single={num_single_layers}, "
+          f"img_tokens={num_img_tokens}, text_seq={text_seq_len}) ...",
+          file=sys.stderr)
+
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError("TRT engine serialization failed for dynamic-batch FLUX DiT")
+    return bytes(plan)
 
 
 def load_flux_dit_weights(

--- a/python/tensorrt_model_connect/families/flux/flux_vae_builder.py
+++ b/python/tensorrt_model_connect/families/flux/flux_vae_builder.py
@@ -376,6 +376,11 @@ def _add_self_attention_2d(
     hw = h * w
     attn_scale = 1.0 / np.sqrt(max(c, 1))
     identity = inp
+    # When ``b`` is a runtime-dynamic ``-1`` we must let TRT infer the merged
+    # batch*spatial leading dim via a single ``-1`` placeholder; ``b * hw``
+    # would produce ``-hw``, which TRT refuses.
+    dynamic_leading = b == -1
+    flat_leading = -1 if dynamic_leading else b * hw
 
     # GroupNorm
     normed = _add_group_norm_4d(
@@ -386,7 +391,7 @@ def _add_self_attention_2d(
     # Reshape [B, C, H, W] -> [B*H*W, C] (2D for matmul compatibility)
     flatten = network.add_shuffle(normed)
     flatten.first_transpose = trt.Permutation([0, 2, 3, 1])  # [B, H, W, C]
-    flatten.reshape_dims = (b * hw, c)
+    flatten.reshape_dims = (flat_leading, c)
 
     flat = flatten.get_output(0)  # [B*HW, C]
 
@@ -423,7 +428,7 @@ def _add_self_attention_2d(
 
     # Flatten context to 2D for output projection: [B*HW, C]
     ctx_flat = network.add_shuffle(context)
-    ctx_flat.reshape_dims = (b * hw, c)
+    ctx_flat.reshape_dims = (flat_leading, c)
 
     # Output projection: [B*HW, C] @ [C, C] -> [B*HW, C]
     out_w = weights[f"{prefix}.to_out.0.weight"].reshape(c, c)
@@ -482,14 +487,16 @@ def build_flux_vae_decoder_engine(
     scaling_factor: float = 0.3611,
     shift_factor: float = 0.1159,
     patch_size: tuple[int, int] = (1, 1),
+    max_batch_size: int = 1,
+    opt_batch_size: int | None = None,
     verbose: bool = False,
     build_timing: dict | None = None,
     timing_component: str = "vae_decoder",
 ) -> bytes:
     """Build FLUX AutoencoderKL decoder TRT engine using TRT Python API.
 
-    Input:  latents [1, latent_channels, h_lat, w_lat] float32
-    Output: image   [1, 3, h_lat*8*patch_h, w_lat*8*patch_w] float32
+    Input:  latents [B, latent_channels, h_lat, w_lat] float32
+    Output: image   [B, 3, h_lat*8*patch_h, w_lat*8*patch_w] float32
 
     For patch_size=(1,1) (FLUX.1): standard 8x spatial upsampling.
     For patch_size=(2,2) (FLUX.2): decoder conv_out produces C*ph*pw channels,
@@ -497,7 +504,16 @@ def build_flux_vae_decoder_engine(
 
     The engine applies: x = latents / scaling_factor + shift_factor,
     then runs through the full decoder network.
+
+    When ``max_batch_size > 1`` the leading batch dim of ``latents`` is
+    dynamic (``-1``) so the runtime binding is uniform with the other
+    diffusion components. Per design Decision E, the VAE *always* caps at
+    ``max_batch = opt_batch = 1`` and the pipeline loops one latent at a time
+    (peak-memory bound). ``max_batch_size == 1`` (the default) preserves the
+    legacy static-shape engine byte-for-byte.
     """
+    if max_batch_size < 1:
+        raise ValueError(f"max_batch_size must be >= 1 (got {max_batch_size})")
     from ...build_timing import timed_weight_loading
 
     total_t0 = time.monotonic()
@@ -532,8 +548,28 @@ def build_flux_vae_decoder_engine(
     config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
 
     # --- Input ---
-    latents = network.add_input(
-        "latents", trt.float32, (1, latent_channels, h_lat, w_lat))
+    # When dynamic batching is enabled the leading dim is ``-1`` even though
+    # the profile clamps both kMIN/kOPT/kMAX to 1 (Decision E). This keeps the
+    # binding shape uniform across all diffusion components — the runtime
+    # treats every dim 0 as dynamic and only the VAE attaches a (1, 1, 1)
+    # profile.
+    if max_batch_size > 1:
+        from ...engine_builder import add_dynamic_batch_profile
+
+        latents = network.add_input(
+            "latents", trt.float32, (-1, latent_channels, h_lat, w_lat))
+        add_dynamic_batch_profile(
+            builder,
+            config,
+            network,
+            input_names=["latents"],
+            max_batch=1,  # VAE always caps at 1 — Decision E.
+            opt_batch=1,
+            static_shape={"latents": (latent_channels, h_lat, w_lat)},
+        )
+    else:
+        latents = network.add_input(
+            "latents", trt.float32, (1, latent_channels, h_lat, w_lat))
 
     # --- Scaling transform: x = latents / scaling_factor + shift_factor ---
     scale_t = network.add_constant(
@@ -635,20 +671,26 @@ def build_flux_vae_decoder_engine(
 
     # --- Unpatchify (pixel shuffle) for patched VAEs ---
     if patch_h > 1 or patch_w > 1:
-        # conv_out produces [1, out_ch * ph * pw, H, W]
-        # Unpatchify to [1, out_ch, H * ph, W * pw]
+        # conv_out produces [B, out_ch * ph * pw, H, W]
+        # Unpatchify to [B, out_ch, H * ph, W * pw]
         out_ch = conv_out_channels // (patch_h * patch_w)
+        # ``-1`` propagates the (possibly dynamic) batch dim through both
+        # shuffles — see the comment on ``flat_leading`` in
+        # ``_add_self_attention_2d`` for why we cannot substitute the static
+        # value ``1`` here.
+        leading = -1 if x.shape[0] == -1 else x.shape[0]
 
-        # Reshape: [1, out_ch, ph, pw, H, W]
+        # Reshape: [B, out_ch, ph, pw, H, W]
         reshape1 = network.add_shuffle(x)
-        reshape1.reshape_dims = (1, out_ch, patch_h, patch_w, cur_h, cur_w)
+        reshape1.reshape_dims = (leading, out_ch, patch_h, patch_w, cur_h, cur_w)
 
-        # Transpose: [1, out_ch, H, ph, W, pw]
+        # Transpose: [B, out_ch, H, ph, W, pw]
         reshape1.second_transpose = trt.Permutation([0, 1, 4, 2, 5, 3])
 
-        # Reshape: [1, out_ch, H * ph, W * pw]
+        # Reshape: [B, out_ch, H * ph, W * pw]
         reshape2 = network.add_shuffle(reshape1.get_output(0))
-        reshape2.reshape_dims = (1, out_ch, cur_h * patch_h, cur_w * patch_w)
+        reshape2.reshape_dims = (
+            leading, out_ch, cur_h * patch_h, cur_w * patch_w)
         x = reshape2.get_output(0)
 
         print(f"[flux-vae] unpatchify: [{conv_out_channels},{cur_h},{cur_w}] -> "

--- a/python/tensorrt_model_connect/families/flux/t5_encoder_builder.py
+++ b/python/tensorrt_model_connect/families/flux/t5_encoder_builder.py
@@ -39,6 +39,8 @@ def build_t5_encoder_engine(
     relative_attention_num_buckets: int = 32,
     relative_attention_max_distance: int = 128,
     eps: float = 1e-6,
+    max_batch_size: int = 1,
+    opt_batch_size: int | None = None,
     verbose: bool = False,
 ) -> bytes:
     """Build T5 encoder TRT engine plan.
@@ -62,11 +64,38 @@ def build_t5_encoder_engine(
         relative_attention_num_buckets: T5 relative position bias buckets.
         relative_attention_max_distance: Max distance for relative position.
         eps: RMSNorm epsilon.
+        max_batch_size: Maximum runtime batch size. ``1`` (default) preserves
+            the legacy static-shape engine byte-for-byte. ``>1`` enables a
+            dynamic leading batch dim via a single TRT optimization profile
+            covering ``[1, max_batch_size]`` (design Decision C, default
+            cap is 8 for text encoders).
+        opt_batch_size: Profile ``kOPT``. Defaults to ``min(max_batch_size,
+            4)``; only consulted when ``max_batch_size > 1``.
         verbose: Enable TRT builder verbose logging.
 
     Returns:
         Serialized TRT engine plan bytes.
     """
+    if max_batch_size < 1:
+        raise ValueError(f"max_batch_size must be >= 1 (got {max_batch_size})")
+    if max_batch_size > 1:
+        return _build_t5_encoder_engine_batched(
+            weights,
+            d_model=d_model,
+            num_heads=num_heads,
+            d_kv=d_kv,
+            d_ff=d_ff,
+            num_layers=num_layers,
+            vocab_size=vocab_size,
+            max_seq_len=max_seq_len,
+            relative_attention_num_buckets=relative_attention_num_buckets,
+            relative_attention_max_distance=relative_attention_max_distance,
+            eps=eps,
+            max_batch_size=max_batch_size,
+            opt_batch_size=opt_batch_size,
+            verbose=verbose,
+        )
+
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
@@ -239,6 +268,216 @@ def build_t5_encoder_engine(
     if plan is None:
         raise RuntimeError("TRT engine serialization failed for T5 encoder")
     return bytes(plan)
+
+
+# ============================================================================
+# Dynamic-batch path
+# ============================================================================
+#
+# When ``max_batch_size > 1`` we build a separate engine where every input
+# carries a leading dynamic batch dim and a single
+# :class:`IOptimizationProfile` spans ``[1, max_batch_size]`` with
+# ``kOPT = min(max_batch_size, 4)`` (design Decisions A and C). The legacy
+# static-shape path above is left untouched so ``max_batch_size == 1`` stays
+# byte-for-byte identical.
+
+def _build_t5_encoder_engine_batched(
+    weights: WeightDict,
+    *,
+    d_model: int,
+    num_heads: int,
+    d_kv: int,
+    d_ff: int,
+    num_layers: int,
+    vocab_size: int,
+    max_seq_len: int,
+    relative_attention_num_buckets: int,
+    relative_attention_max_distance: int,
+    eps: float,
+    max_batch_size: int,
+    opt_batch_size: int | None,
+    verbose: bool,
+) -> bytes:
+    """Build a dynamic-leading-batch T5 encoder TRT engine."""
+    from ...engine_builder import add_dynamic_batch_profile
+
+    opt_batch = min(max_batch_size, 4) if opt_batch_size is None else opt_batch_size
+
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+
+    # --- Inputs (dynamic leading batch dim) ---
+    input_ids = network.add_input("input_ids", trt.int32, (-1, max_seq_len))
+    attention_mask_input = network.add_input(
+        "attention_mask", trt.float32, (-1, max_seq_len))
+
+    add_dynamic_batch_profile(
+        builder,
+        config,
+        network,
+        input_names=["input_ids", "attention_mask"],
+        max_batch=max_batch_size,
+        opt_batch=opt_batch,
+        static_shape={
+            "input_ids": (max_seq_len,),
+            "attention_mask": (max_seq_len,),
+        },
+    )
+
+    # --- Constants ---
+    eps_t = graph_ops.add_constant(
+        network, (1, 1, 1), np.array([eps], dtype=np.float32))
+
+    # Embedding table [vocab_size, d_model]; gather over [B, S] -> [B, S, d_model]
+    embed_table = graph_ops.add_constant(
+        network, (vocab_size, d_model), weights["shared.weight"])
+
+    gather = network.add_gather(embed_table, input_ids, 0)
+    hidden = gather.get_output(0)  # [B, S, d_model]
+
+    # --- Relative position bias (constant across batch) ---
+    bucket_indices = graph_ops.make_t5_relative_position_bias(
+        num_heads, max_seq_len,
+        num_buckets=relative_attention_num_buckets,
+        max_distance=relative_attention_max_distance,
+    )
+
+    # Attention mask: [B, S] -> [B, 1, 1, S] for broadcast over heads & queries.
+    attn_mask_4d = network.add_shuffle(attention_mask_input)
+    attn_mask_4d.reshape_dims = (-1, 1, 1, max_seq_len)
+    attn_mask = attn_mask_4d.get_output(0)
+
+    per_layer_bias = []
+    for layer_idx in range(num_layers):
+        bias_key = (f"encoder.block.{layer_idx}.layer.0.SelfAttention."
+                    f"relative_attention_bias.weight")
+        if bias_key in weights:
+            rel_bias_weight = weights[bias_key]
+        else:
+            rel_bias_weight = weights[
+                "encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight"]
+
+        bias_table = np.zeros(
+            (num_heads, max_seq_len, max_seq_len), dtype=np.float32)
+        for q_pos in range(max_seq_len):
+            for k_pos in range(max_seq_len):
+                bucket = bucket_indices[q_pos, k_pos]
+                for h in range(num_heads):
+                    bias_table[h, q_pos, k_pos] = rel_bias_weight[bucket, h]
+
+        # Constant [1, num_heads, S, S] broadcasts cleanly across batch.
+        rel_bias_const = graph_ops.add_constant(
+            network, (1, num_heads, max_seq_len, max_seq_len),
+            bias_table.reshape(1, num_heads, max_seq_len, max_seq_len))
+        # Combine constant position bias with per-sample padding mask.
+        position_bias_masked = network.add_elementwise(
+            rel_bias_const, attn_mask, trt.ElementWiseOperation.SUM)
+        per_layer_bias.append(position_bias_masked.get_output(0))
+
+    attention_size = num_heads * d_kv
+
+    for layer_idx in range(num_layers):
+        prefix = f"encoder.block.{layer_idx}"
+
+        # === Self-attention ===
+        norm1_gamma = weights[f"{prefix}.layer.0.layer_norm.weight"]
+        normed = graph_ops.add_rms_norm_last_dim(
+            network, hidden, d_model, norm1_gamma, eps_t)
+
+        w_q = weights[f"{prefix}.layer.0.SelfAttention.q.weight"]
+        w_k = weights[f"{prefix}.layer.0.SelfAttention.k.weight"]
+        w_v = weights[f"{prefix}.layer.0.SelfAttention.v.weight"]
+        w_o = weights[f"{prefix}.layer.0.SelfAttention.o.weight"]
+
+        q = graph_ops.add_matmul_rhs_constant(
+            network, normed, d_model, attention_size, w_q)
+        k = graph_ops.add_matmul_rhs_constant(
+            network, normed, d_model, attention_size, w_k)
+        v = graph_ops.add_matmul_rhs_constant(
+            network, normed, d_model, attention_size, w_v)
+
+        # [B, S, H*D] -> [B, H, S, D] for IAttention
+        q_4d = _to_heads_4d_batched(network, q, num_heads, d_kv, max_seq_len)
+        k_4d = _to_heads_4d_batched(network, k, num_heads, d_kv, max_seq_len)
+        v_4d = _to_heads_4d_batched(network, v, num_heads, d_kv, max_seq_len)
+
+        # T5 attention is unscaled; mask carries the only score adjustments.
+        ctx_4d = graph_ops.add_attention_core(
+            network, q_4d, k_4d, v_4d, causal=False,
+            mask=per_layer_bias[layer_idx], scale=1.0)
+        context_flat = _to_rows_3d_batched(
+            network, ctx_4d, num_heads, d_kv, max_seq_len)
+
+        attn_out = graph_ops.add_matmul_rhs_constant(
+            network, context_flat, attention_size, d_model, w_o)
+
+        hidden = network.add_elementwise(
+            hidden, attn_out, trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === FFN ===
+        norm2_gamma = weights[f"{prefix}.layer.1.layer_norm.weight"]
+        ffn_normed = graph_ops.add_rms_norm_last_dim(
+            network, hidden, d_model, norm2_gamma, eps_t)
+
+        w_fc1 = weights[f"{prefix}.layer.1.DenseReluDense.wi_0.weight"]
+        w_fc1_gate = weights[f"{prefix}.layer.1.DenseReluDense.wi_1.weight"]
+        w_fc2 = weights[f"{prefix}.layer.1.DenseReluDense.wo.weight"]
+
+        fc1 = graph_ops.add_matmul_rhs_constant(
+            network, ffn_normed, d_model, d_ff, w_fc1)
+        fc1_gate = graph_ops.add_matmul_rhs_constant(
+            network, ffn_normed, d_model, d_ff, w_fc1_gate)
+
+        activated = graph_ops.add_gelu_new(network, fc1)
+        gated = network.add_elementwise(
+            activated, fc1_gate, trt.ElementWiseOperation.PROD)
+
+        ffn_out = graph_ops.add_matmul_rhs_constant(
+            network, gated.get_output(0), d_ff, d_model, w_fc2)
+
+        hidden = network.add_elementwise(
+            hidden, ffn_out, trt.ElementWiseOperation.SUM).get_output(0)
+
+    # --- Final norm ---
+    final_norm_gamma = weights["encoder.final_layer_norm.weight"]
+    hidden = graph_ops.add_rms_norm_last_dim(
+        network, hidden, d_model, final_norm_gamma, eps_t)
+
+    # --- Output ---
+    cast_out = network.add_cast(hidden, trt.float32)
+    out_final = cast_out.get_output(0)
+    out_final.name = "text_embeddings"
+    network.mark_output(out_final)
+
+    print(f"[t5-encoder] Building dynamic-batch TRT engine "
+          f"(B=1..{max_batch_size}, opt={opt_batch}, d_model={d_model}, "
+          f"layers={num_layers}, seq={max_seq_len}) ...",
+          file=sys.stderr)
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError(
+            "TRT engine serialization failed for dynamic-batch T5 encoder")
+    return bytes(plan)
+
+
+def _to_heads_4d_batched(network, x, num_heads: int, head_dim: int, seq_len: int):
+    """``[B, S, H*D]`` -> ``[B, H, S, D]``."""
+    r = network.add_shuffle(x)
+    r.reshape_dims = (-1, seq_len, num_heads, head_dim)
+    r.second_transpose = trt.Permutation([0, 2, 1, 3])
+    return r.get_output(0)
+
+
+def _to_rows_3d_batched(network, x, num_heads: int, head_dim: int, seq_len: int):
+    """``[B, H, S, D]`` -> ``[B, S, H*D]``."""
+    r = network.add_shuffle(x)
+    r.first_transpose = trt.Permutation([0, 2, 1, 3])
+    r.reshape_dims = (-1, seq_len, num_heads * head_dim)
+    return r.get_output(0)
 
 
 def load_t5_weights(

--- a/python/tensorrt_model_connect/families/pixart/vae_2d_builder.py
+++ b/python/tensorrt_model_connect/families/pixart/vae_2d_builder.py
@@ -354,6 +354,8 @@ def build_vae_2d_decoder_engine(
     verbose: bool = False,
     build_timing: dict | None = None,
     timing_component: str = "vae_decoder",
+    max_batch_size: int = 1,
+    opt_batch_size: int | None = None,
 ) -> bytes:
     """Build a TRT engine for AutoencoderKL decoder using the TensorRT Python API.
 
@@ -365,7 +367,22 @@ def build_vae_2d_decoder_engine(
 
     Input tensor:  "latent_input"    [1, latent_channels, h_lat, w_lat]
     Output tensor: "decoder_output"  [1, 3, h_out, w_out]
+
+    Per design Decision E the VAE always slices at ``max_batch=1`` even when
+    a dynamic-batch profile is attached; the pipeline loops sequential B=1
+    forwards for B>1 outputs. ``max_batch_size`` is accepted so the wider
+    builder API is uniform across components; values >1 still produce a
+    profile capped at 1 here (and the leading dim becomes dynamic ``-1``
+    so the runtime can bind shape ``(1, C, H, W)`` against the engine).
     """
+    if max_batch_size < 1:
+        raise ValueError(f"max_batch_size must be >= 1 (got {max_batch_size})")
+    # Decision E: VAE always caps at 1 regardless of the requested ceiling.
+    vae_max_batch = 1
+    if opt_batch_size is None:
+        opt_batch_size = vae_max_batch
+    dynamic_batch = max_batch_size > 1
+
     from tensorrt_model_connect import trt_compat
     trt = trt_compat.get_trt()
     from ...graph_ops import add_conv2d, add_silu
@@ -392,9 +409,17 @@ def build_vae_2d_decoder_engine(
     config = builder.create_builder_config()
     config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 16 << 30)
 
-    # Input
-    inp = network.add_input("latent_input", trt.float32,
-                            (1, latent_channels, h_lat, w_lat))
+    # Input. Static-batch path keeps the original ``[1, C, H, W]`` shape;
+    # dynamic-batch path turns the leading dim into ``-1`` so the runtime
+    # can bind ``(1, C, H, W)`` against the engine (Decision E pins the
+    # actual VAE cap at 1, but the input is still declared dynamic for
+    # parity with the other components).
+    if dynamic_batch:
+        inp = network.add_input("latent_input", trt.float32,
+                                (-1, latent_channels, h_lat, w_lat))
+    else:
+        inp = network.add_input("latent_input", trt.float32,
+                                (1, latent_channels, h_lat, w_lat))
 
     # post_quant_conv: Conv2d(latent_channels, latent_channels, 1x1)
     # Applied before the decoder in AutoencoderKL.decode().
@@ -492,7 +517,20 @@ def build_vae_2d_decoder_engine(
     x_out.name = "decoder_output"
     network.mark_output(x_out)
 
-    print("[vae-2d] Building TRT engine ...", file=sys.stderr)
+    if dynamic_batch:
+        from ...engine_builder import add_dynamic_batch_profile
+        add_dynamic_batch_profile(
+            builder, config, network,
+            input_names=["latent_input"],
+            max_batch=vae_max_batch,
+            opt_batch=opt_batch_size,
+            static_shape={
+                "latent_input": (latent_channels, h_lat, w_lat),
+            },
+        )
+
+    print(f"[vae-2d] Building TRT engine (max_batch={vae_max_batch}) ...",
+          file=sys.stderr)
     plan = builder.build_serialized_network(network, config)
     if plan is None:
         raise RuntimeError("TRT engine build failed for VAE decoder")

--- a/python/tensorrt_model_connect/families/qwen_image/qwen25_vl_text_encoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen_image/qwen25_vl_text_encoder_builder.py
@@ -323,6 +323,8 @@ def build_qwen25vl_text_encoder_engine(
     image_grid_thw: tuple[int, int, int] | None = None,
     vision_spatial_merge_size: int = 2,
     vision_tokens_per_second: int = 2,
+    max_batch_size: int = 1,
+    opt_batch_size: int | None = None,
     verbose: bool = False,
 ) -> Path:
     """Build the TRT engine and serialize the plan to ``out_path``.
@@ -356,11 +358,34 @@ def build_qwen25vl_text_encoder_engine(
             used to build the static vision/text plan.
         vision_spatial_merge_size: Qwen2.5-VL spatial merge size.
         vision_tokens_per_second: Qwen2.5-VL temporal mRoPE scale.
+        max_batch_size: Maximum prompt batch size the engine should accept.
+            When ``1`` (default) the engine is byte-for-byte identical to the
+            pre-batch build (engine inputs are ``[max_seq_len]``). When ``>1``
+            the engine inputs gain a dynamic leading batch dim
+            ``[-1, max_seq_len]`` with a TensorRT optimization profile of
+            ``kMIN=1, kOPT=opt_batch_size, kMAX=max_batch_size``. Per the
+            diffusion batch-inference design (Decision C, 2026-05-19) the
+            text encoder caps at 8 for Qwen-Image.
+        opt_batch_size: Optimization-profile ``kOPT`` for the dynamic batch
+            dim. Ignored when ``max_batch_size==1``. Defaults to
+            ``min(max_batch_size, 4)`` to match the N-of-best UX target.
         verbose: Enable TRT verbose logging.
 
     Returns:
         Resolved ``Path`` to the written plan file.
+
+    Notes:
+        The internal compute graph still assumes a rank-1 ``[max_seq_len]``
+        layout; the batched-graph rewrite lives in a follow-up. ``max_batch_size
+        > 1`` is currently wired through the builder signature and the
+        dynamic-batch profile, but a full bf16 batched compute path is
+        deferred. Tests monkeypatch TRT so they exercise the wiring rather
+        than the full graph.
     """
+    if max_batch_size < 1:
+        raise ValueError(
+            f"max_batch_size must be >= 1 (got {max_batch_size})"
+        )
     out_path = Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -399,14 +424,47 @@ def build_qwen25vl_text_encoder_engine(
     max_S = cfg.max_seq_len
 
     # ---- Engine inputs (stay fp32 -- C++ runtime / debug runner bind fp32). ----
-    input_ids = network.add_input("input_ids", trt.int32, (max_S,))
-    attn_mask_1d = network.add_input("attention_mask", trt.float32, (max_S,))
+    # When ``max_batch_size > 1`` the leading dim becomes dynamic via a TRT
+    # optimization profile; otherwise the engine keeps the rank-1 shape that
+    # the pre-batch path used so old bundles/build callers behave identically.
+    # Edit-mode `image_hidden` / `image_mask` keep their rank-2/rank-1 shapes
+    # — Edit-mode batching is a follow-up.
+    use_dynamic_batch = max_batch_size > 1
+    if use_dynamic_batch:
+        input_ids = network.add_input("input_ids", trt.int32, (-1, max_S))
+        attn_mask_1d = network.add_input(
+            "attention_mask", trt.float32, (-1, max_S))
+    else:
+        input_ids = network.add_input("input_ids", trt.int32, (max_S,))
+        attn_mask_1d = network.add_input(
+            "attention_mask", trt.float32, (max_S,))
     image_hidden = None
     image_mask_1d = None
     if enable_image_inputs:
         image_hidden = network.add_input(
             "image_hidden", trt.float32, (max_S, cfg.hidden_size))
         image_mask_1d = network.add_input("image_mask", trt.float32, (max_S,))
+
+    if use_dynamic_batch:
+        # Diffusion batch-inference RFC, Decision C: kMIN=1, kOPT=min(N,4),
+        # kMAX=N. Single wide profile per component (Decision A).
+        from ...engine_builder import add_dynamic_batch_profile
+
+        opt_batch = (
+            min(max_batch_size, 4) if opt_batch_size is None else opt_batch_size
+        )
+        add_dynamic_batch_profile(
+            builder,
+            trt_config,
+            network,
+            input_names=["input_ids", "attention_mask"],
+            max_batch=max_batch_size,
+            opt_batch=opt_batch,
+            static_shape={
+                "input_ids": (max_S,),
+                "attention_mask": (max_S,),
+            },
+        )
 
     # ---- Shared constants. ----
     # eps stored in work dtype so it doesn't constantly need upcasting.

--- a/python/tensorrt_model_connect/families/qwen_image/qwen_image_dit_builder.py
+++ b/python/tensorrt_model_connect/families/qwen_image/qwen_image_dit_builder.py
@@ -1812,6 +1812,8 @@ def build_qwen_image_dit_engine(
     n_text: int,
     image_token_shapes: list[tuple[int, int]] | None = None,
     batch_size: int = 1,
+    max_batch_size: int = 1,
+    opt_batch_size: int | None = None,
     verbose: bool = False,
 ) -> Path:
     """Build the full Qwen-Image MMDiT denoiser as a single TRT engine.
@@ -1821,7 +1823,7 @@ def build_qwen_image_dit_engine(
     ``txt_in``, ``time_text_embed``, final ``AdaLayerNormContinuous``,
     ``proj_out``).
 
-    Engine inputs (fp32, all static shapes):
+    Engine inputs (fp32):
       ``img_patched`` [B, N_img, in_channels]
           packed-patch latents (already produced by the patchify engine /
           diffusers pack_latents). For Qwen-Image: in_channels = 64.
@@ -1834,6 +1836,13 @@ def build_qwen_image_dit_engine(
       ``timestep``  [B]
           diffusion timestep (fp32; will be cast/multiplied by ``scale=1000``
           inside the sinusoidal embedding, matching diffusers).
+
+    When ``max_batch_size == 1`` every input has a statically baked leading
+    dim of 1 (byte-for-byte identical to the pre-batch build). When
+    ``max_batch_size > 1`` the leading dim is replaced with ``-1`` and a
+    TensorRT optimization profile attaches with
+    ``kMIN=1, kOPT=opt_batch_size, kMAX=max_batch_size`` per design Decisions
+    A and C (2026-05-19).
 
     Engine output (fp32):
       ``noise_patched`` [B, N_img, out_channels * patch_size**2]
@@ -1850,12 +1859,26 @@ def build_qwen_image_dit_engine(
     Real Qwen-Image-2512 weights load via the diffusers state-dict keys
     (no remapping); see ``_validate_full_weights`` for the full key list.
 
+    Args:
+        batch_size: Legacy static-batch knob retained for backwards
+            compatibility with existing callers that drove a fixed B>1
+            engine. Prefer ``max_batch_size`` for the dynamic-profile path.
+            When both default to 1 the build is byte-for-byte identical to
+            today's behavior.
+        max_batch_size: Maximum DiT batch the engine should accept. Drives
+            the dynamic optimization profile when ``>1`` (Decisions A and C).
+            Per Decision C the Qwen-Image DiT cap is 4.
+        opt_batch_size: ``kOPT`` for the dynamic batch dim. Ignored when
+            ``max_batch_size==1``. Defaults to ``min(max_batch_size, 4)``.
+
     Returns the path to the written serialised plan.
     """
-    if batch_size != 1:
-        raise NotImplementedError(
-            "build_qwen_image_dit_engine currently supports batch_size=1 only"
+    if max_batch_size < 1:
+        raise ValueError(
+            f"max_batch_size must be >= 1 (got {max_batch_size})"
         )
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1 (got {batch_size})")
     if cfg.num_attention_heads * cfg.attention_head_dim != cfg.hidden_size:
         raise ValueError(
             f"hidden_size ({cfg.hidden_size}) != num_heads ({cfg.num_attention_heads}) "
@@ -1903,13 +1926,44 @@ def build_qwen_image_dit_engine(
 
     builder, config, network = _make_builder(verbose)
 
+    # When ``max_batch_size > 1`` we expose a dynamic leading batch dim via a
+    # TensorRT optimization profile (design Decision A: one wide profile per
+    # component). Otherwise the engine remains statically batched at
+    # ``batch_size`` (today's behavior). The internal compute graph still
+    # uses the static ``batch_size`` everywhere it bakes a shape — full
+    # dynamic-batch correctness for the inner blocks is a Phase 1.5 follow-up
+    # (see RFC 2026-05-11). The profile call below is the source of truth
+    # for the engine's batch envelope.
+    use_dynamic_batch = max_batch_size > 1
+    input_batch = -1 if use_dynamic_batch else batch_size
+
     img_patched = network.add_input(
-        "img_patched", trt.float32, (batch_size, n_img, in_ch),
+        "img_patched", trt.float32, (input_batch, n_img, in_ch),
     )
     txt_hidden = network.add_input(
-        "txt_hidden", trt.float32, (batch_size, n_text, txt_d),
+        "txt_hidden", trt.float32, (input_batch, n_text, txt_d),
     )
-    timestep = network.add_input("timestep", trt.float32, (batch_size,))
+    timestep = network.add_input("timestep", trt.float32, (input_batch,))
+
+    if use_dynamic_batch:
+        from ...engine_builder import add_dynamic_batch_profile
+
+        opt_batch = (
+            min(max_batch_size, 4) if opt_batch_size is None else opt_batch_size
+        )
+        add_dynamic_batch_profile(
+            builder,
+            config,
+            network,
+            input_names=["img_patched", "txt_hidden", "timestep"],
+            max_batch=max_batch_size,
+            opt_batch=opt_batch,
+            static_shape={
+                "img_patched": (n_img, in_ch),
+                "txt_hidden": (n_text, txt_d),
+                "timestep": (),
+            },
+        )
 
     # ----- img_in: Linear(in_ch -> hidden) over [B, N_img, in_ch].
     img_in_w = np.asarray(weights["img_in.weight"], dtype=np.float32)
@@ -1995,14 +2049,17 @@ def build_qwen_image_dit_engine(
     noise.name = "noise_patched"
     network.mark_output(noise)
 
+    b_label = (
+        f"1..{max_batch_size}" if use_dynamic_batch else str(batch_size)
+    )
     print(
         f"[qwen-image-dit] Building full denoiser engine "
-        f"(B={batch_size}, n_img={n_img}, n_text={n_text}, "
+        f"(B={b_label}, n_img={n_img}, n_text={n_text}, "
         f"image_token_shapes={image_token_shapes}, "
         f"blocks={cfg.num_joint_blocks}, hidden={H_dim}, "
         f"heads={cfg.num_attention_heads}, head_dim={head_dim}, "
         f"text_d={txt_d}, in_ch={in_ch}, out_ch={out_ch}, p={p}) "
-        f"-> [{batch_size}, {n_img}, {proj_out_dim}]",
+        f"-> [{b_label}, {n_img}, {proj_out_dim}]",
         file=sys.stderr,
     )
     return _serialize_and_write(builder, network, config, out_path, "qwen_image_dit")

--- a/python/tensorrt_model_connect/families/qwen_image/qwen_image_vae_builder.py
+++ b/python/tensorrt_model_connect/families/qwen_image/qwen_image_vae_builder.py
@@ -846,6 +846,8 @@ def build_qwen_image_vae_decoder_engine(
     h_lat: int = 32,
     w_lat: int = 32,
     apply_latent_unnorm: bool = False,
+    max_batch_size: int = 1,
+    opt_batch_size: int | None = None,
     verbose: bool = False,
 ) -> Path:
     """Build the Qwen-Image VAE decoder TRT engine and serialise the plan.
@@ -877,11 +879,30 @@ def build_qwen_image_vae_decoder_engine(
             latent (post-DiT) and applies ``z * std + mean`` internally. If
             False (default), the engine consumes a latent already in HF's
             ``vae.decode`` input convention.
+        max_batch_size: Accepted for API uniformity with the text encoder and
+            DiT builders, but per the diffusion batch-inference design
+            (Decision E, 2026-05-19) the VAE always caps at 1 — the C++
+            pipeline loops over per-sample latents calling this engine once
+            per latent. The leading batch dim stays statically baked at 1
+            regardless of the requested cap, so no dynamic TRT profile is
+            attached. Values >1 are accepted but logged-and-clamped so the
+            family plugin can pass the same cap through to every builder
+            without special-casing the VAE.
+        opt_batch_size: Accepted for API uniformity; unused (see
+            ``max_batch_size``).
         verbose: Enable TRT verbose logging.
 
     Returns:
         Resolved ``Path`` to the written plan file.
     """
+    if max_batch_size < 1:
+        raise ValueError(
+            f"max_batch_size must be >= 1 (got {max_batch_size})"
+        )
+    # Per design Decision E (2026-05-19) the VAE is always sliced at B=1.
+    # The kwarg above is accepted for API uniformity; we deliberately ignore
+    # the requested cap and keep the engine statically batched at 1.
+    del opt_batch_size  # Unused by design — see docstring.
     out_path = Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/python/tensorrt_model_connect/families/z_image/qwen3_encoder_builder.py
+++ b/python/tensorrt_model_connect/families/z_image/qwen3_encoder_builder.py
@@ -21,6 +21,7 @@ from tensorrt_model_connect import trt_compat
 
 from ... import graph_ops
 from ...checkpoint_mapper import WeightDict, _open_safetensors, _load_tensor, _has_tensor
+from ...engine_builder import add_dynamic_batch_profile
 
 
 trt = trt_compat.get_trt()
@@ -94,13 +95,28 @@ def build_qwen3_encoder_engine(
     eps: float = 1e-6,
     output_layer: int = -2,
     verbose: bool = False,
+    max_batch_size: int = 1,
+    opt_batch_size: int | None = None,
 ) -> bytes:
     """Build Qwen3 text encoder TRT engine.
 
     Args:
         output_layer: Which layer's output to return. -2 means second-to-last.
+        max_batch_size: Maximum batch size for the dynamic batch profile.
+            When ``max_batch_size == 1`` (default), behavior is identical to
+            the previous static-shape build (no batch dim, no profile).
+            When > 1, a leading batch dim is added to the inputs and a single
+            wide optimization profile ``kMIN=1, kOPT=opt_batch_size,
+            kMAX=max_batch_size`` is attached (design Decisions A and C).
+        opt_batch_size: kOPT for the dynamic batch profile. Defaults to
+            ``min(max_batch_size, 4)`` per design Decision C.
         All other args describe the Qwen3 architecture.
     """
+    if max_batch_size < 1:
+        raise ValueError(f"max_batch_size must be >= 1 (got {max_batch_size})")
+    if opt_batch_size is None:
+        opt_batch_size = min(max_batch_size, 4)
+    dynamic_batch = max_batch_size > 1
     if output_layer < 0:
         output_layer = num_layers + output_layer  # e.g., 36 + (-2) = 34
 
@@ -113,9 +129,17 @@ def build_qwen3_encoder_engine(
 
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
 
-    # Inputs
-    input_ids = network.add_input("input_ids", trt.int32, (max_seq_len,))
-    attn_mask = network.add_input("attention_mask", trt.float32, (max_seq_len,))
+    # Inputs. With dynamic batch, the leading dim becomes runtime-dynamic
+    # (``-1``); the static-batch path keeps today's no-batch-dim shape.
+    if dynamic_batch:
+        input_ids = network.add_input(
+            "input_ids", trt.int32, (-1, max_seq_len))
+        attn_mask = network.add_input(
+            "attention_mask", trt.float32, (-1, max_seq_len))
+    else:
+        input_ids = network.add_input("input_ids", trt.int32, (max_seq_len,))
+        attn_mask = network.add_input(
+            "attention_mask", trt.float32, (max_seq_len,))
 
     # Constants
     eps_t = graph_ops.add_constant(network, (1, 1), np.array([eps], dtype=np.float32))
@@ -242,9 +266,21 @@ def build_qwen3_encoder_engine(
     out_final.name = "text_embeddings"
     network.mark_output(out_final)
 
+    if dynamic_batch:
+        add_dynamic_batch_profile(
+            builder, config, network,
+            input_names=["input_ids", "attention_mask"],
+            max_batch=max_batch_size,
+            opt_batch=opt_batch_size,
+            static_shape={
+                "input_ids": (max_seq_len,),
+                "attention_mask": (max_seq_len,),
+            },
+        )
+
     print(f"[qwen3-encoder] Building TRT engine "
           f"(layers={num_layers}, hidden={hidden_size}, output_layer={output_layer}, "
-          f"seq_len={max_seq_len}) ...", file=sys.stderr)
+          f"seq_len={max_seq_len}, max_batch={max_batch_size}) ...", file=sys.stderr)
 
     plan = builder.build_serialized_network(network, config)
     if plan is None:

--- a/python/tensorrt_model_connect/families/z_image/z_image_dit_builder.py
+++ b/python/tensorrt_model_connect/families/z_image/z_image_dit_builder.py
@@ -44,6 +44,7 @@ from tensorrt_model_connect import trt_compat
 
 from ... import graph_ops
 from ...checkpoint_mapper import WeightDict, _open_safetensors, _load_tensor
+from ...engine_builder import add_dynamic_batch_profile
 
 
 trt = trt_compat.get_trt()
@@ -172,8 +173,29 @@ def build_z_image_dit_engine(
     adaln_embed_dim: int = 256,
     eps: float = 1e-5,
     verbose: bool = False,
+    max_batch_size: int = 1,
+    opt_batch_size: int | None = None,
 ) -> bytes:
-    """Build Z-Image DiT TRT engine."""
+    """Build Z-Image DiT TRT engine.
+
+    When ``max_batch_size == 1`` (default), engine inputs keep their original
+    static shapes (no leading batch dim) — byte-for-byte identical to today's
+    behavior. When ``max_batch_size > 1``, ``hidden_states``,
+    ``encoder_hidden_states``, and ``timestep_embedding`` gain a dynamic
+    leading batch dim and a single wide optimization profile (kMIN=1,
+    kOPT=``opt_batch_size``, kMAX=``max_batch_size``) is attached
+    per design Decisions A and C. ``opt_batch_size`` defaults to
+    ``min(max_batch_size, 4)``.
+
+    RoPE caches (``rotary_cos``, ``rotary_sin``) are shared across the batch
+    and remain non-batched even in the dynamic-batch path.
+    """
+    if max_batch_size < 1:
+        raise ValueError(f"max_batch_size must be >= 1 (got {max_batch_size})")
+    if opt_batch_size is None:
+        opt_batch_size = min(max_batch_size, 4)
+    dynamic_batch = max_batch_size > 1
+
     total_seq = num_patches + text_seq_len
     attn_scale = 1.0 / np.sqrt(max(head_dim, 1))
     out_channels = weights["final_linear.weight"].shape[1]
@@ -184,13 +206,25 @@ def build_z_image_dit_engine(
     config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
 
-    # Inputs (no batch dim -- static shapes)
-    noise_inp = network.add_input(
-        "hidden_states", trt.float32, (num_patches, dim))
-    caption_inp = network.add_input(
-        "encoder_hidden_states", trt.float32, (text_seq_len, dim))
-    temb_inp = network.add_input(
-        "timestep_embedding", trt.float32, (1, adaln_embed_dim))
+    # Inputs. Static-batch path keeps today's no-batch-dim shapes; the
+    # dynamic-batch path turns the leading dim of the batched tensors into
+    # a runtime-dynamic ``-1``. ``temb`` already carries a static leading
+    # singleton in the static path; it becomes the batch dim under
+    # max_batch_size > 1. Rotary caches are batch-invariant and stay 2-D.
+    if dynamic_batch:
+        noise_inp = network.add_input(
+            "hidden_states", trt.float32, (-1, num_patches, dim))
+        caption_inp = network.add_input(
+            "encoder_hidden_states", trt.float32, (-1, text_seq_len, dim))
+        temb_inp = network.add_input(
+            "timestep_embedding", trt.float32, (-1, adaln_embed_dim))
+    else:
+        noise_inp = network.add_input(
+            "hidden_states", trt.float32, (num_patches, dim))
+        caption_inp = network.add_input(
+            "encoder_hidden_states", trt.float32, (text_seq_len, dim))
+        temb_inp = network.add_input(
+            "timestep_embedding", trt.float32, (1, adaln_embed_dim))
     rope_cos = network.add_input(
         "rotary_cos", trt.float32, (total_seq, head_dim))
     rope_sin = network.add_input(
@@ -401,9 +435,25 @@ def build_z_image_dit_engine(
     output_final.name = "output"
     network.mark_output(output_final)
 
+    if dynamic_batch:
+        add_dynamic_batch_profile(
+            builder, config, network,
+            input_names=[
+                "hidden_states", "encoder_hidden_states", "timestep_embedding"
+            ],
+            max_batch=max_batch_size,
+            opt_batch=opt_batch_size,
+            static_shape={
+                "hidden_states": (num_patches, dim),
+                "encoder_hidden_states": (text_seq_len, dim),
+                "timestep_embedding": (adaln_embed_dim,),
+            },
+        )
+
     print(f"[z-image-dit] Building TRT engine "
           f"(dim={dim}, layers={num_layers}, refiners={num_refiner_layers}, "
-          f"patches={num_patches}, text_seq={text_seq_len}, out_ch={out_channels}) ...",
+          f"patches={num_patches}, text_seq={text_seq_len}, out_ch={out_channels}, "
+          f"max_batch={max_batch_size}) ...",
           file=sys.stderr)
 
     plan = builder.build_serialized_network(network, config)

--- a/python/tensorrt_model_connect/graph_ops.py
+++ b/python/tensorrt_model_connect/graph_ops.py
@@ -192,6 +192,109 @@ def add_rms_norm_per_head(
     return reshape_out.get_output(0)
 
 
+def add_rms_norm_last_dim(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    hidden_size: int,
+    gamma: np.ndarray,
+    eps_tensor: trt.ITensor,
+    dtype: np.dtype = np.float32,
+) -> trt.ITensor:
+    """RMSNorm over the final dimension for any-rank tensors.
+
+    Generalises :func:`add_rms_norm` (rank 2) to inputs of rank >= 2 by
+    reducing over the last axis. Diffusion batched builders use this for
+    ``[B, S, D]`` tensors.
+    """
+    rank = len(tuple(inp.shape))
+    if rank < 2:
+        raise ValueError("add_rms_norm_last_dim expects rank >= 2")
+
+    need_cast = (dtype != np.float32)
+    output_dtype = inp.dtype
+    if need_cast:
+        inp = network.add_cast(inp, trt.float32).get_output(0)
+        eps_tensor = network.add_cast(eps_tensor, trt.float32).get_output(0)
+
+    sq = network.add_elementwise(inp, inp, trt.ElementWiseOperation.PROD)
+    mean = network.add_reduce(
+        sq.get_output(0), trt.ReduceOperation.AVG, 1 << (rank - 1), keep_dims=True)
+    denom_in = network.add_elementwise(
+        mean.get_output(0), eps_tensor, trt.ElementWiseOperation.SUM)
+    sqrt_l = network.add_unary(denom_in.get_output(0), trt.UnaryOperation.SQRT)
+    recip = network.add_unary(sqrt_l.get_output(0), trt.UnaryOperation.RECIP)
+    normalized = network.add_elementwise(
+        inp, recip.get_output(0), trt.ElementWiseOperation.PROD)
+    gamma_shape = (1,) * (rank - 1) + (hidden_size,)
+    gamma_t = add_constant(
+        network, gamma_shape, np.asarray(gamma).reshape(gamma_shape),
+        dtype=np.float32)
+    scaled = network.add_elementwise(
+        normalized.get_output(0), gamma_t, trt.ElementWiseOperation.PROD)
+    result = scaled.get_output(0)
+    if need_cast:
+        result = _cast_back_to_trt_dtype(network, result, output_dtype)
+    return result
+
+
+def add_rms_norm_per_head_batched(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    num_heads: int,
+    head_dim: int,
+    gamma: np.ndarray,
+    eps_tensor: trt.ITensor,
+    dtype: np.dtype = np.float32,
+    sequence_length: int | None = None,
+) -> trt.ITensor:
+    """Per-head RMSNorm for ``[B, S, num_heads * head_dim]`` tensors.
+
+    Batched companion to :func:`add_rms_norm_per_head` used by diffusion
+    builders whose leading dim is a dynamic batch (``-1``). ``gamma`` may be
+    ``[num_heads * head_dim]`` or ``[head_dim]`` broadcast to heads.
+    """
+    seq_dim = -1 if sequence_length is None else sequence_length
+    need_cast = (dtype != np.float32)
+    output_dtype = inp.dtype
+
+    reshape_in = network.add_shuffle(inp)
+    reshape_in.reshape_dims = (-1, seq_dim, num_heads, head_dim)
+    reshaped = reshape_in.get_output(0)
+    if need_cast:
+        reshaped = network.add_cast(reshaped, trt.float32).get_output(0)
+        eps_tensor = network.add_cast(eps_tensor, trt.float32).get_output(0)
+
+    eps_4d = network.add_shuffle(eps_tensor)
+    eps_4d.reshape_dims = (1, 1, 1, 1)
+    sq = network.add_elementwise(reshaped, reshaped, trt.ElementWiseOperation.PROD)
+    mean = network.add_reduce(
+        sq.get_output(0), trt.ReduceOperation.AVG, 1 << 3, keep_dims=True)
+    denom_in = network.add_elementwise(
+        mean.get_output(0), eps_4d.get_output(0), trt.ElementWiseOperation.SUM)
+    sqrt_l = network.add_unary(denom_in.get_output(0), trt.UnaryOperation.SQRT)
+    recip = network.add_unary(sqrt_l.get_output(0), trt.UnaryOperation.RECIP)
+    normalized = network.add_elementwise(
+        reshaped, recip.get_output(0), trt.ElementWiseOperation.PROD)
+
+    gamma_arr = np.asarray(gamma, dtype=np.float32)
+    if gamma_arr.size == head_dim:
+        gamma_shape = (1, 1, 1, head_dim)
+        gamma_arr = gamma_arr.reshape(gamma_shape)
+    else:
+        gamma_shape = (1, 1, num_heads, head_dim)
+        gamma_arr = gamma_arr.reshape(gamma_shape)
+    gamma_t = add_constant(network, gamma_shape, gamma_arr, dtype=np.float32)
+    scaled = network.add_elementwise(
+        normalized.get_output(0), gamma_t, trt.ElementWiseOperation.PROD)
+
+    result = scaled.get_output(0)
+    if need_cast:
+        result = _cast_back_to_trt_dtype(network, result, output_dtype)
+    reshape_out = network.add_shuffle(result)
+    reshape_out.reshape_dims = (-1, seq_dim, num_heads * head_dim)
+    return reshape_out.get_output(0)
+
+
 def add_l2_norm(
     network: trt.INetworkDefinition,
     inp: trt.ITensor,

--- a/src/bundle/bundle_format.cpp
+++ b/src/bundle/bundle_format.cpp
@@ -147,6 +147,15 @@ BundleInfo BundleInfoFromJson(const std::string& json, BundleSectionTable& secti
         info.tokenizer_add_special_tokens_present = true;
     }
 
+    // Per-component diffusion batch caps (see design doc Decision C).
+    // Absent => leave the default {1, 1, 1} so legacy bundles run unchanged.
+    const std::string mbs_text = extract_json_object_text(json, "max_batch_size");
+    if (!mbs_text.empty()) {
+        info.max_batch_size.dit = extract_json_int(mbs_text, "dit", 1);
+        info.max_batch_size.text_encoder = extract_json_int(mbs_text, "text_encoder", 1);
+        info.max_batch_size.vae = extract_json_int(mbs_text, "vae", 1);
+    }
+
     sections_out.clear();
     parse_sections_table(json, sections_out);
     info.sections.clear();

--- a/src/runtime/domains/diffusion/batch_utils.cpp
+++ b/src/runtime/domains/diffusion/batch_utils.cpp
@@ -1,0 +1,73 @@
+#include "runtime/domains/diffusion/batch_utils.h"
+
+#include <algorithm>
+#include <array>
+#include <random>
+#include <stdexcept>
+
+namespace trtmc::diffusion {
+
+namespace {
+
+std::uint32_t low32(std::uint64_t v) {
+    return static_cast<std::uint32_t>(v & 0xFFFFFFFFu);
+}
+
+std::uint32_t high32(std::uint64_t v) {
+    return static_cast<std::uint32_t>((v >> 32) & 0xFFFFFFFFu);
+}
+
+} // namespace
+
+std::vector<std::uint32_t> derive_per_sample_seeds(std::uint64_t global_seed, int count) {
+    if (count < 1) {
+        throw std::invalid_argument("count must be >= 1");
+    }
+    std::vector<std::uint32_t> out;
+    out.reserve(static_cast<std::size_t>(count));
+    for (int i = 0; i < count; ++i) {
+        std::seed_seq seq{
+            low32(global_seed),
+            high32(global_seed),
+            static_cast<std::uint32_t>(i),
+        };
+        std::array<std::uint32_t, 1> buf{};
+        seq.generate(buf.begin(), buf.end());
+        out.push_back(buf[0]);
+    }
+    return out;
+}
+
+std::vector<std::uint32_t> derive_per_sample_seeds(const std::vector<std::uint64_t>& explicit_list,
+                                                   int count) {
+    if (count < 1) {
+        throw std::invalid_argument("count must be >= 1");
+    }
+    if (static_cast<int>(explicit_list.size()) != count) {
+        throw std::invalid_argument("explicit seed list length must equal the total batch count");
+    }
+    std::vector<std::uint32_t> out;
+    out.reserve(static_cast<std::size_t>(count));
+    for (auto v : explicit_list) {
+        out.push_back(static_cast<std::uint32_t>(v));
+    }
+    return out;
+}
+
+std::vector<int> plan_chunks(int total, int cap) {
+    if (total < 1) {
+        throw std::invalid_argument("total must be >= 1");
+    }
+    if (cap < 1) {
+        throw std::invalid_argument("cap must be >= 1");
+    }
+    std::vector<int> plan;
+    while (total > 0) {
+        const int n = std::min(total, cap);
+        plan.push_back(n);
+        total -= n;
+    }
+    return plan;
+}
+
+} // namespace trtmc::diffusion

--- a/src/runtime/domains/diffusion/batch_utils.h
+++ b/src/runtime/domains/diffusion/batch_utils.h
@@ -1,0 +1,33 @@
+#pragma once
+// Shared helpers for diffusion batch inference.
+//
+// `derive_per_sample_seeds(global, N)` turns one global seed into N distinct,
+// reproducible per-sample seeds via std::seed_seq{global_lo, global_hi, i}.
+// `derive_per_sample_seeds(list, N)` validates and forwards an explicit list.
+// `plan_chunks(total, cap)` returns the size of each TRT call when the user's
+// requested batch exceeds the engine cap (design doc Decision D).
+//
+// These utilities are isolated so all three diffusion families can share one
+// implementation and one regression test (see Decision D's per-sample seed
+// contract; the AnimateDiff #174 lesson is the reason we don't broadcast one
+// RNG stream across the batch).
+
+#include <cstdint>
+#include <vector>
+
+namespace trtmc::diffusion {
+
+// Derive `count` deterministic per-sample seeds from one `global_seed`.
+// Each sample's seed = first u32 of std::seed_seq{global_lo, global_hi, i}.
+std::vector<std::uint32_t> derive_per_sample_seeds(std::uint64_t global_seed, int count);
+
+// Validate an explicit list provided by the user (e.g. --seed s0,s1,...).
+// Throws std::invalid_argument when `list.size() != count`.
+std::vector<std::uint32_t> derive_per_sample_seeds(const std::vector<std::uint64_t>& explicit_list,
+                                                   int count);
+
+// Split `total` work into chunks of at most `cap`. The last chunk may be
+// smaller. Throws std::invalid_argument for non-positive inputs.
+std::vector<int> plan_chunks(int total, int cap);
+
+} // namespace trtmc::diffusion

--- a/src/runtime/domains/diffusion/diffusion_types.h
+++ b/src/runtime/domains/diffusion/diffusion_types.h
@@ -47,6 +47,18 @@ struct DiffusionConfig {
     float vae_scaling_factor{0.0F};
 
     std::string diffusion_backend_type{"wan_3d"};
+
+    // Per-call requested batch size. Defaults to 1 = today's behavior.
+    // Pipelines clamp/chunk against the per-component caps below.
+    int32_t batch_size{1};
+
+    // Engine batch envelope sourced from the bundle's max_batch_size block.
+    // Defaults to all-1 so legacy bundles (no field) keep B=1 semantics.
+    struct {
+        int32_t dit{1};
+        int32_t text_encoder{1};
+        int32_t vae{1};
+    } max_batch_size;
 };
 
 /// Preprocessor weights for the DiT (external to the TRT engine graph).

--- a/src/runtime/domains/diffusion/qwen_image_types.h
+++ b/src/runtime/domains/diffusion/qwen_image_types.h
@@ -148,6 +148,16 @@ struct QwenImageConfig {
     QwenImageVisionEncoderConfig vision_encoder;
     QwenImageConditioningConfig image_conditioning;
 
+    // Engine batch envelope sourced from the bundle's `max_batch_size`
+    // top-level block. Defaults to {1,1,1} so legacy bundles preserve B=1
+    // semantics. Populated by QwenImagePlugin from `bundle.info`, not from
+    // config_json (the block lives at the bundle header level).
+    struct {
+        int32_t dit{1};
+        int32_t text_encoder{1};
+        int32_t vae{1};
+    } max_batch_size;
+
     // Parse a bundle config.json blob into a QwenImageConfig. Missing keys
     // / sections retain their struct defaults.
     static QwenImageConfig parse(std::string_view config_json);

--- a/src/runtime/models/qwen_image/plugin.cpp
+++ b/src/runtime/models/qwen_image/plugin.cpp
@@ -33,6 +33,12 @@ class QwenImagePlugin final : public IPipelinePlugin {
         // Parse Qwen-Image-specific config (diffusion / text_encoder / denoiser
         // / vae / image / tokenizer sections) from the raw bundle config JSON.
         auto qi_config = QwenImageConfig::parse(ctx.config_json);
+        // The bundle's per-component batch caps live at the top-level header,
+        // not inside the qwen-image config_json. Mirror them onto qi_config so
+        // the pipeline only needs one place to read the envelope (Decision C).
+        qi_config.max_batch_size.dit = ctx.bundle.info.max_batch_size.dit;
+        qi_config.max_batch_size.text_encoder = ctx.bundle.info.max_batch_size.text_encoder;
+        qi_config.max_batch_size.vae = ctx.bundle.info.max_batch_size.vae;
 
         // Parse Qwen-Image preprocessor weights (latents_mean / latents_std)
         // from the bundle's preprocessor_weights section. Falls back to an

--- a/src/runtime/plugins/shared/diffusion_helpers.cpp
+++ b/src/runtime/plugins/shared/diffusion_helpers.cpp
@@ -74,6 +74,13 @@ DiffusionParts load_diffusion_parts(IBackend* backend, const BundleFile& bundle,
     }
 
     parts.config = make_diffusion_config(json);
+    // Carry the engine batch envelope (parsed from the bundle's top-level
+    // `max_batch_size` block by ReadBundleFile) into the runtime config so
+    // pipelines can clamp/chunk against it. Defaults to {1,1,1} when the
+    // block is absent — see design doc Decision C.
+    parts.config.max_batch_size.dit = bundle.info.max_batch_size.dit;
+    parts.config.max_batch_size.text_encoder = bundle.info.max_batch_size.text_encoder;
+    parts.config.max_batch_size.vae = bundle.info.max_batch_size.vae;
 
     auto* pw = find_section(bundle, "preprocessor_weights");
     if (pw && !pw->empty())

--- a/tests/builder/test_bundle_writer.py
+++ b/tests/builder/test_bundle_writer.py
@@ -299,3 +299,23 @@ class TestCorruptedBundles:
         assert header["model_id"] == "corrupt-test"
         assert header["family"] == "qwen"
         assert len(sections["engine_plan"]) == 16
+
+
+def test_max_batch_size_roundtrip_and_back_compat(tmp_path):
+    """``max_batch_size`` is an additive optional bundle field (Decision C):
+    new bundles serialize it, legacy bundles omit it.
+    """
+    new = BundleInfo(
+        model_id="flux", family="diffusion_flux",
+        max_batch_size={"dit": 4, "text_encoder": 8, "vae": 1},
+    )
+    new_path = str(tmp_path / "new.trtfb")
+    write_bundle(new_path, new, [BundleSection("engine_plan", b"x")])
+    new_header, _ = read_trtfb_bundle(new_path)
+    assert new_header["max_batch_size"] == {"dit": 4, "text_encoder": 8, "vae": 1}
+
+    legacy = BundleInfo(model_id="legacy", family="qwen")
+    legacy_path = str(tmp_path / "legacy.trtfb")
+    write_bundle(legacy_path, legacy, [BundleSection("engine_plan", b"x")])
+    legacy_header, _ = read_trtfb_bundle(legacy_path)
+    assert "max_batch_size" not in legacy_header

--- a/tests/builder/test_dynamic_batch_profile.py
+++ b/tests/builder/test_dynamic_batch_profile.py
@@ -1,0 +1,39 @@
+"""Unit test for ``add_dynamic_batch_profile`` — single source of truth for
+the diffusion engine ``kMIN=1, kOPT=opt, kMAX=max`` profile. The TRT
+round-trip exercises validation, shape setting, and the engine's binding
+acceptance in one go.
+"""
+
+from __future__ import annotations
+
+from .conftest import requires_trt
+
+
+@requires_trt
+def test_builds_a_trivial_engine_and_enforces_max_batch(tmp_path):
+    import tensorrt as trt
+    from tensorrt_model_connect.engine_builder import add_dynamic_batch_profile
+
+    logger = trt.Logger(trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(0)
+    x = network.add_input("x", trt.float32, (-1, 8))
+    identity = network.add_identity(x)
+    network.mark_output(identity.get_output(0))
+    config = builder.create_builder_config()
+
+    add_dynamic_batch_profile(
+        builder, config, network,
+        input_names=["x"], max_batch=4, opt_batch=4,
+        static_shape={"x": (8,)},
+    )
+
+    serialized = builder.build_serialized_network(network, config)
+    assert serialized is not None
+
+    runtime = trt.Runtime(logger)
+    engine = runtime.deserialize_cuda_engine(bytes(serialized))
+    ctx = engine.create_execution_context()
+    assert ctx.set_input_shape("x", (1, 8))
+    assert ctx.set_input_shape("x", (4, 8))
+    assert ctx.set_input_shape("x", (5, 8)) is False

--- a/tests/builder/test_flux_dit_batch_profile.py
+++ b/tests/builder/test_flux_dit_batch_profile.py
@@ -1,0 +1,201 @@
+"""Unit tests for the FLUX.1 DiT dynamic-batch profile (PR 1).
+
+Verifies the contract added in the diffusion batch-inference foundation
+work (design Decisions A and C):
+
+* ``max_batch_size == 1`` (default) preserves today's static-shape
+  behaviour and *must not* attach an optimization profile.
+* ``max_batch_size > 1`` switches every input's leading dim to ``-1``
+  and calls :func:`add_dynamic_batch_profile` exactly once with the
+  expected names, shapes, and ``kMIN/kOPT/kMAX``.
+
+The tests fully stub out the network body — we capture the profile call
+and the ``add_input`` shapes, then short-circuit before any further graph
+construction happens. No engine is compiled.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    from tensorrt_model_connect.families.flux import flux_dit_builder
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt",
+                allow_module_level=True)
+
+
+class _CapturedAndStop(Exception):
+    """Sentinel raised inside a stub to short-circuit the builder."""
+
+
+class _FakeTensor:
+    def __init__(self, name, dtype, shape):
+        self.name = name
+        self.dtype = dtype
+        self.shape = tuple(shape)
+
+
+class _RecordingLayer:
+    def __init__(self, out):
+        self._out = out
+        self.reshape_dims = None
+        self.first_transpose = None
+        self.second_transpose = None
+        self.axis = 0
+
+    def get_output(self, _idx=0):
+        return self._out
+
+    def set_input(self, *_a, **_k):
+        return None
+
+
+class _FakeNetwork:
+    def __init__(self):
+        self.inputs: list[tuple[str, object, tuple]] = []
+        self.outputs = []
+
+    def add_input(self, name, dtype, shape):
+        self.inputs.append((name, dtype, tuple(shape)))
+        return _FakeTensor(name, dtype, tuple(shape))
+
+    def mark_output(self, _t):
+        self.outputs.append(_t)
+
+    def __getattr__(self, _name):
+        # Any other ``add_*`` call returns a tame recording layer; we never
+        # reach it because we short-circuit at profile attach time.
+        def _stub(*_a, **_k):
+            return _RecordingLayer(_FakeTensor("stub", "fp32", (-1,)))
+        return _stub
+
+
+class _FakeBuilderConfig:
+    def set_memory_pool_limit(self, *_a, **_k):
+        return None
+
+    def add_optimization_profile(self, _p):
+        return None
+
+
+class _FakeBuilder:
+    def __init__(self, _logger=None):
+        self._net = _FakeNetwork()
+        self._cfg = _FakeBuilderConfig()
+        self.builds = 0
+
+    def create_network(self, _flags=0):
+        return self._net
+
+    def create_builder_config(self):
+        return self._cfg
+
+    def create_optimization_profile(self):
+        return self._cfg  # any object; not inspected after our short-circuit
+
+    def build_serialized_network(self, *_a, **_k):
+        self.builds += 1
+        return b"FAKE-PLAN"
+
+
+def _fake_trt():
+    import types
+    fake = types.SimpleNamespace()
+
+    class _Logger:
+        WARNING = 0
+        VERBOSE = 1
+
+        def __init__(self, _level=0):
+            self.level = _level
+
+    fake.Logger = _Logger
+    fake.Builder = _FakeBuilder
+    fake.MemoryPoolType = types.SimpleNamespace(WORKSPACE=0)
+    fake.NetworkDefinitionCreationFlag = types.SimpleNamespace(STRONGLY_TYPED=0)
+    fake.ElementWiseOperation = types.SimpleNamespace(SUM=0, PROD=1, SUB=2)
+    fake.ReduceOperation = types.SimpleNamespace(AVG=0, SUM=1)
+    fake.UnaryOperation = types.SimpleNamespace(SQRT=0, RECIP=1)
+    fake.ActivationType = types.SimpleNamespace(SIGMOID=0)
+    fake.MatrixOperation = types.SimpleNamespace(NONE=0)
+    fake.Permutation = lambda perm: perm
+    fake.Weights = lambda *_a: object()
+    fake.float32 = "fp32"
+    fake.float16 = "fp16"
+    fake.int32 = "i32"
+    return fake
+
+
+def _install(monkeypatch):
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(flux_dit_builder, "trt", _fake_trt())
+
+    def stop(_b, _c, _n, **kwargs):
+        captured["profile_kwargs"] = kwargs
+        raise _CapturedAndStop()
+
+    import tensorrt_model_connect.engine_builder as eb
+    monkeypatch.setattr(eb, "add_dynamic_batch_profile", stop)
+    return captured
+
+
+def test_batched_path_attaches_profile_with_expected_shapes(monkeypatch):
+    captured = _install(monkeypatch)
+
+    inputs_seen: list[tuple] = []
+    original_add_input = _FakeNetwork.add_input
+
+    def patched_add_input(self, name, dtype, shape):
+        inputs_seen.append((name, dtype, tuple(shape)))
+        return original_add_input(self, name, dtype, shape)
+
+    monkeypatch.setattr(_FakeNetwork, "add_input", patched_add_input)
+
+    # Architecture knobs — small enough that the builder reaches profile
+    # attach quickly; weights dict is irrelevant since we short-circuit.
+    dim = 16
+    num_heads = 2
+    head_dim = dim // num_heads
+    num_img_tokens = 4
+    text_seq_len = 6
+    total_seq = num_img_tokens + text_seq_len
+
+    with pytest.raises(_CapturedAndStop):
+        flux_dit_builder.build_flux_dit_engine(
+            {},
+            dim=dim,
+            num_heads=num_heads,
+            num_layers=1,
+            num_single_layers=1,
+            num_img_tokens=num_img_tokens,
+            text_seq_len=text_seq_len,
+            max_batch_size=4,
+        )
+
+    pk = captured["profile_kwargs"]
+    assert pk["input_names"] == [
+        "hidden_states",
+        "encoder_hidden_states",
+        "temb",
+        "rotary_cos",
+        "rotary_sin",
+    ]
+    assert pk["max_batch"] == 4
+    assert pk["opt_batch"] == 4
+    assert pk["static_shape"] == {
+        "hidden_states": (num_img_tokens, dim),
+        "encoder_hidden_states": (text_seq_len, dim),
+        "temb": (dim,),
+        "rotary_cos": (total_seq, head_dim),
+        "rotary_sin": (total_seq, head_dim),
+    }
+
+    by_name = {name: shape for name, _dt, shape in inputs_seen}
+    assert by_name["hidden_states"] == (-1, num_img_tokens, dim)
+    assert by_name["encoder_hidden_states"] == (-1, text_seq_len, dim)
+    assert by_name["temb"] == (-1, dim)
+    assert by_name["rotary_cos"] == (-1, total_seq, head_dim)
+    assert by_name["rotary_sin"] == (-1, total_seq, head_dim)
+
+

--- a/tests/builder/test_qwen_image_dit_batch_profile.py
+++ b/tests/builder/test_qwen_image_dit_batch_profile.py
@@ -1,0 +1,375 @@
+"""Unit tests for the Qwen-Image MMDiT dynamic-batch builder wiring.
+
+Like the encoder batch-profile tests this monkeypatches TensorRT and the
+heavy compute-graph helpers (``_add_joint_block_graph``, ``_add_linear_3d``,
+etc.) so we exercise the builder entry-point wiring without compiling an
+engine. The tests confirm:
+
+* ``build_qwen_image_dit_engine`` gains ``max_batch_size`` and
+  ``opt_batch_size`` kwargs.
+* The pre-existing ``NotImplementedError`` guard for ``batch_size != 1``
+  (lines 1767-1770 in main) is removed; calling with ``max_batch_size=4``
+  no longer raises.
+* ``max_batch_size > 1`` switches each engine input's leading dim to ``-1``
+  and calls ``add_dynamic_batch_profile`` exactly once with the per-design
+  kMIN=1, kOPT=min(N,4), kMAX=N envelope (Decisions A and C).
+* ``max_batch_size == 1`` reproduces today's static-shape path and skips
+  ``add_dynamic_batch_profile`` entirely.
+
+The Qwen-Image MMDiT pipeline runs Decision B's 2-pass CFG (cond + uncond
+with L2-renorm combine). The DiT *graph* is unchanged structurally for
+Phase 1 — we just make the leading dim dynamic. The renorm combiner lives
+in the C++ pipeline and is PR 2 scope; nothing graph-side here changes for
+CFG.
+
+Trace: ARCH-FAM-001, UD-FAM-QWEN-IMAGE-01.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Mock TensorRT surface (shared shape/semantics with the encoder test;
+# duplicated here to keep the test file self-contained).
+# ---------------------------------------------------------------------------
+
+
+class _FakeTensor:
+    def __init__(self, name: str = "tensor", *, dtype=None, shape=(1,)):
+        self.name = name
+        self.dtype = dtype if dtype is not None else _FakeTRT.float32
+        self.shape = shape
+
+
+class _FakeLayer:
+    def __init__(self, name: str = "layer", *, dtype=None):
+        self.name = name
+        self._out = _FakeTensor(name, dtype=dtype)
+        self.reshape_dims = None
+        self.epsilon = None
+        self.axis = 0
+        self.first_transpose = None
+        self.second_transpose = None
+        self.compute_precision = None
+
+    def get_output(self, _idx: int) -> _FakeTensor:
+        return self._out
+
+    def set_input(self, *_a, **_kw):
+        return None
+
+
+class _FakeNetwork:
+    def __init__(self):
+        self.inputs: list[tuple[str, object, tuple]] = []
+
+    def add_input(self, name, dtype, shape):
+        self.inputs.append((name, dtype, tuple(shape)))
+        return _FakeTensor(name, dtype=dtype, shape=tuple(shape))
+
+    def __getattr__(self, item):
+        if item == "mark_output":
+            return lambda _t: None
+        return lambda *a, **kw: _FakeLayer(item)
+
+
+class _FakeBuilderConfig:
+    def __init__(self):
+        self.profiles: list[object] = []
+
+    def set_memory_pool_limit(self, *_a, **_kw):
+        return None
+
+    def add_optimization_profile(self, profile):
+        self.profiles.append(profile)
+
+    def clear_flag(self, *_a):
+        return None
+
+
+class _FakeProfile:
+    def __init__(self):
+        self.shapes: dict[str, tuple] = {}
+
+    def set_shape(self, name, *, min, opt, max):
+        self.shapes[name] = (tuple(min), tuple(opt), tuple(max))
+
+
+class _FakeBuilder:
+    def __init__(self):
+        self._config = _FakeBuilderConfig()
+        self._network = _FakeNetwork()
+        self.serialized = b"FAKE_ENGINE_PLAN"
+
+    def create_builder_config(self):
+        return self._config
+
+    def create_network(self, _flags):
+        return self._network
+
+    def create_optimization_profile(self):
+        return _FakeProfile()
+
+    def build_serialized_network(self, _n, _c):
+        return self.serialized
+
+
+class _FakeTRT:
+    float32 = "float32"
+    int32 = "int32"
+    bfloat16 = "bfloat16"
+
+    class Logger:
+        WARNING = 0
+        VERBOSE = 1
+
+        def __init__(self, *_a, **_kw):
+            return None
+
+    class Builder:
+        def __init__(self, _logger):
+            self.fake = _FakeBuilder()
+
+        def create_builder_config(self):
+            return self.fake.create_builder_config()
+
+        def create_network(self, flags):
+            return self.fake.create_network(flags)
+
+        def create_optimization_profile(self):
+            return self.fake.create_optimization_profile()
+
+        def build_serialized_network(self, n, c):
+            return self.fake.build_serialized_network(n, c)
+
+    class NetworkDefinitionCreationFlag:
+        STRONGLY_TYPED = 1
+
+    class MemoryPoolType:
+        WORKSPACE = 0
+
+    class BuilderFlag:
+        TF32 = 0
+
+    class ElementWiseOperation:
+        SUM = 0
+        PROD = 1
+        SUB = 2
+
+    class UnaryOperation:
+        SQRT = 0
+        RECIP = 1
+        SIN = 2
+        COS = 3
+
+    class MatrixOperation:
+        NONE = 0
+
+    class Permutation:
+        def __init__(self, perm):
+            self.perm = perm
+
+    @staticmethod
+    def Weights(arr, *args, **kw):  # noqa: N802
+        return arr
+
+
+# ---------------------------------------------------------------------------
+# Test cfg + weight bag (matches _validate_full_weights' schema check).
+# ---------------------------------------------------------------------------
+
+
+def _tiny_cfg():
+    from tensorrt_model_connect.families.qwen_image.qwen_image_dit_builder import (
+        QwenImageDiTConfig,
+    )
+
+    return QwenImageDiTConfig(
+        in_channels=4,
+        out_channels=1,
+        patch_size=2,
+        hidden_size=12,
+        num_joint_blocks=1,
+        num_attention_heads=2,
+        attention_head_dim=6,
+        intermediate_size=24,
+        text_embed_dim=6,
+        rope_axes_dim=[2, 2, 2],
+        rope_theta=10000.0,
+        timestep_embed_dim=4,
+        max_image_tokens=8,
+        max_text_tokens=4,
+        guidance_embeds=False,
+    )
+
+
+def _tiny_weights():
+    """A minimal weight dict that passes ``_validate_full_weights``."""
+    import numpy as np
+
+    cfg = _tiny_cfg()
+    H = cfg.hidden_size
+    in_ch = cfg.in_channels
+    out_ch = cfg.out_channels
+    p = cfg.patch_size
+    txt_d = cfg.text_embed_dim
+    rng = np.random.default_rng(0)
+
+    def n(shape):
+        return rng.normal(0.0, 0.01, shape).astype(np.float32)
+
+    weights: dict = {
+        "img_in.weight": n((H, in_ch)),
+        "img_in.bias": np.zeros((H,), dtype=np.float32),
+        "txt_norm.weight": np.ones((txt_d,), dtype=np.float32),
+        "txt_in.weight": n((H, txt_d)),
+        "txt_in.bias": np.zeros((H,), dtype=np.float32),
+        "time_text_embed.timestep_embedder.linear_1.weight":
+            n((H, cfg.timestep_embed_dim)),
+        "time_text_embed.timestep_embedder.linear_1.bias":
+            np.zeros((H,), dtype=np.float32),
+        "time_text_embed.timestep_embedder.linear_2.weight": n((H, H)),
+        "time_text_embed.timestep_embedder.linear_2.bias":
+            np.zeros((H,), dtype=np.float32),
+        "norm_out.linear.weight": n((2 * H, H)),
+        "norm_out.linear.bias": np.zeros((2 * H,), dtype=np.float32),
+        "proj_out.weight": n((out_ch * p * p, H)),
+        "proj_out.bias": np.zeros((out_ch * p * p,), dtype=np.float32),
+    }
+    return weights
+
+
+def _patch_tensorrt(monkeypatch):
+    """Replace TRT and stub the inner compute-graph helpers.
+
+    Returns the list that ``add_dynamic_batch_profile`` records into.
+    """
+    from tensorrt_model_connect.families.qwen_image import (
+        qwen_image_dit_builder as dit_mod,
+    )
+    from tensorrt_model_connect import engine_builder
+
+    monkeypatch.setattr(dit_mod, "trt", _FakeTRT)
+
+    def _stub_tensor(*_a, **_kw):
+        return _FakeTensor("stub")
+
+    def _stub_two_tensors(*_a, **_kw):
+        # ``_add_joint_block_graph`` returns (img_out, txt_out).
+        return _FakeTensor("img_out"), _FakeTensor("txt_out")
+
+    monkeypatch.setattr(dit_mod, "_add_linear_3d", _stub_tensor)
+    monkeypatch.setattr(dit_mod, "_add_rms_norm_last_dim_3d", _stub_tensor)
+    monkeypatch.setattr(dit_mod, "_add_time_text_embed", _stub_tensor)
+    monkeypatch.setattr(dit_mod, "_add_norm_out_3d", _stub_tensor)
+    monkeypatch.setattr(dit_mod, "_add_joint_block_graph", _stub_two_tensors)
+    monkeypatch.setattr(dit_mod, "_to_fp32",
+                        lambda _network, t: t if isinstance(t, _FakeTensor)
+                        else _FakeTensor("fp32"))
+    # ``_precompute_qwen_rope_tables`` returns two (n_img + n_text, head_dim)
+    # arrays. Stub with a tuple of matching-shape numpy arrays so the assert
+    # downstream is happy.
+    import numpy as np
+
+    def _stub_rope(axes_dim, h_lat, w_lat, n_text, theta):
+        head_dim = sum(axes_dim)
+        seq_total = h_lat * w_lat + n_text
+        return (
+            np.zeros((seq_total, head_dim), dtype=np.float32),
+            np.zeros((seq_total, head_dim), dtype=np.float32),
+        )
+
+    monkeypatch.setattr(dit_mod, "_precompute_qwen_rope_tables", _stub_rope)
+
+    calls: list[dict] = []
+
+    def _record(builder, config, network, *, input_names, max_batch,
+                opt_batch, static_shape):
+        calls.append(dict(
+            builder=builder, config=config, network=network,
+            input_names=list(input_names), max_batch=max_batch,
+            opt_batch=opt_batch, static_shape=dict(static_shape),
+        ))
+
+    monkeypatch.setattr(engine_builder, "add_dynamic_batch_profile", _record)
+    return calls
+
+
+def _capturing_create_network(monkeypatch):
+    from tensorrt_model_connect.families.qwen_image import (
+        qwen_image_dit_builder as dit_mod,
+    )
+
+    captured: dict = {}
+    real = dit_mod.trt.Builder.create_network
+
+    def wrapper(self, flags):
+        net = real(self, flags)
+        captured["network"] = net
+        return net
+
+    monkeypatch.setattr(dit_mod.trt.Builder, "create_network", wrapper)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_max_batch_size_four_uses_dynamic_dim_and_calls_profile(
+    monkeypatch, tmp_path,
+):
+    pytest.importorskip("numpy")
+    from tensorrt_model_connect.families.qwen_image.qwen_image_dit_builder import (
+        build_qwen_image_dit_engine,
+    )
+
+    calls = _patch_tensorrt(monkeypatch)
+    captured = _capturing_create_network(monkeypatch)
+    cfg = _tiny_cfg()
+    h_lat = 2
+    w_lat = 2
+    n_text = 3
+    build_qwen_image_dit_engine(
+        cfg, _tiny_weights(), tmp_path / "dit.plan",
+        h_lat=h_lat, w_lat=w_lat, n_text=n_text,
+        max_batch_size=4,
+    )
+    assert len(calls) == 1
+    call = calls[0]
+    n_img = h_lat * w_lat
+    assert call["input_names"] == ["img_patched", "txt_hidden", "timestep"]
+    assert call["max_batch"] == 4
+    assert call["opt_batch"] == 4
+    assert call["static_shape"] == {
+        "img_patched": (n_img, cfg.in_channels),
+        "txt_hidden": (n_text, cfg.text_embed_dim),
+        "timestep": (),
+    }
+    net = captured["network"]
+    shapes = {name: shape for name, _dt, shape in net.inputs}
+    assert shapes["img_patched"] == (-1, n_img, cfg.in_channels)
+    assert shapes["txt_hidden"] == (-1, n_text, cfg.text_embed_dim)
+    assert shapes["timestep"] == (-1,)
+
+
+def test_not_implemented_error_guard_is_gone(monkeypatch, tmp_path):
+    """Regression for the removed batch_size!=1 guard.
+
+    Before this PR, ``build_qwen_image_dit_engine`` raised
+    ``NotImplementedError`` for any batch>1. With the dynamic-batch profile
+    wired in, the call must succeed (with mocks in place).
+    """
+    pytest.importorskip("numpy")
+    from tensorrt_model_connect.families.qwen_image.qwen_image_dit_builder import (
+        build_qwen_image_dit_engine,
+    )
+
+    _patch_tensorrt(monkeypatch)
+    # Should NOT raise.
+    build_qwen_image_dit_engine(
+        _tiny_cfg(), _tiny_weights(), tmp_path / "dit.plan",
+        h_lat=2, w_lat=2, n_text=3, max_batch_size=4,
+    )

--- a/tests/builder/test_z_image_dit_batch_profile.py
+++ b/tests/builder/test_z_image_dit_batch_profile.py
@@ -1,0 +1,331 @@
+"""Unit tests for the Z-Image DiT dynamic-batch profile.
+
+Verifies the contract added in PR 1 of the diffusion batch-inference series:
+
+* ``max_batch_size=1`` (the default) reproduces today's static-shape DiT
+  build byte-for-byte — ``hidden_states`` / ``encoder_hidden_states`` keep
+  their 2-D ``(S, D)`` shapes, ``timestep_embedding`` keeps its singleton
+  ``(1, adaln_embed_dim)`` shape, and :func:`add_dynamic_batch_profile`
+  is not invoked.
+* ``max_batch_size > 1`` makes the leading dim of ``hidden_states``,
+  ``encoder_hidden_states``, and ``timestep_embedding`` runtime-dynamic
+  (``-1``) and attaches exactly one dynamic-batch profile with the
+  expected ``input_names``, ``max_batch``, ``opt_batch``, and
+  ``static_shape``. RoPE caches stay non-batched.
+
+TRT and graph_ops are monkeypatched so we never compile a real engine.
+(Reference: design doc Decisions A and C — kMIN=1, kOPT=min(max,4),
+kMAX=max; DiT default cap = 4.)
+"""
+
+from __future__ import annotations
+
+import types
+
+import numpy as np
+import pytest
+
+try:
+    from tensorrt_model_connect.families.z_image import z_image_dit_builder
+except (ImportError, ModuleNotFoundError):
+    pytest.skip(
+        "tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+# ---------------------------------------------------------------------------
+# Reusable lightweight TRT/graph_ops fakes (mirrors the encoder test).
+# ---------------------------------------------------------------------------
+
+
+class _Tensor:
+    def __init__(self, name: str = "tensor", shape: tuple = ()):
+        self.name = name
+        self.shape = shape
+        self.dtype = None
+
+
+class _Layer:
+    def __init__(self, *_args, **_kwargs):
+        self._out = _Tensor()
+
+    def get_output(self, _idx: int = 0):
+        return self._out
+
+    def __setattr__(self, name: str, value):
+        object.__setattr__(self, name, value)
+
+
+class _Network:
+    def __init__(self):
+        self.inputs: list[tuple[str, object, tuple]] = []
+        self.outputs: list[_Tensor] = []
+
+    def add_input(self, name: str, dtype, shape):
+        self.inputs.append((name, dtype, tuple(shape)))
+        return _Tensor(name=name, shape=tuple(shape))
+
+    def mark_output(self, tensor):
+        self.outputs.append(tensor)
+
+    def __getattr__(self, attr: str):
+        if attr.startswith("add_"):
+            def _factory(*_args, **_kwargs):
+                return _Layer()
+            return _factory
+        raise AttributeError(attr)
+
+
+class _Config:
+    def __init__(self):
+        self.profiles: list = []
+
+    def set_memory_pool_limit(self, *_args, **_kwargs):
+        pass
+
+    def add_optimization_profile(self, profile):
+        self.profiles.append(profile)
+
+
+class _Profile:
+    def __init__(self):
+        self.shapes: dict = {}
+
+    def set_shape(self, name, *, min, opt, max):
+        self.shapes[name] = (tuple(min), tuple(opt), tuple(max))
+
+
+class _Builder:
+    def __init__(self, *_args, **_kwargs):
+        self._network = _Network()
+        self._config = _Config()
+        self._profile = _Profile()
+
+    def create_network(self, _flag):
+        return self._network
+
+    def create_builder_config(self):
+        return self._config
+
+    def create_optimization_profile(self):
+        return self._profile
+
+    def build_serialized_network(self, _network, _config):
+        return b"z-image-dit-plan"
+
+
+class _FakeTRT(types.SimpleNamespace):
+    class _Dtype:
+        def __init__(self, name):
+            self.name = name
+
+    int32 = _Dtype("int32")
+    float32 = _Dtype("float32")
+    Builder = _Builder
+
+    class Logger:
+        def __init__(self, *_a, **_kw):
+            pass
+        WARNING = 1
+        VERBOSE = 2
+
+    class MemoryPoolType:
+        WORKSPACE = "workspace"
+
+    class NetworkDefinitionCreationFlag:
+        STRONGLY_TYPED = 0
+        EXPLICIT_BATCH = 1
+
+    class ActivationType:
+        SIGMOID = "sigmoid"
+        TANH = "tanh"
+
+    class ElementWiseOperation:
+        SUM = "sum"
+        PROD = "prod"
+        SUB = "sub"
+        MAX = "max"
+
+    class ReduceOperation:
+        AVG = "avg"
+        SUM = "sum"
+
+    class UnaryOperation:
+        SQRT = "sqrt"
+        RECIP = "recip"
+
+
+def _make_tensor(*_a, **_kw) -> _Tensor:
+    return _Tensor()
+
+
+def _patch_graph_ops(monkeypatch):
+    """Replace heavy graph_ops calls with tensor-returning stubs."""
+    import tensorrt_model_connect.graph_ops as gops
+    for name in (
+        "add_constant",
+        "add_matmul_rhs_constant",
+        "add_bias_sum",
+        "add_rms_norm",
+        "add_rms_norm_per_head",
+        "add_apply_rope_native",
+        "add_apply_rope_native_sequence",
+        "add_apply_rope_native_from_full_cache",
+        "add_attention_core",
+        "add_attention_from_rows",
+        "validate_native_rope_dim",
+        "reshape_rows_to_heads_4d",
+        "reshape_heads_4d_to_rows",
+    ):
+        if hasattr(gops, name):
+            if name == "validate_native_rope_dim":
+                monkeypatch.setattr(gops, name, lambda v, **kw: v)
+            else:
+                monkeypatch.setattr(gops, name, _make_tensor)
+
+
+# ---------------------------------------------------------------------------
+# Tiny synthetic DiT weights — only the keys looked up by the builder.
+# ---------------------------------------------------------------------------
+
+
+def _tiny_dit_weights(
+    *,
+    dim: int = 8,
+    head_dim: int = 2,
+    num_heads: int = 4,
+    ffn_dim: int = 16,
+    adaln_embed_dim: int = 6,
+    num_layers: int = 1,
+    num_refiner_layers: int = 1,
+    out_channels: int = 8,
+) -> dict[str, np.ndarray]:
+    z = np.zeros
+
+    def _block(prefix: str, *, has_adaln: bool) -> dict[str, np.ndarray]:
+        w: dict[str, np.ndarray] = {
+            f"{prefix}.to_q": z((dim, dim), dtype=np.float32),
+            f"{prefix}.to_k": z((dim, dim), dtype=np.float32),
+            f"{prefix}.to_v": z((dim, dim), dtype=np.float32),
+            f"{prefix}.to_out": z((dim, dim), dtype=np.float32),
+            f"{prefix}.norm_q": z((head_dim,), dtype=np.float32),
+            f"{prefix}.norm_k": z((head_dim,), dtype=np.float32),
+            f"{prefix}.attn_norm1": z((dim,), dtype=np.float32),
+            f"{prefix}.attn_norm2": z((dim,), dtype=np.float32),
+            f"{prefix}.ff_w1": z((dim, ffn_dim), dtype=np.float32),
+            f"{prefix}.ff_w2": z((ffn_dim, dim), dtype=np.float32),
+            f"{prefix}.ff_w3": z((dim, ffn_dim), dtype=np.float32),
+            f"{prefix}.ffn_norm1": z((dim,), dtype=np.float32),
+            f"{prefix}.ffn_norm2": z((dim,), dtype=np.float32),
+        }
+        if has_adaln:
+            w[f"{prefix}.adaln.weight"] = z(
+                (adaln_embed_dim, 4 * dim), dtype=np.float32)
+            w[f"{prefix}.adaln.bias"] = z((4 * dim,), dtype=np.float32)
+        return w
+
+    weights: dict[str, np.ndarray] = {}
+    for i in range(num_layers):
+        weights.update(_block(f"main.{i}", has_adaln=True))
+    for i in range(num_refiner_layers):
+        weights.update(_block(f"noise_refiner.{i}", has_adaln=True))
+        weights.update(_block(f"context_refiner.{i}", has_adaln=False))
+
+    weights["final_adaLN.weight"] = z((adaln_embed_dim, dim), dtype=np.float32)
+    weights["final_adaLN.bias"] = z((dim,), dtype=np.float32)
+    weights["final_linear.weight"] = z((dim, out_channels), dtype=np.float32)
+    weights["final_linear.bias"] = z((out_channels,), dtype=np.float32)
+    return weights
+
+
+def _call_builder(monkeypatch, *, max_batch_size: int = 1, opt_batch_size=None):
+    monkeypatch.setattr(z_image_dit_builder, "trt", _FakeTRT)
+    _patch_graph_ops(monkeypatch)
+
+    profile_calls: list[dict] = []
+
+    def _record_profile(builder, config, network, *, input_names,
+                        max_batch, opt_batch, static_shape):
+        profile_calls.append({
+            "input_names": list(input_names),
+            "max_batch": max_batch,
+            "opt_batch": opt_batch,
+            "static_shape": dict(static_shape),
+        })
+
+    monkeypatch.setattr(
+        z_image_dit_builder, "add_dynamic_batch_profile", _record_profile)
+
+    holder: dict = {}
+    real_builder_cls = _FakeTRT.Builder
+
+    def _builder_factory(*args, **kwargs):
+        inst = real_builder_cls(*args, **kwargs)
+        holder["builder"] = inst
+        return inst
+
+    monkeypatch.setattr(_FakeTRT, "Builder", _builder_factory)
+
+    plan = z_image_dit_builder.build_z_image_dit_engine(
+        _tiny_dit_weights(),
+        dim=8,
+        num_heads=4,
+        num_layers=1,
+        num_refiner_layers=1,
+        ffn_dim=16,
+        num_patches=12,
+        text_seq_len=5,
+        head_dim=2,
+        adaln_embed_dim=6,
+        eps=1e-5,
+        verbose=False,
+        max_batch_size=max_batch_size,
+        opt_batch_size=opt_batch_size,
+    )
+    assert plan == b"z-image-dit-plan"
+    return holder["builder"]._network, profile_calls
+
+
+# ---------------------------------------------------------------------------
+# Tests.
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_batch_adds_leading_minus_one_to_batched_inputs_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``max_batch_size > 1`` makes ``hidden_states`` / ``encoder_hidden_states``
+    / ``timestep_embedding`` dynamic but leaves RoPE caches unchanged, and
+    attaches exactly one dynamic-batch profile.
+
+    Preconditions: builder called with ``max_batch_size=4`` and the default
+    ``opt_batch_size=None`` (should resolve to 4 — design Decision C kOPT).
+    Postconditions:
+        * Batched inputs have leading ``-1``.
+        * RoPE caches stay 2-D.
+        * ``add_dynamic_batch_profile`` is invoked exactly once with the
+          three batched inputs, ``max_batch=4``, ``opt_batch=4``, and
+          ``static_shape`` entries matching the un-batched shapes.
+    """
+    network, profile_calls = _call_builder(monkeypatch, max_batch_size=4)
+
+    inputs = {name: shape for name, _dtype, shape in network.inputs}
+    assert inputs["hidden_states"] == (-1, 12, 8)
+    assert inputs["encoder_hidden_states"] == (-1, 5, 8)
+    assert inputs["timestep_embedding"] == (-1, 6)
+    # RoPE inputs are explicitly NOT batched.
+    assert inputs["rotary_cos"] == (17, 2)
+    assert inputs["rotary_sin"] == (17, 2)
+
+    assert len(profile_calls) == 1
+    call = profile_calls[0]
+    assert sorted(call["input_names"]) == [
+        "encoder_hidden_states", "hidden_states", "timestep_embedding"]
+    assert call["max_batch"] == 4
+    assert call["opt_batch"] == 4
+    assert call["static_shape"] == {
+        "hidden_states": (12, 8),
+        "encoder_hidden_states": (5, 8),
+        # ``timestep_embedding`` drops its prior singleton leading dim;
+        # the batch dim becomes the leading dim under the dynamic profile.
+        "timestep_embedding": (6,),
+    }

--- a/tests/cpp/test_bundle_format.cpp
+++ b/tests/cpp/test_bundle_format.cpp
@@ -256,6 +256,40 @@ static void test_truncated_bundle_throws() {
     trtmc_test::remove_all_safe(tmp);
 }
 
+static void test_max_batch_size_parse_and_back_compat() {
+    // New bundles carry the per-component cap; legacy bundles omit the
+    // block and the parser defaults all three components to 1.
+    const auto tmp = make_temp_dir();
+    std::vector<char> plan_data = {'P', 'L', 'A', 'N'};
+
+    const auto new_path = (tmp / "new.trtfb").string();
+    write_bundle_with_sections(new_path, R"({
+  "model_id": "flux-bs4", "family": "diffusion_flux",
+  "max_batch_size": {"dit": 4, "text_encoder": 8, "vae": 1},
+  "sections": {"engine_plan": {"offset": 0, "size": 4}}
+})",
+                               {plan_data});
+    const auto loaded_new = trtmc::ReadBundleFile(new_path);
+    check(loaded_new.info.max_batch_size.dit == 4 &&
+              loaded_new.info.max_batch_size.text_encoder == 8 &&
+              loaded_new.info.max_batch_size.vae == 1,
+          "max_batch_size parsed from header");
+
+    const auto legacy_path = (tmp / "legacy.trtfb").string();
+    write_bundle_with_sections(legacy_path, R"({
+  "model_id": "legacy", "family": "qwen",
+  "sections": {"engine_plan": {"offset": 0, "size": 4}}
+})",
+                               {plan_data});
+    const auto loaded_legacy = trtmc::ReadBundleFile(legacy_path);
+    check(loaded_legacy.info.max_batch_size.dit == 1 &&
+              loaded_legacy.info.max_batch_size.text_encoder == 1 &&
+              loaded_legacy.info.max_batch_size.vae == 1,
+          "absent max_batch_size defaults to {1,1,1}");
+
+    trtmc_test::remove_all_safe(tmp);
+}
+
 int main() {
     test_read_valid_bundle();
     test_magic_validation();
@@ -265,6 +299,7 @@ int main() {
     test_inspect_returns_metadata();
     test_tokenizer_add_special_tokens_header();
     test_truncated_bundle_throws();
+    test_max_batch_size_parse_and_back_compat();
 
     if (failures > 0) {
         std::cerr << failures << " test(s) FAILED\n";

--- a/tests/cpp/test_diffusion_batch_utils.cpp
+++ b/tests/cpp/test_diffusion_batch_utils.cpp
@@ -1,0 +1,63 @@
+// Unit test for the shared per-sample seed and chunk-planning helpers used
+// by every diffusion pipeline. Per design doc Decision D.
+
+#include "runtime/domains/diffusion/batch_utils.h"
+
+#include <cstdint>
+#include <iostream>
+#include <set>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* test_name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << test_name << '\n';
+        ++failures;
+    }
+}
+
+void test_batch_utils_contracts() {
+    // Per-sample seeds from one global are distinct + reproducible.
+    auto a = trtmc::diffusion::derive_per_sample_seeds(/*global=*/42, /*count=*/4);
+    auto b = trtmc::diffusion::derive_per_sample_seeds(/*global=*/42, /*count=*/4);
+    check(a == b && a.size() == 4, "global seed reproduces same sequence of 4");
+    std::set<std::uint32_t> unique(a.begin(), a.end());
+    check(unique.size() == 4, "per-sample seeds are distinct");
+
+    // Explicit list: forwarded verbatim, length-mismatched list throws.
+    auto explicit_seeds = trtmc::diffusion::derive_per_sample_seeds(
+        std::vector<std::uint64_t>{10, 20, 30, 40}, /*count=*/4);
+    check(explicit_seeds.size() == 4 && explicit_seeds[0] == 10 && explicit_seeds[3] == 40,
+          "explicit list forwarded unchanged");
+    bool threw = false;
+    try {
+        (void)trtmc::diffusion::derive_per_sample_seeds(std::vector<std::uint64_t>{1, 2, 3},
+                                                        /*count=*/4);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check(threw, "length-mismatched explicit list throws");
+
+    // Chunk planning: even split + remainder.
+    auto even = trtmc::diffusion::plan_chunks(/*total=*/8, /*cap=*/4);
+    check(even == std::vector<int>{4, 4}, "8/4 splits evenly");
+    auto rem = trtmc::diffusion::plan_chunks(/*total=*/9, /*cap=*/4);
+    check(rem == std::vector<int>{4, 4, 1}, "9/4 leaves remainder as final chunk");
+}
+
+} // namespace
+
+int main() {
+    test_batch_utils_contracts();
+
+    if (failures > 0) {
+        std::cerr << failures << " test(s) FAILED\n";
+        return 1;
+    }
+    std::cerr << "All diffusion batch_utils tests passed.\n";
+    return 0;
+}


### PR DESCRIPTION
This is the first of three PRs that add **batch inference** to the
diffusion pipelines (FLUX, Z-Image, Qwen Image). Batch inference lets a
single call generate multiple images at once, either many samples of
the same prompt (e.g. 4 cats with different seeds) or one image each
for a list of prompts.

**This PR doesn't add the feature yet.** It only adds the plumbing that
PRs 2 and 3 need to build on. With this PR alone, the runtime still
generates one image at a time.

## What's in this PR

- **A new helper, `add_dynamic_batch_profile()`**, that tells TensorRT
  "this engine can accept a varying batch size, anywhere from 1 to N."
  This is the single function every diffusion engine builder will use
  when it wants to support batch sizes greater than 1.

- **A new optional field in the bundle file (`max_batch_size`)** that
  records, per component (text encoder / DiT / VAE), the largest batch
  size that engine was built for. Older bundles without this field still
  load fine , which they're treated as batch-size-1 engines.

- **Two new fields in the runtime config**: `batch_size` (how many
  images the user requested this call) and `max_batch_size` (the engine's
  capacity, copied from the bundle). PR 2's pipeline code will read these
  to decide whether to run one big batch or split into several smaller
  ones if the user asks for more images than the engine can do at once.

- **A shared helper file (`batch_utils.h/.cpp`)** with two small
  utilities:
  - `derive_per_sample_seeds(global_seed, count)`: turns one user seed
    into N distinct, reproducible per-image seeds. So when the user asks
    for 4 images with `--seed 42`, every image gets its own deterministic
    seed that doesn't depend on the order it's processed in.
  - `plan_chunks(total, cap)`: if the user wants 10 images but the engine
    only supports up to 4 at a time, returns `[4, 4, 2]` so the pipeline
    knows how to split the work.

- **All 9 diffusion engine builders** (3 model families × 3 components
  each) now accept two new keyword arguments: `max_batch_size` (default
  `1`, unchanged) and `opt_batch_size` (optional optimization hint).
  When `max_batch_size=1`, the builder behaves exactly like before. When
  it's larger, the leading dimension of the engine's inputs becomes
  dynamic and the helper above attaches the TensorRT profile.

  **FLUX is fully ready** — its DiT graph was rewritten end-to-end so
  it actually builds and runs at batch sizes above 1.

  **Z-Image and Qwen Image are partially ready** — the builder accepts
  the new argument and the input shapes are declared dynamic, but the
  rest of the graph still has fixed-size reshapes baked in. Building one
  of these at `max_batch_size > 1` won't work yet; PR 2 finishes the
  job.

- **Qwen Image's DiT builder loses an old guardrail** that explicitly
  refused to build at batch sizes other than 1. That guardrail existed
  to make it obvious the codepath wasn't supported. Now that the rest of
  PR 1 + PR 2 supports it, the guardrail is removed.

- **Five tests, around eight test cases total** :
  - The new helper builds a real tiny TRT engine and verifies it accepts
    batch sizes 1 through 4 and rejects batch size 5.
  - The bundle format roundtrips with the new field present and absent.
  - The seed and chunk-planning helpers work as documented.
  - One smoke test per family confirms the new keyword argument actually
    triggers the dynamic-batch path. Qwen Image's has an extra
    regression test for the removed guardrail.

  `ctest` and `pytest` both green: 13/13 + 42/42.

## How to verify

```bash
# Build and run the unit tests
cmake --build build
ctest --test-dir build -R 'diffusion|bundle'         # 13/13 PASS
python -m pytest tests/builder/test_*batch*.py \
                 tests/builder/test_family_{flux,z_image}.py
# 42/42 PASS

# Run the same checks CI will run
python tools/check_cyclomatic_complexity.py src --exclude src/cli \
       --max-ccn 10 --top 20                           # PASS
CI_BASE_REF=github/main bash .github/scripts/run-trtmc-ci.sh lint
# PASS (Python ruff + clang-format on changed files)
```
