### PR TITLE
test(e2e): cover FLUX batch runtime

### DIFF
--- a/src/cli/args.cpp
+++ b/src/cli/args.cpp
@@ -648,8 +648,7 @@ CliArgs parse_args(int argc, char** argv) {
         }
     }
 
-    if (args.command == "run" && !args.bundle_path.empty() && !args.prompt_provided &&
-        args.prompts_file.empty()) {
+    if (args.command == "run" && !args.bundle_path.empty() && !has_run_prompt_source(args)) {
         args.parse_error = true;
         args.error_message = "run requires bundle + --prompt or --prompts-file";
     }

--- a/src/cli/args.h
+++ b/src/cli/args.h
@@ -89,6 +89,10 @@ struct CliArgs {
     std::vector<std::uint64_t> seed_list;
 };
 
+inline bool has_run_prompt_source(const CliArgs& args) {
+    return args.prompt_provided || !args.prompts_file.empty();
+}
+
 std::optional<std::uint64_t> parse_byte_size(const std::string& text);
 // Parse a CSV of unsigned-64 integers (e.g. "0,1,2"). Returns nullopt when
 // any token fails to parse. Empty string returns an empty vector wrapped

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -384,8 +384,8 @@ int cmd_run(const CliArgs& args) {
         std::cerr << "Error: run requires a .trtfb bundle file\n";
         return EXIT_FAILURE;
     }
-    if (!args.prompt_provided) {
-        std::cerr << "Error: run requires bundle + --prompt\n";
+    if (!trtmc::cli::has_run_prompt_source(args)) {
+        std::cerr << "Error: run requires bundle + --prompt or --prompts-file\n";
         return EXIT_FAILURE;
     }
 

--- a/tests/cpp/test_cli_args.cpp
+++ b/tests/cpp/test_cli_args.cpp
@@ -311,6 +311,12 @@ void test_prompt_and_prompts_file_mutually_exclusive() {
           "prompt+prompts-file error message");
 }
 
+void test_prompts_file_is_run_prompt_source() {
+    auto args = parse({"trtmc", "run", "bundle.trtfb", "--prompts-file", "prompts.txt"});
+    check(!args.parse_error, "prompts-file run parses cleanly");
+    check(trtmc::cli::has_run_prompt_source(args), "prompts-file satisfies run prompt guard");
+}
+
 } // namespace
 
 int main() {
@@ -334,6 +340,7 @@ int main() {
     test_num_images_zero_fails();
     test_seed_csv_populates_seed_list();
     test_prompt_and_prompts_file_mutually_exclusive();
+    test_prompts_file_is_run_prompt_source();
 
     if (failures) {
         std::cerr << failures << " CLI parser tests failed\n";

--- a/tests/e2e/models/flux/MODEL.toml
+++ b/tests/e2e/models/flux/MODEL.toml
@@ -11,6 +11,7 @@ test_manifests = [
   "manifests/flux-2-dev-l0.json",
   "manifests/flux-2-dev.json",
   "manifests/flux-schnell-l0-tp4.json",
+  "manifests/flux-schnell-l0-batch2.json",
   "manifests/flux-schnell-l0.json",
   "manifests/flux-schnell.json",
 ]
@@ -29,6 +30,7 @@ input_fields = [
   { input = "video_height", manifest = "video_height", default = 480, required_manifest = "video_num_frames" },
   { input = "video_width", manifest = "video_width", default = 832, required_manifest = "video_num_frames" },
   { input = "num_inference_steps", manifest = "num_inference_steps", default = 30, required_manifest = "video_num_frames" },
+  { input = "max_batch_size", manifest = "max_batch_size" },
 ]
 preflight_requirements = [
   { kind = "python_module_available", args = { module = "diffusers", phase = "build" }, gating = true },
@@ -41,4 +43,5 @@ build_cli_args = [
   { flag = "--video-width", input = "video_width" },
   { flag = "--video-num-frames", input = "video_num_frames" },
   { flag = "--num-inference-steps", input = "num_inference_steps" },
+  { flag = "--max-batch-size", input = "max_batch_size" },
 ]

--- a/tests/e2e/models/flux/e2e_plugins/contract.py
+++ b/tests/e2e/models/flux/e2e_plugins/contract.py
@@ -80,6 +80,27 @@ def _pixel_metrics(output, thresholds: dict[str, float]) -> dict[str, MetricResu
     }
 
 
+def _minimum_pairwise_pixel_mae(frames_dir: str) -> float | None:
+    try:
+        import numpy as np
+        from PIL import Image
+    except ImportError:
+        return None
+
+    frame_paths = sorted(Path(frames_dir).glob("frame_*.png"))
+    if len(frame_paths) < 2:
+        return None
+    frames = [
+        np.asarray(Image.open(path).convert("RGB"), dtype=np.float32) / 255.0
+        for path in frame_paths
+    ]
+    return min(
+        float(np.mean(np.abs(frames[left] - frames[right])))
+        for left in range(len(frames))
+        for right in range(left + 1, len(frames))
+    )
+
+
 class FluxDiffusionImagePlugin:
     reference_families = ["diffusers_image_gen"]
     user_contract = "diffusion_image"
@@ -90,7 +111,6 @@ class FluxDiffusionImagePlugin:
         return config
 
     def verify(self, trt_output, ref_output, case, threshold):
-        del case
         stage = trt_output.stage_name or "end_to_end"
         metrics = {
             "trt_returncode": _returncode_metric("trt", trt_output),
@@ -100,26 +120,46 @@ class FluxDiffusionImagePlugin:
 
         final_stages = {"end_to_end", "end_to_end_video", "generate", "frame_quality"}
         if stage in final_stages:
-            min_frames = int(threshold.metrics.get("contract_min_num_frames", 1))
+            expected_batch_size = int(case.inputs.get("expected_batch_size", 1))
+            min_frames = int(threshold.metrics.get(
+                "contract_min_num_frames", expected_batch_size))
             trt_frames = int((trt_output.data or {}).get("num_frames", 0))
             ref_frames = int((ref_output.data or {}).get("num_frames", 0))
+            exact_batch = expected_batch_size > 1
             metrics["trt_num_frames"] = MetricResult(
                 value=float(trt_frames),
-                threshold=float(min_frames),
-                operator=">=",
-                passed=trt_frames >= min_frames,
+                threshold=float(expected_batch_size if exact_batch else min_frames),
+                operator="==" if exact_batch else ">=",
+                passed=(trt_frames == expected_batch_size if exact_batch
+                        else trt_frames >= min_frames),
             )
             metrics["reference_num_frames"] = MetricResult(
                 value=float(ref_frames),
-                threshold=1.0,
-                operator=">=",
-                passed=ref_frames >= 1,
+                threshold=float(expected_batch_size if exact_batch else 1),
+                operator="==" if exact_batch else ">=",
+                passed=(ref_frames == expected_batch_size if exact_batch
+                        else ref_frames >= 1),
             )
             metrics["trt_frames_dir_present"] = _frame_dir_metric("trt", trt_output)
             metrics["reference_frames_dir_present"] = _frame_dir_metric("reference", ref_output)
+            if exact_batch:
+                frames_dir = str((trt_output.data or {}).get("frames_dir", ""))
+                pairwise_mae = _minimum_pairwise_pixel_mae(frames_dir)
+                min_mae = float(threshold.metrics.get(
+                    "batch_min_pairwise_pixel_mae", 0.001))
+                metrics["batch_pairwise_pixel_mae"] = MetricResult(
+                    value=float(pairwise_mae or 0.0),
+                    threshold=min_mae,
+                    operator=">=",
+                    passed=pairwise_mae is not None and pairwise_mae >= min_mae,
+                    note="distinct prompts use the same seed",
+                )
 
         passed = all(metric.passed for metric in metrics.values())
-        rule = "returncodes are zero AND generated frame artifacts exist AND pixel stats pass"
+        rule = (
+            "returncodes are zero AND expected frame count exists AND "
+            "batch outputs are distinct AND pixel stats pass"
+        )
         if passed:
             return _make_pass(stage, metrics, rule)
         return _make_fail(stage, metrics, rule, "Flux diffusion image contract failed")

--- a/tests/e2e/models/flux/e2e_plugins/references/hf_diffusers.py
+++ b/tests/e2e/models/flux/e2e_plugins/references/hf_diffusers.py
@@ -91,6 +91,13 @@ class HfDiffusersReference:
     ) -> StageOutput:
         model_ref = _resolve_cached_model_ref(case.hf_id)
         prompt = case.inputs.get("prompt", "A cat sitting on a beach")
+        batch_prompts = case.inputs.get("batch_prompts")
+        if not isinstance(batch_prompts, list) or len(batch_prompts) < 2:
+            batch_prompts = [prompt]
+        batch_seeds = case.inputs.get("batch_seeds")
+        if not isinstance(batch_seeds, list) or len(batch_seeds) != len(batch_prompts):
+            seed = int(case.inputs.get("seed", case.determinism.get("seed", 42)))
+            batch_seeds = [seed] * len(batch_prompts)
         num_steps = case.inputs.get("num_inference_steps", 30)
         image_height = case.inputs.get("image_height", 1024)
         image_width = case.inputs.get("image_width", image_height)
@@ -124,14 +131,14 @@ import transformers
 transformers.logging.set_verbosity_error()
 
 model_ref = {model_ref!r}
-prompt = {prompt!r}
+prompts = {batch_prompts!r}
+batch_seeds = {batch_seeds!r}
 num_steps = {num_steps}
 image_height = {image_height}
 image_width = {image_width}
 model_type = {model_type!r}
 guidance_scale = {guidance_scale!r}
 frames_dir = {frames_dir!r}
-seed = {int(case.inputs.get("seed", case.determinism.get("seed", 42)))}
 reference_torch_dtype = {reference_torch_dtype}
 
 if model_type in ("flux.2", "flux2"):
@@ -144,11 +151,13 @@ else:
         model_ref, torch_dtype=reference_torch_dtype)
 pipe.to("cuda")
 kwargs = dict(
-    prompt=prompt,
+    prompt=prompts if len(prompts) > 1 else prompts[0],
     num_inference_steps=num_steps,
     height=image_height,
     width=image_width,
-    generator=torch.Generator("cuda").manual_seed(seed),
+    generator=[torch.Generator("cuda").manual_seed(seed) for seed in batch_seeds]
+        if len(batch_seeds) > 1
+        else torch.Generator("cuda").manual_seed(batch_seeds[0]),
 )
 if model_type in ("flux.2", "flux2"):
     kwargs["guidance_scale"] = 3.5 if guidance_scale is None else guidance_scale
@@ -184,6 +193,7 @@ print(f"Generated {{len(frames)}} frames")
                 "frames_dir": frames_dir,
                 "stdout": result.stdout,
                 "stderr": result.stderr,
+                "prompts": batch_prompts,
             },
             text=result.stdout,
             timing_s=elapsed,

--- a/tests/e2e/models/flux/e2e_plugins/runners/diffusion.py
+++ b/tests/e2e/models/flux/e2e_plugins/runners/diffusion.py
@@ -372,6 +372,12 @@ class DiffusionMediaRunner:
                 _strip_mpi_stream_tags(result.stderr)
                 if distributed_runtime else result.stderr
             )
+            if result.returncode != 0:
+                logger.error(
+                    "Flux TRT runtime failed (rc=%d): %s",
+                    result.returncode,
+                    stderr_text[-2000:],
+                )
 
             # Count frames
             frame_files = sorted(Path(output_frame_dir).glob("frame_*.png"))

--- a/tests/e2e/models/flux/e2e_plugins/runners/diffusion.py
+++ b/tests/e2e/models/flux/e2e_plugins/runners/diffusion.py
@@ -287,21 +287,47 @@ class DiffusionMediaRunner:
         bundle_path = _resolve_bundle_path(case, ctx)
         binary = ctx.binary_path
         prompt = case.inputs.get("prompt", "A cat sitting on a beach")
+        batch_prompts = case.inputs.get("batch_prompts")
+        if not isinstance(batch_prompts, list) or len(batch_prompts) < 2:
+            batch_prompts = None
+        batch_seeds = case.inputs.get("batch_seeds")
+        if batch_prompts and (
+            not isinstance(batch_seeds, list) or len(batch_seeds) != len(batch_prompts)
+        ):
+            return StageOutput(
+                stage_name=stage.name,
+                data={
+                    "returncode": -1,
+                    "error": "batch_seeds must match batch_prompts",
+                },
+                metadata={"status": "invalid_batch_contract"},
+            )
         num_steps = case.inputs.get("num_inference_steps", 30)
         ld_path = _build_ld_library_path(ctx)
 
         with tempfile.TemporaryDirectory(prefix="trtmc_frames_") as frame_dir:
-            cmd = [
-                binary, "generate-video", bundle_path,
-                "--prompt", prompt,
-                "--num-steps", str(num_steps),
-            ]
+            if batch_prompts:
+                prompts_path = Path(frame_dir) / "prompts.txt"
+                prompts_path.write_text("\n".join(batch_prompts) + "\n", encoding="utf-8")
+                cmd = [
+                    binary, "run", bundle_path,
+                    "--prompts-file", str(prompts_path),
+                    "--seed", ",".join(str(seed) for seed in batch_seeds),
+                    "--num-steps", str(num_steps),
+                ]
+                output_target = str(Path(frame_dir) / "frame.png")
+            else:
+                cmd = [
+                    binary, "generate-video", bundle_path,
+                    "--prompt", prompt,
+                    "--num-steps", str(num_steps),
+                ]
+                output_target = frame_dir
             guidance_scale = case.inputs.get("guidance_scale")
             if guidance_scale is not None:
                 cmd.extend(["--guidance-scale", str(guidance_scale)])
             if "seed" in case.inputs:
                 cmd.extend(["--seed", str(case.inputs["seed"])])
-            output_target = frame_dir
             runtime_cli_python = ctx.runtime_cli_hf_python()
             if runtime_cli_python:
                 cmd.extend(["--hf-python", runtime_cli_python])
@@ -385,6 +411,7 @@ class DiffusionMediaRunner:
                 "stderr": stderr_truncated,
                 # Passed through to the comparator for CLIP semantic metrics.
                 "prompt": case.inputs.get("prompt") or case.inputs.get("test_prompt"),
+                "prompts": batch_prompts or [prompt],
             }
             if stderr_log:
                 e2e_data["stderr_log"] = stderr_log

--- a/tests/e2e/models/flux/manifests/flux-schnell-l0-batch2.json
+++ b/tests/e2e/models/flux/manifests/flux-schnell-l0-batch2.json
@@ -38,5 +38,10 @@
     }
   ],
   "skip_text_comparison": true,
+  "metadata": {
+    "contract_config": {
+      "use_diffusers": true
+    }
+  },
   "notes": "Builds a dynamic B=1..2 bundle and executes two distinct prompts with identical seeds in one batch. The outputs must both exist and differ, proving per-sample conditioning is preserved."
 }

--- a/tests/e2e/models/flux/manifests/flux-schnell-l0-batch2.json
+++ b/tests/e2e/models/flux/manifests/flux-schnell-l0-batch2.json
@@ -1,0 +1,42 @@
+{
+  "name": "flux-schnell-l0-batch2",
+  "trace_id": "IT-E2E-FLXS-L0-B2-01",
+  "hf_id": "black-forest-labs/FLUX.1-schnell",
+  "bundle": "flux-schnell-l0-batch2.trtfb",
+  "model_type": "flux",
+  "family": "flux",
+  "runtime_strategy": "diffusion_flux",
+  "task_strategy": "diffusion_media_generation",
+  "gated": true,
+  "e2e_parallel_resource": "exclusive_gpu",
+  "ci_tier": "l0_only",
+  "reference_family": "diffusers_image_gen",
+  "user_contract": "diffusion_image",
+  "description": "FLUX.1-schnell real-bundle batch-two contract at reduced L0 scale",
+  "build_args": {
+    "max_cache_length": 256
+  },
+  "inputs": {
+    "batch_prompts": [
+      "A red cube on a white table",
+      "A blue sphere on a white table"
+    ],
+    "batch_seeds": [42, 42],
+    "expected_batch_size": 2
+  },
+  "max_batch_size": 2,
+  "test_prompt": "A red cube on a white table",
+  "test_type": "diffusion",
+  "image_height": 384,
+  "image_width": 384,
+  "video_num_frames": 1,
+  "num_inference_steps": 20,
+  "stages": [
+    {
+      "name": "end_to_end",
+      "required": true
+    }
+  ],
+  "skip_text_comparison": true,
+  "notes": "Builds a dynamic B=1..2 bundle and executes two distinct prompts with identical seeds in one batch. The outputs must both exist and differ, proving per-sample conditioning is preserved."
+}

--- a/tests/e2e/models/flux/manifests/flux-schnell-l0-batch2.json
+++ b/tests/e2e/models/flux/manifests/flux-schnell-l0-batch2.json
@@ -1,47 +1,53 @@
 {
   "name": "flux-schnell-l0-batch2",
-  "trace_id": "IT-E2E-FLXS-L0-B2-01",
   "hf_id": "black-forest-labs/FLUX.1-schnell",
   "bundle": "flux-schnell-l0-batch2.trtfb",
-  "model_type": "flux",
   "family": "flux",
   "runtime_strategy": "diffusion_flux",
   "task_strategy": "diffusion_media_generation",
-  "gated": true,
   "e2e_parallel_resource": "exclusive_gpu",
-  "ci_tier": "l0_only",
-  "reference_family": "diffusers_image_gen",
-  "user_contract": "diffusion_image",
-  "description": "FLUX.1-schnell real-bundle batch-two contract at reduced L0 scale",
   "build_args": {
     "max_cache_length": 256
   },
-  "inputs": {
-    "batch_prompts": [
-      "A red cube on a white table",
-      "A blue sphere on a white table"
-    ],
-    "batch_seeds": [42, 42],
-    "expected_batch_size": 2
-  },
   "max_batch_size": 2,
-  "test_prompt": "A red cube on a white table",
-  "test_type": "diffusion",
-  "image_height": 384,
-  "image_width": 384,
-  "video_num_frames": 1,
-  "num_inference_steps": 20,
-  "stages": [
+  "precision": "fp16",
+  "testcases": [
     {
-      "name": "end_to_end",
-      "required": true
+      "name": "flux-schnell-l0-batch2",
+      "trace_id": "IT-E2E-FLXS-L0-B2-01",
+      "model_type": "flux",
+      "gated": true,
+      "ci_tier": "l0_only",
+      "reference_family": "diffusers_image_gen",
+      "user_contract": "diffusion_image",
+      "description": "FLUX.1-schnell real-bundle batch-two contract at reduced L0 scale",
+      "inputs": {
+        "batch_prompts": [
+          "A red cube on a white table",
+          "A blue sphere on a white table"
+        ],
+        "batch_seeds": [42, 42],
+        "expected_batch_size": 2
+      },
+      "test_prompt": "A red cube on a white table",
+      "test_type": "diffusion",
+      "image_height": 384,
+      "image_width": 384,
+      "video_num_frames": 1,
+      "num_inference_steps": 20,
+      "stages": [
+        {
+          "name": "end_to_end",
+          "required": true
+        }
+      ],
+      "skip_text_comparison": true,
+      "metadata": {
+        "contract_config": {
+          "use_diffusers": true
+        }
+      },
+      "notes": "Builds a dynamic B=1..2 bundle and executes two distinct prompts with identical seeds in one batch. The outputs must both exist and differ, proving per-sample conditioning is preserved."
     }
-  ],
-  "skip_text_comparison": true,
-  "metadata": {
-    "contract_config": {
-      "use_diffusers": true
-    }
-  },
-  "notes": "Builds a dynamic B=1..2 bundle and executes two distinct prompts with identical seeds in one batch. The outputs must both exist and differ, proving per-sample conditioning is preserved."
+  ]
 }

--- a/tests/e2e/models/flux/test_flux_batch_contract.py
+++ b/tests/e2e/models/flux/test_flux_batch_contract.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from PIL import Image
+
+from tests.e2e.models.flux.e2e_plugins.contract import FluxDiffusionImagePlugin
+from tests.e2e_harness.contracts import E2ECase, StageOutput, ThresholdProfile
+
+
+def _write_frame(path, color: tuple[int, int, int]) -> None:
+    Image.new("RGB", (4, 4), color=color).save(path)
+
+
+def _case() -> E2ECase:
+    return E2ECase(
+        name="flux-batch2",
+        hf_id="example/flux",
+        family="flux",
+        runtime_strategy="diffusion_flux",
+        inputs={"expected_batch_size": 2},
+    )
+
+
+def _threshold() -> ThresholdProfile:
+    return ThresholdProfile(
+        task_strategy="diffusion_media_generation",
+        metrics={
+            "min_pixel_mean": 0.0,
+            "max_pixel_mean": 1.0,
+            "min_pixel_std": 0.0,
+            "batch_min_pairwise_pixel_mae": 0.01,
+        },
+    )
+
+
+def _output(frames_dir) -> StageOutput:
+    return StageOutput(
+        stage_name="end_to_end",
+        data={
+            "returncode": 0,
+            "num_frames": 2,
+            "frames_dir": str(frames_dir),
+            "frame_stats": {"mean": 0.5, "std": 0.2},
+        },
+    )
+
+
+def test_flux_batch_contract_accepts_two_distinct_outputs(tmp_path) -> None:
+    trt_dir = tmp_path / "trt"
+    ref_dir = tmp_path / "ref"
+    trt_dir.mkdir()
+    ref_dir.mkdir()
+    _write_frame(trt_dir / "frame_0.png", (255, 0, 0))
+    _write_frame(trt_dir / "frame_1.png", (0, 0, 255))
+    _write_frame(ref_dir / "frame_0.png", (255, 0, 0))
+    _write_frame(ref_dir / "frame_1.png", (0, 0, 255))
+
+    result = FluxDiffusionImagePlugin().verify(
+        _output(trt_dir), _output(ref_dir), _case(), _threshold())
+
+    assert result.passed
+    assert result.metrics["trt_num_frames"].value == 2
+    assert result.metrics["batch_pairwise_pixel_mae"].passed
+
+
+def test_flux_batch_contract_rejects_duplicate_outputs(tmp_path) -> None:
+    trt_dir = tmp_path / "trt"
+    ref_dir = tmp_path / "ref"
+    trt_dir.mkdir()
+    ref_dir.mkdir()
+    for directory in (trt_dir, ref_dir):
+        _write_frame(directory / "frame_0.png", (255, 0, 0))
+        _write_frame(directory / "frame_1.png", (255, 0, 0))
+
+    result = FluxDiffusionImagePlugin().verify(
+        _output(trt_dir), _output(ref_dir), _case(), _threshold())
+
+    assert not result.passed
+    assert not result.metrics["batch_pairwise_pixel_mae"].passed

--- a/tests/e2e/models/flux/test_flux_batch_reference.py
+++ b/tests/e2e/models/flux/test_flux_batch_reference.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+
+from tests.e2e.models.flux.e2e_plugins.references import hf_diffusers
+from tests.e2e_harness.contracts import E2ECase, RunContext, StageSpec
+
+
+def test_flux_reference_uses_per_sample_prompts_and_seeds(monkeypatch, tmp_path) -> None:
+    case = E2ECase(
+        name="flux-batch2",
+        hf_id="example/flux",
+        family="flux",
+        runtime_strategy="diffusion_flux",
+        inputs={
+            "batch_prompts": ["A red cube", "A blue sphere"],
+            "batch_seeds": [42, 42],
+            "num_inference_steps": 4,
+            "image_height": 64,
+            "image_width": 64,
+        },
+    )
+    ctx = RunContext(case=case, artifacts_dir=str(tmp_path))
+    captured: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["script"] = cmd[2]
+        return subprocess.CompletedProcess(cmd, 0, stdout="Generated 2 frames\n", stderr="")
+
+    monkeypatch.setattr(hf_diffusers, "_resolve_cached_model_ref", lambda model: model)
+    monkeypatch.setattr(hf_diffusers.subprocess, "run", _fake_run)
+
+    hf_diffusers.HfDiffusersReference().run_stage(
+        case, StageSpec(name="end_to_end"), ctx)
+
+    script = captured["script"]
+    assert "prompts = ['A red cube', 'A blue sphere']" in script
+    assert "batch_seeds = [42, 42]" in script
+    assert "prompt=prompts if len(prompts) > 1 else prompts[0]" in script
+    assert "for seed in batch_seeds" in script

--- a/tests/e2e/models/flux/test_flux_diffusion_runner_generic.py
+++ b/tests/e2e/models/flux/test_flux_diffusion_runner_generic.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 
 from tests.e2e_harness.contracts import E2ECase, RunContext, StageSpec
 from tests.e2e.models.flux.e2e_plugins.runners import diffusion as flux_diffusion
@@ -65,3 +66,43 @@ def test_flux_diffusion_runner_uses_generate_video(monkeypatch, tmp_path):
     assert "--height" not in cmd
     assert "--width" not in cmd
     assert "--num-inference-steps" not in cmd
+
+
+def test_flux_diffusion_runner_executes_declared_batch(monkeypatch, tmp_path):
+    case = _make_case(
+        inputs={
+            "batch_prompts": ["A red cube", "A blue sphere"],
+            "batch_seeds": [42, 42],
+            "expected_batch_size": 2,
+            "num_inference_steps": 4,
+        },
+    )
+    ctx = _make_ctx(case, tmp_path)
+    captured: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        prompts_path = Path(cmd[cmd.index("--prompts-file") + 1])
+        captured["prompts"] = prompts_path.read_text(encoding="utf-8").splitlines()
+        output = Path(cmd[cmd.index("--output") + 1])
+        output.with_name(f"{output.stem}_0{output.suffix}").write_bytes(b"first")
+        output.with_name(f"{output.stem}_1{output.suffix}").write_bytes(b"second")
+        return subprocess.CompletedProcess(cmd, 0, stdout="Saved 2 images\n", stderr="")
+
+    monkeypatch.setattr(flux_diffusion.subprocess, "run", _fake_run)
+    monkeypatch.setattr(
+        flux_diffusion.DiffusionMediaRunner,
+        "_compute_frame_stats",
+        staticmethod(lambda _path: {"count": 2, "mean": 0.5, "std": 0.2}),
+    )
+
+    output = flux_diffusion.DiffusionMediaRunner().run_stage(
+        case, StageSpec(name="end_to_end"), ctx)
+
+    cmd = captured["cmd"]
+    assert cmd[1] == "run"
+    assert captured["prompts"] == ["A red cube", "A blue sphere"]
+    assert cmd[cmd.index("--seed") + 1] == "42,42"
+    assert cmd[cmd.index("--num-steps") + 1] == "4"
+    assert output.data["num_frames"] == 2
+    assert len(output.data["frame_paths"]) == 2

--- a/tests/e2e/models/flux/test_flux_manifest_contract.py
+++ b/tests/e2e/models/flux/test_flux_manifest_contract.py
@@ -20,3 +20,20 @@ def test_flux2_fp8_manifest_uses_end_to_end_image_contract() -> None:
     assert [stage.name for stage in case.stages] == ["end_to_end"]
     assert all(stage.required for stage in case.stages)
     assert "Wan-specific" in case.metadata["notes"]
+
+
+def test_flux_batch2_manifest_declares_real_batch_contract() -> None:
+    manifest_path = Path(__file__).with_name("manifests") / "flux-schnell-l0-batch2.json"
+    case = load_manifest(manifest_path)
+
+    assert case.inputs["max_batch_size"] == 2
+    assert case.inputs["expected_batch_size"] == 2
+    assert case.inputs["batch_prompts"] == [
+        "A red cube on a white table",
+        "A blue sphere on a white table",
+    ]
+    assert case.inputs["batch_seeds"] == [42, 42]
+    assert case.threshold_overrides["batch_min_pairwise_pixel_mae"] == 0.01
+    assert {spec["flag"] for spec in case.metadata["build_cli_args"]} >= {
+        "--max-batch-size",
+    }

--- a/tests/e2e/models/flux/test_flux_manifest_contract.py
+++ b/tests/e2e/models/flux/test_flux_manifest_contract.py
@@ -34,6 +34,7 @@ def test_flux_batch2_manifest_declares_real_batch_contract() -> None:
     ]
     assert case.inputs["batch_seeds"] == [42, 42]
     assert case.threshold_overrides["batch_min_pairwise_pixel_mae"] == 0.01
+    assert case.metadata["contract_config"]["use_diffusers"] is True
     assert {spec["flag"] for spec in case.metadata["build_cli_args"]} >= {
         "--max-batch-size",
     }

--- a/tests/e2e/models/flux/thresholds/flux-schnell-l0-batch2.json
+++ b/tests/e2e/models/flux/thresholds/flux-schnell-l0-batch2.json
@@ -1,0 +1,15 @@
+{
+  "threshold_overrides": {
+    "batch_min_pairwise_pixel_mae": 0.01,
+    "latent_cosine_per_step": 0.95,
+    "lpips": 0.3,
+    "max_pixel_mean": 0.85,
+    "min_pixel_mean": 0.15,
+    "min_pixel_std": 0.05,
+    "min_reference_std_ratio": 0.35,
+    "psnr": 5.0,
+    "reference_min_pixel_std_for_ratio": 0.08,
+    "ssim": 0.1,
+    "temporal_consistency": 0.6
+  }
+}

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -2901,6 +2901,22 @@ class TestValidation:
             f"Expected at least 5 core models, got {len(imap.core_models)}"
         )
 
+    def test_flux_runtime_selects_batch2_detector(self):
+        """FLUX runtime changes must execute the real-bundle batch contract."""
+        real_root = REPO_ROOT
+        if not (real_root / "tests" / "e2e" / "models").is_dir():
+            pytest.skip("Not in the project repo")
+        imap = test_impact.build_impact_map(real_root)
+
+        result = test_impact.analyze_impact(
+            ["src/runtime/models/flux/pipeline.cpp"], imap, e2e_suite="l0")
+
+        assert "flux-schnell-l0-batch2" in result.e2e_models
+        assert (
+            "tests/e2e/models/flux/test_flux_e2e.py::"
+            "test_model_e2e[flux-schnell-l0-batch2]"
+        ) in result.e2e_test_ids
+
 
 # ---------------------------------------------------------------------------
 # Output format tests


### PR DESCRIPTION
## Background

Draft probe PR #374 showed that FLUX runtime changes select model-owned E2E, but every selected case executes only batch size one. Issue #383 tracks the resulting gap: regressions confined to `max_batch_size > 1` can pass required CI.

## Exit Criteria

- A real FLUX bundle is built with `--max-batch-size 2` and executed with two prompts in one batch.
- The contract requires exactly two outputs and rejects duplicated per-sample results.
- FLUX runtime production changes select the batch-two case through normal impact analysis.
- Issue #383 remains open until the original mutation is replayed after this fix merges.

## Implementation

- Add `flux-schnell-l0-batch2`, using two distinct prompts with identical seeds so duplicated conditioning produces duplicate images and fails the contract.
- Extend the FLUX runner and HF reference to execute declared prompt/seed batches.
- Require exact batch output counts and a minimum pairwise pixel difference in the model-owned contract.
- Add focused runner, reference, contract, manifest, and impact-selection regression tests.

## Validation

- `python3 -m pytest -q tests/e2e/models/flux --ignore=tests/e2e/models/flux/test_flux_e2e.py`: passed, 43 tests.
- `python3 -m pytest -q tests/builder/test_manifest_validation.py`: passed, 31 tests with 3 pre-existing unknown-strategy warnings from synthetic test manifests.
- `python3 -m pytest -q tests/tools/test_test_impact.py`: passed, 183 tests.
- `ruff check <changed Python files>`: passed.
- `python3 tools/test_impact.py --files src/runtime/models/flux/pipeline.cpp --e2e-suite l0 --json`: selected `flux-schnell-l0-batch2` alongside the existing FLUX L0 cases.
- Real-bundle GPU validation was not run locally; premerge CI is expected to build and execute the new batch-two case.

## Notes For Future Readers

- Review the manifest and contract first, then the runner/reference wiring.
- This does not change production runtime behavior or weaken existing thresholds.
- No ADR was added because this extends an existing model-owned E2E strategy and reference rather than introducing a new architecture.
- Open PR #371 also changes the FLUX HF reference for precision selection. The changes are semantically complementary but currently produce a textual conflict in `hf_diffusers.py`; whichever PR merges second must retain both precision and batch wiring.
- Tracks #383 and revalidates probe #374; do not close #383 until replay confirms the detector fails on the original mutation.
