### PR TITLE
fix(bark): restore large-model speech parity

### DIFF
--- a/tests/e2e/models/bark/manifests/bark-large.json
+++ b/tests/e2e/models/bark/manifests/bark-large.json
@@ -5,7 +5,7 @@
   "family": "bark",
   "runtime_strategy": "text_to_audio_bark",
   "task_strategy": "text_to_audio",
-  "precision": "fp16",
+  "precision": "fp32",
   "e2e_size": "large",
   "max_cache_length": 1024,
   "trust_remote_code": false,


### PR DESCRIPTION
## Background

PR #371 changed the canonical `bark-large` E2E bundle from implicit FP32 to explicit FP16. The first post-merge nightly happened to pass, but a fresh clean-image FP16 rebuild selected a different autoregressive path: 213 semantic / 640 coarse tokens instead of 237 / 712, and Whisper transcribed `This is a test of the text-to-speech system.` The resulting NED was `0.1764705882`, above the unchanged `0.15` contract.

The July 7 mutable-image failure was more severe because the optional codec context hit Myelin `kErrorNoFunction` and Bark fell back to a synthetic waveform. That systemic image issue is handled by #410. This PR addresses the independent FP16 speech-parity regression that remains after all contexts load successfully.

## Exit Criteria

- Restore the full Bark Large speech contract without changing its prompt, seed, ASR reference, comparator, or threshold.
- Rebuild the canonical bundle from scratch with nightly-default builder settings.
- Keep the change scoped to `bark-large`.

## Implementation

- Restore the canonical Bark Large manifest to explicit FP32 precision, matching its pre-#371 behavior.

## Validation

- Before: fresh full FP16 rebuild loaded every engine but failed with ASR NED `0.1764705882 > 0.15`.
- After A/B: fresh FP32 build restored the 237 / 712 token path and passed with NED `0.1372549020 <= 0.15`.
- After branch validation: a second independent manifest-driven FP32 rebuild passed the exact node in 411.66 seconds with the same NED, real TRT codec decode, and no Myelin/context signature.
- Impact analysis selects only `tests/e2e/models/bark/test_bark_e2e.py::test_model_e2e[bark-large]` and reports `rebuild_cpp: false`.
- JSON parsing, `git diff --check`, and `tools/legal_headers.py --check` pass.

## Notes

No threshold, comparator, prompt, seed, reference, or other test-passing criterion is changed. The FP32 bundle is 4,997,765,852 bytes versus 2,817,558,552 bytes for the reproduced FP16 bundle, an increase of about 2.03 GiB. A single FP16 optimization-level-1 experiment passed but generated a third token path, so it was not used as a durability fix.
