### PR TITLE
feat(task-eval): add SeedTTS text-to-audio evaluation

### DIFF
--- a/python/tensorrt_model_connect/families/bark/diff_audio.py
+++ b/python/tensorrt_model_connect/families/bark/diff_audio.py
@@ -634,7 +634,11 @@ def stage4_greedy_parity(args) -> bool:
     config = ModelConfig.from_dir(model_dir)
     plg = find_plugin(config.model_type)
     weights = plg.load_weights(model_dir, config)
-    max_cache = 256
+    # Bark semantic generation starts after a fixed 256-token text/history
+    # prefix plus the semantic infer token. Keep the full diagnostic sequence
+    # in cache so Stage 4 compares against HF full-context generation rather
+    # than introducing a TRT-only sliding window before the first token.
+    max_cache = max(1024, 257 + max_sem_tokens)
 
     sem_plan = plg.build_engine(config, weights, max_cache)
     extra = plg.build_extra_engines(config, weights, max_cache)
@@ -699,6 +703,7 @@ def stage4_greedy_parity(args) -> bool:
         hf_semantic_output = model.semantic.generate(
             inputs["input_ids"],
             semantic_generation_config=sem_gen_cfg,
+            attention_mask=inputs.get("attention_mask"),
         )
     hf_sem_all = hf_semantic_output[0].cpu().numpy()
     hf_sem_tokens = hf_sem_all[hf_sem_all < semantic_pad_token]
@@ -907,6 +912,9 @@ def stage4_greedy_parity(args) -> bool:
             model.generation_config, "fine_acoustics_config", {})
         if BarkFineGenerationConfig is not None and fine_gen_cfg_dict:
             fine_gen_cfg = BarkFineGenerationConfig(**fine_gen_cfg_dict)
+            # BarkFineModel uses argmax only when temperature is exactly 1.0;
+            # its default 0.5 path samples with torch.multinomial.
+            fine_gen_cfg.temperature = 1.0
         else:
             fine_gen_cfg = None
 
@@ -961,9 +969,10 @@ def stage4_greedy_parity(args) -> bool:
             input_embeds = np.zeros(
                 (fine_seq_length, fine_hidden), dtype=np.float32)
             actual_frames = min(n_frames, fine_seq_length)
-            for frame in range(actual_frames):
+            for frame in range(fine_seq_length):
                 for cb in range(cb_idx + 1):
-                    code = int(trt_fine_codes[cb, frame])
+                    code = (int(trt_fine_codes[cb, frame])
+                            if frame < actual_frames else codebook_size)
                     input_embeds[frame] += fine_embed[cb, code]
                 input_embeds[frame] += fine_pos_embed[frame]
 

--- a/python/tensorrt_model_connect/families/bark/encodec_builder.py
+++ b/python/tensorrt_model_connect/families/bark/encodec_builder.py
@@ -8,7 +8,6 @@ Architecture:
   -> LSTM (unrolled for TRT)
   -> 4 upsample stages (ConvTranspose1d + 2x residual blocks with ELU)
   -> Conv1d output
-  -> Tanh
   Output: waveform [1, 1, T*320]
 
 Weight norm fusion: v * (g / ||v||_2) => fused_weight
@@ -137,7 +136,7 @@ def build_encodec_decoder_engine(
         f"{prefix}layers.0.conv.weight_g", f"{prefix}layers.0.conv.weight_v")
     input_conv_b = _to_np(f"{prefix}layers.0.conv.bias") if _has_key(
         f"{prefix}layers.0.conv.bias") else None
-    x = graph_ops.add_causal_pad_1d(network, x, 6)  # (7-1)*1 = 6
+    x = graph_ops.add_reflect_pad_1d(network, x, 6, 0)  # HF pad_mode="reflect"
     x = graph_ops.add_conv1d(network, x, input_conv_w, input_conv_b, 512, 7)
 
     # === LSTM (model.1): 2 layers, hidden_size=512, with residual ===
@@ -204,7 +203,7 @@ def build_encodec_decoder_engine(
             f"{prefix}layers.{res_idx}.block.1.conv.weight_v")
         conv1_b = _to_np(f"{prefix}layers.{res_idx}.block.1.conv.bias") if _has_key(
             f"{prefix}layers.{res_idx}.block.1.conv.bias") else None
-        x = graph_ops.add_causal_pad_1d(network, x, 2)  # (3-1)*1 = 2
+        x = graph_ops.add_reflect_pad_1d(network, x, 2, 0)
         x = graph_ops.add_conv1d(network, x, conv1_w, conv1_b, hidden_ch, 3)
 
         # block.2: ELU, block.3: SConv1d(hidden_ch -> out_ch, k=1)
@@ -228,17 +227,14 @@ def build_encodec_decoder_engine(
         x = network.add_elementwise(
             x, shortcut, trt.ElementWiseOperation.SUM).get_output(0)
 
-    # === Output: ELU + Conv1d(32 -> 1, k=7, causal) + Tanh ===
+    # === Output: ELU + Conv1d(32 -> 1, k=7, causal) ===
     x = graph_ops.add_elu(network, x)
     out_conv_w = _get_fused_conv_weight(
         f"{prefix}layers.15.conv.weight_g", f"{prefix}layers.15.conv.weight_v")
     out_conv_b = _to_np(f"{prefix}layers.15.conv.bias") if _has_key(
         f"{prefix}layers.15.conv.bias") else None
-    x = graph_ops.add_causal_pad_1d(network, x, 6)  # (7-1)*1 = 6
+    x = graph_ops.add_reflect_pad_1d(network, x, 6, 0)
     x = graph_ops.add_conv1d(network, x, out_conv_w, out_conv_b, 1, 7)
-
-    # Tanh activation
-    x = network.add_activation(x, trt.ActivationType.TANH).get_output(0)
 
     x.name = "waveform"
     network.mark_output(x)

--- a/python/tensorrt_model_connect/families/bark/graph_ops.py
+++ b/python/tensorrt_model_connect/families/bark/graph_ops.py
@@ -1997,25 +1997,34 @@ def add_reflect_pad_1d(
     pad_left: int,
     pad_right: int,
 ) -> trt.ITensor:
-    """Reflect padding for 1D tensor [N, C, L].
+    """PyTorch-compatible reflect padding for a static [N, C, L] tensor."""
+    _, _, length = inp.shape
+    if pad_left < 0 or pad_right < 0:
+        raise ValueError("reflect padding must be non-negative")
+    if pad_left >= length or pad_right >= length:
+        raise ValueError("reflect padding must be smaller than input length")
 
-    For TRT, we approximate reflect padding with replicate padding
-    since TRT does not have native reflect mode.
-    """
-    # Use slice + concatenate to implement reflect padding
-    # For simplicity, use zero padding as a fallback
-    n, c, length = inp.shape
-    reshape_in = network.add_shuffle(inp)
-    reshape_in.reshape_dims = (n, c, 1, length)
+    parts: list[trt.ITensor] = []
+    if pad_left:
+        left_indices = np.arange(pad_left, 0, -1, dtype=np.int32)
+        left_index_tensor = add_constant(
+            network, (pad_left,), left_indices, dtype=np.int32)
+        parts.append(network.add_gather(inp, left_index_tensor, 2).get_output(0))
 
-    pad = network.add_padding_nd(
-        reshape_in.get_output(0),
-        pre_padding=(0, pad_left),
-        post_padding=(0, pad_right))
+    parts.append(inp)
 
-    reshape_out = network.add_shuffle(pad.get_output(0))
-    reshape_out.reshape_dims = (n, c, length + pad_left + pad_right)
-    return reshape_out.get_output(0)
+    if pad_right:
+        right_indices = np.arange(
+            length - 2, length - pad_right - 2, -1, dtype=np.int32)
+        right_index_tensor = add_constant(
+            network, (pad_right,), right_indices, dtype=np.int32)
+        parts.append(network.add_gather(inp, right_index_tensor, 2).get_output(0))
+
+    if len(parts) == 1:
+        return inp
+    concat = network.add_concatenation(parts)
+    concat.axis = 2
+    return concat.get_output(0)
 
 
 def add_slice_trim_right(
@@ -2150,7 +2159,7 @@ def add_lstm_unrolled(
     c_rec.set_input(1, c_new)
 
     # Collect h at every timestep: [1, H] → [1, seq_length, H]
-    h_output = loop.add_loop_output(h_rec.get_output(0), trt.LoopOutput.CONCATENATE, 1)
+    h_output = loop.add_loop_output(h_new, trt.LoopOutput.CONCATENATE, 1)
     h_output.set_input(1, trip_count.get_output(0))
 
     return h_output.get_output(0)

--- a/python/tensorrt_model_connect/families/bark/plugin.py
+++ b/python/tensorrt_model_connect/families/bark/plugin.py
@@ -853,7 +853,8 @@ def _build_bark_decoder_engine(
             weights[f"{lp}.w_fc1"])
         fc1 = graph_ops.add_bias_sum(network, fc1, ffn_hidden,
             weights[f"{lp}.b_fc1"])
-        gelu = graph_ops.add_gelu_new(network, fc1)
+        # HF BarkMLP uses nn.GELU() with the exact erf formulation.
+        gelu = graph_ops.add_gelu_erf(network, fc1)
         fc2 = graph_ops.add_matmul_rhs_constant(
             network, gelu, ffn_hidden, hidden,
             weights[f"{lp}.w_fc2"])
@@ -1024,7 +1025,8 @@ def _build_bark_fine_engine(
         fc1_bias = weights.get(f"{lp}.fc1_bias")
         if fc1_bias is not None:
             fc1 = graph_ops.add_bias_sum(network, fc1, mlp_size, fc1_bias)
-        gelu = graph_ops.add_gelu_new(network, fc1)
+        # HF BarkMLP uses nn.GELU() with the exact erf formulation.
+        gelu = graph_ops.add_gelu_erf(network, fc1)
         fc2 = graph_ops.add_matmul_rhs_constant(
             network, gelu, mlp_size, hidden, weights[f"{lp}.w_fc2"])
         fc2_bias = weights.get(f"{lp}.fc2_bias")

--- a/python/tensorrt_model_connect/families/bark/runtime_config_schema.py
+++ b/python/tensorrt_model_connect/families/bark/runtime_config_schema.py
@@ -42,6 +42,13 @@ SCHEMA = Schema(
             default=-1,  # -1 -> use default RNG state
             allowed_layers=_SESSION,
         ),
+        ConfigField(
+            name="fine_temperature",
+            type_tag="float",
+            default=0.5,
+            allowed_layers=_SESSION,
+            validator=lambda v: isinstance(v, (int, float)) and v > 0.0,
+        ),
     ),
 )
 

--- a/src/runtime/models/bark/bark_config.h
+++ b/src/runtime/models/bark/bark_config.h
@@ -44,6 +44,7 @@ struct BarkConfig {
     // Sampling parameters
     float semantic_temperature{0.7F};
     float coarse_temperature{0.7F};
+    float fine_temperature{0.5F};
     int32_t top_k{50};
     float min_eos_p{0.0F}; // 0 = disabled (matching HF bark-small default)
     bool greedy{false};    // if true, use argmax instead of sampling

--- a/src/runtime/models/bark/bark_generation_plan.h
+++ b/src/runtime/models/bark/bark_generation_plan.h
@@ -36,6 +36,10 @@ struct BarkFinePlan {
     int32_t last_predicted_codebook{8};
 };
 
+inline bool bark_fine_uses_sampling(const BarkConfig& cfg) {
+    return !cfg.greedy && std::abs(cfg.fine_temperature - 1.0F) > 1e-6F;
+}
+
 inline std::vector<int32_t> remap_bark_semantic_tokens(const std::vector<int32_t>& semantic_tokens,
                                                        const BarkConfig& cfg) {
     std::vector<int32_t> remapped;
@@ -164,6 +168,36 @@ inline std::vector<int32_t> initialize_bark_fine_codes(const std::vector<int32_t
         codes[static_cast<std::size_t>(codebook) * n_frames + frame] = raw;
     }
     return codes;
+}
+
+inline void build_bark_fine_input_embeddings(std::vector<float>& host_embeds,
+                                             const std::vector<int32_t>& codes, int32_t cb_idx,
+                                             int32_t n_frames, int32_t actual_frames,
+                                             int32_t max_seq, int32_t fine_hidden,
+                                             int32_t fine_cb_size, int32_t padding_code,
+                                             const std::vector<float>& fine_embed,
+                                             const std::vector<float>& fine_position_embed) {
+    std::fill(host_embeds.begin(), host_embeds.end(), 0.0F);
+    for (int32_t frame = 0; frame < max_seq; ++frame) {
+        float* dst = host_embeds.data() + static_cast<std::size_t>(frame) * fine_hidden;
+        for (int32_t cb = 0; cb <= cb_idx; ++cb) {
+            const int32_t code = frame < actual_frames
+                                     ? codes[static_cast<std::size_t>(cb) * n_frames + frame]
+                                     : padding_code;
+            const float* table =
+                fine_embed.data() + static_cast<std::size_t>(cb) * fine_cb_size * fine_hidden;
+            const float* row = table + static_cast<std::size_t>(code) * fine_hidden;
+            for (int32_t h = 0; h < fine_hidden; ++h) {
+                dst[h] += row[h];
+            }
+        }
+
+        const float* pos_row =
+            fine_position_embed.data() + static_cast<std::size_t>(frame) * fine_hidden;
+        for (int32_t h = 0; h < fine_hidden; ++h) {
+            dst[h] += pos_row[h];
+        }
+    }
 }
 
 inline std::vector<int32_t> make_bark_codec_input_codes(const std::vector<int32_t>& codes_flat,

--- a/src/runtime/models/bark/config_schema.cpp
+++ b/src/runtime/models/bark/config_schema.cpp
@@ -10,6 +10,16 @@
 
 namespace trtmc::config::schemas {
 
+namespace {
+bool is_positive_float(const std::any& value) {
+    if (value.type() == typeid(float))
+        return std::any_cast<float>(value) > 0.0F;
+    if (value.type() == typeid(double))
+        return std::any_cast<double>(value) > 0.0;
+    return false;
+}
+} // namespace
+
 Schema make_audio_bark_schema() {
     const std::set<Layer> session = {Layer::SessionRequest, Layer::PlatformProfile};
     return Schema{
@@ -18,6 +28,7 @@ Schema make_audio_bark_schema() {
             ConfigField{"dump_path", "string", std::any{std::string{}}, session, nullptr},
             ConfigField{"greedy", "bool", std::any{false}, session, nullptr},
             ConfigField{"seed", "int64", std::any{std::int64_t{-1}}, session, nullptr},
+            ConfigField{"fine_temperature", "float", std::any{0.5F}, session, is_positive_float},
         },
     };
 }

--- a/src/runtime/models/bark/pipeline.cpp
+++ b/src/runtime/models/bark/pipeline.cpp
@@ -115,32 +115,6 @@ std::vector<float> synthesize_simple_waveform(const std::vector<int32_t>& codes_
     return waveform;
 }
 
-void build_fine_input_embeddings(std::vector<float>& host_embeds, const std::vector<int32_t>& codes,
-                                 int32_t cb_idx, int32_t n_frames, int32_t actual_frames,
-                                 int32_t fine_hidden, int32_t fine_cb_size,
-                                 const std::vector<float>& fine_embed,
-                                 const std::vector<float>& fine_position_embed) {
-    std::fill(host_embeds.begin(), host_embeds.end(), 0.0F);
-    for (int32_t frame = 0; frame < actual_frames; ++frame) {
-        float* dst = host_embeds.data() + static_cast<std::size_t>(frame) * fine_hidden;
-        for (int32_t cb = 0; cb <= cb_idx; ++cb) {
-            const int32_t code = codes[static_cast<std::size_t>(cb) * n_frames + frame];
-            const float* table =
-                fine_embed.data() + static_cast<std::size_t>(cb) * fine_cb_size * fine_hidden;
-            const float* row = table + static_cast<std::size_t>(code) * fine_hidden;
-            for (int32_t h = 0; h < fine_hidden; ++h) {
-                dst[h] += row[h];
-            }
-        }
-
-        const float* pos_row =
-            fine_position_embed.data() + static_cast<std::size_t>(frame) * fine_hidden;
-        for (int32_t h = 0; h < fine_hidden; ++h) {
-            dst[h] += pos_row[h];
-        }
-    }
-}
-
 void update_fine_codes_from_logits(std::vector<int32_t>& codes,
                                    const std::vector<float>& host_logits, int32_t cb_idx,
                                    int32_t n_frames, int32_t actual_frames, int32_t fine_cb_size,
@@ -347,11 +321,14 @@ int32_t BarkPipeline::sample_top_k(const float* logits, int32_t vocab_size, floa
     top_k = std::min(top_k, vocab_size);
     std::vector<int32_t> indices(static_cast<std::size_t>(vocab_size));
     std::iota(indices.begin(), indices.end(), 0);
-    std::partial_sort(indices.begin(), indices.begin() + top_k, indices.end(),
-                      [logits](int32_t a, int32_t b) { return logits[a] > logits[b]; });
+    if (top_k < vocab_size) {
+        std::partial_sort(indices.begin(), indices.begin() + top_k, indices.end(),
+                          [logits](int32_t a, int32_t b) { return logits[a] > logits[b]; });
+    }
 
     std::vector<float> probs(static_cast<std::size_t>(top_k));
-    float max_logit = logits[indices[0]];
+    const float max_logit =
+        top_k < vocab_size ? logits[indices[0]] : *std::max_element(logits, logits + vocab_size);
     float sum = 0.0F;
     for (int32_t i = 0; i < top_k; ++i) {
         probs[i] = std::exp((logits[indices[i]] - max_logit) / temperature);
@@ -522,8 +499,9 @@ std::vector<int32_t> BarkPipeline::run_fine(const std::vector<int32_t>& coarse_t
     for (int32_t cb_idx = plan.first_predicted_codebook; cb_idx < plan.last_predicted_codebook;
          ++cb_idx) {
         // Build input embeddings on host
-        build_fine_input_embeddings(host_embeds, codes, cb_idx, plan.n_frames, plan.actual_frames,
-                                    fine_hidden, fine_cb_size, fine_embed_, fine_position_embed_);
+        build_bark_fine_input_embeddings(host_embeds, codes, cb_idx, plan.n_frames,
+                                         plan.actual_frames, max_seq, fine_hidden, fine_cb_size,
+                                         cfg.codebook_size, fine_embed_, fine_position_embed_);
 
         // Build TensorMap
         Tensor embed_tensor;
@@ -551,8 +529,18 @@ std::vector<int32_t> BarkPipeline::run_fine(const std::vector<int32_t>& coarse_t
                      logits_tensor.nbytes());
         std::memcpy(host_logits.data(), logits_tensor.data, logits_bytes);
 
-        update_fine_codes_from_logits(codes, host_logits, cb_idx, plan.n_frames, plan.actual_frames,
-                                      fine_cb_size, cfg.codebook_size);
+        if (bark_fine_uses_sampling(cfg)) {
+            const int32_t valid_range = std::min(cfg.codebook_size, fine_cb_size);
+            for (int32_t frame = 0; frame < plan.actual_frames; ++frame) {
+                const float* frame_logits =
+                    host_logits.data() + static_cast<std::size_t>(frame) * fine_cb_size;
+                codes[static_cast<std::size_t>(cb_idx) * plan.n_frames + frame] =
+                    sample_top_k(frame_logits, valid_range, cfg.fine_temperature, valid_range);
+            }
+        } else {
+            update_fine_codes_from_logits(codes, host_logits, cb_idx, plan.n_frames,
+                                          plan.actual_frames, fine_cb_size, cfg.codebook_size);
+        }
     }
 
     std::cerr << "[trtmc] Bark fine: predicted codebooks 2-7 for " << plan.n_frames << " frames"

--- a/src/runtime/models/bark/plugin.cpp
+++ b/src/runtime/models/bark/plugin.cpp
@@ -97,6 +97,8 @@ BarkConfig make_bark_config(const PipelineContext& ctx) {
             bark_cfg.dump_path = ctx.runtime_config->get<std::string>("audio_bark", "dump_path");
             bark_cfg.greedy = ctx.runtime_config->get<bool>("audio_bark", "greedy");
             bark_cfg.seed = ctx.runtime_config->get<std::int64_t>("audio_bark", "seed");
+            bark_cfg.fine_temperature =
+                ctx.runtime_config->get<float>("audio_bark", "fine_temperature");
         } catch (const std::exception&) {
             // Schema not registered or type mismatch: stay at defaults.
         }

--- a/tests/builder/test_graph_ops_extended.py
+++ b/tests/builder/test_graph_ops_extended.py
@@ -752,7 +752,73 @@ class TestAddCausalPad1d:
 
 
 # ===================================================================
-# 9. add_slice_trim_right (TRT)
+# 9. add_reflect_pad_1d (TRT)
+# ===================================================================
+
+@requires_trt
+class TestAddReflectPad1d:
+    def test_matches_torch_reflect_padding(self, trt_runner):
+        import torch
+        import torch.nn.functional as F
+        from tensorrt_model_connect.families.bark import graph_ops as bark_graph_ops
+
+        x_np = np.arange(1, 6, dtype=np.float32).reshape(1, 1, 5)
+
+        def build(net, inp):
+            out = bark_graph_ops.add_reflect_pad_1d(
+                net, inp["x"], pad_left=3, pad_right=2)
+            return {"out": out}
+
+        result = trt_runner(build, {"x": x_np})
+        expected = F.pad(torch.from_numpy(x_np), (3, 2), mode="reflect").numpy()
+        np.testing.assert_array_equal(result["out"], expected)
+
+
+# ===================================================================
+# 10. add_lstm_unrolled (TRT)
+# ===================================================================
+
+@requires_trt
+class TestAddLstmUnrolled:
+    def test_matches_torch_lstm(self, trt_runner):
+        import torch
+        import torch.nn as nn
+        from tensorrt_model_connect.families.bark import graph_ops as bark_graph_ops
+
+        rng = np.random.RandomState(7)
+        batch, seq_length, input_size, hidden_size = 1, 4, 2, 3
+        x_np = rng.randn(batch, seq_length, input_size).astype(np.float32)
+        w_ih = rng.randn(4 * hidden_size, input_size).astype(np.float32)
+        w_hh = rng.randn(4 * hidden_size, hidden_size).astype(np.float32)
+        b_ih = rng.randn(4 * hidden_size).astype(np.float32)
+        b_hh = rng.randn(4 * hidden_size).astype(np.float32)
+
+        def build(net, inp):
+            out = bark_graph_ops.add_lstm_unrolled(
+                net,
+                inp["x"],
+                w_ih,
+                w_hh,
+                b_ih,
+                b_hh,
+                hidden_size,
+                seq_length,
+            )
+            return {"out": out}
+
+        result = trt_runner(build, {"x": x_np})
+        lstm = nn.LSTM(input_size, hidden_size, batch_first=True)
+        with torch.no_grad():
+            lstm.weight_ih_l0.copy_(torch.from_numpy(w_ih))
+            lstm.weight_hh_l0.copy_(torch.from_numpy(w_hh))
+            lstm.bias_ih_l0.copy_(torch.from_numpy(b_ih))
+            lstm.bias_hh_l0.copy_(torch.from_numpy(b_hh))
+        expected = lstm(torch.from_numpy(x_np))[0].detach().numpy()
+        np.testing.assert_allclose(result["out"], expected, atol=1e-5, rtol=1e-5)
+
+
+# ===================================================================
+# 11. add_slice_trim_right (TRT)
 # ===================================================================
 
 @requires_trt
@@ -785,7 +851,7 @@ class TestAddSliceTrimRight:
 
 
 # ===================================================================
-# 10. add_batch_norm_2d (TRT)
+# 12. add_batch_norm_2d (TRT)
 # ===================================================================
 
 @requires_trt

--- a/tests/cpp/models/bark/test_bark_config_schema.cpp
+++ b/tests/cpp/models/bark/test_bark_config_schema.cpp
@@ -19,7 +19,7 @@ int main() {
     trtmc::load_model_plugin_for_strategy("text_to_audio_bark");
     const auto* schema = schemas.lookup("audio_bark");
     check(schema != nullptr, "bark plugin registers audio_bark schema");
-    check(schema != nullptr && schema->fields.size() == 3, "audio_bark field count");
+    check(schema != nullptr && schema->fields.size() == 4, "audio_bark field count");
 
     if (failures > 0) {
         std::cerr << failures << " bark config schema test(s) failed\n";

--- a/tests/cpp/models/bark/test_bark_generation_plan.cpp
+++ b/tests/cpp/models/bark/test_bark_generation_plan.cpp
@@ -106,6 +106,48 @@ void test_fine_plan_and_code_initialization() {
           "bark fine code init maps codebook one tokens");
 }
 
+void test_fine_sampling_policy_matches_hf() {
+    trtmc::BarkConfig cfg = make_config();
+    cfg.fine_temperature = 0.5F;
+    check(trtmc::bark_fine_uses_sampling(cfg),
+          "bark fine samples when HF temperature differs from one");
+
+    cfg.fine_temperature = 1.0F;
+    check(!trtmc::bark_fine_uses_sampling(cfg), "bark fine uses argmax at HF temperature one");
+
+    cfg.fine_temperature = 0.5F;
+    cfg.greedy = true;
+    check(!trtmc::bark_fine_uses_sampling(cfg), "bark global greedy disables fine sampling");
+}
+
+void test_fine_input_embeddings_use_hf_padding_code() {
+    constexpr int32_t n_frames = 1;
+    constexpr int32_t actual_frames = 1;
+    constexpr int32_t max_seq = 2;
+    constexpr int32_t hidden = 1;
+    constexpr int32_t codebook_size = 4;
+    constexpr int32_t fine_cb_size = 5;
+    const std::vector<int32_t> codes = {
+        1, 2, 4, 4, 4, 4, 4, 4,
+    };
+    std::vector<float> embeddings(8 * fine_cb_size * hidden, 0.0F);
+    for (int32_t cb = 0; cb < 8; ++cb) {
+        for (int32_t code = 0; code < fine_cb_size; ++code) {
+            embeddings[static_cast<std::size_t>(cb) * fine_cb_size + code] =
+                static_cast<float>(10 * cb + code);
+        }
+    }
+    const std::vector<float> positions = {100.0F, 200.0F};
+    std::vector<float> output(max_seq * hidden, 0.0F);
+
+    trtmc::build_bark_fine_input_embeddings(output, codes, 2, n_frames, actual_frames, max_seq,
+                                            hidden, fine_cb_size, codebook_size, embeddings,
+                                            positions);
+
+    check(output[0] == 137.0F, "bark fine embeddings use generated codes for real frames");
+    check(output[1] == 242.0F, "bark fine embeddings use HF padding code for padded frames");
+}
+
 void test_codec_input_builder_transposes_codebooks() {
     const std::vector<int32_t> codes_flat = {
         10, 11, 12, 20, 21, 22, 30, 31, 32,
@@ -130,6 +172,8 @@ int main() {
     test_coarse_window_plan_builds_context_and_history();
     test_codec_plan_prefers_fine_codes_when_available();
     test_fine_plan_and_code_initialization();
+    test_fine_sampling_policy_matches_hf();
+    test_fine_input_embeddings_use_hf_padding_code();
     test_codec_input_builder_transposes_codebooks();
 
     if (g_failures != 0) {

--- a/tests/task_eval/validation_suites.yaml
+++ b/tests/task_eval/validation_suites.yaml
@@ -394,3 +394,56 @@ suites:
         Intended for local/p2021 validation first. This suite is kept separate
         from librispeech_clean_asr because RNNT streaming baselines can differ
         from encoder-decoder ASR baselines.
+
+  - id: seedtts_en_tts_intelligibility
+    description: >
+      Local English text-to-audio evaluation on SeedTTS. Generated speech is
+      checked for a valid non-silent waveform and transcribed with ASR to
+      measure intelligibility against the requested text. Reference-waveform
+      duration is used only as a broad health check; sample-level waveform
+      similarity is intentionally not treated as a quality metric.
+    user_contract: tts_audio
+    default_model_names:
+      - bark-large
+      - bark-small
+      - magpie-tts-357m
+    dataset:
+      kind: seedtts_json
+      default_path: /mnt/data/SeedTTS_en_meta/seedtts_en_meta.json
+      prompt_source: messages
+      answer_field: reference
+      audio_field: reference_wav
+      language: en
+    selectors:
+      task_strategies:
+        - text_to_audio
+      runtime_strategies:
+        - text_to_audio_bark
+        - text_to_audio_magpie
+      user_contracts:
+        - tts_audio
+      families:
+        - bark
+        - magpie_tts
+    generation:
+      max_new_tokens: 750
+      seed: 42
+    scoring:
+      scorer: tts_intelligibility
+      asr_model: openai/whisper-large-v3-turbo
+      max_wer: 0.25
+      max_ned: 0.20
+      min_rms: 0.001
+      min_duration_ratio: 0.5
+      max_duration_ratio: 2.0
+    build:
+      min_max_cache_length: 1024
+    gates:
+      max_pass_rate_drop_from_hf: 0.05
+      min_correctness_agreement: 0.95
+    ci:
+      eligible: false
+      lane: local_only
+      notes: >
+        Start with a sampled local run. ASR dependencies and calibrated
+        per-family thresholds are required before enabling a CI gate.

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import struct
+import wave
 from pathlib import Path
 
 from tools import task_eval
@@ -26,6 +28,34 @@ def _write_mmlu(path: Path) -> None:
                 "answer": "A",
                 "subject": "subject_b",
             },
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_pcm_wav(path: Path, *, seconds: float = 1.0, sample_rate: int = 24000) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    samples = [1000 if index % 2 else -1000 for index in range(int(seconds * sample_rate))]
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(struct.pack(f"<{len(samples)}h", *samples))
+
+
+def _write_seedtts(path: Path) -> None:
+    reference_wav = path.parent / "reference.wav"
+    _write_pcm_wav(reference_wav)
+    payload = {
+        "speaker": "ryan",
+        "requests": [
+            {
+                "id": "seedtts-1",
+                "messages": [{"role": "assistant", "content": "The test sentence."}],
+                "reference": "The test sentence.",
+                "reference_wav": "reference.wav",
+                "prompt_text": "A speaker prompt.",
+            }
         ],
     }
     path.write_text(json.dumps(payload), encoding="utf-8")
@@ -158,6 +188,18 @@ def test_default_suites_do_not_split_librispeech_asr_by_family() -> None:
     assert "librispeech_clean_asr" in suite_ids
     assert "librispeech_clean_asr_whisper" not in suite_ids
     assert "librispeech_clean_asr_canary" not in suite_ids
+
+
+def test_default_suites_include_seedtts_tts_intelligibility() -> None:
+    suite = task_eval.suite_by_id(task_eval.load_suites(), "seedtts_en_tts_intelligibility")
+
+    assert suite["dataset"]["kind"] == "seedtts_json"
+    assert suite["scoring"]["scorer"] == "tts_intelligibility"
+    assert suite["default_model_names"] == [
+        "bark-large",
+        "bark-small",
+        "magpie-tts-357m",
+    ]
 
 
 def test_default_suites_include_librispeech_clean_asr_streaming() -> None:
@@ -451,6 +493,41 @@ def test_prepare_mmlu_writes_answers_and_trtfb_jsonl(tmp_path: Path) -> None:
     }]
     assert manifest["suite"] == "mmlu_five_shot_mcq"
     assert manifest["request_count"] == 1
+
+
+def test_prepare_seedtts_writes_resolved_audio_and_scoring_contract(tmp_path: Path) -> None:
+    dataset = tmp_path / "SeedTTS_en_meta" / "seedtts_en_meta.json"
+    dataset.parent.mkdir()
+    _write_seedtts(dataset)
+    suite = task_eval.suite_by_id(task_eval.load_suites(), "seedtts_en_tts_intelligibility")
+
+    outputs = task_eval.prepare_seedtts_dataset(
+        dataset_path=dataset,
+        work_dir=tmp_path / "work",
+        suite=suite,
+        limit=1,
+    )
+
+    answers = json.loads(outputs["answers"].read_text(encoding="utf-8"))
+    prompts = task_eval.load_jsonl(outputs["prompts"])
+    manifest = json.loads(outputs["manifest"].read_text(encoding="utf-8"))
+    reference_wav = str((dataset.parent / "reference.wav").resolve())
+
+    assert answers["requests"][0]["answer"] == "The test sentence."
+    assert answers["requests"][0]["reference_wav"] == reference_wav
+    assert answers["scoring"]["max_wer"] == 0.25
+    assert prompts == [{
+        "sample_id": "seedtts-1",
+        "dataset_index": 0,
+        "eval_index": 0,
+        "subject": "en",
+        "answer": "The test sentence.",
+        "prompt": "The test sentence.",
+        "reference_wav": reference_wav,
+        "language": "en",
+    }]
+    assert manifest["dataset_kind"] == "seedtts_json"
+    assert manifest["scoring"]["scorer"] == "tts_intelligibility"
 
 
 def test_prepare_vlm_mmmu_pro_vision_writes_image_prompt_jsonl(tmp_path: Path) -> None:
@@ -916,6 +993,159 @@ def test_score_predictions_accepts_answer_aliases() -> None:
     assert score["samples"][0]["answer_aliases"] == ["on"]
 
 
+def test_tts_intelligibility_scores_asr_and_waveform_health(tmp_path: Path) -> None:
+    reference_wav = tmp_path / "reference.wav"
+    generated_wav = tmp_path / "generated.wav"
+    _write_pcm_wav(reference_wav)
+    _write_pcm_wav(generated_wav, seconds=1.1)
+    answers = {
+        "scoring": {
+            "max_wer": 0.25,
+            "max_ned": 0.20,
+            "min_rms": 0.001,
+            "min_duration_ratio": 0.5,
+            "max_duration_ratio": 2.0,
+        },
+        "requests": [{
+            "id": "seedtts-1",
+            "reference": "The test sentence.",
+            "answer": "The test sentence.",
+            "reference_wav": str(reference_wav),
+            "subject": "en",
+        }],
+    }
+    predictions = {"responses": [{
+        "sample_id": "seedtts-1",
+        "output_text": "the test sentence",
+        "wav_path": str(generated_wav),
+    }]}
+
+    score = task_eval.score_predictions(predictions, answers, scorer="tts_intelligibility")
+
+    assert score["overall_accuracy"] == 1.0
+    assert score["mean_wer"] == 0.0
+    assert score["samples"][0]["wav_exists"] is True
+    assert 1.09 < score["samples"][0]["duration_ratio"] < 1.11
+
+
+def test_tts_intelligibility_fails_wrong_or_missing_audio(tmp_path: Path) -> None:
+    reference_wav = tmp_path / "reference.wav"
+    _write_pcm_wav(reference_wav)
+    answers = {
+        "scoring": {"max_wer": 0.25, "max_ned": 0.20},
+        "requests": [{
+            "reference": "The test sentence.",
+            "answer": "The test sentence.",
+            "reference_wav": str(reference_wav),
+        }],
+    }
+    predictions = {"responses": [{
+        "sample_id": "seedtts-1",
+        "output_text": "completely different words",
+        "wav_path": str(tmp_path / "missing.wav"),
+    }]}
+
+    score = task_eval.score_predictions(predictions, answers, scorer="tts_intelligibility")
+
+    assert score["overall_accuracy"] == 0.0
+    assert score["samples"][0]["correct"] is False
+    assert score["samples"][0]["wer"] > 0.25
+
+
+def test_tts_disagreement_reports_full_normalized_transcripts(tmp_path: Path) -> None:
+    reference_wav = tmp_path / "reference.wav"
+    hf_wav = tmp_path / "hf.wav"
+    trtfb_wav = tmp_path / "trtfb.wav"
+    for wav_path in (reference_wav, hf_wav, trtfb_wav):
+        _write_pcm_wav(wav_path)
+    answers = {
+        "requests": [{
+            "answer": "I'm never more aware of a room's acoustics.",
+            "reference_wav": str(reference_wav),
+        }],
+    }
+    hf = {"responses": [{
+        "sample_id": "seedtts-1",
+        "output_text": "I'm never more aware of a room's acoustics.",
+        "wav_path": str(hf_wav),
+    }]}
+    trtfb = {"responses": [{
+        "sample_id": "seedtts-1",
+        "output_text": "I am never more aware of other rooms.",
+        "wav_path": str(trtfb_wav),
+    }]}
+
+    summary = task_eval.compare_prediction_sets(
+        hf, trtfb, answers, scorer="tts_intelligibility")
+
+    assert summary["disagreements"][0]["hf_prediction"] == (
+        "i m never more aware of a room s acoustics")
+    assert summary["disagreements"][0]["trtfb_prediction"] == (
+        "i am never more aware of other rooms")
+
+
+def test_run_tts_trtfb_generates_audio_and_batches_asr(tmp_path: Path, monkeypatch) -> None:
+    dataset = tmp_path / "SeedTTS_en_meta" / "seedtts_en_meta.json"
+    dataset.parent.mkdir()
+    _write_seedtts(dataset)
+    suite = task_eval.suite_by_id(task_eval.load_suites(), "seedtts_en_tts_intelligibility")
+    work_dir = tmp_path / "work"
+    task_eval.prepare_seedtts_dataset(
+        dataset_path=dataset,
+        work_dir=work_dir,
+        suite=suite,
+        limit=1,
+        task_eval_config={
+            "family": "bark",
+            "model_max_new_tokens": 12,
+            "runtime_config": {"audio_magpie": {"seed": 42}},
+        },
+    )
+    commands: list[list[str]] = []
+
+    class Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, **_kwargs):
+        commands.append(cmd)
+        output = Path(cmd[cmd.index("--output") + 1])
+        _write_pcm_wav(output)
+        return Result()
+
+    monkeypatch.setattr(task_eval.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        task_eval,
+        "_transcribe_audio_files",
+        lambda paths, **_kwargs: ["The test sentence." for _path in paths],
+    )
+    args = argparse.Namespace(
+        work_dir=str(work_dir),
+        raw_output="",
+        predictions="",
+        log="",
+        max_new_tokens=None,
+        bundle="model.trtfb",
+        trtmc_binary="build/trtmc",
+        hf_python="",
+        backend_dir="",
+        config="",
+        set=[],
+        cuda_visible_devices="",
+    )
+
+    task_eval.run_tts_trtfb(args)
+
+    assert commands[0][:3] == ["build/trtmc", "generate-audio", "model.trtfb"]
+    assert commands[0][commands[0].index("--max-new-tokens") + 1] == "12"
+    assert "audio_magpie.seed=42" in commands[0]
+    assert "audio_bark.seed=42" in commands[0]
+    predictions = json.loads((work_dir / "trtfb_predictions.json").read_text(encoding="utf-8"))
+    assert predictions["responses"][0]["output_text"] == "The test sentence."
+    assert Path(predictions["responses"][0]["wav_path"]).is_file()
+
+
 def test_ocrbench_v2_scores_short_vqa_with_contains() -> None:
     answers = {"requests": [{
         "answer": "San Francisco",
@@ -1118,6 +1348,35 @@ def test_selected_models_for_suite_accepts_manifest_name() -> None:
     )
 
     assert [model["name"] for model in selected] == ["decoder-chat"]
+
+
+def test_seedtts_default_selection_uses_canonical_single_device_models() -> None:
+    suite = task_eval.suite_by_id(task_eval.load_suites(), "seedtts_en_tts_intelligibility")
+
+    selected = task_eval.selected_models_for_suite(
+        suite,
+        task_eval.load_manifest_records(),
+        single_device_only=True,
+    )
+
+    assert {model["name"] for model in selected} == {
+        "bark-large",
+        "bark-small",
+        "magpie-tts-357m",
+    }
+
+
+def test_seedtts_plan_marks_only_default_models_selected() -> None:
+    suite = task_eval.suite_by_id(task_eval.load_suites(), "seedtts_en_tts_intelligibility")
+    rows = task_eval.build_plan(
+        [suite],
+        task_eval.load_manifest_records(),
+        suite_id=suite["id"],
+        include_non_matching=True,
+    )
+    selected = {row["model"] for row in rows if row["selected"]}
+
+    assert selected == {"bark-large", "bark-small", "magpie-tts-357m"}
 
 
 def test_waives_exclude_default_selection_but_explicit_model_can_debug(tmp_path: Path) -> None:

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -12,6 +12,7 @@ import os
 import random
 import re
 import shutil
+import struct
 import traceback
 import subprocess
 import sys
@@ -123,6 +124,8 @@ def manifest_record(path: Path) -> dict[str, Any]:
         "build_args": build_args if isinstance(build_args, dict) else {},
         "fp8_scales": raw.get("fp8_scales", ""),
         "task_eval": task_eval_config if isinstance(task_eval_config, dict) else {},
+        "runtime_config": raw.get("runtime_config", {}) if isinstance(raw.get("runtime_config", {}), dict) else {},
+        "max_new_tokens": raw.get("max_new_tokens"),
     }
 
 
@@ -356,6 +359,101 @@ def prepare_mmlu_dataset(
             "answers": str(answers_path),
             "prompts": str(prompts_path),
         },
+    }
+    if task_eval_config:
+        manifest["task_eval"] = task_eval_config
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return {"answers": answers_path, "prompts": prompts_path, "manifest": manifest_path}
+
+
+def load_seedtts_requests(
+    dataset_path: Path,
+    *,
+    limit: int = 0,
+    sample_seed: int | None = None,
+) -> tuple[dict[str, Any], list[tuple[int, dict[str, Any]]]]:
+    data = json.loads(dataset_path.read_text(encoding="utf-8"))
+    requests = data.get("requests")
+    if not isinstance(requests, list):
+        raise ValueError(f"{dataset_path}: expected top-level 'requests' list")
+    indexed = list(enumerate(requests))
+    if sample_seed is not None:
+        rng = random.Random(sample_seed)
+        rng.shuffle(indexed)
+    if limit > 0:
+        indexed = indexed[:limit]
+    return data, indexed
+
+
+def prepare_seedtts_dataset(
+    *,
+    dataset_path: Path,
+    work_dir: Path,
+    suite: dict[str, Any],
+    limit: int = 0,
+    subject: str = "",
+    sample_seed: int | None = None,
+    task_eval_config: dict[str, Any] | None = None,
+) -> dict[str, Path]:
+    if subject:
+        raise ValueError("SeedTTS task eval does not support --subject; select a language suite instead")
+    data, indexed = load_seedtts_requests(
+        dataset_path,
+        limit=limit,
+        sample_seed=sample_seed,
+    )
+    dataset_config = suite.get("dataset", {})
+    language = str(dataset_config.get("language", "") or "")
+    prepared_requests: list[dict[str, Any]] = []
+    prompt_rows: list[dict[str, Any]] = []
+    for out_idx, (dataset_index, request) in enumerate(indexed):
+        if not isinstance(request, dict):
+            raise ValueError(f"{dataset_path}: request {dataset_index} must be an object")
+        reference = str(request.get("reference", "") or "").strip()
+        if not reference:
+            raise ValueError(f"{dataset_path}: request {dataset_index} has no reference text")
+        audio_ref = str(request.get("reference_wav", "") or "")
+        if not audio_ref:
+            raise ValueError(f"{dataset_path}: request {dataset_index} has no reference_wav")
+        reference_wav = resolve_dataset_asset_path(dataset_path, audio_ref)
+        sample_id = str(request.get("id", f"seedtts_{dataset_index:06d}"))
+        prepared = dict(request)
+        prepared["answer"] = reference
+        prepared["reference_wav"] = str(reference_wav)
+        prepared["subject"] = language
+        prepared_requests.append(prepared)
+        prompt_rows.append({
+            "sample_id": sample_id,
+            "dataset_index": dataset_index,
+            "eval_index": out_idx,
+            "subject": language,
+            "answer": reference,
+            "prompt": reference,
+            "reference_wav": str(reference_wav),
+            "language": language,
+        })
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    answers_path = work_dir / "answers.json"
+    prompts_path = work_dir / "prompts.jsonl"
+    manifest_path = work_dir / "manifest.json"
+    answers = _copy_dataset_header(data, prepared_requests)
+    answers["scoring"] = suite.get("scoring", {})
+    answers_path.write_text(json.dumps(answers, indent=2, ensure_ascii=False), encoding="utf-8")
+    with prompts_path.open("w", encoding="utf-8") as f:
+        for row in prompt_rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+    manifest = {
+        "suite": suite["id"],
+        "dataset": str(dataset_path),
+        "dataset_kind": dataset_config.get("kind", ""),
+        "request_count": len(indexed),
+        "language": language,
+        "limit": limit,
+        "sample_seed": sample_seed,
+        "generation": suite.get("generation", {}),
+        "scoring": suite.get("scoring", {}),
+        "files": {"answers": str(answers_path), "prompts": str(prompts_path)},
     }
     if task_eval_config:
         manifest["task_eval"] = task_eval_config
@@ -1056,6 +1154,16 @@ def prepare_task_dataset(
             sample_seed=sample_seed,
             task_eval_config=task_eval_config,
         )
+    if dataset_kind == "seedtts_json":
+        return prepare_seedtts_dataset(
+            dataset_path=dataset_path,
+            work_dir=work_dir,
+            suite=suite,
+            limit=limit,
+            subject=subject,
+            sample_seed=sample_seed,
+            task_eval_config=task_eval_config,
+        )
     if dataset_kind == "vlm_chat_json":
         return prepare_vlm_chat_dataset(
             dataset_path=dataset_path,
@@ -1243,7 +1351,8 @@ def run_vlm_trtfb(args: argparse.Namespace) -> None:
     top_k = args.top_k if args.top_k is not None else int(defaults.get("top_k", 1))
     top_p = args.top_p if args.top_p is not None else float(defaults.get("top_p", 1.0))
     min_p = args.min_p if args.min_p is not None else float(defaults.get("min_p", 0.0))
-    seed = args.seed if args.seed is not None else int(defaults.get("seed", -1))
+    arg_seed = getattr(args, "seed", None)
+    seed = arg_seed if arg_seed is not None else int(defaults.get("seed", -1))
 
     env = os.environ.copy()
     if args.cuda_visible_devices:
@@ -2378,6 +2487,169 @@ def score_ocrbench_v2_predictions(
     }
 
 
+def _read_wav_metrics(path: Path) -> dict[str, Any]:
+    with path.open("rb") as f:
+        if f.read(4) != b"RIFF":
+            raise ValueError(f"{path}: not a RIFF WAV file")
+        f.read(4)
+        if f.read(4) != b"WAVE":
+            raise ValueError(f"{path}: not a WAVE file")
+        audio_format = 1
+        channels = 1
+        sample_rate = 0
+        bits_per_sample = 16
+        data = b""
+        while True:
+            chunk_id = f.read(4)
+            if len(chunk_id) < 4:
+                break
+            size_bytes = f.read(4)
+            if len(size_bytes) < 4:
+                break
+            chunk_size = struct.unpack("<I", size_bytes)[0]
+            payload = f.read(chunk_size)
+            if chunk_size % 2:
+                f.read(1)
+            if chunk_id == b"fmt " and len(payload) >= 16:
+                audio_format, channels, sample_rate = struct.unpack("<HHI", payload[:8])
+                bits_per_sample = struct.unpack("<H", payload[14:16])[0]
+            elif chunk_id == b"data":
+                data = payload
+    bytes_per_sample = max(bits_per_sample // 8, 1)
+    frame_size = bytes_per_sample * max(channels, 1)
+    frame_count = len(data) // frame_size
+    duration_s = frame_count / sample_rate if sample_rate else 0.0
+    if not data or bits_per_sample not in {16, 32}:
+        rms = 0.0
+    elif audio_format == 3 and bits_per_sample == 32:
+        count = len(data) // 4
+        samples = struct.unpack(f"<{count}f", data[:count * 4])
+        rms = math.sqrt(sum(float(value) ** 2 for value in samples) / count) if count else 0.0
+    elif audio_format == 1 and bits_per_sample == 16:
+        count = len(data) // 2
+        samples = struct.unpack(f"<{count}h", data[:count * 2])
+        rms = math.sqrt(sum((float(value) / 32768.0) ** 2 for value in samples) / count) if count else 0.0
+    else:
+        rms = 0.0
+    return {
+        "sample_rate": sample_rate,
+        "channels": channels,
+        "duration_s": duration_s,
+        "rms": rms,
+        "frame_count": frame_count,
+    }
+
+
+def _tts_normalize_text(text: str) -> str:
+    return " ".join(re.findall(r"\w+", text.lower(), flags=re.UNICODE))
+
+
+def _tts_word_error_rate(prediction: str, reference: str) -> float:
+    predicted_words = _tts_normalize_text(prediction).split()
+    reference_words = _tts_normalize_text(reference).split()
+    if not reference_words:
+        return 0.0 if not predicted_words else 1.0
+    return _levenshtein_distance(predicted_words, reference_words) / len(reference_words)
+
+
+def score_tts_intelligibility_predictions(
+    predictions_data: dict[str, Any],
+    answers_data: dict[str, Any],
+) -> dict[str, Any]:
+    responses = predictions_data.get("responses", [])
+    requests = answers_data.get("requests", [])
+    if len(responses) != len(requests):
+        raise ValueError(
+            f"Predictions and answers must have the same length: {len(responses)} != {len(requests)}"
+        )
+    config = answers_data.get("scoring", {})
+    config = config if isinstance(config, dict) else {}
+    max_wer = float(config.get("max_wer", 0.25))
+    max_ned = float(config.get("max_ned", 0.20))
+    min_rms = float(config.get("min_rms", 0.001))
+    min_duration_ratio = float(config.get("min_duration_ratio", 0.5))
+    max_duration_ratio = float(config.get("max_duration_ratio", 2.0))
+    correct = 0
+    samples: list[dict[str, Any]] = []
+    wers: list[float] = []
+    neds: list[float] = []
+    for idx, (response, request) in enumerate(zip(responses, requests, strict=True)):
+        reference = str(request.get("reference", request.get("answer", "")))
+        transcript = str(response.get("output_text", response.get("asr_transcript", "")) or "")
+        wav_path = Path(str(response.get("wav_path", "")))
+        wav_exists = wav_path.is_file()
+        metrics: dict[str, Any] = {}
+        error = str(response.get("error", "") or "")
+        if wav_exists:
+            try:
+                metrics = _read_wav_metrics(wav_path)
+            except (OSError, ValueError, struct.error) as exc:
+                error = str(exc)
+        rms = float(response.get("rms", metrics.get("rms", 0.0)) or 0.0)
+        duration_s = float(response.get("duration_s", metrics.get("duration_s", 0.0)) or 0.0)
+        reference_duration_s = 0.0
+        reference_wav = Path(str(request.get("reference_wav", "")))
+        if reference_wav.is_file():
+            try:
+                reference_duration_s = float(_read_wav_metrics(reference_wav)["duration_s"])
+            except (OSError, ValueError, struct.error):
+                reference_duration_s = 0.0
+        duration_ratio = duration_s / reference_duration_s if reference_duration_s > 0 else 0.0
+        wer = _tts_word_error_rate(transcript, reference)
+        normalized_prediction = _tts_normalize_text(transcript)
+        normalized_reference = _tts_normalize_text(reference)
+        ned = 1.0 - _normalized_edit_similarity(normalized_prediction, normalized_reference)
+        wers.append(wer)
+        neds.append(ned)
+        ok = (
+            not error
+            and wav_exists
+            and rms >= min_rms
+            and min_duration_ratio <= duration_ratio <= max_duration_ratio
+            and bool(normalized_prediction)
+            and wer <= max_wer
+            and ned <= max_ned
+        )
+        correct += int(ok)
+        samples.append({
+            "index": idx,
+            "sample_id": response.get("sample_id", f"sample_{idx}"),
+            "subject": request.get("subject", ""),
+            "answer": reference,
+            "prediction": transcript,
+            "wav_path": str(wav_path) if str(wav_path) else "",
+            "wav_exists": wav_exists,
+            "rms": rms,
+            "duration_s": duration_s,
+            "reference_duration_s": reference_duration_s,
+            "duration_ratio": duration_ratio,
+            "wer": wer,
+            "ned": ned,
+            "score": 1.0 if ok else 0.0,
+            "correct": ok,
+            "skipped": False,
+            "error": error,
+        })
+    total = len(requests)
+    return {
+        "overall_accuracy": correct / total if total else 0.0,
+        "correct": correct,
+        "valid_count": total,
+        "skipped_count": 0,
+        "total_count": total,
+        "mean_wer": _mean(wers),
+        "mean_ned": _mean(neds),
+        "thresholds": {
+            "max_wer": max_wer,
+            "max_ned": max_ned,
+            "min_rms": min_rms,
+            "min_duration_ratio": min_duration_ratio,
+            "max_duration_ratio": max_duration_ratio,
+        },
+        "samples": samples,
+    }
+
+
 def score_predictions(
     predictions_data: dict[str, Any],
     answers_data: dict[str, Any],
@@ -2388,6 +2660,8 @@ def score_predictions(
         return score_ocrbench_v2_predictions(predictions_data, answers_data)
     if scorer == "asr_transcript":
         return score_asr_transcript_predictions(predictions_data, answers_data)
+    if scorer == "tts_intelligibility":
+        return score_tts_intelligibility_predictions(predictions_data, answers_data)
 
     responses = predictions_data.get("responses", [])
     requests = answers_data.get("requests", [])
@@ -2478,6 +2752,9 @@ def compare_prediction_sets(
         if scorer == "asr_transcript":
             hf_pred = normalize_asr_transcript(str(hf_row.get("output_text", "")))
             trt_pred = normalize_asr_transcript(str(trt_row.get("output_text", "")))
+        elif scorer == "tts_intelligibility":
+            hf_pred = _tts_normalize_text(str(hf_row.get("output_text", "")))
+            trt_pred = _tts_normalize_text(str(trt_row.get("output_text", "")))
         else:
             hf_pred = parse_multi_choice_response(clean_text(str(hf_row.get("output_text", ""))))
             trt_pred = parse_multi_choice_response(clean_text(str(trt_row.get("output_text", ""))))
@@ -2485,7 +2762,11 @@ def compare_prediction_sets(
         trtfb_sample = trtfb_score["samples"][idx]
         hf_ok = bool(hf_sample.get("correct", False))
         trt_ok = bool(trtfb_sample.get("correct", False))
-        agreement_match = (hf_ok == trt_ok) if scorer in {"ocrbench_v2", "asr_transcript"} else (hf_pred == trt_pred)
+        agreement_match = (
+            hf_ok == trt_ok
+            if scorer in {"ocrbench_v2", "asr_transcript", "tts_intelligibility"}
+            else hf_pred == trt_pred
+        )
         agreement += int(agreement_match)
         if hf_ok and trt_ok:
             buckets["both_correct"] += 1
@@ -2574,6 +2855,123 @@ def _is_vlm_dataset_kind(kind: str) -> bool:
 
 def _is_asr_dataset_kind(kind: str) -> bool:
     return kind in {"asr_chat_json"}
+
+
+def _is_tts_dataset_kind(kind: str) -> bool:
+    return kind == "seedtts_json"
+
+
+def work_scoring(work_dir: Path) -> dict[str, Any]:
+    scoring = work_manifest(work_dir).get("scoring", {})
+    return scoring if isinstance(scoring, dict) else {}
+
+
+def _write_pcm16_wav(path: Path, audio: Any, sample_rate: int) -> None:
+    import numpy as np
+
+    samples = np.asarray(audio, dtype=np.float32).reshape(-1)
+    peak = float(np.max(np.abs(samples))) if samples.size else 0.0
+    if peak > 1.0:
+        samples = samples / peak
+    pcm = (samples * 32767.0).clip(-32768, 32767).astype(np.int16)
+    data = pcm.tobytes()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as f:
+        f.write(b"RIFF")
+        f.write(struct.pack("<I", 36 + len(data)))
+        f.write(b"WAVEfmt ")
+        f.write(struct.pack("<IHHIIHH", 16, 1, 1, sample_rate, sample_rate * 2, 2, 16))
+        f.write(b"data")
+        f.write(struct.pack("<I", len(data)))
+        f.write(data)
+
+
+def _transcribe_audio_files(
+    wav_paths: list[Path],
+    *,
+    python: str,
+    model_id: str,
+    local_files_only: bool = False,
+) -> list[str]:
+    if not wav_paths:
+        return []
+    script = """
+import json
+import numpy as np
+import torch
+from scipy.io import wavfile
+from scipy.signal import resample
+from transformers import pipeline
+
+paths = %(paths)r
+model_id = %(model_id)r
+local_files_only = %(local_files_only)r
+device = 0 if torch.cuda.is_available() else -1
+model_kwargs = {"local_files_only": True} if local_files_only else {}
+transcriber = pipeline(
+    "automatic-speech-recognition",
+    model=model_id,
+    device=device,
+    model_kwargs=model_kwargs,
+)
+target_sample_rate = int(transcriber.feature_extractor.sampling_rate)
+waveforms = []
+for path in paths:
+    sample_rate, audio = wavfile.read(path)
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    if np.issubdtype(audio.dtype, np.integer):
+        info = np.iinfo(audio.dtype)
+        audio = audio.astype(np.float32) / max(abs(info.min), info.max)
+    else:
+        audio = audio.astype(np.float32)
+    if sample_rate != target_sample_rate:
+        target_length = int(round(len(audio) * target_sample_rate / sample_rate))
+        audio = resample(audio, target_length).astype(np.float32)
+    waveforms.append(audio)
+outputs = transcriber(waveforms, batch_size=min(8, len(waveforms)))
+if isinstance(outputs, dict):
+    outputs = [outputs]
+print(json.dumps([str(item.get("text", "")).strip() for item in outputs]))
+""" % {
+        "paths": [str(path) for path in wav_paths],
+        "model_id": model_id,
+        "local_files_only": local_files_only,
+    }
+    proc = subprocess.run(
+        [python, "-c", script],
+        check=False,
+        text=True,
+        capture_output=True,
+        timeout=max(600, 120 * len(wav_paths)),
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"TTS ASR transcription failed rc={proc.returncode}: {proc.stderr[-2000:]}"
+        )
+    for line in reversed(proc.stdout.splitlines()):
+        try:
+            transcripts = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(transcripts, list) and len(transcripts) == len(wav_paths):
+            return [str(value) for value in transcripts]
+    raise RuntimeError("TTS ASR transcription produced no parseable transcript list")
+
+
+def _tts_response_row(sample_id: str, wav_path: Path, wall_ms: float, source: str) -> dict[str, Any]:
+    metrics = _read_wav_metrics(wav_path)
+    return {
+        "sample_id": sample_id,
+        "output_text": "",
+        "wav_path": str(wav_path),
+        "wav_exists": True,
+        "rms": metrics["rms"],
+        "duration_s": metrics["duration_s"],
+        "sample_rate": metrics["sample_rate"],
+        "wall_ms": wall_ms,
+        "source": source,
+    }
 
 
 def _is_canary_asr_reference(args: argparse.Namespace) -> bool:
@@ -3221,8 +3619,116 @@ def _run_nemo_asr_hf_pipeline_reference(
     write_predictions(pred_path, responses)
 
 
+def run_tts_hf_reference(args: argparse.Namespace) -> None:
+    try:
+        import numpy as np
+        import torch
+    except Exception as exc:  # pragma: no cover - runtime dependency
+        raise RuntimeError("TTS run-hf requires numpy and torch") from exc
+
+    work_dir = Path(args.work_dir)
+    answers = json.loads((work_dir / "answers.json").read_text(encoding="utf-8"))
+    prompt_rows = load_jsonl(work_dir / "prompts.jsonl")
+    if len(prompt_rows) != len(answers["requests"]):
+        raise ValueError("answers.json and prompts.jsonl must contain the same number of samples")
+    defaults = generation_defaults(work_dir)
+    seed = args.seed if args.seed is not None else int(defaults.get("seed", 42))
+    device = torch.device(args.device)
+    output_dir = work_dir / "hf_audio"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    is_magpie = "magpie" in args.model.lower()
+
+    if is_magpie:
+        try:
+            from nemo.collections.tts.models import MagpieTTSModel
+        except Exception as exc:  # pragma: no cover - runtime dependency
+            raise RuntimeError("Magpie TTS reference requires NeMo MagpieTTSModel") from exc
+        model = MagpieTTSModel.from_pretrained(args.model).eval().to(device)
+        processor = None
+    else:
+        try:
+            from transformers import AutoProcessor, BarkModel, logging
+        except Exception as exc:  # pragma: no cover - runtime dependency
+            raise RuntimeError("Bark TTS reference requires transformers BarkModel") from exc
+        logging.set_verbosity_error()
+        processor = AutoProcessor.from_pretrained(
+            args.model,
+            trust_remote_code=args.trust_remote_code,
+            local_files_only=args.local_files_only,
+        )
+        dtype = _model_dtype(torch, args.dtype)
+        model = BarkModel.from_pretrained(
+            args.model,
+            trust_remote_code=args.trust_remote_code,
+            local_files_only=args.local_files_only,
+            torch_dtype=dtype,
+        ).eval().to(device)
+
+    raw_path = work_dir / (args.raw_output or "hf_raw.jsonl")
+    pred_path = work_dir / (args.predictions or "hf_predictions.json")
+    responses: list[dict[str, Any]] = []
+    with raw_path.open("w", encoding="utf-8") as raw_f:
+        for idx, prompt_row in enumerate(prompt_rows):
+            prompt = str(prompt_row.get("prompt", ""))
+            sample_id = str(prompt_row.get("sample_id", f"seedtts_{idx:06d}"))
+            sample_seed = seed + idx
+            random.seed(sample_seed)
+            np.random.seed(sample_seed)
+            torch.manual_seed(sample_seed)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(sample_seed)
+            start = time.perf_counter()
+            with torch.inference_mode():
+                if is_magpie:
+                    audio_tensor, audio_len = model.do_tts(
+                        transcript=prompt,
+                        language=str(prompt_row.get("language", "en") or "en"),
+                        use_cfg=True,
+                    )
+                    audio = audio_tensor.detach().cpu().numpy().reshape(-1)
+                    actual_len = int(audio_len.item()) if audio_len.numel() else len(audio)
+                    audio = audio[:actual_len]
+                    sample_rate = 22050
+                else:
+                    inputs = processor(prompt, return_tensors="pt")
+                    inputs = _to_device(inputs, device)
+                    audio_values = model.generate(**inputs)
+                    audio = audio_values.detach().cpu().numpy().reshape(-1)
+                    sample_rate = int(model.generation_config.sample_rate)
+            wall_ms = (time.perf_counter() - start) * 1000.0
+            wav_path = output_dir / f"{_safe_sample_filename(sample_id, '.wav')}"
+            _write_pcm16_wav(wav_path, np.asarray(audio), sample_rate)
+            row = _tts_response_row(sample_id, wav_path, wall_ms, "hf")
+            responses.append(row)
+            raw_f.write(json.dumps(row, ensure_ascii=False) + "\n")
+            raw_f.flush()
+            print(f"[task_eval.tts_hf] sample={idx + 1}/{len(prompt_rows)}", file=sys.stderr)
+
+    del model
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    scoring = work_scoring(work_dir)
+    transcripts = _transcribe_audio_files(
+        [Path(row["wav_path"]) for row in responses],
+        python=sys.executable,
+        model_id=str(scoring.get("asr_model", "openai/whisper-large-v3-turbo")),
+        local_files_only=args.local_files_only,
+    )
+    for row, transcript in zip(responses, transcripts, strict=True):
+        row["output_text"] = transcript
+        row["asr_transcript"] = transcript
+    write_predictions(pred_path, responses)
+    with raw_path.open("w", encoding="utf-8") as raw_f:
+        for row in responses:
+            raw_f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
 def run_hf_reference(args: argparse.Namespace) -> None:
     dataset_kind = _work_dataset_kind(Path(args.work_dir))
+    if _is_tts_dataset_kind(dataset_kind):
+        run_tts_hf_reference(args)
+        return
     if _is_vlm_dataset_kind(dataset_kind):
         run_vlm_hf_reference(args)
         return
@@ -3342,9 +3848,119 @@ def run_hf_reference(args: argparse.Namespace) -> None:
         torch.cuda.empty_cache()
 
 
+def _runtime_config_tokens(config: dict[str, Any], prefix: str = "") -> list[str]:
+    tokens: list[str] = []
+    for key, value in config.items():
+        name = f"{prefix}.{key}" if prefix else str(key)
+        if isinstance(value, dict):
+            tokens.extend(_runtime_config_tokens(value, name))
+        elif isinstance(value, bool):
+            tokens.append(f"{name}={'true' if value else 'false'}")
+        elif value is not None:
+            tokens.append(f"{name}={value}")
+    return tokens
+
+
+def run_tts_trtfb(args: argparse.Namespace) -> None:
+    work_dir = Path(args.work_dir)
+    defaults = generation_defaults(work_dir)
+    task_config = work_manifest(work_dir).get("task_eval", {})
+    task_config = task_config if isinstance(task_config, dict) else {}
+    prompt_rows = load_jsonl(work_dir / "prompts.jsonl")
+    output_dir = work_dir / "trtfb_audio"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    raw_output = work_dir / (args.raw_output or "trtfb_raw.jsonl")
+    predictions = work_dir / (args.predictions or "trtfb_predictions.json")
+    log_path = work_dir / (args.log or "trtfb_run.log")
+    model_max_new_tokens = task_config.get("model_max_new_tokens")
+    max_new_tokens = (
+        args.max_new_tokens
+        if args.max_new_tokens is not None
+        else int(model_max_new_tokens if model_max_new_tokens is not None else defaults.get("max_new_tokens", 0))
+    )
+    runtime_config = task_config.get("runtime_config", {})
+    runtime_config = runtime_config if isinstance(runtime_config, dict) else {}
+    set_tokens = _runtime_config_tokens(runtime_config) + list(args.set or [])
+    family = str(task_config.get("family", "") or "")
+    arg_seed = getattr(args, "seed", None)
+    seed = arg_seed if arg_seed is not None else int(defaults.get("seed", -1))
+    has_explicit_bark_seed = any(
+        token.split("=", 1)[0] == "audio_bark.seed" for token in set_tokens
+    )
+    env = os.environ.copy()
+    if args.cuda_visible_devices:
+        env["CUDA_VISIBLE_DEVICES"] = args.cuda_visible_devices
+    responses: list[dict[str, Any]] = []
+    with raw_output.open("w", encoding="utf-8") as raw_f, log_path.open("w", encoding="utf-8") as log_f:
+        for idx, prompt_row in enumerate(prompt_rows):
+            sample_id = str(prompt_row.get("sample_id", f"seedtts_{idx:06d}"))
+            wav_path = output_dir / _safe_sample_filename(sample_id, ".wav")
+            cmd = [
+                _trtmc_binary_from_args(args),
+                "generate-audio",
+                args.bundle,
+                "--prompt",
+                str(prompt_row.get("prompt", "")),
+                "--output",
+                str(wav_path),
+            ]
+            if max_new_tokens > 0:
+                cmd.extend(["--max-new-tokens", str(max_new_tokens)])
+            if args.hf_python:
+                cmd.extend(["--hf-python", args.hf_python])
+            if args.backend_dir:
+                cmd.extend(["--backend-dir", args.backend_dir])
+            if args.config:
+                cmd.extend(["--config", args.config])
+            sample_set_tokens = list(set_tokens)
+            if family == "bark" and seed >= 0 and not has_explicit_bark_seed:
+                sample_set_tokens.append(f"audio_bark.seed={seed + idx}")
+            for token in sample_set_tokens:
+                cmd.extend(["--set", token])
+            log_f.write(f"$ {' '.join(cmd)}\n")
+            start = time.perf_counter()
+            proc = subprocess.run(cmd, check=False, text=True, capture_output=True, env=env)
+            wall_ms = (time.perf_counter() - start) * 1000.0
+            if proc.stdout:
+                log_f.write(proc.stdout)
+                if not proc.stdout.endswith("\n"):
+                    log_f.write("\n")
+            if proc.stderr:
+                log_f.write(proc.stderr)
+                if not proc.stderr.endswith("\n"):
+                    log_f.write("\n")
+            if proc.returncode != 0:
+                raise RuntimeError(
+                    f"TRTFB TTS task eval failed for sample {idx} rc={proc.returncode}; see {log_path}"
+                )
+            if not wav_path.is_file():
+                raise RuntimeError(f"TRTFB TTS task eval produced no WAV for sample {idx}: {wav_path}")
+            row = _tts_response_row(sample_id, wav_path, wall_ms, "trtfb")
+            responses.append(row)
+            raw_f.write(json.dumps(row, ensure_ascii=False) + "\n")
+            raw_f.flush()
+            print(f"[task_eval.tts_trtfb] sample={idx + 1}/{len(prompt_rows)}", file=sys.stderr)
+    scoring = work_scoring(work_dir)
+    transcripts = _transcribe_audio_files(
+        [Path(row["wav_path"]) for row in responses],
+        python=str(args.hf_python or sys.executable),
+        model_id=str(scoring.get("asr_model", "openai/whisper-large-v3-turbo")),
+    )
+    for row, transcript in zip(responses, transcripts, strict=True):
+        row["output_text"] = transcript
+        row["asr_transcript"] = transcript
+    write_predictions(predictions, responses)
+    with raw_output.open("w", encoding="utf-8") as raw_f:
+        for row in responses:
+            raw_f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
 def run_trtfb(args: argparse.Namespace) -> None:
     work_dir = Path(args.work_dir)
     dataset_kind = _work_dataset_kind(work_dir)
+    if _is_tts_dataset_kind(dataset_kind):
+        run_tts_trtfb(args)
+        return
     if _is_vlm_dataset_kind(dataset_kind):
         run_vlm_trtfb(args)
         return
@@ -3724,8 +4340,15 @@ def eval_one_model(
     dataset_kind = str(suite.get("dataset", {}).get("kind", ""))
     reference_backend = str(model.get("reference_backend", "hf_transformers") or "hf_transformers")
     task_eval_config = model.get("task_eval", {})
-    if not isinstance(task_eval_config, dict):
-        task_eval_config = {}
+    task_eval_config = dict(task_eval_config) if isinstance(task_eval_config, dict) else {}
+    model_family = str(model.get("family", "") or "")
+    if model_family:
+        task_eval_config["family"] = model_family
+    runtime_config = model.get("runtime_config", {})
+    if isinstance(runtime_config, dict) and runtime_config:
+        task_eval_config["runtime_config"] = runtime_config
+    if model.get("max_new_tokens") is not None:
+        task_eval_config["model_max_new_tokens"] = model["max_new_tokens"]
     prepare_task_dataset(
         dataset_path=dataset_path,
         work_dir=work_dir,
@@ -3753,7 +4376,11 @@ def eval_one_model(
         bundle_path = engine_dir / str(model["bundle"])
 
     max_prompt_len = None
-    if not args.skip_prompt_length_check and not _is_asr_dataset_kind(dataset_kind):
+    if (
+        not args.skip_prompt_length_check
+        and not _is_asr_dataset_kind(dataset_kind)
+        and not _is_tts_dataset_kind(dataset_kind)
+    ):
         prompt_rows_path = work_dir / "prompts.jsonl"
         max_prompt_len = max_prompt_token_length(
             model_id=str(model["hf_id"]),
@@ -4565,7 +5192,13 @@ def cmd_eval(args: argparse.Namespace) -> int:
     suites = load_suites(Path(args.suites))
     suite = suite_by_id(suites, args.suite)
     dataset_kind = suite.get("dataset", {}).get("kind", "")
-    if dataset_kind not in {"mmlu_five_shot_json", "vlm_chat_json", "vlm_unified_json", "asr_chat_json"}:
+    if dataset_kind not in {
+        "mmlu_five_shot_json",
+        "vlm_chat_json",
+        "vlm_unified_json",
+        "asr_chat_json",
+        "seedtts_json",
+    }:
         raise ValueError(f"eval does not support dataset kind {dataset_kind!r}")
     models = load_manifest_records(Path(args.models_dir))
     waives = load_waives(Path(args.waives), args.waive_platform) if args.waives else {}


### PR DESCRIPTION
## Background

Text-to-audio models had E2E smoke coverage but no task-level comparison against their Hugging Face behavior. Bark also had codec and fine-generation differences that obscured whether intelligibility failures came from model generation or decoder conversion.

## Exit Criteria

- Evaluate compatible Bark and Magpie models on SeedTTS prompts using the existing task-eval entry point.
- Report waveform health and ASR-based intelligibility for both HF and TRTFB outputs without weakening quality thresholds.
- Correct reproducible Bark decoder and fine-generation differences and cover them with focused regressions.
- Keep the suite local-only until its observed quality is suitable for a CI gate.

## Implementation

- Add a `seedtts_en_tts_intelligibility` suite with Bark and Magpie defaults, explicit TP model support, deterministic per-sample seeds, reusable HF outputs, and model-scoped workers.
- Add SeedTTS preparation, HF/TRTFB audio runners, ASR transcription, WER/NED scoring, waveform health checks, and full normalized disagreement reporting to `tools/task_eval.py`.
- Align Bark's EnCodec graph with HF by using exact reflect padding, returning the current LSTM timestep, and removing the extra output `tanh`.
- Align Bark fine-stage padding and sampling behavior while retaining deterministic greedy parity diagnostics.

## Validation

- `PYTHONPATH=python python3 -m pytest -q tests/tools/test_task_eval.py`: 63 passed.
- `python3 -m ruff check tools/task_eval.py tests/tools/test_task_eval.py python/tensorrt_model_connect/families/bark`: passed.
- `clang-format --dry-run --Werror <modified Bark C++ files>`: passed.
- P2021 `PYTHONPATH=python /opt/venv/bin/python3 -m pytest -q tests/tools/test_task_eval.py`: 63 passed.
- P2021 `./build/test_bark_generation_plan && ./build/test_bark_config_schema`: passed.
- P2021 Bark codec differential: waveform cosine improved from 0.751 to 1.000 with maximum absolute error 0.002.
- P2021 SeedTTS, 10 samples: Magpie previously reached 1.000 correctness/agreement; the latest Bark-large run reached HF 1.000, TRTFB 0.600, agreement 0.600.

## Notes For Future Readers

- Review the Bark graph fixes first, then the task-eval runner/scorer, and finally the suite declaration and tests.
- Bark-large currently has 8/10 content-intelligible samples: two failures are semantic sampling errors and two additional composite failures are duration-only. The suite deliberately remains `local_only`; this PR does not relax its thresholds to hide those failures.
- Identical numeric seeds do not produce identical stochastic samples across PyTorch multinomial and the C++ sampler. Greedy stage parity and codec parity are used to isolate conversion defects from stochastic quality variation.
