### PR TITLE
fix(vl): batch multimodal prefill across families

### DIFF
--- a/python/tensorrt_model_connect/families/deepseek_ocr/default_decoder.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/default_decoder.py
@@ -115,7 +115,6 @@ def build_standard_decoder_engine(
     # The legacy single-profile graph below stays in place for paths the
     # dual-profile builder does not yet cover:
     #
-    #   - embed_input=True             (VL prefill replacement, Bark sub-engines)
     #   - debug_layer_outputs=True     (per-layer hidden-state dumps)
     #   - hidden_state_output=True     (speech / Bark hidden output)
     #   - config.raw.dynamic_kv_cache  (TriAttention multi-bucket decode)
@@ -124,8 +123,7 @@ def build_standard_decoder_engine(
     # bisects against the legacy graph). It is *not* intended as a
     # supported user-facing flag.
     _dual_profile_disabled_for = (
-        embed_input
-        or debug_layer_outputs
+        debug_layer_outputs
         or hidden_state_output
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
@@ -134,7 +132,14 @@ def build_standard_decoder_engine(
         raise NotImplementedError(
             "split prefill engine is not supported for this standard decoder "
             "configuration")
-    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
+    # Generative VL families are not packaged as split decoder bundles. The engine builder
+    # therefore reaches these families with role="decode" when its global split
+    # default falls back to one engine. Keep VL's one engine dual-profile so
+    # the runtime still receives a sequence-prefill context.
+    vl_single_engine_fallback = embed_input and decoder_engine_role == "decode"
+    if not _dual_profile_disabled_for and (
+        decoder_engine_role in ("dual_profile", "prefill") or vl_single_engine_fallback
+    ):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -147,6 +152,7 @@ def build_standard_decoder_engine(
             interleaved_rope=interleaved_rope,
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
+            embed_input=embed_input,
             verbose=verbose,
             profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )

--- a/python/tensorrt_model_connect/families/deepseek_ocr/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/default_dual_profile_decoder.py
@@ -161,6 +161,7 @@ def build_dual_profile_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    embed_input: bool = False,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     profile_mode: str = "dual_profile",
@@ -246,6 +247,13 @@ def build_dual_profile_decoder_engine(
     token_id = network.add_input("token_id", trt.int32, (-1,))
     position_id = network.add_input("position_id", trt.int32, (-1,))
     attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
+    input_embed_tensor = None
+    use_input_embed_tensor = None
+    if embed_input:
+        input_embed_tensor = network.add_input(
+            "input_embed", trt.float32, (-1, hidden))
+        use_input_embed_tensor = network.add_input(
+            "use_input_embed", trt.float32, (-1, 1))
 
     cache_shape: tuple[int, int]
     if multi_bucket_decode:
@@ -285,6 +293,11 @@ def build_dual_profile_decoder_engine(
             (min_sq, max_cache_length + min_sq),
             (opt_sq, max_cache_length + opt_sq),
             (max_sq, max_cache_length + max_sq))
+        if embed_input:
+            prof.set_shape(
+                "input_embed", (min_sq, hidden), (opt_sq, hidden), (max_sq, hidden))
+            prof.set_shape(
+                "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
         if multi_bucket_decode:
             cmn = cache_rows_min if cache_rows_min is not None else 1
             cop = cache_rows_opt if cache_rows_opt is not None else max_cache_length
@@ -408,6 +421,28 @@ def build_dual_profile_decoder_engine(
     # ---- Embedding -------------------------------------------------------
     emb = network.add_gather(embedding_table, token_id, 0)
     hidden_state = emb.get_output(0)  # (Sq, hidden)
+
+    if input_embed_tensor is not None and use_input_embed_tensor is not None:
+        token_embed = hidden_state
+        if token_embed.dtype != work_trt_dtype:
+            token_embed = network.add_cast(token_embed, work_trt_dtype).get_output(0)
+        input_embed = input_embed_tensor
+        if input_embed.dtype != work_trt_dtype:
+            input_embed = network.add_cast(input_embed, work_trt_dtype).get_output(0)
+        embed_selector = use_input_embed_tensor
+        if embed_selector.dtype != work_trt_dtype:
+            embed_selector = network.add_cast(embed_selector, work_trt_dtype).get_output(0)
+        one = _const_in_work_dtype(
+            network, (1, 1), np.array([[1.0]], dtype=work_np_dtype),
+            work_np_dtype, work_trt_dtype)
+        inverse_selector = network.add_elementwise(
+            one, embed_selector, trt.ElementWiseOperation.SUB).get_output(0)
+        token_part = network.add_elementwise(
+            inverse_selector, token_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        embed_part = network.add_elementwise(
+            embed_selector, input_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden_state = network.add_elementwise(
+            token_part, embed_part, trt.ElementWiseOperation.SUM).get_output(0)
 
     if position_type == "learned" and position_embed_table is not None:
         pos_gather = network.add_gather(position_embed_table, position_id, 0)

--- a/python/tensorrt_model_connect/families/deepseek_ocr/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/graph_blocks.py
@@ -169,6 +169,7 @@ def add_attention_block(
     interleaved_rope: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
+    sequence_length: int | None = 1,
 ) -> dict[str, trt.ITensor]:
     """Pre-norm -> QKV -> RoPE -> cache concat -> attention -> output proj.
 
@@ -222,11 +223,13 @@ def add_attention_block(
     q_norm = weights.get(f"{prefix}.q_norm")
     if q_norm is not None:
         q = graph_ops.add_rms_norm_per_head(
-            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype)
+            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
     k_norm = weights.get(f"{prefix}.k_norm")
     if k_norm is not None:
         k = graph_ops.add_rms_norm_per_head(
-            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype)
+            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
 
     # ------------------------------------------------------------------ #
     # RoPE via native IRotaryEmbeddingLayer                              #
@@ -243,35 +246,40 @@ def add_attention_block(
         q = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
         k = graph_ops.add_apply_rope_native(
             network, k, num_kv_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
 
     # Save present K/V (before concatenation, this is the raw projection output)
     present_k = k
     present_v = v
 
     # Reshape current K, V for concatenation
-    k_reshape = network.add_shuffle(k)
-    k_reshape.reshape_dims = (1, kv_attention_size)
-    v_reshape = network.add_shuffle(v)
-    v_reshape.reshape_dims = (1, kv_attention_size)
+    current_k = k
+    current_v = v
+    if sequence_length is not None:
+        k_reshape = network.add_shuffle(k)
+        k_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        v_reshape = network.add_shuffle(v)
+        v_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        current_k = k_reshape.get_output(0)
+        current_v = v_reshape.get_output(0)
 
     # Concatenate with cache
     all_k = network.add_concatenation(
-        [cache_k, k_reshape.get_output(0)])
+        [cache_k, current_k])
     all_k.axis = 0
     all_v = network.add_concatenation(
-        [cache_v, v_reshape.get_output(0)])
+        [cache_v, current_v])
     all_v.axis = 0
 
     # ------------------------------------------------------------------ #
     # Attention core — native IAttention or FFI kernel                    #
     # ------------------------------------------------------------------ #
     if use_native_attention:
-        kv_seq = None if dynamic_kv_cache else attention_window
+        kv_seq = None if dynamic_kv_cache or sequence_length is None else attention_window
         if alibi_slopes_tensor is not None:
             if alibi_indices_tensor is None:
                 raise ValueError("ALiBi attention requires cache position indices")
@@ -296,7 +304,7 @@ def add_attention_block(
             num_heads=num_heads,
             head_dim=head_dim,
             num_kv_heads=num_kv_heads,
-            q_seq=1,
+            q_seq=sequence_length,
             kv_seq=kv_seq,
             causal=False,
             mask=mask_4d,

--- a/python/tensorrt_model_connect/families/deepseek_ocr/graph_ops.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/graph_ops.py
@@ -2654,6 +2654,46 @@ def add_apply_rope_native_from_full_cache(
         sequence_length=sequence_length)
 
 
+def _add_decomposed_attention_core(
+    network: trt.INetworkDefinition,
+    q_4d: trt.ITensor,
+    k_4d: trt.ITensor,
+    v_4d: trt.ITensor,
+    *,
+    mask: trt.ITensor | None,
+    scale: float | None,
+    fp32_accumulation: bool,
+) -> trt.ITensor:
+    """Scaled dot-product attention using primitive TensorRT layers."""
+    output_dtype = q_4d.dtype
+    if fp32_accumulation and output_dtype != trt.float32:
+        q_4d = network.add_cast(q_4d, trt.float32).get_output(0)
+        k_4d = network.add_cast(k_4d, trt.float32).get_output(0)
+        v_4d = network.add_cast(v_4d, trt.float32).get_output(0)
+        if mask is not None and mask.dtype != trt.float32:
+            mask = network.add_cast(mask, trt.float32).get_output(0)
+
+    if scale is None:
+        head_dim = q_4d.shape[-1]
+        scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+    scale_t = _scalar_constant_for_trt_dtype(
+        network, (1, 1, 1, 1), scale, q_4d.dtype)
+    q_scaled = network.add_elementwise(
+        q_4d, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
+    scores = network.add_matrix_multiply(
+        q_scaled, trt.MatrixOperation.NONE,
+        k_4d, trt.MatrixOperation.TRANSPOSE).get_output(0)
+    if mask is not None:
+        scores = network.add_elementwise(
+            scores, mask, trt.ElementWiseOperation.SUM).get_output(0)
+    probs = network.add_softmax(scores)
+    probs.axes = 1 << 3
+    context = network.add_matrix_multiply(
+        probs.get_output(0), trt.MatrixOperation.NONE,
+        v_4d, trt.MatrixOperation.NONE).get_output(0)
+    return _cast_back_to_trt_dtype(network, context, output_dtype)
+
+
 def add_attention_core(
     network: trt.INetworkDefinition,
     q_4d: trt.ITensor,
@@ -2901,6 +2941,14 @@ def add_attention_from_rows(
         tag=None if tag is None else tag + ".v")
     if scale is None:
         scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+    # TensorRT 11.2 can segfault while compiling masked IAttention with
+    # head_dim=128 and dynamic or multi-row queries. Decompose that shape.
+    decompose_masked_attention = (
+        (q_seq != 1 or kv_seq is None)
+        and mask is not None
+        and head_dim == 128
+        and not causal
+    )
     if logit_softcap is not None and float(logit_softcap) > 0.0:
         if causal:
             raise NotImplementedError(
@@ -2909,6 +2957,16 @@ def add_attention_from_rows(
             network, q_4d, k_4d, v_4d,
             num_heads=num_heads, num_kv_heads=kv_heads, head_dim=head_dim,
             mask=mask, scale=scale, logit_softcap=float(logit_softcap))
+    elif decompose_masked_attention:
+        k_4d = _repeat_kv_heads_4d(
+            network, k_4d, num_heads=num_heads, num_kv_heads=kv_heads,
+            head_dim=head_dim)
+        v_4d = _repeat_kv_heads_4d(
+            network, v_4d, num_heads=num_heads, num_kv_heads=kv_heads,
+            head_dim=head_dim)
+        ctx_4d = _add_decomposed_attention_core(
+            network, q_4d, k_4d, v_4d, mask=mask, scale=scale,
+            fp32_accumulation=fp32_accumulation)
     else:
         ctx_4d = add_attention_core(
             network, q_4d, k_4d, v_4d, causal=causal, mask=mask, scale=scale,

--- a/python/tensorrt_model_connect/families/deepseek_ocr/plugin.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/plugin.py
@@ -291,7 +291,7 @@ class DeepSeekOCRPlugin:
         head_dim = attention_size // num_heads
         kv_attention_size = graph_blocks.infer_kv_attention_size(
             weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
-        attention_window = max_cache_length + 1
+        opt_prefill_length = min(64, max_cache_length)
         if precision == "fp16":
             work_np_dtype, work_trt_dtype = np.float16, trt.float16
         elif precision == "fp32":
@@ -323,16 +323,16 @@ class DeepSeekOCRPlugin:
         # -----------------------------------------------------------
         # Inputs
         # -----------------------------------------------------------
-        token_id = network.add_input("token_id", trt.int32, (1,))
-        position_id = network.add_input("position_id", trt.int32, (1,))
+        token_id = network.add_input("token_id", trt.int32, (-1,))
+        position_id = network.add_input("position_id", trt.int32, (-1,))
         attention_mask = network.add_input(
-            "attention_mask", trt.float32, (1, attention_window))
+            "attention_mask", trt.float32, (-1, -1))
 
         # VL embed_input: allow vision features to override embedding
         input_embed_tensor = network.add_input(
-            "input_embed", trt.float32, (1, hidden))
+            "input_embed", trt.float32, (-1, hidden))
         use_input_embed_tensor = network.add_input(
-            "use_input_embed", trt.float32, (1,))
+            "use_input_embed", trt.float32, (-1, 1))
 
         cache_k_inputs = []
         cache_v_inputs = []
@@ -345,6 +345,26 @@ class DeepSeekOCRPlugin:
                 trt.float32, (max_cache_length, kv_attention_size))
             cache_k_inputs.append(ck)
             cache_v_inputs.append(cv)
+
+        def _add_profile(opt_sq: int, max_sq: int, *, fixed: bool = False) -> None:
+            profile = builder.create_optimization_profile()
+            min_sq = opt_sq if fixed else 1
+            profile.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
+            profile.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
+            profile.set_shape(
+                "attention_mask",
+                (min_sq, max_cache_length + min_sq),
+                (opt_sq, max_cache_length + opt_sq),
+                (max_sq, max_cache_length + max_sq))
+            profile.set_shape(
+                "input_embed", (min_sq, hidden), (opt_sq, hidden), (max_sq, hidden))
+            profile.set_shape(
+                "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
+            trt_config.add_optimization_profile(profile)
+
+        _add_profile(opt_prefill_length, max_cache_length)
+        _add_profile(1, 1, fixed=True)
+
         if work_trt_dtype != trt.float32:
             attention_mask = network.add_cast(
                 attention_mask, work_trt_dtype).get_output(0)
@@ -369,9 +389,9 @@ class DeepSeekOCRPlugin:
 
         graph_ops.validate_native_rope_dim(head_dim, field_name="head_dim")
         cos_half_np = graph_ops.make_rope_table_half_dim(
-            attention_window, head_dim, config.rope_theta, True)
+            max_cache_length * 2, head_dim, config.rope_theta, True)
         sin_half_np = graph_ops.make_rope_table_half_dim(
-            attention_window, head_dim, config.rope_theta, False)
+            max_cache_length * 2, head_dim, config.rope_theta, False)
         cos_half_tensor = graph_ops.add_constant(
             network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype)
         sin_half_tensor = graph_ops.add_constant(
@@ -395,19 +415,17 @@ class DeepSeekOCRPlugin:
         token_embed = gather.get_output(0)
 
         # Conditional: (1 - flag) * token_embed + flag * input_embed
-        flag_broadcast = network.add_shuffle(use_input_embed_tensor)
-        flag_broadcast.reshape_dims = (1, 1)
         one_const = graph_ops.add_constant(
             network, (1, 1), np.array([1.0], dtype=io_np_dtype),
             dtype=io_np_dtype)
         inv_flag = network.add_elementwise(
-            one_const, flag_broadcast.get_output(0),
+            one_const, use_input_embed_tensor,
             trt.ElementWiseOperation.SUB)
         tok_part = network.add_elementwise(
             inv_flag.get_output(0), token_embed,
             trt.ElementWiseOperation.PROD)
         embed_part = network.add_elementwise(
-            flag_broadcast.get_output(0), input_embed_tensor,
+            use_input_embed_tensor, input_embed_tensor,
             trt.ElementWiseOperation.PROD)
         hidden_sum = network.add_elementwise(
             tok_part.get_output(0), embed_part.get_output(0),
@@ -465,6 +483,7 @@ class DeepSeekOCRPlugin:
                 norm_topk_prob=norm_topk_prob,
                 routed_scaling_factor=routed_scaling_factor,
                 dtype=layer_np_dtype,
+                sequence_length=None,
             )
 
             hidden_state = result["hidden"]
@@ -492,10 +511,22 @@ class DeepSeekOCRPlugin:
                 None, io_eps_tensor, "rmsnorm", dtype=io_np_dtype)
 
         # -----------------------------------------------------------
-        # LM head (logits)
+        # LM head (last prompt row only)
         # -----------------------------------------------------------
+        hidden_shape = network.add_shape(hidden_state).get_output(0)
+        one_hidden = graph_ops.add_constant(
+            network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
+        last_start = network.add_elementwise(
+            hidden_shape, one_hidden, trt.ElementWiseOperation.SUB).get_output(0)
+        last_size = graph_ops.add_constant(
+            network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
+        last_slice = network.add_slice(
+            hidden_state, start=(0, 0), shape=(0, 0), stride=(1, 1))
+        last_slice.set_input(1, last_start)
+        last_slice.set_input(2, last_size)
+        last_hidden = last_slice.get_output(0)
         logits = graph_ops.add_matmul_rhs_constant(
-            network, hidden_state, hidden, vocab, weights["w_out"],
+            network, last_hidden, hidden, vocab, weights["w_out"],
             dtype=io_np_dtype)
         b_out = np.zeros(vocab, dtype=np.float32)
         logits = graph_ops.add_bias_sum(
@@ -666,8 +697,8 @@ def _add_moe_with_shared_experts(
     topk = network.add_topk(
         sm.get_output(0), trt.TopKOperation.MAX,
         num_experts_per_tok, 1 << 1)
-    top_values = topk.get_output(0)   # [1, top_k]
-    top_indices = topk.get_output(1)  # [1, top_k]
+    top_values = topk.get_output(0)   # [Sq, top_k]
+    top_indices = topk.get_output(1)  # [Sq, top_k]
 
     # 4. Weight normalization (matches HF MoEGate):
     #    norm_topk_prob=True  -> renormalize: values / sum(values)
@@ -688,8 +719,11 @@ def _add_moe_with_shared_experts(
     else:
         final_weights = top_values
 
-    # 5. Compute ALL routed expert outputs and stack
-    expert_outputs = []
+    # 5. Compute every routed expert and derive its per-row gate from the
+    # dynamic [Sq, top_k] routing result. This keeps the same dense expert
+    # evaluation strategy as the legacy Sq=1 graph while supporting sequence
+    # prefill without assuming a fixed first dimension.
+    result = None
     for e in range(n_routed_experts):
         exp_out = _add_swiglu_expert(
             network, inp, hidden_size, moe_intermediate,
@@ -698,30 +732,18 @@ def _add_moe_with_shared_experts(
             weights[f"{prefix}.expert.{e}.w_down"],
             dtype=dtype,
         )
-        expert_outputs.append(exp_out)
-
-    stacked = network.add_concatenation(expert_outputs)
-    stacked.axis = 0
-    stacked_out = stacked.get_output(0)  # [n_routed_experts, hidden_size]
-
-    # 6. Gather selected experts, scale, and sum
-    result = None
-    for k in range(num_experts_per_tok):
-        idx_slice = network.add_slice(
-            top_indices, start=(0, k), shape=(1, 1), stride=(1, 1))
-        idx_flat = network.add_shuffle(idx_slice.get_output(0))
-        idx_flat.reshape_dims = (1,)
-
-        w_slice = network.add_slice(
-            final_weights,
-            start=(0, k), shape=(1, 1), stride=(1, 1))
-
-        expert_out = network.add_gather(
-            stacked_out, idx_flat.get_output(0), 0)
-
+        expert_index = graph_ops.add_constant(
+            network, (1, 1), np.array([[e]], dtype=np.int32), dtype=np.int32)
+        selected = network.add_elementwise(
+            top_indices, expert_index, trt.ElementWiseOperation.EQUAL).get_output(0)
+        selected = network.add_cast(selected, final_weights.dtype).get_output(0)
+        selected_weights = network.add_elementwise(
+            final_weights, selected, trt.ElementWiseOperation.PROD).get_output(0)
+        expert_weight = network.add_reduce(
+            selected_weights, trt.ReduceOperation.SUM, 1 << 1,
+            keep_dims=True).get_output(0)
         scaled_expert = network.add_elementwise(
-            expert_out.get_output(0), w_slice.get_output(0),
-            trt.ElementWiseOperation.PROD)
+            exp_out, expert_weight, trt.ElementWiseOperation.PROD)
 
         if result is None:
             result = scaled_expert.get_output(0)
@@ -780,9 +802,9 @@ def _add_decoder_layer(
     norm_topk_prob: bool = False,
     routed_scaling_factor: float = 1.0,
     dtype=np.float32,
+    sequence_length: int | None = 1,
 ) -> dict[str, trt.ITensor]:
     """One decoder layer: standard MHA + (dense MLP or MoE with shared experts)."""
-    attention_window = max_cache_length + 1
 
     # Pre-attention RMSNorm
     norm1 = _apply_norm(
@@ -803,34 +825,38 @@ def _add_decoder_layer(
 
     q = graph_ops.add_apply_rope_native(
         network, q, num_heads, head_dim, cos_half_tensor, sin_half_tensor,
-        position_id, head_dim)
+        position_id, head_dim, sequence_length=sequence_length)
     k = graph_ops.add_apply_rope_native(
         network, k, num_kv_heads, head_dim, cos_half_tensor, sin_half_tensor,
-        position_id, head_dim)
+        position_id, head_dim, sequence_length=sequence_length)
 
     # Save present K/V
     present_k = k
     present_v = v
 
-    # Reshape for cache concatenation
-    k_reshape = network.add_shuffle(k)
-    k_reshape.reshape_dims = (1, kv_attention_size)
-    v_reshape = network.add_shuffle(v)
-    v_reshape.reshape_dims = (1, kv_attention_size)
+    current_k = k
+    current_v = v
+    if sequence_length is not None:
+        k_reshape = network.add_shuffle(k)
+        k_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        current_k = k_reshape.get_output(0)
+        v_reshape = network.add_shuffle(v)
+        v_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        current_v = v_reshape.get_output(0)
 
     # Concatenate with cache
     all_k = network.add_concatenation(
-        [cache_k, k_reshape.get_output(0)])
+        [cache_k, current_k])
     all_k.axis = 0
     all_v = network.add_concatenation(
-        [cache_v, v_reshape.get_output(0)])
+        [cache_v, current_v])
     all_v.axis = 0
 
     mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask)
     context_flat = graph_ops.add_attention_from_rows(
         network, q, all_k.get_output(0), all_v.get_output(0),
         num_heads=num_heads, head_dim=head_dim, num_kv_heads=num_kv_heads,
-        q_seq=1, kv_seq=attention_window,
+        q_seq=sequence_length, kv_seq=None if sequence_length is None else max_cache_length + 1,
         mask=mask_4d,
         fp32_accumulation=dtype != np.float32)
 

--- a/python/tensorrt_model_connect/families/deepseek_ocr/plugin.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/plugin.py
@@ -51,6 +51,10 @@ from .checkpoint_mapper import (
 )
 from . import graph_ops
 from . import graph_blocks
+from .prefill_config import (
+    MAX_SEQUENCE_PREFILL_LENGTH,
+    sequence_prefill_profile_lengths,
+)
 from ...parallel_config import (
     normalize_parallel_config,
     require_tensorrt_11_for_tensor_parallel,
@@ -291,7 +295,8 @@ class DeepSeekOCRPlugin:
         head_dim = attention_size // num_heads
         kv_attention_size = graph_blocks.infer_kv_attention_size(
             weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
-        opt_prefill_length = min(64, max_cache_length)
+        opt_prefill_length, max_prefill_length = sequence_prefill_profile_lengths(
+            max_cache_length)
         if precision == "fp16":
             work_np_dtype, work_trt_dtype = np.float16, trt.float16
         elif precision == "fp32":
@@ -362,7 +367,7 @@ class DeepSeekOCRPlugin:
                 "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
             trt_config.add_optimization_profile(profile)
 
-        _add_profile(opt_prefill_length, max_cache_length)
+        _add_profile(opt_prefill_length, max_prefill_length)
         _add_profile(1, 1, fixed=True)
 
         if work_trt_dtype != trt.float32:
@@ -612,6 +617,7 @@ class DeepSeekOCRPlugin:
             "image_token_id": config.raw.get("image_token_id", 128815),
             "fixed_image_size": 768,
             "num_image_pad_tokens": 145,  # 144 projected + 1 view_separator
+            "prefill_max_length": MAX_SEQUENCE_PREFILL_LENGTH,
             "vision_output_dim": hidden,
             "preprocessor_type": "simple_chw",
             "image_mean": [0.5, 0.5, 0.5],

--- a/python/tensorrt_model_connect/families/deepseek_ocr/prefill_config.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/prefill_config.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepSeek-OCR sequence-prefill limits shared by its engine builders."""
+
+# The model contributes 145 image tokens before a short text prompt. Keeping
+# the dynamic profile bounded avoids TensorRT tactic exploration over a
+# 4096-row, 64-expert MoE graph; longer prompts retain the runtime's explicit
+# token-by-token compatibility fallback.
+MAX_SEQUENCE_PREFILL_LENGTH = 256
+
+
+def sequence_prefill_profile_lengths(max_cache_length: int) -> tuple[int, int]:
+    """Return the preferred and maximum sequence-prefill profile lengths."""
+    max_prefill_length = min(max_cache_length, MAX_SEQUENCE_PREFILL_LENGTH)
+    return min(64, max_prefill_length), max_prefill_length

--- a/python/tensorrt_model_connect/families/deepseek_ocr/tp_builder.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/tp_builder.py
@@ -183,30 +183,27 @@ def _add_moe_tp(
     else:
         scaled_weights = top_values
 
-    expert_outputs = []
+    routed_local = None
     for expert_idx in range(n_routed_experts):
-        expert_outputs.append(_add_swiglu_local(
+        expert_output = _add_swiglu_local(
             network, inp, hidden_size, moe_intermediate,
             weights[f"{prefix}.expert.{expert_idx}.w_gate"],
             weights[f"{prefix}.expert.{expert_idx}.w_up"],
             weights[f"{prefix}.expert.{expert_idx}.w_down"],
-        ))
-
-    stacked = network.add_concatenation(expert_outputs)
-    stacked.axis = 0
-    stacked_out = stacked.get_output(0)
-
-    routed_local = None
-    for top_idx in range(num_experts_per_tok):
-        idx_slice = network.add_slice(
-            top_indices, start=(0, top_idx), shape=(1, 1), stride=(1, 1))
-        idx_flat = network.add_shuffle(idx_slice.get_output(0))
-        idx_flat.reshape_dims = (1,)
-        w_slice = network.add_slice(
-            scaled_weights, start=(0, top_idx), shape=(1, 1), stride=(1, 1))
-        expert_out = network.add_gather(stacked_out, idx_flat.get_output(0), 0)
+        )
+        expert_index = graph_ops.add_constant(
+            network, (1, 1), np.array([[expert_idx]], dtype=np.int32),
+            dtype=np.int32)
+        selected = network.add_elementwise(
+            top_indices, expert_index, trt.ElementWiseOperation.EQUAL).get_output(0)
+        selected = network.add_cast(selected, scaled_weights.dtype).get_output(0)
+        selected_weights = network.add_elementwise(
+            scaled_weights, selected, trt.ElementWiseOperation.PROD).get_output(0)
+        expert_weight = network.add_reduce(
+            selected_weights, trt.ReduceOperation.SUM, 1 << 1,
+            keep_dims=True).get_output(0)
         scaled = network.add_elementwise(
-            expert_out.get_output(0), w_slice.get_output(0),
+            expert_output, expert_weight,
             trt.ElementWiseOperation.PROD)
         if routed_local is None:
             routed_local = scaled.get_output(0)
@@ -255,9 +252,8 @@ def _add_decoder_layer_tp(
     tp_size: int,
     norm_topk_prob: bool = False,
     routed_scaling_factor: float = 1.0,
+    sequence_length: int | None = 1,
 ) -> dict[str, trt.ITensor]:
-    attention_window = max_cache_length + 1
-
     norm1 = _apply_norm(
         network, hidden, hidden_size,
         weights[f"{prefix}.input_norm"], None, eps_tensor, "rmsnorm")
@@ -274,29 +270,35 @@ def _add_decoder_layer_tp(
 
     q = graph_ops.add_apply_rope_native(
         network, q, num_heads, head_dim, cos_half_tensor, sin_half_tensor,
-        position_id, head_dim)
+        position_id, head_dim, sequence_length=sequence_length)
     k = graph_ops.add_apply_rope_native(
         network, k, num_kv_heads, head_dim, cos_half_tensor, sin_half_tensor,
-        position_id, head_dim)
+        position_id, head_dim, sequence_length=sequence_length)
 
     present_k = k
     present_v = v
 
-    k_reshape = network.add_shuffle(k)
-    k_reshape.reshape_dims = (1, kv_attention_size)
-    v_reshape = network.add_shuffle(v)
-    v_reshape.reshape_dims = (1, kv_attention_size)
+    current_k = k
+    current_v = v
+    if sequence_length is not None:
+        k_reshape = network.add_shuffle(k)
+        k_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        current_k = k_reshape.get_output(0)
+        v_reshape = network.add_shuffle(v)
+        v_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        current_v = v_reshape.get_output(0)
 
-    all_k = network.add_concatenation([cache_k, k_reshape.get_output(0)])
+    all_k = network.add_concatenation([cache_k, current_k])
     all_k.axis = 0
-    all_v = network.add_concatenation([cache_v, v_reshape.get_output(0)])
+    all_v = network.add_concatenation([cache_v, current_v])
     all_v.axis = 0
 
     mask_4d = graph_ops.add_2d_mask_to_4d(network, attention_mask)
     context_flat = graph_ops.add_attention_from_rows(
         network, q, all_k.get_output(0), all_v.get_output(0),
         num_heads=num_heads, head_dim=head_dim, num_kv_heads=num_kv_heads,
-        q_seq=1, kv_seq=attention_window,
+        q_seq=sequence_length,
+        kv_seq=None if sequence_length is None else max_cache_length + 1,
         mask=mask_4d)
 
     attn_out = graph_ops.add_matmul_rhs_constant(
@@ -378,7 +380,7 @@ def build_deepseek_ocr_tp_engine(
     attention_size = int(rank_weights["_attention_size"])
     kv_attention_size = int(rank_weights["_kv_attention_size"])
     head_dim = attention_size // num_heads
-    attention_window = max_cache_length + 1
+    opt_prefill_length = min(64, max_cache_length)
 
     n_routed_experts = int(rank_weights["_n_routed_experts"])
     num_experts_per_tok = int(rank_weights["_num_experts_per_tok"])
@@ -395,15 +397,19 @@ def build_deepseek_ocr_tp_engine(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    multi_device_preview = getattr(
+        trt.PreviewFeature, "MULTIDEVICE_RUNTIME_10_16", None)
+    if multi_device_preview is not None:
+        trt_config.set_preview_feature(multi_device_preview, True)
 
-    token_id = network.add_input("token_id", trt.int32, (1,))
-    position_id = network.add_input("position_id", trt.int32, (1,))
+    token_id = network.add_input("token_id", trt.int32, (-1,))
+    position_id = network.add_input("position_id", trt.int32, (-1,))
     attention_mask = network.add_input(
-        "attention_mask", trt.float32, (1, attention_window))
+        "attention_mask", trt.float32, (-1, -1))
     input_embed_tensor = network.add_input(
-        "input_embed", trt.float32, (1, hidden))
+        "input_embed", trt.float32, (-1, hidden))
     use_input_embed_tensor = network.add_input(
-        "use_input_embed", trt.float32, (1,))
+        "use_input_embed", trt.float32, (-1, 1))
 
     cache_k_inputs = []
     cache_v_inputs = []
@@ -415,13 +421,32 @@ def build_deepseek_ocr_tp_engine(
             graph_ops.layer_tensor_name("cache_v", layer_idx),
             trt.float32, (max_cache_length, kv_attention_size)))
 
+    def _add_profile(opt_sq: int, max_sq: int, *, fixed: bool = False) -> None:
+        profile = builder.create_optimization_profile()
+        min_sq = opt_sq if fixed else 1
+        profile.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
+        profile.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
+        profile.set_shape(
+            "attention_mask",
+            (min_sq, max_cache_length + min_sq),
+            (opt_sq, max_cache_length + opt_sq),
+            (max_sq, max_cache_length + max_sq))
+        profile.set_shape(
+            "input_embed", (min_sq, hidden), (opt_sq, hidden), (max_sq, hidden))
+        profile.set_shape(
+            "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
+        trt_config.add_optimization_profile(profile)
+
+    _add_profile(opt_prefill_length, max_cache_length)
+    _add_profile(1, 1, fixed=True)
+
     embedding_table = graph_ops.add_constant(
         network, (vocab, hidden), rank_weights["embedding"])
     graph_ops.validate_native_rope_dim(head_dim, field_name="head_dim")
     cos_half_np = graph_ops.make_rope_table_half_dim(
-        attention_window, head_dim, config.rope_theta, True)
+        max_cache_length * 2, head_dim, config.rope_theta, True)
     sin_half_np = graph_ops.make_rope_table_half_dim(
-        attention_window, head_dim, config.rope_theta, False)
+        max_cache_length * 2, head_dim, config.rope_theta, False)
     cos_half_tensor = graph_ops.add_constant(network, cos_half_np.shape, cos_half_np)
     sin_half_tensor = graph_ops.add_constant(network, sin_half_np.shape, sin_half_np)
     eps_tensor = graph_ops.add_constant(
@@ -429,16 +454,14 @@ def build_deepseek_ocr_tp_engine(
 
     gather = network.add_gather(embedding_table, token_id, 0)
     token_embed = gather.get_output(0)
-    flag_broadcast = network.add_shuffle(use_input_embed_tensor)
-    flag_broadcast.reshape_dims = (1, 1)
     one_const = graph_ops.add_constant(
         network, (1, 1), np.array([1.0], dtype=np.float32))
     inv_flag = network.add_elementwise(
-        one_const, flag_broadcast.get_output(0), trt.ElementWiseOperation.SUB)
+        one_const, use_input_embed_tensor, trt.ElementWiseOperation.SUB)
     tok_part = network.add_elementwise(
         inv_flag.get_output(0), token_embed, trt.ElementWiseOperation.PROD)
     embed_part = network.add_elementwise(
-        flag_broadcast.get_output(0), input_embed_tensor,
+        use_input_embed_tensor, input_embed_tensor,
         trt.ElementWiseOperation.PROD)
     hidden_sum = network.add_elementwise(
         tok_part.get_output(0), embed_part.get_output(0),
@@ -477,6 +500,7 @@ def build_deepseek_ocr_tp_engine(
             tp_size=parallel.tp_size,
             norm_topk_prob=norm_topk_prob,
             routed_scaling_factor=routed_scaling_factor,
+            sequence_length=None,
         )
         hidden_state = result["hidden"]
         present_k_outputs.append(result["present_k"])
@@ -488,8 +512,21 @@ def build_deepseek_ocr_tp_engine(
             network, hidden_state, hidden, final_norm,
             None, eps_tensor, "rmsnorm")
 
+    hidden_shape = network.add_shape(hidden_state).get_output(0)
+    one_hidden = graph_ops.add_constant(
+        network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
+    last_start = network.add_elementwise(
+        hidden_shape, one_hidden, trt.ElementWiseOperation.SUB).get_output(0)
+    last_size = graph_ops.add_constant(
+        network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
+    last_slice = network.add_slice(
+        hidden_state, start=(0, 0), shape=(0, 0), stride=(1, 1))
+    last_slice.set_input(1, last_start)
+    last_slice.set_input(2, last_size)
+    last_hidden = last_slice.get_output(0)
+
     logits = graph_ops.add_matmul_rhs_constant(
-        network, hidden_state, hidden, vocab, rank_weights["w_out"])
+        network, last_hidden, hidden, vocab, rank_weights["w_out"])
     logits = graph_ops.add_bias_sum(
         network, logits, vocab, np.zeros(vocab, dtype=np.float32))
     logits.name = "logits"

--- a/python/tensorrt_model_connect/families/deepseek_ocr/tp_builder.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/tp_builder.py
@@ -12,6 +12,7 @@ import numpy as np
 from tensorrt_model_connect import trt_compat
 
 from . import graph_ops
+from .prefill_config import sequence_prefill_profile_lengths
 from ...parallel_config import add_all_reduce_sum, normalize_parallel_config
 from .standard_decoder_builder import _apply_norm
 
@@ -380,7 +381,7 @@ def build_deepseek_ocr_tp_engine(
     attention_size = int(rank_weights["_attention_size"])
     kv_attention_size = int(rank_weights["_kv_attention_size"])
     head_dim = attention_size // num_heads
-    opt_prefill_length = min(64, max_cache_length)
+    opt_prefill_length, max_prefill_length = sequence_prefill_profile_lengths(max_cache_length)
 
     n_routed_experts = int(rank_weights["_n_routed_experts"])
     num_experts_per_tok = int(rank_weights["_num_experts_per_tok"])
@@ -437,7 +438,7 @@ def build_deepseek_ocr_tp_engine(
             "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
         trt_config.add_optimization_profile(profile)
 
-    _add_profile(opt_prefill_length, max_cache_length)
+    _add_profile(opt_prefill_length, max_prefill_length)
     _add_profile(1, 1, fixed=True)
 
     embedding_table = graph_ops.add_constant(

--- a/python/tensorrt_model_connect/families/deepseek_ocr/vl_debug_runner.py
+++ b/python/tensorrt_model_connect/families/deepseek_ocr/vl_debug_runner.py
@@ -63,6 +63,20 @@ def _require_trt_runtime() -> None:
         raise ImportError("cuda-python is required for VL debug runner execution")
 
 
+def _profile_min_shape(engine: Any, name: str, profile_index: int) -> tuple[int, ...]:
+    """Resolve a concrete single-step shape for a possibly dynamic tensor."""
+    declared = tuple(int(dim) for dim in engine.get_tensor_shape(name))
+    if all(dim >= 0 for dim in declared):
+        return declared
+    profile_shapes = engine.get_tensor_profile_shape(name, profile_index)
+    if not profile_shapes:
+        raise RuntimeError(f"Missing optimization profile shape for {name!r}")
+    resolved = tuple(int(dim) for dim in profile_shapes[0])
+    if any(dim < 0 for dim in resolved):
+        raise RuntimeError(f"Invalid optimization profile shape for {name!r}: {resolved}")
+    return resolved
+
+
 class TrtRunner:
     """Device-resident TRT inference runner for debugging and diff testing.
 
@@ -106,17 +120,19 @@ class TrtRunner:
         # decode profile (profile 1, Sq=1). For per-step decode runs the
         # debug_runner must select the decode profile and call
         # set_input_shape on every dynamic input before each execute. We
-        # detect dual-profile via num_optimization_profiles > 1 and the
-        # presence of -1 dims on token_id / position_id / attention_mask.
-        self._dynamic_inputs: list[str] = []
+        # detect dual-profile via num_optimization_profiles > 1 and resolve
+        # every dynamic input from the selected profile's minimum shape.
+        self._dynamic_input_shapes: dict[str, tuple[int, ...]] = {}
         self._is_dual_profile = self.engine.num_optimization_profiles > 1
-        for input_name in ("token_id", "position_id", "attention_mask"):
-            try:
-                shape = tuple(self.engine.get_tensor_shape(input_name))
-            except Exception:
+        self._profile_index = 1 if self._is_dual_profile else 0
+        for index in range(self.engine.num_io_tensors):
+            input_name = self.engine.get_tensor_name(index)
+            if self.engine.get_tensor_mode(input_name) != trt.TensorIOMode.INPUT:
                 continue
-            if any(d < 0 for d in shape):
-                self._dynamic_inputs.append(input_name)
+            shape = tuple(self.engine.get_tensor_shape(input_name))
+            if any(dim < 0 for dim in shape):
+                self._dynamic_input_shapes[input_name] = _profile_min_shape(
+                    self.engine, input_name, self._profile_index)
         if self._is_dual_profile:
             # Profile 1 = decode (Sq=1). step() always runs single-token, so
             # we lock the context to that profile once and never switch.
@@ -215,14 +231,18 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name == "input_embed":
                 self._has_embed_input = True
-                embed_shape = tuple(self.engine.get_tensor_shape(name))
+                embed_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 embed_bytes = int(np.prod(embed_shape)) * 4
                 self._h_input_embed = np.zeros(embed_shape, dtype=np.float32)
                 err, self._d_input_embed = cudart.cudaMalloc(embed_bytes)
                 _check_cuda(err)
             elif name == "use_input_embed":
-                self._h_use_input_embed = np.zeros((1,), dtype=np.float32)
-                err, self._d_use_input_embed = cudart.cudaMalloc(4)
+                selector_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_use_input_embed = np.zeros(selector_shape, dtype=np.float32)
+                err, self._d_use_input_embed = cudart.cudaMalloc(
+                    self._h_use_input_embed.nbytes)
                 _check_cuda(err)
 
         # DeepStack inputs (auto-detected from engine bindings)
@@ -235,15 +255,19 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name.startswith("deepstack_embed_"):
                 self._deepstack_names.append(name)
-                shape = tuple(self.engine.get_tensor_shape(name))
+                shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 nbytes = int(np.prod(shape)) * 4
                 self._h_deepstack[name] = np.zeros(shape, dtype=np.float32)
                 err, d_ptr = cudart.cudaMalloc(nbytes)
                 _check_cuda(err)
                 self._d_deepstack[name] = d_ptr
             elif name == "deepstack_active":
-                self._h_deepstack_active = np.zeros((1,), dtype=np.float32)
-                err, self._d_deepstack_active = cudart.cudaMalloc(4)
+                active_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_deepstack_active = np.zeros(active_shape, dtype=np.float32)
+                err, self._d_deepstack_active = cudart.cudaMalloc(
+                    self._h_deepstack_active.nbytes)
                 _check_cuda(err)
 
         # Debug output device/host buffers
@@ -333,7 +357,7 @@ class TrtRunner:
                 self._h_input_embed.nbytes, H2D, stream)
             cudart.cudaMemcpyAsync(
                 self._d_use_input_embed, self._h_use_input_embed.ctypes.data,
-                4, H2D, stream)
+                self._h_use_input_embed.nbytes, H2D, stream)
 
         # DeepStack H2D transfers
         if self._deepstack_names:
@@ -352,7 +376,7 @@ class TrtRunner:
                 cudart.cudaMemcpyAsync(
                     self._d_deepstack_active,
                     self._h_deepstack_active.ctypes.data,
-                    4, H2D, stream)
+                    self._h_deepstack_active.nbytes, H2D, stream)
 
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
@@ -381,15 +405,11 @@ class TrtRunner:
         for name in self._debug_output_names:
             self.context.set_tensor_address(name, self._d_debug[name])
 
-        # Dual-profile engines need explicit shapes for the dynamic
-        # inputs every step. step() is single-token decode, so all three
-        # shapes are fixed: Sq=1 and K = max_cache_length + 1.
-        if self._dynamic_inputs:
-            for name in self._dynamic_inputs:
-                if name == "attention_mask":
-                    self.context.set_input_shape(name, (1, attention_window))
-                else:
-                    self.context.set_input_shape(name, (1,))
+        # Dynamic inputs use the selected profile's minimum shapes. Both the
+        # prefill and decode profiles have Sq=1 minima, so this covers token,
+        # mask, image embedding, selector, and DeepStack inputs uniformly.
+        for name, shape in self._dynamic_input_shapes.items():
+            self.context.set_input_shape(name, shape)
 
         # Execute
         self.context.execute_async_v3(stream)
@@ -483,24 +503,16 @@ class TrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask,
-                self._d_logits]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        if self._d_input_embed:
-            bufs.append(self._d_input_embed)
-        if self._d_use_input_embed:
-            bufs.append(self._d_use_input_embed)
-        for d_ptr in self._d_deepstack.values():
-            bufs.append(d_ptr)
-        if self._d_deepstack_active:
-            bufs.append(self._d_deepstack_active)
-        for d_ptr in self._d_debug.values():
-            bufs.append(d_ptr)
+        bufs = []
+        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
+                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+            d_ptr = getattr(self, name, 0)
+            if d_ptr:
+                bufs.append(d_ptr)
+        for name in ("_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v"):
+            bufs.extend(getattr(self, name, []))
+        bufs.extend(getattr(self, "_d_deepstack", {}).values())
+        bufs.extend(getattr(self, "_d_debug", {}).values())
         for d_ptr in bufs:
             cudart.cudaFree(d_ptr)
         if hasattr(self, "stream"):

--- a/python/tensorrt_model_connect/families/internvl/default_decoder.py
+++ b/python/tensorrt_model_connect/families/internvl/default_decoder.py
@@ -115,7 +115,6 @@ def build_standard_decoder_engine(
     # The legacy single-profile graph below stays in place for paths the
     # dual-profile builder does not yet cover:
     #
-    #   - embed_input=True             (VL prefill replacement, Bark sub-engines)
     #   - debug_layer_outputs=True     (per-layer hidden-state dumps)
     #   - hidden_state_output=True     (speech / Bark hidden output)
     #   - config.raw.dynamic_kv_cache  (TriAttention multi-bucket decode)
@@ -124,8 +123,7 @@ def build_standard_decoder_engine(
     # bisects against the legacy graph). It is *not* intended as a
     # supported user-facing flag.
     _dual_profile_disabled_for = (
-        embed_input
-        or debug_layer_outputs
+        debug_layer_outputs
         or hidden_state_output
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
@@ -134,7 +132,14 @@ def build_standard_decoder_engine(
         raise NotImplementedError(
             "split prefill engine is not supported for this standard decoder "
             "configuration")
-    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
+    # Generative VL families are not packaged as split decoder bundles. The engine builder
+    # therefore reaches these families with role="decode" when its global split
+    # default falls back to one engine. Keep VL's one engine dual-profile so
+    # the runtime still receives a sequence-prefill context.
+    vl_single_engine_fallback = embed_input and decoder_engine_role == "decode"
+    if not _dual_profile_disabled_for and (
+        decoder_engine_role in ("dual_profile", "prefill") or vl_single_engine_fallback
+    ):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -147,6 +152,7 @@ def build_standard_decoder_engine(
             interleaved_rope=interleaved_rope,
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
+            embed_input=embed_input,
             verbose=verbose,
             profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )

--- a/python/tensorrt_model_connect/families/internvl/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/internvl/default_dual_profile_decoder.py
@@ -161,6 +161,7 @@ def build_dual_profile_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    embed_input: bool = False,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     profile_mode: str = "dual_profile",
@@ -246,6 +247,13 @@ def build_dual_profile_decoder_engine(
     token_id = network.add_input("token_id", trt.int32, (-1,))
     position_id = network.add_input("position_id", trt.int32, (-1,))
     attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
+    input_embed_tensor = None
+    use_input_embed_tensor = None
+    if embed_input:
+        input_embed_tensor = network.add_input(
+            "input_embed", trt.float32, (-1, hidden))
+        use_input_embed_tensor = network.add_input(
+            "use_input_embed", trt.float32, (-1, 1))
 
     cache_shape: tuple[int, int]
     if multi_bucket_decode:
@@ -285,6 +293,11 @@ def build_dual_profile_decoder_engine(
             (min_sq, max_cache_length + min_sq),
             (opt_sq, max_cache_length + opt_sq),
             (max_sq, max_cache_length + max_sq))
+        if embed_input:
+            prof.set_shape(
+                "input_embed", (min_sq, hidden), (opt_sq, hidden), (max_sq, hidden))
+            prof.set_shape(
+                "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
         if multi_bucket_decode:
             cmn = cache_rows_min if cache_rows_min is not None else 1
             cop = cache_rows_opt if cache_rows_opt is not None else max_cache_length
@@ -408,6 +421,28 @@ def build_dual_profile_decoder_engine(
     # ---- Embedding -------------------------------------------------------
     emb = network.add_gather(embedding_table, token_id, 0)
     hidden_state = emb.get_output(0)  # (Sq, hidden)
+
+    if input_embed_tensor is not None and use_input_embed_tensor is not None:
+        token_embed = hidden_state
+        if token_embed.dtype != work_trt_dtype:
+            token_embed = network.add_cast(token_embed, work_trt_dtype).get_output(0)
+        input_embed = input_embed_tensor
+        if input_embed.dtype != work_trt_dtype:
+            input_embed = network.add_cast(input_embed, work_trt_dtype).get_output(0)
+        embed_selector = use_input_embed_tensor
+        if embed_selector.dtype != work_trt_dtype:
+            embed_selector = network.add_cast(embed_selector, work_trt_dtype).get_output(0)
+        one = _const_in_work_dtype(
+            network, (1, 1), np.array([[1.0]], dtype=work_np_dtype),
+            work_np_dtype, work_trt_dtype)
+        inverse_selector = network.add_elementwise(
+            one, embed_selector, trt.ElementWiseOperation.SUB).get_output(0)
+        token_part = network.add_elementwise(
+            inverse_selector, token_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        embed_part = network.add_elementwise(
+            embed_selector, input_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden_state = network.add_elementwise(
+            token_part, embed_part, trt.ElementWiseOperation.SUM).get_output(0)
 
     if position_type == "learned" and position_embed_table is not None:
         pos_gather = network.add_gather(position_embed_table, position_id, 0)

--- a/python/tensorrt_model_connect/families/internvl/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/internvl/graph_blocks.py
@@ -169,6 +169,7 @@ def add_attention_block(
     interleaved_rope: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
+    sequence_length: int | None = 1,
 ) -> dict[str, trt.ITensor]:
     """Pre-norm -> QKV -> RoPE -> cache concat -> attention -> output proj.
 
@@ -222,11 +223,13 @@ def add_attention_block(
     q_norm = weights.get(f"{prefix}.q_norm")
     if q_norm is not None:
         q = graph_ops.add_rms_norm_per_head(
-            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype)
+            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
     k_norm = weights.get(f"{prefix}.k_norm")
     if k_norm is not None:
         k = graph_ops.add_rms_norm_per_head(
-            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype)
+            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
 
     # ------------------------------------------------------------------ #
     # RoPE via native IRotaryEmbeddingLayer                              #
@@ -243,35 +246,40 @@ def add_attention_block(
         q = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
         k = graph_ops.add_apply_rope_native(
             network, k, num_kv_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
 
     # Save present K/V (before concatenation, this is the raw projection output)
     present_k = k
     present_v = v
 
     # Reshape current K, V for concatenation
-    k_reshape = network.add_shuffle(k)
-    k_reshape.reshape_dims = (1, kv_attention_size)
-    v_reshape = network.add_shuffle(v)
-    v_reshape.reshape_dims = (1, kv_attention_size)
+    current_k = k
+    current_v = v
+    if sequence_length is not None:
+        k_reshape = network.add_shuffle(k)
+        k_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        v_reshape = network.add_shuffle(v)
+        v_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        current_k = k_reshape.get_output(0)
+        current_v = v_reshape.get_output(0)
 
     # Concatenate with cache
     all_k = network.add_concatenation(
-        [cache_k, k_reshape.get_output(0)])
+        [cache_k, current_k])
     all_k.axis = 0
     all_v = network.add_concatenation(
-        [cache_v, v_reshape.get_output(0)])
+        [cache_v, current_v])
     all_v.axis = 0
 
     # ------------------------------------------------------------------ #
     # Attention core — native IAttention or FFI kernel                    #
     # ------------------------------------------------------------------ #
     if use_native_attention:
-        kv_seq = None if dynamic_kv_cache else attention_window
+        kv_seq = None if dynamic_kv_cache or sequence_length is None else attention_window
         if alibi_slopes_tensor is not None:
             if alibi_indices_tensor is None:
                 raise ValueError("ALiBi attention requires cache position indices")
@@ -296,7 +304,7 @@ def add_attention_block(
             num_heads=num_heads,
             head_dim=head_dim,
             num_kv_heads=num_kv_heads,
-            q_seq=1,
+            q_seq=sequence_length,
             kv_seq=kv_seq,
             causal=False,
             mask=mask_4d,

--- a/python/tensorrt_model_connect/families/internvl/graph_ops.py
+++ b/python/tensorrt_model_connect/families/internvl/graph_ops.py
@@ -2630,6 +2630,46 @@ def add_apply_rope_native_from_full_cache(
         sequence_length=sequence_length)
 
 
+def _add_decomposed_attention_core(
+    network: trt.INetworkDefinition,
+    q_4d: trt.ITensor,
+    k_4d: trt.ITensor,
+    v_4d: trt.ITensor,
+    *,
+    mask: trt.ITensor | None,
+    scale: float | None,
+    fp32_accumulation: bool,
+) -> trt.ITensor:
+    """Scaled dot-product attention using primitive TensorRT layers."""
+    output_dtype = q_4d.dtype
+    if fp32_accumulation and output_dtype != trt.float32:
+        q_4d = network.add_cast(q_4d, trt.float32).get_output(0)
+        k_4d = network.add_cast(k_4d, trt.float32).get_output(0)
+        v_4d = network.add_cast(v_4d, trt.float32).get_output(0)
+        if mask is not None and mask.dtype != trt.float32:
+            mask = network.add_cast(mask, trt.float32).get_output(0)
+
+    if scale is None:
+        head_dim = q_4d.shape[-1]
+        scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+    scale_t = _scalar_constant_for_trt_dtype(
+        network, (1, 1, 1, 1), scale, q_4d.dtype)
+    q_scaled = network.add_elementwise(
+        q_4d, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
+    scores = network.add_matrix_multiply(
+        q_scaled, trt.MatrixOperation.NONE,
+        k_4d, trt.MatrixOperation.TRANSPOSE).get_output(0)
+    if mask is not None:
+        scores = network.add_elementwise(
+            scores, mask, trt.ElementWiseOperation.SUM).get_output(0)
+    probs = network.add_softmax(scores)
+    probs.axes = 1 << 3
+    context = network.add_matrix_multiply(
+        probs.get_output(0), trt.MatrixOperation.NONE,
+        v_4d, trt.MatrixOperation.NONE).get_output(0)
+    return _cast_back_to_trt_dtype(network, context, output_dtype)
+
+
 def add_attention_core(
     network: trt.INetworkDefinition,
     q_4d: trt.ITensor,
@@ -2877,6 +2917,14 @@ def add_attention_from_rows(
         tag=None if tag is None else tag + ".v")
     if scale is None:
         scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+    # TensorRT 11.2 can segfault while compiling masked IAttention with
+    # head_dim=128 and dynamic or multi-row queries. Decompose that shape.
+    decompose_masked_attention = (
+        (q_seq != 1 or kv_seq is None)
+        and mask is not None
+        and head_dim == 128
+        and not causal
+    )
     if logit_softcap is not None and float(logit_softcap) > 0.0:
         if causal:
             raise NotImplementedError(
@@ -2885,6 +2933,16 @@ def add_attention_from_rows(
             network, q_4d, k_4d, v_4d,
             num_heads=num_heads, num_kv_heads=kv_heads, head_dim=head_dim,
             mask=mask, scale=scale, logit_softcap=float(logit_softcap))
+    elif decompose_masked_attention:
+        k_4d = _repeat_kv_heads_4d(
+            network, k_4d, num_heads=num_heads, num_kv_heads=kv_heads,
+            head_dim=head_dim)
+        v_4d = _repeat_kv_heads_4d(
+            network, v_4d, num_heads=num_heads, num_kv_heads=kv_heads,
+            head_dim=head_dim)
+        ctx_4d = _add_decomposed_attention_core(
+            network, q_4d, k_4d, v_4d, mask=mask, scale=scale,
+            fp32_accumulation=fp32_accumulation)
     else:
         ctx_4d = add_attention_core(
             network, q_4d, k_4d, v_4d, causal=causal, mask=mask, scale=scale,

--- a/python/tensorrt_model_connect/families/internvl/tp_builder.py
+++ b/python/tensorrt_model_connect/families/internvl/tp_builder.py
@@ -308,6 +308,10 @@ def build_dual_profile_tp_decoder_engine(
         1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     trt_config = builder.create_builder_config()
     trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
+    multi_device_preview = getattr(
+        trt.PreviewFeature, "MULTIDEVICE_RUNTIME_10_16", None)
+    if multi_device_preview is not None:
+        trt_config.set_preview_feature(multi_device_preview, True)
 
     if precision == "fp16":
         work_np_dtype, work_trt_dtype = np.float16, trt.float16
@@ -324,9 +328,9 @@ def build_dual_profile_tp_decoder_engine(
     use_input_embed_tensor = None
     if embed_input:
         input_embed_tensor = network.add_input(
-            "input_embed", work_trt_dtype, (1, hidden))
+            "input_embed", trt.float32, (-1, hidden))
         use_input_embed_tensor = network.add_input(
-            "use_input_embed", trt.float32, (1,))
+            "use_input_embed", trt.float32, (-1, 1))
 
     cache_shape: tuple[int, int]
     if multi_bucket_decode:
@@ -366,6 +370,11 @@ def build_dual_profile_tp_decoder_engine(
             (min_sq, max_cache_length + min_sq),
             (opt_sq, max_cache_length + opt_sq),
             (max_sq, max_cache_length + max_sq))
+        if embed_input:
+            prof.set_shape(
+                "input_embed", (min_sq, hidden), (opt_sq, hidden), (max_sq, hidden))
+            prof.set_shape(
+                "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
         if multi_bucket_decode:
             cmn = cache_rows_min if cache_rows_min is not None else 1
             cop = cache_rows_opt if cache_rows_opt is not None else max_cache_length
@@ -465,22 +474,25 @@ def build_dual_profile_tp_decoder_engine(
     hidden_state = emb.get_output(0)  # (Sq, hidden)
 
     if embed_input and input_embed_tensor is not None and use_input_embed_tensor is not None:
-        flag_broadcast = network.add_shuffle(use_input_embed_tensor)
-        flag_broadcast.reshape_dims = (1, 1)
-        flag_for_math = flag_broadcast.get_output(0)
-        if work_trt_dtype != trt.float32:
-            flag_for_math = network.add_cast(flag_for_math, work_trt_dtype).get_output(0)
-        one_const = graph_ops.add_constant(
-            network, (1, 1), np.array([1.0], dtype=work_np_dtype),
-            dtype=work_np_dtype)
+        token_embed = hidden_state
+        if token_embed.dtype != work_trt_dtype:
+            token_embed = network.add_cast(token_embed, work_trt_dtype).get_output(0)
+        input_embed = input_embed_tensor
+        if input_embed.dtype != work_trt_dtype:
+            input_embed = network.add_cast(input_embed, work_trt_dtype).get_output(0)
+        embed_selector = use_input_embed_tensor
+        if embed_selector.dtype != work_trt_dtype:
+            embed_selector = network.add_cast(embed_selector, work_trt_dtype).get_output(0)
+        one_const = _const_in_work_dtype(
+            network, (1, 1), np.array([[1.0]], dtype=work_np_dtype),
+            work_np_dtype, work_trt_dtype)
         inv_flag = network.add_elementwise(
-            one_const, flag_for_math,
-            trt.ElementWiseOperation.SUB)
+            one_const, embed_selector, trt.ElementWiseOperation.SUB)
         tok_part = network.add_elementwise(
-            inv_flag.get_output(0), hidden_state,
+            inv_flag.get_output(0), token_embed,
             trt.ElementWiseOperation.PROD)
         embed_part = network.add_elementwise(
-            flag_for_math, input_embed_tensor,
+            embed_selector, input_embed,
             trt.ElementWiseOperation.PROD)
         hidden_state_sum = network.add_elementwise(
             tok_part.get_output(0), embed_part.get_output(0),

--- a/python/tensorrt_model_connect/families/internvl/vl_debug_runner.py
+++ b/python/tensorrt_model_connect/families/internvl/vl_debug_runner.py
@@ -63,6 +63,20 @@ def _require_trt_runtime() -> None:
         raise ImportError("cuda-python is required for VL debug runner execution")
 
 
+def _profile_min_shape(engine: Any, name: str, profile_index: int) -> tuple[int, ...]:
+    """Resolve a concrete single-step shape for a possibly dynamic tensor."""
+    declared = tuple(int(dim) for dim in engine.get_tensor_shape(name))
+    if all(dim >= 0 for dim in declared):
+        return declared
+    profile_shapes = engine.get_tensor_profile_shape(name, profile_index)
+    if not profile_shapes:
+        raise RuntimeError(f"Missing optimization profile shape for {name!r}")
+    resolved = tuple(int(dim) for dim in profile_shapes[0])
+    if any(dim < 0 for dim in resolved):
+        raise RuntimeError(f"Invalid optimization profile shape for {name!r}: {resolved}")
+    return resolved
+
+
 class TrtRunner:
     """Device-resident TRT inference runner for debugging and diff testing.
 
@@ -106,17 +120,19 @@ class TrtRunner:
         # decode profile (profile 1, Sq=1). For per-step decode runs the
         # debug_runner must select the decode profile and call
         # set_input_shape on every dynamic input before each execute. We
-        # detect dual-profile via num_optimization_profiles > 1 and the
-        # presence of -1 dims on token_id / position_id / attention_mask.
-        self._dynamic_inputs: list[str] = []
+        # detect dual-profile via num_optimization_profiles > 1 and resolve
+        # every dynamic input from the selected profile's minimum shape.
+        self._dynamic_input_shapes: dict[str, tuple[int, ...]] = {}
         self._is_dual_profile = self.engine.num_optimization_profiles > 1
-        for input_name in ("token_id", "position_id", "attention_mask"):
-            try:
-                shape = tuple(self.engine.get_tensor_shape(input_name))
-            except Exception:
+        self._profile_index = 1 if self._is_dual_profile else 0
+        for index in range(self.engine.num_io_tensors):
+            input_name = self.engine.get_tensor_name(index)
+            if self.engine.get_tensor_mode(input_name) != trt.TensorIOMode.INPUT:
                 continue
-            if any(d < 0 for d in shape):
-                self._dynamic_inputs.append(input_name)
+            shape = tuple(self.engine.get_tensor_shape(input_name))
+            if any(dim < 0 for dim in shape):
+                self._dynamic_input_shapes[input_name] = _profile_min_shape(
+                    self.engine, input_name, self._profile_index)
         if self._is_dual_profile:
             # Profile 1 = decode (Sq=1). step() always runs single-token, so
             # we lock the context to that profile once and never switch.
@@ -215,14 +231,18 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name == "input_embed":
                 self._has_embed_input = True
-                embed_shape = tuple(self.engine.get_tensor_shape(name))
+                embed_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 embed_bytes = int(np.prod(embed_shape)) * 4
                 self._h_input_embed = np.zeros(embed_shape, dtype=np.float32)
                 err, self._d_input_embed = cudart.cudaMalloc(embed_bytes)
                 _check_cuda(err)
             elif name == "use_input_embed":
-                self._h_use_input_embed = np.zeros((1,), dtype=np.float32)
-                err, self._d_use_input_embed = cudart.cudaMalloc(4)
+                selector_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_use_input_embed = np.zeros(selector_shape, dtype=np.float32)
+                err, self._d_use_input_embed = cudart.cudaMalloc(
+                    self._h_use_input_embed.nbytes)
                 _check_cuda(err)
 
         # DeepStack inputs (auto-detected from engine bindings)
@@ -235,15 +255,19 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name.startswith("deepstack_embed_"):
                 self._deepstack_names.append(name)
-                shape = tuple(self.engine.get_tensor_shape(name))
+                shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 nbytes = int(np.prod(shape)) * 4
                 self._h_deepstack[name] = np.zeros(shape, dtype=np.float32)
                 err, d_ptr = cudart.cudaMalloc(nbytes)
                 _check_cuda(err)
                 self._d_deepstack[name] = d_ptr
             elif name == "deepstack_active":
-                self._h_deepstack_active = np.zeros((1,), dtype=np.float32)
-                err, self._d_deepstack_active = cudart.cudaMalloc(4)
+                active_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_deepstack_active = np.zeros(active_shape, dtype=np.float32)
+                err, self._d_deepstack_active = cudart.cudaMalloc(
+                    self._h_deepstack_active.nbytes)
                 _check_cuda(err)
 
         # Debug output device/host buffers
@@ -333,7 +357,7 @@ class TrtRunner:
                 self._h_input_embed.nbytes, H2D, stream)
             cudart.cudaMemcpyAsync(
                 self._d_use_input_embed, self._h_use_input_embed.ctypes.data,
-                4, H2D, stream)
+                self._h_use_input_embed.nbytes, H2D, stream)
 
         # DeepStack H2D transfers
         if self._deepstack_names:
@@ -352,7 +376,7 @@ class TrtRunner:
                 cudart.cudaMemcpyAsync(
                     self._d_deepstack_active,
                     self._h_deepstack_active.ctypes.data,
-                    4, H2D, stream)
+                    self._h_deepstack_active.nbytes, H2D, stream)
 
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
@@ -381,15 +405,11 @@ class TrtRunner:
         for name in self._debug_output_names:
             self.context.set_tensor_address(name, self._d_debug[name])
 
-        # Dual-profile engines need explicit shapes for the dynamic
-        # inputs every step. step() is single-token decode, so all three
-        # shapes are fixed: Sq=1 and K = max_cache_length + 1.
-        if self._dynamic_inputs:
-            for name in self._dynamic_inputs:
-                if name == "attention_mask":
-                    self.context.set_input_shape(name, (1, attention_window))
-                else:
-                    self.context.set_input_shape(name, (1,))
+        # Dynamic inputs use the selected profile's minimum shapes. Both the
+        # prefill and decode profiles have Sq=1 minima, so this covers token,
+        # mask, image embedding, selector, and DeepStack inputs uniformly.
+        for name, shape in self._dynamic_input_shapes.items():
+            self.context.set_input_shape(name, shape)
 
         # Execute
         self.context.execute_async_v3(stream)
@@ -483,24 +503,16 @@ class TrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask,
-                self._d_logits]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        if self._d_input_embed:
-            bufs.append(self._d_input_embed)
-        if self._d_use_input_embed:
-            bufs.append(self._d_use_input_embed)
-        for d_ptr in self._d_deepstack.values():
-            bufs.append(d_ptr)
-        if self._d_deepstack_active:
-            bufs.append(self._d_deepstack_active)
-        for d_ptr in self._d_debug.values():
-            bufs.append(d_ptr)
+        bufs = []
+        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
+                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+            d_ptr = getattr(self, name, 0)
+            if d_ptr:
+                bufs.append(d_ptr)
+        for name in ("_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v"):
+            bufs.extend(getattr(self, name, []))
+        bufs.extend(getattr(self, "_d_deepstack", {}).values())
+        bufs.extend(getattr(self, "_d_debug", {}).values())
         for d_ptr in bufs:
             cudart.cudaFree(d_ptr)
         if hasattr(self, "stream"):

--- a/python/tensorrt_model_connect/families/lance/default_decoder.py
+++ b/python/tensorrt_model_connect/families/lance/default_decoder.py
@@ -115,7 +115,6 @@ def build_standard_decoder_engine(
     # The legacy single-profile graph below stays in place for paths the
     # dual-profile builder does not yet cover:
     #
-    #   - embed_input=True             (VL prefill replacement, Bark sub-engines)
     #   - debug_layer_outputs=True     (per-layer hidden-state dumps)
     #   - hidden_state_output=True     (speech / Bark hidden output)
     #   - config.raw.dynamic_kv_cache  (TriAttention multi-bucket decode)
@@ -124,8 +123,7 @@ def build_standard_decoder_engine(
     # bisects against the legacy graph). It is *not* intended as a
     # supported user-facing flag.
     _dual_profile_disabled_for = (
-        embed_input
-        or debug_layer_outputs
+        debug_layer_outputs
         or hidden_state_output
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
@@ -134,7 +132,14 @@ def build_standard_decoder_engine(
         raise NotImplementedError(
             "split prefill engine is not supported for this standard decoder "
             "configuration")
-    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
+    # Generative VL families are not packaged as split decoder bundles. The engine builder
+    # therefore reaches these families with role="decode" when its global split
+    # default falls back to one engine. Keep VL's one engine dual-profile so
+    # the runtime still receives a sequence-prefill context.
+    vl_single_engine_fallback = embed_input and decoder_engine_role == "decode"
+    if not _dual_profile_disabled_for and (
+        decoder_engine_role in ("dual_profile", "prefill") or vl_single_engine_fallback
+    ):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -147,6 +152,7 @@ def build_standard_decoder_engine(
             interleaved_rope=interleaved_rope,
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
+            embed_input=embed_input,
             verbose=verbose,
             profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )

--- a/python/tensorrt_model_connect/families/lance/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/lance/default_dual_profile_decoder.py
@@ -161,6 +161,7 @@ def build_dual_profile_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    embed_input: bool = False,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     profile_mode: str = "dual_profile",
@@ -246,6 +247,13 @@ def build_dual_profile_decoder_engine(
     token_id = network.add_input("token_id", trt.int32, (-1,))
     position_id = network.add_input("position_id", trt.int32, (-1,))
     attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
+    input_embed_tensor = None
+    use_input_embed_tensor = None
+    if embed_input:
+        input_embed_tensor = network.add_input(
+            "input_embed", trt.float32, (-1, hidden))
+        use_input_embed_tensor = network.add_input(
+            "use_input_embed", trt.float32, (-1, 1))
 
     cache_shape: tuple[int, int]
     if multi_bucket_decode:
@@ -285,6 +293,11 @@ def build_dual_profile_decoder_engine(
             (min_sq, max_cache_length + min_sq),
             (opt_sq, max_cache_length + opt_sq),
             (max_sq, max_cache_length + max_sq))
+        if embed_input:
+            prof.set_shape(
+                "input_embed", (min_sq, hidden), (opt_sq, hidden), (max_sq, hidden))
+            prof.set_shape(
+                "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
         if multi_bucket_decode:
             cmn = cache_rows_min if cache_rows_min is not None else 1
             cop = cache_rows_opt if cache_rows_opt is not None else max_cache_length
@@ -408,6 +421,28 @@ def build_dual_profile_decoder_engine(
     # ---- Embedding -------------------------------------------------------
     emb = network.add_gather(embedding_table, token_id, 0)
     hidden_state = emb.get_output(0)  # (Sq, hidden)
+
+    if input_embed_tensor is not None and use_input_embed_tensor is not None:
+        token_embed = hidden_state
+        if token_embed.dtype != work_trt_dtype:
+            token_embed = network.add_cast(token_embed, work_trt_dtype).get_output(0)
+        input_embed = input_embed_tensor
+        if input_embed.dtype != work_trt_dtype:
+            input_embed = network.add_cast(input_embed, work_trt_dtype).get_output(0)
+        embed_selector = use_input_embed_tensor
+        if embed_selector.dtype != work_trt_dtype:
+            embed_selector = network.add_cast(embed_selector, work_trt_dtype).get_output(0)
+        one = _const_in_work_dtype(
+            network, (1, 1), np.array([[1.0]], dtype=work_np_dtype),
+            work_np_dtype, work_trt_dtype)
+        inverse_selector = network.add_elementwise(
+            one, embed_selector, trt.ElementWiseOperation.SUB).get_output(0)
+        token_part = network.add_elementwise(
+            inverse_selector, token_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        embed_part = network.add_elementwise(
+            embed_selector, input_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden_state = network.add_elementwise(
+            token_part, embed_part, trt.ElementWiseOperation.SUM).get_output(0)
 
     if position_type == "learned" and position_embed_table is not None:
         pos_gather = network.add_gather(position_embed_table, position_id, 0)

--- a/python/tensorrt_model_connect/families/lance/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/lance/graph_blocks.py
@@ -169,6 +169,7 @@ def add_attention_block(
     interleaved_rope: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
+    sequence_length: int | None = 1,
 ) -> dict[str, trt.ITensor]:
     """Pre-norm -> QKV -> RoPE -> cache concat -> attention -> output proj.
 
@@ -222,11 +223,13 @@ def add_attention_block(
     q_norm = weights.get(f"{prefix}.q_norm")
     if q_norm is not None:
         q = graph_ops.add_rms_norm_per_head(
-            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype)
+            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
     k_norm = weights.get(f"{prefix}.k_norm")
     if k_norm is not None:
         k = graph_ops.add_rms_norm_per_head(
-            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype)
+            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
 
     # ------------------------------------------------------------------ #
     # RoPE via native IRotaryEmbeddingLayer                              #
@@ -243,35 +246,40 @@ def add_attention_block(
         q = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
         k = graph_ops.add_apply_rope_native(
             network, k, num_kv_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
 
     # Save present K/V (before concatenation, this is the raw projection output)
     present_k = k
     present_v = v
 
     # Reshape current K, V for concatenation
-    k_reshape = network.add_shuffle(k)
-    k_reshape.reshape_dims = (1, kv_attention_size)
-    v_reshape = network.add_shuffle(v)
-    v_reshape.reshape_dims = (1, kv_attention_size)
+    current_k = k
+    current_v = v
+    if sequence_length is not None:
+        k_reshape = network.add_shuffle(k)
+        k_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        v_reshape = network.add_shuffle(v)
+        v_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        current_k = k_reshape.get_output(0)
+        current_v = v_reshape.get_output(0)
 
     # Concatenate with cache
     all_k = network.add_concatenation(
-        [cache_k, k_reshape.get_output(0)])
+        [cache_k, current_k])
     all_k.axis = 0
     all_v = network.add_concatenation(
-        [cache_v, v_reshape.get_output(0)])
+        [cache_v, current_v])
     all_v.axis = 0
 
     # ------------------------------------------------------------------ #
     # Attention core — native IAttention or FFI kernel                    #
     # ------------------------------------------------------------------ #
     if use_native_attention:
-        kv_seq = None if dynamic_kv_cache else attention_window
+        kv_seq = None if dynamic_kv_cache or sequence_length is None else attention_window
         if alibi_slopes_tensor is not None:
             if alibi_indices_tensor is None:
                 raise ValueError("ALiBi attention requires cache position indices")
@@ -296,7 +304,7 @@ def add_attention_block(
             num_heads=num_heads,
             head_dim=head_dim,
             num_kv_heads=num_kv_heads,
-            q_seq=1,
+            q_seq=sequence_length,
             kv_seq=kv_seq,
             causal=False,
             mask=mask_4d,

--- a/python/tensorrt_model_connect/families/lance/graph_ops.py
+++ b/python/tensorrt_model_connect/families/lance/graph_ops.py
@@ -2630,6 +2630,46 @@ def add_apply_rope_native_from_full_cache(
         sequence_length=sequence_length)
 
 
+def _add_decomposed_attention_core(
+    network: trt.INetworkDefinition,
+    q_4d: trt.ITensor,
+    k_4d: trt.ITensor,
+    v_4d: trt.ITensor,
+    *,
+    mask: trt.ITensor | None,
+    scale: float | None,
+    fp32_accumulation: bool,
+) -> trt.ITensor:
+    """Scaled dot-product attention using primitive TensorRT layers."""
+    output_dtype = q_4d.dtype
+    if fp32_accumulation and output_dtype != trt.float32:
+        q_4d = network.add_cast(q_4d, trt.float32).get_output(0)
+        k_4d = network.add_cast(k_4d, trt.float32).get_output(0)
+        v_4d = network.add_cast(v_4d, trt.float32).get_output(0)
+        if mask is not None and mask.dtype != trt.float32:
+            mask = network.add_cast(mask, trt.float32).get_output(0)
+
+    if scale is None:
+        head_dim = q_4d.shape[-1]
+        scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+    scale_t = _scalar_constant_for_trt_dtype(
+        network, (1, 1, 1, 1), scale, q_4d.dtype)
+    q_scaled = network.add_elementwise(
+        q_4d, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
+    scores = network.add_matrix_multiply(
+        q_scaled, trt.MatrixOperation.NONE,
+        k_4d, trt.MatrixOperation.TRANSPOSE).get_output(0)
+    if mask is not None:
+        scores = network.add_elementwise(
+            scores, mask, trt.ElementWiseOperation.SUM).get_output(0)
+    probs = network.add_softmax(scores)
+    probs.axes = 1 << 3
+    context = network.add_matrix_multiply(
+        probs.get_output(0), trt.MatrixOperation.NONE,
+        v_4d, trt.MatrixOperation.NONE).get_output(0)
+    return _cast_back_to_trt_dtype(network, context, output_dtype)
+
+
 def add_attention_core(
     network: trt.INetworkDefinition,
     q_4d: trt.ITensor,
@@ -2877,6 +2917,14 @@ def add_attention_from_rows(
         tag=None if tag is None else tag + ".v")
     if scale is None:
         scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+    # TensorRT 11.2 can segfault while compiling masked IAttention with
+    # head_dim=128 and dynamic or multi-row queries. Decompose that shape.
+    decompose_masked_attention = (
+        (q_seq != 1 or kv_seq is None)
+        and mask is not None
+        and head_dim == 128
+        and not causal
+    )
     if logit_softcap is not None and float(logit_softcap) > 0.0:
         if causal:
             raise NotImplementedError(
@@ -2885,6 +2933,16 @@ def add_attention_from_rows(
             network, q_4d, k_4d, v_4d,
             num_heads=num_heads, num_kv_heads=kv_heads, head_dim=head_dim,
             mask=mask, scale=scale, logit_softcap=float(logit_softcap))
+    elif decompose_masked_attention:
+        k_4d = _repeat_kv_heads_4d(
+            network, k_4d, num_heads=num_heads, num_kv_heads=kv_heads,
+            head_dim=head_dim)
+        v_4d = _repeat_kv_heads_4d(
+            network, v_4d, num_heads=num_heads, num_kv_heads=kv_heads,
+            head_dim=head_dim)
+        ctx_4d = _add_decomposed_attention_core(
+            network, q_4d, k_4d, v_4d, mask=mask, scale=scale,
+            fp32_accumulation=fp32_accumulation)
     else:
         ctx_4d = add_attention_core(
             network, q_4d, k_4d, v_4d, causal=causal, mask=mask, scale=scale,

--- a/python/tensorrt_model_connect/families/lance/vl_debug_runner.py
+++ b/python/tensorrt_model_connect/families/lance/vl_debug_runner.py
@@ -63,6 +63,20 @@ def _require_trt_runtime() -> None:
         raise ImportError("cuda-python is required for VL debug runner execution")
 
 
+def _profile_min_shape(engine: Any, name: str, profile_index: int) -> tuple[int, ...]:
+    """Resolve a concrete single-step shape for a possibly dynamic tensor."""
+    declared = tuple(int(dim) for dim in engine.get_tensor_shape(name))
+    if all(dim >= 0 for dim in declared):
+        return declared
+    profile_shapes = engine.get_tensor_profile_shape(name, profile_index)
+    if not profile_shapes:
+        raise RuntimeError(f"Missing optimization profile shape for {name!r}")
+    resolved = tuple(int(dim) for dim in profile_shapes[0])
+    if any(dim < 0 for dim in resolved):
+        raise RuntimeError(f"Invalid optimization profile shape for {name!r}: {resolved}")
+    return resolved
+
+
 class TrtRunner:
     """Device-resident TRT inference runner for debugging and diff testing.
 
@@ -106,17 +120,19 @@ class TrtRunner:
         # decode profile (profile 1, Sq=1). For per-step decode runs the
         # debug_runner must select the decode profile and call
         # set_input_shape on every dynamic input before each execute. We
-        # detect dual-profile via num_optimization_profiles > 1 and the
-        # presence of -1 dims on token_id / position_id / attention_mask.
-        self._dynamic_inputs: list[str] = []
+        # detect dual-profile via num_optimization_profiles > 1 and resolve
+        # every dynamic input from the selected profile's minimum shape.
+        self._dynamic_input_shapes: dict[str, tuple[int, ...]] = {}
         self._is_dual_profile = self.engine.num_optimization_profiles > 1
-        for input_name in ("token_id", "position_id", "attention_mask"):
-            try:
-                shape = tuple(self.engine.get_tensor_shape(input_name))
-            except Exception:
+        self._profile_index = 1 if self._is_dual_profile else 0
+        for index in range(self.engine.num_io_tensors):
+            input_name = self.engine.get_tensor_name(index)
+            if self.engine.get_tensor_mode(input_name) != trt.TensorIOMode.INPUT:
                 continue
-            if any(d < 0 for d in shape):
-                self._dynamic_inputs.append(input_name)
+            shape = tuple(self.engine.get_tensor_shape(input_name))
+            if any(dim < 0 for dim in shape):
+                self._dynamic_input_shapes[input_name] = _profile_min_shape(
+                    self.engine, input_name, self._profile_index)
         if self._is_dual_profile:
             # Profile 1 = decode (Sq=1). step() always runs single-token, so
             # we lock the context to that profile once and never switch.
@@ -215,14 +231,18 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name == "input_embed":
                 self._has_embed_input = True
-                embed_shape = tuple(self.engine.get_tensor_shape(name))
+                embed_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 embed_bytes = int(np.prod(embed_shape)) * 4
                 self._h_input_embed = np.zeros(embed_shape, dtype=np.float32)
                 err, self._d_input_embed = cudart.cudaMalloc(embed_bytes)
                 _check_cuda(err)
             elif name == "use_input_embed":
-                self._h_use_input_embed = np.zeros((1,), dtype=np.float32)
-                err, self._d_use_input_embed = cudart.cudaMalloc(4)
+                selector_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_use_input_embed = np.zeros(selector_shape, dtype=np.float32)
+                err, self._d_use_input_embed = cudart.cudaMalloc(
+                    self._h_use_input_embed.nbytes)
                 _check_cuda(err)
 
         # DeepStack inputs (auto-detected from engine bindings)
@@ -235,15 +255,19 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name.startswith("deepstack_embed_"):
                 self._deepstack_names.append(name)
-                shape = tuple(self.engine.get_tensor_shape(name))
+                shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 nbytes = int(np.prod(shape)) * 4
                 self._h_deepstack[name] = np.zeros(shape, dtype=np.float32)
                 err, d_ptr = cudart.cudaMalloc(nbytes)
                 _check_cuda(err)
                 self._d_deepstack[name] = d_ptr
             elif name == "deepstack_active":
-                self._h_deepstack_active = np.zeros((1,), dtype=np.float32)
-                err, self._d_deepstack_active = cudart.cudaMalloc(4)
+                active_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_deepstack_active = np.zeros(active_shape, dtype=np.float32)
+                err, self._d_deepstack_active = cudart.cudaMalloc(
+                    self._h_deepstack_active.nbytes)
                 _check_cuda(err)
 
         # Debug output device/host buffers
@@ -333,7 +357,7 @@ class TrtRunner:
                 self._h_input_embed.nbytes, H2D, stream)
             cudart.cudaMemcpyAsync(
                 self._d_use_input_embed, self._h_use_input_embed.ctypes.data,
-                4, H2D, stream)
+                self._h_use_input_embed.nbytes, H2D, stream)
 
         # DeepStack H2D transfers
         if self._deepstack_names:
@@ -352,7 +376,7 @@ class TrtRunner:
                 cudart.cudaMemcpyAsync(
                     self._d_deepstack_active,
                     self._h_deepstack_active.ctypes.data,
-                    4, H2D, stream)
+                    self._h_deepstack_active.nbytes, H2D, stream)
 
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
@@ -381,15 +405,11 @@ class TrtRunner:
         for name in self._debug_output_names:
             self.context.set_tensor_address(name, self._d_debug[name])
 
-        # Dual-profile engines need explicit shapes for the dynamic
-        # inputs every step. step() is single-token decode, so all three
-        # shapes are fixed: Sq=1 and K = max_cache_length + 1.
-        if self._dynamic_inputs:
-            for name in self._dynamic_inputs:
-                if name == "attention_mask":
-                    self.context.set_input_shape(name, (1, attention_window))
-                else:
-                    self.context.set_input_shape(name, (1,))
+        # Dynamic inputs use the selected profile's minimum shapes. Both the
+        # prefill and decode profiles have Sq=1 minima, so this covers token,
+        # mask, image embedding, selector, and DeepStack inputs uniformly.
+        for name, shape in self._dynamic_input_shapes.items():
+            self.context.set_input_shape(name, shape)
 
         # Execute
         self.context.execute_async_v3(stream)
@@ -483,24 +503,16 @@ class TrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask,
-                self._d_logits]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        if self._d_input_embed:
-            bufs.append(self._d_input_embed)
-        if self._d_use_input_embed:
-            bufs.append(self._d_use_input_embed)
-        for d_ptr in self._d_deepstack.values():
-            bufs.append(d_ptr)
-        if self._d_deepstack_active:
-            bufs.append(self._d_deepstack_active)
-        for d_ptr in self._d_debug.values():
-            bufs.append(d_ptr)
+        bufs = []
+        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
+                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+            d_ptr = getattr(self, name, 0)
+            if d_ptr:
+                bufs.append(d_ptr)
+        for name in ("_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v"):
+            bufs.extend(getattr(self, name, []))
+        bufs.extend(getattr(self, "_d_deepstack", {}).values())
+        bufs.extend(getattr(self, "_d_debug", {}).values())
         for d_ptr in bufs:
             cudart.cudaFree(d_ptr)
         if hasattr(self, "stream"):

--- a/python/tensorrt_model_connect/families/locateanything/default_decoder.py
+++ b/python/tensorrt_model_connect/families/locateanything/default_decoder.py
@@ -115,7 +115,6 @@ def build_standard_decoder_engine(
     # The legacy single-profile graph below stays in place for paths the
     # dual-profile builder does not yet cover:
     #
-    #   - embed_input=True             (VL prefill replacement, Bark sub-engines)
     #   - debug_layer_outputs=True     (per-layer hidden-state dumps)
     #   - hidden_state_output=True     (speech / Bark hidden output)
     #   - config.raw.dynamic_kv_cache  (TriAttention multi-bucket decode)
@@ -124,8 +123,7 @@ def build_standard_decoder_engine(
     # bisects against the legacy graph). It is *not* intended as a
     # supported user-facing flag.
     _dual_profile_disabled_for = (
-        embed_input
-        or debug_layer_outputs
+        debug_layer_outputs
         or hidden_state_output
         or bool(config.raw.get("dynamic_kv_cache", False))
         or _os.environ.get("TRTMC_NO_DUAL_PROFILE") == "1"
@@ -134,7 +132,14 @@ def build_standard_decoder_engine(
         raise NotImplementedError(
             "split prefill engine is not supported for this standard decoder "
             "configuration")
-    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
+    # Generative VL families are not packaged as split decoder bundles. The engine builder
+    # therefore reaches these families with role="decode" when its global split
+    # default falls back to one engine. Keep VL's one engine dual-profile so
+    # the runtime still receives a sequence-prefill context.
+    vl_single_engine_fallback = embed_input and decoder_engine_role == "decode"
+    if not _dual_profile_disabled_for and (
+        decoder_engine_role in ("dual_profile", "prefill") or vl_single_engine_fallback
+    ):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -147,6 +152,7 @@ def build_standard_decoder_engine(
             interleaved_rope=interleaved_rope,
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
+            embed_input=embed_input,
             verbose=verbose,
             profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )

--- a/python/tensorrt_model_connect/families/locateanything/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/locateanything/default_dual_profile_decoder.py
@@ -161,6 +161,7 @@ def build_dual_profile_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    embed_input: bool = False,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     profile_mode: str = "dual_profile",
@@ -246,6 +247,13 @@ def build_dual_profile_decoder_engine(
     token_id = network.add_input("token_id", trt.int32, (-1,))
     position_id = network.add_input("position_id", trt.int32, (-1,))
     attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
+    input_embed_tensor = None
+    use_input_embed_tensor = None
+    if embed_input:
+        input_embed_tensor = network.add_input(
+            "input_embed", trt.float32, (-1, hidden))
+        use_input_embed_tensor = network.add_input(
+            "use_input_embed", trt.float32, (-1, 1))
 
     cache_shape: tuple[int, int]
     if multi_bucket_decode:
@@ -285,6 +293,11 @@ def build_dual_profile_decoder_engine(
             (min_sq, max_cache_length + min_sq),
             (opt_sq, max_cache_length + opt_sq),
             (max_sq, max_cache_length + max_sq))
+        if embed_input:
+            prof.set_shape(
+                "input_embed", (min_sq, hidden), (opt_sq, hidden), (max_sq, hidden))
+            prof.set_shape(
+                "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
         if multi_bucket_decode:
             cmn = cache_rows_min if cache_rows_min is not None else 1
             cop = cache_rows_opt if cache_rows_opt is not None else max_cache_length
@@ -408,6 +421,28 @@ def build_dual_profile_decoder_engine(
     # ---- Embedding -------------------------------------------------------
     emb = network.add_gather(embedding_table, token_id, 0)
     hidden_state = emb.get_output(0)  # (Sq, hidden)
+
+    if input_embed_tensor is not None and use_input_embed_tensor is not None:
+        token_embed = hidden_state
+        if token_embed.dtype != work_trt_dtype:
+            token_embed = network.add_cast(token_embed, work_trt_dtype).get_output(0)
+        input_embed = input_embed_tensor
+        if input_embed.dtype != work_trt_dtype:
+            input_embed = network.add_cast(input_embed, work_trt_dtype).get_output(0)
+        embed_selector = use_input_embed_tensor
+        if embed_selector.dtype != work_trt_dtype:
+            embed_selector = network.add_cast(embed_selector, work_trt_dtype).get_output(0)
+        one = _const_in_work_dtype(
+            network, (1, 1), np.array([[1.0]], dtype=work_np_dtype),
+            work_np_dtype, work_trt_dtype)
+        inverse_selector = network.add_elementwise(
+            one, embed_selector, trt.ElementWiseOperation.SUB).get_output(0)
+        token_part = network.add_elementwise(
+            inverse_selector, token_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        embed_part = network.add_elementwise(
+            embed_selector, input_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden_state = network.add_elementwise(
+            token_part, embed_part, trt.ElementWiseOperation.SUM).get_output(0)
 
     if position_type == "learned" and position_embed_table is not None:
         pos_gather = network.add_gather(position_embed_table, position_id, 0)

--- a/python/tensorrt_model_connect/families/locateanything/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/locateanything/graph_blocks.py
@@ -169,6 +169,7 @@ def add_attention_block(
     interleaved_rope: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
+    sequence_length: int | None = 1,
 ) -> dict[str, trt.ITensor]:
     """Pre-norm -> QKV -> RoPE -> cache concat -> attention -> output proj.
 
@@ -222,11 +223,13 @@ def add_attention_block(
     q_norm = weights.get(f"{prefix}.q_norm")
     if q_norm is not None:
         q = graph_ops.add_rms_norm_per_head(
-            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype)
+            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
     k_norm = weights.get(f"{prefix}.k_norm")
     if k_norm is not None:
         k = graph_ops.add_rms_norm_per_head(
-            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype)
+            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
 
     # ------------------------------------------------------------------ #
     # RoPE via native IRotaryEmbeddingLayer                              #
@@ -243,35 +246,40 @@ def add_attention_block(
         q = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
         k = graph_ops.add_apply_rope_native(
             network, k, num_kv_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
 
     # Save present K/V (before concatenation, this is the raw projection output)
     present_k = k
     present_v = v
 
     # Reshape current K, V for concatenation
-    k_reshape = network.add_shuffle(k)
-    k_reshape.reshape_dims = (1, kv_attention_size)
-    v_reshape = network.add_shuffle(v)
-    v_reshape.reshape_dims = (1, kv_attention_size)
+    current_k = k
+    current_v = v
+    if sequence_length is not None:
+        k_reshape = network.add_shuffle(k)
+        k_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        v_reshape = network.add_shuffle(v)
+        v_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        current_k = k_reshape.get_output(0)
+        current_v = v_reshape.get_output(0)
 
     # Concatenate with cache
     all_k = network.add_concatenation(
-        [cache_k, k_reshape.get_output(0)])
+        [cache_k, current_k])
     all_k.axis = 0
     all_v = network.add_concatenation(
-        [cache_v, v_reshape.get_output(0)])
+        [cache_v, current_v])
     all_v.axis = 0
 
     # ------------------------------------------------------------------ #
     # Attention core — native IAttention or FFI kernel                    #
     # ------------------------------------------------------------------ #
     if use_native_attention:
-        kv_seq = None if dynamic_kv_cache else attention_window
+        kv_seq = None if dynamic_kv_cache or sequence_length is None else attention_window
         if alibi_slopes_tensor is not None:
             if alibi_indices_tensor is None:
                 raise ValueError("ALiBi attention requires cache position indices")
@@ -296,7 +304,7 @@ def add_attention_block(
             num_heads=num_heads,
             head_dim=head_dim,
             num_kv_heads=num_kv_heads,
-            q_seq=1,
+            q_seq=sequence_length,
             kv_seq=kv_seq,
             causal=False,
             mask=mask_4d,

--- a/python/tensorrt_model_connect/families/locateanything/graph_ops.py
+++ b/python/tensorrt_model_connect/families/locateanything/graph_ops.py
@@ -2630,6 +2630,46 @@ def add_apply_rope_native_from_full_cache(
         sequence_length=sequence_length)
 
 
+def _add_decomposed_attention_core(
+    network: trt.INetworkDefinition,
+    q_4d: trt.ITensor,
+    k_4d: trt.ITensor,
+    v_4d: trt.ITensor,
+    *,
+    mask: trt.ITensor | None,
+    scale: float | None,
+    fp32_accumulation: bool,
+) -> trt.ITensor:
+    """Scaled dot-product attention using primitive TensorRT layers."""
+    output_dtype = q_4d.dtype
+    if fp32_accumulation and output_dtype != trt.float32:
+        q_4d = network.add_cast(q_4d, trt.float32).get_output(0)
+        k_4d = network.add_cast(k_4d, trt.float32).get_output(0)
+        v_4d = network.add_cast(v_4d, trt.float32).get_output(0)
+        if mask is not None and mask.dtype != trt.float32:
+            mask = network.add_cast(mask, trt.float32).get_output(0)
+
+    if scale is None:
+        head_dim = q_4d.shape[-1]
+        scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+    scale_t = _scalar_constant_for_trt_dtype(
+        network, (1, 1, 1, 1), scale, q_4d.dtype)
+    q_scaled = network.add_elementwise(
+        q_4d, scale_t, trt.ElementWiseOperation.PROD).get_output(0)
+    scores = network.add_matrix_multiply(
+        q_scaled, trt.MatrixOperation.NONE,
+        k_4d, trt.MatrixOperation.TRANSPOSE).get_output(0)
+    if mask is not None:
+        scores = network.add_elementwise(
+            scores, mask, trt.ElementWiseOperation.SUM).get_output(0)
+    probs = network.add_softmax(scores)
+    probs.axes = 1 << 3
+    context = network.add_matrix_multiply(
+        probs.get_output(0), trt.MatrixOperation.NONE,
+        v_4d, trt.MatrixOperation.NONE).get_output(0)
+    return _cast_back_to_trt_dtype(network, context, output_dtype)
+
+
 def add_attention_core(
     network: trt.INetworkDefinition,
     q_4d: trt.ITensor,
@@ -2877,6 +2917,14 @@ def add_attention_from_rows(
         tag=None if tag is None else tag + ".v")
     if scale is None:
         scale = float(1.0 / np.sqrt(head_dim)) if head_dim > 0 else 1.0
+    # TensorRT 11.2 can segfault while compiling masked IAttention with
+    # head_dim=128 and dynamic or multi-row queries. Decompose that shape.
+    decompose_masked_attention = (
+        (q_seq != 1 or kv_seq is None)
+        and mask is not None
+        and head_dim == 128
+        and not causal
+    )
     if logit_softcap is not None and float(logit_softcap) > 0.0:
         if causal:
             raise NotImplementedError(
@@ -2885,6 +2933,16 @@ def add_attention_from_rows(
             network, q_4d, k_4d, v_4d,
             num_heads=num_heads, num_kv_heads=kv_heads, head_dim=head_dim,
             mask=mask, scale=scale, logit_softcap=float(logit_softcap))
+    elif decompose_masked_attention:
+        k_4d = _repeat_kv_heads_4d(
+            network, k_4d, num_heads=num_heads, num_kv_heads=kv_heads,
+            head_dim=head_dim)
+        v_4d = _repeat_kv_heads_4d(
+            network, v_4d, num_heads=num_heads, num_kv_heads=kv_heads,
+            head_dim=head_dim)
+        ctx_4d = _add_decomposed_attention_core(
+            network, q_4d, k_4d, v_4d, mask=mask, scale=scale,
+            fp32_accumulation=fp32_accumulation)
     else:
         ctx_4d = add_attention_core(
             network, q_4d, k_4d, v_4d, causal=causal, mask=mask, scale=scale,

--- a/python/tensorrt_model_connect/families/locateanything/vl_debug_runner.py
+++ b/python/tensorrt_model_connect/families/locateanything/vl_debug_runner.py
@@ -63,6 +63,20 @@ def _require_trt_runtime() -> None:
         raise ImportError("cuda-python is required for VL debug runner execution")
 
 
+def _profile_min_shape(engine: Any, name: str, profile_index: int) -> tuple[int, ...]:
+    """Resolve a concrete single-step shape for a possibly dynamic tensor."""
+    declared = tuple(int(dim) for dim in engine.get_tensor_shape(name))
+    if all(dim >= 0 for dim in declared):
+        return declared
+    profile_shapes = engine.get_tensor_profile_shape(name, profile_index)
+    if not profile_shapes:
+        raise RuntimeError(f"Missing optimization profile shape for {name!r}")
+    resolved = tuple(int(dim) for dim in profile_shapes[0])
+    if any(dim < 0 for dim in resolved):
+        raise RuntimeError(f"Invalid optimization profile shape for {name!r}: {resolved}")
+    return resolved
+
+
 class TrtRunner:
     """Device-resident TRT inference runner for debugging and diff testing.
 
@@ -106,17 +120,19 @@ class TrtRunner:
         # decode profile (profile 1, Sq=1). For per-step decode runs the
         # debug_runner must select the decode profile and call
         # set_input_shape on every dynamic input before each execute. We
-        # detect dual-profile via num_optimization_profiles > 1 and the
-        # presence of -1 dims on token_id / position_id / attention_mask.
-        self._dynamic_inputs: list[str] = []
+        # detect dual-profile via num_optimization_profiles > 1 and resolve
+        # every dynamic input from the selected profile's minimum shape.
+        self._dynamic_input_shapes: dict[str, tuple[int, ...]] = {}
         self._is_dual_profile = self.engine.num_optimization_profiles > 1
-        for input_name in ("token_id", "position_id", "attention_mask"):
-            try:
-                shape = tuple(self.engine.get_tensor_shape(input_name))
-            except Exception:
+        self._profile_index = 1 if self._is_dual_profile else 0
+        for index in range(self.engine.num_io_tensors):
+            input_name = self.engine.get_tensor_name(index)
+            if self.engine.get_tensor_mode(input_name) != trt.TensorIOMode.INPUT:
                 continue
-            if any(d < 0 for d in shape):
-                self._dynamic_inputs.append(input_name)
+            shape = tuple(self.engine.get_tensor_shape(input_name))
+            if any(dim < 0 for dim in shape):
+                self._dynamic_input_shapes[input_name] = _profile_min_shape(
+                    self.engine, input_name, self._profile_index)
         if self._is_dual_profile:
             # Profile 1 = decode (Sq=1). step() always runs single-token, so
             # we lock the context to that profile once and never switch.
@@ -215,14 +231,18 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name == "input_embed":
                 self._has_embed_input = True
-                embed_shape = tuple(self.engine.get_tensor_shape(name))
+                embed_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 embed_bytes = int(np.prod(embed_shape)) * 4
                 self._h_input_embed = np.zeros(embed_shape, dtype=np.float32)
                 err, self._d_input_embed = cudart.cudaMalloc(embed_bytes)
                 _check_cuda(err)
             elif name == "use_input_embed":
-                self._h_use_input_embed = np.zeros((1,), dtype=np.float32)
-                err, self._d_use_input_embed = cudart.cudaMalloc(4)
+                selector_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_use_input_embed = np.zeros(selector_shape, dtype=np.float32)
+                err, self._d_use_input_embed = cudart.cudaMalloc(
+                    self._h_use_input_embed.nbytes)
                 _check_cuda(err)
 
         # DeepStack inputs (auto-detected from engine bindings)
@@ -235,15 +255,19 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name.startswith("deepstack_embed_"):
                 self._deepstack_names.append(name)
-                shape = tuple(self.engine.get_tensor_shape(name))
+                shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 nbytes = int(np.prod(shape)) * 4
                 self._h_deepstack[name] = np.zeros(shape, dtype=np.float32)
                 err, d_ptr = cudart.cudaMalloc(nbytes)
                 _check_cuda(err)
                 self._d_deepstack[name] = d_ptr
             elif name == "deepstack_active":
-                self._h_deepstack_active = np.zeros((1,), dtype=np.float32)
-                err, self._d_deepstack_active = cudart.cudaMalloc(4)
+                active_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_deepstack_active = np.zeros(active_shape, dtype=np.float32)
+                err, self._d_deepstack_active = cudart.cudaMalloc(
+                    self._h_deepstack_active.nbytes)
                 _check_cuda(err)
 
         # Debug output device/host buffers
@@ -333,7 +357,7 @@ class TrtRunner:
                 self._h_input_embed.nbytes, H2D, stream)
             cudart.cudaMemcpyAsync(
                 self._d_use_input_embed, self._h_use_input_embed.ctypes.data,
-                4, H2D, stream)
+                self._h_use_input_embed.nbytes, H2D, stream)
 
         # DeepStack H2D transfers
         if self._deepstack_names:
@@ -352,7 +376,7 @@ class TrtRunner:
                 cudart.cudaMemcpyAsync(
                     self._d_deepstack_active,
                     self._h_deepstack_active.ctypes.data,
-                    4, H2D, stream)
+                    self._h_deepstack_active.nbytes, H2D, stream)
 
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
@@ -381,15 +405,11 @@ class TrtRunner:
         for name in self._debug_output_names:
             self.context.set_tensor_address(name, self._d_debug[name])
 
-        # Dual-profile engines need explicit shapes for the dynamic
-        # inputs every step. step() is single-token decode, so all three
-        # shapes are fixed: Sq=1 and K = max_cache_length + 1.
-        if self._dynamic_inputs:
-            for name in self._dynamic_inputs:
-                if name == "attention_mask":
-                    self.context.set_input_shape(name, (1, attention_window))
-                else:
-                    self.context.set_input_shape(name, (1,))
+        # Dynamic inputs use the selected profile's minimum shapes. Both the
+        # prefill and decode profiles have Sq=1 minima, so this covers token,
+        # mask, image embedding, selector, and DeepStack inputs uniformly.
+        for name, shape in self._dynamic_input_shapes.items():
+            self.context.set_input_shape(name, shape)
 
         # Execute
         self.context.execute_async_v3(stream)
@@ -483,24 +503,16 @@ class TrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask,
-                self._d_logits]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        if self._d_input_embed:
-            bufs.append(self._d_input_embed)
-        if self._d_use_input_embed:
-            bufs.append(self._d_use_input_embed)
-        for d_ptr in self._d_deepstack.values():
-            bufs.append(d_ptr)
-        if self._d_deepstack_active:
-            bufs.append(self._d_deepstack_active)
-        for d_ptr in self._d_debug.values():
-            bufs.append(d_ptr)
+        bufs = []
+        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
+                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+            d_ptr = getattr(self, name, 0)
+            if d_ptr:
+                bufs.append(d_ptr)
+        for name in ("_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v"):
+            bufs.extend(getattr(self, name, []))
+        bufs.extend(getattr(self, "_d_deepstack", {}).values())
+        bufs.extend(getattr(self, "_d_debug", {}).values())
         for d_ptr in bufs:
             cudart.cudaFree(d_ptr)
         if hasattr(self, "stream"):

--- a/python/tensorrt_model_connect/families/phi4_multimodal/default_decoder.py
+++ b/python/tensorrt_model_connect/families/phi4_multimodal/default_decoder.py
@@ -89,7 +89,7 @@ def build_standard_decoder_engine(
             rotated-half (LLaMA/Qwen) where (d, d+half) share frequencies.
         scale_attn_weights: Whether to scale attention scores by 1/sqrt(head_dim).
             Most models use this (True, default). GPT-Neo does NOT scale (False).
-        embed_input: If True, add input_embed [1, hidden] and use_input_embed [1]
+        embed_input: If True, add input_embed [Sq, hidden] and use_input_embed [Sq, 1]
             engine inputs. When use_input_embed==1, the decoder uses input_embed
             directly instead of the embedding lookup. Used for VL models where
             the vision encoder provides fused embeddings during prefill.
@@ -115,7 +115,6 @@ def build_standard_decoder_engine(
     # The legacy single-profile graph below stays in place for paths the
     # dual-profile builder does not yet cover:
     #
-    #   - embed_input=True             (VL prefill replacement, Bark sub-engines)
     #   - debug_layer_outputs=True     (per-layer hidden-state dumps)
     #   - hidden_state_output=True     (speech / Bark hidden output)
     #   - config.raw.dynamic_kv_cache  (TriAttention multi-bucket decode)
@@ -125,8 +124,7 @@ def build_standard_decoder_engine(
     # supported user-facing flag.
     requested_fp32_layers = tuple(config.raw.get("_fp32_layers", ()))
     _dual_profile_disabled_for = (
-        embed_input
-        or debug_layer_outputs
+        debug_layer_outputs
         or hidden_state_output
         or bool(requested_fp32_layers)
         or bool(config.raw.get("dynamic_kv_cache", False))
@@ -136,7 +134,13 @@ def build_standard_decoder_engine(
         raise NotImplementedError(
             "split prefill engine is not supported for this standard decoder "
             "configuration")
-    if not _dual_profile_disabled_for and decoder_engine_role in ("dual_profile", "prefill"):
+    # Phi-4 Multimodal is packaged as one decoder engine, so the global split
+    # fallback reaches this family with role="decode". Keep that engine
+    # dual-profile when vision embeddings are enabled.
+    vl_single_engine_fallback = embed_input and decoder_engine_role == "decode"
+    if not _dual_profile_disabled_for and (
+        decoder_engine_role in ("dual_profile", "prefill") or vl_single_engine_fallback
+    ):
         return build_dual_profile_decoder_engine(
             config, weights, max_cache_length,
             precision=precision,
@@ -149,6 +153,7 @@ def build_standard_decoder_engine(
             interleaved_rope=interleaved_rope,
             parallel_residual=parallel_residual,
             scale_attn_weights=scale_attn_weights,
+            embed_input=embed_input,
             verbose=verbose,
             profile_mode=("prefill" if decoder_engine_role == "prefill" else "dual_profile"),
         )

--- a/python/tensorrt_model_connect/families/phi4_multimodal/default_dual_profile_decoder.py
+++ b/python/tensorrt_model_connect/families/phi4_multimodal/default_dual_profile_decoder.py
@@ -161,6 +161,7 @@ def build_dual_profile_decoder_engine(
     interleaved_rope: bool = False,
     parallel_residual: bool = False,
     scale_attn_weights: bool = True,
+    embed_input: bool = False,
     verbose: bool = False,
     dynamic_kv_profile_rows: list[int] | None = None,
     profile_mode: str = "dual_profile",
@@ -246,6 +247,13 @@ def build_dual_profile_decoder_engine(
     token_id = network.add_input("token_id", trt.int32, (-1,))
     position_id = network.add_input("position_id", trt.int32, (-1,))
     attention_mask = network.add_input("attention_mask", trt.float32, (-1, -1))
+    input_embed_tensor = None
+    use_input_embed_tensor = None
+    if embed_input:
+        input_embed_tensor = network.add_input(
+            "input_embed", trt.float32, (-1, hidden))
+        use_input_embed_tensor = network.add_input(
+            "use_input_embed", trt.float32, (-1, 1))
 
     cache_shape: tuple[int, int]
     if multi_bucket_decode:
@@ -285,6 +293,11 @@ def build_dual_profile_decoder_engine(
             (min_sq, max_cache_length + min_sq),
             (opt_sq, max_cache_length + opt_sq),
             (max_sq, max_cache_length + max_sq))
+        if embed_input:
+            prof.set_shape(
+                "input_embed", (min_sq, hidden), (opt_sq, hidden), (max_sq, hidden))
+            prof.set_shape(
+                "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
         if multi_bucket_decode:
             cmn = cache_rows_min if cache_rows_min is not None else 1
             cop = cache_rows_opt if cache_rows_opt is not None else max_cache_length
@@ -350,12 +363,32 @@ def build_dual_profile_decoder_engine(
     if position_type == "rope":
         kmax = max_cache_length + max_prefill_length
         graph_ops.validate_native_rope_dim(rotary_embedding_dim)
+        rope_frequency_factors = None
+        rope_attention_factor = 1.0
+        rope_scaling = config.raw.get("rope_scaling") or {}
+        if rope_scaling.get("type") == "longrope":
+            original_max = int(config.raw.get(
+                "original_max_position_embeddings",
+                config.raw.get("max_position_embeddings", kmax)))
+            max_positions = int(config.raw.get(
+                "max_position_embeddings", original_max))
+            extension_factor = max_positions / max(original_max, 1)
+            rope_attention_factor = float(rope_scaling.get(
+                "attention_factor",
+                1.0 if extension_factor <= 1.0 else np.sqrt(
+                    1.0 + np.log(extension_factor) / np.log(original_max))))
+            factor_key = "long_factor" if kmax > original_max else "short_factor"
+            rope_frequency_factors = rope_scaling.get(factor_key)
         cos_half_np = graph_ops.make_rope_table_half_dim(
             kmax, head_dim, config.rope_theta, True,
-            partial_rotary_factor, interleaved=interleaved_rope)
+            partial_rotary_factor, interleaved=interleaved_rope,
+            frequency_factors=rope_frequency_factors,
+            attention_factor=rope_attention_factor)
         sin_half_np = graph_ops.make_rope_table_half_dim(
             kmax, head_dim, config.rope_theta, False,
-            partial_rotary_factor, interleaved=interleaved_rope)
+            partial_rotary_factor, interleaved=interleaved_rope,
+            frequency_factors=rope_frequency_factors,
+            attention_factor=rope_attention_factor)
         cos_half_table = _const_in_work_dtype(
             network, cos_half_np.shape, cos_half_np,
             work_np_dtype, work_trt_dtype)
@@ -408,6 +441,28 @@ def build_dual_profile_decoder_engine(
     # ---- Embedding -------------------------------------------------------
     emb = network.add_gather(embedding_table, token_id, 0)
     hidden_state = emb.get_output(0)  # (Sq, hidden)
+
+    if input_embed_tensor is not None and use_input_embed_tensor is not None:
+        token_embed = hidden_state
+        if token_embed.dtype != work_trt_dtype:
+            token_embed = network.add_cast(token_embed, work_trt_dtype).get_output(0)
+        input_embed = input_embed_tensor
+        if input_embed.dtype != work_trt_dtype:
+            input_embed = network.add_cast(input_embed, work_trt_dtype).get_output(0)
+        embed_selector = use_input_embed_tensor
+        if embed_selector.dtype != work_trt_dtype:
+            embed_selector = network.add_cast(embed_selector, work_trt_dtype).get_output(0)
+        one = _const_in_work_dtype(
+            network, (1, 1), np.array([[1.0]], dtype=work_np_dtype),
+            work_np_dtype, work_trt_dtype)
+        inverse_selector = network.add_elementwise(
+            one, embed_selector, trt.ElementWiseOperation.SUB).get_output(0)
+        token_part = network.add_elementwise(
+            inverse_selector, token_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        embed_part = network.add_elementwise(
+            embed_selector, input_embed, trt.ElementWiseOperation.PROD).get_output(0)
+        hidden_state = network.add_elementwise(
+            token_part, embed_part, trt.ElementWiseOperation.SUM).get_output(0)
 
     if position_type == "learned" and position_embed_table is not None:
         pos_gather = network.add_gather(position_embed_table, position_id, 0)
@@ -518,7 +573,8 @@ def build_dual_profile_decoder_engine(
             num_heads=num_heads, head_dim=head_dim,
             num_kv_heads=num_kv_heads,
             q_seq=None, kv_seq=None, causal=False, mask=mask_4d,
-            scale=attn_scale, tag=f"{prefix}.attn")
+            scale=attn_scale, tag=f"{prefix}.attn",
+            explicit_attention=bool(weights.get("_explicit_attention", False)))
 
         attn_out = matmul(context, attention_size, hidden,
                           weights[f"{prefix}.w_o"], f"{prefix}.w_o")

--- a/python/tensorrt_model_connect/families/phi4_multimodal/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/phi4_multimodal/graph_blocks.py
@@ -169,6 +169,7 @@ def add_attention_block(
     interleaved_rope: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
+    sequence_length: int | None = 1,
 ) -> dict[str, trt.ITensor]:
     """Pre-norm -> QKV -> RoPE -> cache concat -> attention -> output proj.
 
@@ -222,11 +223,13 @@ def add_attention_block(
     q_norm = weights.get(f"{prefix}.q_norm")
     if q_norm is not None:
         q = graph_ops.add_rms_norm_per_head(
-            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype)
+            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
     k_norm = weights.get(f"{prefix}.k_norm")
     if k_norm is not None:
         k = graph_ops.add_rms_norm_per_head(
-            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype)
+            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
 
     # ------------------------------------------------------------------ #
     # RoPE via native IRotaryEmbeddingLayer                              #
@@ -243,35 +246,40 @@ def add_attention_block(
         q = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
         k = graph_ops.add_apply_rope_native(
             network, k, num_kv_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
 
     # Save present K/V (before concatenation, this is the raw projection output)
     present_k = k
     present_v = v
 
     # Reshape current K, V for concatenation
-    k_reshape = network.add_shuffle(k)
-    k_reshape.reshape_dims = (1, kv_attention_size)
-    v_reshape = network.add_shuffle(v)
-    v_reshape.reshape_dims = (1, kv_attention_size)
+    current_k = k
+    current_v = v
+    if sequence_length is not None:
+        k_reshape = network.add_shuffle(k)
+        k_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        v_reshape = network.add_shuffle(v)
+        v_reshape.reshape_dims = (sequence_length, kv_attention_size)
+        current_k = k_reshape.get_output(0)
+        current_v = v_reshape.get_output(0)
 
     # Concatenate with cache
     all_k = network.add_concatenation(
-        [cache_k, k_reshape.get_output(0)])
+        [cache_k, current_k])
     all_k.axis = 0
     all_v = network.add_concatenation(
-        [cache_v, v_reshape.get_output(0)])
+        [cache_v, current_v])
     all_v.axis = 0
 
     # ------------------------------------------------------------------ #
     # Attention core — native IAttention or FFI kernel                    #
     # ------------------------------------------------------------------ #
     if use_native_attention:
-        kv_seq = None if dynamic_kv_cache else attention_window
+        kv_seq = None if dynamic_kv_cache or sequence_length is None else attention_window
         if alibi_slopes_tensor is not None:
             if alibi_indices_tensor is None:
                 raise ValueError("ALiBi attention requires cache position indices")
@@ -296,7 +304,7 @@ def add_attention_block(
             num_heads=num_heads,
             head_dim=head_dim,
             num_kv_heads=num_kv_heads,
-            q_seq=1,
+            q_seq=sequence_length,
             kv_seq=kv_seq,
             causal=False,
             mask=mask_4d,

--- a/python/tensorrt_model_connect/families/phi4_multimodal/vl_debug_runner.py
+++ b/python/tensorrt_model_connect/families/phi4_multimodal/vl_debug_runner.py
@@ -63,6 +63,20 @@ def _require_trt_runtime() -> None:
         raise ImportError("cuda-python is required for VL debug runner execution")
 
 
+def _profile_min_shape(engine: Any, name: str, profile_index: int) -> tuple[int, ...]:
+    """Resolve a concrete single-step shape for a possibly dynamic tensor."""
+    declared = tuple(int(dim) for dim in engine.get_tensor_shape(name))
+    if all(dim >= 0 for dim in declared):
+        return declared
+    profile_shapes = engine.get_tensor_profile_shape(name, profile_index)
+    if not profile_shapes:
+        raise RuntimeError(f"Missing optimization profile shape for {name!r}")
+    resolved = tuple(int(dim) for dim in profile_shapes[0])
+    if any(dim < 0 for dim in resolved):
+        raise RuntimeError(f"Invalid optimization profile shape for {name!r}: {resolved}")
+    return resolved
+
+
 class TrtRunner:
     """Device-resident TRT inference runner for debugging and diff testing.
 
@@ -106,17 +120,19 @@ class TrtRunner:
         # decode profile (profile 1, Sq=1). For per-step decode runs the
         # debug_runner must select the decode profile and call
         # set_input_shape on every dynamic input before each execute. We
-        # detect dual-profile via num_optimization_profiles > 1 and the
-        # presence of -1 dims on token_id / position_id / attention_mask.
-        self._dynamic_inputs: list[str] = []
+        # detect dual-profile via num_optimization_profiles > 1 and resolve
+        # every dynamic input from the selected profile's minimum shape.
+        self._dynamic_input_shapes: dict[str, tuple[int, ...]] = {}
         self._is_dual_profile = self.engine.num_optimization_profiles > 1
-        for input_name in ("token_id", "position_id", "attention_mask"):
-            try:
-                shape = tuple(self.engine.get_tensor_shape(input_name))
-            except Exception:
+        self._profile_index = 1 if self._is_dual_profile else 0
+        for index in range(self.engine.num_io_tensors):
+            input_name = self.engine.get_tensor_name(index)
+            if self.engine.get_tensor_mode(input_name) != trt.TensorIOMode.INPUT:
                 continue
-            if any(d < 0 for d in shape):
-                self._dynamic_inputs.append(input_name)
+            shape = tuple(self.engine.get_tensor_shape(input_name))
+            if any(dim < 0 for dim in shape):
+                self._dynamic_input_shapes[input_name] = _profile_min_shape(
+                    self.engine, input_name, self._profile_index)
         if self._is_dual_profile:
             # Profile 1 = decode (Sq=1). step() always runs single-token, so
             # we lock the context to that profile once and never switch.
@@ -215,14 +231,18 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name == "input_embed":
                 self._has_embed_input = True
-                embed_shape = tuple(self.engine.get_tensor_shape(name))
+                embed_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 embed_bytes = int(np.prod(embed_shape)) * 4
                 self._h_input_embed = np.zeros(embed_shape, dtype=np.float32)
                 err, self._d_input_embed = cudart.cudaMalloc(embed_bytes)
                 _check_cuda(err)
             elif name == "use_input_embed":
-                self._h_use_input_embed = np.zeros((1,), dtype=np.float32)
-                err, self._d_use_input_embed = cudart.cudaMalloc(4)
+                selector_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_use_input_embed = np.zeros(selector_shape, dtype=np.float32)
+                err, self._d_use_input_embed = cudart.cudaMalloc(
+                    self._h_use_input_embed.nbytes)
                 _check_cuda(err)
 
         # DeepStack inputs (auto-detected from engine bindings)
@@ -235,15 +255,19 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name.startswith("deepstack_embed_"):
                 self._deepstack_names.append(name)
-                shape = tuple(self.engine.get_tensor_shape(name))
+                shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 nbytes = int(np.prod(shape)) * 4
                 self._h_deepstack[name] = np.zeros(shape, dtype=np.float32)
                 err, d_ptr = cudart.cudaMalloc(nbytes)
                 _check_cuda(err)
                 self._d_deepstack[name] = d_ptr
             elif name == "deepstack_active":
-                self._h_deepstack_active = np.zeros((1,), dtype=np.float32)
-                err, self._d_deepstack_active = cudart.cudaMalloc(4)
+                active_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_deepstack_active = np.zeros(active_shape, dtype=np.float32)
+                err, self._d_deepstack_active = cudart.cudaMalloc(
+                    self._h_deepstack_active.nbytes)
                 _check_cuda(err)
 
         # Debug output device/host buffers
@@ -333,7 +357,7 @@ class TrtRunner:
                 self._h_input_embed.nbytes, H2D, stream)
             cudart.cudaMemcpyAsync(
                 self._d_use_input_embed, self._h_use_input_embed.ctypes.data,
-                4, H2D, stream)
+                self._h_use_input_embed.nbytes, H2D, stream)
 
         # DeepStack H2D transfers
         if self._deepstack_names:
@@ -352,7 +376,7 @@ class TrtRunner:
                 cudart.cudaMemcpyAsync(
                     self._d_deepstack_active,
                     self._h_deepstack_active.ctypes.data,
-                    4, H2D, stream)
+                    self._h_deepstack_active.nbytes, H2D, stream)
 
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
@@ -381,15 +405,11 @@ class TrtRunner:
         for name in self._debug_output_names:
             self.context.set_tensor_address(name, self._d_debug[name])
 
-        # Dual-profile engines need explicit shapes for the dynamic
-        # inputs every step. step() is single-token decode, so all three
-        # shapes are fixed: Sq=1 and K = max_cache_length + 1.
-        if self._dynamic_inputs:
-            for name in self._dynamic_inputs:
-                if name == "attention_mask":
-                    self.context.set_input_shape(name, (1, attention_window))
-                else:
-                    self.context.set_input_shape(name, (1,))
+        # Dynamic inputs use the selected profile's minimum shapes. Both the
+        # prefill and decode profiles have Sq=1 minima, so this covers token,
+        # mask, image embedding, selector, and DeepStack inputs uniformly.
+        for name, shape in self._dynamic_input_shapes.items():
+            self.context.set_input_shape(name, shape)
 
         # Execute
         self.context.execute_async_v3(stream)
@@ -483,24 +503,16 @@ class TrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask,
-                self._d_logits]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        if self._d_input_embed:
-            bufs.append(self._d_input_embed)
-        if self._d_use_input_embed:
-            bufs.append(self._d_use_input_embed)
-        for d_ptr in self._d_deepstack.values():
-            bufs.append(d_ptr)
-        if self._d_deepstack_active:
-            bufs.append(self._d_deepstack_active)
-        for d_ptr in self._d_debug.values():
-            bufs.append(d_ptr)
+        bufs = []
+        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
+                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+            d_ptr = getattr(self, name, 0)
+            if d_ptr:
+                bufs.append(d_ptr)
+        for name in ("_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v"):
+            bufs.extend(getattr(self, name, []))
+        bufs.extend(getattr(self, "_d_deepstack", {}).values())
+        bufs.extend(getattr(self, "_d_debug", {}).values())
         for d_ptr in bufs:
             cudart.cudaFree(d_ptr)
         if hasattr(self, "stream"):

--- a/src/runtime/models/deepseek_ocr/pipeline.cpp
+++ b/src/runtime/models/deepseek_ocr/pipeline.cpp
@@ -6,6 +6,7 @@
 #include "runtime/models/deepseek_ocr/pipeline.h"
 
 #include "runtime/models/deepseek_ocr/image_preprocessor.h"
+#include "runtime/models/deepseek_ocr/tensor_names.h"
 
 #include <algorithm>
 #include <cstring>
@@ -14,28 +15,40 @@
 
 namespace trtmc {
 
-DeepseekOcrPipeline::DeepseekOcrPipeline(std::unique_ptr<TrtModule> text_decoder,
-                                         std::unique_ptr<TrtModule> vision_encoder,
-                                         std::unique_ptr<DeepseekOcrInferenceState> state,
-                                         DeepseekOcrConfig config,
-                                         DeepseekOcrPreprocessConfig vl_preprocess,
-                                         cudaStream_t stream, std::shared_ptr<ITokenizer> tokenizer,
-                                         std::string model_id_str,
-                                         std::unique_ptr<DeepseekOcrISampler> sampler)
-    : text_decoder_(std::move(text_decoder)), vision_encoder_(std::move(vision_encoder)),
-      state_(std::move(state)), config_(config), vl_preprocess_(std::move(vl_preprocess)),
-      stream_(stream), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
-      sampler_(std::move(sampler)) {
-    if (!text_decoder_ || !text_decoder_->ok())
-        throw std::runtime_error("DeepseekOcrPipeline: invalid text decoder");
-    if (!state_ || !state_->ok())
-        throw std::runtime_error("DeepseekOcrPipeline: invalid inference state");
+namespace {
 
-    // Sync image_token_id from DeepseekOcrPreprocessConfig if not set in DeepseekOcrConfig
-    if (config_.image_token_id < 0 && vl_preprocess_.image_token_id >= 0)
-        config_.image_token_id = vl_preprocess_.image_token_id;
-    if (config_.vision_output_dim <= 0 && vl_preprocess_.vision_output_dim > 0)
-        config_.vision_output_dim = vl_preprocess_.vision_output_dim;
+void validate_pipeline_components(const TrtModule* text_decoder,
+                                  const DeepseekOcrInferenceState* state,
+                                  const TrtModule* prefill) {
+    if (text_decoder == nullptr || !text_decoder->ok())
+        throw std::runtime_error("DeepseekOcrPipeline: invalid text decoder");
+    if (state == nullptr || !state->ok())
+        throw std::runtime_error("DeepseekOcrPipeline: invalid inference state");
+    if (prefill != nullptr && !prefill->ok())
+        throw std::runtime_error("DeepseekOcrPipeline: invalid prefill decoder");
+}
+
+void sync_vision_config(DeepseekOcrConfig& config, const DeepseekOcrPreprocessConfig& preprocess) {
+    if (config.image_token_id < 0 && preprocess.image_token_id >= 0)
+        config.image_token_id = preprocess.image_token_id;
+    if (config.vision_output_dim <= 0 && preprocess.vision_output_dim > 0)
+        config.vision_output_dim = preprocess.vision_output_dim;
+}
+
+} // namespace
+
+DeepseekOcrPipeline::DeepseekOcrPipeline(
+    std::unique_ptr<TrtModule> text_decoder, std::unique_ptr<TrtModule> vision_encoder,
+    std::unique_ptr<DeepseekOcrInferenceState> state, DeepseekOcrConfig config,
+    DeepseekOcrPreprocessConfig vl_preprocess, cudaStream_t stream,
+    std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
+    std::unique_ptr<DeepseekOcrISampler> sampler, std::unique_ptr<TrtModule> prefill)
+    : text_decoder_(std::move(text_decoder)), prefill_(std::move(prefill)),
+      vision_encoder_(std::move(vision_encoder)), state_(std::move(state)), config_(config),
+      vl_preprocess_(std::move(vl_preprocess)), stream_(stream), tokenizer_(std::move(tokenizer)),
+      model_id_(std::move(model_id_str)), sampler_(std::move(sampler)) {
+    validate_pipeline_components(text_decoder_.get(), state_.get(), prefill_.get());
+    sync_vision_config(config_, vl_preprocess_);
 }
 
 TextResult DeepseekOcrPipeline::generate(const std::string& prompt, const GenerateConfig& cfg) {
@@ -95,6 +108,193 @@ select_deepstack_feature_pointers(const std::vector<std::vector<float>>& deepsta
                              : nullptr);
     }
     return embeds;
+}
+
+struct VlSequenceEmbeddingInputs {
+    std::vector<float> input_embed;
+    std::vector<float> use_input_embed;
+    std::vector<std::vector<float>> deepstack_embed;
+    std::vector<float> deepstack_active;
+};
+
+VlSequenceEmbeddingInputs
+build_vl_sequence_embedding_inputs(const std::vector<int32_t>& input_ids, int32_t image_token_id,
+                                   const std::vector<float>& image_features,
+                                   const std::vector<std::vector<float>>& deepstack_features,
+                                   int32_t num_features, int32_t feature_dim) {
+    const auto sq = input_ids.size();
+    VlSequenceEmbeddingInputs result;
+    result.input_embed.assign(sq * static_cast<std::size_t>(feature_dim), 0.0F);
+    result.use_input_embed.assign(sq, 0.0F);
+    result.deepstack_active.assign(sq, 0.0F);
+    result.deepstack_embed.resize(deepstack_features.size());
+    for (auto& level : result.deepstack_embed)
+        level.assign(sq * static_cast<std::size_t>(feature_dim), 0.0F);
+
+    int32_t feature_index = 0;
+    for (std::size_t token_index = 0; token_index < sq; ++token_index) {
+        if (input_ids[token_index] != image_token_id || feature_index >= num_features)
+            continue;
+        const auto source_offset = static_cast<std::size_t>(feature_index) * feature_dim;
+        const auto target_offset = token_index * static_cast<std::size_t>(feature_dim);
+        std::copy_n(image_features.data() + source_offset, feature_dim,
+                    result.input_embed.data() + target_offset);
+        result.use_input_embed[token_index] = 1.0F;
+
+        for (std::size_t level_index = 0; level_index < deepstack_features.size(); ++level_index) {
+            const auto& source = deepstack_features[level_index];
+            if (source_offset + static_cast<std::size_t>(feature_dim) > source.size())
+                continue;
+            std::copy_n(source.data() + source_offset, feature_dim,
+                        result.deepstack_embed[level_index].data() + target_offset);
+            result.deepstack_active[token_index] = 1.0F;
+        }
+        ++feature_index;
+    }
+    return result;
+}
+
+bool gather_vl_prefill_kv_pointers(TrtModule& prefill, const DeepseekOcrConfig& config,
+                                   std::vector<const void*>& present_k,
+                                   std::vector<const void*>& present_v) {
+    present_k.resize(static_cast<std::size_t>(config.num_layers));
+    present_v.resize(static_cast<std::size_t>(config.num_layers));
+    for (int32_t layer = 0; layer < config.num_layers; ++layer) {
+        const auto index = static_cast<std::size_t>(layer);
+        present_k[index] =
+            prefill.device_ptr(deepseek_ocr_expand_layer_name(config.present_k_pattern, layer));
+        present_v[index] =
+            prefill.device_ptr(deepseek_ocr_expand_layer_name(config.present_v_pattern, layer));
+        if (present_k[index] == nullptr || present_v[index] == nullptr)
+            return false;
+    }
+    return true;
+}
+
+DeepseekOcrKvCache* eligible_vl_prefill_cache(TrtModule* prefill, DeepseekOcrInferenceState* state,
+                                              const DeepseekOcrConfig& config,
+                                              int32_t sequence_length, int32_t feature_dim) {
+    if (prefill == nullptr)
+        return nullptr;
+    if (sequence_length <= 0 || feature_dim <= 0 || config.num_layers <= 0)
+        return nullptr;
+    if (!prefill->has_input("input_embed"))
+        return nullptr;
+    if (config.prefill_max_length > 0 && sequence_length > config.prefill_max_length)
+        return nullptr;
+    return dynamic_cast<DeepseekOcrKvCache*>(state);
+}
+
+bool valid_vl_features(const std::vector<float>& image_features, int32_t num_features,
+                       int32_t feature_dim) {
+    if (num_features < 0)
+        return false;
+    const auto required =
+        static_cast<std::size_t>(num_features) * static_cast<std::size_t>(feature_dim);
+    return image_features.size() >= required;
+}
+
+void add_vl_prefill_base_inputs(TensorMap& inputs, DeepseekOcrInferenceState& state,
+                                const std::vector<int32_t>& input_ids,
+                                VlSequenceEmbeddingInputs& embedding_inputs, int32_t feature_dim) {
+    const auto sequence_length = static_cast<int32_t>(input_ids.size());
+    inputs["token_id"] =
+        Tensor{const_cast<int32_t*>(input_ids.data()), {sequence_length}, DType::kInt32};
+    state.prepare_step(inputs, sequence_length);
+    inputs["input_embed"] = Tensor{
+        embedding_inputs.input_embed.data(), {sequence_length, feature_dim}, DType::kFloat32};
+    inputs["use_input_embed"] =
+        Tensor{embedding_inputs.use_input_embed.data(), {sequence_length, 1}, DType::kFloat32};
+}
+
+bool add_vl_prefill_deepstack_inputs(TrtModule& prefill, TensorMap& inputs,
+                                     VlSequenceEmbeddingInputs& embedding_inputs,
+                                     int32_t sequence_length, int32_t feature_dim) {
+    if (!prefill.has_input("deepstack_active"))
+        return true;
+    inputs["deepstack_active"] =
+        Tensor{embedding_inputs.deepstack_active.data(), {sequence_length, 1}, DType::kFloat32};
+    for (std::size_t level = 0;; ++level) {
+        const auto name = "deepstack_embed_" + std::to_string(level);
+        if (!prefill.has_input(name))
+            break;
+        if (level >= embedding_inputs.deepstack_embed.size())
+            return false;
+        inputs[name] = Tensor{embedding_inputs.deepstack_embed[level].data(),
+                              {sequence_length, feature_dim},
+                              DType::kFloat32};
+    }
+    return true;
+}
+
+bool copy_last_prefill_logits(const TensorMap& outputs, int32_t vocab_size,
+                              std::vector<float>& logits) {
+    const auto logits_it = outputs.find("logits");
+    if (logits_it == outputs.end())
+        return false;
+    const auto size = static_cast<std::size_t>(vocab_size);
+    if (logits_it->second.numel() < size)
+        return false;
+    const auto offset = logits_it->second.numel() - size;
+    logits.resize(size);
+    std::memcpy(logits.data(), static_cast<const float*>(logits_it->second.data) + offset,
+                size * sizeof(float));
+    return true;
+}
+
+int32_t resolve_input_embed_dim(const TrtModule& decoder, int32_t configured_dim) {
+    if (configured_dim > 0)
+        return configured_dim;
+    const auto declared_shape = decoder.tensor_shape("input_embed");
+    if (!declared_shape.empty())
+        return static_cast<int32_t>(declared_shape.back());
+    throw std::runtime_error("DeepseekOcrPipeline: invalid input embedding dimension");
+}
+
+std::vector<int64_t> selector_shape(const TrtModule& decoder, const std::string& name) {
+    return decoder.input_rank(name) == 2 ? std::vector<int64_t>{1, 1} : std::vector<int64_t>{1};
+}
+
+void add_text_step_deepstack_inputs(TrtModule& decoder, TensorMap& inputs, int32_t embed_dim,
+                                    const std::vector<const float*>& deepstack_embeds,
+                                    float& deepstack_active, std::vector<float>& zero_deepstack) {
+    if (!decoder.has_input("deepstack_active"))
+        return;
+    inputs["deepstack_active"] =
+        Tensor{&deepstack_active, selector_shape(decoder, "deepstack_active"), DType::kFloat32};
+    for (std::size_t index = 0;; ++index) {
+        const auto name = "deepstack_embed_" + std::to_string(index);
+        if (!decoder.has_input(name))
+            break;
+        const float* embed = index < deepstack_embeds.size() ? deepstack_embeds[index] : nullptr;
+        if (embed == nullptr) {
+            if (zero_deepstack.empty())
+                zero_deepstack.resize(static_cast<std::size_t>(embed_dim), 0.0F);
+            embed = zero_deepstack.data();
+        }
+        inputs[name] = Tensor{const_cast<float*>(embed), {1, embed_dim}, DType::kFloat32};
+    }
+}
+
+void add_text_step_embedding_inputs(TrtModule& decoder, const DeepseekOcrConfig& config,
+                                    TensorMap& inputs, const float* input_embed,
+                                    float& use_input_embed,
+                                    const std::vector<const float*>& deepstack_embeds,
+                                    float& deepstack_active, std::vector<float>& zero_embed,
+                                    std::vector<float>& zero_deepstack) {
+    if (!decoder.has_input("input_embed"))
+        return;
+    const int32_t embed_dim = resolve_input_embed_dim(decoder, config.vision_output_dim);
+    if (input_embed == nullptr) {
+        zero_embed.resize(static_cast<std::size_t>(embed_dim), 0.0F);
+        input_embed = zero_embed.data();
+    }
+    inputs["input_embed"] =
+        Tensor{const_cast<float*>(input_embed), {1, embed_dim}, DType::kFloat32};
+    inputs["use_input_embed"] =
+        Tensor{&use_input_embed, selector_shape(decoder, "use_input_embed"), DType::kFloat32};
+    add_text_step_deepstack_inputs(decoder, inputs, embed_dim, deepstack_embeds, deepstack_active,
+                                   zero_deepstack);
 }
 
 Tensor make_pixel_values_tensor(const DeepseekOcrPreprocessedImage& preprocessed,
@@ -227,6 +427,10 @@ DeepseekOcrPipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
     active_sampler->reset();
 
     state_->reset();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
     state_->bind_to(*text_decoder_);
 
     std::vector<float> logits;
@@ -267,18 +471,59 @@ std::vector<int32_t> DeepseekOcrPipeline::generate_vl_from_ids(
     active_sampler->reset();
 
     state_->reset();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
     state_->bind_to(*text_decoder_);
 
     std::vector<float> logits;
-    int32_t feature_index = 0;
-
-    for (const auto& tid : input_ids)
-        run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
-                             feature_index, logits);
+    if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,
+                                feature_dim, logits)) {
+        int32_t feature_index = 0;
+        for (const auto& tid : input_ids)
+            run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
+                                 feature_index, logits);
+    }
+    state_->mark_prefill_complete();
 
     std::vector<int32_t> output = input_ids;
     run_vl_decode_loop(active_sampler, params, output, logits, max_new_tokens);
     return output;
+}
+
+bool DeepseekOcrPipeline::run_vl_prefill_batched(
+    const std::vector<int32_t>& input_ids, const std::vector<float>& image_features,
+    const std::vector<std::vector<float>>& deepstack_features, int32_t num_features,
+    int32_t feature_dim, std::vector<float>& logits) {
+    const auto sq = static_cast<int32_t>(input_ids.size());
+    auto* kv_cache =
+        eligible_vl_prefill_cache(prefill_.get(), state_.get(), config_, sq, feature_dim);
+    if (kv_cache == nullptr)
+        return false;
+    if (!valid_vl_features(image_features, num_features, feature_dim))
+        return false;
+
+    kv_cache->bind_cache_inputs(*prefill_);
+    auto embedding_inputs =
+        build_vl_sequence_embedding_inputs(input_ids, config_.image_token_id, image_features,
+                                           deepstack_features, num_features, feature_dim);
+
+    TensorMap inputs;
+    add_vl_prefill_base_inputs(inputs, *state_, input_ids, embedding_inputs, feature_dim);
+    if (!add_vl_prefill_deepstack_inputs(*prefill_, inputs, embedding_inputs, sq, feature_dim))
+        return false;
+
+    auto outputs = prefill_->forward(inputs);
+    if (!copy_last_prefill_logits(outputs, config_.vocab_size, logits))
+        return false;
+
+    std::vector<const void*> present_k;
+    std::vector<const void*> present_v;
+    if (!gather_vl_prefill_kv_pointers(*prefill_, config_, present_k, present_v))
+        return false;
+    kv_cache->write_prefill_kv(present_k, present_v, sq);
+    return true;
 }
 
 void DeepseekOcrPipeline::run_vl_prefill_token(
@@ -315,38 +560,13 @@ void DeepseekOcrPipeline::run_vl_decode_loop(DeepseekOcrISampler* sampler,
 }
 
 void DeepseekOcrPipeline::run_text_step(int32_t token_id, std::vector<float>& logits) {
-    TensorMap inputs;
-
-    Tensor token_t;
-    token_t.data = &token_id;
-    token_t.shape = {1};
-    token_t.dtype = DType::kInt32;
-    inputs["token_id"] = token_t;
-
-    state_->prepare_step(inputs);
-
-    auto outputs = text_decoder_->forward(inputs);
-
-    auto it = outputs.find("logits");
-    if (it == outputs.end())
-        throw std::runtime_error("DeepseekOcrPipeline: no 'logits' output");
-
-    auto n = it->second.numel();
-    logits.resize(static_cast<std::size_t>(n));
-    std::memcpy(logits.data(), it->second.data, n * sizeof(float));
-
-    state_->advance();
+    run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, logits);
 }
 
 void DeepseekOcrPipeline::run_text_step_with_embed(
     int32_t token_id, const float* input_embed, float use_input_embed,
     const std::vector<const float*>& deepstack_embeds, float deepstack_active,
     std::vector<float>& logits) {
-    if (!text_decoder_->has_input("input_embed")) {
-        run_text_step(token_id, logits);
-        return;
-    }
-
     TensorMap inputs;
 
     Tensor token_t;
@@ -357,56 +577,10 @@ void DeepseekOcrPipeline::run_text_step_with_embed(
 
     state_->prepare_step(inputs);
 
-    // use_input_embed scalar: 1.0 = use input_embed, 0.0 = use token embedding
-    Tensor use_embed_t;
-    use_embed_t.data = &use_input_embed;
-    use_embed_t.shape = {1};
-    use_embed_t.dtype = DType::kFloat32;
-    inputs["use_input_embed"] = use_embed_t;
-
-    // Provide the input embedding vector
-    int32_t embed_dim = config_.vision_output_dim;
     std::vector<float> zero_embed;
-    if (input_embed == nullptr) {
-        zero_embed.resize(static_cast<std::size_t>(embed_dim), 0.0F);
-        input_embed = zero_embed.data();
-    }
-
-    Tensor embed_t;
-    embed_t.data = const_cast<float*>(input_embed);
-    embed_t.shape = {static_cast<int64_t>(embed_dim)};
-    embed_t.dtype = DType::kFloat32;
-    inputs["input_embed"] = embed_t;
-
-    // DeepStack: if the engine has deepstack inputs, provide inactive zeros.
-    if (text_decoder_->has_input("deepstack_active")) {
-        Tensor ds_active_t;
-        ds_active_t.data = &deepstack_active;
-        ds_active_t.shape = {1};
-        ds_active_t.dtype = DType::kFloat32;
-        inputs["deepstack_active"] = ds_active_t;
-
-        std::vector<float> zero_deepstack;
-        for (std::size_t i = 0;; ++i) {
-            const std::string name = "deepstack_embed_" + std::to_string(i);
-            if (!text_decoder_->has_input(name))
-                break;
-
-            const float* deepstack_embed =
-                i < deepstack_embeds.size() ? deepstack_embeds[i] : nullptr;
-            if (deepstack_embed == nullptr) {
-                if (zero_deepstack.empty())
-                    zero_deepstack.resize(static_cast<std::size_t>(embed_dim), 0.0F);
-                deepstack_embed = zero_deepstack.data();
-            }
-
-            Tensor ds_embed_t;
-            ds_embed_t.data = const_cast<float*>(deepstack_embed);
-            ds_embed_t.shape = {1, static_cast<int64_t>(embed_dim)};
-            ds_embed_t.dtype = DType::kFloat32;
-            inputs[name] = ds_embed_t;
-        }
-    }
+    std::vector<float> zero_deepstack;
+    add_text_step_embedding_inputs(*text_decoder_, config_, inputs, input_embed, use_input_embed,
+                                   deepstack_embeds, deepstack_active, zero_embed, zero_deepstack);
 
     auto outputs = text_decoder_->forward(inputs);
 

--- a/src/runtime/models/deepseek_ocr/pipeline.h
+++ b/src/runtime/models/deepseek_ocr/pipeline.h
@@ -31,6 +31,10 @@ struct DeepseekOcrConfig {
     int32_t image_token_id{-1};
     int32_t vision_output_dim{0};
     bool has_position_input{true};
+    int32_t num_layers{0};
+    int32_t prefill_max_length{0};
+    std::string present_k_pattern{"present_k_{i}"};
+    std::string present_v_pattern{"present_v_{i}"};
 };
 
 class DeepseekOcrPipeline final : public IPipeline {
@@ -41,7 +45,8 @@ class DeepseekOcrPipeline final : public IPipeline {
                         DeepseekOcrPreprocessConfig vl_preprocess, cudaStream_t stream,
                         std::shared_ptr<ITokenizer> tokenizer = nullptr,
                         std::string model_id_str = "",
-                        std::unique_ptr<DeepseekOcrISampler> sampler = nullptr);
+                        std::unique_ptr<DeepseekOcrISampler> sampler = nullptr,
+                        std::unique_ptr<TrtModule> prefill = nullptr);
 
     TextResult generate(const std::string& prompt, const GenerateConfig& cfg = {}) override;
 
@@ -65,6 +70,7 @@ class DeepseekOcrPipeline final : public IPipeline {
 
   private:
     std::unique_ptr<TrtModule> text_decoder_;
+    std::unique_ptr<TrtModule> prefill_;
     std::unique_ptr<TrtModule> vision_encoder_;
     std::unique_ptr<DeepseekOcrInferenceState> state_;
     DeepseekOcrConfig config_;
@@ -90,6 +96,12 @@ class DeepseekOcrPipeline final : public IPipeline {
                               const std::vector<std::vector<float>>& deepstack_features,
                               int32_t num_features, int32_t feature_dim, int32_t& feature_index,
                               std::vector<float>& logits);
+
+    bool run_vl_prefill_batched(const std::vector<int32_t>& input_ids,
+                                const std::vector<float>& image_features,
+                                const std::vector<std::vector<float>>& deepstack_features,
+                                int32_t num_features, int32_t feature_dim,
+                                std::vector<float>& logits);
 
     void run_vl_decode_loop(DeepseekOcrISampler* sampler, const DeepseekOcrSamplingParams& params,
                             std::vector<int32_t>& output, std::vector<float>& logits,

--- a/src/runtime/models/deepseek_ocr/plugin.cpp
+++ b/src/runtime/models/deepseek_ocr/plugin.cpp
@@ -92,14 +92,19 @@ DeepseekOcrKvCacheNames build_kv_cache_names(const BaseConfig& config) {
     return kv_names;
 }
 
-LoadedModule load_text_module(const PipelineContext& ctx, TextModuleRuntime& runtime,
-                              const std::shared_ptr<DeepseekOcrCudaStream>& stream) {
+DualProfileModules load_text_modules(const PipelineContext& ctx, TextModuleRuntime& runtime,
+                                     const std::shared_ptr<DeepseekOcrCudaStream>& stream) {
     auto loaded =
-        load_trt_module_from_plan(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
+        load_dual_profile_modules(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
                                   runtime.engine_section.c_str(), runtime.options);
-    loaded.module->keep_alive(stream);
-    if (runtime.tp_group.owner)
-        loaded.module->keep_alive(runtime.tp_group.owner);
+    loaded.decode->keep_alive(stream);
+    if (loaded.prefill)
+        loaded.prefill->keep_alive(stream);
+    if (runtime.tp_group.owner) {
+        loaded.decode->keep_alive(runtime.tp_group.owner);
+        if (loaded.prefill)
+            loaded.prefill->keep_alive(runtime.tp_group.owner);
+    }
     return loaded;
 }
 
@@ -152,13 +157,13 @@ class VLPlugin final : public IPipelinePlugin {
 
         DeepseekOcrKvCacheNames kv_names = build_kv_cache_names(ctx.config);
 
-        auto loaded = load_text_module(ctx, text_runtime, shared_stream);
+        auto loaded = load_text_modules(ctx, text_runtime, shared_stream);
 
-        cudaStream_t stream = loaded.module->stream();
+        cudaStream_t stream = loaded.decode->stream();
         const std::string cache_k_name =
             kv_names.cache_k.empty() ? std::string("cache_k_0") : kv_names.cache_k.front();
-        int32_t kv_dim = decoder_cache_row_width(*loaded.module, cache_k_name, ctx.config);
-        DType cache_dtype = loaded.module->tensor_dtype(cache_k_name);
+        int32_t kv_dim = decoder_cache_row_width(*loaded.decode, cache_k_name, ctx.config);
+        DType cache_dtype = loaded.decode->tensor_dtype(cache_k_name);
         std::unique_ptr<DeepseekOcrInferenceState> state =
             std::make_unique<DeepseekOcrKvCache>(ctx.config.num_layers, ctx.config.max_cache_length,
                                                  kv_dim, stream, cache_dtype, std::move(kv_names));
@@ -171,7 +176,11 @@ class VLPlugin final : public IPipelinePlugin {
         vlc.id_eos = ctx.config.id_eos;
         vlc.image_token_id = extract_json_int(ctx.config_json, "image_token_id", -1);
         vlc.vision_output_dim = extract_json_int(ctx.config_json, "vision_output_dim", 0);
-        vlc.has_position_input = loaded.module->has_input("position_id");
+        vlc.has_position_input = loaded.decode->has_input("position_id");
+        vlc.num_layers = ctx.config.num_layers;
+        vlc.prefill_max_length = ctx.config.max_cache_length;
+        vlc.present_k_pattern = ctx.config.io_map.present_k_pattern;
+        vlc.present_v_pattern = ctx.config.io_map.present_v_pattern;
 
         bool has_vision_engine = extract_json_int(ctx.config_json, "has_vision_engine", 0) != 0;
 
@@ -187,8 +196,9 @@ class VLPlugin final : public IPipelinePlugin {
         auto vl_preprocess = deepseek_ocr_parse_preprocess_config(config_text, preproc_text);
 
         return std::make_unique<DeepseekOcrPipeline>(
-            std::move(loaded.module), std::move(vision_module), std::move(state), vlc,
-            vl_preprocess, stream, std::move(tokenizer), ctx.bundle.info.model_id);
+            std::move(loaded.decode), std::move(vision_module), std::move(state), vlc,
+            vl_preprocess, stream, std::move(tokenizer), ctx.bundle.info.model_id, nullptr,
+            std::move(loaded.prefill));
     }
 };
 

--- a/src/runtime/models/deepseek_ocr/plugin.cpp
+++ b/src/runtime/models/deepseek_ocr/plugin.cpp
@@ -178,7 +178,8 @@ class VLPlugin final : public IPipelinePlugin {
         vlc.vision_output_dim = extract_json_int(ctx.config_json, "vision_output_dim", 0);
         vlc.has_position_input = loaded.decode->has_input("position_id");
         vlc.num_layers = ctx.config.num_layers;
-        vlc.prefill_max_length = ctx.config.max_cache_length;
+        vlc.prefill_max_length =
+            extract_json_int(ctx.config_json, "prefill_max_length", ctx.config.max_cache_length);
         vlc.present_k_pattern = ctx.config.io_map.present_k_pattern;
         vlc.present_v_pattern = ctx.config.io_map.present_v_pattern;
 

--- a/src/runtime/models/internvl/pipeline.cpp
+++ b/src/runtime/models/internvl/pipeline.cpp
@@ -6,6 +6,7 @@
 #include "runtime/models/internvl/pipeline.h"
 
 #include "runtime/models/internvl/image_preprocessor.h"
+#include "runtime/models/internvl/tensor_names.h"
 
 #include <algorithm>
 #include <cstring>
@@ -14,27 +15,41 @@
 
 namespace trtmc {
 
+namespace {
+
+void validate_pipeline_components(const TrtModule* text_decoder,
+                                  const InternvlInferenceState* state, const TrtModule* prefill) {
+    if (text_decoder == nullptr || !text_decoder->ok())
+        throw std::runtime_error("InternVlPipeline: invalid text decoder");
+    if (state == nullptr || !state->ok())
+        throw std::runtime_error("InternVlPipeline: invalid inference state");
+    if (prefill != nullptr && !prefill->ok())
+        throw std::runtime_error("InternVlPipeline: invalid prefill decoder");
+}
+
+void sync_vision_config(InternVlConfig& config, const InternVlPreprocessConfig& preprocess) {
+    if (config.image_token_id < 0 && preprocess.image_token_id >= 0)
+        config.image_token_id = preprocess.image_token_id;
+    if (config.vision_output_dim <= 0 && preprocess.vision_output_dim > 0)
+        config.vision_output_dim = preprocess.vision_output_dim;
+}
+
+} // namespace
+
 InternVlPipeline::InternVlPipeline(std::unique_ptr<TrtModule> text_decoder,
                                    std::unique_ptr<TrtModule> vision_encoder,
                                    std::unique_ptr<InternvlInferenceState> state,
                                    InternVlConfig config, InternVlPreprocessConfig vl_preprocess,
                                    cudaStream_t stream, std::shared_ptr<ITokenizer> tokenizer,
                                    std::string model_id_str,
-                                   std::unique_ptr<InternVlISampler> sampler)
-    : text_decoder_(std::move(text_decoder)), vision_encoder_(std::move(vision_encoder)),
-      state_(std::move(state)), config_(config), vl_preprocess_(std::move(vl_preprocess)),
-      stream_(stream), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
-      sampler_(std::move(sampler)) {
-    if (!text_decoder_ || !text_decoder_->ok())
-        throw std::runtime_error("InternVlPipeline: invalid text decoder");
-    if (!state_ || !state_->ok())
-        throw std::runtime_error("InternVlPipeline: invalid inference state");
-
-    // Sync image_token_id from InternVlPreprocessConfig if not set in InternVlConfig
-    if (config_.image_token_id < 0 && vl_preprocess_.image_token_id >= 0)
-        config_.image_token_id = vl_preprocess_.image_token_id;
-    if (config_.vision_output_dim <= 0 && vl_preprocess_.vision_output_dim > 0)
-        config_.vision_output_dim = vl_preprocess_.vision_output_dim;
+                                   std::unique_ptr<InternVlISampler> sampler,
+                                   std::unique_ptr<TrtModule> prefill)
+    : text_decoder_(std::move(text_decoder)), prefill_(std::move(prefill)),
+      vision_encoder_(std::move(vision_encoder)), state_(std::move(state)), config_(config),
+      vl_preprocess_(std::move(vl_preprocess)), stream_(stream), tokenizer_(std::move(tokenizer)),
+      model_id_(std::move(model_id_str)), sampler_(std::move(sampler)) {
+    validate_pipeline_components(text_decoder_.get(), state_.get(), prefill_.get());
+    sync_vision_config(config_, vl_preprocess_);
 }
 
 TextResult InternVlPipeline::generate(const std::string& prompt, const GenerateConfig& cfg) {
@@ -94,6 +109,193 @@ select_deepstack_feature_pointers(const std::vector<std::vector<float>>& deepsta
                              : nullptr);
     }
     return embeds;
+}
+
+struct VlSequenceEmbeddingInputs {
+    std::vector<float> input_embed;
+    std::vector<float> use_input_embed;
+    std::vector<std::vector<float>> deepstack_embed;
+    std::vector<float> deepstack_active;
+};
+
+VlSequenceEmbeddingInputs
+build_vl_sequence_embedding_inputs(const std::vector<int32_t>& input_ids, int32_t image_token_id,
+                                   const std::vector<float>& image_features,
+                                   const std::vector<std::vector<float>>& deepstack_features,
+                                   int32_t num_features, int32_t feature_dim) {
+    const auto sq = input_ids.size();
+    VlSequenceEmbeddingInputs result;
+    result.input_embed.assign(sq * static_cast<std::size_t>(feature_dim), 0.0F);
+    result.use_input_embed.assign(sq, 0.0F);
+    result.deepstack_active.assign(sq, 0.0F);
+    result.deepstack_embed.resize(deepstack_features.size());
+    for (auto& level : result.deepstack_embed)
+        level.assign(sq * static_cast<std::size_t>(feature_dim), 0.0F);
+
+    int32_t feature_index = 0;
+    for (std::size_t token_index = 0; token_index < sq; ++token_index) {
+        if (input_ids[token_index] != image_token_id || feature_index >= num_features)
+            continue;
+        const auto source_offset = static_cast<std::size_t>(feature_index) * feature_dim;
+        const auto target_offset = token_index * static_cast<std::size_t>(feature_dim);
+        std::copy_n(image_features.data() + source_offset, feature_dim,
+                    result.input_embed.data() + target_offset);
+        result.use_input_embed[token_index] = 1.0F;
+
+        for (std::size_t level_index = 0; level_index < deepstack_features.size(); ++level_index) {
+            const auto& source = deepstack_features[level_index];
+            if (source_offset + static_cast<std::size_t>(feature_dim) > source.size())
+                continue;
+            std::copy_n(source.data() + source_offset, feature_dim,
+                        result.deepstack_embed[level_index].data() + target_offset);
+            result.deepstack_active[token_index] = 1.0F;
+        }
+        ++feature_index;
+    }
+    return result;
+}
+
+bool gather_vl_prefill_kv_pointers(TrtModule& prefill, const InternVlConfig& config,
+                                   std::vector<const void*>& present_k,
+                                   std::vector<const void*>& present_v) {
+    present_k.resize(static_cast<std::size_t>(config.num_layers));
+    present_v.resize(static_cast<std::size_t>(config.num_layers));
+    for (int32_t layer = 0; layer < config.num_layers; ++layer) {
+        const auto index = static_cast<std::size_t>(layer);
+        present_k[index] =
+            prefill.device_ptr(internvl_expand_layer_name(config.present_k_pattern, layer));
+        present_v[index] =
+            prefill.device_ptr(internvl_expand_layer_name(config.present_v_pattern, layer));
+        if (present_k[index] == nullptr || present_v[index] == nullptr)
+            return false;
+    }
+    return true;
+}
+
+InternvlKvCache* eligible_vl_prefill_cache(TrtModule* prefill, InternvlInferenceState* state,
+                                           const InternVlConfig& config, int32_t sequence_length,
+                                           int32_t feature_dim) {
+    if (prefill == nullptr)
+        return nullptr;
+    if (sequence_length <= 0 || feature_dim <= 0 || config.num_layers <= 0)
+        return nullptr;
+    if (!prefill->has_input("input_embed"))
+        return nullptr;
+    if (config.prefill_max_length > 0 && sequence_length > config.prefill_max_length)
+        return nullptr;
+    return dynamic_cast<InternvlKvCache*>(state);
+}
+
+bool valid_vl_features(const std::vector<float>& image_features, int32_t num_features,
+                       int32_t feature_dim) {
+    if (num_features < 0)
+        return false;
+    const auto required =
+        static_cast<std::size_t>(num_features) * static_cast<std::size_t>(feature_dim);
+    return image_features.size() >= required;
+}
+
+void add_vl_prefill_base_inputs(TensorMap& inputs, InternvlInferenceState& state,
+                                const std::vector<int32_t>& input_ids,
+                                VlSequenceEmbeddingInputs& embedding_inputs, int32_t feature_dim) {
+    const auto sequence_length = static_cast<int32_t>(input_ids.size());
+    inputs["token_id"] =
+        Tensor{const_cast<int32_t*>(input_ids.data()), {sequence_length}, DType::kInt32};
+    state.prepare_step(inputs, sequence_length);
+    inputs["input_embed"] = Tensor{
+        embedding_inputs.input_embed.data(), {sequence_length, feature_dim}, DType::kFloat32};
+    inputs["use_input_embed"] =
+        Tensor{embedding_inputs.use_input_embed.data(), {sequence_length, 1}, DType::kFloat32};
+}
+
+bool add_vl_prefill_deepstack_inputs(TrtModule& prefill, TensorMap& inputs,
+                                     VlSequenceEmbeddingInputs& embedding_inputs,
+                                     int32_t sequence_length, int32_t feature_dim) {
+    if (!prefill.has_input("deepstack_active"))
+        return true;
+    inputs["deepstack_active"] =
+        Tensor{embedding_inputs.deepstack_active.data(), {sequence_length, 1}, DType::kFloat32};
+    for (std::size_t level = 0;; ++level) {
+        const auto name = "deepstack_embed_" + std::to_string(level);
+        if (!prefill.has_input(name))
+            break;
+        if (level >= embedding_inputs.deepstack_embed.size())
+            return false;
+        inputs[name] = Tensor{embedding_inputs.deepstack_embed[level].data(),
+                              {sequence_length, feature_dim},
+                              DType::kFloat32};
+    }
+    return true;
+}
+
+bool copy_last_prefill_logits(const TensorMap& outputs, int32_t vocab_size,
+                              std::vector<float>& logits) {
+    const auto logits_it = outputs.find("logits");
+    if (logits_it == outputs.end())
+        return false;
+    const auto size = static_cast<std::size_t>(vocab_size);
+    if (logits_it->second.numel() < size)
+        return false;
+    const auto offset = logits_it->second.numel() - size;
+    logits.resize(size);
+    std::memcpy(logits.data(), static_cast<const float*>(logits_it->second.data) + offset,
+                size * sizeof(float));
+    return true;
+}
+
+int32_t resolve_input_embed_dim(const TrtModule& decoder, int32_t configured_dim) {
+    if (configured_dim > 0)
+        return configured_dim;
+    const auto declared_shape = decoder.tensor_shape("input_embed");
+    if (!declared_shape.empty())
+        return static_cast<int32_t>(declared_shape.back());
+    throw std::runtime_error("InternVlPipeline: invalid input embedding dimension");
+}
+
+std::vector<int64_t> selector_shape(const TrtModule& decoder, const std::string& name) {
+    return decoder.input_rank(name) == 2 ? std::vector<int64_t>{1, 1} : std::vector<int64_t>{1};
+}
+
+void add_text_step_deepstack_inputs(TrtModule& decoder, TensorMap& inputs, int32_t embed_dim,
+                                    const std::vector<const float*>& deepstack_embeds,
+                                    float& deepstack_active, std::vector<float>& zero_deepstack) {
+    if (!decoder.has_input("deepstack_active"))
+        return;
+    inputs["deepstack_active"] =
+        Tensor{&deepstack_active, selector_shape(decoder, "deepstack_active"), DType::kFloat32};
+    for (std::size_t index = 0;; ++index) {
+        const auto name = "deepstack_embed_" + std::to_string(index);
+        if (!decoder.has_input(name))
+            break;
+        const float* embed = index < deepstack_embeds.size() ? deepstack_embeds[index] : nullptr;
+        if (embed == nullptr) {
+            if (zero_deepstack.empty())
+                zero_deepstack.resize(static_cast<std::size_t>(embed_dim), 0.0F);
+            embed = zero_deepstack.data();
+        }
+        inputs[name] = Tensor{const_cast<float*>(embed), {1, embed_dim}, DType::kFloat32};
+    }
+}
+
+void add_text_step_embedding_inputs(TrtModule& decoder, const InternVlConfig& config,
+                                    TensorMap& inputs, const float* input_embed,
+                                    float& use_input_embed,
+                                    const std::vector<const float*>& deepstack_embeds,
+                                    float& deepstack_active, std::vector<float>& zero_embed,
+                                    std::vector<float>& zero_deepstack) {
+    if (!decoder.has_input("input_embed"))
+        return;
+    const int32_t embed_dim = resolve_input_embed_dim(decoder, config.vision_output_dim);
+    if (input_embed == nullptr) {
+        zero_embed.resize(static_cast<std::size_t>(embed_dim), 0.0F);
+        input_embed = zero_embed.data();
+    }
+    inputs["input_embed"] =
+        Tensor{const_cast<float*>(input_embed), {1, embed_dim}, DType::kFloat32};
+    inputs["use_input_embed"] =
+        Tensor{&use_input_embed, selector_shape(decoder, "use_input_embed"), DType::kFloat32};
+    add_text_step_deepstack_inputs(decoder, inputs, embed_dim, deepstack_embeds, deepstack_active,
+                                   zero_deepstack);
 }
 
 Tensor make_pixel_values_tensor(const InternVlPreprocessedImage& preprocessed,
@@ -223,6 +425,10 @@ std::vector<int32_t> InternVlPipeline::generate_from_ids(const std::vector<int32
     active_sampler->reset();
 
     state_->reset();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
     state_->bind_to(*text_decoder_);
 
     std::vector<float> logits;
@@ -263,18 +469,59 @@ std::vector<int32_t> InternVlPipeline::generate_vl_from_ids(
     active_sampler->reset();
 
     state_->reset();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
     state_->bind_to(*text_decoder_);
 
     std::vector<float> logits;
-    int32_t feature_index = 0;
-
-    for (const auto& tid : input_ids)
-        run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
-                             feature_index, logits);
+    if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,
+                                feature_dim, logits)) {
+        int32_t feature_index = 0;
+        for (const auto& tid : input_ids)
+            run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
+                                 feature_index, logits);
+    }
+    state_->mark_prefill_complete();
 
     std::vector<int32_t> output = input_ids;
     run_vl_decode_loop(active_sampler, params, output, logits, max_new_tokens);
     return output;
+}
+
+bool InternVlPipeline::run_vl_prefill_batched(
+    const std::vector<int32_t>& input_ids, const std::vector<float>& image_features,
+    const std::vector<std::vector<float>>& deepstack_features, int32_t num_features,
+    int32_t feature_dim, std::vector<float>& logits) {
+    const auto sq = static_cast<int32_t>(input_ids.size());
+    auto* kv_cache =
+        eligible_vl_prefill_cache(prefill_.get(), state_.get(), config_, sq, feature_dim);
+    if (kv_cache == nullptr)
+        return false;
+    if (!valid_vl_features(image_features, num_features, feature_dim))
+        return false;
+
+    kv_cache->bind_cache_inputs(*prefill_);
+    auto embedding_inputs =
+        build_vl_sequence_embedding_inputs(input_ids, config_.image_token_id, image_features,
+                                           deepstack_features, num_features, feature_dim);
+
+    TensorMap inputs;
+    add_vl_prefill_base_inputs(inputs, *state_, input_ids, embedding_inputs, feature_dim);
+    if (!add_vl_prefill_deepstack_inputs(*prefill_, inputs, embedding_inputs, sq, feature_dim))
+        return false;
+
+    auto outputs = prefill_->forward(inputs);
+    if (!copy_last_prefill_logits(outputs, config_.vocab_size, logits))
+        return false;
+
+    std::vector<const void*> present_k;
+    std::vector<const void*> present_v;
+    if (!gather_vl_prefill_kv_pointers(*prefill_, config_, present_k, present_v))
+        return false;
+    kv_cache->write_prefill_kv(present_k, present_v, sq);
+    return true;
 }
 
 void InternVlPipeline::run_vl_prefill_token(
@@ -311,27 +558,7 @@ void InternVlPipeline::run_vl_decode_loop(InternVlISampler* sampler,
 }
 
 void InternVlPipeline::run_text_step(int32_t token_id, std::vector<float>& logits) {
-    TensorMap inputs;
-
-    Tensor token_t;
-    token_t.data = &token_id;
-    token_t.shape = {1};
-    token_t.dtype = DType::kInt32;
-    inputs["token_id"] = token_t;
-
-    state_->prepare_step(inputs);
-
-    auto outputs = text_decoder_->forward(inputs);
-
-    auto it = outputs.find("logits");
-    if (it == outputs.end())
-        throw std::runtime_error("InternVlPipeline: no 'logits' output");
-
-    auto n = it->second.numel();
-    logits.resize(static_cast<std::size_t>(n));
-    std::memcpy(logits.data(), it->second.data, n * sizeof(float));
-
-    state_->advance();
+    run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, logits);
 }
 
 void InternVlPipeline::run_text_step_with_embed(int32_t token_id, const float* input_embed,
@@ -339,11 +566,6 @@ void InternVlPipeline::run_text_step_with_embed(int32_t token_id, const float* i
                                                 const std::vector<const float*>& deepstack_embeds,
                                                 float deepstack_active,
                                                 std::vector<float>& logits) {
-    if (!text_decoder_->has_input("input_embed")) {
-        run_text_step(token_id, logits);
-        return;
-    }
-
     TensorMap inputs;
 
     Tensor token_t;
@@ -354,56 +576,10 @@ void InternVlPipeline::run_text_step_with_embed(int32_t token_id, const float* i
 
     state_->prepare_step(inputs);
 
-    // use_input_embed scalar: 1.0 = use input_embed, 0.0 = use token embedding
-    Tensor use_embed_t;
-    use_embed_t.data = &use_input_embed;
-    use_embed_t.shape = {1};
-    use_embed_t.dtype = DType::kFloat32;
-    inputs["use_input_embed"] = use_embed_t;
-
-    // Provide the input embedding vector
-    int32_t embed_dim = config_.vision_output_dim;
     std::vector<float> zero_embed;
-    if (input_embed == nullptr) {
-        zero_embed.resize(static_cast<std::size_t>(embed_dim), 0.0F);
-        input_embed = zero_embed.data();
-    }
-
-    Tensor embed_t;
-    embed_t.data = const_cast<float*>(input_embed);
-    embed_t.shape = {static_cast<int64_t>(embed_dim)};
-    embed_t.dtype = DType::kFloat32;
-    inputs["input_embed"] = embed_t;
-
-    // DeepStack: if the engine has deepstack inputs, provide inactive zeros.
-    if (text_decoder_->has_input("deepstack_active")) {
-        Tensor ds_active_t;
-        ds_active_t.data = &deepstack_active;
-        ds_active_t.shape = {1};
-        ds_active_t.dtype = DType::kFloat32;
-        inputs["deepstack_active"] = ds_active_t;
-
-        std::vector<float> zero_deepstack;
-        for (std::size_t i = 0;; ++i) {
-            const std::string name = "deepstack_embed_" + std::to_string(i);
-            if (!text_decoder_->has_input(name))
-                break;
-
-            const float* deepstack_embed =
-                i < deepstack_embeds.size() ? deepstack_embeds[i] : nullptr;
-            if (deepstack_embed == nullptr) {
-                if (zero_deepstack.empty())
-                    zero_deepstack.resize(static_cast<std::size_t>(embed_dim), 0.0F);
-                deepstack_embed = zero_deepstack.data();
-            }
-
-            Tensor ds_embed_t;
-            ds_embed_t.data = const_cast<float*>(deepstack_embed);
-            ds_embed_t.shape = {1, static_cast<int64_t>(embed_dim)};
-            ds_embed_t.dtype = DType::kFloat32;
-            inputs[name] = ds_embed_t;
-        }
-    }
+    std::vector<float> zero_deepstack;
+    add_text_step_embedding_inputs(*text_decoder_, config_, inputs, input_embed, use_input_embed,
+                                   deepstack_embeds, deepstack_active, zero_embed, zero_deepstack);
 
     auto outputs = text_decoder_->forward(inputs);
 

--- a/src/runtime/models/internvl/pipeline.h
+++ b/src/runtime/models/internvl/pipeline.h
@@ -31,6 +31,10 @@ struct InternVlConfig {
     int32_t image_token_id{-1};
     int32_t vision_output_dim{0};
     bool has_position_input{true};
+    int32_t num_layers{0};
+    int32_t prefill_max_length{0};
+    std::string present_k_pattern{"present_k_{i}"};
+    std::string present_v_pattern{"present_v_{i}"};
 };
 
 class InternVlPipeline final : public IPipeline {
@@ -40,7 +44,8 @@ class InternVlPipeline final : public IPipeline {
                      std::unique_ptr<InternvlInferenceState> state, InternVlConfig config,
                      InternVlPreprocessConfig vl_preprocess, cudaStream_t stream,
                      std::shared_ptr<ITokenizer> tokenizer = nullptr, std::string model_id_str = "",
-                     std::unique_ptr<InternVlISampler> sampler = nullptr);
+                     std::unique_ptr<InternVlISampler> sampler = nullptr,
+                     std::unique_ptr<TrtModule> prefill = nullptr);
 
     TextResult generate(const std::string& prompt, const GenerateConfig& cfg = {}) override;
 
@@ -64,6 +69,7 @@ class InternVlPipeline final : public IPipeline {
 
   private:
     std::unique_ptr<TrtModule> text_decoder_;
+    std::unique_ptr<TrtModule> prefill_;
     std::unique_ptr<TrtModule> vision_encoder_;
     std::unique_ptr<InternvlInferenceState> state_;
     InternVlConfig config_;
@@ -89,6 +95,12 @@ class InternVlPipeline final : public IPipeline {
                               const std::vector<std::vector<float>>& deepstack_features,
                               int32_t num_features, int32_t feature_dim, int32_t& feature_index,
                               std::vector<float>& logits);
+
+    bool run_vl_prefill_batched(const std::vector<int32_t>& input_ids,
+                                const std::vector<float>& image_features,
+                                const std::vector<std::vector<float>>& deepstack_features,
+                                int32_t num_features, int32_t feature_dim,
+                                std::vector<float>& logits);
 
     void run_vl_decode_loop(InternVlISampler* sampler, const InternVlSamplingParams& params,
                             std::vector<int32_t>& output, std::vector<float>& logits,

--- a/src/runtime/models/internvl/plugin.cpp
+++ b/src/runtime/models/internvl/plugin.cpp
@@ -92,14 +92,19 @@ InternvlKvCacheNames build_kv_cache_names(const BaseConfig& config) {
     return kv_names;
 }
 
-LoadedModule load_text_module(const PipelineContext& ctx, TextModuleRuntime& runtime,
-                              const std::shared_ptr<InternVlCudaStream>& stream) {
+DualProfileModules load_text_modules(const PipelineContext& ctx, TextModuleRuntime& runtime,
+                                     const std::shared_ptr<InternVlCudaStream>& stream) {
     auto loaded =
-        load_trt_module_from_plan(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
+        load_dual_profile_modules(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
                                   runtime.engine_section.c_str(), runtime.options);
-    loaded.module->keep_alive(stream);
-    if (runtime.tp_group.owner)
-        loaded.module->keep_alive(runtime.tp_group.owner);
+    loaded.decode->keep_alive(stream);
+    if (loaded.prefill)
+        loaded.prefill->keep_alive(stream);
+    if (runtime.tp_group.owner) {
+        loaded.decode->keep_alive(runtime.tp_group.owner);
+        if (loaded.prefill)
+            loaded.prefill->keep_alive(runtime.tp_group.owner);
+    }
     return loaded;
 }
 
@@ -152,12 +157,12 @@ class VLPlugin final : public IPipelinePlugin {
 
         InternvlKvCacheNames kv_names = build_kv_cache_names(ctx.config);
 
-        auto loaded = load_text_module(ctx, text_runtime, shared_stream);
+        auto loaded = load_text_modules(ctx, text_runtime, shared_stream);
 
-        cudaStream_t stream = loaded.module->stream();
+        cudaStream_t stream = loaded.decode->stream();
         const std::string cache_k_name =
             kv_names.cache_k.empty() ? std::string("cache_k_0") : kv_names.cache_k.front();
-        int32_t kv_dim = decoder_cache_row_width(*loaded.module, cache_k_name, ctx.config);
+        int32_t kv_dim = decoder_cache_row_width(*loaded.decode, cache_k_name, ctx.config);
         DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
         std::unique_ptr<InternvlInferenceState> state =
             std::make_unique<InternvlKvCache>(ctx.config.num_layers, ctx.config.max_cache_length,
@@ -171,7 +176,11 @@ class VLPlugin final : public IPipelinePlugin {
         vlc.id_eos = ctx.config.id_eos;
         vlc.image_token_id = extract_json_int(ctx.config_json, "image_token_id", -1);
         vlc.vision_output_dim = extract_json_int(ctx.config_json, "vision_output_dim", 0);
-        vlc.has_position_input = loaded.module->has_input("position_id");
+        vlc.has_position_input = loaded.decode->has_input("position_id");
+        vlc.num_layers = ctx.config.num_layers;
+        vlc.prefill_max_length = ctx.config.max_cache_length;
+        vlc.present_k_pattern = ctx.config.io_map.present_k_pattern;
+        vlc.present_v_pattern = ctx.config.io_map.present_v_pattern;
 
         bool has_vision_engine = extract_json_int(ctx.config_json, "has_vision_engine", 0) != 0;
 
@@ -187,8 +196,9 @@ class VLPlugin final : public IPipelinePlugin {
         auto vl_preprocess = internvl_parse_preprocess_config(config_text, preproc_text);
 
         return std::make_unique<InternVlPipeline>(
-            std::move(loaded.module), std::move(vision_module), std::move(state), vlc,
-            vl_preprocess, stream, std::move(tokenizer), ctx.bundle.info.model_id);
+            std::move(loaded.decode), std::move(vision_module), std::move(state), vlc,
+            vl_preprocess, stream, std::move(tokenizer), ctx.bundle.info.model_id, nullptr,
+            std::move(loaded.prefill));
     }
 };
 

--- a/src/runtime/models/lance/pipeline.cpp
+++ b/src/runtime/models/lance/pipeline.cpp
@@ -6,6 +6,7 @@
 #include "runtime/models/lance/pipeline.h"
 
 #include "runtime/models/lance/image_preprocessor.h"
+#include "runtime/models/lance/tensor_names.h"
 
 #include <algorithm>
 #include <cstring>
@@ -14,26 +15,40 @@
 
 namespace trtmc {
 
+namespace {
+
+void validate_pipeline_components(const TrtModule* text_decoder, const LanceInferenceState* state,
+                                  const TrtModule* prefill) {
+    if (text_decoder == nullptr || !text_decoder->ok())
+        throw std::runtime_error("LancePipeline: invalid text decoder");
+    if (state == nullptr || !state->ok())
+        throw std::runtime_error("LancePipeline: invalid inference state");
+    if (prefill != nullptr && !prefill->ok())
+        throw std::runtime_error("LancePipeline: invalid prefill decoder");
+}
+
+void sync_vision_config(LanceConfig& config, const LancePreprocessConfig& preprocess) {
+    if (config.image_token_id < 0 && preprocess.image_token_id >= 0)
+        config.image_token_id = preprocess.image_token_id;
+    if (config.vision_output_dim <= 0 && preprocess.vision_output_dim > 0)
+        config.vision_output_dim = preprocess.vision_output_dim;
+}
+
+} // namespace
+
 LancePipeline::LancePipeline(std::unique_ptr<TrtModule> text_decoder,
                              std::unique_ptr<TrtModule> vision_encoder,
                              std::unique_ptr<LanceInferenceState> state, LanceConfig config,
                              LancePreprocessConfig vl_preprocess, cudaStream_t stream,
                              std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
-                             std::unique_ptr<LanceISampler> sampler)
-    : text_decoder_(std::move(text_decoder)), vision_encoder_(std::move(vision_encoder)),
-      state_(std::move(state)), config_(config), vl_preprocess_(std::move(vl_preprocess)),
-      stream_(stream), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
-      sampler_(std::move(sampler)) {
-    if (!text_decoder_ || !text_decoder_->ok())
-        throw std::runtime_error("LancePipeline: invalid text decoder");
-    if (!state_ || !state_->ok())
-        throw std::runtime_error("LancePipeline: invalid inference state");
-
-    // Sync image_token_id from LancePreprocessConfig if not set in LanceConfig
-    if (config_.image_token_id < 0 && vl_preprocess_.image_token_id >= 0)
-        config_.image_token_id = vl_preprocess_.image_token_id;
-    if (config_.vision_output_dim <= 0 && vl_preprocess_.vision_output_dim > 0)
-        config_.vision_output_dim = vl_preprocess_.vision_output_dim;
+                             std::unique_ptr<LanceISampler> sampler,
+                             std::unique_ptr<TrtModule> prefill)
+    : text_decoder_(std::move(text_decoder)), prefill_(std::move(prefill)),
+      vision_encoder_(std::move(vision_encoder)), state_(std::move(state)), config_(config),
+      vl_preprocess_(std::move(vl_preprocess)), stream_(stream), tokenizer_(std::move(tokenizer)),
+      model_id_(std::move(model_id_str)), sampler_(std::move(sampler)) {
+    validate_pipeline_components(text_decoder_.get(), state_.get(), prefill_.get());
+    sync_vision_config(config_, vl_preprocess_);
 }
 
 TextResult LancePipeline::generate(const std::string& prompt, const GenerateConfig& cfg) {
@@ -93,6 +108,193 @@ select_deepstack_feature_pointers(const std::vector<std::vector<float>>& deepsta
                              : nullptr);
     }
     return embeds;
+}
+
+struct VlSequenceEmbeddingInputs {
+    std::vector<float> input_embed;
+    std::vector<float> use_input_embed;
+    std::vector<std::vector<float>> deepstack_embed;
+    std::vector<float> deepstack_active;
+};
+
+VlSequenceEmbeddingInputs
+build_vl_sequence_embedding_inputs(const std::vector<int32_t>& input_ids, int32_t image_token_id,
+                                   const std::vector<float>& image_features,
+                                   const std::vector<std::vector<float>>& deepstack_features,
+                                   int32_t num_features, int32_t feature_dim) {
+    const auto sq = input_ids.size();
+    VlSequenceEmbeddingInputs result;
+    result.input_embed.assign(sq * static_cast<std::size_t>(feature_dim), 0.0F);
+    result.use_input_embed.assign(sq, 0.0F);
+    result.deepstack_active.assign(sq, 0.0F);
+    result.deepstack_embed.resize(deepstack_features.size());
+    for (auto& level : result.deepstack_embed)
+        level.assign(sq * static_cast<std::size_t>(feature_dim), 0.0F);
+
+    int32_t feature_index = 0;
+    for (std::size_t token_index = 0; token_index < sq; ++token_index) {
+        if (input_ids[token_index] != image_token_id || feature_index >= num_features)
+            continue;
+        const auto source_offset = static_cast<std::size_t>(feature_index) * feature_dim;
+        const auto target_offset = token_index * static_cast<std::size_t>(feature_dim);
+        std::copy_n(image_features.data() + source_offset, feature_dim,
+                    result.input_embed.data() + target_offset);
+        result.use_input_embed[token_index] = 1.0F;
+
+        for (std::size_t level_index = 0; level_index < deepstack_features.size(); ++level_index) {
+            const auto& source = deepstack_features[level_index];
+            if (source_offset + static_cast<std::size_t>(feature_dim) > source.size())
+                continue;
+            std::copy_n(source.data() + source_offset, feature_dim,
+                        result.deepstack_embed[level_index].data() + target_offset);
+            result.deepstack_active[token_index] = 1.0F;
+        }
+        ++feature_index;
+    }
+    return result;
+}
+
+bool gather_vl_prefill_kv_pointers(TrtModule& prefill, const LanceConfig& config,
+                                   std::vector<const void*>& present_k,
+                                   std::vector<const void*>& present_v) {
+    present_k.resize(static_cast<std::size_t>(config.num_layers));
+    present_v.resize(static_cast<std::size_t>(config.num_layers));
+    for (int32_t layer = 0; layer < config.num_layers; ++layer) {
+        const auto index = static_cast<std::size_t>(layer);
+        present_k[index] =
+            prefill.device_ptr(lance_expand_layer_name(config.present_k_pattern, layer));
+        present_v[index] =
+            prefill.device_ptr(lance_expand_layer_name(config.present_v_pattern, layer));
+        if (present_k[index] == nullptr || present_v[index] == nullptr)
+            return false;
+    }
+    return true;
+}
+
+LanceKvCache* eligible_vl_prefill_cache(TrtModule* prefill, LanceInferenceState* state,
+                                        const LanceConfig& config, int32_t sequence_length,
+                                        int32_t feature_dim) {
+    if (prefill == nullptr)
+        return nullptr;
+    if (sequence_length <= 0 || feature_dim <= 0 || config.num_layers <= 0)
+        return nullptr;
+    if (!prefill->has_input("input_embed"))
+        return nullptr;
+    if (config.prefill_max_length > 0 && sequence_length > config.prefill_max_length)
+        return nullptr;
+    return dynamic_cast<LanceKvCache*>(state);
+}
+
+bool valid_vl_features(const std::vector<float>& image_features, int32_t num_features,
+                       int32_t feature_dim) {
+    if (num_features < 0)
+        return false;
+    const auto required =
+        static_cast<std::size_t>(num_features) * static_cast<std::size_t>(feature_dim);
+    return image_features.size() >= required;
+}
+
+void add_vl_prefill_base_inputs(TensorMap& inputs, LanceInferenceState& state,
+                                const std::vector<int32_t>& input_ids,
+                                VlSequenceEmbeddingInputs& embedding_inputs, int32_t feature_dim) {
+    const auto sequence_length = static_cast<int32_t>(input_ids.size());
+    inputs["token_id"] =
+        Tensor{const_cast<int32_t*>(input_ids.data()), {sequence_length}, DType::kInt32};
+    state.prepare_step(inputs, sequence_length);
+    inputs["input_embed"] = Tensor{
+        embedding_inputs.input_embed.data(), {sequence_length, feature_dim}, DType::kFloat32};
+    inputs["use_input_embed"] =
+        Tensor{embedding_inputs.use_input_embed.data(), {sequence_length, 1}, DType::kFloat32};
+}
+
+bool add_vl_prefill_deepstack_inputs(TrtModule& prefill, TensorMap& inputs,
+                                     VlSequenceEmbeddingInputs& embedding_inputs,
+                                     int32_t sequence_length, int32_t feature_dim) {
+    if (!prefill.has_input("deepstack_active"))
+        return true;
+    inputs["deepstack_active"] =
+        Tensor{embedding_inputs.deepstack_active.data(), {sequence_length, 1}, DType::kFloat32};
+    for (std::size_t level = 0;; ++level) {
+        const auto name = "deepstack_embed_" + std::to_string(level);
+        if (!prefill.has_input(name))
+            break;
+        if (level >= embedding_inputs.deepstack_embed.size())
+            return false;
+        inputs[name] = Tensor{embedding_inputs.deepstack_embed[level].data(),
+                              {sequence_length, feature_dim},
+                              DType::kFloat32};
+    }
+    return true;
+}
+
+bool copy_last_prefill_logits(const TensorMap& outputs, int32_t vocab_size,
+                              std::vector<float>& logits) {
+    const auto logits_it = outputs.find("logits");
+    if (logits_it == outputs.end())
+        return false;
+    const auto size = static_cast<std::size_t>(vocab_size);
+    if (logits_it->second.numel() < size)
+        return false;
+    const auto offset = logits_it->second.numel() - size;
+    logits.resize(size);
+    std::memcpy(logits.data(), static_cast<const float*>(logits_it->second.data) + offset,
+                size * sizeof(float));
+    return true;
+}
+
+int32_t resolve_input_embed_dim(const TrtModule& decoder, int32_t configured_dim) {
+    if (configured_dim > 0)
+        return configured_dim;
+    const auto declared_shape = decoder.tensor_shape("input_embed");
+    if (!declared_shape.empty())
+        return static_cast<int32_t>(declared_shape.back());
+    throw std::runtime_error("LancePipeline: invalid input embedding dimension");
+}
+
+std::vector<int64_t> selector_shape(const TrtModule& decoder, const std::string& name) {
+    return decoder.input_rank(name) == 2 ? std::vector<int64_t>{1, 1} : std::vector<int64_t>{1};
+}
+
+void add_text_step_deepstack_inputs(TrtModule& decoder, TensorMap& inputs, int32_t embed_dim,
+                                    const std::vector<const float*>& deepstack_embeds,
+                                    float& deepstack_active, std::vector<float>& zero_deepstack) {
+    if (!decoder.has_input("deepstack_active"))
+        return;
+    inputs["deepstack_active"] =
+        Tensor{&deepstack_active, selector_shape(decoder, "deepstack_active"), DType::kFloat32};
+    for (std::size_t index = 0;; ++index) {
+        const auto name = "deepstack_embed_" + std::to_string(index);
+        if (!decoder.has_input(name))
+            break;
+        const float* embed = index < deepstack_embeds.size() ? deepstack_embeds[index] : nullptr;
+        if (embed == nullptr) {
+            if (zero_deepstack.empty())
+                zero_deepstack.resize(static_cast<std::size_t>(embed_dim), 0.0F);
+            embed = zero_deepstack.data();
+        }
+        inputs[name] = Tensor{const_cast<float*>(embed), {1, embed_dim}, DType::kFloat32};
+    }
+}
+
+void add_text_step_embedding_inputs(TrtModule& decoder, const LanceConfig& config,
+                                    TensorMap& inputs, const float* input_embed,
+                                    float& use_input_embed,
+                                    const std::vector<const float*>& deepstack_embeds,
+                                    float& deepstack_active, std::vector<float>& zero_embed,
+                                    std::vector<float>& zero_deepstack) {
+    if (!decoder.has_input("input_embed"))
+        return;
+    const int32_t embed_dim = resolve_input_embed_dim(decoder, config.vision_output_dim);
+    if (input_embed == nullptr) {
+        zero_embed.resize(static_cast<std::size_t>(embed_dim), 0.0F);
+        input_embed = zero_embed.data();
+    }
+    inputs["input_embed"] =
+        Tensor{const_cast<float*>(input_embed), {1, embed_dim}, DType::kFloat32};
+    inputs["use_input_embed"] =
+        Tensor{&use_input_embed, selector_shape(decoder, "use_input_embed"), DType::kFloat32};
+    add_text_step_deepstack_inputs(decoder, inputs, embed_dim, deepstack_embeds, deepstack_active,
+                                   zero_deepstack);
 }
 
 Tensor make_pixel_values_tensor(const LancePreprocessedImage& preprocessed,
@@ -222,6 +424,10 @@ std::vector<int32_t> LancePipeline::generate_from_ids(const std::vector<int32_t>
     active_sampler->reset();
 
     state_->reset();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
     state_->bind_to(*text_decoder_);
 
     std::vector<float> logits;
@@ -262,18 +468,59 @@ std::vector<int32_t> LancePipeline::generate_vl_from_ids(
     active_sampler->reset();
 
     state_->reset();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
     state_->bind_to(*text_decoder_);
 
     std::vector<float> logits;
-    int32_t feature_index = 0;
-
-    for (const auto& tid : input_ids)
-        run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
-                             feature_index, logits);
+    if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,
+                                feature_dim, logits)) {
+        int32_t feature_index = 0;
+        for (const auto& tid : input_ids)
+            run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
+                                 feature_index, logits);
+    }
+    state_->mark_prefill_complete();
 
     std::vector<int32_t> output = input_ids;
     run_vl_decode_loop(active_sampler, params, output, logits, max_new_tokens);
     return output;
+}
+
+bool LancePipeline::run_vl_prefill_batched(
+    const std::vector<int32_t>& input_ids, const std::vector<float>& image_features,
+    const std::vector<std::vector<float>>& deepstack_features, int32_t num_features,
+    int32_t feature_dim, std::vector<float>& logits) {
+    const auto sq = static_cast<int32_t>(input_ids.size());
+    auto* kv_cache =
+        eligible_vl_prefill_cache(prefill_.get(), state_.get(), config_, sq, feature_dim);
+    if (kv_cache == nullptr)
+        return false;
+    if (!valid_vl_features(image_features, num_features, feature_dim))
+        return false;
+
+    kv_cache->bind_cache_inputs(*prefill_);
+    auto embedding_inputs =
+        build_vl_sequence_embedding_inputs(input_ids, config_.image_token_id, image_features,
+                                           deepstack_features, num_features, feature_dim);
+
+    TensorMap inputs;
+    add_vl_prefill_base_inputs(inputs, *state_, input_ids, embedding_inputs, feature_dim);
+    if (!add_vl_prefill_deepstack_inputs(*prefill_, inputs, embedding_inputs, sq, feature_dim))
+        return false;
+
+    auto outputs = prefill_->forward(inputs);
+    if (!copy_last_prefill_logits(outputs, config_.vocab_size, logits))
+        return false;
+
+    std::vector<const void*> present_k;
+    std::vector<const void*> present_v;
+    if (!gather_vl_prefill_kv_pointers(*prefill_, config_, present_k, present_v))
+        return false;
+    kv_cache->write_prefill_kv(present_k, present_v, sq);
+    return true;
 }
 
 void LancePipeline::run_vl_prefill_token(int32_t token_id, const std::vector<float>& image_features,
@@ -309,38 +556,13 @@ void LancePipeline::run_vl_decode_loop(LanceISampler* sampler, const LanceSampli
 }
 
 void LancePipeline::run_text_step(int32_t token_id, std::vector<float>& logits) {
-    TensorMap inputs;
-
-    Tensor token_t;
-    token_t.data = &token_id;
-    token_t.shape = {1};
-    token_t.dtype = DType::kInt32;
-    inputs["token_id"] = token_t;
-
-    state_->prepare_step(inputs);
-
-    auto outputs = text_decoder_->forward(inputs);
-
-    auto it = outputs.find("logits");
-    if (it == outputs.end())
-        throw std::runtime_error("LancePipeline: no 'logits' output");
-
-    auto n = it->second.numel();
-    logits.resize(static_cast<std::size_t>(n));
-    std::memcpy(logits.data(), it->second.data, n * sizeof(float));
-
-    state_->advance();
+    run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, logits);
 }
 
 void LancePipeline::run_text_step_with_embed(int32_t token_id, const float* input_embed,
                                              float use_input_embed,
                                              const std::vector<const float*>& deepstack_embeds,
                                              float deepstack_active, std::vector<float>& logits) {
-    if (!text_decoder_->has_input("input_embed")) {
-        run_text_step(token_id, logits);
-        return;
-    }
-
     TensorMap inputs;
 
     Tensor token_t;
@@ -351,56 +573,10 @@ void LancePipeline::run_text_step_with_embed(int32_t token_id, const float* inpu
 
     state_->prepare_step(inputs);
 
-    // use_input_embed scalar: 1.0 = use input_embed, 0.0 = use token embedding
-    Tensor use_embed_t;
-    use_embed_t.data = &use_input_embed;
-    use_embed_t.shape = {1};
-    use_embed_t.dtype = DType::kFloat32;
-    inputs["use_input_embed"] = use_embed_t;
-
-    // Provide the input embedding vector
-    int32_t embed_dim = config_.vision_output_dim;
     std::vector<float> zero_embed;
-    if (input_embed == nullptr) {
-        zero_embed.resize(static_cast<std::size_t>(embed_dim), 0.0F);
-        input_embed = zero_embed.data();
-    }
-
-    Tensor embed_t;
-    embed_t.data = const_cast<float*>(input_embed);
-    embed_t.shape = {static_cast<int64_t>(embed_dim)};
-    embed_t.dtype = DType::kFloat32;
-    inputs["input_embed"] = embed_t;
-
-    // DeepStack: if the engine has deepstack inputs, provide inactive zeros.
-    if (text_decoder_->has_input("deepstack_active")) {
-        Tensor ds_active_t;
-        ds_active_t.data = &deepstack_active;
-        ds_active_t.shape = {1};
-        ds_active_t.dtype = DType::kFloat32;
-        inputs["deepstack_active"] = ds_active_t;
-
-        std::vector<float> zero_deepstack;
-        for (std::size_t i = 0;; ++i) {
-            const std::string name = "deepstack_embed_" + std::to_string(i);
-            if (!text_decoder_->has_input(name))
-                break;
-
-            const float* deepstack_embed =
-                i < deepstack_embeds.size() ? deepstack_embeds[i] : nullptr;
-            if (deepstack_embed == nullptr) {
-                if (zero_deepstack.empty())
-                    zero_deepstack.resize(static_cast<std::size_t>(embed_dim), 0.0F);
-                deepstack_embed = zero_deepstack.data();
-            }
-
-            Tensor ds_embed_t;
-            ds_embed_t.data = const_cast<float*>(deepstack_embed);
-            ds_embed_t.shape = {1, static_cast<int64_t>(embed_dim)};
-            ds_embed_t.dtype = DType::kFloat32;
-            inputs[name] = ds_embed_t;
-        }
-    }
+    std::vector<float> zero_deepstack;
+    add_text_step_embedding_inputs(*text_decoder_, config_, inputs, input_embed, use_input_embed,
+                                   deepstack_embeds, deepstack_active, zero_embed, zero_deepstack);
 
     auto outputs = text_decoder_->forward(inputs);
 

--- a/src/runtime/models/lance/pipeline.h
+++ b/src/runtime/models/lance/pipeline.h
@@ -31,6 +31,10 @@ struct LanceConfig {
     int32_t image_token_id{-1};
     int32_t vision_output_dim{0};
     bool has_position_input{true};
+    int32_t num_layers{0};
+    int32_t prefill_max_length{0};
+    std::string present_k_pattern{"present_k_{i}"};
+    std::string present_v_pattern{"present_v_{i}"};
 };
 
 class LancePipeline final : public IPipeline {
@@ -40,7 +44,8 @@ class LancePipeline final : public IPipeline {
                   std::unique_ptr<LanceInferenceState> state, LanceConfig config,
                   LancePreprocessConfig vl_preprocess, cudaStream_t stream,
                   std::shared_ptr<ITokenizer> tokenizer = nullptr, std::string model_id_str = "",
-                  std::unique_ptr<LanceISampler> sampler = nullptr);
+                  std::unique_ptr<LanceISampler> sampler = nullptr,
+                  std::unique_ptr<TrtModule> prefill = nullptr);
 
     TextResult generate(const std::string& prompt, const GenerateConfig& cfg = {}) override;
 
@@ -64,6 +69,7 @@ class LancePipeline final : public IPipeline {
 
   private:
     std::unique_ptr<TrtModule> text_decoder_;
+    std::unique_ptr<TrtModule> prefill_;
     std::unique_ptr<TrtModule> vision_encoder_;
     std::unique_ptr<LanceInferenceState> state_;
     LanceConfig config_;
@@ -89,6 +95,12 @@ class LancePipeline final : public IPipeline {
                               const std::vector<std::vector<float>>& deepstack_features,
                               int32_t num_features, int32_t feature_dim, int32_t& feature_index,
                               std::vector<float>& logits);
+
+    bool run_vl_prefill_batched(const std::vector<int32_t>& input_ids,
+                                const std::vector<float>& image_features,
+                                const std::vector<std::vector<float>>& deepstack_features,
+                                int32_t num_features, int32_t feature_dim,
+                                std::vector<float>& logits);
 
     void run_vl_decode_loop(LanceISampler* sampler, const LanceSamplingParams& params,
                             std::vector<int32_t>& output, std::vector<float>& logits,

--- a/src/runtime/models/lance/plugin.cpp
+++ b/src/runtime/models/lance/plugin.cpp
@@ -92,14 +92,19 @@ LanceKvCacheNames build_kv_cache_names(const BaseConfig& config) {
     return kv_names;
 }
 
-LoadedModule load_text_module(const PipelineContext& ctx, TextModuleRuntime& runtime,
-                              const std::shared_ptr<LanceCudaStream>& stream) {
+DualProfileModules load_text_modules(const PipelineContext& ctx, TextModuleRuntime& runtime,
+                                     const std::shared_ptr<LanceCudaStream>& stream) {
     auto loaded =
-        load_trt_module_from_plan(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
+        load_dual_profile_modules(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
                                   runtime.engine_section.c_str(), runtime.options);
-    loaded.module->keep_alive(stream);
-    if (runtime.tp_group.owner)
-        loaded.module->keep_alive(runtime.tp_group.owner);
+    loaded.decode->keep_alive(stream);
+    if (loaded.prefill)
+        loaded.prefill->keep_alive(stream);
+    if (runtime.tp_group.owner) {
+        loaded.decode->keep_alive(runtime.tp_group.owner);
+        if (loaded.prefill)
+            loaded.prefill->keep_alive(runtime.tp_group.owner);
+    }
     return loaded;
 }
 
@@ -152,12 +157,12 @@ class VLPlugin final : public IPipelinePlugin {
 
         LanceKvCacheNames kv_names = build_kv_cache_names(ctx.config);
 
-        auto loaded = load_text_module(ctx, text_runtime, shared_stream);
+        auto loaded = load_text_modules(ctx, text_runtime, shared_stream);
 
-        cudaStream_t stream = loaded.module->stream();
+        cudaStream_t stream = loaded.decode->stream();
         const std::string cache_k_name =
             kv_names.cache_k.empty() ? std::string("cache_k_0") : kv_names.cache_k.front();
-        int32_t kv_dim = decoder_cache_row_width(*loaded.module, cache_k_name, ctx.config);
+        int32_t kv_dim = decoder_cache_row_width(*loaded.decode, cache_k_name, ctx.config);
         DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
         std::unique_ptr<LanceInferenceState> state =
             std::make_unique<LanceKvCache>(ctx.config.num_layers, ctx.config.max_cache_length,
@@ -171,7 +176,11 @@ class VLPlugin final : public IPipelinePlugin {
         vlc.id_eos = ctx.config.id_eos;
         vlc.image_token_id = extract_json_int(ctx.config_json, "image_token_id", -1);
         vlc.vision_output_dim = extract_json_int(ctx.config_json, "vision_output_dim", 0);
-        vlc.has_position_input = loaded.module->has_input("position_id");
+        vlc.has_position_input = loaded.decode->has_input("position_id");
+        vlc.num_layers = ctx.config.num_layers;
+        vlc.prefill_max_length = ctx.config.max_cache_length;
+        vlc.present_k_pattern = ctx.config.io_map.present_k_pattern;
+        vlc.present_v_pattern = ctx.config.io_map.present_v_pattern;
 
         bool has_vision_engine = extract_json_int(ctx.config_json, "has_vision_engine", 0) != 0;
 
@@ -186,9 +195,10 @@ class VLPlugin final : public IPipelinePlugin {
             bundle_section_text(ctx.bundle, "preprocessor_config.json");
         auto vl_preprocess = lance_parse_preprocess_config(config_text, preproc_text);
 
-        return std::make_unique<LancePipeline>(std::move(loaded.module), std::move(vision_module),
+        return std::make_unique<LancePipeline>(std::move(loaded.decode), std::move(vision_module),
                                                std::move(state), vlc, vl_preprocess, stream,
-                                               std::move(tokenizer), ctx.bundle.info.model_id);
+                                               std::move(tokenizer), ctx.bundle.info.model_id,
+                                               nullptr, std::move(loaded.prefill));
     }
 };
 

--- a/src/runtime/models/locateanything/pipeline.cpp
+++ b/src/runtime/models/locateanything/pipeline.cpp
@@ -6,6 +6,7 @@
 #include "runtime/models/locateanything/pipeline.h"
 
 #include "runtime/models/locateanything/image_preprocessor.h"
+#include "runtime/models/locateanything/tensor_names.h"
 
 #include <algorithm>
 #include <charconv>
@@ -31,6 +32,25 @@ bool is_coordinate_token(std::string_view token) {
 bool is_localization_token(std::string_view token) {
     return token == "<ref>" || token == "</ref>" || token == "<box>" || token == "</box>" ||
            is_coordinate_token(token);
+}
+
+void validate_pipeline_components(const TrtModule* text_decoder,
+                                  const LocateanythingInferenceState* state,
+                                  const TrtModule* prefill) {
+    if (text_decoder == nullptr || !text_decoder->ok())
+        throw std::runtime_error("LocateAnythingPipeline: invalid text decoder");
+    if (state == nullptr || !state->ok())
+        throw std::runtime_error("LocateAnythingPipeline: invalid inference state");
+    if (prefill != nullptr && !prefill->ok())
+        throw std::runtime_error("LocateAnythingPipeline: invalid prefill decoder");
+}
+
+void sync_vision_config(LocateAnythingConfig& config,
+                        const LocateAnythingPreprocessConfig& preprocess) {
+    if (config.image_token_id < 0 && preprocess.image_token_id >= 0)
+        config.image_token_id = preprocess.image_token_id;
+    if (config.vision_output_dim <= 0 && preprocess.vision_output_dim > 0)
+        config.vision_output_dim = preprocess.vision_output_dim;
 }
 
 } // namespace
@@ -64,21 +84,13 @@ LocateAnythingPipeline::LocateAnythingPipeline(
     std::unique_ptr<LocateanythingInferenceState> state, LocateAnythingConfig config,
     LocateAnythingPreprocessConfig vl_preprocess, cudaStream_t stream,
     std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
-    std::unique_ptr<LocateAnythingISampler> sampler)
-    : text_decoder_(std::move(text_decoder)), vision_encoder_(std::move(vision_encoder)),
-      state_(std::move(state)), config_(config), vl_preprocess_(std::move(vl_preprocess)),
-      stream_(stream), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
-      sampler_(std::move(sampler)) {
-    if (!text_decoder_ || !text_decoder_->ok())
-        throw std::runtime_error("LocateAnythingPipeline: invalid text decoder");
-    if (!state_ || !state_->ok())
-        throw std::runtime_error("LocateAnythingPipeline: invalid inference state");
-
-    // Sync image_token_id from LocateAnythingPreprocessConfig if not set in LocateAnythingConfig
-    if (config_.image_token_id < 0 && vl_preprocess_.image_token_id >= 0)
-        config_.image_token_id = vl_preprocess_.image_token_id;
-    if (config_.vision_output_dim <= 0 && vl_preprocess_.vision_output_dim > 0)
-        config_.vision_output_dim = vl_preprocess_.vision_output_dim;
+    std::unique_ptr<LocateAnythingISampler> sampler, std::unique_ptr<TrtModule> prefill)
+    : text_decoder_(std::move(text_decoder)), prefill_(std::move(prefill)),
+      vision_encoder_(std::move(vision_encoder)), state_(std::move(state)), config_(config),
+      vl_preprocess_(std::move(vl_preprocess)), stream_(stream), tokenizer_(std::move(tokenizer)),
+      model_id_(std::move(model_id_str)), sampler_(std::move(sampler)) {
+    validate_pipeline_components(text_decoder_.get(), state_.get(), prefill_.get());
+    sync_vision_config(config_, vl_preprocess_);
 }
 
 TextResult LocateAnythingPipeline::generate(const std::string& prompt, const GenerateConfig& cfg) {
@@ -138,6 +150,194 @@ select_deepstack_feature_pointers(const std::vector<std::vector<float>>& deepsta
                              : nullptr);
     }
     return embeds;
+}
+
+struct VlSequenceEmbeddingInputs {
+    std::vector<float> input_embed;
+    std::vector<float> use_input_embed;
+    std::vector<std::vector<float>> deepstack_embed;
+    std::vector<float> deepstack_active;
+};
+
+VlSequenceEmbeddingInputs
+build_vl_sequence_embedding_inputs(const std::vector<int32_t>& input_ids, int32_t image_token_id,
+                                   const std::vector<float>& image_features,
+                                   const std::vector<std::vector<float>>& deepstack_features,
+                                   int32_t num_features, int32_t feature_dim) {
+    const auto sq = input_ids.size();
+    VlSequenceEmbeddingInputs result;
+    result.input_embed.assign(sq * static_cast<std::size_t>(feature_dim), 0.0F);
+    result.use_input_embed.assign(sq, 0.0F);
+    result.deepstack_active.assign(sq, 0.0F);
+    result.deepstack_embed.resize(deepstack_features.size());
+    for (auto& level : result.deepstack_embed)
+        level.assign(sq * static_cast<std::size_t>(feature_dim), 0.0F);
+
+    int32_t feature_index = 0;
+    for (std::size_t token_index = 0; token_index < sq; ++token_index) {
+        if (input_ids[token_index] != image_token_id || feature_index >= num_features)
+            continue;
+        const auto source_offset = static_cast<std::size_t>(feature_index) * feature_dim;
+        const auto target_offset = token_index * static_cast<std::size_t>(feature_dim);
+        std::copy_n(image_features.data() + source_offset, feature_dim,
+                    result.input_embed.data() + target_offset);
+        result.use_input_embed[token_index] = 1.0F;
+
+        for (std::size_t level_index = 0; level_index < deepstack_features.size(); ++level_index) {
+            const auto& source = deepstack_features[level_index];
+            if (source_offset + static_cast<std::size_t>(feature_dim) > source.size())
+                continue;
+            std::copy_n(source.data() + source_offset, feature_dim,
+                        result.deepstack_embed[level_index].data() + target_offset);
+            result.deepstack_active[token_index] = 1.0F;
+        }
+        ++feature_index;
+    }
+    return result;
+}
+
+bool gather_vl_prefill_kv_pointers(TrtModule& prefill, const LocateAnythingConfig& config,
+                                   std::vector<const void*>& present_k,
+                                   std::vector<const void*>& present_v) {
+    present_k.resize(static_cast<std::size_t>(config.num_layers));
+    present_v.resize(static_cast<std::size_t>(config.num_layers));
+    for (int32_t layer = 0; layer < config.num_layers; ++layer) {
+        const auto index = static_cast<std::size_t>(layer);
+        present_k[index] =
+            prefill.device_ptr(locateanything_expand_layer_name(config.present_k_pattern, layer));
+        present_v[index] =
+            prefill.device_ptr(locateanything_expand_layer_name(config.present_v_pattern, layer));
+        if (present_k[index] == nullptr || present_v[index] == nullptr)
+            return false;
+    }
+    return true;
+}
+
+LocateanythingKvCache* eligible_vl_prefill_cache(TrtModule* prefill,
+                                                 LocateanythingInferenceState* state,
+                                                 const LocateAnythingConfig& config,
+                                                 int32_t sequence_length, int32_t feature_dim) {
+    if (prefill == nullptr)
+        return nullptr;
+    if (sequence_length <= 0 || feature_dim <= 0 || config.num_layers <= 0)
+        return nullptr;
+    if (!prefill->has_input("input_embed"))
+        return nullptr;
+    if (config.prefill_max_length > 0 && sequence_length > config.prefill_max_length)
+        return nullptr;
+    return dynamic_cast<LocateanythingKvCache*>(state);
+}
+
+bool valid_vl_features(const std::vector<float>& image_features, int32_t num_features,
+                       int32_t feature_dim) {
+    if (num_features < 0)
+        return false;
+    const auto required =
+        static_cast<std::size_t>(num_features) * static_cast<std::size_t>(feature_dim);
+    return image_features.size() >= required;
+}
+
+void add_vl_prefill_base_inputs(TensorMap& inputs, LocateanythingInferenceState& state,
+                                const std::vector<int32_t>& input_ids,
+                                VlSequenceEmbeddingInputs& embedding_inputs, int32_t feature_dim) {
+    const auto sequence_length = static_cast<int32_t>(input_ids.size());
+    inputs["token_id"] =
+        Tensor{const_cast<int32_t*>(input_ids.data()), {sequence_length}, DType::kInt32};
+    state.prepare_step(inputs, sequence_length);
+    inputs["input_embed"] = Tensor{
+        embedding_inputs.input_embed.data(), {sequence_length, feature_dim}, DType::kFloat32};
+    inputs["use_input_embed"] =
+        Tensor{embedding_inputs.use_input_embed.data(), {sequence_length, 1}, DType::kFloat32};
+}
+
+bool add_vl_prefill_deepstack_inputs(TrtModule& prefill, TensorMap& inputs,
+                                     VlSequenceEmbeddingInputs& embedding_inputs,
+                                     int32_t sequence_length, int32_t feature_dim) {
+    if (!prefill.has_input("deepstack_active"))
+        return true;
+    inputs["deepstack_active"] =
+        Tensor{embedding_inputs.deepstack_active.data(), {sequence_length, 1}, DType::kFloat32};
+    for (std::size_t level = 0;; ++level) {
+        const auto name = "deepstack_embed_" + std::to_string(level);
+        if (!prefill.has_input(name))
+            break;
+        if (level >= embedding_inputs.deepstack_embed.size())
+            return false;
+        inputs[name] = Tensor{embedding_inputs.deepstack_embed[level].data(),
+                              {sequence_length, feature_dim},
+                              DType::kFloat32};
+    }
+    return true;
+}
+
+bool copy_last_prefill_logits(const TensorMap& outputs, int32_t vocab_size,
+                              std::vector<float>& logits) {
+    const auto logits_it = outputs.find("logits");
+    if (logits_it == outputs.end())
+        return false;
+    const auto size = static_cast<std::size_t>(vocab_size);
+    if (logits_it->second.numel() < size)
+        return false;
+    const auto offset = logits_it->second.numel() - size;
+    logits.resize(size);
+    std::memcpy(logits.data(), static_cast<const float*>(logits_it->second.data) + offset,
+                size * sizeof(float));
+    return true;
+}
+
+int32_t resolve_input_embed_dim(const TrtModule& decoder, int32_t configured_dim) {
+    if (configured_dim > 0)
+        return configured_dim;
+    const auto declared_shape = decoder.tensor_shape("input_embed");
+    if (!declared_shape.empty())
+        return static_cast<int32_t>(declared_shape.back());
+    throw std::runtime_error("LocateAnythingPipeline: invalid input embedding dimension");
+}
+
+std::vector<int64_t> selector_shape(const TrtModule& decoder, const std::string& name) {
+    return decoder.input_rank(name) == 2 ? std::vector<int64_t>{1, 1} : std::vector<int64_t>{1};
+}
+
+void add_text_step_deepstack_inputs(TrtModule& decoder, TensorMap& inputs, int32_t embed_dim,
+                                    const std::vector<const float*>& deepstack_embeds,
+                                    float& deepstack_active, std::vector<float>& zero_deepstack) {
+    if (!decoder.has_input("deepstack_active"))
+        return;
+    inputs["deepstack_active"] =
+        Tensor{&deepstack_active, selector_shape(decoder, "deepstack_active"), DType::kFloat32};
+    for (std::size_t index = 0;; ++index) {
+        const auto name = "deepstack_embed_" + std::to_string(index);
+        if (!decoder.has_input(name))
+            break;
+        const float* embed = index < deepstack_embeds.size() ? deepstack_embeds[index] : nullptr;
+        if (embed == nullptr) {
+            if (zero_deepstack.empty())
+                zero_deepstack.resize(static_cast<std::size_t>(embed_dim), 0.0F);
+            embed = zero_deepstack.data();
+        }
+        inputs[name] = Tensor{const_cast<float*>(embed), {1, embed_dim}, DType::kFloat32};
+    }
+}
+
+void add_text_step_embedding_inputs(TrtModule& decoder, const LocateAnythingConfig& config,
+                                    TensorMap& inputs, const float* input_embed,
+                                    float& use_input_embed,
+                                    const std::vector<const float*>& deepstack_embeds,
+                                    float& deepstack_active, std::vector<float>& zero_embed,
+                                    std::vector<float>& zero_deepstack) {
+    if (!decoder.has_input("input_embed"))
+        return;
+    const int32_t embed_dim = resolve_input_embed_dim(decoder, config.vision_output_dim);
+    if (input_embed == nullptr) {
+        zero_embed.resize(static_cast<std::size_t>(embed_dim), 0.0F);
+        input_embed = zero_embed.data();
+    }
+    inputs["input_embed"] =
+        Tensor{const_cast<float*>(input_embed), {1, embed_dim}, DType::kFloat32};
+    inputs["use_input_embed"] =
+        Tensor{&use_input_embed, selector_shape(decoder, "use_input_embed"), DType::kFloat32};
+    add_text_step_deepstack_inputs(decoder, inputs, embed_dim, deepstack_embeds, deepstack_active,
+                                   zero_deepstack);
 }
 
 Tensor make_pixel_values_tensor(const LocateAnythingPreprocessedImage& preprocessed,
@@ -271,6 +471,10 @@ LocateAnythingPipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
     active_sampler->reset();
 
     state_->reset();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
     state_->bind_to(*text_decoder_);
 
     std::vector<float> logits;
@@ -312,18 +516,59 @@ std::vector<int32_t> LocateAnythingPipeline::generate_vl_from_ids(
     active_sampler->reset();
 
     state_->reset();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
     state_->bind_to(*text_decoder_);
 
     std::vector<float> logits;
-    int32_t feature_index = 0;
-
-    for (const auto& tid : input_ids)
-        run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
-                             feature_index, logits);
+    if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,
+                                feature_dim, logits)) {
+        int32_t feature_index = 0;
+        for (const auto& tid : input_ids)
+            run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
+                                 feature_index, logits);
+    }
+    state_->mark_prefill_complete();
 
     std::vector<int32_t> output = input_ids;
     run_vl_decode_loop(active_sampler, params, output, logits, max_new_tokens);
     return output;
+}
+
+bool LocateAnythingPipeline::run_vl_prefill_batched(
+    const std::vector<int32_t>& input_ids, const std::vector<float>& image_features,
+    const std::vector<std::vector<float>>& deepstack_features, int32_t num_features,
+    int32_t feature_dim, std::vector<float>& logits) {
+    const auto sq = static_cast<int32_t>(input_ids.size());
+    auto* kv_cache =
+        eligible_vl_prefill_cache(prefill_.get(), state_.get(), config_, sq, feature_dim);
+    if (kv_cache == nullptr)
+        return false;
+    if (!valid_vl_features(image_features, num_features, feature_dim))
+        return false;
+
+    kv_cache->bind_cache_inputs(*prefill_);
+    auto embedding_inputs =
+        build_vl_sequence_embedding_inputs(input_ids, config_.image_token_id, image_features,
+                                           deepstack_features, num_features, feature_dim);
+
+    TensorMap inputs;
+    add_vl_prefill_base_inputs(inputs, *state_, input_ids, embedding_inputs, feature_dim);
+    if (!add_vl_prefill_deepstack_inputs(*prefill_, inputs, embedding_inputs, sq, feature_dim))
+        return false;
+
+    auto outputs = prefill_->forward(inputs);
+    if (!copy_last_prefill_logits(outputs, config_.vocab_size, logits))
+        return false;
+
+    std::vector<const void*> present_k;
+    std::vector<const void*> present_v;
+    if (!gather_vl_prefill_kv_pointers(*prefill_, config_, present_k, present_v))
+        return false;
+    kv_cache->write_prefill_kv(present_k, present_v, sq);
+    return true;
 }
 
 void LocateAnythingPipeline::run_vl_prefill_token(
@@ -361,38 +606,13 @@ void LocateAnythingPipeline::run_vl_decode_loop(LocateAnythingISampler* sampler,
 }
 
 void LocateAnythingPipeline::run_text_step(int32_t token_id, std::vector<float>& logits) {
-    TensorMap inputs;
-
-    Tensor token_t;
-    token_t.data = &token_id;
-    token_t.shape = {1};
-    token_t.dtype = DType::kInt32;
-    inputs["token_id"] = token_t;
-
-    state_->prepare_step(inputs);
-
-    auto outputs = text_decoder_->forward(inputs);
-
-    auto it = outputs.find("logits");
-    if (it == outputs.end())
-        throw std::runtime_error("LocateAnythingPipeline: no 'logits' output");
-
-    auto n = it->second.numel();
-    logits.resize(static_cast<std::size_t>(n));
-    std::memcpy(logits.data(), it->second.data, n * sizeof(float));
-
-    state_->advance();
+    run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, logits);
 }
 
 void LocateAnythingPipeline::run_text_step_with_embed(
     int32_t token_id, const float* input_embed, float use_input_embed,
     const std::vector<const float*>& deepstack_embeds, float deepstack_active,
     std::vector<float>& logits) {
-    if (!text_decoder_->has_input("input_embed")) {
-        run_text_step(token_id, logits);
-        return;
-    }
-
     TensorMap inputs;
 
     Tensor token_t;
@@ -403,56 +623,10 @@ void LocateAnythingPipeline::run_text_step_with_embed(
 
     state_->prepare_step(inputs);
 
-    // use_input_embed scalar: 1.0 = use input_embed, 0.0 = use token embedding
-    Tensor use_embed_t;
-    use_embed_t.data = &use_input_embed;
-    use_embed_t.shape = {1};
-    use_embed_t.dtype = DType::kFloat32;
-    inputs["use_input_embed"] = use_embed_t;
-
-    // Provide the input embedding vector
-    int32_t embed_dim = config_.vision_output_dim;
     std::vector<float> zero_embed;
-    if (input_embed == nullptr) {
-        zero_embed.resize(static_cast<std::size_t>(embed_dim), 0.0F);
-        input_embed = zero_embed.data();
-    }
-
-    Tensor embed_t;
-    embed_t.data = const_cast<float*>(input_embed);
-    embed_t.shape = {static_cast<int64_t>(embed_dim)};
-    embed_t.dtype = DType::kFloat32;
-    inputs["input_embed"] = embed_t;
-
-    // DeepStack: if the engine has deepstack inputs, provide inactive zeros.
-    if (text_decoder_->has_input("deepstack_active")) {
-        Tensor ds_active_t;
-        ds_active_t.data = &deepstack_active;
-        ds_active_t.shape = {1};
-        ds_active_t.dtype = DType::kFloat32;
-        inputs["deepstack_active"] = ds_active_t;
-
-        std::vector<float> zero_deepstack;
-        for (std::size_t i = 0;; ++i) {
-            const std::string name = "deepstack_embed_" + std::to_string(i);
-            if (!text_decoder_->has_input(name))
-                break;
-
-            const float* deepstack_embed =
-                i < deepstack_embeds.size() ? deepstack_embeds[i] : nullptr;
-            if (deepstack_embed == nullptr) {
-                if (zero_deepstack.empty())
-                    zero_deepstack.resize(static_cast<std::size_t>(embed_dim), 0.0F);
-                deepstack_embed = zero_deepstack.data();
-            }
-
-            Tensor ds_embed_t;
-            ds_embed_t.data = const_cast<float*>(deepstack_embed);
-            ds_embed_t.shape = {1, static_cast<int64_t>(embed_dim)};
-            ds_embed_t.dtype = DType::kFloat32;
-            inputs[name] = ds_embed_t;
-        }
-    }
+    std::vector<float> zero_deepstack;
+    add_text_step_embedding_inputs(*text_decoder_, config_, inputs, input_embed, use_input_embed,
+                                   deepstack_embeds, deepstack_active, zero_embed, zero_deepstack);
 
     auto outputs = text_decoder_->forward(inputs);
 

--- a/src/runtime/models/locateanything/pipeline.h
+++ b/src/runtime/models/locateanything/pipeline.h
@@ -38,6 +38,10 @@ struct LocateAnythingConfig {
     int32_t image_token_id{-1};
     int32_t vision_output_dim{0};
     bool has_position_input{true};
+    int32_t num_layers{0};
+    int32_t prefill_max_length{0};
+    std::string present_k_pattern{"present_k_{i}"};
+    std::string present_v_pattern{"present_v_{i}"};
 };
 
 class LocateAnythingPipeline final : public IPipeline {
@@ -49,7 +53,8 @@ class LocateAnythingPipeline final : public IPipeline {
                            LocateAnythingPreprocessConfig vl_preprocess, cudaStream_t stream,
                            std::shared_ptr<ITokenizer> tokenizer = nullptr,
                            std::string model_id_str = "",
-                           std::unique_ptr<LocateAnythingISampler> sampler = nullptr);
+                           std::unique_ptr<LocateAnythingISampler> sampler = nullptr,
+                           std::unique_ptr<TrtModule> prefill = nullptr);
 
     TextResult generate(const std::string& prompt, const GenerateConfig& cfg = {}) override;
 
@@ -73,6 +78,7 @@ class LocateAnythingPipeline final : public IPipeline {
 
   private:
     std::unique_ptr<TrtModule> text_decoder_;
+    std::unique_ptr<TrtModule> prefill_;
     std::unique_ptr<TrtModule> vision_encoder_;
     std::unique_ptr<LocateanythingInferenceState> state_;
     LocateAnythingConfig config_;
@@ -98,6 +104,12 @@ class LocateAnythingPipeline final : public IPipeline {
                               const std::vector<std::vector<float>>& deepstack_features,
                               int32_t num_features, int32_t feature_dim, int32_t& feature_index,
                               std::vector<float>& logits);
+
+    bool run_vl_prefill_batched(const std::vector<int32_t>& input_ids,
+                                const std::vector<float>& image_features,
+                                const std::vector<std::vector<float>>& deepstack_features,
+                                int32_t num_features, int32_t feature_dim,
+                                std::vector<float>& logits);
 
     void run_vl_decode_loop(LocateAnythingISampler* sampler,
                             const LocateAnythingSamplingParams& params,

--- a/src/runtime/models/locateanything/plugin.cpp
+++ b/src/runtime/models/locateanything/plugin.cpp
@@ -92,14 +92,19 @@ LocateanythingKvCacheNames build_kv_cache_names(const BaseConfig& config) {
     return kv_names;
 }
 
-LoadedModule load_text_module(const PipelineContext& ctx, TextModuleRuntime& runtime,
-                              const std::shared_ptr<LocateAnythingCudaStream>& stream) {
+DualProfileModules load_text_modules(const PipelineContext& ctx, TextModuleRuntime& runtime,
+                                     const std::shared_ptr<LocateAnythingCudaStream>& stream) {
     auto loaded =
-        load_trt_module_from_plan(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
+        load_dual_profile_modules(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
                                   runtime.engine_section.c_str(), runtime.options);
-    loaded.module->keep_alive(stream);
-    if (runtime.tp_group.owner)
-        loaded.module->keep_alive(runtime.tp_group.owner);
+    loaded.decode->keep_alive(stream);
+    if (loaded.prefill)
+        loaded.prefill->keep_alive(stream);
+    if (runtime.tp_group.owner) {
+        loaded.decode->keep_alive(runtime.tp_group.owner);
+        if (loaded.prefill)
+            loaded.prefill->keep_alive(runtime.tp_group.owner);
+    }
     return loaded;
 }
 
@@ -152,12 +157,12 @@ class VLPlugin final : public IPipelinePlugin {
 
         LocateanythingKvCacheNames kv_names = build_kv_cache_names(ctx.config);
 
-        auto loaded = load_text_module(ctx, text_runtime, shared_stream);
+        auto loaded = load_text_modules(ctx, text_runtime, shared_stream);
 
-        cudaStream_t stream = loaded.module->stream();
+        cudaStream_t stream = loaded.decode->stream();
         const std::string cache_k_name =
             kv_names.cache_k.empty() ? std::string("cache_k_0") : kv_names.cache_k.front();
-        int32_t kv_dim = decoder_cache_row_width(*loaded.module, cache_k_name, ctx.config);
+        int32_t kv_dim = decoder_cache_row_width(*loaded.decode, cache_k_name, ctx.config);
         DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
         std::unique_ptr<LocateanythingInferenceState> state =
             std::make_unique<LocateanythingKvCache>(ctx.config.num_layers,
@@ -172,7 +177,11 @@ class VLPlugin final : public IPipelinePlugin {
         vlc.id_eos = ctx.config.id_eos;
         vlc.image_token_id = extract_json_int(ctx.config_json, "image_token_id", -1);
         vlc.vision_output_dim = extract_json_int(ctx.config_json, "vision_output_dim", 0);
-        vlc.has_position_input = loaded.module->has_input("position_id");
+        vlc.has_position_input = loaded.decode->has_input("position_id");
+        vlc.num_layers = ctx.config.num_layers;
+        vlc.prefill_max_length = ctx.config.max_cache_length;
+        vlc.present_k_pattern = ctx.config.io_map.present_k_pattern;
+        vlc.present_v_pattern = ctx.config.io_map.present_v_pattern;
 
         bool has_vision_engine = extract_json_int(ctx.config_json, "has_vision_engine", 0) != 0;
 
@@ -188,8 +197,9 @@ class VLPlugin final : public IPipelinePlugin {
         auto vl_preprocess = locateanything_parse_preprocess_config(config_text, preproc_text);
 
         return std::make_unique<LocateAnythingPipeline>(
-            std::move(loaded.module), std::move(vision_module), std::move(state), vlc,
-            vl_preprocess, stream, std::move(tokenizer), ctx.bundle.info.model_id);
+            std::move(loaded.decode), std::move(vision_module), std::move(state), vlc,
+            vl_preprocess, stream, std::move(tokenizer), ctx.bundle.info.model_id, nullptr,
+            std::move(loaded.prefill));
     }
 };
 

--- a/src/runtime/models/phi4_multimodal/pipeline.cpp
+++ b/src/runtime/models/phi4_multimodal/pipeline.cpp
@@ -6,6 +6,7 @@
 #include "runtime/models/phi4_multimodal/pipeline.h"
 
 #include "runtime/models/phi4_multimodal/image_preprocessor.h"
+#include "runtime/models/phi4_multimodal/tensor_names.h"
 
 #include <algorithm>
 #include <cstring>
@@ -14,26 +15,41 @@
 
 namespace trtmc {
 
+namespace {
+
+void validate_pipeline_components(const TrtModule* text_decoder,
+                                  const Phi4MultimodalInferenceState* state,
+                                  const TrtModule* prefill) {
+    if (text_decoder == nullptr || !text_decoder->ok())
+        throw std::runtime_error("Phi4MultimodalPipeline: invalid text decoder");
+    if (state == nullptr || !state->ok())
+        throw std::runtime_error("Phi4MultimodalPipeline: invalid inference state");
+    if (prefill != nullptr && !prefill->ok())
+        throw std::runtime_error("Phi4MultimodalPipeline: invalid prefill decoder");
+}
+
+void sync_vision_config(Phi4MultimodalConfig& config,
+                        const Phi4MultimodalPreprocessConfig& preprocess) {
+    if (config.image_token_id < 0 && preprocess.image_token_id >= 0)
+        config.image_token_id = preprocess.image_token_id;
+    if (config.vision_output_dim <= 0 && preprocess.vision_output_dim > 0)
+        config.vision_output_dim = preprocess.vision_output_dim;
+}
+
+} // namespace
+
 Phi4MultimodalPipeline::Phi4MultimodalPipeline(
     std::unique_ptr<TrtModule> text_decoder, std::unique_ptr<TrtModule> vision_encoder,
     std::unique_ptr<Phi4MultimodalInferenceState> state, Phi4MultimodalConfig config,
     Phi4MultimodalPreprocessConfig vl_preprocess, cudaStream_t stream,
     std::shared_ptr<ITokenizer> tokenizer, std::string model_id_str,
-    std::unique_ptr<Phi4MultimodalISampler> sampler)
-    : text_decoder_(std::move(text_decoder)), vision_encoder_(std::move(vision_encoder)),
-      state_(std::move(state)), config_(config), vl_preprocess_(std::move(vl_preprocess)),
-      stream_(stream), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
-      sampler_(std::move(sampler)) {
-    if (!text_decoder_ || !text_decoder_->ok())
-        throw std::runtime_error("Phi4MultimodalPipeline: invalid text decoder");
-    if (!state_ || !state_->ok())
-        throw std::runtime_error("Phi4MultimodalPipeline: invalid inference state");
-
-    // Sync image_token_id from Phi4MultimodalPreprocessConfig if not set in Phi4MultimodalConfig
-    if (config_.image_token_id < 0 && vl_preprocess_.image_token_id >= 0)
-        config_.image_token_id = vl_preprocess_.image_token_id;
-    if (config_.vision_output_dim <= 0 && vl_preprocess_.vision_output_dim > 0)
-        config_.vision_output_dim = vl_preprocess_.vision_output_dim;
+    std::unique_ptr<Phi4MultimodalISampler> sampler, std::unique_ptr<TrtModule> prefill)
+    : text_decoder_(std::move(text_decoder)), prefill_(std::move(prefill)),
+      vision_encoder_(std::move(vision_encoder)), state_(std::move(state)), config_(config),
+      vl_preprocess_(std::move(vl_preprocess)), stream_(stream), tokenizer_(std::move(tokenizer)),
+      model_id_(std::move(model_id_str)), sampler_(std::move(sampler)) {
+    validate_pipeline_components(text_decoder_.get(), state_.get(), prefill_.get());
+    sync_vision_config(config_, vl_preprocess_);
 }
 
 TextResult Phi4MultimodalPipeline::generate(const std::string& prompt, const GenerateConfig& cfg) {
@@ -93,6 +109,194 @@ select_deepstack_feature_pointers(const std::vector<std::vector<float>>& deepsta
                              : nullptr);
     }
     return embeds;
+}
+
+struct VlSequenceEmbeddingInputs {
+    std::vector<float> input_embed;
+    std::vector<float> use_input_embed;
+    std::vector<std::vector<float>> deepstack_embed;
+    std::vector<float> deepstack_active;
+};
+
+VlSequenceEmbeddingInputs
+build_vl_sequence_embedding_inputs(const std::vector<int32_t>& input_ids, int32_t image_token_id,
+                                   const std::vector<float>& image_features,
+                                   const std::vector<std::vector<float>>& deepstack_features,
+                                   int32_t num_features, int32_t feature_dim) {
+    const auto sq = input_ids.size();
+    VlSequenceEmbeddingInputs result;
+    result.input_embed.assign(sq * static_cast<std::size_t>(feature_dim), 0.0F);
+    result.use_input_embed.assign(sq, 0.0F);
+    result.deepstack_active.assign(sq, 0.0F);
+    result.deepstack_embed.resize(deepstack_features.size());
+    for (auto& level : result.deepstack_embed)
+        level.assign(sq * static_cast<std::size_t>(feature_dim), 0.0F);
+
+    int32_t feature_index = 0;
+    for (std::size_t token_index = 0; token_index < sq; ++token_index) {
+        if (input_ids[token_index] != image_token_id || feature_index >= num_features)
+            continue;
+        const auto source_offset = static_cast<std::size_t>(feature_index) * feature_dim;
+        const auto target_offset = token_index * static_cast<std::size_t>(feature_dim);
+        std::copy_n(image_features.data() + source_offset, feature_dim,
+                    result.input_embed.data() + target_offset);
+        result.use_input_embed[token_index] = 1.0F;
+
+        for (std::size_t level_index = 0; level_index < deepstack_features.size(); ++level_index) {
+            const auto& source = deepstack_features[level_index];
+            if (source_offset + static_cast<std::size_t>(feature_dim) > source.size())
+                continue;
+            std::copy_n(source.data() + source_offset, feature_dim,
+                        result.deepstack_embed[level_index].data() + target_offset);
+            result.deepstack_active[token_index] = 1.0F;
+        }
+        ++feature_index;
+    }
+    return result;
+}
+
+bool gather_vl_prefill_kv_pointers(TrtModule& prefill, const Phi4MultimodalConfig& config,
+                                   std::vector<const void*>& present_k,
+                                   std::vector<const void*>& present_v) {
+    present_k.resize(static_cast<std::size_t>(config.num_layers));
+    present_v.resize(static_cast<std::size_t>(config.num_layers));
+    for (int32_t layer = 0; layer < config.num_layers; ++layer) {
+        const auto index = static_cast<std::size_t>(layer);
+        present_k[index] =
+            prefill.device_ptr(phi4_multimodal_expand_layer_name(config.present_k_pattern, layer));
+        present_v[index] =
+            prefill.device_ptr(phi4_multimodal_expand_layer_name(config.present_v_pattern, layer));
+        if (present_k[index] == nullptr || present_v[index] == nullptr)
+            return false;
+    }
+    return true;
+}
+
+Phi4MultimodalKvCache* eligible_vl_prefill_cache(TrtModule* prefill,
+                                                 Phi4MultimodalInferenceState* state,
+                                                 const Phi4MultimodalConfig& config,
+                                                 int32_t sequence_length, int32_t feature_dim) {
+    if (prefill == nullptr)
+        return nullptr;
+    if (sequence_length <= 0 || feature_dim <= 0 || config.num_layers <= 0)
+        return nullptr;
+    if (!prefill->has_input("input_embed"))
+        return nullptr;
+    if (config.prefill_max_length > 0 && sequence_length > config.prefill_max_length)
+        return nullptr;
+    return dynamic_cast<Phi4MultimodalKvCache*>(state);
+}
+
+bool valid_vl_features(const std::vector<float>& image_features, int32_t num_features,
+                       int32_t feature_dim) {
+    if (num_features < 0)
+        return false;
+    const auto required =
+        static_cast<std::size_t>(num_features) * static_cast<std::size_t>(feature_dim);
+    return image_features.size() >= required;
+}
+
+void add_vl_prefill_base_inputs(TensorMap& inputs, Phi4MultimodalInferenceState& state,
+                                const std::vector<int32_t>& input_ids,
+                                VlSequenceEmbeddingInputs& embedding_inputs, int32_t feature_dim) {
+    const auto sequence_length = static_cast<int32_t>(input_ids.size());
+    inputs["token_id"] =
+        Tensor{const_cast<int32_t*>(input_ids.data()), {sequence_length}, DType::kInt32};
+    state.prepare_step(inputs, sequence_length);
+    inputs["input_embed"] = Tensor{
+        embedding_inputs.input_embed.data(), {sequence_length, feature_dim}, DType::kFloat32};
+    inputs["use_input_embed"] =
+        Tensor{embedding_inputs.use_input_embed.data(), {sequence_length, 1}, DType::kFloat32};
+}
+
+bool add_vl_prefill_deepstack_inputs(TrtModule& prefill, TensorMap& inputs,
+                                     VlSequenceEmbeddingInputs& embedding_inputs,
+                                     int32_t sequence_length, int32_t feature_dim) {
+    if (!prefill.has_input("deepstack_active"))
+        return true;
+    inputs["deepstack_active"] =
+        Tensor{embedding_inputs.deepstack_active.data(), {sequence_length, 1}, DType::kFloat32};
+    for (std::size_t level = 0;; ++level) {
+        const auto name = "deepstack_embed_" + std::to_string(level);
+        if (!prefill.has_input(name))
+            break;
+        if (level >= embedding_inputs.deepstack_embed.size())
+            return false;
+        inputs[name] = Tensor{embedding_inputs.deepstack_embed[level].data(),
+                              {sequence_length, feature_dim},
+                              DType::kFloat32};
+    }
+    return true;
+}
+
+bool copy_last_prefill_logits(const TensorMap& outputs, int32_t vocab_size,
+                              std::vector<float>& logits) {
+    const auto logits_it = outputs.find("logits");
+    if (logits_it == outputs.end())
+        return false;
+    const auto size = static_cast<std::size_t>(vocab_size);
+    if (logits_it->second.numel() < size)
+        return false;
+    const auto offset = logits_it->second.numel() - size;
+    logits.resize(size);
+    std::memcpy(logits.data(), static_cast<const float*>(logits_it->second.data) + offset,
+                size * sizeof(float));
+    return true;
+}
+
+int32_t resolve_input_embed_dim(const TrtModule& decoder, int32_t configured_dim) {
+    if (configured_dim > 0)
+        return configured_dim;
+    const auto declared_shape = decoder.tensor_shape("input_embed");
+    if (!declared_shape.empty())
+        return static_cast<int32_t>(declared_shape.back());
+    throw std::runtime_error("Phi4MultimodalPipeline: invalid input embedding dimension");
+}
+
+std::vector<int64_t> selector_shape(const TrtModule& decoder, const std::string& name) {
+    return decoder.input_rank(name) == 2 ? std::vector<int64_t>{1, 1} : std::vector<int64_t>{1};
+}
+
+void add_text_step_deepstack_inputs(TrtModule& decoder, TensorMap& inputs, int32_t embed_dim,
+                                    const std::vector<const float*>& deepstack_embeds,
+                                    float& deepstack_active, std::vector<float>& zero_deepstack) {
+    if (!decoder.has_input("deepstack_active"))
+        return;
+    inputs["deepstack_active"] =
+        Tensor{&deepstack_active, selector_shape(decoder, "deepstack_active"), DType::kFloat32};
+    for (std::size_t index = 0;; ++index) {
+        const auto name = "deepstack_embed_" + std::to_string(index);
+        if (!decoder.has_input(name))
+            break;
+        const float* embed = index < deepstack_embeds.size() ? deepstack_embeds[index] : nullptr;
+        if (embed == nullptr) {
+            if (zero_deepstack.empty())
+                zero_deepstack.resize(static_cast<std::size_t>(embed_dim), 0.0F);
+            embed = zero_deepstack.data();
+        }
+        inputs[name] = Tensor{const_cast<float*>(embed), {1, embed_dim}, DType::kFloat32};
+    }
+}
+
+void add_text_step_embedding_inputs(TrtModule& decoder, const Phi4MultimodalConfig& config,
+                                    TensorMap& inputs, const float* input_embed,
+                                    float& use_input_embed,
+                                    const std::vector<const float*>& deepstack_embeds,
+                                    float& deepstack_active, std::vector<float>& zero_embed,
+                                    std::vector<float>& zero_deepstack) {
+    if (!decoder.has_input("input_embed"))
+        return;
+    const int32_t embed_dim = resolve_input_embed_dim(decoder, config.vision_output_dim);
+    if (input_embed == nullptr) {
+        zero_embed.resize(static_cast<std::size_t>(embed_dim), 0.0F);
+        input_embed = zero_embed.data();
+    }
+    inputs["input_embed"] =
+        Tensor{const_cast<float*>(input_embed), {1, embed_dim}, DType::kFloat32};
+    inputs["use_input_embed"] =
+        Tensor{&use_input_embed, selector_shape(decoder, "use_input_embed"), DType::kFloat32};
+    add_text_step_deepstack_inputs(decoder, inputs, embed_dim, deepstack_embeds, deepstack_active,
+                                   zero_deepstack);
 }
 
 Tensor make_pixel_values_tensor(const Phi4MultimodalPreprocessedImage& preprocessed,
@@ -225,6 +429,10 @@ Phi4MultimodalPipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
     active_sampler->reset();
 
     state_->reset();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
     state_->bind_to(*text_decoder_);
 
     std::vector<float> logits;
@@ -266,18 +474,59 @@ std::vector<int32_t> Phi4MultimodalPipeline::generate_vl_from_ids(
     active_sampler->reset();
 
     state_->reset();
+    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
     state_->bind_to(*text_decoder_);
 
     std::vector<float> logits;
-    int32_t feature_index = 0;
-
-    for (const auto& tid : input_ids)
-        run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
-                             feature_index, logits);
+    if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,
+                                feature_dim, logits)) {
+        int32_t feature_index = 0;
+        for (const auto& tid : input_ids)
+            run_vl_prefill_token(tid, image_features, deepstack_features, num_features, feature_dim,
+                                 feature_index, logits);
+    }
+    state_->mark_prefill_complete();
 
     std::vector<int32_t> output = input_ids;
     run_vl_decode_loop(active_sampler, params, output, logits, max_new_tokens);
     return output;
+}
+
+bool Phi4MultimodalPipeline::run_vl_prefill_batched(
+    const std::vector<int32_t>& input_ids, const std::vector<float>& image_features,
+    const std::vector<std::vector<float>>& deepstack_features, int32_t num_features,
+    int32_t feature_dim, std::vector<float>& logits) {
+    const auto sq = static_cast<int32_t>(input_ids.size());
+    auto* kv_cache =
+        eligible_vl_prefill_cache(prefill_.get(), state_.get(), config_, sq, feature_dim);
+    if (kv_cache == nullptr)
+        return false;
+    if (!valid_vl_features(image_features, num_features, feature_dim))
+        return false;
+
+    kv_cache->bind_cache_inputs(*prefill_);
+    auto embedding_inputs =
+        build_vl_sequence_embedding_inputs(input_ids, config_.image_token_id, image_features,
+                                           deepstack_features, num_features, feature_dim);
+
+    TensorMap inputs;
+    add_vl_prefill_base_inputs(inputs, *state_, input_ids, embedding_inputs, feature_dim);
+    if (!add_vl_prefill_deepstack_inputs(*prefill_, inputs, embedding_inputs, sq, feature_dim))
+        return false;
+
+    auto outputs = prefill_->forward(inputs);
+    if (!copy_last_prefill_logits(outputs, config_.vocab_size, logits))
+        return false;
+
+    std::vector<const void*> present_k;
+    std::vector<const void*> present_v;
+    if (!gather_vl_prefill_kv_pointers(*prefill_, config_, present_k, present_v))
+        return false;
+    kv_cache->write_prefill_kv(present_k, present_v, sq);
+    return true;
 }
 
 void Phi4MultimodalPipeline::run_vl_prefill_token(
@@ -315,38 +564,13 @@ void Phi4MultimodalPipeline::run_vl_decode_loop(Phi4MultimodalISampler* sampler,
 }
 
 void Phi4MultimodalPipeline::run_text_step(int32_t token_id, std::vector<float>& logits) {
-    TensorMap inputs;
-
-    Tensor token_t;
-    token_t.data = &token_id;
-    token_t.shape = {1};
-    token_t.dtype = DType::kInt32;
-    inputs["token_id"] = token_t;
-
-    state_->prepare_step(inputs);
-
-    auto outputs = text_decoder_->forward(inputs);
-
-    auto it = outputs.find("logits");
-    if (it == outputs.end())
-        throw std::runtime_error("Phi4MultimodalPipeline: no 'logits' output");
-
-    auto n = it->second.numel();
-    logits.resize(static_cast<std::size_t>(n));
-    std::memcpy(logits.data(), it->second.data, n * sizeof(float));
-
-    state_->advance();
+    run_text_step_with_embed(token_id, nullptr, 0.0F, {}, 0.0F, logits);
 }
 
 void Phi4MultimodalPipeline::run_text_step_with_embed(
     int32_t token_id, const float* input_embed, float use_input_embed,
     const std::vector<const float*>& deepstack_embeds, float deepstack_active,
     std::vector<float>& logits) {
-    if (!text_decoder_->has_input("input_embed")) {
-        run_text_step(token_id, logits);
-        return;
-    }
-
     TensorMap inputs;
 
     Tensor token_t;
@@ -357,56 +581,10 @@ void Phi4MultimodalPipeline::run_text_step_with_embed(
 
     state_->prepare_step(inputs);
 
-    // use_input_embed scalar: 1.0 = use input_embed, 0.0 = use token embedding
-    Tensor use_embed_t;
-    use_embed_t.data = &use_input_embed;
-    use_embed_t.shape = {1};
-    use_embed_t.dtype = DType::kFloat32;
-    inputs["use_input_embed"] = use_embed_t;
-
-    // Provide the input embedding vector
-    int32_t embed_dim = config_.vision_output_dim;
     std::vector<float> zero_embed;
-    if (input_embed == nullptr) {
-        zero_embed.resize(static_cast<std::size_t>(embed_dim), 0.0F);
-        input_embed = zero_embed.data();
-    }
-
-    Tensor embed_t;
-    embed_t.data = const_cast<float*>(input_embed);
-    embed_t.shape = {static_cast<int64_t>(embed_dim)};
-    embed_t.dtype = DType::kFloat32;
-    inputs["input_embed"] = embed_t;
-
-    // DeepStack: if the engine has deepstack inputs, provide inactive zeros.
-    if (text_decoder_->has_input("deepstack_active")) {
-        Tensor ds_active_t;
-        ds_active_t.data = &deepstack_active;
-        ds_active_t.shape = {1};
-        ds_active_t.dtype = DType::kFloat32;
-        inputs["deepstack_active"] = ds_active_t;
-
-        std::vector<float> zero_deepstack;
-        for (std::size_t i = 0;; ++i) {
-            const std::string name = "deepstack_embed_" + std::to_string(i);
-            if (!text_decoder_->has_input(name))
-                break;
-
-            const float* deepstack_embed =
-                i < deepstack_embeds.size() ? deepstack_embeds[i] : nullptr;
-            if (deepstack_embed == nullptr) {
-                if (zero_deepstack.empty())
-                    zero_deepstack.resize(static_cast<std::size_t>(embed_dim), 0.0F);
-                deepstack_embed = zero_deepstack.data();
-            }
-
-            Tensor ds_embed_t;
-            ds_embed_t.data = const_cast<float*>(deepstack_embed);
-            ds_embed_t.shape = {1, static_cast<int64_t>(embed_dim)};
-            ds_embed_t.dtype = DType::kFloat32;
-            inputs[name] = ds_embed_t;
-        }
-    }
+    std::vector<float> zero_deepstack;
+    add_text_step_embedding_inputs(*text_decoder_, config_, inputs, input_embed, use_input_embed,
+                                   deepstack_embeds, deepstack_active, zero_embed, zero_deepstack);
 
     auto outputs = text_decoder_->forward(inputs);
 

--- a/src/runtime/models/phi4_multimodal/pipeline.h
+++ b/src/runtime/models/phi4_multimodal/pipeline.h
@@ -31,6 +31,10 @@ struct Phi4MultimodalConfig {
     int32_t image_token_id{-1};
     int32_t vision_output_dim{0};
     bool has_position_input{true};
+    int32_t num_layers{0};
+    int32_t prefill_max_length{0};
+    std::string present_k_pattern{"present_k_{i}"};
+    std::string present_v_pattern{"present_v_{i}"};
 };
 
 class Phi4MultimodalPipeline final : public IPipeline {
@@ -42,7 +46,8 @@ class Phi4MultimodalPipeline final : public IPipeline {
                            Phi4MultimodalPreprocessConfig vl_preprocess, cudaStream_t stream,
                            std::shared_ptr<ITokenizer> tokenizer = nullptr,
                            std::string model_id_str = "",
-                           std::unique_ptr<Phi4MultimodalISampler> sampler = nullptr);
+                           std::unique_ptr<Phi4MultimodalISampler> sampler = nullptr,
+                           std::unique_ptr<TrtModule> prefill = nullptr);
 
     TextResult generate(const std::string& prompt, const GenerateConfig& cfg = {}) override;
 
@@ -66,6 +71,7 @@ class Phi4MultimodalPipeline final : public IPipeline {
 
   private:
     std::unique_ptr<TrtModule> text_decoder_;
+    std::unique_ptr<TrtModule> prefill_;
     std::unique_ptr<TrtModule> vision_encoder_;
     std::unique_ptr<Phi4MultimodalInferenceState> state_;
     Phi4MultimodalConfig config_;
@@ -91,6 +97,12 @@ class Phi4MultimodalPipeline final : public IPipeline {
                               const std::vector<std::vector<float>>& deepstack_features,
                               int32_t num_features, int32_t feature_dim, int32_t& feature_index,
                               std::vector<float>& logits);
+
+    bool run_vl_prefill_batched(const std::vector<int32_t>& input_ids,
+                                const std::vector<float>& image_features,
+                                const std::vector<std::vector<float>>& deepstack_features,
+                                int32_t num_features, int32_t feature_dim,
+                                std::vector<float>& logits);
 
     void run_vl_decode_loop(Phi4MultimodalISampler* sampler,
                             const Phi4MultimodalSamplingParams& params,

--- a/src/runtime/models/phi4_multimodal/plugin.cpp
+++ b/src/runtime/models/phi4_multimodal/plugin.cpp
@@ -92,14 +92,19 @@ Phi4MultimodalKvCacheNames build_kv_cache_names(const BaseConfig& config) {
     return kv_names;
 }
 
-LoadedModule load_text_module(const PipelineContext& ctx, TextModuleRuntime& runtime,
-                              const std::shared_ptr<Phi4MultimodalCudaStream>& stream) {
+DualProfileModules load_text_modules(const PipelineContext& ctx, TextModuleRuntime& runtime,
+                                     const std::shared_ptr<Phi4MultimodalCudaStream>& stream) {
     auto loaded =
-        load_trt_module_from_plan(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
+        load_dual_profile_modules(ctx.backend, find_section(ctx.bundle, runtime.engine_section),
                                   runtime.engine_section.c_str(), runtime.options);
-    loaded.module->keep_alive(stream);
-    if (runtime.tp_group.owner)
-        loaded.module->keep_alive(runtime.tp_group.owner);
+    loaded.decode->keep_alive(stream);
+    if (loaded.prefill)
+        loaded.prefill->keep_alive(stream);
+    if (runtime.tp_group.owner) {
+        loaded.decode->keep_alive(runtime.tp_group.owner);
+        if (loaded.prefill)
+            loaded.prefill->keep_alive(runtime.tp_group.owner);
+    }
     return loaded;
 }
 
@@ -152,12 +157,12 @@ class VLPlugin final : public IPipelinePlugin {
 
         Phi4MultimodalKvCacheNames kv_names = build_kv_cache_names(ctx.config);
 
-        auto loaded = load_text_module(ctx, text_runtime, shared_stream);
+        auto loaded = load_text_modules(ctx, text_runtime, shared_stream);
 
-        cudaStream_t stream = loaded.module->stream();
+        cudaStream_t stream = loaded.decode->stream();
         const std::string cache_k_name =
             kv_names.cache_k.empty() ? std::string("cache_k_0") : kv_names.cache_k.front();
-        int32_t kv_dim = decoder_cache_row_width(*loaded.module, cache_k_name, ctx.config);
+        int32_t kv_dim = decoder_cache_row_width(*loaded.decode, cache_k_name, ctx.config);
         DType cache_dtype = cache_dtype_from_precision(ctx.config.precision);
         std::unique_ptr<Phi4MultimodalInferenceState> state =
             std::make_unique<Phi4MultimodalKvCache>(ctx.config.num_layers,
@@ -172,7 +177,11 @@ class VLPlugin final : public IPipelinePlugin {
         vlc.id_eos = ctx.config.id_eos;
         vlc.image_token_id = extract_json_int(ctx.config_json, "image_token_id", -1);
         vlc.vision_output_dim = extract_json_int(ctx.config_json, "vision_output_dim", 0);
-        vlc.has_position_input = loaded.module->has_input("position_id");
+        vlc.has_position_input = loaded.decode->has_input("position_id");
+        vlc.num_layers = ctx.config.num_layers;
+        vlc.prefill_max_length = ctx.config.max_cache_length;
+        vlc.present_k_pattern = ctx.config.io_map.present_k_pattern;
+        vlc.present_v_pattern = ctx.config.io_map.present_v_pattern;
 
         bool has_vision_engine = extract_json_int(ctx.config_json, "has_vision_engine", 0) != 0;
 
@@ -188,8 +197,9 @@ class VLPlugin final : public IPipelinePlugin {
         auto vl_preprocess = phi4_multimodal_parse_preprocess_config(config_text, preproc_text);
 
         return std::make_unique<Phi4MultimodalPipeline>(
-            std::move(loaded.module), std::move(vision_module), std::move(state), vlc,
-            vl_preprocess, stream, std::move(tokenizer), ctx.bundle.info.model_id);
+            std::move(loaded.decode), std::move(vision_module), std::move(state), vlc,
+            vl_preprocess, stream, std::move(tokenizer), ctx.bundle.info.model_id, nullptr,
+            std::move(loaded.prefill));
     }
 };
 

--- a/tests/cpp/models/deepseek_ocr/test_deepseek_ocr_vl_pipeline.cpp
+++ b/tests/cpp/models/deepseek_ocr/test_deepseek_ocr_vl_pipeline.cpp
@@ -760,6 +760,51 @@ static void test_vl_sequence_prefill_uses_one_text_launch() {
     cudaStreamDestroy(stream);
 }
 
+static void test_vl_sequence_prefill_over_limit_uses_compatibility_path() {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto decode_stats = std::make_shared<CountingTextStats>();
+    auto prefill_stats = std::make_shared<CountingTextStats>();
+    auto decoder = std::make_unique<CountingTextModule>(decode_stats, false, stream);
+    auto prefill = std::make_unique<CountingTextModule>(prefill_stats, true, stream);
+    auto vision = std::make_unique<FakeSequenceVisionModule>();
+    auto cache = std::make_unique<trtmc::DeepseekOcrKvCache>(1, 8, 4, stream);
+
+    trtmc::DeepseekOcrConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 2;
+    cfg.image_token_id = 1;
+    cfg.vision_output_dim = 4;
+    cfg.num_layers = 1;
+    cfg.prefill_max_length = 2;
+
+    trtmc::DeepseekOcrPreprocessConfig vl_pp;
+    vl_pp.preprocessor_type = "simple_chw";
+    vl_pp.fixed_image_size = 4;
+    vl_pp.in_channels = 3;
+
+    auto tokenizer = std::make_shared<VLFixedTokenizer>();
+    trtmc::DeepseekOcrPipeline pipeline(std::move(decoder), std::move(vision), std::move(cache),
+                                        cfg, vl_pp, stream, tokenizer, "", nullptr,
+                                        std::move(prefill));
+
+    float pixels[2 * 2 * 3] = {0.5F, 0.5F, 0.5F, 0.4F, 0.4F, 0.4F,
+                               0.3F, 0.3F, 0.3F, 0.2F, 0.2F, 0.2F};
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 1;
+    gen_cfg.eos_token_id = 2;
+    auto result = pipeline.generate("test", pixels, 2, 2, gen_cfg);
+
+    check(result.token_ids == std::vector<int32_t>{2},
+          "sequence prefill limit: output remains correct");
+    check(prefill_stats->calls == 0, "sequence prefill limit: prefill launch skipped");
+    check(decode_stats->calls == 3,
+          "sequence prefill limit: token-by-token compatibility path used");
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_vl_generate_with_tokenizer() {
     // Covers the string-based generate(const string&, cfg) method
     auto engine = build_mock_decoder();
@@ -809,6 +854,7 @@ int main() {
     test_vl_generate_with_vision_encoder();
     test_vl_generate_with_embed_decoder();
     test_vl_sequence_prefill_uses_one_text_launch();
+    test_vl_sequence_prefill_over_limit_uses_compatibility_path();
     test_vl_generate_with_tokenizer();
     if (failures > 0)
         std::cerr << failures << " FAILED\n";

--- a/tests/cpp/models/deepseek_ocr/test_deepseek_ocr_vl_pipeline.cpp
+++ b/tests/cpp/models/deepseek_ocr/test_deepseek_ocr_vl_pipeline.cpp
@@ -41,8 +41,10 @@
 #include <cstdint>
 #include <cuda_runtime_api.h>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 static int failures = 0;
@@ -54,6 +56,130 @@ static void check(bool c, const char* n) {
 }
 
 static trtmc::TrtLogger g_logger;
+
+struct CountingTextStats {
+    int32_t calls{0};
+    std::unordered_map<std::string, std::vector<int64_t>> shapes;
+    std::unordered_map<std::string, std::vector<float>> float_values;
+};
+
+class CountingTextModule final : public trtmc::ITrtModule {
+  public:
+    CountingTextModule(std::shared_ptr<CountingTextStats> stats, bool prefill, cudaStream_t stream)
+        : stats_(std::move(stats)), prefill_(prefill), stream_(stream),
+          present_k_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}),
+          present_v_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        ++stats_->calls;
+        stats_->shapes.clear();
+        stats_->float_values.clear();
+        for (const auto& [name, tensor] : inputs) {
+            stats_->shapes[name] = tensor.shape;
+            if (tensor.dtype == trtmc::DType::kFloat32) {
+                const auto* begin = static_cast<const float*>(tensor.data);
+                stats_->float_values[name] =
+                    std::vector<float>(begin, begin + static_cast<std::ptrdiff_t>(tensor.numel()));
+            }
+        }
+        return {{"logits", trtmc::Tensor{logits_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap& inputs) override { (void)forward(inputs); }
+    void sync() override {}
+    cudaStream_t stream() const override { return stream_; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return prefill_ ? 0 : 1; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return {}; }
+    std::vector<trtmc::TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" || name == "attention_mask" ||
+               name == "input_embed" || name == "use_input_embed" || name == "deepstack_active" ||
+               name == "deepstack_embed_0" || name == "cache_k_0" || name == "cache_v_0";
+    }
+    bool has_output(const std::string& name) const override {
+        return name == "logits" || name == "present_k_0" || name == "present_v_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        if (name == "cache_k_0" || name == "cache_v_0")
+            return {8, 4};
+        return {};
+    }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return prefill_ ? 2 : 1; }
+    void* device_ptr(const std::string& name) const override {
+        if (name == "present_k_0")
+            return const_cast<void*>(present_k_.data());
+        if (name == "present_v_0")
+            return const_cast<void*>(present_v_.data());
+        return nullptr;
+    }
+    void bind_external(const std::string&, void*) override {}
+    int32_t input_rank(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" ? 1 : 2;
+    }
+    bool input_is_dynamic(const std::string&) const override { return prefill_; }
+    bool ok() const override { return !prefill_ || (present_k_.ok() && present_v_.ok()); }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::shared_ptr<CountingTextStats> stats_;
+    bool prefill_{false};
+    cudaStream_t stream_{nullptr};
+    mutable trtmc::DeviceTensor present_k_;
+    mutable trtmc::DeviceTensor present_v_;
+    std::vector<float> logits_{0.1F, 0.2F, 0.9F, 0.3F};
+};
+
+class FakeSequenceVisionModule final : public trtmc::ITrtModule {
+  public:
+    trtmc::TensorMap forward(const trtmc::TensorMap&) override {
+        return {{"image_features", trtmc::Tensor{features_.data(), {1, 4}, trtmc::DType::kFloat32}},
+                {"deepstack_features_0",
+                 trtmc::Tensor{deepstack_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap&) override {}
+    void sync() override {}
+    cudaStream_t stream() const override { return nullptr; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<trtmc::TensorInfo> input_info() const override {
+        return {{"pixel_values", {3, 4, 4}, trtmc::DType::kFloat32, true}};
+    }
+    std::vector<trtmc::TensorInfo> output_info() const override {
+        return {{"image_features", {1, 4}, trtmc::DType::kFloat32, false}};
+    }
+    bool has_input(const std::string& name) const override { return name == "pixel_values"; }
+    bool has_output(const std::string& name) const override {
+        return name == "image_features" || name == "deepstack_features_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string&) const override { return {}; }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string&) const override { return nullptr; }
+    void bind_external(const std::string&, void*) override {}
+    bool ok() const override { return true; }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::vector<float> features_{10.0F, 11.0F, 12.0F, 13.0F};
+    std::vector<float> deepstack_{20.0F, 21.0F, 22.0F, 23.0F};
+};
 
 // ---------------------------------------------------------------------------
 // Inline FixedTokenizer for string-based generate() tests
@@ -577,6 +703,63 @@ static void test_vl_generate_with_embed_decoder() {
     cudaStreamDestroy(stream);
 }
 
+static void test_vl_sequence_prefill_uses_one_text_launch() {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto decode_stats = std::make_shared<CountingTextStats>();
+    auto prefill_stats = std::make_shared<CountingTextStats>();
+    auto decoder = std::make_unique<CountingTextModule>(decode_stats, false, stream);
+    auto prefill = std::make_unique<CountingTextModule>(prefill_stats, true, stream);
+    auto vision = std::make_unique<FakeSequenceVisionModule>();
+    auto cache = std::make_unique<trtmc::DeepseekOcrKvCache>(1, 8, 4, stream);
+
+    trtmc::DeepseekOcrConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 2;
+    cfg.image_token_id = 1;
+    cfg.vision_output_dim = 4;
+    cfg.num_layers = 1;
+    cfg.prefill_max_length = 8;
+
+    trtmc::DeepseekOcrPreprocessConfig vl_pp;
+    vl_pp.preprocessor_type = "simple_chw";
+    vl_pp.fixed_image_size = 4;
+    vl_pp.in_channels = 3;
+
+    auto tokenizer = std::make_shared<VLFixedTokenizer>();
+    trtmc::DeepseekOcrPipeline pipeline(std::move(decoder), std::move(vision), std::move(cache),
+                                        cfg, vl_pp, stream, tokenizer, "", nullptr,
+                                        std::move(prefill));
+
+    float pixels[2 * 2 * 3] = {0.5F, 0.5F, 0.5F, 0.4F, 0.4F, 0.4F,
+                               0.3F, 0.3F, 0.3F, 0.2F, 0.2F, 0.2F};
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 1;
+    gen_cfg.eos_token_id = 2;
+    auto result = pipeline.generate("test", pixels, 2, 2, gen_cfg);
+
+    check(result.token_ids == std::vector<int32_t>{2}, "sequence prefill: output remains correct");
+    check(prefill_stats->calls == 1, "sequence prefill: one prefill launch");
+    check(decode_stats->calls == 0, "sequence prefill: no prompt-linear decode launches");
+    check(prefill_stats->shapes["token_id"] == std::vector<int64_t>{3},
+          "sequence prefill: token shape");
+    check(prefill_stats->shapes["input_embed"] == std::vector<int64_t>({3, 4}),
+          "sequence prefill: input embed shape");
+    check(prefill_stats->shapes["use_input_embed"] == std::vector<int64_t>({3, 1}),
+          "sequence prefill: embed selector shape");
+    check(prefill_stats->shapes["deepstack_embed_0"] == std::vector<int64_t>({3, 4}),
+          "sequence prefill: deepstack embed shape");
+    check(prefill_stats->shapes["deepstack_active"] == std::vector<int64_t>({3, 1}),
+          "sequence prefill: deepstack selector shape");
+    check(prefill_stats->float_values["use_input_embed"] == std::vector<float>({1.0F, 0.0F, 0.0F}),
+          "sequence prefill: image embedding selected by position");
+    check(prefill_stats->float_values["deepstack_active"] == std::vector<float>({1.0F, 0.0F, 0.0F}),
+          "sequence prefill: deepstack selected by position");
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_vl_generate_with_tokenizer() {
     // Covers the string-based generate(const string&, cfg) method
     auto engine = build_mock_decoder();
@@ -625,6 +808,7 @@ int main() {
     test_vl_generate_with_image_no_encoder();
     test_vl_generate_with_vision_encoder();
     test_vl_generate_with_embed_decoder();
+    test_vl_sequence_prefill_uses_one_text_launch();
     test_vl_generate_with_tokenizer();
     if (failures > 0)
         std::cerr << failures << " FAILED\n";

--- a/tests/cpp/models/internvl/test_internvl_vl_pipeline.cpp
+++ b/tests/cpp/models/internvl/test_internvl_vl_pipeline.cpp
@@ -41,8 +41,10 @@
 #include <cstdint>
 #include <cuda_runtime_api.h>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 static int failures = 0;
@@ -54,6 +56,130 @@ static void check(bool c, const char* n) {
 }
 
 static trtmc::TrtLogger g_logger;
+
+struct CountingTextStats {
+    int32_t calls{0};
+    std::unordered_map<std::string, std::vector<int64_t>> shapes;
+    std::unordered_map<std::string, std::vector<float>> float_values;
+};
+
+class CountingTextModule final : public trtmc::ITrtModule {
+  public:
+    CountingTextModule(std::shared_ptr<CountingTextStats> stats, bool prefill, cudaStream_t stream)
+        : stats_(std::move(stats)), prefill_(prefill), stream_(stream),
+          present_k_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}),
+          present_v_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        ++stats_->calls;
+        stats_->shapes.clear();
+        stats_->float_values.clear();
+        for (const auto& [name, tensor] : inputs) {
+            stats_->shapes[name] = tensor.shape;
+            if (tensor.dtype == trtmc::DType::kFloat32) {
+                const auto* begin = static_cast<const float*>(tensor.data);
+                stats_->float_values[name] =
+                    std::vector<float>(begin, begin + static_cast<std::ptrdiff_t>(tensor.numel()));
+            }
+        }
+        return {{"logits", trtmc::Tensor{logits_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap& inputs) override { (void)forward(inputs); }
+    void sync() override {}
+    cudaStream_t stream() const override { return stream_; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return prefill_ ? 0 : 1; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return {}; }
+    std::vector<trtmc::TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" || name == "attention_mask" ||
+               name == "input_embed" || name == "use_input_embed" || name == "deepstack_active" ||
+               name == "deepstack_embed_0" || name == "cache_k_0" || name == "cache_v_0";
+    }
+    bool has_output(const std::string& name) const override {
+        return name == "logits" || name == "present_k_0" || name == "present_v_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        if (name == "cache_k_0" || name == "cache_v_0")
+            return {8, 4};
+        return {};
+    }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return prefill_ ? 2 : 1; }
+    void* device_ptr(const std::string& name) const override {
+        if (name == "present_k_0")
+            return const_cast<void*>(present_k_.data());
+        if (name == "present_v_0")
+            return const_cast<void*>(present_v_.data());
+        return nullptr;
+    }
+    void bind_external(const std::string&, void*) override {}
+    int32_t input_rank(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" ? 1 : 2;
+    }
+    bool input_is_dynamic(const std::string&) const override { return prefill_; }
+    bool ok() const override { return !prefill_ || (present_k_.ok() && present_v_.ok()); }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::shared_ptr<CountingTextStats> stats_;
+    bool prefill_{false};
+    cudaStream_t stream_{nullptr};
+    mutable trtmc::DeviceTensor present_k_;
+    mutable trtmc::DeviceTensor present_v_;
+    std::vector<float> logits_{0.1F, 0.2F, 0.9F, 0.3F};
+};
+
+class FakeSequenceVisionModule final : public trtmc::ITrtModule {
+  public:
+    trtmc::TensorMap forward(const trtmc::TensorMap&) override {
+        return {{"image_features", trtmc::Tensor{features_.data(), {1, 4}, trtmc::DType::kFloat32}},
+                {"deepstack_features_0",
+                 trtmc::Tensor{deepstack_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap&) override {}
+    void sync() override {}
+    cudaStream_t stream() const override { return nullptr; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<trtmc::TensorInfo> input_info() const override {
+        return {{"pixel_values", {3, 4, 4}, trtmc::DType::kFloat32, true}};
+    }
+    std::vector<trtmc::TensorInfo> output_info() const override {
+        return {{"image_features", {1, 4}, trtmc::DType::kFloat32, false}};
+    }
+    bool has_input(const std::string& name) const override { return name == "pixel_values"; }
+    bool has_output(const std::string& name) const override {
+        return name == "image_features" || name == "deepstack_features_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string&) const override { return {}; }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string&) const override { return nullptr; }
+    void bind_external(const std::string&, void*) override {}
+    bool ok() const override { return true; }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::vector<float> features_{10.0F, 11.0F, 12.0F, 13.0F};
+    std::vector<float> deepstack_{20.0F, 21.0F, 22.0F, 23.0F};
+};
 
 // ---------------------------------------------------------------------------
 // Inline FixedTokenizer for string-based generate() tests
@@ -576,6 +702,62 @@ static void test_vl_generate_with_embed_decoder() {
     cudaStreamDestroy(stream);
 }
 
+static void test_vl_sequence_prefill_uses_one_text_launch() {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto decode_stats = std::make_shared<CountingTextStats>();
+    auto prefill_stats = std::make_shared<CountingTextStats>();
+    auto decoder = std::make_unique<CountingTextModule>(decode_stats, false, stream);
+    auto prefill = std::make_unique<CountingTextModule>(prefill_stats, true, stream);
+    auto vision = std::make_unique<FakeSequenceVisionModule>();
+    auto cache = std::make_unique<trtmc::InternvlKvCache>(1, 8, 4, stream);
+
+    trtmc::InternVlConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 2;
+    cfg.image_token_id = 1;
+    cfg.vision_output_dim = 4;
+    cfg.num_layers = 1;
+    cfg.prefill_max_length = 8;
+
+    trtmc::InternVlPreprocessConfig vl_pp;
+    vl_pp.preprocessor_type = "simple_chw";
+    vl_pp.fixed_image_size = 4;
+    vl_pp.in_channels = 3;
+
+    auto tokenizer = std::make_shared<VLFixedTokenizer>();
+    trtmc::InternVlPipeline pipeline(std::move(decoder), std::move(vision), std::move(cache), cfg,
+                                     vl_pp, stream, tokenizer, "", nullptr, std::move(prefill));
+
+    float pixels[2 * 2 * 3] = {0.5F, 0.5F, 0.5F, 0.4F, 0.4F, 0.4F,
+                               0.3F, 0.3F, 0.3F, 0.2F, 0.2F, 0.2F};
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 1;
+    gen_cfg.eos_token_id = 2;
+    auto result = pipeline.generate("test", pixels, 2, 2, gen_cfg);
+
+    check(result.token_ids == std::vector<int32_t>{2}, "sequence prefill: output remains correct");
+    check(prefill_stats->calls == 1, "sequence prefill: one prefill launch");
+    check(decode_stats->calls == 0, "sequence prefill: no prompt-linear decode launches");
+    check(prefill_stats->shapes["token_id"] == std::vector<int64_t>{3},
+          "sequence prefill: token shape");
+    check(prefill_stats->shapes["input_embed"] == std::vector<int64_t>({3, 4}),
+          "sequence prefill: input embed shape");
+    check(prefill_stats->shapes["use_input_embed"] == std::vector<int64_t>({3, 1}),
+          "sequence prefill: embed selector shape");
+    check(prefill_stats->shapes["deepstack_embed_0"] == std::vector<int64_t>({3, 4}),
+          "sequence prefill: deepstack embed shape");
+    check(prefill_stats->shapes["deepstack_active"] == std::vector<int64_t>({3, 1}),
+          "sequence prefill: deepstack selector shape");
+    check(prefill_stats->float_values["use_input_embed"] == std::vector<float>({1.0F, 0.0F, 0.0F}),
+          "sequence prefill: image embedding selected by position");
+    check(prefill_stats->float_values["deepstack_active"] == std::vector<float>({1.0F, 0.0F, 0.0F}),
+          "sequence prefill: deepstack selected by position");
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_vl_generate_with_tokenizer() {
     // Covers the string-based generate(const string&, cfg) method
     auto engine = build_mock_decoder();
@@ -624,6 +806,7 @@ int main() {
     test_vl_generate_with_image_no_encoder();
     test_vl_generate_with_vision_encoder();
     test_vl_generate_with_embed_decoder();
+    test_vl_sequence_prefill_uses_one_text_launch();
     test_vl_generate_with_tokenizer();
     if (failures > 0)
         std::cerr << failures << " FAILED\n";

--- a/tests/cpp/models/lance/test_lance_vl_pipeline.cpp
+++ b/tests/cpp/models/lance/test_lance_vl_pipeline.cpp
@@ -41,8 +41,10 @@
 #include <cstdint>
 #include <cuda_runtime_api.h>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 static int failures = 0;
@@ -54,6 +56,130 @@ static void check(bool c, const char* n) {
 }
 
 static trtmc::TrtLogger g_logger;
+
+struct CountingTextStats {
+    int32_t calls{0};
+    std::unordered_map<std::string, std::vector<int64_t>> shapes;
+    std::unordered_map<std::string, std::vector<float>> float_values;
+};
+
+class CountingTextModule final : public trtmc::ITrtModule {
+  public:
+    CountingTextModule(std::shared_ptr<CountingTextStats> stats, bool prefill, cudaStream_t stream)
+        : stats_(std::move(stats)), prefill_(prefill), stream_(stream),
+          present_k_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}),
+          present_v_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        ++stats_->calls;
+        stats_->shapes.clear();
+        stats_->float_values.clear();
+        for (const auto& [name, tensor] : inputs) {
+            stats_->shapes[name] = tensor.shape;
+            if (tensor.dtype == trtmc::DType::kFloat32) {
+                const auto* begin = static_cast<const float*>(tensor.data);
+                stats_->float_values[name] =
+                    std::vector<float>(begin, begin + static_cast<std::ptrdiff_t>(tensor.numel()));
+            }
+        }
+        return {{"logits", trtmc::Tensor{logits_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap& inputs) override { (void)forward(inputs); }
+    void sync() override {}
+    cudaStream_t stream() const override { return stream_; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return prefill_ ? 0 : 1; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return {}; }
+    std::vector<trtmc::TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" || name == "attention_mask" ||
+               name == "input_embed" || name == "use_input_embed" || name == "deepstack_active" ||
+               name == "deepstack_embed_0" || name == "cache_k_0" || name == "cache_v_0";
+    }
+    bool has_output(const std::string& name) const override {
+        return name == "logits" || name == "present_k_0" || name == "present_v_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        if (name == "cache_k_0" || name == "cache_v_0")
+            return {8, 4};
+        return {};
+    }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return prefill_ ? 2 : 1; }
+    void* device_ptr(const std::string& name) const override {
+        if (name == "present_k_0")
+            return const_cast<void*>(present_k_.data());
+        if (name == "present_v_0")
+            return const_cast<void*>(present_v_.data());
+        return nullptr;
+    }
+    void bind_external(const std::string&, void*) override {}
+    int32_t input_rank(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" ? 1 : 2;
+    }
+    bool input_is_dynamic(const std::string&) const override { return prefill_; }
+    bool ok() const override { return !prefill_ || (present_k_.ok() && present_v_.ok()); }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::shared_ptr<CountingTextStats> stats_;
+    bool prefill_{false};
+    cudaStream_t stream_{nullptr};
+    mutable trtmc::DeviceTensor present_k_;
+    mutable trtmc::DeviceTensor present_v_;
+    std::vector<float> logits_{0.1F, 0.2F, 0.9F, 0.3F};
+};
+
+class FakeSequenceVisionModule final : public trtmc::ITrtModule {
+  public:
+    trtmc::TensorMap forward(const trtmc::TensorMap&) override {
+        return {{"image_features", trtmc::Tensor{features_.data(), {1, 4}, trtmc::DType::kFloat32}},
+                {"deepstack_features_0",
+                 trtmc::Tensor{deepstack_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap&) override {}
+    void sync() override {}
+    cudaStream_t stream() const override { return nullptr; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<trtmc::TensorInfo> input_info() const override {
+        return {{"pixel_values", {3, 4, 4}, trtmc::DType::kFloat32, true}};
+    }
+    std::vector<trtmc::TensorInfo> output_info() const override {
+        return {{"image_features", {1, 4}, trtmc::DType::kFloat32, false}};
+    }
+    bool has_input(const std::string& name) const override { return name == "pixel_values"; }
+    bool has_output(const std::string& name) const override {
+        return name == "image_features" || name == "deepstack_features_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string&) const override { return {}; }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string&) const override { return nullptr; }
+    void bind_external(const std::string&, void*) override {}
+    bool ok() const override { return true; }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::vector<float> features_{10.0F, 11.0F, 12.0F, 13.0F};
+    std::vector<float> deepstack_{20.0F, 21.0F, 22.0F, 23.0F};
+};
 
 // ---------------------------------------------------------------------------
 // Inline FixedTokenizer for string-based generate() tests
@@ -576,6 +702,62 @@ static void test_vl_generate_with_embed_decoder() {
     cudaStreamDestroy(stream);
 }
 
+static void test_vl_sequence_prefill_uses_one_text_launch() {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto decode_stats = std::make_shared<CountingTextStats>();
+    auto prefill_stats = std::make_shared<CountingTextStats>();
+    auto decoder = std::make_unique<CountingTextModule>(decode_stats, false, stream);
+    auto prefill = std::make_unique<CountingTextModule>(prefill_stats, true, stream);
+    auto vision = std::make_unique<FakeSequenceVisionModule>();
+    auto cache = std::make_unique<trtmc::LanceKvCache>(1, 8, 4, stream);
+
+    trtmc::LanceConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 2;
+    cfg.image_token_id = 1;
+    cfg.vision_output_dim = 4;
+    cfg.num_layers = 1;
+    cfg.prefill_max_length = 8;
+
+    trtmc::LancePreprocessConfig vl_pp;
+    vl_pp.preprocessor_type = "simple_chw";
+    vl_pp.fixed_image_size = 4;
+    vl_pp.in_channels = 3;
+
+    auto tokenizer = std::make_shared<VLFixedTokenizer>();
+    trtmc::LancePipeline pipeline(std::move(decoder), std::move(vision), std::move(cache), cfg,
+                                  vl_pp, stream, tokenizer, "", nullptr, std::move(prefill));
+
+    float pixels[2 * 2 * 3] = {0.5F, 0.5F, 0.5F, 0.4F, 0.4F, 0.4F,
+                               0.3F, 0.3F, 0.3F, 0.2F, 0.2F, 0.2F};
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 1;
+    gen_cfg.eos_token_id = 2;
+    auto result = pipeline.generate("test", pixels, 2, 2, gen_cfg);
+
+    check(result.token_ids == std::vector<int32_t>{2}, "sequence prefill: output remains correct");
+    check(prefill_stats->calls == 1, "sequence prefill: one prefill launch");
+    check(decode_stats->calls == 0, "sequence prefill: no prompt-linear decode launches");
+    check(prefill_stats->shapes["token_id"] == std::vector<int64_t>{3},
+          "sequence prefill: token shape");
+    check(prefill_stats->shapes["input_embed"] == std::vector<int64_t>({3, 4}),
+          "sequence prefill: input embed shape");
+    check(prefill_stats->shapes["use_input_embed"] == std::vector<int64_t>({3, 1}),
+          "sequence prefill: embed selector shape");
+    check(prefill_stats->shapes["deepstack_embed_0"] == std::vector<int64_t>({3, 4}),
+          "sequence prefill: deepstack embed shape");
+    check(prefill_stats->shapes["deepstack_active"] == std::vector<int64_t>({3, 1}),
+          "sequence prefill: deepstack selector shape");
+    check(prefill_stats->float_values["use_input_embed"] == std::vector<float>({1.0F, 0.0F, 0.0F}),
+          "sequence prefill: image embedding selected by position");
+    check(prefill_stats->float_values["deepstack_active"] == std::vector<float>({1.0F, 0.0F, 0.0F}),
+          "sequence prefill: deepstack selected by position");
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_vl_generate_with_tokenizer() {
     // Covers the string-based generate(const string&, cfg) method
     auto engine = build_mock_decoder();
@@ -624,6 +806,7 @@ int main() {
     test_vl_generate_with_image_no_encoder();
     test_vl_generate_with_vision_encoder();
     test_vl_generate_with_embed_decoder();
+    test_vl_sequence_prefill_uses_one_text_launch();
     test_vl_generate_with_tokenizer();
     if (failures > 0)
         std::cerr << failures << " FAILED\n";

--- a/tests/cpp/models/locateanything/test_locateanything_vl_pipeline.cpp
+++ b/tests/cpp/models/locateanything/test_locateanything_vl_pipeline.cpp
@@ -41,8 +41,10 @@
 #include <cstdint>
 #include <cuda_runtime_api.h>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 static int failures = 0;
@@ -54,6 +56,130 @@ static void check(bool c, const char* n) {
 }
 
 static trtmc::TrtLogger g_logger;
+
+struct CountingTextStats {
+    int32_t calls{0};
+    std::unordered_map<std::string, std::vector<int64_t>> shapes;
+    std::unordered_map<std::string, std::vector<float>> float_values;
+};
+
+class CountingTextModule final : public trtmc::ITrtModule {
+  public:
+    CountingTextModule(std::shared_ptr<CountingTextStats> stats, bool prefill, cudaStream_t stream)
+        : stats_(std::move(stats)), prefill_(prefill), stream_(stream),
+          present_k_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}),
+          present_v_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        ++stats_->calls;
+        stats_->shapes.clear();
+        stats_->float_values.clear();
+        for (const auto& [name, tensor] : inputs) {
+            stats_->shapes[name] = tensor.shape;
+            if (tensor.dtype == trtmc::DType::kFloat32) {
+                const auto* begin = static_cast<const float*>(tensor.data);
+                stats_->float_values[name] =
+                    std::vector<float>(begin, begin + static_cast<std::ptrdiff_t>(tensor.numel()));
+            }
+        }
+        return {{"logits", trtmc::Tensor{logits_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap& inputs) override { (void)forward(inputs); }
+    void sync() override {}
+    cudaStream_t stream() const override { return stream_; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return prefill_ ? 0 : 1; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return {}; }
+    std::vector<trtmc::TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" || name == "attention_mask" ||
+               name == "input_embed" || name == "use_input_embed" || name == "deepstack_active" ||
+               name == "deepstack_embed_0" || name == "cache_k_0" || name == "cache_v_0";
+    }
+    bool has_output(const std::string& name) const override {
+        return name == "logits" || name == "present_k_0" || name == "present_v_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        if (name == "cache_k_0" || name == "cache_v_0")
+            return {8, 4};
+        return {};
+    }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return prefill_ ? 2 : 1; }
+    void* device_ptr(const std::string& name) const override {
+        if (name == "present_k_0")
+            return const_cast<void*>(present_k_.data());
+        if (name == "present_v_0")
+            return const_cast<void*>(present_v_.data());
+        return nullptr;
+    }
+    void bind_external(const std::string&, void*) override {}
+    int32_t input_rank(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" ? 1 : 2;
+    }
+    bool input_is_dynamic(const std::string&) const override { return prefill_; }
+    bool ok() const override { return !prefill_ || (present_k_.ok() && present_v_.ok()); }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::shared_ptr<CountingTextStats> stats_;
+    bool prefill_{false};
+    cudaStream_t stream_{nullptr};
+    mutable trtmc::DeviceTensor present_k_;
+    mutable trtmc::DeviceTensor present_v_;
+    std::vector<float> logits_{0.1F, 0.2F, 0.9F, 0.3F};
+};
+
+class FakeSequenceVisionModule final : public trtmc::ITrtModule {
+  public:
+    trtmc::TensorMap forward(const trtmc::TensorMap&) override {
+        return {{"image_features", trtmc::Tensor{features_.data(), {1, 4}, trtmc::DType::kFloat32}},
+                {"deepstack_features_0",
+                 trtmc::Tensor{deepstack_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap&) override {}
+    void sync() override {}
+    cudaStream_t stream() const override { return nullptr; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<trtmc::TensorInfo> input_info() const override {
+        return {{"pixel_values", {3, 4, 4}, trtmc::DType::kFloat32, true}};
+    }
+    std::vector<trtmc::TensorInfo> output_info() const override {
+        return {{"image_features", {1, 4}, trtmc::DType::kFloat32, false}};
+    }
+    bool has_input(const std::string& name) const override { return name == "pixel_values"; }
+    bool has_output(const std::string& name) const override {
+        return name == "image_features" || name == "deepstack_features_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string&) const override { return {}; }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string&) const override { return nullptr; }
+    void bind_external(const std::string&, void*) override {}
+    bool ok() const override { return true; }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::vector<float> features_{10.0F, 11.0F, 12.0F, 13.0F};
+    std::vector<float> deepstack_{20.0F, 21.0F, 22.0F, 23.0F};
+};
 
 // ---------------------------------------------------------------------------
 // Inline FixedTokenizer for string-based generate() tests
@@ -632,6 +758,63 @@ static void test_vl_generate_with_embed_decoder() {
     cudaStreamDestroy(stream);
 }
 
+static void test_vl_sequence_prefill_uses_one_text_launch() {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto decode_stats = std::make_shared<CountingTextStats>();
+    auto prefill_stats = std::make_shared<CountingTextStats>();
+    auto decoder = std::make_unique<CountingTextModule>(decode_stats, false, stream);
+    auto prefill = std::make_unique<CountingTextModule>(prefill_stats, true, stream);
+    auto vision = std::make_unique<FakeSequenceVisionModule>();
+    auto cache = std::make_unique<trtmc::LocateanythingKvCache>(1, 8, 4, stream);
+
+    trtmc::LocateAnythingConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 2;
+    cfg.image_token_id = 1;
+    cfg.vision_output_dim = 4;
+    cfg.num_layers = 1;
+    cfg.prefill_max_length = 8;
+
+    trtmc::LocateAnythingPreprocessConfig vl_pp;
+    vl_pp.preprocessor_type = "simple_chw";
+    vl_pp.fixed_image_size = 4;
+    vl_pp.in_channels = 3;
+
+    auto tokenizer = std::make_shared<VLFixedTokenizer>();
+    trtmc::LocateAnythingPipeline pipeline(std::move(decoder), std::move(vision), std::move(cache),
+                                           cfg, vl_pp, stream, tokenizer, "", nullptr,
+                                           std::move(prefill));
+
+    float pixels[2 * 2 * 3] = {0.5F, 0.5F, 0.5F, 0.4F, 0.4F, 0.4F,
+                               0.3F, 0.3F, 0.3F, 0.2F, 0.2F, 0.2F};
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 1;
+    gen_cfg.eos_token_id = 2;
+    auto result = pipeline.generate("test", pixels, 2, 2, gen_cfg);
+
+    check(result.token_ids == std::vector<int32_t>{2}, "sequence prefill: output remains correct");
+    check(prefill_stats->calls == 1, "sequence prefill: one prefill launch");
+    check(decode_stats->calls == 0, "sequence prefill: no prompt-linear decode launches");
+    check(prefill_stats->shapes["token_id"] == std::vector<int64_t>{3},
+          "sequence prefill: token shape");
+    check(prefill_stats->shapes["input_embed"] == std::vector<int64_t>({3, 4}),
+          "sequence prefill: input embed shape");
+    check(prefill_stats->shapes["use_input_embed"] == std::vector<int64_t>({3, 1}),
+          "sequence prefill: embed selector shape");
+    check(prefill_stats->shapes["deepstack_embed_0"] == std::vector<int64_t>({3, 4}),
+          "sequence prefill: deepstack embed shape");
+    check(prefill_stats->shapes["deepstack_active"] == std::vector<int64_t>({3, 1}),
+          "sequence prefill: deepstack selector shape");
+    check(prefill_stats->float_values["use_input_embed"] == std::vector<float>({1.0F, 0.0F, 0.0F}),
+          "sequence prefill: image embedding selected by position");
+    check(prefill_stats->float_values["deepstack_active"] == std::vector<float>({1.0F, 0.0F, 0.0F}),
+          "sequence prefill: deepstack selected by position");
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_vl_generate_with_tokenizer() {
     // Covers the string-based generate(const string&, cfg) method
     auto engine = build_mock_decoder();
@@ -681,6 +864,7 @@ int main() {
     test_vl_generate_with_image_no_encoder();
     test_vl_generate_with_vision_encoder();
     test_vl_generate_with_embed_decoder();
+    test_vl_sequence_prefill_uses_one_text_launch();
     test_vl_generate_with_tokenizer();
     if (failures > 0)
         std::cerr << failures << " FAILED\n";

--- a/tests/cpp/models/phi4_multimodal/test_phi4_multimodal_vl_pipeline.cpp
+++ b/tests/cpp/models/phi4_multimodal/test_phi4_multimodal_vl_pipeline.cpp
@@ -41,8 +41,10 @@
 #include <cstdint>
 #include <cuda_runtime_api.h>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 static int failures = 0;
@@ -54,6 +56,130 @@ static void check(bool c, const char* n) {
 }
 
 static trtmc::TrtLogger g_logger;
+
+struct CountingTextStats {
+    int32_t calls{0};
+    std::unordered_map<std::string, std::vector<int64_t>> shapes;
+    std::unordered_map<std::string, std::vector<float>> float_values;
+};
+
+class CountingTextModule final : public trtmc::ITrtModule {
+  public:
+    CountingTextModule(std::shared_ptr<CountingTextStats> stats, bool prefill, cudaStream_t stream)
+        : stats_(std::move(stats)), prefill_(prefill), stream_(stream),
+          present_k_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}),
+          present_v_(prefill ? trtmc::DeviceTensor::zeros({8, 4}, trtmc::DType::kFloat32, stream)
+                             : trtmc::DeviceTensor{}) {}
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        ++stats_->calls;
+        stats_->shapes.clear();
+        stats_->float_values.clear();
+        for (const auto& [name, tensor] : inputs) {
+            stats_->shapes[name] = tensor.shape;
+            if (tensor.dtype == trtmc::DType::kFloat32) {
+                const auto* begin = static_cast<const float*>(tensor.data);
+                stats_->float_values[name] =
+                    std::vector<float>(begin, begin + static_cast<std::ptrdiff_t>(tensor.numel()));
+            }
+        }
+        return {{"logits", trtmc::Tensor{logits_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap& inputs) override { (void)forward(inputs); }
+    void sync() override {}
+    cudaStream_t stream() const override { return stream_; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return prefill_ ? 0 : 1; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return {}; }
+    std::vector<trtmc::TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" || name == "attention_mask" ||
+               name == "input_embed" || name == "use_input_embed" || name == "deepstack_active" ||
+               name == "deepstack_embed_0" || name == "cache_k_0" || name == "cache_v_0";
+    }
+    bool has_output(const std::string& name) const override {
+        return name == "logits" || name == "present_k_0" || name == "present_v_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        if (name == "cache_k_0" || name == "cache_v_0")
+            return {8, 4};
+        return {};
+    }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return prefill_ ? 2 : 1; }
+    void* device_ptr(const std::string& name) const override {
+        if (name == "present_k_0")
+            return const_cast<void*>(present_k_.data());
+        if (name == "present_v_0")
+            return const_cast<void*>(present_v_.data());
+        return nullptr;
+    }
+    void bind_external(const std::string&, void*) override {}
+    int32_t input_rank(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" ? 1 : 2;
+    }
+    bool input_is_dynamic(const std::string&) const override { return prefill_; }
+    bool ok() const override { return !prefill_ || (present_k_.ok() && present_v_.ok()); }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::shared_ptr<CountingTextStats> stats_;
+    bool prefill_{false};
+    cudaStream_t stream_{nullptr};
+    mutable trtmc::DeviceTensor present_k_;
+    mutable trtmc::DeviceTensor present_v_;
+    std::vector<float> logits_{0.1F, 0.2F, 0.9F, 0.3F};
+};
+
+class FakeSequenceVisionModule final : public trtmc::ITrtModule {
+  public:
+    trtmc::TensorMap forward(const trtmc::TensorMap&) override {
+        return {{"image_features", trtmc::Tensor{features_.data(), {1, 4}, trtmc::DType::kFloat32}},
+                {"deepstack_features_0",
+                 trtmc::Tensor{deepstack_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap&) override {}
+    void sync() override {}
+    cudaStream_t stream() const override { return nullptr; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<trtmc::TensorInfo> input_info() const override {
+        return {{"pixel_values", {3, 4, 4}, trtmc::DType::kFloat32, true}};
+    }
+    std::vector<trtmc::TensorInfo> output_info() const override {
+        return {{"image_features", {1, 4}, trtmc::DType::kFloat32, false}};
+    }
+    bool has_input(const std::string& name) const override { return name == "pixel_values"; }
+    bool has_output(const std::string& name) const override {
+        return name == "image_features" || name == "deepstack_features_0";
+    }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string&) const override { return {}; }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string&) const override { return nullptr; }
+    void bind_external(const std::string&, void*) override {}
+    bool ok() const override { return true; }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    std::vector<float> features_{10.0F, 11.0F, 12.0F, 13.0F};
+    std::vector<float> deepstack_{20.0F, 21.0F, 22.0F, 23.0F};
+};
 
 // ---------------------------------------------------------------------------
 // Inline FixedTokenizer for string-based generate() tests
@@ -577,6 +703,63 @@ static void test_vl_generate_with_embed_decoder() {
     cudaStreamDestroy(stream);
 }
 
+static void test_vl_sequence_prefill_uses_one_text_launch() {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto decode_stats = std::make_shared<CountingTextStats>();
+    auto prefill_stats = std::make_shared<CountingTextStats>();
+    auto decoder = std::make_unique<CountingTextModule>(decode_stats, false, stream);
+    auto prefill = std::make_unique<CountingTextModule>(prefill_stats, true, stream);
+    auto vision = std::make_unique<FakeSequenceVisionModule>();
+    auto cache = std::make_unique<trtmc::Phi4MultimodalKvCache>(1, 8, 4, stream);
+
+    trtmc::Phi4MultimodalConfig cfg;
+    cfg.vocab_size = 4;
+    cfg.id_eos = 2;
+    cfg.image_token_id = 1;
+    cfg.vision_output_dim = 4;
+    cfg.num_layers = 1;
+    cfg.prefill_max_length = 8;
+
+    trtmc::Phi4MultimodalPreprocessConfig vl_pp;
+    vl_pp.preprocessor_type = "simple_chw";
+    vl_pp.fixed_image_size = 4;
+    vl_pp.in_channels = 3;
+
+    auto tokenizer = std::make_shared<VLFixedTokenizer>();
+    trtmc::Phi4MultimodalPipeline pipeline(std::move(decoder), std::move(vision), std::move(cache),
+                                           cfg, vl_pp, stream, tokenizer, "", nullptr,
+                                           std::move(prefill));
+
+    float pixels[2 * 2 * 3] = {0.5F, 0.5F, 0.5F, 0.4F, 0.4F, 0.4F,
+                               0.3F, 0.3F, 0.3F, 0.2F, 0.2F, 0.2F};
+    trtmc::GenerateConfig gen_cfg;
+    gen_cfg.max_new_tokens = 1;
+    gen_cfg.eos_token_id = 2;
+    auto result = pipeline.generate("test", pixels, 2, 2, gen_cfg);
+
+    check(result.token_ids == std::vector<int32_t>{2}, "sequence prefill: output remains correct");
+    check(prefill_stats->calls == 1, "sequence prefill: one prefill launch");
+    check(decode_stats->calls == 0, "sequence prefill: no prompt-linear decode launches");
+    check(prefill_stats->shapes["token_id"] == std::vector<int64_t>{3},
+          "sequence prefill: token shape");
+    check(prefill_stats->shapes["input_embed"] == std::vector<int64_t>({3, 4}),
+          "sequence prefill: input embed shape");
+    check(prefill_stats->shapes["use_input_embed"] == std::vector<int64_t>({3, 1}),
+          "sequence prefill: embed selector shape");
+    check(prefill_stats->shapes["deepstack_embed_0"] == std::vector<int64_t>({3, 4}),
+          "sequence prefill: deepstack embed shape");
+    check(prefill_stats->shapes["deepstack_active"] == std::vector<int64_t>({3, 1}),
+          "sequence prefill: deepstack selector shape");
+    check(prefill_stats->float_values["use_input_embed"] == std::vector<float>({1.0F, 0.0F, 0.0F}),
+          "sequence prefill: image embedding selected by position");
+    check(prefill_stats->float_values["deepstack_active"] == std::vector<float>({1.0F, 0.0F, 0.0F}),
+          "sequence prefill: deepstack selected by position");
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_vl_generate_with_tokenizer() {
     // Covers the string-based generate(const string&, cfg) method
     auto engine = build_mock_decoder();
@@ -625,6 +808,7 @@ int main() {
     test_vl_generate_with_image_no_encoder();
     test_vl_generate_with_vision_encoder();
     test_vl_generate_with_embed_decoder();
+    test_vl_sequence_prefill_uses_one_text_launch();
     test_vl_generate_with_tokenizer();
     if (failures > 0)
         std::cerr << failures << " FAILED\n";

--- a/tests/e2e/models/deepseek_ocr/e2e_plugins/runners/vl_debug_runner.py
+++ b/tests/e2e/models/deepseek_ocr/e2e_plugins/runners/vl_debug_runner.py
@@ -61,6 +61,20 @@ def _require_trt_runtime() -> None:
         raise ImportError("cuda-python is required for VL debug runner execution")
 
 
+def _profile_min_shape(engine: Any, name: str, profile_index: int) -> tuple[int, ...]:
+    """Resolve a concrete single-step shape for a possibly dynamic tensor."""
+    declared = tuple(int(dim) for dim in engine.get_tensor_shape(name))
+    if all(dim >= 0 for dim in declared):
+        return declared
+    profile_shapes = engine.get_tensor_profile_shape(name, profile_index)
+    if not profile_shapes:
+        raise RuntimeError(f"Missing optimization profile shape for {name!r}")
+    resolved = tuple(int(dim) for dim in profile_shapes[0])
+    if any(dim < 0 for dim in resolved):
+        raise RuntimeError(f"Invalid optimization profile shape for {name!r}: {resolved}")
+    return resolved
+
+
 class TrtRunner:
     """Device-resident TRT inference runner for debugging and diff testing.
 
@@ -104,17 +118,19 @@ class TrtRunner:
         # decode profile (profile 1, Sq=1). For per-step decode runs the
         # debug_runner must select the decode profile and call
         # set_input_shape on every dynamic input before each execute. We
-        # detect dual-profile via num_optimization_profiles > 1 and the
-        # presence of -1 dims on token_id / position_id / attention_mask.
-        self._dynamic_inputs: list[str] = []
+        # detect dual-profile via num_optimization_profiles > 1 and resolve
+        # every dynamic input from the selected profile's minimum shape.
+        self._dynamic_input_shapes: dict[str, tuple[int, ...]] = {}
         self._is_dual_profile = self.engine.num_optimization_profiles > 1
-        for input_name in ("token_id", "position_id", "attention_mask"):
-            try:
-                shape = tuple(self.engine.get_tensor_shape(input_name))
-            except Exception:
+        self._profile_index = 1 if self._is_dual_profile else 0
+        for index in range(self.engine.num_io_tensors):
+            input_name = self.engine.get_tensor_name(index)
+            if self.engine.get_tensor_mode(input_name) != trt.TensorIOMode.INPUT:
                 continue
-            if any(d < 0 for d in shape):
-                self._dynamic_inputs.append(input_name)
+            shape = tuple(self.engine.get_tensor_shape(input_name))
+            if any(dim < 0 for dim in shape):
+                self._dynamic_input_shapes[input_name] = _profile_min_shape(
+                    self.engine, input_name, self._profile_index)
         if self._is_dual_profile:
             # Profile 1 = decode (Sq=1). step() always runs single-token, so
             # we lock the context to that profile once and never switch.
@@ -213,14 +229,18 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name == "input_embed":
                 self._has_embed_input = True
-                embed_shape = tuple(self.engine.get_tensor_shape(name))
+                embed_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 embed_bytes = int(np.prod(embed_shape)) * 4
                 self._h_input_embed = np.zeros(embed_shape, dtype=np.float32)
                 err, self._d_input_embed = cudart.cudaMalloc(embed_bytes)
                 _check_cuda(err)
             elif name == "use_input_embed":
-                self._h_use_input_embed = np.zeros((1,), dtype=np.float32)
-                err, self._d_use_input_embed = cudart.cudaMalloc(4)
+                selector_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_use_input_embed = np.zeros(selector_shape, dtype=np.float32)
+                err, self._d_use_input_embed = cudart.cudaMalloc(
+                    self._h_use_input_embed.nbytes)
                 _check_cuda(err)
 
         # DeepStack inputs (auto-detected from engine bindings)
@@ -233,15 +253,19 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name.startswith("deepstack_embed_"):
                 self._deepstack_names.append(name)
-                shape = tuple(self.engine.get_tensor_shape(name))
+                shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 nbytes = int(np.prod(shape)) * 4
                 self._h_deepstack[name] = np.zeros(shape, dtype=np.float32)
                 err, d_ptr = cudart.cudaMalloc(nbytes)
                 _check_cuda(err)
                 self._d_deepstack[name] = d_ptr
             elif name == "deepstack_active":
-                self._h_deepstack_active = np.zeros((1,), dtype=np.float32)
-                err, self._d_deepstack_active = cudart.cudaMalloc(4)
+                active_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_deepstack_active = np.zeros(active_shape, dtype=np.float32)
+                err, self._d_deepstack_active = cudart.cudaMalloc(
+                    self._h_deepstack_active.nbytes)
                 _check_cuda(err)
 
         # Debug output device/host buffers
@@ -331,7 +355,7 @@ class TrtRunner:
                 self._h_input_embed.nbytes, H2D, stream)
             cudart.cudaMemcpyAsync(
                 self._d_use_input_embed, self._h_use_input_embed.ctypes.data,
-                4, H2D, stream)
+                self._h_use_input_embed.nbytes, H2D, stream)
 
         # DeepStack H2D transfers
         if self._deepstack_names:
@@ -350,7 +374,7 @@ class TrtRunner:
                 cudart.cudaMemcpyAsync(
                     self._d_deepstack_active,
                     self._h_deepstack_active.ctypes.data,
-                    4, H2D, stream)
+                    self._h_deepstack_active.nbytes, H2D, stream)
 
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
@@ -379,15 +403,11 @@ class TrtRunner:
         for name in self._debug_output_names:
             self.context.set_tensor_address(name, self._d_debug[name])
 
-        # Dual-profile engines need explicit shapes for the dynamic
-        # inputs every step. step() is single-token decode, so all three
-        # shapes are fixed: Sq=1 and K = max_cache_length + 1.
-        if self._dynamic_inputs:
-            for name in self._dynamic_inputs:
-                if name == "attention_mask":
-                    self.context.set_input_shape(name, (1, attention_window))
-                else:
-                    self.context.set_input_shape(name, (1,))
+        # Dynamic inputs use the selected profile's minimum shapes. Both the
+        # prefill and decode profiles have Sq=1 minima, so this covers token,
+        # mask, image embedding, selector, and DeepStack inputs uniformly.
+        for name, shape in self._dynamic_input_shapes.items():
+            self.context.set_input_shape(name, shape)
 
         # Execute
         self.context.execute_async_v3(stream)
@@ -481,24 +501,16 @@ class TrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask,
-                self._d_logits]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        if self._d_input_embed:
-            bufs.append(self._d_input_embed)
-        if self._d_use_input_embed:
-            bufs.append(self._d_use_input_embed)
-        for d_ptr in self._d_deepstack.values():
-            bufs.append(d_ptr)
-        if self._d_deepstack_active:
-            bufs.append(self._d_deepstack_active)
-        for d_ptr in self._d_debug.values():
-            bufs.append(d_ptr)
+        bufs = []
+        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
+                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+            d_ptr = getattr(self, name, 0)
+            if d_ptr:
+                bufs.append(d_ptr)
+        for name in ("_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v"):
+            bufs.extend(getattr(self, name, []))
+        bufs.extend(getattr(self, "_d_deepstack", {}).values())
+        bufs.extend(getattr(self, "_d_debug", {}).values())
         for d_ptr in bufs:
             cudart.cudaFree(d_ptr)
         if hasattr(self, "stream"):

--- a/tests/e2e/models/deepseek_ocr/test_deepseek_ocr_builder_tp.py
+++ b/tests/e2e/models/deepseek_ocr/test_deepseek_ocr_builder_tp.py
@@ -18,7 +18,8 @@ try:
     deepseek_ocr_module = importlib.import_module(
         "tensorrt_model_connect.families.deepseek_ocr.plugin")
     from tensorrt_model_connect.checkpoint_mapper import WeightDict
-    from tensorrt_model_connect.families.deepseek_ocr import tp_builder
+    from tensorrt_model_connect import trt_compat
+    from tensorrt_model_connect.families.deepseek_ocr import graph_ops, tp_builder
     from tensorrt_model_connect.families.deepseek_ocr.prefill_config import (
         sequence_prefill_profile_lengths,
     )
@@ -272,3 +273,34 @@ def test_deepseek_ocr_bounds_sequence_prefill_profile(
     max_cache_length: int, expected: tuple[int, int]
 ) -> None:
     assert sequence_prefill_profile_lengths(max_cache_length) == expected
+
+
+def test_deepseek_ocr_decomposes_multirow_sequence_attention() -> None:
+    trt = trt_compat.get_trt()
+    builder = trt.Builder(trt.Logger(trt.Logger.ERROR))
+    network = builder.create_network(
+        1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
+    head_dim = 128
+    hidden_size = 2 * head_dim
+    q = network.add_input("q", trt.float16, (2, hidden_size))
+    k = network.add_input("k", trt.float16, (5, hidden_size))
+    v = network.add_input("v", trt.float16, (5, hidden_size))
+    mask = network.add_input("mask", trt.float16, (2, 5))
+    mask_4d = graph_ops.add_2d_mask_to_4d(network, mask)
+
+    output = graph_ops.add_attention_from_rows(
+        network, q, k, v,
+        num_heads=2,
+        num_kv_heads=2,
+        head_dim=head_dim,
+        q_seq=2,
+        kv_seq=5,
+        mask=mask_4d,
+        fp32_accumulation=True,
+    )
+
+    assert output.shape == (2, hidden_size)
+    layer_types = [
+        network.get_layer(idx).type for idx in range(network.num_layers)
+    ]
+    assert layer_types.count(trt.LayerType.MATRIX_MULTIPLY) == 2

--- a/tests/e2e/models/deepseek_ocr/test_deepseek_ocr_builder_tp.py
+++ b/tests/e2e/models/deepseek_ocr/test_deepseek_ocr_builder_tp.py
@@ -19,6 +19,9 @@ try:
         "tensorrt_model_connect.families.deepseek_ocr.plugin")
     from tensorrt_model_connect.checkpoint_mapper import WeightDict
     from tensorrt_model_connect.families.deepseek_ocr import tp_builder
+    from tensorrt_model_connect.families.deepseek_ocr.prefill_config import (
+        sequence_prefill_profile_lengths,
+    )
     from tensorrt_model_connect.parallel_config import ParallelConfig
 except (ImportError, ModuleNotFoundError):
     pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
@@ -257,4 +260,15 @@ def test_deepseek_ocr_uses_official_768_single_view_contract() -> None:
     assert vl_config is not None
     assert vl_config["fixed_image_size"] == 768
     assert vl_config["num_image_pad_tokens"] == 145
+    assert vl_config["prefill_max_length"] == 256
     assert vl_config["preprocessor_type"] == "simple_chw"
+
+
+@pytest.mark.parametrize(
+    ("max_cache_length", "expected"),
+    [(4096, (64, 256)), (128, (64, 128)), (32, (32, 32))],
+)
+def test_deepseek_ocr_bounds_sequence_prefill_profile(
+    max_cache_length: int, expected: tuple[int, int]
+) -> None:
+    assert sequence_prefill_profile_lengths(max_cache_length) == expected

--- a/tests/e2e/models/internvl/e2e_plugins/runners/vl_debug_runner.py
+++ b/tests/e2e/models/internvl/e2e_plugins/runners/vl_debug_runner.py
@@ -61,6 +61,20 @@ def _require_trt_runtime() -> None:
         raise ImportError("cuda-python is required for VL debug runner execution")
 
 
+def _profile_min_shape(engine: Any, name: str, profile_index: int) -> tuple[int, ...]:
+    """Resolve a concrete single-step shape for a possibly dynamic tensor."""
+    declared = tuple(int(dim) for dim in engine.get_tensor_shape(name))
+    if all(dim >= 0 for dim in declared):
+        return declared
+    profile_shapes = engine.get_tensor_profile_shape(name, profile_index)
+    if not profile_shapes:
+        raise RuntimeError(f"Missing optimization profile shape for {name!r}")
+    resolved = tuple(int(dim) for dim in profile_shapes[0])
+    if any(dim < 0 for dim in resolved):
+        raise RuntimeError(f"Invalid optimization profile shape for {name!r}: {resolved}")
+    return resolved
+
+
 class TrtRunner:
     """Device-resident TRT inference runner for debugging and diff testing.
 
@@ -104,17 +118,19 @@ class TrtRunner:
         # decode profile (profile 1, Sq=1). For per-step decode runs the
         # debug_runner must select the decode profile and call
         # set_input_shape on every dynamic input before each execute. We
-        # detect dual-profile via num_optimization_profiles > 1 and the
-        # presence of -1 dims on token_id / position_id / attention_mask.
-        self._dynamic_inputs: list[str] = []
+        # detect dual-profile via num_optimization_profiles > 1 and resolve
+        # every dynamic input from the selected profile's minimum shape.
+        self._dynamic_input_shapes: dict[str, tuple[int, ...]] = {}
         self._is_dual_profile = self.engine.num_optimization_profiles > 1
-        for input_name in ("token_id", "position_id", "attention_mask"):
-            try:
-                shape = tuple(self.engine.get_tensor_shape(input_name))
-            except Exception:
+        self._profile_index = 1 if self._is_dual_profile else 0
+        for index in range(self.engine.num_io_tensors):
+            input_name = self.engine.get_tensor_name(index)
+            if self.engine.get_tensor_mode(input_name) != trt.TensorIOMode.INPUT:
                 continue
-            if any(d < 0 for d in shape):
-                self._dynamic_inputs.append(input_name)
+            shape = tuple(self.engine.get_tensor_shape(input_name))
+            if any(dim < 0 for dim in shape):
+                self._dynamic_input_shapes[input_name] = _profile_min_shape(
+                    self.engine, input_name, self._profile_index)
         if self._is_dual_profile:
             # Profile 1 = decode (Sq=1). step() always runs single-token, so
             # we lock the context to that profile once and never switch.
@@ -213,14 +229,18 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name == "input_embed":
                 self._has_embed_input = True
-                embed_shape = tuple(self.engine.get_tensor_shape(name))
+                embed_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 embed_bytes = int(np.prod(embed_shape)) * 4
                 self._h_input_embed = np.zeros(embed_shape, dtype=np.float32)
                 err, self._d_input_embed = cudart.cudaMalloc(embed_bytes)
                 _check_cuda(err)
             elif name == "use_input_embed":
-                self._h_use_input_embed = np.zeros((1,), dtype=np.float32)
-                err, self._d_use_input_embed = cudart.cudaMalloc(4)
+                selector_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_use_input_embed = np.zeros(selector_shape, dtype=np.float32)
+                err, self._d_use_input_embed = cudart.cudaMalloc(
+                    self._h_use_input_embed.nbytes)
                 _check_cuda(err)
 
         # DeepStack inputs (auto-detected from engine bindings)
@@ -233,15 +253,19 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name.startswith("deepstack_embed_"):
                 self._deepstack_names.append(name)
-                shape = tuple(self.engine.get_tensor_shape(name))
+                shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 nbytes = int(np.prod(shape)) * 4
                 self._h_deepstack[name] = np.zeros(shape, dtype=np.float32)
                 err, d_ptr = cudart.cudaMalloc(nbytes)
                 _check_cuda(err)
                 self._d_deepstack[name] = d_ptr
             elif name == "deepstack_active":
-                self._h_deepstack_active = np.zeros((1,), dtype=np.float32)
-                err, self._d_deepstack_active = cudart.cudaMalloc(4)
+                active_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_deepstack_active = np.zeros(active_shape, dtype=np.float32)
+                err, self._d_deepstack_active = cudart.cudaMalloc(
+                    self._h_deepstack_active.nbytes)
                 _check_cuda(err)
 
         # Debug output device/host buffers
@@ -331,7 +355,7 @@ class TrtRunner:
                 self._h_input_embed.nbytes, H2D, stream)
             cudart.cudaMemcpyAsync(
                 self._d_use_input_embed, self._h_use_input_embed.ctypes.data,
-                4, H2D, stream)
+                self._h_use_input_embed.nbytes, H2D, stream)
 
         # DeepStack H2D transfers
         if self._deepstack_names:
@@ -350,7 +374,7 @@ class TrtRunner:
                 cudart.cudaMemcpyAsync(
                     self._d_deepstack_active,
                     self._h_deepstack_active.ctypes.data,
-                    4, H2D, stream)
+                    self._h_deepstack_active.nbytes, H2D, stream)
 
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
@@ -379,15 +403,11 @@ class TrtRunner:
         for name in self._debug_output_names:
             self.context.set_tensor_address(name, self._d_debug[name])
 
-        # Dual-profile engines need explicit shapes for the dynamic
-        # inputs every step. step() is single-token decode, so all three
-        # shapes are fixed: Sq=1 and K = max_cache_length + 1.
-        if self._dynamic_inputs:
-            for name in self._dynamic_inputs:
-                if name == "attention_mask":
-                    self.context.set_input_shape(name, (1, attention_window))
-                else:
-                    self.context.set_input_shape(name, (1,))
+        # Dynamic inputs use the selected profile's minimum shapes. Both the
+        # prefill and decode profiles have Sq=1 minima, so this covers token,
+        # mask, image embedding, selector, and DeepStack inputs uniformly.
+        for name, shape in self._dynamic_input_shapes.items():
+            self.context.set_input_shape(name, shape)
 
         # Execute
         self.context.execute_async_v3(stream)
@@ -481,24 +501,16 @@ class TrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask,
-                self._d_logits]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        if self._d_input_embed:
-            bufs.append(self._d_input_embed)
-        if self._d_use_input_embed:
-            bufs.append(self._d_use_input_embed)
-        for d_ptr in self._d_deepstack.values():
-            bufs.append(d_ptr)
-        if self._d_deepstack_active:
-            bufs.append(self._d_deepstack_active)
-        for d_ptr in self._d_debug.values():
-            bufs.append(d_ptr)
+        bufs = []
+        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
+                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+            d_ptr = getattr(self, name, 0)
+            if d_ptr:
+                bufs.append(d_ptr)
+        for name in ("_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v"):
+            bufs.extend(getattr(self, name, []))
+        bufs.extend(getattr(self, "_d_deepstack", {}).values())
+        bufs.extend(getattr(self, "_d_debug", {}).values())
         for d_ptr in bufs:
             cudart.cudaFree(d_ptr)
         if hasattr(self, "stream"):

--- a/tests/e2e/models/internvl/test_internvl_builder_tp.py
+++ b/tests/e2e/models/internvl/test_internvl_builder_tp.py
@@ -19,6 +19,26 @@ from tensorrt_model_connect.parallel_config import ParallelConfig
 
 class _Config:
     model_type = "internvl_chat"
+    raw = {}
+
+
+def test_internvl_embed_input_dispatches_to_dual_profile_builder(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.internvl.default_decoder")
+    calls: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"internvl-dual-profile-plan"
+
+    monkeypatch.setattr(module, "build_dual_profile_decoder_engine", fake_build)
+    config = _Config()
+    config.raw = {"_decoder_engine_role": "decode"}
+    result = module.build_standard_decoder_engine(
+        config, {}, 31, precision="fp16", embed_input=True)
+
+    assert result == b"internvl-dual-profile-plan"
+    assert calls["build"][3]["embed_input"] is True
 
 
 def test_internvl_tp_builder_rejects_single_device_mode() -> None:

--- a/tests/e2e/models/lance/e2e_plugins/runners/vl_debug_runner.py
+++ b/tests/e2e/models/lance/e2e_plugins/runners/vl_debug_runner.py
@@ -61,6 +61,20 @@ def _require_trt_runtime() -> None:
         raise ImportError("cuda-python is required for VL debug runner execution")
 
 
+def _profile_min_shape(engine: Any, name: str, profile_index: int) -> tuple[int, ...]:
+    """Resolve a concrete single-step shape for a possibly dynamic tensor."""
+    declared = tuple(int(dim) for dim in engine.get_tensor_shape(name))
+    if all(dim >= 0 for dim in declared):
+        return declared
+    profile_shapes = engine.get_tensor_profile_shape(name, profile_index)
+    if not profile_shapes:
+        raise RuntimeError(f"Missing optimization profile shape for {name!r}")
+    resolved = tuple(int(dim) for dim in profile_shapes[0])
+    if any(dim < 0 for dim in resolved):
+        raise RuntimeError(f"Invalid optimization profile shape for {name!r}: {resolved}")
+    return resolved
+
+
 class TrtRunner:
     """Device-resident TRT inference runner for debugging and diff testing.
 
@@ -104,17 +118,19 @@ class TrtRunner:
         # decode profile (profile 1, Sq=1). For per-step decode runs the
         # debug_runner must select the decode profile and call
         # set_input_shape on every dynamic input before each execute. We
-        # detect dual-profile via num_optimization_profiles > 1 and the
-        # presence of -1 dims on token_id / position_id / attention_mask.
-        self._dynamic_inputs: list[str] = []
+        # detect dual-profile via num_optimization_profiles > 1 and resolve
+        # every dynamic input from the selected profile's minimum shape.
+        self._dynamic_input_shapes: dict[str, tuple[int, ...]] = {}
         self._is_dual_profile = self.engine.num_optimization_profiles > 1
-        for input_name in ("token_id", "position_id", "attention_mask"):
-            try:
-                shape = tuple(self.engine.get_tensor_shape(input_name))
-            except Exception:
+        self._profile_index = 1 if self._is_dual_profile else 0
+        for index in range(self.engine.num_io_tensors):
+            input_name = self.engine.get_tensor_name(index)
+            if self.engine.get_tensor_mode(input_name) != trt.TensorIOMode.INPUT:
                 continue
-            if any(d < 0 for d in shape):
-                self._dynamic_inputs.append(input_name)
+            shape = tuple(self.engine.get_tensor_shape(input_name))
+            if any(dim < 0 for dim in shape):
+                self._dynamic_input_shapes[input_name] = _profile_min_shape(
+                    self.engine, input_name, self._profile_index)
         if self._is_dual_profile:
             # Profile 1 = decode (Sq=1). step() always runs single-token, so
             # we lock the context to that profile once and never switch.
@@ -213,14 +229,18 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name == "input_embed":
                 self._has_embed_input = True
-                embed_shape = tuple(self.engine.get_tensor_shape(name))
+                embed_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 embed_bytes = int(np.prod(embed_shape)) * 4
                 self._h_input_embed = np.zeros(embed_shape, dtype=np.float32)
                 err, self._d_input_embed = cudart.cudaMalloc(embed_bytes)
                 _check_cuda(err)
             elif name == "use_input_embed":
-                self._h_use_input_embed = np.zeros((1,), dtype=np.float32)
-                err, self._d_use_input_embed = cudart.cudaMalloc(4)
+                selector_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_use_input_embed = np.zeros(selector_shape, dtype=np.float32)
+                err, self._d_use_input_embed = cudart.cudaMalloc(
+                    self._h_use_input_embed.nbytes)
                 _check_cuda(err)
 
         # DeepStack inputs (auto-detected from engine bindings)
@@ -233,15 +253,19 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name.startswith("deepstack_embed_"):
                 self._deepstack_names.append(name)
-                shape = tuple(self.engine.get_tensor_shape(name))
+                shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 nbytes = int(np.prod(shape)) * 4
                 self._h_deepstack[name] = np.zeros(shape, dtype=np.float32)
                 err, d_ptr = cudart.cudaMalloc(nbytes)
                 _check_cuda(err)
                 self._d_deepstack[name] = d_ptr
             elif name == "deepstack_active":
-                self._h_deepstack_active = np.zeros((1,), dtype=np.float32)
-                err, self._d_deepstack_active = cudart.cudaMalloc(4)
+                active_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_deepstack_active = np.zeros(active_shape, dtype=np.float32)
+                err, self._d_deepstack_active = cudart.cudaMalloc(
+                    self._h_deepstack_active.nbytes)
                 _check_cuda(err)
 
         # Debug output device/host buffers
@@ -331,7 +355,7 @@ class TrtRunner:
                 self._h_input_embed.nbytes, H2D, stream)
             cudart.cudaMemcpyAsync(
                 self._d_use_input_embed, self._h_use_input_embed.ctypes.data,
-                4, H2D, stream)
+                self._h_use_input_embed.nbytes, H2D, stream)
 
         # DeepStack H2D transfers
         if self._deepstack_names:
@@ -350,7 +374,7 @@ class TrtRunner:
                 cudart.cudaMemcpyAsync(
                     self._d_deepstack_active,
                     self._h_deepstack_active.ctypes.data,
-                    4, H2D, stream)
+                    self._h_deepstack_active.nbytes, H2D, stream)
 
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
@@ -379,15 +403,11 @@ class TrtRunner:
         for name in self._debug_output_names:
             self.context.set_tensor_address(name, self._d_debug[name])
 
-        # Dual-profile engines need explicit shapes for the dynamic
-        # inputs every step. step() is single-token decode, so all three
-        # shapes are fixed: Sq=1 and K = max_cache_length + 1.
-        if self._dynamic_inputs:
-            for name in self._dynamic_inputs:
-                if name == "attention_mask":
-                    self.context.set_input_shape(name, (1, attention_window))
-                else:
-                    self.context.set_input_shape(name, (1,))
+        # Dynamic inputs use the selected profile's minimum shapes. Both the
+        # prefill and decode profiles have Sq=1 minima, so this covers token,
+        # mask, image embedding, selector, and DeepStack inputs uniformly.
+        for name, shape in self._dynamic_input_shapes.items():
+            self.context.set_input_shape(name, shape)
 
         # Execute
         self.context.execute_async_v3(stream)
@@ -481,24 +501,16 @@ class TrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask,
-                self._d_logits]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        if self._d_input_embed:
-            bufs.append(self._d_input_embed)
-        if self._d_use_input_embed:
-            bufs.append(self._d_use_input_embed)
-        for d_ptr in self._d_deepstack.values():
-            bufs.append(d_ptr)
-        if self._d_deepstack_active:
-            bufs.append(self._d_deepstack_active)
-        for d_ptr in self._d_debug.values():
-            bufs.append(d_ptr)
+        bufs = []
+        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
+                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+            d_ptr = getattr(self, name, 0)
+            if d_ptr:
+                bufs.append(d_ptr)
+        for name in ("_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v"):
+            bufs.extend(getattr(self, name, []))
+        bufs.extend(getattr(self, "_d_deepstack", {}).values())
+        bufs.extend(getattr(self, "_d_debug", {}).values())
         for d_ptr in bufs:
             cudart.cudaFree(d_ptr)
         if hasattr(self, "stream"):

--- a/tests/e2e/models/lance/test_lance_builder.py
+++ b/tests/e2e/models/lance/test_lance_builder.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused tests for the LANCE decoder builder."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+pytest.importorskip("tensorrt", reason="TensorRT is required for family builder tests")
+
+
+def test_lance_embed_input_dispatches_to_dual_profile_builder(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.lance.default_decoder")
+    calls: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"lance-dual-profile-plan"
+
+    monkeypatch.setattr(module, "build_dual_profile_decoder_engine", fake_build)
+    config = type("Config", (), {"raw": {"_decoder_engine_role": "decode"}})()
+    result = module.build_standard_decoder_engine(
+        config, {}, 31, precision="fp16", embed_input=True)
+
+    assert result == b"lance-dual-profile-plan"
+    assert calls["build"][3]["embed_input"] is True

--- a/tests/e2e/models/locateanything/e2e_plugins/runners/vl_debug_runner.py
+++ b/tests/e2e/models/locateanything/e2e_plugins/runners/vl_debug_runner.py
@@ -61,6 +61,20 @@ def _require_trt_runtime() -> None:
         raise ImportError("cuda-python is required for VL debug runner execution")
 
 
+def _profile_min_shape(engine: Any, name: str, profile_index: int) -> tuple[int, ...]:
+    """Resolve a concrete single-step shape for a possibly dynamic tensor."""
+    declared = tuple(int(dim) for dim in engine.get_tensor_shape(name))
+    if all(dim >= 0 for dim in declared):
+        return declared
+    profile_shapes = engine.get_tensor_profile_shape(name, profile_index)
+    if not profile_shapes:
+        raise RuntimeError(f"Missing optimization profile shape for {name!r}")
+    resolved = tuple(int(dim) for dim in profile_shapes[0])
+    if any(dim < 0 for dim in resolved):
+        raise RuntimeError(f"Invalid optimization profile shape for {name!r}: {resolved}")
+    return resolved
+
+
 class TrtRunner:
     """Device-resident TRT inference runner for debugging and diff testing.
 
@@ -104,17 +118,19 @@ class TrtRunner:
         # decode profile (profile 1, Sq=1). For per-step decode runs the
         # debug_runner must select the decode profile and call
         # set_input_shape on every dynamic input before each execute. We
-        # detect dual-profile via num_optimization_profiles > 1 and the
-        # presence of -1 dims on token_id / position_id / attention_mask.
-        self._dynamic_inputs: list[str] = []
+        # detect dual-profile via num_optimization_profiles > 1 and resolve
+        # every dynamic input from the selected profile's minimum shape.
+        self._dynamic_input_shapes: dict[str, tuple[int, ...]] = {}
         self._is_dual_profile = self.engine.num_optimization_profiles > 1
-        for input_name in ("token_id", "position_id", "attention_mask"):
-            try:
-                shape = tuple(self.engine.get_tensor_shape(input_name))
-            except Exception:
+        self._profile_index = 1 if self._is_dual_profile else 0
+        for index in range(self.engine.num_io_tensors):
+            input_name = self.engine.get_tensor_name(index)
+            if self.engine.get_tensor_mode(input_name) != trt.TensorIOMode.INPUT:
                 continue
-            if any(d < 0 for d in shape):
-                self._dynamic_inputs.append(input_name)
+            shape = tuple(self.engine.get_tensor_shape(input_name))
+            if any(dim < 0 for dim in shape):
+                self._dynamic_input_shapes[input_name] = _profile_min_shape(
+                    self.engine, input_name, self._profile_index)
         if self._is_dual_profile:
             # Profile 1 = decode (Sq=1). step() always runs single-token, so
             # we lock the context to that profile once and never switch.
@@ -213,14 +229,18 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name == "input_embed":
                 self._has_embed_input = True
-                embed_shape = tuple(self.engine.get_tensor_shape(name))
+                embed_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 embed_bytes = int(np.prod(embed_shape)) * 4
                 self._h_input_embed = np.zeros(embed_shape, dtype=np.float32)
                 err, self._d_input_embed = cudart.cudaMalloc(embed_bytes)
                 _check_cuda(err)
             elif name == "use_input_embed":
-                self._h_use_input_embed = np.zeros((1,), dtype=np.float32)
-                err, self._d_use_input_embed = cudart.cudaMalloc(4)
+                selector_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_use_input_embed = np.zeros(selector_shape, dtype=np.float32)
+                err, self._d_use_input_embed = cudart.cudaMalloc(
+                    self._h_use_input_embed.nbytes)
                 _check_cuda(err)
 
         # DeepStack inputs (auto-detected from engine bindings)
@@ -233,15 +253,19 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name.startswith("deepstack_embed_"):
                 self._deepstack_names.append(name)
-                shape = tuple(self.engine.get_tensor_shape(name))
+                shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 nbytes = int(np.prod(shape)) * 4
                 self._h_deepstack[name] = np.zeros(shape, dtype=np.float32)
                 err, d_ptr = cudart.cudaMalloc(nbytes)
                 _check_cuda(err)
                 self._d_deepstack[name] = d_ptr
             elif name == "deepstack_active":
-                self._h_deepstack_active = np.zeros((1,), dtype=np.float32)
-                err, self._d_deepstack_active = cudart.cudaMalloc(4)
+                active_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_deepstack_active = np.zeros(active_shape, dtype=np.float32)
+                err, self._d_deepstack_active = cudart.cudaMalloc(
+                    self._h_deepstack_active.nbytes)
                 _check_cuda(err)
 
         # Debug output device/host buffers
@@ -331,7 +355,7 @@ class TrtRunner:
                 self._h_input_embed.nbytes, H2D, stream)
             cudart.cudaMemcpyAsync(
                 self._d_use_input_embed, self._h_use_input_embed.ctypes.data,
-                4, H2D, stream)
+                self._h_use_input_embed.nbytes, H2D, stream)
 
         # DeepStack H2D transfers
         if self._deepstack_names:
@@ -350,7 +374,7 @@ class TrtRunner:
                 cudart.cudaMemcpyAsync(
                     self._d_deepstack_active,
                     self._h_deepstack_active.ctypes.data,
-                    4, H2D, stream)
+                    self._h_deepstack_active.nbytes, H2D, stream)
 
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
@@ -379,15 +403,11 @@ class TrtRunner:
         for name in self._debug_output_names:
             self.context.set_tensor_address(name, self._d_debug[name])
 
-        # Dual-profile engines need explicit shapes for the dynamic
-        # inputs every step. step() is single-token decode, so all three
-        # shapes are fixed: Sq=1 and K = max_cache_length + 1.
-        if self._dynamic_inputs:
-            for name in self._dynamic_inputs:
-                if name == "attention_mask":
-                    self.context.set_input_shape(name, (1, attention_window))
-                else:
-                    self.context.set_input_shape(name, (1,))
+        # Dynamic inputs use the selected profile's minimum shapes. Both the
+        # prefill and decode profiles have Sq=1 minima, so this covers token,
+        # mask, image embedding, selector, and DeepStack inputs uniformly.
+        for name, shape in self._dynamic_input_shapes.items():
+            self.context.set_input_shape(name, shape)
 
         # Execute
         self.context.execute_async_v3(stream)
@@ -481,24 +501,16 @@ class TrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask,
-                self._d_logits]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        if self._d_input_embed:
-            bufs.append(self._d_input_embed)
-        if self._d_use_input_embed:
-            bufs.append(self._d_use_input_embed)
-        for d_ptr in self._d_deepstack.values():
-            bufs.append(d_ptr)
-        if self._d_deepstack_active:
-            bufs.append(self._d_deepstack_active)
-        for d_ptr in self._d_debug.values():
-            bufs.append(d_ptr)
+        bufs = []
+        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
+                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+            d_ptr = getattr(self, name, 0)
+            if d_ptr:
+                bufs.append(d_ptr)
+        for name in ("_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v"):
+            bufs.extend(getattr(self, name, []))
+        bufs.extend(getattr(self, "_d_deepstack", {}).values())
+        bufs.extend(getattr(self, "_d_debug", {}).values())
         for d_ptr in bufs:
             cudart.cudaFree(d_ptr)
         if hasattr(self, "stream"):

--- a/tests/e2e/models/locateanything/test_locateanything_family_plugin_weights.py
+++ b/tests/e2e/models/locateanything/test_locateanything_family_plugin_weights.py
@@ -9,7 +9,7 @@ Shared test code is limited to filesystem and serialization helpers.
 
 from __future__ import annotations
 
-
+import importlib
 
 from tests.builder.family_plugin_test_support import (
     ModelConfig,
@@ -17,6 +17,24 @@ from tests.builder.family_plugin_test_support import (
     _write_config,
     _write_safetensors,
 )
+
+
+def test_locateanything_embed_input_dispatches_to_dual_profile_builder(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.locateanything.default_decoder")
+    calls: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"locateanything-dual-profile-plan"
+
+    monkeypatch.setattr(module, "build_dual_profile_decoder_engine", fake_build)
+    config = type("Config", (), {"raw": {"_decoder_engine_role": "decode"}})()
+    result = module.build_standard_decoder_engine(
+        config, {}, 31, precision="fp16", embed_input=True)
+
+    assert result == b"locateanything-dual-profile-plan"
+    assert calls["build"][3]["embed_input"] is True
 
 
 class TestLocateAnythingPlugin:

--- a/tests/e2e/models/phi4_multimodal/e2e_plugins/runners/vl_debug_runner.py
+++ b/tests/e2e/models/phi4_multimodal/e2e_plugins/runners/vl_debug_runner.py
@@ -61,6 +61,20 @@ def _require_trt_runtime() -> None:
         raise ImportError("cuda-python is required for VL debug runner execution")
 
 
+def _profile_min_shape(engine: Any, name: str, profile_index: int) -> tuple[int, ...]:
+    """Resolve a concrete single-step shape for a possibly dynamic tensor."""
+    declared = tuple(int(dim) for dim in engine.get_tensor_shape(name))
+    if all(dim >= 0 for dim in declared):
+        return declared
+    profile_shapes = engine.get_tensor_profile_shape(name, profile_index)
+    if not profile_shapes:
+        raise RuntimeError(f"Missing optimization profile shape for {name!r}")
+    resolved = tuple(int(dim) for dim in profile_shapes[0])
+    if any(dim < 0 for dim in resolved):
+        raise RuntimeError(f"Invalid optimization profile shape for {name!r}: {resolved}")
+    return resolved
+
+
 class TrtRunner:
     """Device-resident TRT inference runner for debugging and diff testing.
 
@@ -104,17 +118,19 @@ class TrtRunner:
         # decode profile (profile 1, Sq=1). For per-step decode runs the
         # debug_runner must select the decode profile and call
         # set_input_shape on every dynamic input before each execute. We
-        # detect dual-profile via num_optimization_profiles > 1 and the
-        # presence of -1 dims on token_id / position_id / attention_mask.
-        self._dynamic_inputs: list[str] = []
+        # detect dual-profile via num_optimization_profiles > 1 and resolve
+        # every dynamic input from the selected profile's minimum shape.
+        self._dynamic_input_shapes: dict[str, tuple[int, ...]] = {}
         self._is_dual_profile = self.engine.num_optimization_profiles > 1
-        for input_name in ("token_id", "position_id", "attention_mask"):
-            try:
-                shape = tuple(self.engine.get_tensor_shape(input_name))
-            except Exception:
+        self._profile_index = 1 if self._is_dual_profile else 0
+        for index in range(self.engine.num_io_tensors):
+            input_name = self.engine.get_tensor_name(index)
+            if self.engine.get_tensor_mode(input_name) != trt.TensorIOMode.INPUT:
                 continue
-            if any(d < 0 for d in shape):
-                self._dynamic_inputs.append(input_name)
+            shape = tuple(self.engine.get_tensor_shape(input_name))
+            if any(dim < 0 for dim in shape):
+                self._dynamic_input_shapes[input_name] = _profile_min_shape(
+                    self.engine, input_name, self._profile_index)
         if self._is_dual_profile:
             # Profile 1 = decode (Sq=1). step() always runs single-token, so
             # we lock the context to that profile once and never switch.
@@ -213,14 +229,18 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name == "input_embed":
                 self._has_embed_input = True
-                embed_shape = tuple(self.engine.get_tensor_shape(name))
+                embed_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 embed_bytes = int(np.prod(embed_shape)) * 4
                 self._h_input_embed = np.zeros(embed_shape, dtype=np.float32)
                 err, self._d_input_embed = cudart.cudaMalloc(embed_bytes)
                 _check_cuda(err)
             elif name == "use_input_embed":
-                self._h_use_input_embed = np.zeros((1,), dtype=np.float32)
-                err, self._d_use_input_embed = cudart.cudaMalloc(4)
+                selector_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_use_input_embed = np.zeros(selector_shape, dtype=np.float32)
+                err, self._d_use_input_embed = cudart.cudaMalloc(
+                    self._h_use_input_embed.nbytes)
                 _check_cuda(err)
 
         # DeepStack inputs (auto-detected from engine bindings)
@@ -233,15 +253,19 @@ class TrtRunner:
             name = self.engine.get_tensor_name(i)
             if name.startswith("deepstack_embed_"):
                 self._deepstack_names.append(name)
-                shape = tuple(self.engine.get_tensor_shape(name))
+                shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
                 nbytes = int(np.prod(shape)) * 4
                 self._h_deepstack[name] = np.zeros(shape, dtype=np.float32)
                 err, d_ptr = cudart.cudaMalloc(nbytes)
                 _check_cuda(err)
                 self._d_deepstack[name] = d_ptr
             elif name == "deepstack_active":
-                self._h_deepstack_active = np.zeros((1,), dtype=np.float32)
-                err, self._d_deepstack_active = cudart.cudaMalloc(4)
+                active_shape = _profile_min_shape(
+                    self.engine, name, self._profile_index)
+                self._h_deepstack_active = np.zeros(active_shape, dtype=np.float32)
+                err, self._d_deepstack_active = cudart.cudaMalloc(
+                    self._h_deepstack_active.nbytes)
                 _check_cuda(err)
 
         # Debug output device/host buffers
@@ -331,7 +355,7 @@ class TrtRunner:
                 self._h_input_embed.nbytes, H2D, stream)
             cudart.cudaMemcpyAsync(
                 self._d_use_input_embed, self._h_use_input_embed.ctypes.data,
-                4, H2D, stream)
+                self._h_use_input_embed.nbytes, H2D, stream)
 
         # DeepStack H2D transfers
         if self._deepstack_names:
@@ -350,7 +374,7 @@ class TrtRunner:
                 cudart.cudaMemcpyAsync(
                     self._d_deepstack_active,
                     self._h_deepstack_active.ctypes.data,
-                    4, H2D, stream)
+                    self._h_deepstack_active.nbytes, H2D, stream)
 
         # Set tensor addresses
         self.context.set_tensor_address("token_id", self._d_token_id)
@@ -379,15 +403,11 @@ class TrtRunner:
         for name in self._debug_output_names:
             self.context.set_tensor_address(name, self._d_debug[name])
 
-        # Dual-profile engines need explicit shapes for the dynamic
-        # inputs every step. step() is single-token decode, so all three
-        # shapes are fixed: Sq=1 and K = max_cache_length + 1.
-        if self._dynamic_inputs:
-            for name in self._dynamic_inputs:
-                if name == "attention_mask":
-                    self.context.set_input_shape(name, (1, attention_window))
-                else:
-                    self.context.set_input_shape(name, (1,))
+        # Dynamic inputs use the selected profile's minimum shapes. Both the
+        # prefill and decode profiles have Sq=1 minima, so this covers token,
+        # mask, image embedding, selector, and DeepStack inputs uniformly.
+        for name, shape in self._dynamic_input_shapes.items():
+            self.context.set_input_shape(name, shape)
 
         # Execute
         self.context.execute_async_v3(stream)
@@ -481,24 +501,16 @@ class TrtRunner:
     def __del__(self):
         if cudart is None:
             return
-        if not hasattr(self, "_d_token_id"):
-            return
-        bufs = [self._d_token_id, self._d_position_id, self._d_mask,
-                self._d_logits]
-        bufs.extend(self._d_cache_k)
-        bufs.extend(self._d_cache_v)
-        bufs.extend(self._d_present_k)
-        bufs.extend(self._d_present_v)
-        if self._d_input_embed:
-            bufs.append(self._d_input_embed)
-        if self._d_use_input_embed:
-            bufs.append(self._d_use_input_embed)
-        for d_ptr in self._d_deepstack.values():
-            bufs.append(d_ptr)
-        if self._d_deepstack_active:
-            bufs.append(self._d_deepstack_active)
-        for d_ptr in self._d_debug.values():
-            bufs.append(d_ptr)
+        bufs = []
+        for name in ("_d_token_id", "_d_position_id", "_d_mask", "_d_logits",
+                     "_d_input_embed", "_d_use_input_embed", "_d_deepstack_active"):
+            d_ptr = getattr(self, name, 0)
+            if d_ptr:
+                bufs.append(d_ptr)
+        for name in ("_d_cache_k", "_d_cache_v", "_d_present_k", "_d_present_v"):
+            bufs.extend(getattr(self, name, []))
+        bufs.extend(getattr(self, "_d_deepstack", {}).values())
+        bufs.extend(getattr(self, "_d_debug", {}).values())
         for d_ptr in bufs:
             cudart.cudaFree(d_ptr)
         if hasattr(self, "stream"):

--- a/tests/e2e/models/phi4_multimodal/test_phi4_multimodal_family_plugin.py
+++ b/tests/e2e/models/phi4_multimodal/test_phi4_multimodal_family_plugin.py
@@ -17,6 +17,7 @@ Postconditions: Plugin correctly splits fused weights and produces expected per-
 
 from __future__ import annotations
 
+import importlib
 import json
 from pathlib import Path
 
@@ -35,6 +36,27 @@ except (ImportError, ModuleNotFoundError):
 # ---- helpers ----
 
 RNG = np.random.RandomState(42)
+
+
+def test_phi4_multimodal_embed_input_dispatches_to_dual_profile_builder(monkeypatch) -> None:
+    module = importlib.import_module(
+        "tensorrt_model_connect.families.phi4_multimodal.default_decoder")
+    calls: dict[str, object] = {}
+
+    def fake_build(config, weights, max_cache_length, **kwargs):
+        calls["build"] = (config, weights, max_cache_length, kwargs)
+        return b"phi4-multimodal-dual-profile-plan"
+
+    monkeypatch.setattr(module, "build_dual_profile_decoder_engine", fake_build)
+    config = type("Config", (), {"raw": {"_decoder_engine_role": "decode"}})()
+    result = module.build_standard_decoder_engine(
+        config, {}, 31, precision="fp16", embed_input=True,
+        partial_rotary_factor=0.75)
+
+    assert result == b"phi4-multimodal-dual-profile-plan"
+    kwargs = calls["build"][3]
+    assert kwargs["embed_input"] is True
+    assert kwargs["partial_rotary_factor"] == 0.75
 
 
 def _rand(*shape: int) -> np.ndarray:


### PR DESCRIPTION
## Background

Qwen-VL fixed token-at-a-time multimodal prompt prefill in #482, but the same copied runtime and builder pattern remained in DeepSeek-OCR, InternVL, LANCE, LocateAnything, and Phi-4 Multimodal. Prompt prefill therefore launched the text engine once per input token instead of once per sequence.

Closes #489.

## Exit Criteria

- Each affected family submits a supported multimodal prompt through one sequence-prefill invocation and keeps decode at one token per invocation.
- Registered single-device and TP paths build dynamic sequence profiles and hand all prompt KV rows to decode.
- Legacy single-profile bundles retain the existing token-by-token compatibility fallback.
- Model-specific LocateAnything token decoding and Phi-4 Multimodal attention/LongRoPE behavior remain intact.

## Implementation

- Add dynamic `Sq` profiles for token IDs, masks, image embeddings, selectors, and DeepStack inputs; slice only the last prompt row for logits while exporting every prompt K/V row.
- Load profile 0 as the prefill context and profile 1 as decode, execute prefill once, copy its K/V rows into the decode cache, and fall back explicitly when a prefill profile is unavailable.
- Extend registered TP builders for InternVL and DeepSeek-OCR. DeepSeek's MoE routing now applies top-k gates per sequence row, and TensorRT's multi-device runtime preview is enabled when available.
- Preserve Phi-4 Multimodal explicit attention and LongRoPE frequency scaling, plus LocateAnything's visible localization-token decoding.
- Add a launch-count/shape regression to every affected C++ pipeline and focused builder-dispatch coverage.

## Validation

- `git diff --name-only -- '*.py' | xargs ruff check`: passed.
- `git diff --name-only -- '*.cpp' '*.h' | xargs clang-format --dry-run --Werror`: passed.
- `python3 tools/legal_headers.py --check`: passed with no findings.
- `python3 tools/check_cyclomatic_complexity.py --max-ccn 10 <five changed pipeline.cpp files>`: passed; maximum CCN 9.
- `pytest -q tests/tools/test_model_plugin_encapsulation_static.py`: 156 passed.
- `cmake --build <build> --target test_deepseek_ocr_vl_pipeline test_internvl_vl_pipeline test_lance_vl_pipeline test_locateanything_vl_pipeline test_phi4_multimodal_vl_pipeline -j 8`: all five targets built.
- On the p2021 GPU validation container, `ctest --test-dir <build> --output-on-failure -R 'test_(deepseek_ocr|internvl|lance|locateanything|phi4_multimodal)_vl_pipeline'`: 5/5 passed.
- On the same GPU container, the focused InternVL/DeepSeek/LocateAnything/LANCE/Phi builder and plugin pytest set: 42 passed.
- GPU builder smokes successfully serialized two-profile engines for DeepSeek-OCR single-device and TP, InternVL TP, the shared InternVL/LANCE/LocateAnything path, and Phi-4 Multimodal with explicit attention plus LongRoPE.

## Notes For Future Readers

- Review the C++ runtime handoff first, then the common dynamic builder changes, followed by DeepSeek's per-row MoE routing and Phi's LongRoPE/explicit-attention preservation.
- The family-local duplication is intentional: repository encapsulation rules prohibit production model families from importing or including sibling model implementations.
