### PR TITLE
fix(gpt2): reject prompt-prefixed continuations

### DIFF
--- a/tests/e2e/models/gpt2/e2e_plugins/contract.py
+++ b/tests/e2e/models/gpt2/e2e_plugins/contract.py
@@ -35,6 +35,13 @@ def strip_prompt_echo(text: str, prompt: str) -> str:
     return text
 
 
+def starts_with_prompt_echo(text: str, prompt: str) -> bool:
+    """Return whether generated text starts with the input prompt."""
+    norm_text = normalize_text(text)
+    norm_prompt = normalize_text(prompt)
+    return bool(norm_prompt and norm_text.startswith(norm_prompt))
+
+
 _CHAT_ROLE_PREFIXES = (
     "### response:", "### assistant:", "assistant:",
     "<|assistant|>", "<|im_start|>assistant\n",
@@ -176,6 +183,8 @@ class Gpt2CausalContinuationPlugin:
         config = contract_config(case)
         preserve_prompt_echo = bool(config.get("preserve_prompt_echo"))
         reconstruction_check = bool(config.get("seq2seq_reconstruction"))
+        prompt_echoed = starts_with_prompt_echo(trt_output.text or "", prompt)
+        prompt_excluded = preserve_prompt_echo or not prompt_echoed
         if preserve_prompt_echo:
             trt_text = normalize_text(trt_output.text or "")
             ref_text = normalize_text(ref_output.text or "")
@@ -206,6 +215,17 @@ class Gpt2CausalContinuationPlugin:
         prefix_match = (trt_text[:prefix_len] == ref_text[:prefix_len]) if prefix_len > 0 else True
 
         metrics = {
+            "prompt_excluded": MetricResult(
+                value=1.0 if prompt_excluded else 0.0,
+                threshold=1.0,
+                operator="==",
+                passed=prompt_excluded,
+                note=(
+                    "prompt echo explicitly allowed"
+                    if preserve_prompt_echo
+                    else "TRT output must not start with the input prompt"
+                ),
+            ),
             "ned": MetricResult(
                 value=ned,
                 threshold=ned_threshold,
@@ -236,19 +256,27 @@ class Gpt2CausalContinuationPlugin:
                 note="visible HF reconstruction text",
             )
 
-        passed = ned <= ned_threshold
+        passed = prompt_excluded and ned <= ned_threshold
         rule = (
             "seq2seq reconstruction parity against HF reference"
             if reconstruction_check
-            else "ned <= threshold (continuation parity)"
+            else (
+                "ned <= threshold (prompt echo explicitly allowed)"
+                if preserve_prompt_echo
+                else "prompt excluded AND ned <= threshold (continuation parity)"
+            )
         )
         if passed:
             return make_pass("full_generation", metrics, rule)
+        if not prompt_excluded:
+            message = "TRT continuation includes the input prompt"
+        else:
+            message = f"Continuation diverged: NED={ned:.3f}"
         return make_fail(
             "full_generation",
             metrics,
             rule,
-            f"Continuation diverged: NED={ned:.3f}",
+            message,
         )
 
 plugin = Gpt2CausalContinuationPlugin()

--- a/tests/e2e/models/gpt2/test_gpt2_continuation_contract.py
+++ b/tests/e2e/models/gpt2/test_gpt2_continuation_contract.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the GPT-2 continuation contract."""
+
+from __future__ import annotations
+
+from tests.e2e.models.gpt2.e2e_plugins.contract import Gpt2CausalContinuationPlugin
+from tests.e2e_harness.contracts import E2ECase, StageOutput, ThresholdProfile
+
+
+def _case(*, preserve_prompt_echo: bool = False) -> E2ECase:
+    metadata = {}
+    if preserve_prompt_echo:
+        metadata["contract_config"] = {"preserve_prompt_echo": True}
+    return E2ECase(
+        name="gpt2-continuation-contract",
+        hf_id="openai-community/gpt2",
+        family="gpt2",
+        runtime_strategy="gpt2_decoder_kv_cache",
+        reference_family="causal_base_continuation",
+        user_contract="continuation_parity",
+        inputs={"prompt": "The capital of France is"},
+        metadata=metadata,
+    )
+
+
+def _verify(trt_text: str, ref_text: str, *, preserve_prompt_echo: bool = False):
+    return Gpt2CausalContinuationPlugin().verify(
+        StageOutput(stage_name="full_generation", text=trt_text),
+        StageOutput(stage_name="full_generation", text=ref_text),
+        _case(preserve_prompt_echo=preserve_prompt_echo),
+        ThresholdProfile(
+            task_strategy="text_generation_causal",
+            metrics={"contract_ned_threshold": 0.25},
+        ),
+    )
+
+
+def test_rejects_prompt_prefixed_trt_continuation() -> None:
+    result = _verify("The capital of France is Paris.", "Paris.")
+
+    assert not result.passed
+    assert not result.metrics["prompt_excluded"].passed
+
+
+def test_accepts_clean_trt_continuation() -> None:
+    result = _verify("Paris.", "Paris.")
+
+    assert result.passed
+    assert result.metrics["prompt_excluded"].passed
+
+
+def test_allows_prompt_echo_when_explicitly_configured() -> None:
+    output = "The capital of France is Paris."
+    result = _verify(output, output, preserve_prompt_echo=True)
+
+    assert result.passed
+    assert result.metrics["prompt_excluded"].passed


### PR DESCRIPTION
## Background
RedTeam-CI-SELECT PR #398 returned the full GPT-2 token sequence, including the input prompt. CI selected and executed all intended GPT-2 cases, but the model-owned continuation contract stripped the echoed prompt before comparison and reported a pass. This is the escaped verdict gap tracked by #401.

## Exit Criteria
- Default GPT-2 continuation validation fails when TRT output starts with the input prompt.
- Clean continuation-only output remains accepted.
- Explicit `preserve_prompt_echo` contracts retain their existing behavior.

## Implementation
- Add a `prompt_excluded` metric to the GPT-2 continuation contract and include it in the composite verdict.
- Continue stripping the prompt only to calculate useful continuation-parity diagnostics; stripping no longer hides a product-contract failure.
- Add focused regression coverage for rejected prompt echo, clean continuation output, and the explicit opt-in behavior.

## Validation
- `pytest -q tests/e2e/models/gpt2/test_gpt2_continuation_contract.py`: failed before the fix because prompt-prefixed output was accepted; passed 3 tests after the fix.
- `pytest -q tests/e2e/models/gpt2/test_gpt2_continuation_contract.py tests/e2e/models/gpt2/test_gpt2_registry_contract.py`: passed 4 tests.
- `ruff check tests/e2e/models/gpt2/e2e_plugins/contract.py tests/e2e/models/gpt2/test_gpt2_continuation_contract.py`: passed.
- `python tools/legal_headers.py --check`: passed with no findings.
- `python tools/test_impact.py --validate`: passed; existing allowlist warnings remain.

## Notes For Future Readers
- `prefix_match` remains diagnostic rather than a hard gate; this fix gates the actual escaped condition without tightening accepted NED parity behavior.
- Keep #401 open after this PR merges. The issue is complete only after replaying the exact mutation from #398 against the merged fix and confirming CI now rejects it.

Related to #401
