### PR TITLE
test(ci): probe RedTeam-S6-QUANT scale corruption

### DIFF
--- a/python/tensorrt_model_connect/families/qwen/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen/plugin.py
@@ -85,6 +85,10 @@ class QwenPlugin:
         quant_ctx=None, verbose: bool = False, parallel_config=None,
         debug_layer_outputs: bool = False,
     ) -> bytes:
+        if quant_ctx is not None:
+            for scales in quant_ctx.profile.scale_map.scales.values():
+                scales.input_scale = 1.0e6
+                scales.weight_scale = 1.0e6
         parallel = normalize_parallel_config(parallel_config)
         if parallel.enabled:
             if debug_layer_outputs:


### PR DESCRIPTION
DO NOT MERGE — disposable RedTeam-S6-QUANT probe.

## Background

This probe checks whether required CI rejects a Qwen FP8 bundle whose calibrated quantization scales are corrupted before TensorRT graph construction. The same detector passed `qwen3-0.6b-fp8` on main Nightly run `28861271480`.

## Exit Criteria

- Impact analysis selects the Qwen family, including the single-device FP8 case.
- The real Qwen FP8 bundle reaches build and inference with corrupted Q/DQ scales.
- The existing text-generation numerical contract rejects the output and makes Premerge CI red.
- This PR is closed without merge after evidence is recorded.

## Implementation

- For Qwen builds with a quantization context, replace every calibrated input and weight scale with `1.0e6` immediately before engine construction.
- Non-quantized Qwen cases are unchanged because they have no quantization context.

## Validation

- `git diff --check`: passed.
- `python3 tools/test_impact.py --files python/tensorrt_model_connect/families/qwen/plugin.py --json`: selected all Qwen manifests; single-device defaults are executable and TP variants remain policy-excluded.
- `python3 -m pytest -q -m 'not gpu' tests/e2e/models/qwen/test_qwen_builder_engine.py tests/e2e/models/qwen/test_qwen_manifest_contract.py`: 17 passed, 3 GPU tests deselected.
- Full targeted pytest without deselection: 17 passed and 3 failed because the local host could not initialize CUDA (`error: 100`); CI is the required GPU execution environment.
- `python3 -m py_compile python/tensorrt_model_connect/families/qwen/plugin.py`: passed.

## Notes For Future Readers

- Expected first failing gate: `qwen3-0.6b-fp8` numerical comparison (`compare_fail`) after successful real-bundle build and inference.
- ADR intentionally omitted: this is a one-site disposable mutation with no architectural decision.
- Close without merge and delete the probe branch after classification.
