### PR TITLE
fix(qwen3-omni): restore real audio decoding

### DIFF
--- a/python/tensorrt_model_connect/families/qwen3_omni/audio_runtime.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/audio_runtime.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Official Qwen3-Omni Talker bridge used by the model-owned C++ runtime.
+
+The TensorRT Thinker produces the assistant text.  This bridge runs the
+checkpoint's trained Talker and residual-code predictor for that exact text,
+then returns frame-major RVQ codes to the TensorRT Code2Wav engine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import os
+import struct
+import sys
+from dataclasses import dataclass
+
+import numpy as np
+
+
+_SYSTEM_PROMPT = (
+    "You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, "
+    "capable of perceiving auditory and visual inputs, as well as generating "
+    "text and speech."
+)
+_INPUT_HEADER = struct.Struct("<II")
+_STOP_MARKERS = ("<|im_end|>", "<|endoftext|>")
+
+
+@dataclass(frozen=True)
+class TalkerRequest:
+    prompt: str
+    assistant_text: str
+
+
+def _read_request(payload: bytes) -> TalkerRequest:
+    if len(payload) < _INPUT_HEADER.size:
+        raise ValueError("Qwen3-Omni Talker request is missing its length header")
+    prompt_size, assistant_size = _INPUT_HEADER.unpack_from(payload)
+    expected = _INPUT_HEADER.size + prompt_size + assistant_size
+    if len(payload) != expected:
+        raise ValueError(f"Qwen3-Omni Talker request has {len(payload)} bytes; expected {expected}")
+    offset = _INPUT_HEADER.size
+    prompt = payload[offset : offset + prompt_size].decode("utf-8")
+    assistant = payload[offset + prompt_size :].decode("utf-8")
+    return TalkerRequest(prompt=prompt, assistant_text=_clean_assistant_text(assistant))
+
+
+def _clean_assistant_text(text: str) -> str:
+    for marker in _STOP_MARKERS:
+        text = text.split(marker, 1)[0]
+    text = text.strip()
+    if not text:
+        raise ValueError("TensorRT Thinker produced no speakable assistant text")
+    return text
+
+
+def _chatml(request: TalkerRequest) -> str:
+    return (
+        f"<|im_start|>system\n{_SYSTEM_PROMPT}<|im_end|>\n"
+        f"<|im_start|>user\n{request.prompt}<|im_end|>\n"
+        f"<|im_start|>assistant\n{request.assistant_text}<|im_end|>\n"
+    )
+
+
+def _generate_codes(
+    model_id: str, revision: str, request: TalkerRequest, max_frames: int
+) -> np.ndarray:
+    import torch
+    from transformers import AutoConfig, AutoTokenizer
+    from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+        Qwen3OmniMoeForConditionalGeneration,
+    )
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("Qwen3-Omni official Talker requires a CUDA device")
+
+    load_kwargs = {
+        "local_files_only": True,
+        "trust_remote_code": True,
+    }
+    if revision:
+        load_kwargs["revision"] = revision
+    config = AutoConfig.from_pretrained(model_id, **load_kwargs)
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_id,
+        **load_kwargs,
+    )
+    model = Qwen3OmniMoeForConditionalGeneration.from_pretrained(
+        model_id,
+        config=config,
+        dtype=torch.bfloat16,
+        low_cpu_mem_usage=True,
+        **load_kwargs,
+    ).eval()
+
+    device = torch.device("cuda:0")
+    thinker_embedding = model.thinker.get_input_embeddings()
+    model.talker.to(device).eval()
+    del model.thinker
+    del model.code2wav
+    gc.collect()
+
+    input_ids = tokenizer(_chatml(request), add_special_tokens=False, return_tensors="pt").input_ids
+    thinker_embed = thinker_embedding(input_ids).to(device)
+    thinker_hidden = torch.zeros_like(thinker_embed)
+    input_ids = input_ids.to(device)
+
+    im_start_indexes = torch.cat(
+        (
+            torch.nonzero(input_ids[0] == config.im_start_token_id).squeeze(-1),
+            torch.tensor([input_ids.shape[-1]], device=device, dtype=input_ids.dtype),
+        ),
+        dim=-1,
+    )
+    multimodal_mask = torch.zeros_like(input_ids, dtype=torch.bool)
+    talker_special_tokens = torch.tensor(
+        [[config.tts_bos_token_id, config.tts_eos_token_id, config.tts_pad_token_id]],
+        device="cpu",
+        dtype=input_ids.dtype,
+    )
+    tts_bos_embed, tts_eos_embed, tts_pad_embed = model.talker.text_projection(
+        thinker_embedding(talker_special_tokens).to(device)
+    ).chunk(3, dim=1)
+
+    talker_input_embeds = []
+    talker_input_ids = []
+    trailing_text_hidden = None
+    speaker_id = config.talker_config.speaker_id["ethan"]
+    for index in range(len(im_start_indexes) - 1):
+        start = int(im_start_indexes[index])
+        end = int(im_start_indexes[index + 1])
+        role = int(input_ids[0, start + 1])
+        if role == config.system_token_id:
+            continue
+        if role == config.user_token_id:
+            talker_input_embeds.append(
+                model._get_talker_user_parts(
+                    start, end, multimodal_mask, thinker_hidden, thinker_embed
+                )
+            )
+            talker_input_ids.append(input_ids[:, start:end])
+        elif role == config.assistant_token_id and index == len(im_start_indexes) - 2:
+            assistant_embeds, assistant_ids, trailing_text_hidden = (
+                model._get_talker_assistant_parts(
+                    start,
+                    end,
+                    speaker_id,
+                    thinker_embed,
+                    tts_pad_embed,
+                    tts_bos_embed,
+                    tts_eos_embed,
+                )
+            )
+            talker_input_embeds.append(assistant_embeds)
+            talker_input_ids.append(assistant_ids)
+
+    if trailing_text_hidden is None or not talker_input_embeds:
+        raise RuntimeError("Qwen3-Omni Talker could not construct the assistant segment")
+
+    talker_embed = torch.cat(talker_input_embeds, dim=1)
+    attention_mask = torch.ones(talker_embed.shape[:2], device=device, dtype=torch.long)
+    suppressed = [
+        token_id
+        for token_id in range(
+            config.talker_config.text_config.vocab_size - 1024,
+            config.talker_config.text_config.vocab_size,
+        )
+        if token_id != config.talker_config.codec_eos_token_id
+    ]
+
+    torch.manual_seed(42)
+    result = model.talker.generate(
+        inputs_embeds=talker_embed,
+        attention_mask=attention_mask,
+        trailing_text_hidden=trailing_text_hidden,
+        tts_pad_embed=tts_pad_embed,
+        talker_input_ids=torch.cat(talker_input_ids, dim=1),
+        max_new_tokens=max_frames,
+        do_sample=False,
+        eos_token_id=config.talker_config.codec_eos_token_id,
+        pad_token_id=config.talker_config.codec_eos_token_id,
+        suppress_tokens=suppressed,
+        output_hidden_states=True,
+        return_dict_in_generate=True,
+    )
+    code_groups = [hidden[-1] for hidden in result.hidden_states if hidden[-1] is not None]
+    if not code_groups:
+        raise RuntimeError("Qwen3-Omni official Talker produced no codec frames")
+    codes = torch.stack(code_groups, dim=1).transpose(1, 2).squeeze(0).to(torch.int32).cpu().numpy()
+    expected_codebooks = int(config.talker_config.num_code_groups)
+    if codes.ndim != 2 or codes.shape[0] != expected_codebooks:
+        raise RuntimeError(
+            f"Qwen3-Omni Talker returned shape {codes.shape}; "
+            f"expected [{expected_codebooks}, frames]"
+        )
+    if codes.shape[1] > max_frames:
+        raise RuntimeError(
+            f"Qwen3-Omni Talker returned {codes.shape[1]} frames; maximum is {max_frames}"
+        )
+    codebook_size = int(config.talker_config.code_predictor_config.vocab_size)
+    if np.any(codes < 0) or np.any(codes >= codebook_size):
+        raise RuntimeError("Qwen3-Omni Talker returned an out-of-range codec token")
+    return np.ascontiguousarray(codes.T, dtype="<i4")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-id", required=True)
+    parser.add_argument("--revision", default="")
+    parser.add_argument("--max-frames", required=True, type=int)
+    args = parser.parse_args(argv)
+    if not 1 <= args.max_frames <= 32:
+        parser.error("--max-frames must be in [1, 32]")
+
+    os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+    request = _read_request(sys.stdin.buffer.read())
+    codes = _generate_codes(args.model_id, args.revision, request, args.max_frames)
+    sys.stdout.buffer.write(codes.tobytes(order="C"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/tensorrt_model_connect/families/qwen3_omni/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/plugin.py
@@ -8,11 +8,11 @@ Qwen3-Omni is a 3-stage multimodal model:
      - Vision encoder (reuses Qwen VL pattern with 3D RoPE)
      - Audio encoder (Whisper-like mel -> transformer encoder)
      - MoE text decoder (Qwen3 MoE architecture)
-  2. Talker: Text embeddings -> RVQ speech codec tokens
-     - Takes Thinker hidden states + text tokens
-     - Produces 8-codebook RVQ tokens (codebook-by-codebook autoregressive)
+  2. Talker: Text embeddings -> 16-group RVQ speech codec tokens
+     - Runs the checkpoint's complete 20-layer MoE Talker and residual-code
+       predictor through the model-owned runtime bridge
   3. Code2Wav: Codec tokens -> audio waveform
-     - ConvNet-based waveform synthesizer (transposed convolutions)
+     - Exports the complete official pre-transformer, upsampler, and decoder
 
 The Thinker MoE decoder follows Qwen3 MoE (sibling model) with the same
 top-k softmax routing. Vision/audio features inject via embed_input mode
@@ -30,16 +30,15 @@ Weight key mapping:
     model.thinker.audio_tower.conv2.weight/bias
     model.thinker.audio_tower.layers.{i}.*
 
-  Talker:
-    model.talker.layers.{i}.*
-    model.talker.codec_head.{cb}.weight
-
   Code2Wav:
-    model.code2wav.upsample_blocks.{i}.weight/bias
+    model.code2wav.pre_transformer.*
+    model.code2wav.upsample.*
+    model.code2wav.decoder.*
 """
 
 from __future__ import annotations
 
+import io
 import sys
 from pathlib import Path
 
@@ -62,6 +61,18 @@ from .standard_decoder_builder import _mark_debug_output
 
 trt = trt_compat.get_trt()
 
+
+def _talker_model_locator(model_dir: Path) -> tuple[str, str]:
+    """Return a portable HF repo/revision pair, or the resolved local path."""
+    resolved = model_dir.resolve()
+    cache_repo = resolved.parent.parent.name
+    if resolved.parent.name == "snapshots" and cache_repo.startswith("models--"):
+        namespace, separator, repository = cache_repo.removeprefix("models--").partition("--")
+        if separator and namespace and repository:
+            return f"{namespace}/{repository}", resolved.name
+    return str(resolved), ""
+
+
 class Qwen3OmniPlugin:
     name = "qwen3_omni"
     runtime_strategy = "qwen3_omni_multimodal"
@@ -72,6 +83,8 @@ class Qwen3OmniPlugin:
         self._talker_cfg: dict = {}
         self._audio_encoder_cfg: dict = {}
         self._code2wav_cfg: dict = {}
+        self._talker_model_id = ""
+        self._talker_model_revision = ""
 
     def matches(self, model_type: str) -> bool:
         mt = model_type.lower()
@@ -89,6 +102,7 @@ class Qwen3OmniPlugin:
           - Code2Wav weights (model.code2wav.*)
         """
         model_dir_path = Path(model_dir)
+        self._talker_model_id, self._talker_model_revision = _talker_model_locator(model_dir_path)
         readers = _open_safetensors(model_dir_path)
 
         hidden = config.hidden_size
@@ -308,13 +322,14 @@ class Qwen3OmniPlugin:
         weights["_talker_cfg"] = talker_cfg
 
         # Detect Code2Wav config
-        code2wav_cfg = self._detect_code2wav(readers)
+        code2wav_cfg = self._detect_code2wav(readers, config)
         self._code2wav_cfg = code2wav_cfg
         weights["_code2wav_cfg"] = code2wav_cfg
 
-        # Load audio encoder, talker, and code2wav weights.
-        # Handle both prefixes: thinker.audio_tower.* and
-        # model.thinker.audio_tower.* (similarly for talker/code2wav).
+        # Load only weights consumed by native extra-engine builders. The
+        # official Talker bridge loads its own checkpoint tensors at runtime;
+        # duplicating them here adds several GB to build memory for no output.
+        # Handle both common checkpoint prefixes.
         for reader in readers:
             for key in reader.keys():
                 # Audio tower weights
@@ -324,13 +339,6 @@ class Qwen3OmniPlugin:
                 elif key.startswith("model.thinker.audio_tower."):
                     canon = key[len("model.thinker."):]
                     weights[f"audio.{canon}"] = _load_tensor([reader], key)
-                # Talker weights
-                elif key.startswith("talker."):
-                    weights[f"talker.{key[len('talker.'):]}"] = (
-                        _load_tensor([reader], key))
-                elif key.startswith("model.talker."):
-                    weights[f"talker.{key[len('model.talker.'):]}"] = (
-                        _load_tensor([reader], key))
                 # Code2Wav weights
                 elif key.startswith("code2wav."):
                     weights[f"code2wav.{key[len('code2wav.'):]}"] = (
@@ -482,36 +490,43 @@ class Qwen3OmniPlugin:
             "codebook_size": int(codebook_size),
         }
 
-    def _detect_code2wav(self, readers) -> dict:
-        """Detect Code2Wav dimensions from weight shapes."""
-        # Look for upsample blocks (try both prefixes)
-        upsample_base = "code2wav.upsample"
-        if not _has_tensor(readers, f"{upsample_base}.0.weight"):
-            upsample_base = "code2wav.upsample_blocks"
-        if not _has_tensor(readers, f"{upsample_base}.0.weight"):
-            upsample_base = "model.code2wav.upsample_blocks"
-        n_upsample = 0
-        while _has_tensor(
-            readers, f"{upsample_base}.{n_upsample}.weight"
-        ):
-            n_upsample += 1
-
-        # Look for codebook embedding (try both prefixes)
+    def _detect_code2wav(self, readers, config: ModelConfig) -> dict:
+        """Detect the official Qwen3-Omni Code2Wav checkpoint layout."""
+        raw = config.raw.get("code2wav_config", {})
         embed_key = "code2wav.code_embedding.weight"
         if not _has_tensor(readers, embed_key):
-            embed_key = "code2wav.codebook_embed.weight"
+            embed_key = "model.code2wav.code_embedding.weight"
         if not _has_tensor(readers, embed_key):
-            embed_key = "model.code2wav.codebook_embed.weight"
-        if _has_tensor(readers, embed_key):
-            embed_w = _load_tensor(readers, embed_key)
-            codebook_vocab, embed_dim = embed_w.shape
-        else:
-            codebook_vocab, embed_dim = 0, 0
+            return {}
+
+        embedding = _load_tensor(readers, embed_key)
+        num_quantizers = int(raw.get("num_quantizers", 0))
+        codebook_size = int(raw.get("codebook_size", 0))
+        if (
+            num_quantizers <= 0
+            or codebook_size <= 0
+            or embedding.shape != (num_quantizers * codebook_size, int(raw.get("hidden_size", 0)))
+        ):
+            raise RuntimeError("Qwen3-Omni Code2Wav checkpoint/config dimensions do not match")
+
+        required = (
+            "code2wav.pre_transformer.layers.0.self_attn.q_proj.weight",
+            "code2wav.upsample.0.0.conv.weight",
+            "code2wav.decoder.0.conv.weight",
+            "code2wav.decoder.6.conv.weight",
+        )
+        if not all(_has_tensor(readers, name) for name in required):
+            raise RuntimeError(
+                "Qwen3-Omni Code2Wav checkpoint is incomplete: expected the "
+                "official pre-transformer, nested upsampler, and decoder layout"
+            )
 
         return {
-            "n_upsample_blocks": int(n_upsample),
-            "codebook_vocab": int(codebook_vocab),
-            "embed_dim": int(embed_dim),
+            "available": True,
+            "config": dict(raw),
+            "max_frames": 32,
+            "upsample_factor": 1920,
+            "output_delay": 555,
         }
 
     def build_engine(
@@ -772,48 +787,35 @@ class Qwen3OmniPlugin:
                 verbose=verbose)
 
     def build_extra_engines(
-        self, config: ModelConfig, weights: WeightDict,
-        max_cache_length: int, *, precision: str = "fp32",
+        self,
+        config: ModelConfig,
+        weights: WeightDict,
+        max_cache_length: int,
+        *,
+        precision: str = "fp32",
         verbose: bool = False,
         build_timing: dict | None = None,
     ) -> dict:
-        """Build audio encoder, Talker, and Code2Wav engines."""
+        """Build the audio encoder and official Code2Wav engines."""
         result = {}
 
         # Build audio encoder engine
         audio_cfg = weights.get("_audio_encoder_cfg", {})
         if audio_cfg and audio_cfg.get("num_layers", 0) > 0:
             if verbose:
-                print("[trtmc build]   Building audio encoder engine ...",
-                      file=sys.stderr)
+                print("[trtmc build]   Building audio encoder engine ...", file=sys.stderr)
             with timed_trt_compile(build_timing, "extra_omni_audio_encoder"):
-                audio_plan = _build_audio_encoder_engine(
-                    weights, audio_cfg, verbose=verbose)
+                audio_plan = _build_audio_encoder_engine(weights, audio_cfg, verbose=verbose)
             if audio_plan is not None:
                 result["audio_encoder_plan"] = audio_plan
 
-        # Build Talker engine
-        talker_cfg = weights.get("_talker_cfg", {})
-        if talker_cfg and talker_cfg.get("num_layers", 0) > 0:
-            if verbose:
-                print("[trtmc build]   Building Talker engine ...",
-                      file=sys.stderr)
-            with timed_trt_compile(build_timing, "extra_omni_talker_decoder"):
-                talker_plan = _build_talker_engine(
-                    weights, talker_cfg, config, max_cache_length,
-                    verbose=verbose)
-            if talker_plan is not None:
-                result["talker_engine_plan"] = talker_plan
-
         # Build Code2Wav engine
         code2wav_cfg = weights.get("_code2wav_cfg", {})
-        if code2wav_cfg and code2wav_cfg.get("n_upsample_blocks", 0) > 0:
+        if code2wav_cfg.get("available"):
             if verbose:
-                print("[trtmc build]   Building Code2Wav engine ...",
-                      file=sys.stderr)
+                print("[trtmc build]   Building Code2Wav engine ...", file=sys.stderr)
             with timed_trt_compile(build_timing, "extra_omni_code2wav_decoder"):
-                code2wav_plan = _build_code2wav_engine(
-                    weights, code2wav_cfg, verbose=verbose)
+                code2wav_plan = _build_code2wav_engine(weights, code2wav_cfg, verbose=verbose)
             if code2wav_plan is not None:
                 result["code2wav_engine_plan"] = code2wav_plan
 
@@ -890,7 +892,7 @@ class Qwen3OmniPlugin:
         # Audio output config (flat keys matching C++ fast_path_config parser)
         overrides["audio_sample_rate"] = 24000
         overrides["omni_n_codebooks"] = self._talker_cfg.get(
-            "n_codebooks", 8)
+            "n_codebooks", 16)
         overrides["omni_codebook_size"] = self._talker_cfg.get(
             "codebook_size", 2048)
 
@@ -900,6 +902,15 @@ class Qwen3OmniPlugin:
         overrides["omni_talker_num_layers"] = self._talker_cfg.get(
             "num_layers", 0)
         overrides["omni_talker_max_cache_length"] = 1024
+        overrides["omni_talker_model_id"] = self._talker_model_id
+        overrides["omni_talker_model_revision"] = self._talker_model_revision
+
+        # The official decoder is causal and exported at a fixed 32-frame
+        # shape. Shorter generations are zero-padded and trimmed by the
+        # runtime using the model's 1920x stride and 555-sample causal delay.
+        overrides["omni_code2wav_max_frames"] = self._code2wav_cfg.get("max_frames", 32)
+        overrides["omni_code2wav_upsample_factor"] = self._code2wav_cfg.get("upsample_factor", 1920)
+        overrides["omni_code2wav_output_delay"] = self._code2wav_cfg.get("output_delay", 555)
 
         # Audio encoder config (flat keys for C++ parser)
         overrides["omni_audio_embed_dim"] = self._audio_encoder_cfg.get(
@@ -1220,229 +1231,155 @@ def _build_audio_encoder_engine(
 
 
 # ---------------------------------------------------------------------------
-# Talker engine builder (RVQ codec predictor)
-# ---------------------------------------------------------------------------
-
-def _build_talker_engine(
-    weights: WeightDict,
-    talker_cfg: dict,
-    config: ModelConfig,
-    max_cache_length: int,
-    verbose: bool = False,
-) -> bytes | None:
-    """Build Talker decoder engine.
-
-    The Talker takes Thinker hidden states and text tokens as input and
-    produces RVQ codec tokens. It uses a standard KV-cache decoder architecture
-    with codebook prediction heads.
-
-    Input: token_id [1] int32, standard KV cache inputs
-    Output: codec_logits [1, codebook_size] float32
-    """
-    talker_hidden = talker_cfg.get("hidden_size", 0)
-    talker_vocab = talker_cfg.get("vocab_size", 0)
-    num_layers = talker_cfg.get("num_layers", 0)
-    n_codebooks = talker_cfg.get("n_codebooks", 8)
-    codebook_size = talker_cfg.get("codebook_size", 2048)
-
-    if num_layers == 0 or talker_hidden == 0:
-        return None
-
-    if verbose:
-        print(f"[trtmc build]   Talker projection: layers={num_layers}, "
-              f"hidden={talker_hidden}, vocab={talker_vocab}, "
-              f"codebooks={n_codebooks}, cb_size={codebook_size}",
-              file=sys.stderr)
-
-    input_hidden = talker_cfg.get("hidden_size", talker_hidden)
-    decoder_hidden = talker_cfg.get("decoder_hidden_size", talker_hidden)
-    if (
-        "talker.hidden_projection.linear_fc1.weight" not in weights
-        or "talker.hidden_projection.linear_fc2.weight" not in weights
-        or "talker.codec_head.weight" not in weights
-    ):
-        return None
-
-    lm_head_keys = [
-        f"talker.code_predictor.lm_head.{i}.weight"
-        for i in range(max(n_codebooks - 1, 0))
-    ]
-    if any(k not in weights for k in lm_head_keys):
-        return None
-
-    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
-    builder = trt.Builder(logger)
-    network = builder.create_network(
-        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
-    trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
-
-    input_embed = network.add_input(
-        "input_embed", trt.float32, (input_hidden,))
-    hidden_in = network.add_shuffle(input_embed)
-    hidden_in.reshape_dims = (1, input_hidden)
-    hidden = hidden_in.get_output(0)
-
-    fc1_w = _transpose_2d(
-        weights["talker.hidden_projection.linear_fc1.weight"], "talker_fc1")
-    fc1 = graph_ops.add_matmul_rhs_constant(
-        network, hidden, input_hidden, input_hidden, fc1_w)
-    fc1_b = weights.get("talker.hidden_projection.linear_fc1.bias")
-    if fc1_b is not None:
-        fc1 = graph_ops.add_bias_sum(
-            network, fc1, input_hidden, fc1_b.astype(np.float32))
-
-    sigmoid = network.add_activation(fc1, trt.ActivationType.SIGMOID)
-    silu = network.add_elementwise(
-        fc1, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
-
-    fc2_w = _transpose_2d(
-        weights["talker.hidden_projection.linear_fc2.weight"], "talker_fc2")
-    hidden = graph_ops.add_matmul_rhs_constant(
-        network, silu.get_output(0), input_hidden, decoder_hidden, fc2_w)
-    fc2_b = weights.get("talker.hidden_projection.linear_fc2.bias")
-    if fc2_b is not None:
-        hidden = graph_ops.add_bias_sum(
-            network, hidden, decoder_hidden, fc2_b.astype(np.float32))
-
-    codec_head = weights["talker.codec_head.weight"]
-    head_parts = []
-    first_head_rows = min(codebook_size, codec_head.shape[0])
-    if first_head_rows < codebook_size:
-        return None
-    first_head = _transpose_2d(
-        codec_head[:codebook_size], "talker_codec_head")
-    head_parts.append(graph_ops.add_matmul_rhs_constant(
-        network, hidden, decoder_hidden, codebook_size, first_head))
-
-    for i, key in enumerate(lm_head_keys):
-        head = _transpose_2d(weights[key], f"talker_lm_head_{i}")
-        head_parts.append(graph_ops.add_matmul_rhs_constant(
-            network, hidden, decoder_hidden, codebook_size, head))
-
-    if len(head_parts) == 1:
-        logits = head_parts[0]
-    else:
-        concat = network.add_concatenation(head_parts)
-        concat.axis = 1
-        logits = concat.get_output(0)
-
-    logits.name = "logits"
-    network.mark_output(logits)
-
-    plan = builder.build_serialized_network(network, trt_config)
-    if plan is None:
-        raise RuntimeError("TensorRT Qwen3-Omni Talker projection build failed")
-    return bytes(plan)
-
-
-# ---------------------------------------------------------------------------
 # Code2Wav engine builder (ConvNet waveform synthesizer)
 # ---------------------------------------------------------------------------
+
 
 def _build_code2wav_engine(
     weights: WeightDict,
     code2wav_cfg: dict,
     verbose: bool = False,
 ) -> bytes | None:
-    """Build Code2Wav engine: RVQ codec tokens -> audio waveform.
+    """Build the official Code2Wav graph: RVQ codes -> speech waveform.
 
-    Similar to EnCodec decoder: embedding lookup -> transposed convolutions.
+    The released checkpoint uses an eight-layer sliding-attention
+    pre-transformer, two ConvNeXt upsamplers, and four causal HiFi-GAN-style
+    decoder blocks. The old placeholder builder looked for flat
+    ``upsample_blocks.N.weight`` tensors that do not exist in this checkpoint,
+    so it silently omitted the engine. Exporting the upstream model-owned
+    module to ONNX preserves all 230 checkpoint tensors and lets TensorRT fuse
+    the complete static audio decoder.
     """
-    n_upsample = code2wav_cfg.get("n_upsample_blocks", 0)
-    codebook_vocab = code2wav_cfg.get("codebook_vocab", 0)
-    embed_dim = code2wav_cfg.get("embed_dim", 0)
-
-    if n_upsample == 0 or codebook_vocab == 0:
+    if not code2wav_cfg.get("available"):
         return None
 
-    # Max frames for the engine
-    max_frames = 256
+    import gc
+    import torch
+    from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import (
+        Qwen3OmniMoeCode2WavConfig,
+    )
+    from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+        Qwen3OmniMoeCode2Wav,
+    )
 
-    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
-    builder = trt.Builder(logger)
-    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
-    trt_config = builder.create_builder_config()
-    trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 2 << 30)
+    model_config = Qwen3OmniMoeCode2WavConfig(**code2wav_cfg["config"])
+    model = Qwen3OmniMoeCode2Wav(model_config)
 
-    # Input: codec tokens [n_codebooks, max_frames] int32
-    n_codebooks = 8
-    codec_input = network.add_input(
-        "codec_tokens", trt.int32, (n_codebooks, max_frames))
+    state = {}
+    for name in model.state_dict():
+        key = f"code2wav.{name}"
+        value = weights.get(key)
+        if value is None:
+            raise RuntimeError(f"Qwen3-Omni Code2Wav checkpoint tensor is missing: {key}")
+        state[name] = torch.from_numpy(np.ascontiguousarray(value, dtype=np.float32))
+    model.load_state_dict(state, strict=True)
+    model.eval()
 
-    # Codebook embedding lookup
-    embed_key = "code2wav.codebook_embed.weight"
-    if embed_key not in weights:
-        return None
+    class _StaticCode2Wav(torch.nn.Module):
+        """Static, export-safe equivalent of the official forward method."""
 
-    embed_w = weights[embed_key].astype(np.float32)
-    embed_table = graph_ops.add_constant(
-        network, (codebook_vocab, embed_dim), embed_w)
+        def __init__(self, module):
+            super().__init__()
+            self.module = module
 
-    # For now, just lookup first codebook and sum all
-    # This is a simplified version — full implementation would handle
-    # all codebooks with separate embedding tables
-    # Flatten tokens, gather, reshape, sum across codebooks
-    flat_tokens = network.add_shuffle(codec_input)
-    flat_tokens.reshape_dims = (n_codebooks * max_frames,)
+        def forward(self, codes):
+            codes = codes.to(torch.int64)
+            hidden = self.module.code_embedding(codes + self.module.code_offset).mean(1)
 
-    gathered = network.add_gather(embed_table, flat_tokens.get_output(0), 0)
-    reshaped = network.add_shuffle(gathered.get_output(0))
-    reshaped.reshape_dims = (n_codebooks, max_frames, embed_dim)
+            # Supplying the official 72-frame sliding causal mask explicitly
+            # avoids the torch.diff-based dynamic mask helper, which is not
+            # representable in ONNX opset 17. The engine shape is static.
+            length = hidden.shape[1]
+            indices = torch.arange(length, device=hidden.device)
+            row = indices[:, None]
+            col = indices[None, :]
+            allowed = (col <= row) & (col > row - self.module.config.sliding_window)
+            mask = torch.where(
+                allowed,
+                torch.zeros((), dtype=hidden.dtype, device=hidden.device),
+                torch.full(
+                    (),
+                    torch.finfo(hidden.dtype).min,
+                    dtype=hidden.dtype,
+                    device=hidden.device,
+                ),
+            )[None, None]
+            hidden = self.module.pre_transformer(
+                inputs_embeds=hidden,
+                attention_mask={
+                    "sliding_attention": mask,
+                    "full_attention": mask,
+                },
+            ).last_hidden_state
+            hidden = hidden.permute(0, 2, 1)
+            for blocks in self.module.upsample:
+                for block in blocks:
+                    hidden = block(hidden)
+            for block in self.module.decoder:
+                hidden = block(hidden)
+            return hidden.clamp(min=-1, max=1)
 
-    # Sum across codebooks
-    summed = network.add_reduce(
-        reshaped.get_output(0), trt.ReduceOperation.SUM, 1 << 0,
-        keep_dims=False)
-    hidden = summed.get_output(0)  # [max_frames, embed_dim]
-
-    # Transpose to [1, embed_dim, max_frames] for convolutions
-    transpose = network.add_shuffle(hidden)
-    transpose.reshape_dims = (1, max_frames, embed_dim)
-    transpose.second_transpose = trt.Permutation([0, 2, 1])
-    hidden = transpose.get_output(0)
-
-    # Upsampling transposed convolutions
-    total_upsample = 1
-    for i in range(n_upsample):
-        up_w_key = f"code2wav.upsample_blocks.{i}.weight"
-        up_b_key = f"code2wav.upsample_blocks.{i}.bias"
-        up_w = weights.get(up_w_key)
-        if up_w is None:
-            break
-
-        up_w_np = up_w.astype(np.float32)
-        out_channels = up_w_np.shape[1]  # transposed conv: [in, out, K]
-        kernel_size = up_w_np.shape[2] if up_w_np.ndim == 3 else 4
-        stride = kernel_size // 2 if kernel_size > 1 else 1
-
-        deconv = network.add_deconvolution_nd(
-            hidden, out_channels, (kernel_size,),
-            trt.Weights(np.ascontiguousarray(up_w_np)),
-            trt.Weights(weights[up_b_key].astype(np.float32)
-                        if up_b_key in weights
-                        else np.zeros(out_channels, dtype=np.float32)))
-        deconv.stride_nd = (stride,)
-        deconv.padding_nd = ((kernel_size - stride) // 2,)
-
-        relu = network.add_activation(
-            deconv.get_output(0), trt.ActivationType.RELU)
-        hidden = relu.get_output(0)
-        total_upsample *= stride
-
-    # Output: waveform [1, 1, num_samples]
-    hidden.name = "waveform"
-    network.mark_output(hidden)
-
+    max_frames = int(code2wav_cfg["max_frames"])
+    num_quantizers = int(model_config.num_quantizers)
+    export_module = _StaticCode2Wav(model).eval()
+    dummy_codes = torch.zeros((1, num_quantizers, max_frames), dtype=torch.int32)
+    onnx_buffer = io.BytesIO()
     if verbose:
-        print(f"[trtmc build] Building Qwen3-Omni Code2Wav engine "
-              f"({n_upsample} upsample blocks, embed={embed_dim}, "
-              f"max_frames={max_frames}, upsample={total_upsample}x) ...",
-              file=sys.stderr)
+        print(
+            "[trtmc build]   Exporting official Qwen3-Omni Code2Wav "
+            f"({num_quantizers} codebooks x {max_frames} frames) ...",
+            file=sys.stderr,
+        )
+    with torch.inference_mode():
+        torch.onnx.export(
+            export_module,
+            dummy_codes,
+            onnx_buffer,
+            opset_version=17,
+            input_names=["codec_tokens"],
+            output_names=["waveform"],
+            dynamo=False,
+        )
 
-    plan = builder.build_serialized_network(network, trt_config)
+    del export_module, model, state, dummy_codes
+    gc.collect()
+
+    logger = trt.Logger(trt.Logger.INFO if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    network = builder.create_network(
+        trt_compat.network_creation_flags(
+            explicit_batch=True,
+            strongly_typed=True,
+        )
+    )
+    parser = trt.OnnxParser(network, logger)
+    if not parser.parse(onnx_buffer.getvalue()):
+        errors = [str(parser.get_error(i)) for i in range(parser.num_errors)]
+        raise RuntimeError("Qwen3-Omni Code2Wav ONNX parsing failed:\n" + "\n".join(errors))
+
+    expected_samples = max_frames * int(code2wav_cfg["upsample_factor"]) - int(
+        code2wav_cfg["output_delay"]
+    )
+    if tuple(network.get_input(0).shape) != (1, num_quantizers, max_frames) or tuple(
+        network.get_output(0).shape
+    ) != (1, 1, expected_samples):
+        raise RuntimeError(
+            "Qwen3-Omni Code2Wav ONNX shape contract mismatch: "
+            f"input={tuple(network.get_input(0).shape)}, "
+            f"output={tuple(network.get_output(0).shape)}"
+        )
+
+    build_config = builder.create_builder_config()
+    build_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 2 << 30)
+    if verbose:
+        print(
+            "[trtmc build]   Building complete Qwen3-Omni Code2Wav "
+            f"TensorRT engine ({expected_samples} samples) ...",
+            file=sys.stderr,
+        )
+    plan = builder.build_serialized_network(network, build_config)
     if plan is None:
-        raise RuntimeError("TensorRT Code2Wav build failed")
+        raise RuntimeError("TensorRT Qwen3-Omni Code2Wav build failed")
     return bytes(plan)
 
 

--- a/src/runtime/models/qwen3_omni/omni_audio_plan.h
+++ b/src/runtime/models/qwen3_omni/omni_audio_plan.h
@@ -24,21 +24,10 @@ struct OmniAudioEncodePlan {
     std::size_t output_elements{0};
 };
 
-struct OmniTalkerPlan {
-    bool should_run_talker{false};
-    int32_t num_tokens{0};
-};
-
 struct OmniCodecPlan {
     bool should_run_codec{false};
     int32_t n_codebooks{0};
     int32_t n_frames{0};
-};
-
-struct OmniTalkerDecodePlan {
-    int32_t n_codebooks{0};
-    int32_t codebook_size{0};
-    int32_t num_tokens{0};
 };
 
 inline OmniAudioEncodePlan make_omni_audio_encode_plan(const OmniConfig& config,
@@ -65,15 +54,6 @@ inline std::vector<float> build_omni_audio_encoder_input(const float* mel_featur
     return input_padded;
 }
 
-inline OmniTalkerPlan make_omni_talker_plan(std::size_t text_token_count,
-                                            std::size_t hidden_state_count,
-                                            bool has_talker_engine) {
-    OmniTalkerPlan plan;
-    plan.should_run_talker = has_talker_engine && text_token_count > 0 && hidden_state_count > 0;
-    plan.num_tokens = static_cast<int32_t>(text_token_count);
-    return plan;
-}
-
 inline OmniCodecPlan make_omni_codec_plan(const OmniConfig& config, std::size_t codec_token_count) {
     OmniCodecPlan plan;
     plan.n_codebooks = config.talker_n_codebooks;
@@ -82,39 +62,6 @@ inline OmniCodecPlan make_omni_codec_plan(const OmniConfig& config, std::size_t 
         plan.should_run_codec ? static_cast<int32_t>(codec_token_count) / plan.n_codebooks : 0;
     plan.should_run_codec = plan.should_run_codec && plan.n_frames > 0;
     return plan;
-}
-
-inline OmniTalkerDecodePlan make_omni_talker_decode_plan(int32_t n_codebooks, int32_t codebook_size,
-                                                         int32_t num_tokens) {
-    OmniTalkerDecodePlan plan;
-    plan.n_codebooks = n_codebooks;
-    plan.codebook_size = codebook_size;
-    plan.num_tokens = num_tokens;
-    return plan;
-}
-
-inline int32_t select_omni_codebook_argmax(const std::vector<float>& logits, int32_t offset,
-                                           int32_t codebook_size) {
-    if (offset + codebook_size > static_cast<int32_t>(logits.size())) {
-        return 0;
-    }
-
-    int32_t best = 0;
-    for (int32_t index = 1; index < codebook_size; ++index) {
-        if (logits[offset + index] > logits[offset + best]) {
-            best = index;
-        }
-    }
-    return best;
-}
-
-inline void append_omni_talker_codes_from_logits(const std::vector<float>& logits,
-                                                 const OmniTalkerDecodePlan& plan,
-                                                 std::vector<int32_t>& all_codes) {
-    for (int32_t codebook = 0; codebook < plan.n_codebooks; ++codebook) {
-        const int32_t offset = codebook * plan.codebook_size;
-        all_codes.push_back(select_omni_codebook_argmax(logits, offset, plan.codebook_size));
-    }
 }
 
 inline std::vector<int32_t>
@@ -129,6 +76,17 @@ build_omni_code2wav_input_codes(const std::vector<int32_t>& codec_tokens, int32_
         }
     }
     return input_codes;
+}
+
+inline std::size_t code2wav_output_samples(const OmniConfig& config, int32_t actual_frames,
+                                           std::size_t engine_output_samples) {
+    if (actual_frames <= 0 || config.code2wav_upsample_factor <= 0)
+        return 0;
+    const auto untrimmed = static_cast<std::size_t>(actual_frames) *
+                           static_cast<std::size_t>(config.code2wav_upsample_factor);
+    const auto delay = static_cast<std::size_t>(std::max(config.code2wav_output_delay, 0));
+    const auto model_samples = untrimmed > delay ? untrimmed - delay : 0;
+    return std::min(engine_output_samples, model_samples);
 }
 
 } // namespace trtmc

--- a/src/runtime/models/qwen3_omni/omni_config.h
+++ b/src/runtime/models/qwen3_omni/omni_config.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace trtmc {
 
@@ -16,6 +17,7 @@ struct OmniConfig {
     int32_t thinker_hidden_size{0};
     int32_t thinker_num_layers{0};
     int32_t thinker_num_heads{0};
+    int32_t thinker_eos_token_id{151645};
     int32_t num_experts{8};
     int32_t num_experts_per_tok{2};
 
@@ -26,11 +28,16 @@ struct OmniConfig {
 
     int32_t talker_hidden_size{0};
     int32_t talker_num_layers{0};
-    int32_t talker_n_codebooks{8};
+    int32_t talker_n_codebooks{16};
     int32_t talker_codebook_size{2048};
 
-    int32_t code2wav_upsample_factor{320};
-    int32_t code2wav_max_frames{256};
+    int32_t code2wav_upsample_factor{1920};
+    int32_t code2wav_output_delay{555};
+    int32_t code2wav_max_frames{32};
+
+    std::string hf_python;
+    std::string talker_model_id;
+    std::string talker_model_revision;
 
     bool greedy{false};
     float temperature{0.7F};

--- a/src/runtime/models/qwen3_omni/pipeline.cpp
+++ b/src/runtime/models/qwen3_omni/pipeline.cpp
@@ -6,27 +6,36 @@
 #include "runtime/models/qwen3_omni/pipeline.h"
 
 #include "runtime/models/qwen3_omni/omni_audio_plan.h"
+#include "runtime/models/qwen3_omni/talker_runtime.h"
 #include "trtmc/tokenizer.h"
 
 #include <algorithm>
-#include <cmath>
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
 
 namespace trtmc {
 
+namespace {
+
+std::string format_omni_chat_prompt(const std::string& prompt) {
+    return "<|im_start|>system\n"
+           "You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of "
+           "perceiving auditory and visual inputs, as well as generating text and speech."
+           "<|im_end|>\n<|im_start|>user\n" +
+           prompt + "<|im_end|>\n<|im_start|>assistant\n";
+}
+
+} // namespace
+
 // ─── OmniPipeline (TrtModule-based) ───
 
 OmniPipeline::OmniPipeline(std::unique_ptr<TrtModule> thinker,
                            std::unique_ptr<Qwen3OmniInferenceState> thinker_state,
-                           std::unique_ptr<TrtModule> talker,
-                           std::unique_ptr<Qwen3OmniInferenceState> talker_state,
                            std::unique_ptr<TrtModule> code2wav, OmniConfig config,
                            cudaStream_t stream, std::shared_ptr<ITokenizer> tokenizer,
                            std::string model_id_str)
     : thinker_(std::move(thinker)), thinker_state_(std::move(thinker_state)),
-      talker_(std::move(talker)), talker_state_(std::move(talker_state)),
       code2wav_(std::move(code2wav)), config_(std::make_unique<OmniConfig>(std::move(config))),
       stream_(stream), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)) {
     if (!thinker_ || !thinker_->ok())
@@ -37,8 +46,7 @@ OmniPipeline::OmniPipeline(std::unique_ptr<TrtModule> thinker,
 
 OmniPipeline::~OmniPipeline() = default;
 
-void OmniPipeline::run_thinker_step(int32_t token_id, std::vector<float>& logits,
-                                    std::vector<float>* hidden_state) {
+void OmniPipeline::run_thinker_step(int32_t token_id, std::vector<float>& logits) {
     Tensor token_tensor;
     token_tensor.data = &token_id;
     token_tensor.shape = {1};
@@ -59,60 +67,7 @@ void OmniPipeline::run_thinker_step(int32_t token_id, std::vector<float>& logits
     logits.resize(static_cast<std::size_t>(n));
     std::memcpy(logits.data(), lt.data, n * sizeof(float));
 
-    if (hidden_state != nullptr) {
-        auto hs_it = outputs.find("hidden_state");
-        if (hs_it == outputs.end())
-            throw std::runtime_error("OmniPipeline thinker: no 'hidden_state' output");
-
-        const auto& ht = hs_it->second;
-        auto hn = ht.numel();
-        hidden_state->resize(static_cast<std::size_t>(hn));
-        std::memcpy(hidden_state->data(), ht.data, hn * sizeof(float));
-    }
-
     thinker_state_->advance();
-}
-
-void OmniPipeline::run_talker_embed_step(const float* embed_ptr, int32_t embed_size,
-                                         std::vector<float>& logits) {
-    float use_input_embed = 1.0F;
-
-    std::vector<float> embed_buf(embed_ptr, embed_ptr + embed_size);
-
-    Tensor token_tensor;
-    int32_t dummy_token = 0;
-    token_tensor.data = &dummy_token;
-    token_tensor.shape = {1};
-    token_tensor.dtype = DType::kInt32;
-
-    Tensor embed_tensor;
-    embed_tensor.data = embed_buf.data();
-    embed_tensor.shape = {static_cast<int64_t>(embed_size)};
-    embed_tensor.dtype = DType::kFloat32;
-
-    Tensor use_embed_tensor;
-    use_embed_tensor.data = &use_input_embed;
-    use_embed_tensor.shape = {1};
-    use_embed_tensor.dtype = DType::kFloat32;
-
-    TensorMap inputs;
-    inputs["token_id"] = token_tensor;
-    inputs["input_embed"] = embed_tensor;
-    inputs["use_input_embed"] = use_embed_tensor;
-    talker_state_->prepare_step(inputs);
-
-    TensorMap outputs = talker_->forward(inputs);
-
-    auto it = outputs.find("logits");
-    if (it == outputs.end())
-        throw std::runtime_error("OmniPipeline talker: no 'logits' output");
-
-    const auto& lt = it->second;
-    auto n = lt.numel();
-    logits.resize(static_cast<std::size_t>(n));
-    std::memcpy(logits.data(), lt.data, n * sizeof(float));
-
-    talker_state_->advance();
 }
 
 static int32_t omni_argmax(const std::vector<float>& logits) {
@@ -123,11 +78,9 @@ static int32_t omni_argmax(const std::vector<float>& logits) {
 }
 
 std::vector<int32_t> OmniPipeline::run_thinker(const std::vector<int32_t>& input_ids,
-                                               int32_t max_tokens,
-                                               std::vector<float>& hidden_states_out) {
+                                               int32_t max_tokens) {
     thinker_state_->reset();
     thinker_state_->bind_to(*thinker_);
-    hidden_states_out.clear();
 
     std::vector<float> logits;
 
@@ -144,12 +97,10 @@ std::vector<int32_t> OmniPipeline::run_thinker(const std::vector<int32_t>& input
         if (logits.empty())
             break;
         int32_t token = omni_argmax(logits);
-        if (token == 0)
+        if (token == 0 || token == config_->thinker_eos_token_id)
             break;
         output_ids.push_back(token);
-        std::vector<float> hidden_state;
-        run_thinker_step(token, logits, &hidden_state);
-        hidden_states_out.insert(hidden_states_out.end(), hidden_state.begin(), hidden_state.end());
+        run_thinker_step(token, logits);
     }
 
     std::cerr << "[trtmc] Omni Thinker: generated " << output_ids.size() << " text tokens"
@@ -157,68 +108,21 @@ std::vector<int32_t> OmniPipeline::run_thinker(const std::vector<int32_t>& input
     return output_ids;
 }
 
-std::vector<int32_t> OmniPipeline::run_talker(const std::vector<float>& hidden_states,
-                                              int32_t num_tokens) {
-    if (!talker_ || !talker_state_) {
-        std::cerr << "[trtmc] Omni: no Talker engine" << std::endl;
-        return {};
-    }
-
-    talker_state_->reset();
-    talker_state_->bind_to(*talker_);
-
-    const int32_t n_codebooks = config_->talker_n_codebooks;
-    const int32_t codebook_size = config_->talker_codebook_size;
-    const int32_t talker_hidden = config_->talker_hidden_size;
-
-    const OmniTalkerDecodePlan decode_plan =
-        make_omni_talker_decode_plan(n_codebooks, codebook_size, num_tokens);
-
-    std::vector<int32_t> all_codes;
-    all_codes.reserve(static_cast<std::size_t>(num_tokens) * n_codebooks);
-
-    std::vector<float> logits;
-    for (int32_t t = 0; t < num_tokens; ++t) {
-        const float* ep = hidden_states.data() + static_cast<std::size_t>(t) * talker_hidden;
-        run_talker_embed_step(ep, talker_hidden, logits);
-        append_omni_talker_codes_from_logits(logits, decode_plan, all_codes);
-    }
-
-    std::cerr << "[trtmc] Omni Talker: generated " << all_codes.size() << " codec tokens ("
-              << num_tokens << " frames x " << n_codebooks << " codebooks)" << std::endl;
-    return all_codes;
-}
-
 std::vector<float> OmniPipeline::run_code2wav(const std::vector<int32_t>& codec_tokens,
                                               int32_t n_codebooks, int32_t n_frames) {
     if (!code2wav_) {
-        std::cerr << "[trtmc] Omni: no Code2Wav engine, generating simple waveform" << std::endl;
-        const int32_t samples_per_frame = config_->sample_rate / 75;
-        const int32_t total_samples = n_frames * samples_per_frame;
-        std::vector<float> waveform(static_cast<std::size_t>(total_samples), 0.0F);
-        for (int32_t f = 0; f < n_frames; ++f) {
-            const float freq = 200.0F + static_cast<float>(codec_tokens[f * n_codebooks]) * 800.0F /
-                                            static_cast<float>(config_->talker_codebook_size);
-            const float amp = 0.3F;
-            for (int32_t s = 0; s < samples_per_frame; ++s) {
-                const auto idx = static_cast<std::size_t>(f) * samples_per_frame + s;
-                const float t = static_cast<float>(s) / static_cast<float>(config_->sample_rate);
-                waveform[idx] = amp * std::sin(2.0F * 3.14159265F * freq * t);
-            }
-        }
-        return waveform;
+        throw std::runtime_error("OmniPipeline: required Code2Wav engine is unavailable");
     }
 
     const int32_t max_frames = config_->code2wav_max_frames;
     const int32_t actual_frames = std::min(n_frames, max_frames);
-    const int32_t upsample = config_->code2wav_upsample_factor;
 
     std::vector<int32_t> input_codes =
         build_omni_code2wav_input_codes(codec_tokens, n_codebooks, max_frames, actual_frames);
 
     Tensor codes_tensor;
     codes_tensor.data = input_codes.data();
-    codes_tensor.shape = {static_cast<int64_t>(n_codebooks), static_cast<int64_t>(max_frames)};
+    codes_tensor.shape = {1, static_cast<int64_t>(n_codebooks), static_cast<int64_t>(max_frames)};
     codes_tensor.dtype = DType::kInt32;
 
     TensorMap inputs;
@@ -234,9 +138,8 @@ std::vector<float> OmniPipeline::run_code2wav(const std::vector<int32_t>& codec_
 
     const auto& wt = it->second;
     const auto total_out = wt.numel();
-    const auto trimmed =
-        static_cast<std::size_t>(actual_frames) * static_cast<std::size_t>(upsample);
-    const auto copy_n = std::min(total_out, trimmed);
+    const auto copy_n =
+        code2wav_output_samples(*config_, actual_frames, static_cast<std::size_t>(total_out));
 
     std::vector<float> waveform(static_cast<std::size_t>(copy_n));
     std::memcpy(waveform.data(), wt.data, copy_n * sizeof(float));
@@ -249,7 +152,7 @@ std::vector<float> OmniPipeline::run_code2wav(const std::vector<int32_t>& codec_
 AudioResult OmniPipeline::generate_audio(const std::string& prompt, const GenerateConfig& cfg) {
     std::vector<int32_t> input_ids;
     if (tokenizer_)
-        input_ids = tokenizer_->encode(prompt);
+        input_ids = tokenizer_->encode(format_omni_chat_prompt(prompt));
 
     int32_t max_tokens = cfg.max_new_tokens > 0 ? cfg.max_new_tokens : 768;
 
@@ -259,26 +162,36 @@ AudioResult OmniPipeline::generate_audio(const std::string& prompt, const Genera
     std::cerr << "[trtmc] Omni: starting pipeline with " << input_ids.size() << " input tokens"
               << std::endl;
 
-    std::vector<float> hidden_states;
-    auto text_tokens = run_thinker(input_ids, max_tokens, hidden_states);
+    auto text_tokens = run_thinker(input_ids, max_tokens);
     if (text_tokens.empty()) {
         std::cerr << "[trtmc] Omni: Thinker produced no tokens" << std::endl;
         return result;
     }
 
-    const OmniTalkerPlan talker_plan =
-        make_omni_talker_plan(text_tokens.size(), hidden_states.size(), talker_ != nullptr);
-    if (talker_plan.should_run_talker) {
-        auto codec_tokens = run_talker(hidden_states, talker_plan.num_tokens);
+    if (!tokenizer_)
+        throw std::runtime_error("OmniPipeline: tokenizer is required for official Talker input");
+    const std::string assistant_text = tokenizer_->decode(text_tokens);
+    std::cerr << "[trtmc] Omni Thinker text: " << assistant_text << std::endl;
 
-        const OmniCodecPlan codec_plan = make_omni_codec_plan(*config_, codec_tokens.size());
-        if (codec_plan.should_run_codec) {
-            auto waveform = run_code2wav(codec_tokens, codec_plan.n_codebooks, codec_plan.n_frames);
-            if (!waveform.empty()) {
-                result.samples = std::move(waveform);
-                result.num_samples = static_cast<int32_t>(result.samples.size());
-            }
-        }
+    auto talker_result = run_qwen3_omni_official_talker(
+        config_->hf_python, config_->talker_model_id, config_->talker_model_revision, prompt,
+        assistant_text, config_->talker_n_codebooks, config_->code2wav_max_frames);
+    if (talker_result.exit_code != 0) {
+        throw std::runtime_error("OmniPipeline: official Talker failed: " +
+                                 talker_result.stderr_data);
+    }
+
+    const OmniCodecPlan codec_plan =
+        make_omni_codec_plan(*config_, talker_result.frame_major_codes.size());
+    if (!codec_plan.should_run_codec)
+        throw std::runtime_error("OmniPipeline: official Talker produced no codec frames");
+    std::cerr << "[trtmc] Omni official Talker: " << codec_plan.n_frames << " frames x "
+              << codec_plan.n_codebooks << " codebooks" << std::endl;
+    auto waveform =
+        run_code2wav(talker_result.frame_major_codes, codec_plan.n_codebooks, codec_plan.n_frames);
+    if (!waveform.empty()) {
+        result.samples = std::move(waveform);
+        result.num_samples = static_cast<int32_t>(result.samples.size());
     }
 
     std::cerr << "[trtmc] Omni: generated " << result.num_samples << " samples ("

--- a/src/runtime/models/qwen3_omni/pipeline.h
+++ b/src/runtime/models/qwen3_omni/pipeline.h
@@ -6,8 +6,8 @@
 #pragma once
 
 // OmniPipeline: omni multimodal pipeline with thinker + talker + code2wav.
-// Uses TrtModule(thinker) + Qwen3OmniKvCache + TrtModule(talker) + Qwen3OmniKvCache +
-// TrtModule(code2wav).
+// Uses a TensorRT Thinker, the checkpoint's official model-owned Talker bridge,
+// and a TensorRT Code2Wav decoder.
 
 #include "runtime/models/qwen3_omni/inference_state.h"
 #include "runtime/models/qwen3_omni/kv_cache.h"
@@ -28,8 +28,6 @@ class OmniPipeline final : public IPipeline {
   public:
     OmniPipeline(std::unique_ptr<TrtModule> thinker,
                  std::unique_ptr<Qwen3OmniInferenceState> thinker_state,
-                 std::unique_ptr<TrtModule> talker,
-                 std::unique_ptr<Qwen3OmniInferenceState> talker_state,
                  std::unique_ptr<TrtModule> code2wav, OmniConfig config, cudaStream_t stream,
                  std::shared_ptr<ITokenizer> tokenizer = nullptr, std::string model_id_str = "");
 
@@ -41,20 +39,13 @@ class OmniPipeline final : public IPipeline {
     const char* pipeline_type() const override { return "OmniPipeline"; }
 
   private:
-    void run_thinker_step(int32_t token_id, std::vector<float>& logits,
-                          std::vector<float>* hidden_state = nullptr);
-    void run_talker_embed_step(const float* embed_ptr, int32_t embed_size,
-                               std::vector<float>& logits);
-    std::vector<int32_t> run_thinker(const std::vector<int32_t>& input_ids, int32_t max_tokens,
-                                     std::vector<float>& hidden_states_out);
-    std::vector<int32_t> run_talker(const std::vector<float>& hidden_states, int32_t num_tokens);
+    void run_thinker_step(int32_t token_id, std::vector<float>& logits);
+    std::vector<int32_t> run_thinker(const std::vector<int32_t>& input_ids, int32_t max_tokens);
     std::vector<float> run_code2wav(const std::vector<int32_t>& codec_tokens, int32_t n_codebooks,
                                     int32_t n_frames);
 
     std::unique_ptr<TrtModule> thinker_;
     std::unique_ptr<Qwen3OmniInferenceState> thinker_state_;
-    std::unique_ptr<TrtModule> talker_;
-    std::unique_ptr<Qwen3OmniInferenceState> talker_state_;
     std::unique_ptr<TrtModule> code2wav_;
     std::unique_ptr<OmniConfig> config_;
     cudaStream_t stream_;

--- a/src/runtime/models/qwen3_omni/plugin.cpp
+++ b/src/runtime/models/qwen3_omni/plugin.cpp
@@ -4,13 +4,15 @@
  */
 
 // Qwen3OmniPlugin: handles "qwen3_omni_multimodal" strategy.
-// Omni pipeline with thinker (MoE decoder), optional talker, and optional code2wav.
+// Omni pipeline with TensorRT Thinker/Code2Wav and the official model-owned Talker bridge.
 
 #include "plugin_helpers.h"
 #include "runtime/models/qwen3_omni/pipeline.h"
 #include "runtime/models/qwen3_omni/recurrent_state.h"
 #include "trtmc/runtime/pipeline_registry.h"
 #include "utils/json_helpers.h"
+
+#include <cstdlib>
 
 namespace trtmc {
 
@@ -30,43 +32,25 @@ class Qwen3OmniPlugin final : public IPipelinePlugin {
             ctx.backend, find_section(ctx.bundle, "engine_plan"), "omni thinker", opts);
         cudaStream_t stream = thinker_loaded.module->stream();
         int32_t kv_dim = compute_kv_dim(ctx.config);
-        DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
+        // The cache allocation must follow the engine binding, not the bundle's
+        // requested precision. Legacy Qwen3-Omni builders emitted FP32 cache
+        // bindings even for a bundle labelled BF16; allocating BF16 here
+        // truncated every present K/V row and corrupted subsequent tokens.
+        DType cache_dtype = thinker_loaded.module->tensor_dtype("cache_k_0");
         std::unique_ptr<Qwen3OmniInferenceState> thinker_state = std::make_unique<Qwen3OmniKvCache>(
             ctx.config.num_layers, ctx.config.max_cache_length, kv_dim, stream, cache_dtype);
         if (!thinker_state->ok())
             throw std::runtime_error("OmniPipeline: failed to create thinker Qwen3OmniKvCache");
 
-        int32_t omni_talker_hidden_size = extract_json_int(json, "omni_talker_hidden_size", 0);
-        int32_t omni_talker_max_cache_length =
-            extract_json_int(json, "omni_talker_max_cache_length", 1024);
-        int32_t omni_talker_num_layers = extract_json_int(json, "omni_talker_num_layers", 0);
-
-        // Talker (optional)
-        std::unique_ptr<TrtModule> talker_module;
-        std::unique_ptr<Qwen3OmniInferenceState> talker_state;
-        auto talker_loaded = try_load_trt_module_from_plan(
-            ctx.backend, find_section(ctx.bundle, "talker_engine_plan"), "talker", opts);
-        if (talker_loaded.module && talker_loaded.module->ok()) {
-            talker_module = std::move(talker_loaded.module);
-            if (talker_module->has_input("cache_k_0")) {
-                int32_t talker_kv_dim = omni_talker_hidden_size;
-                int32_t talker_cache_len = omni_talker_max_cache_length;
-                int32_t talker_layers =
-                    omni_talker_num_layers > 0 ? omni_talker_num_layers : ctx.config.num_layers;
-                talker_state = std::make_unique<Qwen3OmniKvCache>(
-                    talker_layers, talker_cache_len, talker_kv_dim, stream, cache_dtype);
-            } else {
-                talker_state = std::make_unique<Qwen3OmniRecurrentState>(
-                    0, std::vector<Qwen3OmniRecurrentState::TensorSpec>{}, stream);
-            }
-        }
-
-        // Code2Wav (optional)
+        // Code2Wav is required for the audio-capable Qwen3-Omni bundle.
         std::unique_ptr<TrtModule> code2wav_module;
         auto code2wav_loaded = try_load_trt_module_from_plan(
             ctx.backend, find_section(ctx.bundle, "code2wav_engine_plan"), "code2wav", opts);
         if (code2wav_loaded.module && code2wav_loaded.module->ok())
             code2wav_module = std::move(code2wav_loaded.module);
+        if (!code2wav_module)
+            throw std::runtime_error(
+                "OmniPipeline: required official Code2Wav engine is missing from bundle");
 
         // Build OmniConfig
         OmniConfig omni_cfg;
@@ -76,17 +60,31 @@ class Qwen3OmniPlugin final : public IPipelinePlugin {
         omni_cfg.thinker_num_heads = ctx.config.num_heads;
         omni_cfg.num_experts = extract_json_int(json, "num_local_experts", 8);
         omni_cfg.num_experts_per_tok = extract_json_int(json, "num_experts_per_tok", 2);
-        omni_cfg.talker_hidden_size = omni_talker_hidden_size;
-        omni_cfg.talker_num_layers = omni_talker_num_layers;
-        omni_cfg.talker_n_codebooks = extract_json_int(json, "omni_n_codebooks", 8);
+        omni_cfg.talker_hidden_size = extract_json_int(json, "omni_talker_hidden_size", 0);
+        omni_cfg.talker_num_layers = extract_json_int(json, "omni_talker_num_layers", 0);
+        omni_cfg.talker_n_codebooks = extract_json_int(json, "omni_n_codebooks", 16);
         omni_cfg.talker_codebook_size = extract_json_int(json, "omni_codebook_size", 2048);
+        omni_cfg.code2wav_max_frames = extract_json_int(json, "omni_code2wav_max_frames", 32);
+        omni_cfg.code2wav_upsample_factor =
+            extract_json_int(json, "omni_code2wav_upsample_factor", 1920);
+        omni_cfg.code2wav_output_delay = extract_json_int(json, "omni_code2wav_output_delay", 555);
+        omni_cfg.hf_python = ctx.hf_python;
+        omni_cfg.talker_model_id = extract_json_string(
+            json, "omni_talker_model_id",
+            extract_json_string(json, "omni_talker_model_path", ctx.bundle.info.model_id));
+        omni_cfg.talker_model_revision =
+            extract_json_string(json, "omni_talker_model_revision", "");
+        if (const char* override_path = std::getenv("TRTMC_QWEN3_OMNI_MODEL_PATH");
+            override_path != nullptr && override_path[0] != '\0') {
+            omni_cfg.talker_model_id = override_path;
+            omni_cfg.talker_model_revision.clear();
+        }
 
         auto tokenizer = create_tokenizer_from_bundle(ctx.bundle);
 
         return std::make_unique<OmniPipeline>(
-            std::move(thinker_loaded.module), std::move(thinker_state), std::move(talker_module),
-            std::move(talker_state), std::move(code2wav_module), std::move(omni_cfg), stream,
-            std::move(tokenizer), ctx.bundle.info.model_id);
+            std::move(thinker_loaded.module), std::move(thinker_state), std::move(code2wav_module),
+            std::move(omni_cfg), stream, std::move(tokenizer), ctx.bundle.info.model_id);
     }
 };
 

--- a/src/runtime/models/qwen3_omni/talker_runtime.cpp
+++ b/src/runtime/models/qwen3_omni/talker_runtime.cpp
@@ -1,0 +1,239 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/qwen3_omni/talker_runtime.h"
+
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <poll.h>
+#include <stdexcept>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace trtmc {
+namespace {
+
+using Pipe = std::array<int, 2>;
+
+struct ProcessPipes {
+    Pipe input{-1, -1};
+    Pipe output{-1, -1};
+    Pipe error{-1, -1};
+};
+
+void close_fd(int& fd) {
+    if (fd >= 0) {
+        close(fd);
+        fd = -1;
+    }
+}
+
+void close_all(ProcessPipes& pipes) {
+    for (Pipe* pipe : {&pipes.input, &pipes.output, &pipes.error}) {
+        close_fd((*pipe)[0]);
+        close_fd((*pipe)[1]);
+    }
+}
+
+bool open_all(ProcessPipes& pipes) {
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, pipes.input.data()) != 0)
+        return false;
+    for (Pipe* pipe : {&pipes.output, &pipes.error}) {
+        if (::pipe(pipe->data()) != 0) {
+            close_all(pipes);
+            return false;
+        }
+    }
+    return true;
+}
+
+void append_u32_le(std::vector<char>& output, std::uint32_t value) {
+    for (int shift = 0; shift < 32; shift += 8)
+        output.push_back(static_cast<char>((value >> shift) & 0xffU));
+}
+
+std::vector<char> make_request(const std::string& prompt, const std::string& assistant_text) {
+    if (prompt.size() > UINT32_MAX || assistant_text.size() > UINT32_MAX)
+        throw std::runtime_error("Qwen3-Omni Talker request text is too large");
+    std::vector<char> request;
+    request.reserve(8 + prompt.size() + assistant_text.size());
+    append_u32_le(request, static_cast<std::uint32_t>(prompt.size()));
+    append_u32_le(request, static_cast<std::uint32_t>(assistant_text.size()));
+    request.insert(request.end(), prompt.begin(), prompt.end());
+    request.insert(request.end(), assistant_text.begin(), assistant_text.end());
+    return request;
+}
+
+bool send_all(int fd, const std::vector<char>& data) {
+    std::size_t offset = 0;
+    while (offset < data.size()) {
+        const auto count = send(fd, data.data() + offset, data.size() - offset, MSG_NOSIGNAL);
+        if (count < 0 && errno == EINTR)
+            continue;
+        if (count <= 0)
+            return false;
+        offset += static_cast<std::size_t>(count);
+    }
+    return true;
+}
+
+void read_ready_fd(pollfd& descriptor, std::vector<char>& output) {
+    char buffer[65536];
+    for (;;) {
+        const auto count = read(descriptor.fd, buffer, sizeof(buffer));
+        if (count > 0) {
+            output.insert(output.end(), buffer, buffer + count);
+        } else if (count == 0) {
+            close(descriptor.fd);
+            descriptor.fd = -1;
+        } else if (errno != EINTR && errno != EAGAIN) {
+            close(descriptor.fd);
+            descriptor.fd = -1;
+        }
+        return;
+    }
+}
+
+[[noreturn]] void exec_child(ProcessPipes& pipes, const std::vector<std::string>& argv) {
+    if (dup2(pipes.input[0], STDIN_FILENO) < 0 || dup2(pipes.output[1], STDOUT_FILENO) < 0 ||
+        dup2(pipes.error[1], STDERR_FILENO) < 0) {
+        _exit(127);
+    }
+    close_all(pipes);
+
+    std::vector<char*> child_argv;
+    child_argv.reserve(argv.size() + 1);
+    for (const auto& argument : argv)
+        child_argv.push_back(const_cast<char*>(argument.c_str()));
+    child_argv.push_back(nullptr);
+    execvp(child_argv[0], child_argv.data());
+    _exit(127);
+}
+
+void drain_output(ProcessPipes& pipes, std::vector<char>& stdout_data,
+                  std::vector<char>& stderr_data) {
+    pollfd descriptors[2] = {
+        {pipes.output[0], POLLIN, 0},
+        {pipes.error[0], POLLIN, 0},
+    };
+    while (descriptors[0].fd >= 0 || descriptors[1].fd >= 0) {
+        const int ready = poll(descriptors, 2, -1);
+        if (ready < 0 && errno == EINTR)
+            continue;
+        if (ready < 0)
+            break;
+        for (int index = 0; index < 2; ++index) {
+            if (descriptors[index].fd >= 0 &&
+                (descriptors[index].revents & (POLLIN | POLLHUP | POLLERR))) {
+                read_ready_fd(descriptors[index], index == 0 ? stdout_data : stderr_data);
+            }
+        }
+    }
+    close_fd(descriptors[0].fd);
+    close_fd(descriptors[1].fd);
+    pipes.output[0] = -1;
+    pipes.error[0] = -1;
+}
+
+int wait_for_child(pid_t pid) {
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno != EINTR)
+            return -1;
+    }
+    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+}
+
+int run_process(const std::vector<std::string>& argv, const std::vector<char>& input,
+                std::vector<char>& stdout_data, std::vector<char>& stderr_data) {
+    ProcessPipes pipes;
+    if (!open_all(pipes))
+        return -1;
+
+    const pid_t pid = fork();
+    if (pid < 0) {
+        close_all(pipes);
+        return -1;
+    }
+    if (pid == 0)
+        exec_child(pipes, argv);
+
+    close_fd(pipes.input[0]);
+    close_fd(pipes.output[1]);
+    close_fd(pipes.error[1]);
+    const bool wrote_request = send_all(pipes.input[1], input);
+    close_fd(pipes.input[1]);
+    drain_output(pipes, stdout_data, stderr_data);
+    const int exit_code = wait_for_child(pid);
+    close_all(pipes);
+    if (!wrote_request)
+        return -1;
+    return exit_code;
+}
+
+std::vector<std::string> make_talker_argv(const std::string& hf_python, const std::string& model_id,
+                                          const std::string& model_revision, int32_t max_frames) {
+    std::vector<std::string> argv = {
+        hf_python,
+        "-m",
+        "tensorrt_model_connect.families.qwen3_omni.audio_runtime",
+        "--model-id",
+        model_id,
+        "--max-frames",
+        std::to_string(max_frames),
+    };
+    if (!model_revision.empty()) {
+        argv.emplace_back("--revision");
+        argv.push_back(model_revision);
+    }
+    return argv;
+}
+
+} // namespace
+
+Qwen3OmniTalkerRuntimeResult
+run_qwen3_omni_official_talker(const std::string& hf_python, const std::string& model_id,
+                               const std::string& model_revision, const std::string& prompt,
+                               const std::string& assistant_text, int32_t n_codebooks,
+                               int32_t max_frames) {
+    Qwen3OmniTalkerRuntimeResult result;
+    if (hf_python.empty()) {
+        result.stderr_data = "--hf-python is required for the official Qwen3-Omni Talker";
+        return result;
+    }
+    if (model_id.empty() || n_codebooks <= 0 || max_frames <= 0) {
+        result.stderr_data = "invalid Qwen3-Omni official Talker runtime configuration";
+        return result;
+    }
+
+    const auto argv = make_talker_argv(hf_python, model_id, model_revision, max_frames);
+    std::vector<char> stdout_data;
+    std::vector<char> stderr_data;
+    result.exit_code =
+        run_process(argv, make_request(prompt, assistant_text), stdout_data, stderr_data);
+    result.stderr_data.assign(stderr_data.begin(), stderr_data.end());
+    if (result.exit_code != 0)
+        return result;
+    if (stdout_data.empty() || stdout_data.size() % sizeof(int32_t) != 0) {
+        result.exit_code = -1;
+        result.stderr_data += "\nQwen3-Omni official Talker returned an invalid binary payload";
+        return result;
+    }
+
+    result.frame_major_codes.resize(stdout_data.size() / sizeof(int32_t));
+    std::memcpy(result.frame_major_codes.data(), stdout_data.data(), stdout_data.size());
+    if (result.frame_major_codes.size() % static_cast<std::size_t>(n_codebooks) != 0 ||
+        result.frame_major_codes.size() >
+            static_cast<std::size_t>(n_codebooks) * static_cast<std::size_t>(max_frames)) {
+        result.exit_code = -1;
+        result.frame_major_codes.clear();
+        result.stderr_data += "\nQwen3-Omni official Talker returned an invalid codec shape";
+    }
+    return result;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/qwen3_omni/talker_runtime.h
+++ b/src/runtime/models/qwen3_omni/talker_runtime.h
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace trtmc {
+
+struct Qwen3OmniTalkerRuntimeResult {
+    int exit_code{-1};
+    std::vector<int32_t> frame_major_codes;
+    std::string stderr_data;
+};
+
+Qwen3OmniTalkerRuntimeResult
+run_qwen3_omni_official_talker(const std::string& hf_python, const std::string& model_id,
+                               const std::string& model_revision, const std::string& prompt,
+                               const std::string& assistant_text, int32_t n_codebooks,
+                               int32_t max_frames);
+
+} // namespace trtmc

--- a/tests/cpp/models/qwen3_omni/test_qwen3_omni_audio_plan.cpp
+++ b/tests/cpp/models/qwen3_omni/test_qwen3_omni_audio_plan.cpp
@@ -9,10 +9,9 @@
 // Trace ID:       UT-AUD-CPP-09
 // Architecture:   ARCH-FAC-001
 // Unit Design:    UD-AUD-01
-// Intent:         Omni audio plan: encode padding/trimming, generation gating, codec decode
+// Intent:         Omni audio plan: encode padding/trimming and official codec decode
 // Preconditions:  OmniConfig with valid audio parameters
-// Postconditions: Frames padded/trimmed correctly, talker/codec gates match config, codebook argmax
-// correct
+// Postconditions: Frames padded/trimmed correctly and codec tensor/sample contracts hold
 // =============================================================================
 
 #include "runtime/models/qwen3_omni/omni_audio_plan.h"
@@ -62,36 +61,12 @@ void test_audio_encode_input_builder_zero_pads_tail() {
     check(padded[6] == 0.0F && padded.back() == 0.0F, "omni input builder zero-pads unused tail");
 }
 
-void test_generation_plans_gate_talker_and_codec() {
+void test_codec_plan_derives_official_frame_shape() {
     const trtmc::OmniConfig cfg = make_config();
-    const auto talker_plan = trtmc::make_omni_talker_plan(5, 0, true);
-    check(!talker_plan.should_run_talker, "omni talker plan requires hidden states");
-
-    const auto active_talker_plan = trtmc::make_omni_talker_plan(5, 10, true);
-    check(active_talker_plan.should_run_talker, "omni talker plan enables active talker stage");
-    check(active_talker_plan.num_tokens == 5, "omni talker plan forwards token count");
-
     const auto codec_plan = trtmc::make_omni_codec_plan(cfg, 8);
     check(codec_plan.should_run_codec, "omni codec plan enables codec with token payload");
     check(codec_plan.n_codebooks == 4, "omni codec plan forwards codebook count");
     check(codec_plan.n_frames == 2, "omni codec plan derives frame count");
-}
-
-void test_talker_decode_helpers_extract_codebook_argmax() {
-    const auto decode_plan = trtmc::make_omni_talker_decode_plan(2, 4, 3);
-    std::vector<int32_t> all_codes;
-    const std::vector<float> logits = {
-        0.1F, 0.4F, 0.3F, 0.2F, 0.0F, 1.0F, 0.5F, 0.6F,
-    };
-
-    trtmc::append_omni_talker_codes_from_logits(logits, decode_plan, all_codes);
-
-    check(decode_plan.num_tokens == 3, "omni talker decode plan forwards token count");
-    check(all_codes.size() == 2, "omni talker decode helper appends one code per codebook");
-    check(all_codes[0] == 1 && all_codes[1] == 1,
-          "omni talker decode helper selects argmax in each codebook slice");
-    check(trtmc::select_omni_codebook_argmax(logits, 20, 4) == 0,
-          "omni talker argmax helper returns zero for out-of-range slices");
 }
 
 void test_code2wav_input_builder_transposes_frame_major_tokens() {
@@ -111,14 +86,27 @@ void test_code2wav_input_builder_transposes_frame_major_tokens() {
           "omni code2wav input builder zero-pads trailing frames");
 }
 
+void test_code2wav_output_uses_official_stride_and_causal_delay() {
+    trtmc::OmniConfig cfg;
+    cfg.code2wav_upsample_factor = 1920;
+    cfg.code2wav_output_delay = 555;
+
+    check(trtmc::code2wav_output_samples(cfg, 16, 60885) == 30165,
+          "omni code2wav output trims the official causal decoder delay");
+    check(trtmc::code2wav_output_samples(cfg, 32, 60885) == 60885,
+          "omni code2wav output preserves the full static engine result");
+    check(trtmc::code2wav_output_samples(cfg, 0, 60885) == 0,
+          "omni code2wav output rejects zero frames");
+}
+
 } // namespace
 
 int main() {
     test_audio_encode_plan_pads_and_trims_frames();
     test_audio_encode_input_builder_zero_pads_tail();
-    test_generation_plans_gate_talker_and_codec();
-    test_talker_decode_helpers_extract_codebook_argmax();
+    test_codec_plan_derives_official_frame_shape();
     test_code2wav_input_builder_transposes_frame_major_tokens();
+    test_code2wav_output_uses_official_stride_and_causal_delay();
 
     if (g_failures != 0) {
         std::cerr << g_failures << " omni audio plan test(s) failed\n";

--- a/tests/cpp/models/qwen3_omni/test_qwen3_omni_pipeline.cpp
+++ b/tests/cpp/models/qwen3_omni/test_qwen3_omni_pipeline.cpp
@@ -56,8 +56,8 @@ void test_omni_pipeline_construction() {
     check(thinker_cache->ok(), "omni thinker cache ok");
 
     trtmc::OmniConfig cfg;
-    trtmc::OmniPipeline pipeline(std::move(thinker), std::move(thinker_cache), nullptr, nullptr,
-                                 nullptr, cfg, stream, nullptr, "test-omni");
+    trtmc::OmniPipeline pipeline(std::move(thinker), std::move(thinker_cache), nullptr, cfg, stream,
+                                 nullptr, "test-omni");
 
     check(std::string(pipeline.pipeline_type()) == "OmniPipeline", "OmniPipeline: pipeline_type");
     check(std::string(pipeline.model_id()) == "test-omni", "OmniPipeline: model_id");
@@ -81,9 +81,8 @@ void test_omni_generate_audio() {
     auto thinker_cache = std::make_unique<trtmc::Qwen3OmniKvCache>(0, 8, 0, stream);
 
     trtmc::OmniConfig cfg;
-    trtmc::OmniPipeline pipeline(std::move(thinker), std::move(thinker_cache), nullptr, nullptr,
-                                 nullptr, cfg, stream, std::make_shared<OmniFixedTokenizer>(),
-                                 "test-omni-gen");
+    trtmc::OmniPipeline pipeline(std::move(thinker), std::move(thinker_cache), nullptr, cfg, stream,
+                                 std::make_shared<OmniFixedTokenizer>(), "test-omni-gen");
 
     trtmc::GenerateConfig gen_cfg;
     gen_cfg.max_new_tokens = 1;
@@ -102,8 +101,7 @@ void test_omni_validates_thinker() {
         cudaStream_t stream;
         cudaStreamCreate(&stream);
         trtmc::OmniConfig cfg;
-        trtmc::OmniPipeline p(nullptr, nullptr, nullptr, nullptr, nullptr, cfg, stream, nullptr,
-                              "x");
+        trtmc::OmniPipeline p(nullptr, nullptr, nullptr, cfg, stream, nullptr, "x");
         check(false, "null thinker should throw");
         cudaStreamDestroy(stream);
     } catch (const std::exception&) {

--- a/tests/e2e/models/qwen3_omni/MODEL.toml
+++ b/tests/e2e/models/qwen3_omni/MODEL.toml
@@ -9,7 +9,7 @@ test_manifests = [
 
 [e2e_defaults.omni_multimodal]
 reference_backend = "torch_reference"
-oracle_level = "L4_invariants"
+oracle_level = "L3_snapshot_regression"
 stages = [
   { name = "thinker_decode", required = true },
   { name = "vision_encode", required = false },

--- a/tests/e2e/models/qwen3_omni/data/qwen3_omni_hf_reference.json
+++ b/tests/e2e/models/qwen3_omni/data/qwen3_omni_hf_reference.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "source": "official_hugging_face_qwen3_omni",
-  "reference_role": "human_review_only",
-  "comparison_mode": "invariant_only",
+  "reference_role": "automated_waveform_oracle",
+  "comparison_mode": "waveform_cosine_and_invariants",
   "model_id": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
   "resolved_revision": "26291f793822fb6be9555850f06dfe95f2d7e695",
   "transformers_version": "5.2.0",

--- a/tests/e2e/models/qwen3_omni/e2e_plugins/comparators/omni.py
+++ b/tests/e2e/models/qwen3_omni/e2e_plugins/comparators/omni.py
@@ -4,21 +4,106 @@
 """Omni-multimodal comparator — compare TRT vs reference multi-branch outputs.
 
 Metrics per branch: thinker token agreement, vision/audio embedding cosine,
-talker token match, code2wav spectral distance, e2e text edit distance.
+talker audio validity and duration, and e2e text edit distance.
 """
 
 from __future__ import annotations
 
 import logging
+import struct
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import numpy as np
 
-from ..contracts import CompareResult, MetricResult, StageOutput, StageSpec, StageStatus, ThresholdProfile
+from ..contracts import (
+    CompareResult,
+    MetricResult,
+    StageOutput,
+    StageSpec,
+    StageStatus,
+    ThresholdProfile,
+)
 from ._helpers import cosine_similarity, normalized_edit_distance
 
 logger = logging.getLogger(__name__)
+
+_SIMPLE_WAVEFORM_FALLBACK = "no Code2Wav engine, generating simple waveform"
+
+
+def _read_wav(path: Path) -> tuple[dict[str, Any], str]:
+    """Read the PCM16 reference or IEEE-float32 product WAV."""
+    try:
+        payload = path.read_bytes()
+    except OSError as exc:
+        return {}, f"invalid WAV: {exc}"
+
+    if len(payload) < 12 or payload[:4] != b"RIFF" or payload[8:12] != b"WAVE":
+        return {}, "invalid WAV: missing RIFF/WAVE header"
+
+    fmt: bytes | None = None
+    audio: bytes | None = None
+    offset = 12
+    while offset + 8 <= len(payload):
+        chunk_name = payload[offset : offset + 4]
+        chunk_size = struct.unpack_from("<I", payload, offset + 4)[0]
+        chunk_start = offset + 8
+        chunk_end = chunk_start + chunk_size
+        if chunk_end > len(payload):
+            return {}, f"truncated WAV chunk {chunk_name!r}"
+        if chunk_name == b"fmt ":
+            fmt = payload[chunk_start:chunk_end]
+        elif chunk_name == b"data":
+            audio = payload[chunk_start:chunk_end]
+        offset = chunk_end + (chunk_size & 1)
+
+    if fmt is None or len(fmt) < 16 or audio is None:
+        return {}, "invalid WAV: missing fmt or data chunk"
+
+    audio_format, channels, sample_rate, _byte_rate, block_align, bits_per_sample = (
+        struct.unpack_from("<HHIIHH", fmt)
+    )
+    sample_width = bits_per_sample // 8
+    expected_block_align = channels * sample_width
+    encoding = {
+        (1, 16): "pcm_s16le",
+        (3, 32): "ieee_float32le",
+    }.get((audio_format, bits_per_sample), "unsupported")
+    if (
+        channels != 1
+        or sample_rate < 1
+        or block_align != expected_block_align
+        or expected_block_align < 1
+        or not audio
+        or len(audio) % expected_block_align != 0
+        or encoding == "unsupported"
+    ):
+        return {
+            "channels": channels,
+            "sample_width_bytes": sample_width,
+            "sample_rate_hz": sample_rate,
+            "num_samples": len(audio) // expected_block_align if expected_block_align > 0 else 0,
+            "encoding": encoding,
+        }, "WAV must be non-empty mono PCM16 or IEEE float32"
+
+    num_samples = len(audio) // expected_block_align
+    if encoding == "pcm_s16le":
+        samples = np.frombuffer(audio, dtype="<i2").astype(np.float32) / 32768.0
+    else:
+        samples = np.frombuffer(audio, dtype="<f4").astype(np.float32)
+        if not np.all(np.isfinite(samples)):
+            return {}, "IEEE float32 WAV contains non-finite samples"
+    return {
+        "channels": channels,
+        "sample_width_bytes": sample_width,
+        "encoding": encoding,
+        "sample_rate_hz": sample_rate,
+        "num_samples": num_samples,
+        "duration_s": num_samples / sample_rate,
+        "rms": float(np.sqrt(np.mean(np.square(samples)))),
+        "peak": float(np.max(np.abs(samples))),
+        "samples": samples,
+    }, ""
 
 
 def _is_invariant_only(ref: StageOutput) -> bool:
@@ -60,7 +145,7 @@ class OmniComparator:
         th = threshold.metrics
 
         if _is_invariant_only(ref):
-            return self._compare_invariants(trt, stage)
+            return self._compare_invariants(trt, ref, th, stage)
 
         # Dispatch to stage-specific comparison
         if stage_name == "thinker_decode":
@@ -75,8 +160,11 @@ class OmniComparator:
             return self._compare_generic(trt, ref, th, stage)
 
     def _compare_thinker(
-        self, trt: StageOutput, ref: StageOutput,
-        th: Dict[str, float], stage: StageSpec,
+        self,
+        trt: StageOutput,
+        ref: StageOutput,
+        th: Dict[str, float],
+        stage: StageSpec,
     ) -> CompareResult:
         """Compare thinker text decoding output."""
         trt_tokens = trt.data.get("token_ids", [])
@@ -88,7 +176,8 @@ class OmniComparator:
             agreement = _token_agreement(trt_tokens, ref_tokens)
             thresh = th.get("thinker_token_agreement", 0.8)
             metrics["thinker_token_agreement"] = MetricResult(
-                value=agreement, threshold=thresh, operator=">=", passed=agreement >= thresh)
+                value=agreement, threshold=thresh, operator=">=", passed=agreement >= thresh
+            )
 
         trt_text = trt.text or ""
         ref_text = ref.text or ""
@@ -96,7 +185,8 @@ class OmniComparator:
             ned = normalized_edit_distance(trt_text, ref_text)
             thresh = th.get("thinker_text_edit_distance", 0.3)
             metrics["thinker_text_edit_distance"] = MetricResult(
-                value=ned, threshold=thresh, operator="<=", passed=ned <= thresh)
+                value=ned, threshold=thresh, operator="<=", passed=ned <= thresh
+            )
 
         passed = all(m.passed for m in metrics.values()) if metrics else False
         return CompareResult(
@@ -108,8 +198,11 @@ class OmniComparator:
         )
 
     def _compare_encoder(
-        self, trt: StageOutput, ref: StageOutput,
-        th: Dict[str, float], stage: StageSpec,
+        self,
+        trt: StageOutput,
+        ref: StageOutput,
+        th: Dict[str, float],
+        stage: StageSpec,
     ) -> CompareResult:
         """Compare vision/audio encoder embedding output."""
         trt_emb = trt.data.get("embedding", [])
@@ -133,11 +226,14 @@ class OmniComparator:
         branch = stage.name.replace("_encode", "")
         metric_name = f"{branch}_embedding_cosine"
         # Look up threshold: canonical name -> stage-based name -> generic fallback
-        thresh = th.get(metric_name, th.get(
-            f"{stage.name}_embedding_cosine", th.get("encoder_embedding_cosine", 0.95)))
+        thresh = th.get(
+            metric_name,
+            th.get(f"{stage.name}_embedding_cosine", th.get("encoder_embedding_cosine", 0.95)),
+        )
         metrics: Dict[str, MetricResult] = {
             metric_name: MetricResult(
-                value=cosine, threshold=thresh, operator=">=", passed=cosine >= thresh),
+                value=cosine, threshold=thresh, operator=">=", passed=cosine >= thresh
+            ),
         }
 
         passed = all(m.passed for m in metrics.values())
@@ -150,8 +246,11 @@ class OmniComparator:
         )
 
     def _compare_talker(
-        self, trt: StageOutput, ref: StageOutput,
-        th: Dict[str, float], stage: StageSpec,
+        self,
+        trt: StageOutput,
+        ref: StageOutput,
+        th: Dict[str, float],
+        stage: StageSpec,
     ) -> CompareResult:
         """Compare talker decoding output (tokens and/or audio)."""
         metrics: Dict[str, MetricResult] = {}
@@ -163,7 +262,8 @@ class OmniComparator:
             agreement = _token_agreement(trt_tokens, ref_tokens)
             thresh = th.get("talker_token_match", 0.7)
             metrics["talker_token_match"] = MetricResult(
-                value=agreement, threshold=thresh, operator=">=", passed=agreement >= thresh)
+                value=agreement, threshold=thresh, operator=">=", passed=agreement >= thresh
+            )
 
         passed = all(m.passed for m in metrics.values()) if metrics else True
         return CompareResult(
@@ -175,8 +275,11 @@ class OmniComparator:
         )
 
     def _compare_e2e(
-        self, trt: StageOutput, ref: StageOutput,
-        th: Dict[str, float], stage: StageSpec,
+        self,
+        trt: StageOutput,
+        ref: StageOutput,
+        th: Dict[str, float],
+        stage: StageSpec,
     ) -> CompareResult:
         """Compare end-to-end omni output (text edit distance)."""
         trt_text = trt.text or ""
@@ -186,7 +289,8 @@ class OmniComparator:
         thresh = th.get("e2e_text_edit_distance", 0.3)
         metrics: Dict[str, MetricResult] = {
             "e2e_text_edit_distance": MetricResult(
-                value=ned, threshold=thresh, operator="<=", passed=ned <= thresh),
+                value=ned, threshold=thresh, operator="<=", passed=ned <= thresh
+            ),
         }
 
         passed = all(m.passed for m in metrics.values())
@@ -199,8 +303,11 @@ class OmniComparator:
         )
 
     def _compare_generic(
-        self, trt: StageOutput, ref: StageOutput,
-        th: Dict[str, float], stage: StageSpec,
+        self,
+        trt: StageOutput,
+        ref: StageOutput,
+        th: Dict[str, float],
+        stage: StageSpec,
     ) -> CompareResult:
         """Fallback: compare any stage with available data."""
         # Try embedding comparison
@@ -223,26 +330,147 @@ class OmniComparator:
     def _compare_invariants(
         self,
         trt: StageOutput,
+        ref: StageOutput,
+        th: Dict[str, float],
         stage: StageSpec,
     ) -> CompareResult:
-        """L4 invariant checks for omni stages without a strong reference."""
+        """L4 invariants, calibrated by pinned HF audio shape when available."""
         metrics: Dict[str, MetricResult] = {}
 
         if stage.name == "talker_decode":
             audio_path = str(trt.metadata.get("audio_output_path", "") or "")
             audio_size = 0
+            wav_evidence: dict[str, Any] = {}
+            wav_error = "audio artifact is missing"
             if audio_path:
                 path = Path(audio_path)
                 if path.is_file():
                     audio_size = path.stat().st_size
-            has_audio = audio_size > 0
+                    wav_evidence, wav_error = _read_wav(path)
+            bytes_min = th.get("audio_artifact_bytes_min", 44.0)
             metrics["audio_artifact_bytes"] = MetricResult(
                 value=float(audio_size),
-                threshold=1.0,
+                threshold=bytes_min,
                 operator=">=",
-                passed=has_audio,
-                note="generated audio artifact is non-empty",
+                passed=audio_size >= bytes_min,
+                note="generated audio artifact includes a WAV header and PCM payload",
             )
+            metrics["audio_wav_valid"] = MetricResult(
+                value=1.0 if not wav_error else 0.0,
+                threshold=1.0,
+                operator="==",
+                passed=not wav_error,
+                note=wav_error or "audio artifact is a complete PCM WAV",
+            )
+
+            fallback_used = _SIMPLE_WAVEFORM_FALLBACK in str(trt.metadata.get("stderr", "") or "")
+            metrics["simple_waveform_fallback_absent"] = MetricResult(
+                value=0.0 if fallback_used else 1.0,
+                threshold=1.0,
+                operator="==",
+                passed=not fallback_used,
+                note="Code2Wav synthetic fallback must never certify",
+            )
+
+            if wav_evidence:
+                channels = int(wav_evidence.get("channels", 0))
+                encoding = str(wav_evidence.get("encoding", ""))
+                sample_rate = int(wav_evidence.get("sample_rate_hz", 0))
+                num_samples = int(wav_evidence.get("num_samples", 0))
+                duration_s = float(wav_evidence.get("duration_s", 0.0))
+                rms = float(wav_evidence.get("rms", 0.0))
+                peak = float(wav_evidence.get("peak", 0.0))
+                ref_sample_rate = int((ref.data or {}).get("sample_rate", 0))
+                ref_num_samples = int((ref.data or {}).get("num_samples", 0))
+                duration_ratio = num_samples / ref_num_samples if ref_num_samples > 0 else 0.0
+                duration_min = th.get("audio_duration_s_min", 0.5)
+                duration_ratio_min = th.get("audio_reference_duration_ratio_min", 0.5)
+                rms_min = th.get("audio_rms_min", 0.005)
+                peak_min = th.get("audio_peak_min", 0.02)
+                metrics.update(
+                    {
+                        "audio_channels": MetricResult(
+                            value=float(channels),
+                            threshold=1.0,
+                            operator="==",
+                            passed=channels == 1,
+                        ),
+                        "audio_encoding_supported": MetricResult(
+                            value=1.0 if encoding in ("pcm_s16le", "ieee_float32le") else 0.0,
+                            threshold=1.0,
+                            operator="==",
+                            passed=encoding in ("pcm_s16le", "ieee_float32le"),
+                            note=f"decoded {encoding}",
+                        ),
+                        "audio_sample_rate_hz": MetricResult(
+                            value=float(sample_rate),
+                            threshold=float(ref_sample_rate),
+                            operator="==",
+                            passed=ref_sample_rate > 0 and sample_rate == ref_sample_rate,
+                            note="must match the pinned official-HF reference",
+                        ),
+                        "audio_duration_s": MetricResult(
+                            value=duration_s,
+                            threshold=duration_min,
+                            operator=">=",
+                            passed=duration_s >= duration_min,
+                        ),
+                        "audio_reference_duration_ratio": MetricResult(
+                            value=duration_ratio,
+                            threshold=duration_ratio_min,
+                            operator=">=",
+                            passed=duration_ratio >= duration_ratio_min,
+                            note=f"TRT samples={num_samples}, HF samples={ref_num_samples}",
+                        ),
+                        "audio_rms": MetricResult(
+                            value=rms,
+                            threshold=rms_min,
+                            operator=">=",
+                            passed=rms >= rms_min,
+                        ),
+                        "audio_peak": MetricResult(
+                            value=peak,
+                            threshold=peak_min,
+                            operator=">=",
+                            passed=peak >= peak_min,
+                        ),
+                    }
+                )
+                waveform_cosine_min = th.get("audio_reference_waveform_cosine_min", 0.25)
+                reference_path = Path(str((ref.data or {}).get("wav_path", "") or ""))
+                waveform_cosine = 0.0
+                waveform_note = "pinned official-HF waveform is missing or invalid"
+                if reference_path.is_file():
+                    reference_evidence, reference_error = _read_wav(reference_path)
+                    if not reference_error and reference_evidence:
+                        actual_samples = np.asarray(wav_evidence["samples"], dtype=np.float32)
+                        reference_samples = np.asarray(
+                            reference_evidence["samples"], dtype=np.float32
+                        )
+                        common_samples = min(actual_samples.size, reference_samples.size)
+                        actual_common = actual_samples[:common_samples]
+                        reference_common = reference_samples[:common_samples]
+                        denominator = float(
+                            np.linalg.norm(actual_common) * np.linalg.norm(reference_common)
+                        )
+                        waveform_cosine = (
+                            float(np.dot(actual_common, reference_common) / denominator)
+                            if denominator > 0.0
+                            else 0.0
+                        )
+                        waveform_note = (
+                            f"compared {common_samples} aligned PCM samples against the "
+                            "pinned official-HF waveform"
+                        )
+                    else:
+                        waveform_note = f"invalid pinned official-HF waveform: {reference_error}"
+                metrics["audio_reference_waveform_cosine"] = MetricResult(
+                    value=waveform_cosine,
+                    threshold=waveform_cosine_min,
+                    operator=">=",
+                    passed=waveform_cosine >= waveform_cosine_min,
+                    note=waveform_note,
+                )
         elif stage.name in ("thinker_decode", "end_to_end"):
             text = trt.text or str(trt.data.get("text", "") or "")
             if not text:
@@ -257,8 +485,7 @@ class OmniComparator:
             )
         else:
             has_output = bool(trt.text) or any(
-                value not in ("", None, [], {})
-                for value in (trt.data or {}).values()
+                value not in ("", None, [], {}) for value in (trt.data or {}).values()
             )
             metrics["non_empty_output"] = MetricResult(
                 value=1.0 if has_output else 0.0,

--- a/tests/e2e/models/qwen3_omni/e2e_plugins/references/torch_reference.py
+++ b/tests/e2e/models/qwen3_omni/e2e_plugins/references/torch_reference.py
@@ -44,9 +44,7 @@ def _load_snapshot(path: Path) -> dict[str, Any]:
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        raise RuntimeError(
-            f"Qwen3-Omni HF snapshot could not be read at {path}: {exc}"
-        ) from exc
+        raise RuntimeError(f"Qwen3-Omni HF snapshot could not be read at {path}: {exc}") from exc
     return _require_mapping(raw, "root")
 
 
@@ -54,19 +52,20 @@ def _validate_provenance(case: E2ECase, snapshot: dict[str, Any]) -> None:
     expected = {
         "schema_version": SNAPSHOT_SCHEMA_VERSION,
         "source": "official_hugging_face_qwen3_omni",
-        "reference_role": "human_review_only",
-        "comparison_mode": "invariant_only",
+        "reference_role": "automated_waveform_oracle",
+        "comparison_mode": "waveform_cosine_and_invariants",
         "model_id": case.hf_id,
         "system_prompt": QWEN_AUDIO_SYSTEM_PROMPT,
         "prompt": str(case.inputs.get("prompt", "") or "").strip(),
         "speaker": str(case.metadata.get("reference_speaker", DEFAULT_SPEAKER)),
-        "seed": int(case.inputs.get(
-            "seed", case.determinism.get("seed", DEFAULT_SEED))),
+        "seed": int(case.inputs.get("seed", case.determinism.get("seed", DEFAULT_SEED))),
         "thinker_max_new_tokens": int(case.inputs.get("max_new_tokens", 16)),
-        "talker_max_new_tokens": int(case.metadata.get(
-            "reference_talker_max_new_tokens",
-            DEFAULT_TALKER_MAX_NEW_TOKENS,
-        )),
+        "talker_max_new_tokens": int(
+            case.metadata.get(
+                "reference_talker_max_new_tokens",
+                DEFAULT_TALKER_MAX_NEW_TOKENS,
+            )
+        ),
         "thinker_do_sample": False,
         "talker_do_sample": False,
     }
@@ -93,34 +92,26 @@ def _validate_provenance(case: E2ECase, snapshot: dict[str, Any]) -> None:
 def _decode_audio(snapshot: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:
     audio = _require_mapping(snapshot.get("audio"), "audio")
     if audio.get("encoding") != "gzip+base64" or audio.get("format") != "wav":
-        raise RuntimeError(
-            "Qwen3-Omni HF snapshot audio must use gzip+base64 WAV encoding"
-        )
+        raise RuntimeError("Qwen3-Omni HF snapshot audio must use gzip+base64 WAV encoding")
     chunks = audio.get("gzip_base64_chunks")
     if (
         not isinstance(chunks, list)
         or not chunks
         or any(not isinstance(chunk, str) or not chunk for chunk in chunks)
     ):
-        raise RuntimeError(
-            "Qwen3-Omni HF snapshot audio chunks must be non-empty strings"
-        )
+        raise RuntimeError("Qwen3-Omni HF snapshot audio chunks must be non-empty strings")
 
     try:
         compressed = base64.b64decode("".join(chunks), validate=True)
     except (binascii.Error, ValueError) as exc:
-        raise RuntimeError(
-            f"Qwen3-Omni HF snapshot audio is not valid base64: {exc}"
-        ) from exc
+        raise RuntimeError(f"Qwen3-Omni HF snapshot audio is not valid base64: {exc}") from exc
     if not compressed or len(compressed) > MAX_COMPRESSED_BYTES:
         raise RuntimeError(
             "Qwen3-Omni HF snapshot compressed audio size is outside the "
             f"allowed range: {len(compressed)} bytes"
         )
     if len(compressed) != audio.get("gzip_bytes"):
-        raise RuntimeError(
-            "Qwen3-Omni HF snapshot compressed audio size does not match provenance"
-        )
+        raise RuntimeError("Qwen3-Omni HF snapshot compressed audio size does not match provenance")
     compressed_sha = hashlib.sha256(compressed).hexdigest()
     if compressed_sha != audio.get("gzip_sha256"):
         raise RuntimeError(
@@ -130,23 +121,16 @@ def _decode_audio(snapshot: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:
     try:
         wav_bytes = gzip.decompress(compressed)
     except (OSError, EOFError) as exc:
-        raise RuntimeError(
-            f"Qwen3-Omni HF snapshot audio is not valid gzip data: {exc}"
-        ) from exc
+        raise RuntimeError(f"Qwen3-Omni HF snapshot audio is not valid gzip data: {exc}") from exc
     if not wav_bytes or len(wav_bytes) > MAX_WAV_BYTES:
         raise RuntimeError(
-            "Qwen3-Omni HF snapshot WAV size is outside the allowed range: "
-            f"{len(wav_bytes)} bytes"
+            f"Qwen3-Omni HF snapshot WAV size is outside the allowed range: {len(wav_bytes)} bytes"
         )
     if len(wav_bytes) != audio.get("raw_bytes"):
-        raise RuntimeError(
-            "Qwen3-Omni HF snapshot WAV size does not match provenance"
-        )
+        raise RuntimeError("Qwen3-Omni HF snapshot WAV size does not match provenance")
     wav_sha = hashlib.sha256(wav_bytes).hexdigest()
     if wav_sha != audio.get("raw_sha256"):
-        raise RuntimeError(
-            "Qwen3-Omni HF snapshot WAV SHA-256 does not match provenance"
-        )
+        raise RuntimeError("Qwen3-Omni HF snapshot WAV SHA-256 does not match provenance")
     return wav_bytes, audio
 
 
@@ -186,7 +170,7 @@ def _validate_wav(path: Path, audio: dict[str, Any]) -> tuple[int, int]:
 
 
 class TorchReference:
-    """Materialize pinned official HF audio while preserving the L4 gate."""
+    """Materialize pinned official HF audio for the waveform-regression gate."""
 
     @property
     def backend_name(self) -> str:
@@ -194,9 +178,7 @@ class TorchReference:
         # provenance-checked snapshot rather than a per-CI 30B model load.
         return "torch_reference"
 
-    def run_stage(
-        self, case: E2ECase, stage: StageSpec, ctx: RunContext
-    ) -> StageOutput:
+    def run_stage(self, case: E2ECase, stage: StageSpec, ctx: RunContext) -> StageOutput:
         if case.task_strategy != "omni_multimodal" or stage.name != "talker_decode":
             return StageOutput(
                 stage_name=stage.name,
@@ -208,9 +190,7 @@ class TorchReference:
 
         snapshot_value = case.metadata.get("golden_snapshot_path", "")
         if not snapshot_value:
-            raise RuntimeError(
-                "Qwen3-Omni HF audio reference requires golden_snapshot_path"
-            )
+            raise RuntimeError("Qwen3-Omni HF audio reference requires golden_snapshot_path")
         snapshot_path = Path(str(snapshot_value))
         if not snapshot_path.is_absolute():
             snapshot_path = Path(__file__).resolve().parents[2] / snapshot_path
@@ -220,8 +200,7 @@ class TorchReference:
         _validate_provenance(case, snapshot)
         wav_bytes, audio = _decode_audio(snapshot)
 
-        model_dir = Path(_case_artifact_dir(
-            ctx.artifacts_dir or tempfile.gettempdir(), case.name))
+        model_dir = Path(_case_artifact_dir(ctx.artifacts_dir or tempfile.gettempdir(), case.name))
         wav_path = model_dir / "hf_reference.wav"
         wav_path.write_bytes(wav_bytes)
         sample_rate, num_samples = _validate_wav(wav_path, audio)
@@ -235,7 +214,7 @@ class TorchReference:
             "num_samples": num_samples,
             "duration_s": num_samples / sample_rate,
             "decoded_text": str(snapshot.get("decoded_text", "") or ""),
-            "reference_role": "human_review_only",
+            "reference_role": "automated_waveform_oracle",
             "system_prompt": QWEN_AUDIO_SYSTEM_PROMPT,
             "prompt": str(snapshot["prompt"]),
             "speaker": str(snapshot["speaker"]),
@@ -254,14 +233,14 @@ class TorchReference:
             timing_s=elapsed,
             metadata={
                 "backend": "torch_reference",
-                "source": "official_hf_pinned_human_review",
-                "comparison_mode": "invariant_only",
+                "source": "official_hf_pinned_waveform_oracle",
+                "comparison_mode": "waveform_cosine_and_invariants",
                 "snapshot_path": str(snapshot_path),
                 "resolved_revision": data["resolved_revision"],
                 "raw_sha256": data["raw_sha256"],
                 "note": (
-                    "Pinned official HF WAV is human-review evidence; the "
-                    "automated gate remains L4 TRT invariants."
+                    "Pinned official HF WAV gates aligned waveform cosine plus "
+                    "the L4 TRT audio invariants."
                 ),
             },
         )

--- a/tests/e2e/models/qwen3_omni/e2e_plugins/runners/omni.py
+++ b/tests/e2e/models/qwen3_omni/e2e_plugins/runners/omni.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_RUNTIME_TIMEOUT_S = 600
 _MAX_RUNTIME_TIMEOUT_S = 3600
+_SIMPLE_WAVEFORM_FALLBACK = "no Code2Wav engine, generating simple waveform"
 
 
 def _runtime_timeout_s(case: E2ECase) -> int:
@@ -63,17 +64,18 @@ class OmniMultimodalRunner:
     def strategy_name(self) -> str:
         return "qwen3_omni_multimodal"
 
-    def run_stage(
-        self, case: E2ECase, stage: StageSpec, ctx: RunContext
-    ) -> StageOutput:
+    def run_stage(self, case: E2ECase, stage: StageSpec, ctx: RunContext) -> StageOutput:
         stage_name = stage.name
 
         cmd, stage_meta = _build_omni_command(case, stage, ctx)
         if cmd is None:
             return StageOutput(
                 stage_name=stage_name,
-                metadata={"error": stage_meta.get("error", "Unsupported stage"),
-                          "skipped": True, **stage_meta},
+                metadata={
+                    "error": stage_meta.get("error", "Unsupported stage"),
+                    "skipped": True,
+                    **stage_meta,
+                },
             )
 
         runtime_cli_python = ctx.runtime_cli_hf_python()
@@ -89,7 +91,11 @@ class OmniMultimodalRunner:
         t0 = time.monotonic()
         try:
             result = subprocess.run(
-                cmd, capture_output=True, text=True, env=env, timeout=timeout_s,
+                cmd,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=timeout_s,
             )
         except subprocess.TimeoutExpired as exc:
             elapsed = time.monotonic() - t0
@@ -116,13 +122,18 @@ class OmniMultimodalRunner:
 
         if result.returncode != 0:
             truncated, log_path = save_full_stderr(
-                result.stderr, ctx.artifacts_dir or "",
-                f"omni_{stage_name}", case.name)
-            msg = (f"Omni stage {stage_name} failed (rc={result.returncode}): "
-                   f"{truncated}")
+                result.stderr, ctx.artifacts_dir or "", f"omni_{stage_name}", case.name
+            )
+            msg = f"Omni stage {stage_name} failed (rc={result.returncode}): {truncated}"
             if log_path:
                 msg += f" (full stderr: {log_path})"
             raise RuntimeError(msg)
+
+        if stage_name == "talker_decode" and _SIMPLE_WAVEFORM_FALLBACK in (result.stderr or ""):
+            raise RuntimeError(
+                "Qwen3-Omni talker_decode used the synthetic simple-waveform "
+                "fallback because the Code2Wav engine is missing"
+            )
 
         data = _parse_stage_output(result.stdout.strip(), stage_name)
 
@@ -152,9 +163,7 @@ class CompositePipelineRunner:
     def strategy_name(self) -> str:
         return "composite_pipeline"
 
-    def run_stage(
-        self, case: E2ECase, stage: StageSpec, ctx: RunContext
-    ) -> StageOutput:
+    def run_stage(self, case: E2ECase, stage: StageSpec, ctx: RunContext) -> StageOutput:
         stage_name = stage.name
 
         cmd, stage_meta = _build_composite_command(case, stage, ctx)
@@ -170,16 +179,19 @@ class CompositePipelineRunner:
         logger.info("Running composite stage %s: %s", stage_name, " ".join(cmd))
         t0 = time.monotonic()
         result = subprocess.run(
-            cmd, capture_output=True, text=True, env=env, timeout=600,
+            cmd,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=600,
         )
         elapsed = time.monotonic() - t0
 
         if result.returncode != 0:
             truncated, log_path = save_full_stderr(
-                result.stderr, ctx.artifacts_dir or "",
-                f"composite_{stage_name}", case.name)
-            msg = (f"Composite stage {stage_name} failed (rc={result.returncode}): "
-                   f"{truncated}")
+                result.stderr, ctx.artifacts_dir or "", f"composite_{stage_name}", case.name
+            )
+            msg = f"Composite stage {stage_name} failed (rc={result.returncode}): {truncated}"
             if log_path:
                 msg += f" (full stderr: {log_path})"
             raise RuntimeError(msg)
@@ -226,10 +238,12 @@ def _build_omni_command(
 
     if stage_name == "vision_encode":
         if not image:
-            stage_meta.update({
-                "error": "vision_encode requires image input",
-                "stage_resolution": "unsupported_missing_image",
-            })
+            stage_meta.update(
+                {
+                    "error": "vision_encode requires image input",
+                    "stage_resolution": "unsupported_missing_image",
+                }
+            )
             return None, stage_meta
         cmd = [ctx.binary_path, "embed", bundle_path, "--image", str(image)]
         if prompt:
@@ -239,10 +253,12 @@ def _build_omni_command(
 
     if stage_name == "audio_encode":
         if not audio:
-            stage_meta.update({
-                "error": "audio_encode requires audio input",
-                "stage_resolution": "unsupported_missing_audio",
-            })
+            stage_meta.update(
+                {
+                    "error": "audio_encode requires audio input",
+                    "stage_resolution": "unsupported_missing_audio",
+                }
+            )
             return None, stage_meta
         cmd = [ctx.binary_path, "transcribe", bundle_path, "--audio", str(audio)]
         if max_new_tokens > 0:
@@ -257,9 +273,13 @@ def _build_omni_command(
             "talker_decode.wav",
         )
         cmd = [
-            ctx.binary_path, "generate-audio", bundle_path,
-            "--prompt", str(prompt),
-            "--output", out_audio,
+            ctx.binary_path,
+            "generate-audio",
+            bundle_path,
+            "--prompt",
+            str(prompt),
+            "--output",
+            out_audio,
         ]
         if max_new_tokens > 0:
             cmd.extend(["--max-new-tokens", str(max_new_tokens)])
@@ -273,9 +293,13 @@ def _build_omni_command(
             "talker_decode.wav",
         )
         cmd = [
-            ctx.binary_path, "speak", bundle_path,
-            "--audio-in", str(audio),
-            "--audio-out", out_audio,
+            ctx.binary_path,
+            "speak",
+            bundle_path,
+            "--audio-in",
+            str(audio),
+            "--audio-out",
+            out_audio,
         ]
         if max_new_tokens > 0:
             cmd.extend(["--max-new-tokens", str(max_new_tokens)])
@@ -288,9 +312,7 @@ def _build_omni_command(
         cmd.extend(["--prompt", str(prompt)])
     if image and stage_name == "end_to_end":
         cmd.extend(["--image", str(image)])
-    if max_new_tokens > 0 and stage_name in (
-        "thinker_decode", "talker_decode", "end_to_end"
-    ):
+    if max_new_tokens > 0 and stage_name in ("thinker_decode", "talker_decode", "end_to_end"):
         cmd.extend(["--max-new-tokens", str(max_new_tokens)])
     stage_meta["entrypoint"] = "run"
     if stage_name not in ("thinker_decode", "talker_decode", "end_to_end"):

--- a/tests/e2e/models/qwen3_omni/manifests/qwen3-omni-30b-a3b-instruct.json
+++ b/tests/e2e/models/qwen3_omni/manifests/qwen3-omni-30b-a3b-instruct.json
@@ -15,7 +15,7 @@
       "name": "qwen3-omni-30b-a3b-instruct",
       "trace_id": "IT-E2E-QWEN3-OMNI-01",
       "reference_backend": "torch_reference",
-      "oracle_level": "L4_invariants",
+      "oracle_level": "L3_snapshot_regression",
       "golden_snapshot_path": "data/qwen3_omni_hf_reference.json",
       "user_contract": "tts_audio",
       "prompt": "Please say hello from Qwen3 Omni in one short sentence.",
@@ -26,12 +26,15 @@
       "seed": 42,
       "reference_speaker": "Ethan",
       "reference_talker_max_new_tokens": 32,
+      "metadata": {
+        "runtime_cli_requires_hf_python": true
+      },
       "stages": [
         {
           "name": "talker_decode",
           "required": true,
           "artifact_type": "waveform",
-          "comparison_mode": "invariant_check"
+          "comparison_mode": "waveform_cosine_and_invariants"
         }
       ]
     }

--- a/tests/e2e/models/qwen3_omni/test_hidden_state_flow.py
+++ b/tests/e2e/models/qwen3_omni/test_hidden_state_flow.py
@@ -8,49 +8,46 @@ ROOT = Path(__file__).resolve().parents[4]
 
 
 def test_qwen3_omni_thinker_marks_hidden_state_output() -> None:
-    source = (
-        ROOT
-        / "python/tensorrt_model_connect/families/qwen3_omni/plugin.py"
-    ).read_text()
+    source = (ROOT / "python/tensorrt_model_connect/families/qwen3_omni/plugin.py").read_text()
 
     assert 'hidden_out.name = "hidden_state"' in source
     assert "network.mark_output(hidden_out)" in source
 
 
-def test_qwen3_omni_runtime_feeds_generated_hidden_states_to_talker() -> None:
+def test_qwen3_omni_runtime_feeds_generated_text_to_official_talker() -> None:
     source = (ROOT / "src/runtime/models/qwen3_omni/pipeline.cpp").read_text()
 
-    assert 'outputs.find("hidden_state")' in source
-    assert "hidden_states_out.insert" in source
-    assert "run_thinker_step(token, logits, &hidden_state)" in source
+    assert "tokenizer_->decode(text_tokens)" in source
+    assert "run_qwen3_omni_official_talker" in source
+    assert "format_omni_chat_prompt(prompt)" in source
+    assert "token == config_->thinker_eos_token_id" in source
+    assert 'outputs.find("hidden_state")' not in source
 
 
 def test_qwen3_omni_detects_real_talker_checkpoint_keys() -> None:
-    source = (
-        ROOT
-        / "python/tensorrt_model_connect/families/qwen3_omni/plugin.py"
-    ).read_text()
+    source = (ROOT / "python/tensorrt_model_connect/families/qwen3_omni/plugin.py").read_text()
 
     assert "talker.model.codec_embedding.weight" in source
     assert "talker.code_predictor.lm_head" in source
     assert "num_code_groups" in source
 
 
-def test_qwen3_omni_builds_stateless_talker_projection() -> None:
-    source = (
-        ROOT
-        / "python/tensorrt_model_connect/families/qwen3_omni/plugin.py"
-    ).read_text()
+def test_qwen3_omni_does_not_build_incomplete_talker_projection() -> None:
+    source = (ROOT / "python/tensorrt_model_connect/families/qwen3_omni/plugin.py").read_text()
 
-    assert "talker.hidden_projection.linear_fc1.weight" in source
-    assert "talker.hidden_projection.linear_fc2.weight" in source
-    assert "talker.codec_head.weight" in source
-    assert 'input_embed", trt.float32' in source
-    assert "network.add_concatenation(head_parts)" in source
+    assert "def _build_talker_engine" not in source
+    assert 'result["talker_engine_plan"]' not in source
+    assert "def _build_code2wav_engine" in source
 
 
-def test_qwen3_omni_runtime_allows_stateless_talker_engine() -> None:
+def test_qwen3_omni_runtime_requires_official_code2wav_and_python_talker() -> None:
     source = (ROOT / "src/runtime/models/qwen3_omni/plugin.cpp").read_text()
+    builder = (ROOT / "python/tensorrt_model_connect/families/qwen3_omni/plugin.py").read_text()
 
-    assert 'talker_module->has_input("cache_k_0")' in source
-    assert "std::make_unique<Qwen3OmniRecurrentState>" in source
+    assert "required official Code2Wav engine is missing" in source
+    assert "omni_cfg.hf_python = ctx.hf_python" in source
+    assert 'tensor_dtype("cache_k_0")' in source
+    assert '"omni_talker_model_id"' in source
+    assert 'overrides["omni_talker_model_id"] = self._talker_model_id' in builder
+    assert 'overrides["omni_talker_model_revision"]' in builder
+    assert 'find_section(ctx.bundle, "talker_engine_plan")' not in source

--- a/tests/e2e/models/qwen3_omni/test_qwen3_omni_audio_runtime.py
+++ b/tests/e2e/models/qwen3_omni/test_qwen3_omni_audio_runtime.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from tensorrt_model_connect.families.qwen3_omni.audio_runtime import (
+    TalkerRequest,
+    _chatml,
+    _read_request,
+)
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.qwen3_omni.plugin import (
+    Qwen3OmniPlugin,
+    _talker_model_locator,
+)
+
+
+def _payload(prompt: str, assistant: str) -> bytes:
+    prompt_bytes = prompt.encode("utf-8")
+    assistant_bytes = assistant.encode("utf-8")
+    return (
+        struct.pack("<II", len(prompt_bytes), len(assistant_bytes)) + prompt_bytes + assistant_bytes
+    )
+
+
+def test_talker_request_preserves_prompt_and_trims_generated_stop_marker() -> None:
+    request = _read_request(_payload("Say hello.", "Hello from Qwen-Omni!<|im_end|>ignored"))
+
+    assert request == TalkerRequest(prompt="Say hello.", assistant_text="Hello from Qwen-Omni!")
+
+
+def test_talker_request_rejects_empty_assistant_text() -> None:
+    with pytest.raises(ValueError, match="no speakable assistant text"):
+        _read_request(_payload("Say hello.", "<|im_end|>"))
+
+
+def test_talker_request_rejects_truncated_payload() -> None:
+    with pytest.raises(ValueError, match="expected"):
+        _read_request(struct.pack("<II", 3, 4) + b"abc")
+
+
+def test_talker_chatml_contains_model_roles_and_exact_text() -> None:
+    rendered = _chatml(TalkerRequest(prompt="question", assistant_text="answer"))
+
+    assert "<|im_start|>system\n" in rendered
+    assert "<|im_start|>user\nquestion<|im_end|>" in rendered
+    assert "<|im_start|>assistant\nanswer<|im_end|>" in rendered
+
+
+def test_talker_model_locator_pins_hugging_face_snapshot(tmp_path) -> None:
+    snapshot = tmp_path / "models--Qwen--Qwen3-Omni-30B-A3B-Instruct" / "snapshots" / "abc123"
+    snapshot.mkdir(parents=True)
+
+    assert _talker_model_locator(snapshot) == (
+        "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+        "abc123",
+    )
+
+
+def test_talker_model_locator_preserves_deliberate_local_directory(tmp_path) -> None:
+    model_dir = tmp_path / "local-model"
+    model_dir.mkdir()
+
+    assert _talker_model_locator(model_dir) == (str(model_dir.resolve()), "")
+
+
+def test_bundle_config_persists_portable_talker_locator() -> None:
+    plugin = Qwen3OmniPlugin()
+    plugin._talker_model_id = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    plugin._talker_model_revision = "abc123"
+
+    overrides = plugin.get_bundle_config_overrides(ModelConfig.create_tiny("qwen3_omni"))
+
+    assert overrides["omni_talker_model_id"] == "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    assert overrides["omni_talker_model_revision"] == "abc123"

--- a/tests/e2e/models/qwen3_omni/test_qwen3_omni_comparator.py
+++ b/tests/e2e/models/qwen3_omni/test_qwen3_omni_comparator.py
@@ -5,6 +5,10 @@
 
 from __future__ import annotations
 
+import math
+import struct
+import wave
+
 from tests.e2e.models.qwen3_omni.e2e_plugins.comparators.omni import OmniComparator
 from tests.e2e_harness.contracts import (
     StageOutput,
@@ -17,27 +21,114 @@ from tests.e2e_harness.contracts import (
 def _invariant_ref(stage_name: str) -> StageOutput:
     return StageOutput(
         stage_name=stage_name,
-        data={"_invariant_only": True},
+        data={
+            "_invariant_only": True,
+            "sample_rate": 24_000,
+            "num_samples": 37_845,
+        },
         metadata={"source": "invariant_only"},
     )
 
 
-def test_omni_invariant_talker_requires_non_empty_audio(tmp_path) -> None:
+def _write_wav(path, *, num_samples: int, amplitude: float = 0.2) -> None:
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(24_000)
+        samples = (
+            int(amplitude * 32767 * math.sin(2 * math.pi * 440 * i / 24_000))
+            for i in range(num_samples)
+        )
+        wav_file.writeframes(b"".join(struct.pack("<h", sample) for sample in samples))
+
+
+def _write_float32_wav(path, *, num_samples: int, amplitude: float = 0.2) -> None:
+    samples = b"".join(
+        struct.pack("<f", amplitude * math.sin(2 * math.pi * 440 * i / 24_000))
+        for i in range(num_samples)
+    )
+    data_size = len(samples)
+    path.write_bytes(
+        b"RIFF"
+        + struct.pack("<I", 36 + data_size)
+        + b"WAVEfmt "
+        + struct.pack("<IHHIIHH", 16, 3, 1, 24_000, 24_000 * 4, 4, 32)
+        + b"data"
+        + struct.pack("<I", data_size)
+        + samples
+    )
+
+
+def _threshold() -> ThresholdProfile:
+    return ThresholdProfile(
+        task_strategy="omni_multimodal",
+        metrics={
+            "audio_artifact_bytes_min": 44.0,
+            "audio_duration_s_min": 0.5,
+            "audio_reference_duration_ratio_min": 0.5,
+            "audio_rms_min": 0.005,
+            "audio_peak_min": 0.02,
+            "audio_reference_waveform_cosine_min": 0.25,
+        },
+    )
+
+
+def test_omni_invariant_talker_requires_meaningful_audio(tmp_path) -> None:
     audio = tmp_path / "talker.wav"
-    audio.write_bytes(b"RIFFaudio")
+    _write_wav(audio, num_samples=24_000)
+    reference = _invariant_ref("talker_decode")
+    reference.data["wav_path"] = str(audio)
 
     result = OmniComparator().compare(
         StageOutput(
             stage_name="talker_decode",
             metadata={"audio_output_path": str(audio)},
         ),
-        _invariant_ref("talker_decode"),
-        ThresholdProfile(task_strategy="omni_multimodal"),
+        reference,
+        _threshold(),
         StageSpec(name="talker_decode"),
     )
 
     assert result.status == StageStatus.PASSED.value
     assert result.metrics["audio_artifact_bytes"].passed is True
+    assert result.metrics["audio_wav_valid"].passed is True
+    assert result.metrics["audio_reference_duration_ratio"].passed is True
+    assert result.metrics["audio_rms"].passed is True
+
+
+def test_omni_invariant_talker_accepts_product_float32_wav(tmp_path) -> None:
+    audio = tmp_path / "talker.wav"
+    reference_audio = tmp_path / "reference.wav"
+    _write_float32_wav(audio, num_samples=24_000)
+    _write_wav(reference_audio, num_samples=24_000)
+    reference = _invariant_ref("talker_decode")
+    reference.data["wav_path"] = str(reference_audio)
+
+    result = OmniComparator().compare(
+        StageOutput(stage_name="talker_decode", metadata={"audio_output_path": str(audio)}),
+        reference,
+        _threshold(),
+        StageSpec(name="talker_decode"),
+    )
+
+    assert result.status == StageStatus.PASSED.value
+    assert result.metrics["audio_wav_valid"].passed is True
+    assert result.metrics["audio_encoding_supported"].passed is True
+
+
+def test_omni_waveform_oracle_fails_closed_without_reference_audio(tmp_path) -> None:
+    audio = tmp_path / "talker.wav"
+    _write_wav(audio, num_samples=24_000)
+
+    result = OmniComparator().compare(
+        StageOutput(stage_name="talker_decode", metadata={"audio_output_path": str(audio)}),
+        _invariant_ref("talker_decode"),
+        _threshold(),
+        StageSpec(name="talker_decode"),
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert result.metrics["audio_reference_waveform_cosine"].passed is False
 
 
 def test_omni_invariant_talker_fails_without_audio(tmp_path) -> None:
@@ -47,12 +138,106 @@ def test_omni_invariant_talker_fails_without_audio(tmp_path) -> None:
             metadata={"audio_output_path": str(tmp_path / "missing.wav")},
         ),
         _invariant_ref("talker_decode"),
-        ThresholdProfile(task_strategy="omni_multimodal"),
+        _threshold(),
         StageSpec(name="talker_decode"),
     )
 
     assert result.status == StageStatus.FAILED.value
     assert result.metrics["audio_artifact_bytes"].passed is False
+
+
+def test_omni_invariant_talker_rejects_non_wav_bytes(tmp_path) -> None:
+    audio = tmp_path / "talker.wav"
+    audio.write_bytes(b"RIFFaudio")
+
+    result = OmniComparator().compare(
+        StageOutput(
+            stage_name="talker_decode",
+            metadata={"audio_output_path": str(audio)},
+        ),
+        _invariant_ref("talker_decode"),
+        _threshold(),
+        StageSpec(name="talker_decode"),
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert result.metrics["audio_wav_valid"].passed is False
+
+
+def test_omni_invariant_talker_rejects_short_fallback_waveform(tmp_path) -> None:
+    audio = tmp_path / "talker.wav"
+    _write_wav(audio, num_samples=5_120)
+
+    result = OmniComparator().compare(
+        StageOutput(
+            stage_name="talker_decode",
+            metadata={
+                "audio_output_path": str(audio),
+                "stderr": ("[trtmc] Omni: no Code2Wav engine, generating simple waveform\n"),
+            },
+        ),
+        _invariant_ref("talker_decode"),
+        _threshold(),
+        StageSpec(name="talker_decode"),
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert result.metrics["simple_waveform_fallback_absent"].passed is False
+    assert result.metrics["audio_duration_s"].passed is False
+    assert result.metrics["audio_reference_duration_ratio"].passed is False
+
+
+def test_omni_invariant_talker_rejects_silent_audio(tmp_path) -> None:
+    audio = tmp_path / "talker.wav"
+    _write_wav(audio, num_samples=24_000, amplitude=0.0)
+
+    result = OmniComparator().compare(
+        StageOutput(
+            stage_name="talker_decode",
+            metadata={"audio_output_path": str(audio)},
+        ),
+        _invariant_ref("talker_decode"),
+        _threshold(),
+        StageSpec(name="talker_decode"),
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert result.metrics["audio_rms"].passed is False
+    assert result.metrics["audio_peak"].passed is False
+
+
+def test_omni_invariant_talker_compares_pinned_reference_waveform(tmp_path) -> None:
+    reference = tmp_path / "reference.wav"
+    matching = tmp_path / "matching.wav"
+    unrelated = tmp_path / "unrelated.wav"
+    _write_wav(reference, num_samples=24_000)
+    _write_wav(matching, num_samples=24_000)
+    with wave.open(str(unrelated), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(24_000)
+        samples = (
+            int(0.2 * 32767 * math.sin(2 * math.pi * 880 * i / 24_000)) for i in range(24_000)
+        )
+        wav_file.writeframes(b"".join(struct.pack("<h", sample) for sample in samples))
+
+    reference_output = _invariant_ref("talker_decode")
+    reference_output.data["wav_path"] = str(reference)
+    matching_result = OmniComparator().compare(
+        StageOutput(stage_name="talker_decode", metadata={"audio_output_path": str(matching)}),
+        reference_output,
+        _threshold(),
+        StageSpec(name="talker_decode"),
+    )
+    unrelated_result = OmniComparator().compare(
+        StageOutput(stage_name="talker_decode", metadata={"audio_output_path": str(unrelated)}),
+        reference_output,
+        _threshold(),
+        StageSpec(name="talker_decode"),
+    )
+
+    assert matching_result.metrics["audio_reference_waveform_cosine"].passed is True
+    assert unrelated_result.metrics["audio_reference_waveform_cosine"].passed is False
 
 
 def test_omni_invariant_text_stage_requires_non_empty_output() -> None:

--- a/tests/e2e/models/qwen3_omni/test_qwen3_omni_reference.py
+++ b/tests/e2e/models/qwen3_omni/test_qwen3_omni_reference.py
@@ -19,9 +19,7 @@ from tests.e2e_harness.manifest_loader import get_case_by_name
 MODEL_DIR = Path(__file__).resolve().parent
 SNAPSHOT_PATH = MODEL_DIR / "data" / "qwen3_omni_hf_reference.json"
 OFFICIAL_PROMPT = "Please say hello from Qwen3 Omni in one short sentence."
-EXPECTED_WAV_SHA256 = (
-    "2648af9d3de015de2e7c73f829e374b95f287a9c5e1c548569a33068e8aa99ef"
-)
+EXPECTED_WAV_SHA256 = "2648af9d3de015de2e7c73f829e374b95f287a9c5e1c548569a33068e8aa99ef"
 
 
 def _case(
@@ -36,7 +34,7 @@ def _case(
         runtime_strategy="qwen3_omni_multimodal",
         task_strategy="omni_multimodal",
         reference_backend="torch_reference",
-        oracle_level="L4_invariants",
+        oracle_level="L3_snapshot_regression",
         inputs={"prompt": prompt, "max_new_tokens": 16, "seed": 42},
         determinism={"seed": 42, "reruns": 0},
         metadata={
@@ -47,17 +45,25 @@ def _case(
     )
 
 
-def test_manifest_uses_pinned_hf_evidence_without_strengthening_l4_oracle() -> None:
+def test_manifest_uses_pinned_hf_waveform_as_l4_oracle() -> None:
     case = get_case_by_name("qwen3-omni-30b-a3b-instruct", MODEL_DIR)
 
     assert case is not None
     assert case.reference_backend == "torch_reference"
-    assert case.oracle_level == "L4_invariants"
+    assert case.oracle_level == "L3_snapshot_regression"
     assert case.inputs["prompt"] == OFFICIAL_PROMPT
     assert case.inputs["seed"] == 42
     assert case.metadata["reference_speaker"] == "Ethan"
     assert case.metadata["reference_talker_max_new_tokens"] == 32
     assert Path(case.metadata["golden_snapshot_path"]) == SNAPSHOT_PATH
+    assert case.threshold_overrides == {
+        "audio_artifact_bytes_min": 44.0,
+        "audio_duration_s_min": 0.5,
+        "audio_reference_duration_ratio_min": 0.5,
+        "audio_rms_min": 0.005,
+        "audio_peak_min": 0.02,
+        "audio_reference_waveform_cosine_min": 0.25,
+    }
     assert any(
         requirement.kind == "asset_exists"
         and Path(requirement.args["path"]) == SNAPSHOT_PATH
@@ -83,19 +89,17 @@ def test_pinned_reference_materializes_case_local_playable_hf_audio(
 
     expected_wav = tmp_path / "artifacts" / case.name / "hf_reference.wav"
     assert output.data["_invariant_only"] is True
-    assert output.data["reference_role"] == "human_review_only"
+    assert output.data["reference_role"] == "automated_waveform_oracle"
     assert output.data["wav_path"] == str(expected_wav)
     assert output.data["sample_rate"] == 24_000
     assert output.data["num_samples"] == 37_845
     assert output.data["duration_s"] == pytest.approx(1.576875)
     assert output.data["decoded_text"] == "Hello from Qwen-Omni!"
-    assert output.data["resolved_revision"] == (
-        "26291f793822fb6be9555850f06dfe95f2d7e695"
-    )
+    assert output.data["resolved_revision"] == ("26291f793822fb6be9555850f06dfe95f2d7e695")
     assert output.data["raw_sha256"] == EXPECTED_WAV_SHA256
     assert output.text == "Hello from Qwen-Omni!"
-    assert output.metadata["source"] == "official_hf_pinned_human_review"
-    assert output.metadata["comparison_mode"] == "invariant_only"
+    assert output.metadata["source"] == "official_hf_pinned_waveform_oracle"
+    assert output.metadata["comparison_mode"] == "waveform_cosine_and_invariants"
     assert hashlib.sha256(expected_wav.read_bytes()).hexdigest() == EXPECTED_WAV_SHA256
     assert output.timing_s >= 0.0
 
@@ -128,9 +132,9 @@ def test_snapshot_records_complete_generation_provenance() -> None:
 def test_reference_rejects_prompt_drift(tmp_path: Path) -> None:
     case = _case(prompt="A different prompt")
 
-    with pytest.raises(RuntimeError, match=(
-        r"provenance mismatch for prompt: expected 'A different prompt', got "
-    )):
+    with pytest.raises(
+        RuntimeError, match=(r"provenance mismatch for prompt: expected 'A different prompt', got ")
+    ):
         torch_reference.TorchReference().run_stage(
             case,
             StageSpec(name="talker_decode"),

--- a/tests/e2e/models/qwen3_omni/test_qwen3_omni_runner.py
+++ b/tests/e2e/models/qwen3_omni/test_qwen3_omni_runner.py
@@ -53,8 +53,7 @@ def test_thinker_stage_drops_unsupported_stage_flag(monkeypatch, tmp_path) -> No
 
     monkeypatch.setattr(omni.subprocess, "run", _fake_run)
 
-    out = omni.OmniMultimodalRunner().run_stage(
-        case, StageSpec(name="thinker_decode"), ctx)
+    out = omni.OmniMultimodalRunner().run_stage(case, StageSpec(name="thinker_decode"), ctx)
 
     cmd = captured["cmd"]
     assert cmd[1] == "run"
@@ -75,12 +74,12 @@ def test_vision_stage_maps_to_embed_without_stage_flag(monkeypatch, tmp_path) ->
     def _fake_run(cmd, **kwargs):
         captured["cmd"] = cmd
         return subprocess.CompletedProcess(
-            cmd, 0, stdout='{"embedding": [0.1, 0.2], "dim": 2}\n', stderr="")
+            cmd, 0, stdout='{"embedding": [0.1, 0.2], "dim": 2}\n', stderr=""
+        )
 
     monkeypatch.setattr(omni.subprocess, "run", _fake_run)
 
-    out = omni.OmniMultimodalRunner().run_stage(
-        case, StageSpec(name="vision_encode"), ctx)
+    out = omni.OmniMultimodalRunner().run_stage(case, StageSpec(name="vision_encode"), ctx)
 
     cmd = captured["cmd"]
     assert cmd[1] == "embed"
@@ -90,11 +89,7 @@ def test_vision_stage_maps_to_embed_without_stage_flag(monkeypatch, tmp_path) ->
 
 
 def test_qwen3_omni_manifest_owns_extended_runtime_budget() -> None:
-    manifest_path = (
-        Path(__file__).parent
-        / "manifests"
-        / "qwen3-omni-30b-a3b-instruct.json"
-    )
+    manifest_path = Path(__file__).parent / "manifests" / "qwen3-omni-30b-a3b-instruct.json"
     model = load_model_manifest(manifest_path)
 
     assert model.testcases[0].inputs["runtime_timeout_s"] == 900
@@ -117,8 +112,7 @@ def test_omni_runner_uses_model_owned_runtime_budget(monkeypatch, tmp_path) -> N
 
     monkeypatch.setattr(omni.subprocess, "run", _fake_run)
 
-    omni.OmniMultimodalRunner().run_stage(
-        case, StageSpec(name="thinker_decode"), ctx)
+    omni.OmniMultimodalRunner().run_stage(case, StageSpec(name="thinker_decode"), ctx)
 
     assert captured["timeout"] == 900
 
@@ -143,15 +137,28 @@ def test_omni_timeout_preserves_partial_stderr(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(omni.subprocess, "run", _timeout)
 
     with pytest.raises(RuntimeError, match="model-owned runtime budget of 900s"):
-        omni.OmniMultimodalRunner().run_stage(
-            case, StageSpec(name="thinker_decode"), ctx)
+        omni.OmniMultimodalRunner().run_stage(case, StageSpec(name="thinker_decode"), ctx)
 
-    timeout_log = (
-        tmp_path
-        / case.name
-        / "omni_thinker_decode_timeout_stderr.log"
-    )
+    timeout_log = tmp_path / case.name / "omni_thinker_decode_timeout_stderr.log"
     assert "still loading" in timeout_log.read_text(encoding="utf-8")
+
+
+def test_talker_rejects_simple_waveform_fallback(monkeypatch, tmp_path) -> None:
+    case = _make_case(inputs={"prompt": "hello", "max_new_tokens": 16})
+    ctx = _make_ctx(case, tmp_path)
+
+    def _fallback(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="",
+            stderr=("[trtmc] Omni: no Code2Wav engine, generating simple waveform\n"),
+        )
+
+    monkeypatch.setattr(omni.subprocess, "run", _fallback)
+
+    with pytest.raises(RuntimeError, match="Code2Wav engine is missing"):
+        omni.OmniMultimodalRunner().run_stage(case, StageSpec(name="talker_decode"), ctx)
 
 
 def test_composite_runner_uses_run_without_stage_flag(monkeypatch, tmp_path) -> None:
@@ -170,8 +177,7 @@ def test_composite_runner_uses_run_without_stage_flag(monkeypatch, tmp_path) -> 
 
     monkeypatch.setattr(omni.subprocess, "run", _fake_run)
 
-    out = omni.CompositePipelineRunner().run_stage(
-        case, StageSpec(name="end_to_end"), ctx)
+    out = omni.CompositePipelineRunner().run_stage(case, StageSpec(name="end_to_end"), ctx)
 
     cmd = captured["cmd"]
     assert cmd[1] == "run"

--- a/tests/e2e/models/qwen3_omni/thresholds/qwen3-omni-30b-a3b-instruct.json
+++ b/tests/e2e/models/qwen3_omni/thresholds/qwen3-omni-30b-a3b-instruct.json
@@ -1,5 +1,10 @@
 {
   "threshold_overrides": {
-    "audio_artifact_bytes_min": 1.0
+    "audio_artifact_bytes_min": 44.0,
+    "audio_duration_s_min": 0.5,
+    "audio_reference_duration_ratio_min": 0.5,
+    "audio_rms_min": 0.005,
+    "audio_peak_min": 0.02,
+    "audio_reference_waveform_cosine_min": 0.25
   }
 }


### PR DESCRIPTION
## Background

The prior Qwen3-Omni bundle omitted the real Code2Wav decoder, used an incomplete projection in place of the released Talker, and could certify a short synthetic waveform. It also allocated Thinker KV cache storage from bundle metadata even when the engine cache bindings were FP32, corrupting generated text.

## Exit Criteria

- Product inference generates meaningful speech through the released Talker and TensorRT Code2Wav path.
- Synthetic fallback, silent or short audio, missing references, and poor Hugging Face waveform agreement fail CI.
- Impact analysis selects only `qwen3_omni`.

## Implementation

- Build the complete official 230-tensor Code2Wav graph as one required TensorRT engine.
- Feed TensorRT Thinker text into the official model-owned Talker, pin its Hugging Face model ID and revision in bundle metadata, and pass its 16-codebook frames to Code2Wav.
- Allocate Thinker KV cache storage from the actual engine binding dtype and remove fake-Talker and fallback paths.
- Parse both PCM16 reference WAVs and IEEE-float32 product WAVs; fail closed on waveform cosine, duration, RMS, peak, sample rate, and fallback checks.

## Validation

- Exact model-owned product E2E: passed in 598.43s. Generated 58,965 samples (2.456875s), RMS 0.06414084, peak 0.43496311, waveform cosine 0.46928450 (required >= 0.25), and no fallback.
- Focused Python model tests: 37 passed.
- Focused C++ Qwen3-Omni tests: 2/2 passed.
- Model catalog validation: all 77 entries valid.
- Impact analysis: only `qwen3_omni`, direct selection.
- Source quality: passed.

## Notes For Future Readers

Review the cache-dtype/runtime path first, then the Talker bridge, Code2Wav builder, and fail-closed oracle. The Talker uses the official pinned checkpoint through `--hf-python`; Thinker and Code2Wav run in TensorRT. This repairs the output path, but does not make Talker a bundled TensorRT engine.
