### PR TITLE
perf(wan): accelerate host preprocessing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,6 +437,9 @@ foreach(_trtmc_model IN LISTS TRTMC_RUNTIME_MODEL_IDS)
           "but cuBLAS was not found")
       endif()
       target_link_libraries(trtmc_model_${_trtmc_model} PRIVATE ${TRTMC_CUBLAS_LIBRARY})
+    elseif(_trtmc_model_link_library STREQUAL "threads")
+      find_package(Threads REQUIRED)
+      target_link_libraries(trtmc_model_${_trtmc_model} PRIVATE Threads::Threads)
     else()
       message(FATAL_ERROR
         "Unknown runtime_link_libraries entry '${_trtmc_model_link_library}' "

--- a/src/runtime/models/wan/MODEL.toml
+++ b/src/runtime/models/wan/MODEL.toml
@@ -6,6 +6,7 @@ runtime_library = "libtrtmc_model_wan.so"
 runtime_plugins = ["plugin.cpp|register_wan_plugin"]
 runtime_strategies = ["diffusion_wan"]
 legacy_runtime_strategy_aliases = ["diffusion|default|_|_|diffusion_wan"]
+runtime_link_libraries = ["threads"]
 gnu_warning_suppressed_sources = ["pipeline.cpp"]
 runtime_tests = [
   "test_wan_pipeline|test_wan_pipeline.cpp|trtmc_model_wan|_|_",

--- a/src/runtime/models/wan/pipeline.cpp
+++ b/src/runtime/models/wan/pipeline.cpp
@@ -16,10 +16,12 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <numeric>
 #include <random>
+#include <thread>
 
 namespace trtmc {
 
@@ -103,17 +105,81 @@ struct DDIMState {
 
 void cpu_matmul_bias(const float* A, const float* B, const float* bias, float* out, int32_t M,
                      int32_t K, int32_t N) {
-    for (int32_t i = 0; i < M; ++i) {
-        for (int32_t j = 0; j < N; ++j) {
-            double acc = 0.0;
-            for (int32_t k = 0; k < K; ++k) {
-                acc += static_cast<double>(A[i * K + k]) * static_cast<double>(B[k * N + j]);
-            }
-            if (bias != nullptr) {
-                acc += static_cast<double>(bias[j]);
-            }
-            out[i * N + j] = static_cast<float>(acc);
+    const auto operation_count = static_cast<std::uint64_t>(M) * static_cast<std::uint64_t>(K) *
+                                 static_cast<std::uint64_t>(N);
+    int32_t max_threads = static_cast<int32_t>(std::thread::hardware_concurrency());
+    if (max_threads <= 0) {
+        max_threads = 1;
+    }
+    max_threads = std::min<int32_t>(max_threads, 16);
+    if (const char* value = std::getenv("TRTMC_WAN_CPU_GEMM_THREADS")) {
+        char* end = nullptr;
+        const long parsed = std::strtol(value, &end, 10);
+        if (end != value && *end == '\0' && parsed > 0) {
+            max_threads = static_cast<int32_t>(std::min<long>(parsed, 256));
         }
+    }
+
+    // Thread creation is not worthwhile for small timestep projections. The
+    // large text and patch projections have independent output rows and are
+    // safe to split without changing any element's reduction order.
+    const int32_t num_threads =
+        operation_count >= 16'000'000ULL ? std::min<int32_t>(M, max_threads) : 1;
+
+    const auto compute_rows = [=](int32_t row_begin, int32_t row_end, double* accumulators) {
+        for (int32_t i = row_begin; i < row_end; ++i) {
+            std::fill_n(accumulators, N, 0.0);
+            for (int32_t k = 0; k < K; ++k) {
+                const double a = static_cast<double>(A[i * K + k]);
+                const float* b_row = B + static_cast<std::size_t>(k) * static_cast<std::size_t>(N);
+                for (int32_t j = 0; j < N; ++j) {
+                    accumulators[j] += a * static_cast<double>(b_row[j]);
+                }
+            }
+            float* out_row = out + static_cast<std::size_t>(i) * static_cast<std::size_t>(N);
+            for (int32_t j = 0; j < N; ++j) {
+                double value = accumulators[j];
+                if (bias != nullptr) {
+                    value += static_cast<double>(bias[j]);
+                }
+                out_row[j] = static_cast<float>(value);
+            }
+        }
+    };
+
+    if (num_threads == 1) {
+        std::vector<double> accumulators(static_cast<std::size_t>(N));
+        compute_rows(0, M, accumulators.data());
+        return;
+    }
+
+    // Allocate all scratch storage before starting workers so an allocation
+    // failure cannot escape a worker thread and terminate the process.
+    std::vector<double> thread_accumulators(static_cast<std::size_t>(num_threads) *
+                                            static_cast<std::size_t>(N));
+    std::vector<std::thread> workers;
+    workers.reserve(static_cast<std::size_t>(num_threads));
+    const int32_t rows_per_thread = (M + num_threads - 1) / num_threads;
+    try {
+        for (int32_t thread_index = 0; thread_index < num_threads; ++thread_index) {
+            const int32_t row_begin = thread_index * rows_per_thread;
+            const int32_t row_end = std::min<int32_t>(M, row_begin + rows_per_thread);
+            if (row_begin >= row_end) {
+                break;
+            }
+            double* accumulators =
+                thread_accumulators.data() +
+                static_cast<std::size_t>(thread_index) * static_cast<std::size_t>(N);
+            workers.emplace_back(compute_rows, row_begin, row_end, accumulators);
+        }
+    } catch (...) {
+        for (auto& worker : workers) {
+            worker.join();
+        }
+        throw;
+    }
+    for (auto& worker : workers) {
+        worker.join();
     }
 }
 
@@ -924,11 +990,11 @@ void WanPipeline::init_vae_caches() {
     const int32_t num_caches = config_.num_vae_caches;
     auto out_infos = vae_->output_info();
 
-    // We need a stream for DeviceTensor operations — get it from the VAE module
-    // by querying the device pointer (which implicitly gives us a usable device).
-    // DeviceTensor needs a cudaStream_t; we create a dedicated one.
-    cudaStream_t cache_stream = nullptr;
-    cudaStreamCreate(&cache_stream);
+    // Cache initialization, VAE execution, and cache_out -> cache_in copies must
+    // share a stream. Using a separate stream here leaves the asynchronous
+    // memset/copies unordered relative to the VAE enqueue and makes consecutive
+    // generations nondeterministic.
+    const cudaStream_t cache_stream = vae_->stream();
 
     for (int32_t ci = 0; ci < num_caches; ++ci) {
         const std::string cache_out_name = "cache_out_" + std::to_string(ci);
@@ -962,14 +1028,6 @@ void WanPipeline::init_vae_caches() {
     vae_caches_initialized_ = true;
 
     std::cerr << "[diffusion] VAE caches initialized: " << vae_cache_in_.size() << " cache pairs\n";
-
-    // Clean up the stream (DeviceTensors store a copy)
-    // Note: DeviceTensor operations are async on their stored stream.
-    // We keep the stream alive since DeviceTensors reference it.
-    // Actually, DeviceTensors keep a copy of the stream handle, so we
-    // must NOT destroy it. Store it as a shared_ptr via keep_alive.
-    auto stream_deleter = [](void* s) { cudaStreamDestroy(static_cast<cudaStream_t>(s)); };
-    vae_->keep_alive(std::shared_ptr<void>(cache_stream, stream_deleter));
 }
 
 void WanPipeline::zero_vae_caches() {


### PR DESCRIPTION
## Background

Wan2.1 T2V spent most of its L0 request latency in host-side preprocessing rather than TensorRT engine execution. On the GB300 benchmark workload (384x672, 5 frames, 15 steps), the frozen runtime averaged about 8.3 s locally while the three engines accounted for about 0.30 s per request.

## Exit Criteria

- Preserve the frozen runtime's output checksum and pixel statistics across repeated generation.
- Beat both Hugging Face eager and the valid `torch.compile` comparator under one fixed, NVIDIA-aligned benchmark contract.
- Keep threading and linkage model-scoped and portable.

## Implementation

- Reorder the Wan CPU matmul loop for contiguous weight access while retaining ascending-`k` double-precision reduction for every output.
- Split only large independent output rows across a bounded worker set (16 by default, configurable with `TRTMC_WAN_CPU_GEMM_THREADS`).
- Declare `Threads::Threads` through the Wan model manifest.
- Run VAE cache initialization and cache copies on the VAE module stream. The faster host path exposed an existing cross-stream race; ordering these operations restored deterministic repeated output.

## Validation

The controlled GB300 workload used an FP16 TRTMC build and requested `torch_dtype=float16` for Hugging Face (with required FP32 parameters retained), at 384x672, 5 frames, 15 steps, seed 42, concurrency 1, 3 warmups, 10 measured requests, explicit CUDA synchronization, exclusive GPU locks, and stable observed clocks.

| Backend | Warm mean | p90 | CV | Relative result |
| --- | ---: | ---: | ---: | --- |
| Hugging Face eager | 1.4016 s | 1.4237 s | 1.40% | baseline |
| `torch.compile`, `max-autotune-no-cudagraphs` | 0.5994 s | 0.6059 s | 1.34% | 2.338x faster than eager |
| TensorRT-Model-Connect | 0.4643 s | 0.4720 s | 1.14% | 3.019x faster than eager; 1.291x faster than compiled |

- The optimized runtime reproduced the frozen TRTMC checksum and final pixel statistics on all 10 measured requests.
- The eager-versus-compiled full-frame comparison measured 55.93 dB global PSNR and 0.999974 mean per-frame SSIM.
- Canonical `torch.compile(mode="max-autotune")` failed before its first output because Wan classifier-free guidance invoked the transformer twice and the second CUDA-graph call overwrote the first output. The table therefore names the successful no-CUDA-graphs fallback explicitly; its first compiled request took 196.69 s.
- [Premerge CI at `9c6bda9d`](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29128560731): all checks passed, including the Wan model proof.
- `ctest --test-dir build -R '^test_wan_(pipeline|c_abi_runtime_regression)$' --output-on-failure`: 2/2 passed from a clean archive of this commit.
- `python -m pytest tests/tools/test_model_plugin_encapsulation_static.py -q`: 156 passed.
- `clang-format --dry-run --Werror src/runtime/models/wan/pipeline.cpp`: passed.

## Notes For Future Readers

- These are GB300 L0 measurements, not Jetson Thor measurements. Thor still requires a compatible TensorRT 11.x stack, native engine builds, and on-device latency, memory, power, and quality validation.
- The compiled comparison is `max-autotune-no-cudagraphs`, not canonical `max-autotune`; keep that distinction in future performance claims.
- Start review with the matmul reduction order in `pipeline.cpp`, then the VAE stream ordering, then the manifest/CMake linkage change.
