### PR TITLE
feat(lance): add Lance image/video understanding (x2t)

### DIFF
--- a/python/tensorrt_model_connect/families/lance/__init__.py
+++ b/python/tensorrt_model_connect/families/lance/__init__.py
@@ -1,0 +1,6 @@
+"""Lance family package. Exposes the module-level ``plugin`` for auto-discovery."""
+from __future__ import annotations
+
+from .plugin import plugin
+
+__all__ = ["plugin"]

--- a/python/tensorrt_model_connect/families/lance/plugin.py
+++ b/python/tensorrt_model_connect/families/lance/plugin.py
@@ -1,0 +1,156 @@
+"""Lance family plugin — ByteDance ``bytedance-research/Lance`` unified model.
+
+Scope (Stage 1): the **understanding** path only — ``x2t_image`` and
+``x2t_video``. Lance's understanding sub-model is a Qwen2.5-VL ViT vision
+encoder feeding a Lance text decoder, which maps onto the existing
+``vision_language`` runtime strategy.
+
+Lance is a Mixture-of-Transformer-Experts model: every decoder layer carries a
+second ``*_moe_gen`` parameter set, plus ``llm2vae`` / ``vae2llm`` /
+``time_embedder`` / ``latent_pos_embed`` tensors. Those drive flow-matching
+image/video **generation** and are intentionally NOT consumed here:
+``load_standard_weights`` only reads the unsuffixed understanding-expert keys
+(``self_attn.q_proj``, ``mlp.*``, ``input_layernorm`` …), so the generation
+expert is dropped automatically. Generation/editing is a later stage that needs
+a new runtime strategy and is out of scope for this plugin.
+
+Architecture (confirmed against ``modeling/lance/qwen2_navit.py``): the
+understanding decoder is GQA (16/2) with **QKV bias** (Qwen2 style) **and**
+per-head **QK-norm** over ``head_dim`` (``qk_norm_und``) + SwiGLU + standard
+RoPE; ViT is the standard Qwen2.5-VL encoder shipped with bare ``blocks.*`` /
+``merger.*`` / ``patch_embed.*`` names (we re-add the ``visual.`` prefix the
+shared vision builder expects). The shared decoder builder applies QKV-bias and
+QK-norm conditionally when the weights are present.
+
+Numerical validation: the TRT decoder matches an independent eager reference
+exactly (per-layer and logits), and end-to-end ``trtmc run`` at **bf16** is
+verified correct ("White car driving on the street." / "White"). Reduced
+precision relies on the #184 builder fix (now in main): for embed bundles
+``input_embed`` is bound as fp32 and cast inside the graph, and ``build_engine``
+forwards ``precision`` so bf16/fp16 build true reduced-precision engines.
+
+Checkpoint layout: the Lance HF repo is not a flat HF checkpoint (it nests
+``Lance_3B/llm_config.json`` and a separate ``Qwen2.5-VL-ViT/`` dir). Run
+``scripts/prepare_lance_model.py`` to stage a directory this plugin can build:
+``config.json`` (model_type=lance), ``model.safetensors``, the tokenizer files,
+and the ViT at ``vision/model.safetensors``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from ...config import ModelConfig
+from ...checkpoint_mapper import (
+    WeightDict,
+    load_standard_weights,
+    _open_safetensors,
+    _load_tensor,
+)
+# Reuse the Qwen-VL building blocks: the understanding decoder is a Qwen2.5-VL
+# decoder, and the ViT is the Qwen2.5-VL vision encoder.
+from ..qwen_vl.standard_decoder_builder import build_standard_decoder_engine
+from ..qwen_vl.qwen_vl_vision_builder import build_qwen_vl_vision_engine
+
+# Standard Qwen2.5-VL ViT input size; the runtime resizes images to this.
+_DEFAULT_FIXED_IMAGE_SIZE = 448
+# Lance LLM weights live under this prefix. The generation expert (``*_moe_gen``)
+# and the VAE/time-embedder/latent-pos tensors are deliberately not requested.
+_LLM_PREFIX = "language_model.model"
+_LM_HEAD_KEY = "language_model.lm_head.weight"
+
+
+class LancePlugin:
+    name = "lance"
+    runtime_strategy = "vision_language"
+    # During VL prefill the decoder consumes ViT features as input_embed in
+    # place of the image-pad token embeddings.
+    embed_input = True
+
+    def matches(self, model_type: str) -> bool:
+        # Lance shares model_type "qwen2_5_vl" with real Qwen2.5-VL, so
+        # scripts/prepare_lance_model.py stamps model_type="lance" to route
+        # the checkpoint here instead of the qwen_vl plugin.
+        return model_type.lower() == "lance"
+
+    def load_weights(self, model_dir: str, config: ModelConfig) -> WeightDict:
+        # Reads only the understanding-expert weights; *_moe_gen and the
+        # generation-only tensors are never requested and thus ignored.
+        return load_standard_weights(
+            model_dir,
+            config,
+            model_prefix=_LLM_PREFIX,
+            lm_head_key=_LM_HEAD_KEY,
+        )
+
+    def build_engine(
+        self, config: ModelConfig, weights: WeightDict,
+        max_cache_length: int, *, precision: str = "fp32",
+        quant_ctx=None, verbose: bool = False,
+        debug_layer_outputs: bool = False,
+        parallel_config=None,
+    ) -> bytes:
+        return build_standard_decoder_engine(
+            config, weights, max_cache_length, precision=precision,
+            verbose=verbose, quant_ctx=quant_ctx, embed_input=True,
+            debug_layer_outputs=debug_layer_outputs,
+        )
+
+    def build_vision_engine(
+        self, model_dir: str, config: ModelConfig, weights: WeightDict,
+        *, precision: str = "fp32", verbose: bool = False,
+    ) -> bytes | None:
+        vision_config = config.raw.get("vision_config")
+        if vision_config is None:
+            return None
+        vision_weights = _load_lance_vision_weights(model_dir)
+        return build_qwen_vl_vision_engine(
+            vision_config, vision_weights,
+            fixed_image_size=_DEFAULT_FIXED_IMAGE_SIZE,
+            verbose=verbose,
+        )
+
+    def get_vl_config(self, config: ModelConfig) -> dict | None:
+        vision_config = config.raw.get("vision_config")
+        if vision_config is None:
+            return None
+
+        patch_size = vision_config.get("patch_size", 14)
+        merge_size = vision_config.get("spatial_merge_size", 2)
+        fixed = _DEFAULT_FIXED_IMAGE_SIZE
+        num_patches = (fixed // patch_size) ** 2
+        num_merged = num_patches // (merge_size * merge_size)
+
+        return {
+            "image_token_id": config.raw.get("image_token_id", 151655),
+            "fixed_image_size": fixed,
+            "num_image_pad_tokens": num_merged,
+            "vision_output_dim": config.hidden_size,
+            "preprocessor_type": "qwen_merge_group",
+            "vl_prompt_template": (
+                "<|im_start|>user\n"
+                "<|vision_start|>{image_pads}<|vision_end|>\n"
+                "{prompt}<|im_end|>\n"
+                "<|im_start|>assistant\n"
+            ),
+            "image_token_str": "<|image_pad|>",
+        }
+
+
+def _load_lance_vision_weights(model_dir: str) -> WeightDict:
+    """Load the Qwen2.5-VL ViT weights, adding the ``visual.`` prefix the shared
+    vision builder expects. The staged ViT lives at ``<model_dir>/vision/``."""
+    vit_dir = Path(model_dir) / "vision"
+    if not (vit_dir / "model.safetensors").exists():
+        raise FileNotFoundError(
+            f"Lance ViT weights not found at {vit_dir}/model.safetensors. "
+            "Run scripts/prepare_lance_model.py to stage the model."
+        )
+    readers = _open_safetensors(vit_dir)
+    weights = WeightDict()
+    for reader in readers:
+        for key in reader.keys():
+            weights[f"visual.{key}"] = _load_tensor([reader], key)
+    return weights
+
+
+plugin = LancePlugin()

--- a/scripts/prepare_lance_model.py
+++ b/scripts/prepare_lance_model.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Stage a ``bytedance-research/Lance`` checkpoint into a buildable directory.
+
+The Lance HF repo is not a flat HF checkpoint: the LLM lives under
+``Lance_3B/`` (or ``Lance_3B_Video/``) as ``llm_config.json`` +
+``model.safetensors``, and the Qwen2.5-VL ViT is a separate ``Qwen2.5-VL-ViT/``
+dir. ``trtmc build`` expects a single directory with a ``config.json`` whose
+``model_type`` selects a family plugin.
+
+This script writes a staged directory (symlinks, no copies of large weights):
+
+    <out>/
+      config.json            # = <variant>/llm_config.json, model_type -> "lance"
+      model.safetensors      # -> <variant>/model.safetensors  (Lance LLM)
+      tokenizer.json, vocab.json, merges.txt, generation_config.json [, tokenizer_config.json]
+      vision/model.safetensors  # -> Qwen2.5-VL-ViT/vit.safetensors
+
+Then build it (understanding path):
+
+    ./build/trtmc build <out> -o /tmp/lance.trtfb --max-cache-length 384 --precision bf16
+
+Generation/editing tasks (t2i/t2v/edit) are not supported yet; this stages the
+understanding sub-model that the ``lance`` family plugin builds.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_VARIANT_DIRS = {"image": "Lance_3B", "video": "Lance_3B_Video"}
+# Files the native tokenizer / builder may look for at the top level.
+_TOP_LEVEL_FILES = [
+    "model.safetensors",
+    "tokenizer.json",
+    "vocab.json",
+    "merges.txt",
+    "generation_config.json",
+    "tokenizer_config.json",
+]
+
+
+def _resolve_src(src: str | None) -> Path:
+    if src:
+        return Path(src).expanduser().resolve()
+    # Fall back to the local HF cache snapshot.
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        sys.exit("error: --src not given and huggingface_hub is unavailable")
+    return Path(snapshot_download(
+        repo_id="bytedance-research/Lance",
+        allow_patterns=["Lance_3B/*", "Lance_3B_Video/*", "Qwen2.5-VL-ViT/*"],
+    )).resolve()
+
+
+def _symlink(target: Path, link: Path) -> None:
+    link.parent.mkdir(parents=True, exist_ok=True)
+    if link.exists() or link.is_symlink():
+        link.unlink()
+    os.symlink(target, link)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--src", default=None,
+                    help="Lance HF snapshot dir (default: download via huggingface_hub)")
+    ap.add_argument("--variant", choices=sorted(_VARIANT_DIRS), default="image",
+                    help="image -> Lance_3B (default); video -> Lance_3B_Video")
+    ap.add_argument("--out", required=True, help="Output staged directory")
+    args = ap.parse_args()
+
+    src = _resolve_src(args.src)
+    llm_dir = src / _VARIANT_DIRS[args.variant]
+    vit_path = src / "Qwen2.5-VL-ViT" / "vit.safetensors"
+    out = Path(args.out).expanduser().resolve()
+
+    if not (llm_dir / "llm_config.json").exists():
+        sys.exit(f"error: {llm_dir}/llm_config.json not found (bad --src/--variant?)")
+    if not vit_path.exists():
+        sys.exit(f"error: {vit_path} not found")
+
+    out.mkdir(parents=True, exist_ok=True)
+
+    # config.json from llm_config.json, with model_type stamped to "lance" so
+    # find_plugin() routes to the Lance plugin instead of qwen_vl.
+    cfg = json.loads((llm_dir / "llm_config.json").read_text())
+    cfg["model_type"] = "lance"
+    (out / "config.json").write_text(json.dumps(cfg, indent=2))
+
+    for name in _TOP_LEVEL_FILES:
+        srcf = llm_dir / name
+        if srcf.exists():
+            _symlink(srcf, out / name)
+        elif name == "model.safetensors":
+            sys.exit(f"error: {srcf} not found")
+
+    _symlink(vit_path, out / "vision" / "model.safetensors")
+
+    print(f"Staged Lance ({args.variant}) at: {out}")
+    print(f"  LLM : {llm_dir}")
+    print(f"  ViT : {vit_path}")
+    print("Build with:")
+    print(f"  ./build/trtmc build {out} -o /tmp/lance.trtfb "
+          f"--max-cache-length 384 --precision bf16")
+    print("  ./build/trtmc run /tmp/lance.trtfb --prompt 'Describe this image.' "
+          "--image <img> --max-new-tokens 40 --greedy")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/builder/test_families.py
+++ b/tests/builder/test_families.py
@@ -301,6 +301,8 @@ _POSITIVE_MATCH_CASES = [
     ("qwen2_vl", "qwen_vl"),
     ("qwen2_5_vl", "qwen_vl"),
     ("qwen3_vl", "qwen_vl"),
+    # Lance (staged with model_type stamped "lance"; understanding path)
+    ("lance", "lance"),
     # OLMo
     ("olmo", "olmo"),
     # XGLM

--- a/tests/e2e/models/lance-3b-x2t-image.json
+++ b/tests/e2e/models/lance-3b-x2t-image.json
@@ -1,0 +1,18 @@
+{
+  "name": "lance-3b-x2t-image",
+  "trace_id": "IT-E2E-LANCE-X2T-01",
+  "hf_id": "bytedance-research/Lance",
+  "bundle": "lance-3b-x2t-image.trtfb",
+  "family": "lance",
+  "runtime_strategy": "vision_language",
+  "precision": "bf16",
+  "max_cache_length": 384,
+  "prompt": "What color is the vehicle in this image? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.001,
+  "layer_atol": 0.05,
+  "test_image": "tests/e2e/data/test_img.jpeg",
+  "trust_remote_code": false,
+  "core": false,
+  "skip_reason": "Lance image-understanding (x2t) is wired through the lance family plugin + vision_language runtime and is VERIFIED ACCURATE end-to-end at bf16: `trtmc run` on tests/e2e/data/test_img.jpeg answers 'White car driving on the street.' / 'White', and the TRT decoder matches an independent eager reference exactly per-layer and per-logit. Reduced-precision embed bundles rely on the #184 fix (now in main). Not yet auto-runnable in the harness because (1) the Lance HF repo is not a flat checkpoint and must be staged via scripts/prepare_lance_model.py (the harness runs `trtmc build <hf_id>` directly), and (2) there is no HF AutoModel reference for Lance (library_name=Lance, custom modeling.lance) so a Lance reference adapter is needed. Remove skip_reason once staging is wired into the VL runner and a Lance reference backend exists."
+}

--- a/tools/test_impact_fallback_allowlist.txt
+++ b/tools/test_impact_fallback_allowlist.txt
@@ -101,6 +101,7 @@ no_impact scripts/magpie_tokenizer.py # developer utility script; no CI test imp
 no_impact scripts/new_family.py # developer utility script; no CI test impact is intentional
 no_impact scripts/new_torchtrt_family.py # developer utility script; no CI test impact is intentional
 no_impact scripts/perf_evolve_prompt.py # developer utility script; no CI test impact is intentional
+no_impact scripts/prepare_lance_model.py # one-off Lance model staging helper; not imported by package/tests, no CI test impact is intentional
 no_impact scripts/profile_magpie_tts.py # developer utility script; no CI test impact is intentional
 no_impact scripts/reporting/__init__.py # developer utility script; no CI test impact is intentional
 no_impact scripts/reporting/vlm_assessment.py # developer utility script; no CI test impact is intentional


### PR DESCRIPTION
## Background

TRT-MC had no support for [`bytedance-research/Lance`](https://huggingface.co/bytedance-research/Lance), a 3B "native unified multimodal" model (image+video understanding, generation, and editing) built on Qwen2.5-VL-3B with a Qwen2.5-VL ViT and a Wan2.2 VAE. This PR adds the **understanding** path (image/video → text), which is the most tractable capability and maps cleanly onto the existing `vision_language` runtime strategy.

Rebased on top of #184 (`fix(vl): honor reduced precision for embed bundles`), which this PR depends on for bf16 embed-bundle correctness.

## Exit Criteria

- A `lance` family plugin builds a `.trtfb` bundle and the `vision_language` runtime answers image-understanding questions correctly at bf16.
- Numerical correctness validated against an independent reference.
- `scripts/check_family_coverage.py` stays green.
- Non-goal: generation/editing (`t2i`/`t2v`/`image_edit`/`video_edit`) is explicitly out of scope here (it needs a new runtime strategy).

## Implementation

- **`python/tensorrt_model_connect/families/lance/`** — the family plugin (`name="lance"`, `runtime_strategy="vision_language"`, `embed_input=True`). Lance is a Mixture-of-Transformer-Experts checkpoint; the loader reads only the **understanding-expert** weights via `load_standard_weights(model_prefix="language_model.model", ...)`, which naturally drops the `*_moe_gen` generation expert plus the `llm2vae`/`vae2llm`/`time_embedder`/`latent_pos_embed` tensors. It reuses the Qwen2.5-VL decoder builder (QKV-bias + per-head QK-norm, applied conditionally) and the Qwen2.5-VL ViT builder (re-adding the `visual.` prefix Lance ships bare). `build_engine` forwards `precision` so reduced-precision embed bundles build correctly on top of #184.
- **`scripts/prepare_lance_model.py`** — the Lance HF repo is not a flat checkpoint (it nests `Lance_3B/llm_config.json` and a separate `Qwen2.5-VL-ViT/` dir). This stages a buildable directory: `config.json` (with `model_type` stamped `lance` so it routes to this plugin instead of `qwen_vl`), the LLM `model.safetensors`, tokenizer files, and the ViT at `vision/model.safetensors`.
- **`tests/e2e/models/lance-3b-x2t-image.json`** — E2E manifest for `x2t_image` (satisfies the coverage gate), `skip_reason`-gated for now.
- **`tools/test_impact_fallback_allowlist.txt`** — registers the staging helper as `no_impact` (one-off script, not imported by package/tests) so the CI impact-analysis gate passes.

## Validation

- `ruff check python/tensorrt_model_connect/families/lance/ scripts/prepare_lance_model.py`: **passed**.
- `python3 scripts/check_family_coverage.py`: **green** — `[OK] lance (1 model)`.
- `python3 tools/test_impact.py --validate`: **passed** (196 models, 12 core, 73 families).
- End-to-end `./build/trtmc run` at **bf16** on `tests/e2e/data/test_img.jpeg`:
  - "Describe this image in one sentence." → **"White car driving on the street."**
  - "What color is the vehicle? Answer in one word." → **"White"**
  - (bf16 decoder engine is ~6.5 GB vs ~13 GB fp32, confirming true reduced precision.)
- TRT decoder vs an **independent eager PyTorch reference**: **exact match** per-layer and per-logit.

## Notes For Future Readers

- **Why `skip_reason`:** the E2E harness builds `trtmc build <hf_id>` directly, but Lance needs `scripts/prepare_lance_model.py` staging first; and there is no HF AutoModel reference for Lance (`library_name=Lance`, custom `modeling.lance`), so a Lance reference backend is needed. Remove `skip_reason` once both are wired into the VL runner.
- **bf16** works after #184 (input_embed bound as fp32 and cast inside the graph) + forwarding `precision` here. The original reduced-precision bug was filed as #182.
- **Generation/editing** is a larger future stage: an LLM-as-flow-matching-denoiser runtime strategy + Wan VAE decode, reusing `families/wan_t2v` and the C++ flow-match scheduler.
- **Review order:** `families/lance/plugin.py` (loader + build reuse) → `scripts/prepare_lance_model.py` (staging contract) → the manifest.
