### PR TITLE
ci: verify CI Docker image versions

### DIFF
--- a/.github/scripts/ensure-ci-docker-image.sh
+++ b/.github/scripts/ensure-ci-docker-image.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image="${TRTMC_CI_IMAGE:-trtmc-dev-gb300:manylinux_2_39}"
+dockerfile="${TRTMC_CI_DOCKERFILE:-Dockerfile}"
+
+read_docker_arg() {
+  local name="$1"
+  awk -F= -v key="$name" '
+    $1 == "ARG " key {
+      print $2
+      exit
+    }
+  ' "$dockerfile"
+}
+
+expected_trt="$(read_docker_arg TENSORRT_VERSION)"
+expected_modelopt="$(read_docker_arg MODELOPT_VERSION)"
+
+if [ -z "$expected_trt" ]; then
+  echo "ERROR: Could not find ARG TENSORRT_VERSION in $dockerfile" >&2
+  exit 1
+fi
+
+if [ -z "$expected_modelopt" ]; then
+  echo "ERROR: Could not find ARG MODELOPT_VERSION in $dockerfile" >&2
+  exit 1
+fi
+
+summary() {
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "$*" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+query_image_versions() {
+  docker run --rm --entrypoint /bin/bash "$image" -lc '
+python3 - <<'"'"'PY'"'"'
+import importlib.metadata as metadata
+
+import tensorrt
+
+print(f"TENSORRT_VERSION={tensorrt.__version__}")
+print("MODELOPT_VERSION=" + metadata.version("nvidia-modelopt"))
+PY
+'
+}
+
+collect_docker_input_changes() {
+  local base="${CI_BASE_REF:-}"
+  if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+    return 0
+  fi
+
+  git diff --name-only "$base"...HEAD -- \
+    Dockerfile \
+    scripts/docker_build_gb300.sh \
+    .github/scripts/start-gha-container.sh \
+    .github/scripts/ensure-ci-docker-image.sh \
+    .github/workflows/trtmc-ci.yml \
+    .github/workflows/nightly.yml
+}
+
+rebuild_reasons=()
+mapfile -t changed_paths < <(collect_docker_input_changes)
+if [ "${#changed_paths[@]}" -gt 0 ]; then
+  rebuild_reasons+=("CI Docker image inputs changed")
+fi
+
+version_file="$(mktemp)"
+trap 'rm -f "$version_file"' EXIT
+
+if ! docker image inspect "$image" >/dev/null 2>&1; then
+  rebuild_reasons+=("CI Docker image '$image' is missing")
+else
+  if ! query_image_versions > "$version_file"; then
+    rebuild_reasons+=("CI Docker image '$image' could not report dependency versions")
+  else
+    current_trt="$(awk -F= '$1 == "TENSORRT_VERSION" { print $2 }' "$version_file")"
+    current_modelopt="$(awk -F= '$1 == "MODELOPT_VERSION" { print $2 }' "$version_file")"
+
+    if [ "$current_trt" != "$expected_trt" ]; then
+      rebuild_reasons+=("TensorRT version mismatch: image has '${current_trt:-unknown}', Dockerfile expects '$expected_trt'")
+    fi
+
+    if [ "$current_modelopt" != "$expected_modelopt" ]; then
+      rebuild_reasons+=("modelopt version mismatch: image has '${current_modelopt:-unknown}', Dockerfile expects '$expected_modelopt'")
+    fi
+  fi
+fi
+
+if [ "${#rebuild_reasons[@]}" -gt 0 ]; then
+  echo "Rebuilding CI Docker image '$image' from $dockerfile"
+  printf '  reason: %s\n' "${rebuild_reasons[@]}"
+  summary "Rebuilding CI Docker image \`$image\` from \`$dockerfile\`."
+  for reason in "${rebuild_reasons[@]}"; do
+    summary "- $reason"
+  done
+  if [ "${#changed_paths[@]}" -gt 0 ]; then
+    summary ""
+    summary "Changed CI Docker image inputs:"
+    for path in "${changed_paths[@]}"; do
+      summary "- \`$path\`"
+    done
+  fi
+
+  empty_context="${RUNNER_TEMP:-/tmp}/trtmc-empty-docker-context"
+  mkdir -p "$empty_context"
+  docker build \
+    -t "$image" \
+    -f "$dockerfile" \
+    "$empty_context"
+else
+  echo "CI Docker image '$image' already matches $dockerfile"
+fi
+
+query_image_versions > "$version_file"
+current_trt="$(awk -F= '$1 == "TENSORRT_VERSION" { print $2 }' "$version_file")"
+current_modelopt="$(awk -F= '$1 == "MODELOPT_VERSION" { print $2 }' "$version_file")"
+
+if [ "$current_trt" != "$expected_trt" ]; then
+  echo "ERROR: CI Docker image '$image' has TensorRT '$current_trt'; expected '$expected_trt' from $dockerfile" >&2
+  exit 1
+fi
+
+if [ "$current_modelopt" != "$expected_modelopt" ]; then
+  echo "ERROR: CI Docker image '$image' has modelopt '$current_modelopt'; expected '$expected_modelopt' from $dockerfile" >&2
+  exit 1
+fi
+
+echo "CI Docker image '$image' verified: TensorRT $current_trt, modelopt $current_modelopt"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,26 +64,28 @@ jobs:
           if [ -d "$GITHUB_WORKSPACE" ]; then
             chmod -R a+rwX "$GITHUB_WORKSPACE" 2>/dev/null || true
             docker rm -f "$TRTMC_CI_CONTAINER_NAME" >/dev/null 2>&1 || true
-            docker image inspect "$TRTMC_CI_IMAGE" >/dev/null || {
-              echo "::error::Docker image '$TRTMC_CI_IMAGE' is not present on the self-hosted runner. Set repository variable TRTMC_MANYLINUX_CI_IMAGE if the runner uses a different local manylinux image tag."
-              exit 1
-            }
-            docker run --rm \
-              -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
-              -w "$GITHUB_WORKSPACE" \
-              "$TRTMC_CI_IMAGE" \
-              bash -lc '
-                set -euo pipefail
-                cleanup_workspace() {
-                  find . -mindepth 1 -maxdepth 1 ! -name .git -exec chmod -R u+rwX {} + 2>/dev/null || true
-                  find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
-                }
-                cleanup_workspace || {
-                  echo "::warning::Initial workspace cleanup failed; retrying after canceled-run processes settle"
-                  sleep 10
-                  cleanup_workspace
-                }
-              '
+            if docker image inspect "$TRTMC_CI_IMAGE" >/dev/null 2>&1; then
+              docker run --rm \
+                -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+                -w "$GITHUB_WORKSPACE" \
+                "$TRTMC_CI_IMAGE" \
+                bash -lc '
+                  set -euo pipefail
+                  cleanup_workspace() {
+                    find . -mindepth 1 -maxdepth 1 ! -name .git -exec chmod -R u+rwX {} + 2>/dev/null || true
+                    find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+                  }
+                  cleanup_workspace || {
+                    echo "::warning::Initial workspace cleanup failed; retrying after canceled-run processes settle"
+                    sleep 10
+                    cleanup_workspace
+                  }
+                '
+            else
+              echo "::warning::Docker image '$TRTMC_CI_IMAGE' is not present before checkout; using host workspace cleanup so the checked-out Dockerfile can build it later."
+              find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 ! -name .git -exec chmod -R u+rwX {} + 2>/dev/null || true
+              find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} + || true
+            fi
           fi
 
       - name: Check out nightly ref
@@ -113,6 +115,10 @@ jobs:
           echo "FULL_E2E=$FULL_E2E"
           echo "RUN_COVERAGE_MAP=$RUN_COVERAGE_MAP"
           echo "REBUILD_ENGINES=$REBUILD_ENGINES"
+
+      - name: Ensure CI Docker image
+        timeout-minutes: 180
+        run: bash .github/scripts/ensure-ci-docker-image.sh
 
       - name: Start CI container
         timeout-minutes: 5

--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -146,41 +146,9 @@ jobs:
             echo "CI mode: branch/manual unit gates"
           fi
 
-      - name: Detect CI Docker image changes
-        id: ci_image
-        run: |
-          set -euo pipefail
-          mapfile -t changed_paths < <(
-            git diff --name-only "$CI_BASE_REF"...HEAD -- \
-              Dockerfile \
-              scripts/docker_build_gb300.sh \
-              .github/scripts/start-gha-container.sh \
-              .github/workflows/trtmc-ci.yml
-          )
-
-          if [ "${#changed_paths[@]}" -gt 0 ]; then
-            echo "rebuild=true" >> "$GITHUB_OUTPUT"
-            {
-              echo "Changed CI Docker image inputs:"
-              printf '  %s\n' "${changed_paths[@]}"
-            } | tee -a "$GITHUB_STEP_SUMMARY"
-          else
-            echo "rebuild=false" >> "$GITHUB_OUTPUT"
-            echo "No CI Docker image inputs changed."
-          fi
-
-      - name: Rebuild CI Docker image
-        if: ${{ steps.ci_image.outputs.rebuild == 'true' }}
+      - name: Ensure CI Docker image
         timeout-minutes: 180
-        run: |
-          set -euo pipefail
-          empty_context="${RUNNER_TEMP:-/tmp}/trtmc-empty-docker-context"
-          mkdir -p "$empty_context"
-          echo "Rebuilding CI Docker image '$TRTMC_CI_IMAGE' from Dockerfile"
-          docker build \
-            -t "$TRTMC_CI_IMAGE" \
-            -f Dockerfile \
-            "$empty_context"
+        run: bash .github/scripts/ensure-ci-docker-image.sh
 
       - name: Start CI container
         timeout-minutes: 5


### PR DESCRIPTION
## Background
The self-hosted CI tag can outlive Dockerfile dependency upgrades. After the repo moved to TensorRT 11, a runner-local `trtmc-dev-gb300:manylinux_2_39` tag could still point at a TRT 10 image unless the current PR directly touched Docker inputs.

## Exit Criteria
- CI rebuilds the local image when Docker-related inputs changed.
- CI also rebuilds when the image tag is missing or its TensorRT/modelopt versions do not match the repo Dockerfile.
- Premerge and nightly both start tests only after the image has been verified.

## Implementation
- Added `.github/scripts/ensure-ci-docker-image.sh` to read `TENSORRT_VERSION` and `MODELOPT_VERSION` from `Dockerfile`, inspect the current image tag, rebuild from the repo Dockerfile when stale, and verify the resulting versions.
- Replaced the premerge-only diff gate with the helper so version drift is caught even when the PR does not touch Docker files.
- Added the same helper to nightly and changed nightly pre-clean to tolerate a missing image before checkout, since the checked-out Dockerfile can now rebuild it.

## Validation
- `bash -n .github/scripts/ensure-ci-docker-image.sh`: passed.
- `TRTMC_CI_IMAGE=trtmc-dev-gb300:manylinux_2_39 bash .github/scripts/ensure-ci-docker-image.sh`: first run detected local TRT 10.16.1.11 vs Dockerfile TRT 11.0.0.114, rebuilt from `Dockerfile`, and verified TensorRT 11.0.0.114/modelopt 0.44.0.
- Same helper command after rebuild: passed no-rebuild path and verified TensorRT 11.0.0.114/modelopt 0.44.0.
- YAML parse check for `.github/workflows/trtmc-ci.yml` and `.github/workflows/nightly.yml`: passed.

## Notes For Future Readers
Issue #245 was also checked locally on the rebuilt TRT 11 image. `Qwen/Qwen3-0.6B --precision fp16 --max-cache-length 2048` still reproduces the Myelin attention failure under TensorRT 11.0.0.114; the `--max-cache-length 256` control builds successfully.