### PR TITLE
fix(qwen-vl): batch multimodal prefill

### DIFF
--- a/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_decoder.py
@@ -115,7 +115,6 @@ def build_standard_decoder_engine(
     # The legacy single-profile graph below stays in place for paths the
     # dual-profile builder does not yet cover:
     #
-    #   - embed_input=True             (VL prefill replacement, Bark sub-engines)
     #   - debug_layer_outputs=True     (per-layer hidden-state dumps)
     #   - hidden_state_output=True     (speech / Bark hidden output)
     #   - config.raw.dynamic_kv_cache  (TriAttention multi-bucket decode)
@@ -124,8 +123,7 @@ def build_standard_decoder_engine(
     # bisects against the legacy graph). It is *not* intended as a
     # supported user-facing flag.
     _dual_profile_disabled_for = (
-        embed_input
-        or debug_layer_outputs
+        debug_layer_outputs
         or hidden_state_output
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
@@ -134,7 +132,14 @@ def build_standard_decoder_engine(
         raise NotImplementedError(
             "split prefill engine is not supported for this standard decoder "
             "configuration")
-    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
+    # Qwen-VL is not packaged as a split decoder bundle. The engine builder
+    # therefore reaches this family with role="decode" when its global split
+    # default falls back to one engine. Keep VL's one engine dual-profile so
+    # the runtime still receives a sequence-prefill context.
+    vl_single_engine_fallback = embed_input and decoder_engine_role == "decode"
+    if not _dual_profile_disabled_for and (
+        decoder_engine_role in ("dual_profile", "prefill") or vl_single_engine_fallback
+    ):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -147,6 +152,7 @@ def build_standard_decoder_engine(
             interleaved_rope=interleaved_rope,
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
+            embed_input=embed_input,
             verbose=verbose,
             profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )

--- a/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/default_dual_profile_decoder.py
@@ -161,6 +161,7 @@ def build_dual_profile_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    embed_input: bool = False,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     profile_mode: str = "dual_profile",
@@ -246,6 +247,13 @@ def build_dual_profile_decoder_engine(
     token_id = network.add_input("token_id", trt.int32, (-1,))
     position_id = network.add_input("position_id", trt.int32, (-1,))
     attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
+    input_embed_tensor = None
+    use_input_embed_tensor = None
+    if embed_input:
+        input_embed_tensor = network.add_input(
+            "input_embed", trt.float32, (-1, hidden))
+        use_input_embed_tensor = network.add_input(
+            "use_input_embed", trt.float32, (-1, 1))
 
     cache_shape: tuple[int, int]
     if multi_bucket_decode:
@@ -285,6 +293,11 @@ def build_dual_profile_decoder_engine(
             (min_sq, max_cache_length + min_sq),
             (opt_sq, max_cache_length + opt_sq),
             (max_sq, max_cache_length + max_sq))
+        if embed_input:
+            prof.set_shape(
+                "input_embed", (min_sq, hidden), (opt_sq, hidden), (max_sq, hidden))
+            prof.set_shape(
+                "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
         if multi_bucket_decode:
             cmn = cache_rows_min if cache_rows_min is not None else 1
             cop = cache_rows_opt if cache_rows_opt is not None else max_cache_length
@@ -408,6 +421,28 @@ def build_dual_profile_decoder_engine(
     # ---- Embedding -------------------------------------------------------
     emb = network.add_gather(embedding_table, token_id, 0)
     hidden_state = emb.get_output(0)  # (Sq, hidden)
+
+    if input_embed_tensor is not None and use_input_embed_tensor is not None:
+        token_embed = hidden_state
+        if token_embed.dtype != work_trt_dtype:
+            token_embed = network.add_cast(token_embed, work_trt_dtype).get_output(0)
+        input_embed = input_embed_tensor
+        if input_embed.dtype != work_trt_dtype:
+            input_embed = network.add_cast(input_embed, work_trt_dtype).get_output(0)
+        embed_selector = use_input_embed_tensor
+        if embed_selector.dtype != work_trt_dtype:
+            embed_selector = network.add_cast(embed_selector, work_trt_dtype).get_output(0)
+        one = _const_in_work_dtype(
+            network, (1, 1), np.array([[1.0]], dtype=work_np_dtype),
+            work_np_dtype, work_trt_dtype)
+        inverse_selector = network.add_elementwise(
+            one, embed_selector, trt.ElementWiseOperation.SUB).get_output(0)
+        token_part = network.add_elementwise(
+            inverse_selector, token_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        embed_part = network.add_elementwise(
+            embed_selector, input_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden_state = network.add_elementwise(
+            token_part, embed_part, trt.ElementWiseOperation.SUM).get_output(0)
 
     if position_type == "learned" and position_embed_table is not None:
         pos_gather = network.add_gather(position_embed_table, position_id, 0)

--- a/python/tensorrt_model_connect/families/qwen_vl/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/graph_blocks.py
@@ -169,6 +169,7 @@ def add_attention_block(
     interleaved_rope: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
+    sequence_length: int | None = 1,
 ) -> dict[str, trt.ITensor]:
     """Pre-norm -> QKV -> RoPE -> cache concat -> attention -> output proj.
 
@@ -222,11 +223,13 @@ def add_attention_block(
     q_norm = weights.get(f"{prefix}.q_norm")
     if q_norm is not None:
         q = graph_ops.add_rms_norm_per_head(
-            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype)
+            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
     k_norm = weights.get(f"{prefix}.k_norm")
     if k_norm is not None:
         k = graph_ops.add_rms_norm_per_head(
-            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype)
+            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
 
     # ------------------------------------------------------------------ #
     # RoPE via native IRotaryEmbeddingLayer                              #
@@ -243,35 +246,40 @@ def add_attention_block(
         q = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
         k = graph_ops.add_apply_rope_native(
             network, k, num_kv_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
 
     # Save present K/V (before concatenation, this is the raw projection output)
     present_k = k
     present_v = v
 
     # Reshape current K, V for concatenation
-    k_reshape = network.add_shuffle(k)
-    k_reshape.reshape_dims = (1, kv_attention_size)
-    v_reshape = network.add_shuffle(v)
-    v_reshape.reshape_dims = (1, kv_attention_size)
+    current_k = k
+    current_v = v
+    if sequence_length is not None:
+        k_reshape = network.add_shuffle(k)
+        k_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        v_reshape = network.add_shuffle(v)
+        v_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        current_k = k_reshape.get_output(0)
+        current_v = v_reshape.get_output(0)
 
     # Concatenate with cache
     all_k = network.add_concatenation(
-        [cache_k, k_reshape.get_output(0)])
+        [cache_k, current_k])
     all_k.axis = 0
     all_v = network.add_concatenation(
-        [cache_v, v_reshape.get_output(0)])
+        [cache_v, current_v])
     all_v.axis = 0
 
     # ------------------------------------------------------------------ #
     # Attention core — native IAttention or FFI kernel                    #
     # ------------------------------------------------------------------ #
     if use_native_attention:
-        kv_seq = None if dynamic_kv_cache else attention_window
+        kv_seq = None if dynamic_kv_cache or sequence_length is None else attention_window
         if alibi_slopes_tensor is not None:
             if alibi_indices_tensor is None:
                 raise ValueError("ALiBi attention requires cache position indices")
@@ -296,7 +304,7 @@ def add_attention_block(
             num_heads=num_heads,
             head_dim=head_dim,
             num_kv_heads=num_kv_heads,
-            q_seq=1,
+            q_seq=sequence_length,
             kv_seq=kv_seq,
             causal=False,
             mask=mask_4d,

--- a/python/tensorrt_model_connect/families/qwen_vl/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/plugin.py
@@ -359,8 +359,8 @@ def _build_qwen3_vl_decoder(
     at the first N layers (where N = deepstack_num_levels).
 
     Extra engine inputs (when deepstack_num_levels > 0):
-      - deepstack_embed_0..N: [1, hidden] per-level embeddings
-      - deepstack_active: [1] flag (1.0 during VL prefill, 0.0 during decode)
+      - deepstack_embed_0..N: [Sq, hidden] per-level embeddings
+      - deepstack_active: [Sq, 1] per-position selector
     """
     from .standard_decoder_builder import _mark_debug_output
 
@@ -388,6 +388,7 @@ def _build_qwen3_vl_decoder(
     kv_attention_size = graph_blocks.infer_kv_attention_size(
         weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
     attention_window = max_cache_length + 1
+    opt_prefill_length = min(64, max_cache_length)
 
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
@@ -396,14 +397,14 @@ def _build_qwen3_vl_decoder(
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
     # --- Inputs ---
-    token_id = network.add_input("token_id", trt.int32, (1,))
-    position_id = network.add_input("position_id", trt.int32, (1,))
+    token_id = network.add_input("token_id", trt.int32, (-1,))
+    position_id = network.add_input("position_id", trt.int32, (-1,))
     attention_mask = network.add_input(
-        "attention_mask", trt.float32, (1, attention_window))
+        "attention_mask", trt.float32, (-1, -1))
 
     # VL embed_input
-    input_embed_tensor = network.add_input("input_embed", trt.float32, (1, hidden))
-    use_input_embed_tensor = network.add_input("use_input_embed", trt.float32, (1,))
+    input_embed_tensor = network.add_input("input_embed", trt.float32, (-1, hidden))
+    use_input_embed_tensor = network.add_input("use_input_embed", trt.float32, (-1, 1))
 
     # DeepStack inputs
     ds_embed_inputs = []
@@ -411,10 +412,10 @@ def _build_qwen3_vl_decoder(
     if deepstack_num_levels > 0:
         for i in range(deepstack_num_levels):
             ds_in = network.add_input(
-                f"deepstack_embed_{i}", trt.float32, (1, hidden))
+                f"deepstack_embed_{i}", trt.float32, (-1, hidden))
             ds_embed_inputs.append(ds_in)
         ds_active_tensor = network.add_input(
-            "deepstack_active", trt.float32, (1,))
+            "deepstack_active", trt.float32, (-1, 1))
 
     # KV cache inputs
     cache_k_inputs = []
@@ -428,6 +429,34 @@ def _build_qwen3_vl_decoder(
             trt.float32, (max_cache_length, kv_attention_size))
         cache_k_inputs.append(ck)
         cache_v_inputs.append(cv)
+
+    def _add_profile(opt_sq: int, max_sq: int, *, fixed: bool = False) -> None:
+        profile = builder.create_optimization_profile()
+        min_sq = opt_sq if fixed else 1
+        profile.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
+        profile.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
+        profile.set_shape(
+            "attention_mask",
+            (min_sq, max_cache_length + min_sq),
+            (opt_sq, max_cache_length + opt_sq),
+            (max_sq, max_cache_length + max_sq))
+        profile.set_shape(
+            "input_embed", (min_sq, hidden), (opt_sq, hidden), (max_sq, hidden))
+        profile.set_shape(
+            "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
+        for level in range(deepstack_num_levels):
+            profile.set_shape(
+                f"deepstack_embed_{level}",
+                (min_sq, hidden), (opt_sq, hidden), (max_sq, hidden))
+        if deepstack_num_levels > 0:
+            profile.set_shape(
+                "deepstack_active", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
+        trt_config.add_optimization_profile(profile)
+
+    decoder_engine_role = str(config.raw.get("_decoder_engine_role", "dual_profile"))
+    _add_profile(opt_prefill_length, max_cache_length)
+    if decoder_engine_role != "prefill":
+        _add_profile(1, 1, fixed=True)
 
     fp32_attention_mask = attention_mask
     fp32_ds_embed_inputs = list(ds_embed_inputs)
@@ -491,19 +520,17 @@ def _build_qwen3_vl_decoder(
     token_embed = gather.get_output(0)
 
     # Conditional: (1 - flag) * token_embed + flag * input_embed
-    flag_broadcast = network.add_shuffle(use_input_embed_tensor)
-    flag_broadcast.reshape_dims = (1, 1)
     one_const = graph_ops.add_constant(
         network, (1, 1), np.array([1.0], dtype=work_np_dtype),
         dtype=work_np_dtype)
     inv_flag = network.add_elementwise(
-        one_const, flag_broadcast.get_output(0),
+        one_const, use_input_embed_tensor,
         trt.ElementWiseOperation.SUB)
     tok_part = network.add_elementwise(
         inv_flag.get_output(0), token_embed,
         trt.ElementWiseOperation.PROD)
     embed_part = network.add_elementwise(
-        flag_broadcast.get_output(0), input_embed_tensor,
+        use_input_embed_tensor, input_embed_tensor,
         trt.ElementWiseOperation.PROD)
     hidden_sum = network.add_elementwise(
         tok_part.get_output(0), embed_part.get_output(0),
@@ -558,6 +585,7 @@ def _build_qwen3_vl_decoder(
             rotary_embedding_dim=head_dim,
             dtype=layer_np_dtype,
             quant_ctx=quant_ctx,
+            sequence_length=None,
         )
 
         attn_out = attn["attn_out"]
@@ -578,10 +606,8 @@ def _build_qwen3_vl_decoder(
                 fp32_ds_embed_inputs[layer_idx]
                 if layer_is_fp32 else ds_embed_inputs[layer_idx])
             assert layer_ds_active is not None
-            ds_active_broadcast = network.add_shuffle(layer_ds_active)
-            ds_active_broadcast.reshape_dims = (1, 1)
             ds_scaled = network.add_elementwise(
-                layer_ds_embed, ds_active_broadcast.get_output(0),
+                layer_ds_embed, layer_ds_active,
                 trt.ElementWiseOperation.PROD)
             post_attn_ds = network.add_elementwise(
                 post_attn, ds_scaled.get_output(0),
@@ -620,9 +646,20 @@ def _build_qwen3_vl_decoder(
             network, hidden_state, hidden, final_norm, None,
             eps_tensor, "rmsnorm", dtype=work_np_dtype)
 
-    # --- LM head ---
+    # --- LM head (last prompt row only) ---
+    hidden_shape = network.add_shape(hidden_state).get_output(0)
+    one_hidden = graph_ops.add_constant(
+        network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
+    last_start = network.add_elementwise(
+        hidden_shape, one_hidden, trt.ElementWiseOperation.SUB).get_output(0)
+    last_size = graph_ops.add_constant(
+        network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
+    last_slice = network.add_slice(hidden_state, start=(0, 0), shape=(0, 0), stride=(1, 1))
+    last_slice.set_input(1, last_start)
+    last_slice.set_input(2, last_size)
+    last_hidden = last_slice.get_output(0)
     logits = graph_ops.add_matmul_rhs_constant(
-        network, hidden_state, hidden, vocab, weights["w_out"],
+        network, last_hidden, hidden, vocab, weights["w_out"],
         dtype=work_np_dtype)
     b_out = np.zeros(vocab, dtype=work_np_dtype)
     logits = graph_ops.add_bias_sum(

--- a/python/tensorrt_model_connect/families/qwen_vl/vl_debug_runner.py
+++ b/python/tensorrt_model_connect/families/qwen_vl/vl_debug_runner.py
@@ -63,6 +63,20 @@ def _require_trt_runtime() -> None:
         raise ImportError("cuda-python is required for VL debug runner execution")
 
 
+def _profile_min_shape(engine: Any, name: str, profile_index: int) -> tuple[int, ...]:
+    """Resolve a concrete single-step shape for a possibly dynamic tensor."""
+    declared = tuple(int(dim) for dim in engine.get_tensor_shape(name))
+    if all(dim >= 0 for dim in declared):
+        return declared
+    profile_shapes = engine.get_tensor_profile_shape(name, profile_index)
+    if not profile_shapes:
+        raise RuntimeError(f"Missing optimization profile shape for {name!r}")
+    resolved = tuple(int(dim) for dim in profile_shapes[0])
+    if any(dim < 0 for dim in resolved):
+        raise RuntimeError(f"Invalid optimization profile shape for {name!r}: {resolved}")
+    return resolved
+
+
 class TrtRunner:
     """Device-resident TRT inference runner for debugging and diff testing.
 
@@ -106,17 +120,19 @@ class TrtRunner:
         # decode profile (profile 1, Sq=1). For per-step decode runs the
         # debug_runner must select the decode profile and call
         # set_input_shape on every dynamic input before each execute. We
-        # detect dual-profile via num_optimization_profiles > 1 and the
-        # presence of -1 dims on token_id / position_id / attention_mask.
-        self._dynamic_inputs: list[str] = []
+        # detect dual-profile via num_optimization_profiles > 1 and resolve
+        # every dynamic input from the selected profile's minimum shape.
+        self._dynamic_input_shapes: dict[str, tuple[int, ...]] = {}
         self._is_dual_profile = self.engine.num_optimization_profiles > 1
-        for input_name in ("token_id", "position_id", "attention_mask"):
-            try:
-                shape = tuple(self.engine.get_tensor_shape(input_name))
-            except Exception:
+        self._profile_index = 1 if self._is_dual_profile else 0
+        for index in range(self.engine.num_io_tensors):
+            input_name = self.engine.get_tensor_name(index)
+            if self.engine.get_tensor_mode(input_name) != trt.TensorIOMode.INPUT:
                 continue
-            if any(d < 0 for d in shape):
-                self._dynamic_inputs.append(input_name)
+            shape = tuple(self.engine.get_tensor_shape(input_name))
+            if any(dim < 0 for dim in shape):
+                self._dynamic_input_shapes[input_name] = _profile_min_shape(
+                    self.engine, input_name, self._profile_index)
         if self._is_dual_profile:
             # Profile 1 = decode (Sq=1). step() always runs single-token, so
             # we lock the context to that profile once and never switch.
@@ -215,14 +231,18 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name == "input_embed":
                 self._has_embed_input = True
-                embed_shape = tuple(self.engine.get_tensor_shape(name))
+                embed_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 embed_bytes = int(np.prod(embed_shape)) * 4
                 self._h_input_embed = np.zeros(embed_shape, dtype=np.float32)
                 err, self._d_input_embed = cudart.cudaMalloc(embed_bytes)
                 _check_cuda(err)
             elif name == "use_input_embed":
-                self._h_use_input_embed = np.zeros((1,), dtype=np.float32)
-                err, self._d_use_input_embed = cudart.cudaMalloc(4)
+                selector_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_use_input_embed = np.zeros(selector_shape, dtype=np.float32)
+                err, self._d_use_input_embed = cudart.cudaMalloc(
+                    self._h_use_input_embed.nbytes)
                 _check_cuda(err)
 
         # DeepStack inputs (auto-detected from engine bindings)
@@ -235,15 +255,19 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name.startswith("deepstack_embed_"):
                 self._deepstack_names.append(name)
-                shape = tuple(self.engine.get_tensor_shape(name))
+                shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 nbytes = int(np.prod(shape)) * 4
                 self._h_deepstack[name] = np.zeros(shape, dtype=np.float32)
                 err, d_ptr = cudart.cudaMalloc(nbytes)
                 _check_cuda(err)
                 self._d_deepstack[name] = d_ptr
             elif name == "deepstack_active":
-                self._h_deepstack_active = np.zeros((1,), dtype=np.float32)
-                err, self._d_deepstack_active = cudart.cudaMalloc(4)
+                active_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_deepstack_active = np.zeros(active_shape, dtype=np.float32)
+                err, self._d_deepstack_active = cudart.cudaMalloc(
+                    self._h_deepstack_active.nbytes)
                 _check_cuda(err)
 
         # Debug output device/host buffers
@@ -333,7 +357,7 @@ class TrtRunner:
                 self._h_input_embed.nbytes, H2D, stream)
             cudart.cudaMemcpyAsync(
                 self._d_use_input_embed, self._h_use_input_embed.ctypes.data,
-                4, H2D, stream)
+                self._h_use_input_embed.nbytes, H2D, stream)
 
         # DeepStack H2D transfers
         if self._deepstack_names:
@@ -352,7 +376,7 @@ class TrtRunner:
                 cudart.cudaMemcpyAsync(
                     self._d_deepstack_active,
                     self._h_deepstack_active.ctypes.data,
-                    4, H2D, stream)
+                    self._h_deepstack_active.nbytes, H2D, stream)
 
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
@@ -381,15 +405,11 @@ class TrtRunner:
         for name in self._debug_output_names:
             self.context.set_tensor_address(name, self._d_debug[name])
 
-        # Dual-profile engines need explicit shapes for the dynamic
-        # inputs every step. step() is single-token decode, so all three
-        # shapes are fixed: Sq=1 and K = max_cache_length + 1.
-        if self._dynamic_inputs:
-            for name in self._dynamic_inputs:
-                if name == "attention_mask":
-                    self.context.set_input_shape(name, (1, attention_window))
-                else:
-                    self.context.set_input_shape(name, (1,))
+        # Dynamic inputs use the selected profile's minimum shapes. Both the
+        # prefill and decode profiles have Sq=1 minima, so this covers token,
+        # mask, image embedding, selector, and DeepStack inputs uniformly.
+        for name, shape in self._dynamic_input_shapes.items():
+            self.context.set_input_shape(name, shape)
 
         # Execute
         self.context.execute_async_v3(stream)
@@ -483,24 +503,16 @@ class TrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask,
-                self._d_logits]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        if self._d_input_embed:
-            bufs.append(self._d_input_embed)
-        if self._d_use_input_embed:
-            bufs.append(self._d_use_input_embed)
-        for d_ptr in self._d_deepstack.values():
-            bufs.append(d_ptr)
-        if self._d_deepstack_active:
-            bufs.append(self._d_deepstack_active)
-        for d_ptr in self._d_debug.values():
-            bufs.append(d_ptr)
+        bufs = []
+        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
+                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+            d_ptr = getattr(self, name, 0)
+            if d_ptr:
+                bufs.append(d_ptr)
+        for name in ("_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v"):
+            bufs.extend(getattr(self, name, []))
+        bufs.extend(getattr(self, "_d_deepstack", {}).values())
+        bufs.extend(getattr(self, "_d_debug", {}).values())
         for d_ptr in bufs:
             cudart.cudaFree(d_ptr)
         if hasattr(self, "stream"):

--- a/src/runtime/models/qwen_vl/pipeline.cpp
+++ b/src/runtime/models/qwen_vl/pipeline.cpp
@@ -6,6 +6,7 @@
 #include "runtime/models/qwen_vl/pipeline.h"
 
 #include "runtime/models/qwen_vl/image_preprocessor.h"
+#include "runtime/models/qwen_vl/tensor_names.h"
 
 #include <algorithm>
 #include <cstring>
@@ -14,26 +15,40 @@
 
 namespace trtmc {
 
+namespace {
+
+void validate_pipeline_components(const TrtModule* text_decoder, const QwenVlInferenceState* state,
+                                  const TrtModule* prefill) {
+    if (text_decoder == nullptr || !text_decoder->ok())
+        throw std::runtime_error("QwenVlPipeline: invalid text decoder");
+    if (state == nullptr || !state->ok())
+        throw std::runtime_error("QwenVlPipeline: invalid inference state");
+    if (prefill != nullptr && !prefill->ok())
+        throw std::runtime_error("QwenVlPipeline: invalid prefill decoder");
+}
+
+void sync_vision_config(QwenVlConfig& config, const QwenVlPreprocessConfig& preprocess) {
+    if (config.image_token_id < 0 && preprocess.image_token_id >= 0)
+        config.image_token_id = preprocess.image_token_id;
+    if (config.vision_output_dim <= 0 && preprocess.vision_output_dim > 0)
+        config.vision_output_dim = preprocess.vision_output_dim;
+}
+
+} // namespace
+
 QwenVlPipeline::QwenVlPipeline(std::unique_ptr<TrtModule> text_decoder,
                                std::unique_ptr<TrtModule> vision_encoder,
                                std::unique_ptr<QwenVlInferenceState> state, QwenVlConfig config,
                                QwenVlPreprocessConfig vl_preprocess, cudaStream_t stream,
                                std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
-                               std::unique_ptr<QwenVlISampler> sampler)
-    : text_decoder_(std::move(text_decoder)), vision_encoder_(std::move(vision_encoder)),
-      state_(std::move(state)), config_(config), vl_preprocess_(std::move(vl_preprocess)),
-      stream_(stream), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
-      sampler_(std::move(sampler)) {
-    if (!text_decoder_ || !text_decoder_->ok())
-        throw std::runtime_error("QwenVlPipeline: invalid text decoder");
-    if (!state_ || !state_->ok())
-        throw std::runtime_error("QwenVlPipeline: invalid inference state");
-
-    // Sync image_token_id from QwenVlPreprocessConfig if not set in QwenVlConfig
-    if (config_.image_token_id < 0 && vl_preprocess_.image_token_id >= 0)
-        config_.image_token_id = vl_preprocess_.image_token_id;
-    if (config_.vision_output_dim <= 0 && vl_preprocess_.vision_output_dim > 0)
-        config_.vision_output_dim = vl_preprocess_.vision_output_dim;
+                               std::unique_ptr<QwenVlISampler> sampler,
+                               std::unique_ptr<TrtModule> prefill)
+    : text_decoder_(std::move(text_decoder)), prefill_(std::move(prefill)),
+      vision_encoder_(std::move(vision_encoder)), state_(std::move(state)), config_(config),
+      vl_preprocess_(std::move(vl_preprocess)), stream_(stream), tokenizer_(std::move(tokenizer)),
+      model_id_(std::move(model_id_str)), sampler_(std::move(sampler)) {
+    validate_pipeline_components(text_decoder_.get(), state_.get(), prefill_.get());
+    sync_vision_config(config_, vl_preprocess_);
 }
 
 TextResult QwenVlPipeline::generate(const std::string& prompt, const GenerateConfig& cfg) {
@@ -93,6 +108,193 @@ select_deepstack_feature_pointers(const std::vector<std::vector<float>>& deepsta
                              : nullptr);
     }
     return embeds;
+}
+
+struct VlSequenceEmbeddingInputs {
+    std::vector<float> input_embed;
+    std::vector<float> use_input_embed;
+    std::vector<std::vector<float>> deepstack_embed;
+    std::vector<float> deepstack_active;
+};
+
+VlSequenceEmbeddingInputs
+build_vl_sequence_embedding_inputs(const std::vector<int32_t>& input_ids, int32_t image_token_id,
+                                   const std::vector<float>& image_features,
+                                   const std::vector<std::vector<float>>& deepstack_features,
+                                   int32_t num_features, int32_t feature_dim) {
+    const auto sq = input_ids.size();
+    VlSequenceEmbeddingInputs result;
+    result.input_embed.assign(sq * static_cast<std::size_t>(feature_dim), 0.0F);
+    result.use_input_embed.assign(sq, 0.0F);
+    result.deepstack_active.assign(sq, 0.0F);
+    result.deepstack_embed.resize(deepstack_features.size());
+    for (auto& level : result.deepstack_embed)
+        level.assign(sq * static_cast<std::size_t>(feature_dim), 0.0F);
+
+    int32_t feature_index = 0;
+    for (std::size_t token_index = 0; token_index < sq; ++token_index) {
+        if (input_ids[token_index] != image_token_id || feature_index >= num_features)
+            continue;
+        const auto source_offset = static_cast<std::size_t>(feature_index) * feature_dim;
+        const auto target_offset = token_index * static_cast<std::size_t>(feature_dim);
+        std::copy_n(image_features.data() + source_offset, feature_dim,
+                    result.input_embed.data() + target_offset);
+        result.use_input_embed[token_index] = 1.0F;
+
+        for (std::size_t level_index = 0; level_index < deepstack_features.size(); ++level_index) {
+            const auto& source = deepstack_features[level_index];
+            if (source_offset + static_cast<std::size_t>(feature_dim) > source.size())
+                continue;
+            std::copy_n(source.data() + source_offset, feature_dim,
+                        result.deepstack_embed[level_index].data() + target_offset);
+            result.deepstack_active[token_index] = 1.0F;
+        }
+        ++feature_index;
+    }
+    return result;
+}
+
+bool gather_vl_prefill_kv_pointers(TrtModule& prefill, const QwenVlConfig& config,
+                                   std::vector<const void*>& present_k,
+                                   std::vector<const void*>& present_v) {
+    present_k.resize(static_cast<std::size_t>(config.num_layers));
+    present_v.resize(static_cast<std::size_t>(config.num_layers));
+    for (int32_t layer = 0; layer < config.num_layers; ++layer) {
+        const auto index = static_cast<std::size_t>(layer);
+        present_k[index] =
+            prefill.device_ptr(qwen_vl_expand_layer_name(config.present_k_pattern, layer));
+        present_v[index] =
+            prefill.device_ptr(qwen_vl_expand_layer_name(config.present_v_pattern, layer));
+        if (present_k[index] == nullptr || present_v[index] == nullptr)
+            return false;
+    }
+    return true;
+}
+
+QwenVlKvCache* eligible_vl_prefill_cache(TrtModule* prefill, QwenVlInferenceState* state,
+                                         const QwenVlConfig& config, int32_t sequence_length,
+                                         int32_t feature_dim) {
+    if (prefill == nullptr)
+        return nullptr;
+    if (sequence_length <= 0 || feature_dim <= 0 || config.num_layers <= 0)
+        return nullptr;
+    if (!prefill->has_input("input_embed"))
+        return nullptr;
+    if (config.prefill_max_length > 0 && sequence_length > config.prefill_max_length)
+        return nullptr;
+    return dynamic_cast<QwenVlKvCache*>(state);
+}
+
+bool valid_vl_features(const std::vector<float>& image_features, int32_t num_features,
+                       int32_t feature_dim) {
+    if (num_features < 0)
+        return false;
+    const auto required =
+        static_cast<std::size_t>(num_features) * static_cast<std::size_t>(feature_dim);
+    return image_features.size() >= required;
+}
+
+void add_vl_prefill_base_inputs(TensorMap& inputs, QwenVlInferenceState& state,
+                                const std::vector<int32_t>& input_ids,
+                                VlSequenceEmbeddingInputs& embedding_inputs, int32_t feature_dim) {
+    const auto sequence_length = static_cast<int32_t>(input_ids.size());
+    inputs["token_id"] =
+        Tensor{const_cast<int32_t*>(input_ids.data()), {sequence_length}, DType::kInt32};
+    state.prepare_step(inputs, sequence_length);
+    inputs["input_embed"] = Tensor{
+        embedding_inputs.input_embed.data(), {sequence_length, feature_dim}, DType::kFloat32};
+    inputs["use_input_embed"] =
+        Tensor{embedding_inputs.use_input_embed.data(), {sequence_length, 1}, DType::kFloat32};
+}
+
+bool add_vl_prefill_deepstack_inputs(TrtModule& prefill, TensorMap& inputs,
+                                     VlSequenceEmbeddingInputs& embedding_inputs,
+                                     int32_t sequence_length, int32_t feature_dim) {
+    if (!prefill.has_input("deepstack_active"))
+        return true;
+    inputs["deepstack_active"] =
+        Tensor{embedding_inputs.deepstack_active.data(), {sequence_length, 1}, DType::kFloat32};
+    for (std::size_t level = 0;; ++level) {
+        const auto name = "deepstack_embed_" + std::to_string(level);
+        if (!prefill.has_input(name))
+            break;
+        if (level >= embedding_inputs.deepstack_embed.size())
+            return false;
+        inputs[name] = Tensor{embedding_inputs.deepstack_embed[level].data(),
+                              {sequence_length, feature_dim},
+                              DType::kFloat32};
+    }
+    return true;
+}
+
+bool copy_last_prefill_logits(const TensorMap& outputs, int32_t vocab_size,
+                              std::vector<float>& logits) {
+    const auto logits_it = outputs.find("logits");
+    if (logits_it == outputs.end())
+        return false;
+    const auto size = static_cast<std::size_t>(vocab_size);
+    if (logits_it->second.numel() < size)
+        return false;
+    const auto offset = logits_it->second.numel() - size;
+    logits.resize(size);
+    std::memcpy(logits.data(), static_cast<const float*>(logits_it->second.data) + offset,
+                size * sizeof(float));
+    return true;
+}
+
+int32_t resolve_input_embed_dim(const TrtModule& decoder, int32_t configured_dim) {
+    if (configured_dim > 0)
+        return configured_dim;
+    const auto declared_shape = decoder.tensor_shape("input_embed");
+    if (!declared_shape.empty())
+        return static_cast<int32_t>(declared_shape.back());
+    throw std::runtime_error("QwenVlPipeline: invalid input embedding dimension");
+}
+
+std::vector<int64_t> selector_shape(const TrtModule& decoder, const std::string& name) {
+    return decoder.input_rank(name) == 2 ? std::vector<int64_t>{1, 1} : std::vector<int64_t>{1};
+}
+
+void add_text_step_deepstack_inputs(TrtModule& decoder, TensorMap& inputs, int32_t embed_dim,
+                                    const std::vector<const float*>& deepstack_embeds,
+                                    float& deepstack_active, std::vector<float>& zero_deepstack) {
+    if (!decoder.has_input("deepstack_active"))
+        return;
+    inputs["deepstack_active"] =
+        Tensor{&deepstack_active, selector_shape(decoder, "deepstack_active"), DType::kFloat32};
+    for (std::size_t index = 0;; ++index) {
+        const auto name = "deepstack_embed_" + std::to_string(index);
+        if (!decoder.has_input(name))
+            break;
+        const float* embed = index < deepstack_embeds.size() ? deepstack_embeds[index] : nullptr;
+        if (embed == nullptr) {
+            if (zero_deepstack.empty())
+                zero_deepstack.resize(static_cast<std::size_t>(embed_dim), 0.0F);
+            embed = zero_deepstack.data();
+        }
+        inputs[name] = Tensor{const_cast<float*>(embed), {1, embed_dim}, DType::kFloat32};
+    }
+}
+
+void add_text_step_embedding_inputs(TrtModule& decoder, const QwenVlConfig& config,
+                                    TensorMap& inputs, const float* input_embed,
+                                    float& use_input_embed,
+                                    const std::vector<const float*>& deepstack_embeds,
+                                    float& deepstack_active, std::vector<float>& zero_embed,
+                                    std::vector<float>& zero_deepstack) {
+    if (!decoder.has_input("input_embed"))
+        return;
+    const int32_t embed_dim = resolve_input_embed_dim(decoder, config.vision_output_dim);
+    if (input_embed == nullptr) {
+        zero_embed.resize(static_cast<std::size_t>(embed_dim), 0.0F);
+        input_embed = zero_embed.data();
+    }
+    inputs["input_embed"] =
+        Tensor{const_cast<float*>(input_embed), {1, embed_dim}, DType::kFloat32};
+    inputs["use_input_embed"] =
+        Tensor{&use_input_embed, selector_shape(decoder, "use_input_embed"), DType::kFloat32};
+    add_text_step_deepstack_inputs(decoder, inputs, embed_dim, deepstack_embeds, deepstack_active,
+                                   zero_deepstack);
 }
 
 Tensor make_pixel_values_tensor(const QwenVlPreprocessedImage& preprocessed,
@@ -222,6 +424,10 @@ std::vector<int32_t> QwenVlPipeline::generate_from_ids(const std::vector<int32_t
     active_sampler->reset();
 
     state_->reset();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
     state_->bind_to(*text_decoder_);
 
     std::vector<float> logits;
@@ -262,18 +468,59 @@ std::vector<int32_t> QwenVlPipeline::generate_vl_from_ids(
     active_sampler->reset();
 
     state_->reset();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
     state_->bind_to(*text_decoder_);
 
     std::vector<float> logits;
-    int32_t feature_index = 0;
-
-    for (const auto& tid : input_ids)
-        run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
-                             feature_index, logits);
+    if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,
+                                feature_dim, logits)) {
+        int32_t feature_index = 0;
+        for (const auto& tid : input_ids)
+            run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
+                                 feature_index, logits);
+    }
+    state_->mark_prefill_complete();
 
     std::vector<int32_t> output = input_ids;
     run_vl_decode_loop(active_sampler, params, output, logits, max_new_tokens);
     return output;
+}
+
+bool QwenVlPipeline::run_vl_prefill_batched(
+    const std::vector<int32_t>& input_ids, const std::vector<float>& image_features,
+    const std::vector<std::vector<float>>& deepstack_features, int32_t num_features,
+    int32_t feature_dim, std::vector<float>& logits) {
+    const auto sq = static_cast<int32_t>(input_ids.size());
+    auto* kv_cache =
+        eligible_vl_prefill_cache(prefill_.get(), state_.get(), config_, sq, feature_dim);
+    if (kv_cache == nullptr)
+        return false;
+    if (!valid_vl_features(image_features, num_features, feature_dim))
+        return false;
+
+    kv_cache->bind_cache_inputs(*prefill_);
+    auto embedding_inputs =
+        build_vl_sequence_embedding_inputs(input_ids, config_.image_token_id, image_features,
+                                           deepstack_features, num_features, feature_dim);
+
+    TensorMap inputs;
+    add_vl_prefill_base_inputs(inputs, *state_, input_ids, embedding_inputs, feature_dim);
+    if (!add_vl_prefill_deepstack_inputs(*prefill_, inputs, embedding_inputs, sq, feature_dim))
+        return false;
+
+    auto outputs = prefill_->forward(inputs);
+    if (!copy_last_prefill_logits(outputs, config_.vocab_size, logits))
+        return false;
+
+    std::vector<const void*> present_k;
+    std::vector<const void*> present_v;
+    if (!gather_vl_prefill_kv_pointers(*prefill_, config_, present_k, present_v))
+        return false;
+    kv_cache->write_prefill_kv(present_k, present_v, sq);
+    return true;
 }
 
 void QwenVlPipeline::run_vl_prefill_token(int32_t token_id,
@@ -310,38 +557,13 @@ void QwenVlPipeline::run_vl_decode_loop(QwenVlISampler* sampler, const QwenVlSam
 }
 
 void QwenVlPipeline::run_text_step(int32_t token_id, std::vector<float>& logits) {
-    TensorMap inputs;
-
-    Tensor token_t;
-    token_t.data = &token_id;
-    token_t.shape = {1};
-    token_t.dtype = DType::kInt32;
-    inputs["token_id"] = token_t;
-
-    state_->prepare_step(inputs);
-
-    auto outputs = text_decoder_->forward(inputs);
-
-    auto it = outputs.find("logits");
-    if (it == outputs.end())
-        throw std::runtime_error("QwenVlPipeline: no 'logits' output");
-
-    auto n = it->second.numel();
-    logits.resize(static_cast<std::size_t>(n));
-    std::memcpy(logits.data(), it->second.data, n * sizeof(float));
-
-    state_->advance();
+    run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, logits);
 }
 
 void QwenVlPipeline::run_text_step_with_embed(int32_t token_id, const float* input_embed,
                                               float use_input_embed,
                                               const std::vector<const float*>& deepstack_embeds,
                                               float deepstack_active, std::vector<float>& logits) {
-    if (!text_decoder_->has_input("input_embed")) {
-        run_text_step(token_id, logits);
-        return;
-    }
-
     TensorMap inputs;
 
     Tensor token_t;
@@ -352,56 +574,10 @@ void QwenVlPipeline::run_text_step_with_embed(int32_t token_id, const float* inp
 
     state_->prepare_step(inputs);
 
-    // use_input_embed scalar: 1.0 = use input_embed, 0.0 = use token embedding
-    Tensor use_embed_t;
-    use_embed_t.data = &use_input_embed;
-    use_embed_t.shape = {1};
-    use_embed_t.dtype = DType::kFloat32;
-    inputs["use_input_embed"] = use_embed_t;
-
-    // Provide the input embedding vector
-    int32_t embed_dim = config_.vision_output_dim;
     std::vector<float> zero_embed;
-    if (input_embed == nullptr) {
-        zero_embed.resize(static_cast<std::size_t>(embed_dim), 0.0F);
-        input_embed = zero_embed.data();
-    }
-
-    Tensor embed_t;
-    embed_t.data = const_cast<float*>(input_embed);
-    embed_t.shape = {static_cast<int64_t>(embed_dim)};
-    embed_t.dtype = DType::kFloat32;
-    inputs["input_embed"] = embed_t;
-
-    // DeepStack: if the engine has deepstack inputs, provide inactive zeros.
-    if (text_decoder_->has_input("deepstack_active")) {
-        Tensor ds_active_t;
-        ds_active_t.data = &deepstack_active;
-        ds_active_t.shape = {1};
-        ds_active_t.dtype = DType::kFloat32;
-        inputs["deepstack_active"] = ds_active_t;
-
-        std::vector<float> zero_deepstack;
-        for (std::size_t i = 0;; ++i) {
-            const std::string name = "deepstack_embed_" + std::to_string(i);
-            if (!text_decoder_->has_input(name))
-                break;
-
-            const float* deepstack_embed =
-                i < deepstack_embeds.size() ? deepstack_embeds[i] : nullptr;
-            if (deepstack_embed == nullptr) {
-                if (zero_deepstack.empty())
-                    zero_deepstack.resize(static_cast<std::size_t>(embed_dim), 0.0F);
-                deepstack_embed = zero_deepstack.data();
-            }
-
-            Tensor ds_embed_t;
-            ds_embed_t.data = const_cast<float*>(deepstack_embed);
-            ds_embed_t.shape = {1, static_cast<int64_t>(embed_dim)};
-            ds_embed_t.dtype = DType::kFloat32;
-            inputs[name] = ds_embed_t;
-        }
-    }
+    std::vector<float> zero_deepstack;
+    add_text_step_embedding_inputs(*text_decoder_, config_, inputs, input_embed, use_input_embed,
+                                   deepstack_embeds, deepstack_active, zero_embed, zero_deepstack);
 
     auto outputs = text_decoder_->forward(inputs);
 

--- a/src/runtime/models/qwen_vl/pipeline.h
+++ b/src/runtime/models/qwen_vl/pipeline.h
@@ -31,6 +31,10 @@ struct QwenVlConfig {
     int32_t image_token_id{-1};
     int32_t vision_output_dim{0};
     bool has_position_input{true};
+    int32_t num_layers{0};
+    int32_t prefill_max_length{0};
+    std::string present_k_pattern{"present_k_{i}"};
+    std::string present_v_pattern{"present_v_{i}"};
 };
 
 class QwenVlPipeline final : public IPipeline {
@@ -40,7 +44,8 @@ class QwenVlPipeline final : public IPipeline {
                    std::unique_ptr<QwenVlInferenceState> state, QwenVlConfig config,
                    QwenVlPreprocessConfig vl_preprocess, cudaStream_t stream,
                    std::shared_ptr<ITokenizer> tokenizer = nullptr, std::string model_id_str = "",
-                   std::unique_ptr<QwenVlISampler> sampler = nullptr);
+                   std::unique_ptr<QwenVlISampler> sampler = nullptr,
+                   std::unique_ptr<TrtModule> prefill = nullptr);
 
     TextResult generate(const std::string& prompt, const GenerateConfig& cfg = {}) override;
 
@@ -64,6 +69,7 @@ class QwenVlPipeline final : public IPipeline {
 
   private:
     std::unique_ptr<TrtModule> text_decoder_;
+    std::unique_ptr<TrtModule> prefill_;
     std::unique_ptr<TrtModule> vision_encoder_;
     std::unique_ptr<QwenVlInferenceState> state_;
     QwenVlConfig config_;
@@ -89,6 +95,12 @@ class QwenVlPipeline final : public IPipeline {
                               const std::vector<std::vector<float>>& deepstack_features,
                               int32_t num_features, int32_t feature_dim, int32_t& feature_index,
                               std::vector<float>& logits);
+
+    bool run_vl_prefill_batched(const std::vector<int32_t>& input_ids,
+                                const std::vector<float>& image_features,
+                                const std::vector<std::vector<float>>& deepstack_features,
+                                int32_t num_features, int32_t feature_dim,
+                                std::vector<float>& logits);
 
     void run_vl_decode_loop(QwenVlISampler* sampler, const QwenVlSamplingParams& params,
                             std::vector<int32_t>& output, std::vector<float>& logits,

--- a/src/runtime/models/qwen_vl/plugin.cpp
+++ b/src/runtime/models/qwen_vl/plugin.cpp
@@ -92,14 +92,19 @@ QwenVlKvCacheNames build_kv_cache_names(const BaseConfig& config) {
     return kv_names;
 }
 
-LoadedModule load_text_module(const PipelineContext& ctx, TextModuleRuntime& runtime,
-                              const std::shared_ptr<QwenVlCudaStream>& stream) {
+DualProfileModules load_text_modules(const PipelineContext& ctx, TextModuleRuntime& runtime,
+                                     const std::shared_ptr<QwenVlCudaStream>& stream) {
     auto loaded =
-        load_trt_module_from_plan(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
+        load_dual_profile_modules(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
                                   runtime.engine_section.c_str(), runtime.options);
-    loaded.module->keep_alive(stream);
-    if (runtime.tp_group.owner)
-        loaded.module->keep_alive(runtime.tp_group.owner);
+    loaded.decode->keep_alive(stream);
+    if (loaded.prefill)
+        loaded.prefill->keep_alive(stream);
+    if (runtime.tp_group.owner) {
+        loaded.decode->keep_alive(runtime.tp_group.owner);
+        if (loaded.prefill)
+            loaded.prefill->keep_alive(runtime.tp_group.owner);
+    }
     return loaded;
 }
 
@@ -152,13 +157,13 @@ class VLPlugin final : public IPipelinePlugin {
 
         QwenVlKvCacheNames kv_names = build_kv_cache_names(ctx.config);
 
-        auto loaded = load_text_module(ctx, text_runtime, shared_stream);
+        auto loaded = load_text_modules(ctx, text_runtime, shared_stream);
 
-        cudaStream_t stream = loaded.module->stream();
+        cudaStream_t stream = loaded.decode->stream();
         const std::string cache_k_name =
             kv_names.cache_k.empty() ? std::string("cache_k_0") : kv_names.cache_k.front();
-        int32_t kv_dim = decoder_cache_row_width(*loaded.module, cache_k_name, ctx.config);
-        DType cache_dtype = loaded.module->tensor_dtype(cache_k_name);
+        int32_t kv_dim = decoder_cache_row_width(*loaded.decode, cache_k_name, ctx.config);
+        DType cache_dtype = loaded.decode->tensor_dtype(cache_k_name);
         std::unique_ptr<QwenVlInferenceState> state =
             std::make_unique<QwenVlKvCache>(ctx.config.num_layers, ctx.config.max_cache_length,
                                             kv_dim, stream, cache_dtype, std::move(kv_names));
@@ -171,7 +176,11 @@ class VLPlugin final : public IPipelinePlugin {
         vlc.id_eos = ctx.config.id_eos;
         vlc.image_token_id = extract_json_int(ctx.config_json, "image_token_id", -1);
         vlc.vision_output_dim = extract_json_int(ctx.config_json, "vision_output_dim", 0);
-        vlc.has_position_input = loaded.module->has_input("position_id");
+        vlc.has_position_input = loaded.decode->has_input("position_id");
+        vlc.num_layers = ctx.config.num_layers;
+        vlc.prefill_max_length = ctx.config.max_cache_length;
+        vlc.present_k_pattern = ctx.config.io_map.present_k_pattern;
+        vlc.present_v_pattern = ctx.config.io_map.present_v_pattern;
 
         bool has_vision_engine = extract_json_int(ctx.config_json, "has_vision_engine", 0) != 0;
 
@@ -186,9 +195,10 @@ class VLPlugin final : public IPipelinePlugin {
             bundle_section_text(ctx.bundle, "preprocessor_config.json");
         auto vl_preprocess = qwen_vl_parse_preprocess_config(config_text, preproc_text);
 
-        return std::make_unique<QwenVlPipeline>(std::move(loaded.module), std::move(vision_module),
+        return std::make_unique<QwenVlPipeline>(std::move(loaded.decode), std::move(vision_module),
                                                 std::move(state), vlc, vl_preprocess, stream,
-                                                std::move(tokenizer), ctx.bundle.info.model_id);
+                                                std::move(tokenizer), ctx.bundle.info.model_id,
+                                                nullptr, std::move(loaded.prefill));
     }
 };
 

--- a/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
+++ b/tests/cpp/models/qwen_vl/test_qwen_vl_vl_pipeline.cpp
@@ -41,8 +41,10 @@
 #include <cstdint>
 #include <cuda_runtime_api.h>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 static int failures = 0;
@@ -54,6 +56,130 @@ static void check(bool c, const char* n) {
 }
 
 static trtmc::TrtLogger g_logger;
+
+struct CountingTextStats {
+    int32_t calls{0};
+    std::unordered_map<std::string, std::vector<int64_t>> shapes;
+    std::unordered_map<std::string, std::vector<float>> float_values;
+};
+
+class CountingTextModule final : public trtmc::ITrtModule {
+  public:
+    CountingTextModule(std::shared_ptr<CountingTextStats> stats, bool prefill, cudaStream_t stream)
+        : stats_(std::move(stats)), prefill_(prefill), stream_(stream),
+          present_k_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}),
+          present_v_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        ++stats_->calls;
+        stats_->shapes.clear();
+        stats_->float_values.clear();
+        for (const auto& [name, tensor] : inputs) {
+            stats_->shapes[name] = tensor.shape;
+            if (tensor.dtype == trtmc::DType::kFloat32) {
+                const auto* begin = static_cast<const float*>(tensor.data);
+                stats_->float_values[name] =
+                    std::vector<float>(begin, begin + static_cast<std::ptrdiff_t>(tensor.numel()));
+            }
+        }
+        return {{"logits", trtmc::Tensor{logits_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap& inputs) override { (void)forward(inputs); }
+    void sync() override {}
+    cudaStream_t stream() const override { return stream_; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return prefill_ ? 0 : 1; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return {}; }
+    std::vector<trtmc::TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" || name == "attention_mask" ||
+               name == "input_embed" || name == "use_input_embed" || name == "deepstack_active" ||
+               name == "deepstack_embed_0" || name == "cache_k_0" || name == "cache_v_0";
+    }
+    bool has_output(const std::string& name) const override {
+        return name == "logits" || name == "present_k_0" || name == "present_v_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        if (name == "cache_k_0" || name == "cache_v_0")
+            return {8, 4};
+        return {};
+    }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return prefill_ ? 2 : 1; }
+    void* device_ptr(const std::string& name) const override {
+        if (name == "present_k_0")
+            return const_cast<void*>(present_k_.data());
+        if (name == "present_v_0")
+            return const_cast<void*>(present_v_.data());
+        return nullptr;
+    }
+    void bind_external(const std::string&, void*) override {}
+    int32_t input_rank(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" ? 1 : 2;
+    }
+    bool input_is_dynamic(const std::string&) const override { return prefill_; }
+    bool ok() const override { return !prefill_ || (present_k_.ok() && present_v_.ok()); }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::shared_ptr<CountingTextStats> stats_;
+    bool prefill_{false};
+    cudaStream_t stream_{nullptr};
+    mutable trtmc::DeviceTensor present_k_;
+    mutable trtmc::DeviceTensor present_v_;
+    std::vector<float> logits_{0.1F, 0.2F, 0.9F, 0.3F};
+};
+
+class FakeSequenceVisionModule final : public trtmc::ITrtModule {
+  public:
+    trtmc::TensorMap forward(const trtmc::TensorMap&) override {
+        return {{"image_features", trtmc::Tensor{features_.data(), {1, 4}, trtmc::DType::kFloat32}},
+                {"deepstack_features_0",
+                 trtmc::Tensor{deepstack_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap&) override {}
+    void sync() override {}
+    cudaStream_t stream() const override { return nullptr; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<trtmc::TensorInfo> input_info() const override {
+        return {{"pixel_values", {3, 4, 4}, trtmc::DType::kFloat32, true}};
+    }
+    std::vector<trtmc::TensorInfo> output_info() const override {
+        return {{"image_features", {1, 4}, trtmc::DType::kFloat32, false}};
+    }
+    bool has_input(const std::string& name) const override { return name == "pixel_values"; }
+    bool has_output(const std::string& name) const override {
+        return name == "image_features" || name == "deepstack_features_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string&) const override { return {}; }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string&) const override { return nullptr; }
+    void bind_external(const std::string&, void*) override {}
+    bool ok() const override { return true; }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::vector<float> features_{10.0F, 11.0F, 12.0F, 13.0F};
+    std::vector<float> deepstack_{20.0F, 21.0F, 22.0F, 23.0F};
+};
 
 // ---------------------------------------------------------------------------
 // Inline FixedTokenizer for string-based generate() tests
@@ -576,6 +702,62 @@ static void test_vl_generate_with_embed_decoder() {
     cudaStreamDestroy(stream);
 }
 
+static void test_vl_sequence_prefill_uses_one_text_launch() {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto decode_stats = std::make_shared<CountingTextStats>();
+    auto prefill_stats = std::make_shared<CountingTextStats>();
+    auto decoder = std::make_unique<CountingTextModule>(decode_stats, false, stream);
+    auto prefill = std::make_unique<CountingTextModule>(prefill_stats, true, stream);
+    auto vision = std::make_unique<FakeSequenceVisionModule>();
+    auto cache = std::make_unique<trtmc::QwenVlKvCache>(1, 8, 4, stream);
+
+    trtmc::QwenVlConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 2;
+    cfg.image_token_id = 1;
+    cfg.vision_output_dim = 4;
+    cfg.num_layers = 1;
+    cfg.prefill_max_length = 8;
+
+    trtmc::QwenVlPreprocessConfig vl_pp;
+    vl_pp.preprocessor_type = "simple_chw";
+    vl_pp.fixed_image_size = 4;
+    vl_pp.in_channels = 3;
+
+    auto tokenizer = std::make_shared<VLFixedTokenizer>();
+    trtmc::QwenVlPipeline pipeline(std::move(decoder), std::move(vision), std::move(cache), cfg,
+                                   vl_pp, stream, tokenizer, "", nullptr, std::move(prefill));
+
+    float pixels[2 * 2 * 3] = {0.5F, 0.5F, 0.5F, 0.4F, 0.4F, 0.4F,
+                               0.3F, 0.3F, 0.3F, 0.2F, 0.2F, 0.2F};
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 1;
+    gen_cfg.eos_token_id = 2;
+    auto result = pipeline.generate("test", pixels, 2, 2, gen_cfg);
+
+    check(result.token_ids == std::vector<int32_t>{2}, "sequence prefill: output remains correct");
+    check(prefill_stats->calls == 1, "sequence prefill: one prefill launch");
+    check(decode_stats->calls == 0, "sequence prefill: no prompt-linear decode launches");
+    check(prefill_stats->shapes["token_id"] == std::vector<int64_t>{3},
+          "sequence prefill: token shape");
+    check(prefill_stats->shapes["input_embed"] == std::vector<int64_t>({3, 4}),
+          "sequence prefill: input embed shape");
+    check(prefill_stats->shapes["use_input_embed"] == std::vector<int64_t>({3, 1}),
+          "sequence prefill: embed selector shape");
+    check(prefill_stats->shapes["deepstack_embed_0"] == std::vector<int64_t>({3, 4}),
+          "sequence prefill: deepstack embed shape");
+    check(prefill_stats->shapes["deepstack_active"] == std::vector<int64_t>({3, 1}),
+          "sequence prefill: deepstack selector shape");
+    check(prefill_stats->float_values["use_input_embed"] == std::vector<float>({1.0F, 0.0F, 0.0F}),
+          "sequence prefill: image embedding selected by position");
+    check(prefill_stats->float_values["deepstack_active"] == std::vector<float>({1.0F, 0.0F, 0.0F}),
+          "sequence prefill: deepstack selected by position");
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_vl_generate_with_tokenizer() {
     // Covers the string-based generate(const string&, cfg) method
     auto engine = build_mock_decoder();
@@ -624,6 +806,7 @@ int main() {
     test_vl_generate_with_image_no_encoder();
     test_vl_generate_with_vision_encoder();
     test_vl_generate_with_embed_decoder();
+    test_vl_sequence_prefill_uses_one_text_launch();
     test_vl_generate_with_tokenizer();
     if (failures > 0)
         std::cerr << failures << " FAILED\n";

--- a/tests/e2e/models/qwen_vl/e2e_plugins/runners/vl_debug_runner.py
+++ b/tests/e2e/models/qwen_vl/e2e_plugins/runners/vl_debug_runner.py
@@ -61,6 +61,20 @@ def _require_trt_runtime() -> None:
         raise ImportError("cuda-python is required for VL debug runner execution")
 
 
+def _profile_min_shape(engine: Any, name: str, profile_index: int) -> tuple[int, ...]:
+    """Resolve a concrete single-step shape for a possibly dynamic tensor."""
+    declared = tuple(int(dim) for dim in engine.get_tensor_shape(name))
+    if all(dim >= 0 for dim in declared):
+        return declared
+    profile_shapes = engine.get_tensor_profile_shape(name, profile_index)
+    if not profile_shapes:
+        raise RuntimeError(f"Missing optimization profile shape for {name!r}")
+    resolved = tuple(int(dim) for dim in profile_shapes[0])
+    if any(dim < 0 for dim in resolved):
+        raise RuntimeError(f"Invalid optimization profile shape for {name!r}: {resolved}")
+    return resolved
+
+
 class TrtRunner:
     """Device-resident TRT inference runner for debugging and diff testing.
 
@@ -104,17 +118,19 @@ class TrtRunner:
         # decode profile (profile 1, Sq=1). For per-step decode runs the
         # debug_runner must select the decode profile and call
         # set_input_shape on every dynamic input before each execute. We
-        # detect dual-profile via num_optimization_profiles > 1 and the
-        # presence of -1 dims on token_id / position_id / attention_mask.
-        self._dynamic_inputs: list[str] = []
+        # detect dual-profile via num_optimization_profiles > 1 and resolve
+        # every dynamic input from the selected profile's minimum shape.
+        self._dynamic_input_shapes: dict[str, tuple[int, ...]] = {}
         self._is_dual_profile = self.engine.num_optimization_profiles > 1
-        for input_name in ("token_id", "position_id", "attention_mask"):
-            try:
-                shape = tuple(self.engine.get_tensor_shape(input_name))
-            except Exception:
+        self._profile_index = 1 if self._is_dual_profile else 0
+        for index in range(self.engine.num_io_tensors):
+            input_name = self.engine.get_tensor_name(index)
+            if self.engine.get_tensor_mode(input_name) != trt.TensorIOMode.INPUT:
                 continue
-            if any(d < 0 for d in shape):
-                self._dynamic_inputs.append(input_name)
+            shape = tuple(self.engine.get_tensor_shape(input_name))
+            if any(dim < 0 for dim in shape):
+                self._dynamic_input_shapes[input_name] = _profile_min_shape(
+                    self.engine, input_name, self._profile_index)
         if self._is_dual_profile:
             # Profile 1 = decode (Sq=1). step() always runs single-token, so
             # we lock the context to that profile once and never switch.
@@ -213,14 +229,18 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name == "input_embed":
                 self._has_embed_input = True
-                embed_shape = tuple(self.engine.get_tensor_shape(name))
+                embed_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 embed_bytes = int(np.prod(embed_shape)) * 4
                 self._h_input_embed = np.zeros(embed_shape, dtype=np.float32)
                 err, self._d_input_embed = cudart.cudaMalloc(embed_bytes)
                 _check_cuda(err)
             elif name == "use_input_embed":
-                self._h_use_input_embed = np.zeros((1,), dtype=np.float32)
-                err, self._d_use_input_embed = cudart.cudaMalloc(4)
+                selector_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_use_input_embed = np.zeros(selector_shape, dtype=np.float32)
+                err, self._d_use_input_embed = cudart.cudaMalloc(
+                    self._h_use_input_embed.nbytes)
                 _check_cuda(err)
 
         # DeepStack inputs (auto-detected from engine bindings)
@@ -233,15 +253,19 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name.startswith("deepstack_embed_"):
                 self._deepstack_names.append(name)
-                shape = tuple(self.engine.get_tensor_shape(name))
+                shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 nbytes = int(np.prod(shape)) * 4
                 self._h_deepstack[name] = np.zeros(shape, dtype=np.float32)
                 err, d_ptr = cudart.cudaMalloc(nbytes)
                 _check_cuda(err)
                 self._d_deepstack[name] = d_ptr
             elif name == "deepstack_active":
-                self._h_deepstack_active = np.zeros((1,), dtype=np.float32)
-                err, self._d_deepstack_active = cudart.cudaMalloc(4)
+                active_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_deepstack_active = np.zeros(active_shape, dtype=np.float32)
+                err, self._d_deepstack_active = cudart.cudaMalloc(
+                    self._h_deepstack_active.nbytes)
                 _check_cuda(err)
 
         # Debug output device/host buffers
@@ -331,7 +355,7 @@ class TrtRunner:
                 self._h_input_embed.nbytes, H2D, stream)
             cudart.cudaMemcpyAsync(
                 self._d_use_input_embed, self._h_use_input_embed.ctypes.data,
-                4, H2D, stream)
+                self._h_use_input_embed.nbytes, H2D, stream)
 
         # DeepStack H2D transfers
         if self._deepstack_names:
@@ -350,7 +374,7 @@ class TrtRunner:
                 cudart.cudaMemcpyAsync(
                     self._d_deepstack_active,
                     self._h_deepstack_active.ctypes.data,
-                    4, H2D, stream)
+                    self._h_deepstack_active.nbytes, H2D, stream)
 
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
@@ -379,15 +403,11 @@ class TrtRunner:
         for name in self._debug_output_names:
             self.context.set_tensor_address(name, self._d_debug[name])
 
-        # Dual-profile engines need explicit shapes for the dynamic
-        # inputs every step. step() is single-token decode, so all three
-        # shapes are fixed: Sq=1 and K = max_cache_length + 1.
-        if self._dynamic_inputs:
-            for name in self._dynamic_inputs:
-                if name == "attention_mask":
-                    self.context.set_input_shape(name, (1, attention_window))
-                else:
-                    self.context.set_input_shape(name, (1,))
+        # Dynamic inputs use the selected profile's minimum shapes. Both the
+        # prefill and decode profiles have Sq=1 minima, so this covers token,
+        # mask, image embedding, selector, and DeepStack inputs uniformly.
+        for name, shape in self._dynamic_input_shapes.items():
+            self.context.set_input_shape(name, shape)
 
         # Execute
         self.context.execute_async_v3(stream)
@@ -481,24 +501,16 @@ class TrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask,
-                self._d_logits]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        if self._d_input_embed:
-            bufs.append(self._d_input_embed)
-        if self._d_use_input_embed:
-            bufs.append(self._d_use_input_embed)
-        for d_ptr in self._d_deepstack.values():
-            bufs.append(d_ptr)
-        if self._d_deepstack_active:
-            bufs.append(self._d_deepstack_active)
-        for d_ptr in self._d_debug.values():
-            bufs.append(d_ptr)
+        bufs = []
+        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
+                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+            d_ptr = getattr(self, name, 0)
+            if d_ptr:
+                bufs.append(d_ptr)
+        for name in ("_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v"):
+            bufs.extend(getattr(self, name, []))
+        bufs.extend(getattr(self, "_d_deepstack", {}).values())
+        bufs.extend(getattr(self, "_d_debug", {}).values())
         for d_ptr in bufs:
             cudart.cudaFree(d_ptr)
         if hasattr(self, "stream"):

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py
@@ -100,6 +100,25 @@ def test_qwen25_vl_plugin_forwards_precision_to_standard_builder(monkeypatch) ->
     assert kwargs["verbose"] is True
 
 
+def test_qwen25_vl_embed_input_dispatches_to_dual_profile_builder(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen_vl.default_decoder")
+    calls: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"qwen-vl-dual-profile-plan"
+
+    monkeypatch.setattr(module, "build_dual_profile_decoder_engine", fake_build)
+    config = _config(qwen3=False)
+    config.raw["_decoder_engine_role"] = "decode"
+    result = module.build_standard_decoder_engine(
+        config, {}, 31, precision="fp16", embed_input=True)
+
+    assert result == b"qwen-vl-dual-profile-plan"
+    assert calls["build"][3]["embed_input"] is True
+
+
 def test_qwen3_vl_vision_component_can_stay_fp32(monkeypatch) -> None:
     module = importlib.import_module(
         "tensorrt_model_connect.families.qwen_vl.plugin")

--- a/tests/e2e/models/qwen_vl/test_qwen_vl_debug_runner.py
+++ b/tests/e2e/models/qwen_vl/test_qwen_vl_debug_runner.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+RUNNER_MODULES = (
+    "tensorrt_model_connect.families.qwen_vl.vl_debug_runner",
+    "tests.e2e.models.qwen_vl.e2e_plugins.runners.vl_debug_runner",
+)
+
+
+class FakeEngine:
+    def __init__(self, declared, profile_shapes=()):
+        self.declared = declared
+        self.profile_shapes = profile_shapes
+        self.profile_requests: list[tuple[str, int]] = []
+
+    def get_tensor_shape(self, name):
+        assert name == "input_embed"
+        return self.declared
+
+    def get_tensor_profile_shape(self, name, profile_index):
+        self.profile_requests.append((name, profile_index))
+        return self.profile_shapes
+
+
+@pytest.mark.parametrize("module_name", RUNNER_MODULES)
+def test_profile_min_shape_resolves_dynamic_decode_input(module_name) -> None:
+    module = importlib.import_module(module_name)
+    engine = FakeEngine(
+        (-1, 2048),
+        ((1, 2048), (1, 2048), (1, 2048)),
+    )
+
+    assert module._profile_min_shape(engine, "input_embed", 1) == (1, 2048)
+    assert engine.profile_requests == [("input_embed", 1)]
+
+
+@pytest.mark.parametrize("module_name", RUNNER_MODULES)
+def test_profile_min_shape_preserves_static_input(module_name) -> None:
+    module = importlib.import_module(module_name)
+    engine = FakeEngine((1, 2048))
+
+    assert module._profile_min_shape(engine, "input_embed", 0) == (1, 2048)
+    assert engine.profile_requests == []
+
+
+@pytest.mark.parametrize("module_name", RUNNER_MODULES)
+def test_profile_min_shape_rejects_unresolved_profile(module_name) -> None:
+    module = importlib.import_module(module_name)
+    engine = FakeEngine(
+        (-1, 2048),
+        ((-1, 2048), (-1, 2048), (-1, 2048)),
+    )
+
+    with pytest.raises(RuntimeError, match="Invalid optimization profile shape"):
+        module._profile_min_shape(engine, "input_embed", 0)


### PR DESCRIPTION
## Background

Qwen-VL submitted every multimodal prompt token through the text decoder separately. This made text-engine launch count and latency grow linearly with prompt length even though the model output remained correct.

Fixes #479.

## Exit Criteria

- Submit the complete Qwen2.5-VL and Qwen3-VL multimodal prompt through one sequence-prefill invocation.
- Preserve KV-cache, position, attention-mask, image-embedding, and DeepStack semantics.
- Keep single-token autoregressive decode and legacy single-profile bundle compatibility.
- Preserve the reviewed model precision configurations and expected white-vehicle answer.

## Implementation

- Build Qwen-VL text engines with dynamic sequence inputs and separate prefill/decode optimization profiles, including per-position image and DeepStack selectors.
- Load independent prefill and decode execution contexts, copy batched present K/V rows into the decode cache, and continue decoding from the completed prompt.
- Fall back to the existing token-by-token path for legacy bundles without a prefill profile.
- Add deterministic regression coverage for one-call sequence prefill, multimodal input shapes/selectors, and Qwen2.5-VL dual-profile builder dispatch.
- Resolve all dynamic debug-runner inputs from the selected decode profile so the differential harness can allocate and bind sequence-shaped image and DeepStack tensors.

## Validation

- `cmake --build build --target trtmc test_qwen_vl_vl_pipeline -j 8`: passed.
- `./build/test_qwen_vl_vl_pipeline`: passed; the three-token multimodal prompt uses one prefill launch and sequence-shaped inputs.
- `PYTHONPATH=python python -m pytest tests/builder -q -p no:cacheprovider`: 660 passed, 8 skipped.
- `PYTHONPATH=python python -m pytest tests/e2e/models/qwen_vl -q -p no:cacheprovider`: 65 passed, including fresh Qwen2.5-VL and Qwen3-VL builds and E2E runs.
- `PYTHONPATH=python python -m pytest tests/e2e/models/qwen_vl/test_qwen_vl_debug_runner.py tests/e2e/models/qwen_vl/test_qwen_vl_builder_tp.py -q -p no:cacheprovider`: 12 passed.
- `PYTHONPATH=python python -m pytest tests/tools/test_model_plugin_encapsulation_static.py -q -p no:cacheprovider`: 156 passed.
- `PYTHONPATH=python python tools/diff_vl.py --bundle /tmp/qwen3-vl-2b.trtfb --image tests/e2e/models/qwen_vl/data/test_img.jpeg --vision-only --model Qwen/Qwen3-VL-2B-Instruct --atol 0.1`: passed vision encoding and text-decoder embedding checks.
- `python tools/check_cyclomatic_complexity.py src --exclude src/cli --max-ccn 10 --top 20 --fail-on-missing-lizard`: passed with maximum CCN 10.
- `python tools/legal_headers.py --check`, Ruff, clang-format, family coverage, and `git diff --check`: passed.
- `Qwen/Qwen3-VL-2B-Instruct` with the issue image and prompt: returned `White`; one vision launch, one text prefill launch, and one text decode launch (previously 222 text launches).
- `Qwen/Qwen2.5-VL-3B-Instruct` with the issue image and prompt: returned `White`; one vision launch, one text prefill launch, and one text decode launch (previously 282 text launches).

## Notes For Future Readers

- Review the dynamic graph/profile changes first, then the runtime cache handoff, followed by the deterministic regression test.
- The generic CLI image benchmark routing remains outside this change, as scoped by #479.
