### PR TITLE
test(bark): validate merged fix on GPUs 2 and 3

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,15 +85,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          path: bark-validation-source
           fetch-depth: 0
           persist-credentials: false
 
       - name: Resolve exact revision
+        working-directory: ${{ github.workspace }}/bark-validation-source
         run: echo "BARK_VALIDATION_REVISION=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
       - name: Ensure CI Docker image
         id: ci_image
         timeout-minutes: 90
+        working-directory: ${{ github.workspace }}/bark-validation-source
         run: bash .github/scripts/ensure-ci-docker-image.sh
 
       - name: Run Bark proof on requested physical GPU
@@ -101,6 +104,7 @@ jobs:
         env:
           TRTMC_CI_IMAGE: ${{ steps.ci_image.outputs.image_ref }}
           TRTMC_GPU_ID: ${{ inputs.bark_gpu_id }}
+        working-directory: ${{ github.workspace }}/bark-validation-source
         run: |
           output_dir="$RUNNER_TEMP/bark-gpu-${{ inputs.bark_gpu_id }}"
           bash .github/scripts/run-model-proof.sh \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,11 @@ on:
         description: "Git ref to test with the full nightly workflow"
         required: false
         default: "main"
+      bark_gpu_validation:
+        description: "Temporary diagnostic: run Bark proof on physical GPUs 2 and 3"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -53,7 +58,64 @@ env:
   HUGGING_FACE_HUB_TOKEN: ${{ secrets.HF_TOKEN }}
 
 jobs:
+  bark-gpu-validation:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.bark_gpu_validation }}
+    name: Bark physical GPU ${{ matrix.gpu }}
+    runs-on: ${{ fromJSON(vars.TRTMC_MODEL_RUNNER_LABELS || vars.TRTMC_RUNNER_LABELS || '["self-hosted"]') }}
+    timeout-minutes: 300
+    strategy:
+      fail-fast: false
+      matrix:
+        gpu: [2, 3]
+    env:
+      TRTMC_MODEL_PROOF_BUILD_JOBS: ${{ vars.TRTMC_MODEL_PROOF_BUILD_JOBS || '2' }}
+      TRTMC_MODEL_PROOF_GPU_IDS: "0,1,2,3"
+      TRTMC_MODEL_PROOF_SLOTS_PER_GPU: ${{ vars.TRTMC_MODEL_PROOF_SLOTS_PER_GPU || '4' }}
+      TRTMC_MODEL_PROOF_GPU_LOCK_DIR: ${{ vars.TRTMC_MODEL_PROOF_GPU_LOCK_DIR || '/tmp/trtmc-model-proof-gpu-locks' }}
+      TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS: ${{ vars.TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS || '3600' }}
+      TRTMC_HF_CACHE: ${{ vars.TRTMC_HF_HOME || '/workspace/users/yifeif/tensorrt-model-connect/hf-cache' }}
+      TRTMC_MODEL_REFERENCE_CACHE_ROOT: ${{ vars.TRTMC_MODEL_REFERENCE_CACHE_ROOT || '/workspace/users/yifeif/tensorrt-model-connect' }}
+
+    steps:
+      - name: Check out exact merged revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve exact revision
+        run: echo "BARK_VALIDATION_REVISION=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Ensure CI Docker image
+        id: ci_image
+        timeout-minutes: 90
+        run: bash .github/scripts/ensure-ci-docker-image.sh
+
+      - name: Run Bark proof on requested physical GPU
+        timeout-minutes: 150
+        env:
+          TRTMC_CI_IMAGE: ${{ steps.ci_image.outputs.image_ref }}
+          TRTMC_GPU_ID: ${{ matrix.gpu }}
+        run: |
+          output_dir="$RUNNER_TEMP/bark-gpu-${{ matrix.gpu }}"
+          bash .github/scripts/run-model-proof.sh \
+            --model bark \
+            --revision "$BARK_VALIDATION_REVISION" \
+            --suite premerge \
+            --output-dir "$output_dir"
+
+      - name: Upload Bark GPU diagnostic artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: bark-gpu-${{ matrix.gpu }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/bark-gpu-${{ matrix.gpu }}/artifacts
+          retention-days: 7
+          if-no-files-found: error
+
   nightly-ci:
+    if: ${{ !inputs.bark_gpu_validation }}
     name: Nightly Full CI
     runs-on: ${{ fromJSON(vars.TRTMC_RUNNER_LABELS || '["self-hosted"]') }}
     timeout-minutes: 720

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: TensorRT-Model-Connect Nightly CI
+name: Bark GPU Diagnostic
 
 on:
   schedule:
@@ -17,6 +17,14 @@ on:
         required: false
         type: boolean
         default: false
+      bark_gpu_id:
+        description: "Physical GPU for the temporary Bark diagnostic"
+        required: false
+        type: choice
+        options:
+          - "2"
+          - "3"
+        default: "2"
 
 permissions:
   contents: write
@@ -60,13 +68,9 @@ env:
 jobs:
   bark-gpu-validation:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.bark_gpu_validation }}
-    name: Bark physical GPU ${{ matrix.gpu }}
+    name: Bark physical GPU ${{ inputs.bark_gpu_id }}
     runs-on: ${{ fromJSON(vars.TRTMC_MODEL_RUNNER_LABELS || vars.TRTMC_RUNNER_LABELS || '["self-hosted"]') }}
     timeout-minutes: 300
-    strategy:
-      fail-fast: false
-      matrix:
-        gpu: [2, 3]
     env:
       TRTMC_MODEL_PROOF_BUILD_JOBS: ${{ vars.TRTMC_MODEL_PROOF_BUILD_JOBS || '2' }}
       TRTMC_MODEL_PROOF_GPU_IDS: "0,1,2,3"
@@ -96,9 +100,9 @@ jobs:
         timeout-minutes: 150
         env:
           TRTMC_CI_IMAGE: ${{ steps.ci_image.outputs.image_ref }}
-          TRTMC_GPU_ID: ${{ matrix.gpu }}
+          TRTMC_GPU_ID: ${{ inputs.bark_gpu_id }}
         run: |
-          output_dir="$RUNNER_TEMP/bark-gpu-${{ matrix.gpu }}"
+          output_dir="$RUNNER_TEMP/bark-gpu-${{ inputs.bark_gpu_id }}"
           bash .github/scripts/run-model-proof.sh \
             --model bark \
             --revision "$BARK_VALIDATION_REVISION" \
@@ -109,8 +113,8 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: bark-gpu-${{ matrix.gpu }}-${{ github.run_id }}
-          path: ${{ runner.temp }}/bark-gpu-${{ matrix.gpu }}/artifacts
+          name: bark-gpu-${{ inputs.bark_gpu_id }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/bark-gpu-${{ inputs.bark_gpu_id }}/artifacts
           retention-days: 7
           if-no-files-found: error
 


### PR DESCRIPTION
## Background

PR #451 was validated without GPU affinity, but its three premerge runs naturally landed on physical GPUs 1, 0, and 0. Physical GPUs 2 and 3 therefore remained unverified.

## Exit Criteria

- Run the exact merged revision `9059ead9` through the full Bark model proof on physical GPU 2 and physical GPU 3.
- Compare semantic tokens, coarse tokens, WAV output, and component timings with the #451 baseline.
- Do not merge this diagnostic workflow or change the normal CI GPU-selection policy.

## Implementation

- Add a temporary workflow-dispatch mode that skips the normal nightly job.
- Run two isolated matrix jobs with diagnostic-only `TRTMC_GPU_ID` values 2 and 3.
- Check out the exact merged source revision rather than building this workflow commit.

## Validation

- `python -m pytest tests/tools/test_github_actions_ci.py -q`: 60 passed.
- YAML parsing and `git diff --check`: passed.
- [GPU 3 run 29303191110](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29303191110): Bark proof passed on an exclusive physical GPU 3 lease. The artifact identifies source revision `9059ead9`; semantic tokens, coarse tokens, and WAV match the #451 baseline byte-for-byte. Coarse execution was 4.1767 s.
- [GPU 2 run 29303666358](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29303666358): Bark proof passed on an exclusive physical GPU 2 lease. The artifact identifies source revision `9059ead9`; semantic tokens, coarse tokens, and WAV match the #451 baseline byte-for-byte. Coarse execution was 4.2029 s.
- The first GPU 2 matrix job in run 29303191110 failed during checkout before any Bark or GPU work because two self-hosted jobs raced on a shared workspace. The successful retry used an isolated checkout directory and a single-GPU dispatch.

## Notes For Future Readers

- This PR exists only to obtain GPU 2/3 artifacts. Validation is complete; close it and delete the branch without merging.
