### PR TITLE
fix(e2e): complete premerge L0 user contracts

### DIFF
--- a/python/tensorrt_model_connect/families/qwen_moe/__init__.py
+++ b/python/tensorrt_model_connect/families/qwen_moe/__init__.py
@@ -44,6 +44,13 @@ def __dir__() -> list[str]:
 
 class _FamilyModule(types.ModuleType):
     def __setattr__(self, name, value):
+        # Importing ``qwen_moe.plugin`` directly makes importlib publish the
+        # submodule on this package.  Preserve the package API, which exposes
+        # the FamilyPlugin instance as ``qwen_moe.plugin``.
+        if name == "plugin" and isinstance(value, types.ModuleType):
+            super().__setattr__("_plugin", value)
+            super().__setattr__("plugin", value.plugin)
+            return
         super().__setattr__(name, value)
         if (
             not name.startswith("__")

--- a/tests/e2e/models/internvl/manifests/internvl3-2b-tp2.json
+++ b/tests/e2e/models/internvl/manifests/internvl3-2b-tp2.json
@@ -5,6 +5,7 @@
   "family": "internvl",
   "runtime_strategy": "internvl_vision_language",
   "task_strategy": "vision_language_generation",
+  "user_contract": "image-text-to-text",
   "e2e_parallel_resource": "exclusive_gpu",
   "max_cache_length": 384,
   "trust_remote_code": false,

--- a/tests/e2e/models/internvl/manifests/internvl3-2b.json
+++ b/tests/e2e/models/internvl/manifests/internvl3-2b.json
@@ -6,6 +6,7 @@
   "runtime_strategy": "internvl_vision_language",
   "task_strategy": "vision_language_generation",
   "precision": "fp16",
+  "user_contract": "image-text-to-text",
   "max_cache_length": 384,
   "trust_remote_code": false,
   "testcases": [

--- a/tests/e2e/models/internvl/test_internvl_manifest_contract.py
+++ b/tests/e2e/models/internvl/test_internvl_manifest_contract.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """InternVL-owned manifest contract tests."""
 
 from __future__ import annotations

--- a/tests/e2e/models/internvl/test_internvl_manifest_contract.py
+++ b/tests/e2e/models/internvl/test_internvl_manifest_contract.py
@@ -1,0 +1,21 @@
+"""InternVL-owned manifest contract tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.e2e_harness.manifest_loader import load_manifest
+
+
+@pytest.mark.parametrize("manifest_name", ["internvl3-2b.json", "internvl3-2b-tp2.json"])
+def test_internvl3_2b_manifest_declares_hf_image_text_to_text_contract(
+    manifest_name: str,
+) -> None:
+    manifest_path = Path(__file__).with_name("manifests") / manifest_name
+    case = load_manifest(manifest_path)
+
+    assert case.hf_id == "OpenGVLab/InternVL3-2B-hf"
+    assert case.task_strategy == "vision_language_generation"
+    assert case.user_contract == "image-text-to-text"

--- a/tests/e2e/models/locateanything/manifests/locateanything-3b.json
+++ b/tests/e2e/models/locateanything/manifests/locateanything-3b.json
@@ -6,6 +6,7 @@
   "runtime_strategy": "locateanything_vision_language",
   "task_strategy": "vision_language_generation",
   "precision": "fp16",
+  "user_contract": "image-text-to-text",
   "max_cache_length": 384,
   "trust_remote_code": true,
   "testcases": [

--- a/tests/e2e/models/locateanything/test_locateanything_manifest_contract.py
+++ b/tests/e2e/models/locateanything/test_locateanything_manifest_contract.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """LocateAnything-owned manifest contract tests."""
 
 from __future__ import annotations

--- a/tests/e2e/models/locateanything/test_locateanything_manifest_contract.py
+++ b/tests/e2e/models/locateanything/test_locateanything_manifest_contract.py
@@ -1,0 +1,16 @@
+"""LocateAnything-owned manifest contract tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.e2e_harness.manifest_loader import load_manifest
+
+
+def test_locateanything_manifest_declares_hf_image_text_to_text_contract() -> None:
+    manifest_path = Path(__file__).with_name("manifests") / "locateanything-3b.json"
+    case = load_manifest(manifest_path)
+
+    assert case.hf_id == "nvidia/LocateAnything-3B"
+    assert case.task_strategy == "vision_language_generation"
+    assert case.user_contract == "image-text-to-text"

--- a/tests/e2e/models/qwen_moe/test_qwen_moe_builder_tp.py
+++ b/tests/e2e/models/qwen_moe/test_qwen_moe_builder_tp.py
@@ -23,6 +23,12 @@ except (ImportError, ModuleNotFoundError):
     pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
 
 
+def test_direct_plugin_module_import_preserves_package_plugin_api():
+    from tensorrt_model_connect.families import qwen_moe
+
+    assert qwen_moe.plugin is qwen_moe_module.plugin
+
+
 def _config(num_kv_heads: int = 4) -> SimpleNamespace:
     return SimpleNamespace(
         raw={},

--- a/tests/e2e/models/qwen_moe/test_qwen_moe_manifest_contract.py
+++ b/tests/e2e/models/qwen_moe/test_qwen_moe_manifest_contract.py
@@ -1,0 +1,21 @@
+"""Qwen3-MoE-owned manifest contract tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.e2e_harness.manifest_loader import load_manifest
+
+
+def test_tiny_random_qwen3_moe_is_an_explicit_runtime_smoke_case() -> None:
+    """Keep the missing HF contract intentional until HF declares one."""
+    manifest_path = Path(__file__).with_name("manifests") / "qwen3-moe-tiny-random.json"
+    case = load_manifest(manifest_path)
+
+    assert case.hf_id == "amd-quark/tiny-random-qwen3_moe"
+    assert case.task_strategy == "text_generation_causal"
+    assert case.user_contract == ""
+    assert case.metadata["single_process_debug_generation"] is True
+    skip_reason = case.metadata["skip_comparison_reason"]
+    assert "runtime smoke test" in skip_reason
+    assert "HF text parity is not meaningful" in skip_reason

--- a/tests/e2e/models/qwen_moe/test_qwen_moe_manifest_contract.py
+++ b/tests/e2e/models/qwen_moe/test_qwen_moe_manifest_contract.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Qwen3-MoE-owned manifest contract tests."""
 
 from __future__ import annotations
@@ -7,8 +10,8 @@ from pathlib import Path
 from tests.e2e_harness.manifest_loader import load_manifest
 
 
-def test_tiny_random_qwen3_moe_is_an_explicit_runtime_smoke_case() -> None:
-    """Keep the missing HF contract intentional until HF declares one."""
+def test_tiny_random_qwen3_moe_does_not_infer_an_hf_contract() -> None:
+    """Keep the missing HF contract explicit while allowing HF parity."""
     manifest_path = Path(__file__).with_name("manifests") / "qwen3-moe-tiny-random.json"
     case = load_manifest(manifest_path)
 
@@ -16,6 +19,5 @@ def test_tiny_random_qwen3_moe_is_an_explicit_runtime_smoke_case() -> None:
     assert case.task_strategy == "text_generation_causal"
     assert case.user_contract == ""
     assert case.metadata["single_process_debug_generation"] is True
-    skip_reason = case.metadata["skip_comparison_reason"]
-    assert "runtime smoke test" in skip_reason
-    assert "HF text parity is not meaningful" in skip_reason
+    assert "skip_comparison" not in case.metadata
+    assert "skip_comparison_reason" not in case.metadata

--- a/tests/e2e_harness/contracts.py
+++ b/tests/e2e_harness/contracts.py
@@ -206,7 +206,6 @@ class UserContract(enum.Enum):
     RANKING_ORDER = "ranking_order"
     VL_ANSWER = "vl_answer"
     OCR_TEXT = "ocr_text"
-    IMAGE_TEXT_TO_TEXT = "image-text-to-text"
     DIFFUSION_IMAGE = "diffusion_image"
     DIFFUSION_VIDEO = "diffusion_video"
     DIFFUSION_TEXT_GENERATION = "diffusion_text_generation"

--- a/tests/e2e_harness/contracts.py
+++ b/tests/e2e_harness/contracts.py
@@ -206,6 +206,7 @@ class UserContract(enum.Enum):
     RANKING_ORDER = "ranking_order"
     VL_ANSWER = "vl_answer"
     OCR_TEXT = "ocr_text"
+    IMAGE_TEXT_TO_TEXT = "image-text-to-text"
     DIFFUSION_IMAGE = "diffusion_image"
     DIFFUSION_VIDEO = "diffusion_video"
     DIFFUSION_TEXT_GENERATION = "diffusion_text_generation"


### PR DESCRIPTION
## Background

The Premerge L0 coverage report identified InternVL3 and LocateAnything cases without the user contract declared by their canonical Hugging Face model metadata. Enabling the TensorRT-backed Qwen-MoE tests also exposed a lazy package export regression that prevented the existing runtime validation from executing correctly.

## Exit Criteria

- InternVL3 and LocateAnything manifests declare the canonical Hugging Face `image-text-to-text` contract.
- The tiny-random Qwen3-MoE case does not invent a user contract that its Hugging Face repository does not declare, while its HF parity comparison remains enabled.
- Direct Qwen-MoE plugin-module imports preserve the public `FamilyPlugin` instance and family discovery behavior.

## Implementation

- Added `image-text-to-text` directly to the two InternVL execution variants and LocateAnything, keeping the contract model-owned rather than extending the global enum.
- Added model-owned manifest regression tests, including coverage that the tiny-random Qwen3-MoE checkpoint has no inferred contract and no comparison skip.
- Preserved the Qwen-MoE plugin instance when importlib publishes the directly imported plugin submodule, with a focused regression test for the package API.
- Rebasing onto current `main` retains the grouped manifest schema and the composite-stage isolation verification introduced by #371.

## Validation

- `PYTHONPATH=python:tools:. python3 -m pytest -q -rs tests/e2e/models/qwen_moe/test_qwen_moe_manifest_contract.py tests/e2e/models/qwen_moe/test_qwen_moe_family_plugin.py tests/e2e/models/qwen_moe/test_qwen_moe_builder_tp.py tests/e2e/models/internvl --ignore=tests/e2e/models/internvl/test_internvl_e2e.py tests/e2e/models/locateanything --ignore=tests/e2e/models/locateanything/test_locateanything_e2e.py`: 43 passed.
- `python3 -m pytest -q tests/tools/test_model_plugin_isolation.py`: 45 passed.
- `python3 tools/legal_headers.py --check`: passed with no findings.
- `python3 tools/test_impact.py --validate`: passed for 195 models, 12 core models, and 76 families; existing warnings remain.
- Ruff checks and `git diff --check`: passed.

## Notes For Future Readers

- Review the manifest contract changes and their model-owned tests first, then the independent Qwen-MoE lazy export fix.
- Do not assign an inferred contract to the tiny-random Qwen3-MoE checkpoint unless its canonical Hugging Face repository declares one.
