### PR TITLE
fix(rwkv): restore continuation parity

### DIFF
--- a/tests/e2e/models/rwkv/e2e_plugins/contract.py
+++ b/tests/e2e/models/rwkv/e2e_plugins/contract.py
@@ -201,7 +201,10 @@ class RwkvCausalContinuationPlugin:
             )
 
         ned = levenshtein_ned(trt_text, ref_text)
-        ned_threshold = threshold.metrics.get("contract_ned_threshold", 0.25)
+        ned_threshold = threshold.metrics.get(
+            "normalized_text_edit_distance",
+            threshold.metrics.get("contract_ned_threshold", 0.2),
+        )
         prefix_len = min(50, min(len(trt_text), len(ref_text)))
         prefix_match = (trt_text[:prefix_len] == ref_text[:prefix_len]) if prefix_len > 0 else True
 

--- a/tests/e2e/models/rwkv/manifests/rwkv-169m.json
+++ b/tests/e2e/models/rwkv/manifests/rwkv-169m.json
@@ -5,7 +5,7 @@
   "family": "rwkv",
   "runtime_strategy": "rwkv_recurrent",
   "task_strategy": "text_generation_causal",
-  "precision": "fp16",
+  "precision": "fp32",
   "max_cache_length": 32,
   "trust_remote_code": false,
   "testcases": [

--- a/tests/e2e/models/rwkv/test_rwkv_continuation_contract.py
+++ b/tests/e2e/models/rwkv/test_rwkv_continuation_contract.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the RWKV continuation contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.models.rwkv.e2e_plugins.contract import RwkvCausalContinuationPlugin
+from tests.e2e_harness.contracts import (
+    E2ECase,
+    StageOutput,
+    StageStatus,
+    ThresholdProfile,
+)
+
+
+def test_rwkv_acceptance_manifest_retains_full_precision() -> None:
+    manifest_path = Path(__file__).parent / "manifests" / "rwkv-169m.json"
+    manifest = json.loads(manifest_path.read_text())
+
+    assert manifest["precision"] == "fp32"
+    assert manifest["testcases"][0]["reference_precision"] == "fp32"
+
+
+_REFERENCE = "the capital of the French Republic. The capital of"
+
+
+def _case() -> E2ECase:
+    return E2ECase(
+        name="rwkv-169m",
+        hf_id="RWKV/rwkv-4-169m-pile",
+        family="rwkv",
+        runtime_strategy="rwkv_recurrent",
+        reference_family="causal_base_continuation",
+        user_contract="continuation_parity",
+        inputs={"prompt": "The capital of France is"},
+    )
+
+
+def _verify(trt_text: str):
+    return RwkvCausalContinuationPlugin().verify(
+        StageOutput(stage_name="full_generation", text=trt_text),
+        StageOutput(stage_name="full_generation", text=_REFERENCE),
+        _case(),
+        ThresholdProfile(
+            task_strategy="text_generation_causal",
+            metrics={"normalized_text_edit_distance": 0.2},
+        ),
+    )
+
+
+def test_rejects_nightly_continuation_above_declared_ned_limit() -> None:
+    """Regression for the false pass in Nightly run 29445075597."""
+    result = _verify("the capital of the French Republic. The")
+
+    assert result.status == StageStatus.FAILED.value
+    assert result.metrics["ned"].value == pytest.approx(0.22)
+    assert result.metrics["ned"].threshold == pytest.approx(0.2)
+    assert not result.metrics["ned"].passed
+
+
+def test_accepts_continuation_within_declared_ned_limit() -> None:
+    result = _verify(_REFERENCE)
+
+    assert result.status == StageStatus.PASSED.value
+    assert result.metrics["ned"].value == pytest.approx(0.0)
+    assert result.metrics["ned"].threshold == pytest.approx(0.2)
+    assert result.metrics["ned"].passed


### PR DESCRIPTION
## Background

Nightly run 29445075597 reported RWKV as passing with TRT output `the capital of the French Republic. The` versus HF output `the capital of the French Republic. The capital of`. Their normalized text edit distance was 0.22, above the model's declared 0.20 limit. The regression began when the acceptance manifest was converted from full precision to FP16 while its reference remained FP32, and the active contract simultaneously used a weaker legacy default.

## Exit Criteria

- Restore TRT/HF continuation parity for the acceptance model.
- Enforce the declared normalized edit-distance limit of 0.20.
- Prevent the acceptance manifest from silently returning to mismatched precision.
- Keep impact and isolated CI limited to RWKV.

## Implementation

- Restore the RWKV acceptance bundle to FP32, matching its FP32 reference and avoiding recurrent decode drift.
- Read `normalized_text_edit_distance` directly, with the legacy key retained only as a compatibility fallback.
- Add regressions for the captured false-green continuation, a valid continuation, and the required acceptance precision.

## Validation

- TensorRT 11.2 GPU0 E2E: passed in 96.39 seconds. TRT and HF both produced `the capital of the French Republic. The capital of`; NED was 0.0 against the 0.20 limit.
- FP32 bundle build: passed in 44.65 seconds; the engine itself compiled in 37.51 seconds.
- [Premerge run 29465892121](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29465892121): passed in 3m56s on the final commit. It selected one RWKV owner/case, staged one DSO with zero siblings, built the engine once, reproduced exact TRT/HF text with NED 0.0, and certified one HTML report with zero issues.
- `env PYTHONPATH=python python3 -m pytest tests/e2e/models/rwkv/test_rwkv_continuation_contract.py tests/e2e/models/rwkv/test_rwkv_builder_engine.py tests/e2e/models/rwkv/test_rwkv_builder_tp.py tests/e2e/models/rwkv/test_rwkv_debug_runner.py tests/e2e/models/rwkv/test_rwkv_diff_logits_dispatch.py -q`: 10 passed, 2 skipped.
- `ruff check tests/e2e/models/rwkv/e2e_plugins/contract.py tests/e2e/models/rwkv/test_rwkv_continuation_contract.py`: passed.
- `python3 tools/model_ci.py impact --repo-root . --base github/main --head HEAD`: selected only `rwkv`; no fallback models or general unit suite.
- `git diff --check`: passed.

## Notes For Future Readers

Review the manifest precision first, then the contract threshold lookup and focused regression. FP16 remains inappropriate for this acceptance checkpoint because small recurrent state differences change greedy token selection.
