### PR TITLE
fix(cli): validate text sampling arguments

### DIFF
--- a/src/cli/args.cpp
+++ b/src/cli/args.cpp
@@ -2,11 +2,61 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cerrno>
+#include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <limits>
 
 namespace trtmc::cli {
+
+namespace {
+
+bool has_ascii_space(const char* text) {
+    if (!text)
+        return false;
+    for (const unsigned char* p = reinterpret_cast<const unsigned char*>(text); *p; ++p) {
+        if (std::isspace(*p))
+            return true;
+    }
+    return false;
+}
+
+bool parse_strict_int(const char* text, int& out) {
+    if (!text || *text == '\0' || has_ascii_space(text))
+        return false;
+
+    errno = 0;
+    char* end = nullptr;
+    const long value = std::strtol(text, &end, 10);
+    if (errno == ERANGE || end == text || *end != '\0' ||
+        value < static_cast<long>(std::numeric_limits<int>::min()) ||
+        value > static_cast<long>(std::numeric_limits<int>::max())) {
+        return false;
+    }
+
+    out = static_cast<int>(value);
+    return true;
+}
+
+bool parse_strict_float(const char* text, float& out) {
+    if (!text || *text == '\0' || has_ascii_space(text))
+        return false;
+
+    errno = 0;
+    char* end = nullptr;
+    const double value = std::strtod(text, &end);
+    if (errno == ERANGE || end == text || *end != '\0' || !std::isfinite(value) ||
+        value < -static_cast<double>(std::numeric_limits<float>::max()) ||
+        value > static_cast<double>(std::numeric_limits<float>::max())) {
+        return false;
+    }
+
+    out = static_cast<float>(value);
+    return true;
+}
+
+} // namespace
 
 std::optional<std::uint64_t> parse_byte_size(const std::string& text) {
     if (text.empty())
@@ -163,12 +213,38 @@ CliArgs parse_args(int argc, char** argv) {
             return true;
         };
 
+        auto parse_int_value = [&](const std::string& name, const std::string& expectation) {
+            int value = 0;
+            if (!parse_strict_int(argv[++i], value)) {
+                args.parse_error = true;
+                args.error_message = name + " expects " + expectation;
+                return std::optional<int>{};
+            }
+            return std::optional<int>{value};
+        };
+
+        auto parse_float_value = [&](const std::string& name, const std::string& expectation) {
+            float value = 0.0F;
+            if (!parse_strict_float(argv[++i], value)) {
+                args.parse_error = true;
+                args.error_message = name + " expects " + expectation;
+                return std::optional<float>{};
+            }
+            return std::optional<float>{value};
+        };
+
         if ((arg == "--prompt" || arg == "-p") && need_value(arg)) {
             args.prompt = argv[++i];
             continue;
         }
         if (arg == "--max-new-tokens" && need_value(arg)) {
-            args.max_new_tokens = std::atoi(argv[++i]);
+            auto value = parse_int_value(arg, "an integer > 0");
+            if (!value || *value <= 0) {
+                args.parse_error = true;
+                args.error_message = arg + " expects an integer > 0";
+                return args;
+            }
+            args.max_new_tokens = *value;
             continue;
         }
         if (arg == "--block-length" && need_value(arg)) {
@@ -188,19 +264,43 @@ CliArgs parse_args(int argc, char** argv) {
             continue;
         }
         if (arg == "--temperature" && need_value(arg)) {
-            args.temperature = static_cast<float>(std::atof(argv[++i]));
+            auto value = parse_float_value(arg, "a finite number >= 0");
+            if (!value || *value < 0.0F) {
+                args.parse_error = true;
+                args.error_message = arg + " expects a finite number >= 0";
+                return args;
+            }
+            args.temperature = *value;
             continue;
         }
         if (arg == "--top-p" && need_value(arg)) {
-            args.top_p = static_cast<float>(std::atof(argv[++i]));
+            auto value = parse_float_value(arg, "a finite number in [0, 1]");
+            if (!value || *value < 0.0F || *value > 1.0F) {
+                args.parse_error = true;
+                args.error_message = arg + " expects a finite number in [0, 1]";
+                return args;
+            }
+            args.top_p = *value;
             continue;
         }
         if (arg == "--min-p" && need_value(arg)) {
-            args.min_p = static_cast<float>(std::atof(argv[++i]));
+            auto value = parse_float_value(arg, "a finite number in [0, 1]");
+            if (!value || *value < 0.0F || *value > 1.0F) {
+                args.parse_error = true;
+                args.error_message = arg + " expects a finite number in [0, 1]";
+                return args;
+            }
+            args.min_p = *value;
             continue;
         }
         if (arg == "--top-k" && need_value(arg)) {
-            args.top_k = std::atoi(argv[++i]);
+            auto value = parse_int_value(arg, "an integer >= 0");
+            if (!value || *value < 0) {
+                args.parse_error = true;
+                args.error_message = arg + " expects an integer >= 0";
+                return args;
+            }
+            args.top_k = *value;
             continue;
         }
         if (arg == "--seed" && need_value(arg)) {

--- a/tests/cpp/test_cli_args.cpp
+++ b/tests/cpp/test_cli_args.cpp
@@ -27,6 +27,11 @@ static void check(bool condition, const char* test_name) {
     }
 }
 
+static void check_message_contains(const std::string& message, const std::string& needle,
+                                   const char* test_name) {
+    check(message.find(needle) != std::string::npos, test_name);
+}
+
 namespace {
 
 trtmc::cli::CliArgs parse(std::initializer_list<std::string> args) {
@@ -190,6 +195,65 @@ void test_bad_kv_cache_size_fails() {
     check(args.error_message.find("--kv-cache-size expects") == 0, "bad kv cache message");
 }
 
+void test_invalid_generation_sampling_values_fail() {
+    auto negative_tokens =
+        parse({"trtmc", "run", "bundle.trtfb", "--prompt", "hello", "--max-new-tokens", "-5"});
+    check(negative_tokens.parse_error, "negative max tokens parse error");
+    check_message_contains(negative_tokens.error_message, "--max-new-tokens expects an integer > 0",
+                           "negative max tokens message");
+
+    auto malformed_tokens =
+        parse({"trtmc", "run", "bundle.trtfb", "--prompt", "hello", "--max-new-tokens", "abc"});
+    check(malformed_tokens.parse_error, "malformed max tokens parse error");
+    check_message_contains(malformed_tokens.error_message,
+                           "--max-new-tokens expects an integer > 0",
+                           "malformed max tokens message");
+
+    auto negative_temperature =
+        parse({"trtmc", "run", "bundle.trtfb", "--prompt", "hello", "--temperature", "-1"});
+    check(negative_temperature.parse_error, "negative temperature parse error");
+    check_message_contains(negative_temperature.error_message,
+                           "--temperature expects a finite number >= 0",
+                           "negative temperature message");
+
+    auto malformed_top_k =
+        parse({"trtmc", "run", "bundle.trtfb", "--prompt", "hello", "--top-k", "abc"});
+    check(malformed_top_k.parse_error, "malformed top-k parse error");
+    check_message_contains(malformed_top_k.error_message, "--top-k expects an integer >= 0",
+                           "malformed top-k message");
+
+    auto negative_top_k =
+        parse({"trtmc", "run", "bundle.trtfb", "--prompt", "hello", "--top-k", "-1"});
+    check(negative_top_k.parse_error, "negative top-k parse error");
+    check_message_contains(negative_top_k.error_message, "--top-k expects an integer >= 0",
+                           "negative top-k message");
+
+    auto out_of_range_top_p =
+        parse({"trtmc", "run", "bundle.trtfb", "--prompt", "hello", "--top-p", "5.0"});
+    check(out_of_range_top_p.parse_error, "out-of-range top-p parse error");
+    check_message_contains(out_of_range_top_p.error_message,
+                           "--top-p expects a finite number in [0, 1]",
+                           "out-of-range top-p message");
+
+    auto out_of_range_min_p =
+        parse({"trtmc", "run", "bundle.trtfb", "--prompt", "hello", "--min-p", "-0.1"});
+    check(out_of_range_min_p.parse_error, "out-of-range min-p parse error");
+    check_message_contains(out_of_range_min_p.error_message,
+                           "--min-p expects a finite number in [0, 1]",
+                           "out-of-range min-p message");
+}
+
+void test_generation_sampling_boundaries_parse() {
+    auto args = parse({"trtmc", "run", "bundle.trtfb", "--prompt", "hello", "--max-new-tokens", "1",
+                       "--temperature", "0", "--top-p", "0", "--min-p", "1", "--top-k", "0"});
+    check(!args.parse_error, "generation sampling boundary values parse");
+    check(args.max_new_tokens == 1, "boundary max tokens");
+    check(args.temperature == 0.0F, "boundary temperature");
+    check(args.top_p == 0.0F, "boundary top-p");
+    check(args.min_p == 1.0F, "boundary min-p");
+    check(args.top_k == 0, "boundary top-k");
+}
+
 void test_unexpected_positional_fails() {
     auto args = parse({"trtmc", "run", "one.trtfb", "two.trtfb"});
     check(args.parse_error, "unexpected positional parse error");
@@ -213,6 +277,8 @@ int main() {
     test_unknown_flag_fails();
     test_missing_value_fails();
     test_bad_kv_cache_size_fails();
+    test_invalid_generation_sampling_values_fail();
+    test_generation_sampling_boundaries_parse();
     test_unexpected_positional_fails();
 
     if (failures) {


### PR DESCRIPTION
## Background
Fixes #202.

`trtmc run` accepted invalid text generation and sampling flags such as
`--max-new-tokens -5`, `--temperature -1`, `--top-k abc`, and `--top-p 5.0`.
Those values were silently coerced by `atoi`/`atof` and could still exit with
success.

## Exit Criteria
- Invalid explicit text generation and sampling CLI values fail during argument
  parsing with a non-zero exit and a clear error message.
- Existing valid boundaries remain accepted, including `--temperature 0`,
  top-p/min-p endpoints, and `--top-k 0`.

## Implementation
- Add strict CLI integer and float parsers that reject malformed strings,
  whitespace, overflow, NaN, and Inf.
- Validate bounds for `--max-new-tokens`, `--temperature`, `--top-p`, `--min-p`,
  and `--top-k` before runtime execution.
- Add C++ parser regression coverage for the issue examples and accepted
  boundary values.

## Validation
- `docker exec trtmc-dev cmake --build /workspace/tensorrt-model-connect/build --target test_cli_args trtmc -j`: passed.
- `docker exec trtmc-dev ctest --test-dir /workspace/tensorrt-model-connect/build -R test_cli_args --output-on-failure`: passed.
- `docker exec trtmc-dev /workspace/tensorrt-model-connect/build/trtmc run /tmp/missing.trtfb --prompt hello --max-new-tokens -5`: returned code 1 with `Error: --max-new-tokens expects an integer > 0`.
- `docker exec trtmc-dev /workspace/tensorrt-model-connect/build/trtmc run /tmp/missing.trtfb --prompt hello --temperature -1`: returned code 1 with `Error: --temperature expects a finite number >= 0`.
- `docker exec trtmc-dev /workspace/tensorrt-model-connect/build/trtmc run /tmp/missing.trtfb --prompt hello --top-k abc`: returned code 1 with `Error: --top-k expects an integer >= 0`.
- `docker exec trtmc-dev /workspace/tensorrt-model-connect/build/trtmc run /tmp/missing.trtfb --prompt hello --top-p 5.0`: returned code 1 with `Error: --top-p expects a finite number in [0, 1]`.

## Notes For Future Readers
The direct CLI checks intentionally use a missing bundle path; the expected
failure happens during argument parsing, before any bundle load or runtime
execution.
