### PR TITLE
test(ci): replay RedTeam-S2-SECTIONS routing

### DIFF
--- a/src/runtime/models/pixart/diffusion_helpers.cpp
+++ b/src/runtime/models/pixart/diffusion_helpers.cpp
@@ -151,7 +151,7 @@ DiffusionParts load_diffusion_parts(IBackend* backend, const BundleFile& bundle,
     parts.denoiser =
         load_trt_module_from_plan(backend, find_section(bundle, denoiser_section_name),
                                   denoiser_section_name.c_str(), effective_denoiser_options);
-    parts.vae = load_trt_module_from_plan(backend, find_section(bundle, "vae_decoder_plan"),
+    parts.vae = load_trt_module_from_plan(backend, find_section(bundle, "vae_decoder"),
                                           "vae_decoder_plan", options);
     parts.vision = try_load_trt_module_from_plan(
         backend, find_section(bundle, "vision_engine_plan"), "vision_engine_plan", options);


### PR DESCRIPTION
> **DO NOT MERGE - disposable CI red-team replay**

## Background

PR #407 proved that CI reaches the intended PixArt missing-section failure, but the harness misclassified the nonzero TRT process exit as `compare_fail` and continued into the HF reference. PR #411 fixed that verdict routing and merged as `e1843398`.

This PR replays the exact #407 mutation against the merged fix. Related to #409; keep the issue open until this replay produces the expected evidence.

## Exit Criteria

- Impact analysis selects the C++ tier plus `pixart-sigma-1024-l0` and `pixart-sigma-1024-tp4`.
- The real PixArt L0 bundle builds successfully and still contains `vae_decoder_plan`.
- The mutated C++ runtime exits on the missing lookup with `Bundle missing vae_decoder_plan`.
- The required result is `trt_run_fail` with an error stage, not `compare_fail`.
- CI stops before running the HF reference or comparison.

## Implementation

- Change only the PixArt C++ VAE lookup from `vae_decoder_plan` to nonexistent `vae_decoder`.
- Leave the producer, error label, manifests, references, contracts, thresholds, and CI selection logic unchanged.
- The complete mutated source file is byte-identical to the source used by #407.

## Validation

- `cmp src/runtime/models/pixart/diffusion_helpers.cpp ../redteam-s2-sections-pixart-vae/src/runtime/models/pixart/diffusion_helpers.cpp`: passed; exact #407 source mutation reproduced.
- `clang-format --dry-run --Werror src/runtime/models/pixart/diffusion_helpers.cpp`: passed.
- `python3 tools/test_impact.py --files src/runtime/models/pixart/diffusion_helpers.cpp --json`: selected the C++ tier and both expected PixArt cases through `cpp_runtime_model`.
- `python3 tools/legal_headers.py --check`: passed with zero findings.
- `python3 tools/check_cyclomatic_complexity.py src --exclude src/cli --max-ccn 10 --top 20`: passed.

## Notes For Future Readers

- Current policy executes the required single-device L0 case and excludes the TP4 case.
- ADR intentionally omitted because this is a disposable one-line fault injection and makes no architectural decision.
- Close this PR without merging and delete its branch after collecting the CI artifacts.
- Close #409 only if the replay is classified as `trt_run_fail` and contains no reference execution.
