### PR TITLE
fix(mixtral): restore nightly continuation parity

### DIFF
--- a/tests/e2e/models/mixtral/manifests/mixtral-stories-15m.json
+++ b/tests/e2e/models/mixtral/manifests/mixtral-stories-15m.json
@@ -5,10 +5,7 @@
   "family": "mixtral",
   "runtime_strategy": "mixtral_decoder_moe",
   "task_strategy": "text_generation_causal",
-  "precision": "fp16",
-  "fp32_layers": [
-    5
-  ],
+  "precision": "fp32",
   "max_cache_length": 256,
   "trust_remote_code": false,
   "testcases": [


### PR DESCRIPTION
## Background

PR #371 changed the canonical `mixtral-stories-15m` E2E bundle from FP32 to mixed FP16 with decoder layer 5 retained in FP32. The July 6 and July 7 nightlies then produced the same divergent continuation at normalized edit distance 0.293478, above the unchanged 0.25 contract.

The failure is tactic-sensitive. A local TensorRT 11.0 / CUDA 13.0 GB300 run at builder optimization level 4 reproduced the nightly output byte-for-byte (SHA-256 `8e245370bfae047ad0e37f97d678f9aa9e09be5da0df3f137ba719c4c8de8ba7`).

## Exit Criteria

- Restore the canonical continuation contract without changing its threshold or comparator.
- Rebuild the bundle from scratch under the locally reproduced failing builder setting.
- Keep the change scoped to `mixtral-stories-15m`.

## Implementation

- Restore the canonical manifest to explicit FP32 precision.
- Remove the now-inapplicable layer-5 FP32 selector.

## Validation

- Before: exact E2E rebuild at optimization level 4 failed with NED `0.29347826086956524 > 0.25`; the generated artifact matched both failing nightlies byte-for-byte.
- After: the same E2E rebuild and optimization level passed with NED `0.0` and an exact reference continuation.
- Impact analysis selects only `tests/e2e/models/mixtral/test_mixtral_e2e.py::test_model_e2e[mixtral-stories-15m]` and reports `rebuild_cpp: false`.
- `git diff --check` and JSON parsing pass.

## Notes

No threshold, comparator, reference, or test-passing criterion is changed.
