### PR TITLE
test(ci): probe RedTeam-S2-SECTIONS PixArt VAE lookup

### DIFF
--- a/src/runtime/models/pixart/diffusion_helpers.cpp
+++ b/src/runtime/models/pixart/diffusion_helpers.cpp
@@ -151,7 +151,7 @@ DiffusionParts load_diffusion_parts(IBackend* backend, const BundleFile& bundle,
     parts.denoiser =
         load_trt_module_from_plan(backend, find_section(bundle, denoiser_section_name),
                                   denoiser_section_name.c_str(), effective_denoiser_options);
-    parts.vae = load_trt_module_from_plan(backend, find_section(bundle, "vae_decoder_plan"),
+    parts.vae = load_trt_module_from_plan(backend, find_section(bundle, "vae_decoder"),
                                           "vae_decoder_plan", options);
     parts.vision = try_load_trt_module_from_plan(
         backend, find_section(bundle, "vision_engine_plan"), "vision_engine_plan", options);


### PR DESCRIPTION
> **DO NOT MERGE - disposable CI red-team probe**

- Plan version: 3.1
- Campaign: 1
- Probe ID: RedTeam-S2-SECTIONS
- Assurance claim: `G-SEAM`
- Lifecycle seam: `S2 Sections`
- Invariant: PixArt Python emits `vae_decoder_plan` and the C++ runtime consumes that exact required section
- Baseline SHA: `c4884b596b5a511c44ae1294f5a51c977bd1c5cc`
- Expected detector: required `pixart-sigma-1024-l0` E2E during C++ pipeline creation
- Expected result: bundle build succeeds, then runtime fails with `Bundle missing vae_decoder_plan`

## Background
The baseline audit identifies Python bundle writing versus C++ bundle reading as a cross-language seam. Recent control run 28789582764 built the real PixArt L0 bundle in 116.4 seconds and passed both standard and isolated E2E.

## Exit Criteria
- Impact analysis selects the C++ tier and the PixArt L0 E2E.
- The real PixArt bundle still builds successfully.
- C++ runtime rejects the mismatched VAE section lookup before generation.
- The failure propagates through the required Premerge CI check.

## Implementation
- Change only the C++ consumer lookup from the producer-owned `vae_decoder_plan` name to nonexistent `vae_decoder`.
- Leave the Python producer, manifests, oracle, thresholds, expected outputs, and error label unchanged.
- ADR intentionally omitted: this is a disposable one-line fault injection and makes no architectural decision.

## Validation
- `clang-format --dry-run --Werror src/runtime/models/pixart/diffusion_helpers.cpp`: passed.
- `python tools/legal_headers.py --check`: passed with no findings.
- `python tools/check_cyclomatic_complexity.py src --exclude src/cli --max-ccn 10 --top 20`: passed.
- `python tools/test_impact.py --files src/runtime/models/pixart/diffusion_helpers.cpp --json`: selected `pixart-sigma-1024-l0`, `pixart-sigma-1024-tp4`, and the C++ tier through `cpp_runtime_model`.
- Targeted local compilation was not run because this clean worktree has no configured build directory; CI owns compilation and the real model build.

## Notes For Future Readers
- Current policy excludes the TP4 testcase, so the required single-device L0 case is the execution target.
- Draft PR #336 changes PixArt Python implementation but not this C++ consumer file; there is no file-level detector conflict.
- Close this PR without merging after collecting the result and artifacts.
