### PR TITLE
ci: minimize premerge work by impact

### DIFF
--- a/.github/scripts/ensure-ci-docker-image.sh
+++ b/.github/scripts/ensure-ci-docker-image.sh
@@ -8,6 +8,7 @@ base_image="${TRTMC_CI_IMAGE:-trtmc-dev-gb300:manylinux_2_39}"
 dockerfile="${TRTMC_CI_DOCKERFILE:-Dockerfile}"
 lock_file="${TRTMC_CI_IMAGE_LOCK_FILE:-/tmp/trtmc-ci-docker-image.lock}"
 lock_timeout="${TRTMC_CI_IMAGE_LOCK_TIMEOUT:-5400}"
+verification_dir="${TRTMC_CI_IMAGE_VERIFICATION_DIR:-/tmp/trtmc-ci-image-verifications}"
 fingerprint_label="org.nvidia.trtmc.ci-input-fingerprint"
 
 if ! [[ "$lock_timeout" =~ ^[1-9][0-9]*$ ]]; then
@@ -147,6 +148,36 @@ if [ -z "$expected_modelopt" ]; then
   exit 1
 fi
 
+emit_image_ref() {
+  local resolved_ref="$1"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "image_ref=$resolved_ref" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+# Every matrix child uses the same immutable merge snapshot and host-local
+# Docker daemon. Validate the image once per workflow run, then let siblings
+# reuse that proof after a cheap immutable-image-ID check. The global flock
+# makes the stamp atomic and also keeps separate runs from rebuilding together.
+verification_stamp=""
+run_id="${GITHUB_RUN_ID:-}"
+run_attempt="${GITHUB_RUN_ATTEMPT:-1}"
+if [[ "$run_id" =~ ^[0-9]+$ ]] && [[ "$run_attempt" =~ ^[1-9][0-9]*$ ]]; then
+  mkdir -p "$verification_dir"
+  verification_stamp="${verification_dir%/}/${run_id}-${run_attempt}-${expected_fingerprint}.verified"
+  if [ -f "$verification_stamp" ]; then
+    stamped_ref="$(<"$verification_stamp")"
+    current_ref="$(docker image inspect --format '{{.Id}}' "$image" 2>/dev/null || true)"
+    if [[ "$stamped_ref" =~ ^sha256:[0-9a-f]{64}$ ]] && \
+       [ "$current_ref" = "$stamped_ref" ]; then
+      emit_image_ref "$current_ref"
+      echo "CI Docker image '$image' reused from this workflow run's verified image $current_ref"
+      exit 0
+    fi
+    rm -f -- "$verification_stamp"
+  fi
+fi
+
 summary() {
   if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     printf '%s\n' "$*" >> "$GITHUB_STEP_SUMMARY"
@@ -214,6 +245,7 @@ collect_docker_input_changes() {
 }
 
 rebuild_reasons=()
+image_metadata_valid=false
 mapfile -t changed_paths < <(collect_docker_input_changes)
 
 version_file="$(mktemp)"
@@ -261,6 +293,9 @@ else
     if [ "$current_python_profiles" != "$expected_python_profiles" ]; then
       rebuild_reasons+=("prebuilt Python profiles differ: image has '${current_python_profiles:-missing}', source expects '$expected_python_profiles'")
     fi
+    if [ "${#rebuild_reasons[@]}" -eq 0 ]; then
+      image_metadata_valid=true
+    fi
   fi
 fi
 
@@ -284,6 +319,7 @@ if [ "${#rebuild_reasons[@]}" -gt 0 ]; then
     -t "$image" \
     -f "$dockerfile" \
     .
+  image_metadata_valid=false
 else
   echo "CI Docker image '$image' already matches $dockerfile"
 fi
@@ -294,12 +330,14 @@ if [ "$current_fingerprint" != "$expected_fingerprint" ]; then
   exit 1
 fi
 
-query_image_versions > "$version_file"
-current_trt="$(awk -F= '$1 == "TENSORRT_VERSION" { print $2 }' "$version_file")"
-current_modelopt="$(awk -F= '$1 == "MODELOPT_VERSION" { print $2 }' "$version_file")"
-current_nlohmann="$(awk -F= '$1 == "NLOHMANN_JSON_HEADER" { print $2 }' "$version_file")"
-current_nemo_prompt_rnnt="$(awk -F= '$1 == "NEMO_PROMPT_RNNT" { print $2 }' "$version_file")"
-current_python_profiles="$(awk -F= '$1 == "PYTHON_PROFILES" { print $2 }' "$version_file")"
+if [ "$image_metadata_valid" != "true" ]; then
+  query_image_versions > "$version_file"
+  current_trt="$(awk -F= '$1 == "TENSORRT_VERSION" { print $2 }' "$version_file")"
+  current_modelopt="$(awk -F= '$1 == "MODELOPT_VERSION" { print $2 }' "$version_file")"
+  current_nlohmann="$(awk -F= '$1 == "NLOHMANN_JSON_HEADER" { print $2 }' "$version_file")"
+  current_nemo_prompt_rnnt="$(awk -F= '$1 == "NEMO_PROMPT_RNNT" { print $2 }' "$version_file")"
+  current_python_profiles="$(awk -F= '$1 == "PYTHON_PROFILES" { print $2 }' "$version_file")"
+fi
 
 if [ "$current_trt" != "$expected_trt" ]; then
   echo "ERROR: CI Docker image '$image' has TensorRT '$current_trt'; expected '$expected_trt' from $dockerfile" >&2
@@ -331,8 +369,11 @@ if ! [[ "$image_ref" =~ ^sha256:[0-9a-f]{64}$ ]]; then
   echo "ERROR: CI Docker image '$image' returned an invalid immutable ID: $image_ref" >&2
   exit 1
 fi
-if [ -n "${GITHUB_OUTPUT:-}" ]; then
-  echo "image_ref=$image_ref" >> "$GITHUB_OUTPUT"
+emit_image_ref "$image_ref"
+if [ -n "$verification_stamp" ]; then
+  stamp_tmp="${verification_stamp}.tmp.$$"
+  printf '%s\n' "$image_ref" > "$stamp_tmp"
+  mv -f -- "$stamp_tmp" "$verification_stamp"
 fi
 
 echo "CI Docker image '$image' verified: TensorRT $current_trt, modelopt $current_modelopt, nlohmann/json headers, NeMo prompt RNN-T and prebuilt Python profiles ($current_python_profiles) present, image $image_ref"

--- a/.github/scripts/run-gha-stage.sh
+++ b/.github/scripts/run-gha-stage.sh
@@ -13,6 +13,26 @@ if [ "$(docker inspect -f '{{.State.Running}}' "$container_name" 2>/dev/null || 
   exit 1
 fi
 
+if [ "${TRTMC_CI_HARDENED:-false}" = "true" ]; then
+  docker exec \
+    -w "$GITHUB_WORKSPACE" \
+    -e CI_BASE_REF \
+    -e GITHUB_EVENT_NAME \
+    -e GITHUB_REF_NAME \
+    -e GITHUB_RUN_ID \
+    -e GITHUB_RUN_ATTEMPT \
+    -e PYTHONHASHSEED \
+    -e BUILD_ALL_TIMEOUT \
+    -e CPP_UNIT_TIMEOUT \
+    -e PYTHON_BUILDER_TIMEOUT \
+    -e TRTMC_UNIT_BUILD_JOBS \
+    -e TRTMC_UNIT_TEST_JOBS \
+    -e TRTMC_PREMERGE_UNIT_SCOPE \
+    "$container_name" \
+    bash .github/scripts/run-trtmc-ci.sh "$stage"
+  exit $?
+fi
+
 docker exec \
   -w "$GITHUB_WORKSPACE" \
   -e CI_BASE_REF \
@@ -47,6 +67,9 @@ docker exec \
   -e BUILD_ALL_TIMEOUT \
   -e CPP_UNIT_TIMEOUT \
   -e PYTHON_BUILDER_TIMEOUT \
+  -e TRTMC_UNIT_BUILD_JOBS \
+  -e TRTMC_UNIT_TEST_JOBS \
+  -e TRTMC_PREMERGE_UNIT_SCOPE \
   -e CPP_COVERAGE_TIMEOUT \
   -e CPP_COVERAGE_BUILD_DIR \
   -e GRAPH_OP_TIMEOUT \

--- a/.github/scripts/run-gha-stage.sh
+++ b/.github/scripts/run-gha-stage.sh
@@ -7,6 +7,11 @@ set -euo pipefail
 stage="${1:?usage: run-gha-stage.sh <stage>}"
 
 container_name="${TRTMC_CI_CONTAINER_NAME:-trtmc-ci-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}}"
+workspace="${TRTMC_CI_WORKSPACE:-${GITHUB_WORKSPACE:-}}"
+if [ -z "$workspace" ] || [ ! -d "$workspace" ]; then
+  echo "::error::CI workspace does not exist: ${workspace:-unset}"
+  exit 1
+fi
 
 if [ "$(docker inspect -f '{{.State.Running}}' "$container_name" 2>/dev/null || true)" != "true" ]; then
   echo "::error::CI container '$container_name' is not running. Start it with .github/scripts/start-gha-container.sh before running stages."
@@ -15,7 +20,7 @@ fi
 
 if [ "${TRTMC_CI_HARDENED:-false}" = "true" ]; then
   docker exec \
-    -w "$GITHUB_WORKSPACE" \
+    -w "$workspace" \
     -e CI_BASE_REF \
     -e GITHUB_EVENT_NAME \
     -e GITHUB_REF_NAME \
@@ -34,7 +39,7 @@ if [ "${TRTMC_CI_HARDENED:-false}" = "true" ]; then
 fi
 
 docker exec \
-  -w "$GITHUB_WORKSPACE" \
+  -w "$workspace" \
   -e CI_BASE_REF \
   -e ENGINE_DIR \
   -e TRTMC_STORAGE_ROOT \

--- a/.github/scripts/run-model-proof.sh
+++ b/.github/scripts/run-model-proof.sh
@@ -1957,6 +1957,7 @@ trap - EXIT
   [ "$hf_cache_repository_count" -gt 0 ] || \
     die "selected Hugging Face cache evidence produced no repository copies"
 
+  printf '%s\n' "$resource_class" > "$artifacts_dir/gpu-lease-requested.txt"
   select_proof_gpu "$resource_class"
   local gpu_id="$proof_gpu_id"
   local gpu_slot_ids

--- a/.github/scripts/run-trtmc-ci.sh
+++ b/.github/scripts/run-trtmc-ci.sh
@@ -464,6 +464,109 @@ print('|'.join(tests))
   fi
 }
 
+run_premerge_unit_tests() {
+  verify_environment
+
+  local source_root="$PWD"
+  local scratch_dir="${TRTMC_CI_SCRATCH_DIR:-/tmp}"
+  local build_dir="${TRTMC_PREMERGE_UNIT_BUILD_DIR:-$scratch_dir/premerge-unit-build}"
+  local build_jobs="${TRTMC_UNIT_BUILD_JOBS:-8}"
+  local test_jobs="${TRTMC_UNIT_TEST_JOBS:-8}"
+  local unit_scope="${TRTMC_PREMERGE_UNIT_SCOPE:-all}"
+  local -a python_tests=()
+  local -a native_targets=()
+  local -a ctest_selector=()
+
+  if ! [[ "$build_jobs" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: TRTMC_UNIT_BUILD_JOBS must be a positive integer" >&2
+    return 2
+  fi
+  if ! [[ "$test_jobs" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: TRTMC_UNIT_TEST_JOBS must be a positive integer" >&2
+    return 2
+  fi
+
+  case "$unit_scope" in
+    cli)
+      python_tests=(
+        tests/builder/test_cli.py
+        tests/builder/test_cli_coverage.py
+        tests/builder/test_config_cli_support.py
+        tests/builder/test_config_isolation_demo.py
+        tests/builder/test_max_batch_size_cli.py
+        tests/builder/test_owned_schedulers.py::test_package_main_module_invokes_build_cli_main
+      )
+      native_targets=(trtmc test_cli_args test_config_cli_support)
+      ctest_selector=(-R '^(test_cli_args|test_config_cli_support)$')
+      ;;
+    all)
+      python_tests=(
+        tests/builder/
+        tests/tools/
+        tests/e2e_harness/test_*.py
+      )
+      native_targets=(trtmc trtmc_platform_cpp_tests)
+      ctest_selector=(-L platform)
+      ;;
+    *)
+      echo "ERROR: TRTMC_PREMERGE_UNIT_SCOPE must be cli or all" >&2
+      return 2
+      ;;
+  esac
+  echo "Premerge unit scope: $unit_scope"
+
+  # Run source-only Python tests first so inexpensive contract failures stop
+  # before any native compilation. PYTHONPATH exposes the checkout without an
+  # editable install, network access, or writes outside the checkout.
+  run_with_timeout "${PYTHON_BUILDER_TIMEOUT:-20m}" \
+    env PYTHONPATH="$source_root/python:$source_root${PYTHONPATH:+:$PYTHONPATH}" \
+    python -m pytest "${python_tests[@]}" \
+      -q -x -n "$test_jobs" --dist=worksteal -p no:cacheprovider \
+      -m "not gpu and not trt and not e2e and not model_proof_allocator" \
+      --ignore=tests/builder/test_flashinfer_benchmark.py \
+      --ignore=tests/builder/test_tvm_ffi_plugin.py
+
+  # These tests intentionally launch several simultaneous model projections
+  # and assert tight lease deadlines. Run them after the parallel phase so
+  # unrelated CPU load cannot change the allocator behavior under test.
+  if [ "$unit_scope" = "all" ]; then
+    run_with_timeout "${PYTHON_BUILDER_TIMEOUT:-20m}" \
+      env PYTHONPATH="$source_root/python:$source_root${PYTHONPATH:+:$PYTHONPATH}" \
+      python -m pytest tests/tools/test_model_proof_runner.py \
+        -q -x -p no:cacheprovider -m model_proof_allocator
+  fi
+
+  rm -rf -- "$build_dir"
+  cmake -S "$source_root" -B "$build_dir" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DTRTMC_BUILD_TESTS=ON \
+    -DTRTMC_BUILD_BENCHMARKS=OFF \
+    -DTRTMC_ENABLE_LIBTORCH_MULTINOMIAL=OFF \
+    -DTRTMC_BUILD_DIFFUSION_KERNELS=OFF \
+    -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+  run_with_timeout "${BUILD_ALL_TIMEOUT:-15m}" \
+    cmake --build "$build_dir" --parallel "$build_jobs" \
+      --target "${native_targets[@]}"
+
+  if [ "$unit_scope" = "cli" ]; then
+    run_with_timeout 1m "$build_dir/trtmc" version
+    run_with_timeout 1m "$build_dir/trtmc" --help
+  fi
+
+  local leaked_plugin
+  leaked_plugin="$(
+    find "$build_dir" -type f -name 'libtrtmc_model_*.so*' -print -quit
+  )"
+  if [ -n "$leaked_plugin" ]; then
+    echo "ERROR: source-only unit build produced a model plugin: $leaked_plugin" >&2
+    return 1
+  fi
+
+  run_with_timeout "${CPP_UNIT_TIMEOUT:-20m}" \
+    ctest --test-dir "$build_dir" --output-on-failure --stop-on-failure \
+      "${ctest_selector[@]}" -j "$test_jobs"
+}
+
 write_skipped_python_coverage() {
   local reason="${1:-Skipped}"
   echo '<?xml version="1.0" ?><coverage version="7.6" timestamp="0" lines-valid="0" lines-covered="0" line-rate="1.0" branches-valid="0" branches-covered="0" branch-rate="1.0" complexity="0"><packages/></coverage>' > coverage/python-cobertura.xml
@@ -563,12 +666,10 @@ for test in selected:
     echo "Selective Python tests:"
     printf '  %s\n' "${selected_python_tests[@]}"
     run_with_timeout "${PYTHON_BUILDER_TIMEOUT:-40m}" python -m pytest "${selected_python_tests[@]}" -v \
-      --ignore=tests/builder/test_cli.py \
       -n auto "${cov_args[@]}"
   else
     echo "Running all builder + tools tests"
     run_with_timeout "${PYTHON_BUILDER_TIMEOUT:-40m}" python -m pytest tests/builder/ tests/tools/ tests/e2e_harness/test_*.py -v \
-      --ignore=tests/builder/test_cli.py \
       -n auto "${cov_args[@]}"
   fi
 
@@ -1819,6 +1920,9 @@ run_stage() {
     python-builder)
       run_step "Setup TensorRT-Model-Connect wheel runtime" setup_wheel_runtime_environment
       run_step "Python builder and tools tests" run_python_builder_tests
+      ;;
+    premerge-unit)
+      run_step "Source-only C++ and Python unit tests" run_premerge_unit_tests
       ;;
     cpp-coverage)
       run_step "Setup TensorRT-Model-Connect source checks" setup_source_check_environment

--- a/.github/scripts/start-gha-container.sh
+++ b/.github/scripts/start-gha-container.sh
@@ -17,9 +17,51 @@ docker image inspect "$TRTMC_CI_IMAGE" >/dev/null || {
 
 docker rm -f "$container_name" >/dev/null 2>&1 || true
 
+hardened="${TRTMC_CI_HARDENED:-false}"
 extra_mounts=()
-if [ -d /workspace/users/yifeif ]; then
-  extra_mounts+=(-v /workspace/users/yifeif:/workspace/users/yifeif)
+container_options=()
+workspace_mount="$GITHUB_WORKSPACE:$GITHUB_WORKSPACE"
+if [ "$hardened" = "true" ]; then
+  scratch_parent="$(realpath -m "${RUNNER_TEMP:-/tmp}")"
+  scratch_host_input="${TRTMC_CI_SCRATCH_HOST:-${scratch_parent%/}/trtmc-premerge-unit-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}}"
+  if [ -L "$scratch_host_input" ]; then
+    echo "::error::Hardened unit scratch must not be a symlink: $scratch_host_input"
+    exit 1
+  fi
+  scratch_host="$(realpath -m "$scratch_host_input")"
+  case "$scratch_host" in
+    "$scratch_parent"/*) ;;
+    *)
+      echo "::error::Hardened unit scratch must be inside RUNNER_TEMP: $scratch_host"
+      exit 1
+      ;;
+  esac
+  mkdir -p "$scratch_host/tmp"
+  extra_mounts+=(-v "$scratch_host:/work")
+  workspace_mount+=":ro"
+  container_options+=(
+    --network none
+    --read-only
+    --tmpfs /tmp:rw,exec,nosuid,nodev,size=16g
+    --cap-drop ALL
+    --security-opt no-new-privileges
+    --user "$(id -u):$(id -g)"
+    --ipc private
+    --runtime runc
+    -e HOME=/tmp
+    -e TMPDIR=/work/tmp
+    -e PIP_NO_INDEX=1
+    -e TRTMC_CI_SCRATCH_DIR=/work
+    -e NVIDIA_VISIBLE_DEVICES=void
+    -e CUDA_VISIBLE_DEVICES=
+  )
+else
+  if [ -d /workspace/users/yifeif ]; then
+    extra_mounts+=(-v /workspace/users/yifeif:/workspace/users/yifeif)
+  fi
+  # Preserve the existing trusted nightly-container options. Premerge unit
+  # jobs use the fixed hardened options above instead of repository variables.
+  read -r -a container_options <<< "${TRTMC_CONTAINER_OPTIONS:-}"
 fi
 
 mkdir_if_set() {
@@ -31,14 +73,16 @@ mkdir_if_set() {
   fi
 }
 
-mkdir_if_set "${TRTMC_STORAGE_ROOT:-}"
-mkdir_if_set "${ENGINE_DIR:-}"
-mkdir_if_set "${HF_HOME:-}"
-mkdir_if_set "${HF_HUB_CACHE:-}"
-mkdir_if_set "${HUGGINGFACE_HUB_CACHE:-}"
-mkdir_if_set "${HF_MODULES_CACHE:-}"
+if [ "$hardened" != "true" ]; then
+  mkdir_if_set "${TRTMC_STORAGE_ROOT:-}"
+  mkdir_if_set "${ENGINE_DIR:-}"
+  mkdir_if_set "${HF_HOME:-}"
+  mkdir_if_set "${HF_HUB_CACHE:-}"
+  mkdir_if_set "${HUGGINGFACE_HUB_CACHE:-}"
+  mkdir_if_set "${HF_MODULES_CACHE:-}"
+fi
 
-if [ -n "${GITHUB_WORKSPACE:-}" ] && [ -d "$GITHUB_WORKSPACE" ]; then
+if [ "$hardened" != "true" ] && [ -n "${GITHUB_WORKSPACE:-}" ] && [ -d "$GITHUB_WORKSPACE" ]; then
   chmod -R a+rwX "$GITHUB_WORKSPACE" 2>/dev/null || {
     echo "::warning::Could not normalize workspace permissions before entering the CI container."
   }
@@ -47,6 +91,14 @@ fi
 env_args=()
 add_env() {
   local name="$1"
+  if [ "$hardened" = "true" ]; then
+    case "$name" in
+      CI_BASE_REF | GITHUB_EVENT_NAME | GITHUB_REF_NAME | GITHUB_RUN_ID | GITHUB_RUN_ATTEMPT | \
+        PYTHONHASHSEED | BUILD_ALL_TIMEOUT | CPP_UNIT_TIMEOUT | PYTHON_BUILDER_TIMEOUT | \
+        TRTMC_UNIT_BUILD_JOBS | TRTMC_UNIT_TEST_JOBS | TRTMC_PREMERGE_UNIT_SCOPE) ;;
+      *) return ;;
+    esac
+  fi
   env_args+=(-e "${name}=${!name-}")
 }
 
@@ -83,6 +135,9 @@ for name in \
   BUILD_ALL_TIMEOUT \
   CPP_UNIT_TIMEOUT \
   PYTHON_BUILDER_TIMEOUT \
+  TRTMC_UNIT_BUILD_JOBS \
+  TRTMC_UNIT_TEST_JOBS \
+  TRTMC_PREMERGE_UNIT_SCOPE \
   CPP_COVERAGE_TIMEOUT \
   CPP_COVERAGE_BUILD_DIR \
   GRAPH_OP_TIMEOUT \
@@ -110,15 +165,21 @@ for name in \
   add_env "$name"
 done
 
-# shellcheck disable=SC2086
 docker run -d \
   --name "$container_name" \
-  $TRTMC_CONTAINER_OPTIONS \
+  "${container_options[@]}" \
   "${extra_mounts[@]}" \
-  -v "$GITHUB_WORKSPACE:$GITHUB_WORKSPACE" \
+  -v "$workspace_mount" \
   -w "$GITHUB_WORKSPACE" \
   "${env_args[@]}" \
   "$TRTMC_CI_IMAGE" \
   bash -lc 'trap "exit 0" TERM INT; sleep infinity & wait'
+
+if [ "$hardened" = "true" ] && \
+   docker exec "$container_name" bash -lc 'compgen -G "/dev/nvidia*" >/dev/null'; then
+  echo "::error::Hardened unit container unexpectedly exposes NVIDIA devices."
+  docker rm -f "$container_name" >/dev/null 2>&1 || true
+  exit 1
+fi
 
 echo "Started CI container: $container_name"

--- a/.github/scripts/start-gha-container.sh
+++ b/.github/scripts/start-gha-container.sh
@@ -5,6 +5,11 @@
 set -euo pipefail
 
 container_name="${TRTMC_CI_CONTAINER_NAME:-trtmc-ci-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}}"
+workspace="${TRTMC_CI_WORKSPACE:-${GITHUB_WORKSPACE:-}}"
+if [ -z "$workspace" ] || [ ! -d "$workspace" ]; then
+  echo "::error::CI workspace does not exist: ${workspace:-unset}"
+  exit 1
+fi
 
 if [ -n "${GITHUB_ENV:-}" ]; then
   echo "TRTMC_CI_CONTAINER_NAME=${container_name}" >> "$GITHUB_ENV"
@@ -20,7 +25,7 @@ docker rm -f "$container_name" >/dev/null 2>&1 || true
 hardened="${TRTMC_CI_HARDENED:-false}"
 extra_mounts=()
 container_options=()
-workspace_mount="$GITHUB_WORKSPACE:$GITHUB_WORKSPACE"
+workspace_mount="$workspace:$workspace"
 if [ "$hardened" = "true" ]; then
   scratch_parent="$(realpath -m "${RUNNER_TEMP:-/tmp}")"
   scratch_host_input="${TRTMC_CI_SCRATCH_HOST:-${scratch_parent%/}/trtmc-premerge-unit-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}}"
@@ -82,8 +87,8 @@ if [ "$hardened" != "true" ]; then
   mkdir_if_set "${HF_MODULES_CACHE:-}"
 fi
 
-if [ "$hardened" != "true" ] && [ -n "${GITHUB_WORKSPACE:-}" ] && [ -d "$GITHUB_WORKSPACE" ]; then
-  chmod -R a+rwX "$GITHUB_WORKSPACE" 2>/dev/null || {
+if [ "$hardened" != "true" ]; then
+  chmod -R a+rwX "$workspace" 2>/dev/null || {
     echo "::warning::Could not normalize workspace permissions before entering the CI container."
   }
 fi
@@ -170,7 +175,7 @@ docker run -d \
   "${container_options[@]}" \
   "${extra_mounts[@]}" \
   -v "$workspace_mount" \
-  -w "$GITHUB_WORKSPACE" \
+  -w "$workspace" \
   "${env_args[@]}" \
   "$TRTMC_CI_IMAGE" \
   bash -lc 'trap "exit 0" TERM INT; sleep infinity & wait'

--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -141,6 +141,8 @@ jobs:
       affected_models: ${{ steps.impact.outputs.affected_models }}
       expected_count: ${{ steps.impact.outputs.expected_count }}
       mode: ${{ steps.impact.outputs.mode }}
+      run_unit_tests: ${{ steps.impact.outputs.run_unit_tests }}
+      unit_scope: ${{ steps.impact.outputs.unit_scope }}
 
     steps:
       - name: Check out pinned merge snapshot
@@ -184,30 +186,118 @@ jobs:
           python3 tools/model_ci.py impact \
             --base "$BASE_SHA" \
             --head "$TESTED_SHA" \
-            --platform-change-policy all \
+            --platform-change-policy fallback \
+            --fallback-model deepseek_v2 \
+            --fallback-model patchtsmixer \
+            --fallback-model segformer \
+            --fallback-model whisper \
+            --fallback-model ltx_video \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Summarize selection
         env:
           AFFECTED_MODELS: ${{ steps.impact.outputs.affected_models }}
           MODE: ${{ steps.impact.outputs.mode }}
+          RUN_UNIT_TESTS: ${{ steps.impact.outputs.run_unit_tests }}
+          UNIT_SCOPE: ${{ steps.impact.outputs.unit_scope }}
         run: |
           {
             echo "### Model impact"
             echo
             echo "- Mode: \`$MODE\`"
             echo "- Models: \`$AFFECTED_MODELS\`"
+            echo "- Run source-only units: \`$RUN_UNIT_TESTS\`"
+            echo "- Unit scope: \`$UNIT_SCOPE\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  model-proof:
-    name: 3 / Model / ${{ matrix.model }}
+  unit-tests:
+    name: 3 / Unit / C++ and Python
     needs:
       - legal
       - impact
     if: >-
       ${{
         needs.legal.outputs.authorized == 'true' &&
-        needs.impact.outputs.has_models == 'true'
+        needs.impact.outputs.run_unit_tests == 'true'
+      }}
+    runs-on: ${{ fromJSON(vars.TRTMC_RUNNER_LABELS || '["self-hosted"]') }}
+    timeout-minutes: 180
+    permissions:
+      contents: read
+      packages: read
+    env:
+      CI_BASE_REF: ${{ needs.legal.outputs.base_sha }}
+      TRTMC_CI_IMAGE: ${{ vars.TRTMC_MANYLINUX_CI_IMAGE || 'trtmc-dev-gb300:manylinux_2_39' }}
+      TRTMC_CI_CONTAINER_NAME: trtmc-premerge-unit-${{ github.run_id }}-${{ github.run_attempt }}
+      TRTMC_CI_HARDENED: "true"
+      TRTMC_UNIT_BUILD_JOBS: ${{ vars.TRTMC_UNIT_BUILD_JOBS || '8' }}
+      TRTMC_UNIT_TEST_JOBS: ${{ vars.TRTMC_UNIT_TEST_JOBS || '8' }}
+      TRTMC_PREMERGE_UNIT_SCOPE: ${{ needs.impact.outputs.unit_scope }}
+      PYTHONHASHSEED: "0"
+
+    steps:
+      - name: Check out pinned merge snapshot
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.legal.outputs.tested_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+          lfs: false
+
+      - name: Log in to GitHub Container Registry
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          docker_config="${RUNNER_TEMP}/trtmc-docker-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-unit"
+          mkdir -p "$docker_config"
+          echo "DOCKER_CONFIG=$docker_config" >> "$GITHUB_ENV"
+          printf '%s' "$GHCR_TOKEN" | DOCKER_CONFIG="$docker_config" docker login ghcr.io \
+            --username "$GITHUB_ACTOR" --password-stdin
+
+      - name: Ensure CI Docker image
+        id: ci_image
+        timeout-minutes: 90
+        run: bash .github/scripts/ensure-ci-docker-image.sh
+
+      - name: Start clean unit-test container
+        timeout-minutes: 5
+        env:
+          TRTMC_CI_IMAGE: ${{ steps.ci_image.outputs.image_ref }}
+        run: bash .github/scripts/start-gha-container.sh
+
+      - name: Run source-only unit tests
+        timeout-minutes: 60
+        run: bash .github/scripts/run-gha-stage.sh premerge-unit
+
+      - name: Clean unit-test container
+        if: ${{ always() }}
+        run: |
+          docker rm -f "$TRTMC_CI_CONTAINER_NAME" >/dev/null 2>&1 || true
+          unit_scratch="${RUNNER_TEMP}/trtmc-premerge-unit-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf -- "$unit_scratch"
+          if [ -n "${DOCKER_CONFIG:-}" ]; then
+            rm -rf "$DOCKER_CONFIG"
+          fi
+
+  model-proof:
+    name: 4 / Model / ${{ matrix.model }}
+    needs:
+      - legal
+      - impact
+      - unit-tests
+    if: >-
+      ${{
+        always() &&
+        needs.legal.outputs.authorized == 'true' &&
+        needs.impact.outputs.has_models == 'true' &&
+        (
+          (needs.impact.outputs.run_unit_tests == 'true' &&
+           needs.unit-tests.result == 'success') ||
+          (needs.impact.outputs.run_unit_tests == 'false' &&
+           needs.unit-tests.result == 'skipped')
+        )
       }}
     strategy:
       fail-fast: true
@@ -224,14 +314,22 @@ jobs:
     secrets: inherit
 
   no-model:
-    name: 3 / No model changes
+    name: 4 / No model changes
     needs:
       - legal
       - impact
+      - unit-tests
     if: >-
       ${{
+        always() &&
         needs.legal.outputs.authorized == 'true' &&
-        needs.impact.outputs.has_models == 'false'
+        needs.impact.outputs.has_models == 'false' &&
+        (
+          (needs.impact.outputs.run_unit_tests == 'true' &&
+           needs.unit-tests.result == 'success') ||
+          (needs.impact.outputs.run_unit_tests == 'false' &&
+           needs.unit-tests.result == 'skipped')
+        )
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -242,14 +340,18 @@ jobs:
           IMPACT_MODE: ${{ needs.impact.outputs.mode }}
         run: |
           set -euo pipefail
-          test "$IMPACT_MODE" = "none"
-          echo "No model-owned or platform inputs changed." >> "$GITHUB_STEP_SUMMARY"
+          case "$IMPACT_MODE" in
+            none) echo "No model-owned, platform, or unit inputs changed." ;;
+            unit) echo "Unit tests cover this change; no model proof is required." ;;
+            *) echo "Unexpected zero-model impact mode: $IMPACT_MODE" >&2; exit 1 ;;
+          esac >> "$GITHUB_STEP_SUMMARY"
 
   report:
-    name: 4 / Combined HTML report
+    name: 5 / Combined HTML report
     needs:
       - legal
       - impact
+      - unit-tests
       - model-proof
       - no-model
     if: >-
@@ -272,6 +374,8 @@ jobs:
           HAS_MODELS: ${{ needs.impact.outputs.has_models }}
           LEGAL_RESULT: ${{ needs.legal.result }}
           IMPACT_RESULT: ${{ needs.impact.result }}
+          UNIT_RESULT: ${{ needs.unit-tests.result }}
+          RUN_UNIT_TESTS: ${{ needs.impact.outputs.run_unit_tests }}
           MODEL_RESULT: ${{ needs.model-proof.result }}
           NO_MODEL_RESULT: ${{ needs.no-model.result }}
           REPORT_OUTPUT_DIR: ${{ runner.temp }}/model-proof-report-${{ github.run_id }}-${{ github.run_attempt }}
@@ -284,6 +388,7 @@ jobs:
           python3 - \
             "$REPORT_OUTPUT_DIR" "$EXPECTED_MODELS" "$REVISION" "$SUITE" \
             "$HAS_MODELS" "$LEGAL_RESULT" "$IMPACT_RESULT" \
+            "$RUN_UNIT_TESTS" "$UNIT_RESULT" \
             "$MODEL_RESULT" "$NO_MODEL_RESULT" <<'PY'
           import html
           import json
@@ -298,6 +403,8 @@ jobs:
               has_models,
               legal_result,
               impact_result,
+              run_unit_tests,
+              unit_result,
               model_result,
               no_model_result,
           ) = sys.argv[1:]
@@ -313,6 +420,8 @@ jobs:
               "legal": legal_result,
               "impact": impact_result,
           }
+          if run_unit_tests == "true":
+              upstream_results["unit-tests"] = unit_result
           if has_models == "true":
               upstream_results["model-proof"] = model_result
           elif has_models == "false":
@@ -391,6 +500,8 @@ jobs:
           HAS_MODELS: ${{ needs.impact.outputs.has_models }}
           LEGAL_RESULT: ${{ needs.legal.result }}
           IMPACT_RESULT: ${{ needs.impact.result }}
+          UNIT_RESULT: ${{ needs.unit-tests.result }}
+          RUN_UNIT_TESTS: ${{ needs.impact.outputs.run_unit_tests }}
           MODEL_RESULT: ${{ needs.model-proof.result }}
           NO_MODEL_RESULT: ${{ needs.no-model.result }}
         run: |
@@ -406,6 +517,9 @@ jobs:
               --upstream-result "legal=$LEGAL_RESULT"
               --upstream-result "impact=$IMPACT_RESULT"
             )
+            if [ "$RUN_UNIT_TESTS" = "true" ]; then
+              upstream_args+=(--upstream-result "unit-tests=$UNIT_RESULT")
+            fi
             case "$HAS_MODELS" in
               true) upstream_args+=(--upstream-result "model-proof=$MODEL_RESULT") ;;
               false) upstream_args+=(--upstream-result "no-model=$NO_MODEL_RESULT") ;;
@@ -495,6 +609,7 @@ jobs:
     needs:
       - legal
       - impact
+      - unit-tests
       - model-proof
       - no-model
       - report
@@ -510,6 +625,8 @@ jobs:
           TESTED_SHA: ${{ needs.legal.outputs.tested_sha }}
           LEGAL_RESULT: ${{ needs.legal.result }}
           IMPACT_RESULT: ${{ needs.impact.result }}
+          UNIT_RESULT: ${{ needs.unit-tests.result }}
+          RUN_UNIT_TESTS: ${{ needs.impact.outputs.run_unit_tests }}
           MODEL_RESULT: ${{ needs.model-proof.result }}
           NO_MODEL_RESULT: ${{ needs.no-model.result }}
           REPORT_RESULT: ${{ needs.report.result }}
@@ -537,6 +654,24 @@ jobs:
             echo "::error::Ownership and impact result: $IMPACT_RESULT"
             exit 1
           }
+          case "$RUN_UNIT_TESTS" in
+            true)
+              test "$UNIT_RESULT" = "success" || {
+                echo "::error::Source-only unit test result: $UNIT_RESULT"
+                exit 1
+              }
+              ;;
+            false)
+              test "$UNIT_RESULT" = "skipped" || {
+                echo "::error::Unit tests ran unexpectedly: $UNIT_RESULT"
+                exit 1
+              }
+              ;;
+            *)
+              echo "::error::Invalid run_unit_tests output: $RUN_UNIT_TESTS"
+              exit 1
+              ;;
+          esac
           test "$REPORT_RESULT" = "success" || {
             echo "::error::Combined HTML report result: $REPORT_RESULT"
             exit 1

--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -229,6 +229,7 @@ jobs:
       CI_BASE_REF: ${{ needs.legal.outputs.base_sha }}
       TRTMC_CI_IMAGE: ${{ vars.TRTMC_MANYLINUX_CI_IMAGE || 'trtmc-dev-gb300:manylinux_2_39' }}
       TRTMC_CI_CONTAINER_NAME: trtmc-premerge-unit-${{ github.run_id }}-${{ github.run_attempt }}
+      TRTMC_CI_WORKSPACE: ${{ github.workspace }}/premerge-unit-checkout
       TRTMC_CI_HARDENED: "true"
       TRTMC_UNIT_BUILD_JOBS: ${{ vars.TRTMC_UNIT_BUILD_JOBS || '8' }}
       TRTMC_UNIT_TEST_JOBS: ${{ vars.TRTMC_UNIT_TEST_JOBS || '8' }}
@@ -240,6 +241,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.legal.outputs.tested_sha }}
+          path: premerge-unit-checkout
           fetch-depth: 0
           persist-credentials: false
           clean: true
@@ -259,16 +261,19 @@ jobs:
       - name: Ensure CI Docker image
         id: ci_image
         timeout-minutes: 90
+        working-directory: ${{ env.TRTMC_CI_WORKSPACE }}
         run: bash .github/scripts/ensure-ci-docker-image.sh
 
       - name: Start clean unit-test container
         timeout-minutes: 5
+        working-directory: ${{ env.TRTMC_CI_WORKSPACE }}
         env:
           TRTMC_CI_IMAGE: ${{ steps.ci_image.outputs.image_ref }}
         run: bash .github/scripts/start-gha-container.sh
 
       - name: Run source-only unit tests
         timeout-minutes: 60
+        working-directory: ${{ env.TRTMC_CI_WORKSPACE }}
         run: bash .github/scripts/run-gha-stage.sh premerge-unit
 
       - name: Clean unit-test container

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -619,13 +619,22 @@ endif()
 if(TRTMC_BUILD_TESTS)
 enable_testing()
 add_custom_target(trtmc_cpp_tests)
+add_custom_target(trtmc_platform_cpp_tests)
 
 # --- Test helper function ---
 # Usage:
 #   trtmc_add_test(test_name)               -- links trtmc_core, adds src/ include
 #   trtmc_add_test(test_name REQUIRES_TRT)  -- also links TensorRT test deps
+#   trtmc_add_test(test_name MODEL_OWNED)    -- excludes it from platform units
+#   trtmc_add_test(test_name REQUIRES_GPU)   -- excludes it from CPU platform units
 function(trtmc_add_test TEST_NAME)
-  cmake_parse_arguments(ARG "NO_SRC_INCLUDE;REQUIRES_TRT" "SOURCE" "EXTRA_INCLUDES" ${ARGN})
+  cmake_parse_arguments(
+    ARG
+    "NO_SRC_INCLUDE;REQUIRES_TRT;REQUIRES_GPU;MODEL_OWNED"
+    "SOURCE"
+    "EXTRA_INCLUDES"
+    ${ARGN}
+  )
   if(ARG_REQUIRES_TRT AND NOT _trtmc_can_build_trt_backend)
     message(STATUS "Skipping ${TEST_NAME}: TensorRT SDK not available")
     return()
@@ -661,6 +670,14 @@ function(trtmc_add_test TEST_NAME)
     target_compile_definitions(${TEST_NAME} PRIVATE TRTMC_HAS_TRT=0)
   endif()
   add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+  if(ARG_MODEL_OWNED)
+    set_tests_properties(${TEST_NAME} PROPERTIES LABELS "model")
+  elseif(ARG_REQUIRES_GPU)
+    set_tests_properties(${TEST_NAME} PROPERTIES LABELS "gpu")
+  else()
+    add_dependencies(trtmc_platform_cpp_tests ${TEST_NAME})
+    set_tests_properties(${TEST_NAME} PROPERTIES LABELS "platform")
+  endif()
 endfunction()
 
 function(_trtmc_manifest_csv_to_list VALUE OUTPUT_VAR)
@@ -693,6 +710,7 @@ function(trtmc_add_model_manifest_tests)
       trtmc_add_test(
         ${_trtmc_test_name}
         SOURCE "tests/cpp/models/${_trtmc_model}/${_trtmc_test_source}"
+        MODEL_OWNED
         ${_trtmc_test_options}
       )
       if(NOT TARGET ${_trtmc_test_name})
@@ -722,14 +740,16 @@ trtmc_add_test(test_bundle_format)
 trtmc_add_test(test_bundle_e2e          NO_SRC_INCLUDE)
 trtmc_add_test(test_bundle_view)
 trtmc_add_test(test_pipeline_registry)
-trtmc_add_test(test_model_plugin_loader)
+trtmc_add_test(test_model_plugin_loader MODEL_OWNED)
 add_dependencies(test_model_plugin_loader trtmc_model_plugins)
 trtmc_add_test(test_backend_loader)
 trtmc_add_test(test_trt_version)
 
 # C ABI
 trtmc_add_test(test_c_abi_entry                NO_SRC_INCLUDE)
-trtmc_add_test(test_c_abi_runtime_regression   NO_SRC_INCLUDE)
+# This regression drives the qwen runtime strategy and therefore requires a
+# real model plugin even though its source lives beside the shared C ABI tests.
+trtmc_add_test(test_c_abi_runtime_regression   NO_SRC_INCLUDE MODEL_OWNED)
 trtmc_add_test(test_cabi_batch                 NO_SRC_INCLUDE)
 
 # Config / parsing
@@ -747,23 +767,23 @@ trtmc_add_test(test_trt_logger REQUIRES_TRT)
 if(TARGET trtmc_backend_trt)
   target_link_libraries(test_trt_logger PRIVATE trtmc_backend_trt)
 endif()
-trtmc_add_test(test_trt_runtime_lifetime REQUIRES_TRT)
+trtmc_add_test(test_trt_runtime_lifetime REQUIRES_TRT REQUIRES_GPU)
 if(TARGET trtmc_backend_trt)
   target_link_libraries(test_trt_runtime_lifetime PRIVATE trtmc_backend_trt)
 endif()
-trtmc_add_test(test_trt_module REQUIRES_TRT)
+trtmc_add_test(test_trt_module REQUIRES_TRT REQUIRES_GPU)
 if(TARGET trtmc_backend_trt)
   target_link_libraries(test_trt_module PRIVATE trtmc_backend_trt)
 endif()
 
 # CUDA / device
-trtmc_add_test(test_cuda_buffer REQUIRES_TRT)
-trtmc_add_test(test_cuda_stream REQUIRES_TRT)
-trtmc_add_test(test_cuda_graph REQUIRES_TRT)
+trtmc_add_test(test_cuda_buffer REQUIRES_TRT REQUIRES_GPU)
+trtmc_add_test(test_cuda_stream REQUIRES_TRT REQUIRES_GPU)
+trtmc_add_test(test_cuda_graph REQUIRES_TRT REQUIRES_GPU)
 if(TARGET trtmc_backend_trt)
   target_link_libraries(test_cuda_graph PRIVATE trtmc_backend_trt)
 endif()
-trtmc_add_test(test_device_tensor)
+trtmc_add_test(test_device_tensor REQUIRES_GPU)
 
 # Pipelines (public API)
 trtmc_add_test(test_pipeline_api                NO_SRC_INCLUDE)
@@ -798,17 +818,17 @@ trtmc_add_test(test_io_map)
 trtmc_add_test(test_decoder_config)
 
 # TVM-FFI plugin
-trtmc_add_test(test_tvm_ffi_plugin REQUIRES_TRT)
+trtmc_add_test(test_tvm_ffi_plugin REQUIRES_TRT REQUIRES_GPU)
 if(TARGET test_tvm_ffi_plugin AND _trtmc_has_tvm_ffi)
   target_include_directories(test_tvm_ffi_plugin SYSTEM PRIVATE ${TRTMC_TVM_FFI_INCLUDE_DIR})
   target_link_libraries(test_tvm_ffi_plugin PRIVATE ${TRTMC_TVM_FFI_LIBRARY})
 endif()
 
 # TVM-FFI plugin V2 (self-contained test with IPluginV2DynamicExt)
-trtmc_add_test(test_tvm_ffi_plugin_v2 NO_SRC_INCLUDE REQUIRES_TRT)
+trtmc_add_test(test_tvm_ffi_plugin_v2 NO_SRC_INCLUDE REQUIRES_TRT REQUIRES_GPU)
 
-# TVM-FFI module loader (loads FlashInfer .so from C++)
-trtmc_add_test(test_tvm_ffi_module_loader REQUIRES_TRT)
+# TVM-FFI module loader (loads a CUDA FlashInfer .so when configured)
+trtmc_add_test(test_tvm_ffi_module_loader REQUIRES_TRT REQUIRES_GPU)
 if(TARGET test_tvm_ffi_module_loader AND _trtmc_has_tvm_ffi)
   target_include_directories(test_tvm_ffi_module_loader SYSTEM PRIVATE ${TRTMC_TVM_FFI_INCLUDE_DIR})
   target_link_libraries(test_tvm_ffi_module_loader PRIVATE ${TRTMC_TVM_FFI_LIBRARY})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ markers = [
     "e2e: end-to-end tests requiring GPU and engine bundles",
     "unit: Unit tests — no GPU, no TRT",
     "gpu: Requires NVIDIA GPU",
+    "model_proof_allocator: resource-sensitive model-proof lease concurrency tests",
     "slow: Slow tests (>30s)",
     "text: Text generation models",
     "vision: Vision/VL models",

--- a/tests/builder/conftest.py
+++ b/tests/builder/conftest.py
@@ -66,11 +66,12 @@ def _trt_available() -> bool:
     try:
         import tensorrt as trt  # noqa: F401
         try:
-            from cuda.bindings import runtime as cudart  # noqa: F401
+            from cuda.bindings import runtime as cudart
         except ImportError:
-            from cuda import cudart  # type: ignore[no-redef]  # noqa: F401
-        return True
-    except ImportError:
+            from cuda import cudart  # type: ignore[no-redef]
+        status, count = cudart.cudaGetDeviceCount()
+        return int(status) == 0 and int(count) > 0
+    except (ImportError, RuntimeError):
         return False
 
 

--- a/tests/builder/test_ffi_architecture.py
+++ b/tests/builder/test_ffi_architecture.py
@@ -181,6 +181,8 @@ class TestFlashInferKernelSetup:
     """Verify kernels/flashinfer_decode.setup() works correctly."""
 
     @requires_flashinfer
+    @pytest.mark.gpu
+    @pytest.mark.trt
     def test_setup_returns_valid_kernel_name_and_so_path(self):
         """setup() returns (kernel_name, so_path) with valid .so file."""
         from tensorrt_model_connect.kernels import flashinfer_decode
@@ -192,6 +194,8 @@ class TestFlashInferKernelSetup:
         assert Path(so_path).stat().st_size > 0
 
     @requires_flashinfer
+    @pytest.mark.gpu
+    @pytest.mark.trt
     def test_setup_registers_tvm_ffi_global(self):
         """setup() registers the kernel as a TVM-FFI global function."""
         import tvm_ffi
@@ -202,6 +206,8 @@ class TestFlashInferKernelSetup:
         assert func is not None
 
     @requires_flashinfer
+    @pytest.mark.gpu
+    @pytest.mark.trt
     def test_setup_different_head_dims(self):
         """setup() works for different head dimensions."""
         from tensorrt_model_connect.kernels import flashinfer_decode

--- a/tests/tools/test_e2e_python_profiles.py
+++ b/tests/tools/test_e2e_python_profiles.py
@@ -83,6 +83,7 @@ def test_resolve_case_python_profiles_uses_manifest_profile_named_env(monkeypatc
 def test_resolve_profile_python_materializes_declared_venv(monkeypatch, tmp_path):
     requirements = tmp_path / "empty.lock.txt"
     requirements.write_text("", encoding="utf-8")
+    monkeypatch.delenv(shared_profiles.PREBUILT_ONLY_ENV, raising=False)
     monkeypatch.setenv("TRTMC_PYTHON_PROFILE_ROOT", str(tmp_path / "profiles"))
     monkeypatch.setattr(
         shared_profiles,

--- a/tests/tools/test_ensure_ci_docker_image.py
+++ b/tests/tools/test_ensure_ci_docker_image.py
@@ -109,6 +109,8 @@ def _run_ensure_script(
     rebuilt_profiles: str = DEFAULT_PROFILES,
     changed_paths: tuple[str, ...] = (),
     repo_root: Path = REPO_ROOT,
+    run_id: str = "",
+    verification_dir: Path | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], str, str]:
     bin_dir, log_path = _write_fake_docker(tmp_path, existing_images)
     if changed_paths:
@@ -145,8 +147,12 @@ exit 2
             "TRTMC_CI_IMAGE": "trtmc-dev-gb300:manylinux_2_39",
             "CI_BASE_REF": "fake-base" if changed_paths else "",
             "FAKE_GIT_CHANGED_PATHS": "\n".join(changed_paths),
+            "GITHUB_RUN_ID": run_id,
+            "GITHUB_RUN_ATTEMPT": "1",
         }
     )
+    if verification_dir is not None:
+        env["TRTMC_CI_IMAGE_VERIFICATION_DIR"] = str(verification_dir)
     script = repo_root / SCRIPT.relative_to(REPO_ROOT)
     result = subprocess.run(
         ["bash", str(script)],
@@ -200,7 +206,7 @@ default_execution_profiles = ["reference|demo"]
     (demo_root / "verify.py").write_text("import demo_package\n", encoding="utf-8")
 
     (repo_root / "Dockerfile").write_text(
-        "ARG TENSORRT_VERSION=11.0.0.114\nARG MODELOPT_VERSION=0.44.0\n",
+        "ARG TENSORRT_VERSION=11.2.0.113\nARG MODELOPT_VERSION=0.44.0\n",
         encoding="utf-8",
     )
     return repo_root, manifest, requirements
@@ -291,6 +297,33 @@ def test_matching_fingerprint_image_is_reused_for_pr_rerun(tmp_path: Path) -> No
     assert result.returncode == 0, result.stderr
     assert "build " not in docker_log
     assert f"CI Docker image '{resolved_image}' already matches" in result.stdout
+
+
+def test_matching_image_is_fully_validated_once_per_workflow_run(tmp_path: Path) -> None:
+    verification_dir = tmp_path / "verification"
+    bootstrap_result, bootstrap_env, bootstrap_log = _run_ensure_script(
+        tmp_path / "bootstrap",
+        existing_images={},
+        run_id="12345",
+        verification_dir=verification_dir,
+    )
+    assert bootstrap_result.returncode == 0, bootstrap_result.stderr
+    resolved_image = re.search(r"^TRTMC_CI_IMAGE=(.+)$", bootstrap_env, re.MULTILINE).group(1)
+    fingerprint = re.search(
+        r"--label org\.nvidia\.trtmc\.ci-input-fingerprint=([0-9a-f]{64})",
+        bootstrap_log,
+    ).group(1)
+
+    result, _, docker_log = _run_ensure_script(
+        tmp_path / "sibling",
+        existing_images={resolved_image: fingerprint},
+        run_id="12345",
+        verification_dir=verification_dir,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert " run " not in f" {docker_log} "
+    assert "reused from this workflow run's verified image" in result.stdout
 
 
 def test_missing_prebuilt_profiles_rebuilds_the_image(tmp_path: Path) -> None:

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -112,6 +112,18 @@ def test_github_stage_wrapper_exports_e2e_gpu_controls() -> None:
     assert "-e TRTMC_E2E_DEPRIORITIZE_GPU0" in text
 
 
+def test_github_stage_wrapper_exports_premerge_unit_parallelism() -> None:
+    stage = (REPO_ROOT / ".github" / "scripts" / "run-gha-stage.sh").read_text()
+    start = (REPO_ROOT / ".github" / "scripts" / "start-gha-container.sh").read_text()
+    for name in (
+        "TRTMC_UNIT_BUILD_JOBS",
+        "TRTMC_UNIT_TEST_JOBS",
+        "TRTMC_PREMERGE_UNIT_SCOPE",
+    ):
+        assert f"-e {name}" in stage
+        assert name in start
+
+
 def test_github_stage_wrapper_exports_diffusion_vlm_config() -> None:
     text = (REPO_ROOT / ".github" / "scripts" / "run-gha-stage.sh").read_text()
     start_text = (REPO_ROOT / ".github" / "scripts" / "start-gha-container.sh").read_text()
@@ -186,6 +198,7 @@ def test_diffusion_vlm_shared_ci_has_no_model_owned_default() -> None:
 def test_full_python_builder_runs_e2e_harness_unit_tests() -> None:
     text = (REPO_ROOT / ".github" / "scripts" / "run-trtmc-ci.sh").read_text()
     assert "tests/e2e_harness/test_*.py" in text
+    assert "--ignore=tests/builder/test_cli.py" not in text
 
 
 def test_selective_python_always_runs_static_ci_smoke_tests() -> None:
@@ -266,7 +279,7 @@ def test_github_workflows_publish_html_reports_for_nightly_and_model_proof() -> 
 
     premerge = (REPO_ROOT / ".github/workflows/trtmc-ci.yml").read_text()
     assert "model-proof.yml" in premerge
-    assert "4 / Combined HTML report" in premerge
+    assert "5 / Combined HTML report" in premerge
     assert "Download isolated model proof artifacts" in premerge
     assert "merge-multiple: false" in premerge
     assert (
@@ -346,7 +359,7 @@ def test_legal_job_pins_snapshot_rejects_forks_and_consumes_run_ci() -> None:
 def test_unrelated_label_cannot_emit_or_satisfy_required_contexts() -> None:
     text = (REPO_ROOT / ".github/workflows/trtmc-ci.yml").read_text()
     legal = text.split("\n  legal:", maxsplit=1)[1].split("\n  impact:", maxsplit=1)[0]
-    impact = text.split("\n  impact:", maxsplit=1)[1].split("\n  model-proof:", maxsplit=1)[0]
+    impact = text.split("\n  impact:", maxsplit=1)[1].split("\n  unit-tests:", maxsplit=1)[0]
     required = text.split("\n  required:", maxsplit=1)[1]
 
     # Both ruleset contexts exist only on the run-ci event. Unrelated labels
@@ -374,7 +387,10 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     text = (REPO_ROOT / ".github/workflows/trtmc-ci.yml").read_text()
 
     legal = text.split("\n  legal:", maxsplit=1)[1].split("\n  impact:", maxsplit=1)[0]
-    impact = text.split("\n  impact:", maxsplit=1)[1].split("\n  model-proof:", maxsplit=1)[0]
+    impact = text.split("\n  impact:", maxsplit=1)[1].split("\n  unit-tests:", maxsplit=1)[0]
+    unit_tests = text.split("\n  unit-tests:", maxsplit=1)[1].split(
+        "\n  model-proof:", maxsplit=1
+    )[0]
     model_proof = text.split("\n  model-proof:", maxsplit=1)[1].split("\n  no-model:", maxsplit=1)[
         0
     ]
@@ -388,16 +404,45 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     assert "needs.legal.outputs.authorized == 'true'" in impact
     assert "python3 tools/model_ci.py validate" in impact
     assert "python3 tools/model_ci.py impact" in impact
-    assert "--platform-change-policy all" in impact
+    assert "--platform-change-policy fallback" in impact
+    assert "--platform-change-policy all" not in impact
+    assert impact.count("--fallback-model ") == 5
+    for model in ("deepseek_v2", "patchtsmixer", "segformer", "whisper", "ltx_video"):
+        assert f"--fallback-model {model}" in impact
     assert "matrix: ${{ steps.impact.outputs.matrix }}" in impact
+    assert "run_unit_tests: ${{ steps.impact.outputs.run_unit_tests }}" in impact
+    assert "unit_scope: ${{ steps.impact.outputs.unit_scope }}" in impact
+
+    assert "name: 3 / Unit / C++ and Python" in unit_tests
+    assert "needs.impact.outputs.run_unit_tests == 'true'" in unit_tests
+    assert "Start clean unit-test container" in unit_tests
+    assert "run-gha-stage.sh premerge-unit" in unit_tests
+    assert "TRTMC_PREMERGE_UNIT_SCOPE: ${{ needs.impact.outputs.unit_scope }}" in unit_tests
+    assert 'TRTMC_CI_HARDENED: "true"' in unit_tests
+    assert "TRTMC_CONTAINER_OPTIONS:" not in unit_tests
+    assert "id: ci_image" in unit_tests
+    assert "TRTMC_CI_IMAGE: ${{ steps.ci_image.outputs.image_ref }}" in unit_tests
+    assert "timeout-minutes: 90" in unit_tests
+    assert "timeout-minutes: 60" in unit_tests
+    assert "Build trtmc pip package" not in unit_tests
+    assert "chmod -R a+rwX" not in unit_tests
+    assert ".ci/premerge-unit-build" not in unit_tests
+    assert 'unit_scratch="${RUNNER_TEMP}/trtmc-premerge-unit-' in unit_tests
+    assert 'rm -rf -- "$unit_scratch"' in unit_tests
 
     assert "- legal" in model_proof
     assert "- impact" in model_proof
+    assert "- unit-tests" in model_proof
     assert "needs.legal.outputs.authorized == 'true'" in model_proof
     assert "needs.impact.outputs.has_models == 'true'" in model_proof
+    assert "needs.impact.outputs.run_unit_tests == 'true'" in model_proof
+    assert "needs.impact.outputs.run_unit_tests == 'false'" in model_proof
+    assert "needs.unit-tests.result == 'success'" in model_proof
+    assert "needs.unit-tests.result == 'skipped'" in model_proof
     assert "uses: ./.github/workflows/model-proof.yml" in model_proof
-    assert "name: 3 / Model / ${{ matrix.model }}" in model_proof
+    assert "name: 4 / Model / ${{ matrix.model }}" in model_proof
     assert "fail-fast: true" in model_proof
+    assert "continue-on-error" not in model_proof
     assert "max-parallel: 16" in model_proof
     assert "matrix: ${{ fromJSON(needs.impact.outputs.matrix) }}" in model_proof
     assert "model: ${{ matrix.model }}" in model_proof
@@ -406,13 +451,15 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
 
     assert "- legal" in no_model
     assert "- impact" in no_model
+    assert "- unit-tests" in no_model
     assert "needs.legal.outputs.authorized == 'true'" in no_model
     assert "needs.impact.outputs.has_models == 'false'" in no_model
-    assert 'test "$IMPACT_MODE" = "none"' in no_model
+    assert 'none) echo "No model-owned, platform, or unit inputs changed."' in no_model
+    assert 'unit) echo "Unit tests cover this change; no model proof is required."' in no_model
 
-    for dependency in ("legal", "impact", "model-proof", "no-model"):
+    for dependency in ("legal", "impact", "unit-tests", "model-proof", "no-model"):
         assert f"- {dependency}" in report
-    assert "4 / Combined HTML report" in report
+    assert "5 / Combined HTML report" in report
     assert "always()" in report
     assert "github.event.label.name == 'run-ci'" in report
     assert "needs.legal.outputs.authorized == 'true'" not in report
@@ -423,6 +470,7 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     assert "needs.legal.outputs.tested_sha || github.sha" in report
     assert '--upstream-result "legal=$LEGAL_RESULT"' in report
     assert '--upstream-result "impact=$IMPACT_RESULT"' in report
+    assert '--upstream-result "unit-tests=$UNIT_RESULT"' in report
     assert '--upstream-result "model-proof=$MODEL_RESULT"' in report
     assert '--upstream-result "no-model=$NO_MODEL_RESULT"' in report
     assert "scripts/generate_model_proof_report.py" in report
@@ -432,11 +480,12 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     assert "Upload combined model proof HTML report" in report
     assert "Enforce combined report certification" in report
 
-    for dependency in ("legal", "impact", "model-proof", "no-model", "report"):
+    for dependency in ("legal", "impact", "unit-tests", "model-proof", "no-model", "report"):
         assert f"- {dependency}" in required
     assert "'Premerge CI' || 'Ignored label / Premerge CI'" in required
     assert "always()" in required
     assert 'test "$MODEL_RESULT" = "success"' in required
+    assert 'test "$UNIT_RESULT" = "success"' in required
     assert 'test "$REPORT_RESULT" = "success"' in required
 
 
@@ -463,6 +512,8 @@ def test_premerge_report_bootstrap_names_upstream_failure_before_checkout(
             "premerge",
             "",
             "failure",
+            "skipped",
+            "false",
             "skipped",
             "skipped",
             "skipped",
@@ -593,7 +644,7 @@ def test_nightly_uses_manylinux_image_and_builds_wheel_first() -> None:
     assert "Setup TensorRT-Model-Connect" not in text
 
 
-def test_premerge_delegates_only_model_owned_work_to_the_proof() -> None:
+def test_premerge_keeps_model_proofs_separate_from_source_only_units() -> None:
     premerge = (REPO_ROOT / ".github/workflows/trtmc-ci.yml").read_text()
     for obsolete_global_stage in (
         "Build trtmc pip package",
@@ -605,8 +656,124 @@ def test_premerge_delegates_only_model_owned_work_to_the_proof() -> None:
         "Selective E2E tests",
     ):
         assert obsolete_global_stage not in premerge
-    assert "run-gha-stage.sh" not in premerge
+    assert premerge.count("run-gha-stage.sh") == 1
+    assert "run-gha-stage.sh premerge-unit" in premerge
     assert "uses: ./.github/workflows/model-proof.yml" in premerge
+
+
+def test_premerge_unit_stage_builds_no_model_plugins_or_native_wheel() -> None:
+    script = (REPO_ROOT / ".github" / "scripts" / "run-trtmc-ci.sh").read_text()
+    stage = script.split("run_premerge_unit_tests() {", maxsplit=1)[1].split(
+        "\nwrite_skipped_python_coverage() {", maxsplit=1
+    )[0]
+    cmake = (REPO_ROOT / "CMakeLists.txt").read_text()
+
+    assert "pip install" not in stage
+    assert 'PYTHONPATH="$source_root/python:$source_root' in stage
+    assert 'TRTMC_CI_SCRATCH_DIR:-/tmp' in stage
+    assert 'TRTMC_PREMERGE_UNIT_BUILD_DIR:-$scratch_dir/premerge-unit-build' in stage
+    assert '-m "not gpu and not trt and not e2e and not model_proof_allocator"' in stage
+    assert "tests/builder/" in stage
+    assert "tests/tools/" in stage
+    assert "tests/e2e_harness/test_*.py" in stage
+    assert "-q -x" in stage
+    assert "--dist=worksteal" in stage
+    assert 'not model_proof_allocator"' in stage
+    assert "-m model_proof_allocator" in stage
+    assert "native_targets=(trtmc test_cli_args test_config_cli_support)" in stage
+    assert "native_targets=(trtmc trtmc_platform_cpp_tests)" in stage
+    assert 'TRTMC_PREMERGE_UNIT_SCOPE:-all' in stage
+    assert "tests/builder/test_cli.py" in stage
+    assert '"$build_dir/trtmc" version' in stage
+    assert '"$build_dir/trtmc" --help' in stage
+    assert "--stop-on-failure" in stage
+    assert "libtrtmc_model_*.so*" in stage
+    assert "-DTRTMC_ENABLE_TRT=OFF" not in stage
+    assert "-DTRTMC_BUILD_BACKEND_TRT=OFF" not in stage
+    assert "-DTRTMC_ENABLE_TVM_FFI=OFF" not in stage
+    assert "conan " not in stage
+    assert "build_pip_package" not in stage
+    assert "trtmc_model_plugins" not in stage
+    assert "add_custom_target(trtmc_platform_cpp_tests)" in cmake
+    assert "trtmc_add_test(test_model_plugin_loader MODEL_OWNED)" in cmake
+    assert "test_c_abi_runtime_regression   NO_SRC_INCLUDE MODEL_OWNED" in cmake
+    assert "MODEL_OWNED\n        ${_trtmc_test_options}" in cmake
+    for gpu_test in (
+        "test_trt_runtime_lifetime REQUIRES_TRT REQUIRES_GPU",
+        "test_trt_module REQUIRES_TRT REQUIRES_GPU",
+        "test_cuda_buffer REQUIRES_TRT REQUIRES_GPU",
+        "test_cuda_stream REQUIRES_TRT REQUIRES_GPU",
+        "test_cuda_graph REQUIRES_TRT REQUIRES_GPU",
+        "test_device_tensor REQUIRES_GPU",
+        "test_tvm_ffi_plugin REQUIRES_TRT REQUIRES_GPU",
+        "test_tvm_ffi_plugin_v2 NO_SRC_INCLUDE REQUIRES_TRT REQUIRES_GPU",
+        "test_tvm_ffi_module_loader REQUIRES_TRT REQUIRES_GPU",
+    ):
+        assert f"trtmc_add_test({gpu_test})" in cmake
+
+
+def test_premerge_unit_container_is_unprivileged_offline_and_cpu_only() -> None:
+    start = (REPO_ROOT / ".github" / "scripts" / "start-gha-container.sh").read_text()
+    workflow = (REPO_ROOT / ".github" / "workflows" / "trtmc-ci.yml").read_text()
+    unit_tests = workflow.split("\n  unit-tests:", maxsplit=1)[1].split(
+        "\n  model-proof:", maxsplit=1
+    )[0]
+
+    for option in (
+        "--network none",
+        "--read-only",
+        "--tmpfs /tmp:rw,exec,nosuid,nodev,size=16g",
+        "--cap-drop ALL",
+        "--security-opt no-new-privileges",
+        '--user "$(id -u):$(id -g)"',
+        "--ipc private",
+        "-e HOME=/tmp",
+        "-e TMPDIR=/work/tmp",
+        "-e PIP_NO_INDEX=1",
+        "-e TRTMC_CI_SCRATCH_DIR=/work",
+        "-e NVIDIA_VISIBLE_DEVICES=void",
+        "-e CUDA_VISIBLE_DEVICES=",
+        "--runtime runc",
+        'workspace_mount+=":ro"',
+        'extra_mounts+=(-v "$scratch_host:/work")',
+    ):
+        assert option in start
+    assert 'if [ "$hardened" = "true" ]' in start
+    assert 'if [ "$hardened" != "true" ]' in start
+    assert 'compgen -G "/dev/nvidia*"' in start
+    assert "Hardened unit scratch must be inside RUNNER_TEMP" in start
+    assert "Hardened unit scratch must not be a symlink" in start
+    assert 'TRTMC_CI_HARDENED: "true"' in unit_tests
+    assert "--gpus" not in unit_tests
+    assert "/workspace/users/yifeif:/workspace/users/yifeif" not in unit_tests
+    hardened_allowlist = start.split('if [ "$hardened" = "true" ]; then', maxsplit=2)[2]
+    hardened_allowlist = hardened_allowlist.split('env_args+=', maxsplit=1)[0]
+    assert "HF_TOKEN" not in hardened_allowlist
+    assert "HUGGING_FACE_HUB_TOKEN" not in hardened_allowlist
+
+    stage = (REPO_ROOT / ".github" / "scripts" / "run-gha-stage.sh").read_text()
+    hardened_exec = stage.split(
+        'if [ "${TRTMC_CI_HARDENED:-false}" = "true" ]; then', maxsplit=1
+    )[1].split("\nfi", maxsplit=1)[0]
+    assert "TRTMC_PREMERGE_UNIT_SCOPE" in hardened_exec
+    assert "HF_TOKEN" not in hardened_exec
+    assert "HUGGING_FACE_HUB_TOKEN" not in hardened_exec
+
+
+def test_unowned_gpu_only_builder_suites_are_excluded_from_cpu_units() -> None:
+    stage = (REPO_ROOT / ".github" / "scripts" / "run-trtmc-ci.sh").read_text()
+    for relative in (
+        "tests/builder/test_flashinfer_benchmark.py",
+        "tests/builder/test_tvm_ffi_plugin.py",
+    ):
+        assert f"--ignore={relative}" in stage
+
+    ffi_architecture = (REPO_ROOT / "tests/builder/test_ffi_architecture.py").read_text()
+    flashinfer_section = ffi_architecture.split(
+        "class TestFlashInferKernelSetup:", maxsplit=1
+    )[1].split("class TestEngineBuilderKernelArtifacts:", maxsplit=1)[0]
+    assert flashinfer_section.count("@pytest.mark.gpu") == 3
+    assert flashinfer_section.count("@pytest.mark.trt") == 3
 
 
 def test_model_proof_runs_one_isolated_model_with_unique_complete_evidence() -> None:

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -418,6 +418,9 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     assert "Start clean unit-test container" in unit_tests
     assert "run-gha-stage.sh premerge-unit" in unit_tests
     assert "TRTMC_PREMERGE_UNIT_SCOPE: ${{ needs.impact.outputs.unit_scope }}" in unit_tests
+    assert "TRTMC_CI_WORKSPACE: ${{ github.workspace }}/premerge-unit-checkout" in unit_tests
+    assert "path: premerge-unit-checkout" in unit_tests
+    assert unit_tests.count("working-directory: ${{ env.TRTMC_CI_WORKSPACE }}") == 3
     assert 'TRTMC_CI_HARDENED: "true"' in unit_tests
     assert "TRTMC_CONTAINER_OPTIONS:" not in unit_tests
     assert "id: ci_image" in unit_tests
@@ -746,6 +749,8 @@ def test_premerge_unit_container_is_unprivileged_offline_and_cpu_only() -> None:
     assert 'TRTMC_CI_HARDENED: "true"' in unit_tests
     assert "--gpus" not in unit_tests
     assert "/workspace/users/yifeif:/workspace/users/yifeif" not in unit_tests
+    assert 'workspace="${TRTMC_CI_WORKSPACE:-${GITHUB_WORKSPACE:-}}"' in start
+    assert 'workspace_mount="$workspace:$workspace"' in start
     hardened_allowlist = start.split('if [ "$hardened" = "true" ]; then', maxsplit=2)[2]
     hardened_allowlist = hardened_allowlist.split('env_args+=', maxsplit=1)[0]
     assert "HF_TOKEN" not in hardened_allowlist

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -11,6 +11,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL = REPO_ROOT / "tools" / "model_ci.py"
@@ -161,8 +163,25 @@ def _run(
     )
 
 
-def _impact(repo: Path, base: str, head: str) -> dict[str, object]:
-    result = _run(repo, "impact", "--base", base, "--head", head)
+def _impact(
+    repo: Path,
+    base: str,
+    head: str,
+    *,
+    fallback_models: tuple[str, ...] = ("model_a",),
+) -> dict[str, object]:
+    args = [
+        "impact",
+        "--base",
+        base,
+        "--head",
+        head,
+        "--platform-change-policy",
+        "fallback",
+    ]
+    for model in fallback_models:
+        args.extend(("--fallback-model", model))
+    result = _run(repo, *args)
     return json.loads(result.stdout)
 
 
@@ -185,6 +204,7 @@ def test_validate_and_all_emit_deterministic_matrix_and_github_outputs(
     )
 
     assert validated["models"] == ["model_a", "model_b"]
+    assert result["schema_version"] == 2
     assert result["matrix"] == {"include": [{"model": "model_a"}, {"model": "model_b"}]}
     assert output.read_text(encoding="utf-8").splitlines() == [
         'matrix={"include":[{"model":"model_a"},{"model":"model_b"}]}',
@@ -192,6 +212,8 @@ def test_validate_and_all_emit_deterministic_matrix_and_github_outputs(
         'affected_models=["model_a","model_b"]',
         "expected_count=2",
         "mode=all",
+        "run_unit_tests=false",
+        "unit_scope=none",
     ]
 
 
@@ -250,6 +272,8 @@ def test_impact_selects_only_model_a(tmp_path: Path) -> None:
     assert result["mode"] == "models"
     assert result["affected_models"] == ["model_a"]
     assert result["matrix"] == {"include": [{"model": "model_a"}]}
+    assert result["run_unit_tests"] is False
+    assert result["unit_scope"] == "none"
 
 
 def test_impact_selects_each_modified_model_once(tmp_path: Path) -> None:
@@ -287,17 +311,21 @@ def test_impact_treats_legal_and_docs_as_no_model_change(tmp_path: Path) -> None
     assert result["mode"] == "none"
     assert result["has_models"] is False
     assert result["matrix"] == {"include": []}
+    assert result["run_unit_tests"] is False
+    assert result["unit_scope"] == "none"
 
 
-def test_impact_treats_platform_change_as_all_models(tmp_path: Path) -> None:
+def test_impact_treats_platform_change_as_fixed_fallback(tmp_path: Path) -> None:
     repo, base = _make_repo(tmp_path)
     _write(repo, "src/runtime/core/core.cpp", "// changed platform core\n")
     head = _commit(repo, "platform")
 
     result = _impact(repo, base, head)
 
-    assert result["mode"] == "all"
-    assert result["affected_models"] == ["model_a", "model_b"]
+    assert result["mode"] == "fallback"
+    assert result["affected_models"] == ["model_a"]
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
 
 
 def test_impact_treats_shared_family_registry_as_platform(tmp_path: Path) -> None:
@@ -307,8 +335,83 @@ def test_impact_treats_shared_family_registry_as_platform(tmp_path: Path) -> Non
 
     result = _impact(repo, base, head)
 
-    assert result["mode"] == "all"
+    assert result["mode"] == "fallback"
+    assert result["affected_models"] == ["model_a"]
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
+
+
+@pytest.mark.parametrize(
+    "path, expected_scope",
+    (
+        ("src/cli/main.cpp", "cli"),
+        ("src/cli/args.h", "cli"),
+        ("src/runtime/config/cli_support.cpp", "cli"),
+        ("include/trtmc/config/cli_support.h", "cli"),
+        ("python/tensorrt_model_connect/build_cli.py", "cli"),
+        ("python/tensorrt_model_connect/runtime_config/cli_support.py", "cli"),
+        ("tests/builder/test_cli.py", "all"),
+        ("tests/cpp/test_cli_args.cpp", "all"),
+        ("tests/tools/test_cli_contract.py", "all"),
+    ),
+)
+def test_cli_and_unit_test_changes_run_units_without_model_proofs(
+    tmp_path: Path,
+    path: str,
+    expected_scope: str,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, path, "// changed\n" if path.endswith((".cpp", ".h")) else "# changed\n")
+    head = _commit(repo, "unit-only change")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "unit"
+    assert result["affected_models"] == []
+    assert result["matrix"] == {"include": []}
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == expected_scope
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "CMakeLists.txt",
+        ".github/workflows/trtmc-ci.yml",
+        "tools/model_ci.py",
+        "new_platform/implementation.py",
+    ),
+)
+def test_broad_or_unknown_changes_select_only_fixed_fallback(
+    tmp_path: Path,
+    path: str,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, path, "# changed\n")
+    head = _commit(repo, "broad change")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["affected_models"] == ["model_a"]
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
+
+
+def test_mixed_model_and_broad_change_keeps_direct_model_plus_fallback(
+    tmp_path: Path,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, "src/runtime/models/model_b/plugin.cpp", "// changed model b\n")
+    _write(repo, "CMakeLists.txt", "# changed platform\n")
+    head = _commit(repo, "mixed change")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
     assert result["affected_models"] == ["model_a", "model_b"]
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
 
 
 def test_impact_includes_deletions_and_both_sides_of_rename(tmp_path: Path) -> None:
@@ -329,10 +432,39 @@ def test_impact_includes_deletions_and_both_sides_of_rename(tmp_path: Path) -> N
     assert any(str(change["status"]).startswith("R") for change in result["changes"])
 
 
-def test_impact_rejects_unknown_source_path(tmp_path: Path) -> None:
+def test_whole_model_deletion_runs_units_and_fixed_fallback(tmp_path: Path) -> None:
     repo, base = _make_repo(tmp_path)
-    _write(repo, "mystery/implementation.py", "VALUE = 1\n")
-    head = _commit(repo, "unknown source")
+    _git(
+        repo,
+        "rm",
+        "-r",
+        "python/tensorrt_model_connect/families/model_b",
+        "src/runtime/models/model_b",
+        "tests/e2e/models/model_b",
+        "tests/cpp/models/model_b",
+    )
+    head = _commit(repo, "delete model b")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["affected_models"] == ["model_a"]
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
+
+
+def test_deleting_configured_fallback_requires_policy_update(tmp_path: Path) -> None:
+    repo, base = _make_repo(tmp_path)
+    _git(
+        repo,
+        "rm",
+        "-r",
+        "python/tensorrt_model_connect/families/model_a",
+        "src/runtime/models/model_a",
+        "tests/e2e/models/model_a",
+        "tests/cpp/models/model_a",
+    )
+    head = _commit(repo, "delete fallback model")
 
     result = _run(
         repo,
@@ -341,11 +473,119 @@ def test_impact_rejects_unknown_source_path(tmp_path: Path) -> None:
         base,
         "--head",
         head,
+        "--platform-change-policy",
+        "fallback",
+        "--fallback-model",
+        "model_a",
         check=False,
     )
 
     assert result.returncode == 2
-    assert "has no model, platform, CI, legal, or docs owner" in result.stderr
+    assert "fallback models are absent from the head catalog" in result.stderr
+
+
+def test_impact_rejects_unowned_path_below_model_root(tmp_path: Path) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, "tests/e2e/models/unowned/test_unowned.py", "VALUE = 1\n")
+    head = _commit(repo, "unowned model source")
+
+    result = _run(
+        repo,
+        "impact",
+        "--base",
+        base,
+        "--head",
+        head,
+        "--platform-change-policy",
+        "fallback",
+        "--fallback-model",
+        "model_a",
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "under a model root but has no MODEL.toml owner" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "tests/builder/test_dynamic_batch_profile.py",
+        "tests/builder/test_flashinfer_benchmark.py",
+        "tests/builder/test_graph_blocks.py",
+        "tests/builder/test_tvm_ffi_plugin.py",
+        "tests/cpp/test_c_abi_runtime_regression.cpp",
+        "tests/cpp/test_cuda_buffer.cpp",
+        "tests/cpp/test_cuda_graph.cpp",
+        "tests/cpp/test_cuda_stream.cpp",
+        "tests/cpp/test_device_tensor.cpp",
+        "tests/cpp/test_model_plugin_loader.cpp",
+        "tests/cpp/test_trt_module.cpp",
+        "tests/cpp/test_trt_runtime_lifetime.cpp",
+        "tests/cpp/test_tvm_ffi_module_loader.cpp",
+        "tests/cpp/test_tvm_ffi_plugin.cpp",
+        "tests/cpp/test_tvm_ffi_plugin_v2.cpp",
+    ),
+)
+def test_model_coupled_shared_tests_fail_closed_until_owned(
+    tmp_path: Path,
+    path: str,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, path, "// changed coupled test\n")
+    head = _commit(repo, "change coupled test")
+
+    result = _run(
+        repo,
+        "impact",
+        "--base",
+        base,
+        "--head",
+        head,
+        "--platform-change-policy",
+        "fallback",
+        "--fallback-model",
+        "model_a",
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "model-coupled test has no isolated model owner" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "fallback_args, message",
+    (
+        ((), "requires at least one --fallback-model"),
+        (("model_a", "model_a"), "contains duplicates"),
+        (("missing",), "absent from the head catalog"),
+        (("../unsafe",), "contains unsafe ids"),
+    ),
+)
+def test_broad_impact_rejects_invalid_fallback_configuration(
+    tmp_path: Path,
+    fallback_args: tuple[str, ...],
+    message: str,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, "CMakeLists.txt", "# changed platform\n")
+    head = _commit(repo, "broad change")
+    args = [
+        "impact",
+        "--base",
+        base,
+        "--head",
+        head,
+        "--platform-change-policy",
+        "fallback",
+    ]
+    for model in fallback_args:
+        args.extend(("--fallback-model", model))
+
+    result = _run(repo, *args, check=False)
+
+    assert result.returncode == 2
+    assert message in result.stderr
 
 
 def test_validate_rejects_overlapping_runtime_ownership(tmp_path: Path) -> None:

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -81,7 +81,7 @@ def _write_successful_fake_docker(tmp_path: Path) -> tuple[Path, Path]:
         "    fi\n"
         '    if [[ " $* " == *" --inner "* ]]; then\n'
         '      if [ -n "${FAKE_PROOF_RELEASE_FILE:-}" ]; then\n'
-        "        deadline=$((SECONDS + 30))\n"
+        "        deadline=$((SECONDS + 600))\n"
         '        while [ ! -e "$FAKE_PROOF_RELEASE_FILE" ]; do\n'
         '          [ "$SECONDS" -lt "$deadline" ] || exit 98\n'
         "          sleep 0.05\n"
@@ -678,7 +678,8 @@ def test_model_proof_serializes_image_setup_and_uses_the_verified_image_id() -> 
         "TRTMC_CI_IMAGE_LOCK_FILE",
         'flock -w "$lock_timeout" 9',
         "docker image inspect --format '{{.Id}}'",
-        'echo "image_ref=$image_ref" >> "$GITHUB_OUTPUT"',
+        'echo "image_ref=$resolved_ref" >> "$GITHUB_OUTPUT"',
+        "verification_stamp",
     ):
         assert contract in ensure
     assert "id: ci_image" in workflow
@@ -1398,7 +1399,10 @@ def test_selected_hf_cache_with_unreadable_file_is_delegated_to_root_helper(
     unreadable = selected_repo / "unreadable-cache-marker"
     unreadable.write_text("persistent cache\n", encoding="utf-8")
     unreadable.chmod(0)
-    assert not os.access(unreadable, os.R_OK)
+    # Root can read mode-000 files through DAC_OVERRIDE, so assert the fixture's
+    # permissions directly. The proof below still verifies that the dedicated
+    # root helper receives and reflinks this exact repository.
+    assert unreadable.stat().st_mode & 0o777 == 0
     env.update(
         {
             "FAKE_UNREADABLE_REFLINK": "1",
@@ -1667,7 +1671,11 @@ def test_explicit_runner_gpu_id_cannot_bypass_a_busy_slot(tmp_path: Path) -> Non
             capture_output=True,
             text=True,
             check=False,
-            timeout=15,
+            # Source projection and cache preparation happen before GPU
+            # admission so queued jobs do not hold scarce slots during CPU
+            # setup. Allow that setup to finish on a loaded CI host; the
+            # in-runner lease timeout remains one second and is asserted below.
+            timeout=60,
         )
 
     assert result.returncode != 0
@@ -1704,6 +1712,7 @@ def test_explicit_runner_gpu_must_be_in_the_configured_allowlist(tmp_path: Path)
     assert not _proof_gpu_ids_if_present(docker_log)
 
 
+@pytest.mark.model_proof_allocator
 def test_four_shared_proofs_use_unique_slots_on_one_gpu(
     tmp_path: Path,
 ) -> None:
@@ -1741,7 +1750,7 @@ def test_four_shared_proofs_use_unique_slots_on_one_gpu(
         )
         processes.append((process, docker_log, output))
 
-    deadline = time.monotonic() + 30
+    deadline = time.monotonic() + 90
     while time.monotonic() < deadline and not all(
         (output / "artifacts" / "gpu-lease.json").is_file() for _, _, output in processes
     ):
@@ -1768,6 +1777,7 @@ def test_four_shared_proofs_use_unique_slots_on_one_gpu(
     assert sorted(selected_slots) == [0, 1, 2, 3]
 
 
+@pytest.mark.model_proof_allocator
 def test_shared_slot_allocator_spreads_across_gpus_before_using_second_slots(
     tmp_path: Path,
 ) -> None:
@@ -1805,7 +1815,7 @@ def test_shared_slot_allocator_spreads_across_gpus_before_using_second_slots(
         )
         processes.append((process, output))
 
-    deadline = time.monotonic() + 30
+    deadline = time.monotonic() + 90
     while time.monotonic() < deadline and not all(
         (output / "artifacts" / "gpu-lease.json").is_file() for _, output in processes
     ):
@@ -1934,6 +1944,7 @@ def test_expected_resource_class_must_match_projected_e2e_manifest(
     assert not _proof_gpu_ids_if_present(docker_log)
 
 
+@pytest.mark.model_proof_allocator
 def test_fifth_shared_proof_times_out_when_all_four_slots_are_busy(
     tmp_path: Path,
 ) -> None:
@@ -1971,7 +1982,7 @@ def test_fifth_shared_proof_times_out_when_all_four_slots_are_busy(
             capture_output=True,
             text=True,
             check=False,
-            timeout=15,
+            timeout=90,
         )
     finally:
         for lock_stream in lock_streams:
@@ -1982,6 +1993,7 @@ def test_fifth_shared_proof_times_out_when_all_four_slots_are_busy(
     assert not _proof_gpu_ids_if_present(docker_log)
 
 
+@pytest.mark.model_proof_allocator
 def test_gpu_allocator_mutex_contention_obeys_lease_timeout(
     tmp_path: Path,
 ) -> None:
@@ -1996,10 +2008,9 @@ def test_gpu_allocator_mutex_contention_obeys_lease_timeout(
     )
     lock_dir = tmp_path / "gpu-locks"
     lock_dir.mkdir()
-    started = time.monotonic()
     with (lock_dir / "allocator.lock").open("w", encoding="utf-8") as lock_stream:
         fcntl.flock(lock_stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        result = subprocess.run(
+        process = subprocess.Popen(
             [
                 "bash",
                 str(RUNNER),
@@ -2012,23 +2023,38 @@ def test_gpu_allocator_mutex_contention_obeys_lease_timeout(
             ],
             cwd=REPO_ROOT,
             env=env,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            check=False,
-            timeout=15,
         )
-    elapsed = time.monotonic() - started
+        try:
+            requested = output / "artifacts" / "gpu-lease-requested.txt"
+            deadline = time.monotonic() + 90
+            while time.monotonic() < deadline and not requested.is_file():
+                if process.poll() is not None:
+                    break
+                time.sleep(0.05)
+            assert requested.is_file(), "proof never reached GPU lease acquisition"
+            started = time.monotonic()
+            stdout, stderr = process.communicate(timeout=15)
+            elapsed = time.monotonic() - started
+        finally:
+            if process.poll() is None:
+                process.terminate()
+                process.communicate(timeout=10)
 
-    assert result.returncode != 0
+    assert process.returncode != 0, stdout + stderr
     assert elapsed < 5
-    assert "timed out after 1s waiting for a shared model-proof GPU lease" in result.stderr
+    assert "timed out after 1s waiting for a shared model-proof GPU lease" in stderr
     assert not _proof_gpu_ids_if_present(docker_log)
 
 
+@pytest.mark.model_proof_allocator
 def test_exclusive_gpu_reservation_drains_existing_shared_and_blocks_new_shared(
     tmp_path: Path,
 ) -> None:
     lock_dir = tmp_path / "gpu-locks"
+    first_release_file = tmp_path / "release-first-shared"
 
     first_dir = tmp_path / "first-shared"
     first_dir.mkdir()
@@ -2042,7 +2068,7 @@ def test_exclusive_gpu_reservation_drains_existing_shared_and_blocks_new_shared(
             "TRTMC_MODEL_PROOF_GPU_IDS": "6",
             "TRTMC_MODEL_PROOF_SLOTS_PER_GPU": "2",
             "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS": "10",
-            "FAKE_PROOF_DELAY_SECONDS": "4",
+            "FAKE_PROOF_RELEASE_FILE": str(first_release_file),
         }
     )
     first = subprocess.Popen(
@@ -2075,13 +2101,12 @@ def test_exclusive_gpu_reservation_drains_existing_shared_and_blocks_new_shared(
             "TRTMC_GPU_ID": "6",
             "TRTMC_MODEL_PROOF_GPU_IDS": "6",
             "TRTMC_MODEL_PROOF_SLOTS_PER_GPU": "2",
-            "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS": "10",
-            "FAKE_PROOF_DELAY_SECONDS": "1",
+            "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS": "600",
         }
     )
     exclusive: subprocess.Popen[str] | None = None
     try:
-        deadline = time.monotonic() + 10
+        deadline = time.monotonic() + 90
         while (
             time.monotonic() < deadline
             and not (first_output / "artifacts" / "gpu-lease.json").is_file()
@@ -2108,7 +2133,7 @@ def test_exclusive_gpu_reservation_drains_existing_shared_and_blocks_new_shared(
         )
 
         reservation = lock_dir / "gpu-6-reservation.lock"
-        deadline = time.monotonic() + 10
+        deadline = time.monotonic() + 90
         while time.monotonic() < deadline and not _lock_is_busy(reservation):
             time.sleep(0.05)
         assert _lock_is_busy(reservation), "exclusive proof never reserved GPU 6"
@@ -2143,12 +2168,13 @@ def test_exclusive_gpu_reservation_drains_existing_shared_and_blocks_new_shared(
             capture_output=True,
             text=True,
             check=False,
-            timeout=15,
+            timeout=90,
         )
         assert blocked.returncode != 0
         assert "waiting for a shared model-proof GPU lease" in blocked.stderr
         assert not _proof_gpu_ids_if_present(blocked_log)
 
+        first_release_file.touch()
         first_stdout, first_stderr = first.communicate(timeout=30)
         assert first.returncode == 0, first_stdout + first_stderr
         exclusive_stdout, exclusive_stderr = exclusive.communicate(timeout=30)
@@ -2160,6 +2186,7 @@ def test_exclusive_gpu_reservation_drains_existing_shared_and_blocks_new_shared(
         assert not _lock_is_busy(lock_dir / "gpu-6-slot-0.lock")
         assert not _lock_is_busy(lock_dir / "gpu-6-slot-1.lock")
     finally:
+        first_release_file.touch(exist_ok=True)
         if first.poll() is None:
             first.terminate()
             first.communicate(timeout=10)

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -118,6 +118,49 @@ LEGAL_OR_DOC_EXACT = frozenset(
 )
 LEGAL_OR_DOC_PREFIXES = ("website/",)
 
+# These shared surfaces are covered by CPU/C++ unit tests and do not change a
+# model implementation or its isolated E2E contract. Model-root ownership is
+# resolved before this list, so model-owned C++ tests remain model impact.
+UNIT_TEST_ONLY_EXACT = frozenset(
+    {
+        "include/trtmc/config/cli_support.h",
+        "python/tensorrt_model_connect/__main__.py",
+        "python/tensorrt_model_connect/build_cli.py",
+        "python/tensorrt_model_connect/runtime_config/cli_support.py",
+        "src/runtime/config/cli_support.cpp",
+    }
+)
+UNIT_TEST_ONLY_PREFIXES = (
+    "tests/builder/",
+    "tests/cpp/",
+    "tests/tools/",
+)
+CLI_UNIT_ONLY_PREFIXES = ("src/cli/",)
+
+# These shared-location tests require real model plugins or GPU execution and
+# therefore cannot be certified by the source-only CPU aggregate. Fail closed
+# on a direct edit until each test is moved behind explicit model ownership or
+# uses a synthetic CPU fixture.
+MODEL_COUPLED_TEST_EXACT = frozenset(
+    {
+        "tests/builder/test_dynamic_batch_profile.py",
+        "tests/builder/test_flashinfer_benchmark.py",
+        "tests/builder/test_graph_blocks.py",
+        "tests/builder/test_tvm_ffi_plugin.py",
+        "tests/cpp/test_c_abi_runtime_regression.cpp",
+        "tests/cpp/test_cuda_buffer.cpp",
+        "tests/cpp/test_cuda_graph.cpp",
+        "tests/cpp/test_cuda_stream.cpp",
+        "tests/cpp/test_device_tensor.cpp",
+        "tests/cpp/test_model_plugin_loader.cpp",
+        "tests/cpp/test_trt_module.cpp",
+        "tests/cpp/test_trt_runtime_lifetime.cpp",
+        "tests/cpp/test_tvm_ffi_module_loader.cpp",
+        "tests/cpp/test_tvm_ffi_plugin.cpp",
+        "tests/cpp/test_tvm_ffi_plugin_v2.cpp",
+    }
+)
+
 PLATFORM_EXACT = frozenset(
     {
         ".clang-format",
@@ -479,11 +522,24 @@ def _classify_path(path: str, catalog: OwnershipCatalog) -> tuple[str, str | Non
         raise ModelCIError(f"path is under a model root but has no MODEL.toml owner: {path}")
     if _is_legal_or_docs(path):
         return "legal_docs", None
+    if path in MODEL_COUPLED_TEST_EXACT:
+        raise ModelCIError(
+            "model-coupled test has no isolated model owner; move it into a "
+            f"MODEL.toml contract or use a synthetic plugin before changing it: {path}"
+        )
+    if path in UNIT_TEST_ONLY_EXACT or any(
+        path.startswith(prefix) for prefix in CLI_UNIT_ONLY_PREFIXES
+    ):
+        return "unit_cli", None
+    if any(
+        path.startswith(prefix) for prefix in UNIT_TEST_ONLY_PREFIXES
+    ):
+        return "unit_tests", None
     if path in PLATFORM_EXACT or any(path.startswith(prefix) for prefix in PLATFORM_PREFIXES):
         return "platform", None
     if any(path.startswith(prefix) for prefix in CI_OR_TOOLING_PREFIXES):
         return "ci_tooling", None
-    raise ModelCIError(f"changed path has no model, platform, CI, legal, or docs owner: {path}")
+    return "unknown", None
 
 
 def _diff_entries(repo_root: Path, base: str, head: str) -> tuple[DiffEntry, ...]:
@@ -532,18 +588,22 @@ def _result(
     mode: str,
     changes: list[dict[str, object]],
     matrix_models: Iterable[str] | None = None,
+    run_unit_tests: bool = False,
+    unit_scope: str = "none",
 ) -> dict[str, object]:
     selected = sorted(set(models))
     scheduled = list(matrix_models) if matrix_models is not None else selected
     if len(scheduled) != len(set(scheduled)) or set(scheduled) != set(selected):
         raise ModelCIError("matrix model order must contain each affected model exactly once")
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "mode": mode,
         "has_models": bool(selected),
         "expected_count": len(selected),
         "affected_models": selected,
         "matrix": {"include": [{"model": model} for model in scheduled]},
+        "run_unit_tests": run_unit_tests,
+        "unit_scope": unit_scope,
         "changes": changes,
     }
 
@@ -653,6 +713,7 @@ def calculate_impact(
     head: str,
     *,
     platform_change_policy: str,
+    fallback_models: Sequence[str] = (),
 ) -> dict[str, object]:
     base_sha = _resolve_revision(repo_root, base)
     head_sha = _resolve_revision(repo_root, head)
@@ -666,6 +727,7 @@ def calculate_impact(
     head_catalog = discover_catalog(repo_root, head, allow_legacy_shared_runtime=True)
     affected: set[str] = set()
     broad_change = False
+    unit_scope = "none"
     serialized_changes: list[dict[str, object]] = []
     for change in _diff_entries(repo_root, comparison_base, head_sha):
         classifications: list[dict[str, str]] = []
@@ -683,8 +745,14 @@ def calculate_impact(
             if owner is not None:
                 item["model"] = owner
                 affected.add(owner)
-            elif kind in {"platform", "ci_tooling"}:
+            elif kind == "unit_cli":
+                if unit_scope == "none":
+                    unit_scope = "cli"
+            elif kind == "unit_tests":
+                unit_scope = "all"
+            elif kind in {"platform", "ci_tooling", "unknown"}:
                 broad_change = True
+                unit_scope = "all"
             classifications.append(item)
         serialized_changes.append(
             {
@@ -701,14 +769,35 @@ def calculate_impact(
     ):
         broad_change = True
     if broad_change:
-        if platform_change_policy != "all":
+        affected.intersection_update(head_catalog.models)
+        if platform_change_policy == "all":
+            affected.update(head_catalog.models)
+            mode = "all"
+        elif platform_change_policy == "fallback":
+            requested_fallback = list(fallback_models)
+            if not requested_fallback:
+                raise ModelCIError(
+                    "platform or CI/tooling fallback requires at least one --fallback-model"
+                )
+            if len(requested_fallback) != len(set(requested_fallback)):
+                raise ModelCIError("fallback model list contains duplicates")
+            invalid = [model for model in requested_fallback if not _MODEL_ID_RE.fullmatch(model)]
+            if invalid:
+                raise ModelCIError(f"fallback model list contains unsafe ids: {invalid}")
+            missing = sorted(set(requested_fallback) - set(head_catalog.models))
+            if missing:
+                raise ModelCIError(f"fallback models are absent from the head catalog: {missing}")
+            affected.update(requested_fallback)
+            mode = "fallback"
+        else:
             raise ModelCIError(
-                "platform or CI/tooling change requires --platform-change-policy all"
+                "platform or CI/tooling change requires --platform-change-policy "
+                "fallback or all"
             )
-        affected.update(head_catalog.models)
-        mode = "all"
     elif affected:
         mode = "models"
+    elif unit_scope != "none":
+        mode = "unit"
     else:
         mode = "none"
     result = _result(
@@ -716,6 +805,8 @@ def calculate_impact(
         mode=mode,
         changes=serialized_changes,
         matrix_models=_scheduled_models(repo_root, head_catalog, affected),
+        run_unit_tests=unit_scope != "none" or broad_change,
+        unit_scope="all" if broad_change else unit_scope,
     )
     result["base_revision"] = base_catalog.revision
     result["head_revision"] = head_catalog.revision
@@ -729,6 +820,8 @@ def _write_github_output(path: Path, result: dict[str, object]) -> None:
         "affected_models": json.dumps(result["affected_models"], separators=(",", ":")),
         "expected_count": str(result["expected_count"]),
         "mode": str(result["mode"]),
+        "run_unit_tests": str(bool(result["run_unit_tests"])).lower(),
+        "unit_scope": str(result["unit_scope"]),
     }
     with path.open("a", encoding="utf-8") as stream:
         for key, value in outputs.items():
@@ -905,7 +998,17 @@ def build_parser() -> argparse.ArgumentParser:
     impact.add_argument("--repo-root", type=_repo_root, default=default_root)
     impact.add_argument("--base", required=True)
     impact.add_argument("--head", required=True)
-    impact.add_argument("--platform-change-policy", choices=("all", "fail"), default="all")
+    impact.add_argument(
+        "--platform-change-policy",
+        choices=("fallback", "all", "fail"),
+        default="fail",
+    )
+    impact.add_argument(
+        "--fallback-model",
+        action="append",
+        default=[],
+        help="Fixed representative model to include for broad premerge impact (repeatable)",
+    )
     _add_common_output(impact)
 
     all_models = subparsers.add_parser("all", help="emit every model as a matrix")
@@ -939,6 +1042,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 args.base,
                 args.head,
                 platform_change_policy=args.platform_change_policy,
+                fallback_models=args.fallback_model,
             )
             if args.github_output is not None:
                 _write_github_output(args.github_output, result)


### PR DESCRIPTION
## Background

Premerge currently treats non-model changes as a reason to run every model and repeats expensive CI-image verification in matrix children. That wastes the four-GPU runner and delays model-owned PRs that should only prove their own isolated model.

## Exit Criteria

- Model-owned changes run only the affected isolated model proofs.
- CLI-only changes run focused source-only C++ and Python units with no model proof.
- Potentially broad changes run CPU units plus exactly five representative model proofs: `deepseek_v2`, `patchtsmixer`, `segformer`, `whisper`, and `ltx_video`.
- GPU/model-coupled tests that lack isolated ownership fail closed instead of silently disappearing from coverage.
- The existing combined HTML model report and required fail-fast gate remain intact.

## Implementation

- Extend impact analysis with `none`, `cli`, and `all` unit scopes and a fixed fallback-model policy. Direct model ownership is resolved first, so multi-model PRs still produce one named matrix job per affected model.
- Add a source-only unit job ahead of the model matrix. It builds no model plugin, runs no GPU tests, and executes in an immutable, non-root, offline container with a read-only checkout and isolated scratch storage.
- Separate CPU-safe CTests from model-owned and GPU-only tests. Direct edits to unowned GPU/model-coupled test sources fail closed until they gain a model owner or synthetic CPU fixture.
- Verify the CI image once per workflow run and reuse its immutable image ID in matrix siblings.
- Keep matrix `fail-fast: true`, propagate unit/model/report results through the required gate, and retain the single combined HTML report.

## Validation

- `PYTHONPATH=python:. python -m pytest tests/tools/test_github_actions_ci.py tests/tools/test_model_ci.py tests/tools/test_ensure_ci_docker_image.py tests/tools/test_e2e_python_profiles.py -q -x`: 125 passed.
- `PYTHONPATH=python:. python -m pytest tests/tools/test_model_proof_runner.py -m model_proof_allocator -q -x -p no:cacheprovider`: 5 passed, 66 deselected.
- Hardened CPU Python phase: 2,116 passed, 1 skipped; no GPU devices, network, root user, or writable source checkout.
- Hardened C++ aggregate: 33/33 platform CTests passed and no `libtrtmc_model_*.so` was produced.
- Focused CLI scope: 94 Python tests and 2/2 CTests passed, including `trtmc version` and `trtmc --help` smoke checks.
- `python tools/legal_headers.py --check`: 8,063 tracked files, 0 findings.
- `python tools/model_ci.py impact ...`: mode `fallback`, unit scope `all`, and exactly the five configured representative models.
- Ruff, shell syntax, workflow YAML parsing, catalog validation, and `git diff --check` passed.

## Notes For Future Readers

- Review `tools/model_ci.py` first, then `.github/workflows/trtmc-ci.yml`, followed by the hardened container/CMake changes.
- Nightly coverage remains the full 77-model suite. The five-model list is only the bounded premerge fallback for potentially broad changes.
- Production CLI files are intentionally unit-only per the premerge policy; native CLI smoke tests cover the shared entrypoint without consuming a GPU model slot.
