### PR TITLE
test(ci): probe RedTeam-CI GPT-2 selection

### DIFF
--- a/src/runtime/models/gpt2/pipeline.cpp
+++ b/src/runtime/models/gpt2/pipeline.cpp
@@ -356,9 +356,7 @@ TextResult Gpt2TextGenerationPipeline::generate(const std::string& prompt,
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
-    std::vector<int32_t> new_tokens(timed.token_ids.begin() +
-                                        static_cast<std::ptrdiff_t>(input_ids.size()),
-                                    timed.token_ids.end());
+    std::vector<int32_t> new_tokens(timed.token_ids.begin(), timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
     return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};


### PR DESCRIPTION
## Background

The CI Red-Team plan requires direct evidence that a production change selects and executes its owning model tests. This probe places a known-red postprocessing defect in the GPT-2 runtime and observes whether impact analysis selects the GPT-2 family and required E2E contracts.

The mutation and detector are independent: the probe changes only production runtime code and does not modify `tools/test_impact.py`, manifests, tests, references, or thresholds.

## Exit Criteria

- Impact analysis classifies the changed file as `cpp_runtime_model`.
- It selects `distilgpt2`, `gpt2-125m`, `gpt2-125m-tp4`, and the C++ tier.
- Premerge executes the two single-device GPT-2 cases; the multi-device case may remain excluded by current policy.
- At least one required GPT-2 E2E fails because the returned text incorrectly includes prompt tokens.
- Logs and artifacts identify both the selected models and the user-contract failure.

## Implementation

- Decode the complete GPT-2 token sequence instead of slicing off the input prompt before returning generated text.
- Preserve model build, inference, sampler, references, and all CI selection logic.

## Validation

- `python3 tools/legal_headers.py --check`: passed.
- `clang-format --dry-run --Werror src/runtime/models/gpt2/pipeline.cpp`: passed.
- `python3 tools/check_cyclomatic_complexity.py src/runtime/models/gpt2/pipeline.cpp --max-ccn 10 --top 20`: passed; maximum CCN 10.
- `python3 tools/test_impact.py --base github/main --json`: matched `cpp_runtime_model` and selected all three GPT-2 manifests plus the C++ tier.
- `python3 -m pytest tests/tools/test_test_impact.py -q`: 183 passed.
- Focused C++ compilation was not run locally because the existing container has no build configured for this worktree; GitHub CI is the intended compile, selection, and behavior detector.

## Notes For Future Readers

- **DO NOT MERGE:** this is a disposable `RedTeam-CI-SELECT` known-red mutation.
- Expected first behavior detector: required `gpt2-125m` or `distilgpt2` E2E contract.
- Benign control: successful main nightly run `27343857392`.
- Do not modify impact analysis, manifests, references, or thresholds to make this PR pass.
