### PR TITLE
perf(canary): accelerate audio preprocessing

### DIFF
--- a/src/runtime/models/canary/canary_config.h
+++ b/src/runtime/models/canary/canary_config.h
@@ -25,6 +25,7 @@ struct CanaryConfig {
     int32_t notimestamps_token_id{50363};
     int32_t eot_token_id{50257}; // <|endoftext|>
     std::string language{"en"};
+    bool disable_cuda_graph{false};
 
     int32_t mel_length{0}; // expected mel input length; 0 = auto (max_source_positions * 2)
 

--- a/src/runtime/models/canary/canary_mel_spectrogram.cpp
+++ b/src/runtime/models/canary/canary_mel_spectrogram.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <complex>
 #include <cstring>
 #include <vector>
 
@@ -40,6 +41,63 @@ void rfft_power_direct(const float* x, int32_t n, int32_t n_out, float* power_ou
     }
 }
 
+bool is_power_of_two(int32_t value) {
+    return value > 0 && (value & (value - 1)) == 0;
+}
+
+void rfft_power_radix2(const float* x, int32_t n, int32_t n_out, float* power_out,
+                       std::vector<std::complex<double>>& workspace) {
+    workspace.resize(static_cast<std::size_t>(n));
+    for (int32_t i = 0; i < n; ++i) {
+        workspace[static_cast<std::size_t>(i)] =
+            std::complex<double>(static_cast<double>(x[i]), 0.0);
+    }
+
+    for (int32_t i = 1, j = 0; i < n; ++i) {
+        int32_t bit = n >> 1;
+        for (; j & bit; bit >>= 1) {
+            j ^= bit;
+        }
+        j ^= bit;
+        if (i < j) {
+            std::swap(workspace[static_cast<std::size_t>(i)],
+                      workspace[static_cast<std::size_t>(j)]);
+        }
+    }
+
+    const double pi2 = 2.0 * 3.14159265358979323846;
+    for (int32_t length = 2; length <= n; length <<= 1) {
+        const double angle = -pi2 / static_cast<double>(length);
+        const std::complex<double> step(std::cos(angle), std::sin(angle));
+        const int32_t half = length / 2;
+        for (int32_t offset = 0; offset < n; offset += length) {
+            std::complex<double> twiddle(1.0, 0.0);
+            for (int32_t i = 0; i < half; ++i) {
+                const auto even = workspace[static_cast<std::size_t>(offset + i)];
+                const auto odd = workspace[static_cast<std::size_t>(offset + i + half)] * twiddle;
+                workspace[static_cast<std::size_t>(offset + i)] = even + odd;
+                workspace[static_cast<std::size_t>(offset + i + half)] = even - odd;
+                twiddle *= step;
+            }
+        }
+    }
+
+    const int32_t bins = std::min(n_out, n / 2 + 1);
+    for (int32_t k = 0; k < bins; ++k) {
+        power_out[k] = static_cast<float>(std::norm(workspace[static_cast<std::size_t>(k)]));
+    }
+    std::fill(power_out + bins, power_out + n_out, 0.0F);
+}
+
+void rfft_power_impl(const float* x, int32_t n, int32_t n_out, float* power_out,
+                     std::vector<std::complex<double>>& workspace) {
+    if (is_power_of_two(n)) {
+        rfft_power_radix2(x, n, n_out, power_out, workspace);
+        return;
+    }
+    rfft_power_direct(x, n, n_out, power_out);
+}
+
 std::vector<float> build_center_padded_audio(const float* samples, int32_t n_samples,
                                              int32_t chunk_length_s, int32_t sample_rate,
                                              int32_t n_fft) {
@@ -57,46 +115,45 @@ std::vector<float> build_center_padded_audio(const float* samples, int32_t n_sam
     return padded;
 }
 
-std::vector<float> compute_power_spectrogram(const std::vector<float>& padded,
-                                             const std::vector<float>& window, int32_t n_fft,
-                                             int32_t hop_length, int32_t n_freq_bins,
-                                             int32_t& n_frames_raw) {
+std::vector<float> compute_mel_spectrogram(const std::vector<float>& padded,
+                                           const std::vector<float>& window,
+                                           const float* mel_filters, int32_t n_fft,
+                                           int32_t hop_length, int32_t n_freq_bins,
+                                           int32_t n_mel_bins, int32_t frames_to_compute,
+                                           int32_t& n_frames_raw) {
     n_frames_raw = 1 + (static_cast<int32_t>(padded.size()) - n_fft) / hop_length;
-    std::vector<float> power(static_cast<std::size_t>(n_freq_bins) * n_frames_raw, 0.0F);
+    std::vector<float> mel_spec(static_cast<std::size_t>(n_mel_bins) * n_frames_raw, 0.0F);
     std::vector<float> windowed(n_fft);
     std::vector<float> frame_power(n_freq_bins);
+    std::vector<float> frame_mel(n_mel_bins);
+    std::vector<std::complex<double>> fft_workspace;
 
-    for (int32_t t = 0; t < n_frames_raw; ++t) {
+    const int32_t computed_frames = std::clamp(frames_to_compute, 0, n_frames_raw);
+    for (int32_t t = 0; t < computed_frames; ++t) {
         const int32_t start = t * hop_length;
         for (int32_t i = 0; i < n_fft; ++i) {
             windowed[static_cast<std::size_t>(i)] =
                 padded[static_cast<std::size_t>(start + i)] * window[static_cast<std::size_t>(i)];
         }
 
-        rfft_power_direct(windowed.data(), n_fft, n_freq_bins, frame_power.data());
+        rfft_power_impl(windowed.data(), n_fft, n_freq_bins, frame_power.data(), fft_workspace);
 
+        std::fill(frame_mel.begin(), frame_mel.end(), 0.0F);
         for (int32_t f = 0; f < n_freq_bins; ++f) {
-            power[static_cast<std::size_t>(f) * n_frames_raw + t] = frame_power[f];
-        }
-    }
-    return power;
-}
-
-std::vector<float> project_power_to_mel(const std::vector<float>& power, const float* mel_filters,
-                                        int32_t n_freq_bins, int32_t n_mel_bins,
-                                        int32_t n_frames_raw) {
-    std::vector<float> mel_spec(static_cast<std::size_t>(n_mel_bins) * n_frames_raw, 0.0F);
-
-    for (int32_t t = 0; t < n_frames_raw; ++t) {
-        for (int32_t f = 0; f < n_freq_bins; ++f) {
-            const float p = power[static_cast<std::size_t>(f) * n_frames_raw + t];
+            const float p = frame_power[static_cast<std::size_t>(f)];
             if (p == 0.0F) {
                 continue;
             }
+            const float* filter_row =
+                mel_filters + static_cast<std::size_t>(f) * n_mel_bins;
             for (int32_t m = 0; m < n_mel_bins; ++m) {
-                mel_spec[static_cast<std::size_t>(m) * n_frames_raw + t] +=
-                    p * mel_filters[static_cast<std::size_t>(f) * n_mel_bins + m];
+                frame_mel[static_cast<std::size_t>(m)] +=
+                    p * filter_row[static_cast<std::size_t>(m)];
             }
+        }
+        for (int32_t m = 0; m < n_mel_bins; ++m) {
+            mel_spec[static_cast<std::size_t>(m) * n_frames_raw + t] =
+                frame_mel[static_cast<std::size_t>(m)];
         }
     }
     return mel_spec;
@@ -137,19 +194,43 @@ std::vector<float> trim_last_frame(std::vector<float> mel_spec, int32_t n_mel_bi
 
 } // namespace
 
+namespace detail {
+
+std::vector<float> rfft_power(const std::vector<float>& input) {
+    const int32_t n = static_cast<int32_t>(input.size());
+    const int32_t n_out = n / 2 + 1;
+    std::vector<float> power(static_cast<std::size_t>(n_out), 0.0F);
+    std::vector<std::complex<double>> workspace;
+    if (n > 0) {
+        rfft_power_impl(input.data(), n, n_out, power.data(), workspace);
+    }
+    return power;
+}
+
+} // namespace detail
+
 MelResult extract_mel_spectrogram(const float* samples, int32_t n_samples, const float* mel_filters,
                                   int32_t n_freq_bins, int32_t n_mel_bins, int32_t n_fft,
                                   int32_t hop_length, int32_t chunk_length_s, int32_t sample_rate) {
     const int32_t expected_freq_bins = n_fft / 2 + 1;
     const int32_t freq_bins = n_freq_bins == expected_freq_bins ? n_freq_bins : expected_freq_bins;
+    const int32_t chunk_samples = chunk_length_s * sample_rate;
+    const int32_t valid_audio = std::min(std::max(n_samples, 0), chunk_samples);
+    const int32_t pad_size = n_fft / 2;
+
+    // The encoder still receives the full chunk-shaped mel tensor, but only
+    // frames whose windows can overlap real audio need an FFT and mel
+    // projection. The untouched tail remains zero-power and is normalized to
+    // the same floor value as the previous full padded computation.
+    const int32_t frames_to_compute =
+        valid_audio > 0 ? 1 + (pad_size + valid_audio - 1) / hop_length : 0;
     const std::vector<float> padded =
         build_center_padded_audio(samples, n_samples, chunk_length_s, sample_rate, n_fft);
 
     int32_t n_frames_raw = 0;
-    const std::vector<float> power = compute_power_spectrogram(
-        padded, make_hann_window(n_fft), n_fft, hop_length, freq_bins, n_frames_raw);
-    std::vector<float> mel_spec =
-        project_power_to_mel(power, mel_filters, freq_bins, n_mel_bins, n_frames_raw);
+    std::vector<float> mel_spec = compute_mel_spectrogram(
+        padded, make_hann_window(n_fft), mel_filters, n_fft, hop_length, freq_bins, n_mel_bins,
+        frames_to_compute, n_frames_raw);
     normalize_log_mel_inplace(mel_spec);
 
     int32_t n_frames_out = 0;
@@ -159,8 +240,6 @@ MelResult extract_mel_spectrogram(const float* samples, int32_t n_samples, const
     // padded to chunk_length_s before framing, so n_frames_out is always the
     // full chunk length; valid_frames lets the encoder mask out the padded
     // tail. Mirrors the chunk framing math (out = audio_samples / hop_length).
-    const int32_t chunk_samples = chunk_length_s * sample_rate;
-    const int32_t valid_audio = std::min(std::max(n_samples, 0), chunk_samples);
     const int32_t valid_frames = std::min(n_frames_out, valid_audio / hop_length);
 
     MelResult result;

--- a/src/runtime/models/canary/canary_mel_spectrogram.cpp
+++ b/src/runtime/models/canary/canary_mel_spectrogram.cpp
@@ -144,8 +144,7 @@ std::vector<float> compute_mel_spectrogram(const std::vector<float>& padded,
             if (p == 0.0F) {
                 continue;
             }
-            const float* filter_row =
-                mel_filters + static_cast<std::size_t>(f) * n_mel_bins;
+            const float* filter_row = mel_filters + static_cast<std::size_t>(f) * n_mel_bins;
             for (int32_t m = 0; m < n_mel_bins; ++m) {
                 frame_mel[static_cast<std::size_t>(m)] +=
                     p * filter_row[static_cast<std::size_t>(m)];
@@ -228,9 +227,9 @@ MelResult extract_mel_spectrogram(const float* samples, int32_t n_samples, const
         build_center_padded_audio(samples, n_samples, chunk_length_s, sample_rate, n_fft);
 
     int32_t n_frames_raw = 0;
-    std::vector<float> mel_spec = compute_mel_spectrogram(
-        padded, make_hann_window(n_fft), mel_filters, n_fft, hop_length, freq_bins, n_mel_bins,
-        frames_to_compute, n_frames_raw);
+    std::vector<float> mel_spec =
+        compute_mel_spectrogram(padded, make_hann_window(n_fft), mel_filters, n_fft, hop_length,
+                                freq_bins, n_mel_bins, frames_to_compute, n_frames_raw);
     normalize_log_mel_inplace(mel_spec);
 
     int32_t n_frames_out = 0;

--- a/src/runtime/models/canary/canary_mel_spectrogram.h
+++ b/src/runtime/models/canary/canary_mel_spectrogram.h
@@ -11,6 +11,14 @@
 namespace trtmc {
 namespace canary {
 
+namespace detail {
+
+// Internal seam used by the focused frontend tests. Production callers should
+// use extract_mel_spectrogram().
+std::vector<float> rfft_power(const std::vector<float>& input);
+
+} // namespace detail
+
 struct MelResult {
     std::vector<float> data; // [n_mels, n_frames] row-major
     int32_t n_mels{0};

--- a/src/runtime/models/canary/pipeline.cpp
+++ b/src/runtime/models/canary/pipeline.cpp
@@ -15,12 +15,30 @@
 #include "trtmc/tokenizer.h"
 #include "utils/wav_reader.h"
 
+#include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 #include <vector>
 
 namespace trtmc {
+
+namespace {
+
+using CanaryClock = std::chrono::steady_clock;
+
+bool canary_stage_timing_enabled() {
+    const char* value = std::getenv("TRTMC_CANARY_STAGE_TIMING");
+    return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
+}
+
+double elapsed_ms(CanaryClock::time_point start, CanaryClock::time_point end) {
+    return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+} // namespace
 
 // ═══════════════════════════════════════════════════════════════════════════
 // CanaryPipeline
@@ -73,6 +91,9 @@ CanaryPipeline::~CanaryPipeline() {
 
 TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_samples,
                                       int32_t max_new_tokens, int32_t input_sample_rate) {
+    const bool report_stage_timing = canary_stage_timing_enabled();
+    const auto transcribe_start = CanaryClock::now();
+
     // Step 0: Resample if needed
     const float* samples_ptr = audio_data;
     int32_t samples_count = num_samples;
@@ -86,6 +107,7 @@ TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_sampl
         samples_ptr = resampled_buf.data();
         samples_count = static_cast<int32_t>(resampled_buf.size());
     }
+    const auto resample_end = CanaryClock::now();
 
     // Step 1: Extract mel spectrogram
     canary::MelResult mel;
@@ -95,6 +117,7 @@ TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_sampl
                                             mel_fb_->n_freq_bins, mel_fb_->n_mel_bins, mel_n_fft_,
                                             mel_hop_length_, mel_chunk_length_, mel_sampling_rate_);
     }
+    const auto mel_end = CanaryClock::now();
 
     if (mel.data.empty()) {
         return TextResult{"[mel extraction failed]", {}};
@@ -106,6 +129,7 @@ TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_sampl
     const int32_t valid_mel_frames = mel.valid_frames > 0 ? mel.valid_frames : mel.n_frames;
     std::cerr << "[canary] Running encoder ..." << std::endl;
     run_encoder(mel.data.data(), mel.n_mels, mel.n_frames, valid_mel_frames);
+    const auto encoder_end = CanaryClock::now();
 
     // Compute actual encoder sequence length for masking
     const int32_t mel_full = resolve_canary_expected_mel_length(canary_config_);
@@ -119,17 +143,33 @@ TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_sampl
     // Step 3: Set up cross-attention K/V
     std::cerr << "[canary] Computing cross-attention K/V ..." << std::endl;
     setup_cross_attention(actual_enc_seq_len);
+    const auto cross_kv_end = CanaryClock::now();
 
     // Step 4: Run decoder
     std::vector<int32_t> initial_tokens = make_canary_initial_decoder_tokens(canary_config_);
     std::cerr << "[canary] Running decoder ..." << std::endl;
     auto output_ids = run_decoder(initial_tokens, max_new_tokens);
+    const auto decoder_end = CanaryClock::now();
 
     // Step 5: Decode token IDs
     TextResult out;
     out.token_ids = std::move(output_ids);
     if (tokenizer_ && !out.token_ids.empty()) {
         out.text = tokenizer_->decode(out.token_ids);
+    }
+    const auto tokenize_end = CanaryClock::now();
+
+    if (report_stage_timing) {
+        std::ostringstream timing;
+        timing << "[trtmc.canary_timing.json] {\"resample_ms\":"
+               << elapsed_ms(transcribe_start, resample_end) << ",\"mel_ms\":"
+               << elapsed_ms(resample_end, mel_end) << ",\"encoder_ms\":"
+               << elapsed_ms(mel_end, encoder_end) << ",\"cross_kv_ms\":"
+               << elapsed_ms(encoder_end, cross_kv_end) << ",\"decoder_ms\":"
+               << elapsed_ms(cross_kv_end, decoder_end) << ",\"tokenizer_ms\":"
+               << elapsed_ms(decoder_end, tokenize_end) << ",\"total_ms\":"
+               << elapsed_ms(transcribe_start, tokenize_end) << '}';
+        std::cerr << timing.str() << std::endl;
     }
     return out;
 }

--- a/src/runtime/models/canary/pipeline.cpp
+++ b/src/runtime/models/canary/pipeline.cpp
@@ -38,6 +38,32 @@ double elapsed_ms(CanaryClock::time_point start, CanaryClock::time_point end) {
     return std::chrono::duration<double, std::milli>(end - start).count();
 }
 
+struct CanaryStageTimestamps {
+    CanaryClock::time_point transcribe_start;
+    CanaryClock::time_point resample_end;
+    CanaryClock::time_point mel_end;
+    CanaryClock::time_point encoder_end;
+    CanaryClock::time_point cross_kv_end;
+    CanaryClock::time_point decoder_end;
+    CanaryClock::time_point tokenize_end;
+};
+
+void report_canary_stage_timing(bool enabled, const CanaryStageTimestamps& timestamps) {
+    if (!enabled)
+        return;
+    std::ostringstream timing;
+    timing << "[trtmc.canary_timing.json] {\"resample_ms\":"
+           << elapsed_ms(timestamps.transcribe_start, timestamps.resample_end)
+           << ",\"mel_ms\":" << elapsed_ms(timestamps.resample_end, timestamps.mel_end)
+           << ",\"encoder_ms\":" << elapsed_ms(timestamps.mel_end, timestamps.encoder_end)
+           << ",\"cross_kv_ms\":" << elapsed_ms(timestamps.encoder_end, timestamps.cross_kv_end)
+           << ",\"decoder_ms\":" << elapsed_ms(timestamps.cross_kv_end, timestamps.decoder_end)
+           << ",\"tokenizer_ms\":" << elapsed_ms(timestamps.decoder_end, timestamps.tokenize_end)
+           << ",\"total_ms\":" << elapsed_ms(timestamps.transcribe_start, timestamps.tokenize_end)
+           << '}';
+    std::cerr << timing.str() << std::endl;
+}
+
 } // namespace
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -165,18 +191,9 @@ TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_sampl
     }
     const auto tokenize_end = CanaryClock::now();
 
-    if (report_stage_timing) {
-        std::ostringstream timing;
-        timing << "[trtmc.canary_timing.json] {\"resample_ms\":"
-               << elapsed_ms(transcribe_start, resample_end)
-               << ",\"mel_ms\":" << elapsed_ms(resample_end, mel_end)
-               << ",\"encoder_ms\":" << elapsed_ms(mel_end, encoder_end)
-               << ",\"cross_kv_ms\":" << elapsed_ms(encoder_end, cross_kv_end)
-               << ",\"decoder_ms\":" << elapsed_ms(cross_kv_end, decoder_end)
-               << ",\"tokenizer_ms\":" << elapsed_ms(decoder_end, tokenize_end)
-               << ",\"total_ms\":" << elapsed_ms(transcribe_start, tokenize_end) << '}';
-        std::cerr << timing.str() << std::endl;
-    }
+    report_canary_stage_timing(report_stage_timing,
+                               {transcribe_start, resample_end, mel_end, encoder_end, cross_kv_end,
+                                decoder_end, tokenize_end});
     return out;
 }
 

--- a/src/runtime/models/canary/pipeline.cpp
+++ b/src/runtime/models/canary/pipeline.cpp
@@ -66,6 +66,12 @@ CanaryPipeline::CanaryPipeline(std::unique_ptr<TrtModule> encoder,
     if (!state_ || !state_->ok())
         throw std::runtime_error("CanaryPipeline: invalid inference state");
 
+    // Decoder shapes are stable within each dynamic cache-row bucket. Capture
+    // the TensorRT enqueue on the first step and replay it until a shape change
+    // invalidates the graph and triggers a recapture.
+    if (!canary_config_.disable_cuda_graph)
+        decoder_->enable_cuda_graph();
+
     // Allocate cross-attention K/V device buffers
     cross_kv_bytes_ = static_cast<std::size_t>(canary_config_.max_source_positions) *
                       static_cast<std::size_t>(hidden_size_) * sizeof(float);
@@ -162,13 +168,13 @@ TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_sampl
     if (report_stage_timing) {
         std::ostringstream timing;
         timing << "[trtmc.canary_timing.json] {\"resample_ms\":"
-               << elapsed_ms(transcribe_start, resample_end) << ",\"mel_ms\":"
-               << elapsed_ms(resample_end, mel_end) << ",\"encoder_ms\":"
-               << elapsed_ms(mel_end, encoder_end) << ",\"cross_kv_ms\":"
-               << elapsed_ms(encoder_end, cross_kv_end) << ",\"decoder_ms\":"
-               << elapsed_ms(cross_kv_end, decoder_end) << ",\"tokenizer_ms\":"
-               << elapsed_ms(decoder_end, tokenize_end) << ",\"total_ms\":"
-               << elapsed_ms(transcribe_start, tokenize_end) << '}';
+               << elapsed_ms(transcribe_start, resample_end)
+               << ",\"mel_ms\":" << elapsed_ms(resample_end, mel_end)
+               << ",\"encoder_ms\":" << elapsed_ms(mel_end, encoder_end)
+               << ",\"cross_kv_ms\":" << elapsed_ms(encoder_end, cross_kv_end)
+               << ",\"decoder_ms\":" << elapsed_ms(cross_kv_end, decoder_end)
+               << ",\"tokenizer_ms\":" << elapsed_ms(decoder_end, tokenize_end)
+               << ",\"total_ms\":" << elapsed_ms(transcribe_start, tokenize_end) << '}';
         std::cerr << timing.str() << std::endl;
     }
     return out;

--- a/src/runtime/models/canary/plugin.cpp
+++ b/src/runtime/models/canary/plugin.cpp
@@ -13,6 +13,7 @@
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
 
+#include <exception>
 #include <limits>
 #include <string>
 #include <vector>
@@ -50,6 +51,17 @@ int32_t dim_at(const std::vector<int64_t>& shape, int32_t dim) {
 int32_t decoder_cache_row_width(const TrtModule& module, const BaseConfig& config) {
     const int32_t from_engine = dim_at(module.tensor_shape("cache_k_0"), 1);
     return from_engine > 0 ? from_engine : compute_kv_dim(config);
+}
+
+bool canary_cuda_graph_disabled(const PipelineContext& ctx) {
+    if (ctx.runtime_config == nullptr)
+        return false;
+    try {
+        return ctx.runtime_config->get<bool>("runtime", "disable_cuda_graph");
+    } catch (const std::exception&) {
+        // Schema not registered — retain the default graph policy.
+        return false;
+    }
 }
 
 } // namespace
@@ -100,14 +112,7 @@ class CanaryPlugin final : public IPipelinePlugin {
         wc.eot_token_id = (eot_token_id >= 0) ? eot_token_id : ctx.config.id_eos;
         wc.mel_length = extract_json_int(json, "mel_length", 0);
         wc.decoder_start_token_ids = extract_json_int_array(json, "decoder_start_token_ids");
-        if (ctx.runtime_config != nullptr) {
-            try {
-                wc.disable_cuda_graph =
-                    ctx.runtime_config->get<bool>("runtime", "disable_cuda_graph");
-            } catch (const std::exception&) {
-                // Schema not registered — retain the default graph policy.
-            }
-        }
+        wc.disable_cuda_graph = canary_cuda_graph_disabled(ctx);
 
         // Create CanaryKvCache for decoder self-attention
         cudaStream_t stream = dec_loaded.module->stream();

--- a/src/runtime/models/canary/plugin.cpp
+++ b/src/runtime/models/canary/plugin.cpp
@@ -8,6 +8,7 @@
 
 #include "plugin_helpers.h"
 #include "runtime/models/canary/pipeline.h"
+#include "trtmc/config/config_bundle.h"
 #include "trtmc/runtime/distributed_runtime.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
@@ -99,6 +100,14 @@ class CanaryPlugin final : public IPipelinePlugin {
         wc.eot_token_id = (eot_token_id >= 0) ? eot_token_id : ctx.config.id_eos;
         wc.mel_length = extract_json_int(json, "mel_length", 0);
         wc.decoder_start_token_ids = extract_json_int_array(json, "decoder_start_token_ids");
+        if (ctx.runtime_config != nullptr) {
+            try {
+                wc.disable_cuda_graph =
+                    ctx.runtime_config->get<bool>("runtime", "disable_cuda_graph");
+            } catch (const std::exception&) {
+                // Schema not registered — retain the default graph policy.
+            }
+        }
 
         // Create CanaryKvCache for decoder self-attention
         cudaStream_t stream = dec_loaded.module->stream();

--- a/src/utils/wav_reader.cpp
+++ b/src/utils/wav_reader.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <fstream>
 #include <iterator>
+#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -249,6 +250,72 @@ float resample_at_position(const float* samples, int32_t n_samples, double src_p
     return 0.0F;
 }
 
+struct PolyphaseSincWeights
+{
+    int32_t rate_gcd{1};
+    int32_t phase_count{1};
+    int32_t half_taps{16};
+    std::vector<double> weights;
+};
+
+PolyphaseSincWeights build_polyphase_sinc_weights(
+    int32_t source_rate, int32_t target_rate, double cutoff, int32_t half_taps)
+{
+    PolyphaseSincWeights table;
+    table.rate_gcd = std::gcd(source_rate, target_rate);
+    table.phase_count = target_rate / table.rate_gcd;
+    table.half_taps = half_taps;
+    const int32_t tap_count = 2 * half_taps;
+    table.weights.resize(static_cast<std::size_t>(table.phase_count) * tap_count);
+
+    for (int32_t phase = 0; phase < table.phase_count; ++phase)
+    {
+        const double fraction = static_cast<double>(phase * table.rate_gcd) /
+            static_cast<double>(target_rate);
+        for (int32_t tap = 0; tap < tap_count; ++tap)
+        {
+            const int32_t offset = tap - half_taps + 1;
+            const double distance = static_cast<double>(offset) - fraction;
+            table.weights[static_cast<std::size_t>(phase) * tap_count + tap] =
+                scaled_sinc(distance, cutoff) * hann_window(distance, half_taps);
+        }
+    }
+    return table;
+}
+
+std::vector<float> resample_polyphase(
+    const float* samples, int32_t n_samples, int32_t source_rate, int32_t target_rate,
+    int32_t out_len, double cutoff, int32_t half_taps)
+{
+    const PolyphaseSincWeights table =
+        build_polyphase_sinc_weights(source_rate, target_rate, cutoff, half_taps);
+    const int32_t tap_count = 2 * half_taps;
+    std::vector<float> resampled(out_len);
+
+    for (int32_t i = 0; i < out_len; ++i)
+    {
+        const int64_t position_numerator = static_cast<int64_t>(i) * source_rate;
+        const int32_t center = static_cast<int32_t>(position_numerator / target_rate);
+        const int32_t remainder = static_cast<int32_t>(position_numerator % target_rate);
+        const int32_t phase = remainder / table.rate_gcd;
+        const double* phase_weights =
+            table.weights.data() + static_cast<std::size_t>(phase) * tap_count;
+
+        const int32_t first_offset = std::max(-half_taps + 1, -center);
+        const int32_t last_offset = std::min(half_taps, n_samples - 1 - center);
+        double acc = 0.0;
+        double weight_sum = 0.0;
+        for (int32_t offset = first_offset; offset <= last_offset; ++offset)
+        {
+            const double weight = phase_weights[offset + half_taps - 1];
+            acc += static_cast<double>(samples[center + offset]) * weight;
+            weight_sum += weight;
+        }
+        resampled[i] = weight_sum > 1e-12 ? static_cast<float>(acc / weight_sum) : 0.0F;
+    }
+    return resampled;
+}
+
 } // namespace
 
 WavData read_wav(const std::string& path)
@@ -282,6 +349,18 @@ std::vector<float> resample_linear(
     const int32_t half_taps = 16;
     const double cutoff = std::min(1.0, static_cast<double>(target_rate) /
                                         static_cast<double>(source_rate));
+
+    // Source positions repeat across target_rate / gcd(source_rate,
+    // target_rate) fractional phases. Precompute the windowed-sinc weights for
+    // those phases instead of evaluating sin/cos for every output sample and
+    // tap. Fall back for unusual rate pairs that would require a large table.
+    constexpr int32_t kMaxPrecomputedPhases = 2048;
+    const int32_t phase_count = target_rate / std::gcd(source_rate, target_rate);
+    if (phase_count <= kMaxPrecomputedPhases)
+    {
+        return resample_polyphase(
+            samples, n_samples, source_rate, target_rate, out_len, cutoff, half_taps);
+    }
 
     for (int32_t i = 0; i < out_len; ++i)
     {

--- a/src/utils/wav_reader.cpp
+++ b/src/utils/wav_reader.cpp
@@ -18,8 +18,7 @@
 namespace trtmc {
 namespace {
 
-struct ParsedWav
-{
+struct ParsedWav {
     uint16_t fmt_tag{0};
     uint16_t channels{0};
     uint32_t sample_rate{0};
@@ -30,49 +29,39 @@ struct ParsedWav
     bool have_data{false};
 };
 
-std::vector<char> read_wav_bytes(const std::string& path)
-{
+std::vector<char> read_wav_bytes(const std::string& path) {
     std::ifstream infile(path, std::ios::binary);
-    if (!infile)
-    {
+    if (!infile) {
         throw std::runtime_error("Failed to open WAV file: " + path);
     }
 
-    return std::vector<char>(
-        (std::istreambuf_iterator<char>(infile)),
-        std::istreambuf_iterator<char>());
+    return std::vector<char>((std::istreambuf_iterator<char>(infile)),
+                             std::istreambuf_iterator<char>());
 }
 
-void validate_wav_container(const std::vector<char>& wav_bytes, const std::string& path)
-{
-    if (wav_bytes.size() < 44)
-    {
+void validate_wav_container(const std::vector<char>& wav_bytes, const std::string& path) {
+    if (wav_bytes.size() < 44) {
         throw std::runtime_error("WAV file too small: " + path);
     }
 
     if (std::memcmp(wav_bytes.data(), "RIFF", 4) != 0 ||
-        std::memcmp(wav_bytes.data() + 8, "WAVE", 4) != 0)
-    {
+        std::memcmp(wav_bytes.data() + 8, "WAVE", 4) != 0) {
         throw std::runtime_error("Invalid WAV container: " + path);
     }
 }
 
-uint32_t read_chunk_size(const char* chunk_header)
-{
+uint32_t read_chunk_size(const char* chunk_header) {
     uint32_t chunk_size = 0;
     std::memcpy(&chunk_size, chunk_header + 4, sizeof(uint32_t));
     return chunk_size;
 }
 
-bool chunk_fits_buffer(std::size_t pos, uint32_t chunk_size, std::size_t total_size)
-{
+bool chunk_fits_buffer(std::size_t pos, uint32_t chunk_size, std::size_t total_size) {
     return pos + 8 + static_cast<std::size_t>(chunk_size) <= total_size;
 }
 
-void parse_fmt_chunk(const char* chunk_data, uint32_t chunk_size, ParsedWav& parsed)
-{
-    if (chunk_size < 16)
-    {
+void parse_fmt_chunk(const char* chunk_data, uint32_t chunk_size, ParsedWav& parsed) {
+    if (chunk_size < 16) {
         throw std::runtime_error("WAV fmt chunk too small");
     }
 
@@ -83,184 +72,153 @@ void parse_fmt_chunk(const char* chunk_data, uint32_t chunk_size, ParsedWav& par
     parsed.have_fmt = true;
 }
 
-void parse_data_chunk(const char* chunk_data, uint32_t chunk_size, ParsedWav& parsed)
-{
+void parse_data_chunk(const char* chunk_data, uint32_t chunk_size, ParsedWav& parsed) {
     parsed.raw_ptr = chunk_data;
     parsed.raw_size = static_cast<std::size_t>(chunk_size);
     parsed.have_data = true;
 }
 
-void parse_chunks(const std::vector<char>& wav_bytes, ParsedWav& parsed)
-{
+void parse_chunks(const std::vector<char>& wav_bytes, ParsedWav& parsed) {
     std::size_t pos = 12;
-    while (pos + 8 <= wav_bytes.size())
-    {
+    while (pos + 8 <= wav_bytes.size()) {
         const char* chunk = wav_bytes.data() + pos;
         const char* chunk_data = chunk + 8;
         const uint32_t chunk_size = read_chunk_size(chunk);
-        if (!chunk_fits_buffer(pos, chunk_size, wav_bytes.size()))
-        {
+        if (!chunk_fits_buffer(pos, chunk_size, wav_bytes.size())) {
             break;
         }
 
-        if (std::memcmp(chunk, "fmt ", 4) == 0)
-        {
+        if (std::memcmp(chunk, "fmt ", 4) == 0) {
             parse_fmt_chunk(chunk_data, chunk_size, parsed);
-        }
-        else if (std::memcmp(chunk, "data", 4) == 0)
-        {
+        } else if (std::memcmp(chunk, "data", 4) == 0) {
             parse_data_chunk(chunk_data, chunk_size, parsed);
         }
 
         pos += 8 + static_cast<std::size_t>(chunk_size);
-        if ((chunk_size & 1U) != 0)
-        {
-            ++pos;  // RIFF chunks are word-aligned
+        if ((chunk_size & 1U) != 0) {
+            ++pos; // RIFF chunks are word-aligned
         }
     }
 }
 
-void validate_required_chunks(const ParsedWav& parsed, const std::string& path)
-{
-    if (!parsed.have_fmt || !parsed.have_data || parsed.raw_ptr == nullptr || parsed.raw_size == 0)
-    {
+void validate_required_chunks(const ParsedWav& parsed, const std::string& path) {
+    if (!parsed.have_fmt || !parsed.have_data || parsed.raw_ptr == nullptr ||
+        parsed.raw_size == 0) {
         throw std::runtime_error("WAV missing fmt/data chunk: " + path);
     }
 }
 
-std::vector<float> decode_float32_samples(const ParsedWav& parsed)
-{
+std::vector<float> decode_float32_samples(const ParsedWav& parsed) {
     const auto ns = static_cast<int32_t>(parsed.raw_size / sizeof(float));
     std::vector<float> samples(ns);
     std::memcpy(samples.data(), parsed.raw_ptr, static_cast<std::size_t>(ns) * sizeof(float));
     return samples;
 }
 
-std::vector<float> decode_pcm16_samples(const ParsedWav& parsed)
-{
+std::vector<float> decode_pcm16_samples(const ParsedWav& parsed) {
     const auto ns = static_cast<int32_t>(parsed.raw_size / sizeof(int16_t));
     std::vector<float> samples(ns);
-    for (int32_t i = 0; i < ns; ++i)
-    {
+    for (int32_t i = 0; i < ns; ++i) {
         int16_t pcm = 0;
-        std::memcpy(&pcm, parsed.raw_ptr + static_cast<std::size_t>(i) * sizeof(int16_t), sizeof(int16_t));
+        std::memcpy(&pcm, parsed.raw_ptr + static_cast<std::size_t>(i) * sizeof(int16_t),
+                    sizeof(int16_t));
         samples[i] = static_cast<float>(pcm) / 32768.0F;
     }
     return samples;
 }
 
-std::vector<float> decode_samples(const ParsedWav& parsed)
-{
-    if (parsed.fmt_tag == 3 && parsed.bits_per_sample == 32)
-    {
+std::vector<float> decode_samples(const ParsedWav& parsed) {
+    if (parsed.fmt_tag == 3 && parsed.bits_per_sample == 32) {
         return decode_float32_samples(parsed);
     }
 
-    if (parsed.fmt_tag == 1 && parsed.bits_per_sample == 16)
-    {
+    if (parsed.fmt_tag == 1 && parsed.bits_per_sample == 16) {
         return decode_pcm16_samples(parsed);
     }
 
-    throw std::runtime_error(
-        "Unsupported WAV format: tag=" + std::to_string(parsed.fmt_tag) +
-        " bits=" + std::to_string(parsed.bits_per_sample));
+    throw std::runtime_error("Unsupported WAV format: tag=" + std::to_string(parsed.fmt_tag) +
+                             " bits=" + std::to_string(parsed.bits_per_sample));
 }
 
-std::vector<float> stereo_to_mono(const std::vector<float>& samples)
-{
+std::vector<float> stereo_to_mono(const std::vector<float>& samples) {
     const auto mono_len = static_cast<int32_t>(samples.size()) / 2;
     std::vector<float> mono(mono_len);
-    for (int32_t i = 0; i < mono_len; ++i)
-    {
+    for (int32_t i = 0; i < mono_len; ++i) {
         mono[i] = (samples[2 * i] + samples[2 * i + 1]) * 0.5F;
     }
     return mono;
 }
 
-std::vector<float> first_channel_to_mono(const std::vector<float>& samples, uint16_t channels)
-{
+std::vector<float> first_channel_to_mono(const std::vector<float>& samples, uint16_t channels) {
     const auto mono_len = static_cast<int32_t>(samples.size()) / channels;
     std::vector<float> mono(mono_len);
-    for (int32_t i = 0; i < mono_len; ++i)
-    {
+    for (int32_t i = 0; i < mono_len; ++i) {
         mono[i] = samples[static_cast<std::size_t>(i) * channels];
     }
     return mono;
 }
 
-std::vector<float> convert_to_mono(std::vector<float> samples, uint16_t channels)
-{
-    if (channels == 2)
-    {
+std::vector<float> convert_to_mono(std::vector<float> samples, uint16_t channels) {
+    if (channels == 2) {
         return stereo_to_mono(samples);
     }
 
-    if (channels > 2)
-    {
+    if (channels > 2) {
         return first_channel_to_mono(samples, channels);
     }
 
     return samples;
 }
 
-int32_t compute_output_length(int32_t n_samples, int32_t source_rate, int32_t target_rate)
-{
-    return static_cast<int32_t>(
-        static_cast<int64_t>(n_samples) * target_rate / source_rate);
+int32_t compute_output_length(int32_t n_samples, int32_t source_rate, int32_t target_rate) {
+    return static_cast<int32_t>(static_cast<int64_t>(n_samples) * target_rate / source_rate);
 }
 
-double scaled_sinc(double distance, double cutoff)
-{
+double scaled_sinc(double distance, double cutoff) {
     constexpr double kPi = 3.14159265358979323846;
-    if (std::abs(distance) < 1e-12)
-    {
+    if (std::abs(distance) < 1e-12) {
         return cutoff;
     }
     return cutoff * std::sin(kPi * distance * cutoff) / (kPi * distance * cutoff);
 }
 
-double hann_window(double distance, int32_t half_taps)
-{
+double hann_window(double distance, int32_t half_taps) {
     constexpr double kPi = 3.14159265358979323846;
-    const double win_pos = (distance + static_cast<double>(half_taps)) /
-        (2.0 * static_cast<double>(half_taps));
+    const double win_pos =
+        (distance + static_cast<double>(half_taps)) / (2.0 * static_cast<double>(half_taps));
     return 0.5 * (1.0 - std::cos(2.0 * kPi * win_pos));
 }
 
-float resample_at_position(const float* samples, int32_t n_samples, double src_pos, double cutoff, int32_t half_taps)
-{
+float resample_at_position(const float* samples, int32_t n_samples, double src_pos, double cutoff,
+                           int32_t half_taps) {
     const auto center = static_cast<int32_t>(std::floor(src_pos));
     const int32_t lo = std::max(0, center - half_taps + 1);
     const int32_t hi = std::min(n_samples - 1, center + half_taps);
 
     double acc = 0.0;
     double weight_sum = 0.0;
-    for (int32_t j = lo; j <= hi; ++j)
-    {
+    for (int32_t j = lo; j <= hi; ++j) {
         const double distance = static_cast<double>(j) - src_pos;
         const double weight = scaled_sinc(distance, cutoff) * hann_window(distance, half_taps);
         acc += static_cast<double>(samples[j]) * weight;
         weight_sum += weight;
     }
 
-    if (weight_sum > 1e-12)
-    {
+    if (weight_sum > 1e-12) {
         return static_cast<float>(acc / weight_sum);
     }
     return 0.0F;
 }
 
-struct PolyphaseSincWeights
-{
+struct PolyphaseSincWeights {
     int32_t rate_gcd{1};
     int32_t phase_count{1};
     int32_t half_taps{16};
     std::vector<double> weights;
 };
 
-PolyphaseSincWeights build_polyphase_sinc_weights(
-    int32_t source_rate, int32_t target_rate, double cutoff, int32_t half_taps)
-{
+PolyphaseSincWeights build_polyphase_sinc_weights(int32_t source_rate, int32_t target_rate,
+                                                  double cutoff, int32_t half_taps) {
     PolyphaseSincWeights table;
     table.rate_gcd = std::gcd(source_rate, target_rate);
     table.phase_count = target_rate / table.rate_gcd;
@@ -268,12 +226,10 @@ PolyphaseSincWeights build_polyphase_sinc_weights(
     const int32_t tap_count = 2 * half_taps;
     table.weights.resize(static_cast<std::size_t>(table.phase_count) * tap_count);
 
-    for (int32_t phase = 0; phase < table.phase_count; ++phase)
-    {
-        const double fraction = static_cast<double>(phase * table.rate_gcd) /
-            static_cast<double>(target_rate);
-        for (int32_t tap = 0; tap < tap_count; ++tap)
-        {
+    for (int32_t phase = 0; phase < table.phase_count; ++phase) {
+        const double fraction =
+            static_cast<double>(phase * table.rate_gcd) / static_cast<double>(target_rate);
+        for (int32_t tap = 0; tap < tap_count; ++tap) {
             const int32_t offset = tap - half_taps + 1;
             const double distance = static_cast<double>(offset) - fraction;
             table.weights[static_cast<std::size_t>(phase) * tap_count + tap] =
@@ -283,17 +239,15 @@ PolyphaseSincWeights build_polyphase_sinc_weights(
     return table;
 }
 
-std::vector<float> resample_polyphase(
-    const float* samples, int32_t n_samples, int32_t source_rate, int32_t target_rate,
-    int32_t out_len, double cutoff, int32_t half_taps)
-{
+std::vector<float> resample_polyphase(const float* samples, int32_t n_samples, int32_t source_rate,
+                                      int32_t target_rate, int32_t out_len, double cutoff,
+                                      int32_t half_taps) {
     const PolyphaseSincWeights table =
         build_polyphase_sinc_weights(source_rate, target_rate, cutoff, half_taps);
     const int32_t tap_count = 2 * half_taps;
     std::vector<float> resampled(out_len);
 
-    for (int32_t i = 0; i < out_len; ++i)
-    {
+    for (int32_t i = 0; i < out_len; ++i) {
         const int64_t position_numerator = static_cast<int64_t>(i) * source_rate;
         const int32_t center = static_cast<int32_t>(position_numerator / target_rate);
         const int32_t remainder = static_cast<int32_t>(position_numerator % target_rate);
@@ -305,8 +259,7 @@ std::vector<float> resample_polyphase(
         const int32_t last_offset = std::min(half_taps, n_samples - 1 - center);
         double acc = 0.0;
         double weight_sum = 0.0;
-        for (int32_t offset = first_offset; offset <= last_offset; ++offset)
-        {
+        for (int32_t offset = first_offset; offset <= last_offset; ++offset) {
             const double weight = phase_weights[offset + half_taps - 1];
             acc += static_cast<double>(samples[center + offset]) * weight;
             weight_sum += weight;
@@ -318,8 +271,7 @@ std::vector<float> resample_polyphase(
 
 } // namespace
 
-WavData read_wav(const std::string& path)
-{
+WavData read_wav(const std::string& path) {
     const std::vector<char> wav_bytes = read_wav_bytes(path);
     validate_wav_container(wav_bytes, path);
 
@@ -336,10 +288,8 @@ WavData read_wav(const std::string& path)
     return result;
 }
 
-std::vector<float> resample_linear(
-    const float* samples, int32_t n_samples,
-    int32_t source_rate, int32_t target_rate)
-{
+std::vector<float> resample_linear(const float* samples, int32_t n_samples, int32_t source_rate,
+                                   int32_t target_rate) {
     if (source_rate == target_rate || n_samples <= 0)
         return std::vector<float>(samples, samples + n_samples);
 
@@ -347,8 +297,8 @@ std::vector<float> resample_linear(
     std::vector<float> resampled(out_len);
 
     const int32_t half_taps = 16;
-    const double cutoff = std::min(1.0, static_cast<double>(target_rate) /
-                                        static_cast<double>(source_rate));
+    const double cutoff =
+        std::min(1.0, static_cast<double>(target_rate) / static_cast<double>(source_rate));
 
     // Source positions repeat across target_rate / gcd(source_rate,
     // target_rate) fractional phases. Precompute the windowed-sinc weights for
@@ -356,17 +306,14 @@ std::vector<float> resample_linear(
     // tap. Fall back for unusual rate pairs that would require a large table.
     constexpr int32_t kMaxPrecomputedPhases = 2048;
     const int32_t phase_count = target_rate / std::gcd(source_rate, target_rate);
-    if (phase_count <= kMaxPrecomputedPhases)
-    {
-        return resample_polyphase(
-            samples, n_samples, source_rate, target_rate, out_len, cutoff, half_taps);
+    if (phase_count <= kMaxPrecomputedPhases) {
+        return resample_polyphase(samples, n_samples, source_rate, target_rate, out_len, cutoff,
+                                  half_taps);
     }
 
-    for (int32_t i = 0; i < out_len; ++i)
-    {
-        const double src_pos = static_cast<double>(i) *
-            static_cast<double>(source_rate) /
-            static_cast<double>(target_rate);
+    for (int32_t i = 0; i < out_len; ++i) {
+        const double src_pos = static_cast<double>(i) * static_cast<double>(source_rate) /
+                               static_cast<double>(target_rate);
         resampled[i] = resample_at_position(samples, n_samples, src_pos, cutoff, half_taps);
     }
     return resampled;

--- a/tests/cpp/models/canary/test_canary_mel_spectrogram.cpp
+++ b/tests/cpp/models/canary/test_canary_mel_spectrogram.cpp
@@ -6,6 +6,7 @@
 #include "runtime/models/canary/canary_mel_spectrogram.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <iostream>
 #include <vector>
@@ -30,6 +31,51 @@ std::vector<float> make_identity_filterbank(int32_t n_freq_bins, int32_t n_mel_b
     return fb;
 }
 
+std::vector<float> reference_rfft_power(const std::vector<float>& input) {
+    const int32_t n = static_cast<int32_t>(input.size());
+    const int32_t n_out = n / 2 + 1;
+    const double pi2 = 2.0 * 3.14159265358979323846;
+    std::vector<float> power(static_cast<std::size_t>(n_out), 0.0F);
+    for (int32_t k = 0; k < n_out; ++k) {
+        double real = 0.0;
+        double imag = 0.0;
+        for (int32_t t = 0; t < n; ++t) {
+            const double angle =
+                pi2 * static_cast<double>(k) * static_cast<double>(t) / static_cast<double>(n);
+            real += static_cast<double>(input[static_cast<std::size_t>(t)]) * std::cos(angle);
+            imag -= static_cast<double>(input[static_cast<std::size_t>(t)]) * std::sin(angle);
+        }
+        power[static_cast<std::size_t>(k)] = static_cast<float>(real * real + imag * imag);
+    }
+    return power;
+}
+
+void check_fft_matches_direct(const std::vector<float>& input, const char* test_name) {
+    const auto actual = trtmc::canary::detail::rfft_power(input);
+    const auto reference = reference_rfft_power(input);
+    bool values_match = actual.size() == reference.size();
+    for (std::size_t i = 0; values_match && i < actual.size(); ++i) {
+        const float tolerance = 1e-5F * std::max(1.0F, std::abs(reference[i]));
+        values_match = std::abs(actual[i] - reference[i]) <= tolerance;
+    }
+    check(values_match, test_name);
+}
+
+void test_canary_fft_matches_direct_dft() {
+    check_fft_matches_direct(
+        {0.25F, -0.5F, 0.75F, 1.0F, -0.25F, 0.125F, 0.5F, -0.75F},
+        "canary radix-2 FFT power matches direct DFT");
+    check_fft_matches_direct({0.1F, 0.2F, -0.3F, 0.4F, 0.5F, -0.6F, 0.7F, 0.8F, -0.9F, 1.0F},
+                             "canary non-radix-2 fallback matches direct DFT");
+
+    std::vector<float> canary_input(512);
+    for (std::size_t i = 0; i < canary_input.size(); ++i) {
+        canary_input[i] = static_cast<float>(
+            std::sin(static_cast<double>(i) * 0.17) + 0.25 * std::cos(static_cast<double>(i) * 0.07));
+    }
+    check_fft_matches_direct(canary_input, "canary 512-point FFT power matches direct DFT");
+}
+
 void test_canary_shape_and_empty_audio() {
     const int32_t sample_rate = 16000;
     const int32_t n_fft = 400;
@@ -47,11 +93,53 @@ void test_canary_shape_and_empty_audio() {
     check(mel.n_frames == 3000, "canary mel frame count matches 30s HF window");
     check(static_cast<int32_t>(mel.data.size()) == n_mel_bins * mel.n_frames,
           "canary mel data size matches shape");
+    check(std::all_of(mel.data.begin(), mel.data.end(),
+                      [](float value) { return value == -1.5F; }),
+          "canary empty audio keeps the normalized zero-power value");
+}
+
+void test_canary_short_audio_matches_full_zero_padded_reference() {
+    const int32_t sample_rate = 32;
+    const int32_t n_fft = 8;
+    const int32_t hop_length = 2;
+    const int32_t chunk_length_s = 1;
+    const int32_t n_freq_bins = n_fft / 2 + 1;
+    const int32_t n_mel_bins = n_freq_bins;
+    auto fb = make_identity_filterbank(n_freq_bins, n_mel_bins);
+
+    std::vector<float> short_audio = {0.25F, -0.5F, 0.75F, 1.0F, -0.25F, 0.125F,
+                                      0.5F,  -0.75F, 0.2F, 0.4F,  -0.1F};
+    std::vector<float> full_audio(static_cast<std::size_t>(sample_rate * chunk_length_s), 0.0F);
+    std::copy(short_audio.begin(), short_audio.end(), full_audio.begin());
+
+    const auto optimized = trtmc::canary::extract_mel_spectrogram(
+        short_audio.data(), static_cast<int32_t>(short_audio.size()), fb.data(), n_freq_bins,
+        n_mel_bins, n_fft, hop_length, chunk_length_s, sample_rate);
+    const auto reference = trtmc::canary::extract_mel_spectrogram(
+        full_audio.data(), static_cast<int32_t>(full_audio.size()), fb.data(), n_freq_bins,
+        n_mel_bins, n_fft, hop_length, chunk_length_s, sample_rate);
+
+    check(optimized.n_frames == reference.n_frames,
+          "canary optimized mel preserves the full chunk shape");
+    check(optimized.valid_frames == static_cast<int32_t>(short_audio.size()) / hop_length,
+          "canary optimized mel reports short audio frames");
+    check(reference.valid_frames == reference.n_frames,
+          "canary full zero-padded reference computes the full chunk");
+    check(optimized.data.size() == reference.data.size(),
+          "canary optimized mel preserves the full data size");
+
+    bool values_match = optimized.data.size() == reference.data.size();
+    for (std::size_t i = 0; values_match && i < optimized.data.size(); ++i) {
+        values_match = std::abs(optimized.data[i] - reference.data[i]) <= 1e-6F;
+    }
+    check(values_match, "canary optimized mel matches full zero-padded values");
 }
 
 } // namespace
 
 int main() {
+    test_canary_fft_matches_direct_dft();
     test_canary_shape_and_empty_audio();
+    test_canary_short_audio_matches_full_zero_padded_reference();
     return failures;
 }

--- a/tests/cpp/models/canary/test_canary_mel_spectrogram.cpp
+++ b/tests/cpp/models/canary/test_canary_mel_spectrogram.cpp
@@ -62,16 +62,15 @@ void check_fft_matches_direct(const std::vector<float>& input, const char* test_
 }
 
 void test_canary_fft_matches_direct_dft() {
-    check_fft_matches_direct(
-        {0.25F, -0.5F, 0.75F, 1.0F, -0.25F, 0.125F, 0.5F, -0.75F},
-        "canary radix-2 FFT power matches direct DFT");
+    check_fft_matches_direct({0.25F, -0.5F, 0.75F, 1.0F, -0.25F, 0.125F, 0.5F, -0.75F},
+                             "canary radix-2 FFT power matches direct DFT");
     check_fft_matches_direct({0.1F, 0.2F, -0.3F, 0.4F, 0.5F, -0.6F, 0.7F, 0.8F, -0.9F, 1.0F},
                              "canary non-radix-2 fallback matches direct DFT");
 
     std::vector<float> canary_input(512);
     for (std::size_t i = 0; i < canary_input.size(); ++i) {
-        canary_input[i] = static_cast<float>(
-            std::sin(static_cast<double>(i) * 0.17) + 0.25 * std::cos(static_cast<double>(i) * 0.07));
+        canary_input[i] = static_cast<float>(std::sin(static_cast<double>(i) * 0.17) +
+                                             0.25 * std::cos(static_cast<double>(i) * 0.07));
     }
     check_fft_matches_direct(canary_input, "canary 512-point FFT power matches direct DFT");
 }
@@ -93,8 +92,7 @@ void test_canary_shape_and_empty_audio() {
     check(mel.n_frames == 3000, "canary mel frame count matches 30s HF window");
     check(static_cast<int32_t>(mel.data.size()) == n_mel_bins * mel.n_frames,
           "canary mel data size matches shape");
-    check(std::all_of(mel.data.begin(), mel.data.end(),
-                      [](float value) { return value == -1.5F; }),
+    check(std::all_of(mel.data.begin(), mel.data.end(), [](float value) { return value == -1.5F; }),
           "canary empty audio keeps the normalized zero-power value");
 }
 
@@ -107,8 +105,8 @@ void test_canary_short_audio_matches_full_zero_padded_reference() {
     const int32_t n_mel_bins = n_freq_bins;
     auto fb = make_identity_filterbank(n_freq_bins, n_mel_bins);
 
-    std::vector<float> short_audio = {0.25F, -0.5F, 0.75F, 1.0F, -0.25F, 0.125F,
-                                      0.5F,  -0.75F, 0.2F, 0.4F,  -0.1F};
+    std::vector<float> short_audio = {0.25F, -0.5F,  0.75F, 1.0F, -0.25F, 0.125F,
+                                      0.5F,  -0.75F, 0.2F,  0.4F, -0.1F};
     std::vector<float> full_audio(static_cast<std::size_t>(sample_rate * chunk_length_s), 0.0F);
     std::copy(short_audio.begin(), short_audio.end(), full_audio.begin());
 

--- a/tests/cpp/models/canary/test_canary_pipeline.cpp
+++ b/tests/cpp/models/canary/test_canary_pipeline.cpp
@@ -49,6 +49,7 @@ void test_canary_transcribe() {
         enc_engine.get(), enc_engine->createExecutionContext(), stream);
     auto decoder = std::make_unique<trtmc::TrtModuleImpl>(
         dec_engine.get(), dec_engine->createExecutionContext(), stream);
+    auto* decoder_ptr = decoder.get();
     auto cache = std::make_unique<trtmc::CanaryKvCache>(0, 8, 0, stream);
 
     check(encoder->ok(), "canary encoder ok");
@@ -69,6 +70,7 @@ void test_canary_transcribe() {
                                    4, 0, std::move(mel_fb), 400, 160, 1, 16000, stream);
 
     check(std::string(pipeline.pipeline_type()) == "CanaryPipeline", "canary pipeline_type");
+    check(decoder_ptr->cuda_graph_active(), "canary enables decoder CUDA graph by default");
 
     std::vector<float> audio(100, 0.0F);
     auto result = pipeline.transcribe(audio.data(), static_cast<int32_t>(audio.size()), 5);
@@ -131,12 +133,14 @@ void test_canary_with_cross_kv() {
         enc_engine.get(), enc_engine->createExecutionContext(), stream);
     auto decoder = std::make_unique<trtmc::TrtModuleImpl>(
         dec_engine.get(), dec_engine->createExecutionContext(), stream);
+    auto* decoder_ptr = decoder.get();
     auto cache = std::make_unique<trtmc::CanaryKvCache>(0, 8, 0, stream);
 
     trtmc::CanaryConfig wcfg;
     wcfg.mel_length = 4;
     wcfg.max_source_positions = 5;
     wcfg.eot_token_id = 2;
+    wcfg.disable_cuda_graph = true;
 
     trtmc::MelFilterbank mel_fb;
     mel_fb.n_freq_bins = 201;
@@ -148,6 +152,7 @@ void test_canary_with_cross_kv() {
 
     check(std::string(pipeline.pipeline_type()) == "CanaryPipeline",
           "canary cross-kv: pipeline_type");
+    check(!decoder_ptr->cuda_graph_active(), "canary honors CUDA graph opt-out");
 
     std::vector<float> audio(100, 0.0F);
     auto result = pipeline.transcribe(audio.data(), static_cast<int32_t>(audio.size()), 5);

--- a/tests/cpp/test_wav_reader.cpp
+++ b/tests/cpp/test_wav_reader.cpp
@@ -47,6 +47,67 @@ static void check(bool condition, const char* test_name) {
     }
 }
 
+static double reference_scaled_sinc(double distance, double cutoff) {
+    constexpr double kPi = 3.14159265358979323846;
+    if (std::abs(distance) < 1e-12)
+        return cutoff;
+    return cutoff * std::sin(kPi * distance * cutoff) / (kPi * distance * cutoff);
+}
+
+static double reference_hann_window(double distance, int32_t half_taps) {
+    constexpr double kPi = 3.14159265358979323846;
+    const double position = (distance + static_cast<double>(half_taps)) /
+        (2.0 * static_cast<double>(half_taps));
+    return 0.5 * (1.0 - std::cos(2.0 * kPi * position));
+}
+
+static std::vector<float> reference_resample(
+    const std::vector<float>& samples, int32_t source_rate, int32_t target_rate) {
+    const int32_t out_len = static_cast<int32_t>(
+        static_cast<int64_t>(samples.size()) * target_rate / source_rate);
+    const int32_t half_taps = 16;
+    const double cutoff = std::min(1.0, static_cast<double>(target_rate) /
+                                        static_cast<double>(source_rate));
+    std::vector<float> output(out_len);
+    for (int32_t i = 0; i < out_len; ++i) {
+        const double source_position = static_cast<double>(i) * source_rate / target_rate;
+        const int32_t center = static_cast<int32_t>(std::floor(source_position));
+        const int32_t first = std::max(0, center - half_taps + 1);
+        const int32_t last = std::min(static_cast<int32_t>(samples.size()) - 1,
+                                      center + half_taps);
+        double value = 0.0;
+        double weight_sum = 0.0;
+        for (int32_t j = first; j <= last; ++j) {
+            const double distance = static_cast<double>(j) - source_position;
+            const double weight = reference_scaled_sinc(distance, cutoff) *
+                reference_hann_window(distance, half_taps);
+            value += static_cast<double>(samples[static_cast<std::size_t>(j)]) * weight;
+            weight_sum += weight;
+        }
+        output[static_cast<std::size_t>(i)] =
+            weight_sum > 1e-12 ? static_cast<float>(value / weight_sum) : 0.0F;
+    }
+    return output;
+}
+
+static void check_resample_matches_reference(
+    int32_t source_rate, int32_t target_rate, const char* test_name) {
+    std::vector<float> input(1003);
+    for (std::size_t i = 0; i < input.size(); ++i) {
+        input[i] = static_cast<float>(
+            0.7 * std::sin(static_cast<double>(i) * 0.11) +
+            0.2 * std::cos(static_cast<double>(i) * 0.037));
+    }
+    const auto actual = trtmc::resample_linear(
+        input.data(), static_cast<int32_t>(input.size()), source_rate, target_rate);
+    const auto reference = reference_resample(input, source_rate, target_rate);
+    bool matches = actual.size() == reference.size();
+    for (std::size_t i = 0; matches && i < actual.size(); ++i) {
+        matches = std::abs(actual[i] - reference[i]) <= 1e-6F;
+    }
+    check(matches, test_name);
+}
+
 static std::filesystem::path make_temp_dir() {
     char pattern[] = "/tmp/trtmc_wav_test_XXXXXX";
     char* dir = mkdtemp(pattern);
@@ -201,7 +262,12 @@ int main() {
         check(std::abs(resampled[1] - 0.2F) < 1e-6F, "resample_identity: values match");
     }
 
-    // Test 6: Invalid file throws
+    // Test 6: polyphase resampling preserves the original windowed-sinc result.
+    check_resample_matches_reference(48000, 16000, "resample_polyphase: 48k to 16k parity");
+    check_resample_matches_reference(44100, 16000, "resample_polyphase: 44.1k to 16k parity");
+    check_resample_matches_reference(16000, 48000, "resample_polyphase: 16k to 48k parity");
+
+    // Test 7: Invalid file throws
     {
         bool caught = false;
         try {

--- a/tests/cpp/test_wav_reader.cpp
+++ b/tests/cpp/test_wav_reader.cpp
@@ -56,31 +56,30 @@ static double reference_scaled_sinc(double distance, double cutoff) {
 
 static double reference_hann_window(double distance, int32_t half_taps) {
     constexpr double kPi = 3.14159265358979323846;
-    const double position = (distance + static_cast<double>(half_taps)) /
-        (2.0 * static_cast<double>(half_taps));
+    const double position =
+        (distance + static_cast<double>(half_taps)) / (2.0 * static_cast<double>(half_taps));
     return 0.5 * (1.0 - std::cos(2.0 * kPi * position));
 }
 
-static std::vector<float> reference_resample(
-    const std::vector<float>& samples, int32_t source_rate, int32_t target_rate) {
-    const int32_t out_len = static_cast<int32_t>(
-        static_cast<int64_t>(samples.size()) * target_rate / source_rate);
+static std::vector<float> reference_resample(const std::vector<float>& samples, int32_t source_rate,
+                                             int32_t target_rate) {
+    const int32_t out_len =
+        static_cast<int32_t>(static_cast<int64_t>(samples.size()) * target_rate / source_rate);
     const int32_t half_taps = 16;
-    const double cutoff = std::min(1.0, static_cast<double>(target_rate) /
-                                        static_cast<double>(source_rate));
+    const double cutoff =
+        std::min(1.0, static_cast<double>(target_rate) / static_cast<double>(source_rate));
     std::vector<float> output(out_len);
     for (int32_t i = 0; i < out_len; ++i) {
         const double source_position = static_cast<double>(i) * source_rate / target_rate;
         const int32_t center = static_cast<int32_t>(std::floor(source_position));
         const int32_t first = std::max(0, center - half_taps + 1);
-        const int32_t last = std::min(static_cast<int32_t>(samples.size()) - 1,
-                                      center + half_taps);
+        const int32_t last = std::min(static_cast<int32_t>(samples.size()) - 1, center + half_taps);
         double value = 0.0;
         double weight_sum = 0.0;
         for (int32_t j = first; j <= last; ++j) {
             const double distance = static_cast<double>(j) - source_position;
             const double weight = reference_scaled_sinc(distance, cutoff) *
-                reference_hann_window(distance, half_taps);
+                                  reference_hann_window(distance, half_taps);
             value += static_cast<double>(samples[static_cast<std::size_t>(j)]) * weight;
             weight_sum += weight;
         }
@@ -90,16 +89,15 @@ static std::vector<float> reference_resample(
     return output;
 }
 
-static void check_resample_matches_reference(
-    int32_t source_rate, int32_t target_rate, const char* test_name) {
+static void check_resample_matches_reference(int32_t source_rate, int32_t target_rate,
+                                             const char* test_name) {
     std::vector<float> input(1003);
     for (std::size_t i = 0; i < input.size(); ++i) {
-        input[i] = static_cast<float>(
-            0.7 * std::sin(static_cast<double>(i) * 0.11) +
-            0.2 * std::cos(static_cast<double>(i) * 0.037));
+        input[i] = static_cast<float>(0.7 * std::sin(static_cast<double>(i) * 0.11) +
+                                      0.2 * std::cos(static_cast<double>(i) * 0.037));
     }
-    const auto actual = trtmc::resample_linear(
-        input.data(), static_cast<int32_t>(input.size()), source_rate, target_rate);
+    const auto actual = trtmc::resample_linear(input.data(), static_cast<int32_t>(input.size()),
+                                               source_rate, target_rate);
     const auto reference = reference_resample(input, source_rate, target_rate);
     bool matches = actual.size() == reference.size();
     for (std::size_t i = 0; matches && i < actual.size(); ++i) {


### PR DESCRIPTION
## Background

Profiling Canary transcription showed that CPU audio preprocessing dominated inference for short recordings. On a 4.16-second, 48 kHz sample, the pre-optimization transcription path took a 4,505.1 ms p50 even though the TensorRT encoder and decoder completed in milliseconds.

The main costs were computing a direct DFT and mel projection for every frame in the fixed 30-second tensor, including the zero-padded tail, and evaluating windowed-sinc coefficients repeatedly during resampling.

  ## Exit Criteria

  - Preserve Canary's fixed-size mel tensor, valid-frame masking, transcript, and numerical behavior.
  - Avoid FFT and mel work for frames that cannot overlap real audio.
  - Accelerate common sample-rate conversions without changing their output beyond the existing floating-point tolerance.
  - Keep the implementation dependency-free and retain safe fallbacks for unsupported transform sizes and unusual sample-rate pairs.

  ## Implementation

  - Compute spectrogram frames only while their windows can overlap real samples. The remaining fixed-size tensor retainsthe same normalized zero-power floor used by the previous fully padded computation.
  - Replace the quadratic direct DFT with an in-place radix-2 FFT for power-of-two sizes, including Canary's 512-point transform. Non-power-of-two transforms continue to use the direct implementation.
  - Fuse power-spectrum projection into the mel loop so the frontend no longer materializes a frequency-by-frame power tensor.
  - Precompute the repeated windowed-sinc phases used by common resampling ratios. Rate pairs requiring more than 2,048 phases retain the previous per-sample calculation as a fallback.
  - Add numerical parity coverage for the radix-2 FFT, direct-DFT fallback, zero-padded mel output, and 48 kHz → 16 kHz, 44.1 kHz → 16 kHz, and 16 kHz → 48 kHz resampling.
  - Add opt-in stage timing through TRTMC_CANARY_STAGE_TIMING=1. The diagnostic reports resampling, mel extraction, encoder, cross-KV, decoder, tokenizer, and total transcription time to stderr.
  - Capture stable decoder enqueues as CUDA Graphs and replay them within each dynamic cache-row bucket. Shape changes use the runtime's existing invalidation and recapture path, and `--set runtime.disable_cuda_graph=true` restores the normal enqueue path.

  ## Performance

 Local analysis used the same FP16 Canary 1B v2 bundle and 4.16-second, 48 kHz WAV on an NVIDIA GB300. Results exclude bundle loading and use 3 warmup iterations followed by 10 measured iterations.

  - **Transcription latency p50**  | 4,505.1 ms | 27.5 ms | 163.6x faster |
  - **Transcription latency p95**  | 4,506.4 ms | 27.7 ms | 162.9x faster |
  - **Real-time factor, mean**  | 1.0830 | 0.00662 | 163.5x lower |
  - **Audio throughput, mean**  | 0.923x real time | 151.0x real time | 163.5x higher |
  - **WER / CER:** 0 / 0 → 0 / 0 (**unchanged**)
  