### PR TITLE
test(ci): probe RedTeam-R6 Qwen seed determinism

### DIFF
--- a/src/runtime/models/qwen/sampler.cpp
+++ b/src/runtime/models/qwen/sampler.cpp
@@ -23,6 +23,7 @@
 #endif
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <limits>
 #include <numeric>
@@ -439,8 +440,10 @@ create_qwen_sampler(const QwenSamplingParams& params,
         return std::make_unique<GreedySampler>();
     }
 
-    uint64_t seed = (params.seed >= 0) ? static_cast<uint64_t>(params.seed)
-                                       : 42ULL; // deterministic default for reproducibility
+    uint64_t seed = (params.seed >= 0)
+                        ? static_cast<uint64_t>(
+                              std::chrono::high_resolution_clock::now().time_since_epoch().count())
+                        : 42ULL; // deterministic default for reproducibility
 #if TRTMC_HAS_LIBTORCH_MULTINOMIAL && TRTMC_HAS_CUDA_KERNELS
     if (options.prefer_torch_cuda_multinomial)
         return std::make_unique<TorchCudaMultinomialSampler>(seed);


### PR DESCRIPTION
## Background

The CI Red-Team plan identifies runtime lifecycle and determinism as a high-priority evidence gap. The Qwen sampling manifest `qwen3-0.6b-topp` supplies seed `42` and requests one determinism rerun, so it provides an existing independent detector for an ignored-seed defect.

## Exit Criteria

- Impact analysis selects `qwen3-0.6b-topp` for the Qwen runtime change.
- The normal seeded run completes and the determinism rerun executes the same command.
- The rerun fails with `determinism_fail` because the runtime no longer honors the supplied seed.
- Qwen cases without an explicit sampling seed remain unaffected.

## Implementation

- Replace the explicit Qwen sampling seed with a high-resolution runtime clock value.
- Preserve greedy behavior and the deterministic default used when no explicit seed is provided.
- Keep the mutation limited to `src/runtime/models/qwen/sampler.cpp`.

## Validation

- `python3 tools/legal_headers.py --check`: passed.
- `clang-format --dry-run --Werror src/runtime/models/qwen/sampler.cpp`: passed.
- `python3 tools/check_cyclomatic_complexity.py src/runtime/models/qwen/sampler.cpp --max-ccn 10 --top 20`: passed; maximum CCN 8.
- `python3 tools/test_impact.py --base github/main --json`: selected the Qwen family, including `qwen3-0.6b-topp`.
- `python3 -m pytest tests/tools/test_test_impact.py -q`: 183 passed.
- Focused C++ compilation was not run locally because the existing container has no build configured for this worktree; GitHub CI is the intended compile and behavior detector.

## Notes For Future Readers

- **DO NOT MERGE:** this is a disposable `RedTeam-R6-LIFECYCLE` mutation.
- Do not weaken the determinism contract or change its expected output to make this PR pass.
- Do not add `run-ci` while another campaign probe is running; probes must remain serialized.
