### PR TITLE
fix(ci): resolve LTX selective HF cache

### DIFF
--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -23,7 +23,6 @@ from .config import ModelConfig
 from .engine_build_budget import enforce_single_full_bundle_build
 from .families import (
     available_plugin_ids,
-    family_hf_allow_patterns,
     family_has_capability,
     find_plugin,
     find_diffusion_plugin,
@@ -31,6 +30,7 @@ from .families import (
     resolve_family_model_dir,
     resolve_nemo_archive_model_dir,
 )
+from .hf_snapshot import GENERIC_HF_ALLOW_PATTERNS, hf_snapshot_allow_patterns
 from .bundle_writer import BundleInfo, BundleSection, write_bundle
 from . import trt_compat
 from .triattention_export import (
@@ -91,27 +91,8 @@ def _untracked_compile_time(
     return max(0.0, measured_compile_elapsed - tracked_compile_elapsed)
 
 
-# Standard HF file patterns to download (matches what the builder needs).
-_HF_ALLOW_PATTERNS = [
-    "config.json",
-    "generation_config.json",
-    "preprocessor_config.json",
-    "processor_config.json",
-    "model.safetensors",
-    "model-*.safetensors",
-    "model.safetensors-*.safetensors",
-    "model.safetensors.index.json",
-    "pytorch_model.bin",
-    "tokenizer.json",
-    "tokenizer_config.json",
-    "chat_template.jinja",
-    "vocab.json",
-    "merges.txt",
-    "special_tokens_map.json",
-    "*.model",
-    "*.spm",
-    "*.py",
-]
+# Compatibility alias for existing callers and tests.
+_HF_ALLOW_PATTERNS = [*GENERIC_HF_ALLOW_PATTERNS]
 
 
 def _compute_dynamic_kv_profile_rows(
@@ -545,7 +526,7 @@ def _resolve_model(model_id_or_path: str) -> str:
     try:
         local_dir = snapshot_download(
             repo_id=model_id_or_path,
-            allow_patterns=_HF_ALLOW_PATTERNS + family_hf_allow_patterns() + ["*.nemo"],
+            allow_patterns=hf_snapshot_allow_patterns(),
         )
     except Exception as exc:
         _raise_friendly_download_error(model_id_or_path, exc)

--- a/python/tensorrt_model_connect/hf_snapshot.py
+++ b/python/tensorrt_model_connect/hf_snapshot.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared Hugging Face snapshot selection contract."""
+
+from __future__ import annotations
+
+from .families import family_hf_allow_patterns
+
+
+GENERIC_HF_ALLOW_PATTERNS = (
+    "config.json",
+    "generation_config.json",
+    "preprocessor_config.json",
+    "processor_config.json",
+    "model.safetensors",
+    "model-*.safetensors",
+    "model.safetensors-*.safetensors",
+    "model.safetensors.index.json",
+    "pytorch_model.bin",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "chat_template.jinja",
+    "vocab.json",
+    "merges.txt",
+    "special_tokens_map.json",
+    "*.model",
+    "*.spm",
+    "*.py",
+)
+
+
+def hf_snapshot_allow_patterns() -> list[str]:
+    """Return every model file pattern accepted by the shared builder."""
+    return [*GENERIC_HF_ALLOW_PATTERNS, *family_hf_allow_patterns(), "*.nemo"]

--- a/tests/e2e/models/ltx_video/e2e_plugins/references/hf_diffusers.py
+++ b/tests/e2e/models/ltx_video/e2e_plugins/references/hf_diffusers.py
@@ -39,8 +39,17 @@ def _resolve_cached_model_ref(hf_id: str) -> str:
         return hf_id
     try:
         from huggingface_hub import snapshot_download
+        from tensorrt_model_connect.hf_snapshot import hf_snapshot_allow_patterns
 
-        return str(Path(snapshot_download(hf_id, local_files_only=True)))
+        return str(
+            Path(
+                snapshot_download(
+                    hf_id,
+                    allow_patterns=hf_snapshot_allow_patterns(),
+                    local_files_only=True,
+                )
+            )
+        )
     except Exception:
         return hf_id
 

--- a/tests/e2e/models/ltx_video/test_ltx_video_hf_diffusers_reference.py
+++ b/tests/e2e/models/ltx_video/test_ltx_video_hf_diffusers_reference.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the LTX Video Hugging Face diffusers reference."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+from tensorrt_model_connect.hf_snapshot import hf_snapshot_allow_patterns
+
+from tests.e2e.models.ltx_video.e2e_plugins.references.hf_diffusers import (
+    _resolve_cached_model_ref,
+)
+
+
+def test_resolve_cached_model_ref_uses_selective_snapshot_patterns(
+    monkeypatch, tmp_path
+) -> None:
+    snapshot_path = tmp_path / "snapshot"
+    snapshot_path.mkdir()
+    expected_patterns = hf_snapshot_allow_patterns()
+
+    def snapshot_download(repo_id: str, **kwargs) -> str:
+        assert repo_id == "Lightricks/LTX-Video"
+        assert kwargs["local_files_only"] is True
+        assert kwargs["allow_patterns"] == expected_patterns
+        return str(snapshot_path)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        SimpleNamespace(snapshot_download=snapshot_download),
+    )
+
+    assert _resolve_cached_model_ref("Lightricks/LTX-Video") == str(snapshot_path)

--- a/tools/test_impact_fallback_allowlist.txt
+++ b/tools/test_impact_fallback_allowlist.txt
@@ -158,6 +158,7 @@ shared_builder_module python/tensorrt_model_connect/engine_builder.py # shared P
 shared_builder_module python/tensorrt_model_connect/engine_defs/__init__.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/engine_defs/base.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/fp8_calibrate.py # shared Python builder surface; broad builder impact is intentional
+shared_builder_module python/tensorrt_model_connect/hf_snapshot.py # shared HF snapshot selection used by every builder and gated offline reference; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/kernels/__init__.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/kernels/flashinfer_decode.py # shared Python builder surface; broad builder impact is intentional
 shared_builder_module python/tensorrt_model_connect/parallel_config.py # shared Python builder surface for tensor-parallel build config and sharding; broad builder impact is intentional


### PR DESCRIPTION
## Background

PR #448 run 29304187036 passed the Hugging Face cache preflight, built the LTX bundle, and generated all TensorRT frames. The Hugging Face reference still returned no frames because it retried the private selective cache without the file allowlist, caught that lookup failure, and fell back to the Hub ID while networking was disabled.

## Exit Criteria

- The LTX reference resolves a selectively populated local snapshot without network access.
- Engine builds and the LTX reference use the same Hugging Face snapshot file patterns.
- A source-only regression test fails if the LTX reference omits or changes that shared pattern list.
- No comparison threshold or model-proof pass condition changes.

## Implementation

- Move the builder's Hugging Face snapshot patterns into a small shared module.
- Use that shared list when the LTX reference resolves its offline cache.
- Add a model-owned regression test and classify the shared module conservatively for CI impact analysis.

## Validation

- `PYTHONPATH=python python -m pytest tests/e2e/models/ltx_video/test_ltx_video_hf_diffusers_reference.py tests/e2e/models/ltx_video/test_ltx_video_repro.py tests/builder/test_engine_builder_utils.py tests/tools/test_warm_hf_cache_static.py tests/tools/test_model_plugin_encapsulation_static.py -q` — 219 passed
- `PYTHONPATH=python python -m pytest tests/e2e/models/ltx_video -q --ignore=tests/e2e/models/ltx_video/test_ltx_video_e2e.py -m 'not gpu and not trt'` — 8 passed
- `CI_BASE_REF=github/main bash .github/scripts/run-trtmc-ci.sh source-quality` — passed
- `python tools/legal_headers.py --check` — passed
- `python tools/test_impact.py --validate` — passed

## Notes

The full GPU LTX proof is left to GitHub CI so this fix is validated independently from PR #448's GPU lease changes. After this PR passes and merges, #448 can rebase and rerun against it.
