### PR TITLE
test(ci): verify CLI-only coverage

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -4,6 +4,7 @@
  */
 
 // trtmc CLI — command-line interface using the new C++ library API.
+// CI coverage experiment: CLI-only changes must run units without model proofs.
 //
 // Usage:
 //   trtmc build           <hf-model-or-dir> -o <bundle.trtfb> [builder args...]


### PR DESCRIPTION
## Background

This disposable draft PR verifies that a production CLI-only change runs focused CPU unit coverage without scheduling any model proof.

## Exit Criteria

- Impact analysis reports `unit_scope=cli`.
- The C++ and Python unit job passes.
- No model matrix job is created.

## Implementation

- Add a comment-only coverage probe to `src/cli/main.cpp`.

## Validation

- `python tools/model_ci.py impact --base github/main --head HEAD --platform-change-policy fallback ...`: mode `unit`, unit scope `cli`, zero affected models.

## Notes For Future Readers

- This PR is an experiment only and must not be merged.

## Observed Result

- [Run 29125869302](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29125869302) passed in 1m44s.
- The focused unit job passed in 39s and the model matrix was skipped.
