### PR TITLE
fix(z-image): align DiT caption semantics with HF and keep fp16 transients finite

### DIFF
--- a/python/tensorrt_model_connect/families/z_image/qwen3_encoder_builder.py
+++ b/python/tensorrt_model_connect/families/z_image/qwen3_encoder_builder.py
@@ -6,7 +6,7 @@
 Builds a TRT engine for the Qwen3 model used as a text encoder in Z-Image.
 Unlike the standard decoder builder, this:
   - Processes the entire sequence at once (no KV cache)
-  - Uses bidirectional causal attention (full attention mask)
+  - Uses causal attention plus a padding mask
   - Returns hidden_states from a configurable layer (default: layer -2)
 
 Engine I/O:
@@ -28,6 +28,7 @@ from ...engine_builder import add_dynamic_batch_profile
 
 
 trt = trt_compat.get_trt()
+
 
 def load_qwen3_encoder_weights(
     model_dir: str,
@@ -192,18 +193,14 @@ def build_qwen3_encoder_engine(
         network, (max_seq_len,), np.arange(max_seq_len, dtype=np.int32),
         dtype=np.int32)
 
-    # Build attention mask for native IAttention. attn_mask input is 0.0 for
-    # valid tokens and -1e9 for padding; [1, 1, 1, S] broadcasts across heads
-    # and query positions.
-    # We mask padded positions with -1e9
-    mask_reshape = network.add_shuffle(attn_mask)
-    mask_reshape.reshape_dims = (1, 1, 1, max_seq_len)
+    # Input IDs are right-padded and only valid-prefix outputs are consumed.
+    # Native causal attention therefore also prevents every consumed query
+    # from attending to padding, without materializing a 512x512 additive mask.
+    # Keep attn_mask in the engine interface for runtime compatibility.
+    del attn_mask
 
+    output_hidden = hidden
     for layer_idx in range(num_layers):
-        if layer_idx == output_layer:
-            # Save this hidden state as output
-            output_hidden = hidden
-
         # RMSNorm
         normed = graph_ops.add_rms_norm(
             network, hidden, hidden_size,
@@ -250,7 +247,8 @@ def build_qwen3_encoder_engine(
             num_kv_heads=num_kv_heads,
             head_dim=head_dim,
             q_seq=max_seq_len, kv_seq=max_seq_len,
-            mask=mask_reshape.get_output(0),
+            causal=True,
+            mask=None,
             tag=f"layer.{layer_idx}.attn")
 
         # Output projection
@@ -290,6 +288,11 @@ def build_qwen3_encoder_engine(
         # Residual
         hidden = network.add_elementwise(
             hidden, down, trt.ElementWiseOperation.SUM).get_output(0)
+
+        if layer_idx == output_layer:
+            # HF captures decoder-layer outputs, so hidden_states[-2] is
+            # the output after decoder layer N-2, not its input.
+            output_hidden = hidden
 
     # Use the output from the target layer
     if output_layer >= num_layers:
@@ -406,15 +409,14 @@ def _add_apply_rope_native_batched(network, inp, cos_cache_2d, sin_cache_2d,
 
 def _add_attention_from_batched_rows(network, q, k, v, *,
                                      num_heads: int, num_kv_heads: int,
-                                     head_dim: int, q_seq: int, kv_seq: int,
-                                     mask):
+                                     head_dim: int, q_seq: int, kv_seq: int):
     """Native IAttention for ``[B, S, H*D]`` Q and ``[B, S, KVH*D]`` K/V."""
     q_4d = _reshape_batched_rows_to_heads_4d(network, q, num_heads, head_dim, q_seq)
     k_4d = _reshape_batched_rows_to_heads_4d(network, k, num_kv_heads, head_dim, kv_seq)
     v_4d = _reshape_batched_rows_to_heads_4d(network, v, num_kv_heads, head_dim, kv_seq)
     ctx_4d = graph_ops.add_attention_core(
         network, q_4d, k_4d, v_4d,
-        causal=False, mask=mask,
+        causal=True, mask=None,
         scale=float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0,
     )
     return _reshape_heads_4d_to_batched_rows(
@@ -503,15 +505,12 @@ def _build_qwen3_encoder_engine_batched(
         network, rope_sin_half_np.shape, rope_sin_half_np,
         dtype=work_np_dtype)
 
-    mask_reshape = network.add_shuffle(attn_mask)
-    mask_reshape.reshape_dims = (-1, 1, 1, max_seq_len)
-    mask_4d = mask_reshape.get_output(0)
+    # See the static path: right padding is outside every consumed query's
+    # causal receptive field, so no explicit padding matrix is required.
+    del attn_mask
 
     output_hidden = hidden
     for layer_idx in range(num_layers):
-        if layer_idx == output_layer:
-            output_hidden = hidden
-
         normed = graph_ops.add_rms_norm_last_dim(
             network, hidden, hidden_size,
             weights[f"layer.{layer_idx}.input_layernorm"], eps_t,
@@ -549,8 +548,7 @@ def _build_qwen3_encoder_engine_batched(
         ctx_flat = _add_attention_from_batched_rows(
             network, q, k, v,
             num_heads=num_heads, num_kv_heads=num_kv_heads,
-            head_dim=head_dim, q_seq=max_seq_len, kv_seq=max_seq_len,
-            mask=mask_4d)
+            head_dim=head_dim, q_seq=max_seq_len, kv_seq=max_seq_len)
 
         attn_out = graph_ops.add_matmul_rhs_constant(
             network, ctx_flat, num_heads * head_dim, hidden_size,
@@ -581,6 +579,9 @@ def _build_qwen3_encoder_engine_batched(
 
         hidden = network.add_elementwise(
             hidden, down, trt.ElementWiseOperation.SUM).get_output(0)
+
+        if layer_idx == output_layer:
+            output_hidden = hidden
 
     if output_layer >= num_layers:
         output_hidden = hidden

--- a/python/tensorrt_model_connect/families/z_image/z_image_dit_builder.py
+++ b/python/tensorrt_model_connect/families/z_image/z_image_dit_builder.py
@@ -265,6 +265,8 @@ def build_z_image_dit_engine(
         temb_inp = network.add_cast(temb_inp, work_trt_dtype).get_output(0)
         rope_cos = network.add_cast(rope_cos, work_trt_dtype).get_output(0)
         rope_sin = network.add_cast(rope_sin, work_trt_dtype).get_output(0)
+    attention_mask = network.add_input(
+        "attention_mask", trt.float32, (total_seq,))
 
     # Constants
     eps_t = graph_ops.add_constant(
@@ -303,6 +305,14 @@ def build_z_image_dit_engine(
 
     noise = noise_inp
     caption = caption_inp
+    full_mask_r = network.add_shuffle(attention_mask)
+    full_mask_r.reshape_dims = (1, 1, 1, total_seq)
+    full_attention_mask = full_mask_r.get_output(0)
+    cap_mask_slice = network.add_slice(
+        attention_mask, start=(num_patches,), shape=(text_seq_len,), stride=(1,))
+    cap_mask_r = network.add_shuffle(cap_mask_slice.get_output(0))
+    cap_mask_r.reshape_dims = (1, 1, 1, text_seq_len)
+    cap_attention_mask = cap_mask_r.get_output(0)
 
     # --- Noise refiner (on noise only, with AdaLN) ---
     noise_cos = _slice_rope(network, rope_cos, 0, num_patches, head_dim)
@@ -335,6 +345,7 @@ def build_z_image_dit_engine(
             network, layer_caption, weights, tp,
             dim, num_heads, head_dim, ffn_dim, text_seq_len,
             layer_eps, scale_t, layer_cos, layer_sin,
+            attention_mask=cap_attention_mask,
             dtype=layer_dtype,
         )
         caption = _cast_back_from_fp32(selector, caption)
@@ -353,6 +364,7 @@ def build_z_image_dit_engine(
             network, layer_unified, weights, tp, layer_temb,
             dim, num_heads, head_dim, ffn_dim, adaln_embed_dim,
             total_seq, layer_eps, scale_t, layer_cos, layer_sin, layer_ones,
+            attention_mask=full_attention_mask,
             dtype=layer_dtype,
         )
         unified_t = _cast_back_from_fp32(selector, unified_t)
@@ -467,12 +479,13 @@ def _per_head_rms_norm(
 
 def _multi_head_attention(
         network, q, k, v, num_heads, head_dim, q_seq, kv_seq, scale_t,
-        dtype=np.float32):
+        mask=None, dtype=np.float32):
     """Standard multi-head attention."""
     return graph_ops.add_attention_from_rows(
         network, q, k, v,
         num_heads=num_heads, head_dim=head_dim,
         q_seq=q_seq, kv_seq=kv_seq,
+        mask=mask,
         scale=scale_t,
         explicit_attention=(dtype != np.float32))
 
@@ -480,7 +493,7 @@ def _multi_head_attention(
 def _add_plain_dit_block(
     network, x, weights, prefix,
     dim, num_heads, head_dim, ffn_dim, seq_len,
-    eps_t, scale_t, cos_t, sin_t, dtype=np.float32,
+    eps_t, scale_t, cos_t, sin_t, attention_mask=None, dtype=np.float32,
 ):
     """Plain DiT block (no AdaLN): pre-norm attention + post-norm + SwiGLU FFN.
 
@@ -519,7 +532,7 @@ def _add_plain_dit_block(
     # Attention
     attn_out = _multi_head_attention(
         network, q, k, v, num_heads, head_dim, seq_len, seq_len, scale_t,
-        dtype=dtype)
+        mask=attention_mask, dtype=dtype)
     attn_out = graph_ops.add_matmul_rhs_constant(
         network, attn_out, dim, dim, weights[f"{prefix}.to_out"], dtype=dtype)
 
@@ -561,7 +574,8 @@ def _add_plain_dit_block(
 def _add_adaln_dit_block(
     network, x, weights, prefix, temb,
     dim, num_heads, head_dim, ffn_dim, adaln_embed_dim,
-    seq_len, eps_t, scale_t, cos_t, sin_t, ones_t, dtype=np.float32,
+    seq_len, eps_t, scale_t, cos_t, sin_t, ones_t,
+    attention_mask=None, dtype=np.float32,
 ):
     """AdaLN DiT block (noise_refiner): 4-chunk modulation + tanh gating + attention + SwiGLU.
 
@@ -627,7 +641,7 @@ def _add_adaln_dit_block(
 
     attn_out = _multi_head_attention(
         network, q, k, v, num_heads, head_dim, seq_len, seq_len, scale_t,
-        dtype=dtype)
+        mask=attention_mask, dtype=dtype)
     attn_out = graph_ops.add_matmul_rhs_constant(
         network, attn_out, dim, dim, weights[f"{prefix}.to_out"], dtype=dtype)
 
@@ -749,13 +763,15 @@ def _reshape_heads_4d_to_batched_rows(network, x, num_heads: int, head_dim: int,
     return r.get_output(0)
 
 
-def _mha_batched(network, q, k, v, num_heads: int, head_dim: int, seq_len: int):
+def _mha_batched(
+    network, q, k, v, num_heads: int, head_dim: int, seq_len: int, mask=None,
+):
     """Multi-head attention for ``[B, S, H*D]`` Q/K/V tensors."""
     q_4d = _reshape_batched_rows_to_heads_4d(network, q, num_heads, head_dim, seq_len)
     k_4d = _reshape_batched_rows_to_heads_4d(network, k, num_heads, head_dim, seq_len)
     v_4d = _reshape_batched_rows_to_heads_4d(network, v, num_heads, head_dim, seq_len)
     ctx_4d = graph_ops.add_attention_core(
-        network, q_4d, k_4d, v_4d, causal=False, mask=None,
+        network, q_4d, k_4d, v_4d, causal=False, mask=mask,
         scale=float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0)
     return _reshape_heads_4d_to_batched_rows(network, ctx_4d, num_heads, head_dim, seq_len)
 
@@ -868,12 +884,14 @@ def _build_z_image_dit_engine_batched(
         "rotary_cos", trt.float32, (-1, total_seq, head_dim))
     rope_sin = network.add_input(
         "rotary_sin", trt.float32, (-1, total_seq, head_dim))
+    attention_mask = network.add_input(
+        "attention_mask", trt.float32, (-1, total_seq))
 
     add_dynamic_batch_profile(
         builder, config, network,
         input_names=[
             "hidden_states", "encoder_hidden_states", "timestep_embedding",
-            "rotary_cos", "rotary_sin",
+            "rotary_cos", "rotary_sin", "attention_mask",
         ],
         max_batch=max_batch_size,
         opt_batch=opt_batch_size,
@@ -883,6 +901,7 @@ def _build_z_image_dit_engine_batched(
             "timestep_embedding": (adaln_embed_dim,),
             "rotary_cos": (total_seq, head_dim),
             "rotary_sin": (total_seq, head_dim),
+            "attention_mask": (total_seq,),
         },
     )
 
@@ -902,6 +921,16 @@ def _build_z_image_dit_engine_batched(
 
     noise = noise_inp
     caption = caption_inp
+    full_mask_r = network.add_shuffle(attention_mask)
+    full_mask_r.reshape_dims = (-1, 1, 1, total_seq)
+    full_attention_mask = full_mask_r.get_output(0)
+    cap_mask_slice = network.add_slice(
+        attention_mask, start=(0, num_patches), shape=(0, 0), stride=(1, 1))
+    cap_mask_slice.set_input(
+        2, _dynamic_batch_shape(network, attention_mask, (text_seq_len,)))
+    cap_mask_r = network.add_shuffle(cap_mask_slice.get_output(0))
+    cap_mask_r.reshape_dims = (-1, 1, 1, text_seq_len)
+    cap_attention_mask = cap_mask_r.get_output(0)
 
     noise_cos = _slice_batched_sequence(network, rope_cos, 0, num_patches, head_dim)
     noise_sin = _slice_batched_sequence(network, rope_sin, 0, num_patches, head_dim)
@@ -922,7 +951,7 @@ def _build_z_image_dit_engine_batched(
         caption = _add_plain_dit_block_batched(
             network, caption, weights, tp,
             dim, num_heads, head_dim, ffn_dim, text_seq_len,
-            eps_t, cap_cos, cap_sin,
+            eps_t, cap_cos, cap_sin, cap_attention_mask,
         )
 
     for i in range(num_layers):
@@ -984,7 +1013,8 @@ def _build_z_image_dit_engine_batched(
             network, k, rope_cos, rope_sin, num_heads, head_dim, total_seq)
 
         attn_out = _mha_batched(
-            network, q, k, v, num_heads, head_dim, total_seq)
+            network, q, k, v, num_heads, head_dim, total_seq,
+            full_attention_mask)
         attn_out = graph_ops.add_matmul_rhs_constant(
             network, attn_out, dim, dim, weights[f"{tp}.to_out"])
         attn_out_normed = graph_ops.add_rms_norm_last_dim(
@@ -1069,7 +1099,7 @@ def _build_z_image_dit_engine_batched(
 def _add_plain_dit_block_batched(
     network, x, weights, prefix,
     dim, num_heads, head_dim, ffn_dim, seq_len,
-    eps_t, cos_t, sin_t,
+    eps_t, cos_t, sin_t, attention_mask=None,
 ):
     """Plain DiT block (no AdaLN) for ``[B, S, D]`` tensors."""
     normed = graph_ops.add_rms_norm_last_dim(
@@ -1094,7 +1124,8 @@ def _add_plain_dit_block_batched(
     k = _apply_rope_batched_from_full_cache(
         network, k, cos_t, sin_t, num_heads, head_dim, seq_len)
 
-    attn_out = _mha_batched(network, q, k, v, num_heads, head_dim, seq_len)
+    attn_out = _mha_batched(
+        network, q, k, v, num_heads, head_dim, seq_len, attention_mask)
     attn_out = graph_ops.add_matmul_rhs_constant(
         network, attn_out, dim, dim, weights[f"{prefix}.to_out"])
     attn_out_normed = graph_ops.add_rms_norm_last_dim(

--- a/python/tensorrt_model_connect/families/z_image/z_image_dit_builder.py
+++ b/python/tensorrt_model_connect/families/z_image/z_image_dit_builder.py
@@ -162,6 +162,14 @@ def _load_dit_block(
         weights[f"{tp}.adaln.bias"] = _f(f"{p}.adaLN_modulation.0.bias")
 
 
+# FP16 blocks: pre-scale applied to one linear stage per sandwich-normed
+# branch, compensated exactly in the post-norm epsilon (see
+# build_z_image_dit_engine). 1/64 leaves substantial headroom below the
+# observed 63k transient peaks; TRT fp16 GEMMs can overflow internal partial
+# accumulations even when their stored inputs and outputs remain finite.
+_SANDWICH_PRESCALE = 1.0 / 64.0
+
+
 def build_z_image_dit_engine(
     weights: WeightDict,
     *,
@@ -289,6 +297,28 @@ def build_z_image_dit_engine(
             network, (1, 1), np.array([1.0], dtype=np.float32),
             dtype=np.float32)
 
+    # HF-correct caption embeddings drive fp16-block transients close to the
+    # 65504 storage limit: the attention out-projection output peaks at 63k+
+    # at 512px and the SwiGLU gated product feeding ff_w2 peaks at 63k+ at
+    # 1024px (the previous caption semantics already sat near 56k). On P2021,
+    # TensorRT GEMMs become non-finite at these magnitudes because internal
+    # fp16 partial accumulations can overflow before the result is stored.
+    # Both branches are sandwich-normed — an RMSNorm sits directly after the
+    # projection — so pre-scaling one linear stage per branch (to_out for
+    # attention; ff_w3 for the FFN, whose scale rides linearly through the
+    # gated product and ff_w2) shrinks the hot transients and the branch
+    # output by _SANDWICH_PRESCALE, which the compensated post-norm epsilon
+    # cancels in real arithmetic: RMSNorm_eps(x) ==
+    # RMSNorm_{eps*a^2}(a*x).
+    # The epsilon constant must live in fp32: the compensated value
+    # underflows fp16.
+    sandwich_eps_t = None
+    if precision == "fp16":
+        sandwich_eps_t = graph_ops.add_constant(
+            network, (1, 1),
+            np.array([eps * _SANDWICH_PRESCALE ** 2], dtype=np.float32),
+            dtype=np.float32)
+
     def _layer_inputs(selector: int, *tensors):
         if selector not in selected_fp32_layers:
             return work_np_dtype, eps_t, ones_t, tensors
@@ -329,6 +359,7 @@ def build_z_image_dit_engine(
             num_patches, layer_eps, scale_t,
             layer_cos, layer_sin, layer_ones,
             dtype=layer_dtype,
+            sandwich_eps_t=sandwich_eps_t,
         )
         noise = _cast_back_from_fp32(selector, noise)
 
@@ -347,6 +378,7 @@ def build_z_image_dit_engine(
             layer_eps, scale_t, layer_cos, layer_sin,
             attention_mask=cap_attention_mask,
             dtype=layer_dtype,
+            sandwich_eps_t=sandwich_eps_t,
         )
         caption = _cast_back_from_fp32(selector, caption)
 
@@ -366,6 +398,7 @@ def build_z_image_dit_engine(
             total_seq, layer_eps, scale_t, layer_cos, layer_sin, layer_ones,
             attention_mask=full_attention_mask,
             dtype=layer_dtype,
+            sandwich_eps_t=sandwich_eps_t,
         )
         unified_t = _cast_back_from_fp32(selector, unified_t)
 
@@ -490,10 +523,36 @@ def _multi_head_attention(
         explicit_attention=(dtype != np.float32))
 
 
+def _sandwich_prescale_params(
+    weights, prefix, eps_t, sandwich_eps_t, dtype,
+):
+    """Linear weights and post-norm eps for one block's transient chains.
+
+    In FP16 blocks every tensor between the pre-norm and the post-norm is
+    transient (an RMSNorm follows immediately), yet two of them sit at the
+    fp16 cliff: the attention out-projection output (observed 63k+ at 512px)
+    and the SwiGLU gated product feeding ff_w2 (observed 63k+ at 1024px).
+    Scale one linear stage per branch — to_out
+    for attention, ff_w3 for the FFN (silu applies to the un-scaled w1
+    branch, so the ff_w3 scale rides linearly through the gated product and
+    ff_w2) — and hand back the epsilon-compensated post-norm constant that
+    preserves the unscaled formulation in real arithmetic.
+    """
+    w_to_out = weights[f"{prefix}.to_out"]
+    w_ff3 = weights[f"{prefix}.ff_w3"]
+    norm2_eps_t = eps_t
+    if sandwich_eps_t is not None and dtype != np.float32:
+        w_to_out = w_to_out * _SANDWICH_PRESCALE
+        w_ff3 = w_ff3 * _SANDWICH_PRESCALE
+        norm2_eps_t = sandwich_eps_t
+    return w_to_out, w_ff3, norm2_eps_t
+
+
 def _add_plain_dit_block(
     network, x, weights, prefix,
     dim, num_heads, head_dim, ffn_dim, seq_len,
     eps_t, scale_t, cos_t, sin_t, attention_mask=None, dtype=np.float32,
+    sandwich_eps_t=None,
 ):
     """Plain DiT block (no AdaLN): pre-norm attention + post-norm + SwiGLU FFN.
 
@@ -502,6 +561,8 @@ def _add_plain_dit_block(
         x = x + attention_norm2(attn_out)          # norm2 = post-norm
         x = x + ffn_norm2(feed_forward(ffn_norm1(x)))  # norm2 = post-norm
     """
+    w_to_out, w_ff3, norm2_eps_t = _sandwich_prescale_params(
+        weights, prefix, eps_t, sandwich_eps_t, dtype)
     # Pre-attention norm
     normed = graph_ops.add_rms_norm(
         network, x, dim, weights[f"{prefix}.attn_norm1"], eps_t,
@@ -534,11 +595,11 @@ def _add_plain_dit_block(
         network, q, k, v, num_heads, head_dim, seq_len, seq_len, scale_t,
         mask=attention_mask, dtype=dtype)
     attn_out = graph_ops.add_matmul_rhs_constant(
-        network, attn_out, dim, dim, weights[f"{prefix}.to_out"], dtype=dtype)
+        network, attn_out, dim, dim, w_to_out, dtype=dtype)
 
-    # Post-norm on attn output
+    # Post-norm on attn output (eps compensated when to_out is pre-scaled)
     attn_out_normed = graph_ops.add_rms_norm(
-        network, attn_out, dim, weights[f"{prefix}.attn_norm2"], eps_t,
+        network, attn_out, dim, weights[f"{prefix}.attn_norm2"], norm2_eps_t,
         dtype=dtype)
 
     # Residual
@@ -553,7 +614,7 @@ def _add_plain_dit_block(
         network, ffn_normed, dim, ffn_dim, weights[f"{prefix}.ff_w1"],
         dtype=dtype)
     up_proj = graph_ops.add_matmul_rhs_constant(
-        network, ffn_normed, dim, ffn_dim, weights[f"{prefix}.ff_w3"],
+        network, ffn_normed, dim, ffn_dim, w_ff3,
         dtype=dtype)
     gate_sigmoid = network.add_activation(gate_proj, trt.ActivationType.SIGMOID)
     gate_silu = network.add_elementwise(gate_proj, gate_sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
@@ -562,9 +623,9 @@ def _add_plain_dit_block(
         network, gated.get_output(0), ffn_dim, dim, weights[f"{prefix}.ff_w2"],
         dtype=dtype)
 
-    # Post-norm on FFN output
+    # Post-norm on FFN output (eps compensated when ff_w2 is pre-scaled)
     ffn_out_normed = graph_ops.add_rms_norm(
-        network, down_proj, dim, weights[f"{prefix}.ffn_norm2"], eps_t,
+        network, down_proj, dim, weights[f"{prefix}.ffn_norm2"], norm2_eps_t,
         dtype=dtype)
 
     x = network.add_elementwise(x, ffn_out_normed, trt.ElementWiseOperation.SUM).get_output(0)
@@ -576,6 +637,7 @@ def _add_adaln_dit_block(
     dim, num_heads, head_dim, ffn_dim, adaln_embed_dim,
     seq_len, eps_t, scale_t, cos_t, sin_t, ones_t,
     attention_mask=None, dtype=np.float32,
+    sandwich_eps_t=None,
 ):
     """AdaLN DiT block (noise_refiner): 4-chunk modulation + tanh gating + attention + SwiGLU.
 
@@ -591,6 +653,8 @@ def _add_adaln_dit_block(
         ffn_out = feed_forward(ffn_norm1(x) * scale_mlp)
         x = x + gate_mlp * ffn_norm2(ffn_out)
     """
+    w_to_out, w_ff3, norm2_eps_t = _sandwich_prescale_params(
+        weights, prefix, eps_t, sandwich_eps_t, dtype)
     # AdaLN modulation: just Linear, no SiLU
     adaln_w = weights[f"{prefix}.adaln.weight"]
     adaln_b = weights[f"{prefix}.adaln.bias"]
@@ -643,11 +707,11 @@ def _add_adaln_dit_block(
         network, q, k, v, num_heads, head_dim, seq_len, seq_len, scale_t,
         mask=attention_mask, dtype=dtype)
     attn_out = graph_ops.add_matmul_rhs_constant(
-        network, attn_out, dim, dim, weights[f"{prefix}.to_out"], dtype=dtype)
+        network, attn_out, dim, dim, w_to_out, dtype=dtype)
 
-    # Post-norm on attn output
+    # Post-norm on attn output (eps compensated when to_out is pre-scaled)
     attn_out_normed = graph_ops.add_rms_norm(
-        network, attn_out, dim, weights[f"{prefix}.attn_norm2"], eps_t,
+        network, attn_out, dim, weights[f"{prefix}.attn_norm2"], norm2_eps_t,
         dtype=dtype)
 
     gated_attn = network.add_elementwise(attn_out_normed, gate_msa, trt.ElementWiseOperation.PROD)
@@ -663,7 +727,7 @@ def _add_adaln_dit_block(
         network, ffn_normed, dim, ffn_dim, weights[f"{prefix}.ff_w1"],
         dtype=dtype)
     up_proj = graph_ops.add_matmul_rhs_constant(
-        network, ffn_normed, dim, ffn_dim, weights[f"{prefix}.ff_w3"],
+        network, ffn_normed, dim, ffn_dim, w_ff3,
         dtype=dtype)
     gate_sigmoid = network.add_activation(gate_proj, trt.ActivationType.SIGMOID)
     gate_silu = network.add_elementwise(gate_proj, gate_sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
@@ -672,9 +736,9 @@ def _add_adaln_dit_block(
         network, gated.get_output(0), ffn_dim, dim, weights[f"{prefix}.ff_w2"],
         dtype=dtype)
 
-    # Post-norm on FFN output
+    # Post-norm on FFN output (eps compensated when ff_w2 is pre-scaled)
     ffn_out_normed = graph_ops.add_rms_norm(
-        network, down_proj, dim, weights[f"{prefix}.ffn_norm2"], eps_t,
+        network, down_proj, dim, weights[f"{prefix}.ffn_norm2"], norm2_eps_t,
         dtype=dtype)
 
     gated_ffn = network.add_elementwise(ffn_out_normed, gate_mlp, trt.ElementWiseOperation.PROD)

--- a/src/runtime/models/z_image/pipeline.cpp
+++ b/src/runtime/models/z_image/pipeline.cpp
@@ -238,13 +238,13 @@ bool ZImagePipeline::run_text_encoder(const std::vector<int32_t>& input_ids,
     }
 
     // Build TensorMap for TrtModule::forward()
-    const bool encoder_is_batched = text_encoder_->input_rank("input_ids") == 2;
-    const std::vector<int64_t> encoder_shape =
-        encoder_is_batched ? std::vector<int64_t>{1, static_cast<int64_t>(seq_len)}
-                           : std::vector<int64_t>{static_cast<int64_t>(seq_len)};
+    const auto ids_shape =
+        z_image_text_encoder_input_shape(text_encoder_->input_rank("input_ids"), seq_len);
+    const auto mask_shape =
+        z_image_text_encoder_input_shape(text_encoder_->input_rank("attention_mask"), seq_len);
     TensorMap inputs;
-    inputs["input_ids"] = Tensor{padded_ids.data(), encoder_shape, DType::kInt32};
-    inputs["attention_mask"] = Tensor{mask.data(), encoder_shape, DType::kFloat32};
+    inputs["input_ids"] = Tensor{padded_ids.data(), ids_shape, DType::kInt32};
+    inputs["attention_mask"] = Tensor{mask.data(), mask_shape, DType::kFloat32};
 
     auto outputs = text_encoder_->forward(inputs);
 
@@ -279,7 +279,9 @@ bool ZImagePipeline::run_denoiser(const std::vector<float>& hidden,
                                   const std::vector<float>& encoder_hidden,
                                   const std::vector<float>& temb,
                                   const std::vector<float>& cos_vals,
-                                  const std::vector<float>& sin_vals, std::vector<float>& output) {
+                                  const std::vector<float>& sin_vals,
+                                  const std::vector<float>& attention_mask,
+                                  std::vector<float>& output) {
     if (!denoiser_) {
         std::cerr << "[z-image] No denoiser module\n";
         return false;
@@ -301,6 +303,9 @@ bool ZImagePipeline::run_denoiser(const std::vector<float>& hidden,
     inputs["rotary_sin"] = Tensor{const_cast<float*>(sin_vals.data()),
                                   {static_cast<int64_t>(sin_vals.size())},
                                   DType::kFloat32};
+    inputs["attention_mask"] = Tensor{const_cast<float*>(attention_mask.data()),
+                                      {static_cast<int64_t>(attention_mask.size())},
+                                      DType::kFloat32};
 
     auto outputs = denoiser_->forward(inputs);
 
@@ -317,14 +322,12 @@ bool ZImagePipeline::run_denoiser(const std::vector<float>& hidden,
 // ``batch_size``. The output is contiguous ``[B, num_patches, patch_dim]``.
 // ---------------------------------------------------------------------------
 
-bool ZImagePipeline::run_denoiser_batched(const std::vector<float>& hidden,
-                                          const std::vector<float>& encoder_hidden,
-                                          const std::vector<float>& temb,
-                                          const std::vector<float>& cos_vals,
-                                          const std::vector<float>& sin_vals, int32_t batch_size,
-                                          int32_t num_patches, int32_t dit_dim, int32_t text_seq,
-                                          int32_t freq_dim, int32_t total_seq, int32_t head_dim,
-                                          int32_t patch_dim, std::vector<float>& output) {
+bool ZImagePipeline::run_denoiser_batched(
+    const std::vector<float>& hidden, const std::vector<float>& encoder_hidden,
+    const std::vector<float>& temb, const std::vector<float>& cos_vals,
+    const std::vector<float>& sin_vals, const std::vector<float>& attention_mask,
+    int32_t batch_size, int32_t num_patches, int32_t dit_dim, int32_t text_seq, int32_t freq_dim,
+    int32_t total_seq, int32_t head_dim, int32_t patch_dim, std::vector<float>& output) {
     if (!denoiser_) {
         std::cerr << "[z-image] No denoiser module\n";
         return false;
@@ -357,6 +360,10 @@ bool ZImagePipeline::run_denoiser_batched(const std::vector<float>& hidden,
                                   {static_cast<int64_t>(batch_size),
                                    static_cast<int64_t>(total_seq), static_cast<int64_t>(head_dim)},
                                   DType::kFloat32};
+    inputs["attention_mask"] =
+        Tensor{const_cast<float*>(attention_mask.data()),
+               {static_cast<int64_t>(batch_size), static_cast<int64_t>(total_seq)},
+               DType::kFloat32};
 
     auto outputs = denoiser_->forward(inputs);
 
@@ -816,17 +823,19 @@ std::vector<ImageResult> ZImagePipeline::generate_image_batch_chunk(
     std::vector<float> caption_projected_b(static_cast<std::size_t>(batch) * caption_size);
     std::vector<float> rope_cos_b(static_cast<std::size_t>(batch) * rope_size);
     std::vector<float> rope_sin_b(static_cast<std::size_t>(batch) * rope_size);
+    std::vector<float> attention_mask_b(static_cast<std::size_t>(batch) *
+                                        static_cast<std::size_t>(total_seq));
     std::vector<float> latents(static_cast<std::size_t>(batch) * latent_size);
 
     if (!run_qwen3_encoder_for_chunk(prompts, resolved_seeds, prompt_offset, batch, layout,
-                                     caption_projected_b, rope_cos_b, rope_sin_b, latents,
-                                     supplied_initial_latents)) {
+                                     caption_projected_b, rope_cos_b, rope_sin_b, attention_mask_b,
+                                     latents, supplied_initial_latents)) {
         return {};
     }
 
     if (!run_denoise_loop_for_chunk(batch, num_inference_steps, freq_dim, engine_is_batched,
                                     prompt_offset, layout, caption_projected_b, rope_cos_b,
-                                    rope_sin_b, latents)) {
+                                    rope_sin_b, attention_mask_b, latents)) {
         return {};
     }
 
@@ -840,8 +849,8 @@ bool ZImagePipeline::run_qwen3_encoder_for_chunk(
     const std::vector<std::string>& prompts, const std::vector<std::uint32_t>& resolved_seeds,
     std::size_t prompt_offset, int32_t batch, const ZImageLayout& layout,
     std::vector<float>& caption_projected_b, std::vector<float>& rope_cos_b,
-    std::vector<float>& rope_sin_b, std::vector<float>& latents,
-    const std::vector<float>& supplied_initial_latents) {
+    std::vector<float>& rope_sin_b, std::vector<float>& attention_mask_b,
+    std::vector<float>& latents, const std::vector<float>& supplied_initial_latents) {
     const auto latent_size = static_cast<std::size_t>(layout.z_dim) *
                              static_cast<std::size_t>(layout.h_lat) *
                              static_cast<std::size_t>(layout.w_lat);
@@ -881,6 +890,12 @@ bool ZImagePipeline::run_qwen3_encoder_for_chunk(
                   rope_sin_b.begin() +
                       static_cast<std::ptrdiff_t>(b) * static_cast<std::ptrdiff_t>(rope_size));
 
+        const auto attention_mask =
+            make_z_image_attention_mask(layout.num_patches, layout.text_seq, cap_padded_len);
+        std::copy(attention_mask.begin(), attention_mask.end(),
+                  attention_mask_b.begin() +
+                      static_cast<std::ptrdiff_t>(b) * static_cast<std::ptrdiff_t>(total_seq));
+
         if (!supplied_initial_latents.empty()) {
             std::copy(supplied_initial_latents.begin(), supplied_initial_latents.end(),
                       latents.begin());
@@ -894,10 +909,11 @@ bool ZImagePipeline::run_qwen3_encoder_for_chunk(
 
 bool ZImagePipeline::run_denoiser_unbatched_step(
     int32_t batch, int32_t step, std::size_t prompt_offset, std::size_t hidden_size,
-    std::size_t caption_size, std::size_t rope_size, std::size_t patch_size,
-    const std::vector<float>& hidden_b, const std::vector<float>& caption_projected_b,
-    const std::vector<float>& temb_one, const std::vector<float>& rope_cos_b,
-    const std::vector<float>& rope_sin_b, std::vector<float>& denoiser_output) {
+    std::size_t caption_size, std::size_t rope_size, std::size_t attention_mask_size,
+    std::size_t patch_size, const std::vector<float>& hidden_b,
+    const std::vector<float>& caption_projected_b, const std::vector<float>& temb_one,
+    const std::vector<float>& rope_cos_b, const std::vector<float>& rope_sin_b,
+    const std::vector<float>& attention_mask_b, std::vector<float>& denoiser_output) {
     denoiser_output.resize(static_cast<std::size_t>(batch) * patch_size);
     for (int32_t b = 0; b < batch; ++b) {
         const auto* h_ptr = hidden_b.data() + static_cast<std::size_t>(b) * hidden_size;
@@ -905,12 +921,15 @@ bool ZImagePipeline::run_denoiser_unbatched_step(
             caption_projected_b.data() + static_cast<std::size_t>(b) * caption_size;
         const auto* cos_ptr = rope_cos_b.data() + static_cast<std::size_t>(b) * rope_size;
         const auto* sin_ptr = rope_sin_b.data() + static_cast<std::size_t>(b) * rope_size;
+        const auto* mask_ptr =
+            attention_mask_b.data() + static_cast<std::size_t>(b) * attention_mask_size;
         std::vector<float> hidden_one(h_ptr, h_ptr + hidden_size);
         std::vector<float> cap_one(cap_ptr, cap_ptr + caption_size);
         std::vector<float> cos_one(cos_ptr, cos_ptr + rope_size);
         std::vector<float> sin_one(sin_ptr, sin_ptr + rope_size);
+        std::vector<float> mask_one(mask_ptr, mask_ptr + attention_mask_size);
         std::vector<float> out_one;
-        if (!run_denoiser(hidden_one, cap_one, temb_one, cos_one, sin_one, out_one)) {
+        if (!run_denoiser(hidden_one, cap_one, temb_one, cos_one, sin_one, mask_one, out_one)) {
             std::cerr << "[z-image] DiT failed at step " << step << " sample "
                       << (prompt_offset + static_cast<std::size_t>(b)) << "\n";
             return false;
@@ -926,7 +945,8 @@ bool ZImagePipeline::run_denoise_loop_for_chunk(
     int32_t batch, int32_t num_inference_steps, int32_t freq_dim, bool engine_is_batched,
     std::size_t prompt_offset, const ZImageLayout& layout,
     const std::vector<float>& caption_projected_b, const std::vector<float>& rope_cos_b,
-    const std::vector<float>& rope_sin_b, std::vector<float>& latents) {
+    const std::vector<float>& rope_sin_b, const std::vector<float>& attention_mask_b,
+    std::vector<float>& latents) {
     const auto latent_size = static_cast<std::size_t>(layout.z_dim) *
                              static_cast<std::size_t>(layout.h_lat) *
                              static_cast<std::size_t>(layout.w_lat);
@@ -978,16 +998,17 @@ bool ZImagePipeline::run_denoise_loop_for_chunk(
 
         if (engine_is_batched) {
             if (!run_denoiser_batched(hidden_b, caption_projected_b, temb_b, rope_cos_b, rope_sin_b,
-                                      batch, layout.num_patches, layout.dit_dim, layout.text_seq,
-                                      freq_dim, total_seq, layout.head_dim, layout.patch_dim,
-                                      denoiser_output)) {
+                                      attention_mask_b, batch, layout.num_patches, layout.dit_dim,
+                                      layout.text_seq, freq_dim, total_seq, layout.head_dim,
+                                      layout.patch_dim, denoiser_output)) {
                 std::cerr << "[z-image] Batched DiT failed at step " << step << "\n";
                 return false;
             }
         } else {
-            if (!run_denoiser_unbatched_step(batch, step, prompt_offset, hidden_size, caption_size,
-                                             rope_size, patch_size, hidden_b, caption_projected_b,
-                                             temb_one, rope_cos_b, rope_sin_b, denoiser_output)) {
+            if (!run_denoiser_unbatched_step(
+                    batch, step, prompt_offset, hidden_size, caption_size, rope_size,
+                    static_cast<std::size_t>(total_seq), patch_size, hidden_b, caption_projected_b,
+                    temb_one, rope_cos_b, rope_sin_b, attention_mask_b, denoiser_output)) {
                 return false;
             }
         }

--- a/src/runtime/models/z_image/pipeline.h
+++ b/src/runtime/models/z_image/pipeline.h
@@ -83,7 +83,8 @@ class ZImagePipeline final : public IPipeline {
                           std::vector<float>& text_embeddings);
     bool run_denoiser(const std::vector<float>& hidden, const std::vector<float>& encoder_hidden,
                       const std::vector<float>& temb, const std::vector<float>& cos_vals,
-                      const std::vector<float>& sin_vals, std::vector<float>& output);
+                      const std::vector<float>& sin_vals, const std::vector<float>& attention_mask,
+                      std::vector<float>& output);
 
     /// Batched DiT forward. Every input carries a leading batch dim of size
     /// ``batch_size`` and the output is contiguous ``[B, num_patches,
@@ -91,7 +92,8 @@ class ZImagePipeline final : public IPipeline {
     bool run_denoiser_batched(const std::vector<float>& hidden,
                               const std::vector<float>& encoder_hidden,
                               const std::vector<float>& temb, const std::vector<float>& cos_vals,
-                              const std::vector<float>& sin_vals, int32_t batch_size,
+                              const std::vector<float>& sin_vals,
+                              const std::vector<float>& attention_mask, int32_t batch_size,
                               int32_t num_patches, int32_t dit_dim, int32_t text_seq,
                               int32_t freq_dim, int32_t total_seq, int32_t head_dim,
                               int32_t patch_dim, std::vector<float>& output);
@@ -131,14 +133,12 @@ class ZImagePipeline final : public IPipeline {
     /// Run the Qwen3 text encoder + caption projection + RoPE + latent
     /// initialization for every sample in a chunk. Fills the four batched
     /// buffers in-place. Returns false on encoder failure.
-    bool run_qwen3_encoder_for_chunk(const std::vector<std::string>& prompts,
-                                     const std::vector<std::uint32_t>& resolved_seeds,
-                                     std::size_t prompt_offset, int32_t batch,
-                                     const ZImageLayout& layout,
-                                     std::vector<float>& caption_projected_b,
-                                     std::vector<float>& rope_cos_b, std::vector<float>& rope_sin_b,
-                                     std::vector<float>& latents,
-                                     const std::vector<float>& supplied_initial_latents);
+    bool run_qwen3_encoder_for_chunk(
+        const std::vector<std::string>& prompts, const std::vector<std::uint32_t>& resolved_seeds,
+        std::size_t prompt_offset, int32_t batch, const ZImageLayout& layout,
+        std::vector<float>& caption_projected_b, std::vector<float>& rope_cos_b,
+        std::vector<float>& rope_sin_b, std::vector<float>& attention_mask_b,
+        std::vector<float>& latents, const std::vector<float>& supplied_initial_latents);
 
     /// Run the FlowMatchEuler denoise loop for one chunk. ``latents`` is
     /// updated in-place. Returns false if any DiT invocation fails.
@@ -148,6 +148,7 @@ class ZImagePipeline final : public IPipeline {
                                     const std::vector<float>& caption_projected_b,
                                     const std::vector<float>& rope_cos_b,
                                     const std::vector<float>& rope_sin_b,
+                                    const std::vector<float>& attention_mask_b,
                                     std::vector<float>& latents);
 
     /// Per-step fallback when the DiT engine is the legacy static (rank-2)
@@ -156,10 +157,11 @@ class ZImagePipeline final : public IPipeline {
     /// itself stays under the CCN gate.
     bool run_denoiser_unbatched_step(
         int32_t batch, int32_t step, std::size_t prompt_offset, std::size_t hidden_size,
-        std::size_t caption_size, std::size_t rope_size, std::size_t patch_size,
-        const std::vector<float>& hidden_b, const std::vector<float>& caption_projected_b,
-        const std::vector<float>& temb_one, const std::vector<float>& rope_cos_b,
-        const std::vector<float>& rope_sin_b, std::vector<float>& denoiser_output);
+        std::size_t caption_size, std::size_t rope_size, std::size_t attention_mask_size,
+        std::size_t patch_size, const std::vector<float>& hidden_b,
+        const std::vector<float>& caption_projected_b, const std::vector<float>& temb_one,
+        const std::vector<float>& rope_cos_b, const std::vector<float>& rope_sin_b,
+        const std::vector<float>& attention_mask_b, std::vector<float>& denoiser_output);
 
     /// VAE-decode each sample in the chunk at B=1, routing through
     /// ``decode_z_image_result`` so non-rank-0 TP ranks return empty

--- a/src/runtime/models/z_image/z_image_diffusion_types.h
+++ b/src/runtime/models/z_image/z_image_diffusion_types.h
@@ -110,4 +110,23 @@ inline bool validate_z_image_initial_latents(std::size_t expected_size, std::siz
     return true;
 }
 
+inline std::vector<int64_t> z_image_text_encoder_input_shape(int32_t input_rank, int32_t seq_len) {
+    if (input_rank == 2) {
+        return {1, static_cast<int64_t>(seq_len)};
+    }
+    return {static_cast<int64_t>(seq_len)};
+}
+
+inline std::vector<float> make_z_image_attention_mask(int32_t num_patches, int32_t text_seq_len,
+                                                      int32_t cap_padded_len) {
+    const int32_t clamped_caption_len =
+        cap_padded_len < 0 ? 0 : (cap_padded_len > text_seq_len ? text_seq_len : cap_padded_len);
+    std::vector<float> mask(static_cast<std::size_t>(num_patches + text_seq_len), -1.0e9F);
+    const auto valid_tokens = static_cast<std::size_t>(num_patches + clamped_caption_len);
+    for (std::size_t index = 0; index < valid_tokens; ++index) {
+        mask[index] = 0.0F;
+    }
+    return mask;
+}
+
 } // namespace trtmc

--- a/tests/cpp/models/z_image/test_z_image_pipeline.cpp
+++ b/tests/cpp/models/z_image/test_z_image_pipeline.cpp
@@ -43,11 +43,30 @@ void test_zimage_initial_latent_contract() {
           "Z-Image rejects one latent for multiple prompts");
 }
 
+void test_zimage_text_encoder_input_shape() {
+    check(trtmc::z_image_text_encoder_input_shape(1, 512) == std::vector<int64_t>({512}),
+          "Z-Image static text encoder keeps rank-1 input");
+    check(trtmc::z_image_text_encoder_input_shape(2, 512) == std::vector<int64_t>({1, 512}),
+          "Z-Image dynamic text encoder adds batch dimension");
+}
+
+void test_zimage_attention_mask() {
+    const auto mask = trtmc::make_z_image_attention_mask(2, 5, 3);
+    check(mask.size() == 7, "Z-Image attention mask covers image and caption tokens");
+    check(mask[0] == 0.0F && mask[1] == 0.0F && mask[2] == 0.0F && mask[3] == 0.0F &&
+              mask[4] == 0.0F,
+          "Z-Image attention mask keeps image and padded HF caption tokens visible");
+    check(mask[5] < -1.0e8F && mask[6] < -1.0e8F,
+          "Z-Image attention mask hides unused fixed caption slots");
+}
+
 } // namespace
 
 int main() {
     test_zimage_construction();
     test_zimage_initial_latent_contract();
+    test_zimage_text_encoder_input_shape();
+    test_zimage_attention_mask();
     if (failures > 0) {
         std::cerr << failures << " z-image pipeline test(s) FAILED\n";
     }

--- a/tests/e2e/models/z_image/test_z_image_dit_batch_profile.py
+++ b/tests/e2e/models/z_image/test_z_image_dit_batch_profile.py
@@ -31,8 +31,7 @@ import pytest
 try:
     from tensorrt_model_connect.families.z_image import z_image_dit_builder
 except (ImportError, ModuleNotFoundError):
-    pytest.skip(
-        "tensorrt_model_connect requires tensorrt", allow_module_level=True)
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
 
 
 # ---------------------------------------------------------------------------
@@ -76,8 +75,10 @@ class _Network:
 
     def __getattr__(self, attr: str):
         if attr.startswith("add_"):
+
             def _factory(*_args, **_kwargs):
                 return _Layer()
+
             return _factory
         raise AttributeError(attr)
 
@@ -91,12 +92,18 @@ def test_static_fp16_attention_uses_fp32_accumulation(
         calls.append(kwargs)
         return _Tensor()
 
-    monkeypatch.setattr(
-        z_image_dit_builder.graph_ops, "add_attention_from_rows", _attention)
+    monkeypatch.setattr(z_image_dit_builder.graph_ops, "add_attention_from_rows", _attention)
 
     z_image_dit_builder._multi_head_attention(
-        None, _Tensor(), _Tensor(), _Tensor(),
-        num_heads=2, head_dim=4, q_seq=8, kv_seq=8, scale_t=0.5,
+        None,
+        _Tensor(),
+        _Tensor(),
+        _Tensor(),
+        num_heads=2,
+        head_dim=4,
+        q_seq=8,
+        kv_seq=8,
+        scale_t=0.5,
         dtype=np.float16,
     )
 
@@ -159,6 +166,7 @@ class _FakeTRT(types.SimpleNamespace):
     class Logger:
         def __init__(self, *_a, **_kw):
             pass
+
         WARNING = 1
         VERBOSE = 2
 
@@ -195,6 +203,7 @@ def _make_tensor(*_a, **_kw) -> _Tensor:
 def _patch_graph_ops(monkeypatch):
     """Replace heavy graph_ops calls with tensor-returning stubs."""
     import tensorrt_model_connect.families.z_image.graph_ops as gops
+
     for name in (
         "add_constant",
         "add_matmul_rhs_constant",
@@ -254,8 +263,7 @@ def _tiny_dit_weights(
             f"{prefix}.ffn_norm2": z((dim,), dtype=np.float32),
         }
         if has_adaln:
-            w[f"{prefix}.adaln.weight"] = z(
-                (adaln_embed_dim, 4 * dim), dtype=np.float32)
+            w[f"{prefix}.adaln.weight"] = z((adaln_embed_dim, 4 * dim), dtype=np.float32)
             w[f"{prefix}.adaln.bias"] = z((4 * dim,), dtype=np.float32)
         return w
 
@@ -286,17 +294,19 @@ def _call_builder(
 
     profile_calls: list[dict] = []
 
-    def _record_profile(builder, config, network, *, input_names,
-                        max_batch, opt_batch, static_shape):
-        profile_calls.append({
-            "input_names": list(input_names),
-            "max_batch": max_batch,
-            "opt_batch": opt_batch,
-            "static_shape": dict(static_shape),
-        })
+    def _record_profile(
+        builder, config, network, *, input_names, max_batch, opt_batch, static_shape
+    ):
+        profile_calls.append(
+            {
+                "input_names": list(input_names),
+                "max_batch": max_batch,
+                "opt_batch": opt_batch,
+                "static_shape": dict(static_shape),
+            }
+        )
 
-    monkeypatch.setattr(
-        z_image_dit_builder, "add_dynamic_batch_profile", _record_profile)
+    monkeypatch.setattr(z_image_dit_builder, "add_dynamic_batch_profile", _record_profile)
 
     holder: dict = {}
     real_builder_cls = _FakeTRT.Builder
@@ -335,6 +345,17 @@ def _call_builder(
 # ---------------------------------------------------------------------------
 
 
+def test_static_dit_accepts_runtime_caption_attention_mask(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Static DiT masks caption slots beyond HF's multiple-of-32 padding."""
+    network, profile_calls = _call_builder(monkeypatch, max_batch_size=1)
+
+    inputs = {name: shape for name, _dtype, shape in network.inputs}
+    assert inputs["attention_mask"] == (17,)
+    assert profile_calls == []
+
+
 def test_dynamic_batch_adds_leading_minus_one_to_all_inputs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -354,12 +375,18 @@ def test_dynamic_batch_adds_leading_minus_one_to_all_inputs(
     assert inputs["timestep_embedding"] == (-1, 6)
     assert inputs["rotary_cos"] == (-1, 17, 2)
     assert inputs["rotary_sin"] == (-1, 17, 2)
+    assert inputs["attention_mask"] == (-1, 17)
 
     assert len(profile_calls) == 1
     call = profile_calls[0]
     assert sorted(call["input_names"]) == [
-        "encoder_hidden_states", "hidden_states", "rotary_cos",
-        "rotary_sin", "timestep_embedding"]
+        "attention_mask",
+        "encoder_hidden_states",
+        "hidden_states",
+        "rotary_cos",
+        "rotary_sin",
+        "timestep_embedding",
+    ]
     assert call["max_batch"] == 4
     assert call["opt_batch"] == 4
     assert call["static_shape"] == {
@@ -368,6 +395,7 @@ def test_dynamic_batch_adds_leading_minus_one_to_all_inputs(
         "timestep_embedding": (6,),
         "rotary_cos": (17, 2),
         "rotary_sin": (17, 2),
+        "attention_mask": (17,),
     }
 
 
@@ -387,4 +415,5 @@ def test_static_fp16_accepts_selective_fp32_dit_layers(
         "timestep_embedding",
         "rotary_cos",
         "rotary_sin",
+        "attention_mask",
     ]

--- a/tests/e2e/models/z_image/test_z_image_dit_batch_profile.py
+++ b/tests/e2e/models/z_image/test_z_image_dit_batch_profile.py
@@ -417,3 +417,48 @@ def test_static_fp16_accepts_selective_fp32_dit_layers(
         "rotary_sin",
         "attention_mask",
     ]
+
+
+def test_sandwich_prescale_params_fp16_scales_and_swaps_eps() -> None:
+    """FP16 blocks pre-scale to_out/ff_w3 and use the compensated post-norm eps."""
+    weights = {
+        "b.to_out": np.ones((4, 4), dtype=np.float32),
+        "b.ff_w3": np.full((4, 4), 2.0, dtype=np.float32),
+    }
+    eps_t, sandwich_eps_t = object(), object()
+
+    w_out, w_ff3, norm_eps = z_image_dit_builder._sandwich_prescale_params(
+        weights, "b", eps_t, sandwich_eps_t, np.float16)
+    alpha = z_image_dit_builder._SANDWICH_PRESCALE
+    np.testing.assert_allclose(w_out, np.full((4, 4), alpha))
+    np.testing.assert_allclose(w_ff3, np.full((4, 4), 2.0 * alpha))
+    assert norm_eps is sandwich_eps_t
+
+    # FP32 blocks (pinned selectors) keep the original weights and epsilon.
+    w_out, w_ff3, norm_eps = z_image_dit_builder._sandwich_prescale_params(
+        weights, "b", eps_t, sandwich_eps_t, np.float32)
+    assert w_out is weights["b.to_out"]
+    assert w_ff3 is weights["b.ff_w3"]
+    assert norm_eps is eps_t
+
+    # FP32 base precision never creates a sandwich constant.
+    w_out, _w_ff3, norm_eps = z_image_dit_builder._sandwich_prescale_params(
+        weights, "b", eps_t, None, np.float16)
+    assert w_out is weights["b.to_out"]
+    assert norm_eps is eps_t
+
+
+def test_sandwich_prescale_epsilon_identity() -> None:
+    """The prescale and epsilon compensation preserve RMSNorm in real arithmetic."""
+    rng = np.random.default_rng(3)
+    x = rng.standard_normal((5, 64)).astype(np.float64) * 37.0
+    gamma = rng.standard_normal(64)
+    eps = 1e-5
+    alpha = z_image_dit_builder._SANDWICH_PRESCALE
+
+    def rms_norm(v, e):
+        return v / np.sqrt((v ** 2).mean(axis=-1, keepdims=True) + e) * gamma
+
+    np.testing.assert_allclose(
+        rms_norm(x, eps), rms_norm(alpha * x, eps * alpha * alpha),
+        rtol=1e-12)

--- a/tests/e2e/models/z_image/test_z_image_family_plugin.py
+++ b/tests/e2e/models/z_image/test_z_image_family_plugin.py
@@ -15,6 +15,7 @@ import json
 import struct
 import sys
 import types
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -27,6 +28,19 @@ try:
     import tensorrt_model_connect.families.z_image as zimg_mod
 except (ImportError, ModuleNotFoundError):
     pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+@pytest.mark.parametrize(
+    "manifest_name",
+    ["z-image-turbo.json", "z-image-turbo-l0.json"],
+)
+def test_caption_mask_manifests_preserve_audited_precision(manifest_name: str) -> None:
+    """Caption parity must preserve the reduced-precision contract from #371."""
+    manifest_path = Path(__file__).parent / "manifests" / manifest_name
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["precision"] == "fp16"
+    assert manifest["fp32_layers"] == [2, 3, 4, 7, 8]
 
 
 def _cfg(**raw_overrides: object) -> ModelConfig:

--- a/tests/e2e/models/z_image/test_z_image_qwen3_encoder_builder.py
+++ b/tests/e2e/models/z_image/test_z_image_qwen3_encoder_builder.py
@@ -326,7 +326,67 @@ def test_build_qwen3_encoder_engine_success_with_gqa_and_negative_output_layer(m
     assert [t.dtype for t in builder.network.outputs] == ["float32"]
     assert attention_calls
     assert all(call["num_kv_heads"] == 1 for call in attention_calls)
+    assert all(call["causal"] is True for call in attention_calls)
+    assert all(call["mask"] is None for call in attention_calls)
     assert not any(op == "add_concatenation" for op, _args, _kwargs in builder.network.calls)
+
+
+@pytest.mark.unit
+def test_qwen3_encoder_negative_output_layer_is_captured_after_selected_layer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HF ``hidden_states[-2]`` is the output after the penultimate decoder layer."""
+    fake_trt = _make_fake_trt()
+    mod = _import_qwen3_with_fake_trt(fake_trt)
+
+    monkeypatch.setattr(mod.graph_ops, "add_constant", _fake_tensor_fn("const"))
+    monkeypatch.setattr(mod.graph_ops, "add_rms_norm", _fake_tensor_fn("rms"))
+    monkeypatch.setattr(mod.graph_ops, "add_matmul_rhs_constant", _fake_tensor_fn("mm"))
+    monkeypatch.setattr(mod.graph_ops, "add_attention_from_rows", _fake_tensor_fn("attention"))
+    residual_outputs: list[_FakeTensor] = []
+    original_add_elementwise = _FakeNetwork.add_elementwise
+
+    def recording_add_elementwise(self, *args, **kwargs):
+        layer = original_add_elementwise(self, *args, **kwargs)
+        if (
+            args[-1] == fake_trt.ElementWiseOperation.SUM
+            and any(getattr(arg, "name", "").startswith("mm_") for arg in args[:-1])
+        ):
+            residual_outputs.append(layer.get_output(0))
+        return layer
+
+    monkeypatch.setattr(_FakeNetwork, "add_elementwise", recording_add_elementwise)
+
+    plan = mod.build_qwen3_encoder_engine(
+        _make_qwen3_weights(
+            hidden_size=4,
+            num_layers=3,
+            num_heads=2,
+            num_kv_heads=1,
+            head_dim=2,
+            intermediate_size=6,
+            vocab_size=10,
+        ),
+        hidden_size=4,
+        num_layers=3,
+        num_heads=2,
+        num_kv_heads=1,
+        head_dim=2,
+        intermediate_size=6,
+        vocab_size=10,
+        max_seq_len=3,
+        output_layer=-2,
+    )
+
+    assert plan == b"engine-plan"
+    builder = fake_trt.Builder.last_instance
+    # The recorder selects the two decoder residual SUMs per layer.
+    # For three layers, HF hidden_states[-2] is the hidden state after layer 1,
+    # i.e. the fourth residual SUM.
+    cast_inputs = [args[0] for op, args, _kwargs in builder.network.calls if op == "add_cast"]
+    assert len(residual_outputs) == 6
+    assert cast_inputs
+    assert cast_inputs[-1] is residual_outputs[3]
 
 
 @pytest.mark.unit

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -1777,6 +1777,43 @@ def test_build_bundle_command_uses_manifest_build_settings(tmp_path: Path) -> No
     assert "--verbose" in cmd
 
 
+def test_build_bundle_command_passes_manifest_fp32_layers(tmp_path: Path) -> None:
+    """Reduced-precision selectors must reach the build, matching the E2E harness."""
+    model = {
+        "name": "case",
+        "hf_id": "org/model",
+        "max_cache_length": 256,
+        "precision": "fp16",
+        "fp32_layers": [2, 3, 4, 7, 8],
+    }
+
+    cmd = task_eval.build_bundle_command(
+        model,
+        trtmc_binary="build/trtmc",
+        bundle_path=tmp_path / "case.trtfb",
+    )
+
+    idx = cmd.index("--fp32-layers")
+    assert cmd[idx : idx + 2] == ["--fp32-layers", "2,3,4,7,8"]
+
+
+def test_build_bundle_command_omits_fp32_layers_when_absent(tmp_path: Path) -> None:
+    model = {
+        "name": "case",
+        "hf_id": "org/model",
+        "max_cache_length": 256,
+        "precision": "fp16",
+    }
+
+    cmd = task_eval.build_bundle_command(
+        model,
+        trtmc_binary="build/trtmc",
+        bundle_path=tmp_path / "case.trtfb",
+    )
+
+    assert "--fp32-layers" not in cmd
+
+
 def test_suite_build_cache_minimum_overrides_manifest_cache() -> None:
     suite = {"build": {"min_max_cache_length": 1024}}
     model = {"max_cache_length": 256}

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -152,6 +152,7 @@ def manifest_record(path: Path) -> dict[str, Any]:
             build_args.get("max_cache_length", 256) if isinstance(build_args, dict) else 256,
         ),
         "precision": raw.get("precision", "fp32"),
+        "fp32_layers": raw.get("fp32_layers", []),
         "quantization": raw.get("quantization", {}),
         "build_args": build_args if isinstance(build_args, dict) else {},
         "fp8_scales": raw.get("fp8_scales", ""),
@@ -5052,6 +5053,10 @@ def build_bundle_command(
     precision = str(model.get("precision", "fp32") or "fp32")
     if precision != "fp32":
         cmd.extend(["--precision", precision])
+    fp32_layers = model.get("fp32_layers") or []
+    if fp32_layers:
+        cmd.extend(
+            ["--fp32-layers", ",".join(str(layer) for layer in fp32_layers)])
     quantization = model.get("quantization", {})
     if isinstance(quantization, dict):
         quant_format = quantization.get("format")


### PR DESCRIPTION
## Background

Refs #386. Deterministic DPG evaluation showed Z-Image HF/TRT background divergence even with identical prompts, seeds, dimensions, steps, and serialized initial latents. The TRT Qwen3 encoder used bidirectional attention and captured the wrong decoder boundary, while the fixed-length DiT attended caption slots that Diffusers excludes.

Correcting those semantics exposed two independent reduced-precision issues under the audited #371 profile (`"precision": "fp16"`, `"fp32_layers": [2,3,4,7,8]`): TensorRT FP16 GEMMs became non-finite when attention/FFN transients approached the FP16 range, and task-eval silently dropped `fp32_layers`, causing an all-FP16 1024px VAE that returned NaN.

An earlier revision used `[1,2]` as a diagnostic workaround. That workaround is removed; this PR preserves #371's selector profile unchanged.

## Exit Criteria

- Match Diffusers Qwen3 causal attention and `hidden_states[-2]` semantics.
- Mask fixed DiT caption slots beyond HF's multiple-of-32 padded span.
- Keep `[2,3,4,7,8]` and produce finite 512px and 1024px denoising.
- Pass the original P2021 DPG limit-10 slice without changing comparison thresholds.
- Ensure task-eval bundle builds honor manifest `fp32_layers`.

## Implementation

- Uses causal Qwen3 attention and captures the selected decoder output after the corresponding layer. The exact runtime prompt matches HF `hidden_states[-2]` at per-token cosine `>= 0.999998`.
- Adds a per-sample DiT additive mask for both static and dynamic-batch builders and propagates it through C++ single-sample and batched runtime paths.
- Prescales one linear stage in each FP16 sandwich-normalized DiT branch by `1/64`: `to_out` for attention and `ff_w3` for the SwiGLU branch. The scale propagates linearly to the post-projection output, while the following RMSNorm epsilon is compensated by `1/4096` in FP32. This keeps TensorRT FP16 GEMM partial accumulations away from overflow while preserving the branch in real arithmetic. FP32-pinned selectors and FP32 base builds are unchanged.
- Propagates manifest `fp32_layers` through `tools/task_eval.py` as `--fp32-layers`, matching the E2E harness.
- Adds a manifest guard that locks Z-Image L0/nightly to `[2,3,4,7,8]`.

## Root-Cause Evidence

- Qwen is not the numerical bug: TRT vs HF `hidden_states[-2]` token cosine has minimum `0.999998`, relative L2 `0.001953`.
- The old 512px path became non-finite at step 1 when attention projection magnitudes approached the FP16 limit. Prescaling `to_out` restores a finite trajectory.
- At 1024px, the mixed-precision Torch replica measured `63104` at `layers.14.feed_forward.w2` input. P2021 TensorRT later became non-finite because internal FP16 GEMM partial accumulations overflowed; prescaling `ff_w3` moves this transient away from the cliff.
- The task-eval omission is independent: the all-FP16 VAE returns NaN for both zero latents and real HF final latents. Forwarding selector `2` restores the audited FP32 VAE.

## Validation

- `PYTHONPATH=python python3 -m pytest -q tests/e2e/models/z_image --ignore=tests/e2e/models/z_image/test_z_image_e2e.py`: `24 passed`.
- `PYTHONPATH=python python3 -m pytest -q tests/tools/test_task_eval.py`: `92 passed`.
- Ruff on all changed Python files: passed.
- P2021 TensorRT 10.16 L0 E2E with a rebuilt bundle and selectors `[2,3,4,7,8]`: passed; all nine steps finite. Fixed-latent step 1 is `[-4.15554, 3.89911]`; HF/TRT frame PSNR independently recomputed as `35.5438 dB`.
- P2021 DPG limit-10 at 1024px with a rebuilt bundle: `10/10`; HF was regenerated. TRT/HF image CLIP cosine mean `0.99237` (min `0.95064`), SSIM mean `0.95755`, prompt-clipscore delta `+0.07167`.
- Pure-FP16 VAE probe: zero latent and real HF latent both reproduce NaN; the selector-aware DPG bundle produces non-degenerate images.

## Notes For Future Readers

- Review order: Qwen builder, DiT mask/runtime plumbing, `_sandwich_prescale_params`, then task-eval forwarding.
- The RMSNorm compensation is an exact real-arithmetic identity; actual FP16 weights still undergo normal quantization. A P2021 audit found prescaling introduced zeros in about `0.000985%` of the affected weight elements, while the deterministic HF/TRT image checks remained close.
- The Z-Image TP builder is unchanged because it rejects per-layer FP32 selectors. If TP FP16 is enabled later, it needs a separate precision audit.
- `tools/task_eval.py` overlaps open PR #396 in a different region and merges cleanly.
- P2021 evidence is under `/localhome/local-chaofengw/trtmc/ai-loop/diffusion-task-eval-2026-06-30/z-image-fp16-fix-3c104e9f/`; the final DPG run is `artifacts/sandwich-v4/`, and the final L0 result is `/tmp/e2e_artifacts/z-image-turbo-l0/result.json`.
