### PR TITLE
fix(tests): drop unsettable INormalizationLayer.compute_precision (TRT 11)

### DIFF
--- a/tests/builder/test_graph_ops_native_attn.py
+++ b/tests/builder/test_graph_ops_native_attn.py
@@ -147,13 +147,14 @@ class TestAddLayerNormNative:
         eps = 1e-5
 
         def build(network, trt_inputs):
-            import tensorrt as trt
             gamma_t = graph_ops.add_constant(network, (1, hidden_size), gamma)
             beta_t = graph_ops.add_constant(network, (1, hidden_size), beta)
             norm = network.add_normalization_v2(
                 trt_inputs["x"], gamma_t, beta_t, 1 << 1)
             norm.epsilon = eps
-            norm.compute_precision = trt.float32
+            # Strongly-typed network: normalization compute precision is inferred,
+            # not set (the INormalizationLayer.compute_precision setter was removed
+            # in TRT 11); this fp32 graph already normalizes in fp32.
             return {"out": norm.get_output(0)}
 
         out = _run_strongly_typed(build, {"x": x})["out"]
@@ -173,13 +174,14 @@ class TestAddLayerNormNative:
         eps = 1e-5
 
         def build(network, trt_inputs):
-            import tensorrt as trt
             gamma_t = graph_ops.add_constant(network, (1, H), gamma)
             beta_t = graph_ops.add_constant(network, (1, H), beta)
             norm = network.add_normalization_v2(
                 trt_inputs["x"], gamma_t, beta_t, 1 << 1)
             norm.epsilon = eps
-            norm.compute_precision = trt.float32
+            # Strongly-typed network: normalization compute precision is inferred,
+            # not set (the INormalizationLayer.compute_precision setter was removed
+            # in TRT 11); this fp32 graph already normalizes in fp32.
             return {"out": norm.get_output(0)}
 
         out = _run_strongly_typed(build, {"x": x})["out"]


### PR DESCRIPTION
## What

`tests/builder/test_graph_ops_native_attn.py` builds **`STRONGLY_TYPED`** TRT
networks (via its `_run_strongly_typed` helper), then in two `build()` closures does:
```python
norm = network.add_normalization_v2(...)
norm.epsilon = eps
norm.compute_precision = trt.float32
```
In a strongly-typed network TRT **infers** compute precision, and the
`INormalizationLayer.compute_precision` **setter was removed in TRT 11**. On
TRT-11 runners that line raises:
```
AttributeError: 'INormalizationLayer' object has no attribute 'compute_precision'
tests/builder/test_graph_ops_native_attn.py:156: AttributeError
```
failing the `TestAddLayerNormNative` tests. The set is **redundant** (the fp32
strongly-typed graph already normalizes in fp32), so this drops it (and the
now-unused `import tensorrt as trt` in those closures).

This is the same class of fix as #237 (which removed `tensor.dtype = trt.float32`
from the strongly-typed graph-op conftest helper).

## Why it surfaced now
The runner pool is migrating to **TRT 11** (`remove-torchtrt-trt11`, `trt11-*`).
The test passes on TRT-10 runners (attr still present) and fails on TRT-11 ones.
It's the last removed-setter TRT-11 gap I can find in the builder graph-op test
suite (a `grep` for `.dtype = trt` / `.compute_precision = ` / `set_output_type`
/ `dynamic_range` across `conftest.py`, `test_graph_ops*.py`, `test_graph_blocks.py`,
`test_graph_ops_native_attn.py` now comes back clean after this change).

## Impact
Because this runs in the **Python builder** stage, a failure here can block any
PR that gets broad test selection (e.g. one touching a shared builder module),
even though the PR is unrelated to graph ops.

## Validation
- `ruff check --config ruff.toml`: passes (unused imports removed).
- `pytest tests/builder/test_graph_ops_native_attn.py::TestAddLayerNormNative`
  on TRT 10: **4 passed** — removing the redundant set leaves results unchanged.

(Validated on TRT 10 locally; the TRT-11 behavior is the removed
`INormalizationLayer.compute_precision` setter, matching the CI symptom and the
strongly-typed-network design.)
