### PR TITLE
feat(wan_t2v): support expand_timesteps=True for Wan 2.2 TI2V-5B

### DIFF
--- a/python/tensorrt_model_connect/families/wan_t2v/plugin.py
+++ b/python/tensorrt_model_connect/families/wan_t2v/plugin.py
@@ -40,14 +40,49 @@ class WanT2VPlugin:
     _SCALE_FACTOR_TEMPORAL = 4
     _SCALE_FACTOR_SPATIAL = 8
 
+    # When True, the DiT consumes per-patch timestep embeddings (Wan 2.2
+    # ``expand_timesteps``). Subclasses for Wan 2.2 variants override this.
+    _EXPAND_TIMESTEPS = False
+
     def matches(self, model_type: str) -> bool:
         mt = model_type.lower()
         return mt in ("wan", "wan2.1", "wan_t2v")
+
+    def _resolve_expand_timesteps(self, transformer_source) -> bool:
+        """Read ``expand_timesteps`` from the HF transformer config.
+
+        Accepts either a directory path (string/Path) containing ``config.json``
+        or an already-parsed config ``dict``. Falls back to the class-level
+        default ``_EXPAND_TIMESTEPS`` if the flag is absent (Wan 2.1) or the
+        file is unreadable. The transformer ``config.json`` is the source of
+        truth — Wan 2.2 sets this to True, which switches the DiT to per-patch
+        AdaLN modulation.
+        """
+        import json
+        from pathlib import Path
+
+        cfg = None
+        if isinstance(transformer_source, dict):
+            cfg = transformer_source
+        else:
+            cfg_path = Path(transformer_source) / "config.json"
+            if not cfg_path.exists():
+                return self._EXPAND_TIMESTEPS
+            try:
+                with cfg_path.open("r", encoding="utf-8") as fh:
+                    cfg = json.load(fh)
+            except (OSError, json.JSONDecodeError):
+                return self._EXPAND_TIMESTEPS
+        value = cfg.get("expand_timesteps")
+        if value is None:
+            return self._EXPAND_TIMESTEPS
+        return bool(value)
 
     def load_weights(
         self, model_dir: str, config: ModelConfig,
     ) -> WeightDict:
         """Load weights from all three subdirectories."""
+        import json
         from pathlib import Path
 
         model_path = Path(model_dir)
@@ -62,6 +97,18 @@ class WanT2VPlugin:
         else:
             raise ValueError(
                 f"Expected diffusers format with model_index.json in {model_dir}")
+
+        # Stash the transformer config so get_diffusion_config() can pull
+        # ``expand_timesteps`` (and similar architecture flags) without
+        # re-reading the file. engine_builder mirrors this dict onto
+        # config.raw["_transformer_config"] before invoking get_diffusion_config.
+        transformer_cfg_path = model_path / "transformer" / "config.json"
+        if transformer_cfg_path.exists():
+            try:
+                with transformer_cfg_path.open("r", encoding="utf-8") as fh:
+                    weights["_transformer_config"] = json.load(fh)
+            except (OSError, json.JSONDecodeError):
+                pass
 
         return weights
 
@@ -107,6 +154,14 @@ class WanT2VPlugin:
         text_encoder_dir = weights["_text_encoder_dir"]
         transformer_dir = weights["_transformer_dir"]
         vae_dir = weights["_vae_dir"]
+
+        # Wan 2.2 sets ``expand_timesteps=True`` in the transformer config to
+        # tell the DiT to consume per-patch timestep embeddings instead of a
+        # single scalar broadcast across patches. Without honoring this flag
+        # the first denoising step explodes (lat_std -> 1e33 -> NaN) because
+        # the AdaLN modulation never sees the per-patch shift/scale the model
+        # was trained against.
+        expand_timesteps = self._resolve_expand_timesteps(transformer_dir)
 
         # Video dimensions from config (480x832@17fr matches HF reference)
         video_height = config.raw.get("video_height", 480)
@@ -184,6 +239,7 @@ class WanT2VPlugin:
                         ffn_activation="gelu_new",
                         verbose=verbose,
                         parallel_config=parallel.for_rank(rank),
+                        expand_timesteps=expand_timesteps,
                     )
             else:
                 dit_plan = build_standard_dit_engine(
@@ -199,6 +255,7 @@ class WanT2VPlugin:
                     cross_attn_norm=True,
                     ffn_activation="gelu_new",
                     verbose=verbose,
+                    expand_timesteps=expand_timesteps,
                 )
 
         # 3. Causal 3D VAE decoder
@@ -251,6 +308,20 @@ class WanT2VPlugin:
         video_width = config.raw.get("video_width", 832)
         video_num_frames = config.raw.get("video_num_frames", 17)
 
+        # ``expand_timesteps`` is needed at runtime so the C++ pipeline
+        # produces the matching per-patch timestep embedding shape that the
+        # DiT engine expects (Wan 2.2). Source-of-truth ordering:
+        #   1. The parsed transformer ``config.json`` mirrored onto
+        #      ``config.raw["_transformer_config"]`` by load_weights.
+        #   2. An explicit override in the build/user config.
+        #   3. The plugin class default ``_EXPAND_TIMESTEPS``.
+        transformer_cfg = config.raw.get("_transformer_config")
+        if isinstance(transformer_cfg, dict):
+            expand_timesteps = self._resolve_expand_timesteps(transformer_cfg)
+        else:
+            expand_timesteps = bool(
+                config.raw.get("expand_timesteps", self._EXPAND_TIMESTEPS))
+
         return {
             "diffusion_backend_type": "wan_3d",
             "scheduler": "flow_match_euler",
@@ -269,6 +340,7 @@ class WanT2VPlugin:
             "scale_factor_spatial": self._SCALE_FACTOR_SPATIAL,
             "freq_dim": self._DIT_FREQ_DIM,
             "text_seq_len": self._T5_MAX_SEQ_LEN,
+            "expand_timesteps": expand_timesteps,
             "latents_mean": [
                 -0.7571, -0.7089, -0.9113, 0.1075,
                 -0.1745, 0.9653, -0.1517, 1.5508,

--- a/python/tensorrt_model_connect/families/wan_t2v/standard_dit_builder.py
+++ b/python/tensorrt_model_connect/families/wan_t2v/standard_dit_builder.py
@@ -52,6 +52,7 @@ def build_standard_dit_engine(
     use_rope: bool = True,
     eps: float = 1e-6,
     verbose: bool = False,
+    expand_timesteps: bool = False,
 ) -> bytes:
     """Build DiT denoiser TRT engine plan.
 
@@ -89,11 +90,23 @@ def build_standard_dit_engine(
             fixed position embeddings, e.g. PixArt).
         eps: LayerNorm epsilon.
         verbose: Enable TRT builder verbose logging.
+        expand_timesteps: When True, the engine consumes per-patch timestep
+            embeddings — ``timestep_embedding`` has shape ``(num_patches,
+            6 * dim)`` and ``time_embed`` has shape ``(num_patches, dim)``.
+            Matches diffusers ``WanTransformer3DModel`` with
+            ``expand_timesteps=True`` (Wan 2.2). When False (default), the
+            timestep is broadcast as a scalar across all patches (Wan 2.1
+            behaviour).
 
     Returns:
         Serialized TRT engine plan bytes.
     """
     head_dim = dim // num_heads
+    # Per-patch leading dimension for the AdaLN modulation tensors when
+    # the model was trained with ``expand_timesteps=True``. Each row of the
+    # input then carries an independent timestep embedding instead of a
+    # single value broadcast over the patch axis.
+    temb_lead = num_patches if expand_timesteps else 1
 
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
@@ -105,12 +118,15 @@ def build_standard_dit_engine(
     # Inputs
     hidden_inp = network.add_input(
         "hidden_states", trt.float32, (num_patches, dim))
-    # Block modulation temb from external embedder: [1, 6 * dim]
+    # Block modulation temb from external embedder.
+    # Wan 2.1: [1, 6*dim] (broadcast across patches).
+    # Wan 2.2 (expand_timesteps=True): [num_patches, 6*dim] (per-patch).
     temb_inp = network.add_input(
-        "timestep_embedding", trt.float32, (1, 6 * dim))
-    # Time embed for final output modulation: [1, dim]
+        "timestep_embedding", trt.float32, (temb_lead, 6 * dim))
+    # Time embed for the final output AdaLN modulation.
+    # Wan 2.1: [1, dim] (broadcast). Wan 2.2: [num_patches, dim].
     time_embed_inp = network.add_input(
-        "time_embed", trt.float32, (1, dim))
+        "time_embed", trt.float32, (temb_lead, dim))
     encoder_hidden = network.add_input(
         "encoder_hidden_states", trt.float32, (text_seq_len, context_dim))
 
@@ -150,13 +166,15 @@ def build_standard_dit_engine(
         modulation = network.add_elementwise(
             sst_const, temb_inp, trt.ElementWiseOperation.SUM)
 
-        # Chunk into 6 parts: shift_sa, scale_sa, gate_sa, shift_ff, scale_ff, gate_ff
+        # Chunk into 6 parts: shift_sa, scale_sa, gate_sa, shift_ff, scale_ff, gate_ff.
+        # Each chunk has shape (temb_lead, dim) — broadcast over patches when
+        # expand_timesteps=False, per-patch when True.
         chunks = []
         for i in range(6):
             s = network.add_slice(
                 modulation.get_output(0),
                 start=(0, i * dim),
-                shape=(1, dim),
+                shape=(temb_lead, dim),
                 stride=(1, 1),
             )
             chunks.append(s.get_output(0))
@@ -356,16 +374,19 @@ def build_standard_dit_engine(
 
     # --- Final output: AdaLN modulation + projection ---
     # HF: shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
-    # scale_shift_table: [1, 2, dim], time_embed: [1, dim] -> unsqueeze -> [1, 1, dim]
-    # Result after add: [1, 2, dim], chunk -> shift [1, 1, dim], scale [1, 1, dim]
-    final_sst = weights["scale_shift_table"]  # [1, 2, dim]
+    # scale_shift_table: [1, 2, dim], time_embed: [B, dim] -> unsqueeze -> [B, 1, dim]
+    # Result after add: [B, 2, dim], chunk -> shift [B, 1, dim], scale [B, 1, dim].
+    # With expand_timesteps=True we use B = num_patches so each patch carries
+    # its own (shift, scale); otherwise B = 1 and the modulation broadcasts.
+    final_sst = weights["scale_shift_table"]  # [1, 2, dim] in the checkpoint
     final_sst_const = graph_ops.add_constant(
         network, (1, 2 * dim), final_sst.reshape(1, 2 * dim))
 
-    # time_embed_inp: [1, dim] -> tile to [1, 2*dim] for broadcast add
+    # time_embed_inp: [temb_lead, dim] -> tile across the modulation axis to
+    # produce [temb_lead, 2*dim] so we can add the (shift, scale) constant.
     time_embed_tiled = network.add_concatenation(
         [time_embed_inp, time_embed_inp])
-    time_embed_tiled.axis = 1  # [1, 2*dim]
+    time_embed_tiled.axis = 1  # [temb_lead, 2*dim]
 
     final_modulation = network.add_elementwise(
         final_sst_const, time_embed_tiled.get_output(0),
@@ -373,10 +394,10 @@ def build_standard_dit_engine(
 
     final_shift = network.add_slice(
         final_modulation.get_output(0),
-        start=(0, 0), shape=(1, dim), stride=(1, 1))
+        start=(0, 0), shape=(temb_lead, dim), stride=(1, 1))
     final_scale = network.add_slice(
         final_modulation.get_output(0),
-        start=(0, dim), shape=(1, dim), stride=(1, 1))
+        start=(0, dim), shape=(temb_lead, dim), stride=(1, 1))
 
     # Final LayerNorm + AdaLN modulation
     hidden = graph_ops.add_adaptive_layernorm(
@@ -400,7 +421,8 @@ def build_standard_dit_engine(
 
     # --- Build ---
     print(f"[dit-builder] Building TRT engine "
-          f"(dim={dim}, layers={num_layers}, patches={num_patches}) ...",
+          f"(dim={dim}, layers={num_layers}, patches={num_patches}, "
+          f"expand_timesteps={expand_timesteps}) ...",
           file=sys.stderr)
     plan = builder.build_serialized_network(network, config)
     if plan is None:

--- a/python/tensorrt_model_connect/families/wan_t2v/standard_dit_tp_builder.py
+++ b/python/tensorrt_model_connect/families/wan_t2v/standard_dit_tp_builder.py
@@ -61,6 +61,7 @@ def build_standard_dit_engine(
     eps: float = 1e-6,
     verbose: bool = False,
     parallel_config: ParallelConfig | None = None,
+    expand_timesteps: bool = False,
 ) -> bytes:
     """Build DiT denoiser TRT engine plan.
 
@@ -114,6 +115,10 @@ def build_standard_dit_engine(
     local_num_heads = num_heads // parallel.tp_size
     local_dim = dim // parallel.tp_size
     local_ffn_dim = ffn_dim // parallel.tp_size
+    # Per-patch leading dimension for the AdaLN modulation when the model
+    # was trained with expand_timesteps=True (Wan 2.2). See
+    # standard_dit_builder.build_standard_dit_engine for the rationale.
+    temb_lead = num_patches if expand_timesteps else 1
 
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
@@ -125,12 +130,15 @@ def build_standard_dit_engine(
     # Inputs
     hidden_inp = network.add_input(
         "hidden_states", trt.float32, (num_patches, dim))
-    # Block modulation temb from external embedder: [1, 6 * dim]
+    # Block modulation temb from external embedder.
+    # Wan 2.1: [1, 6*dim] (broadcast across patches).
+    # Wan 2.2 (expand_timesteps=True): [num_patches, 6*dim] (per-patch).
     temb_inp = network.add_input(
-        "timestep_embedding", trt.float32, (1, 6 * dim))
-    # Time embed for final output modulation: [1, dim]
+        "timestep_embedding", trt.float32, (temb_lead, 6 * dim))
+    # Time embed for the final output AdaLN modulation.
+    # Wan 2.1: [1, dim] (broadcast). Wan 2.2: [num_patches, dim].
     time_embed_inp = network.add_input(
-        "time_embed", trt.float32, (1, dim))
+        "time_embed", trt.float32, (temb_lead, dim))
     encoder_hidden = network.add_input(
         "encoder_hidden_states", trt.float32, (text_seq_len, context_dim))
 
@@ -170,13 +178,15 @@ def build_standard_dit_engine(
         modulation = network.add_elementwise(
             sst_const, temb_inp, trt.ElementWiseOperation.SUM)
 
-        # Chunk into 6 parts: shift_sa, scale_sa, gate_sa, shift_ff, scale_ff, gate_ff
+        # Chunk into 6 parts: shift_sa, scale_sa, gate_sa, shift_ff, scale_ff, gate_ff.
+        # Each chunk has shape (temb_lead, dim) — broadcast over patches when
+        # expand_timesteps=False, per-patch when True.
         chunks = []
         for i in range(6):
             s = network.add_slice(
                 modulation.get_output(0),
                 start=(0, i * dim),
-                shape=(1, dim),
+                shape=(temb_lead, dim),
                 stride=(1, 1),
             )
             chunks.append(s.get_output(0))
@@ -340,16 +350,19 @@ def build_standard_dit_engine(
 
     # --- Final output: AdaLN modulation + projection ---
     # HF: shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
-    # scale_shift_table: [1, 2, dim], time_embed: [1, dim] -> unsqueeze -> [1, 1, dim]
-    # Result after add: [1, 2, dim], chunk -> shift [1, 1, dim], scale [1, 1, dim]
-    final_sst = weights["scale_shift_table"]  # [1, 2, dim]
+    # scale_shift_table: [1, 2, dim], time_embed: [B, dim] -> unsqueeze -> [B, 1, dim]
+    # Result after add: [B, 2, dim], chunk -> shift [B, 1, dim], scale [B, 1, dim].
+    # With expand_timesteps=True we use B = num_patches so each patch carries
+    # its own (shift, scale); otherwise B = 1 and the modulation broadcasts.
+    final_sst = weights["scale_shift_table"]  # [1, 2, dim] in the checkpoint
     final_sst_const = graph_ops.add_constant(
         network, (1, 2 * dim), final_sst.reshape(1, 2 * dim))
 
-    # time_embed_inp: [1, dim] -> tile to [1, 2*dim] for broadcast add
+    # time_embed_inp: [temb_lead, dim] -> tile across the modulation axis to
+    # produce [temb_lead, 2*dim] so we can add the (shift, scale) constant.
     time_embed_tiled = network.add_concatenation(
         [time_embed_inp, time_embed_inp])
-    time_embed_tiled.axis = 1  # [1, 2*dim]
+    time_embed_tiled.axis = 1  # [temb_lead, 2*dim]
 
     final_modulation = network.add_elementwise(
         final_sst_const, time_embed_tiled.get_output(0),
@@ -357,10 +370,10 @@ def build_standard_dit_engine(
 
     final_shift = network.add_slice(
         final_modulation.get_output(0),
-        start=(0, 0), shape=(1, dim), stride=(1, 1))
+        start=(0, 0), shape=(temb_lead, dim), stride=(1, 1))
     final_scale = network.add_slice(
         final_modulation.get_output(0),
-        start=(0, dim), shape=(1, dim), stride=(1, 1))
+        start=(0, dim), shape=(temb_lead, dim), stride=(1, 1))
 
     # Final LayerNorm + AdaLN modulation
     hidden = graph_ops.add_adaptive_layernorm(
@@ -387,7 +400,8 @@ def build_standard_dit_engine(
         f", tp={parallel.tp_size}, rank={parallel.rank}"
         if parallel.enabled else "")
     print(f"[dit-builder] Building TRT engine "
-          f"(dim={dim}, layers={num_layers}, patches={num_patches}{tp_suffix}) ...",
+          f"(dim={dim}, layers={num_layers}, patches={num_patches}, "
+          f"expand_timesteps={expand_timesteps}{tp_suffix}) ...",
           file=sys.stderr)
     plan = builder.build_serialized_network(network, config)
     if plan is None:

--- a/src/runtime/domains/diffusion/diffusion_types.h
+++ b/src/runtime/domains/diffusion/diffusion_types.h
@@ -46,6 +46,14 @@ struct DiffusionConfig {
     bool use_rope{true};
     float vae_scaling_factor{0.0F};
 
+    // Wan 2.2 ``expand_timesteps``: when true, the DiT consumes per-patch
+    // timestep embeddings (shape ``[num_patches, ...]``) instead of a single
+    // scalar broadcast across all patches. The C++ runtime mirrors the
+    // per-patch path in WanTransformer3DModel.forward() by tiling the scalar
+    // timestep across the patch axis. Required for Wan 2.2 TI2V-5B to match
+    // the HF reference output.
+    bool expand_timesteps{false};
+
     std::string diffusion_backend_type{"wan_3d"};
 };
 

--- a/src/runtime/models/wan/pipeline.cpp
+++ b/src/runtime/models/wan/pipeline.cpp
@@ -581,15 +581,23 @@ bool WanPipeline::run_denoiser(const std::vector<float>& hidden, const std::vect
     const int32_t num_patches =
         static_cast<int32_t>(hidden.size() / static_cast<std::size_t>(dit_dim));
 
+    // ``temb_lead`` matches the AdaLN modulation leading dimension baked into
+    // the DiT engine: 1 for Wan 2.1 (scalar timestep broadcast across
+    // patches) and num_patches for Wan 2.2 (per-patch timestep embedding).
+    const int64_t temb_lead =
+        config_.expand_timesteps ? static_cast<int64_t>(num_patches) : 1;
+
     TensorMap inputs;
     inputs["hidden_states"] =
         Tensor{const_cast<float*>(hidden.data()),
                {static_cast<int64_t>(num_patches), static_cast<int64_t>(dit_dim)},
                DType::kFloat32};
     inputs["timestep_embedding"] = Tensor{
-        const_cast<float*>(temb_6d.data()), {6, static_cast<int64_t>(dit_dim)}, DType::kFloat32};
+        const_cast<float*>(temb_6d.data()),
+        {temb_lead, static_cast<int64_t>(6 * dit_dim)}, DType::kFloat32};
     inputs["time_embed"] = Tensor{
-        const_cast<float*>(time_embed.data()), {static_cast<int64_t>(dit_dim)}, DType::kFloat32};
+        const_cast<float*>(time_embed.data()),
+        {temb_lead, static_cast<int64_t>(dit_dim)}, DType::kFloat32};
     inputs["encoder_hidden_states"] =
         Tensor{const_cast<float*>(encoder_hidden.data()),
                {static_cast<int64_t>(encoder_hidden.size() / static_cast<std::size_t>(dit_dim)),
@@ -648,16 +656,47 @@ void WanPipeline::compute_timestep_embedding(float timestep, std::vector<float>&
                     weights_.time_emb_0_bias.data(), hidden_1.data(), 1, freq_dim, dim);
     cpu_silu_inplace(hidden_1.data(), static_cast<std::size_t>(dim));
 
-    time_embed.resize(static_cast<std::size_t>(dim));
+    // Compute the single-row time embed and 6d projection first, then expand
+    // (tile) the rows ``num_patches`` times when the DiT was trained with
+    // ``expand_timesteps=True``. For pure T2V the per-patch timestep is the
+    // same scalar across every spatial-temporal patch, so tiling matches the
+    // diffusers reference exactly without re-running the MLPs per patch.
+    std::vector<float> time_embed_row(static_cast<std::size_t>(dim));
     cpu_matmul_bias(hidden_1.data(), weights_.time_emb_2_weight.data(),
-                    weights_.time_emb_2_bias.data(), time_embed.data(), 1, dim, dim);
+                    weights_.time_emb_2_bias.data(), time_embed_row.data(), 1, dim, dim);
 
-    std::vector<float> silu_te(time_embed.begin(), time_embed.end());
+    std::vector<float> silu_te(time_embed_row.begin(), time_embed_row.end());
     cpu_silu_inplace(silu_te.data(), static_cast<std::size_t>(dim));
 
-    temb_6d.resize(static_cast<std::size_t>(6 * dim));
+    std::vector<float> temb_6d_row(static_cast<std::size_t>(6 * dim));
     cpu_matmul_bias(silu_te.data(), weights_.time_proj_weight.data(),
-                    weights_.time_proj_bias.data(), temb_6d.data(), 1, dim, 6 * dim);
+                    weights_.time_proj_bias.data(), temb_6d_row.data(), 1, dim, 6 * dim);
+
+    int32_t rows = 1;
+    if (config_.expand_timesteps) {
+        const int32_t t_lat =
+            (config_.video_num_frames - 1) / std::max(config_.scale_factor_temporal, 1) + 1;
+        const int32_t h_lat = config_.video_height / std::max(config_.scale_factor_spatial, 1);
+        const int32_t w_lat = config_.video_width / std::max(config_.scale_factor_spatial, 1);
+        int32_t pt = 1, ph = 2, pw = 2;
+        if (config_.patch_size.size() >= 3) {
+            pt = config_.patch_size[0];
+            ph = config_.patch_size[1];
+            pw = config_.patch_size[2];
+        }
+        rows = (t_lat / std::max(pt, 1)) * (h_lat / std::max(ph, 1)) * (w_lat / std::max(pw, 1));
+        rows = std::max(rows, 1);
+    }
+
+    time_embed.resize(static_cast<std::size_t>(rows) * static_cast<std::size_t>(dim));
+    temb_6d.resize(static_cast<std::size_t>(rows) * static_cast<std::size_t>(6 * dim));
+    for (int32_t r = 0; r < rows; ++r) {
+        std::copy_n(time_embed_row.data(), dim,
+                    time_embed.data() + static_cast<std::size_t>(r) * static_cast<std::size_t>(dim));
+        std::copy_n(temb_6d_row.data(), 6 * dim,
+                    temb_6d.data() +
+                        static_cast<std::size_t>(r) * static_cast<std::size_t>(6 * dim));
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/runtime/models/wan/pipeline.cpp
+++ b/src/runtime/models/wan/pipeline.cpp
@@ -584,20 +584,19 @@ bool WanPipeline::run_denoiser(const std::vector<float>& hidden, const std::vect
     // ``temb_lead`` matches the AdaLN modulation leading dimension baked into
     // the DiT engine: 1 for Wan 2.1 (scalar timestep broadcast across
     // patches) and num_patches for Wan 2.2 (per-patch timestep embedding).
-    const int64_t temb_lead =
-        config_.expand_timesteps ? static_cast<int64_t>(num_patches) : 1;
+    const int64_t temb_lead = config_.expand_timesteps ? static_cast<int64_t>(num_patches) : 1;
 
     TensorMap inputs;
     inputs["hidden_states"] =
         Tensor{const_cast<float*>(hidden.data()),
                {static_cast<int64_t>(num_patches), static_cast<int64_t>(dit_dim)},
                DType::kFloat32};
-    inputs["timestep_embedding"] = Tensor{
-        const_cast<float*>(temb_6d.data()),
-        {temb_lead, static_cast<int64_t>(6 * dit_dim)}, DType::kFloat32};
-    inputs["time_embed"] = Tensor{
-        const_cast<float*>(time_embed.data()),
-        {temb_lead, static_cast<int64_t>(dit_dim)}, DType::kFloat32};
+    inputs["timestep_embedding"] = Tensor{const_cast<float*>(temb_6d.data()),
+                                          {temb_lead, static_cast<int64_t>(6 * dit_dim)},
+                                          DType::kFloat32};
+    inputs["time_embed"] = Tensor{const_cast<float*>(time_embed.data()),
+                                  {temb_lead, static_cast<int64_t>(dit_dim)},
+                                  DType::kFloat32};
     inputs["encoder_hidden_states"] =
         Tensor{const_cast<float*>(encoder_hidden.data()),
                {static_cast<int64_t>(encoder_hidden.size() / static_cast<std::size_t>(dit_dim)),
@@ -692,7 +691,8 @@ void WanPipeline::compute_timestep_embedding(float timestep, std::vector<float>&
     temb_6d.resize(static_cast<std::size_t>(rows) * static_cast<std::size_t>(6 * dim));
     for (int32_t r = 0; r < rows; ++r) {
         std::copy_n(time_embed_row.data(), dim,
-                    time_embed.data() + static_cast<std::size_t>(r) * static_cast<std::size_t>(dim));
+                    time_embed.data() +
+                        static_cast<std::size_t>(r) * static_cast<std::size_t>(dim));
         std::copy_n(temb_6d_row.data(), 6 * dim,
                     temb_6d.data() +
                         static_cast<std::size_t>(r) * static_cast<std::size_t>(6 * dim));

--- a/src/runtime/plugins/shared/diffusion_helpers.cpp
+++ b/src/runtime/plugins/shared/diffusion_helpers.cpp
@@ -37,6 +37,7 @@ DiffusionConfig make_diffusion_config(const std::string& json) {
     dc.guidance_embeds = extract_json_int(json, "guidance_embeds", 0) != 0;
     dc.use_rope = extract_json_int(json, "use_rope", 1) != 0;
     dc.vae_scaling_factor = extract_json_float(json, "vae_scaling_factor", 0.0F);
+    dc.expand_timesteps = extract_json_int(json, "expand_timesteps", 0) != 0;
     dc.diffusion_backend_type = extract_json_string(json, "diffusion_backend_type", "wan_3d");
     return dc;
 }


### PR DESCRIPTION
Wan 2.2 TI2V-5B's transformer config has expand_timesteps=True; the wan_t2v family currently treats the timestep as a scalar (Wan 2.1 behavior), causing the DiT to explode to lat_std=1.35e+33->NaN at step 1 and produce a uniform pale-blue video.

Python: standard_dit_builder + standard_dit_tp_builder + plugin take an expand_timesteps parameter and rewire the TRT engine inputs to (num_patches, ...) when set.

C++ runtime: DiffusionConfig gains a bool field; wan/pipeline.cpp tiles the timestep embedding across num_patches when set.

Backwards compatible (Wan 2.1 bundles unaffected). See commit message for open questions on the I2V path and TP smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)