### PR TITLE
fix(gpt-oss): apply YaRN scaling and sliding-window attention

### DIFF
--- a/python/tensorrt_model_connect/families/gpt_oss/graph_ops.py
+++ b/python/tensorrt_model_connect/families/gpt_oss/graph_ops.py
@@ -471,8 +471,15 @@ def make_yarn_rope_table_half_dim(
     beta_fast: float,
     beta_slow: float,
     interleaved: bool = False,
+    truncate: bool = True,
+    attention_factor: float | None = None,
 ) -> np.ndarray:
     """Build a YaRN RoPE table for TRT native IRotaryEmbeddingLayer.
+
+    Matches transformers ``_compute_yarn_parameters``: ``truncate=False``
+    keeps float correction-range bounds, and cos/sin values are scaled by
+    ``attention_factor`` (defaulting to the paper's ``0.1 * ln(factor) + 1``
+    mscale when unset).
 
     Returns [max_cache_length, head_dim // 2], matching the half-dimension
     cache layout required by IRotaryEmbeddingLayer.
@@ -488,19 +495,75 @@ def make_yarn_rope_table_half_dim(
         rope_theta ** (np.arange(0, head_dim, 2, dtype=np.float64) / head_dim))
     freq_inter = freq_extra / scaling_factor
 
-    low = max(int(np.floor(_yarn_correction_dim(
-        beta_fast, head_dim, rope_theta, original_max_position_embeddings))), 0)
-    high = min(int(np.ceil(_yarn_correction_dim(
-        beta_slow, head_dim, rope_theta, original_max_position_embeddings))), half - 1)
-    ramp = np.clip((np.arange(half, dtype=np.float64) - low) / max(high - low, 1), 0.0, 1.0)
+    low = _yarn_correction_dim(
+        beta_fast, head_dim, rope_theta, original_max_position_embeddings)
+    high = _yarn_correction_dim(
+        beta_slow, head_dim, rope_theta, original_max_position_embeddings)
+    if truncate:
+        low = np.floor(low)
+        high = np.ceil(high)
+    low = max(float(low), 0.0)
+    high = min(float(high), float(head_dim - 1))
+    if low == high:
+        high += 0.001  # prevent singularity (HF parity)
+    ramp = np.clip(
+        (np.arange(half, dtype=np.float64) - low) / (high - low), 0.0, 1.0)
     inv_freq = freq_inter * ramp + freq_extra * (1 - ramp)
 
-    table = np.full((max_cache_length, half), default, dtype=np.float32)
-    for pos in range(max_cache_length):
-        for d in range(half):
-            angle = pos * inv_freq[d]
-            table[pos, d] = np.cos(angle) if cosine else np.sin(angle)
-    return table
+    if attention_factor is None:
+        attention_factor = (
+            0.1 * float(np.log(scaling_factor)) + 1.0
+            if scaling_factor > 1.0 else 1.0)
+
+    positions = np.arange(max_cache_length, dtype=np.float64)[:, None]
+    angles = positions * inv_freq[None, :]
+    table = (np.cos(angles) if cosine else np.sin(angles)) * attention_factor
+    return table.astype(np.float32)
+
+
+def add_sliding_window_mask(
+    network: trt.INetworkDefinition,
+    attention_mask: trt.ITensor,
+    position_id: trt.ITensor,
+    attention_window: int,
+    sliding_window: int,
+) -> trt.ITensor:
+    """Combine the runtime causal mask with a sliding-window restriction.
+
+    Cache column ``c`` of the attention window holds the K/V row written at
+    position ``c`` and the final column holds the current token, so a
+    sliding-attention layer at position ``p`` may only attend to columns
+    ``c >= p - (sliding_window - 1)``. Columns below that bound receive a
+    large negative penalty on top of the runtime-provided causal mask.
+
+    Returns a ``[1, attention_window]`` mask tensor in the dtype of
+    ``attention_mask``.
+    """
+    iota = add_constant(
+        network, (1, attention_window),
+        np.arange(attention_window, dtype=np.float32).reshape(1, -1))
+    pos_float = network.add_cast(position_id, trt.float32).get_output(0)
+    pos_2d = network.add_shuffle(pos_float)
+    pos_2d.reshape_dims = (1, 1)
+    window_span = add_constant(
+        network, (1, 1),
+        np.array([[float(sliding_window - 1)]], dtype=np.float32))
+    threshold = network.add_elementwise(
+        pos_2d.get_output(0), window_span,
+        trt.ElementWiseOperation.SUB).get_output(0)
+    out_of_window = network.add_elementwise(
+        iota, threshold, trt.ElementWiseOperation.LESS).get_output(0)
+    penalty_value = add_constant(
+        network, (1, 1), np.array([[-1e9]], dtype=np.float32))
+    zero = add_constant(
+        network, (1, 1), np.array([[0.0]], dtype=np.float32))
+    penalty = network.add_select(
+        out_of_window, penalty_value, zero).get_output(0)
+    if penalty.dtype != attention_mask.dtype:
+        penalty = network.add_cast(
+            penalty, attention_mask.dtype).get_output(0)
+    return network.add_elementwise(
+        attention_mask, penalty, trt.ElementWiseOperation.SUM).get_output(0)
 
 
 def make_llama4_attention_scale_table(

--- a/python/tensorrt_model_connect/families/gpt_oss/plugin.py
+++ b/python/tensorrt_model_connect/families/gpt_oss/plugin.py
@@ -47,6 +47,7 @@ from ...parallel_config import (
     require_tensorrt_11_for_tensor_parallel,
 )
 from .standard_decoder_builder import _apply_norm, _mark_debug_output
+from .utils import make_rope_half_tables
 
 
 trt = trt_compat.get_trt()
@@ -309,6 +310,18 @@ class GptOssPlugin:
             attention_mask = network.add_cast(
                 attention_mask, work_trt_dtype).get_output(0)
 
+        # GPT-OSS alternates sliding_attention (windowed) and full_attention
+        # layers. The runtime mask only encodes causal validity, so build a
+        # second mask that additionally hides cache columns older than the
+        # sliding window and feed it to the sliding layers.
+        layer_types = list(config.raw.get("layer_types") or [])
+        sliding_window = int(config.raw.get("sliding_window") or 0)
+        sliding_attention_mask = None
+        if sliding_window > 0 and "sliding_attention" in layer_types:
+            sliding_attention_mask = graph_ops.add_sliding_window_mask(
+                network, attention_mask, position_id,
+                attention_window, sliding_window)
+
         # -----------------------------------------------------------
         # Shared constants
         # -----------------------------------------------------------
@@ -316,38 +329,11 @@ class GptOssPlugin:
             network, (vocab, hidden), weights["embedding"],
             dtype=work_np_dtype)
 
-        # GPT-OSS uses YaRN RoPE scaling (rope_parameters in config.json)
-        rope_params = config.raw.get("rope_parameters", {})
-        rope_type = rope_params.get("rope_type", "default")
-
-        if rope_type == "yarn":
-            yarn_factor = float(rope_params.get("factor", 1.0))
-            yarn_orig_max = int(rope_params.get(
-                "original_max_position_embeddings", 4096))
-            yarn_beta_fast = float(rope_params.get("beta_fast", 32.0))
-            yarn_beta_slow = float(rope_params.get("beta_slow", 1.0))
-
-            cos_half_np = graph_ops.make_yarn_rope_table_half_dim(
-                attention_window, head_dim,
-                config.rope_theta, True,
-                scaling_factor=yarn_factor,
-                original_max_position_embeddings=yarn_orig_max,
-                beta_fast=yarn_beta_fast,
-                beta_slow=yarn_beta_slow)
-            sin_half_np = graph_ops.make_yarn_rope_table_half_dim(
-                attention_window, head_dim,
-                config.rope_theta, False,
-                scaling_factor=yarn_factor,
-                original_max_position_embeddings=yarn_orig_max,
-                beta_fast=yarn_beta_fast,
-                beta_slow=yarn_beta_slow)
-        else:
-            cos_half_np = graph_ops.make_rope_table_half_dim(
-                attention_window, head_dim,
-                config.rope_theta, True)
-            sin_half_np = graph_ops.make_rope_table_half_dim(
-                attention_window, head_dim,
-                config.rope_theta, False)
+        # GPT-OSS uses YaRN RoPE scaling. Hub checkpoints serialize it under
+        # rope_scaling; transformers 5.x configs use rope_parameters. The
+        # shared helper accepts both and applies HF-exact YaRN semantics.
+        cos_half_np, sin_half_np = make_rope_half_tables(
+            config, attention_window, head_dim)
 
         cos_half_tensor = graph_ops.add_constant(
             network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype)
@@ -391,12 +377,21 @@ class GptOssPlugin:
                     return tensor
                 return network.add_cast(tensor, layer_trt_dtype).get_output(0)
 
+            layer_type = (
+                layer_types[layer_idx] if layer_idx < len(layer_types)
+                else "full_attention")
+            layer_mask = (
+                sliding_attention_mask
+                if (sliding_attention_mask is not None
+                    and layer_type == "sliding_attention")
+                else attention_mask)
+
             result = _add_gpt_oss_decoder_layer(
                 network=network,
                 hidden=layer_cast(hidden_state),
                 cache_k=layer_cast(cache_k_inputs[layer_idx]),
                 cache_v=layer_cast(cache_v_inputs[layer_idx]),
-                attention_mask=layer_cast(attention_mask),
+                attention_mask=layer_cast(layer_mask),
                 position_id=position_id,
                 cos_half_tensor=layer_cast(cos_half_tensor),
                 sin_half_tensor=layer_cast(sin_half_tensor),

--- a/python/tensorrt_model_connect/families/gpt_oss/tp_builder.py
+++ b/python/tensorrt_model_connect/families/gpt_oss/tp_builder.py
@@ -14,6 +14,7 @@ from tensorrt_model_connect import trt_compat
 from . import graph_blocks, graph_ops
 from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
 from .standard_decoder_builder import _apply_norm, _mark_debug_output
+from .utils import make_rope_half_tables
 
 trt = trt_compat.get_trt()
 
@@ -492,34 +493,7 @@ def _make_rope_tables(
     attention_window: int,
     head_dim: int,
 ) -> tuple[np.ndarray, np.ndarray]:
-    rope_params = config.raw.get("rope_parameters", {})
-    rope_type = rope_params.get("rope_type", "default")
-    if rope_type == "yarn":
-        yarn_factor = float(rope_params.get("factor", 1.0))
-        yarn_orig_max = int(rope_params.get(
-            "original_max_position_embeddings", 4096))
-        yarn_beta_fast = float(rope_params.get("beta_fast", 32.0))
-        yarn_beta_slow = float(rope_params.get("beta_slow", 1.0))
-        return (
-            graph_ops.make_yarn_rope_table_half_dim(
-                attention_window, head_dim, config.rope_theta, True,
-                scaling_factor=yarn_factor,
-                original_max_position_embeddings=yarn_orig_max,
-                beta_fast=yarn_beta_fast,
-                beta_slow=yarn_beta_slow),
-            graph_ops.make_yarn_rope_table_half_dim(
-                attention_window, head_dim, config.rope_theta, False,
-                scaling_factor=yarn_factor,
-                original_max_position_embeddings=yarn_orig_max,
-                beta_fast=yarn_beta_fast,
-                beta_slow=yarn_beta_slow),
-        )
-    return (
-        graph_ops.make_rope_table_half_dim(
-            attention_window, head_dim, config.rope_theta, True),
-        graph_ops.make_rope_table_half_dim(
-            attention_window, head_dim, config.rope_theta, False),
-    )
+    return make_rope_half_tables(config, attention_window, head_dim)
 
 
 def build_gpt_oss_tp_engine(
@@ -591,16 +565,34 @@ def build_gpt_oss_tp_engine(
     if debug_layer_outputs:
         _mark_debug_output(network, hidden_state, "debug_embed")
 
+    # Sliding-attention layers attend only within the configured window;
+    # feed them a mask that additionally hides out-of-window cache columns.
+    layer_types = list(config.raw.get("layer_types") or [])
+    sliding_window = int(config.raw.get("sliding_window") or 0)
+    sliding_attention_mask = None
+    if sliding_window > 0 and "sliding_attention" in layer_types:
+        sliding_attention_mask = graph_ops.add_sliding_window_mask(
+            network, attention_mask, position_id,
+            attention_window, sliding_window)
+
     present_k_outputs = []
     present_v_outputs = []
     for layer_idx in range(num_layers):
         prefix = f"layer.{layer_idx}"
+        layer_type = (
+            layer_types[layer_idx] if layer_idx < len(layer_types)
+            else "full_attention")
+        layer_mask = (
+            sliding_attention_mask
+            if (sliding_attention_mask is not None
+                and layer_type == "sliding_attention")
+            else attention_mask)
         result = _add_gpt_oss_tp_decoder_layer(
             network=network,
             hidden=hidden_state,
             cache_k=cache_k_inputs[layer_idx],
             cache_v=cache_v_inputs[layer_idx],
-            attention_mask=attention_mask,
+            attention_mask=layer_mask,
             position_id=position_id,
             cos_half_tensor=cos_half_tensor,
             sin_half_tensor=sin_half_tensor,

--- a/python/tensorrt_model_connect/families/gpt_oss/utils.py
+++ b/python/tensorrt_model_connect/families/gpt_oss/utils.py
@@ -16,6 +16,59 @@ from . import graph_ops
 trt = trt_compat.get_trt()
 
 
+def resolve_rope_parameters(config) -> dict:
+    """Return the RoPE scaling dict from the raw HF config.json.
+
+    Configs serialized by transformers < 5.x store the scaling dict under
+    ``rope_scaling``; transformers 5.x standardizes on ``rope_parameters``.
+    GPT-OSS checkpoints on the Hub still ship ``rope_scaling``, so accept
+    both (``rope_parameters`` wins when both are present).
+    """
+    raw = getattr(config, "raw", None) or {}
+    for key in ("rope_parameters", "rope_scaling"):
+        params = raw.get(key)
+        if isinstance(params, dict):
+            return params
+    return {}
+
+
+def make_rope_half_tables(
+    config,
+    attention_window: int,
+    head_dim: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build (cos, sin) half-dim RoPE tables honoring YaRN when configured."""
+    rope_params = resolve_rope_parameters(config)
+    rope_type = rope_params.get(
+        "rope_type", rope_params.get("type", "default"))
+    if rope_type == "yarn":
+        attention_factor = rope_params.get("attention_factor")
+        yarn_kwargs = dict(
+            scaling_factor=float(rope_params.get("factor", 1.0)),
+            original_max_position_embeddings=int(rope_params.get(
+                "original_max_position_embeddings", 4096)),
+            beta_fast=float(rope_params.get("beta_fast", 32.0)),
+            beta_slow=float(rope_params.get("beta_slow", 1.0)),
+            truncate=bool(rope_params.get("truncate", True)),
+            attention_factor=(
+                None if attention_factor is None else float(attention_factor)),
+        )
+        return (
+            graph_ops.make_yarn_rope_table_half_dim(
+                attention_window, head_dim, config.rope_theta, True,
+                **yarn_kwargs),
+            graph_ops.make_yarn_rope_table_half_dim(
+                attention_window, head_dim, config.rope_theta, False,
+                **yarn_kwargs),
+        )
+    return (
+        graph_ops.make_rope_table_half_dim(
+            attention_window, head_dim, config.rope_theta, True),
+        graph_ops.make_rope_table_half_dim(
+            attention_window, head_dim, config.rope_theta, False),
+    )
+
+
 @dataclass(frozen=True)
 class BuilderContext:
     """TensorRT objects shared by engine builders."""

--- a/tests/e2e/models/gpt_oss/test_gpt_oss_rope_and_sliding.py
+++ b/tests/e2e/models/gpt_oss/test_gpt_oss_rope_and_sliding.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for GPT-OSS YaRN RoPE resolution and sliding-window attention.
+
+Trace: ARCH-FAM-001, UD-FAM-GPT-OSS
+Intent: GPT-OSS config.json ships ``rope_scaling`` (yarn, factor 32) and
+    alternating ``layer_types`` with ``sliding_window: 128``. The engine
+    builder previously read only ``rope_parameters`` (silently skipping YaRN)
+    and applied a full causal mask to every layer (ignoring the sliding
+    window). Both defects produce garbage generation for prompts longer than
+    the sliding window while short-prompt smoke tests still pass.
+Preconditions: Synthetic tiny GPT-OSS configs/weights; no HF checkpoint.
+Postconditions: RoPE tables honor rope_scaling with HF-exact YaRN semantics
+    (attention factor, non-truncated correction range) and sliding layers
+    attend only within the configured window.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
+
+try:
+    # NOTE: never import the ``plugin`` submodule directly here — the import
+    # machinery would rebind the package attribute ``gpt_oss.plugin`` from
+    # the plugin *instance* to the submodule and break sibling tests.
+    import tensorrt_model_connect.families.gpt_oss as gpt_oss
+    from tensorrt_model_connect.families.gpt_oss import graph_ops
+    from tensorrt_model_connect.families.gpt_oss.config import ModelConfig
+    from tensorrt_model_connect.families.gpt_oss.utils import (
+        make_rope_half_tables,
+        resolve_rope_parameters,
+    )
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
+
+
+GPT_OSS_ROPE_SCALING = {
+    "beta_fast": 32.0,
+    "beta_slow": 1.0,
+    "factor": 32.0,
+    "original_max_position_embeddings": 4096,
+    "rope_type": "yarn",
+    "truncate": False,
+}
+
+
+def _hf_yarn_reference(
+    positions: int,
+    head_dim: int,
+    base: float,
+    factor: float,
+    original_max: int,
+    beta_fast: float,
+    beta_slow: float,
+    truncate: bool,
+) -> tuple[np.ndarray, float]:
+    """Independent port of transformers._compute_yarn_parameters."""
+
+    def find_correction_dim(num_rotations: float) -> float:
+        return (head_dim * math.log(original_max / (num_rotations * 2 * math.pi))
+                ) / (2 * math.log(base))
+
+    low = find_correction_dim(beta_fast)
+    high = find_correction_dim(beta_slow)
+    if truncate:
+        low = math.floor(low)
+        high = math.ceil(high)
+    low = max(low, 0)
+    high = min(high, head_dim - 1)
+    if low == high:
+        high += 0.001
+
+    pos_freqs = base ** (np.arange(0, head_dim, 2, dtype=np.float64) / head_dim)
+    inv_extra = 1.0 / pos_freqs
+    inv_inter = 1.0 / (factor * pos_freqs)
+    ramp = np.clip(
+        (np.arange(head_dim // 2, dtype=np.float64) - low) / (high - low), 0.0, 1.0)
+    extrapolation_factor = 1.0 - ramp
+    inv_freq = inv_inter * (1.0 - extrapolation_factor) + inv_extra * extrapolation_factor
+    attention_factor = 0.1 * math.log(factor) + 1.0 if factor > 1.0 else 1.0
+    return inv_freq, attention_factor
+
+
+# ---------------------------------------------------------------------------
+# RoPE parameter resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_rope_parameters_accepts_rope_scaling_key():
+    """GPT-OSS Hub checkpoints serialize the yarn dict under rope_scaling."""
+    config = ModelConfig.create_tiny(
+        "gpt_oss", rope_scaling=GPT_OSS_ROPE_SCALING)
+    assert resolve_rope_parameters(config) == GPT_OSS_ROPE_SCALING
+
+
+def test_resolve_rope_parameters_prefers_rope_parameters_key():
+    params = {"rope_type": "yarn", "factor": 8.0}
+    config = ModelConfig.create_tiny(
+        "gpt_oss",
+        rope_parameters=params, rope_scaling=GPT_OSS_ROPE_SCALING)
+    assert resolve_rope_parameters(config) == params
+
+
+def test_resolve_rope_parameters_defaults_to_empty():
+    config = ModelConfig.create_tiny("gpt_oss")
+    assert resolve_rope_parameters(config) == {}
+
+
+def test_make_rope_half_tables_applies_yarn_from_rope_scaling():
+    """The original defect: rope_scaling configs fell back to default RoPE."""
+    config = ModelConfig.create_tiny(
+        "gpt_oss", rope_theta=150000.0,
+        rope_scaling=dict(GPT_OSS_ROPE_SCALING))
+    head_dim, window = 64, 16
+
+    cos_yarn, sin_yarn = make_rope_half_tables(config, window, head_dim)
+    cos_default = graph_ops.make_rope_table_half_dim(
+        window, head_dim, 150000.0, True)
+
+    assert not np.allclose(cos_yarn, cos_default), (
+        "rope_scaling yarn config must not silently fall back to default RoPE")
+
+    inv_freq, attention_factor = _hf_yarn_reference(
+        window, head_dim, 150000.0, 32.0, 4096, 32.0, 1.0, truncate=False)
+    positions = np.arange(window, dtype=np.float64)[:, None]
+    expected_cos = np.cos(positions * inv_freq[None, :]) * attention_factor
+    expected_sin = np.sin(positions * inv_freq[None, :]) * attention_factor
+    np.testing.assert_allclose(cos_yarn, expected_cos, rtol=0, atol=1e-5)
+    np.testing.assert_allclose(sin_yarn, expected_sin, rtol=0, atol=1e-5)
+
+
+def test_yarn_table_truncate_flag_changes_correction_range():
+    """truncate=False keeps float correction bounds (HF parity)."""
+    kwargs = dict(
+        scaling_factor=32.0, original_max_position_embeddings=4096,
+        beta_fast=32.0, beta_slow=1.0)
+    cos_no_trunc = graph_ops.make_yarn_rope_table_half_dim(
+        16, 64, 150000.0, True, truncate=False, **kwargs)
+    cos_trunc = graph_ops.make_yarn_rope_table_half_dim(
+        16, 64, 150000.0, True, truncate=True, **kwargs)
+    assert not np.allclose(cos_no_trunc, cos_trunc)
+
+
+def test_yarn_table_explicit_attention_factor():
+    kwargs = dict(
+        scaling_factor=32.0, original_max_position_embeddings=4096,
+        beta_fast=32.0, beta_slow=1.0, truncate=False)
+    cos_default_factor = graph_ops.make_yarn_rope_table_half_dim(
+        4, 64, 150000.0, True, **kwargs)
+    cos_unit_factor = graph_ops.make_yarn_rope_table_half_dim(
+        4, 64, 150000.0, True, attention_factor=1.0, **kwargs)
+    expected_factor = 0.1 * math.log(32.0) + 1.0
+    np.testing.assert_allclose(
+        cos_default_factor, cos_unit_factor * expected_factor,
+        rtol=0, atol=1e-6)
+    # Position 0 cosine is exactly the attention factor.
+    np.testing.assert_allclose(
+        cos_default_factor[0], np.full(32, expected_factor),
+        rtol=0, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Sliding-window attention (requires a CUDA-capable TensorRT build)
+# ---------------------------------------------------------------------------
+
+def _tiny_gpt_oss_config(layer_types: list[str], sliding_window: int) -> ModelConfig:
+    return ModelConfig.create_tiny(
+        "gpt_oss",
+        vocab_size=32,
+        hidden_size=32,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        rope_theta=150000.0,
+        num_local_experts=2,
+        num_experts_per_tok=1,
+        layer_types=layer_types,
+        sliding_window=sliding_window,
+    )
+
+
+def _tiny_gpt_oss_weights(config: ModelConfig, seed: int = 7):
+    from tensorrt_model_connect.families.gpt_oss.checkpoint_mapper import WeightDict
+
+    rng = np.random.default_rng(seed)
+    hidden = config.hidden_size
+    vocab = config.vocab_size
+    num_heads = config.num_attention_heads
+    num_kv = config.num_key_value_heads
+    head_dim = config.head_dim
+    attn = num_heads * head_dim
+    kv_attn = num_kv * head_dim
+    experts = config.raw["num_local_experts"]
+    inter = 16
+
+    def w(*shape):
+        return rng.standard_normal(shape).astype(np.float32) * 0.1
+
+    weights = WeightDict()
+    weights["embedding"] = w(vocab, hidden)
+    weights["final_norm"] = np.ones(hidden, dtype=np.float32)
+    weights["w_out"] = w(hidden, vocab)
+    for i in range(config.num_hidden_layers):
+        p = f"layer.{i}"
+        weights[f"{p}.input_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{p}.post_attn_norm"] = np.ones(hidden, dtype=np.float32)
+        weights[f"{p}.w_q"] = w(hidden, attn)
+        weights[f"{p}.w_k"] = w(hidden, kv_attn)
+        weights[f"{p}.w_v"] = w(hidden, kv_attn)
+        weights[f"{p}.w_o"] = w(attn, hidden)
+        weights[f"{p}.q_bias"] = w(attn)
+        weights[f"{p}.k_bias"] = w(kv_attn)
+        weights[f"{p}.v_bias"] = w(kv_attn)
+        weights[f"{p}.o_bias"] = w(hidden)
+        weights[f"{p}.sinks"] = w(num_heads)
+        weights[f"{p}.router"] = w(hidden, experts)
+        weights[f"{p}.router_bias"] = w(experts)
+        for e in range(experts):
+            weights[f"{p}.expert.{e}.w_gate"] = w(hidden, inter)
+            weights[f"{p}.expert.{e}.w_up"] = w(hidden, inter)
+            weights[f"{p}.expert.{e}.w_down"] = w(inter, hidden)
+            weights[f"{p}.expert.{e}.gate_bias"] = w(inter)
+            weights[f"{p}.expert.{e}.up_bias"] = w(inter)
+            weights[f"{p}.expert.{e}.down_bias"] = w(hidden)
+    weights["_attention_size"] = attn
+    weights["_num_experts"] = experts
+    weights["_moe_intermediate_size"] = inter
+    weights["_num_experts_per_tok"] = config.raw["num_experts_per_tok"]
+    return weights
+
+
+def _require_cuda() -> None:
+    try:
+        from cuda.bindings import runtime as cudart
+    except ImportError:
+        try:
+            from cuda import cudart  # type: ignore[no-redef]
+        except ImportError:
+            pytest.skip("cuda-python is required for engine execution tests")
+    err, count = cudart.cudaGetDeviceCount()
+    if int(err) != 0 or count == 0:
+        pytest.skip("No CUDA device available for engine execution tests")
+
+
+def test_sliding_layers_restrict_attention_to_window():
+    """Engines with sliding layer_types must diverge from all-full engines
+    exactly when the prompt outgrows the sliding window."""
+    _require_cuda()
+    from tensorrt_model_connect.families.gpt_oss.debug_runner import TrtRunner
+
+    sliding_window = 4
+    max_cache = 12
+    num_layers = 2
+    tokens = [3, 5, 7, 11, 13, 17, 19, 23, 29, 31]
+
+    plugin = gpt_oss.plugin
+    logits_by_mode: dict[str, list[np.ndarray]] = {}
+    for mode, layer_types in (
+        ("sliding", ["sliding_attention", "full_attention"]),
+        ("full", ["full_attention", "full_attention"]),
+    ):
+        config = _tiny_gpt_oss_config(layer_types, sliding_window)
+        weights = _tiny_gpt_oss_weights(config)
+        plan = plugin.build_engine(
+            config, weights, max_cache, precision="fp32")
+        runner = TrtRunner(
+            engine_plan=plan, max_cache_length=max_cache,
+            num_layers=num_layers)
+        logits_by_mode[mode] = [
+            runner.step(t)["logits"].flatten().copy() for t in tokens]
+        del runner
+
+    # While the context fits in the window the two engines are identical
+    # (sliding penalty masks nothing until position_id > window - 1).
+    for step in range(sliding_window):
+        np.testing.assert_allclose(
+            logits_by_mode["sliding"][step], logits_by_mode["full"][step],
+            rtol=0, atol=1e-4,
+            err_msg=f"step {step} must be unaffected by the sliding window")
+
+    # Once the context exceeds the window the sliding engine must diverge.
+    late_diffs = [
+        float(np.max(np.abs(
+            logits_by_mode["sliding"][step] - logits_by_mode["full"][step])))
+        for step in range(sliding_window, len(tokens))
+    ]
+    assert max(late_diffs) > 1e-3, (
+        "sliding_attention layers did not restrict attention to the window; "
+        f"per-step max diffs: {late_diffs}")


### PR DESCRIPTION
## Background

Fixes #399. GPT-OSS TRT engines produced garbage for prompts longer than 128 tokens (first TRT token already wrong on the 408-token MMLU five-shot prompt) while the short-prompt E2E smoke kept passing. Two engine-builder defects were isolated:

1. **YaRN silently skipped.** The Hub checkpoint's `config.json` stores the scaling dict under `rope_scaling`; `plugin.py`/`tp_builder.py` read only `rope_parameters`, so `rope_type` fell back to `default` and engines were built with unscaled RoPE tables and no attention factor.
2. **Sliding-window attention missing.** `layer_types` alternates `sliding_attention` (window 128) and `full_attention`, but every layer received the same full causal mask.

Root cause was confirmed differentially: injecting exactly these two defects into the HF reference reproduces the TRT garbage **token-for-token** (`[2167, 30, 4066, 2167, 4066, 30, 4066, 1008]`, first-generation-step logit cosine 0.9996); either defect alone does not match.

## Exit Criteria

- The GB300 fp16 engine built from this branch answers the previously-failing MMLU sample with a valid option letter matching HF.
- The short GPT-OSS CI prompt still generates coherent Harmony output.
- No change to the C++ runtime, model manifests, task-eval gates, or other families.

## Implementation

- `utils.py`: new `resolve_rope_parameters` (accepts `rope_parameters` or `rope_scaling`) and `make_rope_half_tables`, shared by both builders.
- `graph_ops.py`: `make_yarn_rope_table_half_dim` now matches transformers `_compute_yarn_parameters` exactly — honors the `truncate` flag (GPT-OSS ships `truncate: false`), applies `attention_factor` (default mscale `0.1*ln(factor)+1`), HF clamp/singularity semantics. New `add_sliding_window_mask` derives the window restriction in-graph from `position_id` (columns `c < position_id - (window-1)` get a large negative penalty on top of the runtime causal mask), so the C++ runtime and engine I/O contract are unchanged.
- `plugin.py` / `tp_builder.py`: build the sliding mask once and feed it to layers whose `layer_types` entry is `sliding_attention`; full-attention layers keep the original mask.

## Validation

- `pytest tests/e2e/models/gpt_oss/test_gpt_oss_rope_and_sliding.py` (GB300 container, TRT 11.0.0.114): 7 passed — includes a GPU property test that builds tiny sliding/full engine pairs and asserts they agree inside the window and diverge beyond it.
- `pytest tests/builder` (GB300 container): 645 passed, 8 skipped.
- Each `tests/e2e/models/gpt_oss/test_*.py` file: passed in its own process (see note below on a pre-existing combined-run issue).
- YaRN table cross-check vs transformers `GptOssRotaryEmbedding` (real snapshot config, 416 positions): max abs diff 2.4e-5.
- GB300 end-to-end rebuild + rerun of the failing sample (`mmlu_five_shot_mcq`, `--limit 1 --sample-seed 1234`, fresh fp16 bundle, cache 416): TRT now outputs `B` matching HF `B<|return|>` — `prediction_agreement_rate 1.0`, `trtfb_valid_prediction_rate 1.0` (previously 0.0/0.0 with garbage text).
- Short CI prompt ("capital of France", 23 tokens) through the fixed bundle: coherent Harmony analysis output ending in "The answer: Paris." — short-prompt behavior preserved.

## Notes For Future Readers

- Review order: `utils.py` → `graph_ops.py` → `plugin.py` → `tp_builder.py` → tests.
- Complementary to #396 (task-eval GPT-OSS prompt/scoring contract). #396 makes invalid TRT output measurable; this PR makes the engine produce valid output. No file overlap.
- The lenient GPT-OSS E2E thresholds (`logit_cosine_p5: 0.2` etc.) allowed both defects to pass CI; consider tightening them and adding a >128-token prompt case as a follow-up.
- Pre-existing, unrelated to this diff: running several `tests/e2e/models/gpt_oss/test_*.py` files in one pytest process fails on unmodified main because importing the `tp_builder`/`plugin` submodules rebinds the lazy `gpt_oss.plugin` package attribute from the plugin instance to the module; the new test file deliberately avoids importing the `plugin` submodule. Also pre-existing: importing `families.gpt_oss.utils` before the plugin module trips a circular import via the package `__getattr__`.
- The bundle-header GPU-name metadata bug (records physical GPU 0's name regardless of `CUDA_VISIBLE_DEVICES`) is out of scope and still open.
