### PR TITLE
ci: scope task-eval premerge impact

### DIFF
--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -139,6 +139,8 @@ jobs:
       has_models: ${{ steps.impact.outputs.has_models }}
       matrix: ${{ steps.impact.outputs.matrix }}
       affected_models: ${{ steps.impact.outputs.affected_models }}
+      direct_models: ${{ steps.impact.outputs.direct_models }}
+      fallback_models: ${{ steps.impact.outputs.fallback_models }}
       expected_count: ${{ steps.impact.outputs.expected_count }}
       mode: ${{ steps.impact.outputs.mode }}
       run_unit_tests: ${{ steps.impact.outputs.run_unit_tests }}
@@ -197,6 +199,8 @@ jobs:
       - name: Summarize selection
         env:
           AFFECTED_MODELS: ${{ steps.impact.outputs.affected_models }}
+          DIRECT_MODELS: ${{ steps.impact.outputs.direct_models }}
+          FALLBACK_MODELS: ${{ steps.impact.outputs.fallback_models }}
           MODE: ${{ steps.impact.outputs.mode }}
           RUN_UNIT_TESTS: ${{ steps.impact.outputs.run_unit_tests }}
           UNIT_SCOPE: ${{ steps.impact.outputs.unit_scope }}
@@ -206,6 +210,8 @@ jobs:
             echo
             echo "- Mode: \`$MODE\`"
             echo "- Models: \`$AFFECTED_MODELS\`"
+            echo "- Directly affected models: \`$DIRECT_MODELS\`"
+            echo "- Representative fallback models: \`$FALLBACK_MODELS\`"
             echo "- Run source-only units: \`$RUN_UNIT_TESTS\`"
             echo "- Unit scope: \`$UNIT_SCOPE\`"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -317,7 +323,7 @@ jobs:
           fi
 
   model-proof:
-    name: 4 / Model / ${{ matrix.model }}
+    name: 4 / Model / ${{ matrix.model }} [${{ matrix.selection_kind }}]
     needs:
       - legal
       - impact

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -410,8 +410,12 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     for model in ("deepseek_v2", "patchtsmixer", "segformer", "whisper", "ltx_video"):
         assert f"--fallback-model {model}" in impact
     assert "matrix: ${{ steps.impact.outputs.matrix }}" in impact
+    assert "direct_models: ${{ steps.impact.outputs.direct_models }}" in impact
+    assert "fallback_models: ${{ steps.impact.outputs.fallback_models }}" in impact
     assert "run_unit_tests: ${{ steps.impact.outputs.run_unit_tests }}" in impact
     assert "unit_scope: ${{ steps.impact.outputs.unit_scope }}" in impact
+    assert "Directly affected models" in impact
+    assert "Representative fallback models" in impact
 
     assert "name: 3 / Unit / C++ and Python" in unit_tests
     assert "needs.impact.outputs.run_unit_tests == 'true'" in unit_tests
@@ -443,7 +447,10 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     assert "needs.unit-tests.result == 'success'" in model_proof
     assert "needs.unit-tests.result == 'skipped'" in model_proof
     assert "uses: ./.github/workflows/model-proof.yml" in model_proof
-    assert "name: 4 / Model / ${{ matrix.model }}" in model_proof
+    assert (
+        "name: 4 / Model / ${{ matrix.model }} [${{ matrix.selection_kind }}]"
+        in model_proof
+    )
     assert "fail-fast: true" in model_proof
     assert "continue-on-error" not in model_proof
     assert "max-parallel: 16" in model_proof

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -107,6 +107,14 @@ def _make_repo(
     for model_id in model_ids:
         _add_model(repo, model_id)
     _write(repo, "python/tensorrt_model_connect/families/__init__.py", "# registry\n")
+    _write(
+        repo,
+        "pyproject.toml",
+        "[project]\n"
+        'dependencies = ["runtime-package>=1"]\n\n'
+        "[project.optional-dependencies]\n"
+        'test = ["pytest>=7"]\n',
+    )
     _write(repo, "CMakeLists.txt", "# platform build\n")
     _write(repo, "src/runtime/core/core.cpp", "// platform core\n")
     _write(repo, "README.md", "# Documentation\n")
@@ -143,6 +151,9 @@ def _make_repo(
     _write(repo, "tools/diffusion_helpers.py", "# shared diffusion helpers\n")
     _write(repo, "tools/model_plugin_isolation.py", "# proof verifier\n")
     _write(repo, "tools/test_impact.py", "# shared impact analyzer\n")
+    _write(repo, "tools/task_eval.py", "# task-eval runner\n")
+    _write(repo, "tests/task_eval/validation_suites.yaml", "suites: []\n")
+    _write(repo, "tests/tools/test_task_eval.py", "# task-eval unit tests\n")
     _write(repo, "tools/tool_helpers.py", "# shared tool helpers\n")
     _write(repo, "scripts/repro_trt_fp8_mha.py", "# unrelated model script\n")
     _write(repo, "tools/diff_t5.py", "# unrelated model diff\n")
@@ -204,12 +215,22 @@ def test_validate_and_all_emit_deterministic_matrix_and_github_outputs(
     )
 
     assert validated["models"] == ["model_a", "model_b"]
-    assert result["schema_version"] == 2
-    assert result["matrix"] == {"include": [{"model": "model_a"}, {"model": "model_b"}]}
+    assert result["schema_version"] == 3
+    assert result["direct_models"] == ["model_a", "model_b"]
+    assert result["fallback_models"] == []
+    assert result["matrix"] == {
+        "include": [
+            {"model": "model_a", "selection_kind": "direct"},
+            {"model": "model_b", "selection_kind": "direct"},
+        ]
+    }
     assert output.read_text(encoding="utf-8").splitlines() == [
-        'matrix={"include":[{"model":"model_a"},{"model":"model_b"}]}',
+        'matrix={"include":[{"model":"model_a","selection_kind":"direct"},'
+        '{"model":"model_b","selection_kind":"direct"}]}',
         "has_models=true",
         'affected_models=["model_a","model_b"]',
+        'direct_models=["model_a","model_b"]',
+        "fallback_models=[]",
         "expected_count=2",
         "mode=all",
         "run_unit_tests=false",
@@ -251,9 +272,9 @@ def test_matrix_schedules_unknown_then_longest_known_premerge_models(
     assert result["affected_models"] == ["model_a", "model_b", "model_c"]
     assert result["matrix"] == {
         "include": [
-            {"model": "model_c"},
-            {"model": "model_b"},
-            {"model": "model_a"},
+            {"model": "model_c", "selection_kind": "direct"},
+            {"model": "model_b", "selection_kind": "direct"},
+            {"model": "model_a", "selection_kind": "direct"},
         ]
     }
 
@@ -271,7 +292,9 @@ def test_impact_selects_only_model_a(tmp_path: Path) -> None:
 
     assert result["mode"] == "models"
     assert result["affected_models"] == ["model_a"]
-    assert result["matrix"] == {"include": [{"model": "model_a"}]}
+    assert result["direct_models"] == ["model_a"]
+    assert result["fallback_models"] == []
+    assert result["matrix"] == {"include": [{"model": "model_a", "selection_kind": "direct"}]}
     assert result["run_unit_tests"] is False
     assert result["unit_scope"] == "none"
 
@@ -324,6 +347,9 @@ def test_impact_treats_platform_change_as_fixed_fallback(tmp_path: Path) -> None
 
     assert result["mode"] == "fallback"
     assert result["affected_models"] == ["model_a"]
+    assert result["direct_models"] == []
+    assert result["fallback_models"] == ["model_a"]
+    assert result["matrix"] == {"include": [{"model": "model_a", "selection_kind": "fallback"}]}
     assert result["run_unit_tests"] is True
     assert result["unit_scope"] == "all"
 
@@ -366,6 +392,8 @@ def test_cli_and_unit_test_changes_run_units_without_model_proofs(
 
     assert result["mode"] == "unit"
     assert result["affected_models"] == []
+    assert result["direct_models"] == []
+    assert result["fallback_models"] == []
     assert result["matrix"] == {"include": []}
     assert result["run_unit_tests"] is True
     assert result["unit_scope"] == expected_scope
@@ -422,6 +450,99 @@ def test_mixed_model_and_broad_change_keeps_direct_model_plus_fallback(
 
     assert result["mode"] == "fallback"
     assert result["affected_models"] == ["model_a", "model_b"]
+    assert result["direct_models"] == ["model_b"]
+    assert result["fallback_models"] == ["model_a"]
+    assert result["matrix"] == {
+        "include": [
+            {"model": "model_a", "selection_kind": "fallback"},
+            {"model": "model_b", "selection_kind": "direct"},
+        ]
+    }
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
+
+
+def test_task_eval_only_pr_runs_units_without_model_proofs(tmp_path: Path) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(
+        repo,
+        "pyproject.toml",
+        "[project]\n"
+        'dependencies = ["runtime-package>=1"]\n\n'
+        "[project.optional-dependencies]\n"
+        'test = ["pytest>=7"]\n'
+        'task-eval = ["rouge-score>=0.1.2", "sacrebleu>=2.4"]\n',
+    )
+    _write(
+        repo,
+        "tests/task_eval/validation_suites.yaml",
+        "suites:\n  - id: elf_text_parity\n",
+    )
+    _write(repo, "tests/tools/test_task_eval.py", "# expanded task-eval unit tests\n")
+    _write(repo, "tests/tools/test_test_impact.py", "# task-eval impact tests\n")
+    _write(repo, "tools/task_eval.py", "# expanded task-eval runner\n")
+    _write(repo, "tools/elf_hf_reference.py", "# isolated ELF reference\n")
+    _write(
+        repo,
+        "tools/prepare_elf_task_eval_datasets.py",
+        "# ELF task-eval dataset preparation\n",
+    )
+    _write(repo, "tools/test_impact.py", "# task-eval impact refinement\n")
+    head = _commit(repo, "add task-eval coverage")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "unit"
+    assert result["affected_models"] == []
+    assert result["direct_models"] == []
+    assert result["fallback_models"] == []
+    assert result["matrix"] == {"include": []}
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
+    assert {
+        classification["kind"]
+        for change in result["changes"]
+        for classification in change["classifications"]
+    } == {"unit_tests"}
+
+
+def test_task_eval_optional_extra_mixed_with_runtime_dependency_uses_fallback(
+    tmp_path: Path,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(
+        repo,
+        "pyproject.toml",
+        "[project]\n"
+        'dependencies = ["runtime-package>=1", "new-runtime-package>=1"]\n\n'
+        "[project.optional-dependencies]\n"
+        'test = ["pytest>=7"]\n'
+        'task-eval = ["rouge-score>=0.1.2"]\n',
+    )
+    head = _commit(repo, "change runtime and task-eval dependencies")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "fallback"
+    assert result["direct_models"] == []
+    assert result["fallback_models"] == ["model_a"]
+
+
+def test_task_eval_and_model_change_runs_direct_model_proof_plus_units(
+    tmp_path: Path,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, "tools/task_eval.py", "# expanded task-eval runner\n")
+    _write(repo, "src/runtime/models/model_b/plugin.cpp", "// changed model b\n")
+    head = _commit(repo, "change task-eval and model b")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "models"
+    assert result["affected_models"] == ["model_b"]
+    assert result["direct_models"] == ["model_b"]
+    assert result["fallback_models"] == []
+    assert result["matrix"] == {"include": [{"model": "model_b", "selection_kind": "direct"}]}
     assert result["run_unit_tests"] is True
     assert result["unit_scope"] == "all"
 

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -130,9 +130,22 @@ UNIT_TEST_ONLY_EXACT = frozenset(
         "src/runtime/config/cli_support.cpp",
     }
 )
+# Task-eval and the selective impact analyzer are certified by the complete
+# source-only tools suite. Representative model proofs do not execute these
+# entrypoints, so treating them as broad model impact would add GPU work
+# without validating the changed behavior.
+FULL_UNIT_TEST_ONLY_EXACT = frozenset(
+    {
+        "tools/elf_hf_reference.py",
+        "tools/prepare_elf_task_eval_datasets.py",
+        "tools/task_eval.py",
+        "tools/test_impact.py",
+    }
+)
 UNIT_TEST_ONLY_PREFIXES = (
     "tests/builder/",
     "tests/cpp/",
+    "tests/task_eval/",
     "tests/tools/",
 )
 # These shared-location tests require real model plugins or GPU execution and
@@ -202,6 +215,7 @@ CI_OR_TOOLING_PREFIXES = (
 
 _MODEL_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*\Z")
 _MANIFEST_ID_RE = re.compile(r'(?m)^\s*id\s*=\s*"([^"]+)"\s*$')
+_TASK_EVAL_OPTIONAL_EXTRA_RE = re.compile(r"task-eval\s*=\s*\[.*\]\s*\Z")
 
 
 class ModelCIError(RuntimeError):
@@ -527,7 +541,7 @@ def _classify_path(path: str, catalog: OwnershipCatalog) -> tuple[str, str | Non
         )
     if path in UNIT_TEST_ONLY_EXACT:
         return "unit_cli", None
-    if any(
+    if path in FULL_UNIT_TEST_ONLY_EXACT or any(
         path.startswith(prefix) for prefix in UNIT_TEST_ONLY_PREFIXES
     ):
         return "unit_tests", None
@@ -578,26 +592,81 @@ def _diff_entries(repo_root: Path, base: str, head: str) -> tuple[DiffEntry, ...
     return tuple(entries)
 
 
+def _is_task_eval_optional_extra_only_change(
+    repo_root: Path,
+    base: str,
+    head: str,
+) -> bool:
+    """Return whether pyproject changed only the one-line task-eval extra.
+
+    Keep this deliberately fail-closed: comments, multiline rewrites, build
+    metadata, and runtime dependency changes remain platform impact until a
+    reviewer adds a more precise contract.
+    """
+    diff = str(
+        _run_git(
+            repo_root,
+            [
+                "diff",
+                "--no-ext-diff",
+                "--no-color",
+                "--unified=0",
+                base,
+                head,
+                "--",
+                "pyproject.toml",
+            ],
+            text=True,
+        )
+    )
+    changed_lines = [
+        line[1:].strip()
+        for line in diff.splitlines()
+        if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))
+    ]
+    return bool(changed_lines) and all(
+        _TASK_EVAL_OPTIONAL_EXTRA_RE.fullmatch(line) is not None for line in changed_lines
+    )
+
+
 def _result(
     models: Iterable[str],
     *,
     mode: str,
     changes: list[dict[str, object]],
     matrix_models: Iterable[str] | None = None,
+    direct_models: Iterable[str] | None = None,
+    fallback_models: Iterable[str] = (),
     run_unit_tests: bool = False,
     unit_scope: str = "none",
 ) -> dict[str, object]:
     selected = sorted(set(models))
+    direct = set(selected if direct_models is None else direct_models)
+    fallback = set(fallback_models)
+    if direct.intersection(fallback):
+        raise ModelCIError("direct and fallback model selections must not overlap")
+    if direct.union(fallback) != set(selected):
+        raise ModelCIError("direct and fallback selections must explain every affected model")
     scheduled = list(matrix_models) if matrix_models is not None else selected
     if len(scheduled) != len(set(scheduled)) or set(scheduled) != set(selected):
         raise ModelCIError("matrix model order must contain each affected model exactly once")
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "mode": mode,
         "has_models": bool(selected),
         "expected_count": len(selected),
         "affected_models": selected,
-        "matrix": {"include": [{"model": model} for model in scheduled]},
+        "direct_models": sorted(direct),
+        "fallback_models": sorted(fallback),
+        "matrix": {
+            "include": [
+                {
+                    "model": model,
+                    "selection_kind": "fallback" if model in fallback else "direct",
+                }
+                for model in scheduled
+            ]
+        },
         "run_unit_tests": run_unit_tests,
         "unit_scope": unit_scope,
         "changes": changes,
@@ -722,8 +791,14 @@ def calculate_impact(
     base_catalog = discover_catalog(repo_root, comparison_base, allow_legacy_shared_runtime=True)
     head_catalog = discover_catalog(repo_root, head, allow_legacy_shared_runtime=True)
     affected: set[str] = set()
+    fallback_selected: set[str] = set()
     broad_change = False
     unit_scope = "none"
+    pyproject_task_eval_only = _is_task_eval_optional_extra_only_change(
+        repo_root,
+        comparison_base,
+        head_sha,
+    )
     serialized_changes: list[dict[str, object]] = []
     for change in _diff_entries(repo_root, comparison_base, head_sha):
         classifications: list[dict[str, str]] = []
@@ -737,6 +812,8 @@ def calculate_impact(
                 continue
             seen_path_revision.add((path, catalog.revision))
             kind, owner = _classify_path(path, catalog)
+            if path == "pyproject.toml" and pyproject_task_eval_only:
+                kind = "unit_tests"
             item = {"path": path, "kind": kind}
             if owner is not None:
                 item["model"] = owner
@@ -758,6 +835,7 @@ def calculate_impact(
                 "classifications": classifications,
             }
         )
+    direct_affected = set(affected)
     if (
         affected - set(head_catalog.models)
         or affected.intersection(base_catalog.legacy_shared_runtime)
@@ -766,8 +844,10 @@ def calculate_impact(
         broad_change = True
     if broad_change:
         affected.intersection_update(head_catalog.models)
+        direct_affected.intersection_update(head_catalog.models)
         if platform_change_policy == "all":
             affected.update(head_catalog.models)
+            direct_affected.update(head_catalog.models)
             mode = "all"
         elif platform_change_policy == "fallback":
             requested_fallback = list(fallback_models)
@@ -784,6 +864,7 @@ def calculate_impact(
             if missing:
                 raise ModelCIError(f"fallback models are absent from the head catalog: {missing}")
             affected.update(requested_fallback)
+            fallback_selected.update(set(requested_fallback) - direct_affected)
             mode = "fallback"
         else:
             raise ModelCIError(
@@ -801,6 +882,8 @@ def calculate_impact(
         mode=mode,
         changes=serialized_changes,
         matrix_models=_scheduled_models(repo_root, head_catalog, affected),
+        direct_models=direct_affected,
+        fallback_models=fallback_selected,
         run_unit_tests=unit_scope != "none" or broad_change,
         unit_scope="all" if broad_change else unit_scope,
     )
@@ -814,6 +897,8 @@ def _write_github_output(path: Path, result: dict[str, object]) -> None:
         "matrix": json.dumps(result["matrix"], separators=(",", ":")),
         "has_models": str(bool(result["has_models"])).lower(),
         "affected_models": json.dumps(result["affected_models"], separators=(",", ":")),
+        "direct_models": json.dumps(result["direct_models"], separators=(",", ":")),
+        "fallback_models": json.dumps(result["fallback_models"], separators=(",", ":")),
         "expected_count": str(result["expected_count"]),
         "mode": str(result["mode"]),
         "run_unit_tests": str(bool(result["run_unit_tests"])).lower(),


### PR DESCRIPTION
## Background

Premerge currently treats task-eval-only changes as broad platform or CI impact and runs five representative model proofs that do not execute the changed task-eval entrypoints. Run 29308739796 on PR #420 exposed this mismatch.

## Exit Criteria

- Task-eval-only changes run the complete source-only unit scope without model proofs.
- Mixed runtime, build, workflow, or dependency changes retain the conservative representative-model fallback.
- Premerge summaries distinguish directly affected models from representative fallback models.

## Implementation

- Classify task-eval suite metadata, runner/reference helpers, and the selective impact analyzer as full source-only unit impact.
- Refine `pyproject.toml` only when every changed line is the one-line `task-eval` optional extra; multiline, mixed, or runtime dependency edits remain broad impact.
- Extend the impact schema and matrix with direct/fallback selection metadata while retaining the aggregate affected-model output used by reports and the required gate.
- Add PR #420-shaped, mixed-dependency, and mixed-model regression coverage.

## Validation

- `python -m pytest tests/tools/test_model_ci.py tests/tools/test_github_actions_ci.py -q -x`: 112 passed.
- `env CI_BASE_REF=github/main bash .github/scripts/run-trtmc-ci.sh source-quality`: passed Ruff and cyclomatic-complexity checks.
- `python tools/legal_headers.py --check`: 8,072 tracked files, 0 findings.
- `python tools/model_ci.py impact ...` against PR #420 base/head `9059ead9...39282df1`: `mode=unit`, full unit scope, and an empty model matrix.
- `python tools/model_ci.py impact ...` against this branch: `mode=fallback` with the configured five representative models, confirming selector/workflow self-changes remain conservative.
- `python -m pytest tests/tools -q`: 1,536 passed; one environment-only failure because this workspace filesystem rejects the test's required `cp --reflink=always` operation in `test_distinct_explicit_hf_cache_paths_reach_both_containers`. The changed selector/workflow tests pass independently.

## Notes For Future Readers

- Review `tools/model_ci.py` first, followed by the workflow summary/matrix changes and the regression tests.
- Do not broaden the `pyproject.toml` exception without an equally specific diff contract; unknown or mixed changes must continue to fail safe into representative model proofs.
- This PR intentionally triggers the five-model fallback because it changes the premerge selector and workflow. Once merged and rebased, PR #420's task-eval-only diff resolves to source-only units.
