### PR TITLE
fix(segformer): correct CI evidence

### DIFF
--- a/tests/e2e/models/segformer/e2e_plugins/contract.py
+++ b/tests/e2e/models/segformer/e2e_plugins/contract.py
@@ -201,10 +201,21 @@ class SegformerSegmentationPlugin:
             ref_img = ref_img.resize((trt_arr.shape[1], trt_arr.shape[0]), Image.NEAREST)
             ref_arr = np.array(ref_img, dtype=np.int32)
 
+        required_thresholds = ("mIoU", "pixel_accuracy")
+        missing_thresholds = [
+            name for name in required_thresholds if name not in threshold.metrics
+        ]
+        if missing_thresholds:
+            return make_error(
+                "full_inference",
+                "Missing required SegFormer threshold(s): "
+                + ", ".join(missing_thresholds),
+            )
+
         miou = _compute_iou(trt_arr, ref_arr)
         pixel_acc = _pixel_accuracy(trt_arr, ref_arr)
-        miou_threshold = threshold.metrics.get("contract_miou_threshold", 0.5)
-        pixel_threshold = threshold.metrics.get("contract_pixel_accuracy", 0.85)
+        miou_threshold = float(threshold.metrics["mIoU"])
+        pixel_threshold = float(threshold.metrics["pixel_accuracy"])
         metrics = {
             "mIoU": MetricResult(
                 value=miou,

--- a/tests/e2e/models/segformer/e2e_plugins/runners/segmentation.py
+++ b/tests/e2e/models/segformer/e2e_plugins/runners/segmentation.py
@@ -49,6 +49,45 @@ def _strip_mpirun_tags(text: str) -> str:
     return "\n".join(lines)
 
 
+def _save_segmentation_visualization(
+    class_map,
+    *,
+    image_path: str,
+    visualization_path: str,
+) -> str:
+    """Save a deterministic, input-sized color view of a class-ID map."""
+    from PIL import Image
+    import numpy as np
+
+    class_ids = np.asarray(class_map, dtype=np.int32)
+    if class_ids.ndim != 2 or class_ids.size == 0:
+        raise ValueError("SegFormer class map must be a non-empty 2D array")
+    if int(class_ids.min()) < 0 or int(class_ids.max()) > 255:
+        raise ValueError("SegFormer class IDs must fit in an 8-bit image")
+
+    with Image.open(image_path) as input_image:
+        target_size = input_image.size
+    resampling = getattr(Image, "Resampling", Image)
+    resized = Image.fromarray(class_ids.astype(np.uint8)).resize(
+        target_size,
+        resample=resampling.NEAREST,
+    )
+    resized_ids = np.asarray(resized, dtype=np.uint8)
+
+    # Match the HF reference visualization exactly: the same fixed seed and
+    # class-ID-indexed palette make side-by-side colors directly comparable.
+    random_state = np.random.RandomState(42)
+    palette = random_state.randint(
+        0,
+        255,
+        (int(resized_ids.max()) + 1, 3),
+        dtype=np.uint8,
+    )
+    palette[0] = [0, 0, 0]
+    Image.fromarray(palette[resized_ids]).save(visualization_path)
+    return visualization_path
+
+
 class SegmentationRunner:
     """TRT inference runner for semantic segmentation models."""
 
@@ -153,14 +192,24 @@ class SegmentationRunner:
             )
         elapsed = time.monotonic() - t0
 
-        # Parse class map from output image
+        # Parse the raw class map and create a report-only visualization. Keep
+        # the raw map for numerical comparison, but expose only the colorized,
+        # input-sized image through the report artifact contract.
         class_map = None
+        visualization_path = None
         if result.returncode == 0 and os.path.isfile(output_path):
             try:
                 from PIL import Image
                 import numpy as np
                 class_img = np.array(Image.open(output_path).convert("L"))
                 class_map = class_img.astype(np.int32)
+                visualization_path = _save_segmentation_visualization(
+                    class_map,
+                    image_path=str(image_path),
+                    visualization_path=str(
+                        Path(output_path).with_name("seg_output_viz.png")
+                    ),
+                )
             except Exception as e:
                 logger.warning("Failed to load segmentation output: %s", e)
 
@@ -176,14 +225,17 @@ class SegmentationRunner:
         if stderr_log:
             seg_meta["stderr_log"] = stderr_log
 
+        data = {
+            "class_map": class_map,
+            "class_map_path": output_path,
+            "image_path": str(image_path),
+        }
+        if visualization_path:
+            data["viz_path"] = visualization_path
+
         return StageOutput(
             stage_name="full_inference",
-            data={
-                "class_map": class_map,
-                "output_path": output_path,
-                "segmentation_map_path": output_path,
-                "image_path": str(image_path),
-            },
+            data=data,
             timing_s=elapsed,
             metadata=seg_meta,
         )

--- a/tests/e2e/models/segformer/test_segformer_ci_evidence.py
+++ b/tests/e2e/models/segformer/test_segformer_ci_evidence.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused checks for SegFormer acceptance thresholds and report evidence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+from PIL import Image
+
+from tests.e2e.models.segformer.e2e_plugins.contract import (
+    SegformerSegmentationPlugin,
+)
+from tests.e2e.models.segformer.e2e_plugins.runners.segmentation import (
+    SegmentationRunner,
+    _save_segmentation_visualization,
+)
+from tests.e2e_harness.contracts import (
+    E2ECase,
+    RunContext,
+    StageOutput,
+    ThresholdProfile,
+)
+from tests.e2e_harness.orchestrator import _auto_register_artifacts
+
+
+def _output(class_map: np.ndarray) -> StageOutput:
+    return StageOutput(stage_name="full_inference", data={"class_map": class_map})
+
+
+def test_contract_consumes_declared_segmentation_thresholds() -> None:
+    trt = np.array([[0, 0], [0, 1]], dtype=np.int32)
+    ref = np.array([[0, 1], [1, 1]], dtype=np.int32)
+    thresholds = ThresholdProfile(
+        task_strategy="segmentation",
+        metrics={
+            "mIoU": 0.60,
+            "pixel_accuracy": 0.85,
+            # Legacy names must not weaken the declared acceptance criteria.
+            "contract_miou_threshold": 0.10,
+            "contract_pixel_accuracy": 0.10,
+        },
+    )
+
+    result = SegformerSegmentationPlugin().verify(_output(trt), _output(ref), None, thresholds)
+
+    assert result.status == "failed"
+    assert result.metrics["mIoU"].threshold == 0.60
+    assert result.metrics["pixel_accuracy"].threshold == 0.85
+    assert not result.metrics["mIoU"].passed
+    assert not result.metrics["pixel_accuracy"].passed
+
+
+def test_contract_requires_both_declared_thresholds() -> None:
+    class_map = np.zeros((2, 2), dtype=np.int32)
+    thresholds = ThresholdProfile(
+        task_strategy="segmentation",
+        metrics={"pixel_accuracy": 0.85},
+    )
+
+    result = SegformerSegmentationPlugin().verify(
+        _output(class_map), _output(class_map), None, thresholds
+    )
+
+    assert result.status == "error"
+    assert "mIoU" in result.message
+
+
+def test_trt_visualization_matches_hf_palette_and_input_size(
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "input.png"
+    visualization_path = tmp_path / "seg_output_viz.png"
+    Image.new("RGB", (6, 4), color="white").save(input_path)
+    class_map = np.array([[0, 1, 2], [2, 1, 0]], dtype=np.int32)
+
+    returned = _save_segmentation_visualization(
+        class_map,
+        image_path=str(input_path),
+        visualization_path=str(visualization_path),
+    )
+
+    assert returned == str(visualization_path)
+    rendered = np.asarray(Image.open(visualization_path).convert("RGB"))
+    assert rendered.shape == (4, 6, 3)
+
+    random_state = np.random.RandomState(42)
+    hf_palette = random_state.randint(0, 255, (3, 3), dtype=np.uint8)
+    hf_palette[0] = [0, 0, 0]
+    expected_ids = np.asarray(
+        Image.fromarray(class_map.astype(np.uint8)).resize(
+            (6, 4),
+            resample=getattr(Image, "Resampling", Image).NEAREST,
+        )
+    )
+    np.testing.assert_array_equal(rendered, hf_palette[expected_ids])
+
+
+def test_runner_registers_only_human_readable_segmentation_artifact(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "input.png"
+    binary_path = tmp_path / "trtmc"
+    Image.new("RGB", (6, 4), color="white").save(input_path)
+    binary_path.touch()
+    raw_class_map = np.array([[0, 1, 2], [2, 1, 0]], dtype=np.uint8)
+
+    def fake_run(command, **_kwargs):
+        output_path = Path(command[command.index("--output") + 1])
+        Image.fromarray(raw_class_map).save(output_path)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "tests.e2e.models.segformer.e2e_plugins.runners.segmentation.subprocess.run",
+        fake_run,
+    )
+    case = E2ECase(
+        name="segformer-report-test",
+        hf_id="nvidia/segformer-b0-finetuned-ade-512-512",
+        family="segformer",
+        runtime_strategy="segformer_segmentation",
+        task_strategy="segmentation",
+        bundle="segformer-report-test.trtfb",
+        inputs={"image": str(input_path)},
+    )
+    artifacts_dir = tmp_path / "artifacts"
+    output = SegmentationRunner()._run_full_inference(
+        case,
+        RunContext(
+            case=case,
+            artifacts_dir=str(artifacts_dir),
+            binary_path=str(binary_path),
+            engine_dir=str(tmp_path),
+        ),
+    )
+
+    assert output.data["class_map_path"].endswith("seg_output.png")
+    assert output.data["viz_path"].endswith("seg_output_viz.png")
+    assert "output_path" not in output.data
+    assert "segmentation_map_path" not in output.data
+
+    class Sink:
+        base_dir = artifacts_dir / case.name
+
+        def __init__(self) -> None:
+            self.artifacts = {}
+
+        def register_artifact(self, key, value) -> None:
+            self.artifacts[key] = value
+
+    sink = Sink()
+    _auto_register_artifacts(sink, output, "trt")
+    assert sink.artifacts == {"trt_segmentation_map": "seg_output_viz.png"}


### PR DESCRIPTION
## Background

Nightly run 29445075597 exposed two SegFormer CI evidence gaps: the configured mIoU 0.60 threshold was replaced by a legacy 0.50 default, and the HTML report compared a raw 128x128 grayscale TRT class map with a colorized 640x382 Hugging Face visualization.

## Exit Criteria

- Enforce the declared mIoU 0.60 and pixel_accuracy 0.85 thresholds.
- Preserve raw class maps for numerical comparison and publish directly comparable TRT/Hugging Face visualizations.
- Keep the change model-owned so impact analysis selects only SegFormer.

## Implementation

- Require the declared threshold keys in the SegFormer contract instead of using legacy defaults.
- Colorize the TRT class map with the same deterministic palette as the Hugging Face reference and resize it to the input resolution with nearest-neighbor sampling.
- Register only the human-readable visualization in the HTML report while retaining raw class IDs for numerical validation.
- Add focused regressions for thresholds, visualization parity, and report artifact registration.

## Validation

### Local

- SegFormer-owned pytest selection: 35 passed, 3 skipped.
- Ruff checks on all changed Python files: passed.
- Model CI impact from github/main to HEAD: affected_models is only segformer; no fallback models; no general unit-test scope.
- git diff --check: passed.

### Live selective CI

[Premerge run 29460974675](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29460974675) passed end to end in 4m35s; the isolated SegFormer model job passed in 3m42s.

- Selection and isolation: one owner (segformer), one E2E case (segformer-b0-ade), one full bundle/engine build invocation, one model DSO, zero sibling models, strict plugin search, and network disabled.
- Numerical proof: mIoU 0.8283914726393657 >= 0.60 and pixel accuracy 0.950927734375 >= 0.85.
- Report proof: the TRT and Hugging Face segmentation images are both 640x382 RGB visualizations; the combined HTML report found zero missing, duplicate, invalid, or unexpected model issues.
- Graph proof: Legal compliance, Ownership and impact, Source quality, the direct segformer model node, Combined HTML report, and the Premerge CI gate all passed. The unrelated general C++/Python unit lane was skipped.

## Notes For Future Readers

Review the contract threshold lookup first, the runner visualization second, and the focused regression tests last. Numerical acceptance is stricter after this change; no pass criterion was weakened.