### PR TITLE
fix(canary): restore source quality checks

### DIFF
--- a/.github/scripts/run-trtmc-ci.sh
+++ b/.github/scripts/run-trtmc-ci.sh
@@ -1945,6 +1945,10 @@ run_stage() {
       run_step "Setup TensorRT-Model-Connect source checks" setup_source_check_environment
       run_step "Lint changed files" lint_changed_files
       ;;
+    source-quality)
+      run_step "Check cyclomatic complexity" check_cyclomatic_complexity
+      run_step "Lint changed files" lint_changed_files
+      ;;
     cpp-unit)
       run_step "Setup TensorRT-Model-Connect source checks" setup_source_check_environment
       run_step "C++ unit tests" run_cpp_unit_tests

--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -210,6 +210,36 @@ jobs:
             echo "- Unit scope: \`$UNIT_SCOPE\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  source-quality:
+    name: Source quality
+    needs: legal
+    if: ${{ needs.legal.outputs.authorized == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      CI_BASE_REF: ${{ needs.legal.outputs.base_sha }}
+
+    steps:
+      - name: Check out pinned merge snapshot
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.legal.outputs.tested_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install source quality tools
+        run: python -m pip install --disable-pip-version-check --quiet lizard ruff clang-format
+
+      - name: Check source quality
+        run: bash .github/scripts/run-trtmc-ci.sh source-quality
+
   unit-tests:
     name: 3 / Unit / C++ and Python
     needs:
@@ -614,6 +644,7 @@ jobs:
     needs:
       - legal
       - impact
+      - source-quality
       - unit-tests
       - model-proof
       - no-model
@@ -630,6 +661,7 @@ jobs:
           TESTED_SHA: ${{ needs.legal.outputs.tested_sha }}
           LEGAL_RESULT: ${{ needs.legal.result }}
           IMPACT_RESULT: ${{ needs.impact.result }}
+          SOURCE_QUALITY_RESULT: ${{ needs.source-quality.result }}
           UNIT_RESULT: ${{ needs.unit-tests.result }}
           RUN_UNIT_TESTS: ${{ needs.impact.outputs.run_unit_tests }}
           MODEL_RESULT: ${{ needs.model-proof.result }}
@@ -657,6 +689,10 @@ jobs:
           test -n "$TESTED_SHA"
           test "$IMPACT_RESULT" = "success" || {
             echo "::error::Ownership and impact result: $IMPACT_RESULT"
+            exit 1
+          }
+          test "$SOURCE_QUALITY_RESULT" = "success" || {
+            echo "::error::Source quality result: $SOURCE_QUALITY_RESULT"
             exit 1
           }
           case "$RUN_UNIT_TESTS" in

--- a/src/runtime/models/canary/canary_decode_policy.h
+++ b/src/runtime/models/canary/canary_decode_policy.h
@@ -62,6 +62,104 @@ struct CanaryBeamHypothesis {
     bool finished{false};
 };
 
+inline double canary_log_normalizer(const std::vector<float>& logits) {
+    const float max_logit = *std::max_element(logits.begin(), logits.end());
+    double exp_sum = 0.0;
+    for (const float logit : logits) {
+        exp_sum += std::exp(static_cast<double>(logit - max_logit));
+    }
+    return static_cast<double>(max_logit) + std::log(exp_sum);
+}
+
+inline std::vector<int32_t> canary_top_token_indices(const std::vector<float>& logits,
+                                                     int32_t beam_size) {
+    std::vector<int32_t> indices(logits.size());
+    for (std::size_t i = 0; i < indices.size(); ++i) {
+        indices[i] = static_cast<int32_t>(i);
+    }
+    const int32_t top_count = std::min<int32_t>(beam_size, static_cast<int32_t>(indices.size()));
+    std::partial_sort(indices.begin(), indices.begin() + top_count, indices.end(),
+                      [&logits](int32_t lhs, int32_t rhs) {
+                          const float lhs_logit = logits[static_cast<std::size_t>(lhs)];
+                          const float rhs_logit = logits[static_cast<std::size_t>(rhs)];
+                          return lhs_logit == rhs_logit ? lhs < rhs : lhs_logit > rhs_logit;
+                      });
+    indices.resize(static_cast<std::size_t>(top_count));
+    return indices;
+}
+
+inline void append_canary_beam_candidates(const CanaryBeamHypothesis& beam,
+                                          const std::vector<float>& logits, int32_t eot_token_id,
+                                          int32_t beam_size,
+                                          std::vector<CanaryBeamHypothesis>& candidates) {
+    const double log_normalizer = canary_log_normalizer(logits);
+    for (const int32_t token : canary_top_token_indices(logits, beam_size)) {
+        CanaryBeamHypothesis candidate = beam;
+        candidate.output_ids.push_back(token);
+        candidate.score +=
+            static_cast<double>(logits[static_cast<std::size_t>(token)]) - log_normalizer;
+        candidate.finished = token == eot_token_id;
+        candidates.push_back(std::move(candidate));
+    }
+}
+
+template <typename LogitsFn>
+inline bool
+expand_canary_beam(const CanaryBeamHypothesis& beam, const std::vector<int32_t>& initial_tokens,
+                   int32_t eot_token_id, int32_t beam_size, LogitsFn& logits_for_prefix,
+                   std::vector<CanaryBeamHypothesis>& candidates, CanaryDecodeLoopResult& result) {
+    std::vector<int32_t> prefix = initial_tokens;
+    prefix.insert(prefix.end(), beam.output_ids.begin(), beam.output_ids.end());
+    std::vector<float> logits;
+    if (!logits_for_prefix(prefix, logits, result.error)) {
+        result.decode_failed = true;
+        return false;
+    }
+    if (logits.empty()) {
+        result.decode_failed = true;
+        result.error = "Canary beam search received empty logits";
+        return false;
+    }
+    append_canary_beam_candidates(beam, logits, eot_token_id, beam_size, candidates);
+    return true;
+}
+
+template <typename LogitsFn>
+inline bool collect_canary_beam_candidates(const std::vector<CanaryBeamHypothesis>& beams,
+                                           const std::vector<int32_t>& initial_tokens,
+                                           int32_t eot_token_id, int32_t beam_size,
+                                           LogitsFn& logits_for_prefix,
+                                           std::vector<CanaryBeamHypothesis>& candidates,
+                                           bool& all_finished, CanaryDecodeLoopResult& result) {
+    all_finished = true;
+    for (const auto& beam : beams) {
+        if (beam.finished) {
+            candidates.push_back(beam);
+            continue;
+        }
+        all_finished = false;
+        if (!expand_canary_beam(beam, initial_tokens, eot_token_id, beam_size, logits_for_prefix,
+                                candidates, result)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+inline void rank_canary_beam_candidates(std::vector<CanaryBeamHypothesis>& candidates,
+                                        int32_t beam_size) {
+    std::stable_sort(candidates.begin(), candidates.end(),
+                     [](const CanaryBeamHypothesis& lhs, const CanaryBeamHypothesis& rhs) {
+                         if (lhs.score != rhs.score) {
+                             return lhs.score > rhs.score;
+                         }
+                         return lhs.output_ids < rhs.output_ids;
+                     });
+    if (candidates.size() > static_cast<std::size_t>(beam_size)) {
+        candidates.resize(static_cast<std::size_t>(beam_size));
+    }
+}
+
 template <typename LogitsFn>
 inline CanaryDecodeLoopResult
 run_canary_beam_search(const std::vector<int32_t>& initial_tokens, int32_t max_new_tokens,
@@ -73,71 +171,22 @@ run_canary_beam_search(const std::vector<int32_t>& initial_tokens, int32_t max_n
     std::vector<CanaryBeamHypothesis> beams(1);
     for (int32_t step = 0; step < max_new_tokens; ++step) {
         std::vector<CanaryBeamHypothesis> candidates;
-        bool all_finished = true;
-        for (const auto& beam : beams) {
-            if (beam.finished) {
-                candidates.push_back(beam);
-                continue;
-            }
-            all_finished = false;
-            std::vector<int32_t> prefix = initial_tokens;
-            prefix.insert(prefix.end(), beam.output_ids.begin(), beam.output_ids.end());
-            std::vector<float> logits;
-            if (!logits_for_prefix(prefix, logits, result.error)) {
-                result.decode_failed = true;
-                return result;
-            }
-            if (logits.empty()) {
-                result.decode_failed = true;
-                result.error = "Canary beam search received empty logits";
-                return result;
-            }
-
-            const float max_logit = *std::max_element(logits.begin(), logits.end());
-            double exp_sum = 0.0;
-            for (const float logit : logits)
-                exp_sum += std::exp(static_cast<double>(logit - max_logit));
-            const double log_normalizer = static_cast<double>(max_logit) + std::log(exp_sum);
-
-            std::vector<int32_t> indices(logits.size());
-            for (std::size_t i = 0; i < indices.size(); ++i)
-                indices[i] = static_cast<int32_t>(i);
-            const int32_t top_count =
-                std::min<int32_t>(beam_size, static_cast<int32_t>(indices.size()));
-            std::partial_sort(
-                indices.begin(), indices.begin() + top_count, indices.end(),
-                [&logits](int32_t lhs, int32_t rhs) {
-                    const float lhs_logit = logits[static_cast<std::size_t>(lhs)];
-                    const float rhs_logit = logits[static_cast<std::size_t>(rhs)];
-                    return lhs_logit == rhs_logit ? lhs < rhs : lhs_logit > rhs_logit;
-                });
-            for (int32_t i = 0; i < top_count; ++i) {
-                const int32_t token = indices[static_cast<std::size_t>(i)];
-                CanaryBeamHypothesis candidate = beam;
-                candidate.output_ids.push_back(token);
-                candidate.score += static_cast<double>(logits[static_cast<std::size_t>(token)]) -
-                                   log_normalizer;
-                candidate.finished = token == eot_token_id;
-                candidates.push_back(std::move(candidate));
-            }
+        bool all_finished = false;
+        if (!collect_canary_beam_candidates(beams, initial_tokens, eot_token_id, beam_size,
+                                            logits_for_prefix, candidates, all_finished, result)) {
+            return result;
         }
-        if (all_finished)
+        if (all_finished) {
             break;
+        }
 
-        std::stable_sort(candidates.begin(), candidates.end(),
-                         [](const CanaryBeamHypothesis& lhs,
-                            const CanaryBeamHypothesis& rhs) {
-                             if (lhs.score != rhs.score)
-                                 return lhs.score > rhs.score;
-                             return lhs.output_ids < rhs.output_ids;
-                         });
-        if (candidates.size() > static_cast<std::size_t>(beam_size))
-            candidates.resize(static_cast<std::size_t>(beam_size));
+        rank_canary_beam_candidates(candidates, beam_size);
         beams = std::move(candidates);
     }
 
-    if (!beams.empty())
+    if (!beams.empty()) {
         result.output_ids = std::move(beams.front().output_ids);
+    }
     return result;
 }
 

--- a/src/runtime/models/canary/canary_request.h
+++ b/src/runtime/models/canary/canary_request.h
@@ -15,6 +15,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace trtmc {
@@ -32,8 +33,8 @@ inline int32_t canary_token_id(const ITokenizer* tokenizer, std::string_view tok
 
 inline int32_t canary_language_token_id(const CanaryConfig& model, const ITokenizer* tokenizer,
                                         const std::string& language) {
-    const auto it = std::find(model.supported_languages.begin(), model.supported_languages.end(),
-                              language);
+    const auto it =
+        std::find(model.supported_languages.begin(), model.supported_languages.end(), language);
     if (it != model.supported_languages.end()) {
         const auto index = static_cast<std::size_t>(it - model.supported_languages.begin());
         if (index < model.language_token_ids.size())
@@ -46,14 +47,17 @@ inline int32_t canary_language_token_id(const CanaryConfig& model, const ITokeni
     return tokenizer->id_for_token("<|" + language + "|>");
 }
 
-inline void validate_canary_request(const CanaryConfig& model, const TranscriptionConfig& request,
-                                    const ITokenizer* tokenizer) {
+inline void validate_canary_output_limits(const CanaryConfig& model,
+                                          const TranscriptionConfig& request) {
     if (request.max_output_tokens <= 0 ||
         (model.max_target_positions > 0 &&
          request.max_output_tokens > model.max_target_positions)) {
         throw std::invalid_argument("Canary max_output_tokens must be in [1, " +
                                     std::to_string(model.max_target_positions) + "]");
     }
+}
+
+inline void validate_canary_request_options(const TranscriptionConfig& request) {
     if (request.beam_size < 1 || request.beam_size > CanaryMaxBeamSize) {
         throw std::invalid_argument("Canary beam_size must be in [1, " +
                                     std::to_string(CanaryMaxBeamSize) + "]");
@@ -65,16 +69,18 @@ inline void validate_canary_request(const CanaryConfig& model, const Transcripti
         request.task != TranscriptionTask::kTranslate) {
         throw std::invalid_argument("Canary task must be kTranscribe or kTranslate");
     }
-    if (request.source_language.empty() ||
-        canary_language_token_id(model, tokenizer, request.source_language) < 0) {
-        throw std::invalid_argument("Canary does not support source language '" +
-                                    request.source_language + "' in this bundle");
+}
+
+inline void validate_canary_language(const CanaryConfig& model, const ITokenizer* tokenizer,
+                                     const std::string& language, std::string_view role) {
+    if (language.empty() || canary_language_token_id(model, tokenizer, language) < 0) {
+        throw std::invalid_argument("Canary does not support " + std::string(role) + " language '" +
+                                    language + "' in this bundle");
     }
-    if (request.target_language.empty() ||
-        canary_language_token_id(model, tokenizer, request.target_language) < 0) {
-        throw std::invalid_argument("Canary does not support target language '" +
-                                    request.target_language + "' in this bundle");
-    }
+}
+
+inline void validate_canary_language_pair(const CanaryConfig& model,
+                                          const TranscriptionConfig& request) {
     if (request.task == TranscriptionTask::kTranscribe &&
         request.source_language != request.target_language) {
         throw std::invalid_argument(
@@ -93,6 +99,9 @@ inline void validate_canary_request(const CanaryConfig& model, const Transcripti
                 "supported language");
         }
     }
+}
+
+inline void validate_canary_durations(const TranscriptionConfig& request) {
     if (!std::isfinite(request.max_input_duration_seconds) ||
         request.max_input_duration_seconds < 0.0F) {
         throw std::invalid_argument(
@@ -100,42 +109,47 @@ inline void validate_canary_request(const CanaryConfig& model, const Transcripti
     }
     if (!std::isfinite(request.segment_duration_seconds) ||
         request.segment_duration_seconds < 0.0F) {
-        throw std::invalid_argument(
-            "Canary segment_duration_seconds must be a finite value >= 0");
+        throw std::invalid_argument("Canary segment_duration_seconds must be a finite value >= 0");
     }
 }
 
-inline std::vector<int32_t> make_canary_request_tokens(const CanaryConfig& model,
-                                                       const TranscriptionConfig& request,
-                                                       const ITokenizer* tokenizer) {
-    validate_canary_request(model, request, tokenizer);
-    std::vector<int32_t> tokens = model.decoder_start_token_ids;
-    if (tokens.empty()) {
-        if (request.source_language != model.language ||
-            request.target_language != model.language || !request.punctuation ||
-            request.timestamps || request.task != TranscriptionTask::kTranscribe) {
-            throw std::invalid_argument(
-                "Canary bundle does not contain configurable decoder prompt metadata; rebuild "
-                "it from the local checkpoint");
-        }
-        return {model.decoder_start_token_id, model.language_token_id,
-                model.transcribe_token_id, model.notimestamps_token_id};
-    }
+inline void validate_canary_request(const CanaryConfig& model, const TranscriptionConfig& request,
+                                    const ITokenizer* tokenizer) {
+    validate_canary_output_limits(model, request);
+    validate_canary_request_options(request);
+    validate_canary_language(model, tokenizer, request.source_language, "source");
+    validate_canary_language(model, tokenizer, request.target_language, "target");
+    validate_canary_language_pair(model, request);
+    validate_canary_durations(request);
+}
 
+inline std::vector<int32_t> make_canary_legacy_request_tokens(const CanaryConfig& model,
+                                                              const TranscriptionConfig& request) {
+    if (request.source_language != model.language || request.target_language != model.language ||
+        !request.punctuation || request.timestamps ||
+        request.task != TranscriptionTask::kTranscribe) {
+        throw std::invalid_argument(
+            "Canary bundle does not contain configurable decoder prompt metadata; rebuild "
+            "it from the local checkpoint");
+    }
+    return {model.decoder_start_token_id, model.language_token_id, model.transcribe_token_id,
+            model.notimestamps_token_id};
+}
+
+inline void validate_canary_prompt_positions(const CanaryConfig& model, std::size_t token_count) {
     const int32_t positions[] = {model.source_language_position, model.target_language_position,
                                  model.punctuation_position, model.timestamp_position};
     for (const int32_t position : positions) {
-        if (position < 0 || static_cast<std::size_t>(position) >= tokens.size()) {
+        if (position < 0 || static_cast<std::size_t>(position) >= token_count) {
             throw std::invalid_argument(
                 "Canary bundle prompt metadata is incompatible with configurable decoding");
         }
     }
+}
 
-    tokens[static_cast<std::size_t>(model.source_language_position)] =
-        canary_language_token_id(model, tokenizer, request.source_language);
-    tokens[static_cast<std::size_t>(model.target_language_position)] =
-        canary_language_token_id(model, tokenizer, request.target_language);
-
+inline std::pair<int32_t, int32_t>
+canary_output_control_token_ids(const CanaryConfig& model, const TranscriptionConfig& request,
+                                const ITokenizer* tokenizer) {
     const int32_t punctuation_id = canary_token_id(
         tokenizer, request.punctuation ? "<|pnc|>" : "<|nopnc|>",
         request.punctuation ? model.punctuation_token_id : model.no_punctuation_token_id);
@@ -146,6 +160,27 @@ inline std::vector<int32_t> make_canary_request_tokens(const CanaryConfig& model
         throw std::invalid_argument(
             "Canary bundle tokenizer is missing punctuation or timestamp control tokens");
     }
+    return {punctuation_id, timestamp_id};
+}
+
+inline std::vector<int32_t> make_canary_request_tokens(const CanaryConfig& model,
+                                                       const TranscriptionConfig& request,
+                                                       const ITokenizer* tokenizer) {
+    validate_canary_request(model, request, tokenizer);
+    std::vector<int32_t> tokens = model.decoder_start_token_ids;
+    if (tokens.empty()) {
+        return make_canary_legacy_request_tokens(model, request);
+    }
+
+    validate_canary_prompt_positions(model, tokens.size());
+
+    tokens[static_cast<std::size_t>(model.source_language_position)] =
+        canary_language_token_id(model, tokenizer, request.source_language);
+    tokens[static_cast<std::size_t>(model.target_language_position)] =
+        canary_language_token_id(model, tokenizer, request.target_language);
+
+    const auto [punctuation_id, timestamp_id] =
+        canary_output_control_token_ids(model, request, tokenizer);
     tokens[static_cast<std::size_t>(model.punctuation_position)] = punctuation_id;
     tokens[static_cast<std::size_t>(model.timestamp_position)] = timestamp_id;
     return tokens;

--- a/src/runtime/models/canary/pipeline.cpp
+++ b/src/runtime/models/canary/pipeline.cpp
@@ -16,8 +16,8 @@
 #include "trtmc/tokenizer.h"
 #include "utils/wav_reader.h"
 
-#include <chrono>
 #include <cctype>
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -52,17 +52,25 @@ struct CanaryStageTimestamps {
     CanaryClock::time_point tokenize_end;
 };
 
+bool is_canary_control_token_start(const std::string& text, std::size_t position) {
+    return text[position] == '<' && position + 1 < text.size() && text[position + 1] == '|';
+}
+
+bool is_canary_control_token_end(const std::string& text, std::size_t position) {
+    return text[position] == '>' && position > 0 && text[position - 1] == '|';
+}
+
 std::string remove_punctuation_outside_control_tokens(const std::string& text) {
     std::string cleaned;
     cleaned.reserve(text.size());
     bool in_control_token = false;
     for (std::size_t i = 0; i < text.size(); ++i) {
         const unsigned char ch = static_cast<unsigned char>(text[i]);
-        if (!in_control_token && ch == '<' && i + 1 < text.size() && text[i + 1] == '|')
+        if (!in_control_token && is_canary_control_token_start(text, i))
             in_control_token = true;
         if (in_control_token || std::ispunct(ch) == 0)
             cleaned.push_back(static_cast<char>(ch));
-        if (in_control_token && ch == '>' && i > 0 && text[i - 1] == '|')
+        if (in_control_token && is_canary_control_token_end(text, i))
             in_control_token = false;
     }
     return cleaned;
@@ -82,6 +90,88 @@ void report_canary_stage_timing(bool enabled, const CanaryStageTimestamps& times
            << ",\"total_ms\":" << elapsed_ms(timestamps.transcribe_start, timestamps.tokenize_end)
            << '}';
     std::cerr << timing.str() << std::endl;
+}
+
+void validate_canary_audio_input(const float* audio_data, int32_t num_samples) {
+    if (audio_data == nullptr || num_samples <= 0) {
+        throw std::invalid_argument("Canary transcription requires non-empty audio samples");
+    }
+}
+
+void validate_canary_output_budget(const CanaryConfig& model, const TranscriptionConfig& cfg,
+                                   std::size_t prompt_tokens) {
+    const int32_t available_output_tokens =
+        model.max_target_positions - static_cast<int32_t>(prompt_tokens);
+    if (available_output_tokens <= 0 || cfg.max_output_tokens > available_output_tokens) {
+        throw std::invalid_argument("Canary max_output_tokens must be in [1, " +
+                                    std::to_string(std::max(available_output_tokens, 0)) +
+                                    "] after accounting for the decoder prompt");
+    }
+}
+
+double validate_canary_input_duration(int32_t num_samples, int32_t sample_rate,
+                                      const TranscriptionConfig& cfg) {
+    const double duration_seconds =
+        static_cast<double>(num_samples) / static_cast<double>(sample_rate);
+    if (cfg.max_input_duration_seconds > 0.0F &&
+        duration_seconds > static_cast<double>(cfg.max_input_duration_seconds) + 1.0e-6) {
+        throw std::invalid_argument("Canary input duration " + std::to_string(duration_seconds) +
+                                    " seconds exceeds max_input_duration_seconds=" +
+                                    std::to_string(cfg.max_input_duration_seconds));
+    }
+    return duration_seconds;
+}
+
+double resolve_canary_segment_duration(double input_duration_seconds, double model_segment_seconds,
+                                       const TranscriptionConfig& cfg) {
+    const double segment_seconds = cfg.segment_duration_seconds > 0.0F
+                                       ? static_cast<double>(cfg.segment_duration_seconds)
+                                       : model_segment_seconds;
+    if (segment_seconds <= 0.0 || segment_seconds > model_segment_seconds) {
+        throw std::invalid_argument(
+            "Canary segment_duration_seconds must be > 0 and <= the bundle limit of " +
+            std::to_string(model_segment_seconds) + " seconds");
+    }
+    if (cfg.segment_duration_seconds <= 0.0F && input_duration_seconds > model_segment_seconds) {
+        throw std::invalid_argument(
+            "Canary input exceeds the bundle's single-segment limit of " +
+            std::to_string(model_segment_seconds) +
+            " seconds; set segment_duration_seconds to enable segmented decoding");
+    }
+    return segment_seconds;
+}
+
+int32_t canary_segment_sample_count(double segment_seconds, int32_t sample_rate) {
+    const int64_t segment_samples =
+        static_cast<int64_t>(std::llround(segment_seconds * static_cast<double>(sample_rate)));
+    if (segment_samples <= 0 || segment_samples > std::numeric_limits<int32_t>::max()) {
+        throw std::invalid_argument("Canary segment duration produces an invalid sample count");
+    }
+    return static_cast<int32_t>(segment_samples);
+}
+
+void append_canary_transcription_segment(TextResult& combined, TextResult segment, int64_t offset,
+                                         int32_t count, int32_t sample_rate,
+                                         const TranscriptionConfig& cfg) {
+    if (!cfg.punctuation) {
+        segment.text = remove_punctuation_outside_control_tokens(segment.text);
+    }
+    if (cfg.timestamps) {
+        TranscriptionSegment timed;
+        timed.start_seconds = static_cast<double>(offset) / static_cast<double>(sample_rate);
+        timed.end_seconds = static_cast<double>(offset + count) / static_cast<double>(sample_rate);
+        timed.text = segment.text;
+        timed.token_ids = segment.token_ids;
+        combined.segments.push_back(std::move(timed));
+    }
+    if (!combined.text.empty() && !segment.text.empty()) {
+        combined.text += '\n';
+    }
+    combined.text += segment.text;
+    combined.token_ids.insert(combined.token_ids.end(), segment.token_ids.begin(),
+                              segment.token_ids.end());
+    combined.prefill_ms += segment.prefill_ms;
+    combined.decode_ms += segment.decode_ms;
 }
 
 } // namespace
@@ -151,51 +241,18 @@ TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_sampl
 
 TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_samples,
                                       const TranscriptionConfig& cfg) {
-    if (audio_data == nullptr || num_samples <= 0)
-        throw std::invalid_argument("Canary transcription requires non-empty audio samples");
+    validate_canary_audio_input(audio_data, num_samples);
 
     auto initial_tokens = make_canary_request_tokens(canary_config_, cfg, tokenizer_.get());
-    const int32_t available_output_tokens =
-        canary_config_.max_target_positions - static_cast<int32_t>(initial_tokens.size());
-    if (available_output_tokens <= 0 || cfg.max_output_tokens > available_output_tokens) {
-        throw std::invalid_argument("Canary max_output_tokens must be in [1, " +
-                                    std::to_string(std::max(available_output_tokens, 0)) +
-                                    "] after accounting for the decoder prompt");
-    }
+    validate_canary_output_budget(canary_config_, cfg, initial_tokens.size());
 
-    const int32_t sample_rate = cfg.input_sample_rate > 0 ? cfg.input_sample_rate
-                                                          : mel_sampling_rate_;
-    const double duration_seconds =
-        static_cast<double>(num_samples) / static_cast<double>(sample_rate);
-    if (cfg.max_input_duration_seconds > 0.0F &&
-        duration_seconds > static_cast<double>(cfg.max_input_duration_seconds) + 1.0e-6) {
-        throw std::invalid_argument(
-            "Canary input duration " + std::to_string(duration_seconds) +
-            " seconds exceeds max_input_duration_seconds=" +
-            std::to_string(cfg.max_input_duration_seconds));
-    }
-
+    const int32_t sample_rate =
+        cfg.input_sample_rate > 0 ? cfg.input_sample_rate : mel_sampling_rate_;
+    const double duration_seconds = validate_canary_input_duration(num_samples, sample_rate, cfg);
     const double model_segment_seconds = static_cast<double>(mel_chunk_length_);
-    double segment_seconds = static_cast<double>(cfg.segment_duration_seconds);
-    if (segment_seconds <= 0.0)
-        segment_seconds = model_segment_seconds;
-    if (segment_seconds <= 0.0 || segment_seconds > model_segment_seconds) {
-        throw std::invalid_argument(
-            "Canary segment_duration_seconds must be > 0 and <= the bundle limit of " +
-            std::to_string(model_segment_seconds) + " seconds");
-    }
-    if (cfg.segment_duration_seconds <= 0.0F && duration_seconds > model_segment_seconds) {
-        throw std::invalid_argument(
-            "Canary input exceeds the bundle's single-segment limit of " +
-            std::to_string(model_segment_seconds) +
-            " seconds; set segment_duration_seconds to enable segmented decoding");
-    }
-
-    const int64_t segment_samples_64 =
-        static_cast<int64_t>(std::llround(segment_seconds * static_cast<double>(sample_rate)));
-    if (segment_samples_64 <= 0 || segment_samples_64 > std::numeric_limits<int32_t>::max())
-        throw std::invalid_argument("Canary segment duration produces an invalid sample count");
-    const int32_t segment_samples = static_cast<int32_t>(segment_samples_64);
+    const double segment_seconds =
+        resolve_canary_segment_duration(duration_seconds, model_segment_seconds, cfg);
+    const int32_t segment_samples = canary_segment_sample_count(segment_seconds, sample_rate);
 
     TextResult combined;
     for (int64_t offset = 0; offset < num_samples; offset += segment_samples) {
@@ -203,25 +260,8 @@ TextResult CanaryPipeline::transcribe(const float* audio_data, int32_t num_sampl
             std::min<int64_t>(segment_samples, static_cast<int64_t>(num_samples) - offset));
         auto segment = transcribe_segment(audio_data + offset, count, sample_rate, initial_tokens,
                                           cfg.max_output_tokens, cfg.beam_size);
-        if (!cfg.punctuation)
-            segment.text = remove_punctuation_outside_control_tokens(segment.text);
-        if (cfg.timestamps) {
-            TranscriptionSegment timed;
-            timed.start_seconds =
-                static_cast<double>(offset) / static_cast<double>(sample_rate);
-            timed.end_seconds =
-                static_cast<double>(offset + count) / static_cast<double>(sample_rate);
-            timed.text = segment.text;
-            timed.token_ids = segment.token_ids;
-            combined.segments.push_back(std::move(timed));
-        }
-        if (!combined.text.empty() && !segment.text.empty())
-            combined.text += '\n';
-        combined.text += segment.text;
-        combined.token_ids.insert(combined.token_ids.end(), segment.token_ids.begin(),
-                                  segment.token_ids.end());
-        combined.prefill_ms += segment.prefill_ms;
-        combined.decode_ms += segment.decode_ms;
+        append_canary_transcription_segment(combined, std::move(segment), offset, count,
+                                            sample_rate, cfg);
     }
     return combined;
 }

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -492,6 +492,39 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     assert 'test "$REPORT_RESULT" = "success"' in required
 
 
+def test_premerge_ci_requires_gpu_free_source_quality() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/trtmc-ci.yml").read_text()
+    source_quality = workflow.split("\n  source-quality:", maxsplit=1)[1].split(
+        "\n  unit-tests:", maxsplit=1
+    )[0]
+    required = workflow.split("\n  required:", maxsplit=1)[1]
+    stage = (REPO_ROOT / ".github/scripts/run-trtmc-ci.sh").read_text()
+    source_quality_stage = stage.split("    source-quality)", maxsplit=1)[1].split(
+        "      ;;", maxsplit=1
+    )[0]
+
+    assert "name: Source quality" in source_quality
+    assert "needs: legal" in source_quality
+    assert "needs.legal.outputs.authorized == 'true'" in source_quality
+    assert "runs-on: ubuntu-latest" in source_quality
+    assert "CI_BASE_REF: ${{ needs.legal.outputs.base_sha }}" in source_quality
+    assert "ref: ${{ needs.legal.outputs.tested_sha }}" in source_quality
+    assert "fetch-depth: 0" in source_quality
+    assert "actions/setup-python@v5" in source_quality
+    assert "pip install --disable-pip-version-check --quiet lizard ruff clang-format" in source_quality
+    assert "bash .github/scripts/run-trtmc-ci.sh source-quality" in source_quality
+    assert "self-hosted" not in source_quality
+    assert "docker" not in source_quality.lower()
+    assert "cuda" not in source_quality.lower()
+
+    assert 'run_step "Check cyclomatic complexity" check_cyclomatic_complexity' in source_quality_stage
+    assert 'run_step "Lint changed files" lint_changed_files' in source_quality_stage
+
+    assert "- source-quality" in required
+    assert "SOURCE_QUALITY_RESULT: ${{ needs.source-quality.result }}" in required
+    assert 'test "$SOURCE_QUALITY_RESULT" = "success"' in required
+
+
 def test_premerge_report_bootstrap_names_upstream_failure_before_checkout(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Background

PR #443 added configurable Canary decoding, but the nightly source-quality stage found five Canary functions above the repository's CCN limit of 10. The premerge workflow did not run complexity or changed-file formatting checks, so those failures reached `main` before nightly detected them.

## Exit Criteria

- Canary source has no function above CCN 10.
- Existing Canary request and beam-search behavior remains covered by host-only tests.
- Premerge runs complexity, Ruff, and clang-format checks without a GPU runner.
- The final `Premerge CI` gate fails when source quality fails.

## Implementation

- Split Canary request validation, prompt construction, beam expansion, segment planning, and result assembly into focused helpers.
- Added a `source-quality` CI stage that runs the existing complexity and changed-file lint functions.
- Added a GitHub-hosted Ubuntu `Source quality` job and made it a dependency of the final required gate.
- Added a workflow contract test covering runner choice, tools, checkout refs, stage dispatch, and required-gate wiring.

## Validation

- `CI_BASE_REF=github/main bash .github/scripts/run-trtmc-ci.sh source-quality`
- `python3 -m pytest -q tests/tools/test_github_actions_ci.py` (59 passed)
- Built and ran `test_canary_decode_policy` and `test_canary_host_plan` with host `g++`.
- `g++ -std=c++17 -fsyntax-only ... src/runtime/models/canary/pipeline.cpp`
- `python3 tools/legal_headers.py --check`
- `bash -n .github/scripts/run-trtmc-ci.sh`

## Notes

The new job uses `ubuntu-latest` and does not invoke Docker, CUDA, or a self-hosted/GPU runner. It runs only for the one-shot authorized `run-ci` path, while unrelated labels retain the existing ignored-label behavior.
