### PR TITLE
test(ci): replay RedTeam-S5-BATCH detector

### DIFF
--- a/src/runtime/models/flux/pipeline.cpp
+++ b/src/runtime/models/flux/pipeline.cpp
@@ -1668,7 +1668,7 @@ bool FluxPipeline::prepare_flux_batch_conditioning(
     std::vector<float>& encoder_hidden_batch, std::vector<float>& cos_batch,
     std::vector<float>& sin_batch, std::vector<float>& latents_batch) {
     const bool is_flux2 = !weights_.vae_bn_mean.empty();
-    const auto chunk_end = chunk_begin + static_cast<std::size_t>(B);
+    const auto chunk_end = chunk_begin + 1;
 
     // 1-3. Prompt prep + tokenize + generation plan.
     std::vector<std::vector<int32_t>> per_sample_input_ids;


### PR DESCRIPTION
## Background

Issue #383 was fixed by PR #384, which added a real-bundle FLUX batch-two detector. This draft PR replays the original RT-S5-BATCH mutation against the merged detector.

## Exit Criteria

- Impact analysis selects `flux-schnell-l0-batch2` for this FLUX runtime change.
- The batch-two E2E executes the mutated path and fails because only the first prompt is prepared.
- Batch-one FLUX coverage remains unaffected.

This is a disposable red-team mutation and must not be merged.

## Implementation

- Restrict `prepare_flux_batch_conditioning` to prepare only the first sample in a multi-sample chunk.
- Preserve the batch-one fast path, matching the original mutation from draft PR #374.

## Validation

- `python3 -m pytest tests/tools/test_test_impact.py -k flux_runtime_selects_batch2_detector -q`: 1 passed.
- `python3 -m pytest tests/e2e/models/flux/test_flux_batch_contract.py tests/e2e/models/flux/test_flux_diffusion_runner_generic.py tests/e2e/models/flux/test_flux_manifest_contract.py -q`: 6 passed.
- `clang-format --dry-run --Werror src/runtime/models/flux/pipeline.cpp`: passed.
- GitHub Premerge CI: expected to fail specifically in `flux-schnell-l0-batch2`.

## Notes For Future Readers

- Do not weaken or change the detector to make this PR pass.
- After the expected failure is recorded, close this PR without merging and close #383 with the replay evidence.

Refs: #383
