### PR TITLE
feat(locateanything): add LocateAnything-3B support

### DIFF
--- a/python/tensorrt_model_connect/builders/default_decoder.py
+++ b/python/tensorrt_model_connect/builders/default_decoder.py
@@ -25,7 +25,7 @@ from .. import graph_ops
 from .. import graph_blocks
 from ..config import ModelConfig
 from .default_dual_profile_decoder import build_dual_profile_decoder_engine
-from .utils import create_builder_context
+from .utils import const_in_work_dtype, create_builder_context
 
 trt = trt_compat.get_trt()
 
@@ -342,10 +342,9 @@ def build_standard_decoder_engine(
         flag_for_math = flag_broadcast.get_output(0)
         if work_trt_dtype != trt.float32:
             flag_for_math = network.add_cast(flag_for_math, work_trt_dtype).get_output(0)
-        one_const = graph_ops.add_constant(
+        one_const = const_in_work_dtype(
             network, (1, 1), np.array([1.0], dtype=work_np_dtype),
-            dtype=work_np_dtype)
-        one_const = _cast_work_dtype(one_const)
+            work_np_dtype, work_trt_dtype)
         inv_flag = network.add_elementwise(
             one_const, flag_for_math,
             trt.ElementWiseOperation.SUB)

--- a/python/tensorrt_model_connect/debug_runner.py
+++ b/python/tensorrt_model_connect/debug_runner.py
@@ -2665,6 +2665,44 @@ def _preprocess_simple_chw(
     return img_np.transpose(2, 0, 1).astype(np.float32)
 
 
+def _preprocess_locateanything_patchify(
+    image_path: str,
+    fixed_image_size: int = 448,
+    image_mean: tuple[float, ...] = (0.5, 0.5, 0.5),
+    image_std: tuple[float, ...] = (0.5, 0.5, 0.5),
+    patch_size: int = 14,
+    interpolation: str = "bicubic",
+    **_kwargs: Any,
+) -> tuple[np.ndarray, np.ndarray]:
+    """LocateAnything preprocessing: [N, C, pH, pW] plus [1, 2] grid."""
+    from PIL import Image
+
+    if patch_size <= 0 or fixed_image_size % patch_size != 0:
+        raise ValueError(
+            "LocateAnything fixed_image_size must be divisible by patch_size")
+
+    resample = _resolve_pil_interpolation(interpolation)
+    img = Image.open(image_path).convert("RGB")
+    img = img.resize((fixed_image_size, fixed_image_size), resample)
+    img_np = np.array(img, dtype=np.float32) / 255.0
+
+    mean = np.array(image_mean, dtype=np.float32)
+    std = np.array(image_std, dtype=np.float32)
+    img_np = (img_np - mean) / std
+
+    img_chw = img_np.transpose(2, 0, 1)
+    channels = img_chw.shape[0]
+    grid_h = fixed_image_size // patch_size
+    grid_w = fixed_image_size // patch_size
+    pixel_values = img_chw.reshape(
+        channels, grid_h, patch_size, grid_w, patch_size
+    ).transpose(1, 3, 0, 2, 4).reshape(
+        grid_h * grid_w, channels, patch_size, patch_size
+    )
+    image_grid_hws = np.array([[grid_h, grid_w]], dtype=np.int32)
+    return pixel_values.astype(np.float32), image_grid_hws
+
+
 def _preprocess_center_crop_chw(
     image_path: str,
     fixed_image_size: int = 448,
@@ -2774,6 +2812,55 @@ def _preprocess_pad_center_chw(
     return img_np.transpose(2, 0, 1).astype(np.float32)
 
 
+def preprocess_image_inputs_for_trt(
+    image_path: str,
+    preprocessor_type: str = "qwen_merge_group",
+    **kwargs: Any,
+) -> dict[str, np.ndarray]:
+    """Load and preprocess image inputs for a TRT vision engine.
+
+    Returns named arrays keyed by TensorRT input name. Most models only need
+    pixel_values; LocateAnything also needs image_grid_hws.
+    """
+    temporal = kwargs.get("temporal_patch_size", 1)
+
+    if preprocessor_type == "locateanything_patchify":
+        pixel_values, image_grid_hws = _preprocess_locateanything_patchify(
+            image_path, **kwargs)
+        return {
+            "pixel_values": pixel_values,
+            "image_grid_hws": image_grid_hws,
+        }
+
+    if preprocessor_type == "simple_chw":
+        result = _preprocess_simple_chw(image_path, **kwargs)
+        if temporal > 1 and result.shape[0] < temporal * 3:
+            result = np.tile(result, (temporal, 1, 1))
+        return {"pixel_values": result}
+    if preprocessor_type == "center_crop_chw":
+        result = _preprocess_center_crop_chw(image_path, **kwargs)
+        if temporal > 1 and result.shape[0] < temporal * 3:
+            result = np.tile(result, (temporal, 1, 1))
+        return {"pixel_values": result}
+    if preprocessor_type == "aspect_preserve_chw":
+        result = _preprocess_aspect_preserve_chw(image_path, **kwargs)
+        if temporal > 1 and result.shape[0] < temporal * 3:
+            result = np.tile(result, (temporal, 1, 1))
+        return {"pixel_values": result}
+    if preprocessor_type == "pad_center_chw":
+        result = _preprocess_pad_center_chw(image_path, **kwargs)
+        if temporal > 1 and result.shape[0] < temporal * 3:
+            result = np.tile(result, (temporal, 1, 1))
+        return {"pixel_values": result}
+    if preprocessor_type != "qwen_merge_group":
+        warnings.warn(
+            f"Unknown preprocessor_type {preprocessor_type!r}, "
+            f"falling back to qwen_merge_group",
+            stacklevel=2,
+        )
+    return {"pixel_values": _preprocess_qwen_merge_group(image_path, **kwargs)}
+
+
 def preprocess_image_for_trt(
     image_path: str,
     preprocessor_type: str = "qwen_merge_group",
@@ -2781,41 +2868,11 @@ def preprocess_image_for_trt(
 ) -> np.ndarray:
     """Load and preprocess an image for the TRT vision engine.
 
-    Dispatches to the appropriate strategy based on preprocessor_type:
-      "qwen_merge_group":    [C*T, H, W] with merge-group patch permutation
-      "simple_chw":          [C, H, W] standard resize + normalize
-      "center_crop_chw":     [C, H, W] center-crop to square, then resize + normalize
-      "aspect_preserve_chw": [C, H, W] aspect-preserving resize + zero-pad
-      "pad_center_chw":      [C, H, W] aspect-preserving resize + centered zero-pad
+    Compatibility wrapper returning only pixel_values. Use
+    preprocess_image_inputs_for_trt when the engine has auxiliary inputs.
     """
-    temporal = kwargs.get("temporal_patch_size", 1)
-    if preprocessor_type == "simple_chw":
-        result = _preprocess_simple_chw(image_path, **kwargs)
-        if temporal > 1 and result.shape[0] < temporal * 3:
-            result = np.tile(result, (temporal, 1, 1))
-        return result
-    if preprocessor_type == "center_crop_chw":
-        result = _preprocess_center_crop_chw(image_path, **kwargs)
-        if temporal > 1 and result.shape[0] < temporal * 3:
-            result = np.tile(result, (temporal, 1, 1))
-        return result
-    if preprocessor_type == "aspect_preserve_chw":
-        result = _preprocess_aspect_preserve_chw(image_path, **kwargs)
-        if temporal > 1 and result.shape[0] < temporal * 3:
-            result = np.tile(result, (temporal, 1, 1))
-        return result
-    if preprocessor_type == "pad_center_chw":
-        result = _preprocess_pad_center_chw(image_path, **kwargs)
-        if temporal > 1 and result.shape[0] < temporal * 3:
-            result = np.tile(result, (temporal, 1, 1))
-        return result
-    if preprocessor_type != "qwen_merge_group":
-        warnings.warn(
-            f"Unknown preprocessor_type {preprocessor_type!r}, "
-            f"falling back to qwen_merge_group",
-            stacklevel=2,
-        )
-    return _preprocess_qwen_merge_group(image_path, **kwargs)
+    return preprocess_image_inputs_for_trt(
+        image_path, preprocessor_type=preprocessor_type, **kwargs)["pixel_values"]
 
 
 class SegmentationTrtRunner:
@@ -2952,13 +3009,18 @@ class VLTrtRunner:
             "preprocessor_type", "qwen_merge_group")
 
         # Preprocessor config
-        self.temporal_patch_size = self.preproc_config.get("temporal_patch_size", 2)
-        self.patch_size = self.preproc_config.get("patch_size", 14)
-        self.merge_size = self.preproc_config.get("merge_size", 2)
+        self.temporal_patch_size = self.preproc_config.get(
+            "temporal_patch_size", self.config.get("temporal_patch_size", 2))
+        self.patch_size = self.preproc_config.get(
+            "patch_size", self.config.get("patch_size", 14))
+        self.merge_size = self.preproc_config.get(
+            "merge_size", self.config.get("merge_size", 2))
         self.image_mean = tuple(self.preproc_config.get(
-            "image_mean", [0.48145466, 0.4578275, 0.40821073]))
+            "image_mean", self.config.get(
+                "image_mean", [0.48145466, 0.4578275, 0.40821073])))
         self.image_std = tuple(self.preproc_config.get(
-            "image_std", [0.26862954, 0.26130258, 0.27577711]))
+            "image_std", self.config.get(
+                "image_std", [0.26862954, 0.26130258, 0.27577711])))
         self.interpolation = self.config.get("interpolation", "bicubic")
 
         self.tokenizer = tokenizer
@@ -2975,7 +3037,7 @@ class VLTrtRunner:
         if self.vision_runner is None:
             raise RuntimeError("No vision engine in bundle")
 
-        pixel_values = preprocess_image_for_trt(
+        vision_inputs = preprocess_image_inputs_for_trt(
             image_path,
             preprocessor_type=self.preprocessor_type,
             fixed_image_size=self.fixed_image_size,
@@ -2986,7 +3048,7 @@ class VLTrtRunner:
             merge_size=self.merge_size,
             interpolation=self.interpolation,
         )
-        results = self.vision_runner.encode(pixel_values=pixel_values)
+        results = self.vision_runner.encode(**vision_inputs)
         return results["image_features"]
 
     def format_prompt(self, user_prompt: str) -> str:

--- a/python/tensorrt_model_connect/families/llama/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/llama/standard_decoder_builder.py
@@ -25,6 +25,7 @@ from ... import graph_ops
 from ... import graph_blocks
 from ...config import ModelConfig
 from .dual_profile_decoder_builder import build_dual_profile_decoder_engine
+from ...builders.utils import const_in_work_dtype
 
 trt = trt_compat.get_trt()
 
@@ -343,9 +344,10 @@ def build_standard_decoder_engine(
         flag_for_math = flag_broadcast.get_output(0)
         if work_trt_dtype != trt.float32:
             flag_for_math = network.add_cast(flag_for_math, work_trt_dtype).get_output(0)
-        one_const = graph_ops.add_constant(
+        one_const = const_in_work_dtype(
             network, (1, 1), np.array([1.0], dtype=work_np_dtype),
-            dtype=work_np_dtype)
+            work_np_dtype, work_trt_dtype)
+        token_embed = _cast_work_dtype(token_embed)
         inv_flag = network.add_elementwise(
             one_const, flag_for_math,
             trt.ElementWiseOperation.SUB)

--- a/python/tensorrt_model_connect/families/locateanything/__init__.py
+++ b/python/tensorrt_model_connect/families/locateanything/__init__.py
@@ -1,0 +1,5 @@
+"""LocateAnything family plugin."""
+
+from .plugin import plugin
+
+__all__ = ["plugin"]

--- a/python/tensorrt_model_connect/families/locateanything/plugin.py
+++ b/python/tensorrt_model_connect/families/locateanything/plugin.py
@@ -1,0 +1,327 @@
+"""LocateAnything family plugin.
+
+LocateAnything-3B is a custom-code vision-language model:
+  - Vision: MoonViT patch encoder.
+  - Projector: LayerNorm + two-layer MLP (``mlp1``).
+  - Text: Qwen2.5 decoder under ``language_model.model.*``.
+
+This plugin wires the Qwen text decoder and bundle metadata.  The MoonViT
+vision engine is intentionally not emitted yet because the current C++ VL
+runtime passes only ``pixel_values`` to vision engines, while LocateAnything
+requires patchified inputs plus ``image_grid_hws``.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ...checkpoint_mapper import (
+    WeightDict,
+    _has_tensor,
+    _load_tensor,
+    _open_safetensors,
+    _transpose_2d,
+)
+from ...config import ModelConfig
+from ...parallel_config import (
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
+from ...builders.default_decoder import build_standard_decoder_engine
+
+if TYPE_CHECKING:
+    from ...quantization.context import QuantContext
+
+
+_DEFAULT_FIXED_IMAGE_SIZE = 448
+
+
+class LocateAnythingPlugin:
+    name = "locateanything"
+    runtime_strategy = "vision_language"
+    embed_input = True
+
+    def matches(self, model_type: str) -> bool:
+        return model_type.lower() == "locateanything"
+
+    def load_weights(
+        self,
+        model_dir: str,
+        config: ModelConfig,
+    ) -> WeightDict:
+        return _load_locateanything_text_weights(model_dir, config)
+
+    def build_engine(
+        self,
+        config: ModelConfig,
+        weights: WeightDict,
+        max_cache_length: int,
+        *,
+        precision: str = "fp32",
+        quant_ctx: "QuantContext | None" = None,
+        verbose: bool = False,
+        debug_layer_outputs: bool = False,
+        parallel_config=None,
+    ) -> bytes:
+        parallel = normalize_parallel_config(parallel_config)
+        if parallel.enabled:
+            require_tensorrt_11_for_tensor_parallel(
+                parallel, feature="LocateAnything tensor-parallel builds")
+            if debug_layer_outputs:
+                raise ValueError(
+                    "LocateAnything tensor-parallel builds do not support "
+                    "debug layer outputs")
+            from ..qwen_vl.decoder_tp_builder import build_qwen_vl_tp_decoder_engine
+
+            return build_qwen_vl_tp_decoder_engine(
+                config,
+                weights,
+                max_cache_length,
+                precision=precision,
+                quant_ctx=quant_ctx,
+                embed_input=True,
+                deepstack_num_levels=0,
+                verbose=verbose,
+                debug_layer_outputs=debug_layer_outputs,
+                parallel_config=parallel,
+            )
+
+        return build_standard_decoder_engine(
+            config,
+            weights,
+            max_cache_length,
+            precision=precision,
+            quant_ctx=quant_ctx,
+            embed_input=True,
+            verbose=verbose,
+            debug_layer_outputs=debug_layer_outputs,
+        )
+
+    def build_vision_engine(
+        self,
+        model_dir: str,
+        config: ModelConfig,
+        weights: WeightDict,
+        *,
+        precision: str = "fp32",
+        verbose: bool = False,
+    ) -> bytes | None:
+        print(
+            "[trtmc build] LocateAnything MoonViT vision engine is not yet "
+            "emitted: runtime support for image_grid_hws is required. "
+            "Building text decoder only.",
+            file=sys.stderr,
+        )
+        return None
+
+    def get_vl_config(self, config: ModelConfig) -> dict | None:
+        vision_config = config.raw.get("vision_config")
+        if not isinstance(vision_config, dict):
+            return None
+
+        patch_size = _first_int(vision_config.get("patch_size", 14), 14)
+        merge_kernel = vision_config.get("merge_kernel_size", [2, 2])
+        if isinstance(merge_kernel, (list, tuple)) and len(merge_kernel) >= 2:
+            merge_h = _first_int(merge_kernel[0], 2)
+            merge_w = _first_int(merge_kernel[1], 2)
+        else:
+            merge_h = merge_w = 2
+
+        fixed_image_size = _DEFAULT_FIXED_IMAGE_SIZE
+        grid_h = fixed_image_size // patch_size
+        grid_w = fixed_image_size // patch_size
+        num_image_tokens = (grid_h * grid_w) // max(merge_h * merge_w, 1)
+
+        return {
+            "image_token_id": config.raw.get(
+                "image_token_index", config.raw.get("image_token_id", 151665)),
+            "fixed_image_size": fixed_image_size,
+            "num_image_pad_tokens": num_image_tokens,
+            "vision_output_dim": config.hidden_size,
+            "preprocessor_type": "locateanything_patchify",
+            "interpolation": "bicubic",
+            "vl_prompt_template": (
+                "<|im_start|>system\n"
+                "You are a helpful assistant.<|im_end|>\n"
+                "<|im_start|>user\n"
+                "<image-1>{prompt}<|im_end|>\n"
+                "<|im_start|>assistant\n"
+            ),
+            "image_token_str": "<IMG_CONTEXT>",
+            "locateanything_vision_engine_supported": False,
+            "locateanything_vision_note": (
+                "MoonViT requires patchified pixel_values plus image_grid_hws; "
+                "current TRT MC VL runtime passes only pixel_values."),
+            "box_start_token_id": config.raw.get("box_start_token_id", 151668),
+            "box_end_token_id": config.raw.get("box_end_token_id", 151669),
+            "coord_start_token_id": config.raw.get("coord_start_token_id", 151677),
+            "coord_end_token_id": config.raw.get("coord_end_token_id", 152677),
+            "ref_start_token_id": config.raw.get("ref_start_token_id", 151672),
+            "ref_end_token_id": config.raw.get("ref_end_token_id", 151673),
+            "none_token_id": config.raw.get("none_token_id", 4064),
+        }
+
+    def get_bundle_config_overrides(self, config: ModelConfig) -> dict | None:
+        return {
+            "model_type": "locateanything",
+            "runtime_strategy": "vision_language",
+            "embed_input": True,
+        }
+
+
+def _first_int(value: object, default: int) -> int:
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return default
+        value = value[0]
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _load_locateanything_text_weights(
+    model_dir: str,
+    config: ModelConfig,
+) -> WeightDict:
+    """Load the Qwen text decoder from LocateAnything safetensors."""
+    from pathlib import Path
+
+    model_dir_path = Path(model_dir)
+    readers = _open_safetensors(model_dir_path)
+
+    hidden = config.hidden_size
+    vocab = config.vocab_size
+    num_layers = config.num_hidden_layers
+    weights = WeightDict()
+
+    embed_key = _first_existing_tensor(
+        readers,
+        [
+            "language_model.model.embed_tokens.weight",
+            "model.language_model.model.embed_tokens.weight",
+            "model.embed_tokens.weight",
+        ],
+        "text token embedding",
+    )
+    embedding = _load_tensor(readers, embed_key)
+    assert embedding.shape == (vocab, hidden), (
+        f"Embedding shape {embedding.shape} != ({vocab}, {hidden})")
+    weights["embedding"] = embedding.astype(np.float32)
+
+    layer_prefix = _detect_layer_prefix(readers)
+    attention_size = 0
+    kv_attention_size = 0
+    mlp_size = 0
+
+    for layer_idx in range(num_layers):
+        prefix = f"layer.{layer_idx}"
+        hf_prefix = f"{layer_prefix}.{layer_idx}"
+
+        weights[f"{prefix}.input_norm"] = _load_tensor(
+            readers, f"{hf_prefix}.input_layernorm.weight").astype(np.float32)
+        weights[f"{prefix}.post_attn_norm"] = _load_tensor(
+            readers, f"{hf_prefix}.post_attention_layernorm.weight").astype(np.float32)
+
+        q_raw = _load_tensor(readers, f"{hf_prefix}.self_attn.q_proj.weight")
+        k_raw = _load_tensor(readers, f"{hf_prefix}.self_attn.k_proj.weight")
+        v_raw = _load_tensor(readers, f"{hf_prefix}.self_attn.v_proj.weight")
+        o_raw = _load_tensor(readers, f"{hf_prefix}.self_attn.o_proj.weight")
+
+        if attention_size == 0:
+            attention_size = q_raw.shape[0]
+        if kv_attention_size == 0:
+            kv_attention_size = k_raw.shape[0]
+
+        weights[f"{prefix}.w_q"] = _transpose_2d(q_raw, "q_proj")
+        weights[f"{prefix}.w_k"] = _transpose_2d(k_raw, "k_proj")
+        weights[f"{prefix}.w_v"] = _transpose_2d(v_raw, "v_proj")
+        weights[f"{prefix}.w_o"] = _transpose_2d(o_raw, "o_proj")
+
+        for proj_name, weight_key in [
+            ("q_bias", "self_attn.q_proj.bias"),
+            ("k_bias", "self_attn.k_proj.bias"),
+            ("v_bias", "self_attn.v_proj.bias"),
+        ]:
+            full_key = f"{hf_prefix}.{weight_key}"
+            if _has_tensor(readers, full_key):
+                weights[f"{prefix}.{proj_name}"] = _load_tensor(
+                    readers, full_key).astype(np.float32)
+
+        gate_raw = _load_tensor(readers, f"{hf_prefix}.mlp.gate_proj.weight")
+        up_raw = _load_tensor(readers, f"{hf_prefix}.mlp.up_proj.weight")
+        down_raw = _load_tensor(readers, f"{hf_prefix}.mlp.down_proj.weight")
+
+        if mlp_size == 0:
+            mlp_size = gate_raw.shape[0]
+
+        weights[f"{prefix}.w_gate"] = _transpose_2d(gate_raw, "gate")
+        weights[f"{prefix}.w_up"] = _transpose_2d(up_raw, "up")
+        weights[f"{prefix}.w_down"] = _transpose_2d(down_raw, "down")
+
+    final_norm_key = _first_existing_tensor(
+        readers,
+        [
+            f"{layer_prefix.rsplit('.layers', 1)[0]}.norm.weight",
+            "language_model.model.norm.weight",
+            "model.norm.weight",
+        ],
+        "text final norm",
+        required=False,
+    )
+    if final_norm_key is not None:
+        weights["final_norm"] = _load_tensor(readers, final_norm_key).astype(np.float32)
+    else:
+        weights["final_norm"] = np.ones(hidden, dtype=np.float32)
+
+    lm_head_key = _first_existing_tensor(
+        readers,
+        [
+            "language_model.lm_head.weight",
+            "lm_head.weight",
+            "model.lm_head.weight",
+        ],
+        "LM head",
+        required=False,
+    )
+    if lm_head_key is not None:
+        weights["w_out"] = _transpose_2d(_load_tensor(readers, lm_head_key), "lm_head")
+    else:
+        weights["w_out"] = _transpose_2d(embedding.copy(), "embedding_tied")
+
+    weights["_attention_size"] = attention_size
+    weights["_kv_attention_size"] = kv_attention_size
+    weights["_mlp_size"] = mlp_size
+    return weights
+
+
+def _first_existing_tensor(
+    readers,
+    names: list[str],
+    description: str,
+    *,
+    required: bool = True,
+) -> str | None:
+    for name in names:
+        if _has_tensor(readers, name):
+            return name
+    if required:
+        raise RuntimeError(f"Cannot find LocateAnything {description} weights")
+    return None
+
+
+def _detect_layer_prefix(readers) -> str:
+    for prefix in [
+        "language_model.model.layers",
+        "model.language_model.model.layers",
+        "model.layers",
+    ]:
+        if _has_tensor(readers, f"{prefix}.0.input_layernorm.weight"):
+            return prefix
+    raise RuntimeError("Cannot find LocateAnything text decoder layer weights")
+
+
+plugin = LocateAnythingPlugin()

--- a/python/tensorrt_model_connect/families/locateanything/plugin.py
+++ b/python/tensorrt_model_connect/families/locateanything/plugin.py
@@ -5,15 +5,12 @@ LocateAnything-3B is a custom-code vision-language model:
   - Projector: LayerNorm + two-layer MLP (``mlp1``).
   - Text: Qwen2.5 decoder under ``language_model.model.*``.
 
-This plugin wires the Qwen text decoder and bundle metadata.  The MoonViT
-vision engine is intentionally not emitted yet because the current C++ VL
-runtime passes only ``pixel_values`` to vision engines, while LocateAnything
-requires patchified inputs plus ``image_grid_hws``.
+This plugin wires a fixed single-image TRT MC contract: 448x448 image input,
+14x14 MoonViT patches, 32x32 patch grid, 2x2 merge, and 256 image tokens.
 """
 
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -109,13 +106,11 @@ class LocateAnythingPlugin:
         precision: str = "fp32",
         verbose: bool = False,
     ) -> bytes | None:
-        print(
-            "[trtmc build] LocateAnything MoonViT vision engine is not yet "
-            "emitted: runtime support for image_grid_hws is required. "
-            "Building text decoder only.",
-            file=sys.stderr,
-        )
-        return None
+        from .vision_builder import build_locateanything_vision_engine
+
+        return build_locateanything_vision_engine(
+            model_dir, config, fixed_image_size=_DEFAULT_FIXED_IMAGE_SIZE,
+            verbose=verbose)
 
     def get_vl_config(self, config: ModelConfig) -> dict | None:
         vision_config = config.raw.get("vision_config")
@@ -139,22 +134,25 @@ class LocateAnythingPlugin:
             "image_token_id": config.raw.get(
                 "image_token_index", config.raw.get("image_token_id", 151665)),
             "fixed_image_size": fixed_image_size,
+            "patch_size": patch_size,
+            "merge_size": merge_h,
             "num_image_pad_tokens": num_image_tokens,
             "vision_output_dim": config.hidden_size,
             "preprocessor_type": "locateanything_patchify",
+            "image_mean": [0.5, 0.5, 0.5],
+            "image_std": [0.5, 0.5, 0.5],
+            "temporal_patch_size": 1,
             "interpolation": "bicubic",
             "vl_prompt_template": (
                 "<|im_start|>system\n"
                 "You are a helpful assistant.<|im_end|>\n"
                 "<|im_start|>user\n"
-                "<image-1>{prompt}<|im_end|>\n"
+                "<img>{image_pads}</img>{prompt}<|im_end|>\n"
                 "<|im_start|>assistant\n"
             ),
             "image_token_str": "<IMG_CONTEXT>",
-            "locateanything_vision_engine_supported": False,
-            "locateanything_vision_note": (
-                "MoonViT requires patchified pixel_values plus image_grid_hws; "
-                "current TRT MC VL runtime passes only pixel_values."),
+            "locateanything_fixed_vision_grid_h": grid_h,
+            "locateanything_fixed_vision_grid_w": grid_w,
             "box_start_token_id": config.raw.get("box_start_token_id", 151668),
             "box_end_token_id": config.raw.get("box_end_token_id", 151669),
             "coord_start_token_id": config.raw.get("coord_start_token_id", 151677),

--- a/python/tensorrt_model_connect/families/locateanything/vision_builder.py
+++ b/python/tensorrt_model_connect/families/locateanything/vision_builder.py
@@ -1,0 +1,230 @@
+"""LocateAnything MoonViT vision engine builder.
+
+The HF MoonViT implementation uses Python shape loops and complex-valued RoPE.
+For TRT MC's initial LocateAnything contract we export a fixed single-image
+path: 448x448 input, 14x14 patches, 32x32 patch grid, 2x2 merge, producing
+256 projected image features.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import math
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+
+from ...checkpoint_mapper import _has_tensor, _load_tensor, _open_safetensors
+from ...config import ModelConfig
+from ..qwen_vl.onnx_vision_builder import build_engine_from_onnx
+
+
+def build_locateanything_vision_engine(
+    model_dir: str,
+    config: ModelConfig,
+    *,
+    fixed_image_size: int = 448,
+    verbose: bool = False,
+) -> bytes:
+    """Build MoonViT + mlp1 as a TRT vision engine.
+
+    Inputs:
+        pixel_values: [1024, 3, 14, 14] float32 for the fixed 448x448 path.
+        The export is traced with image_grid_hws=[[32, 32]]; TensorRT may
+        constant-fold that fixed grid and omit it from the final engine inputs.
+
+    Output:
+        image_features: [256, hidden_size] float32
+    """
+    import torch
+
+    model_dir_path = Path(model_dir)
+    modeling_vit = _load_modeling_vit(model_dir_path)
+    _patch_moonvit_for_onnx(modeling_vit)
+
+    vision_model = _build_moonvit(modeling_vit, config)
+    projector = _build_projector(config)
+    _load_vision_and_projector_weights(model_dir_path, vision_model, projector)
+
+    wrapper = _LocateAnythingVisionWrapper(vision_model, projector).eval()
+
+    vision_config = config.raw.get("vision_config", {})
+    patch_size = int(vision_config.get("patch_size", 14))
+    grid_h = fixed_image_size // patch_size
+    grid_w = fixed_image_size // patch_size
+    num_patches = grid_h * grid_w
+
+    dummy_pixel = torch.zeros(num_patches, 3, patch_size, patch_size, dtype=torch.float32)
+    dummy_grid = torch.tensor([[grid_h, grid_w]], dtype=torch.int32)
+
+    if verbose:
+        print(
+            "[trtmc build] Exporting LocateAnything MoonViT vision path "
+            f"to ONNX (grid={grid_h}x{grid_w}, patches={num_patches}) ...",
+            file=sys.stderr,
+        )
+
+    onnx_buffer = io.BytesIO()
+    with torch.no_grad():
+        export_kwargs = dict(
+            opset_version=17,
+            input_names=["pixel_values", "image_grid_hws"],
+            output_names=["image_features"],
+        )
+        try:
+            torch.onnx.export(
+                wrapper,
+                (dummy_pixel, dummy_grid),
+                onnx_buffer,
+                dynamo=False,
+                **export_kwargs,
+            )
+        except TypeError:
+            torch.onnx.export(
+                wrapper,
+                (dummy_pixel, dummy_grid),
+                onnx_buffer,
+                **export_kwargs,
+            )
+
+    onnx_bytes = onnx_buffer.getvalue()
+    if verbose:
+        print(
+            f"[trtmc build] LocateAnything vision ONNX export done "
+            f"({len(onnx_bytes) / (1024 * 1024):.1f} MB)",
+            file=sys.stderr,
+        )
+    return build_engine_from_onnx(onnx_bytes, verbose=verbose)
+
+
+class _LocateAnythingVisionWrapper:
+    def __new__(cls, vision_model, projector):
+        import torch
+
+        class Wrapper(torch.nn.Module):
+            def __init__(self, vision_model, projector):
+                super().__init__()
+                self.vision_model = vision_model
+                self.projector = projector
+
+            def forward(self, pixel_values, image_grid_hws):
+                features = self.vision_model(pixel_values, image_grid_hws)
+                return self.projector(torch.cat(features, dim=0))
+
+        return Wrapper(vision_model, projector)
+
+
+def _load_modeling_vit(model_dir: Path) -> ModuleType:
+    path = model_dir / "modeling_vit.py"
+    if not path.exists():
+        raise RuntimeError(
+            "LocateAnything vision build requires modeling_vit.py from the "
+            "HF repository. Re-download the model with trust_remote_code files."
+        )
+    module_name = f"trtmc_locateanything_modeling_vit_{abs(hash(str(path)))}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot import LocateAnything MoonViT module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _patch_moonvit_for_onnx(modeling_vit: ModuleType) -> None:
+    """Replace export-hostile HF helpers with equivalent real-valued ops."""
+
+    def real_apply_rope(xq, xk, freqs_cis):
+        import torch
+
+        freqs_real = torch.view_as_real(freqs_cis)
+        cos = freqs_real.select(-1, 0).unsqueeze(-2)
+        sin = freqs_real.select(-1, 1).unsqueeze(-2)
+
+        def rotate(x):
+            x_pair = x.float().reshape(*x.shape[:-1], -1, 2)
+            x0 = x_pair[..., 0]
+            x1 = x_pair[..., 1]
+            y = torch.stack((x0 * cos - x1 * sin, x0 * sin + x1 * cos), dim=-1)
+            return y.flatten(-2).to(dtype=x.dtype)
+
+        return rotate(xq), rotate(xk)
+
+    def full_sequence_attention(q, k, v, q_cu_seqlens=None, k_cu_seqlens=None):
+        import torch
+
+        q = q.transpose(0, 1)
+        k = k.transpose(0, 1)
+        v = v.transpose(0, 1)
+        attn = (q @ k.transpose(-2, -1)) / math.sqrt(q.shape[-1])
+        out = torch.softmax(attn, dim=-1, dtype=torch.float32).to(q.dtype) @ v
+        return out.transpose(0, 1).reshape(q.shape[1], -1)
+
+    modeling_vit.apply_rope = real_apply_rope
+    modeling_vit.VL_VISION_ATTENTION_FUNCTIONS["eager"] = full_sequence_attention
+
+
+def _build_moonvit(modeling_vit: ModuleType, config: ModelConfig):
+    vision_config = dict(config.raw.get("vision_config", {}))
+    vision_config.pop("auto_map", None)
+    vision_config.pop("model_type", None)
+    vision_config.pop("torch_dtype", None)
+    vision_config["_attn_implementation"] = "eager"
+    cfg = modeling_vit.MoonViTConfig(**vision_config)
+    cfg._attn_implementation = "eager"
+    return modeling_vit.MoonVitPretrainedModel(cfg).eval()
+
+
+def _build_projector(config: ModelConfig):
+    import torch
+
+    vit_hidden = int(config.raw.get("vision_config", {}).get("hidden_size", 1152))
+    llm_hidden = int(config.hidden_size)
+    return torch.nn.Sequential(
+        torch.nn.LayerNorm(vit_hidden * 4),
+        torch.nn.Linear(vit_hidden * 4, llm_hidden),
+        torch.nn.GELU(),
+        torch.nn.Linear(llm_hidden, llm_hidden),
+    ).eval()
+
+
+def _load_vision_and_projector_weights(model_dir: Path, vision_model, projector) -> None:
+    import torch
+
+    readers = _open_safetensors(model_dir)
+    _load_module_state(readers, vision_model, ("vision_model", "model.vision_model"))
+    _load_module_state(readers, projector, ("mlp1", "model.mlp1"))
+
+    # Force float32 export even when the source checkpoint stores bf16/fp16.
+    vision_model.to(dtype=torch.float32)
+    projector.to(dtype=torch.float32)
+
+
+def _load_module_state(readers, module, prefixes: tuple[str, ...]) -> None:
+    import torch
+
+    state = {}
+    missing = []
+    for key in module.state_dict().keys():
+        tensor_key = _find_prefixed_tensor(readers, prefixes, key)
+        if tensor_key is None:
+            missing.append(key)
+            continue
+        state[key] = torch.from_numpy(_load_tensor(readers, tensor_key).astype(np.float32))
+    if missing:
+        preview = ", ".join(missing[:8])
+        raise RuntimeError(
+            f"LocateAnything vision checkpoint is missing {len(missing)} tensors: {preview}"
+        )
+    module.load_state_dict(state, strict=True)
+
+
+def _find_prefixed_tensor(readers, prefixes: tuple[str, ...], key: str) -> str | None:
+    for prefix in prefixes:
+        candidate = f"{prefix}.{key}"
+        if _has_tensor(readers, candidate):
+            return candidate
+    return None

--- a/python/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
+++ b/python/tensorrt_model_connect/families/qwen/standard_decoder_builder.py
@@ -25,6 +25,7 @@ from ... import graph_ops
 from ... import graph_blocks
 from ...config import ModelConfig
 from .dual_profile_decoder_builder import build_dual_profile_decoder_engine
+from ...builders.utils import const_in_work_dtype
 
 trt = trt_compat.get_trt()
 
@@ -344,9 +345,10 @@ def build_standard_decoder_engine(
         flag_for_math = flag_broadcast.get_output(0)
         if work_trt_dtype != trt.float32:
             flag_for_math = network.add_cast(flag_for_math, work_trt_dtype).get_output(0)
-        one_const = graph_ops.add_constant(
+        one_const = const_in_work_dtype(
             network, (1, 1), np.array([1.0], dtype=work_np_dtype),
-            dtype=work_np_dtype)
+            work_np_dtype, work_trt_dtype)
+        token_embed = _cast_work_dtype(token_embed)
         inv_flag = network.add_elementwise(
             one_const, flag_for_math,
             trt.ElementWiseOperation.SUB)

--- a/src/runtime/domains/multimodal/image_preprocessor.cpp
+++ b/src/runtime/domains/multimodal/image_preprocessor.cpp
@@ -1,4 +1,7 @@
 #include "runtime/domains/multimodal/image_preprocessor.h"
+
+#include "stb_image.h"
+#include "stb_image_resize2.h"
 #include "trtmc/runtime/domains/multimodal/image_transform_helper.h"
 #include "utils/json_helpers.h"
 
@@ -7,17 +10,13 @@
 #include <iostream>
 #include <string>
 
-#include "stb_image.h"
-#include "stb_image_resize2.h"
-
 namespace trtmc {
 
 // ---------------------------------------------------------------------------
 // Interpolation filter resolution
 // ---------------------------------------------------------------------------
 
-static stbir_filter resolve_stbir_filter(const std::string& interpolation)
-{
+static stbir_filter resolve_stbir_filter(const std::string& interpolation) {
     if (interpolation == "bilinear")
         return STBIR_FILTER_TRIANGLE;
     if (interpolation == "nearest")
@@ -31,39 +30,30 @@ static stbir_filter resolve_stbir_filter(const std::string& interpolation)
 // ---------------------------------------------------------------------------
 
 struct LoadedImage {
-    std::vector<float> img_chw;  // [C, H, W] normalized
+    std::vector<float> img_chw; // [C, H, W] normalized
     int target_size{0};
     int channels{0};
     bool ok{false};
 };
 
 // Resize raw uint8 RGB buffer to target_size x target_size using the given filter.
-static std::vector<unsigned char> resize_raw(
-    const unsigned char* raw, int width, int height,
-    int target_size, stbir_filter filter)
-{
-    std::vector<unsigned char> resized(
-        static_cast<std::size_t>(target_size) * target_size * 3);
+static std::vector<unsigned char> resize_raw(const unsigned char* raw, int width, int height,
+                                             int target_size, stbir_filter filter) {
+    std::vector<unsigned char> resized(static_cast<std::size_t>(target_size) * target_size * 3);
 
-    void* result = stbir_resize(
-        raw, width, height, width * 3,
-        resized.data(), target_size, target_size, target_size * 3,
-        STBIR_RGB, STBIR_TYPE_UINT8,
-        STBIR_EDGE_CLAMP, filter);
+    void* result =
+        stbir_resize(raw, width, height, width * 3, resized.data(), target_size, target_size,
+                     target_size * 3, STBIR_RGB, STBIR_TYPE_UINT8, STBIR_EDGE_CLAMP, filter);
 
-    if (result == nullptr)
-    {
+    if (result == nullptr) {
         return {};
     }
     return resized;
 }
 
 // Convert resized uint8 HWC buffer to float32 CHW, normalizing per channel.
-static bool normalize_to_chw(
-    const std::vector<unsigned char>& resized,
-    int target_size, const VLPreprocessConfig& config,
-    std::vector<float>& out_chw)
-{
+static bool normalize_to_chw(const std::vector<unsigned char>& resized, int target_size,
+                             const VLPreprocessConfig& config, std::vector<float>& out_chw) {
     ImageNormalizationParams params;
     params.width = target_size;
     params.height = target_size;
@@ -81,14 +71,11 @@ static bool normalize_to_chw(
 // Load strategies
 // ---------------------------------------------------------------------------
 
-static LoadedImage load_resize_normalize(
-    const runtime::adapters::io::DecodedImage& image,
-    const VLPreprocessConfig& config)
-{
+static LoadedImage load_resize_normalize(const runtime::adapters::io::DecodedImage& image,
+                                         const VLPreprocessConfig& config) {
     LoadedImage loaded;
 
-    if (image.empty())
-    {
+    if (image.empty()) {
         std::cerr << "[trtmc] Failed to preprocess image: decoded image missing" << std::endl;
         return loaded;
     }
@@ -99,15 +86,13 @@ static LoadedImage load_resize_normalize(
     auto resized = resize_raw(image.pixels.data(), image.width, image.height, target_size,
                               resolve_stbir_filter(config.interpolation));
 
-    if (resized.empty())
-    {
+    if (resized.empty()) {
         std::cerr << "[trtmc] Failed to resize image" << std::endl;
         return loaded;
     }
 
     // 3. Normalize to [C, H, W]
-    if (!normalize_to_chw(resized, target_size, config, loaded.img_chw))
-    {
+    if (!normalize_to_chw(resized, target_size, config, loaded.img_chw)) {
         std::cerr << "[trtmc] Failed to normalize image" << std::endl;
         return loaded;
     }
@@ -118,15 +103,13 @@ static LoadedImage load_resize_normalize(
 }
 
 // Center-crop to square, then resize + normalize.
-static LoadedImage load_crop_resize_normalize(
-    const runtime::adapters::io::DecodedImage& image,
-    const VLPreprocessConfig& config)
-{
+static LoadedImage load_crop_resize_normalize(const runtime::adapters::io::DecodedImage& image,
+                                              const VLPreprocessConfig& config) {
     LoadedImage loaded;
 
-    if (image.empty())
-    {
-        std::cerr << "[trtmc] Failed to preprocess cropped image: decoded image missing" << std::endl;
+    if (image.empty()) {
+        std::cerr << "[trtmc] Failed to preprocess cropped image: decoded image missing"
+                  << std::endl;
         return loaded;
     }
 
@@ -135,12 +118,10 @@ static LoadedImage load_crop_resize_normalize(
     const int x_off = (image.width - crop_size) / 2;
     const int y_off = (image.height - crop_size) / 2;
 
-    std::vector<unsigned char> cropped(
-        static_cast<std::size_t>(crop_size) * crop_size * 3);
-    for (int y = 0; y < crop_size; ++y)
-    {
-        const unsigned char* src_row = image.pixels.data()
-            + (static_cast<std::size_t>(y + y_off) * image.width + x_off) * 3;
+    std::vector<unsigned char> cropped(static_cast<std::size_t>(crop_size) * crop_size * 3);
+    for (int y = 0; y < crop_size; ++y) {
+        const unsigned char* src_row =
+            image.pixels.data() + (static_cast<std::size_t>(y + y_off) * image.width + x_off) * 3;
         unsigned char* dst_row = cropped.data() + static_cast<std::size_t>(y) * crop_size * 3;
         std::memcpy(dst_row, src_row, static_cast<std::size_t>(crop_size) * 3);
     }
@@ -148,14 +129,12 @@ static LoadedImage load_crop_resize_normalize(
     const int target_size = config.fixed_image_size;
     auto resized = resize_raw(cropped.data(), crop_size, crop_size, target_size,
                               resolve_stbir_filter(config.interpolation));
-    if (resized.empty())
-    {
+    if (resized.empty()) {
         std::cerr << "[trtmc] Failed to resize cropped image" << std::endl;
         return loaded;
     }
 
-    if (!normalize_to_chw(resized, target_size, config, loaded.img_chw))
-    {
+    if (!normalize_to_chw(resized, target_size, config, loaded.img_chw)) {
         std::cerr << "[trtmc] Failed to normalize cropped image" << std::endl;
         return loaded;
     }
@@ -166,15 +145,14 @@ static LoadedImage load_crop_resize_normalize(
 }
 
 // Aspect-ratio-preserving resize + zero-pad to square, then normalize.
-static LoadedImage load_aspect_preserve_resize_normalize(
-    const runtime::adapters::io::DecodedImage& image,
-    const VLPreprocessConfig& config)
-{
+static LoadedImage
+load_aspect_preserve_resize_normalize(const runtime::adapters::io::DecodedImage& image,
+                                      const VLPreprocessConfig& config) {
     LoadedImage loaded;
 
-    if (image.empty())
-    {
-        std::cerr << "[trtmc] Failed to preprocess aspect-preserve image: decoded image missing" << std::endl;
+    if (image.empty()) {
+        std::cerr << "[trtmc] Failed to preprocess aspect-preserve image: decoded image missing"
+                  << std::endl;
         return loaded;
     }
 
@@ -182,39 +160,33 @@ static LoadedImage load_aspect_preserve_resize_normalize(
     const stbir_filter filter = resolve_stbir_filter(config.interpolation);
 
     // Compute scaled dimensions that fit inside target_size x target_size
-    const float scale = static_cast<float>(target_size) /
-                        static_cast<float>(std::max(image.width, image.height));
+    const float scale =
+        static_cast<float>(target_size) / static_cast<float>(std::max(image.width, image.height));
     const int new_w = std::max(1, static_cast<int>(image.width * scale));
     const int new_h = std::max(1, static_cast<int>(image.height * scale));
 
     // Resize preserving aspect ratio
-    std::vector<unsigned char> resized_small(
-        static_cast<std::size_t>(new_w) * new_h * 3);
+    std::vector<unsigned char> resized_small(static_cast<std::size_t>(new_w) * new_h * 3);
 
     void* resize_result = stbir_resize(
-        image.pixels.data(), image.width, image.height, image.width * 3,
-        resized_small.data(), new_w, new_h, new_w * 3,
-        STBIR_RGB, STBIR_TYPE_UINT8,
-        STBIR_EDGE_CLAMP, filter);
+        image.pixels.data(), image.width, image.height, image.width * 3, resized_small.data(),
+        new_w, new_h, new_w * 3, STBIR_RGB, STBIR_TYPE_UINT8, STBIR_EDGE_CLAMP, filter);
 
-    if (resize_result == nullptr)
-    {
+    if (resize_result == nullptr) {
         std::cerr << "[trtmc] Failed to resize image (aspect-preserve)" << std::endl;
         return loaded;
     }
 
     // Zero-pad to target_size x target_size (top-left aligned)
-    std::vector<unsigned char> padded(
-        static_cast<std::size_t>(target_size) * target_size * 3, 0);
-    for (int y = 0; y < new_h; ++y)
-    {
-        const unsigned char* src_row = resized_small.data() + static_cast<std::size_t>(y) * new_w * 3;
+    std::vector<unsigned char> padded(static_cast<std::size_t>(target_size) * target_size * 3, 0);
+    for (int y = 0; y < new_h; ++y) {
+        const unsigned char* src_row =
+            resized_small.data() + static_cast<std::size_t>(y) * new_w * 3;
         unsigned char* dst_row = padded.data() + static_cast<std::size_t>(y) * target_size * 3;
         std::memcpy(dst_row, src_row, static_cast<std::size_t>(new_w) * 3);
     }
 
-    if (!normalize_to_chw(padded, target_size, config, loaded.img_chw))
-    {
+    if (!normalize_to_chw(padded, target_size, config, loaded.img_chw)) {
         std::cerr << "[trtmc] Failed to normalize aspect-preserve image" << std::endl;
         return loaded;
     }
@@ -226,15 +198,14 @@ static LoadedImage load_aspect_preserve_resize_normalize(
 
 // Aspect-ratio-preserving resize + center-pad with mean color, then normalize.
 // Matches PIL ImageOps.pad(image, (size, size), color=mean*255).
-static LoadedImage load_pad_center_resize_normalize(
-    const runtime::adapters::io::DecodedImage& image,
-    const VLPreprocessConfig& config)
-{
+static LoadedImage
+load_pad_center_resize_normalize(const runtime::adapters::io::DecodedImage& image,
+                                 const VLPreprocessConfig& config) {
     LoadedImage loaded;
 
-    if (image.empty())
-    {
-        std::cerr << "[trtmc] Failed to preprocess pad-center image: decoded image missing" << std::endl;
+    if (image.empty()) {
+        std::cerr << "[trtmc] Failed to preprocess pad-center image: decoded image missing"
+                  << std::endl;
         return loaded;
     }
 
@@ -250,17 +221,13 @@ static LoadedImage load_pad_center_resize_normalize(
     const int new_h = std::max(1, static_cast<int>(image.height * scale));
 
     // Resize preserving aspect ratio
-    std::vector<unsigned char> resized_small(
-        static_cast<std::size_t>(new_w) * new_h * 3);
+    std::vector<unsigned char> resized_small(static_cast<std::size_t>(new_w) * new_h * 3);
 
     void* resize_result = stbir_resize(
-        image.pixels.data(), image.width, image.height, image.width * 3,
-        resized_small.data(), new_w, new_h, new_w * 3,
-        STBIR_RGB, STBIR_TYPE_UINT8,
-        STBIR_EDGE_CLAMP, filter);
+        image.pixels.data(), image.width, image.height, image.width * 3, resized_small.data(),
+        new_w, new_h, new_w * 3, STBIR_RGB, STBIR_TYPE_UINT8, STBIR_EDGE_CLAMP, filter);
 
-    if (resize_result == nullptr)
-    {
+    if (resize_result == nullptr) {
         std::cerr << "[trtmc] Failed to resize image (pad-center)" << std::endl;
         return loaded;
     }
@@ -270,10 +237,8 @@ static LoadedImage load_pad_center_resize_normalize(
     const unsigned char pad_g = static_cast<unsigned char>(config.image_mean[1] * 255.0F);
     const unsigned char pad_b = static_cast<unsigned char>(config.image_mean[2] * 255.0F);
 
-    std::vector<unsigned char> padded(
-        static_cast<std::size_t>(target_size) * target_size * 3);
-    for (std::size_t i = 0; i < padded.size(); i += 3)
-    {
+    std::vector<unsigned char> padded(static_cast<std::size_t>(target_size) * target_size * 3);
+    for (std::size_t i = 0; i < padded.size(); i += 3) {
         padded[i + 0] = pad_r;
         padded[i + 1] = pad_g;
         padded[i + 2] = pad_b;
@@ -282,17 +247,15 @@ static LoadedImage load_pad_center_resize_normalize(
     // Center the resized image in the padded canvas
     const int x_off = (target_size - new_w) / 2;
     const int y_off = (target_size - new_h) / 2;
-    for (int y = 0; y < new_h; ++y)
-    {
-        const unsigned char* src_row = resized_small.data()
-            + static_cast<std::size_t>(y) * new_w * 3;
-        unsigned char* dst_row = padded.data()
-            + (static_cast<std::size_t>(y + y_off) * target_size + x_off) * 3;
+    for (int y = 0; y < new_h; ++y) {
+        const unsigned char* src_row =
+            resized_small.data() + static_cast<std::size_t>(y) * new_w * 3;
+        unsigned char* dst_row =
+            padded.data() + (static_cast<std::size_t>(y + y_off) * target_size + x_off) * 3;
         std::memcpy(dst_row, src_row, static_cast<std::size_t>(new_w) * 3);
     }
 
-    if (!normalize_to_chw(padded, target_size, config, loaded.img_chw))
-    {
+    if (!normalize_to_chw(padded, target_size, config, loaded.img_chw)) {
         std::cerr << "[trtmc] Failed to normalize pad-center image" << std::endl;
         return loaded;
     }
@@ -306,10 +269,8 @@ static LoadedImage load_pad_center_resize_normalize(
 // Strategy: qwen_merge_group
 // ---------------------------------------------------------------------------
 
-static PreprocessedImage preprocess_qwen_merge_group(
-    const LoadedImage& loaded,
-    const VLPreprocessConfig& config)
-{
+static PreprocessedImage preprocess_qwen_merge_group(const LoadedImage& loaded,
+                                                     const VLPreprocessConfig& config) {
     PreprocessedImage result;
     ImageTransformParams params;
     params.layout = ImageTransformLayout::kQwenMergeGroup;
@@ -321,8 +282,7 @@ static PreprocessedImage preprocess_qwen_merge_group(
 
     result.height = loaded.target_size;
     result.width = loaded.target_size;
-    result.ok = transform_chw_layout(
-        loaded.img_chw, params, result.pixel_values, result.channels);
+    result.ok = transform_chw_layout(loaded.img_chw, params, result.pixel_values, result.channels);
     return result;
 }
 
@@ -330,10 +290,8 @@ static PreprocessedImage preprocess_qwen_merge_group(
 // Strategy: simple_chw
 // ---------------------------------------------------------------------------
 
-static PreprocessedImage preprocess_simple_chw(
-    const LoadedImage& loaded,
-    const VLPreprocessConfig& config)
-{
+static PreprocessedImage preprocess_simple_chw(const LoadedImage& loaded,
+                                               const VLPreprocessConfig& config) {
     PreprocessedImage result;
     ImageTransformParams params;
     params.layout = ImageTransformLayout::kSimpleChw;
@@ -342,29 +300,24 @@ static PreprocessedImage preprocess_simple_chw(
 
     result.height = loaded.target_size;
     result.width = loaded.target_size;
-    result.ok = transform_chw_layout(
-        loaded.img_chw, params, result.pixel_values, result.channels);
+    result.ok = transform_chw_layout(loaded.img_chw, params, result.pixel_values, result.channels);
 
     (void)config;
     return result;
 }
 
-
 // ---------------------------------------------------------------------------
 // Strategy: locateanything_patchify
 // ---------------------------------------------------------------------------
 
-static PreprocessedImage preprocess_locateanything_patchify(
-    const LoadedImage& loaded,
-    const VLPreprocessConfig& config)
-{
+static PreprocessedImage preprocess_locateanything_patchify(const LoadedImage& loaded,
+                                                            const VLPreprocessConfig& config) {
     PreprocessedImage result;
     const int patch = config.patch_size;
     const int channels = loaded.channels;
     const int height = loaded.target_size;
     const int width = loaded.target_size;
-    if (patch <= 0 || height % patch != 0 || width % patch != 0 || channels <= 0)
-    {
+    if (patch <= 0 || height % patch != 0 || width % patch != 0 || channels <= 0) {
         std::cerr << "[trtmc] Invalid LocateAnything patchify shape" << std::endl;
         return result;
     }
@@ -372,26 +325,21 @@ static PreprocessedImage preprocess_locateanything_patchify(
     const int grid_h = height / patch;
     const int grid_w = width / patch;
     const int num_patches = grid_h * grid_w;
-    result.pixel_values.resize(
-        static_cast<std::size_t>(num_patches) * channels * patch * patch);
+    result.pixel_values.resize(static_cast<std::size_t>(num_patches) * channels * patch * patch);
 
-    for (int gh = 0; gh < grid_h; ++gh)
-    {
-        for (int gw = 0; gw < grid_w; ++gw)
-        {
+    for (int gh = 0; gh < grid_h; ++gh) {
+        for (int gw = 0; gw < grid_w; ++gw) {
             const int patch_idx = gh * grid_w + gw;
-            for (int c = 0; c < channels; ++c)
-            {
-                for (int ph = 0; ph < patch; ++ph)
-                {
-                    for (int pw = 0; pw < patch; ++pw)
-                    {
+            for (int c = 0; c < channels; ++c) {
+                for (int ph = 0; ph < patch; ++ph) {
+                    for (int pw = 0; pw < patch; ++pw) {
                         const std::size_t dst =
-                            (((static_cast<std::size_t>(patch_idx) * channels + c) * patch + ph)
-                             * patch + pw);
+                            (((static_cast<std::size_t>(patch_idx) * channels + c) * patch + ph) *
+                                 patch +
+                             pw);
                         const std::size_t src =
-                            (static_cast<std::size_t>(c) * height + gh * patch + ph) * width
-                            + gw * patch + pw;
+                            (static_cast<std::size_t>(c) * height + gh * patch + ph) * width +
+                            gw * patch + pw;
                         result.pixel_values[dst] = loaded.img_chw[src];
                     }
                 }
@@ -411,13 +359,11 @@ static PreprocessedImage preprocess_locateanything_patchify(
 // Dispatcher
 // ---------------------------------------------------------------------------
 
-using LoadImageFn = LoadedImage (*)(
-    const runtime::adapters::io::DecodedImage& image,
-    const VLPreprocessConfig& config);
+using LoadImageFn = LoadedImage (*)(const runtime::adapters::io::DecodedImage& image,
+                                    const VLPreprocessConfig& config);
 
-using PreprocessImageFn = PreprocessedImage (*)(
-    const LoadedImage& loaded,
-    const VLPreprocessConfig& config);
+using PreprocessImageFn = PreprocessedImage (*)(const LoadedImage& loaded,
+                                                const VLPreprocessConfig& config);
 
 struct PreprocessDispatch {
     LoadImageFn load_fn;
@@ -425,8 +371,7 @@ struct PreprocessDispatch {
     bool warn_unknown_type{false};
 };
 
-static PreprocessDispatch resolve_preprocess_dispatch(const std::string& preprocessor_type)
-{
+static PreprocessDispatch resolve_preprocess_dispatch(const std::string& preprocessor_type) {
     if (preprocessor_type == "center_crop_chw")
         return {load_crop_resize_normalize, preprocess_simple_chw, false};
     if (preprocessor_type == "aspect_preserve_chw")
@@ -442,24 +387,19 @@ static PreprocessDispatch resolve_preprocess_dispatch(const std::string& preproc
     return {load_resize_normalize, preprocess_qwen_merge_group, warn_unknown};
 }
 
-static PreprocessedImage run_preprocess_dispatch(
-    const runtime::adapters::io::DecodedImage& image,
-    const VLPreprocessConfig& config,
-    const PreprocessDispatch& dispatch)
-{
+static PreprocessedImage run_preprocess_dispatch(const runtime::adapters::io::DecodedImage& image,
+                                                 const VLPreprocessConfig& config,
+                                                 const PreprocessDispatch& dispatch) {
     LoadedImage loaded = dispatch.load_fn(image, config);
-    if (!loaded.ok)
-    {
+    if (!loaded.ok) {
         return PreprocessedImage{};
     }
     return dispatch.preprocess_fn(loaded, config);
 }
 
-runtime::adapters::io::DecodedImage decode_image_rgb(const std::string& image_path)
-{
+runtime::adapters::io::DecodedImage decode_image_rgb(const std::string& image_path) {
     runtime::adapters::io::DecodedImage image;
-    if (image_path.empty())
-    {
+    if (image_path.empty()) {
         return image;
     }
 
@@ -467,10 +407,9 @@ runtime::adapters::io::DecodedImage decode_image_rgb(const std::string& image_pa
     int height = 0;
     int channels = 0;
     unsigned char* raw = stbi_load(image_path.c_str(), &width, &height, &channels, 3);
-    if (raw == nullptr)
-    {
-        std::cerr << "[trtmc] Failed to load image: " << image_path
-                  << " (" << stbi_failure_reason() << ")" << std::endl;
+    if (raw == nullptr) {
+        std::cerr << "[trtmc] Failed to load image: " << image_path << " (" << stbi_failure_reason()
+                  << ")" << std::endl;
         return image;
     }
 
@@ -482,39 +421,28 @@ runtime::adapters::io::DecodedImage decode_image_rgb(const std::string& image_pa
     return image;
 }
 
-PreprocessedImage preprocess_decoded_image(
-    const runtime::adapters::io::DecodedImage& image,
-    const VLPreprocessConfig& config)
-{
+PreprocessedImage preprocess_decoded_image(const runtime::adapters::io::DecodedImage& image,
+                                           const VLPreprocessConfig& config) {
     const auto dispatch = resolve_preprocess_dispatch(config.preprocessor_type);
-    if (dispatch.warn_unknown_type)
-    {
-        std::cerr << "[trtmc] WARNING: Unknown preprocessor_type \""
-                  << config.preprocessor_type << "\", falling back to qwen_merge_group"
-                  << std::endl;
+    if (dispatch.warn_unknown_type) {
+        std::cerr << "[trtmc] WARNING: Unknown preprocessor_type \"" << config.preprocessor_type
+                  << "\", falling back to qwen_merge_group" << std::endl;
     }
 
     return run_preprocess_dispatch(image, config, dispatch);
 }
 
-PreprocessedImage load_and_preprocess_image(
-    const std::string& image_path,
-    const VLPreprocessConfig& config)
-{
+PreprocessedImage load_and_preprocess_image(const std::string& image_path,
+                                            const VLPreprocessConfig& config) {
     return preprocess_decoded_image(decode_image_rgb(image_path), config);
 }
 
-std::string format_vl_prompt(
-    const std::string& user_prompt,
-    const VLPreprocessConfig& config)
-{
+std::string format_vl_prompt(const std::string& user_prompt, const VLPreprocessConfig& config) {
     // Build image_pads string: repeat image_token_str num_image_pad_tokens times
     std::string image_pads;
-    image_pads.reserve(
-        static_cast<std::size_t>(config.num_image_pad_tokens)
-        * config.image_token_str.size());
-    for (int32_t i = 0; i < config.num_image_pad_tokens; ++i)
-    {
+    image_pads.reserve(static_cast<std::size_t>(config.num_image_pad_tokens) *
+                       config.image_token_str.size());
+    for (int32_t i = 0; i < config.num_image_pad_tokens; ++i) {
         image_pads += config.image_token_str;
     }
 
@@ -523,25 +451,21 @@ std::string format_vl_prompt(
 
     const std::string pads_placeholder = "{image_pads}";
     const std::size_t pads_pos = result.find(pads_placeholder);
-    if (pads_pos != std::string::npos)
-    {
+    if (pads_pos != std::string::npos) {
         result.replace(pads_pos, pads_placeholder.size(), image_pads);
     }
 
     const std::string prompt_placeholder = "{prompt}";
     const std::size_t prompt_pos = result.find(prompt_placeholder);
-    if (prompt_pos != std::string::npos)
-    {
+    if (prompt_pos != std::string::npos) {
         result.replace(prompt_pos, prompt_placeholder.size(), user_prompt);
     }
 
     return result;
 }
 
-static void assign_image_norm_triplet(const std::vector<float>& values, float (&target)[3])
-{
-    if (values.size() < 3)
-    {
+static void assign_image_norm_triplet(const std::vector<float>& values, float (&target)[3]) {
+    if (values.size() < 3) {
         return;
     }
     target[0] = values[0];
@@ -549,27 +473,23 @@ static void assign_image_norm_triplet(const std::vector<float>& values, float (&
     target[2] = values[2];
 }
 
-static void unescape_newline_sequences(std::string& text)
-{
+static void unescape_newline_sequences(std::string& text) {
     std::size_t pos = 0;
-    while ((pos = text.find("\\n", pos)) != std::string::npos)
-    {
+    while ((pos = text.find("\\n", pos)) != std::string::npos) {
         text.replace(pos, 2, "\n");
         ++pos;
     }
 }
 
-static void parse_base_vl_config(
-    const std::string& config_text,
-    VLPreprocessConfig& cfg)
-{
-    cfg.preprocessor_type = extract_json_string(config_text, "preprocessor_type", "qwen_merge_group");
+static void parse_base_vl_config(const std::string& config_text, VLPreprocessConfig& cfg) {
+    cfg.preprocessor_type =
+        extract_json_string(config_text, "preprocessor_type", "qwen_merge_group");
     cfg.image_token_id = extract_json_int(config_text, "image_token_id", -1);
     cfg.fixed_image_size = extract_json_int(config_text, "fixed_image_size", 448);
     cfg.patch_size = extract_json_int(config_text, "patch_size", cfg.patch_size);
     cfg.merge_size = extract_json_int(config_text, "merge_size", cfg.merge_size);
-    cfg.temporal_patch_size = extract_json_int(
-        config_text, "temporal_patch_size", cfg.temporal_patch_size);
+    cfg.temporal_patch_size =
+        extract_json_int(config_text, "temporal_patch_size", cfg.temporal_patch_size);
     cfg.num_image_pad_tokens = extract_json_int(config_text, "num_image_pad_tokens", 256);
     cfg.vision_output_dim = extract_json_int(config_text, "vision_output_dim", 0);
     cfg.vl_prompt_template = extract_json_string(config_text, "vl_prompt_template", "");
@@ -577,13 +497,10 @@ static void parse_base_vl_config(
     cfg.interpolation = extract_json_string(config_text, "interpolation", "bicubic");
 }
 
-static void maybe_apply_resample_fallback(
-    const std::string& config_text,
-    const std::string& preprocessor_config_text,
-    VLPreprocessConfig& cfg)
-{
-    if (!extract_json_string(config_text, "interpolation", "").empty())
-    {
+static void maybe_apply_resample_fallback(const std::string& config_text,
+                                          const std::string& preprocessor_config_text,
+                                          VLPreprocessConfig& cfg) {
+    if (!extract_json_string(config_text, "interpolation", "").empty()) {
         return;
     }
 
@@ -596,13 +513,10 @@ static void maybe_apply_resample_fallback(
         cfg.interpolation = "bicubic";
 }
 
-static void apply_preprocessor_config_overrides(
-    const std::string& config_text,
-    const std::string& preprocessor_config_text,
-    VLPreprocessConfig& cfg)
-{
-    if (preprocessor_config_text.empty())
-    {
+static void apply_preprocessor_config_overrides(const std::string& config_text,
+                                                const std::string& preprocessor_config_text,
+                                                VLPreprocessConfig& cfg) {
+    if (preprocessor_config_text.empty()) {
         return;
     }
 
@@ -619,10 +533,8 @@ static void apply_preprocessor_config_overrides(
     maybe_apply_resample_fallback(config_text, preprocessor_config_text, cfg);
 }
 
-static void apply_config_image_norm_overrides(
-    const std::string& config_text,
-    VLPreprocessConfig& cfg)
-{
+static void apply_config_image_norm_overrides(const std::string& config_text,
+                                              VLPreprocessConfig& cfg) {
     auto mean_vals = extract_json_float_array(config_text, "image_mean", 3);
     assign_image_norm_triplet(mean_vals, cfg.image_mean);
 
@@ -630,10 +542,8 @@ static void apply_config_image_norm_overrides(
     assign_image_norm_triplet(std_vals, cfg.image_std);
 }
 
-VLPreprocessConfig parse_vl_preprocess_config(
-    const std::string& config_text,
-    const std::string& preprocessor_config_text)
-{
+VLPreprocessConfig parse_vl_preprocess_config(const std::string& config_text,
+                                              const std::string& preprocessor_config_text) {
     VLPreprocessConfig cfg;
     parse_base_vl_config(config_text, cfg);
     unescape_newline_sequences(cfg.vl_prompt_template);

--- a/src/runtime/domains/multimodal/image_preprocessor.cpp
+++ b/src/runtime/domains/multimodal/image_preprocessor.cpp
@@ -349,6 +349,64 @@ static PreprocessedImage preprocess_simple_chw(
     return result;
 }
 
+
+// ---------------------------------------------------------------------------
+// Strategy: locateanything_patchify
+// ---------------------------------------------------------------------------
+
+static PreprocessedImage preprocess_locateanything_patchify(
+    const LoadedImage& loaded,
+    const VLPreprocessConfig& config)
+{
+    PreprocessedImage result;
+    const int patch = config.patch_size;
+    const int channels = loaded.channels;
+    const int height = loaded.target_size;
+    const int width = loaded.target_size;
+    if (patch <= 0 || height % patch != 0 || width % patch != 0 || channels <= 0)
+    {
+        std::cerr << "[trtmc] Invalid LocateAnything patchify shape" << std::endl;
+        return result;
+    }
+
+    const int grid_h = height / patch;
+    const int grid_w = width / patch;
+    const int num_patches = grid_h * grid_w;
+    result.pixel_values.resize(
+        static_cast<std::size_t>(num_patches) * channels * patch * patch);
+
+    for (int gh = 0; gh < grid_h; ++gh)
+    {
+        for (int gw = 0; gw < grid_w; ++gw)
+        {
+            const int patch_idx = gh * grid_w + gw;
+            for (int c = 0; c < channels; ++c)
+            {
+                for (int ph = 0; ph < patch; ++ph)
+                {
+                    for (int pw = 0; pw < patch; ++pw)
+                    {
+                        const std::size_t dst =
+                            (((static_cast<std::size_t>(patch_idx) * channels + c) * patch + ph)
+                             * patch + pw);
+                        const std::size_t src =
+                            (static_cast<std::size_t>(c) * height + gh * patch + ph) * width
+                            + gw * patch + pw;
+                        result.pixel_values[dst] = loaded.img_chw[src];
+                    }
+                }
+            }
+        }
+    }
+
+    result.image_grid_hws = {grid_h, grid_w};
+    result.channels = channels;
+    result.height = height;
+    result.width = width;
+    result.ok = true;
+    return result;
+}
+
 // ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
@@ -377,6 +435,8 @@ static PreprocessDispatch resolve_preprocess_dispatch(const std::string& preproc
         return {load_pad_center_resize_normalize, preprocess_simple_chw, false};
     if (preprocessor_type == "simple_chw")
         return {load_resize_normalize, preprocess_simple_chw, false};
+    if (preprocessor_type == "locateanything_patchify")
+        return {load_resize_normalize, preprocess_locateanything_patchify, false};
 
     const bool warn_unknown = (preprocessor_type != "qwen_merge_group");
     return {load_resize_normalize, preprocess_qwen_merge_group, warn_unknown};
@@ -506,6 +566,10 @@ static void parse_base_vl_config(
     cfg.preprocessor_type = extract_json_string(config_text, "preprocessor_type", "qwen_merge_group");
     cfg.image_token_id = extract_json_int(config_text, "image_token_id", -1);
     cfg.fixed_image_size = extract_json_int(config_text, "fixed_image_size", 448);
+    cfg.patch_size = extract_json_int(config_text, "patch_size", cfg.patch_size);
+    cfg.merge_size = extract_json_int(config_text, "merge_size", cfg.merge_size);
+    cfg.temporal_patch_size = extract_json_int(
+        config_text, "temporal_patch_size", cfg.temporal_patch_size);
     cfg.num_image_pad_tokens = extract_json_int(config_text, "num_image_pad_tokens", 256);
     cfg.vision_output_dim = extract_json_int(config_text, "vision_output_dim", 0);
     cfg.vl_prompt_template = extract_json_string(config_text, "vl_prompt_template", "");

--- a/src/runtime/domains/multimodal/image_preprocessor.h
+++ b/src/runtime/domains/multimodal/image_preprocessor.h
@@ -31,9 +31,9 @@ struct VLPreprocessConfig {
 
 // Preprocessed pixel values ready for the vision TRT engine.
 struct PreprocessedImage {
-    std::vector<float> pixel_values;  // Layout depends on preprocessor_type
-    std::vector<int32_t> image_grid_hws;  // [height, width] patch grid for patchified inputs
-    int32_t channels{0};              // C*T for qwen_merge_group, C for simple_chw
+    std::vector<float> pixel_values;     // Layout depends on preprocessor_type
+    std::vector<int32_t> image_grid_hws; // [height, width] patch grid for patchified inputs
+    int32_t channels{0};                 // C*T for qwen_merge_group, C for simple_chw
     int32_t height{0};
     int32_t width{0};
     bool ok{false};
@@ -52,23 +52,18 @@ struct PreprocessedImage {
 // is not yet implemented; callers must process one image at a time.
 runtime::adapters::io::DecodedImage decode_image_rgb(const std::string& image_path);
 
-PreprocessedImage preprocess_decoded_image(
-    const runtime::adapters::io::DecodedImage& image,
-    const VLPreprocessConfig& config);
+PreprocessedImage preprocess_decoded_image(const runtime::adapters::io::DecodedImage& image,
+                                           const VLPreprocessConfig& config);
 
-PreprocessedImage load_and_preprocess_image(
-    const std::string& image_path,
-    const VLPreprocessConfig& config);
+PreprocessedImage load_and_preprocess_image(const std::string& image_path,
+                                            const VLPreprocessConfig& config);
 
 // Format a VL prompt with image pad tokens from the template.
 // Replaces {image_pads} and {prompt} in vl_prompt_template.
-std::string format_vl_prompt(
-    const std::string& user_prompt,
-    const VLPreprocessConfig& config);
+std::string format_vl_prompt(const std::string& user_prompt, const VLPreprocessConfig& config);
 
 // Parse VLPreprocessConfig from config.json text.
-VLPreprocessConfig parse_vl_preprocess_config(
-    const std::string& config_text,
-    const std::string& preprocessor_config_text);
+VLPreprocessConfig parse_vl_preprocess_config(const std::string& config_text,
+                                              const std::string& preprocessor_config_text);
 
 } // namespace trtmc

--- a/src/runtime/domains/multimodal/image_preprocessor.h
+++ b/src/runtime/domains/multimodal/image_preprocessor.h
@@ -32,6 +32,7 @@ struct VLPreprocessConfig {
 // Preprocessed pixel values ready for the vision TRT engine.
 struct PreprocessedImage {
     std::vector<float> pixel_values;  // Layout depends on preprocessor_type
+    std::vector<int32_t> image_grid_hws;  // [height, width] patch grid for patchified inputs
     int32_t channels{0};              // C*T for qwen_merge_group, C for simple_chw
     int32_t height{0};
     int32_t width{0};
@@ -45,6 +46,7 @@ struct PreprocessedImage {
 //   "center_crop_chw":     [C, H, W] center-crop to square, then resize + normalize
 //   "aspect_preserve_chw": [C, H, W] aspect-ratio-preserving resize + zero-pad
 //   "pad_center_chw":      [C, H, W] aspect-ratio-preserving resize + center-pad with mean color
+//   "locateanything_patchify": [num_patches, C, patch_size, patch_size]
 //
 // NOTE: Only single-image input is supported. Multi-image batching
 // is not yet implemented; callers must process one image at a time.

--- a/src/runtime/models/vision_language/pipeline.cpp
+++ b/src/runtime/models/vision_language/pipeline.cpp
@@ -142,8 +142,7 @@ void copy_deepstack_outputs(const TensorMap& outputs,
             break;
         auto ds_n = ds_it->second.numel();
         deepstack_features->emplace_back(static_cast<std::size_t>(ds_n));
-        std::memcpy(deepstack_features->back().data(), ds_it->second.data,
-                    ds_n * sizeof(float));
+        std::memcpy(deepstack_features->back().data(), ds_it->second.data, ds_n * sizeof(float));
     }
 }
 

--- a/src/runtime/models/vision_language/pipeline.cpp
+++ b/src/runtime/models/vision_language/pipeline.cpp
@@ -116,8 +116,7 @@ TextResult VLPipeline::generate(const std::string& prompt, const float* image_pi
 
     std::vector<float> features;
     std::vector<std::vector<float>> deepstack_features;
-    if (!run_vision_encoder(preprocessed.pixel_values.data(), preprocessed.pixel_values.size(),
-                            features, &deepstack_features))
+    if (!run_vision_encoder(preprocessed, features, &deepstack_features))
         throw std::runtime_error("VLPipeline: vision encoder failed");
 
     int32_t dim = infer_feature_dim(*vision_encoder_, config_.vision_output_dim);
@@ -354,7 +353,7 @@ void VLPipeline::run_text_step_with_embed(int32_t token_id, const float* input_e
     state_->advance();
 }
 
-bool VLPipeline::run_vision_encoder(const float* pixel_values, std::size_t pixel_count,
+bool VLPipeline::run_vision_encoder(const PreprocessedImage& preprocessed,
                                     std::vector<float>& image_features,
                                     std::vector<std::vector<float>>* deepstack_features) {
     if (!vision_encoder_ || !vision_encoder_->ok())
@@ -362,7 +361,7 @@ bool VLPipeline::run_vision_encoder(const float* pixel_values, std::size_t pixel
 
     // Build input tensor for pixel values
     Tensor pixel_t;
-    pixel_t.data = const_cast<float*>(pixel_values);
+    pixel_t.data = const_cast<float*>(preprocessed.pixel_values.data());
     // Get the shape from the vision engine's input
     auto inputs_info = vision_encoder_->input_info();
     for (const auto& info : inputs_info) {
@@ -373,12 +372,21 @@ bool VLPipeline::run_vision_encoder(const float* pixel_values, std::size_t pixel
     }
     if (pixel_t.shape.empty()) {
         // Fallback: use the pixel_count as a flat shape
-        pixel_t.shape = {static_cast<int64_t>(pixel_count)};
+        pixel_t.shape = {static_cast<int64_t>(preprocessed.pixel_values.size())};
     }
     pixel_t.dtype = DType::kFloat32;
 
     TensorMap inputs;
     inputs["pixel_values"] = pixel_t;
+
+    if (vision_encoder_->has_input("image_grid_hws") && !preprocessed.image_grid_hws.empty()) {
+        Tensor grid_t;
+        grid_t.data = const_cast<int32_t*>(preprocessed.image_grid_hws.data());
+        grid_t.shape = {
+            static_cast<int64_t>(preprocessed.image_grid_hws.size() / 2), 2};
+        grid_t.dtype = DType::kInt32;
+        inputs["image_grid_hws"] = grid_t;
+    }
 
     auto outputs = vision_encoder_->forward(inputs);
 

--- a/src/runtime/models/vision_language/pipeline.cpp
+++ b/src/runtime/models/vision_language/pipeline.cpp
@@ -90,6 +90,63 @@ select_deepstack_feature_pointers(const std::vector<std::vector<float>>& deepsta
     return embeds;
 }
 
+Tensor make_pixel_values_tensor(const PreprocessedImage& preprocessed, const TrtModule& encoder) {
+    Tensor pixel_t;
+    pixel_t.data = const_cast<float*>(preprocessed.pixel_values.data());
+    for (const auto& info : encoder.input_info()) {
+        if (info.name == "pixel_values") {
+            pixel_t.shape = info.shape;
+            break;
+        }
+    }
+    if (pixel_t.shape.empty())
+        pixel_t.shape = {static_cast<int64_t>(preprocessed.pixel_values.size())};
+    pixel_t.dtype = DType::kFloat32;
+    return pixel_t;
+}
+
+void add_image_grid_input(TensorMap& inputs, const PreprocessedImage& preprocessed,
+                          const TrtModule& encoder) {
+    if (!encoder.has_input("image_grid_hws") || preprocessed.image_grid_hws.empty())
+        return;
+
+    Tensor grid_t;
+    grid_t.data = const_cast<int32_t*>(preprocessed.image_grid_hws.data());
+    grid_t.shape = {static_cast<int64_t>(preprocessed.image_grid_hws.size() / 2), 2};
+    grid_t.dtype = DType::kInt32;
+    inputs["image_grid_hws"] = grid_t;
+}
+
+bool copy_float_output(const TensorMap& outputs, const std::string& name,
+                       std::vector<float>& values) {
+    auto it = outputs.find(name);
+    if (it == outputs.end())
+        return false;
+
+    auto n = it->second.numel();
+    values.resize(static_cast<std::size_t>(n));
+    std::memcpy(values.data(), it->second.data, n * sizeof(float));
+    return true;
+}
+
+void copy_deepstack_outputs(const TensorMap& outputs,
+                            std::vector<std::vector<float>>* deepstack_features) {
+    if (deepstack_features == nullptr)
+        return;
+
+    deepstack_features->clear();
+    for (std::size_t i = 0;; ++i) {
+        const std::string name = "deepstack_features_" + std::to_string(i);
+        auto ds_it = outputs.find(name);
+        if (ds_it == outputs.end())
+            break;
+        auto ds_n = ds_it->second.numel();
+        deepstack_features->emplace_back(static_cast<std::size_t>(ds_n));
+        std::memcpy(deepstack_features->back().data(), ds_it->second.data,
+                    ds_n * sizeof(float));
+    }
+}
+
 } // namespace
 
 std::pair<int32_t, int32_t> VLPipeline::resolve_gen_limits(const GenerateConfig& cfg) const {
@@ -359,62 +416,18 @@ bool VLPipeline::run_vision_encoder(const PreprocessedImage& preprocessed,
     if (!vision_encoder_ || !vision_encoder_->ok())
         return false;
 
-    // Build input tensor for pixel values
-    Tensor pixel_t;
-    pixel_t.data = const_cast<float*>(preprocessed.pixel_values.data());
-    // Get the shape from the vision engine's input
-    auto inputs_info = vision_encoder_->input_info();
-    for (const auto& info : inputs_info) {
-        if (info.name == "pixel_values") {
-            pixel_t.shape = info.shape;
-            break;
-        }
-    }
-    if (pixel_t.shape.empty()) {
-        // Fallback: use the pixel_count as a flat shape
-        pixel_t.shape = {static_cast<int64_t>(preprocessed.pixel_values.size())};
-    }
-    pixel_t.dtype = DType::kFloat32;
-
     TensorMap inputs;
-    inputs["pixel_values"] = pixel_t;
-
-    if (vision_encoder_->has_input("image_grid_hws") && !preprocessed.image_grid_hws.empty()) {
-        Tensor grid_t;
-        grid_t.data = const_cast<int32_t*>(preprocessed.image_grid_hws.data());
-        grid_t.shape = {
-            static_cast<int64_t>(preprocessed.image_grid_hws.size() / 2), 2};
-        grid_t.dtype = DType::kInt32;
-        inputs["image_grid_hws"] = grid_t;
-    }
+    inputs["pixel_values"] = make_pixel_values_tensor(preprocessed, *vision_encoder_);
+    add_image_grid_input(inputs, preprocessed, *vision_encoder_);
 
     auto outputs = vision_encoder_->forward(inputs);
 
-    // Extract image_features output
-    auto it = outputs.find("image_features");
-    if (it == outputs.end()) {
+    if (!copy_float_output(outputs, "image_features", image_features)) {
         std::cerr << "[trtmc] Vision encoder has no 'image_features' output" << std::endl;
         return false;
     }
 
-    auto n = it->second.numel();
-    image_features.resize(static_cast<std::size_t>(n));
-    std::memcpy(image_features.data(), it->second.data, n * sizeof(float));
-
-    if (deepstack_features != nullptr) {
-        deepstack_features->clear();
-        for (std::size_t i = 0;; ++i) {
-            const std::string name = "deepstack_features_" + std::to_string(i);
-            auto ds_it = outputs.find(name);
-            if (ds_it == outputs.end())
-                break;
-            auto ds_n = ds_it->second.numel();
-            deepstack_features->emplace_back(static_cast<std::size_t>(ds_n));
-            std::memcpy(deepstack_features->back().data(), ds_it->second.data,
-                        ds_n * sizeof(float));
-        }
-    }
-
+    copy_deepstack_outputs(outputs, deepstack_features);
     return true;
 }
 

--- a/src/runtime/models/vision_language/pipeline.h
+++ b/src/runtime/models/vision_language/pipeline.h
@@ -94,8 +94,8 @@ class VLPipeline final : public IPipeline {
                                   const std::vector<const float*>& deepstack_embeds,
                                   float deepstack_active, std::vector<float>& logits);
 
-    // Run vision encoder on preprocessed pixel values.
-    bool run_vision_encoder(const float* pixel_values, std::size_t pixel_count,
+    // Run vision encoder on preprocessed image inputs.
+    bool run_vision_encoder(const PreprocessedImage& preprocessed,
                             std::vector<float>& image_features,
                             std::vector<std::vector<float>>* deepstack_features = nullptr);
 };

--- a/tests/builder/test_debug_runner_extended.py
+++ b/tests/builder/test_debug_runner_extended.py
@@ -667,6 +667,42 @@ class TestPreprocessImageDispatch:
         # 3 channels * 2 temporal = 6 channels
         assert result.shape == (6, 28, 28)
 
+    def test_locateanything_patchify_inputs(self, tmp_path):
+        """locateanything_patchify returns pixel_values and image_grid_hws."""
+        from tensorrt_model_connect.debug_runner import (
+            preprocess_image_for_trt,
+            preprocess_image_inputs_for_trt,
+        )
+
+        from PIL import Image
+        img = Image.new("RGB", (4, 4), color=(64, 128, 255))
+        img_path = str(tmp_path / "test.png")
+        img.save(img_path)
+
+        inputs = preprocess_image_inputs_for_trt(
+            img_path,
+            preprocessor_type="locateanything_patchify",
+            fixed_image_size=4,
+            patch_size=2,
+            image_mean=(0.0, 0.0, 0.0),
+            image_std=(1.0, 1.0, 1.0),
+            interpolation="nearest",
+        )
+
+        assert set(inputs) == {"pixel_values", "image_grid_hws"}
+        assert inputs["pixel_values"].shape == (4, 3, 2, 2)
+        assert inputs["pixel_values"].dtype == np.float32
+        assert inputs["image_grid_hws"].tolist() == [[2, 2]]
+        assert preprocess_image_for_trt(
+            img_path,
+            preprocessor_type="locateanything_patchify",
+            fixed_image_size=4,
+            patch_size=2,
+            image_mean=(0.0, 0.0, 0.0),
+            image_std=(1.0, 1.0, 1.0),
+            interpolation="nearest",
+        ).shape == (4, 3, 2, 2)
+
     def test_center_crop_chw_dispatch(self, tmp_path):
         """center_crop_chw returns [C, H, W] for rectangular input."""
         from tensorrt_model_connect.debug_runner import preprocess_image_for_trt

--- a/tests/builder/test_families.py
+++ b/tests/builder/test_families.py
@@ -341,6 +341,8 @@ _POSITIVE_MATCH_CASES = [
     # InternVL
     ("internvl_chat", "internvl"),
     ("internvl3", "internvl"),
+    # LocateAnything
+    ("locateanything", "locateanything"),
     # BERT (encoder-only)
     ("bert", "bert"),
     # RoBERTa / XLM-RoBERTa (encoder-only)
@@ -539,6 +541,10 @@ class TestRuntimeStrategy:
         plugin = find_plugin("internvl_chat")
         assert getattr(plugin, "runtime_strategy", None) == "vision_language"
 
+    def test_locateanything_strategy(self):
+        plugin = find_plugin("locateanything")
+        assert getattr(plugin, "runtime_strategy", None) == "vision_language"
+
     def test_omni_strategy(self):
         plugin = find_plugin("qwen3_omni")
         assert getattr(plugin, "runtime_strategy", None) == "omni_multimodal"
@@ -593,6 +599,10 @@ class TestEmbedInput:
         plugin = find_plugin("internvl_chat")
         assert getattr(plugin, "embed_input", False) is True
 
+    def test_locateanything_has_embed_input(self):
+        plugin = find_plugin("locateanything")
+        assert getattr(plugin, "embed_input", False) is True
+
     def test_omni_has_embed_input(self):
         plugin = find_plugin("qwen3_omni")
         assert getattr(plugin, "embed_input", False) is True
@@ -615,6 +625,11 @@ class TestVLMethods:
 
     def test_internvl_has_vl_methods(self):
         plugin = find_plugin("internvl_chat")
+        assert callable(getattr(plugin, "build_vision_engine", None))
+        assert callable(getattr(plugin, "get_vl_config", None))
+
+    def test_locateanything_has_vl_methods(self):
+        plugin = find_plugin("locateanything")
         assert callable(getattr(plugin, "build_vision_engine", None))
         assert callable(getattr(plugin, "get_vl_config", None))
 

--- a/tests/builder/test_family_plugins.py
+++ b/tests/builder/test_family_plugins.py
@@ -1809,6 +1809,132 @@ class TestInternVLPlugin:
 
 
 # =========================================================================
+# 12. LocateAnything — MoonViT + Qwen2 text decoder
+# =========================================================================
+
+class TestLocateAnythingPlugin:
+    VOCAB, HIDDEN, LAYERS, HEADS, KV_HEADS, MLP = 64, 16, 2, 4, 2, 32
+
+    def _make_text_tensors(self):
+        head_dim = self.HIDDEN // self.HEADS
+        kv_hidden = self.KV_HEADS * head_dim
+        tensors = {}
+        tensors["language_model.model.embed_tokens.weight"] = _rand(
+            self.VOCAB, self.HIDDEN)
+        for i in range(self.LAYERS):
+            p = f"language_model.model.layers.{i}"
+            tensors[f"{p}.input_layernorm.weight"] = _rand(self.HIDDEN)
+            tensors[f"{p}.post_attention_layernorm.weight"] = _rand(self.HIDDEN)
+            tensors[f"{p}.self_attn.q_proj.weight"] = _rand(self.HIDDEN, self.HIDDEN)
+            tensors[f"{p}.self_attn.k_proj.weight"] = _rand(kv_hidden, self.HIDDEN)
+            tensors[f"{p}.self_attn.v_proj.weight"] = _rand(kv_hidden, self.HIDDEN)
+            tensors[f"{p}.self_attn.o_proj.weight"] = _rand(self.HIDDEN, self.HIDDEN)
+            tensors[f"{p}.self_attn.q_proj.bias"] = _rand(self.HIDDEN)
+            tensors[f"{p}.self_attn.k_proj.bias"] = _rand(kv_hidden)
+            tensors[f"{p}.self_attn.v_proj.bias"] = _rand(kv_hidden)
+            tensors[f"{p}.mlp.gate_proj.weight"] = _rand(self.MLP, self.HIDDEN)
+            tensors[f"{p}.mlp.up_proj.weight"] = _rand(self.MLP, self.HIDDEN)
+            tensors[f"{p}.mlp.down_proj.weight"] = _rand(self.HIDDEN, self.MLP)
+        tensors["language_model.model.norm.weight"] = _rand(self.HIDDEN)
+        tensors["language_model.lm_head.weight"] = _rand(self.VOCAB, self.HIDDEN)
+        return tensors
+
+    def _write_locateanything_config(self, tmp_path):
+        config = {
+            "model_type": "locateanything",
+            "architectures": ["LocateAnythingForConditionalGeneration"],
+            "image_token_index": 151665,
+            "box_start_token_id": 151668,
+            "box_end_token_id": 151669,
+            "coord_start_token_id": 151677,
+            "coord_end_token_id": 152677,
+            "text_config": {
+                "model_type": "qwen2",
+                "architectures": ["Qwen2ForCausalLM"],
+                "vocab_size": self.VOCAB,
+                "hidden_size": self.HIDDEN,
+                "intermediate_size": self.MLP,
+                "num_hidden_layers": self.LAYERS,
+                "num_attention_heads": self.HEADS,
+                "num_key_value_heads": self.KV_HEADS,
+                "rms_norm_eps": 1e-6,
+                "rope_theta": 1000000.0,
+                "max_position_embeddings": 32768,
+            },
+            "vision_config": {
+                "model_type": "moonvit",
+                "hidden_size": 64,
+                "num_attention_heads": 4,
+                "num_hidden_layers": 2,
+                "patch_size": 14,
+                "merge_kernel_size": [2, 2],
+            },
+        }
+        _write_config(tmp_path, config)
+
+    def test_load_text_weights_keys(self, tmp_path):
+        from tensorrt_model_connect.families.locateanything import plugin
+
+        self._write_locateanything_config(tmp_path)
+        tensors = self._make_text_tensors()
+        tensors["vision_model.patch_embed.proj.weight"] = _rand(64, 3, 14, 14)
+        tensors["mlp1.1.weight"] = _rand(self.HIDDEN, 64 * 4)
+        _write_safetensors(tmp_path, tensors)
+
+        cfg = ModelConfig.from_dir(tmp_path)
+        weights = plugin.load_weights(str(tmp_path), cfg)
+
+        assert cfg.model_type == "locateanything"
+        assert cfg.hidden_size == self.HIDDEN
+        assert "embedding" in weights
+        for i in range(self.LAYERS):
+            for key in ("input_norm", "post_attn_norm", "w_q", "w_k", "w_v",
+                        "w_o", "w_gate", "w_up", "w_down"):
+                assert f"layer.{i}.{key}" in weights
+            assert f"layer.{i}.q_bias" in weights
+            assert f"layer.{i}.k_bias" in weights
+            assert f"layer.{i}.v_bias" in weights
+        assert weights["w_out"].shape == (self.HIDDEN, self.VOCAB)
+        assert weights["_kv_attention_size"] == self.KV_HEADS * (
+            self.HIDDEN // self.HEADS)
+
+    def test_vision_weights_not_in_text(self, tmp_path):
+        from tensorrt_model_connect.families.locateanything import plugin
+
+        self._write_locateanything_config(tmp_path)
+        tensors = self._make_text_tensors()
+        tensors["vision_model.encoder.blocks.0.wqkv.weight"] = _rand(192, 64)
+        tensors["vision_model.patch_embed.pos_emb.weight"] = _rand(64, 64, 64)
+        tensors["mlp1.1.weight"] = _rand(self.HIDDEN, 64 * 4)
+        _write_safetensors(tmp_path, tensors)
+
+        cfg = ModelConfig.from_dir(tmp_path)
+        weights = plugin.load_weights(str(tmp_path), cfg)
+
+        for key in weights:
+            assert not key.startswith("vision_model."), f"Vision key leaked: {key}"
+            assert not key.startswith("mlp1."), f"Projector key leaked: {key}"
+
+    def test_get_vl_config(self, tmp_path):
+        from tensorrt_model_connect.families.locateanything import plugin
+
+        self._write_locateanything_config(tmp_path)
+        cfg = ModelConfig.from_dir(tmp_path)
+        vl_cfg = plugin.get_vl_config(cfg)
+
+        assert vl_cfg is not None
+        assert vl_cfg["image_token_id"] == 151665
+        assert vl_cfg["fixed_image_size"] == 448
+        assert vl_cfg["num_image_pad_tokens"] == 256
+        assert vl_cfg["vision_output_dim"] == self.HIDDEN
+        assert vl_cfg["preprocessor_type"] == "locateanything_patchify"
+        assert vl_cfg["image_token_str"] == "<IMG_CONTEXT>"
+        assert vl_cfg["locateanything_vision_engine_supported"] is False
+        assert vl_cfg["box_start_token_id"] == 151668
+        assert "{prompt}" in vl_cfg["vl_prompt_template"]
+
+
+# =========================================================================
 # Eagle VLM — embedding and reranking
 # =========================================================================
 

--- a/tests/builder/test_family_plugins.py
+++ b/tests/builder/test_family_plugins.py
@@ -1928,9 +1928,14 @@ class TestLocateAnythingPlugin:
         assert vl_cfg["num_image_pad_tokens"] == 256
         assert vl_cfg["vision_output_dim"] == self.HIDDEN
         assert vl_cfg["preprocessor_type"] == "locateanything_patchify"
+        assert vl_cfg["patch_size"] == 14
+        assert vl_cfg["merge_size"] == 2
+        assert vl_cfg["image_mean"] == [0.5, 0.5, 0.5]
+        assert vl_cfg["image_std"] == [0.5, 0.5, 0.5]
         assert vl_cfg["image_token_str"] == "<IMG_CONTEXT>"
-        assert vl_cfg["locateanything_vision_engine_supported"] is False
+        assert "locateanything_vision_engine_supported" not in vl_cfg
         assert vl_cfg["box_start_token_id"] == 151668
+        assert "{image_pads}" in vl_cfg["vl_prompt_template"]
         assert "{prompt}" in vl_cfg["vl_prompt_template"]
 
 

--- a/tests/cpp/test_image_preprocessor.cpp
+++ b/tests/cpp/test_image_preprocessor.cpp
@@ -35,29 +35,23 @@
 
 static int failures = 0;
 
-static void check(bool condition, const char* test_name)
-{
-    if (!condition)
-    {
+static void check(bool condition, const char* test_name) {
+    if (!condition) {
         std::cerr << "FAIL: " << test_name << '\n';
         ++failures;
     }
 }
 
-static void check_near(float actual, float expected, float tol, const char* test_name)
-{
+static void check_near(float actual, float expected, float tol, const char* test_name) {
     check(std::abs(actual - expected) <= tol, test_name);
 }
 
 // Pure helper test: HWC uint8 -> CHW float normalization in-memory.
-static void test_helper_normalize_hwc_to_chw()
-{
-    const std::vector<unsigned char> image_hwc = {
-        // Pixel 0 (x=0): R, G, B
-        0, 64, 255,
-        // Pixel 1 (x=1): R, G, B
-        255, 128, 0
-    };
+static void test_helper_normalize_hwc_to_chw() {
+    const std::vector<unsigned char> image_hwc = {// Pixel 0 (x=0): R, G, B
+                                                  0, 64, 255,
+                                                  // Pixel 1 (x=1): R, G, B
+                                                  255, 128, 0};
 
     trtmc::ImageNormalizationParams params;
     params.width = 2;
@@ -84,8 +78,7 @@ static void test_helper_normalize_hwc_to_chw()
 }
 
 // Pure helper test: std <= 1e-8 uses inv_std=1 branch (no division by near-zero).
-static void test_helper_normalize_std_floor_branch()
-{
+static void test_helper_normalize_std_floor_branch() {
     const std::vector<unsigned char> image_hwc = {128, 10, 20};
 
     trtmc::ImageNormalizationParams params;
@@ -95,7 +88,7 @@ static void test_helper_normalize_std_floor_branch()
     params.image_mean[0] = 0.5F;
     params.image_mean[1] = 0.0F;
     params.image_mean[2] = 0.0F;
-    params.image_std[0] = 0.0F;   // hits fallback branch
+    params.image_std[0] = 0.0F; // hits fallback branch
     params.image_std[1] = 0.5F;
     params.image_std[2] = 1.0F;
 
@@ -109,14 +102,11 @@ static void test_helper_normalize_std_floor_branch()
 }
 
 // Pure helper test: simple CHW layout branch keeps data unchanged.
-static void test_helper_transform_simple_chw_branch()
-{
-    const std::vector<float> input_chw = {
-        // Channel 0 (2x2)
-        1.0F, 2.0F, 3.0F, 4.0F,
-        // Channel 1 (2x2)
-        5.0F, 6.0F, 7.0F, 8.0F
-    };
+static void test_helper_transform_simple_chw_branch() {
+    const std::vector<float> input_chw = {// Channel 0 (2x2)
+                                          1.0F, 2.0F, 3.0F, 4.0F,
+                                          // Channel 1 (2x2)
+                                          5.0F, 6.0F, 7.0F, 8.0F};
 
     trtmc::ImageTransformParams params;
     params.layout = trtmc::ImageTransformLayout::kSimpleChw;
@@ -133,11 +123,9 @@ static void test_helper_transform_simple_chw_branch()
 }
 
 // Pure helper test: qwen merge-group branch reorders patch positions and duplicates T channels.
-static void test_helper_transform_qwen_merge_group_branch()
-{
+static void test_helper_transform_qwen_merge_group_branch() {
     std::vector<float> input_chw(16);
-    for (int i = 0; i < 16; ++i)
-    {
+    for (int i = 0; i < 16; ++i) {
         input_chw[static_cast<std::size_t>(i)] = static_cast<float>(i);
     }
 
@@ -156,18 +144,13 @@ static void test_helper_transform_qwen_merge_group_branch()
     check(out_channels == 2, "helper qwen transform: out_channels=C*T=2");
     check(out_values.size() == 32, "helper qwen transform: output size=2*4*4");
 
-    const std::vector<float> expected_channel = {
-        0.0F, 1.0F, 4.0F, 5.0F,
-        2.0F, 3.0F, 6.0F, 7.0F,
-        8.0F, 9.0F, 12.0F, 13.0F,
-        10.0F, 11.0F, 14.0F, 15.0F
-    };
+    const std::vector<float> expected_channel = {0.0F,  1.0F,  4.0F,  5.0F, 2.0F,  3.0F,
+                                                 6.0F,  7.0F,  8.0F,  9.0F, 12.0F, 13.0F,
+                                                 10.0F, 11.0F, 14.0F, 15.0F};
 
     bool first_channel_ok = true;
-    for (std::size_t i = 0; i < expected_channel.size(); ++i)
-    {
-        if (std::abs(out_values[i] - expected_channel[i]) > 1e-6F)
-        {
+    for (std::size_t i = 0; i < expected_channel.size(); ++i) {
+        if (std::abs(out_values[i] - expected_channel[i]) > 1e-6F) {
             first_channel_ok = false;
             break;
         }
@@ -176,10 +159,8 @@ static void test_helper_transform_qwen_merge_group_branch()
 
     bool second_channel_ok = true;
     const std::size_t offset = 16;
-    for (std::size_t i = 0; i < expected_channel.size(); ++i)
-    {
-        if (std::abs(out_values[offset + i] - expected_channel[i]) > 1e-6F)
-        {
+    for (std::size_t i = 0; i < expected_channel.size(); ++i) {
+        if (std::abs(out_values[offset + i] - expected_channel[i]) > 1e-6F) {
             second_channel_ok = false;
             break;
         }
@@ -188,14 +169,12 @@ static void test_helper_transform_qwen_merge_group_branch()
 }
 
 // Write a tiny 4x4 PPM image (binary format) to a file.
-static std::string write_test_ppm(const std::string& dir)
-{
+static std::string write_test_ppm(const std::string& dir) {
     const std::string path = dir + "/test_image.ppm";
     std::ofstream out(path, std::ios::binary);
     out << "P6\n4 4\n255\n";
     // 4x4 pixels, each RGB
-    for (int i = 0; i < 16; ++i)
-    {
+    for (int i = 0; i < 16; ++i) {
         unsigned char r = static_cast<unsigned char>(i * 16);
         unsigned char g = static_cast<unsigned char>(128);
         unsigned char b = static_cast<unsigned char>(255 - i * 16);
@@ -208,8 +187,7 @@ static std::string write_test_ppm(const std::string& dir)
 }
 
 // Test: qwen_merge_group strategy — default, produces [C*T, H, W] with permutation.
-static void test_qwen_merge_group_strategy()
-{
+static void test_qwen_merge_group_strategy() {
     trtmc_test::TempDirGuard tmp;
     const std::string& dir = tmp.path();
 
@@ -218,7 +196,7 @@ static void test_qwen_merge_group_strategy()
 
     // Configure for a small fixed size
     trtmc::VLPreprocessConfig config;
-    config.fixed_image_size = 8;  // small for testing
+    config.fixed_image_size = 8; // small for testing
     config.temporal_patch_size = 2;
     config.in_channels = 3;
     config.preprocessor_type = "qwen_merge_group";
@@ -242,10 +220,8 @@ static void test_qwen_merge_group_strategy()
 
     // Check normalization range: (pixel/255 - 0.5) / 0.5 is in [-1, 1]
     bool in_range = true;
-    for (float v : result.pixel_values)
-    {
-        if (v < -1.1F || v > 1.1F)
-        {
+    for (float v : result.pixel_values) {
+        if (v < -1.1F || v > 1.1F) {
             in_range = false;
             break;
         }
@@ -254,8 +230,7 @@ static void test_qwen_merge_group_strategy()
 }
 
 // Test: simple_chw strategy — produces [C, H, W] without permutation.
-static void test_simple_chw_strategy()
-{
+static void test_simple_chw_strategy() {
     trtmc_test::TempDirGuard tmp;
     const std::string& dir = tmp.path();
 
@@ -281,15 +256,12 @@ static void test_simple_chw_strategy()
     check(result.width == 8, "simple_chw: width = fixed_image_size = 8");
 
     const std::size_t expected_size = 3 * 8 * 8;
-    check(result.pixel_values.size() == expected_size,
-          "simple_chw: pixel_values size = C * H * W");
+    check(result.pixel_values.size() == expected_size, "simple_chw: pixel_values size = C * H * W");
 
     // Check normalization range: (pixel/255 - 0.5) / 0.5 is in [-1, 1]
     bool in_range = true;
-    for (float v : result.pixel_values)
-    {
-        if (v < -1.1F || v > 1.1F)
-        {
+    for (float v : result.pixel_values) {
+        if (v < -1.1F || v > 1.1F) {
             in_range = false;
             break;
         }
@@ -298,8 +270,7 @@ static void test_simple_chw_strategy()
 }
 
 // Test: locateanything_patchify strategy produces [patches, C, pH, pW] plus grid metadata.
-static void test_locateanything_patchify_strategy()
-{
+static void test_locateanything_patchify_strategy() {
     trtmc_test::TempDirGuard tmp;
     const std::string& dir = tmp.path();
     const std::string image_path = write_test_ppm(dir);
@@ -335,8 +306,7 @@ static void test_locateanything_patchify_strategy()
 }
 
 // Test: load non-existent image returns ok=false.
-static void test_load_missing_image()
-{
+static void test_load_missing_image() {
     trtmc::VLPreprocessConfig config;
     config.fixed_image_size = 8;
 
@@ -345,8 +315,7 @@ static void test_load_missing_image()
 }
 
 // Test: format_vl_prompt replaces {image_pads} and {prompt}.
-static void test_format_vl_prompt()
-{
+static void test_format_vl_prompt() {
     trtmc::VLPreprocessConfig config;
     config.num_image_pad_tokens = 3;
     config.image_token_str = "<|pad|>";
@@ -355,12 +324,10 @@ static void test_format_vl_prompt()
     const std::string result = trtmc::format_vl_prompt("Describe this", config);
 
     // Should contain 3 copies of <|pad|>
-    check(result.find("<|pad|><|pad|><|pad|>") != std::string::npos,
-          "3 image pad tokens present");
+    check(result.find("<|pad|><|pad|><|pad|>") != std::string::npos, "3 image pad tokens present");
 
     // Should contain the user prompt
-    check(result.find("Describe this") != std::string::npos,
-          "user prompt present");
+    check(result.find("Describe this") != std::string::npos, "user prompt present");
 
     // Should have the template structure
     check(result.find("USER: ") == 0, "starts with USER: ");
@@ -368,8 +335,7 @@ static void test_format_vl_prompt()
 }
 
 // Test: parse_vl_preprocess_config extracts fields correctly.
-static void test_parse_vl_config()
-{
+static void test_parse_vl_config() {
     const std::string config_json = R"({
         "image_token_id": 151655,
         "fixed_image_size": 448,
@@ -407,8 +373,7 @@ static void test_parse_vl_config()
 }
 
 // Test: preprocessor_type defaults to "qwen_merge_group" when absent.
-static void test_parse_vl_config_default_preprocessor_type()
-{
+static void test_parse_vl_config_default_preprocessor_type() {
     const std::string config_json = R"({
         "image_token_id": 100
     })";
@@ -419,26 +384,22 @@ static void test_parse_vl_config_default_preprocessor_type()
 }
 
 // Test: preprocessor_type = "simple_chw" round-trips through parse.
-static void test_parse_vl_config_simple_chw()
-{
+static void test_parse_vl_config_simple_chw() {
     const std::string config_json = R"({
         "preprocessor_type": "simple_chw"
     })";
 
     auto cfg = trtmc::parse_vl_preprocess_config(config_json, "");
-    check(cfg.preprocessor_type == "simple_chw",
-          "preprocessor_type simple_chw parsed correctly");
+    check(cfg.preprocessor_type == "simple_chw", "preprocessor_type simple_chw parsed correctly");
 }
 
 // Write a non-square 6x4 PPM image (binary format) to a file.
-static std::string write_test_ppm_nonsquare(const std::string& dir)
-{
+static std::string write_test_ppm_nonsquare(const std::string& dir) {
     const std::string path = dir + "/test_nonsquare.ppm";
     std::ofstream out(path, std::ios::binary);
     out << "P6\n6 4\n255\n";
     // 6x4 pixels, each RGB
-    for (int i = 0; i < 24; ++i)
-    {
+    for (int i = 0; i < 24; ++i) {
         unsigned char r = static_cast<unsigned char>(i * 10);
         unsigned char g = static_cast<unsigned char>(128);
         unsigned char b = static_cast<unsigned char>(255 - i * 10);
@@ -451,8 +412,7 @@ static std::string write_test_ppm_nonsquare(const std::string& dir)
 }
 
 // Test Gap 1: unknown preprocessor_type falls back to qwen_merge_group with ok=true.
-static void test_unknown_preprocessor_type_fallback()
-{
+static void test_unknown_preprocessor_type_fallback() {
     trtmc_test::TempDirGuard tmp;
     const std::string& dir = tmp.path();
     const std::string image_path = write_test_ppm(dir);
@@ -479,8 +439,7 @@ static void test_unknown_preprocessor_type_fallback()
 }
 
 // Test Gap 2: center_crop_chw strategy with non-square image.
-static void test_center_crop_chw_strategy()
-{
+static void test_center_crop_chw_strategy() {
     trtmc_test::TempDirGuard tmp;
     const std::string& dir = tmp.path();
     const std::string image_path = write_test_ppm_nonsquare(dir);
@@ -508,10 +467,8 @@ static void test_center_crop_chw_strategy()
           "center_crop_chw: pixel_values size = C * H * W");
 
     bool in_range = true;
-    for (float v : result.pixel_values)
-    {
-        if (v < -1.1F || v > 1.1F)
-        {
+    for (float v : result.pixel_values) {
+        if (v < -1.1F || v > 1.1F) {
             in_range = false;
             break;
         }
@@ -520,8 +477,7 @@ static void test_center_crop_chw_strategy()
 }
 
 // Test Gap 3: aspect_preserve_chw strategy with non-square image.
-static void test_aspect_preserve_chw_strategy()
-{
+static void test_aspect_preserve_chw_strategy() {
     trtmc_test::TempDirGuard tmp;
     const std::string& dir = tmp.path();
     const std::string image_path = write_test_ppm_nonsquare(dir);
@@ -553,14 +509,12 @@ static void test_aspect_preserve_chw_strategy()
     // The 6x4 image scaled to fit 8x8 -> new_w=8, new_h=5 (6/6*8=8, 4/6*8=5.33->5)
     // So rows 5-7 should be padded zeros -> normalized to -1.0
     // Check last row of first channel
-    const float expected_pad = (0.0F / 255.0F - 0.5F) / 0.5F;  // -1.0
+    const float expected_pad = (0.0F / 255.0F - 0.5F) / 0.5F; // -1.0
     bool pad_ok = true;
-    for (int x = 0; x < 8; ++x)
-    {
+    for (int x = 0; x < 8; ++x) {
         // Channel 0, row 7, col x
         const std::size_t idx = static_cast<std::size_t>(0) * 64 + 7 * 8 + x;
-        if (std::abs(result.pixel_values[idx] - expected_pad) > 0.01F)
-        {
+        if (std::abs(result.pixel_values[idx] - expected_pad) > 0.01F) {
             pad_ok = false;
             break;
         }
@@ -569,8 +523,7 @@ static void test_aspect_preserve_chw_strategy()
 }
 
 // Test: pad_center_chw strategy — aspect-ratio-preserving resize + center-pad with mean color.
-static void test_pad_center_chw_strategy()
-{
+static void test_pad_center_chw_strategy() {
     trtmc_test::TempDirGuard tmp;
     const std::string& dir = tmp.path();
     const std::string image_path = write_test_ppm_nonsquare(dir);
@@ -607,11 +560,9 @@ static void test_pad_center_chw_strategy()
     const float expected_pad = (pad_pixel / 255.0F - 0.5F) / 0.5F;
     bool pad_ok = true;
     // Check row 0 of first channel (should be padded)
-    for (int x = 0; x < 8; ++x)
-    {
+    for (int x = 0; x < 8; ++x) {
         const std::size_t idx = static_cast<std::size_t>(0) * 64 + 0 * 8 + x;
-        if (std::abs(result.pixel_values[idx] - expected_pad) > 0.05F)
-        {
+        if (std::abs(result.pixel_values[idx] - expected_pad) > 0.05F) {
             pad_ok = false;
             break;
         }
@@ -620,32 +571,27 @@ static void test_pad_center_chw_strategy()
 }
 
 // Test Gap 4: interpolation defaults to "bicubic".
-static void test_parse_interpolation_default()
-{
+static void test_parse_interpolation_default() {
     const std::string config_json = R"({
         "preprocessor_type": "simple_chw"
     })";
 
     auto cfg = trtmc::parse_vl_preprocess_config(config_json, "");
-    check(cfg.interpolation == "bicubic",
-          "interpolation defaults to bicubic");
+    check(cfg.interpolation == "bicubic", "interpolation defaults to bicubic");
 }
 
 // Test Gap 4: interpolation = "bilinear" round-trips.
-static void test_parse_interpolation_bilinear()
-{
+static void test_parse_interpolation_bilinear() {
     const std::string config_json = R"({
         "interpolation": "bilinear"
     })";
 
     auto cfg = trtmc::parse_vl_preprocess_config(config_json, "");
-    check(cfg.interpolation == "bilinear",
-          "interpolation bilinear parsed from config.json");
+    check(cfg.interpolation == "bilinear", "interpolation bilinear parsed from config.json");
 }
 
 // Test Gap 4: resample int from preprocessor_config.json maps correctly.
-static void test_parse_resample_from_preprocessor()
-{
+static void test_parse_resample_from_preprocessor() {
     // config.json does NOT set interpolation -> fallback to resample int
     const std::string config_json = R"({
         "preprocessor_type": "simple_chw"
@@ -656,37 +602,32 @@ static void test_parse_resample_from_preprocessor()
     })";
 
     auto cfg = trtmc::parse_vl_preprocess_config(config_json, preproc_json);
-    check(cfg.interpolation == "bilinear",
-          "resample=2 maps to bilinear");
+    check(cfg.interpolation == "bilinear", "resample=2 maps to bilinear");
 
     // Test resample=3 -> bicubic
     const std::string preproc_json3 = R"({
         "resample": 3
     })";
     auto cfg3 = trtmc::parse_vl_preprocess_config(config_json, preproc_json3);
-    check(cfg3.interpolation == "bicubic",
-          "resample=3 maps to bicubic");
+    check(cfg3.interpolation == "bicubic", "resample=3 maps to bicubic");
 
     // Test resample=0 -> nearest
     const std::string preproc_json0 = R"({
         "resample": 0
     })";
     auto cfg0 = trtmc::parse_vl_preprocess_config(config_json, preproc_json0);
-    check(cfg0.interpolation == "nearest",
-          "resample=0 maps to nearest");
+    check(cfg0.interpolation == "nearest", "resample=0 maps to nearest");
 
     // Test: explicit config.json interpolation overrides resample
     const std::string config_explicit = R"({
         "interpolation": "nearest"
     })";
     auto cfg_override = trtmc::parse_vl_preprocess_config(config_explicit, preproc_json);
-    check(cfg_override.interpolation == "nearest",
-          "explicit interpolation overrides resample");
+    check(cfg_override.interpolation == "nearest", "explicit interpolation overrides resample");
 }
 
 // Test: parse_vl_preprocess_config with complete JSON (all fields populated).
-static void test_parse_complete_json()
-{
+static void test_parse_complete_json() {
     const std::string config_json = R"({
         "image_token_id": 200,
         "fixed_image_size": 336,
@@ -713,7 +654,8 @@ static void test_parse_complete_json()
     check(cfg.num_image_pad_tokens == 128, "complete: num_image_pad_tokens=128");
     check(cfg.vision_output_dim == 4096, "complete: vision_output_dim=4096");
     check(cfg.image_token_str == "<img>", "complete: image_token_str=<img>");
-    check(cfg.preprocessor_type == "center_crop_chw", "complete: preprocessor_type=center_crop_chw");
+    check(cfg.preprocessor_type == "center_crop_chw",
+          "complete: preprocessor_type=center_crop_chw");
     check(cfg.interpolation == "bilinear", "complete: interpolation=bilinear");
     check(cfg.patch_size == 16, "complete: patch_size=16");
     check(cfg.merge_size == 4, "complete: merge_size=4");
@@ -731,8 +673,7 @@ static void test_parse_complete_json()
 }
 
 // Test: parse_vl_preprocess_config with missing fields uses defaults.
-static void test_parse_missing_fields_defaults()
-{
+static void test_parse_missing_fields_defaults() {
     // Config JSON with only one field
     const std::string config_json = R"({
         "image_token_id": 42
@@ -744,7 +685,8 @@ static void test_parse_missing_fields_defaults()
     check(cfg.fixed_image_size == 448, "defaults: fixed_image_size=448");
     check(cfg.num_image_pad_tokens == 256, "defaults: num_image_pad_tokens=256");
     check(cfg.vision_output_dim == 0, "defaults: vision_output_dim=0");
-    check(cfg.preprocessor_type == "qwen_merge_group", "defaults: preprocessor_type=qwen_merge_group");
+    check(cfg.preprocessor_type == "qwen_merge_group",
+          "defaults: preprocessor_type=qwen_merge_group");
     check(cfg.interpolation == "bicubic", "defaults: interpolation=bicubic");
     check(cfg.vl_prompt_template.empty(), "defaults: vl_prompt_template empty");
     check(cfg.image_token_str.empty(), "defaults: image_token_str empty");
@@ -754,8 +696,7 @@ static void test_parse_missing_fields_defaults()
 }
 
 // Test: parse_vl_preprocess_config with empty JSON string.
-static void test_parse_empty_json()
-{
+static void test_parse_empty_json() {
     auto cfg = trtmc::parse_vl_preprocess_config("", "");
 
     // All fields should be at their struct default values
@@ -769,8 +710,7 @@ static void test_parse_empty_json()
 }
 
 // Test: parse_vl_preprocess_config with empty config but populated preprocessor.
-static void test_parse_only_preprocessor_config()
-{
+static void test_parse_only_preprocessor_config() {
     const std::string preproc_json = R"({
         "patch_size": 32,
         "merge_size": 1,
@@ -793,8 +733,7 @@ static void test_parse_only_preprocessor_config()
 }
 
 // Test: format_vl_prompt with empty template returns empty string.
-static void test_format_vl_prompt_empty_template()
-{
+static void test_format_vl_prompt_empty_template() {
     trtmc::VLPreprocessConfig config;
     config.num_image_pad_tokens = 5;
     config.image_token_str = "<pad>";
@@ -805,8 +744,7 @@ static void test_format_vl_prompt_empty_template()
 }
 
 // Test: format_vl_prompt with template missing placeholders.
-static void test_format_vl_prompt_no_placeholders()
-{
+static void test_format_vl_prompt_no_placeholders() {
     trtmc::VLPreprocessConfig config;
     config.num_image_pad_tokens = 2;
     config.image_token_str = "<tok>";
@@ -818,8 +756,7 @@ static void test_format_vl_prompt_no_placeholders()
 }
 
 // Test: preprocessor_type = "aspect_preserve_chw" round-trips through parse.
-static void test_parse_vl_config_aspect_preserve()
-{
+static void test_parse_vl_config_aspect_preserve() {
     const std::string config_json = R"({
         "preprocessor_type": "aspect_preserve_chw"
     })";
@@ -830,8 +767,7 @@ static void test_parse_vl_config_aspect_preserve()
 }
 
 // Test: preprocessor_type = "center_crop_chw" round-trips through parse.
-static void test_parse_vl_config_center_crop()
-{
+static void test_parse_vl_config_center_crop() {
     const std::string config_json = R"({
         "preprocessor_type": "center_crop_chw"
     })";
@@ -842,8 +778,7 @@ static void test_parse_vl_config_center_crop()
 }
 
 // Test: vl_prompt_template with escaped newlines (\n) gets unescaped.
-static void test_parse_vl_prompt_template_newline_unescape()
-{
+static void test_parse_vl_prompt_template_newline_unescape() {
     const std::string config_json = R"({
         "vl_prompt_template": "Line1\\nLine2\\nLine3"
     })";
@@ -854,8 +789,7 @@ static void test_parse_vl_prompt_template_newline_unescape()
           "newline_unescape: template contains real newlines");
 }
 
-int main()
-{
+int main() {
     test_helper_normalize_hwc_to_chw();
     test_helper_normalize_std_floor_branch();
     test_helper_transform_simple_chw_branch();
@@ -887,8 +821,7 @@ int main()
     test_parse_vl_config_center_crop();
     test_parse_vl_prompt_template_newline_unescape();
 
-    if (failures > 0)
-    {
+    if (failures > 0) {
         std::cerr << failures << " test(s) FAILED\n";
         return 1;
     }

--- a/tests/cpp/test_image_preprocessor.cpp
+++ b/tests/cpp/test_image_preprocessor.cpp
@@ -297,6 +297,43 @@ static void test_simple_chw_strategy()
     check(in_range, "simple_chw: all normalized values in [-1.1, 1.1]");
 }
 
+// Test: locateanything_patchify strategy produces [patches, C, pH, pW] plus grid metadata.
+static void test_locateanything_patchify_strategy()
+{
+    trtmc_test::TempDirGuard tmp;
+    const std::string& dir = tmp.path();
+    const std::string image_path = write_test_ppm(dir);
+
+    trtmc::VLPreprocessConfig config;
+    config.fixed_image_size = 4;
+    config.patch_size = 2;
+    config.in_channels = 3;
+    config.preprocessor_type = "locateanything_patchify";
+    config.interpolation = "nearest";
+    config.image_mean[0] = 0.5F;
+    config.image_mean[1] = 0.5F;
+    config.image_mean[2] = 0.5F;
+    config.image_std[0] = 0.5F;
+    config.image_std[1] = 0.5F;
+    config.image_std[2] = 0.5F;
+
+    auto result = trtmc::load_and_preprocess_image(image_path, config);
+
+    check(result.ok, "locateanything_patchify: image loaded successfully");
+    check(result.channels == 3, "locateanything_patchify: channels = C = 3");
+    check(result.height == 4, "locateanything_patchify: height = fixed_image_size = 4");
+    check(result.width == 4, "locateanything_patchify: width = fixed_image_size = 4");
+    check(result.image_grid_hws.size() == 2, "locateanything_patchify: grid has two entries");
+    check(result.image_grid_hws[0] == 2, "locateanything_patchify: grid height = 2");
+    check(result.image_grid_hws[1] == 2, "locateanything_patchify: grid width = 2");
+
+    const std::size_t expected_size = 4 * 3 * 2 * 2;
+    check(result.pixel_values.size() == expected_size,
+          "locateanything_patchify: pixel_values size = patches * C * pH * pW");
+    check_near(result.pixel_values[0], -1.0F, 1e-5F,
+               "locateanything_patchify: first patch first red pixel normalized");
+}
+
 // Test: load non-existent image returns ok=false.
 static void test_load_missing_image()
 {
@@ -826,6 +863,7 @@ int main()
 
     test_qwen_merge_group_strategy();
     test_simple_chw_strategy();
+    test_locateanything_patchify_strategy();
     test_load_missing_image();
     test_format_vl_prompt();
     test_parse_vl_config();

--- a/tests/e2e/models/locateanything-3b.json
+++ b/tests/e2e/models/locateanything-3b.json
@@ -13,5 +13,5 @@
   "layer_atol": 0.05,
   "test_image": "tests/e2e/data/test_img.jpeg",
   "trust_remote_code": true,
-  "skip": "LocateAnything text decoder packaging is supported, but MoonViT vision execution needs runtime support for image_grid_hws before end-to-end image grounding can be validated."
+  "notes": "Initial LocateAnything support uses the fixed 448x448 single-image MoonViT path and the existing TRT MC autoregressive VL generation path."
 }

--- a/tests/e2e/models/locateanything-3b.json
+++ b/tests/e2e/models/locateanything-3b.json
@@ -1,0 +1,17 @@
+{
+  "name": "locateanything-3b",
+  "trace_id": "IT-E2E-LA3B-01",
+  "hf_id": "nvidia/LocateAnything-3B",
+  "bundle": "locateanything-3b.trtfb",
+  "family": "locateanything",
+  "runtime_strategy": "vision_language",
+  "ci_tier": "l0_only",
+  "max_cache_length": 384,
+  "prompt": "Find the red vehicle in this image.",
+  "max_new_tokens": 32,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "test_image": "tests/e2e/data/test_img.jpeg",
+  "trust_remote_code": true,
+  "skip": "LocateAnything text decoder packaging is supported, but MoonViT vision execution needs runtime support for image_grid_hws before end-to-end image grounding can be validated."
+}

--- a/tests/e2e_harness/references/hf_transformers.py
+++ b/tests/e2e_harness/references/hf_transformers.py
@@ -96,6 +96,11 @@ def _vl_prompt_has_image_placeholder(text: str) -> bool:
     ))
 
 
+def _is_locateanything_vl_case(case: E2ECase) -> bool:
+    """Return true for LocateAnything VL cases."""
+    return case.family.lower() == "locateanything" or "locateanything" in case.hf_id.lower()
+
+
 def _normalize_vl_prompt_guard(text: str) -> str:
     """Normalize decoded VL text for prompt-only reference detection."""
     normalized = " ".join(str(text or "").split()).strip().lower()
@@ -1533,6 +1538,9 @@ class HfTransformersReference:
         self, case: E2ECase, stage: StageSpec, ctx: RunContext
     ) -> StageOutput:
         """Run HF vision-language model for reference generation."""
+        if _is_locateanything_vl_case(case):
+            return self._run_locateanything_vl_full_generation(case, stage, ctx)
+
         artifacts_dir = ctx.artifacts_dir or tempfile.gettempdir()
         model_dir = _case_artifact_dir(artifacts_dir, case.name) if ctx.artifacts_dir else artifacts_dir
         text_path = str(Path(model_dir) / "hf_vl_text.txt")
@@ -1645,6 +1653,266 @@ class HfTransformersReference:
             output_readers=(lambda: {"text": _read_text_artifact(text_path)},),
             text_reader=lambda: _read_text_artifact(text_path),
             metadata={"trust_remote_code": trust_remote_code},
+            failure_label="HF VL generation",
+        )
+
+    def _run_locateanything_vl_full_generation(
+        self, case: E2ECase, stage: StageSpec, ctx: RunContext
+    ) -> StageOutput:
+        """Run LocateAnything HF reference without the optional remote processor."""
+        artifacts_dir = ctx.artifacts_dir or tempfile.gettempdir()
+        model_dir = _case_artifact_dir(artifacts_dir, case.name) if ctx.artifacts_dir else artifacts_dir
+        text_path = str(Path(model_dir) / "hf_vl_text.txt")
+
+        prompt = case.inputs.get("prompt", "Describe this image.")
+        max_new_tokens = case.inputs.get("max_new_tokens", 30)
+        trust_remote_code = case.metadata.get("trust_remote_code", False)
+        image_path = self._resolve_image_path(case.inputs.get("image", ""))
+        hf_id = case.hf_id
+        model_ref = _resolve_cached_model_ref(hf_id)
+        torch_dtype_expr = _torch_dtype_for_case(case)
+
+        script = textwrap.dedent(f"""\
+            import json
+            import sys
+            from pathlib import Path
+
+            import torch
+            from tensorrt_model_connect.debug_runner import (
+                preprocess_image_inputs_for_trt,
+            )
+            from transformers import AutoConfig, AutoModel, AutoTokenizer
+
+            hf_id = {hf_id!r}
+            model_ref = {model_ref!r}
+            prompt = {prompt!r}
+            max_new_tokens = {max_new_tokens}
+            trust_remote_code = {trust_remote_code!r}
+            image_path = {image_path!r}
+            text_path = {text_path!r}
+
+            def _install_tied_weight_compat():
+                from transformers.cache_utils import DynamicCache
+                from transformers.modeling_utils import PreTrainedModel
+
+                if not hasattr(DynamicCache, "to_legacy_cache"):
+                    def _to_legacy_cache(self):
+                        return tuple(
+                            (layer.keys, layer.values) for layer in self.layers
+                        )
+
+                    DynamicCache.to_legacy_cache = _to_legacy_cache
+
+                if not hasattr(DynamicCache, "from_legacy_cache"):
+                    @classmethod
+                    def _from_legacy_cache(cls, past_key_values=None):
+                        cache = cls()
+                        if past_key_values is None:
+                            return cache
+                        for layer_idx, (key_states, value_states) in enumerate(
+                            past_key_values
+                        ):
+                            cache.update(key_states, value_states, layer_idx)
+                        return cache
+
+                    DynamicCache.from_legacy_cache = _from_legacy_cache
+
+                if not hasattr(PreTrainedModel, "all_tied_weights_keys"):
+                    PreTrainedModel.all_tied_weights_keys = {{}}
+                original = PreTrainedModel.get_expanded_tied_weights_keys
+
+                def _compat_get_expanded_tied_weights_keys(self, all_submodels=False):
+                    tied_mapping = getattr(self, "_tied_weights_keys", None)
+                    if not isinstance(tied_mapping, list):
+                        return original(self, all_submodels=all_submodels)
+                    if all_submodels:
+                        expanded_tied_weights = {{}}
+                        for prefix, submodule in self.named_modules(
+                            remove_duplicate=False
+                        ):
+                            if isinstance(submodule, PreTrainedModel):
+                                submodel_tied_weights = (
+                                    submodule.get_expanded_tied_weights_keys(
+                                        all_submodels=False
+                                    )
+                                )
+                                if prefix:
+                                    submodel_tied_weights = {{
+                                        f"{{prefix}}.{{key}}": f"{{prefix}}.{{value}}"
+                                        for key, value in submodel_tied_weights.items()
+                                    }}
+                                expanded_tied_weights.update(submodel_tied_weights)
+                        return expanded_tied_weights
+                    if not getattr(self.config, "tie_word_embeddings", False):
+                        return {{}}
+                    if "lm_head.weight" in tied_mapping:
+                        return {{"lm_head.weight": "model.embed_tokens.weight"}}
+                    return {{}}
+
+                PreTrainedModel.get_expanded_tied_weights_keys = (
+                    _compat_get_expanded_tied_weights_keys
+                )
+
+            def _load_locateanything_config(model_ref):
+                config = AutoConfig.from_pretrained(
+                    model_ref, trust_remote_code=trust_remote_code)
+                raw_config_path = Path(model_ref) / "config.json"
+                if raw_config_path.is_file() and hasattr(config, "text_config"):
+                    raw_config = json.loads(raw_config_path.read_text(encoding="utf-8"))
+                    raw_text_config = raw_config.get("text_config", {{}})
+                    if not hasattr(config.text_config, "rope_theta"):
+                        rope_theta = raw_text_config.get("rope_theta")
+                        if rope_theta is None:
+                            rope_parameters = raw_text_config.get("rope_parameters", {{}})
+                            rope_theta = rope_parameters.get("rope_theta", 10000.0)
+                        config.text_config.rope_theta = float(rope_theta)
+                return config
+
+            def _load_locateanything_tokenizer(model_ref):
+                try:
+                    return AutoTokenizer.from_pretrained(
+                        model_ref, trust_remote_code=trust_remote_code)
+                except Exception as auto_exc:
+                    from tokenizers import Tokenizer
+
+                    model_path = Path(model_ref)
+                    raw_tokenizer = Tokenizer.from_file(
+                        str(model_path / "tokenizer.json"))
+                    tokenizer_config = {{}}
+                    tokenizer_config_path = model_path / "tokenizer_config.json"
+                    if tokenizer_config_path.is_file():
+                        tokenizer_config = json.loads(
+                            tokenizer_config_path.read_text(encoding="utf-8"))
+                    model_max_length = int(
+                        tokenizer_config.get("model_max_length", 16384))
+
+                    class TokenizersWrapper:
+                        def __init__(self, tok, max_length):
+                            self._tok = tok
+                            self.model_max_length = max_length
+
+                        def encode(self, text, add_special_tokens=False):
+                            return self._tok.encode(
+                                text,
+                                add_special_tokens=add_special_tokens).ids
+
+                        def __call__(self, text, return_tensors=None):
+                            ids = self.encode(text, add_special_tokens=False)
+                            if return_tensors == "pt":
+                                input_ids = torch.tensor([ids], dtype=torch.long)
+                                attention_mask = torch.ones_like(input_ids)
+                                return {{
+                                    "input_ids": input_ids,
+                                    "attention_mask": attention_mask,
+                                }}
+                            return {{"input_ids": ids}}
+
+                        def decode(self, ids, skip_special_tokens=True):
+                            if torch.is_tensor(ids):
+                                ids = ids.detach().cpu().tolist()
+                            if isinstance(ids, int):
+                                ids = [ids]
+                            return self._tok.decode(
+                                [int(token) for token in ids],
+                                skip_special_tokens=skip_special_tokens)
+
+                        def batch_decode(self, batch_ids, skip_special_tokens=True):
+                            return [
+                                self.decode(ids, skip_special_tokens=skip_special_tokens)
+                                for ids in batch_ids
+                            ]
+
+                    print(
+                        f"WARN AutoTokenizer failed ({{auto_exc}}); "
+                        "using tokenizer.json fallback",
+                        file=sys.stderr,
+                    )
+                    return TokenizersWrapper(raw_tokenizer, model_max_length)
+
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            _install_tied_weight_compat()
+            config = _load_locateanything_config(model_ref)
+            tokenizer = _load_locateanything_tokenizer(model_ref)
+            model = AutoModel.from_pretrained(
+                model_ref, config=config, trust_remote_code=trust_remote_code,
+                torch_dtype={torch_dtype_expr})
+            model.to(device)
+            model.eval()
+
+            image_inputs = preprocess_image_inputs_for_trt(
+                image_path,
+                preprocessor_type="locateanything_patchify",
+                fixed_image_size=448,
+                image_mean=(0.5, 0.5, 0.5),
+                image_std=(0.5, 0.5, 0.5),
+                patch_size=14,
+                interpolation="bicubic",
+            )
+            pixel_values = torch.from_numpy(image_inputs["pixel_values"]).to(device)
+            image_grid_hws = torch.from_numpy(
+                image_inputs["image_grid_hws"]).to(device=device, dtype=torch.int32)
+
+            image_pads = "<IMG_CONTEXT>" * 256
+            prompt_text = (
+                "<|im_start|>system\\n"
+                "You are a helpful assistant.<|im_end|>\\n"
+                "<|im_start|>user\\n"
+                f"<img>{{image_pads}}</img>{{prompt}}<|im_end|>\\n"
+                "<|im_start|>assistant\\n"
+            )
+            inputs = tokenizer(prompt_text, return_tensors="pt")
+            input_ids = inputs["input_ids"].to(device)
+            attention_mask = inputs.get("attention_mask")
+            if attention_mask is not None:
+                attention_mask = attention_mask.to(device)
+
+            generate_kwargs = {{
+                "pixel_values": pixel_values,
+                "image_grid_hws": image_grid_hws,
+                "input_ids": input_ids,
+                "tokenizer": tokenizer,
+                "max_new_tokens": max_new_tokens,
+                "use_cache": True,
+                "generation_mode": "slow",
+                "do_sample": False,
+            }}
+            if attention_mask is not None:
+                generate_kwargs["attention_mask"] = attention_mask
+
+            with torch.no_grad():
+                output = model.generate(**generate_kwargs)
+
+            if isinstance(output, str):
+                text = output
+            elif isinstance(output, (list, tuple)) and output and isinstance(output[0], str):
+                text = output[0]
+            else:
+                input_len = input_ids.shape[-1]
+                generated_ids = output[0][input_len:] if output.ndim > 1 else output[input_len:]
+                text = tokenizer.decode(generated_ids, skip_special_tokens=True)
+            if not text.strip():
+                raise RuntimeError("HF LocateAnything reference produced empty text")
+
+            with open(text_path, "w") as f:
+                f.write(text)
+            print(f"OK text={{text[:100]!r}}")
+        """)
+
+        python = ctx.reference_python_path() or sys.executable
+        return run_reference_subprocess(
+            command=[python, "-c", script],
+            timeout_s=1800,
+            label="hf_vl_generation",
+            artifact_dir=ctx.artifacts_dir or "",
+            case_name=case.name,
+            stage_name=stage.name,
+            env=_reference_env(ctx),
+            output_readers=(lambda: {"text": _read_text_artifact(text_path)},),
+            text_reader=lambda: _read_text_artifact(text_path),
+            metadata={
+                "trust_remote_code": trust_remote_code,
+                "reference_variant": "locateanything_manual_processor",
+            },
             failure_label="HF VL generation",
         )
 

--- a/tests/e2e_harness/references/hf_transformers.py
+++ b/tests/e2e_harness/references/hf_transformers.py
@@ -1829,6 +1829,44 @@ class HfTransformersReference:
                     )
                     return TokenizersWrapper(raw_tokenizer, model_max_length)
 
+            def _repair_locateanything_rotary_buffers(model):
+                # Restore non-persistent Qwen2 RoPE buffers zeroed by remote loading.
+                repaired = 0
+                model_device = next(model.parameters()).device
+                for module in model.language_model.modules():
+                    if not (
+                        hasattr(module, "_set_cos_sin_cache")
+                        and hasattr(module, "base")
+                        and hasattr(module, "dim")
+                    ):
+                        continue
+                    buffer_device = getattr(
+                        getattr(module, "inv_freq", None), "device", model_device)
+                    inv_freq = 1.0 / (
+                        float(module.base) ** (
+                            torch.arange(
+                                0,
+                                int(module.dim),
+                                2,
+                                device=buffer_device,
+                                dtype=torch.float32,
+                            ) / float(module.dim)
+                        )
+                    )
+                    module.register_buffer("inv_freq", inv_freq, persistent=False)
+                    seq_len = int(
+                        getattr(
+                            module,
+                            "max_position_embeddings",
+                            getattr(model.config.text_config, "max_position_embeddings", 32768),
+                        )
+                    )
+                    module._set_cos_sin_cache(
+                        seq_len=seq_len, device=inv_freq.device, dtype=torch.float32)
+                    repaired += 1
+                if repaired == 0:
+                    raise RuntimeError("LocateAnything reference did not find RoPE buffers")
+
             device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
             _install_tied_weight_compat()
             config = _load_locateanything_config(model_ref)
@@ -1838,6 +1876,7 @@ class HfTransformersReference:
                 torch_dtype={torch_dtype_expr})
             model.to(device)
             model.eval()
+            _repair_locateanything_rotary_buffers(model)
 
             image_inputs = preprocess_image_inputs_for_trt(
                 image_path,

--- a/tests/tools/test_hf_transformers_reference_helpers.py
+++ b/tests/tools/test_hf_transformers_reference_helpers.py
@@ -178,6 +178,77 @@ def test_run_reference_subprocess_timeout_saves_stderr(monkeypatch, tmp_path) ->
     assert log_path.read_text(encoding="utf-8") == "late stderr"
 
 
+def test_locateanything_vl_reference_uses_manual_processor(
+    monkeypatch, tmp_path
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        text_path = tmp_path / "locateanything-3b" / "hf_vl_text.txt"
+        text_path.write_text("found", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, stdout="OK text='found'\n", stderr="")
+
+    monkeypatch.setattr(
+        hf_transformers, "_resolve_cached_model_ref", lambda hf_id: "/cached/model"
+    )
+    monkeypatch.setattr(hf_transformers.subprocess, "run", _fake_run)
+
+    case = E2ECase(
+        name="locateanything-3b",
+        hf_id="nvidia/LocateAnything-3B",
+        family="locateanything",
+        runtime_strategy="vision_language",
+        task_strategy="vision_language_generation",
+        inputs={
+            "prompt": "Find the red vehicle in this image.",
+            "max_new_tokens": 1,
+            "image": "tests/e2e/data/test_img.jpeg",
+        },
+        metadata={"precision": "bf16", "trust_remote_code": True},
+    )
+    ctx = RunContext(
+        case=case,
+        artifacts_dir=str(tmp_path),
+        reference_python="/ref/python",
+    )
+
+    out = HfTransformersReference().run_stage(
+        case, StageSpec(name="full_generation"), ctx
+    )
+
+    cmd = captured["cmd"]
+    assert cmd[:2] == ["/ref/python", "-c"]
+    script = cmd[2]
+    assert "AutoProcessor" not in script
+    assert "from transformers import AutoConfig, AutoModel, AutoTokenizer" in script
+    assert "def _install_tied_weight_compat" in script
+    assert "all_tied_weights_keys" in script
+    assert "DynamicCache.to_legacy_cache" in script
+    assert "DynamicCache.from_legacy_cache" in script
+    assert "get_expanded_tied_weights_keys" in script
+    assert "model.embed_tokens.weight" in script
+    assert "def _load_locateanything_config" in script
+    assert "config.text_config.rope_theta" in script
+    assert "AutoModel.from_pretrained" in script
+    assert "config=config" in script
+    assert "def _load_locateanything_tokenizer" in script
+    assert "Tokenizer.from_file" in script
+    assert "model_max_length" in script
+    assert "def batch_decode" in script
+    assert "preprocess_image_inputs_for_trt" in script
+    assert 'preprocessor_type="locateanything_patchify"' in script
+    assert 'image_pads = "<IMG_CONTEXT>" * 256' in script
+    assert 'f"<img>{image_pads}</img>{prompt}<|im_end|>\\n"' in script
+    assert '"generation_mode": "slow"' in script
+    assert '"do_sample": False' in script
+    assert "torch_dtype=torch.bfloat16" in script
+    assert out.text == "found"
+    assert out.metadata["reference_variant"] == "locateanything_manual_processor"
+    assert out.logits is None
+
+
 def test_nemotron_labs_diffusion_reference_uses_custom_auto_model_path(
     monkeypatch, tmp_path
 ) -> None:

--- a/tools/diff_vl.py
+++ b/tools/diff_vl.py
@@ -59,6 +59,10 @@ def _is_qwen_vl(model_type: str) -> bool:
     return "qwen" in mt and "vl" in mt
 
 
+def _is_locateanything(model_type: str) -> bool:
+    return model_type.lower() == "locateanything"
+
+
 def _get_hf_vision_features_qwen(
     model_id: str,
     image_path: str,
@@ -137,6 +141,98 @@ def _get_hf_vision_features_qwen(
     del model
     _free_gpu()
     return hf_features_np, trt_pixel_values
+
+
+def _get_hf_vision_features_locateanything(
+    model_id: str,
+    image_path: str,
+    fixed_image_size: int = 448,
+) -> tuple[np.ndarray, np.ndarray]:
+    """LocateAnything HF vision features: MoonViT output after mlp1."""
+    import importlib.util
+    import torch
+    from PIL import Image
+
+    from tensorrt_model_connect.config import ModelConfig
+    from tensorrt_model_connect.families.locateanything.vision_builder import (
+        _build_moonvit,
+        _build_projector,
+        _load_modeling_vit,
+        _load_vision_and_projector_weights,
+    )
+
+    model_dir = Path(model_id)
+    if not model_dir.is_dir():
+        from huggingface_hub import snapshot_download
+        model_dir = Path(snapshot_download(
+            repo_id=model_id,
+            allow_patterns=[
+                "config.json",
+                "preprocessor_config.json",
+                "processor_config.json",
+                "chat_template.json",
+                "tokenizer.json",
+                "tokenizer_config.json",
+                "special_tokens_map.json",
+                "*.py",
+                "*.safetensors",
+                "*.safetensors.index.json",
+            ],
+        ))
+
+    print(f"[diff_vl] Loading HF LocateAnything vision path from {model_dir} ...",
+          file=sys.stderr)
+
+    cfg = ModelConfig.from_dir(model_dir)
+    modeling_vit = _load_modeling_vit(model_dir)
+    vision_model = _build_moonvit(modeling_vit, cfg)
+    projector = _build_projector(cfg)
+    _load_vision_and_projector_weights(model_dir, vision_model, projector)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    vision_model.to(device=device, dtype=torch.float32).eval()
+    projector.to(device=device, dtype=torch.float32).eval()
+
+    processor_path = model_dir / "image_processing_locateanything.py"
+    spec = importlib.util.spec_from_file_location(
+        "trtmc_locateanything_image_processing_ref", processor_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot import LocateAnything image processor: {processor_path}")
+    processor_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(processor_module)
+    vision_config = cfg.raw.get("vision_config", {})
+    image_processor = processor_module.LocateAnythingImageProcessor(
+        patch_size=int(vision_config.get("patch_size", 14)),
+        merge_kernel_size=vision_config.get("merge_kernel_size", [2, 2]),
+        image_mean=(0.5, 0.5, 0.5),
+        image_std=(0.5, 0.5, 0.5),
+    )
+
+    image = Image.open(image_path).convert("RGB")
+    image_fixed = image.resize((fixed_image_size, fixed_image_size), Image.BICUBIC)
+    image_inputs = image_processor(images=[image_fixed], return_tensors="pt")
+    pixel_values_hf = image_inputs["pixel_values"]
+    image_grid_hws = image_inputs["image_grid_hws"]
+
+    print(f"[diff_vl] HF pixel_values: {pixel_values_hf.shape}, "
+          f"image_grid_hws: {image_grid_hws.tolist()}", file=sys.stderr)
+
+    with torch.no_grad():
+        vit_features = vision_model(
+            pixel_values_hf.to(device=device, dtype=torch.float32),
+            image_grid_hws.to(device=device),
+        )
+        hf_features = projector(torch.cat(vit_features, dim=0))
+
+    hf_features_np = hf_features.float().cpu().numpy()
+    print(f"[diff_vl] HF features: shape={hf_features_np.shape}, "
+          f"mean={hf_features_np.mean():.6f}, std={hf_features_np.std():.6f}",
+          file=sys.stderr)
+
+    pixel_values_np = pixel_values_hf.float().cpu().numpy()
+    del vision_model, projector
+    _free_gpu()
+    return hf_features_np, pixel_values_np
 
 
 def _get_hf_vision_features_generic(
@@ -230,6 +326,9 @@ def _get_hf_vision_features(
     if _is_qwen_vl(model_type):
         return _get_hf_vision_features_qwen(
             model_id, image_path, fixed_image_size)
+    if _is_locateanything(model_type):
+        return _get_hf_vision_features_locateanything(
+            model_id, image_path, fixed_image_size)
     return _get_hf_vision_features_generic(
         model_id, image_path, fixed_image_size)
 
@@ -248,7 +347,7 @@ def test_vision_features(
     """
     from tensorrt_model_connect.debug_runner import (
         VisionTrtRunner, load_vision_engine_from_bundle,
-        preprocess_image_for_trt, load_preprocessor_config_from_bundle,
+        preprocess_image_inputs_for_trt, load_preprocessor_config_from_bundle,
         load_config_from_bundle,
     )
 
@@ -260,9 +359,14 @@ def test_vision_features(
     config = load_config_from_bundle(bundle_path)
     preproc = load_preprocessor_config_from_bundle(bundle_path)
     fixed_image_size = config.get("fixed_image_size", 448)
-    temporal = preproc.get("temporal_patch_size", 1)
-    image_mean = tuple(preproc.get("image_mean", [0.48145466, 0.4578275, 0.40821073]))
-    image_std = tuple(preproc.get("image_std", [0.26862954, 0.26130258, 0.27577711]))
+    temporal = preproc.get(
+        "temporal_patch_size", config.get("temporal_patch_size", 1))
+    image_mean = tuple(preproc.get(
+        "image_mean", config.get(
+            "image_mean", [0.48145466, 0.4578275, 0.40821073])))
+    image_std = tuple(preproc.get(
+        "image_std", config.get(
+            "image_std", [0.26862954, 0.26130258, 0.27577711])))
     preprocessor_type = config.get("preprocessor_type", "qwen_merge_group")
     interpolation = config.get("interpolation", "bicubic")
 
@@ -280,19 +384,20 @@ def test_vision_features(
     runner = VisionTrtRunner(vision_plan)
 
     # Prepare TRT pixel values
-    vis_patch_size = preproc.get("patch_size", 14)
-    vis_merge_size = preproc.get("merge_size", 2)
-    trt_pixel = preprocess_image_for_trt(
+    vis_patch_size = preproc.get("patch_size", config.get("patch_size", 14))
+    vis_merge_size = preproc.get("merge_size", config.get("merge_size", 2))
+    trt_inputs = preprocess_image_inputs_for_trt(
         image_path, preprocessor_type=preprocessor_type,
         fixed_image_size=fixed_image_size,
         temporal_patch_size=temporal, image_mean=image_mean, image_std=image_std,
         patch_size=vis_patch_size, merge_size=vis_merge_size,
         interpolation=interpolation)
 
-    print(f"[diff_vl] TRT vision input: {trt_pixel.shape}", file=sys.stderr)
+    shapes = {name: value.shape for name, value in trt_inputs.items()}
+    print(f"[diff_vl] TRT vision inputs: {shapes}", file=sys.stderr)
 
     # Run TRT vision encoder
-    results = runner.encode(pixel_values=trt_pixel)
+    results = runner.encode(**trt_inputs)
     trt_features = results["image_features"]
 
     print(f"[diff_vl] TRT features: shape={trt_features.shape}, "
@@ -489,7 +594,31 @@ def test_vl_generation(
                     data = load_section_from_bundle(bundle_path, name)
                     if data:
                         (Path(tmpdir) / name).write_bytes(data)
-                tokenizer = AutoTokenizer.from_pretrained(tmpdir)
+                try:
+                    tokenizer = AutoTokenizer.from_pretrained(tmpdir)
+                except Exception as auto_exc:
+                    from tokenizers import Tokenizer
+
+                    raw_tokenizer = Tokenizer.from_file(
+                        str(Path(tmpdir) / "tokenizer.json"))
+
+                    class TokenizersWrapper:
+                        def __init__(self, tok):
+                            self._tok = tok
+
+                        def encode(self, text, add_special_tokens=False):
+                            return self._tok.encode(
+                                text,
+                                add_special_tokens=add_special_tokens).ids
+
+                        def decode(self, ids, skip_special_tokens=True):
+                            return self._tok.decode(
+                                ids,
+                                skip_special_tokens=skip_special_tokens)
+
+                    tokenizer = TokenizersWrapper(raw_tokenizer)
+                    print(f"[diff_vl] WARN: AutoTokenizer failed ({auto_exc}); "
+                          "using tokenizer.json fallback", file=sys.stderr)
         else:
             tokenizer = AutoTokenizer.from_pretrained(model_source)
     except Exception as e:


### PR DESCRIPTION
## Background
LocateAnything-3B needs TRT MC vision-language support beyond text decoder packaging. Its MoonViT path consumes patchified image inputs and a fixed image grid, then injects projected image embeddings through the existing `embed_input` VL decoder path.

## Exit Criteria
- Build a TRT MC bundle for `nvidia/LocateAnything-3B`.
- Run LocateAnything vision parity against the HF MoonViT + projector path.
- Run Python and C++ VL smoke tests.
- Support bf16 decoder builds for the `embed_input` path.

## Implementation
- Added a LocateAnything vision builder that exports fixed 448x448 MoonViT + `mlp1` to a TRT vision engine.
- Added `locateanything_patchify` preprocessing in C++ and Python debug tooling.
- Wired VL runtime handling for auxiliary grid metadata when a vision engine exposes it.
- Updated `diff_vl.py` with LocateAnything HF vision reference extraction and tokenizer fallback.
- Fixed bf16 `embed_input` blending by casting the blend constant and token embedding to the runtime work dtype before TensorRT elementwise ops.
- Enabled the LocateAnything E2E manifest and added focused regression tests.

## Validation
- `docker exec trtmc-dev-gb300-codex pytest -q tests/builder/test_standard_decoder.py -k 'embed_input'`: passed.
- `docker exec trtmc-dev-gb300-codex pytest -q tests/builder/test_families.py tests/builder/test_family_plugins.py -k LocateAnything`: passed.
- `docker exec trtmc-dev-gb300-codex pytest -q tests/tools/test_diff_vl.py`: passed.
- `docker exec trtmc-dev-gb300-codex ./build/trtmc build /root/.cache/huggingface/hub/models--nvidia--LocateAnything-3B/snapshots/7a81d810571dc5f244b2f0b6868128f24b1cbd85 -o /tmp/locateanything-3b-bf16.trtfb --trust-remote-code --max-cache-length 64 --precision bf16`: passed.
- `docker exec trtmc-dev-gb300-codex python tools/diff_vl.py --bundle /tmp/locateanything-3b-bf16.trtfb --image tests/e2e/data/test_img.jpeg --model /root/.cache/huggingface/hub/models--nvidia--LocateAnything-3B/snapshots/7a81d810571dc5f244b2f0b6868128f24b1cbd85 --max-new-tokens 1`: passed; TRT/HF vision cosine `0.999997`, Python VL generated `!`, C++ smoke generated `!`.
- `git -C /home/samli/Git/TensorRT-Model-Connect diff --check`: passed.

## Notes For Future Readers
- Initial LocateAnything support is intentionally fixed to the single-image 448x448 path.
- The fixed `image_grid_hws=[[32,32]]` is constant-folded in the built vision engine, so the final engine exposes `pixel_values` as its runtime input.
