### PR TITLE
ci: name model jobs and harden premerge proofs

### DIFF
--- a/.github/scripts/run-model-proof.sh
+++ b/.github/scripts/run-model-proof.sh
@@ -1809,8 +1809,11 @@ PY
   # Convert the cache evidence into a positive, proof-private view. Reflink
   # only the selected repositories into the job work directory so Transformers
   # can update cache metadata without writing to, or seeing, the persistent
-  # Hub. Requiring --reflink=always fails closed instead of silently turning
-  # the isolation step into a full byte-for-byte copy.
+  # Hub. The copy helper runs as root because cache files can legitimately be
+  # unreadable by the Actions account. It receives only the validated selected
+  # repository (read-only) and its empty private destination. Requiring
+  # --reflink=always fails closed instead of silently turning the isolation step
+  # into a full byte-for-byte copy.
   local hf_private_root="$work_dir/hf-private"
   local hf_private_hub="$hf_private_root/hub"
   local hf_cache_mounts="$work_dir/hf-cache-mounts.tsv"
@@ -1895,21 +1898,59 @@ PY
     die "selected Hugging Face cache evidence failed closed validation"
   fi
 
+  local runner_uid runner_gid
+  runner_uid="$(id -u)"
+  runner_gid="$(id -g)"
   local hf_repo_source hf_repo_folder
   local hf_cache_repository_count=0
   while IFS=$'\t' read -r hf_repo_source hf_repo_folder; do
     [ -n "$hf_repo_source" ] && [ -n "$hf_repo_folder" ] || \
       die "selected Hugging Face cache copy evidence is malformed"
-    [ ! -e "$hf_private_hub/$hf_repo_folder" ] || \
+    local hf_repo_destination="$hf_private_hub/$hf_repo_folder"
+    [ ! -e "$hf_repo_destination" ] || \
       die "selected Hugging Face cache copy destination already exists"
-    if ! cp -a --reflink=always -- \
-        "$hf_repo_source" "$hf_private_hub/$hf_repo_folder"; then
+    mkdir -m 0700 -- "$hf_repo_destination"
+
+    local cache_copy_container_name="${container_name}-hf-cache-copy-$hf_cache_repository_count"
+    proof_container_name="$cache_copy_container_name"
+    docker rm -f "$cache_copy_container_name" >/dev/null 2>&1 || true
+    local -a cache_copy_docker_args=(
+      run --rm
+      --name "$cache_copy_container_name"
+      --read-only
+      --network none
+      --cap-drop ALL
+      --cap-add DAC_OVERRIDE
+      --cap-add CHOWN
+      --security-opt no-new-privileges
+      --pids-limit 32
+      --user 0:0
+      --mount "type=bind,src=$hf_repo_source,dst=/selected-hf-repo,readonly"
+      --mount "type=bind,src=$hf_repo_destination,dst=/private-hf-repo"
+      --entrypoint /bin/bash
+    )
+    if ! docker "${cache_copy_docker_args[@]}" "$image" -ceu '
+runner_owner="$1:$2"
+return_destination() {
+  chmod -R u+rwX -- /private-hf-repo >/dev/null 2>&1 || true
+  chown -hR -- "$runner_owner" /private-hf-repo >/dev/null 2>&1 || true
+}
+trap return_destination EXIT
+chown 0:0 /private-hf-repo
+cp -a --reflink=always --no-preserve=ownership -- \
+  /selected-hf-repo/. /private-hf-repo/
+chmod -R u+rwX -- /private-hf-repo
+chown -hR -- "$runner_owner" /private-hf-repo
+trap - EXIT
+' -- "$runner_uid" "$runner_gid"; then
       die "selected Hugging Face cache repository could not be reflinked: $hf_repo_folder"
     fi
-    [ -d "$hf_private_hub/$hf_repo_folder" ] && \
-      [ ! -L "$hf_private_hub/$hf_repo_folder" ] || \
+    [ -d "$hf_repo_destination" ] && \
+      [ ! -L "$hf_repo_destination" ] || \
       die "selected Hugging Face cache reflink produced an invalid repository"
-    chmod -R u+rwX -- "$hf_private_hub/$hf_repo_folder" || \
+    [ "$(stat -c '%u:%g' "$hf_repo_destination")" = "$runner_uid:$runner_gid" ] || \
+      die "selected Hugging Face cache reflink did not return ownership to the runner"
+    chmod -R u+rwX -- "$hf_repo_destination" || \
       die "selected Hugging Face cache reflink could not be made writable"
     hf_cache_repository_count=$((hf_cache_repository_count + 1))
   done < "$hf_cache_mounts"

--- a/.github/workflows/model-proof.yml
+++ b/.github/workflows/model-proof.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   prove:
-    name: ${{ inputs.model }} / Build + reference test
+    name: ${{ inputs.model }}
     runs-on: ${{ fromJSON(vars.TRTMC_MODEL_RUNNER_LABELS || vars.TRTMC_RUNNER_LABELS || '["self-hosted"]') }}
     # Reserve time after the bounded image/proof steps for fallback generation
     # and artifact publication even when a model reaches its proof timeout.

--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -210,7 +210,7 @@ jobs:
         needs.impact.outputs.has_models == 'true'
       }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       max-parallel: 16
       matrix: ${{ fromJSON(needs.impact.outputs.matrix) }}
     permissions:

--- a/tests/e2e/models/bark/manifests/bark-small.json
+++ b/tests/e2e/models/bark/manifests/bark-small.json
@@ -6,6 +6,7 @@
   "runtime_strategy": "text_to_audio_bark",
   "task_strategy": "text_to_audio",
   "precision": "fp16",
+  "e2e_parallel_resource": "exclusive_gpu",
   "max_cache_length": 1024,
   "trust_remote_code": false,
   "testcases": [

--- a/tests/e2e/models/bark/test_bark_build_contract.py
+++ b/tests/e2e/models/bark/test_bark_build_contract.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Family-owned CI build contract tests for Bark."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_acceptance_build_reserves_gpu_for_stable_tactic_selection() -> None:
+    manifest_path = Path(__file__).parent / "manifests" / "bark-small.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["e2e_parallel_resource"] == "exclusive_gpu"

--- a/tests/e2e/models/qwen3_omni/e2e_plugins/runners/omni.py
+++ b/tests/e2e/models/qwen3_omni/e2e_plugins/runners/omni.py
@@ -24,6 +24,33 @@ from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_RUNTIME_TIMEOUT_S = 600
+_MAX_RUNTIME_TIMEOUT_S = 3600
+
+
+def _runtime_timeout_s(case: E2ECase) -> int:
+    """Return the model-owned runtime budget for this testcase."""
+    value = case.inputs.get("runtime_timeout_s", _DEFAULT_RUNTIME_TIMEOUT_S)
+    if (
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or value < 1
+        or value > _MAX_RUNTIME_TIMEOUT_S
+    ):
+        raise ValueError(
+            "runtime_timeout_s must be an integer from 1 to "
+            f"{_MAX_RUNTIME_TIMEOUT_S}; got {value!r}"
+        )
+    return value
+
+
+def _timeout_stream(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
 
 class OmniMultimodalRunner:
     """Execute TRT omni-multimodal inference via the C++ binary.
@@ -58,10 +85,33 @@ class OmniMultimodalRunner:
             env["LD_LIBRARY_PATH"] = ctx.ld_library_path
 
         logger.info("Running omni stage %s: %s", stage_name, " ".join(cmd))
+        timeout_s = _runtime_timeout_s(case)
         t0 = time.monotonic()
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, env=env, timeout=600,
-        )
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, env=env, timeout=timeout_s,
+            )
+        except subprocess.TimeoutExpired as exc:
+            elapsed = time.monotonic() - t0
+            stderr = _timeout_stream(exc.stderr)
+            if not stderr:
+                stderr = "No partial stderr was captured before timeout.\n"
+            truncated, log_path = save_full_stderr(
+                stderr,
+                ctx.artifacts_dir or "",
+                f"omni_{stage_name}_timeout",
+                case.name,
+            )
+            msg = (
+                f"Omni stage {stage_name} exceeded its model-owned runtime "
+                f"budget of {timeout_s}s after {elapsed:.1f}s; command: "
+                f"{' '.join(cmd)}"
+            )
+            if truncated:
+                msg += f"; partial stderr: {truncated.rstrip()}"
+            if log_path:
+                msg += f" (full partial stderr: {log_path})"
+            raise RuntimeError(msg) from exc
         elapsed = time.monotonic() - t0
 
         if result.returncode != 0:

--- a/tests/e2e/models/qwen3_omni/manifests/qwen3-omni-30b-a3b-instruct.json
+++ b/tests/e2e/models/qwen3_omni/manifests/qwen3-omni-30b-a3b-instruct.json
@@ -18,6 +18,9 @@
       "golden_snapshot_path": "data/qwen3_omni_hf_reference.json",
       "user_contract": "tts_audio",
       "prompt": "Please say hello from Qwen3 Omni in one short sentence.",
+      "inputs": {
+        "runtime_timeout_s": 900
+      },
       "max_new_tokens": 16,
       "seed": 42,
       "reference_speaker": "Ethan",

--- a/tests/e2e/models/qwen3_omni/test_qwen3_omni_runner.py
+++ b/tests/e2e/models/qwen3_omni/test_qwen3_omni_runner.py
@@ -6,9 +6,13 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
+
+import pytest
 
 from tests.e2e.models.qwen3_omni.e2e_plugins.runners import omni
 from tests.e2e_harness.contracts import E2ECase, RunContext, StageSpec
+from tests.e2e_harness.manifest_loader import load_model_manifest
 
 
 def _make_case(inputs: dict | None = None, **overrides) -> E2ECase:
@@ -44,6 +48,7 @@ def test_thinker_stage_drops_unsupported_stage_flag(monkeypatch, tmp_path) -> No
 
     def _fake_run(cmd, **kwargs):
         captured["cmd"] = cmd
+        captured["timeout"] = kwargs["timeout"]
         return subprocess.CompletedProcess(cmd, 0, stdout="hello back", stderr="")
 
     monkeypatch.setattr(omni.subprocess, "run", _fake_run)
@@ -54,6 +59,7 @@ def test_thinker_stage_drops_unsupported_stage_flag(monkeypatch, tmp_path) -> No
     cmd = captured["cmd"]
     assert cmd[1] == "run"
     assert "--stage" not in cmd
+    assert captured["timeout"] == 600
     assert out.metadata["cli_stage_supported"] is False
     assert out.metadata["entrypoint"] == "run"
 
@@ -81,6 +87,71 @@ def test_vision_stage_maps_to_embed_without_stage_flag(monkeypatch, tmp_path) ->
     assert "--stage" not in cmd
     assert out.metadata["entrypoint"] == "embed"
     assert out.data["embedding"] == [0.1, 0.2]
+
+
+def test_qwen3_omni_manifest_owns_extended_runtime_budget() -> None:
+    manifest_path = (
+        Path(__file__).parent
+        / "manifests"
+        / "qwen3-omni-30b-a3b-instruct.json"
+    )
+    model = load_model_manifest(manifest_path)
+
+    assert model.testcases[0].inputs["runtime_timeout_s"] == 900
+
+
+def test_omni_runner_uses_model_owned_runtime_budget(monkeypatch, tmp_path) -> None:
+    case = _make_case(
+        inputs={
+            "prompt": "hello",
+            "max_new_tokens": 7,
+            "runtime_timeout_s": 900,
+        }
+    )
+    ctx = _make_ctx(case, tmp_path)
+    captured: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["timeout"] = kwargs["timeout"]
+        return subprocess.CompletedProcess(cmd, 0, stdout="hello back", stderr="")
+
+    monkeypatch.setattr(omni.subprocess, "run", _fake_run)
+
+    omni.OmniMultimodalRunner().run_stage(
+        case, StageSpec(name="thinker_decode"), ctx)
+
+    assert captured["timeout"] == 900
+
+
+def test_omni_timeout_preserves_partial_stderr(monkeypatch, tmp_path) -> None:
+    case = _make_case(
+        inputs={
+            "prompt": "hello",
+            "runtime_timeout_s": 900,
+        }
+    )
+    ctx = _make_ctx(case, tmp_path)
+
+    def _timeout(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd,
+            kwargs["timeout"],
+            output=b"",
+            stderr=b'[trtmc.load_timing] label="omni thinker" still loading\n',
+        )
+
+    monkeypatch.setattr(omni.subprocess, "run", _timeout)
+
+    with pytest.raises(RuntimeError, match="model-owned runtime budget of 900s"):
+        omni.OmniMultimodalRunner().run_stage(
+            case, StageSpec(name="thinker_decode"), ctx)
+
+    timeout_log = (
+        tmp_path
+        / case.name
+        / "omni_thinker_decode_timeout_stderr.log"
+    )
+    assert "still loading" in timeout_log.read_text(encoding="utf-8")
 
 
 def test_composite_runner_uses_run_without_stage_flag(monkeypatch, tmp_path) -> None:

--- a/tests/e2e/models/timesfm/manifests/timesfm-2.0-500m-official.json
+++ b/tests/e2e/models/timesfm/manifests/timesfm-2.0-500m-official.json
@@ -5,6 +5,7 @@
   "family": "timesfm",
   "runtime_strategy": "timesfm_trt",
   "task_strategy": "neural_operator",
+  "e2e_parallel_resource": "exclusive_gpu",
   "precision": "fp16",
   "fp32_layers": [
     0,

--- a/tests/e2e/models/timesfm/test_timesfm_build_contract.py
+++ b/tests/e2e/models/timesfm/test_timesfm_build_contract.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Family-owned CI build contract tests for TimesFM."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_acceptance_build_reserves_gpu_for_stable_tactic_selection() -> None:
+    manifest_path = Path(__file__).parent / "manifests" / "timesfm-2.0-500m-official.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["e2e_parallel_resource"] == "exclusive_gpu"

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -197,6 +197,8 @@ def test_qwen_flashinfer_scripts_skip_pytest_collection() -> None:
 def test_github_workflows_keep_e2e_artifact_retention_aligned_with_ci_mode() -> None:
     proof = (REPO_ROOT / ".github/workflows/model-proof.yml").read_text()
     nightly = (REPO_ROOT / ".github" / "workflows" / "nightly.yml").read_text()
+    assert "    name: ${{ inputs.model }}\n" in proof
+    assert "Build + reference test" not in proof
     assert (
         "name: model-proof-${{ inputs.model }}-${{ inputs.revision }}-${{ github.run_attempt }}"
     ) in proof

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -357,7 +357,7 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     assert "needs.impact.outputs.has_models == 'true'" in model_proof
     assert "uses: ./.github/workflows/model-proof.yml" in model_proof
     assert "name: 3 / Model / ${{ matrix.model }}" in model_proof
-    assert "fail-fast: false" in model_proof
+    assert "fail-fast: true" in model_proof
     assert "max-parallel: 16" in model_proof
     assert "matrix: ${{ fromJSON(needs.impact.outputs.matrix) }}" in model_proof
     assert "model: ${{ matrix.model }}" in model_proof

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -456,6 +456,7 @@ def test_inner_proof_runs_the_exact_model_owned_python_test_selection() -> None:
         ("flux", "exclusive_gpu"),
         ("gpt2", "exclusive_gpu"),
         ("mixtral", "exclusive_gpu"),
+        ("timesfm", "exclusive_gpu"),
     ),
 )
 def test_selection_derives_the_most_restrictive_gpu_resource_class(

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -452,6 +452,7 @@ def test_inner_proof_runs_the_exact_model_owned_python_test_selection() -> None:
 @pytest.mark.parametrize(
     ("family", "expected_resource"),
     (
+        ("bark", "exclusive_gpu"),
         ("convbert", "shared"),
         ("flux", "exclusive_gpu"),
         ("gpt2", "exclusive_gpu"),

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -52,6 +52,33 @@ def _write_successful_fake_docker(tmp_path: Path) -> tuple[Path, Path]:
         "      fi\n"
         "      exit 0\n"
         "    fi\n"
+        '    if [[ " $* " == *"dst=/selected-hf-repo,readonly"* ]]; then\n'
+        '      if [ "${FAKE_REFLINK_EXIT_CODE:-0}" -ne 0 ]; then\n'
+        '        exit "$FAKE_REFLINK_EXIT_CODE"\n'
+        "      fi\n"
+        '      selected_repo=""\n'
+        '      private_repo=""\n'
+        '      for argument in "$@"; do\n'
+        '        case "$argument" in\n'
+        "          type=bind,src=*,dst=/selected-hf-repo,readonly)\n"
+        '            selected_repo="${argument#type=bind,src=}"\n'
+        '            selected_repo="${selected_repo%,dst=/selected-hf-repo,readonly}"\n'
+        "            ;;\n"
+        "          type=bind,src=*,dst=/private-hf-repo)\n"
+        '            private_repo="${argument#type=bind,src=}"\n'
+        '            private_repo="${private_repo%,dst=/private-hf-repo}"\n'
+        "            ;;\n"
+        "        esac\n"
+        "      done\n"
+        '      [ -n "$selected_repo" ] && [ -n "$private_repo" ] || exit 96\n'
+        '      if [ "${FAKE_UNREADABLE_REFLINK:-0}" = 1 ]; then\n'
+        "        printf '%s\\n' \"${FAKE_UNREADABLE_REFLINK_CONTENT:-private copy}\" > "
+        '"$private_repo/unreadable-cache-marker"\n'
+        "      else\n"
+        '        /bin/cp -a --reflink=always -- "$selected_repo/." "$private_repo/"\n'
+        "      fi\n"
+        "      exit 0\n"
+        "    fi\n"
         '    if [[ " $* " == *" --inner "* ]]; then\n'
         '      if [ -n "${FAKE_PROOF_RELEASE_FILE:-}" ]; then\n'
         "        deadline=$((SECONDS + 30))\n"
@@ -576,7 +603,7 @@ def test_runner_declares_the_hermetic_container_boundary() -> None:
     assert "-e HF_HOME=/work/hf-home" in proof
     assert "-e HF_MODULES_CACHE=/work/hf-modules" in proof
     assert "-e TRANSFORMERS_CACHE=/hf-cache/hub" in proof
-    assert "cp -a --reflink=always --" in text
+    assert "cp -a --reflink=always --no-preserve=ownership --" in text
     assert "chmod -R u+rwX --" in text
     assert "-e TRTMC_STORAGE_ROOT=/work/reference-private" in proof
     assert "TRTMC_MODEL_REFERENCE_CACHE_ROOT" not in proof
@@ -1105,7 +1132,42 @@ def test_host_cache_uses_full_hub_only_for_check_and_positive_view_for_proof() -
     assert "hf_repo_mount_args" not in host
     assert "src=$hf_hub_cache,dst=/hf-cache/hub" not in proof
     assert "dst=/hf-cache/modules" not in proof
-    assert "cp -a --reflink=always --" in host
+    assert "cp -a --reflink=always --no-preserve=ownership --" in host
+
+
+def test_selected_hf_cache_reflink_helper_has_a_minimal_mount_and_capability_boundary() -> None:
+    text = RUNNER.read_text(encoding="utf-8")
+    helper = text.split("local -a cache_copy_docker_args=(", maxsplit=1)[1].split(
+        "select_proof_gpu", maxsplit=1
+    )[0]
+
+    for contract in (
+        "--read-only",
+        "--network none",
+        "--cap-drop ALL",
+        "--cap-add DAC_OVERRIDE",
+        "--cap-add CHOWN",
+        "--security-opt no-new-privileges",
+        "--pids-limit 32",
+        "--user 0:0",
+        "type=bind,src=$hf_repo_source,dst=/selected-hf-repo,readonly",
+        "type=bind,src=$hf_repo_destination,dst=/private-hf-repo",
+        "--entrypoint /bin/bash",
+        "cp -a --reflink=always --no-preserve=ownership --",
+        'chown -hR -- "$runner_owner" /private-hf-repo',
+    ):
+        assert contract in helper
+    assert helper.count("--cap-add") == 2
+    assert "dst=/selected-hf-repo,readonly" in helper
+    assert "dst=/private-hf-repo,readonly" not in helper
+    assert "src=$hf_hub_cache" not in helper
+    assert "src=$hf_private_hub" not in helper
+    assert "src=$projection_dir" not in helper
+    assert "src=$artifacts_dir" not in helper
+    assert "--gpus" not in helper
+    assert "HF_TOKEN" not in helper
+    assert "/var/run/docker.sock" not in helper
+    assert "if ! cp -a" not in helper
 
 
 def test_sana_reference_cache_is_copied_to_selected_private_view(
@@ -1302,40 +1364,97 @@ def test_distinct_explicit_hf_cache_paths_reach_both_containers(
         for line in docker_log.read_text(encoding="utf-8").splitlines()
         if line.startswith("run ")
     ]
-    assert len(docker_runs) == 2
-    warm, proof = docker_runs
+    assert len(docker_runs) == 3
+    warm, cache_copy, proof = docker_runs
     assert f"--mount type=bind,src={hub_cache},dst=/hf-cache/hub,readonly" in warm
     assert f"src={modules_cache}" not in warm
+    assert f"--mount type=bind,src={selected_repo},dst=/selected-hf-repo,readonly" in cache_copy
+    private_repo = output / "work" / "hf-private" / "hub" / "models--fixture--model"
+    assert f"--mount type=bind,src={private_repo},dst=/private-hf-repo" in cache_copy
+    assert "--user 0:0" in cache_copy
+    assert "--cap-drop ALL --cap-add DAC_OVERRIDE --cap-add CHOWN" in cache_copy
+    assert "--network none" in cache_copy
+    assert f"src={hub_cache},dst=/hf-cache/hub" not in cache_copy
+    assert f"src={modules_cache}" not in cache_copy
     assert f"src={hub_cache},dst=/hf-cache/hub" not in proof
     assert f"src={selected_repo}" not in proof
     assert f"src={modules_cache}" not in proof
     private_hub = output / "work" / "hf-private" / "hub"
     assert f"--mount type=bind,src={private_hub},dst=/hf-cache/hub" in proof
     assert f"src={private_hub},dst=/hf-cache/hub,readonly" not in proof
-    private_repo = private_hub / "models--fixture--model"
     assert (private_repo / "selected-cache-marker").read_text(encoding="utf-8") == "selected\n"
     write_probe = private_repo / "test-write-probe"
     write_probe.write_text("writable\n", encoding="utf-8")
     assert write_probe.read_text(encoding="utf-8") == "writable\n"
 
 
+def test_selected_hf_cache_with_unreadable_file_is_delegated_to_root_helper(
+    tmp_path: Path,
+) -> None:
+    fake_bin, docker_log = _write_successful_fake_docker(tmp_path)
+    output = tmp_path / "proof"
+    env = _fake_proof_environment(tmp_path, fake_bin, docker_log, output)
+    selected_repo = tmp_path / "hf-cache" / "hub" / "models--fixture--model"
+    unreadable = selected_repo / "unreadable-cache-marker"
+    unreadable.write_text("persistent cache\n", encoding="utf-8")
+    unreadable.chmod(0)
+    assert not os.access(unreadable, os.R_OK)
+    env.update(
+        {
+            "FAKE_UNREADABLE_REFLINK": "1",
+            "FAKE_UNREADABLE_REFLINK_CONTENT": "private reflink",
+        }
+    )
+
+    try:
+        result = subprocess.run(
+            [
+                "bash",
+                str(RUNNER),
+                "--model",
+                "convbert",
+                "--revision",
+                "HEAD",
+                "--output-dir",
+                str(output),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        source_mode = unreadable.stat().st_mode & 0o777
+    finally:
+        unreadable.chmod(0o600)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert source_mode == 0
+    assert unreadable.read_text(encoding="utf-8") == "persistent cache\n"
+    private_repo = output / "work" / "hf-private" / "hub" / "models--fixture--model"
+    assert (private_repo / "unreadable-cache-marker").read_text(encoding="utf-8") == (
+        "private reflink\n"
+    )
+    docker_runs = [
+        line
+        for line in docker_log.read_text(encoding="utf-8").splitlines()
+        if line.startswith("run ")
+    ]
+    assert len(docker_runs) == 3
+    _warm, cache_copy, proof = docker_runs
+    assert f"--mount type=bind,src={selected_repo},dst=/selected-hf-repo,readonly" in cache_copy
+    assert "--user 0:0" in cache_copy
+    assert "--cap-add DAC_OVERRIDE" in cache_copy
+    assert f"src={selected_repo}" not in proof
+
+
 def test_selected_hf_cache_fails_closed_when_reflink_is_unavailable(
     tmp_path: Path,
 ) -> None:
     fake_bin, docker_log = _write_successful_fake_docker(tmp_path)
-    fake_cp = fake_bin / "cp"
-    fake_cp.write_text(
-        "#!/usr/bin/env bash\n"
-        "set -euo pipefail\n"
-        'printf \'%s\\n\' "$*" > "$FAKE_CP_LOG"\n'
-        "exit 73\n",
-        encoding="utf-8",
-    )
-    fake_cp.chmod(0o755)
     output = tmp_path / "proof"
     env = _fake_proof_environment(tmp_path, fake_bin, docker_log, output)
-    cp_log = tmp_path / "cp.log"
-    env["FAKE_CP_LOG"] = str(cp_log)
+    env["FAKE_REFLINK_EXIT_CODE"] = "73"
 
     result = subprocess.run(
         [
@@ -1357,14 +1476,15 @@ def test_selected_hf_cache_fails_closed_when_reflink_is_unavailable(
 
     assert result.returncode != 0
     assert "selected Hugging Face cache repository could not be reflinked" in result.stderr
-    assert cp_log.read_text(encoding="utf-8").startswith("-a --reflink=always -- ")
-    docker_runs = [
-        line
-        for line in docker_log.read_text(encoding="utf-8").splitlines()
-        if line.startswith("run ")
-    ]
-    assert len(docker_runs) == 1
+    docker_text = docker_log.read_text(encoding="utf-8")
+    assert "cp -a --reflink=always --no-preserve=ownership --" in docker_text
+    docker_runs = [line for line in docker_text.splitlines() if line.startswith("run ")]
+    assert len(docker_runs) == 2
     assert "warm_hf_cache.py" in docker_runs[0]
+    assert "dst=/selected-hf-repo,readonly" in docker_runs[1]
+    assert "dst=/private-hf-repo" in docker_runs[1]
+    assert "--cap-drop ALL --cap-add DAC_OVERRIDE --cap-add CHOWN" in docker_runs[1]
+    assert " --inner " not in f" {docker_text} "
 
 
 def test_selected_hf_cache_evidence_rejects_path_escape_before_proof(


### PR DESCRIPTION
## Background

The premerge matrix already carries each model identifier, but the reusable job's final display segment is the generic `Build + reference test`. GitHub's visualization graph emphasizes that final segment, making 77 model nodes difficult to distinguish.

Full-matrix validation also exposed three infrastructure-sensitive failures: shared-GPU tactic selection for TimesFM and Bark, protected Hugging Face cache files, and Qwen3-Omni runtime exceeding the generic 600-second budget after building its large bundle.

## Exit Criteria

- Every reusable model-proof node displays its actual model identifier.
- Isolation, one-engine-build enforcement, comparisons, and reporting remain strict.
- TimesFM and Bark build deterministically without changing acceptance thresholds.
- Qwen3-Omni receives a bounded model-owned runtime budget without changing output requirements.
- Runner-unreadable cache files can be copied without mutating or broadly exposing the persistent cache.
- A required-model failure immediately cancels sibling matrix work.

## Implementation

- Name the reusable proof job `${{ inputs.model }}` and test that the generic suffix cannot return.
- Give TimesFM and Bark an `exclusive_gpu` resource contract, with model-owned contract tests and proof-runner coverage.
- Enable matrix `fail-fast`.
- Reflink each validated selected Hugging Face repository through a root helper container. The helper has a read-only root filesystem, no network or GPU, no inherited capabilities, only `DAC_OVERRIDE` and `CHOWN`, and mounts only the selected repository plus its empty private destination. The persistent cache remains read-only and reflink failure remains fatal.
- Give the Qwen3-Omni testcase a 900-second runtime budget. Cases without an override retain the 600-second default; overrides are restricted to 1–3600 seconds. A timeout preserves partial stderr and reports the model-owned budget, stage, and command.

## Validation

- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_github_actions_ci.py -q`: 52 passed.
- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_model_proof_runner.py -q`: 71 passed.
- `PYTHONPATH=python:. python3 -m pytest tests/e2e/models/bark/test_bark_build_contract.py tests/e2e/models/timesfm/test_timesfm_build_contract.py -q`: 2 passed.
- `PYTHONPATH=python:. python3 -m pytest tests/e2e/models/qwen3_omni/test_qwen3_omni_runner.py tests/builder/test_manifest_validation.py -q`: 39 passed with 3 existing diagnostic warnings.
- `PYTHONPATH=python:. python3 -m pytest tests/e2e/models/qwen3_omni -q`: 22 passed, 1 skipped, 1 deselected.
- `python3 -m ruff check tests/e2e/models/bark/test_bark_build_contract.py tests/e2e/models/qwen3_omni/e2e_plugins/runners/omni.py tests/e2e/models/qwen3_omni/test_qwen3_omni_runner.py tests/e2e/models/timesfm/test_timesfm_build_contract.py tests/tools/test_github_actions_ci.py tests/tools/test_model_proof_runner.py`: passed.
- `bash -n .github/scripts/run-model-proof.sh`: passed.
- `git diff --check github/main...HEAD`: passed.

## Evidence

- TimesFM’s shared-GPU plans moved relative L2 from `0.00178` to `0.00648` against the unchanged `0.004` gate.
- Bark’s shared-GPU plans moved seeded ASR NED from `0.0189` to `0.1698` against the unchanged `0.15` gate. Source, build arguments, and reference audio were unchanged.
- GPT-2 failed before GPU acquisition because a selected mode-`0600` cache file was owned by `nobody:nogroup`; the restricted helper handles that case while leaving the source unchanged.
- Qwen3-Omni built its engine exactly once, then exceeded 600 seconds during inference. Previous passing executions took 355.5 and 487.75 seconds, including 327.2 and 454.94 seconds of bundle loading, supporting the model-local 900-second ceiling.
- Run `29057623769` demonstrated fail-fast behavior: after Qwen3-Omni failed, active sibling matrix work dropped to zero.

## Notes For Future Readers

Review the workflow naming and fail-fast wiring first, then the cache boundary, followed by the three model-owned resource/runtime contracts. The workflow edit conservatively selects all 77 models; selective model PRs remain limited to their affected ownership folders.
