### PR TITLE
feat(e2e/diffusion): add CLIP semantic metrics gate for image diffusion models

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,11 @@ RUN pip install \
     sentencepiece \
     ftfy
 
+# CLIP semantic metrics for diffusion E2E comparator (clip_metrics.py).
+# open-clip-torch must be pinned to a CPU-compatible version; it will use
+# the torch installation already present in this image for GPU inference.
+RUN pip install "open-clip-torch>=2.20"
+
 # NeMo currently declares transformers~=4.57; force the runtime pin we need.
 RUN pip install "nemo_toolkit[tts]==2.7.0" && \
     pip install --upgrade "transformers==5.2.0" && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dependencies = [
 [project.optional-dependencies]
 chronos = ["chronos-forecasting>=2.2.2"]
 test = ["pytest>=7.0", "torch>=2.0"]
+# clip: required by tests/e2e_harness/comparators/clip_metrics.py for
+# CLIP-based semantic metrics on diffusion model outputs.  Gracefully skipped
+# at runtime when absent, but all CLIP gates become no-ops without it.
+clip = ["open-clip-torch>=2.20", "Pillow>=9.0"]
 
 [tool.conan-py-build.wheel]
 packages = ["python/tensorrt_model_connect"]

--- a/scripts/validate_clip_metrics_local.py
+++ b/scripts/validate_clip_metrics_local.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Local validation script for CLIP semantic metrics on diffusion image outputs.
+
+Validates the clip_metrics module before enabling it in CI.
+Accepts two image directories (or two single image files) + a prompt,
+then prints a table of all CLIP metric values.
+
+Usage examples:
+
+  # Two directories of frame_*.png files
+  python scripts/validate_clip_metrics_local.py \\
+      --trt-dir  /tmp/e2e_artifacts/flux-schnell/trt_frames \\
+      --ref-dir  /tmp/e2e_artifacts/flux-schnell/hf_frames \\
+      --prompt   "A photo of a cat sitting on a windowsill at sunset"
+
+  # Two single image files
+  python scripts/validate_clip_metrics_local.py \\
+      --trt-img  /tmp/trt_output.png \\
+      --ref-img  /tmp/hf_output.png \\
+      --prompt   "A photo of a cat sitting on a windowsill at sunset"
+
+  # Auto-load prompt from manifest
+  python scripts/validate_clip_metrics_local.py \\
+      --manifest flux-schnell \\
+      --trt-dir  /tmp/e2e_artifacts/flux-schnell/trt_frames \\
+      --ref-dir  /tmp/e2e_artifacts/flux-schnell/hf_frames
+
+  # Batch: scan an artifacts root for model sub-dirs with trt_frames/ hf_frames/
+  python scripts/validate_clip_metrics_local.py \\
+      --artifacts-root /tmp/e2e_artifacts
+
+Requirements:
+  pip install open-clip-torch Pillow torch
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+
+# Locate clip_metrics without installing the harness package.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+try:
+    from tests.e2e_harness.comparators.clip_metrics import (
+        CLIP_MAX_TOKENS,
+        CLIP_MODEL,
+        CLIP_PRETRAINED,
+        ClipMetrics,
+        compute_clip_metrics,
+    )
+except ImportError as exc:
+    sys.exit(f"ERROR: could not import clip_metrics — {exc}")
+
+
+# ── terminal colours ─────────────────────────────────────────────────────────
+
+_GREEN = "\033[32m"
+_RED = "\033[31m"
+_YELLOW = "\033[33m"
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+
+
+def _c(text: str, color: str) -> str:
+    return f"{color}{text}{_RESET}" if sys.stdout.isatty() else text
+
+
+def _verdict(ok: bool) -> str:
+    return _c("PASS", _GREEN) if ok else _c("FAIL", _RED)
+
+
+# ── result printing ──────────────────────────────────────────────────────────
+
+def _print_result(
+    model_name: str,
+    prompt: str,
+    metrics: ClipMetrics,
+    thresholds: dict,
+) -> bool:
+    eps = thresholds.get("max_prompt_clipscore_drop", 3.0)
+    hf_floor = thresholds.get("min_hf_prompt_clipscore", 20.0)
+    img_thr = thresholds.get("min_trt_hf_image_clip_cosine", 0.0)
+
+    delta_ok = metrics.prompt_clipscore_delta >= -eps
+    hf_ok = metrics.hf_prompt_clipscore >= hf_floor
+    # img gate is inactive (report-only) when threshold is 0.0
+    img_ok = metrics.trt_hf_image_clip_cosine >= img_thr if img_thr > 0.0 else True
+    overall = delta_ok and hf_ok and img_ok
+
+    print(f"\n{_c('─' * 62, _BOLD)}")
+    print(f"{_c('Model:', _BOLD)} {model_name}")
+    print(f"{_c('CLIP: ', _BOLD)}{CLIP_MODEL} / {CLIP_PRETRAINED}")
+    prompt_disp = prompt[:80] + "…" if len(prompt) > 80 else prompt
+    print(f"{_c('Prompt:', _BOLD)} {prompt_disp}")
+    if metrics.prompt_truncated:
+        print(_c(f"  ⚠  Prompt > {CLIP_MAX_TOKENS} tokens — CLIP truncated it.", _YELLOW))
+    print("─" * 62)
+
+    rows = [
+        ("trt_prompt_clipscore",     f"{metrics.trt_prompt_clipscore:.2f}",         "diagnostic", True),
+        ("hf_prompt_clipscore",      f"{metrics.hf_prompt_clipscore:.2f}",          f">= {hf_floor:.1f}", hf_ok),
+        ("prompt_clipscore_delta",   f"{metrics.prompt_clipscore_delta:+.2f}",      f">= {-eps:.1f}", delta_ok),
+        ("trt_hf_image_clip_cosine", f"{metrics.trt_hf_image_clip_cosine:.4f}",
+         f">= {img_thr:.2f}" if img_thr > 0.0 else "report-only", img_ok),
+    ]
+    for name, value, threshold, ok in rows:
+        if threshold == "diagnostic":
+            verdict = _c("INFO", _YELLOW)
+        elif threshold == "report-only":
+            verdict = _c("INFO", _YELLOW)
+        else:
+            verdict = _verdict(ok)
+        print(f"  {name:<35s}  {value:>8s}   [{threshold:>14s}]   {verdict}")
+
+    print("─" * 62)
+    print(f"  {_c('OVERALL PASS', _GREEN) if overall else _c('OVERALL FAIL', _RED)}")
+    return overall
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _load_prompt_from_manifest(name: str) -> str | None:
+    path = _REPO_ROOT / "tests" / "e2e" / "models" / f"{name}.json"
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    return data.get("prompt") or data.get("test_prompt")
+
+
+def _single_img_to_frames_dir(img: Path, tmp: Path) -> Path:
+    d = tmp / img.stem
+    d.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(img, d / "frame_0000.png")
+    return d
+
+
+def _run_one(name: str, trt_dir: str, ref_dir: str, prompt: str, thresholds: dict) -> bool:
+    metrics = compute_clip_metrics(trt_dir, ref_dir, prompt)
+    if metrics is None:
+        print(f"\n[{name}] CLIP metrics returned None — check open-clip-torch install and frame files.")
+        return False
+    return _print_result(name, prompt, metrics, thresholds)
+
+
+def _batch_scan(root: Path, thresholds: dict) -> None:
+    passed = failed = skipped = 0
+    for model_dir in sorted(root.iterdir()):
+        if not model_dir.is_dir():
+            continue
+        trt = model_dir / "trt_frames"
+        ref = model_dir / "hf_frames"
+        if not (trt.exists() and ref.exists()):
+            skipped += 1
+            continue
+        prompt = _load_prompt_from_manifest(model_dir.name)
+        if not prompt:
+            print(f"\n[{model_dir.name}] No prompt in manifest — skipping.")
+            skipped += 1
+            continue
+        ok = _run_one(model_dir.name, str(trt), str(ref), prompt, thresholds)
+        if ok:
+            passed += 1
+        else:
+            failed += 1
+
+    print(f"\n{'=' * 62}")
+    print(f"Batch: {passed} passed / {failed} failed / {skipped} skipped")
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate CLIP semantic metrics for diffusion image models.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    src = parser.add_mutually_exclusive_group()
+    src.add_argument("--trt-dir", metavar="DIR", help="TRT frames directory (frame_*.png)")
+    src.add_argument("--trt-img", metavar="IMG", help="Single TRT output image")
+
+    dst = parser.add_mutually_exclusive_group()
+    dst.add_argument("--ref-dir", metavar="DIR", help="HF reference frames directory")
+    dst.add_argument("--ref-img", metavar="IMG", help="Single HF reference image")
+
+    parser.add_argument("--prompt", help="Text prompt used for generation")
+    parser.add_argument("--manifest", metavar="NAME",
+                        help="Manifest name (e.g. flux-schnell) to auto-load prompt")
+    parser.add_argument("--artifacts-root", metavar="DIR",
+                        help="Batch mode: root dir containing model sub-dirs")
+
+    # Threshold knobs for calibration exploration
+    parser.add_argument("--max-drop", type=float, default=3.0,
+                        help="max_prompt_clipscore_drop (default 3.0)")
+    parser.add_argument("--hf-floor", type=float, default=20.0,
+                        help="min_hf_prompt_clipscore (default 20.0)")
+    parser.add_argument("--img-thr", type=float, default=0.0,
+                        help="min_trt_hf_image_clip_cosine (default 0.0 = report-only)")
+
+    args = parser.parse_args()
+
+    thresholds = {
+        "max_prompt_clipscore_drop": args.max_drop,
+        "min_hf_prompt_clipscore": args.hf_floor,
+        "min_trt_hf_image_clip_cosine": args.img_thr,
+    }
+
+    if args.artifacts_root:
+        _batch_scan(Path(args.artifacts_root), thresholds)
+        return
+
+    if not (args.trt_dir or args.trt_img) or not (args.ref_dir or args.ref_img):
+        parser.error(
+            "Provide --trt-dir/--trt-img and --ref-dir/--ref-img, "
+            "or use --artifacts-root for batch mode."
+        )
+
+    prompt = args.prompt
+    if not prompt and args.manifest:
+        prompt = _load_prompt_from_manifest(args.manifest)
+        if not prompt:
+            sys.exit(f"ERROR: no prompt found in manifest '{args.manifest}'")
+    if not prompt:
+        sys.exit("ERROR: --prompt is required (or --manifest to auto-load it)")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        trt_dir = (
+            str(_single_img_to_frames_dir(Path(args.trt_img), tmp_path))
+            if args.trt_img else args.trt_dir
+        )
+        ref_dir = (
+            str(_single_img_to_frames_dir(Path(args.ref_img), tmp_path))
+            if args.ref_img else args.ref_dir
+        )
+        ok = _run_one(args.manifest or "local", trt_dir, ref_dir, prompt, thresholds)
+
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e_harness/comparators/clip_metrics.py
+++ b/tests/e2e_harness/comparators/clip_metrics.py
@@ -1,0 +1,167 @@
+"""CLIP-based semantic metrics for image diffusion reference comparison.
+
+Provides reference-relative semantic parity that works WITHOUT shared
+initial latents (unlike PSNR/SSIM). Captures prompt fidelity and
+image-image semantic similarity.
+
+Intentionally blind to fine perceptual quality — MUST be paired with
+PSNR/SSIM (shared-latent models) or LPIPS for full quality coverage.
+
+Scope: text-to-image and image-to-image models only.
+       Video models are excluded (video_num_frames > 1).
+"""
+from __future__ import annotations
+
+import functools
+import logging
+from pathlib import Path
+from typing import NamedTuple
+
+logger = logging.getLogger(__name__)
+
+# Pin model identity here so CI scores never drift silently across upgrades.
+CLIP_MODEL = "ViT-B-32"
+CLIP_PRETRAINED = "laion2b_s34b_b79k"
+
+# CLIP text encoder context length. Prompts longer than this are truncated.
+CLIP_MAX_TOKENS = 77
+
+# Number of frames sampled per directory when computing metrics.
+_DEFAULT_MAX_FRAMES = 4
+
+
+class ClipMetrics(NamedTuple):
+    trt_prompt_clipscore: float
+    hf_prompt_clipscore: float
+    prompt_clipscore_delta: float
+    trt_hf_image_clip_cosine: float
+    prompt_truncated: bool
+
+
+@functools.lru_cache(maxsize=1)
+def _load_clip():
+    """Lazy-load open_clip on CPU / fp32. Returns bundle or None on ImportError."""
+    try:
+        import open_clip
+    except ImportError:
+        logger.warning(
+            "open_clip not installed — CLIP metrics will be skipped. "
+            "Install with: pip install open-clip-torch"
+        )
+        return None
+
+    model, _, preprocess = open_clip.create_model_and_transforms(
+        CLIP_MODEL, pretrained=CLIP_PRETRAINED
+    )
+    # fp32 + eval for determinism across environments.
+    model = model.eval().float()
+    tokenizer = open_clip.get_tokenizer(CLIP_MODEL)
+    logger.debug("Loaded CLIP %s / %s", CLIP_MODEL, CLIP_PRETRAINED)
+    return model, preprocess, tokenizer
+
+
+def _embed_images(paths: list[Path]):
+    """Return L2-normalised image embeddings tensor [N, D] or None."""
+    bundle = _load_clip()
+    if bundle is None or not paths:
+        return None
+    import torch
+    from PIL import Image
+
+    model, preprocess, _ = bundle
+    tensors = []
+    for p in paths:
+        try:
+            tensors.append(preprocess(Image.open(p).convert("RGB")))
+        except Exception as exc:
+            logger.warning("CLIP: could not open %s: %s", p, exc)
+    if not tensors:
+        return None
+    with torch.no_grad():
+        batch = torch.stack(tensors)
+        emb = model.encode_image(batch).float()
+        emb = emb / emb.norm(dim=-1, keepdim=True)
+    return emb  # [N, D]
+
+
+def _embed_text(prompt: str) -> tuple:
+    """Return (L2-normalised text embedding [D], was_truncated: bool) or (None, False)."""
+    bundle = _load_clip()
+    if bundle is None:
+        return None, False
+    import torch
+
+    model, _, tokenizer = bundle
+    # Detect truncation by encoding with a large context length and comparing.
+    full_tokens = tokenizer([prompt], context_length=10_000)[0]
+    truncated = int((full_tokens != 0).sum()) > CLIP_MAX_TOKENS
+
+    with torch.no_grad():
+        tok = tokenizer([prompt])
+        emb = model.encode_text(tok).float()
+        emb = emb / emb.norm(dim=-1, keepdim=True)
+    return emb[0], truncated  # [D], bool
+
+
+def compute_clip_metrics(
+    trt_dir: str,
+    ref_dir: str,
+    prompt: str | None,
+    max_frames: int = _DEFAULT_MAX_FRAMES,
+) -> ClipMetrics | None:
+    """Compute CLIP semantic metrics between TRT and HF reference image dirs.
+
+    Returns None when:
+    - open_clip is not installed
+    - prompt is empty / None
+    - no frame_*.png files found in either directory
+
+    Caller should treat None as "skipped", not as a failure.
+    """
+    if not prompt:
+        logger.debug("CLIP metrics skipped: no prompt provided")
+        return None
+
+    trt_frames = sorted(Path(trt_dir).glob("frame_*.png"))[:max_frames]
+    ref_frames = sorted(Path(ref_dir).glob("frame_*.png"))[:max_frames]
+
+    if not trt_frames:
+        logger.debug("CLIP metrics skipped: no TRT frames in %s", trt_dir)
+        return None
+    if not ref_frames:
+        logger.debug("CLIP metrics skipped: no reference frames in %s", ref_dir)
+        return None
+
+    trt_emb = _embed_images(trt_frames)  # [Nt, D]
+    ref_emb = _embed_images(ref_frames)  # [Nr, D]
+    txt_emb, truncated = _embed_text(prompt)  # [D], bool
+
+    if trt_emb is None or ref_emb is None or txt_emb is None:
+        return None
+
+    # Prompt-fidelity CLIPScore: 100 * max(cos(text, image), 0), mean over frames.
+    trt_cos = float((trt_emb @ txt_emb).mean())
+    hf_cos = float((ref_emb @ txt_emb).mean())
+    trt_score = 100.0 * max(trt_cos, 0.0)
+    hf_score = 100.0 * max(hf_cos, 0.0)
+
+    # Image-image semantic similarity: frame-by-frame cosine, averaged.
+    n = min(len(trt_frames), len(ref_frames))
+    img_cos = float((trt_emb[:n] * ref_emb[:n]).sum(dim=-1).mean())
+
+    if truncated:
+        logger.warning(
+            "CLIP: prompt exceeds %d tokens and was truncated — "
+            "clipscore reflects only the first ~%d tokens: %.60s…",
+            CLIP_MAX_TOKENS,
+            CLIP_MAX_TOKENS,
+            prompt,
+        )
+
+    return ClipMetrics(
+        trt_prompt_clipscore=trt_score,
+        hf_prompt_clipscore=hf_score,
+        prompt_clipscore_delta=trt_score - hf_score,
+        trt_hf_image_clip_cosine=img_cos,
+        prompt_truncated=truncated,
+    )

--- a/tests/e2e_harness/comparators/diffusion.py
+++ b/tests/e2e_harness/comparators/diffusion.py
@@ -281,6 +281,73 @@ class DiffusionComparator:
                 if not ssim_ok:
                     all_pass = False
 
+            # --- CLIP semantic metrics (image models only; video excluded) ---
+            # Works without shared initial latents: measures semantic parity in
+            # CLIP embedding space rather than pixel space.
+            # Gates: (a) prompt_clipscore_delta and (c) hf_prompt_clipscore are
+            # hard gates at their default values; (b) trt_hf_image_clip_cosine
+            # is report-only (threshold=None) until per-model calibration.
+            from .clip_metrics import compute_clip_metrics
+
+            prompt = trt.data.get("prompt")
+            clip = (
+                compute_clip_metrics(frames_dir, ref_frames_dir, prompt)
+                if trt.data.get("num_frames", 1) <= 1
+                else None
+            )
+            if clip is not None:
+                # (a) One-sided: TRT prompt fidelity must not drop below HF by > eps.
+                #     Positive delta (TRT > HF) is always a pass.
+                eps = thresholds.get("max_prompt_clipscore_drop", 3.0)
+                delta_ok = clip.prompt_clipscore_delta >= -eps
+                metrics["prompt_clipscore_delta"] = MetricResult(
+                    value=clip.prompt_clipscore_delta,
+                    threshold=-eps,
+                    operator=">=",
+                    passed=delta_ok,
+                    note=(
+                        f"trt={clip.trt_prompt_clipscore:.2f}, "
+                        f"hf={clip.hf_prompt_clipscore:.2f}"
+                        + (" [prompt truncated]" if clip.prompt_truncated else "")
+                    ),
+                )
+                if not delta_ok:
+                    all_pass = False
+
+                # (b) Image-image semantic similarity.
+                #     Default 0.0 = report-only until calibration sets per-model override.
+                img_thr = thresholds.get("min_trt_hf_image_clip_cosine", 0.0)
+                img_ok = img_thr <= 0.0 or clip.trt_hf_image_clip_cosine >= img_thr
+                metrics["trt_hf_image_clip_cosine"] = MetricResult(
+                    value=clip.trt_hf_image_clip_cosine,
+                    threshold=img_thr if img_thr > 0.0 else None,
+                    operator=">=",
+                    passed=img_ok,
+                )
+                if not img_ok:
+                    all_pass = False
+
+                # (c) Reference self-check: HF output must itself be semantically valid.
+                #     Catches cases where the reference pipeline produced a blank/broken image.
+                hf_floor = thresholds.get("min_hf_prompt_clipscore", 20.0)
+                hf_ok = clip.hf_prompt_clipscore >= hf_floor
+                metrics["hf_prompt_clipscore"] = MetricResult(
+                    value=clip.hf_prompt_clipscore,
+                    threshold=hf_floor,
+                    operator=">=",
+                    passed=hf_ok,
+                )
+                if not hf_ok:
+                    all_pass = False
+
+                # Diagnostic-only (not gated): raw TRT clipscore for logging.
+                metrics["trt_prompt_clipscore"] = MetricResult(
+                    value=clip.trt_prompt_clipscore,
+                    threshold=None,
+                    operator="info",
+                    passed=True,
+                )
+
         n_gated = sum(1 for m in metrics.values() if m.threshold is not None)
         n_passed = sum(1 for m in metrics.values() if m.threshold is not None and m.passed)
         return CompareResult(

--- a/tests/e2e_harness/comparators/test_clip_metrics.py
+++ b/tests/e2e_harness/comparators/test_clip_metrics.py
@@ -1,0 +1,475 @@
+"""Unit tests for clip_metrics.py — no GPU, no open_clip, no PIL required.
+
+Strategy: mock _embed_images and _embed_text (the two functions that touch
+external libs) so tests exercise all compute_clip_metrics paths purely in
+terms of torch tensor arithmetic, which is always available in the harness
+environment.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tests.e2e_harness.comparators.clip_metrics import (
+    ClipMetrics,
+    compute_clip_metrics,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_dummy_png(path: Path) -> None:
+    """Write a minimal valid PNG (4×4 grey) without requiring PIL."""
+    import struct
+    import zlib
+
+    def _chunk(tag: bytes, data: bytes) -> bytes:
+        c = struct.pack(">I", len(data)) + tag + data
+        return c + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+
+    w = h = 4
+    raw = b"".join(b"\x00" + bytes([128, 128, 128] * w) for _ in range(h))
+    png = (
+        b"\x89PNG\r\n\x1a\n"
+        + _chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+        + _chunk(b"IDAT", zlib.compress(raw))
+        + _chunk(b"IEND", b"")
+    )
+    path.write_bytes(png)
+
+
+def _frames_dir(tmp: Path, name: str, n: int = 1) -> Path:
+    d = tmp / name
+    d.mkdir()
+    for i in range(n):
+        _write_dummy_png(d / f"frame_{i:04d}.png")
+    return d
+
+
+def _unit_vec(dim: int, idx: int = 0):
+    """Return a 1-D torch tensor that is a unit vector along `idx`."""
+    import torch
+    v = torch.zeros(dim)
+    v[idx] = 1.0
+    return v
+
+
+# Common mock signatures expected by compute_clip_metrics:
+#   _embed_images(paths) -> Tensor[N, D] | None
+#   _embed_text(prompt)  -> (Tensor[D], bool)          (embedding, truncated)
+
+_MODULE = "tests.e2e_harness.comparators.clip_metrics"
+
+
+# ---------------------------------------------------------------------------
+# Tests: early-exit / None paths
+# ---------------------------------------------------------------------------
+
+class TestEarlyReturns:
+    def test_none_when_prompt_is_none(self, tmp_path):
+        trt = _frames_dir(tmp_path, "trt")
+        ref = _frames_dir(tmp_path, "ref")
+        assert compute_clip_metrics(str(trt), str(ref), prompt=None) is None
+
+    def test_none_when_prompt_empty(self, tmp_path):
+        trt = _frames_dir(tmp_path, "trt")
+        ref = _frames_dir(tmp_path, "ref")
+        assert compute_clip_metrics(str(trt), str(ref), prompt="") is None
+
+    def test_none_when_no_trt_frames(self, tmp_path):
+        trt = tmp_path / "empty"
+        trt.mkdir()
+        ref = _frames_dir(tmp_path, "ref")
+        assert compute_clip_metrics(str(trt), str(ref), "a cat") is None
+
+    def test_none_when_no_ref_frames(self, tmp_path):
+        trt = _frames_dir(tmp_path, "trt")
+        ref = tmp_path / "empty"
+        ref.mkdir()
+        assert compute_clip_metrics(str(trt), str(ref), "a cat") is None
+
+    def test_none_when_open_clip_missing(self, tmp_path):
+        trt = _frames_dir(tmp_path, "trt")
+        ref = _frames_dir(tmp_path, "ref")
+        with patch(f"{_MODULE}._load_clip", return_value=None):
+            assert compute_clip_metrics(str(trt), str(ref), "a cat") is None
+
+    def test_none_when_embed_images_returns_none(self, tmp_path):
+        trt = _frames_dir(tmp_path, "trt")
+        ref = _frames_dir(tmp_path, "ref")
+        txt = _unit_vec(512, 0)
+        with (
+            patch(f"{_MODULE}._embed_images", return_value=None),
+            patch(f"{_MODULE}._embed_text", return_value=(txt, False)),
+        ):
+            assert compute_clip_metrics(str(trt), str(ref), "a cat") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: metric arithmetic
+# ---------------------------------------------------------------------------
+
+class TestMetricArithmetic:
+    """All paths that reach the actual cosine math."""
+
+    def _run(self, tmp_path, trt_emb, ref_emb, txt_emb, truncated=False, prompt="a cat"):
+        """Helper: mock embed functions, return ClipMetrics."""
+        trt = _frames_dir(tmp_path, "trt")
+        ref = _frames_dir(tmp_path, "ref")
+        call = {"n": 0}
+
+        def _fake_embed_images(paths):
+            call["n"] += 1
+            return trt_emb if call["n"] == 1 else ref_emb
+
+        with (
+            patch(f"{_MODULE}._embed_images", side_effect=_fake_embed_images),
+            patch(f"{_MODULE}._embed_text", return_value=(txt_emb, truncated)),
+        ):
+            return compute_clip_metrics(str(trt), str(ref), prompt)
+
+    def test_returns_clip_metrics_namedtuple(self, tmp_path):
+        e = _unit_vec(512, 0).unsqueeze(0)
+        t = _unit_vec(512, 0)
+        result = self._run(tmp_path, e, e, t)
+        assert isinstance(result, ClipMetrics)
+
+    def test_identical_embeddings_delta_zero(self, tmp_path):
+        e = _unit_vec(512, 0).unsqueeze(0)
+        t = _unit_vec(512, 0)
+        result = self._run(tmp_path, e, e, t)
+        assert result is not None
+        assert result.prompt_clipscore_delta == pytest.approx(0.0, abs=1e-4)
+
+    def test_identical_embeddings_image_cosine_one(self, tmp_path):
+        e = _unit_vec(512, 0).unsqueeze(0)
+        t = _unit_vec(512, 0)
+        result = self._run(tmp_path, e, e, t)
+        assert result is not None
+        assert result.trt_hf_image_clip_cosine == pytest.approx(1.0, abs=1e-4)
+
+    def test_positive_delta_when_trt_more_aligned(self, tmp_path):
+        """TRT embedding closer to text than HF → delta > 0."""
+        import torch
+        # trt cos(text)=0.9, hf cos(text)=0.7
+        trt_e = torch.zeros(512)
+        trt_e[0] = 0.9
+        trt_e[1] = (1 - 0.81) ** 0.5
+        ref_e = torch.zeros(512)
+        ref_e[0] = 0.7
+        ref_e[1] = (1 - 0.49) ** 0.5
+        txt   = _unit_vec(512, 0)
+        result = self._run(tmp_path, trt_e.unsqueeze(0), ref_e.unsqueeze(0), txt)
+        assert result is not None
+        assert result.prompt_clipscore_delta > 0
+
+    def test_large_negative_delta_when_trt_orthogonal_to_text(self, tmp_path):
+        """TRT cosine=0 (orthogonal), HF cosine=0.28 → clipscore delta ≈ -28."""
+        import torch
+        trt_e = _unit_vec(512, 1).unsqueeze(0)          # orthogonal to text
+        ref_e = torch.zeros(512)
+        ref_e[0] = 0.28
+        ref_e[1] = (1 - 0.0784) ** 0.5
+        txt = _unit_vec(512, 0)
+        result = self._run(tmp_path, trt_e, ref_e.unsqueeze(0), txt)
+        assert result is not None
+        assert result.trt_prompt_clipscore == pytest.approx(0.0, abs=1e-4)
+        assert result.prompt_clipscore_delta < -20.0
+
+    def test_clipscore_formula_100x_max_cos_0(self, tmp_path):
+        """CLIPScore = 100 * max(cos, 0): negative cosine yields 0, not negative."""
+        import torch
+        # cos(trt, text) = -0.5  →  clipscore should be 0.0
+        trt_e = torch.zeros(512)
+        trt_e[0] = -0.5
+        trt_e[1] = (1 - 0.25) ** 0.5
+        ref_e = _unit_vec(512, 0).unsqueeze(0)
+        txt   = _unit_vec(512, 0)
+        result = self._run(tmp_path, trt_e.unsqueeze(0), ref_e, txt)
+        assert result is not None
+        assert result.trt_prompt_clipscore == pytest.approx(0.0, abs=1e-4)
+
+    def test_hf_floor_when_reference_broken(self, tmp_path):
+        """HF embedding orthogonal to text → hf_prompt_clipscore == 0."""
+        trt_e = _unit_vec(512, 0).unsqueeze(0)
+        ref_e = _unit_vec(512, 1).unsqueeze(0)  # orthogonal to text
+        txt   = _unit_vec(512, 0)
+        result = self._run(tmp_path, trt_e, ref_e, txt)
+        assert result is not None
+        assert result.hf_prompt_clipscore == pytest.approx(0.0, abs=1e-4)
+
+    def test_prompt_truncated_flag_propagated(self, tmp_path):
+        e = _unit_vec(512, 0).unsqueeze(0)
+        t = _unit_vec(512, 0)
+        result = self._run(tmp_path, e, e, t, truncated=True, prompt="a cat " * 30)
+        assert result is not None
+        assert result.prompt_truncated is True
+
+    def test_prompt_not_truncated_flag(self, tmp_path):
+        e = _unit_vec(512, 0).unsqueeze(0)
+        t = _unit_vec(512, 0)
+        result = self._run(tmp_path, e, e, t, truncated=False)
+        assert result is not None
+        assert result.prompt_truncated is False
+
+    def test_max_frames_limits_glob(self, tmp_path):
+        """max_frames=2 should pass only 2 paths to _embed_images."""
+        trt = _frames_dir(tmp_path, "trt", n=5)
+        ref = _frames_dir(tmp_path, "ref", n=5)
+        e = _unit_vec(512, 0).unsqueeze(0)
+        t = _unit_vec(512, 0)
+        captured = []
+
+        def _fake_embed(paths):
+            captured.append(len(paths))
+            return e
+
+        with (
+            patch(f"{_MODULE}._embed_images", side_effect=_fake_embed),
+            patch(f"{_MODULE}._embed_text", return_value=(t, False)),
+        ):
+            compute_clip_metrics(str(trt), str(ref), "a cat", max_frames=2)
+
+        assert all(n == 2 for n in captured)
+
+
+# ---------------------------------------------------------------------------
+# Tests: comparator gate wiring
+# ---------------------------------------------------------------------------
+
+class TestDiffusionComparatorClipGates:
+    """Verify the three CLIP gates are correctly wired inside _compare_frames."""
+
+    def _trt_output(self, frames_dir: str, prompt: str | None, num_frames: int = 1):
+        from tests.e2e_harness.contracts import StageOutput
+        return StageOutput(
+            stage_name="end_to_end",
+            data={
+                "returncode": 0,
+                "num_frames": num_frames,
+                "frame_stats": {"mean": 0.5, "std": 0.2},
+                "frames_dir": frames_dir,
+                "prompt": prompt,
+            },
+            text=None, timing_s=0.0, metadata={},
+        )
+
+    def _ref_output(self, frames_dir: str):
+        from tests.e2e_harness.contracts import StageOutput
+        return StageOutput(
+            stage_name="end_to_end",
+            data={
+                "returncode": 0,
+                "num_frames": 1,
+                "frame_stats": {"mean": 0.5, "std": 0.2},
+                "frames_dir": frames_dir,
+            },
+            text=None, timing_s=0.0, metadata={},
+        )
+
+    def _threshold(self, overrides: dict | None = None):
+        from tests.e2e_harness.contracts import ThresholdProfile
+        metrics = {
+            "psnr": 5.0, "ssim": 0.1,
+            "min_pixel_mean": 0.15, "max_pixel_mean": 0.85,
+            "min_pixel_std": 0.05,
+            "reference_min_pixel_std_for_ratio": 0.08,
+            "min_reference_std_ratio": 0.35,
+            "max_prompt_clipscore_drop": 3.0,
+            "min_hf_prompt_clipscore": 20.0,
+            "min_trt_hf_image_clip_cosine": 0.0,
+        }
+        if overrides:
+            metrics.update(overrides)
+        return ThresholdProfile(
+            task_strategy="diffusion_media_generation",
+            profile_name="default",
+            metrics=metrics,
+        )
+
+    def _stage(self):
+        from tests.e2e_harness.contracts import StageSpec
+        return StageSpec(name="end_to_end", required=True)
+
+    def _fake_clip(self, delta: float = 0.0, hf_score: float = 25.0, img_cos: float = 0.9):
+        """Return a ClipMetrics with controlled values."""
+        return ClipMetrics(
+            trt_prompt_clipscore=hf_score + delta,
+            hf_prompt_clipscore=hf_score,
+            prompt_clipscore_delta=delta,
+            trt_hf_image_clip_cosine=img_cos,
+            prompt_truncated=False,
+        )
+
+    def test_clip_metric_keys_present_in_result(self, tmp_path):
+        from tests.e2e_harness.comparators.diffusion import DiffusionComparator
+        trt_dir = _frames_dir(tmp_path, "trt")
+        ref_dir = _frames_dir(tmp_path, "ref")
+
+        with patch(
+            f"{_MODULE}.compute_clip_metrics",
+            return_value=self._fake_clip(),
+        ):
+            result = DiffusionComparator().compare(
+                self._trt_output(str(trt_dir), "a cat"),
+                self._ref_output(str(ref_dir)),
+                self._threshold(),
+                self._stage(),
+            )
+
+        assert "prompt_clipscore_delta" in result.metrics
+        assert "trt_hf_image_clip_cosine" in result.metrics
+        assert "hf_prompt_clipscore" in result.metrics
+        assert "trt_prompt_clipscore" in result.metrics
+
+    def test_large_negative_delta_fails_gate(self, tmp_path):
+        from tests.e2e_harness.comparators.diffusion import DiffusionComparator
+        from tests.e2e_harness.contracts import StageStatus
+        trt_dir = _frames_dir(tmp_path, "trt")
+        ref_dir = _frames_dir(tmp_path, "ref")
+
+        with patch(
+            f"{_MODULE}.compute_clip_metrics",
+            return_value=self._fake_clip(delta=-10.0),
+        ):
+            result = DiffusionComparator().compare(
+                self._trt_output(str(trt_dir), "a cat"),
+                self._ref_output(str(ref_dir)),
+                self._threshold({"max_prompt_clipscore_drop": 3.0}),
+                self._stage(),
+            )
+
+        assert not result.metrics["prompt_clipscore_delta"].passed
+        assert result.status == StageStatus.FAILED.value
+
+    def test_positive_delta_always_passes(self, tmp_path):
+        from tests.e2e_harness.comparators.diffusion import DiffusionComparator
+        trt_dir = _frames_dir(tmp_path, "trt")
+        ref_dir = _frames_dir(tmp_path, "ref")
+
+        with patch(
+            f"{_MODULE}.compute_clip_metrics",
+            return_value=self._fake_clip(delta=+5.0),
+        ):
+            result = DiffusionComparator().compare(
+                self._trt_output(str(trt_dir), "a cat"),
+                self._ref_output(str(ref_dir)),
+                self._threshold(),
+                self._stage(),
+            )
+
+        assert result.metrics["prompt_clipscore_delta"].passed
+
+    def test_hf_floor_fail_when_reference_broken(self, tmp_path):
+        from tests.e2e_harness.comparators.diffusion import DiffusionComparator
+        from tests.e2e_harness.contracts import StageStatus
+        trt_dir = _frames_dir(tmp_path, "trt")
+        ref_dir = _frames_dir(tmp_path, "ref")
+
+        with patch(
+            f"{_MODULE}.compute_clip_metrics",
+            return_value=self._fake_clip(hf_score=5.0),  # below 20.0 floor
+        ):
+            result = DiffusionComparator().compare(
+                self._trt_output(str(trt_dir), "a cat"),
+                self._ref_output(str(ref_dir)),
+                self._threshold({"min_hf_prompt_clipscore": 20.0}),
+                self._stage(),
+            )
+
+        assert not result.metrics["hf_prompt_clipscore"].passed
+        assert result.status == StageStatus.FAILED.value
+
+    def test_img_cosine_report_only_when_threshold_zero(self, tmp_path):
+        """min_trt_hf_image_clip_cosine=0.0 must never cause a failure."""
+        from tests.e2e_harness.comparators.diffusion import DiffusionComparator
+        trt_dir = _frames_dir(tmp_path, "trt")
+        ref_dir = _frames_dir(tmp_path, "ref")
+
+        with patch(
+            f"{_MODULE}.compute_clip_metrics",
+            return_value=self._fake_clip(img_cos=-0.5),  # terrible similarity
+        ):
+            result = DiffusionComparator().compare(
+                self._trt_output(str(trt_dir), "a cat"),
+                self._ref_output(str(ref_dir)),
+                self._threshold({"min_trt_hf_image_clip_cosine": 0.0}),
+                self._stage(),
+            )
+
+        assert result.metrics["trt_hf_image_clip_cosine"].passed
+
+    def test_img_cosine_active_when_threshold_positive(self, tmp_path):
+        """min_trt_hf_image_clip_cosine > 0 must fail when cosine is below it."""
+        from tests.e2e_harness.comparators.diffusion import DiffusionComparator
+        from tests.e2e_harness.contracts import StageStatus
+        trt_dir = _frames_dir(tmp_path, "trt")
+        ref_dir = _frames_dir(tmp_path, "ref")
+
+        with patch(
+            f"{_MODULE}.compute_clip_metrics",
+            return_value=self._fake_clip(img_cos=0.5),
+        ):
+            result = DiffusionComparator().compare(
+                self._trt_output(str(trt_dir), "a cat"),
+                self._ref_output(str(ref_dir)),
+                self._threshold({"min_trt_hf_image_clip_cosine": 0.8}),
+                self._stage(),
+            )
+
+        assert not result.metrics["trt_hf_image_clip_cosine"].passed
+        assert result.status == StageStatus.FAILED.value
+
+    def test_clip_skipped_when_no_prompt(self, tmp_path):
+        """No prompt in trt.data → CLIP block skipped, no crash."""
+        from tests.e2e_harness.comparators.diffusion import DiffusionComparator
+        trt_dir = _frames_dir(tmp_path, "trt")
+        ref_dir = _frames_dir(tmp_path, "ref")
+
+        result = DiffusionComparator().compare(
+            self._trt_output(str(trt_dir), prompt=None),
+            self._ref_output(str(ref_dir)),
+            self._threshold(),
+            self._stage(),
+        )
+
+        assert "prompt_clipscore_delta" not in result.metrics
+        assert result.status is not None
+
+    def test_trt_prompt_clipscore_is_diagnostic_only(self, tmp_path):
+        """trt_prompt_clipscore must have threshold=None (never gate)."""
+        from tests.e2e_harness.comparators.diffusion import DiffusionComparator
+        trt_dir = _frames_dir(tmp_path, "trt")
+        ref_dir = _frames_dir(tmp_path, "ref")
+
+        with patch(
+            f"{_MODULE}.compute_clip_metrics",
+            return_value=self._fake_clip(),
+        ):
+            result = DiffusionComparator().compare(
+                self._trt_output(str(trt_dir), "a cat"),
+                self._ref_output(str(ref_dir)),
+                self._threshold(),
+                self._stage(),
+            )
+
+        assert result.metrics["trt_prompt_clipscore"].threshold is None
+
+    def test_clip_skipped_for_video_models(self, tmp_path):
+        """num_frames > 1 → CLIP block must be skipped entirely."""
+        from tests.e2e_harness.comparators.diffusion import DiffusionComparator
+        trt_dir = _frames_dir(tmp_path, "trt", n=4)
+        ref_dir = _frames_dir(tmp_path, "ref", n=4)
+
+        result = DiffusionComparator().compare(
+            self._trt_output(str(trt_dir), "a cat", num_frames=4),
+            self._ref_output(str(ref_dir)),
+            self._threshold(),
+            self._stage(),
+        )
+
+        assert "prompt_clipscore_delta" not in result.metrics
+        assert "trt_hf_image_clip_cosine" not in result.metrics

--- a/tests/e2e_harness/runners/diffusion.py
+++ b/tests/e2e_harness/runners/diffusion.py
@@ -583,6 +583,8 @@ class DiffusionMediaRunner:
                 "frame_paths": frame_paths,
                 "stdout": stdout_text,
                 "stderr": stderr_truncated,
+                # Passed through to the comparator for CLIP semantic metrics.
+                "prompt": case.inputs.get("prompt") or case.inputs.get("test_prompt"),
             }
             if stderr_log:
                 e2e_data["stderr_log"] = stderr_log

--- a/tests/e2e_harness/thresholds/defaults/diffusion_media_generation.json
+++ b/tests/e2e_harness/thresholds/defaults/diffusion_media_generation.json
@@ -1,5 +1,5 @@
 {
-  "description": "Default thresholds for diffusion media generation. PSNR/SSIM are relaxed because cross-implementation diffusion (TRT vs HF Diffusers) produces visually different but valid images due to FP precision differences compounding through denoising steps. Distribution checks (pixel mean/std) are the primary sanity gates.",
+  "description": "Default thresholds for diffusion media generation. PSNR/SSIM are relaxed because cross-implementation diffusion (TRT vs HF Diffusers) produces visually different but valid images due to FP precision differences compounding through denoising steps. Distribution checks (pixel mean/std) are the primary sanity gates. CLIP semantic metrics provide reference-relative semantic parity without requiring shared initial latents; thresholds start at report-only defaults until per-model calibration writes overrides.",
   "metrics": {
     "latent_cosine_per_step": 0.95,
     "psnr": 5.0,
@@ -10,6 +10,9 @@
     "max_pixel_mean": 0.85,
     "min_pixel_std": 0.05,
     "reference_min_pixel_std_for_ratio": 0.08,
-    "min_reference_std_ratio": 0.35
+    "min_reference_std_ratio": 0.35,
+    "max_prompt_clipscore_drop": 3.0,
+    "min_hf_prompt_clipscore": 20.0,
+    "min_trt_hf_image_clip_cosine": 0.0
   }
 }

--- a/tools/test_impact_fallback_allowlist.txt
+++ b/tools/test_impact_fallback_allowlist.txt
@@ -107,6 +107,7 @@ no_impact scripts/reporting/__init__.py # developer utility script; no CI test i
 no_impact scripts/reporting/vlm_assessment.py # developer utility script; no CI test impact is intentional
 no_impact scripts/sdpa_nan_repro.py # developer utility script; no CI test impact is intentional
 no_impact scripts/templates/model_family/registration.cpp # developer utility script; no CI test impact is intentional
+no_impact scripts/validate_clip_metrics_local.py # developer utility script for local CLIP metric validation; no CI test impact is intentional
 no_impact scripts/validate_family.sh # developer utility script; no CI test impact is intentional
 no_impact scripts/validate_torchtrt_family.sh # developer utility script; no CI test impact is intentional
 no_impact tools/__init__.py # developer utility script; no CI test impact is intentional


### PR DESCRIPTION
## Background

Diffusion models in the E2E harness are labelled `hf_diffusers` (oracle level L1) but are effectively pseudo-L1: TRT and HF runs start from different random noise, so PSNR/SSIM values are meaningless. The only active gates were pixel mean/std distribution checks, which are too coarse to catch semantic regressions (e.g. a model outputting a valid-looking but wrong-content image).

## Exit Criteria

- CLIP semantic scores are computed and gated for all image diffusion models (T2I, I2I) in E2E runs
- Video models (`num_frames > 1`) are explicitly excluded
- CLIP dependency is available in the CI Docker image
- All gates have unit test coverage; tests run without GPU, PIL, or open_clip

## Implementation

**New module** `tests/e2e_harness/comparators/clip_metrics.py`
- Model pinned to `ViT-B-32 / laion2b_s34b_b79k` for reproducibility
- All heavy deps (`open_clip`, `PIL`, `torch`) lazy-imported; missing deps return `None` (graceful skip, no test failure)
- `compute_clip_metrics(trt_dir, ref_dir, prompt)` → `ClipMetrics` NamedTuple or `None`

**Three gates** wired into `DiffusionComparator._compare_frames`:
- **(a)** `prompt_clipscore_delta >= -3.0` — hard gate; one-sided so TRT improvements always pass
- **(b)** `trt_hf_image_clip_cosine` — `threshold=None`, report-only until per-model calibration
- **(c)** `hf_prompt_clipscore >= 20.0` — hard gate; catches degenerate/blank HF reference output

Video guard: `trt.data["num_frames"] <= 1` required before calling CLIP — frame-averaged CLIP scores on video are semantically invalid.

**Dependency**: `open-clip-torch>=2.20` added to `Dockerfile` (isolated `RUN` layer for cache efficiency) and to `pyproject.toml` as `[clip]` optional group.

**Local validation**: `scripts/validate_clip_metrics_local.py` — standalone CLI for threshold calibration before CI rollout. Supports single-image mode, directory mode, manifest auto-load, and batch scan.

## Validation

- `pytest tests/e2e_harness/comparators/test_clip_metrics.py -v`: **25 passed** (no GPU, no open_clip, no PIL required)
- `ruff check` on all modified files: **all checks passed**

## Notes For Future Readers

- Review order: `clip_metrics.py` → `diffusion.py` diff → `test_clip_metrics.py` → `Dockerfile` / `pyproject.toml`
- Gate (b) (`trt_hf_image_clip_cosine`) is intentionally inert at default `0.0`; activate it per model by setting `threshold_overrides.min_trt_hf_image_clip_cosine` in the model manifest after calibration
- Gate (a) and (c) are live from day one at their defaults; if a model has unusually low HF CLIP scores, add a manifest `threshold_overrides.min_hf_prompt_clipscore` override
- The CLIP model/pretrained weights are pinned as module-level constants; changing them silently shifts all historical baselines
- `open-clip-torch` must be installed **before** the final NeMo `torch` reinstall block in Dockerfile so the torch pin is not disturbed — the new `RUN` layer is placed correctly before the NeMo block