### PR TITLE
feat(runtime): report prefill/decode timing for the Qwen-VL pipeline

### DIFF
--- a/src/runtime/models/qwen_vl/pipeline.cpp
+++ b/src/runtime/models/qwen_vl/pipeline.cpp
@@ -204,6 +204,8 @@ TextResult QwenVlPipeline::generate(const std::string& prompt, const GenerateCon
 
     auto result = TextResult{std::move(text), std::move(new_tokens)};
     result.setup_ms = last_setup_ms_;
+    result.prefill_ms = last_prefill_ms_;
+    result.decode_ms = last_decode_ms_;
     return result;
 }
 
@@ -632,6 +634,8 @@ TextResult QwenVlPipeline::generate(const std::string& prompt, const float* imag
                                     out.end());
     auto result = TextResult{tokenizer_->decode(new_tokens), std::move(new_tokens)};
     result.setup_ms = last_setup_ms_;
+    result.prefill_ms = last_prefill_ms_;
+    result.decode_ms = last_decode_ms_;
     return result;
 }
 
@@ -668,11 +672,15 @@ std::vector<int32_t> QwenVlPipeline::generate_from_ids(const std::vector<int32_t
     reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
+    const auto t_prefill_start = std::chrono::steady_clock::now();
 
     for (std::size_t i = 0; i + 1 < input_ids.size(); ++i)
         run_text_step(input_ids[i], logits);
 
     run_text_step(input_ids.back(), logits);
+    const auto t_decode_start = std::chrono::steady_clock::now();
+    last_prefill_ms_ =
+        std::chrono::duration<double, std::milli>(t_decode_start - t_prefill_start).count();
 
     std::vector<int32_t> output = input_ids;
     const int32_t vocab_size = static_cast<int32_t>(logits.size());
@@ -685,6 +693,9 @@ std::vector<int32_t> QwenVlPipeline::generate_from_ids(const std::vector<int32_t
         run_text_step(result.token_id, logits);
     }
 
+    last_decode_ms_ = std::chrono::duration<double, std::milli>(
+                          std::chrono::steady_clock::now() - t_decode_start)
+                          .count();
     return output;
 }
 
@@ -702,6 +713,7 @@ std::vector<int32_t> QwenVlPipeline::generate_vl_from_ids(
     reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
+    const auto t_prefill_start = std::chrono::steady_clock::now();
     const bool use_mrope = text_decoder_->has_input("mrope_position_ids");
     const auto mrope =
         use_mrope ? qwen_vl_build_mrope_positions(input_ids, config_.image_token_id, num_features,
@@ -718,10 +730,16 @@ std::vector<int32_t> QwenVlPipeline::generate_vl_from_ids(
         }
     }
     state_->mark_prefill_complete();
+    const auto t_decode_start = std::chrono::steady_clock::now();
+    last_prefill_ms_ =
+        std::chrono::duration<double, std::milli>(t_decode_start - t_prefill_start).count();
 
     std::vector<int32_t> output = input_ids;
     run_vl_decode_loop(active_sampler, params, output, logits, max_new_tokens,
                        use_mrope ? mrope.next_position : -1);
+    last_decode_ms_ = std::chrono::duration<double, std::milli>(
+                          std::chrono::steady_clock::now() - t_decode_start)
+                          .count();
     return output;
 }
 

--- a/src/runtime/models/qwen_vl/pipeline.h
+++ b/src/runtime/models/qwen_vl/pipeline.h
@@ -93,6 +93,8 @@ class QwenVlPipeline final : public IPipeline {
     std::unique_ptr<TrtModule> vision_encoder_;
     std::unique_ptr<QwenVlInferenceState> state_;
     double last_setup_ms_{0.0};
+    double last_prefill_ms_{0.0};
+    double last_decode_ms_{0.0};
     QwenVlConfig config_;
     QwenVlPreprocessConfig vl_preprocess_;
     cudaStream_t stream_;


### PR DESCRIPTION
## What
Report real **prefill/decode timing** for the Qwen-VL pipeline so `trtmc run --benchmark` produces meaningful `decode_ms` / `tokens_per_sec` for VL (previously `decode_ms=0`, `tokens_per_sec=inf` — the pipeline timed only setup).

Times the prefill and decode phases in **both** `generate_vl_from_ids` (covering ToT's batched *and* token-by-token prefill paths) and `generate_from_ids`, and surfaces them on `TextResult` (which already carries `prefill_ms`/`decode_ms`).

## Note
This **re-ports the intent of the original #267** onto the refactored `qwen_vl` runtime. The original patched `src/runtime/models/vision_language/pipeline.cpp`, which no longer exists on ToT (refactored to per-family `qwen_vl/`), and assumed token-by-token prefill (ToT now has batched).

## Sanity
`trtmc run ... --benchmark 3 --warmup 1` on a Qwen3-VL-2B bf16 engine:
- before: `decode_ms=0.00 tokens_per_sec=inf`
- after: `prefill_ms=24.20 decode_ms=265.56 tokens_per_sec=241.00` — matches independent engine_timing decode (~247-265 tok/s).
