### PR TITLE
perf(whisper): accelerate mel frontend

### DIFF
--- a/src/runtime/models/whisper/pipeline.cpp
+++ b/src/runtime/models/whisper/pipeline.cpp
@@ -15,12 +15,58 @@
 #include "trtmc/tokenizer.h"
 #include "utils/wav_reader.h"
 
+#include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 #include <vector>
 
 namespace trtmc {
+
+namespace {
+
+using WhisperClock = std::chrono::steady_clock;
+
+bool whisper_stage_timing_enabled() {
+    const char* value = std::getenv("TRTMC_WHISPER_STAGE_TIMING");
+    return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
+}
+
+double elapsed_ms(WhisperClock::time_point start, WhisperClock::time_point end) {
+    return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+struct WhisperStageTimestamps {
+    WhisperClock::time_point transcribe_start;
+    WhisperClock::time_point resample_end;
+    WhisperClock::time_point mel_end;
+    WhisperClock::time_point encoder_end;
+    WhisperClock::time_point cross_kv_end;
+    WhisperClock::time_point decoder_end;
+    WhisperClock::time_point postprocess_end;
+};
+
+void report_whisper_stage_timing(bool enabled, const WhisperStageTimestamps& timestamps) {
+    if (!enabled) {
+        return;
+    }
+    std::ostringstream timing;
+    timing << "[trtmc.whisper_timing.json] {\"frontend_ms\":"
+           << elapsed_ms(timestamps.transcribe_start, timestamps.mel_end) << ",\"resample_ms\":"
+           << elapsed_ms(timestamps.transcribe_start, timestamps.resample_end)
+           << ",\"mel_ms\":" << elapsed_ms(timestamps.resample_end, timestamps.mel_end)
+           << ",\"encoder_ms\":" << elapsed_ms(timestamps.mel_end, timestamps.encoder_end)
+           << ",\"cross_kv_ms\":" << elapsed_ms(timestamps.encoder_end, timestamps.cross_kv_end)
+           << ",\"decoder_ms\":" << elapsed_ms(timestamps.cross_kv_end, timestamps.decoder_end)
+           << ",\"postprocess_ms\":"
+           << elapsed_ms(timestamps.decoder_end, timestamps.postprocess_end) << ",\"total_ms\":"
+           << elapsed_ms(timestamps.transcribe_start, timestamps.postprocess_end) << '}';
+    std::cerr << timing.str() << std::endl;
+}
+
+} // namespace
 
 // ═══════════════════════════════════════════════════════════════════════════
 // WhisperPipeline
@@ -86,6 +132,9 @@ WhisperPipeline::~WhisperPipeline() {
 
 TextResult WhisperPipeline::transcribe(const float* audio_data, int32_t num_samples,
                                        int32_t max_new_tokens, int32_t input_sample_rate) {
+    const bool report_stage_timing = whisper_stage_timing_enabled();
+    const auto transcribe_start = WhisperClock::now();
+
     // Step 0: Resample if needed
     const float* samples_ptr = audio_data;
     int32_t samples_count = num_samples;
@@ -99,6 +148,7 @@ TextResult WhisperPipeline::transcribe(const float* audio_data, int32_t num_samp
         samples_ptr = resampled_buf.data();
         samples_count = static_cast<int32_t>(resampled_buf.size());
     }
+    const auto resample_end = WhisperClock::now();
 
     // Step 1: Extract mel spectrogram
     whisper::MelResult mel;
@@ -108,6 +158,7 @@ TextResult WhisperPipeline::transcribe(const float* audio_data, int32_t num_samp
                                                mel_n_fft_, mel_hop_length_, mel_chunk_length_,
                                                mel_sampling_rate_);
     }
+    const auto mel_end = WhisperClock::now();
 
     if (mel.data.empty()) {
         return TextResult{"[mel extraction failed]", {}};
@@ -116,6 +167,7 @@ TextResult WhisperPipeline::transcribe(const float* audio_data, int32_t num_samp
     // Step 2: Run encoder
     std::cerr << "[whisper] Running encoder ..." << std::endl;
     run_encoder(mel.data.data(), mel.n_mels, mel.n_frames);
+    const auto encoder_end = WhisperClock::now();
 
     // Compute actual encoder sequence length for masking
     const int32_t mel_full = resolve_whisper_expected_mel_length(whisper_config_);
@@ -129,11 +181,13 @@ TextResult WhisperPipeline::transcribe(const float* audio_data, int32_t num_samp
     // Step 3: Set up cross-attention K/V
     std::cerr << "[whisper] Computing cross-attention K/V ..." << std::endl;
     setup_cross_attention(actual_enc_seq_len);
+    const auto cross_kv_end = WhisperClock::now();
 
     // Step 4: Run decoder
     std::vector<int32_t> initial_tokens = make_whisper_initial_decoder_tokens(whisper_config_);
     std::cerr << "[whisper] Running decoder ..." << std::endl;
     auto output_ids = run_decoder(initial_tokens, max_new_tokens);
+    const auto decoder_end = WhisperClock::now();
 
     // Step 5: Decode token IDs
     TextResult out;
@@ -141,6 +195,10 @@ TextResult WhisperPipeline::transcribe(const float* audio_data, int32_t num_samp
     if (tokenizer_ && !out.token_ids.empty()) {
         out.text = tokenizer_->decode(out.token_ids);
     }
+    const auto postprocess_end = WhisperClock::now();
+    report_whisper_stage_timing(report_stage_timing,
+                                {transcribe_start, resample_end, mel_end, encoder_end, cross_kv_end,
+                                 decoder_end, postprocess_end});
     return out;
 }
 

--- a/src/runtime/models/whisper/whisper_mel_spectrogram.cpp
+++ b/src/runtime/models/whisper/whisper_mel_spectrogram.cpp
@@ -7,6 +7,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <complex>
+#include <cstddef>
 #include <cstring>
 #include <vector>
 
@@ -25,20 +27,125 @@ std::vector<float> make_hann_window(int32_t length) {
     return window;
 }
 
-void rfft_power_direct(const float* x, int32_t n, int32_t n_out, float* power_out) {
-    const double pi2 = 2.0 * 3.14159265358979323846;
-    for (int32_t k = 0; k < n_out; ++k) {
-        double re = 0.0;
-        double im = 0.0;
-        const double w = pi2 * static_cast<double>(k) / static_cast<double>(n);
-        for (int32_t t = 0; t < n; ++t) {
-            const double angle = w * static_cast<double>(t);
-            re += static_cast<double>(x[t]) * std::cos(angle);
-            im -= static_cast<double>(x[t]) * std::sin(angle);
+bool is_power_of_two(int32_t value) {
+    return value > 0 && (value & (value - 1)) == 0;
+}
+
+void fft_radix2_inplace(std::vector<std::complex<double>>& values, bool inverse) {
+    const std::size_t size = values.size();
+    for (std::size_t i = 1, j = 0; i < size; ++i) {
+        std::size_t bit = size >> 1;
+        for (; (j & bit) != 0; bit >>= 1) {
+            j ^= bit;
         }
-        power_out[k] = static_cast<float>(re * re + im * im);
+        j ^= bit;
+        if (i < j) {
+            std::swap(values[i], values[j]);
+        }
+    }
+
+    constexpr double kPi2 = 2.0 * 3.14159265358979323846;
+    for (std::size_t length = 2; length <= size; length <<= 1) {
+        const double angle = (inverse ? kPi2 : -kPi2) / static_cast<double>(length);
+        const std::complex<double> step(std::cos(angle), std::sin(angle));
+        const std::size_t half = length / 2;
+        for (std::size_t offset = 0; offset < size; offset += length) {
+            std::complex<double> twiddle(1.0, 0.0);
+            for (std::size_t i = 0; i < half; ++i) {
+                const auto even = values[offset + i];
+                const auto odd = values[offset + i + half] * twiddle;
+                values[offset + i] = even + odd;
+                values[offset + i + half] = even - odd;
+                twiddle *= step;
+            }
+        }
+    }
+
+    if (inverse) {
+        const double scale = 1.0 / static_cast<double>(size);
+        for (auto& value : values) {
+            value *= scale;
+        }
     }
 }
+
+class RfftPowerPlan {
+  public:
+    explicit RfftPowerPlan(int32_t n) : n_(n) {
+        if (n_ <= 0 || is_power_of_two(n_)) {
+            return;
+        }
+
+        fft_size_ = 1;
+        while (fft_size_ < static_cast<std::size_t>(2 * n_ - 1)) {
+            fft_size_ <<= 1;
+        }
+
+        chirp_.resize(static_cast<std::size_t>(n_));
+        kernel_fft_.assign(fft_size_, {0.0, 0.0});
+        constexpr double kPi = 3.14159265358979323846;
+        for (int32_t i = 0; i < n_; ++i) {
+            const double index = static_cast<double>(i);
+            const double angle = kPi * index * index / static_cast<double>(n_);
+            chirp_[static_cast<std::size_t>(i)] = {std::cos(angle), -std::sin(angle)};
+            const std::complex<double> kernel(std::cos(angle), std::sin(angle));
+            kernel_fft_[static_cast<std::size_t>(i)] = kernel;
+            if (i != 0) {
+                kernel_fft_[fft_size_ - static_cast<std::size_t>(i)] = kernel;
+            }
+        }
+        fft_radix2_inplace(kernel_fft_, false);
+    }
+
+    void execute(const float* input, int32_t n_out, float* power_out) {
+        const int32_t bins = std::min(n_out, n_ / 2 + 1);
+        if (n_ <= 0) {
+            std::fill(power_out, power_out + n_out, 0.0F);
+            return;
+        }
+
+        if (is_power_of_two(n_)) {
+            workspace_.resize(static_cast<std::size_t>(n_));
+            for (int32_t i = 0; i < n_; ++i) {
+                workspace_[static_cast<std::size_t>(i)] = {static_cast<double>(input[i]), 0.0};
+            }
+            fft_radix2_inplace(workspace_, false);
+            write_power(bins, n_out, power_out);
+            return;
+        }
+
+        workspace_.assign(fft_size_, {0.0, 0.0});
+        for (int32_t i = 0; i < n_; ++i) {
+            workspace_[static_cast<std::size_t>(i)] =
+                static_cast<double>(input[i]) * chirp_[static_cast<std::size_t>(i)];
+        }
+        fft_radix2_inplace(workspace_, false);
+        for (std::size_t i = 0; i < fft_size_; ++i) {
+            workspace_[i] *= kernel_fft_[i];
+        }
+        fft_radix2_inplace(workspace_, true);
+        for (int32_t k = 0; k < bins; ++k) {
+            const auto value =
+                workspace_[static_cast<std::size_t>(k)] * chirp_[static_cast<std::size_t>(k)];
+            power_out[k] = static_cast<float>(std::norm(value));
+        }
+        std::fill(power_out + bins, power_out + n_out, 0.0F);
+    }
+
+  private:
+    void write_power(int32_t bins, int32_t n_out, float* power_out) const {
+        for (int32_t k = 0; k < bins; ++k) {
+            power_out[k] = static_cast<float>(std::norm(workspace_[static_cast<std::size_t>(k)]));
+        }
+        std::fill(power_out + bins, power_out + n_out, 0.0F);
+    }
+
+    int32_t n_{0};
+    std::size_t fft_size_{0};
+    std::vector<std::complex<double>> chirp_;
+    std::vector<std::complex<double>> kernel_fft_;
+    std::vector<std::complex<double>> workspace_;
+};
 
 std::vector<float> build_center_padded_audio(const float* samples, int32_t n_samples,
                                              int32_t chunk_length_s, int32_t sample_rate,
@@ -57,46 +164,44 @@ std::vector<float> build_center_padded_audio(const float* samples, int32_t n_sam
     return padded;
 }
 
-std::vector<float> compute_power_spectrogram(const std::vector<float>& padded,
-                                             const std::vector<float>& window, int32_t n_fft,
-                                             int32_t hop_length, int32_t n_freq_bins,
-                                             int32_t& n_frames_raw) {
+std::vector<float> compute_mel_spectrogram(const std::vector<float>& padded,
+                                           const std::vector<float>& window,
+                                           const float* mel_filters, int32_t n_fft,
+                                           int32_t hop_length, int32_t n_freq_bins,
+                                           int32_t n_mel_bins, int32_t frames_to_compute,
+                                           int32_t& n_frames_raw) {
     n_frames_raw = 1 + (static_cast<int32_t>(padded.size()) - n_fft) / hop_length;
-    std::vector<float> power(static_cast<std::size_t>(n_freq_bins) * n_frames_raw, 0.0F);
+    std::vector<float> mel_spec(static_cast<std::size_t>(n_mel_bins) * n_frames_raw, 0.0F);
     std::vector<float> windowed(n_fft);
     std::vector<float> frame_power(n_freq_bins);
+    std::vector<float> frame_mel(n_mel_bins);
+    RfftPowerPlan fft_plan(n_fft);
 
-    for (int32_t t = 0; t < n_frames_raw; ++t) {
+    const int32_t computed_frames = std::clamp(frames_to_compute, 0, n_frames_raw);
+    for (int32_t t = 0; t < computed_frames; ++t) {
         const int32_t start = t * hop_length;
         for (int32_t i = 0; i < n_fft; ++i) {
             windowed[static_cast<std::size_t>(i)] =
                 padded[static_cast<std::size_t>(start + i)] * window[static_cast<std::size_t>(i)];
         }
 
-        rfft_power_direct(windowed.data(), n_fft, n_freq_bins, frame_power.data());
+        fft_plan.execute(windowed.data(), n_freq_bins, frame_power.data());
 
+        std::fill(frame_mel.begin(), frame_mel.end(), 0.0F);
         for (int32_t f = 0; f < n_freq_bins; ++f) {
-            power[static_cast<std::size_t>(f) * n_frames_raw + t] = frame_power[f];
-        }
-    }
-    return power;
-}
-
-std::vector<float> project_power_to_mel(const std::vector<float>& power, const float* mel_filters,
-                                        int32_t n_freq_bins, int32_t n_mel_bins,
-                                        int32_t n_frames_raw) {
-    std::vector<float> mel_spec(static_cast<std::size_t>(n_mel_bins) * n_frames_raw, 0.0F);
-
-    for (int32_t t = 0; t < n_frames_raw; ++t) {
-        for (int32_t f = 0; f < n_freq_bins; ++f) {
-            const float p = power[static_cast<std::size_t>(f) * n_frames_raw + t];
+            const float p = frame_power[static_cast<std::size_t>(f)];
             if (p == 0.0F) {
                 continue;
             }
+            const float* filter_row = mel_filters + static_cast<std::size_t>(f) * n_mel_bins;
             for (int32_t m = 0; m < n_mel_bins; ++m) {
-                mel_spec[static_cast<std::size_t>(m) * n_frames_raw + t] +=
-                    p * mel_filters[static_cast<std::size_t>(f) * n_mel_bins + m];
+                frame_mel[static_cast<std::size_t>(m)] +=
+                    p * filter_row[static_cast<std::size_t>(m)];
             }
+        }
+        for (int32_t m = 0; m < n_mel_bins; ++m) {
+            mel_spec[static_cast<std::size_t>(m) * n_frames_raw + t] =
+                frame_mel[static_cast<std::size_t>(m)];
         }
     }
     return mel_spec;
@@ -137,19 +242,38 @@ std::vector<float> trim_last_frame(std::vector<float> mel_spec, int32_t n_mel_bi
 
 } // namespace
 
+namespace detail {
+
+std::vector<float> rfft_power(const std::vector<float>& input) {
+    const int32_t n = static_cast<int32_t>(input.size());
+    const int32_t n_out = n / 2 + 1;
+    std::vector<float> power(static_cast<std::size_t>(n_out), 0.0F);
+    if (n > 0) {
+        RfftPowerPlan plan(n);
+        plan.execute(input.data(), n_out, power.data());
+    }
+    return power;
+}
+
+} // namespace detail
+
 MelResult extract_mel_spectrogram(const float* samples, int32_t n_samples, const float* mel_filters,
                                   int32_t n_freq_bins, int32_t n_mel_bins, int32_t n_fft,
                                   int32_t hop_length, int32_t chunk_length_s, int32_t sample_rate) {
     const int32_t expected_freq_bins = n_fft / 2 + 1;
     const int32_t freq_bins = n_freq_bins == expected_freq_bins ? n_freq_bins : expected_freq_bins;
+    const int32_t chunk_samples = chunk_length_s * sample_rate;
+    const int32_t valid_audio = std::min(std::max(n_samples, 0), chunk_samples);
+    const int32_t pad_size = n_fft / 2;
+    const int32_t frames_to_compute =
+        valid_audio > 0 && hop_length > 0 ? 1 + (pad_size + valid_audio - 1) / hop_length : 0;
     const std::vector<float> padded =
         build_center_padded_audio(samples, n_samples, chunk_length_s, sample_rate, n_fft);
 
     int32_t n_frames_raw = 0;
-    const std::vector<float> power = compute_power_spectrogram(
-        padded, make_hann_window(n_fft), n_fft, hop_length, freq_bins, n_frames_raw);
     std::vector<float> mel_spec =
-        project_power_to_mel(power, mel_filters, freq_bins, n_mel_bins, n_frames_raw);
+        compute_mel_spectrogram(padded, make_hann_window(n_fft), mel_filters, n_fft, hop_length,
+                                freq_bins, n_mel_bins, frames_to_compute, n_frames_raw);
     normalize_log_mel_inplace(mel_spec);
 
     int32_t n_frames_out = 0;

--- a/src/runtime/models/whisper/whisper_mel_spectrogram.h
+++ b/src/runtime/models/whisper/whisper_mel_spectrogram.h
@@ -11,6 +11,14 @@
 namespace trtmc {
 namespace whisper {
 
+namespace detail {
+
+// Internal seam used by the focused frontend tests. Production callers should
+// use extract_mel_spectrogram().
+std::vector<float> rfft_power(const std::vector<float>& input);
+
+} // namespace detail
+
 struct MelResult {
     std::vector<float> data; // [n_mels, n_frames] row-major
     int32_t n_mels{0};

--- a/tests/cpp/models/whisper/test_whisper_mel_spectrogram.cpp
+++ b/tests/cpp/models/whisper/test_whisper_mel_spectrogram.cpp
@@ -31,6 +31,165 @@ std::vector<float> make_identity_filterbank(int32_t n_freq_bins, int32_t n_mel_b
     return fb;
 }
 
+std::vector<float> reference_rfft_power(const std::vector<float>& input) {
+    const int32_t n = static_cast<int32_t>(input.size());
+    const int32_t n_out = n / 2 + 1;
+    const double pi2 = 2.0 * 3.14159265358979323846;
+    std::vector<float> power(static_cast<std::size_t>(n_out), 0.0F);
+    for (int32_t k = 0; k < n_out; ++k) {
+        double real = 0.0;
+        double imag = 0.0;
+        for (int32_t t = 0; t < n; ++t) {
+            const double angle =
+                pi2 * static_cast<double>(k) * static_cast<double>(t) / static_cast<double>(n);
+            real += static_cast<double>(input[static_cast<std::size_t>(t)]) * std::cos(angle);
+            imag -= static_cast<double>(input[static_cast<std::size_t>(t)]) * std::sin(angle);
+        }
+        power[static_cast<std::size_t>(k)] = static_cast<float>(real * real + imag * imag);
+    }
+    return power;
+}
+
+bool vectors_close(const std::vector<float>& actual, const std::vector<float>& expected,
+                   float relative_tolerance, float absolute_tolerance) {
+    if (actual.size() != expected.size()) {
+        return false;
+    }
+    for (std::size_t i = 0; i < actual.size(); ++i) {
+        const float tolerance =
+            absolute_tolerance +
+            relative_tolerance * std::abs(expected[static_cast<std::size_t>(i)]);
+        if (std::abs(actual[i] - expected[i]) > tolerance) {
+            std::cerr << "mismatch at " << i << ": actual=" << actual[i]
+                      << " expected=" << expected[i] << " tolerance=" << tolerance << '\n';
+            return false;
+        }
+    }
+    return true;
+}
+
+void check_fft_matches_direct(const std::vector<float>& input, const char* test_name) {
+    const auto actual = trtmc::whisper::detail::rfft_power(input);
+    const auto reference = reference_rfft_power(input);
+    check(vectors_close(actual, reference, 1e-5F, 1e-6F), test_name);
+}
+
+void test_whisper_fft_matches_direct_dft() {
+    check_fft_matches_direct({0.25F, -0.5F, 0.75F, 1.0F, -0.25F, 0.125F, 0.5F, -0.75F},
+                             "whisper radix-2 FFT power matches direct DFT");
+
+    std::vector<float> whisper_input(400);
+    for (std::size_t i = 0; i < whisper_input.size(); ++i) {
+        whisper_input[i] = static_cast<float>(std::sin(static_cast<double>(i) * 0.17) +
+                                              0.25 * std::cos(static_cast<double>(i) * 0.07));
+    }
+    check_fft_matches_direct(whisper_input, "whisper 400-point FFT power matches direct DFT");
+}
+
+std::vector<float> make_hf_5_2_filterbank() {
+    // WhisperFeatureExtractor 5.2.0 with feature_size=4,
+    // sampling_rate=16000, n_fft=32. Layout is [frequency, mel].
+    return {
+        0.0F,           0.0F,           0.0F,           0.0F,           0.00133960015F,
+        0.0F,           0.0F,           0.0F,           0.00060509576F, 0.00073521355F,
+        0.0F,           0.0F,           0.0F,           0.00088614809F, 0.00016090245F,
+        0.0F,           0.0F,           0.00033586150F, 0.00046726403F, 0.0F,
+        0.0F,           0.0F,           0.00059016780F, 0.00003439805F, 0.0F,
+        0.0F,           0.00042571520F, 0.00012267498F, 0.0F,           0.0F,
+        0.00026126259F, 0.00021095191F, 0.0F,           0.0F,           0.00009680999F,
+        0.00029922883F, 0.0F,           0.0F,           0.0F,           0.00033170475F,
+        0.0F,           0.0F,           0.0F,           0.00028431836F, 0.0F,
+        0.0F,           0.0F,           0.00023693196F, 0.0F,           0.0F,
+        0.0F,           0.00018954557F, 0.0F,           0.0F,           0.0F,
+        0.00014215918F, 0.0F,           0.0F,           0.0F,           0.00009477279F,
+        0.0F,           0.0F,           0.0F,           0.00004738639F, 0.0F,
+        0.0F,           0.0F,           0.0F,
+    };
+}
+
+trtmc::whisper::MelResult extract_hf_fixture_mel(const std::vector<float>& audio) {
+    const auto filterbank = make_hf_5_2_filterbank();
+    return trtmc::whisper::extract_mel_spectrogram(audio.data(), static_cast<int32_t>(audio.size()),
+                                                   filterbank.data(), 17, 4, 32, 8, 1, 16000);
+}
+
+void check_hf_5_2_fixture(const std::vector<float>& audio, const std::vector<int32_t>& indices,
+                          const std::vector<float>& expected, const char* test_name) {
+    const auto mel = extract_hf_fixture_mel(audio);
+    check(mel.n_mels == 4 && mel.n_frames == 2000, "Whisper HF fixture shape matches");
+    std::vector<float> selected;
+    selected.reserve(static_cast<std::size_t>(mel.n_mels) * indices.size());
+    for (int32_t m = 0; m < mel.n_mels; ++m) {
+        for (const int32_t index : indices) {
+            selected.push_back(mel.data[static_cast<std::size_t>(m) * mel.n_frames + index]);
+        }
+    }
+    check(vectors_close(selected, expected, 1e-5F, 2e-5F), test_name);
+}
+
+void test_whisper_matches_pinned_hf_frontend() {
+    std::vector<float> short_audio(64, 0.0F);
+    for (int32_t i = 0; i < 32; ++i) {
+        short_audio[static_cast<std::size_t>(i + 16)] =
+            static_cast<float>(0.35 * std::sin(static_cast<double>(i) * 0.47) +
+                               0.2 * std::cos(static_cast<double>(i) * 0.19));
+    }
+    const std::vector<int32_t> short_indices = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 1999};
+    const std::vector<float> short_expected = {
+        -1.47796965F, 0.19769770F,  0.49146098F,  0.52203035F,  0.37673461F,  0.47700906F,
+        0.44652843F,  0.16935682F,  -1.47796965F, -1.47796965F, -1.47796965F, -1.47796965F,
+        -1.47796965F, -1.47796965F, 0.14345938F,  0.44907600F,  0.51333833F,  0.45681787F,
+        0.50315177F,  0.45515430F,  0.14392549F,  -1.47796965F, -1.47796965F, -1.47796965F,
+        -1.47796965F, -1.47796965F, -1.47796965F, -0.00149941F, 0.21142197F,  0.23270231F,
+        0.23056060F,  0.27122152F,  0.29486173F,  0.06656158F,  -1.47796965F, -1.47796965F,
+        -1.47796965F, -1.47796965F, -1.47796965F, -1.47796965F, -0.27518058F, -0.17686820F,
+        -0.36955905F, -0.69783723F, -0.04921615F, 0.08560586F,  -0.08074880F, -1.47796965F,
+        -1.47796965F, -1.47796965F, -1.47796965F, -1.47796965F,
+    };
+    check_hf_5_2_fixture(short_audio, short_indices, short_expected,
+                         "Whisper short audio matches Transformers 5.2.0");
+
+    const std::vector<float> padded_audio(64, 0.0F);
+    const std::vector<int32_t> padded_indices = {0, 1, 2, 999, 1999};
+    check_hf_5_2_fixture(padded_audio, padded_indices, std::vector<float>(20, -1.5F),
+                         "Whisper zero-padded audio matches Transformers 5.2.0");
+
+    std::vector<float> boundary_audio(16000, 0.0F);
+    for (int32_t i = 0; i < 15968; ++i) {
+        boundary_audio[static_cast<std::size_t>(i + 16)] =
+            static_cast<float>(0.35 * std::sin(static_cast<double>(i) * 0.047) +
+                               0.2 * std::cos(static_cast<double>(i) * 0.019));
+    }
+    const std::vector<int32_t> boundary_indices = {0,    1,    2,    3,    10,  999,
+                                                   1995, 1996, 1997, 1998, 1999};
+    const std::vector<float> boundary_expected = {
+        -1.39574528F, 0.09532887F,  0.41899896F,  0.51257664F,  0.37318176F,  0.35541523F,
+        0.53302789F,  0.49865597F,  0.43587410F,  0.29114467F,  -0.11682808F, -1.39574528F,
+        0.02567625F,  0.19092834F,  -0.06663859F, -0.05304563F, -0.15682101F, -0.23419797F,
+        -0.14918065F, -0.05524480F, 0.07153308F,  -0.17537153F, -1.39574528F, -0.11697865F,
+        -0.00449359F, -0.16378736F, -0.49035490F, -0.60813010F, -0.72875285F, -0.60238636F,
+        -0.29121733F, -0.17834580F, -0.31444991F, -1.39574528F, -0.25144815F, -0.12285542F,
+        -0.29862618F, -0.92274916F, -1.04521441F, -1.18764424F, -1.04027009F, -0.43942106F,
+        -0.30394208F, -0.47242820F,
+    };
+    check_hf_5_2_fixture(boundary_audio, boundary_indices, boundary_expected,
+                         "Whisper chunk-boundary audio matches Transformers 5.2.0");
+}
+
+void test_whisper_skipped_tail_matches_full_zero_padding() {
+    std::vector<float> short_audio(64, 0.0F);
+    for (std::size_t i = 0; i < short_audio.size(); ++i) {
+        short_audio[i] = static_cast<float>(0.3 * std::sin(static_cast<double>(i) * 0.41));
+    }
+    std::vector<float> explicitly_padded(16000, 0.0F);
+    std::copy(short_audio.begin(), short_audio.end(), explicitly_padded.begin());
+
+    const auto short_mel = extract_hf_fixture_mel(short_audio);
+    const auto full_mel = extract_hf_fixture_mel(explicitly_padded);
+    check(vectors_close(short_mel.data, full_mel.data, 1e-6F, 1e-6F),
+          "Whisper skipped zero tail preserves full-padding features");
+}
+
 void test_whisper_shape_and_energy() {
     const int32_t sample_rate = 16000;
     const int32_t n_fft = 400;
@@ -69,6 +228,9 @@ void test_whisper_shape_and_energy() {
 } // namespace
 
 int main() {
+    test_whisper_fft_matches_direct_dft();
+    test_whisper_matches_pinned_hf_frontend();
+    test_whisper_skipped_tail_matches_full_zero_padding();
     test_whisper_shape_and_energy();
     return failures;
 }


### PR DESCRIPTION
## Background

Closes #498.

Whisper computed every STFT frame in the fixed 30-second input window with a scalar `O(N^2)` direct DFT. For short audio, almost all of that work covered zero padding, and frontend processing dominated the complete transcription latency.

## Exit Criteria

- Use an optimized transform for Whisper's non-power-of-two 400-point FFT.
- Do not evaluate STFT frames whose windows cannot overlap real audio.
- Preserve Whisper feature and transcript quality for short, padded, and boundary inputs.
- Expose frontend, encoder, decoder, and postprocess timing for diagnosis.

## Implementation

- Add a reusable per-extraction real-FFT plan. Power-of-two inputs use radix-2 FFT; Whisper's 400-point transform uses Bluestein convolution backed by a 1024-point radix-2 FFT.
- Fuse power-spectrum-to-mel projection into the frame loop instead of materializing the full power tensor.
- Stop processing after the last frame that can overlap source audio. The untouched tail retains the same zero-power/log-mel padding semantics.
- Add opt-in JSON stage timing through `TRTMC_WHISPER_STAGE_TIMING=1`.
- Add numerical tests against the former direct DFT and pinned Transformers 5.2.0 frontend values for short, zero-padded, and full-chunk boundary inputs.

## Validation

On the same GB300-class GPU, bundle, decoded PCM, precision, warmup count, iteration count, synchronization boundary, and host transcript output:

| Measurement | Baseline p50 | Optimized p50 | Speedup |
| --- | ---: | ---: | ---: |
| Complete task E2E, 4.16-second input, 5 warmups + 50 samples | 2,744.49 ms | 37.93 ms | 72.36x |
| Frontend-only, 1-second input padded to 30 seconds | 2,755.27 ms | 27.18 ms | 101.37x |
| Frontend-only, full 30-second input | 2,775.69 ms | 134.37 ms | 20.66x |

The optimized 50-sample stage breakdown had p50 frontend 18.51 ms (resample 1.09 ms, mel 17.41 ms), encoder 9.38 ms, cross-attention setup 0.06 ms, decoder 10.17 ms, and postprocess 0.002 ms.

- Repository Whisper manifest task evaluation: passed all ASR probes against the pinned HF reference.
- Native 50-sample replay: stable transcript, output hash, character count, and token count; output matched the baseline.
- `ctest --test-dir build --output-on-failure -R whisper_mel_spectrogram`: passed.
- `python3 -m pytest tests/tools/test_model_plugin_encapsulation_static.py -q`: 156 passed.
- `python3 tools/legal_headers.py --check`: passed with no findings.
- `clang-format --dry-run --Werror` on all changed C++ files: passed.
- `python3 tools/check_cyclomatic_complexity.py --max-ccn 10 src/runtime/models/whisper/pipeline.cpp src/runtime/models/whisper/whisper_mel_spectrogram.cpp tests/cpp/models/whisper/test_whisper_mel_spectrogram.cpp`: passed; maximum CCN 10.

## Notes For Future Readers

- Review the FFT plan and frame-overlap bound first, then the golden frontend tests, and finally the opt-in pipeline timing.
- The stage timing is disabled by default and does not alter the public result schema.
- Bluestein is required here because Whisper's default `n_fft=400` cannot use radix-2 FFT directly.
