### PR TITLE
test(ci): verify single-model coverage

### DIFF
--- a/python/tensorrt_model_connect/families/gpt2/MODEL.toml
+++ b/python/tensorrt_model_connect/families/gpt2/MODEL.toml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# CI coverage experiment: this Python ownership change must select only gpt2.
 id = "gpt2"
 plugin = "gpt2"
 module = "plugin"


### PR DESCRIPTION
> [!CAUTION]
> CI COVERAGE EXPERIMENT — DO NOT MERGE.

## Background

This draft PR verifies that a change inside one model-ownership root schedules only that model's isolated proof.

## Exit Criteria

- Impact reports `mode=models`, `unit_scope=none`, and only `gpt2`.
- The graph contains one model job named `gpt2`.
- The isolated GPT2 proof, combined HTML, and the required gate pass.

## Implementation

- Add a harmless comment to GPT2's Python ownership manifest.

## Validation

- Current `model_ci.py impact`: only `gpt2`; no unit job.
- TOML parsing and `git diff --check`: passed.

## Notes For Future Readers

- This PR is an experiment only and must not be merged.

## Observed Result

- [Run 29125973164](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29125973164) passed with only GPT2 selected.
- Units and the no-model path were skipped; GPT2 and the combined HTML report passed.
- The 53m15s total exposed GPU admission starvation; the fairness fix subsequently merged in PR #438.
