### PR TITLE
test(ci): probe RedTeam-S3-TENSOR output binding

### DIFF
--- a/src/runtime/models/timm_vit/pipeline.cpp
+++ b/src/runtime/models/timm_vit/pipeline.cpp
@@ -15,7 +15,7 @@ namespace {
 
 const Tensor* find_logits_output(const TensorMap& outputs) {
     for (const auto& [name, tensor] : outputs) {
-        if (name.find("logits") != std::string::npos || outputs.size() == 1)
+        if (name == "classification_logits")
             return &tensor;
     }
     return nullptr;


### PR DESCRIPTION
> **DO NOT MERGE - disposable CI red-team probe**

## Background

RedTeam-S3-TENSOR validates the build/runtime tensor-name seam. The TIMM ViT Python builder emits a real TensorRT plan whose only output is `logits`; the C++ image-classification pipeline must consume that output before returning top-1 classification data.

The active model-owned CI lane has no C++ or cross-language seam test that binds these two names. Its current detector is the required real-bundle TIMM ViT E2E.

## Exit Criteria

- Impact analysis selects the C++ tier plus default and TP4 TIMM ViT cases.
- The real single-device TIMM ViT bundle builds and runs through the C++ classification pipeline.
- The mutated consumer fails to select the producer-owned `logits` tensor.
- TRT reports `top_class=-1` and `num_classes=0`, while the reference produces a nonnegative top class.
- The required image-classification contract fails with `top1_match=0` and propagates through Premerge CI.

## Implementation

- Change only `ImageClassificationPipeline::find_logits_output` to accept nonexistent `classification_logits`.
- Leave the Python producer, plan output, manifest, image, reference, contract, thresholds, and CI selection unchanged.
- ADR intentionally omitted because this is a disposable one-site fault injection and makes no architectural decision.

## Validation

- Main Nightly run `28861271480`: the benign TIMM ViT control passed in 193.4 seconds with `top1_match=1`.
- `git diff ca746dae..011e7dea -- src/runtime/models/timm_vit python/tensorrt_model_connect/families/timm_vit tests/e2e/models/timm_vit`: no changes between the control and admitted baseline.
- `clang-format --dry-run --Werror src/runtime/models/timm_vit/pipeline.cpp`: passed.
- `python3 tools/test_impact.py --files src/runtime/models/timm_vit/pipeline.cpp --json`: selected the C++ tier and both expected TIMM ViT cases through `cpp_runtime_model`.
- `python3 tools/legal_headers.py --check`: passed with zero findings.
- `python3 tools/check_cyclomatic_complexity.py src --exclude src/cli --max-ccn 10 --top 20`: passed.
- `python3 -m pytest -q tests/e2e/models/timm_vit/test_timm_vit_family_plugin.py`: skipped because TensorRT is unavailable in the local environment; this is not counted as passing validation.

## Notes For Future Readers

- Current policy executes the required single-device default case and excludes TP4.
- The CLI deterministically serializes an empty classification result as `top_class=-1`, `top_score=0`, and `num_classes=0`; the contract requires exact top-1 agreement.
- Close this draft without merging and delete its branch after collecting CI evidence.
