### PR TITLE
fix(vision): make model plugins own preprocessing

### DIFF
--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -404,6 +404,8 @@ class IPipeline {
     }
 
     // -- Segmentation --
+    // Image pixels are RGB HWC float values in [0, 1]. The owning model family
+    // applies its bundle-defined resize, normalization, and layout transform.
     virtual SegmentResult segment(const float* pixels, int32_t height, int32_t width) {
         (void)pixels;
         (void)height;
@@ -438,6 +440,8 @@ class IPipeline {
     }
 
     // -- Image classification --
+    // Image pixels are RGB HWC float values in [0, 1]. The owning model family
+    // applies its bundle-defined resize, crop, normalization, and layout transform.
     virtual ClassificationResult classify(const float* pixels, int32_t height, int32_t width) {
         (void)pixels;
         (void)height;

--- a/python/tensorrt_model_connect/families/timm_vit/plugin.py
+++ b/python/tensorrt_model_connect/families/timm_vit/plugin.py
@@ -474,6 +474,7 @@ class TimmVitPlugin:
             "image_mean": mean,
             "image_std": std,
             "crop_pct": float(config.raw.get("crop_pct", 0.9)),
+            "interpolation": str(config.raw.get("interpolation", "bicubic")),
         }
 
 

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -28,7 +28,6 @@
 //   trtmc version
 
 #include "cli/args.h"
-#include "stb_image_resize2.h"
 #include "stb_image_write.h"
 #include "trtmc/bundle.h"
 #include "trtmc/config/cli_support.h"
@@ -770,40 +769,12 @@ int cmd_segment(const CliArgs& args) {
         return EXIT_FAILURE;
     }
 
-    // Preprocess: resize to 512x512, normalize with ImageNet mean/std, convert to CHW
-    const int32_t target_h = 512;
-    const int32_t target_w = 512;
-    const float mean[3] = {0.485F, 0.456F, 0.406F};
-    const float stdv[3] = {0.229F, 0.224F, 0.225F};
-
-    std::vector<float> resized_pixels(static_cast<std::size_t>(3) * target_h * target_w);
-    if (stbir_resize(image.pixels.data(), image.width, image.height,
-                     image.width * 3 * static_cast<int32_t>(sizeof(float)), resized_pixels.data(),
-                     target_w, target_h, target_w * 3 * static_cast<int32_t>(sizeof(float)),
-                     STBIR_RGB, STBIR_TYPE_FLOAT, STBIR_EDGE_CLAMP,
-                     STBIR_FILTER_TRIANGLE) == nullptr) {
-        std::cerr << "Error: failed to resize segmentation image\n";
-        return EXIT_FAILURE;
-    }
-
-    std::vector<float> chw_pixels(static_cast<std::size_t>(3) * target_h * target_w);
-    for (int32_t y = 0; y < target_h; ++y) {
-        for (int32_t x = 0; x < target_w; ++x) {
-            const auto src_idx = static_cast<std::size_t>((y * target_w + x) * 3);
-            for (int32_t c = 0; c < 3; ++c) {
-                const float val = (resized_pixels[src_idx + c] - mean[c]) / stdv[c];
-                chw_pixels[static_cast<std::size_t>(c) * target_h * target_w +
-                           static_cast<std::size_t>(y) * target_w + x] = val;
-            }
-        }
-    }
-
-    auto result = pipeline->segment(chw_pixels.data(), target_h, target_w);
+    auto result = pipeline->segment(image.pixels.data(), image.height, image.width);
 
     // Save class map as grayscale PNG (pixel value = class index)
     const std::string out_path = args.output_dir.empty() ? "/tmp/seg_output.png" : args.output_dir;
-    const int32_t out_h = result.height > 0 ? result.height : target_h;
-    const int32_t out_w = result.width > 0 ? result.width : target_w;
+    const int32_t out_h = result.height > 0 ? result.height : image.height;
+    const int32_t out_w = result.width > 0 ? result.width : image.width;
     const auto total_px = static_cast<std::size_t>(out_h) * out_w;
     std::vector<unsigned char> gray(total_px);
     for (std::size_t i = 0; i < total_px && i < result.mask.size(); ++i)
@@ -816,52 +787,6 @@ int cmd_segment(const CliArgs& args) {
 
     std::cout << "Segmentation saved: " << out_path << " (" << out_w << "x" << out_h << ")\n";
     return EXIT_SUCCESS;
-}
-
-std::vector<float> preprocess_classification_image(const trtmc::io::LoadedImage& image) {
-    constexpr int32_t target = 224;
-    constexpr float crop_pct = 0.9F;
-    const int32_t resize_short = static_cast<int32_t>(static_cast<float>(target) / crop_pct + 0.5F);
-    const float mean[3] = {0.5F, 0.5F, 0.5F};
-    const float stdv[3] = {0.5F, 0.5F, 0.5F};
-
-    int32_t resized_h = resize_short;
-    int32_t resized_w = resize_short;
-    if (image.height <= image.width) {
-        resized_h = resize_short;
-        resized_w =
-            std::max(1, static_cast<int32_t>(
-                            static_cast<float>(image.width) * resize_short / image.height + 0.5F));
-    } else {
-        resized_w = resize_short;
-        resized_h =
-            std::max(1, static_cast<int32_t>(
-                            static_cast<float>(image.height) * resize_short / image.width + 0.5F));
-    }
-
-    const int32_t crop_y = std::max(0, (resized_h - target) / 2);
-    const int32_t crop_x = std::max(0, (resized_w - target) / 2);
-    std::vector<float> chw(static_cast<std::size_t>(3) * target * target);
-
-    for (int32_t y = 0; y < target; ++y) {
-        const int32_t ry = crop_y + y;
-        const int32_t src_y =
-            std::min(image.height - 1,
-                     static_cast<int32_t>(static_cast<float>(ry) * image.height / resized_h));
-        for (int32_t x = 0; x < target; ++x) {
-            const int32_t rx = crop_x + x;
-            const int32_t src_x =
-                std::min(image.width - 1,
-                         static_cast<int32_t>(static_cast<float>(rx) * image.width / resized_w));
-            const auto src_idx = static_cast<std::size_t>((src_y * image.width + src_x) * 3);
-            for (int32_t c = 0; c < 3; ++c) {
-                const float val = (image.pixels[src_idx + c] - mean[c]) / stdv[c];
-                chw[static_cast<std::size_t>(c) * target * target +
-                    static_cast<std::size_t>(y) * target + x] = val;
-            }
-        }
-    }
-    return chw;
 }
 
 int cmd_classify(const CliArgs& args) {
@@ -877,21 +802,18 @@ int cmd_classify(const CliArgs& args) {
         return EXIT_FAILURE;
     }
 
-    auto chw_pixels = preprocess_classification_image(image);
-    constexpr int32_t target = 224;
-
     trtmc::ClassificationResult result;
     if (args.benchmark > 0) {
         const int warmup_n = std::max(0, args.warmup);
         const int bench_n = args.benchmark;
         for (int i = 0; i < warmup_n; ++i)
-            result = pipeline->classify(chw_pixels.data(), target, target);
+            result = pipeline->classify(image.pixels.data(), image.height, image.width);
 
         std::vector<double> times;
         times.reserve(static_cast<std::size_t>(bench_n));
         for (int i = 0; i < bench_n; ++i) {
             const auto t0 = std::chrono::steady_clock::now();
-            result = pipeline->classify(chw_pixels.data(), target, target);
+            result = pipeline->classify(image.pixels.data(), image.height, image.width);
             const auto t1 = std::chrono::steady_clock::now();
             times.push_back(std::chrono::duration<double, std::milli>(t1 - t0).count());
         }
@@ -900,7 +822,7 @@ int cmd_classify(const CliArgs& args) {
         std::cerr << std::fixed << std::setprecision(6) << "[trtmc.benchmark] classify_ms=" << mean
                   << " iterations=" << bench_n << " warmup=" << warmup_n << '\n';
     } else {
-        result = pipeline->classify(chw_pixels.data(), target, target);
+        result = pipeline->classify(image.pixels.data(), image.height, image.width);
     }
 
     std::cout << "{"

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -28,6 +28,7 @@
 //   trtmc version
 
 #include "cli/args.h"
+#include "stb_image_resize2.h"
 #include "stb_image_write.h"
 #include "trtmc/bundle.h"
 #include "trtmc/config/cli_support.h"
@@ -775,19 +776,22 @@ int cmd_segment(const CliArgs& args) {
     const float mean[3] = {0.485F, 0.456F, 0.406F};
     const float stdv[3] = {0.229F, 0.224F, 0.225F};
 
+    std::vector<float> resized_pixels(static_cast<std::size_t>(3) * target_h * target_w);
+    if (stbir_resize(image.pixels.data(), image.width, image.height,
+                     image.width * 3 * static_cast<int32_t>(sizeof(float)), resized_pixels.data(),
+                     target_w, target_h, target_w * 3 * static_cast<int32_t>(sizeof(float)),
+                     STBIR_RGB, STBIR_TYPE_FLOAT, STBIR_EDGE_CLAMP,
+                     STBIR_FILTER_TRIANGLE) == nullptr) {
+        std::cerr << "Error: failed to resize segmentation image\n";
+        return EXIT_FAILURE;
+    }
+
     std::vector<float> chw_pixels(static_cast<std::size_t>(3) * target_h * target_w);
     for (int32_t y = 0; y < target_h; ++y) {
         for (int32_t x = 0; x < target_w; ++x) {
-            // Bilinear-ish nearest-neighbor resize
-            const int32_t src_y =
-                std::min(static_cast<int32_t>(static_cast<float>(y) * image.height / target_h),
-                         image.height - 1);
-            const int32_t src_x =
-                std::min(static_cast<int32_t>(static_cast<float>(x) * image.width / target_w),
-                         image.width - 1);
-            const auto src_idx = static_cast<std::size_t>((src_y * image.width + src_x) * 3);
+            const auto src_idx = static_cast<std::size_t>((y * target_w + x) * 3);
             for (int32_t c = 0; c < 3; ++c) {
-                const float val = (image.pixels[src_idx + c] - mean[c]) / stdv[c];
+                const float val = (resized_pixels[src_idx + c] - mean[c]) / stdv[c];
                 chw_pixels[static_cast<std::size_t>(c) * target_h * target_w +
                            static_cast<std::size_t>(y) * target_w + x] = val;
             }

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -1301,9 +1301,10 @@ int cmd_solve(const CliArgs& args) {
 
 int cmd_transcribe(const CliArgs& args) {
     const std::vector<std::string> audio_paths =
-        !args.audio_inputs.empty() ? args.audio_inputs
-                                   : (args.audio_in.empty() ? std::vector<std::string>{}
-                                                            : std::vector<std::string>{args.audio_in});
+        !args.audio_inputs.empty()
+            ? args.audio_inputs
+            : (args.audio_in.empty() ? std::vector<std::string>{}
+                                     : std::vector<std::string>{args.audio_in});
     if (args.bundle_path.empty() || audio_paths.empty()) {
         std::cerr << "Error: transcribe requires bundle + --audio\n";
         return EXIT_FAILURE;
@@ -1319,8 +1320,8 @@ int cmd_transcribe(const CliArgs& args) {
             return EXIT_FAILURE;
         }
         const bool has_offline_only_controls =
-            args.beam_size != 1 || args.transcription_task != "transcribe" ||
-            !args.punctuation || args.timestamps || args.max_input_seconds > 0.0F ||
+            args.beam_size != 1 || args.transcription_task != "transcribe" || !args.punctuation ||
+            args.timestamps || args.max_input_seconds > 0.0F ||
             args.segment_length_seconds > 0.0F ||
             (args.language.empty() &&
              (args.source_language != "en" || args.target_language != "en"));

--- a/src/runtime/models/segformer/MODEL.toml
+++ b/src/runtime/models/segformer/MODEL.toml
@@ -6,7 +6,7 @@ runtime_library = "libtrtmc_model_segformer.so"
 runtime_plugins = ["plugin.cpp|register_segformer_plugin"]
 runtime_strategies = ["segformer_segmentation"]
 runtime_tests = [
-  "test_segformer_preprocess_seam|test_segformer_preprocess_seam.cpp|_|_|_",
+  "test_segformer_preprocess_seam|test_segformer_preprocess_seam.cpp|trtmc_model_segformer|_|_",
   "test_segformer_postprocess_seam|test_segformer_postprocess_seam.cpp|_|_|_",
   "test_segformer_segment_pipeline|test_segformer_segment_pipeline.cpp|trtmc_model_segformer|_|REQUIRES_TRT",
 ]

--- a/src/runtime/models/segformer/plugin.cpp
+++ b/src/runtime/models/segformer/plugin.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace trtmc {
 
@@ -34,6 +35,23 @@ TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::stri
 
 std::string tp_engine_section_name(int32_t rank) {
     return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+SegformerPreprocessConfig make_segformer_preprocess_config(const std::string& json) {
+    SegformerPreprocessConfig cfg;
+    cfg.num_classes = extract_json_int(json, "num_classes", cfg.num_classes);
+    cfg.input_image_h = extract_json_int(json, "input_image_h", cfg.input_image_h);
+    cfg.input_image_w = extract_json_int(json, "input_image_w", cfg.input_image_w);
+    cfg.output_h = extract_json_int(json, "output_h", cfg.output_h);
+    cfg.output_w = extract_json_int(json, "output_w", cfg.output_w);
+
+    auto mean = extract_json_float_array(json, "image_mean", 3);
+    if (mean.size() == 3)
+        cfg.image_mean = std::move(mean);
+    auto stdv = extract_json_float_array(json, "image_std", 3);
+    if (stdv.size() == 3)
+        cfg.image_std = std::move(stdv);
+    return cfg;
 }
 
 } // namespace
@@ -61,6 +79,7 @@ class SegformerPlugin final : public IPipelinePlugin {
         auto loaded = load_trt_module_from_plan(
             ctx.backend, find_section(ctx.bundle, encoder_section), "engine_plan", encoder_opts);
         return std::make_unique<SegmentPipeline>(std::move(loaded.module),
+                                                 make_segformer_preprocess_config(ctx.config_json),
                                                  ctx.bundle.info.model_id);
     }
 };

--- a/src/runtime/models/segformer/segformer_postprocess_seam.h
+++ b/src/runtime/models/segformer/segformer_postprocess_seam.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <algorithm>
-#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -92,65 +90,6 @@ compute_segformer_class_map_from_logits(const std::vector<float>& logits,
         }
     }
 
-    return SegformerPostprocessStatus::kOk;
-}
-
-inline SegformerPostprocessStatus
-resize_segformer_logits_and_compute_class_map(const std::vector<float>& logits,
-                                              const SegformerLogitsShape& shape, int32_t target_h,
-                                              int32_t target_w, std::vector<int32_t>& class_map) {
-    std::size_t expected_logits_size = 0;
-    if (!get_segformer_logits_expected_size(shape, expected_logits_size) || target_h <= 0 ||
-        target_w <= 0) {
-        class_map.clear();
-        return SegformerPostprocessStatus::kInvalidShape;
-    }
-    if (logits.size() != expected_logits_size) {
-        class_map.clear();
-        return SegformerPostprocessStatus::kLogitsSizeMismatch;
-    }
-    if (target_h == shape.output_h && target_w == shape.output_w)
-        return compute_segformer_class_map_from_logits(logits, shape, class_map);
-
-    const auto source_plane = static_cast<std::size_t>(shape.output_h) * shape.output_w;
-    class_map.resize(static_cast<std::size_t>(target_h) * target_w);
-    for (int32_t y = 0; y < target_h; ++y) {
-        const float source_y = (static_cast<float>(y) + 0.5F) * static_cast<float>(shape.output_h) /
-                                   static_cast<float>(target_h) -
-                               0.5F;
-        const float clamped_y = std::clamp(source_y, 0.0F, static_cast<float>(shape.output_h - 1));
-        const int32_t y0 = static_cast<int32_t>(std::floor(clamped_y));
-        const int32_t y1 = std::min(y0 + 1, shape.output_h - 1);
-        const float y_weight = clamped_y - static_cast<float>(y0);
-        for (int32_t x = 0; x < target_w; ++x) {
-            const float source_x = (static_cast<float>(x) + 0.5F) *
-                                       static_cast<float>(shape.output_w) /
-                                       static_cast<float>(target_w) -
-                                   0.5F;
-            const float clamped_x =
-                std::clamp(source_x, 0.0F, static_cast<float>(shape.output_w - 1));
-            const int32_t x0 = static_cast<int32_t>(std::floor(clamped_x));
-            const int32_t x1 = std::min(x0 + 1, shape.output_w - 1);
-            const float x_weight = clamped_x - static_cast<float>(x0);
-
-            int32_t best_class = 0;
-            float best_value = -std::numeric_limits<float>::infinity();
-            for (int32_t c = 0; c < shape.num_classes; ++c) {
-                const auto base = static_cast<std::size_t>(c) * source_plane;
-                const auto at = [&](int32_t yy, int32_t xx) {
-                    return logits[base + static_cast<std::size_t>(yy) * shape.output_w + xx];
-                };
-                const float top = at(y0, x0) * (1.0F - x_weight) + at(y0, x1) * x_weight;
-                const float bottom = at(y1, x0) * (1.0F - x_weight) + at(y1, x1) * x_weight;
-                const float value = top * (1.0F - y_weight) + bottom * y_weight;
-                if (value > best_value) {
-                    best_value = value;
-                    best_class = c;
-                }
-            }
-            class_map[static_cast<std::size_t>(y) * target_w + x] = best_class;
-        }
-    }
     return SegformerPostprocessStatus::kOk;
 }
 

--- a/src/runtime/models/segformer/segformer_postprocess_seam.h
+++ b/src/runtime/models/segformer/segformer_postprocess_seam.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -90,6 +92,65 @@ compute_segformer_class_map_from_logits(const std::vector<float>& logits,
         }
     }
 
+    return SegformerPostprocessStatus::kOk;
+}
+
+inline SegformerPostprocessStatus
+resize_segformer_logits_and_compute_class_map(const std::vector<float>& logits,
+                                              const SegformerLogitsShape& shape, int32_t target_h,
+                                              int32_t target_w, std::vector<int32_t>& class_map) {
+    std::size_t expected_logits_size = 0;
+    if (!get_segformer_logits_expected_size(shape, expected_logits_size) || target_h <= 0 ||
+        target_w <= 0) {
+        class_map.clear();
+        return SegformerPostprocessStatus::kInvalidShape;
+    }
+    if (logits.size() != expected_logits_size) {
+        class_map.clear();
+        return SegformerPostprocessStatus::kLogitsSizeMismatch;
+    }
+    if (target_h == shape.output_h && target_w == shape.output_w)
+        return compute_segformer_class_map_from_logits(logits, shape, class_map);
+
+    const auto source_plane = static_cast<std::size_t>(shape.output_h) * shape.output_w;
+    class_map.resize(static_cast<std::size_t>(target_h) * target_w);
+    for (int32_t y = 0; y < target_h; ++y) {
+        const float source_y = (static_cast<float>(y) + 0.5F) * static_cast<float>(shape.output_h) /
+                                   static_cast<float>(target_h) -
+                               0.5F;
+        const float clamped_y = std::clamp(source_y, 0.0F, static_cast<float>(shape.output_h - 1));
+        const int32_t y0 = static_cast<int32_t>(std::floor(clamped_y));
+        const int32_t y1 = std::min(y0 + 1, shape.output_h - 1);
+        const float y_weight = clamped_y - static_cast<float>(y0);
+        for (int32_t x = 0; x < target_w; ++x) {
+            const float source_x = (static_cast<float>(x) + 0.5F) *
+                                       static_cast<float>(shape.output_w) /
+                                       static_cast<float>(target_w) -
+                                   0.5F;
+            const float clamped_x =
+                std::clamp(source_x, 0.0F, static_cast<float>(shape.output_w - 1));
+            const int32_t x0 = static_cast<int32_t>(std::floor(clamped_x));
+            const int32_t x1 = std::min(x0 + 1, shape.output_w - 1);
+            const float x_weight = clamped_x - static_cast<float>(x0);
+
+            int32_t best_class = 0;
+            float best_value = -std::numeric_limits<float>::infinity();
+            for (int32_t c = 0; c < shape.num_classes; ++c) {
+                const auto base = static_cast<std::size_t>(c) * source_plane;
+                const auto at = [&](int32_t yy, int32_t xx) {
+                    return logits[base + static_cast<std::size_t>(yy) * shape.output_w + xx];
+                };
+                const float top = at(y0, x0) * (1.0F - x_weight) + at(y0, x1) * x_weight;
+                const float bottom = at(y1, x0) * (1.0F - x_weight) + at(y1, x1) * x_weight;
+                const float value = top * (1.0F - y_weight) + bottom * y_weight;
+                if (value > best_value) {
+                    best_value = value;
+                    best_class = c;
+                }
+            }
+            class_map[static_cast<std::size_t>(y) * target_w + x] = best_class;
+        }
+    }
     return SegformerPostprocessStatus::kOk;
 }
 

--- a/src/runtime/models/segformer/segformer_preprocess_seam.cpp
+++ b/src/runtime/models/segformer/segformer_preprocess_seam.cpp
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/segformer/segformer_preprocess_seam.h"
+
+#include "stb_image_resize2.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace trtmc {
+
+namespace {
+
+void validate_segformer_preprocess_config(const SegformerPreprocessConfig& config) {
+    if (config.input_image_h <= 0 || config.input_image_w <= 0) {
+        throw std::invalid_argument("SegFormer input dimensions must be positive");
+    }
+    if (config.image_mean.size() != 3 || config.image_std.size() != 3) {
+        throw std::invalid_argument("SegFormer image mean/std must contain three channels");
+    }
+    for (float value : config.image_std) {
+        if (value == 0.0F)
+            throw std::invalid_argument("SegFormer image std must be non-zero");
+    }
+}
+
+} // namespace
+
+std::vector<float> preprocess_segformer_image(const float* image_pixels, int32_t image_height,
+                                              int32_t image_width,
+                                              const SegformerPreprocessConfig& config) {
+    if (image_pixels == nullptr || image_height <= 0 || image_width <= 0) {
+        throw std::invalid_argument("SegFormer source image must be non-empty");
+    }
+    validate_segformer_preprocess_config(config);
+
+    const int32_t input_h = config.input_image_h;
+    const int32_t input_w = config.input_image_w;
+    std::vector<float> resized(static_cast<std::size_t>(input_h) * input_w * 3U);
+    if (stbir_resize(image_pixels, image_width, image_height,
+                     image_width * 3 * static_cast<int32_t>(sizeof(float)), resized.data(), input_w,
+                     input_h, input_w * 3 * static_cast<int32_t>(sizeof(float)), STBIR_RGB,
+                     STBIR_TYPE_FLOAT, STBIR_EDGE_CLAMP, STBIR_FILTER_TRIANGLE) == nullptr) {
+        throw std::runtime_error("Failed to resize SegFormer input image");
+    }
+
+    std::vector<float> pixel_values(static_cast<std::size_t>(3) * input_h * input_w);
+    for (int32_t y = 0; y < input_h; ++y) {
+        for (int32_t x = 0; x < input_w; ++x) {
+            const auto src_idx = static_cast<std::size_t>((y * input_w + x) * 3);
+            for (int32_t c = 0; c < 3; ++c) {
+                const auto channel = static_cast<std::size_t>(c);
+                const float value = (resized[src_idx + channel] - config.image_mean[channel]) /
+                                    config.image_std[channel];
+                pixel_values[channel * static_cast<std::size_t>(input_h) * input_w +
+                             static_cast<std::size_t>(y) * input_w + x] = value;
+            }
+        }
+    }
+    return pixel_values;
+}
+
+std::vector<float> preprocess_segformer_image(const runtime::adapters::io::DecodedImage& image,
+                                              const SegformerPreprocessConfig& config) {
+    if (image.empty() || image.channels < 3) {
+        throw std::invalid_argument("SegFormer decoded image must contain RGB pixels");
+    }
+
+    std::vector<float> pixels(static_cast<std::size_t>(image.height) * image.width * 3U);
+    for (int32_t y = 0; y < image.height; ++y) {
+        for (int32_t x = 0; x < image.width; ++x) {
+            const auto src_idx = static_cast<std::size_t>((y * image.width + x) * image.channels);
+            const auto dst_idx = static_cast<std::size_t>((y * image.width + x) * 3);
+            for (int32_t c = 0; c < 3; ++c) {
+                pixels[dst_idx + static_cast<std::size_t>(c)] =
+                    static_cast<float>(image.pixels[src_idx + static_cast<std::size_t>(c)]) /
+                    255.0F;
+            }
+        }
+    }
+    return preprocess_segformer_image(pixels.data(), image.height, image.width, config);
+}
+
+} // namespace trtmc

--- a/src/runtime/models/segformer/segformer_preprocess_seam.h
+++ b/src/runtime/models/segformer/segformer_preprocess_seam.h
@@ -7,9 +7,7 @@
 
 #include "runtime/models/segformer/decoded_image.h"
 
-#include <algorithm>
 #include <cstdint>
-#include <stdexcept>
 #include <vector>
 
 namespace trtmc {
@@ -24,36 +22,11 @@ struct SegformerPreprocessConfig {
     std::vector<float> image_std{0.229F, 0.224F, 0.225F};
 };
 
-inline std::vector<float>
-preprocess_segformer_image(const runtime::adapters::io::DecodedImage& image,
-                           const SegformerPreprocessConfig& config) {
-    if (image.empty()) {
-        throw std::runtime_error("Failed to preprocess SegFormer image: decoded image missing");
-    }
+std::vector<float> preprocess_segformer_image(const float* image_pixels, int32_t image_height,
+                                              int32_t image_width,
+                                              const SegformerPreprocessConfig& config);
 
-    const int32_t input_h = config.input_image_h;
-    const int32_t input_w = config.input_image_w;
-    std::vector<float> pixel_values(static_cast<std::size_t>(3) * input_h * input_w);
-
-    for (int32_t y = 0; y < input_h; ++y) {
-        for (int32_t x = 0; x < input_w; ++x) {
-            const float src_y = static_cast<float>(y) * static_cast<float>(image.height) /
-                                static_cast<float>(input_h);
-            const float src_x = static_cast<float>(x) * static_cast<float>(image.width) /
-                                static_cast<float>(input_w);
-            const int32_t y0 = std::min(static_cast<int32_t>(src_y), image.height - 1);
-            const int32_t x0 = std::min(static_cast<int32_t>(src_x), image.width - 1);
-            const auto src_idx = static_cast<std::size_t>((y0 * image.width + x0) * image.channels);
-            for (int32_t c = 0; c < 3; ++c) {
-                float value = static_cast<float>(image.pixels[src_idx + c]) / 255.0F;
-                value = (value - config.image_mean[c]) / config.image_std[c];
-                pixel_values[static_cast<std::size_t>(c) * input_h * input_w +
-                             static_cast<std::size_t>(y) * input_w + x] = value;
-            }
-        }
-    }
-
-    return pixel_values;
-}
+std::vector<float> preprocess_segformer_image(const runtime::adapters::io::DecodedImage& image,
+                                              const SegformerPreprocessConfig& config);
 
 } // namespace trtmc

--- a/src/runtime/models/segformer/segment_pipeline.cpp
+++ b/src/runtime/models/segformer/segment_pipeline.cpp
@@ -5,35 +5,17 @@
 
 #include "runtime/models/segformer/segment_pipeline.h"
 
+#include "runtime/models/segformer/segformer_postprocess_seam.h"
+
 #include <cstdint>
-#include <cstring>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace trtmc {
 
 namespace {
-
-// Argmax over class dimension: logits[C, H, W] -> class_map[H, W].
-void argmax_class_map(const float* logits, int32_t num_classes, int32_t out_h, int32_t out_w,
-                      std::vector<int32_t>& class_map) {
-    const auto plane_size = static_cast<std::size_t>(out_h) * out_w;
-    class_map.resize(plane_size);
-
-    for (std::size_t px = 0; px < plane_size; ++px) {
-        int32_t best_class = 0;
-        float best_val = -1e30F;
-        for (int32_t c = 0; c < num_classes; ++c) {
-            const float val = logits[static_cast<std::size_t>(c) * plane_size + px];
-            if (val > best_val) {
-                best_val = val;
-                best_class = c;
-            }
-        }
-        class_map[px] = best_class;
-    }
-}
 
 // Extract (num_classes, H, W) from output shape, handling optional batch dim.
 bool parse_segmentation_shape(const std::vector<int64_t>& shape, int32_t& num_classes,
@@ -66,16 +48,21 @@ const Tensor* find_segmentation_output(const TensorMap& outputs) {
 
 // ─── SegmentPipeline ───
 
-SegmentPipeline::SegmentPipeline(std::unique_ptr<TrtModule> model, std::string model_id_str)
-    : model_(std::move(model)), model_id_(std::move(model_id_str)) {
+SegmentPipeline::SegmentPipeline(std::unique_ptr<TrtModule> model,
+                                 SegformerPreprocessConfig preprocess_config,
+                                 std::string model_id_str)
+    : model_(std::move(model)), preprocess_config_(std::move(preprocess_config)),
+      model_id_(std::move(model_id_str)) {
     if (!model_ || !model_->ok())
         throw std::runtime_error("SegmentPipeline: invalid model");
 }
 
 SegmentResult SegmentPipeline::segment(const float* pixels, int32_t height, int32_t width) {
+    auto pixel_values = preprocess_segformer_image(pixels, height, width, preprocess_config_);
+
     Tensor img_t;
-    img_t.data = const_cast<float*>(pixels);
-    img_t.shape = {3, height, width};
+    img_t.data = pixel_values.data();
+    img_t.shape = {3, preprocess_config_.input_image_h, preprocess_config_.input_image_w};
     img_t.dtype = DType::kFloat32;
 
     auto outputs = model_->forward({{"pixel_values", img_t}});
@@ -89,9 +76,15 @@ SegmentResult SegmentPipeline::segment(const float* pixels, int32_t height, int3
     int32_t num_classes = 0, out_h = 0, out_w = 0;
 
     if (parse_segmentation_shape(out_tensor->shape, num_classes, out_h, out_w)) {
-        result.height = out_h;
-        result.width = out_w;
-        argmax_class_map(data, num_classes, out_h, out_w, result.mask);
+        const auto logits_size = static_cast<std::size_t>(num_classes) * out_h * out_w;
+        const std::vector<float> logits(data, data + logits_size);
+        const SegformerLogitsShape logits_shape{num_classes, out_h, out_w};
+        const auto status = resize_segformer_logits_and_compute_class_map(
+            logits, logits_shape, height, width, result.mask);
+        if (status != SegformerPostprocessStatus::kOk)
+            throw std::runtime_error("SegmentPipeline: invalid SegFormer logits shape");
+        result.height = height;
+        result.width = width;
     } else {
         auto n = out_tensor->numel();
         result.height = height;

--- a/src/runtime/models/segformer/segment_pipeline.cpp
+++ b/src/runtime/models/segformer/segment_pipeline.cpp
@@ -79,12 +79,12 @@ SegmentResult SegmentPipeline::segment(const float* pixels, int32_t height, int3
         const auto logits_size = static_cast<std::size_t>(num_classes) * out_h * out_w;
         const std::vector<float> logits(data, data + logits_size);
         const SegformerLogitsShape logits_shape{num_classes, out_h, out_w};
-        const auto status = resize_segformer_logits_and_compute_class_map(
-            logits, logits_shape, height, width, result.mask);
+        const auto status =
+            compute_segformer_class_map_from_logits(logits, logits_shape, result.mask);
         if (status != SegformerPostprocessStatus::kOk)
             throw std::runtime_error("SegmentPipeline: invalid SegFormer logits shape");
-        result.height = height;
-        result.width = width;
+        result.height = out_h;
+        result.width = out_w;
     } else {
         auto n = out_tensor->numel();
         result.height = height;

--- a/src/runtime/models/segformer/segment_pipeline.h
+++ b/src/runtime/models/segformer/segment_pipeline.h
@@ -8,6 +8,7 @@
 // SegmentPipeline: single-pass segmentation (SegFormer).
 // Uses a single TrtModule for pixel_values -> logits/mask output.
 
+#include "runtime/models/segformer/segformer_preprocess_seam.h"
 #include "trtmc/pipeline.h"
 #include "trtmc/runtime/trt_module.h"
 
@@ -20,7 +21,9 @@ namespace trtmc {
 
 class SegmentPipeline final : public IPipeline {
   public:
-    explicit SegmentPipeline(std::unique_ptr<TrtModule> model, std::string model_id_str = "");
+    explicit SegmentPipeline(std::unique_ptr<TrtModule> model,
+                             SegformerPreprocessConfig preprocess_config = {},
+                             std::string model_id_str = "");
 
     SegmentResult segment(const float* pixels, int32_t height, int32_t width) override;
 
@@ -29,6 +32,7 @@ class SegmentPipeline final : public IPipeline {
 
   private:
     std::unique_ptr<TrtModule> model_;
+    SegformerPreprocessConfig preprocess_config_;
     std::string model_id_;
 };
 

--- a/src/runtime/models/timm_vit/MODEL.toml
+++ b/src/runtime/models/timm_vit/MODEL.toml
@@ -5,3 +5,6 @@ id = "timm_vit"
 runtime_library = "libtrtmc_model_timm_vit.so"
 runtime_plugins = ["plugin.cpp|register_timm_vit_plugin"]
 runtime_strategies = ["timm_vit_image_classification"]
+runtime_tests = [
+  "test_timm_vit_image_preprocess_seam|test_timm_vit_image_preprocess_seam.cpp|trtmc_model_timm_vit|_|_",
+]

--- a/src/runtime/models/timm_vit/image_preprocess_seam.cpp
+++ b/src/runtime/models/timm_vit/image_preprocess_seam.cpp
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/timm_vit/image_preprocess_seam.h"
+
+#include "stb_image_resize2.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+namespace {
+
+stbir_filter resolve_timm_vit_resize_filter(const std::string& interpolation) {
+    if (interpolation == "bilinear")
+        return STBIR_FILTER_TRIANGLE;
+    if (interpolation == "bicubic")
+        return STBIR_FILTER_CATMULLROM;
+    throw std::invalid_argument("Unsupported timm ViT interpolation: " + interpolation);
+}
+
+void validate_timm_vit_preprocess_config(const TimmVitPreprocessConfig& config) {
+    if (config.input_image_h <= 0 || config.input_image_w <= 0) {
+        throw std::invalid_argument("timm ViT input dimensions must be positive");
+    }
+    if (config.crop_pct <= 0.0F || config.crop_pct > 1.0F) {
+        throw std::invalid_argument("timm ViT crop_pct must be in (0, 1]");
+    }
+    if (config.image_mean.size() != 3 || config.image_std.size() != 3) {
+        throw std::invalid_argument("timm ViT image mean/std must contain three channels");
+    }
+    for (float value : config.image_std) {
+        if (value == 0.0F)
+            throw std::invalid_argument("timm ViT image std must be non-zero");
+    }
+}
+
+int32_t torchvision_center_crop_offset(int32_t resized, int32_t target) {
+    const int32_t difference = resized - target;
+    const int32_t half = difference / 2;
+    // torchvision uses Python round(), whose .5 ties round to the nearest even integer.
+    return (difference % 2 != 0 && half % 2 != 0) ? half + 1 : half;
+}
+
+} // namespace
+
+TimmVitResizeShape compute_timm_vit_resize_shape(int32_t image_height, int32_t image_width,
+                                                 const TimmVitPreprocessConfig& config) {
+    if (image_height <= 0 || image_width <= 0) {
+        throw std::invalid_argument("timm ViT source dimensions must be positive");
+    }
+    validate_timm_vit_preprocess_config(config);
+
+    if (config.input_image_h == config.input_image_w) {
+        // timm's center-crop eval transform passes floor(input_size / crop_pct) as a scalar
+        // torchvision Resize size. A scalar fixes the shorter edge and floors the aspect-ratio
+        // calculation for the longer edge.
+        const int32_t resized_short = static_cast<int32_t>(
+            std::floor(static_cast<float>(config.input_image_h) / config.crop_pct));
+        if (image_height <= image_width) {
+            return {resized_short, static_cast<int32_t>(static_cast<int64_t>(resized_short) *
+                                                        image_width / image_height)};
+        }
+        return {
+            static_cast<int32_t>(static_cast<int64_t>(resized_short) * image_height / image_width),
+            resized_short};
+    }
+
+    const float required_scale =
+        std::max(static_cast<float>(config.input_image_h) / static_cast<float>(image_height),
+                 static_cast<float>(config.input_image_w) / static_cast<float>(image_width));
+    const float resize_scale = required_scale / config.crop_pct;
+    return {
+        std::max(config.input_image_h,
+                 static_cast<int32_t>(std::floor(static_cast<float>(image_height) * resize_scale))),
+        std::max(config.input_image_w,
+                 static_cast<int32_t>(std::floor(static_cast<float>(image_width) * resize_scale))),
+    };
+}
+
+std::vector<float> preprocess_timm_vit_image(const float* image_pixels, int32_t image_height,
+                                             int32_t image_width,
+                                             const TimmVitPreprocessConfig& config) {
+    if (image_pixels == nullptr || image_height <= 0 || image_width <= 0) {
+        throw std::invalid_argument("timm ViT source image must be non-empty");
+    }
+    validate_timm_vit_preprocess_config(config);
+
+    const auto resize_shape = compute_timm_vit_resize_shape(image_height, image_width, config);
+    const int32_t resized_h = resize_shape.height;
+    const int32_t resized_w = resize_shape.width;
+
+    std::vector<float> resized(static_cast<std::size_t>(resized_h) * resized_w * 3U);
+    if (stbir_resize(image_pixels, image_width, image_height,
+                     image_width * 3 * static_cast<int32_t>(sizeof(float)), resized.data(),
+                     resized_w, resized_h, resized_w * 3 * static_cast<int32_t>(sizeof(float)),
+                     STBIR_RGB, STBIR_TYPE_FLOAT, STBIR_EDGE_CLAMP,
+                     resolve_timm_vit_resize_filter(config.interpolation)) == nullptr) {
+        throw std::runtime_error("Failed to resize timm ViT input image");
+    }
+
+    const int32_t crop_y = torchvision_center_crop_offset(resized_h, config.input_image_h);
+    const int32_t crop_x = torchvision_center_crop_offset(resized_w, config.input_image_w);
+    const auto output_plane = static_cast<std::size_t>(config.input_image_h) * config.input_image_w;
+    std::vector<float> pixel_values(3U * output_plane);
+    for (int32_t y = 0; y < config.input_image_h; ++y) {
+        for (int32_t x = 0; x < config.input_image_w; ++x) {
+            const auto src_idx =
+                static_cast<std::size_t>((((crop_y + y) * resized_w + crop_x + x) * 3));
+            for (int32_t c = 0; c < 3; ++c) {
+                const auto channel = static_cast<std::size_t>(c);
+                pixel_values[channel * output_plane +
+                             static_cast<std::size_t>(y) * config.input_image_w + x] =
+                    (resized[src_idx + channel] - config.image_mean[channel]) /
+                    config.image_std[channel];
+            }
+        }
+    }
+    return pixel_values;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/timm_vit/image_preprocess_seam.h
+++ b/src/runtime/models/timm_vit/image_preprocess_seam.h
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+struct TimmVitPreprocessConfig {
+    int32_t input_image_h{224};
+    int32_t input_image_w{224};
+    std::vector<float> image_mean{0.5F, 0.5F, 0.5F};
+    std::vector<float> image_std{0.5F, 0.5F, 0.5F};
+    float crop_pct{0.9F};
+    std::string interpolation{"bicubic"};
+};
+
+struct TimmVitResizeShape {
+    int32_t height{0};
+    int32_t width{0};
+};
+
+TimmVitResizeShape compute_timm_vit_resize_shape(int32_t image_height, int32_t image_width,
+                                                 const TimmVitPreprocessConfig& config);
+
+std::vector<float> preprocess_timm_vit_image(const float* image_pixels, int32_t image_height,
+                                             int32_t image_width,
+                                             const TimmVitPreprocessConfig& config);
+
+} // namespace trtmc

--- a/src/runtime/models/timm_vit/pipeline.cpp
+++ b/src/runtime/models/timm_vit/pipeline.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cstring>
 #include <stdexcept>
+#include <utility>
 
 namespace trtmc {
 
@@ -24,17 +25,21 @@ const Tensor* find_logits_output(const TensorMap& outputs) {
 } // namespace
 
 ImageClassificationPipeline::ImageClassificationPipeline(std::unique_ptr<TrtModule> model,
+                                                         TimmVitPreprocessConfig preprocess_config,
                                                          std::string model_id_str)
-    : model_(std::move(model)), model_id_(std::move(model_id_str)) {
+    : model_(std::move(model)), preprocess_config_(std::move(preprocess_config)),
+      model_id_(std::move(model_id_str)) {
     if (!model_ || !model_->ok())
         throw std::runtime_error("ImageClassificationPipeline: invalid model");
 }
 
 ClassificationResult ImageClassificationPipeline::classify(const float* pixels, int32_t height,
                                                            int32_t width) {
+    auto pixel_values = preprocess_timm_vit_image(pixels, height, width, preprocess_config_);
+
     Tensor img_t;
-    img_t.data = const_cast<float*>(pixels);
-    img_t.shape = {1, 3, height, width};
+    img_t.data = pixel_values.data();
+    img_t.shape = {1, 3, preprocess_config_.input_image_h, preprocess_config_.input_image_w};
     img_t.dtype = DType::kFloat32;
 
     auto outputs = model_->forward({{"pixel_values", img_t}});

--- a/src/runtime/models/timm_vit/pipeline.h
+++ b/src/runtime/models/timm_vit/pipeline.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "runtime/models/timm_vit/image_preprocess_seam.h"
 #include "trtmc/pipeline.h"
 #include "trtmc/runtime/trt_module.h"
 
@@ -16,6 +17,7 @@ namespace trtmc {
 class ImageClassificationPipeline final : public IPipeline {
   public:
     explicit ImageClassificationPipeline(std::unique_ptr<TrtModule> model,
+                                         TimmVitPreprocessConfig preprocess_config = {},
                                          std::string model_id_str = "");
 
     ClassificationResult classify(const float* pixels, int32_t height, int32_t width) override;
@@ -25,6 +27,7 @@ class ImageClassificationPipeline final : public IPipeline {
 
   private:
     std::unique_ptr<TrtModule> model_;
+    TimmVitPreprocessConfig preprocess_config_;
     std::string model_id_;
 };
 

--- a/src/runtime/models/timm_vit/plugin.cpp
+++ b/src/runtime/models/timm_vit/plugin.cpp
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 
 namespace trtmc {
 
@@ -33,6 +34,22 @@ TensorParallelRuntimeConfig parse_tensor_parallel_runtime_config(const std::stri
 
 std::string tp_engine_section_name(int32_t rank) {
     return "engine_plan_tp_rank" + std::to_string(rank);
+}
+
+TimmVitPreprocessConfig make_timm_vit_preprocess_config(const std::string& json) {
+    TimmVitPreprocessConfig cfg;
+    cfg.input_image_h = extract_json_int(json, "input_image_h", cfg.input_image_h);
+    cfg.input_image_w = extract_json_int(json, "input_image_w", cfg.input_image_w);
+    cfg.crop_pct = extract_json_float(json, "crop_pct", cfg.crop_pct);
+    cfg.interpolation = extract_json_string(json, "interpolation", cfg.interpolation);
+
+    auto mean = extract_json_float_array(json, "image_mean", 3);
+    if (mean.size() == 3)
+        cfg.image_mean = std::move(mean);
+    auto stdv = extract_json_float_array(json, "image_std", 3);
+    if (stdv.size() == 3)
+        cfg.image_std = std::move(stdv);
+    return cfg;
 }
 
 } // namespace
@@ -56,8 +73,9 @@ class TimmVitPlugin final : public IPipelinePlugin {
 
         auto loaded = load_trt_module_from_plan(
             ctx.backend, find_section(ctx.bundle, engine_section), "engine_plan", opts);
-        return std::make_unique<ImageClassificationPipeline>(std::move(loaded.module),
-                                                             ctx.bundle.info.model_id);
+        return std::make_unique<ImageClassificationPipeline>(
+            std::move(loaded.module), make_timm_vit_preprocess_config(ctx.config_json),
+            ctx.bundle.info.model_id);
     }
 };
 

--- a/tests/cpp/models/segformer/test_segformer_postprocess_seam.cpp
+++ b/tests/cpp/models/segformer/test_segformer_postprocess_seam.cpp
@@ -121,6 +121,25 @@ void test_segformer_postprocess_logits_size_mismatch() {
     check(class_map.empty(), "postprocess logits mismatch: class_map cleared");
 }
 
+void test_segformer_postprocess_resizes_logits_before_argmax() {
+    const trtmc::SegformerLogitsShape shape{2, 2, 2};
+    const std::vector<float> logits = {
+        0.0F, 0.0F, 0.0F, 0.0F, -1.0F, 1.0F, 1.0F, 1.0F,
+    };
+
+    std::vector<int32_t> class_map;
+    const auto status =
+        trtmc::resize_segformer_logits_and_compute_class_map(logits, shape, 3, 3, class_map);
+
+    check(status == trtmc::SegformerPostprocessStatus::kOk,
+          "postprocess resized logits: status ok");
+    check(class_map.size() == 9, "postprocess resized logits: output size");
+    if (class_map.size() == 9) {
+        check(class_map[0] == 0, "postprocess resized logits: top-left class");
+        check(class_map[4] == 1, "postprocess resized logits: bilinear center class");
+    }
+}
+
 } // namespace
 
 int main() {
@@ -128,6 +147,7 @@ int main() {
     test_segformer_postprocess_tie_selects_first_class();
     test_segformer_postprocess_invalid_shape();
     test_segformer_postprocess_logits_size_mismatch();
+    test_segformer_postprocess_resizes_logits_before_argmax();
 
     if (g_failures != 0) {
         std::cerr << g_failures << " SegFormer postprocess seam test(s) failed" << '\n';

--- a/tests/cpp/models/segformer/test_segformer_postprocess_seam.cpp
+++ b/tests/cpp/models/segformer/test_segformer_postprocess_seam.cpp
@@ -121,25 +121,6 @@ void test_segformer_postprocess_logits_size_mismatch() {
     check(class_map.empty(), "postprocess logits mismatch: class_map cleared");
 }
 
-void test_segformer_postprocess_resizes_logits_before_argmax() {
-    const trtmc::SegformerLogitsShape shape{2, 2, 2};
-    const std::vector<float> logits = {
-        0.0F, 0.0F, 0.0F, 0.0F, -1.0F, 1.0F, 1.0F, 1.0F,
-    };
-
-    std::vector<int32_t> class_map;
-    const auto status =
-        trtmc::resize_segformer_logits_and_compute_class_map(logits, shape, 3, 3, class_map);
-
-    check(status == trtmc::SegformerPostprocessStatus::kOk,
-          "postprocess resized logits: status ok");
-    check(class_map.size() == 9, "postprocess resized logits: output size");
-    if (class_map.size() == 9) {
-        check(class_map[0] == 0, "postprocess resized logits: top-left class");
-        check(class_map[4] == 1, "postprocess resized logits: bilinear center class");
-    }
-}
-
 } // namespace
 
 int main() {
@@ -147,8 +128,6 @@ int main() {
     test_segformer_postprocess_tie_selects_first_class();
     test_segformer_postprocess_invalid_shape();
     test_segformer_postprocess_logits_size_mismatch();
-    test_segformer_postprocess_resizes_logits_before_argmax();
-
     if (g_failures != 0) {
         std::cerr << g_failures << " SegFormer postprocess seam test(s) failed" << '\n';
         return 1;

--- a/tests/cpp/models/segformer/test_segformer_preprocess_seam.cpp
+++ b/tests/cpp/models/segformer/test_segformer_preprocess_seam.cpp
@@ -75,10 +75,27 @@ void test_segformer_preprocess_rejects_empty_image() {
     try {
         trtmc::SegformerPreprocessConfig config;
         (void)trtmc::preprocess_segformer_image({}, config);
-    } catch (const std::runtime_error&) {
+    } catch (const std::invalid_argument&) {
         threw = true;
     }
     check(threw, "segformer preprocess rejects empty image");
+}
+
+void test_segformer_preprocess_uses_bilinear_resize() {
+    const std::vector<float> pixels = {
+        0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F,
+    };
+    trtmc::SegformerPreprocessConfig config;
+    config.input_image_h = 3;
+    config.input_image_w = 3;
+    config.image_mean = {0.0F, 0.0F, 0.0F};
+    config.image_std = {1.0F, 1.0F, 1.0F};
+
+    const auto pixel_values = trtmc::preprocess_segformer_image(pixels.data(), 2, 2, config);
+    check(pixel_values.size() == 27, "segformer bilinear resize size");
+    if (pixel_values.size() == 27) {
+        check_close(pixel_values[4], 0.5F, 1e-6F, "segformer bilinear resize blends center pixel");
+    }
 }
 
 } // namespace
@@ -86,6 +103,7 @@ void test_segformer_preprocess_rejects_empty_image() {
 int main() {
     test_segformer_preprocess_normalizes_decoded_image();
     test_segformer_preprocess_rejects_empty_image();
+    test_segformer_preprocess_uses_bilinear_resize();
 
     if (g_failures != 0) {
         std::cerr << g_failures << " SegFormer preprocess seam test(s) failed\n";

--- a/tests/cpp/models/segformer/test_segformer_segment_pipeline.cpp
+++ b/tests/cpp/models/segformer/test_segformer_segment_pipeline.cpp
@@ -38,6 +38,15 @@ static void check(bool condition, const char* name) {
 
 static trtmc::TrtLogger g_logger;
 
+static trtmc::SegformerPreprocessConfig make_test_preprocess_config() {
+    trtmc::SegformerPreprocessConfig config;
+    config.input_image_h = 4;
+    config.input_image_w = 4;
+    config.output_h = 4;
+    config.output_w = 4;
+    return config;
+}
+
 // Mock: pixel_values[3,4,4] float -> output_mask[1,16] float.
 static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_segment_engine() {
     auto b = trtmc::TrtUniquePtr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(g_logger));
@@ -160,7 +169,7 @@ static void test_segment_pipeline() {
 
     auto module = std::make_unique<trtmc::TrtModuleImpl>(engine.get(),
                                                          engine->createExecutionContext(), stream);
-    trtmc::SegmentPipeline pipeline(std::move(module));
+    trtmc::SegmentPipeline pipeline(std::move(module), make_test_preprocess_config());
 
     check(std::string(pipeline.pipeline_type()) == "SegmentPipeline", "segment name");
 
@@ -183,7 +192,7 @@ static void test_segment_with_class_output() {
 
     auto module = std::make_unique<trtmc::TrtModuleImpl>(engine.get(),
                                                          engine->createExecutionContext(), stream);
-    trtmc::SegmentPipeline pipeline(std::move(module));
+    trtmc::SegmentPipeline pipeline(std::move(module), make_test_preprocess_config());
 
     float img[3 * 4 * 4] = {0};
     auto result = pipeline.segment(img, 4, 4);
@@ -216,7 +225,7 @@ static void test_segment_4d_output() {
 
     auto module = std::make_unique<trtmc::TrtModuleImpl>(engine.get(),
                                                          engine->createExecutionContext(), stream);
-    trtmc::SegmentPipeline pipeline(std::move(module));
+    trtmc::SegmentPipeline pipeline(std::move(module), make_test_preprocess_config());
 
     float img[3 * 4 * 4] = {0};
     auto result = pipeline.segment(img, 4, 4);
@@ -239,7 +248,7 @@ static void test_segment_mask_named_output() {
 
     auto module = std::make_unique<trtmc::TrtModuleImpl>(engine.get(),
                                                          engine->createExecutionContext(), stream);
-    trtmc::SegmentPipeline pipeline(std::move(module));
+    trtmc::SegmentPipeline pipeline(std::move(module), make_test_preprocess_config());
 
     float img[3 * 4 * 4] = {0};
     auto result = pipeline.segment(img, 4, 4);

--- a/tests/cpp/models/timm_vit/test_timm_vit_image_preprocess_seam.cpp
+++ b/tests/cpp/models/timm_vit/test_timm_vit_image_preprocess_seam.cpp
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/timm_vit/image_preprocess_seam.h"
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++g_failures;
+    }
+}
+
+void check_close(float actual, float expected, float tolerance, const char* name) {
+    if (std::fabs(actual - expected) > tolerance) {
+        std::cerr << "FAIL: " << name << " actual=" << actual << " expected=" << expected << '\n';
+        ++g_failures;
+    }
+}
+
+void test_timm_vit_preprocess_uses_configured_bilinear_resize() {
+    const std::vector<float> pixels = {
+        0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F,
+    };
+    trtmc::TimmVitPreprocessConfig config;
+    config.input_image_h = 3;
+    config.input_image_w = 3;
+    config.crop_pct = 1.0F;
+    config.interpolation = "bilinear";
+    config.image_mean = {0.0F, 0.0F, 0.0F};
+    config.image_std = {1.0F, 1.0F, 1.0F};
+
+    const auto pixel_values = trtmc::preprocess_timm_vit_image(pixels.data(), 2, 2, config);
+    check(pixel_values.size() == 27, "timm ViT preprocess size");
+    if (pixel_values.size() == 27) {
+        check_close(pixel_values[4], 0.5F, 1e-6F, "timm ViT bilinear resize blends center pixel");
+    }
+}
+
+void test_timm_vit_preprocess_applies_bundle_normalization() {
+    const std::vector<float> pixels(3U * 2U * 2U, 0.75F);
+    trtmc::TimmVitPreprocessConfig config;
+    config.input_image_h = 2;
+    config.input_image_w = 2;
+    config.crop_pct = 1.0F;
+    config.interpolation = "bilinear";
+    config.image_mean = {0.25F, 0.5F, 0.75F};
+    config.image_std = {0.5F, 0.25F, 0.125F};
+
+    const auto pixel_values = trtmc::preprocess_timm_vit_image(pixels.data(), 2, 2, config);
+    check_close(pixel_values[0], 1.0F, 1e-6F, "timm ViT red normalization");
+    check_close(pixel_values[4], 1.0F, 1e-6F, "timm ViT green normalization");
+    check_close(pixel_values[8], 0.0F, 1e-6F, "timm ViT blue normalization");
+}
+
+void test_timm_vit_resize_matches_torchvision_short_edge_geometry() {
+    trtmc::TimmVitPreprocessConfig config;
+    config.input_image_h = 224;
+    config.input_image_w = 224;
+    config.crop_pct = 0.9F;
+
+    const auto landscape = trtmc::compute_timm_vit_resize_shape(320, 426, config);
+    check(landscape.height == 248, "timm ViT landscape short edge uses floor size");
+    check(landscape.width == 330, "timm ViT landscape aspect ratio uses floor size");
+
+    const auto portrait = trtmc::compute_timm_vit_resize_shape(426, 320, config);
+    check(portrait.height == 330, "timm ViT portrait aspect ratio uses floor size");
+    check(portrait.width == 248, "timm ViT portrait short edge uses floor size");
+}
+
+void test_timm_vit_preprocess_rejects_invalid_interpolation() {
+    bool threw = false;
+    try {
+        const std::vector<float> pixels(12U, 0.0F);
+        trtmc::TimmVitPreprocessConfig config;
+        config.input_image_h = 2;
+        config.input_image_w = 2;
+        config.crop_pct = 1.0F;
+        config.interpolation = "nearest";
+        (void)trtmc::preprocess_timm_vit_image(pixels.data(), 2, 2, config);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check(threw, "timm ViT rejects unsupported interpolation");
+}
+
+} // namespace
+
+int main() {
+    test_timm_vit_preprocess_uses_configured_bilinear_resize();
+    test_timm_vit_preprocess_applies_bundle_normalization();
+    test_timm_vit_resize_matches_torchvision_short_edge_geometry();
+    test_timm_vit_preprocess_rejects_invalid_interpolation();
+
+    if (g_failures != 0) {
+        std::cerr << g_failures << " timm ViT preprocess test(s) failed\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/e2e/models/segformer/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/segformer/e2e_plugins/references/hf_transformers.py
@@ -659,9 +659,8 @@ class HfTransformersReference:
             inputs = processor(images=image, return_tensors="pt")
             with torch.no_grad():
                 outputs = model(**inputs)
-            class_map = processor.post_process_semantic_segmentation(
-                outputs, target_sizes=[image.size[::-1]])[0]
-            class_map = class_map.cpu().numpy().astype(np.int32)
+            logits = outputs.logits[0].float().cpu().numpy()
+            class_map = np.argmax(logits, axis=0).astype(np.int32)
             np.save(output_path, class_map)
             print(f"OK classes={{class_map.max() + 1}}")
         """)

--- a/tests/e2e/models/segformer/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/segformer/e2e_plugins/references/hf_transformers.py
@@ -659,8 +659,9 @@ class HfTransformersReference:
             inputs = processor(images=image, return_tensors="pt")
             with torch.no_grad():
                 outputs = model(**inputs)
-            logits = outputs.logits[0].float().cpu().numpy()
-            class_map = np.argmax(logits, axis=0).astype(np.int32)
+            class_map = processor.post_process_semantic_segmentation(
+                outputs, target_sizes=[image.size[::-1]])[0]
+            class_map = class_map.cpu().numpy().astype(np.int32)
             np.save(output_path, class_map)
             print(f"OK classes={{class_map.max() + 1}}")
         """)

--- a/tests/e2e/models/timm_vit/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/timm_vit/e2e_plugins/references/hf_transformers.py
@@ -646,35 +646,11 @@ class HfTransformersReference:
             import timm
             import torch
             from PIL import Image
+            from timm.data import create_transform, resolve_model_data_config
 
             hf_id = {hf_id!r}
             image_path = {image_path!r}
             output_path = {output_path!r}
-
-            target = 224
-            crop_pct = 0.9
-            resize_short = int(target / crop_pct + 0.5)
-            image = Image.open(image_path).convert("RGB")
-            width, height = image.size
-            if height <= width:
-                resized_h = resize_short
-                resized_w = max(1, int(width * resize_short / height + 0.5))
-            else:
-                resized_w = resize_short
-                resized_h = max(1, int(height * resize_short / width + 0.5))
-
-            source = np.asarray(image, dtype=np.float32) / 255.0
-            crop_x = max(0, (resized_w - target) // 2)
-            crop_y = max(0, (resized_h - target) // 2)
-            chw = np.empty((3, target, target), dtype=np.float32)
-            for y in range(target):
-                ry = crop_y + y
-                src_y = min(height - 1, int(float(ry) * height / resized_h))
-                for x in range(target):
-                    rx = crop_x + x
-                    src_x = min(width - 1, int(float(rx) * width / resized_w))
-                    chw[:, y, x] = (source[src_y, src_x, :] - 0.5) / 0.5
-            chw = chw[None, ...].copy()
 
             model_ref = f"hf-hub:{{hf_id}}"
             try:
@@ -684,9 +660,12 @@ class HfTransformersReference:
             model.eval()
             device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
             model.to(device)
+            data_config = resolve_model_data_config(model)
+            transform = create_transform(**data_config, is_training=False)
+            image = Image.open(image_path).convert("RGB")
+            tensor = transform(image).unsqueeze(0).to(device)
 
             with torch.no_grad():
-                tensor = torch.from_numpy(chw).to(device)
                 logits = model(tensor)[0].float().cpu().numpy()
 
             top_class = int(np.argmax(logits))

--- a/tests/e2e/models/timm_vit/test_timm_vit_family_plugin.py
+++ b/tests/e2e/models/timm_vit/test_timm_vit_family_plugin.py
@@ -83,6 +83,28 @@ def test_model_config_uses_timm_architecture_when_model_type_absent(tmp_path: Pa
     assert plugin.matches(cfg.model_type)
 
 
+def test_bundle_config_preserves_image_preprocess_contract(tmp_path: Path):
+    _write_tiny_vit(tmp_path)
+    raw = json.loads((tmp_path / "config.json").read_text())
+    raw.update({
+        "mean": [0.1, 0.2, 0.3],
+        "std": [0.4, 0.5, 0.6],
+        "crop_pct": 0.875,
+        "interpolation": "bilinear",
+    })
+    (tmp_path / "config.json").write_text(json.dumps(raw))
+    cfg = ModelConfig.from_dir(tmp_path)
+
+    bundle_config = plugin.get_bundle_config_overrides(cfg)
+
+    assert bundle_config["input_image_h"] == 224
+    assert bundle_config["input_image_w"] == 224
+    assert bundle_config["image_mean"] == [0.1, 0.2, 0.3]
+    assert bundle_config["image_std"] == [0.4, 0.5, 0.6]
+    assert bundle_config["crop_pct"] == pytest.approx(0.875)
+    assert bundle_config["interpolation"] == "bilinear"
+
+
 def test_load_weights_maps_timm_vit_shapes(tmp_path: Path):
     raw = _write_tiny_vit(tmp_path)
     cfg = ModelConfig.from_dir(tmp_path)

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -344,8 +344,6 @@ def test_impact_treats_shared_family_registry_as_platform(tmp_path: Path) -> Non
 @pytest.mark.parametrize(
     "path, expected_scope",
     (
-        ("src/cli/main.cpp", "cli"),
-        ("src/cli/args.h", "cli"),
         ("src/runtime/config/cli_support.cpp", "cli"),
         ("include/trtmc/config/cli_support.h", "cli"),
         ("python/tensorrt_model_connect/build_cli.py", "cli"),
@@ -371,6 +369,20 @@ def test_cli_and_unit_test_changes_run_units_without_model_proofs(
     assert result["matrix"] == {"include": []}
     assert result["run_unit_tests"] is True
     assert result["unit_scope"] == expected_scope
+
+
+@pytest.mark.parametrize("path", ("src/cli/main.cpp", "src/cli/args.h"))
+def test_runtime_cli_changes_run_model_fallback(tmp_path: Path, path: str) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, path, "// changed\n")
+    head = _commit(repo, "runtime CLI change")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["affected_models"] == ["model_a"]
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
 
 
 @pytest.mark.parametrize(

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -135,8 +135,6 @@ UNIT_TEST_ONLY_PREFIXES = (
     "tests/cpp/",
     "tests/tools/",
 )
-CLI_UNIT_ONLY_PREFIXES = ("src/cli/",)
-
 # These shared-location tests require real model plugins or GPU execution and
 # therefore cannot be certified by the source-only CPU aggregate. Fail closed
 # on a direct edit until each test is moved behind explicit model ownership or
@@ -527,9 +525,7 @@ def _classify_path(path: str, catalog: OwnershipCatalog) -> tuple[str, str | Non
             "model-coupled test has no isolated model owner; move it into a "
             f"MODEL.toml contract or use a synthetic plugin before changing it: {path}"
         )
-    if path in UNIT_TEST_ONLY_EXACT or any(
-        path.startswith(prefix) for prefix in CLI_UNIT_ONLY_PREFIXES
-    ):
+    if path in UNIT_TEST_ONLY_EXACT:
         return "unit_cli", None
     if any(
         path.startswith(prefix) for prefix in UNIT_TEST_ONLY_PREFIXES


### PR DESCRIPTION
## Background

SegFormer preprocessing was hard-coded in `src/cli/main.cpp`, so the model plugin expected already-normalized CHW input and the existing model-owned preprocessing seam was bypassed. The timm ViT classification path had the same ownership problem. In addition, `tools/model_ci.py` classified every `src/cli/` edit as unit-only, which allowed runtime image preprocessing changes to reach premerge with zero model proofs.

## Exit Criteria

- SegFormer and timm ViT pipelines accept the public raw RGB HWC `[0, 1]` image contract and apply bundle-defined transforms inside the owning model family.
- HF references use the model libraries' corresponding preprocessing semantics.
- Runtime CLI changes select model proofs instead of unit tests only.
- Preserve SegFormer's existing engine-resolution class-map output and model precision.

## Implementation

- Move SegFormer bilinear resize, ImageNet normalization, and CHW conversion into its runtime plugin; parse dimensions and normalization values from bundle config.
- Route SegFormer argmax through its model-owned postprocess seam without changing the established 128x128 class-map contract.
- Add a timm ViT preprocessing seam for official short-edge resize, center crop, normalization, and interpolation. The resize geometry matches timm/torchvision (`floor(224 / 0.9) = 248` for the supported model).
- Make the generic `segment` and `classify` CLI commands pass decoded raw images to the model pipelines.
- Remove the blanket `src/cli/` unit-only CI classification. Runtime CLI changes now use the configured premerge fallback models, while direct ownership also selects SegFormer and timm ViT.

## Validation

- `PYTHONPATH=python python3 -m pytest tests/tools/test_model_ci.py tests/e2e/models/timm_vit/test_timm_vit_family_plugin.py -q`: 55 passed.
- Focused local C++ build and CTest for SegFormer preprocessing/postprocessing and timm ViT preprocessing: passed.
- `python3 tools/legal_headers.py --check`: passed with zero findings.
- Focused cyclomatic-complexity check for changed model sources: passed; maximum CCN 9.
- P2021 CTest for SegFormer preprocessing, postprocessing, GPU pipeline, and timm ViT preprocessing: 4/4 passed.
- P2021 model E2E with existing bundles: SegFormer 1 passed; timm ViT 1 passed.
- P2021 ADE20K limit-10, seed 1234: passed; HF/TRTMC mIoU `0.220123/0.220582`, backend pixel agreement `0.995148`, backend mIoU `0.950854`.
- P2021 Imagenette limit-10, seed 1234: passed; HF/TRTMC top-1 accuracy `0.7000/0.7000`, top-1 agreement `1.0000`.
- Final CI impact calculation: `expected_count=6`, including direct `segformer` and `timm_vit` coverage plus the five configured platform fallback representatives.

## Notes For Future Readers

- Review the model-owned preprocessing seams first, then the thin CLI deletion, then the CI routing change.
- The impact set is intentionally broader than two models because this PR also changes the public pipeline contract, runtime CLI, and CI impact tool. It is no longer allowed to produce a zero-model premerge matrix.
- Prompted segmentation is unchanged. No model precision or engine input shape was changed.
