### PR TITLE
ci(e2e): generalize diff-aware model impact

### DIFF
--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -111,6 +111,18 @@ def mock_repo(tmp_path):
          "hf_id": "nvidia/Nemotron-Labs-Diffusion-8B"},
         {"name": "convbert-base", "family": "convbert", "runtime_strategy": "encoder_only",
          "hf_id": "YituTech/conv-bert-base"},
+        {"name": "patchtst-granite", "family": "patchtst",
+         "runtime_strategy": "patchtst_trt",
+         "hf_id": "ibm-granite/granite-timeseries-patchtst"},
+        {"name": "patchtst-regression", "family": "patchtst",
+         "runtime_strategy": "patchtst_trt",
+         "hf_id": "hf-internal-testing/tiny-random-PatchTSTForRegression"},
+        {"name": "patchtsmixer-granite", "family": "patchtsmixer",
+         "runtime_strategy": "patchtsmixer_trt",
+         "hf_id": "ibm-granite/granite-timeseries-patchtsmixer"},
+        {"name": "timesfm-official", "family": "timesfm",
+         "runtime_strategy": "timesfm_trt",
+         "hf_id": "google/timesfm-2.0-500m-pytorch"},
         {"name": "chronos-bolt-tiny", "family": "chronos_bolt",
          "runtime_strategy": "chronos_bolt_trt",
          "hf_id": "amazon/chronos-bolt-tiny"},
@@ -196,6 +208,10 @@ def mock_repo(tmp_path):
             "builder.py": "from ... import graph_ops\n",
         },
     )
+    _write_family(families_dir, "patchtst", "from ..config import C\n")
+    _write_family(families_dir, "patchtsmixer", "from ..config import C\n")
+    _write_family(families_dir, "timesfm", "from ..config import C\n")
+    _write_family(families_dir, "chronos_bolt", "from ..config import C\n")
 
     # Placeholder source files
     (python_package_dir / "standard_decoder_builder.py").write_text("")
@@ -954,6 +970,13 @@ class TestHarness:
         """Diff refinement dispatch keeps named rules in reviewable order."""
         assert [rule.name for rule in test_impact.DIFF_REFINEMENT_RULES] == [
             "harness_shared_fp8_scales",
+            "e2e_timing_estimates_known_models",
+            "runtime_strategy_matrix_known_strategies",
+            "pyproject_known_profiles",
+            "python_profiles_known_profiles",
+            "shared_builder_config_lookup_family_registry",
+            "shared_builder_config_lookup_cli",
+            "shared_builder_config_lookup_engine",
             "sam3_public_prompted_segmentation_api",
             "sam3_engine_builder_metadata",
             "sam3_segment_sam_cli_usage",
@@ -963,6 +986,7 @@ class TestHarness:
             "sam3_harness_contract",
             "harness_reference_sam3_prompted_segmentation",
             "sam3_harness_repro_prompt",
+            "harness_shared_known_identifiers",
             "e2e_warm_hf_cache_diffusers_components",
             "shared_builder_fp8_scales_cli",
             "shared_builder_fp8_scales_engine",
@@ -970,10 +994,433 @@ class TestHarness:
             "harness_manifest_diffusion_thresholds",
             "harness_reference_dpr_context_encoder",
             "harness_reference_vl_generated_only_decode",
+            "harness_reference_known_identifiers",
             "e2e_waives_model_lines",
         ]
         assert all(callable(rule.matches) and callable(rule.refine)
                    for rule in test_impact.DIFF_REFINEMENT_RULES)
+
+    def test_metadata_rules_refine_known_model_and_strategy_diffs(self, imap):
+        """Registry additions for any known model/strategy avoid all-model E2E."""
+        timing_diff = """
+diff --git a/tests/e2e/timing_estimates.json b/tests/e2e/timing_estimates.json
+@@ -1 +1 @@
++    "chronos-bolt-tiny": 45,
++    "qwen3-0.6b": 38,
+"""
+        broad_timing = test_impact.classify_file("tests/e2e/timing_estimates.json", imap)
+        refined_timing = test_impact.maybe_refine_match_with_diff(
+            "tests/e2e/timing_estimates.json", broad_timing, timing_diff, imap)
+        assert refined_timing.rule == "e2e_timing_estimates_known_models"
+        assert refined_timing.models == ["chronos-bolt-tiny", "qwen3-0.6b"]
+
+        matrix_diff = """
+diff --git a/tests/runtime_strategy_matrix.yaml b/tests/runtime_strategy_matrix.yaml
+@@ -1 +1 @@
++    "decoder_moe": {
++      "task_strategy": "text_generation_causal",
++      "cli_commands": ["solve"],
++      "runner_class": "tests.e2e_harness.runners.text_generation.TextGenerationCausalRunner",
++      "comparator_class": "tests.e2e_harness.comparators.text.TextComparator",
++      "diff_framework_check_classes": [],
++      "diff_framework_exemption": "No diff_framework check currently registers runtime_strategies=['decoder_moe']."
++    },
++    "chronos_bolt_trt": {
++      "task_strategy": "neural_operator",
++      "cli_commands": ["solve"],
++      "runner_class": "tests.e2e_harness.runners.neural_operator.NeuralOperatorRunner",
++      "comparator_class": "tests.e2e_harness.comparators.neural_operator.NeuralOperatorComparator",
++      "diff_framework_check_classes": [],
++      "diff_framework_exemption": "No diff_framework check currently registers runtime_strategies=['chronos_bolt_trt']."
++    },
+"""
+        broad_matrix = test_impact.classify_file("tests/runtime_strategy_matrix.yaml", imap)
+        refined_matrix = test_impact.maybe_refine_match_with_diff(
+            "tests/runtime_strategy_matrix.yaml", broad_matrix, matrix_diff, imap)
+        assert refined_matrix.rule == "runtime_strategy_matrix_known_strategies"
+        assert refined_matrix.models == [
+            "chronos-bolt-tiny",
+            "mixtral-15m",
+        ]
+
+    def test_shared_builder_rules_refine_config_lookup_to_candidate_models(self, imap):
+        """Config-object plugin lookup is scoped to PR-level candidate models."""
+        candidate_models = ["chronos-bolt-tiny"]
+        init_diff = """
+diff --git a/python/tensorrt_model_connect/families/__init__.py b/python/tensorrt_model_connect/families/__init__.py
+@@ -1 +1 @@
+-def find_plugin(model_type: str) -> "FamilyPlugin | None":
+-    \"\"\"Find the first plugin that matches the given model_type.\"\"\"
++def find_plugin(model_type: object) -> "FamilyPlugin | None":
++    \"\"\"Find the first plugin that matches a model type or config object.\"\"\"
++    model_type_str = str(getattr(model_type, "model_type", model_type))
+-        if p.matches(model_type):
++        matches_config = getattr(p, "matches_config", None)
++        if callable(matches_config) and matches_config(model_type):
++            return p
++        if p.matches(model_type_str):
+"""
+        broad_init = test_impact.classify_file(
+            "python/tensorrt_model_connect/families/__init__.py", imap)
+        refined_init = test_impact.maybe_refine_match_with_diff(
+            "python/tensorrt_model_connect/families/__init__.py",
+            broad_init,
+            init_diff,
+            imap,
+            candidate_models,
+        )
+        assert refined_init.rule == "shared_builder_config_lookup_family_registry"
+        assert refined_init.models == ["chronos-bolt-tiny"]
+
+        cli_diff = """
+diff --git a/python/tensorrt_model_connect/build_cli.py b/python/tensorrt_model_connect/build_cli.py
+@@ -1 +1 @@
+-    plugin = find_plugin(config.model_type)
++    plugin = find_plugin(config)
+-        raw_plugin = find_plugin(config.model_type)
++        raw_plugin = find_plugin(config)
+"""
+        broad_cli = test_impact.classify_file(
+            "python/tensorrt_model_connect/build_cli.py", imap)
+        refined_cli = test_impact.maybe_refine_match_with_diff(
+            "python/tensorrt_model_connect/build_cli.py",
+            broad_cli,
+            cli_diff,
+            imap,
+            candidate_models,
+        )
+        assert refined_cli.rule == "shared_builder_config_lookup_cli"
+        assert refined_cli.models == ["chronos-bolt-tiny"]
+
+    def test_harness_rules_refine_registry_diffs_for_known_identifiers(self, imap):
+        """Harness additions stay scoped to mentioned models and runtime strategies."""
+        expected = [
+            "chronos-bolt-tiny",
+            "patchtsmixer-granite",
+            "patchtst-granite",
+            "patchtst-regression",
+            "timesfm-official",
+        ]
+
+        contracts_diff = """
+diff --git a/tests/e2e_harness/contracts.py b/tests/e2e_harness/contracts.py
+@@ -1 +1 @@
++    # 5.28 TIME_SERIES_POINT_FORECAST
++    "patchtst-granite": ReferenceFamily.TIME_SERIES_POINT_FORECAST.value,
++    "patchtsmixer-granite": ReferenceFamily.TIME_SERIES_POINT_FORECAST.value,
++    "timesfm-official": ReferenceFamily.TIME_SERIES_POINT_FORECAST.value,
++    # 5.29 TIME_SERIES_QUANTILE_FORECAST
++    "chronos-bolt-tiny": ReferenceFamily.TIME_SERIES_QUANTILE_FORECAST.value,
++    # 5.30 TIME_SERIES_REGRESSION
++    "patchtst-regression": ReferenceFamily.TIME_SERIES_REGRESSION.value,
++    "patchtst_trt": "neural_operator",
++    "patchtsmixer_trt": "neural_operator",
++    "timesfm_trt": "neural_operator",
++    "chronos_bolt_trt": "neural_operator",
+"""
+        broad_contracts = test_impact.classify_file("tests/e2e_harness/contracts.py", imap)
+        refined_contracts = test_impact.maybe_refine_match_with_diff(
+            "tests/e2e_harness/contracts.py", broad_contracts, contracts_diff, imap)
+        assert refined_contracts.rule == "harness_shared_known_identifiers"
+        assert refined_contracts.models == expected
+
+        manifest_loader_diff = """
+diff --git a/tests/e2e_harness/manifest_loader.py b/tests/e2e_harness/manifest_loader.py
+@@ -1 +1 @@
++    if manifest.get("runtime_strategy") == "chronos_bolt_trt":
++        reqs.append(PreflightRequirement(
++            kind="python_module_available",
++            args={"module": "chronos", "phase": "build"},
++            gating=True,
++        ))
++    "patchtst_trt",
++    "patchtsmixer_trt",
++    "timesfm_trt",
++    "chronos_bolt_trt",
+"""
+        broad_loader = test_impact.classify_file("tests/e2e_harness/manifest_loader.py", imap)
+        refined_loader = test_impact.maybe_refine_match_with_diff(
+            "tests/e2e_harness/manifest_loader.py", broad_loader, manifest_loader_diff, imap)
+        assert refined_loader.rule == "harness_shared_known_identifiers"
+        assert refined_loader.models == expected
+
+    def test_generic_shared_file_diff_selects_non_time_series_models(
+        self, imap, mock_repo, monkeypatch,
+    ):
+        """Shared metadata diffs refine non-time-series models too."""
+        diffs = {
+            "pyproject.toml": """
+diff --git a/pyproject.toml b/pyproject.toml
+@@ -1 +1 @@
++qwen = ["qwen-builder>=1"]
+""",
+            "tests/e2e_harness/contracts.py": """
+diff --git a/tests/e2e_harness/contracts.py b/tests/e2e_harness/contracts.py
+@@ -1 +1 @@
++    "flux-schnell": ReferenceFamily.DIFFUSERS_IMAGE_GEN.value,
+""",
+            "tests/runtime_strategy_matrix.yaml": """
+diff --git a/tests/runtime_strategy_matrix.yaml b/tests/runtime_strategy_matrix.yaml
+@@ -1 +1 @@
++    "decoder_moe": {
++      "task_strategy": "text_generation_causal",
++      "cli_commands": ["run"],
++      "runner_class": "tests.e2e_harness.runners.text_generation.TextGenerationCausalRunner",
++      "comparator_class": "tests.e2e_harness.comparators.text.TextComparator",
++      "diff_framework_check_classes": []
++    },
+""",
+        }
+        monkeypatch.setattr(
+            test_impact,
+            "get_file_diff",
+            lambda _base, _head, _repo_root, path: diffs.get(path, ""),
+        )
+
+        result = test_impact.analyze_impact(
+            sorted(diffs),
+            imap,
+            base="base",
+            head="head",
+            repo_root=mock_repo,
+        )
+
+        assert result.e2e_models == [
+            "flux-schnell",
+            "mixtral-15m",
+            "qwen3-0.6b",
+            "qwen3-4b",
+        ]
+
+    def test_time_series_pr_style_diff_selects_only_time_series(
+        self, imap, mock_repo, monkeypatch,
+    ):
+        """Aggregate shared-file time-series plumbing does not trigger all-model E2E."""
+        contracts_diff = """
+diff --git a/tests/e2e_harness/contracts.py b/tests/e2e_harness/contracts.py
+@@ -1 +1 @@
++    # 5.28 TIME_SERIES_POINT_FORECAST
++    "patchtst-granite": ReferenceFamily.TIME_SERIES_POINT_FORECAST.value,
++    "patchtsmixer-granite": ReferenceFamily.TIME_SERIES_POINT_FORECAST.value,
++    "timesfm-official": ReferenceFamily.TIME_SERIES_POINT_FORECAST.value,
++    # 5.29 TIME_SERIES_QUANTILE_FORECAST
++    "chronos-bolt-tiny": ReferenceFamily.TIME_SERIES_QUANTILE_FORECAST.value,
++    # 5.30 TIME_SERIES_REGRESSION
++    "patchtst-regression": ReferenceFamily.TIME_SERIES_REGRESSION.value,
++    "patchtst_trt": "neural_operator",
++    "patchtsmixer_trt": "neural_operator",
++    "timesfm_trt": "neural_operator",
++    "chronos_bolt_trt": "neural_operator",
+"""
+        manifest_loader_diff = """
+diff --git a/tests/e2e_harness/manifest_loader.py b/tests/e2e_harness/manifest_loader.py
+@@ -1 +1 @@
++    if manifest.get("runtime_strategy") == "chronos_bolt_trt":
++        reqs.append(PreflightRequirement(
++            kind="python_module_available",
++            args={"module": "chronos", "phase": "build"},
++            gating=True,
++        ))
++    "patchtst_trt",
++    "patchtsmixer_trt",
++    "timesfm_trt",
++    "chronos_bolt_trt",
+"""
+        diffs = {
+            "pyproject.toml": """
+diff --git a/pyproject.toml b/pyproject.toml
+@@ -1 +1 @@
++chronos = ["chronos-forecasting>=2.2.2"]
+""",
+            "python/tensorrt_model_connect/build_cli.py": """
+diff --git a/python/tensorrt_model_connect/build_cli.py b/python/tensorrt_model_connect/build_cli.py
+@@ -1 +1 @@
+-    plugin = find_plugin(config.model_type)
++    plugin = find_plugin(config)
+-        raw_plugin = find_plugin(config.model_type)
++        raw_plugin = find_plugin(config)
+""",
+            "python/tensorrt_model_connect/engine_builder.py": """
+diff --git a/python/tensorrt_model_connect/engine_builder.py b/python/tensorrt_model_connect/engine_builder.py
+@@ -1 +1 @@
+-    plugin = find_plugin(config.model_type)
++    plugin = find_plugin(config)
+""",
+            "python/tensorrt_model_connect/families/__init__.py": """
+diff --git a/python/tensorrt_model_connect/families/__init__.py b/python/tensorrt_model_connect/families/__init__.py
+@@ -1 +1 @@
+-def find_plugin(model_type: str) -> "FamilyPlugin | None":
++def find_plugin(model_type: object) -> "FamilyPlugin | None":
++    model_type_str = str(getattr(model_type, "model_type", model_type))
+-        if p.matches(model_type):
++        matches_config = getattr(p, "matches_config", None)
++        if callable(matches_config) and matches_config(model_type):
++            return p
++        if p.matches(model_type_str):
+""",
+            "python/tensorrt_model_connect/python_profiles.toml": """
+diff --git a/python/tensorrt_model_connect/python_profiles.toml b/python/tensorrt_model_connect/python_profiles.toml
+@@ -1 +1 @@
++[profiles.chronos]
++kind = "venv"
++requirements = "python_profile_requirements/chronos.lock.txt"
++system_site_packages = true
++verification_script = '''
++import chronos
++import transformers
++config = transformers.T5Config(
++    d_model=16,
++    d_ff=32,
++    num_layers=1,
++    num_decoder_layers=1,
++    num_heads=2,
++    dropout_rate=0.0,
++    decoder_start_token_id=0,
++    pad_token_id=0,
++    eos_token_id=1,
++)
++config.architectures = ["ChronosBoltModelForForecasting"]
++config.chronos_config = {
++    "context_length": 16,
++    "prediction_length": 4,
++    "input_patch_size": 4,
++    "input_patch_stride": 4,
++    "quantiles": [0.1, 0.5, 0.9],
++    "use_reg_token": True,
++}
++chronos.chronos_bolt.ChronosBoltModelForForecasting(config).eval()
++print(
++    f"chronos={chronos.__version__} "
++    f"transformers={transformers.__version__} "
++    "chronos_bolt_ctor=ok"
++)
++'''
++[family_defaults.chronos_bolt]
++build = "chronos"
++reference = "chronos"
+""",
+            "tests/e2e/timing_estimates.json": """
+diff --git a/tests/e2e/timing_estimates.json b/tests/e2e/timing_estimates.json
+@@ -1 +1 @@
++    "chronos-bolt-tiny": 45,
++    "patchtsmixer-granite": 30,
++    "patchtst-granite": 38,
++    "patchtst-regression": 32,
++    "timesfm-official": 111,
+""",
+            "tests/e2e_harness/contracts.py": contracts_diff,
+            "tests/e2e_harness/manifest_loader.py": manifest_loader_diff,
+            "tests/e2e_harness/orchestrator.py": """
+diff --git a/tests/e2e_harness/orchestrator.py b/tests/e2e_harness/orchestrator.py
+@@ -1 +1 @@
++    "patchtst_trt",
++    "patchtsmixer_trt",
++    "timesfm_trt",
++    "chronos_bolt_trt",
+""",
+            "tests/e2e_harness/references/torch_reference.py": """
+diff --git a/tests/e2e_harness/references/torch_reference.py b/tests/e2e_harness/references/torch_reference.py
+@@ -1 +1 @@
++        if task == "neural_operator" and _is_supported_time_series_case(case):
++            return self._run_time_series_ref(case, stage, ctx)
++def _run_time_series_forward(case: E2ECase):
++    if case.family == "patchtst":
++        return _run_patchtst_forward(case)
++    if case.family == "patchtsmixer":
++        return _run_patchtsmixer_forward(case)
++    if case.family == "timesfm":
++        return _run_timesfm_forward(case)
++    if case.family == "chronos_bolt":
++        return _run_chronos_bolt_forward(case)
++def _run_patchtst_forward(case: E2ECase):
++    import torch
++    import transformers
++    return torch.tensor([0.0]), "prediction_outputs"
++def _run_patchtsmixer_forward(case: E2ECase):
++    import torch
++    import transformers
++    return torch.tensor([0.0]), "prediction_outputs"
++def _run_timesfm_forward(case: E2ECase):
++    import torch
++    import transformers
++    return torch.tensor([0.0]), "mean_predictions"
++def _run_chronos_bolt_forward(case: E2ECase):
++    import torch
++    import chronos
++    return torch.tensor([0.0]), "quantile_preds"
+""",
+            "tests/runtime_strategy_matrix.yaml": """
+diff --git a/tests/runtime_strategy_matrix.yaml b/tests/runtime_strategy_matrix.yaml
+@@ -1 +1 @@
++    "patchtst_trt": {
++      "task_strategy": "neural_operator",
++      "cli_commands": ["solve"],
++      "runner_class": "tests.e2e_harness.runners.neural_operator.NeuralOperatorRunner",
++      "comparator_class": "tests.e2e_harness.comparators.neural_operator.NeuralOperatorComparator",
++      "diff_framework_check_classes": [],
++      "diff_framework_exemption": "No diff_framework check currently registers runtime_strategies=['patchtst_trt']."
++    },
++    "patchtsmixer_trt": {
++      "task_strategy": "neural_operator",
++      "cli_commands": ["solve"],
++      "runner_class": "tests.e2e_harness.runners.neural_operator.NeuralOperatorRunner",
++      "comparator_class": "tests.e2e_harness.comparators.neural_operator.NeuralOperatorComparator",
++      "diff_framework_check_classes": [],
++      "diff_framework_exemption": "No diff_framework check currently registers runtime_strategies=['patchtsmixer_trt']."
++    },
++    "timesfm_trt": {
++      "task_strategy": "neural_operator",
++      "cli_commands": ["solve"],
++      "runner_class": "tests.e2e_harness.runners.neural_operator.NeuralOperatorRunner",
++      "comparator_class": "tests.e2e_harness.comparators.neural_operator.NeuralOperatorComparator",
++      "diff_framework_check_classes": [],
++      "diff_framework_exemption": "No diff_framework check currently registers runtime_strategies=['timesfm_trt']."
++    },
++    "chronos_bolt_trt": {
++      "task_strategy": "neural_operator",
++      "cli_commands": ["solve"],
++      "runner_class": "tests.e2e_harness.runners.neural_operator.NeuralOperatorRunner",
++      "comparator_class": "tests.e2e_harness.comparators.neural_operator.NeuralOperatorComparator",
++      "diff_framework_check_classes": [],
++      "diff_framework_exemption": "No diff_framework check currently registers runtime_strategies=['chronos_bolt_trt']."
++    },
+""",
+        }
+        for model_name in (
+            "chronos-bolt-tiny",
+            "patchtsmixer-granite",
+            "patchtst-granite",
+            "patchtst-regression",
+            "timesfm-official",
+        ):
+            diffs[f"tests/e2e/models/{model_name}.json"] = (
+                f"diff --git a/tests/e2e/models/{model_name}.json "
+                f"b/tests/e2e/models/{model_name}.json\n"
+                "@@ -1 +1 @@\n"
+                f"+{{\"name\": \"{model_name}\"}}\n"
+            )
+
+        monkeypatch.setattr(
+            test_impact,
+            "get_file_diff",
+            lambda _base, _head, _repo_root, path: diffs.get(path, ""),
+        )
+        result = test_impact.analyze_impact(
+            sorted(diffs),
+            imap,
+            base="base",
+            head="head",
+            repo_root=mock_repo,
+        )
+
+        assert result.e2e_models == [
+            "chronos-bolt-tiny",
+            "patchtsmixer-granite",
+            "patchtst-granite",
+            "patchtst-regression",
+            "timesfm-official",
+        ]
+        assert "qwen3-0.6b" not in result.e2e_models
 
     def test_sam3_public_pipeline_rule_refines_prompted_segmentation_diff(self, imap):
         """SAM3 prompted-segmentation API additions stay scoped to segmentation."""

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -272,6 +272,7 @@ class ImpactMap:
     e2e_data_file_to_models: Dict[str, List[str]]
     path_scope_overrides: Dict[str, List[str]]
     l0_replacement_by_model: Dict[str, str]
+    reference_family_to_models: Dict[str, List[str]]
 
 
 @dataclass
@@ -369,6 +370,49 @@ def _scan_cpp_runtime_model_manifests(models_dir: Path) -> Dict[str, List[str]]:
     return scoped
 
 
+def _scan_contract_reference_families(
+    contracts_path: Path,
+    known_models: Set[str],
+) -> Dict[str, List[str]]:
+    """Build ReferenceFamily value -> models from the static contract table."""
+    try:
+        text = contracts_path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+
+    reference_family_block = re.search(
+        r"class\s+ReferenceFamily\([^)]*\):(?P<body>.*?)(?=^class\s+\w+\()",
+        text,
+        re.M | re.S,
+    )
+    if reference_family_block is None:
+        return {}
+
+    enum_values: Dict[str, str] = {}
+    for match in re.finditer(
+        r"^\s*([A-Z][A-Z0-9_]*)\s*=\s*\"([^\"]+)\"",
+        reference_family_block.group("body"),
+        re.M,
+    ):
+        enum_values[match.group(1)] = match.group(2)
+
+    models_by_reference_family: Dict[str, Set[str]] = {}
+    for match in re.finditer(
+        r"\"([^\"]+)\"\s*:\s*(?:\(\s*)?ReferenceFamily\.([A-Z0-9_]+)\.value",
+        text,
+        re.S,
+    ):
+        model, enum_name = match.groups()
+        reference_family = enum_values.get(enum_name)
+        if reference_family and model in known_models:
+            models_by_reference_family.setdefault(reference_family, set()).add(model)
+
+    return {
+        reference_family: sorted(models)
+        for reference_family, models in models_by_reference_family.items()
+    }
+
+
 def _iter_manifest_data_paths(value: object) -> List[str]:
     """Return repo-relative tests/e2e/data paths referenced by a manifest."""
     paths: Set[str] = set()
@@ -399,6 +443,7 @@ def build_impact_map(repo_root: Path) -> ImpactMap:
     task_strategy_to_models: Dict[str, List[str]] = {}
     manifest_field_to_models_sets: Dict[str, Set[str]] = {}
     e2e_data_file_to_models_sets: Dict[str, Set[str]] = {}
+    reference_family_to_models_sets: Dict[str, Set[str]] = {}
     all_model_names: List[str] = []
     core_models: List[str] = []
     model_metadata: Dict[str, Dict] = {}
@@ -437,9 +482,17 @@ def build_impact_map(repo_root: Path) -> ImpactMap:
                 f"tests/e2e/data/{fp8_scales}", set()).add(name)
         for data_path in _iter_manifest_data_paths(data):
             e2e_data_file_to_models_sets.setdefault(data_path, set()).add(name)
+        reference_family = data.get("reference_family")
+        if isinstance(reference_family, str) and reference_family:
+            reference_family_to_models_sets.setdefault(reference_family, set()).add(name)
 
     builder_to_families = _scan_family_imports(families_dir) if families_dir.is_dir() else {}
     cpp_runtime_model_strategies = _scan_cpp_runtime_model_manifests(runtime_models_dir)
+    for reference_family, models in _scan_contract_reference_families(
+        repo_root / "tests" / "e2e_harness" / "contracts.py",
+        set(all_model_names),
+    ).items():
+        reference_family_to_models_sets.setdefault(reference_family, set()).update(models)
 
     def _models_for_scoped_strategies(strategies: Set[str]) -> List[str]:
         models: Set[str] = set()
@@ -500,6 +553,10 @@ def build_impact_map(repo_root: Path) -> ImpactMap:
         },
         path_scope_overrides=path_scope_overrides,
         l0_replacement_by_model=l0_replacement_by_model,
+        reference_family_to_models={
+            reference_family: sorted(models)
+            for reference_family, models in reference_family_to_models_sets.items()
+        },
     )
 
 # ---------------------------------------------------------------------------
@@ -1507,14 +1564,30 @@ def analyze_impact(
     all_tiers: Set[str] = set()
     rebuild_cpp = False
     matched_rules: List[Dict] = []
+    diff_text_by_path: Dict[str, str] = {}
+    candidate_models: List[str] = []
+
+    if base and head and repo_root:
+        for fpath in changed_files:
+            diff_text = get_file_diff(base, head, repo_root, fpath)
+            if diff_text:
+                diff_text_by_path[fpath] = diff_text
+        candidate_models = _candidate_models_from_diffs(
+            changed_files,
+            imap,
+        )
 
     for fpath in changed_files:
         match = classify_file(fpath, imap)
-        diff_text = None
-        if base and head and repo_root:
-            diff_text = get_file_diff(base, head, repo_root, fpath)
+        diff_text = diff_text_by_path.get(fpath)
         if diff_text:
-            match = maybe_refine_match_with_diff(fpath, match, diff_text, imap)
+            match = maybe_refine_match_with_diff(
+                fpath,
+                match,
+                diff_text,
+                imap,
+                candidate_models,
+            )
         all_models.update(match.models)
         if match.rule in ("manifest", "e2e_data_file"):
             exact_models.update(match.models)
@@ -1628,7 +1701,7 @@ def _significant_diff_lines(diff_text: str) -> List[str]:
         content = raw_line[1:].strip()
         if not content:
             continue
-        if re.fullmatch(r"[\[\]{}(),;]+", content):
+        if re.fullmatch(r"[\[\]{}(),;:'\"]+", content):
             continue
         lines.append(content)
     return lines
@@ -1684,6 +1757,199 @@ def _segmentation_task_models(imap: ImpactMap) -> List[str]:
         ["segmentation", "prompted_segmentation", "object_detection"], imap)
 
 
+def _models_for_families(families: Tuple[str, ...], imap: ImpactMap) -> List[str]:
+    models: Set[str] = set()
+    for family in families:
+        models.update(imap.family_to_models.get(family, []))
+    return sorted(models)
+
+
+def _canonical_identifier(value: str) -> str:
+    return re.sub(r"_+", "_", re.sub(r"[^a-z0-9]+", "_", value.lower())).strip("_")
+
+
+def _diff_identifier_fragments(line: str) -> Set[str]:
+    fragments: Set[str] = set()
+    for token in re.findall(r"[A-Za-z0-9][A-Za-z0-9_.-]*", line):
+        fragments.add(_canonical_identifier(token))
+        for part in re.split(r"[.]", token):
+            part = _canonical_identifier(part)
+            if part:
+                fragments.add(part)
+    return {fragment for fragment in fragments if fragment}
+
+
+def _models_for_profile_name(profile: str, imap: ImpactMap) -> List[str]:
+    families = PYTHON_PROFILE_TO_FAMILIES.get(profile, [profile])
+    return _models_for_families(tuple(families), imap)
+
+
+def _line_identifier_models(
+    line: str,
+    imap: ImpactMap,
+    include_task_strategies: bool = False,
+) -> List[str]:
+    fragments = _diff_identifier_fragments(line)
+    models: Set[str] = set()
+    model_fragments = {
+        _canonical_identifier(model)
+        for model in imap.all_model_names
+    }
+
+    for model in imap.all_model_names:
+        if _canonical_identifier(model) in fragments:
+            models.add(model)
+    for runtime_strategy, strategy_models in imap.strategy_to_models.items():
+        if _canonical_identifier(runtime_strategy) in fragments:
+            models.update(strategy_models)
+    for family, family_models in imap.family_to_models.items():
+        if _canonical_identifier(family) in fragments - model_fragments:
+            models.update(family_models)
+    for reference_family, reference_models in imap.reference_family_to_models.items():
+        if _canonical_identifier(reference_family) in fragments:
+            models.update(reference_models)
+    for profile in PYTHON_PROFILE_TO_FAMILIES:
+        if _canonical_identifier(profile) in fragments:
+            models.update(_models_for_profile_name(profile, imap))
+    if include_task_strategies:
+        for task_strategy, task_models in imap.task_strategy_to_models.items():
+            if _canonical_identifier(task_strategy) in fragments:
+                models.update(task_models)
+
+    return sorted(models)
+
+
+def _models_from_diff_identifiers(
+    lines: List[str],
+    imap: ImpactMap,
+    include_task_strategies: bool = False,
+) -> List[str]:
+    models: Set[str] = set()
+    for line in lines:
+        models.update(
+            _line_identifier_models(
+                line,
+                imap,
+                include_task_strategies=include_task_strategies,
+            )
+        )
+    return sorted(models)
+
+
+def _is_narrow_model_set(models: List[str], imap: ImpactMap) -> bool:
+    return bool(models) and len(set(models)) < len(imap.all_model_names_set)
+
+
+def _line_is_metadata_comment(line: str) -> bool:
+    return line.lstrip().startswith("#")
+
+
+def _line_matches_allowed_tokens(line: str, allowed_tokens: Tuple[str, ...]) -> bool:
+    normalized = _normalize_diff_line(line)
+    return any(token in normalized for token in allowed_tokens)
+
+
+def _scoped_models_from_path(path: str, imap: ImpactMap) -> List[str]:
+    match = classify_file(path, imap)
+    candidate_rule_names = {
+        "cpp_runtime_model",
+        "e2e_data_file",
+        "family_package",
+        "family_plugin",
+        "manifest",
+        "python_profile_requirements",
+        "specialized_builder",
+    }
+    if match.rule not in candidate_rule_names:
+        return []
+    if not _is_narrow_model_set(match.models, imap):
+        return []
+    if match.rule in _BROAD_FALLBACK_RULES:
+        return []
+    if match.rule.endswith("_unknown"):
+        return []
+    return match.models
+
+
+def _candidate_models_from_diffs(
+    changed_files: List[str],
+    imap: ImpactMap,
+) -> List[str]:
+    models: Set[str] = set()
+    for path in changed_files:
+        models.update(_scoped_models_from_path(path, imap))
+    return sorted(models)
+
+
+_PROFILE_METADATA_TOKENS: Tuple[str, ...] = (
+    "'''",
+    "architectures",
+    "build",
+    "config",
+    "context_length",
+    "ctor",
+    "d_ff",
+    "d_model",
+    "decoder_start_token_id",
+    "dropout_rate",
+    "eos_token_id",
+    "eval",
+    "family_defaults",
+    "import",
+    "input_patch_size",
+    "input_patch_stride",
+    "kind",
+    "num_decoder_layers",
+    "num_heads",
+    "num_layers",
+    "pad_token_id",
+    "prediction_length",
+    "print",
+    "profiles",
+    "quantiles",
+    "reference",
+    "requirements",
+    "system_site_packages",
+    "transformers",
+    "use_reg_token",
+    "venv",
+    "verification_script",
+)
+
+_HARNESS_REGISTRY_TOKENS: Tuple[str, ...] = (
+    "args",
+    "build",
+    "case.family",
+    "case.metadata",
+    "case.reference_family",
+    "cli_commands",
+    "comparisonmode",
+    "comparator_class",
+    "diff_framework",
+    "family",
+    "gating",
+    "import",
+    "kind",
+    "metadata",
+    "overrides",
+    "phase",
+    "preflightrequirement",
+    "python_module_available",
+    "referencefamily",
+    "reference_family",
+    "reqs.append",
+    "return",
+    "runner_class",
+    "runtime_strategy",
+    "stage",
+    "task",
+    "task_strategy",
+    "torch",
+    "transformers",
+    "usercontract",
+)
+
+
 @dataclass(frozen=True)
 class TokenDiffRefinementRule(DiffRefinementRule):
     name: str
@@ -1706,6 +1972,108 @@ class TokenDiffRefinementRule(DiffRefinementRule):
         return RuleMatch(
             self.name,
             self.models_for_impact(imap),
+            match.unit_tiers,
+            match.rebuild_cpp,
+        )
+
+
+@dataclass(frozen=True)
+class IdentifierDiffRefinementRule(DiffRefinementRule):
+    name: str
+    paths: Tuple[str, ...] = ()
+    path_prefixes: Tuple[str, ...] = ()
+    allowed_tokens: Tuple[str, ...] = ()
+    include_task_strategies: bool = False
+
+    def _path_matches(self, path: str) -> bool:
+        return path in self.paths or path.startswith(self.path_prefixes)
+
+    def matches(self, path: str, lines: List[str], imap: ImpactMap) -> bool:
+        if not self._path_matches(path):
+            return False
+        scoped_models = _models_from_diff_identifiers(
+            lines,
+            imap,
+            include_task_strategies=self.include_task_strategies,
+        )
+        if not _is_narrow_model_set(scoped_models, imap):
+            return False
+        return all(
+            _line_is_metadata_comment(line)
+            or _line_identifier_models(
+                line,
+                imap,
+                include_task_strategies=self.include_task_strategies,
+            )
+            or _line_matches_allowed_tokens(line, self.allowed_tokens)
+            for line in lines
+        )
+
+    def refine(
+        self,
+        path: str,
+        match: RuleMatch,
+        lines: List[str],
+        imap: ImpactMap,
+    ) -> RuleMatch:
+        del path
+        return RuleMatch(
+            self.name,
+            _models_from_diff_identifiers(
+                lines,
+                imap,
+                include_task_strategies=self.include_task_strategies,
+            ),
+            match.unit_tiers,
+            match.rebuild_cpp,
+        )
+
+
+@dataclass(frozen=True)
+class CandidateTokenDiffRefinementRule(DiffRefinementRule):
+    name: str
+    path: str
+    allowed_tokens: Tuple[str, ...]
+
+    def matches(self, path: str, lines: List[str], imap: ImpactMap) -> bool:
+        del path, lines, imap
+        return False
+
+    def refine(
+        self,
+        path: str,
+        match: RuleMatch,
+        lines: List[str],
+        imap: ImpactMap,
+    ) -> RuleMatch:
+        del path, match, lines, imap
+        raise RuntimeError("candidate-aware rules must use refine_with_candidates")
+
+    def matches_with_candidates(
+        self,
+        path: str,
+        lines: List[str],
+        imap: ImpactMap,
+        candidate_models: List[str],
+    ) -> bool:
+        return (
+            path == self.path
+            and _is_narrow_model_set(candidate_models, imap)
+            and _all_lines_match_tokens(lines, self.allowed_tokens)
+        )
+
+    def refine_with_candidates(
+        self,
+        path: str,
+        match: RuleMatch,
+        lines: List[str],
+        imap: ImpactMap,
+        candidate_models: List[str],
+    ) -> RuleMatch:
+        del path, lines, imap
+        return RuleMatch(
+            self.name,
+            sorted(set(candidate_models)),
             match.unit_tiers,
             match.rebuild_cpp,
         )
@@ -1874,6 +2242,102 @@ class HarnessSharedFp8ScalesRule(DiffRefinementRule):
         )
 
 
+class KnownModelTimingEstimateRule(DiffRefinementRule):
+    name = "e2e_timing_estimates_known_models"
+    path = "tests/e2e/timing_estimates.json"
+
+    @staticmethod
+    def _models_from_lines(lines: List[str], imap: ImpactMap) -> List[str]:
+        models: Set[str] = set()
+        for line in lines:
+            match = re.fullmatch(r'"([^"]+)":\s*[0-9]+,?', line)
+            if match is None:
+                return []
+            model = match.group(1)
+            if model not in imap.all_model_names_set:
+                return []
+            models.add(model)
+        return sorted(models)
+
+    def matches(self, path: str, lines: List[str], imap: ImpactMap) -> bool:
+        return path == self.path and bool(self._models_from_lines(lines, imap))
+
+    def refine(
+        self,
+        path: str,
+        match: RuleMatch,
+        lines: List[str],
+        imap: ImpactMap,
+    ) -> RuleMatch:
+        del path
+        return RuleMatch(
+            self.name,
+            self._models_from_lines(lines, imap),
+            match.unit_tiers,
+            match.rebuild_cpp,
+        )
+
+
+class RuntimeStrategyMatrixRule(DiffRefinementRule):
+    name = "runtime_strategy_matrix_known_strategies"
+    path = "tests/runtime_strategy_matrix.yaml"
+    allowed_tokens = (
+        "cli_commands",
+        "comparator_class",
+        "diff_framework_check_classes",
+        "diff_framework_exemption",
+        "neural_operator",
+        "no_diff_framework_check_currently_registers_runtime_strategies",
+        "runner_class",
+        "solve",
+        "task_strategy",
+        "tests.e2e_harness.comparators",
+        "tests.e2e_harness.runners",
+    )
+
+    @staticmethod
+    def _strategies_from_lines(lines: List[str], imap: ImpactMap) -> List[str]:
+        strategies: Set[str] = set()
+        for line in lines:
+            match = re.match(r'"([^"]+)":\s*\{', line.strip())
+            if match and match.group(1) in imap.strategy_to_models:
+                strategies.add(match.group(1))
+        return sorted(strategies)
+
+    def matches(self, path: str, lines: List[str], imap: ImpactMap) -> bool:
+        if path != self.path:
+            return False
+        strategies = self._strategies_from_lines(lines, imap)
+        if not strategies:
+            return False
+        normalized_lines = [
+            _normalize_diff_line(line)
+            for line in lines
+            if any(ch.isalnum() for ch in _normalize_diff_line(line))
+        ]
+        strategy_tokens = tuple(strategies)
+        return all(
+            any(token in line for token in strategy_tokens)
+            or any(token in line for token in self.allowed_tokens)
+            for line in normalized_lines
+        )
+
+    def refine(
+        self,
+        path: str,
+        match: RuleMatch,
+        lines: List[str],
+        imap: ImpactMap,
+    ) -> RuleMatch:
+        del path
+        return RuleMatch(
+            self.name,
+            _models_for_runtime_strategies(self._strategies_from_lines(lines, imap), imap),
+            match.unit_tiers,
+            match.rebuild_cpp,
+        )
+
+
 class HarnessReferenceDprContextEncoderRule(DiffRefinementRule):
     name = "harness_reference_dpr_context_encoder"
     path = "tests/e2e_harness/references/hf_transformers.py"
@@ -2030,6 +2494,58 @@ class E2EWaivesModelLinesRule(DiffRefinementRule):
 
 DIFF_REFINEMENT_RULES: tuple[DiffRefinementRule, ...] = (
     HarnessSharedFp8ScalesRule(),
+    KnownModelTimingEstimateRule(),
+    RuntimeStrategyMatrixRule(),
+    IdentifierDiffRefinementRule(
+        "pyproject_known_profiles",
+        paths=("pyproject.toml",),
+        allowed_tokens=(
+            "dependencies",
+            "optional_dependencies",
+            "project",
+            "version",
+        ),
+    ),
+    IdentifierDiffRefinementRule(
+        "python_profiles_known_profiles",
+        paths=("python/tensorrt_model_connect/python_profiles.toml",),
+        allowed_tokens=_PROFILE_METADATA_TOKENS,
+    ),
+    CandidateTokenDiffRefinementRule(
+        "shared_builder_config_lookup_family_registry",
+        "python/tensorrt_model_connect/families/__init__.py",
+        (
+            "callable(matches_config)",
+            "def_find_plugin",
+            "familyplugin",
+            "getattr(model_type",
+            "getattr(p",
+            "matches_config",
+            "model_type",
+            "model_type_str",
+            "p.matches",
+            "return_p",
+        ),
+    ),
+    CandidateTokenDiffRefinementRule(
+        "shared_builder_config_lookup_cli",
+        "python/tensorrt_model_connect/build_cli.py",
+        (
+            "find_plugin(config)",
+            "find_plugin(config.model_type)",
+            "plugin",
+            "raw_plugin",
+        ),
+    ),
+    CandidateTokenDiffRefinementRule(
+        "shared_builder_config_lookup_engine",
+        "python/tensorrt_model_connect/engine_builder.py",
+        (
+            "find_plugin(config)",
+            "find_plugin(config.model_type)",
+            "plugin",
+        ),
+    ),
     TokenDiffRefinementRule(
         "sam3_public_prompted_segmentation_api",
         "include/trtmc/pipeline.h",
@@ -2181,6 +2697,15 @@ DIFF_REFINEMENT_RULES: tuple[DiffRefinementRule, ...] = (
         ),
         _sam3_models,
     ),
+    IdentifierDiffRefinementRule(
+        "harness_shared_known_identifiers",
+        paths=(
+            "tests/e2e_harness/contracts.py",
+            "tests/e2e_harness/manifest_loader.py",
+            "tests/e2e_harness/orchestrator.py",
+        ),
+        allowed_tokens=_HARNESS_REGISTRY_TOKENS,
+    ),
     TokenDiffRefinementRule(
         "e2e_warm_hf_cache_diffusers_components",
         "scripts/warm_hf_cache.py",
@@ -2276,6 +2801,91 @@ DIFF_REFINEMENT_RULES: tuple[DiffRefinementRule, ...] = (
     ),
     HarnessReferenceDprContextEncoderRule(),
     HarnessReferenceVlGeneratedOnlyDecodeRule(),
+    IdentifierDiffRefinementRule(
+        "harness_reference_known_identifiers",
+        path_prefixes=("tests/e2e_harness/references/",),
+        allowed_tokens=_HARNESS_REGISTRY_TOKENS + (
+            "1.0",
+            "align_window",
+            "any",
+            "arch",
+            "architectures",
+            "backend",
+            "branch_input",
+            "candidate",
+            "case",
+            "channels",
+            "coerce_numeric_sequence",
+            "context",
+            "cpu",
+            "ctx",
+            "data",
+            "def_",
+            "detach",
+            "dtype",
+            "elapsed",
+            "else",
+            "error",
+            "eval",
+            "exc",
+            "expected_len",
+            "field",
+            "field_input",
+            "float",
+            "for",
+            "forecast",
+            "freq",
+            "from_pretrained",
+            "full_inference",
+            "getattr",
+            "hf_id",
+            "gt",
+            "in",
+            "inputs",
+            "int",
+            "isinstance",
+            "json",
+            "key",
+            "logits",
+            "max",
+            "mean_predictions",
+            "model",
+            "num_input_channels",
+            "observed_mask",
+            "output",
+            "padding",
+            "past",
+            "path",
+            "payload",
+            "pipe.predict",
+            "prediction",
+            "project_dir",
+            "quantile_preds",
+            "raw",
+            "reference_output_name",
+            "regression",
+            "reshape",
+            "result",
+            "run_time_series",
+            "scale",
+            "script",
+            "series",
+            "stderr",
+            "str",
+            "subprocess",
+            "sys",
+            "tensor",
+            "text",
+            "time",
+            "trunk",
+            "trunk_input",
+            "try",
+            "typing",
+            "unsupported",
+            "value",
+            "valid_len",
+        ),
+    ),
     E2EWaivesModelLinesRule(),
 )
 
@@ -2285,13 +2895,27 @@ def maybe_refine_match_with_diff(
     match: RuleMatch,
     diff_text: str,
     imap: ImpactMap,
+    candidate_models: Optional[List[str]] = None,
 ) -> RuleMatch:
     """Narrow broad file matches when the diff is demonstrably feature-scoped."""
     lines = _significant_diff_lines(diff_text)
     if not lines:
         return match
 
+    if candidate_models is None:
+        candidate_models = []
+
     for rule in DIFF_REFINEMENT_RULES:
+        if isinstance(rule, CandidateTokenDiffRefinementRule):
+            if rule.matches_with_candidates(path, lines, imap, candidate_models):
+                return rule.refine_with_candidates(
+                    path,
+                    match,
+                    lines,
+                    imap,
+                    candidate_models,
+                )
+            continue
         if rule.matches(path, lines, imap):
             return rule.refine(path, match, lines, imap)
 


### PR DESCRIPTION
## Background
PR #247 exposed a broader weakness in the E2E impact selector: additive model plumbing in shared files could fall back to all-model E2E even when the changed lines identified a narrow set of affected models. The first version of this PR scoped the known time-series case; this update generalizes that idea so the selector can infer affected models across families.

## Exit Criteria
- Shared registry/profile metadata diffs refine to known affected models across model families, not only time-series.
- Shared builder plugin-lookup plumbing can use a PR-level candidate model set, but only when candidates come from model-owned paths.
- Unrecognized shared-file behavior still keeps the conservative all-model fallback.
- This selector-only PR itself does not request E2E models.

## Implementation
- Add generic diff identifier extraction for exact model names, families, runtime strategies, Python profiles, and contract reference families.
- Add generic refinement rules for `pyproject.toml`, `python_profiles.toml`, harness shared registry files, harness reference files, timing estimates, and runtime strategy matrix entries.
- Add candidate-aware shared builder lookup rules that scope only when the same PR touches model-owned paths such as manifests, family packages, profile requirements, or runtime model directories.
- Keep specialized SAM3/FP8/DPR refinements ahead of the generic fallbacks.

## Validation
- `docker run --rm -i -v /workspace/users/yizhuoz:/workspace/users/yizhuoz -w /workspace/users/yizhuoz/trt-transformers-timeseries -e PYTHONPATH=/workspace/users/yizhuoz/trt-transformers-timeseries/python trtmc-dev-gb300:latest bash -lc 'git config --global --add safe.directory /workspace/users/yizhuoz/trt-transformers-timeseries && python -m pytest tests/tools/test_test_impact.py tests/tools/test_e2e_python_profiles.py -q'`: passed, `149 passed`.
- `python3 tools/test_impact.py --base 51a5b063 --head bae3162539d91a673d7010a717701b9811184ea3 --json --verbose`: passed; selected `chronos-bolt-tiny-official`, `patchtsmixer-granite-official`, `patchtst-etth1-regression-distribution`, `patchtst-granite-official`, and `timesfm-2.0-500m-official`.
- `python3 tools/test_impact.py --base 51a5b063 --head fbcd11c3 --json --verbose`: passed; selected the same five time-series L0 models while task-eval files mapped to tools only.
- `python3 tools/test_impact.py --base github/main --head HEAD --json --verbose`: passed; this PR selects no E2E models and the `tools` unit tier.
- `env GITHUB_WORKSPACE=/workspace/users/yizhuoz/trt-transformers-timeseries CI_BASE_REF=github/main bash .github/scripts/run-gha-stage.sh lint`: passed.

## Notes For Future Readers
- The generic rules are diff-aware but still conservative: every changed line must be explained by known model identifiers or allowed registry/profile syntax, otherwise the original broad rule remains in force.
- PR-level candidates intentionally come only from model-owned paths. Task-scoped harness files are not allowed to narrow unrelated shared builder changes.
