### PR TITLE
fix(bark): verify replayed tactics across GPUs

### DIFF
--- a/python/tensorrt_model_connect/families/bark/timing_cache.py
+++ b/python/tensorrt_model_connect/families/bark/timing_cache.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import hashlib
+import math
 import os
 from pathlib import Path
 import re
@@ -30,7 +31,7 @@ class _CacheState:
     mode: str
     path: Path
     cache: Any
-    original_sha256: str | None
+    tactic_hashes: dict[str, int] | None
 
 
 def _mode() -> str:
@@ -81,6 +82,58 @@ def _expected_sha256(path: Path, payload: bytes) -> str:
     return actual
 
 
+def _query_tactic_hashes(cache: Any, path: Path) -> dict[str, int]:
+    for method in ("queryKeys", "query"):
+        if not hasattr(cache, method):
+            raise RuntimeError(f"TensorRT does not support verified Bark tactic queries ({method})")
+    try:
+        keys = list(cache.queryKeys())
+    except (RuntimeError, TypeError, ValueError) as exc:
+        raise RuntimeError(f"failed to query verified Bark timing cache {path}: {exc}") from exc
+    if not keys:
+        raise RuntimeError(f"verified Bark timing cache has no tactic entries: {path}")
+
+    tactics: dict[str, int] = {}
+    try:
+        for key in keys:
+            key_text = str(key)
+            value = cache.query(key)
+            tactic_hash = int(value.tacticHash)
+            timing_msec = float(value.timingMSec)
+            if tactic_hash == (1 << 64) - 1 or not math.isfinite(timing_msec) or timing_msec < 0:
+                raise ValueError(f"invalid tactic value for {key_text}")
+            if key_text in tactics:
+                raise ValueError(f"duplicate timing-cache key {key_text}")
+            tactics[key_text] = tactic_hash
+    except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+        raise RuntimeError(f"failed to inspect verified Bark timing cache {path}: {exc}") from exc
+    return tactics
+
+
+def _replay_tactics(cache: Any, path: Path) -> dict[str, int]:
+    if not hasattr(cache, "update"):
+        raise RuntimeError("TensorRT does not support verified Bark tactic replay (update)")
+    expected = _query_tactic_hashes(cache, path)
+    try:
+        for key in cache.queryKeys():
+            if not cache.update(key, cache.query(key)):
+                raise RuntimeError(f"TensorRT rejected tactic {key}")
+    except (RuntimeError, TypeError, ValueError) as exc:
+        raise RuntimeError(f"failed to replay verified Bark tactics from {path}: {exc}") from exc
+    return expected
+
+
+def _tactic_delta(expected: dict[str, int], actual: dict[str, int]) -> str:
+    added = sorted(actual.keys() - expected.keys())
+    removed = sorted(expected.keys() - actual.keys())
+    changed = sorted(key for key in expected.keys() & actual.keys() if expected[key] != actual[key])
+    samples = [f"added {key}={actual[key]}" for key in added[:2]]
+    samples.extend(f"removed {key}={expected[key]}" for key in removed[:2])
+    samples.extend(f"changed {key}={expected[key]}->{actual[key]}" for key in changed[:2])
+    detail = "; ".join(samples) if samples else "no key-level difference found"
+    return f"added={len(added)}, removed={len(removed)}, changed={len(changed)}; {detail}"
+
+
 def _attach(config: Any, mode: str) -> _CacheState:
     path_text = os.environ.get(_PATH_ENV, "").strip()
     if not path_text:
@@ -97,7 +150,8 @@ def _attach(config: Any, mode: str) -> _CacheState:
         raise RuntimeError(f"failed to read Bark timing cache {path}: {exc}") from exc
     if mode == "verified" and not payload:
         raise RuntimeError(f"verified Bark timing cache is empty: {path}")
-    original_sha256 = _expected_sha256(path, payload) if mode == "verified" else None
+    if mode == "verified":
+        _expected_sha256(path, payload)
 
     for flag_name in ("EDITABLE_TIMING_CACHE", "DISABLE_COMPILATION_CACHE"):
         _set_required_flag(config, flag_name)
@@ -106,12 +160,13 @@ def _attach(config: Any, mode: str) -> _CacheState:
 
     try:
         cache = config.create_timing_cache(payload)
-        accepted = config.set_timing_cache(cache, False)
+        tactic_hashes = _replay_tactics(cache, path) if mode == "verified" else None
+        accepted = config.set_timing_cache(cache, mode == "verified")
     except (RuntimeError, TypeError, ValueError) as exc:
         raise RuntimeError(f"failed to attach {mode} Bark timing cache {path}: {exc}") from exc
     if not accepted:
         raise RuntimeError(f"TensorRT rejected {mode} Bark timing cache {path}")
-    return _CacheState(mode, path, cache, original_sha256)
+    return _CacheState(mode, path, cache, tactic_hashes)
 
 
 def _active_cache(config: Any, state: _CacheState) -> Any:
@@ -122,13 +177,14 @@ def _active_cache(config: Any, state: _CacheState) -> Any:
     return state.cache
 
 
-def _verify_unchanged(config: Any, state: _CacheState) -> None:
-    payload = _serialize(_active_cache(config, state), state.path)
-    actual = hashlib.sha256(payload).hexdigest()
-    if actual != state.original_sha256:
+def _verify_tactics_unchanged(config: Any, state: _CacheState) -> None:
+    if state.tactic_hashes is None:
+        raise RuntimeError("verified Bark timing cache is missing its tactic fingerprint")
+    actual = _query_tactic_hashes(_active_cache(config, state), state.path)
+    if actual != state.tactic_hashes:
         raise RuntimeError(
-            f"verified Bark timing cache changed during build: {state.path}; "
-            "a timing-cache miss or tactic update occurred"
+            f"verified Bark tactic selection changed during build: {state.path}; "
+            f"{_tactic_delta(state.tactic_hashes, actual)}"
         )
 
 
@@ -156,7 +212,7 @@ def build_bark_serialized_network(builder: Any, network: Any, config: Any) -> An
         trt_compat.unwrap(network), trt_compat.unwrap(config)
     )
     if mode == "verified":
-        _verify_unchanged(config, state)
+        _verify_tactics_unchanged(config, state)
     elif plan is not None:
         _save_recording(config, state)
     return plan

--- a/tests/e2e/models/bark/test_bark_timing_cache.py
+++ b/tests/e2e/models/bark/test_bark_timing_cache.py
@@ -14,9 +14,24 @@ from tensorrt_model_connect.families.bark import timing_cache
 class _FakeCache:
     def __init__(self, payload: bytes):
         self.payload = bytearray(payload)
+        self.tactics = {"0x01": SimpleNamespace(tacticHash=101, timingMSec=1.0)}
+        self.updated_keys: list[str] = []
 
     def serialize(self) -> bytes:
         return bytes(self.payload)
+
+    def queryKeys(self) -> list[str]:
+        return list(self.tactics)
+
+    def query(self, key: str):
+        return self.tactics[key]
+
+    def update(self, key: str, value) -> bool:
+        if key not in self.tactics:
+            return False
+        self.updated_keys.append(key)
+        self.tactics[key] = value
+        return True
 
 
 class _FakeConfig:
@@ -27,6 +42,7 @@ class _FakeConfig:
         self.max_num_tactics = -1
         self.avg_timing_iterations = -1
         self.created_payloads: list[bytes] = []
+        self.ignore_mismatches: list[bool] = []
 
     def set_flag(self, flag: str) -> None:
         self.flags.append(flag)
@@ -36,7 +52,7 @@ class _FakeConfig:
         return _FakeCache(payload)
 
     def set_timing_cache(self, cache: _FakeCache, ignore_mismatch: bool) -> bool:
-        assert ignore_mismatch is False
+        self.ignore_mismatches.append(ignore_mismatch)
         self.cache = cache
         return True
 
@@ -45,8 +61,17 @@ class _FakeConfig:
 
 
 class _FakeBuilder:
-    def __init__(self, appended_payload: bytes = b""):
+    def __init__(
+        self,
+        appended_payload: bytes = b"",
+        tactic_hash: int | None = None,
+        timing_msec: float | None = None,
+        add_tactic: bool = False,
+    ):
         self.appended_payload = appended_payload
+        self.tactic_hash = tactic_hash
+        self.timing_msec = timing_msec
+        self.add_tactic = add_tactic
         self.calls = 0
 
     def build_serialized_network(self, network, config):
@@ -55,6 +80,19 @@ class _FakeBuilder:
         if self.appended_payload:
             assert config.cache is not None
             config.cache.payload.extend(self.appended_payload)
+        if self.tactic_hash is not None:
+            assert config.cache is not None
+            config.cache.tactics["0x01"] = SimpleNamespace(
+                tacticHash=self.tactic_hash, timingMSec=2.0
+            )
+        if self.timing_msec is not None:
+            assert config.cache is not None
+            config.cache.tactics["0x01"] = SimpleNamespace(
+                tacticHash=101, timingMSec=self.timing_msec
+            )
+        if self.add_tactic:
+            assert config.cache is not None
+            config.cache.tactics["0x02"] = SimpleNamespace(tacticHash=303, timingMSec=3.0)
         return b"plan"
 
 
@@ -107,11 +145,12 @@ def test_record_mode_accumulates_an_editable_cache(
     assert first_config.builder_optimization_level == 3
     assert first_config.max_num_tactics == 7
     assert first_config.avg_timing_iterations == 5
+    assert first_config.ignore_mismatches == [False]
 
 
-@pytest.mark.parametrize("mutate_cache", [False, True])
-def test_verified_mode_is_strict_and_rejects_tactic_updates(
-    monkeypatch, tmp_path, fake_builder_flags, mutate_cache
+@pytest.mark.parametrize("mutate_serialized_cache", [False, True])
+def test_verified_mode_accepts_device_metadata_changes_when_tactics_are_unchanged(
+    monkeypatch, tmp_path, fake_builder_flags, mutate_serialized_cache
 ) -> None:
     cache_path = tmp_path / "bark.cache"
     payload = b"verified-tactics"
@@ -120,14 +159,11 @@ def test_verified_mode_is_strict_and_rejects_tactic_updates(
     monkeypatch.setenv("TRTMC_BARK_TIMING_CACHE_PATH", str(cache_path))
     monkeypatch.setenv("TRTMC_BARK_TIMING_CACHE_SHA256", hashlib.sha256(payload).hexdigest())
     config = _FakeConfig()
-    builder = _FakeBuilder(b"-new-tactic" if mutate_cache else b"")
+    builder = _FakeBuilder(b"-device-metadata" if mutate_serialized_cache else b"")
 
-    if mutate_cache:
-        with pytest.raises(RuntimeError, match="timing-cache miss or tactic update"):
-            timing_cache.build_bark_serialized_network(builder, "network", config)
-    else:
-        plan = timing_cache.build_bark_serialized_network(builder, "network", config)
-        assert plan == b"plan"
+    plan = timing_cache.build_bark_serialized_network(builder, "network", config)
+
+    assert plan == b"plan"
 
     assert config.created_payloads == [payload]
     assert config.flags == [
@@ -135,7 +171,57 @@ def test_verified_mode_is_strict_and_rejects_tactic_updates(
         "no-compilation-cache",
         "error-on-miss",
     ]
+    assert config.ignore_mismatches == [True]
+    assert config.cache is not None
+    assert config.cache.updated_keys == ["0x01"]
     assert cache_path.read_bytes() == payload
+
+
+def test_verified_mode_rejects_tactic_updates(monkeypatch, tmp_path, fake_builder_flags) -> None:
+    cache_path = tmp_path / "bark.cache"
+    payload = b"verified-tactics"
+    cache_path.write_bytes(payload)
+    monkeypatch.setenv("TRTMC_BARK_TIMING_CACHE_MODE", "verified")
+    monkeypatch.setenv("TRTMC_BARK_TIMING_CACHE_PATH", str(cache_path))
+    monkeypatch.setenv("TRTMC_BARK_TIMING_CACHE_SHA256", hashlib.sha256(payload).hexdigest())
+
+    with pytest.raises(RuntimeError, match="tactic selection changed"):
+        timing_cache.build_bark_serialized_network(
+            _FakeBuilder(tactic_hash=202), "network", _FakeConfig()
+        )
+
+
+def test_verified_mode_accepts_updated_timing_for_the_same_tactic(
+    monkeypatch, tmp_path, fake_builder_flags
+) -> None:
+    cache_path = tmp_path / "bark.cache"
+    payload = b"verified-tactics"
+    cache_path.write_bytes(payload)
+    monkeypatch.setenv("TRTMC_BARK_TIMING_CACHE_MODE", "verified")
+    monkeypatch.setenv("TRTMC_BARK_TIMING_CACHE_PATH", str(cache_path))
+    monkeypatch.setenv("TRTMC_BARK_TIMING_CACHE_SHA256", hashlib.sha256(payload).hexdigest())
+
+    plan = timing_cache.build_bark_serialized_network(
+        _FakeBuilder(timing_msec=9.5), "network", _FakeConfig()
+    )
+
+    assert plan == b"plan"
+
+
+def test_verified_mode_rejects_new_timing_cache_keys(
+    monkeypatch, tmp_path, fake_builder_flags
+) -> None:
+    cache_path = tmp_path / "bark.cache"
+    payload = b"verified-tactics"
+    cache_path.write_bytes(payload)
+    monkeypatch.setenv("TRTMC_BARK_TIMING_CACHE_MODE", "verified")
+    monkeypatch.setenv("TRTMC_BARK_TIMING_CACHE_PATH", str(cache_path))
+    monkeypatch.setenv("TRTMC_BARK_TIMING_CACHE_SHA256", hashlib.sha256(payload).hexdigest())
+
+    with pytest.raises(RuntimeError, match=r"added=1, removed=0, changed=0"):
+        timing_cache.build_bark_serialized_network(
+            _FakeBuilder(add_tactic=True), "network", _FakeConfig()
+        )
 
 
 def test_verified_mode_rejects_wrong_digest_before_tensorrt_attach(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Background

PR #449 pinned one verified Bark editable timing-cache file and rejected any post-build byte change. A later GB300 proof on physical GPU 2 failed because the cache changed even though the TensorRT, CUDA, build inputs, and pinned cache SHA matched the successful GPU 0 proof: https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29241731704/job/86793338246

TensorRT timing-cache values contain both a selected tactic hash and device-specific timing data. The verified invariant must be the selected tactic for every cache key, not the serialized cache bytes from one physical GPU.

## Exit Criteria

- Bark can use the verified cache on any GB300 selected by CI without GPU affinity.
- Every timing-cache key resolves to the pinned tactic hash after each engine build.
- New, removed, or changed tactic entries still fail closed.
- FP16, the default builder optimization level, exact Bark output checks, and performance thresholds remain unchanged.

## Implementation

- Keep the pre-attach SHA-256 check, editable-cache flag, disabled compilation cache, and error-on-cache-miss flag from #449.
- Query every verified cache entry and replay its selected tactic through `ITimingCache.update()` before attach.
- Allow TensorRT to attach the verified cache across device verification headers.
- Compare the complete `TimingCacheKey -> tacticHash` mapping after each engine build. Ignore only `timingMSec` and serialized device metadata; report sampled key-level deltas on failure.

## Validation

- `PYTHONPATH=python python -m pytest tests/e2e/models/bark/test_bark_timing_cache.py tests/e2e/models/bark/test_bark_build_contract.py tests/e2e/models/bark/test_bark_builder_engine.py tests/e2e/models/bark/test_bark_encodec_builder.py tests/e2e/models/bark/test_bark_runner_cli_alignment.py tests/e2e/models/bark/test_bark_tokenizer.py tests/e2e/models/bark/test_bark_warm_hf_cache_metadata.py -q`: 38 passed, 3 skipped.
- `PYTHONPATH=python python -m ruff check python/tensorrt_model_connect/families/bark/timing_cache.py tests/e2e/models/bark/test_bark_timing_cache.py`: passed.
- Independent GB300 with TensorRT 11.0: all 213 entries in an existing Bark editable cache were queried, replayed with `update()`, attached, and re-queried with an identical tactic fingerprint.
- Three unpinned premerge repeats passed with `gpu_slot: null` and the shared physical-GPU pool `[0, 1, 2, 3]`: [run 29245664336](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29245664336) on physical GPU 1, then [run 29246295286](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29246295286) and [run 29246864830](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29246864830) on physical GPU 0. All used TensorRT 11.2.0.113 / CUDA 13.3.
- All three repeats produced semantic tokens, coarse tokens, and TRT WAV files that are byte-identical to each other and to #449's successful physical-GPU-0 proof. Coarse execution was 4.1587 s, 4.1502 s, and 4.1822 s for 6,770 launches, versus 4.1577 s in the baseline.
- The third job took 26m17s, but its measured Bark work did not regress: bundle build was 212.0 s, E2E was 6m17s, and total engine execution was 4.5041 s. The extra wall time was outside Bark's measured build/inference/reference/contract phases; the resulting Bark DSO hash also matched the first two repeats.

## Notes For Future Readers

- Review `timing_cache.py` first, then the fake-cache mutation cases in `test_bark_timing_cache.py`.
- A serialized timing-cache SHA remains useful for input provenance, but post-build byte identity is not a portable correctness invariant across physical GPUs.
