### PR TITLE
fix(e2e): add Nemotron 3.5 ASR contract

### DIFF
--- a/tests/e2e/models/nemotron_speech_streaming/manifests/nemotron-3.5-asr-streaming-0.6b.json
+++ b/tests/e2e/models/nemotron_speech_streaming/manifests/nemotron-3.5-asr-streaming-0.6b.json
@@ -5,6 +5,7 @@
   "family": "nemotron_speech_streaming",
   "runtime_strategy": "nemotron_speech_streaming_speech_to_text_rnnt",
   "task_strategy": "speech_to_text",
+  "user_contract": "automatic-speech-recognition",
   "precision": "fp16",
   "max_cache_length": 128,
   "trust_remote_code": false,

--- a/tests/e2e/models/nemotron_speech_streaming/test_nemotron_speech_streaming_manifest_contract.py
+++ b/tests/e2e/models/nemotron_speech_streaming/test_nemotron_speech_streaming_manifest_contract.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Nemotron Speech Streaming-owned manifest contract tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.e2e_harness.manifest_loader import load_manifest
+
+
+def test_nemotron_35_asr_manifest_declares_hf_asr_contract() -> None:
+    manifest_path = (
+        Path(__file__).with_name("manifests")
+        / "nemotron-3.5-asr-streaming-0.6b.json"
+    )
+    case = load_manifest(manifest_path)
+
+    assert case.hf_id == "nvidia/nemotron-3.5-asr-streaming-0.6b"
+    assert case.task_strategy == "speech_to_text"
+    assert case.user_contract == "automatic-speech-recognition"


### PR DESCRIPTION
## Background

The `nvidia/nemotron-3.5-asr-streaming-0.6b` manifest was added after the previous user-contract coverage audit and had no declared contract. Its canonical Hugging Face metadata and Transformers Quick Start both explicitly use the `automatic-speech-recognition` pipeline.

## Exit Criteria

- The Nemotron 3.5 streaming ASR manifest declares the literal Hugging Face Quick Start contract.
- Model-owned regression coverage prevents the contract from being omitted or replaced with a locally inferred name.

## Implementation

- Added `user_contract: automatic-speech-recognition` at model scope so every testcase inherits it.
- Added a focused manifest contract test that locks the HF repository, TRTMC task strategy, and user contract together.

## Validation

- `PYTHONPATH=python:. python3 -m pytest -q tests/e2e/models/nemotron_speech_streaming/test_nemotron_speech_streaming_manifest_contract.py`: 1 passed locally and 1 passed on NVIDIA DRIVE P2021.
- `PYTHONPATH=python:tools:. python3 -m pytest -q -rs tests/e2e/models/nemotron_speech_streaming --ignore=tests/e2e/models/nemotron_speech_streaming/test_nemotron_speech_streaming_e2e.py`: 6 passed / 3 skipped locally because Torch was unavailable; 9 passed on P2021 with Torch 2.12 and CUDA available.
- `PYTHONPATH=python:. python3 -m pytest -q tests/builder/test_manifest_validation.py`: 33 passed locally and 33 passed on P2021.
- `python3 tools/legal_headers.py --check`: passed locally and on P2021.
- `python3 tools/test_impact.py --validate`: passed locally for 198 models, 12 core models, and 77 families; existing warnings remain.
- Ruff and `git diff --check`: passed locally.

## Notes For Future Readers

- The contract intentionally follows the canonical HF literal `automatic-speech-recognition`, rather than the older internal `exact_transcript` label used by legacy ASR manifests.
- Full model E2E was not rebuilt because this change only adds manifest metadata and does not change the engine, runner, reference, comparator, or runtime.
- `amd-quark/tiny-random-qwen3_moe` remains out of scope because its canonical HF repository has no model card, Quick Start, or pipeline tag from which to source a contract.
