### PR TITLE
ci: keep static guard tests in premerge

### DIFF
--- a/.github/scripts/run-trtmc-ci.sh
+++ b/.github/scripts/run-trtmc-ci.sh
@@ -478,24 +478,23 @@ run_python_builder_tests() {
   python -m pip install --disable-pip-version-check --quiet "pytest-cov>=6.0"
   mkdir -p coverage
 
-  if [ "${FULL_E2E:-false}" != "true" ]; then
-    if ! python3 -c "import json; d=json.load(open('impact.json')); tiers=d['unit_tiers']; exit(0 if 'builder' in tiers or 'tools' in tiers else 1)"; then
-      echo "Skipping: neither builder nor tools tier affected by this change"
-      write_skipped_python_coverage "Skipped: neither builder nor tools tier affected"
-      return 0
-    fi
-  fi
-
   local selected_tests_file="coverage/python-selected-tests.txt"
   if [ "${FULL_E2E:-false}" != "true" ]; then
     python3 -c "
 import json
 d = json.load(open('impact.json'))
-tests = d.get('builder_tests', []) + d.get('tools_tests', [])
+tests = set(d.get('builder_tests', []) + d.get('tools_tests', []))
 fallback = set(d.get('fallback_tiers', []))
 if fallback.intersection({'builder', 'tools'}):
     tests = []
-for test in tests:
+else:
+    tests.update({
+        'tests/tools/test_github_actions_ci.py',
+        'tests/tools/test_model_plugin_encapsulation_static.py',
+        'tests/tools/test_schedule_e2e.py',
+        'tests/tools/test_test_impact.py',
+    })
+for test in sorted(tests):
     print(test)
 " > "$selected_tests_file"
   fi

--- a/scripts/run_e2e_parallel.sh
+++ b/scripts/run_e2e_parallel.sh
@@ -229,6 +229,52 @@ else
             "${FILTER_ARGS[@]}" "${COLLECT_ARGS[@]}" "${E2E_SELECTION_ARGS[@]}"
     )
     TESTS=$(printf "%s\n" "$COLLECTED_TESTS" | grep "test_model_e2e\[" | sort || true)
+    if [ -n "$MODELS_FILE" ]; then
+        TESTS=$(
+            printf "%s\n" "$TESTS" | python3 -c '
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+BUNDLE_PREFIX = "bundle:"
+
+
+def names_from_param(value: str) -> list[str]:
+    if value.startswith(BUNDLE_PREFIX):
+        return [name for name in value[len(BUNDLE_PREFIX):].split("+") if name]
+    return [value] if value else []
+
+
+def names_from_line(raw: str) -> list[str]:
+    value = raw.split("#", 1)[0].strip()
+    if not value:
+        return []
+    if "[" in value and "]" in value:
+        value = value.rsplit("[", 1)[1].split("]", 1)[0]
+    return names_from_param(value)
+
+
+selected = {
+    name
+    for raw in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+    for name in names_from_line(raw)
+}
+
+for raw in sys.stdin:
+    test_id = raw.strip()
+    if not test_id:
+        continue
+    match = re.search(r"\[(.+?)\]", test_id)
+    if not match:
+        continue
+    names = names_from_param(match.group(1))
+    if names and all(name in selected for name in names):
+        print(test_id)
+' "$MODELS_FILE"
+        )
+    fi
 fi
 
 TOTAL=$(printf "%s\n" "$TESTS" | sed '/^$/d' | wc -l)

--- a/tests/e2e/models/canary/runner.py
+++ b/tests/e2e/models/canary/runner.py
@@ -8,7 +8,7 @@ import sys
 from contextlib import contextmanager
 from pathlib import Path
 
-from tests.e2e.models._bundle_group_runner import (
+from tests.e2e_harness.bundle_group_runner import (
     model_case_names_for_dir,
     run_model_e2e_case_or_group,
 )

--- a/tests/e2e/models/nemotron_labs_diffusion/runner.py
+++ b/tests/e2e/models/nemotron_labs_diffusion/runner.py
@@ -8,7 +8,7 @@ import sys
 from contextlib import contextmanager
 from pathlib import Path
 
-from tests.e2e.models._bundle_group_runner import (
+from tests.e2e_harness.bundle_group_runner import (
     model_case_names_for_dir,
     run_model_e2e_case_or_group,
 )

--- a/tests/e2e_harness/bundle_group_runner.py
+++ b/tests/e2e_harness/bundle_group_runner.py
@@ -1,4 +1,4 @@
-"""Scoped grouped-bundle execution support for model-owned E2E entrypoints."""
+"""Shared grouped-bundle execution support for model-owned E2E entrypoints."""
 
 from __future__ import annotations
 

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -130,6 +130,17 @@ def test_full_python_builder_runs_e2e_harness_unit_tests() -> None:
     assert "tests/e2e_harness/test_*.py" in text
 
 
+def test_selective_python_always_runs_static_ci_smoke_tests() -> None:
+    text = (REPO_ROOT / ".github" / "scripts" / "run-trtmc-ci.sh").read_text()
+    for test_path in (
+        "tests/tools/test_github_actions_ci.py",
+        "tests/tools/test_model_plugin_encapsulation_static.py",
+        "tests/tools/test_schedule_e2e.py",
+        "tests/tools/test_test_impact.py",
+    ):
+        assert test_path in text
+
+
 def test_python_package_coverage_gate_excludes_family_owned_modules() -> None:
     text = (REPO_ROOT / ".github" / "scripts" / "run-trtmc-ci.sh").read_text()
     assert "write_python_package_gate_coverage_config" in text

--- a/tests/tools/test_model_e2e_runner_grouping.py
+++ b/tests/tools/test_model_e2e_runner_grouping.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-from tests.e2e.models import _bundle_group_runner as model_case_runner
+from tests.e2e_harness import bundle_group_runner as model_case_runner
 
 
 def _load_runner(family: str, module_name: str):

--- a/tests/tools/test_model_plugin_encapsulation_static.py
+++ b/tests/tools/test_model_plugin_encapsulation_static.py
@@ -8186,6 +8186,21 @@ def test_model_owned_python_does_not_import_sibling_models() -> None:
     assert not violations, _format_violations(violations)
 
 
+def test_e2e_models_root_has_no_shared_python_helpers() -> None:
+    """Trace: ARCH-MODPLUG-001
+    Intent: keep shared E2E harness helpers out of model-owned namespace.
+    Preconditions: tests/e2e/models contains model-family directories.
+    Postconditions: root Python helpers live under tests/e2e_harness instead.
+    """
+    violations = [
+        (path, 0, "shared E2E Python helpers belong under tests/e2e_harness")
+        for path in sorted(E2E_MODELS.glob("*.py"))
+        if path.name != "__init__.py"
+    ]
+
+    assert not violations, _format_violations(violations)
+
+
 def test_model_owned_unit_tests_do_not_live_under_tests_tools() -> None:
     """Trace: ARCH-MODPLUG-001
     Intent: keep concrete model unit tests with their owning model.

--- a/tests/tools/test_schedule_e2e.py
+++ b/tests/tools/test_schedule_e2e.py
@@ -571,6 +571,10 @@ def test_run_e2e_parallel_collects_grouped_entries_when_models_file_is_present(
                             "tests/e2e/models/fake_family/"
                             "test_fake_family_e2e.py::test_model_e2e[solo]"
                         )
+                    print(
+                        "tests/e2e/models/other_family/"
+                        "test_other_family_e2e.py::test_model_e2e[unrelated]"
+                    )
                     raise SystemExit(0)
 
                 tests = [

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1121,11 +1121,12 @@ class TestSafetyNet:
     def test_e2e_bundle_group_runner(self, imap):
         """Changing grouped-bundle helper -> only opt-in grouped families."""
         match = test_impact.classify_file(
-            "tests/e2e/models/_bundle_group_runner.py",
+            "tests/e2e_harness/bundle_group_runner.py",
             imap,
         )
         assert match.rule == "e2e_bundle_group_runner"
         assert match.models == ["canary-grouped", "nld-grouped"]
+        assert match.unit_tiers == ["tools"]
         assert "speech-streaming-case" not in match.models
 
     def test_e2e_model_owned_waives_self(self, imap):
@@ -2881,6 +2882,19 @@ class TestCoverageMapIntegration:
             "tests/tools/test_github_actions_ci.py",
             "tests/tools/test_schedule_e2e.py",
         ]
+        assert result.fallback_tiers == []
+
+    @pytest.mark.parametrize("coverage_map", [None, {}])
+    def test_bundle_group_runner_selects_grouping_tests(self, imap, coverage_map):
+        """Shared bundle helper edits select tests that Python coverage cannot infer."""
+        result = test_impact.analyze_impact(
+            ["tests/e2e_harness/bundle_group_runner.py"],
+            imap,
+            coverage_map=coverage_map,
+        )
+
+        assert result.unit_tiers == ["tools"]
+        assert result.tools_tests == ["tests/tools/test_model_e2e_runner_grouping.py"]
         assert result.fallback_tiers == []
 
     def test_github_ci_config_selects_tools_tier(self, imap):

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1249,8 +1249,10 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
         ClassificationRule(
             priority=9,
             name="e2e_bundle_group_runner",
-            matcher=_path_in({"tests/e2e/models/_bundle_group_runner.py"}),
-            resolver=_match_result("e2e_bundle_group_runner", _bundle_group_runner_models),
+            matcher=_path_in({"tests/e2e_harness/bundle_group_runner.py"}),
+            resolver=_match_result(
+                "e2e_bundle_group_runner", _bundle_group_runner_models, ["tools"],
+            ),
             covered_by=("TestSafetyNet.test_e2e_bundle_group_runner",),
         ),
         ClassificationRule(
@@ -1838,6 +1840,9 @@ _EXPLICIT_TOOLS_TEST_TARGETS = {
     "scripts/run_e2e_parallel.sh": (
         "tests/tools/test_github_actions_ci.py",
         "tests/tools/test_schedule_e2e.py",
+    ),
+    "tests/e2e_harness/bundle_group_runner.py": (
+        "tests/tools/test_model_e2e_runner_grouping.py",
     ),
 }
 


### PR DESCRIPTION
## Background
#260 exposed that selective premerge impact analysis could skip cheap static tests that validate CI wiring, impact mapping, scheduler behavior, and model ownership boundaries. That let the runner-script marker regression and shared grouped-bundle helper placement issue escape until later PRs ran different tools/static coverage.

This PR also fixes a scheduler-selection regression found while validating the guard change: selective impact listed five E2E models, but grouped pytest collection produced 141 scheduler entries because most model-family runners do not honor `--e2e-models-file`.

## Exit Criteria
- Selective premerge Python tests always include the critical static CI guard set.
- Shared grouped-bundle runner code no longer lives under the model-owned `tests/e2e/models` namespace.
- Changes to the grouped-bundle helper select the grouping regression test even when no coverage map exists.
- Model-file E2E scheduling cannot run unrelated families that appear during broad pytest collection.

## Implementation
- Updated `.github/scripts/run-trtmc-ci.sh` so non-full premerge Python selection always includes `test_github_actions_ci.py`, `test_model_plugin_encapsulation_static.py`, `test_schedule_e2e.py`, and `test_test_impact.py`, while preserving broad fallback behavior that runs the full builder/tools suite.
- Moved the grouped-bundle helper from `tests/e2e/models/_bundle_group_runner.py` to `tests/e2e_harness/bundle_group_runner.py` and updated model runner imports.
- Retargeted `tools/test_impact.py` to the harness helper path, classified helper changes as tools-tier, and explicitly selected `tests/tools/test_model_e2e_runner_grouping.py` for that helper.
- Added static coverage that rejects root-level Python helpers under `tests/e2e/models` so shared harness code stays out of model-owned namespace.
- Filtered collected pytest node IDs back to the selected `--models-file` names before scheduling. This preserves grouped bundle node IDs while dropping unrelated families whose runners ignore `--e2e-models-file`.

## Validation
- `PYTHONPATH=python:. /tmp/trtmc-ci-guard-venv/bin/python -m pytest tests/tools/test_github_actions_ci.py::test_selective_python_always_runs_static_ci_smoke_tests tests/tools/test_github_actions_ci.py::test_full_e2e_collection_uses_model_e2e_files_with_visible_errors tests/tools/test_test_impact.py::TestSafetyNet::test_e2e_bundle_group_runner tests/tools/test_test_impact.py::TestCoverageMapIntegration::test_e2e_runner_selects_explicit_tools_tests tests/tools/test_test_impact.py::TestCoverageMapIntegration::test_bundle_group_runner_selects_grouping_tests tests/tools/test_model_plugin_encapsulation_static.py::test_model_owned_python_does_not_import_sibling_models tests/tools/test_model_plugin_encapsulation_static.py::test_e2e_models_root_has_no_shared_python_helpers tests/tools/test_model_e2e_runner_grouping.py -q`: passed, 12 tests.
- `PYTHONPATH=python:. /tmp/trtmc-ci-guard-venv/bin/python -m pytest tests/tools/test_github_actions_ci.py tests/tools/test_test_impact.py -q`: passed, 219 tests.
- `PYTHONPATH=python:. /tmp/trtmc-ci-guard-venv/bin/python -m pytest tests/tools/test_model_plugin_encapsulation_static.py -q`: passed, 155 tests.
- `PYTHONPATH=python:. /tmp/trtmc-ci-guard-venv/bin/python -m pytest tests/tools/test_schedule_e2e.py -q`: passed, 14 tests.
- `PYTHONPATH=python:. /tmp/trtmc-ci-guard-venv/bin/python -m pytest tests/tools/test_github_actions_ci.py tests/tools/test_test_impact.py tests/tools/test_schedule_e2e.py -q`: passed, 233 tests.
- Local reproduction with the PR's five-model file: raw pytest collection produced 141 node IDs; scheduler filtering reduced that to 2 entries: canary base plus the grouped NLD bundle.
- `git diff --check`: passed.

## Notes For Future Readers
Review `.github/scripts/run-trtmc-ci.sh` first for the always-run smoke policy, then `scripts/run_e2e_parallel.sh` for model-file scheduler filtering, then `tools/test_impact.py` for helper-specific selection behavior. The fixed smoke list intentionally runs even for selective premerge jobs whose changed files do not otherwise affect builder/tools tiers.
