### PR TITLE
ci(e2e): narrow impact scope for support files

### DIFF
--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -668,6 +668,7 @@ class TestCppScope:
         assert "rnnt-small" in match.models
         assert "bark-small" not in match.models
         assert "qwen3-0.6b" not in match.models
+        assert "flux-schnell" not in match.models
 
     def test_scoped_cpp_helper_diffusion_seam(self, imap):
         """diffusion seam helper -> only diffusion pipelines that include it."""
@@ -678,6 +679,18 @@ class TestCppScope:
         assert "flux-2-dev" in match.models
         assert "flux-2-dev-fp8" not in match.models
         assert "qwen3-0.6b" not in match.models
+
+    def test_third_party_stb_scopes_to_image_models(self, imap):
+        """STB image headers affect image/video runtimes, not text-only models."""
+        match = test_impact.classify_file("third_party/stb/stb_image.h", imap)
+        assert match.rule == "third_party_stb_image"
+        assert "qwen25vl-3b" in match.models
+        assert "flux-schnell" in match.models
+        assert "sam-vit" in match.models
+        assert "segformer-b0" in match.models
+        assert "qwen3-0.6b" not in match.models
+        assert match.unit_tiers == ["cpp"]
+        assert match.rebuild_cpp is True
 
 
 # ---------------------------------------------------------------------------
@@ -757,6 +770,26 @@ class TestNoImpact:
         assert match.rule == "no_impact"
         assert match.models == []
 
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "CODEOWNERS",
+            "hf_links_wave1.txt",
+            "ruff.toml",
+            "tests/__init__.py",
+            "tests/assets/test_image.jpg",
+            "tests/engine_defs/__init__.py",
+            "verify_encoder.py",
+        ],
+    )
+    def test_repo_metadata_and_test_assets_no_impact(self, imap, path):
+        """Repo metadata and standalone test assets should not select E2E models."""
+        match = test_impact.classify_file(path, imap)
+        assert match.rule == "no_impact"
+        assert match.models == []
+        assert match.unit_tiers == []
+        assert match.rebuild_cpp is False
+
     def test_gitignore_no_impact(self, imap):
         """.gitignore -> no E2E tests."""
         match = test_impact.classify_file(".gitignore", imap)
@@ -793,6 +826,61 @@ class TestNoImpact:
         assert result.e2e_models == []
         assert result.unit_tiers == []
         assert result.rebuild_cpp is False
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tests/e2e/timing_estimates.json",
+            "tests/e2e_partition.py",
+            "tests/runtime_strategy_matrix.yaml",
+        ],
+    )
+    def test_e2e_schedule_metadata_tools_only(self, imap, path):
+        """E2E scheduling/catalog metadata should run tools tests, not every model."""
+        match = test_impact.classify_file(path, imap)
+        assert match.rule == "e2e_schedule_metadata"
+        assert match.models == []
+        assert match.unit_tiers == ["tools"]
+        assert match.rebuild_cpp is False
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tests/e2e/__init__.py",
+            "tests/e2e/conftest.py",
+            "tests/e2e/test_full_pipeline.py",
+        ],
+    )
+    def test_legacy_e2e_tests_do_not_select_models(self, imap, path):
+        """Legacy direct E2E tests are not the manifest-harness model selector."""
+        match = test_impact.classify_file(path, imap)
+        assert match.rule == "legacy_e2e_test_support"
+        assert match.models == []
+        assert match.unit_tiers == ["tools"]
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tests/run_qwen3_fi.py",
+            "tests/test_flashinfer_plugin_e2e.py",
+            "tests/test_flashinfer_trt_attention.py",
+            "tests/test_qwen3_flashinfer_e2e.py",
+            "tests/test_tvm_ffi_e2e.py",
+        ],
+    )
+    def test_standalone_gpu_tests_do_not_select_models(self, imap, path):
+        """Standalone GPU test files should not drive manifest-harness model scope."""
+        match = test_impact.classify_file(path, imap)
+        assert match.rule == "standalone_gpu_test_support"
+        assert match.models == []
+        assert match.unit_tiers == ["tools"]
+
+    def test_local_qwen3_fixture_scopes_to_qwen3(self, imap):
+        """Checked-in local Qwen3 fixture files map to Qwen3 0.6B manifests."""
+        imap.model_metadata["qwen3-0.6b"]["hf_id"] = "Qwen/Qwen3-0.6B"
+        match = test_impact.classify_file("models/hf/qwen3/config.json", imap)
+        assert match.rule == "local_qwen3_hf_fixture"
+        assert match.models == ["qwen3-0.6b"]
 
 
 class TestE2EDataFiles:
@@ -892,6 +980,16 @@ class TestUnitTiers:
         assert match.models == []
         assert match.unit_tiers == ["tools"]
         assert match.rebuild_cpp is False
+
+    def test_cpp_example_tool_triggers_cpp_tier(self, imap):
+        """C++ example tools require C++ validation, not E2E model execution."""
+        match = test_impact.classify_file(
+            "examples/trtmc_dataset_benchmark.cpp", imap)
+
+        assert match.rule == "cpp_example_tool"
+        assert match.models == []
+        assert match.unit_tiers == ["cpp"]
+        assert match.rebuild_cpp is True
 
     def test_source_implies_unit_tier(self, imap):
         """C++ source change implies 'cpp' unit tier alongside E2E."""

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -194,6 +194,18 @@ THRESHOLD_PROFILE_TASK_STRATEGIES: Dict[str, List[str]] = {
     "segmentation": ["segmentation"],
 }
 
+# Third-party image loaders are used by image/video-producing or image-consuming
+# runtime paths, not by every model family.
+STB_IMAGE_TASK_STRATEGIES = [
+    "diffusion_media_generation",
+    "image_classification",
+    "object_detection",
+    "omni_multimodal",
+    "prompted_segmentation",
+    "segmentation",
+    "vision_language_generation",
+]
+
 # Shared C++ helper -> affected task_strategies
 SHARED_CPP_HELPER_STRATEGIES: Dict[str, List[str]] = {
     "diffusion_helpers": [
@@ -231,6 +243,12 @@ _NO_IMPACT_PATTERNS = [
     r"^plugins/trtmc-agent-skills/",
     r"^LICENSE",
     r"^CLAUDE\.md$",
+    r"^CODEOWNERS$",
+    r"^hf_links_wave1\.txt$",
+    r"^ruff\.toml$",
+    r"^verify_encoder\.py$",
+    r"^tests/(__init__\.py|engine_defs/__init__\.py)$",
+    r"^tests/assets/",
     r"^recovery-",
 ]
 
@@ -847,6 +865,18 @@ def _task_strategy_models(task_strategies: List[str]) -> ModelsResolver:
     return _resolver
 
 
+def _hf_id_models(hf_ids: Set[str]) -> ModelsResolver:
+    def _resolver(context: RuleContext, imap: ImpactMap) -> List[str]:
+        del context
+        return sorted(
+            model
+            for model, metadata in imap.model_metadata.items()
+            if metadata.get("hf_id") in hf_ids
+        )
+
+    return _resolver
+
+
 def _runtime_strategy_models(
     strategies_getter: Callable[[RuleContext, ImpactMap], List[str]],
 ) -> ModelsResolver:
@@ -1210,6 +1240,18 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             ),
         ),
         ClassificationRule(
+            priority=225,
+            name="third_party_stb_image",
+            matcher=_path_startswith("third_party/stb/"),
+            resolver=_match_result(
+                "third_party_stb_image",
+                _task_strategy_models(STB_IMAGE_TASK_STRATEGIES),
+                ["cpp"],
+                True,
+            ),
+            covered_by=("TestCppScope.test_third_party_stb_scopes_to_image_models",),
+        ),
+        ClassificationRule(
             priority=230,
             name="cpp_source",
             matcher=_path_startswith_any(("src/", "include/")),
@@ -1384,6 +1426,19 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             ),
         ),
         ClassificationRule(
+            priority=395,
+            name="e2e_schedule_metadata",
+            matcher=_path_in({
+                "tests/e2e/timing_estimates.json",
+                "tests/e2e_partition.py",
+                "tests/runtime_strategy_matrix.yaml",
+            }),
+            resolver=_match_result(
+                "e2e_schedule_metadata", _no_models, ["tools"], False,
+            ),
+            covered_by=("TestNoImpact.test_e2e_schedule_metadata_tools_only",),
+        ),
+        ClassificationRule(
             priority=400,
             name="e2e_runner_script",
             matcher=_path_in({
@@ -1395,11 +1450,35 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             covered_by=("TestNoImpact.test_e2e_runner_scripts_trigger_all_models",),
         ),
         ClassificationRule(
+            priority=405,
+            name="legacy_e2e_test_support",
+            matcher=_regex_rule(r"tests/e2e/(?:__init__|conftest|test_[\w_]+)\.py$"),
+            resolver=_match_result(
+                "legacy_e2e_test_support", _no_models, ["tools"], False,
+            ),
+            covered_by=("TestNoImpact.test_legacy_e2e_tests_do_not_select_models",),
+        ),
+        ClassificationRule(
             priority=410,
             name="e2e_waives",
             matcher=_path_equals("tests/e2e/waives.txt"),
             resolver=_match_result("e2e_waives", _all_models),
             covered_by=("TestHarness.test_waives_diff_can_be_refined",),
+        ),
+        ClassificationRule(
+            priority=415,
+            name="standalone_gpu_test_support",
+            matcher=_path_in({
+                "tests/run_qwen3_fi.py",
+                "tests/test_flashinfer_plugin_e2e.py",
+                "tests/test_flashinfer_trt_attention.py",
+                "tests/test_qwen3_flashinfer_e2e.py",
+                "tests/test_tvm_ffi_e2e.py",
+            }),
+            resolver=_match_result(
+                "standalone_gpu_test_support", _no_models, ["tools"], False,
+            ),
+            covered_by=("TestNoImpact.test_standalone_gpu_tests_do_not_select_models",),
         ),
         ClassificationRule(
             priority=420,
@@ -1421,6 +1500,23 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             matcher=_path_startswith("tests/tools/"),
             resolver=_match_result("unit_tools", _no_models),
             covered_by=("TestUnitTiers.test_unit_tier_tools",),
+        ),
+        ClassificationRule(
+            priority=450,
+            name="local_qwen3_hf_fixture",
+            matcher=_regex_rule(r"models/hf/(?:Qwen__Qwen3-0\.6B|qwen3)(?:/.*)?$"),
+            resolver=_match_result(
+                "local_qwen3_hf_fixture",
+                _hf_id_models({"Qwen/Qwen3-0.6B"}),
+            ),
+            covered_by=("TestNoImpact.test_local_qwen3_fixture_scopes_to_qwen3",),
+        ),
+        ClassificationRule(
+            priority=455,
+            name="cpp_example_tool",
+            matcher=_regex_rule(r"examples/.+\.cpp$"),
+            resolver=_match_result("cpp_example_tool", _no_models, ["cpp"], True),
+            covered_by=("TestUnitTiers.test_cpp_example_tool_triggers_cpp_tier",),
         ),
         ClassificationRule(
             priority=460,

--- a/tools/test_impact_fallback_allowlist.txt
+++ b/tools/test_impact_fallback_allowlist.txt
@@ -8,57 +8,12 @@
 # allowlist entry with a rationale.
 
 catch_all .dockerignore # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all CODEOWNERS # tracked path has no precise impact rule yet; catch-all stays conservative
 catch_all Dockerfile # tracked path has no precise impact rule yet; catch-all stays conservative
 catch_all _pyproject_backend.py # root PEP 517/660 backend routes wheel builds and editable installs; catch-all stays conservative
 catch_all conanfile.py # release wheel native packaging recipe; catch-all stays conservative
 catch_all conftest.py # tracked path has no precise impact rule yet; catch-all stays conservative
 catch_all docker-compose.yml # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all examples/trtmc_dataset_benchmark.cpp # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all hf_links_wave1.txt # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/Qwen__Qwen3-0.6B/.gitattributes # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/Qwen__Qwen3-0.6B/LICENSE # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/Qwen__Qwen3-0.6B/config.json # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/Qwen__Qwen3-0.6B/generation_config.json # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/Qwen__Qwen3-0.6B/merges.txt # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/Qwen__Qwen3-0.6B/tokenizer.json # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/Qwen__Qwen3-0.6B/tokenizer_config.json # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/Qwen__Qwen3-0.6B/vocab.json # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/qwen3/config.json # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/qwen3/model.safetensors # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/qwen3/trtmc_decoder/config.json # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/qwen3/trtmc_decoder/transitions.txt # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/qwen3/trtmc_decoder/vocab.txt # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all models/hf/qwen3/trtmc_decoder/weights.txt # tracked path has no precise impact rule yet; catch-all stays conservative
 catch_all pyproject.toml # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all ruff.toml # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/__init__.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/assets/test_image.jpg # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/assets/test_scene.jpg # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/e2e/__init__.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/e2e/conftest.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/e2e/test_bundle_inspect.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/e2e/test_cache_correctness.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/e2e/test_diffusion_pipeline.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/e2e/test_error_handling.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/e2e/test_full_pipeline.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/e2e/test_inference.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/e2e/test_logit_parity.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/e2e/test_runner_parity.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/e2e/test_vl_pipeline.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/e2e/timing_estimates.json # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/e2e_partition.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/engine_defs/__init__.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/run_qwen3_fi.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/runtime_strategy_matrix.yaml # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/test_flashinfer_plugin_e2e.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/test_flashinfer_trt_attention.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/test_qwen3_flashinfer_e2e.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all tests/test_tvm_ffi_e2e.py # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all third_party/stb/stb_image.h # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all third_party/stb/stb_image_resize2.h # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all third_party/stb/stb_image_write.h # tracked path has no precise impact rule yet; catch-all stays conservative
-catch_all verify_encoder.py # tracked path has no precise impact rule yet; catch-all stays conservative
 harness_shared tests/e2e_harness/__init__.py # shared E2E harness surface; broad E2E impact is intentional
 harness_shared tests/e2e_harness/artifact_sink.py # shared E2E harness surface; broad E2E impact is intentional
 harness_shared tests/e2e_harness/conftest_gpu.py # shared E2E harness surface; broad E2E impact is intentional
@@ -70,7 +25,6 @@ harness_shared tests/e2e_harness/registry.py # shared E2E harness surface; broad
 harness_shared tests/e2e_harness/result_schema.py # shared E2E harness surface; broad E2E impact is intentional
 harness_shared tests/e2e_harness/runtime_config.py # shared E2E harness surface; broad E2E impact is intentional
 harness_shared tests/e2e_harness/thresholds/__init__.py # shared E2E harness surface; broad E2E impact is intentional
-harness_shared tests/e2e_harness/test_orchestrator_phases.py # shared E2E harness surface; broad E2E impact is intentional
 no_impact scripts/_build_fp8_onnx_monolithic.py # developer utility script; no CI test impact is intentional
 no_impact scripts/_inject_fp8_qdq_proto.py # developer utility script; no CI test impact is intentional
 no_impact scripts/_mk_fp8_bf16_bundle.py # developer utility script; no CI test impact is intentional
@@ -157,12 +111,10 @@ no_impact tools/diff_vl.py # developer utility script; no CI test impact is inte
 no_impact tools/diffusion_helpers.py # developer utility script; no CI test impact is intentional
 no_impact tools/evaluate_diffusion_vlm_similarity.py # developer utility script; no CI test impact is intentional
 no_impact tools/layer_profiler.py # developer utility script; no CI test impact is intentional
-no_impact tools/make_elf_replay_artifact.py # developer utility script; no CI test impact is intentional
 no_impact tools/nsys_to_layer_timing.py # developer utility script; no CI test impact is intentional
 no_impact tools/perf_compare.py # developer utility script; no CI test impact is intentional
 no_impact tools/perfdb.py # developer utility script; no CI test impact is intentional
 no_impact tools/profile_report.py # developer utility script; no CI test impact is intentional
-no_impact tools/prepare_elf_model_dir.py # developer utility script; no CI test impact is intentional
 no_impact tools/sol_estimate.py # developer utility script; no CI test impact is intentional
 no_impact tools/test_graph_ops.py # developer utility script; no CI test impact is intentional
 no_impact tools/test_impact.py # developer utility script; no CI test impact is intentional
@@ -170,7 +122,6 @@ no_impact tools/test_impact_fallback_allowlist.txt # validation metadata; no CI 
 no_impact tools/test_runner_parity.py # developer utility script; no CI test impact is intentional
 no_impact tools/tool_helpers.py # developer utility script; no CI test impact is intentional
 no_impact tools/trtmc_profile.py # developer utility script; no CI test impact is intentional
-no_impact tools/validate_elf_replay_artifact.py # developer utility script; no CI test impact is intentional
 no_impact tools/validate_dit.py # developer utility script; no CI test impact is intentional
 no_impact tools/validate_t5.py # developer utility script; no CI test impact is intentional
 no_impact tools/validation/timm_vit/benchmark_trt_paths.py # developer validation helper; no CI test impact is intentional
@@ -198,7 +149,6 @@ shared_builder_module python/tensorrt_model_connect/kernels/__init__.py # shared
 shared_builder_module python/tensorrt_model_connect/kernels/flashinfer_decode.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/parallel_config.py # shared Python builder surface for tensor-parallel build config and sharding; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/pipeline.py # shared Python builder surface; broad builder impact is intentional
-shared_builder_module python/tensorrt_model_connect/python_profile_requirements/internlm.lock.txt # shared Python profile lockfile; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/python_profiles.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/python_profiles.toml # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/quantization/__init__.py # shared Python builder surface; broad builder impact is intentional


### PR DESCRIPTION
## Background
PR #257 exposed that several support files still fell through to broad all-model E2E selection. Some of those files only affect scheduling, standalone tests, local fixtures, examples, or image-only helpers, so they should not make the CI run every model.

## Exit Criteria
- Support/config/test-only files that do not affect all model runtime paths avoid all-model E2E selection.
- Existing broad shared surfaces remain conservative and visible in the fallback allowlist.
- The impact map validates cleanly after rebasing onto `github/main`.

## Implementation
- Added named impact rules for E2E scheduling metadata, legacy direct E2E support files, standalone GPU test files, local Qwen3 fixtures, C++ example tools, and STB image headers.
- Kept mel-spectrogram helper scope aligned with the upstream scoped-helper rule from PR #257.
- Removed obsolete reviewed fallback allowlist entries now covered by precise classifiers.
- Added focused unit coverage for the new classifications.

## Validation
- `python3 tools/test_impact.py --validate`: passed.
- `docker run --rm -v /workspace/users/yizhuoz:/workspace/users/yizhuoz -w /workspace/users/yizhuoz/worktrees/trtmc-pr257-e2e-impact fdac1e509fdb bash -lc 'git config --global --add safe.directory /workspace/users/yizhuoz/worktrees/trtmc-pr257-e2e-impact && python3 -m pytest tests/tools/test_test_impact.py -q'`: passed, 165 tests.\n- `python3 tools/test_impact.py --base github/main --head HEAD --json`: PR impact is tools-only, selecting `tests/tools/test_test_impact.py` and no E2E models.\n- `git diff --check`: passed.\n\n## Notes For Future Readers\n- Review `tools/test_impact.py` first; the tests mirror each added classifier.\n- The remaining broad fallback entries are intentionally conservative shared surfaces, not missed cleanup from this change.