### PR TITLE
feat(canary): add configurable ASR decoding

### DIFF
--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -18,17 +18,68 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace trtmc {
 
 // --- Result types (all value types, user owns the data) ---
 
+struct TranscriptionSegment {
+    double start_seconds{0.0};
+    double end_seconds{0.0};
+    std::string text;
+    std::vector<int32_t> token_ids;
+};
+
 struct TextResult {
+    TextResult() = default;
+    TextResult(std::string result_text, std::vector<int32_t> result_token_ids,
+               double result_prefill_ms = 0.0, double result_decode_ms = 0.0,
+               std::vector<TranscriptionSegment> result_segments = {})
+        : text(std::move(result_text)), token_ids(std::move(result_token_ids)),
+          prefill_ms(result_prefill_ms), decode_ms(result_decode_ms),
+          segments(std::move(result_segments)) {}
+
     std::string text;
     std::vector<int32_t> token_ids;
     double prefill_ms{0.0};
     double decode_ms{0.0};
+    // Populated by transcription pipelines when timestamp intervals are
+    // requested and supported.
+    std::vector<TranscriptionSegment> segments;
+};
+
+enum class TranscriptionTask {
+    kTranscribe,
+    kTranslate,
+};
+
+struct TranscriptionConfig {
+    // Maximum number of decoder output tokens. The valid upper bound is
+    // model-specific and excludes the decoder prompt tokens.
+    int32_t max_output_tokens{224};
+    // Source sample rate in Hz. 0 means the samples are already at the model
+    // rate. A positive value is resampled when necessary.
+    int32_t input_sample_rate{0};
+    // 1 preserves greedy decoding. Values greater than 1 select beam search.
+    int32_t beam_size{1};
+    std::string source_language{"en"};
+    std::string target_language{"en"};
+    TranscriptionTask task{TranscriptionTask::kTranscribe};
+    bool punctuation{true};
+    bool timestamps{false};
+    // 0 disables the caller-specified duration limit. A positive value is a
+    // hard input limit in seconds; longer inputs are rejected.
+    float max_input_duration_seconds{0.0F};
+    // 0 processes one model-sized segment. A positive value splits the input
+    // into independent segments of this many seconds and joins their text.
+    float segment_duration_seconds{0.0F};
+};
+
+struct TranscriptionRequest {
+    std::vector<float> audio_samples;
+    TranscriptionConfig config;
 };
 
 struct ImageResult {
@@ -279,6 +330,29 @@ class IPipeline {
         (void)max_tokens;
         (void)input_sample_rate;
         throw std::runtime_error(std::string(pipeline_type()) + " does not support transcribe()");
+    }
+
+    // Typed transcription configuration. The default forwards to the legacy
+    // overload so existing speech pipelines remain compatible.
+    virtual TextResult transcribe(const float* audio_samples, int32_t num_samples,
+                                  const TranscriptionConfig& cfg) {
+        return transcribe(audio_samples, num_samples, cfg.max_output_tokens,
+                          cfg.input_sample_rate);
+    }
+
+    // Each request owns its samples and its complete per-input configuration.
+    // Pipelines may override this for true batching; the default preserves the
+    // request order and executes sequentially.
+    virtual std::vector<TextResult>
+    transcribe_batch(const std::vector<TranscriptionRequest>& requests) {
+        std::vector<TextResult> results;
+        results.reserve(requests.size());
+        for (const auto& request : requests) {
+            results.push_back(transcribe(request.audio_samples.data(),
+                                         static_cast<int32_t>(request.audio_samples.size()),
+                                         request.config));
+        }
+        return results;
     }
 
     // -- Streaming transcription (cache-aware ASR) --

--- a/python/tensorrt_model_connect/families/canary/MODEL.toml
+++ b/python/tensorrt_model_connect/families/canary/MODEL.toml
@@ -4,6 +4,7 @@
 id = "canary"
 plugin = "canary"
 module = "plugin"
+model_dir_adapter = "nemo_archive.py|resolve_model_dir"
 nemo_archive_adapter = "nemo_archive.py|resolve_nemo_archive"
 nemo_model_type = "canary"
 nemo_target_patterns = [

--- a/python/tensorrt_model_connect/families/canary/nemo_archive.py
+++ b/python/tensorrt_model_connect/families/canary/nemo_archive.py
@@ -20,12 +20,16 @@ _TARGET_MARKERS = ("encdecmultitaskmodel", "canary")
 def _read_model_config(nemo_path: Path) -> dict[str, Any]:
     import yaml
 
-    with tarfile.open(str(nemo_path), "r") as tar:
-        for member in tar.getmembers():
-            if Path(member.name).name == "model_config.yaml":
-                handle = tar.extractfile(member)
-                if handle is not None:
-                    return yaml.safe_load(handle.read()) or {}
+    try:
+        with tarfile.open(str(nemo_path), "r") as tar:
+            for member in tar.getmembers():
+                if Path(member.name).name == "model_config.yaml":
+                    handle = tar.extractfile(member)
+                    if handle is not None:
+                        loaded = yaml.safe_load(handle.read()) or {}
+                        return loaded if isinstance(loaded, dict) else {}
+    except (OSError, tarfile.TarError, yaml.YAMLError):
+        return {}
     return {}
 
 
@@ -55,7 +59,11 @@ def resolve_nemo_archive(nemo_path: Path) -> str | None:
     dec_layers = int(dec_cfg.get("num_layers", 8))
     dec_heads = int(dec_cfg.get("num_attention_heads", 8))
     dec_ffn = int(dec_cfg.get("inner_size", 4 * hidden))
-    vocab_size = int(cfg.get("vocab_size", 1024))
+    decoder_cfg = cfg.get("decoder", {})
+    head_cfg = cfg.get("head", {})
+    vocab_size = int(
+        cfg.get("vocab_size") or head_cfg.get("num_classes")
+        or decoder_cfg.get("num_classes") or 1024)
 
     tmp_dir = tempfile.mkdtemp(prefix="trtmc_nemo_canary_")
     tmp_path = Path(tmp_dir)
@@ -79,3 +87,14 @@ def resolve_nemo_archive(nemo_path: Path) -> str | None:
         file=sys.stderr,
     )
     return tmp_dir
+
+
+def resolve_model_dir(model_dir: Path) -> str | None:
+    """Stage a local directory containing a compatible Canary archive."""
+    if not model_dir.is_dir():
+        return None
+    for nemo_path in sorted(model_dir.glob("*.nemo")):
+        resolved = resolve_nemo_archive(nemo_path)
+        if resolved is not None:
+            return resolved
+    return None

--- a/python/tensorrt_model_connect/families/canary/plugin.py
+++ b/python/tensorrt_model_connect/families/canary/plugin.py
@@ -47,6 +47,11 @@ from .decoder_tp_builder import build_canary_tp_decoder_engine
 
 trt = trt_compat.get_trt()
 
+_CANARY_V2_LANGUAGES = [
+    "bg", "hr", "cs", "da", "nl", "en", "et", "fi", "fr", "de", "el", "hu", "it",
+    "lv", "lt", "mt", "pl", "pt", "ro", "sk", "sl", "es", "sv", "ru", "uk",
+]
+
 
 def _cfg_int(*values, default: int) -> int:
     for value in values:
@@ -95,20 +100,31 @@ def _load_nemo_archive(path: str):
     return state_dict, config_dict
 
 
-def _extract_tokenizer_from_nemo(nemo_path: str, dest_dir: Path) -> None:
+def _extract_tokenizer_from_nemo(
+    nemo_path: str, dest_dir: Path, nemo_cfg: dict | None = None,
+) -> Path:
     nemo = Path(nemo_path)
     if nemo.is_dir():
         nemo_files = sorted(nemo.glob("*.nemo"))
         if nemo_files:
             nemo = nemo_files[0]
+    tokenizer_cfg = (nemo_cfg or {}).get("tokenizer", {})
+    configured_name = str(tokenizer_cfg.get("model_path", "")).removeprefix("nemo:")
     with tarfile.open(str(nemo), "r") as tar:
-        for member in tar.getmembers():
-            bn = Path(member.name).name
-            if bn.endswith(".model") and "tokenizer" in bn.lower():
-                f = tar.extractfile(member)
-                if f:
-                    (dest_dir / "tokenizer.model").write_bytes(f.read())
-                    break
+        candidates = [
+            member for member in tar.getmembers()
+            if Path(member.name).name.endswith(".model")
+            and "tokenizer" in Path(member.name).name.lower()
+        ]
+        selected = next(
+            (member for member in candidates
+             if Path(member.name).name == Path(configured_name).name),
+            candidates[0] if candidates else None,
+        )
+        if selected is not None:
+            f = tar.extractfile(selected)
+            if f:
+                (dest_dir / "tokenizer.model").write_bytes(f.read())
     # Generate a fast tokenizer.json from the SentencePiece model.
     # Use the tokenizers library directly to avoid HF warnings in stdout.
     tok_model_path = dest_dir / "tokenizer.model"
@@ -146,6 +162,64 @@ def _extract_tokenizer_from_nemo(nemo_path: str, dest_dir: Path) -> None:
         tok_cfg.write_text(json.dumps({
             "tokenizer_class": "PreTrainedTokenizerFast",
         }, indent=2))
+    return tok_model_path
+
+
+def _canary_prompt_metadata(nemo_cfg: dict, tokenizer_model: Path) -> dict:
+    import sentencepiece as spm
+
+    processor = spm.SentencePieceProcessor(model_file=str(tokenizer_model))
+
+    def token_id(piece: str) -> int:
+        value = int(processor.piece_to_id(piece))
+        if value < 0 or processor.id_to_piece(value) != piece:
+            raise ValueError(
+                f"Canary tokenizer {tokenizer_model} is missing required token {piece!r}")
+        return value
+
+    def has_token(piece: str) -> bool:
+        value = int(processor.piece_to_id(piece))
+        return value >= 0 and processor.id_to_piece(value) == piece
+
+    defaults = {}
+    for prompt in nemo_cfg.get("prompt_defaults", []):
+        if prompt.get("role") == "user":
+            defaults = dict(prompt.get("slots", {}))
+            break
+    source = str(defaults.get("source_lang", "<|en|>"))
+    target = str(defaults.get("target_lang", source))
+    prompt_pieces = [
+        "▁", "<|startofcontext|>", "<|startoftranscript|>",
+        str(defaults.get("emotion", "<|emo:undefined|>")), source, target,
+        str(defaults.get("pnc", "<|pnc|>")),
+        str(defaults.get("itn", "<|noitn|>")),
+        str(defaults.get("timestamp", "<|notimestamp|>")),
+        str(defaults.get("diarize", "<|nodiarize|>")),
+    ]
+
+    configured_languages = nemo_cfg.get("supported_languages")
+    if configured_languages:
+        languages = [str(language) for language in configured_languages]
+    else:
+        languages = [
+            language for language in _CANARY_V2_LANGUAGES
+            if has_token(f"<|{language}|>")
+        ]
+    return {
+        "decoder_start_token_ids": [token_id(piece) for piece in prompt_pieces],
+        "eot_token_id": token_id("<|endoftext|>"),
+        "canary_supported_languages": languages,
+        "canary_language_token_ids": [token_id(f"<|{language}|>") for language in languages],
+        "canary_source_language_position": 4,
+        "canary_target_language_position": 5,
+        "canary_punctuation_position": 6,
+        "canary_timestamp_position": 8,
+        "canary_punctuation_token_id": token_id("<|pnc|>"),
+        "canary_no_punctuation_token_id": token_id("<|nopnc|>"),
+        "canary_timestamp_token_id": token_id("<|timestamp|>"),
+        "canary_no_timestamp_token_id": token_id("<|notimestamp|>"),
+        "canary_translation_requires_english": True,
+    }
 
 
 def _sinusoidal_pe(max_len: int, d_model: int) -> np.ndarray:
@@ -569,6 +643,7 @@ class CanaryPlugin:
 
     def __init__(self):
         self._vl_config: dict = {}
+        self._prompt_metadata: dict = {}
 
     def matches(self, model_type: str) -> bool:
         return model_type.lower() in ("canary", "canary_asr", "enc_dec_multi_task")
@@ -576,7 +651,9 @@ class CanaryPlugin:
     def load_weights(self, model_dir: str, config: ModelConfig) -> WeightDict:
         w = WeightDict()
         sd, ncfg = _load_nemo_archive(model_dir)
-        _extract_tokenizer_from_nemo(model_dir, Path(model_dir))
+        tokenizer_model = _extract_tokenizer_from_nemo(model_dir, Path(model_dir), ncfg)
+        if tokenizer_model.exists():
+            self._prompt_metadata = _canary_prompt_metadata(ncfg, tokenizer_model)
 
         ec = ncfg.get("encoder", {})
         hidden = int(ec.get("d_model", 1024))
@@ -954,17 +1031,14 @@ class CanaryPlugin:
 
     def get_bundle_config_overrides(self, config: ModelConfig) -> dict | None:
         """Override synthetic config with actual values from the NeMo model."""
-        return {
+        overrides = {
             "num_hidden_layers": config.num_hidden_layers,
             "num_attention_heads": config.num_attention_heads,
             "hidden_size": config.hidden_size,
             "vocab_size": config.vocab_size,
-            # NeMo canary2 default prompt context_ids:
-            # ▁ <|startofcontext|> <|startoftranscript|> <|emo:undefined|>
-            # <|en|> <|en|> <|pnc|> <|noitn|> <|notimestamp|> <|nodiarize|>
-            "decoder_start_token_ids": [16053, 7, 4, 16, 64, 64, 5, 9, 11, 13],
-            "eot_token_id": 3,  # <|endoftext|>
         }
+        overrides.update(self._prompt_metadata)
+        return overrides
 
     def get_vl_config(self, config: ModelConfig) -> dict | None:
         return self._vl_config or {

--- a/src/cli/args.cpp
+++ b/src/cli/args.cpp
@@ -220,7 +220,9 @@ void print_usage() {
            "  trtmc solve           <bundle.trtfb> --field-input CSV\n"
            "  trtmc solve           <bundle.trtfb> --branch-input CSV [--trunk-input CSV]\n"
            "  trtmc transcribe      <bundle.trtfb> --audio FILE.wav [--max-new-tokens N] "
-           "[--language TAG] "
+           "[--beam-size N] [--language TAG] [--source-language TAG] [--target-language TAG] "
+           "[--task transcribe|translate] [--punctuation|--no-punctuation] [--timestamps] "
+           "[--max-input-seconds F] [--segment-length-seconds F] "
            "[--stream] [--chunk-ms N] [--att-context-size L,R] "
            "[--pad-and-drop-preencoded] [--hf-python PATH]\n"
            "  trtmc speak           <bundle.trtfb> --audio-in INPUT.wav --audio-out OUTPUT.wav\n"
@@ -579,11 +581,79 @@ CliArgs parse_args(int argc, char** argv) {
             continue;
         }
         if (arg == "--audio" && need_value(arg)) {
-            args.audio_in = argv[++i];
+            args.audio_inputs.emplace_back(argv[++i]);
+            if (args.audio_in.empty())
+                args.audio_in = args.audio_inputs.back();
             continue;
         }
         if (arg == "--language" && need_value(arg)) {
             args.language = argv[++i];
+            args.source_language = args.language;
+            args.target_language = args.language;
+            continue;
+        }
+        if (arg == "--beam-size" && need_value(arg)) {
+            auto value = parse_int_value(arg, "an integer in [1, 16]");
+            if (!value || *value < 1 || *value > 16) {
+                args.parse_error = true;
+                args.error_message = arg + " expects an integer in [1, 16]";
+                return args;
+            }
+            args.beam_size = *value;
+            continue;
+        }
+        if (arg == "--source-language" && need_value(arg)) {
+            args.source_language = argv[++i];
+            continue;
+        }
+        if (arg == "--target-language" && need_value(arg)) {
+            args.target_language = argv[++i];
+            continue;
+        }
+        if (arg == "--task" && need_value(arg)) {
+            args.transcription_task = argv[++i];
+            if (args.transcription_task != "transcribe" &&
+                args.transcription_task != "translate") {
+                args.parse_error = true;
+                args.error_message = "--task expects transcribe or translate";
+                return args;
+            }
+            continue;
+        }
+        if (arg == "--punctuation") {
+            args.punctuation = true;
+            continue;
+        }
+        if (arg == "--no-punctuation") {
+            args.punctuation = false;
+            continue;
+        }
+        if (arg == "--timestamps") {
+            args.timestamps = true;
+            continue;
+        }
+        if (arg == "--no-timestamps") {
+            args.timestamps = false;
+            continue;
+        }
+        if (arg == "--max-input-seconds" && need_value(arg)) {
+            auto value = parse_float_value(arg, "a finite number > 0");
+            if (!value || *value <= 0.0F) {
+                args.parse_error = true;
+                args.error_message = arg + " expects a finite number > 0";
+                return args;
+            }
+            args.max_input_seconds = *value;
+            continue;
+        }
+        if (arg == "--segment-length-seconds" && need_value(arg)) {
+            auto value = parse_float_value(arg, "a finite number > 0");
+            if (!value || *value <= 0.0F) {
+                args.parse_error = true;
+                args.error_message = arg + " expects a finite number > 0";
+                return args;
+            }
+            args.segment_length_seconds = *value;
             continue;
         }
         if (arg == "--point-x" && need_value(arg)) {

--- a/src/cli/args.h
+++ b/src/cli/args.h
@@ -30,6 +30,7 @@ struct CliArgs {
     std::string sde_noise_raw;
     std::string document;
     std::string audio_in;
+    std::vector<std::string> audio_inputs;
     std::string audio_out;
     std::string field_input;
     std::string branch_input;
@@ -68,6 +69,14 @@ struct CliArgs {
     int att_context_left{70};
     int att_context_right{13};
     std::string language;
+    int beam_size{1};
+    std::string source_language{"en"};
+    std::string target_language{"en"};
+    std::string transcription_task{"transcribe"};
+    bool punctuation{true};
+    bool timestamps{false};
+    float max_input_seconds{0.0F};
+    float segment_length_seconds{0.0F};
     std::string runtime_cache;
     std::vector<std::string> backend_search_paths;
     std::vector<std::string> model_plugin_search_paths;

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -17,7 +17,9 @@
 //                        Image-generation extras:
 //                        [--negative-prompt "text"] [--num-inference-steps N]
 //                        [--height N] [--width N]
-//   trtmc transcribe      <bundle.trtfb> --audio FILE.wav [--max-new-tokens N] [--hf-python PATH]
+//   trtmc transcribe      <bundle.trtfb> --audio FILE.wav [--beam-size N]
+//                        [--source-language TAG] [--target-language TAG]
+//                        [--task transcribe|translate] [--timestamps]
 //   trtmc speak           <bundle.trtfb> --audio-in INPUT.wav --audio-out OUTPUT.wav
 //   trtmc generate-video  <bundle.trtfb> --prompt "text" --output DIR [--num-steps N]
 //   trtmc classify        <bundle.trtfb> --image PATH [--benchmark N] [--warmup N]
@@ -1294,17 +1296,36 @@ int cmd_solve(const CliArgs& args) {
 }
 
 int cmd_transcribe(const CliArgs& args) {
-    if (args.bundle_path.empty() || args.audio_in.empty()) {
+    const std::vector<std::string> audio_paths =
+        !args.audio_inputs.empty() ? args.audio_inputs
+                                   : (args.audio_in.empty() ? std::vector<std::string>{}
+                                                            : std::vector<std::string>{args.audio_in});
+    if (args.bundle_path.empty() || audio_paths.empty()) {
         std::cerr << "Error: transcribe requires bundle + --audio\n";
         return EXIT_FAILURE;
     }
 
     auto pipeline = trtmc::load(args.bundle_path, make_load_options(args));
 
-    auto audio = trtmc::io::read_wav(args.audio_in);
     int32_t max_tokens = args.max_new_tokens > 0 ? args.max_new_tokens : 224;
 
     if (args.stream) {
+        if (audio_paths.size() != 1) {
+            std::cerr << "Error: --stream accepts exactly one --audio input\n";
+            return EXIT_FAILURE;
+        }
+        const bool has_offline_only_controls =
+            args.beam_size != 1 || args.transcription_task != "transcribe" ||
+            !args.punctuation || args.timestamps || args.max_input_seconds > 0.0F ||
+            args.segment_length_seconds > 0.0F ||
+            (args.language.empty() &&
+             (args.source_language != "en" || args.target_language != "en"));
+        if (has_offline_only_controls) {
+            std::cerr << "Error: decoding, duration, and segment controls are only "
+                         "supported for offline transcription\n";
+            return EXIT_FAILURE;
+        }
+        auto audio = trtmc::io::read_wav(audio_paths.front());
         trtmc::TranscriptionStreamConfig cfg;
         cfg.input_sample_rate = audio.sample_rate;
         cfg.max_new_tokens = max_tokens;
@@ -1335,10 +1356,42 @@ int cmd_transcribe(const CliArgs& args) {
         return EXIT_SUCCESS;
     }
 
-    auto result =
-        pipeline->transcribe(audio.samples.data(), static_cast<int32_t>(audio.samples.size()),
-                             max_tokens, audio.sample_rate);
-    std::cout << result.text << '\n';
+    std::vector<trtmc::TranscriptionRequest> requests;
+    requests.reserve(audio_paths.size());
+    for (const auto& path : audio_paths) {
+        auto audio = trtmc::io::read_wav(path);
+        trtmc::TranscriptionRequest request;
+        request.audio_samples = std::move(audio.samples);
+        request.config.max_output_tokens = max_tokens;
+        request.config.input_sample_rate = audio.sample_rate;
+        request.config.beam_size = args.beam_size;
+        request.config.source_language = args.source_language;
+        request.config.target_language = args.target_language;
+        request.config.task = args.transcription_task == "translate"
+                                  ? trtmc::TranscriptionTask::kTranslate
+                                  : trtmc::TranscriptionTask::kTranscribe;
+        request.config.punctuation = args.punctuation;
+        request.config.timestamps = args.timestamps;
+        request.config.max_input_duration_seconds = args.max_input_seconds;
+        request.config.segment_duration_seconds = args.segment_length_seconds;
+        requests.push_back(std::move(request));
+    }
+
+    auto results = pipeline->transcribe_batch(requests);
+    for (std::size_t i = 0; i < results.size(); ++i) {
+        if (args.timestamps) {
+            for (const auto& segment : results[i].segments) {
+                if (results.size() > 1)
+                    std::cout << audio_paths[i] << '\t';
+                std::cout << std::fixed << std::setprecision(3) << segment.start_seconds << '\t'
+                          << segment.end_seconds << '\t' << segment.text << '\n';
+            }
+        } else {
+            if (results.size() > 1)
+                std::cout << audio_paths[i] << '\t';
+            std::cout << results[i].text << '\n';
+        }
+    }
     return EXIT_SUCCESS;
 }
 

--- a/src/runtime/models/canary/canary_config.h
+++ b/src/runtime/models/canary/canary_config.h
@@ -33,6 +33,20 @@ struct CanaryConfig {
     // When non-empty, transcribe() uses this instead of building from individual fields.
     // Set from bundle config.json "decoder_start_token_ids" for compatible ASR variants.
     std::vector<int32_t> decoder_start_token_ids;
+
+    // Canary prompt metadata is derived from the checkpoint tokenizer while
+    // building the bundle. The positions refer to decoder_start_token_ids.
+    std::vector<std::string> supported_languages;
+    std::vector<int32_t> language_token_ids;
+    int32_t source_language_position{4};
+    int32_t target_language_position{5};
+    int32_t punctuation_position{6};
+    int32_t timestamp_position{8};
+    int32_t punctuation_token_id{-1};
+    int32_t no_punctuation_token_id{-1};
+    int32_t timestamp_token_id{-1};
+    int32_t no_timestamp_token_id{-1};
+    bool translation_requires_english{true};
 };
 
 } // namespace trtmc

--- a/src/runtime/models/canary/canary_decode_policy.h
+++ b/src/runtime/models/canary/canary_decode_policy.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <string>
 #include <utility>
@@ -51,6 +53,91 @@ run_canary_decode_loop(const std::vector<int32_t>& initial_tokens, int32_t max_n
         }
     }
 
+    return result;
+}
+
+struct CanaryBeamHypothesis {
+    std::vector<int32_t> output_ids;
+    double score{0.0};
+    bool finished{false};
+};
+
+template <typename LogitsFn>
+inline CanaryDecodeLoopResult
+run_canary_beam_search(const std::vector<int32_t>& initial_tokens, int32_t max_new_tokens,
+                       int32_t eot_token_id, int32_t beam_size, LogitsFn&& logits_for_prefix) {
+    CanaryDecodeLoopResult result;
+    if (max_new_tokens <= 0 || beam_size <= 0)
+        return result;
+
+    std::vector<CanaryBeamHypothesis> beams(1);
+    for (int32_t step = 0; step < max_new_tokens; ++step) {
+        std::vector<CanaryBeamHypothesis> candidates;
+        bool all_finished = true;
+        for (const auto& beam : beams) {
+            if (beam.finished) {
+                candidates.push_back(beam);
+                continue;
+            }
+            all_finished = false;
+            std::vector<int32_t> prefix = initial_tokens;
+            prefix.insert(prefix.end(), beam.output_ids.begin(), beam.output_ids.end());
+            std::vector<float> logits;
+            if (!logits_for_prefix(prefix, logits, result.error)) {
+                result.decode_failed = true;
+                return result;
+            }
+            if (logits.empty()) {
+                result.decode_failed = true;
+                result.error = "Canary beam search received empty logits";
+                return result;
+            }
+
+            const float max_logit = *std::max_element(logits.begin(), logits.end());
+            double exp_sum = 0.0;
+            for (const float logit : logits)
+                exp_sum += std::exp(static_cast<double>(logit - max_logit));
+            const double log_normalizer = static_cast<double>(max_logit) + std::log(exp_sum);
+
+            std::vector<int32_t> indices(logits.size());
+            for (std::size_t i = 0; i < indices.size(); ++i)
+                indices[i] = static_cast<int32_t>(i);
+            const int32_t top_count =
+                std::min<int32_t>(beam_size, static_cast<int32_t>(indices.size()));
+            std::partial_sort(
+                indices.begin(), indices.begin() + top_count, indices.end(),
+                [&logits](int32_t lhs, int32_t rhs) {
+                    const float lhs_logit = logits[static_cast<std::size_t>(lhs)];
+                    const float rhs_logit = logits[static_cast<std::size_t>(rhs)];
+                    return lhs_logit == rhs_logit ? lhs < rhs : lhs_logit > rhs_logit;
+                });
+            for (int32_t i = 0; i < top_count; ++i) {
+                const int32_t token = indices[static_cast<std::size_t>(i)];
+                CanaryBeamHypothesis candidate = beam;
+                candidate.output_ids.push_back(token);
+                candidate.score += static_cast<double>(logits[static_cast<std::size_t>(token)]) -
+                                   log_normalizer;
+                candidate.finished = token == eot_token_id;
+                candidates.push_back(std::move(candidate));
+            }
+        }
+        if (all_finished)
+            break;
+
+        std::stable_sort(candidates.begin(), candidates.end(),
+                         [](const CanaryBeamHypothesis& lhs,
+                            const CanaryBeamHypothesis& rhs) {
+                             if (lhs.score != rhs.score)
+                                 return lhs.score > rhs.score;
+                             return lhs.output_ids < rhs.output_ids;
+                         });
+        if (candidates.size() > static_cast<std::size_t>(beam_size))
+            candidates.resize(static_cast<std::size_t>(beam_size));
+        beams = std::move(candidates);
+    }
+
+    if (!beams.empty())
+        result.output_ids = std::move(beams.front().output_ids);
     return result;
 }
 

--- a/src/runtime/models/canary/canary_request.h
+++ b/src/runtime/models/canary/canary_request.h
@@ -1,0 +1,154 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "runtime/models/canary/canary_config.h"
+#include "trtmc/pipeline.h"
+#include "trtmc/tokenizer.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace trtmc {
+
+constexpr int32_t CanaryMaxBeamSize = 16;
+
+inline int32_t canary_token_id(const ITokenizer* tokenizer, std::string_view token,
+                               int32_t configured_id) {
+    if (configured_id >= 0)
+        return configured_id;
+    if (tokenizer == nullptr)
+        return -1;
+    return tokenizer->id_for_token(token);
+}
+
+inline int32_t canary_language_token_id(const CanaryConfig& model, const ITokenizer* tokenizer,
+                                        const std::string& language) {
+    const auto it = std::find(model.supported_languages.begin(), model.supported_languages.end(),
+                              language);
+    if (it != model.supported_languages.end()) {
+        const auto index = static_cast<std::size_t>(it - model.supported_languages.begin());
+        if (index < model.language_token_ids.size())
+            return model.language_token_ids[index];
+    }
+    if (!model.supported_languages.empty())
+        return -1;
+    if (tokenizer == nullptr)
+        return language == model.language ? model.language_token_id : -1;
+    return tokenizer->id_for_token("<|" + language + "|>");
+}
+
+inline void validate_canary_request(const CanaryConfig& model, const TranscriptionConfig& request,
+                                    const ITokenizer* tokenizer) {
+    if (request.max_output_tokens <= 0 ||
+        (model.max_target_positions > 0 &&
+         request.max_output_tokens > model.max_target_positions)) {
+        throw std::invalid_argument("Canary max_output_tokens must be in [1, " +
+                                    std::to_string(model.max_target_positions) + "]");
+    }
+    if (request.beam_size < 1 || request.beam_size > CanaryMaxBeamSize) {
+        throw std::invalid_argument("Canary beam_size must be in [1, " +
+                                    std::to_string(CanaryMaxBeamSize) + "]");
+    }
+    if (request.input_sample_rate < 0) {
+        throw std::invalid_argument("Canary input_sample_rate must be 0 or a positive Hz value");
+    }
+    if (request.task != TranscriptionTask::kTranscribe &&
+        request.task != TranscriptionTask::kTranslate) {
+        throw std::invalid_argument("Canary task must be kTranscribe or kTranslate");
+    }
+    if (request.source_language.empty() ||
+        canary_language_token_id(model, tokenizer, request.source_language) < 0) {
+        throw std::invalid_argument("Canary does not support source language '" +
+                                    request.source_language + "' in this bundle");
+    }
+    if (request.target_language.empty() ||
+        canary_language_token_id(model, tokenizer, request.target_language) < 0) {
+        throw std::invalid_argument("Canary does not support target language '" +
+                                    request.target_language + "' in this bundle");
+    }
+    if (request.task == TranscriptionTask::kTranscribe &&
+        request.source_language != request.target_language) {
+        throw std::invalid_argument(
+            "Canary transcribe task requires source_language == target_language; use the "
+            "translate task for different languages");
+    }
+    if (request.task == TranscriptionTask::kTranslate) {
+        if (request.source_language == request.target_language) {
+            throw std::invalid_argument(
+                "Canary translate task requires different source and target languages");
+        }
+        if (model.translation_requires_english && request.source_language != "en" &&
+            request.target_language != "en") {
+            throw std::invalid_argument(
+                "This Canary bundle only supports translation between English and another "
+                "supported language");
+        }
+    }
+    if (!std::isfinite(request.max_input_duration_seconds) ||
+        request.max_input_duration_seconds < 0.0F) {
+        throw std::invalid_argument(
+            "Canary max_input_duration_seconds must be a finite value >= 0");
+    }
+    if (!std::isfinite(request.segment_duration_seconds) ||
+        request.segment_duration_seconds < 0.0F) {
+        throw std::invalid_argument(
+            "Canary segment_duration_seconds must be a finite value >= 0");
+    }
+}
+
+inline std::vector<int32_t> make_canary_request_tokens(const CanaryConfig& model,
+                                                       const TranscriptionConfig& request,
+                                                       const ITokenizer* tokenizer) {
+    validate_canary_request(model, request, tokenizer);
+    std::vector<int32_t> tokens = model.decoder_start_token_ids;
+    if (tokens.empty()) {
+        if (request.source_language != model.language ||
+            request.target_language != model.language || !request.punctuation ||
+            request.timestamps || request.task != TranscriptionTask::kTranscribe) {
+            throw std::invalid_argument(
+                "Canary bundle does not contain configurable decoder prompt metadata; rebuild "
+                "it from the local checkpoint");
+        }
+        return {model.decoder_start_token_id, model.language_token_id,
+                model.transcribe_token_id, model.notimestamps_token_id};
+    }
+
+    const int32_t positions[] = {model.source_language_position, model.target_language_position,
+                                 model.punctuation_position, model.timestamp_position};
+    for (const int32_t position : positions) {
+        if (position < 0 || static_cast<std::size_t>(position) >= tokens.size()) {
+            throw std::invalid_argument(
+                "Canary bundle prompt metadata is incompatible with configurable decoding");
+        }
+    }
+
+    tokens[static_cast<std::size_t>(model.source_language_position)] =
+        canary_language_token_id(model, tokenizer, request.source_language);
+    tokens[static_cast<std::size_t>(model.target_language_position)] =
+        canary_language_token_id(model, tokenizer, request.target_language);
+
+    const int32_t punctuation_id = canary_token_id(
+        tokenizer, request.punctuation ? "<|pnc|>" : "<|nopnc|>",
+        request.punctuation ? model.punctuation_token_id : model.no_punctuation_token_id);
+    const int32_t timestamp_id = canary_token_id(
+        tokenizer, request.timestamps ? "<|timestamp|>" : "<|notimestamp|>",
+        request.timestamps ? model.timestamp_token_id : model.no_timestamp_token_id);
+    if (punctuation_id < 0 || timestamp_id < 0) {
+        throw std::invalid_argument(
+            "Canary bundle tokenizer is missing punctuation or timestamp control tokens");
+    }
+    tokens[static_cast<std::size_t>(model.punctuation_position)] = punctuation_id;
+    tokens[static_cast<std::size_t>(model.timestamp_position)] = timestamp_id;
+    return tokens;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/canary/pipeline.cpp
+++ b/src/runtime/models/canary/pipeline.cpp
@@ -11,14 +11,18 @@
 #include "runtime/models/canary/canary_decode_policy.h"
 #include "runtime/models/canary/canary_host_plan.h"
 #include "runtime/models/canary/canary_mel_spectrogram.h"
+#include "runtime/models/canary/canary_request.h"
 #include "runtime/models/canary/decode_runtime.h"
 #include "trtmc/tokenizer.h"
 #include "utils/wav_reader.h"
 
 #include <chrono>
+#include <cctype>
+#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <vector>
@@ -47,6 +51,22 @@ struct CanaryStageTimestamps {
     CanaryClock::time_point decoder_end;
     CanaryClock::time_point tokenize_end;
 };
+
+std::string remove_punctuation_outside_control_tokens(const std::string& text) {
+    std::string cleaned;
+    cleaned.reserve(text.size());
+    bool in_control_token = false;
+    for (std::size_t i = 0; i < text.size(); ++i) {
+        const unsigned char ch = static_cast<unsigned char>(text[i]);
+        if (!in_control_token && ch == '<' && i + 1 < text.size() && text[i + 1] == '|')
+            in_control_token = true;
+        if (in_control_token || std::ispunct(ch) == 0)
+            cleaned.push_back(static_cast<char>(ch));
+        if (in_control_token && ch == '>' && i > 0 && text[i - 1] == '|')
+            in_control_token = false;
+    }
+    return cleaned;
+}
 
 void report_canary_stage_timing(bool enabled, const CanaryStageTimestamps& timestamps) {
     if (!enabled)
@@ -123,6 +143,93 @@ CanaryPipeline::~CanaryPipeline() {
 
 TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_samples,
                                       int32_t max_new_tokens, int32_t input_sample_rate) {
+    TranscriptionConfig cfg;
+    cfg.max_output_tokens = max_new_tokens;
+    cfg.input_sample_rate = input_sample_rate;
+    return transcribe(audio_data, num_samples, cfg);
+}
+
+TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_samples,
+                                      const TranscriptionConfig& cfg) {
+    if (audio_data == nullptr || num_samples <= 0)
+        throw std::invalid_argument("Canary transcription requires non-empty audio samples");
+
+    auto initial_tokens = make_canary_request_tokens(canary_config_, cfg, tokenizer_.get());
+    const int32_t available_output_tokens =
+        canary_config_.max_target_positions - static_cast<int32_t>(initial_tokens.size());
+    if (available_output_tokens <= 0 || cfg.max_output_tokens > available_output_tokens) {
+        throw std::invalid_argument("Canary max_output_tokens must be in [1, " +
+                                    std::to_string(std::max(available_output_tokens, 0)) +
+                                    "] after accounting for the decoder prompt");
+    }
+
+    const int32_t sample_rate = cfg.input_sample_rate > 0 ? cfg.input_sample_rate
+                                                          : mel_sampling_rate_;
+    const double duration_seconds =
+        static_cast<double>(num_samples) / static_cast<double>(sample_rate);
+    if (cfg.max_input_duration_seconds > 0.0F &&
+        duration_seconds > static_cast<double>(cfg.max_input_duration_seconds) + 1.0e-6) {
+        throw std::invalid_argument(
+            "Canary input duration " + std::to_string(duration_seconds) +
+            " seconds exceeds max_input_duration_seconds=" +
+            std::to_string(cfg.max_input_duration_seconds));
+    }
+
+    const double model_segment_seconds = static_cast<double>(mel_chunk_length_);
+    double segment_seconds = static_cast<double>(cfg.segment_duration_seconds);
+    if (segment_seconds <= 0.0)
+        segment_seconds = model_segment_seconds;
+    if (segment_seconds <= 0.0 || segment_seconds > model_segment_seconds) {
+        throw std::invalid_argument(
+            "Canary segment_duration_seconds must be > 0 and <= the bundle limit of " +
+            std::to_string(model_segment_seconds) + " seconds");
+    }
+    if (cfg.segment_duration_seconds <= 0.0F && duration_seconds > model_segment_seconds) {
+        throw std::invalid_argument(
+            "Canary input exceeds the bundle's single-segment limit of " +
+            std::to_string(model_segment_seconds) +
+            " seconds; set segment_duration_seconds to enable segmented decoding");
+    }
+
+    const int64_t segment_samples_64 =
+        static_cast<int64_t>(std::llround(segment_seconds * static_cast<double>(sample_rate)));
+    if (segment_samples_64 <= 0 || segment_samples_64 > std::numeric_limits<int32_t>::max())
+        throw std::invalid_argument("Canary segment duration produces an invalid sample count");
+    const int32_t segment_samples = static_cast<int32_t>(segment_samples_64);
+
+    TextResult combined;
+    for (int64_t offset = 0; offset < num_samples; offset += segment_samples) {
+        const int32_t count = static_cast<int32_t>(
+            std::min<int64_t>(segment_samples, static_cast<int64_t>(num_samples) - offset));
+        auto segment = transcribe_segment(audio_data + offset, count, sample_rate, initial_tokens,
+                                          cfg.max_output_tokens, cfg.beam_size);
+        if (!cfg.punctuation)
+            segment.text = remove_punctuation_outside_control_tokens(segment.text);
+        if (cfg.timestamps) {
+            TranscriptionSegment timed;
+            timed.start_seconds =
+                static_cast<double>(offset) / static_cast<double>(sample_rate);
+            timed.end_seconds =
+                static_cast<double>(offset + count) / static_cast<double>(sample_rate);
+            timed.text = segment.text;
+            timed.token_ids = segment.token_ids;
+            combined.segments.push_back(std::move(timed));
+        }
+        if (!combined.text.empty() && !segment.text.empty())
+            combined.text += '\n';
+        combined.text += segment.text;
+        combined.token_ids.insert(combined.token_ids.end(), segment.token_ids.begin(),
+                                  segment.token_ids.end());
+        combined.prefill_ms += segment.prefill_ms;
+        combined.decode_ms += segment.decode_ms;
+    }
+    return combined;
+}
+
+TextResult CanaryPipeline::transcribe_segment(const float* audio_data, int32_t num_samples,
+                                              int32_t input_sample_rate,
+                                              const std::vector<int32_t>& initial_tokens,
+                                              int32_t max_output_tokens, int32_t beam_size) {
     const bool report_stage_timing = canary_stage_timing_enabled();
     const auto transcribe_start = CanaryClock::now();
 
@@ -178,9 +285,8 @@ TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_sampl
     const auto cross_kv_end = CanaryClock::now();
 
     // Step 4: Run decoder
-    std::vector<int32_t> initial_tokens = make_canary_initial_decoder_tokens(canary_config_);
     std::cerr << "[canary] Running decoder ..." << std::endl;
-    auto output_ids = run_decoder(initial_tokens, max_new_tokens);
+    auto output_ids = run_decoder(initial_tokens, max_output_tokens, beam_size);
     const auto decoder_end = CanaryClock::now();
 
     // Step 5: Decode token IDs
@@ -277,7 +383,28 @@ void CanaryPipeline::setup_cross_attention(int32_t actual_enc_seq_len) {
 }
 
 std::vector<int32_t> CanaryPipeline::run_decoder(const std::vector<int32_t>& initial_tokens,
-                                                 int32_t max_new_tokens) {
+                                                 int32_t max_new_tokens, int32_t beam_size) {
+    if (beam_size > 1) {
+        auto result = run_canary_beam_search(
+            initial_tokens, max_new_tokens, canary_config_.eot_token_id, beam_size,
+            [this](const std::vector<int32_t>& prefix, std::vector<float>& logits,
+                   std::string& error) {
+                try {
+                    state_->reset();
+                    state_->bind_to(*decoder_);
+                    for (const int32_t token : prefix)
+                        run_decoder_step(token, logits);
+                    return true;
+                } catch (const std::exception& e) {
+                    error = e.what();
+                    return false;
+                }
+            });
+        if (result.decode_failed)
+            throw std::runtime_error("Canary beam search failed: " + result.error);
+        return result.output_ids;
+    }
+
     state_->reset();
     state_->bind_to(*decoder_);
 

--- a/src/runtime/models/canary/pipeline.h
+++ b/src/runtime/models/canary/pipeline.h
@@ -38,16 +38,22 @@ class CanaryPipeline final : public IPipeline {
 
     TextResult transcribe(const float* audio_data, int32_t num_samples, int32_t max_new_tokens,
                           int32_t input_sample_rate = 0) override;
+    TextResult transcribe(const float* audio_data, int32_t num_samples,
+                          const TranscriptionConfig& cfg) override;
 
     const char* model_id() const override { return model_id_.c_str(); }
     const char* pipeline_type() const override { return "CanaryPipeline"; }
 
   private:
+    TextResult transcribe_segment(const float* audio_data, int32_t num_samples,
+                                  int32_t input_sample_rate,
+                                  const std::vector<int32_t>& initial_tokens,
+                                  int32_t max_output_tokens, int32_t beam_size);
     void run_encoder(const float* mel_data, int32_t mel_bins, int32_t mel_length,
                      int32_t valid_mel_frames);
     void setup_cross_attention(int32_t actual_enc_seq_len);
     std::vector<int32_t> run_decoder(const std::vector<int32_t>& initial_tokens,
-                                     int32_t max_new_tokens);
+                                     int32_t max_new_tokens, int32_t beam_size);
     void run_decoder_step(int32_t token_id, std::vector<float>& logits);
 
     std::unique_ptr<TrtModule> encoder_;

--- a/src/runtime/models/canary/plugin.cpp
+++ b/src/runtime/models/canary/plugin.cpp
@@ -111,7 +111,25 @@ class CanaryPlugin final : public IPipelinePlugin {
         int32_t eot_token_id = extract_json_int(json, "eot_token_id", -1);
         wc.eot_token_id = (eot_token_id >= 0) ? eot_token_id : ctx.config.id_eos;
         wc.mel_length = extract_json_int(json, "mel_length", 0);
-        wc.decoder_start_token_ids = extract_json_int_array(json, "decoder_start_token_ids");
+        wc.decoder_start_token_ids =
+            extract_json_int_array(json, "decoder_start_token_ids", 256);
+        wc.supported_languages = extract_json_string_array(json, "canary_supported_languages");
+        wc.language_token_ids =
+            extract_json_int_array(json, "canary_language_token_ids", 256);
+        wc.source_language_position =
+            extract_json_int(json, "canary_source_language_position", 4);
+        wc.target_language_position =
+            extract_json_int(json, "canary_target_language_position", 5);
+        wc.punctuation_position = extract_json_int(json, "canary_punctuation_position", 6);
+        wc.timestamp_position = extract_json_int(json, "canary_timestamp_position", 8);
+        wc.punctuation_token_id = extract_json_int(json, "canary_punctuation_token_id", -1);
+        wc.no_punctuation_token_id =
+            extract_json_int(json, "canary_no_punctuation_token_id", -1);
+        wc.timestamp_token_id = extract_json_int(json, "canary_timestamp_token_id", -1);
+        wc.no_timestamp_token_id =
+            extract_json_int(json, "canary_no_timestamp_token_id", -1);
+        wc.translation_requires_english =
+            extract_json_bool(json, "canary_translation_requires_english", true);
         wc.disable_cuda_graph = canary_cuda_graph_disabled(ctx);
 
         // Create CanaryKvCache for decoder self-attention

--- a/tests/builder/test_engine_builder.py
+++ b/tests/builder/test_engine_builder.py
@@ -130,6 +130,30 @@ class TestResolveModel:
         finally:
             shutil.rmtree(staged)
 
+    def test_local_canary_directory_stages_archive_before_generic_config(self, tmp_path):
+        """A local Canary directory resolves without a remote model ID."""
+        (tmp_path / "config.json").write_text('{"model_type":"unrelated"}')
+        nemo_path = tmp_path / "local-canary.nemo"
+        config_bytes = (
+            b"target: nemo.collections.asr.models.aed_multitask_models."
+            b"EncDecMultiTaskModel\nencoder:\n  d_model: 16\n"
+            b"head:\n  num_classes: 321\n"
+        )
+        with tarfile.open(nemo_path, "w") as archive:
+            member = tarfile.TarInfo("model_config.yaml")
+            member.size = len(config_bytes)
+            archive.addfile(member, io.BytesIO(config_bytes))
+
+        staged = Path(_resolve_model(str(tmp_path)))
+        try:
+            assert staged != tmp_path
+            staged_config = (staged / "config.json").read_text()
+            assert '"model_type": "canary"' in staged_config
+            assert '"vocab_size": 321' in staged_config
+            assert (staged / nemo_path.name).resolve() == nemo_path.resolve()
+        finally:
+            shutil.rmtree(staged)
+
 
 class TestFindPlugin:
     def test_unsupported_model_type(self):

--- a/tests/cpp/models/canary/test_canary_decode_policy.cpp
+++ b/tests/cpp/models/canary/test_canary_decode_policy.cpp
@@ -131,6 +131,35 @@ void test_decode_loop_handles_zero_budget_and_empty_logits() {
           "canary decode loop treats empty-logit case as clean no-op");
 }
 
+void test_beam_search_recovers_better_sequence_than_greedy_prefix() {
+    const auto result = trtmc::run_canary_beam_search(
+        {9}, 2, 2, 2,
+        [](const std::vector<int32_t>& prefix, std::vector<float>& logits, std::string&) {
+            if (prefix.size() == 1) {
+                logits = {0.0F, -0.1F, -10.0F};
+            } else if (prefix.back() == 1) {
+                logits = {-10.0F, -10.0F, 2.0F};
+            } else {
+                logits = {0.0F, 0.0F, 0.0F};
+            }
+            return true;
+        });
+    check(!result.decode_failed, "Canary beam search succeeds");
+    check(result.output_ids == std::vector<int32_t>({1, 2}),
+          "Canary beam search selects highest sequence probability and stops on EOT");
+}
+
+void test_beam_search_reports_replay_failure() {
+    const auto result = trtmc::run_canary_beam_search(
+        {9}, 2, 2, 2,
+        [](const std::vector<int32_t>&, std::vector<float>&, std::string& error) {
+            error = "replay-fail";
+            return false;
+        });
+    check(result.decode_failed, "Canary beam search reports prefix replay failure");
+    check(result.error == "replay-fail", "Canary beam search forwards replay error");
+}
+
 } // namespace
 
 int main() {
@@ -138,6 +167,8 @@ int main() {
     test_decode_loop_reports_prefill_failure();
     test_decode_loop_reports_decode_failure_after_emitting_token();
     test_decode_loop_handles_zero_budget_and_empty_logits();
+    test_beam_search_recovers_better_sequence_than_greedy_prefix();
+    test_beam_search_reports_replay_failure();
 
     if (g_failures != 0) {
         std::cerr << g_failures << " canary decode policy test(s) failed\n";

--- a/tests/cpp/models/canary/test_canary_host_plan.cpp
+++ b/tests/cpp/models/canary/test_canary_host_plan.cpp
@@ -18,6 +18,7 @@
 #include "runtime/models/canary/canary_cross_kv_apply.h"
 #include "runtime/models/canary/canary_cross_kv_plan.h"
 #include "runtime/models/canary/canary_host_plan.h"
+#include "runtime/models/canary/canary_request.h"
 
 #include <cstdint>
 #include <cstring>
@@ -74,6 +75,68 @@ void test_encoder_length_planning() {
           "canary actual encoder length returns zero for full-length mel");
     check(trtmc::compute_canary_actual_encoder_length(100, 0, 1500) == 0,
           "canary actual encoder length returns zero for invalid full mel length");
+}
+
+trtmc::CanaryConfig configurable_canary() {
+    trtmc::CanaryConfig cfg;
+    cfg.max_target_positions = 64;
+    cfg.decoder_start_token_ids = {100, 101, 102, 103, 20, 20, 30, 31, 40, 41};
+    cfg.supported_languages = {"en", "fr"};
+    cfg.language_token_ids = {20, 21};
+    cfg.punctuation_token_id = 30;
+    cfg.no_punctuation_token_id = 32;
+    cfg.timestamp_token_id = 42;
+    cfg.no_timestamp_token_id = 40;
+    return cfg;
+}
+
+void test_configurable_request_prompt() {
+    const auto model = configurable_canary();
+    trtmc::TranscriptionConfig request;
+    request.max_output_tokens = 20;
+    request.beam_size = 4;
+    request.task = trtmc::TranscriptionTask::kTranslate;
+    request.source_language = "en";
+    request.target_language = "fr";
+    request.punctuation = false;
+    request.timestamps = true;
+
+    const auto tokens = trtmc::make_canary_request_tokens(model, request, nullptr);
+    check(tokens == std::vector<int32_t>({100, 101, 102, 103, 20, 21, 32, 31, 42, 41}),
+          "Canary request replaces language and output control prompt slots");
+}
+
+void test_configurable_request_validation() {
+    const auto model = configurable_canary();
+    trtmc::TranscriptionConfig request;
+    request.max_output_tokens = 20;
+
+    auto rejects = [&model](const trtmc::TranscriptionConfig& candidate) {
+        try {
+            (void)trtmc::make_canary_request_tokens(model, candidate, nullptr);
+            return false;
+        } catch (const std::invalid_argument&) {
+            return true;
+        }
+    };
+
+    request.target_language = "fr";
+    check(rejects(request), "Canary transcription rejects different target language");
+    request.task = trtmc::TranscriptionTask::kTranslate;
+    request.target_language = "en";
+    check(rejects(request), "Canary translation rejects equal languages");
+    request.target_language = "fr";
+    request.source_language = "de";
+    check(rejects(request), "Canary rejects language absent from bundle metadata");
+    request.source_language = "en";
+    request.beam_size = 17;
+    check(rejects(request), "Canary rejects beam size above supported bound");
+    request.beam_size = 1;
+    request.max_output_tokens = 65;
+    check(rejects(request), "Canary rejects output length above model bound");
+    request.max_output_tokens = 20;
+    request.segment_duration_seconds = -1.0F;
+    check(rejects(request), "Canary rejects negative segment duration");
 }
 
 void test_mel_padding_and_truncation_are_row_major() {
@@ -198,6 +261,8 @@ void test_cross_kv_apply_reports_failures() {
 int main() {
     test_expected_mel_length_and_initial_tokens();
     test_encoder_length_planning();
+    test_configurable_request_prompt();
+    test_configurable_request_validation();
     test_mel_padding_and_truncation_are_row_major();
     test_encoder_mask_and_cross_kv_plan();
     test_cross_kv_apply_tracks_zero_and_copy_operations();

--- a/tests/cpp/models/canary/test_canary_pipeline.cpp
+++ b/tests/cpp/models/canary/test_canary_pipeline.cpp
@@ -60,6 +60,13 @@ void test_canary_transcribe() {
     wcfg.mel_length = 4;
     wcfg.max_source_positions = 5;
     wcfg.eot_token_id = 2;
+    wcfg.decoder_start_token_ids = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    wcfg.supported_languages = {"en"};
+    wcfg.language_token_ids = {0};
+    wcfg.punctuation_token_id = 0;
+    wcfg.no_punctuation_token_id = 1;
+    wcfg.timestamp_token_id = 1;
+    wcfg.no_timestamp_token_id = 2;
 
     trtmc::MelFilterbank mel_fb;
     mel_fb.n_freq_bins = 201;
@@ -76,6 +83,15 @@ void test_canary_transcribe() {
     auto result = pipeline.transcribe(audio.data(), static_cast<int32_t>(audio.size()), 5);
     check(result.token_ids.size() == 1, "canary transcribe produces 1 token");
     check(result.token_ids[0] == 2, "canary transcribe token is eot=2");
+
+    trtmc::TranscriptionConfig request;
+    request.max_output_tokens = 5;
+    request.input_sample_rate = 16000;
+    request.timestamps = true;
+    const auto timed = pipeline.transcribe(audio.data(), static_cast<int32_t>(audio.size()), request);
+    check(timed.segments.size() == 1, "canary timestamp request returns one segment");
+    check(timed.segments[0].start_seconds == 0.0 && timed.segments[0].end_seconds > 0.0,
+          "canary timestamp segment reports input interval in seconds");
 
     cudaStreamDestroy(stream);
 }

--- a/tests/cpp/test_cli_args.cpp
+++ b/tests/cpp/test_cli_args.cpp
@@ -170,6 +170,8 @@ void test_audio_and_solve_flags() {
         parse({"trtmc", "transcribe", "bundle.trtfb", "--audio", "input.wav", "--stream",
                "--chunk-ms", "80", "--att-context-size", "5,2", "--pad-and-drop-preencoded"});
     check(transcribe.audio_in == "input.wav", "transcribe audio");
+    check(transcribe.audio_inputs == std::vector<std::string>({"input.wav"}),
+          "transcribe audio list");
     check(transcribe.stream, "transcribe stream");
     check(transcribe.chunk_ms == 80, "transcribe chunk ms");
     check(transcribe.att_context_left == 5 && transcribe.att_context_right == 2,
@@ -180,6 +182,37 @@ void test_audio_and_solve_flags() {
         parse({"trtmc", "solve", "bundle.trtfb", "--branch-input", "1,2", "--trunk-input", "3,4"});
     check(solve.branch_input == "1,2", "solve branch");
     check(solve.trunk_input == "3,4", "solve trunk");
+}
+
+void test_canary_transcription_flags_and_batch() {
+    auto args = parse({"trtmc", "transcribe", "bundle.trtfb", "--audio", "one.wav",
+                       "--audio", "two.wav", "--beam-size", "4", "--source-language", "en",
+                       "--target-language", "fr", "--task", "translate", "--no-punctuation",
+                       "--timestamps", "--max-input-seconds", "45.5",
+                       "--segment-length-seconds", "20"});
+    check(!args.parse_error, "Canary transcription controls parse");
+    check(args.audio_inputs == std::vector<std::string>({"one.wav", "two.wav"}),
+          "Canary repeated audio inputs form batch");
+    check(args.beam_size == 4, "Canary beam size");
+    check(args.source_language == "en" && args.target_language == "fr",
+          "Canary source and target languages");
+    check(args.transcription_task == "translate", "Canary translation task");
+    check(!args.punctuation, "Canary punctuation toggle");
+    check(args.timestamps, "Canary timestamp toggle");
+    check(args.max_input_seconds > 45.49F && args.max_input_seconds < 45.51F,
+          "Canary maximum input seconds");
+    check(args.segment_length_seconds == 20.0F, "Canary segment length seconds");
+
+    check(parse({"trtmc", "transcribe", "b.trtfb", "--audio", "a.wav", "--beam-size", "0"})
+              .parse_error,
+          "Canary rejects zero beam size");
+    check(parse({"trtmc", "transcribe", "b.trtfb", "--audio", "a.wav", "--task", "other"})
+              .parse_error,
+          "Canary rejects unknown task");
+    check(parse({"trtmc", "transcribe", "b.trtfb", "--audio", "a.wav",
+                 "--max-input-seconds", "nan"})
+              .parse_error,
+          "Canary rejects non-finite duration");
 }
 
 void test_unknown_command_fails() {
@@ -329,6 +362,7 @@ int main() {
     test_detect_parses_contract_flags();
     test_inspect_and_config_flags();
     test_audio_and_solve_flags();
+    test_canary_transcription_flags_and_batch();
     test_unknown_command_fails();
     test_unknown_flag_fails();
     test_missing_value_fails();

--- a/tests/cpp/test_pipeline_api.cpp
+++ b/tests/cpp/test_pipeline_api.cpp
@@ -53,6 +53,21 @@ class DummyPipeline final : public trtmc::IPipeline {
     const char* pipeline_type() const override { return "DummyPipeline"; }
 };
 
+class RecordingTranscriptionPipeline final : public trtmc::IPipeline {
+  public:
+    const char* model_id() const override { return "recording"; }
+    const char* pipeline_type() const override { return "RecordingTranscriptionPipeline"; }
+
+    trtmc::TextResult transcribe(const float* audio, int32_t count,
+                                 const trtmc::TranscriptionConfig& cfg) override {
+        observed.push_back(cfg);
+        return {std::to_string(count) + ":" + std::to_string(audio == nullptr ? -1 : audio[0]),
+                {cfg.beam_size}};
+    }
+
+    std::vector<trtmc::TranscriptionConfig> observed;
+};
+
 static void test_null_input_returns_null() {
     auto* p = trtmc_create_pipeline(nullptr, 0);
     check(p == nullptr, "null input returns nullptr");
@@ -233,6 +248,27 @@ static void test_ipipeline_default_virtuals() {
     check(threw, "default detect throws");
 }
 
+static void test_transcription_batch_preserves_per_request_config() {
+    RecordingTranscriptionPipeline pipeline;
+    trtmc::TranscriptionRequest first;
+    first.audio_samples = {1.0F, 2.0F};
+    first.config.beam_size = 1;
+    first.config.source_language = "en";
+    trtmc::TranscriptionRequest second;
+    second.audio_samples = {3.0F};
+    second.config.beam_size = 4;
+    second.config.source_language = "fr";
+
+    const auto results = pipeline.transcribe_batch({first, second});
+    check(results.size() == 2, "transcription batch result count");
+    check(results[0].token_ids == std::vector<int32_t>({1}) &&
+              results[1].token_ids == std::vector<int32_t>({4}),
+          "transcription batch preserves request order");
+    check(pipeline.observed.size() == 2 && pipeline.observed[0].source_language == "en" &&
+              pipeline.observed[1].source_language == "fr",
+          "transcription batch preserves per-request config");
+}
+
 int main() {
     test_null_input_returns_null();
     test_invalid_path_returns_null();
@@ -241,6 +277,7 @@ int main() {
     test_sizeof_ipipeline_is_vtable();
     test_delete_null_safe();
     test_ipipeline_default_virtuals();
+    test_transcription_batch_preserves_per_request_config();
 
     if (failures > 0) {
         std::cerr << failures << " test(s) FAILED\n";

--- a/tests/e2e/models/canary/test_canary_family_plugin_weights.py
+++ b/tests/e2e/models/canary/test_canary_family_plugin_weights.py
@@ -10,6 +10,7 @@ Shared test code is limited to filesystem and serialization helpers.
 from __future__ import annotations
 
 import importlib
+import sys
 from types import SimpleNamespace
 
 import numpy as np
@@ -300,6 +301,57 @@ class TestCanaryPlugin:
         assert weights["_dec_layers"] == self.DEC_LAYERS
         assert weights["_hidden"] == self.HIDDEN
         assert weights["_vocab"] == self.VOCAB
+
+    def test_prompt_metadata_is_derived_from_local_tokenizer(self, monkeypatch, tmp_path):
+        canary_module = importlib.import_module(
+            "tensorrt_model_connect.families.canary.plugin")
+
+        pieces = [
+            "<unk>", "▁", "<|startofcontext|>", "<|startoftranscript|>",
+            "<|emo:neutral|>", "<|de|>", "<|en|>", "<|pnc|>", "<|nopnc|>",
+            "<|itn|>", "<|noitn|>", "<|timestamp|>", "<|notimestamp|>",
+            "<|nodiarize|>", "<|endoftext|>",
+        ]
+
+        class FakeSentencePiece:
+            def __init__(self, model_file):
+                assert model_file.endswith("tokenizer.model")
+
+            def piece_to_id(self, piece):
+                return pieces.index(piece) if piece in pieces else 0
+
+            def id_to_piece(self, index):
+                return pieces[index]
+
+        monkeypatch.setitem(
+            sys.modules,
+            "sentencepiece",
+            SimpleNamespace(SentencePieceProcessor=FakeSentencePiece),
+        )
+        metadata = canary_module._canary_prompt_metadata(
+            {
+                "supported_languages": ["de", "en"],
+                "prompt_defaults": [{
+                    "role": "user",
+                    "slots": {
+                        "source_lang": "<|de|>",
+                        "target_lang": "<|en|>",
+                        "emotion": "<|emo:neutral|>",
+                        "pnc": "<|nopnc|>",
+                        "itn": "<|itn|>",
+                        "timestamp": "<|timestamp|>",
+                        "diarize": "<|nodiarize|>",
+                    },
+                }],
+            },
+            tmp_path / "tokenizer.model",
+        )
+
+        assert metadata["decoder_start_token_ids"] == [1, 2, 3, 4, 5, 6, 8, 9, 11, 13]
+        assert metadata["canary_supported_languages"] == ["de", "en"]
+        assert metadata["canary_language_token_ids"] == [5, 6]
+        assert metadata["canary_no_punctuation_token_id"] == 8
+        assert metadata["canary_timestamp_token_id"] == 11
 
     def test_tp_build_rejects_single_device_mode(self):
         decoder_tp_builder = self._tp_builder_module()

--- a/website/docs/api/cli-reference.md
+++ b/website/docs/api/cli-reference.md
@@ -77,3 +77,23 @@ Common options include `--hf-python`, `--backend-dir`, `--runtime-cache`, `--cud
 Text-generation options include `--max-new-tokens`, `--greedy`, `--temperature`, `--top-k`, `--top-p`, `--min-p`, `--seed`, `--chat-template`, and `--no-thinking`.
 
 Object detection is available through `trtmc detect` for pipelines that implement `IPipeline::detect`.
+
+### Canary transcription options
+
+`trtmc transcribe` accepts repeated `--audio` inputs. These options apply to
+every input in that CLI batch:
+
+| Option | Purpose |
+| --- | --- |
+| `--beam-size N` | Greedy at `1`; Canary beam search at `2` through `16`. |
+| `--source-language TAG` | Language code for the input audio. |
+| `--target-language TAG` | Language code for the decoded text. |
+| `--task transcribe|translate` | Validate and select ASR versus translation prompting. |
+| `--punctuation`, `--no-punctuation` | Enable or remove punctuation in decoded text. |
+| `--timestamps` | Print segment start/end seconds with each transcript. |
+| `--max-new-tokens N` | Per-segment decoder output limit. |
+| `--max-input-seconds F` | Reject inputs longer than this duration. |
+| `--segment-length-seconds F` | Decode independent audio windows of this duration. |
+
+See [Configurable Canary Decoding](/tutorials/intermediate/canary-decoding)
+for bounds, batch output, and local checkpoint examples.

--- a/website/docs/api/cpp-api.md
+++ b/website/docs/api/cpp-api.md
@@ -77,6 +77,35 @@ auto partial = stream->accept_audio(samples, num_samples, false);
 auto final = stream->finish();
 ```
 
+## Offline transcription
+
+`TranscriptionConfig` carries per-request offline ASR controls:
+
+```cpp
+trtmc::TranscriptionConfig cfg;
+cfg.input_sample_rate = 16000;
+cfg.max_output_tokens = 80;
+cfg.beam_size = 4;
+cfg.source_language = "en";
+cfg.target_language = "fr";
+cfg.task = trtmc::TranscriptionTask::kTranslate;
+cfg.punctuation = true;
+cfg.timestamps = true;
+cfg.max_input_duration_seconds = 300.0F;
+cfg.segment_duration_seconds = 20.0F;
+
+auto result = pipe->transcribe(samples, num_samples, cfg);
+for (const auto& segment : result.segments) {
+    std::cout << segment.start_seconds << "\t" << segment.end_seconds
+              << "\t" << segment.text << "\n";
+}
+```
+
+`transcribe_batch(const std::vector<TranscriptionRequest>&)` preserves each
+request's samples and config. The default implementation is sequential and
+returns results in request order. The legacy max-token/sample-rate overload is
+still supported.
+
 ## C ABI
 
 The C ABI is for FFI and backward-compatible integrations:

--- a/website/docs/tutorials/intermediate/canary-decoding.md
+++ b/website/docs/tutorials/intermediate/canary-decoding.md
@@ -1,0 +1,153 @@
+---
+title: Configurable Canary Decoding
+---
+
+This tutorial builds a Canary bundle from a local NeMo checkpoint and uses the
+offline decoding controls exposed by the CLI and C++ API.
+
+## Build from a local checkpoint
+
+The input may be a `.nemo` archive or a directory containing one compatible
+Canary archive. No remote model identifier is required.
+
+```bash
+CANARY_NEMO=/models/canary-1b-v2.nemo
+
+./build/trtmc build "$CANARY_NEMO" \
+  -o /tmp/canary-1b-v2.trtfb \
+  --precision fp16 \
+  --max-cache-length 128
+
+./build/trtmc inspect /tmp/canary-1b-v2.trtfb --list-engines
+```
+
+The builder reads `model_config.yaml`, the checkpoint weights, prompt defaults,
+and the SentencePiece vocabulary from the local archive. The generated bundle
+records the exact decoder prompt and control token IDs from that checkpoint.
+An archive missing a required prompt or language token fails during the build.
+
+## Greedy transcription
+
+Omitting the new controls preserves English greedy transcription with
+punctuation and no timestamps:
+
+```bash
+./build/trtmc transcribe /tmp/canary-1b-v2.trtfb \
+  --audio /data/input.wav \
+  --max-new-tokens 80
+```
+
+`--language fr` remains a shorthand for an equal source and target language.
+The explicit form is:
+
+```bash
+./build/trtmc transcribe /tmp/canary-1b-v2.trtfb \
+  --audio /data/french.wav \
+  --source-language fr \
+  --target-language fr \
+  --task transcribe
+```
+
+## Translation and beam search
+
+Canary 1B v2 translates between English and each other supported language.
+The source and target must differ for `translate`; one of them must be `en`.
+
+```bash
+./build/trtmc transcribe /tmp/canary-1b-v2.trtfb \
+  --audio /data/english.wav \
+  --source-language en \
+  --target-language fr \
+  --task translate \
+  --beam-size 4 \
+  --max-new-tokens 120
+```
+
+`--beam-size 1` is the backward-compatible greedy path. Values from 2 through
+16 use deterministic beam search. The current engine stores one decoder
+hypothesis, so beam search replays candidate prefixes and trades throughput for
+search quality.
+
+Use `--no-punctuation` to request the checkpoint's no-punctuation prompt and
+remove remaining punctuation from decoded text. `--punctuation` is the default.
+
+## Duration, segmentation, and timestamps
+
+```bash
+./build/trtmc transcribe /tmp/canary-1b-v2.trtfb \
+  --audio /data/long.wav \
+  --segment-length-seconds 20 \
+  --max-input-seconds 300 \
+  --timestamps
+```
+
+Timestamp output is tab-separated:
+
+```text
+0.000   20.000  First decoded segment...
+20.000  40.000  Second decoded segment...
+```
+
+Each interval is an independently decoded audio window. These are segment-level
+input boundaries, not word alignment from Canary's auxiliary CTC timestamp
+model. Segment decoding has no overlap or cross-segment decoder context.
+
+| Option | Units and bounds | Behavior |
+| --- | --- | --- |
+| `--max-new-tokens` | Tokens; at least 1 and no more than the bundle target limit minus prompt tokens | Applied independently to every segment. |
+| `--beam-size` | Integer in `[1, 16]` | `1` is greedy; larger values use beam search. |
+| `--max-input-seconds` | Seconds; finite and greater than 0 | Rejects an input whose total duration exceeds the value. |
+| `--segment-length-seconds` | Seconds; finite, greater than 0, and no greater than the bundle audio window | Splits long input into ordered independent requests. |
+
+Without `--segment-length-seconds`, an input longer than the bundle's audio
+window is rejected instead of being silently truncated.
+
+## Batch CLI behavior
+
+Repeat `--audio` to process more than one input. Decoding flags are batch-wide,
+results retain input order, and every output line starts with its source path.
+
+```bash
+./build/trtmc transcribe /tmp/canary-1b-v2.trtfb \
+  --audio /data/one.wav \
+  --audio /data/two.wav \
+  --source-language en \
+  --target-language en \
+  --beam-size 2
+```
+
+## C++ API
+
+The C++ batch API carries a complete configuration per request:
+
+```cpp
+#include <trtmc/pipeline.h>
+
+auto pipeline = trtmc::load("/tmp/canary-1b-v2.trtfb");
+
+trtmc::TranscriptionRequest english;
+english.audio_samples = english_pcm;
+english.config.input_sample_rate = 16000;
+english.config.max_output_tokens = 80;
+english.config.beam_size = 1;
+english.config.source_language = "en";
+english.config.target_language = "en";
+
+trtmc::TranscriptionRequest translation = english;
+translation.audio_samples = second_pcm;
+translation.config.beam_size = 4;
+translation.config.target_language = "fr";
+translation.config.task = trtmc::TranscriptionTask::kTranslate;
+translation.config.timestamps = true;
+
+std::vector<trtmc::TextResult> results =
+    pipeline->transcribe_batch({english, translation});
+```
+
+The default batch implementation executes requests sequentially and preserves
+their order and individual configs. The legacy four-argument `transcribe`
+overload remains available and maps to the default greedy configuration.
+
+Unsupported languages, mismatched task/language combinations, invalid beam
+sizes, excessive output lengths, and invalid duration values throw
+`std::invalid_argument` with the failing option named in the message.

--- a/website/docs/tutorials/intermediate/multimodal-and-speech.md
+++ b/website/docs/tutorials/intermediate/multimodal-and-speech.md
@@ -68,6 +68,9 @@ Key ideas:
 
 `speech_to_text` bundles use audio preprocessing, mel feature extraction, encoder/decoder execution, and text decoding.
 
+For local Canary checkpoints, multilingual prompts, beam search, batching, and
+segment controls, continue with [Configurable Canary Decoding](canary-decoding.md).
+
 ```mermaid
 flowchart LR
   Audio["PCM audio"] --> Resample["Resample if needed"]

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -27,6 +27,7 @@ const sidebars = {
         'tutorials/beginner/inspect-bundles',
         'tutorials/beginner/text-generation',
         'tutorials/intermediate/multimodal-and-speech',
+        'tutorials/intermediate/canary-decoding',
         'tutorials/intermediate/diffusion-and-time-series',
         'tutorials/advanced/quantization-and-runtime-knobs',
         'tutorials/advanced/validation-and-benchmarking'


### PR DESCRIPTION
## Background

Canary decoding was fixed to a single English, punctuated, no-timestamp prompt and greedy argmax decoding. The public transcription API also had no per-request control object or batch contract, and local NeMo bundle generation hardcoded the public checkpoint's prompt token IDs.

Closes #424.

## Exit Criteria

- Expose beam size, source/target languages, task, punctuation, timestamps, output length, input duration, and segment length through the CLI and C++ API.
- Preserve omitted-option defaults and greedy decoding.
- Preserve per-input configuration in C++ batches and define CLI controls as batch-wide.
- Build compatible local `.nemo` archives or containing directories without a remote model ID.
- Reject unsupported values and combinations with actionable errors.

## Implementation

- Adds `TranscriptionConfig`, `TranscriptionRequest`, timestamped segments, and a sequential per-request `transcribe_batch` default while retaining the legacy transcription overload.
- Resolves Canary prompt slots from bundle metadata, validates task/language/duration bounds, implements deterministic beam search by replaying prefixes against the single-hypothesis cache, and supports bounded independent audio segments.
- Extends `trtmc transcribe` with repeated audio inputs and batch-wide decoding flags. Timestamp output reports segment input intervals; punctuation-off applies both the prompt control and output enforcement.
- Derives prompt, language, punctuation, timestamp, EOT, tokenizer, and vocabulary metadata from local NeMo archives. A family-owned directory adapter stages mixed local snapshots safely.
- Adds C++ and synthetic builder regressions plus CLI, API, and local-checkpoint documentation.

## Validation

- `cmake --build build-trt --target trtmc trtmc_model_canary test_cli_args test_pipeline_api test_canary_host_plan test_canary_decode_policy test_canary_pipeline -j 8`: passed against TensorRT 11.2.0.113.
- `ctest --test-dir build-trt --output-on-failure -R '^(test_cli_args|test_pipeline_api|test_canary_host_plan|test_canary_decode_policy|test_canary_pipeline)$'`: 5/5 passed, including the GPU-backed Canary pipeline test.
- `python -m pytest -q tests/builder/test_engine_builder.py tests/e2e/models/canary/test_canary_family_plugin_weights.py`: 23 passed.
- `python -m pytest -q tests/tools/test_model_plugin_encapsulation_static.py`: 156 passed.
- `python -m ruff check ...`: passed for all modified Python files.
- `python tools/legal_headers.py --check`: 0 findings.
- `npm run build` in `website/`: Docusaurus production build passed.
- Built `/tmp/canary-issue-424.trtfb` directly from the cached local Canary 1B v2 `.nemo` with TensorRT 11.2.0.113; bundle creation completed in 261.6 seconds and embedded all 25 language/control mappings.
- GPU smoke matrix passed for greedy defaults, beam size 2, English-to-French translation, punctuation-off, timestamp intervals, 2-second segmentation, repeated-input batching, one-token output enforcement, and actionable task/duration rejection.

## Notes For Future Readers

- Review the public contract in `include/trtmc/pipeline.h`, then prompt validation in `canary_request.h`, and finally the runtime loop in the Canary pipeline.
- Beam search is correct but intentionally replays prefixes because the current engine/cache owns one hypothesis; a future batched beam cache can optimize this without changing the API.
- Timestamp intervals are independently decoded input-segment boundaries, not word alignment from Canary's auxiliary CTC timestamp model.
- The repository-wide documentation reference scanner still reports 17 pre-existing legacy `graph_ops.py`/`graph_blocks.py` path errors outside this change; the production documentation build passes.