### PR TITLE
[codex] test(ci): reject cross-model dependency

### DIFF
--- a/python/tensorrt_model_connect/families/distilbert/plugin.py
+++ b/python/tensorrt_model_connect/families/distilbert/plugin.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 import numpy as np
 
+from ..convbert.config import ModelConfig as _ConvBertModelConfig
 from .config import ModelConfig
 from .checkpoint_mapper import (
     WeightDict,
@@ -37,7 +38,10 @@ from ...parallel_config import (
     normalize_parallel_config,
     require_tensorrt_11_for_tensor_parallel,
 )
+
 from .encoder_builder import build_encoder_engine
+
+_CROSS_MODEL_DEPENDENCY_PROBE = _ConvBertModelConfig
 
 
 class DistilBertPlugin:


### PR DESCRIPTION
## Background

Validation-only child of #377. This draft intentionally adds a DistilBERT import from ConvBERT to prove that a hidden cross-model source dependency is rejected.

## Final-flow demonstration

[One-shot workflow run 28937736406](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/28937736406) produced the expected rejection against pinned merge snapshot `e964d11481650a99270e4edff67328f4ae2daaaf`.

- `run-ci` was consumed after GitHub pinned the snapshot.
- `Legal compliance` passed.
- `Ownership and impact` selected exactly `distilbert` from the one modified DistilBERT-owned file.
- No ConvBERT proof, unrelated model proof, global coverage stage, or all-model E2E stage ran.
- The isolated proof ran for 72 seconds after runner acquisition; the DistilBERT proof itself failed in 33 seconds. The preceding 3h13m delay was solely the repository's single-runner queue.
- The positive projection excluded all 7,298 sibling-model files, built exactly one DistilBERT DSO, and passed its C++ test.
- Python collection then failed on the intentional import with `ModuleNotFoundError: No module named 'tensorrt_model_connect.families.convbert'`.
- The required `Premerge CI` gate remained red. No test or acceptance criterion was weakened.

## Failure report

The failed proof still uploaded both required downloadable artifacts:

- [Full proof evidence](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/28937736406/artifacts/8171173798): status, logs, JUnit, projection metadata, and diagnostics.
- [Standalone HTML failure report](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/28937736406/artifacts/8171174355): the human-readable report and batch index.

The HTML report contains the rejected import, exact error, pinned snapshot, isolation evidence, and every stage that completed before the intentional failure. Media evidence is correctly absent because execution stopped before E2E.

Do not merge this intentionally failing validation draft.
