### PR TITLE
perf(qwen3-omni): keep Talker resident

### DIFF
--- a/python/tensorrt_model_connect/families/qwen3_omni/audio_runtime.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/audio_runtime.py
@@ -14,7 +14,10 @@ import gc
 import os
 import struct
 import sys
+import time
+import traceback
 from dataclasses import dataclass
+from typing import BinaryIO, Callable, Protocol
 
 import numpy as np
 
@@ -25,6 +28,13 @@ _SYSTEM_PROMPT = (
     "text and speech."
 )
 _INPUT_HEADER = struct.Struct("<II")
+_WORKER_REQUEST_HEADER = struct.Struct("<II")
+_WORKER_RESPONSE_HEADER = struct.Struct("<IIId")
+_WORKER_MAGIC = 0x514F4D4E
+_WORKER_READY = 1
+_WORKER_OK = 2
+_WORKER_ERROR = 3
+_MAX_REQUEST_BYTES = 64 * 1024 * 1024
 _STOP_MARKERS = ("<|im_end|>", "<|endoftext|>")
 
 
@@ -32,6 +42,10 @@ _STOP_MARKERS = ("<|im_end|>", "<|endoftext|>")
 class TalkerRequest:
     prompt: str
     assistant_text: str
+
+
+class _TalkerModel(Protocol):
+    def generate_codes(self, request: TalkerRequest) -> np.ndarray: ...
 
 
 def _read_request(payload: bytes) -> TalkerRequest:
@@ -64,145 +78,234 @@ def _chatml(request: TalkerRequest) -> str:
     )
 
 
+class _OfficialTalker:
+    def __init__(self, model_id: str, revision: str, max_frames: int) -> None:
+        import torch
+        from transformers import AutoConfig, AutoTokenizer
+        from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+            Qwen3OmniMoeForConditionalGeneration,
+        )
+
+        if not torch.cuda.is_available():
+            raise RuntimeError("Qwen3-Omni official Talker requires a CUDA device")
+
+        load_kwargs = {
+            "local_files_only": True,
+            "trust_remote_code": True,
+        }
+        if revision:
+            load_kwargs["revision"] = revision
+        self._torch = torch
+        self._config = AutoConfig.from_pretrained(model_id, **load_kwargs)
+        self._tokenizer = AutoTokenizer.from_pretrained(model_id, **load_kwargs)
+        self._model = Qwen3OmniMoeForConditionalGeneration.from_pretrained(
+            model_id,
+            config=self._config,
+            dtype=torch.bfloat16,
+            low_cpu_mem_usage=True,
+            **load_kwargs,
+        ).eval()
+        self._max_frames = max_frames
+        self._device = torch.device("cuda:0")
+        self._thinker_embedding = self._model.thinker.get_input_embeddings()
+        self._model.talker.to(self._device).eval()
+        del self._model.thinker
+        del self._model.code2wav
+        gc.collect()
+
+        special_tokens = torch.tensor(
+            [
+                [
+                    self._config.tts_bos_token_id,
+                    self._config.tts_eos_token_id,
+                    self._config.tts_pad_token_id,
+                ]
+            ],
+            device="cpu",
+            dtype=torch.long,
+        )
+        special_embeds = self._model.talker.text_projection(
+            self._thinker_embedding(special_tokens).to(self._device)
+        )
+        self._tts_bos_embed, self._tts_eos_embed, self._tts_pad_embed = special_embeds.chunk(
+            3, dim=1
+        )
+        self._speaker_id = self._config.talker_config.speaker_id["ethan"]
+        self._suppressed = [
+            token_id
+            for token_id in range(
+                self._config.talker_config.text_config.vocab_size - 1024,
+                self._config.talker_config.text_config.vocab_size,
+            )
+            if token_id != self._config.talker_config.codec_eos_token_id
+        ]
+        self._expected_codebooks = int(self._config.talker_config.num_code_groups)
+        self._codebook_size = int(self._config.talker_config.code_predictor_config.vocab_size)
+
+    def generate_codes(self, request: TalkerRequest) -> np.ndarray:
+        torch = self._torch
+        with torch.inference_mode():
+            input_ids = self._tokenizer(
+                _chatml(request), add_special_tokens=False, return_tensors="pt"
+            ).input_ids
+            thinker_embed = self._thinker_embedding(input_ids).to(self._device)
+            thinker_hidden = torch.zeros_like(thinker_embed)
+            input_ids = input_ids.to(self._device)
+
+            im_start_indexes = torch.cat(
+                (
+                    torch.nonzero(input_ids[0] == self._config.im_start_token_id).squeeze(-1),
+                    torch.tensor([input_ids.shape[-1]], device=self._device, dtype=input_ids.dtype),
+                ),
+                dim=-1,
+            )
+            multimodal_mask = torch.zeros_like(input_ids, dtype=torch.bool)
+            talker_input_embeds = []
+            talker_input_ids = []
+            trailing_text_hidden = None
+            for index in range(len(im_start_indexes) - 1):
+                start = int(im_start_indexes[index])
+                end = int(im_start_indexes[index + 1])
+                role = int(input_ids[0, start + 1])
+                if role == self._config.system_token_id:
+                    continue
+                if role == self._config.user_token_id:
+                    talker_input_embeds.append(
+                        self._model._get_talker_user_parts(
+                            start, end, multimodal_mask, thinker_hidden, thinker_embed
+                        )
+                    )
+                    talker_input_ids.append(input_ids[:, start:end])
+                elif role == self._config.assistant_token_id and index == len(im_start_indexes) - 2:
+                    assistant_embeds, assistant_ids, trailing_text_hidden = (
+                        self._model._get_talker_assistant_parts(
+                            start,
+                            end,
+                            self._speaker_id,
+                            thinker_embed,
+                            self._tts_pad_embed,
+                            self._tts_bos_embed,
+                            self._tts_eos_embed,
+                        )
+                    )
+                    talker_input_embeds.append(assistant_embeds)
+                    talker_input_ids.append(assistant_ids)
+
+            if trailing_text_hidden is None or not talker_input_embeds:
+                raise RuntimeError("Qwen3-Omni Talker could not construct the assistant segment")
+
+            talker_embed = torch.cat(talker_input_embeds, dim=1)
+            attention_mask = torch.ones(
+                talker_embed.shape[:2], device=self._device, dtype=torch.long
+            )
+            torch.manual_seed(42)
+            torch.cuda.manual_seed_all(42)
+            result = self._model.talker.generate(
+                inputs_embeds=talker_embed,
+                attention_mask=attention_mask,
+                trailing_text_hidden=trailing_text_hidden,
+                tts_pad_embed=self._tts_pad_embed,
+                talker_input_ids=torch.cat(talker_input_ids, dim=1),
+                max_new_tokens=self._max_frames,
+                do_sample=False,
+                eos_token_id=self._config.talker_config.codec_eos_token_id,
+                pad_token_id=self._config.talker_config.codec_eos_token_id,
+                suppress_tokens=self._suppressed,
+                output_hidden_states=True,
+                return_dict_in_generate=True,
+            )
+            code_groups = [hidden[-1] for hidden in result.hidden_states if hidden[-1] is not None]
+            if not code_groups:
+                raise RuntimeError("Qwen3-Omni official Talker produced no codec frames")
+            codes = (
+                torch.stack(code_groups, dim=1)
+                .transpose(1, 2)
+                .squeeze(0)
+                .to(torch.int32)
+                .cpu()
+                .numpy()
+            )
+
+        if codes.ndim != 2 or codes.shape[0] != self._expected_codebooks:
+            raise RuntimeError(
+                f"Qwen3-Omni Talker returned shape {codes.shape}; "
+                f"expected [{self._expected_codebooks}, frames]"
+            )
+        if codes.shape[1] > self._max_frames:
+            raise RuntimeError(
+                f"Qwen3-Omni Talker returned {codes.shape[1]} frames; maximum is {self._max_frames}"
+            )
+        if np.any(codes < 0) or np.any(codes >= self._codebook_size):
+            raise RuntimeError("Qwen3-Omni Talker returned an out-of-range codec token")
+        return np.ascontiguousarray(codes.T, dtype="<i4")
+
+
 def _generate_codes(
     model_id: str, revision: str, request: TalkerRequest, max_frames: int
 ) -> np.ndarray:
-    import torch
-    from transformers import AutoConfig, AutoTokenizer
-    from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
-        Qwen3OmniMoeForConditionalGeneration,
-    )
+    return _OfficialTalker(model_id, revision, max_frames).generate_codes(request)
 
-    if not torch.cuda.is_available():
-        raise RuntimeError("Qwen3-Omni official Talker requires a CUDA device")
 
-    load_kwargs = {
-        "local_files_only": True,
-        "trust_remote_code": True,
-    }
-    if revision:
-        load_kwargs["revision"] = revision
-    config = AutoConfig.from_pretrained(model_id, **load_kwargs)
-    tokenizer = AutoTokenizer.from_pretrained(
-        model_id,
-        **load_kwargs,
-    )
-    model = Qwen3OmniMoeForConditionalGeneration.from_pretrained(
-        model_id,
-        config=config,
-        dtype=torch.bfloat16,
-        low_cpu_mem_usage=True,
-        **load_kwargs,
-    ).eval()
+def _read_exact(stream: BinaryIO, size: int, *, allow_clean_eof: bool = False) -> bytes | None:
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining:
+        chunk = stream.read(remaining)
+        if not chunk:
+            if allow_clean_eof and remaining == size:
+                return None
+            raise EOFError(f"Qwen3-Omni Talker worker expected {size} bytes")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
 
-    device = torch.device("cuda:0")
-    thinker_embedding = model.thinker.get_input_embeddings()
-    model.talker.to(device).eval()
-    del model.thinker
-    del model.code2wav
-    gc.collect()
 
-    input_ids = tokenizer(_chatml(request), add_special_tokens=False, return_tensors="pt").input_ids
-    thinker_embed = thinker_embedding(input_ids).to(device)
-    thinker_hidden = torch.zeros_like(thinker_embed)
-    input_ids = input_ids.to(device)
+def _read_worker_payload(stream: BinaryIO) -> bytes | None:
+    header = _read_exact(stream, _WORKER_REQUEST_HEADER.size, allow_clean_eof=True)
+    if header is None:
+        return None
+    magic, payload_size = _WORKER_REQUEST_HEADER.unpack(header)
+    if magic != _WORKER_MAGIC:
+        raise ValueError("Qwen3-Omni Talker worker received an invalid request magic")
+    if payload_size == 0:
+        return None
+    if payload_size > _MAX_REQUEST_BYTES:
+        raise ValueError(f"Qwen3-Omni Talker worker request is too large: {payload_size}")
+    payload = _read_exact(stream, payload_size)
+    assert payload is not None
+    return payload
 
-    im_start_indexes = torch.cat(
-        (
-            torch.nonzero(input_ids[0] == config.im_start_token_id).squeeze(-1),
-            torch.tensor([input_ids.shape[-1]], device=device, dtype=input_ids.dtype),
-        ),
-        dim=-1,
-    )
-    multimodal_mask = torch.zeros_like(input_ids, dtype=torch.bool)
-    talker_special_tokens = torch.tensor(
-        [[config.tts_bos_token_id, config.tts_eos_token_id, config.tts_pad_token_id]],
-        device="cpu",
-        dtype=input_ids.dtype,
-    )
-    tts_bos_embed, tts_eos_embed, tts_pad_embed = model.talker.text_projection(
-        thinker_embedding(talker_special_tokens).to(device)
-    ).chunk(3, dim=1)
 
-    talker_input_embeds = []
-    talker_input_ids = []
-    trailing_text_hidden = None
-    speaker_id = config.talker_config.speaker_id["ethan"]
-    for index in range(len(im_start_indexes) - 1):
-        start = int(im_start_indexes[index])
-        end = int(im_start_indexes[index + 1])
-        role = int(input_ids[0, start + 1])
-        if role == config.system_token_id:
-            continue
-        if role == config.user_token_id:
-            talker_input_embeds.append(
-                model._get_talker_user_parts(
-                    start, end, multimodal_mask, thinker_hidden, thinker_embed
-                )
-            )
-            talker_input_ids.append(input_ids[:, start:end])
-        elif role == config.assistant_token_id and index == len(im_start_indexes) - 2:
-            assistant_embeds, assistant_ids, trailing_text_hidden = (
-                model._get_talker_assistant_parts(
-                    start,
-                    end,
-                    speaker_id,
-                    thinker_embed,
-                    tts_pad_embed,
-                    tts_bos_embed,
-                    tts_eos_embed,
-                )
-            )
-            talker_input_embeds.append(assistant_embeds)
-            talker_input_ids.append(assistant_ids)
+def _write_worker_response(
+    stream: BinaryIO, status: int, payload: bytes = b"", talker_ms: float = 0.0
+) -> None:
+    stream.write(_WORKER_RESPONSE_HEADER.pack(_WORKER_MAGIC, status, len(payload), talker_ms))
+    stream.write(payload)
+    stream.flush()
 
-    if trailing_text_hidden is None or not talker_input_embeds:
-        raise RuntimeError("Qwen3-Omni Talker could not construct the assistant segment")
 
-    talker_embed = torch.cat(talker_input_embeds, dim=1)
-    attention_mask = torch.ones(talker_embed.shape[:2], device=device, dtype=torch.long)
-    suppressed = [
-        token_id
-        for token_id in range(
-            config.talker_config.text_config.vocab_size - 1024,
-            config.talker_config.text_config.vocab_size,
-        )
-        if token_id != config.talker_config.codec_eos_token_id
-    ]
-
-    torch.manual_seed(42)
-    result = model.talker.generate(
-        inputs_embeds=talker_embed,
-        attention_mask=attention_mask,
-        trailing_text_hidden=trailing_text_hidden,
-        tts_pad_embed=tts_pad_embed,
-        talker_input_ids=torch.cat(talker_input_ids, dim=1),
-        max_new_tokens=max_frames,
-        do_sample=False,
-        eos_token_id=config.talker_config.codec_eos_token_id,
-        pad_token_id=config.talker_config.codec_eos_token_id,
-        suppress_tokens=suppressed,
-        output_hidden_states=True,
-        return_dict_in_generate=True,
-    )
-    code_groups = [hidden[-1] for hidden in result.hidden_states if hidden[-1] is not None]
-    if not code_groups:
-        raise RuntimeError("Qwen3-Omni official Talker produced no codec frames")
-    codes = torch.stack(code_groups, dim=1).transpose(1, 2).squeeze(0).to(torch.int32).cpu().numpy()
-    expected_codebooks = int(config.talker_config.num_code_groups)
-    if codes.ndim != 2 or codes.shape[0] != expected_codebooks:
-        raise RuntimeError(
-            f"Qwen3-Omni Talker returned shape {codes.shape}; "
-            f"expected [{expected_codebooks}, frames]"
-        )
-    if codes.shape[1] > max_frames:
-        raise RuntimeError(
-            f"Qwen3-Omni Talker returned {codes.shape[1]} frames; maximum is {max_frames}"
-        )
-    codebook_size = int(config.talker_config.code_predictor_config.vocab_size)
-    if np.any(codes < 0) or np.any(codes >= codebook_size):
-        raise RuntimeError("Qwen3-Omni Talker returned an out-of-range codec token")
-    return np.ascontiguousarray(codes.T, dtype="<i4")
+def _serve_worker(
+    model_id: str,
+    revision: str,
+    max_frames: int,
+    input_stream: BinaryIO,
+    output_stream: BinaryIO,
+    model_factory: Callable[[str, str, int], _TalkerModel] = _OfficialTalker,
+) -> None:
+    model = model_factory(model_id, revision, max_frames)
+    _write_worker_response(output_stream, _WORKER_READY)
+    while (payload := _read_worker_payload(input_stream)) is not None:
+        started = time.perf_counter()
+        try:
+            request = _read_request(payload)
+            codes = model.generate_codes(request)
+            talker_ms = (time.perf_counter() - started) * 1000.0
+            _write_worker_response(output_stream, _WORKER_OK, codes.tobytes(order="C"), talker_ms)
+        except Exception as exc:
+            talker_ms = (time.perf_counter() - started) * 1000.0
+            traceback.print_exc(file=sys.stderr)
+            error = f"{type(exc).__name__}: {exc}".encode("utf-8", errors="replace")
+            _write_worker_response(output_stream, _WORKER_ERROR, error, talker_ms)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -210,11 +313,21 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--model-id", required=True)
     parser.add_argument("--revision", default="")
     parser.add_argument("--max-frames", required=True, type=int)
+    parser.add_argument("--worker", action="store_true")
     args = parser.parse_args(argv)
     if not 1 <= args.max_frames <= 32:
         parser.error("--max-frames must be in [1, 32]")
 
     os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+    if args.worker:
+        _serve_worker(
+            args.model_id,
+            args.revision,
+            args.max_frames,
+            sys.stdin.buffer,
+            sys.stdout.buffer,
+        )
+        return 0
     request = _read_request(sys.stdin.buffer.read())
     codes = _generate_codes(args.model_id, args.revision, request, args.max_frames)
     sys.stdout.buffer.write(codes.tobytes(order="C"))

--- a/src/runtime/models/qwen3_omni/MODEL.toml
+++ b/src/runtime/models/qwen3_omni/MODEL.toml
@@ -7,5 +7,6 @@ runtime_plugins = ["plugin.cpp|register_qwen3_omni_plugin"]
 runtime_strategies = ["qwen3_omni_multimodal"]
 runtime_tests = [
   "test_qwen3_omni_audio_plan|test_qwen3_omni_audio_plan.cpp|_|_|_",
+  "test_qwen3_omni_talker_runtime|test_qwen3_omni_talker_runtime.cpp|_|talker_runtime.cpp|_",
   "test_qwen3_omni_pipeline|test_qwen3_omni_pipeline.cpp|trtmc_model_qwen3_omni|_|REQUIRES_TRT",
 ]

--- a/src/runtime/models/qwen3_omni/pipeline.cpp
+++ b/src/runtime/models/qwen3_omni/pipeline.cpp
@@ -10,13 +10,52 @@
 #include "trtmc/tokenizer.h"
 
 #include <algorithm>
+#include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 
 namespace trtmc {
 
 namespace {
+
+using OmniClock = std::chrono::steady_clock;
+
+struct OmniStageTotals {
+    double input_preparation_ms{0.0};
+    double thinker_and_transfer_ms{0.0};
+    double worker_start_ms{0.0};
+    double talker_ms{0.0};
+    double ipc_ms{0.0};
+    double code2wav_and_transfer_ms{0.0};
+    double output_materialization_ms{0.0};
+};
+
+double elapsed_ms(OmniClock::time_point start, OmniClock::time_point end) {
+    return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+bool omni_stage_timing_enabled() {
+    const char* value = std::getenv("TRTMC_QWEN3_OMNI_STAGE_TIMING");
+    return value != nullptr && value[0] != '\0' && std::strcmp(value, "0") != 0;
+}
+
+void report_omni_stage_timing(const OmniStageTotals& stages, double total_ms) {
+    if (!omni_stage_timing_enabled())
+        return;
+    std::ostringstream timing;
+    timing << "[trtmc.qwen3_omni_timing.json] {\"input_preparation_ms\":"
+           << stages.input_preparation_ms
+           << ",\"thinker_and_transfer_ms\":" << stages.thinker_and_transfer_ms
+           << ",\"worker_start_ms\":" << stages.worker_start_ms
+           << ",\"talker_ms\":" << stages.talker_ms << ",\"ipc_ms\":" << stages.ipc_ms
+           << ",\"code2wav_and_transfer_ms\":" << stages.code2wav_and_transfer_ms
+           << ",\"output_materialization_ms\":" << stages.output_materialization_ms
+           << ",\"total_ms\":" << total_ms << '}';
+    std::cerr << timing.str() << std::endl;
+}
 
 std::string format_omni_chat_prompt(const std::string& prompt) {
     return "<|im_start|>system\n"
@@ -42,6 +81,9 @@ OmniPipeline::OmniPipeline(std::unique_ptr<TrtModule> thinker,
         throw std::runtime_error("OmniPipeline: invalid thinker module");
     if (!thinker_state_ || !thinker_state_->ok())
         throw std::runtime_error("OmniPipeline: invalid thinker cache");
+    talker_runtime_ = std::make_unique<Qwen3OmniTalkerRuntime>(
+        config_->hf_python, config_->talker_model_id, config_->talker_model_revision,
+        config_->talker_n_codebooks, config_->code2wav_max_frames);
 }
 
 OmniPipeline::~OmniPipeline() = default;
@@ -109,7 +151,9 @@ std::vector<int32_t> OmniPipeline::run_thinker(const std::vector<int32_t>& input
 }
 
 std::vector<float> OmniPipeline::run_code2wav(const std::vector<int32_t>& codec_tokens,
-                                              int32_t n_codebooks, int32_t n_frames) {
+                                              int32_t n_codebooks, int32_t n_frames,
+                                              double& code2wav_and_transfer_ms,
+                                              double& output_materialization_ms) {
     if (!code2wav_) {
         throw std::runtime_error("OmniPipeline: required Code2Wav engine is unavailable");
     }
@@ -128,7 +172,9 @@ std::vector<float> OmniPipeline::run_code2wav(const std::vector<int32_t>& codec_
     TensorMap inputs;
     inputs["codec_tokens"] = codes_tensor;
 
+    const auto code2wav_start = OmniClock::now();
     TensorMap outputs = code2wav_->forward(inputs);
+    code2wav_and_transfer_ms = elapsed_ms(code2wav_start, OmniClock::now());
 
     auto it = outputs.find("waveform");
     if (it == outputs.end()) {
@@ -141,8 +187,10 @@ std::vector<float> OmniPipeline::run_code2wav(const std::vector<int32_t>& codec_
     const auto copy_n =
         code2wav_output_samples(*config_, actual_frames, static_cast<std::size_t>(total_out));
 
+    const auto materialize_start = OmniClock::now();
     std::vector<float> waveform(static_cast<std::size_t>(copy_n));
     std::memcpy(waveform.data(), wt.data, copy_n * sizeof(float));
+    output_materialization_ms = elapsed_ms(materialize_start, OmniClock::now());
 
     std::cerr << "[trtmc] Omni Code2Wav: " << actual_frames << " frames -> " << waveform.size()
               << " samples" << std::endl;
@@ -150,9 +198,13 @@ std::vector<float> OmniPipeline::run_code2wav(const std::vector<int32_t>& codec_
 }
 
 AudioResult OmniPipeline::generate_audio(const std::string& prompt, const GenerateConfig& cfg) {
+    const auto total_start = OmniClock::now();
+    OmniStageTotals stages;
+    const auto input_start = OmniClock::now();
     std::vector<int32_t> input_ids;
     if (tokenizer_)
         input_ids = tokenizer_->encode(format_omni_chat_prompt(prompt));
+    stages.input_preparation_ms = elapsed_ms(input_start, OmniClock::now());
 
     int32_t max_tokens = cfg.max_new_tokens > 0 ? cfg.max_new_tokens : 768;
 
@@ -162,21 +214,29 @@ AudioResult OmniPipeline::generate_audio(const std::string& prompt, const Genera
     std::cerr << "[trtmc] Omni: starting pipeline with " << input_ids.size() << " input tokens"
               << std::endl;
 
+    const auto thinker_start = OmniClock::now();
     auto text_tokens = run_thinker(input_ids, max_tokens);
+    stages.thinker_and_transfer_ms = elapsed_ms(thinker_start, OmniClock::now());
     if (text_tokens.empty()) {
         std::cerr << "[trtmc] Omni: Thinker produced no tokens" << std::endl;
+        report_omni_stage_timing(stages, elapsed_ms(total_start, OmniClock::now()));
         return result;
     }
 
     if (!tokenizer_)
         throw std::runtime_error("OmniPipeline: tokenizer is required for official Talker input");
+    const auto text_start = OmniClock::now();
     const std::string assistant_text = tokenizer_->decode(text_tokens);
+    stages.output_materialization_ms += elapsed_ms(text_start, OmniClock::now());
     std::cerr << "[trtmc] Omni Thinker text: " << assistant_text << std::endl;
 
-    auto talker_result = run_qwen3_omni_official_talker(
-        config_->hf_python, config_->talker_model_id, config_->talker_model_revision, prompt,
-        assistant_text, config_->talker_n_codebooks, config_->code2wav_max_frames);
+    auto talker_result = talker_runtime_->run(prompt, assistant_text);
+    stages.worker_start_ms = talker_result.worker_start_ms;
+    stages.talker_ms = talker_result.talker_ms;
+    stages.ipc_ms = talker_result.ipc_ms;
+    stages.output_materialization_ms += talker_result.output_materialization_ms;
     if (talker_result.exit_code != 0) {
+        report_omni_stage_timing(stages, elapsed_ms(total_start, OmniClock::now()));
         throw std::runtime_error("OmniPipeline: official Talker failed: " +
                                  talker_result.stderr_data);
     }
@@ -187,8 +247,11 @@ AudioResult OmniPipeline::generate_audio(const std::string& prompt, const Genera
         throw std::runtime_error("OmniPipeline: official Talker produced no codec frames");
     std::cerr << "[trtmc] Omni official Talker: " << codec_plan.n_frames << " frames x "
               << codec_plan.n_codebooks << " codebooks" << std::endl;
+    double waveform_materialization_ms = 0.0;
     auto waveform =
-        run_code2wav(talker_result.frame_major_codes, codec_plan.n_codebooks, codec_plan.n_frames);
+        run_code2wav(talker_result.frame_major_codes, codec_plan.n_codebooks, codec_plan.n_frames,
+                     stages.code2wav_and_transfer_ms, waveform_materialization_ms);
+    stages.output_materialization_ms += waveform_materialization_ms;
     if (!waveform.empty()) {
         result.samples = std::move(waveform);
         result.num_samples = static_cast<int32_t>(result.samples.size());
@@ -200,6 +263,7 @@ AudioResult OmniPipeline::generate_audio(const std::string& prompt, const Genera
                       : 0.0F)
               << "s @ " << result.sample_rate << " Hz)" << std::endl;
 
+    report_omni_stage_timing(stages, elapsed_ms(total_start, OmniClock::now()));
     return result;
 }
 

--- a/src/runtime/models/qwen3_omni/pipeline.h
+++ b/src/runtime/models/qwen3_omni/pipeline.h
@@ -24,6 +24,8 @@
 
 namespace trtmc {
 
+class Qwen3OmniTalkerRuntime;
+
 class OmniPipeline final : public IPipeline {
   public:
     OmniPipeline(std::unique_ptr<TrtModule> thinker,
@@ -42,12 +44,14 @@ class OmniPipeline final : public IPipeline {
     void run_thinker_step(int32_t token_id, std::vector<float>& logits);
     std::vector<int32_t> run_thinker(const std::vector<int32_t>& input_ids, int32_t max_tokens);
     std::vector<float> run_code2wav(const std::vector<int32_t>& codec_tokens, int32_t n_codebooks,
-                                    int32_t n_frames);
+                                    int32_t n_frames, double& code2wav_and_transfer_ms,
+                                    double& output_materialization_ms);
 
     std::unique_ptr<TrtModule> thinker_;
     std::unique_ptr<Qwen3OmniInferenceState> thinker_state_;
     std::unique_ptr<TrtModule> code2wav_;
     std::unique_ptr<OmniConfig> config_;
+    std::unique_ptr<Qwen3OmniTalkerRuntime> talker_runtime_;
     cudaStream_t stream_;
     std::shared_ptr<ITokenizer> tokenizer_;
     std::string model_id_;

--- a/src/runtime/models/qwen3_omni/talker_runtime.cpp
+++ b/src/runtime/models/qwen3_omni/talker_runtime.cpp
@@ -5,25 +5,62 @@
 
 #include "runtime/models/qwen3_omni/talker_runtime.h"
 
+#include <algorithm>
 #include <array>
 #include <cerrno>
+#include <chrono>
+#include <csignal>
 #include <cstring>
+#include <fcntl.h>
+#include <mutex>
 #include <poll.h>
+#include <pthread.h>
+#include <spawn.h>
 #include <stdexcept>
 #include <sys/socket.h>
 #include <sys/wait.h>
+#include <thread>
 #include <unistd.h>
+#include <utility>
+
+extern char** environ;
 
 namespace trtmc {
 namespace {
 
+using Clock = std::chrono::steady_clock;
 using Pipe = std::array<int, 2>;
+
+constexpr std::uint32_t kWorkerMagic = 0x514f4d4eU;
+constexpr std::uint32_t kWorkerReady = 1;
+constexpr std::uint32_t kWorkerOk = 2;
+constexpr std::uint32_t kWorkerError = 3;
+constexpr std::size_t kResponseHeaderBytes = 20;
+constexpr std::uint32_t kMaxResponseBytes = 64U * 1024U * 1024U;
 
 struct ProcessPipes {
     Pipe input{-1, -1};
     Pipe output{-1, -1};
     Pipe error{-1, -1};
 };
+
+struct WorkerResponse {
+    std::uint32_t status{0};
+    double talker_ms{0.0};
+    std::vector<char> payload;
+};
+
+double elapsed_ms(Clock::time_point start, Clock::time_point end) {
+    return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+void append_error(std::string& destination, const std::string& message) {
+    if (message.empty())
+        return;
+    if (!destination.empty() && destination.back() != '\n')
+        destination.push_back('\n');
+    destination += message;
+}
 
 void close_fd(int& fd) {
     if (fd >= 0) {
@@ -51,9 +88,61 @@ bool open_all(ProcessPipes& pipes) {
     return true;
 }
 
+bool set_nonblocking(int fd) {
+    const int flags = fcntl(fd, F_GETFL, 0);
+    return flags >= 0 && fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
+}
+
+class ScopedSigpipeBlock {
+  public:
+    ScopedSigpipeBlock() {
+        sigemptyset(&blocked_);
+        sigaddset(&blocked_, SIGPIPE);
+        active_ = pthread_sigmask(SIG_BLOCK, &blocked_, &previous_) == 0;
+        sigset_t pending;
+        sigemptyset(&pending);
+        was_pending_ = active_ && sigpending(&pending) == 0 && sigismember(&pending, SIGPIPE) == 1;
+    }
+
+    ~ScopedSigpipeBlock() {
+        if (active_)
+            (void)pthread_sigmask(SIG_SETMASK, &previous_, nullptr);
+    }
+
+    void consume_if_generated(int write_errno) const {
+        if (write_errno != EPIPE || !active_ || was_pending_)
+            return;
+        timespec timeout{0, 0};
+        (void)sigtimedwait(&blocked_, nullptr, &timeout);
+    }
+
+  private:
+    sigset_t blocked_{};
+    sigset_t previous_{};
+    bool active_{false};
+    bool was_pending_{false};
+};
+
 void append_u32_le(std::vector<char>& output, std::uint32_t value) {
     for (int shift = 0; shift < 32; shift += 8)
         output.push_back(static_cast<char>((value >> shift) & 0xffU));
+}
+
+std::uint32_t read_u32_le(const char* input) {
+    std::uint32_t value = 0;
+    for (int shift = 0; shift < 32; shift += 8)
+        value |= static_cast<std::uint32_t>(static_cast<unsigned char>(input[shift / 8])) << shift;
+    return value;
+}
+
+double read_f64_le(const char* input) {
+    static_assert(sizeof(double) == 8, "Qwen3-Omni worker protocol requires binary64 doubles");
+    std::uint64_t bits = 0;
+    for (int shift = 0; shift < 64; shift += 8)
+        bits |= static_cast<std::uint64_t>(static_cast<unsigned char>(input[shift / 8])) << shift;
+    double value = 0.0;
+    std::memcpy(&value, &bits, sizeof(value));
+    return value;
 }
 
 std::vector<char> make_request(const std::string& prompt, const std::string& assistant_text) {
@@ -68,111 +157,40 @@ std::vector<char> make_request(const std::string& prompt, const std::string& ass
     return request;
 }
 
+std::vector<char> frame_request(const std::vector<char>& request) {
+    if (request.size() > UINT32_MAX)
+        throw std::runtime_error("Qwen3-Omni Talker framed request is too large");
+    std::vector<char> frame;
+    frame.reserve(8 + request.size());
+    append_u32_le(frame, kWorkerMagic);
+    append_u32_le(frame, static_cast<std::uint32_t>(request.size()));
+    frame.insert(frame.end(), request.begin(), request.end());
+    return frame;
+}
+
+std::vector<char> shutdown_request() {
+    std::vector<char> frame;
+    append_u32_le(frame, kWorkerMagic);
+    append_u32_le(frame, 0);
+    return frame;
+}
+
 bool send_all(int fd, const std::vector<char>& data) {
+    ScopedSigpipeBlock sigpipe_block;
     std::size_t offset = 0;
     while (offset < data.size()) {
-        const auto count = send(fd, data.data() + offset, data.size() - offset, MSG_NOSIGNAL);
+        const auto count = write(fd, data.data() + offset, data.size() - offset);
         if (count < 0 && errno == EINTR)
             continue;
-        if (count <= 0)
+        if (count <= 0) {
+            const int write_errno = errno;
+            sigpipe_block.consume_if_generated(write_errno);
+            errno = write_errno;
             return false;
+        }
         offset += static_cast<std::size_t>(count);
     }
     return true;
-}
-
-void read_ready_fd(pollfd& descriptor, std::vector<char>& output) {
-    char buffer[65536];
-    for (;;) {
-        const auto count = read(descriptor.fd, buffer, sizeof(buffer));
-        if (count > 0) {
-            output.insert(output.end(), buffer, buffer + count);
-        } else if (count == 0) {
-            close(descriptor.fd);
-            descriptor.fd = -1;
-        } else if (errno != EINTR && errno != EAGAIN) {
-            close(descriptor.fd);
-            descriptor.fd = -1;
-        }
-        return;
-    }
-}
-
-[[noreturn]] void exec_child(ProcessPipes& pipes, const std::vector<std::string>& argv) {
-    if (dup2(pipes.input[0], STDIN_FILENO) < 0 || dup2(pipes.output[1], STDOUT_FILENO) < 0 ||
-        dup2(pipes.error[1], STDERR_FILENO) < 0) {
-        _exit(127);
-    }
-    close_all(pipes);
-
-    std::vector<char*> child_argv;
-    child_argv.reserve(argv.size() + 1);
-    for (const auto& argument : argv)
-        child_argv.push_back(const_cast<char*>(argument.c_str()));
-    child_argv.push_back(nullptr);
-    execvp(child_argv[0], child_argv.data());
-    _exit(127);
-}
-
-void drain_output(ProcessPipes& pipes, std::vector<char>& stdout_data,
-                  std::vector<char>& stderr_data) {
-    pollfd descriptors[2] = {
-        {pipes.output[0], POLLIN, 0},
-        {pipes.error[0], POLLIN, 0},
-    };
-    while (descriptors[0].fd >= 0 || descriptors[1].fd >= 0) {
-        const int ready = poll(descriptors, 2, -1);
-        if (ready < 0 && errno == EINTR)
-            continue;
-        if (ready < 0)
-            break;
-        for (int index = 0; index < 2; ++index) {
-            if (descriptors[index].fd >= 0 &&
-                (descriptors[index].revents & (POLLIN | POLLHUP | POLLERR))) {
-                read_ready_fd(descriptors[index], index == 0 ? stdout_data : stderr_data);
-            }
-        }
-    }
-    close_fd(descriptors[0].fd);
-    close_fd(descriptors[1].fd);
-    pipes.output[0] = -1;
-    pipes.error[0] = -1;
-}
-
-int wait_for_child(pid_t pid) {
-    int status = 0;
-    while (waitpid(pid, &status, 0) < 0) {
-        if (errno != EINTR)
-            return -1;
-    }
-    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
-}
-
-int run_process(const std::vector<std::string>& argv, const std::vector<char>& input,
-                std::vector<char>& stdout_data, std::vector<char>& stderr_data) {
-    ProcessPipes pipes;
-    if (!open_all(pipes))
-        return -1;
-
-    const pid_t pid = fork();
-    if (pid < 0) {
-        close_all(pipes);
-        return -1;
-    }
-    if (pid == 0)
-        exec_child(pipes, argv);
-
-    close_fd(pipes.input[0]);
-    close_fd(pipes.output[1]);
-    close_fd(pipes.error[1]);
-    const bool wrote_request = send_all(pipes.input[1], input);
-    close_fd(pipes.input[1]);
-    drain_output(pipes, stdout_data, stderr_data);
-    const int exit_code = wait_for_child(pid);
-    close_all(pipes);
-    if (!wrote_request)
-        return -1;
-    return exit_code;
 }
 
 std::vector<std::string> make_talker_argv(const std::string& hf_python, const std::string& model_id,
@@ -181,6 +199,7 @@ std::vector<std::string> make_talker_argv(const std::string& hf_python, const st
         hf_python,
         "-m",
         "tensorrt_model_connect.families.qwen3_omni.audio_runtime",
+        "--worker",
         "--model-id",
         model_id,
         "--max-frames",
@@ -193,47 +212,383 @@ std::vector<std::string> make_talker_argv(const std::string& hf_python, const st
     return argv;
 }
 
+void add_spawn_close(posix_spawn_file_actions_t& actions, int fd) {
+    if (fd >= 0 && fd != STDIN_FILENO && fd != STDOUT_FILENO && fd != STDERR_FILENO)
+        posix_spawn_file_actions_addclose(&actions, fd);
+}
+
+int spawn_worker(const std::vector<std::string>& argv, ProcessPipes& pipes, pid_t& pid) {
+    posix_spawn_file_actions_t actions;
+    if (posix_spawn_file_actions_init(&actions) != 0)
+        return -1;
+    int rc = posix_spawn_file_actions_adddup2(&actions, pipes.input[0], STDIN_FILENO);
+    rc = rc == 0 ? posix_spawn_file_actions_adddup2(&actions, pipes.output[1], STDOUT_FILENO) : rc;
+    rc = rc == 0 ? posix_spawn_file_actions_adddup2(&actions, pipes.error[1], STDERR_FILENO) : rc;
+    for (const Pipe* pipe : {&pipes.input, &pipes.output, &pipes.error}) {
+        add_spawn_close(actions, (*pipe)[0]);
+        add_spawn_close(actions, (*pipe)[1]);
+    }
+
+    std::vector<char*> child_argv;
+    child_argv.reserve(argv.size() + 1);
+    for (const auto& argument : argv)
+        child_argv.push_back(const_cast<char*>(argument.c_str()));
+    child_argv.push_back(nullptr);
+    if (rc == 0)
+        rc = posix_spawnp(&pid, child_argv[0], &actions, nullptr, child_argv.data(), environ);
+    posix_spawn_file_actions_destroy(&actions);
+    return rc;
+}
+
 } // namespace
 
-Qwen3OmniTalkerRuntimeResult
-run_qwen3_omni_official_talker(const std::string& hf_python, const std::string& model_id,
-                               const std::string& model_revision, const std::string& prompt,
-                               const std::string& assistant_text, int32_t n_codebooks,
-                               int32_t max_frames) {
-    Qwen3OmniTalkerRuntimeResult result;
-    if (hf_python.empty()) {
-        result.stderr_data = "--hf-python is required for the official Qwen3-Omni Talker";
-        return result;
-    }
-    if (model_id.empty() || n_codebooks <= 0 || max_frames <= 0) {
-        result.stderr_data = "invalid Qwen3-Omni official Talker runtime configuration";
+class Qwen3OmniTalkerRuntime::Impl {
+  public:
+    Impl(std::string hf_python, std::string model_id, std::string model_revision,
+         int32_t n_codebooks, int32_t max_frames, std::vector<std::string> worker_argv)
+        : hf_python_(std::move(hf_python)), model_id_(std::move(model_id)),
+          model_revision_(std::move(model_revision)), n_codebooks_(n_codebooks),
+          max_frames_(max_frames), worker_argv_(std::move(worker_argv)) {}
+
+    ~Impl() { shutdown(); }
+
+    Qwen3OmniTalkerRuntimeResult run(const std::string& prompt, const std::string& assistant_text) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        Qwen3OmniTalkerRuntimeResult result;
+        if (!validate(result.stderr_data))
+            return result;
+
+        if (!ensure_started(result.worker_start_ms, result.stderr_data))
+            return result;
+
+        const auto framed_request = frame_request(make_request(prompt, assistant_text));
+        const auto request_start = Clock::now();
+        if (!send_all(input_fd_, framed_request)) {
+            append_error(result.stderr_data, "Qwen3-Omni Talker worker request write failed: " +
+                                                 std::string(std::strerror(errno)));
+            fail_worker(result.stderr_data);
+            return result;
+        }
+        ++requests_;
+
+        WorkerResponse response;
+        std::string protocol_error;
+        if (!read_response(response, protocol_error)) {
+            append_error(result.stderr_data, protocol_error);
+            fail_worker(result.stderr_data);
+            return result;
+        }
+        const auto response_end = Clock::now();
+        result.talker_ms = response.talker_ms;
+        result.ipc_ms = std::max(0.0, elapsed_ms(request_start, response_end) - result.talker_ms);
+
+        if (response.status == kWorkerError) {
+            result.exit_code = 1;
+            append_error(result.stderr_data,
+                         std::string(response.payload.begin(), response.payload.end()));
+            append_error(result.stderr_data, take_stderr());
+            return result;
+        }
+        if (response.status != kWorkerOk) {
+            append_error(result.stderr_data, "Qwen3-Omni Talker worker returned invalid status");
+            fail_worker(result.stderr_data);
+            return result;
+        }
+
+        const auto materialize_start = Clock::now();
+        result.exit_code =
+            materialize_codes(response.payload, result.frame_major_codes, result.stderr_data) ? 0
+                                                                                              : -1;
+        result.output_materialization_ms = elapsed_ms(materialize_start, Clock::now());
+        append_error(result.stderr_data, take_stderr());
+        if (result.exit_code != 0)
+            stop_worker(false);
         return result;
     }
 
-    const auto argv = make_talker_argv(hf_python, model_id, model_revision, max_frames);
-    std::vector<char> stdout_data;
-    std::vector<char> stderr_data;
-    result.exit_code =
-        run_process(argv, make_request(prompt, assistant_text), stdout_data, stderr_data);
-    result.stderr_data.assign(stderr_data.begin(), stderr_data.end());
-    if (result.exit_code != 0)
-        return result;
-    if (stdout_data.empty() || stdout_data.size() % sizeof(int32_t) != 0) {
-        result.exit_code = -1;
-        result.stderr_data += "\nQwen3-Omni official Talker returned an invalid binary payload";
+    void shutdown() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stop_worker(true);
+    }
+
+    Qwen3OmniTalkerRuntimeStats stats() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return {worker_starts_, requests_, pid_ > 0};
+    }
+
+  private:
+    bool validate(std::string& error) const {
+        if ((worker_argv_.empty() && hf_python_.empty()) || model_id_.empty() ||
+            n_codebooks_ <= 0 || max_frames_ <= 0) {
+            error = "invalid Qwen3-Omni official Talker runtime configuration";
+            if (worker_argv_.empty() && hf_python_.empty())
+                error = "--hf-python is required for the official Qwen3-Omni Talker";
+            return false;
+        }
+        return true;
+    }
+
+    bool ensure_started(double& worker_start_ms, std::string& error) {
+        if (pid_ > 0)
+            return true;
+        const auto start = Clock::now();
+        if (!launch_worker(error) || !await_ready(error))
+            return false;
+        worker_start_ms = elapsed_ms(start, Clock::now());
+        return true;
+    }
+
+    bool launch_worker(std::string& error) {
+        ProcessPipes pipes;
+        if (!open_all(pipes)) {
+            error = "Qwen3-Omni Talker worker pipe creation failed";
+            return false;
+        }
+        const auto argv = worker_argv_.empty() ? make_talker_argv(hf_python_, model_id_,
+                                                                  model_revision_, max_frames_)
+                                               : worker_argv_;
+        pid_t child_pid = -1;
+        const int spawn_rc = spawn_worker(argv, pipes, child_pid);
+        if (spawn_rc != 0) {
+            close_all(pipes);
+            error =
+                "Qwen3-Omni Talker worker spawn failed: " + std::string(std::strerror(spawn_rc));
+            return false;
+        }
+
+        pid_ = child_pid;
+        ++worker_starts_;
+        close_fd(pipes.input[0]);
+        close_fd(pipes.output[1]);
+        close_fd(pipes.error[1]);
+        input_fd_ = pipes.input[1];
+        output_fd_ = pipes.output[0];
+        error_fd_ = pipes.error[0];
+        if (!set_nonblocking(output_fd_) || !set_nonblocking(error_fd_)) {
+            error = "Qwen3-Omni Talker worker pipe setup failed";
+            stop_worker(false);
+            return false;
+        }
+        return true;
+    }
+
+    bool await_ready(std::string& error) {
+        WorkerResponse ready;
+        std::string protocol_error;
+        if (!read_response(ready, protocol_error) || ready.status != kWorkerReady ||
+            !ready.payload.empty()) {
+            error = protocol_error.empty() ? "Qwen3-Omni Talker worker did not become ready"
+                                           : protocol_error;
+            fail_worker(error);
+            return false;
+        }
+        return true;
+    }
+
+    bool read_response(WorkerResponse& response, std::string& error) {
+        if (!ensure_stdout(kResponseHeaderBytes, error))
+            return false;
+        const auto header = consume_stdout(kResponseHeaderBytes);
+        const std::uint32_t magic = read_u32_le(header.data());
+        response.status = read_u32_le(header.data() + 4);
+        const std::uint32_t payload_size = read_u32_le(header.data() + 8);
+        response.talker_ms = read_f64_le(header.data() + 12);
+        if (magic != kWorkerMagic) {
+            error = "Qwen3-Omni Talker worker returned invalid response magic";
+            return false;
+        }
+        if (payload_size > kMaxResponseBytes) {
+            error = "Qwen3-Omni Talker worker response is too large";
+            return false;
+        }
+        if (!ensure_stdout(payload_size, error))
+            return false;
+        response.payload = consume_stdout(payload_size);
+        drain_stderr_now();
+        return true;
+    }
+
+    bool ensure_stdout(std::size_t size, std::string& error) {
+        while (stdout_buffer_.size() < size) {
+            if (!poll_worker_io(error))
+                return false;
+            if (output_fd_ < 0 && stdout_buffer_.size() < size) {
+                error = "Qwen3-Omni Talker worker exited before completing its response";
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool poll_worker_io(std::string& error) {
+        pollfd descriptors[2] = {
+            {output_fd_, POLLIN, 0},
+            {error_fd_, POLLIN, 0},
+        };
+        int ready = -1;
+        do {
+            ready = poll(descriptors, 2, -1);
+        } while (ready < 0 && errno == EINTR);
+        if (ready < 0) {
+            error = "Qwen3-Omni Talker worker poll failed";
+            return false;
+        }
+        drain_poll_descriptor(descriptors[1], error_fd_, stderr_pending_);
+        drain_poll_descriptor(descriptors[0], output_fd_, stdout_buffer_);
+        return true;
+    }
+
+    static void drain_poll_descriptor(const pollfd& descriptor, int& fd,
+                                      std::vector<char>& destination) {
+        if (descriptor.fd >= 0 && (descriptor.revents & (POLLIN | POLLHUP | POLLERR)))
+            drain_fd(fd, destination);
+    }
+
+    static void drain_fd(int& fd, std::vector<char>& destination) {
+        if (fd < 0)
+            return;
+        char buffer[65536];
+        for (;;) {
+            const auto count = read(fd, buffer, sizeof(buffer));
+            if (count > 0) {
+                destination.insert(destination.end(), buffer, buffer + count);
+                continue;
+            }
+            if (count == 0) {
+                close_fd(fd);
+                return;
+            }
+            if (errno == EINTR)
+                continue;
+            if (errno != EAGAIN && errno != EWOULDBLOCK)
+                close_fd(fd);
+            return;
+        }
+    }
+
+    std::vector<char> consume_stdout(std::size_t size) {
+        std::vector<char> result(stdout_buffer_.begin(), stdout_buffer_.begin() + size);
+        stdout_buffer_.erase(stdout_buffer_.begin(), stdout_buffer_.begin() + size);
         return result;
     }
 
-    result.frame_major_codes.resize(stdout_data.size() / sizeof(int32_t));
-    std::memcpy(result.frame_major_codes.data(), stdout_data.data(), stdout_data.size());
-    if (result.frame_major_codes.size() % static_cast<std::size_t>(n_codebooks) != 0 ||
-        result.frame_major_codes.size() >
-            static_cast<std::size_t>(n_codebooks) * static_cast<std::size_t>(max_frames)) {
-        result.exit_code = -1;
-        result.frame_major_codes.clear();
-        result.stderr_data += "\nQwen3-Omni official Talker returned an invalid codec shape";
+    void drain_stderr_now() {
+        if (error_fd_ < 0)
+            return;
+        pollfd descriptor{error_fd_, POLLIN, 0};
+        if (poll(&descriptor, 1, 0) > 0 && (descriptor.revents & (POLLIN | POLLHUP | POLLERR))) {
+            drain_fd(error_fd_, stderr_pending_);
+        }
     }
-    return result;
+
+    std::string take_stderr() {
+        drain_stderr_now();
+        std::string result(stderr_pending_.begin(), stderr_pending_.end());
+        stderr_pending_.clear();
+        return result;
+    }
+
+    bool materialize_codes(const std::vector<char>& payload, std::vector<int32_t>& codes,
+                           std::string& error) const {
+        if (payload.empty() || payload.size() % sizeof(int32_t) != 0) {
+            append_error(error, "Qwen3-Omni official Talker returned an invalid binary payload");
+            return false;
+        }
+        codes.resize(payload.size() / sizeof(int32_t));
+        std::memcpy(codes.data(), payload.data(), payload.size());
+        if (codes.size() % static_cast<std::size_t>(n_codebooks_) != 0 ||
+            codes.size() >
+                static_cast<std::size_t>(n_codebooks_) * static_cast<std::size_t>(max_frames_)) {
+            codes.clear();
+            append_error(error, "Qwen3-Omni official Talker returned an invalid codec shape");
+            return false;
+        }
+        return true;
+    }
+
+    bool wait_for_exit(std::chrono::milliseconds timeout) {
+        const auto deadline = Clock::now() + timeout;
+        while (pid_ > 0) {
+            int status = 0;
+            const pid_t waited = waitpid(pid_, &status, WNOHANG);
+            if (waited == pid_ || (waited < 0 && errno == ECHILD)) {
+                pid_ = -1;
+                return true;
+            }
+            if (waited < 0 && errno != EINTR)
+                return false;
+            if (Clock::now() >= deadline)
+                return false;
+            drain_stderr_now();
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        return true;
+    }
+
+    void stop_worker(bool graceful) {
+        if (pid_ > 0 && graceful && input_fd_ >= 0)
+            (void)send_all(input_fd_, shutdown_request());
+        close_fd(input_fd_);
+        if (pid_ > 0 && !wait_for_exit(std::chrono::milliseconds(graceful ? 2000 : 0))) {
+            kill(pid_, SIGTERM);
+            if (!wait_for_exit(std::chrono::milliseconds(500))) {
+                kill(pid_, SIGKILL);
+                (void)wait_for_exit(std::chrono::milliseconds(500));
+            }
+        }
+        drain_stderr_now();
+        close_fd(output_fd_);
+        close_fd(error_fd_);
+        stdout_buffer_.clear();
+        pid_ = -1;
+    }
+
+    void fail_worker(std::string& error) {
+        stop_worker(false);
+        append_error(error, take_stderr());
+    }
+
+    std::string hf_python_;
+    std::string model_id_;
+    std::string model_revision_;
+    int32_t n_codebooks_{0};
+    int32_t max_frames_{0};
+    std::vector<std::string> worker_argv_;
+    mutable std::mutex mutex_;
+    pid_t pid_{-1};
+    int input_fd_{-1};
+    int output_fd_{-1};
+    int error_fd_{-1};
+    int64_t worker_starts_{0};
+    int64_t requests_{0};
+    std::vector<char> stdout_buffer_;
+    std::vector<char> stderr_pending_;
+};
+
+Qwen3OmniTalkerRuntime::Qwen3OmniTalkerRuntime(std::string hf_python, std::string model_id,
+                                               std::string model_revision, int32_t n_codebooks,
+                                               int32_t max_frames,
+                                               std::vector<std::string> worker_argv)
+    : impl_(std::make_unique<Impl>(std::move(hf_python), std::move(model_id),
+                                   std::move(model_revision), n_codebooks, max_frames,
+                                   std::move(worker_argv))) {}
+
+Qwen3OmniTalkerRuntime::~Qwen3OmniTalkerRuntime() = default;
+Qwen3OmniTalkerRuntime::Qwen3OmniTalkerRuntime(Qwen3OmniTalkerRuntime&&) noexcept = default;
+Qwen3OmniTalkerRuntime&
+Qwen3OmniTalkerRuntime::operator=(Qwen3OmniTalkerRuntime&&) noexcept = default;
+
+Qwen3OmniTalkerRuntimeResult Qwen3OmniTalkerRuntime::run(const std::string& prompt,
+                                                         const std::string& assistant_text) {
+    return impl_->run(prompt, assistant_text);
+}
+
+void Qwen3OmniTalkerRuntime::shutdown() {
+    impl_->shutdown();
+}
+
+Qwen3OmniTalkerRuntimeStats Qwen3OmniTalkerRuntime::stats() const {
+    return impl_->stats();
 }
 
 } // namespace trtmc

--- a/src/runtime/models/qwen3_omni/talker_runtime.h
+++ b/src/runtime/models/qwen3_omni/talker_runtime.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -15,12 +16,37 @@ struct Qwen3OmniTalkerRuntimeResult {
     int exit_code{-1};
     std::vector<int32_t> frame_major_codes;
     std::string stderr_data;
+    double worker_start_ms{0.0};
+    double talker_ms{0.0};
+    double ipc_ms{0.0};
+    double output_materialization_ms{0.0};
 };
 
-Qwen3OmniTalkerRuntimeResult
-run_qwen3_omni_official_talker(const std::string& hf_python, const std::string& model_id,
-                               const std::string& model_revision, const std::string& prompt,
-                               const std::string& assistant_text, int32_t n_codebooks,
-                               int32_t max_frames);
+struct Qwen3OmniTalkerRuntimeStats {
+    int64_t worker_starts{0};
+    int64_t requests{0};
+    bool worker_running{false};
+};
+
+class Qwen3OmniTalkerRuntime {
+  public:
+    Qwen3OmniTalkerRuntime(std::string hf_python, std::string model_id, std::string model_revision,
+                           int32_t n_codebooks, int32_t max_frames,
+                           std::vector<std::string> worker_argv = {});
+    ~Qwen3OmniTalkerRuntime();
+
+    Qwen3OmniTalkerRuntime(Qwen3OmniTalkerRuntime&&) noexcept;
+    Qwen3OmniTalkerRuntime& operator=(Qwen3OmniTalkerRuntime&&) noexcept;
+    Qwen3OmniTalkerRuntime(const Qwen3OmniTalkerRuntime&) = delete;
+    Qwen3OmniTalkerRuntime& operator=(const Qwen3OmniTalkerRuntime&) = delete;
+
+    Qwen3OmniTalkerRuntimeResult run(const std::string& prompt, const std::string& assistant_text);
+    void shutdown();
+    Qwen3OmniTalkerRuntimeStats stats() const;
+
+  private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
 
 } // namespace trtmc

--- a/tests/cpp/models/qwen3_omni/test_qwen3_omni_talker_runtime.cpp
+++ b/tests/cpp/models/qwen3_omni/test_qwen3_omni_talker_runtime.cpp
@@ -1,0 +1,211 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/qwen3_omni/talker_runtime.h"
+
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+constexpr std::uint32_t kWorkerMagic = 0x514f4d4eU;
+constexpr std::uint32_t kWorkerReady = 1;
+constexpr std::uint32_t kWorkerOk = 2;
+constexpr std::uint32_t kWorkerError = 3;
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+bool read_exact(int fd, void* output, std::size_t size) {
+    auto* bytes = static_cast<char*>(output);
+    std::size_t offset = 0;
+    while (offset < size) {
+        const auto count = read(fd, bytes + offset, size - offset);
+        if (count < 0 && errno == EINTR)
+            continue;
+        if (count <= 0)
+            return false;
+        offset += static_cast<std::size_t>(count);
+    }
+    return true;
+}
+
+bool write_all(int fd, const void* input, std::size_t size) {
+    const auto* bytes = static_cast<const char*>(input);
+    std::size_t offset = 0;
+    while (offset < size) {
+        const auto count = write(fd, bytes + offset, size - offset);
+        if (count < 0 && errno == EINTR)
+            continue;
+        if (count <= 0)
+            return false;
+        offset += static_cast<std::size_t>(count);
+    }
+    return true;
+}
+
+std::uint32_t read_u32_le(const char* input) {
+    std::uint32_t value = 0;
+    for (int shift = 0; shift < 32; shift += 8)
+        value |= static_cast<std::uint32_t>(static_cast<unsigned char>(input[shift / 8])) << shift;
+    return value;
+}
+
+void append_u32_le(std::vector<char>& output, std::uint32_t value) {
+    for (int shift = 0; shift < 32; shift += 8)
+        output.push_back(static_cast<char>((value >> shift) & 0xffU));
+}
+
+void append_f64_le(std::vector<char>& output, double value) {
+    std::uint64_t bits = 0;
+    std::memcpy(&bits, &value, sizeof(value));
+    for (int shift = 0; shift < 64; shift += 8)
+        output.push_back(static_cast<char>((bits >> shift) & 0xffU));
+}
+
+bool write_response(std::uint32_t status, const std::vector<char>& payload = {}) {
+    std::vector<char> header;
+    append_u32_le(header, kWorkerMagic);
+    append_u32_le(header, status);
+    append_u32_le(header, static_cast<std::uint32_t>(payload.size()));
+    append_f64_le(header, status == kWorkerReady ? 0.0 : 1.25);
+    return write_all(STDOUT_FILENO, header.data(), header.size()) &&
+           write_all(STDOUT_FILENO, payload.data(), payload.size());
+}
+
+std::string request_prompt(const std::vector<char>& payload) {
+    if (payload.size() < 8)
+        return {};
+    const std::uint32_t prompt_size = read_u32_le(payload.data());
+    if (8 + static_cast<std::size_t>(prompt_size) > payload.size())
+        return {};
+    return std::string(payload.data() + 8, payload.data() + 8 + prompt_size);
+}
+
+int read_fake_request(std::vector<char>& payload) {
+    char header[8];
+    if (!read_exact(STDIN_FILENO, header, sizeof(header)))
+        return 0;
+    const std::uint32_t magic = read_u32_le(header);
+    const std::uint32_t payload_size = read_u32_le(header + 4);
+    if (magic != kWorkerMagic)
+        return 3;
+    if (payload_size == 0)
+        return 0;
+    payload.resize(payload_size);
+    return read_exact(STDIN_FILENO, payload.data(), payload.size()) ? -1 : 4;
+}
+
+int respond_to_fake_request(const std::vector<char>& payload, int32_t request_count) {
+    const std::string prompt = request_prompt(payload);
+    if (prompt == "crash")
+        _exit(9);
+    if (prompt == "error") {
+        const std::string stderr_message = "fixture stderr\n";
+        (void)write_all(STDERR_FILENO, stderr_message.data(), stderr_message.size());
+        const std::string message = "fixture request failed";
+        return write_response(kWorkerError, std::vector<char>(message.begin(), message.end())) ? -1
+                                                                                               : 5;
+    }
+    const int32_t codes[] = {request_count, request_count + 10};
+    std::vector<char> bytes(sizeof(codes));
+    std::memcpy(bytes.data(), codes, sizeof(codes));
+    return write_response(kWorkerOk, bytes) ? -1 : 6;
+}
+
+int run_fake_worker() {
+    if (!write_response(kWorkerReady))
+        return 2;
+    int32_t request_count = 0;
+    for (;;) {
+        std::vector<char> payload;
+        const int read_status = read_fake_request(payload);
+        if (read_status >= 0)
+            return read_status;
+        const int response_status = respond_to_fake_request(payload, ++request_count);
+        if (response_status >= 0)
+            return response_status;
+    }
+}
+
+std::string self_executable() {
+    std::vector<char> path(4096, '\0');
+    const auto size = readlink("/proc/self/exe", path.data(), path.size() - 1);
+    if (size <= 0)
+        return {};
+    return std::string(path.data(), static_cast<std::size_t>(size));
+}
+
+void test_worker_is_reused_and_recovers_after_failure() {
+    trtmc::Qwen3OmniTalkerRuntime runtime("", "fixture", "", 2, 4,
+                                          {self_executable(), "--fake-worker"});
+
+    const auto first = runtime.run("first", "assistant");
+    if (first.exit_code != 0)
+        std::cerr << "first request error: " << first.stderr_data << '\n';
+    check(first.exit_code == 0, "first request succeeds");
+    check(first.frame_major_codes == std::vector<int32_t>({1, 11}),
+          "first request returns fixture codes");
+    check(first.talker_ms == 1.25, "first request reports Talker timing");
+    check(first.ipc_ms >= 0.0, "first request reports IPC timing");
+    check(first.output_materialization_ms >= 0.0,
+          "first request reports output materialization timing");
+
+    const auto second = runtime.run("second", "assistant");
+    check(second.exit_code == 0, "second request succeeds");
+    check(second.frame_major_codes == std::vector<int32_t>({2, 12}),
+          "second request uses the same worker state");
+    auto stats = runtime.stats();
+    check(stats.worker_starts == 1, "two requests initialize one worker");
+    check(stats.requests == 2, "two requests are counted");
+    check(stats.worker_running, "worker remains running after two requests");
+
+    const auto request_error = runtime.run("error", "assistant");
+    check(request_error.exit_code == 1, "request error is explicit");
+    check(request_error.stderr_data.find("fixture request failed") != std::string::npos,
+          "request error payload is propagated");
+    check(request_error.stderr_data.find("fixture stderr") != std::string::npos,
+          "worker stderr is propagated");
+    const auto after_error = runtime.run("after-error", "assistant");
+    check(after_error.exit_code == 0, "worker remains usable after request error");
+    check(after_error.frame_major_codes == std::vector<int32_t>({4, 14}),
+          "request failure does not tear down a healthy worker");
+
+    const auto crash = runtime.run("crash", "assistant");
+    check(crash.exit_code == -1, "worker process failure returns runtime error");
+    check(crash.stderr_data.find("exited") != std::string::npos,
+          "worker process failure is explicit");
+    const auto restarted = runtime.run("after-crash", "assistant");
+    check(restarted.exit_code == 0, "request after crash succeeds");
+    check(restarted.frame_major_codes == std::vector<int32_t>({1, 11}),
+          "next request restarts a failed worker cleanly");
+    stats = runtime.stats();
+    check(stats.worker_starts == 2, "worker restart count is deterministic");
+    check(stats.requests == 6, "request count includes failed request");
+    check(stats.worker_running, "restarted worker remains running");
+
+    runtime.shutdown();
+    check(!runtime.stats().worker_running, "explicit shutdown reaps the worker");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc == 2 && std::string(argv[1]) == "--fake-worker")
+        return run_fake_worker();
+    test_worker_is_reused_and_recovers_after_failure();
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/e2e/models/qwen3_omni/test_hidden_state_flow.py
+++ b/tests/e2e/models/qwen3_omni/test_hidden_state_flow.py
@@ -18,7 +18,7 @@ def test_qwen3_omni_runtime_feeds_generated_text_to_official_talker() -> None:
     source = (ROOT / "src/runtime/models/qwen3_omni/pipeline.cpp").read_text()
 
     assert "tokenizer_->decode(text_tokens)" in source
-    assert "run_qwen3_omni_official_talker" in source
+    assert "talker_runtime_->run(prompt, assistant_text)" in source
     assert "format_omni_chat_prompt(prompt)" in source
     assert "token == config_->thinker_eos_token_id" in source
     assert 'outputs.find("hidden_state")' not in source
@@ -59,6 +59,6 @@ def test_qwen3_omni_runtime_has_no_retired_talker_recurrent_state() -> None:
 
     assert "Qwen3OmniKvCache" in plugin
     assert "Qwen3OmniRecurrentState" not in plugin
-    assert 'runtime/models/qwen3_omni/recurrent_state.h' not in plugin
+    assert "runtime/models/qwen3_omni/recurrent_state.h" not in plugin
     assert not (runtime / "recurrent_state.h").exists()
     assert not (runtime / "recurrent_state.cpp").exists()

--- a/tests/e2e/models/qwen3_omni/test_qwen3_omni_audio_runtime.py
+++ b/tests/e2e/models/qwen3_omni/test_qwen3_omni_audio_runtime.py
@@ -3,14 +3,23 @@
 
 from __future__ import annotations
 
+import io
 import struct
 
+import numpy as np
 import pytest
 
 from tensorrt_model_connect.families.qwen3_omni.audio_runtime import (
     TalkerRequest,
+    _WORKER_ERROR,
+    _WORKER_MAGIC,
+    _WORKER_OK,
+    _WORKER_READY,
+    _WORKER_REQUEST_HEADER,
+    _WORKER_RESPONSE_HEADER,
     _chatml,
     _read_request,
+    _serve_worker,
 )
 from tensorrt_model_connect.config import ModelConfig
 from tensorrt_model_connect.families.qwen3_omni.plugin import (
@@ -25,6 +34,27 @@ def _payload(prompt: str, assistant: str) -> bytes:
     return (
         struct.pack("<II", len(prompt_bytes), len(assistant_bytes)) + prompt_bytes + assistant_bytes
     )
+
+
+def _worker_input(*requests: bytes) -> io.BytesIO:
+    framed = bytearray()
+    for request in requests:
+        framed.extend(_WORKER_REQUEST_HEADER.pack(_WORKER_MAGIC, len(request)))
+        framed.extend(request)
+    framed.extend(_WORKER_REQUEST_HEADER.pack(_WORKER_MAGIC, 0))
+    return io.BytesIO(framed)
+
+
+def _worker_responses(payload: bytes) -> list[tuple[int, bytes, float]]:
+    stream = io.BytesIO(payload)
+    responses = []
+    while header := stream.read(_WORKER_RESPONSE_HEADER.size):
+        magic, status, size, talker_ms = _WORKER_RESPONSE_HEADER.unpack(header)
+        assert magic == _WORKER_MAGIC
+        body = stream.read(size)
+        assert len(body) == size
+        responses.append((status, body, talker_ms))
+    return responses
 
 
 def test_talker_request_preserves_prompt_and_trims_generated_stop_marker() -> None:
@@ -49,6 +79,71 @@ def test_talker_chatml_contains_model_roles_and_exact_text() -> None:
     assert "<|im_start|>system\n" in rendered
     assert "<|im_start|>user\nquestion<|im_end|>" in rendered
     assert "<|im_start|>assistant\nanswer<|im_end|>" in rendered
+
+
+def test_persistent_talker_worker_initializes_once_for_multiple_requests() -> None:
+    lifecycle = {"initializations": 0, "requests": 0}
+
+    class FakeTalker:
+        def __init__(self, model_id: str, revision: str, max_frames: int) -> None:
+            assert (model_id, revision, max_frames) == ("model", "revision", 4)
+            lifecycle["initializations"] += 1
+
+        def generate_codes(self, request: TalkerRequest) -> np.ndarray:
+            lifecycle["requests"] += 1
+            value = lifecycle["requests"]
+            assert request.assistant_text in {"first", "second"}
+            return np.full((1, 2), value, dtype="<i4")
+
+    output = io.BytesIO()
+    _serve_worker(
+        "model",
+        "revision",
+        4,
+        _worker_input(_payload("prompt", "first"), _payload("prompt", "second")),
+        output,
+        FakeTalker,
+    )
+
+    responses = _worker_responses(output.getvalue())
+    assert [response[0] for response in responses] == [_WORKER_READY, _WORKER_OK, _WORKER_OK]
+    assert np.frombuffer(responses[1][1], dtype="<i4").tolist() == [1, 1]
+    assert np.frombuffer(responses[2][1], dtype="<i4").tolist() == [2, 2]
+    assert lifecycle == {"initializations": 1, "requests": 2}
+
+
+def test_persistent_talker_worker_reports_request_error_and_continues() -> None:
+    lifecycle = {"initializations": 0, "requests": 0}
+
+    class RecoveringTalker:
+        def __init__(self, _model_id: str, _revision: str, _max_frames: int) -> None:
+            lifecycle["initializations"] += 1
+
+        def generate_codes(self, _request: TalkerRequest) -> np.ndarray:
+            lifecycle["requests"] += 1
+            if lifecycle["requests"] == 1:
+                raise RuntimeError("intentional request failure")
+            return np.array([[7, 8]], dtype="<i4")
+
+    output = io.BytesIO()
+    _serve_worker(
+        "model",
+        "",
+        4,
+        _worker_input(_payload("prompt", "first"), _payload("prompt", "second")),
+        output,
+        RecoveringTalker,
+    )
+
+    responses = _worker_responses(output.getvalue())
+    assert [response[0] for response in responses] == [
+        _WORKER_READY,
+        _WORKER_ERROR,
+        _WORKER_OK,
+    ]
+    assert b"intentional request failure" in responses[1][1]
+    assert np.frombuffer(responses[2][1], dtype="<i4").tolist() == [7, 8]
+    assert lifecycle == {"initializations": 1, "requests": 2}
 
 
 def test_talker_model_locator_pins_hugging_face_snapshot(tmp_path) -> None:


### PR DESCRIPTION
## Background

Qwen3-Omni `generate_audio()` launched a one-shot Python process for every request. Each process reloaded the official checkpoint, initialized CUDA, moved the Talker to the GPU, generated one response, and exited. The repeated lifecycle work dominated warm inference latency.

Fixes #500.

## Exit Criteria

- Warm audio requests reuse one initialized official Talker per pipeline.
- Requests have explicit framing, errors, stderr propagation, restart behavior, and bounded shutdown.
- Prompt, generation, RNG, and codec state do not leak between requests.
- Real Talker and Code2Wav output continues to pass the repository waveform quality gate.
- Timing separates Thinker, worker startup, Talker, IPC, Code2Wav, and output materialization.

## Implementation

- Add a framed Python worker that loads the official Talker once and serves multiple requests while rebuilding all request-local inputs and generation state.
- Replace the one-shot C++ process helper with a pipeline-owned runtime using `posix_spawn`, bidirectional framing, concurrent stderr draining, failure recovery, and deterministic teardown.
- Keep successful request handling serialized per pipeline and restart the worker after a process or protocol failure.
- Add opt-in stage timing through `TRTMC_QWEN3_OMNI_STAGE_TIMING=1`.
- Add Python protocol tests and a standalone C++ fake-worker lifecycle test covering reuse, request errors, crashes, restart, stderr, and shutdown.

## Validation

### Aligned performance and quality

Measured on one GB300 GPU from the same `main` revision and Release build configuration. Both variants used the same BF16 bundle, model revision, prompt, batch size 1, seed, 16 Thinker output tokens, and a maximum of 32 Talker frames. The measured boundary was host prompt through Thinker, Talker, Code2Wav, synchronization, and host PCM materialization. Pipeline loading and file I/O were excluded; CUDA graphs were disabled; results use 1 warmup and 5 measured requests.

| Warm end-to-end latency | `main` | This change | Improvement |
|---|---:|---:|---:|
| p50 | 39,043.622 ms | 8,299.158 ms | 4.70x |
| Mean | 41,984.018 ms | 8,295.896 ms | 5.06x |
| p95 | 51,884.392 ms | 8,304.261 ms | 6.25x |

All measured requests produced byte-identical audio across `main` and this change: 58,965 samples at 24 kHz with RMS 0.0641397. The fixed build also passed the repository's waveform comparison task eval.

The fixed warm samples averaged approximately 3,854.8 ms in Thinker, 4,438.5 ms in Talker, 0.234 ms in IPC, 1.927 ms in Code2Wav/transfer, and 0.031 ms in output materialization. Worker startup was zero for every measured request after warmup.

### Tests and source gates

- `PYTHONPATH=python pytest -q tests/e2e/models/qwen3_omni --ignore=tests/e2e/models/qwen3_omni/test_qwen3_omni_e2e.py`: 40 passed.
- `ctest --test-dir build --output-on-failure -R qwen3_omni`: 3 passed.
- `pytest -q "tests/test_e2e.py::test_e2e[qwen3-omni-30b-a3b-instruct]" --trtmc-binary build/trtmc --model-plugin-dir build/models --engine-dir "$ENGINE_DIR" --hf-python "$HF_PYTHON" --e2e-platform GB300`: 1 passed in 98.96s.
- `CI_BASE_REF=github/main python3 -m tools.ci pipeline source-quality`: passed, including complexity, formatting, lint, and 156 architecture-contract tests.
- `python3 tools/model_ci.py validate`: passed for all 77 model manifests.
- `python3 tools/legal_headers.py --check`: passed with zero findings.

## Notes For Future Readers

- Review the Python worker protocol first, then the C++ lifecycle implementation, and finally the pipeline ownership/timing changes.
- The Talker now intentionally retains GPU memory until its owning pipeline is destroyed. This trades repeated checkpoint loading for stable warm latency without increasing per-request peak model requirements.
- Timing is opt-in so normal CLI output remains unchanged.
