### PR TITLE
ci: compare PR impact from merge parent

### DIFF
--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -114,7 +114,13 @@ jobs:
           base=""
           case "${GITHUB_EVENT_NAME}" in
             pull_request)
-              base="${{ github.event.pull_request.base.sha }}"
+              # The checked-out PR ref is a synthetic merge commit. Its first
+              # parent is the exact base snapshot used to create that ref.
+              if ! git rev-parse --verify HEAD^2 >/dev/null 2>&1; then
+                echo "::error::Expected pull_request checkout to be a merge commit"
+                exit 1
+              fi
+              base="$(git rev-parse HEAD^1)"
               ;;
             push)
               base="${{ github.event.before }}"

--- a/tests/e2e/models/bark-small-tts-probe01.json
+++ b/tests/e2e/models/bark-small-tts-probe01.json
@@ -5,6 +5,7 @@
   "bundle": "bark-small.trtfb",
   "family": "bark",
   "runtime_strategy": "text_to_audio_bark",
+  "task_strategy": "text_to_audio",
   "reference_family": "tts_bark",
   "user_contract": "tts_audio",
   "test_type": "audio",

--- a/tests/e2e/models/bark-small-tts-probe02.json
+++ b/tests/e2e/models/bark-small-tts-probe02.json
@@ -5,6 +5,7 @@
   "bundle": "bark-small.trtfb",
   "family": "bark",
   "runtime_strategy": "text_to_audio_bark",
+  "task_strategy": "text_to_audio",
   "reference_family": "tts_bark",
   "user_contract": "tts_audio",
   "test_type": "audio",

--- a/tests/e2e/models/magpie-tts-357m-tts-probe01.json
+++ b/tests/e2e/models/magpie-tts-357m-tts-probe01.json
@@ -5,6 +5,7 @@
   "bundle": "magpie-tts-357m.trtfb",
   "family": "magpie_tts",
   "runtime_strategy": "text_to_audio_magpie",
+  "task_strategy": "text_to_audio",
   "reference_backend": "nemo",
   "reference_family": "tts_magpie",
   "user_contract": "tts_audio",

--- a/tests/e2e/models/magpie-tts-357m-tts-probe02.json
+++ b/tests/e2e/models/magpie-tts-357m-tts-probe02.json
@@ -5,6 +5,7 @@
   "bundle": "magpie-tts-357m.trtfb",
   "family": "magpie_tts",
   "runtime_strategy": "text_to_audio_magpie",
+  "task_strategy": "text_to_audio",
   "reference_backend": "nemo",
   "reference_family": "tts_magpie",
   "user_contract": "tts_audio",

--- a/tests/e2e/models/magpie-tts-357m-tts-probe03.json
+++ b/tests/e2e/models/magpie-tts-357m-tts-probe03.json
@@ -5,6 +5,7 @@
   "bundle": "magpie-tts-357m.trtfb",
   "family": "magpie_tts",
   "runtime_strategy": "text_to_audio_magpie",
+  "task_strategy": "text_to_audio",
   "reference_backend": "nemo",
   "reference_family": "tts_magpie",
   "user_contract": "tts_audio",

--- a/tests/e2e/models/magpie-tts-357m-tts-probe04.json
+++ b/tests/e2e/models/magpie-tts-357m-tts-probe04.json
@@ -5,6 +5,7 @@
   "bundle": "magpie-tts-357m.trtfb",
   "family": "magpie_tts",
   "runtime_strategy": "text_to_audio_magpie",
+  "task_strategy": "text_to_audio",
   "reference_backend": "nemo",
   "reference_family": "tts_magpie",
   "user_contract": "tts_audio",

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -222,6 +222,17 @@ def test_premerge_ci_runs_from_manual_dispatch_or_trigger_labels() -> None:
     assert "github.rest.issues.removeLabel" not in text
 
 
+def test_premerge_ci_compares_the_checked_out_merge_snapshot() -> None:
+    text = (REPO_ROOT / ".github" / "workflows" / "trtmc-ci.yml").read_text()
+    base_block = text.split("- name: Resolve comparison base", maxsplit=1)[1].split(
+        "- name: Report CI mode", maxsplit=1
+    )[0]
+
+    assert "git rev-parse --verify HEAD^2" in base_block
+    assert 'base="$(git rev-parse HEAD^1)"' in base_block
+    assert "github.event.pull_request.base.sha" not in base_block
+
+
 def test_label_triggered_premerge_ci_uses_pr_merge_ref_checkout() -> None:
     text = (REPO_ROOT / ".github" / "workflows" / "trtmc-ci.yml").read_text()
     checkout_block = text.split("- name: Check out source", maxsplit=1)[1].split(


### PR DESCRIPTION
## Background
PR #275's label-triggered run compared an old `pull_request.base.sha` with a refreshed synthetic merge ref. The resulting diff included unrelated changes already merged to `main`, so `scripts/run_e2e_parallel.sh` incorrectly expanded a tools-only task-eval change to 105 selective E2E models.

PR #280's first CI run confirmed that the merge-parent fix worked, then exposed six nightly TTS probe manifests that declared a runtime strategy without the required task strategy.

## Exit Criteria
- PR impact analysis uses the base snapshot from the same synthetic merge commit that Actions checked out.
- A stale event base cannot silently expand the changed-file set.
- Static workflow coverage prevents reintroducing `github.event.pull_request.base.sha` for this comparison.
- Impact-map consistency validation passes without weakening its manifest requirements.

## Implementation
- Resolve the pull-request comparison base from `HEAD^1`, the first parent of the checked-out synthetic merge commit.
- Fail explicitly if a pull-request checkout is not a merge commit instead of falling back to a potentially mismatched base.
- Add a GitHub Actions regression test for the merge-parent contract.
- Declare `task_strategy: text_to_audio` on the six Bark and Magpie nightly TTS probe manifests, matching their existing runtime and user contracts.

## Validation
- `python3 tools/test_impact.py --validate`: passed for 231 models across 76 families.
- `python -m pytest tests/tools/test_github_actions_ci.py tests/tools/test_test_impact.py -q`: passed, 220 tests.
- `ruff check tests/tools/test_github_actions_ci.py`: passed.
- All six changed probe manifests pass `python -m json.tool`.
- PR #275 impact reproduction with the old event base: reproduced 105 E2E models and unrelated `main` files.
- PR #275 impact reproduction with the merge ref's first parent: selected only the three task-eval files, the `tools` tier, and 0 E2E models.
- Updated PR #280 impact selection resolves to the `tools` tier plus the `bark-small` and `magpie-tts-357m` L0 replacements, with no C++ rebuild.

## Notes For Future Readers
- Review the workflow base-resolution change first, its static guard second, and the manifest consistency repair last.
- Keep the checkout ref and comparison base from the same merge snapshot; event payload base SHAs can be older than a refreshed PR merge ref.
