### PR TITLE
fix(personaplex): restore speech parity

### DIFF
--- a/python/tensorrt_model_connect/families/personaplex/MODEL.toml
+++ b/python/tensorrt_model_connect/families/personaplex/MODEL.toml
@@ -12,6 +12,12 @@ aliases = [
 prefixes = [
   "personaplex",
 ]
+hf_allow_patterns = [
+  "tokenizer-e351c8d8-checkpoint125.safetensors",
+]
+hf_required_files = [
+  "nvidia/personaplex-7b-v1|tokenizer-e351c8d8-checkpoint125.safetensors",
+]
 hf_warm_dependencies = [
   "personaplex-mimi-codec|kyutai/mimi",
 ]

--- a/python/tensorrt_model_connect/families/personaplex/plugin.py
+++ b/python/tensorrt_model_connect/families/personaplex/plugin.py
@@ -903,7 +903,7 @@ def _translate_personaplex_mimi_weights(
 
 
 def _load_mimi_weights(model_dir: str | Path | None = None):
-    """Load the checkpoint-owned Mimi codec, with kyutai/mimi as fallback.
+    """Load the checkpoint-owned Mimi codec.
 
     Returns a dict mapping weight name -> numpy array.
     Codebook embeddings are computed as embed_sum / cluster_usage.
@@ -912,17 +912,20 @@ def _load_mimi_weights(model_dir: str | Path | None = None):
     from safetensors import safe_open
     import json
 
+    if model_dir is not None:
+        candidate = Path(model_dir) / _PERSONAPLEX_MIMI_FILENAME
+        if not candidate.is_file():
+            raise FileNotFoundError(
+                "PersonaPlex requires its checkpoint-owned Mimi codec: "
+                f"{candidate}"
+            )
+        sf_path = str(candidate)
+    else:
+        sf_path = hf_hub_download("kyutai/mimi", "model.safetensors")
+
     cfg_path = hf_hub_download("kyutai/mimi", "config.json")
     with open(cfg_path) as f:
         mimi_cfg = json.load(f)
-
-    sf_path = None
-    if model_dir is not None:
-        candidate = Path(model_dir) / _PERSONAPLEX_MIMI_FILENAME
-        if candidate.is_file():
-            sf_path = str(candidate)
-    if sf_path is None:
-        sf_path = hf_hub_download("kyutai/mimi", "model.safetensors")
 
     mimi_weights = {}
     with safe_open(sf_path, framework="pt") as sf:

--- a/src/runtime/models/personaplex/audio_helpers.cpp
+++ b/src/runtime/models/personaplex/audio_helpers.cpp
@@ -6,6 +6,7 @@
 #include "audio_helpers.h"
 
 #include <algorithm>
+#include <stdexcept>
 
 namespace trtmc {
 
@@ -64,7 +65,7 @@ std::vector<std::unique_ptr<TrtModule>> load_depth_engines(IBackend* backend,
                                                            const BundleFile& bundle,
                                                            const ModuleCreateOptions& options) {
     std::vector<std::unique_ptr<TrtModule>> depth_engines;
-    auto depth_plans = find_sections_by_prefix(bundle, "depth_engine_plan_");
+    auto depth_plans = find_depth_engine_plans_in_codebook_order(bundle);
     if (!depth_plans.empty()) {
         for (std::size_t i = 0; i < depth_plans.size(); ++i) {
             auto m = extract_optional_module(
@@ -80,6 +81,26 @@ std::vector<std::unique_ptr<TrtModule>> load_depth_engines(IBackend* backend,
             depth_engines.push_back(std::move(m));
     }
     return depth_engines;
+}
+
+std::vector<const std::vector<char>*>
+find_depth_engine_plans_in_codebook_order(const BundleFile& bundle) {
+    constexpr const char* prefix = "depth_engine_plan_";
+    const auto matching_sections = find_sections_by_prefix(bundle, prefix);
+
+    std::vector<const std::vector<char>*> ordered_plans;
+    ordered_plans.reserve(matching_sections.size());
+    // Prefix lookup is lexicographic, which places index 10 before index 2.
+    // Resolve each contiguous codebook section by its exact numeric name.
+    for (std::size_t codebook = 0; codebook < matching_sections.size(); ++codebook) {
+        const auto* plan = find_section(bundle, prefix + std::to_string(codebook));
+        if (plan == nullptr) {
+            throw std::runtime_error(
+                "PersonaPlex depth engine sections must use contiguous numeric indices");
+        }
+        ordered_plans.push_back(plan);
+    }
+    return ordered_plans;
 }
 
 SpeechConfig build_speech_config_from_bundle(const BundleFile& bundle, const std::string& json,

--- a/src/runtime/models/personaplex/audio_helpers.h
+++ b/src/runtime/models/personaplex/audio_helpers.h
@@ -22,6 +22,9 @@ void infer_speech_vocab_sizes(SpeechConfig& sc, const std::string& json, const B
 
 BaseConfig make_depth_engine_config(const std::string& json, const BaseConfig& base);
 
+std::vector<const std::vector<char>*>
+find_depth_engine_plans_in_codebook_order(const BundleFile& bundle);
+
 std::vector<std::unique_ptr<TrtModule>> load_depth_engines(IBackend* backend,
                                                            const BundleFile& bundle,
                                                            const ModuleCreateOptions& options = {});

--- a/tests/cpp/models/personaplex/test_personaplex_speech_pipeline.cpp
+++ b/tests/cpp/models/personaplex/test_personaplex_speech_pipeline.cpp
@@ -5,6 +5,7 @@
 
 #include "../../support/mock_trt_engines.h"
 #include "runtime/backend/trt_module_impl.h"
+#include "runtime/models/personaplex/audio_helpers.h"
 #include "runtime/models/personaplex/kv_cache.h"
 #include "runtime/models/personaplex/pipeline.h"
 #include "runtime/models/personaplex/speech_config.h"
@@ -71,11 +72,32 @@ void test_speech_validates_temporal() {
     check(threw, "speech: null temporal throws");
 }
 
+void test_depth_engines_are_ordered_by_numeric_codebook() {
+    trtmc::BundleFile bundle;
+    const std::vector<int> insertion_order = {10, 2, 0, 7, 1, 9, 5, 3, 8, 4, 6};
+    for (const int codebook : insertion_order) {
+        trtmc::BundleSection section;
+        section.name = "depth_engine_plan_" + std::to_string(codebook);
+        const std::string contents = "plan-" + std::to_string(codebook);
+        section.data.assign(contents.begin(), contents.end());
+        bundle.sections.push_back(std::move(section));
+    }
+
+    const auto plans = trtmc::find_depth_engine_plans_in_codebook_order(bundle);
+    check(plans.size() == insertion_order.size(), "all depth engine plans found");
+    for (std::size_t codebook = 0; codebook < plans.size(); ++codebook) {
+        const std::string contents(plans[codebook]->begin(), plans[codebook]->end());
+        check(contents == "plan-" + std::to_string(codebook),
+              "depth engine plan uses numeric codebook order");
+    }
+}
+
 } // namespace
 
 int main() {
     test_speech_pipeline_construction();
     test_speech_validates_temporal();
+    test_depth_engines_are_ordered_by_numeric_codebook();
     if (failures > 0) {
         std::cerr << failures << " speech pipeline test(s) FAILED\n";
     }

--- a/tests/e2e/models/personaplex/MODEL.toml
+++ b/tests/e2e/models/personaplex/MODEL.toml
@@ -18,5 +18,6 @@ stages = [
 input_fields = [
   { input = "audio", manifest = "test_input_audio" },
   { input = "speech_reference_tokens", manifest = "speech_reference_tokens" },
+  { input = "speech_test_max_frames", manifest = "speech_test_max_frames" },
 ]
 preflight_asset_fields = ["test_input_audio", "speech_reference_tokens"]

--- a/tests/e2e/models/personaplex/e2e_plugins/contract.py
+++ b/tests/e2e/models/personaplex/e2e_plugins/contract.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 from tests.e2e_harness.contracts import MetricResult
+
+
 # Model-owned contract helpers. Keep behavior here so contract semantics do not
 # drift across model families through shared harness code.
 def contract_config(case):
@@ -141,6 +143,13 @@ def make_error(stage_name: str, error: str):
         message=f"Contract verification error: {error}",
     )
 
+
+def _strictest_threshold(metrics, *names: str, default: float) -> float:
+    """Return the strictest configured minimum across equivalent keys."""
+    configured = [float(metrics[name]) for name in names if name in metrics]
+    return max(configured) if configured else default
+
+
 class PersonaPlexSpeechToSpeechPlugin:
     reference_families = ["s2s_personaplex"]
     user_contract = "speech_response"
@@ -154,7 +163,34 @@ class PersonaPlexSpeechToSpeechPlugin:
         trt_wav = trt_output.data.get("wav_path")
         trt_rms = trt_output.data.get("rms")
         trt_duration = trt_output.data.get("duration_s")
-        min_rms = threshold.metrics.get("contract_min_rms", 0.001)
+        min_rms = _strictest_threshold(
+            threshold.metrics,
+            "speech_min_rms",
+            "contract_min_rms",
+            default=0.001,
+        )
+        token_threshold = _strictest_threshold(
+            threshold.metrics,
+            "speech_min_token_match",
+            "contract_token_match",
+            default=0.8,
+        )
+        depth_threshold = _strictest_threshold(
+            threshold.metrics,
+            "depth_token_match_rate",
+            default=0.7,
+        )
+        audio_threshold = _strictest_threshold(
+            threshold.metrics,
+            "audio_token_match_rate",
+            default=0.7,
+        )
+        frame_threshold = _strictest_threshold(
+            threshold.metrics,
+            "frame_exact_match_rate",
+            "speech_min_frame_exact",
+            default=0.7,
+        )
 
         metrics = {}
         has_wav = trt_wav is not None and isinstance(trt_wav, str) and len(trt_wav) > 0
@@ -165,14 +201,15 @@ class PersonaPlexSpeechToSpeechPlugin:
             passed=has_wav,
         )
 
-        if trt_rms is not None:
-            rms_ok = float(trt_rms) >= min_rms
-            metrics["rms"] = MetricResult(
-                value=float(trt_rms),
-                threshold=min_rms,
-                operator=">=",
-                passed=rms_ok,
-            )
+        rms_value = float(trt_rms) if trt_rms is not None else 0.0
+        rms_ok = trt_rms is not None and rms_value >= min_rms
+        metrics["rms"] = MetricResult(
+            value=rms_value,
+            threshold=min_rms,
+            operator=">=",
+            passed=rms_ok,
+            note="configured by speech_min_rms",
+        )
 
         if trt_duration is not None:
             dur_ok = float(trt_duration) >= 0.1
@@ -193,21 +230,83 @@ class PersonaPlexSpeechToSpeechPlugin:
             passed=tokens_available,
         )
         if tokens_available:
-            trt_arr = np.asarray(trt_tokens).reshape(-1)
-            ref_arr = np.asarray(ref_tokens).reshape(-1)
-            token_count = min(trt_arr.size, ref_arr.size)
-            if token_count > 0:
-                token_match = float(np.mean(
-                    trt_arr[:token_count] == ref_arr[:token_count]))
-                token_threshold = threshold.metrics.get(
-                    "contract_token_match", 0.5)
+            trt_arr = np.asarray(trt_tokens)
+            ref_arr = np.asarray(ref_tokens)
+            layout_compatible = (
+                trt_arr.ndim == 2
+                and ref_arr.ndim == 2
+                and trt_arr.shape[1] == ref_arr.shape[1]
+                and trt_arr.shape[1] >= 2
+            )
+            metrics["token_layout_compatible"] = MetricResult(
+                value=1.0 if layout_compatible else 0.0,
+                threshold=1.0,
+                operator="==",
+                passed=layout_compatible,
+                note=(
+                    f"TRT shape={trt_arr.shape}, reference shape={ref_arr.shape}; "
+                    "expected [frames, depth+audio codebooks]"
+                ),
+            )
+
+            frame_count_match = layout_compatible and trt_arr.shape[0] == ref_arr.shape[0]
+            metrics["frame_count_match"] = MetricResult(
+                value=1.0 if frame_count_match else 0.0,
+                threshold=1.0,
+                operator="==",
+                passed=frame_count_match,
+                note=(f"TRT frames={trt_arr.shape[0]}, reference frames={ref_arr.shape[0]}"),
+            )
+
+            frame_count = (
+                min(trt_arr.shape[0], ref_arr.shape[0])
+                if layout_compatible
+                else 0
+            )
+            if frame_count > 0:
+                trt_aligned = trt_arr[:frame_count]
+                ref_aligned = ref_arr[:frame_count]
+
+                token_match = float(np.mean(trt_aligned == ref_aligned))
                 metrics["token_match"] = MetricResult(
                     value=token_match,
                     threshold=token_threshold,
                     operator=">=",
                     passed=token_match >= token_threshold,
+                    note="configured by speech_min_token_match",
                 )
-            else:
+
+                depth_match = float(np.mean(trt_aligned[:, 0] == ref_aligned[:, 0]))
+                metrics["depth_token_match_rate"] = MetricResult(
+                    value=depth_match,
+                    threshold=depth_threshold,
+                    operator=">=",
+                    passed=depth_match >= depth_threshold,
+                )
+
+                audio_match = float(np.mean(trt_aligned[:, 1:] == ref_aligned[:, 1:]))
+                metrics["audio_token_match_rate"] = MetricResult(
+                    value=audio_match,
+                    threshold=audio_threshold,
+                    operator=">=",
+                    passed=audio_match >= audio_threshold,
+                )
+
+                frame_exact = float(np.mean(np.all(
+                    trt_aligned == ref_aligned,
+                    axis=1,
+                )))
+                metrics["frame_exact_match_rate"] = MetricResult(
+                    value=frame_exact,
+                    threshold=frame_threshold,
+                    operator=">=",
+                    passed=frame_exact >= frame_threshold,
+                    note=(
+                        "strictest of frame_exact_match_rate and "
+                        "speech_min_frame_exact"
+                    ),
+                )
+            elif layout_compatible:
                 metrics["non_empty_reference_overlap"] = MetricResult(
                     value=0.0,
                     threshold=1.0,
@@ -215,7 +314,10 @@ class PersonaPlexSpeechToSpeechPlugin:
                     passed=False,
                 )
 
-        rule = "audio health + token match"
+        rule = (
+            "audio health + frame count + aggregate token match + "
+            "depth token match + audio token match + frame exact match"
+        )
         if all(metric.passed for metric in metrics.values()):
             return make_pass("full_generation", metrics, rule)
         return make_fail(

--- a/tests/e2e/models/personaplex/e2e_plugins/runners/audio_speech.py
+++ b/tests/e2e/models/personaplex/e2e_plugins/runners/audio_speech.py
@@ -202,7 +202,7 @@ class SpeechToSpeechRunner:
             cmd = [
                 binary, "speak", bundle_path,
                 "--audio-in", audio_input,
-                "--tail-frames", str(max_frames),
+                "--max-new-tokens", str(max_frames),
             ]
             if distributed_runtime:
                 wrapper = (

--- a/tests/e2e/models/personaplex/test_personaplex_builder_tp.py
+++ b/tests/e2e/models/personaplex/test_personaplex_builder_tp.py
@@ -34,6 +34,11 @@ _MLP = 64
 _VOCAB = 32
 
 
+def test_personaplex_mimi_loader_requires_checkpoint_owned_weights(tmp_path) -> None:
+    with pytest.raises(FileNotFoundError, match="checkpoint-owned Mimi codec"):
+        personaplex_plugin._load_mimi_weights(tmp_path)
+
+
 def _personaplex_tp_builder_module():
     return pytest.importorskip(
         "tensorrt_model_connect.families.personaplex.decoder_tp_builder",

--- a/tests/e2e/models/personaplex/test_personaplex_contract.py
+++ b/tests/e2e/models/personaplex/test_personaplex_contract.py
@@ -16,6 +16,7 @@ from tests.e2e.models.personaplex.e2e_plugins.contract import (
 
 
 _MANIFEST_DIR = Path(__file__).parent / "manifests"
+_THRESHOLD_PATH = Path(__file__).parent / "thresholds" / "personaplex-7b.json"
 
 
 @pytest.mark.parametrize(
@@ -33,12 +34,10 @@ def test_personaplex_builds_require_an_exclusive_gpu(manifest_name: str) -> None
 
 
 def _thresholds() -> ThresholdProfile:
+    threshold_data = json.loads(_THRESHOLD_PATH.read_text(encoding="utf-8"))
     return ThresholdProfile(
         task_strategy="speech_to_speech",
-        metrics={
-            "contract_token_match": 0.5,
-            "contract_min_rms": 0.001,
-        },
+        metrics=threshold_data["threshold_overrides"],
     )
 
 
@@ -69,12 +68,65 @@ def test_contract_compares_runner_tokens_with_official_reference_tokens() -> Non
 
     assert result.passed
     assert result.metrics["token_match"].value == 1.0
+    assert result.metrics["token_match"].threshold == 0.8
+    assert result.metrics["depth_token_match_rate"].passed
+    assert result.metrics["depth_token_match_rate"].threshold == 0.7
+    assert result.metrics["audio_token_match_rate"].passed
+    assert result.metrics["audio_token_match_rate"].threshold == 0.7
+    assert result.metrics["frame_exact_match_rate"].threshold == 0.7
+    assert result.metrics["rms"].threshold == 0.001
 
 
-def test_contract_preserves_original_half_token_match_threshold() -> None:
-    reference = np.arange(24, dtype=np.int32).reshape(3, 8)
+def test_contract_rejects_nightly_token_match_below_declared_minimum() -> None:
+    reference = np.zeros((25, 8), dtype=np.int32)
     actual = reference.copy()
-    actual.reshape(-1)[14:] = -1
+    actual.reshape(-1)[149:] = 1
+    thresholds = _thresholds()
+    thresholds.metrics["contract_token_match"] = 0.5
+    result = PersonaPlexSpeechToSpeechPlugin().verify(
+        StageOutput(
+            stage_name="full_generation",
+            data={
+                "wav_path": "/tmp/output.wav",
+                "rms": 0.01,
+                "output_tokens": actual,
+            },
+        ),
+        StageOutput(
+            stage_name="full_generation",
+            data={"reference_tokens": reference},
+        ),
+        _case(),
+        thresholds,
+    )
+
+    assert not result.passed
+    assert result.metrics["token_match"].value == pytest.approx(0.745)
+    assert result.metrics["token_match"].threshold == 0.8
+    assert not result.metrics["token_match"].passed
+    assert result.metrics["depth_token_match_rate"].passed
+    assert result.metrics["audio_token_match_rate"].passed
+    assert result.metrics["frame_exact_match_rate"].passed
+
+
+def test_contract_rejects_missing_reference_tokens() -> None:
+    result = PersonaPlexSpeechToSpeechPlugin().verify(
+        StageOutput(
+            stage_name="full_generation",
+            data={"wav_path": "/tmp/output.wav", "rms": 0.01},
+        ),
+        StageOutput(stage_name="full_generation", data={}),
+        _case(),
+        _thresholds(),
+    )
+
+    assert not result.passed
+    assert not result.metrics["reference_tokens_available"].passed
+
+
+def test_contract_rejects_extra_runtime_frames() -> None:
+    reference = np.arange(24, dtype=np.int32).reshape(3, 8)
+    actual = np.concatenate([reference, reference[-1:]], axis=0)
     result = PersonaPlexSpeechToSpeechPlugin().verify(
         StageOutput(
             stage_name="full_generation",
@@ -92,21 +144,6 @@ def test_contract_preserves_original_half_token_match_threshold() -> None:
         _thresholds(),
     )
 
-    assert result.passed
-    assert result.metrics["token_match"].value == 14 / 24
-    assert result.metrics["token_match"].threshold == 0.5
-
-
-def test_contract_rejects_missing_reference_tokens() -> None:
-    result = PersonaPlexSpeechToSpeechPlugin().verify(
-        StageOutput(
-            stage_name="full_generation",
-            data={"wav_path": "/tmp/output.wav", "rms": 0.01},
-        ),
-        StageOutput(stage_name="full_generation", data={}),
-        _case(),
-        _thresholds(),
-    )
-
     assert not result.passed
-    assert not result.metrics["reference_tokens_available"].passed
+    assert not result.metrics["frame_count_match"].passed
+    assert result.metrics["token_match"].passed

--- a/tests/e2e/models/personaplex/test_personaplex_reference_audio.py
+++ b/tests/e2e/models/personaplex/test_personaplex_reference_audio.py
@@ -49,6 +49,7 @@ def test_manifest_exposes_model_owned_reference_tokens() -> None:
         model_dir / "data" / "personaplex_recording_official_tokens_greedy.npy"
     )
     assert Path(case.inputs["speech_reference_tokens"]).is_file()
+    assert case.inputs["speech_test_max_frames"] == 100
 
 
 def test_reference_tokens_are_decoded_to_case_local_wav(

--- a/tests/e2e/models/personaplex/test_personaplex_speech_runner.py
+++ b/tests/e2e/models/personaplex/test_personaplex_speech_runner.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused tests for the PersonaPlex speech runtime command."""
+
+from __future__ import annotations
+
+import wave
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from tests.e2e.models.personaplex.e2e_plugins.runners import audio_speech
+from tests.e2e_harness.contracts import E2ECase, RunContext, StageSpec
+
+
+def _write_wav(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    samples = np.array([1024, -1024, 512, -512], dtype="<i2")
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(24_000)
+        wav.writeframes(samples.tobytes())
+
+
+def test_runner_uses_total_frame_budget_without_adding_tail_frames(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    audio_path = tmp_path / "input.wav"
+    _write_wav(audio_path)
+    case = E2ECase(
+        name="personaplex-runner-test",
+        hf_id="nvidia/personaplex-7b-v1",
+        family="personaplex",
+        runtime_strategy="personaplex_speech_to_speech",
+        task_strategy="speech_to_speech",
+        bundle="personaplex.trtfb",
+        inputs={
+            "audio": str(audio_path),
+            "speech_test_max_frames": 100,
+        },
+    )
+    ctx = RunContext(
+        case=case,
+        binary_path="/runtime/trtmc",
+        engine_dir=str(tmp_path / "engines"),
+        artifacts_dir=str(tmp_path / "artifacts"),
+    )
+    seen_command: list[str] = []
+
+    def fake_run(command, **kwargs):
+        seen_command.extend(command)
+        output_path = Path(command[command.index("--audio-out") + 1])
+        _write_wav(output_path)
+        return SimpleNamespace(
+            returncode=0,
+            stdout="generated",
+            stderr=(
+                "[speech] Output frame 0: 1 2 3 4 5 6 7 8\n"
+                "[speech] Output frame 1: 9 10 11 12 13 14 15 16\n"
+            ),
+        )
+
+    monkeypatch.setattr(audio_speech.subprocess, "run", fake_run)
+
+    output = audio_speech.SpeechToSpeechRunner().run_stage(
+        case, StageSpec(name="full_generation"), ctx
+    )
+
+    assert seen_command[seen_command.index("--max-new-tokens") + 1] == "100"
+    assert "--tail-frames" not in seen_command
+    assert output.data["num_frames"] == 2
+    assert output.data["wav_exists"] is True
+    assert Path(output.data["wav_path"]).is_file()

--- a/tests/e2e/models/personaplex/test_personaplex_warm_hf_cache_metadata.py
+++ b/tests/e2e/models/personaplex/test_personaplex_warm_hf_cache_metadata.py
@@ -5,10 +5,21 @@
 
 from __future__ import annotations
 
-from tensorrt_model_connect.families import family_hf_warm_dependencies
+from tensorrt_model_connect.families import (
+    family_hf_allow_patterns,
+    family_hf_required_files_by_id,
+    family_hf_warm_dependencies,
+)
 
 
 def test_personaplex_reference_dependencies_are_family_owned() -> None:
     deps = dict(family_hf_warm_dependencies("personaplex"))
 
     assert deps["personaplex-mimi-codec"] == "kyutai/mimi"
+
+
+def test_personaplex_checkpoint_owned_mimi_is_required() -> None:
+    filename = "tokenizer-e351c8d8-checkpoint125.safetensors"
+
+    assert filename in family_hf_allow_patterns()
+    assert filename in family_hf_required_files_by_id()["nvidia/personaplex-7b-v1"]


### PR DESCRIPTION
## Background
Nightly exposed a PersonaPlex speech token match of 0.745. The acceptance contract was reading permissive fallback keys, but tightening that gate alone only made the regression visible. Runtime tracing found two production causes: depth plans were loaded lexicographically, so plan 10 preceded plan 2, and the warm-cache allowlist omitted the checkpoint-owned Mimi weights, causing production builds to use incompatible fallback encoder weights.

## Exit Criteria
- Production builds use the PersonaPlex checkpoint-owned Mimi codec weights.
- Depth engines are bound in numeric codebook order.
- The L0 speech run emits exactly the expected frame count and passes all declared aggregate, depth, audio, exact-frame, and RMS gates.
- Impact analysis remains scoped to PersonaPlex.

## Implementation
- Resolve contiguous `depth_engine_plan_N` sections by numeric index and cover the 2-versus-10 ordering case in C++.
- Require and warm `tokenizer-e351c8d8-checkpoint125.safetensors` for canonical PersonaPlex production builds instead of silently falling back to unrelated codec weights.
- Pass the model-owned L0 frame budget through `--max-new-tokens`, and reject missing or extra runtime frames.
- Read the declared model thresholds and report aggregate token, depth-codebook, audio-codebook, exact-frame, frame-count, and audio-health results independently.

## Validation
- [GitHub premerge run 29469084292](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29469084292): passed. The isolated model proof rebuilt from scratch and reported 50/50 frames, aggregate 0.9075, depth 0.98, audio 0.8971, exact-frame 0.78, and RMS 0.01865. The combined HTML report and final certification also passed.
- `cmake --build build --target test_personaplex_speech_pipeline -j4 && ./build/test_personaplex_speech_pipeline`: passed.
- `/opt/venv/bin/python -m pytest tests/e2e/models/personaplex/test_personaplex_contract.py tests/e2e/models/personaplex/test_personaplex_reference_audio.py tests/e2e/models/personaplex/test_personaplex_speech_runner.py tests/e2e/models/personaplex/test_personaplex_warm_hf_cache_metadata.py tests/e2e/models/personaplex/test_personaplex_builder_tp.py::test_personaplex_mimi_loader_requires_checkpoint_owned_weights tests/tools/test_warm_hf_cache_static.py -q`: 50 passed.
- Exact CI-image cache preflight with a read-only cache and `--network none`: both the canonical PersonaPlex snapshot and Mimi dependency were cached; zero network calls.
- `PYTHONPATH=python python3 tools/model_ci.py impact --base github/main --head HEAD`: selected only `personaplex`.
- `ruff check` and `clang-format --dry-run --Werror` on changed files: passed.

## Notes For Future Readers
- Start review with `audio_helpers.cpp` for the runtime ordering bug, then `plugin.py` and the family metadata for codec provenance, and finally the model-owned E2E contract.
- Production PersonaPlex builds must not fall back when the checkpoint-owned codec file is absent. The `kyutai/mimi` dependency remains for codec configuration and reference decoding.
- The isolated proof remains network-disabled. The model-owned required-file metadata lets the authenticated nightly cache warmer populate the canonical asset before offline certification.