### PR TITLE
fix(locateanything): preserve grounding output

### DIFF
--- a/src/runtime/models/locateanything/pipeline.cpp
+++ b/src/runtime/models/locateanything/pipeline.cpp
@@ -8,11 +8,56 @@
 #include "runtime/models/locateanything/image_preprocessor.h"
 
 #include <algorithm>
+#include <charconv>
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
 
 namespace trtmc {
+
+namespace {
+
+bool is_coordinate_token(std::string_view token) {
+    if (token.size() < 3 || token.front() != '<' || token.back() != '>')
+        return false;
+
+    int32_t value = 0;
+    const char* begin = token.data() + 1;
+    const char* end = token.data() + token.size() - 1;
+    const auto [parsed_end, error] = std::from_chars(begin, end, value);
+    return error == std::errc{} && parsed_end == end && value >= 0 && value <= 1000;
+}
+
+bool is_localization_token(std::string_view token) {
+    return token == "<ref>" || token == "</ref>" || token == "<box>" || token == "</box>" ||
+           is_coordinate_token(token);
+}
+
+} // namespace
+
+std::string locateanything_decode_generated_text(const ITokenizer& tokenizer,
+                                                 const std::vector<int32_t>& token_ids) {
+    std::string output;
+    std::vector<int32_t> regular_tokens;
+    auto flush_regular_tokens = [&]() {
+        if (regular_tokens.empty())
+            return;
+        output += tokenizer.decode(regular_tokens);
+        regular_tokens.clear();
+    };
+
+    for (const int32_t token_id : token_ids) {
+        const std::string token = tokenizer.token_for_id(token_id);
+        if (!is_localization_token(token)) {
+            regular_tokens.push_back(token_id);
+            continue;
+        }
+        flush_regular_tokens();
+        output += token;
+    }
+    flush_regular_tokens();
+    return output;
+}
 
 LocateAnythingPipeline::LocateAnythingPipeline(
     std::unique_ptr<TrtModule> text_decoder, std::unique_ptr<TrtModule> vision_encoder,
@@ -47,7 +92,7 @@ TextResult LocateAnythingPipeline::generate(const std::string& prompt, const Gen
 
     std::vector<int32_t> new_tokens(
         output_ids.begin() + static_cast<std::ptrdiff_t>(input_ids.size()), output_ids.end());
-    std::string text = tokenizer_->decode(new_tokens);
+    std::string text = locateanything_decode_generated_text(*tokenizer_, new_tokens);
 
     return TextResult{std::move(text), std::move(new_tokens)};
 }
@@ -196,7 +241,8 @@ TextResult LocateAnythingPipeline::generate(const std::string& prompt, const flo
 
     std::vector<int32_t> new_tokens(out.begin() + static_cast<std::ptrdiff_t>(input_ids.size()),
                                     out.end());
-    return TextResult{tokenizer_->decode(new_tokens), std::move(new_tokens)};
+    return TextResult{locateanything_decode_generated_text(*tokenizer_, new_tokens),
+                      std::move(new_tokens)};
 }
 
 LocateAnythingPipeline::GenerationResult

--- a/src/runtime/models/locateanything/pipeline.h
+++ b/src/runtime/models/locateanything/pipeline.h
@@ -24,6 +24,13 @@
 
 namespace trtmc {
 
+// Decode generated LocateAnything tokens while preserving the model's semantic
+// localization tokens. The generic BPE decoder intentionally removes tokens
+// marked as special, but LocateAnything uses <ref>, <box>, and <0>..<1000> as
+// part of its user-visible answer.
+std::string locateanything_decode_generated_text(const ITokenizer& tokenizer,
+                                                 const std::vector<int32_t>& token_ids);
+
 struct LocateAnythingConfig {
     int32_t vocab_size{0};
     int32_t id_bos{0};

--- a/tests/cpp/models/locateanything/test_locateanything_vl_pipeline.cpp
+++ b/tests/cpp/models/locateanything/test_locateanything_vl_pipeline.cpp
@@ -66,6 +66,51 @@ class VLFixedTokenizer : public trtmc::ITokenizer {
     std::string token_for_id(int32_t) const override { return ""; }
 };
 
+class GroundingTokenizer : public trtmc::ITokenizer {
+  public:
+    std::vector<int32_t> encode(const std::string&) const override { return {}; }
+
+    std::string decode(const std::vector<int32_t>& ids) const override {
+        std::string text;
+        for (const int32_t id : ids) {
+            if (id == 2)
+                text += "red";
+            else if (id == 3)
+                text += " vehicle";
+        }
+        return text;
+    }
+
+    int32_t id_for_token(std::string_view) const override { return 0; }
+
+    std::string token_for_id(int32_t id) const override {
+        switch (id) {
+        case 1:
+            return "<ref>";
+        case 4:
+            return "</ref>";
+        case 5:
+            return "<box>";
+        case 6:
+            return "<304>";
+        case 7:
+            return "<267>";
+        case 8:
+            return "<828>";
+        case 9:
+            return "<708>";
+        case 10:
+            return "</box>";
+        case 11:
+            return "<|im_end|>";
+        case 12:
+            return "<-1>";
+        default:
+            return "";
+        }
+    }
+};
+
 // ---------------------------------------------------------------------------
 // Engine builders
 // ---------------------------------------------------------------------------
@@ -127,6 +172,16 @@ static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_mock_vision_encoder() {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+static void test_grounding_decode_preserves_semantic_special_tokens() {
+    GroundingTokenizer tokenizer;
+    const std::vector<int32_t> generated{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    const std::string decoded = trtmc::locateanything_decode_generated_text(tokenizer, generated);
+    check(decoded == "<ref>red vehicle</ref><box><304><267><828><708></box>",
+          "grounding decode: preserves ref, box, and coordinate tokens only");
+    check(trtmc::locateanything_decode_generated_text(tokenizer, {12}).empty(),
+          "grounding decode: rejects negative coordinate syntax");
+}
 
 static void test_vl_text_only() {
     auto engine = build_mock_decoder();
@@ -615,6 +670,7 @@ static void test_vl_generate_with_tokenizer() {
 }
 
 int main() {
+    test_grounding_decode_preserves_semantic_special_tokens();
     test_vl_text_only();
     test_vl_text_only_max_tokens();
     test_vl_validates_decoder();

--- a/tests/e2e/models/locateanything/e2e_plugins/comparator.py
+++ b/tests/e2e/models/locateanything/e2e_plugins/comparator.py
@@ -5,10 +5,153 @@
 
 from __future__ import annotations
 
+import re
+
+from .contracts import (
+    CompareResult,
+    MetricResult,
+    StageOutput,
+    StageSpec,
+    StageStatus,
+    ThresholdProfile,
+)
 from .comparators.vision_language import VisionLanguageComparator
+
+
+_REF_RE = re.compile(r"<ref>.+?</ref>", re.DOTALL)
+_BOX_RE = re.compile(r"<box>((?:<[0-9]{1,4}>){4})</box>")
+_COORD_RE = re.compile(r"<([0-9]{1,4})>")
+
+
+def _localization_boxes(text: str) -> list[tuple[float, float, float, float]] | None:
+    """Parse every valid LocateAnything box in the model's 0..1000 space."""
+    matches = list(_BOX_RE.finditer(text))
+    if (
+        _REF_RE.search(text) is None
+        or not matches
+        or text.count("<box>") != len(matches)
+        or text.count("</box>") != len(matches)
+    ):
+        return None
+
+    boxes: list[tuple[float, float, float, float]] = []
+    for match in matches:
+        values = [int(value) for value in _COORD_RE.findall(match.group(1))]
+        if len(values) != 4 or any(value < 0 or value > 1000 for value in values):
+            return None
+        x1, y1, x2, y2 = values
+        if x2 <= x1 or y2 <= y1:
+            return None
+        boxes.append((float(x1), float(y1), float(x2), float(y2)))
+    return boxes
+
+
+def _box_iou(
+    left: tuple[float, float, float, float],
+    right: tuple[float, float, float, float],
+) -> float:
+    x1 = max(left[0], right[0])
+    y1 = max(left[1], right[1])
+    x2 = min(left[2], right[2])
+    y2 = min(left[3], right[3])
+    intersection = max(0.0, x2 - x1) * max(0.0, y2 - y1)
+    left_area = (left[2] - left[0]) * (left[3] - left[1])
+    right_area = (right[2] - right[0]) * (right[3] - right[1])
+    union = left_area + right_area - intersection
+    return intersection / union if union > 0.0 else 0.0
 
 
 class LocateanythingVisionLanguageGenerationComparator(VisionLanguageComparator):
     """locateanything local comparator for vision_language_generation."""
+
+    def _compare_generation(
+        self,
+        trt: StageOutput,
+        ref: StageOutput,
+        threshold: ThresholdProfile,
+        stage: StageSpec,
+    ) -> CompareResult:
+        """Require the grounded answer and its box, not only shared words."""
+        base = super()._compare_generation(trt, ref, threshold, stage)
+        metrics = dict(base.metrics)
+
+        trt_text = (trt.text or trt.data.get("generated_text") or "").strip()
+        ref_text = (ref.text or ref.data.get("generated_text") or "").strip()
+        trt_boxes = _localization_boxes(trt_text)
+        ref_boxes = _localization_boxes(ref_text)
+
+        metrics["localization_markup_present"] = MetricResult(
+            value=1.0 if trt_boxes is not None else 0.0,
+            threshold=1.0,
+            operator="==",
+            passed=trt_boxes is not None,
+            note="TRT output must contain <ref> text and only valid <box> groups",
+        )
+        metrics["reference_localization_markup_present"] = MetricResult(
+            value=1.0 if ref_boxes is not None else 0.0,
+            threshold=1.0,
+            operator="==",
+            passed=ref_boxes is not None,
+            note="reference output must contain <ref> text and only valid <box> groups",
+        )
+
+        box_count_match = (
+            trt_boxes is not None and ref_boxes is not None and len(trt_boxes) == len(ref_boxes)
+        )
+        metrics["localization_box_count_match"] = MetricResult(
+            value=1.0 if box_count_match else 0.0,
+            threshold=1.0,
+            operator="==",
+            passed=box_count_match,
+            note="TRT and reference must contain the same number of boxes",
+        )
+
+        iou = (
+            min(_box_iou(trt_box, ref_box) for trt_box, ref_box in zip(trt_boxes, ref_boxes))
+            if box_count_match and trt_boxes and ref_boxes
+            else 0.0
+        )
+        iou_threshold = threshold.metrics.get("localization_box_iou", 0.9)
+        metrics["localization_box_iou"] = MetricResult(
+            value=iou,
+            threshold=iou_threshold,
+            operator=">=",
+            passed=iou >= iou_threshold,
+        )
+
+        non_empty_ok = metrics["non_empty_output"].passed
+        ned_metric = metrics.get("normalized_text_edit_distance")
+        if ned_metric is None:
+            ned_metric = MetricResult(
+                value=1.0,
+                threshold=threshold.metrics.get("normalized_text_edit_distance"),
+                operator="<=",
+                passed=False,
+                note="text parity is unavailable for empty output",
+            )
+            metrics["normalized_text_edit_distance"] = ned_metric
+        ned_ok = ned_metric.passed
+        localization_ok = all(
+            metrics[name].passed
+            for name in (
+                "localization_markup_present",
+                "reference_localization_markup_present",
+                "localization_box_count_match",
+                "localization_box_iou",
+            )
+        )
+        passed = non_empty_ok and ned_ok and localization_ok
+        return CompareResult(
+            stage_name=stage.name,
+            status=StageStatus.PASSED.value if passed else StageStatus.FAILED.value,
+            metrics=metrics,
+            composite_rule=(
+                "non_empty_output AND normalized_text_edit_distance AND "
+                "valid TRT/reference localization markup AND matching box count AND "
+                "localization_box_iou"
+            ),
+            message=f"LocateAnything grounded generation compare: {'PASS' if passed else 'FAIL'}",
+        )
+
 
 comparator = LocateanythingVisionLanguageGenerationComparator()

--- a/tests/e2e/models/locateanything/manifests/locateanything-3b.json
+++ b/tests/e2e/models/locateanything/manifests/locateanything-3b.json
@@ -15,7 +15,7 @@
       "trace_id": "IT-E2E-LA3B-01",
       "ci_tier": "l0_only",
       "reference_precision": "fp32",
-      "prompt": "Find the red vehicle in this image.",
+      "prompt": "Find the white vehicle in this image.",
       "max_new_tokens": 32,
       "test_image": "data/test_img.jpeg",
       "notes": "Initial LocateAnything support uses the fixed 448x448 single-image MoonViT path and the existing TRT MC autoregressive VL generation path."

--- a/tests/e2e/models/locateanything/test_locateanything_grounding_comparator.py
+++ b/tests/e2e/models/locateanything/test_locateanything_grounding_comparator.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from tests.e2e_harness.contracts import StageOutput, StageSpec, StageStatus, ThresholdProfile
+from tests.e2e.models.locateanything.e2e_plugins.comparator import (
+    LocateanythingVisionLanguageGenerationComparator,
+)
+
+
+def _compare(trt_text: str, ref_text: str):
+    comparator = LocateanythingVisionLanguageGenerationComparator()
+    return comparator.compare(
+        StageOutput(stage_name="full_generation", text=trt_text),
+        StageOutput(stage_name="full_generation", text=ref_text),
+        ThresholdProfile(
+            task_strategy="vision_language_generation",
+            metrics={
+                "normalized_text_edit_distance": 0.5,
+                "token_agreement_rate": 0.3,
+                "localization_box_iou": 0.9,
+            },
+        ),
+        StageSpec(name="full_generation"),
+    )
+
+
+def test_grounding_comparator_rejects_nightly_output_without_box() -> None:
+    result = _compare(
+        "red vehicle in this image",
+        "<ref>red vehicle in this image</ref><box><304><267><828><708></box>",
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert result.metrics["token_agreement_rate"].passed
+    assert not result.metrics["localization_markup_present"].passed
+
+
+def test_grounding_comparator_accepts_matching_grounded_output() -> None:
+    output = "<ref>red vehicle in this image</ref><box><304><267><828><708></box>"
+    result = _compare(output, output)
+
+    assert result.status == StageStatus.PASSED.value
+    assert result.metrics["localization_box_iou"].value == 1.0
+
+
+def test_grounding_comparator_rejects_wrong_box() -> None:
+    result = _compare(
+        "<ref>red vehicle in this image</ref><box><0><0><100><100></box>",
+        "<ref>red vehicle in this image</ref><box><304><267><828><708></box>",
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert not result.metrics["localization_box_iou"].passed
+
+
+def test_grounding_comparator_rejects_missing_second_box() -> None:
+    result = _compare(
+        "<ref>vehicles</ref><box><304><267><828><708></box>",
+        ("<ref>vehicles</ref><box><304><267><828><708></box><box><20><30><100><120></box>"),
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert not result.metrics["localization_box_count_match"].passed
+
+
+def test_grounding_comparator_reports_empty_output_as_failure() -> None:
+    result = _compare(
+        "",
+        "<ref>white vehicle</ref><box><304><267><828><708></box>",
+    )
+
+    assert result.status == StageStatus.FAILED.value
+    assert not result.metrics["non_empty_output"].passed
+    assert not result.metrics["normalized_text_edit_distance"].passed

--- a/tests/e2e/models/locateanything/test_locateanything_manifest_contract.py
+++ b/tests/e2e/models/locateanything/test_locateanything_manifest_contract.py
@@ -17,3 +17,4 @@ def test_locateanything_manifest_declares_hf_image_text_to_text_contract() -> No
     assert case.hf_id == "nvidia/LocateAnything-3B"
     assert case.task_strategy == "vision_language_generation"
     assert case.user_contract == "image-text-to-text"
+    assert case.inputs["prompt"] == "Find the white vehicle in this image."

--- a/tests/e2e/models/locateanything/thresholds/locateanything-3b.json
+++ b/tests/e2e/models/locateanything/thresholds/locateanything-3b.json
@@ -1,6 +1,7 @@
 {
   "threshold_overrides": {
     "layer_atol": 0.05,
+    "localization_box_iou": 0.9,
     "logit_atol": 0.001,
     "normalized_text_edit_distance": 0.5,
     "semantic_similarity": 0.8,


### PR DESCRIPTION
## Background
Nightly run 29445075597 produced only `red vehicle in this image`, while the Hugging Face reference produced `<ref>red vehicle in this image</ref><box><304><267><828><708></box>`. The run remained green because the generic BPE decoder removed semantic tokens marked special and the comparator allowed word overlap to override failed edit distance. Visual review also found that the fixture contains a white vehicle even though the prompt requested a red one.

## Exit Criteria
- Preserve LocateAnything reference, box, and coordinate tokens in user-visible output.
- Reject empty output, malformed or missing localization markup, box-count mismatches, and boxes that disagree with the reference.
- Use a grounding prompt that describes a target present in the fixture.
- Keep CI ownership and impact limited to `locateanything`.

## Implementation
- Decode ordinary BPE tokens normally while emitting only LocateAnything semantic special tokens (`<ref>`, `<box>`, and coordinates from 0 through 1000); unrelated framing, EOS, and invalid coordinate tokens remain filtered.
- Add a model-local grounded-generation contract requiring non-empty output, normalized edit-distance parity, valid TRT/reference localization markup, equal box counts, and at least 0.9 IoU for every corresponding box.
- Align the manifest prompt with the white vehicle in the checked-in image.
- Add C++ and Python regressions for the exact Nightly failure, a matching box, a wrong box, a missing second box, empty output, invalid coordinates, and the fixture prompt.

## Validation
- `PYTHONPATH=python /opt/venv/bin/python -m pytest tests/e2e/models/locateanything -q`: 14 passed, 1 skipped.
- `cmake --build build --target test_locateanything_vl_pipeline -j8`: passed in the TensorRT/CUDA agent-4 container.
- `ctest --test-dir build --output-on-failure -R ^test_locateanything_vl_pipeline$`: 1 of 1 passed.
- `CI_BASE_REF=a36521ca091c2042c2ebf30c5fd851473c5e6baa bash .github/scripts/run-trtmc-ci.sh source-quality`: passed.
- `PYTHONPATH=python python3 tools/model_ci.py validate`: 77 owners validated.
- `PYTHONPATH=python python3 tools/model_ci.py impact --base github/main --head HEAD`: selected only `locateanything`.
- [Premerge run 29460496701](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29460496701): passed on the final commit. It selected one owner and one case, staged only `libtrtmc_model_locateanything.so`, found zero sibling model DSOs, built the engine once, passed IoU 1.0, and certified one self-contained HTML report with zero issues.

## Notes For Future Readers
Review the decode helper first, then the comparator and manifest. The helper deliberately preserves only tokens that are part of the LocateAnything answer contract; it does not change global tokenizer behavior.
