### PR TITLE
feat(diffusion): accept caller-provided initial latents

### DIFF
--- a/src/runtime/models/flux/flux_generation_plan.h
+++ b/src/runtime/models/flux/flux_generation_plan.h
@@ -47,6 +47,21 @@ struct FluxGenerationPlan {
     flux_scheduler::FlowMatchEulerConfig scheduler_config;
 };
 
+inline bool apply_flux_initial_latents(std::size_t expected_size,
+                                       const std::vector<float>& supplied,
+                                       std::vector<float>& latents, std::string& error) {
+    if (supplied.empty()) {
+        return true;
+    }
+    if (supplied.size() != expected_size) {
+        error = "Flux initial latents contain " + std::to_string(supplied.size()) +
+                " floats; expected " + std::to_string(expected_size);
+        return false;
+    }
+    latents = supplied;
+    return true;
+}
+
 inline FluxGenerationPlan make_flux_generation_plan(const FluxDiffusionConfig& config,
                                                     const FluxPreprocessorWeights& weights,
                                                     int32_t requested_steps,

--- a/src/runtime/models/flux/pipeline.cpp
+++ b/src/runtime/models/flux/pipeline.cpp
@@ -1504,6 +1504,10 @@ FluxPipeline::generate_image_batch(const std::vector<std::string>& prompts,
     if (prompts.empty()) {
         return {};
     }
+    if (!cfg.initial_latents.empty() && prompts.size() != 1U) {
+        throw std::invalid_argument(
+            "FluxPipeline::generate_image_batch: caller initial latents require one prompt");
+    }
 
     const auto total = static_cast<int32_t>(prompts.size());
     const int32_t cap = std::max(1, config_.max_batch_size.dit);
@@ -1935,6 +1939,12 @@ ImageResult FluxPipeline::generate_one_for_batch(const std::string& prompt,
     // Override latent init with the per-sample seed; this is the single
     // behavior change vs. the legacy code (which hardcoded seed=42).
     initialize_flux_latents(latents, per_sample_seed);
+    std::string latent_error;
+    if (!diffusion::apply_flux_initial_latents(plan.latent_size, cfg.initial_latents, latents,
+                                               latent_error)) {
+        std::cerr << "[flux] " << latent_error << "\n";
+        return result;
+    }
     const auto t_prep = Clock::now();
 
     // Step 10: Denoising loop

--- a/src/runtime/models/z_image/pipeline.cpp
+++ b/src/runtime/models/z_image/pipeline.cpp
@@ -728,6 +728,15 @@ ZImagePipeline::generate_image_batch(const std::vector<std::string>& prompts,
               << ", patches: " << layout.num_patches << " (" << layout.nh << "x" << layout.nw
               << "), batch=" << prompts.size() << "\n";
 
+    const auto expected_initial_latents = static_cast<std::size_t>(layout.z_dim) *
+                                          static_cast<std::size_t>(layout.h_lat) *
+                                          static_cast<std::size_t>(layout.w_lat);
+    std::string latent_error;
+    if (!validate_z_image_initial_latents(expected_initial_latents, prompts.size(),
+                                          cfg.initial_latents, latent_error)) {
+        throw std::invalid_argument(latent_error);
+    }
+
     if (!z_weights_.valid) {
         std::cerr << "[z-image] WARNING: Z-Image preprocessor weights not loaded.\n";
         return {};
@@ -754,9 +763,9 @@ ZImagePipeline::generate_image_batch(const std::vector<std::string>& prompts,
                   << prompt_offset << ".."
                   << (prompt_offset + static_cast<std::size_t>(chunk_size) - 1U) << "]\n";
 
-        auto chunk_results = generate_image_batch_chunk(prompts, resolved_seeds, prompt_offset,
-                                                        chunk_size, layout, num_inference_steps,
-                                                        config_.freq_dim, engine_is_batched, cap);
+        auto chunk_results = generate_image_batch_chunk(
+            prompts, resolved_seeds, prompt_offset, chunk_size, layout, num_inference_steps,
+            config_.freq_dim, engine_is_batched, cap, cfg.initial_latents);
         if (chunk_results.empty()) {
             // Fail-fast: any per-chunk failure (encoder / DiT) zeroes the
             // chunk result and we surface an empty batch result, matching
@@ -793,7 +802,8 @@ int32_t ZImagePipeline::resolve_batch_cap(bool engine_is_batched) const {
 std::vector<ImageResult> ZImagePipeline::generate_image_batch_chunk(
     const std::vector<std::string>& prompts, const std::vector<std::uint32_t>& resolved_seeds,
     std::size_t prompt_offset, int32_t batch, const ZImageLayout& layout,
-    int32_t num_inference_steps, int32_t freq_dim, bool engine_is_batched, int32_t /*cap*/) {
+    int32_t num_inference_steps, int32_t freq_dim, bool engine_is_batched, int32_t /*cap*/,
+    const std::vector<float>& supplied_initial_latents) {
     const auto latent_size = static_cast<std::size_t>(layout.z_dim) *
                              static_cast<std::size_t>(layout.h_lat) *
                              static_cast<std::size_t>(layout.w_lat);
@@ -809,7 +819,8 @@ std::vector<ImageResult> ZImagePipeline::generate_image_batch_chunk(
     std::vector<float> latents(static_cast<std::size_t>(batch) * latent_size);
 
     if (!run_qwen3_encoder_for_chunk(prompts, resolved_seeds, prompt_offset, batch, layout,
-                                     caption_projected_b, rope_cos_b, rope_sin_b, latents)) {
+                                     caption_projected_b, rope_cos_b, rope_sin_b, latents,
+                                     supplied_initial_latents)) {
         return {};
     }
 
@@ -829,7 +840,8 @@ bool ZImagePipeline::run_qwen3_encoder_for_chunk(
     const std::vector<std::string>& prompts, const std::vector<std::uint32_t>& resolved_seeds,
     std::size_t prompt_offset, int32_t batch, const ZImageLayout& layout,
     std::vector<float>& caption_projected_b, std::vector<float>& rope_cos_b,
-    std::vector<float>& rope_sin_b, std::vector<float>& latents) {
+    std::vector<float>& rope_sin_b, std::vector<float>& latents,
+    const std::vector<float>& supplied_initial_latents) {
     const auto latent_size = static_cast<std::size_t>(layout.z_dim) *
                              static_cast<std::size_t>(layout.h_lat) *
                              static_cast<std::size_t>(layout.w_lat);
@@ -869,8 +881,13 @@ bool ZImagePipeline::run_qwen3_encoder_for_chunk(
                   rope_sin_b.begin() +
                       static_cast<std::ptrdiff_t>(b) * static_cast<std::ptrdiff_t>(rope_size));
 
-        initialize_latents_data(latents.data() + static_cast<std::size_t>(b) * latent_size,
-                                latent_size, resolved_seeds[sample_idx]);
+        if (!supplied_initial_latents.empty()) {
+            std::copy(supplied_initial_latents.begin(), supplied_initial_latents.end(),
+                      latents.begin());
+        } else {
+            initialize_latents_data(latents.data() + static_cast<std::size_t>(b) * latent_size,
+                                    latent_size, resolved_seeds[sample_idx]);
+        }
     }
     return true;
 }

--- a/src/runtime/models/z_image/pipeline.h
+++ b/src/runtime/models/z_image/pipeline.h
@@ -125,7 +125,8 @@ class ZImagePipeline final : public IPipeline {
     std::vector<ImageResult> generate_image_batch_chunk(
         const std::vector<std::string>& prompts, const std::vector<std::uint32_t>& resolved_seeds,
         std::size_t prompt_offset, int32_t batch, const ZImageLayout& layout,
-        int32_t num_inference_steps, int32_t freq_dim, bool engine_is_batched, int32_t cap);
+        int32_t num_inference_steps, int32_t freq_dim, bool engine_is_batched, int32_t cap,
+        const std::vector<float>& supplied_initial_latents);
 
     /// Run the Qwen3 text encoder + caption projection + RoPE + latent
     /// initialization for every sample in a chunk. Fills the four batched
@@ -136,7 +137,8 @@ class ZImagePipeline final : public IPipeline {
                                      const ZImageLayout& layout,
                                      std::vector<float>& caption_projected_b,
                                      std::vector<float>& rope_cos_b, std::vector<float>& rope_sin_b,
-                                     std::vector<float>& latents);
+                                     std::vector<float>& latents,
+                                     const std::vector<float>& supplied_initial_latents);
 
     /// Run the FlowMatchEuler denoise loop for one chunk. ``latents`` is
     /// updated in-place. Returns false if any DiT invocation fails.

--- a/src/runtime/models/z_image/z_image_diffusion_types.h
+++ b/src/runtime/models/z_image/z_image_diffusion_types.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -90,5 +91,23 @@ struct ZImageCommonPreprocessorWeights {
 
     bool valid{false};
 };
+
+inline bool validate_z_image_initial_latents(std::size_t expected_size, std::size_t prompt_count,
+                                             const std::vector<float>& supplied,
+                                             std::string& error) {
+    if (supplied.empty()) {
+        return true;
+    }
+    if (prompt_count != 1U) {
+        error = "Z-Image caller initial latents require exactly one prompt";
+        return false;
+    }
+    if (supplied.size() != expected_size) {
+        error = "Z-Image initial latents contain " + std::to_string(supplied.size()) +
+                " floats; expected " + std::to_string(expected_size);
+        return false;
+    }
+    return true;
+}
 
 } // namespace trtmc

--- a/tests/cpp/models/flux/test_flux_generation_plan.cpp
+++ b/tests/cpp/models/flux/test_flux_generation_plan.cpp
@@ -77,10 +77,28 @@ void test_flux_generation_plan_derives_layout_and_scheduler() {
     check(scheduler.last_used_dynamic_shifting, "flux scheduler records dynamic shifting");
 }
 
+void test_flux_initial_latents_honor_caller_bytes_and_size() {
+    std::vector<float> latents(4, 0.0F);
+    std::string error;
+    const std::vector<float> supplied = {1.0F, 2.0F, 3.0F, 4.0F};
+
+    check(trtmc::diffusion::apply_flux_initial_latents(supplied.size(), supplied, latents, error),
+          "flux accepts caller initial latents");
+    check(latents == supplied, "flux preserves caller initial latent bytes");
+
+    error.clear();
+    check(!trtmc::diffusion::apply_flux_initial_latents(supplied.size() + 1, supplied, latents,
+                                                        error),
+          "flux rejects wrong caller initial latent size");
+    check(error.find("initial latents") != std::string::npos,
+          "flux reports caller initial latent size mismatch");
+}
+
 } // namespace
 
 int main() {
     test_flux_generation_plan_derives_layout_and_scheduler();
+    test_flux_initial_latents_honor_caller_bytes_and_size();
 
     if (g_failures != 0) {
         std::cerr << g_failures << " flux generation plan test(s) failed\n";

--- a/tests/cpp/models/z_image/test_z_image_pipeline.cpp
+++ b/tests/cpp/models/z_image/test_z_image_pipeline.cpp
@@ -32,10 +32,22 @@ void test_zimage_construction() {
     check(std::string(pipeline.model_id()) == "test-zimage", "ZImagePipeline model_id");
 }
 
+void test_zimage_initial_latent_contract() {
+    std::string error;
+    const std::vector<float> supplied(16, 1.0F);
+    check(trtmc::validate_z_image_initial_latents(supplied.size(), 1, supplied, error),
+          "Z-Image accepts exact caller latent size");
+    check(!trtmc::validate_z_image_initial_latents(supplied.size() + 1, 1, supplied, error),
+          "Z-Image rejects wrong caller latent size");
+    check(!trtmc::validate_z_image_initial_latents(supplied.size(), 2, supplied, error),
+          "Z-Image rejects one latent for multiple prompts");
+}
+
 } // namespace
 
 int main() {
     test_zimage_construction();
+    test_zimage_initial_latent_contract();
     if (failures > 0) {
         std::cerr << failures << " z-image pipeline test(s) FAILED\n";
     }


### PR DESCRIPTION
## Background

Deterministic HF/TRT diffusion comparison requires both implementations to start from the exact same latent tensor. The public generation configuration already carries caller-provided initial latents, but Flux and Z-Image runtime pipelines ignored that field and always generated their own latent bytes.

## Exit Criteria

- Flux and Z-Image single-prompt generation accept exact caller-provided initial latent bytes.
- Invalid latent sizes and ambiguous multi-prompt overrides fail explicitly.
- The runtime capability remains independent of task-eval and model-parity fixes.

## Implementation

- Adds Flux latent-size validation and replaces generated latents only when a caller override is present.
- Adds the equivalent Z-Image shape and single-prompt contract and threads the override through chunk preparation.
- Preserves existing seeded latent generation when no override is supplied.
- Adds focused C++ tests for byte preservation, shape rejection, and the single-prompt restriction.

## Validation

- `python tools/legal_headers.py --check`: passed with zero findings.
- `clang-format --dry-run --Werror <changed C++ files>`: passed after rebasing onto current `main`.
- `python tools/check_cyclomatic_complexity.py src --exclude src/cli --max-ccn 10 --top 20`: passed; maximum CCN is 10.
- P2021 main-based isolated checkout: built and passed `test_flux_generation_plan`.
- P2021 main-based isolated checkout: built the Z-Image plugin and passed `test_z_image_pipeline`.

## Notes For Future Readers

- This is a runtime capability, not a task-eval suite change. PR #385 consumes it to guarantee deterministic comparison.
- Caller-provided latents currently require one prompt because one flat tensor cannot unambiguously describe a multi-sample batch.
- This PR and #387 touch the same Z-Image runtime files for different reasons. Whichever merges second should rebase; the behaviors are complementary.
