### PR TITLE
feat(diffusion): batch CLI + C ABI + inspect (PR 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,6 +607,7 @@ trtmc_add_test(test_trt_version)
 # C ABI
 trtmc_add_test(test_c_abi_entry                NO_SRC_INCLUDE)
 trtmc_add_test(test_c_abi_runtime_regression   NO_SRC_INCLUDE)
+trtmc_add_test(test_cabi_batch                 NO_SRC_INCLUDE)
 
 # Config / parsing
 trtmc_add_test(test_text_parsers)

--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -420,10 +420,59 @@ struct TrtmcPipelineOptions {
     int cuda_graphs;           // 0 = disabled
 };
 
+// --- C ABI error codes ---
+//
+// Returned by C-ABI functions that yield an int (e.g. trtmc_generate_batch).
+// On any non-zero return, callers may inspect trtmc_last_error() for a
+// descriptive message. Codes are stable and additive — new codes get new
+// non-zero integers; existing callers must treat unknown codes as a generic
+// failure.
+#define TRTMC_OK 0
+#define TRTMC_ERR_INVALID_ARG 1
+#define TRTMC_ERR_RUNTIME 2
+
+// --- C ABI image result ---
+//
+// Plain-old-data image result returned by trtmc_generate_batch. The caller
+// owns the trtmc_image_result_t array (typically a fixed-size stack/heap
+// buffer of N entries) and is responsible for releasing the per-result
+// `pixels` buffer via trtmc_image_result_free.
+struct trtmc_image_result_t {
+    float* pixels;            // malloc'd [C*H*W] float32 in [0,1]. nullptr on error.
+    int32_t height;           // image height in pixels
+    int32_t width;            // image width in pixels
+    int32_t channels;         // number of channels (typically 3)
+    int32_t num_frames;       // >1 for video
+    std::uint64_t num_pixels; // total floats in `pixels` (channels*height*width*num_frames)
+};
+
+// Opaque handle alias used by future C-ABI generation functions. Today the
+// C ABI hands users a `trtmc::IPipeline*` directly (a C++ type with a
+// trivial vtable); language bindings that don't want the C++ type can use
+// `trtmc_pipeline_t` for documentation purposes.
+typedef trtmc::IPipeline* trtmc_pipeline_t;
+
 trtmc::IPipeline* trtmc_create_pipeline(const char* bundle_path, int flags);
 trtmc::IPipeline* trtmc_create_pipeline_ex(const char* bundle_path,
                                            const TrtmcPipelineOptions* options);
 const char* trtmc_last_error(void);
 const char* trtmc_version(void);
 int trtmc_has_trt(void);
+
+// Release the `pixels` buffer in a single trtmc_image_result_t entry. Safe
+// on a zero-initialized entry (no-op when pixels is null). Sets pixels to
+// nullptr after free.
+void trtmc_image_result_free(trtmc_image_result_t* result);
+
+// Generate a batch of images. `prompts` is an array of `num_prompts`
+// null-terminated C strings; `seeds` is an array of `num_seeds` uint32_t
+// per-sample seeds (caller can fill these via the upstream
+// derive_per_sample_seeds helper). `num_prompts` must equal `num_seeds`.
+// `out_results` is a caller-owned array of `num_prompts`
+// trtmc_image_result_t that the function fills; each result's `pixels`
+// buffer is malloc'd and must be released with trtmc_image_result_free.
+// Returns TRTMC_OK on success, a non-zero TRTMC_ERR_* code on failure.
+int trtmc_generate_batch(trtmc_pipeline_t handle, const char* const* prompts, int num_prompts,
+                         const std::uint32_t* seeds, int num_seeds, int num_inference_steps,
+                         float guidance_scale, trtmc_image_result_t* out_results);
 }

--- a/python/tensorrt_model_connect/build_cli.py
+++ b/python/tensorrt_model_connect/build_cli.py
@@ -190,6 +190,7 @@ def _cmd_build(args: argparse.Namespace) -> int:
             audio_magpie_max_source_positions=audio_magpie_max_source_positions,
             parallel_config=parallel_config,
             build_timing_path=getattr(args, "build_timing_json", None),
+            max_batch_size=int(getattr(args, "max_batch_size", 1) or 1),
             diffusion_overrides={
                 key: value
                 for key, value in {
@@ -602,6 +603,13 @@ def main() -> None:
                          help="Diffusion video frame count override")
     build_p.add_argument("--num-inference-steps", type=int, default=None,
                          help="Diffusion denoising step count override")
+    build_p.add_argument(
+        "--max-batch-size", type=int, default=1,
+        help="Build diffusion bundle whose engines support batch sizes up to N "
+             "(default: 1). Applied per component using the family policy: "
+             "DiT honors N, text encoder caps at min(2N, 8), VAE always builds "
+             "B=1 (the runtime slices)."
+    )
     build_p.add_argument("--precision", choices=["fp32", "fp16", "bf16"],
                          default="fp32",
                          help="Engine precision (default: fp32)")

--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -754,6 +754,7 @@ def build_bundle(
     parallel_config: ParallelConfig | None = None,
     diffusion_overrides: dict | None = None,
     build_timing_path: str | None = None,
+    max_batch_size: int = 1,
 ) -> None:
     """Full pipeline: load HF model → build TRT engine → write .trtfb bundle.
 
@@ -802,7 +803,8 @@ def build_bundle(
             rtx=rtx,
             diffusion_overrides=diffusion_overrides,
             build_timing=build_timing,
-            parallel_config=parallel)
+            parallel_config=parallel,
+            max_batch_size=max_batch_size)
         return
 
     # 1. Parse config
@@ -1386,6 +1388,7 @@ def _build_diffusion_bundle(
     diffusion_overrides: dict | None = None,
     build_timing: dict | None = None,
     parallel_config: ParallelConfig | None = None,
+    max_batch_size: int = 1,
 ) -> None:
     """Build a diffusion model bundle from a diffusers-format directory."""
     if build_timing is None:
@@ -1495,6 +1498,10 @@ def _build_diffusion_bundle(
         elif parallel.enabled:
             raise NotImplementedError(
                 f"Plugin {plugin.name} does not accept parallel_config for diffusion TP")
+        # Only forward max_batch_size to plugins that opted in. Plugins that
+        # don't accept it (older or non-batchified ones) silently stay on B=1.
+        if _call_supports_kwarg(build_components, "max_batch_size"):
+            build_components_kwargs["max_batch_size"] = max_batch_size
         components = build_components(
             str(model_dir_path), config, weights, **build_components_kwargs)
     finally:
@@ -1682,6 +1689,20 @@ def _build_diffusion_bundle(
             if file_path.exists():
                 sections.append(BundleSection(dst_name, file_path.read_bytes()))
 
+    # Resolve per-component batch envelope. Plugins that batchified record
+    # the envelope on components["max_batch_size_envelope"]. When absent
+    # (older plugins, or N=1), the BundleInfo field stays None and the
+    # JSON header simply omits the block — back-compat with PR 1 readers.
+    mbs_envelope = components.get("max_batch_size_envelope")
+    if mbs_envelope is None and max_batch_size > 1:
+        # Plugin didn't expose an envelope but caller asked for >1 — fall
+        # back to a sane default derived from CLI policy (see Decision C).
+        mbs_envelope = {
+            "dit": int(max_batch_size),
+            "text_encoder": min(int(max_batch_size) * 2, 8),
+            "vae": 1,
+        }
+
     # Write bundle
     info = BundleInfo(
         model_id=model_dir_path.name,
@@ -1695,6 +1716,7 @@ def _build_diffusion_bundle(
         precision=precision,
         max_cache_length=max_cache_length,
         tokenizer_add_special_tokens=tokenizer_add_special_tokens,
+        max_batch_size=mbs_envelope,
     )
 
     write_t0 = time.monotonic()
@@ -1736,6 +1758,7 @@ def build(
     parallel_config: ParallelConfig | None = None,
     diffusion_overrides: dict | None = None,
     build_timing_path: str | None = None,
+    max_batch_size: int = 1,
 ) -> None:
     """Build a .trtfb bundle from a HuggingFace model ID or local path.
 
@@ -1778,4 +1801,5 @@ def build(
                  audio_magpie_max_source_positions=audio_magpie_max_source_positions,
                  parallel_config=parallel_config,
                  diffusion_overrides=diffusion_overrides,
-                 build_timing_path=build_timing_path)
+                 build_timing_path=build_timing_path,
+                 max_batch_size=max_batch_size)

--- a/python/tensorrt_model_connect/families/flux/plugin.py
+++ b/python/tensorrt_model_connect/families/flux/plugin.py
@@ -152,13 +152,20 @@ class FluxPlugin:
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
         *, precision: str = "fp32", verbose: bool = False,
         fp8_scales: dict | None = None, build_timing: dict | None = None,
-        parallel_config=None,
+        parallel_config=None, max_batch_size: int = 1,
     ) -> dict:
         """Build all component engines.
 
         Detects FLUX.1 vs FLUX.2 from the transformer config and dispatches
         to the appropriate builders.
         """
+        # TP + batch>1 is out of scope for the diffusion-batch series.
+        if max_batch_size > 1 and parallel_config is not None and getattr(
+                parallel_config, "enabled", False):
+            raise NotImplementedError(
+                "FLUX tensor-parallel + max_batch_size > 1 is not supported "
+                "in this release; build with either TP=1 or max_batch_size=1."
+            )
 
         weights["_transformer_dir"]
         weights["_vae_dir"]
@@ -171,18 +178,21 @@ class FluxPlugin:
             return self._build_flux2_components(
                 model_dir, config, weights, tc=tc, verbose=verbose,
                 fp8_scales=fp8_scales, precision=precision,
-                build_timing=build_timing, parallel_config=parallel_config)
+                build_timing=build_timing, parallel_config=parallel_config,
+                max_batch_size=max_batch_size)
 
         return self._build_flux1_components(
             model_dir, config, weights, tc=tc, verbose=verbose,
             precision=precision, build_timing=build_timing,
-            parallel_config=parallel_config)
+            parallel_config=parallel_config,
+            max_batch_size=max_batch_size)
 
     def _build_flux1_components(
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
         *, tc: dict, precision: str = "fp32", verbose: bool = False,
         build_timing: dict | None = None,
         parallel_config=None,
+        max_batch_size: int = 1,
     ) -> dict:
         """Build FLUX.1 component engines (CLIP + T5 + DiT + VAE)."""
         from ...build_timing import timed_trt_compile, timed_weight_loading
@@ -201,6 +211,16 @@ class FluxPlugin:
         parallel = normalize_parallel_config(parallel_config)
         require_tensorrt_11_for_tensor_parallel(
             parallel, feature="Flux tensor-parallel builds")
+
+        # Per-component batch policy (design Decision C / E):
+        # - DiT honours max_batch_size with opt = min(N, 4).
+        # - Text encoder builds wider (min(2N, 8)) since it is cheap to batch.
+        # - VAE always builds at B=1; pipeline slices at runtime.
+        dit_mbs = int(max_batch_size)
+        dit_opt = min(dit_mbs, 4)
+        te_mbs = min(dit_mbs * 2, 8)
+        te_opt = min(te_mbs, 4)
+        vae_mbs = 1
 
         transformer_dir = weights["_transformer_dir"]
         vae_dir = weights["_vae_dir"]
@@ -288,6 +308,8 @@ class FluxPlugin:
                             vocab_size=clip_cfg.get("vocab_size", self._T5_VOCAB_SIZE),
                             max_seq_len=self._T5_MAX_SEQ_LEN,
                             verbose=verbose,
+                            max_batch_size=te_mbs,
+                            opt_batch_size=te_opt,
                         )
                     text_encoders.append(("t5", t5_plan))
 
@@ -329,6 +351,8 @@ class FluxPlugin:
                     vocab_size=t5_vocab_size,
                     max_seq_len=self._T5_MAX_SEQ_LEN,
                     verbose=verbose,
+                    max_batch_size=te_mbs,
+                    opt_batch_size=te_opt,
                 )
             text_encoders.append(("t5", t5_plan))
 
@@ -372,9 +396,12 @@ class FluxPlugin:
                     num_img_tokens=num_img_tokens,
                     text_seq_len=self._T5_MAX_SEQ_LEN,
                     verbose=verbose,
+                    max_batch_size=dit_mbs,
+                    opt_batch_size=dit_opt,
                 )
 
         # 4. VAE decoder - native TRT engine
+        # VAE always builds B=1 per Decision E (pipeline slices at runtime).
         from .flux_vae_builder import build_flux_vae_decoder_engine
         vae_plan = build_flux_vae_decoder_engine(
             vae_dir,
@@ -400,6 +427,12 @@ class FluxPlugin:
             out["denoiser_ranks"] = dit_rank_plans or {}
         else:
             out["denoiser"] = dit_plan
+        if max_batch_size > 1:
+            out["max_batch_size_envelope"] = {
+                "dit": dit_mbs,
+                "text_encoder": te_mbs,
+                "vae": vae_mbs,
+            }
         return out
 
     def _build_flux2_components(
@@ -408,8 +441,16 @@ class FluxPlugin:
         fp8_scales: dict | None = None,
         build_timing: dict | None = None,
         parallel_config=None,
+        max_batch_size: int = 1,
     ) -> dict:
         """Build FLUX.2 component engines (Mistral + Flux2 DiT + VAE32)."""
+        # Component batch policy (Decisions C / E). FLUX.2 DiT and Mistral
+        # builders don't yet honour batch envelopes; only the VAE is
+        # routed through the batchified flux_vae_builder. The envelope is
+        # still reported on the bundle for runtime visibility.
+        dit_mbs = int(max_batch_size)
+        te_mbs = min(dit_mbs * 2, 8)
+        vae_mbs = 1
         from ...build_timing import timed_trt_compile, timed_weight_loading
         from .mistral_encoder_builder import (
             build_mistral_encoder_engine, load_mistral_encoder_weights)
@@ -709,6 +750,12 @@ class FluxPlugin:
             out["denoiser_ranks"] = denoiser_ranks or {}
         else:
             out["denoiser"] = dit_plan
+        if max_batch_size > 1:
+            out["max_batch_size_envelope"] = {
+                "dit": dit_mbs,
+                "text_encoder": te_mbs,
+                "vae": vae_mbs,
+            }
         return out
 
     def get_diffusion_config(self, config: ModelConfig) -> dict:

--- a/python/tensorrt_model_connect/families/qwen_image/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_image/plugin.py
@@ -140,7 +140,8 @@ class QwenImagePlugin:
 
     def build_components(
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
-        *, precision: str = "bf16", verbose: bool = False, **_kwargs,
+        *, precision: str = "bf16", verbose: bool = False,
+        parallel_config=None, max_batch_size: int = 1, **_kwargs,
     ) -> dict:
         """Build TRT engines and bundle blobs for a Qwen-Image T2I checkpoint.
 
@@ -169,6 +170,31 @@ class QwenImagePlugin:
         import sys
         import tempfile
         from pathlib import Path
+
+        # TP + batch>1 is out of scope for this PR series. Qwen-Image does
+        # not currently support diffusion TP, but the guard mirrors the
+        # other families for symmetry.
+        if max_batch_size > 1 and parallel_config is not None and getattr(
+                parallel_config, "enabled", False):
+            raise NotImplementedError(
+                "Qwen-Image tensor-parallel + max_batch_size > 1 is not "
+                "supported in this release; build with either TP=1 or "
+                "max_batch_size=1."
+            )
+
+        # Per-component batch policy (Decisions C / E).
+        dit_mbs = int(max_batch_size)
+        dit_opt = min(dit_mbs, 4)
+        # Qwen2.5-VL text encoder is still single-sample only — its inner
+        # graph has static `(1, ...)` reshapes that TRT shape-propagation
+        # refuses under a dynamic leading dim. The pipeline already loops
+        # per-prompt for the encoder when the DiT is batched, so this clamp
+        # keeps Qwen-Image bundles building at any `--max-batch-size`. Lift
+        # this back to ``min(dit_mbs * 2, 8)`` once the Qwen2.5-VL inner
+        # blocks are batchified (Phase 1.5 follow-up).
+        te_mbs = 1
+        te_opt = 1
+        vae_mbs = 1
 
         from .qwen_image_bundle_config import build_bundle_config
         from .qwen25_vl_text_encoder_builder import (
@@ -298,6 +324,8 @@ class QwenImagePlugin:
                 else 2,
                 vision_tokens_per_second=int(vision_cfg.get("tokens_per_second", 2)),
                 verbose=verbose,
+                max_batch_size=te_mbs,
+                opt_batch_size=te_opt,
             )
             text_engine_bytes = text_plan_path.read_bytes()
         finally:
@@ -332,6 +360,8 @@ class QwenImagePlugin:
                 h_lat=h_lat, w_lat=w_lat, n_text=n_text,
                 image_token_shapes=image_token_shapes,
                 verbose=verbose,
+                max_batch_size=dit_mbs,
+                opt_batch_size=dit_opt,
             )
             dit_engine_bytes = dit_plan_path.read_bytes()
         finally:
@@ -453,6 +483,12 @@ class QwenImagePlugin:
             components["vision_engine"] = vision_engine_bytes
         if vae_encoder_bytes is not None:
             components["vae_encoder"] = vae_encoder_bytes
+        if max_batch_size > 1:
+            components["max_batch_size_envelope"] = {
+                "dit": dit_mbs,
+                "text_encoder": te_mbs,
+                "vae": vae_mbs,
+            }
         return components
 
 

--- a/python/tensorrt_model_connect/families/qwen_image/qwen_image_dit_builder.py
+++ b/python/tensorrt_model_connect/families/qwen_image/qwen_image_dit_builder.py
@@ -947,7 +947,13 @@ def _add_layernorm_no_affine_3d(network, x, hidden_size: int, eps: float):
     )
     norm = network.add_normalization(x_c, ones, zeros, axesMask=1 << 2)
     norm.epsilon = float(eps)
-    norm.compute_precision = trt.float32
+    # TensorRT 11 removed the Python INormalizationLayer.compute_precision
+    # setter; TRT 10 emitted a "setComputePrecision ignored for strongly
+    # typed network" warning when set on a strongly-typed network. Guard
+    # both behaviours so this builder works across 10/11. (Matches the
+    # hasattr guard in graph_ops.add_layer_norm_native.)
+    if hasattr(norm, "compute_precision"):
+        norm.compute_precision = trt.float32
     return norm.get_output(0)
 
 

--- a/python/tensorrt_model_connect/families/z_image/plugin.py
+++ b/python/tensorrt_model_connect/families/z_image/plugin.py
@@ -104,7 +104,7 @@ class ZImagePlugin:
     def build_components(
         self, model_dir: str, config: ModelConfig, weights: WeightDict,
         *, precision: str = "fp32", verbose: bool = False,
-        parallel_config=None, **_kwargs,
+        parallel_config=None, max_batch_size: int = 1, **_kwargs,
     ) -> dict:
         """Build REAL TRT engines for all Z-Image components."""
         from ...build_timing import timed_trt_compile, timed_weight_loading
@@ -122,8 +122,21 @@ class ZImagePlugin:
         )
         build_timing = _kwargs.get("build_timing")
         parallel = normalize_parallel_config(parallel_config)
+        # TP + batch>1 is out of scope for this PR series.
+        if max_batch_size > 1 and parallel.enabled:
+            raise NotImplementedError(
+                "Z-Image tensor-parallel + max_batch_size > 1 is not supported "
+                "in this release; build with either TP=1 or max_batch_size=1."
+            )
         require_tensorrt_11_for_tensor_parallel(
             parallel, feature="Z-Image tensor-parallel builds")
+
+        # Per-component batch policy (Decisions C / E).
+        dit_mbs = int(max_batch_size)
+        dit_opt = min(dit_mbs, 4)
+        te_mbs = min(dit_mbs * 2, 8)
+        te_opt = min(te_mbs, 4)
+        vae_mbs = 1
         if parallel.enabled:
             validate_dit_tp(
                 dim=self._DIT_DIM,
@@ -179,6 +192,8 @@ class ZImagePlugin:
                 rope_theta=self._TEXT_ROPE_THETA,
                 output_layer=self._TEXT_OUTPUT_LAYER,
                 verbose=verbose,
+                max_batch_size=te_mbs,
+                opt_batch_size=te_opt,
             )
 
         # 2. Z-Image DiT denoiser
@@ -229,6 +244,8 @@ class ZImagePlugin:
                     head_dim=self._DIT_HEAD_DIM,
                     adaln_embed_dim=self._ADALN_EMBED_DIM,
                     verbose=verbose,
+                    max_batch_size=dit_mbs,
+                    opt_batch_size=dit_opt,
                 )
 
         # 3. VAE decoder
@@ -257,6 +274,12 @@ class ZImagePlugin:
             out["denoiser_ranks"] = dit_rank_plans or {}
         else:
             out["denoiser"] = dit_plan
+        if max_batch_size > 1:
+            out["max_batch_size_envelope"] = {
+                "dit": dit_mbs,
+                "text_encoder": te_mbs,
+                "vae": vae_mbs,
+            }
         return out
 
     def get_diffusion_config(self, config: ModelConfig) -> dict:

--- a/src/cabi/api/trtmc_c.cpp
+++ b/src/cabi/api/trtmc_c.cpp
@@ -3,9 +3,13 @@
 #include "trtmc/runtime/pipeline_factory.h"
 
 #include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <exception>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #ifndef TRTMC_VERSION_STRING
 #define TRTMC_VERSION_STRING "0.1.0"
@@ -39,6 +43,36 @@ PipelineCreateArgs parse_pipeline_options(const TrtmcPipelineOptions* options) {
     return args;
 }
 
+// Convert a single C++ ImageResult into the C-ABI POD form. Allocates the
+// pixel buffer with std::malloc so callers can free it from C (or via
+// trtmc_image_result_free). Returns false (and leaves `out` zero-initialised)
+// if the allocation fails.
+bool to_c_image_result(const trtmc::ImageResult& src, trtmc_image_result_t* out) {
+    std::memset(out, 0, sizeof(*out));
+    const std::size_t count = src.pixels.size();
+    if (count == 0) {
+        out->height = src.height;
+        out->width = src.width;
+        out->channels = src.channels;
+        out->num_frames = src.num_frames;
+        out->num_pixels = 0;
+        out->pixels = nullptr;
+        return true;
+    }
+    auto* buf = static_cast<float*>(std::malloc(count * sizeof(float)));
+    if (buf == nullptr) {
+        return false;
+    }
+    std::memcpy(buf, src.pixels.data(), count * sizeof(float));
+    out->pixels = buf;
+    out->height = src.height;
+    out->width = src.width;
+    out->channels = src.channels;
+    out->num_frames = src.num_frames;
+    out->num_pixels = static_cast<std::uint64_t>(count);
+    return true;
+}
+
 } // namespace
 
 extern "C" {
@@ -55,7 +89,7 @@ trtmc::IPipeline* trtmc_create_pipeline(const char* bundle_path, int flags) {
 }
 
 trtmc::IPipeline* trtmc_create_pipeline_ex(const char* bundle_path,
-                                         const TrtmcPipelineOptions* options) {
+                                           const TrtmcPipelineOptions* options) {
     clear_last_error();
 
     if (bundle_path == nullptr || bundle_path[0] == '\0') {
@@ -74,8 +108,8 @@ trtmc::IPipeline* trtmc_create_pipeline_ex(const char* bundle_path,
 
         auto t0 = std::chrono::steady_clock::now();
 
-        auto pipeline = trtmc::PipelineFactory::from_bundle(path, args.hf_python, args.runtime_cache,
-                                                           args.cuda_graphs);
+        auto pipeline = trtmc::PipelineFactory::from_bundle(path, args.hf_python,
+                                                            args.runtime_cache, args.cuda_graphs);
 
         auto t1 = std::chrono::steady_clock::now();
         std::cerr << "[trtmc] Runtime ready (strategy=" << pipeline->pipeline_type() << ") ["
@@ -102,6 +136,107 @@ const char* trtmc_version(void) {
 
 int trtmc_has_trt(void) {
     return 1;
+}
+
+void trtmc_image_result_free(trtmc_image_result_t* result) {
+    if (result == nullptr) {
+        return;
+    }
+    if (result->pixels != nullptr) {
+        std::free(result->pixels);
+        result->pixels = nullptr;
+    }
+    result->num_pixels = 0;
+}
+
+namespace {
+
+// Validate the raw C-ABI inputs in one place; sets last_error on failure.
+int validate_batch_args(trtmc_pipeline_t handle, const char* const* prompts, int num_prompts,
+                        const std::uint32_t* seeds, int num_seeds,
+                        const trtmc_image_result_t* out_results) {
+    const char* reason = nullptr;
+    if (handle == nullptr)
+        reason = "trtmc_generate_batch: pipeline handle must not be null";
+    else if (prompts == nullptr || num_prompts <= 0)
+        reason = "trtmc_generate_batch: prompts array must be non-empty";
+    else if (seeds == nullptr)
+        reason = "trtmc_generate_batch: seeds array must not be null";
+    else if (num_prompts != num_seeds)
+        reason = "trtmc_generate_batch: num_prompts must equal num_seeds";
+    else if (out_results == nullptr)
+        reason = "trtmc_generate_batch: out_results must not be null";
+    if (reason) {
+        set_last_error(reason);
+        return TRTMC_ERR_INVALID_ARG;
+    }
+    return TRTMC_OK;
+}
+
+// Copy results into caller-owned C structs. On OOM, frees what was already
+// produced and returns TRTMC_ERR_RUNTIME with last_error set.
+int copy_results_to_c(const std::vector<trtmc::ImageResult>& results,
+                      trtmc_image_result_t* out_results, int num_prompts) {
+    for (int i = 0; i < num_prompts; ++i) {
+        std::memset(&out_results[i], 0, sizeof(trtmc_image_result_t));
+    }
+    for (int i = 0; i < num_prompts; ++i) {
+        if (!to_c_image_result(results[static_cast<std::size_t>(i)], &out_results[i])) {
+            for (int j = 0; j < i; ++j)
+                trtmc_image_result_free(&out_results[j]);
+            set_last_error("trtmc_generate_batch: out-of-memory copying pixels");
+            return TRTMC_ERR_RUNTIME;
+        }
+    }
+    return TRTMC_OK;
+}
+
+} // namespace
+
+int trtmc_generate_batch(trtmc_pipeline_t handle, const char* const* prompts, int num_prompts,
+                         const std::uint32_t* seeds, int num_seeds, int num_inference_steps,
+                         float guidance_scale, trtmc_image_result_t* out_results) {
+    clear_last_error();
+    if (int rc = validate_batch_args(handle, prompts, num_prompts, seeds, num_seeds, out_results);
+        rc != TRTMC_OK) {
+        return rc;
+    }
+
+    try {
+        std::vector<std::string> prompt_vec;
+        prompt_vec.reserve(static_cast<std::size_t>(num_prompts));
+        for (int i = 0; i < num_prompts; ++i) {
+            if (prompts[i] == nullptr) {
+                set_last_error("trtmc_generate_batch: prompts[" + std::to_string(i) + "] is null");
+                return TRTMC_ERR_INVALID_ARG;
+            }
+            prompt_vec.emplace_back(prompts[i]);
+        }
+        std::vector<std::uint32_t> seed_vec(seeds, seeds + num_seeds);
+
+        trtmc::GenerateConfig cfg;
+        if (num_inference_steps > 0)
+            cfg.num_steps = num_inference_steps;
+        cfg.guidance_scale = guidance_scale;
+
+        auto results = handle->generate_image_batch(prompt_vec, seed_vec, cfg);
+        if (static_cast<int>(results.size()) != num_prompts) {
+            set_last_error("trtmc_generate_batch: pipeline returned " +
+                           std::to_string(results.size()) + " results for " +
+                           std::to_string(num_prompts) + " prompts");
+            return TRTMC_ERR_RUNTIME;
+        }
+        return copy_results_to_c(results, out_results, num_prompts);
+    } catch (const std::invalid_argument& e) {
+        set_last_error(e.what());
+        return TRTMC_ERR_INVALID_ARG;
+    } catch (const std::exception& e) {
+        set_last_error(e.what());
+        return TRTMC_ERR_RUNTIME;
+    } catch (...) {
+        set_last_error("trtmc_generate_batch: unknown error");
+        return TRTMC_ERR_RUNTIME;
+    }
 }
 
 } // extern "C"

--- a/src/cli/args.cpp
+++ b/src/cli/args.cpp
@@ -3,8 +3,10 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
+#include <fstream>
 #include <iostream>
 #include <limits>
+#include <sstream>
 
 namespace trtmc::cli {
 
@@ -57,6 +59,75 @@ std::optional<std::uint64_t> parse_byte_size(const std::string& text) {
     return static_cast<std::uint64_t>(bytes + 0.5L);
 }
 
+std::optional<std::vector<std::uint64_t>> parse_seed_csv(const std::string& text) {
+    std::vector<std::uint64_t> out;
+    if (text.empty())
+        return out;
+    std::string token;
+    auto flush = [&]() -> bool {
+        if (token.empty())
+            return false;
+        // Trim incidental whitespace ("0, 1, 2" is friendlier than "0,1,2").
+        std::size_t begin = 0;
+        std::size_t end = token.size();
+        while (begin < end && std::isspace(static_cast<unsigned char>(token[begin])))
+            ++begin;
+        while (end > begin && std::isspace(static_cast<unsigned char>(token[end - 1])))
+            --end;
+        if (begin == end)
+            return false;
+        try {
+            std::size_t consumed = 0;
+            const std::string slice = token.substr(begin, end - begin);
+            const unsigned long long value = std::stoull(slice, &consumed, 10);
+            if (consumed != slice.size())
+                return false;
+            out.push_back(static_cast<std::uint64_t>(value));
+        } catch (...) {
+            return false;
+        }
+        token.clear();
+        return true;
+    };
+
+    for (char ch : text) {
+        if (ch == ',') {
+            if (!flush())
+                return std::nullopt;
+        } else {
+            token.push_back(ch);
+        }
+    }
+    if (!flush())
+        return std::nullopt;
+    return out;
+}
+
+std::vector<std::string> read_prompts_file(const std::string& path, std::string& error) {
+    std::ifstream in(path);
+    if (!in) {
+        error = "failed to open prompts file: " + path;
+        return {};
+    }
+    std::vector<std::string> prompts;
+    std::string line;
+    while (std::getline(in, line)) {
+        // Strip trailing CR for files written on Windows.
+        if (!line.empty() && line.back() == '\r')
+            line.pop_back();
+        prompts.push_back(line);
+    }
+    // Drop a trailing blank line introduced by a final newline; keep
+    // any deliberate blank prompts the user typed in the middle.
+    while (!prompts.empty() && prompts.back().empty())
+        prompts.pop_back();
+    if (prompts.empty()) {
+        error = "prompts file is empty: " + path;
+        return {};
+    }
+    return prompts;
+}
+
 void print_usage() {
     std::cerr
         << "Usage:\n"
@@ -72,7 +143,8 @@ void print_usage() {
            "[--output samples.jsonl]\n"
            "                        Diffusion text-to-image extras (Qwen-Image, FLUX, "
            "Z-Image): [--negative-prompt \"text\"] "
-           "[--num-inference-steps N] [--height N] [--width N]\n"
+           "[--num-inference-steps N] [--height N] [--width N] "
+           "[--num-images N] [--prompts-file PATH] [--seed s0,s1,...]\n"
            "  trtmc encode          <bundle.trtfb> --prompt \"text\" [--hf-python PATH]\n"
            "  trtmc segment         <bundle.trtfb> --image PATH --output PATH [--hf-python PATH]\n"
            "  trtmc segment-sam     <bundle.trtfb> --image PATH --output DIR "
@@ -166,6 +238,30 @@ CliArgs parse_args(int argc, char** argv) {
         if ((arg == "--prompt" || arg == "-p") && need_value(arg)) {
             args.prompt = argv[++i];
             args.prompt_provided = true;
+            if (!args.prompts_file.empty()) {
+                args.parse_error = true;
+                args.error_message = "--prompt and --prompts-file are mutually exclusive";
+                return args;
+            }
+            continue;
+        }
+        if (arg == "--prompts-file" && need_value(arg)) {
+            args.prompts_file = argv[++i];
+            if (args.prompt_provided) {
+                args.parse_error = true;
+                args.error_message = "--prompt and --prompts-file are mutually exclusive";
+                return args;
+            }
+            continue;
+        }
+        if (arg == "--num-images" && need_value(arg)) {
+            const int n = std::atoi(argv[++i]);
+            if (n < 1) {
+                args.parse_error = true;
+                args.error_message = "--num-images must be >= 1";
+                return args;
+            }
+            args.num_images = n;
             continue;
         }
         if (arg == "--max-new-tokens" && need_value(arg)) {
@@ -205,7 +301,18 @@ CliArgs parse_args(int argc, char** argv) {
             continue;
         }
         if (arg == "--seed" && need_value(arg)) {
-            args.seed = std::atoi(argv[++i]);
+            const std::string value = argv[++i];
+            if (value.find(',') != std::string::npos) {
+                auto parsed = parse_seed_csv(value);
+                if (!parsed.has_value() || parsed->empty()) {
+                    args.parse_error = true;
+                    args.error_message = "--seed CSV must be a non-empty list of unsigned integers";
+                    return args;
+                }
+                args.seed_list = std::move(*parsed);
+            } else {
+                args.seed = std::atoi(value.c_str());
+            }
             continue;
         }
         if (arg == "--tail-frames" && need_value(arg)) {
@@ -430,9 +537,10 @@ CliArgs parse_args(int argc, char** argv) {
         }
     }
 
-    if (args.command == "run" && !args.bundle_path.empty() && !args.prompt_provided) {
+    if (args.command == "run" && !args.bundle_path.empty() && !args.prompt_provided &&
+        args.prompts_file.empty()) {
         args.parse_error = true;
-        args.error_message = "run requires bundle + --prompt";
+        args.error_message = "run requires bundle + --prompt or --prompts-file";
     }
 
     return args;

--- a/src/cli/args.h
+++ b/src/cli/args.h
@@ -73,9 +73,25 @@ struct CliArgs {
     // New feature knobs should generally prefer these over adding flags.
     std::string config_path;
     std::vector<std::string> set_tokens;
+    // Diffusion batch-inference knobs (PR 3 — `trtmc run` batch dispatch).
+    // `num_images` is the requested batch count when `prompts_file` is empty.
+    // `prompts_file` (one prompt per line) is mutually exclusive with
+    // `--prompt`. `seed_list`, when non-empty, supplies per-sample seeds
+    // explicitly and must match the total batch count at dispatch time.
+    int num_images{1};
+    std::string prompts_file;
+    std::vector<std::uint64_t> seed_list;
 };
 
 std::optional<std::uint64_t> parse_byte_size(const std::string& text);
+// Parse a CSV of unsigned-64 integers (e.g. "0,1,2"). Returns nullopt when
+// any token fails to parse. Empty string returns an empty vector wrapped
+// in an optional (caller should treat empty CSV the same as no flag).
+std::optional<std::vector<std::uint64_t>> parse_seed_csv(const std::string& text);
+// Read one prompt per line from `path`. On failure returns an empty vector
+// and writes a human-readable message to `error`. Trailing newlines and
+// fully-blank lines are stripped; interior blank lines are kept verbatim.
+std::vector<std::string> read_prompts_file(const std::string& path, std::string& error);
 void print_usage();
 CliArgs parse_args(int argc, char** argv);
 

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -21,6 +21,7 @@
 //   trtmc version
 
 #include "cli/args.h"
+#include "runtime/domains/diffusion/batch_utils.h"
 #include "stb_image_write.h"
 #include "trtmc/bundle.h"
 #include "trtmc/config/cli_support.h"
@@ -56,6 +57,25 @@ namespace {
 using trtmc::cli::CliArgs;
 using trtmc::cli::parse_args;
 using trtmc::cli::print_usage;
+
+// Build a per-sample output path. For ``total == 1`` the prefix is used as-is
+// so single-image runs keep their historical filename. Otherwise an
+// ``_<index>`` suffix is inserted before the extension (e.g. ``out.png`` ->
+// ``out_0.png``); prefixes with no extension simply gain ``_<index>`` at the
+// end.
+std::string format_output_path(const std::string& prefix, int index, int total) {
+    if (total <= 1)
+        return prefix;
+    const auto dot = prefix.find_last_of('.');
+    const auto slash = prefix.find_last_of('/');
+    const bool has_ext = dot != std::string::npos && (slash == std::string::npos || dot > slash);
+    std::ostringstream out;
+    if (has_ext)
+        out << prefix.substr(0, dot) << '_' << index << prefix.substr(dot);
+    else
+        out << prefix << '_' << index;
+    return out.str();
+}
 
 trtmc::LoadOptions make_load_options(const CliArgs& args) {
     trtmc::LoadOptions options;
@@ -432,46 +452,123 @@ int cmd_run(const CliArgs& args) {
         auto last = pipeline->generate(prompt, trtmc::GenerateConfig{cfg});
         std::cout << last.text << '\n';
     } else if (is_diffusion) {
-        trtmc::ImageResult result;
+        // Image-conditioned diffusion (img2img) keeps the single-image path —
+        // batched img2img is out of scope for the PR-3 CLI wiring.
         if (!args.image_path.empty()) {
             auto image = trtmc::io::read_image(args.image_path);
             if (image.pixels.empty()) {
                 std::cerr << "Error: failed to load image: " << args.image_path << '\n';
                 return EXIT_FAILURE;
             }
-            result = pipeline->generate_image(prompt, image.pixels.data(), image.height,
-                                              image.width, cfg);
-        } else {
-            result = pipeline->generate_image(prompt, cfg);
-        }
-        if (result.pixels.empty()) {
-            std::cerr << "Error: image generation failed\n";
-            return EXIT_FAILURE;
-        }
+            trtmc::ImageResult result = pipeline->generate_image(prompt, image.pixels.data(),
+                                                                 image.height, image.width, cfg);
+            if (result.pixels.empty()) {
+                std::cerr << "Error: image generation failed\n";
+                return EXIT_FAILURE;
+            }
 
-        // Save as PNG. If -o ends with .png, use as file path; otherwise
-        // treat as directory and write output.png inside it.
-        std::string out_path;
-        if (!args.output_dir.empty() && args.output_dir.size() > 4 &&
-            args.output_dir.substr(args.output_dir.size() - 4) == ".png") {
-            out_path = args.output_dir;
-            auto parent = std::filesystem::path(out_path).parent_path();
-            if (!parent.empty())
-                std::filesystem::create_directories(parent);
-        } else {
-            const std::string out_dir =
-                args.output_dir.empty() ? "/tmp/trtmc_run_output" : args.output_dir;
-            std::filesystem::create_directories(out_dir);
-            out_path = out_dir + "/output.png";
-        }
+            std::string out_path;
+            if (!args.output_dir.empty() && args.output_dir.size() > 4 &&
+                args.output_dir.substr(args.output_dir.size() - 4) == ".png") {
+                out_path = args.output_dir;
+                auto parent = std::filesystem::path(out_path).parent_path();
+                if (!parent.empty())
+                    std::filesystem::create_directories(parent);
+            } else {
+                const std::string out_dir =
+                    args.output_dir.empty() ? "/tmp/trtmc_run_output" : args.output_dir;
+                std::filesystem::create_directories(out_dir);
+                out_path = out_dir + "/output.png";
+            }
 
-        try {
-            trtmc::io::save_png(result, out_path);
-        } catch (const std::exception& e) {
-            std::cerr << "Error: " << e.what() << '\n';
-            return EXIT_FAILURE;
+            try {
+                trtmc::io::save_png(result, out_path);
+            } catch (const std::exception& e) {
+                std::cerr << "Error: " << e.what() << '\n';
+                return EXIT_FAILURE;
+            }
+            std::cout << "Saved " << out_path << " (" << result.width << "x" << result.height
+                      << ")\n";
+        } else {
+            // Text-to-image batch path. Build the prompt list from either
+            // --prompts-file (one prompt per line) or `num_images` copies of
+            // --prompt, then dispatch through generate_image_batch.
+            std::vector<std::string> prompts;
+            if (!args.prompts_file.empty()) {
+                std::string error;
+                prompts = trtmc::cli::read_prompts_file(args.prompts_file, error);
+                if (prompts.empty()) {
+                    std::cerr << "Error: " << error << '\n';
+                    return EXIT_FAILURE;
+                }
+            } else {
+                prompts.assign(static_cast<std::size_t>(std::max(1, args.num_images)), prompt);
+            }
+            const int total = static_cast<int>(prompts.size());
+
+            // Resolve per-sample seeds: explicit CSV when --seed s0,s1,... is
+            // given, else derive deterministic seeds from the scalar seed.
+            std::vector<std::uint32_t> per_sample_seeds;
+            try {
+                if (!args.seed_list.empty()) {
+                    if (static_cast<int>(args.seed_list.size()) != total) {
+                        std::cerr << "Error: --seed CSV length (" << args.seed_list.size()
+                                  << ") must equal the total batch count (" << total << ")\n";
+                        return EXIT_FAILURE;
+                    }
+                    per_sample_seeds =
+                        trtmc::diffusion::derive_per_sample_seeds(args.seed_list, total);
+                } else {
+                    const std::uint64_t global_seed =
+                        args.seed >= 0 ? static_cast<std::uint64_t>(args.seed) : 0ULL;
+                    per_sample_seeds =
+                        trtmc::diffusion::derive_per_sample_seeds(global_seed, total);
+                }
+            } catch (const std::exception& e) {
+                std::cerr << "Error: " << e.what() << '\n';
+                return EXIT_FAILURE;
+            }
+
+            auto results = pipeline->generate_image_batch(prompts, per_sample_seeds, cfg);
+            if (results.empty()) {
+                std::cerr << "Error: image generation failed\n";
+                return EXIT_FAILURE;
+            }
+
+            // Resolve the output prefix. ``-o foo.png`` puts files alongside
+            // ``foo.png``; otherwise treat ``-o`` as a directory containing
+            // ``output.png`` style outputs.
+            std::string out_prefix;
+            if (!args.output_dir.empty() && args.output_dir.size() > 4 &&
+                args.output_dir.substr(args.output_dir.size() - 4) == ".png") {
+                out_prefix = args.output_dir;
+                auto parent = std::filesystem::path(out_prefix).parent_path();
+                if (!parent.empty())
+                    std::filesystem::create_directories(parent);
+            } else {
+                const std::string out_dir =
+                    args.output_dir.empty() ? "/tmp/trtmc_run_output" : args.output_dir;
+                std::filesystem::create_directories(out_dir);
+                out_prefix = out_dir + "/output.png";
+            }
+
+            for (std::size_t i = 0; i < results.size(); ++i) {
+                const auto& r = results[i];
+                if (r.pixels.empty()) {
+                    std::cerr << "Error: image generation failed for sample " << i << '\n';
+                    return EXIT_FAILURE;
+                }
+                const std::string out_path =
+                    format_output_path(out_prefix, static_cast<int>(i), total);
+                try {
+                    trtmc::io::save_png(r, out_path);
+                } catch (const std::exception& e) {
+                    std::cerr << "Error: " << e.what() << '\n';
+                    return EXIT_FAILURE;
+                }
+                std::cout << "Saved " << out_path << " (" << r.width << "x" << r.height << ")\n";
+            }
         }
-        std::cout << "Saved " << out_path << " (" << result.width << "x" << result.height << ")\n";
     } else if (!args.image_path.empty()) {
         // Load image using trtmc_io
         auto image = trtmc::io::read_image(args.image_path);
@@ -1283,6 +1380,14 @@ int cmd_inspect(const CliArgs& args) {
         std::cout << "Max cache length:   " << info.max_cache_length << '\n';
         if (!info.runtime_strategy.empty())
             std::cout << "Runtime strategy:   " << info.runtime_strategy << '\n';
+        // Diffusion batch envelope (PR 1 added the field to BundleInfo;
+        // defaults are 1/1/1 for legacy bundles). VAE is always sliced --
+        // see Decision E in the diffusion batch-inference RFC.
+        std::cout << "Max batch size:\n";
+        std::cout << "  dit:          " << info.max_batch_size.dit << '\n';
+        std::cout << "  text_encoder: " << info.max_batch_size.text_encoder << '\n';
+        std::cout << "  vae:          " << info.max_batch_size.vae
+                  << "  (always sliced -- Decision E)\n";
         if (!info.sections.empty()) {
             std::cout << "Sections:\n";
             for (const auto& section : info.sections) {

--- a/tests/builder/conftest.py
+++ b/tests/builder/conftest.py
@@ -160,7 +160,10 @@ def run_trt_graph(build_fn, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarr
     for name, tensor in trt_outputs.items():
         tensor.name = name
         network.mark_output(tensor)
-        tensor.dtype = trt.float32
+        # In newer TRT (10.x), `ITensor.dtype` is read-only after the layer
+        # graph is built; output dtype is inferred from the producing layer
+        # (here fp32 because inputs + weights are fp32). The explicit set
+        # was a no-op on older TRT and broke on newer.
 
     plan = builder.build_serialized_network(network, config)
     if plan is None:

--- a/tests/builder/test_max_batch_size_cli.py
+++ b/tests/builder/test_max_batch_size_cli.py
@@ -1,0 +1,213 @@
+"""Tests for the ``--max-batch-size`` CLI flag plumbing.
+
+Trace: ARCH-DIFF-BATCH-001, UD-DIFF-BATCH-CLI
+Intent: Verify that ``trtmc build --max-batch-size N`` reaches the family
+plugin's ``build_components`` and that the resulting ``.trtfb`` bundle
+records the expected per-component batch envelope on disk.
+Preconditions: tensorrt_model_connect is importable; tests monkeypatch the
+actual TRT engine builds so no GPU or TRT runtime is required.
+Postconditions: N=1 path stays byte-compatible with PR 1 readers (no
+``max_batch_size`` block in the bundle header) and N=4 produces
+``{"dit": 4, "text_encoder": 8, "vae": 1}``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+try:
+    import tensorrt_model_connect.build_cli as cli
+    import tensorrt_model_connect.engine_builder as eb
+except (ImportError, ModuleNotFoundError):  # pragma: no cover - dependency-only
+    pytest.skip(
+        "tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+def _read_bundle_header(bundle_path: Path) -> dict:
+    """Decode the JSON header from a .trtfb file written by ``write_bundle``."""
+    with open(bundle_path, "rb") as f:
+        magic = f.read(8)
+        assert magic == b"TRTFB\x00\x01\x00", f"bad magic: {magic!r}"
+        header_len = struct.unpack("<Q", f.read(8))[0]
+        return json.loads(f.read(header_len).decode("utf-8"))
+
+
+def _make_fake_diffusion_model_dir(tmp_path: Path) -> Path:
+    """Create a minimal diffusers-format directory that engine_builder accepts.
+
+    Returns the directory path. The pipeline class points to a stub plugin
+    registered via ``_install_stub_plugin``.
+    """
+    model_dir = tmp_path / "fake_diffusion_model"
+    model_dir.mkdir()
+    (model_dir / "model_index.json").write_text(json.dumps({
+        "_class_name": "FakeBatchPipeline",
+    }))
+    return model_dir
+
+
+class _FakeDiffusionPlugin:
+    """Plugin stub that mimics a diffusion family plugin contract."""
+    name = "fake_batch"
+    runtime_strategy = "diffusion"
+    pipeline_classes = ["FakeBatchPipeline"]
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def matches(self, model_type: str) -> bool:
+        return model_type.lower() in ("fake_batch", "fakebatchpipeline")
+
+    def load_weights(self, model_dir, config):  # noqa: ARG002
+        return {}
+
+    def build_components(
+        self, model_dir, config, weights, *,
+        precision="fp32", verbose=False, fp8_scales=None,
+        build_timing=None, parallel_config=None,
+        max_batch_size: int = 1,
+    ):
+        # Mirror the per-component batch policy that the three real plugins
+        # apply (Decisions C / E):
+        #   DiT honours N; text encoder caps at min(2N, 8); VAE always = 1.
+        dit_mbs = int(max_batch_size)
+        te_mbs = min(dit_mbs * 2, 8)
+        vae_mbs = 1
+        self.calls.append({
+            "max_batch_size": max_batch_size,
+            "dit_mbs": dit_mbs,
+            "te_mbs": te_mbs,
+            "vae_mbs": vae_mbs,
+        })
+        out = {
+            "text_encoders": [("fake_te", b"te-plan")],
+            "denoiser": b"dit-plan",
+            "vae_decoder": b"vae-plan",
+            "preprocessor_weights": b"pp",
+        }
+        if max_batch_size > 1:
+            out["max_batch_size_envelope"] = {
+                "dit": dit_mbs,
+                "text_encoder": te_mbs,
+                "vae": vae_mbs,
+            }
+        return out
+
+    def get_diffusion_config(self, config):  # noqa: ARG002
+        return {"diffusion_backend_type": "fake"}
+
+
+def _install_stub_plugin(monkeypatch) -> _FakeDiffusionPlugin:
+    """Patch ``find_diffusion_plugin`` to return a fresh stub plugin instance."""
+    plugin = _FakeDiffusionPlugin()
+    monkeypatch.setattr(
+        eb, "find_diffusion_plugin",
+        lambda pipeline_class: plugin if pipeline_class == "FakeBatchPipeline" else None,
+    )
+    monkeypatch.setattr(
+        eb, "find_plugin", lambda _model_type: None,
+    )
+    # Skip TRT version probing for the fake bundle.
+    monkeypatch.setattr(eb, "_get_trt_version", lambda: "10.0.0")
+    monkeypatch.setattr(eb, "_trt_abi_from_version", lambda _v: "trt10")
+    monkeypatch.setattr(eb, "_get_gpu_name", lambda: "stub-gpu")
+    monkeypatch.setattr(eb, "_setup_trt_import", lambda _rtx: None)
+    # The diffusion bundle path calls trt_compat.resolved_summary() before
+    # invoking the plugin; stub it so the test stays GPU-/TRT-free.
+    from tensorrt_model_connect import trt_compat
+    monkeypatch.setattr(
+        trt_compat, "resolved_summary", lambda: "stub",
+        raising=False,
+    )
+    return plugin
+
+
+def _build_args(model_dir: Path, output: Path, max_batch_size: int) -> argparse.Namespace:
+    return argparse.Namespace(
+        model=str(model_dir),
+        output=str(output),
+        max_cache_length=32,
+        precision="fp32",
+        method="trt",
+        quantize=None,
+        quant_scales=None,
+        quant_calibration_samples=512,
+        verbose=False,
+        fp8=False,
+        fp8_scales=None,
+        save_fp8_scales=None,
+        rtx=False,
+        triattention_stats=None,
+        triattention_kv_budget=None,
+        triattention_divide_length=128,
+        triattention_recent_window=128,
+        triattention_score_aggregation="mean",
+        triattention_count_prompt_tokens=True,
+        triattention_protect_prefill=True,
+        triattention_disable_mlr=False,
+        triattention_disable_trig=False,
+        decoder_engine_layout="split",
+        dynamic_kv_cache=False,
+        dynamic_kv_profile_rows=None,
+        image_height=None,
+        image_width=None,
+        video_height=None,
+        video_width=None,
+        video_num_frames=None,
+        num_inference_steps=None,
+        tensor_parallel_size=1,
+        build_timing_json=None,
+        config=None,
+        set_flags=None,
+        max_batch_size=max_batch_size,
+        _skip_profile_resolution=True,
+    )
+
+
+def test_default_max_batch_size_omits_envelope(monkeypatch, tmp_path):
+    """``--max-batch-size 1`` (the default) must keep the bundle byte-compatible
+    with PR 1 readers: no ``max_batch_size`` block in the JSON header."""
+    plugin = _install_stub_plugin(monkeypatch)
+    model_dir = _make_fake_diffusion_model_dir(tmp_path)
+    output = tmp_path / "out.trtfb"
+
+    rc = cli._cmd_build(_build_args(model_dir, output, max_batch_size=1))
+    assert rc == 0, "CLI should succeed for the default batch size"
+
+    header = _read_bundle_header(output)
+    assert "max_batch_size" not in header, (
+        "Default build (N=1) must not emit max_batch_size in the bundle header"
+    )
+
+    # Plugin should still have been called, with max_batch_size=1.
+    assert len(plugin.calls) == 1
+    assert plugin.calls[0]["max_batch_size"] == 1
+
+
+def test_max_batch_size_four_records_envelope(monkeypatch, tmp_path):
+    """``--max-batch-size 4`` should record the per-component envelope:
+    ``{"dit": 4, "text_encoder": 8, "vae": 1}`` (Decision C / E)."""
+    plugin = _install_stub_plugin(monkeypatch)
+    model_dir = _make_fake_diffusion_model_dir(tmp_path)
+    output = tmp_path / "out.trtfb"
+
+    rc = cli._cmd_build(_build_args(model_dir, output, max_batch_size=4))
+    assert rc == 0
+
+    header = _read_bundle_header(output)
+    assert header.get("max_batch_size") == {
+        "dit": 4,
+        "text_encoder": 8,
+        "vae": 1,
+    }, f"unexpected envelope in bundle header: {header.get('max_batch_size')!r}"
+
+    assert plugin.calls[0]["max_batch_size"] == 4
+    assert plugin.calls[0]["te_mbs"] == 8  # encoder cap policy
+    assert plugin.calls[0]["vae_mbs"] == 1  # VAE always slices
+
+

--- a/tests/cpp/test_cabi_batch.cpp
+++ b/tests/cpp/test_cabi_batch.cpp
@@ -1,0 +1,154 @@
+// =============================================================================
+// ISO 26262 Traceability
+// =============================================================================
+// Trace ID:       UT-ABI-CPP-03
+// Architecture:   ARCH-FAC-001
+// Unit Design:    UD-CABI-01
+// Intent:         C ABI batch image generation: argument validation + happy path
+// Preconditions:  trtmc::IPipeline default `generate_image_batch` available
+// Postconditions: bad inputs return TRTMC_ERR_INVALID_ARG; happy path fills out_results
+// =============================================================================
+
+// =============================================================================
+// Test suite: trtmc_generate_batch (PR 3 — final piece of the diffusion
+// batch-inference series).
+//
+// Purpose:
+//   Validates the new C-ABI entry point for batch image generation. The
+//   existing C-ABI tests (`test_c_abi_entry`, `test_c_abi_runtime_regression`)
+//   skip pipeline creation because it requires a real `.trtfb` bundle and a
+//   GPU. We follow the same pattern here for the argument-validation cases
+//   (null handle / null prompts / mismatched lengths) and additionally use a
+//   tiny in-test fake IPipeline to exercise the happy path end-to-end without
+//   needing a bundle or a GPU.
+//
+// Dependencies:
+//   - trtmc/pipeline.h: trtmc_generate_batch, trtmc_image_result_t,
+//     TRTMC_ERR_INVALID_ARG, TRTMC_OK, trtmc_image_result_free.
+// =============================================================================
+
+#include "trtmc/pipeline.h"
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* test_name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << test_name << '\n';
+        ++failures;
+    }
+}
+
+// Minimal IPipeline subclass that returns a deterministic ImageResult per
+// prompt. The default `generate_image_batch` implementation in pipeline.h
+// loops over `generate_image`, so overriding the single-prompt path is
+// enough to exercise the end-to-end C-ABI conversion (including the
+// per-sample-seed plumbing).
+class FakeImagePipeline final : public trtmc::IPipeline {
+  public:
+    trtmc::ImageResult generate_image(const std::string& prompt,
+                                      const trtmc::GenerateConfig& cfg) override {
+        trtmc::ImageResult r;
+        r.height = 4;
+        r.width = 4;
+        r.channels = 3;
+        r.num_frames = 1;
+        r.pixels.assign(static_cast<std::size_t>(r.channels * r.height * r.width), 0.0F);
+        // Stash a couple of identifying values so the test can confirm the
+        // C-ABI hand-off preserved them: pixel[0] = prompt length, pixel[1]
+        // = effective seed (cast to float).
+        if (!r.pixels.empty())
+            r.pixels[0] = static_cast<float>(prompt.size());
+        if (r.pixels.size() > 1)
+            r.pixels[1] = static_cast<float>(cfg.seed);
+        return r;
+    }
+
+    const char* model_id() const override { return "fake/image"; }
+    const char* pipeline_type() const override { return "fake_image"; }
+};
+
+// -- Argument validation ---------------------------------------------------
+
+void test_invalid_args_return_invalid_arg() {
+    // One consolidated check covering the common invalid-arg shapes.
+    FakeImagePipeline pipe;
+    const char* prompts[] = {"a", "b"};
+    std::uint32_t seeds[] = {1, 2, 3};
+    trtmc_image_result_t out[2]{};
+
+    check(trtmc_generate_batch(nullptr, prompts, 1, seeds, 1, 4, 7.5F, out) ==
+              TRTMC_ERR_INVALID_ARG,
+          "null handle returns TRTMC_ERR_INVALID_ARG");
+    check(trtmc_generate_batch(&pipe, prompts, 2, seeds, 3, 4, 7.5F, out) == TRTMC_ERR_INVALID_ARG,
+          "num_prompts != num_seeds returns TRTMC_ERR_INVALID_ARG");
+}
+
+// -- Happy path -----------------------------------------------------------
+
+void test_batch_fills_results_and_propagates_seeds() {
+    FakeImagePipeline pipe;
+    const char* prompts[] = {"hello", "world!!"};
+    std::uint32_t seeds[] = {42U, 1337U};
+    trtmc_image_result_t out[2]{};
+
+    const int rc = trtmc_generate_batch(&pipe, prompts, 2, seeds, 2, 4, 7.5F, out);
+    check(rc == TRTMC_OK, "happy-path returns TRTMC_OK");
+
+    // Both results filled with the fake's 4x4x3 layout.
+    check(out[0].height == 4 && out[0].width == 4 && out[0].channels == 3, "result[0] shape");
+    check(out[1].height == 4 && out[1].width == 4 && out[1].channels == 3, "result[1] shape");
+    check(out[0].pixels != nullptr, "result[0] pixels allocated");
+    check(out[1].pixels != nullptr, "result[1] pixels allocated");
+    check(out[0].num_pixels == 4U * 4U * 3U, "result[0] num_pixels correct");
+    check(out[1].num_pixels == 4U * 4U * 3U, "result[1] num_pixels correct");
+
+    // Prompt-length sentinel (pixel[0]) and per-sample seed sentinel
+    // (pixel[1]) confirm the conversion preserved per-prompt inputs and
+    // that the C-ABI plumbed each entry's seed through `cfg.seed`.
+    check(out[0].pixels[0] == static_cast<float>(std::string("hello").size()),
+          "result[0] prompt-length sentinel matches");
+    check(out[1].pixels[0] == static_cast<float>(std::string("world!!").size()),
+          "result[1] prompt-length sentinel matches");
+    check(out[0].pixels[1] == static_cast<float>(42),
+          "result[0] seed propagated to pipeline cfg.seed");
+    check(out[1].pixels[1] == static_cast<float>(1337),
+          "result[1] seed propagated to pipeline cfg.seed");
+
+    // Release allocations through the public free helper (the whole point
+    // of the free helper is that callers can release without knowing about
+    // the C++ allocator).
+    trtmc_image_result_free(&out[0]);
+    trtmc_image_result_free(&out[1]);
+    check(out[0].pixels == nullptr, "free clears pixels[0]");
+    check(out[1].pixels == nullptr, "free clears pixels[1]");
+}
+
+void test_image_result_free_null_safe() {
+    trtmc_image_result_free(nullptr); // null pointer
+    trtmc_image_result_t empty{};
+    trtmc_image_result_free(&empty); // pixels==nullptr
+    check(true, "trtmc_image_result_free is null-safe");
+}
+
+} // namespace
+
+int main() {
+    test_invalid_args_return_invalid_arg();
+    test_batch_fills_results_and_propagates_seeds();
+    test_image_result_free_null_safe();
+
+    if (failures > 0) {
+        std::cerr << failures << " test(s) FAILED\n";
+        return 1;
+    }
+    std::cerr << "All C ABI batch tests passed.\n";
+    return 0;
+}

--- a/tests/cpp/test_cli_args.cpp
+++ b/tests/cpp/test_cli_args.cpp
@@ -188,7 +188,8 @@ void test_missing_value_fails() {
 void test_missing_prompt_is_distinct_from_empty_prompt() {
     auto missing = parse({"trtmc", "run", "bundle.trtfb", "--max-new-tokens", "8"});
     check(missing.parse_error, "missing prompt parse error");
-    check(missing.error_message == "run requires bundle + --prompt", "missing prompt message");
+    check(missing.error_message == "run requires bundle + --prompt or --prompts-file",
+          "missing prompt message");
     check(!missing.prompt_provided, "missing prompt not provided");
     check(missing.prompt.empty(), "missing prompt text empty");
 
@@ -211,6 +212,31 @@ void test_unexpected_positional_fails() {
           "unexpected positional message");
 }
 
+void test_num_images_zero_fails() {
+    auto args = parse({"trtmc", "run", "bundle.trtfb", "--num-images", "0"});
+    check(args.parse_error, "num-images zero parse error");
+    check(args.error_message == "--num-images must be >= 1", "num-images error message");
+}
+
+void test_seed_csv_populates_seed_list() {
+    auto args = parse({"trtmc", "run", "bundle.trtfb", "--prompt", "x", "--num-images", "4",
+                       "--seed", "0,1,2,3"});
+    check(!args.parse_error, "seed csv parses cleanly");
+    check(args.num_images == 4, "num-images parsed");
+    check(args.seed_list.size() == 4, "seed list size");
+    check(args.seed_list[0] == 0 && args.seed_list[1] == 1 && args.seed_list[2] == 2 &&
+              args.seed_list[3] == 3,
+          "seed list values");
+}
+
+void test_prompt_and_prompts_file_mutually_exclusive() {
+    auto args =
+        parse({"trtmc", "run", "bundle.trtfb", "--prompt", "hi", "--prompts-file", "prompts.txt"});
+    check(args.parse_error, "prompt+prompts-file parse error");
+    check(args.error_message == "--prompt and --prompts-file are mutually exclusive",
+          "prompt+prompts-file error message");
+}
+
 } // namespace
 
 int main() {
@@ -229,6 +255,9 @@ int main() {
     test_missing_prompt_is_distinct_from_empty_prompt();
     test_bad_kv_cache_size_fails();
     test_unexpected_positional_fails();
+    test_num_images_zero_fails();
+    test_seed_csv_populates_seed_list();
+    test_prompt_and_prompts_file_mutually_exclusive();
 
     if (failures) {
         std::cerr << failures << " CLI parser tests failed\n";


### PR DESCRIPTION
Final of three PRs that add batch inference to the diffusion pipelines
(FLUX, Z-Image, Qwen Image). PR 1 added the engine-side plumbing, PR 2
made the runtime actually generate batches when asked, and **this PR
adds the user-facing surfaces** — the build CLI flag, the run CLI flags,
the C ABI entry point, and the `trtmc inspect` cap block.

After this PR ships, end users can build a bs=4 bundle and run batched
generation from the command line:

```bash
# Build a bundle capable of batches up to 4
trtmc-build build flux --max-batch-size 4 -o flux-bs4.trtfb

# Generate 4 images of one prompt
trtmc run flux-bs4.trtfb --prompt "a cat" --num-images 4
# -> cat_0.png, cat_1.png, cat_2.png, cat_3.png

# Generate one image per line in a prompts file
trtmc run flux-bs4.trtfb --prompts-file prompts.txt

# Combine them: each prompt × 2 images = 2N total
trtmc run flux-bs4.trtfb --prompts-file prompts.txt --num-images 2

# Explicit per-image seeds for deterministic side-by-side
trtmc run flux-bs4.trtfb --prompt "a cat" --num-images 4 --seed 0,1,2,3
```

## What's in this PR

### Build side

- **New flag**: `trtmc-build build --max-batch-size N` (default `1`).
- The flag flows through `engine_builder.build()` →
  `_build_diffusion_bundle()` → the family plugin's `build_components()`.
- The three diffusion family plugins (`flux`, `z_image`, `qwen_image`)
  apply Decision C from the design doc:
  - DiT cap = `N`
  - text encoder cap = `min(2N, 8)`
  - VAE cap = `1` (Decision E — always sliced)
- The resulting envelope is recorded on the bundle as
  `max_batch_size: {dit, text_encoder, vae}`. `--max-batch-size 1`
  omits the block entirely (byte-identical to today; PR 1 readers
  still parse the file fine).
- **TP + batch combo guard**: building with both `--max-batch-size > 1`
  and a `--parallel-config` raises `NotImplementedError`. That
  combination is out of scope for this phase.

### Run side

- **Three new flags** on `trtmc run`:
  - `--num-images N` (default `1`; `N < 1` is a parse error)
  - `--prompts-file PATH` (one prompt per line; mutually exclusive
    with `--prompt`)
  - `--seed s0,s1,...` (CSV list of per-image seeds; length must equal
    the total batch count, validated at dispatch time). Scalar
    `--seed N` still works.
- Output filenames gain a `_<i>` suffix when the total batch is > 1:
  - `out.png` with `--num-images 4` → `out_0.png` … `out_3.png`
  - `dir/out` (no extension) → `dir/out_0` … `dir/out_3`
- The text-to-image diffusion dispatch in `cmd_run` now goes through
  `pipeline->generate_image_batch(prompts, per_sample_seeds, cfg)`
  (the API PR 2 introduced). Image-conditioned diffusion
  (`--image PATH`) keeps the single-image path — batched img2img is
  out of scope.

### C ABI

- **`trtmc_generate_batch`** in `include/trtmc/pipeline.h`'s existing
  `extern "C"` block:
  ```c
  int trtmc_generate_batch(
      trtmc_pipeline_t handle,
      const char* const* prompts, int num_prompts,
      const uint32_t* seeds,      int num_seeds,
      int num_inference_steps, float guidance_scale,
      trtmc_image_result_t* out_results);
  ```
  Returns `TRTMC_OK` on success, `TRTMC_ERR_INVALID_ARG` for bad inputs,
  `TRTMC_ERR_RUNTIME` for OOM or pipeline failures. Pure-C callers
  release the pixel buffers via the new `trtmc_image_result_free`
  helper.

### Inspect

- `trtmc inspect <bundle>` now prints a `Max batch size:` block with the
  per-component caps from the bundle header:
  ```
  Max batch size:
    dit:          4
    text_encoder: 8
    vae:          1  (always sliced -- Decision E)
  ```

## What's NOT in this PR

| Not in this PR | Lands in |
|---|---|
| End-to-end manifests comparing batched output against HuggingFace Diffusers | small follow-up PR |
| Batching the Qwen2.5-VL text encoder's inner graph | Phase 1.5 |
| Folding Qwen Image's two CFG forwards into a single fused `B*2` pass | Phase 1.5 |
| Image-conditioned diffusion (`--image PATH`) batching | follow-up |
| Wan video model batch support | Phase 2 |
| TP + batch combination | future PR |

## How to verify

```bash
# Build
cmake --build build                                # PASS

# C++ tests
./build/test_cli_args                              # PASS (CLI parser)
./build/test_cabi_batch                            # PASS (C ABI)
ctest --test-dir build -R 'cabi|cli|bundle'        # 7/7 PASS

# Python tests
python -m pytest tests/builder/test_max_batch_size_cli.py \
                 tests/builder/test_family_flux.py \
                 tests/builder/test_family_z_image.py \
                 tests/builder/test_cli.py
# 59/59 PASS

# Pre-CI gates
python tools/check_cyclomatic_complexity.py src --exclude src/cli \
       --max-ccn 10 --top 5                        # PASS
ruff check python/                                 # PASS
clang-format --dry-run --Werror <touched C++ files>
                                                   # PASS
```

## Manual end-to-end smoke test (optional)

Once the PR is merged, you can verify batched FLUX generation end-to-end:

```bash
# 1. Build a bs=4 FLUX bundle (takes a few minutes — real engine build)
trtmc-build build black-forest-labs/FLUX.1-dev \
    --max-batch-size 4 \
    -o /tmp/flux-bs4.trtfb

# 2. Verify the bundle's cap block
trtmc inspect /tmp/flux-bs4.trtfb
# Look for:
#   Max batch size:
#     dit:          4
#     text_encoder: 8
#     vae:          1  (always sliced -- Decision E)

# 3. Generate 4 images
trtmc run /tmp/flux-bs4.trtfb --prompt "an astronaut riding a horse" \
    --num-images 4 --seed 0,1,2,3 \
    --output /tmp/horse.png
# Expect: 4 distinct images, /tmp/horse_0.png … /tmp/horse_3.png,
# wall-clock noticeably less than running --num-images 1 four times.
```

## Risk and backwards compatibility

- All new CLI flags default to single-image behavior. Existing scripts
  (`trtmc-build build foo -o foo.trtfb`, `trtmc run foo.trtfb --prompt
  X`) work unchanged.
- The bundle JSON only gains the `max_batch_size` block when
  `--max-batch-size > 1`. With the default `1` the bundle header is
  byte-identical to a PR-1-era bundle.
- The C ABI gains new symbols only; no existing C-ABI function changes
  signature.
- All existing tests pass unchanged.

## Series summary

After this PR lands, the diffusion batch inference feature is complete
for FLUX, Z-Image, and Qwen Image:

| | Before PR series | After PR 3 |
|---|---|---|
| `trtmc-build build --max-batch-size N` | ❌ | ✅ |
| `trtmc run --num-images N` | ❌ | ✅ |
| `trtmc run --prompts-file PATH` | ❌ | ✅ |
| `trtmc run --seed s0,s1,...` | ❌ | ✅ |
| C ABI `trtmc_generate_batch` | ❌ | ✅ |
| `trtmc inspect` shows batch caps | ❌ | ✅ |
| `pipeline->generate_image_batch(...)` (C++) | ❌ | ✅ |
| Per-image deterministic seeds | ❌ | ✅ |
| Auto-chunking when batch exceeds engine cap | ❌ | ✅ |
| Output filename `_<i>` suffix | ❌ | ✅ |

A small follow-up PR will add the end-to-end manifest schema that
compares batched outputs against HuggingFace Diffusers.
