### PR TITLE
feat(lance): native repo build + CI E2E coverage for x2t

### DIFF
--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -357,6 +357,15 @@ def _resolve_model(model_id_or_path: str) -> str:
         if nemo_files:
             return _resolve_nemo_archive(nemo_files[0])
 
+    # Handle an unpacked Lance repo (nested Lance_3B/ + Qwen2.5-VL-ViT/, not a
+    # flat HF checkpoint) by staging it into a buildable dir. Cheap no-op for
+    # any non-Lance local dir.
+    if local.is_dir():
+        from .families.lance.staging import resolve_and_stage_lance
+        staged = resolve_and_stage_lance(str(local))
+        if staged is not None:
+            return staged
+
     # Treat as HuggingFace repo ID — download to HF cache.
     try:
         from huggingface_hub import snapshot_download
@@ -385,6 +394,14 @@ def _resolve_model(model_id_or_path: str) -> str:
     nemo_files = sorted(dl_path.glob("*.nemo"))
     if nemo_files:
         return _resolve_nemo_archive(nemo_files[0])
+
+    # Non-flat repo: probe + stage the Lance repo if its file list matches.
+    # Returns None cheaply for anything that isn't Lance.
+    from .families.lance.staging import resolve_and_stage_lance
+    staged = resolve_and_stage_lance(model_id_or_path)
+    if staged is not None:
+        print(f"[trtmc build] Staged Lance repo from {model_id_or_path}", file=sys.stderr)
+        return staged
 
     print(f"[trtmc build] Downloaded to {local_dir}", file=sys.stderr)
     return local_dir

--- a/python/tensorrt_model_connect/families/lance/plugin.py
+++ b/python/tensorrt_model_connect/families/lance/plugin.py
@@ -30,10 +30,12 @@ precision relies on the #184 builder fix (now in main): for embed bundles
 forwards ``precision`` so bf16/fp16 build true reduced-precision engines.
 
 Checkpoint layout: the Lance HF repo is not a flat HF checkpoint (it nests
-``Lance_3B/llm_config.json`` and a separate ``Qwen2.5-VL-ViT/`` dir). Run
-``scripts/prepare_lance_model.py`` to stage a directory this plugin can build:
-``config.json`` (model_type=lance), ``model.safetensors``, the tokenizer files,
-and the ViT at ``vision/model.safetensors``.
+``Lance_3B/llm_config.json`` and a separate ``Qwen2.5-VL-ViT/`` dir).
+``trtmc build bytedance-research/Lance`` stages it automatically via
+``families.lance.staging`` (config.json with model_type=lance, the LLM
+``model.safetensors``, the tokenizer files, and the ViT at
+``vision/model.safetensors``); ``scripts/prepare_lance_model.py`` is an optional
+convenience wrapper around the same staging.
 """
 from __future__ import annotations
 

--- a/python/tensorrt_model_connect/families/lance/staging.py
+++ b/python/tensorrt_model_connect/families/lance/staging.py
@@ -1,0 +1,119 @@
+"""Stage the ``bytedance-research/Lance`` HF repo into a buildable directory.
+
+The Lance repo is not a flat HF checkpoint: the LLM lives under ``Lance_3B/``
+(or ``Lance_3B_Video/``) as ``llm_config.json`` + ``model.safetensors``, and the
+Qwen2.5-VL ViT is a separate ``Qwen2.5-VL-ViT/`` dir. The builder and the
+``lance`` family plugin expect a single directory with a ``config.json`` whose
+``model_type`` routes to the Lance plugin, plus the ViT at ``vision/``.
+
+This module is the single source of truth for that staging, used by both
+``engine_builder._resolve_model`` (so ``trtmc build bytedance-research/Lance``
+works directly) and ``scripts/prepare_lance_model.py``.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+# variant -> LLM subdir in the Lance repo
+VARIANT_DIRS = {"image": "Lance_3B", "video": "Lance_3B_Video"}
+# Files copied (symlinked) to the top level of the staged dir.
+_TOP_LEVEL_FILES = [
+    "model.safetensors",
+    "tokenizer.json",
+    "vocab.json",
+    "merges.txt",
+    "generation_config.json",
+    "tokenizer_config.json",
+]
+# Only fetch what the understanding path needs (not the video checkpoint or VAE).
+DOWNLOAD_PATTERNS = ["Lance_3B/*", "Lance_3B_Video/*", "Qwen2.5-VL-ViT/*"]
+
+
+def is_lance_repo(path: Path) -> bool:
+    """True if ``path`` is an unpacked Lance repo (any variant + the ViT)."""
+    path = Path(path)
+    if not (path / "Qwen2.5-VL-ViT" / "vit.safetensors").exists():
+        return False
+    return any((path / d / "llm_config.json").exists() for d in VARIANT_DIRS.values())
+
+
+def _symlink(target: Path, link: Path) -> None:
+    link.parent.mkdir(parents=True, exist_ok=True)
+    if link.exists() or link.is_symlink():
+        link.unlink()
+    os.symlink(target, link)
+
+
+def stage_lance_repo(src: Path, out: Path, variant: str = "image") -> Path:
+    """Stage the Lance repo at ``src`` into ``out`` and return ``out``.
+
+    Writes ``config.json`` (= the variant's ``llm_config.json`` with
+    ``model_type`` stamped ``"lance"`` so it routes to the Lance plugin) and
+    symlinks the LLM weights, tokenizer files, and the ViT at ``vision/``.
+    """
+    src, out = Path(src), Path(out)
+    if variant not in VARIANT_DIRS:
+        raise ValueError(f"unknown Lance variant {variant!r}; choices: {sorted(VARIANT_DIRS)}")
+    llm_dir = src / VARIANT_DIRS[variant]
+    vit_path = src / "Qwen2.5-VL-ViT" / "vit.safetensors"
+    if not (llm_dir / "llm_config.json").exists():
+        raise FileNotFoundError(f"{llm_dir}/llm_config.json not found (not a Lance repo?)")
+    if not vit_path.exists():
+        raise FileNotFoundError(f"{vit_path} not found (not a Lance repo?)")
+
+    out.mkdir(parents=True, exist_ok=True)
+    cfg = json.loads((llm_dir / "llm_config.json").read_text())
+    cfg["model_type"] = "lance"
+    (out / "config.json").write_text(json.dumps(cfg, indent=2))
+
+    for name in _TOP_LEVEL_FILES:
+        srcf = llm_dir / name
+        if srcf.exists():
+            _symlink(srcf, out / name)
+        elif name == "model.safetensors":
+            raise FileNotFoundError(f"{srcf} not found")
+
+    _symlink(vit_path, out / "vision" / "model.safetensors")
+    return out
+
+
+def download_lance_repo(repo_id: str = "bytedance-research/Lance") -> Path:
+    """Download the Lance repo (understanding-relevant files only).
+
+    Cache-aware: falls back to ``local_files_only`` so an already-cached repo
+    resolves offline. Non-Lance repos simply fetch nothing matching.
+    """
+    from huggingface_hub import snapshot_download
+    try:
+        return Path(snapshot_download(repo_id=repo_id, allow_patterns=DOWNLOAD_PATTERNS))
+    except Exception:
+        return Path(snapshot_download(
+            repo_id=repo_id, allow_patterns=DOWNLOAD_PATTERNS, local_files_only=True))
+
+
+def resolve_and_stage_lance(model_id_or_path: str, variant: str = "image") -> str | None:
+    """Return a staged, buildable Lance dir, or None if this isn't a Lance repo.
+
+    Handles both a local unpacked Lance repo dir and a remote HF repo id. The
+    staged dir is placed next to the source snapshot so it is reused across
+    builds. Returns None (cheaply) when ``model_id_or_path`` is not Lance.
+    """
+    local = Path(model_id_or_path)
+    if local.is_dir():
+        if not is_lance_repo(local):
+            return None
+        src = local
+    else:
+        # Remote: a Lance-pattern snapshot_download is cache-aware and fetches
+        # nothing for non-Lance repos; the is_lance_repo check then rejects them.
+        try:
+            src = download_lance_repo(model_id_or_path)
+        except Exception:
+            return None
+        if not is_lance_repo(src):
+            return None
+
+    out = src.parent / f"{src.name}__trtmc_lance_{variant}"
+    return str(stage_lance_repo(src, out, variant=variant))

--- a/scripts/prepare_lance_model.py
+++ b/scripts/prepare_lance_model.py
@@ -1,113 +1,44 @@
 #!/usr/bin/env python3
 """Stage a ``bytedance-research/Lance`` checkpoint into a buildable directory.
 
-The Lance HF repo is not a flat HF checkpoint: the LLM lives under
-``Lance_3B/`` (or ``Lance_3B_Video/``) as ``llm_config.json`` +
-``model.safetensors``, and the Qwen2.5-VL ViT is a separate ``Qwen2.5-VL-ViT/``
-dir. ``trtmc build`` expects a single directory with a ``config.json`` whose
-``model_type`` selects a family plugin.
+``trtmc build bytedance-research/Lance`` now stages the nested Lance repo
+automatically (see ``tensorrt_model_connect.families.lance.staging``), so this
+script is mainly a convenience for pre-staging or inspecting the layout. The
+staging logic lives in the family module and is shared with the builder.
 
-This script writes a staged directory (symlinks, no copies of large weights):
-
-    <out>/
-      config.json            # = <variant>/llm_config.json, model_type -> "lance"
-      model.safetensors      # -> <variant>/model.safetensors  (Lance LLM)
-      tokenizer.json, vocab.json, merges.txt, generation_config.json [, tokenizer_config.json]
-      vision/model.safetensors  # -> Qwen2.5-VL-ViT/vit.safetensors
-
-Then build it (understanding path):
-
-    ./build/trtmc build <out> -o /tmp/lance.trtfb --max-cache-length 384 --precision bf16
-
-Generation/editing tasks (t2i/t2v/edit) are not supported yet; this stages the
-understanding sub-model that the ``lance`` family plugin builds.
+    python scripts/prepare_lance_model.py --variant image --out downloads/lance-3b
+    ./build/trtmc build downloads/lance-3b -o /tmp/lance.trtfb \
+        --max-cache-length 384 --precision bf16
 """
 from __future__ import annotations
 
 import argparse
-import json
-import os
-import sys
 from pathlib import Path
 
-_VARIANT_DIRS = {"image": "Lance_3B", "video": "Lance_3B_Video"}
-# Files the native tokenizer / builder may look for at the top level.
-_TOP_LEVEL_FILES = [
-    "model.safetensors",
-    "tokenizer.json",
-    "vocab.json",
-    "merges.txt",
-    "generation_config.json",
-    "tokenizer_config.json",
-]
-
-
-def _resolve_src(src: str | None) -> Path:
-    if src:
-        return Path(src).expanduser().resolve()
-    # Fall back to the local HF cache snapshot.
-    try:
-        from huggingface_hub import snapshot_download
-    except ImportError:
-        sys.exit("error: --src not given and huggingface_hub is unavailable")
-    return Path(snapshot_download(
-        repo_id="bytedance-research/Lance",
-        allow_patterns=["Lance_3B/*", "Lance_3B_Video/*", "Qwen2.5-VL-ViT/*"],
-    )).resolve()
-
-
-def _symlink(target: Path, link: Path) -> None:
-    link.parent.mkdir(parents=True, exist_ok=True)
-    if link.exists() or link.is_symlink():
-        link.unlink()
-    os.symlink(target, link)
+from tensorrt_model_connect.families.lance.staging import (
+    VARIANT_DIRS,
+    download_lance_repo,
+    stage_lance_repo,
+)
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--src", default=None,
                     help="Lance HF snapshot dir (default: download via huggingface_hub)")
-    ap.add_argument("--variant", choices=sorted(_VARIANT_DIRS), default="image",
+    ap.add_argument("--variant", choices=sorted(VARIANT_DIRS), default="image",
                     help="image -> Lance_3B (default); video -> Lance_3B_Video")
     ap.add_argument("--out", required=True, help="Output staged directory")
     args = ap.parse_args()
 
-    src = _resolve_src(args.src)
-    llm_dir = src / _VARIANT_DIRS[args.variant]
-    vit_path = src / "Qwen2.5-VL-ViT" / "vit.safetensors"
-    out = Path(args.out).expanduser().resolve()
-
-    if not (llm_dir / "llm_config.json").exists():
-        sys.exit(f"error: {llm_dir}/llm_config.json not found (bad --src/--variant?)")
-    if not vit_path.exists():
-        sys.exit(f"error: {vit_path} not found")
-
-    out.mkdir(parents=True, exist_ok=True)
-
-    # config.json from llm_config.json, with model_type stamped to "lance" so
-    # find_plugin() routes to the Lance plugin instead of qwen_vl.
-    cfg = json.loads((llm_dir / "llm_config.json").read_text())
-    cfg["model_type"] = "lance"
-    (out / "config.json").write_text(json.dumps(cfg, indent=2))
-
-    for name in _TOP_LEVEL_FILES:
-        srcf = llm_dir / name
-        if srcf.exists():
-            _symlink(srcf, out / name)
-        elif name == "model.safetensors":
-            sys.exit(f"error: {srcf} not found")
-
-    _symlink(vit_path, out / "vision" / "model.safetensors")
+    src = Path(args.src).expanduser().resolve() if args.src else download_lance_repo()
+    out = stage_lance_repo(src, Path(args.out).expanduser().resolve(), variant=args.variant)
 
     print(f"Staged Lance ({args.variant}) at: {out}")
-    print(f"  LLM : {llm_dir}")
-    print(f"  ViT : {vit_path}")
     print("Build with:")
     print(f"  ./build/trtmc build {out} -o /tmp/lance.trtfb "
           f"--max-cache-length 384 --precision bf16")
-    print("  ./build/trtmc run /tmp/lance.trtfb --prompt 'Describe this image.' "
-          "--image <img> --max-new-tokens 40 --greedy")
     return 0
 
 

--- a/tests/e2e/golden/lance-3b-x2t-image/full_generation.json
+++ b/tests/e2e/golden/lance-3b-x2t-image/full_generation.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Golden reference for the Lance x2t image-understanding E2E (full_generation stage). Captured from a validated bf16 `trtmc run` on tests/e2e/data/test_img.jpeg with the prompt 'What color is the vehicle in this image? Answer in one word.'. The VL comparator passes when non_empty AND (normalized_text_edit_distance <= 0.5 OR token_agreement_rate >= 0.3); this robustly accepts the correct answer (case/whitespace tolerant) and fails the reduced-precision garbage that motivated #182/#184.",
+  "text": "White"
+}

--- a/tests/e2e/models/lance-3b-x2t-image.json
+++ b/tests/e2e/models/lance-3b-x2t-image.json
@@ -9,10 +9,13 @@
   "max_cache_length": 384,
   "prompt": "What color is the vehicle in this image? Answer in one word.",
   "max_new_tokens": 10,
-  "logit_atol": 0.001,
-  "layer_atol": 0.05,
   "test_image": "tests/e2e/data/test_img.jpeg",
   "trust_remote_code": false,
   "core": false,
-  "skip_reason": "Lance image-understanding (x2t) is wired through the lance family plugin + vision_language runtime and is VERIFIED ACCURATE end-to-end at bf16: `trtmc run` on tests/e2e/data/test_img.jpeg answers 'White car driving on the street.' / 'White', and the TRT decoder matches an independent eager reference exactly per-layer and per-logit. Reduced-precision embed bundles rely on the #184 fix (now in main). Not yet auto-runnable in the harness because (1) the Lance HF repo is not a flat checkpoint and must be staged via scripts/prepare_lance_model.py (the harness runs `trtmc build <hf_id>` directly), and (2) there is no HF AutoModel reference for Lance (library_name=Lance, custom modeling.lance) so a Lance reference adapter is needed. Remove skip_reason once staging is wired into the VL runner and a Lance reference backend exists."
+  "reference_backend": "golden_snapshot",
+  "golden_snapshot_path": "tests/e2e/golden/lance-3b-x2t-image",
+  "stages": [
+    {"name": "full_generation", "required": true}
+  ],
+  "_notes": "Lance is not a flat HF checkpoint; `trtmc build bytedance-research/Lance` stages it internally (families.lance.staging). No HF AutoModel reference exists (library_name=Lance), so this uses a golden_snapshot for the full_generation (text) stage. Default vision_language_generation thresholds (NED<=0.5 OR token_agreement>=0.3, plus non_empty) accept the correct answer and fail the reduced-precision garbage from #182. Built at bf16 (relies on the #184 fix in main)."
 }

--- a/tools/test_impact_fallback_allowlist.txt
+++ b/tools/test_impact_fallback_allowlist.txt
@@ -37,6 +37,7 @@ catch_all tests/assets/test_image.jpg # tracked path has no precise impact rule 
 catch_all tests/assets/test_scene.jpg # tracked path has no precise impact rule yet; catch-all stays conservative
 catch_all tests/e2e/__init__.py # tracked path has no precise impact rule yet; catch-all stays conservative
 catch_all tests/e2e/conftest.py # tracked path has no precise impact rule yet; catch-all stays conservative
+catch_all tests/e2e/golden/lance-3b-x2t-image/full_generation.json # Lance E2E golden reference; catch-all is conservative (only affects the lance-3b-x2t-image E2E comparison)
 catch_all tests/e2e/test_bundle_inspect.py # tracked path has no precise impact rule yet; catch-all stays conservative
 catch_all tests/e2e/test_cache_correctness.py # tracked path has no precise impact rule yet; catch-all stays conservative
 catch_all tests/e2e/test_diffusion_pipeline.py # tracked path has no precise impact rule yet; catch-all stays conservative


### PR DESCRIPTION
## Background

#183 added Lance x2t image-understanding support, but its E2E manifest was `skip_reason`-gated, so CI **did not actually build, run, or validate** Lance — a coverage gap. It was skipped for two real reasons: the harness builds `trtmc build <hf_id>` directly while the Lance HF repo is not a flat checkpoint (it nests `Lance_3B/` + a separate `Qwen2.5-VL-ViT/`), and there is no HF AutoModel reference for Lance (`library_name=Lance`, custom `modeling.lance`). This PR closes both.

## Exit Criteria

- `tests/test_e2e.py::test_e2e[lance-3b-x2t-image]` **runs** (no longer skips): builds the bundle, runs the C++ binary on the test image, and validates the output.
- The check **gates on content** (fails on garbage), not just on non-empty output.
- No behavior change for non-Lance models.

## Implementation

- **Native repo build** (`engine_builder._resolve_model` + new `families/lance/staging.py`): `trtmc build bytedance-research/Lance` (or a local unpacked Lance repo dir) now stages the nested repo internally — `config.json` (model_type=lance), the LLM `model.safetensors`, tokenizer files, and the ViT at `vision/` — analogous to the existing `.nemo` handling. Cache-aware (resolves offline when cached) and a cheap no-op for non-Lance models. `scripts/prepare_lance_model.py` becomes a thin wrapper over the shared staging.
- **Reference oracle** (`tests/e2e/models/lance-3b-x2t-image.json`): drop `skip_reason`; use a `golden_snapshot` reference with a single `full_generation` (text) stage. The default `vision_language_generation` thresholds — `non_empty AND (normalized_text_edit_distance <= 0.5 OR token_agreement_rate >= 0.3)` — accept the correct bf16 answer and reject the reduced-precision garbage that motivated #182.
- **Golden** (`tests/e2e/golden/lance-3b-x2t-image/full_generation.json`): the validated answer text.

## Validation

- `pytest tests/test_e2e.py -k lance`: **PASSED** (158s) — built Lance via the harness, ran the C++ binary on `tests/e2e/data/test_img.jpeg`, compared to the golden.
- **Negative check**: flipping the golden to a wrong answer makes the same test **FAIL** (18s, reusing the cached bundle) — proving it gates on content, not just non-empty.
- `trtmc build bytedance-research/Lance` (remote id) and a local Lance repo dir both build + run → "White".
- `ruff`, `scripts/check_family_coverage.py`, `tools/test_impact.py --validate`, and `tests/builder/test_families.py` all pass.

## Notes For Future Readers

- The golden is a **regression snapshot**; the thresholds are case/whitespace tolerant (word-level `token_agreement_rate` is lowercased; NED is the alternative), so it's robust across runners while still catching gross output regressions.
- Native build is now the primary path; `prepare_lance_model.py` remains as an optional convenience.
- Generation/editing (t2i/t2v) is still out of scope.
- **Review order:** `families/lance/staging.py` → the two `engine_builder._resolve_model` hooks → the manifest + golden.
