### PR TITLE
perf(segformer): fuse logits postprocessing on GPU

### DIFF
--- a/src/runtime/models/segformer/segformer_postprocess_cuda.cu
+++ b/src/runtime/models/segformer/segformer_postprocess_cuda.cu
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/segformer/segformer_postprocess_cuda.h"
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace trtmc {
+
+namespace {
+
+constexpr int32_t kBlockSize = 256;
+
+__device__ int32_t clamp_index(int32_t value, int32_t upper_bound) {
+    return max(0, min(value, upper_bound - 1));
+}
+
+__global__ void segformer_bilinear_argmax_kernel(const float* __restrict__ logits,
+                                                 int32_t num_classes, int32_t logits_h,
+                                                 int32_t logits_w, int32_t target_h,
+                                                 int32_t target_w,
+                                                 int32_t* __restrict__ class_map) {
+    const int32_t target_index = static_cast<int32_t>(blockIdx.x * blockDim.x + threadIdx.x);
+    const int32_t target_size = target_h * target_w;
+    if (target_index >= target_size)
+        return;
+
+    const int32_t target_y = target_index / target_w;
+    const int32_t target_x = target_index - target_y * target_w;
+    const float source_y = (static_cast<float>(target_y) + 0.5F) * static_cast<float>(logits_h) /
+                               static_cast<float>(target_h) -
+                           0.5F;
+    const float source_x = (static_cast<float>(target_x) + 0.5F) * static_cast<float>(logits_w) /
+                               static_cast<float>(target_w) -
+                           0.5F;
+    const int32_t first_y_unclamped = static_cast<int32_t>(floorf(source_y));
+    const int32_t first_x_unclamped = static_cast<int32_t>(floorf(source_x));
+    const int32_t first_y = clamp_index(first_y_unclamped, logits_h);
+    const int32_t second_y = clamp_index(first_y_unclamped + 1, logits_h);
+    const int32_t first_x = clamp_index(first_x_unclamped, logits_w);
+    const int32_t second_x = clamp_index(first_x_unclamped + 1, logits_w);
+    const float y_lerp = source_y - static_cast<float>(first_y_unclamped);
+    const float x_lerp = source_x - static_cast<float>(first_x_unclamped);
+    const int64_t plane_size = static_cast<int64_t>(logits_h) * logits_w;
+    const int64_t first_row = static_cast<int64_t>(first_y) * logits_w;
+    const int64_t second_row = static_cast<int64_t>(second_y) * logits_w;
+
+    float best_value = -1.0e30F;
+    int32_t best_class = 0;
+    for (int32_t class_index = 0; class_index < num_classes; ++class_index) {
+        const int64_t class_offset = static_cast<int64_t>(class_index) * plane_size;
+        const float top_left = logits[class_offset + first_row + first_x];
+        const float top_right = logits[class_offset + first_row + second_x];
+        const float bottom_left = logits[class_offset + second_row + first_x];
+        const float bottom_right = logits[class_offset + second_row + second_x];
+        const float top = top_left * (1.0F - x_lerp) + top_right * x_lerp;
+        const float bottom = bottom_left * (1.0F - x_lerp) + bottom_right * x_lerp;
+        const float value = top * (1.0F - y_lerp) + bottom * y_lerp;
+        if (value > best_value) {
+            best_value = value;
+            best_class = class_index;
+        }
+    }
+    class_map[target_index] = best_class;
+}
+
+} // namespace
+
+cudaError_t launch_segformer_bilinear_argmax(const float* logits, int32_t num_classes,
+                                             int32_t logits_h, int32_t logits_w, int32_t target_h,
+                                             int32_t target_w, int32_t* class_map,
+                                             cudaStream_t stream) {
+    if (logits == nullptr || class_map == nullptr || num_classes <= 0 || logits_h <= 0 ||
+        logits_w <= 0 || target_h <= 0 || target_w <= 0) {
+        return cudaErrorInvalidValue;
+    }
+    const int64_t target_size = static_cast<int64_t>(target_h) * target_w;
+    if (target_size > INT32_MAX)
+        return cudaErrorInvalidValue;
+    const int32_t grid = static_cast<int32_t>((target_size + kBlockSize - 1) / kBlockSize);
+    segformer_bilinear_argmax_kernel<<<grid, kBlockSize, 0, stream>>>(
+        logits, num_classes, logits_h, logits_w, target_h, target_w, class_map);
+    return cudaGetLastError();
+}
+
+} // namespace trtmc

--- a/src/runtime/models/segformer/segformer_postprocess_cuda.h
+++ b/src/runtime/models/segformer/segformer_postprocess_cuda.h
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cuda_runtime_api.h>
+
+namespace trtmc {
+
+// Bilinearly resize NCHW logits to the requested source geometry and select
+// the highest-scoring class without materializing the resized logits tensor.
+// All pointers refer to device memory and execution is asynchronous on stream.
+cudaError_t launch_segformer_bilinear_argmax(const float* logits, int32_t num_classes,
+                                             int32_t logits_h, int32_t logits_w, int32_t target_h,
+                                             int32_t target_w, int32_t* class_map,
+                                             cudaStream_t stream);
+
+} // namespace trtmc

--- a/src/runtime/models/segformer/segment_pipeline.cpp
+++ b/src/runtime/models/segformer/segment_pipeline.cpp
@@ -6,8 +6,12 @@
 #include "runtime/models/segformer/segment_pipeline.h"
 
 #include "runtime/models/segformer/segformer_postprocess_seam.h"
+#if TRTMC_HAS_CUDA_KERNELS
+#include "runtime/models/segformer/segformer_postprocess_cuda.h"
+#endif
 
 #include <cstdint>
+#include <cuda_runtime_api.h>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -44,6 +48,24 @@ const Tensor* find_segmentation_output(const TensorMap& outputs) {
     return nullptr;
 }
 
+const TensorInfo* find_segmentation_output(const std::vector<TensorInfo>& outputs) {
+    for (const auto& tensor : outputs) {
+        if (tensor.name.find("logits") != std::string::npos ||
+            tensor.name.find("output") != std::string::npos || outputs.size() == 1)
+            return &tensor;
+    }
+    return nullptr;
+}
+
+#if TRTMC_HAS_CUDA_KERNELS
+void check_cuda(const char* operation, cudaError_t status) {
+    if (status != cudaSuccess) {
+        throw std::runtime_error(std::string("SegmentPipeline: ") + operation +
+                                 " failed: " + cudaGetErrorString(status));
+    }
+}
+#endif
+
 } // namespace
 
 // ─── SegmentPipeline ───
@@ -65,8 +87,11 @@ SegmentResult SegmentPipeline::segment(const float* pixels, int32_t height, int3
     img_t.shape = {3, preprocess_config_.input_image_h, preprocess_config_.input_image_w};
     img_t.dtype = DType::kFloat32;
 
-    auto outputs = model_->forward({{"pixel_values", img_t}});
     SegmentResult result;
+    if (try_segment_logits_on_device(img_t, height, width, result))
+        return result;
+
+    auto outputs = model_->forward({{"pixel_values", img_t}});
 
     const Tensor* out_tensor = find_segmentation_output(outputs);
     if (!out_tensor)
@@ -95,6 +120,52 @@ SegmentResult SegmentPipeline::segment(const float* pixels, int32_t height, int3
     }
 
     return result;
+}
+
+bool SegmentPipeline::try_segment_logits_on_device(const Tensor& input, int32_t target_h,
+                                                   int32_t target_w, SegmentResult& result) {
+#if TRTMC_HAS_CUDA_KERNELS
+    const auto outputs = model_->output_info();
+    const TensorInfo* output = find_segmentation_output(outputs);
+    int32_t num_classes = 0, logits_h = 0, logits_w = 0;
+    if (output == nullptr || output->dtype != DType::kFloat32 ||
+        !parse_segmentation_shape(output->shape, num_classes, logits_h, logits_w)) {
+        return false;
+    }
+
+    const auto target_size = static_cast<std::size_t>(target_h) * target_w;
+    const std::vector<int64_t> target_shape{target_h, target_w};
+    if (!device_class_map_.ok() || device_class_map_.shape() != target_shape) {
+        device_class_map_ = DeviceTensor(target_shape, DType::kInt32, model_->stream());
+        if (!device_class_map_.ok())
+            throw std::runtime_error("SegmentPipeline: failed to allocate device class map");
+    }
+
+    const auto* logits = static_cast<const float*>(model_->device_ptr(output->name));
+    if (logits == nullptr)
+        return false;
+
+    model_->forward_async({{"pixel_values", input}});
+    check_cuda("GPU postprocess launch",
+               launch_segformer_bilinear_argmax(
+                   logits, num_classes, logits_h, logits_w, target_h, target_w,
+                   static_cast<int32_t*>(device_class_map_.data()), model_->stream()));
+
+    result.mask.resize(target_size);
+    check_cuda("class-map download", cudaMemcpyAsync(result.mask.data(), device_class_map_.data(),
+                                                     target_size * sizeof(int32_t),
+                                                     cudaMemcpyDeviceToHost, model_->stream()));
+    check_cuda("GPU postprocess synchronization", cudaStreamSynchronize(model_->stream()));
+    result.height = target_h;
+    result.width = target_w;
+    return true;
+#else
+    (void)input;
+    (void)target_h;
+    (void)target_w;
+    (void)result;
+    return false;
+#endif
 }
 
 } // namespace trtmc

--- a/src/runtime/models/segformer/segment_pipeline.h
+++ b/src/runtime/models/segformer/segment_pipeline.h
@@ -10,6 +10,7 @@
 
 #include "runtime/models/segformer/segformer_preprocess_seam.h"
 #include "trtmc/pipeline.h"
+#include "trtmc/runtime/device_tensor.h"
 #include "trtmc/runtime/trt_module.h"
 
 #include <cstdint>
@@ -31,7 +32,11 @@ class SegmentPipeline final : public IPipeline {
     const char* pipeline_type() const override { return "SegmentPipeline"; }
 
   private:
+    bool try_segment_logits_on_device(const Tensor& input, int32_t target_h, int32_t target_w,
+                                      SegmentResult& result);
+
     std::unique_ptr<TrtModule> model_;
+    DeviceTensor device_class_map_;
     SegformerPreprocessConfig preprocess_config_;
     std::string model_id_;
 };

--- a/tests/cpp/models/segformer/test_segformer_segment_pipeline.cpp
+++ b/tests/cpp/models/segformer/test_segformer_segment_pipeline.cpp
@@ -24,8 +24,11 @@
 #include <cstdint>
 #include <cuda_runtime_api.h>
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
+#include <vector>
 
 static int failures = 0;
 
@@ -37,6 +40,77 @@ static void check(bool condition, const char* name) {
 }
 
 static trtmc::TrtLogger g_logger;
+
+class CountingTrtModule final : public trtmc::ITrtModule {
+  public:
+    explicit CountingTrtModule(std::unique_ptr<trtmc::ITrtModule> delegate)
+        : delegate_(std::move(delegate)) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        ++host_forward_calls;
+        return delegate_->forward(inputs);
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap& inputs) override {
+        return delegate_->forward_device(inputs);
+    }
+    void forward_device_async(const trtmc::DeviceTensorMap& inputs) override {
+        delegate_->forward_device_async(inputs);
+    }
+    void forward_async(const trtmc::TensorMap& inputs) override {
+        ++async_forward_calls;
+        delegate_->forward_async(inputs);
+    }
+    void sync() override { delegate_->sync(); }
+    cudaStream_t stream() const override { return delegate_->stream(); }
+    void enable_cuda_graph() override { delegate_->enable_cuda_graph(); }
+    bool cuda_graph_active() const override { return delegate_->cuda_graph_active(); }
+    int32_t profile_idx() const override { return delegate_->profile_idx(); }
+    std::vector<trtmc::TensorInfo> input_info() const override { return delegate_->input_info(); }
+    std::vector<trtmc::TensorInfo> output_info() const override { return delegate_->output_info(); }
+    bool has_input(const std::string& name) const override { return delegate_->has_input(name); }
+    bool has_output(const std::string& name) const override { return delegate_->has_output(name); }
+    trtmc::DType tensor_dtype(const std::string& name) const override {
+        return delegate_->tensor_dtype(name);
+    }
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        return delegate_->tensor_shape(name);
+    }
+    std::vector<int64_t> input_profile_shape(const std::string& name, int32_t profile_idx,
+                                             trtmc::ProfileShapeSelector selector) const override {
+        return delegate_->input_profile_shape(name, profile_idx, selector);
+    }
+    int32_t optimization_profile_count() const override {
+        return delegate_->optimization_profile_count();
+    }
+    void* device_ptr(const std::string& name) const override { return delegate_->device_ptr(name); }
+    void bind_external(const std::string& name, void* ptr) override {
+        delegate_->bind_external(name, ptr);
+    }
+    void bind_external(const std::string& name, void* ptr,
+                       const std::vector<int64_t>& shape) override {
+        delegate_->bind_external(name, ptr, shape);
+    }
+    int32_t input_rank(const std::string& name) const override {
+        return delegate_->input_rank(name);
+    }
+    bool input_is_dynamic(const std::string& name) const override {
+        return delegate_->input_is_dynamic(name);
+    }
+    void reset_execution_context() override { delegate_->reset_execution_context(); }
+    void set_timing_label(std::string label) override {
+        delegate_->set_timing_label(std::move(label));
+    }
+    bool ok() const override { return delegate_->ok(); }
+    void keep_alive(std::shared_ptr<void> resource) override {
+        delegate_->keep_alive(std::move(resource));
+    }
+
+    int32_t host_forward_calls{0};
+    int32_t async_forward_calls{0};
+
+  private:
+    std::unique_ptr<trtmc::ITrtModule> delegate_;
+};
 
 static trtmc::SegformerPreprocessConfig make_test_preprocess_config() {
     trtmc::SegformerPreprocessConfig config;
@@ -101,7 +175,7 @@ static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_segment_engine_mask_outp
         rt->deserializeCudaEngine(plan->data(), plan->size()));
 }
 
-// Mock: pixel_values[3,4,4] float -> logits[1,2,4,4] float.
+// Mock: pixel_values[3,4,4] float -> logits[1,2,2,2] float.
 static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_segment_engine_4d() {
     auto b = trtmc::TrtUniquePtr<nvinfer1::IBuilder>(nvinfer1::createInferBuilder(g_logger));
     auto n = trtmc::TrtUniquePtr<nvinfer1::INetworkDefinition>(b->createNetworkV2(0));
@@ -111,11 +185,12 @@ static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_segment_engine_4d() {
     auto* pv =
         n->addInput("pixel_values", nvinfer1::DataType::kFLOAT, nvinfer1::Dims{3, {3, 4, 4}});
 
-    float cv[32];
-    for (int i = 0; i < 32; ++i)
-        cv[i] = static_cast<float>(i % 2);
-    auto* cst = n->addConstant(nvinfer1::Dims{4, {1, 2, 4, 4}},
-                               nvinfer1::Weights{nvinfer1::DataType::kFLOAT, cv, 32});
+    const float cv[8] = {
+        1.0F, 0.0F, 0.0F, 1.0F, // class 0
+        0.0F, 1.0F, 1.0F, 0.0F, // class 1
+    };
+    auto* cst = n->addConstant(nvinfer1::Dims{4, {1, 2, 2, 2}},
+                               nvinfer1::Weights{nvinfer1::DataType::kFLOAT, cv, 8});
     cst->getOutput(0)->setName("logits");
     n->markOutput(*cst->getOutput(0));
 
@@ -223,15 +298,21 @@ static void test_segment_4d_output() {
     cudaStream_t stream;
     cudaStreamCreate(&stream);
 
-    auto module = std::make_unique<trtmc::TrtModuleImpl>(engine.get(),
-                                                         engine->createExecutionContext(), stream);
+    auto delegate = std::make_unique<trtmc::TrtModuleImpl>(
+        engine.get(), engine->createExecutionContext(), stream);
+    auto module = std::make_unique<CountingTrtModule>(std::move(delegate));
+    auto* counting_module = module.get();
     trtmc::SegmentPipeline pipeline(std::move(module), make_test_preprocess_config());
 
-    float img[3 * 4 * 4] = {0};
-    auto result = pipeline.segment(img, 4, 4);
-    check(result.mask.size() == 16, "segment 4d: mask has 16 entries");
-    check(result.height == 4, "segment 4d: height = 4");
-    check(result.width == 4, "segment 4d: width = 4");
+    float img[3 * 3 * 3] = {0};
+    auto result = pipeline.segment(img, 3, 3);
+    const std::vector<int32_t> expected_mask{0, 0, 1, 0, 0, 0, 1, 0, 0};
+    check(result.mask == expected_mask, "segment 4d: GPU bilinear class map matches golden");
+    check(result.height == 3, "segment 4d: height = 3");
+    check(result.width == 3, "segment 4d: width = 3");
+    check(counting_module->host_forward_calls == 0, "segment 4d: avoids host logits forward path");
+    check(counting_module->async_forward_calls == 1,
+          "segment 4d: uses device-resident async forward path");
 
     cudaStreamDestroy(stream);
 }


### PR DESCRIPTION
## Background

SegFormer source-geometry postprocessing copied the full `[1, 150, 128, 128]` float logits tensor to the host, then performed bilinear resizing and argmax on the CPU. That postprocessing dominated full-pipeline latency even though TensorRT execution itself was fast.

Fixes #487.

## Exit Criteria

- Preserve the source-geometry segmentation behavior introduced by #481.
- Avoid downloading full-resolution logits for the standard float logits output.
- Keep a compatible CPU fallback for unsupported output shapes or devices.
- Cover the optimized path with a regression test that detects host-logits execution.

## Implementation

- Add a CUDA kernel that fuses half-pixel bilinear interpolation and class argmax without materializing resized logits.
- Enqueue inference and postprocessing on the model stream, then download only the final `int32` class map.
- Cache the device class-map allocation across requests.
- Retain the existing CPU path for non-logit outputs and unsupported configurations.
- Extend the SegFormer pipeline test with a golden 2x2-logits-to-3x3-mask case and assertions that the host forward path is not used.

## Validation

- `ctest --test-dir build -R "^test_segformer_" --output-on-failure`: passed 3/3 SegFormer C++ tests on P2021.
- `PYTHONPATH=python python3 -m pytest tests/e2e/models/segformer -q`: passed 38 tests; 3 skipped by their existing conditions.
- `python3 tools/check_cyclomatic_complexity.py src --exclude src/cli --max-ccn 10 --top 20 --fail-on-missing-lizard`: passed; new device path CCN is 9.
- `python3 tools/legal_headers.py --check`: passed with no findings.
- Real-model mask comparison: pixel-for-pixel identical to the corrected CPU result; against the existing HF reference, mIoU `0.9603` and pixel accuracy `0.9930` pass the unchanged `0.94` / `0.99` thresholds.
- 500-request full-pipeline benchmark on P2021: p50 improved from `43.898 ms` to `6.972 ms` (about `6.3x`), with p95 `7.102 ms` and p99 `7.210 ms`.

## Notes For Future Readers

- Review the fused CUDA kernel first, then the device-path selection in `SegmentPipeline`, and finally the regression test.
- The optimized path applies to float32 CHW/NCHW logits. Other output formats continue through the existing CPU fallback.
