### PR TITLE
fix(bundle): record active CUDA device

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "huggingface_hub>=0.23",
     "sentencepiece>=0.1.99",
     "tensorrt>=11.0.0.114,<11.1",
+    "cuda-python>=13.0.3,<14",
     "PyYAML>=6.0",
     "tomli>=2.0; python_version < '3.11'",
 ]

--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -43,6 +43,14 @@ from .parallel_config import (
     require_tensorrt_11_for_tensor_parallel,
 )
 
+try:
+    from cuda.bindings import runtime as cudart
+except ImportError:
+    try:
+        from cuda import cudart  # type: ignore[no-redef]
+    except ImportError:  # pragma: no cover - depends on build environment
+        cudart = None  # type: ignore[assignment]
+
 
 def _setup_trt_import(rtx: bool) -> None:
     """Select the TensorRT Python backend before any TRT API is touched."""
@@ -582,13 +590,24 @@ def _trt_abi_from_version(version: str) -> str:
 
 
 def _get_gpu_name() -> str:
+    if cudart is None:
+        return ""
     try:
-        import subprocess
-        result = subprocess.run(
-            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
-            capture_output=True, text=True, timeout=5)
-        if result.returncode == 0:
-            return result.stdout.strip().split("\n")[0]
+        success = (
+            cudart.cudaError_t.cudaSuccess
+            if hasattr(cudart, "cudaError_t")
+            else 0
+        )
+        status, device = cudart.cudaGetDevice()
+        if status != success:
+            return ""
+        status, properties = cudart.cudaGetDeviceProperties(device)
+        if status != success:
+            return ""
+        name = properties.name
+        if isinstance(name, bytes):
+            return name.decode("utf-8", errors="replace").rstrip("\x00")
+        return str(name).rstrip("\x00")
     except Exception:
         pass
     return ""

--- a/tests/builder/test_engine_builder_utils.py
+++ b/tests/builder/test_engine_builder_utils.py
@@ -18,6 +18,8 @@ import json
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import tensorrt_model_connect.engine_builder as engine_builder
@@ -253,6 +255,62 @@ class TestTrtAbiFromVersion:
 
 class TestGetGpuName:
     """Test _get_gpu_name helper."""
+
+    def test_returns_active_cuda_device_not_first_physical_gpu(self, monkeypatch):
+        """Records the CUDA build device on a heterogeneous GPU host."""
+        props = SimpleNamespace(name=b"NVIDIA GB300")
+        mock_cudart = SimpleNamespace(
+            cudaGetDevice=Mock(return_value=(0, 0)),
+            cudaGetDeviceProperties=Mock(return_value=(0, props)),
+        )
+        mock_smi = SimpleNamespace(
+            returncode=0,
+            stdout=(
+                "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition\n"
+                "NVIDIA GB300\n"
+            ),
+        )
+        monkeypatch.setattr(engine_builder, "cudart", mock_cudart, raising=False)
+        mock_smi_run = Mock(return_value=mock_smi)
+        monkeypatch.setattr("subprocess.run", mock_smi_run)
+
+        assert _get_gpu_name() == "NVIDIA GB300"
+        mock_cudart.cudaGetDeviceProperties.assert_called_once_with(0)
+        mock_smi_run.assert_not_called()
+
+    def test_uses_programmatically_selected_cuda_device(self, monkeypatch):
+        props = SimpleNamespace(name="NVIDIA B200\x00")
+        mock_cudart = SimpleNamespace(
+            cudaGetDevice=Mock(return_value=(0, 2)),
+            cudaGetDeviceProperties=Mock(return_value=(0, props)),
+        )
+        monkeypatch.setattr(engine_builder, "cudart", mock_cudart)
+
+        assert _get_gpu_name() == "NVIDIA B200"
+        mock_cudart.cudaGetDeviceProperties.assert_called_once_with(2)
+
+    def test_returns_empty_when_cuda_runtime_is_unavailable(self, monkeypatch):
+        monkeypatch.setattr(engine_builder, "cudart", None)
+        assert _get_gpu_name() == ""
+
+    def test_returns_empty_when_current_device_query_fails(self, monkeypatch):
+        mock_cudart = SimpleNamespace(
+            cudaGetDevice=Mock(return_value=(1, 0)),
+            cudaGetDeviceProperties=Mock(),
+        )
+        monkeypatch.setattr(engine_builder, "cudart", mock_cudart)
+
+        assert _get_gpu_name() == ""
+        mock_cudart.cudaGetDeviceProperties.assert_not_called()
+
+    def test_returns_empty_when_device_properties_query_fails(self, monkeypatch):
+        mock_cudart = SimpleNamespace(
+            cudaGetDevice=Mock(return_value=(0, 0)),
+            cudaGetDeviceProperties=Mock(return_value=(1, None)),
+        )
+        monkeypatch.setattr(engine_builder, "cudart", mock_cudart)
+
+        assert _get_gpu_name() == ""
 
     def test_returns_string(self):
         result = _get_gpu_name()


### PR DESCRIPTION
## Background

On heterogeneous multi-GPU hosts, bundle metadata recorded the first physical GPU returned by `nvidia-smi` rather than the active CUDA device that built the TensorRT engine. With an RTX PRO 6000 at physical index 0 and a GB300 selected through `CUDA_VISIBLE_DEVICES=1`, the bundle incorrectly reported the RTX GPU.

Closes #404.

## Exit Criteria

- Bundle GPU provenance reflects the current CUDA device, including visibility remapping and programmatic device selection.
- GPU metadata discovery remains non-fatal when CUDA is unavailable or a runtime query fails.
- Text and diffusion bundle builders continue to consume the same corrected metadata helper.

## Implementation

- Query the current device and its properties through the CUDA Runtime API instead of parsing the first `nvidia-smi` row.
- Support both current and legacy `cuda-python` import paths already used elsewhere in the repository.
- Declare `cuda-python>=13.0.3,<14` as a runtime dependency instead of relying on the development image to provide it.
- Decode both byte and string device names and preserve the existing empty-string fallback on discovery failures.
- Add regression coverage for heterogeneous devices, selected logical devices, unavailable CUDA, and CUDA query failures.

## Validation

- `python3 -m pytest tests/builder/test_engine_builder_utils.py tests/builder/test_bundle_writer.py -q`: 55 passed.
- `python3 -m ruff check python/tensorrt_model_connect/engine_builder.py tests/builder/test_engine_builder_utils.py`: passed.
- `python3 tools/legal_headers.py --check`: passed with zero findings.
- Parsed `pyproject.toml` and verified the CUDA bindings dependency declaration.
- Real A30 container query through the updated helper: returned `NVIDIA A30`.
- Full builder suite in the A30 container: 648 passed, 8 skipped, and 2 `add_causal_pad_1d` failures. The same two failures reproduce unchanged on `github/main` in the same container and are unrelated to this diff.
- PR branch helper on GB300 with `CUDA_VISIBLE_DEVICES=1`: returned `NVIDIA GB300`, while `nvidia-smi` still lists the physical RTX GPU first.

## Notes For Future Readers

- `gpu_name` remains informational metadata; this change does not alter TensorRT runtime device selection or engine contents.
- Existing bundles do not need rebuilding for execution correctness. Only newly generated metadata is corrected.
