### PR TITLE
chore(debug): env-gated VL and quant instrumentation hooks

### DIFF
--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -982,6 +982,8 @@ def build_bundle(
         extra_kwargs['quant_ctx'] = quant_ctx
     if _call_supports_kwarg(plugin.build_engine, 'parallel_config'):
         extra_kwargs['parallel_config'] = parallel
+    if __import__("os").environ.get("TRTMC_QUANT_DBG"):
+        __import__("sys").stderr.write("[QDBG eb] extra_kwargs=%s quant_ctx_None=%s supports_quant_ctx=%s\n" % (list(extra_kwargs.keys()), quant_ctx is None, _call_supports_kwarg(plugin.build_engine, "quant_ctx")))
 
     def _split_timing_cache_scope(role: str) -> str:
         quant_label = quantize or "noquant"

--- a/python/tensorrt_model_connect/quantization/context.py
+++ b/python/tensorrt_model_connect/quantization/context.py
@@ -44,6 +44,8 @@ class QuantContext:
         """
         from .. import graph_ops
 
+        if __import__("os").environ.get("TRTMC_QUANT_DBG"):
+            __import__("sys").stderr.write("[QDBG] mqm name=%r sq=%s scale=%s dyn=%s\n" % (weight_name, self.profile.should_quantize(weight_name), self.profile.scale_map.get(weight_name) is not None, self.profile.scale_map.dynamic))
         if self.profile.should_quantize(weight_name):
             scales = self.profile.scale_map.get(weight_name)
             if scales is None:

--- a/src/runtime/core/kv_cache.cpp
+++ b/src/runtime/core/kv_cache.cpp
@@ -5,6 +5,9 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <cstdlib>
+#include <iostream>
+#include <cstdint>
 #include <stdexcept>
 
 namespace trtmc {
@@ -331,6 +334,28 @@ void KvCache::advance(int32_t n_tokens) {
                             cudaMemcpyDeviceToDevice, stream_);
         }
         // position_ stays at max_length_ (cache is full, all slots visible)
+    }
+
+    if (std::getenv("TRTMC_VL_DBG")) {
+        static int kvdbg_adv = 0;
+        if (kvdbg_adv < 2) {
+            cudaStreamSynchronize(stream_);
+            auto dump = [&](const char* tag, void* dptr) {
+                unsigned char buf[64];
+                cudaMemcpy(buf, dptr, 64, cudaMemcpyDeviceToHost);
+                std::cerr << "[KVDBG] adv=" << kvdbg_adv << " elem_bytes=" << cache_element_size_ << " " << tag << ":";
+                for (int j = 0; j < 8; ++j) {
+                    float v;
+                    if (cache_element_size_ == 2) { uint16_t b = reinterpret_cast<uint16_t*>(buf)[j]; uint32_t u = static_cast<uint32_t>(b) << 16; std::memcpy(&v, &u, 4); }
+                    else { v = reinterpret_cast<float*>(buf)[j]; }
+                    std::cerr << " " << v;
+                }
+                std::cerr << "\n";
+            };
+            dump("present_k0", present_k_[0].data());
+            dump("cache_k0", cache_k_[0].data());
+            ++kvdbg_adv;
+        }
     }
 }
 

--- a/src/runtime/models/vision_language/pipeline.cpp
+++ b/src/runtime/models/vision_language/pipeline.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <cstdlib>
 #include <iostream>
 #include <stdexcept>
 
@@ -322,6 +323,17 @@ void VLPipeline::run_text_step(int32_t token_id, std::vector<float>& logits) {
     auto n = it->second.numel();
     logits.resize(static_cast<std::size_t>(n));
     std::memcpy(logits.data(), it->second.data, n * sizeof(float));
+    if (std::getenv("TRTMC_VL_DBG")) {
+        static int vldbg_step = 0;
+        const int32_t* pid = nullptr; const float* msk = nullptr;
+        auto pit = inputs.find("position_id"); if (pit != inputs.end()) pid = static_cast<const int32_t*>(pit->second.data);
+        auto mit = inputs.find("attention_mask"); if (mit != inputs.end()) msk = static_cast<const float*>(mit->second.data);
+        int amax = 0; float mv = logits.empty() ? 0.0f : logits[0];
+        for (std::size_t k = 1; k < logits.size(); ++k) if (logits[k] > mv) { mv = logits[k]; amax = (int)k; }
+        std::cerr << "[VLDBG] step=" << vldbg_step++ << " tok_in=" << token_id << " pos=" << (pid?pid[0]:-1)
+                  << " argmax=" << amax << " maxlogit=" << mv << " mask0=" << (msk?msk[0]:-9.0f)
+                  << " L012=" << logits[0] << "," << logits[1] << "," << logits[2] << "\n";
+    }
 
     state_->advance();
 }
@@ -405,6 +417,17 @@ void VLPipeline::run_text_step_with_embed(int32_t token_id, const float* input_e
     auto n = it->second.numel();
     logits.resize(static_cast<std::size_t>(n));
     std::memcpy(logits.data(), it->second.data, n * sizeof(float));
+    if (std::getenv("TRTMC_VL_DBG")) {
+        static int vldbg_step = 0;
+        const int32_t* pid = nullptr; const float* msk = nullptr;
+        auto pit = inputs.find("position_id"); if (pit != inputs.end()) pid = static_cast<const int32_t*>(pit->second.data);
+        auto mit = inputs.find("attention_mask"); if (mit != inputs.end()) msk = static_cast<const float*>(mit->second.data);
+        int amax = 0; float mv = logits.empty() ? 0.0f : logits[0];
+        for (std::size_t k = 1; k < logits.size(); ++k) if (logits[k] > mv) { mv = logits[k]; amax = (int)k; }
+        std::cerr << "[VLDBG] step=" << vldbg_step++ << " tok_in=" << token_id << " pos=" << (pid?pid[0]:-1)
+                  << " argmax=" << amax << " maxlogit=" << mv << " mask0=" << (msk?msk[0]:-9.0f)
+                  << " L012=" << logits[0] << "," << logits[1] << "," << logits[2] << "\n";
+    }
 
     state_->advance();
 }


### PR DESCRIPTION
**Draft — reference only, not for merge.**

The env-gated debug instrumentation we used to root-cause the vision-language
KV-cache buffer bug (#262) and the VL quantization no-op (#264). All output is
behind environment variables and produces nothing when unset:

- `TRTMC_VL_DBG` — `[VLDBG]` per-step pos/argmax/logits in `run_text_step`, and
  `[KVDBG]` cache-vs-present byte dumps in `KvCache::advance`.
- `TRTMC_QUANT_DBG` — `[QDBG]` `maybe_quantized_matmul` call tracing and the
  `quant_ctx` handoff in the engine builder.

Parked here so the hooks are easy to find again; the mergeable fixes ship
without them.
