### PR TITLE
ci: trigger premerge checks from PR labels

### DIFF
--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -60,7 +60,7 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         (
           github.event_name == 'pull_request' &&
-          contains(fromJSON('["run-e2e", "run-full-ci"]'), github.event.label.name)
+          github.event.label.name == 'run-ci'
         )
       }}
     runs-on: ${{ fromJSON(vars.TRTMC_RUNNER_LABELS || '["self-hosted"]') }}
@@ -241,7 +241,7 @@ jobs:
           ${{
             always() &&
             github.event_name == 'pull_request' &&
-            contains(fromJSON('["run-e2e", "run-full-ci"]'), github.event.label.name)
+            github.event.label.name == 'run-ci'
           }}
         continue-on-error: true
         uses: actions/github-script@v7

--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -1,9 +1,14 @@
 name: TensorRT-Model-Connect Premerge CI
 
+run-name: >-
+  ${{ github.event_name == 'pull_request' && format('PR #{0} {1}', github.event.pull_request.number, github.event.label.name) || format('Manual {0}', github.ref_name) }}
+
 on:
   pull_request:
     branches:
       - main
+    types:
+      - labeled
     paths-ignore:
       - "website/**"
       - ".github/workflows/pages.yml"
@@ -11,6 +16,8 @@ on:
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: read
 
 concurrency:
   group: trtmc-ci-${{ github.workflow }}-${{ github.ref }}
@@ -48,6 +55,14 @@ env:
 jobs:
   premerge-ci:
     name: Premerge CI
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request' &&
+          contains(fromJSON('["run-e2e", "run-full-ci"]'), github.event.label.name)
+        )
+      }}
     runs-on: ${{ fromJSON(vars.TRTMC_RUNNER_LABELS || '["self-hosted"]') }}
     timeout-minutes: 720
 
@@ -220,3 +235,30 @@ jobs:
       - name: Stop CI container
         if: always()
         run: docker rm -f "$TRTMC_CI_CONTAINER_NAME" >/dev/null 2>&1 || true
+
+      - name: Remove trigger label
+        if: >-
+          ${{
+            always() &&
+            github.event_name == 'pull_request' &&
+            contains(fromJSON('["run-e2e", "run-full-ci"]'), github.event.label.name)
+          }}
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = context.payload.label.name;
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: label,
+              });
+            } catch (error) {
+              if (error.status === 404) {
+                core.info(`Trigger label '${label}' was already removed.`);
+                return;
+              }
+              throw error;
+            }

--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -16,8 +16,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: read
 
 concurrency:
   group: trtmc-ci-${{ github.workflow }}-${{ github.ref }}
@@ -235,30 +233,3 @@ jobs:
       - name: Stop CI container
         if: always()
         run: docker rm -f "$TRTMC_CI_CONTAINER_NAME" >/dev/null 2>&1 || true
-
-      - name: Remove trigger label
-        if: >-
-          ${{
-            always() &&
-            github.event_name == 'pull_request' &&
-            github.event.label.name == 'run-ci'
-          }}
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const label = context.payload.label.name;
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                name: label,
-              });
-            } catch (error) {
-              if (error.status === 404) {
-                core.info(`Trigger label '${label}' was already removed.`);
-                return;
-              }
-              throw error;
-            }

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -111,6 +111,35 @@ def test_github_workflows_keep_html_report_in_full_artifacts() -> None:
         assert "!e2e_artifacts/e2e_report.html" not in text
 
 
+def test_premerge_ci_runs_from_manual_dispatch_or_trigger_labels() -> None:
+    text = (REPO_ROOT / ".github" / "workflows" / "trtmc-ci.yml").read_text()
+    trigger_block = text.split("permissions:", maxsplit=1)[0]
+    assert "pull_request:" in trigger_block
+    assert "types:" in trigger_block
+    assert "- labeled" in trigger_block
+    assert "workflow_dispatch:" in trigger_block
+    assert "push:" not in trigger_block
+    assert "issues: write" in text
+    assert "pull-requests: read" in text
+    assert "github.event_name == 'workflow_dispatch'" in text
+    assert 'contains(fromJSON(\'["run-e2e", "run-full-ci"]\'), github.event.label.name)' in text
+    assert "Remove trigger label" in text
+    assert "continue-on-error: true" in text
+    assert "actions/github-script@v7" in text
+    assert "github.rest.issues.removeLabel" in text
+    assert "context.payload.pull_request.number" in text
+
+
+def test_label_triggered_premerge_ci_uses_pr_merge_ref_checkout() -> None:
+    text = (REPO_ROOT / ".github" / "workflows" / "trtmc-ci.yml").read_text()
+    checkout_block = text.split("- name: Check out source", maxsplit=1)[1].split(
+        "\n\n",
+        maxsplit=1,
+    )[0]
+    assert "uses: actions/checkout@v4" in checkout_block
+    assert "ref:" not in checkout_block
+
+
 def test_nightly_workflow_dispatch_can_validate_requested_ref() -> None:
     text = (REPO_ROOT / ".github" / "workflows" / "nightly.yml").read_text()
     assert "workflow_dispatch:" in text

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -122,7 +122,9 @@ def test_premerge_ci_runs_from_manual_dispatch_or_trigger_labels() -> None:
     assert "issues: write" in text
     assert "pull-requests: read" in text
     assert "github.event_name == 'workflow_dispatch'" in text
-    assert 'contains(fromJSON(\'["run-e2e", "run-full-ci"]\'), github.event.label.name)' in text
+    assert "github.event.label.name == 'run-ci'" in text
+    assert "run-e2e" not in text
+    assert "run-full-ci" not in text
     assert "Remove trigger label" in text
     assert "continue-on-error: true" in text
     assert "actions/github-script@v7" in text

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -119,17 +119,15 @@ def test_premerge_ci_runs_from_manual_dispatch_or_trigger_labels() -> None:
     assert "- labeled" in trigger_block
     assert "workflow_dispatch:" in trigger_block
     assert "push:" not in trigger_block
-    assert "issues: write" in text
-    assert "pull-requests: read" in text
+    assert "issues: write" not in text
+    assert "pull-requests: read" not in text
     assert "github.event_name == 'workflow_dispatch'" in text
     assert "github.event.label.name == 'run-ci'" in text
     assert "run-e2e" not in text
     assert "run-full-ci" not in text
-    assert "Remove trigger label" in text
-    assert "continue-on-error: true" in text
-    assert "actions/github-script@v7" in text
-    assert "github.rest.issues.removeLabel" in text
-    assert "context.payload.pull_request.number" in text
+    assert "Remove trigger label" not in text
+    assert "actions/github-script" not in text
+    assert "github.rest.issues.removeLabel" not in text
 
 
 def test_label_triggered_premerge_ci_uses_pr_merge_ref_checkout() -> None:


### PR DESCRIPTION
## Background
The comment-router approach for on-demand CI was reverted because it created dispatch-schema and cleanup failure modes. This PR implements the simpler PR-page trigger path: add one trigger label to the PR and let the existing pull_request workflow run against GitHub's PR merge ref.

## Exit Criteria
- Normal PR open/synchronize activity does not trigger premerge CI after this lands.
- Adding `run-ci` to a PR starts the premerge workflow.
- The run remains a `pull_request` workflow with the default checkout behavior, so the result attaches to the PR checks UI.
- Developers manually remove and re-add `run-ci` when they want another run.

## Implementation
- Narrowed `trtmc-ci.yml` to `pull_request: types: [labeled]` plus manual `workflow_dispatch`.
- Gated the job to manual runs or the `run-ci` label.
- Left trigger-label cleanup manual to avoid GitHub token failures from PR-triggered label mutation.
- Added tests that lock down the trigger label, absence of automatic label mutation, and default PR merge-ref checkout behavior.

## Validation
- `python3 -m pytest tests/tools/test_github_actions_ci.py -q`: passed, 28 tests.
- `bash -n .github/scripts/run-trtmc-ci.sh && bash -n .github/scripts/run-gha-stage.sh`: passed.
- YAML parse for `.github/workflows/*.yml`: passed.
- `git diff --check`: passed.
- Added `run-ci` to PR #213: produced an attached `Premerge CI` pull_request check.

## Notes For Future Readers
To run premerge CI manually after this lands, add the `run-ci` label to the PR. The workflow starts from the PR label event and uses GitHub's default PR merge ref checkout. To request another run, remove `run-ci` and add it again. Nightly remains scheduled separately and is not part of this trigger.
