### PR TITLE
fix(e2e): move shared bundle grouping into harness

### DIFF
--- a/tests/e2e/models/canary/runner.py
+++ b/tests/e2e/models/canary/runner.py
@@ -8,7 +8,7 @@ import sys
 from contextlib import contextmanager
 from pathlib import Path
 
-from tests.e2e.models._bundle_group_runner import (
+from tests.e2e_harness.bundle_group_runner import (
     model_case_names_for_dir,
     run_model_e2e_case_or_group,
 )

--- a/tests/e2e/models/nemotron_labs_diffusion/runner.py
+++ b/tests/e2e/models/nemotron_labs_diffusion/runner.py
@@ -8,7 +8,7 @@ import sys
 from contextlib import contextmanager
 from pathlib import Path
 
-from tests.e2e.models._bundle_group_runner import (
+from tests.e2e_harness.bundle_group_runner import (
     model_case_names_for_dir,
     run_model_e2e_case_or_group,
 )

--- a/tests/e2e_harness/bundle_group_runner.py
+++ b/tests/e2e_harness/bundle_group_runner.py
@@ -1,4 +1,4 @@
-"""Scoped grouped-bundle execution support for model-owned E2E entrypoints."""
+"""Shared grouped-bundle execution support for model-owned E2E entrypoints."""
 
 from __future__ import annotations
 

--- a/tests/tools/test_model_e2e_runner_grouping.py
+++ b/tests/tools/test_model_e2e_runner_grouping.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-from tests.e2e.models import _bundle_group_runner as model_case_runner
+from tests.e2e_harness import bundle_group_runner as model_case_runner
 
 
 def _load_runner(family: str, module_name: str):

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1121,11 +1121,12 @@ class TestSafetyNet:
     def test_e2e_bundle_group_runner(self, imap):
         """Changing grouped-bundle helper -> only opt-in grouped families."""
         match = test_impact.classify_file(
-            "tests/e2e/models/_bundle_group_runner.py",
+            "tests/e2e_harness/bundle_group_runner.py",
             imap,
         )
         assert match.rule == "e2e_bundle_group_runner"
         assert match.models == ["canary-grouped", "nld-grouped"]
+        assert match.unit_tiers == ["tools"]
         assert "speech-streaming-case" not in match.models
 
     def test_e2e_model_owned_waives_self(self, imap):
@@ -2881,6 +2882,19 @@ class TestCoverageMapIntegration:
             "tests/tools/test_github_actions_ci.py",
             "tests/tools/test_schedule_e2e.py",
         ]
+        assert result.fallback_tiers == []
+
+    @pytest.mark.parametrize("coverage_map", [None, {}])
+    def test_bundle_group_runner_selects_grouping_tests(self, imap, coverage_map):
+        """Shared grouping helper edits select their focused tools tests."""
+        result = test_impact.analyze_impact(
+            ["tests/e2e_harness/bundle_group_runner.py"],
+            imap,
+            coverage_map=coverage_map,
+        )
+
+        assert result.unit_tiers == ["tools"]
+        assert result.tools_tests == ["tests/tools/test_model_e2e_runner_grouping.py"]
         assert result.fallback_tiers == []
 
     def test_github_ci_config_selects_tools_tier(self, imap):

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1249,8 +1249,10 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
         ClassificationRule(
             priority=9,
             name="e2e_bundle_group_runner",
-            matcher=_path_in({"tests/e2e/models/_bundle_group_runner.py"}),
-            resolver=_match_result("e2e_bundle_group_runner", _bundle_group_runner_models),
+            matcher=_path_in({"tests/e2e_harness/bundle_group_runner.py"}),
+            resolver=_match_result(
+                "e2e_bundle_group_runner", _bundle_group_runner_models, ["tools"]
+            ),
             covered_by=("TestSafetyNet.test_e2e_bundle_group_runner",),
         ),
         ClassificationRule(
@@ -1838,6 +1840,9 @@ _EXPLICIT_TOOLS_TEST_TARGETS = {
     "scripts/run_e2e_parallel.sh": (
         "tests/tools/test_github_actions_ci.py",
         "tests/tools/test_schedule_e2e.py",
+    ),
+    "tests/e2e_harness/bundle_group_runner.py": (
+        "tests/tools/test_model_e2e_runner_grouping.py",
     ),
 }
 


### PR DESCRIPTION
## Background
The grouped-bundle change from #260 placed a helper directly under `tests/e2e/models`. Canary and Nemotron Labs Diffusion imported that helper, causing the model-isolation guard to classify the shared module as a sibling model import. The full builder/tools gate in PR #269 exposed the regression.

## Exit Criteria
- Keep model-owned runners free of apparent sibling-model imports without weakening the isolation guard.
- Preserve grouped-bundle behavior for Canary and Nemotron Labs Diffusion.
- Keep impact analysis scoped to the families that opt into grouped bundles and run the focused grouping tests when the helper changes.

## Implementation
- Move `_bundle_group_runner.py` from the model-owned tree into `tests/e2e_harness` and update its consumers.
- Retarget the dedicated impact rule to the harness path, retain its focused family selection, and classify helper changes in the tools tier.
- Add an explicit grouping-test target because coverage-based selection cannot reliably infer this test dependency.

## Validation
- `python3 -m pytest tests/tools/test_model_plugin_encapsulation_static.py::test_model_owned_python_does_not_import_sibling_models tests/tools/test_model_e2e_runner_grouping.py tests/tools/test_test_impact.py -q`: passed, 182 tests.
- `python3 -m pytest tests/e2e/models/canary/test_canary_e2e.py tests/e2e/models/nemotron_labs_diffusion/test_nemotron_labs_diffusion_e2e.py --co -q`: passed, 12 tests collected.
- `python3 -m pytest tests/tools -q`: passed, 1150 tests.
- `python3 -m ruff check tests/e2e_harness/bundle_group_runner.py tests/e2e/models/canary/runner.py tests/e2e/models/nemotron_labs_diffusion/runner.py tests/tools/test_model_e2e_runner_grouping.py tests/tools/test_test_impact.py tools/test_impact.py`: passed.
- `git diff --check`: passed.
- `PYTHONPATH=python python3 tools/test_impact.py --files tests/e2e_harness/bundle_group_runner.py --json`: selected only Canary and Nemotron Labs Diffusion E2E cases plus `test_model_e2e_runner_grouping.py` in the tools tier.

## Notes For Future Readers
- Review the helper move and runner imports first, then the focused impact rule.
- This PR does not modify bundle grouping behavior or relax the model-isolation test.
- GPU E2E execution was not run locally because the change is a Python module relocation; both affected model entrypoints passed pytest collection.
