### PR TITLE
feat(nemotron): add Nano 4B EdgeLLM adapter

### DIFF
--- a/python/tensorrt_model_connect/families/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/IMPLEMENTATION.toml
+++ b/python/tensorrt_model_connect/families/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/IMPLEMENTATION.toml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version = 1
+implementation_id = "nemotron3-nano-4b-fp16.tensorrt-edge-llm.a100-pcie80-sm80"
+downstream_runtime = "tensorrt-edge-llm"
+downstream_version = "0.6.1"
+downstream_commit = "2620a9768022f25dff18912db2fb92b2ef264a70"
+
+[model]
+id = "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16"
+revisions = ["dfaf35de3e30f1867dd8dbc38a7fc9fb52d3914f"]
+
+[target]
+os = "linux"
+architecture = "x86_64"
+gpu_architecture = "sm80"
+gpu_name = "NVIDIA A100 80GB PCIe"
+platform_kind = "discrete"
+
+[build]
+entrypoint = "adapter.py"
+timeout_seconds = 21600
+
+[runtime]
+library = "libtrtmc_impl_nemotron3_nano_4b_fp16_tensorrt_edge_llm.so"
+abi = 1

--- a/python/tensorrt_model_connect/families/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/adapter.py
+++ b/python/tensorrt_model_connect/families/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/adapter.py
@@ -1,0 +1,2069 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Capsule-owned NVIDIA Nemotron 3 Nano 4B TensorRT Edge-LLM build subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility.
+    import tomli as tomllib
+
+
+CAPSULE_ROOT = Path(__file__).resolve().parent
+REPOSITORY_ROOT = Path(__file__).resolve().parents[5]
+
+IMPLEMENTATION_ID = "nemotron3-nano-4b-fp16.tensorrt-edge-llm.a100-pcie80-sm80"
+MODEL_ID = "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16"
+MODEL_REVISION = "dfaf35de3e30f1867dd8dbc38a7fc9fb52d3914f"
+RUNTIME_LIBRARY = "libtrtmc_impl_nemotron3_nano_4b_fp16_tensorrt_edge_llm.so"
+EDGE_LLM_PLUGIN = "libNvInfer_edgellm_plugin.so"
+PROFILE_PATH = CAPSULE_ROOT / "profiles" / "a100-pcie80-sm80-fp16.toml"
+DEPENDENCY_PATH = CAPSULE_ROOT / "dependency.lock"
+IMPLEMENTATION_PATH = CAPSULE_ROOT / "IMPLEMENTATION.toml"
+_EDGE_LLM_SOURCE = "https://github.com/NVIDIA/TensorRT-Edge-LLM.git"
+_EDGE_LLM_COMMIT = "2620a9768022f25dff18912db2fb92b2ef264a70"
+_EDGE_LLM_TAG = "v0.6.1"
+_TENSORRT_VERSION = (10, 14, 1, 48)
+_TENSORRT_VERSION_TEXT = ".".join(str(component) for component in _TENSORRT_VERSION)
+_CUDA_VERSION = (12, 8)
+_CUDA_VERSION_TEXT = ".".join(str(component) for component in _CUDA_VERSION)
+_ENGINE_ENV = "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_EDGE_LLM_ENGINE_DIR"
+_RUNTIME_ENV = "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_EDGE_LLM_RUNTIME_LIBRARY"
+_PLUGIN_ENV = "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_EDGE_LLM_PLUGIN_LIBRARY"
+_EDGE_BUILD_DIR_ENV = "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_EDGE_LLM_BUILD_DIR"
+_TRT_INCLUDE_ENV = "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_TENSORRT_INCLUDE_DIR"
+_TRT_LIBRARY_ENV = "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_TENSORRT_LIBRARY"
+_ONNX_PARSER_INCLUDE_ENV = "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_ONNX_PARSER_INCLUDE_DIR"
+_ONNX_PARSER_LIBRARY_ENV = "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_ONNX_PARSER_LIBRARY"
+_CUDA_INCLUDE_ENV = "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_CUDA_INCLUDE_DIR"
+_CUDART_LIBRARY_ENV = "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_CUDART_LIBRARY"
+_ALLOW_FAKE_RUNTIME_BUILD_ENV = "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_ALLOW_FAKE_RUNTIME_BUILD"
+_DEPENDENCY_CACHE_ENV = "_TRTMC_INTERNAL_OPTIMIZED_RUNTIME_DEPENDENCY_ROOT"
+_ACTIVE_CUDA_DEVICE_ENV = "TRTMC_INTERNAL_OPTIMIZED_RUNTIME_CUDA_DEVICE"
+_MAX_ARTIFACT_ENTRIES = 65536
+_MAX_ARTIFACT_TOTAL_SIZE = 1 << 40
+_PRIVATE_SDK_HEADERS = (
+    "trtmc/pipeline.h",
+    "runtime/providers/optimized_runtime_factory.h",
+)
+_BUILD_BINDING_KEYS = {
+    "schema_version",
+    "implementation_id",
+    "manifest_sha256",
+    "request_sha256",
+    "profile_id",
+}
+_REQUIRED_ENGINE_FILES = (
+    "llm.engine",
+    "embedding.safetensors",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "processed_chat_template.json",
+)
+_REQUIRED_TARGET = {
+    "os": "linux",
+    "architecture": "x86_64",
+    "platform_kind": "discrete",
+    "gpu_architecture": "sm80",
+    "gpu_name": "NVIDIA A100 80GB PCIe",
+}
+_EXPECTED_ENGINE_MODEL_CONFIG: dict[str, object] = {
+    "model": "nemotronh",
+    "model_type": "hybrid_mamba",
+    "vocab_size": 131072,
+    "max_position_embeddings": 262144,
+    "hidden_size": 3136,
+    "intermediate_size": 12544,
+    "num_hidden_layers": 42,
+    "num_attention_heads": 40,
+    "num_key_value_heads": 8,
+    "head_dim": 128,
+    "num_mamba_layers": 21,
+    "num_attention_layers": 4,
+    "mamba_num_heads": 96,
+    "mamba_head_dim": 80,
+    "ssm_state_size": 128,
+    "conv_dim": 9728,
+    "conv_kernel": 4,
+    "use_rope": False,
+    "rope_theta": 10000.0,
+    "rope_scaling": None,
+    "partial_rotary_factor": 1.0,
+    "trt_native_ops": False,
+}
+_EXPECTED_ENGINE_BUILDER_CONFIG: dict[str, object] = {
+    "max_input_len": 1024,
+    "max_kv_cache_capacity": 4096,
+    "max_batch_size": 4,
+    "eagle_draft": False,
+    "eagle_base": False,
+    "max_lora_rank": 0,
+    "trt_native_ops": False,
+}
+
+
+def _runtime_source_root() -> Path:
+    """Return this model's runtime adapter from a checkout or installed wheel."""
+
+    packaged = CAPSULE_ROOT / "runtime"
+    if packaged.is_dir():
+        return packaged
+    source = (
+        REPOSITORY_ROOT
+        / "src"
+        / "runtime"
+        / "models"
+        / "nemotron_h"
+        / "nemotron3_nano_4b_edge_llm_adapter"
+    )
+    if source.is_dir():
+        return source
+    raise AdapterError(
+        "Nemotron 3 Nano 4B EdgeLLM runtime adapter source is missing from the model-owned Runtime folder"
+    )
+
+
+class AdapterError(RuntimeError):
+    """The capsule request or one of its pinned inputs is invalid."""
+
+
+@dataclass(frozen=True)
+class _TensorRtInstallation:
+    include_dir: Path
+    library: Path
+    onnx_parser_include_dir: Path
+    onnx_parser_library: Path
+
+
+@dataclass(frozen=True)
+class _CudaInstallation:
+    root: Path
+    include_dir: Path
+    cudart_library: Path
+    compiler: Path
+    version: str
+
+
+@dataclass(frozen=True)
+class _EdgeDependency:
+    source_dir: Path
+    build_dir: Path
+    build_tool: Path
+    plugin: Path
+    tensorrt: _TensorRtInstallation
+    cuda: _CudaInstallation
+
+
+def _load_json(path: Path, description: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise AdapterError(f"Unable to read {description} {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise AdapterError(f"{description} must contain a JSON object: {path}")
+    return value
+
+
+def _load_profile() -> dict[str, Any]:
+    return _load_toml(PROFILE_PATH, "capsule profile")
+
+
+def _load_toml(path: Path, description: str) -> dict[str, Any]:
+    try:
+        with path.open("rb") as input_file:
+            value = tomllib.load(input_file)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise AdapterError(f"Unable to read {description} {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise AdapterError(f"{description} must contain a TOML table: {path}")
+    return value
+
+
+def _private_sdk_include_roots(repository_root: Path | None = None) -> tuple[Path, ...]:
+    """Resolve the source-tree or base-wheel private SDK for this external pack."""
+
+    root = (REPOSITORY_ROOT if repository_root is None else repository_root).resolve()
+
+    def complete(include_roots: tuple[Path, ...]) -> bool:
+        return all(
+            any((include_root / relative).is_file() for include_root in include_roots)
+            for relative in _PRIVATE_SDK_HEADERS
+        )
+
+    source_roots = (root / "src", root / "include")
+    if complete(source_roots):
+        return source_roots
+
+    candidates = [root / "runtime_provider" / "_sdk" / "include"]
+    try:
+        specification = importlib.util.find_spec("tensorrt_model_connect.runtime_provider")
+    except (ImportError, AttributeError, ValueError):
+        specification = None
+    if specification is not None:
+        package_locations = list(specification.submodule_search_locations or ())
+        if specification.origin:
+            package_locations.append(str(Path(specification.origin).parent))
+        for package_location in package_locations:
+            candidates.append(Path(package_location) / "_sdk" / "include")
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.expanduser().resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if complete((resolved,)):
+            return (resolved,)
+    raise AdapterError(
+        "Runtime build requires both private SDK headers from the "
+        "repository source tree or the base wheel's runtime_provider/_sdk/include"
+    )
+
+
+def _implementation_manifest_sha256() -> str:
+    """Bind the adapter and its DSO to the exact selected manifest bytes."""
+
+    try:
+        return hashlib.sha256(IMPLEMENTATION_PATH.read_bytes()).hexdigest()
+    except OSError as exc:
+        raise AdapterError(f"Unable to hash capsule manifest {IMPLEMENTATION_PATH}: {exc}") from exc
+
+
+def _pinned_edge_dependency() -> tuple[str, str, str, str, str]:
+    dependency = _load_toml(DEPENDENCY_PATH, "capsule dependency lock")
+    downstream = _require_mapping(dependency.get("downstream"), "dependency.downstream")
+    expected = {
+        "name": "tensorrt-edge-llm",
+        "source": _EDGE_LLM_SOURCE,
+        "version": "0.6.1",
+        "tag": _EDGE_LLM_TAG,
+        "commit": _EDGE_LLM_COMMIT,
+        "source_mode": "git",
+    }
+    if dict(downstream) != expected:
+        raise AdapterError(
+            "Capsule dependency lock does not name the supported Edge-LLM source pin"
+        )
+    tensorrt = _require_mapping(dependency.get("tensorrt"), "dependency.tensorrt")
+    expected_tensorrt = {"version": _TENSORRT_VERSION_TEXT}
+    if dict(tensorrt) != expected_tensorrt:
+        raise AdapterError("Capsule dependency lock does not name the supported TensorRT release")
+    cuda = _require_mapping(dependency.get("cuda"), "dependency.cuda")
+    expected_cuda = {"version": _CUDA_VERSION_TEXT}
+    if dict(cuda) != expected_cuda:
+        raise AdapterError("Capsule dependency lock does not name the supported CUDA toolkit")
+    return (
+        _EDGE_LLM_SOURCE,
+        _EDGE_LLM_TAG,
+        _EDGE_LLM_COMMIT,
+        _TENSORRT_VERSION_TEXT,
+        _CUDA_VERSION_TEXT,
+    )
+
+
+def _require_mapping(value: Any, description: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise AdapterError(f"{description} must be an object")
+    return value
+
+
+def _validate_capsule_data(profile: Mapping[str, Any]) -> None:
+    expected_profile = {
+        "schema_version": 1,
+        "profile_id": "nemotron3-nano-4b-fp16--a100-pcie80-sm80",
+        "operation": "text-generation-v1",
+        "precision": "fp16",
+        "quantization": "none",
+        "max_input_length": 1024,
+        "max_cache_length": 4096,
+        "max_batch_size": 4,
+        "minimum_memory_mib": 80000,
+        "artifact_layout": "edge_engine_directory_v1",
+    }
+    for field, expected in expected_profile.items():
+        if profile.get(field) != expected:
+            raise AdapterError(
+                f"Capsule profile field {field} must be {expected!r}, got {profile.get(field)!r}"
+            )
+    _pinned_edge_dependency()
+
+
+def _validated_runtime_compile_binding(
+    request: Mapping[str, Any],
+    profile: Mapping[str, Any],
+) -> str:
+    binding = _require_mapping(request.get("build_binding"), "request.build_binding")
+    if set(binding) != _BUILD_BINDING_KEYS:
+        raise AdapterError("Capsule build_binding must contain the exact required field set")
+    if type(binding.get("schema_version")) is not int or binding["schema_version"] != 1:
+        raise AdapterError("Capsule build_binding schema_version must be 1")
+
+    expected_manifest_sha256 = _implementation_manifest_sha256()
+    expected = {
+        "implementation_id": IMPLEMENTATION_ID,
+        "manifest_sha256": expected_manifest_sha256,
+        "profile_id": profile["profile_id"],
+    }
+    for field, expected_value in expected.items():
+        value = binding.get(field)
+        if not isinstance(value, str) or value != expected_value:
+            raise AdapterError(f"Capsule build_binding {field} does not match capsule source")
+    request_sha256 = binding.get("request_sha256")
+    if not isinstance(request_sha256, str) or re.fullmatch(r"[0-9a-f]{64}", request_sha256) is None:
+        raise AdapterError("Capsule build_binding request_sha256 must be a lowercase SHA-256")
+
+    return expected_manifest_sha256
+
+
+def _load_request(path: Path) -> dict[str, Any]:
+    request = _load_json(path, "capsule request")
+    allowed = {
+        "schema_version",
+        "implementation_id",
+        "model",
+        "target",
+        "parameters",
+        "build_binding",
+    }
+    unknown = sorted(set(request) - allowed)
+    if unknown:
+        raise AdapterError(f"Capsule request contains unknown fields: {', '.join(unknown)}")
+    if request.get("schema_version") != 1:
+        raise AdapterError("Capsule request schema_version must be 1")
+    if request.get("implementation_id") != IMPLEMENTATION_ID:
+        raise AdapterError("Capsule request implementation_id does not match this capsule")
+    if request.get("model") != {"id": MODEL_ID, "revision": MODEL_REVISION}:
+        raise AdapterError(
+            "Capsule request does not name the pinned Nemotron 3 Nano 4B model revision"
+        )
+    target = _require_mapping(request.get("target"), "request.target")
+    mismatches = {
+        field: (target.get(field), expected)
+        for field, expected in _REQUIRED_TARGET.items()
+        if type(target.get(field)) is not type(expected) or target.get(field) != expected
+    }
+    if mismatches:
+        raise AdapterError(f"Capsule request target is not the supported A100 target: {mismatches}")
+    parameters = _require_mapping(request.get("parameters"), "request.parameters")
+    allowed_parameters = {
+        "model_source",
+        "precision",
+        "quantization",
+        "max_input_length",
+        "max_cache_length",
+        "max_batch_size",
+        "engine_dir",
+        "runtime_library",
+        "runtime_plugin",
+        "public_options",
+        "runtime_build",
+    }
+    unknown_parameters = sorted(set(parameters) - allowed_parameters)
+    if unknown_parameters:
+        raise AdapterError(
+            "Capsule request contains unsupported parameters: " + ", ".join(unknown_parameters)
+        )
+    if "model_source" in parameters and not isinstance(parameters["model_source"], str):
+        raise AdapterError("Capsule parameter model_source must be a string")
+    for field in (
+        "engine_dir",
+        "runtime_library",
+        "runtime_plugin",
+    ):
+        if field in parameters and (
+            not isinstance(parameters[field], str) or not parameters[field].strip()
+        ):
+            raise AdapterError(f"Capsule parameter {field} must be a non-empty string")
+    public_options = parameters.get("public_options", {})
+    if not isinstance(public_options, dict):
+        raise AdapterError("Capsule parameter public_options must be an object")
+    runtime_build = parameters.get("runtime_build", {})
+    if not isinstance(runtime_build, dict):
+        raise AdapterError("Capsule parameter runtime_build must be an object")
+    _validate_runtime_build(parameters)
+    return request
+
+
+def _public_option_reason(options: Mapping[str, Any]) -> str:
+    """Return why this exact implementation cannot represent an MC option."""
+
+    unsupported_when_set = (
+        "build_timing_json",
+        "build_timing_path",
+        "config",
+        "diffusion_overrides",
+        "dynamic_kv_profile_rows",
+        "dynamic_kv_profile_rows_override",
+        "family_build_options",
+        "fp32_layers",
+        "fp8_scales",
+        "image_height",
+        "image_width",
+        "num_inference_steps",
+        "quant_scales",
+        "save_fp8_scales",
+        "set_flags",
+        "triattention_kv_budget",
+        "triattention_stats",
+        "triattention_stats_path",
+        "video_height",
+        "video_num_frames",
+        "video_width",
+    )
+    for field in unsupported_when_set:
+        if options.get(field) is not None and options.get(field) not in ("", (), [], {}):
+            return f"Nemotron 3 Nano 4B Edge-LLM capsule does not support public option {field}"
+
+    unsupported_when_true = (
+        "dynamic_kv_cache",
+        "rtx",
+        "triattention_disable_mlr",
+        "triattention_disable_trig",
+        "trust_remote_code",
+    )
+    for field in unsupported_when_true:
+        if options.get(field) is True:
+            return (
+                f"Nemotron 3 Nano 4B Edge-LLM capsule does not support public option {field}=true"
+            )
+
+    exact_defaults = {
+        "decoder_engine_layout": "split",
+        "quant_calibration_samples": 512,
+        "tensor_parallel_size": 1,
+        "triattention_count_prompt_tokens": True,
+        "triattention_divide_length": 128,
+        "triattention_protect_prefill": True,
+        "triattention_recent_window": 128,
+        "triattention_score_aggregation": "mean",
+    }
+    recognized = {
+        *unsupported_when_set,
+        *unsupported_when_true,
+        *exact_defaults,
+        "fp8",
+        "max_batch_size",
+        "max_cache_length",
+        "method",
+        "parallel_config",
+        "precision",
+        "quantize",
+        "verbose",
+    }
+
+    def inert(value: Any) -> bool:
+        return (
+            value is None
+            or value is False
+            or value == ""
+            or value == ()
+            or value == []
+            or value == {}
+        )
+
+    unknown = sorted(field for field in set(options) - recognized if not inert(options[field]))
+    if unknown:
+        return (
+            "Nemotron 3 Nano 4B Edge-LLM capsule does not recognize public option(s): "
+            + ", ".join(unknown)
+        )
+
+    for field, expected in exact_defaults.items():
+        if field in options and options[field] != expected:
+            return (
+                f"Nemotron 3 Nano 4B Edge-LLM capsule requires public option {field}={expected!r}; "
+                f"got {options[field]!r}"
+            )
+
+    # A qualified profile owns only the exact request it was validated for.
+    # Never reinterpret an explicit MC request as a different Edge engine.
+    exact_profile_options = {
+        "fp8": (False,),
+        "max_batch_size": (4,),
+        "max_cache_length": (4096,),
+        "method": ("auto",),
+        "precision": ("fp16",),
+        "quantize": (None,),
+    }
+    for field, accepted in exact_profile_options.items():
+        if field in options and options[field] not in accepted:
+            return (
+                "Nemotron 3 Nano 4B Edge-LLM capsule requires public option "
+                f"{field}={accepted[0]!r}; got {options[field]!r}"
+            )
+
+    parallel = options.get("parallel_config")
+    if parallel not in (None, {}):
+        if not isinstance(parallel, dict) or parallel != {
+            "mode": "single",
+            "rank": -1,
+            "require_mpirun": True,
+            "tp_size": 1,
+        }:
+            return "Nemotron 3 Nano 4B Edge-LLM capsule does not support parallel_config"
+    return ""
+
+
+def _profile_parameter_reason(parameters: Mapping[str, Any]) -> str:
+    exact_parameters = {
+        "precision": "fp16",
+        "quantization": "none",
+        "max_input_length": 1024,
+        "max_cache_length": 4096,
+        "max_batch_size": 4,
+    }
+    for field, expected in exact_parameters.items():
+        actual = parameters.get(field)
+        if actual is not None and (type(actual) is not type(expected) or actual != expected):
+            return f"unsupported capsule parameter {field}={actual!r}; expected {expected!r}"
+
+    public_options = _require_mapping(
+        parameters.get("public_options", {}), "request.parameters.public_options"
+    )
+    public_reason = _public_option_reason(public_options)
+    if public_reason:
+        return public_reason
+
+    return ""
+
+
+def _target_profile_reason(target: Mapping[str, Any], profile: Mapping[str, Any]) -> str:
+    """Return why the requested GPU capacity cannot run this profile."""
+
+    gpu_count = target.get("gpu_count")
+    if type(gpu_count) is not int or gpu_count <= 0:
+        return (
+            "Nemotron 3 Nano 4B Edge-LLM capsule requires target.gpu_count to be a positive integer"
+        )
+
+    gpu_memory_mib = target.get("gpu_memory_mib")
+    if type(gpu_memory_mib) is not int:
+        return "Nemotron 3 Nano 4B Edge-LLM capsule requires target.gpu_memory_mib to be an integer"
+    minimum_memory_mib = profile["minimum_memory_mib"]
+    if gpu_memory_mib < minimum_memory_mib:
+        return (
+            "Nemotron 3 Nano 4B Edge-LLM capsule requires target.gpu_memory_mib "
+            f">= {minimum_memory_mib}; got {gpu_memory_mib}"
+        )
+    return ""
+
+
+def _parameter_or_environment(
+    parameters: Mapping[str, Any], parameter_name: str, environment_name: str
+) -> str:
+    value = parameters.get(parameter_name, "")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return os.environ.get(environment_name, "").strip()
+
+
+def _require_payload(
+    parameters: Mapping[str, Any],
+    parameter_name: str,
+    environment_name: str,
+    description: str,
+) -> Path:
+    raw = _parameter_or_environment(parameters, parameter_name, environment_name)
+    if not raw:
+        raise AdapterError(
+            f"{description} is required for this capsule build; provide "
+            f"an explicit regular-file path in request parameter "
+            f"{parameter_name!r} or {environment_name}"
+        )
+    path = Path(raw).expanduser()
+    if path.is_symlink():
+        raise AdapterError(f"{description} must not be a symbolic link: {path}")
+    try:
+        resolved = path.resolve(strict=True)
+        metadata = resolved.stat()
+    except OSError as exc:
+        raise AdapterError(f"{description} is unavailable: {path}: {exc}") from exc
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_size <= 0:
+        raise AdapterError(f"{description} must be a non-empty regular file: {resolved}")
+    return resolved
+
+
+def _regular_file_size(path: Path) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise AdapterError(f"Unable to inspect capsule artifact {path}: {exc}") from exc
+    with os.fdopen(descriptor, "rb") as source:
+        metadata = os.fstat(source.fileno())
+        if not stat.S_ISREG(metadata.st_mode):
+            raise AdapterError(f"Capsule artifact is not a regular file: {path}")
+    return metadata.st_size
+
+
+def _validate_artifact_tree(root: Path) -> None:
+    if root.is_symlink() or not root.is_dir():
+        raise AdapterError(f"Capsule artifact root must be a non-symlink directory: {root}")
+    files: list[tuple[str, Path]] = []
+    entry_count = 0
+    for candidate in sorted(root.rglob("*"), key=lambda path: path.as_posix()):
+        relative = candidate.relative_to(root).as_posix()
+        if not relative or "\\" in relative or len(relative.encode("utf-8")) > 4096:
+            raise AdapterError(f"Unsafe capsule artifact path: {relative!r}")
+        if candidate.is_symlink():
+            raise AdapterError(f"Capsule artifact trees cannot contain symlinks: {candidate}")
+        if candidate.is_file():
+            files.append((relative, candidate))
+        elif not candidate.is_dir():
+            raise AdapterError(f"Unsupported capsule artifact entry: {candidate}")
+        entry_count += 1
+        if entry_count > _MAX_ARTIFACT_ENTRIES:
+            raise AdapterError("Capsule artifact tree exceeds the entry limit")
+
+    total_size = 0
+    for _relative, path in files:
+        total_size += _regular_file_size(path)
+        if total_size > _MAX_ARTIFACT_TOTAL_SIZE:
+            raise AdapterError("Capsule artifact tree exceeds the size limit")
+    if not files:
+        raise AdapterError(f"Capsule artifact directory contains no files: {root}")
+
+
+def _validate_engine_directory(path: Path) -> tuple[Path, int]:
+    if path.is_symlink():
+        raise AdapterError(f"Edge-LLM engine directory must not be a symlink: {path}")
+    try:
+        engine = path.expanduser().resolve(strict=True)
+    except OSError as exc:
+        raise AdapterError(f"Edge-LLM engine directory is unavailable: {path}: {exc}") from exc
+    if not engine.is_dir():
+        raise AdapterError(f"Edge-LLM engine artifact is not a directory: {engine}")
+    config_path = engine / "config.json"
+    if config_path.is_symlink() or not config_path.is_file():
+        raise AdapterError(f"Edge-LLM engine is missing non-symlink config.json: {engine}")
+    config = _load_json(config_path, "Edge-LLM engine config")
+    if config.get("edgellm_version") != "0.6.1":
+        raise AdapterError("Edge-LLM engine was not built by pinned runtime version 0.6.1")
+    for field, expected_value in _EXPECTED_ENGINE_MODEL_CONFIG.items():
+        actual_value = config.get(field)
+        if (
+            field not in config
+            or type(actual_value) is not type(expected_value)
+            or actual_value != expected_value
+        ):
+            raise AdapterError(f"Edge-LLM engine config.{field} must be exactly {expected_value!r}")
+    if "reduced_vocab_size" in config and config["reduced_vocab_size"] is not None:
+        raise AdapterError(
+            "Edge-LLM engine reduced_vocab_size must be absent or null for this profile"
+        )
+    vocab_size = config["vocab_size"]
+    builder = _require_mapping(config.get("builder_config"), "Edge-LLM builder_config")
+    for field, expected_value in _EXPECTED_ENGINE_BUILDER_CONFIG.items():
+        actual_value = builder.get(field)
+        if type(actual_value) is not type(expected_value) or actual_value != expected_value:
+            raise AdapterError(
+                f"Edge-LLM engine builder_config.{field} must be exactly {expected_value!r}"
+            )
+    for filename in _REQUIRED_ENGINE_FILES:
+        artifact = engine / filename
+        if artifact.is_symlink() or not artifact.is_file() or artifact.stat().st_size <= 0:
+            raise AdapterError(f"Edge-LLM engine is missing required artifact {filename}")
+    _validate_artifact_tree(engine)
+    return engine, vocab_size
+
+
+def _snapshot_identity(path: Path) -> tuple[str, str] | None:
+    if path.parent.name != "snapshots" or not path.parent.parent.name.startswith("models--"):
+        return None
+    components = path.parent.parent.name[len("models--") :].split("--")
+    if len(components) != 2 or any(not item for item in components):
+        return None
+    return "/".join(components), path.name.lower()
+
+
+def _materialize_model_source(model_source: str) -> Path:
+    candidate = Path(model_source).expanduser()
+    if candidate.exists():
+        resolved = candidate.resolve(strict=True)
+        if not resolved.is_dir() or _snapshot_identity(resolved) != (MODEL_ID, MODEL_REVISION):
+            raise AdapterError(
+                "Local model source must be the exact pinned Hugging Face cache snapshot"
+            )
+        return resolved
+    if candidate.is_absolute():
+        raise AdapterError(f"Configured model source does not exist: {candidate}")
+    if model_source != MODEL_ID:
+        raise AdapterError(f"Capsule model source must be {MODEL_ID!r}")
+    try:
+        from huggingface_hub import snapshot_download
+
+        downloaded = snapshot_download(repo_id=MODEL_ID, revision=MODEL_REVISION)
+    except Exception as exc:
+        raise AdapterError(f"Unable to materialize {MODEL_ID}@{MODEL_REVISION}: {exc}") from exc
+    resolved = Path(downloaded).resolve(strict=True)
+    if _snapshot_identity(resolved) != (MODEL_ID, MODEL_REVISION):
+        raise AdapterError("Hugging Face did not return the exact pinned snapshot")
+    return resolved
+
+
+def _cuda_runtime() -> Any:
+    try:
+        from cuda.bindings import runtime as cudart
+    except ImportError:
+        try:
+            from cuda import cudart
+        except ImportError as exc:
+            raise AdapterError("CUDA Python is required to build this A100 capsule") from exc
+    return cudart
+
+
+def _select_parent_active_cuda_device() -> None:
+    """Restore the parent's active CUDA ordinal and pin descendant tools to it."""
+
+    raw = os.environ.get(_ACTIVE_CUDA_DEVICE_ENV, "")
+    if not raw:
+        return
+    if len(raw) > 10 or not raw.isascii() or not raw.isdecimal() or str(int(raw)) != raw:
+        raise AdapterError(f"{_ACTIVE_CUDA_DEVICE_ENV} must be a canonical CUDA ordinal")
+    ordinal = int(raw)
+    cudart = _cuda_runtime()
+    success = getattr(getattr(cudart, "cudaError_t", None), "cudaSuccess", 0)
+    try:
+        status = cudart.cudaSetDevice(ordinal)
+        if isinstance(status, tuple):
+            status = status[0]
+        if status not in (success, 0):
+            raise AdapterError(f"cudaSetDevice({ordinal}) failed with status {status}")
+        status, selected = cudart.cudaGetDevice()
+        if status not in (success, 0) or int(selected) != ordinal:
+            raise AdapterError(f"active CUDA device did not remain {ordinal} after cudaSetDevice")
+    except AdapterError:
+        raise
+    except Exception as exc:
+        raise AdapterError(f"Unable to select parent active CUDA device {ordinal}: {exc}") from exc
+
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES", "").strip()
+    if visible:
+        tokens = [token.strip() for token in visible.split(",")]
+        if any(not token for token in tokens) or ordinal >= len(tokens):
+            raise AdapterError(
+                f"{_ACTIVE_CUDA_DEVICE_ENV}={ordinal} is inconsistent with CUDA_VISIBLE_DEVICES"
+            )
+        selected_token = tokens[ordinal]
+    else:
+        selected_token = raw
+    # cudaSetDevice affects this adapter process. Descendant Edge export/build
+    # tools are new processes, so expose only the same selected GPU to them.
+    os.environ["CUDA_VISIBLE_DEVICES"] = selected_token
+
+
+def _probe_build_device() -> None:
+    cudart = _cuda_runtime()
+    try:
+        status, device = cudart.cudaGetDevice()
+        if status != 0:
+            raise AdapterError(f"cudaGetDevice failed with status {status}")
+        status, properties = cudart.cudaGetDeviceProperties(device)
+        if status != 0:
+            raise AdapterError(f"cudaGetDeviceProperties failed with status {status}")
+    except AdapterError:
+        raise
+    except Exception as exc:
+        raise AdapterError(f"Unable to inspect the active CUDA build device: {exc}") from exc
+    name = properties.name
+    if isinstance(name, bytes):
+        name = name.decode("utf-8", errors="replace").rstrip("\x00")
+    memory_mib = int(properties.totalGlobalMem) // (1024 * 1024)
+    if (
+        int(properties.major) != 8
+        or int(properties.minor) != 0
+        or name != "NVIDIA A100 80GB PCIe"
+        or memory_mib < 80000
+    ):
+        raise AdapterError("Active build device is not the supported A100 PCIe 80GB target")
+
+
+def _run_tool(
+    command: list[str], *, verbose: bool, environment: Mapping[str, str] | None = None
+) -> None:
+    try:
+        result = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=dict(environment) if environment is not None else None,
+            check=False,
+        )
+    except OSError as exc:
+        raise AdapterError(f"Unable to launch Edge-LLM tool {command[0]!r}: {exc}") from exc
+    if verbose:
+        # Adapter stdout is a machine-readable, one-JSON-object protocol. Tool
+        # logs always belong on stderr, including in verbose mode.
+        for stream in (result.stdout, result.stderr):
+            if stream:
+                print(stream, file=sys.stderr, end="" if stream.endswith("\n") else "\n")
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise AdapterError(
+            f"Edge-LLM tool failed with exit code {result.returncode}: "
+            f"{' '.join(command)}{': ' + detail if detail else ''}"
+        )
+
+
+def _build_or_resolve_engine(
+    parameters: Mapping[str, Any],
+    output: Path,
+    dependency: _EdgeDependency | None,
+    plugin_path: Path,
+) -> tuple[Path, int, Path | None]:
+    configured_engine = _parameter_or_environment(parameters, "engine_dir", _ENGINE_ENV)
+    if configured_engine:
+        if dependency is not None:
+            _validate_edge_source(dependency.source_dir)
+        engine, vocab_size = _validate_engine_directory(Path(configured_engine))
+        return engine, vocab_size, None
+
+    _probe_build_device()
+    workspace_base = output / ".edge-build-workspace"
+    workspace_base.mkdir(parents=True, exist_ok=True)
+    attempt = Path(tempfile.mkdtemp(prefix="nemotron3-edge-", dir=workspace_base))
+    onnx = attempt / "onnx"
+    engine = attempt / "engine.dir"
+    onnx.mkdir()
+    engine.mkdir()
+    runtime_build = _validate_runtime_build(parameters)
+    if dependency is None:
+        dependency = _resolve_edge_dependency(output, runtime_build)
+    export_script = dependency.source_dir / "tensorrt_edgellm" / "scripts" / "export_llm.py"
+    if not export_script.is_file():
+        raise AdapterError(f"Pinned TensorRT Edge-LLM exporter is missing: {export_script}")
+    export_environment = os.environ.copy()
+    export_environment["PYTHONPATH"] = str(dependency.source_dir)
+    export_environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    export_environment["PYTHONNOUSERSITE"] = "1"
+    _validate_edge_source(dependency.source_dir)
+    model_source = _materialize_model_source(str(parameters.get("model_source") or MODEL_ID))
+    public_options = _require_mapping(
+        parameters.get("public_options", {}), "request.parameters.public_options"
+    )
+    verbose = bool(public_options.get("verbose", False))
+    try:
+        _run_tool(
+            [
+                sys.executable,
+                str(export_script),
+                f"--model_dir={model_source}",
+                f"--output_dir={onnx}",
+                "--device=cuda",
+            ],
+            verbose=verbose,
+            environment=export_environment,
+        )
+        if dependency is not None:
+            _validate_edge_source(dependency.source_dir)
+        _run_tool(
+            [
+                str(dependency.build_tool),
+                f"--onnxDir={onnx}",
+                f"--engineDir={engine}",
+                "--maxInputLen=1024",
+                "--maxKVCacheCapacity=4096",
+                "--maxBatchSize=4",
+            ],
+            verbose=verbose,
+            environment={
+                **os.environ,
+                # Edge-LLM otherwise assumes a process-CWD-relative
+                # build/libNvInfer_edgellm_plugin.so. Bind engine creation to
+                # the exact plugin payload that this capsule will package.
+                "EDGELLM_PLUGIN_PATH": str(plugin_path),
+            },
+        )
+        if dependency is not None:
+            _validate_edge_source(dependency.source_dir)
+        validated, vocab_size = _validate_engine_directory(engine)
+        return validated, vocab_size, attempt
+    except Exception:
+        shutil.rmtree(attempt, ignore_errors=True)
+        raise
+
+
+def _runtime_setting(
+    runtime_build: Mapping[str, Any], field: str, environment: str, default: str = ""
+) -> str:
+    value = runtime_build.get(field)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return os.environ.get(environment, "").strip() or default
+
+
+def _validate_runtime_build(parameters: Mapping[str, Any]) -> Mapping[str, Any]:
+    runtime_build = _require_mapping(parameters.get("runtime_build", {}), "runtime_build")
+    allowed = {
+        "fake",
+        "parallel",
+        "sdk_include_dir",
+        "nlohmann_json_include_dir",
+        "edge_llm_source_dir",
+        "edge_llm_build_dir",
+        "tensorrt_include_dir",
+        "tensorrt_library",
+        "onnx_parser_include_dir",
+        "onnx_parser_library",
+        "cuda_include_dir",
+        "cudart_library",
+    }
+    unknown = sorted(set(runtime_build) - allowed)
+    if unknown:
+        raise AdapterError(f"runtime_build has unknown fields: {', '.join(unknown)}")
+    fake = runtime_build.get("fake", False)
+    if type(fake) is not bool:
+        raise AdapterError("runtime_build.fake must be a boolean")
+    parallel = runtime_build.get("parallel", 2)
+    if type(parallel) is not int or not 1 <= parallel <= 64:
+        raise AdapterError("runtime_build.parallel must be an integer from 1 to 64")
+    for field in allowed - {"fake", "parallel"}:
+        if field in runtime_build and (
+            not isinstance(runtime_build[field], str) or not runtime_build[field].strip()
+        ):
+            raise AdapterError(f"runtime_build.{field} must be a non-empty string")
+    return runtime_build
+
+
+def _run_checked(command: list[str], description: str) -> None:
+    try:
+        result = subprocess.run(command, text=True, capture_output=True, check=False)
+    except OSError as exc:
+        raise AdapterError(f"Unable to launch {description}: {exc}") from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise AdapterError(
+            f"{description} failed with exit code {result.returncode}"
+            f"{': ' + detail[-4000:] if detail else ''}"
+        )
+
+
+def _run_capture(command: list[str], description: str) -> str:
+    try:
+        result = subprocess.run(command, text=True, capture_output=True, check=False)
+    except OSError as exc:
+        raise AdapterError(f"Unable to launch {description}: {exc}") from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise AdapterError(
+            f"{description} failed with exit code {result.returncode}"
+            f"{': ' + detail[-4000:] if detail else ''}"
+        )
+    # Preserve a leading status byte. In particular, ``git submodule status``
+    # uses a leading space to mean that a submodule is initialized at its
+    # pinned commit; stripping both ends would turn that valid state into an
+    # apparent error.
+    return result.stdout.rstrip()
+
+
+def _validate_edge_source(source: Path) -> Path:
+    source_url, _, expected_commit, _, _ = _pinned_edge_dependency()
+    try:
+        resolved = source.expanduser().resolve(strict=True)
+    except OSError as exc:
+        raise AdapterError(f"TensorRT Edge-LLM source is unavailable: {source}: {exc}") from exc
+    required = (
+        resolved / "CMakeLists.txt",
+        resolved / "cpp" / "common" / "version.h",
+        resolved / "3rdParty" / "nlohmannJson" / "include" / "nlohmann" / "json.hpp",
+        resolved / "tensorrt_edgellm" / "scripts" / "export_llm.py",
+    )
+    missing = [str(path) for path in required if not path.is_file()]
+    if missing:
+        raise AdapterError(
+            "TensorRT Edge-LLM source or its nested submodules are incomplete: "
+            + ", ".join(missing)
+        )
+    commit = _run_capture(
+        ["git", "-C", str(resolved), "rev-parse", "HEAD"],
+        "TensorRT Edge-LLM commit inspection",
+    )
+    if commit != expected_commit:
+        raise AdapterError(
+            f"TensorRT Edge-LLM must be pinned at {expected_commit}; got {commit or '<none>'}"
+        )
+    origin = _run_capture(
+        ["git", "-C", str(resolved), "remote", "get-url", "origin"],
+        "TensorRT Edge-LLM origin inspection",
+    )
+    if origin != source_url:
+        raise AdapterError(
+            f"TensorRT Edge-LLM source origin must be {source_url}; got {origin or '<none>'}"
+        )
+    source_changes = _run_capture(
+        [
+            "git",
+            "-C",
+            str(resolved),
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--ignored=matching",
+            "--ignore-submodules=none",
+        ],
+        "TensorRT Edge-LLM source cleanliness inspection",
+    )
+    if source_changes:
+        raise AdapterError(
+            "TensorRT Edge-LLM source must have no tracked, untracked, or ignored "
+            "changes; git status reported: " + source_changes[:4000]
+        )
+    submodule_status = _run_capture(
+        ["git", "-C", str(resolved), "submodule", "status", "--recursive"],
+        "TensorRT Edge-LLM recursive submodule inspection",
+    )
+    invalid_submodules = [
+        line for line in submodule_status.splitlines() if line and not line.startswith(" ")
+    ]
+    if invalid_submodules:
+        raise AdapterError(
+            "TensorRT Edge-LLM recursive submodules must be initialized at their pinned "
+            "commits; git submodule status reported: " + "\n".join(invalid_submodules)[:4000]
+        )
+    submodule_changes = _run_capture(
+        [
+            "git",
+            "-C",
+            str(resolved),
+            "submodule",
+            "--quiet",
+            "foreach",
+            "--recursive",
+            "git status --porcelain=v1 --untracked-files=all --ignored=matching",
+        ],
+        "TensorRT Edge-LLM recursive submodule cleanliness inspection",
+    )
+    if submodule_changes:
+        raise AdapterError(
+            "TensorRT Edge-LLM recursive submodules must have no tracked, untracked, "
+            "or ignored changes; git status reported: " + submodule_changes[:4000]
+        )
+    return resolved
+
+
+def _resolve_edge_source(output: Path, runtime_build: Mapping[str, Any]) -> Path:
+    source_url, expected_tag, expected_commit, _, _ = _pinned_edge_dependency()
+    configured = _runtime_setting(
+        runtime_build,
+        "edge_llm_source_dir",
+        "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_EDGE_LLM_SOURCE_DIR",
+    )
+    if configured:
+        return _validate_edge_source(Path(configured))
+
+    dependency_root = os.environ.get(_DEPENDENCY_CACHE_ENV, "").strip()
+    if dependency_root:
+        cached = Path(dependency_root) / "tensorrt-edge-llm" / expected_commit
+        return _validate_edge_source(cached)
+
+    # Acquire only after this capsule has been selected. The checkout is private
+    # to this build and is discarded after the self-contained bundle is complete.
+    acquired = output / ".edge-source"
+    if acquired.exists():
+        return _validate_edge_source(acquired)
+    _run_checked(
+        [
+            "git",
+            "clone",
+            "--branch",
+            expected_tag,
+            "--single-branch",
+            "--no-checkout",
+            source_url,
+            str(acquired),
+        ],
+        "TensorRT Edge-LLM source acquisition",
+    )
+    _run_checked(
+        ["git", "-C", str(acquired), "checkout", "--detach", expected_commit],
+        "TensorRT Edge-LLM pinned checkout",
+    )
+    _run_checked(
+        ["git", "-C", str(acquired), "submodule", "update", "--init", "--recursive"],
+        "TensorRT Edge-LLM nested submodule bootstrap",
+    )
+    return _validate_edge_source(acquired)
+
+
+def _deduplicate_paths(paths: list[Path]) -> list[Path]:
+    result: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        key = os.path.abspath(os.path.expanduser(str(path)))
+        if key not in seen:
+            seen.add(key)
+            result.append(Path(key))
+    return result
+
+
+def _dependency_prefixes(environment_names: tuple[str, ...], fixed: tuple[str, ...]) -> list[Path]:
+    candidates = [Path(value) for name in environment_names if (value := os.environ.get(name))]
+    candidates.extend(Path(value) for value in fixed)
+    candidates.append(Path(sys.prefix))
+    candidates.extend(Path(value) for value in sys.path if value)
+    return _deduplicate_paths(candidates)
+
+
+def _header_directories(prefixes: list[Path]) -> list[Path]:
+    directories: list[Path] = []
+    for root in prefixes:
+        directories.extend(
+            (
+                root,
+                root / "include",
+                root / "include" / "x86_64-linux-gnu",
+                root / "include" / "aarch64-linux-gnu",
+                root / "tensorrt" / "include",
+                root / "targets" / "x86_64-linux" / "include",
+                root / "targets" / "aarch64-linux" / "include",
+            )
+        )
+    return _deduplicate_paths(directories)
+
+
+def _library_directories(prefixes: list[Path]) -> list[Path]:
+    directories: list[Path] = []
+    for root in prefixes:
+        directories.extend(
+            (
+                root,
+                root / "lib",
+                root / "lib64",
+                root / "lib" / "x86_64-linux-gnu",
+                root / "lib" / "aarch64-linux-gnu",
+                root / "x86_64-linux-gnu",
+                root / "aarch64-linux-gnu",
+                root / "tensorrt_libs",
+                root / "targets" / "x86_64-linux" / "lib",
+                root / "targets" / "aarch64-linux" / "lib",
+            )
+        )
+    return _deduplicate_paths(directories)
+
+
+def _first_header(directories: list[Path], filename: str) -> Path | None:
+    for directory in directories:
+        candidate = directory / filename
+        if candidate.is_file():
+            return candidate.resolve(strict=True)
+    return None
+
+
+def _library_candidates(directories: list[Path], stem: str) -> list[Path]:
+    candidates: list[Path] = []
+    for directory in directories:
+        if not directory.is_dir():
+            continue
+        for pattern in (f"{stem}.so", f"{stem}.so.*"):
+            candidates.extend(sorted(directory.glob(pattern)))
+    return _deduplicate_paths([path for path in candidates if path.is_file()])
+
+
+def _header_tensorrt_version(include_dir: Path) -> tuple[int, int, int, int]:
+    version_header = include_dir / "NvInferVersion.h"
+    try:
+        text = version_header.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise AdapterError(
+            f"Unable to inspect TensorRT version header {version_header}: {exc}"
+        ) from exc
+
+    def component(primary: str, enterprise: str) -> int:
+        for macro in (enterprise, primary):
+            match = re.search(rf"^\s*#\s*define\s+{re.escape(macro)}\s+(\d+)\b", text, re.MULTILINE)
+            if match:
+                return int(match.group(1))
+        raise AdapterError(f"TensorRT version header does not define {primary}: {version_header}")
+
+    return (
+        component("NV_TENSORRT_MAJOR", "TRT_MAJOR_ENTERPRISE"),
+        component("NV_TENSORRT_MINOR", "TRT_MINOR_ENTERPRISE"),
+        component("NV_TENSORRT_PATCH", "TRT_PATCH_ENTERPRISE"),
+        component("NV_TENSORRT_BUILD", "TRT_BUILD_ENTERPRISE"),
+    )
+
+
+def _library_tensorrt_version(library: Path) -> tuple[int, int, int, int]:
+    try:
+        handle = ctypes.CDLL(str(library))
+        values: list[int] = []
+        for name in (
+            "getInferLibMajorVersion",
+            "getInferLibMinorVersion",
+            "getInferLibPatchVersion",
+            "getInferLibBuildVersion",
+        ):
+            function = getattr(handle, name)
+            function.argtypes = []
+            function.restype = ctypes.c_int
+            values.append(int(function()))
+        return tuple(values)  # type: ignore[return-value]
+    except (AttributeError, OSError) as exc:
+        raise AdapterError(f"Unable to inspect TensorRT library {library}: {exc}") from exc
+
+
+def _library_onnx_parser_major(library: Path) -> int:
+    match = re.search(
+        r"^libnvonnxparser\.so\.(\d+)(?:\.|$)",
+        library.resolve(strict=True).name,
+    )
+    if match is None:
+        raise AdapterError(
+            f"TensorRT ONNX parser library does not expose a versioned SONAME filename: {library}"
+        )
+    return int(match.group(1))
+
+
+def _resolve_tensorrt(runtime_build: Mapping[str, Any]) -> _TensorRtInstallation:
+    prefixes = _dependency_prefixes(
+        ("TRT_PACKAGE_DIR", "TENSORRT_ROOT", "TRT_ROOT"),
+        ("/usr", "/usr/local", "/opt/tensorrt"),
+    )
+    prefixes = _deduplicate_paths(
+        [
+            *prefixes,
+            *sorted(Path("/usr/local").glob("TensorRT*")),
+            *sorted(Path("/opt").glob("TensorRT*")),
+            *(
+                Path(value)
+                for value in os.environ.get("LD_LIBRARY_PATH", "").split(os.pathsep)
+                if value
+            ),
+        ]
+    )
+    header_dirs = _header_directories(prefixes)
+    library_dirs = _library_directories(prefixes)
+
+    configured_include = _runtime_setting(runtime_build, "tensorrt_include_dir", _TRT_INCLUDE_ENV)
+    include_candidates = [Path(configured_include)] if configured_include else header_dirs
+    include_dir: Path | None = None
+    header_errors: list[str] = []
+    for candidate in include_candidates:
+        if not (candidate / "NvInfer.h").is_file():
+            continue
+        try:
+            version = _header_tensorrt_version(candidate)
+        except AdapterError as exc:
+            header_errors.append(str(exc))
+            continue
+        if version == _TENSORRT_VERSION:
+            include_dir = candidate.resolve(strict=True)
+            break
+        header_errors.append(
+            f"TensorRT headers at {candidate} are {'.'.join(map(str, version))}, "
+            f"not {_TENSORRT_VERSION_TEXT}"
+        )
+    if include_dir is None:
+        detail = f" ({'; '.join(header_errors)})" if header_errors else ""
+        raise AdapterError(
+            f"Unable to find exact TensorRT {_TENSORRT_VERSION_TEXT} headers in standard locations{detail}"
+        )
+
+    configured_library = _runtime_setting(runtime_build, "tensorrt_library", _TRT_LIBRARY_ENV)
+    library_candidates = (
+        [Path(configured_library)]
+        if configured_library
+        else _library_candidates(library_dirs, "libnvinfer")
+    )
+    library: Path | None = None
+    library_errors: list[str] = []
+    for candidate in library_candidates:
+        if not candidate.is_file():
+            continue
+        try:
+            version = _library_tensorrt_version(candidate.resolve(strict=True))
+        except AdapterError as exc:
+            library_errors.append(str(exc))
+            continue
+        if version == _TENSORRT_VERSION:
+            library = candidate.resolve(strict=True)
+            break
+        library_errors.append(
+            f"TensorRT library {candidate} is {'.'.join(map(str, version))}, "
+            f"not {_TENSORRT_VERSION_TEXT}"
+        )
+    if library is None:
+        detail = f" ({'; '.join(library_errors)})" if library_errors else ""
+        raise AdapterError(
+            f"Unable to find exact TensorRT {_TENSORRT_VERSION_TEXT} libnvinfer in standard locations{detail}"
+        )
+
+    configured_onnx_include = _runtime_setting(
+        runtime_build, "onnx_parser_include_dir", _ONNX_PARSER_INCLUDE_ENV
+    )
+    parser_include_candidate = (
+        Path(configured_onnx_include).resolve(strict=True)
+        if configured_onnx_include
+        else include_dir
+    )
+    onnx_header = _first_header([parser_include_candidate], "NvOnnxParser.h")
+    if onnx_header is None:
+        raise AdapterError("Unable to find NvOnnxParser.h for the selected TensorRT installation")
+    if onnx_header.parent != include_dir:
+        raise AdapterError(
+            "TensorRT ONNX parser headers must come from the selected exact TensorRT "
+            f"include directory: {include_dir}"
+        )
+    # NV_ONNX_PARSER_* identifies the parser API (currently 0.1.0), not the
+    # TensorRT release. Bind compatibility through this shared include tree,
+    # the colocated major-versioned DSO.
+
+    configured_onnx_library = _runtime_setting(
+        runtime_build, "onnx_parser_library", _ONNX_PARSER_LIBRARY_ENV
+    )
+    onnx_libraries = (
+        [Path(configured_onnx_library)]
+        if configured_onnx_library
+        else _library_candidates([library.parent], "libnvonnxparser")
+    )
+    onnx_library = None
+    parser_errors: list[str] = []
+    for path in onnx_libraries:
+        if not path.is_file():
+            continue
+        resolved = path.resolve(strict=True)
+        if resolved.parent != library.parent:
+            parser_errors.append(
+                f"TensorRT ONNX parser {resolved} is outside selected libnvinfer directory "
+                f"{library.parent}"
+            )
+            continue
+        try:
+            parser_library_major = _library_onnx_parser_major(resolved)
+        except AdapterError as exc:
+            parser_errors.append(str(exc))
+            continue
+        if parser_library_major == _TENSORRT_VERSION[0]:
+            onnx_library = resolved
+            break
+        parser_errors.append(
+            f"TensorRT ONNX parser {resolved} has major {parser_library_major}, "
+            f"not {_TENSORRT_VERSION[0]}"
+        )
+    if onnx_library is None:
+        detail = f" ({'; '.join(parser_errors)})" if parser_errors else ""
+        raise AdapterError(
+            f"Unable to find compatible libnvonnxparser beside selected libnvinfer{detail}"
+        )
+    return _TensorRtInstallation(include_dir, library, onnx_header.parent, onnx_library)
+
+
+def _cuda_version(root: Path, include_dir: Path) -> str:
+    # The headers are the compile input, so prefer their version over a
+    # possibly stale toolkit metadata file.
+    cuda_header = include_dir / "cuda.h"
+    if cuda_header.is_file():
+        try:
+            text = cuda_header.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            text = ""
+        match = re.search(r"^\s*#\s*define\s+CUDA_VERSION\s+(\d+)\b", text, re.MULTILINE)
+        if match:
+            encoded = int(match.group(1))
+            return f"{encoded // 1000}.{(encoded % 1000) // 10}"
+    for path in (root / "version.json", root / "version.txt"):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError):
+            continue
+        match = re.search(r"\b(\d+)\.(\d+)(?:\.\d+)?\b", text)
+        if match:
+            return f"{int(match.group(1))}.{int(match.group(2))}"
+    raise AdapterError(f"Unable to determine CUDA toolkit version below {root}")
+
+
+def _cuda_toolkit_root(include_dir: Path) -> Path:
+    for candidate in (include_dir.parent, *include_dir.parents):
+        compiler = candidate / "bin" / "nvcc"
+        if compiler.is_file():
+            return candidate.resolve(strict=True)
+    raise AdapterError(f"Unable to find a CUDA toolkit root for headers at {include_dir}")
+
+
+def _cuda_compiler_version(compiler: Path) -> str:
+    output = _run_capture([str(compiler), "--version"], "CUDA compiler version inspection")
+    match = re.search(r"\brelease\s+(\d+)\.(\d+)\b", output)
+    if match is None:
+        match = re.search(r"\bV(\d+)\.(\d+)(?:\.\d+)?\b", output)
+    if match is None:
+        raise AdapterError(f"Unable to determine CUDA compiler version from {compiler}")
+    return f"{int(match.group(1))}.{int(match.group(2))}"
+
+
+def _cuda_toolkit_roots(prefixes: list[Path]) -> list[Path]:
+    roots: list[Path] = []
+    for prefix in prefixes:
+        for candidate in (prefix, *prefix.parents):
+            if (candidate / "bin" / "nvcc").is_file():
+                roots.append(candidate.resolve(strict=True))
+                break
+    return _deduplicate_paths(roots)
+
+
+def _cuda_installation(
+    root: Path,
+    include_dir: Path,
+    configured_cudart: Path | None,
+) -> _CudaInstallation:
+    root = root.resolve(strict=True)
+    include_dir = include_dir.resolve(strict=True)
+    try:
+        include_dir.relative_to(root)
+    except ValueError as exc:
+        raise AdapterError(
+            "CUDA headers, compiler, and libcudart must come from the same exact "
+            f"CUDA {_CUDA_VERSION_TEXT} toolkit"
+        ) from exc
+    version = _cuda_version(root, include_dir)
+    if version != _CUDA_VERSION_TEXT:
+        raise AdapterError(
+            f"CUDA toolkit headers at {include_dir} are {version}, not {_CUDA_VERSION_TEXT}"
+        )
+    compiler = root / "bin" / "nvcc"
+    if not compiler.is_file() or not os.access(compiler, os.X_OK):
+        raise AdapterError(
+            f"Exact CUDA {_CUDA_VERSION_TEXT} toolkit compiler is unavailable: {compiler}"
+        )
+    compiler = compiler.resolve(strict=True)
+    compiler_version = _cuda_compiler_version(compiler)
+    if compiler_version != _CUDA_VERSION_TEXT:
+        raise AdapterError(
+            f"CUDA compiler {compiler} is {compiler_version}, not {_CUDA_VERSION_TEXT}"
+        )
+    try:
+        compiler.relative_to(root)
+    except ValueError as exc:
+        raise AdapterError(
+            "CUDA headers, compiler, and libcudart must come from the same exact "
+            f"CUDA {_CUDA_VERSION_TEXT} toolkit"
+        ) from exc
+
+    cudart_candidates = (
+        [configured_cudart]
+        if configured_cudart is not None
+        else _library_candidates(_library_directories([root]), "libcudart")
+    )
+    cudart: Path | None = None
+    for candidate in cudart_candidates:
+        if not candidate.is_file():
+            continue
+        resolved = candidate.resolve(strict=True)
+        try:
+            resolved.relative_to(root)
+        except ValueError:
+            continue
+        cudart = resolved
+        break
+    if cudart is None and configured_cudart is not None:
+        raise AdapterError(
+            "CUDA headers, compiler, and libcudart must come from the same exact "
+            f"CUDA {_CUDA_VERSION_TEXT} toolkit"
+        )
+    if cudart is None:
+        raise AdapterError(f"Unable to find libcudart below CUDA toolkit {root}")
+    return _CudaInstallation(root, include_dir, cudart, compiler, version)
+
+
+def _resolve_cuda(runtime_build: Mapping[str, Any]) -> _CudaInstallation:
+    configured_include = _runtime_setting(runtime_build, "cuda_include_dir", _CUDA_INCLUDE_ENV)
+    configured_cudart_value = _runtime_setting(runtime_build, "cudart_library", _CUDART_LIBRARY_ENV)
+    configured_cudart = Path(configured_cudart_value) if configured_cudart_value else None
+    if configured_cudart is not None and not configured_cudart.is_file():
+        raise AdapterError(f"Configured libcudart does not exist: {configured_cudart}")
+
+    # Capsule-specific overrides are exact inputs, not discovery hints. Validate
+    # their single toolkit immediately so an invalid override cannot fall back to
+    # an unrelated host installation.
+    if configured_include:
+        cuda_header = _first_header([Path(configured_include)], "cuda_runtime_api.h")
+        if cuda_header is None:
+            raise AdapterError(
+                f"Configured CUDA include directory has no cuda_runtime_api.h: {configured_include}"
+            )
+        include_dir = cuda_header.parent
+        return _cuda_installation(
+            _cuda_toolkit_root(include_dir),
+            include_dir,
+            configured_cudart,
+        )
+
+    if configured_cudart is not None:
+        cudart = configured_cudart.resolve(strict=True)
+        root = _cuda_toolkit_root(cudart.parent)
+        cuda_header = _first_header(_header_directories([root]), "cuda_runtime_api.h")
+        if cuda_header is None:
+            raise AdapterError(f"Unable to find CUDA toolkit headers below {root}")
+        return _cuda_installation(root, cuda_header.parent, cudart)
+
+    prefixes = _dependency_prefixes(
+        ("CUDA_HOME", "CUDA_PATH", "CUDAToolkit_ROOT"),
+        ("/usr/local/cuda", "/usr/local/cuda-12.8", "/opt/cuda"),
+    )
+    prefixes = _deduplicate_paths(
+        [
+            *prefixes,
+            *sorted(Path("/usr/local").glob("cuda-*")),
+            *(
+                Path(value)
+                for value in os.environ.get("LD_LIBRARY_PATH", "").split(os.pathsep)
+                if value
+            ),
+        ]
+    )
+    errors: list[str] = []
+    for root in _cuda_toolkit_roots(prefixes):
+        cuda_header = _first_header(_header_directories([root]), "cuda_runtime_api.h")
+        if cuda_header is None:
+            errors.append(f"Unable to find CUDA toolkit headers below {root}")
+            continue
+        try:
+            return _cuda_installation(root, cuda_header.parent, None)
+        except AdapterError as exc:
+            errors.append(str(exc))
+    detail = f" ({'; '.join(errors)})" if errors else ""
+    raise AdapterError(
+        f"Unable to find a coherent exact CUDA {_CUDA_VERSION_TEXT} toolkit "
+        f"in standard locations{detail}"
+    )
+
+
+def _cmake_cache_value(build_dir: Path, key: str) -> str:
+    cache = build_dir / "CMakeCache.txt"
+    if not cache.is_file():
+        return ""
+    try:
+        text = cache.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return ""
+    match = re.search(rf"^{re.escape(key)}(?::[^=]+)?=(.*)$", text, re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
+def _edge_products(build_dir: Path) -> tuple[Path, Path, Path, Path] | None:
+    for configuration in ("", "Release", "RelWithDebInfo", "Debug"):
+        suffix = Path(configuration) if configuration else Path()
+        core = build_dir / "cpp" / suffix / "libedgellmCore.a"
+        tokenizer = build_dir / "cpp" / suffix / "libedgellmTokenizer.a"
+        plugin = build_dir / suffix / "libNvInfer_edgellm_plugin.so.1.0"
+        build_tool = build_dir / "examples" / "llm" / suffix / "llm_build"
+        if all(
+            path.is_file() and path.stat().st_size > 0
+            for path in (core, tokenizer, plugin, build_tool)
+        ):
+            return core, tokenizer, plugin, build_tool
+    return None
+
+
+def _edge_build_matches(
+    build_dir: Path,
+    source: Path,
+    tensorrt: _TensorRtInstallation,
+    cuda: _CudaInstallation,
+) -> bool:
+    if _edge_products(build_dir) is None:
+        return False
+    expected = {
+        "CMAKE_HOME_DIRECTORY": source,
+        "TRT_INCLUDE_DIR": tensorrt.include_dir,
+        "NVINFER_LIB": tensorrt.library,
+        "ONNX_PARSER_INCLUDE_DIR": tensorrt.onnx_parser_include_dir,
+        "NV_ONNX_PARSER_LIB": tensorrt.onnx_parser_library,
+        "CUDA_RUNTIME_API_INCLUDE_DIR": cuda.include_dir,
+        "CUDART_LIB": cuda.cudart_library,
+        "CMAKE_CUDA_COMPILER": cuda.compiler,
+    }
+    if _cmake_cache_value(build_dir, "CMAKE_BUILD_TYPE") != "Release":
+        return False
+    for key, path in expected.items():
+        cached = _cmake_cache_value(build_dir, key)
+        if not cached:
+            return False
+        try:
+            if Path(cached).resolve(strict=True) != path.resolve(strict=True):
+                return False
+        except OSError:
+            return False
+    return True
+
+
+def _resolve_edge_dependency(
+    output: Path,
+    runtime_build: Mapping[str, Any],
+) -> _EdgeDependency:
+    source = _resolve_edge_source(output, runtime_build)
+    tensorrt = _resolve_tensorrt(runtime_build)
+    cuda = _resolve_cuda(runtime_build)
+    parallel = runtime_build.get("parallel", 2)
+
+    configured_build = _runtime_setting(runtime_build, "edge_llm_build_dir", _EDGE_BUILD_DIR_ENV)
+    if configured_build:
+        candidate = Path(configured_build)
+        if _edge_build_matches(candidate, source, tensorrt, cuda):
+            products = _edge_products(candidate)
+            assert products is not None
+            return _EdgeDependency(
+                source,
+                candidate.resolve(strict=True),
+                products[3],
+                products[2],
+                tensorrt,
+                cuda,
+            )
+        build_dir = Path(configured_build).expanduser()
+        if (build_dir / "CMakeCache.txt").exists():
+            raise AdapterError(
+                f"Configured TensorRT Edge-LLM build does not match the pinned source, "
+                f"TensorRT {_TENSORRT_VERSION_TEXT}, and CUDA installation: {build_dir}"
+            )
+    else:
+        build_dir = output / ".edge-dependency-build"
+
+    cmake_launcher = "cmake"
+    configure = [
+        cmake_launcher,
+        "-S",
+        str(source),
+        "-B",
+        str(build_dir),
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_UNIT_TESTS=OFF",
+        "-DENABLE_CUTE_DSL_FMHA=OFF",
+        "-DENABLE_NVTX_PROFILING=OFF",
+        f"-DTRT_PACKAGE_DIR={tensorrt.library.parent}",
+        f"-DTRT_INCLUDE_DIR={tensorrt.include_dir}",
+        f"-DNVINFER_LIB={tensorrt.library}",
+        f"-DONNX_PARSER_INCLUDE_DIR={tensorrt.onnx_parser_include_dir}",
+        f"-DNV_ONNX_PARSER_LIB={tensorrt.onnx_parser_library}",
+        f"-DCUDA_DIR={cuda.root}",
+        f"-DCUDA_CTK_VERSION={cuda.version}",
+        f"-DCMAKE_CUDA_COMPILER={cuda.compiler}",
+        f"-DCUDA_RUNTIME_API_INCLUDE_DIR={cuda.include_dir}",
+        f"-DCUDART_LIB={cuda.cudart_library}",
+    ]
+    _run_checked(configure, "pinned TensorRT Edge-LLM CMake configure")
+    _validate_edge_source(source)
+    _run_checked(
+        [
+            cmake_launcher,
+            "--build",
+            str(build_dir),
+            "--parallel",
+            str(parallel),
+            "--target",
+            "edgellmCore",
+            "edgellmTokenizer",
+            "NvInfer_edgellm_plugin",
+            "llm_build",
+        ],
+        "pinned TensorRT Edge-LLM required-target build",
+    )
+    _validate_edge_source(source)
+    products = _edge_products(build_dir)
+    if products is None or not _edge_build_matches(build_dir, source, tensorrt, cuda):
+        raise AdapterError(
+            "TensorRT Edge-LLM build did not produce a complete pinned runtime and llm_build tool"
+        )
+    return _EdgeDependency(
+        source,
+        build_dir.resolve(strict=True),
+        products[3],
+        products[2],
+        tensorrt,
+        cuda,
+    )
+
+
+def _build_runtime_dso(
+    output: Path,
+    parameters: Mapping[str, Any],
+    manifest_sha256: str,
+) -> tuple[Path, Path | None, _EdgeDependency | None]:
+    runtime_build = _validate_runtime_build(parameters)
+    fake = runtime_build.get("fake", False)
+    if fake and os.environ.get(_ALLOW_FAKE_RUNTIME_BUILD_ENV, "").strip() != "1":
+        raise AdapterError(f"Fake runtime builds require {_ALLOW_FAKE_RUNTIME_BUILD_ENV}=1")
+    parallel = runtime_build.get("parallel", 2)
+    build_directory = output / ".runtime-build"
+    configured_sdk_include = _runtime_setting(
+        runtime_build,
+        "sdk_include_dir",
+        "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_SDK_INCLUDE_DIR",
+    )
+    if configured_sdk_include:
+        sdk_include_dirs = configured_sdk_include
+    else:
+        sdk_include_dirs = ";".join(str(root) for root in _private_sdk_include_roots())
+    dependency = None if fake else _resolve_edge_dependency(output, runtime_build)
+    cmake_launcher = "cmake"
+    edge_source = (
+        _runtime_setting(
+            runtime_build,
+            "edge_llm_source_dir",
+            "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_EDGE_LLM_SOURCE_DIR",
+        )
+        if dependency is None
+        else str(dependency.source_dir)
+    )
+    json_default = (
+        str(Path(edge_source) / "3rdParty" / "nlohmannJson" / "include") if edge_source else ""
+    )
+    json_include = _runtime_setting(
+        runtime_build,
+        "nlohmann_json_include_dir",
+        "_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_NLOHMANN_JSON_INCLUDE_DIR",
+        json_default,
+    )
+    if not json_include:
+        raise AdapterError(
+            "Fake Nemotron 3 Nano 4B runtime builds require runtime_build.nlohmann_json_include_dir "
+            "or _TRTMC_INTERNAL_NEMOTRON3_NANO_4B_NLOHMANN_JSON_INCLUDE_DIR"
+        )
+    configure = [
+        cmake_launcher,
+        "-S",
+        str(_runtime_source_root()),
+        "-B",
+        str(build_directory),
+        "-DCMAKE_BUILD_TYPE=Release",
+        f"-DTRTMC_NEMOTRON3_NANO_4B_SDK_INCLUDE_DIRS={sdk_include_dirs}",
+        f"-DTRTMC_NEMOTRON3_NANO_4B_NLOHMANN_JSON_INCLUDE_DIR={json_include}",
+        f"-DTRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME={'ON' if fake else 'OFF'}",
+        f"-DTRTMC_NEMOTRON3_NANO_4B_EDGE_MANIFEST_SHA256={manifest_sha256}",
+    ]
+    if dependency is not None:
+        required = {
+            "TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_SOURCE_DIR": dependency.source_dir,
+            "TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_BUILD_DIR": dependency.build_dir,
+            "TRTMC_NEMOTRON3_NANO_4B_TENSORRT_INCLUDE_DIR": dependency.tensorrt.include_dir,
+            "TRTMC_NEMOTRON3_NANO_4B_TENSORRT_LIBRARY": dependency.tensorrt.library,
+            "TRTMC_NEMOTRON3_NANO_4B_TENSORRT_VERSION": _TENSORRT_VERSION_TEXT,
+            "TRTMC_NEMOTRON3_NANO_4B_CUDA_INCLUDE_DIR": dependency.cuda.include_dir,
+            "TRTMC_NEMOTRON3_NANO_4B_CUDART_LIBRARY": dependency.cuda.cudart_library,
+            "TRTMC_NEMOTRON3_NANO_4B_CUDA_VERSION": _CUDA_VERSION_TEXT,
+            "CMAKE_CUDA_COMPILER": dependency.cuda.compiler,
+        }
+        configure.extend(f"-D{name}={value}" for name, value in required.items())
+    _run_checked(configure, "capsule runtime CMake configure")
+    if dependency is not None:
+        _validate_edge_source(dependency.source_dir)
+    _run_checked(
+        [
+            cmake_launcher,
+            "--build",
+            str(build_directory),
+            "--parallel",
+            str(parallel),
+        ],
+        "capsule runtime build",
+    )
+    if dependency is not None:
+        _validate_edge_source(dependency.source_dir)
+    runtime_candidates = list(build_directory.rglob(RUNTIME_LIBRARY))
+    if len(runtime_candidates) != 1:
+        raise AdapterError(
+            f"Capsule runtime build produced {len(runtime_candidates)} copies of {RUNTIME_LIBRARY}"
+        )
+    plugin_candidates = list(build_directory.rglob(EDGE_LLM_PLUGIN))
+    plugin = plugin_candidates[0] if len(plugin_candidates) == 1 else None
+    return runtime_candidates[0], plugin, dependency
+
+
+def _resolve_runtime_payloads(
+    output: Path,
+    parameters: Mapping[str, Any],
+    manifest_sha256: str,
+) -> tuple[Path, Path, _EdgeDependency | None]:
+    explicit_runtime = _parameter_or_environment(parameters, "runtime_library", _RUNTIME_ENV)
+    if explicit_runtime:
+        runtime = _require_payload(
+            parameters, "runtime_library", _RUNTIME_ENV, "Nemotron 3 Nano 4B Edge-LLM runtime DSO"
+        )
+        built_plugin = None
+        dependency = None
+    else:
+        runtime, built_plugin, dependency = _build_runtime_dso(output, parameters, manifest_sha256)
+    explicit_plugin = _parameter_or_environment(parameters, "runtime_plugin", _PLUGIN_ENV)
+    if explicit_plugin:
+        plugin = _require_payload(
+            parameters, "runtime_plugin", _PLUGIN_ENV, "Nemotron 3 Nano 4B Edge-LLM TensorRT plugin"
+        )
+    elif built_plugin is not None:
+        plugin = built_plugin
+    else:
+        raise AdapterError(
+            "On-demand fake runtime build requires an explicit runtime_plugin payload"
+        )
+    return runtime, plugin, dependency
+
+
+def _software_profile_reason(parameters: Mapping[str, Any]) -> str:
+    """Inspect build viability without fetching, configuring, or building anything."""
+
+    runtime_build = _validate_runtime_build(parameters)
+    fake = runtime_build.get("fake", False)
+    if fake is True and os.environ.get(_ALLOW_FAKE_RUNTIME_BUILD_ENV, "").strip() == "1":
+        return ""
+
+    runtime = _parameter_or_environment(parameters, "runtime_library", _RUNTIME_ENV)
+    plugin = _parameter_or_environment(parameters, "runtime_plugin", _PLUGIN_ENV)
+    engine = _parameter_or_environment(parameters, "engine_dir", _ENGINE_ENV)
+    if runtime or plugin:
+        if not runtime or not plugin:
+            return "Nemotron 3 Nano 4B Edge-LLM prebuilt runtime selection requires both runtime_library and runtime_plugin"
+        try:
+            _require_payload(
+                parameters,
+                "runtime_library",
+                _RUNTIME_ENV,
+                "Nemotron 3 Nano 4B Edge-LLM runtime DSO",
+            )
+            _require_payload(
+                parameters,
+                "runtime_plugin",
+                _PLUGIN_ENV,
+                "Nemotron 3 Nano 4B Edge-LLM TensorRT plugin",
+            )
+        except AdapterError as exc:
+            return str(exc)
+    if engine:
+        try:
+            _validate_engine_directory(Path(engine))
+        except AdapterError as exc:
+            return str(exc)
+    if runtime and plugin and engine:
+        return ""
+
+    # Every non-prebuilt path uses the exact pinned Edge-LLM checkout and its
+    # own exporter and engine builder. There is no ambient-tool fallback.
+    missing_commands = sorted(
+        command for command in ("cmake", "git") if shutil.which(command) is None
+    )
+    if missing_commands:
+        return "Nemotron 3 Nano 4B Edge-LLM build prerequisites are unavailable: " + ", ".join(
+            missing_commands
+        )
+    if not engine:
+        exporter_modules = (
+            "PIL",
+            "datasets",
+            "modelopt",
+            "numpy",
+            "onnx",
+            "onnx_graphsurgeon",
+            "safetensors",
+            "torch",
+            "torchvision",
+            "transformers",
+        )
+        missing_modules = [
+            module for module in exporter_modules if importlib.util.find_spec(module) is None
+        ]
+        if missing_modules:
+            return "Nemotron 3 Nano 4B Edge-LLM build prerequisites are unavailable: " + ", ".join(
+                missing_modules
+            )
+
+    try:
+        _resolve_tensorrt(runtime_build)
+        _resolve_cuda(runtime_build)
+    except AdapterError as exc:
+        return f"Nemotron 3 Nano 4B Edge-LLM software profile is unavailable: {exc}"
+    return ""
+
+
+def _copy_payload(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, destination, follow_symlinks=False)
+    shutil.copymode(source, destination, follow_symlinks=False)
+
+
+def _build(
+    request: Mapping[str, Any],
+    output: Path,
+    profile_data: Mapping[str, Any],
+) -> dict[str, Any]:
+    parameters = _require_mapping(request["parameters"], "request.parameters")
+    manifest_sha256 = _validated_runtime_compile_binding(request, profile_data)
+    reason = _profile_parameter_reason(parameters)
+    if reason:
+        raise AdapterError(reason)
+    output.mkdir(parents=True, exist_ok=True)
+    if any(output.iterdir()):
+        raise AdapterError(f"Capsule build output is not empty: {output}")
+    artifacts = output / "artifacts"
+    artifacts.mkdir()
+    engine_attempt: Path | None = None
+    try:
+        runtime_source, plugin_source, dependency = _resolve_runtime_payloads(
+            output, parameters, manifest_sha256
+        )
+        engine_source, vocab_size, engine_attempt = _build_or_resolve_engine(
+            parameters, output, dependency, plugin_source
+        )
+        engine_destination = artifacts / "engine.dir"
+        shutil.copytree(engine_source, engine_destination, symlinks=False)
+        _copy_payload(runtime_source, artifacts / RUNTIME_LIBRARY)
+        _copy_payload(plugin_source, artifacts / EDGE_LLM_PLUGIN)
+        _validate_artifact_tree(artifacts)
+        _, _, edge_commit, tensorrt_version, cuda_version = _pinned_edge_dependency()
+        descriptor = {
+            "schema_version": 1,
+            # The generic host owns and validates this opaque selection token.
+            # Capsule code only carries it from the build request to its output.
+            "build_binding": dict(
+                _require_mapping(request.get("build_binding"), "request.build_binding")
+            ),
+            "implementation_id": IMPLEMENTATION_ID,
+            "profile_id": str(profile_data["profile_id"]),
+            "operation": "text-generation-v1",
+            "model": {"id": MODEL_ID, "revision": MODEL_REVISION},
+            "target": dict(request["target"]),
+            "runtime": {
+                "abi": 1,
+                "library": RUNTIME_LIBRARY,
+                "plugin": EDGE_LLM_PLUGIN,
+            },
+            "artifacts": {
+                "layout": "directory-tree-v1",
+                "engine_dir": "engine.dir",
+                "runtime_library": RUNTIME_LIBRARY,
+                "runtime_plugin": EDGE_LLM_PLUGIN,
+            },
+            "limits": {
+                "max_input_length": int(profile_data["max_input_length"]),
+                "max_cache_length": int(profile_data["max_cache_length"]),
+                "max_batch_size": int(profile_data["max_batch_size"]),
+                "vocab_size": vocab_size,
+            },
+            "versions": {
+                "model_revision": MODEL_REVISION,
+                "edge_llm": "0.6.1",
+                "edge_llm_commit": edge_commit,
+                "tensorrt": tensorrt_version,
+                "cuda": cuda_version,
+            },
+            "bundle_info": {
+                "model_type": "optimized_runtime",
+                "family": "optimized_runtime",
+                "trt_version": tensorrt_version,
+                "gpu_name": "NVIDIA A100 80GB PCIe",
+                "vocab_size": vocab_size,
+                "max_cache_length": int(profile_data["max_cache_length"]),
+                "runtime_strategy": "text_generation",
+                "precision": str(profile_data["precision"]),
+                "quantization": str(profile_data["quantization"]),
+            },
+            "bundle_config": {
+                "model_id": MODEL_ID,
+                "model_revision": MODEL_REVISION,
+                "model_type": "optimized_runtime",
+                "family": "optimized_runtime",
+                "runtime_provider": IMPLEMENTATION_ID,
+                "runtime_strategy": "text_generation",
+                "precision": str(profile_data["precision"]),
+                "quantization": str(profile_data["quantization"]),
+                "max_cache_length": int(profile_data["max_cache_length"]),
+            },
+        }
+        (output / "descriptor.json").write_text(
+            json.dumps(descriptor, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    finally:
+        if engine_attempt is not None:
+            shutil.rmtree(engine_attempt, ignore_errors=True)
+        runtime_build = output / ".runtime-build"
+        if runtime_build.exists():
+            shutil.rmtree(runtime_build, ignore_errors=True)
+        edge_dependency_build = output / ".edge-dependency-build"
+        if edge_dependency_build.exists():
+            shutil.rmtree(edge_dependency_build, ignore_errors=True)
+        edge_source = output / ".edge-source"
+        if edge_source.exists():
+            shutil.rmtree(edge_source, ignore_errors=True)
+        default_workspace = output / ".edge-build-workspace"
+        if default_workspace.exists():
+            shutil.rmtree(default_workspace, ignore_errors=True)
+
+    return {"schema_version": 1, "descriptor": "descriptor.json", "artifacts": "artifacts"}
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("probe", "build"))
+    parser.add_argument("--request", required=True, type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    if args.operation == "build" and args.output is None:
+        parser.error("build requires --output")
+    if args.operation == "probe" and args.output is not None:
+        parser.error("probe does not accept --output")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        _select_parent_active_cuda_device()
+        args = _parse_args(list(sys.argv[1:] if argv is None else argv))
+        request = _load_request(args.request)
+        profile = _load_profile()
+        _validate_capsule_data(profile)
+        target = _require_mapping(request["target"], "request.target")
+        target_reason = _target_profile_reason(target, profile)
+        if args.operation == "probe":
+            parameters = _require_mapping(request["parameters"], "request.parameters")
+            reason = target_reason or _profile_parameter_reason(parameters)
+            if reason:
+                response = {
+                    "schema_version": 1,
+                    "supported": False,
+                    "reason": reason,
+                }
+            else:
+                software_reason = _software_profile_reason(parameters)
+                if software_reason:
+                    raise AdapterError(software_reason)
+                response = {
+                    "schema_version": 1,
+                    "supported": True,
+                    "profile_id": profile["profile_id"],
+                }
+        else:
+            assert args.output is not None
+            if target_reason:
+                raise AdapterError(target_reason)
+            response = _build(
+                request,
+                args.output.resolve(),
+                profile,
+            )
+        print(json.dumps(response, sort_keys=True, separators=(",", ":")))
+        return 0
+    except (AdapterError, OSError, RuntimeError, ValueError) as exc:
+        print(f"NVIDIA Nemotron 3 Nano 4B Edge-LLM adapter error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/tensorrt_model_connect/families/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/dependency.lock
+++ b/python/tensorrt_model_connect/families/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/dependency.lock
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version = 1
+
+[downstream]
+name = "tensorrt-edge-llm"
+source = "https://github.com/NVIDIA/TensorRT-Edge-LLM.git"
+version = "0.6.1"
+tag = "v0.6.1"
+commit = "2620a9768022f25dff18912db2fb92b2ef264a70"
+source_mode = "git"
+
+[tensorrt]
+version = "10.14.1.48"
+
+[cuda]
+version = "12.8"

--- a/python/tensorrt_model_connect/families/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/profiles/a100-pcie80-sm80-fp16.toml
+++ b/python/tensorrt_model_connect/families/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/profiles/a100-pcie80-sm80-fp16.toml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version = 1
+profile_id = "nemotron3-nano-4b-fp16--a100-pcie80-sm80"
+operation = "text-generation-v1"
+precision = "fp16"
+quantization = "none"
+max_input_length = 1024
+max_cache_length = 4096
+max_batch_size = 4
+minimum_memory_mib = 80000
+artifact_layout = "edge_engine_directory_v1"

--- a/src/runtime/models/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/CMakeLists.txt
+++ b/src/runtime/models/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/CMakeLists.txt
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.24)
+project(trtmc_nemotron3_nano_4b_fp16_edge_llm_runtime LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+option(TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME
+  "Build the capsule ABI/metadata contract without CUDA or Edge-LLM" OFF)
+set(TRTMC_NEMOTRON3_NANO_4B_SDK_INCLUDE_DIRS "" CACHE STRING
+  "Semicolon-separated Model Connect source include roots or installed private SDK root")
+set(TRTMC_NEMOTRON3_NANO_4B_NLOHMANN_JSON_INCLUDE_DIR "" CACHE PATH
+  "Directory containing nlohmann/json.hpp")
+set(TRTMC_NEMOTRON3_NANO_4B_EDGE_MANIFEST_SHA256 "" CACHE STRING
+  "Normalized implementation manifest digest compiled into this DSO")
+
+set(_factory_header_found FALSE)
+set(_pipeline_header "")
+foreach(_sdk_root IN LISTS TRTMC_NEMOTRON3_NANO_4B_SDK_INCLUDE_DIRS)
+  if(EXISTS "${_sdk_root}/runtime/providers/optimized_runtime_factory.h")
+    set(_factory_header_found TRUE)
+  endif()
+  if(NOT _pipeline_header AND EXISTS "${_sdk_root}/trtmc/pipeline.h")
+    set(_pipeline_header "${_sdk_root}/trtmc/pipeline.h")
+  endif()
+endforeach()
+if(NOT _factory_header_found OR NOT _pipeline_header)
+  message(FATAL_ERROR
+    "TRTMC_NEMOTRON3_NANO_4B_SDK_INCLUDE_DIRS must resolve "
+    "runtime/providers/optimized_runtime_factory.h "
+    "and trtmc/pipeline.h")
+endif()
+if(NOT TRTMC_NEMOTRON3_NANO_4B_NLOHMANN_JSON_INCLUDE_DIR OR
+   NOT EXISTS "${TRTMC_NEMOTRON3_NANO_4B_NLOHMANN_JSON_INCLUDE_DIR}/nlohmann/json.hpp")
+  message(FATAL_ERROR
+    "TRTMC_NEMOTRON3_NANO_4B_NLOHMANN_JSON_INCLUDE_DIR must contain nlohmann/json.hpp")
+endif()
+string(LENGTH "${TRTMC_NEMOTRON3_NANO_4B_EDGE_MANIFEST_SHA256}" _manifest_digest_length)
+if(NOT _manifest_digest_length EQUAL 64 OR
+   NOT TRTMC_NEMOTRON3_NANO_4B_EDGE_MANIFEST_SHA256 MATCHES "^[0-9a-f]+$")
+  message(FATAL_ERROR
+    "TRTMC_NEMOTRON3_NANO_4B_EDGE_MANIFEST_SHA256 must be a lowercase SHA-256 digest")
+endif()
+
+set(_target trtmc_impl_nemotron3_nano_4b_fp16_tensorrt_edge_llm)
+add_library(${_target} SHARED adapter.cpp)
+target_compile_definitions(${_target} PRIVATE
+  TRTMC_NEMOTRON3_NANO_4B_EDGE_MANIFEST_SHA256="${TRTMC_NEMOTRON3_NANO_4B_EDGE_MANIFEST_SHA256}")
+target_include_directories(${_target} PRIVATE
+  "${CMAKE_CURRENT_BINARY_DIR}"
+  ${TRTMC_NEMOTRON3_NANO_4B_SDK_INCLUDE_DIRS}
+  "${TRTMC_NEMOTRON3_NANO_4B_NLOHMANN_JSON_INCLUDE_DIR}")
+target_compile_options(${_target} PRIVATE -Wall -Wextra -Wpedantic)
+target_link_libraries(${_target} PRIVATE ${CMAKE_DL_LIBS})
+target_link_options(${_target} PRIVATE
+  $<$<CXX_COMPILER_ID:GNU>:-Wl,--exclude-libs,ALL>
+  $<$<CXX_COMPILER_ID:GNU>:-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports.map>)
+set_target_properties(${_target} PROPERTIES
+  OUTPUT_NAME trtmc_impl_nemotron3_nano_4b_fp16_tensorrt_edge_llm
+  LINK_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/exports.map")
+
+if(TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME)
+  set(TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_MAJOR 10 CACHE STRING
+    "Fake loaded TensorRT major version for capsule contract tests")
+  set(TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_MINOR 14 CACHE STRING
+    "Fake loaded TensorRT minor version for capsule contract tests")
+  set(TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_PATCH 1 CACHE STRING
+    "Fake loaded TensorRT patch version for capsule contract tests")
+  set(TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_BUILD 48 CACHE STRING
+    "Fake loaded TensorRT build version for capsule contract tests")
+  set(TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_CUDA_RUNTIME_VERSION 12080 CACHE STRING
+    "Fake loaded CUDA runtime integer version for capsule contract tests")
+  foreach(_component MAJOR MINOR PATCH BUILD)
+    if(NOT TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_${_component} MATCHES "^[0-9]+$")
+      message(FATAL_ERROR
+        "TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_${_component} must be a non-negative integer")
+    endif()
+  endforeach()
+  if(NOT TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_CUDA_RUNTIME_VERSION MATCHES "^[0-9]+$")
+    message(FATAL_ERROR
+      "TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_CUDA_RUNTIME_VERSION must be a non-negative integer")
+  endif()
+  target_compile_definitions(${_target} PRIVATE
+    TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME=1
+    TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_MAJOR=${TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_MAJOR}
+    TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_MINOR=${TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_MINOR}
+    TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_PATCH=${TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_PATCH}
+    TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_BUILD=${TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_BUILD}
+    TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_CUDA_RUNTIME_VERSION=${TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_CUDA_RUNTIME_VERSION})
+else()
+  set(TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_SOURCE_DIR "" CACHE PATH
+    "Pinned TensorRT Edge-LLM v0.6.1 source directory")
+  set(TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_BUILD_DIR "" CACHE PATH
+    "Complete TensorRT Edge-LLM v0.6.1 build directory")
+  set(TRTMC_NEMOTRON3_NANO_4B_TENSORRT_INCLUDE_DIR "" CACHE PATH
+    "Directory containing NvInfer.h and NvInferVersion.h")
+  set(TRTMC_NEMOTRON3_NANO_4B_TENSORRT_LIBRARY "" CACHE FILEPATH
+    "Exact TensorRT nvinfer library")
+  set(TRTMC_NEMOTRON3_NANO_4B_TENSORRT_VERSION "" CACHE STRING
+    "Exact TensorRT major.minor.patch.build")
+  set(TRTMC_NEMOTRON3_NANO_4B_CUDA_INCLUDE_DIR "" CACHE PATH
+    "Directory containing cuda_runtime_api.h")
+  set(TRTMC_NEMOTRON3_NANO_4B_CUDART_LIBRARY "" CACHE FILEPATH "CUDA runtime library")
+  set(TRTMC_NEMOTRON3_NANO_4B_CUDA_VERSION "" CACHE STRING
+    "Exact CUDA toolkit major.minor version")
+
+  foreach(_required
+      TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_SOURCE_DIR
+      TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_BUILD_DIR
+      TRTMC_NEMOTRON3_NANO_4B_TENSORRT_INCLUDE_DIR
+      TRTMC_NEMOTRON3_NANO_4B_TENSORRT_LIBRARY
+      TRTMC_NEMOTRON3_NANO_4B_TENSORRT_VERSION
+      TRTMC_NEMOTRON3_NANO_4B_CUDA_INCLUDE_DIR
+      TRTMC_NEMOTRON3_NANO_4B_CUDART_LIBRARY
+      TRTMC_NEMOTRON3_NANO_4B_CUDA_VERSION)
+    if(NOT DEFINED ${_required} OR "${${_required}}" STREQUAL "")
+      message(FATAL_ERROR "${_required} is required for the real capsule runtime")
+    endif()
+  endforeach()
+  if(NOT TRTMC_NEMOTRON3_NANO_4B_TENSORRT_VERSION STREQUAL "10.14.1.48")
+    message(FATAL_ERROR
+      "This capsule supports TensorRT 10.14.1.48, got "
+      "${TRTMC_NEMOTRON3_NANO_4B_TENSORRT_VERSION}")
+  endif()
+  if(NOT TRTMC_NEMOTRON3_NANO_4B_CUDA_VERSION STREQUAL "12.8")
+    message(FATAL_ERROR
+      "This capsule supports CUDA 12.8, got ${TRTMC_NEMOTRON3_NANO_4B_CUDA_VERSION}")
+  endif()
+  foreach(_header
+      "${TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_SOURCE_DIR}/cpp/runtime/llmInferenceRuntime.h"
+      "${TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_SOURCE_DIR}/cpp/common/version.h"
+      "${TRTMC_NEMOTRON3_NANO_4B_TENSORRT_INCLUDE_DIR}/NvInfer.h"
+      "${TRTMC_NEMOTRON3_NANO_4B_TENSORRT_INCLUDE_DIR}/NvInferVersion.h"
+      "${TRTMC_NEMOTRON3_NANO_4B_CUDA_INCLUDE_DIR}/cuda.h"
+      "${TRTMC_NEMOTRON3_NANO_4B_CUDA_INCLUDE_DIR}/cuda_runtime_api.h")
+    if(NOT EXISTS "${_header}")
+      message(FATAL_ERROR "Required capsule build header is unavailable: ${_header}")
+    endif()
+  endforeach()
+  foreach(_library
+      TRTMC_NEMOTRON3_NANO_4B_TENSORRT_LIBRARY
+      TRTMC_NEMOTRON3_NANO_4B_CUDART_LIBRARY)
+    if(NOT EXISTS "${${_library}}")
+      message(FATAL_ERROR "Required capsule build library is unavailable: ${${_library}}")
+    endif()
+  endforeach()
+
+  function(_nemotron3_edge_header_define OUT_VAR DEFINE_NAME)
+    file(READ
+      "${TRTMC_NEMOTRON3_NANO_4B_TENSORRT_INCLUDE_DIR}/NvInferVersion.h"
+      _version_header)
+    string(REGEX MATCH
+      "#define[ \t]+${DEFINE_NAME}[ \t]+([A-Za-z0-9_]+)"
+      _define_match "${_version_header}")
+    if(NOT _define_match)
+      set(${OUT_VAR} "" PARENT_SCOPE)
+      return()
+    endif()
+    set(_value "${CMAKE_MATCH_1}")
+    if(NOT _value MATCHES "^[0-9]+$")
+      string(REGEX MATCH "#define[ \t]+${_value}[ \t]+([0-9]+)"
+        _alias_match "${_version_header}")
+      if(_alias_match)
+        set(_value "${CMAKE_MATCH_1}")
+      endif()
+    endif()
+    if(_value MATCHES "^[0-9]+$")
+      set(${OUT_VAR} "${_value}" PARENT_SCOPE)
+    else()
+      set(${OUT_VAR} "" PARENT_SCOPE)
+    endif()
+  endfunction()
+  _nemotron3_edge_header_define(_trt_major TRT_MAJOR_ENTERPRISE)
+  _nemotron3_edge_header_define(_trt_minor TRT_MINOR_ENTERPRISE)
+  _nemotron3_edge_header_define(_trt_patch TRT_PATCH_ENTERPRISE)
+  _nemotron3_edge_header_define(_trt_build TRT_BUILD_ENTERPRISE)
+  if("${_trt_major}" STREQUAL "" OR "${_trt_minor}" STREQUAL "" OR
+     "${_trt_patch}" STREQUAL "" OR "${_trt_build}" STREQUAL "")
+    _nemotron3_edge_header_define(_trt_major NV_TENSORRT_MAJOR)
+    _nemotron3_edge_header_define(_trt_minor NV_TENSORRT_MINOR)
+    _nemotron3_edge_header_define(_trt_patch NV_TENSORRT_PATCH)
+    _nemotron3_edge_header_define(_trt_build NV_TENSORRT_BUILD)
+  endif()
+  set(_header_trt_version
+    "${_trt_major}.${_trt_minor}.${_trt_patch}.${_trt_build}")
+  if(NOT _header_trt_version STREQUAL TRTMC_NEMOTRON3_NANO_4B_TENSORRT_VERSION)
+    message(FATAL_ERROR
+      "TensorRT header version ${_header_trt_version} does not match "
+      "TRTMC_NEMOTRON3_NANO_4B_TENSORRT_VERSION="
+      "${TRTMC_NEMOTRON3_NANO_4B_TENSORRT_VERSION}")
+  endif()
+  file(READ "${TRTMC_NEMOTRON3_NANO_4B_CUDA_INCLUDE_DIR}/cuda.h" _cuda_version_header)
+  if(NOT _cuda_version_header MATCHES "#define[ \t]+CUDA_VERSION[ \t]+12080([^0-9]|$)")
+    message(FATAL_ERROR "This capsule requires exact CUDA 12.8 headers")
+  endif()
+
+  find_package(Git REQUIRED)
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" -C
+      "${TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_SOURCE_DIR}" rev-parse HEAD
+    RESULT_VARIABLE _edge_git_result
+    OUTPUT_VARIABLE _edge_commit
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET)
+  if(NOT _edge_git_result EQUAL 0 OR
+     NOT _edge_commit STREQUAL "2620a9768022f25dff18912db2fb92b2ef264a70")
+    message(FATAL_ERROR
+      "The capsule requires TensorRT Edge-LLM commit "
+      "2620a9768022f25dff18912db2fb92b2ef264a70; got ${_edge_commit}")
+  endif()
+  file(READ
+    "${TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_SOURCE_DIR}/cpp/common/version.h"
+    _edge_version_header)
+  if(NOT _edge_version_header MATCHES "kRUNTIME_VERSION[^\"]*\"0\\.6\\.1\"")
+    message(FATAL_ERROR "The capsule requires TensorRT Edge-LLM runtime version 0.6.1")
+  endif()
+
+  set(_edge_resolved FALSE)
+  foreach(_config "" Release RelWithDebInfo Debug)
+    if(_config)
+      set(_suffix "/${_config}")
+    else()
+      set(_suffix "")
+    endif()
+    set(_edge_core
+      "${TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_BUILD_DIR}/cpp${_suffix}/libedgellmCore.a")
+    set(_edge_tokenizer
+      "${TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_BUILD_DIR}/cpp${_suffix}/libedgellmTokenizer.a")
+    set(_edge_plugin
+      "${TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_BUILD_DIR}${_suffix}/libNvInfer_edgellm_plugin.so.1.0")
+    if(EXISTS "${_edge_core}" AND EXISTS "${_edge_tokenizer}" AND
+       EXISTS "${_edge_plugin}")
+      set(_edge_resolved TRUE)
+      break()
+    endif()
+  endforeach()
+  if(NOT _edge_resolved)
+    message(FATAL_ERROR
+      "TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_BUILD_DIR is not a complete pinned build; expected "
+      "libedgellmCore.a, libedgellmTokenizer.a, and "
+      "libNvInfer_edgellm_plugin.so.1.0")
+  endif()
+
+  enable_language(CUDA)
+  if(NOT CMAKE_CUDA_COMPILER_VERSION MATCHES "^12\\.8(\\.[0-9]+)?$")
+    message(FATAL_ERROR
+      "This capsule requires exact CUDA 12.8 nvcc, got "
+      "${CMAKE_CUDA_COMPILER_VERSION}")
+  endif()
+  target_include_directories(${_target} PRIVATE
+    "${TRTMC_NEMOTRON3_NANO_4B_EDGE_LLM_SOURCE_DIR}/cpp"
+    "${TRTMC_NEMOTRON3_NANO_4B_TENSORRT_INCLUDE_DIR}"
+    "${TRTMC_NEMOTRON3_NANO_4B_CUDA_INCLUDE_DIR}")
+  target_link_libraries(${_target} PRIVATE
+    "${_edge_core}"
+    "${_edge_tokenizer}"
+    "${TRTMC_NEMOTRON3_NANO_4B_TENSORRT_LIBRARY}"
+    "${TRTMC_NEMOTRON3_NANO_4B_CUDART_LIBRARY}")
+  target_link_options(${_target} PRIVATE
+    $<$<CXX_COMPILER_ID:GNU>:-Wl,--allow-multiple-definition>)
+  set_target_properties(${_target} PROPERTIES
+    LINKER_LANGUAGE CUDA
+    CUDA_ARCHITECTURES 80
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+  add_custom_command(TARGET ${_target} POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+      "${_edge_plugin}"
+      "$<TARGET_FILE_DIR:${_target}>/libNvInfer_edgellm_plugin.so"
+    COMMENT "Staging the pinned Edge-LLM TensorRT plugin beside the capsule DSO")
+endif()

--- a/src/runtime/models/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/adapter.cpp
+++ b/src/runtime/models/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/adapter.cpp
@@ -1,0 +1,749 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// This file is owned by this exact model/runtime capsule. It intentionally
+// duplicates the downstream translation instead of importing a shared Edge
+// adapter from Model Connect.
+
+#include "runtime/providers/optimized_runtime_factory.h"
+
+#include <nlohmann/json.hpp>
+
+#ifndef TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME
+#include "common/trtUtils.h"
+#include "runtime/llmInferenceRuntime.h"
+
+#include <NvInferRuntime.h>
+#include <cuda_runtime_api.h>
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdio>
+#include <dlfcn.h>
+#include <exception>
+#include <filesystem>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr const char* kImplementationId =
+    "nemotron3-nano-4b-fp16.tensorrt-edge-llm.a100-pcie80-sm80";
+constexpr const char* kModelId = "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16";
+constexpr const char* kModelRevision = "dfaf35de3e30f1867dd8dbc38a7fc9fb52d3914f";
+constexpr const char* kProfileId = "nemotron3-nano-4b-fp16--a100-pcie80-sm80";
+constexpr const char* kRuntimeLibrary = "libtrtmc_impl_nemotron3_nano_4b_fp16_tensorrt_edge_llm.so";
+constexpr const char* kPluginLibrary = "libNvInfer_edgellm_plugin.so";
+constexpr const char* kEdgeVersion = "0.6.1";
+constexpr const char* kEdgeCommit = "2620a9768022f25dff18912db2fb92b2ef264a70";
+constexpr const char* kTensorRtVersion = "10.14.1.48";
+constexpr const char* kCudaVersion = "12.8";
+constexpr int32_t kMaxInputLength = 1024;
+constexpr int32_t kMaxCacheLength = 4096;
+constexpr int32_t kMaxBatchSize = 4;
+// Edge-LLM's sampling implementation bounds top-k scratch space at 1024 for
+// this supported profile. This is capsule policy, not part of the generic MC
+// package-private factory contract.
+constexpr int32_t kMaxTopK = 1024;
+constexpr int32_t kMinimumMemoryMiB = 80000;
+constexpr std::size_t kMaxMetadataBytes = 16U * 1024U * 1024U;
+
+struct TensorRtRuntimeVersion {
+    int32_t major{0};
+    int32_t minor{0};
+    int32_t patch{0};
+    int32_t build{0};
+};
+
+std::string version_string(const TensorRtRuntimeVersion& version) {
+    return std::to_string(version.major) + "." + std::to_string(version.minor) + "." +
+           std::to_string(version.patch) + "." + std::to_string(version.build);
+}
+
+TensorRtRuntimeVersion loaded_tensorrt_runtime_version() noexcept {
+#ifdef TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME
+    return {TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_MAJOR,
+            TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_MINOR,
+            TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_PATCH,
+            TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_BUILD};
+#else
+    // Query the libnvinfer object actually resolved for this DSO. Bundle
+    // metadata and the provider's compile-time identity are not runtime proof.
+    return {getInferLibMajorVersion(), getInferLibMinorVersion(), getInferLibPatchVersion(),
+            getInferLibBuildVersion()};
+#endif
+}
+
+void require_supported_tensorrt_runtime() {
+    const TensorRtRuntimeVersion observed = loaded_tensorrt_runtime_version();
+    constexpr TensorRtRuntimeVersion supported{10, 14, 1, 48};
+    if (observed.major != supported.major || observed.minor != supported.minor ||
+        observed.patch != supported.patch || observed.build != supported.build) {
+        throw std::runtime_error("loaded TensorRT runtime version " + version_string(observed) +
+                                 " is unsupported; expected " + version_string(supported));
+    }
+}
+
+int32_t loaded_cuda_runtime_version() {
+#ifdef TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME
+    return TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_CUDA_RUNTIME_VERSION;
+#else
+    int runtime_version = 0;
+    if (cudaRuntimeGetVersion(&runtime_version) != cudaSuccess)
+        throw std::runtime_error("failed to query loaded CUDA runtime version");
+    return runtime_version;
+#endif
+}
+
+void require_supported_cuda_runtime() {
+    constexpr int32_t supported = 12080;
+    const int32_t observed = loaded_cuda_runtime_version();
+    if (observed != supported) {
+        throw std::runtime_error("loaded CUDA runtime version " + std::to_string(observed) +
+                                 " is unsupported; expected 12080 (CUDA 12.8)");
+    }
+}
+
+void set_error(char* output, size_t capacity, const std::string& message) noexcept {
+    if (output == nullptr || capacity == 0)
+        return;
+    std::snprintf(output, capacity, "%s", message.c_str());
+}
+
+std::string required_c_string(const char* value, const char* field) {
+    if (value == nullptr || value[0] == '\0')
+        throw std::runtime_error(std::string("create request requires ") + field);
+    return value;
+}
+
+nlohmann::json parse_metadata(const std::string& text) {
+    if (text.empty() || text.size() > kMaxMetadataBytes)
+        throw std::runtime_error("implementation metadata size is outside the capsule limit");
+    std::vector<std::unordered_set<std::string>> object_keys;
+    nlohmann::json::parser_callback_t callback = [&](int, nlohmann::json::parse_event_t event,
+                                                     nlohmann::json& value) {
+        if (event == nlohmann::json::parse_event_t::object_start)
+            object_keys.emplace_back();
+        if (event == nlohmann::json::parse_event_t::key) {
+            const std::string key = value.get<std::string>();
+            if (object_keys.empty() || !object_keys.back().insert(key).second)
+                throw std::runtime_error("duplicate implementation metadata key: " + key);
+        }
+        if (event == nlohmann::json::parse_event_t::object_end) {
+            if (object_keys.empty())
+                throw std::runtime_error("unbalanced implementation metadata object");
+            object_keys.pop_back();
+        }
+        return true;
+    };
+    try {
+        return nlohmann::json::parse(text, callback);
+    } catch (const nlohmann::json::exception& error) {
+        throw std::runtime_error(std::string("invalid implementation metadata: ") + error.what());
+    }
+}
+
+void require_exact_keys(const nlohmann::json& object, std::initializer_list<const char*> expected,
+                        const std::string& context) {
+    if (!object.is_object())
+        throw std::runtime_error(context + " must be an object");
+    std::set<std::string> expected_keys;
+    for (const char* key : expected)
+        expected_keys.insert(key);
+    std::set<std::string> actual_keys;
+    for (auto item = object.begin(); item != object.end(); ++item)
+        actual_keys.insert(item.key());
+    if (actual_keys != expected_keys)
+        throw std::runtime_error(context + " has an unexpected field set");
+}
+
+const nlohmann::json& require_object(const nlohmann::json& object, const char* field,
+                                     const char* context) {
+    const auto value = object.find(field);
+    if (value == object.end() || !value->is_object())
+        throw std::runtime_error(std::string(context) + " requires object field '" + field + "'");
+    return *value;
+}
+
+std::string require_string(const nlohmann::json& object, const char* field,
+                           const std::string& context) {
+    const auto value = object.find(field);
+    if (value == object.end() || !value->is_string() || value->get<std::string>().empty())
+        throw std::runtime_error(context + " requires string field '" + field + "'");
+    return value->get<std::string>();
+}
+
+int32_t require_int32(const nlohmann::json& object, const char* field, const std::string& context) {
+    const auto value = object.find(field);
+    if (value == object.end() || (!value->is_number_integer() && !value->is_number_unsigned())) {
+        throw std::runtime_error(context + " requires integer field '" + field + "'");
+    }
+    const auto parsed = value->get<std::int64_t>();
+    if (parsed < 0 || parsed > std::numeric_limits<int32_t>::max())
+        throw std::runtime_error(context + " integer field is outside int32 range");
+    return static_cast<int32_t>(parsed);
+}
+
+void require_string_value(const nlohmann::json& object, const char* field, const char* expected,
+                          const std::string& context) {
+    const std::string actual = require_string(object, field, context);
+    if (actual != expected) {
+        throw std::runtime_error(context + " field '" + field + "' mismatch: expected '" +
+                                 expected + "', got '" + actual + "'");
+    }
+}
+
+void require_int_value(const nlohmann::json& object, const char* field, int32_t expected,
+                       const std::string& context) {
+    const int32_t actual = require_int32(object, field, context);
+    if (actual != expected) {
+        throw std::runtime_error(context + " field '" + field + "' mismatch: expected " +
+                                 std::to_string(expected) + ", got " + std::to_string(actual));
+    }
+}
+
+void require_sha256(const nlohmann::json& object, const char* field, const std::string& context) {
+    const std::string value = require_string(object, field, context);
+    const bool valid =
+        value.size() == 64 && std::all_of(value.begin(), value.end(), [](char character) {
+            return (character >= '0' && character <= '9') || (character >= 'a' && character <= 'f');
+        });
+    if (!valid)
+        throw std::runtime_error(context + " field '" + field +
+                                 "' must be a lowercase SHA-256 digest");
+}
+
+struct CapsuleMetadata {
+    int32_t vocab_size{0};
+    int32_t minimum_memory_mib{0};
+};
+
+CapsuleMetadata
+validate_metadata(const trtmc::internal::OptimizedRuntimePipelineCreateRequestV1& request) {
+    if (required_c_string(request.implementation_id, "implementation_id") != kImplementationId)
+        throw std::runtime_error("create request implementation_id does not match this capsule");
+    if (required_c_string(request.profile_id, "profile_id") != kProfileId)
+        throw std::runtime_error("create request profile_id does not match this capsule");
+    if (required_c_string(request.model_id, "model_id") != kModelId)
+        throw std::runtime_error("create request model_id does not match this capsule");
+    if (request.implementation_metadata == nullptr || request.implementation_metadata_size == 0)
+        throw std::runtime_error("create request requires implementation_metadata");
+    const nlohmann::json root = parse_metadata(
+        std::string(request.implementation_metadata, request.implementation_metadata_size));
+    require_exact_keys(root,
+                       {"schema_version", "build_binding", "implementation_id", "profile_id",
+                        "operation", "model", "target", "runtime", "artifacts", "limits",
+                        "versions", "bundle_info", "bundle_config"},
+                       "implementation metadata");
+    require_int_value(root, "schema_version", 1, "implementation metadata");
+    require_string_value(root, "implementation_id", kImplementationId, "implementation metadata");
+    require_string_value(root, "profile_id", kProfileId, "implementation metadata");
+    require_string_value(root, "operation", "text-generation-v1", "implementation metadata");
+
+    const auto& build_binding = require_object(root, "build_binding", "implementation metadata");
+    require_exact_keys(
+        build_binding,
+        {"schema_version", "implementation_id", "manifest_sha256", "request_sha256", "profile_id"},
+        "implementation metadata build_binding");
+    require_int_value(build_binding, "schema_version", 1, "implementation metadata build_binding");
+    require_string_value(build_binding, "implementation_id", kImplementationId,
+                         "implementation metadata build_binding");
+    require_string_value(build_binding, "manifest_sha256",
+                         TRTMC_NEMOTRON3_NANO_4B_EDGE_MANIFEST_SHA256,
+                         "implementation metadata build_binding");
+    require_sha256(build_binding, "request_sha256", "implementation metadata build_binding");
+    require_string_value(build_binding, "profile_id", kProfileId,
+                         "implementation metadata build_binding");
+
+    const auto& model = require_object(root, "model", "implementation metadata");
+    require_exact_keys(model, {"id", "revision"}, "implementation metadata model");
+    require_string_value(model, "id", kModelId, "implementation metadata model");
+    require_string_value(model, "revision", kModelRevision, "implementation metadata model");
+
+    const auto& target = require_object(root, "target", "implementation metadata");
+    require_string_value(target, "os", "linux", "implementation metadata target");
+    require_string_value(target, "architecture", "x86_64", "implementation metadata target");
+    require_string_value(target, "platform_kind", "discrete", "implementation metadata target");
+    require_string_value(target, "gpu_architecture", "sm80", "implementation metadata target");
+    require_string_value(target, "gpu_name", "NVIDIA A100 80GB PCIe",
+                         "implementation metadata target");
+    const int32_t observed_memory =
+        require_int32(target, "gpu_memory_mib", "implementation metadata target");
+    if (observed_memory < kMinimumMemoryMiB)
+        throw std::runtime_error("implementation metadata target memory is below profile minimum");
+
+    const auto& runtime = require_object(root, "runtime", "implementation metadata");
+    require_exact_keys(runtime, {"abi", "library", "plugin"}, "implementation metadata runtime");
+    require_int_value(runtime, "abi", 1, "implementation metadata runtime");
+    require_string_value(runtime, "library", kRuntimeLibrary, "implementation metadata runtime");
+    require_string_value(runtime, "plugin", kPluginLibrary, "implementation metadata runtime");
+
+    const auto& artifacts = require_object(root, "artifacts", "implementation metadata");
+    require_string_value(artifacts, "layout", "directory-tree-v1",
+                         "implementation metadata artifacts");
+    require_string_value(artifacts, "engine_dir", "engine.dir",
+                         "implementation metadata artifacts");
+    require_string_value(artifacts, "runtime_library", kRuntimeLibrary,
+                         "implementation metadata artifacts");
+    require_string_value(artifacts, "runtime_plugin", kPluginLibrary,
+                         "implementation metadata artifacts");
+
+    const auto& limits = require_object(root, "limits", "implementation metadata");
+    require_exact_keys(limits,
+                       {"max_input_length", "max_cache_length", "max_batch_size", "vocab_size"},
+                       "implementation metadata limits");
+    require_int_value(limits, "max_input_length", kMaxInputLength,
+                      "implementation metadata limits");
+    require_int_value(limits, "max_cache_length", kMaxCacheLength,
+                      "implementation metadata limits");
+    require_int_value(limits, "max_batch_size", kMaxBatchSize, "implementation metadata limits");
+    const int32_t vocab_size =
+        require_int32(limits, "vocab_size", "implementation metadata limits");
+    if (vocab_size <= 0)
+        throw std::runtime_error("implementation metadata vocab_size must be positive");
+
+    const auto& versions = require_object(root, "versions", "implementation metadata");
+    require_exact_keys(versions,
+                       {"model_revision", "edge_llm", "edge_llm_commit", "tensorrt", "cuda"},
+                       "implementation metadata versions");
+    require_string_value(versions, "model_revision", kModelRevision,
+                         "implementation metadata versions");
+    require_string_value(versions, "edge_llm", kEdgeVersion, "implementation metadata versions");
+    require_string_value(versions, "edge_llm_commit", kEdgeCommit,
+                         "implementation metadata versions");
+    require_string_value(versions, "tensorrt", kTensorRtVersion,
+                         "implementation metadata versions");
+    require_string_value(versions, "cuda", kCudaVersion, "implementation metadata versions");
+
+    return CapsuleMetadata{vocab_size, kMinimumMemoryMiB};
+}
+
+fs::path require_directory(const fs::path& path, const std::string& description) {
+    std::error_code error;
+    const fs::file_status status = fs::symlink_status(path, error);
+    if (error || fs::is_symlink(status) || !fs::is_directory(status))
+        throw std::runtime_error(description + " is not a non-symlink directory: " + path.string());
+    return path;
+}
+
+fs::path adjacent_plugin_path() {
+    static const char anchor = 0;
+    Dl_info info{};
+    if (dladdr(&anchor, &info) == 0 || info.dli_fname == nullptr)
+        throw std::runtime_error("unable to determine capsule DSO location");
+    return fs::path(info.dli_fname).parent_path() / kPluginLibrary;
+}
+
+#ifndef TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME
+class ProcessPluginLibrary {
+  public:
+    ~ProcessPluginLibrary() {
+#ifdef RTLD_NODELETE
+        if (handle != nullptr)
+            (void)dlclose(handle);
+#endif
+    }
+    ProcessPluginLibrary(const ProcessPluginLibrary&) = delete;
+    ProcessPluginLibrary& operator=(const ProcessPluginLibrary&) = delete;
+    void* handle{nullptr};
+
+  private:
+    ProcessPluginLibrary() = default;
+    friend void ensure_edge_plugin_loaded();
+};
+
+void open_edge_plugin(ProcessPluginLibrary& plugin) {
+    const fs::path plugin_path = adjacent_plugin_path();
+    std::error_code status_error;
+    const fs::file_status status = fs::symlink_status(plugin_path, status_error);
+    if (status_error || fs::is_symlink(status) || !fs::is_regular_file(status))
+        throw std::runtime_error("capsule plugin is unavailable: " + plugin_path.string());
+    int flags = RTLD_LAZY | RTLD_LOCAL;
+#ifdef RTLD_NODELETE
+    flags |= RTLD_NODELETE;
+#endif
+    dlerror();
+    plugin.handle = dlopen(plugin_path.c_str(), flags);
+    if (plugin.handle == nullptr) {
+        const char* error = dlerror();
+        throw std::runtime_error("failed to load capsule plugin: " +
+                                 std::string(error ? error : "unknown dlopen error"));
+    }
+}
+
+void initialize_edge_plugin(ProcessPluginLibrary& plugin) {
+    using InitPluginsFn = bool (*)(void*, const char*);
+    dlerror();
+    auto* symbol = dlsym(plugin.handle, "initEdgellmPlugins");
+    const char* symbol_error = dlerror();
+    if (symbol_error != nullptr || symbol == nullptr)
+        throw std::runtime_error("capsule plugin is missing initEdgellmPlugins");
+    auto init_plugins = reinterpret_cast<InitPluginsFn>(symbol);
+    if (!init_plugins(static_cast<nvinfer1::ILogger*>(&trt_edgellm::gLogger), ""))
+        throw std::runtime_error("initEdgellmPlugins returned false");
+}
+
+void ensure_edge_plugin_loaded() {
+    static std::once_flag once;
+    static std::exception_ptr initialization_error;
+    static ProcessPluginLibrary plugin;
+    std::call_once(once, [] {
+        try {
+            open_edge_plugin(plugin);
+            initialize_edge_plugin(plugin);
+        } catch (...) {
+            initialization_error = std::current_exception();
+        }
+    });
+    if (initialization_error)
+        std::rethrow_exception(initialization_error);
+}
+
+void configure_edge_logging() noexcept {
+    // MC's public CLI reserves stdout for the generated result. Edge-LLM 0.6.1
+    // sends INFO messages to stdout by default, which would make the unchanged
+    // Python wrapper return runtime logs as part of the generated text. Keep
+    // warnings and errors (which Edge writes to stderr), but suppress INFO and
+    // VERBOSE output for this model-owned integration.
+    trt_edgellm::gLogger.setLevel(nvinfer1::ILogger::Severity::kWARNING);
+}
+
+class CudaDeviceGuard {
+  public:
+    explicit CudaDeviceGuard(int target_device) {
+        const cudaError_t get_status = cudaGetDevice(&previous_device_);
+        if (get_status != cudaSuccess)
+            throw std::runtime_error("failed to query current CUDA device");
+        if (previous_device_ != target_device) {
+            const cudaError_t set_status = cudaSetDevice(target_device);
+            if (set_status != cudaSuccess)
+                throw std::runtime_error("failed to select capsule CUDA device");
+            restore_ = true;
+        }
+    }
+    ~CudaDeviceGuard() {
+        if (restore_)
+            (void)cudaSetDevice(previous_device_);
+    }
+    CudaDeviceGuard(const CudaDeviceGuard&) = delete;
+    CudaDeviceGuard& operator=(const CudaDeviceGuard&) = delete;
+
+  private:
+    int previous_device_{-1};
+    bool restore_{false};
+};
+#endif
+
+struct EdgeLlmHandle {
+    int32_t max_cache_length{0};
+    int32_t vocab_size{0};
+#ifndef TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME
+    cudaStream_t stream{nullptr};
+    int device{-1};
+    std::unique_ptr<trt_edgellm::rt::LLMInferenceRuntime> runtime;
+    ~EdgeLlmHandle() {
+        int previous_device = -1;
+        bool restore_device = false;
+        if (device >= 0 && cudaGetDevice(&previous_device) == cudaSuccess &&
+            previous_device != device && cudaSetDevice(device) == cudaSuccess) {
+            restore_device = true;
+        }
+        runtime.reset();
+        if (stream != nullptr)
+            (void)cudaStreamDestroy(stream);
+        if (restore_device)
+            (void)cudaSetDevice(previous_device);
+    }
+#endif
+};
+
+#ifdef TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME
+void require_fake_plugin_payload() {
+    const fs::path plugin = adjacent_plugin_path();
+    std::error_code plugin_error;
+    const auto plugin_status = fs::symlink_status(plugin, plugin_error);
+    if (plugin_error || fs::is_symlink(plugin_status) || !fs::is_regular_file(plugin_status))
+        throw std::runtime_error("fake capsule contract requires adjacent plugin payload");
+}
+#else
+cudaDeviceProp query_active_cuda_device(EdgeLlmHandle& handle) {
+    int visible_devices = 0;
+    if (cudaGetDeviceCount(&visible_devices) != cudaSuccess || visible_devices < 1)
+        throw std::runtime_error("Edge-LLM capsule requires at least one visible CUDA GPU");
+    if (cudaGetDevice(&handle.device) != cudaSuccess)
+        throw std::runtime_error("failed to query capsule CUDA device");
+    cudaDeviceProp properties{};
+    if (cudaGetDeviceProperties(&properties, handle.device) != cudaSuccess)
+        throw std::runtime_error("failed to query capsule CUDA device properties");
+    return properties;
+}
+
+void require_supported_a100(const cudaDeviceProp& properties, int32_t minimum_memory_mib) {
+    const std::string gpu_name(properties.name);
+    const auto memory_mib = properties.totalGlobalMem / (1024ULL * 1024ULL);
+    if (properties.major != 8 || properties.minor != 0 || gpu_name != "NVIDIA A100 80GB PCIe" ||
+        memory_mib < static_cast<std::uint64_t>(minimum_memory_mib)) {
+        throw std::runtime_error("active CUDA device does not match the supported A100 target");
+    }
+}
+
+void create_edge_runtime(EdgeLlmHandle& handle, const fs::path& engine_directory);
+#endif
+
+std::unique_ptr<EdgeLlmHandle>
+initialize_edge_handle(const trtmc::internal::OptimizedRuntimePipelineCreateRequestV1& request) {
+    const CapsuleMetadata metadata = validate_metadata(request);
+    const fs::path artifact_root = require_directory(
+        required_c_string(request.artifact_path, "artifact_path"), "capsule artifact root");
+    const fs::path engine_directory =
+        require_directory(artifact_root / "engine.dir", "capsule engine.dir");
+    // Fail before plugin initialization, CUDA allocation, or Edge-LLM runtime
+    // construction if the deployed dependency libraries are unsupported.
+    require_supported_tensorrt_runtime();
+    require_supported_cuda_runtime();
+    auto handle = std::make_unique<EdgeLlmHandle>();
+    handle->max_cache_length = kMaxCacheLength;
+    handle->vocab_size = metadata.vocab_size;
+#ifdef TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME
+    require_fake_plugin_payload();
+    (void)engine_directory;
+#else
+    configure_edge_logging();
+    ensure_edge_plugin_loaded();
+    const cudaDeviceProp properties = query_active_cuda_device(*handle);
+    require_supported_a100(properties, metadata.minimum_memory_mib);
+    create_edge_runtime(*handle, engine_directory);
+#endif
+    return handle;
+}
+
+#ifndef TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME
+void create_edge_runtime(EdgeLlmHandle& handle, const fs::path& engine_directory) {
+    if (cudaStreamCreate(&handle.stream) != cudaSuccess)
+        throw std::runtime_error("failed to create capsule CUDA stream");
+    handle.runtime = std::make_unique<trt_edgellm::rt::LLMInferenceRuntime>(
+        engine_directory.string(), std::string{}, std::unordered_map<std::string, std::string>{},
+        handle.stream);
+}
+#endif
+
+struct EdgeLlmResponse {
+    std::string text;
+    std::vector<int32_t> token_ids;
+};
+
+struct CapsuleGenerationRequest {
+    const char* prompt{nullptr};
+    std::size_t prompt_size{0};
+    int32_t max_new_tokens{0};
+    float temperature{0.0F};
+    int32_t top_k{0};
+    float top_p{0.0F};
+    bool use_chat_template{false};
+    bool enable_thinking{true};
+};
+
+bool valid_sampling_numbers(const CapsuleGenerationRequest& request) noexcept {
+    return std::isfinite(request.temperature) && request.temperature >= 0.0F &&
+           std::isfinite(request.top_p) && request.top_p >= 0.0F && request.top_p <= 1.0F &&
+           (request.top_k > 0 || request.top_p < 1.0F);
+}
+
+bool valid_sampling_limits(const EdgeLlmHandle& handle,
+                           const CapsuleGenerationRequest& request) noexcept {
+    if (request.max_new_tokens <= 0 || request.max_new_tokens > handle.max_cache_length)
+        return false;
+    const int32_t max_top_k = std::min(handle.vocab_size, kMaxTopK);
+    return request.top_k <= max_top_k;
+}
+
+void validate_sampling_request(const EdgeLlmHandle& handle,
+                               const CapsuleGenerationRequest& request) {
+    if (request.top_k == 0 && request.top_p == 1.0F) {
+        throw std::invalid_argument(
+            "Nemotron 3 Nano 4B Edge-LLM 0.6.1 cannot represent top_k <= 0 with top_p == 1.0 "
+            "because it requires at least one sampling filter");
+    }
+    if (!valid_sampling_numbers(request) || !valid_sampling_limits(handle, request))
+        throw std::invalid_argument("invalid Nemotron 3 Nano 4B Edge-LLM sampling request");
+}
+
+#ifndef TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME
+trt_edgellm::rt::LLMGenerationRequest make_edge_request(const CapsuleGenerationRequest& request) {
+    trt_edgellm::rt::LLMGenerationRequest edge_request;
+    trt_edgellm::rt::LLMGenerationRequest::Request item;
+    trt_edgellm::rt::Message message;
+    message.role = "user";
+    const std::string prompt = request.prompt == nullptr
+                                   ? std::string{}
+                                   : std::string(request.prompt, request.prompt_size);
+    message.contents.push_back({"text", prompt});
+    item.messages.push_back(std::move(message));
+    edge_request.requests.push_back(std::move(item));
+    edge_request.temperature = request.temperature;
+    edge_request.topP = request.top_p;
+    edge_request.topK = request.top_k;
+    edge_request.maxGenerateLength = request.max_new_tokens;
+    // This instruction-only checkpoint requires its bundled template. Keep
+    // plain MC CLI, Python, and C++ prompts useful without a shared API change.
+    edge_request.applyChatTemplate = true;
+    edge_request.addGenerationPrompt = true;
+    edge_request.enableThinking = request.enable_thinking;
+    return edge_request;
+}
+#endif
+
+EdgeLlmResponse execute_one(EdgeLlmHandle& handle, const CapsuleGenerationRequest& request) {
+    EdgeLlmResponse result;
+#ifdef TRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME
+    (void)handle;
+    if (request.top_k < 0)
+        throw std::logic_error("fake Edge-LLM received a negative topK");
+    const std::string prompt = request.prompt == nullptr
+                                   ? std::string{}
+                                   : std::string(request.prompt, request.prompt_size);
+    result.text = "fake:" + prompt;
+    const std::size_t count =
+        std::min<std::size_t>(prompt.size(), static_cast<std::size_t>(request.max_new_tokens));
+    result.token_ids.reserve(count);
+    for (std::size_t index = 0; index < count; ++index)
+        result.token_ids.push_back(static_cast<unsigned char>(prompt[index]));
+#else
+    CudaDeviceGuard device_guard(handle.device);
+    auto edge_request = make_edge_request(request);
+    trt_edgellm::rt::LLMGenerationResponse edge_response;
+    if (!handle.runtime->handleRequest(edge_request, edge_response, handle.stream))
+        throw std::runtime_error("TensorRT Edge-LLM handleRequest returned false");
+    if (edge_response.outputTexts.size() != 1 || edge_response.outputIds.size() != 1)
+        throw std::runtime_error("TensorRT Edge-LLM returned an invalid response batch");
+    result.text = std::move(edge_response.outputTexts.front());
+    result.token_ids = std::move(edge_response.outputIds.front());
+#endif
+    return result;
+}
+
+bool uses_default_generation_scalars(const trtmc::GenerateConfig& config) noexcept {
+    return config.num_samples == 1 && config.min_p == 0.0F && config.seed == -1 &&
+           config.guidance_scale == -1.0F && config.cfg_scale == -1.0F && config.num_steps == -1 &&
+           config.sde_gamma == -1.0F;
+}
+
+bool uses_no_diffusion_payload(const trtmc::GenerateConfig& config) noexcept {
+    return config.initial_latents.empty() && config.condition_latents.empty() &&
+           config.condition_mask.empty() && config.sampling_steps.empty() &&
+           config.sde_noises.empty() && config.negative_prompt.empty();
+}
+
+bool uses_default_output_shape(const trtmc::GenerateConfig& config) noexcept {
+    return config.height == 0 && config.width == 0;
+}
+
+bool uses_supported_text_mode(const trtmc::GenerateConfig& config) noexcept {
+    const bool supported_mode =
+        config.text_generation_mode == "auto" || config.text_generation_mode == "ar";
+    return config.eos_token_id == -1 && supported_mode && config.block_length == 0 &&
+           config.confidence_threshold == -1.0F && config.lora_adapter_id.empty();
+}
+
+bool uses_default_stop_options(const trtmc::GenerateConfig& config) noexcept {
+    return config.tail_frames == 0 && !config.stop_on_boxed_answer &&
+           config.stop_check_interval == 16;
+}
+
+void validate_generate_config(const trtmc::GenerateConfig& config) {
+    if (!uses_default_generation_scalars(config) || !uses_no_diffusion_payload(config) ||
+        !uses_default_output_shape(config) || !uses_supported_text_mode(config) ||
+        !uses_default_stop_options(config)) {
+        throw std::invalid_argument("Nemotron 3 Nano 4B Edge-LLM does not support one or more "
+                                    "non-default GenerateConfig fields");
+    }
+}
+
+CapsuleGenerationRequest capsule_request(const std::string& prompt,
+                                         const trtmc::GenerateConfig& config) {
+    validate_generate_config(config);
+    return CapsuleGenerationRequest{prompt.data(),
+                                    prompt.size(),
+                                    config.max_new_tokens,
+                                    config.temperature,
+                                    std::max(config.top_k, int32_t{0}),
+                                    config.top_p,
+                                    config.use_chat_template,
+                                    config.enable_thinking};
+}
+
+class Nemotron3NanoEdgeLlmPipeline final : public trtmc::IPipeline {
+  public:
+    explicit Nemotron3NanoEdgeLlmPipeline(
+        const trtmc::internal::OptimizedRuntimePipelineCreateRequestV1& request)
+        : handle_(initialize_edge_handle(request)) {}
+
+    trtmc::TextResult generate(const std::string& prompt,
+                               const trtmc::GenerateConfig& config) override {
+        const CapsuleGenerationRequest request = capsule_request(prompt, config);
+        validate_sampling_request(*handle_, request);
+        std::lock_guard<std::mutex> lock(mutex_);
+        EdgeLlmResponse response = execute_one(*handle_, request);
+        // Edge-LLM 0.6.1 does not expose a trustworthy prefill/decode split.
+        // Report both metrics as unavailable instead of mislabeling wall time.
+        return trtmc::TextResult(std::move(response.text), std::move(response.token_ids), 0.0, 0.0);
+    }
+
+    const char* pipeline_type() const override { return "Nemotron3NanoTextGenerationPipeline"; }
+    const char* model_id() const override { return kModelId; }
+
+  private:
+    std::unique_ptr<EdgeLlmHandle> handle_;
+    std::mutex mutex_;
+};
+
+trtmc::IPipeline*
+create_pipeline(const trtmc::internal::OptimizedRuntimePipelineCreateRequestV1* request,
+                char* error, std::size_t error_capacity) noexcept {
+    if (request == nullptr ||
+        request->abi_version != trtmc::internal::kOptimizedRuntimeFactoryAbiVersionV1 ||
+        request->struct_size < sizeof(trtmc::internal::OptimizedRuntimePipelineCreateRequestV1)) {
+        set_error(error, error_capacity, "invalid optimized-runtime pipeline create request");
+        return nullptr;
+    }
+    try {
+        return new Nemotron3NanoEdgeLlmPipeline(*request);
+    } catch (const std::exception& exception) {
+        set_error(error, error_capacity, exception.what());
+        return nullptr;
+    } catch (...) {
+        set_error(error, error_capacity, "unknown capsule initialization failure");
+        return nullptr;
+    }
+}
+
+const trtmc::internal::OptimizedRuntimeFactoryV1 kFactoryV1 = {
+    trtmc::internal::kOptimizedRuntimeFactoryAbiVersionV1,
+    sizeof(trtmc::internal::OptimizedRuntimeFactoryV1),
+    kImplementationId,
+    "tensorrt-edge-llm",
+    kEdgeVersion,
+    kEdgeCommit,
+    &create_pipeline,
+};
+
+} // namespace
+
+extern "C" const trtmc::internal::OptimizedRuntimeFactoryV1*
+trtmc_get_optimized_runtime_factory_v1() noexcept {
+    return &kFactoryV1;
+}

--- a/src/runtime/models/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/exports.map
+++ b/src/runtime/models/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/exports.map
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+TRTMC_NEMOTRON3_NANO_4B_EDGE_FACTORY_1 {
+  global:
+    trtmc_get_optimized_runtime_factory_v1;
+  local:
+    *;
+};

--- a/tests/e2e/models/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/test_nemotron3_nano_4b_edge_a100_e2e.py
+++ b/tests/e2e/models/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/test_nemotron3_nano_4b_edge_a100_e2e.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public Model Connect E2E for the supported Nemotron 3 Nano 4B EdgeLLM profile."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tensorrt_model_connect.runtime_provider.target import (
+    TargetResolutionError,
+    _probe_current_target_with_device,
+)
+
+
+_MODEL_ID = "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16"
+
+
+def _run(command: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    assert result.returncode == 0, (
+        f"command failed ({result.returncode}): {' '.join(command)}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return result
+
+
+def _require_supported_a100() -> None:
+    try:
+        target, _ = _probe_current_target_with_device()
+    except TargetResolutionError as exc:
+        pytest.fail(f"the selected A100 proof could not inspect its CUDA target: {exc}")
+    if target["gpu_name"] != "NVIDIA A100 80GB PCIe":
+        pytest.fail(
+            f"the selected A100 proof requires NVIDIA A100 80GB PCIe; found {target['gpu_name']}"
+        )
+
+
+@pytest.mark.e2e
+@pytest.mark.gpu
+@pytest.mark.trt
+@pytest.mark.slow
+def test_public_build_inspect_and_run_delegate_to_edgellm(tmp_path: Path) -> None:
+    """Build and execute through unchanged public commands on the supported GPU."""
+
+    _require_supported_a100()
+    binary_value = os.environ.get("TRTMC_BINARY", "").strip()
+    if not binary_value:
+        pytest.fail("TRTMC_BINARY is required for the A100 EdgeLLM E2E")
+    binary = Path(binary_value).resolve(strict=True)
+
+    bundle = tmp_path / "nemotron3-nano-4b-edge.trtfb"
+    cache = tmp_path / "runtime-cache"
+    output = tmp_path / "generated.jsonl"
+
+    _run(
+        [
+            str(binary),
+            "build",
+            _MODEL_ID,
+            "-o",
+            str(bundle),
+            "--precision",
+            "fp16",
+            "--max-cache-length",
+            "4096",
+            "--max-batch-size",
+            "4",
+        ],
+        timeout=21_600,
+    )
+    inspect = _run([str(binary), "inspect", str(bundle)], timeout=60)
+    assert "optimized_runtime.json" in inspect.stdout
+    assert "optimized_runtime_artifacts/engine.dir/" in inspect.stdout
+
+    _run(
+        [
+            str(binary),
+            "run",
+            str(bundle),
+            "--prompt",
+            "Reply with one short sentence about accelerated computing.",
+            "--greedy",
+            "--top-p",
+            "1",
+            "--top-k",
+            "1",
+            "--no-thinking",
+            "--max-new-tokens",
+            "32",
+            "--runtime-cache",
+            str(cache),
+            "--output",
+            str(output),
+        ],
+        timeout=600,
+    )
+
+    rows = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    generated = rows[0]["generated"].strip()
+    assert len(rows[0]["token_ids"]) > 1
+    assert re.sub(r"<\|[^|>]+\|>", "", generated).strip()
+    assert any(path.is_dir() for path in cache.rglob("engine.dir"))

--- a/tests/e2e/models/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/test_nemotron3_nano_4b_edge_adapter.py
+++ b/tests/e2e/models/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/test_nemotron3_nano_4b_edge_adapter.py
@@ -1,0 +1,1234 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-local contracts for the NVIDIA Nemotron 3 Nano 4B TensorRT Edge-LLM capsule."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[5]
+CAPSULE_ROOT = (
+    REPOSITORY_ROOT
+    / "python"
+    / "tensorrt_model_connect"
+    / "families"
+    / "nemotron_h"
+    / "nemotron3_nano_4b_edge_llm_adapter"
+)
+RUNTIME_ROOT = (
+    REPOSITORY_ROOT
+    / "src"
+    / "runtime"
+    / "models"
+    / "nemotron_h"
+    / "nemotron3_nano_4b_edge_llm_adapter"
+)
+PYTHON_ROOT = REPOSITORY_ROOT / "python"
+if str(PYTHON_ROOT) not in sys.path:
+    sys.path.insert(0, str(PYTHON_ROOT))
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility.
+    import tomli as tomllib
+
+from tensorrt_model_connect.runtime_provider.provider_process import (  # noqa: E402
+    BuildAdapterError,
+    ImplementationRequest,
+    run_build,
+    run_probe,
+)
+from tensorrt_model_connect.runtime_provider.bundle import (  # noqa: E402
+    write_optimized_bundle,
+)
+from tensorrt_model_connect.runtime_provider.manifest import (  # noqa: E402
+    load_implementation_manifest,
+    manifest_contract_sha256,
+)
+from tensorrt_model_connect.runtime_provider.orchestrator import (  # noqa: E402
+    discover_family_implementations_for_model,
+    family_implementation_root,
+)
+
+
+MODEL_ID = "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16"
+MODEL_REVISION = "dfaf35de3e30f1867dd8dbc38a7fc9fb52d3914f"
+IMPLEMENTATION_ID = "nemotron3-nano-4b-fp16.tensorrt-edge-llm.a100-pcie80-sm80"
+PROFILE_ID = "nemotron3-nano-4b-fp16--a100-pcie80-sm80"
+EDGE_COMMIT = "2620a9768022f25dff18912db2fb92b2ef264a70"
+EDGE_SOURCE = "https://github.com/NVIDIA/TensorRT-Edge-LLM.git"
+RUNTIME_LIBRARY = "libtrtmc_impl_nemotron3_nano_4b_fp16_tensorrt_edge_llm.so"
+RUNTIME_PLUGIN = "libNvInfer_edgellm_plugin.so"
+MANIFEST_PATH = CAPSULE_ROOT / "IMPLEMENTATION.toml"
+PROFILE_PATH = CAPSULE_ROOT / "profiles" / "a100-pcie80-sm80-fp16.toml"
+ADAPTER_PATH = CAPSULE_ROOT / "adapter.py"
+EXPECTED_ENGINE_MODEL_CONFIG = {
+    "model": "nemotronh",
+    "model_type": "hybrid_mamba",
+    "vocab_size": 131072,
+    "max_position_embeddings": 262144,
+    "hidden_size": 3136,
+    "intermediate_size": 12544,
+    "num_hidden_layers": 42,
+    "num_attention_heads": 40,
+    "num_key_value_heads": 8,
+    "head_dim": 128,
+    "num_mamba_layers": 21,
+    "num_attention_layers": 4,
+    "mamba_num_heads": 96,
+    "mamba_head_dim": 80,
+    "ssm_state_size": 128,
+    "conv_dim": 9728,
+    "conv_kernel": 4,
+    "use_rope": False,
+    "rope_theta": 10000.0,
+    "rope_scaling": None,
+    "partial_rotary_factor": 1.0,
+    "trt_native_ops": False,
+}
+EXPECTED_ENGINE_BUILDER_CONFIG = {
+    "max_input_len": 1024,
+    "max_kv_cache_capacity": 4096,
+    "max_batch_size": 4,
+    "eagle_draft": False,
+    "eagle_base": False,
+    "max_lora_rank": 0,
+    "trt_native_ops": False,
+}
+REQUIRED_ENGINE_FILES = (
+    "llm.engine",
+    "embedding.safetensors",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "processed_chat_template.json",
+)
+
+
+def test_nemotron3_nano_4b_adapter_package_inventory_is_model_owned() -> None:
+    def source_files(root: Path) -> set[str]:
+        return {
+            path.relative_to(root).as_posix()
+            for path in root.rglob("*")
+            if path.is_file() and "__pycache__" not in path.parts and path.suffix != ".pyc"
+        }
+
+    assert source_files(CAPSULE_ROOT) | {
+        f"runtime/{relative}" for relative in source_files(RUNTIME_ROOT)
+    } == {
+        "IMPLEMENTATION.toml",
+        "adapter.py",
+        "dependency.lock",
+        "profiles/a100-pcie80-sm80-fp16.toml",
+        "runtime/CMakeLists.txt",
+        "runtime/adapter.cpp",
+        "runtime/exports.map",
+    }
+
+
+def test_source_checkout_discovers_edge_llm_only_from_nemotron_h_builder() -> None:
+    root = family_implementation_root("nemotron_h")
+    discovered = discover_family_implementations_for_model("nemotron_h", MODEL_ID)
+
+    assert root == CAPSULE_ROOT.parent
+    assert [manifest.implementation_id for manifest in discovered] == [IMPLEMENTATION_ID]
+
+
+def test_runtime_source_resolves_from_nemotron_h_runtime_folder_in_a_checkout() -> None:
+    adapter = _load_adapter_module()
+
+    assert adapter._runtime_source_root() == RUNTIME_ROOT
+
+
+def test_installed_layout_compiles_the_packaged_nemotron3_nano_4b_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _load_adapter_module()
+    package = tmp_path / "tensorrt_model_connect"
+    packaged_builder = package / "families" / "nemotron_h" / "nemotron3_nano_4b_edge_llm_adapter"
+    packaged_runtime = packaged_builder / "runtime"
+    private_sdk = package / "runtime_provider" / "_sdk" / "include"
+    shutil.copytree(RUNTIME_ROOT, packaged_runtime)
+    for source, relative in (
+        (
+            REPOSITORY_ROOT / "src/runtime/providers/optimized_runtime_factory.h",
+            Path("runtime/providers/optimized_runtime_factory.h"),
+        ),
+        (REPOSITORY_ROOT / "include/trtmc/pipeline.h", Path("trtmc/pipeline.h")),
+    ):
+        destination = private_sdk / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+    monkeypatch.setattr(adapter, "CAPSULE_ROOT", packaged_builder)
+    monkeypatch.setattr(adapter, "REPOSITORY_ROOT", package)
+    monkeypatch.setenv("_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_ALLOW_FAKE_RUNTIME_BUILD", "1")
+    manifest = load_implementation_manifest(MANIFEST_PATH)
+    runtime, plugin, dependency = adapter._build_runtime_dso(
+        tmp_path / "output",
+        {
+            "runtime_build": {
+                "fake": True,
+                "nlohmann_json_include_dir": str(_nlohmann_json_include()),
+                "parallel": 2,
+            }
+        },
+        manifest_contract_sha256(manifest),
+    )
+
+    assert adapter._runtime_source_root() == packaged_runtime
+    assert adapter._private_sdk_include_roots() == (private_sdk,)
+    assert runtime.read_bytes().startswith(b"\x7fELF")
+    assert plugin is None
+    assert dependency is None
+
+
+def _nlohmann_json_include() -> Path:
+    configured = os.environ.get("_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_NLOHMANN_JSON_INCLUDE_DIR", "")
+    trtmc_binary = os.environ.get("TRTMC_BINARY", "")
+    candidates = (
+        ([Path(configured)] if configured else [])
+        + (
+            [Path(trtmc_binary).resolve().parent / "_deps/nlohmann_json-src/include"]
+            if trtmc_binary
+            else []
+        )
+        + [Path("/usr/include")]
+        + sorted(REPOSITORY_ROOT.glob("build*/_deps/nlohmann_json-src/include"))
+    )
+    for candidate in candidates:
+        if (candidate / "nlohmann" / "json.hpp").is_file():
+            return candidate.resolve()
+    pytest.fail(
+        "Nemotron 3 Nano 4B fake-runtime tests require MC's provisioned nlohmann_json include; "
+        "set _TRTMC_INTERNAL_NEMOTRON3_NANO_4B_NLOHMANN_JSON_INCLUDE_DIR"
+    )
+
+
+def _load_adapter_module():
+    name = f"trtmc_nemotron3_nano_4b_edge_adapter_test_{id(object())}"
+    specification = importlib.util.spec_from_file_location(name, ADAPTER_PATH)
+    assert specification is not None and specification.loader is not None
+    module = importlib.util.module_from_spec(specification)
+    sys.modules[name] = module
+    specification.loader.exec_module(module)
+    return module
+
+
+def _target(**changes: object) -> dict[str, object]:
+    target: dict[str, object] = {
+        "os": "linux",
+        "architecture": "x86_64",
+        "platform_kind": "discrete",
+        "gpu_architecture": "sm80",
+        "gpu_name": "NVIDIA A100 80GB PCIe",
+        "gpu_count": 1,
+        "gpu_memory_mib": 81152,
+    }
+    target.update(changes)
+    return target
+
+
+def _request(
+    *,
+    model_id: str = MODEL_ID,
+    revision: str = MODEL_REVISION,
+    target: dict[str, object] | None = None,
+    parameters: dict[str, object] | None = None,
+) -> ImplementationRequest:
+    return ImplementationRequest(
+        model_id=model_id,
+        model_revision=revision,
+        target=target or _target(),
+        parameters=parameters,
+    )
+
+
+def _fake_engine(root: Path) -> Path:
+    root.mkdir()
+    (root / "config.json").write_text(
+        json.dumps(
+            {
+                **EXPECTED_ENGINE_MODEL_CONFIG,
+                "edgellm_version": "0.6.1",
+                "builder_config": EXPECTED_ENGINE_BUILDER_CONFIG,
+            }
+        ),
+        encoding="utf-8",
+    )
+    for filename in REQUIRED_ENGINE_FILES:
+        (root / filename).write_bytes(f"fake-{filename}".encode())
+    return root
+
+
+def _prebuilt_runtime_parameters(tmp_path: Path) -> dict[str, object]:
+    runtime = tmp_path / "runtime-source.so"
+    plugin = tmp_path / "plugin-source.so"
+    runtime.write_bytes(b"fake-runtime-dso")
+    plugin.write_bytes(b"fake-edge-plugin")
+    return {
+        "engine_dir": str(_fake_engine(tmp_path / "prebuilt-engine")),
+        "runtime_library": str(runtime),
+        "runtime_plugin": str(plugin),
+        "precision": "fp16",
+        "quantization": "none",
+        "max_input_length": 1024,
+        "max_cache_length": 4096,
+        "max_batch_size": 4,
+    }
+
+
+def _run_build_after_probe(manifest, request, output: Path):
+    probe = run_probe(manifest, request)
+    assert probe.supported, probe.reason
+    return run_build(manifest, request, output, probe=probe)
+
+
+def _make_cuda_toolkit(
+    root: Path,
+    *,
+    encoded_header_version: int = 12080,
+    compiler_version: str = "12.8",
+) -> tuple[Path, Path, Path]:
+    include = root / "include"
+    include.mkdir(parents=True)
+    (include / "cuda_runtime_api.h").write_text("/* fixture */\n", encoding="utf-8")
+    (include / "cuda.h").write_text(
+        f"#define CUDA_VERSION {encoded_header_version}\n", encoding="utf-8"
+    )
+    compiler = root / "bin" / "nvcc"
+    compiler.parent.mkdir()
+    compiler.write_text(
+        "#!/bin/sh\n"
+        f"printf 'Cuda compilation tools, release {compiler_version}, "
+        f"V{compiler_version}.0\\n'\n",
+        encoding="utf-8",
+    )
+    compiler.chmod(0o755)
+    cudart = root / "lib64" / "libcudart.so"
+    cudart.parent.mkdir()
+    cudart.write_bytes(b"test cudart")
+    return include, compiler, cudart
+
+
+def _make_edge_source(root: Path) -> Path:
+    for relative in (
+        "CMakeLists.txt",
+        "cpp/common/version.h",
+        "3rdParty/nlohmannJson/include/nlohmann/json.hpp",
+        "tensorrt_edgellm/scripts/export_llm.py",
+    ):
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("fixture\n", encoding="utf-8")
+    return root
+
+
+def test_manifest_profile_and_dependency_pins_are_exact_and_capsule_owned() -> None:
+    manifest = load_implementation_manifest(MANIFEST_PATH)
+    with PROFILE_PATH.open("rb") as profile_file:
+        profile = tomllib.load(profile_file)
+    with (CAPSULE_ROOT / "dependency.lock").open("rb") as dependency_file:
+        dependency = tomllib.load(dependency_file)
+
+    assert manifest.implementation_id == IMPLEMENTATION_ID
+    assert manifest.runtime_library == RUNTIME_LIBRARY
+    assert manifest.runtime_abi == 1
+    assert manifest.matches(_request())
+    assert manifest.matches(_request(target=_target(gpu_count=8)))
+    assert not manifest.matches(_request(model_id="nvidia/NVIDIA-Nemotron-Nano-9B-v2"))
+    assert not manifest.matches(_request(revision="0" * 40))
+    assert not manifest.matches(_request(target=_target(gpu_architecture="sm90")))
+    assert not manifest.matches(_request(target=_target(platform_kind="soc")))
+    assert not manifest.matches(_request(target=_target(gpu_name="NVIDIA A100-SXM4-80GB")))
+
+    assert dependency["downstream"] == {
+        "name": "tensorrt-edge-llm",
+        "source": EDGE_SOURCE,
+        "version": "0.6.1",
+        "tag": "v0.6.1",
+        "commit": EDGE_COMMIT,
+        "source_mode": "git",
+    }
+    assert dependency["tensorrt"] == {"version": "10.14.1.48"}
+    assert dependency["cuda"] == {"version": "12.8"}
+    assert profile["profile_id"] == PROFILE_ID
+    assert "model" not in profile
+    assert "target" not in profile
+    assert "versions" not in profile
+    _load_adapter_module()._validate_capsule_data(profile)
+
+
+def test_adapter_restores_parent_active_device_for_heterogeneous_visible_gpus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _load_adapter_module()
+    calls: list[tuple[str, int]] = []
+    selected = {"ordinal": 0}
+
+    class FakeCudaRuntime:
+        class cudaError_t:
+            cudaSuccess = 0
+
+        @staticmethod
+        def cudaSetDevice(ordinal: int):
+            calls.append(("set", ordinal))
+            selected["ordinal"] = ordinal
+            return (0,)
+
+        @staticmethod
+        def cudaGetDevice():
+            calls.append(("get", selected["ordinal"]))
+            return 0, selected["ordinal"]
+
+    monkeypatch.setattr(adapter, "_cuda_runtime", lambda: FakeCudaRuntime)
+    monkeypatch.setenv("TRTMC_INTERNAL_OPTIMIZED_RUNTIME_CUDA_DEVICE", "1")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-slow,GPU-a100")
+
+    adapter._select_parent_active_cuda_device()
+
+    assert calls == [("set", 1), ("get", 1)]
+    assert os.environ["CUDA_VISIBLE_DEVICES"] == "GPU-a100"
+
+
+def test_supported_probe_selects_profile_without_hidden_opt_in(tmp_path: Path) -> None:
+    manifest = load_implementation_manifest(MANIFEST_PATH)
+    parameters = _prebuilt_runtime_parameters(tmp_path)
+
+    probe = run_probe(manifest, _request(parameters=parameters))
+
+    assert probe.supported
+    assert probe.profile_id == PROFILE_ID
+    assert not probe.reason
+
+    unsupported = run_probe(
+        manifest,
+        _request(parameters={**parameters, "precision": "fp32"}),
+    )
+    assert not unsupported.supported
+    assert "precision='fp32'" in unsupported.reason
+
+    unsupported_option = run_probe(
+        manifest,
+        _request(parameters={**parameters, "public_options": {"dynamic_kv_cache": True}}),
+    )
+    assert not unsupported_option.supported
+    assert "dynamic_kv_cache=true" in unsupported_option.reason
+
+    with pytest.raises(BuildAdapterError, match="unsupported parameters: deployment"):
+        run_probe(
+            manifest,
+            _request(parameters={**parameters, "deployment": {"target": "current"}}),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "missing", "reason"),
+    (
+        ("gpu_memory_mib", 79999, False, "gpu_memory_mib >= 80000"),
+        ("gpu_memory_mib", True, False, "gpu_memory_mib to be an integer"),
+        ("gpu_memory_mib", None, True, "gpu_memory_mib to be an integer"),
+        ("gpu_count", 0, False, "gpu_count to be a positive integer"),
+        ("gpu_count", True, False, "gpu_count to be a positive integer"),
+        ("gpu_count", None, True, "gpu_count to be a positive integer"),
+    ),
+)
+def test_probe_rejects_invalid_target_capacity_without_bootstrap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    field: str,
+    value: object,
+    missing: bool,
+    reason: str,
+) -> None:
+    adapter = _load_adapter_module()
+
+    def forbidden_bootstrap(*_args, **_kwargs):
+        raise AssertionError("target rejection must precede Edge-LLM bootstrap")
+
+    for name in (
+        "_software_profile_reason",
+        "_resolve_tensorrt",
+        "_resolve_cuda",
+        "_resolve_edge_source",
+        "_resolve_edge_dependency",
+        "_run_checked",
+    ):
+        monkeypatch.setattr(adapter, name, forbidden_bootstrap)
+    monkeypatch.delenv(adapter._ACTIVE_CUDA_DEVICE_ENV, raising=False)
+
+    payload = _request().to_json()
+    if missing:
+        payload["target"].pop(field)
+    else:
+        payload["target"][field] = value
+    payload["implementation_id"] = adapter.IMPLEMENTATION_ID
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert adapter.main(["probe", "--request", str(request_path)]) == 0
+    response = json.loads(capsys.readouterr().out)
+    assert response["schema_version"] == 1
+    assert response["supported"] is False
+    assert reason in response["reason"]
+
+
+def test_probe_accepts_exact_minimum_target_memory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    adapter = _load_adapter_module()
+    software_checks: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        adapter,
+        "_software_profile_reason",
+        lambda parameters: software_checks.append(dict(parameters)) or "",
+    )
+    monkeypatch.delenv(adapter._ACTIVE_CUDA_DEVICE_ENV, raising=False)
+
+    payload = _request(target=_target(gpu_memory_mib=80000)).to_json()
+    payload["implementation_id"] = adapter.IMPLEMENTATION_ID
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert adapter.main(["probe", "--request", str(request_path)]) == 0
+    response = json.loads(capsys.readouterr().out)
+    assert response == {
+        "profile_id": PROFILE_ID,
+        "schema_version": 1,
+        "supported": True,
+    }
+    assert software_checks == [{}]
+
+
+def test_established_mc_defaults_do_not_change_the_requested_profile() -> None:
+    import inspect
+
+    from tensorrt_model_connect.engine_builder import build
+
+    defaults = {
+        name: parameter.default
+        for name, parameter in inspect.signature(build).parameters.items()
+        if name not in {"model_id_or_path", "output_path"}
+    }
+
+    reason = _load_adapter_module()._public_option_reason(defaults)
+    assert "requires public option max_batch_size=4; got 1" in reason
+
+
+@pytest.mark.parametrize("value", (None, False, "", (), [], {}))
+def test_future_inert_public_option_does_not_couple_to_this_adapter(value) -> None:
+    reason = _load_adapter_module()._public_option_reason({"future_option": value})
+    assert reason == ""
+
+
+def test_future_non_inert_public_option_remains_fail_closed() -> None:
+    reason = _load_adapter_module()._public_option_reason({"future_option": "requested"})
+    assert "does not recognize public option(s): future_option" in reason
+
+
+def test_public_cli_requires_the_exact_qualified_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tensorrt_model_connect.build_cli as build_cli
+
+    captured = {}
+
+    def capture(args) -> int:
+        captured["args"] = args
+        return 0
+
+    monkeypatch.setattr(build_cli, "_cmd_build", capture)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["trtmc", "build", MODEL_ID, "-o", "/tmp/nemotron3-edge-test.trtfb"],
+    )
+    with pytest.raises(SystemExit) as exit_info:
+        build_cli.main()
+
+    assert exit_info.value.code == 0
+    options = build_cli._optimized_cli_public_options(captured["args"])
+    reason = _load_adapter_module()._public_option_reason(options)
+    assert "requires public option max_batch_size=4; got 1" in reason
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "trtmc",
+            "build",
+            MODEL_ID,
+            "-o",
+            "/tmp/nemotron3-edge-test.trtfb",
+            "--precision",
+            "fp16",
+            "--max-cache-length",
+            "4096",
+            "--max-batch-size",
+            "4",
+        ],
+    )
+    with pytest.raises(SystemExit) as exit_info:
+        build_cli.main()
+
+    assert exit_info.value.code == 0
+    options = build_cli._optimized_cli_public_options(captured["args"])
+    assert _load_adapter_module()._public_option_reason(options) == ""
+
+
+@pytest.mark.parametrize("missing_module", ("modelopt", "onnx_graphsurgeon", "torch"))
+def test_qualified_probe_reports_missing_exporter_prerequisite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    missing_module: str,
+) -> None:
+    adapter = _load_adapter_module()
+    monkeypatch.setattr(adapter, "_select_parent_active_cuda_device", lambda: None)
+    monkeypatch.setattr(adapter.shutil, "which", lambda command: f"/usr/bin/{command}")
+    monkeypatch.setattr(
+        adapter.importlib.util,
+        "find_spec",
+        lambda module: None if module == missing_module else object(),
+    )
+    monkeypatch.setattr(adapter, "_resolve_tensorrt", lambda _settings: object())
+    monkeypatch.setattr(adapter, "_resolve_cuda", lambda _settings: object())
+
+    payload = _request().to_json()
+    payload["implementation_id"] = adapter.IMPLEMENTATION_ID
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert adapter.main(["probe", "--request", str(request_path)]) == 1
+    captured = capsys.readouterr()
+    assert not captured.out
+    assert (
+        f"Nemotron 3 Nano 4B Edge-LLM build prerequisites are unavailable: {missing_module}"
+        in captured.err
+    )
+
+
+def test_build_stages_explicit_engine_runtime_and_plugin_payloads(tmp_path: Path) -> None:
+    parameters = _prebuilt_runtime_parameters(tmp_path)
+    manifest = load_implementation_manifest(MANIFEST_PATH)
+    request = _request(parameters=parameters)
+
+    build = _run_build_after_probe(manifest, request, tmp_path / "capsule-output")
+
+    assert (build.artifacts_path / "engine.dir" / "llm.engine").read_bytes() == (b"fake-llm.engine")
+    assert (build.artifacts_path / RUNTIME_LIBRARY).read_bytes() == b"fake-runtime-dso"
+    assert (build.artifacts_path / RUNTIME_PLUGIN).read_bytes() == b"fake-edge-plugin"
+    assert build.descriptor["profile_id"] == PROFILE_ID
+    assert build.descriptor["operation"] == "text-generation-v1"
+    assert build.descriptor["runtime"] == {
+        "abi": 1,
+        "library": RUNTIME_LIBRARY,
+        "plugin": RUNTIME_PLUGIN,
+    }
+    assert build.descriptor["limits"] == {
+        "max_batch_size": 4,
+        "max_cache_length": 4096,
+        "max_input_length": 1024,
+        "vocab_size": 131072,
+    }
+    assert build.descriptor["versions"]["edge_llm"] == "0.6.1"
+    assert build.descriptor["versions"]["cuda"] == "12.8"
+    assert build.descriptor["bundle_config"]["runtime_provider"] == IMPLEMENTATION_ID
+    assert "metadata" not in build.descriptor
+
+    bundle = write_optimized_bundle(tmp_path / "nemotron3-edge.trtfb", manifest, request, build)
+    assert bundle.is_file()
+    assert bundle.stat().st_size > sum(
+        path.stat().st_size for path in build.artifacts_path.rglob("*") if path.is_file()
+    )
+
+
+def _different_value(value: object) -> object:
+    if value is None:
+        return "unexpected"
+    if type(value) is bool:
+        return not value
+    if type(value) is int:
+        return value + 1
+    if type(value) is float:
+        return value + 1.0
+    if type(value) is str:
+        return value + "-other"
+    raise AssertionError(f"No test mutation for {value!r}")
+
+
+@pytest.mark.parametrize("field", tuple(EXPECTED_ENGINE_MODEL_CONFIG))
+def test_engine_validation_rejects_every_model_fingerprint_field(
+    tmp_path: Path, field: str
+) -> None:
+    adapter = _load_adapter_module()
+    engine = _fake_engine(tmp_path / "sibling-engine")
+    config_path = engine / "config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config[field] = _different_value(config[field])
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(adapter.AdapterError, match=rf"config\.{field} must be exactly"):
+        adapter._validate_engine_directory(engine)
+
+
+def test_engine_validation_rejects_missing_nullable_rope_scaling(tmp_path: Path) -> None:
+    adapter = _load_adapter_module()
+    engine = _fake_engine(tmp_path / "missing-rope-scaling-engine")
+    config_path = engine / "config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    del config["rope_scaling"]
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(adapter.AdapterError, match=r"config\.rope_scaling must be exactly None"):
+        adapter._validate_engine_directory(engine)
+
+
+@pytest.mark.parametrize("reduced_vocab_size", (None, 0, 1, False, "0"))
+def test_engine_validation_allows_only_null_reduced_vocab_size(
+    tmp_path: Path, reduced_vocab_size: object
+) -> None:
+    adapter = _load_adapter_module()
+    engine = _fake_engine(tmp_path / "reduced-vocab-engine")
+    config_path = engine / "config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["reduced_vocab_size"] = reduced_vocab_size
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    if reduced_vocab_size is None:
+        assert (
+            adapter._validate_engine_directory(engine)[1]
+            == EXPECTED_ENGINE_MODEL_CONFIG["vocab_size"]
+        )
+    else:
+        with pytest.raises(
+            adapter.AdapterError, match=r"reduced_vocab_size must be absent or null"
+        ):
+            adapter._validate_engine_directory(engine)
+
+
+@pytest.mark.parametrize("field", tuple(EXPECTED_ENGINE_BUILDER_CONFIG))
+def test_engine_validation_rejects_every_builder_fingerprint_field(
+    tmp_path: Path, field: str
+) -> None:
+    adapter = _load_adapter_module()
+    engine = _fake_engine(tmp_path / "wrong-builder-engine")
+    config_path = engine / "config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["builder_config"][field] = _different_value(config["builder_config"][field])
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(adapter.AdapterError, match=rf"builder_config\.{field} must be exactly"):
+        adapter._validate_engine_directory(engine)
+
+
+@pytest.mark.parametrize("filename", REQUIRED_ENGINE_FILES)
+def test_engine_validation_rejects_each_missing_required_artifact(
+    tmp_path: Path, filename: str
+) -> None:
+    adapter = _load_adapter_module()
+    engine = _fake_engine(tmp_path / "incomplete-engine")
+    (engine / filename).unlink()
+
+    with pytest.raises(
+        adapter.AdapterError, match=rf"missing required artifact {re.escape(filename)}"
+    ):
+        adapter._validate_engine_directory(engine)
+
+
+def test_qualified_probe_reports_wrong_tensorrt_without_bootstrapping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    adapter = _load_adapter_module()
+
+    def wrong_tensorrt(_runtime_build):
+        raise adapter.AdapterError("found TensorRT 11.2.0.113, not 10.14.1.48")
+
+    def forbidden_bootstrap(*_args, **_kwargs):
+        raise AssertionError("unsupported probe must not bootstrap Edge-LLM")
+
+    monkeypatch.setattr(adapter, "_resolve_tensorrt", wrong_tensorrt)
+    monkeypatch.setattr(adapter.shutil, "which", lambda command: f"/usr/bin/{command}")
+    monkeypatch.setattr(adapter.importlib.util, "find_spec", lambda _module: object())
+    monkeypatch.setattr(adapter, "_resolve_cuda", forbidden_bootstrap)
+    monkeypatch.setattr(adapter, "_resolve_edge_source", forbidden_bootstrap)
+    monkeypatch.setattr(adapter, "_resolve_edge_dependency", forbidden_bootstrap)
+    monkeypatch.setattr(adapter, "_run_checked", forbidden_bootstrap)
+
+    payload = _request().to_json()
+    payload["implementation_id"] = adapter.IMPLEMENTATION_ID
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert adapter.main(["probe", "--request", str(request_path)]) == 1
+    captured = capsys.readouterr()
+    assert not captured.out
+    assert "TensorRT 11.2.0.113" in captured.err
+
+
+def test_tensorrt_resolution_requires_one_exact_core_and_parser_installation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = _load_adapter_module()
+    include = tmp_path / "include"
+    include.mkdir()
+    (include / "NvInfer.h").write_text("// fixture\n", encoding="utf-8")
+    version_header = include / "NvInferVersion.h"
+    version_header.write_text(
+        "#define NV_TENSORRT_MAJOR 10\n"
+        "#define NV_TENSORRT_MINOR 14\n"
+        "#define NV_TENSORRT_PATCH 1\n"
+        "#define NV_TENSORRT_BUILD 48\n",
+        encoding="utf-8",
+    )
+    (include / "NvOnnxParser.h").write_text("// fixture\n", encoding="utf-8")
+    library_dir = tmp_path / "lib"
+    library_dir.mkdir()
+    core = library_dir / "libnvinfer.so.10.14.1.48"
+    parser = library_dir / "libnvonnxparser.so.10"
+    core.write_bytes(b"exact TensorRT core")
+    parser.write_bytes(b"exact TensorRT parser")
+    runtime_build = {
+        "tensorrt_include_dir": str(include),
+        "tensorrt_library": str(core),
+        "onnx_parser_include_dir": str(include),
+        "onnx_parser_library": str(parser),
+    }
+    monkeypatch.setattr(adapter, "_library_tensorrt_version", lambda _library: (10, 14, 1, 48))
+
+    resolved = adapter._resolve_tensorrt(runtime_build)
+    assert resolved.library == core
+    assert resolved.onnx_parser_library == parser
+
+    version_header.write_text(
+        version_header.read_text(encoding="utf-8").replace(
+            "#define NV_TENSORRT_BUILD 48", "#define NV_TENSORRT_BUILD 47"
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(adapter.AdapterError, match="10.14.1.47, not 10.14.1.48"):
+        adapter._resolve_tensorrt(runtime_build)
+
+
+@pytest.mark.parametrize(
+    ("header_version", "compiler_version"),
+    ((13000, "12.8"), (12080, "13.0")),
+)
+def test_cuda_resolution_rejects_unsupported_toolkit_components(
+    tmp_path: Path,
+    header_version: int,
+    compiler_version: str,
+) -> None:
+    adapter = _load_adapter_module()
+    include, _compiler, cudart = _make_cuda_toolkit(
+        tmp_path / "cuda",
+        encoded_header_version=header_version,
+        compiler_version=compiler_version,
+    )
+
+    with pytest.raises(adapter.AdapterError, match=r"not 12\.8"):
+        adapter._resolve_cuda({"cuda_include_dir": str(include), "cudart_library": str(cudart)})
+
+
+def test_cuda_resolution_pins_one_coherent_12_8_toolkit(tmp_path: Path) -> None:
+    adapter = _load_adapter_module()
+    cuda_root = tmp_path / "cuda"
+    include, compiler, cudart = _make_cuda_toolkit(cuda_root)
+
+    resolved = adapter._resolve_cuda(
+        {"cuda_include_dir": str(include), "cudart_library": str(cudart)}
+    )
+
+    assert resolved.root == cuda_root.resolve()
+    assert resolved.include_dir == include.resolve()
+    assert resolved.cudart_library == cudart.resolve()
+    assert resolved.compiler == compiler.resolve()
+    assert resolved.version == "12.8"
+
+    other_root = tmp_path / "other-cuda"
+    _other_include, _other_compiler, other_cudart = _make_cuda_toolkit(other_root)
+    with pytest.raises(adapter.AdapterError, match="same exact CUDA 12.8 toolkit"):
+        adapter._resolve_cuda(
+            {"cuda_include_dir": str(include), "cudart_library": str(other_cudart)}
+        )
+
+
+def test_selected_build_lazily_clones_exact_edge_tag_and_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("_TRTMC_INTERNAL_OPTIMIZED_RUNTIME_DEPENDENCY_ROOT", raising=False)
+    adapter = _load_adapter_module()
+    output = tmp_path / "output"
+    output.mkdir()
+    acquired = output / ".edge-source"
+    commands: list[list[str]] = []
+
+    def validate(path: Path) -> Path:
+        if path == acquired and len(commands) == 3:
+            return acquired
+        raise adapter.AdapterError("source not present")
+
+    monkeypatch.setattr(adapter, "_validate_edge_source", validate)
+    monkeypatch.setattr(
+        adapter, "_run_checked", lambda command, _description: commands.append(command)
+    )
+
+    assert commands == []
+    assert adapter._resolve_edge_source(output, {}) == acquired
+    assert commands[0] == [
+        "git",
+        "clone",
+        "--branch",
+        "v0.6.1",
+        "--single-branch",
+        "--no-checkout",
+        EDGE_SOURCE,
+        str(acquired),
+    ]
+    assert commands[1][-2:] == ["--detach", EDGE_COMMIT]
+    assert commands[2][-4:] == ["submodule", "update", "--init", "--recursive"]
+
+
+def test_selected_build_uses_ci_staged_pinned_dependency(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = _load_adapter_module()
+    dependency_root = tmp_path / "dependencies"
+    cached = dependency_root / "tensorrt-edge-llm" / EDGE_COMMIT
+    cached.mkdir(parents=True)
+    monkeypatch.setenv("_TRTMC_INTERNAL_OPTIMIZED_RUNTIME_DEPENDENCY_ROOT", str(dependency_root))
+    monkeypatch.setattr(adapter, "_validate_edge_source", lambda path: path.resolve())
+    monkeypatch.setattr(
+        adapter,
+        "_run_checked",
+        lambda *_args: pytest.fail("a staged CI dependency must not be fetched again"),
+    )
+
+    assert adapter._resolve_edge_source(tmp_path / "output", {}) == cached.resolve()
+
+
+def test_edge_source_requires_the_pinned_clean_source_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = _load_adapter_module()
+    source = _make_edge_source(tmp_path / "edge-source")
+    source_status = {"value": ""}
+
+    def inspect(command: list[str], _description: str) -> str:
+        if command[-2:] == ["rev-parse", "HEAD"]:
+            return EDGE_COMMIT
+        if command[-3:] == ["remote", "get-url", "origin"]:
+            return EDGE_SOURCE
+        if "status" in command and "submodule" not in command:
+            return source_status["value"]
+        return ""
+
+    monkeypatch.setattr(adapter, "_run_capture", inspect)
+    assert adapter._validate_edge_source(source) == source.resolve()
+
+    source_status["value"] = " M cpp/common/version.h"
+    with pytest.raises(adapter.AdapterError, match="must have no tracked, untracked, or ignored"):
+        adapter._validate_edge_source(source)
+
+
+def test_build_can_compile_the_capsule_runtime_only_after_selection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    engine = _fake_engine(tmp_path / "prebuilt-engine")
+    plugin = tmp_path / "plugin-source.so"
+    plugin.write_bytes(b"fake-edge-plugin")
+    monkeypatch.setenv("_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_ALLOW_FAKE_RUNTIME_BUILD", "1")
+    manifest = load_implementation_manifest(MANIFEST_PATH)
+    request = _request(
+        parameters={
+            "engine_dir": str(engine),
+            "runtime_plugin": str(plugin),
+            "runtime_build": {
+                "fake": True,
+                "parallel": 2,
+                "nlohmann_json_include_dir": str(_nlohmann_json_include()),
+            },
+        }
+    )
+
+    output = tmp_path / "capsule-output"
+    build = _run_build_after_probe(manifest, request, output)
+
+    runtime = build.artifacts_path / RUNTIME_LIBRARY
+    assert runtime.read_bytes().startswith(b"\x7fELF")
+    assert not (output / ".runtime-build").exists()
+
+
+def test_selected_build_builds_only_required_edge_targets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = _load_adapter_module()
+    source = tmp_path / "edge-source"
+    source.mkdir()
+    trt_include = tmp_path / "trt-include"
+    trt_include.mkdir()
+    trt_library = tmp_path / "libnvinfer.so.10"
+    trt_library.write_bytes(b"trt")
+    onnx_library = tmp_path / "libnvonnxparser.so.10"
+    onnx_library.write_bytes(b"onnx")
+    cuda_root = tmp_path / "cuda"
+    cuda_include = cuda_root / "include"
+    cuda_include.mkdir(parents=True)
+    cudart = cuda_root / "libcudart.so"
+    cudart.write_bytes(b"cudart")
+    cuda_compiler = cuda_root / "bin" / "nvcc"
+    cuda_compiler.parent.mkdir()
+    cuda_compiler.write_bytes(b"nvcc")
+    tensorrt = adapter._TensorRtInstallation(trt_include, trt_library, trt_include, onnx_library)
+    cuda = adapter._CudaInstallation(cuda_root, cuda_include, cudart, cuda_compiler, "12.8")
+    calls: list[list[str]] = []
+    validated_sources: list[Path] = []
+
+    monkeypatch.setattr(adapter, "_resolve_edge_source", lambda *_args: source)
+    monkeypatch.setattr(adapter, "_resolve_tensorrt", lambda _settings: tensorrt)
+    monkeypatch.setattr(adapter, "_resolve_cuda", lambda _settings: cuda)
+    monkeypatch.setattr(
+        adapter,
+        "_validate_edge_source",
+        lambda path: validated_sources.append(path) or path,
+    )
+
+    def fake_run(command: list[str], _description: str) -> None:
+        calls.append(command)
+        build_dir = tmp_path / "output" / ".edge-dependency-build"
+        if command[:2] == ["cmake", "-S"]:
+            build_dir.mkdir(parents=True)
+            (build_dir / "CMakeCache.txt").write_text(
+                "\n".join(
+                    (
+                        f"CMAKE_HOME_DIRECTORY:INTERNAL={source}",
+                        "CMAKE_BUILD_TYPE:STRING=Release",
+                        f"TRT_INCLUDE_DIR:PATH={trt_include}",
+                        f"NVINFER_LIB:FILEPATH={trt_library}",
+                        f"ONNX_PARSER_INCLUDE_DIR:PATH={trt_include}",
+                        f"NV_ONNX_PARSER_LIB:FILEPATH={onnx_library}",
+                        f"CUDA_RUNTIME_API_INCLUDE_DIR:PATH={cuda_include}",
+                        f"CUDART_LIB:FILEPATH={cudart}",
+                        f"CMAKE_CUDA_COMPILER:FILEPATH={cuda_compiler}",
+                    )
+                ),
+                encoding="utf-8",
+            )
+            return
+        for product in (
+            build_dir / "cpp" / "libedgellmCore.a",
+            build_dir / "cpp" / "libedgellmTokenizer.a",
+            build_dir / "libNvInfer_edgellm_plugin.so.1.0",
+            build_dir / "examples" / "llm" / "llm_build",
+        ):
+            product.parent.mkdir(parents=True, exist_ok=True)
+            product.write_bytes(b"product")
+
+    monkeypatch.setattr(adapter, "_run_checked", fake_run)
+    output = tmp_path / "output"
+
+    assert calls == []
+    dependency = adapter._resolve_edge_dependency(output, {"parallel": 3})
+
+    assert dependency.source_dir == source
+    assert dependency.build_tool.name == "llm_build"
+    assert validated_sources == [source, source]
+    assert calls[1][-5:] == [
+        "--target",
+        "edgellmCore",
+        "edgellmTokenizer",
+        "NvInfer_edgellm_plugin",
+        "llm_build",
+    ]
+    reused = adapter._resolve_edge_dependency(
+        output,
+        {"parallel": 3, "edge_llm_build_dir": str(dependency.build_dir)},
+    )
+    assert reused.build_dir == dependency.build_dir
+    assert len(calls) == 2
+
+
+def test_engine_export_uses_pinned_dependency_tools_despite_ambient_poison(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = _load_adapter_module()
+    source = tmp_path / "edge-source"
+    export_script = source / "tensorrt_edgellm" / "scripts" / "export_llm.py"
+    export_script.parent.mkdir(parents=True)
+    export_script.write_text("# pinned exporter\n", encoding="utf-8")
+    build_dir = tmp_path / "edge-build"
+    build_tool = build_dir / "examples" / "llm" / "llm_build"
+    build_tool.parent.mkdir(parents=True)
+    build_tool.write_bytes(b"tool")
+    plugin = build_dir / "libNvInfer_edgellm_plugin.so.1.0"
+    plugin.write_bytes(b"plugin")
+    placeholder = tmp_path / "placeholder"
+    placeholder.write_bytes(b"x")
+    include = tmp_path / "include"
+    include.mkdir()
+    dependency = adapter._EdgeDependency(
+        source,
+        build_dir,
+        build_tool,
+        plugin,
+        adapter._TensorRtInstallation(include, placeholder, include, placeholder),
+        adapter._CudaInstallation(tmp_path, include, placeholder, placeholder, "12.8"),
+    )
+    model_source = tmp_path / "model"
+    model_source.mkdir()
+    poison_bin = tmp_path / "poison-bin"
+    poison_bin.mkdir()
+    for name in ("tensorrt-edgellm-export-llm", "llm_build"):
+        poison_tool = poison_bin / name
+        poison_tool.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
+        poison_tool.chmod(0o755)
+    ambient_python = tmp_path / "ambient-python"
+    ambient_package = ambient_python / "tensorrt_edgellm" / "__init__.py"
+    ambient_package.parent.mkdir(parents=True)
+    ambient_package.write_text("raise RuntimeError('ambient poison')\n", encoding="utf-8")
+    invocations: list[tuple[list[str], object]] = []
+    validated_sources: list[Path] = []
+
+    monkeypatch.setattr(adapter, "_probe_build_device", lambda: None)
+    monkeypatch.setattr(adapter, "_materialize_model_source", lambda _source: model_source)
+    monkeypatch.setattr(
+        adapter,
+        "_validate_edge_source",
+        lambda path: validated_sources.append(path) or path,
+    )
+    monkeypatch.setenv("PATH", str(poison_bin))
+    monkeypatch.setenv("PYTHONPATH", str(ambient_python))
+
+    def fake_tool(command, *, verbose, environment=None):
+        del verbose
+        invocations.append((command, environment))
+        engine_argument = next((item for item in command if item.startswith("--engineDir=")), None)
+        if engine_argument is None:
+            return
+        engine = Path(engine_argument.split("=", 1)[1])
+        _fake_engine_contents = {
+            **EXPECTED_ENGINE_MODEL_CONFIG,
+            "edgellm_version": "0.6.1",
+            "builder_config": EXPECTED_ENGINE_BUILDER_CONFIG,
+        }
+        (engine / "config.json").write_text(json.dumps(_fake_engine_contents), encoding="utf-8")
+        for filename in REQUIRED_ENGINE_FILES:
+            (engine / filename).write_bytes(b"artifact")
+
+    monkeypatch.setattr(adapter, "_run_tool", fake_tool)
+    engine, _vocab_size, attempt = adapter._build_or_resolve_engine(
+        {}, tmp_path / "output", dependency, plugin
+    )
+
+    assert engine.name == "engine.dir"
+    # EdgeLLM v0.6.1 obtains the 4B model's chat template from the pinned
+    # checkpoint. Only the older 9B Nemotron profile needs --chat_template.
+    assert invocations[0][0] == [
+        sys.executable,
+        str(export_script),
+        f"--model_dir={model_source}",
+        f"--output_dir={attempt / 'onnx'}",
+        "--device=cuda",
+    ]
+    assert invocations[0][1]["PYTHONPATH"] == str(source)
+    assert str(ambient_python) not in invocations[0][1]["PYTHONPATH"]
+    assert invocations[0][1]["PYTHONDONTWRITEBYTECODE"] == "1"
+    assert invocations[0][1]["PYTHONNOUSERSITE"] == "1"
+    assert invocations[1][0][0] == str(build_tool)
+    assert invocations[1][1]["EDGELLM_PLUGIN_PATH"] == str(plugin)
+    assert validated_sources == [source, source, source]
+    assert attempt is not None
+
+
+def test_engine_build_revalidates_source_after_each_tool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = _load_adapter_module()
+    source = tmp_path / "edge-source"
+    export_script = source / "tensorrt_edgellm" / "scripts" / "export_llm.py"
+    export_script.parent.mkdir(parents=True)
+    export_script.write_text("# pinned exporter\n", encoding="utf-8")
+    build_dir = tmp_path / "edge-build"
+    build_tool = build_dir / "examples" / "llm" / "llm_build"
+    build_tool.parent.mkdir(parents=True)
+    build_tool.write_bytes(b"tool")
+    plugin = build_dir / "libNvInfer_edgellm_plugin.so.1.0"
+    plugin.write_bytes(b"plugin")
+    placeholder = tmp_path / "placeholder"
+    placeholder.write_bytes(b"x")
+    include = tmp_path / "include"
+    include.mkdir()
+    dependency = adapter._EdgeDependency(
+        source,
+        build_dir,
+        build_tool,
+        plugin,
+        adapter._TensorRtInstallation(include, placeholder, include, placeholder),
+        adapter._CudaInstallation(tmp_path, include, placeholder, placeholder, "12.8"),
+    )
+    model_source = tmp_path / "model"
+    model_source.mkdir()
+    mutation = source / "post-build-poison.py"
+    validations: list[Path] = []
+    tool_calls: list[list[str]] = []
+
+    monkeypatch.setattr(adapter, "_probe_build_device", lambda: None)
+    monkeypatch.setattr(adapter, "_materialize_model_source", lambda _source: model_source)
+
+    def validate(path: Path) -> Path:
+        validations.append(path)
+        if mutation.exists():
+            raise adapter.AdapterError("post-build pinned-source mutation")
+        return path
+
+    def mutate_after_build(command, *, verbose, environment=None):
+        del verbose, environment
+        tool_calls.append(command)
+        if command[0] == str(build_tool):
+            mutation.write_text("poison\n", encoding="utf-8")
+
+    monkeypatch.setattr(adapter, "_validate_edge_source", validate)
+    monkeypatch.setattr(adapter, "_run_tool", mutate_after_build)
+
+    output = tmp_path / "output"
+    with pytest.raises(adapter.AdapterError, match="post-build pinned-source mutation"):
+        adapter._build_or_resolve_engine({}, output, dependency, plugin)
+
+    assert len(tool_calls) == 2
+    assert validations == [source, source, source]
+    workspace = output / ".edge-build-workspace"
+    assert workspace.is_dir()
+    assert not any(workspace.iterdir())
+
+
+def test_verbose_edge_tool_logs_never_pollute_json_stdout(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    adapter = _load_adapter_module()
+    completed = subprocess.CompletedProcess(
+        ["edge-tool"],
+        returncode=0,
+        stdout="child stdout\n",
+        stderr="child stderr\n",
+    )
+    monkeypatch.setattr(adapter.subprocess, "run", lambda *_args, **_kwargs: completed)
+
+    adapter._run_tool(["edge-tool"], verbose=True)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "child stdout\nchild stderr\n"

--- a/tests/e2e/models/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/test_nemotron3_nano_4b_edge_runtime_contract.py
+++ b/tests/e2e/models/nemotron_h/nemotron3_nano_4b_edge_llm_adapter/test_nemotron3_nano_4b_edge_runtime_contract.py
@@ -1,0 +1,547 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compile and exercise this capsule's DSO contract without CUDA or Edge-LLM."""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[5]
+CAPSULE_ROOT = (
+    REPOSITORY_ROOT
+    / "python"
+    / "tensorrt_model_connect"
+    / "families"
+    / "nemotron_h"
+    / "nemotron3_nano_4b_edge_llm_adapter"
+)
+RUNTIME_ROOT = (
+    REPOSITORY_ROOT
+    / "src"
+    / "runtime"
+    / "models"
+    / "nemotron_h"
+    / "nemotron3_nano_4b_edge_llm_adapter"
+)
+PYTHON_ROOT = REPOSITORY_ROOT / "python"
+if str(PYTHON_ROOT) not in sys.path:
+    sys.path.insert(0, str(PYTHON_ROOT))
+
+from tensorrt_model_connect.runtime_provider.provider_process import (  # noqa: E402
+    ImplementationRequest,
+    run_build,
+    run_probe,
+)
+from tensorrt_model_connect.runtime_provider.manifest import (  # noqa: E402
+    load_implementation_manifest,
+    manifest_contract_sha256,
+)
+
+
+IMPLEMENTATION_ID = "nemotron3-nano-4b-fp16.tensorrt-edge-llm.a100-pcie80-sm80"
+MODEL_ID = "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16"
+MODEL_REVISION = "dfaf35de3e30f1867dd8dbc38a7fc9fb52d3914f"
+PROFILE_ID = "nemotron3-nano-4b-fp16--a100-pcie80-sm80"
+RUNTIME_LIBRARY = "libtrtmc_impl_nemotron3_nano_4b_fp16_tensorrt_edge_llm.so"
+EXPECTED_ENGINE_MODEL_CONFIG = {
+    "model": "nemotronh",
+    "model_type": "hybrid_mamba",
+    "vocab_size": 131072,
+    "max_position_embeddings": 262144,
+    "hidden_size": 3136,
+    "intermediate_size": 12544,
+    "num_hidden_layers": 42,
+    "num_attention_heads": 40,
+    "num_key_value_heads": 8,
+    "head_dim": 128,
+    "num_mamba_layers": 21,
+    "num_attention_layers": 4,
+    "mamba_num_heads": 96,
+    "mamba_head_dim": 80,
+    "ssm_state_size": 128,
+    "conv_dim": 9728,
+    "conv_kernel": 4,
+    "use_rope": False,
+    "rope_theta": 10000.0,
+    "rope_scaling": None,
+    "partial_rotary_factor": 1.0,
+    "trt_native_ops": False,
+}
+EXPECTED_ENGINE_BUILDER_CONFIG = {
+    "max_input_len": 1024,
+    "max_kv_cache_capacity": 4096,
+    "max_batch_size": 4,
+    "eagle_draft": False,
+    "eagle_base": False,
+    "max_lora_rank": 0,
+    "trt_native_ops": False,
+}
+
+
+class CreateRequest(ctypes.Structure):
+    _fields_ = [
+        ("abi_version", ctypes.c_uint32),
+        ("struct_size", ctypes.c_uint32),
+        ("implementation_id", ctypes.c_char_p),
+        ("model_id", ctypes.c_char_p),
+        ("profile_id", ctypes.c_char_p),
+        ("bundle_path", ctypes.c_char_p),
+        ("artifact_path", ctypes.c_char_p),
+        ("implementation_metadata", ctypes.c_char_p),
+        ("implementation_metadata_size", ctypes.c_size_t),
+        ("load_options", ctypes.c_void_p),
+    ]
+
+
+class FactoryV1(ctypes.Structure):
+    _fields_ = [
+        ("abi_version", ctypes.c_uint32),
+        ("struct_size", ctypes.c_uint32),
+        ("implementation_id", ctypes.c_char_p),
+        ("runtime_name", ctypes.c_char_p),
+        ("runtime_version", ctypes.c_char_p),
+        ("runtime_commit", ctypes.c_char_p),
+        ("create", ctypes.c_void_p),
+        ("pipeline_abi_version", ctypes.c_uint32),
+    ]
+
+
+CreateFn = ctypes.CFUNCTYPE(
+    ctypes.c_void_p,
+    ctypes.POINTER(CreateRequest),
+    ctypes.POINTER(ctypes.c_char),
+    ctypes.c_size_t,
+)
+
+
+def _nlohmann_json_include() -> Path:
+    configured = os.environ.get("_TRTMC_INTERNAL_NEMOTRON3_NANO_4B_NLOHMANN_JSON_INCLUDE_DIR", "")
+    trtmc_binary = os.environ.get("TRTMC_BINARY", "")
+    candidates = (
+        ([Path(configured)] if configured else [])
+        + (
+            [Path(trtmc_binary).resolve().parent / "_deps/nlohmann_json-src/include"]
+            if trtmc_binary
+            else []
+        )
+        + [Path("/usr/include")]
+        + sorted(REPOSITORY_ROOT.glob("build*/_deps/nlohmann_json-src/include"))
+    )
+    for candidate in candidates:
+        if (candidate / "nlohmann" / "json.hpp").is_file():
+            return candidate.resolve()
+    pytest.fail(
+        "Nemotron 3 Nano 4B fake-runtime tests require MC's provisioned nlohmann_json include; "
+        "set _TRTMC_INTERNAL_NEMOTRON3_NANO_4B_NLOHMANN_JSON_INCLUDE_DIR"
+    )
+
+
+def _run(command: list[str]) -> None:
+    result = subprocess.run(command, text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        pytest.fail(
+            f"command failed ({result.returncode}): {' '.join(command)}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+def _build_fake_runtime(
+    build: Path, *, tensorrt_build: int = 48, cuda_runtime_version: int = 12080
+) -> Path:
+    json_include = _nlohmann_json_include()
+    manifest = load_implementation_manifest(CAPSULE_ROOT / "IMPLEMENTATION.toml")
+    _run(
+        [
+            "cmake",
+            "-S",
+            str(RUNTIME_ROOT),
+            "-B",
+            str(build),
+            "-DTRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_RUNTIME=ON",
+            (
+                "-DTRTMC_NEMOTRON3_NANO_4B_SDK_INCLUDE_DIRS="
+                f"{REPOSITORY_ROOT / 'src'};{REPOSITORY_ROOT / 'include'}"
+            ),
+            f"-DTRTMC_NEMOTRON3_NANO_4B_NLOHMANN_JSON_INCLUDE_DIR={json_include}",
+            f"-DTRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_TENSORRT_BUILD={tensorrt_build}",
+            f"-DTRTMC_NEMOTRON3_NANO_4B_EDGE_FAKE_CUDA_RUNTIME_VERSION={cuda_runtime_version}",
+            (
+                "-DTRTMC_NEMOTRON3_NANO_4B_EDGE_MANIFEST_SHA256="
+                f"{manifest_contract_sha256(manifest)}"
+            ),
+            "-DCMAKE_BUILD_TYPE=Release",
+        ]
+    )
+    _run(["cmake", "--build", str(build), "--parallel", "2"])
+    runtime = build / RUNTIME_LIBRARY
+    assert runtime.is_file()
+    (build / "libNvInfer_edgellm_plugin.so").write_bytes(b"fake-plugin-contract")
+    return runtime
+
+
+@pytest.fixture(scope="module")
+def fake_runtime(tmp_path_factory) -> Path:
+    return _build_fake_runtime(tmp_path_factory.mktemp("nemotron3-edge-runtime-build"))
+
+
+def _fake_engine(root: Path) -> Path:
+    root.mkdir()
+    (root / "config.json").write_text(
+        json.dumps(
+            {
+                **EXPECTED_ENGINE_MODEL_CONFIG,
+                "edgellm_version": "0.6.1",
+                "builder_config": EXPECTED_ENGINE_BUILDER_CONFIG,
+            }
+        ),
+        encoding="utf-8",
+    )
+    for filename in (
+        "llm.engine",
+        "embedding.safetensors",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "processed_chat_template.json",
+    ):
+        (root / filename).write_bytes(filename.encode("utf-8"))
+    return root
+
+
+def _staged_capsule(tmp_path: Path, fake_runtime: Path):
+    engine = _fake_engine(tmp_path / "engine")
+    plugin = fake_runtime.parent / "libNvInfer_edgellm_plugin.so"
+    manifest = load_implementation_manifest(CAPSULE_ROOT / "IMPLEMENTATION.toml")
+    request = ImplementationRequest(
+        model_id=MODEL_ID,
+        model_revision=MODEL_REVISION,
+        target={
+            "os": "linux",
+            "architecture": "x86_64",
+            "platform_kind": "discrete",
+            "gpu_architecture": "sm80",
+            "gpu_memory_mib": 81152,
+            "gpu_count": 8,
+            "gpu_name": "NVIDIA A100 80GB PCIe",
+        },
+        parameters={
+            "engine_dir": str(engine),
+            "runtime_library": str(fake_runtime),
+            "runtime_plugin": str(plugin),
+        },
+    )
+    probe = run_probe(manifest, request)
+    assert probe.supported
+    return run_build(manifest, request, tmp_path / "capsule", probe=probe), request
+
+
+def _create_request(artifact, metadata: dict) -> tuple[CreateRequest, bytes]:
+    metadata_bytes = json.dumps(metadata, sort_keys=True).encode("utf-8")
+    request = CreateRequest(
+        abi_version=1,
+        struct_size=ctypes.sizeof(CreateRequest),
+        implementation_id=IMPLEMENTATION_ID.encode(),
+        model_id=MODEL_ID.encode(),
+        profile_id=PROFILE_ID.encode(),
+        bundle_path=b"fake.trtfb",
+        artifact_path=str(artifact.artifacts_path).encode(),
+        implementation_metadata=metadata_bytes,
+        implementation_metadata_size=len(metadata_bytes),
+        load_options=None,
+    )
+    return request, metadata_bytes
+
+
+def _mutable_descriptor(artifact) -> dict:
+    return json.loads(json.dumps(dict(artifact.descriptor)))
+
+
+def _rejected_create(artifact, metadata: dict) -> bytes:
+    library = ctypes.CDLL(str(artifact.artifacts_path / RUNTIME_LIBRARY))
+    library.trtmc_get_optimized_runtime_factory_v1.restype = ctypes.POINTER(FactoryV1)
+    factory = library.trtmc_get_optimized_runtime_factory_v1().contents
+    create = CreateFn(factory.create)
+    create_request, metadata_bytes = _create_request(artifact, metadata)
+    assert metadata_bytes
+    error = ctypes.create_string_buffer(2048)
+    assert not create(ctypes.byref(create_request), error, len(error))
+    return error.value
+
+
+def test_fake_runtime_exports_exact_identity_and_validates_create_metadata(
+    tmp_path: Path, fake_runtime: Path
+) -> None:
+    artifact, _ = _staged_capsule(tmp_path, fake_runtime)
+    dso_path = artifact.artifacts_path / RUNTIME_LIBRARY
+    library = ctypes.CDLL(str(dso_path))
+    library.trtmc_get_optimized_runtime_factory_v1.restype = ctypes.POINTER(FactoryV1)
+    factory = library.trtmc_get_optimized_runtime_factory_v1().contents
+
+    assert factory.abi_version == 1
+    assert factory.implementation_id.decode() == IMPLEMENTATION_ID
+    assert factory.runtime_name == b"tensorrt-edge-llm"
+    assert factory.runtime_version == b"0.6.1"
+    assert factory.runtime_commit == b"2620a9768022f25dff18912db2fb92b2ef264a70"
+    assert factory.pipeline_abi_version == 1
+
+    exported = subprocess.run(
+        ["nm", "-D", "--defined-only", str(dso_path)],
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout
+    assert (
+        "trtmc_get_optimized_runtime_factory_v1@@TRTMC_NEMOTRON3_NANO_4B_EDGE_FACTORY_1" in exported
+    )
+    assert "trtmc_get_runtime_provider" not in exported
+
+    metadata_bytes = json.dumps(dict(artifact.descriptor), sort_keys=True).encode("utf-8")
+    invalid_metadata = json.loads(metadata_bytes)
+    invalid_metadata["target"]["gpu_name"] = "NVIDIA H100 80GB HBM3"
+    assert b"gpu_name" in _rejected_create(artifact, invalid_metadata)
+
+
+def test_runtime_compile_binding_matches_selected_manifest_and_profile(
+    tmp_path: Path, fake_runtime: Path
+) -> None:
+    artifact, _ = _staged_capsule(tmp_path, fake_runtime)
+    manifest = load_implementation_manifest(CAPSULE_ROOT / "IMPLEMENTATION.toml")
+    binding = artifact.descriptor["build_binding"]
+
+    assert set(binding) == {
+        "schema_version",
+        "implementation_id",
+        "manifest_sha256",
+        "request_sha256",
+        "profile_id",
+    }
+    assert binding["schema_version"] == 1
+    assert binding["manifest_sha256"] == manifest_contract_sha256(manifest)
+    assert binding["implementation_id"] == IMPLEMENTATION_ID
+    assert binding["profile_id"] == PROFILE_ID
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    (
+        ("schema_version", 2),
+        ("implementation_id", IMPLEMENTATION_ID[:-1] + "x"),
+        ("manifest_sha256", "0" * 64),
+        ("profile_id", PROFILE_ID[:-1] + "x"),
+    ),
+)
+def test_runtime_rejects_stable_build_binding_tamper(
+    tmp_path: Path,
+    fake_runtime: Path,
+    field: str,
+    replacement: object,
+) -> None:
+    artifact, _ = _staged_capsule(tmp_path, fake_runtime)
+    metadata = _mutable_descriptor(artifact)
+    original = metadata["build_binding"][field]
+    assert replacement != original
+    if isinstance(original, str) and isinstance(replacement, str):
+        assert len(replacement) == len(original)
+    metadata["build_binding"][field] = replacement
+
+    error = _rejected_create(artifact, metadata)
+    assert field.encode() in error
+
+
+@pytest.mark.parametrize("request_sha256", ("A" * 64, "0" * 63, "g" * 64))
+def test_runtime_rejects_noncanonical_request_digest(
+    tmp_path: Path,
+    fake_runtime: Path,
+    request_sha256: str,
+) -> None:
+    artifact, _ = _staged_capsule(tmp_path, fake_runtime)
+    metadata = _mutable_descriptor(artifact)
+    metadata["build_binding"]["request_sha256"] = request_sha256
+
+    error = _rejected_create(artifact, metadata)
+    assert error == (
+        b"implementation metadata build_binding field 'request_sha256' "
+        b"must be a lowercase SHA-256 digest"
+    )
+
+
+@pytest.mark.parametrize("mutation", ("extra", "missing"))
+def test_runtime_rejects_nonexact_build_binding_field_set(
+    tmp_path: Path,
+    fake_runtime: Path,
+    mutation: str,
+) -> None:
+    artifact, _ = _staged_capsule(tmp_path, fake_runtime)
+    metadata = _mutable_descriptor(artifact)
+    if mutation == "extra":
+        metadata["build_binding"]["unexpected"] = "value"
+    else:
+        del metadata["build_binding"]["request_sha256"]
+
+    error = _rejected_create(artifact, metadata)
+    assert error == b"implementation metadata build_binding has an unexpected field set"
+
+
+def test_runtime_rejects_the_wrong_loaded_tensorrt_build_before_construction(
+    tmp_path: Path,
+) -> None:
+    wrong_runtime = _build_fake_runtime(tmp_path / "wrong-trt-build", tensorrt_build=47)
+    artifact, _ = _staged_capsule(tmp_path, wrong_runtime)
+    assert _rejected_create(artifact, dict(artifact.descriptor)) == (
+        b"loaded TensorRT runtime version 10.14.1.47 is unsupported; expected 10.14.1.48"
+    )
+
+
+def test_runtime_rejects_wrong_cuda_before_plugin_validation(tmp_path: Path) -> None:
+    wrong_runtime = _build_fake_runtime(tmp_path / "wrong-cuda-runtime", cuda_runtime_version=12070)
+    artifact, _ = _staged_capsule(tmp_path, wrong_runtime)
+    (artifact.artifacts_path / "libNvInfer_edgellm_plugin.so").unlink()
+
+    assert _rejected_create(artifact, dict(artifact.descriptor)) == (
+        b"loaded CUDA runtime version 12070 is unsupported; expected 12080 (CUDA 12.8)"
+    )
+
+
+def test_runtime_rejects_missing_adjacent_plugin_payload(
+    tmp_path: Path, fake_runtime: Path
+) -> None:
+    artifact, _ = _staged_capsule(tmp_path, fake_runtime)
+    (artifact.artifacts_path / "libNvInfer_edgellm_plugin.so").unlink()
+
+    assert _rejected_create(artifact, dict(artifact.descriptor)) == (
+        b"fake capsule contract requires adjacent plugin payload"
+    )
+
+
+def test_fake_runtime_factory_returns_an_ipipeline_that_owns_generation(
+    tmp_path: Path, fake_runtime: Path
+) -> None:
+    artifact, _ = _staged_capsule(tmp_path, fake_runtime)
+    metadata = tmp_path / "implementation.json"
+    metadata.write_text(json.dumps(dict(artifact.descriptor), sort_keys=True), encoding="utf-8")
+    client = tmp_path / "factory_client.cpp"
+    client.write_text(
+        r"""
+#include "runtime/providers/optimized_runtime_factory.h"
+
+#include <dlfcn.h>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+int main(int argc, char** argv) {
+    if (argc != 4)
+        return 10;
+    void* dso = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
+    if (dso == nullptr)
+        return 11;
+    auto getter = reinterpret_cast<trtmc::internal::GetOptimizedRuntimeFactoryV1>(
+        dlsym(dso, trtmc::internal::kOptimizedRuntimeFactoryEntrypointV1));
+    if (getter == nullptr)
+        return 12;
+    const auto* factory = getter();
+    std::ifstream input(argv[3]);
+    std::string metadata((std::istreambuf_iterator<char>(input)),
+                         std::istreambuf_iterator<char>());
+    trtmc::internal::OptimizedRuntimePipelineCreateRequestV1 request{};
+    request.abi_version = trtmc::internal::kOptimizedRuntimeFactoryAbiVersionV1;
+    request.struct_size = sizeof(request);
+    request.implementation_id = factory->implementation_id;
+    request.model_id = "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16";
+    request.profile_id = "nemotron3-nano-4b-fp16--a100-pcie80-sm80";
+    request.bundle_path = "fake.trtfb";
+    request.artifact_path = argv[2];
+    request.implementation_metadata = metadata.data();
+    request.implementation_metadata_size = metadata.size();
+    char error[2048]{};
+    std::unique_ptr<trtmc::IPipeline> pipeline(factory->create(&request, error, sizeof(error)));
+    if (!pipeline)
+        throw std::runtime_error(error);
+    trtmc::GenerateConfig config;
+    config.max_new_tokens = 4;
+    config.temperature = 0.0F;
+    config.top_k = 1;
+    config.top_p = 1.0F;
+    config.use_chat_template = true;
+    config.enable_thinking = false;
+    const auto first = pipeline->generate("hello", config);
+    const auto second = pipeline->generate("world", config);
+    if (first.text != "fake:hello" || second.text != "fake:world" ||
+        first.token_ids.size() != 4 || first.prefill_ms != 0.0 || first.decode_ms != 0.0 ||
+        second.prefill_ms != 0.0 || second.decode_ms != 0.0 ||
+        pipeline->model_id() != std::string("nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16") ||
+        pipeline->pipeline_type() != std::string("Nemotron3NanoTextGenerationPipeline"))
+        return 13;
+    config.top_k = -1;
+    config.top_p = 0.8F;
+    const auto normalized = pipeline->generate("normalized", config);
+    if (normalized.text != "fake:normalized")
+        return 14;
+    config.top_p = 1.0F;
+    try {
+        (void)pipeline->generate("unsupported", config);
+        return 15;
+    } catch (const std::invalid_argument& exception) {
+        if (std::string(exception.what()) !=
+            "Nemotron 3 Nano 4B Edge-LLM 0.6.1 cannot represent top_k <= 0 with top_p == 1.0 "
+            "because it requires at least one sampling filter")
+            return 16;
+    }
+    config.top_k = 1;
+    config.min_p = 0.1F;
+    try {
+        (void)pipeline->generate("rejected", config);
+        return 17;
+    } catch (const std::invalid_argument&) {
+    }
+    config.min_p = 0.0F;
+    config.lora_adapter_id = "unsupported-adapter";
+    try {
+        (void)pipeline->generate("rejected-lora", config);
+        return 18;
+    } catch (const std::invalid_argument&) {
+    }
+    std::cout << first.text << "\n" << second.text << "\n";
+    return 0;
+}
+""".lstrip(),
+        encoding="utf-8",
+    )
+    binary = tmp_path / "factory-client"
+    _run(
+        [
+            "c++",
+            "-std=c++17",
+            f"-I{REPOSITORY_ROOT / 'src'}",
+            f"-I{REPOSITORY_ROOT / 'include'}",
+            str(client),
+            "-ldl",
+            "-pthread",
+            "-o",
+            str(binary),
+        ]
+    )
+    completed = subprocess.run(
+        [
+            str(binary),
+            str(artifact.artifacts_path / RUNTIME_LIBRARY),
+            str(artifact.artifacts_path),
+            str(metadata),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == "fake:hello\nfake:world\n"


### PR DESCRIPTION
## Summary

- Adds a model-owned EdgeLLM adapter for `nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16` at revision `dfaf35de3e30f1867dd8dbc38a7fc9fb52d3914f`.
- Pins TensorRT Edge-LLM v0.6.1 at `2620a9768022f25dff18912db2fb92b2ef264a70`.
- Selects only the qualified Linux x86_64 A100 80GB PCIe SM80 FP16 profile.
- Keeps the public CLI, Python, and C++ APIs unchanged: the model-owned build adapter delegates engine construction, packages `engine.dir`, and the model-owned runtime materializes and delegates execution.
- Changes only this model Builder, Runtime, and Test folders.

## Validation

- Local model suite: 95 passed; formatting, lint, diff, and model-impact checks clean.
- A100 E2E: public CLI/Python/C++ dispatch, load-time materialization, direct EdgeLLM token parity, and same-process multi-model sequencing passed.
- Hardened public `build -> inspect -> run` test passed with 17 meaningful generated tokens.
- MC/direct-Edge latency ratio: `0.999892583`; peak-memory ratio: `1.0` across 90 samples per surface.