### PR TITLE
ci: allow comment router to read PR metadata

### DIFF
--- a/.github/workflows/request-trtmc-ci.yml
+++ b/.github/workflows/request-trtmc-ci.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: write
   contents: read
+  pull-requests: read
 
 concurrency:
   group: trtmc-ci-comment-router-${{ github.event.comment.id }}

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -132,6 +132,7 @@ def test_comment_router_dispatches_requested_ci_and_deletes_itself() -> None:
     text = (REPO_ROOT / ".github" / "workflows" / "request-trtmc-ci.yml").read_text()
     assert "issue_comment:" in text
     assert "actions: write" in text
+    assert "pull-requests: read" in text
     assert "COMMENT_BODY: ${{ github.event.comment.body }}" in text
     assert "COMMAND: /trtmc-ci" in text
     assert "IS_PULL_REQUEST: ${{ github.event.issue.pull_request != null }}" in text


### PR DESCRIPTION
## Background
The /trtmc-ci comment router now reads pull request metadata before dispatching CI so the dispatched run can target the PR head branch and attach checks to the PR. The built-in GITHUB_TOKEN had actions: write and contents: read, but not pull-requests: read, so the metadata lookup failed with gh: Resource not accessible by integration (HTTP 403).

## Exit Criteria
- /trtmc-ci can read same-repository pull request metadata using the built-in workflow token.
- No personal access token or extra secret is required.

## Implementation
- Grant pull-requests: read to the comment router workflow permissions.
- Add a workflow wiring assertion so future edits keep that permission in place.

## Validation
- python3 -m pytest tests/tools/test_github_actions_ci.py -q: passed, 29 tests.
- python3 YAML parse check: passed, workflow YAML parses.
- git diff --check github/main..HEAD: passed.

## Notes For Future Readers
- actions: write is for gh workflow run; pull-requests: read is for gh api .../pulls/{number}. Both are intentionally scoped to the built-in token.