### PR TITLE
Revert "fix(tests): skip torch-trt time-series e2e when trtmc binary is absent"

### DIFF
--- a/tests/engine_defs/torch_trt/test_time_series_e2e.py
+++ b/tests/engine_defs/torch_trt/test_time_series_e2e.py
@@ -23,37 +23,7 @@ transformers = pytest.importorskip("transformers")
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-
-
-def _resolve_trtmc_binary() -> Path:
-    """Resolve the C++ trtmc binary, honoring the ``TRTMC_BINARY`` override.
-
-    Mirrors the resolution used by the canonical ``trtmc_binary`` e2e fixture
-    and ``test_family_elf``: an explicit ``TRTMC_BINARY`` wins (e.g. the wheel
-    entrypoint CI installs, ``command -v trtmc``), otherwise fall back to the
-    source-tree ``build/trtmc`` used in local dev.
-    """
-    env_path = os.environ.get("TRTMC_BINARY")
-    if env_path:
-        return Path(env_path)
-    return REPO_ROOT / "build" / "trtmc"
-
-
-TRTMC_BIN = _resolve_trtmc_binary()
-
-
-def _require_trtmc_binary() -> None:
-    """Skip (don't fail) when the trtmc binary prerequisite is unavailable.
-
-    A missing build artifact is an environment gap, not a product defect, so it
-    is gated like the ``@requires_gpu`` / ``@requires_torchtrt`` prerequisites
-    above and like the sibling ``test_pixart_vs_hf`` test, which also skips.
-    """
-    if not TRTMC_BIN.is_file():
-        pytest.skip(
-            f"trtmc binary not found: {TRTMC_BIN} "
-            "(set TRTMC_BINARY to the installed entrypoint, or build ./build/trtmc)"
-        )
+TRTMC_BIN = REPO_ROOT / "build" / "trtmc"
 
 
 def _has_torchtrt() -> bool:
@@ -102,7 +72,7 @@ def _parse_solve_stdout(stdout: str) -> torch.Tensor:
 
 
 def _build_bundle(model_dir: Path, bundle_path: Path, *, max_cache_length: int) -> None:
-    _require_trtmc_binary()
+    assert TRTMC_BIN.exists(), f"Expected built trtmc binary at {TRTMC_BIN}"
     _run(
         [
             str(TRTMC_BIN),
@@ -139,7 +109,7 @@ def _run_solve(bundle_path: Path, *, field_input: list[float] | None = None,
 @requires_torchtrt
 @requires_gpu
 def test_time_series_models_match_reference_end_to_end():
-    _require_trtmc_binary()
+    assert TRTMC_BIN.exists(), f"Expected built binary at {TRTMC_BIN}"
 
     torch.manual_seed(0)
 


### PR DESCRIPTION
Reverts NVIDIA/TensorRT-Model-Connect#214

Will investigate with @yifeif-nv and figure out a better solution.