### PR TITLE
ci: make GPU lease queue event-driven via chained blocking flocks

### DIFF
--- a/.github/scripts/run-model-proof.sh
+++ b/.github/scripts/run-model-proof.sh
@@ -20,9 +20,26 @@ proof_gpu_reservation_file=""
 proof_gpu_allocator_fd=""
 proof_gpu_admission_fd=""
 proof_gpu_admission_file=""
+proof_gpu_predecessor_fd=""
+proof_gpu_predecessor_file=""
 declare -a proof_gpu_slot_ids=()
 declare -a proof_gpu_lease_fds=()
 declare -a proof_gpu_lease_files=()
+
+# Lock-directory file protocol (cross-version contract).
+#
+# Different script revisions share one lock directory on a runner while old
+# and new premerge branches overlap, so the names below and their flock
+# semantics must never change in place. A protocol change requires a new
+# lock-directory generation (for example a gpu-locks-v2 directory) so mixed
+# revisions never interpret each other's files.
+#
+#   allocator.lock                       short critical-section mutex
+#   admission-<scope>.enqueue.lock       serializes ticket creation
+#   admission-<scope>.next               monotonic ticket counter
+#   admission-<scope>-<20 digits>.lock   FIFO ticket, flocked by its owner
+#   gpu-<id>-reservation.lock            exclusive-proof entry fence
+#   gpu-<id>-slot-<n>.lock               slot lease, held while the proof runs
 
 die() {
   if [ -n "$proof_artifacts_dir" ]; then
@@ -72,7 +89,40 @@ release_proof_gpu_lease() {
     close_dynamic_fd "$proof_gpu_allocator_fd"
     proof_gpu_allocator_fd=""
   fi
+  release_admission_predecessor
   release_gpu_admission_ticket
+}
+
+release_admission_predecessor() {
+  if [ -n "$proof_gpu_predecessor_fd" ]; then
+    flock -u "$proof_gpu_predecessor_fd" >/dev/null 2>&1 || true
+    close_dynamic_fd "$proof_gpu_predecessor_fd"
+  fi
+  proof_gpu_predecessor_fd=""
+  proof_gpu_predecessor_file=""
+}
+
+# Block on an already-open fd until its flock is acquired or the deadline
+# passes. Waits in bounded chunks: even if a wakeup were ever lost, the
+# watchdog re-check bounds the extra sleep to one chunk instead of the whole
+# lease timeout. flock exits nonzero on both timeout and interruption; the
+# loop retries either way and the deadline bounds the total wait.
+# Returns 0 once locked and 1 on deadline.
+blocking_flock() {
+  local fd="$1"
+  local deadline="$2"
+  local watchdog="${TRTMC_MODEL_PROOF_FLOCK_WATCHDOG_SECONDS:-30}"
+  [[ "$watchdog" =~ ^[1-9][0-9]*$ ]] || watchdog=30
+  local remaining chunk
+  while true; do
+    remaining=$((deadline - SECONDS))
+    [ "$remaining" -ge 1 ] || return 1
+    chunk="$remaining"
+    [ "$chunk" -le "$watchdog" ] || chunk="$watchdog"
+    if flock -w "$chunk" -x "$fd"; then
+      return 0
+    fi
+  done
 }
 
 acquire_gpu_admission_ticket() {
@@ -81,12 +131,10 @@ acquire_gpu_admission_ticket() {
   local deadline="$3"
   [ -z "$proof_gpu_admission_fd" ] || return 0
 
-  local remaining=$((deadline - SECONDS))
-  [ "$remaining" -gt 0 ] || return 1
   local enqueue_fd enqueue_file="$lock_dir/admission-$scope.enqueue.lock"
   exec {enqueue_fd}>"$enqueue_file" || \
     die "could not open GPU admission enqueue lock: $enqueue_file"
-  if ! flock -w "$remaining" -x "$enqueue_fd"; then
+  if ! blocking_flock "$enqueue_fd" "$deadline"; then
     close_dynamic_fd "$enqueue_fd"
     return 1
   fi
@@ -148,16 +196,25 @@ acquire_gpu_admission_ticket() {
   close_dynamic_fd "$enqueue_fd"
 }
 
-gpu_admission_ticket_has_turn() {
+# Find the youngest live ticket older than ours and keep an fd open on it.
+# The fd is opened while the allocator mutex is held, before the owner could
+# release the ticket, so a wakeup cannot be lost: if the owner finishes right
+# after this scan, blocking on the pinned inode succeeds immediately. Stale
+# tickets (crashed owners hold no flock) are pruned along the way. On return
+# proof_gpu_predecessor_fd is empty when the queue head is ours.
+# Returns 0 on a completed scan and 1 when the deadline passed.
+locate_admission_predecessor() {
   local lock_dir="$1"
   local scope="$2"
-  local ticket_file ticket_fd
-  acquire_gpu_allocator_mutex "$lock_dir" || return 1
+  local deadline="$3"
+  local ticket_file ticket_fd found_self=0
+  release_admission_predecessor
+  acquire_gpu_allocator_mutex "$lock_dir" "$deadline" || return 1
   for ticket_file in "$lock_dir"/"admission-$scope-"*.lock; do
     [ -e "$ticket_file" ] || continue
     if [ "$ticket_file" = "$proof_gpu_admission_file" ]; then
-      release_gpu_allocator_mutex
-      return 0
+      found_self=1
+      break
     fi
     if ! exec {ticket_fd}<"$ticket_file"; then
       continue
@@ -173,12 +230,39 @@ gpu_admission_ticket_has_turn() {
       close_dynamic_fd "$ticket_fd"
       continue
     fi
-    close_dynamic_fd "$ticket_fd"
-    release_gpu_allocator_mutex
-    return 1
+    # A live older ticket. Keep only the youngest one seen so far: waiting on
+    # the immediate predecessor forms a chain in which every release wakes
+    # exactly one successor instead of the whole queue.
+    release_admission_predecessor
+    proof_gpu_predecessor_fd="$ticket_fd"
+    proof_gpu_predecessor_file="$ticket_file"
   done
+  if [ "$found_self" -ne 1 ]; then
+    release_admission_predecessor
+    release_gpu_allocator_mutex
+    die "GPU admission ticket disappeared before service: $proof_gpu_admission_file"
+  fi
   release_gpu_allocator_mutex
-  die "GPU admission ticket disappeared before service: $proof_gpu_admission_file"
+  return 0
+}
+
+# Event-driven FIFO wait: block directly on the immediate predecessor's
+# ticket flock. The kernel wakes us the moment that owner is served or dies;
+# then rescan, because an older ticket may still be live. Returns 0 at the
+# queue head and 1 on deadline.
+wait_for_gpu_admission_turn() {
+  local lock_dir="$1"
+  local scope="$2"
+  local deadline="$3"
+  while true; do
+    locate_admission_predecessor "$lock_dir" "$scope" "$deadline" || return 1
+    [ -n "$proof_gpu_predecessor_fd" ] || return 0
+    if ! blocking_flock "$proof_gpu_predecessor_fd" "$deadline"; then
+      release_admission_predecessor
+      return 1
+    fi
+    release_admission_predecessor
+  done
 }
 
 release_gpu_admission_ticket() {
@@ -253,17 +337,42 @@ python_bin() {
   fi
 }
 
+# The allocator mutex guards short scan/acquire critical sections that a
+# healthy system releases within milliseconds. Never block on another lock
+# while holding it; every blocking wait must happen outside the mutex, or
+# the whole allocator stalls. The bounded wait below turns such a bug into a
+# fast loud failure naming the stuck holder instead of a silent stall.
+#
+# The optional deadline clamps the wait so a caller with a nearly expired
+# lease surfaces the regular lease timeout instead of the stuck-mutex error.
+# Returns 0 when locked and 1 when a clamped deadline expired first.
+proof_gpu_allocator_mutex_stall_seconds=10
 acquire_gpu_allocator_mutex() {
   local lock_dir="$1"
+  local deadline="${2:-}"
   local lock_file="$lock_dir/allocator.lock"
-  exec {proof_gpu_allocator_fd}>"$lock_file" || \
-    die "could not open GPU allocator lock: $lock_file"
-  if flock -n -x "$proof_gpu_allocator_fd"; then
-    return 0
+  local wait="$proof_gpu_allocator_mutex_stall_seconds"
+  if [ -n "$deadline" ]; then
+    local remaining=$((deadline - SECONDS))
+    [ "$remaining" -ge 1 ] || return 1
+    [ "$remaining" -ge "$wait" ] || wait="$remaining"
   fi
-  close_dynamic_fd "$proof_gpu_allocator_fd"
-  proof_gpu_allocator_fd=""
-  return 1
+  # Append mode: the path must not be truncated before the lock is ours, or
+  # the current holder's identity below would be wiped mid-diagnosis.
+  exec {proof_gpu_allocator_fd}>>"$lock_file" || \
+    die "could not open GPU allocator lock: $lock_file"
+  if ! flock -w "$wait" -x "$proof_gpu_allocator_fd"; then
+    close_dynamic_fd "$proof_gpu_allocator_fd"
+    proof_gpu_allocator_fd=""
+    if [ "$wait" -lt "$proof_gpu_allocator_mutex_stall_seconds" ]; then
+      return 1
+    fi
+    local holder="unknown"
+    IFS= read -r holder < "$lock_file" 2>/dev/null || holder="unknown"
+    die "GPU allocator mutex was held for over ${proof_gpu_allocator_mutex_stall_seconds}s; critical sections must never block (last holder: ${holder:-unknown})"
+  fi
+  printf 'pid=%s\n' "$$" > "$lock_file" 2>/dev/null || true
+  return 0
 }
 
 release_gpu_allocator_mutex() {
@@ -315,11 +424,12 @@ try_acquire_shared_gpu_slot() {
   local lock_dir="$1"
   local slots_per_gpu="$2"
   local explicit_slot="$3"
-  shift 3
+  local deadline="$4"
+  shift 4
   local -a candidate_gpu_ids=("$@")
   local slot gpu_id reservation_fd reservation_file slot_fd slot_file
 
-  acquire_gpu_allocator_mutex "$lock_dir" || return 1
+  acquire_gpu_allocator_mutex "$lock_dir" "$deadline" || return 1
   for ((slot = 0; slot < slots_per_gpu; slot++)); do
     if [ -n "$explicit_slot" ] && [ "$slot" -ne "$explicit_slot" ]; then
       continue
@@ -357,11 +467,12 @@ try_acquire_shared_gpu_slot() {
 try_reserve_exclusive_gpu() {
   local lock_dir="$1"
   local slots_per_gpu="$2"
-  shift 2
+  local deadline="$3"
+  shift 3
   local -a candidate_gpu_ids=("$@")
   local gpu_id reservation_fd reservation_file
 
-  acquire_gpu_allocator_mutex "$lock_dir" || return 1
+  acquire_gpu_allocator_mutex "$lock_dir" "$deadline" || return 1
 
   # Prefer a GPU that is already idle so an exclusive proof can start without
   # draining shared work. The allocator mutex makes the all-slot attempt atomic.
@@ -403,17 +514,31 @@ try_reserve_exclusive_gpu() {
   return 1
 }
 
-try_finish_exclusive_gpu_lease() {
+# Incrementally lock every slot of the reserved GPU, keeping each slot as it
+# is acquired. The held reservation fences new proofs out, existing holders
+# only ever release, and slots are taken in fixed 0..n-1 order, so this
+# blocking acquisition cannot deadlock. The allocator mutex must NOT be held
+# here: this function waits. Partially acquired slots are released by the
+# regular cleanup path on failure. Returns 0 leased and 1 on deadline.
+drain_reserved_gpu_slots() {
   local lock_dir="$1"
   local slots_per_gpu="$2"
-  [ -n "$proof_gpu_reservation_fd" ] || return 1
-  acquire_gpu_allocator_mutex "$lock_dir" || return 1
-  if try_acquire_all_gpu_slots "$proof_gpu_id" "$lock_dir" "$slots_per_gpu"; then
-    release_gpu_allocator_mutex
-    return 0
-  fi
-  release_gpu_allocator_mutex
-  return 1
+  local deadline="$3"
+  [ -n "$proof_gpu_reservation_fd" ] || \
+    die "cannot drain GPU slots without holding a reservation"
+  local slot slot_fd slot_file
+  for ((slot = 0; slot < slots_per_gpu; slot++)); do
+    slot_file="$lock_dir/gpu-$proof_gpu_id-slot-$slot.lock"
+    exec {slot_fd}>"$slot_file" || die "could not open GPU slot lock: $slot_file"
+    if ! blocking_flock "$slot_fd" "$deadline"; then
+      close_dynamic_fd "$slot_fd"
+      return 1
+    fi
+    proof_gpu_lease_fds+=("$slot_fd")
+    proof_gpu_lease_files+=("$slot_file")
+    proof_gpu_slot_ids+=("$slot")
+  done
+  return 0
 }
 
 select_proof_gpu() {
@@ -435,6 +560,13 @@ select_proof_gpu() {
   local timeout="${TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS:-10800}"
   [[ "$timeout" =~ ^[1-9][0-9]*$ ]] && [ "$timeout" -le 21600 ] || \
     die "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS must be an integer from 1 to 21600"
+  # Only the queue head ever polls for shared capacity (everyone behind it
+  # blocks on a predecessor ticket), so this interval bounds the wake latency
+  # of exactly one process system-wide.
+  local poll_interval="${TRTMC_MODEL_PROOF_POLL_INTERVAL:-0.25}"
+  [[ "$poll_interval" =~ ^[0-9]+(\.[0-9]+)?$ ]] && \
+    [[ ! "$poll_interval" =~ ^0+(\.0+)?$ ]] || \
+    die "TRTMC_MODEL_PROOF_POLL_INTERVAL must be a positive number of seconds"
 
   local lock_dir="${TRTMC_MODEL_PROOF_GPU_LOCK_DIR:-/tmp/trtmc-model-proof-gpu-locks}"
   [ -n "$lock_dir" ] || die "TRTMC_MODEL_PROOF_GPU_LOCK_DIR must not be empty"
@@ -470,26 +602,21 @@ select_proof_gpu() {
   fi
 
   local deadline=$((SECONDS + timeout))
-  local attempted=0 reserve_rc=0
+  local attempted=0 reserve_rc=0 poll_remaining=0
   local admission_scope="global"
-  # Register once in a monotonic queue. Every retry then retains its position
-  # instead of entering a new race in which younger matrix jobs can repeatedly
-  # overtake an older waiter as GPU capacity becomes available.
-  while ! acquire_gpu_admission_ticket "$lock_dir" "$admission_scope" "$deadline"; do
-    if [ "$SECONDS" -ge "$deadline" ]; then
-      die "timed out after ${timeout}s waiting for a ${resource_class} model-proof GPU lease from: ${candidate_gpu_ids[*]}"
-    fi
-    sleep 1
-  done
-  while ! gpu_admission_ticket_has_turn "$lock_dir" "$admission_scope"; do
-    if [ "$SECONDS" -ge "$deadline" ]; then
-      die "timed out after ${timeout}s waiting for a ${resource_class} model-proof GPU lease from: ${candidate_gpu_ids[*]}"
-    fi
-    sleep 1
-  done
-  if [ "$SECONDS" -ge "$deadline" ]; then
+  # Register once in a crash-safe monotonic queue. Every later wait keeps
+  # this position, so younger matrix jobs can never overtake an older waiter
+  # as GPU capacity becomes available.
+  acquire_gpu_admission_ticket "$lock_dir" "$admission_scope" "$deadline" || \
     die "timed out after ${timeout}s waiting for a ${resource_class} model-proof GPU lease from: ${candidate_gpu_ids[*]}"
+  if [ -n "$proof_artifacts_dir" ]; then
+    # Test-only observation point; not part of the lock protocol.
+    mkdir -p -- "$proof_artifacts_dir"
+    printf '%s\n' "${proof_gpu_admission_file##*/}" \
+      > "$proof_artifacts_dir/gpu-queue-joined.txt"
   fi
+  wait_for_gpu_admission_turn "$lock_dir" "$admission_scope" "$deadline" || \
+    die "timed out after ${timeout}s waiting for a ${resource_class} model-proof GPU lease from: ${candidate_gpu_ids[*]}"
   while true; do
     if [ "$attempted" -eq 1 ] && [ "$SECONDS" -ge "$deadline" ]; then
       die "timed out after ${timeout}s waiting for a ${resource_class} model-proof GPU lease from: ${candidate_gpu_ids[*]}"
@@ -498,19 +625,16 @@ select_proof_gpu() {
 
     if [ "$resource_class" = "shared" ]; then
       if try_acquire_shared_gpu_slot \
-          "$lock_dir" "$slots_per_gpu" "$explicit_slot" "${candidate_gpu_ids[@]}"; then
+          "$lock_dir" "$slots_per_gpu" "$explicit_slot" "$deadline" \
+          "${candidate_gpu_ids[@]}"; then
         release_gpu_admission_ticket
         echo "Leased shared model-proof GPU $proof_gpu_id slot ${proof_gpu_slot_ids[0]} via ${proof_gpu_lease_files[0]}"
         return 0
       fi
-    elif [ -n "$proof_gpu_reservation_fd" ]; then
-      if try_finish_exclusive_gpu_lease "$lock_dir" "$slots_per_gpu"; then
-        echo "Leased exclusive model-proof GPU $proof_gpu_id slots ${proof_gpu_slot_ids[*]}"
-        return 0
-      fi
     else
       set +e
-      try_reserve_exclusive_gpu "$lock_dir" "$slots_per_gpu" "${candidate_gpu_ids[@]}"
+      try_reserve_exclusive_gpu \
+        "$lock_dir" "$slots_per_gpu" "$deadline" "${candidate_gpu_ids[@]}"
       reserve_rc=$?
       set -e
       if [ "$reserve_rc" -eq 0 ]; then
@@ -518,10 +642,28 @@ select_proof_gpu() {
         echo "Leased exclusive model-proof GPU $proof_gpu_id slots ${proof_gpu_slot_ids[*]}"
         return 0
       elif [ "$reserve_rc" -eq 2 ]; then
+        # The GPU is reserved: new proofs are fenced out and the remaining
+        # holders only exit. Give up the queue position so the line advances,
+        # then drain the reserved GPU slot by slot, event-driven.
         release_gpu_admission_ticket
+        drain_reserved_gpu_slots "$lock_dir" "$slots_per_gpu" "$deadline" || \
+          die "timed out after ${timeout}s waiting for a ${resource_class} model-proof GPU lease from: ${candidate_gpu_ids[*]}"
+        echo "Leased exclusive model-proof GPU $proof_gpu_id slots ${proof_gpu_slot_ids[*]}"
+        return 0
       fi
     fi
-    sleep 1
+    # Clamp the poll sleep to the remaining lease budget so a large
+    # configured interval can never sleep past the deadline and report a
+    # smaller timeout than the time actually spent.
+    poll_remaining=$((deadline - SECONDS))
+    if [ "$poll_remaining" -lt 1 ]; then
+      continue
+    fi
+    if [ "${poll_interval%%.*}" -ge "$poll_remaining" ] 2>/dev/null; then
+      sleep "$poll_remaining"
+    else
+      sleep "$poll_interval"
+    fi
   done
 }
 

--- a/.github/scripts/run-model-proof.sh
+++ b/.github/scripts/run-model-proof.sh
@@ -112,7 +112,10 @@ blocking_flock() {
   local fd="$1"
   local deadline="$2"
   local watchdog="${TRTMC_MODEL_PROOF_FLOCK_WATCHDOG_SECONDS:-30}"
-  [[ "$watchdog" =~ ^[1-9][0-9]*$ ]] || watchdog=30
+  # Bound the digit count before integer comparison so an oversized CI value
+  # cannot overflow Bash's signed-integer parser and defeat the watchdog.
+  [[ "$watchdog" =~ ^[1-9][0-9]{0,4}$ ]] && [ "$watchdog" -le 21600 ] || \
+    die "TRTMC_MODEL_PROOF_FLOCK_WATCHDOG_SECONDS must be an integer from 1 to 21600"
   local remaining chunk
   while true; do
     remaining=$((deadline - SECONDS))
@@ -564,9 +567,20 @@ select_proof_gpu() {
   # blocks on a predecessor ticket), so this interval bounds the wake latency
   # of exactly one process system-wide.
   local poll_interval="${TRTMC_MODEL_PROOF_POLL_INTERVAL:-0.25}"
-  [[ "$poll_interval" =~ ^[0-9]+(\.[0-9]+)?$ ]] && \
-    [[ ! "$poll_interval" =~ ^0+(\.0+)?$ ]] || \
-    die "TRTMC_MODEL_PROOF_POLL_INTERVAL must be a positive number of seconds"
+  # Bound the whole-number part before using Bash integer comparisons. Without
+  # this guard, an oversized value falls through to an effectively unbounded sleep.
+  [[ "$poll_interval" =~ ^(0|[1-9][0-9]{0,4})(\.[0-9]+)?$ ]] && \
+    [[ ! "$poll_interval" =~ ^0(\.0+)?$ ]] || \
+    die "TRTMC_MODEL_PROOF_POLL_INTERVAL must be a positive number no greater than 21600 seconds"
+  local poll_whole="${poll_interval%%.*}"
+  local poll_fraction=""
+  if [[ "$poll_interval" == *.* ]]; then
+    poll_fraction="${poll_interval#*.}"
+  fi
+  if [ "$poll_whole" -gt 21600 ] || \
+     { [ "$poll_whole" -eq 21600 ] && [[ "$poll_fraction" =~ [1-9] ]]; }; then
+    die "TRTMC_MODEL_PROOF_POLL_INTERVAL must be a positive number no greater than 21600 seconds"
+  fi
 
   local lock_dir="${TRTMC_MODEL_PROOF_GPU_LOCK_DIR:-/tmp/trtmc-model-proof-gpu-locks}"
   [ -n "$lock_dir" ] || die "TRTMC_MODEL_PROOF_GPU_LOCK_DIR must not be empty"

--- a/.github/scripts/run-trtmc-ci.sh
+++ b/.github/scripts/run-trtmc-ci.sh
@@ -529,8 +529,11 @@ run_premerge_unit_tests() {
   # These tests intentionally launch several simultaneous model projections
   # and assert tight lease deadlines. Run them after the parallel phase so
   # unrelated CPU load cannot change the allocator behavior under test.
+  # Each spawned proof pays the full host-setup cost (~40s on CI runners),
+  # so this serial suite needs its own budget: the previous shared 20m limit
+  # ended up within ~90s of a green run's duration.
   if [ "$unit_scope" = "all" ]; then
-    run_with_timeout "${PYTHON_BUILDER_TIMEOUT:-20m}" \
+    run_with_timeout "${MODEL_PROOF_ALLOCATOR_TIMEOUT:-30m}" \
       env PYTHONPATH="$source_root/python:$source_root${PYTHONPATH:+:$PYTHONPATH}" \
       python -m pytest tests/tools/test_model_proof_runner.py \
         -q -x -p no:cacheprovider -m model_proof_allocator

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -1885,9 +1885,29 @@ def test_automatic_gpu_lease_rejects_invalid_id_configuration(
             "21601",
             "must be an integer from 1 to 21600",
         ),
+        (
+            "TRTMC_MODEL_PROOF_POLL_INTERVAL",
+            "9223372036854775808",
+            "must be a positive number no greater than 21600 seconds",
+        ),
+        (
+            "TRTMC_MODEL_PROOF_POLL_INTERVAL",
+            "21600.1",
+            "must be a positive number no greater than 21600 seconds",
+        ),
+        (
+            "TRTMC_MODEL_PROOF_FLOCK_WATCHDOG_SECONDS",
+            "9223372036854775808",
+            "must be an integer from 1 to 21600",
+        ),
+        (
+            "TRTMC_MODEL_PROOF_FLOCK_WATCHDOG_SECONDS",
+            "21601",
+            "must be an integer from 1 to 21600",
+        ),
     ],
 )
-def test_gpu_lease_rejects_invalid_slot_and_timeout_configuration(
+def test_gpu_lease_rejects_invalid_numeric_configuration(
     tmp_path: Path,
     name: str,
     value: str,
@@ -2008,9 +2028,8 @@ def test_poll_interval_cannot_sleep_past_the_lease_timeout(tmp_path: Path) -> No
 
     The capacity-poll sleep is clamped to the remaining deadline; without the
     clamp a 300s interval would sleep far past a 1s lease timeout while still
-    reporting "timed out after 1s". The elapsed bound discriminates only
-    between "clamped" (host overhead, well under 150s even on a heavily
-    loaded runner) and "unclamped" (at least one full 300s sleep).
+    reporting "timed out after 1s". Measure from the queue-joined marker to the
+    timeout error so loaded-runner host setup cannot weaken the assertion.
     """
     fake_bin, docker_log = _write_successful_fake_docker(tmp_path)
     output = tmp_path / "proof"
@@ -2027,8 +2046,7 @@ def test_poll_interval_cannot_sleep_past_the_lease_timeout(tmp_path: Path) -> No
     lock_dir.mkdir()
     with (lock_dir / "gpu-9-slot-0.lock").open("w", encoding="utf-8") as lock_stream:
         fcntl.flock(lock_stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        started = time.monotonic()
-        result = subprocess.run(
+        process = subprocess.Popen(
             [
                 "bash",
                 str(RUNNER),
@@ -2041,16 +2059,40 @@ def test_poll_interval_cannot_sleep_past_the_lease_timeout(tmp_path: Path) -> No
             ],
             cwd=REPO_ROOT,
             env=env,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            check=False,
-            timeout=420,
         )
-        elapsed = time.monotonic() - started
+        try:
+            joined_file = output / "artifacts" / "gpu-queue-joined.txt"
+            join_deadline = time.monotonic() + 90
+            while time.monotonic() < join_deadline and not joined_file.is_file():
+                assert process.poll() is None
+                time.sleep(0.05)
+            assert joined_file.is_file()
 
-    assert result.returncode != 0
-    assert "timed out after 1s waiting for a shared model-proof GPU lease from: 9" in result.stderr
-    assert elapsed < 150, f"lease timeout was pierced by the poll interval: {elapsed:.3f}s"
+            timeout_message = (
+                "timed out after 1s waiting for a shared model-proof GPU lease from: 9"
+            )
+            error_file = output / "artifacts" / "host-error.log"
+            started = time.monotonic()
+            error_deadline = started + 10
+            while time.monotonic() < error_deadline:
+                if error_file.is_file() and timeout_message in error_file.read_text(
+                    encoding="utf-8"
+                ):
+                    break
+                time.sleep(0.05)
+            lease_elapsed = time.monotonic() - started
+            stdout, stderr = process.communicate(timeout=90)
+        finally:
+            _finish_proof_cases([process])
+
+    assert process.returncode != 0, stdout + stderr
+    assert timeout_message in stderr
+    assert lease_elapsed < 10, (
+        f"lease timeout was pierced by the poll interval: {lease_elapsed:.3f}s"
+    )
     assert not list(lock_dir.glob("admission-global-*.lock"))
 
 

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -121,6 +121,10 @@ def _fake_proof_environment(
             "TRTMC_HF_CACHE": str(tmp_path / "hf-cache"),
             "TRTMC_MODEL_PROOF_GPU_LOCK_DIR": str(tmp_path / "gpu-locks"),
             "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS": "5",
+            # Fast state transitions keep the multi-process coordination tests
+            # deterministic without widening their assertion windows.
+            "TRTMC_MODEL_PROOF_POLL_INTERVAL": "0.05",
+            "TRTMC_MODEL_PROOF_FLOCK_WATCHDOG_SECONDS": "2",
         }
     )
     return env
@@ -195,9 +199,10 @@ def _write_sana_reference_config(path: Path) -> None:
 def _prepare_reference_program() -> str:
     text = RUNNER.read_text(encoding="utf-8")
     function = text.split("prepare_private_model_reference_cache() {", maxsplit=1)[1]
-    function = "prepare_private_model_reference_cache() {" + function.split(
-        "\n\nrun_host() {", maxsplit=1
-    )[0]
+    function = (
+        "prepare_private_model_reference_cache() {"
+        + function.split("\n\nrun_host() {", maxsplit=1)[0]
+    )
     return (
         "set -euo pipefail\n"
         'model="sana_wm"\n'
@@ -636,7 +641,10 @@ def test_runner_keeps_local_fallback_and_workflow_uses_runner_cache_paths() -> N
 
     assert "${HF_HOME:-$HOME/.cache/huggingface}" in runner
     assert "TRTMC_HF_CACHE: ${{ vars.TRTMC_HF_HOME || " in workflow
-    assert "TRTMC_MODEL_REFERENCE_CACHE_ROOT: ${{ vars.TRTMC_MODEL_REFERENCE_CACHE_ROOT || " in workflow
+    assert (
+        "TRTMC_MODEL_REFERENCE_CACHE_ROOT: ${{ vars.TRTMC_MODEL_REFERENCE_CACHE_ROOT || "
+        in workflow
+    )
     assert "TRTMC_HF_HUB_CACHE:" not in workflow
     assert "TRTMC_HF_MODULES_CACHE:" not in workflow
     assert "${TRTMC_HF_HUB_CACHE:-$hf_cache_root/hub}" in runner
@@ -1129,7 +1137,7 @@ def test_host_cache_uses_full_hub_only_for_check_and_positive_view_for_proof() -
     assert '--mount "type=bind,src=$hf_hub_cache,dst=/hf-cache/hub,readonly"' in cache_check
     assert "dst=/hf-cache/modules" not in cache_check
     assert '--mount "type=bind,src=$hf_private_hub,dst=/hf-cache/hub"' in proof
-    assert 'src=$hf_private_hub,dst=/hf-cache/hub,readonly' not in proof
+    assert "src=$hf_private_hub,dst=/hf-cache/hub,readonly" not in proof
     assert "hf_repo_mount_args" not in host
     assert "src=$hf_hub_cache,dst=/hf-cache/hub" not in proof
     assert "dst=/hf-cache/modules" not in proof
@@ -1221,9 +1229,7 @@ def test_sana_reference_cache_is_copied_to_selected_private_view(
     assert not any(path.name == ".git" for path in private_root.rglob(".git"))
     assert {path.name for path in private_root.iterdir()} == {"sana_wm"}
 
-    evidence = json.loads(
-        (artifacts / "model-reference-cache.json").read_text(encoding="utf-8")
-    )
+    evidence = json.loads((artifacts / "model-reference-cache.json").read_text(encoding="utf-8"))
     assert evidence == {
         "schema_version": 1,
         "model": "sana_wm",
@@ -1997,6 +2003,58 @@ def test_fifth_shared_proof_times_out_when_all_four_slots_are_busy(
 
 
 @pytest.mark.model_proof_allocator
+def test_poll_interval_cannot_sleep_past_the_lease_timeout(tmp_path: Path) -> None:
+    """A poll interval larger than the lease budget must not delay the timeout.
+
+    The capacity-poll sleep is clamped to the remaining deadline; without the
+    clamp a 300s interval would sleep far past a 1s lease timeout while still
+    reporting "timed out after 1s". The elapsed bound discriminates only
+    between "clamped" (host overhead, well under 150s even on a heavily
+    loaded runner) and "unclamped" (at least one full 300s sleep).
+    """
+    fake_bin, docker_log = _write_successful_fake_docker(tmp_path)
+    output = tmp_path / "proof"
+    env = _fake_proof_environment(tmp_path, fake_bin, docker_log, output)
+    env.update(
+        {
+            "TRTMC_MODEL_PROOF_GPU_IDS": "9",
+            "TRTMC_MODEL_PROOF_SLOTS_PER_GPU": "1",
+            "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS": "1",
+            "TRTMC_MODEL_PROOF_POLL_INTERVAL": "300",
+        }
+    )
+    lock_dir = tmp_path / "gpu-locks"
+    lock_dir.mkdir()
+    with (lock_dir / "gpu-9-slot-0.lock").open("w", encoding="utf-8") as lock_stream:
+        fcntl.flock(lock_stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        started = time.monotonic()
+        result = subprocess.run(
+            [
+                "bash",
+                str(RUNNER),
+                "--model",
+                "convbert",
+                "--revision",
+                "HEAD",
+                "--output-dir",
+                str(output),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=420,
+        )
+        elapsed = time.monotonic() - started
+
+    assert result.returncode != 0
+    assert "timed out after 1s waiting for a shared model-proof GPU lease from: 9" in result.stderr
+    assert elapsed < 150, f"lease timeout was pierced by the poll interval: {elapsed:.3f}s"
+    assert not list(lock_dir.glob("admission-global-*.lock"))
+
+
+@pytest.mark.model_proof_allocator
 def test_gpu_admission_queue_prunes_a_stale_ticket(tmp_path: Path) -> None:
     fake_bin, docker_log = _write_successful_fake_docker(tmp_path)
     output = tmp_path / "proof"
@@ -2305,9 +2363,7 @@ def test_gpu_admission_ticket_queue_prevents_younger_requests_overtaking_shared_
 
         oldest, _, oldest_output = start_case("oldest-shared", "m2m_100", oldest_release)
         deadline = time.monotonic() + coordination_timeout_s
-        while time.monotonic() < deadline and not list(
-            lock_dir.glob("admission-global-*.lock")
-        ):
+        while time.monotonic() < deadline and not list(lock_dir.glob("admission-global-*.lock")):
             time.sleep(0.05)
         admission_tickets = sorted(lock_dir.glob("admission-global-*.lock"))
         assert len(admission_tickets) == 1
@@ -2354,17 +2410,13 @@ def test_gpu_admission_ticket_queue_prevents_younger_requests_overtaking_shared_
         while (
             time.monotonic() < deadline
             and not (oldest_output / "artifacts" / "gpu-lease.json").is_file()
-            and not (
-                younger_exclusive_output / "artifacts" / "gpu-lease.json"
-            ).is_file()
+            and not (younger_exclusive_output / "artifacts" / "gpu-lease.json").is_file()
             and not (younger_shared_output / "artifacts" / "gpu-lease.json").is_file()
         ):
             time.sleep(0.05)
 
         assert (oldest_output / "artifacts" / "gpu-lease.json").is_file()
-        assert not (
-            younger_exclusive_output / "artifacts" / "gpu-lease.json"
-        ).exists()
+        assert not (younger_exclusive_output / "artifacts" / "gpu-lease.json").exists()
         assert not (younger_shared_output / "artifacts" / "gpu-lease.json").exists()
         assert _gpu_lease(oldest_output)["resource_class"] == "shared"
 
@@ -2420,6 +2472,342 @@ def test_gpu_admission_ticket_queue_prevents_younger_requests_overtaking_shared_
                     process.communicate(timeout=10)
 
 
+def _start_proof_case(
+    tmp_path: Path,
+    name: str,
+    model: str,
+    release_file: Path,
+    common_env: dict[str, str],
+) -> tuple[subprocess.Popen[str], Path]:
+    case_dir = tmp_path / name
+    case_dir.mkdir()
+    fake_bin, docker_log = _write_successful_fake_docker(case_dir)
+    output = case_dir / "proof"
+    env = _fake_proof_environment(tmp_path, fake_bin, docker_log, output)
+    env.update(common_env)
+    env["FAKE_PROOF_RELEASE_FILE"] = str(release_file)
+    process = subprocess.Popen(
+        [
+            "bash",
+            str(RUNNER),
+            "--model",
+            model,
+            "--revision",
+            "HEAD",
+            "--output-dir",
+            str(output),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return process, output
+
+
+def _finish_proof_cases(processes: list[subprocess.Popen[str] | None]) -> None:
+    for process in processes:
+        if process is not None and process.poll() is None:
+            try:
+                process.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.terminate()
+                process.communicate(timeout=10)
+
+
+@pytest.mark.model_proof_allocator
+def test_gpu_lock_directory_file_protocol_is_frozen(tmp_path: Path) -> None:
+    """The lock-directory layout and its live semantics are a contract.
+
+    Old and new script revisions share one lock directory on a runner while
+    premerge branches overlap, so the file names, the ticket flock semantics
+    (a live ticket is exclusively flocked by its owner; the slot lease stays
+    flocked while the proof runs), and the single-hard-link publication must
+    never change in place; a protocol change requires a new lock-directory
+    generation.
+    """
+    lock_dir = tmp_path / "gpu-locks"
+    coordination_timeout_s = 90
+    common_env = {
+        "TRTMC_GPU_ID": "6",
+        "TRTMC_MODEL_PROOF_GPU_IDS": "6",
+        "TRTMC_MODEL_PROOF_SLOTS_PER_GPU": "1",
+        "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS": "600",
+    }
+    holder_release = tmp_path / "release-holder"
+    waiter_release = tmp_path / "release-waiter"
+    waiter_release.touch()
+    holder, holder_output = _start_proof_case(
+        tmp_path, "holder", "convbert", holder_release, common_env
+    )
+    waiter: subprocess.Popen[str] | None = None
+    try:
+        deadline = time.monotonic() + coordination_timeout_s
+        while (
+            time.monotonic() < deadline
+            and not (holder_output / "artifacts" / "gpu-lease.json").is_file()
+        ):
+            time.sleep(0.05)
+        assert (holder_output / "artifacts" / "gpu-lease.json").is_file()
+        # A held lease is an exclusively flocked slot file.
+        assert _lock_is_busy(lock_dir / "gpu-6-slot-0.lock")
+
+        waiter, waiter_output = _start_proof_case(
+            tmp_path, "waiter", "convbert", waiter_release, common_env
+        )
+        deadline = time.monotonic() + coordination_timeout_s
+        while time.monotonic() < deadline and not list(lock_dir.glob("admission-global-*.lock")):
+            time.sleep(0.05)
+        tickets = sorted(lock_dir.glob("admission-global-*.lock"))
+        assert len(tickets) == 1
+        ticket = tickets[0]
+        # Live-ticket semantics: exclusively flocked by its owner from the
+        # moment it becomes visible.
+        assert re.fullmatch(r"admission-global-[0-9]{20}\.lock", ticket.name)
+        assert _lock_is_busy(ticket)
+        # Publication settles to a single hard link with no temporary alias:
+        # the ticket becomes visible via ln just before its .tmp source and
+        # the counter .tmp are removed, so wait out that window first.
+        joined_file = waiter_output / "artifacts" / "gpu-queue-joined.txt"
+        deadline = time.monotonic() + coordination_timeout_s
+        while time.monotonic() < deadline and (
+            list(lock_dir.glob("*.tmp.*")) or not joined_file.is_file()
+        ):
+            time.sleep(0.05)
+        assert not list(lock_dir.glob("*.tmp.*"))
+        assert ticket.stat().st_nlink == 1
+        assert joined_file.read_text(encoding="utf-8") == ticket.name + "\n"
+
+        holder_release.touch()
+        waiter_stdout, waiter_stderr = waiter.communicate(timeout=coordination_timeout_s)
+        assert waiter.returncode == 0, waiter_stdout + waiter_stderr
+        holder_stdout, holder_stderr = holder.communicate(timeout=30)
+        assert holder.returncode == 0, holder_stdout + holder_stderr
+
+        # End-state layout: exactly the frozen protocol files, nothing else.
+        assert sorted(path.name for path in lock_dir.iterdir()) == [
+            "admission-global.enqueue.lock",
+            "admission-global.next",
+            "allocator.lock",
+            "gpu-6-reservation.lock",
+            "gpu-6-slot-0.lock",
+        ]
+        # The slot lease is released once no proof runs.
+        assert not _lock_is_busy(lock_dir / "gpu-6-slot-0.lock")
+    finally:
+        holder_release.touch()
+        _finish_proof_cases([holder, waiter])
+
+
+@pytest.mark.model_proof_allocator
+def test_killed_queue_predecessor_wakes_waiter_and_is_pruned(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "gpu-locks"
+    coordination_timeout_s = 90
+    common_env = {
+        "TRTMC_GPU_ID": "6",
+        "TRTMC_MODEL_PROOF_GPU_IDS": "6",
+        "TRTMC_MODEL_PROOF_SLOTS_PER_GPU": "1",
+        "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS": "600",
+    }
+    holder_release = tmp_path / "release-holder"
+    waiter_release = tmp_path / "release-waiter"
+    waiter_release.touch()
+    holder, holder_output = _start_proof_case(
+        tmp_path, "holder", "m2m_100", holder_release, common_env
+    )
+    doomed: subprocess.Popen[str] | None = None
+    waiter: subprocess.Popen[str] | None = None
+    try:
+        deadline = time.monotonic() + coordination_timeout_s
+        while (
+            time.monotonic() < deadline
+            and not (holder_output / "artifacts" / "gpu-lease.json").is_file()
+        ):
+            time.sleep(0.05)
+        assert (holder_output / "artifacts" / "gpu-lease.json").is_file()
+
+        doomed, _ = _start_proof_case(tmp_path, "doomed", "convbert", waiter_release, common_env)
+        deadline = time.monotonic() + coordination_timeout_s
+        while (
+            time.monotonic() < deadline and len(list(lock_dir.glob("admission-global-*.lock"))) < 1
+        ):
+            time.sleep(0.05)
+        assert len(list(lock_dir.glob("admission-global-*.lock"))) == 1
+
+        waiter, waiter_output = _start_proof_case(
+            tmp_path, "waiter", "convbert", waiter_release, common_env
+        )
+        deadline = time.monotonic() + coordination_timeout_s
+        while (
+            time.monotonic() < deadline and len(list(lock_dir.glob("admission-global-*.lock"))) < 2
+        ):
+            time.sleep(0.05)
+        assert len(list(lock_dir.glob("admission-global-*.lock"))) == 2
+
+        # SIGKILL the middle of the chain: the kernel drops its ticket flock,
+        # which must wake the waiter behind it; the waiter then prunes the
+        # stale ticket and inherits the queue head.
+        doomed.kill()
+        doomed.communicate(timeout=30)
+        holder_release.touch()
+
+        waiter_stdout, waiter_stderr = waiter.communicate(timeout=coordination_timeout_s)
+        assert waiter.returncode == 0, waiter_stdout + waiter_stderr
+        assert (waiter_output / "artifacts" / "gpu-lease.json").is_file()
+        holder_stdout, holder_stderr = holder.communicate(timeout=30)
+        assert holder.returncode == 0, holder_stdout + holder_stderr
+        assert not list(lock_dir.glob("admission-global-*.lock"))
+    finally:
+        holder_release.touch()
+        _finish_proof_cases([holder, doomed, waiter])
+
+
+@pytest.mark.model_proof_allocator
+def test_exclusive_drain_completes_as_holders_release_in_any_order(
+    tmp_path: Path,
+) -> None:
+    lock_dir = tmp_path / "gpu-locks"
+    coordination_timeout_s = 90
+    common_env = {
+        "TRTMC_GPU_ID": "6",
+        "TRTMC_MODEL_PROOF_GPU_IDS": "6",
+        "TRTMC_MODEL_PROOF_SLOTS_PER_GPU": "3",
+        "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS": "600",
+    }
+    releases = [tmp_path / f"release-shared-{index}" for index in range(3)]
+    exclusive_release = tmp_path / "release-exclusive"
+    exclusive_release.touch()
+    holders: list[subprocess.Popen[str] | None] = [None, None, None]
+    holder_outputs: list[Path] = []
+    exclusive: subprocess.Popen[str] | None = None
+    try:
+        for index in range(3):
+            process, output = _start_proof_case(
+                tmp_path, f"shared-{index}", "m2m_100", releases[index], common_env
+            )
+            holders[index] = process
+            holder_outputs.append(output)
+            deadline = time.monotonic() + coordination_timeout_s
+            while (
+                time.monotonic() < deadline
+                and not (output / "artifacts" / "gpu-lease.json").is_file()
+            ):
+                time.sleep(0.05)
+            assert (output / "artifacts" / "gpu-lease.json").is_file()
+
+        exclusive, exclusive_output = _start_proof_case(
+            tmp_path, "exclusive", "bark", exclusive_release, common_env
+        )
+        # The exclusive proof reserves the GPU, gives its queue position back,
+        # and then drains the remaining holders event-driven.
+        deadline = time.monotonic() + coordination_timeout_s
+        while time.monotonic() < deadline and not (
+            _lock_is_busy(lock_dir / "gpu-6-reservation.lock")
+            and not list(lock_dir.glob("admission-global-*.lock"))
+        ):
+            time.sleep(0.05)
+        assert _lock_is_busy(lock_dir / "gpu-6-reservation.lock")
+        assert not list(lock_dir.glob("admission-global-*.lock"))
+
+        # Release the holders in a non-sequential order and wait for each one
+        # to actually exit (its slot flock is then provably dropped) before
+        # releasing the next, so the out-of-order arrival at the drain is
+        # deterministic rather than scheduler-dependent: slot 1 frees while
+        # slot 0 is still held, forcing the drain to sit blocked on slot 0.
+        for index in (1, 0, 2):
+            releases[index].touch()
+            holder = holders[index]
+            assert holder is not None
+            holder_stdout, holder_stderr = holder.communicate(timeout=coordination_timeout_s)
+            assert holder.returncode == 0, f"shared-{index}: " + holder_stdout + holder_stderr
+
+        exclusive_stdout, exclusive_stderr = exclusive.communicate(timeout=coordination_timeout_s)
+        assert exclusive.returncode == 0, exclusive_stdout + exclusive_stderr
+        lease = _gpu_lease(exclusive_output)
+        assert lease["resource_class"] == "exclusive_gpu"
+        assert sorted(lease["gpu_slots"]) == [0, 1, 2]
+    finally:
+        for release_file in releases:
+            release_file.touch()
+        _finish_proof_cases([*holders, exclusive])
+
+
+@pytest.mark.model_proof_allocator
+def test_long_queue_is_served_in_strict_fifo_order(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "gpu-locks"
+    coordination_timeout_s = 90
+    waiter_count = 6
+    common_env = {
+        "TRTMC_GPU_ID": "6",
+        "TRTMC_MODEL_PROOF_GPU_IDS": "6",
+        "TRTMC_MODEL_PROOF_SLOTS_PER_GPU": "1",
+        "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS": "600",
+    }
+    holder_release = tmp_path / "release-holder"
+    waiter_release = tmp_path / "release-waiter"
+    waiter_release.touch()
+    holder, holder_output = _start_proof_case(
+        tmp_path, "holder", "m2m_100", holder_release, common_env
+    )
+    waiters: list[subprocess.Popen[str] | None] = [None] * waiter_count
+    waiter_outputs: list[Path] = []
+    try:
+        deadline = time.monotonic() + coordination_timeout_s
+        while (
+            time.monotonic() < deadline
+            and not (holder_output / "artifacts" / "gpu-lease.json").is_file()
+        ):
+            time.sleep(0.05)
+        assert (holder_output / "artifacts" / "gpu-lease.json").is_file()
+
+        # Start all waiters at once so their host setup runs concurrently
+        # (sequential starts made this test dominate the CI step budget).
+        # The enqueue order is whatever the race produced; the FIFO contract
+        # is asserted afterwards from the recorded ticket numbers.
+        for index in range(waiter_count):
+            process, output = _start_proof_case(
+                tmp_path, f"waiter-{index}", "convbert", waiter_release, common_env
+            )
+            waiters[index] = process
+            waiter_outputs.append(output)
+        deadline = time.monotonic() + coordination_timeout_s
+        while (
+            time.monotonic() < deadline
+            and len(list(lock_dir.glob("admission-global-*.lock"))) < waiter_count
+        ):
+            time.sleep(0.05)
+        assert len(list(lock_dir.glob("admission-global-*.lock"))) == waiter_count
+
+        holder_release.touch()
+        for index, process in enumerate(waiters):
+            assert process is not None
+            stdout, stderr = process.communicate(timeout=coordination_timeout_s)
+            assert process.returncode == 0, f"waiter-{index}: " + stdout + stderr
+        holder.communicate(timeout=30)
+        assert holder.returncode == 0
+
+        # Enqueue order (ticket numbers) must equal service order (lease
+        # creation times): the chain wakes exactly one successor per release
+        # and nobody overtakes.
+        tickets = [
+            (output / "artifacts" / "gpu-queue-joined.txt").read_text(encoding="utf-8")
+            for output in waiter_outputs
+        ]
+        assert len(set(tickets)) == waiter_count
+        order_by_ticket = sorted(range(waiter_count), key=lambda i: tickets[i])
+        lease_times = [
+            (output / "artifacts" / "gpu-lease.json").stat().st_mtime_ns
+            for output in waiter_outputs
+        ]
+        order_by_service = sorted(range(waiter_count), key=lambda i: lease_times[i])
+        assert order_by_service == order_by_ticket
+        assert not list(lock_dir.glob("admission-global-*.lock"))
+    finally:
+        holder_release.touch()
+        _finish_proof_cases([holder, *waiters])
+
+
 def _proof_gpu_ids_if_present(docker_log: Path) -> list[str]:
     if not docker_log.is_file():
         return []
@@ -2466,6 +2854,5 @@ def test_gpu_mapping_exists_only_on_the_hermetic_proof_container() -> None:
     )
     assert (
         "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS: "
-        "${{ vars.TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS || '3600' }}"
-        in workflow
+        "${{ vars.TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS || '3600' }}" in workflow
     )


### PR DESCRIPTION
## Background

Premerge and nightly runs were intermittently failing in `tests/tools/test_model_proof_runner.py`. The GPU allocator checked its queue once per second, so several waiting steps could add up and exceed the short test deadlines on a loaded runner. PR #427 widened one test deadline as a temporary workaround; this PR changes how waiters are woken while preserving the allocation rules.

## Exit Criteria

- [x] Preserve first-in-first-out service, crash recovery, shared-slot spreading, exclusive-GPU reservation, explicit GPU/slot selection, and existing timeout errors.
- [x] Cover predecessor crashes, out-of-order shared-holder exits, a six-waiter queue, the on-disk lock protocol, and poll intervals larger than the lease deadline.
- [x] Reject poll and watchdog settings that are too large for safe Bash integer comparisons.
- [x] Pass the full allocator suite and the remaining model-proof runner tests locally without a GPU.
- [ ] Pass complete Premerge CI on current head `16509d08`.
- [ ] After merge, observe one week of stable allocator behavior before tightening the older 5-second test default in a follow-up PR.

## Implementation

- A waiting proof now blocks on the proof immediately ahead of it. Releasing or crashing the earlier proof wakes its successor immediately instead of making every waiter check once per second.
- An exclusive proof reserves one GPU and waits directly for that GPU's active slots to be released.
- Only the first shared proof in line checks for newly available capacity, using a 0.25-second default interval capped by the remaining lease time.
- Poll and watchdog values are limited to 21,600 seconds before Bash performs integer comparisons, preventing oversized CI settings from bypassing the deadline or causing a tight retry loop.
- `gpu-queue-joined.txt` gives tests a precise point from which to measure queue waiting, excluding unrelated host setup time.
- The allocator test group has a dedicated 30-minute job limit because it now contains 12 process-level tests and every fake proof performs the full host setup. This changes only the outer suite watchdog; individual lease deadlines and correctness assertions are not relaxed.
- Lock-file names and meanings remain unchanged so old and new branches can share the same runner during rollout.

## Validation

- `bash -n .github/scripts/run-model-proof.sh`: passed.
- `python3 -m ruff check tests/tools/test_model_proof_runner.py`: passed.
- `python3 -m ruff format --check tests/tools/test_model_proof_runner.py`: passed.
- `python3 tools/legal_headers.py --check`: passed with no findings.
- `CI_BASE_REF=github/main bash .github/scripts/run-trtmc-ci.sh source-quality`: passed; maximum cyclomatic complexity remained 10.
- `python3 -m pytest tests/tools/test_model_proof_runner.py -m model_proof_allocator -q -p no:cacheprovider`: 12 passed, 70 deselected in 102.00s.
- `python3 -m pytest tests/tools/test_model_proof_runner.py -m "not model_proof_allocator" -q -p no:cacheprovider --deselect tests/tools/test_model_proof_runner.py::test_distinct_explicit_hf_cache_paths_reach_both_containers`: 69 passed, 13 deselected in 72.60s.
- `python3 -m pytest tests/tools/test_github_actions_ci.py -q -p no:cacheprovider`: 60 passed in 0.10s.
- `python3 -m pytest tests/tools/test_model_proof_runner.py -q -k 'rejects_invalid_numeric_configuration or poll_interval_cannot_sleep_past_the_lease_timeout' -p no:cacheprovider`: 8 passed, 74 deselected in 31.36s.
- Previous head `4cf9f724`, run [29234990771](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29234990771): Unit, source quality, legal, ownership, allocator 12/12, and five model proofs passed. LTX failed before its proof started because the runner-managed `$GITHUB_OUTPUT` file was missing; that run is not evidence for the current head.

## Notes For Future Readers

- Never wait on another lock while holding the allocator's short bookkeeping lock.
- Change the lock-file protocol only by introducing a new lock-directory version; do not change it in place while old branches may still run.
- A killed last waiter can leave one unlocked ticket file. The next proof removes it safely.
- Model proofs reserve at most one physical GPU. Multi-device TP2/TP4 cases are outside this allocator and are currently excluded from Premerge and nightly E2E.
