### PR TITLE
feat(nemotron_h): add MoE support for Nemotron-3-Super-120B-A12B

### DIFF
--- a/python/tensorrt_model_connect/families/nemotron_h/plugin.py
+++ b/python/tensorrt_model_connect/families/nemotron_h/plugin.py
@@ -1,10 +1,13 @@
-"""NemotronH family plugin -- Hybrid Mamba-2 + MLP + Attention decoder.
+"""NemotronH family plugin -- Hybrid Mamba-2 + MLP + Attention + MoE decoder.
 
-NemotronH (NVIDIA) uses a heterogeneous layer stack with three layer types
-defined by hybrid_override_pattern (e.g. "M-M-M-MM-M-M-M*-..."):
+NemotronH (NVIDIA) uses a heterogeneous layer stack with four layer types
+defined by hybrid_override_pattern (e.g. "M-M-M-MM-M-M-M*-..." or
+"MEMEMEM*EMEM..."):
   M = Mamba-2 SSM layer
   - = MLP layer (up_proj -> relu2 -> down_proj)
   * = Attention layer (GQA, no RoPE, no bias)
+  E = MoE-FFN layer (factorized/latent MoE with shared expert, DeepSeek-V3-style
+      sigmoid gating with e_score_correction_bias; ReLU^2 inside each expert)
 
 Key differences from Mamba-1 (existing mamba.py):
   Mamba-2 uses State Space Duality (SSD):
@@ -34,8 +37,30 @@ Weight key mapping (HF -> engine):
   backbone.layers.{i}.mixer.up_proj.weight             -> MLP up
   backbone.layers.{i}.mixer.down_proj.weight           -> MLP down
   backbone.layers.{i}.mixer.q/k/v/o_proj.weight        -> Attention QKV + out
+  backbone.layers.{i}.mixer.gate.weight                -> MoE router [num_experts, hidden]
+  backbone.layers.{i}.mixer.gate.e_score_correction_bias -> MoE bias for top-k selection [num_experts]
+  backbone.layers.{i}.mixer.fc1_latent_proj.weight     -> MoE input latent down-proj [latent, hidden]
+  backbone.layers.{i}.mixer.fc2_latent_proj.weight     -> MoE output latent up-proj [hidden, latent]
+  backbone.layers.{i}.mixer.experts.{e}.up_proj.weight   -> Expert up   [moe_intermediate, latent]
+  backbone.layers.{i}.mixer.experts.{e}.down_proj.weight -> Expert down [latent, moe_intermediate]
+  backbone.layers.{i}.mixer.shared_experts.up_proj.weight   -> Shared expert up   [shared_intermediate, hidden]
+  backbone.layers.{i}.mixer.shared_experts.down_proj.weight -> Shared expert down [hidden, shared_intermediate]
   backbone.norm_f.weight                               -> final_norm
   lm_head.weight                                       -> w_lm_head
+
+MoE block compute flow (single E layer, batch=1 single token decode):
+  1) x = RMSNorm(hidden)
+  2) latent_in = x @ fc1_latent_proj          # [1, latent]
+  3) for each routed expert e: o_e = down(relu2(up(latent_in)))   in latent space
+  4) gate_logits = x @ router                  # [1, num_experts]
+     scores = sigmoid(gate_logits)
+     scores_for_select = scores + e_score_correction_bias
+     topk_idx = argtopk(scores_for_select, k=num_experts_per_tok)
+     weights = scores[topk_idx]   (renormalize if norm_topk_prob) * routed_scaling_factor
+  5) latent_out = sum_k weights[k] * o_{topk_idx[k]}
+  6) routed_hidden = latent_out @ fc2_latent_proj
+  7) shared_hidden = shared_down(relu2(shared_up(x)))
+  8) layer_out = hidden + routed_hidden + shared_hidden
 """
 
 from __future__ import annotations
@@ -52,6 +77,7 @@ from ...checkpoint_mapper import (
     _open_safetensors,
     _load_tensor,
     _has_tensor,
+    _target_np_dtype,
     _transpose_2d,
 )
 from ... import graph_ops
@@ -65,8 +91,8 @@ from ...parallel_config import (
 trt = trt_compat.get_trt()
 
 def _parse_layer_types(pattern: str) -> list[str]:
-    """Parse hybrid_override_pattern: M=mamba2, -=mlp, *=attention."""
-    mapping = {"M": "mamba2", "-": "mlp", "*": "attention"}
+    """Parse hybrid_override_pattern: M=mamba2, -=mlp, *=attention, E=moe."""
+    mapping = {"M": "mamba2", "-": "mlp", "*": "attention", "E": "moe"}
     return [mapping[ch] for ch in pattern if ch in mapping]
 
 
@@ -78,10 +104,17 @@ class NemotronHPlugin:
         return model_type.lower() in {"nemotron_h", "nemotron_hybrid"}
 
     def load_weights(
-        self, model_dir: str, config: ModelConfig,
+        self, model_dir: str, config: ModelConfig, *,
+        precision: str = "fp32",
     ) -> WeightDict:
         model_dir_path = Path(model_dir)
         readers = _open_safetensors(model_dir_path)
+        # The bulky MoE expert banks (num_experts x latent x moe_inter) easily
+        # OOM at fp32 for Nemotron-3-Super (40 layers x 512 experts x 2x
+        # 2688x1024 ~= 448 GB at fp32). Keep them in the loader's target dtype
+        # so fp16/bf16 builds stay within memory. The smaller per-layer weights
+        # (router, norms, latent projections, attention, mamba) remain fp32.
+        expert_dtype = _target_np_dtype(precision)
 
         hidden = config.hidden_size
         vocab = config.vocab_size
@@ -108,6 +141,20 @@ class NemotronHPlugin:
         # MLP dimensions
         mlp_intermediate = config.intermediate_size
 
+        # MoE dimensions (only used if any layer has type 'moe').
+        # Nemotron-3-Super uses factorized/latent MoE: each expert's up/down
+        # operates on the moe_latent dimension (smaller than hidden), and the
+        # layer projects hidden -> latent (fc1_latent_proj) before the expert
+        # bank, then latent -> hidden (fc2_latent_proj) after.
+        num_experts = int(raw.get("n_routed_experts", raw.get("num_experts", 0)))
+        num_experts_per_tok = int(raw.get("num_experts_per_tok", 0))
+        moe_intermediate = int(raw.get("moe_intermediate_size", 0))
+        moe_latent_size = int(raw.get("moe_latent_size", 0))
+        shared_expert_intermediate = int(
+            raw.get("moe_shared_expert_intermediate_size", 0))
+        routed_scaling_factor = float(raw.get("routed_scaling_factor", 1.0))
+        norm_topk_prob = bool(raw.get("norm_topk_prob", True))
+
         # Attention dimensions
         q_dim = num_heads * head_dim
         weights = WeightDict()
@@ -120,6 +167,7 @@ class NemotronHPlugin:
 
         mamba_count = 0
         attn_count = 0
+        moe_count = 0
 
         for layer_idx in range(num_layers):
             lt = layer_types[layer_idx]
@@ -211,6 +259,87 @@ class NemotronHPlugin:
 
                 attn_count += 1
 
+            elif lt == "moe":
+                # Validate the MoE config fields are usable
+                assert num_experts > 0 and num_experts_per_tok > 0, (
+                    "MoE 'E' layer present but n_routed_experts / "
+                    "num_experts_per_tok missing from config")
+                assert moe_intermediate > 0 and moe_latent_size > 0, (
+                    "MoE 'E' layer requires moe_intermediate_size and "
+                    "moe_latent_size in config")
+
+                # Router gate weight [num_experts, hidden] -> store as
+                # [hidden, num_experts] for matmul-rhs-constant convention.
+                router_raw = _load_tensor(
+                    readers, f"{hf_prefix}.mixer.gate.weight")
+                weights[f"{prefix}.router"] = _transpose_2d(
+                    router_raw, "router")
+
+                # DeepSeek-V3-style expert score correction bias (added to
+                # sigmoid scores ONLY for top-k selection, not for the
+                # routed combine weights).
+                bias_key = f"{hf_prefix}.mixer.gate.e_score_correction_bias"
+                if _has_tensor(readers, bias_key):
+                    weights[f"{prefix}.router_bias"] = _load_tensor(
+                        readers, bias_key).astype(np.float32)
+
+                # Latent input/output projections (shared across all experts).
+                # fc1: [latent, hidden] -> stored [hidden, latent]
+                # fc2: [hidden, latent] -> stored [latent, hidden]
+                fc1_raw = _load_tensor(
+                    readers, f"{hf_prefix}.mixer.fc1_latent_proj.weight")
+                fc2_raw = _load_tensor(
+                    readers, f"{hf_prefix}.mixer.fc2_latent_proj.weight")
+                weights[f"{prefix}.moe_fc1"] = _transpose_2d(
+                    fc1_raw, "fc1_latent_proj")
+                weights[f"{prefix}.moe_fc2"] = _transpose_2d(
+                    fc2_raw, "fc2_latent_proj")
+
+                # Pack routed experts into batched tensors.
+                # Each expert's HF up_proj has shape [moe_intermediate, latent]
+                # and down_proj has shape [latent, moe_intermediate]. After
+                # per-expert transpose, up:[latent, moe_inter], down:[moe_inter,
+                # latent]. We stack along axis 0 to get:
+                #   experts_w_up:   [num_experts, latent, moe_intermediate]
+                #   experts_w_down: [num_experts, moe_intermediate, latent]
+                experts_w_up = np.empty(
+                    (num_experts, moe_latent_size, moe_intermediate),
+                    dtype=expert_dtype)
+                experts_w_down = np.empty(
+                    (num_experts, moe_intermediate, moe_latent_size),
+                    dtype=expert_dtype)
+                for e in range(num_experts):
+                    exp_hf = f"{hf_prefix}.mixer.experts.{e}"
+                    up_raw = _load_tensor(
+                        readers, f"{exp_hf}.up_proj.weight")
+                    down_raw = _load_tensor(
+                        readers, f"{exp_hf}.down_proj.weight")
+                    experts_w_up[e] = _transpose_2d(
+                        up_raw, f"expert_{e}_up", precision=precision)
+                    experts_w_down[e] = _transpose_2d(
+                        down_raw, f"expert_{e}_down", precision=precision)
+                    del up_raw, down_raw
+                weights[f"{prefix}.experts.w_up"] = experts_w_up
+                weights[f"{prefix}.experts.w_down"] = experts_w_down
+
+                # Shared expert: dense up/relu^2/down on hidden directly.
+                # HF up:   [shared_intermediate, hidden] -> [hidden, shared_inter]
+                # HF down: [hidden, shared_intermediate] -> [shared_inter, hidden]
+                if shared_expert_intermediate > 0:
+                    s_up_raw = _load_tensor(
+                        readers,
+                        f"{hf_prefix}.mixer.shared_experts.up_proj.weight")
+                    s_down_raw = _load_tensor(
+                        readers,
+                        f"{hf_prefix}.mixer.shared_experts.down_proj.weight")
+                    weights[f"{prefix}.shared_expert.w_up"] = _transpose_2d(
+                        s_up_raw, "shared_up", precision=precision)
+                    weights[f"{prefix}.shared_expert.w_down"] = _transpose_2d(
+                        s_down_raw, "shared_down", precision=precision)
+                    del s_up_raw, s_down_raw
+
+                moe_count += 1
+
         # Final norm
         final_norm_key = "backbone.norm_f.weight"
         if _has_tensor(readers, final_norm_key):
@@ -239,8 +368,16 @@ class NemotronHPlugin:
         weights["_n_groups"] = n_groups
         weights["_num_mamba_layers"] = mamba_count
         weights["_num_attention_layers"] = attn_count
+        weights["_num_moe_layers"] = moe_count
         weights["_attention_size"] = q_dim
         weights["_mlp_size"] = mlp_intermediate
+        weights["_num_experts"] = num_experts
+        weights["_num_experts_per_tok"] = num_experts_per_tok
+        weights["_moe_intermediate_size"] = moe_intermediate
+        weights["_moe_latent_size"] = moe_latent_size
+        weights["_shared_expert_intermediate_size"] = shared_expert_intermediate
+        weights["_routed_scaling_factor"] = routed_scaling_factor
+        weights["_norm_topk_prob"] = norm_topk_prob
 
         return weights
 
@@ -281,8 +418,19 @@ class NemotronHPlugin:
         n_groups: int = weights["_n_groups"]
         num_mamba: int = weights["_num_mamba_layers"]
         num_attn: int = weights["_num_attention_layers"]
+        num_moe: int = int(weights.get("_num_moe_layers", 0))
         attention_size: int = weights["_attention_size"]
         mlp_size: int = weights["_mlp_size"]
+        # MoE metadata is only meaningful when num_moe > 0.
+        num_experts: int = int(weights.get("_num_experts", 0))
+        num_experts_per_tok: int = int(weights.get("_num_experts_per_tok", 0))
+        moe_intermediate: int = int(weights.get("_moe_intermediate_size", 0))
+        moe_latent: int = int(weights.get("_moe_latent_size", 0))
+        shared_expert_intermediate: int = int(
+            weights.get("_shared_expert_intermediate_size", 0))
+        routed_scaling_factor: float = float(
+            weights.get("_routed_scaling_factor", 1.0))
+        norm_topk_prob: bool = bool(weights.get("_norm_topk_prob", True))
 
         num_heads = config.num_attention_heads
         num_kv_heads = config.num_key_value_heads
@@ -415,6 +563,24 @@ class NemotronHPlugin:
                 present_v_outputs.append(result["present_v"])
                 attn_counter += 1
 
+            elif lt == "moe":
+                result = _add_moe_layer(
+                    network=network,
+                    hidden=hidden_state,
+                    eps_tensor=eps_tensor,
+                    weights=weights,
+                    prefix=prefix,
+                    hidden_size=hidden,
+                    num_experts=num_experts,
+                    top_k=num_experts_per_tok,
+                    moe_intermediate=moe_intermediate,
+                    moe_latent=moe_latent,
+                    shared_expert_intermediate=shared_expert_intermediate,
+                    routed_scaling_factor=routed_scaling_factor,
+                    norm_topk_prob=norm_topk_prob,
+                )
+                hidden_state = result["hidden"]
+
             if debug_layer_outputs:
                 _mark_debug_output(
                     network, hidden_state, f"debug_hidden_{layer_idx}")
@@ -455,9 +621,11 @@ class NemotronHPlugin:
             print(f"[trtmc build] Building NemotronH hybrid TRT engine "
                   f"({num_layers} layers: {num_mamba} mamba2 + "
                   f"{sum(1 for t in layer_types if t == 'mlp')} mlp + "
-                  f"{num_attn} attention, "
+                  f"{num_attn} attention + {num_moe} moe, "
                   f"hidden={hidden}, d_inner={d_inner}, "
                   f"d_state={d_state}, nheads={mamba_num_heads}, "
+                  f"experts={num_experts}, top_k={num_experts_per_tok}, "
+                  f"moe_inter={moe_intermediate}, moe_latent={moe_latent}, "
                   f"cache={max_cache_length}) ...",
                   file=sys.stderr)
 
@@ -482,13 +650,15 @@ class NemotronHPlugin:
 
         num_mamba = sum(1 for lt in layer_types if lt == "mamba2")
         num_attn = sum(1 for lt in layer_types if lt == "attention")
+        num_moe = sum(1 for lt in layer_types if lt == "moe")
 
         conv_dim = d_inner + 2 * n_groups * d_state
 
-        return {
+        overrides = {
             "layer_types": layer_types,
             "num_mamba_layers": num_mamba,
             "num_attention_layers": num_attn,
+            "num_moe_layers": num_moe,
             "d_inner": d_inner,
             "mamba_d_state": d_state,
             "mamba_d_conv": d_conv,
@@ -497,6 +667,21 @@ class NemotronHPlugin:
             "conv_dim": conv_dim,
             "n_groups": n_groups,
         }
+        if num_moe > 0:
+            overrides.update({
+                "num_experts": int(
+                    raw.get("n_routed_experts", raw.get("num_experts", 0))),
+                "num_experts_per_tok": int(raw.get("num_experts_per_tok", 0)),
+                "moe_intermediate_size": int(
+                    raw.get("moe_intermediate_size", 0)),
+                "moe_latent_size": int(raw.get("moe_latent_size", 0)),
+                "moe_shared_expert_intermediate_size": int(
+                    raw.get("moe_shared_expert_intermediate_size", 0)),
+                "routed_scaling_factor": float(
+                    raw.get("routed_scaling_factor", 1.0)),
+                "norm_topk_prob": bool(raw.get("norm_topk_prob", True)),
+            })
+        return overrides
 
 
 def _mark_debug_output(
@@ -814,6 +999,215 @@ def _add_mlp_layer(
         hidden, down, trt.ElementWiseOperation.SUM)
 
     return {"hidden": residual.get_output(0)}
+
+
+def _add_packed_latent_experts(
+    network: "trt.INetworkDefinition",
+    latent_in: "trt.ITensor",
+    w_up: np.ndarray,
+    w_down: np.ndarray,
+) -> "trt.ITensor":
+    """Run all routed experts in latent space with three batched matmuls.
+
+    Each expert: up([latent]) -> [moe_inter] -> relu^2 -> down -> [latent].
+
+    Inputs:
+      latent_in: [1, latent]
+      w_up:   [num_experts, latent, moe_intermediate]
+      w_down: [num_experts, moe_intermediate, latent]
+
+    Returns expert outputs tensor of shape [num_experts, 1, latent].
+    """
+    num_experts, _, _ = w_up.shape
+    latent_size = w_up.shape[1]
+
+    # Broadcast input [1, latent] -> [num_experts, 1, latent].
+    inp_3d = network.add_shuffle(latent_in)
+    inp_3d.reshape_dims = (1, 1, latent_size)
+    expert_scale = graph_ops.add_constant(
+        network, (num_experts, 1, 1),
+        np.ones((num_experts, 1, 1), dtype=np.float32))
+    batched = network.add_elementwise(
+        inp_3d.get_output(0), expert_scale, trt.ElementWiseOperation.PROD)
+
+    up_w = graph_ops.add_constant(network, w_up.shape, w_up)
+    down_w = graph_ops.add_constant(network, w_down.shape, w_down)
+
+    # up: [E,1,latent] @ [E,latent,moe_inter] -> [E,1,moe_inter]
+    up = network.add_matrix_multiply(
+        batched.get_output(0), trt.MatrixOperation.NONE,
+        up_w, trt.MatrixOperation.NONE)
+
+    # ReLU^2: relu(x) * relu(x)
+    relu = network.add_activation(up.get_output(0), trt.ActivationType.RELU)
+    relu2 = network.add_elementwise(
+        relu.get_output(0), relu.get_output(0),
+        trt.ElementWiseOperation.PROD)
+
+    # down: [E,1,moe_inter] @ [E,moe_inter,latent] -> [E,1,latent]
+    down = network.add_matrix_multiply(
+        relu2.get_output(0), trt.MatrixOperation.NONE,
+        down_w, trt.MatrixOperation.NONE)
+    return down.get_output(0)
+
+
+def _add_moe_layer(
+    *,
+    network: "trt.INetworkDefinition",
+    hidden: "trt.ITensor",
+    eps_tensor: "trt.ITensor",
+    weights: WeightDict,
+    prefix: str,
+    hidden_size: int,
+    num_experts: int,
+    top_k: int,
+    moe_intermediate: int,
+    moe_latent: int,
+    shared_expert_intermediate: int,
+    routed_scaling_factor: float,
+    norm_topk_prob: bool,
+) -> dict[str, "trt.ITensor"]:
+    """Add a Nemotron-3-Super factorized-latent MoE layer.
+
+    Compute flow:
+      x = RMSNorm(hidden)
+      latent_in = x @ fc1_latent_proj          # [1, latent]
+      expert_outs = relu2(up)->down  (in latent space)  -> [E, 1, latent]
+      gate_logits = x @ router                  # [1, num_experts]
+      scores = sigmoid(gate_logits)
+      selection_scores = scores + router_bias   # used only for top-k selection
+      top_idx = argtopk(selection_scores, k=top_k)
+      w_k = scores[top_idx]; if norm_topk_prob: renormalize; w_k *= routed_scaling_factor
+      latent_out = sum_k w_k * expert_outs[top_idx[k]]
+      routed_hidden = latent_out @ fc2_latent_proj
+      shared_hidden = shared_down(relu2(shared_up(x)))      (if shared_expert)
+      out_residual = hidden + routed_hidden + shared_hidden
+    """
+    # ---- 0. Norm ----
+    normed = graph_ops.add_rms_norm(
+        network, hidden, hidden_size,
+        weights[f"{prefix}.input_norm"], eps_tensor)
+
+    # ---- 1. Latent down-projection (replicated, shared by experts) ----
+    latent_in = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, moe_latent,
+        weights[f"{prefix}.moe_fc1"])
+
+    # ---- 2. Batched expert compute in latent space ----
+    expert_outs = _add_packed_latent_experts(
+        network, latent_in,
+        weights[f"{prefix}.experts.w_up"],
+        weights[f"{prefix}.experts.w_down"])
+
+    # ---- 3. Router: scores + DeepSeek-V3-style selection bias ----
+    router_logits = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, num_experts,
+        weights[f"{prefix}.router"])
+    scores_sigmoid_l = network.add_activation(
+        router_logits, trt.ActivationType.SIGMOID)
+    scores = scores_sigmoid_l.get_output(0)  # [1, num_experts]
+
+    router_bias = weights.get(f"{prefix}.router_bias")
+    if router_bias is not None:
+        bias_const = graph_ops.add_constant(
+            network, (1, num_experts),
+            router_bias.reshape(1, num_experts))
+        sel_scores_l = network.add_elementwise(
+            scores, bias_const, trt.ElementWiseOperation.SUM)
+        sel_scores = sel_scores_l.get_output(0)
+    else:
+        sel_scores = scores
+
+    # ---- 4. Top-k selection by sel_scores; gather raw scores for the weights ----
+    topk_l = network.add_topk(
+        sel_scores, trt.TopKOperation.MAX, top_k, 1 << 1)
+    top_indices = topk_l.get_output(1)  # [1, top_k]
+
+    # Gather the raw (sigmoid, no-bias) scores at the selected indices to use
+    # as combine weights. Use a 1-D gather along axis 1 of scores ([1, E]).
+    idx_1d_l = network.add_shuffle(top_indices)
+    idx_1d_l.reshape_dims = (top_k,)
+    gathered_l = network.add_gather(scores, idx_1d_l.get_output(0), 1)
+    raw_weights = gathered_l.get_output(0)  # [1, top_k]
+
+    if norm_topk_prob:
+        sum_w_l = network.add_reduce(
+            raw_weights, trt.ReduceOperation.SUM, 1 << 1, keep_dims=True)
+        norm_w_l = network.add_elementwise(
+            raw_weights, sum_w_l.get_output(0),
+            trt.ElementWiseOperation.DIV)
+        combine_w = norm_w_l.get_output(0)
+    else:
+        combine_w = raw_weights
+
+    if routed_scaling_factor != 1.0:
+        scale_const = graph_ops.add_constant(
+            network, (1, 1),
+            np.array([routed_scaling_factor], dtype=np.float32))
+        scaled_l = network.add_elementwise(
+            combine_w, scale_const, trt.ElementWiseOperation.PROD)
+        combine_w = scaled_l.get_output(0)
+
+    # ---- 5. Combine selected expert outputs in latent space ----
+    routed_latent = None
+    for k in range(top_k):
+        idx_slice = network.add_slice(
+            top_indices, start=(0, k), shape=(1, 1), stride=(1, 1))
+        idx_flat = network.add_shuffle(idx_slice.get_output(0))
+        idx_flat.reshape_dims = (1,)
+
+        w_slice = network.add_slice(
+            combine_w, start=(0, k), shape=(1, 1), stride=(1, 1))
+        w_reshape = network.add_shuffle(w_slice.get_output(0))
+        w_reshape.reshape_dims = (1, 1, 1)
+
+        # expert_outs: [E, 1, latent] -> gather along axis 0 -> [1, 1, latent]
+        expert_pick = network.add_gather(
+            expert_outs, idx_flat.get_output(0), 0)
+        scaled_pick = network.add_elementwise(
+            expert_pick.get_output(0), w_reshape.get_output(0),
+            trt.ElementWiseOperation.PROD)
+        flat_pick = network.add_shuffle(scaled_pick.get_output(0))
+        flat_pick.reshape_dims = (1, moe_latent)
+
+        if routed_latent is None:
+            routed_latent = flat_pick.get_output(0)
+        else:
+            sum_l = network.add_elementwise(
+                routed_latent, flat_pick.get_output(0),
+                trt.ElementWiseOperation.SUM)
+            routed_latent = sum_l.get_output(0)
+
+    # ---- 6. Latent up-projection back to hidden ----
+    routed_hidden = graph_ops.add_matmul_rhs_constant(
+        network, routed_latent, moe_latent, hidden_size,
+        weights[f"{prefix}.moe_fc2"])
+
+    # ---- 7. Shared expert (operates directly on hidden) ----
+    shared_w_up = weights.get(f"{prefix}.shared_expert.w_up")
+    if shared_w_up is not None and shared_expert_intermediate > 0:
+        s_up = graph_ops.add_matmul_rhs_constant(
+            network, normed, hidden_size, shared_expert_intermediate,
+            shared_w_up)
+        s_relu = network.add_activation(s_up, trt.ActivationType.RELU)
+        s_relu2 = network.add_elementwise(
+            s_relu.get_output(0), s_relu.get_output(0),
+            trt.ElementWiseOperation.PROD)
+        shared_hidden = graph_ops.add_matmul_rhs_constant(
+            network, s_relu2.get_output(0), shared_expert_intermediate,
+            hidden_size,
+            weights[f"{prefix}.shared_expert.w_down"])
+        combined_l = network.add_elementwise(
+            routed_hidden, shared_hidden, trt.ElementWiseOperation.SUM)
+        mlp_out = combined_l.get_output(0)
+    else:
+        mlp_out = routed_hidden
+
+    # ---- 8. Residual ----
+    residual_l = network.add_elementwise(
+        hidden, mlp_out, trt.ElementWiseOperation.SUM)
+
+    return {"hidden": residual_l.get_output(0)}
 
 
 plugin = NemotronHPlugin()

--- a/python/tensorrt_model_connect/families/nemotron_h/tp_builder.py
+++ b/python/tensorrt_model_connect/families/nemotron_h/tp_builder.py
@@ -28,6 +28,10 @@ def _slice_first_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
     return np.ascontiguousarray(np.array_split(arr, tp_size, axis=0)[rank])
 
 
+def _slice_middle_dim(arr: np.ndarray, rank: int, tp_size: int) -> np.ndarray:
+    return np.ascontiguousarray(np.array_split(arr, tp_size, axis=1)[rank])
+
+
 def _take_last_dim_segments(arr: np.ndarray, segments: list[tuple[int, int]]) -> np.ndarray:
     return np.ascontiguousarray(
         np.concatenate([arr[..., start:end] for start, end in segments], axis=-1))
@@ -135,16 +139,34 @@ def _validate_nemotron_h_tp(
         raise ValueError(
             "Nemotron-H tensor parallel requires num_attention_heads divisible by tp_size "
             f"({config.num_attention_heads} vs {tp})")
-    if int(config.num_key_value_heads) % tp != 0:
-        raise ValueError(
-            "Nemotron-H tensor parallel requires num_key_value_heads divisible by tp_size "
-            f"({config.num_key_value_heads} vs {tp})")
+    # When num_key_value_heads is divisible by tp_size, we shard K/V across
+    # ranks; otherwise we replicate K/V (every rank carries the full KV head
+    # bank) -- mirrors the policy used by the Qwen-MoE TP builder. This is
+    # required for highly-GQA models like Nemotron-3-Super (num_kv_heads=2)
+    # running at tp_size=8.
 
     for key in ("_d_inner", "_mamba_num_heads", "_n_groups", "_mlp_size"):
         if int(weights[key]) % tp != 0:
             raise ValueError(
                 f"Nemotron-H tensor parallel requires {key} divisible by tp_size "
                 f"({weights[key]} vs {tp})")
+
+    # MoE checks only apply if the layer stack actually contains MoE-FFN
+    # ("E") layers. We shard the routed-expert intermediate dimension across
+    # ranks (column-shard up, row-shard down -> allreduce), and shard the
+    # shared-expert intermediate too. The latent dimension is replicated.
+    if int(weights.get("_num_moe_layers", 0)) > 0:
+        moe_inter = int(weights.get("_moe_intermediate_size", 0))
+        if moe_inter % tp != 0:
+            raise ValueError(
+                "Nemotron-H tensor parallel requires moe_intermediate_size "
+                f"divisible by tp_size ({moe_inter} vs {tp})")
+        shared_inter = int(weights.get("_shared_expert_intermediate_size", 0))
+        if shared_inter and shared_inter % tp != 0:
+            raise ValueError(
+                "Nemotron-H tensor parallel requires "
+                "moe_shared_expert_intermediate_size divisible by tp_size "
+                f"({shared_inter} vs {tp})")
 
 
 def shard_nemotron_h_weights(
@@ -159,6 +181,7 @@ def shard_nemotron_h_weights(
         return weights
 
     dims = _mamba2_rank_dims(weights, parallel)
+    shard_kv = int(config.num_key_value_heads) % parallel.tp_size == 0
     out = type(weights)()
     for key, value in weights.items():
         if not isinstance(value, np.ndarray):
@@ -174,12 +197,35 @@ def shard_nemotron_h_weights(
             out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
         elif key.endswith(".mamba_out_proj"):
             out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        # ---- MoE 'E' layer: per-expert packed banks. Shard the routed
+        # expert intermediate dim (axis -1 on up: [E, latent, inter],
+        # axis 1 on down: [E, inter, latent]). The latent dim stays
+        # replicated, and fc1/fc2 latent projections + router stay
+        # replicated. Must match BEFORE the generic .w_up/.w_down rules.
+        elif key.endswith(".experts.w_up"):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".experts.w_down"):
+            out[key] = _slice_middle_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".shared_expert.w_up"):
+            out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith(".shared_expert.w_down"):
+            out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".router", ".router_bias",
+                            ".moe_fc1", ".moe_fc2")):
+            # Router scoring and latent projections are replicated.
+            out[key] = value
         elif key.endswith(".w_up"):
             out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
         elif key.endswith(".w_down"):
             out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
-        elif key.endswith((".w_q", ".w_k", ".w_v")):
+        elif key.endswith(".w_q"):
             out[key] = _slice_last_dim(value, parallel.rank, parallel.tp_size)
+        elif key.endswith((".w_k", ".w_v")):
+            if shard_kv:
+                out[key] = _slice_last_dim(
+                    value, parallel.rank, parallel.tp_size)
+            else:
+                out[key] = value
         elif key.endswith(".w_o"):
             out[key] = _slice_first_dim(value, parallel.rank, parallel.tp_size)
         else:
@@ -191,6 +237,14 @@ def shard_nemotron_h_weights(
     out["_n_groups"] = dims["local_groups"]
     out["_attention_size"] = int(weights["_attention_size"]) // parallel.tp_size
     out["_mlp_size"] = int(weights["_mlp_size"]) // parallel.tp_size
+    if int(weights.get("_num_moe_layers", 0)) > 0:
+        out["_moe_intermediate_size"] = (
+            int(weights["_moe_intermediate_size"]) // parallel.tp_size)
+        shared_inter = int(
+            weights.get("_shared_expert_intermediate_size", 0))
+        if shared_inter:
+            out["_shared_expert_intermediate_size"] = (
+                shared_inter // parallel.tp_size)
     out["_tensor_parallel_size"] = parallel.tp_size
     out["_tensor_parallel_rank"] = parallel.rank
     return out
@@ -427,6 +481,198 @@ def _add_mlp_tp_layer(
     return {"hidden": residual.get_output(0)}
 
 
+def _add_packed_latent_experts_tp(
+    network: trt.INetworkDefinition,
+    latent_in: trt.ITensor,
+    w_up: np.ndarray,
+    w_down: np.ndarray,
+) -> trt.ITensor:
+    """Run all routed experts on the rank-local sharded intermediate dim.
+
+    Same shape/dataflow as the non-TP variant in plugin.py, except w_up/w_down
+    contain only this rank's slice of the moe_intermediate dim:
+      w_up:   [num_experts, latent, moe_intermediate // tp]
+      w_down: [num_experts, moe_intermediate // tp, latent]
+    The down-proj output is in latent dim and must be summed across ranks
+    (we defer that allreduce until after the routed+shared combine).
+    """
+    num_experts, latent_size, _ = w_up.shape
+
+    inp_3d = network.add_shuffle(latent_in)
+    inp_3d.reshape_dims = (1, 1, latent_size)
+    expert_scale = graph_ops.add_constant(
+        network, (num_experts, 1, 1),
+        np.ones((num_experts, 1, 1), dtype=np.float32))
+    batched = network.add_elementwise(
+        inp_3d.get_output(0), expert_scale, trt.ElementWiseOperation.PROD)
+
+    up_w = graph_ops.add_constant(network, w_up.shape, w_up)
+    down_w = graph_ops.add_constant(network, w_down.shape, w_down)
+
+    up = network.add_matrix_multiply(
+        batched.get_output(0), trt.MatrixOperation.NONE,
+        up_w, trt.MatrixOperation.NONE)
+    relu = network.add_activation(up.get_output(0), trt.ActivationType.RELU)
+    relu2 = network.add_elementwise(
+        relu.get_output(0), relu.get_output(0),
+        trt.ElementWiseOperation.PROD)
+    down = network.add_matrix_multiply(
+        relu2.get_output(0), trt.MatrixOperation.NONE,
+        down_w, trt.MatrixOperation.NONE)
+    return down.get_output(0)
+
+
+def _add_moe_tp_layer(
+    *,
+    network: trt.INetworkDefinition,
+    hidden: trt.ITensor,
+    eps_tensor: trt.ITensor,
+    weights: "WeightDict",
+    prefix: str,
+    hidden_size: int,
+    num_experts: int,
+    top_k: int,
+    moe_intermediate: int,
+    moe_latent: int,
+    shared_expert_intermediate: int,
+    routed_scaling_factor: float,
+    norm_topk_prob: bool,
+    tp_size: int,
+) -> dict[str, trt.ITensor]:
+    """Tensor-parallel Nemotron-3-Super latent MoE block.
+
+    Sharding policy (mirrors the routed-+-shared-expert flow in plugin.py):
+      - router gate, router_bias, fc1_latent_proj, fc2_latent_proj REPLICATED
+      - per-expert up: column-shard (moe_intermediate axis)
+      - per-expert down: row-shard (contracting moe_intermediate axis); each
+        rank's expert output is a partial sum in latent space
+      - shared expert: column-shard up + row-shard down on the hidden->shared
+        intermediate->hidden path; each rank's shared output is partial in
+        hidden space
+      - The routed latent partial is projected back to hidden by the replicated
+        fc2; both partials are summed locally and then all-reduced once.
+    """
+    normed = graph_ops.add_rms_norm(
+        network, hidden, hidden_size,
+        weights[f"{prefix}.input_norm"], eps_tensor)
+
+    # Replicated latent down-projection (every rank computes full latent).
+    latent_in = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, moe_latent,
+        weights[f"{prefix}.moe_fc1"])
+
+    # Per-rank sharded expert bank in latent space.
+    expert_outs = _add_packed_latent_experts_tp(
+        network, latent_in,
+        weights[f"{prefix}.experts.w_up"],
+        weights[f"{prefix}.experts.w_down"])
+
+    # Replicated router (same gating decision on every rank).
+    router_logits = graph_ops.add_matmul_rhs_constant(
+        network, normed, hidden_size, num_experts,
+        weights[f"{prefix}.router"])
+    scores_l = network.add_activation(
+        router_logits, trt.ActivationType.SIGMOID)
+    scores = scores_l.get_output(0)
+
+    router_bias = weights.get(f"{prefix}.router_bias")
+    if router_bias is not None:
+        bias_const = graph_ops.add_constant(
+            network, (1, num_experts),
+            router_bias.reshape(1, num_experts))
+        sel_l = network.add_elementwise(
+            scores, bias_const, trt.ElementWiseOperation.SUM)
+        sel_scores = sel_l.get_output(0)
+    else:
+        sel_scores = scores
+
+    topk = network.add_topk(
+        sel_scores, trt.TopKOperation.MAX, top_k, 1 << 1)
+    top_indices = topk.get_output(1)
+
+    idx_1d = network.add_shuffle(top_indices)
+    idx_1d.reshape_dims = (top_k,)
+    gathered = network.add_gather(scores, idx_1d.get_output(0), 1)
+    raw_weights = gathered.get_output(0)
+
+    if norm_topk_prob:
+        sum_w = network.add_reduce(
+            raw_weights, trt.ReduceOperation.SUM, 1 << 1, keep_dims=True)
+        norm_w = network.add_elementwise(
+            raw_weights, sum_w.get_output(0),
+            trt.ElementWiseOperation.DIV)
+        combine_w = norm_w.get_output(0)
+    else:
+        combine_w = raw_weights
+
+    if routed_scaling_factor != 1.0:
+        scale_const = graph_ops.add_constant(
+            network, (1, 1),
+            np.array([routed_scaling_factor], dtype=np.float32))
+        scaled = network.add_elementwise(
+            combine_w, scale_const, trt.ElementWiseOperation.PROD)
+        combine_w = scaled.get_output(0)
+
+    routed_latent = None
+    for k in range(top_k):
+        idx_slice = network.add_slice(
+            top_indices, start=(0, k), shape=(1, 1), stride=(1, 1))
+        idx_flat = network.add_shuffle(idx_slice.get_output(0))
+        idx_flat.reshape_dims = (1,)
+
+        w_slice = network.add_slice(
+            combine_w, start=(0, k), shape=(1, 1), stride=(1, 1))
+        w_reshape = network.add_shuffle(w_slice.get_output(0))
+        w_reshape.reshape_dims = (1, 1, 1)
+
+        pick = network.add_gather(expert_outs, idx_flat.get_output(0), 0)
+        scaled_pick = network.add_elementwise(
+            pick.get_output(0), w_reshape.get_output(0),
+            trt.ElementWiseOperation.PROD)
+        flat_pick = network.add_shuffle(scaled_pick.get_output(0))
+        flat_pick.reshape_dims = (1, moe_latent)
+
+        if routed_latent is None:
+            routed_latent = flat_pick.get_output(0)
+        else:
+            sum_l = network.add_elementwise(
+                routed_latent, flat_pick.get_output(0),
+                trt.ElementWiseOperation.SUM)
+            routed_latent = sum_l.get_output(0)
+
+    # Replicated latent->hidden projection. After this the routed_hidden is
+    # still a partial-sum across ranks (because the routed_latent only sums
+    # this rank's slice of moe_intermediate).
+    routed_hidden = graph_ops.add_matmul_rhs_constant(
+        network, routed_latent, moe_latent, hidden_size,
+        weights[f"{prefix}.moe_fc2"])
+
+    shared_w_up = weights.get(f"{prefix}.shared_expert.w_up")
+    if shared_w_up is not None and shared_expert_intermediate > 0:
+        s_up = graph_ops.add_matmul_rhs_constant(
+            network, normed, hidden_size, shared_expert_intermediate,
+            shared_w_up)
+        s_relu = network.add_activation(s_up, trt.ActivationType.RELU)
+        s_relu2 = network.add_elementwise(
+            s_relu.get_output(0), s_relu.get_output(0),
+            trt.ElementWiseOperation.PROD)
+        shared_hidden = graph_ops.add_matmul_rhs_constant(
+            network, s_relu2.get_output(0), shared_expert_intermediate,
+            hidden_size,
+            weights[f"{prefix}.shared_expert.w_down"])
+        combined = network.add_elementwise(
+            routed_hidden, shared_hidden, trt.ElementWiseOperation.SUM)
+        mlp_partial = combined.get_output(0)
+    else:
+        mlp_partial = routed_hidden
+
+    # Single all-reduce on the combined hidden partial.
+    mlp_out = add_all_reduce_sum(network, mlp_partial, tp_size)
+    residual = network.add_elementwise(
+        hidden, mlp_out, trt.ElementWiseOperation.SUM)
+    return {"hidden": residual.get_output(0)}
+
+
 def build_nemotron_h_tp_engine(
     config: "ModelConfig",
     weights: "WeightDict",
@@ -459,11 +705,30 @@ def build_nemotron_h_tp_engine(
     n_groups = int(rank_weights["_n_groups"])
     num_mamba = int(rank_weights["_num_mamba_layers"])
     num_attn = int(rank_weights["_num_attention_layers"])
+    num_moe = int(rank_weights.get("_num_moe_layers", 0))
     attention_size = int(rank_weights["_attention_size"])
     mlp_size = int(rank_weights["_mlp_size"])
+    # MoE metadata (only meaningful when num_moe > 0). Note that
+    # _moe_intermediate_size has already been divided by tp_size by the
+    # sharding step, while _moe_latent_size stays full (replicated).
+    num_experts = int(rank_weights.get("_num_experts", 0))
+    num_experts_per_tok = int(rank_weights.get("_num_experts_per_tok", 0))
+    moe_intermediate = int(rank_weights.get("_moe_intermediate_size", 0))
+    moe_latent = int(rank_weights.get("_moe_latent_size", 0))
+    shared_expert_intermediate = int(
+        rank_weights.get("_shared_expert_intermediate_size", 0))
+    routed_scaling_factor = float(
+        rank_weights.get("_routed_scaling_factor", 1.0))
+    norm_topk_prob = bool(rank_weights.get("_norm_topk_prob", True))
 
     num_heads = int(config.num_attention_heads) // parallel.tp_size
-    num_kv_heads = int(config.num_key_value_heads) // parallel.tp_size
+    # K/V sharding policy mirrors qwen_moe: shard when divisible, replicate
+    # otherwise (so highly-GQA models like Nemotron-3-Super with KV=2 still
+    # work at large tp_size).
+    shard_kv = int(config.num_key_value_heads) % parallel.tp_size == 0
+    num_kv_heads = (
+        int(config.num_key_value_heads) // parallel.tp_size
+        if shard_kv else int(config.num_key_value_heads))
     head_dim = int(config.head_dim)
     kv_attention_size = num_kv_heads * head_dim
     attention_window = max_cache_length + 1
@@ -579,6 +844,24 @@ def build_nemotron_h_tp_engine(
             present_k_outputs.append(result["present_k"])
             present_v_outputs.append(result["present_v"])
             attn_counter += 1
+        elif lt == "moe":
+            result = _add_moe_tp_layer(
+                network=network,
+                hidden=hidden_state,
+                eps_tensor=eps_tensor,
+                weights=rank_weights,
+                prefix=prefix,
+                hidden_size=hidden,
+                num_experts=num_experts,
+                top_k=num_experts_per_tok,
+                moe_intermediate=moe_intermediate,
+                moe_latent=moe_latent,
+                shared_expert_intermediate=shared_expert_intermediate,
+                routed_scaling_factor=routed_scaling_factor,
+                norm_topk_prob=norm_topk_prob,
+                tp_size=parallel.tp_size,
+            )
+            hidden_state = result["hidden"]
 
         if debug_layer_outputs:
             _mark_debug_output(network, hidden_state, f"debug_hidden_{layer_idx}")
@@ -612,7 +895,9 @@ def build_nemotron_h_tp_engine(
             "[trtmc build] Nemotron-H TP engine "
             f"(rank={parallel.rank}/{parallel.tp_size}, {num_layers}L, "
             f"local_mamba_heads={mamba_num_heads}, local_attn_heads={num_heads}, "
-            f"local_mlp={mlp_size})",
+            f"local_mlp={mlp_size}, num_moe={num_moe}, "
+            f"experts={num_experts}, top_k={num_experts_per_tok}, "
+            f"local_moe_inter={moe_intermediate}, moe_latent={moe_latent})",
             file=sys.stderr,
         )
 

--- a/tests/builder/test_family_nemotron_h_tp.py
+++ b/tests/builder/test_family_nemotron_h_tp.py
@@ -117,13 +117,16 @@ def test_nemotron_h_tp_slices_mamba_mlp_and_attention_weights():
     assert sharded["_mlp_size"] == 4
 
 
-def test_nemotron_h_tp_validation_rejects_non_divisible_kv_heads():
-    with pytest.raises(ValueError, match="num_key_value_heads"):
-        tp_builder._validate_nemotron_h_tp(
-            _config(num_kv_heads=2),
-            _weights(),
-            ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
-        )
+def test_nemotron_h_tp_validation_accepts_non_divisible_kv_heads():
+    # With the replicate-KV fallback (added for Nemotron-3-Super-120B where
+    # num_kv_heads=2 and tp_size=8), the validator no longer raises when KV
+    # heads don't divide tp_size. Each rank replicates the full KV bank
+    # instead. Mirrors the policy used by qwen_moe TP.
+    tp_builder._validate_nemotron_h_tp(
+        _config(num_kv_heads=2),
+        _weights(),
+        ParallelConfig(mode="tensor_parallel", tp_size=4, rank=0),
+    )
 
 
 def test_nemotron_h_plugin_routes_parallel_builds(monkeypatch):

--- a/tests/e2e/models/nemotron-3-super-120b-tp8.json
+++ b/tests/e2e/models/nemotron-3-super-120b-tp8.json
@@ -1,0 +1,63 @@
+{
+  "name": "nemotron-3-super-120b-tp8",
+  "trace_id": "IT-E2E-NM3SUP-TP8-01",
+  "hf_id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+  "bundle": "nemotron-3-super-120b-tp8.trtfb",
+  "family": "nemotron_h",
+  "runtime_strategy": "hybrid_mamba_attention",
+  "reference_backend": "golden_snapshot",
+  "reference_family": "chat_instruct_template",
+  "user_contract": "chat_response",
+  "ci_tier": "nightly_only",
+  "e2e_parallel_resource": "exclusive_gpu",
+  "precision": "bf16",
+  "max_cache_length": 128,
+  "prompt": "What is the capital of France? Answer in one word.",
+  "max_new_tokens": 10,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": true,
+  "build_args": {
+    "parallel": {
+      "mode": "tensor_parallel",
+      "tp_size": 8
+    }
+  },
+  "distributed_runtime": {
+    "enabled": true,
+    "launcher": "mpirun",
+    "world_size": 8,
+    "capture_gpu_memory": true,
+    "gpu_memory_sample_interval_ms": 200,
+    "export_env": [
+      "LD_LIBRARY_PATH",
+      "CUDA_VISIBLE_DEVICES",
+      "TRTMC_NCCL_RENDEZVOUS"
+    ]
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "command_available",
+      "args": {
+        "command": "mpirun"
+      },
+      "gating": true
+    },
+    {
+      "kind": "gpu_count_min",
+      "args": {
+        "count": 8
+      },
+      "gating": true
+    }
+  ],
+  "metadata": {
+    "golden_snapshot_path": "tests/e2e/data/nemotron_3_super_120b_golden.json"
+  },
+  "notes": "Nemotron-3-Super 120B-A12B BF16 TP8 build/sanity lane. Uses hybrid Mamba2+attention+MoE (E layers): 40 mamba2, 8 attention, 40 latent-MoE (512 routed experts, top-k=22, shared expert, DeepSeek-V3-style sigmoid+e_score_correction_bias gating, routed_scaling_factor=5.0). Reference parity is unavailable in CI; the contract uses a deterministic golden answer."
+}


### PR DESCRIPTION
## Summary

Extends the nemotron_h family hybrid_override_pattern parser + weight loader + TP sharder to recognize 'E' (MoE-FFN) layers, enabling \`nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16\` (88 layers, 22 experts/token, 512 experts total, DeepSeek-V3-style sigmoid+bias top-k gating with shared experts and a factorized latent FC1/FC2). Adds lane \`nemotron-3-super-120b-tp8.json\`.

Also adds a 'replicate-KV when num_kv_heads % tp_size != 0' fallback so the lane can run at tp=8 (num_kv_heads=2 doesn't divide tp_size=8 cleanly).

Architecture and verification details in the commit message.

## Test plan

- [x] AST parse clean.
- [x] Layer-type parser yields 40 mamba2 + 40 moe + 8 attention on the actual 88-char pattern.
- [x] shard_nemotron_h_weights produces correct dims at tp=8 (experts inter 336, shared 672, KV replicated).
- [x] Nano-9B-v2 tp=4 path unchanged (no regression on M/-/* paths).
- [ ] GPU validation gated on host with ≥ 8× ≥40 GB GPUs + NCCL ≥ 2.30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)