### PR TITLE
fix(quant): int8 SmoothQuant and fp8-on-fp16-base accumulation

### DIFF
--- a/python/tensorrt_model_connect/fp8_calibrate.py
+++ b/python/tensorrt_model_connect/fp8_calibrate.py
@@ -23,6 +23,8 @@ import re
 import sys
 from typing import Callable, TYPE_CHECKING
 
+import numpy as np
+
 if TYPE_CHECKING:
     import torch.nn
 
@@ -154,6 +156,16 @@ def extract_scales_from_state_dict(
     scales: dict[str, dict[str, float]] = {}
 
     for key, value in state_dict.items():
+        # SmoothQuant per-input-channel factor lives on the input quantizer as
+        # ``_pre_quant_scale`` (not an ``_amax``). Capture it so the format can
+        # apply the smoothing that the calibrated (smoothed-weight) scales assume.
+        m_pqs = re.match(r"(.+)\.input_quantizer\._pre_quant_scale$", key)
+        if m_pqs is not None:
+            prefix = m_pqs.group(1)
+            pqs = value.detach().cpu().numpy() if hasattr(value, "detach") else value
+            pqs = np.asarray(pqs, dtype=np.float32).reshape(-1)
+            scales.setdefault(prefix, {})["pre_quant_scale"] = pqs
+            continue
         if "_amax" not in key:
             continue
         m = re.match(r"(.+)\.([A-Za-z0-9_]+_quantizer)\._amax", key)
@@ -165,8 +177,15 @@ def extract_scales_from_state_dict(
         scale_field = _QUANTIZER_SCALE_FIELDS.get(qtype)
         if scale_field is None:
             continue
-        amax = value.item() if hasattr(value, "item") else float(value)
-        scale = amax / maxbound
+        # amax may be a scalar (per-tensor, e.g. FP8 / activations) or a
+        # multi-element tensor (per-channel weights, e.g. INT8 weight_quantizer
+        # with shape [out, 1]). Scalar -> float; per-channel -> flat np.ndarray
+        # (formats.py consumes either; it sets IQuantizeLayer.axis for the
+        # per-channel case). Calling .item() on a multi-element amax raised
+        # "Tensor with N elements cannot be converted to Scalar".
+        arr = value.detach().cpu().numpy() if hasattr(value, "detach") else value
+        arr = np.asarray(arr, dtype=np.float32).reshape(-1)
+        scale = float(arr[0]) / maxbound if arr.size == 1 else arr / maxbound
 
         if prefix not in scales:
             scales[prefix] = {}

--- a/python/tensorrt_model_connect/quantization/formats.py
+++ b/python/tensorrt_model_connect/quantization/formats.py
@@ -239,9 +239,25 @@ class INT8SmoothQuantFormat:
 
         out_trt_dtype = activation.dtype
 
+        # SmoothQuant: migrate per-input-channel range from activations into
+        # weights. ModelOpt stores pre_quant_scale (=1/s) on the input quantizer
+        # and calibrates the weight amax on the SMOOTHED weight. MC loads the
+        # ORIGINAL weights, so reproduce the smoothing here: activations are
+        # scaled by pre_quant_scale and weights by 1/pre_quant_scale (per input
+        # channel) — x@W == (x*pqs)@(W/pqs). When pre_quant_scale is absent the
+        # format degrades to plain per-channel-weight int8.
+        pqs = getattr(scales, "pre_quant_scale", None)
+        weight_for_const = weight_array
+        if pqs is not None:
+            pqs = np.asarray(pqs, dtype=np.float32).reshape(-1)  # [lhs_width=in]
+            inv = (1.0 / pqs).astype(np.float32)
+            weight_for_const = np.ascontiguousarray(
+                weight_array.astype(np.float32) * inv[:, None]).astype(
+                    weight_array.dtype)
+
         # Weight Q/DQ: per-channel (axis=1 for [in, out] layout)
         weight_const = graph_ops.add_constant(
-            network, (lhs_width, rhs_width), weight_array, dtype=dtype)
+            network, (lhs_width, rhs_width), weight_for_const, dtype=dtype)
         w_scale = np.asarray(scales.weight_scale, dtype=np.float32)
         if w_scale.ndim == 0:
             w_scale = np.full(rhs_width, float(w_scale), dtype=np.float32)
@@ -253,13 +269,26 @@ class INT8SmoothQuantFormat:
             q_w.get_output(0), w_scale_t, out_trt_dtype)
         dq_w.axis = 1
 
+        # SmoothQuant activation scaling: x_smooth = x * pre_quant_scale
+        # (per input channel), broadcast over the leading (token) dim.
+        act = activation
+        if pqs is not None:
+            pqs_t = graph_ops.add_constant(
+                network, (1, lhs_width), pqs.reshape(1, lhs_width),
+                dtype=np.float32)
+            pqs_in = pqs_t
+            if activation.dtype != trt.float32:
+                pqs_in = network.add_cast(pqs_t, activation.dtype).get_output(0)
+            act = network.add_elementwise(
+                activation, pqs_in, trt.ElementWiseOperation.PROD).get_output(0)
+
         # Activation Q/DQ: per-tensor
         a_scale = np.array(
             [scales.input_scale] if np.isscalar(scales.input_scale)
             else scales.input_scale, dtype=np.float32)
         a_scale_t = graph_ops.add_constant(
             network, a_scale.shape, a_scale, dtype=np.float32)
-        q_a = network.add_quantize(activation, a_scale_t, trt.int8)
+        q_a = network.add_quantize(act, a_scale_t, trt.int8)
         dq_a = network.add_dequantize(
             q_a.get_output(0), a_scale_t, out_trt_dtype)
 

--- a/python/tensorrt_model_connect/quantization/formats.py
+++ b/python/tensorrt_model_connect/quantization/formats.py
@@ -130,8 +130,15 @@ class FP8Format:
         trt = trt_compat.get_trt()
 
         out_trt_dtype = activation.dtype
+        # With fp16 base, materializing the fp8 GEMM result in fp16 overflows
+        # fp16's narrow exponent range on bf16-native models (garbage output):
+        # the running partial sum of many dequantized terms exceeds ~65504.
+        # Dequantize/accumulate in fp32 ONLY for fp16 base, then cast back to the
+        # base dtype. bf16/fp32 base keep their native dtype (range headroom) so
+        # the fast bf16 path sees no perf regression.
+        acc_dtype = trt.float32 if out_trt_dtype == trt.float16 else out_trt_dtype
 
-        # Weight Q/DQ: constant -> quantize(FP8) -> dequantize(work_dtype)
+        # Weight Q/DQ: constant -> quantize(FP8) -> dequantize(acc_dtype)
         weight_const = graph_ops.add_constant(
             network, (lhs_width, rhs_width), weight_array, dtype=dtype)
         w_scale = np.array(
@@ -141,9 +148,9 @@ class FP8Format:
             network, w_scale.shape, w_scale, dtype=np.float32)
         q_w = network.add_quantize(weight_const, w_scale_t, trt.fp8)
         dq_w = network.add_dequantize(
-            q_w.get_output(0), w_scale_t, out_trt_dtype)
+            q_w.get_output(0), w_scale_t, acc_dtype)
 
-        # Activation Q/DQ: input -> quantize(FP8) -> dequantize(work_dtype)
+        # Activation Q/DQ: input -> quantize(FP8) -> dequantize(acc_dtype)
         a_scale = np.array(
             [scales.input_scale] if np.isscalar(scales.input_scale)
             else scales.input_scale, dtype=np.float32)
@@ -151,7 +158,7 @@ class FP8Format:
             network, a_scale.shape, a_scale, dtype=np.float32)
         q_a = network.add_quantize(activation, a_scale_t, trt.fp8)
         dq_a = network.add_dequantize(
-            q_a.get_output(0), a_scale_t, out_trt_dtype)
+            q_a.get_output(0), a_scale_t, acc_dtype)
 
         # Matmul on dequantized tensors (TRT fuses Q/DQ + matmul)
         mm = network.add_matrix_multiply(

--- a/python/tensorrt_model_connect/quantization/scale_providers.py
+++ b/python/tensorrt_model_connect/quantization/scale_providers.py
@@ -85,6 +85,11 @@ class ModelOptCalibrationProvider:
     # Map our format names to ModelOpt config names
     _MTQ_CONFIG_NAMES: dict[str, str] = {
         "fp8": "FP8_DEFAULT_CFG",
+        # INT8SmoothQuantFormat now applies SmoothQuant smoothing in the graph
+        # (activations *pre_quant_scale, weights /pre_quant_scale), so it is
+        # paired with INT8_SMOOTHQUANT_CFG. The calibrated per-channel weight
+        # amax corresponds to the smoothed weights, and pre_quant_scale is
+        # extracted + threaded through LayerScales so the build reproduces it.
         "int8_sq": "INT8_SMOOTHQUANT_CFG",
         "int4_awq": "INT4_AWQ_CFG",
         "nvfp4": "NVFP4_DEFAULT_CFG",
@@ -199,6 +204,7 @@ class ModelOptCalibrationProvider:
             scales[mapped] = LayerScales(
                 input_scale=scale_dict["input_scale"],
                 weight_scale=scale_dict["weight_scale"],
+                pre_quant_scale=scale_dict.get("pre_quant_scale"),
             )
 
         logger.info("Extracted scales for %d layers", len(scales))

--- a/python/tensorrt_model_connect/quantization/scales.py
+++ b/python/tensorrt_model_connect/quantization/scales.py
@@ -25,6 +25,11 @@ class LayerScales:
     weight_scale: float | np.ndarray = 1.0
     output_scale: float | np.ndarray = 1.0
     block_size: int | None = None
+    # Per-input-channel SmoothQuant factor (ModelOpt ``input_quantizer.
+    # _pre_quant_scale``). When present, the format smooths activations by
+    # ``*pre_quant_scale`` and weights by ``/pre_quant_scale`` so the calibrated
+    # (smoothed-weight) scales match what runs. None for non-SmoothQuant formats.
+    pre_quant_scale: np.ndarray | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {}
@@ -36,6 +41,8 @@ class LayerScales:
                 d[k] = v
         if self.block_size is not None:
             d["block_size"] = self.block_size
+        if self.pre_quant_scale is not None:
+            d["pre_quant_scale"] = np.asarray(self.pre_quant_scale).tolist()
         return d
 
     @staticmethod
@@ -47,6 +54,9 @@ class LayerScales:
                 kwargs[k] = np.array(v) if isinstance(v, list) else v
         if "block_size" in d:
             kwargs["block_size"] = d["block_size"]
+        if "pre_quant_scale" in d:
+            kwargs["pre_quant_scale"] = np.asarray(d["pre_quant_scale"],
+                                                   dtype=np.float32)
         return LayerScales(**kwargs)
 
 


### PR DESCRIPTION
## What
Two quant-format correctness fixes:
- **int8 SmoothQuant** — correct per-channel weight scales and apply SmoothQuant smoothing (migrate the per-input-channel activation range into the weights via `pre_quant_scale`) so the graph matches the ModelOpt-calibrated (smoothed-weight) scales. Prior int8 was per-tensor-only and mismatched the calibrated scales.
- **fp8 accumulation** — accumulate the fp8 matmul in fp32 on an fp16 base for numerical stability.

## Validation (rebased on ToT · 805 MMMU-Pro · calib-512 real manifest)
int8 **37.9%** (ref master 42.0%), garbage=0. The residual vs master is the shared upstream vision-encoder delta (see stack note), not this change — int8 tracks its expected drop from bf16.

Part of the VL quant/precision stack: **#263 → #264 → #430 → #431 → #390**.
