### PR TITLE
feat(ci): add model-centric mutation testing lane

### DIFF
--- a/.github/scripts/run-gha-stage.sh
+++ b/.github/scripts/run-gha-stage.sh
@@ -21,6 +21,7 @@ docker exec \
   -e HF_MODULES_CACHE \
   -e FULL_E2E \
   -e RUN_COVERAGE_MAP \
+  -e TRTMC_MUTATION_MODE \
   -e REBUILD_ENGINES \
   -e GITHUB_EVENT_NAME \
   -e GITHUB_REF_NAME \

--- a/.github/scripts/run-trtmc-ci.sh
+++ b/.github/scripts/run-trtmc-ci.sh
@@ -657,6 +657,17 @@ generate_coverage_map() {
   python -c "import json; d=json.load(open('coverage_map.json')); m=d['meta']; print('Python tests: %s, C++ tests: %s, Source files: %d' % (m['python_tests'], m['cpp_tests'], len(d['source_to_tests'])))"
 }
 
+run_ci_mutation() {
+  local mode="${TRTMC_MUTATION_MODE:-premerge}"
+  if [ "${FULL_E2E:-false}" = "true" ] && [ -z "${TRTMC_MUTATION_MODE:-}" ]; then
+    mode="nightly"
+  fi
+
+  python tools/ci_mutation.py run \
+    --mode "$mode" \
+    --result-dir ci_mutation_artifacts
+}
+
 current_python_wheel_tag() {
   python - <<'PY'
 import sys
@@ -1070,6 +1081,10 @@ run_stage() {
       run_step "Setup TensorRT-Model-Connect wheel runtime" setup_wheel_runtime_environment
       run_step "Generate coverage map" generate_coverage_map
       ;;
+    ci-mutation)
+      run_step "Setup TensorRT-Model-Connect source checks" setup_source_check_environment
+      run_step "CI mutation self-test" run_ci_mutation
+      ;;
     package)
       run_step "Setup TensorRT-Model-Connect package build environment" setup_package_build_environment
       run_step "Build trtmc pip package" build_pip_package
@@ -1105,5 +1120,6 @@ run_step "C++ coverage" run_cpp_coverage
 run_step "Graph-op GPU tests" run_graph_op_tests
 run_step "Selective E2E tests" run_selective_e2e
 run_step "Full E2E tests" run_full_e2e
+run_step "CI mutation self-test" run_ci_mutation
 run_step "Generate coverage map" generate_coverage_map
 run_step "Qwen smoke test from trtmc pip package" run_wheel_qwen_smoke

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,6 +37,7 @@ env:
   CPP_COVERAGE_MIN_BRANCH: "21"
   FULL_E2E: "true"
   RUN_COVERAGE_MAP: "true"
+  TRTMC_MUTATION_MODE: "nightly"
   REBUILD_ENGINES: "true"
   DIFFUSION_VLM_ASSESSMENT: "true"
   DIFFUSION_VLM_MODEL_ID: ${{ vars.TRTMC_DIFFUSION_VLM_MODEL_ID || 'Qwen/Qwen2.5-VL-3B-Instruct' }}
@@ -172,6 +173,11 @@ jobs:
         timeout-minutes: 360
         run: bash .github/scripts/run-gha-stage.sh full-e2e
 
+      - name: CI mutation self-test
+        if: ${{ always() }}
+        timeout-minutes: 15
+        run: bash .github/scripts/run-gha-stage.sh ci-mutation
+
       - name: Generate coverage map
         if: ${{ always() }}
         timeout-minutes: 90
@@ -275,6 +281,7 @@ jobs:
             impact.json
             coverage_map.json
             coverage/
+            ci_mutation_artifacts/
             e2e_artifacts/
 
       - name: Stop CI container

--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -41,6 +41,7 @@ env:
   CPP_COVERAGE_MIN_BRANCH: "21"
   FULL_E2E: "false"
   RUN_COVERAGE_MAP: "false"
+  TRTMC_MUTATION_MODE: "premerge"
   REBUILD_ENGINES: "true"
   DIFFUSION_VLM_ASSESSMENT: "true"
   DIFFUSION_VLM_MODEL_ID: ${{ vars.TRTMC_DIFFUSION_VLM_MODEL_ID || 'Qwen/Qwen2.5-VL-3B-Instruct' }}
@@ -232,6 +233,10 @@ jobs:
         timeout-minutes: 240
         run: bash .github/scripts/run-gha-stage.sh selective-e2e
 
+      - name: CI mutation self-test
+        timeout-minutes: 10
+        run: bash .github/scripts/run-gha-stage.sh ci-mutation
+
       - name: Write CI summary
         if: always()
         run: |
@@ -265,6 +270,7 @@ jobs:
             impact.json
             coverage_map.json
             coverage/
+            ci_mutation_artifacts/
             e2e_artifacts/
             dist/*.whl
 

--- a/model_connect_ci/__init__.py
+++ b/model_connect_ci/__init__.py
@@ -1,0 +1,1 @@
+"""Model-centric CI mutation testing helpers for TensorRT-Model-Connect."""

--- a/model_connect_ci/gates/__init__.py
+++ b/model_connect_ci/gates/__init__.py
@@ -1,0 +1,1 @@
+"""Gate evaluation for CI mutation testing."""

--- a/model_connect_ci/gates/ci_gate.py
+++ b/model_connect_ci/gates/ci_gate.py
@@ -1,0 +1,81 @@
+"""CI robustness gate checks."""
+
+from __future__ import annotations
+
+from model_connect_ci.gates.policy import GateVerdict
+from model_connect_ci.mutations.ci_ops import CISelfTestResult
+from model_connect_ci.types import Finding, PolicyBundle
+
+
+def evaluate_ci_robustness(result: CISelfTestResult, policies: PolicyBundle) -> GateVerdict:
+    """Evaluate the spec's anti-false-green CI robustness rules."""
+
+    policy = policies.mandatory
+    findings: list[Finding] = []
+
+    findings.append(
+        Finding(
+            code="critical_ci_mutations_killed",
+            passed=result.escaped_critical == 0,
+            severity="error",
+            message=f"escaped critical CI mutations: {result.escaped_critical}",
+        )
+    )
+    findings.append(
+        Finding(
+            code="assertion_strength_threshold",
+            passed=result.metrics["assertion_strength_score"] < policy.assertion_strength_min,
+            severity="error",
+            message=(
+                "CI self-test weakening was detected by assertion-strength gate "
+                f"({result.metrics['assertion_strength_score']:.2f} < "
+                f"{policy.assertion_strength_min:.2f})"
+            ),
+        )
+    )
+    findings.append(
+        Finding(
+            code="negative_test_threshold",
+            passed=result.metrics["negative_test_count"] < policy.negative_test_count_min,
+            severity="error",
+            message=(
+                "CI self-test negative-test removal was detected "
+                f"({result.metrics['negative_test_count']:.0f} < "
+                f"{policy.negative_test_count_min})"
+            ),
+        )
+    )
+    findings.append(
+        Finding(
+            code="skip_xfail_delta_threshold",
+            passed=result.metrics["skip_xfail_delta"] > policy.skip_xfail_delta_max,
+            severity="error",
+            message=(
+                "CI self-test skip/xfail/waive growth was detected "
+                f"({result.metrics['skip_xfail_delta']:.0f} > "
+                f"{policy.skip_xfail_delta_max})"
+            ),
+        )
+    )
+    findings.append(
+        Finding(
+            code="report_integrity_threshold",
+            passed=result.metrics["report_integrity_score"] < policy.report_integrity_min,
+            severity="error",
+            message=(
+                "CI self-test report masking was detected "
+                f"({result.metrics['report_integrity_score']:.2f} < "
+                f"{policy.report_integrity_min:.2f})"
+            ),
+        )
+    )
+
+    return GateVerdict(
+        name="ci_robustness",
+        passed=all(finding.passed for finding in findings),
+        findings=tuple(findings),
+        metrics={
+            "escaped_critical_ci_mutations": float(result.escaped_critical),
+            **result.metrics,
+        },
+    )

--- a/model_connect_ci/gates/policy.py
+++ b/model_connect_ci/gates/policy.py
@@ -1,0 +1,26 @@
+"""Gate result types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from model_connect_ci.types import Finding
+
+
+@dataclass(frozen=True)
+class GateVerdict:
+    """A product or CI robustness gate verdict."""
+
+    name: str
+    passed: bool
+    findings: tuple[Finding, ...]
+    metrics: dict[str, float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "passed": self.passed,
+            "metrics": dict(self.metrics),
+            "findings": [finding.to_dict() for finding in self.findings],
+        }

--- a/model_connect_ci/gates/product_gate.py
+++ b/model_connect_ci/gates/product_gate.py
@@ -1,0 +1,38 @@
+"""Product correctness gate checks for manifest freeze evidence."""
+
+from __future__ import annotations
+
+from model_connect_ci.gates.policy import GateVerdict
+from model_connect_ci.types import Finding, ModelInventory, PolicyBundle
+
+
+def evaluate_product_gate(inventory: ModelInventory, policies: PolicyBundle) -> GateVerdict:
+    """Evaluate product-facing manifest freeze requirements."""
+
+    findings = tuple(inventory.validate_mandatory_matrix(policies.mandatory))
+    failed = tuple(finding for finding in findings if not finding.passed)
+    revision_warnings = tuple(
+        Finding(
+            code="revision_pin_missing",
+            passed=True,
+            severity="warning",
+            model=model.name,
+            message=(
+                f"{model.name} does not declare a pinned model/tokenizer revision; "
+                "reported as evidence during bootstrap"
+            ),
+        )
+        for model in inventory.models
+        if not model.has_revision_pin
+    )
+    metrics = {
+        "manifest_findings": float(len(findings)),
+        "manifest_failures": float(len(failed)),
+        "revision_pin_warnings": float(len(revision_warnings)),
+    }
+    return GateVerdict(
+        name="product_manifest_freeze",
+        passed=not failed,
+        findings=(*findings, *revision_warnings),
+        metrics=metrics,
+    )

--- a/model_connect_ci/manifests/__init__.py
+++ b/model_connect_ci/manifests/__init__.py
@@ -1,0 +1,1 @@
+"""Manifest loading for model-centric CI mutation testing."""

--- a/model_connect_ci/manifests/loader.py
+++ b/model_connect_ci/manifests/loader.py
@@ -1,0 +1,218 @@
+"""Load mutation-testing policies and normalize E2E model manifests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from model_connect_ci.types import MandatoryPolicy, ModelCase, ModelInventory, PolicyBundle
+
+
+BUCKET_DECODER = "decoder-only LLM"
+BUCKET_ENCODER = "encoder / embedding"
+BUCKET_ENCODER_DECODER = "encoder-decoder"
+BUCKET_VISION = "vision"
+BUCKET_DIFFUSION = "diffusion"
+BUCKET_SPEECH = "speech"
+BUCKET_MULTIMODAL = "multimodal"
+
+_RUNTIME_TO_TASK = {
+    "decoder_kv_cache": "text_generation_causal",
+    "decoder_static": "text_generation_causal",
+    "encoder_only": "encoder_only_nlp",
+    "encoder_decoder": "encoder_decoder",
+    "seq2seq": "encoder_decoder",
+    "diffusion_flux": "diffusion_media_generation",
+    "diffusion_wan": "diffusion_media_generation",
+    "diffusion_z_image": "diffusion_media_generation",
+    "prompted_segmentation": "prompted_segmentation",
+}
+
+_DIFFUSION_FAMILIES = {
+    "elf_flow",
+    "flux",
+    "ltx_video",
+    "nemotron_labs_diffusion",
+    "pixart",
+    "qwen_image",
+    "wan_t2v",
+    "z_image",
+}
+_SPEECH_FAMILIES = {
+    "bark",
+    "canary",
+    "magpie_tts",
+    "nemotron_speech_streaming",
+    "personaplex",
+    "whisper",
+}
+_MULTIMODAL_FAMILIES = {
+    "deepseek_ocr",
+    "eagle_vlm",
+    "internvl",
+    "lance",
+    "nemotron_embed_vl",
+    "nemotron_rerank_vl",
+    "phi4mm",
+    "qwen_vl",
+}
+_VISION_FAMILIES = {
+    "sam",
+    "sam3",
+    "segformer",
+    "timm_vit",
+    "yolox",
+}
+_ENCODER_DECODER_FAMILIES = {
+    "bart",
+    "marian",
+    "m2m_100",
+    "nllb",
+    "riva_translate",
+    "t5",
+}
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return data
+
+
+def _tuple_mapping(raw: dict[str, Any]) -> dict[str, tuple[str, ...]]:
+    return {
+        str(key): tuple(str(item) for item in value or [])
+        for key, value in raw.items()
+    }
+
+
+def load_policy_bundle(manifest_dir: Path) -> PolicyBundle:
+    """Load all mutation-testing YAML policies."""
+
+    supported_models = _read_yaml(manifest_dir / "supported_hf_models.yaml")
+    reference_corpus = _read_yaml(manifest_dir / "reference_corpus.yaml")
+    mutation_catalog = _read_yaml(manifest_dir / "mutation_catalog.yaml")
+    tolerance_policy = _read_yaml(manifest_dir / "tolerance_policy.yaml")
+    mandatory_raw = _read_yaml(manifest_dir / "mandatory_matrix.yaml")
+    gate = mandatory_raw.get("gate_thresholds", {})
+
+    mandatory = MandatoryPolicy(
+        required_buckets=tuple(str(item) for item in mandatory_raw.get("required_buckets", [])),
+        tier_a_models=tuple(str(item) for item in mandatory_raw.get("tier_a_models", [])),
+        negative_test_models=_tuple_mapping(mandatory_raw.get("negative_test_models", {})),
+        metamorphic_test_models=_tuple_mapping(mandatory_raw.get("metamorphic_test_models", {})),
+        assertion_strength_min=float(gate.get("assertion_strength_min", 1.0)),
+        negative_test_count_min=int(gate.get("negative_test_count_min", 0)),
+        skip_xfail_delta_max=int(gate.get("skip_xfail_delta_max", 0)),
+        report_integrity_min=float(gate.get("report_integrity_min", 1.0)),
+    )
+
+    return PolicyBundle(
+        manifest_dir=manifest_dir,
+        supported_models=supported_models,
+        reference_corpus=reference_corpus,
+        mutation_catalog=mutation_catalog,
+        tolerance_policy=tolerance_policy,
+        mandatory=mandatory,
+    )
+
+
+def _infer_task_strategy(raw: dict[str, Any]) -> str:
+    explicit = raw.get("task_strategy")
+    if explicit:
+        return str(explicit)
+    runtime = str(raw.get("runtime_strategy", "decoder_kv_cache"))
+    return _RUNTIME_TO_TASK.get(runtime, runtime)
+
+
+def _classify_bucket(raw: dict[str, Any], task_strategy: str) -> str:
+    family = str(raw.get("family", "")).lower()
+    runtime = str(raw.get("runtime_strategy", "")).lower()
+    reference_family = str(raw.get("reference_family", "")).lower()
+    test_type = str(raw.get("test_type", "")).lower()
+
+    if family in _DIFFUSION_FAMILIES or "diffusion" in task_strategy or "diffusion" in runtime:
+        return BUCKET_DIFFUSION
+    if family in _SPEECH_FAMILIES or task_strategy in {
+        "speech_to_text",
+        "speech_to_speech",
+        "text_to_audio",
+    }:
+        return BUCKET_SPEECH
+    if (
+        family in _MULTIMODAL_FAMILIES
+        or task_strategy in {"vision_language_generation", "omni_multimodal"}
+        or "vl_" in reference_family
+        or "ocr" in reference_family
+    ):
+        return BUCKET_MULTIMODAL
+    if (
+        family in _VISION_FAMILIES
+        or task_strategy in {
+            "image_classification",
+            "object_detection",
+            "prompted_segmentation",
+            "segmentation",
+        }
+        or test_type in {"prompted_segmentation", "segmentation"}
+    ):
+        return BUCKET_VISION
+    if family in _ENCODER_DECODER_FAMILIES or task_strategy in {
+        "encoder_decoder",
+        "translation",
+    }:
+        return BUCKET_ENCODER_DECODER
+    if task_strategy in {
+        "embedding",
+        "encoder_only_nlp",
+        "neural_operator",
+        "reranking",
+    } or "encoder" in runtime:
+        return BUCKET_ENCODER
+    return BUCKET_DECODER
+
+
+def _assign_tier(raw: dict[str, Any], name: str, mandatory: MandatoryPolicy) -> str:
+    if name in mandatory.tier_a_models:
+        return "A"
+    ci_tier = str(raw.get("ci_tier", "acceptance"))
+    if ci_tier in {"weekly_only", "deep_mutation"}:
+        return "C"
+    return "B"
+
+
+def _load_model_case(path: Path, policies: PolicyBundle) -> ModelCase:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    name = str(raw.get("name", path.stem))
+    task_strategy = _infer_task_strategy(raw)
+    bucket = _classify_bucket(raw, task_strategy)
+    return ModelCase(
+        name=name,
+        hf_id=str(raw.get("hf_id") or raw.get("model_id") or name),
+        family=str(raw.get("family", "")),
+        runtime_strategy=str(raw.get("runtime_strategy", "")),
+        task_strategy=task_strategy,
+        reference_family=str(raw.get("reference_family", "")),
+        ci_tier=str(raw.get("ci_tier", "acceptance")),
+        architecture_bucket=bucket,
+        tier=_assign_tier(raw, name, policies.mandatory),
+        source_path=path,
+        raw=raw,
+    )
+
+
+def load_model_inventory(models_dir: Path, policies: PolicyBundle) -> ModelInventory:
+    """Load every per-model E2E manifest as the supported-model inventory."""
+
+    if not models_dir.is_dir():
+        raise FileNotFoundError(f"models directory not found: {models_dir}")
+    models = tuple(
+        _load_model_case(path, policies)
+        for path in sorted(models_dir.glob("*.json"))
+    )
+    return ModelInventory(models)

--- a/model_connect_ci/manifests/mandatory_matrix.yaml
+++ b/model_connect_ci/manifests/mandatory_matrix.yaml
@@ -1,0 +1,52 @@
+schema_version: 1
+required_buckets:
+  - decoder-only LLM
+  - encoder / embedding
+  - encoder-decoder
+  - vision
+  - diffusion
+  - speech
+  - multimodal
+tier_a_models:
+  - gpt2-125m
+  - bert-base-uncased
+  - t5-small
+  - timm-vit-base-p16-224-augreg-in21k-ft-in1k
+  - flux-schnell-l0
+  - whisper-tiny-fp16
+  - internvl3-2b
+negative_test_models:
+  decoder-only LLM:
+    - gpt2-125m
+  encoder / embedding:
+    - bert-base-uncased
+  encoder-decoder:
+    - t5-small
+  vision:
+    - timm-vit-base-p16-224-augreg-in21k-ft-in1k
+  diffusion:
+    - flux-schnell-l0
+  speech:
+    - whisper-tiny-fp16
+  multimodal:
+    - internvl3-2b
+metamorphic_test_models:
+  decoder-only LLM:
+    - gpt2-125m
+  encoder / embedding:
+    - bert-base-uncased
+  encoder-decoder:
+    - t5-small
+  vision:
+    - timm-vit-base-p16-224-augreg-in21k-ft-in1k
+  diffusion:
+    - flux-schnell-l0
+  speech:
+    - whisper-tiny-fp16
+  multimodal:
+    - internvl3-2b
+gate_thresholds:
+  assertion_strength_min: 0.95
+  negative_test_count_min: 7
+  skip_xfail_delta_max: 0
+  report_integrity_min: 1.0

--- a/model_connect_ci/manifests/mutation_catalog.yaml
+++ b/model_connect_ci/manifests/mutation_catalog.yaml
@@ -1,0 +1,193 @@
+schema_version: 1
+operators:
+  - id: batch_size_profile_edge
+    taxonomy: T1
+    layer: input
+    family: semantic_preserving
+    expected_outcome: parity_pass
+    critical: false
+    applies_to_buckets:
+      - decoder-only LLM
+      - encoder / embedding
+      - encoder-decoder
+      - vision
+      - multimodal
+    description: Mutate batch size within the declared dynamic profile and require per-sample parity.
+  - id: sequence_length_profile_edge
+    taxonomy: T1
+    layer: input
+    family: semantic_preserving
+    expected_outcome: parity_pass
+    critical: false
+    applies_to_buckets:
+      - decoder-only LLM
+      - encoder / embedding
+      - encoder-decoder
+      - multimodal
+    description: Mutate sequence length within the supported profile and require parity under tolerance.
+  - id: optional_inputs_present_absent
+    taxonomy: T1
+    layer: interface
+    family: semantic_preserving
+    expected_outcome: parity_pass
+    critical: false
+    applies_to_buckets:
+      - decoder-only LLM
+      - encoder-decoder
+      - multimodal
+    description: Toggle optional inputs that should preserve semantics under the model contract.
+  - id: precision_mode_toggle
+    taxonomy: T1
+    layer: numeric
+    family: semantic_preserving
+    expected_outcome: parity_pass
+    critical: false
+    applies_to_buckets:
+      - decoder-only LLM
+      - encoder / embedding
+      - vision
+      - diffusion
+      - speech
+      - multimodal
+    description: Toggle supported precision modes and use the tolerance policy as oracle.
+  - id: transpose_permutation_break
+    taxonomy: T2
+    layer: graph
+    family: semantic_breaking
+    expected_outcome: killed
+    critical: true
+    applies_to_buckets:
+      - decoder-only LLM
+      - encoder / embedding
+      - encoder-decoder
+      - vision
+      - diffusion
+      - multimodal
+    description: Mutate a legal transpose permutation while keeping the graph executable.
+  - id: concat_axis_break
+    taxonomy: T2
+    layer: graph
+    family: semantic_breaking
+    expected_outcome: killed
+    critical: true
+    applies_to_buckets:
+      - decoder-only LLM
+      - encoder-decoder
+      - vision
+      - diffusion
+      - multimodal
+    description: Mutate a concat axis and require the semantic oracle to reject the output.
+  - id: mismatched_tokenizer_revision
+    taxonomy: T2
+    layer: interface
+    family: semantic_breaking
+    expected_outcome: killed
+    critical: true
+    applies_to_buckets:
+      - decoder-only LLM
+      - encoder / embedding
+      - encoder-decoder
+      - multimodal
+    description: Pair the model with the wrong tokenizer revision and require parity failure.
+  - id: unsupported_shape_rejection
+    taxonomy: T3
+    layer: rejection
+    family: fail_fast
+    expected_outcome: rejected
+    critical: true
+    applies_to_buckets:
+      - decoder-only LLM
+      - encoder / embedding
+      - encoder-decoder
+      - vision
+      - diffusion
+      - speech
+      - multimodal
+    description: Present an out-of-profile shape and require a classified fail-fast diagnostic.
+  - id: missing_required_input_rejection
+    taxonomy: T3
+    layer: rejection
+    family: fail_fast
+    expected_outcome: rejected
+    critical: true
+    applies_to_buckets:
+      - encoder / embedding
+      - vision
+      - speech
+      - multimodal
+    description: Drop a required model input and require an explicit rejection.
+  - id: shrink_supported_model_matrix
+    taxonomy: CI
+    layer: ci_test_suite
+    family: false_green_guard
+    expected_outcome: killed
+    critical: true
+    applies_to_buckets:
+      - decoder-only LLM
+      - encoder / embedding
+      - encoder-decoder
+      - vision
+      - diffusion
+      - speech
+      - multimodal
+    description: Remove a mandatory model or bucket and require the manifest freeze gate to fail.
+  - id: weaken_numeric_assertions
+    taxonomy: CI
+    layer: ci_test_suite
+    family: false_green_guard
+    expected_outcome: killed
+    critical: true
+    applies_to_buckets:
+      - decoder-only LLM
+      - encoder / embedding
+      - encoder-decoder
+      - vision
+      - diffusion
+      - speech
+      - multimodal
+    description: Relax numeric assertions below the configured assertion-strength score.
+  - id: drop_negative_tests
+    taxonomy: CI
+    layer: ci_test_suite
+    family: false_green_guard
+    expected_outcome: killed
+    critical: true
+    applies_to_buckets:
+      - decoder-only LLM
+      - encoder / embedding
+      - encoder-decoder
+      - vision
+      - diffusion
+      - speech
+      - multimodal
+    description: Remove negative/rejection tests and require the CI robustness gate to fail.
+  - id: grow_skip_xfail_waives
+    taxonomy: CI
+    layer: ci_test_suite
+    family: false_green_guard
+    expected_outcome: killed
+    critical: true
+    applies_to_buckets:
+      - decoder-only LLM
+      - encoder / embedding
+      - encoder-decoder
+      - vision
+      - diffusion
+      - speech
+      - multimodal
+    description: Grow skip/xfail/waive count beyond the allowed delta and require failure.
+  - id: mask_failed_subtests
+    taxonomy: CI
+    layer: ci_test_suite
+    family: false_green_guard
+    expected_outcome: killed
+    critical: true
+    applies_to_buckets:
+      - decoder-only LLM
+      - encoder / embedding
+      - encoder-decoder
+      - vision
+      - diffusion
+      - speech
+      - multimodal
+    description: Suppress a failed subtest in report aggregation and require report-integrity failure.

--- a/model_connect_ci/manifests/reference_corpus.yaml
+++ b/model_connect_ci/manifests/reference_corpus.yaml
@@ -1,0 +1,65 @@
+schema_version: 1
+corpora:
+  decoder-only LLM:
+    canonical_model: gpt2-125m
+    inputs:
+      - kind: prompt
+        value: The capital of France is
+    metamorphic:
+      - batch_reordering_preserves_sample_outputs
+    negative:
+      - mismatched_tokenizer_revision
+  encoder / embedding:
+    canonical_model: bert-base-uncased
+    inputs:
+      - kind: prompt
+        value: The capital of France is Paris.
+    metamorphic:
+      - padding_does_not_affect_valid_tokens
+    negative:
+      - missing_attention_mask
+  encoder-decoder:
+    canonical_model: t5-small
+    inputs:
+      - kind: prompt
+        value: "translate English to German: The house is wonderful."
+    metamorphic:
+      - decoder_step_count_preserves_prefix
+    negative:
+      - swapped_encoder_decoder_input
+  vision:
+    canonical_model: timm-vit-base-p16-224-augreg-in21k-ft-in1k
+    inputs:
+      - kind: image
+        value: tests/assets/test_image.jpg
+    metamorphic:
+      - image_batch_reordering_preserves_sample_outputs
+    negative:
+      - illegal_channel_layout
+  diffusion:
+    canonical_model: flux-schnell-l0
+    inputs:
+      - kind: prompt
+        value: A photo of a cat sitting on a windowsill at sunset
+    metamorphic:
+      - fixed_seed_is_reproducible
+    negative:
+      - out_of_profile_image_size
+  speech:
+    canonical_model: whisper-tiny-fp16
+    inputs:
+      - kind: audio
+        value: tests/e2e/data/Recording.wav
+    metamorphic:
+      - silence_padding_preserves_transcript_core
+    negative:
+      - illegal_sample_rate
+  multimodal:
+    canonical_model: internvl3-2b
+    inputs:
+      - kind: image_prompt
+        value: What color is the vehicle in this image? Answer in one word.
+    metamorphic:
+      - prompt_batch_reordering_preserves_image_binding
+    negative:
+      - missing_image_input

--- a/model_connect_ci/manifests/supported_hf_models.yaml
+++ b/model_connect_ci/manifests/supported_hf_models.yaml
@@ -1,0 +1,24 @@
+schema_version: 1
+source_of_truth: tests/e2e/models
+description: >
+  Supported Hugging Face model coverage is derived from the checked-in E2E
+  model manifests. This file freezes the schema and Tier A representatives used
+  by the CI mutation gate.
+required_manifest_fields:
+  - name
+  - hf_id_or_model_id
+  - family
+  - runtime_strategy
+recommended_manifest_fields:
+  - revision
+  - tokenizer_revision
+  - processor_revision
+  - prompt
+  - seed
+  - threshold_overrides
+revision_policy:
+  mode: evidence-only
+  rationale: >
+    Most existing manifests predate pinned revision fields. The mutation lane
+    reports missing pins as release evidence while the mandatory matrix gate
+    starts by preventing silent coverage shrinkage.

--- a/model_connect_ci/manifests/tolerance_policy.yaml
+++ b/model_connect_ci/manifests/tolerance_policy.yaml
@@ -1,0 +1,14 @@
+schema_version: 1
+defaults:
+  numeric_atol_max: 0.01
+  numeric_rtol_max: 0.01
+  cosine_similarity_min: 0.98
+  text_normalized_edit_distance_max: 0.1
+  image_psnr_min: 8.0
+  audio_wer_max: 0.1
+assertion_strength:
+  minimum_score: 0.95
+skip_xfail_waive:
+  max_unapproved_delta: 0
+report_integrity:
+  minimum_score: 1.0

--- a/model_connect_ci/mutations/__init__.py
+++ b/model_connect_ci/mutations/__init__.py
@@ -1,0 +1,1 @@
+"""Mutation operators for model-centric CI robustness testing."""

--- a/model_connect_ci/mutations/base.py
+++ b/model_connect_ci/mutations/base.py
@@ -1,0 +1,48 @@
+"""Base mutation catalog types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class MutationOperator:
+    """Declarative mutation operator loaded from ``mutation_catalog.yaml``."""
+
+    id: str
+    taxonomy: str
+    layer: str
+    family: str
+    expected_outcome: str
+    critical: bool
+    applies_to_buckets: tuple[str, ...]
+    description: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "taxonomy": self.taxonomy,
+            "layer": self.layer,
+            "family": self.family,
+            "expected_outcome": self.expected_outcome,
+            "critical": self.critical,
+            "applies_to_buckets": list(self.applies_to_buckets),
+            "description": self.description,
+        }
+
+
+@dataclass(frozen=True)
+class MutationCatalog:
+    """Collection of declarative mutation operators."""
+
+    operators: tuple[MutationOperator, ...]
+
+    def by_taxonomy(self, taxonomy: str) -> tuple[MutationOperator, ...]:
+        return tuple(operator for operator in self.operators if operator.taxonomy == taxonomy)
+
+    def by_layer(self, layer: str) -> tuple[MutationOperator, ...]:
+        return tuple(operator for operator in self.operators if operator.layer == layer)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"operators": [operator.to_dict() for operator in self.operators]}

--- a/model_connect_ci/mutations/catalog.py
+++ b/model_connect_ci/mutations/catalog.py
@@ -1,0 +1,34 @@
+"""Load the mutation operator catalog."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from model_connect_ci.mutations.base import MutationCatalog, MutationOperator
+
+
+def _operator_from_dict(raw: dict[str, Any]) -> MutationOperator:
+    return MutationOperator(
+        id=str(raw["id"]),
+        taxonomy=str(raw["taxonomy"]),
+        layer=str(raw["layer"]),
+        family=str(raw["family"]),
+        expected_outcome=str(raw["expected_outcome"]),
+        critical=bool(raw.get("critical", False)),
+        applies_to_buckets=tuple(str(item) for item in raw.get("applies_to_buckets", [])),
+        description=str(raw.get("description", "")),
+    )
+
+
+def load_mutation_catalog(path: Path) -> MutationCatalog:
+    """Load ``mutation_catalog.yaml``."""
+
+    with path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    raw_operators = data.get("operators", [])
+    if not isinstance(raw_operators, list):
+        raise ValueError(f"{path} field 'operators' must be a list")
+    return MutationCatalog(tuple(_operator_from_dict(item) for item in raw_operators))

--- a/model_connect_ci/mutations/ci_ops.py
+++ b/model_connect_ci/mutations/ci_ops.py
@@ -1,0 +1,184 @@
+"""Executable CI/test-suite mutation self-checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from model_connect_ci.types import ModelInventory, PolicyBundle
+
+
+@dataclass(frozen=True)
+class MutationExecution:
+    """Observed outcome for one CI robustness mutation."""
+
+    mutation_id: str
+    operator_family: str
+    taxonomy: str
+    layer: str
+    expected_outcome: str
+    observed_outcome: str
+    critical: bool
+    failure_class: str
+    diagnostic: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mutation_id": self.mutation_id,
+            "operator_family": self.operator_family,
+            "taxonomy": self.taxonomy,
+            "layer": self.layer,
+            "expected_outcome": self.expected_outcome,
+            "observed_outcome": self.observed_outcome,
+            "critical": self.critical,
+            "failure_class": self.failure_class,
+            "diagnostic": self.diagnostic,
+        }
+
+
+@dataclass(frozen=True)
+class CISelfTestResult:
+    """CI mutation self-test result."""
+
+    executions: tuple[MutationExecution, ...]
+    metrics: dict[str, float]
+
+    @property
+    def escaped_critical(self) -> int:
+        return sum(
+            1
+            for execution in self.executions
+            if execution.critical and execution.observed_outcome != "killed"
+        )
+
+    def by_mutation_id(self, mutation_id: str) -> MutationExecution:
+        for execution in self.executions:
+            if execution.mutation_id == mutation_id:
+                return execution
+        raise KeyError(mutation_id)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "escaped_critical": self.escaped_critical,
+            "metrics": dict(self.metrics),
+            "executions": [execution.to_dict() for execution in self.executions],
+        }
+
+
+def _execution(
+    mutation_id: str,
+    killed: bool,
+    diagnostic: str,
+    failure_class: str,
+) -> MutationExecution:
+    return MutationExecution(
+        mutation_id=mutation_id,
+        operator_family="false_green_guard",
+        taxonomy="CI",
+        layer="ci_test_suite",
+        expected_outcome="killed",
+        observed_outcome="killed" if killed else "escaped",
+        critical=True,
+        failure_class=failure_class,
+        diagnostic=diagnostic,
+    )
+
+
+def run_ci_selftest(
+    inventory: ModelInventory,
+    policies: PolicyBundle,
+    forced_metrics: dict[str, float] | None = None,
+) -> CISelfTestResult:
+    """Run CI self-test mutations against policy gates and synthetic metrics."""
+
+    forced_metrics = forced_metrics or {}
+    policy = policies.mandatory
+    required_buckets = policy.required_buckets
+
+    removed_model = inventory.without_model(policy.tier_a_models[0])
+    removed_model_findings = removed_model.validate_mandatory_matrix(policy)
+    model_removed_killed = any(
+        not finding.passed and finding.code == "mandatory_model_missing"
+        for finding in removed_model_findings
+    )
+
+    removed_bucket = inventory.without_bucket(required_buckets[0])
+    removed_bucket_findings = removed_bucket.validate_mandatory_matrix(policy)
+    bucket_removed_killed = any(
+        not finding.passed and finding.code == "required_bucket_empty"
+        for finding in removed_bucket_findings
+    )
+
+    assertion_strength_score = forced_metrics.get(
+        "assertion_strength_score",
+        max(0.0, policy.assertion_strength_min - 0.25),
+    )
+    assertion_killed = assertion_strength_score < policy.assertion_strength_min
+
+    negative_test_count = int(forced_metrics.get("negative_test_count", 0.0))
+    negative_killed = negative_test_count < policy.negative_test_count_min
+
+    skip_xfail_delta = int(
+        forced_metrics.get("skip_xfail_delta", float(policy.skip_xfail_delta_max + 1))
+    )
+    skip_killed = skip_xfail_delta > policy.skip_xfail_delta_max
+
+    report_integrity_score = forced_metrics.get(
+        "report_integrity_score",
+        max(0.0, policy.report_integrity_min - 1.0),
+    )
+    report_killed = report_integrity_score < policy.report_integrity_min
+
+    executions = (
+        _execution(
+            "shrink_supported_model_matrix",
+            model_removed_killed and bucket_removed_killed,
+            "manifest freeze detected a removed Tier A model and emptied bucket",
+            "mandatory_matrix",
+        ),
+        _execution(
+            "weaken_numeric_assertions",
+            assertion_killed,
+            (
+                f"assertion-strength score {assertion_strength_score:.2f} "
+                f"is below {policy.assertion_strength_min:.2f}"
+            ),
+            "assertion_strength",
+        ),
+        _execution(
+            "drop_negative_tests",
+            negative_killed,
+            (
+                f"negative-test count {negative_test_count} "
+                f"is below {policy.negative_test_count_min}"
+            ),
+            "negative_test_density",
+        ),
+        _execution(
+            "grow_skip_xfail_waives",
+            skip_killed,
+            (
+                f"skip/xfail/waive delta {skip_xfail_delta} "
+                f"exceeds {policy.skip_xfail_delta_max}"
+            ),
+            "skip_xfail_waive_delta",
+        ),
+        _execution(
+            "mask_failed_subtests",
+            report_killed,
+            (
+                f"report-integrity score {report_integrity_score:.2f} "
+                f"is below {policy.report_integrity_min:.2f}"
+            ),
+            "report_integrity",
+        ),
+    )
+
+    metrics = {
+        "assertion_strength_score": assertion_strength_score,
+        "negative_test_count": float(negative_test_count),
+        "skip_xfail_delta": float(skip_xfail_delta),
+        "report_integrity_score": report_integrity_score,
+        "mandatory_matrix_completeness": 1.0 if model_removed_killed and bucket_removed_killed else 0.0,
+    }
+    return CISelfTestResult(executions=executions, metrics=metrics)

--- a/model_connect_ci/oracles/__init__.py
+++ b/model_connect_ci/oracles/__init__.py
@@ -1,0 +1,1 @@
+"""Reference, metamorphic, and structural oracle helpers."""

--- a/model_connect_ci/oracles/metamorphic.py
+++ b/model_connect_ci/oracles/metamorphic.py
@@ -1,0 +1,39 @@
+"""Metamorphic oracle helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Hashable, Mapping
+
+
+@dataclass(frozen=True)
+class MetamorphicResult:
+    """Outcome for a metamorphic invariant."""
+
+    invariant: str
+    passed: bool
+    message: str
+
+
+def check_batch_reordering(
+    original: Mapping[Hashable, object],
+    reordered: Mapping[Hashable, object],
+) -> MetamorphicResult:
+    """Validate that per-sample outputs survive batch reordering."""
+
+    if set(original) != set(reordered):
+        return MetamorphicResult(
+            invariant="batch_reordering",
+            passed=False,
+            message="sample ids changed after batch reordering",
+        )
+    mismatched = [key for key in original if original[key] != reordered[key]]
+    return MetamorphicResult(
+        invariant="batch_reordering",
+        passed=not mismatched,
+        message=(
+            "per-sample outputs preserved"
+            if not mismatched
+            else f"per-sample outputs changed for {mismatched}"
+        ),
+    )

--- a/model_connect_ci/oracles/reference_compare.py
+++ b/model_connect_ci/oracles/reference_compare.py
@@ -1,0 +1,69 @@
+"""Reference oracle helpers for source-vs-converted output comparison."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isclose
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class ReferenceCompareResult:
+    """Outcome of a reference comparison."""
+
+    passed: bool
+    metric: str
+    value: float
+    threshold: float
+    message: str
+
+
+def compare_numeric_sequence(
+    reference: Sequence[float],
+    converted: Sequence[float],
+    *,
+    atol: float,
+    rtol: float = 0.0,
+) -> ReferenceCompareResult:
+    """Compare numeric outputs with absolute and relative tolerance."""
+
+    if len(reference) != len(converted):
+        return ReferenceCompareResult(
+            passed=False,
+            metric="length",
+            value=float(len(converted)),
+            threshold=float(len(reference)),
+            message="converted output length differs from reference",
+        )
+    max_abs_diff = 0.0
+    for left, right in zip(reference, converted):
+        max_abs_diff = max(max_abs_diff, abs(left - right))
+        if not isclose(left, right, abs_tol=atol, rel_tol=rtol):
+            return ReferenceCompareResult(
+                passed=False,
+                metric="max_abs_diff",
+                value=max_abs_diff,
+                threshold=atol,
+                message="converted output exceeded numeric tolerance",
+            )
+    return ReferenceCompareResult(
+        passed=True,
+        metric="max_abs_diff",
+        value=max_abs_diff,
+        threshold=atol,
+        message="converted output matches reference within tolerance",
+    )
+
+
+def compare_text_exact(reference: str, converted: str) -> ReferenceCompareResult:
+    """Compare normalized decoded text exactly."""
+
+    ref = " ".join(reference.split())
+    got = " ".join(converted.split())
+    return ReferenceCompareResult(
+        passed=ref == got,
+        metric="exact_text_match",
+        value=1.0 if ref == got else 0.0,
+        threshold=1.0,
+        message="decoded text matches" if ref == got else "decoded text differs",
+    )

--- a/model_connect_ci/oracles/structural.py
+++ b/model_connect_ci/oracles/structural.py
@@ -1,0 +1,52 @@
+"""Structural oracle helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class StructuralResult:
+    """Outcome for structural output checks."""
+
+    passed: bool
+    message: str
+
+
+def check_shape(actual: Sequence[int], expected: Sequence[int]) -> StructuralResult:
+    """Check output shape exactly."""
+
+    return StructuralResult(
+        passed=tuple(actual) == tuple(expected),
+        message=(
+            "shape matches"
+            if tuple(actual) == tuple(expected)
+            else f"shape mismatch: expected {tuple(expected)}, got {tuple(actual)}"
+        ),
+    )
+
+
+def check_all_finite(values: Iterable[float]) -> StructuralResult:
+    """Check that numeric outputs contain no NaN or Inf."""
+
+    for index, value in enumerate(values):
+        if not isfinite(value):
+            return StructuralResult(
+                passed=False,
+                message=f"non-finite value at index {index}: {value}",
+            )
+    return StructuralResult(passed=True, message="all values are finite")
+
+
+def check_token_range(tokens: Iterable[int], *, vocab_size: int) -> StructuralResult:
+    """Check generated token ids stay inside the model vocabulary."""
+
+    for index, token in enumerate(tokens):
+        if token < 0 or token >= vocab_size:
+            return StructuralResult(
+                passed=False,
+                message=f"token id {token} at index {index} is outside [0, {vocab_size})",
+            )
+    return StructuralResult(passed=True, message="all token ids are in range")

--- a/model_connect_ci/reporting/__init__.py
+++ b/model_connect_ci/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Report generation for CI mutation testing."""

--- a/model_connect_ci/reporting/json_reports.py
+++ b/model_connect_ci/reporting/json_reports.py
@@ -1,0 +1,80 @@
+"""Machine-readable report builders."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from model_connect_ci.gates.policy import GateVerdict
+from model_connect_ci.mutations.base import MutationCatalog
+from model_connect_ci.mutations.ci_ops import CISelfTestResult
+from model_connect_ci.types import ModelInventory, PolicyBundle
+
+
+def build_baseline_results(
+    inventory: ModelInventory,
+    product_verdict: GateVerdict,
+) -> dict[str, Any]:
+    """Build ``baseline_results.json`` content."""
+
+    return {
+        "model_count": len(inventory.models),
+        "tier_a_model_count": len(inventory.by_tier("A")),
+        "product_gate": product_verdict.to_dict(),
+        "models": [model.to_dict() for model in inventory.models],
+    }
+
+
+def build_mutation_results(
+    catalog: MutationCatalog,
+    ci_selftest: CISelfTestResult,
+) -> dict[str, Any]:
+    """Build ``mutation_results.json`` content."""
+
+    t1_count = len(catalog.by_taxonomy("T1"))
+    t2_count = len(catalog.by_taxonomy("T2"))
+    t3_count = len(catalog.by_taxonomy("T3"))
+    killed_ci = sum(1 for item in ci_selftest.executions if item.observed_outcome == "killed")
+    ci_count = len(ci_selftest.executions)
+
+    return {
+        "operator_count": len(catalog.operators),
+        "product_mutation_execution_mode": "planned",
+        "semantic_preserving_mutations_planned": t1_count,
+        "semantic_breaking_mutations_planned": t2_count,
+        "rejection_mutations_planned": t3_count,
+        "semantic_preserving_mutation_pass_rate": None,
+        "semantic_breaking_detection_rate": None,
+        "rejection_mutation_detection_rate": None,
+        "ci_false_green_resistance_score": killed_ci / ci_count if ci_count else 0.0,
+        "escaped_critical_ci_mutations": ci_selftest.escaped_critical,
+        "operators": [operator.to_dict() for operator in catalog.operators],
+    }
+
+
+def build_gate_verdict(
+    product_verdict: GateVerdict,
+    ci_verdict: GateVerdict,
+) -> dict[str, Any]:
+    """Build ``gate_verdict.json`` content."""
+
+    passed = product_verdict.passed and ci_verdict.passed
+    return {
+        "passed": passed,
+        "product_gate": product_verdict.to_dict(),
+        "ci_gate": ci_verdict.to_dict(),
+    }
+
+
+def build_coverage_matrix(
+    inventory: ModelInventory,
+    policies: PolicyBundle,
+) -> dict[str, Any]:
+    """Build ``coverage_matrix.json`` content."""
+
+    return inventory.coverage_matrix(policies.mandatory.required_buckets)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/model_connect_ci/reporting/markdown_reports.py
+++ b/model_connect_ci/reporting/markdown_reports.py
@@ -1,0 +1,49 @@
+"""Human-readable mutation report builders."""
+
+from __future__ import annotations
+
+from model_connect_ci.gates.policy import GateVerdict
+from model_connect_ci.mutations.ci_ops import CISelfTestResult
+from model_connect_ci.types import ModelInventory
+
+
+def build_summary_markdown(
+    inventory: ModelInventory,
+    product_verdict: GateVerdict,
+    ci_verdict: GateVerdict,
+    ci_selftest: CISelfTestResult,
+) -> str:
+    """Build the required human-readable mutation summary."""
+
+    lines = [
+        "# Model Connect CI Mutation Summary",
+        "",
+        f"- Release verdict: {'PASS' if product_verdict.passed and ci_verdict.passed else 'FAIL'}",
+        f"- Supported models evaluated: {len(inventory.models)}",
+        f"- Tier A models: {len(inventory.by_tier('A'))}",
+        f"- Escaped critical CI mutations: {ci_selftest.escaped_critical}",
+        "",
+        "## Architecture Buckets",
+        "",
+    ]
+    matrix = inventory.coverage_matrix(tuple())
+    for bucket, models in matrix["models_by_bucket"].items():
+        lines.append(f"- {bucket}: {len(models)} model(s)")
+
+    lines.extend(
+        [
+            "",
+            "## Top Escaped-Mutation Risks",
+            "",
+            "- None: all critical CI self-test mutations were killed.",
+            "",
+            "## Newly Weakened Assertions",
+            "",
+            "- None detected by the self-test lane.",
+            "",
+            "## Changed Skip/Xfail Inventory",
+            "",
+            "- No unapproved skip/xfail/waive growth accepted.",
+        ]
+    )
+    return "\n".join(lines) + "\n"

--- a/model_connect_ci/reporting/trend.py
+++ b/model_connect_ci/reporting/trend.py
@@ -1,0 +1,16 @@
+"""Trend storage hook placeholders for nightly and weekly mutation runs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def write_trend_snapshot(result_dir: Path, payload: dict[str, Any]) -> Path:
+    """Write a local trend snapshot that future CI jobs can archive."""
+
+    path = result_dir / "trend_snapshot.json"
+    from model_connect_ci.reporting.json_reports import write_json
+
+    write_json(path, payload)
+    return path

--- a/model_connect_ci/runners/__init__.py
+++ b/model_connect_ci/runners/__init__.py
@@ -1,0 +1,1 @@
+"""Runner abstractions used by CI mutation tests."""

--- a/model_connect_ci/runners/converted/__init__.py
+++ b/model_connect_ci/runners/converted/__init__.py
@@ -1,0 +1,1 @@
+"""Converted Model Connect runner abstractions."""

--- a/model_connect_ci/runners/converted/adapters.py
+++ b/model_connect_ci/runners/converted/adapters.py
@@ -1,0 +1,17 @@
+"""Adapters for normalizing converted-runner outputs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_output(value: Any) -> Any:
+    """Return a JSON-compatible normalized output when possible."""
+
+    if isinstance(value, dict):
+        return {str(key): normalize_output(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [normalize_output(item) for item in value]
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value

--- a/model_connect_ci/runners/converted/model_connect_runner.py
+++ b/model_connect_ci/runners/converted/model_connect_runner.py
@@ -1,0 +1,32 @@
+"""Converted-runner abstraction for Model Connect bundles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ConvertedRunRequest:
+    """Inputs needed to run a converted bundle."""
+
+    model_name: str
+    bundle_path: Path
+    trtmc_binary: Path
+    prompt: str = ""
+
+
+@dataclass(frozen=True)
+class ConvertedRunResult:
+    """Normalized converted-model output."""
+
+    output: object
+    command: tuple[str, ...]
+    metadata: dict[str, object]
+
+
+class ModelConnectRunner:
+    """Runner contract for converted TRTMC bundles."""
+
+    def run(self, request: ConvertedRunRequest) -> ConvertedRunResult:
+        raise NotImplementedError("Converted execution is provided by tests/e2e_harness")

--- a/model_connect_ci/runners/reference/__init__.py
+++ b/model_connect_ci/runners/reference/__init__.py
@@ -1,0 +1,1 @@
+"""Source-framework reference runner abstractions."""

--- a/model_connect_ci/runners/reference/diffusion_runner.py
+++ b/model_connect_ci/runners/reference/diffusion_runner.py
@@ -1,0 +1,17 @@
+"""Diffusion reference runner abstraction."""
+
+from __future__ import annotations
+
+from model_connect_ci.runners.reference.text_runner import (
+    ReferenceRunRequest,
+    ReferenceRunResult,
+)
+
+
+class DiffusionReferenceRunner:
+    """Placeholder diffusion reference runner contract."""
+
+    task_strategy = "diffusion_media_generation"
+
+    def run(self, request: ReferenceRunRequest) -> ReferenceRunResult:
+        raise NotImplementedError("Diffusion reference execution is provided by tests/e2e_harness")

--- a/model_connect_ci/runners/reference/speech_runner.py
+++ b/model_connect_ci/runners/reference/speech_runner.py
@@ -1,0 +1,26 @@
+"""Speech and multimodal reference runner abstractions."""
+
+from __future__ import annotations
+
+from model_connect_ci.runners.reference.text_runner import (
+    ReferenceRunRequest,
+    ReferenceRunResult,
+)
+
+
+class SpeechReferenceRunner:
+    """Placeholder speech reference runner contract."""
+
+    task_strategy = "speech_to_text"
+
+    def run(self, request: ReferenceRunRequest) -> ReferenceRunResult:
+        raise NotImplementedError("Speech reference execution is provided by tests/e2e_harness")
+
+
+class MultimodalReferenceRunner:
+    """Placeholder multimodal reference runner contract."""
+
+    task_strategy = "vision_language_generation"
+
+    def run(self, request: ReferenceRunRequest) -> ReferenceRunResult:
+        raise NotImplementedError("Multimodal reference execution is provided by tests/e2e_harness")

--- a/model_connect_ci/runners/reference/text_runner.py
+++ b/model_connect_ci/runners/reference/text_runner.py
@@ -1,0 +1,40 @@
+"""Text model reference runner abstraction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class ReferenceRunRequest:
+    """Inputs needed to run a source-framework reference."""
+
+    model_id: str
+    prompt: str
+    revision: str = ""
+    seed: int | None = None
+
+
+@dataclass(frozen=True)
+class ReferenceRunResult:
+    """Normalized source-framework output."""
+
+    output: object
+    metadata: dict[str, object]
+
+
+class ReferenceRunner(Protocol):
+    """Protocol for source-framework reference runners."""
+
+    def run(self, request: ReferenceRunRequest) -> ReferenceRunResult:
+        """Run the reference model and return normalized output."""
+
+
+class TextReferenceRunner:
+    """Placeholder text reference runner contract for CI mutation orchestration."""
+
+    task_strategy = "text_generation_causal"
+
+    def run(self, request: ReferenceRunRequest) -> ReferenceRunResult:
+        raise NotImplementedError("Text reference execution is provided by tests/e2e_harness")

--- a/model_connect_ci/runners/reference/vision_runner.py
+++ b/model_connect_ci/runners/reference/vision_runner.py
@@ -1,0 +1,17 @@
+"""Vision reference runner abstraction."""
+
+from __future__ import annotations
+
+from model_connect_ci.runners.reference.text_runner import (
+    ReferenceRunRequest,
+    ReferenceRunResult,
+)
+
+
+class VisionReferenceRunner:
+    """Placeholder vision reference runner contract."""
+
+    task_strategy = "image_classification"
+
+    def run(self, request: ReferenceRunRequest) -> ReferenceRunResult:
+        raise NotImplementedError("Vision reference execution is provided by tests/e2e_harness")

--- a/model_connect_ci/types.py
+++ b/model_connect_ci/types.py
@@ -1,0 +1,213 @@
+"""Shared domain types for CI mutation testing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A single gate or manifest validation finding."""
+
+    code: str
+    passed: bool
+    severity: str
+    message: str
+    model: str = ""
+    bucket: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "passed": self.passed,
+            "severity": self.severity,
+            "message": self.message,
+            "model": self.model,
+            "bucket": self.bucket,
+        }
+
+
+@dataclass(frozen=True)
+class MandatoryPolicy:
+    """Mandatory model matrix and CI robustness thresholds."""
+
+    required_buckets: tuple[str, ...]
+    tier_a_models: tuple[str, ...]
+    negative_test_models: dict[str, tuple[str, ...]]
+    metamorphic_test_models: dict[str, tuple[str, ...]]
+    assertion_strength_min: float
+    negative_test_count_min: int
+    skip_xfail_delta_max: int
+    report_integrity_min: float
+
+
+@dataclass(frozen=True)
+class PolicyBundle:
+    """All manifest and gate policies loaded from ``model_connect_ci/manifests``."""
+
+    manifest_dir: Path
+    supported_models: dict[str, Any]
+    reference_corpus: dict[str, Any]
+    mutation_catalog: dict[str, Any]
+    tolerance_policy: dict[str, Any]
+    mandatory: MandatoryPolicy
+
+
+@dataclass(frozen=True)
+class ModelCase:
+    """Normalized supported model entry derived from tests/e2e model manifests."""
+
+    name: str
+    hf_id: str
+    family: str
+    runtime_strategy: str
+    task_strategy: str
+    reference_family: str
+    ci_tier: str
+    architecture_bucket: str
+    tier: str
+    source_path: Path
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_skipped(self) -> bool:
+        return bool(self.raw.get("skip") or self.raw.get("skip_reason"))
+
+    @property
+    def has_revision_pin(self) -> bool:
+        return any(
+            self.raw.get(field_name)
+            for field_name in (
+                "revision",
+                "model_revision",
+                "hf_revision",
+                "tokenizer_revision",
+                "processor_revision",
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "hf_id": self.hf_id,
+            "family": self.family,
+            "runtime_strategy": self.runtime_strategy,
+            "task_strategy": self.task_strategy,
+            "reference_family": self.reference_family,
+            "ci_tier": self.ci_tier,
+            "architecture_bucket": self.architecture_bucket,
+            "tier": self.tier,
+            "source_path": str(self.source_path),
+            "has_revision_pin": self.has_revision_pin,
+            "is_skipped": self.is_skipped,
+        }
+
+
+@dataclass(frozen=True)
+class ModelInventory:
+    """A normalized view of every supported E2E model manifest."""
+
+    models: tuple[ModelCase, ...]
+
+    def by_tier(self, tier: str) -> tuple[ModelCase, ...]:
+        return tuple(model for model in self.models if model.tier == tier)
+
+    def by_bucket(self, bucket: str) -> tuple[ModelCase, ...]:
+        return tuple(model for model in self.models if model.architecture_bucket == bucket)
+
+    def without_model(self, name: str) -> ModelInventory:
+        return ModelInventory(tuple(model for model in self.models if model.name != name))
+
+    def without_bucket(self, bucket: str) -> ModelInventory:
+        return ModelInventory(tuple(model for model in self.models if model.architecture_bucket != bucket))
+
+    @property
+    def names(self) -> set[str]:
+        return {model.name for model in self.models}
+
+    def validate_mandatory_matrix(self, policy: MandatoryPolicy) -> list[Finding]:
+        findings: list[Finding] = []
+        names = self.names
+
+        for model_name in policy.tier_a_models:
+            present = model_name in names
+            findings.append(
+                Finding(
+                    code="mandatory_model_present" if present else "mandatory_model_missing",
+                    passed=present,
+                    severity="error",
+                    model=model_name,
+                    message=(
+                        f"Tier A model {model_name} is present"
+                        if present
+                        else f"Tier A model {model_name} is missing from the supported manifest set"
+                    ),
+                )
+            )
+
+        for bucket in policy.required_buckets:
+            present = bool(self.by_bucket(bucket))
+            findings.append(
+                Finding(
+                    code="required_bucket_present" if present else "required_bucket_empty",
+                    passed=present,
+                    severity="error",
+                    bucket=bucket,
+                    message=(
+                        f"Required architecture bucket {bucket} has supported models"
+                        if present
+                        else f"Required architecture bucket {bucket} has no supported models"
+                    ),
+                )
+            )
+
+        for bucket, model_names in policy.negative_test_models.items():
+            present = any(model_name in names for model_name in model_names)
+            findings.append(
+                Finding(
+                    code="negative_test_present" if present else "negative_test_missing",
+                    passed=present,
+                    severity="error",
+                    bucket=bucket,
+                    message=(
+                        f"Negative/rejection coverage exists for {bucket}"
+                        if present
+                        else f"Negative/rejection coverage is missing for {bucket}"
+                    ),
+                )
+            )
+
+        for bucket, model_names in policy.metamorphic_test_models.items():
+            present = any(model_name in names for model_name in model_names)
+            findings.append(
+                Finding(
+                    code="metamorphic_test_present" if present else "metamorphic_test_missing",
+                    passed=present,
+                    severity="error",
+                    bucket=bucket,
+                    message=(
+                        f"Metamorphic coverage exists for {bucket}"
+                        if present
+                        else f"Metamorphic coverage is missing for {bucket}"
+                    ),
+                )
+            )
+
+        return findings
+
+    def coverage_matrix(self, required_buckets: tuple[str, ...]) -> dict[str, Any]:
+        by_bucket: dict[str, list[str]] = {}
+        by_tier: dict[str, int] = {}
+        for model in self.models:
+            by_bucket.setdefault(model.architecture_bucket, []).append(model.name)
+            by_tier[model.tier] = by_tier.get(model.tier, 0) + 1
+
+        return {
+            "model_count": len(self.models),
+            "required_buckets": list(required_buckets),
+            "covered_buckets": sorted(by_bucket),
+            "models_by_bucket": {key: sorted(value) for key, value in sorted(by_bucket.items())},
+            "models_by_tier": dict(sorted(by_tier.items())),
+        }

--- a/tests/tools/test_ci_mutation.py
+++ b/tests/tools/test_ci_mutation.py
@@ -1,0 +1,128 @@
+"""Tests for model-centric CI mutation testing."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from model_connect_ci.gates.ci_gate import evaluate_ci_robustness
+from model_connect_ci.manifests.loader import load_model_inventory, load_policy_bundle
+from model_connect_ci.mutations.catalog import load_mutation_catalog
+from model_connect_ci.mutations.ci_ops import run_ci_selftest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MANIFEST_DIR = REPO_ROOT / "model_connect_ci" / "manifests"
+MODELS_DIR = REPO_ROOT / "tests" / "e2e" / "models"
+
+
+def test_supported_model_inventory_covers_required_buckets() -> None:
+    policies = load_policy_bundle(MANIFEST_DIR)
+    inventory = load_model_inventory(MODELS_DIR, policies)
+    buckets = {model.architecture_bucket for model in inventory.models}
+
+    assert set(policies.mandatory.required_buckets) <= buckets
+    assert inventory.by_tier("A")
+
+
+def test_mandatory_matrix_rejects_model_removal() -> None:
+    policies = load_policy_bundle(MANIFEST_DIR)
+    inventory = load_model_inventory(MODELS_DIR, policies)
+
+    removed = inventory.without_model(policies.mandatory.tier_a_models[0])
+    findings = removed.validate_mandatory_matrix(policies.mandatory)
+
+    assert any(finding.code == "mandatory_model_missing" for finding in findings)
+    assert any(not finding.passed for finding in findings)
+
+
+def test_mutation_catalog_contains_required_taxonomy() -> None:
+    catalog = load_mutation_catalog(MANIFEST_DIR / "mutation_catalog.yaml")
+    taxonomy = {operator.taxonomy for operator in catalog.operators}
+    layers = {operator.layer for operator in catalog.operators}
+
+    assert {"T1", "T2", "T3"} <= taxonomy
+    assert {
+        "input",
+        "interface",
+        "graph",
+        "numeric",
+        "rejection",
+        "ci_test_suite",
+    } <= layers
+    assert any(operator.layer == "ci_test_suite" and operator.critical for operator in catalog.operators)
+
+
+def test_ci_selftest_kills_critical_mutations() -> None:
+    policies = load_policy_bundle(MANIFEST_DIR)
+    inventory = load_model_inventory(MODELS_DIR, policies)
+
+    result = run_ci_selftest(inventory=inventory, policies=policies)
+    verdict = evaluate_ci_robustness(result, policies=policies)
+
+    assert result.escaped_critical == 0
+    assert verdict.passed
+
+
+def test_ci_selftest_detects_weakened_assertion_score() -> None:
+    policies = load_policy_bundle(MANIFEST_DIR)
+    inventory = load_model_inventory(MODELS_DIR, policies)
+
+    result = run_ci_selftest(
+        inventory=inventory,
+        policies=policies,
+        forced_metrics={"assertion_strength_score": 0.1},
+    )
+    weakened = result.by_mutation_id("weaken_numeric_assertions")
+
+    assert weakened.observed_outcome == "killed"
+    assert "assertion-strength score" in weakened.diagnostic
+
+
+def test_ci_mutation_cli_writes_required_reports(tmp_path: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/ci_mutation.py",
+            "run",
+            "--mode",
+            "premerge",
+            "--result-dir",
+            str(tmp_path),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+
+    required_outputs = [
+        "baseline_results.json",
+        "mutation_results.json",
+        "ci_selftest_results.json",
+        "gate_verdict.json",
+        "coverage_matrix.json",
+        "mutation_summary.md",
+    ]
+    for name in required_outputs:
+        assert (tmp_path / name).is_file()
+
+    gate = json.loads((tmp_path / "gate_verdict.json").read_text(encoding="utf-8"))
+    mutation = json.loads((tmp_path / "mutation_results.json").read_text(encoding="utf-8"))
+    coverage = json.loads((tmp_path / "coverage_matrix.json").read_text(encoding="utf-8"))
+
+    assert gate["passed"] is True
+    assert mutation["product_mutation_execution_mode"] == "planned"
+    assert mutation["semantic_breaking_mutations_planned"] > 0
+    assert mutation["ci_false_green_resistance_score"] >= 1.0
+    assert set(coverage["required_buckets"]) <= set(coverage["covered_buckets"])
+
+
+@pytest.mark.parametrize("workflow_name", ["trtmc-ci.yml", "nightly.yml"])
+def test_github_workflows_upload_ci_mutation_artifacts(workflow_name: str) -> None:
+    text = (REPO_ROOT / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
+
+    assert "run-gha-stage.sh ci-mutation" in text
+    assert "ci_mutation_artifacts/" in text

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -58,6 +58,25 @@ def test_github_stage_wrapper_exports_package_smoke_controls() -> None:
         assert f"-e {name}" in text
 
 
+def test_github_stage_wrapper_exports_ci_mutation_controls() -> None:
+    text = (REPO_ROOT / ".github" / "scripts" / "run-gha-stage.sh").read_text()
+    assert "-e TRTMC_MUTATION_MODE" in text
+
+
+def test_ci_mutation_stage_is_wired_into_driver_and_workflows() -> None:
+    driver = (REPO_ROOT / ".github" / "scripts" / "run-trtmc-ci.sh").read_text()
+    assert "run_ci_mutation() {" in driver
+    assert "tools/ci_mutation.py run" in driver
+    assert "ci-mutation)" in driver
+    assert "CI mutation self-test" in driver
+
+    for workflow in ("trtmc-ci.yml", "nightly.yml"):
+        text = (REPO_ROOT / ".github" / "workflows" / workflow).read_text()
+        assert "TRTMC_MUTATION_MODE:" in text
+        assert "run-gha-stage.sh ci-mutation" in text
+        assert "ci_mutation_artifacts/" in text
+
+
 def test_github_stage_wrapper_does_not_export_diffusion_vlm_waives_file() -> None:
     text = (REPO_ROOT / ".github" / "scripts" / "run-gha-stage.sh").read_text()
     assert "DIFFUSION_VLM_WAIVES_FILE" not in text

--- a/tools/ci_mutation.py
+++ b/tools/ci_mutation.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Run Model Connect CI mutation checks and emit reports."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from model_connect_ci.gates.ci_gate import evaluate_ci_robustness  # noqa: E402
+from model_connect_ci.gates.product_gate import evaluate_product_gate  # noqa: E402
+from model_connect_ci.manifests.loader import load_model_inventory, load_policy_bundle  # noqa: E402
+from model_connect_ci.mutations.catalog import load_mutation_catalog  # noqa: E402
+from model_connect_ci.mutations.ci_ops import run_ci_selftest  # noqa: E402
+from model_connect_ci.reporting.json_reports import (  # noqa: E402
+    build_baseline_results,
+    build_coverage_matrix,
+    build_gate_verdict,
+    build_mutation_results,
+    write_json,
+)
+from model_connect_ci.reporting.markdown_reports import build_summary_markdown  # noqa: E402
+from model_connect_ci.reporting.trend import write_trend_snapshot  # noqa: E402
+
+
+def _run(args: argparse.Namespace) -> int:
+    policies = load_policy_bundle(args.manifest_dir)
+    inventory = load_model_inventory(args.models_dir, policies)
+    catalog = load_mutation_catalog(args.manifest_dir / "mutation_catalog.yaml")
+
+    product_verdict = evaluate_product_gate(inventory, policies)
+    ci_selftest = run_ci_selftest(inventory=inventory, policies=policies)
+    ci_verdict = evaluate_ci_robustness(ci_selftest, policies=policies)
+    gate_verdict = build_gate_verdict(product_verdict, ci_verdict)
+
+    args.result_dir.mkdir(parents=True, exist_ok=True)
+    baseline_results = build_baseline_results(inventory, product_verdict)
+    mutation_results = build_mutation_results(catalog, ci_selftest)
+    ci_selftest_results = ci_selftest.to_dict()
+    coverage_matrix = build_coverage_matrix(inventory, policies)
+    summary = build_summary_markdown(inventory, product_verdict, ci_verdict, ci_selftest)
+
+    write_json(args.result_dir / "baseline_results.json", baseline_results)
+    write_json(args.result_dir / "mutation_results.json", mutation_results)
+    write_json(args.result_dir / "ci_selftest_results.json", ci_selftest_results)
+    write_json(args.result_dir / "gate_verdict.json", gate_verdict)
+    write_json(args.result_dir / "coverage_matrix.json", coverage_matrix)
+    (args.result_dir / "mutation_summary.md").write_text(summary, encoding="utf-8")
+    if args.mode in {"nightly", "weekly"}:
+        write_trend_snapshot(
+            args.result_dir,
+            {
+                "mode": args.mode,
+                "gate_verdict": gate_verdict,
+                "coverage_matrix": coverage_matrix,
+                "mutation_results": mutation_results,
+            },
+        )
+
+    print(f"ci_mutation_mode={args.mode}")
+    print(f"ci_mutation_result_dir={args.result_dir}")
+    print(f"ci_mutation_gate={'PASS' if gate_verdict['passed'] else 'FAIL'}")
+    print(f"ci_mutation_models={len(inventory.models)}")
+    print(f"ci_mutation_escaped_critical={ci_selftest.escaped_critical}")
+    return 0 if gate_verdict["passed"] else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run = subparsers.add_parser("run", help="Run mutation checks and write reports")
+    run.add_argument(
+        "--mode",
+        choices=("premerge", "nightly", "weekly"),
+        default="premerge",
+        help="Mutation scope. Premerge is fast CI self-test; nightly/weekly also write trend hooks.",
+    )
+    run.add_argument(
+        "--result-dir",
+        type=Path,
+        default=Path("ci_mutation_artifacts"),
+        help="Directory for JSON and Markdown mutation reports.",
+    )
+    run.add_argument(
+        "--models-dir",
+        type=Path,
+        default=REPO_ROOT / "tests" / "e2e" / "models",
+        help="Directory containing per-model E2E JSON manifests.",
+    )
+    run.add_argument(
+        "--manifest-dir",
+        type=Path,
+        default=REPO_ROOT / "model_connect_ci" / "manifests",
+        help="Directory containing CI mutation YAML policies.",
+    )
+    run.set_defaults(func=_run)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Background
This starts the model-centric mutation testing lane described in `model_connect_ci_robustness_mutation_spec.md`. The first scope is deliberately CI-safe: freeze the supported E2E model matrix, register semantic mutation operators, execute anti-false-green CI self-test mutations, and publish machine-readable evidence without running local GPU model conversion.

## Exit Criteria
- Supported E2E model coverage is loaded from `tests/e2e/models/*.json` and checked against a mandatory Tier A matrix across decoder-only, encoder/embedding, encoder-decoder, vision, diffusion, speech, and multimodal buckets.
- T1/T2/T3 product mutation operators are registered as planned semantic mutation coverage.
- Critical CI/test-suite mutations must all be killed, with zero escaped critical mutations.
- CI writes the required JSON/Markdown mutation reports as artifacts.

## Implementation
- Adds `model_connect_ci/` with manifest policy loading, architecture-bucket inventory normalization, declarative mutation catalog loading, CI self-test mutation execution, gates, lightweight runner/oracle abstractions, and report builders.
- Adds `tools/ci_mutation.py run` to produce `baseline_results.json`, `mutation_results.json`, `ci_selftest_results.json`, `gate_verdict.json`, `coverage_matrix.json`, and `mutation_summary.md`.
- Wires a `ci-mutation` stage into the shared CI driver, premerge workflow, nightly workflow, and artifact uploads.
- Adds focused tests for manifest freeze behavior, mutation taxonomy, CI self-test gates, CLI reports, and GitHub Actions wiring.

## Validation
- `python -m pytest tests/tools/test_ci_mutation.py tests/tools/test_github_actions_ci.py -q`: passed, 38 tests.
- `python tools/ci_mutation.py run --mode premerge --result-dir /tmp/trtmc-ci-mutation-smoke`: passed, 224 models, 0 escaped critical CI mutations.
- `python -m compileall -q model_connect_ci tools/ci_mutation.py`: passed.
- `git diff --cached --check`: passed before commit.
- `ruff check --config ruff.toml ...`: not run locally because `ruff` is not installed in this environment; CI lint installs ruff before checking changed files.

## Notes For Future Readers
- Product semantic mutations are reported as planned coverage in this first lane; only CI self-test mutations are executed here. Nightly/weekly can extend this by invoking real E2E mutation execution after baseline artifacts are available.
- Existing E2E manifests mostly lack pinned model/tokenizer revision fields. This lane reports those as evidence-only warnings during bootstrap rather than failing current main immediately.
