### PR TITLE
feat(cosmos_predict): Cosmos-Predict 2 14B + 3 sequence-parallel strategies (Ulysses, Ring, AllGather-KV)

### DIFF
--- a/python/tensorrt_model_connect/families/cosmos_predict/__init__.py
+++ b/python/tensorrt_model_connect/families/cosmos_predict/__init__.py
@@ -1,0 +1,11 @@
+"""Cosmos-Predict2 family package.
+
+Exposes a module-level ``plugin`` attribute consumed by the family
+auto-discovery loader in ``families/__init__.py``.
+"""
+
+from __future__ import annotations
+
+from .plugin import plugin
+
+__all__ = ["plugin"]

--- a/python/tensorrt_model_connect/families/cosmos_predict/cosmos_dit_allgather_kv_builder.py
+++ b/python/tensorrt_model_connect/families/cosmos_predict/cosmos_dit_allgather_kv_builder.py
@@ -1,0 +1,455 @@
+"""Cosmos-Predict2 14B DiT engine builder — AllGather-KV sequence parallel.
+
+This is the AllGather-KV variant of the sequence-parallel Cosmos-Predict2 14B
+denoiser. The patch (sequence) dimension is sharded across ``cp_size`` ranks
+and each rank holds **all** attention heads (heads are *not* sharded). The
+self-attention block uses a single collective per pass: an AllGather on the
+local K and V tensors along the sequence axis, so that every rank reconstructs
+the full ``[num_patches, num_heads, head_dim]`` K/V tensors and can compute
+attention from its local Q rows against the full keys/values.
+
+Engine I/O contract (per-rank, with ``L = num_patches // cp_size``):
+
+    hidden_states         [L, hidden_size]
+    encoder_hidden_states [text_seq_len, text_embed_dim]    (replicated)
+    temb                  [1, hidden_size]                  (replicated)
+    embedded_timestep     [1, hidden_size]                  (replicated)
+    noise_pred            [L, out_channels * pt * ph * pw]  (sharded)
+
+Strategy:
+
+* All Linear projections operate on the local ``L``-row slice (no slicing of
+  weights — heads and feature dims are replicated).
+* Q/K/V have shape ``[L, num_heads * head_dim]`` after projection.
+* Per-head RMSNorm on Q and K — local rows only, no collective.
+* 3-axis RoPE is applied to Q and K using a *per-rank* slice of the precomputed
+  cos/sin tables (positions ``[rank * L, (rank + 1) * L)``).
+* AllGather K and V along sequence axis (gather_axis=0). Each rank now holds
+  the full ``[num_patches, num_heads * head_dim]`` K and V tensors. No further
+  collective is needed in the block.
+* Attention runs with ``q_seq=L`` and ``kv_seq=num_patches`` on each rank,
+  producing a local context ``[L, num_heads * head_dim]``.
+* ``to_out.0`` projection, gate, and residual stay local.
+* Cross-attention is unchanged from the dense builder: text K/V come from the
+  replicated ``encoder_hidden_states``, and Q is local.
+* The final norm_out + proj_out output head is unchanged (operates on the
+  local ``L``-row slice and produces a per-rank ``[L, patch_dim]`` output).
+
+At ``cp_size == 1`` the AllGather is a pass-through (``add_all_gather`` returns
+the input tensor unchanged), so the output is bit-identical to the dense
+builder.
+
+Memory note: holding the full ``[num_patches, num_heads, head_dim]`` K (and
+likewise V) on every rank is the AllGather-KV strategy's main cost. For 14B at
+720x1280 @ 49 frames in fp16, ``num_patches = 13 * 90 * 160 = 187200``; per
+attention block each rank's K (or V) tensor occupies ``187200 * 40 * 128 * 2``
+bytes = ~1.91 GiB.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import (
+    ParallelConfig,
+    add_all_gather,
+    normalize_parallel_config,
+)
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
+
+# Re-use the dense builder's architecture constants and small helpers so the
+# only divergence is the SP-specific I/O layout and the K/V AllGather.
+from .cosmos_dit_builder import (  # noqa: F401  (load_cosmos_dit_weights re-export)
+    COSMOS_14B_ADALN_LORA_DIM,
+    COSMOS_14B_FFN_DIM,
+    COSMOS_14B_HEAD_DIM,
+    COSMOS_14B_HIDDEN_SIZE,
+    COSMOS_14B_NORM_EPS,
+    COSMOS_14B_NUM_HEADS,
+    COSMOS_14B_NUM_LAYERS,
+    COSMOS_14B_OUT_CHANNELS,
+    COSMOS_14B_PATCH_SIZE,
+    COSMOS_14B_ROPE_AXES_DIM,
+    COSMOS_14B_ROPE_SCALE,
+    COSMOS_14B_ROPE_THETA,
+    COSMOS_14B_TEXT_EMBED_DIM,
+    COSMOS_14B_TEXT_SEQ_LEN,
+    COSMOS_14B_VAE_SCALE_SPATIAL,
+    COSMOS_14B_VAE_SCALE_TEMPORAL,
+    _adaln_final,
+    _adaln_zero,
+    _block_weights_or_none,
+    _build_3axis_rope_tables,
+    _silu_2d,
+    load_cosmos_dit_weights,
+)
+
+
+# Self-attention AllGather happens along the sequence axis of a row-major
+# ``[L, num_heads * head_dim]`` tensor. The sequence dim is axis 0.
+_SP_SEQ_GATHER_AXIS = 0
+
+
+def _apply_rope_3axis_local(
+    network: "trt.INetworkDefinition",
+    x: "trt.ITensor",
+    *,
+    num_heads: int,
+    head_dim: int,
+    local_num_patches: int,
+    cos_3d_local: "trt.ITensor",
+    sin_3d_local: "trt.ITensor",
+) -> "trt.ITensor":
+    """Apply per-rank 3-axis RoPE to a ``[L, num_heads * head_dim]`` tensor.
+
+    ``cos_3d_local`` / ``sin_3d_local`` are ``[1, L, head_dim // 2]`` constants
+    containing only the rank's local slice of the full RoPE table.
+    """
+    return graph_ops.add_apply_rope_native_sequence(
+        network,
+        x,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        cos_cache_3d=cos_3d_local,
+        sin_cache_3d=sin_3d_local,
+        rotary_embedding_dim=head_dim,
+        interleaved=False,
+        sequence_length=local_num_patches,
+    )
+
+
+def build_cosmos_dit_allgather_kv_engine(
+    config: "ModelConfig | None",
+    weights: "WeightDict",
+    *,
+    video_height: int,
+    video_width: int,
+    video_num_frames: int,
+    precision: str = "fp16",
+    verbose: bool = False,
+    parallel_config: ParallelConfig,
+    # Architecture knobs match the dense builder; defaults are the locked
+    # Cosmos-Predict2 14B Video2World values.
+    hidden_size: int = COSMOS_14B_HIDDEN_SIZE,
+    num_heads: int = COSMOS_14B_NUM_HEADS,
+    head_dim: int = COSMOS_14B_HEAD_DIM,
+    num_layers: int = COSMOS_14B_NUM_LAYERS,
+    ffn_dim: int = COSMOS_14B_FFN_DIM,
+    out_channels: int = COSMOS_14B_OUT_CHANNELS,
+    text_embed_dim: int = COSMOS_14B_TEXT_EMBED_DIM,
+    text_seq_len: int = COSMOS_14B_TEXT_SEQ_LEN,
+    adaln_lora_dim: int = COSMOS_14B_ADALN_LORA_DIM,
+    patch_size: tuple[int, int, int] = COSMOS_14B_PATCH_SIZE,
+    rope_axes_dim: tuple[int, int, int] = COSMOS_14B_ROPE_AXES_DIM,
+    rope_scale: tuple[float, float, float] = COSMOS_14B_ROPE_SCALE,
+    rope_theta: float = COSMOS_14B_ROPE_THETA,
+    eps: float = COSMOS_14B_NORM_EPS,
+    vae_scale_spatial: int = COSMOS_14B_VAE_SCALE_SPATIAL,
+    vae_scale_temporal: int = COSMOS_14B_VAE_SCALE_TEMPORAL,
+) -> bytes:
+    """Build the AllGather-KV sequence-parallel Cosmos-Predict2 14B DiT engine.
+
+    The ``parallel_config`` keyword argument is required and must have
+    ``mode == "sp_allgather_kv"``. ``cp_size`` may be 1 (in which case the
+    engine is bit-identical to the dense builder — the AllGather collective is
+    a no-op) or any power-of-two divisor of ``num_patches``.
+    """
+    del config  # currently unused; signature mirrors the family-wide convention
+    del precision  # storage dtype is controlled by ``weights`` already
+
+    parallel = normalize_parallel_config(parallel_config)
+    if parallel.mode != "sp_allgather_kv":
+        raise ValueError(
+            "build_cosmos_dit_allgather_kv_engine requires "
+            f"parallel_config.mode='sp_allgather_kv'; got {parallel.mode!r}")
+    cp_size = int(parallel.cp_size)
+    if cp_size <= 0:
+        raise ValueError(
+            f"build_cosmos_dit_allgather_kv_engine: cp_size must be positive; "
+            f"got {cp_size}")
+
+    if num_heads * head_dim != hidden_size:
+        raise ValueError(
+            f"hidden_size={hidden_size} must equal num_heads*head_dim "
+            f"({num_heads}*{head_dim}={num_heads * head_dim})")
+    if sum(rope_axes_dim) != head_dim:
+        raise ValueError(
+            f"sum(rope_axes_dim)={sum(rope_axes_dim)} must equal head_dim "
+            f"({head_dim}); got {rope_axes_dim}")
+    pt, ph, pw = patch_size
+
+    # Latent grid after VAE encode → patches.
+    t_lat = (video_num_frames - 1) // vae_scale_temporal + 1
+    h_lat = video_height // vae_scale_spatial
+    w_lat = video_width // vae_scale_spatial
+    if t_lat % pt != 0 or h_lat % ph != 0 or w_lat % pw != 0:
+        raise ValueError(
+            f"Latent dims (t={t_lat}, h={h_lat}, w={w_lat}) must be divisible "
+            f"by patch_size {patch_size}")
+    t_patches = t_lat // pt
+    h_patches = h_lat // ph
+    w_patches = w_lat // pw
+    num_patches = t_patches * h_patches * w_patches
+    patch_dim = out_channels * pt * ph * pw
+
+    if num_patches % cp_size != 0:
+        raise ValueError(
+            f"AllGather-KV SP requires num_patches ({num_patches}) divisible "
+            f"by cp_size ({cp_size})")
+    local_num_patches = num_patches // cp_size
+
+    # Per-rank slice of the sequence: [rank * L, (rank + 1) * L).
+    # When the engine is being built rank-agnostically (rank == -1), default
+    # to rank 0's slice — the RoPE table content is the only rank-dependent
+    # constant baked in. The runtime must materialize a per-rank engine; this
+    # mirrors the convention used by TP builders elsewhere in the codebase.
+    rank = parallel.rank if parallel.rank >= 0 else 0
+    if rank >= cp_size:
+        raise ValueError(
+            f"rank={rank} must be < cp_size={cp_size}")
+    seq_start = rank * local_num_patches
+
+    # --- Build the TRT network skeleton ---
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    builder_config = builder.create_builder_config()
+    builder_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    # --- Inputs (sequence dim sharded as L = num_patches // cp_size) ---
+    hidden_inp = network.add_input(
+        "hidden_states", trt.float32, (local_num_patches, hidden_size))
+    encoder_hidden_inp = network.add_input(
+        "encoder_hidden_states", trt.float32, (text_seq_len, text_embed_dim))
+    temb_inp = network.add_input(
+        "temb", trt.float32, (1, hidden_size))
+    embedded_timestep_inp = network.add_input(
+        "embedded_timestep", trt.float32, (1, hidden_size))
+
+    # --- Constants ---
+    eps_t = graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+
+    # 3-axis RoPE tables built for the full patch grid, then sliced to the
+    # rank's local sequence range. This keeps the math identical to dense at
+    # cp_size=1 while producing the correct positions for each rank's local Q
+    # rows (and matching local-position K rows pre-AllGather).
+    cos_full, sin_full = _build_3axis_rope_tables(
+        t_patches=t_patches,
+        h_patches=h_patches,
+        w_patches=w_patches,
+        axes_dim=rope_axes_dim,
+        rope_scale=rope_scale,
+        rope_theta=rope_theta,
+    )
+    cos_local = cos_full[seq_start:seq_start + local_num_patches]
+    sin_local = sin_full[seq_start:seq_start + local_num_patches]
+    cos_const = graph_ops.add_constant(
+        network, (1, local_num_patches, head_dim // 2),
+        cos_local.reshape(1, local_num_patches, head_dim // 2))
+    sin_const = graph_ops.add_constant(
+        network, (1, local_num_patches, head_dim // 2),
+        sin_local.reshape(1, local_num_patches, head_dim // 2))
+
+    # Pre-activate temb / embedded_timestep with SiLU (replicated; same across
+    # all ranks).
+    temb_silu = _silu_2d(network, temb_inp)
+    embedded_silu = _silu_2d(network, embedded_timestep_inp)
+
+    hidden = hidden_inp
+
+    # --- Per-block forward ---
+    for layer_idx in range(num_layers):
+        bw = _block_weights_or_none(weights, layer_idx)
+        prefix = f"transformer_blocks.{layer_idx}"
+
+        # === 1. Self-attention with AdaLN-Zero (norm1) ===
+        # AdaLN-Zero modulates per-row, so it stays local: scale/shift/gate are
+        # broadcast across the sequence dim.
+        h1, gate1 = _adaln_zero(
+            network, hidden, temb_silu, embedded_silu,
+            hidden_size=hidden_size,
+            adaln_lora_dim=adaln_lora_dim,
+            eps_tensor=eps_t,
+            w_l1=bw["norm1.linear_1.weight"], b_l1=bw["norm1.linear_1.bias"],
+            w_l2=bw["norm1.linear_2.weight"], b_l2=bw["norm1.linear_2.bias"],
+            w_l3=bw["norm1.linear_3.weight"], b_l3=bw["norm1.linear_3.bias"],
+        )
+        # Q/K/V projections on the local sequence slice. Weights are
+        # replicated (no head sharding under AllGather-KV).
+        q = graph_ops.add_matmul_rhs_constant(
+            network, h1, hidden_size, hidden_size, bw["attn1.to_q.weight"])
+        k = graph_ops.add_matmul_rhs_constant(
+            network, h1, hidden_size, hidden_size, bw["attn1.to_k.weight"])
+        v = graph_ops.add_matmul_rhs_constant(
+            network, h1, hidden_size, hidden_size, bw["attn1.to_v.weight"])
+        # Per-head RMSNorm on Q and K (local rows; per-head along feature dim).
+        nq = bw["attn1.norm_q.weight"]
+        if nq is not None:
+            q = graph_ops.add_rms_norm_per_head(
+                network, q, num_heads, head_dim, nq, eps_t,
+                sequence_length=local_num_patches)
+        nk = bw["attn1.norm_k.weight"]
+        if nk is not None:
+            k = graph_ops.add_rms_norm_per_head(
+                network, k, num_heads, head_dim, nk, eps_t,
+                sequence_length=local_num_patches)
+        # 3-axis RoPE on Q and K using the rank's local slice of the table.
+        q = _apply_rope_3axis_local(
+            network, q,
+            num_heads=num_heads, head_dim=head_dim,
+            local_num_patches=local_num_patches,
+            cos_3d_local=cos_const, sin_3d_local=sin_const)
+        k = _apply_rope_3axis_local(
+            network, k,
+            num_heads=num_heads, head_dim=head_dim,
+            local_num_patches=local_num_patches,
+            cos_3d_local=cos_const, sin_3d_local=sin_const)
+        # AllGather K and V along the sequence axis (axis 0). After this, both
+        # tensors are [num_patches, num_heads * head_dim] on every rank. This
+        # is a no-op when cp_size == 1.
+        k_full = add_all_gather(
+            network, k, cp_size, gather_axis=_SP_SEQ_GATHER_AXIS)
+        v_full = add_all_gather(
+            network, v, cp_size, gather_axis=_SP_SEQ_GATHER_AXIS)
+        # Local-Q against full K/V attention: q_seq=L, kv_seq=num_patches.
+        ctx = graph_ops.add_attention_from_rows(
+            network, q, k_full, v_full,
+            num_heads=num_heads, head_dim=head_dim,
+            q_seq=local_num_patches, kv_seq=num_patches,
+            tag=f"{prefix}.attn1")
+        # to_out.0 projection stays local — [L, hidden_size] in, [L, hidden_size] out.
+        attn_out = graph_ops.add_matmul_rhs_constant(
+            network, ctx, hidden_size, hidden_size,
+            bw["attn1.to_out.0.weight"])
+        gated = network.add_elementwise(
+            attn_out, gate1, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden = network.add_elementwise(
+            hidden, gated, trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === 2. Cross-attention with AdaLN-Zero (norm2) ===
+        # Unchanged from dense: text K/V come from replicated encoder_hidden,
+        # Q is the local sequence slice. No collective needed.
+        h2, gate2 = _adaln_zero(
+            network, hidden, temb_silu, embedded_silu,
+            hidden_size=hidden_size,
+            adaln_lora_dim=adaln_lora_dim,
+            eps_tensor=eps_t,
+            w_l1=bw["norm2.linear_1.weight"], b_l1=bw["norm2.linear_1.bias"],
+            w_l2=bw["norm2.linear_2.weight"], b_l2=bw["norm2.linear_2.bias"],
+            w_l3=bw["norm2.linear_3.weight"], b_l3=bw["norm2.linear_3.bias"],
+        )
+        cq = graph_ops.add_matmul_rhs_constant(
+            network, h2, hidden_size, hidden_size, bw["attn2.to_q.weight"])
+        ck = graph_ops.add_matmul_rhs_constant(
+            network, encoder_hidden_inp, text_embed_dim, hidden_size,
+            bw["attn2.to_k.weight"])
+        cv = graph_ops.add_matmul_rhs_constant(
+            network, encoder_hidden_inp, text_embed_dim, hidden_size,
+            bw["attn2.to_v.weight"])
+        nq2 = bw["attn2.norm_q.weight"]
+        if nq2 is not None:
+            cq = graph_ops.add_rms_norm_per_head(
+                network, cq, num_heads, head_dim, nq2, eps_t,
+                sequence_length=local_num_patches)
+        cross_ctx = graph_ops.add_attention_from_rows(
+            network, cq, ck, cv,
+            num_heads=num_heads, head_dim=head_dim,
+            q_seq=local_num_patches, kv_seq=text_seq_len,
+            tag=f"{prefix}.attn2")
+        cross_out = graph_ops.add_matmul_rhs_constant(
+            network, cross_ctx, hidden_size, hidden_size,
+            bw["attn2.to_out.0.weight"])
+        gated2 = network.add_elementwise(
+            cross_out, gate2, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden = network.add_elementwise(
+            hidden, gated2, trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === 3. FFN with AdaLN-Zero (norm3) ===
+        # FFN is point-wise along the sequence dim → local, no collective.
+        h3, gate3 = _adaln_zero(
+            network, hidden, temb_silu, embedded_silu,
+            hidden_size=hidden_size,
+            adaln_lora_dim=adaln_lora_dim,
+            eps_tensor=eps_t,
+            w_l1=bw["norm3.linear_1.weight"], b_l1=bw["norm3.linear_1.bias"],
+            w_l2=bw["norm3.linear_2.weight"], b_l2=bw["norm3.linear_2.bias"],
+            w_l3=bw["norm3.linear_3.weight"], b_l3=bw["norm3.linear_3.bias"],
+        )
+        ffn_h = graph_ops.add_matmul_rhs_constant(
+            network, h3, hidden_size, ffn_dim, bw["ff.net.0.proj.weight"])
+        if bw["ff.net.0.proj.bias"] is not None:
+            ffn_h = graph_ops.add_bias_sum(
+                network, ffn_h, ffn_dim, bw["ff.net.0.proj.bias"])
+        ffn_h = graph_ops.add_gelu_new(network, ffn_h)
+        ffn_h = graph_ops.add_matmul_rhs_constant(
+            network, ffn_h, ffn_dim, hidden_size, bw["ff.net.2.weight"])
+        if bw["ff.net.2.bias"] is not None:
+            ffn_h = graph_ops.add_bias_sum(
+                network, ffn_h, hidden_size, bw["ff.net.2.bias"])
+        gated3 = network.add_elementwise(
+            ffn_h, gate3, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden = network.add_elementwise(
+            hidden, gated3, trt.ElementWiseOperation.SUM).get_output(0)
+
+    # --- Final norm_out (2 chunks: shift, scale) + proj_out ---
+    # Output head is point-wise along the sequence dim, so it stays on the
+    # local slice. The per-rank output is [L, patch_dim].
+    h_final = _adaln_final(
+        network, hidden, temb_silu, embedded_silu,
+        hidden_size=hidden_size,
+        adaln_lora_dim=adaln_lora_dim,
+        eps_tensor=eps_t,
+        w_l1=weights["norm_out.linear_1.weight"],
+        b_l1=weights.get("norm_out.linear_1.bias"),
+        w_l2=weights["norm_out.linear_2.weight"],
+        b_l2=weights.get("norm_out.linear_2.bias"),
+        w_l3=weights["norm_out.linear_3.weight"],
+        b_l3=weights.get("norm_out.linear_3.bias"),
+    )
+    output = graph_ops.add_matmul_rhs_constant(
+        network, h_final, hidden_size, patch_dim,
+        weights["proj_out.weight"])
+    proj_b = weights.get("proj_out.bias")
+    if proj_b is not None:
+        output = graph_ops.add_bias_sum(network, output, patch_dim, proj_b)
+
+    # Mark output (fp32 by contract).
+    out_cast = network.add_cast(output, trt.float32).get_output(0)
+    out_cast.name = "noise_pred"
+    network.mark_output(out_cast)
+
+    print(
+        f"[cosmos-dit:sp_allgather_kv] Building TRT engine "
+        f"(rank={parallel.rank}, cp_size={cp_size}, "
+        f"hidden={hidden_size}, layers={num_layers}, "
+        f"num_patches={num_patches}, local_num_patches={local_num_patches}, "
+        f"t_lat={t_lat}, h_lat={h_lat}, w_lat={w_lat}, "
+        f"axes_dim={rope_axes_dim}, rope_scale={rope_scale}) ...",
+        file=sys.stderr,
+    )
+    plan = builder.build_serialized_network(network, builder_config)
+    if plan is None:
+        raise RuntimeError(
+            "TRT engine serialization failed for Cosmos DiT (sp_allgather_kv)")
+    return bytes(plan)
+
+
+# Re-export so callers can do
+# ``from cosmos_dit_allgather_kv_builder import load_cosmos_dit_weights``.
+__all__ = [
+    "build_cosmos_dit_allgather_kv_engine",
+    "load_cosmos_dit_weights",
+]

--- a/python/tensorrt_model_connect/families/cosmos_predict/cosmos_dit_allgather_kv_builder.py
+++ b/python/tensorrt_model_connect/families/cosmos_predict/cosmos_dit_allgather_kv_builder.py
@@ -62,12 +62,6 @@ from ...parallel_config import (
     normalize_parallel_config,
 )
 
-trt = trt_compat.get_trt()
-
-if TYPE_CHECKING:
-    from ...checkpoint_mapper import WeightDict
-    from ...config import ModelConfig
-
 # Re-use the dense builder's architecture constants and small helpers so the
 # only divergence is the SP-specific I/O layout and the K/V AllGather.
 from .cosmos_dit_builder import (  # noqa: F401  (load_cosmos_dit_weights re-export)
@@ -94,6 +88,12 @@ from .cosmos_dit_builder import (  # noqa: F401  (load_cosmos_dit_weights re-exp
     _silu_2d,
     load_cosmos_dit_weights,
 )
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+    from ...config import ModelConfig
 
 
 # Self-attention AllGather happens along the sequence axis of a row-major

--- a/python/tensorrt_model_connect/families/cosmos_predict/cosmos_dit_builder.py
+++ b/python/tensorrt_model_connect/families/cosmos_predict/cosmos_dit_builder.py
@@ -1,0 +1,957 @@
+"""Cosmos-Predict2 14B Video2World DiT engine builder.
+
+Builds a single TRT engine for the dense (single-GPU) ``CosmosTransformer3DModel``
+denoiser at the heart of ``nvidia/Cosmos-Predict2-14B-Video2World``.
+
+Architecture (locked from HF ``transformer/config.json`` and the diffusers
+reference impl ``diffusers.models.transformers.transformer_cosmos``)
+----------------------------------------------------------------------
+
+* ``in_channels=17``        — 16 VAE latent channels + 1 padding mask, concatenated
+                              along the channel dimension by the C++ / Python
+                              preprocessor before the engine runs.
+* ``out_channels=16``       — denoising target (epsilon / velocity in the
+                              VAE latent space).
+* ``num_attention_heads=40`` x ``attention_head_dim=128`` -> ``hidden_size=5120``.
+* ``num_layers=36``         — number of ``CosmosTransformerBlock``s.
+* ``mlp_ratio=4.0``         -> ``ffn_dim = 4 * 5120 = 20480``.
+* ``patch_size=(1, 2, 2)``  — temporal=1, spatial=2x2.
+* ``text_embed_dim=1024``   — T5-11B encoder width (different from Wan/Cosmos1).
+* ``adaln_lora_dim=256``    — low-rank channel of the per-block AdaLN-LoRA.
+* ``concat_padding_mask=True`` — caller is responsible for the 16+1 channel
+                              concat; the engine just expects 17 in-channels.
+* ``extra_pos_embed_type=None`` — 14B does not use a learnable position
+                              embedding (the 2B variant does). 3-axis RoPE
+                              is the only positional signal.
+* ``rope_scale=(0.8333, 2.0, 2.0)`` — per-axis (T, H, W) scaling of the RoPE
+                              positions. Determines the (T, H, W) head_dim
+                              split as (16, 56, 56) for the 14B model (the
+                              same axes_dim used by ``QwenEmbedRope`` /
+                              Cosmos diffusers reference).
+* ``max_size=(128, 240, 240)`` — maximum patches along (T, H, W). Used to
+                              pre-compute the RoPE frequency tables once at
+                              build time.
+
+Per-block structure (``CosmosTransformerBlock``)
+-------------------------------------------------
+
+Each block has three :class:`CosmosAdaLayerNormZero` modulators (``norm1``,
+``norm2``, ``norm3``). One AdaLN-LoRA forward looks like::
+
+    a = SiLU(temb)
+    b = SiLU(embedded_timestep)
+    delta_main      = norm.linear_2(SiLU(norm.linear_1(a)))     # [B, 3*dim]
+    delta_residual  = norm.linear_3(b)                          # [B, 3*dim]
+    shift, scale, gate = (delta_main + delta_residual).chunk(3, dim=-1)
+    h = LayerNorm(x, eps=1e-6, affine=False)
+    h = h * (1 + scale) + shift
+    # gate is returned separately for the gated residual that follows the
+    # block sub-layer (self-attn / cross-attn / FFN).
+
+The block forward then runs::
+
+    h1, gate1 = norm1(x, temb, embedded_timestep)
+    x = x + gate1 * self_attention(h1)
+    h2, gate2 = norm2(x, temb, embedded_timestep)
+    x = x + gate2 * cross_attention(h2, encoder_hidden_states)
+    h3, gate3 = norm3(x, temb, embedded_timestep)
+    x = x + gate3 * ffn(h3)
+
+* Self-attention: RMSNorm over each head's ``D`` dim on Q and K, 3-axis
+  RoPE applied to Q and K, no biases on the projections.
+* Cross-attention: RMSNorm on Q only (the diffusers source has no
+  ``norm_k`` for ``attn2``). No RoPE. K/V projected from the 1024-dim T5
+  output via dedicated ``to_k``/``to_v`` weights of shape ``[text_dim, hidden]``.
+* FFN: ``Linear(hidden, ffn_dim) -> gelu_pytorch_tanh -> Linear(ffn_dim, hidden)``,
+  no SwiGLU gating.
+
+Final-output head (``norm_out`` + ``proj_out``)
+------------------------------------------------
+
+A single :class:`CosmosAdaLayerNorm` head produces ``(shift, scale)`` only::
+
+    delta_main     = norm_out.linear_2(SiLU(norm_out.linear_1(SiLU(temb))))
+    delta_residual = norm_out.linear_3(SiLU(embedded_timestep))
+    shift, scale   = (delta_main + delta_residual).chunk(2, dim=-1)
+    h = LayerNorm(x, eps=1e-6, affine=False) * (1 + scale) + shift
+    output = proj_out(h)        # [num_patches, out_channels * pt * ph * pw]
+
+Engine I/O contract
+-------------------
+
+Inputs (all batch=1, fixed shape at build time):
+
+    hidden_states         [num_patches, hidden_size]              fp32
+        Patchified latent. The runner is responsible for the
+        ``[B, 17, T_lat, H_lat, W_lat] -> [num_patches, hidden_size]``
+        reshape (matches the Wan T2V engine convention).
+    encoder_hidden_states [text_seq_len, text_embed_dim]          fp32
+        T5-11B encoder output. ``text_embed_dim`` is 1024 for Cosmos-Predict2.
+    temb                  [1, hidden_size]                        fp32
+        Per-step timestep embedding feeding the LoRA "main" path of every
+        :class:`CosmosAdaLayerNormZero` modulator.
+    embedded_timestep     [1, hidden_size]                        fp32
+        Per-step embedding feeding the LoRA "residual" path (``linear_3``)
+        of every modulator. In diffusers this is the SiLU-activated
+        sinusoidal embedding that bypasses the time-MLP. Pre-activated
+        (i.e. NO SiLU applied here) by the caller, matching what the
+        diffusers ``CosmosEmbedding`` module returns.
+
+Output:
+
+    noise_pred            [num_patches, out_channels * pt * ph * pw]  fp32
+        Pre-unpatchify denoising output. The runner reshapes to
+        ``[1, 16, T_lat, H_lat, W_lat]``.
+
+Single-GPU only. Multi-GPU sequence-parallel and tensor-parallel variants
+are out of scope for this builder (the plugin guards with NotImplementedError
+when ``parallel_config.tp_size != 1``).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+
+
+# ---------------------------------------------------------------------------
+# Cosmos-Predict2 14B architecture constants
+# ---------------------------------------------------------------------------
+
+COSMOS_14B_IN_CHANNELS = 17           # 16 VAE z + 1 padding mask
+COSMOS_14B_OUT_CHANNELS = 16
+COSMOS_14B_NUM_HEADS = 40
+COSMOS_14B_HEAD_DIM = 128
+COSMOS_14B_HIDDEN_SIZE = 5120         # 40 * 128
+COSMOS_14B_NUM_LAYERS = 36
+COSMOS_14B_FFN_DIM = 20480            # mlp_ratio=4.0
+COSMOS_14B_PATCH_SIZE = (1, 2, 2)
+COSMOS_14B_TEXT_EMBED_DIM = 1024
+COSMOS_14B_ADALN_LORA_DIM = 256
+COSMOS_14B_TEXT_SEQ_LEN = 512
+COSMOS_14B_ROPE_THETA = 10000.0
+# Per-axis RoPE head-dim split (T, H, W). 16 + 56 + 56 = 128.
+COSMOS_14B_ROPE_AXES_DIM = (16, 56, 56)
+# Per-axis position scaling factor (matches diffusers ``rope_scale``).
+COSMOS_14B_ROPE_SCALE = (0.8333, 2.0, 2.0)
+# Maximum supported patch grid; needed to bound the RoPE precompute table.
+COSMOS_14B_MAX_SIZE = (128, 240, 240)
+COSMOS_14B_NORM_EPS = 1e-6
+COSMOS_14B_VAE_SCALE_SPATIAL = 8
+COSMOS_14B_VAE_SCALE_TEMPORAL = 4
+
+
+# ---------------------------------------------------------------------------
+# Small TRT helpers
+# ---------------------------------------------------------------------------
+
+def _silu_2d(network: "trt.INetworkDefinition", x: "trt.ITensor") -> "trt.ITensor":
+    """SiLU on a 2-D tensor (broadcast-friendly variant of graph_ops.add_silu)."""
+    sig = network.add_activation(x, trt.ActivationType.SIGMOID).get_output(0)
+    return network.add_elementwise(x, sig, trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def _linear_2d(
+    network: "trt.INetworkDefinition",
+    x: "trt.ITensor",
+    in_dim: int,
+    out_dim: int,
+    weight_t: np.ndarray,
+    bias: np.ndarray | None,
+) -> "trt.ITensor":
+    """Linear(in_dim -> out_dim) on [N, in_dim] input.
+
+    ``weight_t`` must be transposed to ``[in_dim, out_dim]`` order so that
+    ``y = x @ weight_t`` produces ``[N, out_dim]``. The matching
+    ``load_cosmos_dit_weights`` helper does the transpose at load time.
+    """
+    y = graph_ops.add_matmul_rhs_constant(network, x, in_dim, out_dim, weight_t)
+    if bias is not None:
+        y = graph_ops.add_bias_sum(network, y, out_dim, bias)
+    return y
+
+
+def _layer_norm_no_affine_2d(
+    network: "trt.INetworkDefinition",
+    x: "trt.ITensor",
+    hidden_size: int,
+    eps_tensor: "trt.ITensor",
+) -> "trt.ITensor":
+    """LayerNorm with elementwise_affine=False over the last axis."""
+    # Reuse the shared no-affine helper.
+    return graph_ops.add_layer_norm_no_affine(network, x, hidden_size, eps_tensor)
+
+
+# ---------------------------------------------------------------------------
+# CosmosAdaLayerNormZero (per-block: norm1/norm2/norm3)
+#
+# Returns ``(modulated_x, gate)`` so the caller can splice in the sub-layer
+# (self-attn / cross-attn / FFN) and finish the gated residual outside.
+# ---------------------------------------------------------------------------
+
+def _adaln_zero(
+    network: "trt.INetworkDefinition",
+    x: "trt.ITensor",
+    temb_silu: "trt.ITensor",
+    embedded_silu: "trt.ITensor",
+    *,
+    hidden_size: int,
+    adaln_lora_dim: int,
+    eps_tensor: "trt.ITensor",
+    w_l1: np.ndarray,
+    b_l1: np.ndarray | None,
+    w_l2: np.ndarray,
+    b_l2: np.ndarray | None,
+    w_l3: np.ndarray,
+    b_l3: np.ndarray | None,
+) -> tuple["trt.ITensor", "trt.ITensor"]:
+    """One CosmosAdaLayerNormZero step.
+
+    Produces 3 ``hidden_size``-wide modulation chunks ``(shift, scale, gate)``
+    and applies ``LayerNorm * (1 + scale) + shift`` to ``x``. The gate is
+    returned so the caller can use it for the residual add after the
+    following sub-layer.
+
+    ``temb_silu`` / ``embedded_silu`` are [1, hidden_size] tensors already
+    pre-activated with SiLU by ``build_cosmos_dit_engine``.
+    """
+    # LoRA "main" path: SiLU was already applied to temb. We do
+    # Linear-1, SiLU, Linear-2 here.
+    a = _linear_2d(network, temb_silu, hidden_size, adaln_lora_dim, w_l1, b_l1)
+    a = _silu_2d(network, a)
+    a = _linear_2d(network, a, adaln_lora_dim, 3 * hidden_size, w_l2, b_l2)
+    # LoRA "residual" path: Linear-3 from the SiLU-activated embedded_timestep.
+    r = _linear_2d(network, embedded_silu, hidden_size, 3 * hidden_size, w_l3, b_l3)
+    modulation = network.add_elementwise(
+        a, r, trt.ElementWiseOperation.SUM).get_output(0)
+    # Chunk along axis=-1 into (shift, scale, gate), each [1, hidden_size].
+    shift = network.add_slice(
+        modulation,
+        start=(0, 0),
+        shape=(1, hidden_size),
+        stride=(1, 1)).get_output(0)
+    scale = network.add_slice(
+        modulation,
+        start=(0, hidden_size),
+        shape=(1, hidden_size),
+        stride=(1, 1)).get_output(0)
+    gate = network.add_slice(
+        modulation,
+        start=(0, 2 * hidden_size),
+        shape=(1, hidden_size),
+        stride=(1, 1)).get_output(0)
+    # LayerNorm(x, affine=False), then modulate.
+    h = _layer_norm_no_affine_2d(network, x, hidden_size, eps_tensor)
+    one = graph_ops.add_constant(
+        network, (1, 1), np.array([1.0], dtype=np.float32))
+    scale_plus_one = network.add_elementwise(
+        scale, one, trt.ElementWiseOperation.SUM).get_output(0)
+    h = network.add_elementwise(
+        h, scale_plus_one, trt.ElementWiseOperation.PROD).get_output(0)
+    h = network.add_elementwise(
+        h, shift, trt.ElementWiseOperation.SUM).get_output(0)
+    return h, gate
+
+
+# ---------------------------------------------------------------------------
+# CosmosAdaLayerNorm (final norm_out; 2 chunks instead of 3)
+# ---------------------------------------------------------------------------
+
+def _adaln_final(
+    network: "trt.INetworkDefinition",
+    x: "trt.ITensor",
+    temb_silu: "trt.ITensor",
+    embedded_silu: "trt.ITensor",
+    *,
+    hidden_size: int,
+    adaln_lora_dim: int,
+    eps_tensor: "trt.ITensor",
+    w_l1: np.ndarray,
+    b_l1: np.ndarray | None,
+    w_l2: np.ndarray,
+    b_l2: np.ndarray | None,
+    w_l3: np.ndarray,
+    b_l3: np.ndarray | None,
+) -> "trt.ITensor":
+    """Final AdaLN modulator. Same LoRA layout as block norms but 2 chunks.
+
+    ``linear_2.weight`` has shape ``[adaln_lora_dim, 2*hidden_size]`` and
+    ``linear_3.weight`` has shape ``[hidden_size, 2*hidden_size]``.
+    """
+    a = _linear_2d(network, temb_silu, hidden_size, adaln_lora_dim, w_l1, b_l1)
+    a = _silu_2d(network, a)
+    a = _linear_2d(network, a, adaln_lora_dim, 2 * hidden_size, w_l2, b_l2)
+    r = _linear_2d(network, embedded_silu, hidden_size, 2 * hidden_size, w_l3, b_l3)
+    modulation = network.add_elementwise(
+        a, r, trt.ElementWiseOperation.SUM).get_output(0)
+    shift = network.add_slice(
+        modulation, start=(0, 0),
+        shape=(1, hidden_size), stride=(1, 1)).get_output(0)
+    scale = network.add_slice(
+        modulation, start=(0, hidden_size),
+        shape=(1, hidden_size), stride=(1, 1)).get_output(0)
+    h = _layer_norm_no_affine_2d(network, x, hidden_size, eps_tensor)
+    one = graph_ops.add_constant(
+        network, (1, 1), np.array([1.0], dtype=np.float32))
+    scale_plus_one = network.add_elementwise(
+        scale, one, trt.ElementWiseOperation.SUM).get_output(0)
+    h = network.add_elementwise(
+        h, scale_plus_one, trt.ElementWiseOperation.PROD).get_output(0)
+    h = network.add_elementwise(
+        h, shift, trt.ElementWiseOperation.SUM).get_output(0)
+    return h
+
+
+# ---------------------------------------------------------------------------
+# 3-axis RoPE precompute (T, H, W) — baked as a constant
+#
+# Mirrors diffusers ``CosmosRotaryPosEmbed``. Each head_dim chunk
+# corresponds to one axis and is computed as the standard rotate-half RoPE
+# inv_freq formulation, then concatenated along the last axis. ``rope_scale``
+# rescales the position indices per axis before computing the angles.
+# ---------------------------------------------------------------------------
+
+def _rope_table_axis(
+    *,
+    num_positions: int,
+    axis_dim: int,
+    rope_theta: float,
+    scale: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(cos, sin)`` of shape ``[num_positions, axis_dim // 2]``.
+
+    Standard rotate-half layout (LLaMA/Qwen/Cosmos): the cos/sin tables
+    store the *half*-dim frequencies. The application step splits the
+    incoming head_dim into ``(x1, x2)`` halves and computes
+    ``(x1 * c - x2 * s, x2 * c + x1 * s)``.
+    """
+    if axis_dim <= 0 or num_positions <= 0:
+        return (np.zeros((max(num_positions, 1), max(axis_dim // 2, 1)),
+                          dtype=np.float32),
+                np.zeros((max(num_positions, 1), max(axis_dim // 2, 1)),
+                          dtype=np.float32))
+    half = axis_dim // 2
+    # inv_freq[j] = 1 / theta ** (2j / axis_dim)  for j in [0, half)
+    inv_freq = 1.0 / (
+        rope_theta ** (np.arange(0, axis_dim, 2, dtype=np.float64) / axis_dim))
+    positions = np.arange(num_positions, dtype=np.float64) * float(scale)
+    angles = np.outer(positions, inv_freq)  # [num_positions, half]
+    return (np.cos(angles).astype(np.float32),
+            np.sin(angles).astype(np.float32))
+
+
+def _build_3axis_rope_tables(
+    *,
+    t_patches: int,
+    h_patches: int,
+    w_patches: int,
+    axes_dim: tuple[int, int, int],
+    rope_scale: tuple[float, float, float],
+    rope_theta: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build ``cos, sin`` tables of shape ``[num_patches, head_dim // 2]``.
+
+    The per-axis tables are tiled across the 3-D grid (T, H, W) and
+    concatenated along the dim axis so the final layout matches the per-token
+    rotation pattern used inside ``CosmosAttnProcessor2_5``.
+    """
+    ad_t, ad_h, ad_w = axes_dim
+    cos_t, sin_t = _rope_table_axis(
+        num_positions=t_patches, axis_dim=ad_t,
+        rope_theta=rope_theta, scale=rope_scale[0])
+    cos_h, sin_h = _rope_table_axis(
+        num_positions=h_patches, axis_dim=ad_h,
+        rope_theta=rope_theta, scale=rope_scale[1])
+    cos_w, sin_w = _rope_table_axis(
+        num_positions=w_patches, axis_dim=ad_w,
+        rope_theta=rope_theta, scale=rope_scale[2])
+
+    # Broadcast over the 3-D grid: each token (t, h, w) gets
+    #   cos_t[t, :] | cos_h[h, :] | cos_w[w, :]
+    cos_t_grid = np.broadcast_to(
+        cos_t[:, None, None, :], (t_patches, h_patches, w_patches, ad_t // 2))
+    cos_h_grid = np.broadcast_to(
+        cos_h[None, :, None, :], (t_patches, h_patches, w_patches, ad_h // 2))
+    cos_w_grid = np.broadcast_to(
+        cos_w[None, None, :, :], (t_patches, h_patches, w_patches, ad_w // 2))
+    sin_t_grid = np.broadcast_to(
+        sin_t[:, None, None, :], (t_patches, h_patches, w_patches, ad_t // 2))
+    sin_h_grid = np.broadcast_to(
+        sin_h[None, :, None, :], (t_patches, h_patches, w_patches, ad_h // 2))
+    sin_w_grid = np.broadcast_to(
+        sin_w[None, None, :, :], (t_patches, h_patches, w_patches, ad_w // 2))
+
+    cos_table = np.concatenate(
+        [cos_t_grid, cos_h_grid, cos_w_grid], axis=-1).reshape(
+            t_patches * h_patches * w_patches, -1).astype(np.float32)
+    sin_table = np.concatenate(
+        [sin_t_grid, sin_h_grid, sin_w_grid], axis=-1).reshape(
+            t_patches * h_patches * w_patches, -1).astype(np.float32)
+    return (np.ascontiguousarray(cos_table),
+            np.ascontiguousarray(sin_table))
+
+
+def _apply_rope_3axis(
+    network: "trt.INetworkDefinition",
+    x: "trt.ITensor",
+    *,
+    num_heads: int,
+    head_dim: int,
+    num_patches: int,
+    cos_3d: "trt.ITensor",
+    sin_3d: "trt.ITensor",
+) -> "trt.ITensor":
+    """Apply rotate-half RoPE using full per-axis cos/sin tables.
+
+    ``cos_3d`` / ``sin_3d`` are pre-built constants of shape
+    ``[1, num_patches, head_dim // 2]`` (the half-dim cache layout expected
+    by ``IRotaryEmbeddingLayer``). We delegate to
+    ``graph_ops.add_apply_rope_native_sequence`` which handles the
+    [Sq, H*D] -> [1, H, Sq, D] -> rotate -> [Sq, H*D] dance.
+
+    The 3-axis layout is encoded in the *table contents*, not the math:
+    ``_build_3axis_rope_tables`` concatenates per-axis frequencies along the
+    dim axis, so each per-token rotation pair already targets the correct
+    axis.
+    """
+    return graph_ops.add_apply_rope_native_sequence(
+        network,
+        x,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        cos_cache_3d=cos_3d,
+        sin_cache_3d=sin_3d,
+        rotary_embedding_dim=head_dim,
+        interleaved=False,
+        sequence_length=num_patches,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-block weight key fan-out
+#
+# Diffusers ``CosmosTransformer3DModel`` serializes weights under the
+# ``transformer_blocks.{i}.`` prefix. The canonical sub-keys are:
+#
+#   transformer_blocks.{i}.norm1.linear_1.{weight,bias}    [hidden, lora]
+#   transformer_blocks.{i}.norm1.linear_2.{weight,bias}    [lora,   3*hidden]
+#   transformer_blocks.{i}.norm1.linear_3.{weight,bias}    [hidden, 3*hidden]
+#   transformer_blocks.{i}.attn1.to_q.weight               [hidden, hidden]
+#   transformer_blocks.{i}.attn1.to_k.weight               [hidden, hidden]
+#   transformer_blocks.{i}.attn1.to_v.weight               [hidden, hidden]
+#   transformer_blocks.{i}.attn1.to_out.0.weight           [hidden, hidden]
+#   transformer_blocks.{i}.attn1.norm_q.weight             [head_dim]
+#   transformer_blocks.{i}.attn1.norm_k.weight             [head_dim]
+#   transformer_blocks.{i}.norm2.linear_{1,2,3}.{weight,bias}
+#   transformer_blocks.{i}.attn2.to_q.weight               [hidden, hidden]
+#   transformer_blocks.{i}.attn2.to_k.weight               [text_embed, hidden]
+#   transformer_blocks.{i}.attn2.to_v.weight               [text_embed, hidden]
+#   transformer_blocks.{i}.attn2.to_out.0.weight           [hidden, hidden]
+#   transformer_blocks.{i}.attn2.norm_q.weight             [head_dim]
+#   transformer_blocks.{i}.norm3.linear_{1,2,3}.{weight,bias}
+#   transformer_blocks.{i}.ff.net.0.proj.{weight,bias}     [hidden, ffn]
+#   transformer_blocks.{i}.ff.net.2.{weight,bias}          [ffn, hidden]
+#
+# Global keys:
+#
+#   patch_embed.proj.{weight,bias}    [in_channels * pt*ph*pw, hidden]
+#   time_embed.timesteps_proj.linear_1.{weight,bias}  [256, hidden]
+#   time_embed.timesteps_proj.linear_2.{weight,bias}  [hidden, hidden]
+#   time_embed.t_embedder.linear_1.{weight,bias}      [256, hidden]
+#   time_embed.t_embedder.linear_2.{weight,bias}      [hidden, hidden]
+#   time_embed.norm.weight                            (optional RMSNorm on temb)
+#   norm_out.linear_1.{weight,bias}                   [hidden, lora]
+#   norm_out.linear_2.{weight,bias}                   [lora,   2*hidden]
+#   norm_out.linear_3.{weight,bias}                   [hidden, 2*hidden]
+#   proj_out.{weight,bias}                            [hidden, out_channels * pt*ph*pw]
+# ---------------------------------------------------------------------------
+
+
+def _block_weights_or_none(
+    weights: "WeightDict",
+    i: int,
+    *,
+    require_attn_biases: bool = False,
+) -> dict:
+    """Pull out all per-block weight tensors that ``build_cosmos_dit_engine`` needs."""
+    p = f"transformer_blocks.{i}"
+    w = {}
+    # AdaLN-LoRA (3 norms per block, each with linear_1/2/3).
+    for nm in ("norm1", "norm2", "norm3"):
+        w[f"{nm}.linear_1.weight"] = weights[f"{p}.{nm}.linear_1.weight"]
+        w[f"{nm}.linear_1.bias"] = weights.get(f"{p}.{nm}.linear_1.bias")
+        w[f"{nm}.linear_2.weight"] = weights[f"{p}.{nm}.linear_2.weight"]
+        w[f"{nm}.linear_2.bias"] = weights.get(f"{p}.{nm}.linear_2.bias")
+        w[f"{nm}.linear_3.weight"] = weights[f"{p}.{nm}.linear_3.weight"]
+        w[f"{nm}.linear_3.bias"] = weights.get(f"{p}.{nm}.linear_3.bias")
+    # Self-attention (attn1).
+    w["attn1.to_q.weight"] = weights[f"{p}.attn1.to_q.weight"]
+    w["attn1.to_k.weight"] = weights[f"{p}.attn1.to_k.weight"]
+    w["attn1.to_v.weight"] = weights[f"{p}.attn1.to_v.weight"]
+    w["attn1.to_out.0.weight"] = weights[f"{p}.attn1.to_out.0.weight"]
+    w["attn1.norm_q.weight"] = weights.get(f"{p}.attn1.norm_q.weight")
+    w["attn1.norm_k.weight"] = weights.get(f"{p}.attn1.norm_k.weight")
+    # Cross-attention (attn2).
+    w["attn2.to_q.weight"] = weights[f"{p}.attn2.to_q.weight"]
+    w["attn2.to_k.weight"] = weights[f"{p}.attn2.to_k.weight"]
+    w["attn2.to_v.weight"] = weights[f"{p}.attn2.to_v.weight"]
+    w["attn2.to_out.0.weight"] = weights[f"{p}.attn2.to_out.0.weight"]
+    w["attn2.norm_q.weight"] = weights.get(f"{p}.attn2.norm_q.weight")
+    # FFN (gelu_pytorch_tanh -> GELU tanh).
+    w["ff.net.0.proj.weight"] = weights[f"{p}.ff.net.0.proj.weight"]
+    w["ff.net.0.proj.bias"] = weights.get(f"{p}.ff.net.0.proj.bias")
+    w["ff.net.2.weight"] = weights[f"{p}.ff.net.2.weight"]
+    w["ff.net.2.bias"] = weights.get(f"{p}.ff.net.2.bias")
+    return w
+
+
+# ---------------------------------------------------------------------------
+# Engine builder
+# ---------------------------------------------------------------------------
+
+
+def build_cosmos_dit_engine(
+    weights: "WeightDict",
+    *,
+    video_height: int,
+    video_width: int,
+    video_num_frames: int,
+    hidden_size: int = COSMOS_14B_HIDDEN_SIZE,
+    num_heads: int = COSMOS_14B_NUM_HEADS,
+    head_dim: int = COSMOS_14B_HEAD_DIM,
+    num_layers: int = COSMOS_14B_NUM_LAYERS,
+    ffn_dim: int = COSMOS_14B_FFN_DIM,
+    out_channels: int = COSMOS_14B_OUT_CHANNELS,
+    text_embed_dim: int = COSMOS_14B_TEXT_EMBED_DIM,
+    text_seq_len: int = COSMOS_14B_TEXT_SEQ_LEN,
+    adaln_lora_dim: int = COSMOS_14B_ADALN_LORA_DIM,
+    patch_size: tuple[int, int, int] = COSMOS_14B_PATCH_SIZE,
+    rope_axes_dim: tuple[int, int, int] = COSMOS_14B_ROPE_AXES_DIM,
+    rope_scale: tuple[float, float, float] = COSMOS_14B_ROPE_SCALE,
+    rope_theta: float = COSMOS_14B_ROPE_THETA,
+    eps: float = COSMOS_14B_NORM_EPS,
+    vae_scale_spatial: int = COSMOS_14B_VAE_SCALE_SPATIAL,
+    vae_scale_temporal: int = COSMOS_14B_VAE_SCALE_TEMPORAL,
+    verbose: bool = False,
+) -> bytes:
+    """Build the Cosmos-Predict2 14B DiT denoiser TRT engine.
+
+    Args:
+        weights: Output of :func:`load_cosmos_dit_weights`. The transformer
+            weights are expected to be transposed for TRT matmul (i.e.
+            ``[in_dim, out_dim]`` order). RMSNorm/LayerNorm weights are
+            flat 1-D arrays.
+        video_height, video_width, video_num_frames: Pixel-space target. Used
+            to compute the static engine I/O shapes via the VAE compression
+            factors.
+        hidden_size, num_heads, head_dim, num_layers, ffn_dim, out_channels,
+        text_embed_dim, text_seq_len, adaln_lora_dim, patch_size,
+        rope_axes_dim, rope_scale, rope_theta, eps:
+            Architecture constants. Defaults match the 14B Video2World variant.
+        vae_scale_spatial, vae_scale_temporal: Wan-AI VAE compression ratios
+            (8x spatial, 4x temporal). Used to derive latent dimensions.
+        verbose: TRT builder verbose log level.
+
+    Returns:
+        Serialized TRT engine plan as ``bytes``.
+    """
+    if num_heads * head_dim != hidden_size:
+        raise ValueError(
+            f"hidden_size={hidden_size} must equal num_heads*head_dim "
+            f"({num_heads}*{head_dim}={num_heads * head_dim})")
+    if sum(rope_axes_dim) != head_dim:
+        raise ValueError(
+            f"sum(rope_axes_dim)={sum(rope_axes_dim)} must equal head_dim "
+            f"({head_dim}); got {rope_axes_dim}")
+    pt, ph, pw = patch_size
+
+    # Latent dims after VAE encode.
+    t_lat = (video_num_frames - 1) // vae_scale_temporal + 1
+    h_lat = video_height // vae_scale_spatial
+    w_lat = video_width // vae_scale_spatial
+    if t_lat % pt != 0 or h_lat % ph != 0 or w_lat % pw != 0:
+        raise ValueError(
+            f"Latent dims (t={t_lat}, h={h_lat}, w={w_lat}) must be divisible "
+            f"by patch_size {patch_size}")
+    t_patches = t_lat // pt
+    h_patches = h_lat // ph
+    w_patches = w_lat // pw
+    num_patches = t_patches * h_patches * w_patches
+    patch_dim = out_channels * pt * ph * pw
+
+    # --- Build the TRT network skeleton ---
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    # --- Inputs ---
+    hidden_inp = network.add_input(
+        "hidden_states", trt.float32, (num_patches, hidden_size))
+    encoder_hidden_inp = network.add_input(
+        "encoder_hidden_states", trt.float32, (text_seq_len, text_embed_dim))
+    temb_inp = network.add_input(
+        "temb", trt.float32, (1, hidden_size))
+    embedded_timestep_inp = network.add_input(
+        "embedded_timestep", trt.float32, (1, hidden_size))
+
+    # --- Constants ---
+    eps_t = graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+
+    # 3-axis RoPE tables, precomputed once and baked as constants.
+    cos_full, sin_full = _build_3axis_rope_tables(
+        t_patches=t_patches,
+        h_patches=h_patches,
+        w_patches=w_patches,
+        axes_dim=rope_axes_dim,
+        rope_scale=rope_scale,
+        rope_theta=rope_theta,
+    )
+    cos_const = graph_ops.add_constant(
+        network, (1, num_patches, head_dim // 2),
+        cos_full.reshape(1, num_patches, head_dim // 2))
+    sin_const = graph_ops.add_constant(
+        network, (1, num_patches, head_dim // 2),
+        sin_full.reshape(1, num_patches, head_dim // 2))
+
+    # Pre-activate temb / embedded_timestep with SiLU.
+    temb_silu = _silu_2d(network, temb_inp)
+    embedded_silu = _silu_2d(network, embedded_timestep_inp)
+
+    hidden = hidden_inp
+
+    # --- Per-block forward ---
+    for layer_idx in range(num_layers):
+        bw = _block_weights_or_none(weights, layer_idx)
+        prefix = f"transformer_blocks.{layer_idx}"
+
+        # === 1. Self-attention with AdaLN-Zero (norm1) ===
+        h1, gate1 = _adaln_zero(
+            network, hidden, temb_silu, embedded_silu,
+            hidden_size=hidden_size,
+            adaln_lora_dim=adaln_lora_dim,
+            eps_tensor=eps_t,
+            w_l1=bw["norm1.linear_1.weight"], b_l1=bw["norm1.linear_1.bias"],
+            w_l2=bw["norm1.linear_2.weight"], b_l2=bw["norm1.linear_2.bias"],
+            w_l3=bw["norm1.linear_3.weight"], b_l3=bw["norm1.linear_3.bias"],
+        )
+        # Q/K/V projections (no biases).
+        q = graph_ops.add_matmul_rhs_constant(
+            network, h1, hidden_size, hidden_size, bw["attn1.to_q.weight"])
+        k = graph_ops.add_matmul_rhs_constant(
+            network, h1, hidden_size, hidden_size, bw["attn1.to_k.weight"])
+        v = graph_ops.add_matmul_rhs_constant(
+            network, h1, hidden_size, hidden_size, bw["attn1.to_v.weight"])
+        # Per-head RMSNorm on Q and K.
+        nq = bw["attn1.norm_q.weight"]
+        if nq is not None:
+            q = graph_ops.add_rms_norm_per_head(
+                network, q, num_heads, head_dim, nq, eps_t,
+                sequence_length=num_patches)
+        nk = bw["attn1.norm_k.weight"]
+        if nk is not None:
+            k = graph_ops.add_rms_norm_per_head(
+                network, k, num_heads, head_dim, nk, eps_t,
+                sequence_length=num_patches)
+        # 3-axis RoPE on Q and K.
+        q = _apply_rope_3axis(
+            network, q,
+            num_heads=num_heads, head_dim=head_dim,
+            num_patches=num_patches,
+            cos_3d=cos_const, sin_3d=sin_const)
+        k = _apply_rope_3axis(
+            network, k,
+            num_heads=num_heads, head_dim=head_dim,
+            num_patches=num_patches,
+            cos_3d=cos_const, sin_3d=sin_const)
+        ctx = graph_ops.add_attention_from_rows(
+            network, q, k, v,
+            num_heads=num_heads, head_dim=head_dim,
+            q_seq=num_patches, kv_seq=num_patches,
+            tag=f"{prefix}.attn1")
+        attn_out = graph_ops.add_matmul_rhs_constant(
+            network, ctx, hidden_size, hidden_size,
+            bw["attn1.to_out.0.weight"])
+        gated = network.add_elementwise(
+            attn_out, gate1, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden = network.add_elementwise(
+            hidden, gated, trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === 2. Cross-attention with AdaLN-Zero (norm2) ===
+        h2, gate2 = _adaln_zero(
+            network, hidden, temb_silu, embedded_silu,
+            hidden_size=hidden_size,
+            adaln_lora_dim=adaln_lora_dim,
+            eps_tensor=eps_t,
+            w_l1=bw["norm2.linear_1.weight"], b_l1=bw["norm2.linear_1.bias"],
+            w_l2=bw["norm2.linear_2.weight"], b_l2=bw["norm2.linear_2.bias"],
+            w_l3=bw["norm2.linear_3.weight"], b_l3=bw["norm2.linear_3.bias"],
+        )
+        cq = graph_ops.add_matmul_rhs_constant(
+            network, h2, hidden_size, hidden_size, bw["attn2.to_q.weight"])
+        ck = graph_ops.add_matmul_rhs_constant(
+            network, encoder_hidden_inp, text_embed_dim, hidden_size,
+            bw["attn2.to_k.weight"])
+        cv = graph_ops.add_matmul_rhs_constant(
+            network, encoder_hidden_inp, text_embed_dim, hidden_size,
+            bw["attn2.to_v.weight"])
+        nq2 = bw["attn2.norm_q.weight"]
+        if nq2 is not None:
+            cq = graph_ops.add_rms_norm_per_head(
+                network, cq, num_heads, head_dim, nq2, eps_t,
+                sequence_length=num_patches)
+        cross_ctx = graph_ops.add_attention_from_rows(
+            network, cq, ck, cv,
+            num_heads=num_heads, head_dim=head_dim,
+            q_seq=num_patches, kv_seq=text_seq_len,
+            tag=f"{prefix}.attn2")
+        cross_out = graph_ops.add_matmul_rhs_constant(
+            network, cross_ctx, hidden_size, hidden_size,
+            bw["attn2.to_out.0.weight"])
+        gated2 = network.add_elementwise(
+            cross_out, gate2, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden = network.add_elementwise(
+            hidden, gated2, trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === 3. FFN with AdaLN-Zero (norm3) ===
+        h3, gate3 = _adaln_zero(
+            network, hidden, temb_silu, embedded_silu,
+            hidden_size=hidden_size,
+            adaln_lora_dim=adaln_lora_dim,
+            eps_tensor=eps_t,
+            w_l1=bw["norm3.linear_1.weight"], b_l1=bw["norm3.linear_1.bias"],
+            w_l2=bw["norm3.linear_2.weight"], b_l2=bw["norm3.linear_2.bias"],
+            w_l3=bw["norm3.linear_3.weight"], b_l3=bw["norm3.linear_3.bias"],
+        )
+        ffn_h = graph_ops.add_matmul_rhs_constant(
+            network, h3, hidden_size, ffn_dim, bw["ff.net.0.proj.weight"])
+        if bw["ff.net.0.proj.bias"] is not None:
+            ffn_h = graph_ops.add_bias_sum(
+                network, ffn_h, ffn_dim, bw["ff.net.0.proj.bias"])
+        # gelu_pytorch_tanh = tanh-approximation GELU.
+        ffn_h = graph_ops.add_gelu_new(network, ffn_h)
+        ffn_h = graph_ops.add_matmul_rhs_constant(
+            network, ffn_h, ffn_dim, hidden_size, bw["ff.net.2.weight"])
+        if bw["ff.net.2.bias"] is not None:
+            ffn_h = graph_ops.add_bias_sum(
+                network, ffn_h, hidden_size, bw["ff.net.2.bias"])
+        gated3 = network.add_elementwise(
+            ffn_h, gate3, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden = network.add_elementwise(
+            hidden, gated3, trt.ElementWiseOperation.SUM).get_output(0)
+
+    # --- Final norm_out (2 chunks: shift, scale) + proj_out ---
+    h_final = _adaln_final(
+        network, hidden, temb_silu, embedded_silu,
+        hidden_size=hidden_size,
+        adaln_lora_dim=adaln_lora_dim,
+        eps_tensor=eps_t,
+        w_l1=weights["norm_out.linear_1.weight"],
+        b_l1=weights.get("norm_out.linear_1.bias"),
+        w_l2=weights["norm_out.linear_2.weight"],
+        b_l2=weights.get("norm_out.linear_2.bias"),
+        w_l3=weights["norm_out.linear_3.weight"],
+        b_l3=weights.get("norm_out.linear_3.bias"),
+    )
+    output = graph_ops.add_matmul_rhs_constant(
+        network, h_final, hidden_size, patch_dim,
+        weights["proj_out.weight"])
+    proj_b = weights.get("proj_out.bias")
+    if proj_b is not None:
+        output = graph_ops.add_bias_sum(network, output, patch_dim, proj_b)
+
+    # Mark output (fp32 by contract).
+    out_cast = network.add_cast(output, trt.float32).get_output(0)
+    out_cast.name = "noise_pred"
+    network.mark_output(out_cast)
+
+    print(
+        f"[cosmos-dit] Building TRT engine (hidden={hidden_size}, "
+        f"layers={num_layers}, num_patches={num_patches}, "
+        f"t_lat={t_lat}, h_lat={h_lat}, w_lat={w_lat}, "
+        f"axes_dim={rope_axes_dim}, rope_scale={rope_scale}) ...",
+        file=sys.stderr,
+    )
+    plan = builder.build_serialized_network(network, config)
+    if plan is None:
+        raise RuntimeError("TRT engine serialization failed for Cosmos DiT")
+    return bytes(plan)
+
+
+# ---------------------------------------------------------------------------
+# Weight loading
+# ---------------------------------------------------------------------------
+
+
+def load_cosmos_dit_weights(
+    model_dir: str,
+    *,
+    hidden_size: int = COSMOS_14B_HIDDEN_SIZE,
+    num_heads: int = COSMOS_14B_NUM_HEADS,
+    head_dim: int = COSMOS_14B_HEAD_DIM,
+    num_layers: int = COSMOS_14B_NUM_LAYERS,
+    ffn_dim: int = COSMOS_14B_FFN_DIM,
+    text_embed_dim: int = COSMOS_14B_TEXT_EMBED_DIM,
+    adaln_lora_dim: int = COSMOS_14B_ADALN_LORA_DIM,
+    out_channels: int = COSMOS_14B_OUT_CHANNELS,
+    in_channels: int = COSMOS_14B_IN_CHANNELS,
+    patch_size: tuple[int, int, int] = COSMOS_14B_PATCH_SIZE,
+) -> "WeightDict":
+    """Load ``CosmosTransformer3DModel`` weights from the diffusers
+    ``transformer/`` sub-directory of a Cosmos-Predict2 checkpoint.
+
+    Walks the safetensors shards via the shared
+    :func:`checkpoint_mapper._open_safetensors` helper. All projection
+    weights are transposed at load time so the engine builder can use the
+    plain ``x @ W`` form (``W`` in ``[in_dim, out_dim]`` order). Norm / RMS
+    weights are returned as flat 1-D arrays.
+
+    Args:
+        model_dir: Path to the ``transformer/`` directory inside the
+            diffusers checkpoint snapshot.
+        hidden_size, num_heads, head_dim, num_layers, ffn_dim, text_embed_dim,
+        adaln_lora_dim, out_channels, in_channels, patch_size:
+            Architecture constants used to choose which tensors to load.
+            Tensors that are absent from the safetensors index but referenced
+            by the builder will raise ``KeyError`` here -- the builder also
+            tolerates ``None`` for optional biases / norm-q-only attentions.
+
+    Returns:
+        A :class:`WeightDict` keyed by the names the builder expects.
+    """
+    from ...checkpoint_mapper import (
+        WeightDict, _open_safetensors, _load_tensor, _has_tensor)
+
+    model_path = Path(model_dir)
+    readers = _open_safetensors(model_path)
+    weights = WeightDict()
+
+    def _t(name: str) -> np.ndarray:
+        """Load a 2-D weight and transpose ``[out, in] -> [in, out]``."""
+        w = _load_tensor(readers, name)
+        if w.ndim != 2:
+            raise ValueError(
+                f"Expected 2-D weight for {name!r}, got shape {w.shape}")
+        return np.ascontiguousarray(w.T, dtype=np.float32)
+
+    def _f(name: str) -> np.ndarray:
+        """Load a flat (1-D) tensor as fp32."""
+        return _load_tensor(readers, name).astype(np.float32)
+
+    def _maybe_t(name: str) -> np.ndarray | None:
+        return _t(name) if _has_tensor(readers, name) else None
+
+    def _maybe_f(name: str) -> np.ndarray | None:
+        return _f(name) if _has_tensor(readers, name) else None
+
+    # ---- per-block --------------------------------------------------------
+    for i in range(num_layers):
+        p = f"transformer_blocks.{i}"
+        for nm in ("norm1", "norm2", "norm3"):
+            weights[f"{p}.{nm}.linear_1.weight"] = _t(f"{p}.{nm}.linear_1.weight")
+            weights[f"{p}.{nm}.linear_2.weight"] = _t(f"{p}.{nm}.linear_2.weight")
+            weights[f"{p}.{nm}.linear_3.weight"] = _t(f"{p}.{nm}.linear_3.weight")
+            b = _maybe_f(f"{p}.{nm}.linear_1.bias")
+            if b is not None:
+                weights[f"{p}.{nm}.linear_1.bias"] = b
+            b = _maybe_f(f"{p}.{nm}.linear_2.bias")
+            if b is not None:
+                weights[f"{p}.{nm}.linear_2.bias"] = b
+            b = _maybe_f(f"{p}.{nm}.linear_3.bias")
+            if b is not None:
+                weights[f"{p}.{nm}.linear_3.bias"] = b
+        # Self-attention.
+        weights[f"{p}.attn1.to_q.weight"] = _t(f"{p}.attn1.to_q.weight")
+        weights[f"{p}.attn1.to_k.weight"] = _t(f"{p}.attn1.to_k.weight")
+        weights[f"{p}.attn1.to_v.weight"] = _t(f"{p}.attn1.to_v.weight")
+        weights[f"{p}.attn1.to_out.0.weight"] = _t(f"{p}.attn1.to_out.0.weight")
+        nq = _maybe_f(f"{p}.attn1.norm_q.weight")
+        if nq is not None:
+            weights[f"{p}.attn1.norm_q.weight"] = nq
+        nk = _maybe_f(f"{p}.attn1.norm_k.weight")
+        if nk is not None:
+            weights[f"{p}.attn1.norm_k.weight"] = nk
+        # Cross-attention.
+        weights[f"{p}.attn2.to_q.weight"] = _t(f"{p}.attn2.to_q.weight")
+        weights[f"{p}.attn2.to_k.weight"] = _t(f"{p}.attn2.to_k.weight")
+        weights[f"{p}.attn2.to_v.weight"] = _t(f"{p}.attn2.to_v.weight")
+        weights[f"{p}.attn2.to_out.0.weight"] = _t(f"{p}.attn2.to_out.0.weight")
+        nq2 = _maybe_f(f"{p}.attn2.norm_q.weight")
+        if nq2 is not None:
+            weights[f"{p}.attn2.norm_q.weight"] = nq2
+        # FFN (gelu_pytorch_tanh).
+        weights[f"{p}.ff.net.0.proj.weight"] = _t(f"{p}.ff.net.0.proj.weight")
+        weights[f"{p}.ff.net.2.weight"] = _t(f"{p}.ff.net.2.weight")
+        b = _maybe_f(f"{p}.ff.net.0.proj.bias")
+        if b is not None:
+            weights[f"{p}.ff.net.0.proj.bias"] = b
+        b = _maybe_f(f"{p}.ff.net.2.bias")
+        if b is not None:
+            weights[f"{p}.ff.net.2.bias"] = b
+
+    # ---- final norm_out + proj_out ---------------------------------------
+    weights["norm_out.linear_1.weight"] = _t("norm_out.linear_1.weight")
+    weights["norm_out.linear_2.weight"] = _t("norm_out.linear_2.weight")
+    weights["norm_out.linear_3.weight"] = _t("norm_out.linear_3.weight")
+    b = _maybe_f("norm_out.linear_1.bias")
+    if b is not None:
+        weights["norm_out.linear_1.bias"] = b
+    b = _maybe_f("norm_out.linear_2.bias")
+    if b is not None:
+        weights["norm_out.linear_2.bias"] = b
+    b = _maybe_f("norm_out.linear_3.bias")
+    if b is not None:
+        weights["norm_out.linear_3.bias"] = b
+
+    weights["proj_out.weight"] = _t("proj_out.weight")
+    b = _maybe_f("proj_out.bias")
+    if b is not None:
+        weights["proj_out.bias"] = b
+
+    # ---- patch_embed + time_embed (loaded but consumed externally) -------
+    # The patch embedding is a Linear(in_channels * pt*ph*pw, hidden_size) in
+    # the diffusers reference. The C++ preprocessor / Python runner applies
+    # this before the engine runs, so we expose the raw weights for callers
+    # that need them (matches the Wan T2V plugin's preprocessor_weights
+    # contract).
+    if _has_tensor(readers, "patch_embed.proj.weight"):
+        weights["patch_embed.proj.weight"] = _load_tensor(
+            readers, "patch_embed.proj.weight").astype(np.float32)
+    if _has_tensor(readers, "patch_embed.proj.bias"):
+        weights["patch_embed.proj.bias"] = _load_tensor(
+            readers, "patch_embed.proj.bias").astype(np.float32)
+
+    # Time embedding (sinusoidal + 2x MLP). Two MLPs: `timesteps_proj`
+    # produces the per-block ``temb``, and ``t_embedder`` produces the
+    # ``embedded_timestep`` residual. Layout in the safetensors is the
+    # diffusers default ``linear_1`` / ``linear_2`` naming.
+    for prefix in ("time_embed.timesteps_proj", "time_embed.t_embedder"):
+        for sub in ("linear_1", "linear_2"):
+            wk = f"{prefix}.{sub}.weight"
+            bk = f"{prefix}.{sub}.bias"
+            if _has_tensor(readers, wk):
+                weights[wk] = _load_tensor(readers, wk).astype(np.float32)
+            if _has_tensor(readers, bk):
+                weights[bk] = _load_tensor(readers, bk).astype(np.float32)
+    # Optional RMSNorm on the temb output (some diffusers variants apply
+    # a small norm; if absent the caller treats it as identity).
+    if _has_tensor(readers, "time_embed.norm.weight"):
+        weights["time_embed.norm.weight"] = _load_tensor(
+            readers, "time_embed.norm.weight").astype(np.float32)
+
+    return weights

--- a/python/tensorrt_model_connect/families/cosmos_predict/cosmos_dit_builder.py
+++ b/python/tensorrt_model_connect/families/cosmos_predict/cosmos_dit_builder.py
@@ -342,7 +342,6 @@ def _rope_table_axis(
                           dtype=np.float32),
                 np.zeros((max(num_positions, 1), max(axis_dim // 2, 1)),
                           dtype=np.float32))
-    half = axis_dim // 2
     # inv_freq[j] = 1 / theta ** (2j / axis_dim)  for j in [0, half)
     inv_freq = 1.0 / (
         rope_theta ** (np.arange(0, axis_dim, 2, dtype=np.float64) / axis_dim))

--- a/python/tensorrt_model_connect/families/cosmos_predict/cosmos_dit_ring_builder.py
+++ b/python/tensorrt_model_connect/families/cosmos_predict/cosmos_dit_ring_builder.py
@@ -1,0 +1,531 @@
+"""Cosmos-Predict2 14B DiT engine builder — RingAttention sequence-parallel variant.
+
+Sequence-parallel ``cp_size``-way layout. The patch sequence (``num_patches``)
+is sharded across ``cp_size`` ranks; each rank holds ``num_patches // cp_size``
+patches *and all 40 attention heads*. Replicated inputs (text/T5 encoder
+output, ``temb``, ``embedded_timestep``) remain unsharded.
+
+Ring strategy implemented here
+-------------------------------
+
+The classic RingAttention formulation steps K/V around a ring of ``cp_size``
+ranks and accumulates an online stable-softmax over ``cp_size`` partial
+attention computations. Expressing the online-softmax accumulator as a
+*static* TRT graph (running max ``m``, running denominator ``l``,
+exp-rebalancing of the running numerator at every step) is doable in principle
+but requires reimplementing the attention kernel in low-level elementwise /
+reduction ops — TRT's fused ``IFusedMHA`` / ``add_attention_from_rows`` only
+exposes a single softmax over the full K dimension and cannot be split.
+
+This builder therefore implements the **simplified one-pass Ring**:
+
+  1. Q is computed and kept *local* (sharded along seq).
+  2. K and V are computed locally, RMSNorm'd, and have **per-rank RoPE**
+     baked in (each rank's local position table covers its own chunk of the
+     global ``num_patches``). After RoPE, K and V are ``AllGather``-ed along
+     the sequence axis so every rank ends up with the full
+     ``[num_patches, hidden]`` K and V.
+  3. A single full-sequence attention is run with ``q_seq=num_patches/cp_size``
+     and ``kv_seq=num_patches`` — i.e. each rank attends its local Q rows
+     against the gathered K/V. The output is naturally seq-sharded.
+
+That is *one-shot* gathering rather than ``cp_size`` ring rotations, so it is
+mathematically identical to the dense self-attention (and to the
+``AllGather-KV`` variant) — modulo the SP I/O reshape. The framing remains
+"Ring" because:
+
+  * the per-rank state (local Q, local K, local V before gather) and ring
+    topology are preserved;
+  * a real online-softmax loop with ``cp_size - 1`` ``add_all_to_all`` /
+    P2P-rotate steps is a drop-in upgrade against this scaffolding (replace
+    the AllGather + single attention call with the unrolled accumulator).
+
+Cross-attention is unchanged: Q is seq-sharded; K/V are projected from the
+replicated text encoder output (already full sequence).
+
+At ``cp_size == 1`` the ``add_all_gather`` calls in
+``parallel_config`` pass tensors through unchanged, so the engine is
+bit-identical to ``cosmos_dit_builder.build_cosmos_dit_engine`` (modulo TRT
+layer naming).
+
+Constraints
+-----------
+
+* ``num_patches % cp_size == 0`` — checked in
+  :func:`build_cosmos_dit_ring_engine`.
+* All ranks share the same global ``num_patches``; per-rank position offsets
+  for RoPE are computed from ``parallel_config.rank``.
+"""
+
+from __future__ import annotations
+
+import ast as _ast  # imported only for the bottom-of-file ast.parse self-check
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import (
+    ParallelConfig,
+    add_all_gather,
+    normalize_parallel_config,
+)
+
+# Re-export the dense weight loader so callers can use a single import.
+from .cosmos_dit_builder import (  # noqa: F401  (re-exported for plugin users)
+    COSMOS_14B_ADALN_LORA_DIM,
+    COSMOS_14B_FFN_DIM,
+    COSMOS_14B_HEAD_DIM,
+    COSMOS_14B_HIDDEN_SIZE,
+    COSMOS_14B_IN_CHANNELS,
+    COSMOS_14B_MAX_SIZE,
+    COSMOS_14B_NORM_EPS,
+    COSMOS_14B_NUM_HEADS,
+    COSMOS_14B_NUM_LAYERS,
+    COSMOS_14B_OUT_CHANNELS,
+    COSMOS_14B_PATCH_SIZE,
+    COSMOS_14B_ROPE_AXES_DIM,
+    COSMOS_14B_ROPE_SCALE,
+    COSMOS_14B_ROPE_THETA,
+    COSMOS_14B_TEXT_EMBED_DIM,
+    COSMOS_14B_TEXT_SEQ_LEN,
+    COSMOS_14B_VAE_SCALE_SPATIAL,
+    COSMOS_14B_VAE_SCALE_TEMPORAL,
+    _adaln_final,
+    _adaln_zero,
+    _block_weights_or_none,
+    _build_3axis_rope_tables,
+    _silu_2d,
+    load_cosmos_dit_weights,
+)
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+
+
+# ---------------------------------------------------------------------------
+# Per-rank RoPE table slicing
+# ---------------------------------------------------------------------------
+
+
+def _build_per_rank_rope_tables(
+    *,
+    t_patches: int,
+    h_patches: int,
+    w_patches: int,
+    axes_dim: tuple[int, int, int],
+    rope_scale: tuple[float, float, float],
+    rope_theta: float,
+    cp_size: int,
+    rank: int,
+) -> tuple[np.ndarray, np.ndarray, int]:
+    """Build the cos/sin tables covering just this rank's chunk of patches.
+
+    Returns ``(cos_local, sin_local, local_num_patches)`` where the tables
+    have shape ``[local_num_patches, head_dim // 2]``. The slicing is a
+    straightforward sequence-axis split of the full 3-axis RoPE table built
+    by :func:`_build_3axis_rope_tables`: rank ``r`` gets rows
+    ``[r * local : (r + 1) * local]`` of the flattened
+    ``[T*H*W, head_dim/2]`` cache.
+    """
+    cos_full, sin_full = _build_3axis_rope_tables(
+        t_patches=t_patches,
+        h_patches=h_patches,
+        w_patches=w_patches,
+        axes_dim=axes_dim,
+        rope_scale=rope_scale,
+        rope_theta=rope_theta,
+    )
+    num_patches = t_patches * h_patches * w_patches
+    if num_patches % cp_size != 0:
+        raise ValueError(
+            f"num_patches={num_patches} must be divisible by cp_size={cp_size}"
+        )
+    local = num_patches // cp_size
+    start = rank * local
+    stop = start + local
+    cos_local = np.ascontiguousarray(cos_full[start:stop, :])
+    sin_local = np.ascontiguousarray(sin_full[start:stop, :])
+    return cos_local, sin_local, local
+
+
+def _apply_rope_local(
+    network: "trt.INetworkDefinition",
+    x: "trt.ITensor",
+    *,
+    num_heads: int,
+    head_dim: int,
+    local_num_patches: int,
+    cos_local: "trt.ITensor",
+    sin_local: "trt.ITensor",
+) -> "trt.ITensor":
+    """Apply rotate-half RoPE to a [local_num_patches, H*D] tensor.
+
+    Same wrapper as the dense :func:`_apply_rope_3axis` but sized for the
+    per-rank chunk. The 3-axis layout is encoded in the *table contents*
+    (sliced from the full 3-axis cache), not the math.
+    """
+    return graph_ops.add_apply_rope_native_sequence(
+        network,
+        x,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        cos_cache_3d=cos_local,
+        sin_cache_3d=sin_local,
+        rotary_embedding_dim=head_dim,
+        interleaved=False,
+        sequence_length=local_num_patches,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Engine builder
+# ---------------------------------------------------------------------------
+
+
+def build_cosmos_dit_ring_engine(
+    config,
+    weights: "WeightDict",
+    *,
+    video_height: int,
+    video_width: int,
+    video_num_frames: int,
+    precision: str = "fp16",
+    verbose: bool = False,
+    parallel_config: ParallelConfig,
+    hidden_size: int = COSMOS_14B_HIDDEN_SIZE,
+    num_heads: int = COSMOS_14B_NUM_HEADS,
+    head_dim: int = COSMOS_14B_HEAD_DIM,
+    num_layers: int = COSMOS_14B_NUM_LAYERS,
+    ffn_dim: int = COSMOS_14B_FFN_DIM,
+    out_channels: int = COSMOS_14B_OUT_CHANNELS,
+    text_embed_dim: int = COSMOS_14B_TEXT_EMBED_DIM,
+    text_seq_len: int = COSMOS_14B_TEXT_SEQ_LEN,
+    adaln_lora_dim: int = COSMOS_14B_ADALN_LORA_DIM,
+    patch_size: tuple[int, int, int] = COSMOS_14B_PATCH_SIZE,
+    rope_axes_dim: tuple[int, int, int] = COSMOS_14B_ROPE_AXES_DIM,
+    rope_scale: tuple[float, float, float] = COSMOS_14B_ROPE_SCALE,
+    rope_theta: float = COSMOS_14B_ROPE_THETA,
+    eps: float = COSMOS_14B_NORM_EPS,
+    vae_scale_spatial: int = COSMOS_14B_VAE_SCALE_SPATIAL,
+    vae_scale_temporal: int = COSMOS_14B_VAE_SCALE_TEMPORAL,
+) -> bytes:
+    """Build the Cosmos-Predict2 14B DiT denoiser TRT engine for one Ring rank.
+
+    Args:
+        config: Family-level model config (unused inside the builder but
+            preserved for plugin parity with the dense entry point).
+        weights: Output of
+            :func:`cosmos_dit_builder.load_cosmos_dit_weights`. Weights are
+            replicated across ranks — RingAttention shards activations
+            (the sequence dimension), not parameters.
+        video_height, video_width, video_num_frames: Pixel-space target.
+        precision: Reserved for future fp16/bf16 selection. The current
+            implementation matches the dense builder and runs the whole
+            graph in fp32 (TRT may still pick a lower-precision tactic for
+            individual ops).
+        verbose: TRT verbose logger.
+        parallel_config: SP layout. Must have ``mode='sp_ring'``,
+            ``cp_size > 1``, and a concrete non-negative ``rank``.
+        ... (all other kwargs): architecture constants. Defaults match
+            Cosmos-Predict2 14B Video2World.
+
+    Returns:
+        Serialized TRT engine ``bytes`` for ``parallel_config.rank``.
+    """
+    parallel = normalize_parallel_config(parallel_config)
+    parallel.validate()
+    if parallel.mode != "sp_ring":
+        raise ValueError(
+            f"build_cosmos_dit_ring_engine requires mode='sp_ring', "
+            f"got mode={parallel.mode!r}")
+    if parallel.cp_size <= 1:
+        raise ValueError(
+            f"build_cosmos_dit_ring_engine requires cp_size > 1, "
+            f"got cp_size={parallel.cp_size}")
+    if parallel.rank < 0:
+        raise ValueError(
+            "build_cosmos_dit_ring_engine requires a concrete non-negative rank")
+    cp_size = int(parallel.cp_size)
+    rank = int(parallel.rank)
+
+    if num_heads * head_dim != hidden_size:
+        raise ValueError(
+            f"hidden_size={hidden_size} must equal num_heads*head_dim "
+            f"({num_heads}*{head_dim}={num_heads * head_dim})")
+    if sum(rope_axes_dim) != head_dim:
+        raise ValueError(
+            f"sum(rope_axes_dim)={sum(rope_axes_dim)} must equal head_dim "
+            f"({head_dim}); got {rope_axes_dim}")
+    pt, ph, pw = patch_size
+
+    # Latent dims after VAE encode.
+    t_lat = (video_num_frames - 1) // vae_scale_temporal + 1
+    h_lat = video_height // vae_scale_spatial
+    w_lat = video_width // vae_scale_spatial
+    if t_lat % pt != 0 or h_lat % ph != 0 or w_lat % pw != 0:
+        raise ValueError(
+            f"Latent dims (t={t_lat}, h={h_lat}, w={w_lat}) must be divisible "
+            f"by patch_size {patch_size}")
+    t_patches = t_lat // pt
+    h_patches = h_lat // ph
+    w_patches = w_lat // pw
+    num_patches = t_patches * h_patches * w_patches
+    patch_dim = out_channels * pt * ph * pw
+
+    if num_patches % cp_size != 0:
+        raise ValueError(
+            f"Ring SP requires num_patches ({num_patches}) divisible by "
+            f"cp_size ({cp_size})")
+    local_num_patches = num_patches // cp_size
+    if rank >= cp_size:
+        raise ValueError(
+            f"rank={rank} must be < cp_size={cp_size}")
+
+    # --- Build the TRT network skeleton ---
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    config_trt = builder.create_builder_config()
+    config_trt.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    # --- Inputs (per-rank seq-sharded hidden, replicated everything else) ---
+    hidden_inp = network.add_input(
+        "hidden_states", trt.float32, (local_num_patches, hidden_size))
+    encoder_hidden_inp = network.add_input(
+        "encoder_hidden_states", trt.float32, (text_seq_len, text_embed_dim))
+    temb_inp = network.add_input(
+        "temb", trt.float32, (1, hidden_size))
+    embedded_timestep_inp = network.add_input(
+        "embedded_timestep", trt.float32, (1, hidden_size))
+
+    # --- Constants ---
+    eps_t = graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+
+    # Per-rank 3-axis RoPE tables (sliced from the full [num_patches, hd/2]
+    # cache so each rank's tables cover [rank * L, (rank+1) * L)).
+    cos_local_np, sin_local_np, _ = _build_per_rank_rope_tables(
+        t_patches=t_patches,
+        h_patches=h_patches,
+        w_patches=w_patches,
+        axes_dim=rope_axes_dim,
+        rope_scale=rope_scale,
+        rope_theta=rope_theta,
+        cp_size=cp_size,
+        rank=rank,
+    )
+    cos_const = graph_ops.add_constant(
+        network, (1, local_num_patches, head_dim // 2),
+        cos_local_np.reshape(1, local_num_patches, head_dim // 2))
+    sin_const = graph_ops.add_constant(
+        network, (1, local_num_patches, head_dim // 2),
+        sin_local_np.reshape(1, local_num_patches, head_dim // 2))
+
+    # Pre-activate temb / embedded_timestep with SiLU.
+    temb_silu = _silu_2d(network, temb_inp)
+    embedded_silu = _silu_2d(network, embedded_timestep_inp)
+
+    hidden = hidden_inp
+
+    # --- Per-block forward ---
+    for layer_idx in range(num_layers):
+        bw = _block_weights_or_none(weights, layer_idx)
+        prefix = f"transformer_blocks.{layer_idx}"
+
+        # === 1. Self-attention with AdaLN-Zero (norm1) — Ring SP path ===
+        h1, gate1 = _adaln_zero(
+            network, hidden, temb_silu, embedded_silu,
+            hidden_size=hidden_size,
+            adaln_lora_dim=adaln_lora_dim,
+            eps_tensor=eps_t,
+            w_l1=bw["norm1.linear_1.weight"], b_l1=bw["norm1.linear_1.bias"],
+            w_l2=bw["norm1.linear_2.weight"], b_l2=bw["norm1.linear_2.bias"],
+            w_l3=bw["norm1.linear_3.weight"], b_l3=bw["norm1.linear_3.bias"],
+        )
+        # Q/K/V projections (no biases). Inputs are seq-sharded; all-heads
+        # are retained per rank.
+        q = graph_ops.add_matmul_rhs_constant(
+            network, h1, hidden_size, hidden_size, bw["attn1.to_q.weight"])
+        k = graph_ops.add_matmul_rhs_constant(
+            network, h1, hidden_size, hidden_size, bw["attn1.to_k.weight"])
+        v = graph_ops.add_matmul_rhs_constant(
+            network, h1, hidden_size, hidden_size, bw["attn1.to_v.weight"])
+
+        # Per-head RMSNorm on Q and K (sequence length is the local shard).
+        nq = bw["attn1.norm_q.weight"]
+        if nq is not None:
+            q = graph_ops.add_rms_norm_per_head(
+                network, q, num_heads, head_dim, nq, eps_t,
+                sequence_length=local_num_patches)
+        nk = bw["attn1.norm_k.weight"]
+        if nk is not None:
+            k = graph_ops.add_rms_norm_per_head(
+                network, k, num_heads, head_dim, nk, eps_t,
+                sequence_length=local_num_patches)
+
+        # 3-axis RoPE on Q and K — applied *before* the K/V AllGather so the
+        # gathered K already carries the correct global positional encoding
+        # (each rank's cos/sin table targets its own slice of positions).
+        q = _apply_rope_local(
+            network, q,
+            num_heads=num_heads, head_dim=head_dim,
+            local_num_patches=local_num_patches,
+            cos_local=cos_const, sin_local=sin_const)
+        k = _apply_rope_local(
+            network, k,
+            num_heads=num_heads, head_dim=head_dim,
+            local_num_patches=local_num_patches,
+            cos_local=cos_const, sin_local=sin_const)
+
+        # --- Ring "one-shot gather" step ---
+        # AllGather K and V along the sequence axis (axis=0) so every rank
+        # ends up with the full [num_patches, hidden] K / V. This is the
+        # simplified Ring described in the module docstring; the unrolled
+        # cp_size-step online-softmax loop is a future optimization.
+        k_full = add_all_gather(network, k, cp_size, gather_axis=0)
+        v_full = add_all_gather(network, v, cp_size, gather_axis=0)
+
+        # Local Q vs full K/V attention. q_seq is the local shard,
+        # kv_seq is the global num_patches — same call shape as a
+        # cross-attention but with a self-attention weight set.
+        ctx = graph_ops.add_attention_from_rows(
+            network, q, k_full, v_full,
+            num_heads=num_heads, head_dim=head_dim,
+            q_seq=local_num_patches, kv_seq=num_patches,
+            tag=f"{prefix}.attn1.ring")
+        attn_out = graph_ops.add_matmul_rhs_constant(
+            network, ctx, hidden_size, hidden_size,
+            bw["attn1.to_out.0.weight"])
+        gated = network.add_elementwise(
+            attn_out, gate1, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden = network.add_elementwise(
+            hidden, gated, trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === 2. Cross-attention with AdaLN-Zero (norm2) — unchanged.
+        # Q is seq-sharded, K/V come from the replicated T5 encoder output,
+        # so this matches the dense block 1:1 with the only difference
+        # being the q_seq dimension.
+        h2, gate2 = _adaln_zero(
+            network, hidden, temb_silu, embedded_silu,
+            hidden_size=hidden_size,
+            adaln_lora_dim=adaln_lora_dim,
+            eps_tensor=eps_t,
+            w_l1=bw["norm2.linear_1.weight"], b_l1=bw["norm2.linear_1.bias"],
+            w_l2=bw["norm2.linear_2.weight"], b_l2=bw["norm2.linear_2.bias"],
+            w_l3=bw["norm2.linear_3.weight"], b_l3=bw["norm2.linear_3.bias"],
+        )
+        cq = graph_ops.add_matmul_rhs_constant(
+            network, h2, hidden_size, hidden_size, bw["attn2.to_q.weight"])
+        ck = graph_ops.add_matmul_rhs_constant(
+            network, encoder_hidden_inp, text_embed_dim, hidden_size,
+            bw["attn2.to_k.weight"])
+        cv = graph_ops.add_matmul_rhs_constant(
+            network, encoder_hidden_inp, text_embed_dim, hidden_size,
+            bw["attn2.to_v.weight"])
+        nq2 = bw["attn2.norm_q.weight"]
+        if nq2 is not None:
+            cq = graph_ops.add_rms_norm_per_head(
+                network, cq, num_heads, head_dim, nq2, eps_t,
+                sequence_length=local_num_patches)
+        cross_ctx = graph_ops.add_attention_from_rows(
+            network, cq, ck, cv,
+            num_heads=num_heads, head_dim=head_dim,
+            q_seq=local_num_patches, kv_seq=text_seq_len,
+            tag=f"{prefix}.attn2")
+        cross_out = graph_ops.add_matmul_rhs_constant(
+            network, cross_ctx, hidden_size, hidden_size,
+            bw["attn2.to_out.0.weight"])
+        gated2 = network.add_elementwise(
+            cross_out, gate2, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden = network.add_elementwise(
+            hidden, gated2, trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === 3. FFN with AdaLN-Zero (norm3) — pure elementwise / matmul,
+        # seq-sharded throughout (no collectives needed).
+        h3, gate3 = _adaln_zero(
+            network, hidden, temb_silu, embedded_silu,
+            hidden_size=hidden_size,
+            adaln_lora_dim=adaln_lora_dim,
+            eps_tensor=eps_t,
+            w_l1=bw["norm3.linear_1.weight"], b_l1=bw["norm3.linear_1.bias"],
+            w_l2=bw["norm3.linear_2.weight"], b_l2=bw["norm3.linear_2.bias"],
+            w_l3=bw["norm3.linear_3.weight"], b_l3=bw["norm3.linear_3.bias"],
+        )
+        ffn_h = graph_ops.add_matmul_rhs_constant(
+            network, h3, hidden_size, ffn_dim, bw["ff.net.0.proj.weight"])
+        if bw["ff.net.0.proj.bias"] is not None:
+            ffn_h = graph_ops.add_bias_sum(
+                network, ffn_h, ffn_dim, bw["ff.net.0.proj.bias"])
+        ffn_h = graph_ops.add_gelu_new(network, ffn_h)
+        ffn_h = graph_ops.add_matmul_rhs_constant(
+            network, ffn_h, ffn_dim, hidden_size, bw["ff.net.2.weight"])
+        if bw["ff.net.2.bias"] is not None:
+            ffn_h = graph_ops.add_bias_sum(
+                network, ffn_h, hidden_size, bw["ff.net.2.bias"])
+        gated3 = network.add_elementwise(
+            ffn_h, gate3, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden = network.add_elementwise(
+            hidden, gated3, trt.ElementWiseOperation.SUM).get_output(0)
+
+    # --- Final norm_out (2 chunks: shift, scale) + proj_out --- (seq-sharded)
+    h_final = _adaln_final(
+        network, hidden, temb_silu, embedded_silu,
+        hidden_size=hidden_size,
+        adaln_lora_dim=adaln_lora_dim,
+        eps_tensor=eps_t,
+        w_l1=weights["norm_out.linear_1.weight"],
+        b_l1=weights.get("norm_out.linear_1.bias"),
+        w_l2=weights["norm_out.linear_2.weight"],
+        b_l2=weights.get("norm_out.linear_2.bias"),
+        w_l3=weights["norm_out.linear_3.weight"],
+        b_l3=weights.get("norm_out.linear_3.bias"),
+    )
+    output = graph_ops.add_matmul_rhs_constant(
+        network, h_final, hidden_size, patch_dim,
+        weights["proj_out.weight"])
+    proj_b = weights.get("proj_out.bias")
+    if proj_b is not None:
+        output = graph_ops.add_bias_sum(network, output, patch_dim, proj_b)
+
+    # Mark output (fp32 by contract). Per-rank shape is
+    # [local_num_patches, patch_dim].
+    out_cast = network.add_cast(output, trt.float32).get_output(0)
+    out_cast.name = "noise_pred"
+    network.mark_output(out_cast)
+
+    print(
+        f"[cosmos-dit-ring] Building TRT engine "
+        f"(hidden={hidden_size}, layers={num_layers}, "
+        f"num_patches={num_patches}, local={local_num_patches}, "
+        f"cp_size={cp_size}, rank={rank}, "
+        f"t_lat={t_lat}, h_lat={h_lat}, w_lat={w_lat}) ...",
+        file=sys.stderr,
+    )
+    plan = builder.build_serialized_network(network, config_trt)
+    if plan is None:
+        raise RuntimeError(
+            f"TRT engine serialization failed for Cosmos DiT Ring rank={rank}")
+    return bytes(plan)
+
+
+# ---------------------------------------------------------------------------
+# Self-check: ast.parse must succeed on this file. Kept inline so callers
+# importing the module can detect syntax regressions early. ``_ast.parse``
+# is only run when the module is imported with ``__debug__`` enabled (the
+# default outside ``python -O``); it is a no-op otherwise.
+# ---------------------------------------------------------------------------
+
+if __debug__:
+    try:
+        _ast.parse(Path(__file__).read_text(encoding="utf-8"), filename=__file__)
+    except SyntaxError as _e:  # pragma: no cover — defensive, never expected.
+        raise SyntaxError(
+            f"cosmos_dit_ring_builder.py failed self ast.parse: {_e}") from _e

--- a/python/tensorrt_model_connect/families/cosmos_predict/cosmos_dit_ulysses_builder.py
+++ b/python/tensorrt_model_connect/families/cosmos_predict/cosmos_dit_ulysses_builder.py
@@ -1,0 +1,610 @@
+"""Cosmos-Predict2 14B Video2World DiT engine builder (DeepSpeed-Ulysses SP).
+
+Sequence-parallel variant of :mod:`cosmos_dit_builder`. Each rank holds
+``num_patches / cp_size`` patches but *all* attention heads. Inside every
+self-attention block we run two AllToAll collectives that redistribute the
+per-rank tensors from "all heads, local seq" to "local heads, all seq" and
+back, so the attention math itself is computed on the full sequence with a
+subset of heads. All other ops (norms, FFN, cross-attention, output head)
+operate on the seq-sharded tensor directly because:
+
+* The block-wise norms / modulation / FFN are pointwise along the sequence
+  axis, so they parallelize trivially across ``cp_size`` ranks.
+* Cross-attention queries are already seq-sharded; K/V come from
+  ``encoder_hidden_states`` which is replicated everywhere (T5 text embedding
+  is broadcast pre-engine).
+* The final norm_out + proj_out head is pointwise along the sequence axis.
+
+Per-rank engine I/O contract::
+
+    hidden_states         [num_patches / cp_size, hidden_size]            fp32
+    encoder_hidden_states [text_seq_len, text_embed_dim]                  fp32  (replicated)
+    temb                  [1, hidden_size]                                fp32  (replicated)
+    embedded_timestep     [1, hidden_size]                                fp32  (replicated)
+
+    noise_pred            [num_patches / cp_size, out_channels * pt*ph*pw] fp32
+
+The runner (Python wrapper / C++ host) is responsible for the final AllGather
+on ``noise_pred`` that reassembles the full denoised tensor before the
+unpatchify reshape.
+
+Validity constraints:
+
+* ``num_attention_heads % cp_size == 0`` (40 heads -> cp_size in {1, 2, 4, 8}).
+* ``num_patches % cp_size == 0`` (720x1280@49f -> 46800 patches; clean for
+  cp_size in {1, 2, 4, 8}).
+
+At ``cp_size == 1`` the builder degenerates into a graph that is structurally
+equivalent to :func:`cosmos_dit_builder.build_cosmos_dit_engine` (the
+collective helpers are pass-throughs and the per-rank position slice covers
+the full sequence), so the engine can be used as a single-rank dry-run gate.
+
+Weight loading is shared with the dense builder via
+:func:`cosmos_dit_builder.load_cosmos_dit_weights` -- the engine plan bytes
+are identical across ranks; only the per-rank ``cos``/``sin`` RoPE constants
+and the I/O shape differ at build time.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+
+from ... import graph_ops
+from ...parallel_config import (
+    ParallelConfig,
+    add_all_to_all,
+    normalize_parallel_config,
+    require_tensorrt_11_for_tensor_parallel,
+)
+
+from . import cosmos_dit_builder
+from .cosmos_dit_builder import (
+    COSMOS_14B_ADALN_LORA_DIM,
+    COSMOS_14B_FFN_DIM,
+    COSMOS_14B_HEAD_DIM,
+    COSMOS_14B_HIDDEN_SIZE,
+    COSMOS_14B_NORM_EPS,
+    COSMOS_14B_NUM_HEADS,
+    COSMOS_14B_NUM_LAYERS,
+    COSMOS_14B_OUT_CHANNELS,
+    COSMOS_14B_PATCH_SIZE,
+    COSMOS_14B_ROPE_AXES_DIM,
+    COSMOS_14B_ROPE_SCALE,
+    COSMOS_14B_ROPE_THETA,
+    COSMOS_14B_TEXT_EMBED_DIM,
+    COSMOS_14B_TEXT_SEQ_LEN,
+    COSMOS_14B_VAE_SCALE_SPATIAL,
+    COSMOS_14B_VAE_SCALE_TEMPORAL,
+    _adaln_final,
+    _adaln_zero,
+    _block_weights_or_none,
+    _rope_table_axis,
+    _silu_2d,
+)
+
+trt = trt_compat.get_trt()
+
+if TYPE_CHECKING:
+    from ...checkpoint_mapper import WeightDict
+
+
+# ---------------------------------------------------------------------------
+# Per-rank 3-axis RoPE table
+#
+# The dense builder bakes cos/sin tables of shape [num_patches, head_dim/2]
+# from the full (T, H, W) grid. For Ulysses we only need the slice of rows
+# this rank's local sequence covers, but the head_dim axis is unchanged
+# (heads are split *after* RoPE, by the AllToAll).
+#
+# Layout reminder: the dense ``_build_3axis_rope_tables`` walks the 3-D grid
+# in (T, H, W) order with the H, W axes inside T. Slicing rows
+# [rank*L, (rank+1)*L) therefore yields the cos/sin pairs whose linearised
+# positions match the local hidden_states shard the rank receives.
+# ---------------------------------------------------------------------------
+
+
+def _build_3axis_rope_tables_per_rank(
+    *,
+    t_patches: int,
+    h_patches: int,
+    w_patches: int,
+    axes_dim: tuple[int, int, int],
+    rope_scale: tuple[float, float, float],
+    rope_theta: float,
+    cp_size: int,
+    rank: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return per-rank ``cos, sin`` of shape ``[num_patches / cp_size, head_dim // 2]``.
+
+    The full 3-axis tables are computed exactly as in the dense builder
+    (so cp_size=1 is bit-identical), then sliced along axis 0 to keep only
+    the rows ``[rank * L, (rank + 1) * L)`` where ``L = num_patches / cp_size``.
+    """
+    ad_t, ad_h, ad_w = axes_dim
+    cos_t, sin_t = _rope_table_axis(
+        num_positions=t_patches, axis_dim=ad_t,
+        rope_theta=rope_theta, scale=rope_scale[0])
+    cos_h, sin_h = _rope_table_axis(
+        num_positions=h_patches, axis_dim=ad_h,
+        rope_theta=rope_theta, scale=rope_scale[1])
+    cos_w, sin_w = _rope_table_axis(
+        num_positions=w_patches, axis_dim=ad_w,
+        rope_theta=rope_theta, scale=rope_scale[2])
+
+    cos_t_grid = np.broadcast_to(
+        cos_t[:, None, None, :], (t_patches, h_patches, w_patches, ad_t // 2))
+    cos_h_grid = np.broadcast_to(
+        cos_h[None, :, None, :], (t_patches, h_patches, w_patches, ad_h // 2))
+    cos_w_grid = np.broadcast_to(
+        cos_w[None, None, :, :], (t_patches, h_patches, w_patches, ad_w // 2))
+    sin_t_grid = np.broadcast_to(
+        sin_t[:, None, None, :], (t_patches, h_patches, w_patches, ad_t // 2))
+    sin_h_grid = np.broadcast_to(
+        sin_h[None, :, None, :], (t_patches, h_patches, w_patches, ad_h // 2))
+    sin_w_grid = np.broadcast_to(
+        sin_w[None, None, :, :], (t_patches, h_patches, w_patches, ad_w // 2))
+
+    num_patches = t_patches * h_patches * w_patches
+    cos_full = np.concatenate(
+        [cos_t_grid, cos_h_grid, cos_w_grid], axis=-1).reshape(
+            num_patches, -1).astype(np.float32)
+    sin_full = np.concatenate(
+        [sin_t_grid, sin_h_grid, sin_w_grid], axis=-1).reshape(
+            num_patches, -1).astype(np.float32)
+
+    if cp_size <= 1:
+        return (np.ascontiguousarray(cos_full),
+                np.ascontiguousarray(sin_full))
+
+    if num_patches % cp_size != 0:
+        raise ValueError(
+            f"num_patches={num_patches} must be divisible by cp_size={cp_size}")
+    local_len = num_patches // cp_size
+    start = rank * local_len
+    end = start + local_len
+    cos_local = cos_full[start:end, :]
+    sin_local = sin_full[start:end, :]
+    return (np.ascontiguousarray(cos_local),
+            np.ascontiguousarray(sin_local))
+
+
+# ---------------------------------------------------------------------------
+# Self-attention block (Ulysses variant)
+# ---------------------------------------------------------------------------
+
+
+def _self_attention_ulysses(
+    network: "trt.INetworkDefinition",
+    h1: "trt.ITensor",
+    *,
+    bw: dict,
+    num_heads: int,
+    head_dim: int,
+    hidden_size: int,
+    local_num_patches: int,
+    full_num_patches: int,
+    cp_size: int,
+    cos_const: "trt.ITensor",
+    sin_const: "trt.ITensor",
+    eps_t: "trt.ITensor",
+    tag: str,
+) -> "trt.ITensor":
+    """One Ulysses self-attention forward.
+
+    Inputs:
+        h1: AdaLN-modulated activation, shape ``[L, hidden_size]`` where
+            ``L = full_num_patches / cp_size``.
+        cos_const/sin_const: per-rank 3-axis RoPE tables of shape
+            ``[1, L, head_dim // 2]``.
+
+    Output:
+        Pre-residual attention output of shape ``[L, hidden_size]`` (i.e.
+        the result of ``to_out.0(softmax(Q K^T / sqrt(d)) V)``) ready for
+        the gated residual add.
+
+    AllToAll layout (Q/K/V are row-major ``[Sq, num_heads * head_dim]``):
+
+    * Forward direction (heads scatter / seq gather):
+        input  ``[L, num_heads * head_dim]``
+            scatter_axis = 1 (hidden / heads axis)
+            gather_axis  = 0 (sequence axis)
+        output ``[full_num_patches, (num_heads // cp_size) * head_dim]``
+
+    * Backward direction (seq scatter / heads gather), after the local
+      attention has been computed on the full sequence with a head subset:
+        input  ``[full_num_patches, (num_heads // cp_size) * head_dim]``
+            scatter_axis = 0 (sequence axis)
+            gather_axis  = 1 (hidden / heads axis)
+        output ``[L, num_heads * head_dim]``
+    """
+    local_num_heads = num_heads // cp_size
+
+    # Q/K/V projections from the seq-sharded input. Shape [L, hidden].
+    q = graph_ops.add_matmul_rhs_constant(
+        network, h1, hidden_size, hidden_size, bw["attn1.to_q.weight"])
+    k = graph_ops.add_matmul_rhs_constant(
+        network, h1, hidden_size, hidden_size, bw["attn1.to_k.weight"])
+    v = graph_ops.add_matmul_rhs_constant(
+        network, h1, hidden_size, hidden_size, bw["attn1.to_v.weight"])
+
+    # Per-head RMSNorm on Q and K (still per-all-40-heads — heads are not
+    # split yet; the AllToAll comes *after* RMSNorm + RoPE).
+    nq = bw["attn1.norm_q.weight"]
+    if nq is not None:
+        q = graph_ops.add_rms_norm_per_head(
+            network, q, num_heads, head_dim, nq, eps_t,
+            sequence_length=local_num_patches)
+    nk = bw["attn1.norm_k.weight"]
+    if nk is not None:
+        k = graph_ops.add_rms_norm_per_head(
+            network, k, num_heads, head_dim, nk, eps_t,
+            sequence_length=local_num_patches)
+
+    # 3-axis RoPE on Q and K using per-rank cos/sin tables (the table rows
+    # already encode this rank's local position slice).
+    q = graph_ops.add_apply_rope_native_sequence(
+        network, q,
+        num_heads=num_heads, head_dim=head_dim,
+        cos_cache_3d=cos_const, sin_cache_3d=sin_const,
+        rotary_embedding_dim=head_dim,
+        interleaved=False,
+        sequence_length=local_num_patches,
+    )
+    k = graph_ops.add_apply_rope_native_sequence(
+        network, k,
+        num_heads=num_heads, head_dim=head_dim,
+        cos_cache_3d=cos_const, sin_cache_3d=sin_const,
+        rotary_embedding_dim=head_dim,
+        interleaved=False,
+        sequence_length=local_num_patches,
+    )
+
+    # AllToAll #1: scatter heads (axis 1), gather sequence (axis 0).
+    # Each rank ends up with the FULL sequence on its local head subset.
+    if cp_size > 1:
+        q = add_all_to_all(network, q, cp_size, scatter_axis=1, gather_axis=0)
+        k = add_all_to_all(network, k, cp_size, scatter_axis=1, gather_axis=0)
+        v = add_all_to_all(network, v, cp_size, scatter_axis=1, gather_axis=0)
+
+    # Attention on the FULL sequence with the LOCAL head subset.
+    ctx = graph_ops.add_attention_from_rows(
+        network, q, k, v,
+        num_heads=local_num_heads,
+        head_dim=head_dim,
+        q_seq=full_num_patches, kv_seq=full_num_patches,
+        tag=f"{tag}.attn1")
+
+    # AllToAll #2: scatter sequence (axis 0), gather heads (axis 1).
+    # Restore the [L, hidden] row-major layout before the output projection.
+    if cp_size > 1:
+        ctx = add_all_to_all(
+            network, ctx, cp_size, scatter_axis=0, gather_axis=1)
+
+    # Output projection on the seq-sharded, full-head tensor.
+    attn_out = graph_ops.add_matmul_rhs_constant(
+        network, ctx, hidden_size, hidden_size,
+        bw["attn1.to_out.0.weight"])
+    return attn_out
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def build_cosmos_dit_ulysses_engine(
+    config,
+    weights: "WeightDict",
+    *,
+    video_height: int,
+    video_width: int,
+    video_num_frames: int,
+    precision: str = "fp16",
+    verbose: bool = False,
+    parallel_config: ParallelConfig,
+    hidden_size: int = COSMOS_14B_HIDDEN_SIZE,
+    num_heads: int = COSMOS_14B_NUM_HEADS,
+    head_dim: int = COSMOS_14B_HEAD_DIM,
+    num_layers: int = COSMOS_14B_NUM_LAYERS,
+    ffn_dim: int = COSMOS_14B_FFN_DIM,
+    out_channels: int = COSMOS_14B_OUT_CHANNELS,
+    text_embed_dim: int = COSMOS_14B_TEXT_EMBED_DIM,
+    text_seq_len: int = COSMOS_14B_TEXT_SEQ_LEN,
+    adaln_lora_dim: int = COSMOS_14B_ADALN_LORA_DIM,
+    patch_size: tuple[int, int, int] = COSMOS_14B_PATCH_SIZE,
+    rope_axes_dim: tuple[int, int, int] = COSMOS_14B_ROPE_AXES_DIM,
+    rope_scale: tuple[float, float, float] = COSMOS_14B_ROPE_SCALE,
+    rope_theta: float = COSMOS_14B_ROPE_THETA,
+    eps: float = COSMOS_14B_NORM_EPS,
+    vae_scale_spatial: int = COSMOS_14B_VAE_SCALE_SPATIAL,
+    vae_scale_temporal: int = COSMOS_14B_VAE_SCALE_TEMPORAL,
+) -> bytes:
+    """Build the Cosmos-Predict2 14B DiT denoiser TRT engine (Ulysses SP).
+
+    Args:
+        config: Optional :class:`ModelConfig` for plugin parity (unused by
+            the builder itself; engine shape and weight selection are fully
+            determined by the explicit arguments below). Accepted for
+            compatibility with the dispatch path in ``plugin.build_components``.
+        weights: Output of :func:`cosmos_dit_builder.load_cosmos_dit_weights`.
+            All ranks load the same weights; the engine plan bytes are
+            identical across ranks aside from the per-rank cos/sin RoPE
+            constants and the I/O shape.
+        video_height, video_width, video_num_frames: Pixel-space target.
+        precision: Compute precision tag (currently informational only --
+            the dense builder uses fp32 storage for activations; this lane
+            mirrors that contract for bit-exact dry-run parity at cp_size=1).
+        verbose: TRT builder verbose log level.
+        parallel_config: Must be a :class:`ParallelConfig` with
+            ``mode='sp_ulysses'`` and a concrete ``rank``. ``cp_size==1`` is
+            allowed and produces an engine structurally equivalent to the
+            dense builder (the AllToAll calls collapse to pass-through).
+        Remaining kwargs override architecture constants (used by the plugin
+            to lock per-checkpoint values from ``transformer/config.json``).
+
+    Returns:
+        Serialized TRT engine plan as ``bytes``.
+    """
+    del precision  # Reserved for future fp16/bf16 storage variants.
+
+    parallel = normalize_parallel_config(parallel_config)
+    require_tensorrt_11_for_tensor_parallel(
+        parallel, feature="Cosmos-Predict2 sequence-parallel (Ulysses) builds")
+    if parallel.mode != "sp_ulysses":
+        raise ValueError(
+            "build_cosmos_dit_ulysses_engine requires parallel.mode='sp_ulysses'; "
+            f"got mode={parallel.mode!r}")
+    if parallel.rank < 0:
+        raise ValueError(
+            "build_cosmos_dit_ulysses_engine requires a concrete rank "
+            f"(got rank={parallel.rank}); set parallel.for_rank(rank) before "
+            "calling the builder.")
+    cp_size = int(parallel.cp_size)
+    rank = int(parallel.rank)
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be >= 1, got {cp_size}")
+    if rank >= cp_size:
+        raise ValueError(
+            f"rank={rank} must be smaller than cp_size={cp_size}")
+
+    if num_heads * head_dim != hidden_size:
+        raise ValueError(
+            f"hidden_size={hidden_size} must equal num_heads*head_dim "
+            f"({num_heads}*{head_dim}={num_heads * head_dim})")
+    if sum(rope_axes_dim) != head_dim:
+        raise ValueError(
+            f"sum(rope_axes_dim)={sum(rope_axes_dim)} must equal head_dim "
+            f"({head_dim}); got {rope_axes_dim}")
+    if num_heads % cp_size != 0:
+        raise ValueError(
+            f"Ulysses requires num_heads ({num_heads}) divisible by cp_size "
+            f"({cp_size}); 40 heads support cp_size in {{1, 2, 4, 8}}.")
+
+    pt, ph, pw = patch_size
+
+    # Latent dims after VAE encode (identical to dense builder).
+    t_lat = (video_num_frames - 1) // vae_scale_temporal + 1
+    h_lat = video_height // vae_scale_spatial
+    w_lat = video_width // vae_scale_spatial
+    if t_lat % pt != 0 or h_lat % ph != 0 or w_lat % pw != 0:
+        raise ValueError(
+            f"Latent dims (t={t_lat}, h={h_lat}, w={w_lat}) must be divisible "
+            f"by patch_size {patch_size}")
+    t_patches = t_lat // pt
+    h_patches = h_lat // ph
+    w_patches = w_lat // pw
+    full_num_patches = t_patches * h_patches * w_patches
+    if full_num_patches % cp_size != 0:
+        raise ValueError(
+            f"Ulysses requires num_patches ({full_num_patches}) divisible by "
+            f"cp_size ({cp_size}); rerun with a video shape whose "
+            f"patch count is a multiple of {cp_size}.")
+    local_num_patches = full_num_patches // cp_size
+    patch_dim = out_channels * pt * ph * pw
+
+    # --- Build the TRT network skeleton ---
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    builder_config = builder.create_builder_config()
+    builder_config.set_memory_pool_limit(
+        trt.MemoryPoolType.WORKSPACE, 64 << 30)
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+
+    # --- Inputs (per-rank seq shard for hidden_states / noise_pred,
+    #     replicated for everything else) ---
+    hidden_inp = network.add_input(
+        "hidden_states", trt.float32, (local_num_patches, hidden_size))
+    encoder_hidden_inp = network.add_input(
+        "encoder_hidden_states", trt.float32, (text_seq_len, text_embed_dim))
+    temb_inp = network.add_input(
+        "temb", trt.float32, (1, hidden_size))
+    embedded_timestep_inp = network.add_input(
+        "embedded_timestep", trt.float32, (1, hidden_size))
+
+    # --- Constants ---
+    eps_t = graph_ops.add_constant(
+        network, (1, 1), np.array([eps], dtype=np.float32))
+
+    # 3-axis RoPE tables, sliced to the rows this rank owns. cp_size=1 is
+    # a no-op slice that yields exactly the dense table.
+    cos_local, sin_local = _build_3axis_rope_tables_per_rank(
+        t_patches=t_patches,
+        h_patches=h_patches,
+        w_patches=w_patches,
+        axes_dim=rope_axes_dim,
+        rope_scale=rope_scale,
+        rope_theta=rope_theta,
+        cp_size=cp_size,
+        rank=rank,
+    )
+    cos_const = graph_ops.add_constant(
+        network, (1, local_num_patches, head_dim // 2),
+        cos_local.reshape(1, local_num_patches, head_dim // 2))
+    sin_const = graph_ops.add_constant(
+        network, (1, local_num_patches, head_dim // 2),
+        sin_local.reshape(1, local_num_patches, head_dim // 2))
+
+    # Pre-activate temb / embedded_timestep with SiLU (replicated tensors,
+    # no comm needed).
+    temb_silu = _silu_2d(network, temb_inp)
+    embedded_silu = _silu_2d(network, embedded_timestep_inp)
+
+    hidden = hidden_inp
+
+    # --- Per-block forward ---
+    for layer_idx in range(num_layers):
+        bw = _block_weights_or_none(weights, layer_idx)
+        prefix = f"transformer_blocks.{layer_idx}"
+
+        # === 1. Self-attention with AdaLN-Zero (norm1) ===
+        h1, gate1 = _adaln_zero(
+            network, hidden, temb_silu, embedded_silu,
+            hidden_size=hidden_size,
+            adaln_lora_dim=adaln_lora_dim,
+            eps_tensor=eps_t,
+            w_l1=bw["norm1.linear_1.weight"], b_l1=bw["norm1.linear_1.bias"],
+            w_l2=bw["norm1.linear_2.weight"], b_l2=bw["norm1.linear_2.bias"],
+            w_l3=bw["norm1.linear_3.weight"], b_l3=bw["norm1.linear_3.bias"],
+        )
+        attn_out = _self_attention_ulysses(
+            network, h1,
+            bw=bw,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            hidden_size=hidden_size,
+            local_num_patches=local_num_patches,
+            full_num_patches=full_num_patches,
+            cp_size=cp_size,
+            cos_const=cos_const,
+            sin_const=sin_const,
+            eps_t=eps_t,
+            tag=prefix,
+        )
+        gated = network.add_elementwise(
+            attn_out, gate1, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden = network.add_elementwise(
+            hidden, gated, trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === 2. Cross-attention with AdaLN-Zero (norm2) ===
+        # Query is seq-sharded ([L, hidden]); K/V come from the replicated
+        # encoder_hidden_states ([text_seq_len, text_embed_dim]). The
+        # attention math is local — no comm required.
+        h2, gate2 = _adaln_zero(
+            network, hidden, temb_silu, embedded_silu,
+            hidden_size=hidden_size,
+            adaln_lora_dim=adaln_lora_dim,
+            eps_tensor=eps_t,
+            w_l1=bw["norm2.linear_1.weight"], b_l1=bw["norm2.linear_1.bias"],
+            w_l2=bw["norm2.linear_2.weight"], b_l2=bw["norm2.linear_2.bias"],
+            w_l3=bw["norm2.linear_3.weight"], b_l3=bw["norm2.linear_3.bias"],
+        )
+        cq = graph_ops.add_matmul_rhs_constant(
+            network, h2, hidden_size, hidden_size, bw["attn2.to_q.weight"])
+        ck = graph_ops.add_matmul_rhs_constant(
+            network, encoder_hidden_inp, text_embed_dim, hidden_size,
+            bw["attn2.to_k.weight"])
+        cv = graph_ops.add_matmul_rhs_constant(
+            network, encoder_hidden_inp, text_embed_dim, hidden_size,
+            bw["attn2.to_v.weight"])
+        nq2 = bw["attn2.norm_q.weight"]
+        if nq2 is not None:
+            cq = graph_ops.add_rms_norm_per_head(
+                network, cq, num_heads, head_dim, nq2, eps_t,
+                sequence_length=local_num_patches)
+        cross_ctx = graph_ops.add_attention_from_rows(
+            network, cq, ck, cv,
+            num_heads=num_heads, head_dim=head_dim,
+            q_seq=local_num_patches, kv_seq=text_seq_len,
+            tag=f"{prefix}.attn2")
+        cross_out = graph_ops.add_matmul_rhs_constant(
+            network, cross_ctx, hidden_size, hidden_size,
+            bw["attn2.to_out.0.weight"])
+        gated2 = network.add_elementwise(
+            cross_out, gate2, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden = network.add_elementwise(
+            hidden, gated2, trt.ElementWiseOperation.SUM).get_output(0)
+
+        # === 3. FFN with AdaLN-Zero (norm3) ===
+        # Pointwise along the sequence axis: applies directly to the
+        # seq-sharded tensor with no comm.
+        h3, gate3 = _adaln_zero(
+            network, hidden, temb_silu, embedded_silu,
+            hidden_size=hidden_size,
+            adaln_lora_dim=adaln_lora_dim,
+            eps_tensor=eps_t,
+            w_l1=bw["norm3.linear_1.weight"], b_l1=bw["norm3.linear_1.bias"],
+            w_l2=bw["norm3.linear_2.weight"], b_l2=bw["norm3.linear_2.bias"],
+            w_l3=bw["norm3.linear_3.weight"], b_l3=bw["norm3.linear_3.bias"],
+        )
+        ffn_h = graph_ops.add_matmul_rhs_constant(
+            network, h3, hidden_size, ffn_dim, bw["ff.net.0.proj.weight"])
+        if bw["ff.net.0.proj.bias"] is not None:
+            ffn_h = graph_ops.add_bias_sum(
+                network, ffn_h, ffn_dim, bw["ff.net.0.proj.bias"])
+        ffn_h = graph_ops.add_gelu_new(network, ffn_h)
+        ffn_h = graph_ops.add_matmul_rhs_constant(
+            network, ffn_h, ffn_dim, hidden_size, bw["ff.net.2.weight"])
+        if bw["ff.net.2.bias"] is not None:
+            ffn_h = graph_ops.add_bias_sum(
+                network, ffn_h, hidden_size, bw["ff.net.2.bias"])
+        gated3 = network.add_elementwise(
+            ffn_h, gate3, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden = network.add_elementwise(
+            hidden, gated3, trt.ElementWiseOperation.SUM).get_output(0)
+
+    # --- Final norm_out (2 chunks: shift, scale) + proj_out ---
+    # Pointwise along the sequence axis -> seq-sharded output, no comm. The
+    # caller is responsible for the final AllGather on noise_pred.
+    h_final = _adaln_final(
+        network, hidden, temb_silu, embedded_silu,
+        hidden_size=hidden_size,
+        adaln_lora_dim=adaln_lora_dim,
+        eps_tensor=eps_t,
+        w_l1=weights["norm_out.linear_1.weight"],
+        b_l1=weights.get("norm_out.linear_1.bias"),
+        w_l2=weights["norm_out.linear_2.weight"],
+        b_l2=weights.get("norm_out.linear_2.bias"),
+        w_l3=weights["norm_out.linear_3.weight"],
+        b_l3=weights.get("norm_out.linear_3.bias"),
+    )
+    output = graph_ops.add_matmul_rhs_constant(
+        network, h_final, hidden_size, patch_dim,
+        weights["proj_out.weight"])
+    proj_b = weights.get("proj_out.bias")
+    if proj_b is not None:
+        output = graph_ops.add_bias_sum(network, output, patch_dim, proj_b)
+
+    out_cast = network.add_cast(output, trt.float32).get_output(0)
+    out_cast.name = "noise_pred"
+    network.mark_output(out_cast)
+
+    print(
+        f"[cosmos-dit-ulysses] Building TRT engine (hidden={hidden_size}, "
+        f"layers={num_layers}, full_num_patches={full_num_patches}, "
+        f"local_num_patches={local_num_patches}, cp_size={cp_size}, "
+        f"rank={rank}, t_lat={t_lat}, h_lat={h_lat}, w_lat={w_lat}, "
+        f"axes_dim={rope_axes_dim}, rope_scale={rope_scale}) ...",
+        file=sys.stderr,
+    )
+    plan = builder.build_serialized_network(network, builder_config)
+    if plan is None:
+        raise RuntimeError(
+            "TRT engine serialization failed for Cosmos DiT (Ulysses)")
+    return bytes(plan)
+
+
+# ---------------------------------------------------------------------------
+# Weight loading is shared with the dense builder.
+#
+# All ranks load the same weights (Ulysses keeps the projection weights
+# replicated; only the per-rank position slice and the I/O shape differ),
+# so we re-export ``load_cosmos_dit_weights`` here for convenience.
+# ---------------------------------------------------------------------------
+
+load_cosmos_dit_weights = cosmos_dit_builder.load_cosmos_dit_weights

--- a/python/tensorrt_model_connect/families/cosmos_predict/plugin.py
+++ b/python/tensorrt_model_connect/families/cosmos_predict/plugin.py
@@ -1,0 +1,415 @@
+"""Cosmos-Predict2 (image/video-to-world) family plugin.
+
+Target checkpoint:
+    nvidia/Cosmos-Predict2-14B-Video2World          (primary target)
+    nvidia/Cosmos-Predict2-2B-Video2World           (smaller validation tier)
+
+Architecture (per diffusers ``Cosmos2VideoToWorldPipeline`` + the locked HF
+``transformer/config.json`` for the 14B variant):
+
+    * Text encoder : T5EncoderModel (T5-11B style, d_model=1024, 24 layers,
+                                       65536-dim FF, ReLU activation)
+    * Denoiser     : CosmosTransformer3DModel
+                       - 17 in-channels (16 VAE latent + 1 padding mask)
+                       - 36 transformer blocks (self-attn + cross-attn + FFN)
+                       - 40 heads x 128 head_dim = 5120 hidden
+                       - 3-axis RoPE, axes_dim=(16, 56, 56), rope_scale
+                         (0.8333, 2.0, 2.0)
+                       - AdaLN-Zero with a (hidden -> 256 -> 3*hidden) LoRA
+                         decomposition per block, plus a parallel
+                         (hidden -> 3*hidden) residual from
+                         ``embedded_timestep``
+    * VAE          : AutoencoderKLWan (Wan-AI cosmos_cv8x8x8 — same family
+                                       used by Wan2.1, z_dim=16, 8x8x8
+                                       compression)
+    * Scheduler    : FlowMatchEulerDiscreteScheduler
+
+Diffusers repo layout (expected on disk):
+    model_index.json
+    transformer/       (CosmosTransformer3DModel)  - safetensors shards
+    text_encoder/      (T5EncoderModel)            - safetensors shards
+    tokenizer/
+    vae/               (AutoencoderKLWan)          - safetensors shards
+    scheduler/
+
+Build status (this branch)
+--------------------------
+
+* T5 encoder + Wan-shared causal 3D VAE: reuse the
+  ``families.wan_t2v`` builders unchanged (T5-11B has the same Linear/RMS
+  layout as Wan UMT5; the cosmos VAE is the same ``AutoencoderKLWan``).
+* DiT: implemented in :mod:`cosmos_dit_builder` for the dense, single-GPU
+  case. Tensor / sequence-parallel paths still raise
+  ``NotImplementedError`` until the SP layout lands.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from ...checkpoint_mapper import WeightDict
+from ...config import ModelConfig
+
+
+class CosmosPredictPlugin:
+    name = "cosmos_predict"
+    runtime_strategy = "diffusion_wan"  # Reuses the Wan 3D backend.
+    # Diffusers pipeline classes this plugin understands. The orchestrator
+    # uses ``pipeline_classes`` for auto-discovery when ``--from-diffusers``
+    # is selected at build time.
+    pipeline_classes = [
+        "Cosmos2VideoToWorldPipeline",
+        "Cosmos2TextToImagePipeline",
+        # Earlier-generation pipeline names retained for completeness.
+        "CosmosVideoToWorldPipeline",
+        "CosmosTextToWorldPipeline",
+    ]
+
+    # ------------------------------------------------------------------
+    # T5 encoder (T5-11B style, used by Cosmos-Predict2)
+    # ------------------------------------------------------------------
+    _T5_D_MODEL = 1024
+    _T5_NUM_HEADS = 128
+    _T5_D_KV = 128
+    _T5_D_FF = 65536
+    _T5_NUM_LAYERS = 24
+    _T5_VOCAB_SIZE = 32128
+    _T5_MAX_SEQ_LEN = 512
+
+    # ------------------------------------------------------------------
+    # CosmosTransformer3DModel — 14B Video2World defaults. Per-checkpoint
+    # constants are pulled from transformer/config.json at build time when
+    # available; the values here are the fallback / sanity-check baseline.
+    # ------------------------------------------------------------------
+    _DIT_IN_CHANNELS = 17           # 16 VAE z + 1 padding mask
+    _DIT_OUT_CHANNELS = 16
+    _DIT_HIDDEN_SIZE = 5120
+    _DIT_NUM_HEADS = 40
+    _DIT_HEAD_DIM = 128
+    _DIT_NUM_LAYERS = 36
+    _DIT_FFN_DIM = 20480            # mlp_ratio=4.0
+    _DIT_TEXT_EMBED_DIM = 1024
+    _DIT_ADALN_LORA_DIM = 256
+    _DIT_FREQ_DIM = 256
+    _DIT_PATCH_SIZE = (1, 2, 2)
+    _DIT_ROPE_AXES_DIM = (16, 56, 56)
+    _DIT_ROPE_SCALE = (0.8333, 2.0, 2.0)
+    _DIT_NORM_EPS = 1e-6
+
+    # ------------------------------------------------------------------
+    # AutoencoderKLWan (cosmos_cv8x8x8) — 8x8x8 compression, 16 ch
+    # ------------------------------------------------------------------
+    _VAE_Z_DIM = 16
+    _VAE_BASE_DIM = 96
+    _VAE_DIM_MULT = (1, 2, 4, 4)
+    _VAE_NUM_RES_BLOCKS = 2
+    _VAE_TEMPORAL_UPSAMPLE = (False, True, True)
+    _SCALE_FACTOR_TEMPORAL = 4
+    _SCALE_FACTOR_SPATIAL = 8
+
+    # ------------------------------------------------------------------
+    # FamilyPlugin protocol
+    # ------------------------------------------------------------------
+    def matches(self, model_type: str) -> bool:
+        mt = (model_type or "").lower()
+        return mt in (
+            "cosmos_predict",
+            "cosmos_predict2",
+            "cosmos-predict",
+            "cosmos-predict2",
+            "cosmos2_video2world",
+            "cosmos_video2world",
+            "cosmos_transformer3d",
+        )
+
+    def load_weights(
+        self, model_dir: str, config: ModelConfig,
+    ) -> WeightDict:
+        """Resolve sub-directories in a diffusers Cosmos-Predict2 snapshot."""
+        model_path = Path(model_dir)
+        weights = WeightDict()
+
+        if not (model_path / "model_index.json").exists():
+            raise ValueError(
+                "cosmos_predict expects a diffusers snapshot containing "
+                f"model_index.json, got: {model_dir}. Single-file .pt "
+                "checkpoints (e.g. model-720p-16fps.pt) must be converted "
+                "via diffusers' convert_cosmos_to_diffusers.py first."
+            )
+
+        weights["_model_format"] = "diffusers"
+        weights["_model_index"] = json.loads(
+            (model_path / "model_index.json").read_text())
+
+        transformer_dir = model_path / "transformer"
+        vae_dir = model_path / "vae"
+        text_encoder_dir = model_path / "text_encoder"
+        if not transformer_dir.exists():
+            raise ValueError(
+                f"cosmos_predict: missing transformer/ in {model_dir}")
+        if not vae_dir.exists():
+            raise ValueError(
+                f"cosmos_predict: missing vae/ in {model_dir}")
+        if not text_encoder_dir.exists():
+            raise ValueError(
+                f"cosmos_predict: missing text_encoder/ in {model_dir}")
+
+        weights["_transformer_dir"] = str(transformer_dir)
+        weights["_text_encoder_dir"] = str(text_encoder_dir)
+        weights["_vae_dir"] = str(vae_dir)
+
+        def _maybe_json(p: Path) -> dict:
+            return json.loads(p.read_text()) if p.exists() else {}
+
+        weights["_transformer_config"] = _maybe_json(
+            transformer_dir / "config.json")
+        weights["_vae_config"] = _maybe_json(vae_dir / "config.json")
+        weights["_text_encoder_config"] = _maybe_json(
+            text_encoder_dir / "config.json")
+
+        return weights
+
+    def build_engine(
+        self, config: ModelConfig, weights: WeightDict,
+        max_cache_length: int, *, precision: str = "fp32",
+        quant_ctx=None, verbose: bool = False,
+    ) -> bytes:
+        """Not used — diffusion pipelines go through ``build_components``."""
+        raise NotImplementedError(
+            "cosmos_predict is a diffusion family; use build_components()")
+
+    # ------------------------------------------------------------------
+    # Diffusion contract
+    # ------------------------------------------------------------------
+    def build_components(  # noqa: D417 - protocol signature
+        self, model_dir: str, config: ModelConfig, weights: WeightDict,
+        *, precision: str = "fp32", verbose: bool = False,
+        parallel_config=None, **_kwargs,
+    ) -> dict:
+        """Build the three component engines for Cosmos-Predict2."""
+        from ...build_timing import (
+            timed_trt_compile, timed_weight_loading)
+        from ...parallel_config import (
+            normalize_parallel_config,
+            require_tensorrt_11_for_tensor_parallel,
+        )
+        from ..wan_t2v.t5_encoder_builder import (
+            build_t5_encoder_engine, load_t5_weights)
+        from ..wan_t2v.causal_vae_3d_builder import (
+            build_causal_vae_3d_engine, load_vae_weights)
+        from .cosmos_dit_builder import (
+            build_cosmos_dit_engine, load_cosmos_dit_weights)
+
+        build_timing = _kwargs.get("build_timing")
+        parallel = normalize_parallel_config(parallel_config)
+        require_tensorrt_11_for_tensor_parallel(
+            parallel, feature="Cosmos-Predict2 tensor-parallel builds")
+        if parallel.enabled:
+            # Multi-GPU TP/SP variants are out of scope for this branch.
+            raise NotImplementedError(
+                "cosmos_predict: tensor/sequence parallel builds are not "
+                "implemented yet; rerun with parallel_config=None or "
+                "tp_size=1.")
+
+        # Lock per-checkpoint constants from transformer/config.json when
+        # present; otherwise fall back to the 14B defaults baked into this
+        # plugin. ``hidden_size`` is derived from ``num_attention_heads *
+        # attention_head_dim`` to remain consistent with the diffusers
+        # config schema (which does not store ``hidden_size`` directly).
+        tc = weights.get("_transformer_config", {}) or {}
+        dit_heads = int(tc.get(
+            "num_attention_heads", self._DIT_NUM_HEADS))
+        dit_head_dim = int(tc.get(
+            "attention_head_dim", self._DIT_HEAD_DIM))
+        dit_hidden = dit_heads * dit_head_dim
+        dit_layers = int(tc.get(
+            "num_layers", tc.get("num_hidden_layers", self._DIT_NUM_LAYERS)))
+        dit_mlp_ratio = float(tc.get("mlp_ratio", 4.0))
+        dit_ffn_dim = int(round(dit_hidden * dit_mlp_ratio))
+        dit_in_channels = int(tc.get(
+            "in_channels", self._DIT_IN_CHANNELS))
+        dit_out_channels = int(tc.get(
+            "out_channels", self._DIT_OUT_CHANNELS))
+        dit_text_embed_dim = int(tc.get(
+            "text_embed_dim", self._DIT_TEXT_EMBED_DIM))
+        dit_adaln_lora_dim = int(tc.get(
+            "adaln_lora_dim", self._DIT_ADALN_LORA_DIM))
+        dit_patch_size = tuple(tc.get(
+            "patch_size", list(self._DIT_PATCH_SIZE)))
+        dit_rope_axes = tuple(tc.get(
+            "rope_axes_dim", list(self._DIT_ROPE_AXES_DIM)))
+        dit_rope_scale = tuple(tc.get(
+            "rope_scale", list(self._DIT_ROPE_SCALE)))
+        dit_eps = float(tc.get("eps", self._DIT_NORM_EPS))
+
+        # Sanity-check the rope axis split.
+        if sum(dit_rope_axes) != dit_head_dim:
+            raise ValueError(
+                f"sum(rope_axes_dim)={sum(dit_rope_axes)} must equal "
+                f"head_dim={dit_head_dim}; got {dit_rope_axes}")
+
+        # Video dimensions sourced from build args (matches Wan plugin).
+        video_height = int(config.raw.get("video_height", 720))
+        video_width = int(config.raw.get("video_width", 1280))
+        video_num_frames = int(config.raw.get("video_num_frames", 49))
+
+        text_encoder_dir = weights["_text_encoder_dir"]
+        transformer_dir = weights["_transformer_dir"]
+        vae_dir = weights["_vae_dir"]
+
+        # 1. T5 text encoder ------------------------------------------------
+        print("[cosmos-predict] Loading T5 encoder weights ...", file=sys.stderr)
+        with timed_weight_loading(build_timing, "t5_encoder"):
+            t5_weights = load_t5_weights(
+                text_encoder_dir,
+                d_model=self._T5_D_MODEL,
+                num_heads=self._T5_NUM_HEADS,
+                d_kv=self._T5_D_KV,
+                d_ff=self._T5_D_FF,
+                num_layers=self._T5_NUM_LAYERS,
+                vocab_size=self._T5_VOCAB_SIZE,
+                precision=precision,
+            )
+        with timed_trt_compile(build_timing, "t5_encoder"):
+            t5_plan = build_t5_encoder_engine(
+                t5_weights,
+                d_model=self._T5_D_MODEL,
+                num_heads=self._T5_NUM_HEADS,
+                d_kv=self._T5_D_KV,
+                d_ff=self._T5_D_FF,
+                num_layers=self._T5_NUM_LAYERS,
+                vocab_size=self._T5_VOCAB_SIZE,
+                max_seq_len=self._T5_MAX_SEQ_LEN,
+                verbose=verbose,
+            )
+
+        # 2. DiT denoiser ---------------------------------------------------
+        print("[cosmos-predict] Loading DiT weights ...", file=sys.stderr)
+        with timed_weight_loading(build_timing, "dit"):
+            dit_weights = load_cosmos_dit_weights(
+                transformer_dir,
+                hidden_size=dit_hidden,
+                num_heads=dit_heads,
+                head_dim=dit_head_dim,
+                num_layers=dit_layers,
+                ffn_dim=dit_ffn_dim,
+                text_embed_dim=dit_text_embed_dim,
+                adaln_lora_dim=dit_adaln_lora_dim,
+                out_channels=dit_out_channels,
+                in_channels=dit_in_channels,
+                patch_size=dit_patch_size,
+            )
+        with timed_trt_compile(build_timing, "dit"):
+            dit_plan = build_cosmos_dit_engine(
+                dit_weights,
+                video_height=video_height,
+                video_width=video_width,
+                video_num_frames=video_num_frames,
+                hidden_size=dit_hidden,
+                num_heads=dit_heads,
+                head_dim=dit_head_dim,
+                num_layers=dit_layers,
+                ffn_dim=dit_ffn_dim,
+                out_channels=dit_out_channels,
+                text_embed_dim=dit_text_embed_dim,
+                text_seq_len=self._T5_MAX_SEQ_LEN,
+                adaln_lora_dim=dit_adaln_lora_dim,
+                patch_size=dit_patch_size,
+                rope_axes_dim=dit_rope_axes,
+                rope_scale=dit_rope_scale,
+                eps=dit_eps,
+                vae_scale_spatial=self._SCALE_FACTOR_SPATIAL,
+                vae_scale_temporal=self._SCALE_FACTOR_TEMPORAL,
+                verbose=verbose,
+            )
+
+        # 3. Wan-shared causal 3D VAE decoder --------------------------------
+        print("[cosmos-predict] Loading VAE decoder weights ...", file=sys.stderr)
+        with timed_weight_loading(build_timing, "vae_decoder"):
+            vae_weights = load_vae_weights(
+                vae_dir,
+                z_dim=self._VAE_Z_DIM,
+                base_dim=self._VAE_BASE_DIM,
+                dim_mult=self._VAE_DIM_MULT,
+                num_res_blocks=self._VAE_NUM_RES_BLOCKS,
+                norm_type="l2_channel_norm",
+            )
+        h_lat = video_height // self._SCALE_FACTOR_SPATIAL
+        w_lat = video_width // self._SCALE_FACTOR_SPATIAL
+        with timed_trt_compile(build_timing, "vae_decoder"):
+            vae_plan = build_causal_vae_3d_engine(
+                vae_weights,
+                z_dim=self._VAE_Z_DIM,
+                base_dim=self._VAE_BASE_DIM,
+                dim_mult=self._VAE_DIM_MULT,
+                num_res_blocks=self._VAE_NUM_RES_BLOCKS,
+                temporal_upsample=self._VAE_TEMPORAL_UPSAMPLE,
+                h_lat=h_lat,
+                w_lat=w_lat,
+                norm_type="l2_channel_norm",
+                verbose=verbose,
+            )
+
+        return {
+            "text_encoders": [("t5", t5_plan)],
+            "denoiser": dit_plan,
+            "vae_decoder": vae_plan,
+        }
+
+    def get_diffusion_config(self, config: ModelConfig) -> dict:
+        """Return diffusion pipeline configuration for the C++ runtime."""
+        from ..wan_t2v.causal_vae_3d_builder import count_vae_caches
+
+        video_height = int(config.raw.get("video_height", 720))
+        video_width = int(config.raw.get("video_width", 1280))
+        video_num_frames = int(config.raw.get("video_num_frames", 49))
+
+        return {
+            # Borrows Wan's 3D backend: engines, scheduler family, and VAE
+            # plumbing are compatible.
+            "diffusion_backend_type": "wan_3d",
+            "scheduler": "flow_match_euler",
+            "num_inference_steps": int(config.raw.get(
+                "num_inference_steps", 15)),
+            "guidance_scale": float(config.raw.get(
+                "guidance_scale", 7.0)),
+            "flow_shift": float(config.raw.get("flow_shift", 7.0)),
+            "video_height": video_height,
+            "video_width": video_width,
+            "video_num_frames": video_num_frames,
+            "dit_dim": self._DIT_HIDDEN_SIZE,
+            "dit_num_heads": self._DIT_NUM_HEADS,
+            "dit_num_layers": self._DIT_NUM_LAYERS,
+            "patch_size": list(self._DIT_PATCH_SIZE),
+            "z_dim": self._VAE_Z_DIM,
+            "scale_factor_temporal": self._SCALE_FACTOR_TEMPORAL,
+            "scale_factor_spatial": self._SCALE_FACTOR_SPATIAL,
+            "freq_dim": self._DIT_FREQ_DIM,
+            "text_seq_len": self._T5_MAX_SEQ_LEN,
+            "text_encoder_dim": self._T5_D_MODEL,
+            "num_conditioning_frames": int(config.raw.get(
+                "num_conditioning_frames", 1)),
+            "num_vae_caches": count_vae_caches(
+                dim_mult=self._VAE_DIM_MULT,
+                num_res_blocks=self._VAE_NUM_RES_BLOCKS,
+                temporal_upsample=self._VAE_TEMPORAL_UPSAMPLE,
+            ),
+            "latents_mean": [
+                -0.7571, -0.7089, -0.9113, 0.1075,
+                -0.1745, 0.9653, -0.1517, 1.5508,
+                0.4134, -0.0715, 0.5517, -0.3632,
+                -0.1922, -0.9497, 0.2503, -0.2921,
+            ],
+            "latents_std": [
+                2.8184, 1.4541, 2.3275, 2.6558,
+                1.2196, 1.7708, 2.6052, 2.0743,
+                3.2687, 2.1526, 2.8652, 1.5579,
+                1.6382, 1.1253, 2.8251, 1.9160,
+            ],
+            "vae_model_id": "nvidia/Cosmos-Predict2-14B-Video2World",
+        }
+
+
+plugin = CosmosPredictPlugin()

--- a/python/tensorrt_model_connect/families/cosmos_predict/plugin.py
+++ b/python/tensorrt_model_connect/families/cosmos_predict/plugin.py
@@ -205,13 +205,13 @@ class CosmosPredictPlugin:
         build_timing = _kwargs.get("build_timing")
         parallel = normalize_parallel_config(parallel_config)
         require_tensorrt_11_for_tensor_parallel(
-            parallel, feature="Cosmos-Predict2 tensor-parallel builds")
-        if parallel.enabled:
-            # Multi-GPU TP/SP variants are out of scope for this branch.
+            parallel, feature="Cosmos-Predict2 parallel builds")
+        if parallel.enabled and parallel.mode == "tensor_parallel":
+            # Cosmos uses sequence parallelism, not tensor parallelism.
             raise NotImplementedError(
-                "cosmos_predict: tensor/sequence parallel builds are not "
-                "implemented yet; rerun with parallel_config=None or "
-                "tp_size=1.")
+                "cosmos_predict: tensor_parallel is not supported; use "
+                "mode='sp_ulysses', 'sp_ring', or 'sp_allgather_kv' with a "
+                "cp_size > 1, or pass parallel_config=None for single-GPU.")
 
         # Lock per-checkpoint constants from transformer/config.json when
         # present; otherwise fall back to the 14B defaults baked into this
@@ -301,29 +301,58 @@ class CosmosPredictPlugin:
                 in_channels=dit_in_channels,
                 patch_size=dit_patch_size,
             )
+        # SP dispatch: select the DiT builder by parallel mode. All four
+        # builders share an identical kwarg signature except the SP variants
+        # also take ``parallel_config``. At cp_size=1 the SP collectives are
+        # pass-throughs, but framework validation forbids cp_size=1 with
+        # sp_* modes — so users get the dense builder for single-GPU and
+        # an sp_* builder when cp_size > 1.
+        _dit_common_kwargs = dict(
+            video_height=video_height,
+            video_width=video_width,
+            video_num_frames=video_num_frames,
+            hidden_size=dit_hidden,
+            num_heads=dit_heads,
+            head_dim=dit_head_dim,
+            num_layers=dit_layers,
+            ffn_dim=dit_ffn_dim,
+            out_channels=dit_out_channels,
+            text_embed_dim=dit_text_embed_dim,
+            text_seq_len=self._T5_MAX_SEQ_LEN,
+            adaln_lora_dim=dit_adaln_lora_dim,
+            patch_size=dit_patch_size,
+            rope_axes_dim=dit_rope_axes,
+            rope_scale=dit_rope_scale,
+            eps=dit_eps,
+            vae_scale_spatial=self._SCALE_FACTOR_SPATIAL,
+            vae_scale_temporal=self._SCALE_FACTOR_TEMPORAL,
+            verbose=verbose,
+        )
         with timed_trt_compile(build_timing, "dit"):
-            dit_plan = build_cosmos_dit_engine(
-                dit_weights,
-                video_height=video_height,
-                video_width=video_width,
-                video_num_frames=video_num_frames,
-                hidden_size=dit_hidden,
-                num_heads=dit_heads,
-                head_dim=dit_head_dim,
-                num_layers=dit_layers,
-                ffn_dim=dit_ffn_dim,
-                out_channels=dit_out_channels,
-                text_embed_dim=dit_text_embed_dim,
-                text_seq_len=self._T5_MAX_SEQ_LEN,
-                adaln_lora_dim=dit_adaln_lora_dim,
-                patch_size=dit_patch_size,
-                rope_axes_dim=dit_rope_axes,
-                rope_scale=dit_rope_scale,
-                eps=dit_eps,
-                vae_scale_spatial=self._SCALE_FACTOR_SPATIAL,
-                vae_scale_temporal=self._SCALE_FACTOR_TEMPORAL,
-                verbose=verbose,
-            )
+            if parallel.mode == "sp_ulysses":
+                from .cosmos_dit_ulysses_builder import (
+                    build_cosmos_dit_ulysses_engine)
+                dit_plan = build_cosmos_dit_ulysses_engine(
+                    config, dit_weights,
+                    parallel_config=parallel,
+                    **_dit_common_kwargs)
+            elif parallel.mode == "sp_ring":
+                from .cosmos_dit_ring_builder import (
+                    build_cosmos_dit_ring_engine)
+                dit_plan = build_cosmos_dit_ring_engine(
+                    config, dit_weights,
+                    parallel_config=parallel,
+                    **_dit_common_kwargs)
+            elif parallel.mode == "sp_allgather_kv":
+                from .cosmos_dit_allgather_kv_builder import (
+                    build_cosmos_dit_allgather_kv_engine)
+                dit_plan = build_cosmos_dit_allgather_kv_engine(
+                    config, dit_weights,
+                    parallel_config=parallel,
+                    **_dit_common_kwargs)
+            else:  # single
+                dit_plan = build_cosmos_dit_engine(
+                    dit_weights, **_dit_common_kwargs)
 
         # 3. Wan-shared causal 3D VAE decoder --------------------------------
         print("[cosmos-predict] Loading VAE decoder weights ...", file=sys.stderr)

--- a/python/tensorrt_model_connect/parallel_config.py
+++ b/python/tensorrt_model_connect/parallel_config.py
@@ -69,10 +69,6 @@ class ParallelConfig:
         if self.mode in _SP_MODES and self.cp_size == 1:
             raise ValueError(
                 f"parallel.mode={self.mode!r} requires parallel.cp_size > 1")
-        # SP modes need TRT 11+ for ALL_GATHER / ALL_TO_ALL / REDUCE_SCATTER.
-        # Only verify here (not at import) so other modes work on TRT 10.
-        if self.mode in _SP_MODES:
-            _verify_trt_collective_support()
 
     def to_config_dict(self) -> dict[str, object]:
         self.validate()
@@ -407,28 +403,3 @@ def add_reduce_scatter_sum(network, tensor, cp_size: int, scatter_axis: int = -1
     return _finalize_collective_layer(layer, "REDUCE_SCATTER", cp_size)
 
 
-def _verify_trt_collective_support() -> None:
-    """Raise if the active TensorRT lacks the SP collective enum members.
-
-    Only called when a sequence-parallel mode (sp_ulysses / sp_ring /
-    sp_allgather_kv) is actually requested — not at import time, so unit
-    tests and host tooling that import parallel_config under older TRT
-    builds continue to work.
-    """
-    from . import trt_compat
-
-    if not trt_compat.is_available():
-        return
-    try:
-        module = trt_compat.load_module()
-    except ImportError:
-        return
-    collective = getattr(module, "CollectiveOperation", None)
-    if collective is None:
-        return
-    required = ("ALL_REDUCE", "ALL_GATHER", "ALL_TO_ALL", "REDUCE_SCATTER")
-    missing = [name for name in required if not hasattr(collective, name)]
-    if missing:
-        raise RuntimeError(
-            "Active TensorRT is missing required CollectiveOperation members: "
-            f"{missing} (requires TRT 11+)")

--- a/python/tensorrt_model_connect/parallel_config.py
+++ b/python/tensorrt_model_connect/parallel_config.py
@@ -13,38 +13,69 @@ if TYPE_CHECKING:
     from .config import ModelConfig
 
 
+_TP_MODES = frozenset({"tensor_parallel"})
+_SP_MODES = frozenset({"sp_ulysses", "sp_ring", "sp_allgather_kv"})
+_ALL_MODES = frozenset({"single"}) | _TP_MODES | _SP_MODES
+
+
 @dataclass(frozen=True)
 class ParallelConfig:
     mode: str = "single"
     tp_size: int = 1
+    cp_size: int = 1
     rank: int = -1
     require_mpirun: bool = True
 
     @property
     def enabled(self) -> bool:
-        return self.mode == "tensor_parallel" and self.tp_size > 1
+        if self.tp_size > 1 and self.mode in _TP_MODES:
+            return True
+        if self.cp_size > 1 and self.mode in _SP_MODES:
+            return True
+        return False
+
+    @property
+    def world_size(self) -> int:
+        """Total ranks needed for this parallel layout (tp * cp)."""
+        return max(1, int(self.tp_size)) * max(1, int(self.cp_size))
 
     def for_rank(self, rank: int) -> "ParallelConfig":
         return replace(self, rank=rank)
 
     def validate(self) -> None:
-        if self.mode not in {"single", "tensor_parallel"}:
+        if self.mode not in _ALL_MODES:
             raise ValueError(f"Unsupported parallel.mode={self.mode!r}")
         if self.tp_size not in {1, 2, 4, 8}:
             raise ValueError("parallel.tp_size must be one of 1, 2, 4, 8")
+        if self.cp_size <= 0 or self.cp_size > 8:
+            raise ValueError(
+                "parallel.cp_size must be a positive integer <= 8")
+        if self.cp_size not in {1, 2, 4, 8}:
+            raise ValueError("parallel.cp_size must be one of 1, 2, 4, 8")
+        if self.cp_size > 1 and self.mode not in _SP_MODES:
+            raise ValueError(
+                f"parallel.cp_size={self.cp_size} requires a sequence-parallel mode "
+                f"(one of {sorted(_SP_MODES)}); got mode={self.mode!r}")
         if self.rank < -1:
             raise ValueError("parallel.rank must be -1 or a non-negative rank")
-        if self.rank >= self.tp_size:
+        world = self.world_size
+        if self.rank >= world:
             raise ValueError(
-                f"parallel.rank={self.rank} must be smaller than tp_size={self.tp_size}")
+                f"parallel.rank={self.rank} must be smaller than world_size={world}")
         if self.mode == "single" and self.tp_size != 1:
             raise ValueError("parallel.mode=single requires parallel.tp_size=1")
+        if self.mode == "single" and self.cp_size != 1:
+            raise ValueError("parallel.mode=single requires parallel.cp_size=1")
+        if self.mode in _SP_MODES and self.cp_size == 1:
+            raise ValueError(
+                f"parallel.mode={self.mode!r} requires parallel.cp_size > 1")
 
     def to_config_dict(self) -> dict[str, object]:
         self.validate()
         return {
             "mode": self.mode,
             "tp_size": self.tp_size,
+            "cp_size": self.cp_size,
             "rank": self.rank,
             "require_mpirun": self.require_mpirun,
         }
@@ -217,20 +248,51 @@ def shard_standard_decoder_weights(
     return out
 
 
-def add_all_reduce_sum(network, tensor, tp_size: int):
-    """Insert a TRT 11.0+ all-reduce SUM collective for tensor-parallel joins."""
+_TRT11_REQUIRED_MSG = (
+    "Distributed collectives require TensorRT 11.0+ Python bindings "
+    "with INetworkDefinition.add_dist_collective"
+)
+
+
+def _resolve_collective_api(network):
+    """Return (trt_proxy, add_collective) or raise if TRT 11+ API is missing."""
     from tensorrt_model_connect import trt_compat
 
-    tp_size = int(tp_size)
+    add_collective = getattr(network, "add_dist_collective", None)
+    if add_collective is None:
+        raise RuntimeError(_TRT11_REQUIRED_MSG + " (requires TRT 11+)")
+    return trt_compat.get_trt(), add_collective
+
+
+def _finalize_collective_layer(layer, op_name: str, ranks: int):
+    if layer is None:
+        raise RuntimeError(
+            f"TensorRT failed to add {op_name} distributed collective"
+            " (requires TRT 11+)")
+    if not hasattr(layer, "num_ranks"):
+        raise RuntimeError(
+            f"{op_name} requires TensorRT 11.0+ Python bindings "
+            f"with IDistCollectiveLayer.num_ranks (requires TRT 11+)")
+    layer.num_ranks = int(ranks)
+    return layer.get_output(0)
+
+
+def _check_parallel_size(parallel_size: int, op_name: str) -> int:
+    parallel_size = int(parallel_size)
+    if parallel_size < 0:
+        raise RuntimeError(
+            f"{op_name}: parallel_size must be >= 0, got {parallel_size}"
+            " (requires TRT 11+)")
+    return parallel_size
+
+
+def add_all_reduce_sum(network, tensor, tp_size: int):
+    """Insert a TRT 11.0+ all-reduce SUM collective for tensor-parallel joins."""
+    tp_size = _check_parallel_size(tp_size, "add_all_reduce_sum")
     if tp_size <= 1:
         return tensor
 
-    trt = trt_compat.get_trt()
-    add_collective = getattr(network, "add_dist_collective", None)
-    if add_collective is None:
-        raise RuntimeError(
-            "Tensor-parallel builds require TensorRT 11.0+ Python bindings "
-            "with INetworkDefinition.add_dist_collective")
+    trt, add_collective = _resolve_collective_api(network)
     layer = add_collective(
         tensor,
         trt.CollectiveOperation.ALL_REDUCE,
@@ -238,11 +300,133 @@ def add_all_reduce_sum(network, tensor, tp_size: int):
         -1,
         [],
     )
-    if layer is None:
-        raise RuntimeError("TensorRT failed to add ALL_REDUCE distributed collective")
-    if not hasattr(layer, "num_ranks"):
+    return _finalize_collective_layer(layer, "ALL_REDUCE", tp_size)
+
+
+def add_all_gather(network, tensor, cp_size: int, gather_axis: int = -1):
+    """All-gather across ``cp_size`` ranks along ``gather_axis``.
+
+    Output shape matches the input except the gather axis grows by ``cp_size``
+    (each rank contributes its local shard). A pass-through is returned when
+    ``cp_size <= 1``.
+    """
+    cp_size = _check_parallel_size(cp_size, "add_all_gather")
+    if cp_size <= 1:
+        return tensor
+
+    trt, add_collective = _resolve_collective_api(network)
+    gather_axis = int(gather_axis)
+    layer = add_collective(
+        tensor,
+        trt.CollectiveOperation.ALL_GATHER,
+        trt.ReduceOperation.NONE,
+        gather_axis,
+        [],
+    )
+    return _finalize_collective_layer(layer, "ALL_GATHER", cp_size)
+
+
+def add_all_to_all(
+    network,
+    tensor,
+    cp_size: int,
+    scatter_axis: int,
+    gather_axis: int,
+):
+    """All-to-all redistribution across ``cp_size`` ranks.
+
+    Input tensor is sharded along ``gather_axis`` (each rank holds 1/cp_size of
+    that axis) and the output is sharded along ``scatter_axis`` instead. The
+    declared output shape grows ``scatter_axis`` by ``cp_size`` and shrinks
+    ``gather_axis`` by ``cp_size``.
+
+    The underlying TRT 11 API expects the ``axis`` argument to encode both
+    scatter and gather axes; we pass them as a 2-element list. If the runtime
+    only accepts a scalar we fall back to passing the scatter axis and rely on
+    the ``sizes`` argument to encode the gather axis.
+    """
+    cp_size = _check_parallel_size(cp_size, "add_all_to_all")
+    if cp_size <= 1:
+        return tensor
+
+    trt, add_collective = _resolve_collective_api(network)
+    scatter_axis = int(scatter_axis)
+    gather_axis = int(gather_axis)
+    if scatter_axis == gather_axis:
         raise RuntimeError(
-            "Tensor-parallel builds require TensorRT 11.0+ Python bindings "
-            "with IDistCollectiveLayer.num_ranks")
-    layer.num_ranks = tp_size
-    return layer.get_output(0)
+            "add_all_to_all: scatter_axis and gather_axis must differ "
+            f"(both = {scatter_axis}) (requires TRT 11+)")
+
+    # Try the documented 2-axis form first; fall back to scalar+sizes if the
+    # binding rejects the list form.
+    layer = None
+    try:
+        layer = add_collective(
+            tensor,
+            trt.CollectiveOperation.ALL_TO_ALL,
+            trt.ReduceOperation.NONE,
+            [scatter_axis, gather_axis],
+            [],
+        )
+    except TypeError:
+        layer = None
+    if layer is None:
+        layer = add_collective(
+            tensor,
+            trt.CollectiveOperation.ALL_TO_ALL,
+            trt.ReduceOperation.NONE,
+            scatter_axis,
+            [gather_axis],
+        )
+    return _finalize_collective_layer(layer, "ALL_TO_ALL", cp_size)
+
+
+def add_reduce_scatter_sum(network, tensor, cp_size: int, scatter_axis: int = -1):
+    """Reduce-scatter SUM across ``cp_size`` ranks along ``scatter_axis``.
+
+    Output declares ``scatter_axis`` shrunk by ``cp_size`` after a SUM reduction
+    across all ranks. Pass-through when ``cp_size <= 1``.
+    """
+    cp_size = _check_parallel_size(cp_size, "add_reduce_scatter_sum")
+    if cp_size <= 1:
+        return tensor
+
+    trt, add_collective = _resolve_collective_api(network)
+    scatter_axis = int(scatter_axis)
+    layer = add_collective(
+        tensor,
+        trt.CollectiveOperation.REDUCE_SCATTER,
+        trt.ReduceOperation.SUM,
+        scatter_axis,
+        [],
+    )
+    return _finalize_collective_layer(layer, "REDUCE_SCATTER", cp_size)
+
+
+def _verify_trt_collective_support() -> None:
+    """Fail fast if the active TensorRT lacks the SP collective enum members.
+
+    No-op when TensorRT is not importable in the current process (e.g. host
+    tooling or CI runs that do not depend on TRT bindings). When TRT *is*
+    importable, callers can assume the four collective ops exist.
+    """
+    from . import trt_compat
+
+    if not trt_compat.is_available():
+        return
+    try:
+        module = trt_compat.load_module()
+    except ImportError:
+        return
+    collective = getattr(module, "CollectiveOperation", None)
+    if collective is None:
+        return
+    required = ("ALL_REDUCE", "ALL_GATHER", "ALL_TO_ALL", "REDUCE_SCATTER")
+    missing = [name for name in required if not hasattr(collective, name)]
+    if missing:
+        raise RuntimeError(
+            "Active TensorRT is missing required CollectiveOperation members: "
+            f"{missing} (requires TRT 11+)")
+
+
+_verify_trt_collective_support()

--- a/python/tensorrt_model_connect/parallel_config.py
+++ b/python/tensorrt_model_connect/parallel_config.py
@@ -69,6 +69,10 @@ class ParallelConfig:
         if self.mode in _SP_MODES and self.cp_size == 1:
             raise ValueError(
                 f"parallel.mode={self.mode!r} requires parallel.cp_size > 1")
+        # SP modes need TRT 11+ for ALL_GATHER / ALL_TO_ALL / REDUCE_SCATTER.
+        # Only verify here (not at import) so other modes work on TRT 10.
+        if self.mode in _SP_MODES:
+            _verify_trt_collective_support()
 
     def to_config_dict(self) -> dict[str, object]:
         self.validate()
@@ -404,11 +408,12 @@ def add_reduce_scatter_sum(network, tensor, cp_size: int, scatter_axis: int = -1
 
 
 def _verify_trt_collective_support() -> None:
-    """Fail fast if the active TensorRT lacks the SP collective enum members.
+    """Raise if the active TensorRT lacks the SP collective enum members.
 
-    No-op when TensorRT is not importable in the current process (e.g. host
-    tooling or CI runs that do not depend on TRT bindings). When TRT *is*
-    importable, callers can assume the four collective ops exist.
+    Only called when a sequence-parallel mode (sp_ulysses / sp_ring /
+    sp_allgather_kv) is actually requested — not at import time, so unit
+    tests and host tooling that import parallel_config under older TRT
+    builds continue to work.
     """
     from . import trt_compat
 
@@ -427,6 +432,3 @@ def _verify_trt_collective_support() -> None:
         raise RuntimeError(
             "Active TensorRT is missing required CollectiveOperation members: "
             f"{missing} (requires TRT 11+)")
-
-
-_verify_trt_collective_support()

--- a/tests/builder/test_sequence_parallel.py
+++ b/tests/builder/test_sequence_parallel.py
@@ -1,0 +1,357 @@
+"""Tests for sequence-parallel primitives and ParallelConfig SP fields.
+
+The collective primitives are validated against stub network/tensor/layer
+objects that mirror the TRT 11 ``add_dist_collective`` contract. The stubs
+record the arguments TRT would receive and let us assert the declared output
+shape without spinning up a real builder.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from tensorrt_model_connect.parallel_config import (
+    ParallelConfig,
+    add_all_gather,
+    add_all_reduce_sum,
+    add_all_to_all,
+    add_reduce_scatter_sum,
+)
+
+
+# ---------------------------------------------------------------------------
+# Lightweight stubs that imitate the TRT 11 collective layer surface
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeTensor:
+    shape: tuple[int, ...]
+
+
+@dataclass
+class _FakeCollectiveLayer:
+    inp: _FakeTensor
+    op: Any
+    reduce_op: Any
+    axis: Any
+    sizes: list[int]
+    num_ranks: int = 0
+    output_shape: tuple[int, ...] = field(default_factory=tuple)
+
+    def get_output(self, index: int) -> _FakeTensor:
+        assert index == 0
+        return _FakeTensor(shape=self.output_shape)
+
+
+class _FakeCollectiveOperation:
+    ALL_REDUCE = "ALL_REDUCE"
+    ALL_GATHER = "ALL_GATHER"
+    ALL_TO_ALL = "ALL_TO_ALL"
+    REDUCE_SCATTER = "REDUCE_SCATTER"
+
+
+class _FakeReduceOperation:
+    SUM = "SUM"
+    NONE = "NONE"
+
+
+class _FakeTrtModule:
+    CollectiveOperation = _FakeCollectiveOperation
+    ReduceOperation = _FakeReduceOperation
+    __version__ = "11.0.0.114"
+
+
+@dataclass
+class _FakeNetwork:
+    """Records collective calls and emits stub layers with computed shapes."""
+
+    calls: list[dict] = field(default_factory=list)
+    reject_list_axis: bool = False
+
+    def add_dist_collective(self, tensor, op, reduce_op, axis, sizes):
+        if self.reject_list_axis and isinstance(axis, list):
+            raise TypeError("test stub rejects list-axis form")
+        call = {
+            "tensor": tensor,
+            "op": op,
+            "reduce_op": reduce_op,
+            "axis": axis,
+            "sizes": list(sizes),
+        }
+        self.calls.append(call)
+        layer = _FakeCollectiveLayer(
+            inp=tensor,
+            op=op,
+            reduce_op=reduce_op,
+            axis=axis,
+            sizes=list(sizes),
+            output_shape=tuple(tensor.shape),
+        )
+        # The helpers set num_ranks *after* construction; wrap so the setter
+        # recomputes the declared output shape.
+        return _RecordingLayer(layer, op_kind=op, axis=axis, sizes=sizes)
+
+
+class _RecordingLayer:
+    """Wrap _FakeCollectiveLayer so num_ranks assignment recomputes output."""
+
+    def __init__(self, layer: _FakeCollectiveLayer, op_kind, axis, sizes):
+        object.__setattr__(self, "_layer", layer)
+        object.__setattr__(self, "_op_kind", op_kind)
+        object.__setattr__(self, "_axis", axis)
+        object.__setattr__(self, "_sizes", list(sizes))
+
+    @property
+    def num_ranks(self) -> int:
+        return self._layer.num_ranks
+
+    @num_ranks.setter
+    def num_ranks(self, value: int) -> None:
+        self._layer.num_ranks = int(value)
+        self._recompute_shape()
+
+    def _recompute_shape(self) -> None:
+        shape = list(self._layer.inp.shape)
+        n = self._layer.num_ranks
+        kind = self._op_kind
+        axis = self._axis
+        if kind == _FakeCollectiveOperation.ALL_REDUCE:
+            pass  # shape preserved
+        elif kind == _FakeCollectiveOperation.ALL_GATHER:
+            ax = axis if axis >= 0 else len(shape) + axis
+            shape[ax] *= n
+        elif kind == _FakeCollectiveOperation.REDUCE_SCATTER:
+            ax = axis if axis >= 0 else len(shape) + axis
+            shape[ax] //= n
+        elif kind == _FakeCollectiveOperation.ALL_TO_ALL:
+            if isinstance(axis, (list, tuple)):
+                scatter_ax, gather_ax = int(axis[0]), int(axis[1])
+            else:
+                scatter_ax = int(axis)
+                gather_ax = int(self._sizes[0])
+            scatter_ax = scatter_ax if scatter_ax >= 0 else len(shape) + scatter_ax
+            gather_ax = gather_ax if gather_ax >= 0 else len(shape) + gather_ax
+            shape[scatter_ax] *= n
+            shape[gather_ax] //= n
+        self._layer.output_shape = tuple(shape)
+
+    def get_output(self, index: int) -> _FakeTensor:
+        return self._layer.get_output(index)
+
+
+@pytest.fixture
+def fake_trt(monkeypatch):
+    """Patch trt_compat.get_trt + is_available so helpers see our fake module."""
+    from tensorrt_model_connect import trt_compat
+
+    monkeypatch.setattr(trt_compat, "get_trt", lambda: _FakeTrtModule())
+    monkeypatch.setattr(trt_compat, "is_available", lambda module_name=None: True)
+    monkeypatch.setattr(trt_compat, "load_module", lambda: _FakeTrtModule())
+    return _FakeTrtModule()
+
+
+# ---------------------------------------------------------------------------
+# ParallelConfig sequence-parallel validation
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_config_defaults_to_cp_size_one() -> None:
+    cfg = ParallelConfig()
+    cfg.validate()
+    assert cfg.cp_size == 1
+    assert cfg.world_size == 1
+    assert cfg.enabled is False
+
+
+def test_parallel_config_accepts_sp_ulysses_with_cp_size() -> None:
+    cfg = ParallelConfig(mode="sp_ulysses", cp_size=4, rank=2)
+    cfg.validate()
+    assert cfg.enabled is True
+    assert cfg.world_size == 4
+
+
+def test_parallel_config_accepts_sp_ring_and_allgather_kv() -> None:
+    for mode in ("sp_ring", "sp_allgather_kv"):
+        cfg = ParallelConfig(mode=mode, cp_size=2, rank=0)
+        cfg.validate()
+        assert cfg.enabled is True
+
+
+def test_parallel_config_rejects_cp_size_with_tensor_parallel_mode() -> None:
+    with pytest.raises(ValueError, match="cp_size"):
+        ParallelConfig(mode="tensor_parallel", tp_size=2, cp_size=2).validate()
+
+
+def test_parallel_config_rejects_cp_size_with_single_mode() -> None:
+    with pytest.raises(ValueError, match="cp_size"):
+        ParallelConfig(mode="single", cp_size=2).validate()
+
+
+def test_parallel_config_rejects_sp_mode_without_cp_size() -> None:
+    with pytest.raises(ValueError, match="cp_size"):
+        ParallelConfig(mode="sp_ulysses", cp_size=1).validate()
+
+
+def test_parallel_config_rejects_non_power_of_two_cp_size() -> None:
+    with pytest.raises(ValueError, match="cp_size"):
+        ParallelConfig(mode="sp_ring", cp_size=3).validate()
+
+
+def test_parallel_config_rejects_cp_size_too_large() -> None:
+    with pytest.raises(ValueError, match="cp_size"):
+        ParallelConfig(mode="sp_ring", cp_size=16).validate()
+
+
+def test_parallel_config_rejects_zero_cp_size() -> None:
+    with pytest.raises(ValueError, match="cp_size"):
+        ParallelConfig(mode="sp_ring", cp_size=0).validate()
+
+
+def test_parallel_config_allows_hybrid_tp_and_cp() -> None:
+    # Hybrid TP + SP is allowed for future work, even though no caller
+    # consumes it yet. The dataclass must not reject simultaneous tp_size > 1
+    # and cp_size > 1.
+    cfg = ParallelConfig(mode="sp_ulysses", tp_size=2, cp_size=2, rank=3)
+    cfg.validate()
+    assert cfg.enabled is True
+    assert cfg.world_size == 4
+
+
+def test_parallel_config_world_size_hybrid_product() -> None:
+    cfg = ParallelConfig(mode="sp_ring", tp_size=4, cp_size=2, rank=0)
+    cfg.validate()
+    assert cfg.world_size == 8
+
+
+def test_parallel_config_to_config_dict_includes_cp_size() -> None:
+    cfg = ParallelConfig(mode="sp_ulysses", cp_size=2, rank=0)
+    data = cfg.to_config_dict()
+    assert data["cp_size"] == 2
+    assert data["mode"] == "sp_ulysses"
+
+
+# ---------------------------------------------------------------------------
+# Collective primitive shape declarations
+# ---------------------------------------------------------------------------
+
+
+def test_add_all_gather_grows_axis_by_cp_size(fake_trt) -> None:
+    net = _FakeNetwork()
+    inp = _FakeTensor(shape=(1, 4, 16))
+
+    out = add_all_gather(net, inp, cp_size=2, gather_axis=-1)
+
+    assert isinstance(out, _FakeTensor)
+    assert out.shape == (1, 4, 32)
+    assert len(net.calls) == 1
+    call = net.calls[0]
+    assert call["op"] == _FakeCollectiveOperation.ALL_GATHER
+    assert call["reduce_op"] == _FakeReduceOperation.NONE
+    assert call["axis"] == -1
+    assert call["sizes"] == []
+
+
+def test_add_all_gather_pass_through_when_cp_size_one(fake_trt) -> None:
+    net = _FakeNetwork()
+    inp = _FakeTensor(shape=(1, 4, 16))
+
+    out = add_all_gather(net, inp, cp_size=1, gather_axis=-1)
+
+    assert out is inp
+    assert net.calls == []
+
+
+def test_add_all_to_all_redistributes_axes(fake_trt) -> None:
+    net = _FakeNetwork()
+    inp = _FakeTensor(shape=(1, 4, 16))
+
+    out = add_all_to_all(net, inp, cp_size=2, scatter_axis=1, gather_axis=2)
+
+    assert out.shape == (1, 8, 8)
+    call = net.calls[0]
+    assert call["op"] == _FakeCollectiveOperation.ALL_TO_ALL
+    assert call["axis"] == [1, 2]
+
+
+def test_add_all_to_all_falls_back_to_scalar_axis(fake_trt) -> None:
+    net = _FakeNetwork(reject_list_axis=True)
+    inp = _FakeTensor(shape=(1, 4, 16))
+
+    out = add_all_to_all(net, inp, cp_size=2, scatter_axis=1, gather_axis=2)
+
+    assert out.shape == (1, 8, 8)
+    # First call attempted the list form and the stub raised TypeError.
+    # Only the successful scalar call is recorded.
+    assert len(net.calls) == 1
+    call = net.calls[0]
+    assert call["axis"] == 1
+    assert call["sizes"] == [2]
+
+
+def test_add_all_to_all_rejects_identical_axes(fake_trt) -> None:
+    net = _FakeNetwork()
+    inp = _FakeTensor(shape=(1, 4, 16))
+
+    with pytest.raises(RuntimeError, match="must differ"):
+        add_all_to_all(net, inp, cp_size=2, scatter_axis=1, gather_axis=1)
+
+
+def test_add_reduce_scatter_sum_shrinks_axis(fake_trt) -> None:
+    net = _FakeNetwork()
+    inp = _FakeTensor(shape=(1, 4, 16))
+
+    out = add_reduce_scatter_sum(net, inp, cp_size=2, scatter_axis=-1)
+
+    assert out.shape == (1, 4, 8)
+    call = net.calls[0]
+    assert call["op"] == _FakeCollectiveOperation.REDUCE_SCATTER
+    assert call["reduce_op"] == _FakeReduceOperation.SUM
+
+
+def test_add_all_reduce_sum_preserves_shape(fake_trt) -> None:
+    net = _FakeNetwork()
+    inp = _FakeTensor(shape=(1, 4, 16))
+
+    out = add_all_reduce_sum(net, inp, tp_size=2)
+
+    assert out.shape == (1, 4, 16)
+    call = net.calls[0]
+    assert call["op"] == _FakeCollectiveOperation.ALL_REDUCE
+    assert call["reduce_op"] == _FakeReduceOperation.SUM
+    assert call["axis"] == -1
+
+
+# ---------------------------------------------------------------------------
+# Defensive error paths
+# ---------------------------------------------------------------------------
+
+
+def test_primitives_raise_when_add_dist_collective_missing(fake_trt) -> None:
+    class _NoCollectiveNet:
+        pass
+
+    inp = _FakeTensor(shape=(1, 4, 16))
+
+    with pytest.raises(RuntimeError, match="TRT 11"):
+        add_all_gather(_NoCollectiveNet(), inp, cp_size=2)
+    with pytest.raises(RuntimeError, match="TRT 11"):
+        add_all_to_all(
+            _NoCollectiveNet(), inp, cp_size=2, scatter_axis=1, gather_axis=2)
+    with pytest.raises(RuntimeError, match="TRT 11"):
+        add_reduce_scatter_sum(_NoCollectiveNet(), inp, cp_size=2)
+
+
+def test_primitives_reject_negative_parallel_size(fake_trt) -> None:
+    net = _FakeNetwork()
+    inp = _FakeTensor(shape=(1, 4, 16))
+
+    with pytest.raises(RuntimeError, match="parallel_size"):
+        add_all_gather(net, inp, cp_size=-1)
+    with pytest.raises(RuntimeError, match="parallel_size"):
+        add_all_to_all(net, inp, cp_size=-2, scatter_axis=1, gather_axis=2)
+    with pytest.raises(RuntimeError, match="parallel_size"):
+        add_reduce_scatter_sum(net, inp, cp_size=-3)

--- a/tests/e2e/models/cosmos-predict2-14b-l0.json
+++ b/tests/e2e/models/cosmos-predict2-14b-l0.json
@@ -1,0 +1,38 @@
+{
+  "name": "cosmos-predict2-14b-l0",
+  "trace_id": "IT-E2E-COSMOS-PREDICT2-14B-L0-01",
+  "hf_id": "nvidia/Cosmos-Predict2-14B-Video2World",
+  "bundle": "cosmos-predict2-14b-l0.trtfb",
+  "model_type": "cosmos_predict",
+  "family": "cosmos_predict",
+  "runtime_strategy": "diffusion",
+  "ci_tier": "l0_only",
+  "reference_family": "diffusers_video_gen",
+  "user_contract": "diffusion_video",
+  "description": "Cosmos-Predict2 14B Video2World — high-res image+text conditioned video diffusion (T5 + CosmosTransformer3DModel 36L/40H/d128 + AutoencoderKLWan). L0 scaffold targets 384x672 at 5 frames / 15 steps; full sweep runs 720x1280 / 49 frames on B200.",
+  "build_args": {
+    "max_cache_length": 256
+  },
+  "test_prompt": "A robot arm carefully picks up a red cube from a table",
+  "test_image": "first_frame.png",
+  "test_type": "diffusion",
+  "video_num_frames": 5,
+  "video_height": 384,
+  "video_width": 672,
+  "num_inference_steps": 15,
+  "num_conditioning_frames": 1,
+  "guidance_scale": 7.0,
+  "flow_shift": 7.0,
+  "stages": [
+    {
+      "name": "end_to_end",
+      "required": true
+    }
+  ],
+  "min_pixel_mean": 0.10,
+  "max_pixel_mean": 0.90,
+  "min_pixel_std": 0.04,
+  "skip_text_comparison": true,
+  "skip": "scaffold only — 14B dense DiT + 3 SP variants (Ulysses, Ring, AllGather-KV) land in this PR but require B200 host validation; remove once latency sweep evidence is posted",
+  "notes": "Cosmos-Predict2 14B Video2World reuses Wan T2V's T5-11B encoder and AutoencoderKLWan VAE (per nvidia/Cosmos-Predict2-14B-Video2World/vae/config.json _name_or_path=Wan-AI/Wan2.1-T2V-1.3B-Diffusers). DiT is CosmosTransformer3DModel: hidden=5120, num_layers=36, num_heads=40, head_dim=128, ffn_dim=20480, qk_norm=rms, 3 adaLN-Zero norms per block with LoRA decomposition (rank=256), 3-axis RoPE per (T,H,W). The three SP variants ship with this PR and are exercised by tests/builder/test_sequence_parallel.py for primitive correctness."
+}


### PR DESCRIPTION
## Summary

Implements the Cosmos-Predict 2 14B Video2World DiT in TRT (CosmosTransformer3DModel) and three sequence-parallel variants (Ulysses, RingAttention, AllGather-KV) for context-parallel scaling on multi-GPU hosts.

This unblocks the B200 latency-sweep benchmark requested for 14B at 720p×1280×49 frames across cp=2/4/8.

## Commits

1. **feat(cosmos_predict): Cosmos-Predict 2 14B Video2World DiT TRT builder** (957 LOC dense builder + 415 LOC plugin)
   - 36 layers × 40 heads × 128 head_dim → hidden=5120
   - 3 CosmosAdaLayerNormZero per block (LoRA-style modulation)
   - Self-attention (RMSNorm Q+K, 3-axis RoPE) → cross-attention to T5 → FFN
   - Reuses `wan_t2v.t5_encoder_builder` (T5-11B) and `wan_t2v.causal_vae_3d_builder` (AutoencoderKLWan from Wan 2.1 — confirmed in `vae/config.json`)

2. **feat(parallel_config): sequence-parallel infrastructure for SP modes**
   - New `ParallelConfig.cp_size` field, modes: `sp_ulysses`, `sp_ring`, `sp_allgather_kv`
   - `add_all_gather`, `add_all_to_all`, `add_reduce_scatter_sum` wrapping TRT 11 collectives
   - Verified TRT 11.0.0.114 exposes ALL_REDUCE + ALL_GATHER + ALL_TO_ALL + REDUCE_SCATTER + BROADCAST + GATHER + REDUCE + SCATTER
   - 18 unit tests in `tests/builder/test_sequence_parallel.py`

3. **feat(cosmos_predict): 3 sequence-parallel DiT builder variants + plugin dispatch**
   - `cosmos_dit_ulysses_builder.py` (610 LOC) — AlltoAll Q/K/V heads↔seq
   - `cosmos_dit_ring_builder.py` (531 LOC) — simplified one-pass Ring (AllGather K/V once)
   - `cosmos_dit_allgather_kv_builder.py` (455 LOC) — AllGather K/V
   - Plugin dispatch: routes by `parallel.mode`

## Test plan

- [x] All files ast.parse-clean
- [x] Phase 2 unit tests (18 cases) cover collective primitive shape declarations and ParallelConfig validation
- [ ] **GPU validation pending** — needs B200 host with NCCL 2.30+ and accepted Cosmos-Predict2-14B HF license
- [ ] Phase 4: latency sweep cp=2/4/8 manifests + perf table

## Open Qs for first GPU run (per commit docstrings)

- Diffusers AdaLN-LoRA key naming (`linear_3` vs `embedded_timestep_proj`)
- RoPE axis dim split (assumed (16, 56, 56); CosmosRotaryPosEmbed may differ)
- LayerNorm eps (1e-6 vs 1e-5)
- Online-softmax Ring (current Ring is one-pass; cp_size-step unrolled is a follow-up)

## Out of scope

- Cosmos-Predict 2 single-device dense and the SP variants share the same engine I/O contract; the C++ diffusion runtime needs a `diffusion_cosmos` strategy hook OR can reuse `diffusion_wan` if shape contracts match. Phase 4 will determine which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)