### PR TITLE
fix(tests): skip torch-trt time-series e2e when trtmc binary is absent

### DIFF
--- a/tests/engine_defs/torch_trt/test_time_series_e2e.py
+++ b/tests/engine_defs/torch_trt/test_time_series_e2e.py
@@ -23,7 +23,37 @@ transformers = pytest.importorskip("transformers")
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-TRTMC_BIN = REPO_ROOT / "build" / "trtmc"
+
+
+def _resolve_trtmc_binary() -> Path:
+    """Resolve the C++ trtmc binary, honoring the ``TRTMC_BINARY`` override.
+
+    Mirrors the resolution used by the canonical ``trtmc_binary`` e2e fixture
+    and ``test_family_elf``: an explicit ``TRTMC_BINARY`` wins (e.g. the wheel
+    entrypoint CI installs, ``command -v trtmc``), otherwise fall back to the
+    source-tree ``build/trtmc`` used in local dev.
+    """
+    env_path = os.environ.get("TRTMC_BINARY")
+    if env_path:
+        return Path(env_path)
+    return REPO_ROOT / "build" / "trtmc"
+
+
+TRTMC_BIN = _resolve_trtmc_binary()
+
+
+def _require_trtmc_binary() -> None:
+    """Skip (don't fail) when the trtmc binary prerequisite is unavailable.
+
+    A missing build artifact is an environment gap, not a product defect, so it
+    is gated like the ``@requires_gpu`` / ``@requires_torchtrt`` prerequisites
+    above and like the sibling ``test_pixart_vs_hf`` test, which also skips.
+    """
+    if not TRTMC_BIN.is_file():
+        pytest.skip(
+            f"trtmc binary not found: {TRTMC_BIN} "
+            "(set TRTMC_BINARY to the installed entrypoint, or build ./build/trtmc)"
+        )
 
 
 def _has_torchtrt() -> bool:
@@ -72,7 +102,7 @@ def _parse_solve_stdout(stdout: str) -> torch.Tensor:
 
 
 def _build_bundle(model_dir: Path, bundle_path: Path, *, max_cache_length: int) -> None:
-    assert TRTMC_BIN.exists(), f"Expected built trtmc binary at {TRTMC_BIN}"
+    _require_trtmc_binary()
     _run(
         [
             str(TRTMC_BIN),
@@ -109,7 +139,7 @@ def _run_solve(bundle_path: Path, *, field_input: list[float] | None = None,
 @requires_torchtrt
 @requires_gpu
 def test_time_series_models_match_reference_end_to_end():
-    assert TRTMC_BIN.exists(), f"Expected built binary at {TRTMC_BIN}"
+    _require_trtmc_binary()
 
     torch.manual_seed(0)
 


### PR DESCRIPTION
## What

`tests/engine_defs/torch_trt/test_time_series_e2e.py` hard-asserted a source-tree
`build/trtmc` binary, so it **failed** (rather than skipped) anywhere that path is not
populated — including the CI wheel/conan flow, where `trtmc` is installed on `PATH`
instead. A missing build artifact is an environment gap, not a product defect, so it
should skip.

This change resolves the binary the way the rest of the suite already does:

- honor a **`TRTMC_BINARY`** override (as `test_family_elf._find_trtmc_binary` does),
  falling back to the source-tree `build/trtmc` for local dev;
- **`pytest.skip`** when the binary is not found — matching the canonical `trtmc_binary`
  e2e fixture and the directory sibling `test_pixart_vs_hf.py`, both of which already skip.

To make the test **actually execute** in CI (rather than skip), set
`TRTMC_BINARY=$(command -v trtmc)` in the stage that runs `tests/engine_defs/torch_trt/`,
exactly as the selective-e2e stage already injects the installed entrypoint — a CI-config
choice for the owner.

## Why

The test only runs under **broad tier-level** test selection (impact analysis with no
coverage map), which a `shared_builder_module` change triggers. There it produced a
**false red** that blocked an unrelated PR. Full root-cause analysis in #209.

## Validation

- `ruff check --config ruff.toml` on the changed file: passes.
- Binary absent → the test now **skips** cleanly instead of failing:
  ```
  TRTMC_BINARY=/nonexistent/trtmc pytest tests/engine_defs/torch_trt/test_time_series_e2e.py
  SKIPPED [1] ...: trtmc binary not found: /nonexistent/trtmc (set TRTMC_BINARY ...)
  1 skipped
  ```
  (`@requires_torchtrt` / `@requires_gpu` did not skip it — torch-tensorrt and a GPU were
  present — so this is the new binary guard firing, not an unrelated skip.)

No behavior change when a binary is present: the test runs exactly as before.

Fixes #209
