### PR TITLE
fix(tools): whitelist leading-underscore shared modules in encapsulation test

### DIFF
--- a/tests/tools/test_model_plugin_encapsulation_static.py
+++ b/tests/tools/test_model_plugin_encapsulation_static.py
@@ -8174,14 +8174,23 @@ def test_model_owned_python_does_not_import_sibling_models() -> None:
                     if not module.startswith(prefix):
                         continue
                     imported_owner = module[len(prefix):].split(".", 1)[0]
-                    if imported_owner and imported_owner != owner:
-                        violations.append(
-                            (
-                                path,
-                                getattr(node, "lineno", 0),
-                                f"imports sibling model module {module}",
-                            )
+                    if not imported_owner or imported_owner == owner:
+                        continue
+                    # Allow leading-underscore "private" sibling modules — by
+                    # convention these are shared utilities co-located with
+                    # the model packages but not owned by any single family
+                    # (e.g. tests.e2e.models._bundle_group_runner). The
+                    # encapsulation rule applies to coupling between two
+                    # model OWNERS; shared utilities are intentionally shared.
+                    if imported_owner.startswith("_"):
+                        continue
+                    violations.append(
+                        (
+                            path,
+                            getattr(node, "lineno", 0),
+                            f"imports sibling model module {module}",
                         )
+                    )
 
     assert not violations, _format_violations(violations)
 


### PR DESCRIPTION
## Summary
- Encapsulation test \`test_model_owned_python_does_not_import_sibling_models\` is failing on main HEAD because two recently-merged commits landed together without one whitelisting the other:
  - \`2397402e fix(e2e): group shared-bundle testcases (#260)\` — added \`tests/e2e/models/_bundle_group_runner.py\` and imports of it from \`canary/runner.py\` + \`nemotron_labs_diffusion/runner.py\`.
  - \`4196fb58 feat(model-plugins): encapsulate model ownership\` — added the encapsulation test that flags any sibling-path import.
- Fix exempts leading-underscore (\`_*\`) sibling modules — by convention shared utilities, not model-owned code.

## Test plan
- [x] \`pytest tests/tools/test_model_plugin_encapsulation_static.py::test_model_owned_python_does_not_import_sibling_models -v\` → PASS
- [x] \`pytest tests/tools/test_model_plugin_encapsulation_static.py\` (all 154 cases) → PASS
- [x] \`ruff check --config ruff.toml tests/tools/test_model_plugin_encapsulation_static.py\` → clean