### PR TITLE
feat(task-eval): add MMLU continuation parity

### DIFF
--- a/tests/task_eval/validation_suites.yaml
+++ b/tests/task_eval/validation_suites.yaml
@@ -1,0 +1,54 @@
+version: 1
+
+suites:
+  - id: mmlu_five_shot_mcq
+    description: >
+      Local five-shot MMLU multiple-choice accuracy evaluation. This validates
+      user-visible task quality for decoder-style text generation bundles and
+      records HF-reference agreement separately from absolute correctness.
+    user_contract: multiple_choice_qa
+    dataset:
+      kind: mmlu_five_shot_json
+      default_path: /mnt/data/MMLU_five_shot/mmlu_dataset.json
+      answer_field: answer
+      subject_field: subject
+      prompt_source: messages
+    selectors:
+      task_strategies:
+        - text_generation_causal
+      runtime_strategies:
+        - decoder_kv_cache
+        - decoder_moe
+        - ssm_recurrent
+        - rwkv_recurrent
+        - hybrid_mamba_attention
+        - torchtrt_decoder
+      user_contracts:
+        - chat_response
+      exclude_user_contracts:
+        - continuation_parity
+        - code_completion
+        - translation
+        - seq2seq_output
+        - model_card_generation_parity
+    generation:
+      max_new_tokens: 1
+      temperature: 1.0
+      top_k: 1
+      top_p: 1.0
+      min_p: 0.0
+      seed: -1
+      apply_chat_template: false
+      enable_thinking: false
+      do_sample: false
+    build:
+      min_max_cache_length: 0
+    gates:
+      max_accuracy_drop_from_hf: 0.01
+      min_prediction_agreement: 0.98
+    ci:
+      eligible: false
+      lane: local_only
+      notes: >
+        First step is local execution. CI can later consume the same suite
+        manifest with a smaller sampled dataset and explicit model allowlist.

--- a/tests/task_eval/validation_suites.yaml
+++ b/tests/task_eval/validation_suites.yaml
@@ -52,3 +52,52 @@ suites:
       notes: >
         First step is local execution. CI can later consume the same suite
         manifest with a smaller sampled dataset and explicit model allowlist.
+
+  - id: mmlu_continuation_parity
+    description: >
+      Base / completion-model continuation parity. Both the HF reference and the
+      TRTFB bundle greedily continue the same plain-text MMLU prompt; the two
+      continuations are compared token-level (no gold answer, no logits). This
+      measures conversion fidelity for completion models rather than task
+      accuracy.
+    user_contract: continuation_parity
+    dataset:
+      kind: mmlu_five_shot_json
+      default_path: /mnt/data/MMLU_five_shot/mmlu_dataset.json
+      answer_field: answer
+      subject_field: subject
+      prompt_source: messages
+    selectors:
+      task_strategies:
+        - text_generation_causal
+      runtime_strategies:
+        - decoder_kv_cache
+        - decoder_moe
+        - ssm_recurrent
+        - rwkv_recurrent
+        - hybrid_mamba_attention
+        - torchtrt_decoder
+      user_contracts:
+        - continuation_parity
+    generation:
+      max_new_tokens: 64
+      temperature: 1.0
+      top_k: 1
+      top_p: 1.0
+      min_p: 0.0
+      seed: -1
+      apply_chat_template: false
+      enable_thinking: false
+      do_sample: false
+    scoring:
+      scorer: continuation
+    build:
+      min_max_cache_length: 0
+    gates:
+      min_token_prefix_agreement: 0.98
+    ci:
+      eligible: false
+      lane: local_only
+      notes: >
+        Intended for local/p2021 validation before a sampled CI variant is
+        enabled.

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -1,0 +1,603 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from tools import task_eval
+
+
+def _write_mmlu(path: Path) -> None:
+    payload = {
+        "apply_chat_template": False,
+        "batch_size": 1,
+        "max_generate_length": 1,
+        "temperature": 1.0,
+        "top_k": 50,
+        "top_p": 1.0,
+        "requests": [
+            {
+                "messages": [{"role": "user", "content": "Question one\nA. a\nB. b\nAnswer:"}],
+                "answer": "B",
+                "subject": "subject_a",
+            },
+            {
+                "messages": [{"role": "user", "content": "Question two\nA. a\nB. b\nAnswer:"}],
+                "answer": "A",
+                "subject": "subject_b",
+            },
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_plan_selects_chat_text_generation_manifests() -> None:
+    suites = task_eval.load_suites()
+    models = task_eval.load_manifest_records()
+
+    rows = task_eval.build_plan(suites, models, suite_id="mmlu_five_shot_mcq")
+
+    selected = {row["model"]: row for row in rows}
+    assert "qwen3-0.6b-fp16" in selected
+    assert selected["qwen3-0.6b-fp16"]["runtime_strategy"] == "decoder_kv_cache"
+    assert selected["qwen3-0.6b-fp16"]["user_contract"] == "chat_response"
+    assert "gpt2-125m" not in selected
+    assert "codegen-350m" not in selected
+
+
+def test_prepare_mmlu_writes_answers_and_trtfb_jsonl(tmp_path: Path) -> None:
+    dataset = tmp_path / "mmlu.json"
+    _write_mmlu(dataset)
+    suite = task_eval.suite_by_id(task_eval.load_suites(), "mmlu_five_shot_mcq")
+
+    outputs = task_eval.prepare_mmlu_dataset(
+        dataset_path=dataset,
+        work_dir=tmp_path / "work",
+        suite=suite,
+        limit=1,
+    )
+
+    answers = json.loads(outputs["answers"].read_text(encoding="utf-8"))
+    prompts = task_eval.load_jsonl(outputs["prompts"])
+    manifest = json.loads(outputs["manifest"].read_text(encoding="utf-8"))
+
+    assert len(answers["requests"]) == 1
+    assert prompts == [{
+        "sample_id": "mmlu_000000",
+        "dataset_index": 0,
+        "eval_index": 0,
+        "subject": "subject_a",
+        "answer": "B",
+        "prompt": "Question one\nA. a\nB. b\nAnswer:",
+    }]
+    assert manifest["suite"] == "mmlu_five_shot_mcq"
+    assert manifest["request_count"] == 1
+
+
+def test_continuation_parity_exact_and_first_divergence() -> None:
+    hf = {"responses": [
+        {"sample_id": "a", "output_text": "the cat sat"},
+        {"sample_id": "b", "output_text": "hello world"},
+    ]}
+    trtfb = {"responses": [
+        {"sample_id": "a", "output_text": "the cat sat"},
+        {"sample_id": "b", "output_text": "hello there"},
+    ]}
+
+    summary = task_eval.compare_continuation_sets(hf, trtfb, tokenize=lambda s: s.split())
+
+    assert summary["count"] == 2
+    assert summary["exact_match_rate"] == 0.5          # "a" exact, "b" not
+    assert summary["samples"][0]["first_divergence"] == 3  # all 3 tokens match
+    assert summary["samples"][1]["first_divergence"] == 1  # diverge at token index 1
+    # matched prefixes 3 + 1 = 4, ref token counts 3 + 2 = 5
+    assert abs(summary["token_prefix_agreement"] - 4 / 5) < 1e-9
+
+
+def test_continuation_parity_prefers_generated_token_ids() -> None:
+    hf = {"responses": [
+        {"sample_id": "a", "output_text": "same text", "generated_token_ids": [10, 20]},
+        {"sample_id": "b", "output_text": "same text", "generated_token_ids": [1, 2, 3]},
+    ]}
+    trtfb = {"responses": [
+        {"sample_id": "a", "output_text": "same text", "generated_token_ids": [10, 20]},
+        {"sample_id": "b", "output_text": "same text", "generated_token_ids": [1, 2, 4]},
+    ]}
+
+    summary = task_eval.compare_continuation_sets(hf, trtfb, require_token_ids=True)
+
+    assert summary["comparison_granularity"] == "generated_token_ids"
+    assert summary["exact_match_rate"] == 0.5
+    assert summary["token_id_exact_match_rate"] == 0.5
+    assert summary["text_exact_match_rate"] == 1.0
+    assert summary["samples"][1]["first_divergence"] == 2
+    assert summary["samples"][1]["hf_token_at_divergence"] == 3
+    assert summary["samples"][1]["trtfb_token_at_divergence"] == 4
+
+
+def test_continuation_parity_requires_token_ids_when_requested() -> None:
+    hf = {"responses": [{"sample_id": "a", "output_text": "x"}]}
+    trtfb = {"responses": [{"sample_id": "a", "output_text": "x"}]}
+
+    try:
+        task_eval.compare_continuation_sets(hf, trtfb, require_token_ids=True)
+    except ValueError as exc:
+        assert "generated_token_ids" in str(exc)
+    else:
+        raise AssertionError("expected missing token-id validation failure")
+
+
+def test_validation_suites_keep_continuation_and_drop_trace_cloze() -> None:
+    suites = task_eval.load_suites()
+    ids = {suite["id"] for suite in suites}
+    continuation = task_eval.suite_by_id(suites, "mmlu_continuation_parity")
+
+    assert "mmlu_continuation_parity" in ids
+    assert "mmlu_trace_cloze" not in ids
+    assert continuation["dataset"]["kind"] == "mmlu_five_shot_json"
+    assert continuation["scoring"]["scorer"] == "continuation"
+    assert continuation["user_contract"] == "continuation_parity"
+
+
+def test_compare_continuation_cli_writes_json_summary(tmp_path: Path) -> None:
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    (work_dir / "hf_predictions.json").write_text(
+        json.dumps({
+            "responses": [
+                {"sample_id": "a", "output_text": "same", "generated_token_ids": [1, 2]},
+                {"sample_id": "b", "output_text": "left", "generated_token_ids": [3, 4]},
+            ]
+        }),
+        encoding="utf-8",
+    )
+    (work_dir / "trtfb_predictions.json").write_text(
+        json.dumps({
+            "responses": [
+                {"sample_id": "a", "output_text": "same", "generated_token_ids": [1, 2]},
+                {"sample_id": "b", "output_text": "right", "generated_token_ids": [3, 5]},
+            ]
+        }),
+        encoding="utf-8",
+    )
+    output = tmp_path / "continuation.json"
+
+    rc = task_eval.cmd_compare_continuation(argparse.Namespace(
+        work_dir=str(work_dir),
+        hf_predictions="",
+        trtfb_predictions="",
+        model="",
+        trust_remote_code=False,
+        local_files_only=False,
+        output=str(output),
+    ))
+
+    summary = json.loads(output.read_text(encoding="utf-8"))
+    assert rc == 0
+    assert summary["comparison_granularity"] == "generated_token_ids"
+    assert summary["exact_match_rate"] == 0.5
+    assert summary["token_prefix_agreement"] == 0.75
+    assert summary["samples"][1]["first_divergence"] == 1
+
+
+def test_convert_trtfb_uses_generated_text_field(tmp_path: Path) -> None:
+    raw = tmp_path / "trtfb_raw.jsonl"
+    raw.write_text(
+        json.dumps({
+            "sample_id": "mmlu_000000",
+            "gold_answer": "B",
+            "pred_answer": "",
+            "text": "Answer: B",
+            "generated_tokens": 1,
+            "generated_token_ids": [42],
+            "wall_ms": 3.5,
+        }) + "\n",
+        encoding="utf-8",
+    )
+    predictions = tmp_path / "predictions.json"
+
+    task_eval.convert_trtfb_jsonl_to_predictions(raw, predictions)
+
+    payload = json.loads(predictions.read_text(encoding="utf-8"))
+    assert payload["responses"][0]["output_text"] == "Answer: B"
+    assert payload["responses"][0]["generated_token_ids"] == [42]
+    assert payload["responses"][0]["source"] == "trtfb"
+
+
+def test_score_and_compare_mmlu_predictions(tmp_path: Path) -> None:
+    dataset = tmp_path / "mmlu.json"
+    _write_mmlu(dataset)
+    answers = json.loads(dataset.read_text(encoding="utf-8"))
+    hf = {
+        "responses": [
+            {"sample_id": "mmlu_000000", "output_text": "b"},
+            {"sample_id": "mmlu_000001", "output_text": "Answer: A"},
+        ]
+    }
+    trtfb = {
+        "responses": [
+            {"sample_id": "mmlu_000000", "output_text": "B<|im_end|>"},
+            {"sample_id": "mmlu_000001", "output_text": "(B)"},
+        ]
+    }
+
+    hf_score = task_eval.score_predictions(hf, answers)
+    summary = task_eval.compare_prediction_sets(hf, trtfb, answers)
+
+    assert hf_score["overall_accuracy"] == 1.0
+    assert summary["hf"]["overall_accuracy"] == 1.0
+    assert summary["trtfb"]["overall_accuracy"] == 0.5
+    assert summary["accuracy_delta_trtfb_minus_hf"] == -0.5
+    assert summary["prediction_agreement_rate"] == 0.5
+    assert summary["buckets"]["hf_correct_trtfb_wrong"] == 1
+
+
+def test_selected_models_for_suite_accepts_manifest_name() -> None:
+    suite = task_eval.suite_by_id(task_eval.load_suites(), "mmlu_five_shot_mcq")
+    models = task_eval.load_manifest_records()
+
+    selected = task_eval.selected_models_for_suite(
+        suite,
+        models,
+        selectors=["qwen3-0.6b-fp16"],
+        single_device_only=True,
+    )
+
+    assert [model["name"] for model in selected] == ["qwen3-0.6b-fp16"]
+
+
+def test_waives_exclude_default_selection_but_explicit_model_can_debug(tmp_path: Path) -> None:
+    suite = {
+        "id": "mmlu_five_shot_mcq",
+        "selectors": {
+            "task_strategies": ["text_generation_causal"],
+            "runtime_strategies": ["decoder_kv_cache"],
+            "user_contracts": ["chat_response"],
+        },
+    }
+    models = [
+        {
+            "name": "internlm2-1.8b",
+            "hf_id": "internlm/internlm2-math-plus-1_8b",
+            "bundle": "internlm2-1.8b.trtfb",
+            "runtime_strategy": "decoder_kv_cache",
+            "task_strategy": "text_generation_causal",
+            "reference_family": "chat_instruct_template",
+            "user_contract": "chat_response",
+            "family": "internlm",
+            "ci_tier": "default",
+            "requires_multi_device": False,
+            "manifest": "tests/e2e/models/internlm2-1.8b.json",
+            "skip": "",
+        },
+        {
+            "name": "tinyllama-1.1b",
+            "hf_id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+            "bundle": "tinyllama-1.1b.trtfb",
+            "runtime_strategy": "decoder_kv_cache",
+            "task_strategy": "text_generation_causal",
+            "reference_family": "chat_instruct_template",
+            "user_contract": "chat_response",
+            "family": "llama",
+            "ci_tier": "default",
+            "requires_multi_device": False,
+            "manifest": "tests/e2e/models/tinyllama-1.1b.json",
+            "skip": "",
+        },
+    ]
+    waives_path = tmp_path / "waives.txt"
+    waives_path.write_text(
+        "internlm2-1.8b  SKIP  (HF remote code incompatible)\n",
+        encoding="utf-8",
+    )
+    waives = task_eval.load_waives(waives_path)
+
+    selected = task_eval.selected_models_for_suite(suite, models, waives=waives)
+    explicit = task_eval.selected_models_for_suite(
+        suite,
+        models,
+        selectors=["internlm2-1.8b"],
+        waives=waives,
+    )
+    rows = task_eval.build_plan([suite], models, include_non_matching=True, waives=waives)
+    internlm_row = next(row for row in rows if row["model"] == "internlm2-1.8b")
+
+    assert [model["name"] for model in selected] == ["tinyllama-1.1b"]
+    assert [model["name"] for model in explicit] == ["internlm2-1.8b"]
+    assert internlm_row["selected"] is False
+    assert "waived SKIP" in internlm_row["reason"]
+
+
+def test_build_bundle_command_uses_manifest_build_settings(tmp_path: Path) -> None:
+    model = {
+        "name": "case",
+        "hf_id": "org/model",
+        "max_cache_length": 512,
+        "precision": "bf16",
+        "trust_remote_code": True,
+        "build_args": {"backend": "trt", "parallel": {"mode": "tensor_parallel", "tp_size": 2}},
+        "quantization": {"format": "fp8", "calibration_samples": 4},
+    }
+
+    cmd = task_eval.build_bundle_command(
+        model,
+        trtmc_binary="build/trtmc",
+        bundle_path=tmp_path / "case.trtfb",
+        extra_build_args=["--verbose"],
+    )
+
+    assert cmd[:4] == ["build/trtmc", "build", "org/model", "-o"]
+    assert "--max-cache-length" in cmd
+    assert "512" in cmd
+    assert ["--method", "trt"] == cmd[cmd.index("--method"):cmd.index("--method") + 2]
+    assert ["--tp-size", "2"] == cmd[cmd.index("--tp-size"):cmd.index("--tp-size") + 2]
+    assert ["--precision", "bf16"] == cmd[cmd.index("--precision"):cmd.index("--precision") + 2]
+    assert "--trust-remote-code" in cmd
+    assert "--verbose" in cmd
+
+
+def test_suite_build_cache_minimum_overrides_manifest_cache() -> None:
+    suite = {"build": {"min_max_cache_length": 1024}}
+    model = {"max_cache_length": 256}
+
+    assert task_eval.requested_build_max_cache_length(suite, model) == 1024
+    assert task_eval.requested_build_max_cache_length(suite, model, prompt_max_tokens=2048) == 2048
+    assert task_eval.requested_build_max_cache_length(suite, model, 512) == 512
+
+
+def test_prompt_length_validation_rejects_over_cache(tmp_path: Path, monkeypatch) -> None:
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    (work_dir / "prompts.jsonl").write_text(
+        json.dumps({"prompt": "long prompt"}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(task_eval, "max_prompt_token_length", lambda **_kwargs: 513)
+
+    try:
+        task_eval.validate_prompt_lengths_for_cache(
+            model={"name": "case", "hf_id": "org/model"},
+            work_dir=work_dir,
+            max_cache_length=512,
+        )
+    except RuntimeError as exc:
+        assert "max_prompt_tokens=513" in str(exc)
+    else:
+        raise AssertionError("expected prompt length validation failure")
+
+
+def test_eval_one_model_reuses_hf_builds_bundle_and_reruns_trtfb(
+    tmp_path: Path, monkeypatch
+) -> None:
+    dataset = tmp_path / "mmlu.json"
+    _write_mmlu(dataset)
+    suite = task_eval.suite_by_id(task_eval.load_suites(), "mmlu_five_shot_mcq")
+    model = {
+        "name": "gpt2-125m",
+        "hf_id": "openai-community/gpt2",
+        "bundle": "gpt2-125m.trtfb",
+        "max_cache_length": 256,
+        "precision": "fp32",
+        "trust_remote_code": False,
+        "build_args": {},
+        "quantization": {},
+    }
+    work_dir = tmp_path / "work" / suite["id"] / model["name"]
+    work_dir.mkdir(parents=True)
+    task_eval.prepare_mmlu_dataset(
+        dataset_path=dataset,
+        work_dir=work_dir,
+        suite=suite,
+    )
+    (work_dir / "hf_predictions.json").write_text(
+        json.dumps({
+            "responses": [
+                {"sample_id": "mmlu_000000", "output_text": "B"},
+                {"sample_id": "mmlu_000001", "output_text": "A"},
+            ]
+        }),
+        encoding="utf-8",
+    )
+    calls: list[str] = []
+
+    def fake_run_hf(_args):
+        calls.append("hf")
+        raise AssertionError("HF should be reused")
+
+    monkeypatch.setattr(task_eval, "max_prompt_token_length", lambda **_kwargs: 405)
+
+    def fake_ensure_bundle(*_args, **kwargs):
+        calls.append("build")
+        assert kwargs["max_cache_length"] == 405
+        bundle = kwargs["bundle_path"]
+        bundle.parent.mkdir(parents=True, exist_ok=True)
+        bundle.write_bytes(b"bundle")
+        return bundle, True
+
+    def fake_run_trtfb(args):
+        calls.append(f"trtfb-seed={args.seed}")
+        Path(args.work_dir, "trtfb_predictions.json").write_text(
+            json.dumps({
+                "responses": [
+                    {"sample_id": "mmlu_000000", "output_text": "B"},
+                    {"sample_id": "mmlu_000001", "output_text": "B"},
+                ]
+            }),
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(task_eval, "run_hf_reference", fake_run_hf)
+    monkeypatch.setattr(task_eval, "ensure_bundle", fake_ensure_bundle)
+    monkeypatch.setattr(task_eval, "run_trtfb", fake_run_trtfb)
+
+    args = argparse.Namespace(
+        work_root=str(tmp_path / "work"),
+        dataset=str(dataset),
+        limit=0,
+        subject="",
+        sample_seed=None,
+        force_hf=False,
+        force_build=False,
+        build_max_cache_length=None,
+        skip_prompt_length_check=False,
+        bundle="",
+        model=["gpt2-125m"],
+        engine_dir="",
+        trtmc_binary="build/trtmc",
+        extra_build_arg=[],
+        hf_dtype="auto",
+        hf_device="cuda",
+        hf_device_map="",
+        hf_attn_impl="",
+        trust_remote_code=False,
+        local_files_only=True,
+        do_sample=False,
+        apply_chat_template=False,
+        max_new_tokens=None,
+        temperature=None,
+        top_k=None,
+        top_p=None,
+        min_p=None,
+        seed=123,
+        benchmark_binary="build/trtmc_dataset_benchmark",
+        hf_python="",
+        backend_dir="",
+        kv_cache_size="",
+        config="",
+        set=[],
+        cuda_visible_devices="",
+        chat_template=False,
+    )
+
+    result = task_eval.eval_one_model(suite=suite, model=model, args=args)
+
+    assert calls == ["build", "trtfb-seed=123"]
+    assert result["hf_reused"] is True
+    assert result["bundle_built"] is True
+    assert result["trtfb_accuracy"] == 0.5
+    assert (work_dir / "summary.json").is_file()
+
+
+def test_eval_records_model_failure_and_continues(tmp_path: Path, monkeypatch) -> None:
+    suite = {"id": "mmlu_five_shot_mcq", "dataset": {"kind": "mmlu_five_shot_json"}}
+    models = [
+        {"name": "gated", "hf_id": "org/gated", "bundle": "gated.trtfb"},
+        {"name": "ok", "hf_id": "org/ok", "bundle": "ok.trtfb"},
+    ]
+
+    monkeypatch.setattr(task_eval, "load_suites", lambda *_args, **_kwargs: [suite])
+    monkeypatch.setattr(task_eval, "load_manifest_records", lambda *_args, **_kwargs: models)
+    monkeypatch.setattr(
+        task_eval,
+        "selected_models_for_suite",
+        lambda *_args, **_kwargs: models,
+    )
+
+    def fake_eval_one_model(*_args, model, **_kwargs):
+        if model["name"] == "gated":
+            raise RuntimeError("gated repo")
+        return {
+            "suite": suite["id"],
+            "model": "ok",
+            "hf_id": "org/ok",
+            "work_dir": str(tmp_path / "work" / suite["id"] / "ok"),
+            "bundle": str(tmp_path / "bundles" / "ok.trtfb"),
+            "hf_accuracy": 1.0,
+            "trtfb_accuracy": 1.0,
+            "prediction_agreement_rate": 1.0,
+            "hf_reused": False,
+            "bundle_built": True,
+        }
+
+    monkeypatch.setattr(task_eval, "eval_one_model", fake_eval_one_model)
+
+    args = argparse.Namespace(
+        suites="",
+        suite=suite["id"],
+        models_dir="",
+        waives="",
+        waive_platform="",
+        include_waived=False,
+        model=[],
+        single_device_only=True,
+        bundle="",
+        work_root=str(tmp_path / "work"),
+        engine_dir=str(tmp_path / "bundles"),
+        fail_fast=False,
+        disable_model_process_isolation=True,
+    )
+
+    assert task_eval.cmd_eval(args) == 0
+
+    summary = json.loads(
+        (tmp_path / "work" / suite["id"] / "eval_summary.json").read_text(encoding="utf-8")
+    )
+    assert summary["count"] == 2
+    assert summary["passed_count"] == 1
+    assert summary["failed_count"] == 1
+    assert summary["results"][0]["status"] == "failed"
+    assert summary["results"][0]["error"] == "gated repo"
+    assert summary["results"][1]["status"] == "passed"
+    assert summary["results"][1]["model"] == "ok"
+
+
+def test_eval_stops_after_oom_when_gpu_cleanup_is_not_confirmed(tmp_path: Path, monkeypatch) -> None:
+    suite = {"id": "mmlu_five_shot_mcq", "dataset": {"kind": "mmlu_five_shot_json"}}
+    models = [
+        {"name": "oom", "hf_id": "org/oom", "bundle": "oom.trtfb"},
+        {"name": "next", "hf_id": "org/next", "bundle": "next.trtfb"},
+    ]
+
+    monkeypatch.setattr(task_eval, "load_suites", lambda *_args, **_kwargs: [suite])
+    monkeypatch.setattr(task_eval, "load_manifest_records", lambda *_args, **_kwargs: models)
+    monkeypatch.setattr(
+        task_eval,
+        "selected_models_for_suite",
+        lambda *_args, **_kwargs: models,
+    )
+    calls: list[str] = []
+
+    def fake_run_worker(*_args, model, **_kwargs):
+        calls.append(model["name"])
+        return {
+            "suite": suite["id"],
+            "model": model["name"],
+            "hf_id": model["hf_id"],
+            "work_dir": str(tmp_path / "work" / suite["id"] / model["name"]),
+            "bundle": str(tmp_path / "bundles" / model["bundle"]),
+            "status": "failed",
+            "error_type": "RuntimeError",
+            "error": "CUDA out of memory",
+            "worker_log": str(tmp_path / "work" / suite["id"] / model["name"] / "eval_worker.log"),
+            "gpu_cleanup_confirmed": False,
+        }
+
+    monkeypatch.setattr(task_eval, "run_eval_model_worker", fake_run_worker)
+
+    args = argparse.Namespace(
+        suites="",
+        suite=suite["id"],
+        models_dir="",
+        waives="",
+        waive_platform="",
+        include_waived=False,
+        model=[],
+        single_device_only=True,
+        bundle="",
+        work_root=str(tmp_path / "work"),
+        engine_dir=str(tmp_path / "bundles"),
+        fail_fast=False,
+    )
+
+    assert task_eval.cmd_eval(args) == 0
+
+    summary = json.loads(
+        (tmp_path / "work" / suite["id"] / "eval_summary.json").read_text(encoding="utf-8")
+    )
+    assert calls == ["oom"]
+    assert summary["count"] == 2
+    assert summary["failed_count"] == 1
+    assert summary["skipped_count"] == 1
+    assert summary["model_process_isolation"] is True
+    assert summary["results"][1]["status"] == "skipped"
+    assert "GPU cleanup" in summary["results"][1]["reason"]

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -808,6 +808,25 @@ class TestUnitTiers:
             assert match.models == []
             assert match.unit_tiers == ["tools"]
 
+    def test_task_eval_tool_triggers_tools_tier(self, imap):
+        """task_eval tool edits run tools-tier tests without E2E."""
+        match = test_impact.classify_file("tools/task_eval.py", imap)
+
+        assert match.rule == "task_eval_tool"
+        assert match.models == []
+        assert match.unit_tiers == ["tools"]
+        assert match.rebuild_cpp is False
+
+    def test_task_eval_suite_config_triggers_tools_tier(self, imap):
+        """task_eval suite config edits run tools-tier tests without E2E."""
+        match = test_impact.classify_file(
+            "tests/task_eval/validation_suites.yaml", imap)
+
+        assert match.rule == "task_eval_config"
+        assert match.models == []
+        assert match.unit_tiers == ["tools"]
+        assert match.rebuild_cpp is False
+
     def test_source_implies_unit_tier(self, imap):
         """C++ source change implies 'cpp' unit tier alongside E2E."""
         match = test_impact.classify_file(

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -1,0 +1,1831 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import random
+import re
+import traceback
+import subprocess
+import sys
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tests.e2e_harness.contracts import (  # noqa: E402
+    MODEL_REFERENCE_FAMILY,
+    REFERENCE_FAMILY_TO_USER_CONTRACT,
+    RUNTIME_TO_TASK_STRATEGY,
+)
+
+
+DEFAULT_SUITES = REPO_ROOT / "tests" / "task_eval" / "validation_suites.yaml"
+DEFAULT_MODELS_DIR = REPO_ROOT / "tests" / "e2e" / "models"
+DEFAULT_WAIVES = REPO_ROOT / "tests" / "e2e" / "waives.txt"
+ERROR_OUTPUT_TEXT = "TensorRT Edge LLM cannot handle this request. Fails."
+CHOICE_LETTERS = set("ABCDEFGH")
+
+
+def load_structured_file(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".json":
+        return json.loads(text)
+    try:
+        import yaml
+    except Exception as exc:  # pragma: no cover - dependency is in pyproject
+        raise RuntimeError("PyYAML is required for task-eval YAML files") from exc
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a mapping at the top level")
+    return data
+
+
+def load_suites(path: Path = DEFAULT_SUITES) -> list[dict[str, Any]]:
+    data = load_structured_file(path)
+    suites = data.get("suites", [])
+    if not isinstance(suites, list):
+        raise ValueError(f"{path}: 'suites' must be a list")
+    seen: set[str] = set()
+    for suite in suites:
+        suite_id = suite.get("id")
+        if not suite_id or not isinstance(suite_id, str):
+            raise ValueError(f"{path}: every suite needs a string id")
+        if suite_id in seen:
+            raise ValueError(f"{path}: duplicate suite id {suite_id!r}")
+        seen.add(suite_id)
+    return suites
+
+
+def suite_by_id(suites: list[dict[str, Any]], suite_id: str) -> dict[str, Any]:
+    for suite in suites:
+        if suite["id"] == suite_id:
+            return suite
+    known = ", ".join(sorted(s["id"] for s in suites))
+    raise ValueError(f"Unknown suite {suite_id!r}. Known suites: {known}")
+
+
+def _base_case_name(name: str) -> str:
+    return re.sub(r"-tp\d+$", "", name)
+
+
+def infer_reference_family(raw: dict[str, Any]) -> str:
+    if raw.get("reference_family"):
+        return str(raw["reference_family"])
+    name = str(raw.get("name", ""))
+    return MODEL_REFERENCE_FAMILY.get(name) or MODEL_REFERENCE_FAMILY.get(_base_case_name(name), "")
+
+
+def infer_user_contract(raw: dict[str, Any], reference_family: str) -> str:
+    if raw.get("user_contract"):
+        return str(raw["user_contract"])
+    return REFERENCE_FAMILY_TO_USER_CONTRACT.get(reference_family, "")
+
+
+def manifest_record(path: Path) -> dict[str, Any]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    build_args = raw.get("build_args", {})
+    runtime_strategy = str(raw.get("runtime_strategy", "decoder_kv_cache"))
+    task_strategy = str(
+        raw.get("task_strategy") or RUNTIME_TO_TASK_STRATEGY.get(runtime_strategy, "")
+    )
+    reference_family = infer_reference_family(raw)
+    user_contract = infer_user_contract(raw, reference_family)
+    distributed = raw.get("distributed_runtime", {})
+    requires_multi_device = bool(distributed.get("enabled")) or (
+        str(raw.get("ci_tier", "")) == "multi_device"
+    )
+    return {
+        "name": raw.get("name", path.stem),
+        "manifest": str(path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path),
+        "hf_id": raw.get("hf_id") or raw.get("model_id", ""),
+        "bundle": raw.get("bundle", f"{path.stem}.trtfb"),
+        "family": raw.get("family", ""),
+        "runtime_strategy": runtime_strategy,
+        "task_strategy": task_strategy,
+        "reference_family": reference_family,
+        "user_contract": user_contract,
+        "ci_tier": raw.get("ci_tier", "default"),
+        "core": bool(raw.get("core", False)),
+        "skip": raw.get("skip", ""),
+        "requires_multi_device": requires_multi_device,
+        "l0_replacement": raw.get("l0_replacement", ""),
+        "gated": bool(raw.get("gated", False)),
+        "trust_remote_code": bool(raw.get("trust_remote_code", False)),
+        "max_cache_length": raw.get(
+            "max_cache_length",
+            build_args.get("max_cache_length", 256) if isinstance(build_args, dict) else 256,
+        ),
+        "precision": raw.get("precision", "fp32"),
+        "quantization": raw.get("quantization", {}),
+        "build_args": build_args if isinstance(build_args, dict) else {},
+        "fp8_scales": raw.get("fp8_scales", ""),
+    }
+
+
+def load_manifest_records(models_dir: Path = DEFAULT_MODELS_DIR) -> list[dict[str, Any]]:
+    return [manifest_record(path) for path in sorted(models_dir.glob("*.json"))]
+
+
+def load_waives(path: Path = DEFAULT_WAIVES, platform: str = "") -> dict[str, tuple[str, str]]:
+    waives: dict[str, tuple[str, str]] = {}
+    if not path.is_file():
+        return waives
+    platform = platform.strip()
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 2)
+        if len(parts) < 2:
+            continue
+        name_part = parts[0]
+        action = parts[1].upper()
+        reason = parts[2] if len(parts) > 2 else ""
+        if action not in {"SKIP", "XFAIL"}:
+            continue
+        if "/" in name_part:
+            waive_platform, model_name = name_part.split("/", 1)
+            if waive_platform != platform:
+                continue
+        else:
+            model_name = name_part
+        waives[model_name] = (action, reason)
+    return waives
+
+
+def _selector_values(selectors: dict[str, Any], key: str) -> set[str]:
+    values = selectors.get(key, [])
+    if values is None:
+        return set()
+    if isinstance(values, str):
+        return {values}
+    return {str(v) for v in values}
+
+
+def suite_match_reason(suite: dict[str, Any], model: dict[str, Any]) -> tuple[bool, str]:
+    selectors = suite.get("selectors", {})
+    task_strategies = _selector_values(selectors, "task_strategies")
+    runtime_strategies = _selector_values(selectors, "runtime_strategies")
+    user_contracts = _selector_values(selectors, "user_contracts")
+    exclude_user_contracts = _selector_values(selectors, "exclude_user_contracts")
+    families = _selector_values(selectors, "families")
+    exclude_families = _selector_values(selectors, "exclude_families")
+
+    if task_strategies and model["task_strategy"] not in task_strategies:
+        return False, f"task_strategy={model['task_strategy']} not selected"
+    if runtime_strategies and model["runtime_strategy"] not in runtime_strategies:
+        return False, f"runtime_strategy={model['runtime_strategy']} not selected"
+    if user_contracts and model["user_contract"] not in user_contracts:
+        return False, f"user_contract={model['user_contract'] or '<empty>'} not selected"
+    if exclude_user_contracts and model["user_contract"] in exclude_user_contracts:
+        return False, f"user_contract={model['user_contract']} excluded"
+    if families and model["family"] not in families:
+        return False, f"family={model['family']} not selected"
+    if exclude_families and model["family"] in exclude_families:
+        return False, f"family={model['family']} excluded"
+    if model.get("skip"):
+        return False, f"manifest skip: {model['skip']}"
+    return True, "selected"
+
+
+def build_plan(
+    suites: list[dict[str, Any]],
+    models: list[dict[str, Any]],
+    *,
+    suite_id: str | None = None,
+    single_device_only: bool = False,
+    include_non_matching: bool = False,
+    waives: dict[str, tuple[str, str]] | None = None,
+    include_waived: bool = False,
+) -> list[dict[str, Any]]:
+    selected_suites = [suite_by_id(suites, suite_id)] if suite_id else suites
+    rows: list[dict[str, Any]] = []
+    waives = waives or {}
+    for suite in selected_suites:
+        for model in models:
+            matched, reason = suite_match_reason(suite, model)
+            if single_device_only and model["requires_multi_device"]:
+                matched = False
+                reason = "requires multi-device runtime"
+            waive = waives.get(str(model["name"]))
+            if matched and waive and not include_waived:
+                action, waive_reason = waive
+                matched = False
+                reason = f"waived {action}: {waive_reason}".strip()
+            if matched or include_non_matching:
+                rows.append({
+                    "suite": suite["id"],
+                    "dataset_kind": suite.get("dataset", {}).get("kind", ""),
+                    "model": model["name"],
+                    "hf_id": model["hf_id"],
+                    "bundle": model["bundle"],
+                    "runtime_strategy": model["runtime_strategy"],
+                    "task_strategy": model["task_strategy"],
+                    "reference_family": model["reference_family"],
+                    "user_contract": model["user_contract"],
+                    "ci_tier": model["ci_tier"],
+                    "requires_multi_device": model["requires_multi_device"],
+                    "selected": matched,
+                    "reason": reason,
+                    "manifest": model["manifest"],
+                })
+    return rows
+
+
+def print_plan_table(rows: list[dict[str, Any]]) -> None:
+    columns = [
+        ("suite", 20),
+        ("model", 28),
+        ("runtime_strategy", 24),
+        ("user_contract", 22),
+        ("ci_tier", 12),
+        ("scope", 8),
+        ("reason", 32),
+    ]
+    header = "  ".join(name.ljust(width) for name, width in columns)
+    print(header)
+    print("-" * len(header))
+    for row in rows:
+        data = dict(row)
+        data["scope"] = "multi" if row["requires_multi_device"] else "single"
+        print("  ".join(str(data.get(name, ""))[:width].ljust(width) for name, width in columns))
+
+
+def _request_prompt(request: dict[str, Any]) -> str:
+    messages = request.get("messages")
+    if isinstance(messages, list):
+        for msg in reversed(messages):
+            if msg.get("role") == "user" and isinstance(msg.get("content"), str):
+                return msg["content"]
+        parts = [str(msg.get("content", "")) for msg in messages if msg.get("content")]
+        if parts:
+            return "\n".join(parts)
+    prompt = request.get("prompt")
+    if isinstance(prompt, str):
+        return prompt
+    raise ValueError("MMLU request has neither messages content nor prompt")
+
+
+def _copy_dataset_header(data: dict[str, Any], requests: list[dict[str, Any]]) -> dict[str, Any]:
+    out = {k: v for k, v in data.items() if k != "requests"}
+    out["requests"] = requests
+    return out
+
+
+def load_mmlu_requests(
+    dataset_path: Path,
+    *,
+    limit: int = 0,
+    subject: str = "",
+    sample_seed: int | None = None,
+) -> tuple[dict[str, Any], list[tuple[int, dict[str, Any]]]]:
+    data = json.loads(dataset_path.read_text(encoding="utf-8"))
+    requests = data.get("requests")
+    if not isinstance(requests, list):
+        raise ValueError(f"{dataset_path}: expected top-level 'requests' list")
+    indexed = [
+        (idx, req)
+        for idx, req in enumerate(requests)
+        if not subject or str(req.get("subject", "")) == subject
+    ]
+    if sample_seed is not None:
+        rng = random.Random(sample_seed)
+        rng.shuffle(indexed)
+    if limit > 0:
+        indexed = indexed[:limit]
+    return data, indexed
+
+
+def prepare_mmlu_dataset(
+    *,
+    dataset_path: Path,
+    work_dir: Path,
+    suite: dict[str, Any],
+    limit: int = 0,
+    subject: str = "",
+    sample_seed: int | None = None,
+) -> dict[str, Path]:
+    data, indexed = load_mmlu_requests(
+        dataset_path,
+        limit=limit,
+        subject=subject,
+        sample_seed=sample_seed,
+    )
+    work_dir.mkdir(parents=True, exist_ok=True)
+    requests = [req for _idx, req in indexed]
+    answers = _copy_dataset_header(data, requests)
+    answers_path = work_dir / "answers.json"
+    prompts_path = work_dir / "prompts.jsonl"
+    manifest_path = work_dir / "manifest.json"
+
+    answers_path.write_text(json.dumps(answers, indent=2, ensure_ascii=False), encoding="utf-8")
+    with prompts_path.open("w", encoding="utf-8") as f:
+        for out_idx, (dataset_index, request) in enumerate(indexed):
+            sample = {
+                "sample_id": f"mmlu_{dataset_index:06d}",
+                "dataset_index": dataset_index,
+                "eval_index": out_idx,
+                "subject": request.get("subject", ""),
+                "answer": request["answer"],
+                "prompt": _request_prompt(request),
+            }
+            f.write(json.dumps(sample, ensure_ascii=False) + "\n")
+
+    manifest = {
+        "suite": suite["id"],
+        "dataset": str(dataset_path),
+        "dataset_kind": suite.get("dataset", {}).get("kind", ""),
+        "request_count": len(indexed),
+        "subject": subject or "all",
+        "limit": limit,
+        "sample_seed": sample_seed,
+        "generation": suite.get("generation", {}),
+        "files": {
+            "answers": str(answers_path),
+            "prompts": str(prompts_path),
+        },
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return {"answers": answers_path, "prompts": prompts_path, "manifest": manifest_path}
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def max_prompt_token_length(
+    *,
+    model_id: str,
+    prompts_path: Path,
+    local_files_only: bool = False,
+    trust_remote_code: bool = False,
+) -> int:
+    try:
+        from transformers import AutoTokenizer
+    except Exception as exc:  # pragma: no cover - runtime dependency
+        raise RuntimeError("Prompt length check requires transformers") from exc
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_id,
+        local_files_only=local_files_only,
+        trust_remote_code=trust_remote_code,
+    )
+    max_len = 0
+    for row in load_jsonl(prompts_path):
+        prompt = str(row.get("prompt", ""))
+        length = len(tokenizer(prompt, add_special_tokens=False).input_ids)
+        max_len = max(max_len, length)
+    return max_len
+
+
+def validate_prompt_lengths_for_cache(
+    *,
+    model: dict[str, Any],
+    work_dir: Path,
+    max_cache_length: int,
+    local_files_only: bool = False,
+    trust_remote_code: bool = False,
+) -> int:
+    max_prompt_len = max_prompt_token_length(
+        model_id=str(model["hf_id"]),
+        prompts_path=work_dir / "prompts.jsonl",
+        local_files_only=local_files_only,
+        trust_remote_code=trust_remote_code or bool(model.get("trust_remote_code", False)),
+    )
+    if max_prompt_len > max_cache_length:
+        raise RuntimeError(
+            f"Dataset prompt length exceeds bundle cache for {model['name']}: "
+            f"max_prompt_tokens={max_prompt_len}, build_max_cache_length={max_cache_length}. "
+            "Use a smaller dataset slice/subject or set --build-max-cache-length high enough "
+            "for this model and TensorRT target."
+        )
+    return max_prompt_len
+
+
+def write_predictions(path: Path, rows: list[dict[str, Any]]) -> None:
+    payload = {"responses": rows}
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def predictions_file_valid(predictions_path: Path, answers_path: Path) -> bool:
+    if not predictions_path.is_file() or not answers_path.is_file():
+        return False
+    try:
+        predictions = json.loads(predictions_path.read_text(encoding="utf-8"))
+        answers = json.loads(answers_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    responses = predictions.get("responses")
+    requests = answers.get("requests")
+    return isinstance(responses, list) and isinstance(requests, list) and len(responses) == len(requests)
+
+
+def convert_trtfb_jsonl_to_predictions(raw_path: Path, predictions_path: Path) -> None:
+    rows = []
+    for row in load_jsonl(raw_path):
+        rows.append({
+            "sample_id": row.get("sample_id", ""),
+            "output_text": row.get("text", ""),
+            "generated_tokens": row.get("generated_tokens"),
+            "wall_ms": row.get("wall_ms"),
+            "source": "trtfb",
+        })
+    write_predictions(predictions_path, rows)
+
+
+def clean_text(text: str) -> str:
+    text = re.sub(r"(?:<think>)?.*?</think>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<\|.*?\|>", "", text)
+    return text.strip().strip("().,")
+
+
+def _strip_markdown(text: str) -> str:
+    return text.replace("**", "").replace("__", "").replace("`", "")
+
+
+def parse_multi_choice_response(text: str) -> str:
+    text = _strip_markdown(text.strip())
+    match = re.search(r"\banswer\s*(?:is|:)?\s*\(?([A-H])\b", text, re.IGNORECASE)
+    if match:
+        return match.group(1).upper()
+    if len(text) == 1 and text.upper() in CHOICE_LETTERS:
+        return text.upper()
+    match = re.match(r"^[\(]?([A-H])[\.\):\s]", text, re.IGNORECASE)
+    if match:
+        return match.group(1).upper()
+    return text
+
+
+def is_correct(prediction: str, reference: str) -> bool:
+    pred_clean = clean_text(prediction)
+    ref_clean = clean_text(reference)
+    if ref_clean in CHOICE_LETTERS:
+        pred_clean = parse_multi_choice_response(pred_clean)
+    return pred_clean == ref_clean
+
+
+def score_predictions(predictions_data: dict[str, Any], answers_data: dict[str, Any]) -> dict[str, Any]:
+    responses = predictions_data.get("responses", [])
+    requests = answers_data.get("requests", [])
+    if len(responses) != len(requests):
+        raise ValueError(
+            f"Predictions and answers must have the same length: "
+            f"{len(responses)} != {len(requests)}"
+        )
+
+    correct = 0
+    skipped = 0
+    subject_stats: dict[str, Counter[str]] = defaultdict(Counter)
+    samples: list[dict[str, Any]] = []
+    for idx, (response, request) in enumerate(zip(responses, requests, strict=True)):
+        output_text = str(response.get("output_text", ""))
+        subject = str(request.get("subject", ""))
+        answer = str(request["answer"])
+        if output_text == ERROR_OUTPUT_TEXT:
+            skipped += 1
+            samples.append({
+                "index": idx,
+                "sample_id": response.get("sample_id", f"sample_{idx}"),
+                "subject": subject,
+                "answer": answer,
+                "prediction": output_text,
+                "skipped": True,
+                "correct": False,
+            })
+            continue
+        ok = is_correct(output_text, answer)
+        correct += int(ok)
+        subject_stats[subject]["total"] += 1
+        subject_stats[subject]["correct"] += int(ok)
+        samples.append({
+            "index": idx,
+            "sample_id": response.get("sample_id", f"sample_{idx}"),
+            "subject": subject,
+            "answer": answer,
+            "prediction": output_text,
+            "parsed_prediction": parse_multi_choice_response(clean_text(output_text)),
+            "skipped": False,
+            "correct": ok,
+        })
+
+    valid = len(requests) - skipped
+    subject_accuracy = {}
+    for subject, stats in sorted(subject_stats.items()):
+        total = int(stats["total"])
+        subject_accuracy[subject] = {
+            "accuracy": (int(stats["correct"]) / total) if total else 0.0,
+            "correct": int(stats["correct"]),
+            "total": total,
+        }
+    return {
+        "overall_accuracy": (correct / valid) if valid else 0.0,
+        "correct": correct,
+        "valid_count": valid,
+        "skipped_count": skipped,
+        "total_count": len(requests),
+        "subject_accuracy": subject_accuracy,
+        "samples": samples,
+    }
+
+
+def compare_prediction_sets(
+    hf_predictions: dict[str, Any],
+    trtfb_predictions: dict[str, Any],
+    answers: dict[str, Any],
+) -> dict[str, Any]:
+    hf_score = score_predictions(hf_predictions, answers)
+    trtfb_score = score_predictions(trtfb_predictions, answers)
+    hf_responses = hf_predictions["responses"]
+    trt_responses = trtfb_predictions["responses"]
+    requests = answers["requests"]
+    if len(hf_responses) != len(trt_responses):
+        raise ValueError("HF and TRTFB predictions must have the same length")
+
+    agreement = 0
+    buckets = Counter()
+    disagreements: list[dict[str, Any]] = []
+    for idx, (hf_row, trt_row, req) in enumerate(zip(hf_responses, trt_responses, requests, strict=True)):
+        answer = str(req["answer"])
+        hf_pred = parse_multi_choice_response(clean_text(str(hf_row.get("output_text", ""))))
+        trt_pred = parse_multi_choice_response(clean_text(str(trt_row.get("output_text", ""))))
+        hf_ok = is_correct(str(hf_row.get("output_text", "")), answer)
+        trt_ok = is_correct(str(trt_row.get("output_text", "")), answer)
+        agreement += int(hf_pred == trt_pred)
+        if hf_ok and trt_ok:
+            buckets["both_correct"] += 1
+        elif hf_ok and not trt_ok:
+            buckets["hf_correct_trtfb_wrong"] += 1
+        elif not hf_ok and trt_ok:
+            buckets["hf_wrong_trtfb_correct"] += 1
+        else:
+            buckets["both_wrong"] += 1
+        if hf_pred != trt_pred:
+            disagreements.append({
+                "index": idx,
+                "sample_id": hf_row.get("sample_id", f"sample_{idx}"),
+                "subject": req.get("subject", ""),
+                "answer": answer,
+                "hf_prediction": hf_pred,
+                "trtfb_prediction": trt_pred,
+            })
+
+    total = len(requests)
+    return {
+        "hf": hf_score,
+        "trtfb": trtfb_score,
+        "accuracy_delta_trtfb_minus_hf": (
+            trtfb_score["overall_accuracy"] - hf_score["overall_accuracy"]
+        ),
+        "prediction_agreement_rate": (agreement / total) if total else 0.0,
+        "agreement_count": agreement,
+        "total_count": total,
+        "buckets": dict(buckets),
+        "disagreements": disagreements,
+    }
+
+
+def write_summary_markdown(summary: dict[str, Any], path: Path) -> None:
+    lines = [
+        "# Task Evaluation Summary",
+        "",
+        "| Backend | Accuracy | Correct | Valid | Skipped |",
+        "|---|---:|---:|---:|---:|",
+        (
+            f"| HF ref | {summary['hf']['overall_accuracy']:.4f} | "
+            f"{summary['hf']['correct']} | {summary['hf']['valid_count']} | "
+            f"{summary['hf']['skipped_count']} |"
+        ),
+        (
+            f"| TRTFB | {summary['trtfb']['overall_accuracy']:.4f} | "
+            f"{summary['trtfb']['correct']} | {summary['trtfb']['valid_count']} | "
+            f"{summary['trtfb']['skipped_count']} |"
+        ),
+        "",
+        f"- accuracy_delta_trtfb_minus_hf: {summary['accuracy_delta_trtfb_minus_hf']:.4f}",
+        f"- prediction_agreement_rate: {summary['prediction_agreement_rate']:.4f}",
+        "",
+        "| Bucket | Count |",
+        "|---|---:|",
+    ]
+    for key in ("both_correct", "hf_correct_trtfb_wrong", "hf_wrong_trtfb_correct", "both_wrong"):
+        lines.append(f"| {key} | {summary['buckets'].get(key, 0)} |")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def generation_defaults(work_dir: Path) -> dict[str, Any]:
+    manifest_path = work_dir / "manifest.json"
+    if not manifest_path.exists():
+        return {}
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return manifest.get("generation", {})
+
+
+def run_hf_reference(args: argparse.Namespace) -> None:
+    try:
+        import torch
+        from transformers import AutoModelForCausalLM, AutoTokenizer, logging
+    except Exception as exc:  # pragma: no cover - runtime dependency
+        raise RuntimeError("run-hf requires torch and transformers") from exc
+
+    work_dir = Path(args.work_dir)
+    answers = json.loads((work_dir / "answers.json").read_text(encoding="utf-8"))
+    prompt_rows = load_jsonl(work_dir / "prompts.jsonl")
+    if len(prompt_rows) != len(answers["requests"]):
+        raise ValueError("answers.json and prompts.jsonl must contain the same number of samples")
+    defaults = generation_defaults(work_dir)
+    max_new_tokens = args.max_new_tokens if args.max_new_tokens is not None else int(
+        defaults.get("max_new_tokens", 1)
+    )
+    temperature = args.temperature if args.temperature is not None else float(
+        defaults.get("temperature", 1.0)
+    )
+    top_k = args.top_k if args.top_k is not None else int(defaults.get("top_k", 1))
+    top_p = args.top_p if args.top_p is not None else float(defaults.get("top_p", 1.0))
+    seed = args.seed if args.seed is not None else int(defaults.get("seed", -1))
+    do_sample = args.do_sample or bool(defaults.get("do_sample", False))
+    apply_chat_template = args.apply_chat_template or bool(
+        defaults.get("apply_chat_template", answers.get("apply_chat_template", False))
+    )
+
+    logging.set_verbosity_error()
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.model,
+        trust_remote_code=args.trust_remote_code,
+        local_files_only=args.local_files_only,
+    )
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    dtype: str | Any = "auto"
+    if args.dtype == "float16":
+        dtype = torch.float16
+    elif args.dtype == "bfloat16":
+        dtype = torch.bfloat16
+
+    model_kwargs = {
+        "torch_dtype": dtype,
+        "trust_remote_code": args.trust_remote_code,
+        "local_files_only": args.local_files_only,
+    }
+    if args.device_map:
+        model_kwargs["device_map"] = args.device_map
+    if args.attn_impl:
+        model_kwargs["attn_implementation"] = args.attn_impl
+    model = AutoModelForCausalLM.from_pretrained(args.model, **model_kwargs).eval()
+    if not args.device_map:
+        device = torch.device(args.device)
+        model.to(device)
+    else:
+        device = model.device
+
+    raw_path = work_dir / (args.raw_output or "hf_raw.jsonl")
+    pred_path = work_dir / (args.predictions or "hf_predictions.json")
+    responses: list[dict[str, Any]] = []
+    with raw_path.open("w", encoding="utf-8") as raw_f:
+        for idx, request in enumerate(answers["requests"]):
+            prompt = str(prompt_rows[idx].get("prompt") or _request_prompt(request))
+            if apply_chat_template:
+                prompt = tokenizer.apply_chat_template(
+                    request["messages"],
+                    tokenize=False,
+                    add_generation_prompt=True,
+                )
+            encoded = tokenizer(prompt, return_tensors="pt")
+            encoded = {k: v.to(device) for k, v in encoded.items()}
+            if seed >= 0:
+                torch.manual_seed(seed + idx)
+                if torch.cuda.is_available():
+                    torch.cuda.manual_seed_all(seed + idx)
+            start = time.perf_counter()
+            with torch.inference_mode():
+                output_ids = model.generate(
+                    **encoded,
+                    max_new_tokens=max_new_tokens,
+                    do_sample=do_sample,
+                    temperature=temperature,
+                    top_k=top_k,
+                    top_p=top_p,
+                    num_beams=1,
+                    pad_token_id=tokenizer.pad_token_id,
+                    eos_token_id=tokenizer.eos_token_id,
+                )
+            wall_ms = (time.perf_counter() - start) * 1000.0
+            generated = output_ids[0, encoded["input_ids"].shape[1]:]
+            output_text = tokenizer.decode(generated, skip_special_tokens=False)
+            row = {
+                "sample_id": prompt_rows[idx].get("sample_id", f"mmlu_{idx:06d}"),
+                "output_text": output_text,
+                "generated_tokens": int(generated.shape[0]),
+                "wall_ms": wall_ms,
+                "source": "hf",
+            }
+            responses.append(row)
+            raw_f.write(json.dumps(row, ensure_ascii=False) + "\n")
+            raw_f.flush()
+            print(f"[task_eval.hf] sample={idx + 1}/{len(answers['requests'])}", file=sys.stderr)
+    write_predictions(pred_path, responses)
+    # Release the HF torch model and its GPU allocations so any in-process TRT
+    # build/run that follows does not contend with a resident reference model.
+    del model
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+def run_trtfb(args: argparse.Namespace) -> None:
+    work_dir = Path(args.work_dir)
+    defaults = generation_defaults(work_dir)
+    raw_output = work_dir / (args.raw_output or "trtfb_raw.jsonl")
+    predictions = work_dir / (args.predictions or "trtfb_predictions.json")
+    max_new_tokens = args.max_new_tokens if args.max_new_tokens is not None else int(
+        defaults.get("max_new_tokens", 1)
+    )
+    temperature = args.temperature if args.temperature is not None else float(
+        defaults.get("temperature", 1.0)
+    )
+    top_k = args.top_k if args.top_k is not None else int(defaults.get("top_k", 1))
+    top_p = args.top_p if args.top_p is not None else float(defaults.get("top_p", 1.0))
+    min_p = args.min_p if args.min_p is not None else float(defaults.get("min_p", 0.0))
+    seed = args.seed if args.seed is not None else int(defaults.get("seed", -1))
+
+    cmd = [
+        args.benchmark_binary,
+        args.bundle,
+        str(work_dir / "prompts.jsonl"),
+        str(raw_output),
+        "--max-new-tokens",
+        str(max_new_tokens),
+        "--temperature",
+        str(temperature),
+        "--top-k",
+        str(top_k),
+        "--top-p",
+        str(top_p),
+        "--min-p",
+        str(min_p),
+    ]
+    if seed >= 0:
+        cmd.extend(["--seed", str(seed)])
+    if args.hf_python:
+        cmd.extend(["--hf-python", args.hf_python])
+    if args.backend_dir:
+        cmd.extend(["--backend-dir", args.backend_dir])
+    if args.kv_cache_size:
+        cmd.extend(["--kv-cache-size", args.kv_cache_size])
+    if args.config:
+        cmd.extend(["--config", args.config])
+    for token in args.set or []:
+        cmd.extend(["--set", token])
+    if args.chat_template or bool(defaults.get("apply_chat_template", False)):
+        cmd.append("--chat-template")
+    if not bool(defaults.get("enable_thinking", True)):
+        cmd.append("--no-thinking")
+
+    env = os.environ.copy()
+    if args.cuda_visible_devices:
+        env["CUDA_VISIBLE_DEVICES"] = args.cuda_visible_devices
+    log_path = work_dir / (args.log or "trtfb_run.log")
+    with log_path.open("w", encoding="utf-8") as log_f:
+        proc = subprocess.run(cmd, check=False, text=True, stdout=log_f, stderr=subprocess.STDOUT, env=env)
+    if proc.returncode != 0:
+        raise RuntimeError(f"TRTFB task eval failed with rc={proc.returncode}; see {log_path}")
+    convert_trtfb_jsonl_to_predictions(raw_output, predictions)
+
+
+def _manifest_build_method(build_args: dict[str, Any]) -> str | None:
+    backend = str(build_args.get("backend", build_args.get("method", "")) or "").lower()
+    if backend in {"torchtrt", "torch_trt"} or build_args.get("torch_trt", False):
+        return "torchtrt"
+    if backend == "trt":
+        return "trt"
+    return None
+
+
+def _manifest_tensor_parallel_size(build_args: dict[str, Any]) -> int | None:
+    parallel = build_args.get("parallel", {})
+    if isinstance(parallel, dict):
+        value = parallel.get("tp_size", parallel.get("tensor_parallel_size"))
+        mode = str(parallel.get("mode", "") or "").lower()
+    else:
+        value = build_args.get("tp_size", build_args.get("tensor_parallel_size"))
+        mode = str(build_args.get("parallel_mode", "") or "").lower()
+    if value is None:
+        return None
+    try:
+        tp_size = int(value)
+    except (TypeError, ValueError):
+        return None
+    if tp_size > 1 or mode == "tensor_parallel":
+        return tp_size
+    return None
+
+
+def build_bundle_command(
+    model: dict[str, Any],
+    *,
+    trtmc_binary: str,
+    bundle_path: Path,
+    max_cache_length: int | None = None,
+    extra_build_args: list[str] | None = None,
+) -> list[str]:
+    cache_length = int(max_cache_length or model.get("max_cache_length", 256))
+    cmd = [
+        trtmc_binary,
+        "build",
+        str(model["hf_id"]),
+        "-o",
+        str(bundle_path),
+        "--max-cache-length",
+        str(cache_length),
+    ]
+    build_args = model.get("build_args", {})
+    method = _manifest_build_method(build_args)
+    if method:
+        cmd.extend(["--method", method])
+    tp_size = _manifest_tensor_parallel_size(build_args)
+    if tp_size is not None and tp_size > 1:
+        cmd.extend(["--tp-size", str(tp_size)])
+    precision = str(model.get("precision", "fp32") or "fp32")
+    if precision != "fp32":
+        cmd.extend(["--precision", precision])
+    quantization = model.get("quantization", {})
+    if isinstance(quantization, dict):
+        quant_format = quantization.get("format")
+        if quant_format and quant_format != "none":
+            cmd.extend(["--quantize", str(quant_format)])
+            scale_artifact = quantization.get("scale_artifact")
+            if scale_artifact:
+                cmd.extend(["--quant-scales", str(scale_artifact)])
+            calibration_samples = quantization.get("calibration_samples")
+            if calibration_samples is not None:
+                cmd.extend(["--quant-calibration-samples", str(calibration_samples)])
+    if model.get("trust_remote_code"):
+        cmd.append("--trust-remote-code")
+    fp8_scales = model.get("fp8_scales")
+    if fp8_scales:
+        scales_path = REPO_ROOT / "tests" / "e2e" / "data" / str(fp8_scales)
+        if scales_path.is_file():
+            cmd.extend(["--fp8-scales", str(scales_path)])
+    if extra_build_args:
+        cmd.extend(extra_build_args)
+    return cmd
+
+
+def requested_build_max_cache_length(
+    suite: dict[str, Any],
+    model: dict[str, Any],
+    build_max_cache_length: int | None = None,
+    prompt_max_tokens: int | None = None,
+) -> int:
+    if build_max_cache_length is not None:
+        return int(build_max_cache_length)
+    model_cache = int(model.get("max_cache_length", 256) or 256)
+    suite_cache = int(suite.get("build", {}).get("min_max_cache_length", 0) or 0)
+    prompt_cache = int(prompt_max_tokens or 0)
+    return max(model_cache, suite_cache, prompt_cache)
+
+
+def bundle_max_cache_length(bundle_path: Path, trtmc_binary: str) -> int | None:
+    try:
+        proc = subprocess.run(
+            [trtmc_binary, "inspect", str(bundle_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    match = re.search(r"^Max cache length:\s+(\d+)\s*$", proc.stdout, re.MULTILINE)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def ensure_bundle(
+    model: dict[str, Any],
+    *,
+    bundle_path: Path,
+    trtmc_binary: str,
+    max_cache_length: int | None = None,
+    force_build: bool = False,
+    extra_build_args: list[str] | None = None,
+    log_path: Path | None = None,
+) -> tuple[Path, bool]:
+    if bundle_path.is_file() and not force_build:
+        if max_cache_length is None:
+            return bundle_path, False
+        existing_cache = bundle_max_cache_length(bundle_path, trtmc_binary)
+        if existing_cache is None or existing_cache >= max_cache_length:
+            return bundle_path, False
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = build_bundle_command(
+        model,
+        trtmc_binary=trtmc_binary,
+        bundle_path=bundle_path,
+        max_cache_length=max_cache_length,
+        extra_build_args=extra_build_args,
+    )
+    log_path = log_path or bundle_path.with_suffix(".build.log")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w", encoding="utf-8") as log_f:
+        proc = subprocess.run(cmd, check=False, text=True, stdout=log_f, stderr=subprocess.STDOUT)
+    if proc.returncode != 0:
+        raise RuntimeError(f"Bundle build failed for {model['name']} rc={proc.returncode}; see {log_path}")
+    return bundle_path, True
+
+
+def model_matches_selector(model: dict[str, Any], selector: str) -> bool:
+    return selector in {
+        str(model.get("name", "")),
+        str(model.get("hf_id", "")),
+        str(model.get("bundle", "")),
+    }
+
+
+def selected_models_for_suite(
+    suite: dict[str, Any],
+    models: list[dict[str, Any]],
+    *,
+    selectors: list[str] | None = None,
+    single_device_only: bool = False,
+    waives: dict[str, tuple[str, str]] | None = None,
+    include_waived: bool = False,
+) -> list[dict[str, Any]]:
+    rows = build_plan(
+        [suite],
+        models,
+        suite_id=suite["id"],
+        single_device_only=single_device_only,
+        waives=waives,
+        include_waived=include_waived or bool(selectors),
+    )
+    selected_names = {row["model"] for row in rows if row["selected"]}
+    selected = [model for model in models if model["name"] in selected_names]
+    if selectors:
+        filtered: list[dict[str, Any]] = []
+        missing: list[str] = []
+        for selector in selectors:
+            matches = [model for model in selected if model_matches_selector(model, selector)]
+            if not matches:
+                missing.append(selector)
+            filtered.extend(matches)
+        if missing:
+            raise ValueError(f"Model selector(s) not found in suite {suite['id']}: {', '.join(missing)}")
+        # Preserve manifest order and drop duplicates from overlapping selectors.
+        wanted = {model["name"] for model in filtered}
+        selected = [model for model in selected if model["name"] in wanted]
+    return selected
+
+
+def _namespace_for_run_hf(args: argparse.Namespace, model: dict[str, Any], work_dir: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        model=model["hf_id"],
+        work_dir=str(work_dir),
+        predictions="hf_predictions.json",
+        raw_output="hf_raw.jsonl",
+        dtype=args.hf_dtype,
+        device=args.hf_device,
+        device_map=args.hf_device_map,
+        attn_impl=args.hf_attn_impl,
+        trust_remote_code=args.trust_remote_code or bool(model.get("trust_remote_code", False)),
+        local_files_only=args.local_files_only,
+        do_sample=args.do_sample,
+        apply_chat_template=args.apply_chat_template,
+        max_new_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+        top_k=args.top_k,
+        top_p=args.top_p,
+        min_p=args.min_p,
+        seed=args.seed,
+    )
+
+
+def _namespace_for_run_trtfb(args: argparse.Namespace, bundle_path: Path, work_dir: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        bundle=str(bundle_path),
+        work_dir=str(work_dir),
+        benchmark_binary=args.benchmark_binary,
+        hf_python=args.hf_python,
+        backend_dir=args.backend_dir,
+        kv_cache_size=args.kv_cache_size,
+        config=args.config,
+        set=args.set or [],
+        cuda_visible_devices=args.cuda_visible_devices,
+        chat_template=args.chat_template,
+        predictions="trtfb_predictions.json",
+        raw_output="trtfb_raw.jsonl",
+        log="trtfb_run.log",
+        max_new_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+        top_k=args.top_k,
+        top_p=args.top_p,
+        min_p=args.min_p,
+        seed=args.seed,
+    )
+
+
+def run_hf_reference_subprocess(
+    args: argparse.Namespace, model: dict[str, Any], work_dir: Path
+) -> None:
+    """Run the HF reference in a dedicated subprocess.
+
+    Keeping the torch/transformers reference model in its own process guarantees
+    its GPU memory is fully reclaimed when the process exits, before the TRT
+    bundle build and TRTFB inference run for the same model. This prevents the
+    resident reference model from contending with the TRT engine + KV cache.
+    """
+    hf_args = _namespace_for_run_hf(args, model, work_dir)
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "run-hf",
+        "--model", str(hf_args.model),
+        "--work-dir", str(hf_args.work_dir),
+        "--predictions", str(hf_args.predictions),
+        "--raw-output", str(hf_args.raw_output),
+        "--dtype", str(hf_args.dtype),
+        "--device", str(hf_args.device),
+    ]
+    if hf_args.device_map:
+        cmd.extend(["--device-map", str(hf_args.device_map)])
+    if hf_args.attn_impl:
+        cmd.extend(["--attn-impl", str(hf_args.attn_impl)])
+    if hf_args.trust_remote_code:
+        cmd.append("--trust-remote-code")
+    if hf_args.local_files_only:
+        cmd.append("--local-files-only")
+    if hf_args.do_sample:
+        cmd.append("--do-sample")
+    if hf_args.apply_chat_template:
+        cmd.append("--apply-chat-template")
+    for flag, value in (
+        ("--max-new-tokens", hf_args.max_new_tokens),
+        ("--temperature", hf_args.temperature),
+        ("--top-k", hf_args.top_k),
+        ("--top-p", hf_args.top_p),
+        ("--min-p", hf_args.min_p),
+        ("--seed", hf_args.seed),
+    ):
+        if value is not None:
+            cmd.extend([flag, str(value)])
+    log_path = work_dir / "hf_run.log"
+    env = os.environ.copy()
+    env.setdefault("TOKENIZERS_PARALLELISM", "false")
+    env.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    with log_path.open("w", encoding="utf-8") as log_f:
+        proc = subprocess.run(
+            cmd, check=False, text=True, stdout=log_f, stderr=subprocess.STDOUT, env=env
+        )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"HF reference subprocess failed for {model['name']} rc={proc.returncode}; see {log_path}"
+        )
+
+
+def eval_one_model(
+    *,
+    suite: dict[str, Any],
+    model: dict[str, Any],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    work_root = Path(args.work_root)
+    work_dir = work_root / suite["id"] / str(model["name"])
+    dataset_path = Path(args.dataset or suite.get("dataset", {}).get("default_path", ""))
+    if not dataset_path:
+        raise ValueError(f"Suite {suite['id']} has no dataset path; pass --dataset")
+    prepare_mmlu_dataset(
+        dataset_path=dataset_path,
+        work_dir=work_dir,
+        suite=suite,
+        limit=args.limit,
+        subject=args.subject,
+        sample_seed=args.sample_seed,
+    )
+
+    answers_path = work_dir / "answers.json"
+    hf_predictions = work_dir / "hf_predictions.json"
+    hf_reused = predictions_file_valid(hf_predictions, answers_path) and not args.force_hf
+    if not hf_reused:
+        # Run HF in its own process so its GPU memory is fully reclaimed before
+        # the TRT bundle build and TRTFB inference for this model.
+        run_hf_reference_subprocess(args, model, work_dir)
+
+    if args.bundle:
+        if len(args.model or []) != 1:
+            raise ValueError("--bundle can only be used when exactly one --model is selected")
+        bundle_path = Path(args.bundle)
+    else:
+        engine_dir = Path(args.engine_dir or (work_root / "_bundles"))
+        bundle_path = engine_dir / str(model["bundle"])
+
+    max_prompt_len = None
+    if not args.skip_prompt_length_check:
+        max_prompt_len = max_prompt_token_length(
+            model_id=str(model["hf_id"]),
+            prompts_path=work_dir / "prompts.jsonl",
+            local_files_only=args.local_files_only,
+            trust_remote_code=args.trust_remote_code or bool(model.get("trust_remote_code", False)),
+        )
+    max_cache_length = requested_build_max_cache_length(
+        suite,
+        model,
+        args.build_max_cache_length,
+        prompt_max_tokens=max_prompt_len,
+    )
+    if max_prompt_len is not None and max_prompt_len > max_cache_length:
+        raise RuntimeError(
+            f"Dataset prompt length exceeds bundle cache for {model['name']}: "
+            f"max_prompt_tokens={max_prompt_len}, build_max_cache_length={max_cache_length}. "
+            "Use a smaller dataset slice/subject or set --build-max-cache-length high enough "
+            "for this model and TensorRT target."
+        )
+    bundle_path, built = ensure_bundle(
+        model,
+        bundle_path=bundle_path,
+        trtmc_binary=args.trtmc_binary,
+        max_cache_length=max_cache_length,
+        force_build=args.force_build,
+        extra_build_args=args.extra_build_arg,
+        log_path=work_dir / "build.log",
+    )
+
+    # TRT inference intentionally runs every eval invocation so runtime changes
+    # are never hidden behind stale predictions.
+    run_trtfb(_namespace_for_run_trtfb(args, bundle_path, work_dir))
+
+    summary = compare_prediction_sets(
+        json.loads((work_dir / "hf_predictions.json").read_text(encoding="utf-8")),
+        json.loads((work_dir / "trtfb_predictions.json").read_text(encoding="utf-8")),
+        json.loads(answers_path.read_text(encoding="utf-8")),
+    )
+    (work_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    write_summary_markdown(summary, work_dir / "summary.md")
+    result = {
+        "suite": suite["id"],
+        "model": model["name"],
+        "hf_id": model["hf_id"],
+        "work_dir": str(work_dir),
+        "bundle": str(bundle_path),
+        "build_max_cache_length": max_cache_length,
+        "max_prompt_tokens": max_prompt_len,
+        "hf_reused": hf_reused,
+        "bundle_built": built,
+        "hf_accuracy": summary["hf"]["overall_accuracy"],
+        "trtfb_accuracy": summary["trtfb"]["overall_accuracy"],
+        "accuracy_delta_trtfb_minus_hf": summary["accuracy_delta_trtfb_minus_hf"],
+        "prediction_agreement_rate": summary["prediction_agreement_rate"],
+    }
+    (work_dir / "eval_result.json").write_text(
+        json.dumps(result, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return result
+
+
+def add_generation_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--max-new-tokens", type=int)
+    parser.add_argument("--temperature", type=float)
+    parser.add_argument("--top-k", type=int)
+    parser.add_argument("--top-p", type=float)
+    parser.add_argument("--min-p", type=float)
+    parser.add_argument("--seed", type=int)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Local dataset task evaluation for TRTMC bundles.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("list-suites")
+    p.add_argument("--suites", default=str(DEFAULT_SUITES))
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("plan")
+    p.add_argument("--suites", default=str(DEFAULT_SUITES))
+    p.add_argument("--suite")
+    p.add_argument("--models-dir", default=str(DEFAULT_MODELS_DIR))
+    p.add_argument("--waives", default=str(DEFAULT_WAIVES), help="E2E waives file used to skip known-bad models.")
+    p.add_argument("--waive-platform", default="", help="Platform prefix to honor in the waives file.")
+    p.add_argument("--include-waived", action="store_true", help="Include models listed in the waives file.")
+    p.add_argument(
+        "--single-device-only",
+        dest="single_device_only",
+        action="store_true",
+        help="Exclude manifests that require multi-device or distributed runtime.",
+    )
+    p.add_argument("--include-non-matching", action="store_true")
+    p.add_argument("--format", choices=["table", "json"], default="table")
+    p.add_argument("--output")
+
+    p = sub.add_parser("prepare")
+    p.add_argument("--suites", default=str(DEFAULT_SUITES))
+    p.add_argument("--suite", default="mmlu_five_shot_mcq")
+    p.add_argument("--dataset")
+    p.add_argument("--work-dir", required=True)
+    p.add_argument("--limit", type=int, default=0)
+    p.add_argument("--subject", default="")
+    p.add_argument("--sample-seed", type=int)
+
+    p = sub.add_parser("run-hf")
+    p.add_argument("--model", required=True)
+    p.add_argument("--work-dir", required=True)
+    p.add_argument("--predictions")
+    p.add_argument("--raw-output")
+    p.add_argument("--dtype", choices=["auto", "float16", "bfloat16"], default="auto")
+    p.add_argument("--device", default="cuda")
+    p.add_argument("--device-map", default="")
+    p.add_argument("--attn-impl", default="")
+    p.add_argument("--trust-remote-code", action="store_true")
+    p.add_argument("--local-files-only", action="store_true")
+    p.add_argument("--do-sample", action="store_true")
+    p.add_argument("--apply-chat-template", action="store_true")
+    add_generation_args(p)
+
+    p = sub.add_parser("run-trtfb")
+    p.add_argument("--bundle", required=True)
+    p.add_argument("--work-dir", required=True)
+    p.add_argument("--benchmark-binary", default="build/trtmc_dataset_benchmark")
+    p.add_argument("--hf-python", default="")
+    p.add_argument("--backend-dir", default="")
+    p.add_argument("--kv-cache-size", default="")
+    p.add_argument("--config", default="")
+    p.add_argument("--set", action="append", default=[])
+    p.add_argument("--cuda-visible-devices", default="")
+    p.add_argument("--chat-template", action="store_true")
+    p.add_argument("--predictions")
+    p.add_argument("--raw-output")
+    p.add_argument("--log")
+    add_generation_args(p)
+
+    p = sub.add_parser("convert-trtfb")
+    p.add_argument("--raw", required=True)
+    p.add_argument("--predictions", required=True)
+
+    p = sub.add_parser("score")
+    p.add_argument("--answers")
+    p.add_argument("--predictions")
+    p.add_argument("--output")
+    p.add_argument("--work-dir")
+    p.add_argument("--label", default="")
+
+    p = sub.add_parser("compare")
+    p.add_argument("--work-dir", required=True)
+    p.add_argument("--answers")
+    p.add_argument("--hf-predictions")
+    p.add_argument("--trtfb-predictions")
+    p.add_argument("--output", default="")
+    p.add_argument("--markdown", default="")
+
+    p = sub.add_parser("eval-worker", help=argparse.SUPPRESS)
+    p.add_argument("--request", required=True)
+
+    p = sub.add_parser("eval")
+    p.add_argument("--suites", default=str(DEFAULT_SUITES))
+    p.add_argument("--suite", default="mmlu_five_shot_mcq")
+    p.add_argument("--dataset")
+    p.add_argument(
+        "--model",
+        action="append",
+        default=[],
+        help="Manifest name, HF id, or bundle filename to evaluate. Repeatable.",
+    )
+    p.add_argument("--models-dir", default=str(DEFAULT_MODELS_DIR))
+    p.add_argument("--waives", default=str(DEFAULT_WAIVES), help="E2E waives file used to skip known-bad models.")
+    p.add_argument("--waive-platform", default="", help="Platform prefix to honor in the waives file.")
+    p.add_argument("--include-waived", action="store_true", help="Include models listed in the waives file.")
+    p.add_argument("--work-root", default="/tmp/trtmc-task-eval")
+    p.add_argument("--engine-dir", default="")
+    p.add_argument("--bundle", default="", help="Prebuilt bundle path; only valid with one --model.")
+    p.add_argument(
+        "--single-device-only",
+        dest="single_device_only",
+        action="store_true",
+        help="Exclude manifests that require multi-device or distributed runtime.",
+    )
+    p.add_argument("--limit", type=int, default=0)
+    p.add_argument("--subject", default="")
+    p.add_argument("--sample-seed", type=int)
+    p.add_argument("--force-hf", action="store_true", help="Regenerate HF reference outputs.")
+    p.add_argument("--force-build", action="store_true", help="Rebuild the .trtfb bundle.")
+    p.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Stop on the first model failure. By default eval records the failure and continues.",
+    )
+    p.add_argument(
+        "--build-max-cache-length",
+        type=int,
+        help="Override the build max-cache-length. Defaults to max(manifest, suite minimum).",
+    )
+    p.add_argument(
+        "--skip-prompt-length-check",
+        action="store_true",
+        help="Skip tokenizer-based prompt length validation before TRTFB build/run.",
+    )
+    p.add_argument("--trtmc-binary", default="build/trtmc")
+    p.add_argument("--benchmark-binary", default="build/trtmc_dataset_benchmark")
+    p.add_argument("--hf-python", default="")
+    p.add_argument("--backend-dir", default="")
+    p.add_argument("--kv-cache-size", default="")
+    p.add_argument("--config", default="")
+    p.add_argument("--set", action="append", default=[])
+    p.add_argument("--extra-build-arg", action="append", default=[])
+    p.add_argument("--cuda-visible-devices", default="")
+    p.add_argument("--chat-template", action="store_true")
+    p.add_argument("--apply-chat-template", action="store_true")
+    p.add_argument("--trust-remote-code", action="store_true")
+    p.add_argument("--local-files-only", action="store_true")
+    p.add_argument("--do-sample", action="store_true")
+    p.add_argument("--hf-dtype", choices=["auto", "float16", "bfloat16"], default="auto")
+    p.add_argument("--hf-device", default="cuda")
+    p.add_argument("--hf-device-map", default="")
+    p.add_argument("--hf-attn-impl", default="")
+    add_generation_args(p)
+    return parser
+
+
+def cmd_list_suites(args: argparse.Namespace) -> int:
+    suites = load_suites(Path(args.suites))
+    if args.json:
+        print(json.dumps({"suites": suites}, indent=2))
+    else:
+        for suite in suites:
+            print(f"{suite['id']}\t{suite.get('dataset', {}).get('kind', '')}\t{suite.get('description', '')}")
+    return 0
+
+
+def cmd_plan(args: argparse.Namespace) -> int:
+    suites = load_suites(Path(args.suites))
+    models = load_manifest_records(Path(args.models_dir))
+    waives = load_waives(Path(args.waives), args.waive_platform) if args.waives else {}
+    rows = build_plan(
+        suites,
+        models,
+        suite_id=args.suite,
+        single_device_only=args.single_device_only,
+        include_non_matching=args.include_non_matching,
+        waives=waives,
+        include_waived=args.include_waived,
+    )
+    payload = {"count": len(rows), "rows": rows}
+    if args.output:
+        Path(args.output).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    if args.format == "json":
+        print(json.dumps(payload, indent=2))
+    else:
+        print_plan_table(rows)
+    return 0
+
+
+def cmd_prepare(args: argparse.Namespace) -> int:
+    suites = load_suites(Path(args.suites))
+    suite = suite_by_id(suites, args.suite)
+    dataset_kind = suite.get("dataset", {}).get("kind", "")
+    if dataset_kind != "mmlu_five_shot_json":
+        raise ValueError(f"prepare currently supports mmlu_five_shot_json, got {dataset_kind!r}")
+    dataset_path = Path(args.dataset or suite.get("dataset", {}).get("default_path", ""))
+    if not dataset_path:
+        raise ValueError(f"Suite {args.suite} has no dataset path; pass --dataset")
+    outputs = prepare_mmlu_dataset(
+        dataset_path=dataset_path,
+        work_dir=Path(args.work_dir),
+        suite=suite,
+        limit=args.limit,
+        subject=args.subject,
+        sample_seed=args.sample_seed,
+    )
+    print(json.dumps({k: str(v) for k, v in outputs.items()}, indent=2))
+    return 0
+
+
+def cmd_convert_trtfb(args: argparse.Namespace) -> int:
+    convert_trtfb_jsonl_to_predictions(Path(args.raw), Path(args.predictions))
+    return 0
+
+
+def cmd_score(args: argparse.Namespace) -> int:
+    if args.work_dir:
+        work_dir = Path(args.work_dir)
+        answers_path = Path(args.answers) if args.answers else work_dir / "answers.json"
+        predictions_path = (
+            Path(args.predictions)
+            if args.predictions
+            else work_dir / f"{args.label}_predictions.json"
+            if args.label
+            else work_dir / "trtfb_predictions.json"
+        )
+        label = args.label or predictions_path.stem.removesuffix("_predictions")
+        output_path = Path(args.output) if args.output else work_dir / f"{label}_score.json"
+    else:
+        if not args.answers or not args.predictions:
+            raise ValueError("score requires --answers and --predictions without --work-dir")
+        answers_path = Path(args.answers)
+        predictions_path = Path(args.predictions)
+        output_path = Path(args.output) if args.output else predictions_path.with_suffix(".score.json")
+    score = score_predictions(
+        json.loads(predictions_path.read_text(encoding="utf-8")),
+        json.loads(answers_path.read_text(encoding="utf-8")),
+    )
+    output_path.write_text(json.dumps(score, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(
+        f"accuracy={score['overall_accuracy']:.4f} "
+        f"correct={score['correct']}/{score['valid_count']} "
+        f"skipped={score['skipped_count']} output={output_path}"
+    )
+    return 0
+
+
+def cmd_compare(args: argparse.Namespace) -> int:
+    work_dir = Path(args.work_dir)
+    answers_path = Path(args.answers) if args.answers else work_dir / "answers.json"
+    hf_path = Path(args.hf_predictions) if args.hf_predictions else work_dir / "hf_predictions.json"
+    trtfb_path = (
+        Path(args.trtfb_predictions) if args.trtfb_predictions else work_dir / "trtfb_predictions.json"
+    )
+    summary = compare_prediction_sets(
+        json.loads(hf_path.read_text(encoding="utf-8")),
+        json.loads(trtfb_path.read_text(encoding="utf-8")),
+        json.loads(answers_path.read_text(encoding="utf-8")),
+    )
+    output = Path(args.output) if args.output else work_dir / "summary.json"
+    markdown = Path(args.markdown) if args.markdown else work_dir / "summary.md"
+    output.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    write_summary_markdown(summary, markdown)
+    print(
+        f"hf_accuracy={summary['hf']['overall_accuracy']:.4f} "
+        f"trtfb_accuracy={summary['trtfb']['overall_accuracy']:.4f} "
+        f"agreement={summary['prediction_agreement_rate']:.4f} "
+        f"output={output}"
+    )
+    return 0
+
+
+def model_work_dir(args: argparse.Namespace, suite: dict[str, Any], model: dict[str, Any]) -> Path:
+    return Path(args.work_root) / suite["id"] / str(model["name"])
+
+
+def model_bundle_path(args: argparse.Namespace, model: dict[str, Any]) -> Path:
+    if args.bundle:
+        return Path(args.bundle)
+    work_root = Path(args.work_root)
+    engine_dir = Path(args.engine_dir or (work_root / "_bundles"))
+    return engine_dir / str(model["bundle"])
+
+
+def model_failure_result(
+    *,
+    suite: dict[str, Any],
+    model: dict[str, Any],
+    args: argparse.Namespace,
+    exc: BaseException | None = None,
+    error_type: str = "",
+    error: str = "",
+) -> dict[str, Any]:
+    return {
+        "suite": suite["id"],
+        "model": model["name"],
+        "hf_id": model["hf_id"],
+        "work_dir": str(model_work_dir(args, suite, model)),
+        "bundle": str(model_bundle_path(args, model)),
+        "status": "failed",
+        "error_type": error_type or (type(exc).__name__ if exc else "RuntimeError"),
+        "error": error or (str(exc) if exc else ""),
+    }
+
+
+def model_skipped_result(
+    *,
+    suite: dict[str, Any],
+    model: dict[str, Any],
+    args: argparse.Namespace,
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "suite": suite["id"],
+        "model": model["name"],
+        "hf_id": model["hf_id"],
+        "work_dir": str(model_work_dir(args, suite, model)),
+        "bundle": str(model_bundle_path(args, model)),
+        "status": "skipped",
+        "reason": reason,
+    }
+
+
+def gpu_memory_used_mib() -> list[int]:
+    try:
+        proc = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return []
+    if proc.returncode != 0:
+        return []
+    used: list[int] = []
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            used.append(int(line.split()[0]))
+        except (ValueError, IndexError):
+            return []
+    return used
+
+
+def gpu_memory_back_to_baseline(
+    *,
+    before_mib: list[int],
+    timeout_s: float = 30.0,
+    poll_s: float = 2.0,
+    margin_mib: int = 512,
+) -> tuple[bool | None, list[int]]:
+    if not before_mib:
+        return None, []
+    deadline = time.monotonic() + timeout_s
+    current: list[int] = []
+    while time.monotonic() <= deadline:
+        current = gpu_memory_used_mib()
+        if not current or len(current) != len(before_mib):
+            return None, current
+        if all(after <= before + margin_mib for before, after in zip(before_mib, current, strict=True)):
+            return True, current
+        time.sleep(poll_s)
+    return False, current
+
+
+def is_oom_failure(result: dict[str, Any], returncode: int = 0) -> bool:
+    text = " ".join(
+        str(result.get(key, ""))
+        for key in ("error", "error_type", "worker_log_tail")
+    ).lower()
+    return (
+        "out of memory" in text
+        or "cuda oom" in text
+        or "cublas_status_alloc_failed" in text
+        or "cudnn_status_alloc_failed" in text
+        or "std::bad_alloc" in text
+        or returncode == -9
+    )
+
+
+def should_use_model_workers(args: argparse.Namespace, selected: list[dict[str, Any]]) -> bool:
+    return len(selected) > 1 and not bool(getattr(args, "disable_model_process_isolation", False))
+
+
+def _worker_args_payload(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in vars(args).items()
+        if key != "cmd" and isinstance(value, (str, int, float, bool, list, type(None)))
+    }
+
+
+def _read_log_tail(path: Path, max_chars: int = 4096) -> str:
+    if not path.is_file():
+        return ""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    return text[-max_chars:]
+
+
+def run_eval_model_worker(
+    *,
+    suite: dict[str, Any],
+    model: dict[str, Any],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    work_dir = model_work_dir(args, suite, model)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    request_path = work_dir / "eval_worker_request.json"
+    result_path = work_dir / "eval_worker_result.json"
+    log_path = work_dir / "eval_worker.log"
+    before_mib = gpu_memory_used_mib()
+    request = {
+        "suite": suite,
+        "model": model,
+        "args": _worker_args_payload(args),
+        "result_path": str(result_path),
+    }
+    request_path.write_text(json.dumps(request, indent=2, ensure_ascii=False), encoding="utf-8")
+    cmd = [sys.executable, str(Path(__file__).resolve()), "eval-worker", "--request", str(request_path)]
+    env = os.environ.copy()
+    env.setdefault("TOKENIZERS_PARALLELISM", "false")
+    env.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    with log_path.open("w", encoding="utf-8") as log_f:
+        proc = subprocess.run(cmd, check=False, text=True, stdout=log_f, stderr=subprocess.STDOUT, env=env)
+
+    if result_path.is_file():
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+    else:
+        result = model_failure_result(
+            suite=suite,
+            model=model,
+            args=args,
+            error_type="WorkerProcessError",
+            error=f"worker exited with rc={proc.returncode} before writing {result_path}",
+        )
+    result["worker_returncode"] = proc.returncode
+    result["worker_log"] = str(log_path)
+    if proc.returncode != 0 and result.get("status") != "failed":
+        result["status"] = "failed"
+        result["error_type"] = "WorkerProcessError"
+        result["error"] = f"worker exited with rc={proc.returncode}; see {log_path}"
+    if result.get("status") == "failed":
+        result["worker_log_tail"] = _read_log_tail(log_path)
+
+    # Verify GPU memory returned near this model's pre-run baseline for EVERY
+    # model (pass or fail), not only on OOM, so a leak or a still-running child
+    # from one model cannot silently corrupt the next model's run.
+    cleanup_confirmed, after_mib = gpu_memory_back_to_baseline(before_mib=before_mib)
+    result["gpu_memory_before_mib"] = before_mib
+    result["gpu_memory_after_cleanup_mib"] = after_mib
+    result["gpu_cleanup_confirmed"] = cleanup_confirmed
+    if cleanup_confirmed is False:
+        result["gpu_cleanup_error"] = (
+            "GPU memory did not return near the pre-model baseline after the worker exited"
+        )
+    return result
+
+
+def cmd_eval_worker(args: argparse.Namespace) -> int:
+    request = json.loads(Path(args.request).read_text(encoding="utf-8"))
+    suite = request["suite"]
+    model = request["model"]
+    worker_args = argparse.Namespace(**request["args"])
+    result_path = Path(request["result_path"])
+    try:
+        result = eval_one_model(suite=suite, model=model, args=worker_args)
+        result["status"] = "passed"
+        result_path.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+        return 0
+    except Exception as exc:
+        traceback.print_exc()
+        result = model_failure_result(suite=suite, model=model, args=worker_args, exc=exc)
+        result_path.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+        return 1
+
+
+def cmd_eval(args: argparse.Namespace) -> int:
+    suites = load_suites(Path(args.suites))
+    suite = suite_by_id(suites, args.suite)
+    dataset_kind = suite.get("dataset", {}).get("kind", "")
+    if dataset_kind != "mmlu_five_shot_json":
+        raise ValueError(f"eval currently supports mmlu_five_shot_json, got {dataset_kind!r}")
+    models = load_manifest_records(Path(args.models_dir))
+    waives = load_waives(Path(args.waives), args.waive_platform) if args.waives else {}
+    selected = selected_models_for_suite(
+        suite,
+        models,
+        selectors=args.model,
+        single_device_only=args.single_device_only,
+        waives=waives,
+        include_waived=args.include_waived,
+    )
+    if not selected:
+        raise ValueError(f"No models selected for suite {suite['id']}")
+    if args.bundle and len(selected) != 1:
+        raise ValueError("--bundle can only be used when exactly one model is selected")
+
+    results = []
+    use_workers = should_use_model_workers(args, selected)
+    for idx, model in enumerate(selected, start=1):
+        print(f"[task_eval] ({idx}/{len(selected)}) suite={suite['id']} model={model['name']}")
+        if use_workers:
+            result = run_eval_model_worker(suite=suite, model=model, args=args)
+            if result.get("status") == "failed":
+                results.append(result)
+                print(
+                    f"[task_eval] model={model['name']} status=failed "
+                    f"error_type={result.get('error_type', '')} error={result.get('error', '')} "
+                    f"log={result.get('worker_log', '')}"
+                )
+                if args.fail_fast:
+                    raise RuntimeError(
+                        f"Model {model['name']} failed in worker; see {result.get('worker_log', '')}"
+                    )
+                if result.get("gpu_cleanup_confirmed") is False:
+                    reason = (
+                        f"Skipped because GPU cleanup after {model['name']} OOM was not confirmed"
+                    )
+                    print(f"[task_eval] {reason}")
+                    for skipped_model in selected[idx:]:
+                        results.append(
+                            model_skipped_result(
+                                suite=suite,
+                                model=skipped_model,
+                                args=args,
+                                reason=reason,
+                            )
+                        )
+                    break
+                continue
+        else:
+            try:
+                result = eval_one_model(suite=suite, model=model, args=args)
+            except Exception as exc:
+                if args.fail_fast:
+                    raise
+                result = model_failure_result(suite=suite, model=model, args=args, exc=exc)
+                results.append(result)
+                print(
+                    f"[task_eval] model={model['name']} status=failed "
+                    f"error_type={type(exc).__name__} error={exc}"
+                )
+                continue
+        result["status"] = "passed"
+        results.append(result)
+        print(
+            f"[task_eval] model={model['name']} hf={result['hf_accuracy']:.4f} "
+            f"trtfb={result['trtfb_accuracy']:.4f} "
+            f"agreement={result['prediction_agreement_rate']:.4f} "
+            f"hf_reused={result['hf_reused']} bundle_built={result['bundle_built']}"
+        )
+        if result.get("gpu_cleanup_confirmed") is False:
+            reason = (
+                f"Skipped because GPU cleanup after {model['name']} was not confirmed"
+            )
+            print(f"[task_eval] {reason}")
+            for skipped_model in selected[idx:]:
+                results.append(
+                    model_skipped_result(
+                        suite=suite,
+                        model=skipped_model,
+                        args=args,
+                        reason=reason,
+                    )
+                )
+            break
+
+    failed_count = sum(1 for result in results if result.get("status") == "failed")
+    skipped_count = sum(1 for result in results if result.get("status") == "skipped")
+    out = {
+        "suite": suite["id"],
+        "count": len(results),
+        "passed_count": len(results) - failed_count - skipped_count,
+        "failed_count": failed_count,
+        "skipped_count": skipped_count,
+        "model_process_isolation": use_workers,
+        "results": results,
+    }
+    summary_path = Path(args.work_root) / suite["id"] / "eval_summary.json"
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"[task_eval] summary={summary_path}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    if args.cmd == "list-suites":
+        return cmd_list_suites(args)
+    if args.cmd == "plan":
+        return cmd_plan(args)
+    if args.cmd == "prepare":
+        return cmd_prepare(args)
+    if args.cmd == "run-hf":
+        run_hf_reference(args)
+        return 0
+    if args.cmd == "run-trtfb":
+        run_trtfb(args)
+        return 0
+    if args.cmd == "convert-trtfb":
+        return cmd_convert_trtfb(args)
+    if args.cmd == "score":
+        return cmd_score(args)
+    if args.cmd == "compare":
+        return cmd_compare(args)
+    if args.cmd == "eval-worker":
+        return cmd_eval_worker(args)
+    if args.cmd == "eval":
+        return cmd_eval(args)
+    raise AssertionError(f"Unhandled command {args.cmd}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -421,7 +421,28 @@ def write_predictions(path: Path, rows: list[dict[str, Any]]) -> None:
     path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
 
 
-def predictions_file_valid(predictions_path: Path, answers_path: Path) -> bool:
+def _int_list(value: Any) -> list[int] | None:
+    if not isinstance(value, list):
+        return None
+    try:
+        return [int(v) for v in value]
+    except (TypeError, ValueError):
+        return None
+
+
+def _generated_token_ids(row: dict[str, Any]) -> list[int] | None:
+    generated = _int_list(row.get("generated_token_ids"))
+    if generated is not None:
+        return generated
+    return _int_list(row.get("token_ids"))
+
+
+def predictions_file_valid(
+    predictions_path: Path,
+    answers_path: Path,
+    *,
+    require_token_ids: bool = False,
+) -> bool:
     if not predictions_path.is_file() or not answers_path.is_file():
         return False
     try:
@@ -431,7 +452,11 @@ def predictions_file_valid(predictions_path: Path, answers_path: Path) -> bool:
         return False
     responses = predictions.get("responses")
     requests = answers.get("requests")
-    return isinstance(responses, list) and isinstance(requests, list) and len(responses) == len(requests)
+    if not isinstance(responses, list) or not isinstance(requests, list) or len(responses) != len(requests):
+        return False
+    if require_token_ids:
+        return all(isinstance(row, dict) and _generated_token_ids(row) is not None for row in responses)
+    return True
 
 
 def convert_trtfb_jsonl_to_predictions(raw_path: Path, predictions_path: Path) -> None:
@@ -441,6 +466,7 @@ def convert_trtfb_jsonl_to_predictions(raw_path: Path, predictions_path: Path) -
             "sample_id": row.get("sample_id", ""),
             "output_text": row.get("text", ""),
             "generated_tokens": row.get("generated_tokens"),
+            "generated_token_ids": _generated_token_ids(row),
             "wall_ms": row.get("wall_ms"),
             "source": "trtfb",
         })
@@ -726,10 +752,12 @@ def run_hf_reference(args: argparse.Namespace) -> None:
             wall_ms = (time.perf_counter() - start) * 1000.0
             generated = output_ids[0, encoded["input_ids"].shape[1]:]
             output_text = tokenizer.decode(generated, skip_special_tokens=False)
+            generated_token_ids = [int(token_id) for token_id in generated.tolist()]
             row = {
                 "sample_id": prompt_rows[idx].get("sample_id", f"mmlu_{idx:06d}"),
                 "output_text": output_text,
                 "generated_tokens": int(generated.shape[0]),
+                "generated_token_ids": generated_token_ids,
                 "wall_ms": wall_ms,
                 "source": "hf",
             }
@@ -1110,6 +1138,7 @@ def eval_one_model(
     dataset_path = Path(args.dataset or suite.get("dataset", {}).get("default_path", ""))
     if not dataset_path:
         raise ValueError(f"Suite {suite['id']} has no dataset path; pass --dataset")
+    scorer = str(suite.get("scoring", {}).get("scorer", "mcq"))
     prepare_mmlu_dataset(
         dataset_path=dataset_path,
         work_dir=work_dir,
@@ -1137,9 +1166,10 @@ def eval_one_model(
 
     max_prompt_len = None
     if not args.skip_prompt_length_check:
+        prompt_rows_path = work_dir / "prompts.jsonl"
         max_prompt_len = max_prompt_token_length(
             model_id=str(model["hf_id"]),
-            prompts_path=work_dir / "prompts.jsonl",
+            prompts_path=prompt_rows_path,
             local_files_only=args.local_files_only,
             trust_remote_code=args.trust_remote_code or bool(model.get("trust_remote_code", False)),
         )
@@ -1170,17 +1200,7 @@ def eval_one_model(
     # are never hidden behind stale predictions.
     run_trtfb(_namespace_for_run_trtfb(args, bundle_path, work_dir))
 
-    summary = compare_prediction_sets(
-        json.loads((work_dir / "hf_predictions.json").read_text(encoding="utf-8")),
-        json.loads((work_dir / "trtfb_predictions.json").read_text(encoding="utf-8")),
-        json.loads(answers_path.read_text(encoding="utf-8")),
-    )
-    (work_dir / "summary.json").write_text(
-        json.dumps(summary, indent=2, ensure_ascii=False),
-        encoding="utf-8",
-    )
-    write_summary_markdown(summary, work_dir / "summary.md")
-    result = {
+    base_result = {
         "suite": suite["id"],
         "model": model["name"],
         "hf_id": model["hf_id"],
@@ -1190,16 +1210,260 @@ def eval_one_model(
         "max_prompt_tokens": max_prompt_len,
         "hf_reused": hf_reused,
         "bundle_built": built,
-        "hf_accuracy": summary["hf"]["overall_accuracy"],
-        "trtfb_accuracy": summary["trtfb"]["overall_accuracy"],
-        "accuracy_delta_trtfb_minus_hf": summary["accuracy_delta_trtfb_minus_hf"],
-        "prediction_agreement_rate": summary["prediction_agreement_rate"],
     }
+
+    if scorer == "continuation":
+        hf_data = json.loads((work_dir / "hf_predictions.json").read_text(encoding="utf-8"))
+        trtfb_data = json.loads((work_dir / "trtfb_predictions.json").read_text(encoding="utf-8"))
+        summary = compare_continuation_sets(
+            hf_data,
+            trtfb_data,
+            tokenize=_model_tokenizer(model, args),
+        )
+        (work_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        write_continuation_summary_markdown(summary, work_dir / "summary.md")
+        result = {
+            **base_result,
+            "mode": "continuation",
+            "comparison_granularity": summary.get("comparison_granularity", ""),
+            "exact_match_rate": summary["exact_match_rate"],
+            "token_prefix_agreement": summary["token_prefix_agreement"],
+            "mean_first_divergence": summary["mean_first_divergence"],
+            "prediction_agreement_rate": summary["token_prefix_agreement"],
+        }
+    else:
+        hf_data = json.loads((work_dir / "hf_predictions.json").read_text(encoding="utf-8"))
+        trtfb_data = json.loads((work_dir / "trtfb_predictions.json").read_text(encoding="utf-8"))
+        summary = compare_prediction_sets(
+            hf_data, trtfb_data, json.loads(answers_path.read_text(encoding="utf-8"))
+        )
+        (work_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        write_summary_markdown(summary, work_dir / "summary.md")
+        result = {
+            **base_result,
+            "mode": "mcq",
+            "hf_accuracy": summary["hf"]["overall_accuracy"],
+            "trtfb_accuracy": summary["trtfb"]["overall_accuracy"],
+            "accuracy_delta_trtfb_minus_hf": summary["accuracy_delta_trtfb_minus_hf"],
+            "prediction_agreement_rate": summary["prediction_agreement_rate"],
+        }
     (work_dir / "eval_result.json").write_text(
         json.dumps(result, indent=2, ensure_ascii=False),
         encoding="utf-8",
     )
     return result
+
+
+# ---------------------------------------------------------------------------
+# Continuation parity for base / completion models (generation-only, no logits).
+# HF reference and TRTFB both greedily generate from the same plain-text prompt;
+# we compare the two continuations. No gold answer or logprobs are needed — the
+# metric is HF<->TRTFB output agreement (conversion fidelity).
+# ---------------------------------------------------------------------------
+
+
+def _first_divergence(a: list[Any], b: list[Any]) -> int:
+    """Index of the first differing element; min length if one is a prefix."""
+    limit = min(len(a), len(b))
+    for i in range(limit):
+        if a[i] != b[i]:
+            return i
+    return limit
+
+
+def compare_continuation_sets(
+    hf_predictions: dict[str, Any],
+    trtfb_predictions: dict[str, Any],
+    tokenize: Any = None,
+    require_token_ids: bool = False,
+) -> dict[str, Any]:
+    """Compare HF vs TRTFB greedy continuations.
+
+    Prefer generated token ids emitted by the runners. ``tokenize`` is only a
+    compatibility fallback for older prediction files that do not contain ids.
+    """
+    hf_rows = hf_predictions.get("responses", [])
+    trt_rows = trtfb_predictions.get("responses", [])
+    if not isinstance(hf_rows, list) or not isinstance(trt_rows, list):
+        raise ValueError("HF and TRTFB predictions must contain response lists")
+    if len(hf_rows) != len(trt_rows):
+        raise ValueError(
+            f"HF and TRTFB predictions must have the same length: "
+            f"{len(hf_rows)} != {len(trt_rows)}"
+        )
+    if not all(isinstance(row, dict) for row in hf_rows + trt_rows):
+        raise ValueError("HF and TRTFB predictions must contain object rows")
+
+    hf_id_rows = [_generated_token_ids(row) for row in hf_rows]
+    trt_id_rows = [_generated_token_ids(row) for row in trt_rows]
+    has_all_token_ids = all(ids is not None for ids in hf_id_rows + trt_id_rows)
+    if require_token_ids and not has_all_token_ids:
+        missing = []
+        for label, rows in (("hf", hf_id_rows), ("trtfb", trt_id_rows)):
+            missing.extend(f"{label}[{idx}]" for idx, ids in enumerate(rows) if ids is None)
+        raise ValueError(
+            "Continuation token-id metric requires generated_token_ids in every prediction row; "
+            f"missing: {', '.join(missing[:8])}{' ...' if len(missing) > 8 else ''}"
+        )
+    if has_all_token_ids:
+        comparison_granularity = "generated_token_ids"
+    elif tokenize is not None:
+        comparison_granularity = "retokenized_output_text"
+    else:
+        comparison_granularity = "characters"
+
+        def tokenize(s: str) -> list[str]:
+            return list(s)
+
+    exact = 0
+    text_exact = 0
+    total_matched = 0
+    total_reference = 0
+    div_positions: list[int] = []
+    samples: list[dict[str, Any]] = []
+    for idx, (hf_row, trt_row) in enumerate(zip(hf_rows, trt_rows, strict=True)):
+        hf_text = str(hf_row.get("output_text", ""))
+        trt_text = str(trt_row.get("output_text", ""))
+        text_is_exact = hf_text == trt_text
+        text_exact += int(text_is_exact)
+        if has_all_token_ids:
+            hf_tokens = hf_id_rows[idx] or []
+            trt_tokens = trt_id_rows[idx] or []
+        else:
+            hf_tokens = tokenize(hf_text)
+            trt_tokens = tokenize(trt_text)
+        is_exact = hf_tokens == trt_tokens
+        exact += int(is_exact)
+        divergence = _first_divergence(hf_tokens, trt_tokens)
+        reference_len = max(1, len(hf_tokens), len(trt_tokens))
+        total_matched += min(divergence, reference_len)
+        total_reference += reference_len
+        div_positions.append(divergence)
+        hf_token_at_divergence = hf_tokens[divergence] if divergence < len(hf_tokens) else None
+        trt_token_at_divergence = trt_tokens[divergence] if divergence < len(trt_tokens) else None
+        samples.append({
+            "index": idx,
+            "sample_id": hf_row.get("sample_id", f"sample_{idx}"),
+            "exact": is_exact,
+            "text_exact": text_is_exact,
+            "first_divergence": divergence,
+            "hf_len": len(hf_tokens),
+            "trtfb_len": len(trt_tokens),
+            "hf_token_at_divergence": hf_token_at_divergence,
+            "trtfb_token_at_divergence": trt_token_at_divergence,
+        })
+
+    count = len(hf_rows)
+    exact_rate = (exact / count) if count else 0.0
+    prefix_agreement = (total_matched / total_reference) if total_reference else 0.0
+    mean_divergence = (sum(div_positions) / count) if count else 0.0
+    return {
+        "comparison_granularity": comparison_granularity,
+        "exact_match_rate": exact_rate,
+        "token_id_exact_match_rate": exact_rate if has_all_token_ids else None,
+        "text_exact_match_rate": (text_exact / count) if count else 0.0,
+        "token_prefix_agreement": prefix_agreement,
+        "token_id_prefix_agreement": prefix_agreement if has_all_token_ids else None,
+        "mean_first_divergence": mean_divergence,
+        "mean_first_token_id_divergence": mean_divergence if has_all_token_ids else None,
+        "count": count,
+        "exact_count": exact,
+        "text_exact_count": text_exact,
+        "samples": samples,
+    }
+
+
+def cmd_compare_continuation(args: argparse.Namespace) -> int:
+    work_dir = Path(args.work_dir)
+    hf_path = Path(args.hf_predictions) if args.hf_predictions else work_dir / "hf_predictions.json"
+    trtfb_path = (
+        Path(args.trtfb_predictions) if args.trtfb_predictions else work_dir / "trtfb_predictions.json"
+    )
+    tokenize = None
+    if args.model:
+        from transformers import AutoTokenizer
+
+        tok = AutoTokenizer.from_pretrained(
+            args.model,
+            trust_remote_code=args.trust_remote_code,
+            local_files_only=args.local_files_only,
+        )
+        tokenize = lambda s: tok(s, add_special_tokens=False).input_ids  # noqa: E731
+    summary = compare_continuation_sets(
+        json.loads(hf_path.read_text(encoding="utf-8")),
+        json.loads(trtfb_path.read_text(encoding="utf-8")),
+        tokenize=tokenize,
+    )
+    output_path = Path(args.output) if args.output else work_dir / "continuation_parity.json"
+    output_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(
+        f"exact_match={summary['exact_match_rate']:.4f} "
+        f"token_agreement={summary['token_prefix_agreement']:.4f} "
+        f"mean_first_divergence={summary['mean_first_divergence']:.2f} "
+        f"output={output_path}"
+    )
+    return 0
+
+
+def _model_tokenizer(model: dict[str, Any], args: argparse.Namespace) -> Any:
+    """Return a tokenize(str)->list[int] using the model tokenizer, or None."""
+    try:
+        from transformers import AutoTokenizer
+
+        tok = AutoTokenizer.from_pretrained(
+            str(model["hf_id"]),
+            trust_remote_code=getattr(args, "trust_remote_code", False)
+            or bool(model.get("trust_remote_code", False)),
+            local_files_only=getattr(args, "local_files_only", False),
+        )
+        return lambda s: tok(s, add_special_tokens=False).input_ids  # noqa: E731
+    except Exception:
+        return None
+
+
+def _format_optional_float(value: Any, *, precision: int = 4) -> str:
+    if value is None:
+        return "n/a"
+    return f"{float(value):.{precision}f}"
+
+
+def write_continuation_summary_markdown(summary: dict[str, Any], path: Path) -> None:
+    lines = [
+        "# Continuation Parity Summary",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| comparison_granularity | {summary.get('comparison_granularity', '')} |",
+        f"| exact_match_rate | {summary['exact_match_rate']:.4f} |",
+        f"| token_id_exact_match_rate | {_format_optional_float(summary.get('token_id_exact_match_rate'))} |",
+        f"| text_exact_match_rate | {summary['text_exact_match_rate']:.4f} |",
+        f"| token_prefix_agreement | {summary['token_prefix_agreement']:.4f} |",
+        f"| token_id_prefix_agreement | {_format_optional_float(summary.get('token_id_prefix_agreement'))} |",
+        f"| mean_first_divergence | {summary['mean_first_divergence']:.2f} |",
+        f"| mean_first_token_id_divergence | {_format_optional_float(summary.get('mean_first_token_id_divergence'), precision=2)} |",
+        f"| count | {summary['count']} |",
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _format_result_line(model: dict[str, Any], result: dict[str, Any]) -> str:
+    common = f"hf_reused={result['hf_reused']} bundle_built={result['bundle_built']}"
+    if result.get("mode") == "continuation":
+        return (
+            f"model={model['name']} exact={result['exact_match_rate']:.4f} "
+            f"token_agreement={result['token_prefix_agreement']:.4f} "
+            f"mean_first_divergence={result['mean_first_divergence']:.2f} "
+            f"granularity={result.get('comparison_granularity', '')} {common}"
+        )
+    return (
+        f"model={model['name']} hf={result['hf_accuracy']:.4f} "
+        f"trtfb={result['trtfb_accuracy']:.4f} "
+        f"agreement={result['prediction_agreement_rate']:.4f} {common}"
+    )
 
 
 def add_generation_args(parser: argparse.ArgumentParser) -> None:
@@ -1279,6 +1543,15 @@ def build_arg_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("convert-trtfb")
     p.add_argument("--raw", required=True)
     p.add_argument("--predictions", required=True)
+
+    p = sub.add_parser("compare-continuation")
+    p.add_argument("--work-dir", required=True)
+    p.add_argument("--hf-predictions")
+    p.add_argument("--trtfb-predictions")
+    p.add_argument("--model", default="", help="Optional model id; enables token-level parity.")
+    p.add_argument("--trust-remote-code", action="store_true")
+    p.add_argument("--local-files-only", action="store_true")
+    p.add_argument("--output")
 
     p = sub.add_parser("score")
     p.add_argument("--answers")
@@ -1760,12 +2033,7 @@ def cmd_eval(args: argparse.Namespace) -> int:
                 continue
         result["status"] = "passed"
         results.append(result)
-        print(
-            f"[task_eval] model={model['name']} hf={result['hf_accuracy']:.4f} "
-            f"trtfb={result['trtfb_accuracy']:.4f} "
-            f"agreement={result['prediction_agreement_rate']:.4f} "
-            f"hf_reused={result['hf_reused']} bundle_built={result['bundle_built']}"
-        )
+        print(f"[task_eval] {_format_result_line(model, result)}")
         if result.get("gpu_cleanup_confirmed") is False:
             reason = (
                 f"Skipped because GPU cleanup after {model['name']} was not confirmed"
@@ -1816,6 +2084,8 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.cmd == "convert-trtfb":
         return cmd_convert_trtfb(args)
+    if args.cmd == "compare-continuation":
+        return cmd_compare_continuation(args)
     if args.cmd == "score":
         return cmd_score(args)
     if args.cmd == "compare":

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1372,6 +1372,20 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             covered_by=("TestUnitTiers.test_elf_replay_tools_trigger_tools_tier",),
         ),
         ClassificationRule(
+            priority=486,
+            name="task_eval_tool",
+            matcher=_path_equals("tools/task_eval.py"),
+            resolver=_match_result("task_eval_tool", _no_models, ["tools"], False),
+            covered_by=("TestUnitTiers.test_task_eval_tool_triggers_tools_tier",),
+        ),
+        ClassificationRule(
+            priority=487,
+            name="task_eval_config",
+            matcher=_path_startswith("tests/task_eval/"),
+            resolver=_match_result("task_eval_config", _no_models, ["tools"], False),
+            covered_by=("TestUnitTiers.test_task_eval_suite_config_triggers_tools_tier",),
+        ),
+        ClassificationRule(
             priority=490,
             name="no_impact",
             matcher=_no_impact_matcher,


### PR DESCRIPTION
## Background
QA needs a repeatable way to evaluate whether HF text-generation models remain task-usable after conversion to TRTFB. The existing MMLU attempts exposed that true cloze/logprob scoring is not available through the current benchmark/runtime path, so this PR keeps a generation-only continuation parity workflow and removes the temporary trace-cloze suite.

## Exit Criteria
- Add a local task-eval harness that can prepare MMLU prompts, run HF/TRTFB references, and compare outputs.
- Add a continuation-parity suite for base/completion models without requiring runtime logprobs.
- Keep task-eval changes on a lightweight CI path instead of triggering broad E2E selection.

## Implementation
- Adds `tools/task_eval.py` and `tests/task_eval/validation_suites.yaml` for local MMLU task evaluation.
- Adds `mmlu_continuation_parity`, which compares greedy HF and TRTFB continuations using generated token ids when available.
- Removes the temporary `mmlu_trace_cloze` suite until a true logprob path exists.
- Adds `tests/tools/test_task_eval.py` and impact rules so `tools/task_eval.py` and `tests/task_eval/**` run tools-tier tests only.

## Validation
- `python3 -m pytest tests/tools/test_task_eval.py tests/tools/test_test_impact.py -q`: passed, 155 tests.
- `python3 tools/test_impact.py --base github/main --json`: passed; selected no E2E models, tools tier only, no C++ rebuild.
- `python3 tools/test_impact.py --validate`: passed; emitted existing repository warnings only.
- `python3 tools/task_eval.py list-suites`: passed; listed `mmlu_five_shot_mcq` and `mmlu_continuation_parity`.

## Notes For Future Readers
- This PR intentionally does not gate model conversion on MMLU. It provides a QA/local validation tool path.
- True multiple-choice cloze scoring should wait for a benchmark/runtime logprob path such as `--score-candidates` or equivalent.
