### PR TITLE
[codex] test(ci): verify two-model selection

### DIFF
--- a/python/tensorrt_model_connect/families/convbert/MODEL.toml
+++ b/python/tensorrt_model_connect/families/convbert/MODEL.toml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# CI ownership sample: ConvBERT in a two-model change.
 id = "convbert"
 plugin = "convbert"
 module = "plugin"

--- a/python/tensorrt_model_connect/families/distilbert/MODEL.toml
+++ b/python/tensorrt_model_connect/families/distilbert/MODEL.toml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# CI ownership sample: DistilBERT in a two-model change.
 id = "distilbert"
 plugin = "distilbert"
 module = "plugin"


### PR DESCRIPTION
## Background

Validation-only child of #377. This draft changes only the ConvBERT and DistilBERT manifests, using comments that do not alter runtime behavior.

## Exit Criteria

- Select only ConvBERT and DistilBERT.
- Build and test each model from a positive projection with every sibling model physically absent.
- Produce exactly one model DSO, zero sibling dependencies, an offline Hugging Face comparison, and a standalone HTML report for each model.
- Pass the final required gate in a few minutes of active runner time.

## Final Demonstration

[One-shot run 28937736565](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/28937736565) passed against pinned merge revision `5a09d887f2cba5aefc67905315bcf9e11cadd2bc`.

- `run-ci` was consumed after the revision was pinned.
- Legal and Impact passed; Impact selected exactly `convbert` and `distilbert`.
- The graph used one bounded batch node. ConvBERT ran on GPU 0 and DistilBERT on GPU 1; no global package, coverage, Graph Ops, or all-model E2E job ran.
- The parallel proof step took 3m46s; the complete runner job took 4m43s. The preceding 5h35m55s was external single-runner queue time.
- Both projections retained 82 model-owned and 429 platform files while excluding 7,298 sibling-model files.
- Each scratch build produced exactly one model DSO and zero sibling files or DSO dependencies. Network access was disabled and strict plugin search was enabled.
- ConvBERT: C++ 1/1 passed, Python 7 passed with 1 skip, and E2E 1/1 passed with Hugging Face cosine `0.998508334` against threshold `0.95`.
- DistilBERT: C++ 1/1 passed, Python 12/12 passed, and E2E 1/1 passed with Hugging Face cosine `0.999998868` against threshold `0.999`.
- Batch result: 2 expected, 2 run, 2 passed, 0 failed, 0 interrupted, 0 queued. The final `Premerge CI` gate passed.

## Reports

- [Full proof evidence](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/28937736565/artifacts/8175527849): status, proof JSON, logs, JUnit, isolation metadata, and comparison evidence.
- [Standalone HTML reports](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/28937736565/artifacts/8175528426): batch index plus real, non-fallback ConvBERT and DistilBERT reports.

## Notes For Future Readers

- Checkout, immutable image verification, and cache readiness ran once for the batch; model builds and tests remained isolated.
- Keep this PR as validation evidence only. Do not merge it.
