### PR TITLE
fix(vl): honor reduced precision for embed bundles

### DIFF
--- a/python/tensorrt_model_connect/builders/default_decoder.py
+++ b/python/tensorrt_model_connect/builders/default_decoder.py
@@ -210,7 +210,7 @@ def build_standard_decoder_engine(
     use_input_embed_tensor = None
     if embed_input:
         input_embed_tensor = network.add_input(
-            "input_embed", work_trt_dtype, (1, hidden))
+            "input_embed", trt.float32, (1, hidden))
         use_input_embed_tensor = network.add_input(
             "use_input_embed", trt.float32, (1,))
 
@@ -333,6 +333,7 @@ def build_standard_decoder_engine(
     token_embed = gather.get_output(0)
 
     if embed_input and input_embed_tensor is not None and use_input_embed_tensor is not None:
+        token_embed_for_math = _cast_work_dtype(token_embed)
         # Conditional embedding: (1 - flag) * token_embed + flag * input_embed
         # use_input_embed is [1] scalar (FP32), broadcast to [1, hidden]
         flag_broadcast = network.add_shuffle(use_input_embed_tensor)
@@ -344,16 +345,21 @@ def build_standard_decoder_engine(
         one_const = graph_ops.add_constant(
             network, (1, 1), np.array([1.0], dtype=work_np_dtype),
             dtype=work_np_dtype)
+        one_const = _cast_work_dtype(one_const)
         inv_flag = network.add_elementwise(
             one_const, flag_for_math,
             trt.ElementWiseOperation.SUB)
         # (1 - flag) * token_embed
         tok_part = network.add_elementwise(
-            inv_flag.get_output(0), token_embed,
+            inv_flag.get_output(0), token_embed_for_math,
             trt.ElementWiseOperation.PROD)
+        input_embed_for_math = input_embed_tensor
+        if input_embed_for_math.dtype != work_trt_dtype:
+            input_embed_for_math = network.add_cast(
+                input_embed_for_math, work_trt_dtype).get_output(0)
         # flag * input_embed
         embed_part = network.add_elementwise(
-            flag_for_math, input_embed_tensor,
+            flag_for_math, input_embed_for_math,
             trt.ElementWiseOperation.PROD)
         # sum
         hidden_state_sum = network.add_elementwise(

--- a/python/tensorrt_model_connect/families/internvl/plugin.py
+++ b/python/tensorrt_model_connect/families/internvl/plugin.py
@@ -84,7 +84,7 @@ class InternVLPlugin:
                 parallel_config=parallel)
 
         return build_standard_decoder_engine(
-            config, weights, max_cache_length, verbose=verbose,
+            config, weights, max_cache_length, precision=precision, verbose=verbose,
             quant_ctx=quant_ctx, embed_input=True,
             debug_layer_outputs=debug_layer_outputs)
 

--- a/python/tensorrt_model_connect/families/qwen_vl/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/decoder_tp_builder.py
@@ -129,7 +129,7 @@ def build_qwen_vl_tp_decoder_engine(
     input_embed_tensor = None
     use_input_embed_tensor = None
     if embed_input:
-        input_embed_tensor = network.add_input("input_embed", work_trt_dtype, (1, hidden))
+        input_embed_tensor = network.add_input("input_embed", trt.float32, (1, hidden))
         use_input_embed_tensor = network.add_input("use_input_embed", trt.float32, (1,))
 
     deepstack_embed_inputs: list[trt.ITensor] = []
@@ -137,7 +137,7 @@ def build_qwen_vl_tp_decoder_engine(
     if deepstack_num_levels > 0:
         for level in range(deepstack_num_levels):
             deepstack_embed_inputs.append(network.add_input(
-                f"deepstack_embed_{level}", work_trt_dtype, (1, hidden)))
+                f"deepstack_embed_{level}", trt.float32, (1, hidden)))
         deepstack_active_tensor = network.add_input(
             "deepstack_active", trt.float32, (1,))
 
@@ -191,6 +191,7 @@ def build_qwen_vl_tp_decoder_engine(
 
     token_embed = network.add_gather(embedding_table, token_id, 0).get_output(0)
     if embed_input and input_embed_tensor is not None and use_input_embed_tensor is not None:
+        token_embed_for_math = _cast_work_dtype(token_embed)
         flag_broadcast = network.add_shuffle(use_input_embed_tensor)
         flag_broadcast.reshape_dims = (1, 1)
         flag_for_math = flag_broadcast.get_output(0)
@@ -199,12 +200,17 @@ def build_qwen_vl_tp_decoder_engine(
         one_const = graph_ops.add_constant(
             network, (1, 1), np.array([1.0], dtype=work_np_dtype),
             dtype=work_np_dtype)
+        one_const = _cast_work_dtype(one_const)
         inv_flag = network.add_elementwise(
             one_const, flag_for_math, trt.ElementWiseOperation.SUB).get_output(0)
         tok_part = network.add_elementwise(
-            inv_flag, token_embed, trt.ElementWiseOperation.PROD).get_output(0)
+            inv_flag, token_embed_for_math, trt.ElementWiseOperation.PROD).get_output(0)
+        input_embed_for_math = input_embed_tensor
+        if input_embed_for_math.dtype != work_trt_dtype:
+            input_embed_for_math = network.add_cast(
+                input_embed_for_math, work_trt_dtype).get_output(0)
         embed_part = network.add_elementwise(
-            flag_for_math, input_embed_tensor, trt.ElementWiseOperation.PROD).get_output(0)
+            flag_for_math, input_embed_for_math, trt.ElementWiseOperation.PROD).get_output(0)
         hidden_state = network.add_elementwise(
             tok_part, embed_part, trt.ElementWiseOperation.SUM).get_output(0)
     else:
@@ -382,10 +388,14 @@ def _add_tp_decoder_layer(
             ds_active_broadcast = network.add_shuffle(deepstack_active)
             ds_active_broadcast.reshape_dims = (1, 1)
             active = ds_active_broadcast.get_output(0)
-            if active.dtype != deepstack_embed.dtype:
-                active = network.add_cast(active, deepstack_embed.dtype).get_output(0)
+            deepstack_for_math = deepstack_embed
+            if deepstack_for_math.dtype != residual1.dtype:
+                deepstack_for_math = network.add_cast(
+                    deepstack_for_math, residual1.dtype).get_output(0)
+            if active.dtype != deepstack_for_math.dtype:
+                active = network.add_cast(active, deepstack_for_math.dtype).get_output(0)
             ds_scaled = network.add_elementwise(
-                deepstack_embed, active, trt.ElementWiseOperation.PROD).get_output(0)
+                deepstack_for_math, active, trt.ElementWiseOperation.PROD).get_output(0)
             residual1 = network.add_elementwise(
                 residual1, ds_scaled, trt.ElementWiseOperation.SUM).get_output(0)
         norm2 = _apply_norm(

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -103,7 +103,7 @@ class QwenVLPlugin:
                 debug_layer_outputs=debug_layer_outputs,
                 parallel_config=parallel)
         return build_standard_decoder_engine(
-            config, weights, max_cache_length, verbose=verbose,
+            config, weights, max_cache_length, precision=precision, verbose=verbose,
             quant_ctx=quant_ctx, embed_input=True,
             debug_layer_outputs=debug_layer_outputs)
 

--- a/tests/builder/test_engine_internvl_tp.py
+++ b/tests/builder/test_engine_internvl_tp.py
@@ -102,3 +102,39 @@ def test_internvl_parallel_build_rejects_debug_outputs(monkeypatch) -> None:
             parallel_config=ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
             debug_layer_outputs=True,
         )
+
+
+def test_internvl_non_parallel_build_forwards_precision(monkeypatch) -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.internvl.plugin")
+    calls = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = {
+            "config": config,
+            "weights": weights,
+            "max_cache_length": max_cache_length,
+            "kwargs": kwargs,
+        }
+        return b"internvl-plan"
+
+    monkeypatch.setattr(plugin_module, "build_standard_decoder_engine", fake_build)
+
+    config = object()
+    weights = WeightDict()
+    result = plugin_module.plugin.build_engine(
+        config,
+        weights,
+        max_cache_length=512,
+        precision="bf16",
+        verbose=True,
+    )
+
+    assert result == b"internvl-plan"
+    assert calls["build"]["config"] is config
+    assert calls["build"]["weights"] is weights
+    assert calls["build"]["max_cache_length"] == 512
+    kwargs = calls["build"]["kwargs"]
+    assert kwargs["precision"] == "bf16"
+    assert kwargs["embed_input"] is True
+    assert kwargs["verbose"] is True

--- a/tests/builder/test_engine_qwen_vl_tp.py
+++ b/tests/builder/test_engine_qwen_vl_tp.py
@@ -66,3 +66,30 @@ def test_qwen_vl_plugin_routes_parallel_builds(
     assert kwargs["embed_input"] is True
     assert kwargs["deepstack_num_levels"] == deepstack_num_levels
     assert kwargs["verbose"] is True
+
+
+def test_qwen25_vl_plugin_forwards_precision_to_standard_builder(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen_vl.plugin")
+    calls: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"qwen-vl-plan"
+
+    monkeypatch.setattr(module, "build_standard_decoder_engine", fake_build)
+
+    result = module.QwenVLPlugin().build_engine(
+        _config(qwen3=False),
+        {"_attention_size": 16, "_kv_attention_size": 16, "_mlp_size": 32},
+        31,
+        precision="bf16",
+        verbose=True,
+    )
+
+    assert result == b"qwen-vl-plan"
+    _, _, max_cache_length, kwargs = calls["build"]
+    assert max_cache_length == 31
+    assert kwargs["precision"] == "bf16"
+    assert kwargs["embed_input"] is True
+    assert kwargs["verbose"] is True

--- a/tests/builder/test_standard_decoder.py
+++ b/tests/builder/test_standard_decoder.py
@@ -171,6 +171,34 @@ class TestTensorNamingContract:
         assert "token_id" in inputs
         assert "logits" in outputs
 
+    def test_bf16_embed_input_keeps_external_features_fp32(self):
+        """VL image features stay fp32 while reduced-precision cache uses bf16."""
+        import tensorrt as trt
+        from tensorrt_model_connect.builders.default_decoder import build_standard_decoder_engine
+        from tensorrt_model_connect.config import ModelConfig
+
+        hidden, vocab, num_layers = 16, 32, 2
+        num_heads = 4
+        max_cache = 4
+        config = ModelConfig(
+            hidden_size=hidden,
+            vocab_size=vocab,
+            num_hidden_layers=num_layers,
+            num_attention_heads=num_heads,
+            num_key_value_heads=num_heads,
+            rms_norm_eps=1e-5,
+            rope_theta=10000.0,
+        )
+        weights = _make_weights(hidden, vocab, num_layers, hidden, 32)
+
+        plan = build_standard_decoder_engine(
+            config, weights, max_cache, embed_input=True, precision="bf16")
+        engine = _deserialize_engine(plan)
+
+        assert engine.get_tensor_dtype("input_embed") == trt.float32
+        assert engine.get_tensor_dtype("use_input_embed") == trt.float32
+        assert engine.get_tensor_dtype("cache_k_0") == trt.bfloat16
+
     def test_debug_layer_outputs(self):
         """With debug_layer_outputs=True, per-layer debug outputs appear."""
         plan = self._build_engine(debug_layer_outputs=True)


### PR DESCRIPTION
## Background
Issue #182 reports that reduced-precision Qwen2.5-VL bundles built with `--precision bf16` or `--precision fp16` produce incoherent text in the native C++ runtime when using `vision_language` / `embed_input` bundles, while fp32 and the Python debug runner remain coherent.

The root cause is that the Qwen-VL non-parallel plugin path did not forward the requested precision into the shared decoder builder. That left the text engine as fp32 while bundle metadata told the C++ runtime to allocate reduced-precision KV cache buffers. The Python debug path stayed coherent because it derives cache dtype from the engine itself.

## Exit Criteria
- Qwen2.5-VL reduced-precision VL bundles build a reduced-precision text engine that matches bundle metadata and C++ runtime cache allocation.
- External VL feature bindings remain fp32 at the engine boundary so existing host-side fp32 feature buffers are interpreted correctly.
- Regression coverage catches missing precision forwarding and BF16 embed-input dtype contracts.

## Implementation
- Forward `precision` from Qwen-VL and InternVL non-parallel plugin paths into `build_standard_decoder_engine`.
- Keep `input_embed` and Qwen-VL `deepstack_embed_*` TRT inputs as fp32 because the runtime/debug paths provide fp32 feature buffers.
- Cast external feature tensors, token embeddings, and constants inside the TRT graph before reduced-precision embed/deepstack math.
- Add focused builder tests for Qwen-VL and InternVL precision forwarding, plus a TRT-backed BF16 embed-input dtype regression test.

## Validation
- `docker exec trtmc-dev-gb300-issue182-agent ./build/trtmc build Qwen/Qwen2.5-VL-3B-Instruct -o /tmp/q_issue182_bf16_fixed.trtfb --max-cache-length 384 --precision bf16`: passed.
- `docker exec trtmc-dev-gb300-issue182-agent ./build/trtmc run /tmp/q_issue182_bf16_fixed.trtfb --prompt "What color is the vehicle? Answer in one word." --image tests/e2e/data/test_img.jpeg --max-new-tokens 12 --greedy`: passed, native C++ output was `White`.
- `docker exec trtmc-dev-gb300-issue182-agent ./build/trtmc build Qwen/Qwen2.5-VL-3B-Instruct -o /tmp/q_issue182_fp16_fixed.trtfb --max-cache-length 384 --precision fp16`: passed.
- `docker exec trtmc-dev-gb300-issue182-agent ./build/trtmc run /tmp/q_issue182_fp16_fixed.trtfb --prompt "What color is the vehicle? Answer in one word." --image tests/e2e/data/test_img.jpeg --max-new-tokens 12 --greedy`: passed, native C++ output was `White`.
- `docker exec trtmc-dev-gb300-issue182-agent python3 -m pytest tests/builder/test_engine_qwen_vl_tp.py tests/builder/test_engine_internvl_tp.py tests/builder/test_standard_decoder.py::TestTensorNamingContract::test_bf16_embed_input_keeps_external_features_fp32 -q`: passed, `8 passed in 2.75s`.
- `git diff --check`: passed.

## Notes For Future Readers
- Review the Qwen-VL/InternVL plugin precision forwarding first, then the fp32 external-input contract in the shared decoder and Qwen-VL TP builder.
- The fp32 engine boundary is intentional: `TrtModuleImpl::forward_async` copies host buffers into engine bindings and does not perform dtype conversion for external feature tensors.
- Ruff was not run because it was not installed in the investigation container.

Refs: #182
