### PR TITLE
test(ci): probe RedTeam-S1 ALBERT strategy

### DIFF
--- a/python/tensorrt_model_connect/families/albert/plugin.py
+++ b/python/tensorrt_model_connect/families/albert/plugin.py
@@ -42,7 +42,7 @@ def _load_ln(readers, prefix):
 
 class AlbertPlugin:
     name = "albert"
-    runtime_strategy = "albert_encoder_only"
+    runtime_strategy = "bert_encoder_only"
 
     def matches(self, model_type: str) -> bool:
         return model_type.lower() == "albert"


### PR DESCRIPTION
## Background

The CI Red-Team plan prioritizes strategy continuity because many runtime strategies have no diff-framework check. ALBERT uses `albert_encoder_only`, but its family tests do not assert that the builder-emitted strategy remains bound to the ALBERT runtime owner.

This probe emits another existing strategy, `bert_encoder_only`, while leaving the ALBERT graph, bundle, manifests, runtime plugins, and E2E contracts unchanged.

## Exit Criteria

- Impact analysis selects `albert-base`, `albert-base-tp4`, and the builder tier.
- A real ALBERT bundle is built with the mutated strategy.
- Required CI rejects the bundle before reporting the ALBERT E2E contract as passed.
- The failure identifies strategy/dispatch ownership rather than an unrelated infrastructure error.

## Implementation

- Change only `AlbertPlugin.runtime_strategy` from `albert_encoder_only` to the existing but incorrect `bert_encoder_only` strategy.
- Preserve all model weights, graph construction, runtime code, references, and thresholds.

## Validation

- `python3 tools/legal_headers.py --check`: passed.
- `ruff check --config ruff.toml python/tensorrt_model_connect/families/albert/plugin.py`: passed.
- `python3 -m pytest tests/e2e/models/albert/test_albert_family_plugin_weights.py -q`: 2 passed, confirming the mutation does not alter ALBERT weight handling.
- `python3 scripts/check_family_coverage.py`: passed; both ALBERT manifests remain registered.
- `python3 tools/test_impact.py --base github/main --json`: selected `albert-base`, `albert-base-tp4`, and the builder tier.
- `python3 -m pytest tests/tools/test_test_impact.py -q`: 183 passed.
- `python3 tools/check_runtime_strategy_matrix.py`: not usable as this probe's oracle because it reports five pre-existing runner-class errors unrelated to ALBERT; the real-bundle E2E remains the expected detector.

## Notes For Future Readers

- **DO NOT MERGE:** this is a disposable `RedTeam-S1-STRATEGY` mutation.
- Expected first failing gate: required `albert-base` runtime admission/dispatch or encoder E2E contract.
- Benign control: successful main nightly run `27343857392`; the probe must still be evaluated from its own selection, execution, verdict, and artifact evidence.
- Do not modify runtime registration, manifests, references, or thresholds to make this PR pass.
