### PR TITLE
fix(locateanything): harden Thor HF reference loading

### DIFF
--- a/tests/e2e/models/locateanything/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/locateanything/e2e_plugins/references/hf_transformers.py
@@ -891,7 +891,11 @@ class HfTransformersReference:
             from tensorrt_model_connect.families.locateanything.vl_debug_runner import (
                 preprocess_image_inputs_for_trt,
             )
-            from transformers import AutoConfig, AutoModel, AutoTokenizer
+            from transformers import AutoConfig, AutoModel, AutoTokenizer, PretrainedConfig
+
+            if torch.cuda.is_available():
+                # Avoid Thor PyTorch/cuDNN sublibrary mismatches in HF reference conv2d.
+                torch.backends.cudnn.enabled = False
 
             hf_id = {hf_id!r}
             model_ref = {model_ref!r}
@@ -963,19 +967,39 @@ class HfTransformersReference:
                     _compat_get_expanded_tied_weights_keys
                 )
 
+            def _load_locateanything_raw_config(model_ref):
+                raw_config_path = Path(model_ref) / "config.json"
+                if raw_config_path.is_file():
+                    return json.loads(raw_config_path.read_text(encoding="utf-8"))
+                try:
+                    raw_config, _ = PretrainedConfig.get_config_dict(
+                        model_ref, trust_remote_code=trust_remote_code)
+                except Exception:
+                    return {{}}
+                return raw_config if isinstance(raw_config, dict) else {{}}
+
             def _load_locateanything_config(model_ref):
                 config = AutoConfig.from_pretrained(
                     model_ref, trust_remote_code=trust_remote_code)
-                raw_config_path = Path(model_ref) / "config.json"
-                if raw_config_path.is_file() and hasattr(config, "text_config"):
-                    raw_config = json.loads(raw_config_path.read_text(encoding="utf-8"))
+                raw_config = _load_locateanything_raw_config(model_ref)
+                if hasattr(config, "text_config") and not hasattr(
+                    config.text_config, "rope_theta"
+                ):
                     raw_text_config = raw_config.get("text_config", {{}})
-                    if not hasattr(config.text_config, "rope_theta"):
-                        rope_theta = raw_text_config.get("rope_theta")
-                        if rope_theta is None:
-                            rope_parameters = raw_text_config.get("rope_parameters", {{}})
-                            rope_theta = rope_parameters.get("rope_theta", 10000.0)
-                        config.text_config.rope_theta = float(rope_theta)
+                    if not isinstance(raw_text_config, dict):
+                        raw_text_config = {{}}
+                    rope_theta = raw_text_config.get("rope_theta")
+                    if rope_theta is None:
+                        rope_parameters = raw_text_config.get("rope_parameters", {{}})
+                        if isinstance(rope_parameters, dict):
+                            rope_theta = rope_parameters.get("rope_theta")
+                    if rope_theta is None:
+                        rope_scaling = raw_text_config.get("rope_scaling", {{}})
+                        if isinstance(rope_scaling, dict):
+                            rope_theta = rope_scaling.get("rope_theta")
+                    if rope_theta is None:
+                        rope_theta = raw_config.get("rope_theta", 10000.0)
+                    config.text_config.rope_theta = float(rope_theta)
                 return config
 
             def _load_locateanything_tokenizer(model_ref):

--- a/tests/e2e/models/locateanything/e2e_plugins/references/hf_transformers.py
+++ b/tests/e2e/models/locateanything/e2e_plugins/references/hf_transformers.py
@@ -1007,13 +1007,23 @@ class HfTransformersReference:
                     return AutoTokenizer.from_pretrained(
                         model_ref, trust_remote_code=trust_remote_code)
                 except Exception as auto_exc:
+                    from huggingface_hub import hf_hub_download
                     from tokenizers import Tokenizer
 
                     model_path = Path(model_ref)
-                    raw_tokenizer = Tokenizer.from_file(
-                        str(model_path / "tokenizer.json"))
+                    if model_path.is_dir():
+                        tokenizer_json = model_path / "tokenizer.json"
+                        tokenizer_config_path = model_path / "tokenizer_config.json"
+                    else:
+                        tokenizer_json = Path(
+                            hf_hub_download(model_ref, "tokenizer.json"))
+                        try:
+                            tokenizer_config_path = Path(
+                                hf_hub_download(model_ref, "tokenizer_config.json"))
+                        except Exception:
+                            tokenizer_config_path = Path()
+                    raw_tokenizer = Tokenizer.from_file(str(tokenizer_json))
                     tokenizer_config = {{}}
-                    tokenizer_config_path = model_path / "tokenizer_config.json"
                     if tokenizer_config_path.is_file():
                         tokenizer_config = json.loads(
                             tokenizer_config_path.read_text(encoding="utf-8"))

--- a/tests/e2e/models/locateanything/test_locateanything_hf_transformers_reference.py
+++ b/tests/e2e/models/locateanything/test_locateanything_hf_transformers_reference.py
@@ -75,6 +75,7 @@ def test_vl_reference_uses_manual_processor(monkeypatch, tmp_path) -> None:
     assert "AutoModel.from_pretrained" in script
     assert "config=config" in script
     assert "def _load_locateanything_tokenizer" in script
+    assert "hf_hub_download" in script
     assert "Tokenizer.from_file" in script
     assert "model_max_length" in script
     assert "def batch_decode" in script

--- a/tests/e2e/models/locateanything/test_locateanything_hf_transformers_reference.py
+++ b/tests/e2e/models/locateanything/test_locateanything_hf_transformers_reference.py
@@ -57,14 +57,20 @@ def test_vl_reference_uses_manual_processor(monkeypatch, tmp_path) -> None:
     assert cmd[:2] == ["/ref/python", "-c"]
     script = cmd[2]
     assert "AutoProcessor" not in script
-    assert "from transformers import AutoConfig, AutoModel, AutoTokenizer" in script
+    assert (
+        "from transformers import AutoConfig, AutoModel, AutoTokenizer, "
+        "PretrainedConfig"
+    ) in script
     assert "def _install_tied_weight_compat" in script
     assert "all_tied_weights_keys" in script
     assert "DynamicCache.to_legacy_cache" in script
     assert "DynamicCache.from_legacy_cache" in script
     assert "get_expanded_tied_weights_keys" in script
     assert "model.embed_tokens.weight" in script
+    assert "torch.backends.cudnn.enabled = False" in script
     assert "def _load_locateanything_config" in script
+    assert "def _load_locateanything_raw_config" in script
+    assert "PretrainedConfig.get_config_dict" in script
     assert "config.text_config.rope_theta" in script
     assert "AutoModel.from_pretrained" in script
     assert "config=config" in script


### PR DESCRIPTION
## Background
LocateAnything-3B reference generation failed before model construction when the remote Qwen2 text config did not expose `rope_theta` through the loaded `AutoConfig`. On Thor, after that was repaired, the isolated HF reference path also hit a PyTorch/cuDNN sublibrary mismatch in the vision conv path.

## Exit Criteria
- LocateAnything-3B HF reference generation can construct the remote model config when `rope_theta` is missing from `config.text_config`.
- The reference-only VL generation path completes on Thor without the cuDNN sublibrary mismatch.
- Keep the change limited to the HF reference wrapper and its script generation test.

## Implementation
- Load the raw Hugging Face config with `PretrainedConfig.get_config_dict` when a local config file is not available, then fill `config.text_config.rope_theta` from raw text config fields with a conservative fallback.
- Disable cuDNN inside only the isolated LocateAnything HF reference subprocess so the reference vision conv path avoids Thor backend library mismatches without changing TRT runtime behavior.
- Extend the LocateAnything reference wrapper test to assert both generated-script safeguards.

## Validation
- `PYTHONPATH=python:. python3 -m pytest -q tests/e2e/models/locateanything/test_locateanything_hf_transformers_reference.py`: passed, 1 test.
- Thor: `PYTHONPATH=python:. /home/nvidia/trtmc-aarch64-test/venv/bin/python -m pytest -q tests/e2e/models/locateanything/test_locateanything_hf_transformers_reference.py`: passed, 1 test.
- Thor reference-only E2E for `locateanything-3b`: passed, summary at `/home/nvidia/trtmc-aarch64-test/envfail-refonly-locate-cudnnfix-20260715-130939/artifacts/summary.json`.
- p2021 wrapper test: passed, 1 test.
- p2021 full E2E entry reached build, vision compare, and HF reference successfully. Final full E2E failed because the local runtime binary does not include `libtrtmc_model_locateanything.so`, so TRT generation returned empty output. No `rope_theta`, `Qwen2Config`, `CUDNN_STATUS`, `Traceback`, or `RuntimeError` appeared in the reference logs.

## Notes For Future Readers
- The cuDNN disable is intentionally scoped to the spawned HF reference subprocess. It should not affect TRT build, TRT runtime, or other model families.
- Review the generated script block in `tests/e2e/models/locateanything/e2e_plugins/references/hf_transformers.py` first; the test only asserts that the wrapper emits the expected safeguards.