### PR TITLE
test(ci): probe RedTeam-S4-CONFIG T5 EOS

### DIFF
--- a/src/runtime/models/t5/plugin.cpp
+++ b/src/runtime/models/t5/plugin.cpp
@@ -366,7 +366,7 @@ class T5Plugin final : public IPipelinePlugin {
         return std::make_unique<T5Pipeline>(
             std::move(enc_loaded.module), std::move(dec_loaded.module), std::move(cache),
             ctx.config.hidden_size, dl, max_enc_seq_len, ctx.config.vocab_size,
-            decoder_start_token_id, ctx.config.id_eos, stream, std::move(tok),
+            decoder_start_token_id, ctx.config.id_bos, stream, std::move(tok),
             ctx.bundle.info.model_id);
     }
 };


### PR DESCRIPTION
> **DO NOT MERGE - disposable CI red-team probe**

- Plan version: 3.1
- Campaign: 1
- Probe ID: `RT-S4-CONFIG`
- Assurance claim: `G-SEAM`
- Lifecycle stage or seam: `S4 Config`
- Invariant: T5 `eos_token_id` emitted by Python remains the encoder terminator and decoder stop token consumed by C++
- Baseline SHA: `cc076341738d5f1b3fea5bb06103e893938c1e74`
- Expected detector: required `t5-small` seq2seq E2E contract
- Expected result: `compare_fail` from divergent, empty, or overlong TRT translation; compilation and C++ unit tests should pass

## Background

The baseline has separate Python producer and generic C++ parser coverage, but no seam test proving that the T5 plugin wires the parsed EOS field into the runtime EOS slot. A shape-compatible integer mapping error can therefore preserve bundle construction and runtime loading while changing user-visible generation.

The green control is GitHub run `28194897545`: `t5-small` produced `Das Haus ist wunderbar.` with exact HF match and token IDs `[644, 4598, 229, 19250, 5, 1]`.

## Exit Criteria

- Impact analysis selects the T5 C++ tier and `t5-small` E2E.
- The real T5 bundle loads and executes the mutated consumer path.
- The required seq2seq contract fails for the EOS semantic drift.
- Failure evidence includes TRT text/token IDs and HF comparison metrics.

## Implementation

- Pass the parsed BOS value (`0`) into the T5 runtime EOS constructor slot instead of the parsed EOS value (`1`).
- Leave the Python builder, bundle, parser, E2E contract, reference, and thresholds unchanged.

This is the single admitted mutation. It must be closed without merging after observation.

## Validation

- `python3 tools/test_impact.py --base github/main --head HEAD --files src/runtime/models/t5/plugin.cpp --e2e-suite l0 --json`: selected `t5-small`, `t5-small-tp4`, and the C++ tier; default premerge excludes the multi-device testcase from execution.
- `python3 -m pytest tests/e2e/models/t5/test_t5_debug_runner.py tests/e2e/models/t5/test_t5_family_plugin_weights.py -q`: 4 passed.
- `clang-format --dry-run --Werror src/runtime/models/t5/plugin.cpp`: passed.
- `git diff --check github/main...HEAD`: passed.

## Notes For Future Readers

- ADR intentionally skipped: this is a disposable fault injection, not an architectural decision.
- Do not alter the detector, reference, threshold, or expected output to make this PR pass.
- Draft T5 refactor PR #349 does not modify this C++ mutation point.
