### PR TITLE
fix(deepseek-ocr): restore full OCR parity

### DIFF
--- a/python/tensorrt_model_connect/families/deepseek_ocr/plugin.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/plugin.py
@@ -10,15 +10,15 @@ DeepSeek-V2 MoE with shared experts for layers >= first_k_dense_replace, and
 dense SwiGLU for earlier layers.
 
 Vision pipeline:
-  1. SAM ViT-B: [1, 3, 1024, 1024] -> patch embed -> 12 blocks (window/global
+  1. SAM ViT-B: [1, 3, 768, 768] -> patch embed -> 12 blocks (window/global
      attention with relative position biases) -> neck + downsample convs
-     -> [1, 896, 16, 16]
-  2. Qwen2 Decoder-as-Encoder: flatten SAM features [1, 256, 896], concat with
-     learned queries [256, 896], run 24 Qwen2 layers with mixed attention
+     -> [1, 896, 12, 12]
+  2. Qwen2 Decoder-as-Encoder: flatten SAM features [1, 144, 896], concat with
+     learned queries [144, 896], run 24 Qwen2 layers with mixed attention
      (bidirectional for image, causal for queries), take query outputs
-     -> [1, 256, 896]
-  3. Linear Projector: [1, 256, 896] -> [1, 256, 1280]
-  4. View Separator: append [1, 1280] -> total 257 vision tokens
+     -> [1, 144, 896]
+  3. Linear Projector: [1, 144, 896] -> [1, 144, 1280]
+  4. View Separator: append [1, 1280] -> total 145 vision tokens
 
 Architecture:
   - Attention: Standard Q/K/V/O (no biases, no GQA — heads == kv_heads)
@@ -28,8 +28,8 @@ Architecture:
   - Norm: RMSNorm
 
 Operational note:
-  - DeepSeek-OCR VL prefill injects 257 image tokens before user text.
-  - Very small max_cache_length (especially <=257) can degrade OCR output
+  - DeepSeek-OCR VL prefill injects 145 image tokens before user text.
+  - Very small max_cache_length (especially <=145) can degrade OCR output
     (prompt echo / repeated "skip" style tokens). Use 4096 for stable OCR.
 """
 
@@ -258,10 +258,10 @@ class DeepSeekOCRPlugin:
                 verbose=verbose,
                 parallel_config=parallel)
 
-        image_prefill_tokens = 257
+        image_prefill_tokens = 145
         if max_cache_length <= image_prefill_tokens:
             print(
-                "[trtmc build] WARNING: DeepSeek-OCR-2 uses 257 image prefill tokens. "
+                "[trtmc build] WARNING: DeepSeek-OCR-2 uses 145 image prefill tokens. "
                 f"max_cache_length={max_cache_length} is too small and can cause "
                 "prompt echo / repeated skip-like tokens. Use --max-cache-length 4096.",
                 file=sys.stderr,
@@ -548,8 +548,8 @@ class DeepSeekOCRPlugin:
         Native TRT API implementation (no ONNX). Full pipeline:
         SAM ViT-B -> downsample convs -> Qwen2 encoder -> projector -> view_sep.
 
-        Input:  pixel_values  [1, 3, 1024, 1024] float32
-        Output: image_features [257, 1280] float32  (256 projected + 1 view_sep)
+        Input:  pixel_values  [1, 3, 768, 768] float32
+        Output: image_features [145, 1280] float32  (144 projected + 1 view_sep)
         """
         return _build_deepseek_ocr_vision_engine(
             model_dir, config, precision=precision, verbose=verbose)
@@ -579,10 +579,10 @@ class DeepSeekOCRPlugin:
         hidden = config.hidden_size  # 1280 (language decoder hidden)
         return {
             "image_token_id": config.raw.get("image_token_id", 128815),
-            "fixed_image_size": 1024,
-            "num_image_pad_tokens": 257,  # 256 projected + 1 view_separator
+            "fixed_image_size": 768,
+            "num_image_pad_tokens": 145,  # 144 projected + 1 view_separator
             "vision_output_dim": hidden,
-            "preprocessor_type": "pad_center_chw",
+            "preprocessor_type": "simple_chw",
             "image_mean": [0.5, 0.5, 0.5],
             "image_std": [0.5, 0.5, 0.5],
             "interpolation": "bicubic",
@@ -901,6 +901,59 @@ def _get_rel_pos(q_size: int, k_size: int, rel_pos: np.ndarray) -> np.ndarray:
     return rel_pos_resized[indices]
 
 
+def _make_qwen2_vision_attention_mask(
+    image_tokens: int,
+    *,
+    dtype=np.float32,
+) -> np.ndarray:
+    """Match DeepSeek-OCR's mixed image/query attention policy.
+
+    Image rows attend bidirectionally to every image token. Query rows attend
+    to every image token and causally to earlier query rows, matching the
+    checkpoint's ``CustomQwen2Decoder._create_custom_4d_mask`` implementation.
+    """
+    if image_tokens <= 0:
+        raise ValueError("image_tokens must be positive")
+
+    total_tokens = image_tokens * 2
+    mask = np.full((total_tokens, total_tokens), -10000.0, dtype=dtype)
+    mask[:image_tokens, :image_tokens] = 0.0
+    for query_index in range(image_tokens):
+        row = image_tokens + query_index
+        mask[row, :row + 1] = 0.0
+    return mask
+
+
+def _resize_sam_position_embedding(
+    position_embedding: np.ndarray,
+    target_grid_size: int,
+) -> np.ndarray:
+    """Resize SAM's absolute position embedding exactly like the HF model."""
+    if target_grid_size <= 0:
+        raise ValueError("target_grid_size must be positive")
+    if position_embedding.ndim != 4 or position_embedding.shape[0] != 1:
+        raise ValueError(
+            "SAM position embedding must have shape [1, H, W, hidden]")
+    if position_embedding.shape[1] != position_embedding.shape[2]:
+        raise ValueError("SAM position embedding must use a square grid")
+    if position_embedding.shape[1] == target_grid_size:
+        return np.ascontiguousarray(position_embedding, dtype=np.float32)
+
+    import torch
+    import torch.nn.functional as torch_functional
+
+    source = torch.from_numpy(position_embedding).permute(0, 3, 1, 2).float()
+    resized = torch_functional.interpolate(
+        source,
+        size=(target_grid_size, target_grid_size),
+        mode="bicubic",
+        antialias=True,
+        align_corners=False,
+    )
+    return np.ascontiguousarray(
+        resized.permute(0, 2, 3, 1).cpu().numpy(), dtype=np.float32)
+
+
 def _build_sam_attention(
     network: trt.INetworkDefinition,
     inp_4d: trt.ITensor,
@@ -1202,7 +1255,7 @@ def _load_vision_weights(
 
     # --- Qwen2 encoder ---
     vw["qwen2.queries"] = _load_tensor(
-        readers, "model.qwen2_model.query_1024.weight").astype(np.float32)
+        readers, "model.qwen2_model.query_768.weight").astype(np.float32)
     vw["qwen2.final_norm"] = _load_tensor(
         readers, "model.qwen2_model.model.model.norm.weight").astype(np.float32)
 
@@ -1258,8 +1311,8 @@ def _build_deepseek_ocr_vision_engine(
 
     Pipeline: SAM ViT-B -> downsample -> Qwen2 encoder -> projector -> view_sep
 
-    Input:  pixel_values  [1, 3, 1024, 1024] float32
-    Output: image_features [257, 1280] float32 (256 projected + 1 view_sep)
+    Input:  pixel_values  [1, 3, 768, 768] float32
+    Output: image_features [145, 1280] float32 (144 projected + 1 view_sep)
     """
     print("[trtmc build] Building DeepSeek-OCR-2 vision engine (native TRT) ...",
           file=sys.stderr)
@@ -1281,10 +1334,10 @@ def _build_deepseek_ocr_vision_engine(
     sam_head_dim = sam_hidden // sam_heads  # 64
     sam_mlp_dim = int(sam_hidden * 3.7362)  # ~2869, but actual is 3072 from weights
     sam_mlp_dim = vw["sam.block0.mlp.fc1.bias"].shape[0]  # 3072
-    image_size = 1024
+    image_size = 768
     patch_size = 16
-    grid_size = image_size // patch_size  # 64
-    seq_len = grid_size * grid_size  # 4096
+    grid_size = image_size // patch_size  # 48
+    seq_len = grid_size * grid_size  # 2304
     global_attn_indexes = {2, 5, 8, 11}
 
     # Qwen2 config
@@ -1296,12 +1349,15 @@ def _build_deepseek_ocr_vision_engine(
     qwen2_q_dim = qwen2_heads * qwen2_head_dim  # 896
     qwen2_kv_dim = qwen2_kv_heads * qwen2_head_dim  # 128
     qwen2_mlp_dim = vw["qwen2.layer0.w_gate"].shape[1]  # 4864
-    qwen2_num_queries = vw["qwen2.queries"].shape[0]  # 256
-    qwen2_total_seq = seq_len // (4 * 4) + qwen2_num_queries  # 256 + 256 = 512
-    # Wait, SAM output is [1, 896, 16, 16] -> flatten -> [1, 256, 896]
-    sam_out_spatial = 16  # after neck + downsample
-    sam_out_seq = sam_out_spatial * sam_out_spatial  # 256
-    qwen2_total_seq = sam_out_seq + qwen2_num_queries  # 512
+    qwen2_num_queries = vw["qwen2.queries"].shape[0]  # 144
+    # SAM output is [1, 896, 12, 12] -> flatten -> [1, 144, 896].
+    sam_out_spatial = grid_size // 4
+    sam_out_seq = sam_out_spatial * sam_out_spatial
+    if qwen2_num_queries != sam_out_seq:
+        raise ValueError(
+            "DeepSeek-OCR query table does not match the SAM output grid: "
+            f"queries={qwen2_num_queries}, SAM tokens={sam_out_seq}")
+    qwen2_total_seq = sam_out_seq + qwen2_num_queries
 
     # Projector config
     proj_in = qwen2_hidden  # 896
@@ -1332,7 +1388,7 @@ def _build_deepseek_ocr_vision_engine(
         pixel_values = network.add_cast(
             pixel_values, work_trt_dtype).get_output(0)
 
-    # Patch embedding: Conv2d [1, 3, 1024, 1024] -> [1, 768, 64, 64]
+    # Patch embedding: Conv2d [1, 3, 768, 768] -> [1, 768, 48, 48]
     pe_w = vw["sam.patch_embed.weight"]
     pe_b = vw["sam.patch_embed.bias"]
     patch_conv = network.add_convolution_nd(
@@ -1342,13 +1398,15 @@ def _build_deepseek_ocr_vision_engine(
         bias=trt.Weights(np.ascontiguousarray(pe_b, dtype=work_np_dtype)))
     patch_conv.stride_nd = (patch_size, patch_size)
 
-    # NCHW -> NHWC: [1, 768, 64, 64] -> [1, 64, 64, 768]
+    # NCHW -> NHWC: [1, 768, 48, 48] -> [1, 48, 48, 768]
     to_nhwc = network.add_shuffle(patch_conv.get_output(0))
     to_nhwc.first_transpose = trt.Permutation([0, 2, 3, 1])
 
     # Add position embedding
+    resized_position_embedding = _resize_sam_position_embedding(
+        vw["sam.pos_embed"], grid_size)
     pos_c = graph_ops.add_constant(
-        network, (1, grid_size, grid_size, sam_hidden), vw["sam.pos_embed"],
+        network, (1, grid_size, grid_size, sam_hidden), resized_position_embedding,
         dtype=work_np_dtype)
     pos_sum = network.add_elementwise(
         to_nhwc.get_output(0), pos_c, trt.ElementWiseOperation.SUM)
@@ -1453,7 +1511,7 @@ def _build_deepseek_ocr_vision_engine(
     ln2_4d.reshape_dims = (1, grid_size, grid_size, 256)
     ln2_nchw = network.add_shuffle(ln2_4d.get_output(0))
     ln2_nchw.first_transpose = trt.Permutation([0, 3, 1, 2])
-    # SAM neck output: [1, 256, 64, 64]
+    # SAM neck output: [1, 256, 48, 48]
 
     # Downsample: net_2 Conv2d(256->512, 3x3, stride=2, pad=1)
     net2 = network.add_convolution_nd(
@@ -1464,7 +1522,7 @@ def _build_deepseek_ocr_vision_engine(
         bias=trt.Weights(np.zeros(512, dtype=work_np_dtype)))
     net2.stride_nd = (2, 2)
     net2.padding_nd = (1, 1)
-    # [1, 512, 32, 32]
+    # [1, 512, 24, 24]
 
     # Downsample: net_3 Conv2d(512->896, 3x3, stride=2, pad=1)
     net3 = network.add_convolution_nd(
@@ -1475,33 +1533,33 @@ def _build_deepseek_ocr_vision_engine(
         bias=trt.Weights(np.zeros(896, dtype=work_np_dtype)))
     net3.stride_nd = (2, 2)
     net3.padding_nd = (1, 1)
-    # SAM final output: [1, 896, 16, 16]
+    # SAM final output: [1, 896, 12, 12]
 
     # ===================================================================
     # Stage 2: Qwen2 Decoder-as-Encoder
     # ===================================================================
-    # Flatten SAM features: [1, 896, 16, 16] -> NHWC -> [1, 256, 896]
+    # Flatten SAM features: [1, 896, 12, 12] -> NHWC -> [1, 144, 896]
     sam_nhwc = network.add_shuffle(net3.get_output(0))
     sam_nhwc.first_transpose = trt.Permutation([0, 2, 3, 1])
     sam_flat = network.add_shuffle(sam_nhwc.get_output(0))
-    sam_flat.reshape_dims = (1, sam_out_seq, qwen2_hidden)  # [1, 256, 896]
+    sam_flat.reshape_dims = (1, sam_out_seq, qwen2_hidden)  # [1, 144, 896]
 
-    # Learned queries: [256, 896] -> [1, 256, 896]
+    # Learned queries: [144, 896] -> [1, 144, 896]
     queries_c = graph_ops.add_constant(
         network, (1, qwen2_num_queries, qwen2_hidden), vw["qwen2.queries"],
         dtype=work_np_dtype)
 
-    # Concatenate: [1, 256, 896] + [1, 256, 896] -> [1, 512, 896]
+    # Concatenate: [1, 144, 896] + [1, 144, 896] -> [1, 288, 896]
     enc_concat = network.add_concatenation(
         [sam_flat.get_output(0), queries_c])
     enc_concat.axis = 1
-    enc_input = enc_concat.get_output(0)  # [1, 512, 896]
+    enc_input = enc_concat.get_output(0)  # [1, 288, 896]
 
-    # Flatten to 2D for transformer: [512, 896]
+    # Flatten to 2D for transformer: [288, 896]
     enc_2d = network.add_shuffle(enc_input)
     enc_2d.reshape_dims = (qwen2_total_seq, qwen2_hidden)
 
-    # Precompute native RoPE half-dim caches for Qwen2 positions 0..511.
+    # Precompute native RoPE half-dim caches for Qwen2 positions 0..287.
     cos_half_np = graph_ops.make_rope_table_half_dim(
         qwen2_total_seq, qwen2_head_dim, rope_theta, True)
     sin_half_np = graph_ops.make_rope_table_half_dim(
@@ -1516,18 +1574,12 @@ def _build_deepseek_ocr_vision_engine(
         np.arange(qwen2_total_seq, dtype=np.int32),
         dtype=np.int32)
 
-    enc_state = enc_2d.get_output(0)  # [512, 896]
+    enc_state = enc_2d.get_output(0)  # [288, 896]
 
     attn_scale = 1.0 / np.sqrt(qwen2_head_dim)
 
-    # Standard causal mask (lower-triangular). HF Qwen2 SDPA uses is_causal=True
-    # which creates this mask internally. All tokens attend only to preceding tokens.
-    qwen2_mask_np = np.full(
-        (qwen2_total_seq, qwen2_total_seq), -10000.0,
-        dtype=work_np_dtype)
-    for i in range(qwen2_total_seq):
-        for j in range(i + 1):
-            qwen2_mask_np[i, j] = 0.0
+    qwen2_mask_np = _make_qwen2_vision_attention_mask(
+        qwen2_num_queries, dtype=work_np_dtype)
     qwen2_mask_c = graph_ops.add_constant(
         network, (1, qwen2_total_seq, qwen2_total_seq),
         qwen2_mask_np.reshape(1, qwen2_total_seq, qwen2_total_seq),
@@ -1543,7 +1595,7 @@ def _build_deepseek_ocr_vision_engine(
             vw[f"{wp}.input_norm"], None, rms_eps_t, "rmsnorm",
             dtype=work_np_dtype)
 
-        # Q projection: [512, 896] @ [896, 896] -> [512, 896]
+        # Q projection: [288, 896] @ [896, 896] -> [288, 896]
         q = graph_ops.add_matmul_rhs_constant(
             network, norm1, qwen2_hidden, qwen2_q_dim, vw[f"{wp}.w_q"],
             dtype=work_np_dtype)
@@ -1551,7 +1603,7 @@ def _build_deepseek_ocr_vision_engine(
             network, q, qwen2_q_dim, vw[f"{wp}.q_bias"],
             dtype=work_np_dtype)
 
-        # K projection: [512, 896] @ [896, 128] -> [512, 128]
+        # K projection: [288, 896] @ [896, 128] -> [288, 128]
         k = graph_ops.add_matmul_rhs_constant(
             network, norm1, qwen2_hidden, qwen2_kv_dim, vw[f"{wp}.w_k"],
             dtype=work_np_dtype)
@@ -1559,7 +1611,7 @@ def _build_deepseek_ocr_vision_engine(
             network, k, qwen2_kv_dim, vw[f"{wp}.k_bias"],
             dtype=work_np_dtype)
 
-        # V projection: [512, 896] @ [896, 128] -> [512, 128]
+        # V projection: [288, 896] @ [896, 128] -> [288, 128]
         v = graph_ops.add_matmul_rhs_constant(
             network, norm1, qwen2_hidden, qwen2_kv_dim, vw[f"{wp}.w_v"],
             dtype=work_np_dtype)
@@ -1587,7 +1639,7 @@ def _build_deepseek_ocr_vision_engine(
             mask=mask_4d,
             scale=attn_scale)
 
-        # Output projection: [512, 896] @ [896, 896] -> [512, 896]
+        # Output projection: [288, 896] @ [896, 896] -> [288, 896]
         attn_out = graph_ops.add_matmul_rhs_constant(
             network, ctx_flat,
             qwen2_q_dim, qwen2_hidden, vw[f"{wp}.w_o"],
@@ -1629,13 +1681,13 @@ def _build_deepseek_ocr_vision_engine(
         vw["qwen2.final_norm"], None, rms_eps_t, "rmsnorm",
         dtype=work_np_dtype)
 
-    # Extract query outputs: last 256 tokens from [512, 896]
+    # Extract query outputs: last 144 tokens from [288, 896]
     query_out = network.add_slice(
         enc_state,
         start=(sam_out_seq, 0),
         shape=(qwen2_num_queries, qwen2_hidden),
         stride=(1, 1))
-    # [256, 896]
+    # [144, 896]
 
     # ===================================================================
     # Stage 3: Linear Projector
@@ -1645,7 +1697,7 @@ def _build_deepseek_ocr_vision_engine(
         proj_in, proj_out, vw["proj.weight"], dtype=work_np_dtype)
     projected = graph_ops.add_bias_sum(
         network, projected, proj_out, vw["proj.bias"], dtype=work_np_dtype)
-    # [256, 1280]
+    # [144, 1280]
 
     # ===================================================================
     # Stage 4: View Separator
@@ -1656,7 +1708,7 @@ def _build_deepseek_ocr_vision_engine(
     final_concat = network.add_concatenation(
         [projected, view_sep_c])
     final_concat.axis = 0
-    # [257, 1280]
+    # [145, 1280]
 
     output = final_concat.get_output(0)
     if output.dtype != trt.float32:
@@ -1667,7 +1719,7 @@ def _build_deepseek_ocr_vision_engine(
     if verbose:
         print(f"[trtmc build] Building vision TRT engine "
               f"(SAM: {sam_layers} blocks, Qwen2: {qwen2_layers} layers, "
-              f"output: 257x{proj_out}) ...", file=sys.stderr)
+              f"output: 145x{proj_out}) ...", file=sys.stderr)
 
     plan = builder.build_serialized_network(network, trt_config)
     if plan is None:

--- a/python/tensorrt_model_connect/families/deepseek_ocr/tp_builder.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/tp_builder.py
@@ -351,10 +351,10 @@ def build_deepseek_ocr_tp_engine(
             "build_deepseek_ocr_tp_engine requires tensor_parallel mode with "
             "tp_size > 1")
 
-    image_prefill_tokens = 257
+    image_prefill_tokens = 145
     if max_cache_length <= image_prefill_tokens:
         print(
-            "[trtmc build] WARNING: DeepSeek-OCR-2 uses 257 image prefill "
+            "[trtmc build] WARNING: DeepSeek-OCR-2 uses 145 image prefill "
             f"tokens. max_cache_length={max_cache_length} is too small and "
             "can cause prompt echo / repeated skip-like tokens. Use "
             "--max-cache-length 4096.",

--- a/tests/e2e/models/deepseek_ocr/data/deepseek_ocr_l0_golden.json
+++ b/tests/e2e/models/deepseek_ocr/data/deepseek_ocr_l0_golden.json
@@ -1,5 +1,5 @@
 {
-  "text": "Architecture:\n\nAttention: Standard Q/K/V/O (no biases, no GQA -- heads == kv_heads)\n\nRoPE: Standard rotary position embeddings\n\nLayer 0: Dense SwiGLU MLP (intermediate_size=6848)\n\nLayers 1-11: MoE (64 experts, top-6, intermediate=896) + shared experts (2, intermediate=896)\n\nNorm: RMSNorm",
+  "text": "DeepSeek-OCR-2 is a VL model with a DeepSeek-V2-style language decoder. Unlike\n\nthe full DeepSeek-V2 which uses Multi-head Latent Attention (MLA), OCR-2 uses\n\nstandard Llama-style multi-head attention (use_mla=False). The MLP layers use\n\nDeepSeek-V2 MoE with shared experts for layers >= first_k_dense_replace, and\n\ndense SwiGLU for earlier layers.\n\nArchitecture:\n\nAttention:Standard Q/K/V/O no biases, no GQA - heads == kv_heads)\n\nRoPE:Standard rotary position embeddings\n\nLayer 0:Dense SwiGLU MLP (intermediate_size=6848)\n\nLayers 1-11:MoE 64 experts, top-6, intermediate=896) + shared experts 2\n\nNorm: RMSNorm\n\nVision: SAM ViT-B + Qwen2 encoder (not supported in TRT yet, text-only)",
   "required_substrings": [
     "Architecture:",
     "Attention: Standard Q/K/V/O",
@@ -9,5 +9,5 @@
     "Norm: RMS"
   ],
   "source_image": "tests/e2e/models/deepseek_ocr/data/orc_test_img.jpeg",
-  "contract_scope": "L0 short decode validates the visible Architecture section of the OCR fixture."
+  "contract_scope": "L0 validates the complete visible OCR transcript through the Architecture and Vision sections."
 }

--- a/tests/e2e/models/deepseek_ocr/e2e_plugins/contract.py
+++ b/tests/e2e/models/deepseek_ocr/e2e_plugins/contract.py
@@ -185,6 +185,14 @@ def _normalized_substring_hits(text: str, substrings: list[str]) -> tuple[int, l
     ]
     return len(substrings) - len(missing), missing
 
+
+def _ocr_ned_threshold(threshold) -> float:
+    """Read the OCR edit-distance limit declared by the model profile."""
+    return threshold.metrics.get(
+        "normalized_text_edit_distance",
+        threshold.metrics.get("contract_ned_threshold", 0.05),
+    )
+
 class DeepseekOcrVLQAPlugin:
     reference_families = ["ocr_markdown"]
     user_contract = "vl_answer"
@@ -290,7 +298,17 @@ class DeepseekOcrVLQAPlugin:
                 )
 
             hits, missing = _normalized_substring_hits(trt_text, required_substrings)
-            passed = not missing
+            trt_answer = normalize_text(
+                extract_answer(StageOutput(stage_name=stage, text=trt_text), prompt)
+            )
+            ref_answer = normalize_text(
+                extract_answer(StageOutput(stage_name=stage, text=ref_text), prompt)
+            )
+            ned = levenshtein_ned(trt_answer, ref_answer)
+            ned_threshold = _ocr_ned_threshold(threshold)
+            substrings_passed = not missing
+            ned_passed = ned <= ned_threshold
+            passed = substrings_passed and ned_passed
             metrics = {
                 "reference_contract_substrings": MetricResult(
                     value=float(len(required_substrings)),
@@ -303,17 +321,36 @@ class DeepseekOcrVLQAPlugin:
                     value=float(hits),
                     threshold=float(len(required_substrings)),
                     operator="==",
-                    passed=passed,
+                    passed=substrings_passed,
                     note="required OCR substrings present in TRT output",
+                ),
+                "normalized_text_edit_distance": MetricResult(
+                    value=ned,
+                    threshold=ned_threshold,
+                    operator="<=",
+                    passed=ned_passed,
+                    note="distance from the complete human-readable OCR reference",
                 ),
             }
             if passed:
-                return make_pass("full_generation", metrics, "required OCR substrings present")
+                return make_pass(
+                    "full_generation",
+                    metrics,
+                    "required OCR substrings AND normalized text edit distance",
+                )
+
+            failures = []
+            if missing:
+                failures.append("missing expected text: " + ", ".join(missing))
+            if not ned_passed:
+                failures.append(
+                    f"full-text NED={ned:.3f} exceeds {ned_threshold:.3f}"
+                )
             return make_fail(
                 "full_generation",
                 metrics,
-                "required OCR substrings present",
-                "TRT OCR output missing expected text: " + ", ".join(missing),
+                "required OCR substrings AND normalized text edit distance",
+                "TRT OCR output failed parity: " + "; ".join(failures),
             )
 
         if not ref_text:
@@ -363,7 +400,11 @@ class DeepseekOcrVLQAPlugin:
 
         exact = trt_answer == ref_answer
         ned = levenshtein_ned(trt_answer, ref_answer)
-        ned_threshold = threshold.metrics.get("contract_ned_threshold", 0.05 if is_ocr else 0.15)
+        ned_threshold = (
+            _ocr_ned_threshold(threshold)
+            if is_ocr
+            else threshold.metrics.get("contract_ned_threshold", 0.15)
+        )
         metrics = {
             "exact_match": MetricResult(
                 value=1.0 if exact else 0.0,

--- a/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr-l0-tp2.json
+++ b/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr-l0-tp2.json
@@ -34,7 +34,7 @@
       "reference_family": "ocr_markdown",
       "user_contract": "ocr_text",
       "prompt": "Extract the text from this image.",
-      "max_new_tokens": 96,
+      "max_new_tokens": 220,
       "test_image": "data/orc_test_img.jpeg",
       "reference_backend": "golden_snapshot",
       "preflight_requirements": [
@@ -72,7 +72,7 @@
           "ocr_mode": true
         }
       },
-      "notes": "DeepSeek-OCR TP2 coverage. The checkpoint has 10 attention/KV heads, so TP4 is not valid. Uses the same checkpoint, image input, prompt, cache length, golden snapshot, and OCR contract as deepseek-ocr-l0 while running the language decoder through rank-local TP engines."
+      "notes": "DeepSeek-OCR TP2 coverage. The checkpoint has 10 attention/KV heads, so TP4 is not valid. Uses the same checkpoint, 768-pixel single-view input, prompt, cache length, complete OCR golden snapshot, and 220-token budget as deepseek-ocr-l0 while running the language decoder through rank-local TP engines."
     }
   ]
 }

--- a/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr-l0.json
+++ b/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr-l0.json
@@ -25,7 +25,7 @@
       "reference_family": "ocr_markdown",
       "user_contract": "ocr_text",
       "prompt": "Extract the text from this image.",
-      "max_new_tokens": 96,
+      "max_new_tokens": 220,
       "test_image": "data/orc_test_img.jpeg",
       "reference_backend": "golden_snapshot",
       "metadata": {
@@ -36,7 +36,7 @@
           "ocr_mode": true
         }
       },
-      "notes": "PR L0 repro for DeepSeek-OCR. Uses the same checkpoint, image input, deepseek_ocr_vision_language runtime, and full cache budget. Decoder layers 6-11 and selector 12's embedding/final-logit boundary use FP32 to preserve the OCR text contract with TensorRT 11.2 while the remaining decoder path stays FP16. The shorter decode validates the visible Architecture section emitted by the OCR fixture while nightly keeps the full OCR transcript contract."
+      "notes": "PR L0 repro for DeepSeek-OCR. Uses the same checkpoint, image input, 768-pixel single-view vision path, deepseek_ocr_vision_language runtime, and full cache budget. The 220-token decode covers the restored introductory text and the complete Architecture contract while nightly retains a larger completion budget."
     }
   ]
 }

--- a/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr.json
+++ b/tests/e2e/models/deepseek_ocr/manifests/deepseek-ocr.json
@@ -38,7 +38,7 @@
           "ocr_mode": true
         }
       },
-      "notes": "The reference runs the official BF16 model.infer path in the family-owned Transformers 4.46.3 profile and preserves the original OCR prompt and required-substring contract. Decoder layers 6-11 and selector 12's embedding/final-logit boundary use FP32 to preserve that contract with TensorRT 11.2 while the remaining decoder path stays FP16."
+      "notes": "The reference runs the official BF16 model.infer path in the family-owned Transformers 4.46.3 profile and preserves the original OCR prompt and full-text contract. TensorRT uses the checkpoint's official 768-pixel single-view query table, resized SAM position embedding, and mixed image/query attention policy. Decoder layers 6-11 and selector 12's embedding/final-logit boundary remain FP32 for TensorRT 11.2 stability."
     }
   ]
 }

--- a/tests/e2e/models/deepseek_ocr/test_deepseek_ocr_builder_tp.py
+++ b/tests/e2e/models/deepseek_ocr/test_deepseek_ocr_builder_tp.py
@@ -220,3 +220,41 @@ def test_deepseek_ocr_forwards_fp16_to_vision_engine(monkeypatch) -> None:
         "precision": "fp16",
         "verbose": True,
     }
+
+
+def test_deepseek_ocr_vision_mask_keeps_image_attention_bidirectional() -> None:
+    mask = deepseek_ocr_module._make_qwen2_vision_attention_mask(3)
+
+    assert mask.shape == (6, 6)
+    np.testing.assert_array_equal(mask[:3, :3], np.zeros((3, 3)))
+    np.testing.assert_array_equal(mask[:3, 3:], np.full((3, 3), -10000.0))
+    np.testing.assert_array_equal(
+        mask[3], [0.0, 0.0, 0.0, 0.0, -10000.0, -10000.0])
+    np.testing.assert_array_equal(
+        mask[4], [0.0, 0.0, 0.0, 0.0, 0.0, -10000.0])
+    np.testing.assert_array_equal(mask[5], np.zeros(6))
+
+
+def test_deepseek_ocr_vision_mask_rejects_empty_image_sequence() -> None:
+    with pytest.raises(ValueError, match="image_tokens must be positive"):
+        deepseek_ocr_module._make_qwen2_vision_attention_mask(0)
+
+
+def test_deepseek_ocr_resizes_sam_position_embedding_for_768_view() -> None:
+    position_embedding = np.ones((1, 64, 64, 4), dtype=np.float32)
+
+    resized = deepseek_ocr_module._resize_sam_position_embedding(
+        position_embedding, 48)
+
+    assert resized.shape == (1, 48, 48, 4)
+    assert resized.dtype == np.float32
+    np.testing.assert_allclose(resized, 1.0, atol=1e-6)
+
+
+def test_deepseek_ocr_uses_official_768_single_view_contract() -> None:
+    vl_config = deepseek_ocr_module.DeepSeekOCRPlugin().get_vl_config(_config())
+
+    assert vl_config is not None
+    assert vl_config["fixed_image_size"] == 768
+    assert vl_config["num_image_pad_tokens"] == 145
+    assert vl_config["preprocessor_type"] == "simple_chw"

--- a/tests/e2e/models/deepseek_ocr/test_ocr_contract.py
+++ b/tests/e2e/models/deepseek_ocr/test_ocr_contract.py
@@ -244,6 +244,64 @@ def test_vl_qa_ocr_accepts_literal_fixture_spacing_and_terminal_norm() -> None:
 
     assert result.status == StageStatus.PASSED.value
     assert result.metrics["required_ocr_substrings"].value == len(required)
+    assert result.metrics["normalized_text_edit_distance"].passed
+
+
+def test_vl_qa_ocr_rejects_nightly_truncation_despite_marker_hits() -> None:
+    """Regression for the false pass in Nightly run 29445075597."""
+    generated = """\
+Architecture:
+Attention:Standard Q/K/V/O (no biases,no GQA-heads == kv heads)
+RoPE:Standard rotary position embeddings
+Layer 0:Dense SwiGLU MLP (intermediate_size=6848)
+Layers 1-11:MoE (64 experts,top-6,intermediate=896)+ shared experts (2,
+Norm:RMSNorm
+Vision: SAM ViT-B + Qwen2 encoder (not supported in TRT yet, text-only)
+Vision: SAM ViT-B + Qwen2 encoder (not supported in TRT yet, text-only)"""
+    reference = """\
+DeepSeek-OCR-2 is a VL model with a DeepSeek-V2-style language decoder. Unlike
+the full DeepSeek-V2 which uses Multi-head Latent Attention (MLA), OCR-2 uses
+standard Llama-style multi-head attention (use_mla=False). The MLP layers use
+DeepSeek-V2 MoE with shared experts for layers >= first_k_dense_replace, and
+dense SwiGLU for earlier layers.
+Architecture:
+Attention:Standard Q/K/V/O no biases, no GQA - heads == kv_heads)
+RoPE:Standard rotary position embeddings
+Layer 0:Dense SwiGLU MLP (intermediate_size=6848)
+Layers 1-11:MoE 64 experts, top-6, intermediate=896) + shared experts 2
+Norm: RMSNorm
+Vision: SAM ViT-B + Qwen2 encoder (not supported in TRT yet, text-only)"""
+    required = [
+        "Architecture",
+        "Attention:Standard Q/K/V/O",
+        "RoPE:Standard rotary position embeddings",
+        "Layer 0:Dense SwiGLU MLP",
+        "Layers 1-11:MoE",
+        "Vision: SAM ViT-B + Qwen2 encoder",
+    ]
+
+    result = DeepseekOcrVLQAPlugin().verify(
+        StageOutput(
+            stage_name="full_generation",
+            data={"generated_text": generated},
+            metadata={"returncode": 0},
+        ),
+        StageOutput(
+            stage_name="full_generation",
+            data={"text": reference, "required_substrings": required},
+        ),
+        _case(reference_backend="golden_snapshot"),
+        ThresholdProfile(
+            task_strategy="vision_language_generation",
+            metrics={"normalized_text_edit_distance": 0.5},
+        ),
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert result.metrics["required_ocr_substrings"].passed
+    assert not result.metrics["normalized_text_edit_distance"].passed
+    assert result.metrics["normalized_text_edit_distance"].value > 0.63
+    assert "full-text NED" in result.message
 
 
 def test_vl_qa_ocr_still_rejects_truncation_before_terminal_norm() -> None:


### PR DESCRIPTION
## Background

Nightly run 29445075597 reported DeepSeek OCR as passing even though its TensorRT output omitted the introductory text, truncated the shared-expert section, and duplicated the final Vision line. The model-owned comparator accepted six marker strings without applying the declared full-text edit-distance limit.

The runtime mismatch had two model-owned causes: the Qwen2 vision encoder used a fully causal mask instead of the checkpoint's mixed image/query policy, and TensorRT forced a padded 1024-pixel view instead of the checkpoint's official 768-pixel single-view path.

## Exit Criteria

- A clean DeepSeek OCR engine build emits all six required OCR sections and passes the unchanged pinned Hugging Face full-text gate.
- Premerge L0 covers the restored introductory text and complete Architecture contract without weaker thresholds.
- The captured truncated Nightly output is rejected by a regression test.
- Impact analysis selects only `deepseek_ocr`.

## Implementation

- Match the checkpoint's vision attention policy: image tokens attend bidirectionally, while query tokens attend all image tokens and causal earlier queries.
- Use the official 768-pixel single-view path, `query_768` weights, 144 visual queries, exact bicubic SAM position-embedding resize, direct-resize preprocessing, and 145 injected image tokens.
- Require both structural marker coverage and full-text normalized edit distance in the OCR contract.
- Extend L0 and TP2 to 220 generated tokens and replace the Architecture-only golden text with the complete pinned OCR transcript; required markers and the 0.50 NED threshold remain unchanged.
- Add regression tests for the mixed attention mask, 768 vision contract, position resize, and the false-green Nightly output.

## Validation

- [GitHub Premerge run 29467910420](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29467910420): passed on exact head `3ceccc3e7b3f0374cfe34a49b0ee234867d8e149` with TensorRT 11.2 on GB300. The isolated proof built the engine exactly once, selected no sibling models, passed 6/6 OCR markers with NED 0.1330645161, and uploaded the combined HTML report.
- Clean GPU2 Nightly E2E rebuild: passed in 412.16 seconds; 6/6 required OCR markers and NED 0.1920289855 <= 0.50. Artifact: `.repro/official-768/artifacts/deepseek-ocr/result.json`.
- GPU2 L0 using the clean rebuilt bundle: passed; 6/6 required OCR markers and NED 0.1330645161 <= 0.50. Artifact: `.repro/l0-220/artifacts/deepseek-ocr-l0/result.json`.
- `CUDA_VISIBLE_DEVICES=2 PYTHONPATH=python /opt/venv/bin/python -m pytest tests/e2e/models/deepseek_ocr/test_deepseek_ocr_builder_tp.py tests/e2e/models/deepseek_ocr/test_ocr_contract.py -q`: 19 passed.
- TensorRT preprocessing versus the official 768 direct-resize PIL transform: byte-identical, maximum absolute difference 0.0.
- `ruff check` on changed Python files: passed.
- `python3 tools/model_ci.py validate --repo-root .`: passed for all 77 model ownership manifests.
- `python3 tools/model_ci.py impact --repo-root . --base github/main --head HEAD`: selected exactly `deepseek_ocr`; no shared fallback or unit suite.
- `git diff --check`: passed.

## Notes For Future Readers

- The clean local Nightly proof used TensorRT 11.0 on GB300 GPU2; the green GitHub isolated proof covers TensorRT 11.2 on GB300.
- The L0 decode budget increased because the corrected runtime now restores the introductory paragraphs before the Architecture section. Its comparison contract was expanded, not relaxed.
