### PR TITLE
[codex] test(ci): red-team model isolation

### DIFF
--- a/.github/scripts/run-trtmc-ci.sh
+++ b/.github/scripts/run-trtmc-ci.sh
@@ -896,7 +896,13 @@ run_isolated_e2e_group_logged() {
     fi
   else
     echo "FAIL isolated group=$group_id gpu=$gpu_id rc=$group_rc elapsed=${elapsed}s" >&2
-    tail -n 120 "$audit_dir/console.log" >&2 || true
+    if ! awk '
+      /^=== Isolation result verification ===$/ { emit = 1 }
+      emit { print }
+      END { if (!emit) exit 1 }
+    ' "$audit_dir/console.log" >&2; then
+      tail -n 80 "$audit_dir/console.log" >&2 || true
+    fi
   fi
   return "$group_rc"
 }

--- a/.github/scripts/run-trtmc-ci.sh
+++ b/.github/scripts/run-trtmc-ci.sh
@@ -828,7 +828,7 @@ PY
       PYTHONPATH="$source_dir/python:$source_dir" \
       LD_LIBRARY_PATH="$isolated_library_path" \
       "${HF_PYTHON:-/opt/venv/bin/python}" -m pytest \
-        "${group_test_files[@]}" -v \
+        "${group_test_files[@]}" -v --tb=short \
         --rootdir "$source_dir" \
         -c "$source_dir/pyproject.toml" \
         --engine-dir "$engine_dir" \
@@ -848,6 +848,7 @@ PY
   popd >/dev/null
 
   local verification_rc=0
+  echo "=== Isolation result verification ==="
   if python3 "$source_dir/tools/model_plugin_isolation.py" verify-results \
       --repo-root "$source_dir" \
       --models-file "$models_file" \

--- a/python/tensorrt_model_connect/families/gpt2/plugin.py
+++ b/python/tensorrt_model_connect/families/gpt2/plugin.py
@@ -29,6 +29,18 @@ from .standard_decoder_builder import build_standard_decoder_engine
 from .dual_profile_decoder_tp_builder import build_dual_profile_tp_decoder_engine
 
 
+def _validate_redteam_borrowed_resource() -> None:
+    sibling_family = "".join(("be", "rt"))
+    sibling_metadata = (
+        Path(__file__).resolve().parents[1] / sibling_family / "MODEL.toml"
+    ).read_text(encoding="utf-8")
+    if f'id = "{sibling_family}"' not in sibling_metadata:
+        raise RuntimeError("Red-team sibling family metadata is invalid")
+
+
+_validate_redteam_borrowed_resource()
+
+
 class GPT2Plugin:
     name = "gpt2"
     runtime_strategy = "gpt2_decoder_kv_cache"

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -496,6 +496,9 @@ def test_selective_e2e_builds_and_runs_single_family_source_projections() -> Non
     assert "expected exactly 1" in group_runner
     assert "prepare_model_plugin_dir" not in group_runner
     assert 'echo "=== Isolation result verification ==="' in group_runner
+    assert '/^=== Isolation result verification ===$/ { emit = 1 }' in group_runner
+    assert 'tail -n 80 "$audit_dir/console.log"' in group_runner
+    assert 'tail -n 120 "$audit_dir/console.log"' not in group_runner
 
 
 def test_full_e2e_stages_all_runtime_plugins_from_reusable_build() -> None:

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -483,6 +483,7 @@ def test_selective_e2e_builds_and_runs_single_family_source_projections() -> Non
     assert '--target trtmc trtmc_backend_trt "$model_target"' in group_runner
     assert 'PYTHONPATH="$source_dir/python:$source_dir' in group_runner
     assert 'LD_LIBRARY_PATH="$isolated_library_path"' in group_runner
+    assert '"${group_test_files[@]}" -v --tb=short' in group_runner
     assert '--trtmc-binary "$build_dir/trtmc"' in group_runner
     assert '--engine-dir "$engine_dir"' in group_runner
     assert '--model-plugin-dir "$model_plugin_dir"' in group_runner
@@ -494,6 +495,7 @@ def test_selective_e2e_builds_and_runs_single_family_source_projections() -> Non
     assert "verify-results" in group_runner
     assert "expected exactly 1" in group_runner
     assert "prepare_model_plugin_dir" not in group_runner
+    assert 'echo "=== Isolation result verification ==="' in group_runner
 
 
 def test_full_e2e_stages_all_runtime_plugins_from_reusable_build() -> None:

--- a/tests/tools/test_model_plugin_isolation.py
+++ b/tests/tools/test_model_plugin_isolation.py
@@ -649,6 +649,15 @@ def test_verify_results_reports_build_failure_root_cause(tmp_path: Path) -> None
     artifacts_dir = tmp_path / "artifacts"
     report_path = tmp_path / "verification.json"
     result_data = _passing_result("decoder-small")
+    missing_resource = (
+        tmp_path
+        / "different-ci-projection"
+        / "python"
+        / "tensorrt_model_connect"
+        / "families"
+        / "sibling"
+        / "MODEL.toml"
+    )
     result_data.update(
         status="fail",
         failure_type="build_fail",
@@ -656,7 +665,7 @@ def test_verify_results_reports_build_failure_root_cause(tmp_path: Path) -> None
         determinism={
             "build_error": (
                 "Bundle build failed (rc=1):\n"
-                "Error: missing families/sibling/MODEL.toml"
+                f"Error: [Errno 2] No such file or directory: '{missing_resource}'"
             )
         },
     )
@@ -683,11 +692,28 @@ def test_verify_results_reports_build_failure_root_cause(tmp_path: Path) -> None
     )
 
     assert result.returncode == 1
+    assert "MODEL ISOLATION VIOLATION DETECTED" in result.stderr
+    assert "CI rebuilds and runs each model family" in result.stderr
+    assert "Selected model family (builder files): 'decoder_family'" in result.stderr
+    assert "Resource-owning model family (builder files): 'sibling'" in result.stderr
+    assert "Why CI failed:" in result.stderr
+    assert "cross-family dependencies fail" in result.stderr
     assert "FAIL decoder-small (build_fail)" in result.stderr
     assert "Root cause:" in result.stderr
-    assert "Error: missing families/sibling/MODEL.toml" in result.stderr
+    assert str(missing_resource) in result.stderr
     assert "Verification errors:" in result.stderr
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert report["results"][0]["failure_causes"] == [
-        "Bundle build failed (rc=1):\nError: missing families/sibling/MODEL.toml"
+        "Bundle build failed (rc=1):\n"
+        f"Error: [Errno 2] No such file or directory: '{missing_resource}'"
+    ]
+    assert report["results"][0]["isolation_violations"] == [
+        {
+            "resource": (
+                "python/tensorrt_model_connect/families/sibling/MODEL.toml"
+            ),
+            "owner_group": "builder_families",
+            "resource_owner": "sibling",
+            "selected_owners": ["decoder_family"],
+        }
     ]

--- a/tests/tools/test_model_plugin_isolation.py
+++ b/tests/tools/test_model_plugin_isolation.py
@@ -616,7 +616,7 @@ def test_verify_results_rejects_incomplete_execution(
     )
 
     assert result.returncode == 1
-    assert "FAIL decoder-small" in result.stdout
+    assert "FAIL decoder-small" in result.stderr
     assert expected_error in result.stderr
 
 
@@ -642,3 +642,52 @@ def test_verify_results_rejects_missing_result(tmp_path: Path) -> None:
 
     assert result.returncode == 1
     assert "result.json is missing" in result.stderr
+
+
+def test_verify_results_reports_build_failure_root_cause(tmp_path: Path) -> None:
+    repo_root = _make_repo(tmp_path)
+    artifacts_dir = tmp_path / "artifacts"
+    report_path = tmp_path / "verification.json"
+    result_data = _passing_result("decoder-small")
+    result_data.update(
+        status="fail",
+        failure_type="build_fail",
+        stages={},
+        determinism={
+            "build_error": (
+                "Bundle build failed (rc=1):\n"
+                "Error: missing families/sibling/MODEL.toml"
+            )
+        },
+    )
+    result_data["commands"][0]["returncode"] = 1
+    _write_result(artifacts_dir, "decoder-small", result_data)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(TOOL),
+            "verify-results",
+            "--repo-root",
+            str(repo_root),
+            "--model",
+            "decoder-small",
+            "--artifacts-dir",
+            str(artifacts_dir),
+            "--report",
+            str(report_path),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 1
+    assert "FAIL decoder-small (build_fail)" in result.stderr
+    assert "Root cause:" in result.stderr
+    assert "Error: missing families/sibling/MODEL.toml" in result.stderr
+    assert "Verification errors:" in result.stderr
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["results"][0]["failure_causes"] == [
+        "Bundle build failed (rc=1):\nError: missing families/sibling/MODEL.toml"
+    ]

--- a/tools/model_plugin_isolation.py
+++ b/tools/model_plugin_isolation.py
@@ -41,12 +41,21 @@ class RuntimePlugin:
 
 
 _NODE_ID_MODEL_RE = re.compile(r"::test_model_e2e\[([^\]]+)\]")
+_MISSING_FILE_RE = re.compile(
+    r"No such file or directory:\s*['\"](?P<path>[^'\"]+)['\"]"
+)
 
 _MODEL_OWNED_ROOTS = {
     Path("python/tensorrt_model_connect/families"): "builder_families",
     Path("src/runtime/models"): "runtime_plugins",
     Path("tests/e2e/models"): "e2e_families",
     Path("tests/cpp/models"): "runtime_plugins",
+}
+
+_OWNER_GROUP_LABELS = {
+    "builder_families": "model family (builder files)",
+    "runtime_plugins": "runtime model plugin",
+    "e2e_families": "model family (E2E files)",
 }
 
 _MODEL_OWNED_IMPACT_RULES = frozenset(
@@ -642,7 +651,62 @@ def _failure_causes(result: dict[str, object]) -> list[str]:
     return list(dict.fromkeys(causes))
 
 
-def _verify_model_result(model_name: str, artifacts_dir: Path) -> dict[str, object]:
+def _isolation_violations(
+    causes: list[str],
+    repo_root: Path,
+    selected_owners: dict[str, set[str]],
+) -> list[dict[str, object]]:
+    violations: list[dict[str, object]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for cause in causes:
+        for match in _MISSING_FILE_RE.finditer(cause):
+            missing_path = Path(match.group("path"))
+            candidate = (
+                missing_path.resolve()
+                if missing_path.is_absolute()
+                else (repo_root / missing_path).resolve()
+            )
+            try:
+                relative = candidate.relative_to(repo_root)
+            except ValueError:
+                relative = None
+                candidate_parts = candidate.parts
+                for owned_root in _MODEL_OWNED_ROOTS:
+                    root_parts = owned_root.parts
+                    for index in range(len(candidate_parts) - len(root_parts) + 1):
+                        if candidate_parts[index : index + len(root_parts)] == root_parts:
+                            relative = Path(*candidate_parts[index:])
+                            break
+                    if relative is not None:
+                        break
+                if relative is None:
+                    continue
+
+            for owned_root, owner_group in _MODEL_OWNED_ROOTS.items():
+                resource_owner = _owner_under(relative, owned_root)
+                if not resource_owner or resource_owner in selected_owners[owner_group]:
+                    continue
+                key = (relative.as_posix(), owner_group, resource_owner)
+                if key in seen:
+                    continue
+                seen.add(key)
+                violations.append(
+                    {
+                        "resource": relative.as_posix(),
+                        "owner_group": owner_group,
+                        "resource_owner": resource_owner,
+                        "selected_owners": sorted(selected_owners[owner_group]),
+                    }
+                )
+    return violations
+
+
+def _verify_model_result(
+    model_name: str,
+    artifacts_dir: Path,
+    repo_root: Path,
+    selected_owners: dict[str, set[str]],
+) -> dict[str, object]:
     result_path = artifacts_dir / model_name / "result.json"
     errors: list[str] = []
     if not result_path.is_file():
@@ -652,6 +716,7 @@ def _verify_model_result(model_name: str, artifacts_dir: Path) -> dict[str, obje
             "passed": False,
             "failure_type": None,
             "failure_causes": [],
+            "isolation_violations": [],
             "errors": ["result.json is missing"],
         }
     try:
@@ -663,6 +728,7 @@ def _verify_model_result(model_name: str, artifacts_dir: Path) -> dict[str, obje
             "passed": False,
             "failure_type": None,
             "failure_causes": [],
+            "isolation_violations": [],
             "errors": [f"result.json could not be read: {exc}"],
         }
     if not isinstance(result, dict):
@@ -711,14 +777,75 @@ def _verify_model_result(model_name: str, artifacts_dir: Path) -> dict[str, obje
 
     errors.extend(_returncode_failures(result.get("stage_outputs", {}), "stage_outputs"))
     errors = list(dict.fromkeys(errors))
+    failure_causes = _failure_causes(result)
     return {
         "model": model_name,
         "result_path": str(result_path),
         "passed": not errors,
         "failure_type": result.get("failure_type"),
-        "failure_causes": _failure_causes(result),
+        "failure_causes": failure_causes,
+        "isolation_violations": _isolation_violations(
+            failure_causes, repo_root, selected_owners
+        ),
         "errors": errors,
     }
+
+
+def _unique_isolation_violations(
+    results: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    violations: list[dict[str, object]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for result in results:
+        result_violations = result.get("isolation_violations", [])
+        if not isinstance(result_violations, list):
+            continue
+        for violation in result_violations:
+            if not isinstance(violation, dict):
+                continue
+            key = (
+                str(violation.get("resource", "")),
+                str(violation.get("owner_group", "")),
+                str(violation.get("resource_owner", "")),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            violations.append(violation)
+    return violations
+
+
+def _print_isolation_violations(violations: list[dict[str, object]]) -> None:
+    if not violations:
+        return
+    print("MODEL ISOLATION VIOLATION DETECTED", file=sys.stderr)
+    print(
+        "  CI rebuilds and runs each model family from a filtered source tree that "
+        "contains only that family's owned files plus shared/plugin infrastructure.",
+        file=sys.stderr,
+    )
+    for violation in violations:
+        owner_group = str(violation.get("owner_group", ""))
+        scope_label = _OWNER_GROUP_LABELS.get(owner_group, owner_group)
+        selected = ", ".join(
+            f"'{owner}'" for owner in violation.get("selected_owners", [])
+        ) or "<none>"
+        resource_owner = str(violation.get("resource_owner", ""))
+        resource = str(violation.get("resource", ""))
+        print(f"  Selected {scope_label}: {selected}", file=sys.stderr)
+        print(f"  Resource-owning {scope_label}: '{resource_owner}'", file=sys.stderr)
+        print(f"  Cross-family resource: {resource}", file=sys.stderr)
+        print(
+            f"  Why CI failed: {selected} used a resource owned by '{resource_owner}'. "
+            "Strict isolation intentionally removes resources owned by other model "
+            "families, so cross-family dependencies fail.",
+            file=sys.stderr,
+        )
+        print(
+            "  Required boundary: keep the dependency in the selected model family's "
+            "owned files or move it to approved shared/plugin infrastructure.",
+            file=sys.stderr,
+        )
 
 
 def command_verify_results(args: argparse.Namespace) -> int:
@@ -735,8 +862,17 @@ def command_verify_results(args: argparse.Namespace) -> int:
             "No E2E manifest found for selected model(s): " + ", ".join(missing_models)
         )
 
+    selected_manifests = [manifests[name] for name in sorted(model_names)]
+    runtime_plugins = discover_runtime_plugins(repo_root)
+    selected_plugins = plugins_for_models(model_names, manifests, runtime_plugins)
+    selected_owners = {
+        "builder_families": {manifest.family for manifest in selected_manifests},
+        "runtime_plugins": {plugin.model_id for plugin in selected_plugins},
+        "e2e_families": {manifest.family for manifest in selected_manifests},
+    }
     results = [
-        _verify_model_result(model_name, artifacts_dir) for model_name in sorted(model_names)
+        _verify_model_result(model_name, artifacts_dir, repo_root, selected_owners)
+        for model_name in sorted(model_names)
     ]
     report = {
         "schema_version": 1,
@@ -751,6 +887,7 @@ def command_verify_results(args: argparse.Namespace) -> int:
         report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
         print(report_path)
 
+    _print_isolation_violations(_unique_isolation_violations(results))
     for result in results:
         status = "PASS" if result["passed"] else "FAIL"
         failure_type = result.get("failure_type")

--- a/tools/model_plugin_isolation.py
+++ b/tools/model_plugin_isolation.py
@@ -611,6 +611,37 @@ def _returncode_failures(value: object, path: str = "result") -> list[str]:
     return failures
 
 
+def _failure_causes(result: dict[str, object]) -> list[str]:
+    causes: list[str] = []
+    determinism = result.get("determinism")
+    if isinstance(determinism, dict):
+        build_error = determinism.get("build_error")
+        if isinstance(build_error, str) and build_error.strip():
+            causes.append(build_error.strip())
+
+        preflight = determinism.get("preflight")
+        if isinstance(preflight, list):
+            for check in preflight:
+                if not isinstance(check, dict) or check.get("passed") is not False:
+                    continue
+                message = check.get("message")
+                if isinstance(message, str) and message.strip():
+                    causes.append(message.strip())
+
+    stages = result.get("stages")
+    if isinstance(stages, dict):
+        for stage_name, stage in stages.items():
+            if not isinstance(stage, dict):
+                continue
+            if stage.get("status") not in {"failed", "error"}:
+                continue
+            message = stage.get("message")
+            if isinstance(message, str) and message.strip():
+                causes.append(f"{stage_name}: {message.strip()}")
+
+    return list(dict.fromkeys(causes))
+
+
 def _verify_model_result(model_name: str, artifacts_dir: Path) -> dict[str, object]:
     result_path = artifacts_dir / model_name / "result.json"
     errors: list[str] = []
@@ -619,6 +650,8 @@ def _verify_model_result(model_name: str, artifacts_dir: Path) -> dict[str, obje
             "model": model_name,
             "result_path": str(result_path),
             "passed": False,
+            "failure_type": None,
+            "failure_causes": [],
             "errors": ["result.json is missing"],
         }
     try:
@@ -628,6 +661,8 @@ def _verify_model_result(model_name: str, artifacts_dir: Path) -> dict[str, obje
             "model": model_name,
             "result_path": str(result_path),
             "passed": False,
+            "failure_type": None,
+            "failure_causes": [],
             "errors": [f"result.json could not be read: {exc}"],
         }
     if not isinstance(result, dict):
@@ -680,6 +715,8 @@ def _verify_model_result(model_name: str, artifacts_dir: Path) -> dict[str, obje
         "model": model_name,
         "result_path": str(result_path),
         "passed": not errors,
+        "failure_type": result.get("failure_type"),
+        "failure_causes": _failure_causes(result),
         "errors": errors,
     }
 
@@ -716,9 +753,24 @@ def command_verify_results(args: argparse.Namespace) -> int:
 
     for result in results:
         status = "PASS" if result["passed"] else "FAIL"
-        print(f"{status} {result['model']}")
+        failure_type = result.get("failure_type")
+        suffix = f" ({failure_type})" if not result["passed"] and failure_type else ""
+        if result["passed"]:
+            print(f"{status} {result['model']}{suffix}")
+            continue
+
+        print(f"{status} {result['model']}{suffix}", file=sys.stderr)
+        causes = result.get("failure_causes", [])
+        if isinstance(causes, list) and causes:
+            print("  Root cause:", file=sys.stderr)
+            for cause in causes:
+                lines = str(cause).splitlines() or [str(cause)]
+                print(f"    - {lines[0]}", file=sys.stderr)
+                for line in lines[1:]:
+                    print(f"      {line}", file=sys.stderr)
+        print("  Verification errors:", file=sys.stderr)
         for error in result["errors"]:
-            print(f"  {error}", file=sys.stderr)
+            print(f"    - {error}", file=sys.stderr)
     return 0 if report["passed"] else 1
 
 


### PR DESCRIPTION
## Background

This is a disposable red-team PR for the model-family source-projection boundary. It intentionally makes the GPT-2 builder depend on a BERT-owned resource while avoiding a direct sibling Python import.

The full checkout still contains BERT's `MODEL.toml`, so ordinary builder validation remains green. The strict GPT-2 source projection removes BERT, and CI is expected to fail when the GPT-2 plugin loads.

## Exit Criteria

- Full-checkout architecture and GPT-2 builder tests pass.
- Selective CI attributes the change to the GPT-2 family.
- The model-owned isolation rerun stages only GPT-2 and fails on the missing BERT resource.
- The PR remains draft and is not merged.

## Implementation

- Add an import-time GPT-2 validation that reads BERT's family metadata.
- Construct the sibling name dynamically so this exercises source projection rather than the existing direct-import AST guard.

## Validation

- `pytest tests/tools/test_model_plugin_encapsulation_static.py -q`: 155 passed.
- `pytest tests/tools/test_model_plugin_isolation.py -q`: 42 passed.
- Full checkout GPT-2 TP dispatch test: 1 passed.
- Projected GPT-2 TP dispatch test: expected failure with `FileNotFoundError` for `families/bert/MODEL.toml`.
- Impact analysis selects `distilgpt2` and `gpt2-125m` for L0 E2E.

## Notes

Expected status: red. This PR is evidence for the CI guard and must be closed after the expected isolation failure is captured.
