### PR TITLE
ci: cover E2E runner wiring changes

### DIFF
--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -142,9 +142,9 @@ def test_python_package_coverage_gate_excludes_family_owned_modules() -> None:
 
 def test_full_e2e_collection_uses_model_e2e_files_with_visible_errors() -> None:
     text = (REPO_ROOT / "scripts" / "run_e2e_parallel.sh").read_text()
-    full_mode = text.split("# Full mode: collect only canonical model E2E files", maxsplit=1)[
-        1
-    ].split("fi\nTOTAL=", maxsplit=1)[0]
+    full_mode = text.split("mapfile -t E2E_COLLECT_FILES", maxsplit=1)[1].split(
+        "\nTOTAL=", maxsplit=1
+    )[0]
     assert "find tests/e2e/models -mindepth 2 -maxdepth 2 -type f" in full_mode
     assert "-name 'test_*_e2e.py'" in full_mode
     assert '"$HF_PYTHON" -m pytest "${E2E_COLLECT_FILES[@]}" --co -q' in full_mode

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1211,6 +1211,7 @@ class TestNoImpact:
         match = test_impact.classify_file("scripts/run_e2e_parallel.sh", imap)
         assert match.rule == "e2e_runner_script"
         assert match.models == imap.all_model_names
+        assert match.unit_tiers == ["tools"]
 
     def test_scripts_no_impact(self, imap):
         """scripts/ -> no E2E tests."""
@@ -2865,6 +2866,22 @@ class TestCoverageMapIntegration:
         assert result.e2e_models == []
         assert result.tools_tests == ["tests/e2e_harness/test_orchestrator_phases.py"]
         assert "tools" not in result.fallback_tiers
+
+    @pytest.mark.parametrize("coverage_map", [None, {}])
+    def test_e2e_runner_selects_explicit_tools_tests(self, imap, coverage_map):
+        """Shell runner edits select tests that Python coverage cannot discover."""
+        result = test_impact.analyze_impact(
+            ["scripts/run_e2e_parallel.sh"],
+            imap,
+            coverage_map=coverage_map,
+        )
+
+        assert result.unit_tiers == ["tools"]
+        assert result.tools_tests == [
+            "tests/tools/test_github_actions_ci.py",
+            "tests/tools/test_schedule_e2e.py",
+        ]
+        assert result.fallback_tiers == []
 
     def test_github_ci_config_selects_tools_tier(self, imap):
         """CI config edits must not be classified as unit-test no-impact."""

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1647,7 +1647,7 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
                 "scripts/schedule_e2e.py",
                 "scripts/warm_hf_cache.py",
             }),
-            resolver=_match_result("e2e_runner_script", _all_models),
+            resolver=_match_result("e2e_runner_script", _all_models, ["tools"]),
             covered_by=("TestNoImpact.test_e2e_runner_scripts_trigger_all_models",),
         ),
         ClassificationRule(
@@ -1834,6 +1834,23 @@ def _direct_python_test_targets(changed_files: List[str]) -> tuple[List[str], Li
     return sorted(builder_tests), sorted(tools_tests)
 
 
+_EXPLICIT_TOOLS_TEST_TARGETS = {
+    "scripts/run_e2e_parallel.sh": (
+        "tests/tools/test_github_actions_ci.py",
+        "tests/tools/test_schedule_e2e.py",
+    ),
+}
+
+
+def _explicit_tools_test_targets(changed_files: List[str]) -> List[str]:
+    """Return tests for non-Python CI surfaces that coverage cannot observe."""
+    tests: Set[str] = set()
+    for raw_path in changed_files:
+        path = raw_path.replace("\\", "/").strip("/")
+        tests.update(_EXPLICIT_TOOLS_TEST_TARGETS.get(path, ()))
+    return sorted(tests)
+
+
 def _filter_models_by_ci_tier(
     models: List[str],
     imap: ImpactMap,
@@ -1936,6 +1953,9 @@ def analyze_impact(
         fallback_tiers = sel.fallback_tiers
 
     direct_builder_tests, direct_tools_tests = _direct_python_test_targets(changed_files)
+    direct_tools_tests = sorted(
+        set(direct_tools_tests).union(_explicit_tools_test_targets(changed_files))
+    )
     if direct_builder_tests:
         builder_tests = sorted(set(builder_tests).union(direct_builder_tests))
     if direct_tools_tests:


### PR DESCRIPTION
## Background
PR #271 exposed a CI wiring regression after the grouped-bundle runner changes from #260. A static CI test located the full E2E collection block by an outdated comment, while impact analysis did not select that test when the non-Python runner changed.

## Exit Criteria
- Keep the existing E2E collection assertions without depending on comment text.
- Select the CI wiring and scheduler tests whenever `scripts/run_e2e_parallel.sh` changes, with or without a coverage map.
- Preserve the grouped-bundle runner behavior from #260.

## Implementation
- Locate the collection block by its stable `mapfile` and `TOTAL` shell commands while retaining all existing assertions.
- Classify E2E runner scripts as tools-tier changes.
- Add explicit tools-test targets for the shell runner because Python coverage cannot observe tests that inspect or invoke it.
- Add regression coverage for both absent and empty coverage maps.

## Validation
- `python3 -m pytest tests/tools/test_github_actions_ci.py tests/tools/test_test_impact.py -q`: passed, 216 tests.
- `python3 -m pytest tests/tools/test_schedule_e2e.py -q`: passed, 14 tests.
- `python3 -m ruff check tools/test_impact.py tests/tools/test_github_actions_ci.py tests/tools/test_test_impact.py`: passed.
- `git diff --check`: passed.
- `PYTHONPATH=python python3 tools/test_impact.py --files scripts/run_e2e_parallel.sh --json`: selected the tools tier plus `test_github_actions_ci.py` and `test_schedule_e2e.py`.
- `python3 -m pytest tests/tools -q --deselect tests/tools/test_model_plugin_encapsulation_static.py::test_model_owned_python_does_not_import_sibling_models`: passed, 1147 tests with one baseline test deselected.
- `python3 -m pytest tests/tools -q`: the hotfix tests passed, but the suite retains one pre-existing #260 failure where the model-isolation guard classifies imports of shared `_bundle_group_runner` as sibling-model imports.

## Notes For Future Readers
- Review `tools/test_impact.py` first, then the two regression test files.
- This PR does not change E2E collection or scheduling behavior and does not relax any of the collection assertions.
