### PR TITLE
[codex] test(ci): exercise single-model selection

### DIFF
--- a/tests/e2e/models/distilbert/MODEL.toml
+++ b/tests/e2e/models/distilbert/MODEL.toml
@@ -4,6 +4,7 @@
 id = "distilbert"
 plugin = "distilbert"
 test_manifests = [
+  # Keep selective premerge coverage scoped to this model-owned family.
   "manifests/distilbert-base-uncased-tp4.json",
   "manifests/distilbert-base-uncased.json",
 ]


### PR DESCRIPTION
## Background

Exercise the post-legal-merge required checks with the smallest practical model-owned, behavior-neutral change.

## Exit Criteria

- Selective impact analysis chooses exactly one single-device E2E model.
- Legal compliance and Premerge CI run successfully on a branch based on current `main`.
- No runtime behavior or test passing criteria change.

## Implementation

- Add one TOML comment to the DistilBERT model index.
- Leave model manifests, source code, tests, and CI configuration unchanged.

## Validation

- `python3 tools/test_impact.py --base github/main --head HEAD --json`: selected only `distilbert-base-uncased`, with no unit tiers and no C++ rebuild.
- `python3 tools/model_plugin_isolation.py impact-models --impact-json /tmp/single-model-impact.json`: reported only `distilbert-base-uncased`.
- `python3 tools/test_impact.py --validate`: passed with advisory warnings.
- `PYTHONPATH=python python3 -m pytest -q --collect-only tests/e2e/models/distilbert/test_distilbert_e2e.py`: collected exactly one test.
- `python3 tools/legal_headers.py --check`: passed with zero findings.

## Notes For Future Readers

This PR is intentionally a one-line smoke probe for selective model CI after legal compliance landed.
