### PR TITLE
feat(e2e/tts): add nightly TTS probe coverage

### DIFF
--- a/tests/e2e/models/bark-small-tts-probe01.json
+++ b/tests/e2e/models/bark-small-tts-probe01.json
@@ -1,0 +1,29 @@
+{
+  "name": "bark-small-tts-probe01",
+  "trace_id": "IT-E2E-BARKS-TTS-P01",
+  "hf_id": "suno/bark-small",
+  "bundle": "bark-small.trtfb",
+  "family": "bark",
+  "runtime_strategy": "text_to_audio_bark",
+  "reference_family": "tts_bark",
+  "user_contract": "tts_audio",
+  "test_type": "audio",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "bark-small",
+  "l0_replacement_reason": "TTS probe matrix runs in nightly; PR L0 uses the base bark-small case for the same text_to_audio_bark runtime path.",
+  "max_cache_length": 1024,
+  "prompt": "Model Connect generates a clear audio sample for this test.",
+  "max_new_tokens": 0,
+  "logit_atol": 0.01,
+  "trust_remote_code": false,
+  "determinism": {
+    "seed": 0
+  },
+  "threshold_overrides": {
+    "contract_min_rms": 0.005
+  },
+  "tts_probe_id": "probe_01_prompt_round_trip_sentence",
+  "tts_probe_readiness": "ready_now",
+  "tts_probe_purpose": "Cover Model Connect text prompt transport through generate-audio with a distinct sentence while reusing the existing bark-small bundle.",
+  "notes": "Nightly TTS coverage probe for Model Connect input handling: manifest prompt -> CLI prompt -> text_to_audio_bark runtime -> WAV artifact -> tts_audio contract. Golden Bark token checks are intentionally omitted because they are prompt-specific to the base bark-small case."
+}

--- a/tests/e2e/models/bark-small-tts-probe02.json
+++ b/tests/e2e/models/bark-small-tts-probe02.json
@@ -1,0 +1,29 @@
+{
+  "name": "bark-small-tts-probe02",
+  "trace_id": "IT-E2E-BARKS-TTS-P02",
+  "hf_id": "suno/bark-small",
+  "bundle": "bark-small.trtfb",
+  "family": "bark",
+  "runtime_strategy": "text_to_audio_bark",
+  "reference_family": "tts_bark",
+  "user_contract": "tts_audio",
+  "test_type": "audio",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "bark-small",
+  "l0_replacement_reason": "TTS probe matrix runs in nightly; PR L0 uses the base bark-small case for the same text_to_audio_bark runtime path.",
+  "max_cache_length": 1024,
+  "prompt": "Please pause, then continue speaking clearly.",
+  "max_new_tokens": 0,
+  "logit_atol": 0.01,
+  "trust_remote_code": false,
+  "determinism": {
+    "seed": 0
+  },
+  "threshold_overrides": {
+    "contract_min_rms": 0.005
+  },
+  "tts_probe_id": "probe_02_comma_prompt_round_trip",
+  "tts_probe_readiness": "ready_now",
+  "tts_probe_purpose": "Cover Model Connect text prompt transport for a comma-bearing Bark TTS sentence while reusing the existing bark-small bundle.",
+  "notes": "Nightly TTS coverage probe for Model Connect input handling: manifest prompt -> CLI prompt with comma punctuation -> text_to_audio_bark runtime -> WAV artifact -> tts_audio contract. The prompt avoids numbers and abbreviations to keep ASR round-trip normalization stable."
+}

--- a/tests/e2e/models/magpie-tts-357m-tts-probe01.json
+++ b/tests/e2e/models/magpie-tts-357m-tts-probe01.json
@@ -1,0 +1,49 @@
+{
+  "name": "magpie-tts-357m-tts-probe01",
+  "trace_id": "IT-E2E-MGPTTS-P01",
+  "hf_id": "nvidia/magpie_tts_multilingual_357m",
+  "bundle": "magpie-tts-357m.trtfb",
+  "family": "magpie_tts",
+  "runtime_strategy": "text_to_audio_magpie",
+  "reference_backend": "nemo",
+  "reference_family": "tts_magpie",
+  "user_contract": "tts_audio",
+  "test_type": "audio",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "magpie-tts-357m",
+  "l0_replacement_reason": "TTS probe matrix runs in nightly; PR L0 uses the base magpie-tts-357m case for the same text_to_audio_magpie runtime path.",
+  "max_cache_length": 512,
+  "prompt": "Please say this sentence clearly.",
+  "max_new_tokens": 260,
+  "logit_atol": 0.01,
+  "trust_remote_code": false,
+  "runtime_config": {
+    "audio_magpie": {
+      "cfg_scale": 2.5,
+      "temperature": 0.6,
+      "seed": 42
+    }
+  },
+  "threshold_overrides": {
+    "contract_min_rms": 0.005
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "python_module_available",
+      "args": {
+        "module": "nemo.collections.tts.g2p.models.i18n_ipa",
+        "timeout_s": 180
+      },
+      "gating": true
+    }
+  ],
+  "tts_probe_id": "probe_01_short_prompt_round_trip_sentence",
+  "tts_probe_readiness": "ready_now",
+  "tts_probe_purpose": "Cover Model Connect prompt transport through generate-audio with a short Magpie TTS sentence while reusing the existing magpie-tts-357m bundle.",
+  "notes": "Nightly TTS coverage probe for Model Connect input handling: manifest prompt -> CLI prompt -> text_to_audio_magpie runtime -> WAV artifact -> tts_audio contract. The prompt avoids numbers, abbreviations, and domain-specific terms so ASR round-trip failures are less likely to come from text normalization ambiguity."
+}

--- a/tests/e2e/models/magpie-tts-357m-tts-probe02.json
+++ b/tests/e2e/models/magpie-tts-357m-tts-probe02.json
@@ -1,0 +1,49 @@
+{
+  "name": "magpie-tts-357m-tts-probe02",
+  "trace_id": "IT-E2E-MGPTTS-P02",
+  "hf_id": "nvidia/magpie_tts_multilingual_357m",
+  "bundle": "magpie-tts-357m.trtfb",
+  "family": "magpie_tts",
+  "runtime_strategy": "text_to_audio_magpie",
+  "reference_backend": "nemo",
+  "reference_family": "tts_magpie",
+  "user_contract": "tts_audio",
+  "test_type": "audio",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "magpie-tts-357m",
+  "l0_replacement_reason": "TTS probe matrix runs in nightly; PR L0 uses the base magpie-tts-357m case for the same text_to_audio_magpie runtime path.",
+  "max_cache_length": 512,
+  "prompt": "Say hello, then say goodbye.",
+  "max_new_tokens": 220,
+  "logit_atol": 0.01,
+  "trust_remote_code": false,
+  "runtime_config": {
+    "audio_magpie": {
+      "cfg_scale": 2.5,
+      "temperature": 0.6,
+      "seed": 42
+    }
+  },
+  "threshold_overrides": {
+    "contract_min_rms": 0.005
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "python_module_available",
+      "args": {
+        "module": "nemo.collections.tts.g2p.models.i18n_ipa",
+        "timeout_s": 180
+      },
+      "gating": true
+    }
+  ],
+  "tts_probe_id": "probe_02_punctuation_prompt_round_trip",
+  "tts_probe_readiness": "ready_now",
+  "tts_probe_purpose": "Cover Model Connect prompt transport for a short punctuation-bearing Magpie TTS sentence while reusing the existing magpie-tts-357m bundle.",
+  "notes": "Nightly TTS coverage probe for Model Connect input handling: manifest prompt -> CLI prompt with punctuation -> text_to_audio_magpie runtime -> WAV artifact -> tts_audio contract. This keeps the prompt short to limit nightly runtime cost."
+}

--- a/tests/e2e/models/magpie-tts-357m-tts-probe03.json
+++ b/tests/e2e/models/magpie-tts-357m-tts-probe03.json
@@ -1,0 +1,49 @@
+{
+  "name": "magpie-tts-357m-tts-probe03",
+  "trace_id": "IT-E2E-MGPTTS-P03",
+  "hf_id": "nvidia/magpie_tts_multilingual_357m",
+  "bundle": "magpie-tts-357m.trtfb",
+  "family": "magpie_tts",
+  "runtime_strategy": "text_to_audio_magpie",
+  "reference_backend": "nemo",
+  "reference_family": "tts_magpie",
+  "user_contract": "tts_audio",
+  "test_type": "audio",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "magpie-tts-357m",
+  "l0_replacement_reason": "TTS probe matrix runs in nightly; PR L0 uses the base magpie-tts-357m case for the same text_to_audio_magpie runtime path.",
+  "max_cache_length": 512,
+  "prompt": "Can you read this question clearly?",
+  "max_new_tokens": 220,
+  "logit_atol": 0.01,
+  "trust_remote_code": false,
+  "runtime_config": {
+    "audio_magpie": {
+      "cfg_scale": 2.5,
+      "temperature": 0.6,
+      "seed": 42
+    }
+  },
+  "threshold_overrides": {
+    "contract_min_rms": 0.005
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "python_module_available",
+      "args": {
+        "module": "nemo.collections.tts.g2p.models.i18n_ipa",
+        "timeout_s": 180
+      },
+      "gating": true
+    }
+  ],
+  "tts_probe_id": "probe_03_question_prompt_round_trip",
+  "tts_probe_readiness": "ready_now",
+  "tts_probe_purpose": "Cover Model Connect prompt transport for a short question-form Magpie TTS sentence while reusing the existing magpie-tts-357m bundle.",
+  "notes": "Nightly TTS coverage probe for Model Connect input handling: manifest prompt -> CLI prompt with question punctuation -> text_to_audio_magpie runtime -> WAV artifact -> tts_audio contract. The prompt stays short to limit nightly runtime cost."
+}

--- a/tests/e2e/models/magpie-tts-357m-tts-probe04.json
+++ b/tests/e2e/models/magpie-tts-357m-tts-probe04.json
@@ -1,0 +1,49 @@
+{
+  "name": "magpie-tts-357m-tts-probe04",
+  "trace_id": "IT-E2E-MGPTTS-P04",
+  "hf_id": "nvidia/magpie_tts_multilingual_357m",
+  "bundle": "magpie-tts-357m.trtfb",
+  "family": "magpie_tts",
+  "runtime_strategy": "text_to_audio_magpie",
+  "reference_backend": "nemo",
+  "reference_family": "tts_magpie",
+  "user_contract": "tts_audio",
+  "test_type": "audio",
+  "ci_tier": "nightly_only",
+  "l0_replacement": "magpie-tts-357m",
+  "l0_replacement_reason": "TTS probe matrix runs in nightly; PR L0 uses the base magpie-tts-357m case for the same text_to_audio_magpie runtime path.",
+  "max_cache_length": 512,
+  "prompt": "First we test the audio. Then we check the transcript.",
+  "max_new_tokens": 320,
+  "logit_atol": 0.01,
+  "trust_remote_code": false,
+  "runtime_config": {
+    "audio_magpie": {
+      "cfg_scale": 2.5,
+      "temperature": 0.6,
+      "seed": 42
+    }
+  },
+  "threshold_overrides": {
+    "contract_min_rms": 0.005
+  },
+  "preflight_requirements": [
+    {
+      "kind": "binary_exists",
+      "args": {},
+      "gating": true
+    },
+    {
+      "kind": "python_module_available",
+      "args": {
+        "module": "nemo.collections.tts.g2p.models.i18n_ipa",
+        "timeout_s": 180
+      },
+      "gating": true
+    }
+  ],
+  "tts_probe_id": "probe_04_two_sentence_prompt_round_trip",
+  "tts_probe_readiness": "ready_now",
+  "tts_probe_purpose": "Cover Model Connect prompt transport for a short two-sentence Magpie TTS input while reusing the existing magpie-tts-357m bundle.",
+  "notes": "Nightly TTS coverage probe for Model Connect input handling: manifest prompt -> CLI prompt with sentence boundary -> text_to_audio_magpie runtime -> WAV artifact -> tts_audio contract. This covers sentence boundary handling without adding dataset-driven CI load."
+}


### PR DESCRIPTION
## What changed

  This PR expands nightly TTS coverage for Model Connect by adding prompt-focused probe manifests across 2 text-to-audio models:

  - `bark-small`
  - `magpie-tts-357m`

  The new nightly-only TTS probe cases cover:

  - Bark short prompt round-trip sentence
  - Bark comma/punctuation prompt handling
  - Magpie short prompt round-trip sentence
  - Magpie comma/punctuation prompt handling
  - Magpie question-form prompt handling
  - Magpie two-sentence prompt boundary handling

  This adds 6 new nightly TTS probe manifests in total.

  ## Why

  The goal is to validate Model Connect’s text-to-audio input/output handling more broadly, not to test model quality itself.

  These probes exercise common TTS integration paths such as manifest prompt transport, CLI prompt forwarding, punctuation handling, sentence boundary handling, WAV artifact generation, and the existing `tts_audio` user contract.

  ## Verifier updates

  No new verifier metrics are added in this PR.

  The pass/fail gate remains aligned with the existing TTS user contract behavior. The probes intentionally use short, normalization-stable prompts so failures are more likely to indicate Model Connect prompt/audio handling issues instead of model-quality variance.

  ## Harness updates

  - Added 2 nightly-only `bark-small` TTS probe manifests.
  - Added 4 nightly-only `magpie-tts-357m` TTS probe manifests.
  - Reused the existing base TTS cases as PR L0 replacements via `l0_replacement`.

  ## Expected failures

  None.

  Note: Magpie build/reference validation needs an environment with NeMo TTS available, consistent with the existing `magpie-tts-357m` preflight requirement.

  ## Validation

  - JSON parse check for 6 TTS probe manifests
  - Manifest loader check for 6 nightly TTS probe cases
  - `tools/test_impact.py --validate`
  - Impact check for JSON-only PR selects `bark-small` and `magpie-tts-357m` L0 replacements, with no builder unit tier
  - GPU E2E on 94/P2021:
    - `bark-small-tts-probe01`: passed, 48s
    - `bark-small-tts-probe02`: passed, 53s
    - `magpie-tts-357m-tts-probe01`: passed, 56s steady-state
    - `magpie-tts-357m-tts-probe02`: passed, 53s steady-state
    - `magpie-tts-357m-tts-probe03`: passed, 54s steady-state
    - `magpie-tts-357m-tts-probe04`: passed, 55s steady-state

  Remote E2E logs are under:

  `/localhome/local-ndai/trtmc/logs/tts-probe-submit-20260623-steady/`
