### PR TITLE
fix(ci): fingerprint runner Docker images

### DIFF
--- a/.github/scripts/ensure-ci-docker-image.sh
+++ b/.github/scripts/ensure-ci-docker-image.sh
@@ -4,8 +4,39 @@
 
 set -euo pipefail
 
-image="${TRTMC_CI_IMAGE:-trtmc-dev-gb300:manylinux_2_39}"
+base_image="${TRTMC_CI_IMAGE:-trtmc-dev-gb300:manylinux_2_39}"
 dockerfile="${TRTMC_CI_DOCKERFILE:-Dockerfile}"
+fingerprint_label="org.nvidia.trtmc.ci-input-fingerprint"
+
+docker_input_paths=(
+  "$dockerfile"
+  scripts/docker_build_gb300.sh
+  .github/scripts/start-gha-container.sh
+  .github/scripts/ensure-ci-docker-image.sh
+  .github/workflows/trtmc-ci.yml
+  .github/workflows/nightly.yml
+)
+
+compute_docker_input_fingerprint() {
+  local path
+  {
+    for path in "${docker_input_paths[@]}"; do
+      printf '%s\0' "$path"
+      if [ -f "$path" ]; then
+        sha256sum "$path" | awk '{ print $1 }'
+      else
+        printf 'missing\n'
+      fi
+    done
+  } | sha256sum | awk '{ print $1 }'
+}
+
+expected_fingerprint="$(compute_docker_input_fingerprint)"
+image="${base_image}-${expected_fingerprint:0:12}"
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+  printf 'TRTMC_CI_IMAGE=%s\n' "$image" >> "$GITHUB_ENV"
+fi
 
 read_docker_arg() {
   local name="$1"
@@ -42,11 +73,21 @@ python3 - <<'"'"'PY'"'"'
 import importlib.metadata as metadata
 
 import tensorrt
+from nemo.collections.asr.models.rnnt_bpe_models_prompt import (
+    EncDecRNNTBPEModelWithPrompt,
+)
 
 print(f"TENSORRT_VERSION={tensorrt.__version__}")
 print("MODELOPT_VERSION=" + metadata.version("nvidia-modelopt"))
+print("NEMO_PROMPT_RNNT=available")
 PY
 '
+}
+
+query_image_fingerprint() {
+  docker image inspect \
+    --format "{{ index .Config.Labels \"$fingerprint_label\" }}" \
+    "$image"
 }
 
 collect_docker_input_changes() {
@@ -55,20 +96,11 @@ collect_docker_input_changes() {
     return 0
   fi
 
-  git diff --name-only "$base"...HEAD -- \
-    Dockerfile \
-    scripts/docker_build_gb300.sh \
-    .github/scripts/start-gha-container.sh \
-    .github/scripts/ensure-ci-docker-image.sh \
-    .github/workflows/trtmc-ci.yml \
-    .github/workflows/nightly.yml
+  git diff --name-only "$base"...HEAD -- "${docker_input_paths[@]}"
 }
 
 rebuild_reasons=()
 mapfile -t changed_paths < <(collect_docker_input_changes)
-if [ "${#changed_paths[@]}" -gt 0 ]; then
-  rebuild_reasons+=("CI Docker image inputs changed")
-fi
 
 version_file="$(mktemp)"
 trap 'rm -f "$version_file"' EXIT
@@ -76,11 +108,16 @@ trap 'rm -f "$version_file"' EXIT
 if ! docker image inspect "$image" >/dev/null 2>&1; then
   rebuild_reasons+=("CI Docker image '$image' is missing")
 else
+  current_fingerprint="$(query_image_fingerprint 2>/dev/null || true)"
+  if [ "$current_fingerprint" != "$expected_fingerprint" ]; then
+    rebuild_reasons+=("Docker input fingerprint mismatch: image has '${current_fingerprint:-missing}', source expects '$expected_fingerprint'")
+  fi
   if ! query_image_versions > "$version_file"; then
     rebuild_reasons+=("CI Docker image '$image' could not report dependency versions")
   else
     current_trt="$(awk -F= '$1 == "TENSORRT_VERSION" { print $2 }' "$version_file")"
     current_modelopt="$(awk -F= '$1 == "MODELOPT_VERSION" { print $2 }' "$version_file")"
+    current_nemo_prompt_rnnt="$(awk -F= '$1 == "NEMO_PROMPT_RNNT" { print $2 }' "$version_file")"
 
     if [ "$current_trt" != "$expected_trt" ]; then
       rebuild_reasons+=("TensorRT version mismatch: image has '${current_trt:-unknown}', Dockerfile expects '$expected_trt'")
@@ -88,6 +125,10 @@ else
 
     if [ "$current_modelopt" != "$expected_modelopt" ]; then
       rebuild_reasons+=("modelopt version mismatch: image has '${current_modelopt:-unknown}', Dockerfile expects '$expected_modelopt'")
+    fi
+
+    if [ "$current_nemo_prompt_rnnt" != "available" ]; then
+      rebuild_reasons+=("required NeMo prompt RNN-T capability is missing")
     fi
   fi
 fi
@@ -110,6 +151,7 @@ if [ "${#rebuild_reasons[@]}" -gt 0 ]; then
   empty_context="${RUNNER_TEMP:-/tmp}/trtmc-empty-docker-context"
   mkdir -p "$empty_context"
   docker build \
+    --label "$fingerprint_label=$expected_fingerprint" \
     -t "$image" \
     -f "$dockerfile" \
     "$empty_context"
@@ -117,9 +159,16 @@ else
   echo "CI Docker image '$image' already matches $dockerfile"
 fi
 
+current_fingerprint="$(query_image_fingerprint 2>/dev/null || true)"
+if [ "$current_fingerprint" != "$expected_fingerprint" ]; then
+  echo "ERROR: CI Docker image '$image' has input fingerprint '${current_fingerprint:-missing}'; expected '$expected_fingerprint'" >&2
+  exit 1
+fi
+
 query_image_versions > "$version_file"
 current_trt="$(awk -F= '$1 == "TENSORRT_VERSION" { print $2 }' "$version_file")"
 current_modelopt="$(awk -F= '$1 == "MODELOPT_VERSION" { print $2 }' "$version_file")"
+current_nemo_prompt_rnnt="$(awk -F= '$1 == "NEMO_PROMPT_RNNT" { print $2 }' "$version_file")"
 
 if [ "$current_trt" != "$expected_trt" ]; then
   echo "ERROR: CI Docker image '$image' has TensorRT '$current_trt'; expected '$expected_trt' from $dockerfile" >&2
@@ -131,4 +180,9 @@ if [ "$current_modelopt" != "$expected_modelopt" ]; then
   exit 1
 fi
 
-echo "CI Docker image '$image' verified: TensorRT $current_trt, modelopt $current_modelopt"
+if [ "$current_nemo_prompt_rnnt" != "available" ]; then
+  echo "ERROR: CI Docker image '$image' is missing the required NeMo prompt RNN-T capability" >&2
+  exit 1
+fi
+
+echo "CI Docker image '$image' verified: TensorRT $current_trt, modelopt $current_modelopt, NeMo prompt RNN-T available"

--- a/tests/tools/test_ensure_ci_docker_image.py
+++ b/tests/tools/test_ensure_ci_docker_image.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for CI Docker image resolution and validation."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "ensure-ci-docker-image.sh"
+
+
+def _write_fake_docker(tmp_path: Path, existing_images: dict[str, str]) -> tuple[Path, Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    state_path = tmp_path / "images"
+    state_path.write_text(
+        "".join(f"{image}|{fingerprint}\n" for image, fingerprint in existing_images.items())
+    )
+    log_path = tmp_path / "docker.log"
+    docker_path = bin_dir / "docker"
+    docker_path.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%q ' "$@" >> "$FAKE_DOCKER_LOG"
+printf '\n' >> "$FAKE_DOCKER_LOG"
+
+if [ "${1:-}" = "image" ] && [ "${2:-}" = "inspect" ]; then
+  image="${!#}"
+  record="$(awk -F'|' -v image="$image" '$1 == image { print; exit }' "$FAKE_DOCKER_STATE")"
+  [ -n "$record" ] || exit 1
+  if [[ " $* " == *" --format "* ]]; then
+    printf '%s\n' "${record#*|}"
+  fi
+  exit 0
+fi
+
+if [ "${1:-}" = "run" ]; then
+  capability="${FAKE_DOCKER_CAPABILITY:-available}"
+  if [ -f "$FAKE_DOCKER_REBUILT" ]; then
+    capability="available"
+  fi
+  cat <<'EOF'
+TENSORRT_VERSION=11.0.0.114
+MODELOPT_VERSION=0.44.0
+EOF
+  printf 'NEMO_PROMPT_RNNT=%s\n' "$capability"
+  exit 0
+fi
+
+if [ "${1:-}" = "build" ]; then
+  shift
+  tag=""
+  label=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -t)
+        tag="$2"
+        shift 2
+        ;;
+      --label)
+        label="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  [ -n "$tag" ]
+  fingerprint="${label#*=}"
+  printf '%s|%s\n' "$tag" "$fingerprint" >> "$FAKE_DOCKER_STATE"
+  touch "$FAKE_DOCKER_REBUILT"
+  exit 0
+fi
+
+echo "unsupported fake docker invocation: $*" >&2
+exit 2
+"""
+    )
+    docker_path.chmod(0o755)
+    return bin_dir, log_path
+
+
+def _run_ensure_script(
+    tmp_path: Path,
+    *,
+    existing_images: dict[str, str],
+    capability: str = "available",
+    changed_paths: tuple[str, ...] = (),
+) -> tuple[subprocess.CompletedProcess[str], str, str]:
+    bin_dir, log_path = _write_fake_docker(tmp_path, existing_images)
+    if changed_paths:
+        git_path = bin_dir / "git"
+        git_path.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "cat-file" ]; then
+  exit 0
+fi
+if [ "${1:-}" = "diff" ]; then
+  printf '%s\n' "$FAKE_GIT_CHANGED_PATHS"
+  exit 0
+fi
+echo "unsupported fake git invocation: $*" >&2
+exit 2
+"""
+        )
+        git_path.chmod(0o755)
+    github_env = tmp_path / "github.env"
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "FAKE_DOCKER_LOG": str(log_path),
+            "FAKE_DOCKER_STATE": str(tmp_path / "images"),
+            "FAKE_DOCKER_CAPABILITY": capability,
+            "FAKE_DOCKER_REBUILT": str(tmp_path / "rebuilt"),
+            "GITHUB_ENV": str(github_env),
+            "RUNNER_TEMP": str(tmp_path / "runner-temp"),
+            "TRTMC_CI_IMAGE": "trtmc-dev-gb300:manylinux_2_39",
+            "CI_BASE_REF": "fake-base" if changed_paths else "",
+            "FAKE_GIT_CHANGED_PATHS": "\n".join(changed_paths),
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    github_env_text = github_env.read_text() if github_env.exists() else ""
+    return result, github_env_text, log_path.read_text()
+
+
+def test_missing_fingerprint_image_builds_and_exports_resolved_tag(tmp_path: Path) -> None:
+    base_image = "trtmc-dev-gb300:manylinux_2_39"
+
+    result, github_env, docker_log = _run_ensure_script(
+        tmp_path,
+        existing_images={base_image: "legacy-image-without-source-provenance"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    match = re.search(
+        rf"^TRTMC_CI_IMAGE=({re.escape(base_image)}-[0-9a-f]{{12}})$",
+        github_env,
+        re.MULTILINE,
+    )
+    assert match, github_env
+    resolved_image = match.group(1)
+    assert f"-t {resolved_image}" in docker_log
+
+
+def test_missing_required_capability_rebuilds_matching_image(tmp_path: Path) -> None:
+    bootstrap_result, bootstrap_env, bootstrap_log = _run_ensure_script(
+        tmp_path / "bootstrap",
+        existing_images={},
+    )
+    assert bootstrap_result.returncode == 0, bootstrap_result.stderr
+    resolved_image = re.search(
+        r"^TRTMC_CI_IMAGE=(.+)$", bootstrap_env, re.MULTILINE
+    ).group(1)
+    fingerprint = re.search(
+        r"--label org\.nvidia\.trtmc\.ci-input-fingerprint=([0-9a-f]{64})",
+        bootstrap_log,
+    ).group(1)
+
+    result, _, docker_log = _run_ensure_script(
+        tmp_path / "capability-missing",
+        existing_images={resolved_image: fingerprint},
+        capability="missing",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"-t {resolved_image}" in docker_log
+    assert "required NeMo prompt RNN-T capability is missing" in result.stdout
+
+
+def test_matching_fingerprint_image_is_reused_for_pr_rerun(tmp_path: Path) -> None:
+    bootstrap_result, bootstrap_env, bootstrap_log = _run_ensure_script(
+        tmp_path / "bootstrap",
+        existing_images={},
+    )
+    assert bootstrap_result.returncode == 0, bootstrap_result.stderr
+    resolved_image = re.search(
+        r"^TRTMC_CI_IMAGE=(.+)$", bootstrap_env, re.MULTILINE
+    ).group(1)
+    fingerprint = re.search(
+        r"--label org\.nvidia\.trtmc\.ci-input-fingerprint=([0-9a-f]{64})",
+        bootstrap_log,
+    ).group(1)
+
+    result, _, docker_log = _run_ensure_script(
+        tmp_path / "matching",
+        existing_images={resolved_image: fingerprint},
+        changed_paths=(".github/scripts/ensure-ci-docker-image.sh",),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "build " not in docker_log
+    assert f"CI Docker image '{resolved_image}' already matches" in result.stdout


### PR DESCRIPTION
## Background

PR #238 rebuilt the self-hosted runner image with a pinned NeMo main commit and passed the Nemotron 3.5 ASR reference. PR #405 later reused the same mutable image tag on the same runner, but the tag no longer contained the required prompt RNN-T module. The image gate accepted it because it compared only TensorRT and ModelOpt versions.

Closes #408.

## Exit Criteria

- Distinct CI Docker inputs resolve to distinct fingerprint-derived image tags.
- Reused images must match their full source fingerprint and required runtime capabilities.
- A missing, stale, or capability-incomplete image is rebuilt and revalidated.
- E2E oracle behavior and pass criteria remain unchanged.

## Implementation

- Compute a stable SHA-256 fingerprint from the Dockerfile and every script/workflow that defines the CI image contract.
- Derive the effective image tag from the base tag plus a short fingerprint, then export it through `GITHUB_ENV` for all subsequent workflow steps.
- Store the full fingerprint as an image label and verify it before and after reuse/build.
- Probe TensorRT, ModelOpt, and the NeMo prompt RNN-T import before accepting an image.
- Keep changed Docker input paths as diagnostic summary data, while allowing a matching immutable image to be reused on PR reruns.
- Add shell-interface integration tests with an isolated fake Docker CLI for build, reuse, and missing-capability behavior.

## Validation

- `python3 -m pytest tests/tools -q`: 1286 passed.
- `python3 -m pytest tests/tools/test_ensure_ci_docker_image.py tests/tools/test_github_actions_ci.py -q`: 47 passed.
- `python3 -m ruff check tests/tools/test_ensure_ci_docker_image.py`: passed.
- `bash -n .github/scripts/ensure-ci-docker-image.sh`: passed.
- `python3 tools/legal_headers.py --check`: passed with zero findings.
- `shellcheck` was not available in the local environment; CI lint remains the authoritative shell lint gate.

## Notes For Future Readers

- The first run for a new fingerprint intentionally rebuilds the image. Later runs with the same inputs reuse the fingerprint tag.
- This PR does not add image garbage collection. Retention should be handled separately once runner storage policy is defined.
- Review the image resolution script first, then the integration test harness and its three behavioral scenarios.
