### PR TITLE
fix(runtime): size vision-language KV cache from the engine dtype

### DIFF
--- a/src/runtime/models/vision_language/plugin.cpp
+++ b/src/runtime/models/vision_language/plugin.cpp
@@ -152,8 +152,7 @@ class VLPlugin final : public IPipelinePlugin {
         const std::string cache_k_name =
             kv_names.cache_k.empty() ? std::string("cache_k_0") : kv_names.cache_k.front();
         int32_t kv_dim = decoder_cache_row_width(*loaded.module, cache_k_name, ctx.config);
-        // FIX: read the engine's ACTUAL cache dtype (qwen_vl pins KV to fp32 regardless of
-        // --precision; deriving from the precision string undersizes the buffers for bf16/fp16).
+        // KV dtype can differ from --precision; size the cache from the engine, not the string.
         DType cache_dtype = loaded.module->tensor_dtype(cache_k_name);
         std::unique_ptr<IInferenceState> state =
             std::make_unique<KvCache>(ctx.config.num_layers, ctx.config.max_cache_length, kv_dim,

--- a/src/runtime/models/vision_language/plugin.cpp
+++ b/src/runtime/models/vision_language/plugin.cpp
@@ -152,7 +152,9 @@ class VLPlugin final : public IPipelinePlugin {
         const std::string cache_k_name =
             kv_names.cache_k.empty() ? std::string("cache_k_0") : kv_names.cache_k.front();
         int32_t kv_dim = decoder_cache_row_width(*loaded.module, cache_k_name, ctx.config);
-        DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
+        // FIX: read the engine's ACTUAL cache dtype (qwen_vl pins KV to fp32 regardless of
+        // --precision; deriving from the precision string undersizes the buffers for bf16/fp16).
+        DType cache_dtype = loaded.module->tensor_dtype(cache_k_name);
         std::unique_ptr<IInferenceState> state =
             std::make_unique<KvCache>(ctx.config.num_layers, ctx.config.max_cache_length, kv_dim,
                                       stream, cache_dtype, std::move(kv_names));


### PR DESCRIPTION
The vision_language KvCache sized its key/value buffers from the --precision string (e.g. bf16 -> 2 bytes per element), but the qwen_vl decoder keeps its KV tensors in fp32 regardless of --precision. With a bf16 or fp16 base the engine's fp32 present_k/present_v writes then overflowed the undersized buffers and corrupted the heap: usually garbage output, intermittently a Myelin l2cm illegal-memory-access crash.

Read the cache element dtype from the engine via
TrtModule::tensor_dtype(cache_k_name) instead of inferring it from the precision string, so the buffers always match what the engine writes. This unblocks reduced-precision (bf16/fp16) vision-language decoding.