### PR TITLE
feat(quant): NVFP4 — correct output + static 4-bit weight compression

### DIFF
--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -33,7 +33,6 @@ from .checkpoint_mapper import (
     _transpose_2d,
 )
 from ...parallel_config import normalize_parallel_config
-from ...quantization.adapters import StandardDecoderCalibrationAdapter
 from .decoder_tp_builder import build_qwen_vl_tp_decoder_engine
 from .lora import DynamicLoraConfig
 from .standard_decoder_builder import build_standard_decoder_engine
@@ -248,10 +247,18 @@ class QwenVLPlugin:
         """Persist the dynamic binding contract in the bundle config."""
         return DynamicLoraConfig.from_model_config(config).bundle_config()
 
-    def quant_adapter(self, format_name: str) -> StandardDecoderCalibrationAdapter:
-        """Map HF decoder projection names to Qwen-VL graph seam names."""
+    def quant_adapter(self, format_name: str):
+        """VL-aware calibration adapter for Qwen-VL.
+
+        The default (and the standard-decoder) adapter loads via
+        ``AutoModelForCausalLM``, which cannot load a vision-language config
+        (e.g. ``Qwen3VLConfig``). Use a VL adapter that loads via
+        ``AutoModelForImageTextToText`` and calibrates on image+text, mapping
+        the VL language-model layer names onto MC's builder seams.
+        """
         del format_name
-        return StandardDecoderCalibrationAdapter()
+        from ...quantization.adapters import QwenVLCalibrationAdapter
+        return QwenVLCalibrationAdapter()
 
 
 # ---------------------------------------------------------------------------

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -174,9 +174,16 @@ class QwenVLPlugin:
             for index in selected_fp32
             if index >= _VISION_LAYER_OFFSET
         }
-        vision_precision = (
-            "fp32" if precision == "fp16" and _VISION_COMPONENT in selected_fp32
-            else precision)
+        # The vision tower is a separate, unquantized engine at a fixed
+        # precision and does not follow the decoder's bf16 work dtype (it has no
+        # bf16 path). Keep it at fp32 for a bf16 decoder — matching the deployed
+        # baseline, where the ViT is not affected by --precision.
+        if precision == "bf16":
+            vision_precision = "fp32"
+        elif precision == "fp16" and _VISION_COMPONENT in selected_fp32:
+            vision_precision = "fp32"
+        else:
+            vision_precision = precision
         fixed_h, fixed_w = _fixed_image_dimensions(config)
 
         if _is_qwen3_vl(config):
@@ -432,16 +439,29 @@ def _build_qwen3_vl_decoder(
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16
+    elif precision == "bf16":
+        # numpy has no bfloat16, so constants are staged as float16 and the
+        # network computes in bfloat16 (the model's native training dtype).
+        work_np_dtype, work_trt_dtype = np.float16, trt.bfloat16
     elif precision == "fp32":
         work_np_dtype, work_trt_dtype = np.float32, trt.float32
     else:
         raise ValueError(
-            f"Unsupported Qwen3-VL precision {precision!r}; expected fp32 or fp16")
+            f"Unsupported Qwen3-VL precision {precision!r}; "
+            "expected fp32, fp16 or bf16")
     selected_fp32_layers = {
         int(index)
         for index in config.raw.get("_fp32_layers", ())
         if 0 <= int(index) < config.num_hidden_layers
     }
+
+    def _cast_work_dtype(tensor: trt.ITensor) -> trt.ITensor:
+        # Constants are staged in numpy as float16 (numpy has no bfloat16); with a
+        # bfloat16 work dtype they must be cast so strongly-typed elementwise ops
+        # don't mix Half with BFloat16. No-op when the dtype already matches.
+        if tensor.dtype == work_trt_dtype:
+            return tensor
+        return network.add_cast(tensor, work_trt_dtype).get_output(0)
 
     attention_size: int = weights.get("_attention_size", config.attention_size)
     mlp_size: int = weights.get("_mlp_size", config.intermediate_size)
@@ -483,16 +503,19 @@ def _build_qwen3_vl_decoder(
         ds_active_tensor = network.add_input(
             "deepstack_active", trt.float32, (-1, 1))
 
-    # KV cache inputs
+    # KV cache inputs, declared at the work dtype so the runtime KV buffer
+    # matches the decode precision (bf16/fp16 halves KV size and speeds up
+    # decode); the C++ runtime sizes the cache from the engine input dtype.
+    # Mirrors the whisper/canary decoder builders.
     cache_k_inputs = []
     cache_v_inputs = []
     for i in range(num_layers):
         ck = network.add_input(
             graph_ops.layer_tensor_name("cache_k", i),
-            trt.float32, (max_cache_length, kv_attention_size))
+            work_trt_dtype, (max_cache_length, kv_attention_size))
         cv = network.add_input(
             graph_ops.layer_tensor_name("cache_v", i),
-            trt.float32, (max_cache_length, kv_attention_size))
+            work_trt_dtype, (max_cache_length, kv_attention_size))
         cache_k_inputs.append(ck)
         cache_v_inputs.append(cv)
 
@@ -527,20 +550,28 @@ def _build_qwen3_vl_decoder(
     fp32_attention_mask = attention_mask
     fp32_ds_embed_inputs = list(ds_embed_inputs)
     fp32_ds_active_tensor = ds_active_tensor
-    fp32_cache_k_inputs = list(cache_k_inputs)
-    fp32_cache_v_inputs = list(cache_v_inputs)
+    # KV inputs are already at the work dtype. The fp16 mixed-precision fp32
+    # layers read them through an up-cast; bf16/fp32 leave selected_fp32_layers
+    # empty, so these views go unused there.
+    if work_trt_dtype != trt.float32 and selected_fp32_layers:
+        fp32_cache_k_inputs = [
+            network.add_cast(ck, trt.float32).get_output(0)
+            for ck in cache_k_inputs]
+        fp32_cache_v_inputs = [
+            network.add_cast(cv, trt.float32).get_output(0)
+            for cv in cache_v_inputs]
+    else:
+        fp32_cache_k_inputs = list(cache_k_inputs)
+        fp32_cache_v_inputs = list(cache_v_inputs)
     float_inputs = [attention_mask, input_embed_tensor, use_input_embed_tensor]
     float_inputs.extend(ds_embed_inputs)
     if ds_active_tensor is not None:
         float_inputs.append(ds_active_tensor)
-    float_inputs.extend(cache_k_inputs)
-    float_inputs.extend(cache_v_inputs)
     if work_trt_dtype != trt.float32:
         cast_inputs = [
             network.add_cast(value, work_trt_dtype).get_output(0)
             for value in float_inputs
         ]
-        cursor = 0
         attention_mask, input_embed_tensor, use_input_embed_tensor = cast_inputs[:3]
         cursor = 3
         ds_embed_inputs = cast_inputs[cursor:cursor + len(ds_embed_inputs)]
@@ -548,9 +579,6 @@ def _build_qwen3_vl_decoder(
         if ds_active_tensor is not None:
             ds_active_tensor = cast_inputs[cursor]
             cursor += 1
-        cache_k_inputs = cast_inputs[cursor:cursor + num_layers]
-        cursor += num_layers
-        cache_v_inputs = cast_inputs[cursor:cursor + num_layers]
 
     # --- Shared constants ---
     embedding_table = graph_ops.add_constant(
@@ -561,13 +589,13 @@ def _build_qwen3_vl_decoder(
         attention_window, head_dim, config.rope_theta, True)
     sin_half_np = graph_ops.make_rope_table_half_dim(
         attention_window, head_dim, config.rope_theta, False)
-    cos_half_tensor = graph_ops.add_constant(
-        network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype)
-    sin_half_tensor = graph_ops.add_constant(
-        network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype)
-    eps_tensor = graph_ops.add_constant(
+    cos_half_tensor = _cast_work_dtype(graph_ops.add_constant(
+        network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype))
+    sin_half_tensor = _cast_work_dtype(graph_ops.add_constant(
+        network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype))
+    eps_tensor = _cast_work_dtype(graph_ops.add_constant(
         network, (1, 1), np.array([config.rms_norm_eps], dtype=work_np_dtype),
-        dtype=work_np_dtype)
+        dtype=work_np_dtype))
     fp32_cos_half_tensor = None
     fp32_sin_half_tensor = None
     fp32_eps_tensor = None
@@ -583,12 +611,12 @@ def _build_qwen3_vl_decoder(
 
     # --- Embedding (with input_embed override for VL) ---
     gather = network.add_gather(embedding_table, token_id, 0)
-    token_embed = gather.get_output(0)
+    token_embed = _cast_work_dtype(gather.get_output(0))
 
     # Conditional: (1 - flag) * token_embed + flag * input_embed
-    one_const = graph_ops.add_constant(
+    one_const = _cast_work_dtype(graph_ops.add_constant(
         network, (1, 1), np.array([1.0], dtype=work_np_dtype),
-        dtype=work_np_dtype)
+        dtype=work_np_dtype))
     inv_flag = network.add_elementwise(
         one_const, use_input_embed_tensor,
         trt.ElementWiseOperation.SUB)
@@ -736,14 +764,15 @@ def _build_qwen3_vl_decoder(
     logits.name = "logits"
     network.mark_output(logits)
 
-    # --- Present K/V outputs ---
+    # --- Present K/V outputs, marked at the work dtype so they round-trip with
+    # the work-dtype KV cache inputs (fp16 fp32-layers emit fp32 and cast down).
     for i in range(num_layers):
         pk = present_k_outputs[i]
         pv = present_v_outputs[i]
-        if pk.dtype != trt.float32:
-            pk = network.add_cast(pk, trt.float32).get_output(0)
-        if pv.dtype != trt.float32:
-            pv = network.add_cast(pv, trt.float32).get_output(0)
+        if pk.dtype != work_trt_dtype:
+            pk = network.add_cast(pk, work_trt_dtype).get_output(0)
+        if pv.dtype != work_trt_dtype:
+            pv = network.add_cast(pv, work_trt_dtype).get_output(0)
         pk.name = graph_ops.layer_tensor_name("present_k", i)
         pv.name = graph_ops.layer_tensor_name("present_v", i)
         network.mark_output(pk)

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -693,19 +693,30 @@ def _build_qwen3_vl_decoder(
 
         # DeepStack injection: add visual features after attention residual
         if layer_idx < deepstack_num_levels and ds_active_tensor is not None:
-            # deepstack_contribution = deepstack_embed[i] * deepstack_active
             layer_ds_active = (
                 fp32_ds_active_tensor if layer_is_fp32 else ds_active_tensor)
             layer_ds_embed = (
                 fp32_ds_embed_inputs[layer_idx]
                 if layer_is_fp32 else ds_embed_inputs[layer_idx])
             assert layer_ds_active is not None
-            ds_scaled = network.add_elementwise(
-                layer_ds_embed, layer_ds_active,
-                trt.ElementWiseOperation.PROD)
+            # NaN-safe gate: select(active > 0, deepstack_embed, 0) instead of
+            # deepstack_embed * active. On text/decode steps the embed buffer can
+            # carry uninitialized/NaN residue; a plain multiply propagates it as
+            # NaN * 0 = NaN and poisons every logit. The hard-zero branch keeps
+            # the inactive contribution exactly 0 regardless of the buffer.
+            ds_zero = graph_ops.add_constant(
+                network, (1, 1), np.zeros((1, 1), dtype=np.float32),
+                dtype=np.float32)
+            if ds_zero.dtype != layer_ds_active.dtype:
+                ds_zero = network.add_cast(
+                    ds_zero, layer_ds_active.dtype).get_output(0)
+            ds_cond = network.add_elementwise(
+                layer_ds_active, ds_zero,
+                trt.ElementWiseOperation.GREATER).get_output(0)
+            ds_gated = network.add_select(
+                ds_cond, layer_ds_embed, ds_zero).get_output(0)
             post_attn_ds = network.add_elementwise(
-                post_attn, ds_scaled.get_output(0),
-                trt.ElementWiseOperation.SUM)
+                post_attn, ds_gated, trt.ElementWiseOperation.SUM)
             post_attn = post_attn_ds.get_output(0)
 
         # Post-attention norm

--- a/python/tensorrt_model_connect/fp8_calibrate.py
+++ b/python/tensorrt_model_connect/fp8_calibrate.py
@@ -23,6 +23,8 @@ import re
 import sys
 from typing import Callable, TYPE_CHECKING
 
+import numpy as np
+
 if TYPE_CHECKING:
     import torch.nn
 
@@ -154,6 +156,16 @@ def extract_scales_from_state_dict(
     scales: dict[str, dict[str, float]] = {}
 
     for key, value in state_dict.items():
+        # SmoothQuant per-input-channel factor lives on the input quantizer as
+        # ``_pre_quant_scale`` (not an ``_amax``). Capture it so the format can
+        # apply the smoothing that the calibrated (smoothed-weight) scales assume.
+        m_pqs = re.match(r"(.+)\.input_quantizer\._pre_quant_scale$", key)
+        if m_pqs is not None:
+            prefix = m_pqs.group(1)
+            pqs = value.detach().cpu().numpy() if hasattr(value, "detach") else value
+            pqs = np.asarray(pqs, dtype=np.float32).reshape(-1)
+            scales.setdefault(prefix, {})["pre_quant_scale"] = pqs
+            continue
         if "_amax" not in key:
             continue
         m = re.match(r"(.+)\.([A-Za-z0-9_]+_quantizer)\._amax", key)
@@ -165,8 +177,15 @@ def extract_scales_from_state_dict(
         scale_field = _QUANTIZER_SCALE_FIELDS.get(qtype)
         if scale_field is None:
             continue
-        amax = value.item() if hasattr(value, "item") else float(value)
-        scale = amax / maxbound
+        # amax may be a scalar (per-tensor, e.g. FP8 / activations) or a
+        # multi-element tensor (per-channel weights, e.g. INT8 weight_quantizer
+        # with shape [out, 1]). Scalar -> float; per-channel -> flat np.ndarray
+        # (formats.py consumes either; it sets IQuantizeLayer.axis for the
+        # per-channel case). Calling .item() on a multi-element amax raised
+        # "Tensor with N elements cannot be converted to Scalar".
+        arr = value.detach().cpu().numpy() if hasattr(value, "detach") else value
+        arr = np.asarray(arr, dtype=np.float32).reshape(-1)
+        scale = float(arr[0]) / maxbound if arr.size == 1 else arr / maxbound
 
         if prefix not in scales:
             scales[prefix] = {}

--- a/python/tensorrt_model_connect/quantization/adapters.py
+++ b/python/tensorrt_model_connect/quantization/adapters.py
@@ -144,6 +144,204 @@ class StandardDecoderCalibrationAdapter(AutoCausalLMCalibrationAdapter):
         return None
 
 
+class QwenVLCalibrationAdapter:
+    """Calibration adapter for Qwen-VL (Qwen2.5-VL / Qwen3-VL).
+
+    The default ``AutoCausalLMCalibrationAdapter`` loads the checkpoint as
+    ``AutoModelForCausalLM``, which raises for vision-language configs
+    (``Qwen3VLConfig``). This adapter loads the full VL model and feeds
+    image+text calibration batches so the decoder's activation statistics
+    reflect real multimodal inputs, then maps the VL decoder module names
+    (``...language_model.layers.N.<proj>``) to the builder seam IDs
+    (``layer.N.w_q`` etc.). Calibration runs in PyTorch, so it is unaffected
+    by the TRT reduced-precision decoder issue.
+    """
+
+    _RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+        (re.compile(r"language_model\.layers\.(\d+)\.self_attn\.q_proj$"), "w_q"),
+        (re.compile(r"language_model\.layers\.(\d+)\.self_attn\.k_proj$"), "w_k"),
+        (re.compile(r"language_model\.layers\.(\d+)\.self_attn\.v_proj$"), "w_v"),
+        (re.compile(r"language_model\.layers\.(\d+)\.self_attn\.o_proj$"), "w_o"),
+        (re.compile(r"language_model\.layers\.(\d+)\.mlp\.gate_proj$"), "w_gate"),
+        (re.compile(r"language_model\.layers\.(\d+)\.mlp\.up_proj$"), "w_up"),
+        (re.compile(r"language_model\.layers\.(\d+)\.mlp\.down_proj$"), "w_down"),
+        # Fallback for checkpoints without the language_model. prefix.
+        (re.compile(r"(?:^|\.)model\.layers\.(\d+)\.self_attn\.q_proj$"), "w_q"),
+        (re.compile(r"(?:^|\.)model\.layers\.(\d+)\.self_attn\.k_proj$"), "w_k"),
+        (re.compile(r"(?:^|\.)model\.layers\.(\d+)\.self_attn\.v_proj$"), "w_v"),
+        (re.compile(r"(?:^|\.)model\.layers\.(\d+)\.self_attn\.o_proj$"), "w_o"),
+        (re.compile(r"(?:^|\.)model\.layers\.(\d+)\.mlp\.gate_proj$"), "w_gate"),
+        (re.compile(r"(?:^|\.)model\.layers\.(\d+)\.mlp\.up_proj$"), "w_up"),
+        (re.compile(r"(?:^|\.)model\.layers\.(\d+)\.mlp\.down_proj$"), "w_down"),
+    )
+
+    def load_calibration_model(
+        self, model_dir: str, config: "ModelConfig",
+    ) -> tuple[Any, Any | None]:
+        import torch
+        import transformers
+        from transformers import AutoProcessor
+
+        model = None
+        last_exc: Exception | None = None
+        for cls_name in ("AutoModelForImageTextToText", "AutoModelForVision2Seq"):
+            cls = getattr(transformers, cls_name, None)
+            if cls is None:
+                continue
+            try:
+                model = cls.from_pretrained(
+                    model_dir, torch_dtype=torch.float16,
+                    device_map=None, trust_remote_code=False)
+                break
+            except Exception as exc:  # try the next class
+                last_exc = exc
+                model = None
+        if model is None:
+            from transformers import AutoModel
+            try:
+                model = AutoModel.from_pretrained(
+                    model_dir, torch_dtype=torch.float16,
+                    device_map=None, trust_remote_code=False)
+            except Exception as exc:
+                raise RuntimeError(
+                    f"QwenVLCalibrationAdapter could not load the VL model: {exc}"
+                ) from (last_exc or exc)
+        model = model.eval().to("cuda")
+        processor = AutoProcessor.from_pretrained(
+            model_dir, trust_remote_code=False)
+        return model, processor
+
+    @staticmethod
+    def _calibration_images():
+        from PIL import Image, ImageDraw
+        images = []
+        for color in ("red", "green", "blue", "orange"):
+            im = Image.new("RGB", (448, 448), "white")
+            ImageDraw.Draw(im).ellipse([80, 80, 368, 368], fill=color)
+            images.append(im)
+        return images
+
+    @staticmethod
+    def _load_calibration_images():
+        """Calibration image source. [assumption knob — see mc_quantization_understanding.md §10]
+        TRTMC_CALIB_IMAGE_DIR (REAL, representative, DISJOINT-from-eval images) if set — recommended;
+        else synthetic colored circles (_calibration_images) as an explicit PLACEHOLDER."""
+        import os
+        d = os.environ.get("TRTMC_CALIB_IMAGE_DIR")
+        if d and os.path.isdir(d):
+            from PIL import Image
+            imgs = []
+            for f in sorted(os.listdir(d)):
+                if f.lower().endswith((".jpg", ".jpeg", ".png", ".webp")):
+                    try:
+                        imgs.append(Image.open(os.path.join(d, f)).convert("RGB"))
+                    except Exception:
+                        pass
+                if len(imgs) >= 64:
+                    break
+            if imgs:
+                print(f"[qwenvl-calib] using {len(imgs)} real calibration images from {d}", flush=True)
+                return imgs
+        print("[qwenvl-calib] TRTMC_CALIB_IMAGE_DIR unset -> synthetic PLACEHOLDER images "
+              "(not representative; set the env for real accuracy)", flush=True)
+        return QwenVLCalibrationAdapter._calibration_images()
+
+    def iter_calibration_batches(
+        self, model: Any, aux: Any | None, *, model_dir: str,
+        config: "ModelConfig", num_samples: int,
+        calibration_prompts: list[str] | None,
+    ) -> Iterable[Any]:
+        # IMAGE+TEXT calibration (2026-07-03; previously text-only). Feeding real image tokens makes
+        # the decoder's activation statistics reflect true multimodal inference — the primary lever
+        # for VL int8/nvfp4 accuracy (text-only calibration mis-set the activation scales for the
+        # image+text workload). Reference (how, not gospel): TRT-LLM get_calib_dataloader multimodal
+        # branch runs samples through the processor -> pixel_values+input_ids.
+        # ASSUMPTION LOG — each line is a revisitable knob (see mc_quantization_understanding.md §10):
+        #   [modality]   image+text via processor.apply_chat_template (handles the image-token
+        #                expansion previously deferred as "version-fiddly"); per-batch text-only
+        #                fallback if the processor image path raises (robust across transformers vers).
+        #   [images]     TRTMC_CALIB_IMAGE_DIR if set = REAL representative images (recommended; MUST
+        #                be DISJOINT from any eval set — no leakage). Else synthetic colored circles
+        #                (_calibration_images) = PLACEHOLDER: exercises the image path but is NOT
+        #                representative -> weak accuracy gain; replace with real images.
+        #   [prompts]    calibration_prompts if provided, else generic describe/VQA prompts below.
+        #   [chat tmpl]  loaded from the model's tokenizer_config.json (HF/model-specific provenance).
+        #   [count]      num_samples (--quant-calibration-samples); image+text is slower than text.
+        import itertools
+        import json
+        import os
+        processor = aux
+        tokenizer = getattr(processor, "tokenizer", processor)
+        chat_template = None
+        try:
+            tc = os.path.join(model_dir, "tokenizer_config.json")
+            if os.path.isfile(tc):
+                chat_template = json.load(open(tc)).get("chat_template")
+        except Exception:
+            chat_template = None
+        # Custom PAIRED calibration via a manifest (env-gated + additive; unset => unchanged behavior).
+        # Each jsonl line = {"image": <path>, "prompt": <text>}; calibrates on (image_i, prompt_i) pairs —
+        # the representative alternative to the synthetic/generic path when real eval-domain image+question
+        # samples are available (activation ranges then reflect the true multimodal workload).
+        manifest = os.environ.get("TRTMC_CALIB_MANIFEST")
+        if manifest and os.path.isfile(manifest):
+            from PIL import Image
+            entries = [json.loads(line) for line in open(manifest) if line.strip()]
+            print(f"[qwenvl-calib] paired manifest: {len(entries)} (image,prompt) pairs from {manifest}",
+                  flush=True)
+            used = 0
+            for entry in itertools.islice(itertools.cycle(entries), num_samples):
+                image = Image.open(entry["image"]).convert("RGB")
+                prompt = entry["prompt"]
+                try:
+                    msgs = [{"role": "user", "content": [
+                        {"type": "image", "image": image}, {"type": "text", "text": prompt}]}]
+                    enc = processor.apply_chat_template(
+                        msgs, chat_template=chat_template, add_generation_prompt=True,
+                        tokenize=True, return_dict=True, return_tensors="pt")
+                    used += 1
+                except Exception:
+                    enc = tokenizer(prompt, return_tensors="pt", truncation=True, max_length=256)
+                yield {k: (v.to(model.device) if hasattr(v, "to") else v) for k, v in enc.items()}
+            print(f"[qwenvl-calib] paired manifest batches: {used}/{num_samples}", flush=True)
+            return
+        images = self._load_calibration_images()
+        prompts = calibration_prompts or [
+            "Describe this image in detail.",
+            "What objects and text are present in the image?",
+            "Answer the multiple-choice question about the image with the correct option letter.",
+            "What is shown in this image and what can you infer from it?",
+        ]
+        pairs = [(im, pr) for im in images for pr in prompts]
+        used_img = 0
+        for im, pr in itertools.islice(itertools.cycle(pairs), num_samples):
+            try:
+                msgs = [{"role": "user", "content": [
+                    {"type": "image", "image": im}, {"type": "text", "text": pr}]}]
+                enc = processor.apply_chat_template(
+                    msgs, chat_template=chat_template, add_generation_prompt=True,
+                    tokenize=True, return_dict=True, return_tensors="pt")
+                used_img += 1
+            except Exception:
+                enc = tokenizer(pr, return_tensors="pt", truncation=True, max_length=256)
+            yield {k: (v.to(model.device) if hasattr(v, "to") else v)
+                   for k, v in enc.items()}
+        print(f"[qwenvl-calib] image+text batches: {used_img}/{num_samples} "
+              f"(rest = text-only fallback); images={len(images)}", flush=True)
+
+    def run_calibration_batch(self, model: Any, batch: Any) -> None:
+        import torch
+        with torch.no_grad():
+            model(**batch)
+
+    def map_layer_name(self, layer_name: str) -> str | None:
+        for pattern, suffix in self._RULES:
+            match = pattern.search(layer_name)
+            if match is not None:
+                return f"layer.{match.group(1)}.{suffix}"
+        return None
+
+
 def resolve_calibration_adapter(
     plugin: Any | None,
     format_name: str,

--- a/python/tensorrt_model_connect/quantization/formats.py
+++ b/python/tensorrt_model_connect/quantization/formats.py
@@ -239,9 +239,25 @@ class INT8SmoothQuantFormat:
 
         out_trt_dtype = activation.dtype
 
+        # SmoothQuant: migrate per-input-channel range from activations into
+        # weights. ModelOpt stores pre_quant_scale (=1/s) on the input quantizer
+        # and calibrates the weight amax on the SMOOTHED weight. MC loads the
+        # ORIGINAL weights, so reproduce the smoothing here: activations are
+        # scaled by pre_quant_scale and weights by 1/pre_quant_scale (per input
+        # channel) — x@W == (x*pqs)@(W/pqs). When pre_quant_scale is absent the
+        # format degrades to plain per-channel-weight int8.
+        pqs = getattr(scales, "pre_quant_scale", None)
+        weight_for_const = weight_array
+        if pqs is not None:
+            pqs = np.asarray(pqs, dtype=np.float32).reshape(-1)  # [lhs_width=in]
+            inv = (1.0 / pqs).astype(np.float32)
+            weight_for_const = np.ascontiguousarray(
+                weight_array.astype(np.float32) * inv[:, None]).astype(
+                    weight_array.dtype)
+
         # Weight Q/DQ: per-channel (axis=1 for [in, out] layout)
         weight_const = graph_ops.add_constant(
-            network, (lhs_width, rhs_width), weight_array, dtype=dtype)
+            network, (lhs_width, rhs_width), weight_for_const, dtype=dtype)
         w_scale = np.asarray(scales.weight_scale, dtype=np.float32)
         if w_scale.ndim == 0:
             w_scale = np.full(rhs_width, float(w_scale), dtype=np.float32)
@@ -253,13 +269,26 @@ class INT8SmoothQuantFormat:
             q_w.get_output(0), w_scale_t, out_trt_dtype)
         dq_w.axis = 1
 
+        # SmoothQuant activation scaling: x_smooth = x * pre_quant_scale
+        # (per input channel), broadcast over the leading (token) dim.
+        act = activation
+        if pqs is not None:
+            pqs_t = graph_ops.add_constant(
+                network, (1, lhs_width), pqs.reshape(1, lhs_width),
+                dtype=np.float32)
+            pqs_in = pqs_t
+            if activation.dtype != trt.float32:
+                pqs_in = network.add_cast(pqs_t, activation.dtype).get_output(0)
+            act = network.add_elementwise(
+                activation, pqs_in, trt.ElementWiseOperation.PROD).get_output(0)
+
         # Activation Q/DQ: per-tensor
         a_scale = np.array(
             [scales.input_scale] if np.isscalar(scales.input_scale)
             else scales.input_scale, dtype=np.float32)
         a_scale_t = graph_ops.add_constant(
             network, a_scale.shape, a_scale, dtype=np.float32)
-        q_a = network.add_quantize(activation, a_scale_t, trt.int8)
+        q_a = network.add_quantize(act, a_scale_t, trt.int8)
         dq_a = network.add_dequantize(
             q_a.get_output(0), a_scale_t, out_trt_dtype)
 

--- a/python/tensorrt_model_connect/quantization/formats.py
+++ b/python/tensorrt_model_connect/quantization/formats.py
@@ -130,8 +130,15 @@ class FP8Format:
         trt = trt_compat.get_trt()
 
         out_trt_dtype = activation.dtype
+        # With fp16 base, materializing the fp8 GEMM result in fp16 overflows
+        # fp16's narrow exponent range on bf16-native models (garbage output):
+        # the running partial sum of many dequantized terms exceeds ~65504.
+        # Dequantize/accumulate in fp32 ONLY for fp16 base, then cast back to the
+        # base dtype. bf16/fp32 base keep their native dtype (range headroom) so
+        # the fast bf16 path sees no perf regression.
+        acc_dtype = trt.float32 if out_trt_dtype == trt.float16 else out_trt_dtype
 
-        # Weight Q/DQ: constant -> quantize(FP8) -> dequantize(work_dtype)
+        # Weight Q/DQ: constant -> quantize(FP8) -> dequantize(acc_dtype)
         weight_const = graph_ops.add_constant(
             network, (lhs_width, rhs_width), weight_array, dtype=dtype)
         w_scale = np.array(
@@ -141,9 +148,9 @@ class FP8Format:
             network, w_scale.shape, w_scale, dtype=np.float32)
         q_w = network.add_quantize(weight_const, w_scale_t, trt.fp8)
         dq_w = network.add_dequantize(
-            q_w.get_output(0), w_scale_t, out_trt_dtype)
+            q_w.get_output(0), w_scale_t, acc_dtype)
 
-        # Activation Q/DQ: input -> quantize(FP8) -> dequantize(work_dtype)
+        # Activation Q/DQ: input -> quantize(FP8) -> dequantize(acc_dtype)
         a_scale = np.array(
             [scales.input_scale] if np.isscalar(scales.input_scale)
             else scales.input_scale, dtype=np.float32)
@@ -151,7 +158,7 @@ class FP8Format:
             network, a_scale.shape, a_scale, dtype=np.float32)
         q_a = network.add_quantize(activation, a_scale_t, trt.fp8)
         dq_a = network.add_dequantize(
-            q_a.get_output(0), a_scale_t, out_trt_dtype)
+            q_a.get_output(0), a_scale_t, acc_dtype)
 
         # Matmul on dequantized tensors (TRT fuses Q/DQ + matmul)
         mm = network.add_matrix_multiply(

--- a/python/tensorrt_model_connect/quantization/formats.py
+++ b/python/tensorrt_model_connect/quantization/formats.py
@@ -138,17 +138,25 @@ class FP8Format:
         # the fast bf16 path sees no perf regression.
         acc_dtype = trt.float32 if out_trt_dtype == trt.float16 else out_trt_dtype
 
-        # Weight Q/DQ: constant -> quantize(FP8) -> dequantize(acc_dtype)
+        # Weight Q/DQ: constant -> quantize(FP8) -> dequantize(acc_dtype).
+        # STRONGLY_TYPED networks require a quantize's input+scale to share a
+        # dtype and a dequantize's scale to match its output dtype, so cast the
+        # weight const to the work dtype and give each role its own scale cast.
+        # All casts are no-ops for an fp32 base (regression-safe); required for
+        # a bf16/fp16 base, where an fp32 scale would fail the build (arith.divf).
         weight_const = graph_ops.add_constant(
             network, (lhs_width, rhs_width), weight_array, dtype=dtype)
+        weight_const = _cast_output_dtype(network, weight_const, out_trt_dtype)
         w_scale = np.array(
             [scales.weight_scale] if np.isscalar(scales.weight_scale)
             else scales.weight_scale, dtype=np.float32)
         w_scale_t = graph_ops.add_constant(
             network, w_scale.shape, w_scale, dtype=np.float32)
-        q_w = network.add_quantize(weight_const, w_scale_t, trt.fp8)
+        w_scale_q = _cast_output_dtype(network, w_scale_t, out_trt_dtype)
+        w_scale_dq = _cast_output_dtype(network, w_scale_t, acc_dtype)
+        q_w = network.add_quantize(weight_const, w_scale_q, trt.fp8)
         dq_w = network.add_dequantize(
-            q_w.get_output(0), w_scale_t, acc_dtype)
+            q_w.get_output(0), w_scale_dq, acc_dtype)
 
         # Activation Q/DQ: input -> quantize(FP8) -> dequantize(acc_dtype)
         a_scale = np.array(
@@ -156,9 +164,11 @@ class FP8Format:
             else scales.input_scale, dtype=np.float32)
         a_scale_t = graph_ops.add_constant(
             network, a_scale.shape, a_scale, dtype=np.float32)
-        q_a = network.add_quantize(activation, a_scale_t, trt.fp8)
+        a_scale_q = _cast_output_dtype(network, a_scale_t, out_trt_dtype)
+        a_scale_dq = _cast_output_dtype(network, a_scale_t, acc_dtype)
+        q_a = network.add_quantize(activation, a_scale_q, trt.fp8)
         dq_a = network.add_dequantize(
-            q_a.get_output(0), a_scale_t, acc_dtype)
+            q_a.get_output(0), a_scale_dq, acc_dtype)
 
         # Matmul on dequantized tensors (TRT fuses Q/DQ + matmul)
         mm = network.add_matrix_multiply(

--- a/python/tensorrt_model_connect/quantization/formats.py
+++ b/python/tensorrt_model_connect/quantization/formats.py
@@ -20,6 +20,10 @@ if TYPE_CHECKING:
 
 from .scales import LayerScales
 
+# Packed NVFP4 weight buffers must outlive the engine build (TRT holds the raw
+# pointers until serialization); keep references alive here.
+_NVFP4_WEIGHT_KEEPALIVE: list = []
+
 
 @runtime_checkable
 class QuantFormat(Protocol):
@@ -404,10 +408,10 @@ class INT4AWQFormat:
         w_scale_t = graph_ops.add_constant(
             network, w_scale.shape, w_scale, dtype=np.float32)
         q_w = network.add_quantize(weight_const, w_scale_t, trt.int4)
-        q_w.set_block_shape(trt.Dims([block_size]))
+        q_w.block_shape = trt.Dims([block_size])
         dq_w = network.add_dequantize(
             q_w.get_output(0), w_scale_t, out_trt_dtype)
-        dq_w.set_block_shape(trt.Dims([block_size]))
+        dq_w.block_shape = trt.Dims([block_size])
 
         # Activation: stays in working dtype (no activation quantization)
         mm = network.add_matrix_multiply(
@@ -444,10 +448,10 @@ class INT4AWQFormat:
         w_scale_t = graph_ops.add_constant(
             network, w_scale.shape, w_scale, dtype=np.float32)
         q_w = network.add_quantize(w_const, w_scale_t, trt.int4)
-        q_w.set_block_shape(trt.Dims([block_size]))
+        q_w.block_shape = trt.Dims([block_size])
         dq_w = network.add_dequantize(
             q_w.get_output(0), w_scale_t, out_trt_dtype)
-        dq_w.set_block_shape(trt.Dims([block_size]))
+        dq_w.block_shape = trt.Dims([block_size])
 
         # Activation: stays in working dtype (weight-only quantization)
         b_trt = trt.Weights(np.ascontiguousarray(
@@ -487,29 +491,81 @@ class NVFP4Format:
         out_trt_dtype = activation.dtype
         block_size = scales.block_size or 16
 
-        # Weight: static FP4 quantization with block shape
-        weight_const = graph_ops.add_constant(
-            network, (lhs_width, rhs_width), weight_array, dtype=dtype)
-        w_scale = np.asarray(scales.weight_scale, dtype=np.float32)
-        w_scale_t = graph_ops.add_constant(
-            network, w_scale.shape, w_scale, dtype=np.float32)
-        q_w = network.add_quantize(weight_const, w_scale_t, trt.DataType.FP4)
-        q_w.set_block_shape(trt.Dims([block_size]))
-        dq_w = network.add_dequantize(
-            q_w.get_output(0), w_scale_t, out_trt_dtype)
-        dq_w.set_block_shape(trt.Dims([block_size]))
+        # NVFP4 = FP4 (E2M1) values + FP8 (E4M3) per-block scales + FP32 per-tensor
+        # "double" scale. The block structure comes from the dynamic-quantize layer;
+        # we deliberately do NOT set block_shape on the dequantizes — that kNDBLOCKED
+        # path triggers a Myelin quantize-op fusion failure inside the full decoder.
+        def _nvfp4_dynamic(t, axis, amax):
+            # Per-block scales computed at runtime; per-tensor global = amax.
+            ds = graph_ops.add_constant(
+                network, (1,),
+                np.array([max(amax / (6.0 * 448.0), 1e-8)], dtype=np.float32),
+                dtype=np.float32)
+            dq = network.add_dynamic_quantize(
+                t, axis, block_size, trt.DataType.FP4, trt.fp8)
+            dq.set_input(1, ds)
+            sc = network.add_dequantize(
+                dq.get_output(1), ds, out_trt_dtype).get_output(0)
+            return network.add_dequantize(
+                dq.get_output(0), sc, out_trt_dtype).get_output(0)
 
-        # Activation: dynamic quantization (scales computed at runtime)
-        dq_a = network.add_dynamic_quantize_v2(
-            activation,
-            trt.Dims([block_size]),
-            trt.DataType.FP4,
-            trt.float32,  # scale type
-        )
+        wf = np.ascontiguousarray(np.asarray(weight_array, dtype=np.float32))
+        w_amax = float(np.abs(wf).max())
 
+        # Weight: static packed FP4 + FP8 per-block scales + FP32 global, so the
+        # engine stores 4-bit weights (~2-3x smaller). Falls back to the dynamic
+        # (correct but uncompressed) weight path on any failure.
+        try:
+            import ml_dtypes
+            if lhs_width % block_size:
+                raise ValueError(
+                    "in-dim %d not divisible by block %d" % (lhs_width, block_size))
+            nb = lhs_width // block_size
+            w_global = np.float32(max(w_amax / (6.0 * 448.0), 1e-8))
+            woi = np.ascontiguousarray(wf.T)                       # [out, in]
+            wob = woi.reshape(rhs_width, nb, block_size)           # [out, nb, blk]
+            real_blk = np.maximum(np.abs(wob).max(axis=2) / 6.0, 1e-8)
+            fp8_blk = (real_blk / w_global).astype(ml_dtypes.float8_e4m3fn)
+            wq = (wob / real_blk[:, :, None]).reshape(
+                rhs_width, lhs_width).astype(ml_dtypes.float4_e2m1fn)
+            raw = wq.view(np.uint8).reshape(-1)
+            packed = np.ascontiguousarray(
+                (raw[0::2] & 0x0F) | ((raw[1::2] & 0x0F) << 4))    # 2 fp4/byte
+            fp8_bytes = np.ascontiguousarray(fp8_blk.view(np.uint8))
+            g_arr = np.ascontiguousarray([w_global], dtype=np.float32)
+            _NVFP4_WEIGHT_KEEPALIVE.extend([packed, fp8_bytes, g_arr])
+            w_const = network.add_constant(
+                (rhs_width, lhs_width),
+                trt.Weights(trt.DataType.FP4, packed.ctypes.data,
+                            rhs_width * lhs_width)).get_output(0)
+            s8_const = network.add_constant(
+                (rhs_width, nb),
+                trt.Weights(trt.DataType.FP8, fp8_bytes.ctypes.data,
+                            rhs_width * nb)).get_output(0)
+            g_const = graph_ops.add_constant(network, (1,), g_arr, dtype=np.float32)
+            real_scale = network.add_dequantize(
+                s8_const, g_const, out_trt_dtype).get_output(0)
+            dq_w = network.add_dequantize(
+                w_const, real_scale, out_trt_dtype).get_output(0)
+            weight_transposed = True
+        except Exception:
+            weight_const = graph_ops.add_constant(
+                network, (lhs_width, rhs_width), weight_array, dtype=dtype)
+            dq_w = _nvfp4_dynamic(weight_const, 0, w_amax)
+            weight_transposed = False
+
+        # Activation: dynamic per-block; per-tensor global = calibrated amax.
+        NVFP4_MAXBOUND = 6.0
+        a_amax = (float(scales.input_scale) * NVFP4_MAXBOUND
+                  if np.isscalar(scales.input_scale)
+                  and float(scales.input_scale) not in (0.0, 1.0)
+                  else w_amax)
+        dq_a = _nvfp4_dynamic(activation, len(activation.shape) - 1, a_amax)
+
+        w_op = (trt.MatrixOperation.TRANSPOSE if weight_transposed
+                else trt.MatrixOperation.NONE)
         mm = network.add_matrix_multiply(
-            dq_a.get_output(0), trt.MatrixOperation.NONE,
-            dq_w.get_output(0), trt.MatrixOperation.NONE)
+            dq_a, trt.MatrixOperation.NONE, dq_w, w_op)
         return _cast_output_dtype(network, mm.get_output(0), out_trt_dtype)
 
     def wrap_conv2d(
@@ -541,10 +597,10 @@ class NVFP4Format:
         w_scale_t = graph_ops.add_constant(
             network, w_scale.shape, w_scale, dtype=np.float32)
         q_w = network.add_quantize(w_const, w_scale_t, trt.DataType.FP4)
-        q_w.set_block_shape(trt.Dims([block_size]))
+        q_w.block_shape = trt.Dims([block_size])
         dq_w = network.add_dequantize(
             q_w.get_output(0), w_scale_t, out_trt_dtype)
-        dq_w.set_block_shape(trt.Dims([block_size]))
+        dq_w.block_shape = trt.Dims([block_size])
 
         # Activation: dynamic quantization (scales computed at runtime)
         dq_a = network.add_dynamic_quantize_v2(
@@ -599,10 +655,10 @@ class W4A8Format:
         w_scale_t = graph_ops.add_constant(
             network, w_scale.shape, w_scale, dtype=np.float32)
         q_w = network.add_quantize(weight_const, w_scale_t, trt.int4)
-        q_w.set_block_shape(trt.Dims([block_size]))
+        q_w.block_shape = trt.Dims([block_size])
         dq_w = network.add_dequantize(
             q_w.get_output(0), w_scale_t, out_trt_dtype)
-        dq_w.set_block_shape(trt.Dims([block_size]))
+        dq_w.block_shape = trt.Dims([block_size])
 
         # Activation: INT8 per-tensor quantization
         a_scale = np.array(
@@ -648,10 +704,10 @@ class W4A8Format:
         w_scale_t = graph_ops.add_constant(
             network, w_scale.shape, w_scale, dtype=np.float32)
         q_w = network.add_quantize(w_const, w_scale_t, trt.int4)
-        q_w.set_block_shape(trt.Dims([block_size]))
+        q_w.block_shape = trt.Dims([block_size])
         dq_w = network.add_dequantize(
             q_w.get_output(0), w_scale_t, out_trt_dtype)
-        dq_w.set_block_shape(trt.Dims([block_size]))
+        dq_w.block_shape = trt.Dims([block_size])
 
         # Activation: INT8 per-tensor quantization
         a_scale = np.array(

--- a/python/tensorrt_model_connect/quantization/plan.py
+++ b/python/tensorrt_model_connect/quantization/plan.py
@@ -48,9 +48,12 @@ class QuantPlan:
             scale_source = "none"
         elif quant_scales:
             scale_source = "precomputed"
-        elif quant_format == "nvfp4":
-            scale_source = "dynamic"
         else:
+            # nvfp4 (like fp8/int8) calibrates a per-tensor amax via ModelOpt:
+            # the NVFP4 format builds an FP4 double-quantization (dynamic per-block
+            # scales + a static per-tensor global) and needs that calibrated
+            # activation global scale — an empty/dynamic provider leaves it
+            # unset, which collapses the activation quantization to garbage.
             scale_source = "modelopt"
         return cls(
             base_precision=precision,

--- a/python/tensorrt_model_connect/quantization/scale_providers.py
+++ b/python/tensorrt_model_connect/quantization/scale_providers.py
@@ -85,6 +85,11 @@ class ModelOptCalibrationProvider:
     # Map our format names to ModelOpt config names
     _MTQ_CONFIG_NAMES: dict[str, str] = {
         "fp8": "FP8_DEFAULT_CFG",
+        # INT8SmoothQuantFormat now applies SmoothQuant smoothing in the graph
+        # (activations *pre_quant_scale, weights /pre_quant_scale), so it is
+        # paired with INT8_SMOOTHQUANT_CFG. The calibrated per-channel weight
+        # amax corresponds to the smoothed weights, and pre_quant_scale is
+        # extracted + threaded through LayerScales so the build reproduces it.
         "int8_sq": "INT8_SMOOTHQUANT_CFG",
         "int4_awq": "INT4_AWQ_CFG",
         "nvfp4": "NVFP4_DEFAULT_CFG",
@@ -199,6 +204,7 @@ class ModelOptCalibrationProvider:
             scales[mapped] = LayerScales(
                 input_scale=scale_dict["input_scale"],
                 weight_scale=scale_dict["weight_scale"],
+                pre_quant_scale=scale_dict.get("pre_quant_scale"),
             )
 
         logger.info("Extracted scales for %d layers", len(scales))

--- a/python/tensorrt_model_connect/quantization/scales.py
+++ b/python/tensorrt_model_connect/quantization/scales.py
@@ -25,6 +25,11 @@ class LayerScales:
     weight_scale: float | np.ndarray = 1.0
     output_scale: float | np.ndarray = 1.0
     block_size: int | None = None
+    # Per-input-channel SmoothQuant factor (ModelOpt ``input_quantizer.
+    # _pre_quant_scale``). When present, the format smooths activations by
+    # ``*pre_quant_scale`` and weights by ``/pre_quant_scale`` so the calibrated
+    # (smoothed-weight) scales match what runs. None for non-SmoothQuant formats.
+    pre_quant_scale: np.ndarray | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {}
@@ -36,6 +41,8 @@ class LayerScales:
                 d[k] = v
         if self.block_size is not None:
             d["block_size"] = self.block_size
+        if self.pre_quant_scale is not None:
+            d["pre_quant_scale"] = np.asarray(self.pre_quant_scale).tolist()
         return d
 
     @staticmethod
@@ -47,6 +54,9 @@ class LayerScales:
                 kwargs[k] = np.array(v) if isinstance(v, list) else v
         if "block_size" in d:
             kwargs["block_size"] = d["block_size"]
+        if "pre_quant_scale" in d:
+            kwargs["pre_quant_scale"] = np.asarray(d["pre_quant_scale"],
+                                                   dtype=np.float32)
         return LayerScales(**kwargs)
 
 


### PR DESCRIPTION
## What
- **Correct nvfp4 output** — route nvfp4 through the ModelOpt calibration provider (calibrated per-tensor global activation scale) instead of an empty dynamic provider that left the activation scale unset and collapsed the output to ~random.
- **Static 4-bit weight compression** — pack FP4 (E2M1) weights with per-block FP8 scales + FP32 global.
- **TRT 11** — set `block_shape` via the property (the setter was removed in TRT 11).

## Validation (805 MMMU-Pro)
nvfp4 **41.4%** (was ~26% / random before the fix), garbage=0, **1.32× decode speedup** vs bf16 (smallest engine, 4-bit weights).

Stack: #263 → #264 → #430 → #431 → **#390**.
