### PR TITLE
fix(canary): use NeMo mel preprocessing

### DIFF
--- a/python/tensorrt_model_connect/families/canary/plugin.py
+++ b/python/tensorrt_model_connect/families/canary/plugin.py
@@ -760,10 +760,14 @@ class CanaryPlugin:
     def get_audio_config(self, config: ModelConfig) -> dict | None:
         """NeMo mel spectrogram parameters (differ from Whisper defaults)."""
         return {
+            "mel_frontend": "nemo",
             "mel_n_fft": 512,
+            "mel_win_length": 400,
             "mel_hop_length": 160,
             "mel_chunk_length": 30,
             "mel_sampling_rate": 16000,
+            "mel_preemph": 0.97,
+            "mel_normalize": "per_feature",
         }
 
     def build_extra_engines(self, config: ModelConfig, weights, max_cache_length: int, *, precision: str = "fp32", verbose: bool = False) -> dict | None:

--- a/src/runtime/domains/audio/mel_spectrogram.cpp
+++ b/src/runtime/domains/audio/mel_spectrogram.cpp
@@ -194,6 +194,50 @@ void nemo_log_mel_inplace(std::vector<float>& mel_spec) {
         value = std::log(value + kLogGuard);
 }
 
+void normalize_nemo_per_feature_inplace(std::vector<float>& mel_spec, int32_t n_mel_bins,
+                                        int32_t n_frames_raw, int32_t valid_frames) {
+    if (n_mel_bins <= 0 || n_frames_raw <= 0) {
+        return;
+    }
+
+    valid_frames = std::clamp(valid_frames, 0, n_frames_raw);
+    if (valid_frames <= 0) {
+        std::fill(mel_spec.begin(), mel_spec.end(), 0.0F);
+        return;
+    }
+
+    constexpr float kStdGuard = 1e-5F; // NeMo preprocessing CONSTANT.
+    for (int32_t m = 0; m < n_mel_bins; ++m) {
+        const std::size_t base = static_cast<std::size_t>(m) * n_frames_raw;
+
+        double mean = 0.0;
+        for (int32_t t = 0; t < valid_frames; ++t)
+            mean += static_cast<double>(mel_spec[base + static_cast<std::size_t>(t)]);
+        mean /= static_cast<double>(valid_frames);
+
+        if (valid_frames == 1) {
+            mel_spec[base] = 0.0F;
+        } else {
+            double var = 0.0;
+            for (int32_t t = 0; t < valid_frames; ++t) {
+                const double diff =
+                    static_cast<double>(mel_spec[base + static_cast<std::size_t>(t)]) - mean;
+                var += diff * diff;
+            }
+            const double stddev =
+                std::sqrt(var / static_cast<double>(valid_frames - 1)) + kStdGuard;
+            for (int32_t t = 0; t < valid_frames; ++t) {
+                const std::size_t idx = base + static_cast<std::size_t>(t);
+                mel_spec[idx] =
+                    static_cast<float>((static_cast<double>(mel_spec[idx]) - mean) / stddev);
+            }
+        }
+
+        for (int32_t t = valid_frames; t < n_frames_raw; ++t)
+            mel_spec[base + static_cast<std::size_t>(t)] = 0.0F;
+    }
+}
+
 std::vector<float> trim_last_frame_if_needed(std::vector<float> mel_spec, int32_t n_mel_bins,
                                              int32_t n_frames_raw, int32_t& n_frames_out) {
     n_frames_out = n_frames_raw;
@@ -242,7 +286,8 @@ MelResult extract_nemo_mel_spectrogram(const float* samples, int32_t n_samples,
                                        const float* mel_filters, int32_t n_freq_bins,
                                        int32_t n_mel_bins, int32_t n_fft, int32_t win_length,
                                        int32_t hop_length, int32_t chunk_length_s,
-                                       int32_t sample_rate, float preemph) {
+                                       int32_t sample_rate, float preemph,
+                                       bool normalize_per_feature) {
     const std::vector<float> padded = build_nemo_center_padded_audio(
         samples, n_samples, chunk_length_s, sample_rate, n_fft, preemph);
     const int32_t freq_bins = resolve_num_freq_bins(n_freq_bins, n_fft);
@@ -254,6 +299,10 @@ MelResult extract_nemo_mel_spectrogram(const float* samples, int32_t n_samples,
     std::vector<float> mel_spec =
         project_power_to_mel(power, mel_filters, freq_bins, n_mel_bins, n_frames_raw);
     nemo_log_mel_inplace(mel_spec);
+    if (normalize_per_feature) {
+        const int32_t valid_frames = (hop_length > 0) ? (n_samples / hop_length) : 0;
+        normalize_nemo_per_feature_inplace(mel_spec, n_mel_bins, n_frames_raw, valid_frames);
+    }
 
     int32_t n_frames_out = 0;
     mel_spec =

--- a/src/runtime/domains/audio/mel_spectrogram.h
+++ b/src/runtime/domains/audio/mel_spectrogram.h
@@ -33,13 +33,15 @@ MelResult extract_mel_spectrogram(const float* samples, int32_t n_samples, const
 
 // Extract NeMo ASR-style log-mel features.
 //
-// Matches AudioToMelSpectrogramPreprocessor for the Nemotron RNNT config:
+// Matches AudioToMelSpectrogramPreprocessor for NeMo ASR configs:
 // center=True STFT, win_length < n_fft, preemphasis, power mel projection,
-// natural log with additive guard, and no feature normalization.
+// natural log with additive guard, and optional per-feature normalization over
+// the valid audio frames.
 MelResult extract_nemo_mel_spectrogram(const float* samples, int32_t n_samples,
                                        const float* mel_filters, int32_t n_freq_bins,
                                        int32_t n_mel_bins, int32_t n_fft, int32_t win_length,
                                        int32_t hop_length, int32_t chunk_length_s,
-                                       int32_t sample_rate, float preemph);
+                                       int32_t sample_rate, float preemph,
+                                       bool normalize_per_feature = false);
 
 } // namespace trtmc

--- a/src/runtime/models/whisper/pipeline.cpp
+++ b/src/runtime/models/whisper/pipeline.cpp
@@ -26,14 +26,17 @@ WhisperPipeline::WhisperPipeline(
     std::unique_ptr<TrtModule> encoder, std::unique_ptr<TrtModule> decoder,
     std::unique_ptr<IInferenceState> state, WhisperConfig whisper_config, int32_t hidden_size,
     int32_t num_decoder_layers, MelFilterbank mel_fb, int32_t mel_n_fft, int32_t mel_hop_length,
-    int32_t mel_chunk_length, int32_t mel_sampling_rate, cudaStream_t stream,
+    int32_t mel_chunk_length, int32_t mel_sampling_rate, int32_t mel_win_length, float mel_preemph,
+    bool mel_normalize_per_feature, std::string mel_frontend, cudaStream_t stream,
     std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str)
     : encoder_(std::move(encoder)), decoder_(std::move(decoder)), state_(std::move(state)),
       whisper_config_(std::move(whisper_config)), hidden_size_(hidden_size),
       num_decoder_layers_(num_decoder_layers),
       mel_fb_(std::make_unique<MelFilterbank>(std::move(mel_fb))), mel_n_fft_(mel_n_fft),
       mel_hop_length_(mel_hop_length), mel_chunk_length_(mel_chunk_length),
-      mel_sampling_rate_(mel_sampling_rate), stream_(stream), tokenizer_(std::move(tokenizer)),
+      mel_sampling_rate_(mel_sampling_rate), mel_win_length_(mel_win_length),
+      mel_preemph_(mel_preemph), mel_normalize_per_feature_(mel_normalize_per_feature),
+      mel_frontend_(std::move(mel_frontend)), stream_(stream), tokenizer_(std::move(tokenizer)),
       model_id_(std::move(model_id_str)) {
     if (!encoder_ || !encoder_->ok())
         throw std::runtime_error("WhisperPipeline: invalid encoder module");
@@ -53,6 +56,18 @@ WhisperPipeline::WhisperPipeline(
         cudaMalloc(&cross_v_ptrs_[static_cast<std::size_t>(i)], cross_kv_bytes_);
     }
 }
+
+WhisperPipeline::WhisperPipeline(
+    std::unique_ptr<TrtModule> encoder, std::unique_ptr<TrtModule> decoder,
+    std::unique_ptr<IInferenceState> state, WhisperConfig whisper_config, int32_t hidden_size,
+    int32_t num_decoder_layers, MelFilterbank mel_fb, int32_t mel_n_fft, int32_t mel_hop_length,
+    int32_t mel_chunk_length, int32_t mel_sampling_rate, cudaStream_t stream,
+    std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str)
+    : WhisperPipeline(std::move(encoder), std::move(decoder), std::move(state),
+                      std::move(whisper_config), hidden_size, num_decoder_layers, std::move(mel_fb),
+                      mel_n_fft, mel_hop_length, mel_chunk_length, mel_sampling_rate, mel_n_fft,
+                      0.0F, false, "whisper", stream, std::move(tokenizer),
+                      std::move(model_id_str)) {}
 
 WhisperPipeline::~WhisperPipeline() {
     for (auto* ptr : cross_k_ptrs_) {
@@ -84,9 +99,16 @@ TextResult WhisperPipeline::transcribe(const float* audio_data, int32_t num_samp
     // Step 1: Extract mel spectrogram
     MelResult mel;
     if (mel_fb_ && !mel_fb_->data.empty()) {
-        mel = extract_mel_spectrogram(samples_ptr, samples_count, mel_fb_->data.data(),
-                                      mel_fb_->n_freq_bins, mel_fb_->n_mel_bins, mel_n_fft_,
-                                      mel_hop_length_, mel_chunk_length_, mel_sampling_rate_);
+        if (mel_frontend_ == "nemo") {
+            mel = extract_nemo_mel_spectrogram(
+                samples_ptr, samples_count, mel_fb_->data.data(), mel_fb_->n_freq_bins,
+                mel_fb_->n_mel_bins, mel_n_fft_, mel_win_length_, mel_hop_length_,
+                mel_chunk_length_, mel_sampling_rate_, mel_preemph_, mel_normalize_per_feature_);
+        } else {
+            mel = extract_mel_spectrogram(samples_ptr, samples_count, mel_fb_->data.data(),
+                                          mel_fb_->n_freq_bins, mel_fb_->n_mel_bins, mel_n_fft_,
+                                          mel_hop_length_, mel_chunk_length_, mel_sampling_rate_);
+        }
     }
 
     if (mel.data.empty()) {

--- a/src/runtime/models/whisper/pipeline.h
+++ b/src/runtime/models/whisper/pipeline.h
@@ -27,6 +27,14 @@ class WhisperPipeline final : public IPipeline {
                     std::unique_ptr<IInferenceState> state, WhisperConfig whisper_config,
                     int32_t hidden_size, int32_t num_decoder_layers, MelFilterbank mel_fb,
                     int32_t mel_n_fft, int32_t mel_hop_length, int32_t mel_chunk_length,
+                    int32_t mel_sampling_rate, int32_t mel_win_length, float mel_preemph,
+                    bool mel_normalize_per_feature, std::string mel_frontend, cudaStream_t stream,
+                    std::shared_ptr<ITokenizer> tokenizer = nullptr, std::string model_id_str = "");
+
+    WhisperPipeline(std::unique_ptr<TrtModule> encoder, std::unique_ptr<TrtModule> decoder,
+                    std::unique_ptr<IInferenceState> state, WhisperConfig whisper_config,
+                    int32_t hidden_size, int32_t num_decoder_layers, MelFilterbank mel_fb,
+                    int32_t mel_n_fft, int32_t mel_hop_length, int32_t mel_chunk_length,
                     int32_t mel_sampling_rate, cudaStream_t stream,
                     std::shared_ptr<ITokenizer> tokenizer = nullptr, std::string model_id_str = "");
 
@@ -56,6 +64,10 @@ class WhisperPipeline final : public IPipeline {
     int32_t mel_hop_length_;
     int32_t mel_chunk_length_;
     int32_t mel_sampling_rate_;
+    int32_t mel_win_length_;
+    float mel_preemph_;
+    bool mel_normalize_per_feature_;
+    std::string mel_frontend_;
     cudaStream_t stream_;
     std::shared_ptr<ITokenizer> tokenizer_;
     std::string model_id_;

--- a/src/runtime/models/whisper/plugin.cpp
+++ b/src/runtime/models/whisper/plugin.cpp
@@ -21,11 +21,44 @@ struct TensorParallelRuntimeConfig {
     int32_t tp_size{1};
 };
 
+struct SpeechMelRuntimeConfig {
+    int32_t n_fft{400};
+    int32_t hop_length{160};
+    int32_t chunk_length{30};
+    int32_t sampling_rate{16000};
+    int32_t win_length{400};
+    float preemph{0.0F};
+    bool normalize_per_feature{false};
+    std::string frontend{"whisper"};
+};
+
 TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::string& config_json) {
     TensorParallelRuntimeConfig cfg;
     cfg.tp_size = extract_json_int(config_json, "tensor_parallel_size", 1);
     const auto mode = extract_json_string(config_json, "tensor_parallel_mode", "single");
     cfg.enabled = (mode == "tensor_parallel" && cfg.tp_size > 1);
+    return cfg;
+}
+
+SpeechMelRuntimeConfig parse_speech_mel_runtime_config(const std::string& json,
+                                                       const std::string& bundle_model_type,
+                                                       const std::string& bundle_family) {
+    SpeechMelRuntimeConfig cfg;
+    cfg.n_fft = extract_json_int(json, "mel_n_fft", 400);
+    cfg.hop_length = extract_json_int(json, "mel_hop_length", 160);
+    cfg.chunk_length = extract_json_int(json, "mel_chunk_length", 30);
+    cfg.sampling_rate = extract_json_int(json, "mel_sampling_rate", 16000);
+
+    const std::string model_type = extract_json_string(json, "model_type", bundle_model_type);
+    const bool is_canary = (model_type == "canary" || bundle_family == "canary");
+    cfg.frontend = extract_json_string(json, "mel_frontend", is_canary ? "nemo" : "whisper");
+    cfg.win_length =
+        extract_json_int(json, "mel_win_length", (cfg.frontend == "nemo") ? 400 : cfg.n_fft);
+    cfg.preemph = extract_json_float(json, "mel_preemph", (cfg.frontend == "nemo") ? 0.97F : 0.0F);
+
+    const std::string normalize =
+        extract_json_string(json, "mel_normalize", is_canary ? "per_feature" : "");
+    cfg.normalize_per_feature = (cfg.frontend == "nemo" && normalize == "per_feature");
     return cfg;
 }
 
@@ -110,15 +143,15 @@ class WhisperPlugin final : public IPipelinePlugin {
         auto mel_fb = load_mel_filterbank(ctx.bundle);
         auto tok = create_tokenizer_from_bundle(ctx.bundle);
 
-        int32_t mel_n_fft = extract_json_int(json, "mel_n_fft", 400);
-        int32_t mel_hop_length = extract_json_int(json, "mel_hop_length", 160);
-        int32_t mel_chunk_length = extract_json_int(json, "mel_chunk_length", 30);
-        int32_t mel_sampling_rate = extract_json_int(json, "mel_sampling_rate", 16000);
+        SpeechMelRuntimeConfig mel_cfg = parse_speech_mel_runtime_config(
+            json, ctx.bundle.info.model_type, ctx.bundle.info.family);
 
         return std::make_unique<WhisperPipeline>(
             std::move(enc_loaded.module), std::move(dec_loaded.module), std::move(state),
-            std::move(wc), ctx.config.hidden_size, dl, std::move(mel_fb), mel_n_fft, mel_hop_length,
-            mel_chunk_length, mel_sampling_rate, stream, std::move(tok), ctx.bundle.info.model_id);
+            std::move(wc), ctx.config.hidden_size, dl, std::move(mel_fb), mel_cfg.n_fft,
+            mel_cfg.hop_length, mel_cfg.chunk_length, mel_cfg.sampling_rate, mel_cfg.win_length,
+            mel_cfg.preemph, mel_cfg.normalize_per_feature, std::move(mel_cfg.frontend), stream,
+            std::move(tok), ctx.bundle.info.model_id);
     }
 };
 

--- a/tests/builder/test_family_plugins.py
+++ b/tests/builder/test_family_plugins.py
@@ -2207,6 +2207,17 @@ class TestCanaryPlugin:
     HEADS, HEAD_DIM, FFN = 2, 8, 32
     MEL_BINS, CONV_KERNEL, SUB_CH = 8, 3, 4
 
+    def test_audio_config_declares_nemo_frontend(self):
+        from tensorrt_model_connect.families.canary import plugin
+
+        audio_cfg = plugin.get_audio_config(object())
+
+        assert audio_cfg["mel_frontend"] == "nemo"
+        assert audio_cfg["mel_n_fft"] == 512
+        assert audio_cfg["mel_win_length"] == 400
+        assert audio_cfg["mel_preemph"] == 0.97
+        assert audio_cfg["mel_normalize"] == "per_feature"
+
     @staticmethod
     def _make_tp_weights(
         *,

--- a/tests/e2e/waives.txt
+++ b/tests/e2e/waives.txt
@@ -8,5 +8,3 @@ internlm2-1.8b           SKIP   (DynamicCache.from_legacy_cache removed in trans
 phi4-multimodal           SKIP   (phi4-multimodal remote code incompatible with transformers 5.x)
 eagle-embed-vl-1b-v2     SKIP   (HF repo 404)
 eagle-rerank-vl-1b-v2    SKIP   (HF repo 404)
-canary-1b-v2-asr-probe05 XFAIL  (ASR probe low-volume parity gap: TRT transcript diverges from NeMo reference)
-canary-1b-v2-asr-probe06 XFAIL  (ASR probe silence-padding parity gap: TRT transcript diverges from NeMo reference)

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -56,7 +56,10 @@ def mock_repo(tmp_path):
     (tmp_path / "src" / "runtime" / "models" / "vision_language").mkdir(parents=True)
     (tmp_path / "src" / "runtime" / "models" / "flux").mkdir(parents=True)
     (tmp_path / "src" / "runtime" / "models" / "pixart").mkdir(parents=True)
+    (tmp_path / "src" / "runtime" / "models" / "whisper").mkdir(parents=True)
+    (tmp_path / "src" / "runtime" / "models" / "rnnt").mkdir(parents=True)
     (tmp_path / "src" / "runtime" / "core").mkdir(parents=True)
+    (tmp_path / "src" / "runtime" / "domains" / "audio").mkdir(parents=True)
     (tmp_path / "src" / "runtime" / "domains" / "diffusion").mkdir(parents=True)
     (tmp_path / "include" / "trtmc").mkdir(parents=True)
     (tmp_path / "tests" / "e2e" / "data").mkdir(parents=True)
@@ -84,6 +87,8 @@ def mock_repo(tmp_path):
         {"name": "whisper-tiny-fp16", "family": "whisper", "runtime_strategy": "speech_to_text",
          "hf_id": "openai/whisper-tiny", "precision": "fp16", "core": True,
          "test_input_audio": "tests/e2e/data/Recording.wav"},
+        {"name": "rnnt-small", "family": "rnnt", "runtime_strategy": "speech_to_text_rnnt",
+         "hf_id": "nvidia/rnnt-small", "core": True},
         {"name": "flux-schnell", "family": "flux", "runtime_strategy": "diffusion_flux",
          "hf_id": "bf/FLUX", "core": True},
         {"name": "z-image-turbo", "family": "z_image", "runtime_strategy": "diffusion_zimage",
@@ -242,6 +247,22 @@ def mock_repo(tmp_path):
     )
     (tmp_path / "src" / "runtime" / "models" / "pixart" / "pipeline.cpp").write_text(
         '#include "runtime/domains/diffusion/diffusion_denoising_step_seam.h"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "src" / "runtime" / "models" / "whisper" / "MODEL.toml").write_text(
+        'runtime_strategies = ["speech_to_text"]\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "src" / "runtime" / "models" / "whisper" / "pipeline.cpp").write_text(
+        '#include "runtime/domains/audio/mel_spectrogram.h"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "src" / "runtime" / "models" / "rnnt" / "MODEL.toml").write_text(
+        'runtime_strategies = ["speech_to_text_rnnt"]\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "src" / "runtime" / "models" / "rnnt" / "pipeline.cpp").write_text(
+        '#include "runtime/domains/audio/mel_spectrogram.h"\n',
         encoding="utf-8",
     )
     (tmp_path / "tests" / "e2e" / "data" / "flux2-fp8-scales.json").write_text(
@@ -630,6 +651,22 @@ class TestCppScope:
         assert "flux-schnell" in match.models
         assert "flux-2-dev" in match.models
         assert "flux-2-dev-fp8" not in match.models
+        assert "qwen3-0.6b" not in match.models
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "src/runtime/domains/audio/mel_spectrogram.cpp",
+            "src/runtime/domains/audio/mel_spectrogram.h",
+        ],
+    )
+    def test_scoped_cpp_helper_audio_mel_spectrogram(self, imap, path):
+        """mel_spectrogram helper -> only ASR runtime models that include it."""
+        match = test_impact.classify_file(path, imap)
+        assert match.rule == "cpp_scoped_helper"
+        assert "whisper-tiny-fp16" in match.models
+        assert "rnnt-small" in match.models
+        assert "bark-small" not in match.models
         assert "qwen3-0.6b" not in match.models
 
     def test_scoped_cpp_helper_diffusion_seam(self, imap):
@@ -1962,6 +1999,21 @@ class TestAggregation:
             "replacement": "qwen3-0.6b",
             "reason": "scale-only coverage",
         }]
+
+    def test_waive_line_keeps_exact_model_despite_l0_replacement(self, mock_repo):
+        """Waiver edits name exact configs, so L0 should not substitute them."""
+        models_dir = mock_repo / "tests" / "e2e" / "models"
+        qwen4b = json.loads((models_dir / "qwen3-4b.json").read_text())
+        qwen4b["l0_replacement"] = "qwen3-0.6b"
+        qwen4b["l0_replacement_reason"] = "scale-only coverage"
+        _write_json(models_dir / "qwen3-4b.json", qwen4b)
+
+        imap = test_impact.build_impact_map(mock_repo)
+        selected, replacements = test_impact._apply_l0_replacements(
+            ["qwen3-4b"], imap, {"qwen3-4b"})
+
+        assert selected == ["qwen3-4b"]
+        assert replacements == []
 
     def test_nightly_keeps_exact_impacted_models(self, mock_repo):
         """Nightly policy does not apply PR L0 replacements."""

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -504,6 +504,12 @@ def build_impact_map(repo_root: Path) -> ImpactMap:
     scoped_cpp_tokens = {
         "src/runtime/core/gpu_matmul.h": "gpu_matmul",
         "src/runtime/core/gpu_matmul.cpp": "gpu_matmul",
+        "src/runtime/domains/audio/mel_spectrogram.h": (
+            "runtime/domains/audio/mel_spectrogram.h"
+        ),
+        "src/runtime/domains/audio/mel_spectrogram.cpp": (
+            "runtime/domains/audio/mel_spectrogram.h"
+        ),
         "src/runtime/domains/diffusion/diffusion_denoising_step_seam.h": (
             "diffusion_denoising_step_seam.h"
         ),
@@ -615,18 +621,24 @@ def _models_for_task_strategies(
 def _apply_l0_replacements(
     models: List[str],
     imap: ImpactMap,
-    exact_models: Set[str],
+    preserve_models: Set[str],
 ) -> tuple[List[str], List[Dict[str, str]]]:
     """Replace nightly-only scale models with their L0 representatives.
 
     Direct edits to a nightly-only scale model still use the L0 representative:
     the large model's artifact contract is covered by nightly, while PR L0 keeps
     the same plugin/runtime path at smaller scale.
+
+    Waiver diffs are different: they name the exact config whose xfail status
+    changed, so keep those exact model IDs even if they normally have an L0
+    representative.
     """
-    del exact_models  # Retained in the signature to keep call sites stable.
     selected: Set[str] = set()
     replacements: List[Dict[str, str]] = []
     for model in models:
+        if model in preserve_models:
+            selected.add(model)
+            continue
         replacement = imap.l0_replacement_by_model.get(model)
         if replacement:
             selected.add(replacement)
@@ -1193,6 +1205,7 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             resolver=_match_result("cpp_scoped_helper", _scoped_cpp_helper_models),
             covered_by=(
                 "TestCppScope.test_scoped_cpp_helper_gpu_matmul",
+                "TestCppScope.test_scoped_cpp_helper_audio_mel_spectrogram",
                 "TestCppScope.test_scoped_cpp_helper_diffusion_seam",
             ),
         ),
@@ -1560,7 +1573,7 @@ def analyze_impact(
         exclude_ci_tiers = set(_DEFAULT_EXCLUDED_CI_TIERS)
 
     all_models: Set[str] = set()
-    exact_models: Set[str] = set()
+    preserve_l0_models: Set[str] = set()
     all_tiers: Set[str] = set()
     rebuild_cpp = False
     matched_rules: List[Dict] = []
@@ -1589,8 +1602,8 @@ def analyze_impact(
                 candidate_models,
             )
         all_models.update(match.models)
-        if match.rule in ("manifest", "e2e_data_file"):
-            exact_models.update(match.models)
+        if match.rule == "e2e_waives_model_lines":
+            preserve_l0_models.update(match.models)
         all_tiers.update(match.unit_tiers)
         rebuild_cpp = rebuild_cpp or match.rebuild_cpp
         matched_rules.append({
@@ -1603,7 +1616,7 @@ def analyze_impact(
     l0_replacements: List[Dict[str, str]] = []
     if e2e_suite == "l0":
         e2e_models, l0_replacements = _apply_l0_replacements(
-            e2e_models, imap, exact_models,
+            e2e_models, imap, preserve_l0_models,
         )
     cap_applied = False
     if cap is not None and len(e2e_models) > cap:


### PR DESCRIPTION
## Background
Issue #241 tracks Canary ASR parity failures on the low-volume and silence-padding probes. The shared `speech_to_text` runtime was extracting Whisper-style log-mel features for Canary even though Canary is a NeMo ASR model whose encoder expects NeMo `AudioToMelSpectrogramPreprocessor` features.

A first CI run also exposed an impact-selection mismatch: changing the shared mel spectrogram helper selected the full L0 model set instead of the ASR runtime users that actually include that helper.

## Exit Criteria
- Canary probe05 low-volume transcription matches the NeMo reference.
- Canary probe06 silence-padding transcription remains aligned with the NeMo reference.
- Whisper and RNNT preprocessing behavior remains scoped to their existing paths.
- Selective E2E for this PR is scoped to ASR coverage and keeps the newly unwaived Canary probe configs exact.

## Implementation
- Added optional NeMo per-feature normalization over valid audio frames in the shared mel spectrogram helper.
- Extended the `speech_to_text` runtime to select a mel frontend and route Canary through the NeMo frontend while leaving Whisper on the existing Whisper frontend.
- Made the Canary builder emit explicit NeMo frontend parameters: 512-point FFT, 400-sample window, 160-sample hop, 0.97 preemphasis, and per-feature normalization.
- Removed the Canary probe05/probe06 xfail waivers now that both probes pass normally.
- Scoped `mel_spectrogram.{cpp,h}` impact analysis to runtime models that include that helper, and preserved exact `waives.txt` model IDs through L0 replacement.
- Added builder and impact-analysis regression tests.

## Validation
- `cmake -S . -B /workspace/repros/issue241/build-canary-fix -G Ninja -DCMAKE_BUILD_TYPE=Release ... && cmake --build /workspace/repros/issue241/build-canary-fix -j$(nproc)`: passed in the TRT11 image.
- `pytest tests/test_e2e.py::test_e2e[canary-1b-v2-asr-probe05] tests/test_e2e.py::test_e2e[canary-1b-v2-asr-probe06] -vv -s --engine-dir /workspace/repros/issue241/engines --trtmc-binary /workspace/repros/issue241/build-canary-fix/trtmc --hf-python /opt/venv/bin/python3 --e2e-artifacts-dir /workspace/repros/issue241/artifacts-canary-fix-no-waive`: passed, both probes report NED/WER/CER 0.0 and transcript `Hello there, how is the weather today?`.
- `ctest -R test_mel_spectrogram --output-on-failure`: passed.
- `pytest tests/builder/test_family_plugins.py::TestCanaryPlugin::test_audio_config_declares_nemo_frontend -q`: passed.
- `pytest tests/tools/test_e2e_waives.py -q`: passed.
- `python3 tools/test_impact.py --base 3173469cb882f473b639abe43366f0bf3837c839 --json`: passed, selective E2E is now 6 ASR models: `canary-1b-v2`, `canary-1b-v2-asr-probe05`, `canary-1b-v2-asr-probe06`, `nemotron-speech-streaming-en-0.6b`, `whisper-large-v3-turbo`, `whisper-tiny-fp16`.
- `python3 tools/test_impact.py --validate`: passed.
- `docker run ... trtmc-dev-gb300:manylinux_2_39 bash -lc 'git config --global --add safe.directory "*" && python -m pytest tests/tools/test_test_impact.py -q'`: passed, 144 tests.
- `docker run ... trtmc-dev-gb300:manylinux_2_39 bash -lc 'python -m pip install --disable-pip-version-check --quiet ruff && python -m ruff check --config ruff.toml tools/test_impact.py tests/tools/test_test_impact.py'`: passed.
- `git diff --check`: passed.

## Notes For Future Readers
Review the runtime selection in `src/runtime/models/whisper/plugin.cpp` first, then the NeMo normalization helper. Existing Canary bundles are also handled by the `model_type/family == canary` fallback, while new bundles carry explicit `mel_frontend` metadata.

For impact-analysis changes, review `tools/test_impact.py` with `tests/tools/test_test_impact.py`: shared C++ helpers need explicit scoped coverage when their real users are narrower than all runtime models.

Fixes #241
