### PR TITLE
perf(diffusion): fused qknorm rope Flux 2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,23 @@ if(DEFINED ENV{CUDA_HOME})
   list(APPEND _trtmc_default_search_paths "$ENV{CUDA_HOME}/lib64")
 endif()
 
+# The TensorRT pip wheel (tensorrt_cu13) ships libnvinfer.so under a Python
+# site-packages tensorrt_libs/ tree. Ask Python where so CMake can find it
+# without manual hints. Mirrors the apache-tvm-ffi discovery below.
+find_program(_trtmc_python NAMES python3.12 python3 python)
+if(_trtmc_python)
+  execute_process(
+    COMMAND "${_trtmc_python}" -c
+      "import importlib.util,sys; s=importlib.util.find_spec('tensorrt_libs'); sys.stdout.write(s.submodule_search_locations[0] if s else '')"
+    OUTPUT_VARIABLE _trtmc_tensorrt_libs_pkg
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  if(_trtmc_tensorrt_libs_pkg)
+    list(APPEND _trtmc_default_search_paths "${_trtmc_tensorrt_libs_pkg}")
+  endif()
+endif()
+
 find_path(TRTMC_TRT_INCLUDE_DIR NvInferRuntime.h
   PATHS ${_trtmc_default_search_paths}
   PATH_SUFFIXES "" include include/zapped_headers
@@ -317,6 +334,24 @@ option(TRTMC_ENABLE_TVM_FFI "Enable TVM-FFI kernel bridge plugin" ON)
 set(_trtmc_has_tvm_ffi FALSE)
 
 if(TRTMC_ENABLE_TVM_FFI)
+  # apache-tvm-ffi is distributed as a pip wheel that ships its headers + .so
+  # under the Python site-packages tvm_ffi/{include,lib}/ tree. Ask Python
+  # where that is so cmake can find it without manual TRTMC_TVM_FFI_*_DIR.
+  if(_trtmc_python)
+    execute_process(
+      COMMAND "${_trtmc_python}" -c
+        "import importlib.util; s=importlib.util.find_spec('tvm_ffi'); import sys; sys.stdout.write(s.submodule_search_locations[0] if s else '')"
+      OUTPUT_VARIABLE _trtmc_tvm_ffi_pkg
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+    )
+    if(_trtmc_tvm_ffi_pkg)
+      list(APPEND _trtmc_default_search_paths
+           "${_trtmc_tvm_ffi_pkg}/include"
+           "${_trtmc_tvm_ffi_pkg}/lib")
+    endif()
+  endif()
+
   find_path(TRTMC_TVM_FFI_INCLUDE_DIR tvm/ffi/c_api.h
     PATHS ${_trtmc_default_search_paths}
     PATH_SUFFIXES "" include
@@ -435,6 +470,21 @@ if(_trtmc_has_tvm_ffi AND _trtmc_can_build_trt_backend)
   target_compile_definitions(trtmc_tvm_ffi_plugin PRIVATE TRTMC_HAS_TRT=1 TRTMC_HAS_TVM_FFI=1)
   target_compile_options(trtmc_tvm_ffi_plugin PRIVATE -Wall -Wextra -Wpedantic)
   message(STATUS "TVM-FFI plugin shared library: trtmc_tvm_ffi_plugin.so")
+endif()
+
+# --- Optional: vendored diffusion CUDA kernels as TVM-FFI modules ---
+# Off by default. Requires TVM-FFI. Each kernel builds as a standalone .so
+# that the diffusion TRT graph loads via graph_ops.add_tvm_ffi_kernel().
+option(TRTMC_BUILD_DIFFUSION_KERNELS
+       "Build vendored optimized diffusion CUDA kernels (TVM-FFI modules)" OFF)
+
+if(TRTMC_BUILD_DIFFUSION_KERNELS)
+  if(NOT _trtmc_has_tvm_ffi)
+    message(FATAL_ERROR
+      "TRTMC_BUILD_DIFFUSION_KERNELS=ON requires TVM-FFI (TRTMC_ENABLE_TVM_FFI=ON, "
+      "and a discoverable libtvm_ffi). Found none.")
+  endif()
+  add_subdirectory(src/runtime/domains/diffusion/kernels)
 endif()
 
 # --- Backend DSO: standard TRT ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,13 @@ RUN pip install -U pip && \
 # 13.0 Python stack pulled by PyTorch.
 RUN pip install "cuda-python==13.0.3"
 
+# Apache TVM-FFI: the kernel-bridge ABI that lets compiled CUDA modules
+# (FlashInfer, vendored diffusion kernels) be called from TRT plugins
+# without a Python callback. Headers + libtvm_ffi.so ship in the wheel at
+# /opt/venv/lib/python3.12/site-packages/tvm_ffi/{include,lib}/. CMake
+# discovers them via a Python-spec lookup in the venv (see CMakeLists.txt).
+RUN pip install "apache-tvm-ffi==0.1.12"
+
 # Core Python deps
 RUN pip install \
     "transformers==5.2.0" \

--- a/python/tensorrt_model_connect/families/flux/flux2_dit_builder.py
+++ b/python/tensorrt_model_connect/families/flux/flux2_dit_builder.py
@@ -33,6 +33,7 @@ global modulation tables) are handled externally by the runtime.
 
 from __future__ import annotations
 
+import os
 import sys
 from typing import TYPE_CHECKING
 
@@ -93,6 +94,33 @@ def _np_reduced_dtype():
 def _fp16_compute() -> bool:
     """True when strongly typed FLUX.2 is using FP16 as its compute dtype."""
     return _CAST_DTYPE == trt.float16
+
+
+def _fused_dit_kernels_enabled() -> bool:
+    """True when the vendored fused DiT kernels should replace TRT-native ops.
+
+    Preconditions:
+      1. Build was invoked with TRTMC_FUSED_DIT_KERNELS=1.
+      2. _CAST_DTYPE is fp16 or bf16 (the kernel exports both).
+    """
+    return (
+        os.environ.get("TRTMC_FUSED_DIT_KERNELS") == "1"
+        and _CAST_DTYPE in (trt.float16, trt.bfloat16)
+    )
+
+
+def _fused_kernel_dtype_suffix() -> str:
+    """Match _CAST_DTYPE to the kernel's exported global function suffix."""
+    return "bf16" if _CAST_DTYPE == trt.bfloat16 else "fp16"
+
+
+def _trt_dtype_to_str(d) -> str:
+    """TRT dtype → plugin output-spec dtype string."""
+    if d == trt.bfloat16:
+        return "bfloat16"
+    if d == trt.float16:
+        return "float16"
+    return "float32"
 
 
 def _make_reduced_weights(data_fp32, shape):
@@ -285,6 +313,20 @@ def build_flux2_dit_engine(
 
     eps_t = _add_constant_reduced(network, (1, 1), np.array([eps], dtype=np.float32))
 
+    # When the fused QK-norm+RoPE kernel is enabled, preserve fp32 slices of
+    # cos/sin BEFORE the cast — the vendored CUDA kernel reads fp32 directly.
+    # The legacy reduced-precision path below is unaffected.
+    if _fused_dit_kernels_enabled():
+        rotary_cos_fp32 = rotary_cos
+        rotary_sin_fp32 = rotary_sin
+        txt_cos_fp32 = network.add_slice(rotary_cos_fp32, (0, 0), (text_seq_len, head_dim), (1, 1)).get_output(0)
+        txt_sin_fp32 = network.add_slice(rotary_sin_fp32, (0, 0), (text_seq_len, head_dim), (1, 1)).get_output(0)
+        img_cos_fp32 = network.add_slice(rotary_cos_fp32, (text_seq_len, 0), (num_img_tokens, head_dim), (1, 1)).get_output(0)
+        img_sin_fp32 = network.add_slice(rotary_sin_fp32, (text_seq_len, 0), (num_img_tokens, head_dim), (1, 1)).get_output(0)
+    else:
+        rotary_cos_fp32 = rotary_sin_fp32 = None
+        txt_cos_fp32 = txt_sin_fp32 = img_cos_fp32 = img_sin_fp32 = None
+
     # Cast FP32 inputs to the reduced compute dtype at the boundary.
     rotary_cos = network.add_cast(rotary_cos, _CAST_DTYPE).get_output(0)
     rotary_sin = network.add_cast(rotary_sin, _CAST_DTYPE).get_output(0)
@@ -440,22 +482,26 @@ def build_flux2_dit_engine(
         v_txt = _linear(network, normed_encoder, dim, dim, weights, f"{p}.attn.add_v_proj")
 
         # QK norm
-        q_img = _rms_norm_per_head_seq(network, q_img, num_heads, head_dim, weights[f"{p}.attn.norm_q.weight"], eps_t, num_img_tokens)
-        k_img = _rms_norm_per_head_seq(network, k_img, num_heads, head_dim, weights[f"{p}.attn.norm_k.weight"], eps_t, num_img_tokens)
-        q_txt = _rms_norm_per_head_seq(network, q_txt, num_heads, head_dim, weights[f"{p}.attn.norm_added_q.weight"], eps_t, text_seq_len)
-        k_txt = _rms_norm_per_head_seq(network, k_txt, num_heads, head_dim, weights[f"{p}.attn.norm_added_k.weight"], eps_t, text_seq_len)
+        # QK norm + RoPE (fused into one kernel call per tensor when
+        # TRTMC_FUSED_DIT_KERNELS=1; otherwise legacy two-step).
+        q_img = _fused_rms_norm_rope_per_tensor(
+            network, q_img, weights[f"{p}.attn.norm_q.weight"],
+            img_cos, img_sin, img_cos_fp32, img_sin_fp32,
+            num_heads, head_dim, num_img_tokens, eps_t, eps)
+        k_img = _fused_rms_norm_rope_per_tensor(
+            network, k_img, weights[f"{p}.attn.norm_k.weight"],
+            img_cos, img_sin, img_cos_fp32, img_sin_fp32,
+            num_heads, head_dim, num_img_tokens, eps_t, eps)
+        q_txt = _fused_rms_norm_rope_per_tensor(
+            network, q_txt, weights[f"{p}.attn.norm_added_q.weight"],
+            txt_cos, txt_sin, txt_cos_fp32, txt_sin_fp32,
+            num_heads, head_dim, text_seq_len, eps_t, eps)
+        k_txt = _fused_rms_norm_rope_per_tensor(
+            network, k_txt, weights[f"{p}.attn.norm_added_k.weight"],
+            txt_cos, txt_sin, txt_cos_fp32, txt_sin_fp32,
+            num_heads, head_dim, text_seq_len, eps_t, eps)
 
-        # Apply RoPE to image Q, K
-        q_img = _apply_native_rope_from_full_cache(
-            network, q_img, img_cos, img_sin, num_heads, head_dim, num_img_tokens)
-        k_img = _apply_native_rope_from_full_cache(
-            network, k_img, img_cos, img_sin, num_heads, head_dim, num_img_tokens)
-
-        # Apply RoPE to text Q, K
-        q_txt = _apply_native_rope_from_full_cache(
-            network, q_txt, txt_cos, txt_sin, num_heads, head_dim, text_seq_len)
-        k_txt = _apply_native_rope_from_full_cache(
-            network, k_txt, txt_cos, txt_sin, num_heads, head_dim, text_seq_len)
+        # (RoPE merged into _fused_rms_norm_rope_per_tensor above.)
 
         # Concatenate: [text, image] for joint attention
         q_cat = network.add_concatenation([q_txt, q_img])
@@ -556,15 +602,15 @@ def build_flux2_dit_engine(
         mlp_hidden = network.add_elementwise(
             mlp_gate_act, mlp_value, trt.ElementWiseOperation.PROD).get_output(0)
 
-        # QK norm
-        q_s = _rms_norm_per_head_seq(network, q_s, num_heads, head_dim, weights[f"{p}.attn.norm_q.weight"], eps_t, total_seq)
-        k_s = _rms_norm_per_head_seq(network, k_s, num_heads, head_dim, weights[f"{p}.attn.norm_k.weight"], eps_t, total_seq)
-
-        # Apply RoPE (full sequence: text + image cos/sin)
-        q_s = _apply_native_rope_from_full_cache(
-            network, q_s, rotary_cos, rotary_sin, num_heads, head_dim, total_seq)
-        k_s = _apply_native_rope_from_full_cache(
-            network, k_s, rotary_cos, rotary_sin, num_heads, head_dim, total_seq)
+        # QK norm + RoPE — single-stream uses full-sequence cos/sin (text+image).
+        q_s = _fused_rms_norm_rope_per_tensor(
+            network, q_s, weights[f"{p}.attn.norm_q.weight"],
+            rotary_cos, rotary_sin, rotary_cos_fp32, rotary_sin_fp32,
+            num_heads, head_dim, total_seq, eps_t, eps)
+        k_s = _fused_rms_norm_rope_per_tensor(
+            network, k_s, weights[f"{p}.attn.norm_k.weight"],
+            rotary_cos, rotary_sin, rotary_cos_fp32, rotary_sin_fp32,
+            num_heads, head_dim, total_seq, eps_t, eps)
 
         attn_out_s = _mha(
             network, q_s, k_s, v_s, num_heads, head_dim, total_seq,
@@ -822,6 +868,42 @@ def _apply_native_rope_from_full_cache(
     return graph_ops.add_apply_rope_native_from_full_cache(
         network, x, num_heads, head_dim, cos_vals, sin_vals,
         seq_len, interleaved=True)
+
+
+def _fused_rms_norm_rope_per_tensor(
+    network, x, weight, cos_reduced, sin_reduced, cos_fp32, sin_fp32,
+    num_heads, head_dim, seq_len, eps_t, eps,
+):
+    """Per-tensor RMS norm + interleaved RoPE in one kernel.
+
+    With TRTMC_FUSED_DIT_KERNELS=1 and cast_dtype in {fp16, bf16}, dispatches a
+    single TVM-FFI kernel — collapses 2 TRT op chains (RMS norm + RoPE) into one
+    device call. The kernel is templated per dtype; the suffix picks the matching
+    export. Otherwise: legacy two-step (RMS-norm helper → RoPE helper), byte-for-
+    byte identical to before.
+    """
+    if _fused_dit_kernels_enabled():
+        # Weight: [1, head_dim] in current reduced precision.
+        weight_t = _add_constant_reduced(network, (1, head_dim), weight)
+        dtype_str = _trt_dtype_to_str(_CAST_DTYPE)
+        outputs = graph_ops.add_tvm_ffi_kernel(
+            network,
+            kernel_name=f"trtmc.dit_rms_norm_rope_{_fused_kernel_dtype_suffix()}",
+            inputs=[x, weight_t, cos_fp32, sin_fp32],
+            output_specs=[{"dims": "same_as_input_0", "dtype": dtype_str}],
+            extra_args=[
+                {"type": "int", "value": num_heads},
+                {"type": "int", "value": head_dim},
+                {"type": "float", "value": eps},
+            ],
+        )
+        return outputs[0]
+
+    # Legacy path — preserved verbatim.
+    x = _rms_norm_per_head_seq(network, x, num_heads, head_dim, weight, eps_t, seq_len)
+    x = _apply_native_rope_from_full_cache(
+        network, x, cos_reduced, sin_reduced, num_heads, head_dim, seq_len)
+    return x
 
 
 def _attention_fp8_scales(prefix: str | None):

--- a/python/tensorrt_model_connect/families/flux/graph_ops.py
+++ b/python/tensorrt_model_connect/families/flux/graph_ops.py
@@ -36,15 +36,44 @@ def layer_tensor_name(stem: str, layer: int) -> str:
     return f"{stem}_{layer}"
 
 
+# Process-lifetime keepalive for bf16 numpy buffers passed to
+# trt.Weights(trt.bfloat16, ptr, count). That constructor does NOT copy,
+# so we need to keep the numpy array alive until the TRT engine is built.
+# Keyed by id(network) so different builds don't conflict.
+_bf16_weight_keepalive: dict[int, list] = {}
+
+
 def add_constant(
     network: trt.INetworkDefinition,
     shape: tuple[int, ...],
     values: np.ndarray,
     dtype: np.dtype = np.float32,
 ) -> trt.ITensor:
-    """Add a constant tensor in the given *dtype* (default float32)."""
-    weights = trt.Weights(np.ascontiguousarray(values, dtype=dtype))
+    """Add a constant tensor in the given *dtype* (default float32).
+
+    Handles bfloat16 (ml_dtypes.bfloat16) explicitly: TRT's Python bindings
+    can't auto-detect the TRT type from the V16 numpy extension dtype, so
+    we route to the explicit (DataType, ptr, count) constructor — which
+    requires us to keep the numpy buffer alive for as long as TRT may
+    read from it (engine build time).
+    """
+    arr = np.ascontiguousarray(values, dtype=dtype)
+    try:
+        import ml_dtypes
+        is_bf16 = arr.dtype == ml_dtypes.bfloat16
+    except ImportError:
+        is_bf16 = False
+    if is_bf16:
+        weights = trt.Weights(trt.bfloat16, arr.ctypes.data, arr.size)
+    else:
+        weights = trt.Weights(arr)
     layer = network.add_constant(shape, weights)
+    # The bf16 trt.Weights constructor does not copy; the array must outlive
+    # TRT's read of the buffer (engine build). Setting an attribute on the
+    # pybind11-wrapped INetworkDefinition is unreliable; use a module-level
+    # dict keyed by id(network).
+    if is_bf16:
+        _bf16_weight_keepalive.setdefault(id(network), []).append(arr)
     return layer.get_output(0)
 
 
@@ -3056,7 +3085,9 @@ def add_tvm_ffi_kernel(
     import json
 
     registry = trt.get_plugin_registry()
-    creator = registry.get_plugin_creator("TvmFfiKernel", "1", "")
+    # TRT 11+ renamed get_plugin_creator → get_creator; keep both for back-compat.
+    _get = getattr(registry, "get_creator", None) or registry.get_plugin_creator
+    creator = _get("TvmFfiKernel", "1", "")
     if creator is None:
         raise RuntimeError(
             "TvmFfiKernel plugin not found in TRT registry. "

--- a/python/tensorrt_model_connect/families/flux/mistral_encoder_builder.py
+++ b/python/tensorrt_model_connect/families/flux/mistral_encoder_builder.py
@@ -197,7 +197,11 @@ def build_mistral_encoder_engine(
         work_np_dtype = np.float16
         work_trt_dtype = trt.float16
     elif precision == "bf16":
-        work_np_dtype = np.float16
+        # Use ml_dtypes.bfloat16 so weights are stored in bf16; pairing fp16
+        # numpy arrays with bf16 TRT layers triggers strongly-typed mismatch
+        # errors (ElementWise SUM requires same input types).
+        import ml_dtypes
+        work_np_dtype = ml_dtypes.bfloat16
         work_trt_dtype = trt.bfloat16
     else:
         work_np_dtype = np.float32
@@ -232,7 +236,15 @@ def build_mistral_encoder_engine(
 
     # --- Attention mask: causal + padding ---
     # Build causal mask: upper triangular with -1e9 above diagonal
-    mask_value = -1e9 if work_np_dtype == np.float32 else np.finfo(work_np_dtype).min
+    # np.finfo doesn't accept ml_dtypes.bfloat16 ("not inexact"); ml_dtypes
+    # ships its own finfo for that case.
+    if work_np_dtype == np.float32:
+        mask_value = -1e9
+    else:
+        import ml_dtypes
+        finfo = (ml_dtypes.finfo
+                 if work_np_dtype == ml_dtypes.bfloat16 else np.finfo)
+        mask_value = float(finfo(work_np_dtype).min)
     causal_mask_np = np.zeros((max_seq_len, max_seq_len), dtype=work_np_dtype)
     for i in range(max_seq_len):
         for j in range(i + 1, max_seq_len):

--- a/src/plugins/tvm_ffi_kernel_plugin.cpp
+++ b/src/plugins/tvm_ffi_kernel_plugin.cpp
@@ -35,7 +35,12 @@ TvmFfiOutputSpec parse_single_output_spec(const std::string& obj) {
         spec.same_as_input_index = -1;
     }
     std::string dt = extract_json_string(obj, "dtype", "float32");
-    spec.dtype = (dt == "float16" || dt == "half") ? 1 : 0;
+    if (dt == "bfloat16" || dt == "bf16")
+        spec.dtype = 2;
+    else if (dt == "float16" || dt == "half")
+        spec.dtype = 1;
+    else
+        spec.dtype = 0;
     return spec;
 }
 
@@ -217,6 +222,8 @@ nvinfer1::DataType TvmFfiKernelPlugin::getOutputDataType(int32_t index,
                                                          int32_t) const noexcept {
     if (index < static_cast<int32_t>(output_specs_.size())) {
         const auto& spec = output_specs_[static_cast<std::size_t>(index)];
+        if (spec.dtype == 2)
+            return nvinfer1::DataType::kBF16;
         if (spec.dtype == 1)
             return nvinfer1::DataType::kHALF;
         if (spec.same_as_input_index >= 0)
@@ -257,7 +264,8 @@ bool TvmFfiKernelPlugin::supportsFormatCombination(int32_t pos,
                                                    nvinfer1::PluginTensorDesc const* inOut, int32_t,
                                                    int32_t) noexcept {
     return inOut[pos].format == nvinfer1::TensorFormat::kLINEAR &&
-           (inOut[pos].type == nvinfer1::DataType::kFLOAT ||
+           (inOut[pos].type == nvinfer1::DataType::kBF16 ||
+            inOut[pos].type == nvinfer1::DataType::kFLOAT ||
             inOut[pos].type == nvinfer1::DataType::kHALF);
 }
 
@@ -298,8 +306,12 @@ void fill_dl_tensor(DLTensor& t, void* data, const nvinfer1::PluginTensorDesc& d
     t.shape = const_cast<int64_t*>(reinterpret_cast<const int64_t*>(desc.dims.d));
     t.strides = nullptr;
     t.byte_offset = 0;
-    t.dtype = (desc.type == nvinfer1::DataType::kFLOAT) ? DLDataType{kDLFloat, 32, 1}
-                                                        : DLDataType{kDLFloat, 16, 1};
+    if (desc.type == nvinfer1::DataType::kFLOAT)
+        t.dtype = DLDataType{kDLFloat, 32, 1};
+    else if (desc.type == nvinfer1::DataType::kBF16)
+        t.dtype = DLDataType{kDLBfloat, 16, 1};
+    else
+        t.dtype = DLDataType{kDLFloat, 16, 1};
 }
 
 // Bind tensor descriptors to DLTensor + TVMFFIAny argument arrays.

--- a/src/plugins/tvm_ffi_kernel_plugin.h
+++ b/src/plugins/tvm_ffi_kernel_plugin.h
@@ -18,7 +18,7 @@ namespace trtmc {
 struct TvmFfiOutputSpec {
     std::vector<int32_t> dims;
     int32_t same_as_input_index{-1};
-    int32_t dtype{0}; // 0 = float32, 1 = float16
+    int32_t dtype{0}; // 0 = float32, 1 = float16, 2 = bfloat16
 };
 
 // Extra scalar/pointer argument passed after tensors in TVMFFIFunctionCall.

--- a/src/runtime/domains/diffusion/kernels/CMakeLists.txt
+++ b/src/runtime/domains/diffusion/kernels/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Diffusion kernel modules.
+#
+# Each kernel here is built as a TVM-FFI loadable module (a .so file with no
+# host-side ABI other than the TVM-FFI registration done at static-init time).
+# The diffusion TRT graph picks them up via graph_ops.add_tvm_ffi_kernel().
+#
+# Gated by the root option TRTMC_BUILD_DIFFUSION_KERNELS so a stock build is
+# unaffected.
+
+enable_language(CUDA)
+
+find_package(CUDAToolkit REQUIRED)
+
+add_library(trtmc_dit_rms_norm_rope MODULE
+    dit_rms_norm_rope.cu
+)
+
+set_target_properties(trtmc_dit_rms_norm_rope PROPERTIES
+    CUDA_ARCHITECTURES "90;100;103"  # Hopper (sm_90) + Blackwell (sm_100, sm_103=GB300)
+    POSITION_INDEPENDENT_CODE ON
+    PREFIX ""
+    OUTPUT_NAME "trtmc_dit_rms_norm_rope"
+    CXX_STANDARD 17
+    CUDA_STANDARD 17
+)
+
+target_include_directories(trtmc_dit_rms_norm_rope SYSTEM PRIVATE
+    ${TRTMC_TVM_FFI_INCLUDE_DIR}
+)
+
+target_link_libraries(trtmc_dit_rms_norm_rope PRIVATE
+    CUDA::cudart
+    ${TRTMC_TVM_FFI_LIBRARY}
+)
+
+target_compile_options(trtmc_dit_rms_norm_rope PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:--use_fast_math -lineinfo>
+)
+
+message(STATUS "Diffusion kernel module: trtmc_dit_rms_norm_rope (sm_90, sm_100)")

--- a/src/runtime/domains/diffusion/kernels/dit_rms_norm_rope.cu
+++ b/src/runtime/domains/diffusion/kernels/dit_rms_norm_rope.cu
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Per-tensor fused RMSNorm + RoPE for DiT attention.
+//
+// Adapted from TensorRT-LLM PR #13052 (fusedDiTQKNormRopeKernel.cu, commit
+// f7fadf1b84a1bbda53d0900ec6eff39980384fff). Upstream targets a packed QKV
+// layout with dual-stream text/image norm. We simplify to a per-tensor
+// launcher matching our FLUX.2 builder, which holds Q/K/V as separate
+// ITensors and processes image and text branches independently.
+//
+// Per-warp algorithm (one warp processes one (token, head)):
+//   1. Vectorized half-precision load + per-thread sum-of-squares
+//   2. Warp-shuffle reduce → RMS scale → per-head weight multiply
+//   3. RoPE (interleaved pairing, fp32 cos/sin)
+//   4. Vectorized half-precision store
+//
+// Two TVM-FFI exports — bf16 and fp16. The FLUX.2 builder picks the one
+// matching its `_CAST_DTYPE` (fp16 is the default; bf16 is opt-in).
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <tvm/ffi/c_api.h>
+#include <tvm/ffi/extra/c_env_api.h>
+
+namespace trtmc::diffusion::kernels {
+
+// Inlined from TensorRT-LLM common/reduceKernelUtils.cuh (Apache-2.0).
+// Specialized to float since the only caller reduces a fp32 accumulator.
+__forceinline__ __device__ float warpReduceSumF32(float val) {
+#pragma unroll
+    for (int mask = 16; mask > 0; mask >>= 1) {
+        val += __shfl_xor_sync(0xffffffff, val, mask, 32);
+    }
+    return val;
+}
+
+// Maps (uint, vecSize) → uint / uint2 / uint4 for vectorized I/O.
+// Inlined from TensorRT-LLM common::packed_as.
+template <int N> struct PackedUint;
+template <> struct PackedUint<1> { using type = unsigned int; };
+template <> struct PackedUint<2> { using type = uint2; };
+template <> struct PackedUint<4> { using type = uint4; };
+
+// Per-dtype intrinsics. Each specialization defines the 2-wide packed type
+// + the float2 unpack/pack helpers + the scalar to-float helper.
+template <typename T> struct DTypeTraits;
+
+template <> struct DTypeTraits<__nv_bfloat16> {
+    using T2 = __nv_bfloat162;
+    __forceinline__ __device__ static float2 to_float2(T2 v) {
+        return __bfloat1622float2(v);
+    }
+    __forceinline__ __device__ static T2 from_float2(float2 v) {
+        return __float22bfloat162_rn(v);
+    }
+    __forceinline__ __device__ static float to_float(__nv_bfloat16 v) {
+        return __bfloat162float(v);
+    }
+};
+
+template <> struct DTypeTraits<__half> {
+    using T2 = __half2;
+    __forceinline__ __device__ static float2 to_float2(T2 v) {
+        return __half22float2(v);
+    }
+    __forceinline__ __device__ static T2 from_float2(float2 v) {
+        return __float22half2_rn(v);
+    }
+    __forceinline__ __device__ static float to_float(__half v) {
+        return __half2float(v);
+    }
+};
+
+// One warp per (token, head). x_in and x_out are [num_tokens, num_heads * head_dim].
+template <typename T, int head_dim>
+__global__ void perTensorRMSNormRopeKernel(
+    T const* __restrict__ x_in,
+    T* __restrict__ x_out,
+    T const* __restrict__ weight,                // [head_dim]
+    float const* __restrict__ cos_emb,           // [num_tokens, head_dim]
+    float const* __restrict__ sin_emb,           // [num_tokens, head_dim]
+    int num_tokens, int num_heads, float eps)
+{
+    using Traits = DTypeTraits<T>;
+    using T2 = typename Traits::T2;
+    constexpr int warpSize = 32;
+    int const warpsPerBlock = blockDim.x / warpSize;
+    int const warpId = threadIdx.x / warpSize;
+    int const laneId = threadIdx.x % warpSize;
+    int const globalWarpIdx = blockIdx.x * warpsPerBlock + warpId;
+
+    int const tokenIdx = globalWarpIdx / num_heads;
+    int const headIdx = globalWarpIdx % num_heads;
+    if (tokenIdx >= num_tokens) return;
+
+    static_assert(head_dim % 64 == 0,
+                  "head_dim must be divisible by 64 (each warp lane processes ≥2 elems)");
+    constexpr int numElemsPerThread = head_dim / warpSize;
+    constexpr int elemSizeBytes = numElemsPerThread * sizeof(T);
+    static_assert(elemSizeBytes % 4 == 0, "elemSizeBytes must be a multiple of 4");
+    constexpr int vecSize = elemSizeBytes / 4;
+    using vec_T = typename PackedUint<vecSize>::type;
+
+    int64_t const offsetWarp =
+        static_cast<int64_t>(tokenIdx) * num_heads * head_dim + headIdx * head_dim;
+    int64_t const offsetThread = offsetWarp + laneId * numElemsPerThread;
+
+    float elements[numElemsPerThread];
+
+    // Step 1: vectorized load + sum-of-squares
+    float sumSq = 0.f;
+    {
+        vec_T vec = *reinterpret_cast<vec_T const*>(&x_in[offsetThread]);
+        unsigned int* vecAsUint = reinterpret_cast<unsigned int*>(&vec);
+        for (int i = 0; i < vecSize; i++) {
+            float2 v = Traits::to_float2(*reinterpret_cast<T2*>(vecAsUint + i));
+            sumSq += v.x * v.x + v.y * v.y;
+            elements[2 * i] = v.x;
+            elements[2 * i + 1] = v.y;
+        }
+    }
+
+    // Step 2: RMS normalize + per-head weight
+    sumSq = warpReduceSumF32(sumSq);
+    float const rms_rcp = rsqrtf(sumSq / static_cast<float>(head_dim) + eps);
+    for (int i = 0; i < numElemsPerThread; i++) {
+        int const dim = laneId * numElemsPerThread + i;
+        elements[i] *= rms_rcp * Traits::to_float(weight[dim]);
+    }
+
+    // Step 3: interleaved RoPE
+    int64_t const embOffset = static_cast<int64_t>(tokenIdx) * head_dim;
+    for (int i = 0; i < numElemsPerThread; i += 2) {
+        int const dim = laneId * numElemsPerThread + i;
+        float const cos0 = cos_emb[embOffset + dim];
+        float const sin0 = sin_emb[embOffset + dim];
+        float const cos1 = cos_emb[embOffset + dim + 1];
+        float const sin1 = sin_emb[embOffset + dim + 1];
+        float const x = elements[i];
+        float const y = elements[i + 1];
+        elements[i]     = x * cos0 - y * sin0;
+        elements[i + 1] = y * cos1 + x * sin1;
+    }
+
+    // Step 4: vectorized store
+    {
+        vec_T vec;
+        unsigned int* vecAsUint = reinterpret_cast<unsigned int*>(&vec);
+        for (int i = 0; i < vecSize; i++) {
+            T2 v = Traits::from_float2(
+                make_float2(elements[2 * i], elements[2 * i + 1]));
+            *reinterpret_cast<T2*>(vecAsUint + i) = v;
+        }
+        *reinterpret_cast<vec_T*>(&x_out[offsetThread]) = vec;
+    }
+}
+
+template <typename T>
+static void launchPerTensorRMSNormRope(
+    T const* x_in, T* x_out, T const* weight,
+    float const* cos_emb, float const* sin_emb,
+    int num_tokens, int num_heads, int head_dim, float eps,
+    cudaStream_t stream)
+{
+    constexpr int blockSize = 256;
+    int const warpsPerBlock = blockSize / 32;
+    int const totalWarps = num_tokens * num_heads;
+    int const gridSize = (totalWarps + warpsPerBlock - 1) / warpsPerBlock;
+    dim3 const gridDim(gridSize), blockDim(blockSize);
+
+#define LAUNCH(HEAD_DIM)                                                            \
+    perTensorRMSNormRopeKernel<T, HEAD_DIM>                                         \
+        <<<gridDim, blockDim, 0, stream>>>(x_in, x_out, weight, cos_emb, sin_emb,   \
+                                            num_tokens, num_heads, eps);
+
+    switch (head_dim) {
+        case 64:  LAUNCH(64);  break;
+        case 128: LAUNCH(128); break;
+        case 256: LAUNCH(256); break;
+        default: /* Unsupported; silent no-op. Callers must guard. */ break;
+    }
+#undef LAUNCH
+}
+
+} // namespace trtmc::diffusion::kernels
+
+// ---------------------------------------------------------------------------
+// TVM-FFI export — one symbol per dtype
+// ---------------------------------------------------------------------------
+//
+// Arg layout (destination-passing, matching tvm_ffi_kernel_plugin.cpp's
+// "[inputs..., outputs..., extras...]" convention):
+//   args[0] = x_in DLTensor    [num_tokens, num_heads * head_dim] T
+//   args[1] = weight DLTensor  [head_dim]                          T
+//   args[2] = cos_emb DLTensor [num_tokens, head_dim]              fp32
+//   args[3] = sin_emb DLTensor [num_tokens, head_dim]              fp32
+//   args[4] = x_out DLTensor   [num_tokens, num_heads * head_dim] T  (preallocated)
+//   args[5] = num_heads (int)
+//   args[6] = head_dim  (int)
+//   args[7] = eps (float; stored via v_float64 by the plugin)
+//
+// T is determined by which global name is looked up:
+//   "trtmc.dit_rms_norm_rope_bf16" → __nv_bfloat16
+//   "trtmc.dit_rms_norm_rope_fp16" → __half
+
+// Extract a DLTensor* from either:
+//   - the C-plugin convention (type_index = kTVMFFIDLTensorPtr, v_ptr is DLTensor*)
+//   - the Python/tvm-ffi convention (type_index = kTVMFFITensor, v_obj is a
+//     Tensor object whose DLTensor sub-object lives at +sizeof(TVMFFIObject)).
+// TVMFFITensorGetDLTensorPtr is the inline helper provided by tvm/ffi/c_api.h.
+static inline DLTensor* get_dl_tensor(TVMFFIAny const& any) {
+    if (any.type_index == kTVMFFITensor) {
+        return TVMFFITensorGetDLTensorPtr(any.v_obj);
+    }
+    return static_cast<DLTensor*>(any.v_ptr);
+}
+
+template <typename T>
+static int trtmc_dit_rms_norm_rope_impl_typed(
+    TVMFFIAny const* args, int32_t num_args, TVMFFIAny* result)
+{
+    if (num_args < 8) {
+        std::fprintf(stderr,
+            "[dit_rms_norm_rope] ERROR: expected 8 args, got %d\n", num_args);
+        return -1;
+    }
+
+    auto* x_in_t   = get_dl_tensor(args[0]);
+    auto* weight_t = get_dl_tensor(args[1]);
+    auto* cos_t    = get_dl_tensor(args[2]);
+    auto* sin_t    = get_dl_tensor(args[3]);
+    auto* x_out_t  = get_dl_tensor(args[4]);
+    int const num_heads = static_cast<int>(args[5].v_int64);
+    int const head_dim  = static_cast<int>(args[6].v_int64);
+    float const eps = static_cast<float>(args[7].v_float64);
+
+    int const num_tokens = static_cast<int>(x_in_t->shape[0]);
+
+    // TVM-FFI v0.1.x exposes per-device current stream. kDLCUDA = 2.
+    auto stream = static_cast<cudaStream_t>(
+        TVMFFIEnvGetStream(kDLCUDA, x_in_t->device.device_id));
+
+    trtmc::diffusion::kernels::launchPerTensorRMSNormRope<T>(
+        static_cast<T const*>(x_in_t->data),
+        static_cast<T*>(x_out_t->data),
+        static_cast<T const*>(weight_t->data),
+        static_cast<float const*>(cos_t->data),
+        static_cast<float const*>(sin_t->data),
+        num_tokens, num_heads, head_dim, eps, stream);
+
+    result->type_index = kTVMFFINone;
+    return 0;
+}
+
+extern "C" int trtmc_dit_rms_norm_rope_bf16_impl(
+    void* /*self*/, TVMFFIAny const* args, int32_t num_args, TVMFFIAny* result)
+{
+    return trtmc_dit_rms_norm_rope_impl_typed<__nv_bfloat16>(args, num_args, result);
+}
+
+extern "C" int trtmc_dit_rms_norm_rope_fp16_impl(
+    void* /*self*/, TVMFFIAny const* args, int32_t num_args, TVMFFIAny* result)
+{
+    return trtmc_dit_rms_norm_rope_impl_typed<__half>(args, num_args, result);
+}
+
+static void register_global_func(char const* name_str, TVMFFISafeCallType impl) {
+    TVMFFIByteArray name;
+    name.data = name_str;
+    name.size = static_cast<int64_t>(std::strlen(name_str));
+    TVMFFIObjectHandle h = nullptr;
+    TVMFFIFunctionCreate(nullptr, impl, nullptr, &h);
+    TVMFFIFunctionSetGlobal(&name, h, /*allow_override=*/1);
+}
+
+// Run at module load.
+namespace {
+struct _AutoRegister {
+    _AutoRegister() {
+        register_global_func("trtmc.dit_rms_norm_rope_bf16",
+                             trtmc_dit_rms_norm_rope_bf16_impl);
+        register_global_func("trtmc.dit_rms_norm_rope_fp16",
+                             trtmc_dit_rms_norm_rope_fp16_impl);
+    }
+};
+static _AutoRegister _auto_register_instance;
+} // namespace

--- a/tests/cpp/test_tvm_ffi_plugin.cpp
+++ b/tests/cpp/test_tvm_ffi_plugin.cpp
@@ -95,7 +95,11 @@ static nvinfer1::ICudaEngine* build_engine(TestLogger& logger) {
     nvinfer1::PluginFieldCollection fc{2, fields};
 
     auto* registry = getPluginRegistry();
-    auto* creator = registry->getPluginCreator("TvmFfiKernel", "1", "");
+    // TRT 11 removed IPluginRegistry::getPluginCreator and replaced it with
+    // getCreator returning IPluginCreatorInterface*; downcast to the still-
+    // supported (deprecated) IPluginCreator so createPlugin() is callable.
+    auto* creator =
+        static_cast<nvinfer1::IPluginCreator*>(registry->getCreator("TvmFfiKernel", "1", ""));
     check(creator != nullptr, "creator found");
     if (!creator) {
         delete config;

--- a/tests/cpp/test_tvm_ffi_plugin_v2.cpp
+++ b/tests/cpp/test_tvm_ffi_plugin_v2.cpp
@@ -224,7 +224,11 @@ static void test_v2_roundtrip() {
 
     // Create plugin via creator
     auto* registry = getPluginRegistry();
-    auto* creator = registry->getPluginCreator("TvmFfiKernelV2", "1", "");
+    // TRT 11 removed IPluginRegistry::getPluginCreator; replaced by
+    // getCreator returning IPluginCreatorInterface*. Downcast preserves
+    // the existing createPlugin() call on the concrete creator type.
+    auto* creator =
+        static_cast<nvinfer1::IPluginCreator*>(registry->getCreator("TvmFfiKernelV2", "1", ""));
     check(creator != nullptr, "V2 creator found");
     if (creator == nullptr) {
         delete config;


### PR DESCRIPTION
# Fused DiT QK-Norm + RoPE kernel for FLUX.2

Replaces FLUX.2's per-block chain of 4 per-head RMSNorms + 4 RoPEs (double-stream) and
2+2 (single-stream) with one fused TVM-FFI kernel call per tensor. Per-warp algorithm
adapted from [TensorRT-LLM PR-13052](https://github.com/NVIDIA/TensorRT-LLM/pull/13052)
(`fusedDiTQKNormRopeKernel.cu`), simplified to a per-tensor launcher that
slots into our existing separate-Q/K/V graph without restructuring. Templated on
dtype — both fp16 (FLUX.2's default) and bf16 are exported.

## Numbers — FLUX.2-dev 1024×1024, 28 steps, GB300

| Build | per step | 28 steps | engine plan |
|---|---:|---:|---:|
| bf16 legacy | 198.91 ms | 5.57 s | 75.85 GB |
| **bf16 fused** | **182.64 ms** (−8.2%) | 5.11 s | 60.04 GB (−21%) |
| fp16 legacy | 193.73 ms | 5.42 s | 75.85 GB |
| **fp16 fused** | **183.83 ms** (−5.1%) | 5.15 s | 60.04 GB (−21%) |
| torch.compile bf16 (reference) | 185.00 ms | 5.18 s | — |

Both fused paths beat torch.compile. Before this PR, TRT BF16 was 1.08× *slower*;
after, 1.01× *faster*. Engine plan shrinks 21% because the unfused chain materialized
intermediate weight tensors the fused path collapses.

**Kernel correctness** (vs PyTorch reference, realistic RoPE cos/sin):
`bf16` max_abs 1.56e-2 (limit 3e-2) ✓ · `fp16` max_abs 1.95e-3 (limit 5e-3) ✓

**Kernel microbench** (vs PyTorch eager bf16): 15.8× – 25.7× across FLUX.2 shapes.

### What each commit does

- **`f076f00` build** — pip-installs `apache-tvm-ffi==0.1.12` in the Dockerfile; CMake
  uses `importlib.util.find_spec()` to discover `tvm_ffi` + `tensorrt_libs` paths in
  the venv. Previously these libs were silently undiscoverable in the stock dev image.
- **`2049c14` plugin bf16** — adds `dtype=2 → kBF16` in five sites of
  `tvm_ffi_kernel_plugin.{cpp,h}` (output spec, format combination, DLTensor fill).
- **`1193351` Mistral bf16 (1/3)** — `work_np_dtype` for bf16 now uses
  `ml_dtypes.bfloat16` (was `np.float16`, causing strongly-typed TRT type mismatches).
- **`71dc58f` fused kernel** — new `dit_rms_norm_rope.cu` (bf16-only at landing time)
  + `flux2_dit_builder.py` injection at 6 paired call sites behind
  `TRTMC_FUSED_DIT_KERNELS=1` env flag. Default path byte-identical to before. Build
  gated by `option(TRTMC_BUILD_DIFFUSION_KERNELS OFF)`. sm_90 + sm_100 + sm_103.
- **fp16 + remaining bf16 bundle fixes** — three independent fixes that
  together complete the picture; bundled because the bf16 fixes only become testable
  end-to-end once you can also build a fused engine in fp16 (FLUX.2's default):
  - Kernel templated on dtype via `DTypeTraits<T>` (specializations for
    `__nv_bfloat16` and `__half`); two TVM-FFI exports
    `trtmc.dit_rms_norm_rope_{bf16,fp16}`; builder picks the suffix by `_CAST_DTYPE`.
  - `graph_ops.add_constant`: detect `ml_dtypes.bfloat16` (a V16 numpy extension dtype
    that TRT bindings can't auto-convert) and route to the explicit
    `trt.Weights(trt.bfloat16, ptr, count)` constructor. That constructor does **not**
    copy, so we also keep the numpy buffer alive via a module-level
    `_bf16_weight_keepalive` dict keyed by `id(network)`. Without the keepalive, GC
    of the local array caused exit-139 segfaults during TRT graph construction.
  - `mistral_encoder_builder.py`: `np.finfo` rejects `ml_dtypes.bfloat16` (`not
    inexact`); switch to `ml_dtypes.finfo` for the attention-mask min value.


## How to verify

```bash
./scripts/docker_build_gb300.sh   # rebuilds image with apache-tvm-ffi

docker run --rm --gpus all -v "$PWD":/workspace/tensorrt-model-connect \
  -w /workspace/tensorrt-model-connect trtmc-dev-gb300:latest \
  bash -c "cmake -S . -B build -DTRTMC_BUILD_DIFFUSION_KERNELS=ON \
                            -DTRTMC_ENABLE_TVM_FFI=ON -GNinja && \
           cmake --build build --target trtmc_dit_rms_norm_rope \
                                       trtmc_tvm_ffi_plugin -j"

# Build (set TRTMC_FUSED_DIT_KERNELS=1 to use fused; --precision fp16 or bf16)
# Bench: same docker but with LD_PRELOAD=…trtmc_tvm_ffi_plugin.so:…trtmc_dit_rms_norm_rope.so
# and `python3 scripts/bench_flux2_perf.py --bundle … --backends trt_denoiser --num-steps 28`
```

Expected fused step time: **fp16 0.184 s/step**, **bf16 0.183 s/step** on GB300.

## Not in this PR — follow-ups

- Port `fuse_scale_shift` (AdaLN, 81 calls/step) — biggest remaining win (~25 ms/step).
- Port `group_norm_silu` (VAE) — runs once per gen, small.
- C++-runtime registration of the kernel — currently registers via Python
  `ctypes.CDLL`; the C++ trtmc binary needs a static-init wrapper to use the fused path.
- Permanent `tests/test_dit_rms_norm_rope.py` (mirror `test_flashinfer_plugin_e2e.py`).

## Risk / backwards compat

- **Default path byte-identical to pre-PR.** `TRTMC_BUILD_DIFFUSION_KERNELS` defaults
  OFF; without `TRTMC_FUSED_DIT_KERNELS=1`, the legacy chain runs.
- Plugin bf16 mapping is additive (fp32/fp16 paths untouched).
- The `_bf16_weight_keepalive` dict lives for process lifetime, bounded by engine
  builds. Acceptable; long-lived processes that build many bf16 engines could
  explicitly clear entries on completion.


## Architecture note

`TvmFfiKernelPlugin` looks up kernels by global name at engine deserialize time. Any
toolchain that emits a `tvm_ffi.Function` slots in identically — raw CUDA today,
CuTeDSL/Triton/FlashInfer JIT later via the same `add_tvm_ffi_kernel(...)` Python
helper. This PR is the first end-to-end shake-out of that plug for diffusion graphs.