### PR TITLE
feat(task-eval): add performance evaluation

### DIFF
--- a/tests/task_eval/performance_profiles.yaml
+++ b/tests/task_eval/performance_profiles.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 1
+
+profiles:
+  etth1_process_e2e_observation_v1: &etth1_process_e2e
+    description: >
+      Non-blocking HF/TRTFB process-level timing on deterministic ETTh1
+      windows. Each observation includes process startup and model/runtime load;
+      it is not a warm-session latency profile.
+    mode: observation
+    supported_suite_ids:
+      - etth1_time_series_parity
+    supported_dataset_kinds:
+      - time_series_csv
+    backends:
+      - hf
+      - trtfb
+    environment:
+      compatibility_class: gb300-dedicated
+      gpu_name_pattern: GB300
+      exclusive_gpu: true
+      max_background_gpu_utilization_pct: 5
+    scenario:
+      scope: process_e2e
+      synchronization: process_exit
+      warmup_iterations: 1
+      measured_iterations: 5
+      process_repetitions: 3
+      concurrency: 1
+      quantile_method: nearest_rank
+      require_output_match: true
+    metrics:
+      required:
+        - name: request_latency_ms.p50
+          direction: lower
+          max_regression_fraction: 0.05
+        - name: request_latency_ms.p95
+          direction: lower
+          max_regression_fraction: 0.10
+        - name: throughput_units_per_second
+          direction: higher
+          max_regression_fraction: 0.05
+        - name: error_rate
+          direction: lower
+          absolute_max: 0.0
+      optional:
+        - name: peak_device_memory_mb
+          direction: lower
+
+  etth1_process_e2e_blocking_v1:
+    <<: *etth1_process_e2e
+    description: >
+      Blocking form of the ETTh1 process-level profile. It remains unusable
+      until a run from this exact profile is explicitly reviewed and approved
+      as a comparable baseline.
+    mode: blocking

--- a/tests/task_eval/validation_suites.yaml
+++ b/tests/task_eval/validation_suites.yaml
@@ -1234,6 +1234,15 @@ suites:
         gates:
           max_relative_l2: 4.0e-03
           max_absolute_error: 7.0e-03
+    performance:
+      opt_in: true
+      observation_profile: etth1_process_e2e_observation_v1
+      blocking_profile: etth1_process_e2e_blocking_v1
+      notes: >
+        These profiles measure process-level E2E latency and are never inferred
+        from legacy wall_ms. Nightly parity remains unchanged until a profile is
+        explicitly selected; blocking additionally requires an approved,
+        comparable baseline.
     ci:
       eligible: true
       lane: nightly

--- a/tests/tools/test_model_validation.py
+++ b/tests/tools/test_model_validation.py
@@ -1,0 +1,368 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from tools import task_eval
+from tools.model_validation import (
+    Assessment,
+    CompatibilityMode,
+    LegacyTaskEvalFacade,
+    PlanIntegrityError,
+    TaskAdapterRegistry,
+    UnknownTaskAdapterError,
+    UnsupportedLegacyPerformanceError,
+    ValidationPlan,
+    ValidationRequest,
+    WorkloadResolution,
+    compile_legacy_plan,
+)
+
+
+def _suite() -> dict:
+    return {
+        "id": "example_suite",
+        "description": "Example compatibility suite",
+        "user_contract": "example_output",
+        "dataset": {
+            "kind": "reranking_json",
+            "default_path": "/datasets/example.json",
+            "source_revision": "dataset-revision",
+        },
+        "generation": {"seed": 7, "max_new_tokens": 4},
+        "gates": {"min_agreement": 1.0},
+    }
+
+
+def _models() -> list[dict]:
+    return [
+        {
+            "name": "example-model",
+            "hf_id": "org/example-model",
+            "bundle": "example-model.trtfb",
+            "runtime_strategy": "example_runtime",
+            "task_strategy": "reranking",
+            "reference_family": "example",
+            "user_contract": "example_output",
+            "manifest": "tests/e2e/models/example/MODEL.toml",
+        }
+    ]
+
+
+def _request(*, limit: int = 10) -> ValidationRequest:
+    return ValidationRequest(
+        suite_id="example_suite",
+        model_selectors=("example-model",),
+        assessments=(Assessment.TASK, Assessment.FIDELITY),
+        dataset_override="/datasets/override.json",
+        limit=limit,
+        seed=20260717,
+    )
+
+
+def test_compile_legacy_plan_is_deterministic_and_immutable() -> None:
+    first = compile_legacy_plan(_request(), suite=_suite(), models=_models())
+    reordered_suite = {
+        "gates": {"min_agreement": 1.0},
+        "generation": {"max_new_tokens": 4, "seed": 7},
+        "dataset": {
+            "source_revision": "dataset-revision",
+            "default_path": "/datasets/example.json",
+            "kind": "reranking_json",
+        },
+        "user_contract": "example_output",
+        "description": "Example compatibility suite",
+        "id": "example_suite",
+    }
+    reordered_model = dict(reversed(list(_models()[0].items())))
+    second = compile_legacy_plan(_request(), suite=reordered_suite, models=[reordered_model])
+
+    assert first.plan_digest == second.plan_digest
+    assert first.compatibility_mode is CompatibilityMode.LEGACY_TASK_EVAL
+    assert first.workload.resolution is WorkloadResolution.DEFERRED_TO_LEGACY_RUNTIME
+    assert first.workload.ordered_sample_ids == ()
+    assert first.to_dict()["plan_digest"] == first.plan_digest
+    with pytest.raises(FrozenInstanceError):
+        first.schema_version = "changed"  # type: ignore[misc]
+
+
+def test_plan_digest_changes_when_execution_semantics_change() -> None:
+    first = compile_legacy_plan(_request(limit=10), suite=_suite(), models=_models())
+    second = compile_legacy_plan(_request(limit=11), suite=_suite(), models=_models())
+    changed_models = _models()
+    changed_models[0]["precision"] = "float16"
+    third = compile_legacy_plan(_request(limit=10), suite=_suite(), models=changed_models)
+
+    assert first.plan_digest != second.plan_digest
+    assert first.plan_digest != third.plan_digest
+
+
+def test_validation_request_requires_explicit_performance_profile() -> None:
+    with pytest.raises(ValueError, match="performance_profile_id"):
+        ValidationRequest(
+            suite_id="example_suite",
+            assessments=(Assessment.PERFORMANCE,),
+        )
+
+
+def test_legacy_plan_rejects_performance_assessment() -> None:
+    request = ValidationRequest(
+        suite_id="example_suite",
+        assessments=(Assessment.PERFORMANCE,),
+        performance_profile_id="gb300_single_stream_v1",
+    )
+
+    with pytest.raises(UnsupportedLegacyPerformanceError, match="native task adapter"):
+        compile_legacy_plan(request, suite=_suite(), models=_models())
+
+
+def test_facade_compiles_native_performance_plan_for_registered_adapter() -> None:
+    class Adapter:
+        kind = "time_series_csv"
+        version = "1"
+
+    plan = LegacyTaskEvalFacade().compile_eval_plan(
+        suite=_suite(),
+        models=_models(),
+        performance_profile_id="etth1_process_e2e_observation_v1",
+        native_adapter=Adapter(),
+    )
+
+    assert plan.compatibility_mode is CompatibilityMode.NATIVE
+    assert plan.workload.resolution is WorkloadResolution.DEFERRED_TO_NATIVE_PREPARE
+    assert plan.task_adapter_kind == "time_series_csv"
+    assert plan.task_adapter_version == "1"
+    assert Assessment.PERFORMANCE in plan.request.assessments
+    assert plan.request.performance_profile_id == "etth1_process_e2e_observation_v1"
+
+
+def test_facade_writes_and_validates_versioned_plan(tmp_path: Path) -> None:
+    facade = LegacyTaskEvalFacade()
+    plan = facade.compile_eval_plan(
+        suite=_suite(),
+        models=_models(),
+        model_selectors=["example-model"],
+        dataset_override="/datasets/override.json",
+        limit=10,
+        seed=20260717,
+    )
+
+    path = facade.write_plan(plan, tmp_path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    restored = ValidationPlan.from_dict(payload)
+
+    assert path == tmp_path / "validation_plan.json"
+    assert payload["schema_version"] == "1.0"
+    assert payload["kind"] == "model_validation_plan"
+    assert restored == plan
+
+    payload["request"]["limit"] = 99
+    with pytest.raises(PlanIntegrityError, match="digest"):
+        ValidationPlan.from_dict(payload)
+
+
+def test_eval_parser_accepts_performance_profile_configuration() -> None:
+    args = task_eval.build_arg_parser().parse_args(
+        [
+            "eval",
+            "--suite",
+            "etth1_time_series_parity",
+            "--performance-profile",
+            "etth1_process_e2e_observation_v1",
+            "--performance-profiles",
+            "/profiles.yaml",
+            "--performance-baseline",
+            "/approved-baseline.json",
+        ]
+    )
+
+    assert args.performance_profile == "etth1_process_e2e_observation_v1"
+    assert args.performance_profiles == "/profiles.yaml"
+    assert args.performance_baseline == "/approved-baseline.json"
+
+
+def test_task_adapter_registry_fails_closed_on_duplicates_and_unknown_kinds() -> None:
+    class Adapter:
+        kind = "example"
+        version = "1"
+
+        def prepare(self, _work_dir, *, suite_id):
+            return suite_id
+
+        def fidelity_metrics(self, _reference, _candidate, *, gates):
+            return dict(gates)
+
+        def measurement_units(self):
+            return ("sample",)
+
+    registry = TaskAdapterRegistry()
+    adapter = Adapter()
+
+    registry.register(adapter)
+    assert registry.get("example") is adapter
+    assert registry.kinds() == ("example",)
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register(Adapter())
+    with pytest.raises(UnknownTaskAdapterError, match="example-missing"):
+        registry.get("example-missing")
+
+    class IncompleteAdapter:
+        kind = "incomplete"
+        version = "1"
+
+    with pytest.raises(TypeError, match="missing required methods"):
+        registry.register(IncompleteAdapter())
+
+
+def test_cmd_eval_emits_compatibility_plan_without_changing_legacy_summary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    suite = _suite()
+    model = _models()[0]
+    monkeypatch.setattr(task_eval, "load_suites", lambda *_args, **_kwargs: [suite])
+    monkeypatch.setattr(task_eval, "load_manifest_records", lambda *_args, **_kwargs: [model])
+    monkeypatch.setattr(
+        task_eval,
+        "selected_models_for_suite",
+        lambda *_args, **_kwargs: [model],
+    )
+    monkeypatch.setattr(
+        task_eval,
+        "eval_one_model",
+        lambda **_kwargs: {
+            "suite": suite["id"],
+            "model": model["name"],
+            "hf_id": model["hf_id"],
+            "mode": "reranking_parity",
+            "status": "passed",
+            "hf_reused": False,
+            "bundle_built": False,
+            "sample_pass_rate": 1.0,
+            "mean_pairwise_ordering_agreement": 1.0,
+            "min_pairwise_ordering_agreement": 1.0,
+        },
+    )
+    args = argparse.Namespace(
+        suites="",
+        suite=suite["id"],
+        dataset="/datasets/override.json",
+        models_dir="",
+        waives="",
+        waive_platform="",
+        include_waived=False,
+        model=[],
+        single_device_only=True,
+        bundle="",
+        work_root=str(tmp_path / "work"),
+        engine_dir=str(tmp_path / "bundles"),
+        limit=5,
+        sample_seed=17,
+        fail_fast=False,
+        disable_model_process_isolation=True,
+    )
+
+    assert task_eval.cmd_eval(args) == 0
+
+    suite_root = tmp_path / "work" / suite["id"]
+    plan = ValidationPlan.from_dict(
+        json.loads((suite_root / "validation_plan.json").read_text(encoding="utf-8"))
+    )
+    summary = json.loads((suite_root / "eval_summary.json").read_text(encoding="utf-8"))
+
+    assert plan.request.limit == 5
+    assert plan.request.seed == 17
+    assert plan.workload.dataset_path == "/datasets/override.json"
+    assert [case.model_name for case in plan.cases] == ["example-model"]
+    assert summary == {
+        "suite": "example_suite",
+        "count": 1,
+        "passed_count": 1,
+        "failed_count": 0,
+        "skipped_count": 0,
+        "model_process_isolation": False,
+        "results": [
+            {
+                "suite": "example_suite",
+                "model": "example-model",
+                "hf_id": "org/example-model",
+                "mode": "reranking_parity",
+                "status": "passed",
+                "hf_reused": False,
+                "bundle_built": False,
+                "sample_pass_rate": 1.0,
+                "mean_pairwise_ordering_agreement": 1.0,
+                "min_pairwise_ordering_agreement": 1.0,
+            }
+        ],
+    }
+
+
+def test_cmd_eval_emits_native_plan_when_etth1_perf_is_requested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    suite = {
+        "id": "etth1_time_series_parity",
+        "user_contract": "time_series_prediction_parity",
+        "dataset": {"kind": "time_series_csv", "default_path": "/data/ETTh1.csv"},
+    }
+    model = _models()[0]
+    monkeypatch.setattr(task_eval, "load_suites", lambda *_args, **_kwargs: [suite])
+    monkeypatch.setattr(task_eval, "load_manifest_records", lambda *_args, **_kwargs: [model])
+    monkeypatch.setattr(
+        task_eval,
+        "selected_models_for_suite",
+        lambda *_args, **_kwargs: [model],
+    )
+    monkeypatch.setattr(
+        task_eval,
+        "eval_one_model",
+        lambda **_kwargs: {
+            "suite": suite["id"],
+            "model": model["name"],
+            "hf_id": model["hf_id"],
+            "status": "passed",
+            "hf_reused": False,
+            "bundle_built": False,
+        },
+    )
+    monkeypatch.setattr(task_eval, "_format_result_line", lambda *_args: "passed")
+    profile_path = Path(__file__).resolve().parents[1] / "task_eval" / "performance_profiles.yaml"
+    args = argparse.Namespace(
+        suites="",
+        suite=suite["id"],
+        dataset="/data/ETTh1.csv",
+        models_dir="",
+        waives="",
+        waive_platform="",
+        include_waived=False,
+        model=[],
+        single_device_only=True,
+        bundle="",
+        work_root=str(tmp_path / "work"),
+        engine_dir=str(tmp_path / "bundles"),
+        limit=5,
+        sample_seed=17,
+        fail_fast=False,
+        disable_model_process_isolation=True,
+        performance_profile="etth1_process_e2e_observation_v1",
+        performance_profiles=str(profile_path),
+        performance_baseline="",
+    )
+
+    assert task_eval.cmd_eval(args) == 0
+
+    plan = ValidationPlan.from_dict(
+        json.loads(
+            (tmp_path / "work" / suite["id"] / "validation_plan.json").read_text(encoding="utf-8")
+        )
+    )
+    assert plan.compatibility_mode is CompatibilityMode.NATIVE
+    assert plan.task_adapter_kind == "time_series_csv"
+    assert Assessment.PERFORMANCE in plan.request.assessments

--- a/tests/tools/test_model_validation_performance.py
+++ b/tests/tools/test_model_validation_performance.py
@@ -1,0 +1,694 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tools import task_eval
+from tools.model_validation import AssessmentStatus
+from tools.model_validation.adapters.time_series import TimeSeriesTaskAdapter
+from tools.model_validation.measurement import (
+    MeasurementEngine,
+    MeasurementObservation,
+    MeasurementOutput,
+    MeasurementResult,
+    MetricValue,
+    NullMemoryMonitor,
+    nvidia_smi_device_args,
+    percentile_nearest_rank,
+    validate_output_digests,
+)
+from tools.model_validation.performance import (
+    PerformanceBaseline,
+    EnvironmentFingerprint,
+    PerformanceMode,
+    evaluate_performance,
+    load_baseline,
+    load_performance_profile,
+)
+
+
+PROFILE_PATH = Path(__file__).resolve().parents[1] / "task_eval" / "performance_profiles.yaml"
+
+
+def test_repository_etth1_profile_is_process_scoped_observation() -> None:
+    profile = load_performance_profile(PROFILE_PATH, "etth1_process_e2e_observation_v1")
+
+    assert profile.mode is PerformanceMode.OBSERVATION
+    assert profile.scenario.scope.value == "process_e2e"
+    assert profile.scenario.synchronization == "process_exit"
+    assert profile.scenario.warmup_iterations == 1
+    assert profile.scenario.measured_iterations == 5
+    assert profile.scenario.process_repetitions == 3
+    assert profile.scenario.require_output_match is True
+    assert profile.backends == ("hf", "trtfb")
+    assert "etth1_time_series_parity" in profile.supported_suite_ids
+    assert "request_latency_ms.p50" in profile.required_metric_names
+    assert "request_latency_ms.p95" in profile.required_metric_names
+
+    blocking = load_performance_profile(PROFILE_PATH, "etth1_process_e2e_blocking_v1")
+    assert blocking.mode is PerformanceMode.BLOCKING
+    assert blocking.profile_digest != profile.profile_digest
+
+
+def test_profile_loader_rejects_invalid_measurement_counts(tmp_path: Path) -> None:
+    path = tmp_path / "profiles.yaml"
+    path.write_text(
+        """
+version: 1
+profiles:
+  invalid:
+    mode: observation
+    supported_suite_ids: [suite]
+    supported_dataset_kinds: [time_series_csv]
+    backends: [trtfb]
+    scenario:
+      scope: process_e2e
+      synchronization: process_exit
+      warmup_iterations: 0
+      measured_iterations: 0
+      process_repetitions: 1
+      concurrency: 1
+    metrics:
+      required:
+        - name: request_latency_ms.p50
+          direction: lower
+          max_regression_fraction: 0.05
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="measured_iterations"):
+        load_performance_profile(path, "invalid")
+
+
+@pytest.mark.parametrize(
+    ("values", "percentile", "expected"),
+    [
+        ([1.0], 50, 1.0),
+        ([1.0, 2.0, 3.0, 4.0], 50, 2.0),
+        ([1.0, 2.0, 3.0, 4.0], 95, 4.0),
+    ],
+)
+def test_nearest_rank_percentile(values: list[float], percentile: int, expected: float) -> None:
+    assert percentile_nearest_rank(values, percentile) == expected
+
+
+def test_nvidia_smi_sampling_respects_visible_gpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-example,2")
+
+    assert nvidia_smi_device_args() == ["--id", "GPU-example"]
+
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+    assert nvidia_smi_device_args() == ["--id", "-1"]
+
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES")
+    assert nvidia_smi_device_args() == []
+
+
+def test_measurement_engine_excludes_warmup_and_preserves_observations() -> None:
+    profile = load_performance_profile(PROFILE_PATH, "etth1_process_e2e_observation_v1")
+    profile = replace(
+        profile,
+        scenario=replace(
+            profile.scenario,
+            warmup_iterations=1,
+            measured_iterations=3,
+            process_repetitions=1,
+        ),
+    )
+    # One warmup and three measured invocations, each with a start/end pair.
+    clock_values = iter(
+        [
+            0,
+            9_000_000,
+            10_000_000,
+            11_000_000,
+            20_000_000,
+            23_000_000,
+            30_000_000,
+            35_000_000,
+        ]
+    )
+    engine = MeasurementEngine(clock_ns=lambda: next(clock_values))
+
+    result = engine.measure(
+        profile=profile,
+        backend="trtfb",
+        samples=("sample-a",),
+        sample_id=lambda sample: sample,
+        operation=lambda _invocation: MeasurementOutput(unit_count=2.0),
+    )
+
+    assert len(result.observations) == 4
+    assert sum(observation.included for observation in result.observations) == 3
+    assert result.metric("request_latency_ms.p50") == 3.0
+    assert result.metric("request_latency_ms.p95") == 5.0
+    assert result.metric("request_latency_ms.mean") == 3.0
+    assert result.metric("request_latency_ms.mad") == 2.0
+    assert result.metric("request_latency_ms.p50.repetition_mean") == 3.0
+    assert result.metric("request_latency_ms.p50.repetition_cv") == 0.0
+    assert result.metric("throughput_units_per_second") == pytest.approx(6 / 0.009)
+    assert result.metric("error_rate") == 0.0
+
+
+def test_measurement_engine_records_errors_without_hiding_them() -> None:
+    profile = load_performance_profile(PROFILE_PATH, "etth1_process_e2e_observation_v1")
+    profile = replace(
+        profile,
+        scenario=replace(
+            profile.scenario,
+            warmup_iterations=0,
+            measured_iterations=2,
+            process_repetitions=1,
+        ),
+    )
+    clock_values = iter([0, 1_000_000, 2_000_000, 4_000_000])
+    calls = 0
+
+    def operation(_invocation):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("backend failed")
+        return MeasurementOutput(unit_count=1.0)
+
+    result = MeasurementEngine(clock_ns=lambda: next(clock_values)).measure(
+        profile=profile,
+        backend="trtfb",
+        samples=("sample-a",),
+        sample_id=lambda sample: sample,
+        operation=operation,
+    )
+
+    assert result.metric("error_rate") == 0.5
+    assert result.has_errors is True
+    assert result.observations[1].error == "backend failed"
+
+
+def test_measurement_output_must_match_correctness_stage_digest() -> None:
+    result = MeasurementResult(
+        schema_version=1,
+        profile_id="profile",
+        backend="trtfb",
+        scope="process_e2e",
+        observations=(
+            MeasurementObservation(
+                backend="trtfb",
+                sample_id="sample-a",
+                process_repetition=0,
+                iteration=0,
+                warmup=False,
+                included=True,
+                latency_ms=4.0,
+                unit_count=1.0,
+                peak_device_memory_mb=None,
+                error="",
+                output_metadata={"output_digest": "unexpected"},
+            ),
+        ),
+        metrics=(MetricValue("error_rate", 0.0, "fraction"),),
+    )
+
+    validated = validate_output_digests(result, {"sample-a": "expected"})
+
+    assert validated.has_errors is True
+    assert validated.metric("error_rate") == 1.0
+    assert validated.observations[0].unit_count == 0.0
+    assert "differs" in validated.observations[0].error
+
+
+def test_observation_profile_reports_without_an_approved_baseline() -> None:
+    profile = load_performance_profile(PROFILE_PATH, "etth1_process_e2e_observation_v1")
+    measurement = _measurement_result()
+
+    assessment = evaluate_performance(
+        profile=profile,
+        measurement=measurement,
+        comparison_key="comparison-key",
+        correctness_passed=True,
+        environment_compatible=True,
+        baseline=None,
+    )
+
+    assert assessment.status is AssessmentStatus.OBSERVED
+    assert assessment.baseline_status == "missing"
+    assert assessment.blocking is False
+
+
+def test_blocking_profile_requires_approved_comparable_baseline() -> None:
+    profile = replace(
+        load_performance_profile(PROFILE_PATH, "etth1_process_e2e_observation_v1"),
+        mode=PerformanceMode.BLOCKING,
+    )
+    measurement = _measurement_result()
+
+    missing = evaluate_performance(
+        profile=profile,
+        measurement=measurement,
+        comparison_key="comparison-key",
+        correctness_passed=True,
+        environment_compatible=True,
+        baseline=None,
+    )
+    mismatched = evaluate_performance(
+        profile=profile,
+        measurement=measurement,
+        comparison_key="comparison-key",
+        correctness_passed=True,
+        environment_compatible=True,
+        baseline=PerformanceBaseline(
+            schema_version=1,
+            approved=True,
+            profile_id=profile.profile_id,
+            profile_digest=profile.profile_digest,
+            comparison_key="different-key",
+            metrics=measurement.metric_map,
+        ),
+    )
+
+    assert missing.status is AssessmentStatus.BLOCKED
+    assert mismatched.status is AssessmentStatus.BLOCKED
+    assert mismatched.baseline_status == "not_comparable"
+
+
+def test_baseline_loader_requires_candidate_eligibility_and_two_level_approval(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "baseline.json"
+    payload = {
+        "schema_version": 1,
+        "approved": True,
+        "eligible_for_approval": False,
+        "backends": {
+            "trtfb": {
+                "schema_version": 1,
+                "approved": True,
+                "eligible_for_approval": True,
+                "profile_id": "profile",
+                "profile_digest": "digest",
+                "comparison_key": "key",
+                "metrics": {"request_latency_ms.p50": 1.0},
+            }
+        },
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert load_baseline(path, "trtfb").approved is False
+
+    payload["eligible_for_approval"] = True
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    assert load_baseline(path, "trtfb").approved is True
+
+    payload["backends"]["trtfb"]["metrics"] = {
+        "request_latency_ms.p50": float("nan")
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="non-finite"):
+        load_baseline(path, "trtfb")
+
+
+def test_blocking_profile_rejects_baseline_missing_required_metric() -> None:
+    profile = replace(
+        load_performance_profile(
+            PROFILE_PATH, "etth1_process_e2e_observation_v1"
+        ),
+        mode=PerformanceMode.BLOCKING,
+    )
+    measurement = _measurement_result()
+    baseline_metrics = dict(measurement.metric_map)
+    baseline_metrics.pop("request_latency_ms.p95")
+    baseline = PerformanceBaseline(
+        schema_version=1,
+        approved=True,
+        profile_id=profile.profile_id,
+        profile_digest=profile.profile_digest,
+        comparison_key="comparison-key",
+        metrics=baseline_metrics,
+    )
+
+    assessment = evaluate_performance(
+        profile=profile,
+        measurement=measurement,
+        comparison_key="comparison-key",
+        correctness_passed=True,
+        environment_compatible=True,
+        baseline=baseline,
+    )
+
+    assert assessment.status is AssessmentStatus.BLOCKED
+    assert assessment.baseline_status == "not_comparable"
+
+
+def test_blocking_profile_detects_latency_regression() -> None:
+    profile = replace(
+        load_performance_profile(PROFILE_PATH, "etth1_process_e2e_observation_v1"),
+        mode=PerformanceMode.BLOCKING,
+    )
+    measurement = _measurement_result()
+    baseline_metrics = dict(measurement.metric_map)
+    baseline_metrics["request_latency_ms.p50"] = 80.0
+    baseline_metrics["request_latency_ms.p95"] = 90.0
+    baseline = PerformanceBaseline(
+        schema_version=1,
+        approved=True,
+        profile_id=profile.profile_id,
+        profile_digest=profile.profile_digest,
+        comparison_key="comparison-key",
+        metrics=baseline_metrics,
+    )
+
+    assessment = evaluate_performance(
+        profile=profile,
+        measurement=measurement,
+        comparison_key="comparison-key",
+        correctness_passed=True,
+        environment_compatible=True,
+        baseline=baseline,
+    )
+
+    assert assessment.status is AssessmentStatus.FAILED
+    assert any(not gate.passed for gate in assessment.gates)
+
+
+def test_correctness_failure_blocks_measurement_assessment() -> None:
+    profile = load_performance_profile(PROFILE_PATH, "etth1_process_e2e_observation_v1")
+
+    assessment = evaluate_performance(
+        profile=profile,
+        measurement=_measurement_result(),
+        comparison_key="comparison-key",
+        correctness_passed=False,
+        environment_compatible=True,
+        baseline=None,
+    )
+
+    assert assessment.status is AssessmentStatus.BLOCKED
+    assert "correctness" in assessment.reason
+
+
+def test_time_series_adapter_prepares_stable_workload_and_reduces_fidelity(
+    tmp_path: Path,
+) -> None:
+    prompts = [
+        {"sample_id": "etth1-1", "inputs": {"branch_input": [1.0, 2.0]}},
+        {"sample_id": "etth1-2", "inputs": {"branch_input": [2.0, 3.0]}},
+    ]
+    (tmp_path / "prompts.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in prompts),
+        encoding="utf-8",
+    )
+    adapter = TimeSeriesTaskAdapter()
+
+    first = adapter.prepare(tmp_path, suite_id="etth1_time_series_parity")
+    second = adapter.prepare(tmp_path, suite_id="etth1_time_series_parity")
+    hf = {
+        "responses": [
+            {
+                "sample_id": "etth1-1",
+                "output_values": [1.0, 2.0],
+                "output_shape": [2],
+            },
+            {
+                "sample_id": "etth1-2",
+                "output_values": [3.0, 4.0],
+                "output_shape": [2],
+            },
+        ]
+    }
+    trtfb = json.loads(json.dumps(hf))
+
+    fidelity = adapter.fidelity_metrics(
+        hf,
+        trtfb,
+        gates={
+            "max_relative_l2": 1e-6,
+            "max_absolute_error": 1e-6,
+            "min_sample_agreement_rate": 1.0,
+        },
+    )
+
+    assert first == second
+    assert first.ordered_sample_ids == ("etth1-1", "etth1-2")
+    assert len(first.workload_digest) == 64
+    assert fidelity["status"] == "passed"
+    assert fidelity["sample_agreement_rate"] == 1.0
+    assert adapter.prediction_output_digests(hf, label="HF") == (
+        adapter.prediction_output_digests(trtfb, label="TRTFB")
+    )
+
+
+def test_time_series_adapter_rejects_duplicate_sample_ids(tmp_path: Path) -> None:
+    row = {"sample_id": "duplicate", "inputs": {"branch_input": [1.0]}}
+    (tmp_path / "prompts.jsonl").write_text(
+        json.dumps(row) + "\n" + json.dumps(row) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate"):
+        TimeSeriesTaskAdapter().prepare(tmp_path, suite_id="suite")
+
+
+def test_time_series_process_perf_uses_outer_timer_and_writes_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "prompts.jsonl").write_text(
+        json.dumps({"sample_id": "etth1-1", "inputs": {"branch_input": [1.0, 2.0]}}) + "\n",
+        encoding="utf-8",
+    )
+    correctness_predictions = {
+        "responses": [
+            {
+                "sample_id": "etth1-1",
+                "output_values": [1.0, 2.0],
+                "output_shape": [2],
+            }
+        ]
+    }
+    for backend in ("hf", "trtfb"):
+        (tmp_path / f"{backend}_predictions.json").write_text(
+            json.dumps(correctness_predictions),
+            encoding="utf-8",
+        )
+    template = SimpleNamespace(
+        name="template",
+        inputs={},
+        stages=[SimpleNamespace(name="full_inference", required=True)],
+        bundle="model.trtfb",
+    )
+
+    class Executor:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def run_stage(self, _case, _stage, _context):
+            self.calls += 1
+            return SimpleNamespace(
+                data={"output_field": [1.0, 2.0], "output_shape": [2]},
+                metadata={"returncode": 0},
+                # Deliberately absurd: the Measurement Engine must ignore it.
+                timing_s=999.0,
+            )
+
+    reference = Executor()
+    runner = Executor()
+    monkeypatch.setattr(
+        task_eval,
+        "_load_time_series_task_eval_plugins",
+        lambda _work_dir: (template, reference, runner),
+    )
+    args = SimpleNamespace(
+        performance_profile="etth1_process_e2e_observation_v1",
+        performance_profiles=str(PROFILE_PATH),
+        performance_baseline="",
+        hf_python="",
+        trtmc_binary="build/trtmc",
+        model_plugin_dir="",
+    )
+    suite = {
+        "id": "etth1_time_series_parity",
+        "dataset": {"kind": "time_series_csv"},
+    }
+    model = {
+        "name": "chronos",
+        "precision": "fp16",
+        "runtime_strategy": "chronos_bolt_trt",
+    }
+    environment = EnvironmentFingerprint(
+        gpu_name="NVIDIA GB300",
+        driver="1",
+        cuda_version="13",
+        trt_version="11",
+        hostname="runner",
+        gpu_utilization_pct=0,
+    )
+
+    result = task_eval.run_time_series_performance_evaluation(
+        args=args,
+        suite=suite,
+        model=model,
+        work_dir=tmp_path,
+        bundle_path=tmp_path / "model.trtfb",
+        correctness_passed=True,
+        measurement_engine=MeasurementEngine(memory_monitor_factory=NullMemoryMonitor),
+        environment=environment,
+    )
+
+    assert result["status"] == "observed"
+    assert result["measurement_scope"] == "process_e2e"
+    assert reference.calls == 18
+    assert runner.calls == 18
+    assert result["backends"]["hf"]["metrics"]["request_latency_ms.p50"] < 1000
+    assert result["backends"]["trtfb"]["metrics"]["error_rate"] == 0.0
+    assert (tmp_path / "performance" / "measurements.jsonl").is_file()
+    candidate = json.loads(
+        (tmp_path / "performance" / "baseline_candidate.json").read_text(encoding="utf-8")
+    )
+    assert candidate["approved"] is False
+    assert candidate["eligible_for_approval"] is True
+    assert candidate["backends"]["trtfb"]["approved"] is False
+
+
+def test_time_series_perf_blocks_without_running_when_correctness_failed(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "prompts.jsonl").write_text(
+        json.dumps({"sample_id": "etth1-1", "inputs": {"branch_input": [1.0, 2.0]}}) + "\n",
+        encoding="utf-8",
+    )
+    args = SimpleNamespace(
+        performance_profile="etth1_process_e2e_observation_v1",
+        performance_profiles=str(PROFILE_PATH),
+        performance_baseline="",
+    )
+    environment = EnvironmentFingerprint(
+        gpu_name="NVIDIA GB300",
+        driver="1",
+        cuda_version="13",
+        trt_version="11",
+        hostname="runner",
+        gpu_utilization_pct=0,
+    )
+
+    result = task_eval.run_time_series_performance_evaluation(
+        args=args,
+        suite={
+            "id": "etth1_time_series_parity",
+            "dataset": {"kind": "time_series_csv"},
+        },
+        model={"name": "chronos", "precision": "fp16"},
+        work_dir=tmp_path,
+        bundle_path=tmp_path / "model.trtfb",
+        correctness_passed=False,
+        environment=environment,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["backends"]["hf"]["observation_count"] == 0
+    assert "correctness" in result["backends"]["hf"]["assessment"]["reason"]
+
+
+def test_time_series_perf_blocks_output_drift_and_rejects_baseline_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "prompts.jsonl").write_text(
+        json.dumps({"sample_id": "etth1-1", "inputs": {"branch_input": [1.0, 2.0]}}) + "\n",
+        encoding="utf-8",
+    )
+    predictions = {
+        "responses": [
+            {
+                "sample_id": "etth1-1",
+                "output_values": [1.0, 2.0],
+                "output_shape": [2],
+            }
+        ]
+    }
+    for backend in ("hf", "trtfb"):
+        (tmp_path / f"{backend}_predictions.json").write_text(
+            json.dumps(predictions), encoding="utf-8"
+        )
+    template = SimpleNamespace(
+        name="template",
+        inputs={},
+        stages=[SimpleNamespace(name="full_inference", required=True)],
+        bundle="model.trtfb",
+    )
+
+    class DriftingExecutor:
+        def run_stage(self, _case, _stage, _context):
+            return SimpleNamespace(
+                data={"output_field": [9.0, 9.0], "output_shape": [2]},
+                metadata={"returncode": 0},
+                timing_s=0.0,
+            )
+
+    monkeypatch.setattr(
+        task_eval,
+        "_load_time_series_task_eval_plugins",
+        lambda _work_dir: (template, DriftingExecutor(), DriftingExecutor()),
+    )
+    args = SimpleNamespace(
+        performance_profile="etth1_process_e2e_observation_v1",
+        performance_profiles=str(PROFILE_PATH),
+        performance_baseline="",
+        hf_python="",
+        trtmc_binary="build/trtmc",
+        model_plugin_dir="",
+    )
+    environment = EnvironmentFingerprint(
+        gpu_name="NVIDIA GB300",
+        driver="1",
+        cuda_version="13",
+        trt_version="11",
+        hostname="runner",
+        gpu_utilization_pct=0,
+    )
+
+    result = task_eval.run_time_series_performance_evaluation(
+        args=args,
+        suite={
+            "id": "etth1_time_series_parity",
+            "dataset": {"kind": "time_series_csv"},
+        },
+        model={"name": "chronos", "precision": "fp16"},
+        work_dir=tmp_path,
+        bundle_path=tmp_path / "model.trtfb",
+        correctness_passed=True,
+        measurement_engine=MeasurementEngine(memory_monitor_factory=NullMemoryMonitor),
+        environment=environment,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["backends"]["hf"]["metrics"]["error_rate"] == 1.0
+    candidate = json.loads(
+        (tmp_path / "performance" / "baseline_candidate.json").read_text(encoding="utf-8")
+    )
+    assert candidate["eligible_for_approval"] is False
+    assert candidate["backends"]["trtfb"]["eligible_for_approval"] is False
+
+
+def _measurement_result():
+    from tools.model_validation.measurement import MeasurementResult, MetricValue
+
+    return MeasurementResult(
+        schema_version=1,
+        profile_id="etth1_process_e2e_observation_v1",
+        backend="trtfb",
+        scope="process_e2e",
+        observations=(),
+        metrics=(
+            MetricValue("request_latency_ms.p50", 100.0, "ms"),
+            MetricValue("request_latency_ms.p95", 120.0, "ms"),
+            MetricValue("throughput_units_per_second", 10.0, "sample/s"),
+            MetricValue("error_rate", 0.0, "fraction"),
+        ),
+    )

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -233,6 +233,17 @@ def test_default_suites_include_etth1_time_series_parity() -> None:
     assert suite["ci"]["lane"] == "nightly"
     assert suite["ci"]["limit"] == 10
     assert suite["ci"]["sample_seed"] == 20260715
+    assert suite["performance"] == {
+        "opt_in": True,
+        "observation_profile": "etth1_process_e2e_observation_v1",
+        "blocking_profile": "etth1_process_e2e_blocking_v1",
+        "notes": (
+            "These profiles measure process-level E2E latency and are never "
+            "inferred from legacy wall_ms. Nightly parity remains unchanged "
+            "until a profile is explicitly selected; blocking additionally "
+            "requires an approved, comparable baseline.\n"
+        ),
+    }
     expected_gates = {
         "chronos-bolt-tiny-official": (1.0e-06, 8.0e-06),
         "patchtsmixer-granite-official": (5.0e-04, 2.5e-02),
@@ -5531,6 +5542,23 @@ def test_public_ci_artifacts_omit_private_runner_paths(tmp_path: Path) -> None:
             "sample_agreement_rate": 1.0,
             "work_dir": "/private/runner/work",
             "bundle": "/private/runner/engine.trtfb",
+            "performance_artifact": "/private/runner/performance.json",
+            "performance": {
+                "schema_version": 1,
+                "status": "observed",
+                "mode": "observation",
+                "profile_id": "profile",
+                "environment": {
+                    "gpu_name": "NVIDIA GB300",
+                    "hostname": "private-runner",
+                    "compatible": True,
+                },
+                "backends": {
+                    "trtfb": {
+                        "metrics": {"request_latency_ms.p50": 10.0}
+                    }
+                },
+            },
         },
         {"model": "timesfm", "status": "failed", "error": "/private/error"},
     ]
@@ -5548,8 +5576,11 @@ def test_public_ci_artifacts_omit_private_runner_paths(tmp_path: Path) -> None:
     assert "/private" not in public
     assert "work_dir" not in public
     assert "bundle" not in public
+    assert "private-runner" not in public
     numeric_public = artifact_dir / "models" / "chronos" / "summary.json"
     assert "/private" not in numeric_public.read_text(encoding="utf-8")
+    performance_public = artifact_dir / "models" / "chronos" / "performance_result.json"
+    assert "private-runner" not in performance_public.read_text(encoding="utf-8")
 
 
 def test_prepare_vbench_selects_ten_unique_review_dimensions(tmp_path: Path) -> None:

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1650,6 +1650,7 @@ class TestUnitTiers:
         "path",
         [
             "tools/task_eval.py",
+            "tools/model_validation/contracts.py",
             "tools/elf_hf_reference.py",
             "tools/prepare_elf_task_eval_datasets.py",
             "tools/prepare_media_task_eval_datasets.py",

--- a/tools/model_validation/__init__.py
+++ b/tools/model_validation/__init__.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Foundational contracts for the incremental Task Eval architecture migration."""
+
+from .compatibility import LegacyTaskEvalFacade
+from .contracts import (
+    Assessment,
+    AssessmentStatus,
+    CasePlan,
+    CompatibilityMode,
+    PlanIntegrityError,
+    SuiteContract,
+    ValidationPlan,
+    ValidationRequest,
+    WorkloadResolution,
+    WorkloadSpec,
+)
+from .planner import (
+    UnsupportedLegacyPerformanceError,
+    compile_legacy_plan,
+    compile_native_plan,
+)
+from .registry import TaskAdapterRegistry, UnknownTaskAdapterError
+
+__all__ = [
+    "Assessment",
+    "AssessmentStatus",
+    "CasePlan",
+    "CompatibilityMode",
+    "LegacyTaskEvalFacade",
+    "PlanIntegrityError",
+    "SuiteContract",
+    "TaskAdapterRegistry",
+    "UnknownTaskAdapterError",
+    "UnsupportedLegacyPerformanceError",
+    "ValidationPlan",
+    "ValidationRequest",
+    "WorkloadResolution",
+    "WorkloadSpec",
+    "compile_legacy_plan",
+    "compile_native_plan",
+]

--- a/tools/model_validation/adapters/__init__.py
+++ b/tools/model_validation/adapters/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native task adapters migrated from the legacy Task Eval implementation."""
+
+from .time_series import TimeSeriesTaskAdapter
+
+__all__ = ["TimeSeriesTaskAdapter"]

--- a/tools/model_validation/adapters/time_series.py
+++ b/tools/model_validation/adapters/time_series.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native time-series workload identity and fidelity reduction."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from ..contracts import digest_value
+
+
+@dataclass(frozen=True)
+class TimeSeriesSample:
+    sample_id: str
+    inputs: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class PreparedTimeSeriesWorkload:
+    suite_id: str
+    adapter_kind: str
+    adapter_version: str
+    ordered_sample_ids: tuple[str, ...]
+    samples: tuple[TimeSeriesSample, ...]
+    workload_digest: str
+
+
+class TimeSeriesTaskAdapter:
+    kind = "time_series_csv"
+    version = "1"
+
+    def prepare(self, work_dir: Path, *, suite_id: str) -> PreparedTimeSeriesWorkload:
+        path = work_dir / "prompts.jsonl"
+        rows: list[Mapping[str, Any]] = []
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if not isinstance(row, Mapping):
+                raise ValueError(f"{path}:{line_number} must contain an object")
+            rows.append(row)
+        if not rows:
+            raise ValueError("Time-series workload must contain at least one sample")
+        samples: list[TimeSeriesSample] = []
+        seen: set[str] = set()
+        for index, row in enumerate(rows):
+            sample_id = str(row.get("sample_id", f"time_series_{index:06d}"))
+            if not sample_id:
+                raise ValueError(f"Time-series sample {index} has an empty sample ID")
+            if sample_id in seen:
+                raise ValueError(f"Time-series workload has duplicate sample ID {sample_id!r}")
+            seen.add(sample_id)
+            inputs = row.get("inputs")
+            if not isinstance(inputs, Mapping) or not inputs:
+                raise ValueError(f"Time-series sample {sample_id!r} has no numeric inputs")
+            samples.append(TimeSeriesSample(sample_id, dict(inputs)))
+        digest = digest_value(
+            {
+                "suite_id": suite_id,
+                "adapter_kind": self.kind,
+                "adapter_version": self.version,
+                "samples": [
+                    {"sample_id": sample.sample_id, "inputs": sample.inputs} for sample in samples
+                ],
+            }
+        )
+        return PreparedTimeSeriesWorkload(
+            suite_id=suite_id,
+            adapter_kind=self.kind,
+            adapter_version=self.version,
+            ordered_sample_ids=tuple(sample.sample_id for sample in samples),
+            samples=tuple(samples),
+            workload_digest=digest,
+        )
+
+    def fidelity_metrics(
+        self,
+        hf_data: Mapping[str, Any],
+        trtfb_data: Mapping[str, Any],
+        *,
+        gates: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        hf_rows = _response_rows(hf_data, "HF")
+        trtfb_rows = _response_rows(trtfb_data, "TRTMC")
+        if len(hf_rows) != len(trtfb_rows):
+            raise ValueError(
+                "Time-series HF/TRTMC prediction count mismatch: "
+                f"{len(hf_rows)} != {len(trtfb_rows)}"
+            )
+        max_relative_l2 = float(gates.get("max_relative_l2", 0.01))
+        max_absolute_error = float(gates.get("max_absolute_error", 0.1))
+        min_sample_agreement_rate = float(gates.get("min_sample_agreement_rate", 1.0))
+        cases: list[dict[str, Any]] = []
+        for index, (hf_row, trtfb_row) in enumerate(zip(hf_rows, trtfb_rows, strict=True)):
+            hf_id = str(hf_row.get("sample_id", index))
+            trtfb_id = str(trtfb_row.get("sample_id", index))
+            if hf_id != trtfb_id:
+                raise ValueError(
+                    f"Time-series sample id mismatch at {index}: {hf_id!r} != {trtfb_id!r}"
+                )
+            hf_values = hf_row.get("output_values")
+            trtfb_values = trtfb_row.get("output_values")
+            if not isinstance(hf_values, list) or not isinstance(trtfb_values, list):
+                raise ValueError(f"Time-series prediction {hf_id!r} is missing output_values")
+            if len(hf_values) != len(trtfb_values) or not hf_values:
+                cases.append(
+                    {
+                        "sample_id": hf_id,
+                        "passed": False,
+                        "error": (
+                            "output element count mismatch: "
+                            f"HF={len(hf_values)} TRTMC={len(trtfb_values)}"
+                        ),
+                    }
+                )
+                continue
+            hf_vector = [float(value) for value in hf_values]
+            trtfb_vector = [float(value) for value in trtfb_values]
+            if not all(math.isfinite(value) for value in hf_vector + trtfb_vector):
+                cases.append(
+                    {
+                        "sample_id": hf_id,
+                        "passed": False,
+                        "error": "non-finite output value",
+                    }
+                )
+                continue
+            squared_error = sum(
+                (trtfb - hf) ** 2 for hf, trtfb in zip(hf_vector, trtfb_vector, strict=True)
+            )
+            reference_squared_norm = sum(value * value for value in hf_vector)
+            relative_l2 = (
+                math.sqrt(squared_error / reference_squared_norm)
+                if reference_squared_norm >= 1e-24
+                else math.sqrt(squared_error)
+            )
+            absolute_error = max(
+                abs(trtfb - hf) for hf, trtfb in zip(hf_vector, trtfb_vector, strict=True)
+            )
+            cases.append(
+                {
+                    "sample_id": hf_id,
+                    "output_numel": len(hf_vector),
+                    "hf_output_shape": hf_row.get("output_shape", []),
+                    "trtfb_output_shape": trtfb_row.get("output_shape", []),
+                    "relative_l2": relative_l2,
+                    "max_absolute_error": absolute_error,
+                    "passed": (
+                        relative_l2 <= max_relative_l2 and absolute_error <= max_absolute_error
+                    ),
+                }
+            )
+        valid_cases = [case for case in cases if "relative_l2" in case]
+        passed_count = sum(bool(case.get("passed")) for case in cases)
+        agreement_rate = passed_count / len(cases) if cases else 0.0
+        status = (
+            "passed"
+            if cases
+            and len(valid_cases) == len(cases)
+            and agreement_rate >= min_sample_agreement_rate
+            else "failed"
+        )
+        return {
+            "status": status,
+            "sample_count": len(cases),
+            "valid_count": len(valid_cases),
+            "passed_count": passed_count,
+            "sample_agreement_rate": agreement_rate,
+            "mean_relative_l2": (
+                sum(float(case["relative_l2"]) for case in valid_cases) / len(valid_cases)
+                if valid_cases
+                else float("inf")
+            ),
+            "max_relative_l2": max(
+                (float(case["relative_l2"]) for case in valid_cases),
+                default=float("inf"),
+            ),
+            "max_absolute_error": max(
+                (float(case["max_absolute_error"]) for case in valid_cases),
+                default=float("inf"),
+            ),
+            "gates": {
+                "max_relative_l2": max_relative_l2,
+                "max_absolute_error": max_absolute_error,
+                "min_sample_agreement_rate": min_sample_agreement_rate,
+            },
+            "cases": cases,
+        }
+
+    def measurement_units(self) -> tuple[str, ...]:
+        return ("sample",)
+
+    def prediction_output_digests(
+        self,
+        data: Mapping[str, Any],
+        *,
+        label: str,
+    ) -> dict[str, str]:
+        """Identify outputs accepted by the correctness/fidelity stage."""
+
+        digests: dict[str, str] = {}
+        for index, row in enumerate(_response_rows(data, label)):
+            sample_id = str(row.get("sample_id", index))
+            if sample_id in digests:
+                raise ValueError(f"{label} predictions contain duplicate ID {sample_id!r}")
+            values = row.get("output_values")
+            if not isinstance(values, list) or not values:
+                raise ValueError(f"{label} prediction {sample_id!r} has no output_values")
+            numeric_values = [float(value) for value in values]
+            if not all(math.isfinite(value) for value in numeric_values):
+                raise ValueError(f"{label} prediction {sample_id!r} has non-finite output")
+            shape = row.get("output_shape", [])
+            if not isinstance(shape, list):
+                raise ValueError(f"{label} prediction {sample_id!r} has invalid output_shape")
+            digests[sample_id] = digest_value(
+                {"output_values": numeric_values, "output_shape": shape}
+            )
+        return digests
+
+
+def _response_rows(data: Mapping[str, Any], label: str) -> list[Mapping[str, Any]]:
+    rows = data.get("responses", [])
+    if not isinstance(rows, list) or not all(isinstance(row, Mapping) for row in rows):
+        raise ValueError(f"{label} predictions must contain an object response list")
+    return rows

--- a/tools/model_validation/compatibility.py
+++ b/tools/model_validation/compatibility.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility facade between legacy Task Eval and versioned plans."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .contracts import Assessment, ValidationPlan, ValidationRequest
+from .planner import compile_legacy_plan, compile_native_plan
+from .registry import TaskAdapter
+
+
+class LegacyTaskEvalFacade:
+    """Compile and persist plans without changing legacy runtime behavior."""
+
+    def compile_eval_plan(
+        self,
+        *,
+        suite: Mapping[str, Any],
+        models: Sequence[Mapping[str, Any]],
+        model_selectors: Sequence[str] = (),
+        dataset_override: str | None = None,
+        limit: int | None = None,
+        seed: int | None = None,
+        performance_profile_id: str | None = None,
+        native_adapter: TaskAdapter | None = None,
+    ) -> ValidationPlan:
+        normalized_limit = limit if limit and limit > 0 else None
+        assessments = [Assessment.TASK, Assessment.FIDELITY]
+        if performance_profile_id:
+            assessments.append(Assessment.PERFORMANCE)
+        request = ValidationRequest(
+            suite_id=str(suite.get("id", "")),
+            model_selectors=tuple(model_selectors),
+            assessments=tuple(assessments),
+            dataset_override=dataset_override or None,
+            limit=normalized_limit,
+            seed=seed,
+            performance_profile_id=performance_profile_id or None,
+        )
+        if native_adapter is not None:
+            return compile_native_plan(
+                request,
+                suite=suite,
+                models=models,
+                task_adapter_kind=native_adapter.kind,
+                task_adapter_version=native_adapter.version,
+            )
+        return compile_legacy_plan(request, suite=suite, models=models)
+
+    def write_plan(self, plan: ValidationPlan, artifact_root: Path) -> Path:
+        """Atomically write a self-validating plan next to legacy artifacts."""
+
+        artifact_root.mkdir(parents=True, exist_ok=True)
+        destination = artifact_root / "validation_plan.json"
+        temporary = artifact_root / ".validation_plan.json.tmp"
+        try:
+            temporary.write_text(
+                json.dumps(plan.to_dict(), indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            temporary.replace(destination)
+        finally:
+            temporary.unlink(missing_ok=True)
+        return destination

--- a/tools/model_validation/contracts.py
+++ b/tools/model_validation/contracts.py
@@ -1,0 +1,368 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immutable, versioned contracts shared by Model Validation tooling."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = "1.0"
+PLAN_KIND = "model_validation_plan"
+
+
+class Assessment(str, Enum):
+    """An independently reported validation lane."""
+
+    TASK = "task"
+    FIDELITY = "fidelity"
+    PERFORMANCE = "performance"
+
+
+class AssessmentStatus(str, Enum):
+    """Result of one independently evaluated assessment lane."""
+
+    PASSED = "passed"
+    FAILED = "failed"
+    OBSERVED = "observed"
+    BLOCKED = "blocked"
+    NOT_RUN = "not_run"
+
+
+class CompatibilityMode(str, Enum):
+    """How a plan is executed during the incremental migration."""
+
+    LEGACY_TASK_EVAL = "legacy_task_eval"
+    NATIVE = "native"
+
+
+class WorkloadResolution(str, Enum):
+    """Whether ordered samples were resolved while compiling the plan."""
+
+    DEFERRED_TO_LEGACY_RUNTIME = "deferred_to_legacy_runtime"
+    DEFERRED_TO_NATIVE_PREPARE = "deferred_to_native_prepare"
+    RESOLVED = "resolved"
+
+
+class PlanIntegrityError(ValueError):
+    """Raised when a serialized plan does not match its declared digest."""
+
+
+def _canonical_value(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {
+            str(key): _canonical_value(item)
+            for key, item in sorted(value.items(), key=lambda entry: str(entry[0]))
+        }
+    if isinstance(value, (tuple, list)):
+        return [_canonical_value(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted((_canonical_value(item) for item in value), key=repr)
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    raise TypeError(f"Cannot canonicalize value of type {type(value).__name__}")
+
+
+def canonical_json(value: Any) -> str:
+    """Return the canonical JSON representation used by all plan digests."""
+
+    return json.dumps(
+        _canonical_value(value),
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def digest_value(value: Any) -> str:
+    """Return a deterministic SHA-256 digest for JSON-like contract data."""
+
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _require_non_empty(value: str, field_name: str) -> None:
+    if not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+
+
+def _require_sha256(value: str, field_name: str) -> None:
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise ValueError(f"{field_name} must be a lowercase SHA-256 hex digest")
+
+
+@dataclass(frozen=True)
+class ValidationRequest:
+    """User intent before repository configuration is resolved into a plan."""
+
+    suite_id: str
+    model_selectors: tuple[str, ...] = ()
+    assessments: tuple[Assessment, ...] = ()
+    dataset_override: str | None = None
+    limit: int | None = None
+    seed: int | None = None
+    performance_profile_id: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_non_empty(self.suite_id, "suite_id")
+        if any(not selector.strip() for selector in self.model_selectors):
+            raise ValueError("model_selectors cannot contain empty values")
+        if len(set(self.model_selectors)) != len(self.model_selectors):
+            raise ValueError("model_selectors cannot contain duplicates")
+        if len(set(self.assessments)) != len(self.assessments):
+            raise ValueError("assessments cannot contain duplicates")
+        if self.limit is not None and self.limit <= 0:
+            raise ValueError("limit must be positive when provided")
+        if Assessment.PERFORMANCE in self.assessments and not self.performance_profile_id:
+            raise ValueError("performance_profile_id is required for performance assessment")
+        if (
+            Assessment.PERFORMANCE not in self.assessments
+            and self.performance_profile_id is not None
+        ):
+            raise ValueError("performance_profile_id is only valid for performance assessment")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "suite_id": self.suite_id,
+            "model_selectors": list(self.model_selectors),
+            "assessments": [assessment.value for assessment in self.assessments],
+            "dataset_override": self.dataset_override,
+            "limit": self.limit,
+            "seed": self.seed,
+            "performance_profile_id": self.performance_profile_id,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> ValidationRequest:
+        return cls(
+            suite_id=str(payload.get("suite_id", "")),
+            model_selectors=tuple(str(item) for item in payload.get("model_selectors", [])),
+            assessments=tuple(Assessment(str(item)) for item in payload.get("assessments", [])),
+            dataset_override=(
+                str(payload["dataset_override"])
+                if payload.get("dataset_override") is not None
+                else None
+            ),
+            limit=int(payload["limit"]) if payload.get("limit") is not None else None,
+            seed=int(payload["seed"]) if payload.get("seed") is not None else None,
+            performance_profile_id=(
+                str(payload["performance_profile_id"])
+                if payload.get("performance_profile_id") is not None
+                else None
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class SuiteContract:
+    """Minimal immutable identity for a resolved suite contract."""
+
+    suite_id: str
+    user_contract: str
+    dataset_kind: str
+    contract_digest: str
+
+    def __post_init__(self) -> None:
+        _require_non_empty(self.suite_id, "suite_id")
+        _require_non_empty(self.dataset_kind, "dataset_kind")
+        _require_sha256(self.contract_digest, "contract_digest")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "suite_id": self.suite_id,
+            "user_contract": self.user_contract,
+            "dataset_kind": self.dataset_kind,
+            "contract_digest": self.contract_digest,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> SuiteContract:
+        return cls(
+            suite_id=str(payload.get("suite_id", "")),
+            user_contract=str(payload.get("user_contract", "")),
+            dataset_kind=str(payload.get("dataset_kind", "")),
+            contract_digest=str(payload.get("contract_digest", "")),
+        )
+
+
+@dataclass(frozen=True)
+class WorkloadSpec:
+    """Dataset selection known when a validation plan is compiled."""
+
+    dataset_path: str | None
+    dataset_revision: str | None
+    limit: int | None
+    seed: int | None
+    ordered_sample_ids: tuple[str, ...]
+    resolution: WorkloadResolution
+
+    def __post_init__(self) -> None:
+        if self.limit is not None and self.limit <= 0:
+            raise ValueError("limit must be positive when provided")
+        if len(set(self.ordered_sample_ids)) != len(self.ordered_sample_ids):
+            raise ValueError("ordered_sample_ids cannot contain duplicates")
+        if (
+            self.resolution is WorkloadResolution.DEFERRED_TO_LEGACY_RUNTIME
+            and self.ordered_sample_ids
+        ):
+            raise ValueError("legacy-deferred workloads cannot declare resolved sample IDs")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "dataset_path": self.dataset_path,
+            "dataset_revision": self.dataset_revision,
+            "limit": self.limit,
+            "seed": self.seed,
+            "ordered_sample_ids": list(self.ordered_sample_ids),
+            "resolution": self.resolution.value,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> WorkloadSpec:
+        return cls(
+            dataset_path=(
+                str(payload["dataset_path"]) if payload.get("dataset_path") is not None else None
+            ),
+            dataset_revision=(
+                str(payload["dataset_revision"])
+                if payload.get("dataset_revision") is not None
+                else None
+            ),
+            limit=int(payload["limit"]) if payload.get("limit") is not None else None,
+            seed=int(payload["seed"]) if payload.get("seed") is not None else None,
+            ordered_sample_ids=tuple(str(item) for item in payload.get("ordered_sample_ids", [])),
+            resolution=WorkloadResolution(str(payload.get("resolution", ""))),
+        )
+
+
+@dataclass(frozen=True)
+class CasePlan:
+    """One model/backend case selected for a validation run."""
+
+    case_id: str
+    model_name: str
+    hf_id: str
+    bundle: str
+    runtime_strategy: str
+    task_strategy: str
+    reference_family: str
+    user_contract: str
+    manifest: str
+    model_contract_digest: str
+
+    def __post_init__(self) -> None:
+        _require_non_empty(self.case_id, "case_id")
+        _require_non_empty(self.model_name, "model_name")
+        _require_sha256(self.model_contract_digest, "model_contract_digest")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "case_id": self.case_id,
+            "model_name": self.model_name,
+            "hf_id": self.hf_id,
+            "bundle": self.bundle,
+            "runtime_strategy": self.runtime_strategy,
+            "task_strategy": self.task_strategy,
+            "reference_family": self.reference_family,
+            "user_contract": self.user_contract,
+            "manifest": self.manifest,
+            "model_contract_digest": self.model_contract_digest,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> CasePlan:
+        return cls(**{field: str(payload.get(field, "")) for field in cls.__dataclass_fields__})
+
+
+@dataclass(frozen=True)
+class ValidationPlan:
+    """Immutable plan whose digest covers every execution-semantic field."""
+
+    schema_version: str
+    compatibility_mode: CompatibilityMode
+    suite: SuiteContract
+    request: ValidationRequest
+    workload: WorkloadSpec
+    task_adapter_kind: str
+    task_adapter_version: str
+    cases: tuple[CasePlan, ...]
+
+    def __post_init__(self) -> None:
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported validation plan schema {self.schema_version!r}; "
+                f"expected {SCHEMA_VERSION!r}"
+            )
+        if self.request.suite_id != self.suite.suite_id:
+            raise ValueError("request and suite IDs do not match")
+        if self.compatibility_mode is CompatibilityMode.NATIVE:
+            _require_non_empty(self.task_adapter_kind, "task_adapter_kind")
+            _require_non_empty(self.task_adapter_version, "task_adapter_version")
+        elif self.task_adapter_kind or self.task_adapter_version:
+            raise ValueError("legacy plans cannot declare a native task adapter")
+        case_ids = [case.case_id for case in self.cases]
+        if len(set(case_ids)) != len(case_ids):
+            raise ValueError("case IDs must be unique")
+
+    def _content_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "kind": PLAN_KIND,
+            "compatibility_mode": self.compatibility_mode.value,
+            "suite": self.suite.to_dict(),
+            "request": self.request.to_dict(),
+            "workload": self.workload.to_dict(),
+            "task_adapter": {
+                "kind": self.task_adapter_kind,
+                "version": self.task_adapter_version,
+            },
+            "cases": [case.to_dict() for case in self.cases],
+        }
+
+    @property
+    def plan_digest(self) -> str:
+        return digest_value(self._content_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self._content_dict()
+        payload["plan_digest"] = self.plan_digest
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> ValidationPlan:
+        if str(payload.get("kind", "")) != PLAN_KIND:
+            raise ValueError(f"Expected plan kind {PLAN_KIND!r}")
+        raw_cases = payload.get("cases", [])
+        if not isinstance(raw_cases, Sequence) or isinstance(raw_cases, (str, bytes)):
+            raise ValueError("cases must be a sequence")
+        raw_adapter = _mapping(payload.get("task_adapter", {}), "task_adapter")
+        plan = cls(
+            schema_version=str(payload.get("schema_version", "")),
+            compatibility_mode=CompatibilityMode(str(payload.get("compatibility_mode", ""))),
+            suite=SuiteContract.from_dict(_mapping(payload.get("suite"), "suite")),
+            request=ValidationRequest.from_dict(_mapping(payload.get("request"), "request")),
+            workload=WorkloadSpec.from_dict(_mapping(payload.get("workload"), "workload")),
+            task_adapter_kind=str(raw_adapter.get("kind", "")),
+            task_adapter_version=str(raw_adapter.get("version", "")),
+            cases=tuple(CasePlan.from_dict(_mapping(case, "case")) for case in raw_cases),
+        )
+        declared_digest = str(payload.get("plan_digest", ""))
+        if declared_digest != plan.plan_digest:
+            raise PlanIntegrityError("Validation plan digest does not match its semantic content")
+        return plan
+
+
+def _mapping(value: Any, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field_name} must be a mapping")
+    return value

--- a/tools/model_validation/measurement.py
+++ b/tools/model_validation/measurement.py
@@ -1,0 +1,441 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Measurement engine with explicit warmup and raw observation retention."""
+
+from __future__ import annotations
+
+import math
+import os
+import statistics
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field, replace
+from typing import Any, Callable, Mapping, Protocol, Sequence
+
+
+MEASUREMENT_SCHEMA_VERSION = 1
+
+
+def percentile_nearest_rank(values: Sequence[float], percentile: int) -> float:
+    """Return a nearest-rank percentile with a stable, documented algorithm."""
+
+    if not values:
+        raise ValueError("percentile requires at least one value")
+    if percentile <= 0 or percentile > 100:
+        raise ValueError("percentile must be in (0, 100]")
+    ordered = sorted(float(value) for value in values)
+    rank = math.ceil(percentile / 100.0 * len(ordered))
+    return ordered[rank - 1]
+
+
+@dataclass(frozen=True)
+class MeasurementInvocation:
+    sample: Any
+    sample_id: str
+    process_repetition: int
+    iteration: int
+    warmup: bool
+
+
+@dataclass(frozen=True)
+class MeasurementOutput:
+    """Normalized output returned by one backend invocation."""
+
+    unit_count: float = 1.0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MeasurementObservation:
+    backend: str
+    sample_id: str
+    process_repetition: int
+    iteration: int
+    warmup: bool
+    included: bool
+    latency_ms: float
+    unit_count: float
+    peak_device_memory_mb: float | None
+    error: str
+    output_metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "backend": self.backend,
+            "sample_id": self.sample_id,
+            "process_repetition": self.process_repetition,
+            "iteration": self.iteration,
+            "warmup": self.warmup,
+            "included": self.included,
+            "latency_ms": self.latency_ms,
+            "unit_count": self.unit_count,
+            "peak_device_memory_mb": self.peak_device_memory_mb,
+            "error": self.error,
+            "output_metadata": dict(self.output_metadata),
+        }
+
+
+@dataclass(frozen=True)
+class MetricValue:
+    name: str
+    value: float
+    unit: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "value": self.value, "unit": self.unit}
+
+
+@dataclass(frozen=True)
+class MeasurementResult:
+    schema_version: int
+    profile_id: str
+    backend: str
+    scope: str
+    observations: tuple[MeasurementObservation, ...]
+    metrics: tuple[MetricValue, ...]
+
+    @property
+    def metric_map(self) -> dict[str, float]:
+        return {metric.name: metric.value for metric in self.metrics}
+
+    def metric(self, name: str) -> float:
+        try:
+            return self.metric_map[name]
+        except KeyError as exc:
+            raise KeyError(f"Measurement does not provide metric {name!r}") from exc
+
+    @property
+    def has_errors(self) -> bool:
+        return any(observation.error for observation in self.observations)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "profile_id": self.profile_id,
+            "backend": self.backend,
+            "scope": self.scope,
+            "observations": [observation.to_dict() for observation in self.observations],
+            "metrics": [metric.to_dict() for metric in self.metrics],
+        }
+
+
+def validate_output_digests(
+    measurement: MeasurementResult,
+    expected_by_sample: Mapping[str, str],
+) -> MeasurementResult:
+    """Fail observations whose outputs differ from correctness-stage outputs."""
+
+    validated: list[MeasurementObservation] = []
+    for observation in measurement.observations:
+        if observation.error:
+            validated.append(observation)
+            continue
+        expected = expected_by_sample.get(observation.sample_id)
+        actual = str(observation.output_metadata.get("output_digest", ""))
+        if expected is None:
+            error = (
+                f"measurement sample is absent from correctness outputs: {observation.sample_id}"
+            )
+        elif not actual:
+            error = "measurement output did not provide output_digest"
+        elif actual != expected:
+            error = "measurement output differs from correctness-stage output"
+        else:
+            validated.append(observation)
+            continue
+        validated.append(replace(observation, unit_count=0.0, error=error))
+    return replace(
+        measurement,
+        observations=tuple(validated),
+        metrics=_aggregate_metrics(validated),
+    )
+
+
+class MemoryMonitor(Protocol):
+    def start(self) -> None: ...
+
+    def stop(self) -> float | None: ...
+
+
+class NullMemoryMonitor:
+    def start(self) -> None:
+        return None
+
+    def stop(self) -> float | None:
+        return None
+
+
+class NvidiaSmiMemoryMonitor:
+    """Poll maximum memory used on any visible GPU outside the timed window."""
+
+    def __init__(
+        self,
+        *,
+        poll_interval_s: float = 0.05,
+        reader: Callable[[], float | None] | None = None,
+    ) -> None:
+        self._poll_interval_s = poll_interval_s
+        self._reader = reader or _read_peak_gpu_memory_mib
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._peak: float | None = None
+
+    def start(self) -> None:
+        self._stop_event.clear()
+        self._record(self._reader())
+        self._thread = threading.Thread(target=self._poll, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> float | None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=max(1.0, self._poll_interval_s * 4))
+        self._record(self._reader())
+        return self._peak
+
+    def _poll(self) -> None:
+        while not self._stop_event.wait(self._poll_interval_s):
+            self._record(self._reader())
+
+    def _record(self, value: float | None) -> None:
+        if value is not None and (self._peak is None or value > self._peak):
+            self._peak = value
+
+
+def _read_peak_gpu_memory_mib() -> float | None:
+    command = ["nvidia-smi", *nvidia_smi_device_args()]
+    command.extend(
+        [
+            "--query-gpu=memory.used",
+            "--format=csv,noheader,nounits",
+        ]
+    )
+    try:
+        process = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if process.returncode != 0:
+        return None
+    try:
+        values = [float(line.strip()) for line in process.stdout.splitlines() if line.strip()]
+    except ValueError:
+        return None
+    return max(values) if values else None
+
+
+def nvidia_smi_device_args() -> list[str]:
+    """Select the same physical GPU exposed to the measured backend."""
+
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible is None:
+        return []
+    selector = visible.strip().split(",", 1)[0].strip()
+    if not selector:
+        selector = "-1"
+    return ["--id", selector]
+
+
+class MeasurementEngine:
+    """Measure a backend callable without trusting backend-reported timing."""
+
+    def __init__(
+        self,
+        *,
+        clock_ns: Callable[[], int] = time.perf_counter_ns,
+        memory_monitor_factory: Callable[[], MemoryMonitor] = NullMemoryMonitor,
+    ) -> None:
+        self._clock_ns = clock_ns
+        self._memory_monitor_factory = memory_monitor_factory
+
+    def measure(
+        self,
+        *,
+        profile: Any,
+        backend: str,
+        samples: Sequence[Any],
+        sample_id: Callable[[Any], str],
+        operation: Callable[[MeasurementInvocation], MeasurementOutput],
+    ) -> MeasurementResult:
+        if not samples:
+            raise ValueError("Performance measurement requires at least one sample")
+        scenario = profile.scenario
+        observations: list[MeasurementObservation] = []
+        for repetition in range(scenario.process_repetitions):
+            for iteration in range(scenario.warmup_iterations):
+                observations.extend(
+                    self._measure_iteration(
+                        backend=backend,
+                        samples=samples,
+                        sample_id=sample_id,
+                        operation=operation,
+                        repetition=repetition,
+                        iteration=iteration,
+                        warmup=True,
+                    )
+                )
+            for iteration in range(scenario.measured_iterations):
+                observations.extend(
+                    self._measure_iteration(
+                        backend=backend,
+                        samples=samples,
+                        sample_id=sample_id,
+                        operation=operation,
+                        repetition=repetition,
+                        iteration=iteration,
+                        warmup=False,
+                    )
+                )
+        return MeasurementResult(
+            schema_version=MEASUREMENT_SCHEMA_VERSION,
+            profile_id=profile.profile_id,
+            backend=backend,
+            scope=scenario.scope.value,
+            observations=tuple(observations),
+            metrics=_aggregate_metrics(observations),
+        )
+
+    def _measure_iteration(
+        self,
+        *,
+        backend: str,
+        samples: Sequence[Any],
+        sample_id: Callable[[Any], str],
+        operation: Callable[[MeasurementInvocation], MeasurementOutput],
+        repetition: int,
+        iteration: int,
+        warmup: bool,
+    ) -> list[MeasurementObservation]:
+        rows: list[MeasurementObservation] = []
+        for sample in samples:
+            identifier = str(sample_id(sample))
+            invocation = MeasurementInvocation(
+                sample=sample,
+                sample_id=identifier,
+                process_repetition=repetition,
+                iteration=iteration,
+                warmup=warmup,
+            )
+            monitor = self._memory_monitor_factory()
+            monitor.start()
+            start_ns = self._clock_ns()
+            output = MeasurementOutput(unit_count=0.0)
+            error = ""
+            try:
+                output = operation(invocation)
+                if not isinstance(output, MeasurementOutput):
+                    raise TypeError("Measurement operation must return MeasurementOutput")
+                if not math.isfinite(output.unit_count) or output.unit_count <= 0:
+                    raise ValueError("Measurement output unit_count must be positive and finite")
+            except Exception as exc:  # Record backend failures as observations.
+                error = str(exc) or type(exc).__name__
+            end_ns = self._clock_ns()
+            peak_memory = monitor.stop()
+            rows.append(
+                MeasurementObservation(
+                    backend=backend,
+                    sample_id=identifier,
+                    process_repetition=repetition,
+                    iteration=iteration,
+                    warmup=warmup,
+                    included=not warmup,
+                    latency_ms=max(0.0, (end_ns - start_ns) / 1_000_000.0),
+                    unit_count=output.unit_count if not error else 0.0,
+                    peak_device_memory_mb=peak_memory,
+                    error=error,
+                    output_metadata=dict(output.metadata) if not error else {},
+                )
+            )
+        return rows
+
+
+def _aggregate_metrics(
+    observations: Sequence[MeasurementObservation],
+) -> tuple[MetricValue, ...]:
+    included = [observation for observation in observations if observation.included]
+    successful = [observation for observation in included if not observation.error]
+    latencies = [observation.latency_ms for observation in successful]
+    metrics: list[MetricValue] = []
+    if latencies:
+        median = statistics.median(latencies)
+        deviations = [abs(value - median) for value in latencies]
+        metrics.extend(
+            [
+                MetricValue("request_latency_ms.mean", statistics.mean(latencies), "ms"),
+                MetricValue(
+                    "request_latency_ms.stddev",
+                    statistics.pstdev(latencies) if len(latencies) > 1 else 0.0,
+                    "ms",
+                ),
+                MetricValue("request_latency_ms.min", min(latencies), "ms"),
+                MetricValue("request_latency_ms.max", max(latencies), "ms"),
+                MetricValue(
+                    "request_latency_ms.p50",
+                    percentile_nearest_rank(latencies, 50),
+                    "ms",
+                ),
+                MetricValue(
+                    "request_latency_ms.p95",
+                    percentile_nearest_rank(latencies, 95),
+                    "ms",
+                ),
+                MetricValue("request_latency_ms.mad", statistics.median(deviations), "ms"),
+            ]
+        )
+        elapsed_seconds = sum(latencies) / 1000.0
+        metrics.append(
+            MetricValue(
+                "throughput_units_per_second",
+                sum(observation.unit_count for observation in successful) / elapsed_seconds,
+                "sample/s",
+            )
+        )
+    memory_values = [
+        observation.peak_device_memory_mb
+        for observation in successful
+        if observation.peak_device_memory_mb is not None
+    ]
+    if memory_values:
+        metrics.append(MetricValue("peak_device_memory_mb", max(memory_values), "MiB"))
+    repetition_p50s: list[float] = []
+    for repetition in sorted({observation.process_repetition for observation in successful}):
+        repetition_latencies = [
+            observation.latency_ms
+            for observation in successful
+            if observation.process_repetition == repetition
+        ]
+        if repetition_latencies:
+            repetition_p50s.append(percentile_nearest_rank(repetition_latencies, 50))
+    if repetition_p50s:
+        repetition_mean = statistics.mean(repetition_p50s)
+        repetition_stddev = statistics.pstdev(repetition_p50s) if len(repetition_p50s) > 1 else 0.0
+        metrics.extend(
+            [
+                MetricValue(
+                    "request_latency_ms.p50.repetition_mean",
+                    repetition_mean,
+                    "ms",
+                ),
+                MetricValue(
+                    "request_latency_ms.p50.repetition_stddev",
+                    repetition_stddev,
+                    "ms",
+                ),
+                MetricValue(
+                    "request_latency_ms.p50.repetition_cv",
+                    repetition_stddev / repetition_mean if repetition_mean > 0 else 0.0,
+                    "fraction",
+                ),
+            ]
+        )
+    error_count = sum(bool(observation.error) for observation in included)
+    error_rate = error_count / len(included) if included else 1.0
+    metrics.append(MetricValue("error_rate", error_rate, "fraction"))
+    return tuple(metrics)

--- a/tools/model_validation/performance.py
+++ b/tools/model_validation/performance.py
@@ -1,0 +1,633 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Performance profiles, environment identity, baselines, and gate evaluation."""
+
+from __future__ import annotations
+
+import json
+import math
+import socket
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from .contracts import AssessmentStatus, digest_value
+from .measurement import MeasurementResult, nvidia_smi_device_args
+
+
+PERFORMANCE_PROFILE_SCHEMA_VERSION = 1
+PERFORMANCE_BASELINE_SCHEMA_VERSION = 1
+
+
+class PerformanceMode(str, Enum):
+    DISABLED = "disabled"
+    OBSERVATION = "observation"
+    BLOCKING = "blocking"
+
+
+class MeasurementScope(str, Enum):
+    PROCESS_E2E = "process_e2e"
+    WARM_SESSION = "warm_session"
+
+
+class MetricDirection(str, Enum):
+    LOWER = "lower"
+    HIGHER = "higher"
+
+
+@dataclass(frozen=True)
+class EnvironmentPolicy:
+    compatibility_class: str
+    gpu_name_pattern: str
+    exclusive_gpu: bool
+    max_background_gpu_utilization_pct: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "compatibility_class": self.compatibility_class,
+            "gpu_name_pattern": self.gpu_name_pattern,
+            "exclusive_gpu": self.exclusive_gpu,
+            "max_background_gpu_utilization_pct": (self.max_background_gpu_utilization_pct),
+        }
+
+
+@dataclass(frozen=True)
+class MeasurementScenario:
+    scope: MeasurementScope
+    synchronization: str
+    warmup_iterations: int
+    measured_iterations: int
+    process_repetitions: int
+    concurrency: int
+    quantile_method: str
+    require_output_match: bool
+
+    def __post_init__(self) -> None:
+        if self.warmup_iterations < 0:
+            raise ValueError("warmup_iterations cannot be negative")
+        if self.measured_iterations <= 0:
+            raise ValueError("measured_iterations must be positive")
+        if self.process_repetitions <= 0:
+            raise ValueError("process_repetitions must be positive")
+        if self.concurrency != 1:
+            raise ValueError("Only concurrency=1 is currently supported")
+        if self.quantile_method != "nearest_rank":
+            raise ValueError("Only quantile_method=nearest_rank is supported")
+        if self.scope is MeasurementScope.PROCESS_E2E and self.synchronization != "process_exit":
+            raise ValueError("process_e2e scope requires synchronization=process_exit")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scope": self.scope.value,
+            "synchronization": self.synchronization,
+            "warmup_iterations": self.warmup_iterations,
+            "measured_iterations": self.measured_iterations,
+            "process_repetitions": self.process_repetitions,
+            "concurrency": self.concurrency,
+            "quantile_method": self.quantile_method,
+            "require_output_match": self.require_output_match,
+        }
+
+
+@dataclass(frozen=True)
+class MetricPolicy:
+    name: str
+    direction: MetricDirection
+    required: bool
+    max_regression_fraction: float | None = None
+    absolute_max: float | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("Performance metric name must be non-empty")
+        if self.max_regression_fraction is not None and not (
+            0.0 <= self.max_regression_fraction < 1.0
+        ):
+            raise ValueError("max_regression_fraction must be in [0, 1)")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "direction": self.direction.value,
+            "required": self.required,
+            "max_regression_fraction": self.max_regression_fraction,
+            "absolute_max": self.absolute_max,
+        }
+
+
+@dataclass(frozen=True)
+class PerformanceProfile:
+    schema_version: int
+    profile_id: str
+    description: str
+    mode: PerformanceMode
+    supported_suite_ids: tuple[str, ...]
+    supported_dataset_kinds: tuple[str, ...]
+    backends: tuple[str, ...]
+    environment: EnvironmentPolicy
+    scenario: MeasurementScenario
+    metric_policies: tuple[MetricPolicy, ...]
+
+    def __post_init__(self) -> None:
+        if self.schema_version != PERFORMANCE_PROFILE_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported performance profile schema {self.schema_version}")
+        if not self.profile_id:
+            raise ValueError("Performance profile ID must be non-empty")
+        if not self.supported_suite_ids or not self.supported_dataset_kinds:
+            raise ValueError("Performance profile must declare supported suites and kinds")
+        if not self.backends or len(set(self.backends)) != len(self.backends):
+            raise ValueError("Performance profile backends must be non-empty and unique")
+        names = [policy.name for policy in self.metric_policies]
+        if len(set(names)) != len(names):
+            raise ValueError("Performance metric policies must have unique names")
+
+    @property
+    def required_metric_names(self) -> tuple[str, ...]:
+        return tuple(policy.name for policy in self.metric_policies if policy.required)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "profile_id": self.profile_id,
+            "description": self.description,
+            "mode": self.mode.value,
+            "supported_suite_ids": list(self.supported_suite_ids),
+            "supported_dataset_kinds": list(self.supported_dataset_kinds),
+            "backends": list(self.backends),
+            "environment": self.environment.to_dict(),
+            "scenario": self.scenario.to_dict(),
+            "metric_policies": [policy.to_dict() for policy in self.metric_policies],
+        }
+
+    @property
+    def profile_digest(self) -> str:
+        return digest_value(self.to_dict())
+
+    def validate_target(self, *, suite_id: str, dataset_kind: str) -> None:
+        if suite_id not in self.supported_suite_ids:
+            raise ValueError(
+                f"Performance profile {self.profile_id!r} does not support suite {suite_id!r}"
+            )
+        if dataset_kind not in self.supported_dataset_kinds:
+            raise ValueError(
+                f"Performance profile {self.profile_id!r} does not support "
+                f"dataset kind {dataset_kind!r}"
+            )
+
+
+@dataclass(frozen=True)
+class EnvironmentFingerprint:
+    gpu_name: str
+    driver: str
+    cuda_version: str
+    trt_version: str
+    hostname: str
+    gpu_utilization_pct: int | None
+    gpu_temperature_c: float | None = None
+    gpu_power_draw_w: float | None = None
+    gpu_performance_state: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "gpu_name": self.gpu_name,
+            "driver": self.driver,
+            "cuda_version": self.cuda_version,
+            "trt_version": self.trt_version,
+            "hostname": self.hostname,
+            "gpu_utilization_pct": self.gpu_utilization_pct,
+            "gpu_temperature_c": self.gpu_temperature_c,
+            "gpu_power_draw_w": self.gpu_power_draw_w,
+            "gpu_performance_state": self.gpu_performance_state,
+        }
+
+
+def detect_environment() -> EnvironmentFingerprint:
+    gpu_name = ""
+    driver = ""
+    utilization: int | None = None
+    temperature: float | None = None
+    power_draw: float | None = None
+    performance_state = ""
+    nvidia_smi = ["nvidia-smi", *nvidia_smi_device_args()]
+    nvidia_smi.extend(
+        [
+            "--query-gpu=name,driver_version,utilization.gpu,temperature.gpu,power.draw,pstate",
+            "--format=csv,noheader,nounits",
+        ]
+    )
+    try:
+        process = subprocess.run(
+            nvidia_smi,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if process.returncode == 0 and process.stdout.strip():
+            parts = [part.strip() for part in process.stdout.splitlines()[0].split(",")]
+            gpu_name = parts[0] if parts else ""
+            driver = parts[1] if len(parts) > 1 else ""
+            utilization_value = _optional_float(parts[2]) if len(parts) > 2 else None
+            utilization = (
+                int(utilization_value) if utilization_value is not None else None
+            )
+            temperature = _optional_float(parts[3]) if len(parts) > 3 else None
+            power_draw = _optional_float(parts[4]) if len(parts) > 4 else None
+            performance_state = parts[5] if len(parts) > 5 else ""
+    except (OSError, ValueError, subprocess.SubprocessError):
+        pass
+    cuda_version = ""
+    try:
+        process = subprocess.run(
+            ["nvcc", "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        for line in process.stdout.splitlines():
+            if "release" in line.lower():
+                cuda_version = line.lower().split("release", 1)[1].split(",", 1)[0].strip()
+                break
+    except (OSError, subprocess.SubprocessError):
+        pass
+    trt_version = ""
+    try:
+        import tensorrt
+
+        trt_version = str(tensorrt.__version__)
+    except Exception:
+        pass
+    return EnvironmentFingerprint(
+        gpu_name=gpu_name,
+        driver=driver,
+        cuda_version=cuda_version,
+        trt_version=trt_version,
+        hostname=socket.gethostname(),
+        gpu_utilization_pct=utilization,
+        gpu_temperature_c=temperature,
+        gpu_power_draw_w=power_draw,
+        gpu_performance_state=performance_state,
+    )
+
+
+def _optional_float(value: str) -> float | None:
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def check_environment(
+    policy: EnvironmentPolicy, fingerprint: EnvironmentFingerprint
+) -> tuple[bool, tuple[str, ...]]:
+    reasons: list[str] = []
+    if policy.gpu_name_pattern.lower() not in fingerprint.gpu_name.lower():
+        reasons.append(f"GPU {fingerprint.gpu_name!r} does not match {policy.gpu_name_pattern!r}")
+    if (
+        policy.exclusive_gpu
+        and fingerprint.gpu_utilization_pct is not None
+        and fingerprint.gpu_utilization_pct > policy.max_background_gpu_utilization_pct
+    ):
+        reasons.append(
+            f"background GPU utilization exceeds {policy.max_background_gpu_utilization_pct}%"
+        )
+    return not reasons, tuple(reasons)
+
+
+@dataclass(frozen=True)
+class PerformanceBaseline:
+    schema_version: int
+    approved: bool
+    profile_id: str
+    profile_digest: str
+    comparison_key: str
+    metrics: Mapping[str, float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "approved": self.approved,
+            "profile_id": self.profile_id,
+            "profile_digest": self.profile_digest,
+            "comparison_key": self.comparison_key,
+            "metrics": dict(self.metrics),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> PerformanceBaseline:
+        raw_metrics = payload.get("metrics", {})
+        if not isinstance(raw_metrics, Mapping):
+            raise ValueError("Performance baseline metrics must be a mapping")
+        baseline = cls(
+            schema_version=int(payload.get("schema_version", 0)),
+            approved=bool(payload.get("approved", False)),
+            profile_id=str(payload.get("profile_id", "")),
+            profile_digest=str(payload.get("profile_digest", "")),
+            comparison_key=str(payload.get("comparison_key", "")),
+            metrics={str(name): float(value) for name, value in raw_metrics.items()},
+        )
+        if baseline.schema_version != PERFORMANCE_BASELINE_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported performance baseline schema {baseline.schema_version}")
+        non_finite = [
+            name for name, value in baseline.metrics.items() if not math.isfinite(value)
+        ]
+        if non_finite:
+            raise ValueError(
+                "Performance baseline contains non-finite metrics: "
+                + ", ".join(sorted(non_finite))
+            )
+        return baseline
+
+
+@dataclass(frozen=True)
+class MetricGateResult:
+    metric: str
+    current: float
+    baseline: float | None
+    passed: bool
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "metric": self.metric,
+            "current": self.current,
+            "baseline": self.baseline,
+            "passed": self.passed,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class PerformanceAssessment:
+    status: AssessmentStatus
+    blocking: bool
+    reason: str
+    baseline_status: str
+    comparison_key: str
+    gates: tuple[MetricGateResult, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "blocking": self.blocking,
+            "reason": self.reason,
+            "baseline_status": self.baseline_status,
+            "comparison_key": self.comparison_key,
+            "gates": [gate.to_dict() for gate in self.gates],
+        }
+
+
+def evaluate_performance(
+    *,
+    profile: PerformanceProfile,
+    measurement: MeasurementResult,
+    comparison_key: str,
+    correctness_passed: bool,
+    environment_compatible: bool,
+    baseline: PerformanceBaseline | None,
+) -> PerformanceAssessment:
+    blocking = profile.mode is PerformanceMode.BLOCKING
+    if profile.mode is PerformanceMode.DISABLED:
+        return PerformanceAssessment(
+            AssessmentStatus.NOT_RUN, False, "profile disabled", "unused", comparison_key, ()
+        )
+    if not correctness_passed:
+        return PerformanceAssessment(
+            AssessmentStatus.BLOCKED,
+            blocking,
+            "correctness prerequisite failed",
+            "unused",
+            comparison_key,
+            (),
+        )
+    if blocking and not environment_compatible:
+        return PerformanceAssessment(
+            AssessmentStatus.BLOCKED,
+            True,
+            "environment is not compatible with blocking profile",
+            "unused",
+            comparison_key,
+            (),
+        )
+    metrics = measurement.metric_map
+    missing = [name for name in profile.required_metric_names if name not in metrics]
+    if missing:
+        return PerformanceAssessment(
+            AssessmentStatus.BLOCKED,
+            blocking,
+            f"required metrics unavailable: {', '.join(missing)}",
+            "unused",
+            comparison_key,
+            (),
+        )
+    if measurement.has_errors or metrics.get("error_rate", 0.0) > 0.0:
+        return PerformanceAssessment(
+            AssessmentStatus.BLOCKED,
+            blocking,
+            "one or more performance observations failed",
+            "unused",
+            comparison_key,
+            (),
+        )
+
+    baseline_status = "missing"
+    comparable_baseline: PerformanceBaseline | None = None
+    if baseline is not None:
+        if not baseline.approved:
+            baseline_status = "not_approved"
+        elif baseline.profile_id != profile.profile_id:
+            baseline_status = "not_comparable"
+        elif baseline.profile_digest != profile.profile_digest:
+            baseline_status = "not_comparable"
+        elif baseline.comparison_key != comparison_key:
+            baseline_status = "not_comparable"
+        elif any(
+            name not in baseline.metrics for name in profile.required_metric_names
+        ):
+            baseline_status = "not_comparable"
+        else:
+            baseline_status = "comparable"
+            comparable_baseline = baseline
+
+    gates = _evaluate_metric_gates(profile, metrics, comparable_baseline)
+    if not blocking:
+        return PerformanceAssessment(
+            AssessmentStatus.OBSERVED,
+            False,
+            "observation profile does not affect the validation result",
+            baseline_status,
+            comparison_key,
+            gates,
+        )
+    if comparable_baseline is None:
+        return PerformanceAssessment(
+            AssessmentStatus.BLOCKED,
+            True,
+            "blocking profile requires an approved comparable baseline",
+            baseline_status,
+            comparison_key,
+            gates,
+        )
+    if any(not gate.passed for gate in gates):
+        return PerformanceAssessment(
+            AssessmentStatus.FAILED,
+            True,
+            "performance regression detected",
+            baseline_status,
+            comparison_key,
+            gates,
+        )
+    return PerformanceAssessment(
+        AssessmentStatus.PASSED,
+        True,
+        "performance is within approved limits",
+        baseline_status,
+        comparison_key,
+        gates,
+    )
+
+
+def _evaluate_metric_gates(
+    profile: PerformanceProfile,
+    metrics: Mapping[str, float],
+    baseline: PerformanceBaseline | None,
+) -> tuple[MetricGateResult, ...]:
+    results: list[MetricGateResult] = []
+    for policy in profile.metric_policies:
+        if policy.name not in metrics:
+            continue
+        current = metrics[policy.name]
+        if policy.absolute_max is not None:
+            passed = current <= policy.absolute_max
+            results.append(
+                MetricGateResult(
+                    policy.name,
+                    current,
+                    None,
+                    passed,
+                    f"current <= {policy.absolute_max}",
+                )
+            )
+        if (
+            baseline is None
+            or policy.max_regression_fraction is None
+            or policy.name not in baseline.metrics
+        ):
+            continue
+        base = float(baseline.metrics[policy.name])
+        if policy.direction is MetricDirection.LOWER:
+            limit = base * (1.0 + policy.max_regression_fraction)
+            passed = current <= limit
+            reason = f"current <= baseline * {1.0 + policy.max_regression_fraction:.3f}"
+        else:
+            limit = base * (1.0 - policy.max_regression_fraction)
+            passed = current >= limit
+            reason = f"current >= baseline * {1.0 - policy.max_regression_fraction:.3f}"
+        results.append(MetricGateResult(policy.name, current, base, passed, reason))
+    return tuple(results)
+
+
+def load_performance_profile(path: Path, profile_id: str) -> PerformanceProfile:
+    try:
+        import yaml
+    except Exception as exc:  # pragma: no cover - dependency is required by project
+        raise RuntimeError("PyYAML is required for performance profiles") from exc
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"{path} must contain a mapping")
+    version = int(payload.get("version", 0))
+    if version != PERFORMANCE_PROFILE_SCHEMA_VERSION:
+        raise ValueError(f"Unsupported performance profile file version {version}")
+    profiles = payload.get("profiles", {})
+    if not isinstance(profiles, Mapping):
+        raise ValueError(f"{path}: profiles must be a mapping")
+    raw = profiles.get(profile_id)
+    if not isinstance(raw, Mapping):
+        known = ", ".join(sorted(str(name) for name in profiles))
+        raise ValueError(f"Unknown performance profile {profile_id!r}. Known: {known}")
+    return _parse_profile(version, profile_id, raw)
+
+
+def _parse_profile(version: int, profile_id: str, raw: Mapping[str, Any]) -> PerformanceProfile:
+    environment = _require_mapping(raw.get("environment", {}), "environment")
+    scenario = _require_mapping(raw.get("scenario", {}), "scenario")
+    metrics = _require_mapping(raw.get("metrics", {}), "metrics")
+    policies: list[MetricPolicy] = []
+    for required, key in ((True, "required"), (False, "optional")):
+        raw_policies = metrics.get(key, [])
+        if not isinstance(raw_policies, list):
+            raise ValueError(f"metrics.{key} must be a list")
+        for item in raw_policies:
+            mapping = _require_mapping(item, f"metrics.{key} entry")
+            policies.append(
+                MetricPolicy(
+                    name=str(mapping.get("name", "")),
+                    direction=MetricDirection(str(mapping.get("direction", ""))),
+                    required=required,
+                    max_regression_fraction=(
+                        float(mapping["max_regression_fraction"])
+                        if mapping.get("max_regression_fraction") is not None
+                        else None
+                    ),
+                    absolute_max=(
+                        float(mapping["absolute_max"])
+                        if mapping.get("absolute_max") is not None
+                        else None
+                    ),
+                )
+            )
+    return PerformanceProfile(
+        schema_version=version,
+        profile_id=profile_id,
+        description=str(raw.get("description", "")),
+        mode=PerformanceMode(str(raw.get("mode", ""))),
+        supported_suite_ids=tuple(str(item) for item in raw.get("supported_suite_ids", [])),
+        supported_dataset_kinds=tuple(str(item) for item in raw.get("supported_dataset_kinds", [])),
+        backends=tuple(str(item) for item in raw.get("backends", [])),
+        environment=EnvironmentPolicy(
+            compatibility_class=str(environment.get("compatibility_class", "")),
+            gpu_name_pattern=str(environment.get("gpu_name_pattern", "")),
+            exclusive_gpu=bool(environment.get("exclusive_gpu", False)),
+            max_background_gpu_utilization_pct=int(
+                environment.get("max_background_gpu_utilization_pct", 100)
+            ),
+        ),
+        scenario=MeasurementScenario(
+            scope=MeasurementScope(str(scenario.get("scope", ""))),
+            synchronization=str(scenario.get("synchronization", "")),
+            warmup_iterations=int(scenario.get("warmup_iterations", 0)),
+            measured_iterations=int(scenario.get("measured_iterations", 0)),
+            process_repetitions=int(scenario.get("process_repetitions", 0)),
+            concurrency=int(scenario.get("concurrency", 0)),
+            quantile_method=str(scenario.get("quantile_method", "")),
+            require_output_match=bool(scenario.get("require_output_match", False)),
+        ),
+        metric_policies=tuple(policies),
+    )
+
+
+def load_baseline(path: Path, backend: str) -> PerformanceBaseline:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("Performance baseline file must contain a mapping")
+    backends = payload.get("backends", {})
+    if not isinstance(backends, Mapping) or not isinstance(backends.get(backend), Mapping):
+        raise ValueError(f"Performance baseline does not contain backend {backend!r}")
+    backend_payload = dict(backends[backend])
+    backend_payload["approved"] = (
+        bool(payload.get("approved", False))
+        and bool(payload.get("eligible_for_approval", False))
+        and bool(backend_payload.get("approved", False))
+        and bool(backend_payload.get("eligible_for_approval", False))
+    )
+    return PerformanceBaseline.from_dict(backend_payload)
+
+
+def _require_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be a mapping")
+    return value

--- a/tools/model_validation/planner.py
+++ b/tools/model_validation/planner.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Plan compilation for compatibility and future native validation paths."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from .contracts import (
+    SCHEMA_VERSION,
+    Assessment,
+    CasePlan,
+    CompatibilityMode,
+    SuiteContract,
+    ValidationPlan,
+    ValidationRequest,
+    WorkloadResolution,
+    WorkloadSpec,
+    digest_value,
+)
+
+
+class UnsupportedLegacyPerformanceError(ValueError):
+    """Raised when Perf is requested for an unmigrated legacy task."""
+
+
+def compile_legacy_plan(
+    request: ValidationRequest,
+    *,
+    suite: Mapping[str, Any],
+    models: Sequence[Mapping[str, Any]],
+) -> ValidationPlan:
+    """Compile provenance for a run still executed by ``tools/task_eval.py``.
+
+    Legacy plans intentionally defer ordered sample resolution to the existing
+    runtime. They cannot request Performance Evaluation because legacy
+    ``wall_ms`` fields do not share a comparable measurement scope.
+    """
+
+    if Assessment.PERFORMANCE in request.assessments:
+        raise UnsupportedLegacyPerformanceError(
+            "Performance Evaluation requires a native task adapter; legacy Task Eval "
+            "timing is diagnostic only"
+        )
+    return _compile_plan(
+        request,
+        suite=suite,
+        models=models,
+        compatibility_mode=CompatibilityMode.LEGACY_TASK_EVAL,
+        workload_resolution=WorkloadResolution.DEFERRED_TO_LEGACY_RUNTIME,
+        task_adapter_kind="",
+        task_adapter_version="",
+    )
+
+
+def compile_native_plan(
+    request: ValidationRequest,
+    *,
+    suite: Mapping[str, Any],
+    models: Sequence[Mapping[str, Any]],
+    task_adapter_kind: str,
+    task_adapter_version: str,
+) -> ValidationPlan:
+    """Compile a plan that will resolve its workload through a native adapter."""
+
+    if not task_adapter_kind or not task_adapter_version:
+        raise ValueError("Native plans require a task adapter kind and version")
+    return _compile_plan(
+        request,
+        suite=suite,
+        models=models,
+        compatibility_mode=CompatibilityMode.NATIVE,
+        workload_resolution=WorkloadResolution.DEFERRED_TO_NATIVE_PREPARE,
+        task_adapter_kind=task_adapter_kind,
+        task_adapter_version=task_adapter_version,
+    )
+
+
+def _compile_plan(
+    request: ValidationRequest,
+    *,
+    suite: Mapping[str, Any],
+    models: Sequence[Mapping[str, Any]],
+    compatibility_mode: CompatibilityMode,
+    workload_resolution: WorkloadResolution,
+    task_adapter_kind: str,
+    task_adapter_version: str,
+) -> ValidationPlan:
+    suite_id = str(suite.get("id", ""))
+    if suite_id != request.suite_id:
+        raise ValueError(f"Request suite {request.suite_id!r} does not match contract {suite_id!r}")
+    dataset = suite.get("dataset", {})
+    if not isinstance(dataset, Mapping):
+        raise ValueError(f"Suite {suite_id!r} dataset must be a mapping")
+    dataset_kind = str(dataset.get("kind", ""))
+    if not dataset_kind:
+        raise ValueError(f"Suite {suite_id!r} dataset.kind must be non-empty")
+    if not models:
+        raise ValueError(f"Suite {suite_id!r} plan requires at least one selected model")
+
+    suite_contract = SuiteContract(
+        suite_id=suite_id,
+        user_contract=str(suite.get("user_contract", "")),
+        dataset_kind=dataset_kind,
+        contract_digest=digest_value(suite),
+    )
+    dataset_path = request.dataset_override
+    if dataset_path is None and dataset.get("default_path"):
+        dataset_path = str(dataset["default_path"])
+    dataset_revision = dataset.get("source_revision") or dataset.get("sha256")
+    workload = WorkloadSpec(
+        dataset_path=dataset_path,
+        dataset_revision=str(dataset_revision) if dataset_revision else None,
+        limit=request.limit,
+        seed=request.seed,
+        ordered_sample_ids=(),
+        resolution=workload_resolution,
+    )
+    cases = tuple(_case_plan(suite_id, model) for model in models)
+    return ValidationPlan(
+        schema_version=SCHEMA_VERSION,
+        compatibility_mode=compatibility_mode,
+        suite=suite_contract,
+        request=request,
+        workload=workload,
+        task_adapter_kind=task_adapter_kind,
+        task_adapter_version=task_adapter_version,
+        cases=cases,
+    )
+
+
+def _case_plan(suite_id: str, model: Mapping[str, Any]) -> CasePlan:
+    model_name = str(model.get("name", ""))
+    if not model_name:
+        raise ValueError("Selected models must define a non-empty name")
+    return CasePlan(
+        case_id=f"{suite_id}:{model_name}",
+        model_name=model_name,
+        hf_id=str(model.get("hf_id", "")),
+        bundle=str(model.get("bundle", "")),
+        runtime_strategy=str(model.get("runtime_strategy", "")),
+        task_strategy=str(model.get("task_strategy", "")),
+        reference_family=str(model.get("reference_family", "")),
+        user_contract=str(model.get("user_contract", "")),
+        manifest=str(model.get("manifest", "")),
+        model_contract_digest=digest_value(model),
+    )

--- a/tools/model_validation/registry.py
+++ b/tools/model_validation/registry.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail-closed task adapter registration for incremental suite migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class TaskAdapter(Protocol):
+    """Task-local prepare, fidelity, and measurement-unit contract."""
+
+    kind: str
+    version: str
+
+    def prepare(self, work_dir: Path, *, suite_id: str) -> Any: ...
+
+    def fidelity_metrics(
+        self,
+        reference: Mapping[str, Any],
+        candidate: Mapping[str, Any],
+        *,
+        gates: Mapping[str, Any],
+    ) -> dict[str, Any]: ...
+
+    def measurement_units(self) -> tuple[str, ...]: ...
+
+
+class UnknownTaskAdapterError(LookupError):
+    """Raised when no native adapter owns a requested dataset kind."""
+
+
+class TaskAdapterRegistry:
+    """Local registry with explicit ownership and no implicit fallbacks."""
+
+    def __init__(self) -> None:
+        self._adapters: dict[str, TaskAdapter] = {}
+
+    def register(self, adapter: TaskAdapter) -> None:
+        kind = str(getattr(adapter, "kind", "")).strip()
+        version = str(getattr(adapter, "version", "")).strip()
+        if not kind:
+            raise ValueError("Task adapter kind must be non-empty")
+        if not version:
+            raise ValueError(f"Task adapter {kind!r} version must be non-empty")
+        missing_methods = [
+            name
+            for name in ("prepare", "fidelity_metrics", "measurement_units")
+            if not callable(getattr(adapter, name, None))
+        ]
+        if missing_methods:
+            raise TypeError(
+                f"Task adapter {kind!r} is missing required methods: " + ", ".join(missing_methods)
+            )
+        if kind in self._adapters:
+            raise ValueError(f"Task adapter {kind!r} is already registered")
+        self._adapters[kind] = adapter
+
+    def get(self, kind: str) -> TaskAdapter:
+        try:
+            return self._adapters[kind]
+        except KeyError as exc:
+            raise UnknownTaskAdapterError(
+                f"No native task adapter is registered for {kind!r}"
+            ) from exc
+
+    def kinds(self) -> tuple[str, ...]:
+        return tuple(sorted(self._adapters))

--- a/tools/model_validation/time_series_performance.py
+++ b/tools/model_validation/time_series_performance.py
@@ -1,0 +1,380 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native ETTh1 process-scoped Performance Evaluation orchestration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def run_time_series_performance_evaluation(
+    *,
+    args: argparse.Namespace,
+    suite: dict[str, Any],
+    model: dict[str, Any],
+    work_dir: Path,
+    bundle_path: Path,
+    correctness_passed: bool,
+    measurement_engine: Any = None,
+    environment: Any = None,
+) -> dict[str, Any]:
+    """Run explicit process-scoped Perf without consuming legacy ``wall_ms``."""
+    from tools import task_eval as legacy_task_eval
+    from tests.e2e_harness.contracts import RunContext
+    from tools.model_validation.adapters import TimeSeriesTaskAdapter
+    from tools.model_validation.contracts import AssessmentStatus, digest_value
+    from tools.model_validation.measurement import (
+        MeasurementEngine,
+        MeasurementOutput,
+        MeasurementResult,
+        NvidiaSmiMemoryMonitor,
+        NullMemoryMonitor,
+        validate_output_digests,
+    )
+    from tools.model_validation.performance import (
+        check_environment,
+        detect_environment,
+        evaluate_performance,
+        load_baseline,
+        load_performance_profile,
+    )
+
+    profile_id = str(getattr(args, "performance_profile", "") or "")
+    profile = load_performance_profile(
+        Path(getattr(args, "performance_profiles", legacy_task_eval.DEFAULT_PERFORMANCE_PROFILES)),
+        profile_id,
+    )
+    dataset_kind = str(suite.get("dataset", {}).get("kind", ""))
+    profile.validate_target(suite_id=str(suite["id"]), dataset_kind=dataset_kind)
+    adapter = TimeSeriesTaskAdapter()
+    workload = adapter.prepare(work_dir, suite_id=str(suite["id"]))
+    fingerprint = environment or detect_environment()
+    environment_compatible, environment_reasons = check_environment(
+        profile.environment, fingerprint
+    )
+    environment_class = (
+        profile.environment.compatibility_class
+        if environment_compatible
+        else "unmatched-" + digest_value(fingerprint.to_dict())[:12]
+    )
+    performance_dir = work_dir / "performance"
+    performance_dir.mkdir(parents=True, exist_ok=True)
+    if measurement_engine is None:
+        needs_memory = any(
+            policy.name == "peak_device_memory_mb" for policy in profile.metric_policies
+        )
+        measurement_engine = MeasurementEngine(
+            memory_monitor_factory=(NvidiaSmiMemoryMonitor if needs_memory else NullMemoryMonitor)
+        )
+    template = reference = runner = None
+    if correctness_passed:
+        template, reference, runner = legacy_task_eval._load_time_series_task_eval_plugins(work_dir)
+    stage = (
+        legacy_task_eval._time_series_full_inference_stage(template)
+        if template is not None
+        else None
+    )
+
+    measurements: dict[str, Any] = {}
+    assessments: dict[str, Any] = {}
+    comparison_keys: dict[str, str] = {}
+    execution_digests: dict[str, str] = {}
+    measurement_digests: dict[str, str] = {}
+    measurement_result_digests: dict[str, str] = {}
+    baseline_path = str(getattr(args, "performance_baseline", "") or "")
+    bundle_identity: dict[str, Any] = {
+        "filename": bundle_path.name,
+        "exists": bundle_path.is_file(),
+    }
+    if bundle_path.is_file():
+        bundle_stat = bundle_path.stat()
+        bundle_identity.update(
+            {"size_bytes": bundle_stat.st_size, "mtime_ns": bundle_stat.st_mtime_ns}
+        )
+    for backend in profile.backends:
+        comparison_key = digest_value(
+            {
+                "workload_digest": workload.workload_digest,
+                "logical_model_id": str(model["name"]),
+                "backend": backend,
+                "precision": str(model.get("precision", "")),
+                "profile_id": profile.profile_id,
+                "profile_digest": profile.profile_digest,
+                "environment_class": environment_class,
+                "task_adapter": f"{adapter.kind}:{adapter.version}",
+            }
+        )
+        comparison_keys[backend] = comparison_key
+        execution_identity = {
+            "workload_digest": workload.workload_digest,
+            "model_contract_digest": digest_value(model),
+            "logical_model_id": str(model["name"]),
+            "backend": backend,
+            "precision": str(model.get("precision", "")),
+            "runtime_strategy": str(model.get("runtime_strategy", "")),
+            "bundle": bundle_identity if backend == "trtfb" else None,
+            "environment": fingerprint.to_dict(),
+            "task_adapter": f"{adapter.kind}:{adapter.version}",
+        }
+        execution_digests[backend] = digest_value(execution_identity)
+        measurement_digests[backend] = digest_value(
+            {
+                "execution_digest": execution_digests[backend],
+                "scenario": profile.scenario.to_dict(),
+            }
+        )
+        if correctness_passed:
+            operation = _time_series_performance_operation(
+                backend=backend,
+                template=template,
+                executor=reference if backend == "hf" else runner,
+                stage=stage,
+                model=model,
+                args=args,
+                bundle_path=bundle_path,
+                performance_dir=performance_dir,
+                run_context_type=RunContext,
+                measurement_output_type=MeasurementOutput,
+                legacy_api=legacy_task_eval,
+            )
+            measurement = measurement_engine.measure(
+                profile=profile,
+                backend=backend,
+                samples=workload.samples,
+                sample_id=lambda sample: sample.sample_id,
+                operation=operation,
+            )
+            if profile.scenario.require_output_match:
+                prediction_path = work_dir / f"{backend}_predictions.json"
+                prediction_data = json.loads(prediction_path.read_text(encoding="utf-8"))
+                if not isinstance(prediction_data, dict):
+                    raise ValueError(f"{prediction_path} must contain a prediction object")
+                expected_digests = adapter.prediction_output_digests(
+                    prediction_data,
+                    label=backend.upper(),
+                )
+                if set(expected_digests) != set(workload.ordered_sample_ids):
+                    raise ValueError(
+                        f"{backend.upper()} correctness outputs do not match "
+                        "the prepared performance workload"
+                    )
+                measurement = validate_output_digests(measurement, expected_digests)
+        else:
+            measurement = MeasurementResult(
+                schema_version=1,
+                profile_id=profile.profile_id,
+                backend=backend,
+                scope=profile.scenario.scope.value,
+                observations=(),
+                metrics=(),
+            )
+        baseline = load_baseline(Path(baseline_path), backend) if baseline_path else None
+        assessment = evaluate_performance(
+            profile=profile,
+            measurement=measurement,
+            comparison_key=comparison_key,
+            correctness_passed=correctness_passed,
+            environment_compatible=environment_compatible,
+            baseline=baseline,
+        )
+        measurements[backend] = measurement
+        measurement_result_digests[backend] = digest_value(measurement.to_dict())
+        assessments[backend] = assessment
+        (performance_dir / f"{backend}_measurement.json").write_text(
+            json.dumps(measurement.to_dict(), indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    with (performance_dir / "measurements.jsonl").open("w", encoding="utf-8") as stream:
+        for backend in profile.backends:
+            for observation in measurements[backend].observations:
+                stream.write(json.dumps(observation.to_dict(), ensure_ascii=False) + "\n")
+
+    statuses = [assessment.status for assessment in assessments.values()]
+    if any(status is AssessmentStatus.FAILED for status in statuses):
+        overall_status = AssessmentStatus.FAILED
+    elif any(status is AssessmentStatus.BLOCKED for status in statuses):
+        overall_status = AssessmentStatus.BLOCKED
+    elif statuses and all(status is AssessmentStatus.PASSED for status in statuses):
+        overall_status = AssessmentStatus.PASSED
+    else:
+        overall_status = AssessmentStatus.OBSERVED
+    metric_maps = {backend: measurements[backend].metric_map for backend in profile.backends}
+    speedup: dict[str, float] = {}
+    if "hf" in metric_maps and "trtfb" in metric_maps:
+        for name in ("request_latency_ms.p50", "request_latency_ms.p95"):
+            hf_value = metric_maps["hf"].get(name)
+            trtfb_value = metric_maps["trtfb"].get(name)
+            if hf_value is not None and trtfb_value and trtfb_value > 0:
+                speedup[name] = hf_value / trtfb_value
+        hf_throughput = metric_maps["hf"].get("throughput_units_per_second")
+        trtfb_throughput = metric_maps["trtfb"].get("throughput_units_per_second")
+        if hf_throughput and hf_throughput > 0 and trtfb_throughput is not None:
+            speedup["throughput_units_per_second"] = trtfb_throughput / hf_throughput
+
+    result = {
+        "schema_version": 1,
+        "status": overall_status.value,
+        "mode": profile.mode.value,
+        "profile_id": profile.profile_id,
+        "profile_digest": profile.profile_digest,
+        "measurement_scope": profile.scenario.scope.value,
+        "workload": {
+            "digest": workload.workload_digest,
+            "sample_count": len(workload.samples),
+            "ordered_sample_ids": list(workload.ordered_sample_ids),
+            "adapter_kind": adapter.kind,
+            "adapter_version": adapter.version,
+        },
+        "environment": {
+            **fingerprint.to_dict(),
+            "compatibility_class": environment_class,
+            "compatible": environment_compatible,
+            "reasons": list(environment_reasons),
+        },
+        "backends": {
+            backend: {
+                "comparison_key": comparison_keys[backend],
+                "execution_digest": execution_digests[backend],
+                "measurement_digest": measurement_digests[backend],
+                "measurement_result_digest": measurement_result_digests[backend],
+                "metrics": metric_maps[backend],
+                "assessment": assessments[backend].to_dict(),
+                "observation_count": len(measurements[backend].observations),
+            }
+            for backend in profile.backends
+        },
+        "speedup": speedup,
+    }
+    (performance_dir / "performance_result.json").write_text(
+        json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    backend_eligibility = {
+        backend: (
+            correctness_passed
+            and environment_compatible
+            and not measurements[backend].has_errors
+            and all(
+                metric in measurements[backend].metric_map
+                for metric in profile.required_metric_names
+            )
+        )
+        for backend in profile.backends
+    }
+    baseline_candidate = {
+        "schema_version": 1,
+        "approved": False,
+        "eligible_for_approval": all(backend_eligibility.values()),
+        "profile_id": profile.profile_id,
+        "profile_digest": profile.profile_digest,
+        "workload_digest": workload.workload_digest,
+        "model": str(model["name"]),
+        "environment_class": environment_class,
+        "backends": {
+            backend: {
+                "schema_version": 1,
+                "approved": False,
+                "eligible_for_approval": backend_eligibility[backend],
+                "profile_id": profile.profile_id,
+                "profile_digest": profile.profile_digest,
+                "comparison_key": comparison_keys[backend],
+                "execution_digest": execution_digests[backend],
+                "measurement_digest": measurement_digests[backend],
+                "source_measurement_result_digest": measurement_result_digests[backend],
+                "metrics": metric_maps[backend],
+            }
+            for backend in profile.backends
+        },
+    }
+    (performance_dir / "baseline_candidate.json").write_text(
+        json.dumps(baseline_candidate, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
+def _time_series_performance_operation(
+    *,
+    backend: str,
+    template: Any,
+    executor: Any,
+    stage: Any,
+    model: dict[str, Any],
+    args: argparse.Namespace,
+    bundle_path: Path,
+    performance_dir: Path,
+    run_context_type: Any,
+    measurement_output_type: Any,
+    legacy_api: Any,
+) -> Any:
+    if backend not in {"hf", "trtfb"}:
+        raise ValueError(f"Unsupported time-series performance backend {backend!r}")
+
+    def operation(invocation: Any) -> Any:
+        sample = invocation.sample
+        prompt_row = {"sample_id": sample.sample_id, "inputs": dict(sample.inputs)}
+        case = legacy_api._time_series_case_for_request(template, prompt_row, 0)
+        phase = "warmup" if invocation.warmup else "measured"
+        artifact_dir = (
+            performance_dir
+            / backend
+            / f"repetition_{invocation.process_repetition:02d}"
+            / phase
+            / f"iteration_{invocation.iteration:03d}"
+            / sample.sample_id
+        )
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        if backend == "hf":
+            reference_python = legacy_api.model_reference_python(
+                model,
+                str(getattr(args, "hf_python", "") or sys.executable),
+            )
+            context = run_context_type(
+                case=case,
+                artifacts_dir=str(artifact_dir),
+                hf_python=reference_python,
+                reference_python=reference_python,
+            )
+            source = "hf"
+        else:
+            case.bundle = bundle_path.name
+            context = run_context_type(
+                case=case,
+                artifacts_dir=str(artifact_dir),
+                binary_path=str(args.trtmc_binary),
+                hf_python=str(getattr(args, "hf_python", "") or ""),
+                runtime_python=str(getattr(args, "hf_python", "") or ""),
+                engine_dir=str(bundle_path.parent),
+                model_plugin_dir=str(getattr(args, "model_plugin_dir", "") or ""),
+            )
+            source = "trtfb"
+        output = executor.run_stage(case, stage, context)
+        response = legacy_api._time_series_response(case=case, source=source, output=output)
+        if int(response.get("returncode", 0)) != 0:
+            raise RuntimeError(
+                f"{source} performance invocation failed for {sample.sample_id}: "
+                f"returncode={response['returncode']}"
+            )
+        from tools.model_validation.contracts import digest_value
+
+        output_digest = digest_value(
+            {
+                "output_values": response["output_values"],
+                "output_shape": response["output_shape"],
+            }
+        )
+        return measurement_output_type(
+            unit_count=1.0,
+            metadata={
+                "output_digest": output_digest,
+                "output_numel": len(response["output_values"]),
+            },
+        )
+
+    return operation

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -46,9 +46,13 @@ from tests.e2e_harness.registry import (  # noqa: E402
     get_reference,
     get_runner,
 )
+from tools.model_validation import LegacyTaskEvalFacade  # noqa: E402
 
 
 DEFAULT_SUITES = REPO_ROOT / "tests" / "task_eval" / "validation_suites.yaml"
+DEFAULT_PERFORMANCE_PROFILES = (
+    REPO_ROOT / "tests" / "task_eval" / "performance_profiles.yaml"
+)
 DEFAULT_MODELS_DIR = REPO_ROOT / "tests" / "e2e" / "models"
 DEFAULT_WAIVES = REPO_ROOT / "tests" / "e2e" / "waives.txt"
 ERROR_OUTPUT_TEXT = "TensorRT Edge LLM cannot handle this request. Fails."
@@ -214,7 +218,50 @@ def _public_ci_result(result: dict[str, Any]) -> dict[str, Any]:
         "max_absolute_error",
         "error_type",
     )
-    return {key: result[key] for key in keys if key in result}
+    public = {key: result[key] for key in keys if key in result}
+    performance = result.get("performance")
+    if isinstance(performance, dict):
+        public["performance"] = _public_performance_result(performance)
+    return public
+
+
+def _public_performance_result(performance: dict[str, Any]) -> dict[str, Any]:
+    environment = performance.get("environment", {})
+    public_environment_keys = (
+        "gpu_name",
+        "driver",
+        "cuda_version",
+        "trt_version",
+        "gpu_utilization_pct",
+        "gpu_temperature_c",
+        "gpu_power_draw_w",
+        "gpu_performance_state",
+        "compatibility_class",
+        "compatible",
+        "reasons",
+    )
+    public = {
+        key: performance[key]
+        for key in (
+            "schema_version",
+            "status",
+            "mode",
+            "profile_id",
+            "profile_digest",
+            "measurement_scope",
+            "workload",
+            "backends",
+            "speedup",
+        )
+        if key in performance
+    }
+    if isinstance(environment, dict):
+        public["environment"] = {
+            key: environment[key]
+            for key in public_environment_keys
+            if key in environment
+        }
+    return public
 
 
 def _public_time_series_summary(summary: dict[str, Any]) -> dict[str, Any]:
@@ -312,6 +359,19 @@ def write_public_ci_artifacts(
                 raise ValueError(f"Invalid time-series summary for {model_name!r}")
             destination.write_text(
                 json.dumps(_public_time_series_summary(raw_summary), indent=2, ensure_ascii=False)
+                + "\n",
+                encoding="utf-8",
+            )
+        performance = result.get("performance")
+        if isinstance(performance, dict):
+            destination = artifact_dir / "models" / model_name / "performance_result.json"
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_text(
+                json.dumps(
+                    _public_performance_result(performance),
+                    indent=2,
+                    ensure_ascii=False,
+                )
                 + "\n",
                 encoding="utf-8",
             )
@@ -6685,6 +6745,35 @@ def run_time_series_trtfb(args: argparse.Namespace) -> None:
     write_predictions(pred_path, responses)
 
 
+def run_time_series_performance_evaluation(
+    *,
+    args: argparse.Namespace,
+    suite: dict[str, Any],
+    model: dict[str, Any],
+    work_dir: Path,
+    bundle_path: Path,
+    correctness_passed: bool,
+    measurement_engine: Any = None,
+    environment: Any = None,
+) -> dict[str, Any]:
+    """Compatibility entry for native ETTh1 Performance Evaluation."""
+
+    from tools.model_validation.time_series_performance import (
+        run_time_series_performance_evaluation as run_native_performance,
+    )
+
+    return run_native_performance(
+        args=args,
+        suite=suite,
+        model=model,
+        work_dir=work_dir,
+        bundle_path=bundle_path,
+        correctness_passed=correctness_passed,
+        measurement_engine=measurement_engine,
+        environment=environment,
+    )
+
+
 def _vision_case_for_request(
     template: Any,
     prompt_row: dict[str, Any],
@@ -8704,109 +8793,14 @@ def compare_time_series_prediction_sets(
     *,
     gates: dict[str, Any],
 ) -> dict[str, Any]:
-    """Gate every numeric sample with the model-owned E2E parity metrics."""
-    hf_rows = _task_eval_response_rows(hf_data, "HF")
-    trtfb_rows = _task_eval_response_rows(trtfb_data, "TRTMC")
-    if len(hf_rows) != len(trtfb_rows):
-        raise ValueError(
-            f"Time-series HF/TRTMC prediction count mismatch: {len(hf_rows)} != {len(trtfb_rows)}"
-        )
-    max_relative_l2 = float(gates.get("max_relative_l2", 0.01))
-    max_absolute_error = float(gates.get("max_absolute_error", 0.1))
-    min_sample_agreement_rate = float(gates.get("min_sample_agreement_rate", 1.0))
-    cases: list[dict[str, Any]] = []
-    for index, (hf_row, trtfb_row) in enumerate(zip(hf_rows, trtfb_rows, strict=True)):
-        hf_id = str(hf_row.get("sample_id", index))
-        trtfb_id = str(trtfb_row.get("sample_id", index))
-        if hf_id != trtfb_id:
-            raise ValueError(
-                f"Time-series sample id mismatch at {index}: {hf_id!r} != {trtfb_id!r}"
-            )
-        hf_values = hf_row.get("output_values")
-        trtfb_values = trtfb_row.get("output_values")
-        if not isinstance(hf_values, list) or not isinstance(trtfb_values, list):
-            raise ValueError(f"Time-series prediction {hf_id!r} is missing output_values")
-        if len(hf_values) != len(trtfb_values) or not hf_values:
-            cases.append(
-                {
-                    "sample_id": hf_id,
-                    "passed": False,
-                    "error": (
-                        "output element count mismatch: "
-                        f"HF={len(hf_values)} TRTMC={len(trtfb_values)}"
-                    ),
-                }
-            )
-            continue
-        hf_vector = [float(value) for value in hf_values]
-        trtfb_vector = [float(value) for value in trtfb_values]
-        if not all(math.isfinite(value) for value in hf_vector + trtfb_vector):
-            cases.append(
-                {
-                    "sample_id": hf_id,
-                    "passed": False,
-                    "error": "non-finite output value",
-                }
-            )
-            continue
-        squared_error = sum(
-            (trtfb - hf) ** 2 for hf, trtfb in zip(hf_vector, trtfb_vector, strict=True)
-        )
-        reference_squared_norm = sum(value * value for value in hf_vector)
-        relative_l2 = (
-            math.sqrt(squared_error / reference_squared_norm)
-            if reference_squared_norm >= 1e-24
-            else math.sqrt(squared_error)
-        )
-        absolute_error = max(
-            abs(trtfb - hf) for hf, trtfb in zip(hf_vector, trtfb_vector, strict=True)
-        )
-        cases.append(
-            {
-                "sample_id": hf_id,
-                "output_numel": len(hf_vector),
-                "hf_output_shape": hf_row.get("output_shape", []),
-                "trtfb_output_shape": trtfb_row.get("output_shape", []),
-                "relative_l2": relative_l2,
-                "max_absolute_error": absolute_error,
-                "passed": (relative_l2 <= max_relative_l2 and absolute_error <= max_absolute_error),
-            }
-        )
+    """Compatibility wrapper for the native time-series fidelity reducer."""
+    from tools.model_validation.adapters.time_series import TimeSeriesTaskAdapter
 
-    valid_cases = [case for case in cases if "relative_l2" in case]
-    passed_count = sum(bool(case.get("passed")) for case in cases)
-    agreement_rate = passed_count / len(cases) if cases else 0.0
-    status = (
-        "passed"
-        if cases and len(valid_cases) == len(cases) and agreement_rate >= min_sample_agreement_rate
-        else "failed"
+    return TimeSeriesTaskAdapter().fidelity_metrics(
+        hf_data,
+        trtfb_data,
+        gates=gates,
     )
-    return {
-        "status": status,
-        "sample_count": len(cases),
-        "valid_count": len(valid_cases),
-        "passed_count": passed_count,
-        "sample_agreement_rate": agreement_rate,
-        "mean_relative_l2": (
-            sum(float(case["relative_l2"]) for case in valid_cases) / len(valid_cases)
-            if valid_cases
-            else float("inf")
-        ),
-        "max_relative_l2": max(
-            (float(case["relative_l2"]) for case in valid_cases),
-            default=float("inf"),
-        ),
-        "max_absolute_error": max(
-            (float(case["max_absolute_error"]) for case in valid_cases),
-            default=float("inf"),
-        ),
-        "gates": {
-            "max_relative_l2": max_relative_l2,
-            "max_absolute_error": max_absolute_error,
-            "min_sample_agreement_rate": min_sample_agreement_rate,
-        },
-        "cases": cases,
-    }
 
 
 def write_time_series_summary_markdown(summary: dict[str, Any], path: Path) -> None:
@@ -9918,6 +9912,41 @@ def eval_one_model(
                     },
                 }
             )
+    performance_profile_id = str(getattr(args, "performance_profile", "") or "")
+    if performance_profile_id:
+        if dataset_kind != "time_series_csv":
+            raise ValueError(
+                f"No native Performance Evaluation adapter for dataset kind {dataset_kind!r}"
+            )
+        fidelity_status = str(result.get("status", "passed"))
+        performance = run_time_series_performance_evaluation(
+            args=args,
+            suite=suite,
+            model=model,
+            work_dir=work_dir,
+            bundle_path=bundle_path,
+            correctness_passed=fidelity_status == "passed",
+        )
+        result["assessments"] = {
+            "task": {
+                "status": "not_run",
+                "reason": "ETTh1 suite currently defines backend fidelity, not a task-quality gate",
+            },
+            "fidelity": {"status": fidelity_status},
+            "performance": {
+                "status": performance["status"],
+                "mode": performance["mode"],
+                "profile_id": performance["profile_id"],
+            },
+        }
+        result["performance"] = performance
+        result["performance_artifact"] = str(
+            work_dir / "performance" / "performance_result.json"
+        )
+        if performance["mode"] == "blocking" and performance["status"] != "passed":
+            result["status"] = "failed"
+            result["performance_gate_status"] = performance["status"]
+
     (work_dir / "eval_result.json").write_text(
         json.dumps(result, indent=2, ensure_ascii=False),
         encoding="utf-8",
@@ -10524,6 +10553,21 @@ def build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--dataset-cache-root", default=".ci/task-eval-data")
     p.add_argument("--artifact-dir", default="")
     p.add_argument(
+        "--performance-profile",
+        default="",
+        help="Run a native Performance Evaluation profile after correctness checks.",
+    )
+    p.add_argument(
+        "--performance-profiles",
+        default=str(DEFAULT_PERFORMANCE_PROFILES),
+        help="Versioned Performance Evaluation profile file.",
+    )
+    p.add_argument(
+        "--performance-baseline",
+        default="",
+        help="Optional explicitly approved baseline JSON for blocking comparison.",
+    )
+    p.add_argument(
         "--bundle", default="", help="Prebuilt bundle path; only valid with one --model."
     )
     p.add_argument(
@@ -10982,6 +11026,42 @@ def cmd_eval(args: argparse.Namespace) -> int:
         raise ValueError(f"No models selected for suite {suite['id']}")
     if args.bundle and len(selected) != 1:
         raise ValueError("--bundle can only be used when exactly one model is selected")
+
+    performance_profile_id = str(getattr(args, "performance_profile", "") or "")
+    native_adapter = None
+    if performance_profile_id:
+        from tools.model_validation.adapters import TimeSeriesTaskAdapter
+        from tools.model_validation.performance import load_performance_profile
+
+        performance_profile = load_performance_profile(
+            Path(getattr(args, "performance_profiles", DEFAULT_PERFORMANCE_PROFILES)),
+            performance_profile_id,
+        )
+        performance_profile.validate_target(
+            suite_id=str(suite["id"]),
+            dataset_kind=str(dataset_kind),
+        )
+        if dataset_kind != TimeSeriesTaskAdapter.kind:
+            raise ValueError(
+                f"No native Performance Evaluation adapter for dataset kind {dataset_kind!r}"
+            )
+        native_adapter = TimeSeriesTaskAdapter()
+
+    compatibility_facade = LegacyTaskEvalFacade()
+    compatibility_plan = compatibility_facade.compile_eval_plan(
+        suite=suite,
+        models=selected,
+        model_selectors=getattr(args, "model", ()),
+        dataset_override=getattr(args, "dataset", None),
+        limit=getattr(args, "limit", None),
+        seed=getattr(args, "sample_seed", None),
+        performance_profile_id=performance_profile_id or None,
+        native_adapter=native_adapter,
+    )
+    compatibility_facade.write_plan(
+        compatibility_plan,
+        Path(args.work_root) / suite["id"],
+    )
 
     results = []
     use_workers = should_use_model_workers(args, selected)

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1860,12 +1860,18 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
         ClassificationRule(
             priority=486,
             name="task_eval_tool",
-            matcher=_path_in({
-                "tools/task_eval.py",
-                "tools/elf_hf_reference.py",
-                "tools/prepare_elf_task_eval_datasets.py",
-                "tools/prepare_media_task_eval_datasets.py",
-            }),
+            matcher=lambda path, _imap: (
+                RuleContext(path=path)
+                if path.startswith("tools/model_validation/")
+                or path
+                in {
+                    "tools/task_eval.py",
+                    "tools/elf_hf_reference.py",
+                    "tools/prepare_elf_task_eval_datasets.py",
+                    "tools/prepare_media_task_eval_datasets.py",
+                }
+                else None
+            ),
             resolver=_match_result("task_eval_tool", _no_models, ["tools"], False),
             covered_by=("TestUnitTiers.test_task_eval_tool_triggers_tools_tier",),
         ),


### PR DESCRIPTION
## Background

PR #483 introduced Task Eval performance support before the design and integration were approved. Revert PR #484 is open to remove that merge. This stacked Draft PR reintroduces only the implementation, configuration, and tests for review, with all documentation files excluded.

## Exit Criteria

- Provide an extensible model-validation foundation and opt-in Task Eval performance measurement.
- Preserve legacy Task Eval behavior when no performance profile is requested.
- Include performance profiles, regression gates, environment and output-identity checks, and focused tests.
- Add no files under `docs/`, no Markdown files, and no README files.
- Keep the PR in Draft state until the design and implementation are explicitly approved.

## Implementation

- Add deterministic validation contracts, plans, adapter registration, and the Task Eval compatibility layer.
- Add ETTh1 process-level performance measurement with warmups, repeated observations, percentile and stability statistics, and sanitized artifacts.
- Add observation and blocking regression gates that fail closed on incompatible environments, missing baselines, correctness failures, or output drift.
- Add opt-in performance profiles and regression coverage without changing the default Task Eval result path.

## Validation

- `PYTHONPATH=$PWD/python python -m pytest tests/tools/test_model_validation_performance.py tests/tools/test_model_validation.py tests/tools/test_task_eval.py tests/tools/test_test_impact.py -q`: passed, 425 tests.
- `CI_BASE_REF=revert/model-validation-foundation python3 -m tools.ci pipeline source-quality`: passed, including Ruff, cyclomatic complexity, and 156 architecture-contract tests.
- `python tools/legal_headers.py --check`: passed with zero findings.
- `python3 tools/test_impact.py --validate`: passed; existing allowlist warnings only.
- `git diff --name-only revert/model-validation-foundation...HEAD -- '*.md' ':(glob)**/README*' 'docs/**'`: returned no files.
- Stable patch IDs match the original implementation after excluding Markdown files.

## Notes For Future Readers

- This PR is stacked on revert PR #484 so reviewers see only the proposed code, configuration, and tests.
- Review the contracts and planner first, then the measurement and performance gates, followed by the ETTh1 adapter and integration tests.
- Retarget or rebase this Draft only after #484 is merged by an explicitly authorized user action.
- Do not merge this PR without explicit user approval.
