### PR TITLE
ci: attach comment-triggered checks to PRs

### DIFF
--- a/.github/workflows/request-trtmc-ci.yml
+++ b/.github/workflows/request-trtmc-ci.yml
@@ -43,12 +43,20 @@ jobs:
         if: ${{ steps.command.outputs.requested == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_API_URL: ${{ github.event.issue.pull_request.url }}
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
+          head_ref="$(gh api "$PR_API_URL" --jq '.head.ref')"
+          head_repo="$(gh api "$PR_API_URL" --jq '.head.repo.full_name')"
+          if [ "$head_repo" != "$GITHUB_REPOSITORY" ]; then
+            echo "::error::/trtmc-ci only supports pull requests from branches in $GITHUB_REPOSITORY"
+            exit 1
+          fi
+
           gh workflow run trtmc-ci.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref main \
+            --ref "$head_ref" \
             -f checkout_ref="refs/pull/${PR_NUMBER}/merge" \
             -f base_ref="origin/main"
 

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -137,8 +137,13 @@ def test_comment_router_dispatches_requested_ci_and_deletes_itself() -> None:
     assert "IS_PULL_REQUEST: ${{ github.event.issue.pull_request != null }}" in text
     assert "first_line == os.environ[\"COMMAND\"]" in text
     assert "requested = is_pull_request and first_line == os.environ[\"COMMAND\"]" in text
+    assert "PR_API_URL: ${{ github.event.issue.pull_request.url }}" in text
+    assert "gh api \"$PR_API_URL\" --jq '.head.ref'" in text
+    assert "gh api \"$PR_API_URL\" --jq '.head.repo.full_name'" in text
+    assert "only supports pull requests from branches in $GITHUB_REPOSITORY" in text
     assert "gh workflow run trtmc-ci.yml" in text
-    assert "--ref main" in text
+    assert '--ref "$head_ref"' in text
+    assert "--ref main" not in text
     assert 'checkout_ref="refs/pull/${PR_NUMBER}/merge"' in text
     assert 'base_ref="origin/main"' in text
     assert 'pr_number="$PR_NUMBER"' not in text


### PR DESCRIPTION
## Background
The `/trtmc-ci` router merged in PR #206 successfully dispatches CI from a PR comment, but the dispatched run is associated with `main` because the router invokes `workflow_dispatch` with `--ref main`. That makes the run visible in Actions but not attached to the PR checks UI.

## Exit Criteria
- `/trtmc-ci` still validates the PR merge ref.
- The dispatched workflow uses the PR head branch as the workflow dispatch ref so GitHub can associate the check suite with the PR.
- Issue comments and non-command comments still do not dispatch CI.

## Implementation
- Resolve the PR head branch and head repository from the PR API before dispatching `trtmc-ci.yml`.
- Dispatch `trtmc-ci.yml` with `--ref <PR head branch>` while keeping `checkout_ref=refs/pull/<PR>/merge` so validation still runs on the merge ref.
- Reject fork PRs for this path because their head branch is not dispatchable in this repository with the current workflow.
- Updated the GitHub Actions wiring test to lock down head-branch dispatch and prevent regressing back to `--ref main`.

## Validation
- `python3 -m pytest tests/tools/test_github_actions_ci.py -q`: passed, 29 tests.
- YAML parse for all `.github/workflows/*.yml`: passed.
- `git -c filter.lfs.required=false -c filter.lfs.clean= -c filter.lfs.smudge= -c filter.lfs.process= diff --check`: passed.

## Notes For Future Readers
- This keeps the KISS comment-router model from PR #206. The only behavior change is the workflow dispatch ref.
- If fork PR support is needed later, use an explicit status/checks API path instead of dispatching the workflow from a branch ref that does not exist in this repository.
