### PR TITLE
fix(pixart): align runtime generation with Diffusers

### DIFF
--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -334,6 +334,32 @@ def _diffusion_tokenizer_add_special_tokens_from_plugin(
     return bool(detector(model_dir_path, **kwargs))
 
 
+def _diffusion_tokenizer_special_frame_from_plugin(
+    plugin,
+    model_dir_path: Path,
+    *,
+    detect_tokenizer_special_frame=None,
+) -> tuple[list[int], list[int]] | None:
+    detector = getattr(plugin, "diffusion_tokenizer_special_frame", None)
+    if not callable(detector):
+        return None
+    if detect_tokenizer_special_frame is None:
+        detect_tokenizer_special_frame = _detect_tokenizer_special_frame
+    kwargs = {}
+    if _call_supports_kwarg(detector, "detect_tokenizer_special_frame"):
+        kwargs["detect_tokenizer_special_frame"] = detect_tokenizer_special_frame
+    frame = detector(model_dir_path, **kwargs)
+    if frame is None:
+        return None
+    if not isinstance(frame, tuple) or len(frame) != 2:
+        raise TypeError(
+            f"Plugin {plugin.name}.diffusion_tokenizer_special_frame() must "
+            "return (prefix_ids, suffix_ids) or None"
+        )
+    prefix, suffix = frame
+    return [int(token_id) for token_id in prefix], [int(token_id) for token_id in suffix]
+
+
 def _diffusion_tokenizer_bundle_sections_from_plugin(
     plugin,
     model_dir_path: Path,
@@ -1475,8 +1501,17 @@ def _build_diffusion_bundle(
     trt_version = _get_trt_version()
     trt_abi = _trt_abi_from_version(trt_version)
     tokenizer_t0 = time.monotonic()
-    tokenizer_add_special_tokens = _diffusion_tokenizer_add_special_tokens_from_plugin(
+    tokenizer_special_frame = _diffusion_tokenizer_special_frame_from_plugin(
         plugin, model_dir_path)
+    if tokenizer_special_frame is None:
+        tokenizer_special_prefix_ids: list[int] = []
+        tokenizer_special_suffix_ids: list[int] = []
+        tokenizer_add_special_tokens = _diffusion_tokenizer_add_special_tokens_from_plugin(
+            plugin, model_dir_path)
+    else:
+        tokenizer_special_prefix_ids, tokenizer_special_suffix_ids = tokenizer_special_frame
+        tokenizer_add_special_tokens = bool(
+            tokenizer_special_prefix_ids or tokenizer_special_suffix_ids)
     _add_build_timing(
         build_timing, "tokenizer_special_tokens_detection_s",
         time.monotonic() - tokenizer_t0)
@@ -1502,6 +1537,9 @@ def _build_diffusion_bundle(
             "trt_version": trt_version,
             "tokenizer_add_special_tokens": int(tokenizer_add_special_tokens),
         }
+        if tokenizer_special_frame is not None:
+            cfg_dict["tokenizer_special_prefix_ids"] = tokenizer_special_prefix_ids
+            cfg_dict["tokenizer_special_suffix_ids"] = tokenizer_special_suffix_ids
         if trt_abi:
             cfg_dict["trt_abi"] = trt_abi
         if fp8_scales:

--- a/python/tensorrt_model_connect/families/pixart/plugin.py
+++ b/python/tensorrt_model_connect/families/pixart/plugin.py
@@ -169,8 +169,8 @@ class PixArtPlugin:
         head_dim = tc.get("attention_head_dim", self._DIT_HEAD_DIM)
         dit_dim = num_heads * head_dim
         num_layers = tc.get("num_layers", self._DIT_NUM_LAYERS)
-        tc.get("in_channels", self._DIT_IN_CHANNELS)
         patch_size = tc.get("patch_size", self._DIT_PATCH_SIZE)
+        tc.get("in_channels", self._DIT_IN_CHANNELS)
         cross_attn_dim = tc.get("cross_attention_dim", dit_dim)
         ffn_dim = dit_dim * 4  # PixArt uses 4x multiplier
 
@@ -351,6 +351,18 @@ class PixArtPlugin:
                 return bool(detect_tokenizer_add_special_tokens(tok_dir))
         return bool(detect_tokenizer_add_special_tokens(model_dir))
 
+    def diffusion_tokenizer_special_frame(
+        self, model_dir_path, *, detect_tokenizer_special_frame,
+    ):
+        from pathlib import Path
+
+        model_dir = Path(model_dir_path)
+        for tok_subdir in ("tokenizer_2", "tokenizer"):
+            tok_dir = model_dir / tok_subdir
+            if tok_dir.is_dir():
+                return detect_tokenizer_special_frame(tok_dir)
+        return detect_tokenizer_special_frame(model_dir)
+
     def diffusion_tokenizer_bundle_sections(
         self, model_dir_path, *, ensure_tokenizer_json,
     ) -> list[tuple[str, bytes]]:
@@ -404,6 +416,11 @@ class PixArtPlugin:
         head_dim = tc.get("attention_head_dim", self._DIT_HEAD_DIM)
         dit_dim = num_heads * head_dim
         num_layers = tc.get("num_layers", self._DIT_NUM_LAYERS)
+        patch_size = tc.get("patch_size", self._DIT_PATCH_SIZE)
+        sample_size = tc.get("sample_size", self._IMAGE_HEIGHT // self._VAE_SCALE_FACTOR)
+        interpolation_scale = tc.get("interpolation_scale")
+        if interpolation_scale is None:
+            interpolation_scale = max(sample_size // 64, 1)
 
         return {
             "diffusion_backend_type": "wan_3d",
@@ -418,7 +435,7 @@ class PixArtPlugin:
             "dit_dim": dit_dim,
             "dit_num_heads": num_heads,
             "dit_num_layers": num_layers,
-            "patch_size": [1, self._DIT_PATCH_SIZE, self._DIT_PATCH_SIZE],
+            "patch_size": [1, patch_size, patch_size],
             "z_dim": self._VAE_LATENT_CHANNELS,
             "scale_factor_temporal": 1,
             "scale_factor_spatial": self._VAE_SCALE_FACTOR,
@@ -433,6 +450,8 @@ class PixArtPlugin:
             "text_encoder_dim": self._T5_D_MODEL,
             "vae_scaling_factor": self._VAE_SCALING_FACTOR,
             "use_rope": 0,  # PixArt uses fixed sinusoidal pos embed
+            "pos_embed_base_size": sample_size // patch_size,
+            "pos_embed_interpolation_scale": interpolation_scale,
         }
 
 

--- a/src/runtime/models/pixart/diffusion_helpers.cpp
+++ b/src/runtime/models/pixart/diffusion_helpers.cpp
@@ -133,6 +133,9 @@ PixArtDiffusionConfig make_diffusion_config(const std::string& json) {
     dc.guidance_embeds = extract_json_int(json, "guidance_embeds", 0) != 0;
     dc.use_rope = extract_json_int(json, "use_rope", 1) != 0;
     dc.vae_scaling_factor = extract_json_float(json, "vae_scaling_factor", 0.0F);
+    dc.pos_embed_base_size = extract_json_int(json, "pos_embed_base_size", 64);
+    dc.pos_embed_interpolation_scale =
+        extract_json_float(json, "pos_embed_interpolation_scale", 2.0F);
     dc.diffusion_backend_type = extract_json_string(json, "diffusion_backend_type", "wan_3d");
     return dc;
 }

--- a/src/runtime/models/pixart/pipeline.cpp
+++ b/src/runtime/models/pixart/pipeline.cpp
@@ -11,6 +11,7 @@
 #include "runtime/models/pixart/pipeline.h"
 
 #include "runtime/models/pixart/pixart_denoising_step_seam.h"
+#include "runtime/models/pixart/pixart_dpmsolver.h"
 #include "runtime/models/pixart/pixart_generation_conditioning.h"
 #include "runtime/models/pixart/pixart_generation_plan.h"
 
@@ -25,77 +26,9 @@ namespace trtmc {
 
 namespace {
 
+using diffusion::DPMSolverMultistepState;
 using diffusion::PixArtLayout;
 using diffusion::pixart_scheduler::FlowMatchEulerState;
-
-// ---------------------------------------------------------------------------
-// DDIM Scheduler (epsilon-prediction models like PixArt)
-// ---------------------------------------------------------------------------
-
-struct DDIMState {
-    std::vector<double> sigmas; // [num_steps + 1]
-    std::vector<float> timesteps;
-    int32_t num_train_timesteps{1000};
-    std::vector<double> prev_x0;
-    double prev_lambda_src{0.0};
-    bool has_prev{false};
-
-    void set_timesteps(int32_t num_steps, double beta_start = 0.0001, double beta_end = 0.02) {
-        const int32_t T = num_train_timesteps;
-        std::vector<double> alpha_cumprod(static_cast<std::size_t>(T));
-        double cum = 1.0;
-        for (int32_t i = 0; i < T; ++i) {
-            double beta = beta_start + static_cast<double>(i) / static_cast<double>(T - 1) *
-                                           (beta_end - beta_start);
-            cum *= (1.0 - beta);
-            alpha_cumprod[static_cast<std::size_t>(i)] = cum;
-        }
-        timesteps.resize(static_cast<std::size_t>(num_steps));
-        for (int32_t i = 0; i < num_steps; ++i) {
-            double frac = static_cast<double>(i) / static_cast<double>(num_steps);
-            timesteps[static_cast<std::size_t>(i)] =
-                static_cast<float>(std::round((1.0 - frac) * (T - 1)));
-        }
-        sigmas.resize(static_cast<std::size_t>(num_steps) + 1);
-        for (int32_t i = 0; i < num_steps; ++i) {
-            const int32_t t =
-                static_cast<int32_t>(std::round(timesteps[static_cast<std::size_t>(i)]));
-            const double acp =
-                alpha_cumprod[static_cast<std::size_t>(std::max(0, std::min(t, T - 1)))];
-            sigmas[static_cast<std::size_t>(i)] = std::sqrt((1.0 - acp) / acp);
-        }
-        sigmas[static_cast<std::size_t>(num_steps)] = 0.0;
-    }
-
-    void step(const float* eps_pred, const float* x_t, float* x_out, std::size_t count,
-              int32_t step_index) {
-        const auto si = static_cast<std::size_t>(step_index);
-
-        const double raw_src = sigmas[si];
-        const double raw_tgt = sigmas[si + 1];
-        const double alp_src = 1.0 / std::sqrt(1.0 + raw_src * raw_src);
-        const double sig_src = raw_src / std::sqrt(1.0 + raw_src * raw_src);
-        const double alp_tgt = 1.0 / std::sqrt(1.0 + raw_tgt * raw_tgt);
-        const double sig_tgt = raw_tgt / std::sqrt(1.0 + raw_tgt * raw_tgt);
-
-        double lam_src = std::log(alp_src / sig_src);
-        double lam_tgt = std::log(alp_tgt / sig_tgt);
-        double h = lam_tgt - lam_src;
-
-        double ratio = sig_tgt / sig_src;
-        double coeff = -alp_tgt * std::expm1(-h);
-
-        std::vector<double> x0(count);
-        for (std::size_t i = 0; i < count; ++i) {
-            x0[i] = (static_cast<double>(x_t[i]) - sig_src * static_cast<double>(eps_pred[i])) /
-                    alp_src;
-        }
-
-        for (std::size_t i = 0; i < count; ++i) {
-            x_out[i] = static_cast<float>(ratio * static_cast<double>(x_t[i]) + coeff * x0[i]);
-        }
-    }
-};
 
 // ---------------------------------------------------------------------------
 // CPU math helpers (standalone — replaces DiffusionBackendBase methods)
@@ -249,11 +182,14 @@ void compose_pixart_vae_video_frames(const std::vector<float>& all_raw_frames, i
 // Positional embedding
 // ---------------------------------------------------------------------------
 
-void compute_pixart_pos_embed_2d(int32_t nh_p, int32_t nw_p, int32_t dim,
-                                 std::vector<float>& pos_embed_2d) {
+void compute_pixart_pos_embed_2d(int32_t nh_p, int32_t nw_p, int32_t dim, int32_t base_grid_size,
+                                 float interpolation_scale, std::vector<float>& pos_embed_2d) {
     const int32_t half_dim = dim / 2;
     const int32_t quarter_dim = half_dim / 2;
-    const float interp_scale = 2.0F;
+    const float height_scale =
+        diffusion::pixart_position_scale(nh_p, base_grid_size, interpolation_scale);
+    const float width_scale =
+        diffusion::pixart_position_scale(nw_p, base_grid_size, interpolation_scale);
     pos_embed_2d.assign(static_cast<std::size_t>(nh_p * nw_p) * static_cast<std::size_t>(dim),
                         0.0F);
 
@@ -268,8 +204,8 @@ void compute_pixart_pos_embed_2d(int32_t nh_p, int32_t nw_p, int32_t dim,
             const int32_t patch_idx = hi * nw_p + wi;
             float* row = pos_embed_2d.data() +
                          static_cast<std::size_t>(patch_idx) * static_cast<std::size_t>(dim);
-            const double h_pos = static_cast<double>(hi) / static_cast<double>(interp_scale);
-            const double w_pos = static_cast<double>(wi) / static_cast<double>(interp_scale);
+            const double h_pos = static_cast<double>(hi) * static_cast<double>(height_scale);
+            const double w_pos = static_cast<double>(wi) * static_cast<double>(width_scale);
             for (int32_t d = 0; d < quarter_dim; ++d) {
                 const double angle_w = w_pos * omega[static_cast<std::size_t>(d)];
                 row[d] = static_cast<float>(std::sin(angle_w));
@@ -311,7 +247,7 @@ bool predict_pixart_noise(const std::vector<float>& hidden, const std::vector<fl
         std::vector<float> uncond_pred;
         std::vector<float> null_mask;
         if (!encoder_attn_mask.empty()) {
-            null_mask.assign(encoder_attn_mask.size(), 0.0F);
+            null_mask = diffusion::make_pixart_null_attention_mask(encoder_attn_mask.size());
         }
 
         if (!run_denoiser(hidden, temb_6d, time_embed, text_projected, encoder_attn_mask, cond_pred,
@@ -373,7 +309,7 @@ void maybe_truncate_pixart_output(std::vector<float>& denoiser_output, int32_t n
 // Scheduler step dispatch
 // ---------------------------------------------------------------------------
 
-void apply_pixart_scheduler_step(bool use_ddim, DDIMState& ddim_scheduler,
+void apply_pixart_scheduler_step(bool use_ddim, DPMSolverMultistepState& ddim_scheduler,
                                  FlowMatchEulerState& fm_scheduler,
                                  const std::vector<float>& noise_pred_spatial,
                                  std::vector<float>& latents, std::size_t latent_count,
@@ -424,7 +360,7 @@ bool run_pixart_denoising_loop(
     int32_t num_inference_steps, bool use_ddim, float guidance_scale, const PixArtLayout& layout,
     const std::vector<float>& step_timesteps, const std::vector<float>& pos_embed_2d,
     const std::vector<float>& text_projected, const std::vector<float>& null_text,
-    const std::vector<float>& encoder_attn_mask, DDIMState& ddim_scheduler,
+    const std::vector<float>& encoder_attn_mask, DPMSolverMultistepState& ddim_scheduler,
     FlowMatchEulerState& fm_scheduler, std::vector<float>& latents, std::string& error,
     ComputeTembFn&& compute_temb, PatchifyFn&& patchify, EmbedHiddenFn&& embed_hidden,
     UnpatchifyFn&& unpatchify, RunDenoiserFn&& run_denoiser) {
@@ -1186,18 +1122,24 @@ ImageResult PixArtPipeline::generate_image(const std::string& prompt, const Gene
     if (config_.use_rope) {
         compute_3d_rope(layout.nt, layout.nh_p, layout.nw_p, rope_cos, rope_sin);
     } else {
-        compute_pixart_pos_embed_2d(layout.nh_p, layout.nw_p, layout.dim, pos_embed_2d);
+        compute_pixart_pos_embed_2d(layout.nh_p, layout.nw_p, layout.dim,
+                                    config_.pos_embed_base_size,
+                                    config_.pos_embed_interpolation_scale, pos_embed_2d);
     }
 
-    // Initialize random latents
-    std::vector<float> latents = diffusion::make_pixart_initial_latents(plan.latent_count);
+    // Use caller-provided latents for cross-runtime parity; otherwise honor the requested seed.
+    std::vector<float> latents;
+    if (!diffusion::resolve_pixart_initial_latents(plan.latent_count, cfg.initial_latents, cfg.seed,
+                                                   latents, error)) {
+        std::cerr << "[diffusion] " << error << "\n";
+        return video_to_image(result, config_.video_height, config_.video_width);
+    }
 
     // Set up scheduler
     FlowMatchEulerState fm_scheduler;
-    DDIMState ddim_scheduler;
+    DPMSolverMultistepState ddim_scheduler;
     std::vector<float> step_timesteps;
     if (plan.use_ddim) {
-        ddim_scheduler.num_train_timesteps = 1000;
         ddim_scheduler.set_timesteps(plan.num_inference_steps);
         step_timesteps = ddim_scheduler.timesteps;
     } else {

--- a/src/runtime/models/pixart/pixart_diffusion_types.h
+++ b/src/runtime/models/pixart/pixart_diffusion_types.h
@@ -47,6 +47,8 @@ struct PixArtDiffusionConfig {
     bool guidance_embeds{false};
     bool use_rope{true};
     float vae_scaling_factor{0.0F};
+    int32_t pos_embed_base_size{64};
+    float pos_embed_interpolation_scale{2.0F};
 
     std::string diffusion_backend_type;
 

--- a/src/runtime/models/pixart/pixart_dpmsolver.h
+++ b/src/runtime/models/pixart/pixart_dpmsolver.h
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace trtmc::diffusion {
+
+class DPMSolverMultistepState {
+  public:
+    void set_timesteps(int32_t num_steps, double beta_start = 0.0001, double beta_end = 0.02) {
+        if (num_steps <= 0) {
+            throw std::invalid_argument("DPMSolver requires at least one inference step");
+        }
+        constexpr int32_t kTrainTimesteps = 1000;
+        alpha_t_.resize(kTrainTimesteps);
+        sigma_t_.resize(kTrainTimesteps);
+        lambda_t_.resize(kTrainTimesteps);
+        double cumulative_alpha = 1.0;
+        for (int32_t index = 0; index < kTrainTimesteps; ++index) {
+            const double beta = beta_start + static_cast<double>(index) /
+                                                 static_cast<double>(kTrainTimesteps - 1) *
+                                                 (beta_end - beta_start);
+            cumulative_alpha *= 1.0 - beta;
+            const auto offset = static_cast<std::size_t>(index);
+            alpha_t_[offset] = std::sqrt(cumulative_alpha);
+            sigma_t_[offset] = std::sqrt(1.0 - cumulative_alpha);
+            lambda_t_[offset] = std::log(alpha_t_[offset] / sigma_t_[offset]);
+        }
+
+        timesteps.resize(static_cast<std::size_t>(num_steps));
+        for (int32_t index = 0; index < num_steps; ++index) {
+            const double fraction = static_cast<double>(index) / static_cast<double>(num_steps);
+            timesteps[static_cast<std::size_t>(index)] =
+                static_cast<float>(std::round((1.0 - fraction) * (kTrainTimesteps - 1)));
+        }
+        model_outputs_.clear();
+    }
+
+    void step(const float* epsilon, const float* sample, float* output, std::size_t count,
+              int32_t step_index) {
+        if (step_index < 0 || step_index >= static_cast<int32_t>(timesteps.size())) {
+            throw std::out_of_range("DPMSolver step index is outside the timestep schedule");
+        }
+        const int32_t source_timestep = timestep_at(step_index);
+        const auto source = static_cast<std::size_t>(source_timestep);
+        record_model_output(epsilon, sample, count, source);
+
+        const bool final_step = step_index + 1 == static_cast<int32_t>(timesteps.size());
+        const double target_alpha = final_step ? 1.0 : alpha_at(step_index + 1);
+        const double target_sigma = final_step ? 0.0 : sigma_at(step_index + 1);
+        const double target_lambda =
+            final_step ? std::numeric_limits<double>::infinity() : lambda_at(step_index + 1);
+        const double h = target_lambda - lambda_t_[source];
+        const double ratio = target_sigma / sigma_t_[source];
+        const double first_order_coefficient = -target_alpha * std::expm1(-h);
+
+        const bool use_first_order = step_index == 0 || final_step || model_outputs_.size() < 2;
+        if (use_first_order) {
+            write_first_order_output(sample, output, count, ratio, first_order_coefficient,
+                                     model_outputs_.back());
+            return;
+        }
+        write_second_order_output(sample, output, count, step_index, source, h, ratio,
+                                  first_order_coefficient);
+    }
+
+    std::vector<float> timesteps;
+
+  private:
+    void record_model_output(const float* epsilon, const float* sample, std::size_t count,
+                             std::size_t source) {
+        std::vector<double> predicted_x0(count);
+        for (std::size_t index = 0; index < count; ++index) {
+            predicted_x0[index] = (static_cast<double>(sample[index]) -
+                                   sigma_t_[source] * static_cast<double>(epsilon[index])) /
+                                  alpha_t_[source];
+        }
+        model_outputs_.push_back(std::move(predicted_x0));
+        if (model_outputs_.size() > 2) {
+            model_outputs_.erase(model_outputs_.begin());
+        }
+    }
+
+    static void write_first_order_output(const float* sample, float* output, std::size_t count,
+                                         double ratio, double first_order_coefficient,
+                                         const std::vector<double>& current_x0) {
+        for (std::size_t index = 0; index < count; ++index) {
+            output[index] = static_cast<float>(ratio * static_cast<double>(sample[index]) +
+                                               first_order_coefficient * current_x0[index]);
+        }
+    }
+
+    void write_second_order_output(const float* sample, float* output, std::size_t count,
+                                   int32_t step_index, std::size_t source, double h, double ratio,
+                                   double first_order_coefficient) const {
+        const int32_t previous_source_timestep = timestep_at(step_index - 1);
+        const double previous_h =
+            lambda_t_[source] - lambda_t_[static_cast<std::size_t>(previous_source_timestep)];
+        const double r0 = previous_h / h;
+        const auto& previous_x0 = model_outputs_[0];
+        const auto& current_x0 = model_outputs_[1];
+        for (std::size_t index = 0; index < count; ++index) {
+            const double derivative = (current_x0[index] - previous_x0[index]) / r0;
+            output[index] = static_cast<float>(ratio * static_cast<double>(sample[index]) +
+                                               first_order_coefficient * current_x0[index] +
+                                               0.5 * first_order_coefficient * derivative);
+        }
+    }
+
+    int32_t timestep_at(int32_t step_index) const {
+        return std::clamp(
+            static_cast<int32_t>(std::round(timesteps[static_cast<std::size_t>(step_index)])), 0,
+            999);
+    }
+
+    double alpha_at(int32_t step_index) const {
+        return alpha_t_[static_cast<std::size_t>(timestep_at(step_index))];
+    }
+
+    double sigma_at(int32_t step_index) const {
+        return sigma_t_[static_cast<std::size_t>(timestep_at(step_index))];
+    }
+
+    double lambda_at(int32_t step_index) const {
+        return lambda_t_[static_cast<std::size_t>(timestep_at(step_index))];
+    }
+
+    std::vector<double> alpha_t_;
+    std::vector<double> sigma_t_;
+    std::vector<double> lambda_t_;
+    std::vector<std::vector<double>> model_outputs_;
+};
+
+} // namespace trtmc::diffusion

--- a/src/runtime/models/pixart/pixart_generation_conditioning.h
+++ b/src/runtime/models/pixart/pixart_generation_conditioning.h
@@ -27,6 +27,14 @@ struct PixArtTextConditioning {
     std::vector<float> null_text;
 };
 
+inline std::vector<float> make_pixart_null_attention_mask(std::size_t sequence_length) {
+    std::vector<float> mask(sequence_length, -10000.0F);
+    if (!mask.empty()) {
+        mask[0] = 0.0F;
+    }
+    return mask;
+}
+
 inline PixArtConditioningInputs
 make_pixart_conditioning_inputs(const PixArtDiffusionConfig& config, const PixArtLayout& layout,
                                 const std::vector<int32_t>& input_ids) {
@@ -86,6 +94,25 @@ inline std::vector<float> make_pixart_initial_latents(std::size_t latent_count,
             latents[index + 1] = static_cast<float>(radius * std::sin(theta));
     }
     return latents;
+}
+
+inline bool resolve_pixart_initial_latents(std::size_t latent_count,
+                                           const std::vector<float>& supplied_latents,
+                                           int32_t requested_seed, std::vector<float>& latents,
+                                           std::string& error) {
+    if (!supplied_latents.empty()) {
+        if (supplied_latents.size() != latent_count) {
+            error = "PixArt initial latents contain " + std::to_string(supplied_latents.size()) +
+                    " floats; expected " + std::to_string(latent_count);
+            return false;
+        }
+        latents = supplied_latents;
+        return true;
+    }
+
+    const auto seed = requested_seed >= 0 ? static_cast<uint32_t>(requested_seed) : 42U;
+    latents = make_pixart_initial_latents(latent_count, seed);
+    return true;
 }
 
 } // namespace diffusion

--- a/src/runtime/models/pixart/pixart_generation_plan.h
+++ b/src/runtime/models/pixart/pixart_generation_plan.h
@@ -32,6 +32,15 @@ struct PixArtLayout {
     int32_t patch_dim{0};
 };
 
+inline float pixart_position_scale(int32_t runtime_grid_size, int32_t base_grid_size,
+                                   float interpolation_scale) {
+    if (runtime_grid_size <= 0 || base_grid_size <= 0 || interpolation_scale <= 0.0F) {
+        return 1.0F;
+    }
+    return static_cast<float>(base_grid_size) /
+           (static_cast<float>(runtime_grid_size) * interpolation_scale);
+}
+
 inline PixArtLayout make_pixart_layout(const PixArtDiffusionConfig& config) {
     PixArtLayout layout;
     layout.t_lat = (config.video_num_frames - 1) / config.scale_factor_temporal + 1;

--- a/src/tokenizer/unigram_tokenizer.cpp
+++ b/src/tokenizer/unigram_tokenizer.cpp
@@ -550,14 +550,19 @@ class UnigramTokenizer final : public ITokenizer {
     void extract_template_bos_eos(const nlohmann::json& pp) {
         if (!pp.contains("single") || !pp["single"].is_array())
             return;
+        bool seen_sequence = false;
         for (auto& item : pp["single"]) {
+            if (item.contains("Sequence")) {
+                seen_sequence = true;
+                continue;
+            }
             if (!item.contains("SpecialToken"))
                 continue;
             std::string tok_str = item["SpecialToken"].value("id", "");
             auto it = mTokenToId.find(tok_str);
             if (it == mTokenToId.end())
                 continue;
-            if (mBosId < 0)
+            if (!seen_sequence && mBosId < 0)
                 mBosId = it->second;
             else
                 mEosId = it->second;

--- a/tests/builder/test_engine_builder_extended.py
+++ b/tests/builder/test_engine_builder_extended.py
@@ -912,7 +912,12 @@ class TestBuildBundleOrchestration:
             def diffusion_tokenizer_add_special_tokens(
                 self, model_dir_path, *, detect_tokenizer_add_special_tokens,
             ):
-                return False
+                return True
+
+            def diffusion_tokenizer_special_frame(
+                self, model_dir_path, *, detect_tokenizer_special_frame,
+            ):
+                return [], [1]
 
             def diffusion_tokenizer_bundle_sections(
                 self, model_dir_path, *, ensure_tokenizer_json,
@@ -956,6 +961,9 @@ class TestBuildBundleOrchestration:
         cfg = json.loads(section_map["config.json"].decode("utf-8"))
         assert cfg["tensor_parallel_mode"] == "tensor_parallel"
         assert cfg["tensor_parallel_size"] == 4
+        assert cfg["tokenizer_add_special_tokens"] == 1
+        assert cfg["tokenizer_special_prefix_ids"] == []
+        assert cfg["tokenizer_special_suffix_ids"] == [1]
 
     def test_load_weights_precision_not_forwarded_when_unsupported(self, tmp_path):
         """build_bundle remains compatible with plugins that do not accept precision."""

--- a/tests/builder/test_engine_builder_utils.py
+++ b/tests/builder/test_engine_builder_utils.py
@@ -20,6 +20,7 @@ import types
 from pathlib import Path
 
 import pytest
+import tensorrt_model_connect.engine_builder as engine_builder
 
 try:
     from tensorrt_model_connect.engine_builder import (
@@ -193,6 +194,30 @@ class TestDetectTokenizerAddSpecialTokens:
 
         assert _diffusion_tokenizer_add_special_tokens_from_plugin(
             FakeDiffusionPlugin(), tmp_path) is False
+
+    def test_diffusion_detects_exact_tokenizer_special_frame(self, tmp_path):
+        tokenizer_dir = tmp_path / "tokenizer"
+        tokenizer_dir.mkdir()
+
+        class FakeDiffusionPlugin:
+            name = "fake_diffusion"
+
+            def diffusion_tokenizer_special_frame(
+                self, model_dir_path, *, detect_tokenizer_special_frame,
+            ):
+                assert Path(model_dir_path) == tmp_path
+                return detect_tokenizer_special_frame(tokenizer_dir)
+
+        detector_calls = []
+
+        def detector(path):
+            detector_calls.append(Path(path))
+            return [], [1]
+
+        assert engine_builder._diffusion_tokenizer_special_frame_from_plugin(
+            FakeDiffusionPlugin(), tmp_path, detect_tokenizer_special_frame=detector
+        ) == ([], [1])
+        assert detector_calls == [tokenizer_dir]
 
 
 class TestResolveModel:

--- a/tests/cpp/models/pixart/test_pixart_denoising_step_seam.cpp
+++ b/tests/cpp/models/pixart/test_pixart_denoising_step_seam.cpp
@@ -15,7 +15,12 @@
 // =============================================================================
 
 #include "runtime/models/pixart/pixart_denoising_step_seam.h"
+#include "runtime/models/pixart/pixart_dpmsolver.h"
+#include "runtime/models/pixart/pixart_generation_conditioning.h"
+#include "runtime/models/pixart/pixart_generation_plan.h"
 
+#include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <iostream>
 #include <string>
@@ -148,11 +153,75 @@ void test_pixart_step_runner_handles_zero_steps_and_success() {
           "pixart seam applies scheduler updates on success");
 }
 
+void test_pixart_position_scale_matches_diffusers_for_runtime_grid() {
+    using trtmc::diffusion::pixart_position_scale;
+    check(std::abs(pixart_position_scale(32, 64, 2.0F) - 1.0F) < 1e-6F,
+          "PixArt 512px grid uses unit position scale");
+    check(std::abs(pixart_position_scale(64, 64, 2.0F) - 0.5F) < 1e-6F,
+          "PixArt 1024px grid uses half position scale");
+}
+
+void test_pixart_dpmsolver_matches_diffusers_order_two_golden() {
+    trtmc::diffusion::DPMSolverMultistepState scheduler;
+    scheduler.set_timesteps(20);
+    std::vector<float> sample = {0.25F};
+    const std::vector<float> expected = {
+        0.34548814F,  0.48291021F,  0.68116953F,  0.96267649F,  1.35352684F,
+        1.88251323F,  2.57901782F,  3.46979204F,  4.57476371F,  5.87352858F,
+        7.41119091F,  9.13542547F,  10.99540127F, 12.91783338F, 14.81028171F,
+        16.56762662F, 18.08126019F, 19.24990672F, 19.99046704F, 20.24670902F,
+    };
+    for (int32_t step = 0; step < 20; ++step) {
+        const float epsilon = 0.1F + 0.01F * static_cast<float>(step);
+        scheduler.step(&epsilon, sample.data(), sample.data(), sample.size(), step);
+        check(std::abs(sample[0] - expected[static_cast<std::size_t>(step)]) < 2e-4F,
+              "PixArt DPMSolver++ order-two trace matches Diffusers");
+    }
+}
+
+void test_pixart_null_attention_mask_only_keeps_eos_token() {
+    const auto mask = trtmc::diffusion::make_pixart_null_attention_mask(120);
+    check(mask.size() == 120, "PixArt null mask preserves text sequence length");
+    check(mask[0] == 0.0F, "PixArt null mask keeps EOS token");
+    check(std::all_of(mask.begin() + 1, mask.end(), [](float value) { return value == -10000.0F; }),
+          "PixArt null mask rejects padding tokens");
+}
+
+void test_pixart_initial_latents_honor_override_and_requested_seed() {
+    std::vector<float> latents;
+    std::string error;
+    const std::vector<float> supplied = {1.0F, 2.0F, 3.0F, 4.0F};
+    check(trtmc::diffusion::resolve_pixart_initial_latents(supplied.size(), supplied, 99, latents,
+                                                           error),
+          "PixArt accepts caller-supplied initial latents");
+    check(latents == supplied, "PixArt preserves caller-supplied initial latent bytes");
+
+    error.clear();
+    check(!trtmc::diffusion::resolve_pixart_initial_latents(supplied.size() + 1, supplied, 99,
+                                                            latents, error),
+          "PixArt rejects wrong initial latent size");
+    check(error.find("initial latents") != std::string::npos,
+          "PixArt reports initial latent size mismatch");
+
+    std::vector<float> seed_one;
+    std::vector<float> seed_two;
+    error.clear();
+    check(trtmc::diffusion::resolve_pixart_initial_latents(8, {}, 1, seed_one, error),
+          "PixArt generates initial latents for seed one");
+    check(trtmc::diffusion::resolve_pixart_initial_latents(8, {}, 2, seed_two, error),
+          "PixArt generates initial latents for seed two");
+    check(seed_one != seed_two, "PixArt requested seed changes generated initial latents");
+}
+
 } // namespace
 
 int main() {
     test_pixart_step_runner_updates_latents_and_handles_failure();
     test_pixart_step_runner_handles_zero_steps_and_success();
+    test_pixart_position_scale_matches_diffusers_for_runtime_grid();
+    test_pixart_dpmsolver_matches_diffusers_order_two_golden();
+    test_pixart_null_attention_mask_only_keeps_eos_token();
+    test_pixart_initial_latents_honor_override_and_requested_seed();
 
     if (g_failures != 0) {
         std::cerr << g_failures << " PixArt denoising seam test(s) failed\n";

--- a/tests/cpp/test_unigram_tokenizer.cpp
+++ b/tests/cpp/test_unigram_tokenizer.cpp
@@ -22,8 +22,7 @@
 
 static int failures = 0;
 
-void check(bool condition, const std::string& name)
-{
+void check(bool condition, const std::string& name) {
     if (!condition) {
         std::cerr << "FAIL: " << name << std::endl;
         failures++;
@@ -32,10 +31,8 @@ void check(bool condition, const std::string& name)
     }
 }
 
-void check_ids(const std::vector<int32_t>& actual,
-               const std::vector<int32_t>& expected,
-               const std::string& label)
-{
+void check_ids(const std::vector<int32_t>& actual, const std::vector<int32_t>& expected,
+               const std::string& label) {
     if (actual == expected) {
         std::cerr << "PASS: " << label << " (" << actual.size() << " tokens)\n";
         return;
@@ -122,8 +119,30 @@ static const char* kUnigramNoSpecialJson = R"({
   }
 })";
 
-int main()
-{
+static const char* kUnigramSuffixOnlyJson = R"({
+  "model": {
+    "type": "Unigram",
+    "unk_id": 0,
+    "vocab": [["<unk>", 0.0], ["\u2581hello", -1.0]]
+  },
+  "pre_tokenizer": {
+    "type": "Metaspace",
+    "replacement": "\u2581",
+    "add_prefix_space": true
+  },
+  "post_processor": {
+    "type": "TemplateProcessing",
+    "single": [
+      {"Sequence": {"id": "A", "type_id": 0}},
+      {"SpecialToken": {"id": "</s>", "type_id": 0}}
+    ]
+  },
+  "added_tokens": [
+    {"id": 2, "content": "</s>", "special": true}
+  ]
+})";
+
+int main() {
     std::cerr << "Unigram Tokenizer Unit Tests\n\n";
 
     // ════════════════════════════════════════════════════════════
@@ -138,22 +157,32 @@ int main()
 
         // Invalid JSON
         bool threw = false;
-        try { trtmc::CreateUnigramTokenizer("bad", 3, false); }
-        catch (...) { threw = true; }
+        try {
+            trtmc::CreateUnigramTokenizer("bad", 3, false);
+        } catch (...) {
+            threw = true;
+        }
         check(threw, "reject_invalid_json");
 
         // BPE type rejected
         const char* bpe = R"({"model":{"type":"BPE","vocab":{},"merges":[]}})";
         threw = false;
-        try { trtmc::CreateUnigramTokenizer(bpe, std::strlen(bpe), false); }
-        catch (...) { threw = true; }
+        try {
+            trtmc::CreateUnigramTokenizer(bpe, std::strlen(bpe), false);
+        } catch (...) {
+            threw = true;
+        }
         check(threw, "reject_bpe_type");
 
         // WordPiece type rejected
-        const char* wp = R"({"model":{"type":"WordPiece","vocab":{},"continuing_subword_prefix":"##"}})";
+        const char* wp =
+            R"({"model":{"type":"WordPiece","vocab":{},"continuing_subword_prefix":"##"}})";
         threw = false;
-        try { trtmc::CreateUnigramTokenizer(wp, std::strlen(wp), false); }
-        catch (...) { threw = true; }
+        try {
+            trtmc::CreateUnigramTokenizer(wp, std::strlen(wp), false);
+        } catch (...) {
+            threw = true;
+        }
         check(threw, "reject_wordpiece_type");
     }
 
@@ -207,6 +236,11 @@ int main()
         // With special: <s> + tokens + </s>
         check_ids(tok->encode("hello"), {19, 2, 20}, "encode_hello_special");
         check_ids(tok->encode(""), {19, 20}, "encode_empty_special");
+
+        std::string suffix_json(kUnigramSuffixOnlyJson);
+        auto suffix_tok =
+            trtmc::CreateUnigramTokenizer(suffix_json.data(), suffix_json.size(), true);
+        check_ids(suffix_tok->encode("hello"), {1, 2}, "encode_suffix_only_template");
     }
 
     // ════════════════════════════════════════════════════════════
@@ -242,8 +276,7 @@ int main()
 
         auto rt = [&](const std::string& input) {
             auto decoded = tok->decode(tok->encode(input));
-            check(decoded == input,
-                  "roundtrip '" + input + "' -> '" + decoded + "'");
+            check(decoded == input, "roundtrip '" + input + "' -> '" + decoded + "'");
         };
 
         rt("hello");

--- a/tests/e2e/models/pixart/test_pixart_family_plugin.py
+++ b/tests/e2e/models/pixart/test_pixart_family_plugin.py
@@ -403,6 +403,9 @@ def test_get_diffusion_config_uses_transformer_overrides() -> None:
             "num_attention_heads": 5,
             "attention_head_dim": 6,
             "num_layers": 3,
+            "sample_size": 128,
+            "patch_size": 2,
+            "interpolation_scale": 2,
         },
         image_height=640,
         image_width=832,
@@ -415,6 +418,8 @@ def test_get_diffusion_config_uses_transformer_overrides() -> None:
     assert dc["image_height"] == 640
     assert dc["image_width"] == 832
     assert dc["use_rope"] == 0
+    assert dc["pos_embed_base_size"] == 64
+    assert dc["pos_embed_interpolation_scale"] == 2
 
 
 def test_load_pixart_dit_weights_maps_optional_biases(


### PR DESCRIPTION
## Background

Deterministic PixArt comparison exposed runtime differences from the Hugging Face Diffusers pipeline in tokenizer framing, caption masking, scheduler behavior, and latent initialization. These are model/runtime concerns and are intentionally separated from the DPG task-eval suite in #385.

## Exit Criteria

- Match Diffusers tokenizer special-token framing and caption attention semantics.
- Use the PixArt DPMSolver++ multistep schedule and update behavior expected by the reference pipeline.
- Honor requested seeds and exact caller-provided initial latent bytes.
- Cover builder, tokenizer, scheduler, conditioning, and runtime seams independently of task-eval.

## Implementation

- Moves diffusion tokenizer framing decisions behind the PixArt family plugin and preserves the required suffix token behavior.
- Corrects Unigram suffix-only special-token handling.
- Adds a PixArt-owned DPMSolver++ multistep state and routes denoising through the matching timestep/update path.
- Aligns null caption-mask behavior and supports validated caller-provided initial latents.
- Adds builder, family-plugin, tokenizer, scheduler, denoising-seam, and latent-contract tests.

## Validation

- `python tools/legal_headers.py --check`: passed with zero findings.
- `clang-format --dry-run --Werror <changed C++ files>` and changed-file Ruff checks: passed.
- `python tools/check_cyclomatic_complexity.py src --exclude src/cli --max-ccn 10 --top 20`: passed; `DPMSolverMultistepState::step` was split into focused helpers and repository max CCN is 10.
- `PYTHONPATH=python pytest -q tests/builder/test_engine_builder_extended.py tests/builder/test_engine_builder_utils.py tests/e2e/models/pixart/test_pixart_family_plugin.py`: 39 passed, 1 skipped.
- P2021 main-based isolated checkout: built `trtmc_model_pixart` and passed `test_pixart_denoising_step_seam` and `test_unigram_tokenizer`.
- P2021 DPG-Bench limit 10 with the task-eval harness: 9/10 passed; manual review confirmed the remaining count/layout divergence should fail semantic parity.

## Notes For Future Readers

- This PR contains PixArt runtime corrections only. DPG-Bench, task-eval orchestration, comparators, and visual review remain in #385.
- Existing PixArt bundles must be rebuilt because scheduler/tokenizer metadata and runtime behavior change together.
- Review the plugin/engine-builder framing first, then `pixart_dpmsolver.h`, and finally the pipeline/conditioning changes.
