### PR TITLE
fix(e2e): classify nonzero TRT process exits

### DIFF
--- a/tests/e2e_harness/orchestrator.py
+++ b/tests/e2e_harness/orchestrator.py
@@ -1536,6 +1536,19 @@ class E2EOrchestrator:
             state.sink.write_stage_output(stage.name, trt_output, prefix="trt")
             _log_stage_subprocess(state.sink, stage.name, trt_output, "trt")
             _auto_register_artifacts(state.sink, trt_output, "trt")
+            returncode = trt_output.data.get("returncode")
+            if isinstance(returncode, int) and returncode != 0:
+                stderr = trt_output.data.get("stderr")
+                detail = f"returncode={returncode}"
+                if stderr:
+                    detail = f"{detail}: {stderr}"
+                state.stage_results[stage.name] = CompareResult(
+                    stage_name=stage.name,
+                    status=StageStatus.ERROR.value,
+                    message=f"TRT run failed ({detail})",
+                )
+                self._mark_required_stage_failed(state, stage)
+                return None
             runtime_path_error = _validate_trt_runtime_path(state.case, state.ctx, trt_output)
             if runtime_path_error is not None:
                 state.stage_results[stage.name] = CompareResult(

--- a/tests/e2e_harness/test_orchestrator_phases.py
+++ b/tests/e2e_harness/test_orchestrator_phases.py
@@ -319,6 +319,40 @@ def test_run_classifies_trt_stage_error(
     assert data["stages"]["generate"]["status"] == StageStatus.ERROR.value
 
 
+def test_run_stops_after_trt_process_returns_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    case = _make_case("trt-nonzero-returncode")
+    ctx = _make_ctx(tmp_path, case)
+    _patch_bundle_success(monkeypatch, tmp_path)
+    reference = _FakeReference()
+    _patch_plugins(
+        monkeypatch,
+        runner=_FakeRunner(
+            outputs=[
+                StageOutput(
+                    stage_name="generate",
+                    data={"returncode": 1, "stderr": "runtime boom"},
+                    metadata={"command": ["trtmc", "run"]},
+                )
+            ]
+        ),
+        reference=reference,
+        comparator=_FakeComparator(),
+    )
+
+    result = E2EOrchestrator().run(case, ctx)
+
+    assert result.status == E2EStatus.FAIL.value
+    assert result.failure_type == FailureType.TRT_RUN_FAIL.value
+    assert result.stages["generate"].status == StageStatus.ERROR.value
+    assert "TRT run failed" in result.stages["generate"].message
+    assert "returncode=1" in result.stages["generate"].message
+    assert "runtime boom" in result.stages["generate"].message
+    assert reference.calls == 0
+
+
 def test_run_classifies_reference_stage_error(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Background

RedTeam-S2-SECTIONS probe #407 reached the intended PixArt runtime failure and emitted `Error: Bundle missing vae_decoder_plan`. The harness nevertheless ran the HF reference and reported `compare_fail` because diffusion runners return subprocess failures as structured `StageOutput` data instead of raising an exception.

Related to #409. Keep the issue open until the original probe is replayed against the merged fix.

## Exit Criteria

- A nonzero TRT subprocess return code produces `trt_run_fail` and an error stage.
- The result retains the return code and stderr evidence.
- Reference execution and comparison stop after the terminal TRT failure.
- Successful TRT execution followed by a semantic mismatch remains `compare_fail`.

## Implementation

- Inspect the diffusion runner's structured `returncode` immediately after recording TRT stage artifacts and command evidence.
- Convert a nonzero return code into the existing `TRT run failed` error path, preserving stderr in the stage message.
- Return before reference execution so process failures cannot be reclassified by a model contract.
- Add an orchestrator-level regression test that exercises the public `run` flow and verifies the reference is not called.

## Validation

- `python3 -m pytest -q tests/e2e_harness/test_orchestrator_phases.py::test_run_stops_after_trt_process_returns_nonzero`: failed before the fix because the result was `pass`; passed after the fix.
- `python3 -m pytest -q tests/e2e_harness/test_orchestrator_phases.py`: passed, 9 tests.
- `python3 -m pytest -q tests/e2e_harness`: passed, 11 tests.
- `git diff --check`: passed.

## Notes For Future Readers

- Diffusion runners place the subprocess return code and stderr in `StageOutput.data`; the command remains in `StageOutput.metadata` for artifact logging.
- Existing comparison-failure coverage confirms a successful TRT stage with a semantic mismatch still reports `compare_fail`.
- No ADR was added because this is a focused correction to existing failure semantics, not an architectural change.
- After merge, replay the exact #407 mutation and close #409 only when CI reports `trt_run_fail` without running the reference.
