### PR TITLE
feat(e2e/asr): add nightly ASR probe coverage

### DIFF
--- a/tests/e2e/data/asr_probes/README.md
+++ b/tests/e2e/data/asr_probes/README.md
@@ -1,0 +1,19 @@
+# ASR Probe Inputs
+
+These WAV files are generated from the existing ASR fixture at
+`tests/e2e/data/Recording.wav`. They exercise TensorRT Model Connect audio
+input handling paths and TRT-vs-reference transcript parity. They are not
+intended to benchmark ASR model quality.
+
+| ID | File | SR | Ch | Duration | Readiness | Model Connect path |
+|---|---|---:|---:|---:|---|---|
+| probe_01_clean_48k_stereo_baseline | `probe_01_clean_48k_stereo_baseline.wav` | 48000 | 2 | 4.16s | ready_now | WAV decode + stereo input + model-specific resample. |
+| probe_02_clean_16k_mono_no_resample | `probe_02_clean_16k_mono_no_resample.wav` | 16000 | 1 | 4.16s | ready_now | WAV decode without model-side downmix; should avoid 48k->16k resample in ASR preprocessing. |
+| probe_03_clean_48k_mono_resample | `probe_03_clean_48k_mono_resample.wav` | 48000 | 1 | 4.16s | ready_now | WAV decode + 48k->16k resample, without stereo downmix. |
+| probe_04_clean_48k_stereo_gain_skew | `probe_04_clean_48k_stereo_gain_skew.wav` | 48000 | 2 | 4.16s | ready_now | Stereo downmix should be robust when L/R channels are not identical. |
+| probe_05_low_volume_48k_stereo | `probe_05_low_volume_48k_stereo.wav` | 48000 | 2 | 4.16s | ready_now | PCM int16 decode + float normalization + ASR preprocessing. |
+| probe_06_leading_trailing_silence_48k_stereo | `probe_06_leading_trailing_silence_48k_stereo.wav` | 48000 | 2 | 6.16s | ready_now | Longer waveform decode + silence handling + transcript stability. |
+| probe_08_noisy_48k_stereo_snr20 | `probe_08_noisy_48k_stereo_snr20.wav` | 48000 | 2 | 4.16s | nightly_optional | PCM decode + preprocessing under non-clean waveform. |
+
+Use `manifest.json` for detailed purpose and notes. Re-run
+`generate_asr_probe_inputs.py` from this directory to regenerate the WAVs.

--- a/tests/e2e/data/asr_probes/generate_asr_probe_inputs.py
+++ b/tests/e2e/data/asr_probes/generate_asr_probe_inputs.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Generate ASR probe WAV inputs for TensorRT Model Connect E2E coverage."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import wave
+from pathlib import Path
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parent
+SOURCE = ROOT.parent / "Recording.wav"
+
+
+def read_wav(path: Path) -> tuple[int, np.ndarray]:
+    with wave.open(str(path), "rb") as wav:
+        channels = wav.getnchannels()
+        sample_width = wav.getsampwidth()
+        sample_rate = wav.getframerate()
+        frames = wav.readframes(wav.getnframes())
+    if sample_width != 2:
+        raise ValueError(f"Only int16 WAV is supported, got sample_width={sample_width}")
+    audio_i16 = np.frombuffer(frames, dtype="<i2")
+    audio = audio_i16.reshape(-1, channels).astype(np.float32) / 32768.0
+    return sample_rate, audio
+
+
+def write_wav(path: Path, sample_rate: int, audio: np.ndarray) -> None:
+    audio = np.asarray(audio, dtype=np.float32)
+    if audio.ndim == 1:
+        audio = audio[:, None]
+    audio_i16 = np.clip(audio, -1.0, 1.0)
+    audio_i16 = np.round(audio_i16 * 32767.0).astype("<i2")
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(audio_i16.shape[1])
+        wav.setsampwidth(2)
+        wav.setframerate(sample_rate)
+        wav.writeframes(audio_i16.tobytes())
+
+
+def mono(audio: np.ndarray) -> np.ndarray:
+    if audio.ndim == 1:
+        return audio
+    return audio.mean(axis=1)
+
+
+def stereo_from_mono(audio: np.ndarray, *, right_gain: float = 1.0) -> np.ndarray:
+    audio = mono(audio)
+    return np.stack([audio, audio * right_gain], axis=1)
+
+
+def resample_linear(audio: np.ndarray, src_rate: int, dst_rate: int) -> np.ndarray:
+    if src_rate == dst_rate:
+        return audio.copy()
+    if audio.ndim == 1:
+        audio_2d = audio[:, None]
+    else:
+        audio_2d = audio
+    src_n = audio_2d.shape[0]
+    dst_n = int(round(src_n * dst_rate / src_rate))
+    src_x = np.arange(src_n, dtype=np.float64)
+    dst_x = np.linspace(0, src_n - 1, dst_n, dtype=np.float64)
+    channels = [
+        np.interp(dst_x, src_x, audio_2d[:, c]).astype(np.float32)
+        for c in range(audio_2d.shape[1])
+    ]
+    out = np.stack(channels, axis=1)
+    return out[:, 0] if audio.ndim == 1 else out
+
+
+def add_white_noise(audio: np.ndarray, snr_db: float, seed: int = 20260611) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    signal_power = float(np.mean(np.square(audio))) or 1e-12
+    noise_power = signal_power / (10.0 ** (snr_db / 10.0))
+    noise = rng.normal(0.0, np.sqrt(noise_power), size=audio.shape).astype(np.float32)
+    return np.clip(audio + noise, -1.0, 1.0)
+
+
+def main() -> None:
+    sample_rate, original = read_wav(SOURCE)
+    mono_48k = mono(original)
+    mono_16k = resample_linear(mono_48k, sample_rate, 16000)
+    silence_48k = np.zeros((sample_rate,), dtype=np.float32)
+    cases: list[dict[str, object]] = []
+
+    def add_case(
+        name: str,
+        sample_rate_hz: int,
+        audio: np.ndarray,
+        *,
+        purpose: str,
+        model_connect_path: str,
+        readiness: str,
+        notes: str,
+    ) -> None:
+        file_name = f"{name}.wav"
+        write_wav(ROOT / file_name, sample_rate_hz, audio)
+        channels = 1 if audio.ndim == 1 else audio.shape[1]
+        duration_s = round(float(audio.shape[0]) / sample_rate_hz, 3)
+        cases.append(
+            {
+                "id": name,
+                "file": file_name,
+                "sample_rate_hz": sample_rate_hz,
+                "channels": channels,
+                "duration_s": duration_s,
+                "purpose": purpose,
+                "model_connect_path": model_connect_path,
+                "readiness": readiness,
+                "contract_oracle": (
+                    "Compare TRT transcript with reference backend transcript; "
+                    "do not judge model accuracy."
+                ),
+                "notes": notes,
+            }
+        )
+
+    shutil.copyfile(SOURCE, ROOT / "probe_01_clean_48k_stereo_baseline.wav")
+    cases.append(
+        {
+            "id": "probe_01_clean_48k_stereo_baseline",
+            "file": "probe_01_clean_48k_stereo_baseline.wav",
+            "sample_rate_hz": sample_rate,
+            "channels": original.shape[1],
+            "duration_s": round(float(original.shape[0]) / sample_rate, 3),
+            "purpose": "Current smoke input copied as baseline.",
+            "model_connect_path": "WAV decode + stereo input + model-specific resample.",
+            "readiness": "ready_now",
+            "contract_oracle": (
+                "Compare TRT transcript with reference backend transcript; "
+                "do not judge model accuracy."
+            ),
+            "notes": "Expected transcript is the existing short weather sentence.",
+        }
+    )
+
+    add_case(
+        "probe_02_clean_16k_mono_no_resample",
+        16000,
+        mono_16k,
+        purpose="Cover native 16k mono path.",
+        model_connect_path=(
+            "WAV decode without model-side downmix; should avoid 48k->16k "
+            "resample in ASR preprocessing."
+        ),
+        readiness="ready_now",
+        notes="Useful to isolate resampling differences from core decode/runtime differences.",
+    )
+    add_case(
+        "probe_03_clean_48k_mono_resample",
+        48000,
+        mono_48k,
+        purpose="Cover mono 48k resample path.",
+        model_connect_path="WAV decode + 48k->16k resample, without stereo downmix.",
+        readiness="ready_now",
+        notes="Separates resample handling from stereo downmix handling.",
+    )
+    add_case(
+        "probe_04_clean_48k_stereo_gain_skew",
+        48000,
+        stereo_from_mono(mono_48k, right_gain=0.55),
+        purpose="Cover stereo-to-mono with asymmetric channel levels.",
+        model_connect_path="Stereo downmix should be robust when L/R channels are not identical.",
+        readiness="ready_now",
+        notes="Still the same speech content; intended to catch channel handling mistakes.",
+    )
+    add_case(
+        "probe_05_low_volume_48k_stereo",
+        48000,
+        np.clip(stereo_from_mono(mono_48k) * 0.12, -1.0, 1.0),
+        purpose="Cover low-amplitude PCM handling.",
+        model_connect_path="PCM int16 decode + float normalization + ASR preprocessing.",
+        readiness="ready_now",
+        notes="Reference and TRT should see the same low-volume input.",
+    )
+    add_case(
+        "probe_06_leading_trailing_silence_48k_stereo",
+        48000,
+        np.concatenate(
+            [
+                stereo_from_mono(silence_48k),
+                stereo_from_mono(mono_48k),
+                stereo_from_mono(silence_48k),
+            ]
+        ),
+        purpose="Cover non-speech padding around valid speech.",
+        model_connect_path="Longer waveform decode + silence handling + transcript stability.",
+        readiness="ready_now",
+        notes="Detects unexpected trimming, transcript drift, or EOS issues.",
+    )
+    add_case(
+        "probe_08_noisy_48k_stereo_snr20",
+        48000,
+        add_white_noise(stereo_from_mono(mono_48k), snr_db=20.0),
+        purpose="Cover deterministic noisy input handling.",
+        model_connect_path="PCM decode + preprocessing under non-clean waveform.",
+        readiness="nightly_optional",
+        notes="Use only as TRT-vs-reference parity; do not evaluate model noise robustness.",
+    )
+
+    manifest = {
+        "source_audio": "tests/e2e/data/Recording.wav",
+        "source_properties": {
+            "sample_rate_hz": sample_rate,
+            "channels": int(original.shape[1]),
+            "duration_s": round(float(original.shape[0]) / sample_rate, 3),
+        },
+        "principle": (
+            "These probes test Model Connect input handling and TRT-vs-reference "
+            "contract parity, not model accuracy."
+        ),
+        "recommended_metrics": [
+            "CER for ASR-specific character-level transcript parity",
+            "WER substitution/insertion/deletion breakdown for ASR failure triage",
+            "no-speech/blank-audio state reporting for future ASR contract work",
+        ],
+        "cases": cases,
+    }
+    (ROOT / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/data/asr_probes/manifest.json
+++ b/tests/e2e/data/asr_probes/manifest.json
@@ -1,0 +1,100 @@
+{
+  "source_audio": "tests/e2e/data/Recording.wav",
+  "source_properties": {
+    "sample_rate_hz": 48000,
+    "channels": 2,
+    "duration_s": 4.16
+  },
+  "principle": "These probes test Model Connect input handling and TRT-vs-reference contract parity, not model accuracy.",
+  "recommended_metrics": [
+    "CER for ASR-specific character-level transcript parity",
+    "WER substitution/insertion/deletion breakdown for ASR failure triage",
+    "no-speech/blank-audio state reporting for future ASR contract work"
+  ],
+  "cases": [
+    {
+      "id": "probe_01_clean_48k_stereo_baseline",
+      "file": "probe_01_clean_48k_stereo_baseline.wav",
+      "sample_rate_hz": 48000,
+      "channels": 2,
+      "duration_s": 4.16,
+      "purpose": "Current smoke input copied as baseline.",
+      "model_connect_path": "WAV decode + stereo input + model-specific resample.",
+      "readiness": "ready_now",
+      "notes": "Expected transcript is the existing short weather sentence.",
+      "contract_oracle": "Compare TRT transcript with reference backend transcript; do not judge model accuracy."
+    },
+    {
+      "id": "probe_02_clean_16k_mono_no_resample",
+      "file": "probe_02_clean_16k_mono_no_resample.wav",
+      "sample_rate_hz": 16000,
+      "channels": 1,
+      "duration_s": 4.16,
+      "purpose": "Cover native 16k mono path.",
+      "model_connect_path": "WAV decode without model-side downmix; should avoid 48k->16k resample in ASR preprocessing.",
+      "readiness": "ready_now",
+      "notes": "Useful to isolate resampling differences from core decode/runtime differences.",
+      "contract_oracle": "Compare TRT transcript with reference backend transcript; do not judge model accuracy."
+    },
+    {
+      "id": "probe_03_clean_48k_mono_resample",
+      "file": "probe_03_clean_48k_mono_resample.wav",
+      "sample_rate_hz": 48000,
+      "channels": 1,
+      "duration_s": 4.16,
+      "purpose": "Cover mono 48k resample path.",
+      "model_connect_path": "WAV decode + 48k->16k resample, without stereo downmix.",
+      "readiness": "ready_now",
+      "notes": "Separates resample handling from stereo downmix handling.",
+      "contract_oracle": "Compare TRT transcript with reference backend transcript; do not judge model accuracy."
+    },
+    {
+      "id": "probe_04_clean_48k_stereo_gain_skew",
+      "file": "probe_04_clean_48k_stereo_gain_skew.wav",
+      "sample_rate_hz": 48000,
+      "channels": 2,
+      "duration_s": 4.16,
+      "purpose": "Cover stereo-to-mono with asymmetric channel levels.",
+      "model_connect_path": "Stereo downmix should be robust when L/R channels are not identical.",
+      "readiness": "ready_now",
+      "notes": "Still the same speech content; intended to catch channel handling mistakes.",
+      "contract_oracle": "Compare TRT transcript with reference backend transcript; do not judge model accuracy."
+    },
+    {
+      "id": "probe_05_low_volume_48k_stereo",
+      "file": "probe_05_low_volume_48k_stereo.wav",
+      "sample_rate_hz": 48000,
+      "channels": 2,
+      "duration_s": 4.16,
+      "purpose": "Cover low-amplitude PCM handling.",
+      "model_connect_path": "PCM int16 decode + float normalization + ASR preprocessing.",
+      "readiness": "ready_now",
+      "notes": "Reference and TRT should see the same low-volume input; not an accuracy benchmark.",
+      "contract_oracle": "Compare TRT transcript with reference backend transcript; do not judge model accuracy."
+    },
+    {
+      "id": "probe_06_leading_trailing_silence_48k_stereo",
+      "file": "probe_06_leading_trailing_silence_48k_stereo.wav",
+      "sample_rate_hz": 48000,
+      "channels": 2,
+      "duration_s": 6.16,
+      "purpose": "Cover non-speech padding around valid speech.",
+      "model_connect_path": "Longer waveform decode + silence handling + transcript stability.",
+      "readiness": "ready_now",
+      "notes": "Detects unexpected trimming, timestamp-independent transcript drift, or EOS issues.",
+      "contract_oracle": "Compare TRT transcript with reference backend transcript; do not judge model accuracy."
+    },
+    {
+      "id": "probe_08_noisy_48k_stereo_snr20",
+      "file": "probe_08_noisy_48k_stereo_snr20.wav",
+      "sample_rate_hz": 48000,
+      "channels": 2,
+      "duration_s": 4.16,
+      "purpose": "Cover deterministic noisy input handling.",
+      "model_connect_path": "PCM decode + preprocessing under non-clean waveform.",
+      "readiness": "nightly_optional",
+      "notes": "Use only as TRT-vs-reference parity; do not evaluate model noise robustness.",
+      "contract_oracle": "Compare TRT transcript with reference backend transcript; do not judge model accuracy."
+    }
+  ]
+}

--- a/tests/e2e/models/canary-1b-v2-asr-probe01.json
+++ b/tests/e2e/models/canary-1b-v2-asr-probe01.json
@@ -1,0 +1,32 @@
+{
+  "name": "canary-1b-v2-asr-probe01",
+  "trace_id": "IT-E2E-CANRY-ASR-01",
+  "hf_id": "nvidia/canary-1b-v2",
+  "bundle": "canary-1b-v2.trtfb",
+  "family": "canary",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "canary-1b-v2",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 50,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_01_clean_48k_stereo_baseline.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_01_clean_48k_stereo_baseline",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Current smoke input copied as baseline.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: WAV decode + stereo input + model-specific resample."
+}

--- a/tests/e2e/models/canary-1b-v2-asr-probe02.json
+++ b/tests/e2e/models/canary-1b-v2-asr-probe02.json
@@ -1,0 +1,32 @@
+{
+  "name": "canary-1b-v2-asr-probe02",
+  "trace_id": "IT-E2E-CANRY-ASR-02",
+  "hf_id": "nvidia/canary-1b-v2",
+  "bundle": "canary-1b-v2.trtfb",
+  "family": "canary",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "canary-1b-v2",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 50,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_02_clean_16k_mono_no_resample.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_02_clean_16k_mono_no_resample",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover native 16k mono path.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: WAV decode without model-side downmix; should avoid 48k->16k resample in ASR preprocessing."
+}

--- a/tests/e2e/models/canary-1b-v2-asr-probe03.json
+++ b/tests/e2e/models/canary-1b-v2-asr-probe03.json
@@ -1,0 +1,32 @@
+{
+  "name": "canary-1b-v2-asr-probe03",
+  "trace_id": "IT-E2E-CANRY-ASR-03",
+  "hf_id": "nvidia/canary-1b-v2",
+  "bundle": "canary-1b-v2.trtfb",
+  "family": "canary",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "canary-1b-v2",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 50,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_03_clean_48k_mono_resample.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_03_clean_48k_mono_resample",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover mono 48k resample path.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: WAV decode + 48k->16k resample, without stereo downmix."
+}

--- a/tests/e2e/models/canary-1b-v2-asr-probe04.json
+++ b/tests/e2e/models/canary-1b-v2-asr-probe04.json
@@ -1,0 +1,32 @@
+{
+  "name": "canary-1b-v2-asr-probe04",
+  "trace_id": "IT-E2E-CANRY-ASR-04",
+  "hf_id": "nvidia/canary-1b-v2",
+  "bundle": "canary-1b-v2.trtfb",
+  "family": "canary",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "canary-1b-v2",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 50,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_04_clean_48k_stereo_gain_skew.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_04_clean_48k_stereo_gain_skew",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover stereo-to-mono with asymmetric channel levels.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: Stereo downmix should be robust when L/R channels are not identical."
+}

--- a/tests/e2e/models/canary-1b-v2-asr-probe05.json
+++ b/tests/e2e/models/canary-1b-v2-asr-probe05.json
@@ -1,0 +1,32 @@
+{
+  "name": "canary-1b-v2-asr-probe05",
+  "trace_id": "IT-E2E-CANRY-ASR-05",
+  "hf_id": "nvidia/canary-1b-v2",
+  "bundle": "canary-1b-v2.trtfb",
+  "family": "canary",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "canary-1b-v2",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 50,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_05_low_volume_48k_stereo.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_05_low_volume_48k_stereo",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover low-amplitude PCM handling.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: PCM int16 decode + float normalization + ASR preprocessing."
+}

--- a/tests/e2e/models/canary-1b-v2-asr-probe06.json
+++ b/tests/e2e/models/canary-1b-v2-asr-probe06.json
@@ -1,0 +1,32 @@
+{
+  "name": "canary-1b-v2-asr-probe06",
+  "trace_id": "IT-E2E-CANRY-ASR-06",
+  "hf_id": "nvidia/canary-1b-v2",
+  "bundle": "canary-1b-v2.trtfb",
+  "family": "canary",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "canary-1b-v2",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 50,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_06_leading_trailing_silence_48k_stereo.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_06_leading_trailing_silence_48k_stereo",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover non-speech padding around valid speech.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: Longer waveform decode + silence handling + transcript stability."
+}

--- a/tests/e2e/models/canary-1b-v2-asr-probe08.json
+++ b/tests/e2e/models/canary-1b-v2-asr-probe08.json
@@ -1,0 +1,32 @@
+{
+  "name": "canary-1b-v2-asr-probe08",
+  "trace_id": "IT-E2E-CANRY-ASR-08",
+  "hf_id": "nvidia/canary-1b-v2",
+  "bundle": "canary-1b-v2.trtfb",
+  "family": "canary",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "canary-1b-v2",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 50,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_08_noisy_48k_stereo_snr20.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_08_noisy_48k_stereo_snr20",
+  "asr_probe_readiness": "nightly_optional",
+  "asr_probe_purpose": "Cover deterministic noisy input handling.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: PCM decode + preprocessing under non-clean waveform."
+}

--- a/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe01.json
+++ b/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe01.json
@@ -1,0 +1,32 @@
+{
+  "name": "nemotron-speech-streaming-en-0.6b-asr-probe01",
+  "trace_id": "IT-E2E-NEMO-RNNT-ASR-01",
+  "hf_id": "nvidia/nemotron-speech-streaming-en-0.6b",
+  "bundle": "nemotron-speech-streaming-en-0.6b.trtfb",
+  "family": "nemotron_speech_streaming",
+  "runtime_strategy": "speech_to_text_rnnt",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "nemotron-speech-streaming-en-0.6b",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 80,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_01_clean_48k_stereo_baseline.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_01_clean_48k_stereo_baseline",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Current smoke input copied as baseline.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: WAV decode + stereo input + model-specific resample."
+}

--- a/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe02.json
+++ b/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe02.json
@@ -1,0 +1,32 @@
+{
+  "name": "nemotron-speech-streaming-en-0.6b-asr-probe02",
+  "trace_id": "IT-E2E-NEMO-RNNT-ASR-02",
+  "hf_id": "nvidia/nemotron-speech-streaming-en-0.6b",
+  "bundle": "nemotron-speech-streaming-en-0.6b.trtfb",
+  "family": "nemotron_speech_streaming",
+  "runtime_strategy": "speech_to_text_rnnt",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "nemotron-speech-streaming-en-0.6b",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 80,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_02_clean_16k_mono_no_resample.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_02_clean_16k_mono_no_resample",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover native 16k mono path.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: WAV decode without model-side downmix; should avoid 48k->16k resample in ASR preprocessing."
+}

--- a/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe03.json
+++ b/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe03.json
@@ -1,0 +1,32 @@
+{
+  "name": "nemotron-speech-streaming-en-0.6b-asr-probe03",
+  "trace_id": "IT-E2E-NEMO-RNNT-ASR-03",
+  "hf_id": "nvidia/nemotron-speech-streaming-en-0.6b",
+  "bundle": "nemotron-speech-streaming-en-0.6b.trtfb",
+  "family": "nemotron_speech_streaming",
+  "runtime_strategy": "speech_to_text_rnnt",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "nemotron-speech-streaming-en-0.6b",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 80,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_03_clean_48k_mono_resample.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_03_clean_48k_mono_resample",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover mono 48k resample path.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: WAV decode + 48k->16k resample, without stereo downmix."
+}

--- a/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe04.json
+++ b/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe04.json
@@ -1,0 +1,32 @@
+{
+  "name": "nemotron-speech-streaming-en-0.6b-asr-probe04",
+  "trace_id": "IT-E2E-NEMO-RNNT-ASR-04",
+  "hf_id": "nvidia/nemotron-speech-streaming-en-0.6b",
+  "bundle": "nemotron-speech-streaming-en-0.6b.trtfb",
+  "family": "nemotron_speech_streaming",
+  "runtime_strategy": "speech_to_text_rnnt",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "nemotron-speech-streaming-en-0.6b",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 80,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_04_clean_48k_stereo_gain_skew.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_04_clean_48k_stereo_gain_skew",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover stereo-to-mono with asymmetric channel levels.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: Stereo downmix should be robust when L/R channels are not identical."
+}

--- a/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe05.json
+++ b/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe05.json
@@ -1,0 +1,32 @@
+{
+  "name": "nemotron-speech-streaming-en-0.6b-asr-probe05",
+  "trace_id": "IT-E2E-NEMO-RNNT-ASR-05",
+  "hf_id": "nvidia/nemotron-speech-streaming-en-0.6b",
+  "bundle": "nemotron-speech-streaming-en-0.6b.trtfb",
+  "family": "nemotron_speech_streaming",
+  "runtime_strategy": "speech_to_text_rnnt",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "nemotron-speech-streaming-en-0.6b",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 80,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_05_low_volume_48k_stereo.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_05_low_volume_48k_stereo",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover low-amplitude PCM handling.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: PCM int16 decode + float normalization + ASR preprocessing."
+}

--- a/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe06.json
+++ b/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe06.json
@@ -1,0 +1,32 @@
+{
+  "name": "nemotron-speech-streaming-en-0.6b-asr-probe06",
+  "trace_id": "IT-E2E-NEMO-RNNT-ASR-06",
+  "hf_id": "nvidia/nemotron-speech-streaming-en-0.6b",
+  "bundle": "nemotron-speech-streaming-en-0.6b.trtfb",
+  "family": "nemotron_speech_streaming",
+  "runtime_strategy": "speech_to_text_rnnt",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "nemotron-speech-streaming-en-0.6b",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 80,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_06_leading_trailing_silence_48k_stereo.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_06_leading_trailing_silence_48k_stereo",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover non-speech padding around valid speech.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: Longer waveform decode + silence handling + transcript stability."
+}

--- a/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe08.json
+++ b/tests/e2e/models/nemotron-speech-streaming-en-0.6b-asr-probe08.json
@@ -1,0 +1,32 @@
+{
+  "name": "nemotron-speech-streaming-en-0.6b-asr-probe08",
+  "trace_id": "IT-E2E-NEMO-RNNT-ASR-08",
+  "hf_id": "nvidia/nemotron-speech-streaming-en-0.6b",
+  "bundle": "nemotron-speech-streaming-en-0.6b.trtfb",
+  "family": "nemotron_speech_streaming",
+  "runtime_strategy": "speech_to_text_rnnt",
+  "reference_family": "asr_canary",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "nemotron-speech-streaming-en-0.6b",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 128,
+  "prompt": "test",
+  "max_new_tokens": 80,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_08_noisy_48k_stereo_snr20.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_08_noisy_48k_stereo_snr20",
+  "asr_probe_readiness": "nightly_optional",
+  "asr_probe_purpose": "Cover deterministic noisy input handling.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: PCM decode + preprocessing under non-clean waveform."
+}

--- a/tests/e2e/models/whisper-large-v3-turbo-asr-probe01.json
+++ b/tests/e2e/models/whisper-large-v3-turbo-asr-probe01.json
@@ -1,0 +1,32 @@
+{
+  "name": "whisper-large-v3-turbo-asr-probe01",
+  "trace_id": "IT-E2E-WHSPL-ASR-01",
+  "hf_id": "openai/whisper-large-v3-turbo",
+  "bundle": "whisper-large-v3-turbo.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-large-v3-turbo",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_01_clean_48k_stereo_baseline.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_01_clean_48k_stereo_baseline",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Current smoke input copied as baseline.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: WAV decode + stereo input + model-specific resample."
+}

--- a/tests/e2e/models/whisper-large-v3-turbo-asr-probe02.json
+++ b/tests/e2e/models/whisper-large-v3-turbo-asr-probe02.json
@@ -1,0 +1,32 @@
+{
+  "name": "whisper-large-v3-turbo-asr-probe02",
+  "trace_id": "IT-E2E-WHSPL-ASR-02",
+  "hf_id": "openai/whisper-large-v3-turbo",
+  "bundle": "whisper-large-v3-turbo.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-large-v3-turbo",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_02_clean_16k_mono_no_resample.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_02_clean_16k_mono_no_resample",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover native 16k mono path.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: WAV decode without model-side downmix; should avoid 48k->16k resample in ASR preprocessing."
+}

--- a/tests/e2e/models/whisper-large-v3-turbo-asr-probe03.json
+++ b/tests/e2e/models/whisper-large-v3-turbo-asr-probe03.json
@@ -1,0 +1,32 @@
+{
+  "name": "whisper-large-v3-turbo-asr-probe03",
+  "trace_id": "IT-E2E-WHSPL-ASR-03",
+  "hf_id": "openai/whisper-large-v3-turbo",
+  "bundle": "whisper-large-v3-turbo.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-large-v3-turbo",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_03_clean_48k_mono_resample.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_03_clean_48k_mono_resample",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover mono 48k resample path.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: WAV decode + 48k->16k resample, without stereo downmix."
+}

--- a/tests/e2e/models/whisper-large-v3-turbo-asr-probe04.json
+++ b/tests/e2e/models/whisper-large-v3-turbo-asr-probe04.json
@@ -1,0 +1,32 @@
+{
+  "name": "whisper-large-v3-turbo-asr-probe04",
+  "trace_id": "IT-E2E-WHSPL-ASR-04",
+  "hf_id": "openai/whisper-large-v3-turbo",
+  "bundle": "whisper-large-v3-turbo.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-large-v3-turbo",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_04_clean_48k_stereo_gain_skew.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_04_clean_48k_stereo_gain_skew",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover stereo-to-mono with asymmetric channel levels.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: Stereo downmix should be robust when L/R channels are not identical."
+}

--- a/tests/e2e/models/whisper-large-v3-turbo-asr-probe05.json
+++ b/tests/e2e/models/whisper-large-v3-turbo-asr-probe05.json
@@ -1,0 +1,32 @@
+{
+  "name": "whisper-large-v3-turbo-asr-probe05",
+  "trace_id": "IT-E2E-WHSPL-ASR-05",
+  "hf_id": "openai/whisper-large-v3-turbo",
+  "bundle": "whisper-large-v3-turbo.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-large-v3-turbo",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_05_low_volume_48k_stereo.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_05_low_volume_48k_stereo",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover low-amplitude PCM handling.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: PCM int16 decode + float normalization + ASR preprocessing."
+}

--- a/tests/e2e/models/whisper-large-v3-turbo-asr-probe06.json
+++ b/tests/e2e/models/whisper-large-v3-turbo-asr-probe06.json
@@ -1,0 +1,32 @@
+{
+  "name": "whisper-large-v3-turbo-asr-probe06",
+  "trace_id": "IT-E2E-WHSPL-ASR-06",
+  "hf_id": "openai/whisper-large-v3-turbo",
+  "bundle": "whisper-large-v3-turbo.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-large-v3-turbo",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_06_leading_trailing_silence_48k_stereo.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_06_leading_trailing_silence_48k_stereo",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover non-speech padding around valid speech.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: Longer waveform decode + silence handling + transcript stability."
+}

--- a/tests/e2e/models/whisper-large-v3-turbo-asr-probe08.json
+++ b/tests/e2e/models/whisper-large-v3-turbo-asr-probe08.json
@@ -1,0 +1,32 @@
+{
+  "name": "whisper-large-v3-turbo-asr-probe08",
+  "trace_id": "IT-E2E-WHSPL-ASR-08",
+  "hf_id": "openai/whisper-large-v3-turbo",
+  "bundle": "whisper-large-v3-turbo.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-large-v3-turbo",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_08_noisy_48k_stereo_snr20.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_08_noisy_48k_stereo_snr20",
+  "asr_probe_readiness": "nightly_optional",
+  "asr_probe_purpose": "Cover deterministic noisy input handling.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: PCM decode + preprocessing under non-clean waveform."
+}

--- a/tests/e2e/models/whisper-tiny-fp16-asr-probe01.json
+++ b/tests/e2e/models/whisper-tiny-fp16-asr-probe01.json
@@ -1,0 +1,33 @@
+{
+  "name": "whisper-tiny-fp16-asr-probe01",
+  "trace_id": "IT-E2E-WHSPT-FP16-ASR-01",
+  "hf_id": "openai/whisper-tiny",
+  "bundle": "whisper-tiny-fp16.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-tiny-fp16",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_01_clean_48k_stereo_baseline.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_01_clean_48k_stereo_baseline",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Current smoke input copied as baseline.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: WAV decode + stereo input + model-specific resample.",
+  "precision": "fp16"
+}

--- a/tests/e2e/models/whisper-tiny-fp16-asr-probe02.json
+++ b/tests/e2e/models/whisper-tiny-fp16-asr-probe02.json
@@ -1,0 +1,33 @@
+{
+  "name": "whisper-tiny-fp16-asr-probe02",
+  "trace_id": "IT-E2E-WHSPT-FP16-ASR-02",
+  "hf_id": "openai/whisper-tiny",
+  "bundle": "whisper-tiny-fp16.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-tiny-fp16",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_02_clean_16k_mono_no_resample.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_02_clean_16k_mono_no_resample",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover native 16k mono path.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: WAV decode without model-side downmix; should avoid 48k->16k resample in ASR preprocessing.",
+  "precision": "fp16"
+}

--- a/tests/e2e/models/whisper-tiny-fp16-asr-probe03.json
+++ b/tests/e2e/models/whisper-tiny-fp16-asr-probe03.json
@@ -1,0 +1,33 @@
+{
+  "name": "whisper-tiny-fp16-asr-probe03",
+  "trace_id": "IT-E2E-WHSPT-FP16-ASR-03",
+  "hf_id": "openai/whisper-tiny",
+  "bundle": "whisper-tiny-fp16.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-tiny-fp16",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_03_clean_48k_mono_resample.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_03_clean_48k_mono_resample",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover mono 48k resample path.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: WAV decode + 48k->16k resample, without stereo downmix.",
+  "precision": "fp16"
+}

--- a/tests/e2e/models/whisper-tiny-fp16-asr-probe04.json
+++ b/tests/e2e/models/whisper-tiny-fp16-asr-probe04.json
@@ -1,0 +1,33 @@
+{
+  "name": "whisper-tiny-fp16-asr-probe04",
+  "trace_id": "IT-E2E-WHSPT-FP16-ASR-04",
+  "hf_id": "openai/whisper-tiny",
+  "bundle": "whisper-tiny-fp16.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-tiny-fp16",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_04_clean_48k_stereo_gain_skew.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_04_clean_48k_stereo_gain_skew",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover stereo-to-mono with asymmetric channel levels.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: Stereo downmix should be robust when L/R channels are not identical.",
+  "precision": "fp16"
+}

--- a/tests/e2e/models/whisper-tiny-fp16-asr-probe05.json
+++ b/tests/e2e/models/whisper-tiny-fp16-asr-probe05.json
@@ -1,0 +1,33 @@
+{
+  "name": "whisper-tiny-fp16-asr-probe05",
+  "trace_id": "IT-E2E-WHSPT-FP16-ASR-05",
+  "hf_id": "openai/whisper-tiny",
+  "bundle": "whisper-tiny-fp16.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-tiny-fp16",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_05_low_volume_48k_stereo.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_05_low_volume_48k_stereo",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover low-amplitude PCM handling.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: PCM int16 decode + float normalization + ASR preprocessing.",
+  "precision": "fp16"
+}

--- a/tests/e2e/models/whisper-tiny-fp16-asr-probe06.json
+++ b/tests/e2e/models/whisper-tiny-fp16-asr-probe06.json
@@ -1,0 +1,33 @@
+{
+  "name": "whisper-tiny-fp16-asr-probe06",
+  "trace_id": "IT-E2E-WHSPT-FP16-ASR-06",
+  "hf_id": "openai/whisper-tiny",
+  "bundle": "whisper-tiny-fp16.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-tiny-fp16",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_06_leading_trailing_silence_48k_stereo.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_06_leading_trailing_silence_48k_stereo",
+  "asr_probe_readiness": "ready_now",
+  "asr_probe_purpose": "Cover non-speech padding around valid speech.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: Longer waveform decode + silence handling + transcript stability.",
+  "precision": "fp16"
+}

--- a/tests/e2e/models/whisper-tiny-fp16-asr-probe08.json
+++ b/tests/e2e/models/whisper-tiny-fp16-asr-probe08.json
@@ -1,0 +1,33 @@
+{
+  "name": "whisper-tiny-fp16-asr-probe08",
+  "trace_id": "IT-E2E-WHSPT-FP16-ASR-08",
+  "hf_id": "openai/whisper-tiny",
+  "bundle": "whisper-tiny-fp16.trtfb",
+  "family": "whisper",
+  "runtime_strategy": "speech_to_text",
+  "reference_family": "asr_whisper",
+  "user_contract": "exact_transcript",
+  "test_type": "transcription",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "whisper-tiny-fp16",
+  "l0_replacement_reason": "ASR probe matrix runs in nightly; PR L0 uses the base ASR model for the same runtime path.",
+  "max_cache_length": 64,
+  "prompt": "test",
+  "max_new_tokens": 100,
+  "logit_atol": 0.01,
+  "layer_atol": 0.1,
+  "trust_remote_code": false,
+  "test_input_audio": "data/asr_probes/probe_08_noisy_48k_stereo_snr20.wav",
+  "threshold_overrides": {
+    "contract_ned_threshold": 0.1,
+    "contract_wer_threshold": 0.1,
+    "contract_cer_threshold": 0.1,
+    "wer": 0.1,
+    "cer": 0.1
+  },
+  "asr_probe_id": "probe_08_noisy_48k_stereo_snr20",
+  "asr_probe_readiness": "nightly_optional",
+  "asr_probe_purpose": "Cover deterministic noisy input handling.",
+  "notes": "Nightly ASR coverage probe for Model Connect input handling: PCM decode + preprocessing under non-clean waveform.",
+  "precision": "fp16"
+}

--- a/tests/e2e/test_full_pipeline.py
+++ b/tests/e2e/test_full_pipeline.py
@@ -40,6 +40,12 @@ import pytest
 PROJECT_DIR = Path(__file__).resolve().parents[2]
 TOOLS_DIR = PROJECT_DIR / "tools"
 
+_SPEECH_RUNTIME_STRATEGIES = {
+    "speech_to_text",
+    "speech_to_text_rnnt",
+    "speech_to_speech",
+}
+
 # Ensure tools/ is importable for compare_logits, run_hf, etc.
 if str(TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(TOOLS_DIR))
@@ -277,7 +283,12 @@ def test_full_pipeline(built_bundle, trtmc_binary, hf_python, ld_library_path):
         pytest.skip("Segmentation model — use test_segmentation_pipeline")
 
     # Skip audio models (handled by test_audio_pipeline)
-    if entry.get("test_type") == "audio" or entry.get("runtime_strategy") == "text_to_audio":
+    if (
+        entry.get("test_type") == "audio"
+        or entry.get("test_type") == "transcription"
+        or entry.get("runtime_strategy") == "text_to_audio"
+        or entry.get("runtime_strategy") in _SPEECH_RUNTIME_STRATEGIES
+    ):
         pytest.skip("Audio model — use test_audio_pipeline")
 
     # Skip gated models (require HF auth for diff_logits)

--- a/tests/e2e/test_inference.py
+++ b/tests/e2e/test_inference.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 import subprocess
 import pytest
 
+_SPEECH_RUNTIME_STRATEGIES = {
+    "speech_to_text",
+    "speech_to_text_rnnt",
+    "speech_to_speech",
+}
+
 
 @pytest.mark.e2e
 def test_inference_produces_text(model_entry, trtmc_binary, hf_python, ld_library_path):
@@ -15,6 +21,11 @@ def test_inference_produces_text(model_entry, trtmc_binary, hf_python, ld_librar
         pytest.skip("Segmentation model — use test_segmentation_pipeline")
     if model_entry.get("test_type") == "audio":
         pytest.skip("Audio model — use test_audio_pipeline")
+    if (
+        model_entry.get("test_type") == "transcription"
+        or model_entry.get("runtime_strategy") in _SPEECH_RUNTIME_STRATEGIES
+    ):
+        pytest.skip("Speech model — use speech/audio pipeline tests")
     prompt = model_entry.get("prompt", "Hello")
     max_new = model_entry.get("max_new_tokens", 10)
 
@@ -40,6 +51,11 @@ def test_inference_deterministic(model_entry, trtmc_binary, hf_python, ld_librar
         pytest.skip("Segmentation model — use test_segmentation_pipeline")
     if model_entry.get("test_type") == "audio":
         pytest.skip("Audio model — use test_audio_pipeline")
+    if (
+        model_entry.get("test_type") == "transcription"
+        or model_entry.get("runtime_strategy") in _SPEECH_RUNTIME_STRATEGIES
+    ):
+        pytest.skip("Speech model — use speech/audio pipeline tests")
     prompt = model_entry.get("prompt", "Hello")
     max_new = min(model_entry.get("max_new_tokens", 10), 5)
 

--- a/tests/e2e/test_logit_parity.py
+++ b/tests/e2e/test_logit_parity.py
@@ -10,6 +10,12 @@ import pytest
 
 PROJECT_DIR = Path(__file__).resolve().parents[2]
 
+_SPEECH_RUNTIME_STRATEGIES = {
+    "speech_to_text",
+    "speech_to_text_rnnt",
+    "speech_to_speech",
+}
+
 
 @pytest.mark.e2e
 def test_logit_parity(model_entry):
@@ -20,6 +26,11 @@ def test_logit_parity(model_entry):
         pytest.skip("Segmentation model — use test_segmentation_pipeline")
     if model_entry.get("test_type") == "audio":
         pytest.skip("Audio model — use test_audio_pipeline")
+    if (
+        model_entry.get("test_type") == "transcription"
+        or model_entry.get("runtime_strategy") in _SPEECH_RUNTIME_STRATEGIES
+    ):
+        pytest.skip("Speech model — no text logit parity")
     if model_entry.get("runtime_strategy") == "vision_language":
         pytest.skip("VL model — diff_logits requires decoder-only models")
     if model_entry.get("skip_logit_parity"):

--- a/tests/e2e/test_runner_parity.py
+++ b/tests/e2e/test_runner_parity.py
@@ -10,6 +10,12 @@ import pytest
 
 PROJECT_DIR = Path(__file__).resolve().parents[2]
 
+_SPEECH_RUNTIME_STRATEGIES = {
+    "speech_to_text",
+    "speech_to_text_rnnt",
+    "speech_to_speech",
+}
+
 
 @pytest.mark.e2e
 def test_runner_parity(model_entry, trtmc_binary, hf_python, ld_library_path):
@@ -20,6 +26,11 @@ def test_runner_parity(model_entry, trtmc_binary, hf_python, ld_library_path):
         pytest.skip("Segmentation model — no text runner parity")
     if model_entry.get("test_type") == "audio":
         pytest.skip("Audio model — no text runner parity")
+    if (
+        model_entry.get("test_type") == "transcription"
+        or model_entry.get("runtime_strategy") in _SPEECH_RUNTIME_STRATEGIES
+    ):
+        pytest.skip("Speech model — no text runner parity")
     max_new = min(model_entry.get("max_new_tokens", 20), 20)
 
     parity_script = PROJECT_DIR / "tools" / "test_runner_parity.py"

--- a/tests/e2e/waives.txt
+++ b/tests/e2e/waives.txt
@@ -8,3 +8,5 @@ internlm2-1.8b           SKIP   (DynamicCache.from_legacy_cache removed in trans
 phi4-multimodal           SKIP   (phi4-multimodal remote code incompatible with transformers 5.x)
 eagle-embed-vl-1b-v2     SKIP   (HF repo 404)
 eagle-rerank-vl-1b-v2    SKIP   (HF repo 404)
+canary-1b-v2-asr-probe05 XFAIL  (ASR probe low-volume parity gap: TRT transcript diverges from NeMo reference)
+canary-1b-v2-asr-probe06 XFAIL  (ASR probe silence-padding parity gap: TRT transcript diverges from NeMo reference)

--- a/tests/e2e_harness/orchestrator.py
+++ b/tests/e2e_harness/orchestrator.py
@@ -160,9 +160,14 @@ def _check_asset_exists(ctx: RunContext, req: PreflightRequirement) -> tuple[boo
         if candidate.is_file():
             p = candidate
         else:
-            # Fallback: try e2e data dir with just the filename
-            e2e_data = project_root / "tests" / "e2e" / "data"
-            p = e2e_data / Path(asset_path).name
+            e2e_dir = project_root / "tests" / "e2e"
+            candidate = e2e_dir / asset_path
+            if candidate.is_file():
+                p = candidate
+            else:
+                # Backward-compatible fallback for older manifests that
+                # provided bare filenames for assets under tests/e2e/data/.
+                p = e2e_dir / "data" / Path(asset_path).name
     if p.is_file():
         return True, f"Asset found: {p}"
     return False, f"Asset not found: {p}"

--- a/tests/e2e_harness/plugins/asr.py
+++ b/tests/e2e_harness/plugins/asr.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import re
 
-from ..contracts import (CompareResult, E2ECase, MetricResult, StageOutput, ThresholdProfile)
+from ..contracts import MetricResult
 from .base import (normalize_text, levenshtein_ned, make_pass, make_fail, make_error)
 
 _NO_SPEECH_STATE_VALUE = {

--- a/tests/e2e_harness/plugins/asr.py
+++ b/tests/e2e_harness/plugins/asr.py
@@ -1,23 +1,100 @@
 """Contract test plugin for ASR models (Whisper, Canary)."""
 from __future__ import annotations
+
+import re
+
 from ..contracts import (CompareResult, E2ECase, MetricResult, StageOutput, ThresholdProfile)
 from .base import (normalize_text, levenshtein_ned, make_pass, make_fail, make_error)
+
+_NO_SPEECH_STATE_VALUE = {
+    "speech": 0.0,
+    "empty": 1.0,
+    "blank_audio_token": 2.0,
+}
+
+
+def _edit_breakdown(ref_items, hyp_items):
+    """Edit operation counts from reference to hypothesis."""
+    rows = len(ref_items) + 1
+    cols = len(hyp_items) + 1
+    dp = [[0] * cols for _ in range(rows)]
+    for i in range(1, rows):
+        dp[i][0] = i
+    for j in range(1, cols):
+        dp[0][j] = j
+
+    for i in range(1, rows):
+        for j in range(1, cols):
+            sub_cost = 0 if ref_items[i - 1] == hyp_items[j - 1] else 1
+            dp[i][j] = min(
+                dp[i - 1][j - 1] + sub_cost,
+                dp[i - 1][j] + 1,
+                dp[i][j - 1] + 1,
+            )
+
+    i = len(ref_items)
+    j = len(hyp_items)
+    matches = substitutions = insertions = deletions = 0
+    while i > 0 or j > 0:
+        if i > 0 and j > 0 and ref_items[i - 1] == hyp_items[j - 1] and dp[i][j] == dp[i - 1][j - 1]:
+            matches += 1
+            i -= 1
+            j -= 1
+        elif i > 0 and j > 0 and dp[i][j] == dp[i - 1][j - 1] + 1:
+            substitutions += 1
+            i -= 1
+            j -= 1
+        elif i > 0 and dp[i][j] == dp[i - 1][j] + 1:
+            deletions += 1
+            i -= 1
+        else:
+            insertions += 1
+            j -= 1
+
+    return {
+        "matches": matches,
+        "substitutions": substitutions,
+        "insertions": insertions,
+        "deletions": deletions,
+    }
+
 
 def _word_error_rate(ref_words, hyp_words):
     """WER via Levenshtein on word sequences."""
     if not ref_words:
         return 0.0 if not hyp_words else 1.0
-    n, m = len(ref_words), len(hyp_words)
-    dp = list(range(m + 1))
-    for i in range(1, n + 1):
-        prev, dp[0] = dp[0], i
-        for j in range(1, m + 1):
-            ins = dp[j] + 1
-            dele = dp[j - 1] + 1
-            sub = prev + (0 if ref_words[i - 1] == hyp_words[j - 1] else 1)
-            prev = dp[j]
-            dp[j] = min(ins, dele, sub)
-    return dp[m] / n
+    breakdown = _edit_breakdown(ref_words, hyp_words)
+    errors = breakdown["substitutions"] + breakdown["insertions"] + breakdown["deletions"]
+    return errors / len(ref_words)
+
+
+def _wer_words(text):
+    """Words for ASR WER, ignoring edge punctuation around spoken tokens."""
+    words = []
+    for word in str(text or "").split():
+        stripped = re.sub(r"^[^\w]+|[^\w]+$", "", word).lower()
+        if stripped:
+            words.append(stripped)
+    return words
+
+
+def _character_error_rate(ref_text, hyp_text):
+    """CER via Levenshtein on normalized transcript characters."""
+    if not ref_text:
+        return 0.0 if not hyp_text else 1.0
+    breakdown = _edit_breakdown(list(ref_text), list(hyp_text))
+    errors = breakdown["substitutions"] + breakdown["insertions"] + breakdown["deletions"]
+    return errors / len(ref_text)
+
+
+def _no_speech_state(text):
+    stripped = str(text or "").strip()
+    if not stripped:
+        return "empty"
+    if re.fullmatch(r"\[?\s*blank[\s_-]*audio\s*\]?", stripped, flags=re.IGNORECASE):
+        return "blank_audio_token"
+    return "speech"
+
 
 class ASRPlugin:
     reference_families = ["asr_whisper", "asr_canary"]
@@ -29,30 +106,79 @@ class ASRPlugin:
         return {"auto_class": "AutoModelForSpeechSeq2Seq"}
 
     def verify(self, trt_output, ref_output, case, threshold):
-        trt_text = normalize_text(trt_output.data.get("transcript", trt_output.text or ""))
-        ref_text = normalize_text(ref_output.data.get("transcript", ref_output.text or ""))
+        raw_trt_text = trt_output.data.get("transcript", trt_output.text or "")
+        raw_ref_text = ref_output.data.get("transcript", ref_output.text or "")
+        trt_no_speech_state = _no_speech_state(raw_trt_text)
+        ref_no_speech_state = _no_speech_state(raw_ref_text)
+        no_speech_state_match = trt_no_speech_state == ref_no_speech_state
+
+        trt_text = normalize_text(raw_trt_text)
+        ref_text = normalize_text(raw_ref_text)
 
         if not ref_text:
             return make_error("full_generation", "Reference produced empty transcript")
 
         ned = levenshtein_ned(trt_text, ref_text)
 
-        trt_words = trt_text.split()
-        ref_words = ref_text.split()
+        trt_words = _wer_words(trt_text)
+        ref_words = _wer_words(ref_text)
         wer = _word_error_rate(ref_words, trt_words)
+        wer_breakdown = _edit_breakdown(ref_words, trt_words)
+        cer = _character_error_rate(ref_text, trt_text)
 
-        ned_threshold = threshold.metrics.get("contract_ned_threshold", 0.1)
-        wer_threshold = threshold.metrics.get("contract_wer_threshold", 0.1)
+        ned_threshold = threshold.metrics.get(
+            "contract_ned_threshold",
+            threshold.metrics.get("normalized_text_edit_distance", 0.1),
+        )
+        wer_threshold = threshold.metrics.get(
+            "contract_wer_threshold",
+            threshold.metrics.get("wer", 0.1),
+        )
+        cer_threshold = threshold.metrics.get(
+            "contract_cer_threshold",
+            threshold.metrics.get("cer", 0.1),
+        )
 
         metrics = {
             "ned": MetricResult(value=ned, threshold=ned_threshold, operator="<=", passed=ned <= ned_threshold),
             "wer": MetricResult(value=wer, threshold=wer_threshold, operator="<=", passed=wer <= wer_threshold),
+            "cer": MetricResult(
+                value=cer,
+                threshold=cer_threshold,
+                operator="<=",
+                passed=cer <= cer_threshold,
+                note="ASR-specific informational metric; not part of composite gate yet",
+            ),
+            "wer_substitutions": MetricResult(
+                value=float(wer_breakdown["substitutions"]),
+                note="ASR-specific informational WER breakdown",
+            ),
+            "wer_insertions": MetricResult(
+                value=float(wer_breakdown["insertions"]),
+                note="ASR-specific informational WER breakdown",
+            ),
+            "wer_deletions": MetricResult(
+                value=float(wer_breakdown["deletions"]),
+                note="ASR-specific informational WER breakdown",
+            ),
+            "trt_no_speech_state": MetricResult(
+                value=_NO_SPEECH_STATE_VALUE[trt_no_speech_state],
+                note=f"0=speech, 1=empty, 2=blank_audio_token; observed={trt_no_speech_state}",
+            ),
+            "reference_no_speech_state": MetricResult(
+                value=_NO_SPEECH_STATE_VALUE[ref_no_speech_state],
+                note=f"0=speech, 1=empty, 2=blank_audio_token; observed={ref_no_speech_state}",
+            ),
+            "no_speech_state_match": MetricResult(
+                value=1.0 if no_speech_state_match else 0.0,
+                note="Informational only; gate after silence/blank-audio user contract is agreed",
+            ),
         }
 
         passed = ned <= ned_threshold and wer <= wer_threshold
         rule = "ned <= threshold AND wer <= threshold"
         if passed:
             return make_pass("full_generation", metrics, rule)
-        return make_fail("full_generation", metrics, rule, f"Transcript diverged: WER={wer:.3f} NED={ned:.3f}")
+        return make_fail("full_generation", metrics, rule, f"Transcript diverged: WER={wer:.3f} NED={ned:.3f} CER={cer:.3f}")
 
 plugin = ASRPlugin()

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -795,6 +795,20 @@ class TestE2EDataFiles:
         assert match.rule == "e2e_data_file"
         assert match.models == ["qwen25vl-3b"]
 
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tests/e2e/data/asr_probes/manifest.json",
+            "tests/e2e/data/asr_probes/generate_asr_probe_inputs.py",
+        ],
+    )
+    def test_asr_probe_support_files_select_asr(self, imap, path):
+        """ASR probe support files should stay scoped to speech-to-text."""
+        match = test_impact.classify_file(path, imap)
+        assert match.rule == "asr_probe_data"
+        assert "whisper-tiny-fp16" in match.models
+        assert "qwen3-0.6b" not in match.models
+
 
 # ---------------------------------------------------------------------------
 # Unit tier tests

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1416,6 +1416,16 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             covered_by=("TestE2EDataFiles.test_data_file_maps_to_manifest_users",),
         ),
         ClassificationRule(
+            priority=475,
+            name="asr_probe_data",
+            matcher=_regex_rule(r"tests/e2e/data/asr_probes/.+$"),
+            resolver=_match_result(
+                "asr_probe_data",
+                _task_strategy_models(["speech_to_text"]),
+            ),
+            covered_by=("TestE2EDataFiles.test_asr_probe_support_files_select_asr",),
+        ),
+        ClassificationRule(
             priority=480,
             name="fp8_gen_script",
             matcher=_path_equals("scripts/_gen_fp8_bf16.py"),

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -176,6 +176,7 @@ COMPARATOR_TASK_STRATEGIES: Dict[str, List[str]] = {
 
 # E2E contract plugin filename (stem) -> task_strategies
 PLUGIN_TASK_STRATEGIES: Dict[str, List[str]] = {
+    "asr": ["speech_to_text"],
     "diffusion": ["diffusion_media_generation"],
     "vl_qa": ["vision_language_generation"],
     "multimodal_chat": ["omni_multimodal"],


### PR DESCRIPTION
## What changed

  This PR expands nightly ASR coverage for Model Connect by adding generated ASR probe inputs and model manifests across 4 speech-to-text models:

  - `canary-1b-v2`
  - `nemotron-speech-streaming-en-0.6b`
  - `whisper-large-v3-turbo`
  - `whisper-tiny-fp16`

  Each model now runs 7 nightly-only ASR probe cases covering:

  - clean 48 kHz stereo baseline
  - clean 16 kHz mono input
  - clean 48 kHz mono resampling path
  - stereo gain/channel skew
  - low-volume speech
  - leading/trailing silence
  - noisy speech at SNR 20

  This adds 28 new nightly ASR probe manifests in total.

  ## Why

  The goal is to validate Model Connect’s ASR input/output handling more broadly, not to test model quality itself.

  These probes exercise common speech-to-text integration paths such as audio format handling, resampling, channel layout, volume sensitivity, silence handling, and noisy input behavior.

  ## Verifier updates

  The ASR verifier now reports additional ASR-specific diagnostics:

  - normalized edit distance
  - WER
  - CER
  - WER substitution / insertion / deletion breakdown
  - no-speech state comparison between TRT output and reference output

  The pass/fail gate remains aligned with the existing user contract behavior. New metrics are reported for debugging and coverage visibility.

  ## Harness updates

  - Fixed E2E asset lookup so probe inputs under `tests/e2e/data/asr_probes` are resolved correctly.
  - Added ASR skip guards for legacy text/logit/runner parity tests that do not apply to speech-to-text manifests.
  - Added ASR plugin impact mapping for nightly speech-to-text coverage.

  ## Expected failures

  Two Canary probe cases are currently marked XFAIL:

  - `canary-1b-v2-asr-probe05`
  - `canary-1b-v2-asr-probe06`

  These represent known ASR parity gaps for low-volume and silence-padding inputs.

  ## Validation

  - Python compile check for touched Python files
  - JSON parse check for ASR probe manifest and 28 model manifests
  - Manifest loader check: 28 nightly ASR probe cases, no `probe07`
  - `tools/test_impact.py --validate`
  - ASR GPU E2E before removing `probe07`: 33 passed, 3 xfailed, 0 failed