### PR TITLE
fix(segformer): align processor and mask output

### DIFF
--- a/src/runtime/models/segformer/segformer_postprocess_seam.h
+++ b/src/runtime/models/segformer/segformer_postprocess_seam.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -48,12 +50,78 @@ inline bool get_segformer_logits_expected_size(const SegformerLogitsShape& shape
     return true;
 }
 
+namespace segformer_detail {
+
+struct BilinearSpan {
+    int32_t first{0};
+    int32_t second{0};
+    float lerp{0.0F};
+};
+
+inline std::vector<BilinearSpan> make_bilinear_spans(int32_t source_size, int32_t target_size) {
+    std::vector<BilinearSpan> spans(static_cast<std::size_t>(target_size));
+    const float scale = static_cast<float>(source_size) / static_cast<float>(target_size);
+    for (int32_t target_index = 0; target_index < target_size; ++target_index) {
+        const float source_index = (static_cast<float>(target_index) + 0.5F) * scale - 0.5F;
+        const int32_t first_unclamped = static_cast<int32_t>(std::floor(source_index));
+        spans[static_cast<std::size_t>(target_index)] = {
+            std::clamp(first_unclamped, 0, source_size - 1),
+            std::clamp(first_unclamped + 1, 0, source_size - 1),
+            source_index - static_cast<float>(first_unclamped),
+        };
+    }
+    return spans;
+}
+
+inline void resize_class_horizontally(const std::vector<float>& logits, int32_t class_index,
+                                      int32_t source_h, int32_t source_w,
+                                      const std::vector<BilinearSpan>& x_spans,
+                                      std::vector<float>& horizontal) {
+    const std::size_t source_plane_size =
+        static_cast<std::size_t>(source_h) * static_cast<std::size_t>(source_w);
+    const std::size_t target_width = x_spans.size();
+    const std::size_t class_offset = static_cast<std::size_t>(class_index) * source_plane_size;
+    for (int32_t source_y = 0; source_y < source_h; ++source_y) {
+        const std::size_t source_row = class_offset + static_cast<std::size_t>(source_y) * source_w;
+        const std::size_t horizontal_row = static_cast<std::size_t>(source_y) * target_width;
+        for (std::size_t target_x = 0; target_x < target_width; ++target_x) {
+            const auto& span = x_spans[target_x];
+            horizontal[horizontal_row + target_x] =
+                logits[source_row + static_cast<std::size_t>(span.first)] * (1.0F - span.lerp) +
+                logits[source_row + static_cast<std::size_t>(span.second)] * span.lerp;
+        }
+    }
+}
+
+inline void update_class_map(const std::vector<float>& horizontal, int32_t class_index,
+                             std::size_t target_width, const std::vector<BilinearSpan>& y_spans,
+                             std::vector<float>& best_values, std::vector<int32_t>& class_map) {
+    for (std::size_t target_y = 0; target_y < y_spans.size(); ++target_y) {
+        const auto& span = y_spans[target_y];
+        const std::size_t first_row = static_cast<std::size_t>(span.first) * target_width;
+        const std::size_t second_row = static_cast<std::size_t>(span.second) * target_width;
+        const std::size_t target_row = target_y * target_width;
+        for (std::size_t target_x = 0; target_x < target_width; ++target_x) {
+            const std::size_t target_index = target_row + target_x;
+            const float value = horizontal[first_row + target_x] * (1.0F - span.lerp) +
+                                horizontal[second_row + target_x] * span.lerp;
+            if (value > best_values[target_index]) {
+                best_values[target_index] = value;
+                class_map[target_index] = class_index;
+            }
+        }
+    }
+}
+
+} // namespace segformer_detail
+
 inline SegformerPostprocessStatus
 compute_segformer_class_map_from_logits(const std::vector<float>& logits,
-                                        const SegformerLogitsShape& shape,
-                                        std::vector<int32_t>& class_map) {
+                                        const SegformerLogitsShape& shape, int32_t target_h,
+                                        int32_t target_w, std::vector<int32_t>& class_map) {
     std::size_t expected_logits_size = 0;
-    if (!get_segformer_logits_expected_size(shape, expected_logits_size)) {
+    if (!get_segformer_logits_expected_size(shape, expected_logits_size) || target_h <= 0 ||
+        target_w <= 0) {
         class_map.clear();
         return SegformerPostprocessStatus::kInvalidShape;
     }
@@ -64,33 +132,40 @@ compute_segformer_class_map_from_logits(const std::vector<float>& logits,
     }
 
     const int32_t num_classes = shape.num_classes;
-    const int32_t output_h = shape.output_h;
-    const int32_t output_w = shape.output_w;
-    const std::size_t plane_size =
-        static_cast<std::size_t>(output_h) * static_cast<std::size_t>(output_w);
+    const std::size_t target_height = static_cast<std::size_t>(target_h);
+    const std::size_t target_width = static_cast<std::size_t>(target_w);
+    constexpr std::size_t kMaxSize = std::numeric_limits<std::size_t>::max();
+    const std::size_t source_height = static_cast<std::size_t>(shape.output_h);
+    if (target_height > (kMaxSize / target_width) || source_height > (kMaxSize / target_width)) {
+        class_map.clear();
+        return SegformerPostprocessStatus::kInvalidShape;
+    }
 
-    class_map.resize(plane_size);
-    for (int32_t y = 0; y < output_h; ++y) {
-        for (int32_t x = 0; x < output_w; ++x) {
-            const std::size_t pixel_index =
-                static_cast<std::size_t>(y) * static_cast<std::size_t>(output_w) +
-                static_cast<std::size_t>(x);
+    const int32_t source_h = shape.output_h;
+    const int32_t source_w = shape.output_w;
+    const auto x_spans = segformer_detail::make_bilinear_spans(source_w, target_w);
+    const auto y_spans = segformer_detail::make_bilinear_spans(source_h, target_h);
+    const std::size_t target_plane_size = target_height * target_width;
+    std::vector<float> best_values(target_plane_size, -1e30F);
+    std::vector<float> horizontal(source_height * target_width);
+    class_map.assign(target_plane_size, 0);
 
-            int32_t best_class = 0;
-            float best_val = -1e30F;
-            for (int32_t c = 0; c < num_classes; ++c) {
-                const float val = logits[static_cast<std::size_t>(c) * plane_size + pixel_index];
-                if (val > best_val) {
-                    best_val = val;
-                    best_class = c;
-                }
-            }
-
-            class_map[pixel_index] = best_class;
-        }
+    for (int32_t c = 0; c < num_classes; ++c) {
+        segformer_detail::resize_class_horizontally(logits, c, source_h, source_w, x_spans,
+                                                    horizontal);
+        segformer_detail::update_class_map(horizontal, c, target_width, y_spans, best_values,
+                                           class_map);
     }
 
     return SegformerPostprocessStatus::kOk;
+}
+
+inline SegformerPostprocessStatus
+compute_segformer_class_map_from_logits(const std::vector<float>& logits,
+                                        const SegformerLogitsShape& shape,
+                                        std::vector<int32_t>& class_map) {
+    return compute_segformer_class_map_from_logits(logits, shape, shape.output_h, shape.output_w,
+                                                   class_map);
 }
 
 } // namespace trtmc

--- a/src/runtime/models/segformer/segformer_preprocess_seam.cpp
+++ b/src/runtime/models/segformer/segformer_preprocess_seam.cpp
@@ -5,8 +5,8 @@
 
 #include "runtime/models/segformer/segformer_preprocess_seam.h"
 
-#include "stb_image_resize2.h"
-
+#include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <stdexcept>
@@ -15,6 +15,15 @@
 namespace trtmc {
 
 namespace {
+
+constexpr int32_t kPillowPrecisionBits = 22;
+constexpr int32_t kPillowRounding = 1 << (kPillowPrecisionBits - 1);
+constexpr int32_t kPillowCoefficientScale = 1 << kPillowPrecisionBits;
+
+struct BilinearSpan {
+    int32_t first{0};
+    std::vector<int32_t> weights;
+};
 
 void validate_segformer_preprocess_config(const SegformerPreprocessConfig& config) {
     if (config.input_image_h <= 0 || config.input_image_w <= 0) {
@@ -29,6 +38,91 @@ void validate_segformer_preprocess_config(const SegformerPreprocessConfig& confi
     }
 }
 
+std::vector<BilinearSpan> make_pillow_bilinear_spans(int32_t input_size, int32_t output_size) {
+    const double scale = static_cast<double>(input_size) / output_size;
+    const double filter_scale = std::max(scale, 1.0);
+    const double support = filter_scale;
+    const double inverse_filter_scale = 1.0 / filter_scale;
+    std::vector<BilinearSpan> spans(static_cast<std::size_t>(output_size));
+
+    for (int32_t output_index = 0; output_index < output_size; ++output_index) {
+        const double center = (static_cast<double>(output_index) + 0.5) * scale;
+        const int32_t first = std::max(0, static_cast<int32_t>(center - support + 0.5));
+        const int32_t end = std::min(input_size, static_cast<int32_t>(center + support + 0.5));
+        auto& span = spans[static_cast<std::size_t>(output_index)];
+        span.first = first;
+        span.weights.resize(static_cast<std::size_t>(end - first));
+
+        std::vector<double> floating_weights(span.weights.size());
+        double weight_sum = 0.0;
+        for (int32_t input_index = first; input_index < end; ++input_index) {
+            const double distance =
+                std::abs((static_cast<double>(input_index) - center + 0.5) * inverse_filter_scale);
+            const double weight = distance < 1.0 ? 1.0 - distance : 0.0;
+            floating_weights[static_cast<std::size_t>(input_index - first)] = weight;
+            weight_sum += weight;
+        }
+        for (std::size_t i = 0; i < span.weights.size(); ++i) {
+            span.weights[i] = static_cast<int32_t>(0.5 + floating_weights[i] / weight_sum *
+                                                             kPillowCoefficientScale);
+        }
+    }
+    return spans;
+}
+
+uint8_t apply_pillow_bilinear_span(const uint8_t* input, int32_t stride, const BilinearSpan& span) {
+    int64_t sum = kPillowRounding;
+    for (std::size_t i = 0; i < span.weights.size(); ++i) {
+        sum += static_cast<int64_t>(input[(span.first + static_cast<int32_t>(i)) * stride]) *
+               span.weights[i];
+    }
+    return static_cast<uint8_t>(std::clamp<int64_t>(sum >> kPillowPrecisionBits, 0, 255));
+}
+
+std::vector<uint8_t> resize_pillow_bilinear_rgb(const std::vector<uint8_t>& input, int32_t input_h,
+                                                int32_t input_w, int32_t output_h,
+                                                int32_t output_w) {
+    std::vector<uint8_t> horizontal;
+    const std::vector<uint8_t>* vertical_input = &input;
+    if (input_w != output_w) {
+        const auto spans = make_pillow_bilinear_spans(input_w, output_w);
+        horizontal.resize(static_cast<std::size_t>(input_h) * output_w * 3U);
+        for (int32_t y = 0; y < input_h; ++y) {
+            for (int32_t x = 0; x < output_w; ++x) {
+                const auto& span = spans[static_cast<std::size_t>(x)];
+                for (int32_t channel = 0; channel < 3; ++channel) {
+                    const auto input_offset = static_cast<std::size_t>(y) * input_w * 3U +
+                                              static_cast<std::size_t>(channel);
+                    const auto output_offset =
+                        (static_cast<std::size_t>(y) * output_w + x) * 3U + channel;
+                    horizontal[output_offset] =
+                        apply_pillow_bilinear_span(input.data() + input_offset, 3, span);
+                }
+            }
+        }
+        vertical_input = &horizontal;
+    }
+
+    if (input_h == output_h) {
+        return *vertical_input;
+    }
+    const auto spans = make_pillow_bilinear_spans(input_h, output_h);
+    std::vector<uint8_t> output(static_cast<std::size_t>(output_h) * output_w * 3U);
+    for (int32_t y = 0; y < output_h; ++y) {
+        const auto& span = spans[static_cast<std::size_t>(y)];
+        for (int32_t x = 0; x < output_w; ++x) {
+            for (int32_t channel = 0; channel < 3; ++channel) {
+                const auto input_offset = (static_cast<std::size_t>(x) * 3U) + channel;
+                const auto output_offset =
+                    (static_cast<std::size_t>(y) * output_w + x) * 3U + channel;
+                output[output_offset] = apply_pillow_bilinear_span(
+                    vertical_input->data() + input_offset, output_w * 3, span);
+            }
+        }
+    }
+    return output;
+}
+
 } // namespace
 
 std::vector<float> preprocess_segformer_image(const float* image_pixels, int32_t image_height,
@@ -41,13 +135,19 @@ std::vector<float> preprocess_segformer_image(const float* image_pixels, int32_t
 
     const int32_t input_h = config.input_image_h;
     const int32_t input_w = config.input_image_w;
-    std::vector<float> resized(static_cast<std::size_t>(input_h) * input_w * 3U);
-    if (stbir_resize(image_pixels, image_width, image_height,
-                     image_width * 3 * static_cast<int32_t>(sizeof(float)), resized.data(), input_w,
-                     input_h, input_w * 3 * static_cast<int32_t>(sizeof(float)), STBIR_RGB,
-                     STBIR_TYPE_FLOAT, STBIR_EDGE_CLAMP, STBIR_FILTER_TRIANGLE) == nullptr) {
-        throw std::runtime_error("Failed to resize SegFormer input image");
+    const auto source_size = static_cast<std::size_t>(image_height) * image_width * 3U;
+    std::vector<uint8_t> source_u8(source_size);
+    for (std::size_t i = 0; i < source_size; ++i) {
+        const float scaled = std::clamp(image_pixels[i], 0.0F, 1.0F) * 255.0F;
+        source_u8[i] = static_cast<uint8_t>(std::lround(scaled));
     }
+
+    // Hugging Face's SegformerImageProcessor resizes PIL RGB images before
+    // converting them to float tensors. Match Pillow's separable bilinear
+    // filter support, half-pixel centers, fixed-point coefficients, and uint8
+    // rounding at each pass.
+    const auto resized =
+        resize_pillow_bilinear_rgb(source_u8, image_height, image_width, input_h, input_w);
 
     std::vector<float> pixel_values(static_cast<std::size_t>(3) * input_h * input_w);
     for (int32_t y = 0; y < input_h; ++y) {
@@ -55,8 +155,9 @@ std::vector<float> preprocess_segformer_image(const float* image_pixels, int32_t
             const auto src_idx = static_cast<std::size_t>((y * input_w + x) * 3);
             for (int32_t c = 0; c < 3; ++c) {
                 const auto channel = static_cast<std::size_t>(c);
-                const float value = (resized[src_idx + channel] - config.image_mean[channel]) /
-                                    config.image_std[channel];
+                const float rescaled = static_cast<float>(resized[src_idx + channel]) / 255.0F;
+                const float value =
+                    (rescaled - config.image_mean[channel]) / config.image_std[channel];
                 pixel_values[channel * static_cast<std::size_t>(input_h) * input_w +
                              static_cast<std::size_t>(y) * input_w + x] = value;
             }

--- a/src/runtime/models/segformer/segment_pipeline.cpp
+++ b/src/runtime/models/segformer/segment_pipeline.cpp
@@ -79,12 +79,12 @@ SegmentResult SegmentPipeline::segment(const float* pixels, int32_t height, int3
         const auto logits_size = static_cast<std::size_t>(num_classes) * out_h * out_w;
         const std::vector<float> logits(data, data + logits_size);
         const SegformerLogitsShape logits_shape{num_classes, out_h, out_w};
-        const auto status =
-            compute_segformer_class_map_from_logits(logits, logits_shape, result.mask);
+        const auto status = compute_segformer_class_map_from_logits(logits, logits_shape, height,
+                                                                    width, result.mask);
         if (status != SegformerPostprocessStatus::kOk)
             throw std::runtime_error("SegmentPipeline: invalid SegFormer logits shape");
-        result.height = out_h;
-        result.width = out_w;
+        result.height = height;
+        result.width = width;
     } else {
         auto n = out_tensor->numel();
         result.height = height;

--- a/tests/cpp/models/segformer/test_segformer_postprocess_seam.cpp
+++ b/tests/cpp/models/segformer/test_segformer_postprocess_seam.cpp
@@ -121,6 +121,44 @@ void test_segformer_postprocess_logits_size_mismatch() {
     check(class_map.empty(), "postprocess logits mismatch: class_map cleared");
 }
 
+void test_segformer_postprocess_resizes_logits_before_argmax() {
+    const trtmc::SegformerLogitsShape shape{2, 2, 2};
+    const std::vector<float> logits = {
+        // class 0
+        1.0F,
+        0.0F,
+        0.0F,
+        1.0F,
+        // class 1
+        0.0F,
+        1.0F,
+        1.0F,
+        0.0F,
+    };
+
+    std::vector<int32_t> class_map;
+    const auto status =
+        trtmc::compute_segformer_class_map_from_logits(logits, shape, 3, 3, class_map);
+
+    check(status == trtmc::SegformerPostprocessStatus::kOk,
+          "postprocess resize-before-argmax: status ok");
+    check_eq(class_map, std::vector<int32_t>{0, 0, 1, 0, 0, 0, 1, 0, 0},
+             "postprocess resize-before-argmax: HF bilinear class map");
+}
+
+void test_segformer_postprocess_rejects_invalid_target_shape() {
+    const trtmc::SegformerLogitsShape shape{2, 1, 1};
+    const std::vector<float> logits = {1.0F, 0.0F};
+    std::vector<int32_t> class_map = {9};
+
+    const auto status =
+        trtmc::compute_segformer_class_map_from_logits(logits, shape, 0, 4, class_map);
+
+    check(status == trtmc::SegformerPostprocessStatus::kInvalidShape,
+          "postprocess invalid target: status");
+    check(class_map.empty(), "postprocess invalid target: class_map cleared");
+}
+
 } // namespace
 
 int main() {
@@ -128,6 +166,8 @@ int main() {
     test_segformer_postprocess_tie_selects_first_class();
     test_segformer_postprocess_invalid_shape();
     test_segformer_postprocess_logits_size_mismatch();
+    test_segformer_postprocess_resizes_logits_before_argmax();
+    test_segformer_postprocess_rejects_invalid_target_shape();
     if (g_failures != 0) {
         std::cerr << g_failures << " SegFormer postprocess seam test(s) failed" << '\n';
         return 1;

--- a/tests/cpp/models/segformer/test_segformer_preprocess_seam.cpp
+++ b/tests/cpp/models/segformer/test_segformer_preprocess_seam.cpp
@@ -51,6 +51,18 @@ trtmc::runtime::adapters::io::DecodedImage make_two_pixel_image() {
     return image;
 }
 
+trtmc::runtime::adapters::io::DecodedImage make_rectangular_processor_fixture() {
+    trtmc::runtime::adapters::io::DecodedImage image;
+    image.width = 4;
+    image.height = 2;
+    image.channels = 3;
+    image.pixels = {
+        0,   10, 20,  64,  74, 84, 192, 202, 212, 255, 245, 235,
+        255, 0,  128, 192, 32, 96, 64,  224, 48,  0,   255, 16,
+    };
+    return image;
+}
+
 void test_segformer_preprocess_normalizes_decoded_image() {
     trtmc::SegformerPreprocessConfig config;
     config.input_image_h = 1;
@@ -94,7 +106,36 @@ void test_segformer_preprocess_uses_bilinear_resize() {
     const auto pixel_values = trtmc::preprocess_segformer_image(pixels.data(), 2, 2, config);
     check(pixel_values.size() == 27, "segformer bilinear resize size");
     if (pixel_values.size() == 27) {
-        check_close(pixel_values[4], 0.5F, 1e-6F, "segformer bilinear resize blends center pixel");
+        check_close(pixel_values[4], 128.0F / 255.0F, 1e-6F,
+                    "segformer bilinear resize blends center pixel");
+    }
+}
+
+void test_segformer_preprocess_matches_hf_processor_bilinear_golden() {
+    trtmc::SegformerPreprocessConfig config;
+    config.input_image_h = 3;
+    config.input_image_w = 3;
+    config.image_mean = {0.0F, 0.0F, 0.0F};
+    config.image_std = {1.0F, 1.0F, 1.0F};
+
+    // Golden output from the pinned SegformerImageProcessor bilinear resize
+    // contract. The source is rectangular so one axis shrinks while the other
+    // grows, exercising the antialias and half-pixel sampling behavior that
+    // the end-to-end vehicle fixture depends on.
+    const std::vector<float> expected_u8 = {
+        19,  128, 236, 128, 128, 128, 236, 128, 19,  29,  138, 232, 20, 133,
+        239, 10,  128, 246, 39,  148, 228, 79,  110, 127, 118, 72,  26,
+    };
+
+    const auto pixel_values =
+        trtmc::preprocess_segformer_image(make_rectangular_processor_fixture(), config);
+    check(pixel_values.size() == expected_u8.size(), "segformer HF bilinear golden size");
+    if (pixel_values.size() != expected_u8.size()) {
+        return;
+    }
+    for (std::size_t i = 0; i < expected_u8.size(); ++i) {
+        check_close(pixel_values[i], expected_u8[i] / 255.0F, 1e-6F,
+                    "segformer HF bilinear golden value");
     }
 }
 
@@ -104,6 +145,7 @@ int main() {
     test_segformer_preprocess_normalizes_decoded_image();
     test_segformer_preprocess_rejects_empty_image();
     test_segformer_preprocess_uses_bilinear_resize();
+    test_segformer_preprocess_matches_hf_processor_bilinear_golden();
 
     if (g_failures != 0) {
         std::cerr << g_failures << " SegFormer preprocess seam test(s) failed\n";

--- a/tests/cpp/models/segformer/test_segformer_segment_pipeline.cpp
+++ b/tests/cpp/models/segformer/test_segformer_segment_pipeline.cpp
@@ -194,11 +194,11 @@ static void test_segment_with_class_output() {
                                                          engine->createExecutionContext(), stream);
     trtmc::SegmentPipeline pipeline(std::move(module), make_test_preprocess_config());
 
-    float img[3 * 4 * 4] = {0};
-    auto result = pipeline.segment(img, 4, 4);
-    check(result.mask.size() == 16, "segment 2d: mask has 16 entries");
-    check(result.height == 4, "segment 2d: height = 4");
-    check(result.width == 4, "segment 2d: width = 4");
+    float img[3 * 2 * 3] = {0};
+    auto result = pipeline.segment(img, 2, 3);
+    check(result.mask.size() == 6, "segment 2d: mask matches source image size");
+    check(result.height == 2, "segment 2d: height matches source image");
+    check(result.width == 3, "segment 2d: width matches source image");
 
     cudaStreamDestroy(stream);
 }

--- a/tests/e2e/models/segformer/e2e_plugins/contract.py
+++ b/tests/e2e/models/segformer/e2e_plugins/contract.py
@@ -190,16 +190,10 @@ class SegformerSegmentationPlugin:
         trt_arr = np.asarray(trt_mask, dtype=np.int32)
         ref_arr = np.asarray(ref_mask, dtype=np.int32)
         if trt_arr.shape != ref_arr.shape:
-            try:
-                from PIL import Image
-            except ImportError:
-                return make_error(
-                    "full_inference",
-                    f"Shape mismatch {trt_arr.shape} vs {ref_arr.shape} and PIL unavailable",
-                )
-            ref_img = Image.fromarray(ref_arr.astype(np.uint8))
-            ref_img = ref_img.resize((trt_arr.shape[1], trt_arr.shape[0]), Image.NEAREST)
-            ref_arr = np.array(ref_img, dtype=np.int32)
+            return make_error(
+                "full_inference",
+                f"Segmentation shape mismatch: TRT {trt_arr.shape} vs reference {ref_arr.shape}",
+            )
 
         required_thresholds = ("mIoU", "pixel_accuracy")
         missing_thresholds = [

--- a/tests/e2e/models/segformer/test_segformer_ci_evidence.py
+++ b/tests/e2e/models/segformer/test_segformer_ci_evidence.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -37,8 +38,8 @@ def test_contract_consumes_declared_segmentation_thresholds() -> None:
     thresholds = ThresholdProfile(
         task_strategy="segmentation",
         metrics={
-            "mIoU": 0.60,
-            "pixel_accuracy": 0.85,
+            "mIoU": 0.94,
+            "pixel_accuracy": 0.99,
             # Legacy names must not weaken the declared acceptance criteria.
             "contract_miou_threshold": 0.10,
             "contract_pixel_accuracy": 0.10,
@@ -48,8 +49,8 @@ def test_contract_consumes_declared_segmentation_thresholds() -> None:
     result = SegformerSegmentationPlugin().verify(_output(trt), _output(ref), None, thresholds)
 
     assert result.status == "failed"
-    assert result.metrics["mIoU"].threshold == 0.60
-    assert result.metrics["pixel_accuracy"].threshold == 0.85
+    assert result.metrics["mIoU"].threshold == 0.94
+    assert result.metrics["pixel_accuracy"].threshold == 0.99
     assert not result.metrics["mIoU"].passed
     assert not result.metrics["pixel_accuracy"].passed
 
@@ -67,6 +68,32 @@ def test_contract_requires_both_declared_thresholds() -> None:
 
     assert result.status == "error"
     assert "mIoU" in result.message
+
+
+def test_contract_rejects_mask_shape_mismatch() -> None:
+    thresholds = ThresholdProfile(
+        task_strategy="segmentation",
+        metrics={"mIoU": 0.94, "pixel_accuracy": 0.99},
+    )
+
+    result = SegformerSegmentationPlugin().verify(
+        _output(np.zeros((128, 128), dtype=np.int32)),
+        _output(np.zeros((382, 640), dtype=np.int32)),
+        None,
+        thresholds,
+    )
+
+    assert result.status == "error"
+    assert "shape mismatch" in result.message
+
+
+def test_single_gpu_thresholds_reject_the_reproduced_regression() -> None:
+    threshold_path = Path(__file__).parent / "thresholds" / "segformer-b0-ade.json"
+    thresholds = json.loads(threshold_path.read_text())["threshold_overrides"]
+
+    assert thresholds["mIoU"] == 0.94
+    assert thresholds["pixel_accuracy"] == 0.99
+    assert thresholds["min_pixel_agreement"] == 0.99
 
 
 def test_trt_visualization_matches_hf_palette_and_input_size(

--- a/tests/e2e/models/segformer/thresholds/segformer-b0-ade.json
+++ b/tests/e2e/models/segformer/thresholds/segformer-b0-ade.json
@@ -2,8 +2,8 @@
   "threshold_overrides": {
     "boundary_f_score": 0.6,
     "logit_atol": 0.5,
-    "mIoU": 0.6,
-    "min_pixel_agreement": 0.85,
-    "pixel_accuracy": 0.85
+    "mIoU": 0.94,
+    "min_pixel_agreement": 0.99,
+    "pixel_accuracy": 0.99
   }
 }


### PR DESCRIPTION
## Background

The SegFormer runtime diverged from the Hugging Face semantic-segmentation pipeline because image resize semantics differed and the runtime selected classes before restoring logits to source-image geometry. The previous acceptance contract also resized mismatched masks and used thresholds that allowed the regression to pass.

## Exit Criteria

- Match Hugging Face SegFormer preprocessing and semantic-logit postprocessing semantics.
- Return a class map at source-image geometry and reject shape drift.
- Pass the exact-model GPU E2E against the Hugging Face reference at the tightened quality gates.

## Implementation

- Match Pillow's uint8 bilinear resize behavior used by `SegformerImageProcessor`, including half-pixel coordinates, fixed-point coefficients, and per-pass rounding.
- Bilinearly resize class logits with `align_corners=false` semantics before argmax, then return the source-sized mask.
- Reject TRT/reference mask-shape mismatches instead of resizing the reference, and raise the single-GPU gates to mIoU `0.94` and pixel accuracy `0.99`.
- Add focused preprocessing, postprocessing, source-geometry, and contract regressions.

## Validation

- `cmake --build build --target test_segformer_preprocess_seam test_segformer_postprocess_seam test_segformer_segment_pipeline -j8`: passed all focused C++ CPU and GPU pipeline tests.
- `PYTHONPATH=python python -m pytest -q tests/e2e/models/segformer/test_segformer_e2e.py --trtmc-binary=build/trtmc --engine-dir=.artifacts/engines --model-plugin-dir=build/models --e2e-artifacts-dir=.artifacts/e2e-pr`: 1 passed; mIoU `0.95346`, pixel accuracy `0.99255`, output geometry `640x382`.
- `pytest -q tests/e2e/models/segformer --ignore=tests/e2e/models/segformer/test_segformer_e2e.py`: 37 passed, 3 skipped.
- `ruff check` and `clang-format --dry-run --Werror` on changed files: passed.
- `python tools/check_cyclomatic_complexity.py --max-ccn 10 src/runtime/models/segformer`: passed.
- `python tools/legal_headers.py --check` and `python tools/test_impact.py --validate`: passed.

## Notes For Future Readers

- The acceptance reference remains Hugging Face FP32 while the TensorRT engine is FP16, so bit-exact class maps are not expected.
- Review preprocessing parity first, then the resize-before-argmax path, and finally the stricter E2E contract.

Fixes #480
