### PR TITLE
fix(deepseek-ocr): restore full OCR parity

### DIFF
--- a/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr.json
+++ b/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr.json
@@ -5,7 +5,7 @@
   "family": "deepseek_ocr",
   "runtime_strategy": "deepseek_ocr_vision_language",
   "task_strategy": "vision_language_generation",
-  "precision": "fp16",
+  "precision": "fp32",
   "max_cache_length": 4096,
   "trust_remote_code": true,
   "testcases": [


### PR DESCRIPTION
## Background

PR #371 changed the canonical `deepseek-ocr` E2E bundle from FP32 to FP16. The first full nightly afterward produced 5 of 6 required OCR fragments; FP16 inserted a space in `Layer 0: Dense SwiGLU MLP`, while the unchanged contract requires the reference fragment `Layer 0:Dense SwiGLU MLP`.

The local FP16 reproduction generated the exact July 6 output (SHA-256 `99c49b8a268694f31679faa0597402447c562c288df01d0797f28b5c9b8bdb2d`). The July 7 Myelin context-creation failure is a separate systemic image/runtime event.

## Exit Criteria

- Restore all 6 required OCR fragments without changing the comparator or reference.
- Rebuild and run the full 300-token canonical model, including vision validation.
- Keep the change scoped to `deepseek-ocr`.

## Implementation

- Restore the canonical manifest to explicit FP32 precision.

## Validation

- Before: full local FP16 rebuild failed exactly as the July 6 nightly with `required_ocr_substrings = 5/6`.
- After: full local FP32 rebuild passed vision encoding and `required_ocr_substrings = 6/6`.
- The fixed exact E2E node passed in 423.43 seconds with fresh engine and timing-cache directories.
- Impact analysis selects only `tests/e2e/models/deepseek_ocr/test_deepseek_ocr_e2e.py::test_model_e2e[deepseek-ocr]` and reports `rebuild_cpp: false`.
- `git diff --check` and JSON parsing pass.

## Notes

No threshold, comparator, golden data, reference, or test-passing criterion is changed. The canonical test bundle is larger in FP32; this is the precision required by its current OCR contract.
