### PR TITLE
[codex] refactor(families): support incremental specialization

### DIFF
--- a/scripts/autopilot/autorun.py
+++ b/scripts/autopilot/autorun.py
@@ -129,7 +129,8 @@ WORKER_PROMPT = textwrap.dedent("""\
       tests/e2e_harness/comparators/  (text.py, diffusion.py, segmentation.py, etc.)
       tests/e2e_harness/runners/      (how different modalities run inference)
       tools/diff_logits.py            (decoder logit comparison)
-      tensorrt_model_connect/debug_runner.py      (TrtRunner, pure-Python TRT inference)
+      tensorrt_model_connect/families/{family_name}/model/runtime.py
+                                                (family-owned TRT inference)
 
     ### Fix
     If build OR validation fails, diagnose and fix. Resources:
@@ -148,13 +149,15 @@ WORKER_PROMPT = textwrap.dedent("""\
       ```
     - Read existing family plugins for reference at:
       /workspace/users/yifeif/workspaces/{agent_id}/tensorrt-model-connect/python/tensorrt_model_connect/families/
-    - Read graph_ops.py and graph_blocks.py for available TRT operations.
+    - Read the selected family's model/model.py for graph operations and blocks.
     - Read the HF model's modeling code to understand the EXACT computation.
     - If the model uses a novel attention mechanism (disentangled, sliding
       window, linear, etc.), you MUST implement it correctly in the plugin's
       build_engine() — do not approximate or skip it.
     - Edit the plugin on the HOST at:
-      /workspace/users/yifeif/workspaces/{agent_id}/tensorrt-model-connect/python/tensorrt_model_connect/families/{family_name}.py
+      /workspace/users/yifeif/workspaces/{agent_id}/tensorrt-model-connect/python/tensorrt_model_connect/families/{family_name}/
+      Keep plugin.py and config.py at the root; put weight loading in weights/
+      and graph/build/runtime implementation in model/.
 
     ### C++ runtime plugin (if needed for full E2E)
     The goal is FULL onboarding: a user must be able to run the model via
@@ -240,12 +243,14 @@ WORKER_PROMPT = textwrap.dedent("""\
       plugins (decoder, encoder, or modality-specific plugins, etc.).
       Each family gets its own isolated Python plugin and (if needed) its own
       C++ plugin .cpp file. You may ONLY share code through:
-      - graph_ops.py / graph_blocks.py (Python TRT graph construction)
+      - generic package infrastructure outside families/
       - shared/plugin_helpers.h/cpp (C++ TRT module loading, tokenizer, helpers)
       - shared/audio_helpers.h, shared/diffusion_helpers.h (modality-specific shared utils)
       It's fine to DUPLICATE code from an existing plugin into your new file —
       copy-paste is better than tight coupling. Each plugin must be self-contained.
-    - Do NOT edit shared framework files (checkpoint_mapper.py, standard_decoder_builder.py,
+    - Do NOT edit shared framework files or another family. Keep checkpoint mapping
+      and decoder builders under the selected family's weights/ and model/ directories;
+      do not add new files at the family package root. Do not edit
       pipeline_factory.cpp, pipeline_registry.cpp). You CAN add new plugin files and
       edit cmake/trtmc_pipeline_plugins.cmake to register your new plugin.
     - Do NOT skip C++ runtime implementation. The model must work end-to-end.

--- a/scripts/perf_evolve_prompt.py
+++ b/scripts/perf_evolve_prompt.py
@@ -199,9 +199,7 @@ def build_evolve_prompt(
 
     ### Python builder (engine construction):
     - `python/tensorrt_model_connect/families/{family_name}/plugin.py` — family plugin config
-    - `python/tensorrt_model_connect/families/{family_name}/standard_decoder_builder.py` — builder parameters
-    - `python/tensorrt_model_connect/families/{family_name}/graph_ops.py` — TRT graph operations (atomic ops)
-    - `python/tensorrt_model_connect/families/{family_name}/graph_blocks.py` — composable graph blocks
+    - `python/tensorrt_model_connect/families/{family_name}/model/model.py` — model builder, TRT graph operations, and composable blocks
     - `python/tensorrt_model_connect/engine_builder.py` — build orchestrator
 
     ### C++ runtime (execution — for L1 Runtime optimizations):
@@ -215,7 +213,7 @@ def build_evolve_prompt(
     - `tools/perf_compare.py` — benchmarking tool
     - `tools/cpu_profile.py` — CPU phase profiling
     - `tools/diff_logits.py` — correctness checker
-    - `python/tensorrt_model_connect/debug_runner.py` — Python TRT inference runner
+    - `python/tensorrt_model_connect/families/{family_name}/model/runtime.py` — Python TRT inference runner, when the family needs one
     - `python/tensorrt_model_connect/config.py` — ModelConfig dataclass
 
     ## CRITICAL RULES
@@ -444,18 +442,18 @@ def _build_search_space(focus_area: str | None = None) -> str:
           Phase 0 result: +1.2% (noise level).
 
         - **Fused QKV**: Concat Q/K/V weights, single matmul.
-          File: `graph_blocks.py:add_attention_block`
+          File: `model.py:add_attention_block`
           Phase 0 result: 0% (TRT internally fuses same-input matmuls).
 
         - **Fused Gate+Up**: Concat gate+up weights, single matmul.
-          File: `graph_blocks.py:add_swiglu_mlp`
+          File: `model.py:add_swiglu_mlp`
           Phase 0 result: 0% (same reason).
 
         - **Attention scale fusion**: Fold 1/sqrt(head_dim) into Q weights.
           File: Family plugin `load_weights()`.
 
         - **Alternative norm**: Rewrite RMSNorm using `add_reduce` ops.
-          File: `graph_ops.py:add_rms_norm`
+          File: `model.py:add_rms_norm`
 
         Correctness: `--atol 1e-3` for graph changes without precision changes.
         """))

--- a/tests/builder/owned_graph_modules.py
+++ b/tests/builder/owned_graph_modules.py
@@ -6,8 +6,9 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 from pathlib import Path
-from types import ModuleType
+from typing import Any
 
 import pytest
 
@@ -16,54 +17,116 @@ ROOT = Path(__file__).resolve().parents[2]
 FAMILIES = ROOT / "python" / "tensorrt_model_connect" / "families"
 
 
-def _first_family_with(*module_files: str) -> str:
+def _family_dirs():
     for family_dir in sorted(FAMILIES.iterdir()):
-        if not (family_dir / "MODEL.toml").is_file():
+        if not (family_dir / "plugin.py").is_file():
             continue
+        yield family_dir
+
+
+def _first_family_with(*module_files: str) -> str:
+    for family_dir in _family_dirs():
         if all((family_dir / module_file).is_file() for module_file in module_files):
             return family_dir.name
     raise RuntimeError(f"No family owns required graph modules: {module_files}")
 
 
-def load_graph_ops(*required_symbols: str) -> ModuleType:
+def _load_owned_module(
+    module_files: tuple[str, ...],
+    required_symbols: tuple[str, ...],
+):
     last_error: Exception | None = None
-    for family_dir in sorted(FAMILIES.iterdir()):
-        if not (family_dir / "MODEL.toml").is_file():
-            continue
-        if not (family_dir / "graph_ops.py").is_file():
+    for module_file in module_files:
+        module_name = ".".join(Path(module_file).with_suffix("").parts)
+        for family_dir in _family_dirs():
+            if not (family_dir / module_file).is_file():
+                continue
+            try:
+                module = importlib.import_module(
+                    f"tensorrt_model_connect.families.{family_dir.name}.{module_name}"
+                )
+            except ModuleNotFoundError as exc:
+                if exc.name == "tensorrt":
+                    last_error = exc
+                    continue
+                raise
+            if all(hasattr(module, symbol) for symbol in required_symbols):
+                return module
+    if last_error is not None:
+        pytest.skip(
+            f"family {module_files} modules require TensorRT",
+            allow_module_level=True,
+        )
+    suffix = f" with required symbols {required_symbols}" if required_symbols else ""
+    raise RuntimeError(f"No family-owned module in {module_files} found{suffix}")
+
+
+def load_owned_callable(
+    module_file: str,
+    symbol: str,
+    *required_parameters: str,
+):
+    """Load an owner implementation that retains the requested capability."""
+    last_error: Exception | None = None
+    module_name = ".".join(Path(module_file).with_suffix("").parts)
+    for family_dir in _family_dirs():
+        if not (family_dir / module_file).is_file():
             continue
         try:
             module = importlib.import_module(
-                f"tensorrt_model_connect.families.{family_dir.name}.graph_ops")
+                f"tensorrt_model_connect.families.{family_dir.name}.{module_name}"
+            )
         except ModuleNotFoundError as exc:
             if exc.name == "tensorrt":
                 last_error = exc
                 continue
             raise
-        if all(hasattr(module, symbol) for symbol in required_symbols):
-            return module
+        candidate = getattr(module, symbol, None)
+        if candidate is None:
+            continue
+        parameters = inspect.signature(candidate).parameters
+        if all(parameter in parameters for parameter in required_parameters):
+            return candidate
     if last_error is not None:
-        pytest.skip("family graph_ops modules require TensorRT", allow_module_level=True)
-    suffix = f" with required symbols {required_symbols}" if required_symbols else ""
-    raise RuntimeError(f"No family-owned graph_ops.py found{suffix}")
+        pytest.skip(
+            f"family {module_name} modules require TensorRT",
+            allow_module_level=True,
+        )
+    requirement = f" with parameters {required_parameters}" if required_parameters else ""
+    raise RuntimeError(
+        f"No family-owned {module_file} defines {symbol}{requirement}"
+    )
 
 
-def load_graph_blocks() -> ModuleType:
-    last_error: Exception | None = None
-    for family_dir in sorted(FAMILIES.iterdir()):
-        if not (family_dir / "MODEL.toml").is_file():
-            continue
-        if not all((family_dir / module_file).is_file()
-                   for module_file in ("graph_ops.py", "graph_blocks.py")):
-            continue
-        try:
-            return importlib.import_module(
-                f"tensorrt_model_connect.families.{family_dir.name}.graph_blocks")
-        except ModuleNotFoundError as exc:
-            if exc.name == "tensorrt":
-                last_error = exc
-                continue
-            raise
-    if last_error is not None:
-        pytest.skip("family graph_blocks modules require TensorRT", allow_module_level=True)
-    raise RuntimeError("No family-owned graph_blocks.py found")
+class _OwnedModuleProxy:
+    def __init__(self, *module_files: str):
+        self._module_files = module_files
+
+    def __getattr__(self, name: str) -> Any:
+        module = _load_owned_module(self._module_files, (name,))
+        return getattr(module, name)
+
+
+def load_graph_ops(*required_symbols: str):
+    module_files = ("model/model.py", "graph_ops.py")
+    if not required_symbols:
+        return _OwnedModuleProxy(*module_files)
+    return _load_owned_module(module_files, tuple(required_symbols))
+
+
+def load_family_graph_ops(family: str):
+    """Load one family's graph module from either supported layout."""
+    family_dir = FAMILIES / family
+    module_file = (
+        "model/model.py"
+        if (family_dir / "model/model.py").is_file()
+        else "graph_ops.py"
+    )
+    module_name = ".".join(Path(module_file).with_suffix("").parts)
+    return importlib.import_module(
+        f"tensorrt_model_connect.families.{family}.{module_name}"
+    )
+
+
+def load_graph_blocks():
+    return _OwnedModuleProxy("model/model.py", "graph_blocks.py")

--- a/tests/builder/test_checkpoint_mapper.py
+++ b/tests/builder/test_checkpoint_mapper.py
@@ -14,20 +14,23 @@ Postconditions: Weight shapes, dtypes, and values are correct after transpose, c
 from __future__ import annotations
 
 import json
+from importlib import import_module
 from pathlib import Path
 
 import numpy as np
 import pytest
 
 pytest.importorskip("tensorrt_model_connect", reason="tensorrt_model_connect requires tensorrt")
-from tensorrt_model_connect.families.qwen.checkpoint_mapper import (
-    _transpose_2d,
-    _repeat_head_norm,
-    _has_tensor,
-    _load_tensor,
-    load_standard_weights,
-)
 from tensorrt_model_connect.families.qwen.config import ModelConfig
+
+_QWEN_ROOT = Path(__file__).resolve().parents[2] / "python/tensorrt_model_connect/families/qwen"
+_MAPPER_MODULE = "weights" if (_QWEN_ROOT / "weights/__init__.py").is_file() else "checkpoint_mapper"
+_mapper = import_module(f"tensorrt_model_connect.families.qwen.{_MAPPER_MODULE}")
+_transpose_2d = _mapper._transpose_2d
+_repeat_head_norm = _mapper._repeat_head_norm
+_has_tensor = _mapper._has_tensor
+_load_tensor = _mapper._load_tensor
+load_standard_weights = _mapper.load_standard_weights
 
 
 class TestTranspose2d:

--- a/tests/builder/test_checkpoint_mapper_coverage.py
+++ b/tests/builder/test_checkpoint_mapper_coverage.py
@@ -14,15 +14,18 @@ from __future__ import annotations
 import json
 import sys
 import types
+from importlib import import_module
 from pathlib import Path
 
 import numpy as np
 import pytest
 
 pytest.importorskip("tensorrt_model_connect", reason="tensorrt_model_connect requires tensorrt")
-
-from tensorrt_model_connect.families.qwen import checkpoint_mapper as cm
 from tensorrt_model_connect.families.qwen.config import ModelConfig
+
+_QWEN_ROOT = Path(__file__).resolve().parents[2] / "python/tensorrt_model_connect/families/qwen"
+_MAPPER_MODULE = "weights" if (_QWEN_ROOT / "weights/__init__.py").is_file() else "checkpoint_mapper"
+cm = import_module(f"tensorrt_model_connect.families.qwen.{_MAPPER_MODULE}")
 
 
 def _save_safetensors(path: Path, tensors: dict[str, np.ndarray]) -> None:

--- a/tests/builder/test_families.py
+++ b/tests/builder/test_families.py
@@ -225,6 +225,8 @@ def test_repo_family_builders_use_model_local_helpers():
             if path.name == "MODEL.toml":
                 continue
             relative = path.relative_to(family_dir)
+            if "tests" in relative.parts:
+                continue
             package_depth = len(relative.parent.parts)
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
             for node in ast.walk(tree):

--- a/tests/builder/test_families.py
+++ b/tests/builder/test_families.py
@@ -198,63 +198,62 @@ def test_unknown_nemo_archive_has_no_family_adapter(tmp_path):
 
 
 def test_repo_family_builders_use_model_local_helpers():
-    """Model family builders must not import broad shared builder helpers."""
+    """Model family builders must not import broad shared builder helpers.
+
+    Families own only the helpers they use; the filtered-source isolation test
+    verifies that local imports resolve without sibling directories.
+    """
     families_dir = (
         Path(__file__).resolve().parent.parent.parent
         / "python"
         / "tensorrt_model_connect"
         / "families"
     )
-    required_helpers = {
-        "graph_ops.py",
-        "graph_blocks.py",
-        "checkpoint_mapper.py",
-        "default_decoder.py",
-        "default_dual_profile_decoder.py",
-        "default_dual_profile_decoder_tp.py",
-        "utils.py",
+    forbidden_modules = {
+        "builders",
+        "checkpoint_mapper",
+        "config",
+        "graph_blocks",
+        "graph_ops",
     }
-    forbidden_imports = (
-        "from ...checkpoint_mapper import",
-        "from ...config import",
-        "from ...graph_ops import",
-        "from ...graph_blocks import",
-        "from ...builders.",
-        "from ... import graph_ops",
-        "from ... import graph_blocks",
-        "from tensorrt_model_connect.checkpoint_mapper import",
-        "from tensorrt_model_connect.config import",
-        "from tensorrt_model_connect.graph_ops import",
-        "from tensorrt_model_connect.graph_blocks import",
-        "from tensorrt_model_connect.builders.",
-    )
 
-    missing_helpers = []
     central_imports = []
     for family_dir in sorted(families_dir.iterdir()):
         if not family_dir.is_dir() or not (family_dir / "MODEL.toml").is_file():
             continue
-        expected = set(required_helpers)
-        if family_dir.name == "elf_flow":
-            expected.add("model_config.py")
-        else:
-            expected.add("config.py")
-        missing_helpers.extend(
-            f"{family_dir.name}/{helper}"
-            for helper in sorted(expected)
-            if not (family_dir / helper).is_file()
-        )
-
-        for path in sorted(family_dir.glob("*.py")):
+        for path in sorted(family_dir.rglob("*.py")):
             if path.name == "MODEL.toml":
                 continue
-            text = path.read_text(encoding="utf-8")
-            if any(item in text for item in forbidden_imports):
-                central_imports.append(
-                    path.relative_to(families_dir).as_posix()
+            relative = path.relative_to(family_dir)
+            package_depth = len(relative.parent.parts)
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ImportFrom):
+                    continue
+                if node.level == 0:
+                    parts = (node.module or "").split(".")
+                    if (
+                        len(parts) >= 2
+                        and parts[0] == "tensorrt_model_connect"
+                        and parts[1] in forbidden_modules
+                    ):
+                        central_imports.append(relative.as_posix())
+                    continue
+                levels_outside_owner = max(
+                    0,
+                    (node.level - 1) - package_depth,
                 )
+                if levels_outside_owner == 0:
+                    continue
+                modules = [node.module] if node.module else [
+                    alias.name for alias in node.names
+                ]
+                if any(
+                    module and module.split(".", 1)[0] in forbidden_modules
+                    for module in modules
+                ):
+                    central_imports.append(relative.as_posix())
 
-    assert not missing_helpers
     assert not central_imports
 
 

--- a/tests/builder/test_graph_ops_extended.py
+++ b/tests/builder/test_graph_ops_extended.py
@@ -763,7 +763,9 @@ class TestAddReflectPad1d:
     def test_matches_torch_reflect_padding(self, trt_runner):
         import torch
         import torch.nn.functional as F
-        from tensorrt_model_connect.families.bark import graph_ops as bark_graph_ops
+        from tests.builder.owned_graph_modules import load_family_graph_ops
+
+        bark_graph_ops = load_family_graph_ops("bark")
 
         x_np = np.arange(1, 6, dtype=np.float32).reshape(1, 1, 5)
 
@@ -786,7 +788,9 @@ class TestAddLstmUnrolled:
     def test_matches_torch_lstm(self, trt_runner):
         import torch
         import torch.nn as nn
-        from tensorrt_model_connect.families.bark import graph_ops as bark_graph_ops
+        from tests.builder.owned_graph_modules import load_family_graph_ops
+
+        bark_graph_ops = load_family_graph_ops("bark")
 
         rng = np.random.RandomState(7)
         batch, seq_length, input_size, hidden_size = 1, 4, 2, 3

--- a/tests/builder/test_owned_schedulers.py
+++ b/tests/builder/test_owned_schedulers.py
@@ -23,10 +23,12 @@ import numpy as np
 import pytest
 
 
-# Ensure imports resolve to this workspace's Python package.
-_PKG_ROOT = Path(__file__).resolve().parents[2] / "python"
-if str(_PKG_ROOT) not in sys.path:
-    sys.path.insert(0, str(_PKG_ROOT))
+# Ensure imports resolve to this workspace's Python package and owner-local tools.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PKG_ROOT = _REPO_ROOT / "python"
+for import_root in (_REPO_ROOT, _PKG_ROOT):
+    if str(import_root) not in sys.path:
+        sys.path.insert(0, str(import_root))
 
 
 DIFFUSION_SCHEDULER_OWNERS = ("flux", "pixart", "wan_t2v", "z_image")
@@ -36,11 +38,15 @@ DIFFUSION_SCHEDULER_OWNERS = ("flux", "pixart", "wan_t2v", "z_image")
 def scheduler_modules(request: pytest.FixtureRequest):
     """Return the scheduler module pair owned by one diffusion family."""
     family = str(request.param)
-    package = import_module(f"tensorrt_model_connect.families.{family}.schedulers")
-    flow = import_module(
-        f"tensorrt_model_connect.families.{family}.schedulers.flow_match_euler"
+    tools_package = _REPO_ROOT / "tools/families" / family / "schedulers"
+    module_root = (
+        f"tools.families.{family}.schedulers"
+        if tools_package.is_dir()
+        else f"tensorrt_model_connect.families.{family}.schedulers"
     )
-    base = import_module(f"tensorrt_model_connect.families.{family}.schedulers.base")
+    package = import_module(module_root)
+    flow = import_module(f"{module_root}.flow_match_euler")
+    base = import_module(f"{module_root}.base")
     return family, package, flow, base
 
 

--- a/tests/tools/test_family_source_isolation.py
+++ b/tests/tools/test_family_source_isolation.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from tools import family_source_isolation as isolation
+from tools import prune_family_helpers
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FAMILIES_ROOT = REPO_ROOT / "python/tensorrt_model_connect/families"
+
+
+def _module_exists(family_dir: Path, parts: tuple[str, ...]) -> bool:
+    target = family_dir.joinpath(*parts)
+    return target.with_suffix(".py").is_file() or (target / "__init__.py").is_file()
+
+
+def test_resolve_selection_uses_manifest_runtime_owner() -> None:
+    selection = isolation.resolve_selection(REPO_ROOT, "magpie_tts")
+
+    assert selection.family == "magpie_tts"
+    assert selection.runtime_models == ("magpie",)
+    assert "magpie-tts-357m" in selection.e2e_models
+
+
+@pytest.mark.parametrize(
+    ("path", "included"),
+    [
+        ("python/tensorrt_model_connect/families/__init__.py", True),
+        ("python/tensorrt_model_connect/families/base.py", True),
+        ("python/tensorrt_model_connect/families/_time_series_trt.py", False),
+        ("python/tensorrt_model_connect/families/qwen/plugin.py", True),
+        ("python/tensorrt_model_connect/families/llama/plugin.py", False),
+        ("src/runtime/models/qwen/plugin.cpp", True),
+        ("src/runtime/models/llama/plugin.cpp", False),
+        ("tests/cpp/models/qwen/test_qwen_tensor_names.cpp", True),
+        ("tests/cpp/models/llama/test_llama_pipeline.cpp", False),
+        ("tests/e2e_harness/bundle_group_runner.py", True),
+        ("tests/e2e/models/qwen/MODEL.toml", True),
+        ("tests/e2e/models/llama/MODEL.toml", False),
+        ("tools/families/qwen/bench_flashinfer_e2e.py", True),
+        ("tools/families/llama/example.py", False),
+        ("tests/builder/families/qwen/test_family.py", True),
+        ("tests/builder/families/flux/test_family.py", False),
+        ("python/tensorrt_model_connect/build_cli.py", True),
+    ],
+)
+def test_include_path_enforces_family_boundaries(path: str, included: bool) -> None:
+    selection = isolation.FamilySourceSelection(
+        family="qwen",
+        runtime_models=("qwen",),
+        e2e_models=("qwen3-0.6b-fp16",),
+    )
+
+    assert isolation.include_path(PurePosixPath(path), selection) is included
+
+
+def test_materialize_contains_only_selected_owned_directories(tmp_path: Path) -> None:
+    selection = isolation.resolve_selection(REPO_ROOT, "qwen")
+    output = tmp_path / "qwen-source"
+
+    copied = isolation.materialize(REPO_ROOT, output, selection)
+
+    assert copied > 0
+    assert (output / "CMakeLists.txt").is_file()
+    assert (output / "python/tensorrt_model_connect/families/base.py").is_file()
+    assert (output / "python/tensorrt_model_connect/families/qwen/plugin.py").is_file()
+    qwen_family = output / "python/tensorrt_model_connect/families/qwen"
+    assert any(
+        path.is_file()
+        for path in (qwen_family / "model/model.py", qwen_family / "graph_ops.py")
+    )
+    assert not (output / "python/tensorrt_model_connect/families/llama").exists()
+    assert any(
+        path.is_file()
+        for path in (
+            output / "tools/families/qwen/bench_flashinfer_e2e.py",
+            qwen_family / "bench_flashinfer_e2e.py",
+        )
+    )
+    assert not (output / "tools/families/flux").exists()
+    assert not (
+        output / "python/tensorrt_model_connect/families/_time_series_trt.py"
+    ).exists()
+    assert (output / "src/runtime/models/qwen/MODEL.toml").is_file()
+    assert not (output / "src/runtime/models/llama").exists()
+    assert (output / "tests/cpp/models/qwen").is_dir()
+    assert not (output / "tests/cpp/models/llama").exists()
+    assert (output / "tests/e2e/models/qwen/MODEL.toml").is_file()
+    assert not (output / "tests/e2e/models/llama").exists()
+
+    metadata = json.loads(
+        (output / ".trtmc-family-source.json").read_text(encoding="utf-8")
+    )
+    assert metadata["family"] == "qwen"
+    assert metadata["runtime_models"] == ["qwen"]
+    assert metadata["copied_files"] == copied
+
+
+def test_resolve_selection_rejects_unknown_family() -> None:
+    with pytest.raises(SystemExit, match="Unknown Python model family"):
+        isolation.resolve_selection(REPO_ROOT, "not_a_family")
+
+
+def test_family_imports_resolve_without_sibling_or_unapproved_shared_modules() -> None:
+    violations: list[str] = []
+    families_prefix = "tensorrt_model_connect.families"
+
+    for family_dir in sorted(FAMILIES_ROOT.iterdir()):
+        if not (family_dir / "plugin.py").is_file():
+            continue
+        family = family_dir.name
+        for path in sorted(family_dir.rglob("*.py")):
+            relative = path.relative_to(family_dir)
+            package_parts = relative.parent.parts
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        prefix = f"{families_prefix}."
+                        if alias.name.startswith(prefix):
+                            owner = alias.name[len(prefix):].split(".", 1)[0]
+                            if owner != family:
+                                violations.append(
+                                    f"{relative}:{node.lineno}: imports sibling {owner}"
+                                )
+                    continue
+
+                if not isinstance(node, ast.ImportFrom):
+                    continue
+                if node.level == 0:
+                    module = node.module or ""
+                    if module == families_prefix:
+                        names = {alias.name for alias in node.names}
+                        unsupported = names - {"find_plugin"}
+                        if unsupported:
+                            violations.append(
+                                f"{relative}:{node.lineno}: imports unapproved families "
+                                f"surface {sorted(unsupported)}"
+                            )
+                    elif module.startswith(f"{families_prefix}."):
+                        owner = module[len(families_prefix) + 1:].split(".", 1)[0]
+                        if owner != family:
+                            violations.append(
+                                f"{relative}:{node.lineno}: imports sibling {owner}"
+                            )
+                    continue
+
+                parents = node.level - 1
+                if parents <= len(package_parts):
+                    local_parts = package_parts[:len(package_parts) - parents]
+                    if node.module:
+                        target = (*local_parts, *node.module.split("."))
+                        if not _module_exists(family_dir, target):
+                            violations.append(
+                                f"{relative}:{node.lineno}: missing local module "
+                                f"{'.'.join(target)}"
+                            )
+                    else:
+                        for alias in node.names:
+                            target = (*local_parts, alias.name)
+                            if not _module_exists(family_dir, target):
+                                violations.append(
+                                    f"{relative}:{node.lineno}: missing local module "
+                                    f"{'.'.join(target)}"
+                                )
+                    continue
+
+                # Escaping exactly one package reaches families/.  Only its
+                # registry function and protocol module are approved shared
+                # infrastructure.  Escaping farther reaches generic package
+                # infrastructure such as parallel_config and quantization.
+                if parents == len(package_parts) + 1:
+                    if node.module == "base":
+                        continue
+                    if node.module is None and {
+                        alias.name for alias in node.names
+                    } <= {"find_plugin"}:
+                        continue
+                    violations.append(
+                        f"{relative}:{node.lineno}: imports unapproved families-root "
+                        f"module {node.module or [a.name for a in node.names]}"
+                    )
+
+    assert not violations, "\n".join(violations)
+
+
+def test_helper_pruner_keeps_transitive_and_quantization_dependencies(
+    tmp_path: Path,
+) -> None:
+    family_dir = tmp_path / "demo"
+    model_dir = family_dir / "model"
+    model_dir.mkdir(parents=True)
+    (family_dir / "MODEL.toml").write_text('id = "demo"\n', encoding="utf-8")
+    graph_ops = model_dir / "model.py"
+    graph_ops.write_text(
+        "def add_constant():\n"
+        "    return 1\n\n"
+        "def add_matmul_rhs_constant():\n"
+        "    return 2\n\n"
+        "def _helper():\n"
+        "    return 3\n\n"
+        "def used():\n"
+        "    return _helper()\n\n"
+        "def unused():\n"
+        "    return 4\n",
+        encoding="utf-8",
+    )
+    (model_dir / "builder.py").write_text(
+        "from . import model as graph_ops\n\n"
+        "def build():\n"
+        "    return graph_ops.used()\n",
+        encoding="utf-8",
+    )
+
+    result = prune_family_helpers.prune_file(
+        graph_ops, family_dir, write=True
+    )
+
+    assert result.removed_names == ("unused",)
+    updated = graph_ops.read_text(encoding="utf-8")
+    assert "def add_constant" in updated
+    assert "def add_matmul_rhs_constant" in updated
+    assert "def _helper" in updated
+    assert "def used" in updated
+    assert "def unused" not in updated
+
+
+def test_helper_pruner_removes_exact_audited_names(tmp_path: Path) -> None:
+    module = tmp_path / "model.py"
+    module.write_text(
+        "def keep():\n"
+        "    return 1\n\n"
+        "def remove():\n"
+        "    return 2\n",
+        encoding="utf-8",
+    )
+
+    result = prune_family_helpers.prune_named_definitions(
+        module, {"remove"}, write=True
+    )
+
+    assert result.removed_names == ("remove",)
+    assert "def keep" in module.read_text(encoding="utf-8")
+    assert "def remove" not in module.read_text(encoding="utf-8")

--- a/tests/tools/test_family_source_isolation.py
+++ b/tests/tools/test_family_source_isolation.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import ast

--- a/tests/tools/test_family_specialization.py
+++ b/tests/tools/test_family_specialization.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import json

--- a/tests/tools/test_family_specialization.py
+++ b/tests/tools/test_family_specialization.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools import family_specialization as specialization
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _demo_repo(tmp_path: Path) -> Path:
+    family = (
+        tmp_path
+        / "python"
+        / "tensorrt_model_connect"
+        / "families"
+        / "demo"
+    )
+    _write(
+        family / "MODEL.toml",
+        'id = "demo"\nplugin = "demo"\nmodule = "plugin"\n'
+        'debug_runner = "model/runtime.py|runner_from_bundle"\n',
+    )
+    _write(
+        family / "__init__.py",
+        'from .plugin import plugin\n\n__all__ = ["plugin"]\n',
+    )
+    _write(
+        family / "plugin.py",
+        "from .model.model import build_decoder\n\n"
+        "class DemoPlugin:\n"
+        "    def build_engine(self):\n"
+        "        return build_decoder(norm_type='rmsnorm')\n\n"
+        "plugin = DemoPlugin()\n",
+    )
+    _write(family / "config.py", "class ModelConfig:\n    pass\n")
+    _write(family / "weights/__init__.py", "class WeightDict(dict):\n    pass\n")
+    _write(family / "model/__init__.py", '"""Demo model package."""\n')
+    _write(
+        family / "model/model.py",
+        "def used_helper():\n"
+        "    return 1\n\n"
+        "def unused_helper():\n"
+        "    return 2\n\n"
+        "def build_decoder(*, norm_type='rmsnorm'):\n"
+        "    if norm_type == 'rmsnorm':\n"
+        "        return used_helper()\n"
+        "    return 0\n",
+    )
+    _write(
+        family / "model/runtime.py",
+        "def runner_from_bundle():\n"
+        "    return 'runner'\n\n"
+        "def unused_runtime_helper():\n"
+        "    return 'unused'\n",
+    )
+    _write(family / "model/dead.py", "def dead():\n    return None\n")
+    _write(
+        family / "model/tool_runner.py",
+        "class ToolRunner:\n    pass\n",
+    )
+    _write(
+        tmp_path / "tools/families/demo/use_runner.py",
+        "from tensorrt_model_connect.families.demo.model.tool_runner "
+        "import ToolRunner\n",
+    )
+    return tmp_path
+
+
+def test_audit_classifies_production_tool_and_unreachable_modules(
+    tmp_path: Path,
+) -> None:
+    repo = _demo_repo(tmp_path)
+
+    report = specialization.audit_repo(repo, ("demo",))
+    family = report["families"][0]
+
+    assert family["production_modules"] == [
+        "tensorrt_model_connect.families.demo",
+        "tensorrt_model_connect.families.demo.model",
+        "tensorrt_model_connect.families.demo.model.model",
+        "tensorrt_model_connect.families.demo.model.runtime",
+        "tensorrt_model_connect.families.demo.plugin",
+    ]
+    assert family["tool_test_only_modules"] == [
+        "tensorrt_model_connect.families.demo.model.tool_runner"
+    ]
+    assert family["unreachable_modules"] == [
+        "tensorrt_model_connect.families.demo.config",
+        "tensorrt_model_connect.families.demo.model.dead",
+        "tensorrt_model_connect.families.demo.weights",
+    ]
+    assert family["missing_dynamic_entrypoints"] == []
+
+
+def test_audit_reports_symbols_switches_and_layout_violations(tmp_path: Path) -> None:
+    repo = _demo_repo(tmp_path)
+
+    family = specialization.audit_repo(repo, ("demo",))["families"][0]
+
+    unreachable = {
+        (item["path"], item["symbol"])
+        for item in family["unreachable_symbols"]
+    }
+    assert ("model/model.py", "unused_helper") in unreachable
+    assert ("model/runtime.py", "unused_runtime_helper") in unreachable
+    assert family["fixed_strategy_switches"] == [
+        {
+            "function": "build_decoder",
+            "parameter": "norm_type",
+            "value": "rmsnorm",
+            "definitions": [
+                "tensorrt_model_connect.families.demo.model.model"
+            ],
+            "call_sites": [{"path": "plugin.py", "line": 5}],
+        }
+    ]
+    assert family["noncanonical_model_paths"] == [
+        "model/dead.py",
+        "model/tool_runner.py",
+    ]
+    assert {
+        item["kind"] for item in family["violations"]
+    } >= {
+        "fixed_strategy_switch",
+        "noncanonical_model_path",
+        "tool_test_only_model_module",
+        "unreachable_module",
+        "unreachable_symbol",
+    }
+
+
+def test_audit_does_not_fix_switch_with_default_only_call(tmp_path: Path) -> None:
+    repo = _demo_repo(tmp_path)
+    family = repo / "python/tensorrt_model_connect/families/demo"
+    _write(
+        family / "plugin.py",
+        "from .model.model import build_decoder\n\n"
+        "class DemoPlugin:\n"
+        "    def build_engine(self, explicit):\n"
+        "        if explicit:\n"
+        "            return build_decoder(norm_type='rmsnorm')\n"
+        "        return build_decoder()\n\n"
+        "plugin = DemoPlugin()\n",
+    )
+
+    result = specialization.audit_repo(repo, ("demo",))["families"][0]
+
+    assert result["fixed_strategy_switches"] == []
+
+
+def test_audit_reports_missing_manifest_paths_and_sibling_imports(
+    tmp_path: Path,
+) -> None:
+    repo = _demo_repo(tmp_path)
+    family = (
+        repo
+        / "python"
+        / "tensorrt_model_connect"
+        / "families"
+        / "demo"
+    )
+    _write(
+        family / "MODEL.toml",
+        'id = "demo"\nplugin = "demo"\nmodule = "plugin"\n'
+        'debug_runner = "model/missing.py|runner_from_bundle"\n',
+    )
+    _write(
+        family / "plugin.py",
+        "from tensorrt_model_connect.families.other.model import build\n\n"
+        "plugin = build\n",
+    )
+
+    result = specialization.audit_repo(repo, ("demo",))["families"][0]
+
+    assert result["missing_dynamic_entrypoints"] == [
+        {
+            "source": "MODEL.toml",
+            "path": "model/missing.py",
+            "symbol": "runner_from_bundle",
+            "reason": "missing_path",
+        }
+    ]
+    assert result["sibling_family_imports"] == [
+        {
+            "path": "plugin.py",
+            "line": 1,
+            "target": "tensorrt_model_connect.families.other.model",
+        }
+    ]
+
+
+def test_audit_reports_missing_manifest_symbols(tmp_path: Path) -> None:
+    repo = _demo_repo(tmp_path)
+    family = (
+        repo
+        / "python"
+        / "tensorrt_model_connect"
+        / "families"
+        / "demo"
+    )
+    _write(
+        family / "MODEL.toml",
+        'id = "demo"\nplugin = "demo"\nmodule = "plugin"\n'
+        'debug_runner = "model/runtime.py|missing_runner"\n',
+    )
+
+    result = specialization.audit_repo(repo, ("demo",))["families"][0]
+
+    assert result["missing_dynamic_entrypoints"] == [
+        {
+            "source": "MODEL.toml",
+            "path": "model/runtime.py",
+            "symbol": "missing_runner",
+            "reason": "missing_symbol",
+        }
+    ]
+
+
+def test_audit_does_not_treat_profile_boolean_as_python_symbol(
+    tmp_path: Path,
+) -> None:
+    repo = _demo_repo(tmp_path)
+    family = repo / "python/tensorrt_model_connect/families/demo"
+    _write(
+        family / "MODEL.toml",
+        'id = "demo"\nplugin = "demo"\nmodule = "plugin"\n'
+        'python_profile_specs = ["demo|requirements.txt|model/runtime.py|true"]\n',
+    )
+    _write(family / "requirements.txt", "demo==1\n")
+
+    result = specialization.audit_repo(repo, ("demo",))["families"][0]
+
+    assert result["missing_dynamic_entrypoints"] == []
+    entry = next(
+        item
+        for item in result["entrypoints"]["dynamic"]
+        if item["path"] == "model/runtime.py"
+    )
+    assert entry["symbol"] is None
+
+
+def test_audit_resolves_generic_vision_language_runner_convention(
+    tmp_path: Path,
+) -> None:
+    repo = _demo_repo(tmp_path)
+    family = (
+        repo
+        / "python"
+        / "tensorrt_model_connect"
+        / "families"
+        / "demo"
+    )
+    _write(
+        family / "plugin.py",
+        "from .model.model import build_decoder\n\n"
+        "class DemoPlugin:\n"
+        "    runtime_strategy = 'demo_vision_language'\n\n"
+        "    def build_engine(self):\n"
+        "        return build_decoder(norm_type='rmsnorm')\n\n"
+        "plugin = DemoPlugin()\n",
+    )
+    _write(
+        repo / "tools/families/demo/vl_debug_runner.py",
+        "class VLTrtRunner:\n    pass\n",
+    )
+
+    result = specialization.audit_repo(repo, ("demo",))["families"][0]
+    assert result["missing_dynamic_entrypoints"] == []
+
+
+def test_audit_requires_generic_vision_language_runner_convention(
+    tmp_path: Path,
+) -> None:
+    repo = _demo_repo(tmp_path)
+    family = (
+        repo
+        / "python"
+        / "tensorrt_model_connect"
+        / "families"
+        / "demo"
+    )
+    _write(
+        family / "plugin.py",
+        "class DemoPlugin:\n"
+        "    runtime_strategy = 'demo_vision_language'\n\n"
+        "plugin = DemoPlugin()\n",
+    )
+
+    result = specialization.audit_repo(repo, ("demo",))["families"][0]
+
+    assert {
+        "source": "tools/diff_vl.py::<family-dispatch>",
+        "path": "tools/families/demo/vl_debug_runner.py",
+        "reason": "missing_path",
+    } in result["missing_dynamic_entrypoints"]
+
+
+def test_inventory_report_is_deterministic_and_serializable(tmp_path: Path) -> None:
+    repo = _demo_repo(tmp_path)
+
+    first = specialization.audit_repo(repo, ("demo",))
+    second = specialization.audit_repo(repo, ("demo",))
+
+    assert first == second
+    assert json.loads(json.dumps(first, sort_keys=True)) == first
+    assert first["schema_version"] == specialization.SCHEMA_VERSION
+
+
+def test_repository_registers_all_current_families() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+
+    families = specialization.family_dirs(repo_root, ())
+
+    assert len(families) == 76

--- a/tests/tools/test_migrate_family_layout.py
+++ b/tests/tools/test_migrate_family_layout.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import ast

--- a/tests/tools/test_migrate_family_layout.py
+++ b/tests/tools/test_migrate_family_layout.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from tools import migrate_family_layout as layout
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_migrate_rehomes_components_and_rewrites_imports(tmp_path: Path) -> None:
+    family = tmp_path / "python/tensorrt_model_connect/families/demo"
+    _write(family / "__init__.py", "from .plugin import plugin\n")
+    _write(family / "config.py", "class ModelConfig:\n    pass\n")
+    _write(
+        family / "checkpoint_mapper.py",
+        "from .config import ModelConfig\n"
+        "from ...quantization.context import QuantContext\n\n"
+        "def load_weights():\n"
+        "    return ModelConfig, QuantContext\n",
+    )
+    _write(family / "graph_ops.py", "def add_constant():\n    return 1\n")
+    _write(
+        family / "builder.py",
+        "from . import graph_ops\n"
+        "from .config import ModelConfig\n"
+        "from ...parallel_config import ParallelConfig\n",
+    )
+    _write(
+        family / "plugin.py",
+        "from . import graph_ops\n"
+        "from .builder import build\n"
+        "from .checkpoint_mapper import load_weights\n\n"
+        "plugin = object()\n",
+    )
+    _write(
+        family / "diff_vl.py",
+        "from . import graph_ops\n\n"
+        "print(graph_ops.add_constant())\n",
+    )
+    _write(
+        tmp_path / "tests/test_demo.py",
+        "from tensorrt_model_connect.families.demo.graph_ops import add_constant\n",
+    )
+
+    layout.migrate(tmp_path)
+
+    assert not layout.layout_violations(tmp_path)
+    assert {path.name for path in family.iterdir()} == layout.CANONICAL_TOP_LEVEL
+    assert "from .model import model as graph_ops" in (family / "plugin.py").read_text()
+    assert "from .model.builder import build" in (family / "plugin.py").read_text()
+    assert "from .weights import load_weights" in (family / "plugin.py").read_text()
+
+    builder = (family / "model/builder.py").read_text()
+    assert "from . import model as graph_ops" in builder
+    assert "from ..config import ModelConfig" in builder
+    assert "from ....parallel_config import ParallelConfig" in builder
+
+    weights = (family / "weights/__init__.py").read_text()
+    assert "from ..config import ModelConfig" in weights
+    assert "from ....quantization.context import QuantContext" in weights
+
+    external = (tmp_path / "tests/test_demo.py").read_text()
+    assert "families.demo.model.model" in external
+    moved_tool = tmp_path / "tools/families/demo/diff_vl.py"
+    assert moved_tool.is_file()
+    assert "from tensorrt_model_connect.families.demo.model import model as graph_ops" in (
+        moved_tool.read_text()
+    )
+    consolidated = (family / "model/model.py").read_text()
+    assert "def add_constant" in consolidated
+    assert not (family / "model/graph_ops.py").exists()
+
+
+def test_migrate_adds_missing_manifest(tmp_path: Path) -> None:
+    family = tmp_path / "python/tensorrt_model_connect/families/demo"
+    _write(family / "__init__.py", "")
+    _write(family / "config.py", "")
+    _write(family / "checkpoint_mapper.py", "")
+    _write(family / "graph_ops.py", "")
+    _write(family / "plugin.py", "plugin = object()\n")
+
+    layout.migrate(tmp_path)
+
+    manifest = (family / "MODEL.toml").read_text()
+    assert 'id = "demo"' in manifest
+    assert 'module = "plugin"' in manifest
+
+
+def test_migrate_can_target_one_family(tmp_path: Path) -> None:
+    selected = tmp_path / "python/tensorrt_model_connect/families/selected"
+    untouched = tmp_path / "python/tensorrt_model_connect/families/untouched"
+    for family in (selected, untouched):
+        _write(family / "__init__.py", "from .plugin import plugin\n")
+        _write(family / "config.py", "")
+        _write(family / "checkpoint_mapper.py", "")
+        _write(family / "graph_ops.py", "")
+        _write(family / "plugin.py", "plugin = object()\n")
+
+    layout.migrate(tmp_path, ("selected",))
+
+    assert not layout.layout_violations(tmp_path, ("selected",))
+    assert (selected / "model/model.py").is_file()
+    assert (untouched / "graph_ops.py").is_file()
+    assert not (untouched / "model").exists()
+
+
+def test_migrated_family_imports_use_canonical_components() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    families_root = repo_root / "python/tensorrt_model_connect/families"
+    prefix = "tensorrt_model_connect.families."
+    allowed_components = {"config", "model", "plugin", "weights"}
+    violations: list[str] = []
+
+    for source_root in (".github", "python", "scripts", "tests", "tools"):
+        root = repo_root / source_root
+        for path in sorted(root.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            modules: list[tuple[int, str]] = []
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    modules.extend((node.lineno, alias.name) for alias in node.names)
+                elif isinstance(node, ast.ImportFrom) and node.module:
+                    modules.append((node.lineno, node.module))
+
+            for line, module in modules:
+                if not module.startswith(prefix):
+                    continue
+                parts = module[len(prefix):].split(".")
+                family_dir = families_root / parts[0]
+                if not (family_dir / "plugin.py").is_file():
+                    continue
+                if not (family_dir / "model/model.py").is_file():
+                    continue
+                component_parts = parts[1:]
+                if component_parts and component_parts[0] not in allowed_components:
+                    violations.append(f"{path}:{line}: non-canonical family import {module}")
+                    continue
+                if not component_parts:
+                    continue
+                target = family_dir.joinpath(*component_parts)
+                if not (target.with_suffix(".py").is_file() or (target / "__init__.py").is_file()):
+                    violations.append(f"{path}:{line}: missing family module {module}")
+
+    assert not violations, "\n".join(violations)

--- a/tests/tools/test_relocate_family_development.py
+++ b/tests/tools/test_relocate_family_development.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools import relocate_family_development as relocation
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_apply_relocations_moves_owner_tool_and_rewrites_imports(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    family = tmp_path / "python/tensorrt_model_connect/families/demo"
+    source = family / "model/debug_runner.py"
+    _write(source, "class Runner:\n    pass\n")
+    _write(
+        tmp_path / "tools/families/demo/use.py",
+        "from tensorrt_model_connect.families.demo.model.debug_runner "
+        "import Runner\n",
+    )
+    planned = relocation.Relocation(
+        "demo", "model/debug_runner.py", "tools/families/demo/debug_runner.py"
+    )
+    monkeypatch.setattr(relocation, "RELOCATIONS", (planned,))
+
+    relocation.apply_relocations(tmp_path, frozenset({"demo"}))
+
+    destination = tmp_path / "tools/families/demo/debug_runner.py"
+    assert destination.is_file()
+    assert not source.exists()
+    assert "from tools.families.demo.debug_runner import Runner" in (
+        tmp_path / "tools/families/demo/use.py"
+    ).read_text(encoding="utf-8")
+    assert relocation.pending_relocations(tmp_path, frozenset({"demo"})) == []

--- a/tests/tools/test_relocate_family_development.py
+++ b/tests/tools/test_relocate_family_development.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/tools/test_specialize_family.py
+++ b/tests/tools/test_specialize_family.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from tools import specialize_family
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _repo(tmp_path: Path) -> Path:
+    family = (
+        tmp_path
+        / "python"
+        / "tensorrt_model_connect"
+        / "families"
+        / "demo"
+    )
+    _write(family / "MODEL.toml", 'id = "demo"\n')
+    _write(family / "__init__.py", "from .plugin import plugin\n")
+    _write(
+        family / "plugin.py",
+        "from .model.encoder_builder import build_encoder\n\n"
+        "def build_parallel():\n"
+        "    from .model.tp_builder import build_tp\n"
+        "    return build_tp()\n\n"
+        "plugin = build_encoder\n",
+    )
+    _write(family / "config.py", "class ModelConfig:\n    pass\n")
+    _write(family / "weights/__init__.py", "class WeightDict(dict):\n    pass\n")
+    _write(family / "model/__init__.py", '"""Model package."""\n')
+    _write(
+        family / "model/model.py",
+        '"""Core graph."""\n\n'
+        "from __future__ import annotations\n\n"
+        "from .encoder_builder import build_encoder\n\n"
+        "def core():\n"
+        "    return 1\n",
+    )
+    _write(
+        family / "model/encoder_builder.py",
+        '"""Encoder."""\n\n'
+        "from __future__ import annotations\n\n"
+        "from . import model as graph_ops\n\n"
+        "from .model import core as _core\n\n"
+        "def build_encoder():\n"
+        "    return graph_ops.core() + _core()\n",
+    )
+    _write(
+        family / "model/tp_builder.py",
+        '"""Parallel encoder."""\n\n'
+        "from __future__ import annotations\n\n"
+        "from . import model as graph_ops\n\n"
+        "def build_tp():\n"
+        "    return graph_ops.core()\n",
+    )
+    _write(
+        tmp_path / "tests/test_demo.py",
+        "from tensorrt_model_connect.families.demo.model.tp_builder "
+        "import build_tp\n",
+    )
+    return tmp_path
+
+
+def test_specialize_family_merges_model_and_renames_parallel(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    family = repo / "python/tensorrt_model_connect/families/demo"
+    specialization = specialize_family.SpecializationLayout(
+        model_modules=("encoder_builder.py",),
+        parallel_modules=("tp_builder.py",),
+        runtime_modules=(),
+    )
+
+    specialize_family.specialize_family(repo, "demo", specialization)
+
+    assert not (family / "model/encoder_builder.py").exists()
+    assert not (family / "model/tp_builder.py").exists()
+    assert (family / "model/parallel.py").is_file()
+    model_text = (family / "model/model.py").read_text(encoding="utf-8")
+    assert "def core" in model_text
+    assert "def build_encoder" in model_text
+    assert "graph_ops." not in model_text
+    assert "_core" not in model_text
+    assert "from .model import" not in model_text
+    ast.parse(model_text)
+    plugin_text = (family / "plugin.py").read_text(encoding="utf-8")
+    assert "from .model.model import build_encoder" in plugin_text
+    assert "from .model.parallel import build_tp" in plugin_text
+    test_text = (repo / "tests/test_demo.py").read_text(encoding="utf-8")
+    assert "families.demo.model.parallel" in test_text
+
+
+def test_specialize_family_is_idempotent(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    specialization = specialize_family.SpecializationLayout(
+        model_modules=("encoder_builder.py",),
+        parallel_modules=("tp_builder.py",),
+        runtime_modules=(),
+    )
+
+    specialize_family.specialize_family(repo, "demo", specialization)
+    before = {
+        path.relative_to(repo): path.read_bytes()
+        for path in repo.rglob("*")
+        if path.is_file()
+    }
+    specialize_family.specialize_family(repo, "demo", specialization)
+    after = {
+        path.relative_to(repo): path.read_bytes()
+        for path in repo.rglob("*")
+        if path.is_file()
+    }
+
+    assert after == before
+
+
+def test_specialize_family_moves_runtime_components_and_profiles(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    family = repo / "python/tensorrt_model_connect/families/demo"
+    _write(family / "model/debug_runner.py", "class Runner:\n    pass\n")
+    _write(family / "model/vision_builder.py", "def build_vision():\n    return 1\n")
+    _write(family / "model/python_profile_verify.py", "VERIFIED = True\n")
+    _write(
+        family / "model/python_profile_requirements/demo.lock.txt",
+        "demo==1\n",
+    )
+    _write(
+        family / "MODEL.toml",
+        'id = "demo"\n'
+        'debug_runner = "model/debug_runner.py|Runner"\n'
+        'config_adapter = "model/vision_builder.py|build_vision"\n'
+        'python_profile_specs = ["demo|families/demo/model/'
+        'python_profile_requirements/demo.lock.txt|families/demo/model/'
+        'python_profile_verify.py|true"]\n',
+    )
+    _write(
+        repo / "tests/test_paths.py",
+        "from tensorrt_model_connect.families.demo.model.debug_runner import Runner\n"
+        "from tensorrt_model_connect.families.demo.model.vision_builder "
+        "import build_vision\n",
+    )
+    specialization = specialize_family.SpecializationLayout(
+        runtime_modules=("debug_runner.py",),
+        component_modules=(("vision_builder.py", "vision.py"),),
+        profile_paths=(
+            ("python_profile_requirements", "requirements"),
+            ("python_profile_verify.py", "verify.py"),
+        ),
+    )
+
+    specialize_family.specialize_family(repo, "demo", specialization)
+
+    assert (family / "model/runtime.py").is_file()
+    assert (family / "model/components/vision.py").is_file()
+    assert (family / "profiles/requirements/demo.lock.txt").is_file()
+    assert (family / "profiles/verify.py").is_file()
+    manifest = (family / "MODEL.toml").read_text(encoding="utf-8")
+    assert "model/runtime.py|Runner" in manifest
+    assert "model/components/vision.py|build_vision" in manifest
+    assert "/profiles/requirements/" in manifest
+    assert "/profiles/verify.py" in manifest
+    imports = (repo / "tests/test_paths.py").read_text(encoding="utf-8")
+    assert "model.runtime import Runner" in imports
+    assert "model.components.vision import build_vision" in imports
+
+
+def test_specialize_family_normalizes_profile_manifest_without_runtime(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    family = repo / "python/tensorrt_model_connect/families/demo"
+    _write(family / "model/python_profile_verify.py", "VERIFIED = True\n")
+    _write(
+        family / "model/python_profile_requirements/demo.lock.txt",
+        "demo==1\n",
+    )
+    _write(
+        family / "MODEL.toml",
+        'id = "demo"\n'
+        'python_profile_specs = ["demo|families/demo/model/'
+        'python_profile_requirements/demo.lock.txt|families/demo/model/'
+        'python_profile_verify.py|true"]\n',
+    )
+    specialization = specialize_family.SpecializationLayout(
+        profile_paths=(
+            ("python_profile_requirements", "requirements"),
+            ("python_profile_verify.py", "verify.py"),
+        ),
+    )
+
+    specialize_family.specialize_family(repo, "demo", specialization)
+
+    manifest = (family / "MODEL.toml").read_text(encoding="utf-8")
+    assert "/profiles/requirements/" in manifest
+    assert "/profiles/verify.py" in manifest

--- a/tests/tools/test_specialize_family.py
+++ b/tests/tools/test_specialize_family.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import ast

--- a/tests/tools/test_specialize_family_switches.py
+++ b/tests/tools/test_specialize_family_switches.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/tools/test_specialize_family_switches.py
+++ b/tests/tools/test_specialize_family_switches.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools import family_specialization
+from tools import specialize_family_switches
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_apply_report_removes_switch_and_unsupported_branch(tmp_path: Path) -> None:
+    family = tmp_path / "python/tensorrt_model_connect/families/demo"
+    _write(family / "MODEL.toml", 'id = "demo"\nmodule = "plugin"\n')
+    _write(family / "__init__.py", "from .plugin import plugin\n")
+    _write(
+        family / "plugin.py",
+        "from .model.model import build_decoder\n\n"
+        "plugin = build_decoder(norm_type='rmsnorm')\n",
+    )
+    _write(family / "config.py", "class ModelConfig:\n    pass\n")
+    _write(family / "weights/__init__.py", "class WeightDict(dict):\n    pass\n")
+    _write(family / "model/__init__.py", '"""Model package."""\n')
+    _write(
+        family / "model/model.py",
+        "def rms_norm():\n"
+        "    return 'rms'\n\n"
+        "def layer_norm():\n"
+        "    return 'layer'\n\n"
+        "def build_decoder(norm_type='layernorm'):\n"
+        "    if norm_type == 'rmsnorm':\n"
+        "        return rms_norm()\n"
+        "    return layer_norm()\n",
+    )
+    report = family_specialization.audit_repo(tmp_path, ("demo",))
+
+    changed = specialize_family_switches.apply_report(tmp_path, report)
+
+    assert changed == 1
+    plugin = (family / "plugin.py").read_text(encoding="utf-8")
+    model = (family / "model/model.py").read_text(encoding="utf-8")
+    assert "norm_type" not in plugin
+    assert "norm_type" not in model
+    assert model.count("layer_norm()") == 1  # Definition remains for reachability pruning.
+    assert "return rms_norm()" in model
+    assert not family_specialization.audit_repo(
+        tmp_path, ("demo",)
+    )["families"][0]["fixed_strategy_switches"]

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -819,6 +819,16 @@ class TestFamilyPlugin:
         assert match.rule == "family_package"
         assert match.models == ["encoder-package-core"]
 
+    def test_family_development_tool(self, imap):
+        """Family-owned development tools select only their owner models."""
+        match = test_impact.classify_file(
+            "tools/families/decoder_family/debug_runner.py", imap)
+
+        assert match.rule == "family_development_tool"
+        assert sorted(match.models) == ["decoder-large", "decoder-small"]
+        assert match.unit_tiers == ["tools"]
+        assert match.rebuild_cpp is False
+
 # ---------------------------------------------------------------------------
 # Shared module tests (broad impact)
 # ---------------------------------------------------------------------------
@@ -872,7 +882,7 @@ class TestSharedModules:
     def test_python_profile_requirements_scope(self, imap):
         """python profile locks affect only families that use that profile."""
         match = test_impact.classify_file(
-            "python/tensorrt_model_connect/families/sequence_quantile_family/python_profile_requirements/sequence_profile.lock.txt",
+            "python/tensorrt_model_connect/families/sequence_quantile_family/profiles/requirements/sequence_profile.lock.txt",
             imap,
         )
 
@@ -893,10 +903,10 @@ class TestFamilyOwnedBuilder:
         assert match.rule == "shared_builder_module"
         assert sorted(match.models) == sorted(imap.all_model_names)
 
-    def test_family_local_standard_decoder_builder(self, imap):
-        """families/decoder_family/standard_decoder_builder.py -> exactly decoder_family models."""
+    def test_family_local_model_implementation(self, imap):
+        """families/decoder_family/model/model.py -> exactly decoder_family models."""
         match = test_impact.classify_file(
-            "python/tensorrt_model_connect/families/decoder_family/standard_decoder_builder.py",
+            "python/tensorrt_model_connect/families/decoder_family/model/model.py",
             imap,
         )
         assert match.rule == "family_package"
@@ -1491,6 +1501,24 @@ class TestUnitTiers:
             assert match.unit_tiers == ["tools"]
             assert match.rebuild_cpp is False
 
+    def test_family_ownership_tools(self, imap):
+        """Family migration and isolation tools run tools-tier validation."""
+        for path in (
+            "tools/families/__init__.py",
+            "tools/family_source_isolation.py",
+            "tools/family_specialization.py",
+            "tools/migrate_family_layout.py",
+            "tools/prune_family_helpers.py",
+            "tools/relocate_family_development.py",
+            "tools/specialize_family.py",
+            "tools/specialize_family_switches.py",
+        ):
+            match = test_impact.classify_file(path, imap)
+            assert match.rule == "family_ownership_tool"
+            assert match.models == []
+            assert match.unit_tiers == ["tools"]
+            assert match.rebuild_cpp is False
+
     def test_source_implies_unit_tier(self, imap):
         """C++ source change implies 'cpp' unit tier alongside E2E."""
         match = test_impact.classify_file(
@@ -1966,7 +1994,7 @@ diff --git a/python/tensorrt_model_connect/families/__init__.py b/python/tensorr
 diff --git a/python/tensorrt_model_connect/families/sequence_quantile_family/MODEL.toml b/python/tensorrt_model_connect/families/sequence_quantile_family/MODEL.toml
 @@ -1 +1 @@
 +python_profile_specs = [
-+  "sequence_profile|families/sequence_quantile_family/python_profile_requirements/sequence_profile.lock.txt|families/sequence_quantile_family/python_profile_verify.py|true",
++  "sequence_profile|families/sequence_quantile_family/profiles/requirements/sequence_profile.lock.txt|families/sequence_quantile_family/profiles/verify.py|true",
 +]
 +default_execution_profiles = [
 +  "build|sequence_profile",

--- a/tools/cpu_profile_matrix.py
+++ b/tools/cpu_profile_matrix.py
@@ -61,20 +61,23 @@ class StrategySpec(NamedTuple):
     trust_remote_code: bool = False
 
 
-def _family_root() -> Path:
-    return (
-        Path(__file__).resolve().parents[1]
-        / "python"
-        / "tensorrt_model_connect"
-        / "families"
+def _family_handler_paths(filename: str) -> list[Path]:
+    repo_root = Path(__file__).resolve().parents[1]
+    roots = (
+        Path(__file__).resolve().parent / "families",
+        repo_root / "python/tensorrt_model_connect/families",
     )
+    handlers: dict[str, Path] = {}
+    for root in reversed(roots):
+        handlers.update({path.parent.name: path for path in root.glob(f"*/{filename}")})
+    return [handlers[family] for family in sorted(handlers)]
 
 
 @lru_cache(maxsize=1)
 def _family_matrix_modules() -> tuple[ModuleType, ...]:
     """Load optional family-owned matrix specs."""
     modules: list[ModuleType] = []
-    for hook_path in sorted(_family_root().glob("*/cpu_profile_matrix.py")):
+    for hook_path in _family_handler_paths("cpu_profile_matrix.py"):
         module_name = f"_trtmc_cpu_profile_matrix_{hook_path.parent.name}"
         spec = importlib.util.spec_from_file_location(module_name, hook_path)
         if spec is None or spec.loader is None:

--- a/tools/debug_diffusion_pipeline.py
+++ b/tools/debug_diffusion_pipeline.py
@@ -5,7 +5,7 @@
 """Diffusion pipeline debug entrypoint.
 
 Concrete pipeline-debug behavior is owned by model-family modules under
-``python/tensorrt_model_connect/families/*/debug_diffusion_pipeline.py``. This
+``tools/families/*/debug_diffusion_pipeline.py``. This
 shared tool only discovers and dispatches to those handlers.
 """
 
@@ -20,19 +20,25 @@ from types import ModuleType
 from typing import Any
 
 
-def _family_root() -> Path:
+def _family_roots() -> tuple[Path, ...]:
+    repo_root = Path(__file__).resolve().parents[1]
     return (
-        Path(__file__).resolve().parents[1]
-        / "python"
-        / "tensorrt_model_connect"
-        / "families"
+        Path(__file__).resolve().parent / "families",
+        repo_root / "python/tensorrt_model_connect/families",
     )
+
+
+def _family_handler_paths(filename: str) -> list[Path]:
+    handlers: dict[str, Path] = {}
+    for root in reversed(_family_roots()):
+        handlers.update({path.parent.name: path for path in root.glob(f"*/{filename}")})
+    return [handlers[family] for family in sorted(handlers)]
 
 
 @lru_cache(maxsize=1)
 def _family_debug_modules() -> tuple[ModuleType, ...]:
     modules: list[ModuleType] = []
-    for handler_path in sorted(_family_root().glob("*/debug_diffusion_pipeline.py")):
+    for handler_path in _family_handler_paths("debug_diffusion_pipeline.py"):
         module_name = f"_trtmc_debug_diffusion_pipeline_{handler_path.parent.name}"
         spec = importlib.util.spec_from_file_location(module_name, handler_path)
         if spec is None or spec.loader is None:

--- a/tools/diff_audio.py
+++ b/tools/diff_audio.py
@@ -5,7 +5,7 @@
 """Audio diff entrypoint.
 
 Concrete audio comparison behavior is owned by model-family modules under
-``python/tensorrt_model_connect/families/*/diff_audio.py``. This shared tool
+``tools/families/*/diff_audio.py``. This shared tool
 only discovers and dispatches to those handlers.
 """
 
@@ -20,19 +20,25 @@ from types import ModuleType
 from typing import Any
 
 
-def _family_root() -> Path:
+def _family_roots() -> tuple[Path, ...]:
+    repo_root = Path(__file__).resolve().parents[1]
     return (
-        Path(__file__).resolve().parents[1]
-        / "python"
-        / "tensorrt_model_connect"
-        / "families"
+        Path(__file__).resolve().parent / "families",
+        repo_root / "python/tensorrt_model_connect/families",
     )
+
+
+def _family_handler_paths(filename: str) -> list[Path]:
+    handlers: dict[str, Path] = {}
+    for root in reversed(_family_roots()):
+        handlers.update({path.parent.name: path for path in root.glob(f"*/{filename}")})
+    return [handlers[family] for family in sorted(handlers)]
 
 
 @lru_cache(maxsize=1)
 def _family_audio_diff_modules() -> tuple[ModuleType, ...]:
     modules: list[ModuleType] = []
-    for handler_path in sorted(_family_root().glob("*/diff_audio.py")):
+    for handler_path in _family_handler_paths("diff_audio.py"):
         module_name = f"_trtmc_diff_audio_{handler_path.parent.name}"
         spec = importlib.util.spec_from_file_location(module_name, handler_path)
         if spec is None or spec.loader is None:

--- a/tools/diff_logits.py
+++ b/tools/diff_logits.py
@@ -40,17 +40,23 @@ STANDARD_PROMPTS = [
 ]
 
 
+def _family_handler_paths(filename: str) -> list[Path]:
+    repo_root = Path(__file__).resolve().parents[1]
+    roots = (
+        Path(__file__).resolve().parent / "families",
+        repo_root / "python/tensorrt_model_connect/families",
+    )
+    handlers: dict[str, Path] = {}
+    for root in reversed(roots):
+        handlers.update({path.parent.name: path for path in root.glob(f"*/{filename}")})
+    return [handlers[family] for family in sorted(handlers)]
+
+
 @lru_cache(maxsize=1)
 def _family_diff_logits_modules() -> tuple[ModuleType, ...]:
     """Load optional model-owned logit diff hooks from family folders."""
-    family_root = (
-        Path(__file__).resolve().parents[1]
-        / "python"
-        / "tensorrt_model_connect"
-        / "families"
-    )
     modules: list[ModuleType] = []
-    for handler_path in sorted(family_root.glob("*/diff_logits.py")):
+    for handler_path in _family_handler_paths("diff_logits.py"):
         module_name = f"_trtmc_diff_logits_{handler_path.parent.name}"
         spec = importlib.util.spec_from_file_location(module_name, handler_path)
         if spec is None or spec.loader is None:

--- a/tools/diff_t5.py
+++ b/tools/diff_t5.py
@@ -5,7 +5,7 @@
 """Encoder diff entrypoint.
 
 Concrete encoder comparison behavior is owned by model-family modules under
-``python/tensorrt_model_connect/families/*/diff_t5.py``. This shared tool only
+``tools/families/*/diff_t5.py``. This shared tool only
 discovers and dispatches to those handlers.
 """
 
@@ -20,19 +20,25 @@ from types import ModuleType
 from typing import Any
 
 
-def _family_root() -> Path:
+def _family_roots() -> tuple[Path, ...]:
+    repo_root = Path(__file__).resolve().parents[1]
     return (
-        Path(__file__).resolve().parents[1]
-        / "python"
-        / "tensorrt_model_connect"
-        / "families"
+        Path(__file__).resolve().parent / "families",
+        repo_root / "python/tensorrt_model_connect/families",
     )
+
+
+def _family_handler_paths(filename: str) -> list[Path]:
+    handlers: dict[str, Path] = {}
+    for root in reversed(_family_roots()):
+        handlers.update({path.parent.name: path for path in root.glob(f"*/{filename}")})
+    return [handlers[family] for family in sorted(handlers)]
 
 
 @lru_cache(maxsize=1)
 def _family_encoder_diff_modules() -> tuple[ModuleType, ...]:
     modules: list[ModuleType] = []
-    for handler_path in sorted(_family_root().glob("*/diff_t5.py")):
+    for handler_path in _family_handler_paths("diff_t5.py"):
         module_name = f"_trtmc_diff_t5_{handler_path.parent.name}"
         spec = importlib.util.spec_from_file_location(module_name, handler_path)
         if spec is None or spec.loader is None:

--- a/tools/diff_vl.py
+++ b/tools/diff_vl.py
@@ -61,17 +61,23 @@ def _detect_model_type(model_id: str) -> str:
     return getattr(cfg, "model_type", "unknown")
 
 
+def _family_handler_paths(filename: str) -> list[Path]:
+    repo_root = Path(__file__).resolve().parents[1]
+    roots = (
+        repo_root / "tools/families",
+        repo_root / "python/tensorrt_model_connect/families",
+    )
+    handlers: dict[str, Path] = {}
+    for root in reversed(roots):
+        handlers.update({path.parent.name: path for path in root.glob(f"*/{filename}")})
+    return [handlers[family] for family in sorted(handlers)]
+
+
 @lru_cache(maxsize=1)
 def _family_diff_vl_modules() -> tuple[ModuleType, ...]:
     """Load optional model-owned VL diff handlers from family folders."""
-    family_root = (
-        Path(__file__).resolve().parents[1]
-        / "python"
-        / "tensorrt_model_connect"
-        / "families"
-    )
     modules: list[ModuleType] = []
-    for handler_path in sorted(family_root.glob("*/diff_vl.py")):
+    for handler_path in _family_handler_paths("diff_vl.py"):
         module_name = f"_trtmc_diff_vl_{handler_path.parent.name}"
         spec = importlib.util.spec_from_file_location(module_name, handler_path)
         if spec is None or spec.loader is None:
@@ -130,17 +136,18 @@ def _load_family_vl_debug_runner(bundle_path: str) -> ModuleType:
             "VL debug execution requires bundle family metadata so the "
             "owning family vl_debug_runner.py can be selected."
         )
-    module_path = (
-        Path(__file__).resolve().parents[1]
-        / "python"
-        / "tensorrt_model_connect"
-        / "families"
+    repo_root = Path(__file__).resolve().parents[1]
+    candidates = (
+        repo_root / "tools/families" / family / "vl_debug_runner.py",
+        repo_root
+        / "python/tensorrt_model_connect/families"
         / family
-        / "vl_debug_runner.py"
+        / "vl_debug_runner.py",
     )
-    if not module_path.is_file():
+    module_path = next((path for path in candidates if path.is_file()), None)
+    if module_path is None:
         raise RuntimeError(
-            f"Family {family!r} does not provide owned vl_debug_runner.py"
+            f"Family {family!r} does not provide an owned VL debug runner"
         )
     module_name = f"_trtmc_vl_debug_runner_{family}"
     spec = importlib.util.spec_from_file_location(module_name, module_path)

--- a/tools/families/__init__.py
+++ b/tools/families/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Family-owned development tools."""

--- a/tools/families/__init__.py
+++ b/tools/families/__init__.py
@@ -1,0 +1,1 @@
+"""Family-owned development tools."""

--- a/tools/family_source_isolation.py
+++ b/tools/family_source_isolation.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Materialize a source tree containing one model family.
 
 The filtered tree keeps generic repository infrastructure, but narrows each

--- a/tools/family_source_isolation.py
+++ b/tools/family_source_isolation.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Materialize a source tree containing one model family.
+
+The filtered tree keeps generic repository infrastructure, but narrows each
+model-owned root to the selected Python family and the runtime model plugins
+required by that family's E2E manifests.  Building and testing from the result
+therefore catches undeclared sibling-family dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+
+try:
+    from tools import model_plugin_isolation
+except ModuleNotFoundError:  # Direct execution puts tools/ on sys.path.
+    import model_plugin_isolation
+
+
+PYTHON_FAMILIES = PurePosixPath("python/tensorrt_model_connect/families")
+RUNTIME_MODELS = PurePosixPath("src/runtime/models")
+CPP_MODEL_TESTS = PurePosixPath("tests/cpp/models")
+E2E_MODELS = PurePosixPath("tests/e2e/models")
+FAMILY_TOOLS = PurePosixPath("tools/families")
+BUILDER_FAMILY_TESTS = PurePosixPath("tests/builder/families")
+
+# These files are registry/protocol infrastructure.  Any additional shared
+# family module must be reviewed and added explicitly instead of silently
+# becoming available to every isolated family.
+APPROVED_SHARED_FAMILY_FILES = frozenset({"__init__.py", "base.py"})
+
+
+@dataclass(frozen=True)
+class FamilySourceSelection:
+    family: str
+    runtime_models: tuple[str, ...]
+    e2e_models: tuple[str, ...]
+
+
+def resolve_selection(repo_root: Path, family: str) -> FamilySourceSelection:
+    repo_root = repo_root.resolve()
+    family_dir = repo_root / PYTHON_FAMILIES / family
+    if not (family_dir / "plugin.py").is_file():
+        raise SystemExit(f"Unknown Python model family: {family}")
+
+    manifests = model_plugin_isolation.discover_e2e_manifests(repo_root)
+    selected_models = {
+        name for name, manifest in manifests.items() if manifest.family == family
+    }
+    runtime_plugins = model_plugin_isolation.discover_runtime_plugins(repo_root)
+    owners = {
+        plugin.model_id
+        for plugin in model_plugin_isolation.plugins_for_models(
+            selected_models, manifests, runtime_plugins
+        )
+    } if selected_models else set()
+
+    # A family without an E2E manifest can still own a same-named runtime
+    # plugin.  Keeping it makes the filtered tree useful while manifest
+    # coverage is being added; normal covered families use the mapping above.
+    if not owners and family in runtime_plugins:
+        owners.add(family)
+    if not owners:
+        raise SystemExit(
+            f"Family {family!r} has no E2E runtime mapping or same-named runtime plugin"
+        )
+
+    return FamilySourceSelection(
+        family=family,
+        runtime_models=tuple(sorted(owners)),
+        e2e_models=tuple(sorted(selected_models)),
+    )
+
+
+def _owned_child(path: PurePosixPath, root: PurePosixPath) -> str | None:
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return None
+    return relative.parts[0] if len(relative.parts) > 1 else ""
+
+
+def include_path(path: PurePosixPath, selection: FamilySourceSelection) -> bool:
+    child = _owned_child(path, PYTHON_FAMILIES)
+    if child is not None:
+        if not child:
+            return path.name in APPROVED_SHARED_FAMILY_FILES
+        return child == selection.family
+
+    child = _owned_child(path, RUNTIME_MODELS)
+    if child is not None:
+        return not child or child in selection.runtime_models
+
+    child = _owned_child(path, CPP_MODEL_TESTS)
+    if child is not None:
+        return not child or child in selection.runtime_models
+
+    child = _owned_child(path, E2E_MODELS)
+    if child is not None:
+        return not child or child == selection.family
+
+    for root in (FAMILY_TOOLS, BUILDER_FAMILY_TESTS):
+        child = _owned_child(path, root)
+        if child is not None:
+            return not child or child == selection.family
+
+    return True
+
+
+def tracked_files(repo_root: Path) -> tuple[PurePosixPath, ...]:
+    result = subprocess.run(
+        [
+            "git",
+            "-c",
+            f"safe.directory={repo_root}",
+            "ls-files",
+            "-z",
+        ],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    )
+    return tuple(
+        PurePosixPath(os.fsdecode(raw))
+        for raw in result.stdout.split(b"\0")
+        if raw
+    )
+
+
+def selected_worktree_files(
+    repo_root: Path,
+    selection: FamilySourceSelection,
+) -> tuple[PurePosixPath, ...]:
+    """Include new files only from roots owned by the selected family."""
+    roots = (
+        PYTHON_FAMILIES / selection.family,
+        FAMILY_TOOLS / selection.family,
+        BUILDER_FAMILY_TESTS / selection.family,
+        E2E_MODELS / selection.family,
+        *(RUNTIME_MODELS / model for model in selection.runtime_models),
+        *(CPP_MODEL_TESTS / model for model in selection.runtime_models),
+    )
+    files: set[PurePosixPath] = set()
+    for relative_root in roots:
+        root = repo_root / relative_root
+        if not root.is_dir():
+            continue
+        files.update(
+            PurePosixPath(path.relative_to(repo_root).as_posix())
+            for path in root.rglob("*")
+            if (path.is_file() or path.is_symlink())
+            and "__pycache__" not in path.parts
+        )
+    return tuple(sorted(files))
+
+
+def materialize(
+    repo_root: Path,
+    output_dir: Path,
+    selection: FamilySourceSelection,
+    *,
+    force: bool = False,
+) -> int:
+    repo_root = repo_root.resolve()
+    output_dir = output_dir.resolve()
+    if output_dir == repo_root:
+        raise SystemExit("Output directory must differ from the repository root")
+    if output_dir.exists():
+        if not force:
+            raise SystemExit(f"Output directory already exists: {output_dir}")
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+
+    copied = 0
+    source_files = set(tracked_files(repo_root))
+    source_files.update(selected_worktree_files(repo_root, selection))
+    for relative in sorted(source_files):
+        if not include_path(relative, selection):
+            continue
+        source = repo_root / relative
+        # Respect working-tree deletions while still sourcing the file list from
+        # Git so unrelated untracked files cannot leak into the isolated tree.
+        if not source.exists() and not source.is_symlink():
+            continue
+        destination = output_dir / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_symlink():
+            destination.symlink_to(os.readlink(source))
+        else:
+            shutil.copy2(source, destination)
+        copied += 1
+
+    metadata = asdict(selection)
+    metadata["copied_files"] = copied
+    (output_dir / ".trtmc-family-source.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return copied
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plan = subparsers.add_parser("plan", help="Print the resolved ownership plan")
+    plan.add_argument("--family", required=True)
+
+    create = subparsers.add_parser("create", help="Create the filtered source tree")
+    create.add_argument("--family", required=True)
+    create.add_argument("--output-dir", type=Path, required=True)
+    create.add_argument("--force", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    selection = resolve_selection(args.repo_root, args.family)
+    if args.command == "plan":
+        print(json.dumps(asdict(selection), indent=2, sort_keys=True))
+        return 0
+    copied = materialize(
+        args.repo_root,
+        args.output_dir,
+        selection,
+        force=args.force,
+    )
+    print(
+        f"family={selection.family} runtime_models="
+        f"{','.join(selection.runtime_models)} copied_files={copied} "
+        f"output={args.output_dir.resolve()}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/family_specialization.py
+++ b/tools/family_specialization.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Inventory and audit model-family specialization boundaries.
 
 The auditor is development tooling only.  It never becomes an import surface

--- a/tools/family_specialization.py
+++ b/tools/family_specialization.py
@@ -1,0 +1,958 @@
+#!/usr/bin/env python3
+"""Inventory and audit model-family specialization boundaries.
+
+The auditor is development tooling only.  It never becomes an import surface
+for family implementations: every runtime implementation remains physically
+owned by its model family.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+import tomllib
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SCHEMA_VERSION = 1
+FAMILIES_PACKAGE = "tensorrt_model_connect.families"
+APPROVED_FAMILIES_ROOT_IMPORTS = frozenset({"base"})
+MODEL_ROOT_FILES = frozenset({"__init__.py", "model.py", "parallel.py", "runtime.py"})
+MODEL_ROOT_DIRECTORIES = frozenset({"components"})
+MISPLACED_MODEL_PATHS = frozenset(
+    {
+        "runtime_config_schema.py",
+        "python_profile_verify.py",
+        "python_profile_requirements",
+    }
+)
+STRATEGY_PARAMETERS = frozenset(
+    {
+        "activation",
+        "alibi_bias_scale",
+        "cross_attn_norm",
+        "debug_layer_outputs",
+        "embed_input",
+        "ffn_activation",
+        "hidden_state_output",
+        "interleaved_rope",
+        "mlp_type",
+        "norm_type",
+        "parallel_residual",
+        "partial_rotary_factor",
+        "position_type",
+        "qk_norm",
+        "scale_attn_weights",
+        "use_rope",
+    }
+)
+TEXT_SCAN_SUFFIXES = frozenset({".json", ".py", ".sh", ".toml", ".yaml", ".yml"})
+Definition = ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef
+
+
+@dataclass(frozen=True)
+class ModuleInfo:
+    module: str
+    path: Path
+    relative_path: str
+    tree: ast.Module
+    is_init: bool
+    imports: frozenset[str]
+    symbol_imports: frozenset[tuple[str, str]]
+    module_aliases: tuple[tuple[str, str], ...]
+    definitions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DynamicEntryPoint:
+    source: str
+    path: str
+    symbol: str | None
+    exists: bool
+    module: str | None
+    symbol_exists: bool | None
+
+
+def family_dirs(repo_root: Path, selected: tuple[str, ...]) -> list[Path]:
+    root = repo_root / "python/tensorrt_model_connect/families"
+    discovered = sorted(
+        path for path in root.iterdir() if (path / "plugin.py").is_file()
+    )
+    if not selected:
+        return discovered
+    by_name = {path.name: path for path in discovered}
+    missing = sorted(set(selected) - by_name.keys())
+    if missing:
+        raise SystemExit("Unknown model family: " + ", ".join(missing))
+    return [by_name[name] for name in selected]
+
+
+def _module_name(repo_root: Path, path: Path) -> tuple[str, bool] | None:
+    try:
+        relative = path.relative_to(repo_root / "python")
+    except ValueError:
+        return None
+    parts = list(relative.parts)
+    is_init = parts[-1] == "__init__.py"
+    parts[-1] = Path(parts[-1]).stem
+    if is_init:
+        parts.pop()
+    return ".".join(parts), is_init
+
+
+def _resolve_from_module(
+    current_module: str | None,
+    current_is_init: bool,
+    node: ast.ImportFrom,
+) -> str:
+    if node.level == 0:
+        return node.module or ""
+    if current_module is None:
+        return ""
+    package = current_module if current_is_init else current_module.rpartition(".")[0]
+    parts = package.split(".") if package else []
+    parents = node.level - 1
+    if parents > len(parts):
+        return ""
+    base = parts[: len(parts) - parents]
+    if node.module:
+        base.extend(node.module.split("."))
+    return ".".join(base)
+
+
+def _parse_tree(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _module_references(
+    tree: ast.Module,
+    *,
+    current_module: str | None,
+    current_is_init: bool,
+    known_modules: frozenset[str],
+) -> tuple[set[str], set[tuple[str, str]], dict[str, str]]:
+    imports: set[str] = set()
+    symbol_imports: set[tuple[str, str]] = set()
+    aliases: dict[str, str] = {}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                target = alias.name
+                if target in known_modules:
+                    imports.add(target)
+                    aliases[alias.asname or target.rsplit(".", 1)[-1]] = target
+            continue
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        base = _resolve_from_module(current_module, current_is_init, node)
+        if base in known_modules:
+            imports.add(base)
+        for alias in node.names:
+            if alias.name == "*":
+                if base in known_modules:
+                    symbol_imports.add((base, "*"))
+                continue
+            child = f"{base}.{alias.name}" if base else alias.name
+            if child in known_modules:
+                imports.add(child)
+                aliases[alias.asname or alias.name] = child
+            elif base in known_modules:
+                symbol_imports.add((base, alias.name))
+
+    return imports, symbol_imports, aliases
+
+
+def _family_modules(repo_root: Path, family_dir: Path) -> dict[str, ModuleInfo]:
+    paths = sorted(
+        path
+        for path in family_dir.rglob("*.py")
+        if "__pycache__" not in path.parts
+    )
+    names: dict[Path, tuple[str, bool]] = {}
+    for path in paths:
+        result = _module_name(repo_root, path)
+        if result is not None:
+            names[path] = result
+    known = frozenset(module for module, _ in names.values())
+    modules: dict[str, ModuleInfo] = {}
+    for path, (module, is_init) in names.items():
+        tree = _parse_tree(path)
+        imports, symbol_imports, aliases = _module_references(
+            tree,
+            current_module=module,
+            current_is_init=is_init,
+            known_modules=known,
+        )
+        definitions = tuple(
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+        )
+        modules[module] = ModuleInfo(
+            module=module,
+            path=path,
+            relative_path=path.relative_to(family_dir).as_posix(),
+            tree=tree,
+            is_init=is_init,
+            imports=frozenset(imports),
+            symbol_imports=frozenset(symbol_imports),
+            module_aliases=tuple(sorted(aliases.items())),
+            definitions=definitions,
+        )
+    return modules
+
+
+def _walk_strings(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for child in value.values():
+            yield from _walk_strings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_strings(child)
+
+
+def _manifest_path(repo_root: Path, family_dir: Path, raw: str) -> Path:
+    path = Path(raw)
+    if raw.startswith("families/"):
+        return repo_root / "python/tensorrt_model_connect" / path
+    if raw.startswith("model/") or raw.startswith("weights/"):
+        return family_dir / path
+    return family_dir / path
+
+
+def _assigned_names(target: ast.AST) -> set[str]:
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return set().union(*(_assigned_names(child) for child in target.elts))
+    return set()
+
+
+def _module_bound_names(info: ModuleInfo) -> set[str]:
+    names = set(info.definitions)
+    for node in info.tree.body:
+        if isinstance(node, ast.Assign):
+            names.update(
+                set().union(*(_assigned_names(target) for target in node.targets))
+            )
+        elif isinstance(node, ast.AnnAssign):
+            names.update(_assigned_names(node.target))
+        elif isinstance(node, ast.Import):
+            names.update(alias.asname or alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            names.update(alias.asname or alias.name for alias in node.names)
+    return names
+
+
+def _dynamic_entrypoints(
+    repo_root: Path,
+    family_dir: Path,
+    modules: dict[str, ModuleInfo],
+) -> tuple[list[DynamicEntryPoint], set[str], dict[str, set[str]]]:
+    manifest_path = family_dir / "MODEL.toml"
+    manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    module_by_path = {info.path.resolve(): name for name, info in modules.items()}
+    roots: set[str] = set()
+    symbols: dict[str, set[str]] = defaultdict(set)
+    entries: list[DynamicEntryPoint] = []
+
+    plugin_module = str(manifest.get("module", "plugin"))
+    plugin_name = f"{FAMILIES_PACKAGE}.{family_dir.name}.{plugin_module}"
+    if plugin_name in modules:
+        roots.add(plugin_name)
+
+    seen: set[tuple[str, str | None]] = set()
+    for value in _walk_strings(manifest):
+        parts = [part.strip() for part in value.split("|")]
+        for index, part in enumerate(parts):
+            if not re.search(r"\.(?:py|txt)$", part):
+                continue
+            symbol = None
+            if part.endswith(".py") and index + 1 < len(parts):
+                candidate = parts[index + 1]
+                if candidate.isidentifier() and candidate not in {"true", "false"}:
+                    symbol = candidate
+            key = (part, symbol)
+            if key in seen:
+                continue
+            seen.add(key)
+            path = _manifest_path(repo_root, family_dir, part)
+            module = module_by_path.get(path.resolve()) if path.exists() else None
+            symbol_exists = None
+            if symbol is not None:
+                symbol_exists = bool(
+                    module and symbol in _module_bound_names(modules[module])
+                )
+            entries.append(
+                DynamicEntryPoint(
+                    source="MODEL.toml",
+                    path=part,
+                    symbol=symbol,
+                    exists=path.is_file(),
+                    module=module,
+                    symbol_exists=symbol_exists,
+                )
+            )
+            if module:
+                roots.add(module)
+                if symbol:
+                    symbols[module].add(symbol)
+
+    schema = family_dir / "runtime_config_schema.py"
+    if schema.is_file():
+        module = module_by_path.get(schema.resolve())
+        entries.append(
+            DynamicEntryPoint(
+                source="runtime_config.schemas",
+                path="runtime_config_schema.py",
+                symbol=None,
+                exists=True,
+                module=module,
+                symbol_exists=None,
+            )
+        )
+        if module:
+            roots.add(module)
+
+    return sorted(entries, key=lambda item: (item.source, item.path, item.symbol or "")), roots, symbols
+
+
+def _scan_paths(repo_root: Path) -> list[Path]:
+    paths: list[Path] = []
+    for relative in ("tests", "tools", "scripts", "examples", ".github"):
+        root = repo_root / relative
+        if not root.is_dir():
+            continue
+        paths.extend(
+            path
+            for path in root.rglob("*")
+            if path.is_file()
+            and path.suffix in TEXT_SCAN_SUFFIXES
+            and "__pycache__" not in path.parts
+            and ".family-source-validation" not in path.parts
+        )
+    return sorted(paths)
+
+
+def _external_module_roots(
+    repo_root: Path,
+    family_dir: Path,
+    modules: dict[str, ModuleInfo],
+    scan_paths: list[Path],
+) -> tuple[set[str], dict[str, set[str]], dict[str, list[str]]]:
+    known = frozenset(modules)
+    roots: set[str] = set()
+    symbols: dict[str, set[str]] = defaultdict(set)
+    sources: dict[str, list[str]] = defaultdict(list)
+    family_needle = f"{FAMILIES_PACKAGE}.{family_dir.name}."
+
+    for path in scan_paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if family_needle not in text and family_dir.name not in path.parts:
+            continue
+        found: set[str] = set()
+        if path.suffix == ".py":
+            try:
+                tree = ast.parse(text, filename=str(path))
+            except SyntaxError:
+                tree = None
+            if tree is not None:
+                imported, imported_symbols, _ = _module_references(
+                    tree,
+                    current_module=None,
+                    current_is_init=False,
+                    known_modules=known,
+                )
+                found.update(imported)
+                for module, symbol in imported_symbols:
+                    symbols[module].add(symbol)
+                    found.add(module)
+        for module in sorted(known, key=len, reverse=True):
+            matches = re.finditer(
+                rf"(?<![A-Za-z0-9_.]){re.escape(module)}"
+                r"(?:\.([A-Za-z_][A-Za-z0-9_]*))?",
+                text,
+            )
+            for match in matches:
+                suffix = match.group(1)
+                if suffix and f"{module}.{suffix}" in known:
+                    continue
+                found.add(module)
+                if suffix:
+                    symbols[module].add(suffix)
+        for module in sorted(found):
+            roots.add(module)
+            sources[module].append(path.relative_to(repo_root).as_posix())
+
+    return roots, symbols, {key: sorted(set(value)) for key, value in sources.items()}
+
+
+def _convention_tool_roots(
+    repo_root: Path,
+    family_dir: Path,
+    modules: dict[str, ModuleInfo],
+) -> tuple[set[str], dict[str, list[str]], list[dict[str, str]]]:
+    """Resolve generic tools that select family modules from runtime metadata."""
+    roots: set[str] = set()
+    sources: dict[str, list[str]] = defaultdict(list)
+    missing: list[dict[str, str]] = []
+    plugin_text = (family_dir / "plugin.py").read_text(encoding="utf-8")
+    is_vision_language = bool(
+        re.search(
+            r"runtime_strategy\s*=\s*['\"][A-Za-z0-9_]+_vision_language['\"]",
+            plugin_text,
+        )
+    )
+    manifests = repo_root / "tests/e2e/models" / family_dir.name / "manifests"
+    if manifests.is_dir() and not is_vision_language:
+        for path in manifests.glob("*.json"):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            if str(payload.get("runtime_strategy") or "").endswith("_vision_language"):
+                is_vision_language = True
+                break
+
+    if is_vision_language:
+        tool_path = (
+            repo_root
+            / "tools/families"
+            / family_dir.name
+            / "vl_debug_runner.py"
+        )
+        if not tool_path.is_file():
+            missing.append(
+                {
+                    "source": "tools/diff_vl.py::<family-dispatch>",
+                    "path": f"tools/families/{family_dir.name}/vl_debug_runner.py",
+                    "reason": "missing_path",
+                }
+            )
+    return roots, sources, missing
+
+
+def _closure(modules: dict[str, ModuleInfo], seeds: Iterable[str]) -> set[str]:
+    reachable: set[str] = set()
+    pending = deque(seed for seed in seeds if seed in modules)
+    while pending:
+        module = pending.popleft()
+        if module in reachable:
+            continue
+        reachable.add(module)
+        pending.extend(modules[module].imports - reachable)
+    return reachable
+
+
+def _definition_nodes(tree: ast.Module) -> dict[str, list[Definition]]:
+    result: dict[str, list[Definition]] = defaultdict(list)
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            result[node.name].append(node)
+    return result
+
+
+def _loaded_local_names(node: ast.AST, names: set[str]) -> set[str]:
+    loaded = {
+        child.id
+        for child in ast.walk(node)
+        if isinstance(child, ast.Name)
+        and isinstance(child.ctx, ast.Load)
+        and child.id in names
+    }
+    loaded.update(
+        child.value
+        for child in ast.walk(node)
+        if isinstance(child, ast.Constant)
+        and isinstance(child.value, str)
+        and child.value in names
+    )
+    return loaded
+
+
+def _attribute_symbol_roots(info: ModuleInfo) -> dict[str, set[str]]:
+    aliases = dict(info.module_aliases)
+    roots: dict[str, set[str]] = defaultdict(set)
+    for node in ast.walk(info.tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in aliases
+        ):
+            roots[aliases[node.value.id]].add(node.attr)
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) >= 2
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id in aliases
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+        ):
+            roots[aliases[node.args[0].id]].add(node.args[1].value)
+    return roots
+
+
+def _unreachable_symbols(
+    modules: dict[str, ModuleInfo],
+    production_modules: set[str],
+    dynamic_symbols: dict[str, set[str]],
+) -> list[dict[str, Any]]:
+    external_roots: dict[str, set[str]] = defaultdict(set)
+    for source_name in production_modules:
+        source = modules[source_name]
+        for target, symbol in source.symbol_imports:
+            if target in production_modules:
+                if symbol == "*":
+                    external_roots[target].update(modules[target].definitions)
+                else:
+                    external_roots[target].add(symbol)
+        for target, names in _attribute_symbol_roots(source).items():
+            if target in production_modules:
+                external_roots[target].update(names)
+    for module, names in dynamic_symbols.items():
+        external_roots[module].update(names)
+
+    results: list[dict[str, Any]] = []
+    for module_name in sorted(production_modules):
+        info = modules[module_name]
+        definitions = _definition_nodes(info.tree)
+        if not definitions:
+            continue
+        names = set(definitions)
+        dependencies = {
+            name: set().union(
+                *(_loaded_local_names(node, names) for node in nodes)
+            )
+            for name, nodes in definitions.items()
+        }
+        roots = set(external_roots[module_name]) & names
+        for node in info.tree.body:
+            if not isinstance(
+                node,
+                (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Import, ast.ImportFrom),
+            ):
+                roots.update(_loaded_local_names(node, names))
+        pending = deque(sorted(roots))
+        reachable = set(roots)
+        while pending:
+            for dependency in dependencies[pending.popleft()]:
+                if dependency not in reachable:
+                    reachable.add(dependency)
+                    pending.append(dependency)
+
+        for name in sorted(names - reachable):
+            nodes = definitions[name]
+            results.append(
+                {
+                    "module": module_name,
+                    "path": info.relative_path,
+                    "symbol": name,
+                    "line": min(node.lineno for node in nodes),
+                }
+            )
+    return results
+
+
+def _literal_value(node: ast.AST) -> Any:
+    try:
+        value = ast.literal_eval(node)
+    except (ValueError, TypeError):
+        return {"dynamic": ast.unparse(node)}
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return {"literal": repr(value)}
+
+
+def _strategy_switches(
+    modules: dict[str, ModuleInfo],
+    production_modules: set[str],
+) -> list[dict[str, Any]]:
+    definitions: dict[str, list[tuple[str, ast.FunctionDef | ast.AsyncFunctionDef]]] = (
+        defaultdict(list)
+    )
+    for module_name in production_modules:
+        for node in modules[module_name].tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                definitions[node.name].append((module_name, node))
+
+    calls: dict[str, list[tuple[ast.Call, str]]] = defaultdict(list)
+    for module_name in production_modules:
+        info = modules[module_name]
+        for node in ast.walk(info.tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if isinstance(node.func, ast.Name):
+                function = node.func.id
+            elif isinstance(node.func, ast.Attribute):
+                function = node.func.attr
+            else:
+                continue
+            if function not in definitions:
+                continue
+            calls[function].append((node, info.relative_path))
+
+    result: list[dict[str, Any]] = []
+    candidates = sorted({
+        (function, parameter)
+        for function, owners in definitions.items()
+        for _, node in owners
+        for parameter in {
+            arg.arg for arg in (*node.args.args, *node.args.kwonlyargs)
+        } & STRATEGY_PARAMETERS
+    })
+    for function, parameter in candidates:
+        function_calls = calls.get(function, [])
+        values: list[tuple[Any, str, int]] = []
+        for call, path in function_calls:
+            matching = [kw for kw in call.keywords if kw.arg == parameter]
+            if len(matching) != 1:
+                values = []
+                break
+            values.append(
+                (_literal_value(matching[0].value), path, call.lineno)
+            )
+        if not values:
+            continue
+        serialized = {json.dumps(value, sort_keys=True) for value, _, _ in values}
+        if len(serialized) != 1:
+            continue
+        value = values[0][0]
+        if isinstance(value, dict) and "dynamic" in value:
+            continue
+        owners = [
+            module
+            for module, node in definitions[function]
+            if parameter in {arg.arg for arg in (*node.args.args, *node.args.kwonlyargs)}
+        ]
+        if not owners:
+            continue
+        result.append(
+            {
+                "function": function,
+                "parameter": parameter,
+                "value": value,
+                "definitions": sorted(owners),
+                "call_sites": [
+                    {"path": path, "line": line}
+                    for _, path, line in sorted(values, key=lambda item: (item[1], item[2]))
+                ],
+            }
+        )
+    return result
+
+
+def _sibling_imports(family: str, modules: dict[str, ModuleInfo]) -> list[dict[str, Any]]:
+    violations: list[dict[str, Any]] = []
+    prefix = f"{FAMILIES_PACKAGE}."
+    for info in modules.values():
+        for node in ast.walk(info.tree):
+            targets: list[str] = []
+            if isinstance(node, ast.Import):
+                targets.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                target = _resolve_from_module(info.module, info.is_init, node)
+                if target:
+                    targets.append(target)
+            for target in targets:
+                if not target.startswith(prefix):
+                    continue
+                suffix = target[len(prefix):]
+                owner = suffix.split(".", 1)[0]
+                if owner == family or owner in APPROVED_FAMILIES_ROOT_IMPORTS:
+                    continue
+                violations.append(
+                    {
+                        "path": info.relative_path,
+                        "line": node.lineno,
+                        "target": target,
+                    }
+                )
+    return sorted(violations, key=lambda item: (item["path"], item["line"]))
+
+
+def _noncanonical_model_paths(family_dir: Path) -> list[str]:
+    model_dir = family_dir / "model"
+    if not model_dir.is_dir():
+        return ["model/"]
+    result: list[str] = []
+    for path in sorted(model_dir.iterdir()):
+        if path.name == "__pycache__":
+            continue
+        if path.is_file() and path.name not in MODEL_ROOT_FILES:
+            result.append(path.relative_to(family_dir).as_posix())
+        elif path.is_dir() and path.name not in MODEL_ROOT_DIRECTORIES:
+            result.append(path.relative_to(family_dir).as_posix() + "/")
+    return result
+
+
+def _source_metrics(family_dir: Path) -> dict[str, int]:
+    files = [
+        path
+        for path in family_dir.rglob("*")
+        if path.is_file() and "__pycache__" not in path.parts
+    ]
+    model_files = [path for path in files if (family_dir / "model") in path.parents]
+
+    def lines(paths: list[Path]) -> int:
+        total = 0
+        for path in paths:
+            try:
+                total += len(path.read_text(encoding="utf-8").splitlines())
+            except UnicodeDecodeError:
+                pass
+        return total
+
+    return {
+        "files": len(files),
+        "lines": lines(files),
+        "bytes": sum(path.stat().st_size for path in files),
+        "model_files": len(model_files),
+        "model_lines": lines(model_files),
+        "model_bytes": sum(path.stat().st_size for path in model_files),
+    }
+
+
+def audit_family(
+    repo_root: Path,
+    family_dir: Path,
+    *,
+    scan_paths: list[Path] | None = None,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    family_dir = family_dir.resolve()
+    family = family_dir.name
+    modules = _family_modules(repo_root, family_dir)
+    package_module = f"{FAMILIES_PACKAGE}.{family}"
+    dynamic_entries, dynamic_roots, dynamic_symbols = _dynamic_entrypoints(
+        repo_root, family_dir, modules
+    )
+    external_roots, external_symbols, external_sources = _external_module_roots(
+        repo_root,
+        family_dir,
+        modules,
+        scan_paths if scan_paths is not None else _scan_paths(repo_root),
+    )
+    convention_roots, convention_sources, missing_conventions = _convention_tool_roots(
+        repo_root, family_dir, modules
+    )
+    external_roots.update(convention_roots)
+    for module, sources in convention_sources.items():
+        external_sources[module] = sorted(
+            set(external_sources.get(module, ())) | set(sources)
+        )
+
+    production_seeds = {package_module, *dynamic_roots}
+    production_modules = _closure(modules, production_seeds)
+    production_packages = {
+        module_name
+        for module_name, info in modules.items()
+        if info.is_init
+        and any(
+            child.startswith(module_name + ".")
+            for child in production_modules
+        )
+    }
+    production_modules = _closure(
+        modules, production_modules | production_packages
+    )
+    tool_modules = _closure(modules, external_roots) - production_modules
+    unreachable_modules = set(modules) - production_modules - tool_modules
+
+    symbol_roots: dict[str, set[str]] = defaultdict(set)
+    for mapping in (dynamic_symbols, external_symbols):
+        for module, symbols in mapping.items():
+            if module in production_modules:
+                symbol_roots[module].update(symbols)
+    unreachable_symbols = _unreachable_symbols(
+        modules,
+        production_modules,
+        symbol_roots,
+    )
+    sibling_imports = _sibling_imports(family, modules)
+    noncanonical = _noncanonical_model_paths(family_dir)
+    misplaced = sorted(
+        path
+        for path in noncanonical
+        if path.removeprefix("model/").rstrip("/") in MISPLACED_MODEL_PATHS
+    )
+    fixed_switches = _strategy_switches(modules, production_modules)
+    missing_dynamic = [
+        {
+            "source": entry.source,
+            "path": entry.path,
+            "symbol": entry.symbol,
+            "reason": "missing_path" if not entry.exists else "missing_symbol",
+        }
+        for entry in dynamic_entries
+        if not entry.exists or entry.symbol_exists is False
+    ]
+    missing_dynamic.extend(missing_conventions)
+    missing_dynamic.sort(
+        key=lambda item: (
+            item["source"],
+            item["path"],
+            str(item.get("symbol", "")),
+        )
+    )
+
+    module_rows = []
+    for module_name, info in sorted(modules.items()):
+        if module_name in production_modules:
+            classification = "production"
+        elif module_name in tool_modules:
+            classification = "tool_test_only"
+        else:
+            classification = "unreachable"
+        module_rows.append(
+            {
+                "module": module_name,
+                "path": info.relative_path,
+                "classification": classification,
+                "lines": len(info.path.read_text(encoding="utf-8").splitlines()),
+                "bytes": info.path.stat().st_size,
+                "definitions": list(info.definitions),
+                "external_sources": external_sources.get(module_name, []),
+            }
+        )
+
+    tool_model_modules = sorted(
+        info.relative_path
+        for module_name, info in modules.items()
+        if module_name in tool_modules and info.relative_path.startswith("model/")
+    )
+    violations: list[dict[str, Any]] = []
+    categories = {
+        "fixed_strategy_switch": fixed_switches,
+        "missing_dynamic_entrypoint": missing_dynamic,
+        "noncanonical_model_path": [{"path": path} for path in noncanonical],
+        "sibling_family_import": sibling_imports,
+        "tool_test_only_model_module": [{"path": path} for path in tool_model_modules],
+        "unreachable_module": [
+            {"module": module, "path": modules[module].relative_path}
+            for module in sorted(unreachable_modules)
+        ],
+        "unreachable_symbol": unreachable_symbols,
+    }
+    for kind, items in categories.items():
+        violations.extend({"kind": kind, **item} for item in items)
+
+    return {
+        "family": family,
+        "metrics": _source_metrics(family_dir),
+        "entrypoints": {
+            "production_modules": sorted(production_seeds),
+            "dynamic": [
+                {
+                    "source": entry.source,
+                    "path": entry.path,
+                    "symbol": entry.symbol,
+                    "exists": entry.exists,
+                    "module": entry.module,
+                    "symbol_exists": entry.symbol_exists,
+                }
+                for entry in dynamic_entries
+            ],
+        },
+        "modules": module_rows,
+        "production_modules": sorted(production_modules),
+        "tool_test_only_modules": sorted(tool_modules),
+        "unreachable_modules": sorted(unreachable_modules),
+        "unreachable_symbols": unreachable_symbols,
+        "fixed_strategy_switches": fixed_switches,
+        "missing_dynamic_entrypoints": missing_dynamic,
+        "sibling_family_imports": sibling_imports,
+        "noncanonical_model_paths": noncanonical,
+        "misplaced_model_paths": misplaced,
+        "violations": sorted(
+            violations,
+            key=lambda item: (
+                item["kind"],
+                str(item.get("path", "")),
+                str(item.get("module", "")),
+                str(item.get("symbol", "")),
+            ),
+        ),
+    }
+
+
+def audit_repo(repo_root: Path, selected: tuple[str, ...]) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    scan_paths = _scan_paths(repo_root)
+    families = [
+        audit_family(repo_root, family_dir, scan_paths=scan_paths)
+        for family_dir in family_dirs(repo_root, selected)
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "families": families,
+        "summary": {
+            "families": len(families),
+            "files": sum(item["metrics"]["files"] for item in families),
+            "lines": sum(item["metrics"]["lines"] for item in families),
+            "bytes": sum(item["metrics"]["bytes"] for item in families),
+            "model_files": sum(item["metrics"]["model_files"] for item in families),
+            "model_lines": sum(item["metrics"]["model_lines"] for item in families),
+            "model_bytes": sum(item["metrics"]["model_bytes"] for item in families),
+            "violations": sum(len(item["violations"]) for item in families),
+            "unreachable_modules": sum(
+                len(item["unreachable_modules"]) for item in families
+            ),
+            "unreachable_symbols": sum(
+                len(item["unreachable_symbols"]) for item in families
+            ),
+            "fixed_strategy_switches": sum(
+                len(item["fixed_strategy_switches"]) for item in families
+            ),
+        },
+    }
+
+
+def _write_report(report: dict[str, Any], destination: Path | None) -> None:
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if destination is None:
+        sys.stdout.write(text)
+        return
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(text, encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("inventory", "audit"))
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--family", action="append", default=[])
+    parser.add_argument("--all", action="store_true")
+    parser.add_argument("--json", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not args.all and not args.family:
+        raise SystemExit("Select at least one --family or pass --all")
+    if args.all and args.family:
+        raise SystemExit("Use --all or --family, not both")
+    selected = () if args.all else tuple(args.family)
+    report = audit_repo(args.repo_root, selected)
+    _write_report(report, args.json)
+    if args.command == "audit" and report["summary"]["violations"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/migrate_family_layout.py
+++ b/tools/migrate_family_layout.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Migrate and validate model families against the canonical component layout."""
 
 from __future__ import annotations

--- a/tools/migrate_family_layout.py
+++ b/tools/migrate_family_layout.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+"""Migrate and validate model families against the canonical component layout."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CANONICAL_TOP_LEVEL = frozenset(
+    {"MODEL.toml", "__init__.py", "plugin.py", "config.py", "weights", "model"}
+)
+OPTIONAL_TOP_LEVEL = frozenset({"runtime_config_schema.py", "profiles"})
+ALLOWED_TOP_LEVEL = CANONICAL_TOP_LEVEL | OPTIONAL_TOP_LEVEL
+CORE_MODEL_MODULES = ("graph_ops.py", "graph_blocks.py", "utils.py")
+WEIGHT_MODULES = frozenset(
+    {
+        "bundle_sections.py",
+        "magpie_tokenizer.py",
+        "nemo_archive.py",
+        "tokenizer_json.py",
+    }
+)
+TOOL_MODULES = frozenset(
+    {
+        "bench_flashinfer_e2e.py",
+        "bench_flux2_perf.py",
+        "benchmark_qwen3_8b_aime25_vs_hf.py",
+        "build_fp8_onnx_monolithic.py",
+        "build_wan14b.py",
+        "cpu_profile_matrix.py",
+        "debug_diffusion_pipeline.py",
+        "diff_audio.py",
+        "diff_logits.py",
+        "diff_personaplex.py",
+        "diff_segmentation.py",
+        "diff_t5.py",
+        "diff_vl.py",
+        "gen_fp8_bf16.py",
+        "inject_fp8_qdq_proto.py",
+        "make_replay_artifact.py",
+        "mk_fp8_bf16_bundle.py",
+        "perf_hooks.py",
+        "prepare_model.py",
+        "prepare_model_dir.py",
+        "profile.py",
+        "quantize_flux2_fp8.py",
+        "validate_dit.py",
+        "validate_replay_artifact.py",
+        "validate_t5.py",
+    }
+)
+MINIMAL_INIT = 'from .plugin import plugin\n\n__all__ = ["plugin"]\n'
+MODEL_INIT = '"""Family-owned TensorRT model construction components."""\n'
+TOOLS_INIT = '"""Family-owned development tools."""\n'
+TESTS_INIT = '"""Family-specific builder tests."""\n'
+
+
+@dataclass(frozen=True)
+class Move:
+    source: Path
+    destination: Path
+    kind: str
+
+
+def family_dirs(
+    repo_root: Path,
+    families: tuple[str, ...] = (),
+) -> list[Path]:
+    root = repo_root / "python/tensorrt_model_connect/families"
+    available = {
+        path.name: path
+        for path in root.iterdir()
+        if (path / "plugin.py").is_file()
+    }
+    if not families:
+        return [available[name] for name in sorted(available)]
+    unknown = sorted(set(families) - set(available))
+    if unknown:
+        raise SystemExit(f"Unknown model families: {', '.join(unknown)}")
+    return [available[name] for name in sorted(set(families))]
+
+
+def _module_name(repo_root: Path, path: Path) -> str | None:
+    if path.suffix != ".py":
+        return None
+    relative = path.relative_to(repo_root)
+    parts = list(relative.parts)
+    if parts[0] == "python":
+        parts.pop(0)
+    parts[-1] = Path(parts[-1]).stem
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _iter_files(path: Path) -> list[Path]:
+    if path.is_file():
+        return [path]
+    return sorted(
+        candidate
+        for candidate in path.rglob("*")
+        if candidate.is_file() and "__pycache__" not in candidate.parts
+    )
+
+
+def planned_moves(
+    repo_root: Path,
+    families: tuple[str, ...] = (),
+) -> list[Move]:
+    moves: list[Move] = []
+    tests_root = repo_root / "tests/builder/families"
+    tools_root = repo_root / "tools/families"
+
+    for family_dir in family_dirs(repo_root, families):
+        family = family_dir.name
+        for path in sorted(family_dir.iterdir()):
+            if path.name in ALLOWED_TOP_LEVEL or path.name == "__pycache__":
+                continue
+            if path.name == "checkpoint_mapper.py":
+                destination = family_dir / "weights/__init__.py"
+                kind = "weights"
+            elif path.name == "tests" and path.is_dir():
+                destination = tests_root / family
+                kind = "tests"
+            elif path.is_file() and path.name in TOOL_MODULES:
+                destination = tools_root / family / path.name
+                kind = "tools"
+            elif path.is_file() and path.name in WEIGHT_MODULES:
+                destination = family_dir / "weights" / path.name
+                kind = "weights"
+            else:
+                destination = family_dir / "model" / path.name
+                kind = "model"
+            moves.append(Move(path, destination, kind))
+    return moves
+
+
+def _module_mapping(repo_root: Path, moves: list[Move]) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for move in moves:
+        source_files = _iter_files(move.source)
+        for source_file in source_files:
+            relative = source_file.relative_to(move.source) if move.source.is_dir() else Path()
+            destination_file = move.destination / relative if move.source.is_dir() else move.destination
+            old_module = _module_name(repo_root, source_file)
+            new_module = _module_name(repo_root, destination_file)
+            if old_module and new_module and old_module != new_module:
+                mapping[old_module] = new_module
+    return mapping
+
+
+def _map_module(module: str, mapping: dict[str, str]) -> str:
+    for old in sorted(mapping, key=len, reverse=True):
+        if module == old:
+            return mapping[old]
+        if module.startswith(f"{old}."):
+            return f"{mapping[old]}{module[len(old):]}"
+    return module
+
+
+def _collapse_mapping(mapping: dict[str, str]) -> dict[str, str]:
+    collapsed: dict[str, str] = {}
+    for old, initial in mapping.items():
+        current = initial
+        seen = {old}
+        while current not in seen:
+            seen.add(current)
+            updated = _map_module(current, mapping)
+            if updated == current:
+                break
+            current = updated
+        collapsed[old] = current
+    return collapsed
+
+
+def _package_for(module: str, is_init: bool) -> str:
+    return module if is_init else module.rpartition(".")[0]
+
+
+def _resolve_import_from(
+    source_module: str,
+    source_is_init: bool,
+    node: ast.ImportFrom,
+) -> str:
+    if node.level == 0:
+        return node.module or ""
+    package = _package_for(source_module, source_is_init)
+    parts = package.split(".") if package else []
+    parents = node.level - 1
+    base = parts[: max(0, len(parts) - parents)]
+    if node.module:
+        base.extend(node.module.split("."))
+    return ".".join(base)
+
+
+def _relative_spec(source_module: str, source_is_init: bool, target: str) -> str:
+    package = _package_for(source_module, source_is_init)
+    source_parts = package.split(".") if package else []
+    target_parts = target.split(".") if target else []
+    common = 0
+    for source_part, target_part in zip(source_parts, target_parts):
+        if source_part != target_part:
+            break
+        common += 1
+    if common == 0:
+        return target
+    up = len(source_parts) - common
+    suffix = ".".join(target_parts[common:])
+    return "." * (up + 1) + suffix
+
+
+def _line_offsets(text: str) -> list[int]:
+    offsets = [0]
+    for match in re.finditer("\n", text):
+        offsets.append(match.end())
+    return offsets
+
+
+def _rewrite_imports(
+    path: Path,
+    *,
+    old_module: str,
+    new_module: str,
+    old_is_init: bool,
+    new_is_init: bool,
+    mapping: dict[str, str],
+) -> None:
+    original = path.read_text(encoding="utf-8")
+    text = original
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError:
+        return
+    offsets = _line_offsets(text)
+    replacements: list[tuple[int, int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        start = offsets[node.lineno - 1] + node.col_offset
+        end = offsets[(node.end_lineno or node.lineno) - 1] + (node.end_col_offset or 0)
+        statement = text[start:end]
+        match = re.match(r"from\s+([.A-Za-z0-9_]+)\s+import\b", statement, re.DOTALL)
+        if not match:
+            continue
+
+        old_target = _resolve_import_from(old_module, old_is_init, node)
+        if node.module is None:
+            candidates = [f"{old_target}.{alias.name}" for alias in node.names]
+            mapped = [_map_module(candidate, mapping) for candidate in candidates]
+            if mapped and all(candidate != result for candidate, result in zip(candidates, mapped)):
+                parents = {candidate.rpartition(".")[0] for candidate in mapped}
+                if len(parents) == 1:
+                    new_target = parents.pop()
+                else:
+                    new_target = _map_module(old_target, mapping)
+            else:
+                new_target = _map_module(old_target, mapping)
+        else:
+            new_target = _map_module(old_target, mapping)
+
+        if node.level > 0:
+            new_spec = _relative_spec(new_module, new_is_init, new_target)
+        else:
+            new_spec = new_target
+        spec_start = start + match.start(1)
+        spec_end = start + match.end(1)
+        if text[spec_start:spec_end] != new_spec:
+            replacements.append((spec_start, spec_end, new_spec))
+
+        for alias in node.names:
+            candidate = f"{old_target}.{alias.name}" if old_target else alias.name
+            mapped_candidate = _map_module(candidate, mapping)
+            new_name = mapped_candidate.rsplit(".", 1)[-1]
+            if mapped_candidate == candidate or new_name == alias.name:
+                continue
+            alias_start = offsets[alias.lineno - 1] + alias.col_offset
+            alias_end = alias_start + len(alias.name)
+            replacement = new_name
+            if alias.asname is None:
+                replacement = f"{new_name} as {alias.name}"
+            replacements.append((alias_start, alias_end, replacement))
+
+    for start, end, replacement in sorted(replacements, reverse=True):
+        text = text[:start] + replacement + text[end:]
+
+    for old, new in sorted(mapping.items(), key=lambda item: len(item[0]), reverse=True):
+        text = re.sub(rf"\b{re.escape(old)}\b", new, text)
+    if text != original:
+        path.write_text(text, encoding="utf-8")
+
+
+def _move_paths(moves: list[Move]) -> None:
+    for move in moves:
+        if not move.source.exists():
+            continue
+        if move.destination.exists():
+            raise SystemExit(f"Migration destination already exists: {move.destination}")
+        move.destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(move.source), str(move.destination))
+
+
+def _without_module_preamble(text: str, *, remove_graph_ops_import: bool) -> str:
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    removals: list[tuple[int, int]] = []
+    for index, node in enumerate(tree.body):
+        remove = (
+            index == 0
+            and isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        )
+        remove = remove or (
+            isinstance(node, ast.ImportFrom) and node.module == "__future__"
+        )
+        if remove_graph_ops_import and isinstance(node, ast.ImportFrom):
+            remove = remove or (
+                node.level == 1
+                and node.module is None
+                and {alias.name for alias in node.names} == {"graph_ops"}
+            )
+        if remove:
+            removals.append((node.lineno - 1, node.end_lineno or node.lineno))
+    for start, end in reversed(removals):
+        del lines[start:end]
+    body = "".join(lines).strip()
+    if remove_graph_ops_import:
+        body = re.sub(r"\bgraph_ops\.", "", body)
+    return body
+
+
+def _hoist_top_level_imports(text: str) -> str:
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    imports: list[str] = []
+    removals: list[tuple[int, int]] = []
+    for node in tree.body:
+        if not isinstance(node, (ast.Import, ast.ImportFrom)):
+            continue
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            continue
+        imports.append("".join(lines[node.lineno - 1:node.end_lineno]).strip())
+        removals.append((node.lineno - 1, node.end_lineno or node.lineno))
+    for start, end in reversed(removals):
+        del lines[start:end]
+
+    unique_imports = list(dict.fromkeys(imports))
+    body = "".join(lines)
+    marker = "from __future__ import annotations\n"
+    insertion = body.index(marker) + len(marker)
+    import_block = "\n\n" + "\n".join(unique_imports) + "\n"
+    return body[:insertion] + import_block + body[insertion:].lstrip("\n")
+
+
+def _normalize_consolidated_models(
+    repo_root: Path,
+    families: tuple[str, ...] = (),
+) -> None:
+    for family_dir in family_dirs(repo_root, families):
+        path = family_dir / "model/model.py"
+        if not path.is_file():
+            continue
+        original = path.read_text(encoding="utf-8")
+        updated = _hoist_top_level_imports(original)
+        if updated != original:
+            path.write_text(updated, encoding="utf-8")
+
+
+def _consolidate_model_cores(
+    repo_root: Path,
+    reverse_paths: dict[Path, Path],
+    families: tuple[str, ...] = (),
+) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for family_dir in family_dirs(repo_root, families):
+        model_dir = family_dir / "model"
+        sources = [model_dir / name for name in CORE_MODEL_MODULES]
+        existing = [path for path in sources if path.is_file()]
+        if not existing:
+            continue
+        destination = model_dir / "model.py"
+        if destination.exists():
+            raise SystemExit(f"Model consolidation destination exists: {destination}")
+
+        sections = []
+        for source in existing:
+            body = _without_module_preamble(
+                source.read_text(encoding="utf-8"),
+                remove_graph_ops_import=source.name != "graph_ops.py",
+            )
+            if body:
+                title = source.stem.replace("_", " ").title()
+                sections.append(f"# {title}\n\n{body}")
+            old_module = _module_name(repo_root, source)
+            new_module = _module_name(repo_root, destination)
+            if old_module and new_module:
+                mapping[old_module] = new_module
+
+        destination.write_text(
+            '"""Family-owned TensorRT model graph and utility implementation."""\n\n'
+            "from __future__ import annotations\n\n"
+            + "\n\n\n".join(sections)
+            + "\n",
+            encoding="utf-8",
+        )
+        source_context = reverse_paths.get(existing[0].resolve(), existing[0])
+        for source in existing:
+            reverse_paths.pop(source.resolve(), None)
+            source.unlink()
+        reverse_paths[destination.resolve()] = source_context
+    return mapping
+
+
+def _minimal_manifest(family: str) -> str:
+    return (
+        f'id = "{family}"\n'
+        f'plugin = "{family}"\n'
+        'module = "plugin"\n'
+        f'aliases = ["{family}"]\n'
+        f'prefixes = ["{family}"]\n'
+    )
+
+
+def _rewrite_manifest(path: Path) -> None:
+    original = path.read_text(encoding="utf-8")
+    text = original
+    text = text.replace('debug_runner = "debug_runner.py|', 'debug_runner = "model/runtime.py|')
+    text = text.replace('debug_runner = "model/debug_runner.py|', 'debug_runner = "model/runtime.py|')
+    text = text.replace(
+        'nemo_archive_adapter = "nemo_archive.py|',
+        'nemo_archive_adapter = "weights/nemo_archive.py|',
+    )
+    text = text.replace(
+        'config_adapter = "model_config.py|',
+        'config_adapter = "model/model_config.py|',
+    )
+    family = path.parent.name
+    text = text.replace(
+        f"families/{family}/python_profile_requirements/",
+        f"families/{family}/model/python_profile_requirements/",
+    )
+    text = text.replace(
+        f"families/{family}/python_profile_verify.py",
+        f"families/{family}/model/python_profile_verify.py",
+    )
+    if text != original:
+        path.write_text(text, encoding="utf-8")
+
+
+def _rewrite_python_paths(repo_root: Path) -> list[Path]:
+    """Return project Python sources without traversing vendored repositories."""
+    paths = set(repo_root.glob("*.py"))
+    for relative_root in (".github", "python", "scripts", "tests", "tools"):
+        root = repo_root / relative_root
+        if root.is_dir():
+            paths.update(root.rglob("*.py"))
+    return sorted(
+        path
+        for path in paths
+        if "__pycache__" not in path.parts and ".venv" not in path.parts
+    )
+
+
+def migrate(repo_root: Path, families: tuple[str, ...] = ()) -> None:
+    moves = planned_moves(repo_root, families)
+    mapping = _module_mapping(repo_root, moves)
+    reverse_paths: dict[Path, Path] = {}
+    for move in moves:
+        for source_file in _iter_files(move.source):
+            relative = source_file.relative_to(move.source) if move.source.is_dir() else Path()
+            destination = move.destination / relative if move.source.is_dir() else move.destination
+            reverse_paths[destination.resolve()] = source_file
+
+    _move_paths(moves)
+    mapping.update(_consolidate_model_cores(repo_root, reverse_paths, families))
+    _normalize_consolidated_models(repo_root, families)
+    mapping = _collapse_mapping(mapping)
+
+    tools_family_root = repo_root / "tools/families"
+    tests_family_root = repo_root / "tests/builder/families"
+    if tools_family_root.exists():
+        (tools_family_root / "__init__.py").write_text(TOOLS_INIT, encoding="utf-8")
+        for directory in sorted(path for path in tools_family_root.iterdir() if path.is_dir()):
+            (directory / "__init__.py").write_text(TOOLS_INIT, encoding="utf-8")
+    if tests_family_root.exists():
+        (tests_family_root / "__init__.py").write_text(TESTS_INIT, encoding="utf-8")
+        for directory in sorted(path for path in tests_family_root.iterdir() if path.is_dir()):
+            (directory / "__init__.py").write_text(TESTS_INIT, encoding="utf-8")
+
+    selected_families = family_dirs(repo_root, families)
+    for family_dir in selected_families:
+        family = family_dir.name
+        model_dir = family_dir / "model"
+        weights_dir = family_dir / "weights"
+        model_dir.mkdir(exist_ok=True)
+        weights_dir.mkdir(exist_ok=True)
+        model_init = model_dir / "__init__.py"
+        if not model_init.exists():
+            model_init.write_text(MODEL_INIT, encoding="utf-8")
+        weights_init = weights_dir / "__init__.py"
+        if not weights_init.exists():
+            weights_init.write_text('"""Family-owned weight mapping."""\n', encoding="utf-8")
+        (family_dir / "__init__.py").write_text(MINIMAL_INIT, encoding="utf-8")
+        manifest = family_dir / "MODEL.toml"
+        if not manifest.exists():
+            manifest.write_text(_minimal_manifest(family), encoding="utf-8")
+        _rewrite_manifest(manifest)
+
+    for path in _rewrite_python_paths(repo_root):
+        resolved = path.resolve()
+        old_path = reverse_paths.get(resolved, path)
+        old_module = _module_name(repo_root, old_path)
+        new_module = _module_name(repo_root, path)
+        if not old_module or not new_module:
+            continue
+        _rewrite_imports(
+            path,
+            old_module=old_module,
+            new_module=new_module,
+            old_is_init=old_path.name == "__init__.py",
+            new_is_init=path.name == "__init__.py",
+            mapping=mapping,
+        )
+
+    print(
+        f"migrated_families={len(selected_families)} "
+        f"moved_entries={len(moves)} module_rewrites={len(mapping)}"
+    )
+
+
+def layout_violations(
+    repo_root: Path,
+    families: tuple[str, ...] = (),
+) -> list[str]:
+    violations: list[str] = []
+    for family_dir in family_dirs(repo_root, families):
+        names = {
+            path.name for path in family_dir.iterdir() if path.name != "__pycache__"
+        }
+        missing = CANONICAL_TOP_LEVEL - names
+        extra = names - ALLOWED_TOP_LEVEL
+        if missing:
+            violations.append(f"{family_dir.name}: missing {sorted(missing)}")
+        if extra:
+            violations.append(f"{family_dir.name}: extra {sorted(extra)}")
+        if (family_dir / "__init__.py").read_text(encoding="utf-8") != MINIMAL_INIT:
+            violations.append(f"{family_dir.name}: non-canonical __init__.py")
+        for component in ("model", "weights"):
+            path = family_dir / component
+            if not path.is_dir() or not (path / "__init__.py").is_file():
+                violations.append(f"{family_dir.name}: invalid {component}/ component")
+        model_dir = family_dir / "model"
+        if not (model_dir / "model.py").is_file():
+            violations.append(f"{family_dir.name}: missing model/model.py")
+        legacy_core = [name for name in CORE_MODEL_MODULES if (model_dir / name).exists()]
+        if legacy_core:
+            violations.append(
+                f"{family_dir.name}: unconsolidated model modules {legacy_core}"
+            )
+    return violations
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--family",
+        action="append",
+        default=[],
+        help="Limit migration or validation to one family; repeat for multiple families",
+    )
+    parser.add_argument("command", choices=("check", "migrate"))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    families = tuple(args.family)
+    if args.command == "migrate":
+        migrate(repo_root, families)
+    violations = layout_violations(repo_root, families)
+    if violations:
+        print("\n".join(violations), file=sys.stderr)
+        return 1
+    print(f"canonical_family_layouts={len(family_dirs(repo_root, families))}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/perf_compare.py
+++ b/tools/perf_compare.py
@@ -95,14 +95,19 @@ def _get_peak_memory_mb() -> float | None:
 @lru_cache(maxsize=1)
 def _family_perf_modules() -> tuple[ModuleType, ...]:
     """Load optional model-owned performance hooks from family folders."""
-    family_root = (
-        Path(__file__).resolve().parents[1]
-        / "python"
-        / "tensorrt_model_connect"
-        / "families"
+    repo_root = Path(__file__).resolve().parents[1]
+    roots = (
+        Path(__file__).resolve().parent / "families",
+        repo_root / "python/tensorrt_model_connect/families",
     )
+    handlers: dict[str, Path] = {}
+    for root in reversed(roots):
+        handlers.update(
+            {path.parent.name: path for path in root.glob("*/perf_hooks.py")}
+        )
     modules: list[ModuleType] = []
-    for handler_path in sorted(family_root.glob("*/perf_hooks.py")):
+    for family in sorted(handlers):
+        handler_path = handlers[family]
         module_name = f"_trtmc_perf_hooks_{handler_path.parent.name}"
         spec = importlib.util.spec_from_file_location(module_name, handler_path)
         if spec is None or spec.loader is None:

--- a/tools/prune_family_helpers.py
+++ b/tools/prune_family_helpers.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Remove unreachable definitions from family-owned implementation modules."""
 
 from __future__ import annotations

--- a/tools/prune_family_helpers.py
+++ b/tools/prune_family_helpers.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Remove unreachable definitions from family-owned implementation modules."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from tools import family_specialization
+except ModuleNotFoundError:  # Direct execution puts tools/ on sys.path.
+    import family_specialization
+
+
+TARGET_MODULES = (
+    "checkpoint_mapper.py",
+    "model.py",
+    "default_decoder.py",
+    "default_dual_profile_decoder.py",
+    "default_dual_profile_decoder_tp.py",
+    "standard_decoder_builder.py",
+    "dual_profile_decoder_builder.py",
+    "dual_profile_decoder_tp_builder.py",
+    "vl_debug_runner.py",
+)
+EXTERNAL_MODULE_ROOTS = {
+    "model.py": frozenset({"add_constant", "add_matmul_rhs_constant"}),
+    "vl_debug_runner.py": frozenset(
+        {
+            "load_vision_engine_from_bundle",
+            "load_config_from_bundle",
+            "load_preprocessor_config_from_bundle",
+            "VisionTrtRunner",
+            "preprocess_image_inputs_for_trt",
+            "load_section_from_bundle",
+            "load_engine_from_bundle",
+            "TrtRunner",
+            "VLTrtRunner",
+        }
+    ),
+}
+Definition = ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef
+
+
+@dataclass(frozen=True)
+class PruneResult:
+    path: Path
+    removed_names: tuple[str, ...]
+    removed_lines: int
+
+
+def _module_name(family: str, family_dir: Path, path: Path) -> str:
+    parts = list(path.relative_to(family_dir).with_suffix("").parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    suffix = ".".join(parts)
+    base = f"tensorrt_model_connect.families.{family}"
+    return f"{base}.{suffix}" if suffix else base
+
+
+def _resolved_from_module(
+    current_module: str,
+    current_path: Path,
+    node: ast.ImportFrom,
+) -> str | None:
+    if node.level == 0:
+        return node.module
+    package = (
+        current_module
+        if current_path.name == "__init__.py"
+        else current_module.rpartition(".")[0]
+    )
+    parts = package.split(".") if package else []
+    parents = node.level - 1
+    if parents > len(parts):
+        return None
+    base = parts[:len(parts) - parents]
+    if node.module:
+        base.extend(node.module.split("."))
+    return ".".join(base)
+
+
+def _definition_map(tree: ast.Module) -> dict[str, list[Definition]]:
+    definitions: dict[str, list[Definition]] = {}
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            definitions.setdefault(node.name, []).append(node)
+    return definitions
+
+
+def _loaded_definition_names(node: ast.AST, names: set[str]) -> set[str]:
+    loaded = {
+        child.id
+        for child in ast.walk(node)
+        if isinstance(child, ast.Name)
+        and isinstance(child.ctx, ast.Load)
+        and child.id in names
+    }
+    loaded.update(
+        child.value
+        for child in ast.walk(node)
+        if isinstance(child, ast.Constant)
+        and isinstance(child.value, str)
+        and child.value in names
+    )
+    return loaded
+
+
+def _external_roots(
+    target_path: Path,
+    family_dir: Path,
+    definitions: set[str],
+) -> set[str]:
+    family = family_dir.name
+    target_module = _module_name(family, family_dir, target_path)
+    roots: set[str] = set()
+
+    for path in family_dir.rglob("*.py"):
+        if path == target_path:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        current_module = _module_name(family, family_dir, path)
+        aliases: set[str] = set()
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == target_module:
+                        aliases.add(alias.asname or alias.name.rsplit(".", 1)[-1])
+                continue
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            resolved = _resolved_from_module(current_module, path, node)
+            if resolved == target_module:
+                for alias in node.names:
+                    if alias.name == "*":
+                        roots.update(definitions)
+                    elif alias.name in definitions:
+                        roots.add(alias.name)
+                continue
+            for alias in node.names:
+                candidate = f"{resolved}.{alias.name}" if resolved else alias.name
+                if candidate == target_module:
+                    aliases.add(alias.asname or alias.name)
+
+        roots.update(
+            node.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in aliases
+            and node.attr in definitions
+        )
+
+    return roots
+
+
+def reachable_definitions(path: Path, family_dir: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    definitions = _definition_map(tree)
+    names = set(definitions)
+    dependencies = {
+        name: set().union(
+            *(_loaded_definition_names(node, names) for node in nodes)
+        )
+        for name, nodes in definitions.items()
+    }
+    roots = _external_roots(path, family_dir, names)
+
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            roots.update(_loaded_definition_names(node, names))
+
+    # Generic tools receive selected family modules dynamically, so their
+    # calls cannot be attributed to a concrete family by the import scanner.
+    roots.update(names & EXTERNAL_MODULE_ROOTS.get(path.name, frozenset()))
+
+    reachable = set(roots)
+    pending = deque(roots)
+    while pending:
+        for dependency in dependencies[pending.popleft()]:
+            if dependency not in reachable:
+                reachable.add(dependency)
+                pending.append(dependency)
+    return reachable
+
+
+def _removal_spans(
+    lines: list[str],
+    definitions: dict[str, list[Definition]],
+    removed_names: set[str],
+) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    for name in removed_names:
+        for node in definitions[name]:
+            start = node.decorator_list[0].lineno if node.decorator_list else node.lineno
+            end = node.end_lineno or node.lineno
+            # Include an immediately preceding comment/blank section, stopping
+            # at code owned by the previous definition or module statement.
+            while start > 1:
+                previous = lines[start - 2]
+                if previous.strip() and not previous.lstrip().startswith("#"):
+                    break
+                start -= 1
+            spans.append((start - 1, end))
+
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def prune_file(path: Path, family_dir: Path, *, write: bool) -> PruneResult:
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+    definitions = _definition_map(tree)
+    reachable = reachable_definitions(path, family_dir)
+    removed = set(definitions) - reachable
+    return prune_named_definitions(path, removed, write=write)
+
+
+def prune_named_definitions(
+    path: Path,
+    names: set[str],
+    *,
+    write: bool,
+) -> PruneResult:
+    """Remove named top-level definitions emitted by the specialization audit."""
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+    definitions = _definition_map(tree)
+    removed = set(names)
+    if not removed:
+        return PruneResult(path, (), 0)
+    missing = removed - definitions.keys()
+    if missing:
+        raise ValueError(
+            f"Audit symbols no longer exist in {path}: {', '.join(sorted(missing))}"
+        )
+
+    lines = text.splitlines(keepends=True)
+    spans = _removal_spans(lines, definitions, removed)
+    removed_lines = sum(end - start for start, end in spans)
+    if write:
+        for start, end in reversed(spans):
+            del lines[start:end]
+        updated = "".join(lines)
+        updated = re.sub(r"\n{4,}", "\n\n\n", updated)
+        path.write_text(updated, encoding="utf-8")
+    return PruneResult(path, tuple(sorted(removed)), removed_lines)
+
+
+def family_dirs(repo_root: Path, selected: tuple[str, ...]) -> list[Path]:
+    root = repo_root / "python/tensorrt_model_connect/families"
+    if selected:
+        paths = [root / family for family in selected]
+        missing = [
+            path.name for path in paths if not (path / "plugin.py").is_file()
+        ]
+        if missing:
+            raise SystemExit("Unknown model family: " + ", ".join(missing))
+        return paths
+    else:
+        return sorted(
+            path for path in root.iterdir() if (path / "plugin.py").is_file()
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--family", action="append", default=[])
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Rewrite helper files; without this flag, report and fail on dead code",
+    )
+    parser.add_argument(
+        "--strict-audit",
+        action="store_true",
+        help="Prune exactly the unreachable symbols reported by family_specialization.py",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    results: list[PruneResult] = []
+    if args.strict_audit:
+        report = family_specialization.audit_repo(repo_root, tuple(args.family))
+        for family in report["families"]:
+            family_dir = (
+                repo_root
+                / "python/tensorrt_model_connect/families"
+                / family["family"]
+            )
+            by_path: dict[str, set[str]] = {}
+            for item in family["unreachable_symbols"]:
+                by_path.setdefault(item["path"], set()).add(item["symbol"])
+            for relative_path, names in sorted(by_path.items()):
+                result = prune_named_definitions(
+                    family_dir / relative_path,
+                    names,
+                    write=args.write,
+                )
+                if result.removed_names:
+                    results.append(result)
+    else:
+        for family_dir in family_dirs(repo_root, tuple(args.family)):
+            for filename in TARGET_MODULES:
+                for path in sorted(family_dir.rglob(filename)):
+                    if "__pycache__" in path.parts or not path.is_file():
+                        continue
+                    result = prune_file(path, family_dir, write=args.write)
+                    if result.removed_names:
+                        results.append(result)
+    for result in results:
+        print(
+            f"{result.path.relative_to(repo_root)}: "
+            f"{len(result.removed_names)} definitions, "
+            f"{result.removed_lines} lines "
+            f"[{', '.join(result.removed_names)}]"
+        )
+    if results:
+        print(
+            f"total: {len(results)} files, "
+            f"{sum(len(result.removed_names) for result in results)} definitions, "
+            f"{sum(result.removed_lines for result in results)} lines"
+        )
+    return 0 if args.write or not results else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/relocate_family_development.py
+++ b/tools/relocate_family_development.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Move development-only modules out of family runtime packages."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from tools import migrate_family_layout as layout_tools
+except ModuleNotFoundError:  # Direct execution puts tools/ on sys.path.
+    import migrate_family_layout as layout_tools
+
+
+@dataclass(frozen=True)
+class Relocation:
+    family: str
+    source: str
+    destination: str
+
+
+RELOCATIONS = (
+    Relocation("bark", "model/debug_runner.py", "tools/families/bark/debug_runner.py"),
+    Relocation("deepseek_ocr", "model/vl_debug_runner.py", "tools/families/deepseek_ocr/vl_debug_runner.py"),
+    Relocation("elf_flow", "model/debug_runner.py", "tools/families/elf_flow/debug_runner.py"),
+    Relocation("flux", "model/diffusion_runner.py", "tools/families/flux/diffusion_runner.py"),
+    Relocation("flux", "model/schedulers", "tools/families/flux/schedulers"),
+    Relocation("internvl", "model/vl_debug_runner.py", "tools/families/internvl/vl_debug_runner.py"),
+    Relocation("lance", "model/vl_debug_runner.py", "tools/families/lance/vl_debug_runner.py"),
+    Relocation("locateanything", "model/vl_debug_runner.py", "tools/families/locateanything/vl_debug_runner.py"),
+    Relocation("phi4_multimodal", "model/vl_debug_runner.py", "tools/families/phi4_multimodal/vl_debug_runner.py"),
+    Relocation("pixart", "model/diffusion_runner.py", "tools/families/pixart/diffusion_runner.py"),
+    Relocation("pixart", "model/schedulers", "tools/families/pixart/schedulers"),
+    Relocation("qwen_vl", "model/onnx_vision_builder.py", "tools/families/qwen_vl/onnx_vision_builder.py"),
+    Relocation("qwen_vl", "model/vl_debug_runner.py", "tools/families/qwen_vl/vl_debug_runner.py"),
+    Relocation("segformer", "model/debug_runner.py", "tools/families/segformer/debug_runner.py"),
+    Relocation("wan_t2v", "model/diffusion_runner.py", "tools/families/wan_t2v/diffusion_runner.py"),
+    Relocation("wan_t2v", "model/schedulers", "tools/families/wan_t2v/schedulers"),
+    Relocation("whisper", "model/debug_runner.py", "tools/families/whisper/debug_runner.py"),
+    Relocation("z_image", "model/diffusion_runner.py", "tools/families/z_image/diffusion_runner.py"),
+    Relocation("z_image", "model/schedulers", "tools/families/z_image/schedulers"),
+)
+
+
+def _source(repo_root: Path, relocation: Relocation) -> Path:
+    return (
+        repo_root
+        / "python/tensorrt_model_connect/families"
+        / relocation.family
+        / relocation.source
+    )
+
+
+def pending_relocations(
+    repo_root: Path,
+    families: frozenset[str],
+) -> list[Relocation]:
+    return [
+        relocation
+        for relocation in RELOCATIONS
+        if (not families or relocation.family in families)
+        and _source(repo_root, relocation).exists()
+    ]
+
+
+def _files(path: Path) -> list[Path]:
+    if path.is_file():
+        return [path]
+    return sorted(candidate for candidate in path.rglob("*.py") if candidate.is_file())
+
+
+def apply_relocations(repo_root: Path, families: frozenset[str]) -> None:
+    repo_root = repo_root.resolve()
+    pending = pending_relocations(repo_root, families)
+    mapping: dict[str, str] = {}
+    reverse_paths: dict[Path, Path] = {}
+
+    for relocation in pending:
+        source = _source(repo_root, relocation)
+        destination = repo_root / relocation.destination
+        if destination.exists():
+            raise SystemExit(f"Relocation destination exists: {destination}")
+        source_files = _files(source)
+        for source_file in source_files:
+            relative = source_file.relative_to(source) if source.is_dir() else Path()
+            destination_file = destination / relative if source.is_dir() else destination
+            old_module = layout_tools._module_name(repo_root, source_file)
+            new_module = layout_tools._module_name(repo_root, destination_file)
+            if old_module and new_module:
+                mapping[old_module] = new_module
+            reverse_paths[destination_file.resolve()] = source_file
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        family_tools = repo_root / "tools/families" / relocation.family
+        family_tools.mkdir(parents=True, exist_ok=True)
+        init = family_tools / "__init__.py"
+        if not init.exists():
+            init.write_text('"""Family-owned development tools."""\n', encoding="utf-8")
+        shutil.move(str(source), str(destination))
+
+    if not mapping:
+        return
+    mapping = layout_tools._collapse_mapping(mapping)
+    for path in layout_tools._rewrite_python_paths(repo_root):
+        current = layout_tools._module_name(repo_root, path)
+        old_path = reverse_paths.get(path.resolve(), path)
+        old = layout_tools._module_name(repo_root, old_path)
+        if not current or not old:
+            continue
+        layout_tools._rewrite_imports(
+            path,
+            old_module=old,
+            new_module=current,
+            old_is_init=old_path.name == "__init__.py",
+            new_is_init=path.name == "__init__.py",
+            mapping=mapping,
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("check", "apply"))
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--family", action="append", default=[])
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    families = frozenset(args.family)
+    pending = pending_relocations(repo_root, families)
+    if args.command == "check":
+        for relocation in pending:
+            print(f"{relocation.family}: {relocation.source} -> {relocation.destination}")
+        return 1 if pending else 0
+    apply_relocations(repo_root, families)
+    print(f"relocated_family_development_modules={len(pending)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/relocate_family_development.py
+++ b/tools/relocate_family_development.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Move development-only modules out of family runtime packages."""
 
 from __future__ import annotations

--- a/tools/specialize_family.py
+++ b/tools/specialize_family.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Apply reviewed, family-local source specialization layouts."""
 
 from __future__ import annotations

--- a/tools/specialize_family.py
+++ b/tools/specialize_family.py
@@ -1,0 +1,651 @@
+#!/usr/bin/env python3
+"""Apply reviewed, family-local source specialization layouts."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from tools import migrate_family_layout as layout_tools
+except ModuleNotFoundError:  # Direct execution puts tools/ on sys.path.
+    import migrate_family_layout as layout_tools
+
+
+@dataclass(frozen=True)
+class SpecializationLayout:
+    model_modules: tuple[str, ...] = ()
+    parallel_modules: tuple[str, ...] = ()
+    runtime_modules: tuple[str, ...] = ()
+    component_modules: tuple[tuple[str, str], ...] = ()
+    profile_paths: tuple[tuple[str, str], ...] = ()
+
+
+MODEL_MODULES = {
+    "albert": ("encoder_builder.py",),
+    "bert": ("encoder_builder.py",),
+    "convbert": ("builder.py",),
+    "distilbert": ("encoder_builder.py",),
+    "dpr": ("encoder_builder.py",),
+    "electra": ("encoder_builder.py",),
+    "fnet": ("fnet_encoder_builder.py",),
+    "mpnet": ("encoder_builder.py",),
+    "roberta": ("encoder_builder.py",),
+    "xlnet": ("xlnet_builder.py",),
+}
+
+MODEL_MODULES.update(
+    {
+        "bark": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "bloom": ("dual_profile_decoder_builder.py", "standard_decoder_builder.py"),
+        "chronos_bolt": ("time_series_trt.py",),
+        "codegen": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "deepseek_ocr": ("default_decoder.py",),
+        "deepseek_v2": ("default_decoder.py",),
+        "elf_flow": ("builder.py",),
+        "falcon": ("dual_profile_decoder_builder.py", "standard_decoder_builder.py"),
+        "gemma": ("dual_profile_decoder_builder.py", "standard_decoder_builder.py"),
+        "glm": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "gpt2": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "gpt_neo": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "gpt_neox": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "gpt_oss": ("default_decoder.py",),
+        "granite": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "internlm": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "internvl": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "lance": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "llama": ("dual_profile_decoder_builder.py", "standard_decoder_builder.py"),
+        "locateanything": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "ltx_video": ("ltx_dit_builder.py",),
+        "mistral": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "mixtral": ("default_decoder.py",),
+        "nemotron": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "nemotron_labs_diffusion": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "nemotron_speech_streaming": ("canary_encoder_helpers.py",),
+        "olmo": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "opt": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "patchtsmixer": ("time_series_trt.py",),
+        "patchtst": ("time_series_trt.py",),
+        "personaplex": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "phi": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "phi4_multimodal": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "phi_moe": ("default_decoder.py",),
+        "pixart": ("standard_dit_builder.py",),
+        "qwen": ("dual_profile_decoder_builder.py", "standard_decoder_builder.py"),
+        "qwen3_omni": ("default_decoder.py",),
+        "qwen_image": ("qwen_image_dit_builder.py",),
+        "qwen_moe": ("default_decoder.py",),
+        "qwen_vl": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "sam3": ("core_builder.py",),
+        "stablelm": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "starcoder2": ("default_decoder.py", "default_dual_profile_decoder.py"),
+        "timesfm": ("time_series_trt.py",),
+        "wan_t2v": ("standard_dit_builder.py",),
+        "xglm": ("default_decoder.py", "default_dual_profile_decoder.py"),
+    }
+)
+
+COMPONENT_MODULES: dict[str, tuple[tuple[str, str], ...]] = {
+    "bark": (("encodec_builder.py", "codec.py"),),
+    "elf_flow": (
+        ("model_config.py", "config.py"),
+        ("t5_encoder_builder.py", "text_encoder.py"),
+    ),
+    "flux": (
+        ("clip_encoder_builder.py", "clip_encoder.py"),
+        ("flux2_dit_builder.py", "flux2.py"),
+        ("flux2_dit_tp_builder.py", "flux2_parallel.py"),
+        ("flux_dit_builder.py", "flux.py"),
+        ("flux_dit_tp_builder.py", "flux_parallel.py"),
+        ("flux_vae_builder.py", "vae.py"),
+        ("mistral_encoder_builder.py", "mistral_encoder.py"),
+        ("t5_encoder_builder.py", "t5_encoder.py"),
+    ),
+    "internvl": (("internvit_vision_builder.py", "vision.py"),),
+    "lance": (("qwen_vl_vision_builder.py", "vision.py"),),
+    "locateanything": (
+        ("onnx_vision_builder.py", "vision_onnx.py"),
+        ("vision_builder.py", "vision.py"),
+    ),
+    "ltx_video": (
+        ("ltx_vae_builder.py", "vae.py"),
+        ("t5_encoder_builder.py", "text_encoder.py"),
+    ),
+    "magpie_tts": (("nanocodec_builder.py", "codec.py"),),
+    "pixart": (
+        ("t5_encoder_builder.py", "text_encoder.py"),
+        ("vae_2d_builder.py", "vae.py"),
+    ),
+    "qwen3_omni": (("qwen_vl_vision_builder.py", "vision.py"),),
+    "qwen_image": (
+        ("qwen25_vl_text_encoder_builder.py", "text_encoder.py"),
+        ("qwen_image_bundle_config.py", "bundle_config.py"),
+        ("qwen_image_preprocessor.py", "preprocessor.py"),
+        ("qwen_image_vae_builder.py", "vae.py"),
+        ("qwen_vl_vision_builder.py", "vision.py"),
+    ),
+    "qwen_vl": (("qwen_vl_vision_builder.py", "vision.py"),),
+    "sam3": (
+        ("text_encoder_builder.py", "text_encoder.py"),
+        ("vision_encoder_builder.py", "vision_encoder.py"),
+    ),
+    "wan_t2v": (
+        ("causal_vae_3d_builder.py", "vae.py"),
+        ("t5_encoder_builder.py", "text_encoder.py"),
+    ),
+    "z_image": (
+        ("qwen3_encoder_builder.py", "text_encoder.py"),
+        ("vae_2d_builder.py", "vae.py"),
+        ("z_image_dit_builder.py", "dit.py"),
+    ),
+}
+
+PROFILE_PATHS = {
+    family: (
+        ("python_profile_requirements", "requirements"),
+        ("python_profile_verify.py", "verify.py"),
+    )
+    for family in ("chronos_bolt", "internlm")
+}
+
+PARALLEL_MODULES = {
+    "albert": "tp_builder.py",
+    "bark": "decoder_tp_builder.py",
+    "bart": "decoder_tp_builder.py",
+    "bert": "tp_builder.py",
+    "bloom": "dual_profile_decoder_tp_builder.py",
+    "canary": "decoder_tp_builder.py",
+    "codegen": "dual_profile_decoder_tp_builder.py",
+    "convbert": "tp_builder.py",
+    "deberta": "tp_builder.py",
+    "deepseek_ocr": "tp_builder.py",
+    "deepseek_v2": "tp_builder.py",
+    "distilbert": "tp_builder.py",
+    "dpr": "tp_builder.py",
+    "eagle_vlm": "tp_builder.py",
+    "electra": "tp_builder.py",
+    "falcon": "dual_profile_decoder_tp_builder.py",
+    "fnet": "tp_builder.py",
+    "gemma": "dual_profile_decoder_tp_builder.py",
+    "glm": "dual_profile_decoder_tp_builder.py",
+    "gpt2": "default_dual_profile_decoder_tp.py",
+    "gpt_neo": "default_dual_profile_decoder_tp.py",
+    "gpt_neox": "default_dual_profile_decoder_tp.py",
+    "gpt_oss": "tp_builder.py",
+    "granite": "dual_profile_decoder_tp_builder.py",
+    "internlm": "dual_profile_decoder_tp_builder.py",
+    "internvl": "tp_builder.py",
+    "locateanything": "decoder_tp_builder.py",
+    "magpie_tts": "decoder_tp_builder.py",
+    "mamba": "tp_builder.py",
+    "marian": "decoder_tp_builder.py",
+    "mixtral": "tp_builder.py",
+    "modernbert": "tp_builder.py",
+    "mpnet": "tp_builder.py",
+    "nemotron_h": "tp_builder.py",
+    "nemotron_speech_streaming": "predictor_tp_builder.py",
+    "olmo": "dual_profile_decoder_tp_builder.py",
+    "olmo2": "tp_builder.py",
+    "opt": "default_dual_profile_decoder_tp.py",
+    "personaplex": "decoder_tp_builder.py",
+    "phi": "dual_profile_decoder_tp_builder.py",
+    "phi_moe": "tp_builder.py",
+    "pixart": "standard_dit_tp_builder.py",
+    "qwen": "dual_profile_decoder_tp_builder.py",
+    "qwen_moe": "tp_builder.py",
+    "qwen_vl": "decoder_tp_builder.py",
+    "roberta": "tp_builder.py",
+    "rwkv": "tp_builder.py",
+    "sam": "sam_tp_builder.py",
+    "segformer": "segformer_tp_builder.py",
+    "stablelm": "dual_profile_decoder_tp_builder.py",
+    "starcoder2": "dual_profile_decoder_tp_builder.py",
+    "t5": "decoder_tp_builder.py",
+    "timm_vit": "timm_vit_tp_builder.py",
+    "wan_t2v": "standard_dit_tp_builder.py",
+    "whisper": "decoder_tp_builder.py",
+    "xglm": "dual_profile_decoder_tp_builder.py",
+    "xlnet": "tp_builder.py",
+    "z_image": "z_image_dit_tp_builder.py",
+}
+
+RUNTIME_FAMILIES = {
+    "bart",
+    "bloom",
+    "codegen",
+    "deepseek_v2",
+    "falcon",
+    "gemma",
+    "glm",
+    "gpt2",
+    "gpt_neo",
+    "gpt_neox",
+    "gpt_oss",
+    "granite",
+    "internlm",
+    "llama",
+    "m2m_100",
+    "mamba",
+    "marian",
+    "mistral",
+    "mixtral",
+    "nemotron",
+    "nemotron_h",
+    "nemotron_labs_diffusion",
+    "olmo",
+    "olmo2",
+    "opt",
+    "phi",
+    "phi_moe",
+    "qwen",
+    "qwen3_5",
+    "qwen_moe",
+    "rwkv",
+    "stablelm",
+    "starcoder2",
+    "t5",
+    "xglm",
+}
+
+FAMILY_LAYOUTS: dict[str, SpecializationLayout] = {
+    family: SpecializationLayout(
+        model_modules=MODEL_MODULES.get(family, ()),
+        parallel_modules=(PARALLEL_MODULES[family],)
+        if family in PARALLEL_MODULES
+        else (),
+        runtime_modules=("debug_runner.py",) if family in RUNTIME_FAMILIES else (),
+        component_modules=COMPONENT_MODULES.get(family, ()),
+        profile_paths=PROFILE_PATHS.get(family, ()),
+    )
+    for family in sorted(
+        MODEL_MODULES.keys()
+        | PARALLEL_MODULES.keys()
+        | RUNTIME_FAMILIES
+        | COMPONENT_MODULES.keys()
+        | PROFILE_PATHS.keys()
+    )
+}
+
+
+def _strip_merged_preamble(text: str) -> str:
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    removals: list[tuple[int, int]] = []
+    module_aliases: set[str] = set()
+    name_aliases: dict[str, str] = {}
+
+    for index, node in enumerate(tree.body):
+        remove = (
+            index == 0
+            and isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        )
+        remove = remove or (
+            isinstance(node, ast.ImportFrom) and node.module == "__future__"
+        )
+        if isinstance(node, ast.ImportFrom) and node.level == 1:
+            if node.module is None:
+                merged_aliases = [alias for alias in node.names if alias.name == "model"]
+                if merged_aliases and len(merged_aliases) == len(node.names):
+                    module_aliases.update(alias.asname or alias.name for alias in merged_aliases)
+                    remove = True
+            elif node.module == "model":
+                for alias in node.names:
+                    local_name = alias.asname or alias.name
+                    if local_name != alias.name:
+                        name_aliases[local_name] = alias.name
+                remove = True
+        if remove:
+            removals.append((node.lineno - 1, node.end_lineno or node.lineno))
+
+    for start, end in reversed(removals):
+        del lines[start:end]
+    body = "".join(lines).strip()
+    for alias in sorted(module_aliases, key=len, reverse=True):
+        body = re.sub(rf"\b{re.escape(alias)}\.", "", body)
+    for alias, target in sorted(name_aliases.items(), key=lambda item: -len(item[0])):
+        body = re.sub(rf"\b{re.escape(alias)}\b", target, body)
+    return body
+
+
+def _normalize_merged_model(path: Path) -> None:
+    """Remove merge-created self imports and repair known local aliases."""
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    lines = text.splitlines(keepends=True)
+    removals: list[tuple[int, int]] = []
+    aliases: dict[str, str] = {}
+
+    for node in tree.body:
+        if not (
+            isinstance(node, ast.ImportFrom)
+            and node.level == 1
+            and node.module == "model"
+        ):
+            continue
+        removals.append((node.lineno - 1, node.end_lineno or node.lineno))
+        for alias in node.names:
+            local_name = alias.asname or alias.name
+            if local_name != alias.name:
+                aliases[local_name] = alias.name
+
+    defined = {
+        node.name
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+    }
+    for alias, target in {
+        "_const_in_work_dtype": "const_in_work_dtype",
+        "_norm_multi": "norm_multi",
+    }.items():
+        if target in defined and alias not in defined:
+            aliases[alias] = target
+
+    for start, end in reversed(removals):
+        del lines[start:end]
+    updated = "".join(lines)
+    for alias, target in sorted(aliases.items(), key=lambda item: -len(item[0])):
+        updated = re.sub(rf"\b{re.escape(alias)}\b", target, updated)
+    if updated != text:
+        path.write_text(updated, encoding="utf-8")
+
+
+def _merge_into(
+    repo_root: Path,
+    family_dir: Path,
+    sources: tuple[str, ...],
+    destination_name: str,
+) -> dict[str, str]:
+    model_dir = family_dir / "model"
+    destination = model_dir / destination_name
+    existing = [model_dir / name for name in sources if (model_dir / name).is_file()]
+    if not existing:
+        return {}
+    if not destination.is_file():
+        raise SystemExit(f"Missing specialization destination: {destination}")
+
+    text = destination.read_text(encoding="utf-8").rstrip()
+    mapping: dict[str, str] = {}
+    destination_module = layout_tools._module_name(repo_root, destination)
+    for source in existing:
+        body = _strip_merged_preamble(source.read_text(encoding="utf-8"))
+        if body:
+            title = source.stem.replace("_", " ").title()
+            text += f"\n\n\n# {title}\n\n{body}"
+        source_module = layout_tools._module_name(repo_root, source)
+        if source_module and destination_module:
+            mapping[source_module] = destination_module
+        source.unlink()
+    destination.write_text(text + "\n", encoding="utf-8")
+    return mapping
+
+
+def _move_single_module(
+    repo_root: Path,
+    family_dir: Path,
+    sources: tuple[str, ...],
+    destination_name: str,
+) -> tuple[dict[str, str], dict[Path, Path]]:
+    model_dir = family_dir / "model"
+    existing = [model_dir / name for name in sources if (model_dir / name).is_file()]
+    if not existing:
+        return {}, {}
+    destination = model_dir / destination_name
+    if destination.exists():
+        raise SystemExit(f"Specialization destination exists: {destination}")
+    if len(existing) != 1:
+        raise SystemExit(
+            f"{destination_name} consolidation for {family_dir.name} requires one source; "
+            f"found {[path.name for path in existing]}"
+        )
+    source = existing[0]
+    source_module = layout_tools._module_name(repo_root, source)
+    destination_module = layout_tools._module_name(repo_root, destination)
+    shutil.move(str(source), str(destination))
+    mapping = (
+        {source_module: destination_module}
+        if source_module and destination_module
+        else {}
+    )
+    return mapping, {destination.resolve(): source}
+
+
+def _move_mapped_paths(
+    repo_root: Path,
+    family_dir: Path,
+    moves: tuple[tuple[str, str], ...],
+    *,
+    source_root: Path,
+    destination_root: Path,
+) -> tuple[dict[str, str], dict[Path, Path]]:
+    mapping: dict[str, str] = {}
+    reverse_paths: dict[Path, Path] = {}
+    moved = False
+    for source_name, destination_name in moves:
+        source = source_root / source_name
+        if not source.exists():
+            continue
+        destination = destination_root / destination_name
+        if destination.exists():
+            raise SystemExit(f"Specialization destination exists: {destination}")
+        source_files = [source] if source.is_file() else sorted(source.rglob("*.py"))
+        for source_file in source_files:
+            relative = source_file.relative_to(source) if source.is_dir() else Path()
+            destination_file = destination / relative if source.is_dir() else destination
+            old_module = layout_tools._module_name(repo_root, source_file)
+            new_module = layout_tools._module_name(repo_root, destination_file)
+            if old_module and new_module:
+                mapping[old_module] = new_module
+            reverse_paths[destination_file.resolve()] = source_file
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(source), str(destination))
+        moved = True
+
+    if moved:
+        destination_root.mkdir(parents=True, exist_ok=True)
+        init = destination_root / "__init__.py"
+        if not init.exists():
+            init.write_text('"""Family-owned specialized components."""\n', encoding="utf-8")
+    return mapping, reverse_paths
+
+
+def _rewrite_sources(
+    repo_root: Path,
+    mapping: dict[str, str],
+    reverse_paths: dict[Path, Path],
+) -> None:
+    mapping = layout_tools._collapse_mapping(mapping)
+    for path in layout_tools._rewrite_python_paths(repo_root):
+        current = layout_tools._module_name(repo_root, path)
+        old_path = reverse_paths.get(path.resolve(), path)
+        old = layout_tools._module_name(repo_root, old_path)
+        if not current or not old:
+            continue
+        layout_tools._rewrite_imports(
+            path,
+            old_module=old,
+            new_module=current,
+            old_is_init=old_path.name == "__init__.py",
+            new_is_init=path.name == "__init__.py",
+            mapping=mapping,
+        )
+
+
+def _normalize_manifests(
+    repo_root: Path,
+    specializations: dict[str, SpecializationLayout],
+) -> None:
+    for family, specialization in specializations.items():
+        manifest = (
+            repo_root
+            / "python/tensorrt_model_connect/families"
+            / family
+            / "MODEL.toml"
+        )
+        text = manifest.read_text(encoding="utf-8")
+        updated = text
+        if specialization.runtime_modules:
+            updated = updated.replace("model/debug_runner.py|", "model/runtime.py|")
+        for source_name, destination_name in specialization.component_modules:
+            updated = updated.replace(
+                f"model/{source_name}|",
+                f"model/components/{destination_name}|",
+            )
+        if specialization.profile_paths:
+            updated = updated.replace(
+                "/model/python_profile_requirements/",
+                "/profiles/requirements/",
+            )
+            updated = updated.replace(
+                "/model/python_profile_verify.py",
+                "/profiles/verify.py",
+            )
+        if updated != text:
+            manifest.write_text(updated, encoding="utf-8")
+
+
+def specialize_family(
+    repo_root: Path,
+    family: str,
+    specialization: SpecializationLayout,
+) -> None:
+    specialize_families(repo_root, {family: specialization})
+
+
+def specialize_families(
+    repo_root: Path,
+    specializations: dict[str, SpecializationLayout],
+) -> None:
+    repo_root = repo_root.resolve()
+    mapping: dict[str, str] = {}
+    reverse_paths: dict[Path, Path] = {}
+    for family, specialization in specializations.items():
+        family_dir = repo_root / "python/tensorrt_model_connect/families" / family
+        if not (family_dir / "plugin.py").is_file():
+            raise SystemExit(f"Unknown model family: {family}")
+
+        mapping.update(
+            _merge_into(
+                repo_root,
+                family_dir,
+                specialization.model_modules,
+                "model.py",
+            )
+        )
+        parallel_mapping, parallel_reverse = _move_single_module(
+            repo_root,
+            family_dir,
+            specialization.parallel_modules,
+            "parallel.py",
+        )
+        mapping.update(parallel_mapping)
+        reverse_paths.update(parallel_reverse)
+        runtime_mapping, runtime_reverse = _move_single_module(
+            repo_root,
+            family_dir,
+            specialization.runtime_modules,
+            "runtime.py",
+        )
+        mapping.update(runtime_mapping)
+        reverse_paths.update(runtime_reverse)
+        component_mapping, component_reverse = _move_mapped_paths(
+            repo_root,
+            family_dir,
+            specialization.component_modules,
+            source_root=family_dir / "model",
+            destination_root=family_dir / "model/components",
+        )
+        mapping.update(component_mapping)
+        reverse_paths.update(component_reverse)
+        profile_mapping, profile_reverse = _move_mapped_paths(
+            repo_root,
+            family_dir,
+            specialization.profile_paths,
+            source_root=family_dir / "model",
+            destination_root=family_dir / "profiles",
+        )
+        mapping.update(profile_mapping)
+        reverse_paths.update(profile_reverse)
+    _normalize_manifests(repo_root, specializations)
+    if mapping:
+        _rewrite_sources(repo_root, mapping, reverse_paths)
+        layout_tools._normalize_consolidated_models(repo_root)
+    for family in specializations:
+        model_path = (
+            repo_root
+            / "python/tensorrt_model_connect/families"
+            / family
+            / "model/model.py"
+        )
+        if model_path.is_file():
+            _normalize_merged_model(model_path)
+
+
+def pending_paths(repo_root: Path, family: str) -> list[str]:
+    specialization = FAMILY_LAYOUTS[family]
+    model_dir = repo_root / "python/tensorrt_model_connect/families" / family / "model"
+    pending = [
+        name
+        for name in (
+            *specialization.model_modules,
+            *specialization.parallel_modules,
+            *specialization.runtime_modules,
+        )
+        if (model_dir / name).is_file()
+    ]
+    pending.extend(
+        source for source, _ in specialization.component_modules
+        if (model_dir / source).exists()
+    )
+    pending.extend(
+        source for source, _ in specialization.profile_paths
+        if (model_dir / source).exists()
+    )
+    return sorted(pending)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("check", "apply"))
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--family", action="append", default=[])
+    parser.add_argument("--all", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not args.all and not args.family:
+        raise SystemExit("Specify --family or --all")
+    selected = sorted(FAMILY_LAYOUTS) if args.all else args.family
+    unknown = sorted(set(selected) - FAMILY_LAYOUTS.keys())
+    if unknown:
+        raise SystemExit("No reviewed specialization layout for: " + ", ".join(unknown))
+    repo_root = args.repo_root.resolve()
+    pending = {
+        family: pending_paths(repo_root, family)
+        for family in selected
+    }
+    if args.command == "check":
+        for family, paths in pending.items():
+            if paths:
+                print(f"{family}: pending {', '.join(paths)}")
+        return 1 if any(pending.values()) else 0
+
+    specialize_families(
+        repo_root,
+        {family: FAMILY_LAYOUTS[family] for family in selected},
+    )
+    for family in selected:
+        print(f"specialized_family={family}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/specialize_family_switches.py
+++ b/tools/specialize_family_switches.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Inline family-fixed strategy switches and remove unsupported branches."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import copy
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+try:
+    from tools import family_specialization
+except ModuleNotFoundError:  # Direct execution puts tools/ on sys.path.
+    import family_specialization
+
+
+class _ConstantFolder(ast.NodeTransformer):
+    def __init__(self, constants: dict[str, Any]):
+        self.constants = constants
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:
+        if isinstance(node.ctx, ast.Load) and node.id in self.constants:
+            return ast.copy_location(ast.Constant(self.constants[node.id]), node)
+        return node
+
+    def visit_UnaryOp(self, node: ast.UnaryOp) -> ast.AST:
+        node = self.generic_visit(node)
+        if isinstance(node.op, ast.Not) and isinstance(node.operand, ast.Constant):
+            return ast.copy_location(ast.Constant(not node.operand.value), node)
+        return node
+
+    def visit_BoolOp(self, node: ast.BoolOp) -> ast.AST:
+        node = self.generic_visit(node)
+        values = list(node.values)
+        if isinstance(node.op, ast.And):
+            if any(
+                isinstance(value, ast.Constant) and not bool(value.value)
+                for value in values
+            ):
+                return ast.copy_location(ast.Constant(False), node)
+            values = [
+                value
+                for value in values
+                if not (isinstance(value, ast.Constant) and bool(value.value))
+            ]
+        else:
+            if any(
+                isinstance(value, ast.Constant) and bool(value.value)
+                for value in values
+            ):
+                return ast.copy_location(ast.Constant(True), node)
+            values = [
+                value
+                for value in values
+                if not (isinstance(value, ast.Constant) and not bool(value.value))
+            ]
+        if not values:
+            return ast.copy_location(
+                ast.Constant(isinstance(node.op, ast.And)), node
+            )
+        if len(values) == 1:
+            return values[0]
+        node.values = values
+        return node
+
+    def visit_Compare(self, node: ast.Compare) -> ast.AST:
+        node = self.generic_visit(node)
+        operands = [node.left, *node.comparators]
+        if not all(isinstance(operand, ast.Constant) for operand in operands):
+            return node
+        value = eval(  # noqa: S307 - expression is restricted to AST constants.
+            compile(ast.Expression(node), "<family-switch>", "eval"),
+            {"__builtins__": {}},
+            {},
+        )
+        return ast.copy_location(ast.Constant(bool(value)), node)
+
+    def visit_If(self, node: ast.If) -> ast.AST | list[ast.stmt]:
+        node = self.generic_visit(node)
+        if isinstance(node.test, ast.Constant):
+            return node.body if bool(node.test.value) else node.orelse
+        return node
+
+    def visit_IfExp(self, node: ast.IfExp) -> ast.AST:
+        node = self.generic_visit(node)
+        if isinstance(node.test, ast.Constant):
+            return node.body if bool(node.test.value) else node.orelse
+        return node
+
+
+def _prune_terminal_tails(statements: list[ast.stmt]) -> list[ast.stmt]:
+    """Remove statements that became unreachable after constant folding."""
+    result: list[ast.stmt] = []
+    for statement in statements:
+        for attribute in ("body", "orelse", "finalbody"):
+            child = getattr(statement, attribute, None)
+            if isinstance(child, list):
+                setattr(statement, attribute, _prune_terminal_tails(child))
+        if isinstance(statement, ast.Try):
+            for handler in statement.handlers:
+                handler.body = _prune_terminal_tails(handler.body)
+        if isinstance(statement, ast.Match):
+            for case in statement.cases:
+                case.body = _prune_terminal_tails(case.body)
+        result.append(statement)
+        if isinstance(statement, (ast.Return, ast.Raise, ast.Break, ast.Continue)):
+            break
+    return result
+
+
+def _function_name(call: ast.Call) -> str:
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    return ""
+
+
+def _offsets(text: str) -> list[int]:
+    offsets = [0]
+    for line in text.splitlines(keepends=True):
+        offsets.append(offsets[-1] + len(line))
+    return offsets
+
+
+def _span(node: ast.AST, offsets: list[int]) -> tuple[int, int]:
+    start = offsets[node.lineno - 1] + node.col_offset
+    end = offsets[node.end_lineno - 1] + node.end_col_offset
+    return start, end
+
+
+def _remove_call_keywords(
+    path: Path,
+    calls: dict[tuple[int, str], set[str]],
+) -> None:
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+    offsets = _offsets(text)
+    replacements: list[tuple[int, int, str]] = []
+    found: set[tuple[int, str]] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        function = _function_name(node)
+        key = (node.lineno, function)
+        parameters = calls.get(key)
+        if not parameters:
+            continue
+        updated = copy.deepcopy(node)
+        present = {keyword.arg for keyword in updated.keywords}
+        if not parameters <= present:
+            missing = ", ".join(sorted(parameters - present))
+            raise ValueError(f"Missing audited call keywords in {path}:{node.lineno}: {missing}")
+        updated.keywords = [
+            keyword for keyword in updated.keywords if keyword.arg not in parameters
+        ]
+        replacements.append((*_span(node, offsets), ast.unparse(updated)))
+        found.add(key)
+    missing_calls = set(calls) - found
+    if missing_calls:
+        raise ValueError(f"Audited calls no longer found in {path}: {sorted(missing_calls)}")
+    for start, end, replacement in sorted(replacements, reverse=True):
+        text = text[:start] + replacement + text[end:]
+    path.write_text(text, encoding="utf-8")
+
+
+def _specialize_definitions(
+    path: Path,
+    functions: dict[str, dict[str, Any]],
+) -> None:
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+    offsets = _offsets(text)
+    replacements: list[tuple[int, int, str]] = []
+    found: set[str] = set()
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name not in functions:
+            continue
+        constants = functions[node.name]
+        kwonly_names = [argument.arg for argument in node.args.kwonlyargs]
+        positional_names = [argument.arg for argument in node.args.args]
+        defaulted_positional = set(
+            positional_names[len(positional_names) - len(node.args.defaults):]
+        )
+        if not set(constants) <= set(kwonly_names) | defaulted_positional:
+            raise ValueError(
+                "Strategy parameters must be keyword-only or defaulted "
+                f"in {path}:{node.lineno}"
+            )
+        transformed = copy.deepcopy(node)
+        positional_defaults = [
+            None
+        ] * (len(transformed.args.args) - len(transformed.args.defaults)) + list(
+            transformed.args.defaults
+        )
+        kept_positional = [
+            (argument, default)
+            for argument, default in zip(
+                transformed.args.args, positional_defaults
+            )
+            if argument.arg not in constants
+        ]
+        transformed.args.args = [argument for argument, _ in kept_positional]
+        transformed.args.defaults = [
+            default for _, default in kept_positional if default is not None
+        ]
+        kept_args = []
+        kept_defaults = []
+        for argument, default in zip(
+            transformed.args.kwonlyargs, transformed.args.kw_defaults
+        ):
+            if argument.arg not in constants:
+                kept_args.append(argument)
+                kept_defaults.append(default)
+        transformed.args.kwonlyargs = kept_args
+        transformed.args.kw_defaults = kept_defaults
+        transformed = _ConstantFolder(constants).visit(transformed)
+        transformed.body = _prune_terminal_tails(transformed.body)
+        ast.fix_missing_locations(transformed)
+        replacements.append((*_span(node, offsets), ast.unparse(transformed)))
+        found.add(node.name)
+    missing = set(functions) - found
+    if missing:
+        raise ValueError(f"Audited definitions no longer found in {path}: {sorted(missing)}")
+    for start, end, replacement in sorted(replacements, reverse=True):
+        text = text[:start] + replacement + text[end:]
+    path.write_text(text, encoding="utf-8")
+
+
+def apply_report(repo_root: Path, report: dict[str, Any]) -> int:
+    repo_root = repo_root.resolve()
+    changed = 0
+    for family in report["families"]:
+        switches = family["fixed_strategy_switches"]
+        if not switches:
+            continue
+        family_dir = (
+            repo_root
+            / "python/tensorrt_model_connect/families"
+            / family["family"]
+        )
+        module_paths = {
+            row["module"]: family_dir / row["path"]
+            for row in family["modules"]
+        }
+        call_edits: dict[Path, dict[tuple[int, str], set[str]]] = defaultdict(
+            lambda: defaultdict(set)
+        )
+        definitions: dict[Path, dict[str, dict[str, Any]]] = defaultdict(
+            lambda: defaultdict(dict)
+        )
+        for switch in switches:
+            for call in switch["call_sites"]:
+                call_edits[family_dir / call["path"]][
+                    (call["line"], switch["function"])
+                ].add(switch["parameter"])
+            for module in switch["definitions"]:
+                definitions[module_paths[module]][switch["function"]][
+                    switch["parameter"]
+                ] = switch["value"]
+        for path, calls in call_edits.items():
+            _remove_call_keywords(path, calls)
+        for path, functions in definitions.items():
+            _specialize_definitions(path, functions)
+        changed += len(switches)
+    return changed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("check", "apply"))
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--family", action="append", default=[])
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    report = family_specialization.audit_repo(repo_root, tuple(args.family))
+    switches = [
+        (family["family"], switch)
+        for family in report["families"]
+        for switch in family["fixed_strategy_switches"]
+    ]
+    if args.command == "check":
+        for family, switch in switches:
+            print(
+                f"{family}: {switch['function']}.{switch['parameter']}="
+                f"{switch['value']!r}"
+            )
+        return 1 if switches else 0
+    changed = 0
+    for _ in range(20):
+        iteration = family_specialization.audit_repo(
+            repo_root, tuple(args.family)
+        )
+        pending = sum(
+            len(family["fixed_strategy_switches"])
+            for family in iteration["families"]
+        )
+        if not pending:
+            break
+        changed += apply_report(repo_root, iteration)
+    else:
+        raise RuntimeError("Family switch specialization did not converge")
+    print(f"specialized_family_switches={changed}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/specialize_family_switches.py
+++ b/tools/specialize_family_switches.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Inline family-fixed strategy switches and remove unsupported branches."""
 
 from __future__ import annotations

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1309,7 +1309,7 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             resolver=_match_result("family_package", _family_models),
             covered_by=(
                 "TestFamilyPlugin.test_family_only_change",
-                "TestFamilyOwnedBuilder.test_family_local_standard_decoder_builder",
+                "TestFamilyOwnedBuilder.test_family_local_model_implementation",
             ),
         ),
         ClassificationRule(
@@ -1341,7 +1341,8 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             name="python_profile_requirements",
             matcher=_regex_rule(
                 r"python/tensorrt_model_connect/"
-                r"families/([^/]+)/python_profile_requirements/[^/]+\.lock\.txt$"
+                r"families/([^/]+)/(?:profiles/requirements|python_profile_requirements)/"
+                r"[^/]+\.lock\.txt$"
             ),
             resolver=_match_result("python_profile_requirements", _python_profile_models),
             covered_by=("TestSharedModules.test_python_profile_requirements_scope",),
@@ -1715,6 +1716,33 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             }),
             resolver=_match_result("model_plugin_validation_tool", _no_models, ["tools"], False),
             covered_by=("TestUnitTiers.test_model_plugin_validation_tools",),
+        ),
+        ClassificationRule(
+            priority=447,
+            name="family_development_tool",
+            matcher=_regex_rule(r"tools/families/([A-Za-z]\w*)/.+\.py$"),
+            resolver=_match_result(
+                "family_development_tool", _family_models, ["tools"], False,
+            ),
+            covered_by=("TestFamilyPlugin.test_family_development_tool",),
+        ),
+        ClassificationRule(
+            priority=448,
+            name="family_ownership_tool",
+            matcher=_path_in({
+                "tools/families/__init__.py",
+                "tools/family_source_isolation.py",
+                "tools/family_specialization.py",
+                "tools/migrate_family_layout.py",
+                "tools/prune_family_helpers.py",
+                "tools/relocate_family_development.py",
+                "tools/specialize_family.py",
+                "tools/specialize_family_switches.py",
+            }),
+            resolver=_match_result(
+                "family_ownership_tool", _no_models, ["tools"], False,
+            ),
+            covered_by=("TestUnitTiers.test_family_ownership_tools",),
         ),
         ClassificationRule(
             priority=450,

--- a/tools/validate_dit.py
+++ b/tools/validate_dit.py
@@ -5,7 +5,7 @@
 """Denoiser validation entrypoint.
 
 Concrete validation behavior is owned by model-family modules under
-``python/tensorrt_model_connect/families/*/validate_dit.py``. This shared tool
+``tools/families/*/validate_dit.py``. This shared tool
 only discovers and dispatches to those handlers.
 """
 
@@ -20,19 +20,25 @@ from types import ModuleType
 from typing import Any
 
 
-def _family_root() -> Path:
+def _family_roots() -> tuple[Path, ...]:
+    repo_root = Path(__file__).resolve().parents[1]
     return (
-        Path(__file__).resolve().parents[1]
-        / "python"
-        / "tensorrt_model_connect"
-        / "families"
+        Path(__file__).resolve().parent / "families",
+        repo_root / "python/tensorrt_model_connect/families",
     )
+
+
+def _family_handler_paths(filename: str) -> list[Path]:
+    handlers: dict[str, Path] = {}
+    for root in reversed(_family_roots()):
+        handlers.update({path.parent.name: path for path in root.glob(f"*/{filename}")})
+    return [handlers[family] for family in sorted(handlers)]
 
 
 @lru_cache(maxsize=1)
 def _family_validation_modules() -> tuple[ModuleType, ...]:
     modules: list[ModuleType] = []
-    for handler_path in sorted(_family_root().glob("*/validate_dit.py")):
+    for handler_path in _family_handler_paths("validate_dit.py"):
         module_name = f"_trtmc_validate_dit_{handler_path.parent.name}"
         spec = importlib.util.spec_from_file_location(module_name, handler_path)
         if spec is None or spec.loader is None:

--- a/tools/validate_t5.py
+++ b/tools/validate_t5.py
@@ -5,7 +5,7 @@
 """Encoder validation entrypoint.
 
 Concrete validation behavior is owned by model-family modules under
-``python/tensorrt_model_connect/families/*/validate_t5.py``. This shared tool
+``tools/families/*/validate_t5.py``. This shared tool
 only discovers and dispatches to those handlers.
 """
 
@@ -20,19 +20,25 @@ from types import ModuleType
 from typing import Any
 
 
-def _family_root() -> Path:
+def _family_roots() -> tuple[Path, ...]:
+    repo_root = Path(__file__).resolve().parents[1]
     return (
-        Path(__file__).resolve().parents[1]
-        / "python"
-        / "tensorrt_model_connect"
-        / "families"
+        Path(__file__).resolve().parent / "families",
+        repo_root / "python/tensorrt_model_connect/families",
     )
+
+
+def _family_handler_paths(filename: str) -> list[Path]:
+    handlers: dict[str, Path] = {}
+    for root in reversed(_family_roots()):
+        handlers.update({path.parent.name: path for path in root.glob(f"*/{filename}")})
+    return [handlers[family] for family in sorted(handlers)]
 
 
 @lru_cache(maxsize=1)
 def _family_validation_modules() -> tuple[ModuleType, ...]:
     modules: list[ModuleType] = []
-    for handler_path in sorted(_family_root().glob("*/validate_t5.py")):
+    for handler_path in _family_handler_paths("validate_t5.py"):
         module_name = f"_trtmc_validate_t5_{handler_path.parent.name}"
         spec = importlib.util.spec_from_file_location(module_name, handler_path)
         if spec is None or spec.loader is None:


### PR DESCRIPTION
## Background
Model-family specialization currently lands as one repository-wide change, which prevents independent review and CI. This prerequisite adds transition tooling that supports legacy and canonical family layouts at the same time.

## Exit Criteria
- A single family can be migrated and validated without requiring sibling families to change.
- Generic graph and scheduler tests resolve owners from either layout without reducing their behavioral assertions.
- Filtered-source tooling can materialize one selected family plus approved shared infrastructure.

## Implementation
- Add migration, specialization, pruning, relocation, and filtered-source tools.
- Add `--family` scoping to layout migration and validation.
- Make generic owner resolution, developer-tool dispatch, and impact classification understand both legacy and canonical paths.
- Point onboarding and performance workflows at the canonical family-owned layout.
- Add focused tests for migration, specialization, source isolation, and impact analysis.

## Validation
- `PYTHONPATH=python python3 -m pytest -q tests/tools/test_family_source_isolation.py tests/tools/test_family_specialization.py tests/tools/test_migrate_family_layout.py tests/tools/test_relocate_family_development.py tests/tools/test_specialize_family.py tests/tools/test_specialize_family_switches.py tests/tools/test_test_impact.py tests/builder/test_owned_schedulers.py`: 251 passed.
- `PYTHONPATH=python python3 -m pytest -q tests/tools/test_cpu_profile_matrix.py tests/tools/test_diff_audio.py tests/tools/test_diff_logits.py tests/tools/test_diff_vl.py tests/tools/test_perf_compare.py`: 128 passed.
- `PYTHONPATH=python python3 -m pytest -q tests/tools/test_model_plugin_encapsulation_static.py`: 155 passed.
- `PYTHONPATH=python python3 -m pytest -q tests/builder/test_checkpoint_mapper.py tests/builder/test_checkpoint_mapper_coverage.py tests/builder/test_graph_ops_extended.py`: 29 passed, 1 skipped.
- `python3 -m ruff check tests/builder/owned_graph_modules.py tests/builder/test_families.py tests/builder/test_owned_schedulers.py tests/tools/test_family_source_isolation.py tests/tools/test_family_specialization.py tests/tools/test_migrate_family_layout.py tests/tools/test_relocate_family_development.py tests/tools/test_specialize_family.py tests/tools/test_specialize_family_switches.py tests/tools/test_test_impact.py tools/families/__init__.py tools/family_source_isolation.py tools/family_specialization.py tools/migrate_family_layout.py tools/prune_family_helpers.py tools/relocate_family_development.py tools/specialize_family.py tools/specialize_family_switches.py tools/test_impact.py`: passed.

## Notes For Future Readers
- This PR intentionally contains no model-family implementation changes.
- The 76 per-family draft PRs are #283 through #358.
- Per-family specialization PRs are based on this branch so each review contains one owner only; retarget them to `main` after this prerequisite merges, then validate and merge them independently.
