### PR TITLE
test(ci): probe RT-S5-BATCH conditioning

### DIFF
--- a/src/runtime/models/flux/pipeline.cpp
+++ b/src/runtime/models/flux/pipeline.cpp
@@ -1659,7 +1659,7 @@ bool FluxPipeline::prepare_flux_batch_conditioning(
     std::vector<float>& encoder_hidden_batch, std::vector<float>& cos_batch,
     std::vector<float>& sin_batch, std::vector<float>& latents_batch) {
     const bool is_flux2 = !weights_.vae_bn_mean.empty();
-    const auto chunk_end = chunk_begin + static_cast<std::size_t>(B);
+    const auto chunk_end = chunk_begin + 1;
 
     // 1-3. Prompt prep + tokenize + generation plan.
     std::vector<std::vector<int32_t>> per_sample_input_ids;


### PR DESCRIPTION
> **DO NOT MERGE - disposable CI red-team probe**

- Plan version: 3.1
- Campaign: Campaign 1
- Probe ID: `RT-S5-BATCH`
- Assurance claim: `G-SEAM`
- Lifecycle seam: `S5 Profile`
- Invariant: every batch size declared by the bundle profile executes with independent per-sample conditioning
- Baseline SHA: `c6462c95d2acec3e329398775006f6e4995a3954`
- Expected detector: real-bundle FLUX batch E2E
- Expected result: the batch E2E gate fails; a green required-check set is classified as `Escaped`

## Background

The CI red-team plan identifies the absence of batch-above-one manifest coverage as the first Campaign 1 gap. This disposable mutation tests whether CI exercises the FLUX runtime with a real bundle at batch size greater than one.

## Exit Criteria

- CI selection and execution evidence shows whether a real FLUX batch-above-one path ran.
- The first observed detector and final required-check verdict are recorded before this draft PR is closed.
- This mutation is never merged.

## Implementation

- Restrict FLUX batched prompt preparation to the first sample of each multi-sample chunk.
- Preserve the batch-one legacy fast path unchanged.
- Leave all detectors, manifests, thresholds, and expected outputs unchanged.

## Validation

- `python3 -m pytest -q tests/e2e/models/flux/test_flux_manifest_contract.py tests/e2e/models/flux/test_flux_dit_batch_profile.py tests/builder/test_max_batch_size_cli.py tests/builder/test_bundle_writer.py`: passed, 23 tests before the mutation.
- The same command after the mutation: passed, 23 tests, demonstrating that the existing local controls do not execute the corrupted multi-sample runtime path.
- Real-bundle GPU execution was not run locally; observing that detector is the purpose of this draft PR.

## Notes For Future Readers

- Review the single changed line in `FluxPipeline::prepare_flux_batch_conditioning` first.
- A fully green CI result is evidence of an S5 coverage escape, not evidence that the mutation is safe.
- No ADR is appropriate for this disposable probe.
