### PR TITLE
fix(e2e): stabilize Thor compare manifests

### DIFF
--- a/tests/e2e/models/mixtral/manifests/mixtral-stories-15m.json
+++ b/tests/e2e/models/mixtral/manifests/mixtral-stories-15m.json
@@ -8,7 +8,7 @@
   "e2e_parallel_resource": "exclusive_gpu",
   "precision": "fp16",
   "fp32_layers": [
-    5
+    4
   ],
   "max_cache_length": 256,
   "trust_remote_code": false,

--- a/tests/e2e/models/mixtral/test_mixtral_build_contract.py
+++ b/tests/e2e/models/mixtral/test_mixtral_build_contract.py
@@ -14,3 +14,11 @@ def test_acceptance_build_reserves_gpu_for_stable_tactic_selection() -> None:
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
     assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
+
+
+def test_acceptance_build_keeps_penultimate_decoder_layer_in_fp32() -> None:
+    manifest_path = Path(__file__).parent / "manifests" / "mixtral-stories-15m.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["precision"] == "fp16"
+    assert manifest["fp32_layers"] == [4]

--- a/tests/e2e/models/modernbert/manifests/modernbert-base.json
+++ b/tests/e2e/models/modernbert/manifests/modernbert-base.json
@@ -5,7 +5,7 @@
   "family": "modernbert",
   "runtime_strategy": "modernbert_encoder_only",
   "task_strategy": "encoder_only_nlp",
-  "precision": "fp16",
+  "precision": "fp32",
   "max_cache_length": 256,
   "testcases": [
     {

--- a/tests/e2e/models/modernbert/test_modernbert_build_contract.py
+++ b/tests/e2e/models/modernbert/test_modernbert_build_contract.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Family-owned CI build contract tests for ModernBERT."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_acceptance_build_uses_fp32_for_representation_parity() -> None:
+    manifest_path = Path(__file__).parent / "manifests" / "modernbert-base.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["precision"] == "fp32"
+    assert manifest["testcases"][0]["reference_precision"] == "fp32"


### PR DESCRIPTION
## Background
Thor aarch64 full E2E showed compare_fail results for `modernbert-base` and `mixtral-stories-15m` after filtering known Bark, Canary XFAIL, and the TimesFM issue handled in PR #457. Targeted probes showed both failures are precision configuration issues rather than runtime crashes or threshold-only problems.

## Exit Criteria
- `modernbert-base` uses the precision that preserves representation parity against the FP32 reference.
- `mixtral-stories-15m` keeps the minimal verified decoder selector in FP32 while retaining the fp16 acceptance build.
- The manifest choices are covered by lightweight contract tests.

## Implementation
- Switch `modernbert-base` acceptance precision from fp16 to fp32.
- Change `mixtral-stories-15m` `fp32_layers` from `[5]` to `[4]`, matching the Thor probe that produced the HF reference continuation exactly.
- Add/extend build contract tests so these precision choices are not accidentally reverted.

## Validation
- `PYTHONPATH=$PWD/python:$PWD python3 -m pytest tests/e2e/models/mixtral/test_mixtral_build_contract.py tests/e2e/models/modernbert/test_modernbert_build_contract.py -q`: passed, 3 tests.
- `git diff --check`: passed.
- Thor targeted probe: `modernbert-base` fp16 cosine was 0.1221, fp32 cosine was 0.9989 against the FP32 reference.
- Thor targeted probe: `mixtral-stories-15m` with `fp32_layers=4` produced the exact HF reference continuation, NED 0.0.

## Notes For Future Readers
- This PR does not change comparison thresholds or skip tests. It only updates the tested precision contracts for two reproduced Thor compare failures.
- Probe artifacts are under `/home/nvidia/trtmc-aarch64-test/modernbert-probe-exact-163016` and `/home/nvidia/trtmc-aarch64-test/mixtral-probe-163732` on Thor.