### PR TITLE
perf(rnnt): make speech features incremental

### DIFF
--- a/src/runtime/models/nemotron_speech_streaming/audio_helpers.cpp
+++ b/src/runtime/models/nemotron_speech_streaming/audio_helpers.cpp
@@ -5,9 +5,15 @@
 
 #include "audio_helpers.h"
 
+#include "utils/wav_reader.h"
+
 #include <algorithm>
 #include <cmath>
+#include <complex>
+#include <cstddef>
 #include <cstring>
+#include <memory>
+#include <stdexcept>
 #include <vector>
 
 namespace trtmc {
@@ -63,6 +69,71 @@ void rfft_power_direct(const float* x, int32_t n, int32_t n_out, float* power_ou
     }
 }
 
+bool is_power_of_two(int32_t value) {
+    return value > 0 && (value & (value - 1)) == 0;
+}
+
+void rfft_power_radix2(const float* x, int32_t n, int32_t n_out, float* power_out,
+                       std::vector<std::complex<double>>& workspace) {
+    workspace.resize(static_cast<std::size_t>(n));
+    for (int32_t i = 0; i < n; ++i) {
+        workspace[static_cast<std::size_t>(i)] =
+            std::complex<double>(static_cast<double>(x[i]), 0.0);
+    }
+
+    for (int32_t i = 1, j = 0; i < n; ++i) {
+        int32_t bit = n >> 1;
+        for (; (j & bit) != 0; bit >>= 1) {
+            j ^= bit;
+        }
+        j ^= bit;
+        if (i < j) {
+            std::swap(workspace[static_cast<std::size_t>(i)],
+                      workspace[static_cast<std::size_t>(j)]);
+        }
+    }
+
+    const double pi2 = 2.0 * 3.14159265358979323846;
+    for (int32_t length = 2; length <= n; length <<= 1) {
+        const double angle = -pi2 / static_cast<double>(length);
+        const std::complex<double> step(std::cos(angle), std::sin(angle));
+        const int32_t half = length / 2;
+        for (int32_t offset = 0; offset < n; offset += length) {
+            std::complex<double> twiddle(1.0, 0.0);
+            for (int32_t i = 0; i < half; ++i) {
+                const auto even = workspace[static_cast<std::size_t>(offset + i)];
+                const auto odd = workspace[static_cast<std::size_t>(offset + i + half)] * twiddle;
+                workspace[static_cast<std::size_t>(offset + i)] = even + odd;
+                workspace[static_cast<std::size_t>(offset + i + half)] = even - odd;
+                twiddle *= step;
+            }
+        }
+    }
+
+    const int32_t bins = std::min(n_out, n / 2 + 1);
+    for (int32_t k = 0; k < bins; ++k) {
+        power_out[k] = static_cast<float>(std::norm(workspace[static_cast<std::size_t>(k)]));
+    }
+    std::fill(power_out + bins, power_out + n_out, 0.0F);
+}
+
+class RfftPowerPlan {
+  public:
+    explicit RfftPowerPlan(int32_t n) : n_(n) {}
+
+    void execute(const float* input, int32_t n_out, float* power_out) {
+        if (is_power_of_two(n_)) {
+            rfft_power_radix2(input, n_, n_out, power_out, workspace_);
+            return;
+        }
+        rfft_power_direct(input, n_, n_out, power_out);
+    }
+
+  private:
+    int32_t n_{0};
+    std::vector<std::complex<double>> workspace_;
+};
+
 std::vector<float> build_center_padded_audio(const float* samples, int32_t n_samples,
                                              int32_t chunk_length_s, int32_t sample_rate,
                                              int32_t n_fft, float preemphasis) {
@@ -99,46 +170,44 @@ std::vector<float> make_stft_window(const MelSpectrogramOptions& options) {
     return make_hann_window(options.n_fft);
 }
 
-std::vector<float> compute_power_spectrogram(const std::vector<float>& padded,
-                                             const std::vector<float>& window, int32_t n_fft,
-                                             int32_t hop_length, int32_t n_freq_bins,
-                                             int32_t& n_frames_raw) {
+std::vector<float> compute_mel_spectrogram(const std::vector<float>& padded,
+                                           const std::vector<float>& window,
+                                           const float* mel_filters, int32_t n_fft,
+                                           int32_t hop_length, int32_t n_freq_bins,
+                                           int32_t n_mel_bins, int32_t frames_to_compute,
+                                           int32_t& n_frames_raw) {
     n_frames_raw = 1 + (static_cast<int32_t>(padded.size()) - n_fft) / hop_length;
-    std::vector<float> power(static_cast<std::size_t>(n_freq_bins) * n_frames_raw, 0.0F);
+    std::vector<float> mel_spec(static_cast<std::size_t>(n_mel_bins) * n_frames_raw, 0.0F);
     std::vector<float> windowed(n_fft);
     std::vector<float> frame_power(n_freq_bins);
+    std::vector<float> frame_mel(n_mel_bins);
+    RfftPowerPlan fft_plan(n_fft);
 
-    for (int32_t t = 0; t < n_frames_raw; ++t) {
+    const int32_t computed_frames = std::clamp(frames_to_compute, 0, n_frames_raw);
+    for (int32_t t = 0; t < computed_frames; ++t) {
         const int32_t start = t * hop_length;
         for (int32_t i = 0; i < n_fft; ++i) {
             windowed[static_cast<std::size_t>(i)] =
                 padded[static_cast<std::size_t>(start + i)] * window[static_cast<std::size_t>(i)];
         }
 
-        rfft_power_direct(windowed.data(), n_fft, n_freq_bins, frame_power.data());
+        fft_plan.execute(windowed.data(), n_freq_bins, frame_power.data());
 
+        std::fill(frame_mel.begin(), frame_mel.end(), 0.0F);
         for (int32_t f = 0; f < n_freq_bins; ++f) {
-            power[static_cast<std::size_t>(f) * n_frames_raw + t] = frame_power[f];
-        }
-    }
-    return power;
-}
-
-std::vector<float> project_power_to_mel(const std::vector<float>& power, const float* mel_filters,
-                                        int32_t n_freq_bins, int32_t n_mel_bins,
-                                        int32_t n_frames_raw) {
-    std::vector<float> mel_spec(static_cast<std::size_t>(n_mel_bins) * n_frames_raw, 0.0F);
-
-    for (int32_t t = 0; t < n_frames_raw; ++t) {
-        for (int32_t f = 0; f < n_freq_bins; ++f) {
-            const float p = power[static_cast<std::size_t>(f) * n_frames_raw + t];
+            const float p = frame_power[static_cast<std::size_t>(f)];
             if (p == 0.0F) {
                 continue;
             }
+            const float* filter_row = mel_filters + static_cast<std::size_t>(f) * n_mel_bins;
             for (int32_t m = 0; m < n_mel_bins; ++m) {
-                mel_spec[static_cast<std::size_t>(m) * n_frames_raw + t] +=
-                    p * mel_filters[static_cast<std::size_t>(f) * n_mel_bins + m];
+                frame_mel[static_cast<std::size_t>(m)] +=
+                    p * filter_row[static_cast<std::size_t>(m)];
             }
+        }
+        for (int32_t m = 0; m < n_mel_bins; ++m) {
+            mel_spec[static_cast<std::size_t>(m) * n_frames_raw + t] =
+                frame_mel[static_cast<std::size_t>(m)];
         }
     }
     return mel_spec;
@@ -241,22 +310,250 @@ std::vector<float> trim_last_frame(std::vector<float> mel_spec, int32_t n_mel_bi
 
 } // namespace
 
+namespace detail {
+
+std::vector<float> rfft_power(const std::vector<float>& input) {
+    const int32_t n = static_cast<int32_t>(input.size());
+    const int32_t n_out = n / 2 + 1;
+    std::vector<float> power(static_cast<std::size_t>(n_out), 0.0F);
+    if (n > 0) {
+        RfftPowerPlan plan(n);
+        plan.execute(input.data(), n_out, power.data());
+    }
+    return power;
+}
+
+} // namespace detail
+
+class IncrementalMelSpectrogram::Impl {
+  public:
+    Impl(const float* mel_filters, int32_t n_freq_bins, int32_t n_mel_bins,
+         MelSpectrogramOptions options, int32_t input_sample_rate)
+        : options_(std::move(options)), input_sample_rate_(input_sample_rate),
+          n_freq_bins_(n_freq_bins), n_mel_bins_(n_mel_bins), window_(make_stft_window(options_)),
+          fft_plan_(options_.n_fft), windowed_(static_cast<std::size_t>(options_.n_fft)),
+          frame_power_(static_cast<std::size_t>(n_freq_bins)),
+          frame_mel_(static_cast<std::size_t>(n_mel_bins)) {
+        if (mel_filters == nullptr || n_freq_bins != options_.n_fft / 2 + 1 || n_mel_bins <= 0) {
+            throw std::invalid_argument("incremental RNNT mel requires a complete filterbank");
+        }
+        if (input_sample_rate_ <= 0 || options_.sample_rate <= 0 || options_.n_fft <= 0 ||
+            options_.hop_length <= 0) {
+            throw std::invalid_argument("incremental RNNT mel requires positive dimensions");
+        }
+        if (options_.log_scale != MelLogScale::kNaturalLog || options_.normalize_per_feature) {
+            throw std::invalid_argument(
+                "incremental RNNT mel only supports natural-log features without normalization");
+        }
+        mel_filters_.assign(mel_filters,
+                            mel_filters + static_cast<std::size_t>(n_freq_bins_) * n_mel_bins_);
+    }
+
+    void accept_audio(const float* samples, int32_t n_samples) {
+        if (n_samples < 0 || (n_samples > 0 && samples == nullptr)) {
+            throw std::invalid_argument("incremental RNNT mel received invalid audio");
+        }
+        if (n_samples == 0) {
+            return;
+        }
+        raw_audio_.insert(raw_audio_.end(), samples, samples + n_samples);
+    }
+
+    int32_t target_sample_count() const {
+        const int64_t converted =
+            static_cast<int64_t>(raw_audio_.size()) * options_.sample_rate / input_sample_rate_;
+        const int64_t chunk_limit =
+            static_cast<int64_t>(options_.chunk_length_s) * options_.sample_rate;
+        return static_cast<int32_t>(std::min(converted, chunk_limit));
+    }
+
+    int32_t stable_target_sample_count(bool final) const {
+        if (final || input_sample_rate_ == options_.sample_rate) {
+            return target_sample_count();
+        }
+        constexpr int32_t kResampleHalfTaps = 16;
+        const int64_t stable_source =
+            std::max<int64_t>(0, static_cast<int64_t>(raw_audio_.size()) - kResampleHalfTaps);
+        const int64_t stable_target = stable_source * options_.sample_rate / input_sample_rate_;
+        return static_cast<int32_t>(std::min<int64_t>(stable_target, target_sample_count()));
+    }
+
+    int32_t available_frames() const { return target_sample_count() / options_.hop_length; }
+
+    void ensure_resampled_samples(int32_t required_samples, bool final) {
+        if (!final && required_samples > stable_target_sample_count(false)) {
+            throw std::runtime_error(
+                "incremental RNNT mel requested samples before resampler lookahead was ready");
+        }
+        const int32_t bounded_required = std::min(required_samples, target_sample_count());
+        const int32_t start = static_cast<int32_t>(resampled_audio_.size());
+        if (bounded_required <= start) {
+            return;
+        }
+        auto next = resample_linear_range(
+            raw_audio_.data(), static_cast<int32_t>(raw_audio_.size()), input_sample_rate_,
+            options_.sample_rate, start, bounded_required - start);
+        resampled_audio_.insert(resampled_audio_.end(), next.begin(), next.end());
+    }
+
+    float preemphasized_sample(int32_t audio_index) const {
+        if (audio_index < 0 || audio_index >= static_cast<int32_t>(resampled_audio_.size())) {
+            return 0.0F;
+        }
+        const float current = resampled_audio_[static_cast<std::size_t>(audio_index)];
+        if (options_.preemphasis == 0.0F || audio_index == 0) {
+            return current;
+        }
+        return current -
+               options_.preemphasis * resampled_audio_[static_cast<std::size_t>(audio_index - 1)];
+    }
+
+    void compute_frame(int32_t frame) {
+        const int32_t pad_size = options_.n_fft / 2;
+        const int32_t frame_start = frame * options_.hop_length - pad_size;
+        for (int32_t i = 0; i < options_.n_fft; ++i) {
+            windowed_[static_cast<std::size_t>(i)] =
+                preemphasized_sample(frame_start + i) * window_[static_cast<std::size_t>(i)];
+        }
+        fft_plan_.execute(windowed_.data(), n_freq_bins_, frame_power_.data());
+
+        std::fill(frame_mel_.begin(), frame_mel_.end(), 0.0F);
+        for (int32_t f = 0; f < n_freq_bins_; ++f) {
+            const float power = frame_power_[static_cast<std::size_t>(f)];
+            const float* filter_row =
+                mel_filters_.data() + static_cast<std::size_t>(f) * n_mel_bins_;
+            for (int32_t m = 0; m < n_mel_bins_; ++m) {
+                frame_mel_[static_cast<std::size_t>(m)] +=
+                    power * filter_row[static_cast<std::size_t>(m)];
+            }
+        }
+        constexpr float kLogGuard = 5.960464477539063e-08F;
+        for (float value : frame_mel_) {
+            frames_.push_back(std::log(value + kLogGuard));
+        }
+    }
+
+    void ensure_frames(int32_t end_frame, bool final) {
+        if (end_frame < 0 || end_frame > available_frames()) {
+            throw std::out_of_range("incremental RNNT mel frame request exceeds available audio");
+        }
+        const int32_t current_frames = frame_count();
+        if (end_frame <= current_frames) {
+            return;
+        }
+        const int32_t last_frame = end_frame - 1;
+        const int32_t required_samples =
+            last_frame * options_.hop_length + options_.n_fft - options_.n_fft / 2;
+        ensure_resampled_samples(required_samples, final);
+        for (int32_t frame = current_frames; frame < end_frame; ++frame) {
+            compute_frame(frame);
+        }
+    }
+
+    void reset() {
+        raw_audio_.clear();
+        resampled_audio_.clear();
+        frames_.clear();
+    }
+
+    int32_t frame_count() const {
+        return static_cast<int32_t>(frames_.size() / static_cast<std::size_t>(n_mel_bins_));
+    }
+
+    int32_t n_mels() const { return n_mel_bins_; }
+
+    float value(int32_t mel_bin, int32_t frame) const {
+        if (mel_bin < 0 || mel_bin >= n_mel_bins_ || frame < 0 || frame >= frame_count()) {
+            throw std::out_of_range("incremental RNNT mel feature index is out of range");
+        }
+        return frames_[static_cast<std::size_t>(frame) * n_mel_bins_ + mel_bin];
+    }
+
+    IncrementalMelStats stats() const {
+        return {static_cast<int64_t>(raw_audio_.size()),
+                static_cast<int64_t>(resampled_audio_.size()), frame_count()};
+    }
+
+    MelSpectrogramOptions options_;
+    int32_t input_sample_rate_{0};
+    int32_t n_freq_bins_{0};
+    int32_t n_mel_bins_{0};
+    std::vector<float> mel_filters_;
+    std::vector<float> window_;
+    RfftPowerPlan fft_plan_;
+    std::vector<float> raw_audio_;
+    std::vector<float> resampled_audio_;
+    std::vector<float> frames_;
+    std::vector<float> windowed_;
+    std::vector<float> frame_power_;
+    std::vector<float> frame_mel_;
+};
+
+IncrementalMelSpectrogram::IncrementalMelSpectrogram(const float* mel_filters, int32_t n_freq_bins,
+                                                     int32_t n_mel_bins,
+                                                     MelSpectrogramOptions options,
+                                                     int32_t input_sample_rate)
+    : impl_(std::make_unique<Impl>(mel_filters, n_freq_bins, n_mel_bins, std::move(options),
+                                   input_sample_rate)) {}
+
+IncrementalMelSpectrogram::~IncrementalMelSpectrogram() = default;
+IncrementalMelSpectrogram::IncrementalMelSpectrogram(IncrementalMelSpectrogram&&) noexcept =
+    default;
+IncrementalMelSpectrogram&
+IncrementalMelSpectrogram::operator=(IncrementalMelSpectrogram&&) noexcept = default;
+
+void IncrementalMelSpectrogram::accept_audio(const float* samples, int32_t n_samples) {
+    impl_->accept_audio(samples, n_samples);
+}
+
+void IncrementalMelSpectrogram::ensure_frames(int32_t end_frame, bool final) {
+    impl_->ensure_frames(end_frame, final);
+}
+
+void IncrementalMelSpectrogram::reset() {
+    impl_->reset();
+}
+
+int32_t IncrementalMelSpectrogram::available_frames() const {
+    return impl_->available_frames();
+}
+
+int32_t IncrementalMelSpectrogram::frame_count() const {
+    return impl_->frame_count();
+}
+
+int32_t IncrementalMelSpectrogram::n_mels() const {
+    return impl_->n_mels();
+}
+
+float IncrementalMelSpectrogram::value(int32_t mel_bin, int32_t frame) const {
+    return impl_->value(mel_bin, frame);
+}
+
+IncrementalMelStats IncrementalMelSpectrogram::stats() const {
+    return impl_->stats();
+}
+
 MelResult extract_configured_mel_spectrogram(const float* samples, int32_t n_samples,
                                              const float* mel_filters, int32_t n_freq_bins,
                                              int32_t n_mel_bins,
                                              const MelSpectrogramOptions& options) {
     const int32_t expected_freq_bins = options.n_fft / 2 + 1;
     const int32_t freq_bins = n_freq_bins == expected_freq_bins ? n_freq_bins : expected_freq_bins;
+    const int32_t chunk_samples = options.chunk_length_s * options.sample_rate;
+    const int32_t valid_audio = std::min(std::max(n_samples, 0), chunk_samples);
+    const int32_t pad_size = options.n_fft / 2;
+    const int32_t frames_to_compute = valid_audio > 0 && options.hop_length > 0
+                                          ? 1 + (pad_size + valid_audio - 1) / options.hop_length
+                                          : 0;
     const std::vector<float> padded =
         build_center_padded_audio(samples, n_samples, options.chunk_length_s, options.sample_rate,
                                   options.n_fft, options.preemphasis);
 
     int32_t n_frames_raw = 0;
-    const std::vector<float> power =
-        compute_power_spectrogram(padded, make_stft_window(options), options.n_fft,
-                                  options.hop_length, freq_bins, n_frames_raw);
-    std::vector<float> mel_spec =
-        project_power_to_mel(power, mel_filters, freq_bins, n_mel_bins, n_frames_raw);
+    std::vector<float> mel_spec = compute_mel_spectrogram(
+        padded, make_stft_window(options), mel_filters, options.n_fft, options.hop_length,
+        freq_bins, n_mel_bins, frames_to_compute, n_frames_raw);
     apply_log_scale_inplace(mel_spec, options.log_scale);
     if (options.normalize_per_feature) {
         const int32_t valid_frames =

--- a/src/runtime/models/nemotron_speech_streaming/audio_helpers.h
+++ b/src/runtime/models/nemotron_speech_streaming/audio_helpers.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 namespace trtmc {
@@ -33,6 +34,44 @@ struct MelSpectrogramOptions {
     float preemphasis{0.0F};
     MelLogScale log_scale{MelLogScale::kLog10Normalized};
     bool normalize_per_feature{false};
+};
+
+namespace detail {
+
+std::vector<float> rfft_power(const std::vector<float>& input);
+
+} // namespace detail
+
+struct IncrementalMelStats {
+    int64_t accepted_source_samples{0};
+    int64_t generated_resampled_samples{0};
+    int64_t computed_mel_frames{0};
+};
+
+class IncrementalMelSpectrogram {
+  public:
+    IncrementalMelSpectrogram(const float* mel_filters, int32_t n_freq_bins, int32_t n_mel_bins,
+                              MelSpectrogramOptions options, int32_t input_sample_rate);
+    ~IncrementalMelSpectrogram();
+
+    IncrementalMelSpectrogram(IncrementalMelSpectrogram&&) noexcept;
+    IncrementalMelSpectrogram& operator=(IncrementalMelSpectrogram&&) noexcept;
+    IncrementalMelSpectrogram(const IncrementalMelSpectrogram&) = delete;
+    IncrementalMelSpectrogram& operator=(const IncrementalMelSpectrogram&) = delete;
+
+    void accept_audio(const float* samples, int32_t n_samples);
+    void ensure_frames(int32_t end_frame, bool final);
+    void reset();
+
+    int32_t available_frames() const;
+    int32_t frame_count() const;
+    int32_t n_mels() const;
+    float value(int32_t mel_bin, int32_t frame) const;
+    IncrementalMelStats stats() const;
+
+  private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
 };
 
 MelResult extract_configured_mel_spectrogram(const float* samples, int32_t n_samples,

--- a/src/runtime/models/nemotron_speech_streaming/pipeline.cpp
+++ b/src/runtime/models/nemotron_speech_streaming/pipeline.cpp
@@ -12,16 +12,54 @@
 #include "utils/wav_reader.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 #include <utility>
 
 namespace trtmc {
 
 namespace {
+
+using RnntClock = std::chrono::steady_clock;
+
+struct RnntStageTotals {
+    double frontend_ms{0.0};
+    double encoder_and_transfer_ms{0.0};
+    double predictor_joint_and_transfer_ms{0.0};
+    double text_ms{0.0};
+};
+
+bool rnnt_stage_timing_enabled() {
+    const char* value = std::getenv("TRTMC_RNNT_STAGE_TIMING");
+    return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
+}
+
+double elapsed_ms(RnntClock::time_point start, RnntClock::time_point end) {
+    return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+void report_rnnt_stage_timing(bool enabled, const char* mode, const RnntStageTotals& stages,
+                              double total_ms, int64_t source_samples, int64_t resampled_samples,
+                              int64_t mel_frames) {
+    if (!enabled) {
+        return;
+    }
+    std::ostringstream timing;
+    timing << "[trtmc.rnnt_timing.json] {\"mode\":\"" << mode
+           << "\",\"frontend_ms\":" << stages.frontend_ms
+           << ",\"encoder_and_transfer_ms\":" << stages.encoder_and_transfer_ms
+           << ",\"predictor_joint_and_transfer_ms\":" << stages.predictor_joint_and_transfer_ms
+           << ",\"text_ms\":" << stages.text_ms << ",\"total_ms\":" << total_ms
+           << ",\"source_samples\":" << source_samples
+           << ",\"resampled_samples\":" << resampled_samples << ",\"mel_frames\":" << mel_frames
+           << '}';
+    std::cerr << timing.str() << std::endl;
+}
 
 Tensor make_tensor(void* data, std::vector<int64_t> shape, DType dtype) {
     Tensor t;
@@ -56,6 +94,20 @@ int32_t subsampled_frame_count(int32_t frames, bool causal) {
 bool rnnt_stream_debug_enabled() {
     const char* v = std::getenv("TRTMC_RNNT_STREAM_DEBUG");
     return v && std::string(v) != "0";
+}
+
+rnnt::MelSpectrogramOptions make_rnnt_mel_options(const RnntConfig& config) {
+    rnnt::MelSpectrogramOptions options;
+    options.n_fft = config.mel_n_fft;
+    options.win_length = config.mel_win_length;
+    options.hop_length = config.mel_hop_length;
+    options.chunk_length_s = config.mel_chunk_length;
+    options.sample_rate = config.sample_rate;
+    options.symmetric_window = true;
+    options.center_window_in_fft = true;
+    options.preemphasis = config.mel_preemph;
+    options.log_scale = rnnt::MelLogScale::kNaturalLog;
+    return options;
 }
 
 void validate_rnnt_module(const std::unique_ptr<TrtModule>& module, const char* name) {
@@ -107,13 +159,21 @@ class RnntTranscriptionStream final : public ITranscriptionStream {
     RnntTranscriptionStream(RnntPipeline& pipeline, TranscriptionStreamConfig cfg)
         : pipeline_(pipeline), cfg_(cfg),
           schedule_(make_nemotron_streaming_schedule(
-              cfg_.att_context_left, cfg_.att_context_right, cfg_.input_sample_rate,
-              pipeline.config_.mel_hop_length, pipeline.config_.subsampling_factor)) {
+              cfg_.att_context_left, cfg_.att_context_right,
+              cfg_.input_sample_rate > 0 ? cfg_.input_sample_rate : pipeline.config_.sample_rate,
+              pipeline.config_.mel_hop_length, pipeline.config_.subsampling_factor)),
+          transcribe_start_(RnntClock::now()),
+          feature_state_(pipeline_.mel_fb_->data.data(), pipeline_.mel_fb_->n_freq_bins,
+                         pipeline_.mel_fb_->n_mel_bins, make_rnnt_mel_options(pipeline_.config_),
+                         cfg_.input_sample_rate > 0 ? cfg_.input_sample_rate
+                                                    : pipeline_.config_.sample_rate) {
         const auto state_elems = static_cast<std::size_t>(pipeline_.config_.pred_num_layers) *
                                  pipeline_.config_.pred_hidden_size;
         state_h_.assign(state_elems, 0.0F);
         state_c_.assign(state_elems, 0.0F);
+        const auto decode_start = RnntClock::now();
         pred_output_ = pipeline_.run_predictor(pipeline_.config_.blank_id, state_h_, state_c_);
+        stages_.predictor_joint_and_transfer_ms += elapsed_ms(decode_start, RnntClock::now());
         reset_encoder_cache();
     }
 
@@ -127,7 +187,9 @@ class RnntTranscriptionStream final : public ITranscriptionStream {
             throw std::runtime_error("RNNT streaming transcription stream is already finished");
 
         if (num_samples > 0) {
-            audio_.insert(audio_.end(), audio_samples, audio_samples + num_samples);
+            const auto frontend_start = RnntClock::now();
+            feature_state_.accept_audio(audio_samples, num_samples);
+            stages_.frontend_ms += elapsed_ms(frontend_start, RnntClock::now());
             accepted_samples_ += num_samples;
         }
         ++chunk_index_;
@@ -135,8 +197,11 @@ class RnntTranscriptionStream final : public ITranscriptionStream {
         if (is_final)
             return finish();
 
-        const int32_t required_mel = use_first_step_plan() ? schedule_.first_shift_mel_frames
-                                                           : schedule_.next_shift_mel_frames;
+        const int32_t shift = use_first_step_plan() ? schedule_.first_shift_mel_frames
+                                                    : schedule_.next_shift_mel_frames;
+        const int32_t retained_lookahead =
+            schedule_.next_shift_mel_frames - schedule_.first_shift_mel_frames;
+        const int32_t required_mel = shift + retained_lookahead;
         if (available_mel_frames() - next_mel_start_ < required_mel)
             return make_result(false);
 
@@ -150,11 +215,18 @@ class RnntTranscriptionStream final : public ITranscriptionStream {
 
         final_ = process_ready(true);
         final_.is_final = true;
+        const auto feature_stats = feature_state_.stats();
+        report_rnnt_stage_timing(
+            rnnt_stage_timing_enabled(), "streaming", stages_,
+            elapsed_ms(transcribe_start_, RnntClock::now()), feature_stats.accepted_source_samples,
+            feature_stats.generated_resampled_samples, feature_stats.computed_mel_frames);
         return final_;
     }
 
     void reset() override {
-        audio_.clear();
+        transcribe_start_ = RnntClock::now();
+        stages_ = {};
+        feature_state_.reset();
         accepted_samples_ = 0;
         chunk_index_ = 0;
         finished_ = false;
@@ -163,7 +235,9 @@ class RnntTranscriptionStream final : public ITranscriptionStream {
         emitted_.clear();
         std::fill(state_h_.begin(), state_h_.end(), 0.0F);
         std::fill(state_c_.begin(), state_c_.end(), 0.0F);
+        const auto decode_start = RnntClock::now();
         pred_output_ = pipeline_.run_predictor(pipeline_.config_.blank_id, state_h_, state_c_);
+        stages_.predictor_joint_and_transfer_ms += elapsed_ms(decode_start, RnntClock::now());
         reset_encoder_cache();
     }
 
@@ -201,39 +275,10 @@ class RnntTranscriptionStream final : public ITranscriptionStream {
         return true;
     }
 
-    int32_t available_mel_frames() const {
-        int64_t samples = static_cast<int64_t>(audio_.size());
-        if (cfg_.input_sample_rate > 0 && cfg_.input_sample_rate != pipeline_.config_.sample_rate) {
-            samples = samples * pipeline_.config_.sample_rate / cfg_.input_sample_rate;
-        }
-        return static_cast<int32_t>(
-            std::max<int64_t>(0, samples / pipeline_.config_.mel_hop_length));
-    }
+    int32_t available_mel_frames() const { return feature_state_.available_frames(); }
 
-    rnnt::MelResult extract_all_mel(int32_t& actual_frames) const {
-        const float* samples_ptr = audio_.data();
-        int32_t samples_count = static_cast<int32_t>(audio_.size());
-        std::vector<float> resampled;
-        if (cfg_.input_sample_rate > 0 && cfg_.input_sample_rate != pipeline_.config_.sample_rate) {
-            resampled = resample_linear(audio_.data(), static_cast<int32_t>(audio_.size()),
-                                        cfg_.input_sample_rate, pipeline_.config_.sample_rate);
-            samples_ptr = resampled.data();
-            samples_count = static_cast<int32_t>(resampled.size());
-        }
-
-        rnnt::MelResult mel = rnnt::extract_rnnt_mel_spectrogram(
-            samples_ptr, samples_count, pipeline_.mel_fb_->data.data(),
-            pipeline_.mel_fb_->n_freq_bins, pipeline_.mel_fb_->n_mel_bins,
-            pipeline_.config_.mel_n_fft, pipeline_.config_.mel_win_length,
-            pipeline_.config_.mel_hop_length, pipeline_.config_.mel_chunk_length,
-            pipeline_.config_.sample_rate, pipeline_.config_.mel_preemph);
-        actual_frames =
-            std::min(mel.n_frames, std::max(0, samples_count / pipeline_.config_.mel_hop_length));
-        return mel;
-    }
-
-    std::vector<float> make_chunk_mel(const rnnt::MelResult& mel, int32_t start_frame,
-                                      int32_t valid_new_frames, bool first_step) const {
+    std::vector<float> make_chunk_mel(int32_t start_frame, int32_t valid_new_frames,
+                                      bool first_step) const {
         const int32_t chunk_frames =
             first_step ? schedule_.first_shift_mel_frames : schedule_.next_shift_mel_frames;
         const int32_t pre = first_step ? schedule_.first_pre_encode_cache_mel_frames
@@ -244,23 +289,24 @@ class RnntTranscriptionStream final : public ITranscriptionStream {
         for (int32_t m = 0; m < pipeline_.config_.num_mel_bins; ++m) {
             for (int32_t p = 0; p < pre; ++p) {
                 const int32_t src_frame = start_frame - pre + p;
-                if (src_frame >= 0 && src_frame < mel.n_frames) {
+                if (src_frame >= 0 && src_frame < feature_state_.frame_count()) {
                     chunk[static_cast<std::size_t>(m) * total + p] =
-                        mel.data[static_cast<std::size_t>(m) * mel.n_frames + src_frame];
+                        feature_state_.value(m, src_frame);
                 }
             }
             for (int32_t p = 0; p < valid_new_frames; ++p) {
                 const int32_t src_frame = start_frame + p;
-                if (src_frame >= 0 && src_frame < mel.n_frames) {
+                if (src_frame >= 0 && src_frame < feature_state_.frame_count()) {
                     chunk[static_cast<std::size_t>(m) * total + pre + p] =
-                        mel.data[static_cast<std::size_t>(m) * mel.n_frames + src_frame];
+                        feature_state_.value(m, src_frame);
                 }
             }
         }
         return chunk;
     }
 
-    TranscriptionStreamResult make_result(bool is_final) const {
+    TranscriptionStreamResult make_result(bool is_final) {
+        const auto text_start = RnntClock::now();
         TranscriptionStreamResult out;
         out.token_ids = emitted_;
         if (pipeline_.tokenizer_ && !out.token_ids.empty())
@@ -269,6 +315,7 @@ class RnntTranscriptionStream final : public ITranscriptionStream {
         out.chunk_index = chunk_index_;
         out.accepted_samples = accepted_samples_;
         out.sample_rate = cfg_.input_sample_rate;
+        stages_.text_ms += elapsed_ms(text_start, RnntClock::now());
         return out;
     }
 
@@ -292,7 +339,7 @@ class RnntTranscriptionStream final : public ITranscriptionStream {
         print_vector_stats("encoder", enc);
     }
 
-    bool process_next_chunk(const rnnt::MelResult& mel, int32_t actual_mel_frames, bool final) {
+    bool process_next_chunk(int32_t actual_mel_frames, bool final) {
         const bool first_step = use_first_step_plan();
         const int32_t shift = current_shift_mel_frames(first_step);
         const int32_t remaining = actual_mel_frames - next_mel_start_;
@@ -305,15 +352,22 @@ class RnntTranscriptionStream final : public ITranscriptionStream {
         if (valid_query_frames <= 0)
             return false;
 
-        auto chunk = make_chunk_mel(mel, next_mel_start_, valid_new_frames, first_step);
+        const auto frontend_start = RnntClock::now();
+        feature_state_.ensure_frames(next_mel_start_ + valid_new_frames, final);
+        auto chunk = make_chunk_mel(next_mel_start_, valid_new_frames, first_step);
+        stages_.frontend_ms += elapsed_ms(frontend_start, RnntClock::now());
         std::vector<float> next_channel;
         std::vector<float> next_time;
         const auto before_tokens = emitted_.size();
+        const auto encoder_start = RnntClock::now();
         auto enc = pipeline_.run_streaming_encoder(
             cfg_.att_context_right, chunk, cache_last_channel_, cache_last_time_,
             cache_last_channel_len_, valid_query_frames, first_step, next_channel, next_time);
+        stages_.encoder_and_transfer_ms += elapsed_ms(encoder_start, RnntClock::now());
+        const auto decode_start = RnntClock::now();
         pipeline_.decode_encoder_frames(enc, valid_query_frames, token_limit(), pred_output_,
                                         state_h_, state_c_, emitted_);
+        stages_.predictor_joint_and_transfer_ms += elapsed_ms(decode_start, RnntClock::now());
         if (rnnt_stream_debug_enabled())
             trace_streaming_chunk(enc, before_tokens, valid_new_frames, valid_query_frames);
 
@@ -327,15 +381,12 @@ class RnntTranscriptionStream final : public ITranscriptionStream {
     }
 
     TranscriptionStreamResult process_ready(bool final) {
-        if (audio_.empty())
+        if (accepted_samples_ == 0)
             return make_result(final);
-        int32_t actual_mel_frames = 0;
-        rnnt::MelResult mel = extract_all_mel(actual_mel_frames);
-        if (mel.data.empty())
-            return make_result(final);
+        const int32_t actual_mel_frames = available_mel_frames();
 
         while (!token_limit_reached()) {
-            if (!process_next_chunk(mel, actual_mel_frames, final))
+            if (!process_next_chunk(actual_mel_frames, final))
                 break;
         }
         return make_result(final);
@@ -356,7 +407,9 @@ class RnntTranscriptionStream final : public ITranscriptionStream {
     RnntPipeline& pipeline_;
     TranscriptionStreamConfig cfg_;
     RnntStreamingSchedule schedule_;
-    std::vector<float> audio_;
+    RnntClock::time_point transcribe_start_;
+    rnnt::IncrementalMelSpectrogram feature_state_;
+    RnntStageTotals stages_;
     std::vector<float> cache_last_channel_;
     std::vector<float> cache_last_time_;
     std::vector<float> pred_output_;
@@ -483,12 +536,20 @@ RnntPipeline::create_transcription_stream(const TranscriptionStreamConfig& cfg) 
 
 TextResult RnntPipeline::transcribe(const float* audio_data, int32_t num_samples,
                                     int32_t max_new_tokens, int32_t input_sample_rate) {
+    const bool report_timing = rnnt_stage_timing_enabled();
+    const auto transcribe_start = RnntClock::now();
+    RnntStageTotals stages;
+
     int32_t actual_mel_frames = 0;
     auto mel = extract_padded_mel(audio_data, num_samples, input_sample_rate, actual_mel_frames);
+    const auto frontend_end = RnntClock::now();
+    stages.frontend_ms = elapsed_ms(transcribe_start, frontend_end);
     if (mel.empty())
         return TextResult{"[mel extraction failed]", {}};
 
     auto encoder_output = run_encoder(mel, actual_mel_frames);
+    const auto encoder_end = RnntClock::now();
+    stages.encoder_and_transfer_ms = elapsed_ms(frontend_end, encoder_end);
     const int32_t encoder_frames =
         static_cast<int32_t>(encoder_output.size()) / config_.encoder_hidden_size;
     if (encoder_frames <= 0)
@@ -506,11 +567,22 @@ TextResult RnntPipeline::transcribe(const float* audio_data, int32_t num_samples
 
     decode_encoder_frames(encoder_output, encoder_frames, token_limit, pred_output, state_h,
                           state_c, emitted);
+    const auto decode_end = RnntClock::now();
+    stages.predictor_joint_and_transfer_ms = elapsed_ms(encoder_end, decode_end);
 
     TextResult out;
     out.token_ids = std::move(emitted);
     if (tokenizer_ && !out.token_ids.empty())
         out.text = tokenizer_->decode(out.token_ids);
+    const auto text_end = RnntClock::now();
+    stages.text_ms = elapsed_ms(decode_end, text_end);
+    const int64_t resampled_samples =
+        input_sample_rate > 0 && input_sample_rate != config_.sample_rate
+            ? static_cast<int64_t>(num_samples) * config_.sample_rate / input_sample_rate
+            : num_samples;
+    report_rnnt_stage_timing(report_timing, "offline", stages,
+                             elapsed_ms(transcribe_start, text_end), num_samples, resampled_samples,
+                             actual_mel_frames);
     return out;
 }
 

--- a/src/utils/wav_reader.cpp
+++ b/src/utils/wav_reader.cpp
@@ -239,15 +239,17 @@ PolyphaseSincWeights build_polyphase_sinc_weights(int32_t source_rate, int32_t t
     return table;
 }
 
-std::vector<float> resample_polyphase(const float* samples, int32_t n_samples, int32_t source_rate,
-                                      int32_t target_rate, int32_t out_len, double cutoff,
-                                      int32_t half_taps) {
+std::vector<float> resample_polyphase_range(const float* samples, int32_t n_samples,
+                                            int32_t source_rate, int32_t target_rate,
+                                            int32_t output_start, int32_t output_count,
+                                            double cutoff, int32_t half_taps) {
     const PolyphaseSincWeights table =
         build_polyphase_sinc_weights(source_rate, target_rate, cutoff, half_taps);
     const int32_t tap_count = 2 * half_taps;
-    std::vector<float> resampled(out_len);
+    std::vector<float> resampled(output_count);
 
-    for (int32_t i = 0; i < out_len; ++i) {
+    for (int32_t local_index = 0; local_index < output_count; ++local_index) {
+        const int32_t i = output_start + local_index;
         const int64_t position_numerator = static_cast<int64_t>(i) * source_rate;
         const int32_t center = static_cast<int32_t>(position_numerator / target_rate);
         const int32_t remainder = static_cast<int32_t>(position_numerator % target_rate);
@@ -264,7 +266,8 @@ std::vector<float> resample_polyphase(const float* samples, int32_t n_samples, i
             acc += static_cast<double>(samples[center + offset]) * weight;
             weight_sum += weight;
         }
-        resampled[i] = weight_sum > 1e-12 ? static_cast<float>(acc / weight_sum) : 0.0F;
+        resampled[static_cast<std::size_t>(local_index)] =
+            weight_sum > 1e-12 ? static_cast<float>(acc / weight_sum) : 0.0F;
     }
     return resampled;
 }
@@ -290,11 +293,34 @@ WavData read_wav(const std::string& path) {
 
 std::vector<float> resample_linear(const float* samples, int32_t n_samples, int32_t source_rate,
                                    int32_t target_rate) {
-    if (source_rate == target_rate || n_samples <= 0)
-        return std::vector<float>(samples, samples + n_samples);
-
+    if (n_samples <= 0)
+        return {};
+    if (samples == nullptr)
+        throw std::invalid_argument("resample input must not be null");
+    if (source_rate <= 0 || target_rate <= 0)
+        throw std::invalid_argument("resample rates must be positive");
     const int32_t out_len = compute_output_length(n_samples, source_rate, target_rate);
-    std::vector<float> resampled(out_len);
+    return resample_linear_range(samples, n_samples, source_rate, target_rate, 0, out_len);
+}
+
+std::vector<float> resample_linear_range(const float* samples, int32_t n_samples,
+                                         int32_t source_rate, int32_t target_rate,
+                                         int32_t output_start, int32_t output_count) {
+    if (n_samples <= 0 || output_count <= 0)
+        return {};
+    if (samples == nullptr)
+        throw std::invalid_argument("resample input must not be null");
+    if (source_rate <= 0 || target_rate <= 0)
+        throw std::invalid_argument("resample rates must be positive");
+
+    const int32_t full_output_length = compute_output_length(n_samples, source_rate, target_rate);
+    const int32_t range_start = std::clamp(output_start, 0, full_output_length);
+    const int32_t range_count = std::clamp(output_count, 0, full_output_length - range_start);
+    if (range_count <= 0)
+        return {};
+    if (source_rate == target_rate) {
+        return std::vector<float>(samples + range_start, samples + range_start + range_count);
+    }
 
     const int32_t half_taps = 16;
     const double cutoff =
@@ -307,14 +333,17 @@ std::vector<float> resample_linear(const float* samples, int32_t n_samples, int3
     constexpr int32_t kMaxPrecomputedPhases = 2048;
     const int32_t phase_count = target_rate / std::gcd(source_rate, target_rate);
     if (phase_count <= kMaxPrecomputedPhases) {
-        return resample_polyphase(samples, n_samples, source_rate, target_rate, out_len, cutoff,
-                                  half_taps);
+        return resample_polyphase_range(samples, n_samples, source_rate, target_rate, range_start,
+                                        range_count, cutoff, half_taps);
     }
 
-    for (int32_t i = 0; i < out_len; ++i) {
+    std::vector<float> resampled(range_count);
+    for (int32_t local_index = 0; local_index < range_count; ++local_index) {
+        const int32_t i = range_start + local_index;
         const double src_pos = static_cast<double>(i) * static_cast<double>(source_rate) /
                                static_cast<double>(target_rate);
-        resampled[i] = resample_at_position(samples, n_samples, src_pos, cutoff, half_taps);
+        resampled[static_cast<std::size_t>(local_index)] =
+            resample_at_position(samples, n_samples, src_pos, cutoff, half_taps);
     }
     return resampled;
 }

--- a/src/utils/wav_reader.h
+++ b/src/utils/wav_reader.h
@@ -12,7 +12,7 @@
 namespace trtmc {
 
 struct WavData {
-    std::vector<float> samples;  // mono float32 [-1, 1]
+    std::vector<float> samples; // mono float32 [-1, 1]
     int32_t sample_rate{0};
 };
 
@@ -24,8 +24,14 @@ WavData read_wav(const std::string& path);
 
 // Resample audio using linear interpolation.
 // Returns resampled samples at target_rate.
-std::vector<float> resample_linear(
-    const float* samples, int32_t n_samples,
-    int32_t source_rate, int32_t target_rate);
+std::vector<float> resample_linear(const float* samples, int32_t n_samples, int32_t source_rate,
+                                   int32_t target_rate);
+
+// Resample a contiguous range of output indices without recomputing the
+// preceding prefix. Values are identical to slicing resample_linear() for the
+// same complete input.
+std::vector<float> resample_linear_range(const float* samples, int32_t n_samples,
+                                         int32_t source_rate, int32_t target_rate,
+                                         int32_t output_start, int32_t output_count);
 
 } // namespace trtmc

--- a/tests/cpp/models/nemotron_speech_streaming/test_nemotron_speech_streaming_audio_helpers.cpp
+++ b/tests/cpp/models/nemotron_speech_streaming/test_nemotron_speech_streaming_audio_helpers.cpp
@@ -6,9 +6,11 @@
 // Unit tests for RNNT-owned audio feature extraction helpers.
 
 #include "runtime/models/nemotron_speech_streaming/audio_helpers.h"
+#include "utils/wav_reader.h"
 
 #include <cmath>
 #include <iostream>
+#include <string>
 #include <vector>
 
 namespace {
@@ -27,6 +29,184 @@ void check_close(float actual, float expected, float tolerance, const char* name
         std::cerr << "FAIL: " << name << " actual=" << actual << " expected=" << expected << '\n';
         ++g_failures;
     }
+}
+
+std::vector<float> make_identity_filterbank(int32_t n_freq_bins) {
+    std::vector<float> filters(static_cast<std::size_t>(n_freq_bins) * n_freq_bins, 0.0F);
+    for (int32_t i = 0; i < n_freq_bins; ++i) {
+        filters[static_cast<std::size_t>(i) * n_freq_bins + i] = 1.0F;
+    }
+    return filters;
+}
+
+std::vector<float> reference_rfft_power(const std::vector<float>& input) {
+    const int32_t n = static_cast<int32_t>(input.size());
+    const int32_t n_out = n / 2 + 1;
+    const double pi2 = 2.0 * 3.14159265358979323846;
+    std::vector<float> power(static_cast<std::size_t>(n_out), 0.0F);
+    for (int32_t k = 0; k < n_out; ++k) {
+        double real = 0.0;
+        double imag = 0.0;
+        for (int32_t t = 0; t < n; ++t) {
+            const double angle =
+                pi2 * static_cast<double>(k) * static_cast<double>(t) / static_cast<double>(n);
+            real += static_cast<double>(input[static_cast<std::size_t>(t)]) * std::cos(angle);
+            imag -= static_cast<double>(input[static_cast<std::size_t>(t)]) * std::sin(angle);
+        }
+        power[static_cast<std::size_t>(k)] = static_cast<float>(real * real + imag * imag);
+    }
+    return power;
+}
+
+void check_vectors_close(const std::vector<float>& actual, const std::vector<float>& expected,
+                         float tolerance, const char* name) {
+    check(actual.size() == expected.size(), name);
+    for (std::size_t i = 0; i < std::min(actual.size(), expected.size()); ++i) {
+        const float scaled_tolerance = tolerance * std::max(1.0F, std::abs(expected[i]));
+        check_close(actual[i], expected[i], scaled_tolerance, name);
+    }
+}
+
+void test_rnnt_fft_matches_direct_dft() {
+    std::vector<float> input(512);
+    for (std::size_t i = 0; i < input.size(); ++i) {
+        input[i] = static_cast<float>(std::sin(static_cast<double>(i) * 0.17) +
+                                      0.25 * std::cos(static_cast<double>(i) * 0.07));
+    }
+    check_vectors_close(trtmc::rnnt::detail::rfft_power(input), reference_rfft_power(input), 1e-5F,
+                        "rnnt 512-point FFT matches direct DFT");
+}
+
+trtmc::rnnt::MelSpectrogramOptions make_incremental_options() {
+    trtmc::rnnt::MelSpectrogramOptions options;
+    options.n_fft = 8;
+    options.win_length = 6;
+    options.hop_length = 2;
+    options.chunk_length_s = 1;
+    options.sample_rate = 32;
+    options.symmetric_window = true;
+    options.center_window_in_fft = true;
+    options.preemphasis = 0.97F;
+    options.log_scale = trtmc::rnnt::MelLogScale::kNaturalLog;
+    return options;
+}
+
+std::vector<float> make_test_audio(int32_t count) {
+    std::vector<float> audio(static_cast<std::size_t>(count));
+    for (int32_t i = 0; i < count; ++i) {
+        audio[static_cast<std::size_t>(i)] =
+            static_cast<float>(0.35 * std::sin(static_cast<double>(i) * 0.47) +
+                               0.2 * std::cos(static_cast<double>(i) * 0.19));
+    }
+    return audio;
+}
+
+std::vector<float> materialize_incremental(const trtmc::rnnt::IncrementalMelSpectrogram& state) {
+    std::vector<float> output;
+    output.reserve(static_cast<std::size_t>(state.n_mels()) * state.frame_count());
+    for (int32_t mel = 0; mel < state.n_mels(); ++mel) {
+        for (int32_t frame = 0; frame < state.frame_count(); ++frame) {
+            output.push_back(state.value(mel, frame));
+        }
+    }
+    return output;
+}
+
+std::vector<float> run_resampled_chunks(const std::vector<float>& source_audio,
+                                        const std::vector<int32_t>& chunk_sizes,
+                                        trtmc::rnnt::IncrementalMelStats& stats) {
+    const auto options = make_incremental_options();
+    const auto filters = make_identity_filterbank(5);
+    trtmc::rnnt::IncrementalMelSpectrogram state(filters.data(), 5, 5, options, 96);
+    int32_t accepted = 0;
+    for (const int32_t chunk_size : chunk_sizes) {
+        const int32_t take =
+            std::min(chunk_size, static_cast<int32_t>(source_audio.size()) - accepted);
+        state.accept_audio(source_audio.data() + accepted, take);
+        accepted += take;
+        const bool final = accepted == static_cast<int32_t>(source_audio.size());
+        if (final) {
+            state.ensure_frames(16, true);
+            break;
+        }
+
+        constexpr int32_t kResampleHalfTaps = 16;
+        const int32_t stable_target = std::max(0, accepted - kResampleHalfTaps) / 3;
+        const int32_t stable_frames =
+            stable_target >= options.n_fft / 2
+                ? 1 + (stable_target - options.n_fft / 2) / options.hop_length
+                : 0;
+        state.ensure_frames(stable_frames, false);
+    }
+    stats = state.stats();
+    return materialize_incremental(state);
+}
+
+void test_incremental_mel_processes_each_frame_once() {
+    const auto options = make_incremental_options();
+    const auto filters = make_identity_filterbank(5);
+    const auto audio = make_test_audio(32);
+    const auto offline = trtmc::rnnt::extract_configured_mel_spectrogram(
+        audio.data(), static_cast<int32_t>(audio.size()), filters.data(), 5, 5, options);
+
+    trtmc::rnnt::IncrementalMelSpectrogram state(filters.data(), 5, 5, options, 32);
+    state.accept_audio(audio.data(), 8);
+    state.ensure_frames(2, false);
+    state.accept_audio(audio.data() + 8, 8);
+    state.ensure_frames(6, false);
+    state.accept_audio(audio.data() + 16, 16);
+    state.ensure_frames(16, true);
+
+    check_vectors_close(materialize_incremental(state), offline.data, 1e-5F,
+                        "incremental mel matches one-shot features");
+    const auto stats = state.stats();
+    check(stats.accepted_source_samples == 32, "incremental mel accepts each source sample once");
+    check(stats.generated_resampled_samples == 32,
+          "incremental mel materializes each identity-rate sample once");
+    check(stats.computed_mel_frames == 16, "incremental mel computes each frame once");
+}
+
+void test_incremental_resample_matches_one_shot() {
+    const auto options = make_incremental_options();
+    const auto filters = make_identity_filterbank(5);
+    const auto source_audio = make_test_audio(96);
+    const auto resampled = trtmc::resample_linear(source_audio.data(), 96, 96, 32);
+    const auto offline = trtmc::rnnt::extract_configured_mel_spectrogram(
+        resampled.data(), static_cast<int32_t>(resampled.size()), filters.data(), 5, 5, options);
+
+    trtmc::rnnt::IncrementalMelSpectrogram state(filters.data(), 5, 5, options, 96);
+    state.accept_audio(source_audio.data(), 72);
+    state.ensure_frames(6, false);
+    state.accept_audio(source_audio.data() + 72, 24);
+    state.ensure_frames(16, true);
+
+    check_vectors_close(materialize_incremental(state), offline.data, 1e-5F,
+                        "incremental resampling matches one-shot features");
+    const auto stats = state.stats();
+    check(stats.accepted_source_samples == 96,
+          "incremental resampling accepts each source sample once");
+    check(stats.generated_resampled_samples == 32,
+          "incremental resampling generates each target sample once");
+    check(stats.computed_mel_frames == 16, "incremental resampling computes each mel frame once");
+}
+
+void test_incremental_resample_is_chunk_size_independent() {
+    const auto source_audio = make_test_audio(96);
+    trtmc::rnnt::IncrementalMelStats coarse_stats;
+    trtmc::rnnt::IncrementalMelStats irregular_stats;
+    const auto coarse = run_resampled_chunks(source_audio, {24, 24, 24, 24}, coarse_stats);
+    const auto irregular = run_resampled_chunks(source_audio, {17, 31, 11, 37}, irregular_stats);
+
+    check_vectors_close(irregular, coarse, 0.0F,
+                        "incremental features are independent of source chunk sizes");
+    check(coarse_stats.accepted_source_samples == 96 &&
+              irregular_stats.accepted_source_samples == 96,
+          "chunk schedules accept each source sample once");
+    check(coarse_stats.generated_resampled_samples == 32 &&
+              irregular_stats.generated_resampled_samples == 32,
+          "chunk schedules generate each resampled sample once");
+    check(coarse_stats.computed_mel_frames == 16 && irregular_stats.computed_mel_frames == 16,
+          "chunk schedules compute each mel frame once");
 }
 
 void test_rnnt_mel_matches_configured_owned_options() {
@@ -68,7 +248,11 @@ void test_rnnt_mel_matches_configured_owned_options() {
 } // namespace
 
 int main() {
+    test_rnnt_fft_matches_direct_dft();
     test_rnnt_mel_matches_configured_owned_options();
+    test_incremental_mel_processes_each_frame_once();
+    test_incremental_resample_matches_one_shot();
+    test_incremental_resample_is_chunk_size_independent();
 
     if (g_failures != 0) {
         std::cerr << g_failures << " rnnt audio helper test(s) failed\n";

--- a/tests/cpp/test_wav_reader.cpp
+++ b/tests/cpp/test_wav_reader.cpp
@@ -106,6 +106,37 @@ static void check_resample_matches_reference(int32_t source_rate, int32_t target
     check(matches, test_name);
 }
 
+static void check_resample_ranges_match_full(int32_t source_rate, int32_t target_rate,
+                                             const std::vector<int32_t>& range_sizes,
+                                             const char* test_name) {
+    std::vector<float> input(1003);
+    for (std::size_t i = 0; i < input.size(); ++i) {
+        input[i] = static_cast<float>(0.7 * std::sin(static_cast<double>(i) * 0.11) +
+                                      0.2 * std::cos(static_cast<double>(i) * 0.037));
+    }
+    const auto full = trtmc::resample_linear(input.data(), static_cast<int32_t>(input.size()),
+                                             source_rate, target_rate);
+    std::vector<float> ranged;
+    int32_t start = 0;
+    for (const int32_t requested : range_sizes) {
+        auto part = trtmc::resample_linear_range(input.data(), static_cast<int32_t>(input.size()),
+                                                 source_rate, target_rate, start, requested);
+        start += static_cast<int32_t>(part.size());
+        ranged.insert(ranged.end(), part.begin(), part.end());
+    }
+    if (start < static_cast<int32_t>(full.size())) {
+        auto part = trtmc::resample_linear_range(input.data(), static_cast<int32_t>(input.size()),
+                                                 source_rate, target_rate, start,
+                                                 static_cast<int32_t>(full.size()) - start);
+        ranged.insert(ranged.end(), part.begin(), part.end());
+    }
+    bool matches = ranged.size() == full.size();
+    for (std::size_t i = 0; matches && i < full.size(); ++i) {
+        matches = ranged[i] == full[i];
+    }
+    check(matches, test_name);
+}
+
 static std::filesystem::path make_temp_dir() {
     char pattern[] = "/tmp/trtmc_wav_test_XXXXXX";
     char* dir = mkdtemp(pattern);
@@ -265,7 +296,17 @@ int main() {
     check_resample_matches_reference(44100, 16000, "resample_polyphase: 44.1k to 16k parity");
     check_resample_matches_reference(16000, 48000, "resample_polyphase: 16k to 48k parity");
 
-    // Test 7: Invalid file throws
+    // Test 7: independently generated output ranges concatenate bit-exactly.
+    check_resample_ranges_match_full(48000, 16000, {1, 7, 31, 53},
+                                     "resample_ranges: 48k to 16k parity");
+    check_resample_ranges_match_full(44100, 16000, {3, 11, 29, 47},
+                                     "resample_ranges: 44.1k to 16k parity");
+    check_resample_ranges_match_full(16000, 48000, {5, 17, 61, 101},
+                                     "resample_ranges: 16k to 48k parity");
+    check_resample_ranges_match_full(16000, 16000, {2, 13, 37, 89},
+                                     "resample_ranges: identity parity");
+
+    // Test 8: Invalid file throws
     {
         bool caught = false;
         try {


### PR DESCRIPTION
## Background

Nemotron Speech used a scalar direct DFT for every audio frame. Its streaming path also rebuilt the resampled waveform and all mel features from the complete accumulated prefix on every chunk, making frontend work dominate end-to-end latency.

Closes #499.

## Exit Criteria

- Preserve repository task-eval quality for both supported Nemotron Speech checkpoints.
- Compute streaming source samples, resampled samples, and mel frames once per request instead of once per accumulated prefix.
- Improve aligned warm task latency without changing the engine bundle, precision, input, chunk schedule, or transcript.

## Implementation

- Replace the 512-point direct DFT with a reusable radix-2 real-FFT power plan and fuse power-to-mel projection. Keep the direct implementation as a fallback for non-power-of-two transforms.
- Avoid spectral work for the padded tail of offline inputs.
- Add range-based resampling and a stateful streaming feature cache that preserves preemphasis and the model's boundary lookahead while materializing each output sample and mel frame once.
- Add opt-in `TRTMC_RNNT_STAGE_TIMING=1` reporting for frontend, encoder/transfer, predictor/joint/transfer, text, and linear-work counters.

## Validation

Aligned warm inference used the same FP16 bundle and decoded 4.16-second, 48 kHz mono PCM before and after. File I/O and pipeline load were excluded; each task sample was synchronized before and after execution, and CUDA graphs were disabled.

| Model / mode | Warmup / samples | Before p50 | After p50 | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `nvidia/nemotron-speech-streaming-en-0.6b` / offline | 5 / 50 | 4619.591 ms | 35.536 ms | 130.00x |
| `nvidia/nemotron-3.5-asr-streaming-0.6b` / streaming, 1120 ms chunks | 1 / 5 | 18371.158 ms | 27.378 ms | 671.02x |

- Baseline and optimized transcripts matched exactly for both models: 38 characters / 15 tokens offline and 46 characters / 15 tokens streaming. Every timed sample was stable and neither case reached its token limit.
- `pytest -q "tests/test_e2e.py::test_e2e[nemotron-speech-streaming-en-0.6b]" --trtmc-binary "$BUILD_DIR/trtmc" --model-plugin-dir "$BUILD_DIR/models" --engine-dir "$ENGINE_DIR" --hf-python "$HF_PYTHON" --e2e-artifacts-dir "$ARTIFACTS_DIR" --e2e-platform GB300`: passed in 262.43 seconds.
- `pytest -q "tests/test_e2e.py::test_e2e[nemotron-3.5-asr-streaming-0.6b]" --trtmc-binary "$BUILD_DIR/trtmc" --model-plugin-dir "$BUILD_DIR/models" --engine-dir "$ENGINE_DIR" --hf-python "$HF_PYTHON" --e2e-artifacts-dir "$ARTIFACTS_DIR" --e2e-platform GB300`: passed in 67.24 seconds.
- `ctest --test-dir "$BUILD_DIR" --output-on-failure -R 'test_nemotron_speech_streaming_audio_helpers|test_nemotron_speech_streaming_streaming_contract|test_wav_reader'`: 3/3 passed.
- `pytest -q tests/e2e/models/nemotron_speech_streaming --ignore=tests/e2e/models/nemotron_speech_streaming/test_nemotron_speech_streaming_e2e.py`: 13 passed.
- `pytest -q tests/tools/test_model_plugin_encapsulation_static.py`: 156 passed.
- Legal-header checks, clang-format dry-run, warning-clean standalone C++ builds, and cyclomatic complexity with maximum CCN 10 passed.

## Notes For Future Readers

- Review `audio_helpers.cpp` first for the FFT and incremental feature state, then `pipeline.cpp` for stream scheduling and stage accounting.
- The feature-count tests cover different source chunk partitions and require identical features plus one-time source/resample/frame counts.
- This changes runtime preprocessing only; it does not change bundle format or engine contents.
