### PR TITLE
perf(runtime): reuse autoregressive execution state

### DIFF
--- a/examples/trtmc_dataset_benchmark.cpp
+++ b/examples/trtmc_dataset_benchmark.cpp
@@ -398,6 +398,7 @@ int main(int argc, char** argv) {
             output << result.token_ids[token_idx];
         }
         output << "]"
+               << ",\"setup_ms\":" << std::fixed << std::setprecision(6) << result.setup_ms
                << ",\"prefill_ms\":" << std::fixed << std::setprecision(6) << result.prefill_ms
                << ",\"decode_ms\":" << std::fixed << std::setprecision(6) << result.decode_ms
                << ",\"wall_ms\":" << std::fixed << std::setprecision(6) << wall_ms

--- a/include/trtmc/pipeline.h
+++ b/include/trtmc/pipeline.h
@@ -43,6 +43,9 @@ struct TextResult {
 
     std::string text;
     std::vector<int32_t> token_ids;
+    // Time spent resetting per-request logical state and preparing reusable
+    // runtime objects before prefill begins.
+    double setup_ms{0.0};
     double prefill_ms{0.0};
     double decode_ms{0.0};
     // Populated by transcription pipelines when timestamp intervals are

--- a/include/trtmc/runtime/trt_module.h
+++ b/include/trtmc/runtime/trt_module.h
@@ -71,8 +71,9 @@ class ITrtModule {
     virtual int32_t input_rank(const std::string& /*name*/) const { return 0; }
     virtual bool input_is_dynamic(const std::string& /*name*/) const { return false; }
 
-    // Reset any per-generation execution state so consecutive generate()
-    // calls start from a known-good context. Default is no-op.
+    // Reset module-owned per-generation state without replacing the loaded
+    // execution context. Sequence state belongs to the pipeline/state object;
+    // stable TensorRT contexts, profiles, bindings, and CUDA graphs are reused.
     virtual void reset_execution_context() {}
 
     // Human-readable label used for automatic runtime timing logs.

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -302,6 +302,8 @@ void print_text_timing(const trtmc::TextResult& result) {
          << " decode_ms=" << result.decode_ms
          << " total_ms=" << (result.prefill_ms + result.decode_ms);
     std::cerr << line.str() << '\n';
+    std::cerr << std::fixed << std::setprecision(6)
+              << "[trtmc.setup_timing] setup_ms=" << result.setup_ms << '\n';
 }
 
 std::optional<std::vector<float>> read_float32_raw_file(const std::string& path,
@@ -503,12 +505,14 @@ int cmd_run(const CliArgs& args) {
         for (int w = 0; w < warmup_n; ++w)
             pipeline->generate(prompt, cfg);
 
-        std::vector<double> prefill_ms_v, decode_ms_v;
+        std::vector<double> setup_ms_v, prefill_ms_v, decode_ms_v;
+        setup_ms_v.reserve(static_cast<std::size_t>(bench_n));
         prefill_ms_v.reserve(static_cast<std::size_t>(bench_n));
         decode_ms_v.reserve(static_cast<std::size_t>(bench_n));
 
         for (int r = 0; r < bench_n; ++r) {
             auto result = pipeline->generate(prompt, cfg);
+            setup_ms_v.push_back(result.setup_ms);
             prefill_ms_v.push_back(result.prefill_ms);
             decode_ms_v.push_back(result.decode_ms);
         }
@@ -517,12 +521,14 @@ int cmd_run(const CliArgs& args) {
             return std::accumulate(v.begin(), v.end(), 0.0) / static_cast<double>(v.size());
         };
 
+        const double smean = mean(setup_ms_v);
         const double pmean = mean(prefill_ms_v);
         const double dmean = mean(decode_ms_v);
         const int ntoks = cfg.max_new_tokens;
 
         std::cerr << std::fixed << std::setprecision(2);
-        std::cerr << "[trtmc.benchmark] prefill_ms=" << pmean << " decode_ms=" << dmean
+        std::cerr << "[trtmc.benchmark] setup_ms=" << smean << " prefill_ms=" << pmean
+                  << " decode_ms=" << dmean
                   << " tokens_per_sec=" << (ntoks > 0 ? ntoks / (dmean / 1000.0) : 0.0) << '\n';
 
         auto last = pipeline->generate(prompt, trtmc::GenerateConfig{cfg});

--- a/src/runtime/backend/trt_module_impl.cpp
+++ b/src/runtime/backend/trt_module_impl.cpp
@@ -86,26 +86,6 @@ bool TrtModuleImpl::input_is_dynamic(const std::string& name) const {
     return it != buffers_.end() && it->second.is_input && it->second.is_dynamic;
 }
 
-void TrtModuleImpl::recreate_context_with_profile() {
-    delete ctx_;
-    ctx_ = engine_->createExecutionContext();
-    if (!ctx_)
-        throw std::runtime_error("[trt_module] Failed to recreate execution context");
-    if (!attach_distributed_communicator()) {
-        delete ctx_;
-        ctx_ = nullptr;
-        throw std::runtime_error("[trt_module] Failed to attach distributed communicator");
-    }
-    if (engine_->getNbOptimizationProfiles() > 0) {
-        if (!ctx_->setOptimizationProfileAsync(profile_idx_, stream_)) {
-            delete ctx_;
-            ctx_ = nullptr;
-            throw std::runtime_error("[trt_module] Failed to reset optimization profile");
-        }
-        cudaStreamSynchronize(stream_);
-    }
-}
-
 bool TrtModuleImpl::attach_distributed_communicator() {
     if (distributed_communicator_ == nullptr || ctx_ == nullptr)
         return true;
@@ -132,29 +112,13 @@ bool TrtModuleImpl::bind_tensor_address(const std::string& name, const BufferEnt
     return ok;
 }
 
-void TrtModuleImpl::rebind_buffer_to_context(const std::string& name, const BufferEntry& entry) {
-    // Fresh IExecutionContexts have neither tensor addresses nor dynamic
-    // input shapes set; replay both from our cached BufferEntry so the next
-    // enqueueV3 doesn't fail with "Not all shapes are specified".
-    if (entry.d_ptr)
-        bind_tensor_address(name, entry);
-    if (!entry.is_dynamic || entry.shape.empty())
-        return;
-    nvinfer1::Dims dims;
-    dims.nbDims = static_cast<int32_t>(entry.shape.size());
-    for (int32_t d = 0; d < dims.nbDims; ++d)
-        dims.d[d] = entry.shape[d];
-    ctx_->setInputShape(name.c_str(), dims);
-}
-
 void TrtModuleImpl::reset_execution_context() {
-    if (engine_ == nullptr)
-        return;
-    recreate_context_with_profile();
-    if (use_cuda_graph_ && cuda_graph_)
-        cuda_graph_->reset();
-    for (auto& [name, entry] : buffers_)
-        rebind_buffer_to_context(name, entry);
+    // TensorRT execution contexts contain engine/profile/binding state, not
+    // sequence-local KV or sampler state. Replacing the context here made a
+    // warm request pay context creation, profile selection, synchronization,
+    // dynamic-shape replay, and CUDA-graph recapture even when none changed.
+    // Shape changes already invalidate CUDA graphs in update_dynamic_shape(),
+    // and bind_external() updates the live context when a binding changes.
 }
 
 TrtModuleImpl::~TrtModuleImpl() {

--- a/src/runtime/backend/trt_module_impl.h
+++ b/src/runtime/backend/trt_module_impl.h
@@ -22,6 +22,7 @@
 namespace trtmc {
 
 class CudaGraphExec;
+class TrtModuleImplTestPeer;
 
 class TrtModuleImpl final : public ITrtModule {
   public:
@@ -66,6 +67,8 @@ class TrtModuleImpl final : public ITrtModule {
     void keep_alive(std::shared_ptr<void> resource) override;
 
   private:
+    friend class TrtModuleImplTestPeer;
+
     struct BufferEntry {
         void* d_ptr{nullptr};
         std::vector<int64_t> shape;
@@ -113,8 +116,6 @@ class TrtModuleImpl final : public ITrtModule {
     void finish_timing_event(TimingEvent event);
     void record_timed_enqueue();
     bool bind_tensor_address(const std::string& name, const BufferEntry& entry);
-    void recreate_context_with_profile();
-    void rebind_buffer_to_context(const std::string& name, const BufferEntry& entry);
     bool attach_distributed_communicator();
     static bool dims_are_dynamic(const nvinfer1::Dims& dims);
     static std::vector<int64_t> dims_to_shape(const nvinfer1::Dims& dims);

--- a/src/runtime/models/bark/inference_state.h
+++ b/src/runtime/models/bark/inference_state.h
@@ -40,7 +40,8 @@ class BarkInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/bark/kv_cache.cpp
+++ b/src/runtime/models/bark/kv_cache.cpp
@@ -340,15 +340,9 @@ void BarkKvCache::advance(int32_t n_tokens) {
 }
 
 void BarkKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t BarkKvCache::device_memory_bytes() const {

--- a/src/runtime/models/bart/inference_state.h
+++ b/src/runtime/models/bart/inference_state.h
@@ -40,7 +40,8 @@ class BartInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/bart/kv_cache.cpp
+++ b/src/runtime/models/bart/kv_cache.cpp
@@ -340,15 +340,9 @@ void BartKvCache::advance(int32_t n_tokens) {
 }
 
 void BartKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t BartKvCache::device_memory_bytes() const {

--- a/src/runtime/models/bloom/inference_state.h
+++ b/src/runtime/models/bloom/inference_state.h
@@ -40,7 +40,8 @@ class BloomInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/bloom/kv_cache.cpp
+++ b/src/runtime/models/bloom/kv_cache.cpp
@@ -341,15 +341,9 @@ void BloomKvCache::advance(int32_t n_tokens) {
 }
 
 void BloomKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t BloomKvCache::device_memory_bytes() const {

--- a/src/runtime/models/bloom/pipeline.cpp
+++ b/src/runtime/models/bloom/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult BloomTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = bloom_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult BloomTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 BloomTextGenerationPipeline::GenerationResult
@@ -597,6 +601,8 @@ std::string BloomTextGenerationPipeline::resolve_generation_mode(const GenerateC
 }
 
 void BloomTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -605,6 +611,7 @@ void BloomTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t BloomTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/bloom/pipeline.h
+++ b/src/runtime/models/bloom/pipeline.h
@@ -120,6 +120,7 @@ class BloomTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/bloom/triattention_kv_cache.cpp
+++ b/src/runtime/models/bloom/triattention_kv_cache.cpp
@@ -2147,14 +2147,8 @@ void BloomTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t BloomTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/canary/inference_state.h
+++ b/src/runtime/models/canary/inference_state.h
@@ -41,7 +41,8 @@ class CanaryInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/canary/kv_cache.cpp
+++ b/src/runtime/models/canary/kv_cache.cpp
@@ -498,15 +498,9 @@ void CanaryKvCache::copy_lanes_from(const CanaryKvCache& source,
 }
 
 void CanaryKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t CanaryKvCache::device_memory_bytes() const {

--- a/src/runtime/models/codegen/inference_state.h
+++ b/src/runtime/models/codegen/inference_state.h
@@ -40,7 +40,8 @@ class CodegenInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/codegen/kv_cache.cpp
+++ b/src/runtime/models/codegen/kv_cache.cpp
@@ -341,15 +341,9 @@ void CodegenKvCache::advance(int32_t n_tokens) {
 }
 
 void CodegenKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t CodegenKvCache::device_memory_bytes() const {

--- a/src/runtime/models/codegen/pipeline.cpp
+++ b/src/runtime/models/codegen/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult CodegenTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = codegen_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult CodegenTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 CodegenTextGenerationPipeline::GenerationResult
@@ -598,6 +602,8 @@ CodegenTextGenerationPipeline::resolve_generation_mode(const GenerateConfig& cfg
 }
 
 void CodegenTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -606,6 +612,7 @@ void CodegenTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t CodegenTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/codegen/pipeline.h
+++ b/src/runtime/models/codegen/pipeline.h
@@ -120,6 +120,7 @@ class CodegenTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/codegen/triattention_kv_cache.cpp
+++ b/src/runtime/models/codegen/triattention_kv_cache.cpp
@@ -2150,14 +2150,8 @@ void CodegenTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t CodegenTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/deepseek_ocr/inference_state.h
+++ b/src/runtime/models/deepseek_ocr/inference_state.h
@@ -40,7 +40,8 @@ class DeepseekOcrInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/deepseek_ocr/kv_cache.cpp
+++ b/src/runtime/models/deepseek_ocr/kv_cache.cpp
@@ -346,15 +346,9 @@ void DeepseekOcrKvCache::advance(int32_t n_tokens) {
 }
 
 void DeepseekOcrKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t DeepseekOcrKvCache::device_memory_bytes() const {

--- a/src/runtime/models/deepseek_ocr/pipeline.cpp
+++ b/src/runtime/models/deepseek_ocr/pipeline.cpp
@@ -9,6 +9,7 @@
 #include "runtime/models/deepseek_ocr/tensor_names.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
@@ -64,7 +65,9 @@ TextResult DeepseekOcrPipeline::generate(const std::string& prompt, const Genera
         output_ids.begin() + static_cast<std::ptrdiff_t>(input_ids.size()), output_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens)};
+    auto result = TextResult{std::move(text), std::move(new_tokens)};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 namespace {
@@ -398,7 +401,9 @@ TextResult DeepseekOcrPipeline::generate(const std::string& prompt, const float*
 
     std::vector<int32_t> new_tokens(out.begin() + static_cast<std::ptrdiff_t>(input_ids.size()),
                                     out.end());
-    return TextResult{tokenizer_->decode(new_tokens), std::move(new_tokens)};
+    auto result = TextResult{tokenizer_->decode(new_tokens), std::move(new_tokens)};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 DeepseekOcrPipeline::GenerationResult
@@ -408,6 +413,18 @@ DeepseekOcrPipeline::generate_ids(const std::vector<int32_t>& input_ids,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
     auto sp = deepseek_ocr_sampling_params_from_config(cfg, eos);
     return GenerationResult{generate_from_ids(input_ids, max_new, sp)};
+}
+
+void DeepseekOcrPipeline::reset_generation_context(int32_t prompt_length) {
+    const auto start = std::chrono::steady_clock::now();
+    state_->reset();
+    state_->set_prompt_length(prompt_length);
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
+    state_->bind_to(*text_decoder_);
+    last_setup_ms_ =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
 }
 
 std::vector<int32_t>
@@ -426,12 +443,7 @@ DeepseekOcrPipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
     }
     active_sampler->reset();
 
-    state_->reset();
-    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
-    text_decoder_->reset_execution_context();
-    if (prefill_)
-        prefill_->reset_execution_context();
-    state_->bind_to(*text_decoder_);
+    reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
 
@@ -470,12 +482,7 @@ std::vector<int32_t> DeepseekOcrPipeline::generate_vl_from_ids(
     }
     active_sampler->reset();
 
-    state_->reset();
-    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
-    text_decoder_->reset_execution_context();
-    if (prefill_)
-        prefill_->reset_execution_context();
-    state_->bind_to(*text_decoder_);
+    reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
     if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,

--- a/src/runtime/models/deepseek_ocr/pipeline.h
+++ b/src/runtime/models/deepseek_ocr/pipeline.h
@@ -73,6 +73,7 @@ class DeepseekOcrPipeline final : public IPipeline {
     std::unique_ptr<TrtModule> prefill_;
     std::unique_ptr<TrtModule> vision_encoder_;
     std::unique_ptr<DeepseekOcrInferenceState> state_;
+    double last_setup_ms_{0.0};
     DeepseekOcrConfig config_;
     DeepseekOcrPreprocessConfig vl_preprocess_;
     cudaStream_t stream_;
@@ -91,6 +92,8 @@ class DeepseekOcrPipeline final : public IPipeline {
         int32_t feature_dim, int32_t max_new_tokens, const DeepseekOcrSamplingParams& params);
 
     std::pair<int32_t, int32_t> resolve_gen_limits(const GenerateConfig& cfg) const;
+
+    void reset_generation_context(int32_t prompt_length);
 
     void run_vl_prefill_token(int32_t token_id, const std::vector<float>& image_features,
                               const std::vector<std::vector<float>>& deepstack_features,

--- a/src/runtime/models/deepseek_v2/inference_state.h
+++ b/src/runtime/models/deepseek_v2/inference_state.h
@@ -40,7 +40,8 @@ class DeepseekV2InferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/deepseek_v2/kv_cache.cpp
+++ b/src/runtime/models/deepseek_v2/kv_cache.cpp
@@ -344,15 +344,9 @@ void DeepseekV2KvCache::advance(int32_t n_tokens) {
 }
 
 void DeepseekV2KvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t DeepseekV2KvCache::device_memory_bytes() const {

--- a/src/runtime/models/deepseek_v2/pipeline.cpp
+++ b/src/runtime/models/deepseek_v2/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult DeepseekV2TextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = deepseek_v2_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult DeepseekV2TextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 DeepseekV2TextGenerationPipeline::GenerationResult
@@ -598,6 +602,8 @@ DeepseekV2TextGenerationPipeline::resolve_generation_mode(const GenerateConfig& 
 }
 
 void DeepseekV2TextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -606,6 +612,7 @@ void DeepseekV2TextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t DeepseekV2TextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/deepseek_v2/pipeline.h
+++ b/src/runtime/models/deepseek_v2/pipeline.h
@@ -120,6 +120,7 @@ class DeepseekV2TextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/deepseek_v2/triattention_kv_cache.cpp
+++ b/src/runtime/models/deepseek_v2/triattention_kv_cache.cpp
@@ -2155,14 +2155,8 @@ void DeepseekV2TriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t DeepseekV2TriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/falcon/inference_state.h
+++ b/src/runtime/models/falcon/inference_state.h
@@ -40,7 +40,8 @@ class FalconInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/falcon/kv_cache.cpp
+++ b/src/runtime/models/falcon/kv_cache.cpp
@@ -341,15 +341,9 @@ void FalconKvCache::advance(int32_t n_tokens) {
 }
 
 void FalconKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t FalconKvCache::device_memory_bytes() const {

--- a/src/runtime/models/falcon/pipeline.cpp
+++ b/src/runtime/models/falcon/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult FalconTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = falcon_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult FalconTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 FalconTextGenerationPipeline::GenerationResult
@@ -597,6 +601,8 @@ std::string FalconTextGenerationPipeline::resolve_generation_mode(const Generate
 }
 
 void FalconTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -605,6 +611,7 @@ void FalconTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t FalconTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/falcon/pipeline.h
+++ b/src/runtime/models/falcon/pipeline.h
@@ -120,6 +120,7 @@ class FalconTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/falcon/triattention_kv_cache.cpp
+++ b/src/runtime/models/falcon/triattention_kv_cache.cpp
@@ -2150,14 +2150,8 @@ void FalconTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t FalconTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/gemma/inference_state.h
+++ b/src/runtime/models/gemma/inference_state.h
@@ -40,7 +40,8 @@ class GemmaInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/gemma/kv_cache.cpp
+++ b/src/runtime/models/gemma/kv_cache.cpp
@@ -341,15 +341,9 @@ void GemmaKvCache::advance(int32_t n_tokens) {
 }
 
 void GemmaKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t GemmaKvCache::device_memory_bytes() const {

--- a/src/runtime/models/gemma/pipeline.cpp
+++ b/src/runtime/models/gemma/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult GemmaTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = gemma_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult GemmaTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 GemmaTextGenerationPipeline::GenerationResult
@@ -597,6 +601,8 @@ std::string GemmaTextGenerationPipeline::resolve_generation_mode(const GenerateC
 }
 
 void GemmaTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -605,6 +611,7 @@ void GemmaTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t GemmaTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/gemma/pipeline.h
+++ b/src/runtime/models/gemma/pipeline.h
@@ -120,6 +120,7 @@ class GemmaTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/gemma/triattention_kv_cache.cpp
+++ b/src/runtime/models/gemma/triattention_kv_cache.cpp
@@ -2147,14 +2147,8 @@ void GemmaTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t GemmaTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/glm/inference_state.h
+++ b/src/runtime/models/glm/inference_state.h
@@ -40,7 +40,8 @@ class GlmInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/glm/kv_cache.cpp
+++ b/src/runtime/models/glm/kv_cache.cpp
@@ -339,15 +339,9 @@ void GlmKvCache::advance(int32_t n_tokens) {
 }
 
 void GlmKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t GlmKvCache::device_memory_bytes() const {

--- a/src/runtime/models/glm/pipeline.cpp
+++ b/src/runtime/models/glm/pipeline.cpp
@@ -355,6 +355,7 @@ TextResult GlmTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = glm_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -363,7 +364,10 @@ TextResult GlmTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 GlmTextGenerationPipeline::GenerationResult
@@ -596,6 +600,8 @@ std::string GlmTextGenerationPipeline::resolve_generation_mode(const GenerateCon
 }
 
 void GlmTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -604,6 +610,7 @@ void GlmTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t GlmTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/glm/pipeline.h
+++ b/src/runtime/models/glm/pipeline.h
@@ -118,6 +118,7 @@ class GlmTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/glm/triattention_kv_cache.cpp
+++ b/src/runtime/models/glm/triattention_kv_cache.cpp
@@ -2149,14 +2149,8 @@ void GlmTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t GlmTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/gpt2/inference_state.h
+++ b/src/runtime/models/gpt2/inference_state.h
@@ -40,7 +40,8 @@ class Gpt2InferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/gpt2/kv_cache.cpp
+++ b/src/runtime/models/gpt2/kv_cache.cpp
@@ -340,15 +340,9 @@ void Gpt2KvCache::advance(int32_t n_tokens) {
 }
 
 void Gpt2KvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t Gpt2KvCache::device_memory_bytes() const {

--- a/src/runtime/models/gpt2/pipeline.cpp
+++ b/src/runtime/models/gpt2/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult Gpt2TextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = gpt2_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult Gpt2TextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 Gpt2TextGenerationPipeline::GenerationResult
@@ -597,6 +601,8 @@ std::string Gpt2TextGenerationPipeline::resolve_generation_mode(const GenerateCo
 }
 
 void Gpt2TextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -605,6 +611,7 @@ void Gpt2TextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t Gpt2TextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/gpt2/pipeline.h
+++ b/src/runtime/models/gpt2/pipeline.h
@@ -118,6 +118,7 @@ class Gpt2TextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/gpt2/triattention_kv_cache.cpp
+++ b/src/runtime/models/gpt2/triattention_kv_cache.cpp
@@ -2148,14 +2148,8 @@ void Gpt2TriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t Gpt2TriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/gpt_neo/inference_state.h
+++ b/src/runtime/models/gpt_neo/inference_state.h
@@ -40,7 +40,8 @@ class GptNeoInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/gpt_neo/kv_cache.cpp
+++ b/src/runtime/models/gpt_neo/kv_cache.cpp
@@ -341,15 +341,9 @@ void GptNeoKvCache::advance(int32_t n_tokens) {
 }
 
 void GptNeoKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t GptNeoKvCache::device_memory_bytes() const {

--- a/src/runtime/models/gpt_neo/pipeline.cpp
+++ b/src/runtime/models/gpt_neo/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult GptNeoTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = gpt_neo_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult GptNeoTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 GptNeoTextGenerationPipeline::GenerationResult
@@ -597,6 +601,8 @@ std::string GptNeoTextGenerationPipeline::resolve_generation_mode(const Generate
 }
 
 void GptNeoTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -605,6 +611,7 @@ void GptNeoTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t GptNeoTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/gpt_neo/pipeline.h
+++ b/src/runtime/models/gpt_neo/pipeline.h
@@ -120,6 +120,7 @@ class GptNeoTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/gpt_neo/triattention_kv_cache.cpp
+++ b/src/runtime/models/gpt_neo/triattention_kv_cache.cpp
@@ -2150,14 +2150,8 @@ void GptNeoTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t GptNeoTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/gpt_neox/inference_state.h
+++ b/src/runtime/models/gpt_neox/inference_state.h
@@ -40,7 +40,8 @@ class GptNeoxInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/gpt_neox/kv_cache.cpp
+++ b/src/runtime/models/gpt_neox/kv_cache.cpp
@@ -341,15 +341,9 @@ void GptNeoxKvCache::advance(int32_t n_tokens) {
 }
 
 void GptNeoxKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t GptNeoxKvCache::device_memory_bytes() const {

--- a/src/runtime/models/gpt_neox/pipeline.cpp
+++ b/src/runtime/models/gpt_neox/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult GptNeoxTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = gpt_neox_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult GptNeoxTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 GptNeoxTextGenerationPipeline::GenerationResult
@@ -598,6 +602,8 @@ GptNeoxTextGenerationPipeline::resolve_generation_mode(const GenerateConfig& cfg
 }
 
 void GptNeoxTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -606,6 +612,7 @@ void GptNeoxTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t GptNeoxTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/gpt_neox/pipeline.h
+++ b/src/runtime/models/gpt_neox/pipeline.h
@@ -120,6 +120,7 @@ class GptNeoxTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/gpt_neox/triattention_kv_cache.cpp
+++ b/src/runtime/models/gpt_neox/triattention_kv_cache.cpp
@@ -2150,14 +2150,8 @@ void GptNeoxTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t GptNeoxTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/gpt_oss/inference_state.h
+++ b/src/runtime/models/gpt_oss/inference_state.h
@@ -40,7 +40,8 @@ class GptOssInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/gpt_oss/kv_cache.cpp
+++ b/src/runtime/models/gpt_oss/kv_cache.cpp
@@ -341,15 +341,9 @@ void GptOssKvCache::advance(int32_t n_tokens) {
 }
 
 void GptOssKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t GptOssKvCache::device_memory_bytes() const {

--- a/src/runtime/models/gpt_oss/pipeline.cpp
+++ b/src/runtime/models/gpt_oss/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult GptOssTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = gpt_oss_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult GptOssTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 GptOssTextGenerationPipeline::GenerationResult
@@ -597,6 +601,8 @@ std::string GptOssTextGenerationPipeline::resolve_generation_mode(const Generate
 }
 
 void GptOssTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -605,6 +611,7 @@ void GptOssTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t GptOssTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/gpt_oss/pipeline.h
+++ b/src/runtime/models/gpt_oss/pipeline.h
@@ -120,6 +120,7 @@ class GptOssTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/gpt_oss/triattention_kv_cache.cpp
+++ b/src/runtime/models/gpt_oss/triattention_kv_cache.cpp
@@ -2150,14 +2150,8 @@ void GptOssTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t GptOssTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/granite/inference_state.h
+++ b/src/runtime/models/granite/inference_state.h
@@ -40,7 +40,8 @@ class GraniteInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/granite/kv_cache.cpp
+++ b/src/runtime/models/granite/kv_cache.cpp
@@ -341,15 +341,9 @@ void GraniteKvCache::advance(int32_t n_tokens) {
 }
 
 void GraniteKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t GraniteKvCache::device_memory_bytes() const {

--- a/src/runtime/models/granite/pipeline.cpp
+++ b/src/runtime/models/granite/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult GraniteTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = granite_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult GraniteTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 GraniteTextGenerationPipeline::GenerationResult
@@ -598,6 +602,8 @@ GraniteTextGenerationPipeline::resolve_generation_mode(const GenerateConfig& cfg
 }
 
 void GraniteTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -606,6 +612,7 @@ void GraniteTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t GraniteTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/granite/pipeline.h
+++ b/src/runtime/models/granite/pipeline.h
@@ -120,6 +120,7 @@ class GraniteTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/granite/triattention_kv_cache.cpp
+++ b/src/runtime/models/granite/triattention_kv_cache.cpp
@@ -2150,14 +2150,8 @@ void GraniteTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t GraniteTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/internlm/inference_state.h
+++ b/src/runtime/models/internlm/inference_state.h
@@ -40,7 +40,8 @@ class InternlmInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/internlm/kv_cache.cpp
+++ b/src/runtime/models/internlm/kv_cache.cpp
@@ -342,15 +342,9 @@ void InternlmKvCache::advance(int32_t n_tokens) {
 }
 
 void InternlmKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t InternlmKvCache::device_memory_bytes() const {

--- a/src/runtime/models/internlm/pipeline.cpp
+++ b/src/runtime/models/internlm/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult InternlmTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = internlm_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult InternlmTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 InternlmTextGenerationPipeline::GenerationResult
@@ -598,6 +602,8 @@ InternlmTextGenerationPipeline::resolve_generation_mode(const GenerateConfig& cf
 }
 
 void InternlmTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -606,6 +612,7 @@ void InternlmTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t InternlmTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/internlm/pipeline.h
+++ b/src/runtime/models/internlm/pipeline.h
@@ -120,6 +120,7 @@ class InternlmTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/internlm/triattention_kv_cache.cpp
+++ b/src/runtime/models/internlm/triattention_kv_cache.cpp
@@ -2152,14 +2152,8 @@ void InternlmTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t InternlmTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/internvl/inference_state.h
+++ b/src/runtime/models/internvl/inference_state.h
@@ -40,7 +40,8 @@ class InternvlInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/internvl/kv_cache.cpp
+++ b/src/runtime/models/internvl/kv_cache.cpp
@@ -342,15 +342,9 @@ void InternvlKvCache::advance(int32_t n_tokens) {
 }
 
 void InternvlKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t InternvlKvCache::device_memory_bytes() const {

--- a/src/runtime/models/internvl/pipeline.cpp
+++ b/src/runtime/models/internvl/pipeline.cpp
@@ -9,6 +9,7 @@
 #include "runtime/models/internvl/tensor_names.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
@@ -65,7 +66,9 @@ TextResult InternVlPipeline::generate(const std::string& prompt, const GenerateC
         output_ids.begin() + static_cast<std::ptrdiff_t>(input_ids.size()), output_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens)};
+    auto result = TextResult{std::move(text), std::move(new_tokens)};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 namespace {
@@ -398,7 +401,9 @@ TextResult InternVlPipeline::generate(const std::string& prompt, const float* im
 
     std::vector<int32_t> new_tokens(out.begin() + static_cast<std::ptrdiff_t>(input_ids.size()),
                                     out.end());
-    return TextResult{tokenizer_->decode(new_tokens), std::move(new_tokens)};
+    auto result = TextResult{tokenizer_->decode(new_tokens), std::move(new_tokens)};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 InternVlPipeline::GenerationResult
@@ -407,6 +412,18 @@ InternVlPipeline::generate_ids(const std::vector<int32_t>& input_ids, const Gene
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
     auto sp = internvl_sampling_params_from_config(cfg, eos);
     return GenerationResult{generate_from_ids(input_ids, max_new, sp)};
+}
+
+void InternVlPipeline::reset_generation_context(int32_t prompt_length) {
+    const auto start = std::chrono::steady_clock::now();
+    state_->reset();
+    state_->set_prompt_length(prompt_length);
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
+    state_->bind_to(*text_decoder_);
+    last_setup_ms_ =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
 }
 
 std::vector<int32_t> InternVlPipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
@@ -424,12 +441,7 @@ std::vector<int32_t> InternVlPipeline::generate_from_ids(const std::vector<int32
     }
     active_sampler->reset();
 
-    state_->reset();
-    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
-    text_decoder_->reset_execution_context();
-    if (prefill_)
-        prefill_->reset_execution_context();
-    state_->bind_to(*text_decoder_);
+    reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
 
@@ -468,12 +480,7 @@ std::vector<int32_t> InternVlPipeline::generate_vl_from_ids(
     }
     active_sampler->reset();
 
-    state_->reset();
-    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
-    text_decoder_->reset_execution_context();
-    if (prefill_)
-        prefill_->reset_execution_context();
-    state_->bind_to(*text_decoder_);
+    reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
     if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,

--- a/src/runtime/models/internvl/pipeline.h
+++ b/src/runtime/models/internvl/pipeline.h
@@ -72,6 +72,7 @@ class InternVlPipeline final : public IPipeline {
     std::unique_ptr<TrtModule> prefill_;
     std::unique_ptr<TrtModule> vision_encoder_;
     std::unique_ptr<InternvlInferenceState> state_;
+    double last_setup_ms_{0.0};
     InternVlConfig config_;
     InternVlPreprocessConfig vl_preprocess_;
     cudaStream_t stream_;
@@ -90,6 +91,8 @@ class InternVlPipeline final : public IPipeline {
         int32_t feature_dim, int32_t max_new_tokens, const InternVlSamplingParams& params);
 
     std::pair<int32_t, int32_t> resolve_gen_limits(const GenerateConfig& cfg) const;
+
+    void reset_generation_context(int32_t prompt_length);
 
     void run_vl_prefill_token(int32_t token_id, const std::vector<float>& image_features,
                               const std::vector<std::vector<float>>& deepstack_features,

--- a/src/runtime/models/lance/inference_state.h
+++ b/src/runtime/models/lance/inference_state.h
@@ -40,7 +40,8 @@ class LanceInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/lance/kv_cache.cpp
+++ b/src/runtime/models/lance/kv_cache.cpp
@@ -341,15 +341,9 @@ void LanceKvCache::advance(int32_t n_tokens) {
 }
 
 void LanceKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t LanceKvCache::device_memory_bytes() const {

--- a/src/runtime/models/lance/pipeline.cpp
+++ b/src/runtime/models/lance/pipeline.cpp
@@ -9,6 +9,7 @@
 #include "runtime/models/lance/tensor_names.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
@@ -64,7 +65,9 @@ TextResult LancePipeline::generate(const std::string& prompt, const GenerateConf
         output_ids.begin() + static_cast<std::ptrdiff_t>(input_ids.size()), output_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens)};
+    auto result = TextResult{std::move(text), std::move(new_tokens)};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 namespace {
@@ -397,7 +400,9 @@ TextResult LancePipeline::generate(const std::string& prompt, const float* image
 
     std::vector<int32_t> new_tokens(out.begin() + static_cast<std::ptrdiff_t>(input_ids.size()),
                                     out.end());
-    return TextResult{tokenizer_->decode(new_tokens), std::move(new_tokens)};
+    auto result = TextResult{tokenizer_->decode(new_tokens), std::move(new_tokens)};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 LancePipeline::GenerationResult LancePipeline::generate_ids(const std::vector<int32_t>& input_ids,
@@ -406,6 +411,18 @@ LancePipeline::GenerationResult LancePipeline::generate_ids(const std::vector<in
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
     auto sp = lance_sampling_params_from_config(cfg, eos);
     return GenerationResult{generate_from_ids(input_ids, max_new, sp)};
+}
+
+void LancePipeline::reset_generation_context(int32_t prompt_length) {
+    const auto start = std::chrono::steady_clock::now();
+    state_->reset();
+    state_->set_prompt_length(prompt_length);
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
+    state_->bind_to(*text_decoder_);
+    last_setup_ms_ =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
 }
 
 std::vector<int32_t> LancePipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
@@ -423,12 +440,7 @@ std::vector<int32_t> LancePipeline::generate_from_ids(const std::vector<int32_t>
     }
     active_sampler->reset();
 
-    state_->reset();
-    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
-    text_decoder_->reset_execution_context();
-    if (prefill_)
-        prefill_->reset_execution_context();
-    state_->bind_to(*text_decoder_);
+    reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
 
@@ -467,12 +479,7 @@ std::vector<int32_t> LancePipeline::generate_vl_from_ids(
     }
     active_sampler->reset();
 
-    state_->reset();
-    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
-    text_decoder_->reset_execution_context();
-    if (prefill_)
-        prefill_->reset_execution_context();
-    state_->bind_to(*text_decoder_);
+    reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
     if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,

--- a/src/runtime/models/lance/pipeline.h
+++ b/src/runtime/models/lance/pipeline.h
@@ -72,6 +72,7 @@ class LancePipeline final : public IPipeline {
     std::unique_ptr<TrtModule> prefill_;
     std::unique_ptr<TrtModule> vision_encoder_;
     std::unique_ptr<LanceInferenceState> state_;
+    double last_setup_ms_{0.0};
     LanceConfig config_;
     LancePreprocessConfig vl_preprocess_;
     cudaStream_t stream_;
@@ -90,6 +91,8 @@ class LancePipeline final : public IPipeline {
         int32_t feature_dim, int32_t max_new_tokens, const LanceSamplingParams& params);
 
     std::pair<int32_t, int32_t> resolve_gen_limits(const GenerateConfig& cfg) const;
+
+    void reset_generation_context(int32_t prompt_length);
 
     void run_vl_prefill_token(int32_t token_id, const std::vector<float>& image_features,
                               const std::vector<std::vector<float>>& deepstack_features,

--- a/src/runtime/models/llama/inference_state.h
+++ b/src/runtime/models/llama/inference_state.h
@@ -40,7 +40,8 @@ class LlamaInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/llama/kv_cache.cpp
+++ b/src/runtime/models/llama/kv_cache.cpp
@@ -341,15 +341,9 @@ void LlamaKvCache::advance(int32_t n_tokens) {
 }
 
 void LlamaKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t LlamaKvCache::device_memory_bytes() const {

--- a/src/runtime/models/llama/pipeline.cpp
+++ b/src/runtime/models/llama/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult LlamaTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = llama_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult LlamaTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 LlamaTextGenerationPipeline::GenerationResult
@@ -597,6 +601,8 @@ std::string LlamaTextGenerationPipeline::resolve_generation_mode(const GenerateC
 }
 
 void LlamaTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -605,6 +611,7 @@ void LlamaTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t LlamaTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/llama/pipeline.h
+++ b/src/runtime/models/llama/pipeline.h
@@ -120,6 +120,7 @@ class LlamaTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/llama/triattention_kv_cache.cpp
+++ b/src/runtime/models/llama/triattention_kv_cache.cpp
@@ -2147,14 +2147,8 @@ void LlamaTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t LlamaTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/locateanything/inference_state.h
+++ b/src/runtime/models/locateanything/inference_state.h
@@ -40,7 +40,8 @@ class LocateanythingInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/locateanything/kv_cache.cpp
+++ b/src/runtime/models/locateanything/kv_cache.cpp
@@ -346,15 +346,9 @@ void LocateanythingKvCache::advance(int32_t n_tokens) {
 }
 
 void LocateanythingKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t LocateanythingKvCache::device_memory_bytes() const {

--- a/src/runtime/models/locateanything/pipeline.cpp
+++ b/src/runtime/models/locateanything/pipeline.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <charconv>
+#include <chrono>
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
@@ -106,7 +107,9 @@ TextResult LocateAnythingPipeline::generate(const std::string& prompt, const Gen
         output_ids.begin() + static_cast<std::ptrdiff_t>(input_ids.size()), output_ids.end());
     std::string text = locateanything_decode_generated_text(*tokenizer_, new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens)};
+    auto result = TextResult{std::move(text), std::move(new_tokens)};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 namespace {
@@ -441,8 +444,10 @@ TextResult LocateAnythingPipeline::generate(const std::string& prompt, const flo
 
     std::vector<int32_t> new_tokens(out.begin() + static_cast<std::ptrdiff_t>(input_ids.size()),
                                     out.end());
-    return TextResult{locateanything_decode_generated_text(*tokenizer_, new_tokens),
-                      std::move(new_tokens)};
+    auto result = TextResult{locateanything_decode_generated_text(*tokenizer_, new_tokens),
+                             std::move(new_tokens)};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 LocateAnythingPipeline::GenerationResult
@@ -452,6 +457,18 @@ LocateAnythingPipeline::generate_ids(const std::vector<int32_t>& input_ids,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
     auto sp = locateanything_sampling_params_from_config(cfg, eos);
     return GenerationResult{generate_from_ids(input_ids, max_new, sp)};
+}
+
+void LocateAnythingPipeline::reset_generation_context(int32_t prompt_length) {
+    const auto start = std::chrono::steady_clock::now();
+    state_->reset();
+    state_->set_prompt_length(prompt_length);
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
+    state_->bind_to(*text_decoder_);
+    last_setup_ms_ =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
 }
 
 std::vector<int32_t>
@@ -470,12 +487,7 @@ LocateAnythingPipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
     }
     active_sampler->reset();
 
-    state_->reset();
-    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
-    text_decoder_->reset_execution_context();
-    if (prefill_)
-        prefill_->reset_execution_context();
-    state_->bind_to(*text_decoder_);
+    reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
 
@@ -515,12 +527,7 @@ std::vector<int32_t> LocateAnythingPipeline::generate_vl_from_ids(
     }
     active_sampler->reset();
 
-    state_->reset();
-    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
-    text_decoder_->reset_execution_context();
-    if (prefill_)
-        prefill_->reset_execution_context();
-    state_->bind_to(*text_decoder_);
+    reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
     if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,

--- a/src/runtime/models/locateanything/pipeline.h
+++ b/src/runtime/models/locateanything/pipeline.h
@@ -81,6 +81,7 @@ class LocateAnythingPipeline final : public IPipeline {
     std::unique_ptr<TrtModule> prefill_;
     std::unique_ptr<TrtModule> vision_encoder_;
     std::unique_ptr<LocateanythingInferenceState> state_;
+    double last_setup_ms_{0.0};
     LocateAnythingConfig config_;
     LocateAnythingPreprocessConfig vl_preprocess_;
     cudaStream_t stream_;
@@ -99,6 +100,8 @@ class LocateAnythingPipeline final : public IPipeline {
         int32_t feature_dim, int32_t max_new_tokens, const LocateAnythingSamplingParams& params);
 
     std::pair<int32_t, int32_t> resolve_gen_limits(const GenerateConfig& cfg) const;
+
+    void reset_generation_context(int32_t prompt_length);
 
     void run_vl_prefill_token(int32_t token_id, const std::vector<float>& image_features,
                               const std::vector<std::vector<float>>& deepstack_features,

--- a/src/runtime/models/m2m_100/inference_state.h
+++ b/src/runtime/models/m2m_100/inference_state.h
@@ -40,7 +40,8 @@ class M2m100InferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/m2m_100/kv_cache.cpp
+++ b/src/runtime/models/m2m_100/kv_cache.cpp
@@ -341,15 +341,9 @@ void M2m100KvCache::advance(int32_t n_tokens) {
 }
 
 void M2m100KvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t M2m100KvCache::device_memory_bytes() const {

--- a/src/runtime/models/magpie/inference_state.h
+++ b/src/runtime/models/magpie/inference_state.h
@@ -40,7 +40,8 @@ class MagpieInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/magpie/kv_cache.cpp
+++ b/src/runtime/models/magpie/kv_cache.cpp
@@ -341,15 +341,9 @@ void MagpieKvCache::advance(int32_t n_tokens) {
 }
 
 void MagpieKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t MagpieKvCache::device_memory_bytes() const {

--- a/src/runtime/models/marian/inference_state.h
+++ b/src/runtime/models/marian/inference_state.h
@@ -40,7 +40,8 @@ class MarianInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/marian/kv_cache.cpp
+++ b/src/runtime/models/marian/kv_cache.cpp
@@ -341,15 +341,9 @@ void MarianKvCache::advance(int32_t n_tokens) {
 }
 
 void MarianKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t MarianKvCache::device_memory_bytes() const {

--- a/src/runtime/models/mistral/inference_state.h
+++ b/src/runtime/models/mistral/inference_state.h
@@ -40,7 +40,8 @@ class MistralInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/mistral/kv_cache.cpp
+++ b/src/runtime/models/mistral/kv_cache.cpp
@@ -341,15 +341,9 @@ void MistralKvCache::advance(int32_t n_tokens) {
 }
 
 void MistralKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t MistralKvCache::device_memory_bytes() const {

--- a/src/runtime/models/mistral/pipeline.cpp
+++ b/src/runtime/models/mistral/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult MistralTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = mistral_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult MistralTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 MistralTextGenerationPipeline::GenerationResult
@@ -598,6 +602,8 @@ MistralTextGenerationPipeline::resolve_generation_mode(const GenerateConfig& cfg
 }
 
 void MistralTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -606,6 +612,7 @@ void MistralTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t MistralTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/mistral/pipeline.h
+++ b/src/runtime/models/mistral/pipeline.h
@@ -120,6 +120,7 @@ class MistralTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/mistral/triattention_kv_cache.cpp
+++ b/src/runtime/models/mistral/triattention_kv_cache.cpp
@@ -2150,14 +2150,8 @@ void MistralTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t MistralTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/mixtral/inference_state.h
+++ b/src/runtime/models/mixtral/inference_state.h
@@ -40,7 +40,8 @@ class MixtralInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/mixtral/kv_cache.cpp
+++ b/src/runtime/models/mixtral/kv_cache.cpp
@@ -341,15 +341,9 @@ void MixtralKvCache::advance(int32_t n_tokens) {
 }
 
 void MixtralKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t MixtralKvCache::device_memory_bytes() const {

--- a/src/runtime/models/mixtral/pipeline.cpp
+++ b/src/runtime/models/mixtral/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult MixtralTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = mixtral_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult MixtralTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 MixtralTextGenerationPipeline::GenerationResult
@@ -598,6 +602,8 @@ MixtralTextGenerationPipeline::resolve_generation_mode(const GenerateConfig& cfg
 }
 
 void MixtralTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -606,6 +612,7 @@ void MixtralTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t MixtralTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/mixtral/pipeline.h
+++ b/src/runtime/models/mixtral/pipeline.h
@@ -120,6 +120,7 @@ class MixtralTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/mixtral/triattention_kv_cache.cpp
+++ b/src/runtime/models/mixtral/triattention_kv_cache.cpp
@@ -2150,14 +2150,8 @@ void MixtralTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t MixtralTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/nemotron/inference_state.h
+++ b/src/runtime/models/nemotron/inference_state.h
@@ -40,7 +40,8 @@ class NemotronInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/nemotron/kv_cache.cpp
+++ b/src/runtime/models/nemotron/kv_cache.cpp
@@ -342,15 +342,9 @@ void NemotronKvCache::advance(int32_t n_tokens) {
 }
 
 void NemotronKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t NemotronKvCache::device_memory_bytes() const {

--- a/src/runtime/models/nemotron/pipeline.cpp
+++ b/src/runtime/models/nemotron/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult NemotronTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = nemotron_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult NemotronTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 NemotronTextGenerationPipeline::GenerationResult
@@ -598,6 +602,8 @@ NemotronTextGenerationPipeline::resolve_generation_mode(const GenerateConfig& cf
 }
 
 void NemotronTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -606,6 +612,7 @@ void NemotronTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t NemotronTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/nemotron/pipeline.h
+++ b/src/runtime/models/nemotron/pipeline.h
@@ -120,6 +120,7 @@ class NemotronTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/nemotron/triattention_kv_cache.cpp
+++ b/src/runtime/models/nemotron/triattention_kv_cache.cpp
@@ -2152,14 +2152,8 @@ void NemotronTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t NemotronTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/nemotron_h/inference_state.h
+++ b/src/runtime/models/nemotron_h/inference_state.h
@@ -40,7 +40,8 @@ class NemotronHInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/nemotron_h/kv_cache.cpp
+++ b/src/runtime/models/nemotron_h/kv_cache.cpp
@@ -344,15 +344,9 @@ void NemotronHKvCache::advance(int32_t n_tokens) {
 }
 
 void NemotronHKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t NemotronHKvCache::device_memory_bytes() const {

--- a/src/runtime/models/nemotron_labs_diffusion/inference_state.h
+++ b/src/runtime/models/nemotron_labs_diffusion/inference_state.h
@@ -40,7 +40,8 @@ class NemotronLabsDiffusionInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/nemotron_labs_diffusion/kv_cache.cpp
+++ b/src/runtime/models/nemotron_labs_diffusion/kv_cache.cpp
@@ -348,15 +348,9 @@ void NemotronLabsDiffusionKvCache::advance(int32_t n_tokens) {
 }
 
 void NemotronLabsDiffusionKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t NemotronLabsDiffusionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/nemotron_labs_diffusion/pipeline.cpp
+++ b/src/runtime/models/nemotron_labs_diffusion/pipeline.cpp
@@ -358,6 +358,7 @@ TextResult NemotronLabsDiffusionTextGenerationPipeline::generate(const std::stri
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = nemotron_labs_diffusion_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -366,7 +367,10 @@ TextResult NemotronLabsDiffusionTextGenerationPipeline::generate(const std::stri
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 NemotronLabsDiffusionTextGenerationPipeline::GenerationResult
@@ -610,6 +614,8 @@ std::string NemotronLabsDiffusionTextGenerationPipeline::resolve_generation_mode
 }
 
 void NemotronLabsDiffusionTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -618,6 +624,7 @@ void NemotronLabsDiffusionTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t NemotronLabsDiffusionTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/nemotron_labs_diffusion/pipeline.h
+++ b/src/runtime/models/nemotron_labs_diffusion/pipeline.h
@@ -122,6 +122,7 @@ class NemotronLabsDiffusionTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/nemotron_labs_diffusion/triattention_kv_cache.cpp
+++ b/src/runtime/models/nemotron_labs_diffusion/triattention_kv_cache.cpp
@@ -2168,14 +2168,8 @@ void NemotronLabsDiffusionTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t NemotronLabsDiffusionTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/olmo/inference_state.h
+++ b/src/runtime/models/olmo/inference_state.h
@@ -40,7 +40,8 @@ class OlmoInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/olmo/kv_cache.cpp
+++ b/src/runtime/models/olmo/kv_cache.cpp
@@ -340,15 +340,9 @@ void OlmoKvCache::advance(int32_t n_tokens) {
 }
 
 void OlmoKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t OlmoKvCache::device_memory_bytes() const {

--- a/src/runtime/models/olmo/pipeline.cpp
+++ b/src/runtime/models/olmo/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult OlmoTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = olmo_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult OlmoTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 OlmoTextGenerationPipeline::GenerationResult
@@ -597,6 +601,8 @@ std::string OlmoTextGenerationPipeline::resolve_generation_mode(const GenerateCo
 }
 
 void OlmoTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -605,6 +611,7 @@ void OlmoTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t OlmoTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/olmo/pipeline.h
+++ b/src/runtime/models/olmo/pipeline.h
@@ -118,6 +118,7 @@ class OlmoTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/olmo/triattention_kv_cache.cpp
+++ b/src/runtime/models/olmo/triattention_kv_cache.cpp
@@ -2148,14 +2148,8 @@ void OlmoTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t OlmoTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/olmo2/inference_state.h
+++ b/src/runtime/models/olmo2/inference_state.h
@@ -40,7 +40,8 @@ class Olmo2InferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/olmo2/kv_cache.cpp
+++ b/src/runtime/models/olmo2/kv_cache.cpp
@@ -341,15 +341,9 @@ void Olmo2KvCache::advance(int32_t n_tokens) {
 }
 
 void Olmo2KvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t Olmo2KvCache::device_memory_bytes() const {

--- a/src/runtime/models/olmo2/pipeline.cpp
+++ b/src/runtime/models/olmo2/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult Olmo2TextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = olmo2_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult Olmo2TextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 Olmo2TextGenerationPipeline::GenerationResult
@@ -597,6 +601,8 @@ std::string Olmo2TextGenerationPipeline::resolve_generation_mode(const GenerateC
 }
 
 void Olmo2TextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -605,6 +611,7 @@ void Olmo2TextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t Olmo2TextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/olmo2/pipeline.h
+++ b/src/runtime/models/olmo2/pipeline.h
@@ -120,6 +120,7 @@ class Olmo2TextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/olmo2/triattention_kv_cache.cpp
+++ b/src/runtime/models/olmo2/triattention_kv_cache.cpp
@@ -2147,14 +2147,8 @@ void Olmo2TriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t Olmo2TriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/opt/inference_state.h
+++ b/src/runtime/models/opt/inference_state.h
@@ -40,7 +40,8 @@ class OptInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/opt/kv_cache.cpp
+++ b/src/runtime/models/opt/kv_cache.cpp
@@ -339,15 +339,9 @@ void OptKvCache::advance(int32_t n_tokens) {
 }
 
 void OptKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t OptKvCache::device_memory_bytes() const {

--- a/src/runtime/models/opt/pipeline.cpp
+++ b/src/runtime/models/opt/pipeline.cpp
@@ -355,6 +355,7 @@ TextResult OptTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = opt_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -363,7 +364,10 @@ TextResult OptTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 OptTextGenerationPipeline::GenerationResult
@@ -596,6 +600,8 @@ std::string OptTextGenerationPipeline::resolve_generation_mode(const GenerateCon
 }
 
 void OptTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -604,6 +610,7 @@ void OptTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t OptTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/opt/pipeline.h
+++ b/src/runtime/models/opt/pipeline.h
@@ -118,6 +118,7 @@ class OptTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/opt/triattention_kv_cache.cpp
+++ b/src/runtime/models/opt/triattention_kv_cache.cpp
@@ -2149,14 +2149,8 @@ void OptTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t OptTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/personaplex/inference_state.h
+++ b/src/runtime/models/personaplex/inference_state.h
@@ -40,7 +40,8 @@ class PersonaplexInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/personaplex/kv_cache.cpp
+++ b/src/runtime/models/personaplex/kv_cache.cpp
@@ -346,14 +346,9 @@ void PersonaplexKvCache::advance(int32_t n_tokens) {
 }
 
 void PersonaplexKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
 }
 
 std::size_t PersonaplexKvCache::device_memory_bytes() const {

--- a/src/runtime/models/phi/inference_state.h
+++ b/src/runtime/models/phi/inference_state.h
@@ -40,7 +40,8 @@ class PhiInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/phi/kv_cache.cpp
+++ b/src/runtime/models/phi/kv_cache.cpp
@@ -339,15 +339,9 @@ void PhiKvCache::advance(int32_t n_tokens) {
 }
 
 void PhiKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t PhiKvCache::device_memory_bytes() const {

--- a/src/runtime/models/phi/pipeline.cpp
+++ b/src/runtime/models/phi/pipeline.cpp
@@ -355,6 +355,7 @@ TextResult PhiTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = phi_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -363,7 +364,10 @@ TextResult PhiTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 PhiTextGenerationPipeline::GenerationResult
@@ -596,6 +600,8 @@ std::string PhiTextGenerationPipeline::resolve_generation_mode(const GenerateCon
 }
 
 void PhiTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -604,6 +610,7 @@ void PhiTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t PhiTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/phi/pipeline.h
+++ b/src/runtime/models/phi/pipeline.h
@@ -118,6 +118,7 @@ class PhiTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/phi/triattention_kv_cache.cpp
+++ b/src/runtime/models/phi/triattention_kv_cache.cpp
@@ -2149,14 +2149,8 @@ void PhiTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t PhiTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/phi4_multimodal/inference_state.h
+++ b/src/runtime/models/phi4_multimodal/inference_state.h
@@ -40,7 +40,8 @@ class Phi4MultimodalInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/phi4_multimodal/kv_cache.cpp
+++ b/src/runtime/models/phi4_multimodal/kv_cache.cpp
@@ -346,15 +346,9 @@ void Phi4MultimodalKvCache::advance(int32_t n_tokens) {
 }
 
 void Phi4MultimodalKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t Phi4MultimodalKvCache::device_memory_bytes() const {

--- a/src/runtime/models/phi4_multimodal/pipeline.cpp
+++ b/src/runtime/models/phi4_multimodal/pipeline.cpp
@@ -9,6 +9,7 @@
 #include "runtime/models/phi4_multimodal/tensor_names.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
@@ -65,7 +66,9 @@ TextResult Phi4MultimodalPipeline::generate(const std::string& prompt, const Gen
         output_ids.begin() + static_cast<std::ptrdiff_t>(input_ids.size()), output_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens)};
+    auto result = TextResult{std::move(text), std::move(new_tokens)};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 namespace {
@@ -400,7 +403,9 @@ TextResult Phi4MultimodalPipeline::generate(const std::string& prompt, const flo
 
     std::vector<int32_t> new_tokens(out.begin() + static_cast<std::ptrdiff_t>(input_ids.size()),
                                     out.end());
-    return TextResult{tokenizer_->decode(new_tokens), std::move(new_tokens)};
+    auto result = TextResult{tokenizer_->decode(new_tokens), std::move(new_tokens)};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 Phi4MultimodalPipeline::GenerationResult
@@ -410,6 +415,18 @@ Phi4MultimodalPipeline::generate_ids(const std::vector<int32_t>& input_ids,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
     auto sp = phi4_multimodal_sampling_params_from_config(cfg, eos);
     return GenerationResult{generate_from_ids(input_ids, max_new, sp)};
+}
+
+void Phi4MultimodalPipeline::reset_generation_context(int32_t prompt_length) {
+    const auto start = std::chrono::steady_clock::now();
+    state_->reset();
+    state_->set_prompt_length(prompt_length);
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
+    state_->bind_to(*text_decoder_);
+    last_setup_ms_ =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
 }
 
 std::vector<int32_t>
@@ -428,12 +445,7 @@ Phi4MultimodalPipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
     }
     active_sampler->reset();
 
-    state_->reset();
-    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
-    text_decoder_->reset_execution_context();
-    if (prefill_)
-        prefill_->reset_execution_context();
-    state_->bind_to(*text_decoder_);
+    reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
 
@@ -473,12 +485,7 @@ std::vector<int32_t> Phi4MultimodalPipeline::generate_vl_from_ids(
     }
     active_sampler->reset();
 
-    state_->reset();
-    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
-    text_decoder_->reset_execution_context();
-    if (prefill_)
-        prefill_->reset_execution_context();
-    state_->bind_to(*text_decoder_);
+    reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
     if (!run_vl_prefill_batched(input_ids, image_features, deepstack_features, num_features,

--- a/src/runtime/models/phi4_multimodal/pipeline.h
+++ b/src/runtime/models/phi4_multimodal/pipeline.h
@@ -74,6 +74,7 @@ class Phi4MultimodalPipeline final : public IPipeline {
     std::unique_ptr<TrtModule> prefill_;
     std::unique_ptr<TrtModule> vision_encoder_;
     std::unique_ptr<Phi4MultimodalInferenceState> state_;
+    double last_setup_ms_{0.0};
     Phi4MultimodalConfig config_;
     Phi4MultimodalPreprocessConfig vl_preprocess_;
     cudaStream_t stream_;
@@ -92,6 +93,8 @@ class Phi4MultimodalPipeline final : public IPipeline {
         int32_t feature_dim, int32_t max_new_tokens, const Phi4MultimodalSamplingParams& params);
 
     std::pair<int32_t, int32_t> resolve_gen_limits(const GenerateConfig& cfg) const;
+
+    void reset_generation_context(int32_t prompt_length);
 
     void run_vl_prefill_token(int32_t token_id, const std::vector<float>& image_features,
                               const std::vector<std::vector<float>>& deepstack_features,

--- a/src/runtime/models/phi_moe/inference_state.h
+++ b/src/runtime/models/phi_moe/inference_state.h
@@ -40,7 +40,8 @@ class PhiMoeInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/phi_moe/kv_cache.cpp
+++ b/src/runtime/models/phi_moe/kv_cache.cpp
@@ -341,15 +341,9 @@ void PhiMoeKvCache::advance(int32_t n_tokens) {
 }
 
 void PhiMoeKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t PhiMoeKvCache::device_memory_bytes() const {

--- a/src/runtime/models/phi_moe/pipeline.cpp
+++ b/src/runtime/models/phi_moe/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult PhiMoeTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = phi_moe_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult PhiMoeTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 PhiMoeTextGenerationPipeline::GenerationResult
@@ -597,6 +601,8 @@ std::string PhiMoeTextGenerationPipeline::resolve_generation_mode(const Generate
 }
 
 void PhiMoeTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -605,6 +611,7 @@ void PhiMoeTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t PhiMoeTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/phi_moe/pipeline.h
+++ b/src/runtime/models/phi_moe/pipeline.h
@@ -120,6 +120,7 @@ class PhiMoeTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/phi_moe/triattention_kv_cache.cpp
+++ b/src/runtime/models/phi_moe/triattention_kv_cache.cpp
@@ -2150,14 +2150,8 @@ void PhiMoeTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t PhiMoeTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/qwen/inference_state.h
+++ b/src/runtime/models/qwen/inference_state.h
@@ -40,7 +40,8 @@ class QwenInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/qwen/kv_cache.cpp
+++ b/src/runtime/models/qwen/kv_cache.cpp
@@ -340,15 +340,9 @@ void QwenKvCache::advance(int32_t n_tokens) {
 }
 
 void QwenKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t QwenKvCache::device_memory_bytes() const {

--- a/src/runtime/models/qwen/pipeline.cpp
+++ b/src/runtime/models/qwen/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult QwenTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = qwen_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult QwenTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 QwenTextGenerationPipeline::GenerationResult
@@ -597,6 +601,8 @@ std::string QwenTextGenerationPipeline::resolve_generation_mode(const GenerateCo
 }
 
 void QwenTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -605,6 +611,7 @@ void QwenTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t QwenTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/qwen/pipeline.h
+++ b/src/runtime/models/qwen/pipeline.h
@@ -118,6 +118,7 @@ class QwenTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/qwen/triattention_kv_cache.cpp
+++ b/src/runtime/models/qwen/triattention_kv_cache.cpp
@@ -2148,14 +2148,8 @@ void QwenTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t QwenTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/qwen3_5/inference_state.h
+++ b/src/runtime/models/qwen3_5/inference_state.h
@@ -40,7 +40,8 @@ class Qwen35InferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/qwen3_5/kv_cache.cpp
+++ b/src/runtime/models/qwen3_5/kv_cache.cpp
@@ -341,15 +341,9 @@ void Qwen35KvCache::advance(int32_t n_tokens) {
 }
 
 void Qwen35KvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t Qwen35KvCache::device_memory_bytes() const {

--- a/src/runtime/models/qwen3_omni/inference_state.h
+++ b/src/runtime/models/qwen3_omni/inference_state.h
@@ -37,7 +37,8 @@ class Qwen3OmniInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/qwen3_omni/kv_cache.cpp
+++ b/src/runtime/models/qwen3_omni/kv_cache.cpp
@@ -344,15 +344,9 @@ void Qwen3OmniKvCache::advance(int32_t n_tokens) {
 }
 
 void Qwen3OmniKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t Qwen3OmniKvCache::device_memory_bytes() const {

--- a/src/runtime/models/qwen_moe/inference_state.h
+++ b/src/runtime/models/qwen_moe/inference_state.h
@@ -40,7 +40,8 @@ class QwenMoeInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/qwen_moe/kv_cache.cpp
+++ b/src/runtime/models/qwen_moe/kv_cache.cpp
@@ -341,15 +341,9 @@ void QwenMoeKvCache::advance(int32_t n_tokens) {
 }
 
 void QwenMoeKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t QwenMoeKvCache::device_memory_bytes() const {

--- a/src/runtime/models/qwen_moe/pipeline.cpp
+++ b/src/runtime/models/qwen_moe/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult QwenMoeTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = qwen_moe_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult QwenMoeTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 QwenMoeTextGenerationPipeline::GenerationResult
@@ -598,6 +602,8 @@ QwenMoeTextGenerationPipeline::resolve_generation_mode(const GenerateConfig& cfg
 }
 
 void QwenMoeTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -606,6 +612,7 @@ void QwenMoeTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t QwenMoeTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/qwen_moe/pipeline.h
+++ b/src/runtime/models/qwen_moe/pipeline.h
@@ -120,6 +120,7 @@ class QwenMoeTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/qwen_moe/triattention_kv_cache.cpp
+++ b/src/runtime/models/qwen_moe/triattention_kv_cache.cpp
@@ -2150,14 +2150,8 @@ void QwenMoeTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t QwenMoeTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/qwen_vl/inference_state.h
+++ b/src/runtime/models/qwen_vl/inference_state.h
@@ -40,7 +40,8 @@ class QwenVlInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/qwen_vl/kv_cache.cpp
+++ b/src/runtime/models/qwen_vl/kv_cache.cpp
@@ -352,15 +352,9 @@ void QwenVlKvCache::advance(int32_t n_tokens) {
 }
 
 void QwenVlKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t QwenVlKvCache::device_memory_bytes() const {

--- a/src/runtime/models/qwen_vl/pipeline.cpp
+++ b/src/runtime/models/qwen_vl/pipeline.cpp
@@ -10,6 +10,7 @@
 #include "runtime/models/qwen_vl/tensor_names.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
@@ -201,7 +202,9 @@ TextResult QwenVlPipeline::generate(const std::string& prompt, const GenerateCon
         output_ids.begin() + static_cast<std::ptrdiff_t>(input_ids.size()), output_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens)};
+    auto result = TextResult{std::move(text), std::move(new_tokens)};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 namespace {
@@ -573,7 +576,9 @@ TextResult QwenVlPipeline::generate(const std::string& prompt, const float* imag
 
     std::vector<int32_t> new_tokens(out.begin() + static_cast<std::ptrdiff_t>(input_ids.size()),
                                     out.end());
-    return TextResult{tokenizer_->decode(new_tokens), std::move(new_tokens)};
+    auto result = TextResult{tokenizer_->decode(new_tokens), std::move(new_tokens)};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 QwenVlPipeline::GenerationResult QwenVlPipeline::generate_ids(const std::vector<int32_t>& input_ids,
@@ -585,6 +590,18 @@ QwenVlPipeline::GenerationResult QwenVlPipeline::generate_ids(const std::vector<
     return GenerationResult{generate_from_ids(input_ids, max_new, sp)};
 }
 
+void QwenVlPipeline::reset_generation_context(int32_t prompt_length) {
+    const auto start = std::chrono::steady_clock::now();
+    state_->reset();
+    state_->set_prompt_length(prompt_length);
+    text_decoder_->reset_execution_context();
+    if (prefill_)
+        prefill_->reset_execution_context();
+    state_->bind_to(*text_decoder_);
+    last_setup_ms_ =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
+}
+
 std::vector<int32_t> QwenVlPipeline::generate_from_ids(const std::vector<int32_t>& input_ids,
                                                        int32_t max_new_tokens,
                                                        const QwenVlSamplingParams& params) {
@@ -594,12 +611,7 @@ std::vector<int32_t> QwenVlPipeline::generate_from_ids(const std::vector<int32_t
     std::unique_ptr<QwenVlISampler> local_sampler;
     QwenVlISampler* active_sampler = prepare_sampler(params, local_sampler);
 
-    state_->reset();
-    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
-    text_decoder_->reset_execution_context();
-    if (prefill_)
-        prefill_->reset_execution_context();
-    state_->bind_to(*text_decoder_);
+    reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
 
@@ -632,12 +644,7 @@ std::vector<int32_t> QwenVlPipeline::generate_vl_from_ids(
     std::unique_ptr<QwenVlISampler> local_sampler;
     QwenVlISampler* active_sampler = prepare_sampler(params, local_sampler);
 
-    state_->reset();
-    state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
-    text_decoder_->reset_execution_context();
-    if (prefill_)
-        prefill_->reset_execution_context();
-    state_->bind_to(*text_decoder_);
+    reset_generation_context(static_cast<int32_t>(input_ids.size()));
 
     std::vector<float> logits;
     const int32_t grid_h =

--- a/src/runtime/models/qwen_vl/pipeline.h
+++ b/src/runtime/models/qwen_vl/pipeline.h
@@ -92,6 +92,7 @@ class QwenVlPipeline final : public IPipeline {
     std::unique_ptr<TrtModule> prefill_;
     std::unique_ptr<TrtModule> vision_encoder_;
     std::unique_ptr<QwenVlInferenceState> state_;
+    double last_setup_ms_{0.0};
     QwenVlConfig config_;
     QwenVlPreprocessConfig vl_preprocess_;
     cudaStream_t stream_;
@@ -115,6 +116,8 @@ class QwenVlPipeline final : public IPipeline {
         int32_t feature_dim, int32_t max_new_tokens, const QwenVlSamplingParams& params);
 
     std::pair<int32_t, int32_t> resolve_gen_limits(const GenerateConfig& cfg) const;
+
+    void reset_generation_context(int32_t prompt_length);
 
     QwenVlISampler* prepare_sampler(const QwenVlSamplingParams& params,
                                     std::unique_ptr<QwenVlISampler>& local_sampler);

--- a/src/runtime/models/stablelm/inference_state.h
+++ b/src/runtime/models/stablelm/inference_state.h
@@ -40,7 +40,8 @@ class StablelmInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/stablelm/kv_cache.cpp
+++ b/src/runtime/models/stablelm/kv_cache.cpp
@@ -342,15 +342,9 @@ void StablelmKvCache::advance(int32_t n_tokens) {
 }
 
 void StablelmKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t StablelmKvCache::device_memory_bytes() const {

--- a/src/runtime/models/stablelm/pipeline.cpp
+++ b/src/runtime/models/stablelm/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult StablelmTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = stablelm_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult StablelmTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 StablelmTextGenerationPipeline::GenerationResult
@@ -598,6 +602,8 @@ StablelmTextGenerationPipeline::resolve_generation_mode(const GenerateConfig& cf
 }
 
 void StablelmTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -606,6 +612,7 @@ void StablelmTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t StablelmTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/stablelm/pipeline.h
+++ b/src/runtime/models/stablelm/pipeline.h
@@ -120,6 +120,7 @@ class StablelmTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/stablelm/triattention_kv_cache.cpp
+++ b/src/runtime/models/stablelm/triattention_kv_cache.cpp
@@ -2152,14 +2152,8 @@ void StablelmTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t StablelmTriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/starcoder2/inference_state.h
+++ b/src/runtime/models/starcoder2/inference_state.h
@@ -40,7 +40,8 @@ class Starcoder2InferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/starcoder2/kv_cache.cpp
+++ b/src/runtime/models/starcoder2/kv_cache.cpp
@@ -344,15 +344,9 @@ void Starcoder2KvCache::advance(int32_t n_tokens) {
 }
 
 void Starcoder2KvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t Starcoder2KvCache::device_memory_bytes() const {

--- a/src/runtime/models/starcoder2/pipeline.cpp
+++ b/src/runtime/models/starcoder2/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult Starcoder2TextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = starcoder2_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult Starcoder2TextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 Starcoder2TextGenerationPipeline::GenerationResult
@@ -598,6 +602,8 @@ Starcoder2TextGenerationPipeline::resolve_generation_mode(const GenerateConfig& 
 }
 
 void Starcoder2TextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -606,6 +612,7 @@ void Starcoder2TextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t Starcoder2TextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/starcoder2/pipeline.h
+++ b/src/runtime/models/starcoder2/pipeline.h
@@ -120,6 +120,7 @@ class Starcoder2TextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/starcoder2/triattention_kv_cache.cpp
+++ b/src/runtime/models/starcoder2/triattention_kv_cache.cpp
@@ -2155,14 +2155,8 @@ void Starcoder2TriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t Starcoder2TriAttentionKvCache::device_memory_bytes() const {

--- a/src/runtime/models/t5/inference_state.h
+++ b/src/runtime/models/t5/inference_state.h
@@ -40,7 +40,8 @@ class T5InferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/t5/kv_cache.cpp
+++ b/src/runtime/models/t5/kv_cache.cpp
@@ -339,15 +339,9 @@ void T5KvCache::advance(int32_t n_tokens) {
 }
 
 void T5KvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t T5KvCache::device_memory_bytes() const {

--- a/src/runtime/models/whisper/inference_state.h
+++ b/src/runtime/models/whisper/inference_state.h
@@ -40,7 +40,8 @@ class WhisperInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/whisper/kv_cache.cpp
+++ b/src/runtime/models/whisper/kv_cache.cpp
@@ -341,15 +341,9 @@ void WhisperKvCache::advance(int32_t n_tokens) {
 }
 
 void WhisperKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t WhisperKvCache::device_memory_bytes() const {

--- a/src/runtime/models/xglm/inference_state.h
+++ b/src/runtime/models/xglm/inference_state.h
@@ -40,7 +40,8 @@ class XglmInferenceState {
 
     // --- Lifecycle ---
 
-    // Reset state for a new sequence (zero buffers, position = 0).
+    // Reset logical state for a new sequence. Implementations may retain device
+    // storage that remains hidden by logical lengths and attention masks.
     virtual void reset() = 0;
 
     // Bind all state tensors to the given TRT module.

--- a/src/runtime/models/xglm/kv_cache.cpp
+++ b/src/runtime/models/xglm/kv_cache.cpp
@@ -340,15 +340,9 @@ void XglmKvCache::advance(int32_t n_tokens) {
 }
 
 void XglmKvCache::reset() {
+    // Reset only the logical sequence length. Attention masks hide every
+    // stale cache row, and each present row is overwritten before use.
     position_ = 0;
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t XglmKvCache::device_memory_bytes() const {

--- a/src/runtime/models/xglm/pipeline.cpp
+++ b/src/runtime/models/xglm/pipeline.cpp
@@ -353,6 +353,7 @@ TextResult XglmTextGenerationPipeline::generate(const std::string& prompt,
     int32_t eos = (cfg.eos_token_id >= 0) ? cfg.eos_token_id : config_.id_eos;
 
     auto sp = xglm_sampling_params_from_config(cfg, eos);
+    last_setup_ms_ = 0.0;
     auto timed = generate_from_ids(input_ids, max_new, sp, cfg);
 
     // Decode only the NEW tokens (skip input)
@@ -361,7 +362,10 @@ TextResult XglmTextGenerationPipeline::generate(const std::string& prompt,
                                     timed.token_ids.end());
     std::string text = tokenizer_->decode(new_tokens);
 
-    return TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    auto result =
+        TextResult{std::move(text), std::move(new_tokens), timed.prefill_ms, timed.decode_ms};
+    result.setup_ms = last_setup_ms_;
+    return result;
 }
 
 XglmTextGenerationPipeline::GenerationResult
@@ -597,6 +601,8 @@ std::string XglmTextGenerationPipeline::resolve_generation_mode(const GenerateCo
 }
 
 void XglmTextGenerationPipeline::reset_generation_context() {
+    using Clock = std::chrono::steady_clock;
+    const auto start = Clock::now();
     state_->reset();
     state_bound_ = false;
     for (auto& decoder_ctx : decoders_)
@@ -605,6 +611,7 @@ void XglmTextGenerationPipeline::reset_generation_context() {
         prefill_->reset_execution_context();
     if (linear_spec_lora_prefill_)
         linear_spec_lora_prefill_->reset_execution_context();
+    last_setup_ms_ = std::chrono::duration<double, std::milli>(Clock::now() - start).count();
 }
 
 int32_t XglmTextGenerationPipeline::resolve_text_diffusion_block_length(

--- a/src/runtime/models/xglm/pipeline.h
+++ b/src/runtime/models/xglm/pipeline.h
@@ -118,6 +118,7 @@ class XglmTextGenerationPipeline final : public IPipeline {
     std::string logits_output_name_;
     int32_t active_decoder_index_{-1};
     bool state_bound_{false};
+    double last_setup_ms_{0.0};
 
     // Internal: generate from token IDs with sampling parameters and timing.
     struct TimedGenResult {

--- a/src/runtime/models/xglm/triattention_kv_cache.cpp
+++ b/src/runtime/models/xglm/triattention_kv_cache.cpp
@@ -2148,14 +2148,8 @@ void XglmTriAttentionKvCache::reset() {
     cache_positions_.clear();
     for (auto& head_positions : cache_positions_per_head_)
         head_positions.clear();
-    for (int32_t i = 0; i < num_layers_; ++i) {
-        const auto li = static_cast<std::size_t>(i);
-        cudaMemsetAsync(cache_k_[li].data(), 0, cache_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(cache_v_[li].data(), 0, cache_v_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
-        cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
-    }
-    cudaStreamSynchronize(stream_);
+    // Reset only logical sequence metadata. Cache length and position maps ensure
+    // stale device rows are neither scored nor exposed to the attention engine.
 }
 
 std::size_t XglmTriAttentionKvCache::device_memory_bytes() const {

--- a/tests/cpp/models/llama/test_llama_pipeline.cpp
+++ b/tests/cpp/models/llama/test_llama_pipeline.cpp
@@ -53,6 +53,21 @@ static void check(bool condition, const char* test_name) {
 
 static trtmc::TrtLogger g_logger;
 
+namespace trtmc {
+
+class TrtModuleImplTestPeer {
+  public:
+    static void set_execution_context_name(TrtModuleImpl& module, const char* name) {
+        module.ctx_->setName(name);
+    }
+
+    static std::string execution_context_name(const TrtModuleImpl& module) {
+        return module.ctx_->getName();
+    }
+};
+
+} // namespace trtmc
+
 class MockTokenizer final : public trtmc::ITokenizer {
   public:
     std::vector<int32_t> encode(const std::string& text) const override {
@@ -353,6 +368,34 @@ static void test_kv_reset_is_logical_and_masks_stale_rows() {
     cudaStreamDestroy(stream);
 }
 
+static void test_generation_reset_reuses_execution_context() {
+    auto engine = build_mock_decoder();
+    if (!engine)
+        return;
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto* ctx = engine->createExecutionContext();
+    trtmc::TrtModuleImpl module(engine.get(), ctx, stream);
+    trtmc::TrtModuleImplTestPeer::set_execution_context_name(module, "generation-context");
+
+    module.reset_execution_context();
+
+    check(trtmc::TrtModuleImplTestPeer::execution_context_name(module) == "generation-context",
+          "generation reset reuses the loaded execution context");
+
+    int32_t token_id = 7;
+    std::vector<float> attention_mask(8, 0.0F);
+    trtmc::TensorMap inputs;
+    inputs["token_id"] = trtmc::Tensor{&token_id, {1}, trtmc::DType::kInt32};
+    inputs["attention_mask"] = trtmc::Tensor{attention_mask.data(), {8}, trtmc::DType::kFloat32};
+    auto outputs = module.forward(inputs);
+    check(outputs.count("logits") == 1, "reused execution context remains executable");
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_stop_on_boxed_answer() {
     auto engine = build_mock_decoder();
     if (!engine)
@@ -396,6 +439,7 @@ int main() {
     test_generate_max_tokens();
     test_zero_max_tokens();
     test_kv_reset_is_logical_and_masks_stale_rows();
+    test_generation_reset_reuses_execution_context();
     test_stop_on_boxed_answer();
 
     if (failures > 0)

--- a/tests/cpp/models/llama/test_llama_pipeline.cpp
+++ b/tests/cpp/models/llama/test_llama_pipeline.cpp
@@ -313,6 +313,46 @@ static void test_zero_max_tokens() {
     cudaStreamDestroy(stream);
 }
 
+static void test_kv_reset_is_logical_and_masks_stale_rows() {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    trtmc::LlamaKvCache cache(1, 8, 4, stream);
+    std::vector<float> stale_k(32, 3.25F);
+    std::vector<float> stale_v(32, -7.5F);
+    check(cache.cache_k(0).copy_from_host(stale_k.data()), "upload stale K cache rows");
+    check(cache.cache_v(0).copy_from_host(stale_v.data()), "upload stale V cache rows");
+    cache.set_position(5);
+
+    cache.reset();
+
+    std::vector<float> actual_k(stale_k.size());
+    std::vector<float> actual_v(stale_v.size());
+    check(cache.cache_k(0).copy_to_host(actual_k.data()), "download stale K cache rows");
+    check(cache.cache_v(0).copy_to_host(actual_v.data()), "download stale V cache rows");
+    check(actual_k == stale_k, "logical reset preserves allocated K cache storage");
+    check(actual_v == stale_v, "logical reset preserves allocated V cache storage");
+    check(cache.position() == 0, "logical reset clears the visible cache length");
+
+    trtmc::TensorMap inputs;
+    cache.prepare_step(inputs);
+    const auto mask_it = inputs.find("attention_mask");
+    check(mask_it != inputs.end(), "logical reset creates an attention mask");
+    if (mask_it != inputs.end()) {
+        const auto& mask = mask_it->second;
+        check(mask.shape == std::vector<int64_t>{9}, "logical reset mask covers cache and token");
+        const auto* values = static_cast<const float*>(mask.data);
+        bool stale_rows_hidden = values != nullptr;
+        for (int32_t i = 0; stale_rows_hidden && i < 8; ++i)
+            stale_rows_hidden = values[i] < -1000.0F;
+        check(stale_rows_hidden, "logical reset masks every stale cache row");
+        check(values != nullptr && values[8] == 0.0F,
+              "logical reset keeps the current token visible");
+    }
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_stop_on_boxed_answer() {
     auto engine = build_mock_decoder();
     if (!engine)
@@ -355,6 +395,7 @@ int main() {
     test_generate_stops_at_eos();
     test_generate_max_tokens();
     test_zero_max_tokens();
+    test_kv_reset_is_logical_and_masks_stale_rows();
     test_stop_on_boxed_answer();
 
     if (failures > 0)

--- a/tests/cpp/test_trt_module.cpp
+++ b/tests/cpp/test_trt_module.cpp
@@ -42,7 +42,6 @@
 #include <cstring>
 #include <cuda_runtime_api.h>
 #include <iostream>
-#include <string>
 #include <vector>
 
 static int failures = 0;
@@ -56,21 +55,6 @@ static void check(bool condition, const char* test_name) {
 
 // Process-wide logger (TRT requires a single logger for all objects).
 static trtmc::TrtLogger g_logger;
-
-namespace trtmc {
-
-class TrtModuleImplTestPeer {
-  public:
-    static void set_execution_context_name(TrtModuleImpl& module, const char* name) {
-        module.ctx_->setName(name);
-    }
-
-    static std::string execution_context_name(const TrtModuleImpl& module) {
-        return module.ctx_->getName();
-    }
-};
-
-} // namespace trtmc
 
 // Build a tiny TRT engine: identity mapping input[4] → output[4] (float32)
 static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_identity_engine() {
@@ -331,34 +315,6 @@ static void test_bind_external() {
     cudaStreamDestroy(stream);
 }
 
-static void test_generation_reset_reuses_execution_context() {
-    auto engine = build_identity_engine();
-    if (!engine)
-        return;
-
-    cudaStream_t stream;
-    cudaStreamCreate(&stream);
-
-    auto* ctx = engine->createExecutionContext();
-    trtmc::TrtModuleImpl module(engine.get(), ctx, stream);
-    trtmc::TrtModuleImplTestPeer::set_execution_context_name(module, "generation-context");
-
-    module.reset_execution_context();
-
-    check(trtmc::TrtModuleImplTestPeer::execution_context_name(module) == "generation-context",
-          "generation reset reuses the loaded execution context");
-
-    float data[4] = {11.0f, 12.0f, 13.0f, 14.0f};
-    trtmc::Tensor input;
-    input.data = data;
-    input.shape = {4};
-    input.dtype = trtmc::DType::kFloat32;
-    auto outputs = module.forward({{"x", input}});
-    check(outputs.count("y") == 1, "reused execution context remains executable");
-
-    cudaStreamDestroy(stream);
-}
-
 static void test_unique_ptr_ownership() {
     // Modules now live behind unique_ptr<ITrtModule> — verify ownership transfer
     auto engine = build_identity_engine();
@@ -532,7 +488,6 @@ int main() {
     test_introspection();
     test_device_ptr();
     test_bind_external();
-    test_generation_reset_reuses_execution_context();
     test_unique_ptr_ownership();
     test_keep_alive();
     test_forward_device();

--- a/tests/cpp/test_trt_module.cpp
+++ b/tests/cpp/test_trt_module.cpp
@@ -42,6 +42,7 @@
 #include <cstring>
 #include <cuda_runtime_api.h>
 #include <iostream>
+#include <string>
 #include <vector>
 
 static int failures = 0;
@@ -55,6 +56,21 @@ static void check(bool condition, const char* test_name) {
 
 // Process-wide logger (TRT requires a single logger for all objects).
 static trtmc::TrtLogger g_logger;
+
+namespace trtmc {
+
+class TrtModuleImplTestPeer {
+  public:
+    static void set_execution_context_name(TrtModuleImpl& module, const char* name) {
+        module.ctx_->setName(name);
+    }
+
+    static std::string execution_context_name(const TrtModuleImpl& module) {
+        return module.ctx_->getName();
+    }
+};
+
+} // namespace trtmc
 
 // Build a tiny TRT engine: identity mapping input[4] → output[4] (float32)
 static trtmc::TrtUniquePtr<nvinfer1::ICudaEngine> build_identity_engine() {
@@ -315,6 +331,34 @@ static void test_bind_external() {
     cudaStreamDestroy(stream);
 }
 
+static void test_generation_reset_reuses_execution_context() {
+    auto engine = build_identity_engine();
+    if (!engine)
+        return;
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto* ctx = engine->createExecutionContext();
+    trtmc::TrtModuleImpl module(engine.get(), ctx, stream);
+    trtmc::TrtModuleImplTestPeer::set_execution_context_name(module, "generation-context");
+
+    module.reset_execution_context();
+
+    check(trtmc::TrtModuleImplTestPeer::execution_context_name(module) == "generation-context",
+          "generation reset reuses the loaded execution context");
+
+    float data[4] = {11.0f, 12.0f, 13.0f, 14.0f};
+    trtmc::Tensor input;
+    input.data = data;
+    input.shape = {4};
+    input.dtype = trtmc::DType::kFloat32;
+    auto outputs = module.forward({{"x", input}});
+    check(outputs.count("y") == 1, "reused execution context remains executable");
+
+    cudaStreamDestroy(stream);
+}
+
 static void test_unique_ptr_ownership() {
     // Modules now live behind unique_ptr<ITrtModule> — verify ownership transfer
     auto engine = build_identity_engine();
@@ -488,6 +532,7 @@ int main() {
     test_introspection();
     test_device_ptr();
     test_bind_external();
+    test_generation_reset_reuses_execution_context();
     test_unique_ptr_ownership();
     test_keep_alive();
     test_forward_device();

--- a/tests/tools/test_model_plugin_encapsulation_static.py
+++ b/tests/tools/test_model_plugin_encapsulation_static.py
@@ -1817,6 +1817,52 @@ def test_text_decoder_triattention_cache_is_model_owned() -> None:
     assert not violations, _format_violations(violations)
 
 
+def test_model_owned_kv_resets_do_not_clear_reserved_device_capacity() -> None:
+    """Trace: ARCH-MODPLUG-001
+    Intent: keep warm-request KV reset proportional to logical metadata instead
+    of the configured cache capacity.
+    Preconditions: stale cache rows are hidden by each model-owned cache's
+    logical length and attention-mask contract.
+    Postconditions: dense and TriAttention reset implementations contain no
+    device memset or forced stream synchronization.
+    """
+    violations = []
+    for family in sorted(_runtime_model_ids()):
+        prefix = _model_prefix(family)
+        model_dir = RUNTIME_MODELS / family
+        runtime_users = (model_dir / "plugin.cpp", model_dir / "pipeline.cpp")
+        if not any(
+            path.is_file()
+            and f"{prefix}KvCache" in path.read_text(encoding="utf-8", errors="ignore")
+            for path in runtime_users
+        ):
+            continue
+        sources = [(model_dir / "kv_cache.cpp", f"{prefix}KvCache")]
+        triattention_source = model_dir / "triattention_kv_cache.cpp"
+        if triattention_source.is_file():
+            sources.append((triattention_source, f"{prefix}TriAttentionKvCache"))
+
+        for source, class_name in sources:
+            text = source.read_text(encoding="utf-8", errors="ignore")
+            match = re.search(
+                rf"void\s+{re.escape(class_name)}::reset\(\)\s*\{{(?P<body>.*?)^\}}",
+                text,
+                re.MULTILINE | re.DOTALL,
+            )
+            if match is None:
+                violations.append((source, 0, f"missing {class_name}::reset implementation"))
+                continue
+            body = match.group("body")
+            for forbidden in ("cudaMemset", "cudaStreamSynchronize"):
+                if forbidden in body:
+                    line = text[: match.start("body")].count("\n") + 1
+                    violations.append(
+                        (source, line, f"{class_name}::reset performs {forbidden}")
+                    )
+
+    assert not violations, _format_violations(violations)
+
+
 def test_recurrent_sampler_is_model_owned() -> None:
     """Trace: ARCH-MODPLUG-001
     Intent: keep recurrent text sampling policy local to the recurrent model


### PR DESCRIPTION
## Background

Warm autoregressive requests recreated TensorRT execution contexts and cleared the full reserved KV-cache capacity before every prefill. For short generations, that setup work dominated the actual engine execution and made complete-task latency several times slower than necessary.

This PR fixes #497 without changing the prompt-to-text boundary, model precision, or quality thresholds.

## Exit Criteria

- Reuse TensorRT execution contexts when the engine, profile, shapes, and bindings remain compatible.
- Reset logical sequence state without clearing the full reserved KV capacity.
- Prevent stale cache rows from affecting a later request.
- Preserve representative dense, MoE, encoder-decoder, and VLM quality gates.
- Expose request setup time separately from prefill and decode time.

## Implementation

- Keep loaded TensorRT execution contexts, profiles, bindings, and compatible CUDA graphs alive across generation requests. Shape and binding updates continue to be applied at their mutation sites.
- Reset model-owned KV caches through logical length and position metadata. Existing attention masks and cache-length contracts hide stale rows until those rows are overwritten.
- Apply the logical reset contract to both dense and TriAttention cache implementations across registered autoregressive families.
- Add `setup_ms` to `TextResult`, CLI timing diagnostics, benchmark summaries, and dataset-benchmark JSONL output while preserving the existing `TextResult` constructor signature.
- Add deterministic tests that prove an execution context is reused and that stale device rows remain physically allocated but logically invisible after reset.

## Performance And Accuracy

Warm complete-task p50 on a GB300-class GPU. Each before/after pair uses the same bundle, precision, inputs, greedy decoding policy, warmup, iteration count, and synchronization boundary.

| Representative model | Before | After | Speedup | Output/quality check |
| --- | ---: | ---: | ---: | --- |
| Mistral 7B | 292.057 ms | 12.225 ms | 23.89x | 55/55 exact token IDs and text; E2E passed |
| Gemma 2 2B | 259.928 ms | 15.216 ms | 17.08x | 55/55 exact token IDs and text; E2E passed |
| GPT-Neo 125M | 108.075 ms | 11.192 ms | 9.66x | 50/50 exact token IDs and text; varied-length replay 17/17 exact |
| InternVL3 2B | 439.931 ms | 14.414 ms | 30.52x | Output hash unchanged; E2E passed |
| Phi tiny MoE | 313.301 ms | 61.185 ms | 5.12x | 55/55 exact token IDs and text; E2E passed |
| BART base | 7.338 ms | 7.300 ms | 1.01x | 55/55 exact token IDs and text; E2E passed |

BART is intentionally included as an encoder-decoder no-regression control; its request path did not pay the context-recreation overhead seen in the affected decoder and VLM pipelines.

## Validation

- `python3 tools/legal_headers.py --check`: passed, no findings.
- `ruff check --config ruff.toml tests/tools/test_model_plugin_encapsulation_static.py`: passed.
- `git diff --name-only --diff-filter=d -- '*.cpp' '*.h' | xargs -r clang-format --dry-run --Werror`: passed.
- `python3 tools/check_cyclomatic_complexity.py src --exclude src/cli --max-ccn 10 --top 20`: passed; maximum CCN 10.
- `python3 -m pytest tests/tools/test_model_plugin_encapsulation_static.py -q -p no:cacheprovider`: 157 passed.
- `cmake --build build --target trtmc_model_plugins -j 8`: passed for all model plugins.
- `cmake --build build --target trtmc_cpp_tests -j 8`: passed.
- `ctest --test-dir build --output-on-failure -j 8`: 137/137 passed.
- Repository E2E cases for Mistral 7B, Gemma 2 2B, Phi tiny MoE, BART base, and InternVL3 2B: 5/5 passed against their existing reference gates.

## Notes For Future Readers

- No validation thresholds or model precision settings were changed.
- The broad model-file diff follows the repository's model-owned runtime architecture: each registered family owns its cache and generation implementation. The static architecture test prevents a copied family from reintroducing capacity-sized clears.
- Suggested review order: TensorRT module reset behavior, one dense KV-cache implementation and its regression test, then the mechanically equivalent model-owned copies and timing plumbing.
