### PR TITLE
fix(cli): enforce prompt and tokenizer contracts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "onnxscript>=0.2",
     "transformers>=4.40",
     "huggingface_hub>=0.23",
+    "sentencepiece>=0.1.99",
     "tensorrt>=10.16.1,<10.17",
     "PyYAML>=6.0",
     "tomli>=2.0; python_version < '3.11'",

--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -637,6 +637,8 @@ def _ensure_tokenizer_json(model_dir: Path) -> None:
     if (model_dir / "tokenizer.json").exists():
         return
 
+    slow_tokenizer_error: str | None = None
+
     # --- Attempt 1: standard HF slow → fast conversion ---
     try:
         from transformers import AutoTokenizer
@@ -646,8 +648,9 @@ def _ensure_tokenizer_json(model_dir: Path) -> None:
             print("[trtmc build] Generated tokenizer.json from slow tokenizer",
                   file=sys.stderr)
             return
-    except Exception:
-        pass
+        slow_tokenizer_error = "slow tokenizer conversion did not create tokenizer.json"
+    except Exception as e:
+        slow_tokenizer_error = f"slow tokenizer conversion failed: {e}"
 
     # --- Attempt 2: build from SentencePiece model + optional vocab.json ---
     # Marian/NLLB models have source.spm (encoder-side SentencePiece) and
@@ -705,8 +708,15 @@ def _ensure_tokenizer_json(model_dir: Path) -> None:
                   f"({len(vocab)} tokens)", file=sys.stderr)
             return
         except Exception as e:
-            print(f"[trtmc build] Warning: SentencePiece conversion failed: {e}",
-                  file=sys.stderr)
+            detail = (
+                f"{slow_tokenizer_error}; SentencePiece conversion failed: {e}"
+                if slow_tokenizer_error
+                else f"SentencePiece conversion failed: {e}"
+            )
+            raise RuntimeError(
+                f"could not generate tokenizer.json for {model_dir}; {detail}. "
+                "Install sentencepiece for SentencePiece tokenizers or provide tokenizer.json."
+            ) from e
 
     print("[trtmc build] Warning: could not generate tokenizer.json "
           "(C++ runtime may fail to create tokenizer)", file=sys.stderr)

--- a/python/tensorrt_model_connect/families/canary/plugin.py
+++ b/python/tensorrt_model_connect/families/canary/plugin.py
@@ -121,8 +121,11 @@ def _extract_tokenizer_from_nemo(nemo_path: str, dest_dir: Path) -> None:
                             "add_prefix_space": True},
             }
             tok_json_path.write_text(json.dumps(tok_json))
-        except Exception:
-            pass
+        except Exception as e:
+            raise RuntimeError(
+                f"Canary tokenizer.json generation failed for {tok_model_path}: {e}. "
+                "Install sentencepiece or provide tokenizer.json."
+            ) from e
 
     tok_cfg = dest_dir / "tokenizer_config.json"
     if not tok_cfg.exists():

--- a/src/cli/args.cpp
+++ b/src/cli/args.cpp
@@ -165,6 +165,7 @@ CliArgs parse_args(int argc, char** argv) {
 
         if ((arg == "--prompt" || arg == "-p") && need_value(arg)) {
             args.prompt = argv[++i];
+            args.prompt_provided = true;
             continue;
         }
         if (arg == "--max-new-tokens" && need_value(arg)) {
@@ -427,6 +428,11 @@ CliArgs parse_args(int argc, char** argv) {
             args.error_message = "Unexpected positional argument: " + arg;
             return args;
         }
+    }
+
+    if (args.command == "run" && !args.bundle_path.empty() && !args.prompt_provided) {
+        args.parse_error = true;
+        args.error_message = "run requires bundle + --prompt";
     }
 
     return args;

--- a/src/cli/args.h
+++ b/src/cli/args.h
@@ -12,6 +12,7 @@ struct CliArgs {
     std::vector<std::string> build_args;
     std::string bundle_path;
     std::string prompt;
+    bool prompt_provided{false};
     std::string hf_python;
     std::uint64_t kv_cache_size_bytes{0};
     std::string image_path;

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -291,6 +291,10 @@ int cmd_run(const CliArgs& args) {
         std::cerr << "Error: run requires a .trtfb bundle file\n";
         return EXIT_FAILURE;
     }
+    if (!args.prompt_provided) {
+        std::cerr << "Error: run requires bundle + --prompt\n";
+        return EXIT_FAILURE;
+    }
 
     auto pipeline = trtmc::load(args.bundle_path, make_load_options(args));
     if (!pipeline) {
@@ -299,8 +303,7 @@ int cmd_run(const CliArgs& args) {
     }
 
     const std::string ptype = pipeline->pipeline_type();
-    const std::string prompt =
-        args.prompt.empty() && ptype != "ElfFlowPipeline" ? "Hello" : args.prompt;
+    const std::string prompt = args.prompt;
     trtmc::GenerateConfig cfg;
     cfg.max_new_tokens =
         args.max_new_tokens > 0 ? args.max_new_tokens : (ptype == "ElfFlowPipeline" ? 0 : 20);

--- a/tests/builder/test_engine_builder_extended.py
+++ b/tests/builder/test_engine_builder_extended.py
@@ -221,6 +221,14 @@ class TestEnsureTokenizerJson:
 
         assert not (tmp_path / "tokenizer.json").exists()
 
+    def test_sentencepiece_model_conversion_failure_raises(self, tmp_path):
+        """SentencePiece-only tokenizers fail fast instead of producing bad bundles."""
+        (tmp_path / "spiece.model").write_bytes(b"not a real sentencepiece model")
+
+        with patch.dict("sys.modules", {"transformers": None, "sentencepiece": None}):
+            with pytest.raises(RuntimeError, match="SentencePiece conversion failed"):
+                _ensure_tokenizer_json(tmp_path)
+
 
 # ---------------------------------------------------------------------------
 # build_bundle orchestration

--- a/tests/cpp/test_cli_args.cpp
+++ b/tests/cpp/test_cli_args.cpp
@@ -99,6 +99,7 @@ void test_run_parses_common_flags() {
                        "--cuda-graphs"});
     check(args.command == "run", "run command");
     check(args.bundle_path == "bundle.trtfb", "run bundle");
+    check(args.prompt_provided, "run prompt provided");
     check(args.prompt == "hello", "run prompt");
     check(args.max_new_tokens == 8, "run max tokens");
     check(args.generation_mode == "diffusion", "run generation mode");
@@ -184,6 +185,19 @@ void test_missing_value_fails() {
     check(args.error_message == "--prompt requires a value", "missing value message");
 }
 
+void test_missing_prompt_is_distinct_from_empty_prompt() {
+    auto missing = parse({"trtmc", "run", "bundle.trtfb", "--max-new-tokens", "8"});
+    check(missing.parse_error, "missing prompt parse error");
+    check(missing.error_message == "run requires bundle + --prompt", "missing prompt message");
+    check(!missing.prompt_provided, "missing prompt not provided");
+    check(missing.prompt.empty(), "missing prompt text empty");
+
+    auto empty = parse({"trtmc", "run", "bundle.trtfb", "--prompt", "", "--max-new-tokens", "8"});
+    check(empty.prompt_provided, "empty prompt provided");
+    check(empty.prompt.empty(), "empty prompt text empty");
+    check(!empty.parse_error, "empty prompt parse ok");
+}
+
 void test_bad_kv_cache_size_fails() {
     auto args = parse({"trtmc", "run", "bundle.trtfb", "--kv-cache-size=abc"});
     check(args.parse_error, "bad kv cache parse error");
@@ -212,6 +226,7 @@ int main() {
     test_unknown_command_fails();
     test_unknown_flag_fails();
     test_missing_value_fails();
+    test_missing_prompt_is_distinct_from_empty_prompt();
     test_bad_kv_cache_size_fails();
     test_unexpected_positional_fails();
 


### PR DESCRIPTION
## Background

The Blackwell P2021 QA report surfaced two contract gaps that were hidden by environment defaults or runtime fallback behavior. SentencePiece-only tokenizers could produce incomplete bundles when conversion failed, and `trtmc run` accepted a bundle without `--prompt` despite the documented CLI contract.

Fixes #222
Fixes #223

## Exit Criteria

- SentencePiece tokenizer conversion failures stop the build instead of allowing a bundle without `tokenizer.json`.
- `trtmc run <bundle> ...` without `--prompt` fails before loading the bundle.
- `--prompt ""` remains distinguishable from omitting `--prompt` entirely.
- Existing non-SentencePiece tokenizer fallback behavior remains unchanged.

## Implementation

- Declare `sentencepiece` as a Python project dependency.
- Preserve the existing slow-tokenizer fallback behavior for non-SentencePiece sources, but raise an actionable error when a SentencePiece source exists and conversion fails.
- Make Canary tokenizer extraction fail fast when SentencePiece conversion cannot produce `tokenizer.json`.
- Track prompt presence separately from prompt text in the C++ CLI parser, reject missing `--prompt` for `run`, and remove the implicit `"Hello"` fallback.
- Add focused parser and tokenizer regression coverage.

## Validation

- `g++ -std=c++17 -Iinclude -Isrc src/cli/args.cpp tests/cpp/test_cli_args.cpp -o /tmp/test_cli_args && /tmp/test_cli_args`: passed.
- `PYTHONPYCACHEPREFIX=/tmp/trtmc-pycache python3 -m pytest tests/builder/test_engine_builder_extended.py tests/builder/test_engine_builder_utils.py -q`: passed, 64 tests.
- `PYTHONPYCACHEPREFIX=/tmp/trtmc-pycache python3 -m py_compile python/tensorrt_model_connect/engine_builder.py python/tensorrt_model_connect/families/canary/plugin.py`: passed.
- In `trtmc-dev`: `cmake --build build --target trtmc -j2`: passed.
- In `trtmc-dev`: `PYTHONPYCACHEPREFIX=/tmp/trtmc-pycache-container python3 -m pytest tests/builder/test_engine_builder_extended.py tests/builder/test_engine_builder_utils.py tests/builder/test_family_plugins.py::TestCanaryPlugin::test_load_weights_keys tests/builder/test_engine_nemotron_speech_streaming.py -q`: passed, 78 tests with 2 existing SWIG deprecation warnings.
- In `trtmc-dev`: `g++ -std=c++17 -Iinclude -Isrc src/cli/args.cpp tests/cpp/test_cli_args.cpp -o /tmp/test_cli_args && /tmp/test_cli_args`: passed.
- In `trtmc-dev`: `build/trtmc run /tmp/nonexistent.trtfb --max-new-tokens 8`: returned rc=1 with `Error: run requires bundle + --prompt` before bundle load.
- In `trtmc-dev`: `build/trtmc run /tmp/nonexistent.trtfb --prompt "" --max-new-tokens 8`: proceeded to bundle loading and returned `Failed to open bundle file`, confirming explicit empty prompt is not treated as missing.
- `git diff --check`: passed.

## Notes For Future Readers

Review the CLI parser changes first, then the build-tokenizer path. The tokenizer behavior intentionally remains compatible for non-SentencePiece directories that previously only warned when `tokenizer.json` could not be generated.
