### PR TITLE
fix(timesfm): use FP32 acceptance precision

### DIFF
--- a/.github/scripts/ensure-ci-docker-image.sh
+++ b/.github/scripts/ensure-ci-docker-image.sh
@@ -151,7 +151,8 @@ fi
 emit_image_ref() {
   local resolved_ref="$1"
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
-    echo "image_ref=$resolved_ref" >> "$GITHUB_OUTPUT"
+    mkdir -p "$(dirname "$GITHUB_OUTPUT")"
+    printf 'image_ref=%s\n' "$resolved_ref" >> "$GITHUB_OUTPUT"
   fi
 }
 

--- a/tests/e2e/models/timesfm/manifests/timesfm-2.0-500m-official.json
+++ b/tests/e2e/models/timesfm/manifests/timesfm-2.0-500m-official.json
@@ -19,6 +19,12 @@
     8,
     9,
     10,
+    35,
+    36,
+    37,
+    38,
+    39,
+    40,
     41,
     42,
     43,
@@ -26,6 +32,8 @@
     45,
     46,
     47,
+    48,
+    49,
     50,
     51,
     52,
@@ -60,7 +68,7 @@
       },
       "metadata": {
         "core": false,
-        "notes": "Official Google TimesFM 2.0 500M PyTorch checkpoint exercised through unified E2E with short univariate sample input. FP16 GEMMs request FP32 accumulation. Decoder layers 11-40 and 48-49 use FP16, so 32 of 50 decoder layers remain reduced precision. Layers 0-10 and 41-47 plus selectors 50-53 retain the precision-sensitive early and late residual paths, input FFN, frequency embedding, horizon head, and non-invariant biases in FP32."
+        "notes": "Official Google TimesFM 2.0 500M PyTorch checkpoint exercised through unified E2E with short univariate sample input. FP16 GEMMs request FP32 accumulation. Decoder layers 11-34 use FP16, so 24 of 50 decoder layers remain reduced precision. Layers 0-10 and 35-49 plus selectors 50-53 retain the precision-sensitive early and late residual paths, input FFN, frequency embedding, horizon head, and non-invariant biases in FP32."
       }
     }
   ]

--- a/tests/e2e/models/timesfm/manifests/timesfm-2.0-500m-official.json
+++ b/tests/e2e/models/timesfm/manifests/timesfm-2.0-500m-official.json
@@ -6,39 +6,7 @@
   "runtime_strategy": "timesfm_trt",
   "task_strategy": "neural_operator",
   "e2e_parallel_resource": "exclusive_gpu",
-  "precision": "fp16",
-  "fp32_layers": [
-    0,
-    1,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8,
-    9,
-    10,
-    35,
-    36,
-    37,
-    38,
-    39,
-    40,
-    41,
-    42,
-    43,
-    44,
-    45,
-    46,
-    47,
-    48,
-    49,
-    50,
-    51,
-    52,
-    53
-  ],
+  "precision": "fp32",
   "max_cache_length": 2048,
   "testcases": [
     {
@@ -68,7 +36,7 @@
       },
       "metadata": {
         "core": false,
-        "notes": "Official Google TimesFM 2.0 500M PyTorch checkpoint exercised through unified E2E with short univariate sample input. FP16 GEMMs request FP32 accumulation. Decoder layers 11-34 use FP16, so 24 of 50 decoder layers remain reduced precision. Layers 0-10 and 35-49 plus selectors 50-53 retain the precision-sensitive early and late residual paths, input FFN, frequency embedding, horizon head, and non-invariant biases in FP32."
+        "notes": "Official Google TimesFM 2.0 500M PyTorch checkpoint exercised through unified E2E with short univariate sample input. Acceptance uses FP32 to preserve point-forecast parity on GB300/TRT 11.2 without relaxing numeric thresholds."
       }
     }
   ]

--- a/tests/e2e/models/timesfm/test_timesfm_build_contract.py
+++ b/tests/e2e/models/timesfm/test_timesfm_build_contract.py
@@ -14,3 +14,13 @@ def test_acceptance_build_reserves_gpu_for_stable_tactic_selection() -> None:
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
     assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
+
+
+def test_acceptance_build_keeps_late_decoder_tail_in_fp32() -> None:
+    manifest_path = Path(__file__).parent / "manifests" / "timesfm-2.0-500m-official.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    fp32_layers = set(manifest["fp32_layers"])
+
+    assert set(range(35, 50)) <= fp32_layers
+    assert {50, 51, 52, 53} <= fp32_layers

--- a/tests/e2e/models/timesfm/test_timesfm_build_contract.py
+++ b/tests/e2e/models/timesfm/test_timesfm_build_contract.py
@@ -16,11 +16,9 @@ def test_acceptance_build_reserves_gpu_for_stable_tactic_selection() -> None:
     assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
 
 
-def test_acceptance_build_keeps_late_decoder_tail_in_fp32() -> None:
+def test_acceptance_build_uses_fp32_for_point_forecast_parity() -> None:
     manifest_path = Path(__file__).parent / "manifests" / "timesfm-2.0-500m-official.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
-    fp32_layers = set(manifest["fp32_layers"])
-
-    assert set(range(35, 50)) <= fp32_layers
-    assert {50, 51, 52, 53} <= fp32_layers
+    assert manifest["precision"] == "fp32"
+    assert "fp32_layers" not in manifest

--- a/tests/tools/test_ensure_ci_docker_image.py
+++ b/tests/tools/test_ensure_ci_docker_image.py
@@ -111,6 +111,7 @@ def _run_ensure_script(
     repo_root: Path = REPO_ROOT,
     run_id: str = "",
     verification_dir: Path | None = None,
+    github_output: Path | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], str, str]:
     bin_dir, log_path = _write_fake_docker(tmp_path, existing_images)
     if changed_paths:
@@ -153,6 +154,8 @@ exit 2
     )
     if verification_dir is not None:
         env["TRTMC_CI_IMAGE_VERIFICATION_DIR"] = str(verification_dir)
+    if github_output is not None:
+        env["GITHUB_OUTPUT"] = str(github_output)
     script = repo_root / SCRIPT.relative_to(REPO_ROOT)
     result = subprocess.run(
         ["bash", str(script)],
@@ -297,6 +300,30 @@ def test_matching_fingerprint_image_is_reused_for_pr_rerun(tmp_path: Path) -> No
     assert result.returncode == 0, result.stderr
     assert "build " not in docker_log
     assert f"CI Docker image '{resolved_image}' already matches" in result.stdout
+
+
+def test_reused_image_creates_missing_github_output_parent(tmp_path: Path) -> None:
+    bootstrap_result, bootstrap_env, bootstrap_log = _run_ensure_script(
+        tmp_path / "bootstrap",
+        existing_images={},
+    )
+    assert bootstrap_result.returncode == 0, bootstrap_result.stderr
+    resolved_image = re.search(r"^TRTMC_CI_IMAGE=(.+)$", bootstrap_env, re.MULTILINE).group(1)
+    fingerprint = re.search(
+        r"--label org\.nvidia\.trtmc\.ci-input-fingerprint=([0-9a-f]{64})",
+        bootstrap_log,
+    ).group(1)
+    github_output = tmp_path / "missing-file-command-dir" / "set_output"
+
+    result, _, _ = _run_ensure_script(
+        tmp_path / "matching",
+        existing_images={resolved_image: fingerprint},
+        changed_paths=(".github/scripts/ensure-ci-docker-image.sh",),
+        github_output=github_output,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert github_output.read_text(encoding="utf-8") == f"image_ref=sha256:{fingerprint}\n"
 
 
 def test_matching_image_is_fully_validated_once_per_workflow_run(tmp_path: Path) -> None:

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -686,7 +686,8 @@ def test_model_proof_serializes_image_setup_and_uses_the_verified_image_id() -> 
         "TRTMC_CI_IMAGE_LOCK_FILE",
         'flock -w "$lock_timeout" 9',
         "docker image inspect --format '{{.Id}}'",
-        'echo "image_ref=$resolved_ref" >> "$GITHUB_OUTPUT"',
+        'printf \'image_ref=%s\\n\' "$resolved_ref" >> "$GITHUB_OUTPUT"',
+        'mkdir -p "$(dirname "$GITHUB_OUTPUT")"',
         "verification_stamp",
     ):
         assert contract in ensure


### PR DESCRIPTION
## Background
TimesFM 2.0 500M failed point-forecast parity in model proof. The initial hybrid FP16 selector fix improved Thor/p2021 behavior, but GB300/TRT 11.2 premerge still exceeded the existing thresholds (`relative_l2=0.004276 > 0.004`, `max_pointwise_error=0.01086 > 0.007`).

## Exit Criteria
- TimesFM acceptance keeps the existing numeric parity thresholds meaningful.
- The fix does not waive, skip, or relax the test criteria.
- CI image setup still publishes its verified image output robustly.

## Implementation
- Switch `timesfm-2.0-500m-official` acceptance precision to FP32 and remove the partial `fp32_layers` selector list.
- Update the TimesFM build contract test to lock the FP32 acceptance contract.
- Keep the CI image output hardening so model proof jobs can create missing `$GITHUB_OUTPUT` parent directories before publishing `image_ref`.

## Validation
- `PYTHONPATH=$PWD/python:$PWD python3 -m pytest tests/e2e/models/timesfm/test_timesfm_build_contract.py -q`: passed, 2 tests.
- `PYTHONPATH=$PWD/python:$PWD python3 -m pytest tests/tools/test_ensure_ci_docker_image.py tests/tools/test_model_proof_runner.py::test_model_proof_serializes_image_setup_and_uses_the_verified_image_id -q`: passed, 11 tests before this update.
- `bash -n .github/scripts/ensure-ci-docker-image.sh`: passed before this update.
- `git diff --check`: passed.

## Notes For Future Readers
- The GB300/TRT 11.2 artifact from the previous run showed the hybrid selector was still a real compare failure, not a disk or cancellation issue.
- SegFormer passed inside its artifact and LTX was cancelled by fail-fast after TimesFM failed; neither showed a model compare regression in that run.