### PR TITLE
feat(task-eval): add streaming ASR suite and model defaults

### DIFF
--- a/tests/task_eval/validation_suites.yaml
+++ b/tests/task_eval/validation_suites.yaml
@@ -292,3 +292,51 @@ suites:
         Intended for local/p2021 validation first. Pass --dataset for
         machine-specific data roots such as
         /localhome/local-chaofengw/trtmc/data/updated_datasets.
+
+  - id: librispeech_clean_asr_streaming
+    description: >
+      Local ASR transcript evaluation on LibriSpeech clean test samples for
+      streaming/RNNT speech-to-text bundles.
+    user_contract: exact_transcript
+    dataset:
+      kind: asr_chat_json
+      default_path: /mnt/data/librispeech_clean_test/librispeech_clean_test.json
+      answer_field: reference
+      subject_field: subset
+      prompt_source: messages
+      audio_source: messages
+      max_audio_per_sample: 1
+    selectors:
+      model_names:
+        - nemotron-speech-streaming-en-0.6b
+      task_strategies:
+        - speech_to_text
+      runtime_strategies:
+        - nemotron_speech_streaming_speech_to_text_rnnt
+      families:
+        - nemotron_speech_streaming
+    generation:
+      max_new_tokens: 256
+      temperature: 1.0
+      top_k: 1
+      top_p: 1.0
+      min_p: 0.0
+      seed: -1
+      sample_rate: 16000
+      apply_chat_template: false
+      enable_thinking: false
+      do_sample: false
+    scoring:
+      scorer: asr_transcript
+    build:
+      min_max_cache_length: 0
+    gates:
+      max_accuracy_drop_from_hf: 0.05
+      min_prediction_agreement: 0.90
+    ci:
+      eligible: false
+      lane: local_only
+      notes: >
+        Intended for local/p2021 validation first. This suite is kept separate
+        from librispeech_clean_asr because RNNT streaming baselines can differ
+        from encoder-decoder ASR baselines.

--- a/tests/task_eval/validation_suites.yaml
+++ b/tests/task_eval/validation_suites.yaml
@@ -7,6 +7,21 @@ suites:
       user-visible task quality for decoder-style text generation bundles and
       records HF-reference agreement separately from absolute correctness.
     user_contract: multiple_choice_qa
+    default_model_names:
+      - gemma-2-2b
+      - gpt-oss-20b
+      - internlm2-1.8b
+      - nemotron-nano-4b
+      - tinyllama-1.1b
+      - mistral-7b
+      - nemotron-mini-4b
+      - nemotron-h-nano-9b
+      - phi3-mini
+      - phi-moe
+      - qwen3-0.6b-fp16
+      - qwen3-4b-instruct-2507
+      - qwen35-9b
+      - qwen3-moe-30b-a3b
     dataset:
       kind: mmlu_five_shot_json
       default_path: /mnt/data/MMLU_five_shot/mmlu_dataset.json
@@ -54,6 +69,29 @@ suites:
       measures conversion fidelity for completion models rather than task
       accuracy.
     user_contract: continuation_parity
+    default_model_names:
+      - bart-base
+      - bloom-560m
+      - deepseek-v2-lite
+      - deepseek-v2-tiny
+      - falcon-rw-1b
+      - glm-4-9b
+      - gpt2-125m
+      - gpt-neo-125m
+      - pythia-70m
+      - granite-3.1-2b
+      - falcon3-1b
+      - minitron-4b-depth
+      - minitron-4b-width
+      - mamba-130m
+      - mixtral-stories-15m
+      - nemotron-hindi-4b
+      - olmo-1b
+      - olmo2-1b
+      - opt-125m
+      - rwkv-169m
+      - stablelm2-1.6b
+      - xglm-564m
     dataset:
       kind: mmlu_five_shot_json
       default_path: /mnt/data/MMLU_five_shot/mmlu_dataset.json
@@ -95,6 +133,11 @@ suites:
       with gold option-letter answers and records HF-reference agreement
       separately from absolute correctness.
     user_contract: vl_answer
+    default_model_names:
+      - internvl3-2b
+      - internvl3-8b
+      - qwen25vl-3b
+      - qwen3-vl-2b
     dataset:
       kind: vlm_chat_json
       default_path: /mnt/data/MMMU_Pro_vision/mmmu_pro_vision_dataset.json
@@ -148,6 +191,11 @@ suites:
       contract and prompts are normalized to a single user image-first message
       so HF native and TRTFB consume the same controlled input shape.
     user_contract: vl_answer
+    default_model_names:
+      - internvl3-2b
+      - internvl3-8b
+      - qwen25vl-3b
+      - qwen3-vl-2b
     dataset:
       kind: vlm_chat_json
       default_path: /mnt/data/MMMU_Pro_vision/mmmu_pro_vision_dataset.json
@@ -202,6 +250,8 @@ suites:
       validates image-conditioned OCR / visual QA bundles against OCRBench v2
       task-specific gold metrics without requiring dataset-local TRTMC config.
     user_contract: ocr_text
+    default_model_names:
+      - deepseek-ocr
     dataset:
       kind: vlm_unified_json
       default_path: /mnt/data/OCRBench_v2/unified/dataset.json
@@ -248,6 +298,10 @@ suites:
       validates speech-to-text bundles against reference transcripts and records
       HF-reference agreement separately from transcript accuracy.
     user_contract: exact_transcript
+    default_model_names:
+      - whisper-tiny-fp16
+      - whisper-large-v3-turbo
+      - canary-1b-v2
     dataset:
       kind: asr_chat_json
       default_path: /mnt/data/librispeech_clean_test/librispeech_clean_test.json
@@ -298,6 +352,8 @@ suites:
       Local ASR transcript evaluation on LibriSpeech clean test samples for
       streaming/RNNT speech-to-text bundles.
     user_contract: exact_transcript
+    default_model_names:
+      - nemotron-speech-streaming-en-0.6b
     dataset:
       kind: asr_chat_json
       default_path: /mnt/data/librispeech_clean_test/librispeech_clean_test.json
@@ -307,8 +363,6 @@ suites:
       audio_source: messages
       max_audio_per_sample: 1
     selectors:
-      model_names:
-        - nemotron-speech-streaming-en-0.6b
       task_strategies:
         - speech_to_text
       runtime_strategies:

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -160,6 +160,23 @@ def test_default_suites_do_not_split_librispeech_asr_by_family() -> None:
     assert "librispeech_clean_asr_canary" not in suite_ids
 
 
+def test_default_suites_include_librispeech_clean_asr_streaming() -> None:
+    suites = task_eval.load_suites()
+    suite = task_eval.suite_by_id(suites, "librispeech_clean_asr_streaming")
+
+    assert suite["dataset"]["kind"] == "asr_chat_json"
+    assert suite["scoring"]["scorer"] == "asr_transcript"
+    assert suite["selectors"]["model_names"] == [
+        "nemotron-speech-streaming-en-0.6b"
+    ]
+    assert suite["selectors"]["runtime_strategies"] == [
+        "nemotron_speech_streaming_speech_to_text_rnnt"
+    ]
+    assert suite["selectors"]["families"] == ["nemotron_speech_streaming"]
+    non_streaming = task_eval.suite_by_id(suites, "librispeech_clean_asr")
+    assert "nemotron_speech_streaming" in non_streaming["selectors"]["exclude_families"]
+
+
 def test_custom_suite_file_does_not_add_builtin_suites(tmp_path: Path) -> None:
     custom = tmp_path / "suites.json"
     custom.write_text(
@@ -367,6 +384,22 @@ def test_plan_selects_librispeech_asr_models() -> None:
     assert "canary-1b-v2" in selected
     assert selected["canary-1b-v2"]["runtime_strategy"] == "canary_speech_to_text"
     assert "nemotron-nano-v2-speech-embedded" not in selected
+
+
+def test_plan_selects_librispeech_streaming_asr_models() -> None:
+    suites = task_eval.load_suites()
+    models = task_eval.load_manifest_records()
+
+    rows = task_eval.build_plan(suites, models, suite_id="librispeech_clean_asr_streaming")
+
+    selected = {row["model"]: row for row in rows}
+    assert "nemotron-speech-streaming-en-0.6b" in selected
+    assert selected["nemotron-speech-streaming-en-0.6b"]["runtime_strategy"] == (
+        "nemotron_speech_streaming_speech_to_text_rnnt"
+    )
+    assert not any("-asr-probe" in name for name in selected)
+    assert "whisper-tiny-fp16" not in selected
+    assert "canary-1b-v2" not in selected
 
 
 def test_prepare_mmlu_writes_answers_and_trtfb_jsonl(tmp_path: Path) -> None:
@@ -1283,6 +1316,24 @@ def test_asr_reference_detection_identifies_canary() -> None:
     assert task_eval._is_canary_asr_reference(argparse.Namespace(
         model="nvidia/other",
         family="",
+        reference_family="asr_canary",
+    ))
+
+
+def test_nemo_asr_reference_detection_identifies_streaming() -> None:
+    assert task_eval._is_nemo_asr_reference(argparse.Namespace(
+        model="nvidia/nemotron-speech-streaming-en-0.6b",
+        family="",
+        reference_family="",
+    ))
+    assert task_eval._is_nemo_asr_reference(argparse.Namespace(
+        model="nvidia/other",
+        family="nemotron_speech_streaming",
+        reference_family="",
+    ))
+    assert task_eval._is_nemo_asr_reference(argparse.Namespace(
+        model="nvidia/canary-1b-v2",
+        family="canary",
         reference_family="asr_canary",
     ))
 

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -166,7 +166,7 @@ def test_default_suites_include_librispeech_clean_asr_streaming() -> None:
 
     assert suite["dataset"]["kind"] == "asr_chat_json"
     assert suite["scoring"]["scorer"] == "asr_transcript"
-    assert suite["selectors"]["model_names"] == [
+    assert suite["default_model_names"] == [
         "nemotron-speech-streaming-en-0.6b"
     ]
     assert suite["selectors"]["runtime_strategies"] == [
@@ -229,7 +229,12 @@ def test_plan_selects_chat_text_generation_manifests() -> None:
         },
     ]
 
-    rows = task_eval.build_plan(suites, models, suite_id="mmlu_five_shot_mcq")
+    rows = task_eval.build_plan(
+        suites,
+        models,
+        suite_id="mmlu_five_shot_mcq",
+        use_default_models=False,
+    )
 
     selected = {row["model"]: row for row in rows}
     assert any(
@@ -279,9 +284,21 @@ def test_load_manifest_records_discovers_model_owned_manifests(tmp_path: Path) -
     }
 
 
+def test_default_model_names_match_selected_plan_models() -> None:
+    suites = task_eval.load_suites()
+    models = task_eval.load_manifest_records()
+
+    for suite in suites:
+        rows = task_eval.build_plan(suites, models, suite_id=suite["id"])
+        selected_names = {row["model"] for row in rows if row["selected"]}
+
+        assert selected_names == set(suite["default_model_names"]), suite["id"]
+
+
 def test_plan_selects_vlm_mmmu_pro_vision_models() -> None:
     suites = task_eval.load_suites()
     suite = dict(task_eval.suite_by_id(suites, "vlm_mmmu_pro_vision_mcq"))
+    suite.pop("default_model_names")
     suite["selectors"] = {
         **suite["selectors"],
         "runtime_strategies": ["vision_family_vision_language"],
@@ -365,8 +382,8 @@ def test_plan_selects_ocrbench_v2_unified_models() -> None:
 
     selected = {row["model"]: row for row in rows}
     model_by_name = {model["name"]: model for model in models}
-    assert "deepseek-ocr-l0" in selected
-    assert model_by_name["deepseek-ocr-l0"]["reference_backend"] == "golden_snapshot"
+    assert set(selected) == {"deepseek-ocr"}
+    assert model_by_name["deepseek-ocr"]["reference_backend"] == "golden_snapshot"
     assert "qwen25vl-3b" not in selected
     assert "internvl3-2b" not in selected
     assert "locateanything-3b" not in selected
@@ -383,6 +400,11 @@ def test_plan_selects_librispeech_asr_models() -> None:
     assert selected["whisper-tiny-fp16"]["runtime_strategy"] == "whisper_speech_to_text"
     assert "canary-1b-v2" in selected
     assert selected["canary-1b-v2"]["runtime_strategy"] == "canary_speech_to_text"
+    assert set(selected) == {
+        "whisper-tiny-fp16",
+        "whisper-large-v3-turbo",
+        "canary-1b-v2",
+    }
     assert "nemotron-nano-v2-speech-embedded" not in selected
 
 

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -168,7 +168,6 @@ def _selector_values(selectors: dict[str, Any], key: str) -> set[str]:
 
 def suite_match_reason(suite: dict[str, Any], model: dict[str, Any]) -> tuple[bool, str]:
     selectors = suite.get("selectors", {})
-    model_names = _selector_values(selectors, "model_names")
     task_strategies = _selector_values(selectors, "task_strategies")
     runtime_strategies = _selector_values(selectors, "runtime_strategies")
     user_contracts = _selector_values(selectors, "user_contracts")
@@ -176,8 +175,6 @@ def suite_match_reason(suite: dict[str, Any], model: dict[str, Any]) -> tuple[bo
     families = _selector_values(selectors, "families")
     exclude_families = _selector_values(selectors, "exclude_families")
 
-    if model_names and model["name"] not in model_names:
-        return False, f"model={model['name']} not selected"
     if task_strategies and model["task_strategy"] not in task_strategies:
         return False, f"task_strategy={model['task_strategy']} not selected"
     if runtime_strategies and model["runtime_strategy"] not in runtime_strategies:
@@ -202,6 +199,7 @@ def build_plan(
     suite_id: str | None = None,
     single_device_only: bool = False,
     include_non_matching: bool = False,
+    use_default_models: bool = True,
     waives: dict[str, tuple[str, str]] | None = None,
     include_waived: bool = False,
 ) -> list[dict[str, Any]]:
@@ -209,8 +207,14 @@ def build_plan(
     rows: list[dict[str, Any]] = []
     waives = waives or {}
     for suite in selected_suites:
+        default_model_names = (
+            _selector_values(suite, "default_model_names") if use_default_models else set()
+        )
         for model in models:
             matched, reason = suite_match_reason(suite, model)
+            if matched and default_model_names and model["name"] not in default_model_names:
+                matched = False
+                reason = f"model={model['name']} is compatible but not selected by default"
             if single_device_only and model["requires_multi_device"]:
                 matched = False
                 reason = "requires multi-device runtime"
@@ -3572,6 +3576,7 @@ def selected_models_for_suite(
         models,
         suite_id=suite["id"],
         single_device_only=single_device_only,
+        use_default_models=not bool(selectors),
         waives=waives,
         include_waived=include_waived or bool(selectors),
     )

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -168,6 +168,7 @@ def _selector_values(selectors: dict[str, Any], key: str) -> set[str]:
 
 def suite_match_reason(suite: dict[str, Any], model: dict[str, Any]) -> tuple[bool, str]:
     selectors = suite.get("selectors", {})
+    model_names = _selector_values(selectors, "model_names")
     task_strategies = _selector_values(selectors, "task_strategies")
     runtime_strategies = _selector_values(selectors, "runtime_strategies")
     user_contracts = _selector_values(selectors, "user_contracts")
@@ -175,6 +176,8 @@ def suite_match_reason(suite: dict[str, Any], model: dict[str, Any]) -> tuple[bo
     families = _selector_values(selectors, "families")
     exclude_families = _selector_values(selectors, "exclude_families")
 
+    if model_names and model["name"] not in model_names:
+        return False, f"model={model['name']} not selected"
     if task_strategies and model["task_strategy"] not in task_strategies:
         return False, f"task_strategy={model['task_strategy']} not selected"
     if runtime_strategies and model["runtime_strategy"] not in runtime_strategies:
@@ -2576,6 +2579,18 @@ def _is_canary_asr_reference(args: argparse.Namespace) -> bool:
     return reference_family == "asr_canary" or family == "canary" or "canary" in model
 
 
+def _is_nemo_asr_reference(args: argparse.Namespace) -> bool:
+    reference_family = str(getattr(args, "reference_family", "") or "").lower()
+    family = str(getattr(args, "family", "") or "").lower()
+    model = str(getattr(args, "model", "") or "").lower()
+    return (
+        _is_canary_asr_reference(args)
+        or family == "nemotron_speech_streaming"
+        or "nemotron-speech-streaming" in model
+        or reference_family == "asr_nemo"
+    )
+
+
 def _model_dtype(torch_mod: Any, dtype_name: str) -> Any:
     if dtype_name == "float16":
         return torch_mod.float16
@@ -2985,8 +3000,8 @@ def run_vlm_hf_reference(args: argparse.Namespace) -> None:
 
 
 def run_asr_hf_reference(args: argparse.Namespace) -> None:
-    if _is_canary_asr_reference(args):
-        _run_canary_hf_reference(args)
+    if _is_nemo_asr_reference(args):
+        _run_nemo_asr_hf_reference(args)
         return
 
     try:
@@ -3081,7 +3096,7 @@ def run_asr_hf_reference(args: argparse.Namespace) -> None:
         torch.cuda.empty_cache()
 
 
-def _run_canary_hf_reference(args: argparse.Namespace) -> None:
+def _run_nemo_asr_hf_reference(args: argparse.Namespace) -> None:
     work_dir = Path(args.work_dir)
     answers = json.loads((work_dir / "answers.json").read_text(encoding="utf-8"))
     prompt_rows = load_jsonl(work_dir / "prompts.jsonl")
@@ -3097,7 +3112,7 @@ def _run_canary_hf_reference(args: argparse.Namespace) -> None:
     try:
         import nemo.collections.asr as nemo_asr
     except ImportError:
-        _run_canary_hf_pipeline_reference(
+        _run_nemo_asr_hf_pipeline_reference(
             args=args,
             prompt_rows=prompt_rows,
             raw_path=raw_path,
@@ -3122,7 +3137,7 @@ def _run_canary_hf_reference(args: argparse.Namespace) -> None:
             sample_id = str(prompt_row.get("sample_id", f"asr_{idx:06d}"))
             audio_path = str(prompt_row.get("audio", ""))
             if not audio_path:
-                raise ValueError(f"Canary HF reference expects an audio path for sample {idx}")
+                raise ValueError(f"NeMo ASR HF reference expects an audio path for sample {idx}")
             audio, sample_rate = _read_wav_float32(audio_path)
             audio = _resample_audio(audio, sample_rate, target_sr)
             mono_path = canary_audio_dir / _safe_sample_filename(sample_id, ".wav")
@@ -3141,13 +3156,13 @@ def _run_canary_hf_reference(args: argparse.Namespace) -> None:
             responses.append(row)
             raw_f.write(json.dumps(row, ensure_ascii=False) + "\n")
             raw_f.flush()
-            print(f"[task_eval.canary_hf] sample={idx + 1}/{len(prompt_rows)}", file=sys.stderr)
+            print(f"[task_eval.nemo_asr_hf] sample={idx + 1}/{len(prompt_rows)}", file=sys.stderr)
     write_predictions(pred_path, responses)
     del model
     gc.collect()
 
 
-def _run_canary_hf_pipeline_reference(
+def _run_nemo_asr_hf_pipeline_reference(
     *,
     args: argparse.Namespace,
     prompt_rows: list[dict[str, Any]],
@@ -3160,7 +3175,7 @@ def _run_canary_hf_pipeline_reference(
         import torch
         from transformers import pipeline
     except Exception as exc:  # pragma: no cover - runtime dependency
-        raise RuntimeError("Canary ASR reference requires NeMo or transformers pipeline") from exc
+        raise RuntimeError("NeMo ASR reference requires NeMo or transformers pipeline") from exc
 
     device = 0 if str(getattr(args, "device", "")).startswith("cuda") and torch.cuda.is_available() else -1
     pipe = pipeline(
@@ -3179,7 +3194,7 @@ def _run_canary_hf_pipeline_reference(
             sample_id = str(prompt_row.get("sample_id", f"asr_{idx:06d}"))
             audio_path = str(prompt_row.get("audio", ""))
             if not audio_path:
-                raise ValueError(f"Canary HF pipeline reference expects an audio path for sample {idx}")
+                raise ValueError(f"NeMo ASR HF pipeline reference expects an audio path for sample {idx}")
             audio, sample_rate = _read_wav_float32(audio_path)
             audio = _resample_audio(audio, sample_rate, target_sr)
             mono_path = canary_audio_dir / _safe_sample_filename(sample_id, ".wav")
@@ -3198,7 +3213,7 @@ def _run_canary_hf_pipeline_reference(
             responses.append(row)
             raw_f.write(json.dumps(row, ensure_ascii=False) + "\n")
             raw_f.flush()
-            print(f"[task_eval.canary_hf_pipeline] sample={idx + 1}/{len(prompt_rows)}", file=sys.stderr)
+            print(f"[task_eval.nemo_asr_hf_pipeline] sample={idx + 1}/{len(prompt_rows)}", file=sys.stderr)
     write_predictions(pred_path, responses)
 
 


### PR DESCRIPTION
## Background
The LibriSpeech ASR task eval added in #271 covers encoder-decoder Whisper and Canary models. Streaming RNNT models need a separate suite and a NeMo-compatible reference path.

Capability-based suite selectors also selected every compatible manifest by default. That repeated the same checkpoint for ASR probes and for equivalent L0/full E2E manifests after task-eval datasets and generation settings replaced their E2E-specific inputs.

## Exit Criteria
- Evaluate the supported single-device Nemotron streaming ASR model on LibriSpeech.
- Keep streaming RNNT baselines separate from the non-streaming ASR suite.
- Default each task-eval suite to canonical model manifests without blocking explicit compatible model selection.
- Do not treat E2E probes or equivalent L0/full manifests as distinct models by default.

## Implementation
- Add `librispeech_clean_asr_streaming` for `nemotron_speech_streaming_speech_to_text_rnnt`.
- Generalize the Canary-specific NeMo reference path for Nemotron streaming ASR.
- Add suite-level `default_model_names` for deterministic canonical defaults across all current task-eval suites.
- Keep task/runtime/family selectors as capability checks. Explicit `--model` bypasses the default set but must still satisfy those capability selectors.
- Add selection, default-set consistency, and NeMo ASR reference detection tests.

## Validation
- `PYTHONPATH="$PWD/python:$PYTHONPATH" python3 -m pytest tests/tools/test_task_eval.py -q`: 59 passed locally.
- The same test command on p2021: 59 passed.
- p2021 plans select 3 non-streaming ASR models, 1 streaming ASR model, and 1 canonical OCR model.
- Earlier p2021 streaming eval with `--limit 2`: HF accuracy 1.0000, TensorRT-Model-Connect accuracy 1.0000, prediction agreement 1.0000.

## Notes For Future Readers
- E2E probe manifests still exercise input-format variants in the E2E matrix; they are compatible with the ASR suite but are not default dataset-level task-eval models.
- L0/full manifests remain separate for E2E CI scheduling. Task eval defaults to one canonical manifest when their model/build semantics are equivalent under suite-owned inputs.
- TP manifests remain outside single-device defaults and can still be selected explicitly in a compatible multi-device environment.