### PR TITLE
fix(tests): run time-series e2e against the installed trtmc binary (not just ./build)

### DIFF
--- a/tests/engine_defs/torch_trt/test_time_series_e2e.py
+++ b/tests/engine_defs/torch_trt/test_time_series_e2e.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import shutil
 from pathlib import Path
 import subprocess
 import tempfile
@@ -23,7 +24,39 @@ transformers = pytest.importorskip("transformers")
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-TRTMC_BIN = REPO_ROOT / "build" / "trtmc"
+
+
+def _resolve_trtmc_binary() -> Path | None:
+    """Resolve the C++ trtmc binary, preferring an explicit override, then a
+    local source build, then the trtmc installed on PATH.
+
+    In CI there is no source-tree ``build/trtmc``; the wheel installs the native
+    trtmc on PATH (``command -v trtmc``), so ``shutil.which`` finds it and the
+    test runs against the packaged binary. Locally, ``build/trtmc`` (a fresh
+    source build) takes precedence, and ``TRTMC_BINARY`` overrides everything.
+    """
+    for candidate in (
+        os.environ.get("TRTMC_BINARY"),
+        str(REPO_ROOT / "build" / "trtmc"),
+        shutil.which("trtmc"),
+    ):
+        if candidate and Path(candidate).is_file():
+            return Path(candidate)
+    return None
+
+
+TRTMC_BIN = _resolve_trtmc_binary()
+
+
+def _require_trtmc_binary() -> Path:
+    """Skip only when no trtmc binary can be found anywhere (a missing build
+    artifact is an environment gap, gated like ``@requires_gpu``)."""
+    if TRTMC_BIN is None:
+        pytest.skip(
+            "trtmc binary not found (set TRTMC_BINARY, build ./build/trtmc, "
+            "or install the trtmc wheel so it is on PATH)"
+        )
+    return TRTMC_BIN
 
 
 def _has_torchtrt() -> bool:
@@ -72,7 +105,7 @@ def _parse_solve_stdout(stdout: str) -> torch.Tensor:
 
 
 def _build_bundle(model_dir: Path, bundle_path: Path, *, max_cache_length: int) -> None:
-    assert TRTMC_BIN.exists(), f"Expected built trtmc binary at {TRTMC_BIN}"
+    _require_trtmc_binary()
     _run(
         [
             str(TRTMC_BIN),
@@ -109,7 +142,7 @@ def _run_solve(bundle_path: Path, *, field_input: list[float] | None = None,
 @requires_torchtrt
 @requires_gpu
 def test_time_series_models_match_reference_end_to_end():
-    assert TRTMC_BIN.exists(), f"Expected built binary at {TRTMC_BIN}"
+    _require_trtmc_binary()
 
     torch.manual_seed(0)
 


### PR DESCRIPTION
## What

Make `tests/engine_defs/torch_trt/test_time_series_e2e.py` resolve the `trtmc`
binary from the locations that actually exist, in priority order, and **run**
against it — instead of hard-asserting a source-tree `./build/trtmc` that CI
never produces:

```
TRTMC_BINARY (env override)  →  ./build/trtmc (local source build)  →  shutil.which("trtmc")
```

`shutil.which("trtmc")` is the key addition: in CI the wheel installs the native
`trtmc` on `PATH` (`command -v trtmc`), so the test now **executes against the
packaged binary** rather than failing on a missing `./build/trtmc`. It skips
only if *no* binary can be found anywhere. This mirrors how the rest of the
suite resolves the binary — the `trtmc_binary` e2e fixture uses
`--trtmc-binary "$(command -v trtmc)"`, and `test_family_elf` honors `TRTMC_BINARY`.

This is the **run-not-skip** counterpart to the earlier skip-guard attempt
(#214, reverted): same resolver shape, but the `shutil.which` candidate flips
the CI outcome from *skip* to *run*. Full root-cause analysis: #209.

## Why it was broken

The test pinned `TRTMC_BIN = REPO_ROOT / "build" / "trtmc"`. CI builds via
conan + packages the native `trtmc` into the wheel (installed on `PATH`); it
never produces a source-tree `./build/trtmc`. So the test only passed where a
source build happened to exist (local dev, or a runner with a stale `./build/`)
and otherwise turned the missing artifact into a hard `AssertionError` — which
surfaced as a false red under broad tier-level selection and blocked unrelated
PRs.

## Validation

- `ruff check --config ruff.toml` on the changed file: passes.
- Resolver, CI scenario (no `./build/trtmc`, `trtmc` on `PATH`): resolves the
  on-PATH binary → the test **runs**, does not skip.
- Full test run against a real binary: **PASSED** — it builds the
  PatchTST / PatchTSMixer / TimesFM bundles, runs `trtmc solve`, and matches the
  Python reference at `atol=1e-6`. No network (models are constructed in-process).

## Note for review

This makes the (slow, GPU) e2e test **execute** in the stage that globs
`tests/engine_defs/torch_trt/` (currently the python-builder tier under broad
selection). It's lightweight — tiny in-process models, no downloads — but it
does run real GPU work there. If you'd rather it run only in the selective-e2e
/ gpu stage, this binary-resolution change is still the prerequisite; happy to
follow up with stage placement whichever way you prefer. The sibling
`test_pixart_vs_hf.py` has the same hardcoded-path pattern (currently
`--ignore`d in CI) and could get the same treatment in a follow-up.

Refs #209
