### PR TITLE
feat(task-eval): add vision benchmark suites

### DIFF
--- a/tests/e2e/models/sam/e2e_plugins/runners/segmentation.py
+++ b/tests/e2e/models/sam/e2e_plugins/runners/segmentation.py
@@ -137,6 +137,8 @@ class PromptedSegmentationRunner:
         runtime_cli_python = ctx.runtime_cli_hf_python()
         if runtime_cli_python:
             cmd.extend(["--hf-python", str(runtime_cli_python)])
+        if ctx.model_plugin_dir:
+            cmd.extend(["--model-plugin-dir", ctx.model_plugin_dir])
         cmd = _wrap_distributed_command(cmd, case)
 
         env = dict(os.environ)

--- a/tests/e2e/models/segformer/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/segformer/e2e_plugins/references/hf_transformers.py
@@ -632,6 +632,7 @@ class HfTransformersReference:
         artifacts_dir = ctx.artifacts_dir or tempfile.gettempdir()
         model_dir = _case_artifact_dir(artifacts_dir, case.name) if ctx.artifacts_dir else artifacts_dir
         output_path = str(Path(model_dir) / "hf_seg.npy")
+        raw_output_path = str(Path(model_dir) / "hf_seg_raw.npy")
 
         image_path = self._resolve_image_path(case.inputs.get("image", ""))
         trust_remote_code = case.metadata.get("trust_remote_code", False)
@@ -647,6 +648,7 @@ class HfTransformersReference:
             image_path = {image_path!r}
             trust_remote_code = {trust_remote_code!r}
             output_path = {output_path!r}
+            raw_output_path = {raw_output_path!r}
 
             processor = AutoImageProcessor.from_pretrained(
                 hf_id, trust_remote_code=trust_remote_code)
@@ -659,8 +661,12 @@ class HfTransformersReference:
             inputs = processor(images=image, return_tensors="pt")
             with torch.no_grad():
                 outputs = model(**inputs)
-            logits = outputs.logits[0].float().cpu().numpy()
-            class_map = np.argmax(logits, axis=0).astype(np.int32)
+            raw_class_map = outputs.logits[0].argmax(dim=0)
+            raw_class_map = raw_class_map.cpu().numpy().astype(np.int32)
+            np.save(raw_output_path, raw_class_map)
+            class_map = processor.post_process_semantic_segmentation(
+                outputs, target_sizes=[image.size[::-1]])[0]
+            class_map = class_map.cpu().numpy().astype(np.int32)
             np.save(output_path, class_map)
             print(f"OK classes={{class_map.max() + 1}}")
         """)
@@ -672,6 +678,8 @@ class HfTransformersReference:
                 import numpy as np
 
                 data["class_map"] = np.load(output_path)
+                if Path(raw_output_path).is_file():
+                    data["raw_class_map_path"] = raw_output_path
 
                 try:
                     from PIL import Image

--- a/tests/e2e/models/segformer/e2e_plugins/runners/segmentation.py
+++ b/tests/e2e/models/segformer/e2e_plugins/runners/segmentation.py
@@ -132,6 +132,8 @@ class SegmentationRunner:
         runtime_cli_python = ctx.runtime_cli_hf_python()
         if runtime_cli_python:
             cmd.extend(["--hf-python", str(runtime_cli_python)])
+        if ctx.model_plugin_dir:
+            cmd.extend(["--model-plugin-dir", ctx.model_plugin_dir])
         cmd = _wrap_distributed_command(cmd, case)
 
         env = dict(os.environ)

--- a/tests/e2e/models/timm_vit/e2e_plugins/runners/image_classification.py
+++ b/tests/e2e/models/timm_vit/e2e_plugins/runners/image_classification.py
@@ -119,6 +119,8 @@ class ImageClassificationRunner:
         runtime_cli_python = ctx.runtime_cli_hf_python()
         if runtime_cli_python:
             cmd.extend(["--hf-python", runtime_cli_python])
+        if ctx.model_plugin_dir:
+            cmd.extend(["--model-plugin-dir", ctx.model_plugin_dir])
 
         env = dict(os.environ)
         if ctx.ld_library_path:

--- a/tests/task_eval/validation_suites.yaml
+++ b/tests/task_eval/validation_suites.yaml
@@ -584,6 +584,123 @@ suites:
       notes: >
         P2021-only until the DPG-Bench scorecard is visually calibrated.
 
+  - id: imagenette_image_classification
+    description: >
+      HF-to-TRTMC image-classification parity on Imagenette validation, a
+      public ten-class subset of ImageNet-1k. The selected timm checkpoint was
+      fine-tuned on ImageNet-1k at 224x224, so labels retain their original
+      ImageNet-1k class IDs. Gold top-1 accuracy and backend agreement are
+      reported separately.
+    user_contract: image_classification
+    default_model_names:
+      - timm-vit-base-p16-224-augreg-in21k-ft-in1k
+    dataset:
+      kind: image_classification_json
+      name: Imagenette 320 validation (ImageNet-1k subset)
+      default_path: /mnt/data/Imagenette/imagenette2-320_task_eval.json
+      image_field: image
+      answer_field: label
+      subject_field: synset
+    selectors:
+      task_strategies:
+        - image_classification
+      runtime_strategies:
+        - timm_vit_image_classification
+      families:
+        - timm_vit
+      user_contracts:
+        - image_classification
+    scoring:
+      scorer: image_classification_parity
+      task_metric: top1_accuracy
+    gates:
+      max_top1_accuracy_drop_from_hf: 0.01
+      min_top1_agreement: 0.98
+    ci:
+      eligible: false
+      lane: local_only
+
+  - id: ade20k_semantic_segmentation
+    description: >
+      Semantic-segmentation parity and task quality on the ADE20K validation
+      split used by the SegFormer checkpoint. Ground-truth labels are normalized
+      to the checkpoint's 0..149 scene_parse_150 IDs with 255 as ignore.
+    user_contract: segmentation_mask
+    default_model_names:
+      - segformer-b0-ade
+    dataset:
+      kind: semantic_segmentation_json
+      name: ADE20K validation
+      default_path: /mnt/data/ADE20K/ade20k_validation_task_eval.json
+      image_field: image
+      mask_field: mask
+      subject_field: subset
+      num_classes: 150
+      ignore_index: 255
+    selectors:
+      task_strategies:
+        - segmentation
+      runtime_strategies:
+        - segformer_segmentation
+      families:
+        - segformer
+      user_contracts:
+        - segmentation_mask
+    scoring:
+      scorer: semantic_segmentation_parity
+      task_metric: mean_iou
+    gates:
+      min_backend_pixel_agreement: 0.98
+      min_backend_mean_iou: 0.95
+      max_mean_iou_drop_from_hf: 0.01
+    ci:
+      eligible: false
+      lane: local_only
+
+  - id: coco2017_prompted_segmentation
+    description: >
+      Point-prompted segmentation parity on COCO 2017 validation. SAM uses a
+      deterministic foreground point and its instance mask. Backend mask
+      agreement is gated while COCO ground-truth IoU is reported and guarded
+      against regression from the HF reference.
+    user_contract: prompted_mask
+    default_model_names:
+      - sam-vit-base
+    dataset:
+      kind: prompted_segmentation_json
+      name: COCO 2017 validation prompted segmentation
+      default_path: /mnt/data/COCO2017_prompted_segmentation/coco2017_prompted_segmentation.json
+      image_field: image
+      point_mask_field: instance_mask
+      text_mask_field: category_mask
+      subject_field: category
+    selectors:
+      task_strategies:
+        - prompted_segmentation
+      runtime_strategies:
+        - sam_prompted_segmentation
+      families:
+        - sam
+      user_contracts:
+        - prompted_mask
+    scoring:
+      scorer: prompted_segmentation_parity
+      task_metric: mask_iou
+    gates:
+      # Match the reviewed SAM model-owned iou_per_prompt contract. The
+      # aggregate COCO ground-truth guard below independently prevents a
+      # numerically close but worse task result from passing.
+      min_backend_mask_iou: 0.70
+      max_ground_truth_iou_drop_from_hf: 0.05
+    model_overrides:
+      by_family:
+        sam:
+          prompt_mode: point
+          ground_truth_mask_field: instance_mask
+    ci:
+      eligible: false
+      lane: local_only
+
   - id: stsbenchmark_encoder_embedding_parity
     description: >
       HF-versus-TRTMC vector parity for encoder-only NLP and text embedding

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -297,6 +297,321 @@ def test_default_suites_include_one_dpg_bench_diffusion_image_suite() -> None:
     }
 
 
+def test_default_suites_include_model_aligned_vision_tasks() -> None:
+    suites = task_eval.load_suites()
+
+    classification = task_eval.suite_by_id(suites, "imagenette_image_classification")
+    assert classification["dataset"]["kind"] == "image_classification_json"
+    assert classification["scoring"]["task_metric"] == "top1_accuracy"
+    assert classification["default_model_names"] == [
+        "timm-vit-base-p16-224-augreg-in21k-ft-in1k"
+    ]
+
+    semantic = task_eval.suite_by_id(suites, "ade20k_semantic_segmentation")
+    assert semantic["dataset"]["kind"] == "semantic_segmentation_json"
+    assert semantic["dataset"]["num_classes"] == 150
+    assert semantic["scoring"]["task_metric"] == "mean_iou"
+    assert semantic["default_model_names"] == ["segformer-b0-ade"]
+
+    prompted = task_eval.suite_by_id(suites, "coco2017_prompted_segmentation")
+    assert prompted["dataset"]["kind"] == "prompted_segmentation_json"
+    assert prompted["default_model_names"] == ["sam-vit-base"]
+    assert prompted["model_overrides"]["by_family"]["sam"]["prompt_mode"] == "point"
+
+
+def test_prepare_vision_datasets_resolves_model_specific_assets(tmp_path: Path) -> None:
+    image = tmp_path / "image.jpg"
+    mask = tmp_path / "mask.png"
+    category_mask = tmp_path / "category.png"
+    for path in (image, mask, category_mask):
+        path.write_bytes(b"fixture")
+
+    cases = [
+        (
+            "imagenette_image_classification",
+            {
+                "id": "class-1",
+                "image": image.name,
+                "label": 217,
+                "label_name": "English springer",
+                "synset": "n02102040",
+            },
+            task_eval.prepare_image_classification_dataset,
+        ),
+        (
+            "ade20k_semantic_segmentation",
+            {"id": "seg-1", "image": image.name, "mask": mask.name, "subset": "validation"},
+            task_eval.prepare_semantic_segmentation_dataset,
+        ),
+        (
+            "coco2017_prompted_segmentation",
+            {
+                "id": "prompt-1",
+                "image": image.name,
+                "instance_mask": mask.name,
+                "category_mask": category_mask.name,
+                "point_x": 0.25,
+                "point_y": 0.75,
+                "text_prompt": "dog",
+                "category": "dog",
+            },
+            task_eval.prepare_prompted_segmentation_dataset,
+        ),
+    ]
+    suites = task_eval.load_suites()
+    for suite_id, request, prepare in cases:
+        dataset = tmp_path / f"{suite_id}.json"
+        dataset.write_text(
+            json.dumps({"dataset": suite_id, "requests": [request]}), encoding="utf-8"
+        )
+        outputs = prepare(
+            dataset_path=dataset,
+            work_dir=tmp_path / f"work-{suite_id}",
+            suite=task_eval.suite_by_id(suites, suite_id),
+        )
+        rows = task_eval.load_jsonl(outputs["prompts"])
+        assert len(rows) == 1
+        assert rows[0]["image"] == str(image.resolve())
+        manifest = json.loads(outputs["manifest"].read_text(encoding="utf-8"))
+        assert manifest["request_count"] == 1
+
+
+def test_image_classification_parity_separates_accuracy_and_agreement() -> None:
+    answers = {
+        "requests": [
+            {"sample_id": "a", "label": 1, "label_name": "one"},
+            {"sample_id": "b", "label": 2, "label_name": "two"},
+        ]
+    }
+    hf = {"responses": [{"sample_id": "a", "top_class": 1}, {"sample_id": "b", "top_class": 0}]}
+    trtfb = {
+        "responses": [
+            {"sample_id": "a", "top_class": 1},
+            {"sample_id": "b", "top_class": 0},
+        ]
+    }
+
+    summary = task_eval.compare_image_classification_prediction_sets(
+        hf, trtfb, answers, gates={"min_top1_agreement": 1.0}
+    )
+
+    assert summary["status"] == "passed"
+    assert summary["hf_top1_accuracy"] == 0.5
+    assert summary["trtfb_top1_accuracy"] == 0.5
+    assert summary["top1_agreement"] == 1.0
+
+
+def test_image_classification_runner_forwards_model_plugin_dir(monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from tests.e2e.models.timm_vit.e2e_plugins.runners import image_classification
+    from tests.e2e_harness.contracts import RunContext
+
+    case = task_eval.load_manifest(
+        Path(
+            "tests/e2e/models/timm_vit/manifests/"
+            "timm-vit-base-p16-224-augreg-in21k-ft-in1k.json"
+        )
+    )
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(returncode=0, stdout='{"top_class": 1}', stderr="")
+
+    monkeypatch.setattr(image_classification.subprocess, "run", fake_run)
+    context = RunContext(
+        case=case,
+        binary_path="/tmp/trtmc",
+        engine_dir="/tmp/engines",
+        model_plugin_dir="/tmp/plugins/timm_vit",
+    )
+
+    image_classification.ImageClassificationRunner().run_stage(
+        case, case.stages[0], context
+    )
+
+    assert commands[0][-2:] == ["--model-plugin-dir", "/tmp/plugins/timm_vit"]
+
+
+def test_semantic_segmentation_parity_reports_dataset_miou(tmp_path: Path) -> None:
+    import numpy as np
+
+    ground = np.array([[0, 0], [1, 1]], dtype=np.uint8)
+    hf_map = ground.copy()
+    trtfb_map = ground.copy()
+    paths = {}
+    for name, values in (("ground", ground), ("hf", hf_map), ("trtfb", trtfb_map)):
+        path = tmp_path / f"{name}.npy"
+        np.save(path, values)
+        paths[name] = path
+    answers = {"requests": [{"sample_id": "seg", "mask": str(paths["ground"])}]}
+    hf = {"responses": [{"sample_id": "seg", "class_map_path": str(paths["hf"])}]}
+    trtfb = {
+        "responses": [{"sample_id": "seg", "class_map_path": str(paths["trtfb"])}]
+    }
+
+    summary = task_eval.compare_semantic_segmentation_prediction_sets(
+        hf,
+        trtfb,
+        answers,
+        gates={},
+        num_classes=2,
+        ignore_index=255,
+    )
+
+    assert summary["status"] == "passed"
+    assert summary["hf_mean_iou"] == 1.0
+    assert summary["trtfb_mean_iou"] == 1.0
+    assert summary["backend_pixel_agreement"] == 1.0
+
+
+def test_semantic_segmentation_uses_raw_hf_map_for_backend_parity(
+    tmp_path: Path,
+) -> None:
+    import numpy as np
+
+    ground = np.array([[0, 0], [1, 1]], dtype=np.uint8)
+    hf_postprocessed = ground.copy()
+    hf_raw = np.array([[0]], dtype=np.uint8)
+    trtfb_raw = hf_raw.copy()
+    paths = {}
+    for name, values in (
+        ("ground", ground),
+        ("hf", hf_postprocessed),
+        ("hf_raw", hf_raw),
+        ("trtfb", trtfb_raw),
+    ):
+        path = tmp_path / f"{name}.npy"
+        np.save(path, values)
+        paths[name] = path
+    answers = {"requests": [{"sample_id": "seg", "mask": str(paths["ground"])}]}
+    hf = {
+        "responses": [
+            {
+                "sample_id": "seg",
+                "class_map_path": str(paths["hf"]),
+                "raw_class_map_path": str(paths["hf_raw"]),
+            }
+        ]
+    }
+    trtfb = {
+        "responses": [{"sample_id": "seg", "class_map_path": str(paths["trtfb"])}]
+    }
+
+    summary = task_eval.compare_semantic_segmentation_prediction_sets(
+        hf,
+        trtfb,
+        answers,
+        gates={"max_mean_iou_drop_from_hf": 1.0},
+        num_classes=2,
+        ignore_index=255,
+    )
+
+    assert summary["hf_mean_iou"] == 1.0
+    assert summary["backend_pixel_agreement"] == 1.0
+    assert summary["backend_mean_iou"] == 1.0
+
+
+def test_prompted_segmentation_uses_family_prompt_semantics(tmp_path: Path) -> None:
+    import numpy as np
+
+    ground = np.array([[1, 1], [0, 0]], dtype=np.uint8)
+    masks = np.stack([ground, np.zeros_like(ground)])
+    ground_path = tmp_path / "ground.npy"
+    hf_path = tmp_path / "hf.npy"
+    trtfb_path = tmp_path / "trtfb.npy"
+    np.save(ground_path, ground)
+    np.save(hf_path, masks)
+    np.save(trtfb_path, masks)
+    answers = {
+        "requests": [
+            {
+                "sample_id": "prompt",
+                "instance_mask": str(ground_path),
+                "category_mask": str(ground_path),
+                "text_prompt": "object",
+            }
+        ]
+    }
+    hf = {
+        "responses": [
+            {"sample_id": "prompt", "masks_path": str(hf_path), "mask_scores": [0.9, 0.1]}
+        ]
+    }
+    trtfb = {
+        "responses": [
+            {
+                "sample_id": "prompt",
+                "masks_path": str(trtfb_path),
+                "mask_scores": [0.9, 0.1],
+            }
+        ]
+    }
+
+    point = task_eval.compare_prompted_segmentation_prediction_sets(
+        hf,
+        trtfb,
+        answers,
+        gates={},
+        prompt_mode="point",
+        ground_truth_mask_field="instance_mask",
+    )
+    text = task_eval.compare_prompted_segmentation_prediction_sets(
+        hf,
+        trtfb,
+        answers,
+        gates={},
+        prompt_mode="text",
+        ground_truth_mask_field="category_mask",
+    )
+
+    assert point["status"] == "passed"
+    assert text["status"] == "passed"
+    assert point["mean_backend_mask_iou"] == 1.0
+    assert text["mean_backend_mask_iou"] == 1.0
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        (
+            {
+                "mode": "image_classification_parity",
+                "hf_top1_accuracy": 1.0,
+                "trtfb_top1_accuracy": 1.0,
+                "top1_agreement": 1.0,
+            },
+            "hf_top1=1.0000",
+        ),
+        (
+            {
+                "mode": "semantic_segmentation_parity",
+                "hf_mean_iou": 0.5,
+                "trtfb_mean_iou": 0.5,
+                "backend_mean_iou": 1.0,
+            },
+            "backend_miou=1.0000",
+        ),
+        (
+            {
+                "mode": "prompted_segmentation_parity",
+                "mean_backend_mask_iou": 1.0,
+                "hf_mean_ground_truth_iou": 0.8,
+                "trtfb_mean_ground_truth_iou": 0.8,
+            },
+            "backend_mask_iou=1.0000",
+        ),
+    ],
+)
+def test_vision_result_lines_use_task_specific_metrics(result, expected) -> None:
+    result.update({"hf_reused": False, "bundle_built": False, "status": "passed"})
+
+    line = task_eval._format_result_line({"name": "vision-model"}, result)
+
+    assert expected in line
+
+
 def test_default_suites_include_encoder_embedding_parity() -> None:
     suite = task_eval.suite_by_id(
         task_eval.load_suites(), "stsbenchmark_encoder_embedding_parity"

--- a/tools/prepare_vision_task_eval_datasets.py
+++ b/tools/prepare_vision_task_eval_datasets.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prepare model-aligned classification and segmentation task-eval datasets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+
+
+IMAGENET_CLASS_IDS = {
+    "n01440764": (0, "tench"),
+    "n02102040": (217, "English springer"),
+    "n02979186": (482, "cassette player"),
+    "n03000684": (491, "chain saw"),
+    "n03028079": (497, "church"),
+    "n03394916": (566, "French horn"),
+    "n03417042": (569, "garbage truck"),
+    "n03425413": (571, "gas pump"),
+    "n03445777": (574, "golf ball"),
+    "n03888257": (701, "parachute"),
+}
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def prepare_imagenette(source_root: Path, output_root: Path) -> Path:
+    validation_root = source_root / "val"
+    output_dir = output_root / "Imagenette"
+    requests: list[dict[str, Any]] = []
+    for synset, (label, label_name) in IMAGENET_CLASS_IDS.items():
+        class_dir = validation_root / synset
+        if not class_dir.is_dir():
+            raise FileNotFoundError(f"Imagenette class directory not found: {class_dir}")
+        for image_path in sorted(class_dir.iterdir()):
+            if not image_path.is_file():
+                continue
+            relative = Path("images") / "val" / synset / image_path.name
+            destination = output_dir / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(image_path, destination)
+            requests.append(
+                {
+                    "id": f"imagenette_{synset}_{image_path.stem}",
+                    "image": relative.as_posix(),
+                    "label": label,
+                    "label_name": label_name,
+                    "synset": synset,
+                    "subset": "validation",
+                }
+            )
+    output = output_dir / "imagenette2-320_task_eval.json"
+    _write_json(
+        output,
+        {
+            "dataset": "Imagenette 320 validation",
+            "source": "https://s3.amazonaws.com/fast-ai-imageclas/imagenette2-320.tgz",
+            "label_space": "ImageNet-1k original class IDs",
+            "requests": requests,
+        },
+    )
+    return output
+
+
+def prepare_ade20k(source_root: Path, output_root: Path) -> Path:
+    image_root = source_root / "images" / "validation"
+    annotation_root = source_root / "annotations" / "validation"
+    output_dir = output_root / "ADE20K"
+    requests: list[dict[str, Any]] = []
+    for image_path in sorted(image_root.glob("*.jpg")):
+        annotation_path = annotation_root / f"{image_path.stem}.png"
+        if not annotation_path.is_file():
+            raise FileNotFoundError(f"ADE20K annotation not found: {annotation_path}")
+        image_relative = Path("images") / "validation" / image_path.name
+        mask_relative = Path("masks") / "validation" / annotation_path.name
+        image_destination = output_dir / image_relative
+        mask_destination = output_dir / mask_relative
+        image_destination.parent.mkdir(parents=True, exist_ok=True)
+        mask_destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(image_path, image_destination)
+        raw_mask = np.asarray(Image.open(annotation_path).convert("L"), dtype=np.uint8)
+        normalized = np.where(raw_mask == 0, 255, raw_mask - 1).astype(np.uint8)
+        Image.fromarray(normalized, mode="L").save(mask_destination)
+        requests.append(
+            {
+                "id": f"ade20k_{image_path.stem}",
+                "image": image_relative.as_posix(),
+                "mask": mask_relative.as_posix(),
+                "subset": "validation",
+            }
+        )
+    output = output_dir / "ade20k_validation_task_eval.json"
+    _write_json(
+        output,
+        {
+            "dataset": "ADE20K validation",
+            "source": "http://data.csail.mit.edu/places/ADEchallenge/ADEChallengeData2016.zip",
+            "label_normalization": "source 1..150 -> 0..149; source 0 -> ignore 255",
+            "num_classes": 150,
+            "ignore_index": 255,
+            "requests": requests,
+        },
+    )
+    return output
+
+
+def _interior_point(mask: np.ndarray) -> tuple[float, float]:
+    height, width = mask.shape
+    ys, xs = np.nonzero(mask)
+    if xs.size == 0:
+        raise ValueError("Cannot create a point prompt from an empty mask")
+    center_x = int(round(float(xs.mean())))
+    center_y = int(round(float(ys.mean())))
+    if not (0 <= center_x < width and 0 <= center_y < height and mask[center_y, center_x]):
+        middle = xs.size // 2
+        center_x = int(xs[middle])
+        center_y = int(ys[middle])
+    return ((center_x + 0.5) / width, (center_y + 0.5) / height)
+
+
+def _balanced_coco_groups(coco: Any, limit: int) -> list[tuple[int, int, list[dict[str, Any]]]]:
+    grouped: dict[int, list[tuple[int, list[dict[str, Any]]]]] = defaultdict(list)
+    for image_id in sorted(coco.imgs):
+        annotations = coco.loadAnns(coco.getAnnIds(imgIds=[image_id]))
+        by_category: dict[int, list[dict[str, Any]]] = defaultdict(list)
+        for annotation in annotations:
+            by_category[int(annotation["category_id"])].append(annotation)
+        image = coco.imgs[image_id]
+        image_area = float(image["height"] * image["width"])
+        for category_id, category_annotations in by_category.items():
+            instances = [ann for ann in category_annotations if not ann.get("iscrowd", 0)]
+            if not instances:
+                continue
+            largest = max(float(ann.get("area", 0.0)) for ann in instances)
+            if largest < image_area * 0.01:
+                continue
+            grouped[category_id].append((image_id, category_annotations))
+
+    selected: list[tuple[int, int, list[dict[str, Any]]]] = []
+    per_category = max(1, math.ceil(limit / max(1, len(grouped))))
+    for offset in range(per_category):
+        for category_id in sorted(grouped):
+            rows = grouped[category_id]
+            if offset >= len(rows):
+                continue
+            image_id, annotations = rows[offset]
+            selected.append((image_id, category_id, annotations))
+            if len(selected) >= limit:
+                return selected
+    return selected
+
+
+def prepare_coco(source_root: Path, output_root: Path, limit: int) -> Path:
+    try:
+        from pycocotools.coco import COCO
+    except ImportError as exc:
+        raise RuntimeError("COCO preparation requires pycocotools") from exc
+
+    annotation_file = source_root / "annotations" / "instances_val2017.json"
+    image_root = source_root / "val2017"
+    coco = COCO(str(annotation_file))
+    output_dir = output_root / "COCO2017_prompted_segmentation"
+    requests: list[dict[str, Any]] = []
+    copied_images: set[int] = set()
+    for image_id, category_id, category_annotations in _balanced_coco_groups(coco, limit):
+        image = coco.imgs[image_id]
+        category = coco.cats[category_id]
+        non_crowd = [
+            ann for ann in category_annotations if not ann.get("iscrowd", 0)
+        ]
+        instance = max(non_crowd, key=lambda ann: float(ann.get("area", 0.0)))
+        instance_mask = coco.annToMask(instance).astype(bool)
+        category_mask = np.zeros_like(instance_mask)
+        for annotation in category_annotations:
+            category_mask |= coco.annToMask(annotation).astype(bool)
+        point_x, point_y = _interior_point(instance_mask)
+
+        image_relative = Path("images") / image["file_name"]
+        if image_id not in copied_images:
+            image_destination = output_dir / image_relative
+            image_destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(image_root / image["file_name"], image_destination)
+            copied_images.add(image_id)
+        stem = f"{image_id:012d}_{category_id:03d}"
+        instance_relative = Path("masks") / "instances" / f"{stem}.png"
+        category_relative = Path("masks") / "categories" / f"{stem}.png"
+        for relative, mask in (
+            (instance_relative, instance_mask),
+            (category_relative, category_mask),
+        ):
+            destination = output_dir / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            Image.fromarray(mask.astype(np.uint8) * 255, mode="L").save(destination)
+        requests.append(
+            {
+                "id": f"coco2017_{stem}",
+                "image": image_relative.as_posix(),
+                "instance_mask": instance_relative.as_posix(),
+                "category_mask": category_relative.as_posix(),
+                "point_x": point_x,
+                "point_y": point_y,
+                "text_prompt": str(category["name"]),
+                "category": str(category["name"]),
+                "category_id": category_id,
+                "image_id": image_id,
+                "annotation_id": int(instance["id"]),
+                "subset": "val2017",
+            }
+        )
+    output = output_dir / "coco2017_prompted_segmentation.json"
+    _write_json(
+        output,
+        {
+            "dataset": "COCO 2017 validation prompted segmentation",
+            "sources": [
+                "http://images.cocodataset.org/zips/val2017.zip",
+                "http://images.cocodataset.org/annotations/annotations_trainval2017.zip",
+            ],
+            "sampling": "category-balanced round-robin; largest non-crowd instance >=1% image",
+            "requests": requests,
+        },
+    )
+    return output
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--imagenette-root", type=Path, required=True)
+    parser.add_argument("--ade20k-root", type=Path, required=True)
+    parser.add_argument("--coco-root", type=Path, required=True)
+    parser.add_argument("--output-root", type=Path, required=True)
+    parser.add_argument("--coco-limit", type=int, default=500)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    outputs = [
+        prepare_imagenette(args.imagenette_root, args.output_root),
+        prepare_ade20k(args.ade20k_root, args.output_root),
+        prepare_coco(args.coco_root, args.output_root, args.coco_limit),
+    ]
+    for output in outputs:
+        data = json.loads(output.read_text(encoding="utf-8"))
+        print(f"{output}: {len(data['requests'])} requests")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -1194,6 +1194,266 @@ def resolve_dataset_asset_path(dataset_path: Path, asset_ref: str) -> Path:
     raise FileNotFoundError(f"Could not resolve dataset asset {asset_ref!r}; tried: {candidates}")
 
 
+def _load_indexed_json_requests(
+    dataset_path: Path,
+    *,
+    subject: str,
+    subject_field: str,
+    limit: int,
+    sample_seed: int | None,
+) -> tuple[dict[str, Any], list[tuple[int, dict[str, Any]]]]:
+    data = json.loads(dataset_path.read_text(encoding="utf-8"))
+    requests = data.get("requests")
+    if not isinstance(requests, list):
+        raise ValueError(f"{dataset_path}: expected top-level 'requests' list")
+    indexed: list[tuple[int, dict[str, Any]]] = []
+    for index, request in enumerate(requests):
+        if not isinstance(request, dict):
+            raise ValueError(f"{dataset_path}: request {index} must be an object")
+        if subject and str(request.get(subject_field, "")) != subject:
+            continue
+        indexed.append((index, request))
+    if sample_seed is not None:
+        random.Random(sample_seed).shuffle(indexed)
+    if limit > 0:
+        indexed = indexed[:limit]
+    return data, indexed
+
+
+def _write_vision_task_dataset(
+    *,
+    dataset_path: Path,
+    work_dir: Path,
+    suite: dict[str, Any],
+    data: dict[str, Any],
+    indexed: list[tuple[int, dict[str, Any]]],
+    prompt_rows: list[dict[str, Any]],
+    prepared_requests: list[dict[str, Any]],
+    limit: int,
+    subject: str,
+    sample_seed: int | None,
+    task_eval_config: dict[str, Any] | None,
+) -> dict[str, Path]:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    answers_path = work_dir / "answers.json"
+    prompts_path = work_dir / "prompts.jsonl"
+    manifest_path = work_dir / "manifest.json"
+    answers = _copy_dataset_header(data, prepared_requests)
+    answers["scoring"] = suite.get("scoring", {})
+    answers_path.write_text(
+        json.dumps(answers, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    with prompts_path.open("w", encoding="utf-8") as prompts_file:
+        for row in prompt_rows:
+            prompts_file.write(json.dumps(row, ensure_ascii=False) + "\n")
+    manifest = {
+        "suite": suite["id"],
+        "dataset": str(dataset_path),
+        "dataset_kind": suite.get("dataset", {}).get("kind", ""),
+        "request_count": len(indexed),
+        "subject": subject or "all",
+        "limit": limit,
+        "sample_seed": sample_seed,
+        "scoring": suite.get("scoring", {}),
+        "files": {"answers": str(answers_path), "prompts": str(prompts_path)},
+    }
+    if task_eval_config:
+        manifest["task_eval"] = task_eval_config
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return {"answers": answers_path, "prompts": prompts_path, "manifest": manifest_path}
+
+
+def prepare_image_classification_dataset(
+    *,
+    dataset_path: Path,
+    work_dir: Path,
+    suite: dict[str, Any],
+    limit: int = 0,
+    subject: str = "",
+    sample_seed: int | None = None,
+    task_eval_config: dict[str, Any] | None = None,
+) -> dict[str, Path]:
+    dataset_config = suite.get("dataset", {})
+    subject_field = str(dataset_config.get("subject_field", "synset"))
+    data, indexed = _load_indexed_json_requests(
+        dataset_path,
+        subject=subject,
+        subject_field=subject_field,
+        limit=limit,
+        sample_seed=sample_seed,
+    )
+    prepared_requests: list[dict[str, Any]] = []
+    prompt_rows: list[dict[str, Any]] = []
+    for eval_index, (dataset_index, request) in enumerate(indexed):
+        image_ref = str(request.get("image", "") or "")
+        if not image_ref:
+            raise ValueError(f"{dataset_path}: request {dataset_index} has no image")
+        try:
+            label = int(request["label"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{dataset_path}: request {dataset_index} has invalid label"
+            ) from exc
+        image_path = resolve_dataset_asset_path(dataset_path, image_ref)
+        sample_id = str(request.get("id", f"imagenette_{dataset_index:06d}"))
+        row = {
+            "sample_id": sample_id,
+            "dataset_index": dataset_index,
+            "eval_index": eval_index,
+            "subject": str(request.get(subject_field, "")),
+            "image": str(image_path),
+            "label": label,
+            "label_name": str(request.get("label_name", "")),
+        }
+        prompt_rows.append(row)
+        prepared_requests.append({**request, **row})
+    return _write_vision_task_dataset(
+        dataset_path=dataset_path,
+        work_dir=work_dir,
+        suite=suite,
+        data=data,
+        indexed=indexed,
+        prompt_rows=prompt_rows,
+        prepared_requests=prepared_requests,
+        limit=limit,
+        subject=subject,
+        sample_seed=sample_seed,
+        task_eval_config=task_eval_config,
+    )
+
+
+def prepare_semantic_segmentation_dataset(
+    *,
+    dataset_path: Path,
+    work_dir: Path,
+    suite: dict[str, Any],
+    limit: int = 0,
+    subject: str = "",
+    sample_seed: int | None = None,
+    task_eval_config: dict[str, Any] | None = None,
+) -> dict[str, Path]:
+    dataset_config = suite.get("dataset", {})
+    subject_field = str(dataset_config.get("subject_field", "subset"))
+    data, indexed = _load_indexed_json_requests(
+        dataset_path,
+        subject=subject,
+        subject_field=subject_field,
+        limit=limit,
+        sample_seed=sample_seed,
+    )
+    prepared_requests: list[dict[str, Any]] = []
+    prompt_rows: list[dict[str, Any]] = []
+    for eval_index, (dataset_index, request) in enumerate(indexed):
+        image_ref = str(request.get("image", "") or "")
+        mask_ref = str(request.get("mask", "") or "")
+        if not image_ref or not mask_ref:
+            raise ValueError(
+                f"{dataset_path}: request {dataset_index} requires image and mask"
+            )
+        image_path = resolve_dataset_asset_path(dataset_path, image_ref)
+        mask_path = resolve_dataset_asset_path(dataset_path, mask_ref)
+        sample_id = str(request.get("id", f"ade20k_{dataset_index:06d}"))
+        row = {
+            "sample_id": sample_id,
+            "dataset_index": dataset_index,
+            "eval_index": eval_index,
+            "subject": str(request.get(subject_field, "")),
+            "image": str(image_path),
+            "mask": str(mask_path),
+        }
+        prompt_rows.append(row)
+        prepared_requests.append({**request, **row})
+    return _write_vision_task_dataset(
+        dataset_path=dataset_path,
+        work_dir=work_dir,
+        suite=suite,
+        data=data,
+        indexed=indexed,
+        prompt_rows=prompt_rows,
+        prepared_requests=prepared_requests,
+        limit=limit,
+        subject=subject,
+        sample_seed=sample_seed,
+        task_eval_config=task_eval_config,
+    )
+
+
+def prepare_prompted_segmentation_dataset(
+    *,
+    dataset_path: Path,
+    work_dir: Path,
+    suite: dict[str, Any],
+    limit: int = 0,
+    subject: str = "",
+    sample_seed: int | None = None,
+    task_eval_config: dict[str, Any] | None = None,
+) -> dict[str, Path]:
+    dataset_config = suite.get("dataset", {})
+    subject_field = str(dataset_config.get("subject_field", "category"))
+    data, indexed = _load_indexed_json_requests(
+        dataset_path,
+        subject=subject,
+        subject_field=subject_field,
+        limit=limit,
+        sample_seed=sample_seed,
+    )
+    prepared_requests: list[dict[str, Any]] = []
+    prompt_rows: list[dict[str, Any]] = []
+    for eval_index, (dataset_index, request) in enumerate(indexed):
+        required = ("image", "instance_mask", "category_mask", "text_prompt")
+        missing = [field for field in required if not request.get(field)]
+        if missing:
+            raise ValueError(
+                f"{dataset_path}: request {dataset_index} is missing {missing}"
+            )
+        try:
+            point_x = float(request["point_x"])
+            point_y = float(request["point_y"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{dataset_path}: request {dataset_index} has invalid point prompt"
+            ) from exc
+        if not (0.0 <= point_x <= 1.0 and 0.0 <= point_y <= 1.0):
+            raise ValueError(
+                f"{dataset_path}: request {dataset_index} point must be normalized"
+            )
+        image_path = resolve_dataset_asset_path(dataset_path, str(request["image"]))
+        instance_mask = resolve_dataset_asset_path(
+            dataset_path, str(request["instance_mask"])
+        )
+        category_mask = resolve_dataset_asset_path(
+            dataset_path, str(request["category_mask"])
+        )
+        sample_id = str(request.get("id", f"coco_prompt_{dataset_index:06d}"))
+        row = {
+            "sample_id": sample_id,
+            "dataset_index": dataset_index,
+            "eval_index": eval_index,
+            "subject": str(request.get(subject_field, "")),
+            "image": str(image_path),
+            "instance_mask": str(instance_mask),
+            "category_mask": str(category_mask),
+            "point_x": point_x,
+            "point_y": point_y,
+            "text_prompt": str(request["text_prompt"]),
+        }
+        prompt_rows.append(row)
+        prepared_requests.append({**request, **row})
+    return _write_vision_task_dataset(
+        dataset_path=dataset_path,
+        work_dir=work_dir,
+        suite=suite,
+        data=data,
+        indexed=indexed,
+        prompt_rows=prompt_rows,
+        prepared_requests=prepared_requests,
+        limit=limit,
+        subject=subject,
+        sample_seed=sample_seed,
+        task_eval_config=task_eval_config,
+    )
+
+
 def vlm_request_image_refs(request: dict[str, Any]) -> list[str]:
     refs: list[str] = []
     messages = request.get("messages")
@@ -1798,6 +2058,36 @@ def prepare_task_dataset(
         )
     if dataset_kind == "seedtts_json":
         return prepare_seedtts_dataset(
+            dataset_path=dataset_path,
+            work_dir=work_dir,
+            suite=suite,
+            limit=limit,
+            subject=subject,
+            sample_seed=sample_seed,
+            task_eval_config=task_eval_config,
+        )
+    if dataset_kind == "image_classification_json":
+        return prepare_image_classification_dataset(
+            dataset_path=dataset_path,
+            work_dir=work_dir,
+            suite=suite,
+            limit=limit,
+            subject=subject,
+            sample_seed=sample_seed,
+            task_eval_config=task_eval_config,
+        )
+    if dataset_kind == "semantic_segmentation_json":
+        return prepare_semantic_segmentation_dataset(
+            dataset_path=dataset_path,
+            work_dir=work_dir,
+            suite=suite,
+            limit=limit,
+            subject=subject,
+            sample_seed=sample_seed,
+            task_eval_config=task_eval_config,
+        )
+    if dataset_kind == "prompted_segmentation_json":
+        return prepare_prompted_segmentation_dataset(
             dataset_path=dataset_path,
             work_dir=work_dir,
             suite=suite,
@@ -4660,6 +4950,14 @@ def _is_encoder_embedding_dataset_kind(kind: str) -> bool:
     return kind == "sts_pair_jsonl"
 
 
+def _is_vision_task_dataset_kind(kind: str) -> bool:
+    return kind in {
+        "image_classification_json",
+        "semantic_segmentation_json",
+        "prompted_segmentation_json",
+    }
+
+
 def work_scoring(work_dir: Path) -> dict[str, Any]:
     scoring = work_manifest(work_dir).get("scoring", {})
     return scoring if isinstance(scoring, dict) else {}
@@ -5559,6 +5857,246 @@ def _run_nemo_asr_hf_pipeline_reference(
     write_predictions(pred_path, responses)
 
 
+def _load_vision_task_eval_plugins(work_dir: Path) -> tuple[Any, Any, Any]:
+    task_eval_config = work_manifest(work_dir).get("task_eval", {})
+    if not isinstance(task_eval_config, dict):
+        task_eval_config = {}
+    manifest_ref = str(task_eval_config.get("model_manifest", "") or "")
+    if not manifest_ref:
+        raise ValueError("vision task eval requires task_eval.model_manifest")
+    manifest_path = Path(manifest_ref)
+    if not manifest_path.is_absolute():
+        manifest_path = REPO_ROOT / manifest_path
+    case = load_manifest(manifest_path)
+    model_test_dir = str(case.metadata.get("model_test_dir", "") or "")
+    activate_model_plugins(model_test_dir)
+    reference = get_reference(case.reference_backend)
+    runner = get_runner(case.task_strategy)
+    if reference is None:
+        raise RuntimeError(
+            f"No reference plugin {case.reference_backend!r} for {case.family}"
+        )
+    if runner is None:
+        raise RuntimeError(f"No runner plugin {case.task_strategy!r} for {case.family}")
+    return case, reference, runner
+
+
+def _vision_case_for_request(
+    template: Any,
+    prompt_row: dict[str, Any],
+    task_eval_config: dict[str, Any],
+    index: int,
+) -> Any:
+    case = copy.deepcopy(template)
+    case.name = str(prompt_row.get("sample_id", f"vision_{index:06d}"))
+    case.inputs["image"] = str(prompt_row["image"])
+    prompt_mode = str(task_eval_config.get("prompt_mode", "") or "")
+    if prompt_mode == "point":
+        case.inputs["point_x"] = float(prompt_row["point_x"])
+        case.inputs["point_y"] = float(prompt_row["point_y"])
+        case.inputs["is_foreground"] = True
+    elif prompt_mode == "text":
+        text_prompt = str(prompt_row["text_prompt"])
+        case.inputs["prompt"] = text_prompt
+        case.inputs["text_prompt"] = text_prompt
+    return case
+
+
+def _vision_full_inference_stage(case: Any) -> Any:
+    from tests.e2e_harness.contracts import StageSpec
+
+    for stage in case.stages:
+        if stage.name == "full_inference":
+            return stage
+    return StageSpec(name="full_inference", required=True)
+
+
+def _persist_numpy_output(value: Any, path: Path) -> str:
+    import numpy as np
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.save(path, np.asarray(value))
+    return str(path)
+
+
+def _vision_response(
+    *,
+    case: Any,
+    source: str,
+    output: Any,
+    dataset_kind: str,
+    prompt_row: dict[str, Any],
+    artifact_dir: Path,
+) -> dict[str, Any]:
+    data = output.data if isinstance(output.data, dict) else {}
+    metadata = output.metadata if isinstance(output.metadata, dict) else {}
+    response: dict[str, Any] = {
+        "sample_id": case.name,
+        "source": source,
+        "returncode": int(data.get("returncode", metadata.get("returncode", 0))),
+        "image": str(prompt_row["image"]),
+        "wall_ms": float(output.timing_s) * 1000.0,
+    }
+    if dataset_kind == "image_classification_json":
+        response.update(
+            {
+                "top_class": int(data["top_class"]),
+                "top_score": float(data.get("top_score", 0.0)),
+                "num_classes": int(data.get("num_classes", 0)),
+            }
+        )
+        return response
+    if dataset_kind == "semantic_segmentation_json":
+        class_map_path = str(
+            data.get("class_map_path")
+            or data.get("segmentation_map_path")
+            or data.get("output_path")
+            or ""
+        )
+        if not class_map_path and data.get("class_map") is not None:
+            class_map_path = _persist_numpy_output(
+                data["class_map"], artifact_dir / case.name / f"{source}_class_map.npy"
+            )
+        if not class_map_path or not Path(class_map_path).is_file():
+            raise RuntimeError(f"{source} semantic segmentation produced no class map")
+        response["class_map_path"] = class_map_path
+        raw_class_map_path = str(data.get("raw_class_map_path") or "")
+        if raw_class_map_path:
+            if not Path(raw_class_map_path).is_file():
+                raise RuntimeError(
+                    f"{source} semantic segmentation raw class map does not exist: "
+                    f"{raw_class_map_path}"
+                )
+            response["raw_class_map_path"] = raw_class_map_path
+        response["visualization_path"] = str(
+            data.get("viz_path") or data.get("output_path") or ""
+        )
+        return response
+    if dataset_kind == "prompted_segmentation_json":
+        masks_path = str(data.get("masks_path", "") or "")
+        masks = data.get("masks")
+        if not masks_path and masks is not None:
+            masks_path = _persist_numpy_output(
+                masks, artifact_dir / case.name / f"{source}_masks.npy"
+            )
+        if not masks_path or not Path(masks_path).is_file():
+            raise RuntimeError(f"{source} prompted segmentation produced no masks")
+        scores = data.get("mask_scores") or data.get("iou_scores") or data.get("scores") or []
+        response.update(
+            {
+                "masks_path": masks_path,
+                "mask_scores": [float(value) for value in scores],
+                "num_masks": int(data.get("num_masks", 0)),
+                "point_x": prompt_row.get("point_x"),
+                "point_y": prompt_row.get("point_y"),
+                "text_prompt": str(prompt_row.get("text_prompt", "")),
+                "segmented_image_path": str(data.get("segmented_image_path", "") or ""),
+            }
+        )
+        return response
+    raise ValueError(f"Unsupported vision task dataset kind {dataset_kind!r}")
+
+
+def run_vision_hf_reference(args: argparse.Namespace) -> None:
+    from tests.e2e_harness.contracts import RunContext
+
+    work_dir = Path(args.work_dir)
+    template, reference, _runner = _load_vision_task_eval_plugins(work_dir)
+    manifest = work_manifest(work_dir)
+    dataset_kind = str(manifest.get("dataset_kind", ""))
+    task_eval_config = manifest.get("task_eval", {})
+    task_eval_config = task_eval_config if isinstance(task_eval_config, dict) else {}
+    prompt_rows = load_jsonl(work_dir / "prompts.jsonl")
+    artifacts_dir = work_dir / "hf_artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    raw_path = work_dir / (args.raw_output or "hf_raw.jsonl")
+    pred_path = work_dir / (args.predictions or "hf_predictions.json")
+    responses: list[dict[str, Any]] = []
+    with raw_path.open("w", encoding="utf-8") as raw_file:
+        for index, prompt_row in enumerate(prompt_rows):
+            case = _vision_case_for_request(template, prompt_row, task_eval_config, index)
+            context = RunContext(
+                case=case,
+                artifacts_dir=str(artifacts_dir),
+                hf_python=sys.executable,
+                reference_python=sys.executable,
+            )
+            output = reference.run_stage(
+                case, _vision_full_inference_stage(case), context
+            )
+            response = _vision_response(
+                case=case,
+                source="hf",
+                output=output,
+                dataset_kind=dataset_kind,
+                prompt_row=prompt_row,
+                artifact_dir=artifacts_dir,
+            )
+            responses.append(response)
+            raw_file.write(json.dumps(response, ensure_ascii=False) + "\n")
+            raw_file.flush()
+            print(
+                f"[task_eval.vision_hf] sample={index + 1}/{len(prompt_rows)}",
+                file=sys.stderr,
+            )
+    write_predictions(pred_path, responses)
+
+
+def run_vision_trtfb(args: argparse.Namespace) -> None:
+    from tests.e2e_harness.contracts import RunContext
+
+    work_dir = Path(args.work_dir)
+    template, _reference, runner = _load_vision_task_eval_plugins(work_dir)
+    manifest = work_manifest(work_dir)
+    dataset_kind = str(manifest.get("dataset_kind", ""))
+    task_eval_config = manifest.get("task_eval", {})
+    task_eval_config = task_eval_config if isinstance(task_eval_config, dict) else {}
+    prompt_rows = load_jsonl(work_dir / "prompts.jsonl")
+    artifacts_dir = work_dir / "trtfb_artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    raw_path = work_dir / (args.raw_output or "trtfb_raw.jsonl")
+    pred_path = work_dir / (args.predictions or "trtfb_predictions.json")
+    bundle_path = Path(args.bundle).resolve()
+    responses: list[dict[str, Any]] = []
+    with raw_path.open("w", encoding="utf-8") as raw_file:
+        for index, prompt_row in enumerate(prompt_rows):
+            case = _vision_case_for_request(template, prompt_row, task_eval_config, index)
+            case.bundle = bundle_path.name
+            context = RunContext(
+                case=case,
+                artifacts_dir=str(artifacts_dir),
+                binary_path=str(args.trtmc_binary),
+                hf_python=str(getattr(args, "hf_python", "") or ""),
+                runtime_python=str(getattr(args, "hf_python", "") or ""),
+                engine_dir=str(bundle_path.parent),
+                model_plugin_dir=str(getattr(args, "model_plugin_dir", "") or ""),
+            )
+            output = runner.run_stage(
+                case, _vision_full_inference_stage(case), context
+            )
+            response = _vision_response(
+                case=case,
+                source="trtfb",
+                output=output,
+                dataset_kind=dataset_kind,
+                prompt_row=prompt_row,
+                artifact_dir=artifacts_dir,
+            )
+            if response["returncode"] != 0:
+                raise RuntimeError(
+                    f"TRT vision run failed for {case.name}: "
+                    f"returncode={response['returncode']}"
+                )
+            responses.append(response)
+            raw_file.write(json.dumps(response, ensure_ascii=False) + "\n")
+            raw_file.flush()
+            print(
+                f"[task_eval.vision_trtfb] sample={index + 1}/{len(prompt_rows)}",
+                file=sys.stderr,
+            )
+    write_predictions(pred_path, responses)
+
+
 def _load_diffusion_task_eval_plugins(work_dir: Path) -> tuple[Any, Any, Any]:
     task_eval_config = work_manifest(work_dir).get("task_eval", {})
     if not isinstance(task_eval_config, dict):
@@ -5891,6 +6429,9 @@ def run_encoder_embedding_hf_reference(args: argparse.Namespace) -> None:
 
 def run_hf_reference(args: argparse.Namespace) -> None:
     dataset_kind = _work_dataset_kind(Path(args.work_dir))
+    if _is_vision_task_dataset_kind(dataset_kind):
+        run_vision_hf_reference(args)
+        return
     if _is_encoder_embedding_dataset_kind(dataset_kind):
         run_encoder_embedding_hf_reference(args)
         return
@@ -6497,6 +7038,9 @@ def run_encoder_embedding_trtfb(args: argparse.Namespace) -> None:
 def run_trtfb(args: argparse.Namespace) -> None:
     work_dir = Path(args.work_dir)
     dataset_kind = _work_dataset_kind(work_dir)
+    if _is_vision_task_dataset_kind(dataset_kind):
+        run_vision_trtfb(args)
+        return
     if _is_encoder_embedding_dataset_kind(dataset_kind):
         run_encoder_embedding_trtfb(args)
         return
@@ -7103,6 +7647,367 @@ def compare_encoder_embedding_prediction_sets(
     }
 
 
+def _task_eval_response_rows(data: dict[str, Any], label: str) -> list[dict[str, Any]]:
+    rows = data.get("responses", [])
+    if not isinstance(rows, list):
+        raise ValueError(f"{label} predictions must contain a response list")
+    return rows
+
+
+def compare_image_classification_prediction_sets(
+    hf_data: dict[str, Any],
+    trtfb_data: dict[str, Any],
+    answers: dict[str, Any],
+    *,
+    gates: dict[str, Any],
+) -> dict[str, Any]:
+    hf_rows = _task_eval_response_rows(hf_data, "HF")
+    trtfb_rows = _task_eval_response_rows(trtfb_data, "TRTMC")
+    requests = answers.get("requests", [])
+    if not isinstance(requests, list):
+        raise ValueError("Classification answers must contain requests")
+    hf_by_id = {str(row["sample_id"]): row for row in hf_rows}
+    trtfb_by_id = {str(row["sample_id"]): row for row in trtfb_rows}
+    cases: list[dict[str, Any]] = []
+    for request in requests:
+        sample_id = str(request.get("sample_id") or request.get("id") or "")
+        hf_row = hf_by_id.get(sample_id)
+        trtfb_row = trtfb_by_id.get(sample_id)
+        if hf_row is None or trtfb_row is None:
+            cases.append({"sample_id": sample_id, "passed": False, "error": "missing prediction"})
+            continue
+        label = int(request["label"])
+        hf_top = int(hf_row["top_class"])
+        trtfb_top = int(trtfb_row["top_class"])
+        cases.append(
+            {
+                "sample_id": sample_id,
+                "label": label,
+                "label_name": str(request.get("label_name", "")),
+                "hf_top_class": hf_top,
+                "trtfb_top_class": trtfb_top,
+                "hf_correct": hf_top == label,
+                "trtfb_correct": trtfb_top == label,
+                "top1_agreement": hf_top == trtfb_top,
+            }
+        )
+    valid = [case for case in cases if "error" not in case]
+    hf_accuracy = _mean([float(case["hf_correct"]) for case in valid])
+    trtfb_accuracy = _mean([float(case["trtfb_correct"]) for case in valid])
+    agreement = _mean([float(case["top1_agreement"]) for case in valid])
+    max_drop = float(gates.get("max_top1_accuracy_drop_from_hf", 0.01))
+    min_agreement = float(gates.get("min_top1_agreement", 0.98))
+    accuracy_drop = hf_accuracy - trtfb_accuracy
+    status = (
+        "passed"
+        if valid
+        and len(valid) == len(cases)
+        and accuracy_drop <= max_drop
+        and agreement >= min_agreement
+        else "failed"
+    )
+    return {
+        "status": status,
+        "valid_count": len(valid),
+        "sample_count": len(cases),
+        "hf_top1_accuracy": hf_accuracy,
+        "trtfb_top1_accuracy": trtfb_accuracy,
+        "top1_accuracy_drop_from_hf": accuracy_drop,
+        "top1_agreement": agreement,
+        "gates": {
+            "max_top1_accuracy_drop_from_hf": max_drop,
+            "min_top1_agreement": min_agreement,
+        },
+        "cases": cases,
+    }
+
+
+def _load_segmentation_array(path: str) -> Any:
+    import numpy as np
+
+    artifact = Path(path)
+    if artifact.suffix.lower() == ".npy":
+        return np.load(artifact, allow_pickle=False)
+    from PIL import Image
+
+    return np.asarray(Image.open(artifact).convert("L"))
+
+
+def _resize_label_array(values: Any, shape: tuple[int, int]) -> Any:
+    import numpy as np
+
+    array = np.asarray(values)
+    if array.shape == shape:
+        return array
+    from PIL import Image
+
+    resized = Image.fromarray(array.astype(np.uint8)).resize(
+        (shape[1], shape[0]), Image.Resampling.NEAREST
+    )
+    return np.asarray(resized)
+
+
+def _segmentation_confusion(
+    reference: Any,
+    prediction: Any,
+    *,
+    num_classes: int,
+    ignore_index: int | None = None,
+) -> Any:
+    import numpy as np
+
+    ref = np.asarray(reference, dtype=np.int64)
+    pred = _resize_label_array(prediction, ref.shape).astype(np.int64)
+    valid = (ref >= 0) & (ref < num_classes) & (pred >= 0) & (pred < num_classes)
+    if ignore_index is not None:
+        valid &= ref != ignore_index
+    encoded = num_classes * ref[valid] + pred[valid]
+    return np.bincount(encoded, minlength=num_classes * num_classes).reshape(
+        num_classes, num_classes
+    )
+
+
+def _segmentation_metrics(confusion: Any) -> dict[str, float]:
+    import numpy as np
+
+    matrix = np.asarray(confusion, dtype=np.float64)
+    true_positive = np.diag(matrix)
+    gt_total = matrix.sum(axis=1)
+    pred_total = matrix.sum(axis=0)
+    union = gt_total + pred_total - true_positive
+    present = union > 0
+    mean_iou = float(np.mean(true_positive[present] / union[present])) if present.any() else 0.0
+    total = matrix.sum()
+    pixel_accuracy = float(true_positive.sum() / total) if total > 0 else 0.0
+    return {"mean_iou": mean_iou, "pixel_accuracy": pixel_accuracy}
+
+
+def compare_semantic_segmentation_prediction_sets(
+    hf_data: dict[str, Any],
+    trtfb_data: dict[str, Any],
+    answers: dict[str, Any],
+    *,
+    gates: dict[str, Any],
+    num_classes: int,
+    ignore_index: int,
+) -> dict[str, Any]:
+    import numpy as np
+
+    hf_by_id = {
+        str(row["sample_id"]): row
+        for row in _task_eval_response_rows(hf_data, "HF")
+    }
+    trtfb_by_id = {
+        str(row["sample_id"]): row
+        for row in _task_eval_response_rows(trtfb_data, "TRTMC")
+    }
+    requests = answers.get("requests", [])
+    hf_ground = np.zeros((num_classes, num_classes), dtype=np.int64)
+    trtfb_ground = np.zeros_like(hf_ground)
+    backend = np.zeros_like(hf_ground)
+    cases: list[dict[str, Any]] = []
+    for request in requests:
+        sample_id = str(request.get("sample_id") or request.get("id") or "")
+        if sample_id not in hf_by_id or sample_id not in trtfb_by_id:
+            cases.append({"sample_id": sample_id, "passed": False, "error": "missing prediction"})
+            continue
+        ground_truth = _load_segmentation_array(str(request["mask"]))
+        hf_map = _load_segmentation_array(str(hf_by_id[sample_id]["class_map_path"]))
+        hf_backend_map = _load_segmentation_array(
+            str(
+                hf_by_id[sample_id].get("raw_class_map_path")
+                or hf_by_id[sample_id]["class_map_path"]
+            )
+        )
+        trtfb_map = _load_segmentation_array(
+            str(trtfb_by_id[sample_id]["class_map_path"])
+        )
+        hf_conf = _segmentation_confusion(
+            ground_truth,
+            hf_map,
+            num_classes=num_classes,
+            ignore_index=ignore_index,
+        )
+        trtfb_conf = _segmentation_confusion(
+            ground_truth,
+            trtfb_map,
+            num_classes=num_classes,
+            ignore_index=ignore_index,
+        )
+        resized_hf = _resize_label_array(hf_backend_map, trtfb_map.shape)
+        backend_conf = _segmentation_confusion(
+            resized_hf,
+            trtfb_map,
+            num_classes=num_classes,
+        )
+        hf_ground += hf_conf
+        trtfb_ground += trtfb_conf
+        backend += backend_conf
+        case_backend = _segmentation_metrics(backend_conf)
+        cases.append(
+            {
+                "sample_id": sample_id,
+                "backend_pixel_agreement": case_backend["pixel_accuracy"],
+                "backend_mean_iou": case_backend["mean_iou"],
+                "hf_ground_truth_mean_iou": _segmentation_metrics(hf_conf)["mean_iou"],
+                "trtfb_ground_truth_mean_iou": _segmentation_metrics(trtfb_conf)["mean_iou"],
+            }
+        )
+    hf_metrics = _segmentation_metrics(hf_ground)
+    trtfb_metrics = _segmentation_metrics(trtfb_ground)
+    backend_metrics = _segmentation_metrics(backend)
+    min_pixel = float(gates.get("min_backend_pixel_agreement", 0.98))
+    min_backend_iou = float(gates.get("min_backend_mean_iou", 0.95))
+    max_drop = float(gates.get("max_mean_iou_drop_from_hf", 0.01))
+    mean_iou_drop = hf_metrics["mean_iou"] - trtfb_metrics["mean_iou"]
+    valid_count = sum("error" not in case for case in cases)
+    status = (
+        "passed"
+        if valid_count > 0
+        and valid_count == len(cases)
+        and backend_metrics["pixel_accuracy"] >= min_pixel
+        and backend_metrics["mean_iou"] >= min_backend_iou
+        and mean_iou_drop <= max_drop
+        else "failed"
+    )
+    return {
+        "status": status,
+        "sample_count": len(cases),
+        "valid_count": valid_count,
+        "hf_mean_iou": hf_metrics["mean_iou"],
+        "trtfb_mean_iou": trtfb_metrics["mean_iou"],
+        "mean_iou_drop_from_hf": mean_iou_drop,
+        "hf_pixel_accuracy": hf_metrics["pixel_accuracy"],
+        "trtfb_pixel_accuracy": trtfb_metrics["pixel_accuracy"],
+        "backend_mean_iou": backend_metrics["mean_iou"],
+        "backend_pixel_agreement": backend_metrics["pixel_accuracy"],
+        "gates": {
+            "min_backend_pixel_agreement": min_pixel,
+            "min_backend_mean_iou": min_backend_iou,
+            "max_mean_iou_drop_from_hf": max_drop,
+        },
+        "cases": cases,
+    }
+
+
+def _mask_stack(path: str) -> Any:
+    import numpy as np
+
+    masks = np.asarray(np.load(path, allow_pickle=False))
+    while masks.ndim > 3 and masks.shape[0] == 1:
+        masks = masks[0]
+    if masks.ndim == 2:
+        masks = masks[None, ...]
+    if masks.ndim != 3:
+        raise ValueError(f"Expected [mask,height,width] at {path}, got {masks.shape}")
+    return masks.astype(bool)
+
+
+def _selected_prompt_mask(masks: Any, scores: list[Any], prompt_mode: str) -> Any:
+    import numpy as np
+
+    if prompt_mode == "text":
+        return np.any(masks, axis=0)
+    index = int(np.argmax(np.asarray(scores, dtype=np.float64))) if scores else 0
+    return masks[min(index, masks.shape[0] - 1)]
+
+
+def _binary_mask_iou(left: Any, right: Any) -> float:
+    import numpy as np
+
+    left_mask = np.asarray(left, dtype=bool)
+    right_mask = _resize_label_array(np.asarray(right, dtype=np.uint8), left_mask.shape) > 0
+    intersection = np.logical_and(left_mask, right_mask).sum()
+    union = np.logical_or(left_mask, right_mask).sum()
+    return float(intersection / union) if union else 1.0
+
+
+def compare_prompted_segmentation_prediction_sets(
+    hf_data: dict[str, Any],
+    trtfb_data: dict[str, Any],
+    answers: dict[str, Any],
+    *,
+    gates: dict[str, Any],
+    prompt_mode: str,
+    ground_truth_mask_field: str,
+) -> dict[str, Any]:
+    hf_by_id = {
+        str(row["sample_id"]): row
+        for row in _task_eval_response_rows(hf_data, "HF")
+    }
+    trtfb_by_id = {
+        str(row["sample_id"]): row
+        for row in _task_eval_response_rows(trtfb_data, "TRTMC")
+    }
+    cases: list[dict[str, Any]] = []
+    for request in answers.get("requests", []):
+        sample_id = str(request.get("sample_id") or request.get("id") or "")
+        hf_row = hf_by_id.get(sample_id)
+        trtfb_row = trtfb_by_id.get(sample_id)
+        if hf_row is None or trtfb_row is None:
+            cases.append({"sample_id": sample_id, "passed": False, "error": "missing prediction"})
+            continue
+        hf_mask = _selected_prompt_mask(
+            _mask_stack(str(hf_row["masks_path"])),
+            list(hf_row.get("mask_scores", [])),
+            prompt_mode,
+        )
+        trtfb_mask = _selected_prompt_mask(
+            _mask_stack(str(trtfb_row["masks_path"])),
+            list(trtfb_row.get("mask_scores", [])),
+            prompt_mode,
+        )
+        ground_truth = _load_segmentation_array(str(request[ground_truth_mask_field])) > 0
+        backend_iou = _binary_mask_iou(hf_mask, trtfb_mask)
+        hf_gt_iou = _binary_mask_iou(ground_truth, hf_mask)
+        trtfb_gt_iou = _binary_mask_iou(ground_truth, trtfb_mask)
+        cases.append(
+            {
+                "sample_id": sample_id,
+                "prompt_mode": prompt_mode,
+                "text_prompt": str(request.get("text_prompt", "")),
+                "backend_mask_iou": backend_iou,
+                "hf_ground_truth_iou": hf_gt_iou,
+                "trtfb_ground_truth_iou": trtfb_gt_iou,
+                "ground_truth_iou_drop_from_hf": hf_gt_iou - trtfb_gt_iou,
+                "hf_segmented_image_path": str(hf_row.get("segmented_image_path", "")),
+                "trtfb_segmented_image_path": str(
+                    trtfb_row.get("segmented_image_path", "")
+                ),
+            }
+        )
+    valid = [case for case in cases if "error" not in case]
+    mean_backend_iou = _mean([float(case["backend_mask_iou"]) for case in valid])
+    hf_gt_iou = _mean([float(case["hf_ground_truth_iou"]) for case in valid])
+    trtfb_gt_iou = _mean([float(case["trtfb_ground_truth_iou"]) for case in valid])
+    min_backend_iou = float(gates.get("min_backend_mask_iou", 0.90))
+    max_gt_drop = float(gates.get("max_ground_truth_iou_drop_from_hf", 0.05))
+    gt_drop = hf_gt_iou - trtfb_gt_iou
+    status = (
+        "passed"
+        if valid
+        and len(valid) == len(cases)
+        and mean_backend_iou >= min_backend_iou
+        and gt_drop <= max_gt_drop
+        else "failed"
+    )
+    return {
+        "status": status,
+        "sample_count": len(cases),
+        "valid_count": len(valid),
+        "prompt_mode": prompt_mode,
+        "mean_backend_mask_iou": mean_backend_iou,
+        "hf_mean_ground_truth_iou": hf_gt_iou,
+        "trtfb_mean_ground_truth_iou": trtfb_gt_iou,
+        "ground_truth_iou_drop_from_hf": gt_drop,
+        "gates": {
+            "min_backend_mask_iou": min_backend_iou,
+            "max_ground_truth_iou_drop_from_hf": max_gt_drop,
+        },
+        "cases": cases,
+    }
+
+
 def write_encoder_embedding_summary_markdown(summary: dict[str, Any], path: Path) -> None:
     lines = [
         "# Encoder / Embedding Parity Summary",
@@ -7212,6 +8117,7 @@ def eval_one_model(
         and not _is_diffusion_media_dataset_kind(dataset_kind)
         and not _is_diffusion_text_dataset_kind(dataset_kind)
         and not _is_tts_dataset_kind(dataset_kind)
+        and not _is_vision_task_dataset_kind(dataset_kind)
     ):
         prompt_rows_path = work_dir / "prompts.jsonl"
         max_prompt_len = max_prompt_token_length(
@@ -7279,7 +8185,96 @@ def eval_one_model(
     if prompt_normalization is not None:
         base_result["prompt_normalization"] = prompt_normalization
 
-    if scorer == "encoder_embedding_parity":
+    if scorer == "image_classification_parity":
+        hf_data = json.loads(
+            (work_dir / "hf_predictions.json").read_text(encoding="utf-8")
+        )
+        trtfb_data = json.loads(
+            (work_dir / "trtfb_predictions.json").read_text(encoding="utf-8")
+        )
+        summary = compare_image_classification_prediction_sets(
+            hf_data,
+            trtfb_data,
+            json.loads(answers_path.read_text(encoding="utf-8")),
+            gates=suite.get("gates", {}),
+        )
+        (work_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        result = {
+            **base_result,
+            "mode": scorer,
+            "status": summary["status"],
+            "valid_count": summary["valid_count"],
+            "hf_top1_accuracy": summary["hf_top1_accuracy"],
+            "trtfb_top1_accuracy": summary["trtfb_top1_accuracy"],
+            "top1_accuracy_drop_from_hf": summary["top1_accuracy_drop_from_hf"],
+            "top1_agreement": summary["top1_agreement"],
+        }
+    elif scorer == "semantic_segmentation_parity":
+        hf_data = json.loads(
+            (work_dir / "hf_predictions.json").read_text(encoding="utf-8")
+        )
+        trtfb_data = json.loads(
+            (work_dir / "trtfb_predictions.json").read_text(encoding="utf-8")
+        )
+        dataset_config = suite.get("dataset", {})
+        summary = compare_semantic_segmentation_prediction_sets(
+            hf_data,
+            trtfb_data,
+            json.loads(answers_path.read_text(encoding="utf-8")),
+            gates=suite.get("gates", {}),
+            num_classes=int(dataset_config.get("num_classes", 150)),
+            ignore_index=int(dataset_config.get("ignore_index", 255)),
+        )
+        (work_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        result = {
+            **base_result,
+            "mode": scorer,
+            "status": summary["status"],
+            "valid_count": summary["valid_count"],
+            "hf_mean_iou": summary["hf_mean_iou"],
+            "trtfb_mean_iou": summary["trtfb_mean_iou"],
+            "mean_iou_drop_from_hf": summary["mean_iou_drop_from_hf"],
+            "backend_mean_iou": summary["backend_mean_iou"],
+            "backend_pixel_agreement": summary["backend_pixel_agreement"],
+        }
+    elif scorer == "prompted_segmentation_parity":
+        hf_data = json.loads(
+            (work_dir / "hf_predictions.json").read_text(encoding="utf-8")
+        )
+        trtfb_data = json.loads(
+            (work_dir / "trtfb_predictions.json").read_text(encoding="utf-8")
+        )
+        summary = compare_prompted_segmentation_prediction_sets(
+            hf_data,
+            trtfb_data,
+            json.loads(answers_path.read_text(encoding="utf-8")),
+            gates=suite.get("gates", {}),
+            prompt_mode=str(task_eval_config.get("prompt_mode", "")),
+            ground_truth_mask_field=str(
+                task_eval_config.get("ground_truth_mask_field", "instance_mask")
+            ),
+        )
+        (work_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        result = {
+            **base_result,
+            "mode": scorer,
+            "status": summary["status"],
+            "valid_count": summary["valid_count"],
+            "prompt_mode": summary["prompt_mode"],
+            "mean_backend_mask_iou": summary["mean_backend_mask_iou"],
+            "hf_mean_ground_truth_iou": summary["hf_mean_ground_truth_iou"],
+            "trtfb_mean_ground_truth_iou": summary["trtfb_mean_ground_truth_iou"],
+            "ground_truth_iou_drop_from_hf": summary[
+                "ground_truth_iou_drop_from_hf"
+            ],
+        }
+    elif scorer == "encoder_embedding_parity":
         hf_data = json.loads((work_dir / "hf_predictions.json").read_text(encoding="utf-8"))
         trtfb_data = json.loads(
             (work_dir / "trtfb_predictions.json").read_text(encoding="utf-8")
@@ -7817,6 +8812,28 @@ def _format_result_line(model: dict[str, Any], result: dict[str, Any]) -> str:
         return (
             f"model={model['name']} gen_ppl={ppl} "
             f"entropy={result['unigram_entropy']:.4f} "
+            f"status={result.get('status', '')} {common}"
+        )
+    if result.get("mode") == "image_classification_parity":
+        return (
+            f"model={model['name']} hf_top1={result['hf_top1_accuracy']:.4f} "
+            f"trtfb_top1={result['trtfb_top1_accuracy']:.4f} "
+            f"top1_agreement={result['top1_agreement']:.4f} "
+            f"status={result.get('status', '')} {common}"
+        )
+    if result.get("mode") == "semantic_segmentation_parity":
+        return (
+            f"model={model['name']} hf_miou={result['hf_mean_iou']:.4f} "
+            f"trtfb_miou={result['trtfb_mean_iou']:.4f} "
+            f"backend_miou={result['backend_mean_iou']:.4f} "
+            f"status={result.get('status', '')} {common}"
+        )
+    if result.get("mode") == "prompted_segmentation_parity":
+        return (
+            f"model={model['name']} backend_mask_iou="
+            f"{result['mean_backend_mask_iou']:.4f} "
+            f"hf_gt_iou={result['hf_mean_ground_truth_iou']:.4f} "
+            f"trtfb_gt_iou={result['trtfb_mean_ground_truth_iou']:.4f} "
             f"status={result.get('status', '')} {common}"
         )
     return (
@@ -8380,6 +9397,9 @@ def cmd_eval(args: argparse.Namespace) -> int:
         "unconditional_text_json",
         "seedtts_json",
         "sts_pair_jsonl",
+        "image_classification_json",
+        "semantic_segmentation_json",
+        "prompted_segmentation_json",
     }:
         raise ValueError(f"eval does not support dataset kind {dataset_kind!r}")
     models = load_manifest_records(Path(args.models_dir))

--- a/tools/test_impact_fallback_allowlist.txt
+++ b/tools/test_impact_fallback_allowlist.txt
@@ -136,6 +136,7 @@ no_impact tools/nsys_to_layer_timing.py # developer utility script; no CI test i
 no_impact tools/perf_compare.py # developer utility script; no CI test impact is intentional
 no_impact tools/perfdb.py # developer utility script; no CI test impact is intentional
 no_impact tools/prepare_dpg_bench.py # offline dataset conversion utility; task-eval behavior is tested separately
+no_impact tools/prepare_vision_task_eval_datasets.py # offline dataset conversion utility; vision task-eval behavior is tested separately
 no_impact tools/profile_report.py # developer utility script; no CI test impact is intentional
 no_impact tools/sol_estimate.py # developer utility script; no CI test impact is intentional
 no_impact tools/test_graph_ops.py # developer utility script; no CI test impact is intentional


### PR DESCRIPTION
## Background

TRTMC had model-owned image classification and segmentation runtimes but no dataset-level task-eval suites that separated task quality from Hugging Face-to-TRTMC conversion fidelity.

## Exit Criteria

- Evaluate the supported timm classifier, SegFormer semantic segmenter, and SAM point-prompted segmenter on model-aligned public datasets.
- Report gold task metrics separately from backend parity metrics.
- Keep gated, not-yet-validated SAM3 coverage out of this PR.

## Implementation

- Add Imagenette/ImageNet-1k top-1 classification parity for the timm ViT checkpoint.
- Add ADE20K mIoU and pixel-accuracy scoring for SegFormer, while comparing TRTMC against the Hugging Face raw output-resolution class map.
- Add COCO 2017 point-prompted mask parity for SAM with an independent ground-truth IoU regression guard.
- Add reproducible dataset preparation for Imagenette, ADE20K, and balanced COCO prompted-segmentation samples.
- Forward model plugin directories through the model-owned runners used by task eval.

## Validation

- `python3 -m pytest tests/tools/test_task_eval.py -q`: 118 passed.
- `python3 -m pytest tests/e2e/models/sam/test_sam_prompted_segmentation_harness.py tests/e2e/models/sam/test_sam_runner_cli_alignment.py tests/e2e/models/segformer/test_segformer_diff_segmentation.py -q`: 18 passed.
- `python3 -m ruff check ...`: passed for every changed Python file.
- `python3 tools/legal_headers.py --check`: passed with zero findings.
- `python3 tools/model_ci.py validate`: passed for all 77 ownership manifests.
- P2021 limit-10, seed 1234:
  - timm ViT: HF/TRTMC top-1 `0.7/0.7`, prediction agreement `1.0`.
  - SegFormer with #440: HF/TRTMC mIoU `0.220415/0.220582`, backend pixel agreement `0.995148`.
  - SAM: backend mask IoU `0.839592`; HF/TRTMC ground-truth IoU `0.361734/0.394487`.

## Notes For Future Readers

- SegFormer validation depends on #440, which fixes the CLI input resize without changing model precision.
- SAM3 remains in the separate local development worktree until gated checkpoint access is approved and P2021 validation is complete.
- No validation report files are committed.
- Central task-eval files are classified as platform changes, so impact analysis reports all models. The `run-ci` label is intentionally not applied yet.
