### PR TITLE
test(ci): verify shared-runtime coverage

### DIFF
--- a/src/runtime/core/trt_common.cpp
+++ b/src/runtime/core/trt_common.cpp
@@ -5,6 +5,7 @@
 
 // trt_common.cpp — TensorRT logger/runtime helpers plus CUDA graph support.
 // CudaStream/CudaBuffer moved to cuda_common.cpp.
+// CI coverage experiment: shared runtime changes must select the fixed five-model fallback.
 
 #include "runtime/core/trt_common.h"
 


### PR DESCRIPTION
> [!CAUTION]
> CI COVERAGE EXPERIMENT — DO NOT MERGE.

## Background

This draft PR verifies the bounded fallback for a shared runtime change whose impact cannot be localized to one model.

## Exit Criteria

- Impact reports `mode=fallback`, `unit_scope=all`, and exactly five models.
- The graph runs CPU units plus `deepseek_v2`, `patchtsmixer`, `segformer`, `whisper`, and `ltx_video`.
- The five isolated proofs, combined HTML, and the required gate pass.

## Implementation

- Add one harmless comment to a shared TensorRT runtime file.

## Validation

- Current `model_ci.py impact`: all CPU units and exactly the configured five-model fallback.
- `git diff --check`: passed.

## Notes For Future Readers

- This PR is an experiment only and must not be merged.

## Observed Result

- This redundant probe was not retriggered after the selector merged.
- The same broad-impact route was proven by [run 29128399306](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29128399306): all CPU units and exactly the configured five-model fallback passed.
