### PR TITLE
test(ci): replay RedTeam-CI-SELECT GPT-2 probe

### DIFF
--- a/src/runtime/models/gpt2/pipeline.cpp
+++ b/src/runtime/models/gpt2/pipeline.cpp
@@ -356,9 +356,7 @@ TextResult Gpt2TextGenerationPipeline::generate(const std::string& prompt,
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
-    std::vector<int32_t> new_tokens(timed.token_ids.begin() +
-                                        static_cast<std::ptrdiff_t>(input_ids.size()),
-                                    timed.token_ids.end());
+    std::vector<int32_t> new_tokens(timed.token_ids.begin(), timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
     return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};


### PR DESCRIPTION
## Background
This disposable draft PR replays the exact RedTeam-CI-SELECT mutation from #398 after the prompt-exclusion fix in #402 merged to `main`. It validates the final detection step for #401.

**DO NOT MERGE.** This PR intentionally returns incorrect user-visible GPT-2 output.

## Exit Criteria
- CI selects and executes `distilgpt2` and `gpt2-125m` from this production runtime change.
- At least one required GPT-2 E2E contract fails because `prompt_excluded` is false.
- The artifact shows TRT output beginning with the input prompt while the HF reference remains continuation-only.

## Implementation
- Baseline: merged-fix `main` at `c4884b596b5a511c44ae1294f5a51c977bd1c5cc`.
- Mutation: decode the full `timed.token_ids` sequence instead of slicing away `input_ids` before decoding.
- Independence: no changes to the contract, thresholds, manifests, selector, or references.
- Exactness check: the mutated `pipeline.cpp` has SHA-256 `555cc4aa454d23b38fbf2a0a8c6770d43ceaa415d9fc8ec19d59f6da42217fbd`, identical to the file used in #398.

## Validation
- `cmp` against the #398 worktree file: identical.
- `clang-format --dry-run --Werror src/runtime/models/gpt2/pipeline.cpp`: passed.
- `python tools/legal_headers.py --check`: passed with no findings.
- `python tools/check_cyclomatic_complexity.py src --exclude src/cli --max-ccn 10 --top 20`: passed.
- `python tools/test_impact.py --files src/runtime/models/gpt2/pipeline.cpp --json`: selected the C++ tier plus `distilgpt2`, `gpt2-125m`, and `gpt2-125m-tp4`; the multi-device case remains excluded by current policy.

## Notes For Future Readers
- Expected CI outcome is failure at the GPT-2 continuation verdict. A green required E2E result means #401 remains unresolved.
- Close this PR without merging after collecting artifacts. Close #401 only if the replay is detected for the expected reason.

Related to #401
