### PR TITLE
test(repro): add pure TRT Myelin crash harness

### DIFF
--- a/reproducers/issue_428_pure_trt/README.md
+++ b/reproducers/issue_428_pure_trt/README.md
@@ -1,0 +1,90 @@
+# Issue #428 pure TensorRT reproducer
+
+This reproducer removes `.trtfb`, `task_eval`, datasets, tokenizers, and the TRTMC C++ runtime from the failure path. It builds two serialized TensorRT plans directly from the Gemma graph and executes them with the TensorRT Python API and CUDA runtime bindings.
+
+The failure is reproduced by this sequence:
+
+1. Run the split prefill plan with the fixed token IDs `2,4521` (`Hello`).
+2. Copy each prefill `present_k_N` / `present_v_N` output into a shared KV cache.
+3. Bind that cache to the split decode plan.
+4. Run one decode step.
+5. Observe CUDA status 700 during decode synchronization, followed by a Myelin module-unload failure during TensorRT teardown.
+
+Both plans run cleanly when tested separately. The minimal failing boundary is the prefill-produced KV state consumed by the decode engine.
+
+## Validated environment
+
+- TRTMC source: PR #413 at `a10ba64820082ad3d21dfc67bffe444dd95c9626`
+- TensorRT: `11.2.0.113`
+- CUDA image: `13.3`
+- GPU: NVIDIA GB300
+- Model: `google/gemma-2-2b-it`
+- Precision: FP16
+- KV cache length: `1741`
+
+The model snapshot must already be accessible through the Hugging Face cache or normal Hugging Face authentication. Allow at least 16 GiB of free disk space for the two plans and logs.
+
+## One-command reproduction
+
+Run from this directory inside the TRT 11.2 environment:
+
+```bash
+./run_repro.sh
+```
+
+The first invocation builds the prefill and decode plans directly into `/tmp/trtmc-issue428-pure-trt`, then runs inference. Subsequent invocations reuse those plans. Override the location when needed:
+
+```bash
+./run_repro.sh --output-dir /path/with/enough/space
+```
+
+Expected final output on the affected TensorRT build:
+
+```text
+[pure-trt] gemma-2-2b-c1741-prefill: execute_sync_status=0
+[pure-trt] prefill_to_decode_cache=OK
+[pure-trt] gemma-2-2b-c1741-decode: execute_sync_status=700
+[pure-trt] ISSUE_428_REPRODUCED decode_sync_status=700
+[one-click] ISSUE_428_REPRODUCED
+```
+
+`run_repro.sh` returns zero when the known issue is reproduced. It writes `build.log` and `infer.log` under the output directory.
+
+## Re-run inference without rebuilding
+
+```bash
+./run_repro.sh \
+  --output-dir /path/with/existing/plans \
+  --skip-build
+```
+
+## Verify a candidate fix
+
+Use `--expect-fixed` after replacing TensorRT/Myelin with a candidate build:
+
+```bash
+./run_repro.sh \
+  --output-dir /path/with/existing/plans \
+  --skip-build \
+  --expect-fixed
+```
+
+In this mode the wrapper returns zero only when decode and teardown complete cleanly without a CUDA/Myelin safety signature.
+
+## Files
+
+- `build_plans.py` builds standalone prefill and decode `.plan` files. It uses TRTMC only as the network-definition source; it never creates a `.trtfb` bundle.
+- `infer_sequence.py` is the failing pure TensorRT/CUDA inference harness.
+- `infer_engine.py` is a single-prefill-plan control used during minimization.
+- `run_repro.sh` performs preflight, build, inference, log capture, and result classification.
+
+## Current minimization result
+
+| Path | Result |
+| --- | --- |
+| Decode plan with an empty cache | Clean |
+| Prefill plan with `2,4521` | Clean |
+| Prefill plan → shared KV cache → decode plan | CUDA 700; Myelin unload failure |
+| Original standalone `trtmc run` | Exit 139 with the same teardown signature |
+
+This isolates the failure from bundle parsing, tokenizer behavior, task-eval orchestration, dataset content, and the TRTMC C++ runtime.

--- a/reproducers/issue_428_pure_trt/build_plans.py
+++ b/reproducers/issue_428_pure_trt/build_plans.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build issue #428 Gemma prefill/decode TensorRT plans without a .trtfb bundle."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+from pathlib import Path
+import time
+
+import tensorrt as trt
+
+
+def build_role(plugin, config, weights, cache_length: int, role: str, verbose: bool) -> bytes:
+    previous_role = config.raw.get("_decoder_engine_role")
+    config.raw["_decoder_engine_role"] = role
+    try:
+        return plugin.build_engine(
+            config,
+            weights,
+            cache_length,
+            precision="fp16",
+            verbose=verbose,
+        )
+    finally:
+        if previous_role is None:
+            config.raw.pop("_decoder_engine_role", None)
+        else:
+            config.raw["_decoder_engine_role"] = previous_role
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build pure TensorRT plans for the issue #428 reproducer"
+    )
+    parser.add_argument("--model", default="google/gemma-2-2b-it")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--cache-length", type=int, default=1741)
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    prefix = f"gemma-2-2b-c{args.cache_length}"
+    plan_paths = {
+        "prefill": output_dir / f"{prefix}-prefill.plan",
+        "decode": output_dir / f"{prefix}-decode.plan",
+    }
+    metadata_path = output_dir / f"{prefix}-metadata.json"
+    if not args.force and metadata_path.exists() and all(path.exists() for path in plan_paths.values()):
+        print(f"[pure-trt-build] reuse existing plans in {output_dir}", flush=True)
+        print(f"[pure-trt-build] metadata={metadata_path}", flush=True)
+        return 0
+
+    from tensorrt_model_connect.config import ModelConfig
+    from tensorrt_model_connect.engine_builder import _resolve_model
+    from tensorrt_model_connect.families import find_plugin
+
+    model_dir = _resolve_model(args.model)
+    config = ModelConfig.from_dir(model_dir)
+    plugin = find_plugin(config.model_type)
+    if plugin is None or plugin.name != "gemma":
+        raise RuntimeError(
+            f"expected Gemma plugin for {args.model}, got "
+            f"{getattr(plugin, 'name', None)!r}"
+        )
+
+    print(
+        f"[pure-trt-build] TensorRT={trt.__version__} model={args.model} "
+        f"cache_length={args.cache_length} precision=fp16",
+        flush=True,
+    )
+    print("[pure-trt-build] loading Gemma weights", flush=True)
+    weights = plugin.load_weights(model_dir, config, precision="fp16")
+
+    metadata = {
+        "model": args.model,
+        "resolved_model_dir": str(model_dir),
+        "model_type": config.model_type,
+        "num_layers": config.num_hidden_layers,
+        "hidden_size": config.hidden_size,
+        "num_attention_heads": config.num_attention_heads,
+        "num_key_value_heads": config.num_key_value_heads,
+        "cache_length": args.cache_length,
+        "precision": "fp16",
+        "tensorrt_version": trt.__version__,
+        "plans": {},
+    }
+
+    for role in ("prefill", "decode"):
+        print(f"[pure-trt-build] building {role} plan", flush=True)
+        started = time.monotonic()
+        plan = build_role(
+            plugin, config, weights, args.cache_length, role, args.verbose
+        )
+        elapsed = time.monotonic() - started
+        path = plan_paths[role]
+        path.write_bytes(plan)
+        metadata["plans"][role] = {
+            "path": str(path),
+            "bytes": len(plan),
+            "sha256": sha256_bytes(plan),
+            "build_seconds": elapsed,
+        }
+        print(
+            f"[pure-trt-build] {role} plan={path} bytes={len(plan)} "
+            f"seconds={elapsed:.1f}",
+            flush=True,
+        )
+        del plan
+        gc.collect()
+
+    metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+    print(f"[pure-trt-build] metadata={metadata_path}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reproducers/issue_428_pure_trt/infer_engine.py
+++ b/reproducers/issue_428_pure_trt/infer_engine.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the issue #428 prefill engine through TensorRT without TRTMC runtime code."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+from pathlib import Path
+import sys
+
+import numpy as np
+import tensorrt as trt
+
+try:
+    from cuda.bindings import runtime as cudart
+except ImportError:
+    from cuda import cudart  # type: ignore[no-redef]
+
+
+DEFAULT_TOKEN_IDS = (2, 4521)  # Gemma tokenizer encoding for "Hello".
+MASKED_SCORE = -1.0e4
+
+
+def cuda_success() -> object:
+    error_type = getattr(cudart, "cudaError_t", None)
+    return error_type.cudaSuccess if error_type is not None else 0
+
+
+def cuda_status(result: object) -> object:
+    return result[0] if isinstance(result, tuple) else result
+
+
+def cuda_value(result: tuple[object, ...], operation: str) -> int:
+    status = cuda_status(result)
+    if status != cuda_success():
+        raise RuntimeError(f"{operation} failed with CUDA status {status}")
+    return int(result[1])
+
+
+def check_cuda(result: object, operation: str) -> None:
+    status = cuda_status(result)
+    if status != cuda_success():
+        raise RuntimeError(f"{operation} failed with CUDA status {status}")
+
+
+def parse_token_ids(raw: str) -> tuple[int, ...]:
+    values = tuple(int(value.strip()) for value in raw.split(",") if value.strip())
+    if not values:
+        raise argparse.ArgumentTypeError("at least one token ID is required")
+    return values
+
+
+def tensor_nbytes(engine: trt.ICudaEngine, context: trt.IExecutionContext, name: str) -> int:
+    shape = tuple(int(dim) for dim in context.get_tensor_shape(name))
+    if not shape or any(dim < 0 for dim in shape):
+        raise RuntimeError(f"unresolved shape for {name}: {shape}")
+    dtype = np.dtype(trt.nptype(engine.get_tensor_dtype(name)))
+    return int(np.prod(shape, dtype=np.int64)) * dtype.itemsize
+
+
+def make_prefill_mask(sequence_length: int, cache_length: int) -> np.ndarray:
+    """Match GemmaKvCache::write_batched_mask at position zero."""
+    kv_length = cache_length + sequence_length
+    mask = np.full((sequence_length, kv_length), MASKED_SCORE, dtype=np.float32)
+    for row in range(sequence_length):
+        mask[row, cache_length : cache_length + row + 1] = 0.0
+    return mask
+
+
+def free_cuda_buffers(buffers: dict[str, int], stream: int) -> bool:
+    clean = True
+    for name, pointer in reversed(tuple(buffers.items())):
+        status = cuda_status(cudart.cudaFree(pointer))
+        if status != cuda_success():
+            clean = False
+            print(f"[pure-trt] cudaFree({name}) status={status}", file=sys.stderr, flush=True)
+    status = cuda_status(cudart.cudaStreamDestroy(stream))
+    if status != cuda_success():
+        clean = False
+        print(f"[pure-trt] cudaStreamDestroy status={status}", file=sys.stderr, flush=True)
+    return clean
+
+
+def run(plan_path: Path, token_ids: tuple[int, ...], cache_length: int) -> int:
+    print(f"[pure-trt] TensorRT={trt.__version__}", flush=True)
+    print(
+        f"[pure-trt] plan={plan_path} cache_length={cache_length} "
+        f"token_ids={','.join(str(value) for value in token_ids)}",
+        flush=True,
+    )
+
+    logger = trt.Logger(trt.Logger.WARNING)
+    runtime = trt.Runtime(logger)
+    engine = runtime.deserialize_cuda_engine(plan_path.read_bytes())
+    if engine is None:
+        raise RuntimeError(f"failed to deserialize {plan_path}")
+    context = engine.create_execution_context()
+    if context is None:
+        raise RuntimeError("failed to create TensorRT execution context")
+
+    sequence_length = len(token_ids)
+    input_shapes = {
+        "token_id": (sequence_length,),
+        "position_id": (sequence_length,),
+        "attention_mask": (sequence_length, cache_length + sequence_length),
+    }
+    for name, shape in input_shapes.items():
+        if not context.set_input_shape(name, shape):
+            raise RuntimeError(f"set_input_shape({name}, {shape}) failed")
+
+    unresolved = context.infer_shapes()
+    if unresolved:
+        raise RuntimeError(f"TensorRT reports unresolved tensors: {unresolved}")
+
+    buffers: dict[str, int] = {}
+    stream = cuda_value(cudart.cudaStreamCreate(), "cudaStreamCreate")
+    try:
+        for index in range(engine.num_io_tensors):
+            name = engine.get_tensor_name(index)
+            nbytes = tensor_nbytes(engine, context, name)
+            pointer = cuda_value(cudart.cudaMalloc(nbytes), f"cudaMalloc({name}, {nbytes})")
+            buffers[name] = pointer
+            if not context.set_tensor_address(name, pointer):
+                raise RuntimeError(f"set_tensor_address({name}) failed")
+
+        host_inputs = {
+            "token_id": np.asarray(token_ids, dtype=np.int32),
+            "position_id": np.arange(sequence_length, dtype=np.int32),
+            "attention_mask": make_prefill_mask(sequence_length, cache_length),
+        }
+        host_to_device = cudart.cudaMemcpyKind.cudaMemcpyHostToDevice
+        for name, host_array in host_inputs.items():
+            check_cuda(
+                cudart.cudaMemcpyAsync(
+                    buffers[name],
+                    host_array.ctypes.data,
+                    host_array.nbytes,
+                    host_to_device,
+                    stream,
+                ),
+                f"cudaMemcpyAsync({name}, H2D)",
+            )
+
+        for layer in range(26):
+            for prefix in ("cache_k", "cache_v"):
+                name = f"{prefix}_{layer}"
+                check_cuda(
+                    cudart.cudaMemsetAsync(
+                        buffers[name], 0, tensor_nbytes(engine, context, name), stream
+                    ),
+                    f"cudaMemsetAsync({name})",
+                )
+
+        if not context.execute_async_v3(stream):
+            raise RuntimeError("TensorRT execute_async_v3 returned false")
+        print("[pure-trt] enqueue=OK", flush=True)
+
+        sync_status = cuda_status(cudart.cudaStreamSynchronize(stream))
+        print(f"[pure-trt] execute_sync_status={sync_status}", flush=True)
+
+        if sync_status == cuda_success():
+            logits_shape = tuple(int(dim) for dim in context.get_tensor_shape("logits"))
+            logits = np.empty(logits_shape, dtype=np.float32)
+            device_to_host = cudart.cudaMemcpyKind.cudaMemcpyDeviceToHost
+            check_cuda(
+                cudart.cudaMemcpyAsync(
+                    logits.ctypes.data,
+                    buffers["logits"],
+                    logits.nbytes,
+                    device_to_host,
+                    stream,
+                ),
+                "cudaMemcpyAsync(logits, D2H)",
+            )
+            copy_status = cuda_status(cudart.cudaStreamSynchronize(stream))
+            print(f"[pure-trt] logits_sync_status={copy_status}", flush=True)
+            if copy_status == cuda_success():
+                print(f"[pure-trt] top_token={int(np.argmax(logits[-1]))}", flush=True)
+            else:
+                sync_status = copy_status
+
+        cleanup_ok = free_cuda_buffers(buffers, stream)
+        buffers.clear()
+
+        # Mirror TRTMC teardown: buffers first, then context and engine.
+        del context
+        gc.collect()
+        print("[pure-trt] context_destroyed", flush=True)
+        del engine
+        gc.collect()
+        print("[pure-trt] engine_destroyed", flush=True)
+        del runtime
+        gc.collect()
+        print("[pure-trt] runtime_destroyed", flush=True)
+
+        if sync_status != cuda_success() or not cleanup_ok:
+            return 10
+        print("[pure-trt] CLEAN_EXIT", flush=True)
+        return 0
+    except BaseException:
+        if buffers:
+            free_cuda_buffers(buffers, stream)
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Pure TensorRT inference reproducer for issue #428"
+    )
+    parser.add_argument("--plan", type=Path, required=True)
+    parser.add_argument("--cache-length", type=int, default=1741)
+    parser.add_argument(
+        "--token-ids",
+        type=parse_token_ids,
+        default=DEFAULT_TOKEN_IDS,
+        help='Comma-separated token IDs (default: Gemma encoding of "Hello")',
+    )
+    args = parser.parse_args()
+    return run(args.plan, args.token_ids, args.cache_length)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reproducers/issue_428_pure_trt/infer_sequence.py
+++ b/reproducers/issue_428_pure_trt/infer_sequence.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure TensorRT split-prefill/decode reproducer for issue #428."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+from pathlib import Path
+import sys
+
+import numpy as np
+import tensorrt as trt
+
+from infer_engine import (
+    DEFAULT_TOKEN_IDS,
+    MASKED_SCORE,
+    check_cuda,
+    cuda_status,
+    cuda_success,
+    cuda_value,
+    parse_token_ids,
+    tensor_nbytes,
+)
+
+try:
+    from cuda.bindings import runtime as cudart
+except ImportError:
+    from cuda import cudart  # type: ignore[no-redef]
+
+
+class PlanSession:
+    def __init__(
+        self,
+        runtime: trt.Runtime,
+        plan_path: Path,
+        stream: int,
+        *,
+        input_shapes: dict[str, tuple[int, ...]] | None = None,
+        external_buffers: dict[str, int] | None = None,
+    ) -> None:
+        self.name = plan_path.stem
+        self.stream = stream
+        self.engine = runtime.deserialize_cuda_engine(plan_path.read_bytes())
+        if self.engine is None:
+            raise RuntimeError(f"failed to deserialize {plan_path}")
+        self.context = self.engine.create_execution_context()
+        if self.context is None:
+            raise RuntimeError(f"failed to create execution context for {plan_path}")
+        for name, shape in (input_shapes or {}).items():
+            if not self.context.set_input_shape(name, shape):
+                raise RuntimeError(f"{self.name}: set_input_shape({name}, {shape}) failed")
+        unresolved = self.context.infer_shapes()
+        if unresolved:
+            raise RuntimeError(f"{self.name}: unresolved tensors: {unresolved}")
+
+        external_buffers = external_buffers or {}
+        self.buffers: dict[str, int] = {}
+        self.owned_buffers: dict[str, int] = {}
+        for index in range(self.engine.num_io_tensors):
+            name = self.engine.get_tensor_name(index)
+            if name in external_buffers:
+                pointer = external_buffers[name]
+            else:
+                nbytes = tensor_nbytes(self.engine, self.context, name)
+                pointer = cuda_value(
+                    cudart.cudaMalloc(nbytes), f"{self.name}: cudaMalloc({name}, {nbytes})"
+                )
+                self.owned_buffers[name] = pointer
+            self.buffers[name] = pointer
+            if not self.context.set_tensor_address(name, pointer):
+                raise RuntimeError(f"{self.name}: set_tensor_address({name}) failed")
+
+    def nbytes(self, name: str) -> int:
+        return tensor_nbytes(self.engine, self.context, name)
+
+    def copy_host_to_device(self, name: str, array: np.ndarray) -> None:
+        expected = self.nbytes(name)
+        if array.nbytes != expected:
+            raise RuntimeError(
+                f"{self.name}: {name} byte mismatch: host={array.nbytes} engine={expected}"
+            )
+        check_cuda(
+            cudart.cudaMemcpyAsync(
+                self.buffers[name],
+                array.ctypes.data,
+                array.nbytes,
+                cudart.cudaMemcpyKind.cudaMemcpyHostToDevice,
+                self.stream,
+            ),
+            f"{self.name}: cudaMemcpyAsync({name}, H2D)",
+        )
+
+    def copy_device_to_host(self, name: str) -> np.ndarray:
+        shape = tuple(int(dim) for dim in self.context.get_tensor_shape(name))
+        dtype = np.dtype(trt.nptype(self.engine.get_tensor_dtype(name)))
+        output = np.empty(shape, dtype=dtype)
+        check_cuda(
+            cudart.cudaMemcpyAsync(
+                output.ctypes.data,
+                self.buffers[name],
+                output.nbytes,
+                cudart.cudaMemcpyKind.cudaMemcpyDeviceToHost,
+                self.stream,
+            ),
+            f"{self.name}: cudaMemcpyAsync({name}, D2H)",
+        )
+        check_cuda(cudart.cudaStreamSynchronize(self.stream), f"{self.name}: output sync")
+        return output
+
+    def execute(self) -> object:
+        if not self.context.execute_async_v3(self.stream):
+            raise RuntimeError(f"{self.name}: execute_async_v3 returned false")
+        status = cuda_status(cudart.cudaStreamSynchronize(self.stream))
+        print(f"[pure-trt] {self.name}: execute_sync_status={status}", flush=True)
+        return status
+
+    def destroy(self) -> bool:
+        clean = True
+        first_error: tuple[str, object] | None = None
+        for name, pointer in reversed(tuple(self.owned_buffers.items())):
+            status = cuda_status(cudart.cudaFree(pointer))
+            if status != cuda_success():
+                clean = False
+                if first_error is None:
+                    first_error = name, status
+        if first_error is not None:
+            name, status = first_error
+            print(
+                f"[pure-trt] {self.name}: cleanup first_error="
+                f"cudaFree({name}) status={status}",
+                file=sys.stderr,
+                flush=True,
+            )
+        self.owned_buffers.clear()
+        self.buffers.clear()
+        del self.context
+        gc.collect()
+        print(f"[pure-trt] {self.name}: context_destroyed", flush=True)
+        del self.engine
+        gc.collect()
+        print(f"[pure-trt] {self.name}: engine_destroyed", flush=True)
+        return clean
+
+
+def cache_input_names(engine: trt.ICudaEngine) -> tuple[str, ...]:
+    names = []
+    for index in range(engine.num_io_tensors):
+        name = engine.get_tensor_name(index)
+        if (
+            engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT
+            and (name.startswith("cache_k_") or name.startswith("cache_v_"))
+        ):
+            names.append(name)
+    return tuple(names)
+
+
+def allocate_shared_cache(
+    engine: trt.ICudaEngine, context: trt.IExecutionContext
+) -> dict[str, int]:
+    buffers = {}
+    for name in cache_input_names(engine):
+        nbytes = tensor_nbytes(engine, context, name)
+        buffers[name] = cuda_value(cudart.cudaMalloc(nbytes), f"cudaMalloc({name}, {nbytes})")
+    return buffers
+
+
+def make_decode_mask(prompt_length: int, cache_length: int) -> np.ndarray:
+    mask = np.full((1, cache_length + 1), MASKED_SCORE, dtype=np.float32)
+    mask[0, :prompt_length] = 0.0
+    mask[0, -1] = 0.0
+    return mask
+
+
+def free_shared_cache(buffers: dict[str, int]) -> bool:
+    clean = True
+    first_error: tuple[str, object] | None = None
+    for name, pointer in reversed(tuple(buffers.items())):
+        status = cuda_status(cudart.cudaFree(pointer))
+        if status != cuda_success():
+            clean = False
+            if first_error is None:
+                first_error = name, status
+    if first_error is not None:
+        name, status = first_error
+        print(
+            f"[pure-trt] shared-cache: cleanup first_error="
+            f"cudaFree({name}) status={status}",
+            file=sys.stderr,
+            flush=True,
+        )
+    buffers.clear()
+    return clean
+
+
+def run(
+    prefill_plan: Path,
+    decode_plan: Path,
+    token_ids: tuple[int, ...],
+    cache_length: int,
+) -> int:
+    print(f"[pure-trt] TensorRT={trt.__version__}", flush=True)
+    print(
+        f"[pure-trt] prefill_plan={prefill_plan} decode_plan={decode_plan} "
+        f"cache_length={cache_length} token_ids={','.join(map(str, token_ids))}",
+        flush=True,
+    )
+
+    logger = trt.Logger(trt.Logger.WARNING)
+    runtime = trt.Runtime(logger)
+    stream = cuda_value(cudart.cudaStreamCreate(), "cudaStreamCreate")
+
+    # Load decode once to discover the shared fixed-size cache contract.
+    decode_engine_probe = runtime.deserialize_cuda_engine(decode_plan.read_bytes())
+    if decode_engine_probe is None:
+        raise RuntimeError(f"failed to deserialize {decode_plan}")
+    decode_context_probe = decode_engine_probe.create_execution_context()
+    if decode_context_probe is None:
+        raise RuntimeError("failed to create decode probe context")
+    shared_cache = allocate_shared_cache(decode_engine_probe, decode_context_probe)
+    del decode_context_probe
+    del decode_engine_probe
+    gc.collect()
+
+    sequence_length = len(token_ids)
+    prefill_shapes = {
+        "token_id": (sequence_length,),
+        "position_id": (sequence_length,),
+        "attention_mask": (sequence_length, cache_length + sequence_length),
+    }
+    prefill = PlanSession(
+        runtime,
+        prefill_plan,
+        stream,
+        input_shapes=prefill_shapes,
+        external_buffers=shared_cache,
+    )
+    decode = PlanSession(
+        runtime,
+        decode_plan,
+        stream,
+        external_buffers=shared_cache,
+    )
+
+    try:
+        for pointer_name, pointer in shared_cache.items():
+            check_cuda(
+                cudart.cudaMemsetAsync(pointer, 0, decode.nbytes(pointer_name), stream),
+                f"cudaMemsetAsync({pointer_name})",
+            )
+
+        prefill.copy_host_to_device("token_id", np.asarray(token_ids, dtype=np.int32))
+        prefill.copy_host_to_device(
+            "position_id", np.arange(sequence_length, dtype=np.int32)
+        )
+        prefill_mask = np.full(
+            (sequence_length, cache_length + sequence_length),
+            MASKED_SCORE,
+            dtype=np.float32,
+        )
+        for row in range(sequence_length):
+            prefill_mask[row, cache_length : cache_length + row + 1] = 0.0
+        prefill.copy_host_to_device("attention_mask", prefill_mask)
+        prefill_status = prefill.execute()
+        if prefill_status != cuda_success():
+            raise RuntimeError(f"prefill execution failed with CUDA status {prefill_status}")
+
+        prefill_logits = prefill.copy_device_to_host("logits")
+        next_token = int(np.argmax(prefill_logits[-1]))
+        print(f"[pure-trt] prefill_top_token={next_token}", flush=True)
+
+        device_to_device = cudart.cudaMemcpyKind.cudaMemcpyDeviceToDevice
+        for cache_name, cache_pointer in shared_cache.items():
+            present_name = cache_name.replace("cache_", "present_", 1)
+            check_cuda(
+                cudart.cudaMemcpyAsync(
+                    cache_pointer,
+                    prefill.buffers[present_name],
+                    prefill.nbytes(present_name),
+                    device_to_device,
+                    stream,
+                ),
+                f"prefill-to-cache copy {present_name}",
+            )
+        check_cuda(cudart.cudaStreamSynchronize(stream), "prefill-to-cache sync")
+        print("[pure-trt] prefill_to_decode_cache=OK", flush=True)
+
+        decode.copy_host_to_device("token_id", np.asarray([next_token], dtype=np.int32))
+        decode.copy_host_to_device(
+            "position_id", np.asarray([sequence_length], dtype=np.int32)
+        )
+        decode.copy_host_to_device(
+            "attention_mask", make_decode_mask(sequence_length, cache_length)
+        )
+        decode_status = decode.execute()
+        reproduced = decode_status != cuda_success()
+        if reproduced:
+            print(
+                f"[pure-trt] ISSUE_428_REPRODUCED decode_sync_status={decode_status}",
+                flush=True,
+            )
+        else:
+            decode_logits = decode.copy_device_to_host("logits")
+            print(
+                f"[pure-trt] decode_top_token={int(np.argmax(decode_logits[-1]))}",
+                flush=True,
+            )
+
+            row_bytes = decode.nbytes("present_k_0")
+            cache_offset = sequence_length * row_bytes
+            for cache_name, cache_pointer in shared_cache.items():
+                present_name = cache_name.replace("cache_", "present_", 1)
+                check_cuda(
+                    cudart.cudaMemcpyAsync(
+                        cache_pointer + cache_offset,
+                        decode.buffers[present_name],
+                        row_bytes,
+                        device_to_device,
+                        stream,
+                    ),
+                    f"decode-to-cache copy {present_name}",
+                )
+            check_cuda(cudart.cudaStreamSynchronize(stream), "decode-to-cache sync")
+            print("[pure-trt] decode_to_cache=OK", flush=True)
+
+        # Mirror pipeline member teardown: state, prefill module, decode module.
+        clean = free_shared_cache(shared_cache)
+        clean = prefill.destroy() and clean
+        clean = decode.destroy() and clean
+        del runtime
+        gc.collect()
+        print("[pure-trt] runtime_destroyed", flush=True)
+        stream_status = cuda_status(cudart.cudaStreamDestroy(stream))
+        if stream_status != cuda_success():
+            clean = False
+            print(
+                f"[pure-trt] cudaStreamDestroy status={stream_status}",
+                file=sys.stderr,
+                flush=True,
+            )
+        if reproduced:
+            return 42
+        if clean:
+            print("[pure-trt] CLEAN_EXIT", flush=True)
+            return 0
+        return 10
+    except BaseException:
+        if shared_cache:
+            free_shared_cache(shared_cache)
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Pure TensorRT split-engine reproducer for issue #428"
+    )
+    parser.add_argument("--prefill-plan", type=Path, required=True)
+    parser.add_argument("--decode-plan", type=Path, required=True)
+    parser.add_argument("--cache-length", type=int, default=1741)
+    parser.add_argument(
+        "--token-ids",
+        type=parse_token_ids,
+        default=DEFAULT_TOKEN_IDS,
+        help='Comma-separated token IDs (default: Gemma encoding of "Hello")',
+    )
+    args = parser.parse_args()
+    return run(args.prefill_plan, args.decode_plan, args.token_ids, args.cache_length)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reproducers/issue_428_pure_trt/run_repro.sh
+++ b/reproducers/issue_428_pure_trt/run_repro.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+ulimit -c 0
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
+OUTPUT_DIR=${OUTPUT_DIR:-/tmp/trtmc-issue428-pure-trt}
+MODEL=${MODEL:-google/gemma-2-2b-it}
+CACHE_LENGTH=${CACHE_LENGTH:-1741}
+PYTHON=${PYTHON:-python3}
+SKIP_BUILD=0
+FORCE_BUILD=0
+EXPECT_FIXED=${EXPECT_FIXED:-0}
+
+usage() {
+    echo "Usage: $0 [--output-dir PATH] [--skip-build] [--force-build] [--expect-fixed]"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output-dir)
+            OUTPUT_DIR=$2
+            shift 2
+            ;;
+        --skip-build)
+            SKIP_BUILD=1
+            shift
+            ;;
+        --force-build)
+            FORCE_BUILD=1
+            shift
+            ;;
+        --expect-fixed)
+            EXPECT_FIXED=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+mkdir -p -- "${OUTPUT_DIR}"
+export PYTHONPATH="${REPO_ROOT}/python${PYTHONPATH:+:${PYTHONPATH}}"
+
+PREFIX="gemma-2-2b-c${CACHE_LENGTH}"
+PREFILL_PLAN="${OUTPUT_DIR}/${PREFIX}-prefill.plan"
+DECODE_PLAN="${OUTPUT_DIR}/${PREFIX}-decode.plan"
+BUILD_LOG="${OUTPUT_DIR}/build.log"
+INFER_LOG="${OUTPUT_DIR}/infer.log"
+
+echo "[one-click] repo=${REPO_ROOT}"
+echo "[one-click] output_dir=${OUTPUT_DIR}"
+echo "[one-click] model=${MODEL} cache_length=${CACHE_LENGTH}"
+
+"${PYTHON}" -c 'import tensorrt as trt; print(f"[one-click] TensorRT={trt.__version__}")'
+"${PYTHON}" -c 'from cuda.bindings import runtime as c; s,n=c.cudaGetDeviceCount(); print(f"[one-click] cuda_status={s} gpu_count={n}"); raise SystemExit(0 if int(s)==0 and n>0 else 2)'
+
+if [[ ${SKIP_BUILD} -eq 0 ]]; then
+    BUILD_ARGS=(
+        --model "${MODEL}"
+        --output-dir "${OUTPUT_DIR}"
+        --cache-length "${CACHE_LENGTH}"
+    )
+    if [[ ${FORCE_BUILD} -eq 1 ]]; then
+        BUILD_ARGS+=(--force)
+    fi
+    "${PYTHON}" "${SCRIPT_DIR}/build_plans.py" "${BUILD_ARGS[@]}" 2>&1 | tee "${BUILD_LOG}"
+fi
+
+if [[ ! -s "${PREFILL_PLAN}" || ! -s "${DECODE_PLAN}" ]]; then
+    echo "[one-click] SETUP_ERROR missing plan(s): ${PREFILL_PLAN} ${DECODE_PLAN}" >&2
+    exit 2
+fi
+
+set +e
+"${PYTHON}" "${SCRIPT_DIR}/infer_sequence.py" \
+    --prefill-plan "${PREFILL_PLAN}" \
+    --decode-plan "${DECODE_PLAN}" \
+    --cache-length "${CACHE_LENGTH}" \
+    2>&1 | tee "${INFER_LOG}"
+INFER_RC=${PIPESTATUS[0]}
+set -e
+
+REPRODUCED=0
+if grep -Eiq \
+    'ISSUE_428_REPRODUCED|CUDA (error|status)[^0-9]*700|illegal memory access|l2cm_layer_internal' \
+    "${INFER_LOG}"; then
+    REPRODUCED=1
+fi
+
+echo "[one-click] infer_rc=${INFER_RC} reproduced=${REPRODUCED} log=${INFER_LOG}"
+
+if [[ ${EXPECT_FIXED} -eq 1 ]]; then
+    if [[ ${INFER_RC} -eq 0 && ${REPRODUCED} -eq 0 ]]; then
+        echo "[one-click] FIX_VERIFIED"
+        exit 0
+    fi
+    echo "[one-click] FIX_NOT_VERIFIED"
+    exit 1
+fi
+
+if [[ ${REPRODUCED} -eq 1 ]]; then
+    echo "[one-click] ISSUE_428_REPRODUCED"
+    exit 0
+fi
+if [[ ${INFER_RC} -eq 0 ]]; then
+    echo "[one-click] ISSUE_428_NOT_REPRODUCED"
+    exit 1
+fi
+echo "[one-click] UNEXPECTED_INFER_FAILURE"
+exit 2


### PR DESCRIPTION
## Background

Issue #428 reproduces a TensorRT 11.2 / Myelin CUDA illegal-memory-access after generation. The existing path goes through `.trtfb`, task-eval, dataset preparation, tokenization, and the TRTMC C++ runtime, which makes the failure harder to hand to the TensorRT/Myelin owner.

## Exit Criteria

- Provide a one-command reproducer that builds standalone TensorRT plans and executes them without `.trtfb`, task-eval, datasets, or the TRTMC C++ runtime.
- Isolate the smallest observed failing boundary and emit an unambiguous reproduced/not-reproduced result.
- Support reusing existing plans and verifying a candidate fix.

## Implementation

- Build Gemma-2-2B FP16 prefill and decode plans directly from the TRTMC network definitions at cache length 1741.
- Execute the plans through the TensorRT Python API and CUDA runtime bindings using fixed token IDs for `Hello`.
- Copy the prefill K/V outputs into a shared cache, bind that cache to decode, and synchronize one decode step.
- Wrap build and inference in `run_repro.sh`, capture logs, classify CUDA/Myelin signatures, and provide an inverted `--expect-fixed` mode.
- Document the validated environment, expected output, storage requirement, and minimization controls.

## Validation

- `./run_repro.sh --output-dir /repro-output/from-source --force-build`: reproduced from a cold source build on GB300 with TensorRT 11.2.0.113. Prefill built in 120.1 s, decode built in 117.1 s, prefill sync returned 0, and decode sync returned CUDA 700. The wrapper printed `ISSUE_428_REPRODUCED` and returned 0.
- `./run_repro.sh --output-dir /repro-output/from-source --skip-build`: reproduced again using the saved standalone plans.
- `python3 infer_engine.py --plan ...prefill.plan`: passed the single-prefill-plan control with a clean teardown.
- `./run_repro.sh --output-dir /repro-output/from-source --skip-build --expect-fixed`: correctly printed `FIX_NOT_VERIFIED` and returned 1 on the affected runtime.
- `python3 tools/legal_headers.py --check`: passed.
- `ruff check reproducers/issue_428_pure_trt`: passed.
- `bash -n reproducers/issue_428_pure_trt/run_repro.sh`: passed.

## Notes For Future Readers

- Start with `reproducers/issue_428_pure_trt/README.md`, then review `infer_sequence.py` for the exact failing TensorRT boundary.
- The generated plans are about 6.4 GB each and are intentionally not checked in.
- Both individual plans execute cleanly. CUDA 700 appears when decode consumes the KV state produced by prefill.
- This PR adds a reproducer only; it does not change TensorRT graph generation or attempt the Myelin fix.
