### PR TITLE
fix(ci): prevent GPU lease starvation

### DIFF
--- a/.github/scripts/run-model-proof.sh
+++ b/.github/scripts/run-model-proof.sh
@@ -18,6 +18,8 @@ proof_gpu_slots_per_gpu=""
 proof_gpu_reservation_fd=""
 proof_gpu_reservation_file=""
 proof_gpu_allocator_fd=""
+proof_gpu_admission_fd=""
+proof_gpu_admission_file=""
 declare -a proof_gpu_slot_ids=()
 declare -a proof_gpu_lease_fds=()
 declare -a proof_gpu_lease_files=()
@@ -34,6 +36,9 @@ die() {
 cleanup_proof_container() {
   local rc="$1"
   trap - EXIT INT TERM
+  # A queued proof owns no GPU yet, so let the next ticket advance before any
+  # potentially slow container teardown or fallback-report work.
+  release_gpu_admission_ticket
   if [ -n "$proof_container_name" ]; then
     docker rm -f "$proof_container_name" >/dev/null 2>&1 || true
   fi
@@ -67,6 +72,125 @@ release_proof_gpu_lease() {
     close_dynamic_fd "$proof_gpu_allocator_fd"
     proof_gpu_allocator_fd=""
   fi
+  release_gpu_admission_ticket
+}
+
+acquire_gpu_admission_ticket() {
+  local lock_dir="$1"
+  local scope="$2"
+  local deadline="$3"
+  [ -z "$proof_gpu_admission_fd" ] || return 0
+
+  local remaining=$((deadline - SECONDS))
+  [ "$remaining" -gt 0 ] || return 1
+  local enqueue_fd enqueue_file="$lock_dir/admission-$scope.enqueue.lock"
+  exec {enqueue_fd}>"$enqueue_file" || \
+    die "could not open GPU admission enqueue lock: $enqueue_file"
+  if ! flock -w "$remaining" -x "$enqueue_fd"; then
+    close_dynamic_fd "$enqueue_fd"
+    return 1
+  fi
+
+  local counter_file="$lock_dir/admission-$scope.next"
+  local counter_tmp="$counter_file.tmp.$$"
+  local counter=0
+  if [ -e "$counter_file" ]; then
+    IFS= read -r counter < "$counter_file" || \
+      die "could not read GPU admission counter: $counter_file"
+    [[ "$counter" =~ ^(0|[1-9][0-9]*)$ ]] || \
+      die "invalid GPU admission counter in: $counter_file"
+  fi
+  if [ "${#counter}" -gt 19 ] || \
+     { [ "${#counter}" -eq 19 ] && [[ "$counter" > "9000000000000000000" ]]; }; then
+    die "GPU admission counter exceeds the supported range in: $counter_file"
+  fi
+
+  local padded_counter ticket_file ticket_number
+  printf -v padded_counter '%020d' "$counter"
+  # Recover monotonically even if the counter file was lost after tickets were
+  # created. Gaps are harmless, but reusing a live ticket number is not.
+  for ticket_file in "$lock_dir"/"admission-$scope-"*.lock; do
+    [ -e "$ticket_file" ] || continue
+    ticket_number="${ticket_file##*/admission-$scope-}"
+    ticket_number="${ticket_number%.lock}"
+    [[ "$ticket_number" =~ ^[0-9]{20}$ ]] || \
+      die "invalid GPU admission ticket name: $ticket_file"
+    if [[ "$ticket_number" > "$padded_counter" ]]; then
+      padded_counter="$ticket_number"
+    fi
+  done
+  [[ "$padded_counter" < "09000000000000000000" ]] || \
+    die "GPU admission ticket sequence exhausted for scope: $scope"
+  counter=$((10#$padded_counter + 1))
+  printf '%s\n' "$counter" > "$counter_tmp" || \
+    die "could not update GPU admission counter: $counter_file"
+  mv -f -- "$counter_tmp" "$counter_file" || \
+    die "could not publish GPU admission counter: $counter_file"
+
+  local padded_ticket final_ticket
+  printf -v padded_ticket '%020d' "$counter"
+  final_ticket="$lock_dir/admission-$scope-$padded_ticket.lock"
+  proof_gpu_admission_file="$final_ticket.tmp.$$"
+  (set -o noclobber; : > "$proof_gpu_admission_file") 2>/dev/null || \
+    die "could not create GPU admission ticket: $proof_gpu_admission_file"
+  exec {proof_gpu_admission_fd}<>"$proof_gpu_admission_file" || \
+    die "could not open GPU admission ticket: $proof_gpu_admission_file"
+  flock -n -x "$proof_gpu_admission_fd" || \
+    die "could not lock new GPU admission ticket: $proof_gpu_admission_file"
+  printf 'pid=%s model=%s resource_class=%s queue_scope=%s\n' \
+    "$$" "$model" "$proof_gpu_resource_class" "$scope" >&"$proof_gpu_admission_fd"
+  ln -- "$proof_gpu_admission_file" "$final_ticket" || \
+    die "could not publish GPU admission ticket: $final_ticket"
+  rm -f -- "$proof_gpu_admission_file" || \
+    die "could not remove temporary GPU admission ticket: $proof_gpu_admission_file"
+  proof_gpu_admission_file="$final_ticket"
+  flock -u "$enqueue_fd" >/dev/null 2>&1 || true
+  close_dynamic_fd "$enqueue_fd"
+}
+
+gpu_admission_ticket_has_turn() {
+  local lock_dir="$1"
+  local scope="$2"
+  local ticket_file ticket_fd
+  acquire_gpu_allocator_mutex "$lock_dir" || return 1
+  for ticket_file in "$lock_dir"/"admission-$scope-"*.lock; do
+    [ -e "$ticket_file" ] || continue
+    if [ "$ticket_file" = "$proof_gpu_admission_file" ]; then
+      release_gpu_allocator_mutex
+      return 0
+    fi
+    if ! exec {ticket_fd}<"$ticket_file"; then
+      continue
+    fi
+    if flock -n -x "$ticket_fd"; then
+      if ! rm -f -- "$ticket_file"; then
+        flock -u "$ticket_fd" >/dev/null 2>&1 || true
+        close_dynamic_fd "$ticket_fd"
+        release_gpu_allocator_mutex
+        die "could not prune stale GPU admission ticket: $ticket_file"
+      fi
+      flock -u "$ticket_fd" >/dev/null 2>&1 || true
+      close_dynamic_fd "$ticket_fd"
+      continue
+    fi
+    close_dynamic_fd "$ticket_fd"
+    release_gpu_allocator_mutex
+    return 1
+  done
+  release_gpu_allocator_mutex
+  die "GPU admission ticket disappeared before service: $proof_gpu_admission_file"
+}
+
+release_gpu_admission_ticket() {
+  if [ -n "$proof_gpu_admission_file" ]; then
+    rm -f -- "$proof_gpu_admission_file" || true
+  fi
+  if [ -n "$proof_gpu_admission_fd" ]; then
+    flock -u "$proof_gpu_admission_fd" >/dev/null 2>&1 || true
+    close_dynamic_fd "$proof_gpu_admission_fd"
+  fi
+  proof_gpu_admission_fd=""
+  proof_gpu_admission_file=""
 }
 
 usage() {
@@ -347,6 +471,25 @@ select_proof_gpu() {
 
   local deadline=$((SECONDS + timeout))
   local attempted=0 reserve_rc=0
+  local admission_scope="global"
+  # Register once in a monotonic queue. Every retry then retains its position
+  # instead of entering a new race in which younger matrix jobs can repeatedly
+  # overtake an older waiter as GPU capacity becomes available.
+  while ! acquire_gpu_admission_ticket "$lock_dir" "$admission_scope" "$deadline"; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      die "timed out after ${timeout}s waiting for a ${resource_class} model-proof GPU lease from: ${candidate_gpu_ids[*]}"
+    fi
+    sleep 1
+  done
+  while ! gpu_admission_ticket_has_turn "$lock_dir" "$admission_scope"; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      die "timed out after ${timeout}s waiting for a ${resource_class} model-proof GPU lease from: ${candidate_gpu_ids[*]}"
+    fi
+    sleep 1
+  done
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    die "timed out after ${timeout}s waiting for a ${resource_class} model-proof GPU lease from: ${candidate_gpu_ids[*]}"
+  fi
   while true; do
     if [ "$attempted" -eq 1 ] && [ "$SECONDS" -ge "$deadline" ]; then
       die "timed out after ${timeout}s waiting for a ${resource_class} model-proof GPU lease from: ${candidate_gpu_ids[*]}"
@@ -356,6 +499,7 @@ select_proof_gpu() {
     if [ "$resource_class" = "shared" ]; then
       if try_acquire_shared_gpu_slot \
           "$lock_dir" "$slots_per_gpu" "$explicit_slot" "${candidate_gpu_ids[@]}"; then
+        release_gpu_admission_ticket
         echo "Leased shared model-proof GPU $proof_gpu_id slot ${proof_gpu_slot_ids[0]} via ${proof_gpu_lease_files[0]}"
         return 0
       fi
@@ -370,8 +514,11 @@ select_proof_gpu() {
       reserve_rc=$?
       set -e
       if [ "$reserve_rc" -eq 0 ]; then
+        release_gpu_admission_ticket
         echo "Leased exclusive model-proof GPU $proof_gpu_id slots ${proof_gpu_slot_ids[*]}"
         return 0
+      elif [ "$reserve_rc" -eq 2 ]; then
+        release_gpu_admission_ticket
       fi
     fi
     sleep 1

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -225,7 +225,7 @@ def _gpu_lease(output: Path) -> dict:
 
 def _lock_is_busy(path: Path) -> bool:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as stream:
+    with path.open("a+", encoding="utf-8") as stream:
         try:
             fcntl.flock(stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError:
@@ -1991,6 +1991,48 @@ def test_fifth_shared_proof_times_out_when_all_four_slots_are_busy(
     assert result.returncode != 0
     assert "timed out after 1s waiting for a shared model-proof GPU lease from: 9" in result.stderr
     assert not _proof_gpu_ids_if_present(docker_log)
+    assert not list(lock_dir.glob("admission-global-*.lock"))
+
+
+def test_gpu_admission_queue_prunes_a_stale_ticket(tmp_path: Path) -> None:
+    fake_bin, docker_log = _write_successful_fake_docker(tmp_path)
+    output = tmp_path / "proof"
+    env = _fake_proof_environment(tmp_path, fake_bin, docker_log, output)
+    env.update(
+        {
+            "TRTMC_GPU_ID": "9",
+            "TRTMC_MODEL_PROOF_GPU_IDS": "9",
+            "TRTMC_MODEL_PROOF_SLOTS_PER_GPU": "1",
+        }
+    )
+    lock_dir = tmp_path / "gpu-locks"
+    lock_dir.mkdir()
+    stale_ticket = lock_dir / "admission-global-00000000000000000001.lock"
+    stale_ticket.write_text("pid=999999 model=stale\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(RUNNER),
+            "--model",
+            "convbert",
+            "--revision",
+            "HEAD",
+            "--output-dir",
+            str(output),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not stale_ticket.exists()
+    assert not list(lock_dir.glob("admission-global-*.lock"))
+    assert (lock_dir / "admission-global.next").read_text(encoding="utf-8") == "2\n"
+    assert _proof_gpu_ids(docker_log) == ["9"]
 
 
 @pytest.mark.model_proof_allocator
@@ -2195,6 +2237,174 @@ def test_exclusive_gpu_reservation_drains_existing_shared_and_blocks_new_shared(
             exclusive.communicate(timeout=10)
 
 
+def test_gpu_admission_ticket_queue_prevents_younger_requests_overtaking_shared_waiter(
+    tmp_path: Path,
+) -> None:
+    lock_dir = tmp_path / "gpu-locks"
+    common_env = {
+        "TRTMC_GPU_ID": "6",
+        "TRTMC_MODEL_PROOF_GPU_IDS": "6",
+        "TRTMC_MODEL_PROOF_SLOTS_PER_GPU": "1",
+        "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS": "15",
+    }
+
+    def start_case(
+        name: str, model: str, release_file: Path
+    ) -> tuple[subprocess.Popen[str], Path, Path]:
+        case_dir = tmp_path / name
+        case_dir.mkdir()
+        fake_bin, docker_log = _write_successful_fake_docker(case_dir)
+        output = case_dir / "proof"
+        env = _fake_proof_environment(tmp_path, fake_bin, docker_log, output)
+        env.update(common_env)
+        env["FAKE_PROOF_RELEASE_FILE"] = str(release_file)
+        process = subprocess.Popen(
+            [
+                "bash",
+                str(RUNNER),
+                "--model",
+                model,
+                "--revision",
+                "HEAD",
+                "--output-dir",
+                str(output),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        return process, docker_log, output
+
+    first_release = tmp_path / "release-first-exclusive"
+    oldest_release = tmp_path / "release-oldest-shared"
+    younger_shared_release = tmp_path / "release-younger-shared"
+    younger_exclusive_release = tmp_path / "release-younger-exclusive"
+    first, _, first_output = start_case("first-exclusive", "flux", first_release)
+    oldest: subprocess.Popen[str] | None = None
+    younger_shared: subprocess.Popen[str] | None = None
+    younger_exclusive: subprocess.Popen[str] | None = None
+    try:
+        deadline = time.monotonic() + 30
+        while (
+            time.monotonic() < deadline
+            and not (first_output / "artifacts" / "gpu-lease.json").is_file()
+        ):
+            time.sleep(0.05)
+        assert (first_output / "artifacts" / "gpu-lease.json").is_file()
+
+        oldest, _, oldest_output = start_case("oldest-shared", "m2m_100", oldest_release)
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline and not list(
+            lock_dir.glob("admission-global-*.lock")
+        ):
+            time.sleep(0.05)
+        admission_tickets = sorted(lock_dir.glob("admission-global-*.lock"))
+        assert len(admission_tickets) == 1
+        assert "model=m2m_100" in admission_tickets[0].read_text(encoding="utf-8")
+        assert _lock_is_busy(admission_tickets[0])
+
+        younger_exclusive, _, younger_exclusive_output = start_case(
+            "younger-exclusive", "bark", younger_exclusive_release
+        )
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            admission_tickets = sorted(lock_dir.glob("admission-global-*.lock"))
+            if len(admission_tickets) == 2 and all(
+                ticket.stat().st_size > 0 for ticket in admission_tickets
+            ):
+                break
+            time.sleep(0.05)
+        younger_shared, _, younger_shared_output = start_case(
+            "younger-shared", "convbert", younger_shared_release
+        )
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            admission_tickets = sorted(lock_dir.glob("admission-global-*.lock"))
+            if len(admission_tickets) == 3 and all(
+                ticket.stat().st_size > 0 for ticket in admission_tickets
+            ):
+                break
+            time.sleep(0.05)
+        admission_tickets = sorted(lock_dir.glob("admission-global-*.lock"))
+        assert len(admission_tickets) == 3
+        assert [
+            ticket.read_text(encoding="utf-8").split("model=", maxsplit=1)[1].split()[0]
+            for ticket in admission_tickets
+        ] == ["m2m_100", "bark", "convbert"]
+
+        first_release.touch()
+        deadline = time.monotonic() + 30
+        while (
+            time.monotonic() < deadline
+            and not (oldest_output / "artifacts" / "gpu-lease.json").is_file()
+            and not (
+                younger_exclusive_output / "artifacts" / "gpu-lease.json"
+            ).is_file()
+            and not (younger_shared_output / "artifacts" / "gpu-lease.json").is_file()
+        ):
+            time.sleep(0.05)
+
+        assert (oldest_output / "artifacts" / "gpu-lease.json").is_file()
+        assert not (
+            younger_exclusive_output / "artifacts" / "gpu-lease.json"
+        ).exists()
+        assert not (younger_shared_output / "artifacts" / "gpu-lease.json").exists()
+        assert _gpu_lease(oldest_output)["resource_class"] == "shared"
+
+        oldest_release.touch()
+        deadline = time.monotonic() + 30
+        while (
+            time.monotonic() < deadline
+            and not (younger_exclusive_output / "artifacts" / "gpu-lease.json").is_file()
+        ):
+            time.sleep(0.05)
+        assert (younger_exclusive_output / "artifacts" / "gpu-lease.json").is_file()
+        assert not (younger_shared_output / "artifacts" / "gpu-lease.json").exists()
+        assert _gpu_lease(younger_exclusive_output)["resource_class"] == "exclusive_gpu"
+
+        younger_exclusive_release.touch()
+        deadline = time.monotonic() + 30
+        while (
+            time.monotonic() < deadline
+            and not (younger_shared_output / "artifacts" / "gpu-lease.json").is_file()
+        ):
+            time.sleep(0.05)
+        assert (younger_shared_output / "artifacts" / "gpu-lease.json").is_file()
+        assert _gpu_lease(younger_shared_output)["resource_class"] == "shared"
+        younger_shared_release.touch()
+
+        first_stdout, first_stderr = first.communicate(timeout=30)
+        assert first.returncode == 0, first_stdout + first_stderr
+        oldest_stdout, oldest_stderr = oldest.communicate(timeout=30)
+        assert oldest.returncode == 0, oldest_stdout + oldest_stderr
+        younger_shared_stdout, younger_shared_stderr = younger_shared.communicate(timeout=30)
+        assert younger_shared.returncode == 0, younger_shared_stdout + younger_shared_stderr
+        younger_exclusive_stdout, younger_exclusive_stderr = younger_exclusive.communicate(
+            timeout=30
+        )
+        assert younger_exclusive.returncode == 0, (
+            younger_exclusive_stdout + younger_exclusive_stderr
+        )
+        assert not list(lock_dir.glob("admission-global-*.lock"))
+    finally:
+        for release_file in (
+            first_release,
+            oldest_release,
+            younger_shared_release,
+            younger_exclusive_release,
+        ):
+            release_file.touch()
+        for process in (first, oldest, younger_shared, younger_exclusive):
+            if process is not None and process.poll() is None:
+                try:
+                    process.communicate(timeout=30)
+                except subprocess.TimeoutExpired:
+                    process.terminate()
+                    process.communicate(timeout=10)
+
+
 def _proof_gpu_ids_if_present(docker_log: Path) -> list[str]:
     if not docker_log.is_file():
         return []
@@ -2239,4 +2449,8 @@ def test_gpu_mapping_exists_only_on_the_hermetic_proof_container() -> None:
     assert (
         "TRTMC_MODEL_PROOF_GPU_IDS: ${{ vars.TRTMC_MODEL_PROOF_GPU_IDS || '0,1,2,3' }}" in workflow
     )
-    assert "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS:" in workflow
+    assert (
+        "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS: "
+        "${{ vars.TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS || '3600' }}"
+        in workflow
+    )

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -2247,7 +2247,10 @@ def test_gpu_admission_ticket_queue_prevents_younger_requests_overtaking_shared_
         "TRTMC_GPU_ID": "6",
         "TRTMC_MODEL_PROOF_GPU_IDS": "6",
         "TRTMC_MODEL_PROOF_SLOTS_PER_GPU": "1",
-        "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS": "15",
+        # This test deliberately holds several waiters while it observes their
+        # ordering.  The lease timeout must outlive the coordinated setup;
+        # otherwise an older ticket can expire before the last waiter starts.
+        "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS": "180",
     }
 
     def start_case(
@@ -2318,6 +2321,12 @@ def test_gpu_admission_ticket_queue_prevents_younger_requests_overtaking_shared_
             ):
                 break
             time.sleep(0.05)
+        admission_tickets = sorted(lock_dir.glob("admission-global-*.lock"))
+        assert len(admission_tickets) == 2
+        assert [
+            ticket.read_text(encoding="utf-8").split("model=", maxsplit=1)[1].split()[0]
+            for ticket in admission_tickets
+        ] == ["m2m_100", "bark"]
         younger_shared, _, younger_shared_output = start_case(
             "younger-shared", "convbert", younger_shared_release
         )

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -1994,6 +1994,7 @@ def test_fifth_shared_proof_times_out_when_all_four_slots_are_busy(
     assert not list(lock_dir.glob("admission-global-*.lock"))
 
 
+@pytest.mark.model_proof_allocator
 def test_gpu_admission_queue_prunes_a_stale_ticket(tmp_path: Path) -> None:
     fake_bin, docker_log = _write_successful_fake_docker(tmp_path)
     output = tmp_path / "proof"
@@ -2237,6 +2238,7 @@ def test_exclusive_gpu_reservation_drains_existing_shared_and_blocks_new_shared(
             exclusive.communicate(timeout=10)
 
 
+@pytest.mark.model_proof_allocator
 def test_gpu_admission_ticket_queue_prevents_younger_requests_overtaking_shared_waiter(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Background

Model-proof jobs currently poll GPU slot locks independently. Under contention, a younger job can win the next released slot repeatedly, starving an older small-PR proof. Live run `29125973164` demonstrated this when GPT2 was overtaken by younger jobs from run `29124681054`.

## Exit Criteria

- GPU admission is deterministic and oldest-first across shared and exclusive requests.
- Dead or canceled waiters cannot block the queue.
- Lease timeout and cleanup behavior remain fail closed.

## Implementation

- Add a monotonic, lock-backed global admission ticket before GPU slot acquisition.
- Prune stale unlocked tickets and release tickets on success, timeout, cancellation, or teardown.
- Preserve the existing shared-slot and exclusive-GPU lease implementation after admission.

## Validation

- `PYTHONPATH=python:. python -m pytest tests/tools/test_model_proof_runner.py -q -x -p no:cacheprovider`: 73 passed.
- The serialized allocator suite passed: 7 passed, 66 deselected.
- Parallel-phase collection selects 66/73 tests and excludes both admission tests.
- `bash -n .github/scripts/run-model-proof.sh`: passed.
- `git diff --check github/main...HEAD`: passed.

## Notes For Future Readers

- This prevents overtaking and starvation; it does not reserve GPUs or prioritize one workflow over another.
- The first rebased CI run exposed the new admission tests running in parallel; commit `e92e683b` moves them into the deterministic allocator phase.
- The second run exposed a contradictory 15-second lease timeout inside a multi-waiter test whose setup windows were longer; commit `7f668b20` keeps tickets alive through the coordinated assertions.
- Review the admission lifecycle in `run-model-proof.sh` before the allocator tests.
