### PR TITLE
feat(qwen-vl): add dynamic LoRA binding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ add_library(trtmc_core SHARED
   src/runtime/backend/trt_version.cpp
   src/runtime/core/distributed_runtime.cpp
   src/runtime/core/device_tensor.cpp
+  src/runtime/core/pipeline_pool.cpp
   src/runtime/core/stb_impl.cpp
   src/tokenizer/vocab_tokenizer.cpp
   src/tokenizer/ipa_tokenizer.cpp

--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -193,6 +193,9 @@ struct GenerateConfig {
     bool enable_thinking{true};        ///< If false, disable reasoning/thinking mode
     bool stop_on_boxed_answer{false};  ///< Stop once generated text contains a full \boxed{...}
     int32_t stop_check_interval{16};   ///< Token interval for answer-stop checks
+    // Empty selects the base model. A non-empty ID selects a LoRA adapter
+    // registered with a LoRA-capable runtime before generation.
+    std::string lora_adapter_id;
 };
 
 class ITranscriptionStream {
@@ -473,6 +476,27 @@ class IPipeline {
         (void)conf_threshold;
         throw std::runtime_error(std::string(pipeline_type()) + " does not support detect()");
     }
+
+    // -- Dynamic LoRA adapters --
+    // Adapter files remain external to the base bundle. Implementations load
+    // and cache them by ID; GenerateConfig::lora_adapter_id selects one for a
+    // generation request. An empty ID always selects the base model.
+    virtual bool supports_lora_adapters() const { return false; }
+
+    virtual void load_lora_adapter(const std::string& adapter_id, const std::string& adapter_path) {
+        (void)adapter_id;
+        (void)adapter_path;
+        throw std::runtime_error(std::string(pipeline_type()) +
+                                 " does not support dynamic LoRA adapters");
+    }
+
+    virtual void unload_lora_adapter(const std::string& adapter_id) {
+        (void)adapter_id;
+        throw std::runtime_error(std::string(pipeline_type()) +
+                                 " does not support dynamic LoRA adapters");
+    }
+
+    virtual std::vector<std::string> loaded_lora_adapters() const { return {}; }
 
     // -- Metadata --
     virtual const char* model_id() const = 0;

--- a/include/trtmc/runtime/pipeline_factory.h
+++ b/include/trtmc/runtime/pipeline_factory.h
@@ -13,10 +13,13 @@
 
 #include "trtmc/pipeline.h"
 
+#include <cstddef>
 #include <memory>
 #include <string>
 
 namespace trtmc {
+
+class PipelinePool;
 
 class PipelineFactory {
   public:
@@ -26,6 +29,9 @@ class PipelineFactory {
                                                   bool cuda_graphs = false);
     static std::unique_ptr<IPipeline> from_bundle(const std::string& bundle_path,
                                                   const LoadOptions& options);
+    static std::unique_ptr<PipelinePool> from_bundle_pool(const std::string& bundle_path,
+                                                          std::size_t pool_size,
+                                                          const LoadOptions& options = {});
 };
 
 } // namespace trtmc

--- a/include/trtmc/runtime/pipeline_plugin.h
+++ b/include/trtmc/runtime/pipeline_plugin.h
@@ -13,7 +13,9 @@
 
 #include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace trtmc {
 
@@ -96,6 +98,20 @@ class IPipelinePlugin {
     // 3. Loading TRT engines, creating caches, tokenizers, etc.
     // 4. Returning the fully constructed pipeline
     virtual std::unique_ptr<IPipeline> create(const PipelineContext& ctx) = 0;
+
+    // Create independent request lanes for PipelinePool. The default is
+    // correct for every model but deserializes one engine per lane. Plugins
+    // can override this to share engine weights across execution contexts.
+    virtual std::vector<std::unique_ptr<IPipeline>> create_pool(const PipelineContext& ctx,
+                                                                std::size_t count) {
+        if (count == 0)
+            throw std::invalid_argument("Pipeline pool size must be positive");
+        std::vector<std::unique_ptr<IPipeline>> pipelines;
+        pipelines.reserve(count);
+        for (std::size_t index = 0; index < count; ++index)
+            pipelines.push_back(create(ctx));
+        return pipelines;
+    }
 };
 
 } // namespace trtmc

--- a/include/trtmc/runtime/pipeline_pool.h
+++ b/include/trtmc/runtime/pipeline_pool.h
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/pipeline.h"
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+// Owns independent pipeline execution lanes and schedules exclusive access to
+// them. Each lease isolates mutable execution-context, stream, KV-cache, and
+// adapter-binding state for one in-flight request.
+class PipelinePool {
+  private:
+    struct State;
+    class MaintenanceGuard;
+
+  public:
+    class Lease {
+      public:
+        Lease() = default;
+        ~Lease();
+        Lease(Lease&& other) noexcept;
+        Lease& operator=(Lease&& other) noexcept;
+        Lease(const Lease&) = delete;
+        Lease& operator=(const Lease&) = delete;
+
+        IPipeline* get() const;
+        IPipeline& operator*() const { return *get(); }
+        IPipeline* operator->() const { return get(); }
+        explicit operator bool() const { return state_ != nullptr; }
+
+      private:
+        friend class PipelinePool;
+        Lease(std::shared_ptr<State> state, std::size_t index);
+        void release();
+
+        std::shared_ptr<State> state_;
+        std::size_t index_{0};
+    };
+
+    explicit PipelinePool(std::vector<std::unique_ptr<IPipeline>> pipelines);
+    ~PipelinePool();
+    PipelinePool(PipelinePool&&) noexcept;
+    PipelinePool& operator=(PipelinePool&&) noexcept;
+    PipelinePool(const PipelinePool&) = delete;
+    PipelinePool& operator=(const PipelinePool&) = delete;
+
+    Lease acquire();
+    std::optional<Lease> try_acquire();
+
+    std::size_t size() const;
+    std::size_t available() const;
+
+    bool supports_lora_adapters() const;
+    void load_lora_adapter(const std::string& adapter_id, const std::string& adapter_path);
+    void unload_lora_adapter(const std::string& adapter_id);
+    std::vector<std::string> loaded_lora_adapters() const;
+
+  private:
+    std::shared_ptr<State> state_;
+};
+
+} // namespace trtmc

--- a/include/trtmc/runtime/trt_backend.h
+++ b/include/trtmc/runtime/trt_backend.h
@@ -12,6 +12,7 @@
 #include "trtmc/runtime/trt_module.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <cuda_runtime_api.h>
 #include <memory>
 #include <string>
@@ -25,6 +26,7 @@ struct ModuleCreateOptions {
     cudaStream_t stream{nullptr};            // nullptr = backend creates one
     const char* runtime_cache_path{""};      // RTX: JIT kernel cache file path
     bool cuda_graphs{false};                 // RTX: whole-graph CUDA capture
+    int32_t optimization_profile{0};         // profile selected for this execution context
     void* distributed_communicator{nullptr}; // TensorRT 11.0+ NCCL communicator, optional
     std::shared_ptr<void> distributed_owner; // keeps communicator alive
 };
@@ -45,6 +47,13 @@ struct BackendProfileModule {
 
 struct BackendProfileModules {
     std::vector<BackendProfileModule> modules;
+};
+
+// One execution module per request lane. All modules share a single
+// deserialized engine, while each ModuleCreateOptions entry may provide an
+// independent CUDA stream and distributed-runtime ownership.
+struct BackendContextModules {
+    std::vector<std::unique_ptr<ITrtModule>> modules;
 };
 
 // Per-DSO backend. Holds shared state (TRT runtime, RTX runtime cache).
@@ -70,6 +79,13 @@ class IBackend {
     create_profile_modules(const void* plan_data, size_t plan_size,
                            const ModuleCreateOptions& options,
                            const std::vector<int32_t>& profile_indices) = 0;
+
+    // Deserialize once and create one execution context for each options
+    // entry, using its requested optimization profile. Intended for
+    // concurrent request lanes.
+    virtual BackendContextModules
+    create_context_modules(const void* plan_data, size_t plan_size,
+                           const std::vector<ModuleCreateOptions>& options) = 0;
 
     // Backend identity: "trt" or "trt_rtx"
     virtual const char* name() const = 0;

--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -11,6 +11,7 @@ import json
 import re
 import sys
 import time
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -823,6 +824,13 @@ def build_bundle(
                 quant_scales=quant_scales,
                 quant_calibration_samples=quant_calibration_samples,
             )
+            quant_method = str(config.raw.get(
+                "quantization_config", {}).get("quant_method", "")).lower()
+            if (quant_plan.scale_source == "modelopt"
+                    and quant_method in {
+                        "awq", "gptq", "compressed-tensors", "compressed_tensors"
+                    }):
+                quant_plan = replace(quant_plan, scale_source="prequantized")
             exclude_patterns = (plugin.quant_exclude_patterns(quant_plan.quant_format)
                                 if hasattr(plugin, 'quant_exclude_patterns') else None)
             quant_ctx = build_quant_context(

--- a/python/tensorrt_model_connect/families/qwen_vl/checkpoint_mapper.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/checkpoint_mapper.py
@@ -360,14 +360,44 @@ def _to_numpy_fp32(t) -> np.ndarray:
     return np.asarray(t, dtype=np.float32)
 
 
-def _load_tensor(readers: list, name: str) -> np.ndarray:
+def _is_float8_tensor(t) -> bool:
+    """Return whether *t* stores a supported float8 checkpoint tensor."""
+    dtype_name = str(getattr(t, "dtype", "")).lower()
+    return "float8_e4m3" in dtype_name or "f8_e4m3" in dtype_name
+
+
+def _get_raw_tensor(readers: list, name: str):
+    """Look up a tensor without converting away its checkpoint dtype."""
     tensor_map = getattr(readers, "tensor_map", None)
     if tensor_map is not None:
         reader = tensor_map.get(name)
         if reader is None:
             raise KeyError(f"Tensor not found: {name}")
-        return _to_numpy_fp32(reader.get_tensor(name))
-    for r in readers:
-        if name in r.keys():
-            return _to_numpy_fp32(r.get_tensor(name))
+        return reader.get_tensor(name)
+    for reader in readers:
+        if name in reader.keys():
+            return reader.get_tensor(name)
     raise KeyError(f"Tensor not found: {name}")
+
+
+def _load_tensor(readers: list, name: str) -> np.ndarray:
+    raw = _get_raw_tensor(readers, name)
+    value = _to_numpy_fp32(raw)
+    if not _is_float8_tensor(raw):
+        return value
+
+    # Compressed-Tensors float-quantized checkpoints store the dequantization
+    # factor beside each FP8 projection. A non-quantized TRT build consumes
+    # ordinary FP16/FP32 constants, so restore the represented weight here.
+    if not name.endswith(".weight"):
+        raise ValueError(f"Unsupported float8 checkpoint tensor: {name}")
+    scale_name = f"{name[:-len('.weight')]}.weight_scale"
+    if not _has_tensor(readers, scale_name):
+        raise ValueError(
+            f"Float8 checkpoint tensor {name} is missing {scale_name}")
+    scale = _to_numpy_fp32(_get_raw_tensor(readers, scale_name))
+    if scale.size != 1:
+        raise NotImplementedError(
+            "Qwen-VL float8 checkpoint loading currently supports scalar "
+            f"weight scales only; {scale_name} has shape {scale.shape}")
+    return value * float(scale.reshape(-1)[0])

--- a/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
@@ -28,6 +28,7 @@ from . import graph_ops
 from . import graph_blocks
 from .config import ModelConfig
 from .default_dual_profile_decoder import build_dual_profile_decoder_engine
+from .lora import DynamicLoraConfig
 from .utils import const_in_work_dtype, create_builder_context
 
 trt = trt_compat.get_trt()
@@ -106,6 +107,7 @@ def build_standard_decoder_engine(
     # the active engine layout while building.
     config.raw["_decoder_engine_layout_supported"] = True
     decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+    lora_config = DynamicLoraConfig.from_model_config(config)
 
     # Dispatch to the dynamic-Sq builder for dual-profile and split-prefill
     # engines. Quantized builds (``quant_ctx``) thread Q/DQ insertion through
@@ -169,6 +171,15 @@ def build_standard_decoder_engine(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
     attention_window = max_cache_length + 1
     dynamic_kv_cache = bool(config.raw.get("dynamic_kv_cache", False))
+    force_decomposed_attention = bool(
+        config.raw.get("_force_decomposed_attention", False))
+    rope_scaling = config.raw.get("rope_scaling") or {}
+    raw_mrope_section = (
+        rope_scaling.get("mrope_section")
+        if isinstance(rope_scaling, dict) else None)
+    mrope_section = (
+        tuple(int(value) for value in raw_mrope_section)
+        if raw_mrope_section is not None else None)
     dynamic_kv_opt_rows = int(config.raw.get("_dynamic_kv_opt_length", max_cache_length))
     dynamic_kv_opt_rows = max(1, min(dynamic_kv_opt_rows, max_cache_length))
     raw_profile_rows = config.raw.get("_dynamic_kv_profile_rows")
@@ -209,6 +220,9 @@ def build_standard_decoder_engine(
     # ---------------------------------------------------------------
     token_id = network.add_input("token_id", trt.int32, (1,))
     position_id = network.add_input("position_id", trt.int32, (1,))
+    mrope_position_ids = (
+        network.add_input("mrope_position_ids", trt.int32, (3,))
+        if mrope_section is not None else None)
     attention_mask = network.add_input(
         "attention_mask", trt.float32,
         (1, -1) if dynamic_kv_cache else (1, attention_window))
@@ -303,6 +317,14 @@ def build_standard_decoder_engine(
 
     if position_type == "rope":
         graph_ops.validate_native_rope_dim(rotary_embedding_dim)
+        if mrope_section is not None:
+            if len(mrope_section) != 3 or any(value <= 0 for value in mrope_section):
+                raise ValueError(
+                    "rope_scaling.mrope_section must contain three positive integers")
+            if sum(mrope_section) != rotary_embedding_dim // 2:
+                raise ValueError(
+                    "rope_scaling.mrope_section must sum to half the rotary dimension; "
+                    f"got {mrope_section} for rotary dimension {rotary_embedding_dim}")
         cos_half_np = graph_ops.make_rope_table_half_dim(
             attention_window, head_dim, config.rope_theta, True,
             partial_rotary_factor, interleaved=interleaved_rope)
@@ -450,8 +472,12 @@ def build_standard_decoder_engine(
             sin_half_tensor=sin_half_tensor,
             rotary_embedding_dim=rotary_embedding_dim,
             interleaved_rope=interleaved_rope,
+            mrope_position_ids=mrope_position_ids,
+            mrope_section=mrope_section,
             ffi_attention_kernel=ffi_attention_kernel,
             dynamic_kv_cache=dynamic_kv_cache,
+            force_decomposed_attention=force_decomposed_attention,
+            lora_config=lora_config,
         )
 
         hidden_state = result["hidden"]
@@ -582,8 +608,12 @@ def _add_decoder_layer(
     sin_half_tensor: trt.ITensor | None = None,
     rotary_embedding_dim: int = 0,
     interleaved_rope: bool = False,
+    mrope_position_ids: trt.ITensor | None = None,
+    mrope_section: tuple[int, int, int] | None = None,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
+    force_decomposed_attention: bool = False,
+    lora_config: DynamicLoraConfig | None = None,
     eps: float | None = None,
 ) -> dict[str, trt.ITensor]:
     """Add one standard decoder layer block. Returns hidden, present_k, present_v."""
@@ -608,8 +638,12 @@ def _add_decoder_layer(
         sin_half_tensor=sin_half_tensor,
         rotary_embedding_dim=rotary_embedding_dim,
         interleaved_rope=interleaved_rope,
+        mrope_position_ids=mrope_position_ids,
+        mrope_section=mrope_section,
         ffi_attention_kernel=ffi_attention_kernel,
         dynamic_kv_cache=dynamic_kv_cache,
+        force_decomposed_attention=force_decomposed_attention,
+        lora_config=lora_config,
     )
     attn_out = attn["attn_out"]
     present_k = attn["present_k"]
@@ -646,7 +680,8 @@ def _add_decoder_layer(
         mlp_out = graph_blocks.add_swiglu_mlp(
             network, norm2, weights=weights, prefix=prefix,
             hidden_size=hidden_size, mlp_size=mlp_size, dtype=dtype,
-            quant_ctx=quant_ctx, layer_prefix=prefix)
+            quant_ctx=quant_ctx, layer_prefix=prefix,
+            lora_config=lora_config)
 
     # Final residual connection
     if parallel_residual:

--- a/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
@@ -171,8 +171,6 @@ def build_standard_decoder_engine(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
     attention_window = max_cache_length + 1
     dynamic_kv_cache = bool(config.raw.get("dynamic_kv_cache", False))
-    force_decomposed_attention = bool(
-        config.raw.get("_force_decomposed_attention", False))
     rope_scaling = config.raw.get("rope_scaling") or {}
     raw_mrope_section = (
         rope_scaling.get("mrope_section")
@@ -476,7 +474,6 @@ def build_standard_decoder_engine(
             mrope_section=mrope_section,
             ffi_attention_kernel=ffi_attention_kernel,
             dynamic_kv_cache=dynamic_kv_cache,
-            force_decomposed_attention=force_decomposed_attention,
             lora_config=lora_config,
         )
 
@@ -612,7 +609,6 @@ def _add_decoder_layer(
     mrope_section: tuple[int, int, int] | None = None,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
-    force_decomposed_attention: bool = False,
     lora_config: DynamicLoraConfig | None = None,
     eps: float | None = None,
 ) -> dict[str, trt.ITensor]:
@@ -642,7 +638,6 @@ def _add_decoder_layer(
         mrope_section=mrope_section,
         ffi_attention_kernel=ffi_attention_kernel,
         dynamic_kv_cache=dynamic_kv_cache,
-        force_decomposed_attention=force_decomposed_attention,
         lora_config=lora_config,
     )
     attn_out = attn["attn_out"]

--- a/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
@@ -50,6 +50,7 @@ from tensorrt_model_connect import trt_compat
 
 from . import graph_ops
 from . import graph_blocks
+from .lora import DynamicLoraConfig
 from .utils import (
     const_in_work_dtype as _const_in_work_dtype,
     create_builder_context,
@@ -227,6 +228,24 @@ def build_dual_profile_decoder_engine(
     kv_attention_size = graph_blocks.infer_kv_attention_size(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
     rotary_embedding_dim = int(head_dim * partial_rotary_factor)
+    lora_config = DynamicLoraConfig.from_model_config(config)
+    rope_scaling = config.raw.get("rope_scaling") or {}
+    raw_mrope_section = (
+        rope_scaling.get("mrope_section")
+        if isinstance(rope_scaling, dict) else None)
+    mrope_section = (
+        tuple(int(value) for value in raw_mrope_section)
+        if raw_mrope_section is not None else None)
+    if mrope_section is not None:
+        if position_type != "rope":
+            raise ValueError("mRoPE requires position_type='rope'")
+        if len(mrope_section) != 3 or any(value <= 0 for value in mrope_section):
+            raise ValueError(
+                "rope_scaling.mrope_section must contain three positive integers")
+        if sum(mrope_section) != rotary_embedding_dim // 2:
+            raise ValueError(
+                "rope_scaling.mrope_section must sum to half the rotary dimension; "
+                f"got {mrope_section} for rotary dimension {rotary_embedding_dim}")
 
     builder_context = create_builder_context(
         verbose=verbose,
@@ -246,6 +265,9 @@ def build_dual_profile_decoder_engine(
     # ---- Inputs (dynamic Sq) ---------------------------------------------
     token_id = network.add_input("token_id", trt.int32, (-1,))
     position_id = network.add_input("position_id", trt.int32, (-1,))
+    mrope_position_ids = (
+        network.add_input("mrope_position_ids", trt.int32, (3, -1))
+        if mrope_section is not None else None)
     attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
     input_embed_tensor = None
     use_input_embed_tensor = None
@@ -288,6 +310,10 @@ def build_dual_profile_decoder_engine(
         min_sq = opt_sq if fixed else 1
         prof.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
         prof.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
+        if mrope_position_ids is not None:
+            prof.set_shape(
+                "mrope_position_ids",
+                (3, min_sq), (3, opt_sq), (3, max_sq))
         prof.set_shape(
             "attention_mask",
             (min_sq, max_cache_length + min_sq),
@@ -416,7 +442,8 @@ def build_dual_profile_decoder_engine(
     attn_scale = (1.0 / np.sqrt(max(head_dim, 1))) if scale_attn_weights else 1.0
 
     # Quantization-aware matmul (passes weight_name through to QuantContext).
-    matmul = _make_matmul_fn(network, work_np_dtype, quant_ctx)
+    matmul = _make_matmul_fn(
+        network, work_np_dtype, quant_ctx, lora_config=lora_config)
 
     # ---- Embedding -------------------------------------------------------
     emb = network.add_gather(embedding_table, token_id, 0)
@@ -527,16 +554,26 @@ def build_dual_profile_decoder_engine(
         # Position embedding (RoPE only; learned was applied above and ALiBi
         # is added into the attention mask).
         if position_type == "rope":
-            q = graph_ops.add_apply_rope_native(
-                network, q, num_heads, head_dim,
-                cos_half_table, sin_half_table, position_id,
-                rotary_embedding_dim, interleaved_rope,
-                sequence_length=None)
-            k = graph_ops.add_apply_rope_native(
-                network, k, num_kv_heads, head_dim,
-                cos_half_table, sin_half_table, position_id,
-                rotary_embedding_dim, interleaved_rope,
-                sequence_length=None)
+            if mrope_position_ids is not None and mrope_section is not None:
+                q = graph_ops.add_apply_mrope_native_sequence(
+                    network, q, num_heads, head_dim,
+                    cos_half_table, sin_half_table, mrope_position_ids,
+                    mrope_section, rotary_embedding_dim, interleaved_rope)
+                k = graph_ops.add_apply_mrope_native_sequence(
+                    network, k, num_kv_heads, head_dim,
+                    cos_half_table, sin_half_table, mrope_position_ids,
+                    mrope_section, rotary_embedding_dim, interleaved_rope)
+            else:
+                q = graph_ops.add_apply_rope_native(
+                    network, q, num_heads, head_dim,
+                    cos_half_table, sin_half_table, position_id,
+                    rotary_embedding_dim, interleaved_rope,
+                    sequence_length=None)
+                k = graph_ops.add_apply_rope_native(
+                    network, k, num_kv_heads, head_dim,
+                    cos_half_table, sin_half_table, position_id,
+                    rotary_embedding_dim, interleaved_rope,
+                    sequence_length=None)
 
         # Present K / V (this step's raw K / V), shape (Sq, attn_size).
         present_k_outs.append(k)

--- a/python/tensorrt_model_connect/families/qwen_vl/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/graph_blocks.py
@@ -33,6 +33,7 @@ trt = trt_compat.get_trt()
 
 if TYPE_CHECKING:
     from .checkpoint_mapper import WeightDict
+    from .lora import DynamicLoraConfig
     from ...quantization.context import QuantContext
 
 
@@ -41,22 +42,36 @@ if TYPE_CHECKING:
 # blocks themselves).
 # ---------------------------------------------------------------------------
 
-def make_matmul_fn(network, dtype, quant_ctx):
+def make_matmul_fn(network, dtype, quant_ctx, lora_config=None):
     """Create a matmul callable that routes through quant_ctx if present.
 
     Returns a function: (lhs, lhs_w, rhs_w, rhs_weights, weight_name) -> ITensor
     """
-    if quant_ctx is None:
-        def matmul(lhs, lhs_w, rhs_w, rhs_weights, weight_name):
-            return graph_ops.add_matmul_rhs_constant(
+    def matmul(lhs, lhs_w, rhs_w, rhs_weights, weight_name):
+        if quant_ctx is None:
+            base = graph_ops.add_matmul_rhs_constant(
                 network, lhs, lhs_w, rhs_w, rhs_weights, dtype=dtype)
-        return matmul
-    else:
-        def matmul(lhs, lhs_w, rhs_w, rhs_weights, weight_name):
-            return quant_ctx.maybe_quantized_matmul(
+        else:
+            base = quant_ctx.maybe_quantized_matmul(
                 network, lhs, lhs_w, rhs_w, rhs_weights, weight_name,
                 dtype=dtype)
-        return matmul
+
+        if lora_config is None or not lora_config.targets_weight(weight_name):
+            return base
+
+        a_name, b_name = lora_config.input_names(weight_name)
+        lora_a = network.add_input(
+            a_name, lhs.dtype, (lhs_w, lora_config.max_rank))
+        lora_b = network.add_input(
+            b_name, lhs.dtype, (lora_config.max_rank, rhs_w))
+        if lora_a is None or lora_b is None:
+            raise RuntimeError(
+                f"Failed to add dynamic LoRA inputs for projection {weight_name}")
+        delta = graph_ops.add_lora_delta(network, lhs, lora_a, lora_b)
+        return network.add_elementwise(
+            base, delta, trt.ElementWiseOperation.SUM).get_output(0)
+
+    return matmul
 
 
 _make_matmul_fn = make_matmul_fn
@@ -167,9 +182,13 @@ def add_attention_block(
     sin_half_tensor: trt.ITensor | None = None,
     rotary_embedding_dim: int = 0,
     interleaved_rope: bool = False,
+    mrope_position_ids: trt.ITensor | None = None,
+    mrope_section: tuple[int, int, int] | None = None,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
     sequence_length: int | None = 1,
+    force_decomposed_attention: bool = False,
+    lora_config: DynamicLoraConfig | None = None,
 ) -> dict[str, trt.ITensor]:
     """Pre-norm -> QKV -> RoPE -> cache concat -> attention -> output proj.
 
@@ -182,7 +201,7 @@ def add_attention_block(
     ALiBi is represented as a per-head additive attention mask and still uses
     native IAttention.
     """
-    matmul = _make_matmul_fn(network, dtype, quant_ctx)
+    matmul = _make_matmul_fn(network, dtype, quant_ctx, lora_config)
     attention_window = max_cache_length + 1
     if num_kv_heads is None:
         num_kv_heads = num_heads
@@ -243,14 +262,27 @@ def add_attention_block(
                 "TRT native IRotaryEmbeddingLayer")
         rope_dim = rotary_embedding_dim or head_dim
         rope_dim = graph_ops.validate_native_rope_dim(rope_dim)
-        q = graph_ops.add_apply_rope_native(
-            network, q, num_heads, head_dim,
-            cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope, sequence_length=sequence_length)
-        k = graph_ops.add_apply_rope_native(
-            network, k, num_kv_heads, head_dim,
-            cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope, sequence_length=sequence_length)
+        if mrope_position_ids is not None and mrope_section is not None:
+            if sequence_length != 1:
+                raise NotImplementedError(
+                    "graph_blocks mRoPE currently supports single-token execution")
+            q = graph_ops.add_apply_mrope_native(
+                network, q, num_heads, head_dim,
+                cos_half_tensor, sin_half_tensor, mrope_position_ids,
+                mrope_section, rope_dim, interleaved_rope)
+            k = graph_ops.add_apply_mrope_native(
+                network, k, num_kv_heads, head_dim,
+                cos_half_tensor, sin_half_tensor, mrope_position_ids,
+                mrope_section, rope_dim, interleaved_rope)
+        else:
+            q = graph_ops.add_apply_rope_native(
+                network, q, num_heads, head_dim,
+                cos_half_tensor, sin_half_tensor, position_id,
+                rope_dim, interleaved_rope, sequence_length=sequence_length)
+            k = graph_ops.add_apply_rope_native(
+                network, k, num_kv_heads, head_dim,
+                cos_half_tensor, sin_half_tensor, position_id,
+                rope_dim, interleaved_rope, sequence_length=sequence_length)
 
     # Save present K/V (before concatenation, this is the raw projection output)
     present_k = k
@@ -309,6 +341,7 @@ def add_attention_block(
             causal=False,
             mask=mask_4d,
             scale=attention_scale,
+            force_decomposed_attention=force_decomposed_attention,
         )
     elif ffi_attention_kernel is not None:
         if num_kv_heads != num_heads:
@@ -351,9 +384,10 @@ def add_swiglu_mlp(
     dtype: np.dtype = np.float32,
     quant_ctx: QuantContext | None = None,
     layer_prefix: str = "",
+    lora_config: DynamicLoraConfig | None = None,
 ) -> trt.ITensor:
     """Gate/up/down SwiGLU MLP. Returns output tensor."""
-    matmul = _make_matmul_fn(network, dtype, quant_ctx)
+    matmul = _make_matmul_fn(network, dtype, quant_ctx, lora_config)
     _lp = layer_prefix or prefix
 
     gate = matmul(inp, hidden_size, mlp_size,

--- a/python/tensorrt_model_connect/families/qwen_vl/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/graph_blocks.py
@@ -187,7 +187,6 @@ def add_attention_block(
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
     sequence_length: int | None = 1,
-    force_decomposed_attention: bool = False,
     lora_config: DynamicLoraConfig | None = None,
 ) -> dict[str, trt.ITensor]:
     """Pre-norm -> QKV -> RoPE -> cache concat -> attention -> output proj.
@@ -341,7 +340,6 @@ def add_attention_block(
             causal=False,
             mask=mask_4d,
             scale=attention_scale,
-            force_decomposed_attention=force_decomposed_attention,
         )
     elif ffi_attention_kernel is not None:
         if num_kv_heads != num_heads:

--- a/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
@@ -3008,7 +3008,6 @@ def add_attention_from_rows(
     scale: float | None = None,
     logit_softcap: float | None = None,
     fp32_accumulation: bool = False,
-    force_decomposed_attention: bool = False,
     tag: str | None = None,
 ) -> trt.ITensor:
     """Native IAttention for row-major [S, H * D] Q/K/V tensors.
@@ -3031,9 +3030,7 @@ def add_attention_from_rows(
     if scale is None:
         scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
     use_decomposed_attention = (
-        force_decomposed_attention
-        or (logit_softcap is not None and float(logit_softcap) > 0.0)
-    )
+        logit_softcap is not None and float(logit_softcap) > 0.0)
     if use_decomposed_attention:
         if causal:
             raise NotImplementedError(

--- a/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/graph_ops.py
@@ -103,6 +103,43 @@ def add_matmul_rhs_constant(
     return _cast_back_to_trt_dtype(network, mm.get_output(0), lhs.dtype)
 
 
+def add_matmul_rhs_tensor(
+    network: trt.INetworkDefinition,
+    lhs: trt.ITensor,
+    rhs: trt.ITensor,
+    *,
+    fp32_accumulation: bool = True,
+) -> trt.ITensor:
+    """Matrix multiply ``lhs @ rhs`` when both operands are runtime tensors."""
+    if fp32_accumulation:
+        return _add_matrix_multiply_with_fp32_accumulation(
+            network,
+            lhs, trt.MatrixOperation.NONE,
+            rhs, trt.MatrixOperation.NONE,
+        )
+    mm = network.add_matrix_multiply(
+        lhs, trt.MatrixOperation.NONE,
+        rhs, trt.MatrixOperation.NONE,
+    )
+    return _cast_back_to_trt_dtype(network, mm.get_output(0), lhs.dtype)
+
+
+def add_lora_delta(
+    network: trt.INetworkDefinition,
+    lhs: trt.ITensor,
+    lora_a: trt.ITensor,
+    lora_b: trt.ITensor,
+) -> trt.ITensor:
+    """Compute ``(lhs @ A) @ B`` for dynamically bound LoRA tensors.
+
+    ``A`` is stored as ``[in_features, max_rank]`` and ``B`` as
+    ``[max_rank, out_features]``.  The PEFT scale ``alpha / rank`` must be
+    folded into B by the adapter loader before binding.
+    """
+    low_rank = add_matmul_rhs_tensor(network, lhs, lora_a)
+    return add_matmul_rhs_tensor(network, low_rank, lora_b)
+
+
 def add_bias_sum(
     network: trt.INetworkDefinition,
     inp: trt.ITensor,
@@ -2611,6 +2648,96 @@ def add_apply_rope_native_sequence(
         network, rope.get_output(0), attention_size, sequence_length)
 
 
+def add_apply_mrope_native(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    num_heads: int,
+    head_dim: int,
+    cos_cache_2d: trt.ITensor,
+    sin_cache_2d: trt.ITensor,
+    position_ids: trt.ITensor,
+    mrope_section: tuple[int, int, int],
+    rotary_embedding_dim: int,
+    interleaved: bool = False,
+) -> trt.ITensor:
+    """Apply Qwen2.5-VL temporal/height/width RoPE to one token."""
+    rotary_embedding_dim = validate_native_rope_dim(rotary_embedding_dim)
+    sections = tuple(int(value) for value in mrope_section)
+    if len(sections) != 3 or any(value <= 0 for value in sections):
+        raise ValueError("mrope_section must contain three positive integers")
+    if sum(sections) != rotary_embedding_dim // 2:
+        raise ValueError(
+            "mrope_section must sum to half the rotary embedding dimension; "
+            f"got {sections} for rotary dimension {rotary_embedding_dim}")
+
+    def build_cache(cache: trt.ITensor) -> trt.ITensor:
+        selected = network.add_gather(cache, position_ids, 0).get_output(0)
+        offset = 0
+        parts = []
+        for axis, width in enumerate(sections):
+            part = network.add_slice(
+                selected, start=(axis, offset), shape=(1, width), stride=(1, 1))
+            parts.append(part.get_output(0))
+            offset += width
+        joined = network.add_concatenation(parts)
+        joined.axis = 1
+        shaped = network.add_shuffle(joined.get_output(0))
+        shaped.reshape_dims = (1, 1, rotary_embedding_dim // 2)
+        return shaped.get_output(0)
+
+    return add_apply_rope_native_sequence(
+        network, inp, num_heads, head_dim,
+        build_cache(cos_cache_2d), build_cache(sin_cache_2d),
+        rotary_embedding_dim, interleaved, sequence_length=1)
+
+
+def add_apply_mrope_native_sequence(
+    network: trt.INetworkDefinition,
+    inp: trt.ITensor,
+    num_heads: int,
+    head_dim: int,
+    cos_cache_2d: trt.ITensor,
+    sin_cache_2d: trt.ITensor,
+    position_ids: trt.ITensor,
+    mrope_section: tuple[int, int, int],
+    rotary_embedding_dim: int,
+    interleaved: bool = False,
+) -> trt.ITensor:
+    """Apply Qwen2.5-VL mRoPE to a runtime-dynamic token sequence."""
+    rotary_embedding_dim = validate_native_rope_dim(rotary_embedding_dim)
+    sections = tuple(int(value) for value in mrope_section)
+    if len(sections) != 3 or any(value <= 0 for value in sections):
+        raise ValueError("mrope_section must contain three positive integers")
+    half_dim = rotary_embedding_dim // 2
+    if sum(sections) != half_dim:
+        raise ValueError(
+            "mrope_section must sum to half the rotary embedding dimension; "
+            f"got {sections} for rotary dimension {rotary_embedding_dim}")
+
+    def build_cache(cache: trt.ITensor) -> trt.ITensor:
+        selected = network.add_gather(cache, position_ids, 0).get_output(0)
+        offset = 0
+        parts = []
+        for axis, width in enumerate(sections):
+            axis_index = add_constant(
+                network, (1,), np.array([axis], dtype=np.int32), dtype=np.int32)
+            axis_values = network.add_gather(selected, axis_index, 0).get_output(0)
+            column_indices = add_constant(
+                network, (width,), np.arange(offset, offset + width, dtype=np.int32),
+                dtype=np.int32)
+            part = network.add_gather(axis_values, column_indices, 2)
+            parts.append(part.get_output(0))
+            offset += width
+        joined = network.add_concatenation(parts)
+        joined.axis = 2
+        return joined.get_output(0)
+
+    return add_apply_rope_native_sequence(
+        network, inp, num_heads, head_dim,
+        build_cache(cos_cache_2d), build_cache(sin_cache_2d),
+        rotary_embedding_dim, interleaved, sequence_length=None)
+
+
 def add_apply_rope_native_from_full_cache(
     network: trt.INetworkDefinition,
     inp: trt.ITensor,
@@ -2806,7 +2933,7 @@ def _repeat_kv_heads_4d(
     return concat.get_output(0)
 
 
-def _add_attention_core_with_logit_softcap(
+def _add_decomposed_attention_core(
     network: trt.INetworkDefinition,
     q_4d: trt.ITensor,
     k_4d: trt.ITensor,
@@ -2817,7 +2944,7 @@ def _add_attention_core_with_logit_softcap(
     head_dim: int,
     mask: trt.ITensor | None,
     scale: float,
-    logit_softcap: float,
+    logit_softcap: float | None = None,
 ) -> trt.ITensor:
     output_dtype = q_4d.dtype
     k_4d = _repeat_kv_heads_4d(
@@ -2844,8 +2971,10 @@ def _add_attention_core_with_logit_softcap(
     scores = network.add_elementwise(
         scores, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
 
-    scores = add_tanh_softcap(
-        network, scores, logit_softcap, scalar_shape=(1, 1, 1, 1))
+    if logit_softcap is not None and float(logit_softcap) > 0.0:
+        scores = add_tanh_softcap(
+            network, scores, float(logit_softcap),
+            scalar_shape=(1, 1, 1, 1))
 
     if score_mask is not None:
         scores = network.add_elementwise(
@@ -2879,6 +3008,7 @@ def add_attention_from_rows(
     scale: float | None = None,
     logit_softcap: float | None = None,
     fp32_accumulation: bool = False,
+    force_decomposed_attention: bool = False,
     tag: str | None = None,
 ) -> trt.ITensor:
     """Native IAttention for row-major [S, H * D] Q/K/V tensors.
@@ -2900,14 +3030,18 @@ def add_attention_from_rows(
         tag=None if tag is None else tag + ".v")
     if scale is None:
         scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
-    if logit_softcap is not None and float(logit_softcap) > 0.0:
+    use_decomposed_attention = (
+        force_decomposed_attention
+        or (logit_softcap is not None and float(logit_softcap) > 0.0)
+    )
+    if use_decomposed_attention:
         if causal:
             raise NotImplementedError(
-                "logit_softcap attention requires an explicit additive mask")
-        ctx_4d = _add_attention_core_with_logit_softcap(
+                "decomposed attention requires an explicit additive mask")
+        ctx_4d = _add_decomposed_attention_core(
             network, q_4d, k_4d, v_4d,
             num_heads=num_heads, num_kv_heads=kv_heads, head_dim=head_dim,
-            mask=mask, scale=scale, logit_softcap=float(logit_softcap))
+            mask=mask, scale=scale, logit_softcap=logit_softcap)
     else:
         ctx_4d = add_attention_core(
             network, q_4d, k_4d, v_4d, causal=causal, mask=mask, scale=scale,

--- a/python/tensorrt_model_connect/families/qwen_vl/lora.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/lora.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build-time contract for dynamically bound Qwen-VL LoRA weights.
+
+The TensorRT graph consumes one fixed-shape A/B pair for every selected
+projection.  Adapter loading is deliberately outside the graph builder: the
+runtime owns the device buffers and binds their addresses to these inputs.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from .lora_peft import (
+    PeftLoraConfig,
+    load_peft_lora_artifact,
+)
+
+
+PEFT_TO_WEIGHT_NAME = {
+    "q_proj": "w_q",
+    "k_proj": "w_k",
+    "v_proj": "w_v",
+    "o_proj": "w_o",
+    "gate_proj": "w_gate",
+    "up_proj": "w_up",
+    "down_proj": "w_down",
+}
+
+DEFAULT_TARGET_MODULES = tuple(PEFT_TO_WEIGHT_NAME)
+_MAX_SUPPORTED_RANK = 256
+_PEFT_WEIGHT_RE = re.compile(
+    r"(?:^|\.)layers\.(?P<layer>\d+)\."
+    r"(?:self_attn|mlp)\."
+    r"(?P<module>q_proj|k_proj|v_proj|o_proj|gate_proj|up_proj|down_proj)\."
+    r"lora_(?P<side>[AB])(?:\.[^.]+)?\.weight$"
+)
+
+
+def _parse_target_modules(raw: object) -> tuple[str, ...]:
+    if raw is None:
+        return DEFAULT_TARGET_MODULES
+    if not isinstance(raw, str):
+        raise ValueError("qwen_vl_lora.target_modules must be a comma-separated string")
+
+    modules: list[str] = []
+    for item in raw.split(","):
+        name = item.strip()
+        if not name:
+            continue
+        if name not in PEFT_TO_WEIGHT_NAME:
+            supported = ", ".join(DEFAULT_TARGET_MODULES)
+            raise ValueError(
+                f"Unsupported Qwen-VL LoRA target module {name!r}; supported: {supported}")
+        if name not in modules:
+            modules.append(name)
+    if not modules:
+        raise ValueError("qwen_vl_lora.target_modules must select at least one module")
+    return tuple(modules)
+
+
+@dataclass(frozen=True)
+class DynamicLoraConfig:
+    """Validated engine-build settings for dynamic LoRA binding."""
+
+    enabled: bool = False
+    max_rank: int = 0
+    target_modules: tuple[str, ...] = DEFAULT_TARGET_MODULES
+
+    @classmethod
+    def from_model_config(cls, model_config) -> "DynamicLoraConfig":
+        family_options = model_config.raw.get("_family_build_options", {})
+        if not isinstance(family_options, dict):
+            return cls()
+        raw = family_options.get("qwen_vl_lora", {})
+        if not isinstance(raw, dict):
+            raise ValueError("qwen_vl_lora build options must be an object")
+
+        enabled = bool(raw.get("enabled", False))
+        max_rank = int(raw.get("max_rank", 0) or 0)
+        target_modules = _parse_target_modules(raw.get("target_modules"))
+        if not enabled:
+            return cls(target_modules=target_modules)
+        if max_rank <= 0 or max_rank > _MAX_SUPPORTED_RANK:
+            raise ValueError(
+                "qwen_vl_lora.max_rank must be between 1 and "
+                f"{_MAX_SUPPORTED_RANK} when dynamic LoRA is enabled")
+        return cls(enabled=True, max_rank=max_rank, target_modules=target_modules)
+
+    @property
+    def canonical_targets(self) -> frozenset[str]:
+        return frozenset(PEFT_TO_WEIGHT_NAME[name] for name in self.target_modules)
+
+    def targets_weight(self, weight_name: str) -> bool:
+        return self.enabled and weight_name.rsplit(".", 1)[-1] in self.canonical_targets
+
+    def input_names(self, weight_name: str) -> tuple[str, str]:
+        """Return stable TensorRT input names for a canonical projection name."""
+        stem = weight_name.replace(".", "_")
+        return f"lora_a_{stem}", f"lora_b_{stem}"
+
+    def bundle_config(self) -> dict[str, object]:
+        return {
+            "lora_dynamic_binding": self.enabled,
+            "lora_max_rank": self.max_rank,
+            "lora_target_modules": list(self.target_modules) if self.enabled else [],
+            "lora_scale_in_b": self.enabled,
+        }
+
+
+@dataclass(frozen=True)
+class PreparedLoraAdapter:
+    """PEFT adapter tensors normalized for the TensorRT binding contract."""
+
+    adapter_id: str
+    tensors: dict[str, np.ndarray]
+    rank: int
+    scale: float
+
+
+def prepare_peft_adapter(
+    adapter_id: str,
+    adapter_config: dict,
+    peft_tensors: dict[str, np.ndarray],
+    *,
+    max_rank: int,
+    dtype: np.dtype = np.float16,
+) -> PreparedLoraAdapter:
+    """Convert PEFT A/B tensors into padded, scale-folded runtime inputs."""
+    if not adapter_id:
+        raise ValueError("adapter_id must not be empty")
+    peft_config = PeftLoraConfig.from_dict(adapter_config)
+    rank = peft_config.rank
+    scale = peft_config.scale
+    raw_targets = peft_config.target_modules or DEFAULT_TARGET_MODULES
+    targets = _parse_target_modules(",".join(raw_targets))
+    if max_rank <= 0 or rank > max_rank:
+        raise ValueError(
+            f"Adapter rank {rank} exceeds engine max_rank {max_rank}")
+
+    pairs: dict[tuple[int, str], dict[str, np.ndarray]] = {}
+    for name, value in peft_tensors.items():
+        match = _PEFT_WEIGHT_RE.search(name)
+        if match is None:
+            continue
+        module = match.group("module")
+        if module not in targets:
+            continue
+        key = (int(match.group("layer")), module)
+        pairs.setdefault(key, {})[match.group("side")] = np.asarray(value)
+
+    if not pairs:
+        raise ValueError("No supported Qwen-VL LoRA A/B tensors were found")
+
+    prepared: dict[str, np.ndarray] = {}
+    target_dtype = np.dtype(dtype)
+    for (layer, module), sides in sorted(pairs.items()):
+        if set(sides) != {"A", "B"}:
+            missing = "B" if "A" in sides else "A"
+            raise ValueError(f"Missing LoRA {missing} tensor for layer {layer} {module}")
+        a = sides["A"]
+        b = sides["B"]
+        if a.ndim != 2 or b.ndim != 2:
+            raise ValueError(f"LoRA tensors for layer {layer} {module} must be rank-2")
+        if a.shape[0] != rank or b.shape[1] != rank or a.shape[0] != b.shape[1]:
+            raise ValueError(
+                f"LoRA rank mismatch for layer {layer} {module}: "
+                f"A={a.shape}, B={b.shape}, config rank={rank}")
+
+        # PEFT: A=[rank,in], B=[out,rank]. TensorRT: A=[in,max_rank],
+        # B=[max_rank,out]. Unused rank columns/rows remain zero.
+        runtime_a = np.zeros((a.shape[1], max_rank), dtype=target_dtype)
+        runtime_b = np.zeros((max_rank, b.shape[0]), dtype=target_dtype)
+        runtime_a[:, :rank] = a.T.astype(target_dtype, copy=False)
+        runtime_b[:rank, :] = (b.T * scale).astype(target_dtype, copy=False)
+
+        canonical = f"layer.{layer}.{PEFT_TO_WEIGHT_NAME[module]}"
+        names = DynamicLoraConfig(enabled=True, max_rank=max_rank).input_names(canonical)
+        prepared[names[0]] = np.ascontiguousarray(runtime_a)
+        prepared[names[1]] = np.ascontiguousarray(runtime_b)
+
+    return PreparedLoraAdapter(
+        adapter_id=adapter_id,
+        tensors=prepared,
+        rank=rank,
+        scale=scale,
+    )
+
+
+def load_peft_adapter(
+    adapter_id: str,
+    adapter_dir: str | Path,
+    *,
+    max_rank: int,
+    dtype: np.dtype = np.float16,
+) -> PreparedLoraAdapter:
+    """Load and normalize a standard PEFT safetensors adapter directory."""
+    artifact = load_peft_lora_artifact(adapter_dir)
+    return prepare_peft_adapter(
+        adapter_id,
+        {
+            "peft_type": "LORA",
+            "r": artifact.config.rank,
+            "lora_alpha": artifact.config.alpha,
+            "target_modules": list(artifact.config.target_modules),
+        },
+        dict(artifact.tensors),
+        max_rank=max_rank,
+        dtype=dtype,
+    )

--- a/python/tensorrt_model_connect/families/qwen_vl/lora_peft.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/lora_peft.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen-VL loading and validation for standard PEFT LoRA artifacts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+import numpy as np
+
+
+def _enabled(config: Mapping[str, object], key: str) -> bool:
+    value = config.get(key, False)
+    return value is not None and bool(value)
+
+
+def _nonempty(config: Mapping[str, object], key: str) -> bool:
+    value = config.get(key)
+    return value is not None and bool(value)
+
+
+@dataclass(frozen=True)
+class PeftLoraConfig:
+    """Standard PEFT fields that do not depend on a model family."""
+
+    rank: int
+    alpha: float
+    target_modules: tuple[str, ...]
+
+    @property
+    def scale(self) -> float:
+        return self.alpha / self.rank
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, object]) -> "PeftLoraConfig":
+        if str(raw.get("peft_type", "LORA")) != "LORA":
+            raise ValueError("PEFT adapter peft_type must be LORA")
+        if any(_enabled(raw, key) for key in ("use_dora", "use_rslora", "use_qalora")):
+            raise NotImplementedError("DoRA, rsLoRA, and QALoRA adapters are not supported")
+        if _enabled(raw, "fan_in_fan_out"):
+            raise NotImplementedError("fan_in_fan_out LoRA weights are not supported")
+        if str(raw.get("bias", "none")) != "none" or _enabled(raw, "lora_bias"):
+            raise NotImplementedError("LoRA bias adaptation is not supported")
+        if _nonempty(raw, "modules_to_save"):
+            raise NotImplementedError("PEFT modules_to_save are not supported")
+        if _nonempty(raw, "rank_pattern") or _nonempty(raw, "alpha_pattern"):
+            raise NotImplementedError("Per-module LoRA rank/alpha patterns are not supported yet")
+
+        rank = int(raw.get("r", 0) or 0)
+        if rank <= 0:
+            raise ValueError("PEFT adapter_config.json must define a positive rank 'r'")
+        alpha = float(raw.get("lora_alpha", rank))
+
+        raw_targets = raw.get("target_modules")
+        if raw_targets is None:
+            targets: tuple[str, ...] = ()
+        elif isinstance(raw_targets, str):
+            targets = (raw_targets,)
+        elif isinstance(raw_targets, (list, tuple)):
+            targets = tuple(str(item) for item in raw_targets)
+        else:
+            raise ValueError("PEFT target_modules must be a string or list of strings")
+        if any(not target for target in targets):
+            raise ValueError("PEFT target_modules must not contain empty names")
+        targets = tuple(dict.fromkeys(targets))
+        return cls(rank=rank, alpha=alpha, target_modules=targets)
+
+
+@dataclass(frozen=True)
+class PeftLoraArtifact:
+    """A validated PEFT config plus its family-unmapped tensors."""
+
+    config: PeftLoraConfig
+    tensors: Mapping[str, np.ndarray]
+
+
+def load_peft_lora_artifact(adapter_dir: str | Path) -> PeftLoraArtifact:
+    """Load the standard PEFT JSON and safetensors filenames from a directory."""
+    root = Path(adapter_dir)
+    config_path = root / "adapter_config.json"
+    weights_path = root / "adapter_model.safetensors"
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Missing PEFT adapter config: {config_path}")
+    if not weights_path.is_file():
+        raise FileNotFoundError(f"Missing PEFT adapter weights: {weights_path}")
+
+    try:
+        from safetensors.numpy import load_file
+    except ImportError as exc:
+        raise RuntimeError("safetensors is required to load PEFT adapters") from exc
+
+    raw_config = json.loads(config_path.read_text(encoding="utf-8"))
+    if not isinstance(raw_config, dict):
+        raise ValueError("PEFT adapter_config.json must contain a JSON object")
+    return PeftLoraArtifact(
+        config=PeftLoraConfig.from_dict(raw_config),
+        tensors=load_file(str(weights_path)),
+    )

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -33,7 +33,9 @@ from .checkpoint_mapper import (
     _transpose_2d,
 )
 from ...parallel_config import normalize_parallel_config
+from ...quantization.adapters import StandardDecoderCalibrationAdapter
 from .decoder_tp_builder import build_qwen_vl_tp_decoder_engine
+from .lora import DynamicLoraConfig
 from .standard_decoder_builder import build_standard_decoder_engine
 from . import graph_ops
 from . import graph_blocks
@@ -56,9 +58,38 @@ def _is_qwen3_vl(config: ModelConfig) -> bool:
     return bool(vc.get("deepstack_visual_indexes"))
 
 
+def _fixed_image_dimensions(config: ModelConfig) -> tuple[int, int]:
+    """Resolve and validate the fixed Qwen-VL vision profile dimensions."""
+    family_options = config.raw.get("_family_build_options", {})
+    vision_options = (
+        family_options.get("qwen_vl_vision", {})
+        if isinstance(family_options, dict) else {}
+    )
+    if not isinstance(vision_options, dict):
+        raise ValueError("qwen_vl_vision build options must be an object")
+
+    height = int(vision_options.get("image_height", _DEFAULT_FIXED_IMAGE_SIZE))
+    width = int(vision_options.get("image_width", _DEFAULT_FIXED_IMAGE_SIZE))
+    vision_config = config.raw.get("vision_config", {})
+    patch_size = int(vision_config.get("patch_size", 14))
+    merge_size = int(vision_config.get("spatial_merge_size", 2))
+    alignment = patch_size * merge_size
+    if height <= 0 or width <= 0:
+        raise ValueError("Qwen-VL image dimensions must be positive")
+    if height % alignment or width % alignment:
+        raise ValueError(
+            "Qwen-VL image dimensions must be divisible by patch_size * "
+            f"spatial_merge_size ({alignment}); got {height}x{width}")
+    if _is_qwen3_vl(config) and height != width:
+        raise ValueError(
+            "Rectangular vision profiles currently support Qwen2.5-VL only")
+    return height, width
+
+
 class QwenVLPlugin:
     name = "qwen_vl"
     runtime_strategy = "qwen_vl_vision_language"
+    runtime_capabilities = {"decoder_kv"}
     embed_input = True
 
     def matches(self, model_type: str) -> bool:
@@ -80,6 +111,14 @@ class QwenVLPlugin:
         parallel_config=None,
     ) -> bytes:
         parallel = normalize_parallel_config(parallel_config)
+        lora_config = DynamicLoraConfig.from_model_config(config)
+        if lora_config.enabled:
+            if _is_qwen3_vl(config):
+                raise NotImplementedError(
+                    "Dynamic LoRA binding currently supports Qwen2.5-VL only")
+            if parallel.enabled:
+                raise NotImplementedError(
+                    "Dynamic LoRA binding is not yet supported with tensor parallelism")
         if _is_qwen3_vl(config):
             vc = config.raw.get("vision_config", {})
             deepstack_indexes = vc.get("deepstack_visual_indexes", [])
@@ -116,6 +155,12 @@ class QwenVLPlugin:
                 verbose=verbose,
                 debug_layer_outputs=debug_layer_outputs,
                 parallel_config=parallel)
+        # TRT 11's fused IAttention builder currently fails for the long
+        # single-token decoder profiles needed by full-resolution Qwen2.5-VL
+        # image prompts. Keep native attention for smaller profiles and use
+        # the mathematically equivalent decomposed QK/softmax/V graph when the
+        # cache exceeds the validated native-attention range.
+        config.raw["_force_decomposed_attention"] = max_cache_length > 384
         return build_standard_decoder_engine(
             config, weights, max_cache_length, precision=precision, verbose=verbose,
             quant_ctx=quant_ctx, embed_input=True,
@@ -139,12 +184,13 @@ class QwenVLPlugin:
         vision_precision = (
             "fp32" if precision == "fp16" and _VISION_COMPONENT in selected_fp32
             else precision)
+        fixed_h, fixed_w = _fixed_image_dimensions(config)
 
         if _is_qwen3_vl(config):
             from .qwen_vl_vision_builder import build_qwen3_vl_vision_engine
             return build_qwen3_vl_vision_engine(
                 vision_config, vision_weights,
-                fixed_image_size=_DEFAULT_FIXED_IMAGE_SIZE,
+                fixed_image_size=fixed_h,
                 precision=vision_precision,
                 fp32_layers=vision_fp32_layers,
                 verbose=verbose)
@@ -153,6 +199,8 @@ class QwenVLPlugin:
             return build_qwen_vl_vision_engine(
                 vision_config, vision_weights,
                 fixed_image_size=_DEFAULT_FIXED_IMAGE_SIZE,
+                fixed_image_height=fixed_h,
+                fixed_image_width=fixed_w,
                 precision=vision_precision,
                 verbose=verbose)
 
@@ -163,26 +211,34 @@ class QwenVLPlugin:
 
         patch_size = vision_config.get("patch_size", 14)
         merge_size = vision_config.get("spatial_merge_size", 2)
-        fixed_image_size = _DEFAULT_FIXED_IMAGE_SIZE
+        fixed_h, fixed_w = _fixed_image_dimensions(config)
 
-        grid_h = fixed_image_size // patch_size
-        grid_w = fixed_image_size // patch_size
+        grid_h = fixed_h // patch_size
+        grid_w = fixed_w // patch_size
         num_patches = grid_h * grid_w
         num_merged = num_patches // (merge_size * merge_size)
 
-        # Both Qwen2.5-VL and Qwen3-VL use merge-group pixel ordering
-        preproc = "merge_group_chw"
+        # Rectangular buckets preserve the source aspect ratio before applying
+        # Qwen's required merge-group pixel ordering. Square profiles retain
+        # the established direct-resize behavior for compatibility.
+        preproc = (
+            "aspect_preserve_merge_group_chw"
+            if fixed_h != fixed_w else "merge_group_chw"
+        )
 
         vl_cfg = {
             "image_token_id": 151655,
-            "fixed_image_size": fixed_image_size,
+            "fixed_image_size": _DEFAULT_FIXED_IMAGE_SIZE,
+            "fixed_image_height": fixed_h,
+            "fixed_image_width": fixed_w,
             "num_image_pad_tokens": num_merged,
             "vision_output_dim": config.hidden_size,
             "preprocessor_type": preproc,
             "vl_prompt_template": (
+                "<|im_start|>system\n"
+                "You are a helpful assistant.<|im_end|>\n"
                 "<|im_start|>user\n"
-                "<|vision_start|>{image_pads}<|vision_end|>\n"
-                "{prompt}<|im_end|>\n"
+                "{prompt}<|vision_start|>{image_pads}<|vision_end|><|im_end|>\n"
                 "<|im_start|>assistant\n"
             ),
             "image_token_str": "<|image_pad|>",
@@ -193,6 +249,15 @@ class QwenVLPlugin:
             vl_cfg["deepstack_num_levels"] = len(ds_indexes)
 
         return vl_cfg
+
+    def get_lora_config(self, config: ModelConfig) -> dict[str, object]:
+        """Persist the dynamic binding contract in the bundle config."""
+        return DynamicLoraConfig.from_model_config(config).bundle_config()
+
+    def quant_adapter(self, format_name: str) -> StandardDecoderCalibrationAdapter:
+        """Map HF decoder projection names to Qwen-VL graph seam names."""
+        del format_name
+        return StandardDecoderCalibrationAdapter()
 
 
 # ---------------------------------------------------------------------------

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -155,12 +155,6 @@ class QwenVLPlugin:
                 verbose=verbose,
                 debug_layer_outputs=debug_layer_outputs,
                 parallel_config=parallel)
-        # TRT 11's fused IAttention builder currently fails for the long
-        # single-token decoder profiles needed by full-resolution Qwen2.5-VL
-        # image prompts. Keep native attention for smaller profiles and use
-        # the mathematically equivalent decomposed QK/softmax/V graph when the
-        # cache exceeds the validated native-attention range.
-        config.raw["_force_decomposed_attention"] = max_cache_length > 384
         return build_standard_decoder_engine(
             config, weights, max_cache_length, precision=precision, verbose=verbose,
             quant_ctx=quant_ctx, embed_input=True,

--- a/python/tensorrt_model_connect/families/qwen_vl/runtime_config_schema.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/runtime_config_schema.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build-time schemas for Qwen-VL engines."""
+
+from __future__ import annotations
+
+from tensorrt_model_connect.runtime_config import ConfigField, Layer, Schema, register_schema
+
+
+# The build CLI currently resolves ``--config`` / ``--set`` contributions at
+# SESSION_REQUEST priority before forwarding the values to family builders.
+_BUILD = frozenset({Layer.BUILD_TIME, Layer.BUNDLE_DEFAULT, Layer.SESSION_REQUEST})
+
+
+LORA_SCHEMA = Schema(
+    namespace="qwen_vl_lora",
+    fields=(
+        ConfigField(
+            name="enabled",
+            type_tag="bool",
+            default=False,
+            allowed_layers=_BUILD,
+        ),
+        ConfigField(
+            name="max_rank",
+            type_tag="int32",
+            default=0,
+            allowed_layers=_BUILD,
+            validator=lambda value: isinstance(value, int) and 0 <= value <= 256,
+        ),
+        ConfigField(
+            name="target_modules",
+            type_tag="string",
+            default="q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj",
+            allowed_layers=_BUILD,
+        ),
+    ),
+)
+
+VISION_SCHEMA = Schema(
+    namespace="qwen_vl_vision",
+    fields=(
+        ConfigField(
+            name="image_height",
+            type_tag="int32",
+            default=448,
+            allowed_layers=_BUILD,
+            validator=lambda value: isinstance(value, int) and value > 0,
+        ),
+        ConfigField(
+            name="image_width",
+            type_tag="int32",
+            default=448,
+            allowed_layers=_BUILD,
+            validator=lambda value: isinstance(value, int) and value > 0,
+        ),
+    ),
+)
+
+
+register_schema(LORA_SCHEMA)
+register_schema(VISION_SCHEMA)

--- a/python/tensorrt_model_connect/pipeline.py
+++ b/python/tensorrt_model_connect/pipeline.py
@@ -73,6 +73,8 @@ class Pipeline:
         prompt: str,
         *,
         image: str | None = None,
+        lora_adapter: str | None = None,
+        lora_adapter_id: str = "default",
         max_new_tokens: int = 20,
         timeout: float = 120.0,
     ) -> str:
@@ -81,6 +83,8 @@ class Pipeline:
         Args:
             prompt: Input text prompt.
             image: Optional path to an image file (for VL models).
+            lora_adapter: Optional path to a PEFT LoRA adapter directory.
+            lora_adapter_id: Runtime ID assigned to ``lora_adapter``.
             max_new_tokens: Maximum tokens to generate.
             timeout: Subprocess timeout in seconds.
 
@@ -95,6 +99,14 @@ class Pipeline:
 
         if image is not None:
             cmd.extend(["--image", str(image)])
+
+        if lora_adapter is not None:
+            if not lora_adapter_id:
+                raise ValueError("lora_adapter_id must not be empty")
+            cmd.extend([
+                "--lora-adapter", str(lora_adapter),
+                "--lora-adapter-id", lora_adapter_id,
+            ])
 
         if self.hf_python is not None:
             cmd.extend(["--hf-python", self.hf_python])

--- a/python/tensorrt_model_connect/quantization/__init__.py
+++ b/python/tensorrt_model_connect/quantization/__init__.py
@@ -105,6 +105,12 @@ def build_quant_context(
     elif plan.scale_source == "dynamic":
         # NVFP4 uses dynamic quantization (runtime scales)
         provider = DynamicQuantizationProvider()
+    elif plan.scale_source == "prequantized" or str(config.raw.get(
+            "quantization_config", {}).get(
+            "quant_method", "")).lower() in {
+                "awq", "gptq", "compressed-tensors", "compressed_tensors"
+            }:
+        provider = PreQuantizedCheckpointProvider()
     else:
         # Auto-calibrate with ModelOpt
         provider = ModelOptCalibrationProvider(

--- a/python/tensorrt_model_connect/quantization/scale_providers.py
+++ b/python/tensorrt_model_connect/quantization/scale_providers.py
@@ -246,10 +246,64 @@ class PreQuantizedCheckpointProvider:
             return self._extract_gptq(model_dir, config, exclude_patterns)
         elif quant_method == "awq":
             return self._extract_awq(model_dir, config, exclude_patterns)
+        elif quant_method in ("compressed-tensors", "compressed_tensors"):
+            if quant_format.name != "fp8":
+                raise ValueError(
+                    "Compressed-Tensors float-quantized checkpoints require "
+                    f"the fp8 format, got {quant_format.name!r}")
+            if adapter is None:
+                raise ValueError(
+                    "Compressed-Tensors scale extraction requires a family "
+                    "quantization adapter")
+            return self._extract_compressed_tensors(
+                model_dir, exclude_patterns, adapter)
         else:
             raise ValueError(
                 f"Unsupported pre-quantized format: {quant_method!r}. "
-                "Expected 'gptq' or 'awq'.")
+                "Expected 'gptq', 'awq', or 'compressed-tensors'.")
+
+    def _extract_compressed_tensors(
+        self,
+        model_dir: str,
+        exclude_patterns: list[str],
+        adapter: CalibrationAdapter,
+    ) -> QuantScaleMap:
+        """Extract per-tensor FP8 scales from Compressed-Tensors weights."""
+        from safetensors import safe_open
+
+        scales: dict[str, LayerScales] = {}
+        for sf_path in Path(model_dir).glob("*.safetensors"):
+            with safe_open(str(sf_path), framework="pt", device="cpu") as reader:
+                keys = set(reader.keys())
+                for key in keys:
+                    if not key.endswith(".weight_scale"):
+                        continue
+                    layer_name = key.removesuffix(".weight_scale")
+                    input_key = f"{layer_name}.input_scale"
+                    if input_key not in keys:
+                        raise ValueError(
+                            f"Compressed-Tensors layer {layer_name} is missing "
+                            f"{input_key}")
+                    mapped = adapter.map_layer_name(layer_name)
+                    if mapped is None or _matches_exclude_pattern(
+                            mapped, exclude_patterns):
+                        continue
+                    weight_scale = reader.get_tensor(key).float().cpu().numpy()
+                    input_scale = reader.get_tensor(input_key).float().cpu().numpy()
+                    if weight_scale.size != 1 or input_scale.size != 1:
+                        raise NotImplementedError(
+                            "Compressed-Tensors FP8 loading currently supports "
+                            f"per-tensor scales only; {layer_name} has "
+                            f"weight_scale={weight_scale.shape}, "
+                            f"input_scale={input_scale.shape}")
+                    scales[mapped] = LayerScales(
+                        input_scale=float(input_scale.reshape(-1)[0]),
+                        weight_scale=float(weight_scale.reshape(-1)[0]),
+                    )
+
+        logger.info(
+            "Extracted Compressed-Tensors FP8 scales for %d layers", len(scales))
+        return QuantScaleMap(scales=scales)
 
     def _extract_gptq(self, model_dir, config, exclude_patterns):
         """Extract scales from GPTQ checkpoint."""

--- a/src/cli/args.cpp
+++ b/src/cli/args.cpp
@@ -190,6 +190,7 @@ void print_usage() {
            "  trtmc run             <bundle.trtfb> --prompt \"text\" [--image PATH] "
            "[--max-new-tokens N] [--temperature F] [--top-p F] [--min-p F] "
            "[--top-k N] [--seed N] [--benchmark N] [--warmup N] [--hf-python PATH] "
+           "[--lora-adapter DIR] [--lora-adapter-id ID] "
            "[--kv-cache-size SIZE] [--chat-template] [--no-thinking] "
            "[--generation-mode MODE] [--block-length N] [--threshold F] "
            "[--num-samples N] [--num-steps N] [--guidance-scale S] [--cfg-scale S] "
@@ -458,6 +459,19 @@ CliArgs parse_args(int argc, char** argv) {
         }
         if (arg == "--image" && need_value(arg)) {
             args.image_path = argv[++i];
+            continue;
+        }
+        if (arg == "--lora-adapter" && need_value(arg)) {
+            args.lora_adapter_path = argv[++i];
+            continue;
+        }
+        if (arg == "--lora-adapter-id" && need_value(arg)) {
+            args.lora_adapter_id = argv[++i];
+            if (args.lora_adapter_id.empty()) {
+                args.parse_error = true;
+                args.error_message = "--lora-adapter-id must not be empty";
+                return args;
+            }
             continue;
         }
         if ((arg == "--output" || arg == "-o") && need_value(arg)) {

--- a/src/cli/args.h
+++ b/src/cli/args.h
@@ -21,6 +21,8 @@ struct CliArgs {
     std::string hf_python;
     std::uint64_t kv_cache_size_bytes{0};
     std::string image_path;
+    std::string lora_adapter_path;
+    std::string lora_adapter_id{"default"};
     std::string output_dir;
     std::string output_json;
     std::string initial_latents_raw;

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -417,6 +417,10 @@ int cmd_run(const CliArgs& args) {
     cfg.min_p = args.min_p;
     cfg.top_k = args.top_k;
     cfg.seed = args.seed;
+    if (!args.lora_adapter_path.empty()) {
+        pipeline->load_lora_adapter(args.lora_adapter_id, args.lora_adapter_path);
+        cfg.lora_adapter_id = args.lora_adapter_id;
+    }
     if (!args.initial_latents_raw.empty()) {
         std::string error;
         auto latents = read_float32_raw_file(args.initial_latents_raw, error);

--- a/src/runtime/backend/rtx_backend.cpp
+++ b/src/runtime/backend/rtx_backend.cpp
@@ -160,6 +160,30 @@ class RtxBackend final : public IBackend {
         return out;
     }
 
+    BackendContextModules
+    create_context_modules(const void* plan_data, size_t plan_size,
+                           const std::vector<ModuleCreateOptions>& options) override {
+        if (options.empty())
+            throw std::invalid_argument("[trtmc] Context module options must not be empty");
+        auto* engine_raw = runtime_->deserializeCudaEngine(plan_data, plan_size);
+        if (!engine_raw)
+            throw std::runtime_error("[trtmc] Failed to deserialize engine (RTX)");
+        std::shared_ptr<nvinfer1::ICudaEngine> engine(engine_raw,
+                                                      [](nvinfer1::ICudaEngine* p) { delete p; });
+
+        BackendContextModules out;
+        out.modules.reserve(options.size());
+        for (const auto& lane_options : options) {
+            const int32_t profile_idx = lane_options.optimization_profile;
+            if (profile_idx < 0 || profile_idx >= engine->getNbOptimizationProfiles())
+                throw std::invalid_argument("[trtmc] Invalid optimization profile index");
+            StreamSetup stream_setup = resolve_stream(lane_options.stream);
+            out.modules.push_back(
+                create_profile_module(engine, stream_setup, lane_options, profile_idx));
+        }
+        return out;
+    }
+
     const char* name() const override { return "trt_rtx"; }
 
   private:

--- a/src/runtime/backend/trt_backend.cpp
+++ b/src/runtime/backend/trt_backend.cpp
@@ -183,6 +183,49 @@ class TrtBackend final : public IBackend {
         return out;
     }
 
+    BackendContextModules
+    create_context_modules(const void* plan_data, size_t plan_size,
+                           const std::vector<ModuleCreateOptions>& options) override {
+        if (options.empty())
+            throw std::invalid_argument("[trtmc] Context module options must not be empty");
+        auto* engine_raw = runtime_->deserializeCudaEngine(plan_data, plan_size);
+        if (!engine_raw)
+            throw std::runtime_error("[trtmc] Failed to deserialize engine (TRT)");
+        std::shared_ptr<nvinfer1::ICudaEngine> engine(engine_raw,
+                                                      [](nvinfer1::ICudaEngine* p) { delete p; });
+
+        BackendContextModules out;
+        out.modules.reserve(options.size());
+        for (const auto& lane_options : options) {
+            const int32_t profile_idx = lane_options.optimization_profile;
+            if (profile_idx < 0 || profile_idx >= engine->getNbOptimizationProfiles())
+                throw std::invalid_argument("[trtmc] Invalid optimization profile index");
+            auto* ctx = engine->createExecutionContext();
+            if (!ctx)
+                throw std::runtime_error("[trtmc] Failed to create TRT execution context");
+
+            cudaStream_t stream = lane_options.stream;
+            std::shared_ptr<void> stream_owner;
+            if (!stream) {
+                auto owned = std::make_shared<CudaStream>();
+                if (!owned->ok()) {
+                    delete ctx;
+                    throw std::runtime_error("[trtmc] Failed to create CUDA stream");
+                }
+                stream = owned->get();
+                stream_owner = owned;
+            }
+
+            auto module = std::make_unique<TrtModuleImpl>(engine.get(), ctx, stream, profile_idx,
+                                                          lane_options.distributed_communicator);
+            if (!module->ok())
+                throw std::runtime_error("[trtmc] TrtModuleImpl creation failed");
+            keep_backend_resources(*module, engine, stream_owner, lane_options.distributed_owner);
+            out.modules.push_back(std::move(module));
+        }
+        return out;
+    }
+
     const char* name() const override { return "trt"; }
 
   private:

--- a/src/runtime/core/pipeline_pool.cpp
+++ b/src/runtime/core/pipeline_pool.cpp
@@ -1,0 +1,227 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "trtmc/runtime/pipeline_pool.h"
+
+#include <algorithm>
+#include <condition_variable>
+#include <mutex>
+#include <stdexcept>
+#include <utility>
+
+namespace trtmc {
+
+struct PipelinePool::State {
+    struct Slot {
+        std::unique_ptr<IPipeline> pipeline;
+        bool leased{false};
+    };
+
+    explicit State(std::vector<std::unique_ptr<IPipeline>> pipelines) {
+        if (pipelines.empty())
+            throw std::invalid_argument("PipelinePool requires at least one pipeline");
+        slots.reserve(pipelines.size());
+        for (auto& pipeline : pipelines) {
+            if (!pipeline)
+                throw std::invalid_argument("PipelinePool cannot contain a null pipeline");
+            slots.push_back(Slot{std::move(pipeline), false});
+        }
+        available = slots.size();
+    }
+
+    std::vector<Slot> slots;
+    std::size_t available{0};
+    bool maintenance{false};
+    mutable std::mutex mutex;
+    std::condition_variable changed;
+};
+
+namespace {
+
+bool contains_adapter(IPipeline& pipeline, const std::string& adapter_id) {
+    const auto ids = pipeline.loaded_lora_adapters();
+    return std::find(ids.begin(), ids.end(), adapter_id) != ids.end();
+}
+
+} // namespace
+
+class PipelinePool::MaintenanceGuard {
+  public:
+    explicit MaintenanceGuard(const std::shared_ptr<State>& state) : state_(state) {
+        std::unique_lock<std::mutex> lock(state_->mutex);
+        state_->changed.wait(lock, [&] { return !state_->maintenance; });
+        state_->maintenance = true;
+        state_->changed.wait(lock, [&] { return state_->available == state_->slots.size(); });
+    }
+
+    ~MaintenanceGuard() {
+        {
+            const std::lock_guard<std::mutex> lock(state_->mutex);
+            state_->maintenance = false;
+        }
+        state_->changed.notify_all();
+    }
+
+  private:
+    std::shared_ptr<State> state_;
+};
+
+PipelinePool::Lease::Lease(std::shared_ptr<State> state, std::size_t index)
+    : state_(std::move(state)), index_(index) {}
+
+PipelinePool::Lease::~Lease() {
+    release();
+}
+
+PipelinePool::Lease::Lease(Lease&& other) noexcept
+    : state_(std::move(other.state_)), index_(other.index_) {}
+
+PipelinePool::Lease& PipelinePool::Lease::operator=(Lease&& other) noexcept {
+    if (this == &other)
+        return *this;
+    release();
+    state_ = std::move(other.state_);
+    index_ = other.index_;
+    return *this;
+}
+
+IPipeline* PipelinePool::Lease::get() const {
+    if (!state_)
+        throw std::logic_error("PipelinePool lease is empty");
+    return state_->slots[index_].pipeline.get();
+}
+
+void PipelinePool::Lease::release() {
+    if (!state_)
+        return;
+    {
+        const std::lock_guard<std::mutex> lock(state_->mutex);
+        state_->slots[index_].leased = false;
+        ++state_->available;
+    }
+    state_->changed.notify_all();
+    state_.reset();
+}
+
+PipelinePool::PipelinePool(std::vector<std::unique_ptr<IPipeline>> pipelines)
+    : state_(std::make_shared<State>(std::move(pipelines))) {}
+
+PipelinePool::~PipelinePool() = default;
+PipelinePool::PipelinePool(PipelinePool&&) noexcept = default;
+PipelinePool& PipelinePool::operator=(PipelinePool&&) noexcept = default;
+
+PipelinePool::Lease PipelinePool::acquire() {
+    if (!state_)
+        throw std::logic_error("PipelinePool is empty");
+    std::unique_lock<std::mutex> lock(state_->mutex);
+    state_->changed.wait(lock, [&] { return !state_->maintenance && state_->available > 0; });
+    for (std::size_t index = 0; index < state_->slots.size(); ++index) {
+        auto& slot = state_->slots[index];
+        if (slot.leased)
+            continue;
+        slot.leased = true;
+        --state_->available;
+        return Lease(state_, index);
+    }
+    throw std::logic_error("PipelinePool availability invariant violated");
+}
+
+std::optional<PipelinePool::Lease> PipelinePool::try_acquire() {
+    if (!state_)
+        return std::nullopt;
+    const std::lock_guard<std::mutex> lock(state_->mutex);
+    if (state_->maintenance || state_->available == 0)
+        return std::nullopt;
+    for (std::size_t index = 0; index < state_->slots.size(); ++index) {
+        auto& slot = state_->slots[index];
+        if (slot.leased)
+            continue;
+        slot.leased = true;
+        --state_->available;
+        return Lease(state_, index);
+    }
+    return std::nullopt;
+}
+
+std::size_t PipelinePool::size() const {
+    if (!state_)
+        return 0;
+    const std::lock_guard<std::mutex> lock(state_->mutex);
+    return state_->slots.size();
+}
+
+std::size_t PipelinePool::available() const {
+    if (!state_)
+        return 0;
+    const std::lock_guard<std::mutex> lock(state_->mutex);
+    return state_->available;
+}
+
+bool PipelinePool::supports_lora_adapters() const {
+    if (!state_)
+        return false;
+    const std::lock_guard<std::mutex> lock(state_->mutex);
+    return std::all_of(state_->slots.begin(), state_->slots.end(), [](const State::Slot& slot) {
+        return slot.pipeline->supports_lora_adapters();
+    });
+}
+
+void PipelinePool::load_lora_adapter(const std::string& adapter_id,
+                                     const std::string& adapter_path) {
+    if (!state_)
+        throw std::logic_error("PipelinePool is empty");
+    if (adapter_id.empty())
+        throw std::invalid_argument("PipelinePool adapter ID must not be empty");
+    MaintenanceGuard guard(state_);
+    for (const auto& slot : state_->slots) {
+        if (!slot.pipeline->supports_lora_adapters())
+            throw std::runtime_error(std::string(slot.pipeline->pipeline_type()) +
+                                     " does not support dynamic LoRA adapters");
+    }
+    std::vector<IPipeline*> loaded;
+    try {
+        for (const auto& slot : state_->slots) {
+            if (contains_adapter(*slot.pipeline, adapter_id))
+                continue;
+            slot.pipeline->load_lora_adapter(adapter_id, adapter_path);
+            loaded.push_back(slot.pipeline.get());
+        }
+    } catch (...) {
+        for (auto iterator = loaded.rbegin(); iterator != loaded.rend(); ++iterator) {
+            try {
+                if (contains_adapter(**iterator, adapter_id))
+                    (*iterator)->unload_lora_adapter(adapter_id);
+            } catch (...) {
+                // Preserve the original load failure. A later explicit unload
+                // can clean up a plugin that also failed rollback.
+            }
+        }
+        throw;
+    }
+}
+
+void PipelinePool::unload_lora_adapter(const std::string& adapter_id) {
+    if (!state_)
+        throw std::logic_error("PipelinePool is empty");
+    MaintenanceGuard guard(state_);
+    bool found = false;
+    for (const auto& slot : state_->slots) {
+        if (!contains_adapter(*slot.pipeline, adapter_id))
+            continue;
+        slot.pipeline->unload_lora_adapter(adapter_id);
+        found = true;
+    }
+    if (!found)
+        throw std::invalid_argument("PipelinePool: unknown adapter ID '" + adapter_id + "'");
+}
+
+std::vector<std::string> PipelinePool::loaded_lora_adapters() const {
+    if (!state_)
+        return {};
+    MaintenanceGuard guard(state_);
+    return state_->slots.front().pipeline->loaded_lora_adapters();
+}
+
+} // namespace trtmc

--- a/src/runtime/core/pipeline_pool.cpp
+++ b/src/runtime/core/pipeline_pool.cpp
@@ -45,6 +45,19 @@ bool contains_adapter(IPipeline& pipeline, const std::string& adapter_id) {
     return std::find(ids.begin(), ids.end(), adapter_id) != ids.end();
 }
 
+void rollback_loaded_adapters(const std::vector<IPipeline*>& loaded,
+                              const std::string& adapter_id) noexcept {
+    for (auto iterator = loaded.rbegin(); iterator != loaded.rend(); ++iterator) {
+        try {
+            if (contains_adapter(**iterator, adapter_id))
+                (*iterator)->unload_lora_adapter(adapter_id);
+        } catch (...) {
+            // Preserve the original load failure. A later explicit unload can
+            // clean up a plugin that also failed rollback.
+        }
+    }
+}
+
 } // namespace
 
 class PipelinePool::MaintenanceGuard {
@@ -189,15 +202,7 @@ void PipelinePool::load_lora_adapter(const std::string& adapter_id,
             loaded.push_back(slot.pipeline.get());
         }
     } catch (...) {
-        for (auto iterator = loaded.rbegin(); iterator != loaded.rend(); ++iterator) {
-            try {
-                if (contains_adapter(**iterator, adapter_id))
-                    (*iterator)->unload_lora_adapter(adapter_id);
-            } catch (...) {
-                // Preserve the original load failure. A later explicit unload
-                // can clean up a plugin that also failed rollback.
-            }
-        }
+        rollback_loaded_adapters(loaded, adapter_id);
         throw;
     }
 }

--- a/src/runtime/models/qwen_vl/image_preprocessor.cpp
+++ b/src/runtime/models/qwen_vl/image_preprocessor.cpp
@@ -36,19 +36,29 @@ static stbir_filter resolve_stbir_filter(const std::string& interpolation) {
 
 struct LoadedImage {
     std::vector<float> img_chw; // [C, H, W] normalized
-    int target_size{0};
+    int target_height{0};
+    int target_width{0};
     int channels{0};
     bool ok{false};
 };
 
-// Resize raw uint8 RGB buffer to target_size x target_size using the given filter.
+static int target_height(const QwenVlPreprocessConfig& config) {
+    return config.fixed_image_height > 0 ? config.fixed_image_height : config.fixed_image_size;
+}
+
+static int target_width(const QwenVlPreprocessConfig& config) {
+    return config.fixed_image_width > 0 ? config.fixed_image_width : config.fixed_image_size;
+}
+
+// Resize raw uint8 RGB pixels to the fixed vision profile dimensions.
 static std::vector<unsigned char> resize_raw(const unsigned char* raw, int width, int height,
-                                             int target_size, stbir_filter filter) {
-    std::vector<unsigned char> resized(static_cast<std::size_t>(target_size) * target_size * 3);
+                                             int target_width, int target_height,
+                                             stbir_filter filter) {
+    std::vector<unsigned char> resized(static_cast<std::size_t>(target_width) * target_height * 3);
 
     void* result =
-        stbir_resize(raw, width, height, width * 3, resized.data(), target_size, target_size,
-                     target_size * 3, STBIR_RGB, STBIR_TYPE_UINT8, STBIR_EDGE_CLAMP, filter);
+        stbir_resize(raw, width, height, width * 3, resized.data(), target_width, target_height,
+                     target_width * 3, STBIR_RGB, STBIR_TYPE_UINT8, STBIR_EDGE_CLAMP, filter);
 
     if (result == nullptr) {
         return {};
@@ -57,11 +67,12 @@ static std::vector<unsigned char> resize_raw(const unsigned char* raw, int width
 }
 
 // Convert resized uint8 HWC buffer to float32 CHW, normalizing per channel.
-static bool normalize_to_chw(const std::vector<unsigned char>& resized, int target_size,
-                             const QwenVlPreprocessConfig& config, std::vector<float>& out_chw) {
+static bool normalize_to_chw(const std::vector<unsigned char>& resized, int target_width,
+                             int target_height, const QwenVlPreprocessConfig& config,
+                             std::vector<float>& out_chw) {
     ImageNormalizationParams params;
-    params.width = target_size;
-    params.height = target_size;
+    params.width = target_width;
+    params.height = target_height;
     params.channels = config.in_channels;
     params.image_mean[0] = config.image_mean[0];
     params.image_mean[1] = config.image_mean[1];
@@ -85,10 +96,10 @@ static LoadedImage load_resize_normalize(const runtime::adapters::io::DecodedIma
         return loaded;
     }
 
-    const int target_size = config.fixed_image_size;
+    const int dst_h = target_height(config);
+    const int dst_w = target_width(config);
 
-    // 2. Resize to fixed_image_size x fixed_image_size
-    auto resized = resize_raw(image.pixels.data(), image.width, image.height, target_size,
+    auto resized = resize_raw(image.pixels.data(), image.width, image.height, dst_w, dst_h,
                               resolve_stbir_filter(config.interpolation));
 
     if (resized.empty()) {
@@ -97,11 +108,12 @@ static LoadedImage load_resize_normalize(const runtime::adapters::io::DecodedIma
     }
 
     // 3. Normalize to [C, H, W]
-    if (!normalize_to_chw(resized, target_size, config, loaded.img_chw)) {
+    if (!normalize_to_chw(resized, dst_w, dst_h, config, loaded.img_chw)) {
         std::cerr << "[trtmc] Failed to normalize image" << std::endl;
         return loaded;
     }
-    loaded.target_size = target_size;
+    loaded.target_height = dst_h;
+    loaded.target_width = dst_w;
     loaded.channels = config.in_channels;
     loaded.ok = true;
     return loaded;
@@ -131,19 +143,21 @@ static LoadedImage load_crop_resize_normalize(const runtime::adapters::io::Decod
         std::memcpy(dst_row, src_row, static_cast<std::size_t>(crop_size) * 3);
     }
 
-    const int target_size = config.fixed_image_size;
-    auto resized = resize_raw(cropped.data(), crop_size, crop_size, target_size,
+    const int dst_h = target_height(config);
+    const int dst_w = target_width(config);
+    auto resized = resize_raw(cropped.data(), crop_size, crop_size, dst_w, dst_h,
                               resolve_stbir_filter(config.interpolation));
     if (resized.empty()) {
         std::cerr << "[trtmc] Failed to resize cropped image" << std::endl;
         return loaded;
     }
 
-    if (!normalize_to_chw(resized, target_size, config, loaded.img_chw)) {
+    if (!normalize_to_chw(resized, dst_w, dst_h, config, loaded.img_chw)) {
         std::cerr << "[trtmc] Failed to normalize cropped image" << std::endl;
         return loaded;
     }
-    loaded.target_size = target_size;
+    loaded.target_height = dst_h;
+    loaded.target_width = dst_w;
     loaded.channels = config.in_channels;
     loaded.ok = true;
     return loaded;
@@ -161,12 +175,14 @@ load_aspect_preserve_resize_normalize(const runtime::adapters::io::DecodedImage&
         return loaded;
     }
 
-    const int target_size = config.fixed_image_size;
+    const int dst_h = target_height(config);
+    const int dst_w = target_width(config);
     const stbir_filter filter = resolve_stbir_filter(config.interpolation);
 
-    // Compute scaled dimensions that fit inside target_size x target_size
-    const float scale =
-        static_cast<float>(target_size) / static_cast<float>(std::max(image.width, image.height));
+    // Compute scaled dimensions that fit inside the fixed profile.
+    const float scale_w = static_cast<float>(dst_w) / static_cast<float>(image.width);
+    const float scale_h = static_cast<float>(dst_h) / static_cast<float>(image.height);
+    const float scale = std::min(scale_w, scale_h);
     const int new_w = std::max(1, static_cast<int>(image.width * scale));
     const int new_h = std::max(1, static_cast<int>(image.height * scale));
 
@@ -182,20 +198,21 @@ load_aspect_preserve_resize_normalize(const runtime::adapters::io::DecodedImage&
         return loaded;
     }
 
-    // Zero-pad to target_size x target_size (top-left aligned)
-    std::vector<unsigned char> padded(static_cast<std::size_t>(target_size) * target_size * 3, 0);
+    // Zero-pad to the fixed profile (top-left aligned).
+    std::vector<unsigned char> padded(static_cast<std::size_t>(dst_w) * dst_h * 3, 0);
     for (int y = 0; y < new_h; ++y) {
         const unsigned char* src_row =
             resized_small.data() + static_cast<std::size_t>(y) * new_w * 3;
-        unsigned char* dst_row = padded.data() + static_cast<std::size_t>(y) * target_size * 3;
+        unsigned char* dst_row = padded.data() + static_cast<std::size_t>(y) * dst_w * 3;
         std::memcpy(dst_row, src_row, static_cast<std::size_t>(new_w) * 3);
     }
 
-    if (!normalize_to_chw(padded, target_size, config, loaded.img_chw)) {
+    if (!normalize_to_chw(padded, dst_w, dst_h, config, loaded.img_chw)) {
         std::cerr << "[trtmc] Failed to normalize aspect-preserve image" << std::endl;
         return loaded;
     }
-    loaded.target_size = target_size;
+    loaded.target_height = dst_h;
+    loaded.target_width = dst_w;
     loaded.channels = config.in_channels;
     loaded.ok = true;
     return loaded;
@@ -214,13 +231,14 @@ load_pad_center_resize_normalize(const runtime::adapters::io::DecodedImage& imag
         return loaded;
     }
 
-    const int target_size = config.fixed_image_size;
+    const int dst_h = target_height(config);
+    const int dst_w = target_width(config);
     const stbir_filter filter = resolve_stbir_filter(config.interpolation);
 
-    // Compute scaled dimensions that fit inside target_size x target_size
+    // Compute scaled dimensions that fit inside the fixed profile.
     // This matches PIL ImageOps.pad behavior: scale to fit, then center.
-    const float scale_w = static_cast<float>(target_size) / static_cast<float>(image.width);
-    const float scale_h = static_cast<float>(target_size) / static_cast<float>(image.height);
+    const float scale_w = static_cast<float>(dst_w) / static_cast<float>(image.width);
+    const float scale_h = static_cast<float>(dst_h) / static_cast<float>(image.height);
     const float scale = std::min(scale_w, scale_h);
     const int new_w = std::max(1, static_cast<int>(image.width * scale));
     const int new_h = std::max(1, static_cast<int>(image.height * scale));
@@ -242,7 +260,7 @@ load_pad_center_resize_normalize(const runtime::adapters::io::DecodedImage& imag
     const unsigned char pad_g = static_cast<unsigned char>(config.image_mean[1] * 255.0F);
     const unsigned char pad_b = static_cast<unsigned char>(config.image_mean[2] * 255.0F);
 
-    std::vector<unsigned char> padded(static_cast<std::size_t>(target_size) * target_size * 3);
+    std::vector<unsigned char> padded(static_cast<std::size_t>(dst_w) * dst_h * 3);
     for (std::size_t i = 0; i < padded.size(); i += 3) {
         padded[i + 0] = pad_r;
         padded[i + 1] = pad_g;
@@ -250,21 +268,22 @@ load_pad_center_resize_normalize(const runtime::adapters::io::DecodedImage& imag
     }
 
     // Center the resized image in the padded canvas
-    const int x_off = (target_size - new_w) / 2;
-    const int y_off = (target_size - new_h) / 2;
+    const int x_off = (dst_w - new_w) / 2;
+    const int y_off = (dst_h - new_h) / 2;
     for (int y = 0; y < new_h; ++y) {
         const unsigned char* src_row =
             resized_small.data() + static_cast<std::size_t>(y) * new_w * 3;
         unsigned char* dst_row =
-            padded.data() + (static_cast<std::size_t>(y + y_off) * target_size + x_off) * 3;
+            padded.data() + (static_cast<std::size_t>(y + y_off) * dst_w + x_off) * 3;
         std::memcpy(dst_row, src_row, static_cast<std::size_t>(new_w) * 3);
     }
 
-    if (!normalize_to_chw(padded, target_size, config, loaded.img_chw)) {
+    if (!normalize_to_chw(padded, dst_w, dst_h, config, loaded.img_chw)) {
         std::cerr << "[trtmc] Failed to normalize pad-center image" << std::endl;
         return loaded;
     }
-    loaded.target_size = target_size;
+    loaded.target_height = dst_h;
+    loaded.target_width = dst_w;
     loaded.channels = config.in_channels;
     loaded.ok = true;
     return loaded;
@@ -279,14 +298,15 @@ static QwenVlPreprocessedImage preprocess_merge_group_chw(const LoadedImage& loa
     QwenVlPreprocessedImage result;
     ImageTransformParams params;
     params.layout = ImageTransformLayout::kMergeGroupChw;
-    params.target_size = loaded.target_size;
+    params.target_height = loaded.target_height;
+    params.target_width = loaded.target_width;
     params.channels = loaded.channels;
     params.patch_size = config.patch_size;
     params.merge_size = config.merge_size;
     params.temporal_patch_size = config.temporal_patch_size;
 
-    result.height = loaded.target_size;
-    result.width = loaded.target_size;
+    result.height = loaded.target_height;
+    result.width = loaded.target_width;
     result.ok = transform_chw_layout(loaded.img_chw, params, result.pixel_values, result.channels);
     return result;
 }
@@ -300,11 +320,12 @@ static QwenVlPreprocessedImage preprocess_simple_chw(const LoadedImage& loaded,
     QwenVlPreprocessedImage result;
     ImageTransformParams params;
     params.layout = ImageTransformLayout::kSimpleChw;
-    params.target_size = loaded.target_size;
+    params.target_height = loaded.target_height;
+    params.target_width = loaded.target_width;
     params.channels = loaded.channels;
 
-    result.height = loaded.target_size;
-    result.width = loaded.target_size;
+    result.height = loaded.target_height;
+    result.width = loaded.target_width;
     result.ok = transform_chw_layout(loaded.img_chw, params, result.pixel_values, result.channels);
 
     (void)config;
@@ -320,8 +341,8 @@ static QwenVlPreprocessedImage preprocess_patchify_chw(const LoadedImage& loaded
     QwenVlPreprocessedImage result;
     const int patch = config.patch_size;
     const int channels = loaded.channels;
-    const int height = loaded.target_size;
-    const int width = loaded.target_size;
+    const int height = loaded.target_height;
+    const int width = loaded.target_width;
     if (patch <= 0 || height % patch != 0 || width % patch != 0 || channels <= 0) {
         std::cerr << "[trtmc] Invalid patchify shape" << std::endl;
         return result;
@@ -377,6 +398,8 @@ struct PreprocessDispatch {
 };
 
 static PreprocessDispatch resolve_preprocess_dispatch(const std::string& preprocessor_type) {
+    if (preprocessor_type == "aspect_preserve_merge_group_chw")
+        return {load_aspect_preserve_resize_normalize, preprocess_merge_group_chw, false};
     if (preprocessor_type == "center_crop_chw")
         return {load_crop_resize_normalize, preprocess_simple_chw, false};
     if (preprocessor_type == "aspect_preserve_chw")
@@ -471,6 +494,57 @@ std::string qwen_vl_format_prompt(const std::string& user_prompt,
     return result;
 }
 
+QwenVlMropePositions qwen_vl_build_mrope_positions(const std::vector<int32_t>& input_ids,
+                                                   int32_t image_token_id,
+                                                   int32_t num_image_features, int32_t grid_height,
+                                                   int32_t grid_width) {
+    QwenVlMropePositions result;
+    result.token_positions.resize(input_ids.size());
+
+    const auto fill_text_positions = [&result, &input_ids]() {
+        for (std::size_t i = 0; i < input_ids.size(); ++i) {
+            const int32_t position = static_cast<int32_t>(i);
+            result.token_positions[i] = {position, position, position};
+        }
+        result.next_position = static_cast<int32_t>(input_ids.size());
+    };
+
+    const auto image_begin = std::find(input_ids.begin(), input_ids.end(), image_token_id);
+    const bool valid_grid =
+        grid_height > 0 && grid_width > 0 && grid_height * grid_width == num_image_features;
+    if (image_begin == input_ids.end() || !valid_grid) {
+        fill_text_positions();
+        return result;
+    }
+
+    const std::size_t image_offset =
+        static_cast<std::size_t>(std::distance(input_ids.begin(), image_begin));
+    const std::size_t image_end = image_offset + static_cast<std::size_t>(num_image_features);
+    if (image_end > input_ids.size()) {
+        fill_text_positions();
+        return result;
+    }
+
+    for (std::size_t i = 0; i < image_offset; ++i) {
+        const int32_t position = static_cast<int32_t>(i);
+        result.token_positions[i] = {position, position, position};
+    }
+
+    const int32_t vision_base = static_cast<int32_t>(image_offset);
+    for (int32_t i = 0; i < num_image_features; ++i) {
+        result.token_positions[image_offset + static_cast<std::size_t>(i)] = {
+            vision_base, vision_base + i / grid_width, vision_base + i % grid_width};
+    }
+
+    int32_t text_position = vision_base + std::max(grid_height, grid_width);
+    for (std::size_t i = image_end; i < input_ids.size(); ++i) {
+        result.token_positions[i] = {text_position, text_position, text_position};
+        ++text_position;
+    }
+    result.next_position = text_position;
+    return result;
+}
+
 static void assign_image_norm_triplet(const std::vector<float>& values, float (&target)[3]) {
     if (values.size() < 3) {
         return;
@@ -480,19 +554,13 @@ static void assign_image_norm_triplet(const std::vector<float>& values, float (&
     target[2] = values[2];
 }
 
-static void unescape_newline_sequences(std::string& text) {
-    std::size_t pos = 0;
-    while ((pos = text.find("\\n", pos)) != std::string::npos) {
-        text.replace(pos, 2, "\n");
-        ++pos;
-    }
-}
-
 static void parse_base_vl_config(const std::string& config_text, QwenVlPreprocessConfig& cfg) {
     cfg.preprocessor_type =
         extract_json_string(config_text, "preprocessor_type", "merge_group_chw");
     cfg.image_token_id = extract_json_int(config_text, "image_token_id", -1);
     cfg.fixed_image_size = extract_json_int(config_text, "fixed_image_size", 448);
+    cfg.fixed_image_height = extract_json_int(config_text, "fixed_image_height", 0);
+    cfg.fixed_image_width = extract_json_int(config_text, "fixed_image_width", 0);
     cfg.patch_size = extract_json_int(config_text, "patch_size", cfg.patch_size);
     cfg.merge_size = extract_json_int(config_text, "merge_size", cfg.merge_size);
     cfg.temporal_patch_size =
@@ -554,7 +622,6 @@ qwen_vl_parse_preprocess_config(const std::string& config_text,
                                 const std::string& preprocessor_config_text) {
     QwenVlPreprocessConfig cfg;
     parse_base_vl_config(config_text, cfg);
-    unescape_newline_sequences(cfg.vl_prompt_template);
     apply_preprocessor_config_overrides(config_text, preprocessor_config_text, cfg);
     apply_config_image_norm_overrides(config_text, cfg);
 

--- a/src/runtime/models/qwen_vl/image_preprocessor.h
+++ b/src/runtime/models/qwen_vl/image_preprocessor.h
@@ -7,6 +7,7 @@
 
 #include "runtime/models/qwen_vl/decoded_image.h"
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -16,6 +17,8 @@ namespace trtmc {
 // VL preprocessing config parsed from bundle's config.json + preprocessor_config.json.
 struct QwenVlPreprocessConfig {
     int32_t fixed_image_size{448};
+    int32_t fixed_image_height{0};
+    int32_t fixed_image_width{0};
     int32_t patch_size{14};
     int32_t merge_size{2};
     int32_t temporal_patch_size{2};
@@ -44,9 +47,22 @@ struct QwenVlPreprocessedImage {
     bool ok{false};
 };
 
+struct QwenVlMropePositions {
+    std::vector<std::array<int32_t, 3>> token_positions;
+    int32_t next_position{0};
+};
+
+// Build Hugging Face-compatible Qwen2.5-VL temporal/height/width positions
+// for a single image. grid_height/grid_width are post-merge token dimensions.
+QwenVlMropePositions qwen_vl_build_mrope_positions(const std::vector<int32_t>& input_ids,
+                                                   int32_t image_token_id,
+                                                   int32_t num_image_features, int32_t grid_height,
+                                                   int32_t grid_width);
+
 // Load and preprocess a single image for the vision encoder.
 // Dispatches to the appropriate strategy based on config.preprocessor_type:
 //   "merge_group_chw":    [C*T, H, W] with merge-group patch permutation
+//   "aspect_preserve_merge_group_chw": merge-group layout after aspect-preserving resize + pad
 //   "simple_chw":          [C, H, W] standard resize + normalize
 //   "center_crop_chw":     [C, H, W] center-crop to square, then resize + normalize
 //   "aspect_preserve_chw": [C, H, W] aspect-ratio-preserving resize + zero-pad

--- a/src/runtime/models/qwen_vl/image_transform_helper.h
+++ b/src/runtime/models/qwen_vl/image_transform_helper.h
@@ -23,7 +23,8 @@ enum class ImageTransformLayout { kSimpleChw, kMergeGroupChw };
 
 struct ImageTransformParams {
     ImageTransformLayout layout{ImageTransformLayout::kSimpleChw};
-    int32_t target_size{0};
+    int32_t target_height{0};
+    int32_t target_width{0};
     int32_t channels{3};
     int32_t patch_size{14};
     int32_t merge_size{2};
@@ -77,12 +78,12 @@ inline void copy_merge_patch_chw(const std::vector<float>& input_chw,
                     const std::size_t src =
                         static_cast<std::size_t>(c) * pixel_count +
                         static_cast<std::size_t>(orig_h * params.patch_size + py) *
-                            params.target_size +
+                            params.target_width +
                         (orig_w * params.patch_size + px);
                     const std::size_t dst =
                         static_cast<std::size_t>(out_ch) * pixel_count +
                         static_cast<std::size_t>(dst_h * params.patch_size + py) *
-                            params.target_size +
+                            params.target_width +
                         (dst_w * params.patch_size + px);
                     out_values[dst] = input_chw[src];
                 }
@@ -117,12 +118,12 @@ inline bool transform_chw_layout(const std::vector<float>& input_chw,
                                  const ImageTransformParams& params, std::vector<float>& out_values,
                                  int32_t& out_channels) {
     out_channels = 0;
-    if (params.target_size <= 0 || params.channels <= 0) {
+    if (params.target_height <= 0 || params.target_width <= 0 || params.channels <= 0) {
         return false;
     }
 
     const std::size_t pixel_count =
-        static_cast<std::size_t>(params.target_size) * params.target_size;
+        static_cast<std::size_t>(params.target_height) * params.target_width;
     const std::size_t required_size = static_cast<std::size_t>(params.channels) * pixel_count;
     if (input_chw.size() < required_size) {
         return false;
@@ -138,8 +139,15 @@ inline bool transform_chw_layout(const std::vector<float>& input_chw,
         return false;
     }
 
-    const int32_t grid_h = params.target_size / params.patch_size;
-    const int32_t grid_w = params.target_size / params.patch_size;
+    if (params.target_height % params.patch_size != 0 ||
+        params.target_width % params.patch_size != 0) {
+        return false;
+    }
+    const int32_t grid_h = params.target_height / params.patch_size;
+    const int32_t grid_w = params.target_width / params.patch_size;
+    if (grid_h % params.merge_size != 0 || grid_w % params.merge_size != 0) {
+        return false;
+    }
     const int32_t merge_h = grid_h / params.merge_size;
     const int32_t merge_w = grid_w / params.merge_size;
     const int32_t total_channels = params.channels * params.temporal_patch_size;

--- a/src/runtime/models/qwen_vl/image_transform_helper.h
+++ b/src/runtime/models/qwen_vl/image_transform_helper.h
@@ -114,11 +114,28 @@ inline void copy_merge_group_chw(const std::vector<float>& input_chw,
     }
 }
 
+inline bool valid_transform_dimensions(const ImageTransformParams& params) {
+    return params.target_height > 0 && params.target_width > 0 && params.channels > 0;
+}
+
+inline bool valid_merge_parameters(const ImageTransformParams& params) {
+    if (params.patch_size <= 0 || params.merge_size <= 0 || params.temporal_patch_size <= 0)
+        return false;
+    return true;
+}
+
+inline bool valid_merge_grid(const ImageTransformParams& params, int32_t grid_h, int32_t grid_w) {
+    if (params.target_height % params.patch_size != 0 ||
+        params.target_width % params.patch_size != 0)
+        return false;
+    return grid_h % params.merge_size == 0 && grid_w % params.merge_size == 0;
+}
+
 inline bool transform_chw_layout(const std::vector<float>& input_chw,
                                  const ImageTransformParams& params, std::vector<float>& out_values,
                                  int32_t& out_channels) {
     out_channels = 0;
-    if (params.target_height <= 0 || params.target_width <= 0 || params.channels <= 0) {
+    if (!valid_transform_dimensions(params)) {
         return false;
     }
 
@@ -135,17 +152,11 @@ inline bool transform_chw_layout(const std::vector<float>& input_chw,
         return true;
     }
 
-    if (params.patch_size <= 0 || params.merge_size <= 0 || params.temporal_patch_size <= 0) {
+    if (!valid_merge_parameters(params))
         return false;
-    }
-
-    if (params.target_height % params.patch_size != 0 ||
-        params.target_width % params.patch_size != 0) {
-        return false;
-    }
     const int32_t grid_h = params.target_height / params.patch_size;
     const int32_t grid_w = params.target_width / params.patch_size;
-    if (grid_h % params.merge_size != 0 || grid_w % params.merge_size != 0) {
+    if (!valid_merge_grid(params, grid_h, grid_w)) {
         return false;
     }
     const int32_t merge_h = grid_h / params.merge_size;

--- a/src/runtime/models/qwen_vl/kv_cache.cpp
+++ b/src/runtime/models/qwen_vl/kv_cache.cpp
@@ -126,6 +126,15 @@ void QwenVlKvCache::write_position_input(TensorMap& inputs, int32_t seq_len) {
     pos_t.shape = {static_cast<int64_t>(seq_len)};
     pos_t.dtype = DType::kInt32;
     inputs[names_.position_id] = pos_t;
+
+    if (has_mrope_position_input_ && seq_len == 1) {
+        mrope_pos_buf_.fill(position_);
+        Tensor mrope_t;
+        mrope_t.data = mrope_pos_buf_.data();
+        mrope_t.shape = {3};
+        mrope_t.dtype = DType::kInt32;
+        inputs["mrope_position_ids"] = mrope_t;
+    }
 }
 
 void QwenVlKvCache::write_batched_mask(TensorMap& inputs, int32_t seq_len) {
@@ -215,6 +224,7 @@ void QwenVlKvCache::prepare_bidirectional_step(TensorMap& inputs, int32_t seq_le
 void QwenVlKvCache::bind_to(TrtModule& module) {
     bound_module_ = &module;
     has_position_input_ = module.has_input(names_.position_id);
+    has_mrope_position_input_ = module.has_input("mrope_position_ids");
     // Enable dynamic row binding only when cache_k[0] itself is dynamic.
     // Static-shape engines with fixed [max_length, kv_dim] cache reject
     // setInputShape on cache inputs even when other inputs are dynamic.
@@ -242,6 +252,7 @@ void QwenVlKvCache::bind_to(TrtModule& module) {
 
 void QwenVlKvCache::bind_cache_inputs(TrtModule& module) {
     has_position_input_ = module.has_input(names_.position_id);
+    has_mrope_position_input_ = module.has_input("mrope_position_ids");
     for (int32_t i = 0; i < num_layers_; ++i) {
         auto li = static_cast<std::size_t>(i);
         module.bind_external(names_.cache_k[li], cache_k_[li].data());

--- a/src/runtime/models/qwen_vl/kv_cache.h
+++ b/src/runtime/models/qwen_vl/kv_cache.h
@@ -14,6 +14,7 @@
 #include "runtime/models/qwen_vl/inference_state.h"
 #include "trtmc/runtime/device_tensor.h"
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -113,7 +114,9 @@ class QwenVlKvCache : public QwenVlInferenceState {
     // Buffers owned by this object — Tensor.data in prepare_step() points here.
     std::vector<float> mask_buf_;
     std::vector<int32_t> pos_buf_vec_;
+    std::array<int32_t, 3> mrope_pos_buf_{};
     bool has_position_input_{false};
+    bool has_mrope_position_input_{false};
     bool dynamic_binding_enabled_{false};
     int32_t bound_cache_rows_{0};
     DType cache_dtype_{DType::kFloat32};

--- a/src/runtime/models/qwen_vl/lora_peft_artifact.cpp
+++ b/src/runtime/models/qwen_vl/lora_peft_artifact.cpp
@@ -1,0 +1,295 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/qwen_vl/lora_peft_artifact.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace trtmc {
+namespace qwen_vl {
+
+namespace {
+
+using json = nlohmann::json;
+
+std::vector<uint8_t> read_binary_file(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary | std::ios::ate);
+    if (!input)
+        throw std::runtime_error("PEFT LoRA: cannot open " + path.string());
+    const auto end = input.tellg();
+    if (end <= 0)
+        throw std::runtime_error("PEFT LoRA: empty file " + path.string());
+    std::vector<uint8_t> bytes(static_cast<std::size_t>(end));
+    input.seekg(0);
+    input.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+    if (!input)
+        throw std::runtime_error("PEFT LoRA: failed to read " + path.string());
+    return bytes;
+}
+
+json read_json_file(const std::filesystem::path& path) {
+    std::ifstream input(path);
+    if (!input)
+        throw std::runtime_error("PEFT LoRA: cannot open " + path.string());
+    try {
+        return json::parse(input);
+    } catch (const json::exception& exc) {
+        throw std::runtime_error("PEFT LoRA: invalid JSON in " + path.string() + ": " + exc.what());
+    }
+}
+
+std::size_t checked_numel(const std::vector<int64_t>& shape, const std::string& label) {
+    if (shape.empty())
+        throw std::runtime_error("PEFT LoRA: " + label + " has an empty shape");
+    std::size_t count = 1;
+    for (const int64_t dim : shape) {
+        if (dim <= 0)
+            throw std::runtime_error("PEFT LoRA: " + label + " has a non-positive shape");
+        const auto unsigned_dim = static_cast<std::size_t>(dim);
+        if (count > std::numeric_limits<std::size_t>::max() / unsigned_dim)
+            throw std::runtime_error("PEFT LoRA: " + label + " shape overflows size_t");
+        count *= unsigned_dim;
+    }
+    return count;
+}
+
+std::size_t dtype_size(PeftTensorDType dtype) {
+    return dtype == PeftTensorDType::kFloat32 ? sizeof(float) : sizeof(uint16_t);
+}
+
+PeftTensorDType parse_dtype(const std::string& dtype) {
+    if (dtype == "F16")
+        return PeftTensorDType::kFloat16;
+    if (dtype == "BF16")
+        return PeftTensorDType::kBFloat16;
+    if (dtype == "F32")
+        return PeftTensorDType::kFloat32;
+    throw std::runtime_error("PEFT LoRA: unsupported safetensors dtype " + dtype);
+}
+
+uint64_t read_u64_le(const uint8_t* data) {
+    uint64_t value = 0;
+    for (int index = 7; index >= 0; --index)
+        value = (value << 8U) | data[index];
+    return value;
+}
+
+uint16_t load_u16(const uint8_t* data) {
+    uint16_t value;
+    std::memcpy(&value, data, sizeof(value));
+    return value;
+}
+
+float fp16_to_fp32(uint16_t bits) {
+    const bool negative = (bits & 0x8000U) != 0;
+    const uint32_t exponent = (bits >> 10U) & 0x1FU;
+    const uint32_t mantissa = bits & 0x3FFU;
+    float value = 0.0F;
+    if (exponent == 0) {
+        value = std::ldexp(static_cast<float>(mantissa), -24);
+    } else if (exponent == 31U) {
+        value = mantissa == 0 ? std::numeric_limits<float>::infinity()
+                              : std::numeric_limits<float>::quiet_NaN();
+    } else {
+        value = std::ldexp(1.0F + static_cast<float>(mantissa) / 1024.0F,
+                           static_cast<int>(exponent) - 15);
+    }
+    return negative ? -value : value;
+}
+
+float bf16_to_fp32(uint16_t value) {
+    const uint32_t bits = static_cast<uint32_t>(value) << 16U;
+    float output;
+    std::memcpy(&output, &bits, sizeof(output));
+    return output;
+}
+
+bool config_flag(const json& config, const char* key) {
+    return config.contains(key) && !config.at(key).is_null() && config.at(key).get<bool>();
+}
+
+bool config_nonempty(const json& config, const char* key) {
+    return config.contains(key) && !config.at(key).is_null() && !config.at(key).empty();
+}
+
+PeftLoraConfig parse_config(const json& config) {
+    if (!config.is_object())
+        throw std::runtime_error("PEFT LoRA: adapter_config.json must contain an object");
+    try {
+        if (config.value("peft_type", std::string("LORA")) != "LORA")
+            throw std::runtime_error("PEFT LoRA: adapter peft_type must be LORA");
+        if (config_flag(config, "use_dora") || config_flag(config, "use_rslora") ||
+            config_flag(config, "use_qalora"))
+            throw std::runtime_error("PEFT LoRA: DoRA, rsLoRA, and QALoRA are not supported");
+        if (config.value("fan_in_fan_out", false))
+            throw std::runtime_error("PEFT LoRA: fan_in_fan_out is not supported");
+        if (config.value("bias", std::string("none")) != "none" || config.value("lora_bias", false))
+            throw std::runtime_error("PEFT LoRA: adapted bias tensors are not supported");
+        if (config_nonempty(config, "modules_to_save") || config_nonempty(config, "rank_pattern") ||
+            config_nonempty(config, "alpha_pattern"))
+            throw std::runtime_error(
+                "PEFT LoRA: modules_to_save and per-module rank/alpha patterns are not supported");
+
+        PeftLoraConfig parsed;
+        parsed.rank = config.value("r", 0);
+        if (parsed.rank <= 0)
+            throw std::runtime_error("PEFT LoRA: adapter rank must be positive");
+        parsed.alpha = config.value("lora_alpha", static_cast<double>(parsed.rank));
+
+        if (!config.contains("target_modules") || config.at("target_modules").is_null()) {
+            return parsed;
+        }
+        const auto& targets = config.at("target_modules");
+        if (targets.is_string()) {
+            parsed.target_modules.push_back(targets.get<std::string>());
+        } else if (targets.is_array()) {
+            for (const auto& target : targets)
+                parsed.target_modules.push_back(target.get<std::string>());
+        } else {
+            throw std::runtime_error("PEFT LoRA: target_modules must be a string or array");
+        }
+        std::unordered_set<std::string> unique;
+        std::vector<std::string> deduplicated;
+        deduplicated.reserve(parsed.target_modules.size());
+        for (auto& target : parsed.target_modules) {
+            if (target.empty())
+                throw std::runtime_error("PEFT LoRA: target_modules contains an empty name");
+            if (unique.insert(target).second)
+                deduplicated.push_back(std::move(target));
+        }
+        parsed.target_modules = std::move(deduplicated);
+        return parsed;
+    } catch (const json::exception& exc) {
+        throw std::runtime_error(std::string("PEFT LoRA: invalid adapter config: ") + exc.what());
+    }
+}
+
+} // namespace
+
+struct PeftLoraArtifact::Impl {
+    struct Entry {
+        std::size_t info_index{0};
+        std::size_t begin{0};
+        std::size_t end{0};
+    };
+
+    PeftLoraConfig config;
+    std::vector<uint8_t> bytes;
+    std::size_t data_begin{0};
+    std::vector<PeftTensorInfo> tensor_infos;
+    std::unordered_map<std::string, Entry> entries;
+};
+
+PeftLoraArtifact::PeftLoraArtifact(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
+
+PeftLoraArtifact::~PeftLoraArtifact() = default;
+PeftLoraArtifact::PeftLoraArtifact(PeftLoraArtifact&&) noexcept = default;
+PeftLoraArtifact& PeftLoraArtifact::operator=(PeftLoraArtifact&&) noexcept = default;
+
+PeftLoraArtifact PeftLoraArtifact::load(const std::string& adapter_dir) {
+    namespace fs = std::filesystem;
+    const fs::path root(adapter_dir);
+    if (!fs::is_directory(root))
+        throw std::runtime_error("PEFT LoRA: adapter path is not a directory: " + adapter_dir);
+
+    auto impl = std::make_unique<Impl>();
+    impl->config = parse_config(read_json_file(root / "adapter_config.json"));
+    impl->bytes = read_binary_file(root / "adapter_model.safetensors");
+    if (impl->bytes.size() < sizeof(uint64_t))
+        throw std::runtime_error("PEFT LoRA: safetensors file is too small");
+
+    const uint64_t header_size_u64 = read_u64_le(impl->bytes.data());
+    if (header_size_u64 > std::numeric_limits<std::size_t>::max() - sizeof(uint64_t))
+        throw std::runtime_error("PEFT LoRA: safetensors header size overflows");
+    const auto header_size = static_cast<std::size_t>(header_size_u64);
+    impl->data_begin = sizeof(uint64_t) + header_size;
+    if (impl->data_begin > impl->bytes.size())
+        throw std::runtime_error("PEFT LoRA: truncated safetensors header");
+
+    json header;
+    try {
+        const auto* begin = reinterpret_cast<const char*>(impl->bytes.data() + sizeof(uint64_t));
+        header = json::parse(begin, begin + header_size);
+    } catch (const json::exception& exc) {
+        throw std::runtime_error(std::string("PEFT LoRA: invalid safetensors header: ") +
+                                 exc.what());
+    }
+    if (!header.is_object())
+        throw std::runtime_error("PEFT LoRA: safetensors header must be an object");
+
+    impl->tensor_infos.reserve(header.size());
+    try {
+        for (auto item = header.begin(); item != header.end(); ++item) {
+            if (item.key() == "__metadata__")
+                continue;
+            const auto& value = item.value();
+            if (!value.is_object() || !value.contains("dtype") || !value.contains("shape") ||
+                !value.contains("data_offsets"))
+                throw std::runtime_error("PEFT LoRA: malformed tensor header for " + item.key());
+
+            PeftTensorInfo info;
+            info.name = item.key();
+            info.dtype = parse_dtype(value.at("dtype").get<std::string>());
+            info.shape = value.at("shape").get<std::vector<int64_t>>();
+            info.element_count = checked_numel(info.shape, info.name);
+            const auto offsets = value.at("data_offsets").get<std::vector<std::size_t>>();
+            if (offsets.size() != 2 || offsets[0] > offsets[1] ||
+                offsets[1] > impl->bytes.size() - impl->data_begin)
+                throw std::runtime_error("PEFT LoRA: invalid data offsets for " + info.name);
+            if (info.element_count >
+                std::numeric_limits<std::size_t>::max() / dtype_size(info.dtype))
+                throw std::runtime_error("PEFT LoRA: byte size overflows for " + info.name);
+            const std::size_t expected_bytes = info.element_count * dtype_size(info.dtype);
+            if (offsets[1] - offsets[0] != expected_bytes)
+                throw std::runtime_error("PEFT LoRA: byte size mismatch for " + info.name);
+
+            const std::size_t info_index = impl->tensor_infos.size();
+            impl->tensor_infos.push_back(std::move(info));
+            impl->entries.emplace(item.key(), Impl::Entry{info_index, offsets[0], offsets[1]});
+        }
+    } catch (const json::exception& exc) {
+        throw std::runtime_error(std::string("PEFT LoRA: malformed safetensors header: ") +
+                                 exc.what());
+    }
+    return PeftLoraArtifact(std::move(impl));
+}
+
+const PeftLoraConfig& PeftLoraArtifact::config() const {
+    return impl_->config;
+}
+
+const std::vector<PeftTensorInfo>& PeftLoraArtifact::tensors() const {
+    return impl_->tensor_infos;
+}
+
+float PeftLoraArtifact::read_float(const std::string& tensor_name, std::size_t index) const {
+    const auto found = impl_->entries.find(tensor_name);
+    if (found == impl_->entries.end())
+        throw std::invalid_argument("PEFT LoRA: unknown tensor " + tensor_name);
+    const auto& info = impl_->tensor_infos[found->second.info_index];
+    if (index >= info.element_count)
+        throw std::out_of_range("PEFT LoRA: tensor index is out of range for " + tensor_name);
+    const uint8_t* data = impl_->bytes.data() + impl_->data_begin + found->second.begin;
+    if (info.dtype == PeftTensorDType::kFloat32) {
+        float value;
+        std::memcpy(&value, data + index * sizeof(float), sizeof(value));
+        return value;
+    }
+    const uint16_t value = load_u16(data + index * sizeof(uint16_t));
+    return info.dtype == PeftTensorDType::kFloat16 ? fp16_to_fp32(value) : bf16_to_fp32(value);
+}
+
+} // namespace qwen_vl
+} // namespace trtmc

--- a/src/runtime/models/qwen_vl/lora_peft_artifact.cpp
+++ b/src/runtime/models/qwen_vl/lora_peft_artifact.cpp
@@ -124,56 +124,141 @@ bool config_nonempty(const json& config, const char* key) {
     return config.contains(key) && !config.at(key).is_null() && !config.at(key).empty();
 }
 
-PeftLoraConfig parse_config(const json& config) {
+void validate_lora_mode(const json& config) {
+    if (config.value("peft_type", std::string("LORA")) != "LORA")
+        throw std::runtime_error("PEFT LoRA: adapter peft_type must be LORA");
+    if (config_flag(config, "use_dora"))
+        throw std::runtime_error("PEFT LoRA: DoRA is not supported");
+    if (config_flag(config, "use_rslora"))
+        throw std::runtime_error("PEFT LoRA: rsLoRA is not supported");
+    if (config_flag(config, "use_qalora"))
+        throw std::runtime_error("PEFT LoRA: QALoRA is not supported");
+}
+
+void validate_lora_options(const json& config) {
+    if (config.value("fan_in_fan_out", false))
+        throw std::runtime_error("PEFT LoRA: fan_in_fan_out is not supported");
+    if (config.value("bias", std::string("none")) != "none" || config.value("lora_bias", false))
+        throw std::runtime_error("PEFT LoRA: adapted bias tensors are not supported");
+    if (config_nonempty(config, "modules_to_save"))
+        throw std::runtime_error("PEFT LoRA: modules_to_save is not supported");
+    if (config_nonempty(config, "rank_pattern") || config_nonempty(config, "alpha_pattern"))
+        throw std::runtime_error("PEFT LoRA: per-module rank/alpha patterns are not supported");
+}
+
+std::vector<std::string> parse_target_modules(const json& config) {
+    if (!config.contains("target_modules") || config.at("target_modules").is_null())
+        return {};
+    const auto& targets = config.at("target_modules");
+    if (targets.is_string())
+        return {targets.get<std::string>()};
+    if (!targets.is_array())
+        throw std::runtime_error("PEFT LoRA: target_modules must be a string or array");
+    std::vector<std::string> parsed;
+    for (const auto& target : targets)
+        parsed.push_back(target.get<std::string>());
+    return parsed;
+}
+
+std::vector<std::string> deduplicate_targets(std::vector<std::string> targets) {
+    std::unordered_set<std::string> unique;
+    std::vector<std::string> deduplicated;
+    deduplicated.reserve(targets.size());
+    for (auto& target : targets) {
+        if (target.empty())
+            throw std::runtime_error("PEFT LoRA: target_modules contains an empty name");
+        if (unique.insert(target).second)
+            deduplicated.push_back(std::move(target));
+    }
+    return deduplicated;
+}
+
+PeftLoraConfig parse_config_body(const json& config) {
     if (!config.is_object())
         throw std::runtime_error("PEFT LoRA: adapter_config.json must contain an object");
+    validate_lora_mode(config);
+    validate_lora_options(config);
+    PeftLoraConfig parsed;
+    parsed.rank = config.value("r", 0);
+    if (parsed.rank <= 0)
+        throw std::runtime_error("PEFT LoRA: adapter rank must be positive");
+    parsed.alpha = config.value("lora_alpha", static_cast<double>(parsed.rank));
+    parsed.target_modules = deduplicate_targets(parse_target_modules(config));
+    return parsed;
+}
+
+PeftLoraConfig parse_config(const json& config) {
     try {
-        if (config.value("peft_type", std::string("LORA")) != "LORA")
-            throw std::runtime_error("PEFT LoRA: adapter peft_type must be LORA");
-        if (config_flag(config, "use_dora") || config_flag(config, "use_rslora") ||
-            config_flag(config, "use_qalora"))
-            throw std::runtime_error("PEFT LoRA: DoRA, rsLoRA, and QALoRA are not supported");
-        if (config.value("fan_in_fan_out", false))
-            throw std::runtime_error("PEFT LoRA: fan_in_fan_out is not supported");
-        if (config.value("bias", std::string("none")) != "none" || config.value("lora_bias", false))
-            throw std::runtime_error("PEFT LoRA: adapted bias tensors are not supported");
-        if (config_nonempty(config, "modules_to_save") || config_nonempty(config, "rank_pattern") ||
-            config_nonempty(config, "alpha_pattern"))
-            throw std::runtime_error(
-                "PEFT LoRA: modules_to_save and per-module rank/alpha patterns are not supported");
-
-        PeftLoraConfig parsed;
-        parsed.rank = config.value("r", 0);
-        if (parsed.rank <= 0)
-            throw std::runtime_error("PEFT LoRA: adapter rank must be positive");
-        parsed.alpha = config.value("lora_alpha", static_cast<double>(parsed.rank));
-
-        if (!config.contains("target_modules") || config.at("target_modules").is_null()) {
-            return parsed;
-        }
-        const auto& targets = config.at("target_modules");
-        if (targets.is_string()) {
-            parsed.target_modules.push_back(targets.get<std::string>());
-        } else if (targets.is_array()) {
-            for (const auto& target : targets)
-                parsed.target_modules.push_back(target.get<std::string>());
-        } else {
-            throw std::runtime_error("PEFT LoRA: target_modules must be a string or array");
-        }
-        std::unordered_set<std::string> unique;
-        std::vector<std::string> deduplicated;
-        deduplicated.reserve(parsed.target_modules.size());
-        for (auto& target : parsed.target_modules) {
-            if (target.empty())
-                throw std::runtime_error("PEFT LoRA: target_modules contains an empty name");
-            if (unique.insert(target).second)
-                deduplicated.push_back(std::move(target));
-        }
-        parsed.target_modules = std::move(deduplicated);
-        return parsed;
+        return parse_config_body(config);
     } catch (const json::exception& exc) {
         throw std::runtime_error(std::string("PEFT LoRA: invalid adapter config: ") + exc.what());
     }
+}
+
+json parse_safetensors_header(const std::vector<uint8_t>& bytes, std::size_t& data_begin) {
+    if (bytes.size() < sizeof(uint64_t))
+        throw std::runtime_error("PEFT LoRA: safetensors file is too small");
+    const uint64_t header_size_u64 = read_u64_le(bytes.data());
+    if (header_size_u64 > std::numeric_limits<std::size_t>::max() - sizeof(uint64_t))
+        throw std::runtime_error("PEFT LoRA: safetensors header size overflows");
+    const auto header_size = static_cast<std::size_t>(header_size_u64);
+    data_begin = sizeof(uint64_t) + header_size;
+    if (data_begin > bytes.size())
+        throw std::runtime_error("PEFT LoRA: truncated safetensors header");
+    try {
+        const auto* begin = reinterpret_cast<const char*>(bytes.data() + sizeof(uint64_t));
+        auto header = json::parse(begin, begin + header_size);
+        if (!header.is_object())
+            throw std::runtime_error("PEFT LoRA: safetensors header must be an object");
+        return header;
+    } catch (const json::exception& exc) {
+        throw std::runtime_error(std::string("PEFT LoRA: invalid safetensors header: ") +
+                                 exc.what());
+    }
+}
+
+void validate_tensor_fields(const json& value, const std::string& name) {
+    if (!value.is_object() || !value.contains("dtype") || !value.contains("shape") ||
+        !value.contains("data_offsets"))
+        throw std::runtime_error("PEFT LoRA: malformed tensor header for " + name);
+}
+
+std::vector<std::size_t> parse_tensor_offsets(const json& value, std::size_t data_size,
+                                              const std::string& name) {
+    const auto offsets = value.at("data_offsets").get<std::vector<std::size_t>>();
+    if (offsets.size() != 2 || offsets[0] > offsets[1] || offsets[1] > data_size)
+        throw std::runtime_error("PEFT LoRA: invalid data offsets for " + name);
+    return offsets;
+}
+
+void validate_tensor_byte_size(const PeftTensorInfo& info,
+                               const std::vector<std::size_t>& offsets) {
+    if (info.element_count > std::numeric_limits<std::size_t>::max() / dtype_size(info.dtype))
+        throw std::runtime_error("PEFT LoRA: byte size overflows for " + info.name);
+    const std::size_t expected_bytes = info.element_count * dtype_size(info.dtype);
+    if (offsets[1] - offsets[0] != expected_bytes)
+        throw std::runtime_error("PEFT LoRA: byte size mismatch for " + info.name);
+}
+
+struct ParsedTensorEntry {
+    PeftTensorInfo info;
+    std::size_t begin{0};
+    std::size_t end{0};
+};
+
+ParsedTensorEntry parse_tensor_entry(const std::string& name, const json& value,
+                                     std::size_t data_size) {
+    validate_tensor_fields(value, name);
+    ParsedTensorEntry parsed;
+    parsed.info.name = name;
+    parsed.info.dtype = parse_dtype(value.at("dtype").get<std::string>());
+    parsed.info.shape = value.at("shape").get<std::vector<int64_t>>();
+    parsed.info.element_count = checked_numel(parsed.info.shape, name);
+    const auto offsets = parse_tensor_offsets(value, data_size, name);
+    validate_tensor_byte_size(parsed.info, offsets);
+    parsed.begin = offsets[0];
+    parsed.end = offsets[1];
+    return parsed;
 }
 
 } // namespace
@@ -207,57 +292,18 @@ PeftLoraArtifact PeftLoraArtifact::load(const std::string& adapter_dir) {
     auto impl = std::make_unique<Impl>();
     impl->config = parse_config(read_json_file(root / "adapter_config.json"));
     impl->bytes = read_binary_file(root / "adapter_model.safetensors");
-    if (impl->bytes.size() < sizeof(uint64_t))
-        throw std::runtime_error("PEFT LoRA: safetensors file is too small");
-
-    const uint64_t header_size_u64 = read_u64_le(impl->bytes.data());
-    if (header_size_u64 > std::numeric_limits<std::size_t>::max() - sizeof(uint64_t))
-        throw std::runtime_error("PEFT LoRA: safetensors header size overflows");
-    const auto header_size = static_cast<std::size_t>(header_size_u64);
-    impl->data_begin = sizeof(uint64_t) + header_size;
-    if (impl->data_begin > impl->bytes.size())
-        throw std::runtime_error("PEFT LoRA: truncated safetensors header");
-
-    json header;
-    try {
-        const auto* begin = reinterpret_cast<const char*>(impl->bytes.data() + sizeof(uint64_t));
-        header = json::parse(begin, begin + header_size);
-    } catch (const json::exception& exc) {
-        throw std::runtime_error(std::string("PEFT LoRA: invalid safetensors header: ") +
-                                 exc.what());
-    }
-    if (!header.is_object())
-        throw std::runtime_error("PEFT LoRA: safetensors header must be an object");
+    const auto header = parse_safetensors_header(impl->bytes, impl->data_begin);
 
     impl->tensor_infos.reserve(header.size());
     try {
         for (auto item = header.begin(); item != header.end(); ++item) {
             if (item.key() == "__metadata__")
                 continue;
-            const auto& value = item.value();
-            if (!value.is_object() || !value.contains("dtype") || !value.contains("shape") ||
-                !value.contains("data_offsets"))
-                throw std::runtime_error("PEFT LoRA: malformed tensor header for " + item.key());
-
-            PeftTensorInfo info;
-            info.name = item.key();
-            info.dtype = parse_dtype(value.at("dtype").get<std::string>());
-            info.shape = value.at("shape").get<std::vector<int64_t>>();
-            info.element_count = checked_numel(info.shape, info.name);
-            const auto offsets = value.at("data_offsets").get<std::vector<std::size_t>>();
-            if (offsets.size() != 2 || offsets[0] > offsets[1] ||
-                offsets[1] > impl->bytes.size() - impl->data_begin)
-                throw std::runtime_error("PEFT LoRA: invalid data offsets for " + info.name);
-            if (info.element_count >
-                std::numeric_limits<std::size_t>::max() / dtype_size(info.dtype))
-                throw std::runtime_error("PEFT LoRA: byte size overflows for " + info.name);
-            const std::size_t expected_bytes = info.element_count * dtype_size(info.dtype);
-            if (offsets[1] - offsets[0] != expected_bytes)
-                throw std::runtime_error("PEFT LoRA: byte size mismatch for " + info.name);
-
+            auto parsed =
+                parse_tensor_entry(item.key(), item.value(), impl->bytes.size() - impl->data_begin);
             const std::size_t info_index = impl->tensor_infos.size();
-            impl->tensor_infos.push_back(std::move(info));
-            impl->entries.emplace(item.key(), Impl::Entry{info_index, offsets[0], offsets[1]});
+            impl->tensor_infos.push_back(std::move(parsed.info));
+            impl->entries.emplace(item.key(), Impl::Entry{info_index, parsed.begin, parsed.end});
         }
     } catch (const json::exception& exc) {
         throw std::runtime_error(std::string("PEFT LoRA: malformed safetensors header: ") +

--- a/src/runtime/models/qwen_vl/lora_peft_artifact.h
+++ b/src/runtime/models/qwen_vl/lora_peft_artifact.h
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+namespace qwen_vl {
+
+enum class PeftTensorDType {
+    kFloat16,
+    kBFloat16,
+    kFloat32,
+};
+
+struct PeftTensorInfo {
+    std::string name;
+    PeftTensorDType dtype{PeftTensorDType::kFloat32};
+    std::vector<int64_t> shape;
+    std::size_t element_count{0};
+};
+
+struct PeftLoraConfig {
+    int rank{0};
+    double alpha{0.0};
+    std::vector<std::string> target_modules;
+
+    double scale() const { return alpha / static_cast<double>(rank); }
+};
+
+// Qwen-VL's reader for the standard PEFT adapter_config.json and
+// adapter_model.safetensors pair.
+class PeftLoraArtifact {
+  public:
+    static PeftLoraArtifact load(const std::string& adapter_dir);
+
+    ~PeftLoraArtifact();
+    PeftLoraArtifact(PeftLoraArtifact&&) noexcept;
+    PeftLoraArtifact& operator=(PeftLoraArtifact&&) noexcept;
+    PeftLoraArtifact(const PeftLoraArtifact&) = delete;
+    PeftLoraArtifact& operator=(const PeftLoraArtifact&) = delete;
+
+    const PeftLoraConfig& config() const;
+    const std::vector<PeftTensorInfo>& tensors() const;
+    float read_float(const std::string& tensor_name, std::size_t index) const;
+
+  private:
+    struct Impl;
+    explicit PeftLoraArtifact(std::unique_ptr<Impl> impl);
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace qwen_vl
+} // namespace trtmc

--- a/src/runtime/models/qwen_vl/lora_peft_loader.cpp
+++ b/src/runtime/models/qwen_vl/lora_peft_loader.cpp
@@ -1,0 +1,254 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/qwen_vl/lora_peft_loader.h"
+
+#include "runtime/models/qwen_vl/lora_peft_artifact.h"
+
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+#include <limits>
+#include <map>
+#include <regex>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace trtmc {
+namespace {
+
+using qwen_vl::PeftLoraConfig;
+using qwen_vl::PeftTensorInfo;
+
+struct PeftPair {
+    const PeftTensorInfo* a{nullptr};
+    const PeftTensorInfo* b{nullptr};
+};
+
+constexpr const char* kSupportedModules[] = {
+    "q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj",
+};
+
+const std::unordered_map<std::string, std::string> kRuntimeWeightNames = {
+    {"q_proj", "w_q"},       {"k_proj", "w_k"},   {"v_proj", "w_v"},       {"o_proj", "w_o"},
+    {"gate_proj", "w_gate"}, {"up_proj", "w_up"}, {"down_proj", "w_down"},
+};
+
+std::size_t checked_numel(const std::vector<int64_t>& shape, const std::string& label) {
+    if (shape.empty())
+        throw std::runtime_error("Qwen-VL LoRA: " + label + " has an empty shape");
+    std::size_t count = 1;
+    for (const int64_t dim : shape) {
+        if (dim <= 0)
+            throw std::runtime_error("Qwen-VL LoRA: " + label + " has a non-positive shape");
+        const auto unsigned_dim = static_cast<std::size_t>(dim);
+        if (count > std::numeric_limits<std::size_t>::max() / unsigned_dim)
+            throw std::runtime_error("Qwen-VL LoRA: " + label + " shape overflows size_t");
+        count *= unsigned_dim;
+    }
+    return count;
+}
+
+uint32_t round_shift_right(uint32_t value, int shift) {
+    if (shift <= 0)
+        return value;
+    const uint32_t base = value >> shift;
+    const uint32_t mask = (uint32_t{1} << shift) - 1U;
+    const uint32_t remainder = value & mask;
+    const uint32_t halfway = uint32_t{1} << (shift - 1);
+    return base +
+           static_cast<uint32_t>(remainder > halfway || (remainder == halfway && (base & 1U) != 0));
+}
+
+uint16_t fp32_to_fp16(float value) {
+    uint32_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    const uint16_t sign = static_cast<uint16_t>((bits >> 16U) & 0x8000U);
+    const uint32_t absolute = bits & 0x7FFFFFFFU;
+    const uint32_t source_exp = (absolute >> 23U) & 0xFFU;
+    const uint32_t mantissa = absolute & 0x7FFFFFU;
+    if (source_exp == 0xFFU)
+        return static_cast<uint16_t>(sign | (mantissa == 0 ? 0x7C00U : 0x7E00U));
+    if (source_exp == 0)
+        return sign;
+
+    const int exponent = static_cast<int>(source_exp) - 127;
+    if (exponent > 15)
+        return static_cast<uint16_t>(sign | 0x7C00U);
+    if (exponent < -24)
+        return sign;
+    if (exponent < -14) {
+        const int shift = 13 + (-14 - exponent);
+        const uint32_t rounded = round_shift_right(mantissa | 0x800000U, shift);
+        return static_cast<uint16_t>(sign | rounded);
+    }
+
+    uint32_t half_exp = static_cast<uint32_t>(exponent + 15);
+    uint32_t half_mantissa = round_shift_right(mantissa, 13);
+    if (half_mantissa == 0x400U) {
+        half_mantissa = 0;
+        ++half_exp;
+        if (half_exp >= 31U)
+            return static_cast<uint16_t>(sign | 0x7C00U);
+    }
+    return static_cast<uint16_t>(sign | (half_exp << 10U) | half_mantissa);
+}
+
+uint16_t fp32_to_bf16(float value) {
+    uint32_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    bits += 0x7FFFU + ((bits >> 16U) & 1U);
+    return static_cast<uint16_t>(bits >> 16U);
+}
+
+void write_scalar(std::vector<uint8_t>& bytes, DType dtype, std::size_t index, float value) {
+    if (dtype == DType::kFloat32) {
+        std::memcpy(bytes.data() + index * sizeof(float), &value, sizeof(value));
+        return;
+    }
+    uint16_t converted = 0;
+    if (dtype == DType::kFloat16)
+        converted = fp32_to_fp16(value);
+    else if (dtype == DType::kBFloat16)
+        converted = fp32_to_bf16(value);
+    else
+        throw std::runtime_error("Qwen-VL LoRA: engine LoRA inputs must be floating point");
+    std::memcpy(bytes.data() + index * sizeof(uint16_t), &converted, sizeof(converted));
+}
+
+std::set<std::string> parse_target_modules(const PeftLoraConfig& config) {
+    const std::set<std::string> supported(std::begin(kSupportedModules),
+                                          std::end(kSupportedModules));
+    std::set<std::string> targets;
+    if (config.target_modules.empty()) {
+        targets = supported;
+    } else {
+        targets.insert(config.target_modules.begin(), config.target_modules.end());
+    }
+    for (const auto& target : targets) {
+        if (supported.find(target) == supported.end())
+            throw std::runtime_error("Qwen-VL LoRA: unsupported target module " + target);
+    }
+    return targets;
+}
+
+std::string runtime_input_name(char side, int layer, const std::string& module) {
+    return std::string("lora_") + static_cast<char>(side == 'A' ? 'a' : 'b') + "_layer_" +
+           std::to_string(layer) + "_" + kRuntimeWeightNames.at(module);
+}
+
+QwenVlHostLoraAdapter::Buffer make_buffer(const TensorInfo& info) {
+    QwenVlHostLoraAdapter::Buffer output;
+    output.shape = info.shape;
+    output.dtype = info.dtype;
+    output.bytes.resize(checked_numel(info.shape, info.name) * dtype_size(info.dtype), uint8_t{0});
+    return output;
+}
+
+} // namespace
+
+TensorMap QwenVlHostLoraAdapter::tensor_views() {
+    TensorMap views;
+    views.reserve(buffers.size());
+    for (auto& [name, buffer] : buffers)
+        views.emplace(name, Tensor{buffer.bytes.data(), buffer.shape, buffer.dtype});
+    return views;
+}
+
+QwenVlHostLoraAdapter qwen_vl_load_peft_lora_adapter(const std::string& adapter_dir,
+                                                     const std::vector<TensorInfo>& engine_inputs) {
+    const auto artifact = qwen_vl::PeftLoraArtifact::load(adapter_dir);
+    const int rank = artifact.config().rank;
+    const float scale = static_cast<float>(artifact.config().scale());
+    const auto targets = parse_target_modules(artifact.config());
+
+    std::unordered_map<std::string, TensorInfo> expected;
+    expected.reserve(engine_inputs.size());
+    for (const auto& info : engine_inputs)
+        expected.emplace(info.name, info);
+    if (expected.empty())
+        throw std::runtime_error("Qwen-VL LoRA: engine has no dynamic LoRA inputs");
+
+    const std::regex weight_pattern(
+        R"(.*layers\.([0-9]+)\.(self_attn|mlp)\.(q_proj|k_proj|v_proj|o_proj|gate_proj|up_proj|down_proj)\.lora_([AB])(?:\.[^.]+)?\.weight$)");
+    std::map<std::pair<int, std::string>, PeftPair> pairs;
+    for (const auto& tensor : artifact.tensors()) {
+        std::smatch match;
+        if (!std::regex_match(tensor.name, match, weight_pattern))
+            continue;
+        const std::string module = match[3].str();
+        if (targets.find(module) == targets.end())
+            continue;
+        auto& pair = pairs[{std::stoi(match[1].str()), module}];
+        if (match[4].str() == "A")
+            pair.a = &tensor;
+        else
+            pair.b = &tensor;
+    }
+    if (pairs.empty())
+        throw std::runtime_error("Qwen-VL LoRA: no supported decoder LoRA tensors were found");
+
+    QwenVlHostLoraAdapter adapter;
+    for (const auto& [key, pair] : pairs) {
+        const int layer = key.first;
+        const std::string& module = key.second;
+        if (pair.a == nullptr || pair.b == nullptr)
+            throw std::runtime_error("Qwen-VL LoRA: incomplete A/B pair for layer " +
+                                     std::to_string(layer) + " " + module);
+        if (pair.a->shape.size() != 2 || pair.b->shape.size() != 2 || pair.a->shape[0] != rank ||
+            pair.b->shape[1] != rank)
+            throw std::runtime_error("Qwen-VL LoRA: rank or shape mismatch for layer " +
+                                     std::to_string(layer) + " " + module);
+
+        const std::string a_name = runtime_input_name('A', layer, module);
+        const std::string b_name = runtime_input_name('B', layer, module);
+        const auto a_it = expected.find(a_name);
+        const auto b_it = expected.find(b_name);
+        if (a_it == expected.end() || b_it == expected.end())
+            throw std::runtime_error("Qwen-VL LoRA: adapter targets " + module + " at layer " +
+                                     std::to_string(layer) +
+                                     " but the engine was not built with matching inputs");
+        const TensorInfo& a_info = a_it->second;
+        const TensorInfo& b_info = b_it->second;
+        if (a_info.shape.size() != 2 || b_info.shape.size() != 2 ||
+            a_info.shape[0] != pair.a->shape[1] || b_info.shape[1] != pair.b->shape[0] ||
+            a_info.shape[1] != b_info.shape[0] || rank > a_info.shape[1])
+            throw std::runtime_error(
+                "Qwen-VL LoRA: adapter dimensions do not match engine inputs for " + module +
+                " at layer " + std::to_string(layer));
+        if (a_info.dtype != b_info.dtype)
+            throw std::runtime_error("Qwen-VL LoRA: engine A/B input dtypes differ for " + module);
+
+        auto a_output = make_buffer(a_info);
+        auto b_output = make_buffer(b_info);
+        const std::size_t input_size = static_cast<std::size_t>(pair.a->shape[1]);
+        const std::size_t output_size = static_cast<std::size_t>(pair.b->shape[0]);
+        const std::size_t max_rank = static_cast<std::size_t>(a_info.shape[1]);
+        for (std::size_t input = 0; input < input_size; ++input) {
+            for (int r = 0; r < rank; ++r) {
+                const float value = artifact.read_float(
+                    pair.a->name, static_cast<std::size_t>(r) * input_size + input);
+                write_scalar(a_output.bytes, a_output.dtype, input * max_rank + r, value);
+            }
+        }
+        for (int r = 0; r < rank; ++r) {
+            for (std::size_t output = 0; output < output_size; ++output) {
+                const float value =
+                    artifact.read_float(pair.b->name, output * static_cast<std::size_t>(rank) +
+                                                          static_cast<std::size_t>(r));
+                write_scalar(b_output.bytes, b_output.dtype,
+                             static_cast<std::size_t>(r) * output_size + output, value * scale);
+            }
+        }
+        adapter.buffers.emplace(a_name, std::move(a_output));
+        adapter.buffers.emplace(b_name, std::move(b_output));
+    }
+    return adapter;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/qwen_vl/lora_peft_loader.cpp
+++ b/src/runtime/models/qwen_vl/lora_peft_loader.cpp
@@ -150,6 +150,118 @@ QwenVlHostLoraAdapter::Buffer make_buffer(const TensorInfo& info) {
     return output;
 }
 
+using ExpectedInputs = std::unordered_map<std::string, TensorInfo>;
+using PeftPairs = std::map<std::pair<int, std::string>, PeftPair>;
+
+ExpectedInputs index_engine_inputs(const std::vector<TensorInfo>& engine_inputs) {
+    ExpectedInputs expected;
+    expected.reserve(engine_inputs.size());
+    for (const auto& info : engine_inputs)
+        expected.emplace(info.name, info);
+    return expected;
+}
+
+PeftPairs collect_peft_pairs(const qwen_vl::PeftLoraArtifact& artifact,
+                             const std::set<std::string>& targets) {
+    const std::regex weight_pattern(
+        R"(.*layers\.([0-9]+)\.(self_attn|mlp)\.(q_proj|k_proj|v_proj|o_proj|gate_proj|up_proj|down_proj)\.lora_([AB])(?:\.[^.]+)?\.weight$)");
+    PeftPairs pairs;
+    for (const auto& tensor : artifact.tensors()) {
+        std::smatch match;
+        if (!std::regex_match(tensor.name, match, weight_pattern))
+            continue;
+        const std::string module = match[3].str();
+        if (targets.find(module) == targets.end())
+            continue;
+        auto& pair = pairs[{std::stoi(match[1].str()), module}];
+        (match[4].str() == "A" ? pair.a : pair.b) = &tensor;
+    }
+    return pairs;
+}
+
+std::string pair_label(int layer, const std::string& module) {
+    return "layer " + std::to_string(layer) + " " + module;
+}
+
+void validate_peft_pair(const PeftPair& pair, int rank, const std::string& label) {
+    if (pair.a == nullptr || pair.b == nullptr)
+        throw std::runtime_error("Qwen-VL LoRA: incomplete A/B pair for " + label);
+    if (pair.a->shape.size() != 2 || pair.b->shape.size() != 2 || pair.a->shape[0] != rank ||
+        pair.b->shape[1] != rank)
+        throw std::runtime_error("Qwen-VL LoRA: rank or shape mismatch for " + label);
+}
+
+struct RuntimePair {
+    std::string a_name;
+    std::string b_name;
+    const TensorInfo* a{nullptr};
+    const TensorInfo* b{nullptr};
+};
+
+RuntimePair find_runtime_pair(const ExpectedInputs& expected, int layer,
+                              const std::string& module) {
+    RuntimePair pair;
+    pair.a_name = runtime_input_name('A', layer, module);
+    pair.b_name = runtime_input_name('B', layer, module);
+    const auto a_it = expected.find(pair.a_name);
+    const auto b_it = expected.find(pair.b_name);
+    if (a_it == expected.end() || b_it == expected.end()) {
+        throw std::runtime_error("Qwen-VL LoRA: adapter targets " + module + " at layer " +
+                                 std::to_string(layer) +
+                                 " but the engine was not built with matching inputs");
+    }
+    pair.a = &a_it->second;
+    pair.b = &b_it->second;
+    return pair;
+}
+
+void validate_runtime_shapes(const RuntimePair& runtime, const PeftPair& peft, int rank,
+                             const std::string& label) {
+    const auto& a = *runtime.a;
+    const auto& b = *runtime.b;
+    if (a.shape.size() != 2 || b.shape.size() != 2)
+        throw std::runtime_error("Qwen-VL LoRA: invalid engine input ranks for " + label);
+    if (a.shape[0] != peft.a->shape[1] || b.shape[1] != peft.b->shape[0])
+        throw std::runtime_error(
+            "Qwen-VL LoRA: adapter dimensions do not match engine inputs for " + label);
+    if (a.shape[1] != b.shape[0] || rank > a.shape[1])
+        throw std::runtime_error("Qwen-VL LoRA: adapter rank exceeds engine capacity for " + label);
+    if (a.dtype != b.dtype)
+        throw std::runtime_error("Qwen-VL LoRA: engine A/B input dtypes differ for " + label);
+}
+
+QwenVlHostLoraAdapter::Buffer copy_a_weights(const qwen_vl::PeftLoraArtifact& artifact,
+                                             const PeftPair& pair, const TensorInfo& info,
+                                             int rank) {
+    auto output = make_buffer(info);
+    const std::size_t input_size = static_cast<std::size_t>(pair.a->shape[1]);
+    const std::size_t max_rank = static_cast<std::size_t>(info.shape[1]);
+    for (std::size_t input = 0; input < input_size; ++input) {
+        for (int r = 0; r < rank; ++r) {
+            const float value =
+                artifact.read_float(pair.a->name, static_cast<std::size_t>(r) * input_size + input);
+            write_scalar(output.bytes, output.dtype, input * max_rank + r, value);
+        }
+    }
+    return output;
+}
+
+QwenVlHostLoraAdapter::Buffer copy_b_weights(const qwen_vl::PeftLoraArtifact& artifact,
+                                             const PeftPair& pair, const TensorInfo& info, int rank,
+                                             float scale) {
+    auto output = make_buffer(info);
+    const std::size_t output_size = static_cast<std::size_t>(pair.b->shape[0]);
+    for (int r = 0; r < rank; ++r) {
+        for (std::size_t index = 0; index < output_size; ++index) {
+            const float value = artifact.read_float(
+                pair.b->name, index * static_cast<std::size_t>(rank) + static_cast<std::size_t>(r));
+            write_scalar(output.bytes, output.dtype,
+                         static_cast<std::size_t>(r) * output_size + index, value * scale);
+        }
+    }
+    return output;
+}
+
 } // namespace
 
 TensorMap QwenVlHostLoraAdapter::tensor_views() {
@@ -167,29 +279,11 @@ QwenVlHostLoraAdapter qwen_vl_load_peft_lora_adapter(const std::string& adapter_
     const float scale = static_cast<float>(artifact.config().scale());
     const auto targets = parse_target_modules(artifact.config());
 
-    std::unordered_map<std::string, TensorInfo> expected;
-    expected.reserve(engine_inputs.size());
-    for (const auto& info : engine_inputs)
-        expected.emplace(info.name, info);
+    const auto expected = index_engine_inputs(engine_inputs);
     if (expected.empty())
         throw std::runtime_error("Qwen-VL LoRA: engine has no dynamic LoRA inputs");
 
-    const std::regex weight_pattern(
-        R"(.*layers\.([0-9]+)\.(self_attn|mlp)\.(q_proj|k_proj|v_proj|o_proj|gate_proj|up_proj|down_proj)\.lora_([AB])(?:\.[^.]+)?\.weight$)");
-    std::map<std::pair<int, std::string>, PeftPair> pairs;
-    for (const auto& tensor : artifact.tensors()) {
-        std::smatch match;
-        if (!std::regex_match(tensor.name, match, weight_pattern))
-            continue;
-        const std::string module = match[3].str();
-        if (targets.find(module) == targets.end())
-            continue;
-        auto& pair = pairs[{std::stoi(match[1].str()), module}];
-        if (match[4].str() == "A")
-            pair.a = &tensor;
-        else
-            pair.b = &tensor;
-    }
+    const auto pairs = collect_peft_pairs(artifact, targets);
     if (pairs.empty())
         throw std::runtime_error("Qwen-VL LoRA: no supported decoder LoRA tensors were found");
 
@@ -197,56 +291,13 @@ QwenVlHostLoraAdapter qwen_vl_load_peft_lora_adapter(const std::string& adapter_
     for (const auto& [key, pair] : pairs) {
         const int layer = key.first;
         const std::string& module = key.second;
-        if (pair.a == nullptr || pair.b == nullptr)
-            throw std::runtime_error("Qwen-VL LoRA: incomplete A/B pair for layer " +
-                                     std::to_string(layer) + " " + module);
-        if (pair.a->shape.size() != 2 || pair.b->shape.size() != 2 || pair.a->shape[0] != rank ||
-            pair.b->shape[1] != rank)
-            throw std::runtime_error("Qwen-VL LoRA: rank or shape mismatch for layer " +
-                                     std::to_string(layer) + " " + module);
-
-        const std::string a_name = runtime_input_name('A', layer, module);
-        const std::string b_name = runtime_input_name('B', layer, module);
-        const auto a_it = expected.find(a_name);
-        const auto b_it = expected.find(b_name);
-        if (a_it == expected.end() || b_it == expected.end())
-            throw std::runtime_error("Qwen-VL LoRA: adapter targets " + module + " at layer " +
-                                     std::to_string(layer) +
-                                     " but the engine was not built with matching inputs");
-        const TensorInfo& a_info = a_it->second;
-        const TensorInfo& b_info = b_it->second;
-        if (a_info.shape.size() != 2 || b_info.shape.size() != 2 ||
-            a_info.shape[0] != pair.a->shape[1] || b_info.shape[1] != pair.b->shape[0] ||
-            a_info.shape[1] != b_info.shape[0] || rank > a_info.shape[1])
-            throw std::runtime_error(
-                "Qwen-VL LoRA: adapter dimensions do not match engine inputs for " + module +
-                " at layer " + std::to_string(layer));
-        if (a_info.dtype != b_info.dtype)
-            throw std::runtime_error("Qwen-VL LoRA: engine A/B input dtypes differ for " + module);
-
-        auto a_output = make_buffer(a_info);
-        auto b_output = make_buffer(b_info);
-        const std::size_t input_size = static_cast<std::size_t>(pair.a->shape[1]);
-        const std::size_t output_size = static_cast<std::size_t>(pair.b->shape[0]);
-        const std::size_t max_rank = static_cast<std::size_t>(a_info.shape[1]);
-        for (std::size_t input = 0; input < input_size; ++input) {
-            for (int r = 0; r < rank; ++r) {
-                const float value = artifact.read_float(
-                    pair.a->name, static_cast<std::size_t>(r) * input_size + input);
-                write_scalar(a_output.bytes, a_output.dtype, input * max_rank + r, value);
-            }
-        }
-        for (int r = 0; r < rank; ++r) {
-            for (std::size_t output = 0; output < output_size; ++output) {
-                const float value =
-                    artifact.read_float(pair.b->name, output * static_cast<std::size_t>(rank) +
-                                                          static_cast<std::size_t>(r));
-                write_scalar(b_output.bytes, b_output.dtype,
-                             static_cast<std::size_t>(r) * output_size + output, value * scale);
-            }
-        }
-        adapter.buffers.emplace(a_name, std::move(a_output));
-        adapter.buffers.emplace(b_name, std::move(b_output));
+        const auto label = pair_label(layer, module);
+        validate_peft_pair(pair, rank, label);
+        const auto runtime = find_runtime_pair(expected, layer, module);
+        validate_runtime_shapes(runtime, pair, rank, label);
+        adapter.buffers.emplace(runtime.a_name, copy_a_weights(artifact, pair, *runtime.a, rank));
+        adapter.buffers.emplace(runtime.b_name,
+                                copy_b_weights(artifact, pair, *runtime.b, rank, scale));
     }
     return adapter;
 }

--- a/src/runtime/models/qwen_vl/lora_peft_loader.h
+++ b/src/runtime/models/qwen_vl/lora_peft_loader.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/runtime/tensor.h"
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace trtmc {
+
+// Owns normalized host buffers while exposing non-owning Tensor views for the
+// existing GPU adapter cache upload path.
+class QwenVlHostLoraAdapter {
+  public:
+    struct Buffer {
+        std::vector<uint8_t> bytes;
+        std::vector<int64_t> shape;
+        DType dtype{DType::kFloat32};
+    };
+
+    std::unordered_map<std::string, Buffer> buffers;
+    TensorMap tensor_views();
+};
+
+// Load a standard PEFT LoRA directory and normalize its tensors to the fixed
+// shapes and dtypes declared by a LoRA-capable TensorRT engine.
+QwenVlHostLoraAdapter qwen_vl_load_peft_lora_adapter(const std::string& adapter_dir,
+                                                     const std::vector<TensorInfo>& engine_inputs);
+
+} // namespace trtmc

--- a/src/runtime/models/qwen_vl/lora_runtime.cpp
+++ b/src/runtime/models/qwen_vl/lora_runtime.cpp
@@ -1,0 +1,258 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/qwen_vl/lora_runtime.h"
+
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <unordered_set>
+#include <utility>
+
+namespace trtmc {
+namespace qwen_vl {
+
+namespace {
+
+void validate_static_input(const TensorInfo& info) {
+    if (!info.is_input)
+        throw std::invalid_argument("Adapter input contract contains output '" + info.name + "'");
+    if (info.name.empty())
+        throw std::invalid_argument("Adapter input contract contains an empty tensor name");
+    if (info.shape.empty() ||
+        std::any_of(info.shape.begin(), info.shape.end(), [](int64_t dim) { return dim <= 0; })) {
+        throw std::invalid_argument("Adapter input '" + info.name +
+                                    "' must have a fixed, non-empty shape");
+    }
+}
+
+} // namespace
+
+LoraInputBindings::LoraInputBindings(TrtModule& module,
+                                           std::vector<TensorInfo> input_contract)
+    : module_(module) {
+    std::unordered_set<std::string> names;
+    names.reserve(input_contract.size());
+    entries_.reserve(input_contract.size());
+    for (auto& info : input_contract) {
+        validate_static_input(info);
+        if (!module_.has_input(info.name))
+            throw std::invalid_argument("Adapter input '" + info.name +
+                                        "' is not present in the execution module");
+        if (!names.insert(info.name).second)
+            throw std::invalid_argument("Duplicate adapter input '" + info.name + "'");
+        auto zero = DeviceTensor::zeros(info.shape, info.dtype, module_.stream());
+        entries_.push_back(Entry{std::move(info), std::move(zero)});
+        if (!entries_.back().zero.ok())
+            throw std::runtime_error("Failed to allocate zero buffer for adapter input '" +
+                                     entries_.back().info.name + "'");
+    }
+    bind_zero_buffers();
+}
+
+std::vector<std::string> LoraInputBindings::input_names() const {
+    std::vector<std::string> names;
+    names.reserve(entries_.size());
+    for (const auto& entry : entries_)
+        names.push_back(entry.info.name);
+    return names;
+}
+
+std::vector<TensorInfo> LoraInputBindings::input_info() const {
+    std::vector<TensorInfo> infos;
+    infos.reserve(entries_.size());
+    for (const auto& entry : entries_)
+        infos.push_back(entry.info);
+    return infos;
+}
+
+void LoraInputBindings::bind(const DeviceTensorMap& adapter_tensors) {
+    std::unordered_set<std::string> expected;
+    expected.reserve(entries_.size());
+    for (const auto& entry : entries_)
+        expected.insert(entry.info.name);
+    for (const auto& [name, tensor] : adapter_tensors) {
+        if (expected.find(name) == expected.end())
+            throw std::invalid_argument("Unknown adapter tensor '" + name + "'");
+        if (tensor == nullptr || !tensor->ok())
+            throw std::invalid_argument("Invalid adapter tensor '" + name + "'");
+    }
+    for (const auto& entry : entries_) {
+        const auto it = adapter_tensors.find(entry.info.name);
+        if (it == adapter_tensors.end())
+            continue;
+        const DeviceTensor& tensor = *it->second;
+        if (tensor.shape() != entry.info.shape || tensor.dtype() != entry.info.dtype) {
+            throw std::invalid_argument("Shape or dtype mismatch for adapter tensor '" +
+                                        entry.info.name + "'");
+        }
+    }
+
+    // Tensor addresses are execution-context state. Do not replace them while
+    // a previous enqueue on this module can still read the old addresses.
+    module_.sync();
+    for (auto& entry : entries_) {
+        const auto it = adapter_tensors.find(entry.info.name);
+        if (it == adapter_tensors.end()) {
+            module_.bind_external(entry.info.name, entry.zero.data());
+            continue;
+        }
+        DeviceTensor& tensor = *it->second;
+        module_.bind_external(entry.info.name, tensor.data());
+    }
+}
+
+void LoraInputBindings::clear() {
+    module_.sync();
+    bind_zero_buffers();
+}
+
+void LoraInputBindings::bind_zero_buffers() {
+    for (auto& entry : entries_)
+        module_.bind_external(entry.info.name, entry.zero.data());
+}
+
+DeviceTensorMap LoraDeviceWeights::device_view() {
+    DeviceTensorMap view;
+    view.reserve(tensors_.size());
+    for (auto& [name, tensor] : tensors_)
+        view.emplace(name, &tensor);
+    return view;
+}
+
+LoraAdapterCache::LoraAdapterCache(std::vector<TensorInfo> input_contract, cudaStream_t upload_stream,
+                           std::size_t capacity)
+    : upload_stream_(upload_stream), capacity_(capacity) {
+    if (capacity_ == 0)
+        throw std::invalid_argument("Qwen-VL LoRA cache: capacity must be positive");
+    contract_.reserve(input_contract.size());
+    for (auto& info : input_contract) {
+        validate_static_input(info);
+        const std::string name = info.name;
+        if (!contract_.emplace(name, std::move(info)).second)
+            throw std::invalid_argument("Duplicate adapter input '" + name + "'");
+    }
+}
+
+void LoraAdapterCache::register_adapter(const std::string& adapter_id, const TensorMap& host_tensors) {
+    if (contract_.empty())
+        throw std::runtime_error("Qwen-VL LoRA cache: engine has no adapter inputs");
+    if (adapter_id.empty())
+        throw std::invalid_argument("Qwen-VL LoRA cache: adapter ID must not be empty");
+    if (host_tensors.empty())
+        throw std::invalid_argument("Qwen-VL LoRA cache: adapter has no tensors");
+
+    auto weights = std::make_shared<LoraDeviceWeights>();
+    for (const auto& [name, host] : host_tensors) {
+        const auto expected = contract_.find(name);
+        if (expected == contract_.end())
+            throw std::invalid_argument("Qwen-VL LoRA cache: unknown adapter tensor '" + name + "'");
+        if (host.data == nullptr || host.shape != expected->second.shape ||
+            host.dtype != expected->second.dtype) {
+            throw std::invalid_argument("Qwen-VL LoRA cache: shape or dtype mismatch for tensor '" +
+                                        name + "'");
+        }
+        DeviceTensor device(host.shape, host.dtype, upload_stream_);
+        if (!device.ok() || !device.copy_from_host(host.data))
+            throw std::runtime_error("Qwen-VL LoRA cache: failed to upload tensor '" + name + "'");
+        weights->tensors_.emplace(name, std::move(device));
+    }
+    if (cudaStreamSynchronize(upload_stream_) != cudaSuccess)
+        throw std::runtime_error("Qwen-VL LoRA cache: adapter upload synchronization failed");
+
+    const std::lock_guard<std::mutex> lock(mutex_);
+    adapters_[adapter_id] = Entry{std::move(weights), ++clock_};
+    evict_if_needed(adapter_id);
+}
+
+void LoraAdapterCache::unregister_adapter(const std::string& adapter_id) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    const auto it = adapters_.find(adapter_id);
+    if (it == adapters_.end())
+        throw std::invalid_argument("Qwen-VL LoRA cache: unknown adapter ID '" + adapter_id + "'");
+    // Contexts that already acquired this entry retain shared ownership until
+    // their request completes, but new acquisitions fail immediately.
+    adapters_.erase(it);
+}
+
+std::shared_ptr<LoraDeviceWeights> LoraAdapterCache::acquire(const std::string& adapter_id) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    const auto it = adapters_.find(adapter_id);
+    if (it == adapters_.end())
+        throw std::invalid_argument("Qwen-VL LoRA cache: unknown adapter ID '" + adapter_id + "'");
+    it->second.last_use = ++clock_;
+    return it->second.weights;
+}
+
+bool LoraAdapterCache::contains(const std::string& adapter_id) const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return adapters_.find(adapter_id) != adapters_.end();
+}
+
+std::size_t LoraAdapterCache::size() const {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return adapters_.size();
+}
+
+std::vector<std::string> LoraAdapterCache::adapter_ids() const {
+    std::vector<std::string> ids;
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        ids.reserve(adapters_.size());
+        for (const auto& [id, entry] : adapters_) {
+            (void)entry;
+            ids.push_back(id);
+        }
+    }
+    std::sort(ids.begin(), ids.end());
+    return ids;
+}
+
+void LoraAdapterCache::evict_if_needed(const std::string& protected_adapter_id) {
+    while (adapters_.size() > capacity_) {
+        auto victim = adapters_.end();
+        uint64_t oldest = std::numeric_limits<uint64_t>::max();
+        for (auto it = adapters_.begin(); it != adapters_.end(); ++it) {
+            if (it->first == protected_adapter_id || it->second.weights.use_count() > 1)
+                continue;
+            if (it->second.last_use < oldest) {
+                oldest = it->second.last_use;
+                victim = it;
+            }
+        }
+        if (victim == adapters_.end()) {
+            adapters_.erase(protected_adapter_id);
+            throw std::runtime_error(
+                "Qwen-VL LoRA cache: capacity is exhausted by adapters in active use");
+        }
+        adapters_.erase(victim);
+    }
+}
+
+void LoraBindingContext::select(const std::string& adapter_id) {
+    if (adapter_id.empty()) {
+        clear();
+        return;
+    }
+
+    auto weights = cache_.acquire(adapter_id);
+    if (weights == active_weights_)
+        return;
+    auto tensors = weights->device_view();
+    bindings_.bind(tensors);
+    active_adapter_id_ = adapter_id;
+    active_weights_ = std::move(weights);
+}
+
+void LoraBindingContext::clear() {
+    if (active_adapter_id_.empty())
+        return;
+    bindings_.clear();
+    active_adapter_id_.clear();
+    active_weights_.reset();
+}
+
+} // namespace qwen_vl
+} // namespace trtmc

--- a/src/runtime/models/qwen_vl/lora_runtime.cpp
+++ b/src/runtime/models/qwen_vl/lora_runtime.cpp
@@ -28,10 +28,47 @@ void validate_static_input(const TensorInfo& info) {
     }
 }
 
+void validate_adapter_tensor(const std::unordered_map<std::string, TensorInfo>& expected,
+                             const std::string& name, const DeviceTensor* tensor) {
+    if (expected.find(name) == expected.end())
+        throw std::invalid_argument("Unknown adapter tensor '" + name + "'");
+    if (tensor == nullptr || !tensor->ok())
+        throw std::invalid_argument("Invalid adapter tensor '" + name + "'");
+}
+
+void validate_bound_tensor(const TensorInfo& expected, const DeviceTensorMap& adapter_tensors) {
+    const auto it = adapter_tensors.find(expected.name);
+    if (it == adapter_tensors.end())
+        return;
+    const DeviceTensor& tensor = *it->second;
+    if (tensor.shape() != expected.shape || tensor.dtype() != expected.dtype) {
+        throw std::invalid_argument("Shape or dtype mismatch for adapter tensor '" + expected.name +
+                                    "'");
+    }
+}
+
+void validate_host_tensor(const std::unordered_map<std::string, TensorInfo>& contract,
+                          const std::string& name, const Tensor& host) {
+    const auto expected = contract.find(name);
+    if (expected == contract.end())
+        throw std::invalid_argument("Qwen-VL LoRA cache: unknown adapter tensor '" + name + "'");
+    if (host.data == nullptr || host.shape != expected->second.shape ||
+        host.dtype != expected->second.dtype) {
+        throw std::invalid_argument("Qwen-VL LoRA cache: shape or dtype mismatch for tensor '" +
+                                    name + "'");
+    }
+}
+
+DeviceTensor upload_tensor(const Tensor& host, cudaStream_t stream, const std::string& name) {
+    DeviceTensor device(host.shape, host.dtype, stream);
+    if (!device.ok() || !device.copy_from_host(host.data))
+        throw std::runtime_error("Qwen-VL LoRA cache: failed to upload tensor '" + name + "'");
+    return device;
+}
+
 } // namespace
 
-LoraInputBindings::LoraInputBindings(TrtModule& module,
-                                           std::vector<TensorInfo> input_contract)
+LoraInputBindings::LoraInputBindings(TrtModule& module, std::vector<TensorInfo> input_contract)
     : module_(module) {
     std::unordered_set<std::string> names;
     names.reserve(input_contract.size());
@@ -69,26 +106,14 @@ std::vector<TensorInfo> LoraInputBindings::input_info() const {
 }
 
 void LoraInputBindings::bind(const DeviceTensorMap& adapter_tensors) {
-    std::unordered_set<std::string> expected;
+    std::unordered_map<std::string, TensorInfo> expected;
     expected.reserve(entries_.size());
     for (const auto& entry : entries_)
-        expected.insert(entry.info.name);
-    for (const auto& [name, tensor] : adapter_tensors) {
-        if (expected.find(name) == expected.end())
-            throw std::invalid_argument("Unknown adapter tensor '" + name + "'");
-        if (tensor == nullptr || !tensor->ok())
-            throw std::invalid_argument("Invalid adapter tensor '" + name + "'");
-    }
-    for (const auto& entry : entries_) {
-        const auto it = adapter_tensors.find(entry.info.name);
-        if (it == adapter_tensors.end())
-            continue;
-        const DeviceTensor& tensor = *it->second;
-        if (tensor.shape() != entry.info.shape || tensor.dtype() != entry.info.dtype) {
-            throw std::invalid_argument("Shape or dtype mismatch for adapter tensor '" +
-                                        entry.info.name + "'");
-        }
-    }
+        expected.emplace(entry.info.name, entry.info);
+    for (const auto& [name, tensor] : adapter_tensors)
+        validate_adapter_tensor(expected, name, tensor);
+    for (const auto& entry : entries_)
+        validate_bound_tensor(entry.info, adapter_tensors);
 
     // Tensor addresses are execution-context state. Do not replace them while
     // a previous enqueue on this module can still read the old addresses.
@@ -122,8 +147,8 @@ DeviceTensorMap LoraDeviceWeights::device_view() {
     return view;
 }
 
-LoraAdapterCache::LoraAdapterCache(std::vector<TensorInfo> input_contract, cudaStream_t upload_stream,
-                           std::size_t capacity)
+LoraAdapterCache::LoraAdapterCache(std::vector<TensorInfo> input_contract,
+                                   cudaStream_t upload_stream, std::size_t capacity)
     : upload_stream_(upload_stream), capacity_(capacity) {
     if (capacity_ == 0)
         throw std::invalid_argument("Qwen-VL LoRA cache: capacity must be positive");
@@ -136,7 +161,8 @@ LoraAdapterCache::LoraAdapterCache(std::vector<TensorInfo> input_contract, cudaS
     }
 }
 
-void LoraAdapterCache::register_adapter(const std::string& adapter_id, const TensorMap& host_tensors) {
+void LoraAdapterCache::register_adapter(const std::string& adapter_id,
+                                        const TensorMap& host_tensors) {
     if (contract_.empty())
         throw std::runtime_error("Qwen-VL LoRA cache: engine has no adapter inputs");
     if (adapter_id.empty())
@@ -146,18 +172,8 @@ void LoraAdapterCache::register_adapter(const std::string& adapter_id, const Ten
 
     auto weights = std::make_shared<LoraDeviceWeights>();
     for (const auto& [name, host] : host_tensors) {
-        const auto expected = contract_.find(name);
-        if (expected == contract_.end())
-            throw std::invalid_argument("Qwen-VL LoRA cache: unknown adapter tensor '" + name + "'");
-        if (host.data == nullptr || host.shape != expected->second.shape ||
-            host.dtype != expected->second.dtype) {
-            throw std::invalid_argument("Qwen-VL LoRA cache: shape or dtype mismatch for tensor '" +
-                                        name + "'");
-        }
-        DeviceTensor device(host.shape, host.dtype, upload_stream_);
-        if (!device.ok() || !device.copy_from_host(host.data))
-            throw std::runtime_error("Qwen-VL LoRA cache: failed to upload tensor '" + name + "'");
-        weights->tensors_.emplace(name, std::move(device));
+        validate_host_tensor(contract_, name, host);
+        weights->tensors_.emplace(name, upload_tensor(host, upload_stream_, name));
     }
     if (cudaStreamSynchronize(upload_stream_) != cudaSuccess)
         throw std::runtime_error("Qwen-VL LoRA cache: adapter upload synchronization failed");

--- a/src/runtime/models/qwen_vl/lora_runtime.h
+++ b/src/runtime/models/qwen_vl/lora_runtime.h
@@ -63,7 +63,7 @@ class LoraDeviceWeights {
 class LoraAdapterCache {
   public:
     LoraAdapterCache(std::vector<TensorInfo> input_contract, cudaStream_t upload_stream,
-                 std::size_t capacity = 4);
+                     std::size_t capacity = 4);
 
     void register_adapter(const std::string& adapter_id, const TensorMap& host_tensors);
     void unregister_adapter(const std::string& adapter_id);

--- a/src/runtime/models/qwen_vl/lora_runtime.h
+++ b/src/runtime/models/qwen_vl/lora_runtime.h
@@ -1,0 +1,112 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/runtime/device_tensor.h"
+#include "trtmc/runtime/trt_module.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace trtmc {
+namespace qwen_vl {
+
+// Context-local bindings for the fixed-shape LoRA inputs emitted by the
+// Qwen-VL builder.
+class LoraInputBindings {
+  public:
+    LoraInputBindings(TrtModule& module, std::vector<TensorInfo> input_contract);
+
+    bool enabled() const { return !entries_.empty(); }
+    cudaStream_t stream() const { return module_.stream(); }
+    std::vector<std::string> input_names() const;
+    std::vector<TensorInfo> input_info() const;
+
+    // Missing contract inputs are bound to zero, allowing an artifact to
+    // target a subset of the adapter inputs compiled into the engine.
+    void bind(const DeviceTensorMap& adapter_tensors);
+    void clear();
+
+  private:
+    struct Entry {
+        TensorInfo info;
+        DeviceTensor zero;
+    };
+
+    TrtModule& module_;
+    std::vector<Entry> entries_;
+
+    void bind_zero_buffers();
+};
+
+// Immutable device tensors for one normalized adapter. Shared ownership pins
+// the buffers while one or more execution contexts have them bound.
+class LoraDeviceWeights {
+  public:
+    DeviceTensorMap device_view();
+
+  private:
+    friend class LoraAdapterCache;
+    std::unordered_map<std::string, DeviceTensor> tensors_;
+};
+
+// GPU-resident adapter registry for one Qwen-VL engine tensor contract. Cache
+// entries can be shared by multiple context-local LoraBindingContext objects.
+class LoraAdapterCache {
+  public:
+    LoraAdapterCache(std::vector<TensorInfo> input_contract, cudaStream_t upload_stream,
+                 std::size_t capacity = 4);
+
+    void register_adapter(const std::string& adapter_id, const TensorMap& host_tensors);
+    void unregister_adapter(const std::string& adapter_id);
+    std::shared_ptr<LoraDeviceWeights> acquire(const std::string& adapter_id);
+
+    bool contains(const std::string& adapter_id) const;
+    std::size_t size() const;
+    std::vector<std::string> adapter_ids() const;
+
+  private:
+    struct Entry {
+        std::shared_ptr<LoraDeviceWeights> weights;
+        uint64_t last_use{0};
+    };
+
+    std::unordered_map<std::string, TensorInfo> contract_;
+    cudaStream_t upload_stream_{nullptr};
+    std::size_t capacity_{4};
+    uint64_t clock_{0};
+    std::unordered_map<std::string, Entry> adapters_;
+    mutable std::mutex mutex_;
+
+    void evict_if_needed(const std::string& protected_adapter_id);
+};
+
+// One execution context's active adapter selection. Holding active_weights_
+// pins the cache entry until this context is cleared or selects another one.
+class LoraBindingContext {
+  public:
+    LoraBindingContext(LoraInputBindings& bindings, LoraAdapterCache& cache)
+        : bindings_(bindings), cache_(cache) {}
+
+    void select(const std::string& adapter_id);
+    void clear();
+
+    const std::string& active_adapter_id() const { return active_adapter_id_; }
+
+  private:
+    LoraInputBindings& bindings_;
+    LoraAdapterCache& cache_;
+    std::string active_adapter_id_;
+    std::shared_ptr<LoraDeviceWeights> active_weights_;
+};
+
+} // namespace qwen_vl
+} // namespace trtmc

--- a/src/runtime/models/qwen_vl/pipeline.cpp
+++ b/src/runtime/models/qwen_vl/pipeline.cpp
@@ -491,12 +491,50 @@ void copy_deepstack_outputs(const TensorMap& outputs,
     }
 }
 
+int32_t merged_grid_extent(int32_t configured_extent, int32_t fallback_extent, int32_t patch_size,
+                           int32_t merge_size) {
+    if (patch_size <= 0 || merge_size <= 0)
+        return 0;
+    const int32_t extent = configured_extent > 0 ? configured_extent : fallback_extent;
+    return extent / (patch_size * merge_size);
+}
+
+bool add_mrope_prefill_input(TrtModule& prefill, const std::vector<int32_t>& input_ids,
+                             const QwenVlMropePositions* mrope, int32_t sequence_length,
+                             std::vector<int32_t>& positions, TensorMap& inputs) {
+    if (!prefill.has_input("mrope_position_ids"))
+        return true;
+    if (mrope == nullptr || mrope->token_positions.size() != input_ids.size())
+        return false;
+    positions.resize(static_cast<std::size_t>(3 * sequence_length));
+    for (int32_t token_index = 0; token_index < sequence_length; ++token_index) {
+        for (int32_t axis = 0; axis < 3; ++axis) {
+            positions[static_cast<std::size_t>(axis * sequence_length + token_index)] =
+                mrope->token_positions[static_cast<std::size_t>(token_index)]
+                                      [static_cast<std::size_t>(axis)];
+        }
+    }
+    inputs["mrope_position_ids"] = Tensor{positions.data(), {3, sequence_length}, DType::kInt32};
+    return true;
+}
+
 } // namespace
 
 std::pair<int32_t, int32_t> QwenVlPipeline::resolve_gen_limits(const GenerateConfig& cfg) const {
     int32_t max_new = (cfg.max_new_tokens > 0) ? cfg.max_new_tokens : 128;
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
     return {max_new, eos};
+}
+
+QwenVlISampler* QwenVlPipeline::prepare_sampler(const QwenVlSamplingParams& params,
+                                                std::unique_ptr<QwenVlISampler>& local_sampler) {
+    QwenVlISampler* active_sampler = sampler_.get();
+    if (!active_sampler) {
+        local_sampler = create_qwen_vl_sampler(params);
+        active_sampler = local_sampler.get();
+    }
+    active_sampler->reset();
+    return active_sampler;
 }
 
 TextResult QwenVlPipeline::generate(const std::string& prompt, const float* image_pixels,
@@ -553,14 +591,8 @@ std::vector<int32_t> QwenVlPipeline::generate_from_ids(const std::vector<int32_t
     if (max_new_tokens == 0 || input_ids.empty())
         return input_ids;
 
-    // Create a per-call sampler if none was injected at construction time.
-    QwenVlISampler* active_sampler = sampler_.get();
     std::unique_ptr<QwenVlISampler> local_sampler;
-    if (!active_sampler) {
-        local_sampler = create_qwen_vl_sampler(params);
-        active_sampler = local_sampler.get();
-    }
-    active_sampler->reset();
+    QwenVlISampler* active_sampler = prepare_sampler(params, local_sampler);
 
     state_->reset();
     state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
@@ -597,14 +629,8 @@ std::vector<int32_t> QwenVlPipeline::generate_vl_from_ids(
     if (max_new_tokens == 0 || input_ids.empty())
         return input_ids;
 
-    // Create a per-call sampler if none was injected at construction time.
-    QwenVlISampler* active_sampler = sampler_.get();
     std::unique_ptr<QwenVlISampler> local_sampler;
-    if (!active_sampler) {
-        local_sampler = create_qwen_vl_sampler(params);
-        active_sampler = local_sampler.get();
-    }
-    active_sampler->reset();
+    QwenVlISampler* active_sampler = prepare_sampler(params, local_sampler);
 
     state_->reset();
     state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
@@ -615,17 +641,11 @@ std::vector<int32_t> QwenVlPipeline::generate_vl_from_ids(
 
     std::vector<float> logits;
     const int32_t grid_h =
-        vl_preprocess_.patch_size > 0 && vl_preprocess_.merge_size > 0
-            ? (vl_preprocess_.fixed_image_height > 0 ? vl_preprocess_.fixed_image_height
-                                                     : vl_preprocess_.fixed_image_size) /
-                  (vl_preprocess_.patch_size * vl_preprocess_.merge_size)
-            : 0;
+        merged_grid_extent(vl_preprocess_.fixed_image_height, vl_preprocess_.fixed_image_size,
+                           vl_preprocess_.patch_size, vl_preprocess_.merge_size);
     const int32_t grid_w =
-        vl_preprocess_.patch_size > 0 && vl_preprocess_.merge_size > 0
-            ? (vl_preprocess_.fixed_image_width > 0 ? vl_preprocess_.fixed_image_width
-                                                    : vl_preprocess_.fixed_image_size) /
-                  (vl_preprocess_.patch_size * vl_preprocess_.merge_size)
-            : 0;
+        merged_grid_extent(vl_preprocess_.fixed_image_width, vl_preprocess_.fixed_image_size,
+                           vl_preprocess_.patch_size, vl_preprocess_.merge_size);
     const bool use_mrope = text_decoder_->has_input("mrope_position_ids");
     const auto mrope = use_mrope ? qwen_vl_build_mrope_positions(input_ids, config_.image_token_id,
                                                                  num_features, grid_h, grid_w)
@@ -668,19 +688,8 @@ bool QwenVlPipeline::run_vl_prefill_batched(
     TensorMap inputs;
     add_vl_prefill_base_inputs(inputs, *state_, input_ids, embedding_inputs, feature_dim);
     std::vector<int32_t> mrope_positions;
-    if (prefill_->has_input("mrope_position_ids")) {
-        if (mrope == nullptr || mrope->token_positions.size() != input_ids.size())
-            return false;
-        mrope_positions.resize(static_cast<std::size_t>(3 * sq));
-        for (int32_t token_index = 0; token_index < sq; ++token_index) {
-            for (int32_t axis = 0; axis < 3; ++axis) {
-                mrope_positions[static_cast<std::size_t>(axis * sq + token_index)] =
-                    mrope->token_positions[static_cast<std::size_t>(token_index)]
-                                          [static_cast<std::size_t>(axis)];
-            }
-        }
-        inputs["mrope_position_ids"] = Tensor{mrope_positions.data(), {3, sq}, DType::kInt32};
-    }
+    if (!add_mrope_prefill_input(*prefill_, input_ids, mrope, sq, mrope_positions, inputs))
+        return false;
     if (!add_vl_prefill_deepstack_inputs(*prefill_, inputs, embedding_inputs, sq, feature_dim))
         return false;
 

--- a/src/runtime/models/qwen_vl/pipeline.cpp
+++ b/src/runtime/models/qwen_vl/pipeline.cpp
@@ -6,6 +6,7 @@
 #include "runtime/models/qwen_vl/pipeline.h"
 
 #include "runtime/models/qwen_vl/image_preprocessor.h"
+#include "runtime/models/qwen_vl/lora_peft_loader.h"
 #include "runtime/models/qwen_vl/tensor_names.h"
 
 #include <algorithm>
@@ -16,6 +17,36 @@
 namespace trtmc {
 
 namespace {
+
+bool is_lora_input(const std::string& name) {
+    return name.rfind("lora_a_", 0) == 0 || name.rfind("lora_b_", 0) == 0;
+}
+
+std::vector<TensorInfo> qwen_vl_lora_input_contract(const TrtModule& module) {
+    std::vector<TensorInfo> inputs;
+    for (const auto& info : module.input_info()) {
+        if (is_lora_input(info.name))
+            inputs.push_back(info);
+    }
+    return inputs;
+}
+
+bool same_qwen_vl_lora_contract(std::vector<TensorInfo> lhs, std::vector<TensorInfo> rhs) {
+    const auto by_name = [](const TensorInfo& left, const TensorInfo& right) {
+        return left.name < right.name;
+    };
+    std::sort(lhs.begin(), lhs.end(), by_name);
+    std::sort(rhs.begin(), rhs.end(), by_name);
+    if (lhs.size() != rhs.size())
+        return false;
+    for (std::size_t index = 0; index < lhs.size(); ++index) {
+        if (lhs[index].name != rhs[index].name || lhs[index].shape != rhs[index].shape ||
+            lhs[index].dtype != rhs[index].dtype) {
+            return false;
+        }
+    }
+    return true;
+}
 
 void validate_pipeline_components(const TrtModule* text_decoder, const QwenVlInferenceState* state,
                                   const TrtModule* prefill) {
@@ -42,19 +73,125 @@ QwenVlPipeline::QwenVlPipeline(std::unique_ptr<TrtModule> text_decoder,
                                QwenVlPreprocessConfig vl_preprocess, cudaStream_t stream,
                                std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
                                std::unique_ptr<QwenVlISampler> sampler,
-                               std::unique_ptr<TrtModule> prefill)
+                               std::shared_ptr<qwen_vl::LoraAdapterCache> adapter_cache)
+    : QwenVlPipeline(std::move(text_decoder), std::move(vision_encoder), std::move(state), config,
+                     std::move(vl_preprocess), stream, std::move(tokenizer),
+                     std::move(model_id_str), std::move(sampler), nullptr,
+                     std::move(adapter_cache)) {}
+
+QwenVlPipeline::QwenVlPipeline(std::unique_ptr<TrtModule> text_decoder,
+                               std::unique_ptr<TrtModule> vision_encoder,
+                               std::unique_ptr<QwenVlInferenceState> state, QwenVlConfig config,
+                               QwenVlPreprocessConfig vl_preprocess, cudaStream_t stream,
+                               std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
+                               std::unique_ptr<QwenVlISampler> sampler,
+                               std::unique_ptr<TrtModule> prefill,
+                               std::shared_ptr<qwen_vl::LoraAdapterCache> adapter_cache)
     : text_decoder_(std::move(text_decoder)), prefill_(std::move(prefill)),
       vision_encoder_(std::move(vision_encoder)), state_(std::move(state)), config_(config),
       vl_preprocess_(std::move(vl_preprocess)), stream_(stream), tokenizer_(std::move(tokenizer)),
       model_id_(std::move(model_id_str)), sampler_(std::move(sampler)) {
     validate_pipeline_components(text_decoder_.get(), state_.get(), prefill_.get());
     sync_vision_config(config_, vl_preprocess_);
+
+    auto lora_contract = qwen_vl_lora_input_contract(*text_decoder_);
+    lora_bindings_ = std::make_unique<qwen_vl::LoraInputBindings>(*text_decoder_, lora_contract);
+    lora_adapter_cache_ = std::move(adapter_cache);
+    if (!lora_adapter_cache_) {
+        lora_adapter_cache_ =
+            std::make_shared<qwen_vl::LoraAdapterCache>(lora_contract, text_decoder_->stream());
+    }
+    lora_binding_context_ =
+        std::make_unique<qwen_vl::LoraBindingContext>(*lora_bindings_, *lora_adapter_cache_);
+
+    if (prefill_) {
+        auto prefill_contract = qwen_vl_lora_input_contract(*prefill_);
+        if (!same_qwen_vl_lora_contract(lora_contract, prefill_contract)) {
+            throw std::runtime_error(
+                "QwenVlPipeline: prefill and decode LoRA input contracts differ");
+        }
+        prefill_lora_bindings_ =
+            std::make_unique<qwen_vl::LoraInputBindings>(*prefill_, std::move(prefill_contract));
+        if (prefill_lora_bindings_->enabled()) {
+            prefill_lora_binding_context_ = std::make_unique<qwen_vl::LoraBindingContext>(
+                *prefill_lora_bindings_, *lora_adapter_cache_);
+        }
+    }
+}
+
+std::vector<std::string> QwenVlPipeline::lora_input_names() const {
+    return lora_bindings_ ? lora_bindings_->input_names() : std::vector<std::string>{};
+}
+
+void QwenVlPipeline::clear_lora_adapter() {
+    select_lora_adapter("");
+}
+
+void QwenVlPipeline::register_lora_adapter(const std::string& adapter_id,
+                                           const TensorMap& host_tensors) {
+    if (!lora_adapter_cache_)
+        throw std::runtime_error("QwenVlPipeline: LoRA adapter cache is unavailable");
+    if ((lora_binding_context_ && lora_binding_context_->active_adapter_id() == adapter_id) ||
+        (prefill_lora_binding_context_ &&
+         prefill_lora_binding_context_->active_adapter_id() == adapter_id)) {
+        clear_lora_adapter();
+    }
+    lora_adapter_cache_->register_adapter(adapter_id, host_tensors);
+}
+
+void QwenVlPipeline::load_lora_adapter(const std::string& adapter_id,
+                                       const std::string& adapter_path) {
+    if (!has_dynamic_lora())
+        throw std::runtime_error("QwenVlPipeline: engine has no dynamic LoRA inputs");
+    auto adapter = qwen_vl_load_peft_lora_adapter(adapter_path, lora_bindings_->input_info());
+    register_lora_adapter(adapter_id, adapter.tensor_views());
+}
+
+void QwenVlPipeline::unload_lora_adapter(const std::string& adapter_id) {
+    if (!lora_adapter_cache_)
+        throw std::runtime_error("QwenVlPipeline: LoRA adapter cache is unavailable");
+    if ((lora_binding_context_ && lora_binding_context_->active_adapter_id() == adapter_id) ||
+        (prefill_lora_binding_context_ &&
+         prefill_lora_binding_context_->active_adapter_id() == adapter_id)) {
+        clear_lora_adapter();
+    }
+    lora_adapter_cache_->unregister_adapter(adapter_id);
+}
+
+std::vector<std::string> QwenVlPipeline::loaded_lora_adapters() const {
+    return lora_adapter_cache_ ? lora_adapter_cache_->adapter_ids() : std::vector<std::string>{};
+}
+
+void QwenVlPipeline::select_lora_adapter(const std::string& adapter_id) {
+    if (!lora_binding_context_)
+        throw std::runtime_error("QwenVlPipeline: LoRA binding context is unavailable");
+    const std::string previous_decode = lora_binding_context_->active_adapter_id();
+    const std::string previous_prefill = prefill_lora_binding_context_
+                                             ? prefill_lora_binding_context_->active_adapter_id()
+                                             : std::string{};
+    try {
+        lora_binding_context_->select(adapter_id);
+        if (prefill_lora_binding_context_)
+            prefill_lora_binding_context_->select(adapter_id);
+    } catch (...) {
+        try {
+            if (prefill_lora_binding_context_)
+                prefill_lora_binding_context_->select(previous_prefill);
+        } catch (...) {
+        }
+        try {
+            lora_binding_context_->select(previous_decode);
+        } catch (...) {
+        }
+        throw;
+    }
 }
 
 TextResult QwenVlPipeline::generate(const std::string& prompt, const GenerateConfig& cfg) {
     if (!tokenizer_)
         throw std::runtime_error("QwenVlPipeline: no tokenizer configured");
 
+    select_lora_adapter(cfg.lora_adapter_id);
     auto input_ids = tokenizer_->encode(prompt);
     auto [max_new, eos] = resolve_gen_limits(cfg);
     auto sp = qwen_vl_sampling_params_from_config(cfg, eos);
@@ -368,6 +505,7 @@ TextResult QwenVlPipeline::generate(const std::string& prompt, const float* imag
     if (!tokenizer_)
         throw std::runtime_error("QwenVlPipeline: no tokenizer configured");
 
+    select_lora_adapter(cfg.lora_adapter_id);
     bool valid = image_pixels && image_height > 0 && image_width > 0;
     if (!valid || !vision_encoder_)
         return generate(prompt, cfg);
@@ -402,6 +540,7 @@ TextResult QwenVlPipeline::generate(const std::string& prompt, const float* imag
 
 QwenVlPipeline::GenerationResult QwenVlPipeline::generate_ids(const std::vector<int32_t>& input_ids,
                                                               const GenerateConfig& cfg) {
+    select_lora_adapter(cfg.lora_adapter_id);
     int32_t max_new = cfg.max_new_tokens;
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
     auto sp = qwen_vl_sampling_params_from_config(cfg, eos);
@@ -475,24 +614,44 @@ std::vector<int32_t> QwenVlPipeline::generate_vl_from_ids(
     state_->bind_to(*text_decoder_);
 
     std::vector<float> logits;
+    const int32_t grid_h =
+        vl_preprocess_.patch_size > 0 && vl_preprocess_.merge_size > 0
+            ? (vl_preprocess_.fixed_image_height > 0 ? vl_preprocess_.fixed_image_height
+                                                     : vl_preprocess_.fixed_image_size) /
+                  (vl_preprocess_.patch_size * vl_preprocess_.merge_size)
+            : 0;
+    const int32_t grid_w =
+        vl_preprocess_.patch_size > 0 && vl_preprocess_.merge_size > 0
+            ? (vl_preprocess_.fixed_image_width > 0 ? vl_preprocess_.fixed_image_width
+                                                    : vl_preprocess_.fixed_image_size) /
+                  (vl_preprocess_.patch_size * vl_preprocess_.merge_size)
+            : 0;
+    const bool use_mrope = text_decoder_->has_input("mrope_position_ids");
+    const auto mrope = use_mrope ? qwen_vl_build_mrope_positions(input_ids, config_.image_token_id,
+                                                                 num_features, grid_h, grid_w)
+                                 : QwenVlMropePositions{};
     if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,
-                                feature_dim, logits)) {
+                                feature_dim, use_mrope ? &mrope : nullptr, logits)) {
         int32_t feature_index = 0;
-        for (const auto& tid : input_ids)
+        for (std::size_t index = 0; index < input_ids.size(); ++index) {
+            const auto tid = input_ids[index];
+            const auto* position = use_mrope ? &mrope.token_positions[index] : nullptr;
             run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
-                                 feature_index, logits);
+                                 feature_index, position, logits);
+        }
     }
     state_->mark_prefill_complete();
 
     std::vector<int32_t> output = input_ids;
-    run_vl_decode_loop(active_sampler, params, output, logits, max_new_tokens);
+    run_vl_decode_loop(active_sampler, params, output, logits, max_new_tokens,
+                       use_mrope ? mrope.next_position : -1);
     return output;
 }
 
 bool QwenVlPipeline::run_vl_prefill_batched(
     const std::vector<int32_t>& input_ids, const std::vector<float>& image_features,
     const std::vector<std::vector<float>>& deepstack_features, int32_t num_features,
-    int32_t feature_dim, std::vector<float>& logits) {
+    int32_t feature_dim, const QwenVlMropePositions* mrope, std::vector<float>& logits) {
     const auto sq = static_cast<int32_t>(input_ids.size());
     auto* kv_cache =
         eligible_vl_prefill_cache(prefill_.get(), state_.get(), config_, sq, feature_dim);
@@ -508,6 +667,20 @@ bool QwenVlPipeline::run_vl_prefill_batched(
 
     TensorMap inputs;
     add_vl_prefill_base_inputs(inputs, *state_, input_ids, embedding_inputs, feature_dim);
+    std::vector<int32_t> mrope_positions;
+    if (prefill_->has_input("mrope_position_ids")) {
+        if (mrope == nullptr || mrope->token_positions.size() != input_ids.size())
+            return false;
+        mrope_positions.resize(static_cast<std::size_t>(3 * sq));
+        for (int32_t token_index = 0; token_index < sq; ++token_index) {
+            for (int32_t axis = 0; axis < 3; ++axis) {
+                mrope_positions[static_cast<std::size_t>(axis * sq + token_index)] =
+                    mrope->token_positions[static_cast<std::size_t>(token_index)]
+                                          [static_cast<std::size_t>(axis)];
+            }
+        }
+        inputs["mrope_position_ids"] = Tensor{mrope_positions.data(), {3, sq}, DType::kInt32};
+    }
     if (!add_vl_prefill_deepstack_inputs(*prefill_, inputs, embedding_inputs, sq, feature_dim))
         return false;
 
@@ -527,10 +700,12 @@ void QwenVlPipeline::run_vl_prefill_token(int32_t token_id,
                                           const std::vector<float>& image_features,
                                           const std::vector<std::vector<float>>& deepstack_features,
                                           int32_t num_features, int32_t feature_dim,
-                                          int32_t& feature_index, std::vector<float>& logits) {
+                                          int32_t& feature_index,
+                                          const std::array<int32_t, 3>* mrope_position,
+                                          std::vector<float>& logits) {
     const bool use_image_embed = token_id == config_.image_token_id && feature_index < num_features;
     if (!use_image_embed) {
-        run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, logits);
+        run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, mrope_position, logits);
         return;
     }
 
@@ -539,31 +714,42 @@ void QwenVlPipeline::run_vl_prefill_token(int32_t token_id,
     const auto deepstack_embeds =
         select_deepstack_feature_pointers(deepstack_features, feature_index, feature_dim);
     run_text_step_with_embed(token_id, embed, 1.0F, deepstack_embeds,
-                             deepstack_embeds.empty() ? 0.0F : 1.0F, logits);
+                             deepstack_embeds.empty() ? 0.0F : 1.0F, mrope_position, logits);
     ++feature_index;
 }
 
 void QwenVlPipeline::run_vl_decode_loop(QwenVlISampler* sampler, const QwenVlSamplingParams& params,
                                         std::vector<int32_t>& output, std::vector<float>& logits,
-                                        int32_t max_new_tokens) {
+                                        int32_t max_new_tokens, int32_t mrope_position) {
     const int32_t vocab_size = static_cast<int32_t>(logits.size());
     for (int32_t step = 0; step < max_new_tokens; ++step) {
         QwenVlSampleResult result = sampler->sample(logits.data(), vocab_size, params);
         output.push_back(result.token_id);
         if (result.is_eos)
             break;
-        run_text_step(result.token_id, logits);
+        run_text_step(result.token_id, logits, mrope_position);
+        if (mrope_position >= 0)
+            ++mrope_position;
     }
 }
 
-void QwenVlPipeline::run_text_step(int32_t token_id, std::vector<float>& logits) {
-    run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, logits);
+void QwenVlPipeline::run_text_step(int32_t token_id, std::vector<float>& logits,
+                                   int32_t mrope_position) {
+    if (mrope_position < 0 || !text_decoder_->has_input("mrope_position_ids")) {
+        run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, nullptr, logits);
+        return;
+    }
+    std::array<int32_t, 3> mrope_pos{};
+    mrope_pos.fill(mrope_position);
+    run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, &mrope_pos, logits);
 }
 
 void QwenVlPipeline::run_text_step_with_embed(int32_t token_id, const float* input_embed,
                                               float use_input_embed,
                                               const std::vector<const float*>& deepstack_embeds,
-                                              float deepstack_active, std::vector<float>& logits) {
+                                              float deepstack_active,
+                                              const std::array<int32_t, 3>* mrope_position,
+                                              std::vector<float>& logits) {
     TensorMap inputs;
 
     Tensor token_t;
@@ -573,6 +759,11 @@ void QwenVlPipeline::run_text_step_with_embed(int32_t token_id, const float* inp
     inputs["token_id"] = token_t;
 
     state_->prepare_step(inputs);
+
+    if (mrope_position != nullptr && text_decoder_->has_input("mrope_position_ids")) {
+        inputs["mrope_position_ids"] =
+            Tensor{const_cast<int32_t*>(mrope_position->data()), {3}, DType::kInt32};
+    }
 
     std::vector<float> zero_embed;
     std::vector<float> zero_deepstack;

--- a/src/runtime/models/qwen_vl/pipeline.h
+++ b/src/runtime/models/qwen_vl/pipeline.h
@@ -116,6 +116,9 @@ class QwenVlPipeline final : public IPipeline {
 
     std::pair<int32_t, int32_t> resolve_gen_limits(const GenerateConfig& cfg) const;
 
+    QwenVlISampler* prepare_sampler(const QwenVlSamplingParams& params,
+                                    std::unique_ptr<QwenVlISampler>& local_sampler);
+
     void run_vl_prefill_token(int32_t token_id, const std::vector<float>& image_features,
                               const std::vector<std::vector<float>>& deepstack_features,
                               int32_t num_features, int32_t feature_dim, int32_t& feature_index,

--- a/src/runtime/models/qwen_vl/pipeline.h
+++ b/src/runtime/models/qwen_vl/pipeline.h
@@ -11,11 +11,13 @@
 #include "runtime/models/qwen_vl/image_preprocessor.h"
 #include "runtime/models/qwen_vl/inference_state.h"
 #include "runtime/models/qwen_vl/kv_cache.h"
+#include "runtime/models/qwen_vl/lora_runtime.h"
 #include "runtime/models/qwen_vl/sampler.h"
 #include "trtmc/pipeline.h"
 #include "trtmc/runtime/trt_module.h"
 #include "trtmc/tokenizer.h"
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -45,7 +47,16 @@ class QwenVlPipeline final : public IPipeline {
                    QwenVlPreprocessConfig vl_preprocess, cudaStream_t stream,
                    std::shared_ptr<ITokenizer> tokenizer = nullptr, std::string model_id_str = "",
                    std::unique_ptr<QwenVlISampler> sampler = nullptr,
-                   std::unique_ptr<TrtModule> prefill = nullptr);
+                   std::unique_ptr<TrtModule> prefill = nullptr,
+                   std::shared_ptr<qwen_vl::LoraAdapterCache> adapter_cache = nullptr);
+
+    QwenVlPipeline(std::unique_ptr<TrtModule> text_decoder,
+                   std::unique_ptr<TrtModule> vision_encoder,
+                   std::unique_ptr<QwenVlInferenceState> state, QwenVlConfig config,
+                   QwenVlPreprocessConfig vl_preprocess, cudaStream_t stream,
+                   std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
+                   std::unique_ptr<QwenVlISampler> sampler,
+                   std::shared_ptr<qwen_vl::LoraAdapterCache> adapter_cache);
 
     TextResult generate(const std::string& prompt, const GenerateConfig& cfg = {}) override;
 
@@ -54,6 +65,10 @@ class QwenVlPipeline final : public IPipeline {
 
     const char* model_id() const override { return model_id_.c_str(); }
     const char* pipeline_type() const override { return "QwenVlPipeline"; }
+    bool supports_lora_adapters() const override { return has_dynamic_lora(); }
+    void load_lora_adapter(const std::string& adapter_id, const std::string& adapter_path) override;
+    void unload_lora_adapter(const std::string& adapter_id) override;
+    std::vector<std::string> loaded_lora_adapters() const override;
 
     // Token-ID-based generation (for unit tests and internal callers).
     struct GenerationResult {
@@ -64,6 +79,11 @@ class QwenVlPipeline final : public IPipeline {
     // VL preprocessing config (public for testing).
     const QwenVlPreprocessConfig& vl_preprocess_config() const { return vl_preprocess_; }
     bool has_vision_encoder() const { return vision_encoder_ != nullptr; }
+    bool has_dynamic_lora() const { return lora_bindings_ && lora_bindings_->enabled(); }
+    std::vector<std::string> lora_input_names() const;
+    void clear_lora_adapter();
+    void register_lora_adapter(const std::string& adapter_id, const TensorMap& host_tensors);
+    void select_lora_adapter(const std::string& adapter_id);
 
     static int32_t argmax(const std::vector<float>& logits);
 
@@ -78,6 +98,11 @@ class QwenVlPipeline final : public IPipeline {
     std::shared_ptr<ITokenizer> tokenizer_;
     std::string model_id_;
     std::unique_ptr<QwenVlISampler> sampler_;
+    std::unique_ptr<qwen_vl::LoraInputBindings> lora_bindings_;
+    std::unique_ptr<qwen_vl::LoraInputBindings> prefill_lora_bindings_;
+    std::shared_ptr<qwen_vl::LoraAdapterCache> lora_adapter_cache_;
+    std::unique_ptr<qwen_vl::LoraBindingContext> lora_binding_context_;
+    std::unique_ptr<qwen_vl::LoraBindingContext> prefill_lora_binding_context_;
 
     std::vector<int32_t> generate_from_ids(const std::vector<int32_t>& input_ids,
                                            int32_t max_new_tokens,
@@ -94,24 +119,27 @@ class QwenVlPipeline final : public IPipeline {
     void run_vl_prefill_token(int32_t token_id, const std::vector<float>& image_features,
                               const std::vector<std::vector<float>>& deepstack_features,
                               int32_t num_features, int32_t feature_dim, int32_t& feature_index,
+                              const std::array<int32_t, 3>* mrope_position,
                               std::vector<float>& logits);
 
     bool run_vl_prefill_batched(const std::vector<int32_t>& input_ids,
                                 const std::vector<float>& image_features,
                                 const std::vector<std::vector<float>>& deepstack_features,
                                 int32_t num_features, int32_t feature_dim,
-                                std::vector<float>& logits);
+                                const QwenVlMropePositions* mrope, std::vector<float>& logits);
 
     void run_vl_decode_loop(QwenVlISampler* sampler, const QwenVlSamplingParams& params,
                             std::vector<int32_t>& output, std::vector<float>& logits,
-                            int32_t max_new_tokens);
+                            int32_t max_new_tokens, int32_t mrope_position = -1);
 
-    void run_text_step(int32_t token_id, std::vector<float>& logits);
+    void run_text_step(int32_t token_id, std::vector<float>& logits, int32_t mrope_position = -1);
 
     // Run a text step with optional vision embedding override.
     void run_text_step_with_embed(int32_t token_id, const float* input_embed, float use_input_embed,
                                   const std::vector<const float*>& deepstack_embeds,
-                                  float deepstack_active, std::vector<float>& logits);
+                                  float deepstack_active,
+                                  const std::array<int32_t, 3>* mrope_position,
+                                  std::vector<float>& logits);
 
     // Run vision encoder on preprocessed image inputs.
     bool run_vision_encoder(const QwenVlPreprocessedImage& preprocessed,

--- a/src/runtime/models/qwen_vl/plugin.cpp
+++ b/src/runtime/models/qwen_vl/plugin.cpp
@@ -172,6 +172,144 @@ std::string bundle_section_text(const BundleFile& bundle, const std::string& sec
     return {};
 }
 
+struct LaneResources {
+    std::vector<std::shared_ptr<QwenVlCudaStream>> streams;
+    std::vector<ModuleCreateOptions> options;
+};
+
+LaneResources create_lane_resources(std::size_t count, const PipelineContext& ctx,
+                                    TextModuleRuntime& text_runtime,
+                                    const TensorParallelRuntimeConfig& tp_config) {
+    LaneResources resources;
+    resources.streams.reserve(count);
+    resources.options.reserve(count);
+    for (std::size_t index = 0; index < count; ++index) {
+        auto stream = std::make_shared<QwenVlCudaStream>();
+        if (!stream->ok())
+            throw std::runtime_error("VLPlugin: failed to create CUDA stream");
+        ModuleCreateOptions options;
+        options.stream = stream->get();
+        options.runtime_cache_path = ctx.runtime_cache_path.c_str();
+        options.cuda_graphs = ctx.cuda_graphs;
+        configure_text_module_options(text_runtime, options, tp_config);
+        resources.options.push_back(text_runtime.options);
+        resources.streams.push_back(std::move(stream));
+    }
+    return resources;
+}
+
+struct TextLaneModules {
+    std::vector<std::unique_ptr<ITrtModule>> decode;
+    std::vector<std::unique_ptr<ITrtModule>> prefill;
+};
+
+TextLaneModules load_text_lane_modules(const PipelineContext& ctx, TextModuleRuntime& runtime,
+                                       const LaneResources& lanes) {
+    const std::size_t count = lanes.streams.size();
+    TextLaneModules modules;
+    modules.decode.resize(count);
+    modules.prefill.resize(count);
+    if (count == 1) {
+        auto loaded = load_text_modules(ctx, runtime, lanes.streams.front());
+        modules.decode.front() = std::move(loaded.decode);
+        modules.prefill.front() = std::move(loaded.prefill);
+        return modules;
+    }
+
+    std::vector<ModuleCreateOptions> profile_options;
+    profile_options.reserve(count * 2);
+    for (const auto& options : lanes.options) {
+        auto prefill_options = options;
+        prefill_options.optimization_profile = 0;
+        profile_options.push_back(prefill_options);
+        auto decode_options = options;
+        decode_options.optimization_profile = 1;
+        profile_options.push_back(decode_options);
+    }
+    auto loaded =
+        load_context_modules(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
+                             runtime.engine_section.c_str(), profile_options);
+    for (std::size_t index = 0; index < count; ++index) {
+        modules.prefill[index] = std::move(loaded.modules[index * 2]);
+        modules.decode[index] = std::move(loaded.modules[index * 2 + 1]);
+        modules.prefill[index]->keep_alive(lanes.streams[index]);
+        modules.decode[index]->keep_alive(lanes.streams[index]);
+        if (runtime.tp_group.owner) {
+            modules.prefill[index]->keep_alive(runtime.tp_group.owner);
+            modules.decode[index]->keep_alive(runtime.tp_group.owner);
+        }
+    }
+    return modules;
+}
+
+void warn_missing_vision(bool declared, const char* detail) {
+    if (declared)
+        std::cerr << "[trtmc] WARNING: Bundle declares vision engine but " << detail << std::endl;
+}
+
+std::vector<std::unique_ptr<ITrtModule>>
+load_vision_lane_modules(const PipelineContext& ctx, const LaneResources& lanes, bool declared) {
+    const std::size_t count = lanes.streams.size();
+    std::vector<std::unique_ptr<ITrtModule>> modules(count);
+    if (count == 1) {
+        modules.front() = load_vision_module(ctx.backend, ctx.bundle, lanes.options.front(),
+                                             lanes.streams.front(), declared);
+        return modules;
+    }
+    const auto* plan = find_section(ctx.bundle, "vision_engine_plan");
+    if (!plan || plan->empty()) {
+        warn_missing_vision(declared, "the plan is missing");
+        return modules;
+    }
+    try {
+        auto loaded = load_context_modules(ctx.backend, plan, "vision_engine_plan", lanes.options);
+        modules = std::move(loaded.modules);
+        for (std::size_t index = 0; index < count; ++index)
+            modules[index]->keep_alive(lanes.streams[index]);
+        std::cerr << "[trtmc] Vision encoder loaded" << std::endl;
+    } catch (...) {
+        warn_missing_vision(declared, "deserialization failed");
+    }
+    return modules;
+}
+
+QwenVlConfig make_pipeline_config(const PipelineContext& ctx, const ITrtModule& decode) {
+    QwenVlConfig config;
+    config.vocab_size = ctx.config.vocab_size;
+    config.id_bos = ctx.config.id_bos;
+    config.id_eos = ctx.config.id_eos;
+    config.image_token_id = extract_json_int(ctx.config_json, "image_token_id", -1);
+    config.vision_output_dim = extract_json_int(ctx.config_json, "vision_output_dim", 0);
+    config.has_position_input = decode.has_input("position_id");
+    config.num_layers = ctx.config.num_layers;
+    config.prefill_max_length = ctx.config.max_cache_length;
+    config.present_k_pattern = ctx.config.io_map.present_k_pattern;
+    config.present_v_pattern = ctx.config.io_map.present_v_pattern;
+    return config;
+}
+
+std::vector<std::unique_ptr<IPipeline>>
+make_pipeline_lanes(const PipelineContext& ctx, TextLaneModules modules,
+                    std::vector<std::unique_ptr<ITrtModule>> vision_modules,
+                    const LaneResources& lanes, const QwenVlConfig& config,
+                    const QwenVlPreprocessConfig& preprocess, int32_t kv_dim, DType cache_dtype,
+                    std::shared_ptr<ITokenizer> tokenizer) {
+    auto adapter_cache = std::make_shared<qwen_vl::LoraAdapterCache>(
+        lora_input_contract(*modules.decode.front()), lanes.streams.front()->get());
+    std::vector<std::unique_ptr<IPipeline>> pipelines;
+    pipelines.reserve(lanes.streams.size());
+    for (std::size_t index = 0; index < lanes.streams.size(); ++index) {
+        auto state = std::make_unique<QwenVlKvCache>(
+            ctx.config.num_layers, ctx.config.max_cache_length, kv_dim, lanes.streams[index]->get(),
+            cache_dtype, build_kv_cache_names(ctx.config));
+        pipelines.push_back(std::make_unique<QwenVlPipeline>(
+            std::move(modules.decode[index]), std::move(vision_modules[index]), std::move(state),
+            config, preprocess, lanes.streams[index]->get(), tokenizer, ctx.bundle.info.model_id,
+            nullptr, std::move(modules.prefill[index]), adapter_cache));
+    }
+    return pipelines;
+}
+
 } // namespace
 
 class VLPlugin final : public IPipelinePlugin {
@@ -198,103 +336,22 @@ class VLPlugin final : public IPipelinePlugin {
             throw std::runtime_error(
                 "Qwen-VL pipeline pools do not yet support tensor parallelism");
         auto text_runtime = initialize_text_module_runtime(tp_config);
-
-        std::vector<std::shared_ptr<QwenVlCudaStream>> streams;
-        std::vector<ModuleCreateOptions> lane_options;
-        streams.reserve(count);
-        lane_options.reserve(count);
-        for (std::size_t index = 0; index < count; ++index) {
-            auto stream = std::make_shared<QwenVlCudaStream>();
-            if (!stream->ok())
-                throw std::runtime_error("VLPlugin: failed to create CUDA stream");
-            ModuleCreateOptions options;
-            options.stream = stream->get();
-            options.runtime_cache_path = ctx.runtime_cache_path.c_str();
-            options.cuda_graphs = ctx.cuda_graphs;
-            configure_text_module_options(text_runtime, options, tp_config);
-            lane_options.push_back(text_runtime.options);
-            streams.push_back(std::move(stream));
-        }
-
-        std::vector<std::unique_ptr<ITrtModule>> decode_modules(count);
-        std::vector<std::unique_ptr<ITrtModule>> prefill_modules(count);
-        if (count == 1) {
-            auto loaded = load_text_modules(ctx, text_runtime, streams.front());
-            decode_modules.front() = std::move(loaded.decode);
-            prefill_modules.front() = std::move(loaded.prefill);
-        } else {
-            std::vector<ModuleCreateOptions> profile_options;
-            profile_options.reserve(count * 2);
-            for (const auto& options : lane_options) {
-                auto prefill_options = options;
-                prefill_options.optimization_profile = 0;
-                profile_options.push_back(prefill_options);
-                auto decode_options = options;
-                decode_options.optimization_profile = 1;
-                profile_options.push_back(decode_options);
-            }
-            auto loaded = load_context_modules(
-                ctx.backend, find_section(ctx.bundle, text_runtime.engine_section),
-                text_runtime.engine_section.c_str(), profile_options);
-            for (std::size_t index = 0; index < count; ++index) {
-                prefill_modules[index] = std::move(loaded.modules[index * 2]);
-                decode_modules[index] = std::move(loaded.modules[index * 2 + 1]);
-                prefill_modules[index]->keep_alive(streams[index]);
-                decode_modules[index]->keep_alive(streams[index]);
-                if (text_runtime.tp_group.owner) {
-                    prefill_modules[index]->keep_alive(text_runtime.tp_group.owner);
-                    decode_modules[index]->keep_alive(text_runtime.tp_group.owner);
-                }
-            }
-        }
+        auto lanes = create_lane_resources(count, ctx, text_runtime, tp_config);
+        auto text_modules = load_text_lane_modules(ctx, text_runtime, lanes);
 
         const std::string cache_k_name =
             ctx.config.io_map.cache_k_pattern.empty()
                 ? std::string("cache_k_0")
                 : qwen_vl_expand_layer_name(ctx.config.io_map.cache_k_pattern, 0);
-        int32_t kv_dim = decoder_cache_row_width(*decode_modules.front(), cache_k_name, ctx.config);
-        DType cache_dtype = decode_modules.front()->tensor_dtype(cache_k_name);
+        int32_t kv_dim =
+            decoder_cache_row_width(*text_modules.decode.front(), cache_k_name, ctx.config);
+        DType cache_dtype = text_modules.decode.front()->tensor_dtype(cache_k_name);
 
         auto tokenizer = create_tokenizer_from_bundle(ctx.bundle);
-
-        QwenVlConfig vlc;
-        vlc.vocab_size = ctx.config.vocab_size;
-        vlc.id_bos = ctx.config.id_bos;
-        vlc.id_eos = ctx.config.id_eos;
-        vlc.image_token_id = extract_json_int(ctx.config_json, "image_token_id", -1);
-        vlc.vision_output_dim = extract_json_int(ctx.config_json, "vision_output_dim", 0);
-        vlc.has_position_input = decode_modules.front()->has_input("position_id");
-        vlc.num_layers = ctx.config.num_layers;
-        vlc.prefill_max_length = ctx.config.max_cache_length;
-        vlc.present_k_pattern = ctx.config.io_map.present_k_pattern;
-        vlc.present_v_pattern = ctx.config.io_map.present_v_pattern;
-
-        bool has_vision_engine = extract_json_int(ctx.config_json, "has_vision_engine", 0) != 0;
-
-        std::vector<std::unique_ptr<ITrtModule>> vision_modules(count);
-        const auto* vision_plan = find_section(ctx.bundle, "vision_engine_plan");
-        if (count == 1) {
-            vision_modules.front() = load_vision_module(
-                ctx.backend, ctx.bundle, lane_options.front(), streams.front(), has_vision_engine);
-        } else if (vision_plan && !vision_plan->empty()) {
-            try {
-                auto loaded = load_context_modules(ctx.backend, vision_plan, "vision_engine_plan",
-                                                   lane_options);
-                vision_modules = std::move(loaded.modules);
-                for (std::size_t index = 0; index < count; ++index)
-                    vision_modules[index]->keep_alive(streams[index]);
-                std::cerr << "[trtmc] Vision encoder loaded" << std::endl;
-            } catch (...) {
-                if (has_vision_engine) {
-                    std::cerr << "[trtmc] WARNING: Bundle declares vision engine but "
-                                 "deserialization failed"
-                              << std::endl;
-                }
-            }
-        } else if (has_vision_engine) {
-            std::cerr << "[trtmc] WARNING: Bundle declares vision engine but the plan is missing"
-                      << std::endl;
-        }
+        const auto vlc = make_pipeline_config(ctx, *text_modules.decode.front());
+        const bool has_vision_engine =
+            extract_json_int(ctx.config_json, "has_vision_engine", 0) != 0;
+        auto vision_modules = load_vision_lane_modules(ctx, lanes, has_vision_engine);
 
         // Build VL preprocessing config from bundle's config.json +
         // preprocessor_config.json sections.
@@ -303,21 +360,8 @@ class VLPlugin final : public IPipelinePlugin {
             bundle_section_text(ctx.bundle, "preprocessor_config.json");
         auto vl_preprocess = qwen_vl_parse_preprocess_config(config_text, preproc_text);
 
-        auto adapter_cache = std::make_shared<qwen_vl::LoraAdapterCache>(
-            lora_input_contract(*decode_modules.front()), streams.front()->get());
-        std::vector<std::unique_ptr<IPipeline>> pipelines;
-        pipelines.reserve(count);
-        for (std::size_t index = 0; index < count; ++index) {
-            auto state = std::make_unique<QwenVlKvCache>(
-                ctx.config.num_layers, ctx.config.max_cache_length, kv_dim, streams[index]->get(),
-                cache_dtype, build_kv_cache_names(ctx.config));
-            pipelines.push_back(std::make_unique<QwenVlPipeline>(
-                std::move(decode_modules[index]), std::move(vision_modules[index]),
-                std::move(state), vlc, vl_preprocess, streams[index]->get(), tokenizer,
-                ctx.bundle.info.model_id, nullptr, std::move(prefill_modules[index]),
-                adapter_cache));
-        }
-        return pipelines;
+        return make_pipeline_lanes(ctx, std::move(text_modules), std::move(vision_modules), lanes,
+                                   vlc, vl_preprocess, kv_dim, cache_dtype, std::move(tokenizer));
     }
 };
 

--- a/src/runtime/models/qwen_vl/plugin.cpp
+++ b/src/runtime/models/qwen_vl/plugin.cpp
@@ -15,6 +15,7 @@
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
@@ -92,6 +93,43 @@ QwenVlKvCacheNames build_kv_cache_names(const BaseConfig& config) {
     return kv_names;
 }
 
+BackendContextModules load_context_modules(IBackend* backend, const std::vector<char>* plan,
+                                           const char* label,
+                                           const std::vector<ModuleCreateOptions>& options) {
+    if (!plan || plan->empty())
+        throw std::runtime_error(std::string("Bundle missing ") + label);
+    if (!backend)
+        throw std::runtime_error("No backend loaded");
+    const auto started = std::chrono::steady_clock::now();
+    auto loaded = backend->create_context_modules(plan->data(), plan->size(), options);
+    const auto finished = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double, std::milli>(finished - started).count();
+    log_trt_load_timing(label, elapsed, plan->size());
+    if (loaded.modules.size() != options.size())
+        throw std::runtime_error(std::string("Failed to create all execution contexts for ") +
+                                 label);
+    for (auto& module : loaded.modules) {
+        if (!module || !module->ok())
+            throw std::runtime_error(std::string("Failed to create execution context for ") +
+                                     label);
+        module->set_timing_label(label);
+    }
+    return loaded;
+}
+
+bool is_lora_input(const std::string& name) {
+    return name.rfind("lora_a_", 0) == 0 || name.rfind("lora_b_", 0) == 0;
+}
+
+std::vector<TensorInfo> lora_input_contract(const ITrtModule& module) {
+    std::vector<TensorInfo> contract;
+    for (const auto& info : module.input_info()) {
+        if (is_lora_input(info.name))
+            contract.push_back(info);
+    }
+    return contract;
+}
+
 DualProfileModules load_text_modules(const PipelineContext& ctx, TextModuleRuntime& runtime,
                                      const std::shared_ptr<QwenVlCudaStream>& stream) {
     auto loaded =
@@ -139,34 +177,83 @@ std::string bundle_section_text(const BundleFile& bundle, const std::string& sec
 class VLPlugin final : public IPipelinePlugin {
   public:
     std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
+        auto pipelines = create_lanes(ctx, 1);
+        return std::move(pipelines.front());
+    }
+
+    std::vector<std::unique_ptr<IPipeline>> create_pool(const PipelineContext& ctx,
+                                                        std::size_t count) override {
+        return create_lanes(ctx, count);
+    }
+
+  private:
+    std::vector<std::unique_ptr<IPipeline>> create_lanes(const PipelineContext& ctx,
+                                                         std::size_t count) {
+        if (count == 0)
+            throw std::invalid_argument("Qwen-VL pipeline pool size must be positive");
         load_ffi_kernels_from_bundle(ctx.bundle);
 
         const auto tp_config = parse_tensor_parallel_runtime_config(ctx.config_json);
+        if (count > 1 && tp_config.enabled)
+            throw std::runtime_error(
+                "Qwen-VL pipeline pools do not yet support tensor parallelism");
         auto text_runtime = initialize_text_module_runtime(tp_config);
 
-        auto shared_stream = std::make_shared<QwenVlCudaStream>();
-        if (!shared_stream->ok())
-            throw std::runtime_error("VLPlugin: failed to create CUDA stream");
+        std::vector<std::shared_ptr<QwenVlCudaStream>> streams;
+        std::vector<ModuleCreateOptions> lane_options;
+        streams.reserve(count);
+        lane_options.reserve(count);
+        for (std::size_t index = 0; index < count; ++index) {
+            auto stream = std::make_shared<QwenVlCudaStream>();
+            if (!stream->ok())
+                throw std::runtime_error("VLPlugin: failed to create CUDA stream");
+            ModuleCreateOptions options;
+            options.stream = stream->get();
+            options.runtime_cache_path = ctx.runtime_cache_path.c_str();
+            options.cuda_graphs = ctx.cuda_graphs;
+            configure_text_module_options(text_runtime, options, tp_config);
+            lane_options.push_back(text_runtime.options);
+            streams.push_back(std::move(stream));
+        }
 
-        ModuleCreateOptions opts;
-        opts.stream = shared_stream->get();
-        opts.runtime_cache_path = ctx.runtime_cache_path.c_str();
-        opts.cuda_graphs = ctx.cuda_graphs;
+        std::vector<std::unique_ptr<ITrtModule>> decode_modules(count);
+        std::vector<std::unique_ptr<ITrtModule>> prefill_modules(count);
+        if (count == 1) {
+            auto loaded = load_text_modules(ctx, text_runtime, streams.front());
+            decode_modules.front() = std::move(loaded.decode);
+            prefill_modules.front() = std::move(loaded.prefill);
+        } else {
+            std::vector<ModuleCreateOptions> profile_options;
+            profile_options.reserve(count * 2);
+            for (const auto& options : lane_options) {
+                auto prefill_options = options;
+                prefill_options.optimization_profile = 0;
+                profile_options.push_back(prefill_options);
+                auto decode_options = options;
+                decode_options.optimization_profile = 1;
+                profile_options.push_back(decode_options);
+            }
+            auto loaded = load_context_modules(
+                ctx.backend, find_section(ctx.bundle, text_runtime.engine_section),
+                text_runtime.engine_section.c_str(), profile_options);
+            for (std::size_t index = 0; index < count; ++index) {
+                prefill_modules[index] = std::move(loaded.modules[index * 2]);
+                decode_modules[index] = std::move(loaded.modules[index * 2 + 1]);
+                prefill_modules[index]->keep_alive(streams[index]);
+                decode_modules[index]->keep_alive(streams[index]);
+                if (text_runtime.tp_group.owner) {
+                    prefill_modules[index]->keep_alive(text_runtime.tp_group.owner);
+                    decode_modules[index]->keep_alive(text_runtime.tp_group.owner);
+                }
+            }
+        }
 
-        configure_text_module_options(text_runtime, opts, tp_config);
-
-        QwenVlKvCacheNames kv_names = build_kv_cache_names(ctx.config);
-
-        auto loaded = load_text_modules(ctx, text_runtime, shared_stream);
-
-        cudaStream_t stream = loaded.decode->stream();
         const std::string cache_k_name =
-            kv_names.cache_k.empty() ? std::string("cache_k_0") : kv_names.cache_k.front();
-        int32_t kv_dim = decoder_cache_row_width(*loaded.decode, cache_k_name, ctx.config);
-        DType cache_dtype = loaded.decode->tensor_dtype(cache_k_name);
-        std::unique_ptr<QwenVlInferenceState> state =
-            std::make_unique<QwenVlKvCache>(ctx.config.num_layers, ctx.config.max_cache_length,
-                                            kv_dim, stream, cache_dtype, std::move(kv_names));
+            ctx.config.io_map.cache_k_pattern.empty()
+                ? std::string("cache_k_0")
+                : qwen_vl_expand_layer_name(ctx.config.io_map.cache_k_pattern, 0);
+        int32_t kv_dim = decoder_cache_row_width(*decode_modules.front(), cache_k_name, ctx.config);
+        DType cache_dtype = decode_modules.front()->tensor_dtype(cache_k_name);
 
         auto tokenizer = create_tokenizer_from_bundle(ctx.bundle);
 
@@ -176,7 +263,7 @@ class VLPlugin final : public IPipelinePlugin {
         vlc.id_eos = ctx.config.id_eos;
         vlc.image_token_id = extract_json_int(ctx.config_json, "image_token_id", -1);
         vlc.vision_output_dim = extract_json_int(ctx.config_json, "vision_output_dim", 0);
-        vlc.has_position_input = loaded.decode->has_input("position_id");
+        vlc.has_position_input = decode_modules.front()->has_input("position_id");
         vlc.num_layers = ctx.config.num_layers;
         vlc.prefill_max_length = ctx.config.max_cache_length;
         vlc.present_k_pattern = ctx.config.io_map.present_k_pattern;
@@ -184,9 +271,30 @@ class VLPlugin final : public IPipelinePlugin {
 
         bool has_vision_engine = extract_json_int(ctx.config_json, "has_vision_engine", 0) != 0;
 
-        // Try to load the vision encoder engine from the bundle.
-        std::unique_ptr<TrtModule> vision_module =
-            load_vision_module(ctx.backend, ctx.bundle, opts, shared_stream, has_vision_engine);
+        std::vector<std::unique_ptr<ITrtModule>> vision_modules(count);
+        const auto* vision_plan = find_section(ctx.bundle, "vision_engine_plan");
+        if (count == 1) {
+            vision_modules.front() = load_vision_module(
+                ctx.backend, ctx.bundle, lane_options.front(), streams.front(), has_vision_engine);
+        } else if (vision_plan && !vision_plan->empty()) {
+            try {
+                auto loaded = load_context_modules(ctx.backend, vision_plan, "vision_engine_plan",
+                                                   lane_options);
+                vision_modules = std::move(loaded.modules);
+                for (std::size_t index = 0; index < count; ++index)
+                    vision_modules[index]->keep_alive(streams[index]);
+                std::cerr << "[trtmc] Vision encoder loaded" << std::endl;
+            } catch (...) {
+                if (has_vision_engine) {
+                    std::cerr << "[trtmc] WARNING: Bundle declares vision engine but "
+                                 "deserialization failed"
+                              << std::endl;
+                }
+            }
+        } else if (has_vision_engine) {
+            std::cerr << "[trtmc] WARNING: Bundle declares vision engine but the plan is missing"
+                      << std::endl;
+        }
 
         // Build VL preprocessing config from bundle's config.json +
         // preprocessor_config.json sections.
@@ -195,10 +303,21 @@ class VLPlugin final : public IPipelinePlugin {
             bundle_section_text(ctx.bundle, "preprocessor_config.json");
         auto vl_preprocess = qwen_vl_parse_preprocess_config(config_text, preproc_text);
 
-        return std::make_unique<QwenVlPipeline>(std::move(loaded.decode), std::move(vision_module),
-                                                std::move(state), vlc, vl_preprocess, stream,
-                                                std::move(tokenizer), ctx.bundle.info.model_id,
-                                                nullptr, std::move(loaded.prefill));
+        auto adapter_cache = std::make_shared<qwen_vl::LoraAdapterCache>(
+            lora_input_contract(*decode_modules.front()), streams.front()->get());
+        std::vector<std::unique_ptr<IPipeline>> pipelines;
+        pipelines.reserve(count);
+        for (std::size_t index = 0; index < count; ++index) {
+            auto state = std::make_unique<QwenVlKvCache>(
+                ctx.config.num_layers, ctx.config.max_cache_length, kv_dim, streams[index]->get(),
+                cache_dtype, build_kv_cache_names(ctx.config));
+            pipelines.push_back(std::make_unique<QwenVlPipeline>(
+                std::move(decode_modules[index]), std::move(vision_modules[index]),
+                std::move(state), vlc, vl_preprocess, streams[index]->get(), tokenizer,
+                ctx.bundle.info.model_id, nullptr, std::move(prefill_modules[index]),
+                adapter_cache));
+        }
+        return pipelines;
     }
 };
 

--- a/src/runtime/registry/pipeline_factory.cpp
+++ b/src/runtime/registry/pipeline_factory.cpp
@@ -14,6 +14,7 @@
 #include "trtmc/config/schema_registry.h"
 #include "trtmc/runtime/pipeline_plugin.h"
 #include "trtmc/runtime/pipeline_plugin_loader.h"
+#include "trtmc/runtime/pipeline_pool.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "trtmc/runtime/trt_backend.h"
 #include "utils/data_dir.h"
@@ -290,6 +291,53 @@ std::unique_ptr<IPipeline> PipelineFactory::from_bundle(const std::string& bundl
     std::cerr << "[trtmc] Pipeline loaded (strategy=" << strategy << ", backend=trt_new_runtime)"
               << std::endl;
     return pipeline;
+}
+
+std::unique_ptr<PipelinePool> PipelineFactory::from_bundle_pool(const std::string& bundle_path,
+                                                                std::size_t pool_size,
+                                                                const LoadOptions& options) {
+    if (pool_size == 0)
+        throw std::invalid_argument("Pipeline pool size must be positive");
+
+    BundleFile bundle = ReadBundleFile(bundle_path);
+    if (bundle.sections.empty())
+        throw std::runtime_error("Failed to read bundle: " + bundle_path);
+
+    std::string config_text;
+    for (const auto& section : bundle.sections) {
+        if (section.name == "config.json" && !section.data.empty()) {
+            config_text.assign(section.data.begin(), section.data.end());
+            break;
+        }
+    }
+
+    std::string strategy = resolve_runtime_strategy(config_text);
+    auto* plugin = lookup_plugin_or_throw(strategy, options.model_plugin_search_paths);
+    std::string backend_name = extract_json_string(config_text, "engine_backend", "trt");
+    IBackend* backend = load_backend_for_bundle(bundle, config_text, bundle_path, backend_name,
+                                                options.backend_search_paths);
+
+    BaseConfig base_cfg = parse_base_config(config_text, bundle.info.max_cache_length);
+    base_cfg.runtime_strategy = strategy;
+    std::optional<config::ConfigBundle> resolved = try_resolve_runtime_config(
+        config_text, bundle_path, options.config_path, options.set_tokens);
+
+    PipelineContext ctx{bundle,
+                        base_cfg,
+                        config_text,
+                        options.hf_python,
+                        bundle_path,
+                        backend,
+                        options.runtime_cache_path,
+                        options.cuda_graphs,
+                        options.kv_cache_size_bytes,
+                        resolved ? &*resolved : nullptr};
+    auto pipelines = plugin->create_pool(ctx, pool_size);
+    auto pool = std::make_unique<PipelinePool>(std::move(pipelines));
+
+    std::cerr << "[trtmc] Pipeline pool loaded (strategy=" << strategy << ", lanes=" << pool_size
+              << ", backend=trt_new_runtime)" << std::endl;
+    return pool;
 }
 
 std::unique_ptr<IPipeline> load(const std::string& bundle_path, const std::string& hf_python,

--- a/src/utils/json_helpers.cpp
+++ b/src/utils/json_helpers.cpp
@@ -6,6 +6,7 @@
 #include "utils/json_helpers.h"
 
 #include <cctype>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <stdexcept>
@@ -94,20 +95,117 @@ ArrayParseState advance_array_pos(const std::string& text, std::size_t& pos) {
     return ArrayParseState::kReady;
 }
 
+int hex_digit_value(char c) {
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    if (c >= 'a' && c <= 'f')
+        return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F')
+        return c - 'A' + 10;
+    return -1;
+}
+
+bool parse_hex_quad(const std::string& text, std::size_t pos, uint32_t& value) {
+    if (pos + 4 > text.size())
+        return false;
+    value = 0;
+    for (std::size_t i = 0; i < 4; ++i) {
+        const int digit = hex_digit_value(text[pos + i]);
+        if (digit < 0)
+            return false;
+        value = (value << 4U) | static_cast<uint32_t>(digit);
+    }
+    return true;
+}
+
+bool append_utf8(uint32_t codepoint, std::string& out) {
+    if (codepoint <= 0x7FU) {
+        out.push_back(static_cast<char>(codepoint));
+    } else if (codepoint <= 0x7FFU) {
+        out.push_back(static_cast<char>(0xC0U | (codepoint >> 6U)));
+        out.push_back(static_cast<char>(0x80U | (codepoint & 0x3FU)));
+    } else if (codepoint <= 0xFFFFU) {
+        if (codepoint >= 0xD800U && codepoint <= 0xDFFFU)
+            return false;
+        out.push_back(static_cast<char>(0xE0U | (codepoint >> 12U)));
+        out.push_back(static_cast<char>(0x80U | ((codepoint >> 6U) & 0x3FU)));
+        out.push_back(static_cast<char>(0x80U | (codepoint & 0x3FU)));
+    } else if (codepoint <= 0x10FFFFU) {
+        out.push_back(static_cast<char>(0xF0U | (codepoint >> 18U)));
+        out.push_back(static_cast<char>(0x80U | ((codepoint >> 12U) & 0x3FU)));
+        out.push_back(static_cast<char>(0x80U | ((codepoint >> 6U) & 0x3FU)));
+        out.push_back(static_cast<char>(0x80U | (codepoint & 0x3FU)));
+    } else {
+        return false;
+    }
+    return true;
+}
+
 bool read_quoted_token(const std::string& text, std::size_t& pos, std::string& out) {
     if (pos >= text.size() || text[pos] != '"') {
         return false;
     }
 
-    const std::size_t first_quote = pos;
-    const std::size_t second_quote = text.find('"', first_quote + 1);
-    if (second_quote == std::string::npos || second_quote <= first_quote + 1) {
-        return false;
-    }
+    out.clear();
+    ++pos;
+    while (pos < text.size()) {
+        const char c = text[pos++];
+        if (c == '"')
+            return !out.empty();
+        if (static_cast<unsigned char>(c) < 0x20U)
+            return false;
+        if (c != '\\') {
+            out.push_back(c);
+            continue;
+        }
+        if (pos >= text.size())
+            return false;
 
-    out = text.substr(first_quote + 1, second_quote - first_quote - 1);
-    pos = second_quote + 1;
-    return true;
+        const char escaped = text[pos++];
+        switch (escaped) {
+        case '"':
+        case '\\':
+        case '/':
+            out.push_back(escaped);
+            break;
+        case 'b':
+            out.push_back('\b');
+            break;
+        case 'f':
+            out.push_back('\f');
+            break;
+        case 'n':
+            out.push_back('\n');
+            break;
+        case 'r':
+            out.push_back('\r');
+            break;
+        case 't':
+            out.push_back('\t');
+            break;
+        case 'u': {
+            uint32_t codepoint = 0;
+            if (!parse_hex_quad(text, pos, codepoint))
+                return false;
+            pos += 4;
+            if (codepoint >= 0xD800U && codepoint <= 0xDBFFU) {
+                if (pos + 6 > text.size() || text[pos] != '\\' || text[pos + 1] != 'u')
+                    return false;
+                uint32_t low = 0;
+                if (!parse_hex_quad(text, pos + 2, low) || low < 0xDC00U || low > 0xDFFFU)
+                    return false;
+                pos += 6;
+                codepoint = 0x10000U + ((codepoint - 0xD800U) << 10U) + (low - 0xDC00U);
+            }
+            if (!append_utf8(codepoint, out))
+                return false;
+            break;
+        }
+        default:
+            return false;
+        }
+    }
+    return false;
 }
 
 template <typename T, typename Parser>

--- a/src/utils/json_helpers.cpp
+++ b/src/utils/json_helpers.cpp
@@ -141,6 +141,41 @@ bool append_utf8(uint32_t codepoint, std::string& out) {
     return true;
 }
 
+bool append_simple_escape(char escaped, std::string& out) {
+    constexpr std::string_view escape_codes = "\"\\/bfnrt";
+    constexpr std::string_view escape_values = "\"\\/\b\f\n\r\t";
+    const auto index = escape_codes.find(escaped);
+    if (index == std::string_view::npos)
+        return false;
+    out.push_back(escape_values[index]);
+    return true;
+}
+
+bool append_unicode_escape(const std::string& text, std::size_t& pos, std::string& out) {
+    uint32_t codepoint = 0;
+    if (!parse_hex_quad(text, pos, codepoint))
+        return false;
+    pos += 4;
+    if (codepoint < 0xD800U || codepoint > 0xDBFFU)
+        return append_utf8(codepoint, out);
+    if (pos + 6 > text.size() || text[pos] != '\\' || text[pos + 1] != 'u')
+        return false;
+    uint32_t low = 0;
+    if (!parse_hex_quad(text, pos + 2, low) || low < 0xDC00U || low > 0xDFFFU)
+        return false;
+    pos += 6;
+    codepoint = 0x10000U + ((codepoint - 0xD800U) << 10U) + (low - 0xDC00U);
+    return append_utf8(codepoint, out);
+}
+
+bool append_escape(const std::string& text, std::size_t& pos, std::string& out) {
+    if (pos >= text.size())
+        return false;
+    const char escaped = text[pos++];
+    return escaped == 'u' ? append_unicode_escape(text, pos, out)
+                          : append_simple_escape(escaped, out);
+}
+
 bool read_quoted_token(const std::string& text, std::size_t& pos, std::string& out) {
     if (pos >= text.size() || text[pos] != '"') {
         return false;
@@ -158,52 +193,8 @@ bool read_quoted_token(const std::string& text, std::size_t& pos, std::string& o
             out.push_back(c);
             continue;
         }
-        if (pos >= text.size())
+        if (!append_escape(text, pos, out))
             return false;
-
-        const char escaped = text[pos++];
-        switch (escaped) {
-        case '"':
-        case '\\':
-        case '/':
-            out.push_back(escaped);
-            break;
-        case 'b':
-            out.push_back('\b');
-            break;
-        case 'f':
-            out.push_back('\f');
-            break;
-        case 'n':
-            out.push_back('\n');
-            break;
-        case 'r':
-            out.push_back('\r');
-            break;
-        case 't':
-            out.push_back('\t');
-            break;
-        case 'u': {
-            uint32_t codepoint = 0;
-            if (!parse_hex_quad(text, pos, codepoint))
-                return false;
-            pos += 4;
-            if (codepoint >= 0xD800U && codepoint <= 0xDBFFU) {
-                if (pos + 6 > text.size() || text[pos] != '\\' || text[pos + 1] != 'u')
-                    return false;
-                uint32_t low = 0;
-                if (!parse_hex_quad(text, pos + 2, low) || low < 0xDC00U || low > 0xDFFFU)
-                    return false;
-                pos += 6;
-                codepoint = 0x10000U + ((codepoint - 0xD800U) << 10U) + (low - 0xDC00U);
-            }
-            if (!append_utf8(codepoint, out))
-                return false;
-            break;
-        }
-        default:
-            return false;
-        }
     }
     return false;
 }

--- a/tests/builder/test_graph_ops.py
+++ b/tests/builder/test_graph_ops.py
@@ -230,6 +230,28 @@ class TestAddMatmulRhsConstant:
         np.testing.assert_allclose(result["out"], ref, atol=1e-4)
 
 
+# 6b. add_lora_delta
+@requires_trt
+class TestAddLoraDelta:
+    def test_vs_numpy(self, trt_runner):
+        rng = np.random.RandomState(7)
+        lhs_np = rng.randn(3, 8).astype(np.float32)
+        lora_a_np = rng.randn(8, 4).astype(np.float32)
+        lora_b_np = rng.randn(4, 6).astype(np.float32)
+
+        def build(net, inp):
+            return {"out": graph_ops.add_lora_delta(
+                net, inp["x"], inp["lora_a"], inp["lora_b"])}
+
+        result = trt_runner(build, {
+            "x": lhs_np,
+            "lora_a": lora_a_np,
+            "lora_b": lora_b_np,
+        })
+        np.testing.assert_allclose(
+            result["out"], (lhs_np @ lora_a_np) @ lora_b_np, atol=1e-4)
+
+
 # 7. add_bias_sum
 @requires_trt
 class TestAddBiasSum:

--- a/tests/builder/test_graph_ops_native_attn.py
+++ b/tests/builder/test_graph_ops_native_attn.py
@@ -24,10 +24,11 @@ import numpy as np
 import pytest
 
 from tests.builder.conftest import requires_trt
-from tests.builder.owned_graph_modules import load_graph_ops
+from tests.builder.owned_graph_modules import load_family_graph_ops, load_graph_ops
 
 pytest.importorskip("tensorrt_model_connect", reason="tensorrt_model_connect requires tensorrt")
 graph_ops = load_graph_ops()
+qwen_vl_graph_ops = load_family_graph_ops("qwen_vl")
 
 
 # ---------------------------------------------------------------------------
@@ -506,3 +507,48 @@ class TestAddAttentionCore:
         # TRT fused attention can differ from NumPy by sub-1e-3 rounding.
         np.testing.assert_allclose(out, ref, atol=1e-3,
                                    err_msg="masked attention mismatch")
+
+class TestAddApplyMropeNative:
+    """Qwen2.5-VL M-RoPE selects T/H/W frequency sections."""
+
+    @requires_trt
+    def test_matches_numpy_reference(self):
+        num_heads, head_dim = 2, 16
+        sections = (2, 2, 4)
+        positions = np.array([2, 4, 6], dtype=np.int32)
+        rng = np.random.default_rng(29)
+        x = rng.standard_normal((1, num_heads * head_dim)).astype(np.float32)
+        cos = qwen_vl_graph_ops.make_rope_table_half_dim(
+            16, head_dim, 10000.0, True)
+        sin = qwen_vl_graph_ops.make_rope_table_half_dim(
+            16, head_dim, 10000.0, False)
+
+        def build(network, trt_inputs):
+            cos_t = qwen_vl_graph_ops.add_constant(
+                network, cos.shape, cos, dtype=np.float32)
+            sin_t = qwen_vl_graph_ops.add_constant(
+                network, sin.shape, sin, dtype=np.float32)
+            return {
+                "out": qwen_vl_graph_ops.add_apply_mrope_native(
+                    network, trt_inputs["x"], num_heads, head_dim,
+                    cos_t, sin_t, trt_inputs["positions"], sections, head_dim)
+            }
+
+        out = _run_strongly_typed(
+            build, {"x": x, "positions": positions})["out"]
+
+        offsets = np.cumsum((0,) + sections)
+        cos_m = np.concatenate([
+            cos[positions[axis], offsets[axis]:offsets[axis + 1]]
+            for axis in range(3)
+        ])
+        sin_m = np.concatenate([
+            sin[positions[axis], offsets[axis]:offsets[axis + 1]]
+            for axis in range(3)
+        ])
+        xh = x.reshape(num_heads, head_dim)
+        first, second = np.split(xh, 2, axis=-1)
+        ref = np.concatenate(
+            [first * cos_m - second * sin_m,
+             second * cos_m + first * sin_m], axis=-1).reshape(1, -1)
+        np.testing.assert_allclose(out, ref, atol=1e-4)

--- a/tests/builder/test_pipeline.py
+++ b/tests/builder/test_pipeline.py
@@ -130,6 +130,29 @@ class TestPipelineCall:
             assert cmd[idx + 1] == "/tmp/photo.jpg"
             assert output == "A cat sitting on a couch"
 
+    def test_prompt_with_lora_adapter(self):
+        """A PEFT adapter directory and runtime ID are forwarded to the CLI."""
+        pipe = self._make_pipeline()
+        mock_result = MagicMock(returncode=0, stdout="answer\n")
+
+        with patch("tensorrt_model_connect.pipeline.subprocess.run",
+                   return_value=mock_result) as mock_run:
+            output = pipe(
+                "test prompt",
+                lora_adapter="/tmp/test-adapter",
+                lora_adapter_id="adapter-1",
+            )
+
+            cmd = mock_run.call_args[0][0]
+            assert cmd[cmd.index("--lora-adapter") + 1] == "/tmp/test-adapter"
+            assert cmd[cmd.index("--lora-adapter-id") + 1] == "adapter-1"
+            assert output == "answer"
+
+    def test_empty_lora_adapter_id_rejected(self):
+        pipe = self._make_pipeline()
+        with pytest.raises(ValueError, match="lora_adapter_id must not be empty"):
+            pipe("test prompt", lora_adapter="/tmp/test-adapter", lora_adapter_id="")
+
     def test_prompt_without_image(self):
         """When image is None, --image is not in the command."""
         pipe = self._make_pipeline()

--- a/tests/builder/test_quantization.py
+++ b/tests/builder/test_quantization.py
@@ -181,7 +181,6 @@ class TestPreQuantizedCheckpointProvider:
         assert isinstance(result, QuantScaleMap)
         assert len(result.scales) == 0  # no safetensors files present
 
-
 class _FakeAdapter:
     def map_layer_name(self, layer_name: str) -> str | None:
         if layer_name == "skip.this":

--- a/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
+++ b/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
@@ -33,13 +33,20 @@
 #include "runtime/backend/trt_module_impl.h"
 #include "runtime/core/trt_common.h"
 #include "runtime/models/qwen_vl/kv_cache.h"
+#include "runtime/models/qwen_vl/lora_peft_loader.h"
 #include "runtime/models/qwen_vl/pipeline.h"
+#include "trtmc/runtime/pipeline_pool.h"
 #include "trtmc/runtime/trt_module.h"
 #include "trtmc/tokenizer.h"
 
 #include <NvInfer.h>
+#include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <cuda_runtime_api.h>
+#include <filesystem>
+#include <fstream>
+#include <future>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -220,6 +227,73 @@ static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_mock_decoder() {
     auto rt = trtmc::TrtUniquePtr<nvinfer1::IRuntime>(nvinfer1::createInferRuntime(g_logger));
     return trtmc::TrtUniquePtr<nvinfer1::ICudaEngine>(
         rt->deserializeCudaEngine(plan->data(), plan->size()));
+}
+
+static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_mock_lora_decoder() {
+    auto b = trtmc::TrtUniquePtr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(g_logger));
+    auto n = trtmc::TrtUniquePtr<nvinfer1::INetworkDefinition>(b->createNetworkV2(0));
+    auto c = trtmc::TrtUniquePtr<nvinfer1::IBuilderConfig>(b->createBuilderConfig());
+    c->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kWORKSPACE, 4 << 20);
+
+    auto* tok = n->addInput("token_id", nvinfer1::DataType::kINT32, nvinfer1::Dims{1, {1}});
+    auto* mask = n->addInput("attention_mask", nvinfer1::DataType::kFLOAT, nvinfer1::Dims{1, {8}});
+    auto* lora_a =
+        n->addInput("lora_a_layer_0_w_q", nvinfer1::DataType::kFLOAT, nvinfer1::Dims{2, {1, 1}});
+    auto* lora_b =
+        n->addInput("lora_b_layer_0_w_q", nvinfer1::DataType::kFLOAT, nvinfer1::Dims{2, {1, 4}});
+
+    float base_logits[4] = {0.1F, 0.2F, 0.9F, 0.3F};
+    auto* base = n->addConstant(nvinfer1::Dims{2, {1, 4}},
+                                nvinfer1::Weights{nvinfer1::DataType::kFLOAT, base_logits, 4});
+    auto* delta = n->addMatrixMultiply(*lora_a, nvinfer1::MatrixOperation::kNONE, *lora_b,
+                                       nvinfer1::MatrixOperation::kNONE);
+    auto* logits = n->addElementWise(*base->getOutput(0), *delta->getOutput(0),
+                                     nvinfer1::ElementWiseOperation::kSUM);
+    logits->getOutput(0)->setName("logits");
+    n->markOutput(*logits->getOutput(0));
+
+    n->addIdentity(*tok)->getOutput(0)->setName("_t");
+    n->addIdentity(*mask)->getOutput(0)->setName("_m");
+
+    auto plan = trtmc::TrtUniquePtr<nvinfer1::IHostMemory>(b->buildSerializedNetwork(*n, *c));
+    if (!plan)
+        return nullptr;
+    auto rt = trtmc::TrtUniquePtr<nvinfer1::IRuntime>(nvinfer1::createInferRuntime(g_logger));
+    return trtmc::TrtUniquePtr<nvinfer1::ICudaEngine>(
+        rt->deserializeCudaEngine(plan->data(), plan->size()));
+}
+
+static std::filesystem::path write_mock_peft_adapter() {
+    namespace fs = std::filesystem;
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const fs::path root = fs::temp_directory_path() / ("trtmc_qwen_lora_" + std::to_string(nonce));
+    fs::create_directories(root);
+
+    std::ofstream(root / "adapter_config.json")
+        << R"({"peft_type":"LORA","r":1,"lora_alpha":2,)"
+           R"("target_modules":["q_proj"],"bias":"none",)"
+           R"("fan_in_fan_out":false,"use_dora":false,"use_rslora":false,)"
+           R"("modules_to_save":null})";
+
+    const std::string prefix = "base_model.model.model.language_model.layers.0.self_attn.q_proj.";
+    std::string header_text = "{\"" + prefix +
+                              "lora_A.weight\":{\"dtype\":\"BF16\",\"shape\":[1,1],"
+                              "\"data_offsets\":[0,2]},\"" +
+                              prefix +
+                              "lora_B.weight\":{\"dtype\":\"BF16\",\"shape\":[4,1],"
+                              "\"data_offsets\":[2,10]}}";
+    while (header_text.size() % 8 != 0)
+        header_text.push_back(' ');
+
+    std::ofstream weights(root / "adapter_model.safetensors", std::ios::binary);
+    const uint64_t header_size = header_text.size();
+    for (int i = 0; i < 8; ++i)
+        weights.put(static_cast<char>((header_size >> (8 * i)) & 0xFFU));
+    weights.write(header_text.data(), static_cast<std::streamsize>(header_text.size()));
+    // BF16: A=[1], B=[[2], [0], [0], [0]]. Alpha/rank=2 is folded into B.
+    const uint16_t tensor_data[] = {0x3F80U, 0x4000U, 0U, 0U, 0U};
+    weights.write(reinterpret_cast<const char*>(tensor_data), sizeof(tensor_data));
+    return root;
 }
 
 // Mock vision encoder: pixel_values[3,4,4] float32 -> image_features[4] float32
@@ -795,6 +869,180 @@ static void test_vl_generate_with_tokenizer() {
     cudaStreamDestroy(stream);
 }
 
+static void test_vl_dynamic_lora_adapter_switching() {
+    auto engine = build_mock_lora_decoder();
+    if (!engine) {
+        std::cerr << "SKIP dynamic_lora\n";
+        return;
+    }
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto decoder = std::make_unique<trtmc::TrtModuleImpl>(engine.get(),
+                                                          engine->createExecutionContext(), stream);
+    auto cache = std::make_unique<trtmc::QwenVlKvCache>(1, 8, 4, stream);
+    trtmc::QwenVlConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 99;
+    cfg.has_position_input = false;
+    trtmc::QwenVlPreprocessConfig vl_pp;
+    trtmc::QwenVlPipeline pipeline(std::move(decoder), nullptr, std::move(cache), cfg, vl_pp,
+                                   stream);
+
+    check(pipeline.has_dynamic_lora(), "dynamic_lora: engine inputs detected");
+    check(pipeline.lora_input_names().size() == 2, "dynamic_lora: two bindings detected");
+
+    float ones[1] = {1.0F};
+    float adapter_a_delta[4] = {2.0F, 0.0F, 0.0F, 0.0F};
+    float adapter_b_delta[4] = {0.0F, 2.0F, 0.0F, 0.0F};
+    auto make_adapter = [&](float* delta) {
+        trtmc::TensorMap tensors;
+        tensors["lora_a_layer_0_w_q"] = trtmc::Tensor{ones, {1, 1}, trtmc::DType::kFloat32};
+        tensors["lora_b_layer_0_w_q"] = trtmc::Tensor{delta, {1, 4}, trtmc::DType::kFloat32};
+        return tensors;
+    };
+    pipeline.register_lora_adapter("adapter-a", make_adapter(adapter_a_delta));
+    pipeline.register_lora_adapter("adapter-b", make_adapter(adapter_b_delta));
+
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 1;
+
+    auto base = pipeline.generate_ids({3}, gen_cfg);
+    check(base.token_ids.back() == 2, "dynamic_lora: zero binding selects base output");
+
+    gen_cfg.lora_adapter_id = "adapter-a";
+    auto adapter_a = pipeline.generate_ids({3}, gen_cfg);
+    check(adapter_a.token_ids.back() == 0, "dynamic_lora: adapter A selected");
+
+    gen_cfg.lora_adapter_id = "adapter-b";
+    auto adapter_b = pipeline.generate_ids({3}, gen_cfg);
+    check(adapter_b.token_ids.back() == 1, "dynamic_lora: adapter B selected");
+
+    gen_cfg.lora_adapter_id.clear();
+    auto base_again = pipeline.generate_ids({3}, gen_cfg);
+    check(base_again.token_ids.back() == 2, "dynamic_lora: clear restores base output");
+
+    bool unknown_threw = false;
+    try {
+        gen_cfg.lora_adapter_id = "missing";
+        (void)pipeline.generate_ids({3}, gen_cfg);
+    } catch (const std::invalid_argument&) {
+        unknown_threw = true;
+    }
+    check(unknown_threw, "dynamic_lora: unknown adapter rejected");
+
+    const auto adapter_dir = write_mock_peft_adapter();
+    pipeline.load_lora_adapter("adapter-file", adapter_dir.string());
+    check(pipeline.supports_lora_adapters(), "dynamic_lora: public capability detected");
+    check(pipeline.loaded_lora_adapters().size() == 3,
+          "dynamic_lora: public API lists loaded adapters");
+    gen_cfg.lora_adapter_id = "adapter-file";
+    auto adapter_file = pipeline.generate_ids({3}, gen_cfg);
+    check(adapter_file.token_ids.back() == 0, "dynamic_lora: PEFT directory selected");
+    pipeline.unload_lora_adapter("adapter-file");
+    check(pipeline.loaded_lora_adapters().size() == 2, "dynamic_lora: public API unloads adapter");
+    std::filesystem::remove_all(adapter_dir);
+
+    // The Qwen-VL cache must not evict an adapter pinned by the active
+    // execution context. Fill its four-entry capacity, select A, then add E;
+    // the least-recently-used unpinned adapter B should be removed.
+    pipeline.register_lora_adapter("adapter-c", make_adapter(adapter_b_delta));
+    pipeline.register_lora_adapter("adapter-d", make_adapter(adapter_b_delta));
+    gen_cfg.lora_adapter_id = "adapter-a";
+    (void)pipeline.generate_ids({3}, gen_cfg);
+    pipeline.register_lora_adapter("adapter-e", make_adapter(adapter_b_delta));
+    const auto cached_ids = pipeline.loaded_lora_adapters();
+    check(cached_ids.size() == 4, "dynamic_lora: Qwen-VL cache enforces capacity");
+    check(std::find(cached_ids.begin(), cached_ids.end(), "adapter-a") != cached_ids.end(),
+          "dynamic_lora: active adapter remains pinned");
+    check(std::find(cached_ids.begin(), cached_ids.end(), "adapter-b") == cached_ids.end(),
+          "dynamic_lora: least-recently-used unpinned adapter evicted");
+    auto pinned_a = pipeline.generate_ids({3}, gen_cfg);
+    check(pinned_a.token_ids.back() == 0,
+          "dynamic_lora: pinned adapter remains bound after eviction");
+
+    cudaStreamDestroy(stream);
+}
+
+static void test_vl_pool_isolates_concurrent_lora_selection() {
+    auto engine = build_mock_lora_decoder();
+    if (!engine) {
+        std::cerr << "SKIP dynamic_lora_pool\n";
+        return;
+    }
+
+    cudaStream_t stream_a;
+    cudaStream_t stream_b;
+    cudaStreamCreate(&stream_a);
+    cudaStreamCreate(&stream_b);
+
+    auto decoder_a = std::make_unique<trtmc::TrtModuleImpl>(
+        engine.get(), engine->createExecutionContext(), stream_a);
+    auto decoder_b = std::make_unique<trtmc::TrtModuleImpl>(
+        engine.get(), engine->createExecutionContext(), stream_b);
+    std::vector<trtmc::TensorInfo> adapter_contract;
+    for (const auto& info : decoder_a->input_info()) {
+        if (info.name.rfind("lora_a_", 0) == 0 || info.name.rfind("lora_b_", 0) == 0)
+            adapter_contract.push_back(info);
+    }
+    auto adapter_cache =
+        std::make_shared<trtmc::qwen_vl::LoraAdapterCache>(adapter_contract, stream_a);
+
+    trtmc::QwenVlConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 99;
+    cfg.has_position_input = false;
+    trtmc::QwenVlPreprocessConfig vl_pp;
+    auto pipeline_a = std::make_unique<trtmc::QwenVlPipeline>(
+        std::move(decoder_a), nullptr, std::make_unique<trtmc::QwenVlKvCache>(1, 8, 4, stream_a),
+        cfg, vl_pp, stream_a, nullptr, "lane-a", nullptr, adapter_cache);
+    auto pipeline_b = std::make_unique<trtmc::QwenVlPipeline>(
+        std::move(decoder_b), nullptr, std::make_unique<trtmc::QwenVlKvCache>(1, 8, 4, stream_b),
+        cfg, vl_pp, stream_b, nullptr, "lane-b", nullptr, adapter_cache);
+
+    float ones[1] = {1.0F};
+    float adapter_a_delta[4] = {2.0F, 0.0F, 0.0F, 0.0F};
+    float adapter_b_delta[4] = {0.0F, 2.0F, 0.0F, 0.0F};
+    auto make_adapter = [&](float* delta) {
+        trtmc::TensorMap tensors;
+        tensors["lora_a_layer_0_w_q"] = trtmc::Tensor{ones, {1, 1}, trtmc::DType::kFloat32};
+        tensors["lora_b_layer_0_w_q"] = trtmc::Tensor{delta, {1, 4}, trtmc::DType::kFloat32};
+        return tensors;
+    };
+    pipeline_a->register_lora_adapter("adapter-a", make_adapter(adapter_a_delta));
+    pipeline_a->register_lora_adapter("adapter-b", make_adapter(adapter_b_delta));
+    check(pipeline_b->loaded_lora_adapters().size() == 2,
+          "dynamic_lora_pool: lanes share adapter registry");
+
+    {
+        std::vector<std::unique_ptr<trtmc::IPipeline>> lanes;
+        lanes.push_back(std::move(pipeline_a));
+        lanes.push_back(std::move(pipeline_b));
+        trtmc::PipelinePool pool(std::move(lanes));
+        auto lease_a = pool.acquire();
+        auto lease_b = pool.acquire();
+        auto* qwen_a = dynamic_cast<trtmc::QwenVlPipeline*>(lease_a.get());
+        auto* qwen_b = dynamic_cast<trtmc::QwenVlPipeline*>(lease_b.get());
+        check(qwen_a != nullptr && qwen_b != nullptr, "dynamic_lora_pool: leases Qwen lanes");
+
+        trtmc::GenerateConfig config_a;
+        config_a.max_new_tokens = 1;
+        config_a.lora_adapter_id = "adapter-a";
+        trtmc::GenerateConfig config_b = config_a;
+        config_b.lora_adapter_id = "adapter-b";
+        auto result_a = std::async(
+            std::launch::async, [qwen_a, config_a] { return qwen_a->generate_ids({3}, config_a); });
+        auto result_b = std::async(
+            std::launch::async, [qwen_b, config_b] { return qwen_b->generate_ids({3}, config_b); });
+        check(result_a.get().token_ids.back() == 0, "dynamic_lora_pool: request A keeps adapter A");
+        check(result_b.get().token_ids.back() == 1, "dynamic_lora_pool: request B keeps adapter B");
+    }
+    adapter_cache.reset();
+    cudaStreamDestroy(stream_a);
+    cudaStreamDestroy(stream_b);
+}
+
 int main() {
     test_vl_text_only();
     test_vl_text_only_max_tokens();
@@ -808,6 +1056,8 @@ int main() {
     test_vl_generate_with_embed_decoder();
     test_vl_sequence_prefill_uses_one_text_launch();
     test_vl_generate_with_tokenizer();
+    test_vl_dynamic_lora_adapter_switching();
+    test_vl_pool_isolates_concurrent_lora_selection();
     if (failures > 0)
         std::cerr << failures << " FAILED\n";
     return failures;

--- a/tests/cpp/test_cli_args.cpp
+++ b/tests/cpp/test_cli_args.cpp
@@ -100,6 +100,10 @@ void test_run_parses_common_flags() {
                        "--greedy",
                        "--chat-template",
                        "--no-thinking",
+                       "--lora-adapter",
+                       "/tmp/adapter",
+                       "--lora-adapter-id",
+                       "adapter-1",
                        "--kv-cache-size",
                        "2GiB",
                        "--backend-dir",
@@ -123,6 +127,8 @@ void test_run_parses_common_flags() {
     check(args.greedy, "run greedy");
     check(args.chat_template, "run chat template");
     check(args.no_thinking, "run no thinking");
+    check(args.lora_adapter_path == "/tmp/adapter", "run LoRA adapter path");
+    check(args.lora_adapter_id == "adapter-1", "run LoRA adapter ID");
     check(args.kv_cache_size_bytes == 2147483648ULL, "run kv cache size");
     check(args.backend_search_paths.size() == 1 && args.backend_search_paths[0] == "/tmp/lib",
           "run backend dir");

--- a/tests/cpp/test_json_helpers.cpp
+++ b/tests/cpp/test_json_helpers.cpp
@@ -103,6 +103,17 @@ bool test_extract_json_string_nested_braces() {
     return true;
 }
 
+bool test_extract_json_string_escapes_and_unicode() {
+    const std::string json = R"({"prompt":"schema: {\"name\": \"caf\u00e9\"}\nnext \ud83d\ude80"})";
+    const std::string expected = "schema: {\"name\": \"caf\xC3\xA9\"}\nnext \xF0\x9F\x9A\x80";
+    const std::string result = trtmc::extract_json_string(json, "prompt", "fallback");
+    if (result != expected) {
+        std::cerr << "extract_json_string_escapes: got '" << result << "'" << std::endl;
+        return false;
+    }
+    return true;
+}
+
 // ---------------------------------------------------------------------------
 // extract_json_int tests
 // ---------------------------------------------------------------------------
@@ -451,6 +462,7 @@ int main() {
     run("extract_json_string_present", test_extract_json_string_present);
     run("extract_json_string_absent", test_extract_json_string_absent);
     run("extract_json_string_nested", test_extract_json_string_nested_braces);
+    run("extract_json_string_escapes", test_extract_json_string_escapes_and_unicode);
     run("extract_json_string_empty_value", test_extract_json_string_empty_value_returns_fallback);
     run("extract_json_int_positive", test_extract_json_int_positive);
     run("extract_json_int_negative", test_extract_json_int_negative);

--- a/tests/cpp/test_pipeline_api.cpp
+++ b/tests/cpp/test_pipeline_api.cpp
@@ -30,10 +30,14 @@
 // =============================================================================
 
 #include "trtmc/pipeline.h"
+#include "trtmc/runtime/pipeline_pool.h"
 
+#include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <future>
 #include <iostream>
+#include <set>
 #include <stdexcept>
 #include <string>
 
@@ -66,6 +70,32 @@ class RecordingTranscriptionPipeline final : public trtmc::IPipeline {
     }
 
     std::vector<trtmc::TranscriptionConfig> observed;
+};
+
+class PoolTestPipeline final : public trtmc::IPipeline {
+  public:
+    explicit PoolTestPipeline(std::string id) : id_(std::move(id)) {}
+
+    const char* model_id() const override { return id_.c_str(); }
+    const char* pipeline_type() const override { return "PoolTestPipeline"; }
+    bool supports_lora_adapters() const override { return true; }
+
+    void load_lora_adapter(const std::string& adapter_id, const std::string&) override {
+        adapters_.insert(adapter_id);
+    }
+
+    void unload_lora_adapter(const std::string& adapter_id) override {
+        if (adapters_.erase(adapter_id) == 0)
+            throw std::invalid_argument("unknown adapter");
+    }
+
+    std::vector<std::string> loaded_lora_adapters() const override {
+        return {adapters_.begin(), adapters_.end()};
+    }
+
+  private:
+    std::string id_;
+    std::set<std::string> adapters_;
 };
 
 static void test_null_input_returns_null() {
@@ -269,6 +299,46 @@ static void test_transcription_batch_preserves_per_request_config() {
           "transcription batch preserves per-request config");
 }
 
+static void test_pipeline_pool_leases_and_adapter_maintenance() {
+    std::vector<std::unique_ptr<trtmc::IPipeline>> pipelines;
+    pipelines.push_back(std::make_unique<PoolTestPipeline>("lane-0"));
+    pipelines.push_back(std::make_unique<PoolTestPipeline>("lane-1"));
+    trtmc::PipelinePool pool(std::move(pipelines));
+
+    check(pool.size() == 2 && pool.available() == 2, "pipeline pool initial capacity");
+    auto first = pool.acquire();
+    auto second = pool.acquire();
+    check(pool.available() == 0, "pipeline pool leases are exclusive");
+    check(std::string(first->model_id()) != std::string(second->model_id()),
+          "pipeline pool leases distinct lanes");
+    check(!pool.try_acquire().has_value(), "pipeline pool reports exhaustion");
+
+    const std::string released_lane = first->model_id();
+    auto waiter = std::async(std::launch::async, [&pool] {
+        auto lease = pool.acquire();
+        return std::string(lease->model_id());
+    });
+    check(waiter.wait_for(std::chrono::milliseconds(20)) == std::future_status::timeout,
+          "pipeline pool waits when all lanes are busy");
+    first = {};
+    check(waiter.get() == released_lane, "pipeline pool reuses released lane");
+    second = {};
+
+    pool.load_lora_adapter("adapter-a", "/synthetic/adapter");
+    check(pool.supports_lora_adapters(), "pipeline pool reports shared adapter capability");
+    check(pool.loaded_lora_adapters() == std::vector<std::string>{"adapter-a"},
+          "pipeline pool registers adapter across lanes");
+    auto lane_a = pool.acquire();
+    auto lane_b = pool.acquire();
+    check(lane_a->loaded_lora_adapters() == std::vector<std::string>{"adapter-a"} &&
+              lane_b->loaded_lora_adapters() == std::vector<std::string>{"adapter-a"},
+          "pipeline pool keeps lane adapter registries consistent");
+    lane_a = {};
+    lane_b = {};
+    pool.unload_lora_adapter("adapter-a");
+    check(pool.loaded_lora_adapters().empty(), "pipeline pool unloads adapter across lanes");
+}
+
 int main() {
     test_null_input_returns_null();
     test_invalid_path_returns_null();
@@ -278,6 +348,7 @@ int main() {
     test_delete_null_safe();
     test_ipipeline_default_virtuals();
     test_transcription_batch_preserves_per_request_config();
+    test_pipeline_pool_leases_and_adapter_maintenance();
 
     if (failures > 0) {
         std::cerr << failures << " test(s) FAILED\n";

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py
@@ -98,7 +98,6 @@ def test_qwen25_vl_plugin_forwards_precision_to_standard_builder(monkeypatch) ->
     assert kwargs["precision"] == "bf16"
     assert kwargs["embed_input"] is True
     assert kwargs["verbose"] is True
-    assert calls["build"][0].raw["_force_decomposed_attention"] is False
 
 
 def test_qwen25_vl_embed_input_dispatches_to_dual_profile_builder(monkeypatch) -> None:

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py
@@ -98,6 +98,7 @@ def test_qwen25_vl_plugin_forwards_precision_to_standard_builder(monkeypatch) ->
     assert kwargs["precision"] == "bf16"
     assert kwargs["embed_input"] is True
     assert kwargs["verbose"] is True
+    assert calls["build"][0].raw["_force_decomposed_attention"] is False
 
 
 def test_qwen25_vl_embed_input_dispatches_to_dual_profile_builder(monkeypatch) -> None:
@@ -116,6 +117,33 @@ def test_qwen25_vl_embed_input_dispatches_to_dual_profile_builder(monkeypatch) -
         config, {}, 31, precision="fp16", embed_input=True)
 
     assert result == b"qwen-vl-dual-profile-plan"
+    assert calls["build"][3]["embed_input"] is True
+
+
+def test_qwen25_vl_lora_keeps_dual_profile_prefill(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen_vl.default_decoder")
+    calls: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"qwen-vl-lora-dual-profile-plan"
+
+    monkeypatch.setattr(module, "build_dual_profile_decoder_engine", fake_build)
+    config = _config(qwen3=False)
+    config.raw["_decoder_engine_role"] = "decode"
+    config.raw["_family_build_options"] = {
+        "qwen_vl_lora": {
+            "enabled": True,
+            "max_rank": 16,
+            "target_modules": "q_proj,v_proj",
+        }
+    }
+
+    result = module.build_standard_decoder_engine(
+        config, {}, 31, precision="fp16", embed_input=True)
+
+    assert result == b"qwen-vl-lora-dual-profile-plan"
     assert calls["build"][3]["embed_input"] is True
 
 

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_family_plugin_weights.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_family_plugin_weights.py
@@ -9,8 +9,6 @@ Shared test code is limited to filesystem and serialization helpers.
 
 from __future__ import annotations
 
-
-
 from tests.builder.family_plugin_test_support import (
     ModelConfig,
     _rand,

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_registry_contract.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_registry_contract.py
@@ -22,6 +22,7 @@ def test_qwen_vl_runtime_contract() -> None:
     plugin = find_plugin("qwen2_vl")
     assert plugin is not None
     assert getattr(plugin, "runtime_strategy", None) == "qwen_vl_vision_language"
+    assert "decoder_kv" in getattr(plugin, "runtime_capabilities", set())
     assert getattr(plugin, "embed_input", False) is True
     assert callable(getattr(plugin, "build_vision_engine", None))
     assert callable(getattr(plugin, "get_vl_config", None))


### PR DESCRIPTION
 ## Background

  Qwen-VL deployments need to load and switch PEFT LoRA adapters without rebuilding the TensorRT engine or
  duplicating the base-model weights.

  TensorRT requires tensor shapes to be known when the engine is built. This implementation therefore builds fixed-
  shape LoRA inputs using a configured maximum rank, then pads compatible runtime adapters to those shapes.

  ## Exit Criteria

  - Build a Qwen-VL engine with configurable LoRA target modules and maximum rank.
  - Load standard PEFT safetensors adapters at runtime.
  - Select an adapter for each generation call without rebuilding the engine.
  - Preserve the base-model path when no adapter is selected.
  - Allow concurrent requests to use different adapters through independent execution contexts.
  - Keep adapters external to the TensorRT bundle.

  ## Implementation

  ### Qwen-VL LoRA engine

  The Qwen-VL builder can add runtime-bound LoRA A/B inputs to selected decoder projections:

  ```json
  {
    "qwen_vl_lora": {
      "enabled": true,
      "max_rank": 16,
      "target_modules": "q_proj,v_proj"
    }
  }
  ```

  Each selected projection computes:

  output = base_projection(x) + (x × LoRA_A) × LoRA_B

  Unused rank dimensions are zero-padded. When no adapter is selected, zero tensors are bound to the LoRA inputs so
  execution follows the base-model path.

  ### PEFT adapter loading

  The Qwen-VL runtime:

  - Reads adapter_config.json and adapter_model.safetensors.
  - Validates adapter rank, target modules, shapes, and data types.
  - Converts PEFT tensor layouts to the TensorRT input layouts.
  - Folds lora_alpha / rank scaling into the runtime B matrices.
  - Uploads normalized adapter tensors to a GPU-resident cache.
  - Pins active adapters so they cannot be evicted while in use.

  Adapters must fit the engine’s build-time maximum rank and target-module contract.

  ### Runtime selection

  The public pipeline API adds adapter lifecycle operations and per-call selection through
  GenerateConfig::lora_adapter_id.

  The CLI and Python wrapper expose the same behavior:

  trtmc run model.trtfb \
    --prompt "Describe the image" \
    --image input.png \
    --lora-adapter /path/to/adapter \
    --lora-adapter-id adapter-a

  Changing --lora-adapter-id changes the adapter binding without rebuilding the TensorRT engine.

  ### Concurrent requests

  A model-neutral pipeline pool leases independent runtime lanes:

  ```mermaid
  flowchart TB
      Shared["Shared TensorRT Engine Weights<br/>Shared GPU Adapter Cache"]

      Shared --> Lane0["Lane 0<br/>Execution Context 0<br/>CUDA Stream 0<br/>KV Cache 0<br/>Adapter A"]
      Shared --> Lane1["Lane 1<br/>Execution Context 1<br/>CUDA Stream 1<br/>KV Cache 1<br/>Adapter B"]

      RequestA["Request A"] --> Lane0
      RequestB["Request B"] --> Lane1
  ```

  Each lane has its own TensorRT execution context, CUDA stream, KV cache, and adapter binding state. This allows
  requests using different adapters to execute concurrently without rebinding the same execution context.

  Adapter load and unload operations are coordinated across pool lanes.

  ### Qwen-VL compatibility

  The PR also aligns the adapter-enabled execution path with Qwen2.5-VL behavior, including:

  - Multimodal rotary-position handling.
  - Long-context attention fallback.
  - Image preprocessing and configurable vision profiles.
  - Escaped JSON configuration parsing.
  - Prequantized checkpoint handling.

  ## Scope and Non-Goals

  This initial implementation intentionally has the following boundaries:

  - Dynamic LoRA support is limited to the Qwen-VL family.
  - One execution context uses one adapter at a time.
  - Concurrent adapters require separate pool lanes.
  - A single TensorRT enqueue cannot contain batch rows using different adapters.
  - The pool does not provide an automatic request scheduler or dynamic batcher.
  - Unsupported PEFT variants such as DoRA, RS-LoRA, per-module rank patterns, and modules_to_save are rejected.
  - Runtime adapters cannot exceed the engine’s configured maximum rank or target modules.
  - Adapter weights are not embedded in the TensorRT bundle.

  Mixed-adapter batching would require per-row adapter metadata and specialized kernels or grouped GEMM execution. That remains future work.