### PR TITLE
perf(qwen3-omni): batch thinker prefill

### DIFF
--- a/python/tensorrt_model_connect/families/qwen3_omni/checkpoint_mapper.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/checkpoint_mapper.py
@@ -18,9 +18,9 @@ import numpy as np
 
 # Register bfloat16 dtype with numpy (needed for safetensors without torch).
 try:
-    import ml_dtypes  # noqa: F401
+    import ml_dtypes
 except ImportError:
-    pass
+    ml_dtypes = None
 
 from safetensors import safe_open
 
@@ -29,7 +29,13 @@ from .config import ModelConfig
 
 def _target_np_dtype(precision: str) -> np.dtype:
     """Map precision string to numpy dtype for weight storage."""
-    if precision in ("fp16", "bf16"):
+    if precision == "bf16":
+        # Preserve checkpoint BF16 values until TensorRT casts the constant.
+        # Converting them to FP16 first introduces avoidable double rounding.
+        if ml_dtypes is not None:
+            return np.dtype(ml_dtypes.bfloat16)
+        return np.float32
+    if precision == "fp16":
         return np.float16
     return np.float32
 

--- a/python/tensorrt_model_connect/families/qwen3_omni/graph_blocks.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/graph_blocks.py
@@ -169,6 +169,7 @@ def add_attention_block(
     interleaved_rope: bool = False,
     ffi_attention_kernel: str | None = None,
     dynamic_kv_cache: bool = False,
+    sequence_length: int | None = 1,
 ) -> dict[str, trt.ITensor]:
     """Pre-norm -> QKV -> RoPE -> cache concat -> attention -> output proj.
 
@@ -222,11 +223,13 @@ def add_attention_block(
     q_norm = weights.get(f"{prefix}.q_norm")
     if q_norm is not None:
         q = graph_ops.add_rms_norm_per_head(
-            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype)
+            network, q, num_heads, head_dim, q_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
     k_norm = weights.get(f"{prefix}.k_norm")
     if k_norm is not None:
         k = graph_ops.add_rms_norm_per_head(
-            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype)
+            network, k, num_kv_heads, head_dim, k_norm, eps_tensor, dtype=dtype,
+            sequence_length=sequence_length)
 
     # ------------------------------------------------------------------ #
     # RoPE via native IRotaryEmbeddingLayer                              #
@@ -243,21 +246,22 @@ def add_attention_block(
         q = graph_ops.add_apply_rope_native(
             network, q, num_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
         k = graph_ops.add_apply_rope_native(
             network, k, num_kv_heads, head_dim,
             cos_half_tensor, sin_half_tensor, position_id,
-            rope_dim, interleaved_rope)
+            rope_dim, interleaved_rope, sequence_length=sequence_length)
 
     # Save present K/V (before concatenation, this is the raw projection output)
     present_k = k
     present_v = v
 
     # Reshape current K, V for concatenation
+    seq_dim = -1 if sequence_length is None else sequence_length
     k_reshape = network.add_shuffle(k)
-    k_reshape.reshape_dims = (1, kv_attention_size)
+    k_reshape.reshape_dims = (seq_dim, kv_attention_size)
     v_reshape = network.add_shuffle(v)
-    v_reshape.reshape_dims = (1, kv_attention_size)
+    v_reshape.reshape_dims = (seq_dim, kv_attention_size)
 
     # Concatenate with cache
     all_k = network.add_concatenation(
@@ -296,7 +300,7 @@ def add_attention_block(
             num_heads=num_heads,
             head_dim=head_dim,
             num_kv_heads=num_kv_heads,
-            q_seq=1,
+            q_seq=sequence_length,
             kv_seq=kv_seq,
             causal=False,
             mask=mask_4d,

--- a/python/tensorrt_model_connect/families/qwen3_omni/graph_ops.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/graph_ops.py
@@ -46,7 +46,15 @@ def add_constant(
     dtype: np.dtype = np.float32,
 ) -> trt.ITensor:
     """Add a constant tensor in the given *dtype* (default float32)."""
-    weights = trt.Weights(np.ascontiguousarray(values, dtype=dtype))
+    values_array = np.asarray(values)
+    if values_array.dtype.name == "bfloat16":
+        # TensorRT's Python Weights wrapper cannot consume NumPy BF16 arrays.
+        # Promote exactly-representable BF16 values to FP32, then let the
+        # strongly typed graph cast once to its BF16 runtime dtype.
+        constant_values = np.ascontiguousarray(values_array, dtype=np.float32)
+    else:
+        constant_values = np.ascontiguousarray(values_array, dtype=dtype)
+    weights = trt.Weights(constant_values)
     layer = network.add_constant(shape, weights)
     return layer.get_output(0)
 

--- a/python/tensorrt_model_connect/families/qwen3_omni/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/plugin.py
@@ -51,6 +51,7 @@ from .checkpoint_mapper import (
     _open_safetensors,
     _load_tensor,
     _has_tensor,
+    _target_np_dtype,
     _transpose_2d,
 )
 from ...build_timing import timed_trt_compile
@@ -91,7 +92,7 @@ class Qwen3OmniPlugin:
         return mt in ("qwen3_omni", "qwen3_omni_moe", "qwen3omni")
 
     def load_weights(
-        self, model_dir: str, config: ModelConfig,
+        self, model_dir: str, config: ModelConfig, *, precision: str = "fp32",
     ) -> WeightDict:
         """Load Qwen3-Omni weights from safetensors.
 
@@ -111,6 +112,7 @@ class Qwen3OmniPlugin:
         num_heads = config.num_attention_heads
         num_kv_heads = config.num_key_value_heads
         head_dim = config.head_dim
+        target_dtype = _target_np_dtype(precision)
 
         # MoE config lives in thinker_config.text_config for Qwen3-Omni
         thinker_text = (config.raw.get("thinker_config", {})
@@ -144,7 +146,7 @@ class Qwen3OmniPlugin:
         embedding = _load_tensor(readers, embed_key)
         assert embedding.shape == (vocab, hidden), (
             f"Embedding shape {embedding.shape} != ({vocab}, {hidden})")
-        weights["embedding"] = embedding.astype(np.float32)
+        weights["embedding"] = embedding.astype(target_dtype)
 
         attention_size = 0
 
@@ -187,10 +189,10 @@ class Qwen3OmniPlugin:
             if attention_size == 0:
                 attention_size = q_raw.shape[0]
 
-            q_t = _transpose_2d(q_raw, "q_proj")
-            k_t = _transpose_2d(k_raw, "k_proj")
-            v_t = _transpose_2d(v_raw, "v_proj")
-            o_t = _transpose_2d(o_raw, "o_proj")
+            q_t = _transpose_2d(q_raw, "q_proj", precision)
+            k_t = _transpose_2d(k_raw, "k_proj", precision)
+            v_t = _transpose_2d(v_raw, "v_proj", precision)
+            o_t = _transpose_2d(o_raw, "o_proj", precision)
             del q_raw, k_raw, v_raw, o_raw
 
             weights[f"{prefix}.w_q"] = q_t
@@ -220,9 +222,15 @@ class Qwen3OmniPlugin:
                 # MoE layer
                 router_raw = _load_tensor(readers, router_key)
                 weights[f"{prefix}.router"] = _transpose_2d(
-                    router_raw, "router")
+                    router_raw, "router", precision)
                 del router_raw
 
+                expert_gate = np.empty(
+                    (num_experts, hidden, intermediate_size), dtype=target_dtype)
+                expert_up = np.empty(
+                    (num_experts, hidden, intermediate_size), dtype=target_dtype)
+                expert_down = np.empty(
+                    (num_experts, intermediate_size, hidden), dtype=target_dtype)
                 for e in range(num_experts):
                     if moe_expert_fmt == "mlp":
                         # Qwen3-Omni: mlp.experts.{e}.gate_proj/up_proj/down_proj
@@ -244,13 +252,16 @@ class Qwen3OmniPlugin:
                         down_raw = _load_tensor(
                             readers, f"{exp_prefix}.w2.weight")
 
-                    weights[f"{prefix}.expert.{e}.w_gate"] = _transpose_2d(
-                        gate_raw, f"expert_{e}_gate")
-                    weights[f"{prefix}.expert.{e}.w_up"] = _transpose_2d(
-                        up_raw, f"expert_{e}_up")
-                    weights[f"{prefix}.expert.{e}.w_down"] = _transpose_2d(
-                        down_raw, f"expert_{e}_down")
+                    expert_gate[e] = _transpose_2d(
+                        gate_raw, f"expert_{e}_gate", precision)
+                    expert_up[e] = _transpose_2d(
+                        up_raw, f"expert_{e}_up", precision)
+                    expert_down[e] = _transpose_2d(
+                        down_raw, f"expert_{e}_down", precision)
                     del gate_raw, up_raw, down_raw
+                weights[f"{prefix}.experts.w_gate"] = expert_gate
+                weights[f"{prefix}.experts.w_up"] = expert_up
+                weights[f"{prefix}.experts.w_down"] = expert_down
             else:
                 # Dense SwiGLU MLP (some layers may not be MoE)
                 gate_raw = _load_tensor(
@@ -260,9 +271,9 @@ class Qwen3OmniPlugin:
                 down_raw = _load_tensor(
                     readers, f"{hf_prefix}.mlp.down_proj.weight")
 
-                weights[f"{prefix}.w_gate"] = _transpose_2d(gate_raw, "gate")
-                weights[f"{prefix}.w_up"] = _transpose_2d(up_raw, "up")
-                weights[f"{prefix}.w_down"] = _transpose_2d(down_raw, "down")
+                weights[f"{prefix}.w_gate"] = _transpose_2d(gate_raw, "gate", precision)
+                weights[f"{prefix}.w_up"] = _transpose_2d(up_raw, "up", precision)
+                weights[f"{prefix}.w_down"] = _transpose_2d(down_raw, "down", precision)
 
         # Final norm
         final_norm_key = None
@@ -288,10 +299,10 @@ class Qwen3OmniPlugin:
                 break
         if lm_head_key is not None:
             weights["w_out"] = _transpose_2d(
-                _load_tensor(readers, lm_head_key), "lm_head")
+                _load_tensor(readers, lm_head_key), "lm_head", precision)
         else:
             weights["w_out"] = _transpose_2d(
-                embedding.copy(), "embedding_tied")
+                weights["embedding"], "embedding_tied", precision)
 
         weights["_attention_size"] = attention_size
         weights["_num_experts"] = num_experts
@@ -560,6 +571,16 @@ class Qwen3OmniPlugin:
         trt_config = builder.create_builder_config()
         trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
+        if precision == "fp16":
+            work_np_dtype = np.float16
+            work_trt_dtype = trt.float16
+        elif precision == "bf16":
+            work_np_dtype = np.float16
+            work_trt_dtype = trt.bfloat16
+        else:
+            work_np_dtype = np.float32
+            work_trt_dtype = trt.float32
+
         # Inputs
         token_id = network.add_input("token_id", trt.int32, (-1,))
         position_id = network.add_input("position_id", trt.int32, (-1,))
@@ -578,10 +599,10 @@ class Qwen3OmniPlugin:
         for i in range(num_layers):
             ck = network.add_input(
                 graph_ops.layer_tensor_name("cache_k", i),
-                trt.float32, (max_cache_length, kv_attention_size))
+                work_trt_dtype, (max_cache_length, kv_attention_size))
             cv = network.add_input(
                 graph_ops.layer_tensor_name("cache_v", i),
-                trt.float32, (max_cache_length, kv_attention_size))
+                work_trt_dtype, (max_cache_length, kv_attention_size))
             cache_k_inputs.append(ck)
             cache_v_inputs.append(cv)
 
@@ -606,7 +627,7 @@ class Qwen3OmniPlugin:
 
         # Shared constants
         embedding_table = graph_ops.add_constant(
-            network, (vocab, hidden), weights["embedding"])
+            network, (vocab, hidden), weights["embedding"], dtype=work_np_dtype)
 
         graph_ops.validate_native_rope_dim(head_dim, field_name="head_dim")
         cos_half_np = graph_ops.make_rope_table_half_dim(
@@ -614,23 +635,41 @@ class Qwen3OmniPlugin:
         sin_half_np = graph_ops.make_rope_table_half_dim(
             attention_window, head_dim, config.rope_theta, False)
         cos_half_tensor = graph_ops.add_constant(
-            network, cos_half_np.shape, cos_half_np)
+            network, cos_half_np.shape, cos_half_np, dtype=work_np_dtype)
         sin_half_tensor = graph_ops.add_constant(
-            network, sin_half_np.shape, sin_half_np)
+            network, sin_half_np.shape, sin_half_np, dtype=work_np_dtype)
 
         eps_tensor = graph_ops.add_constant(
             network, (1, 1),
-            np.array([config.rms_norm_eps], dtype=np.float32))
+            np.array([config.rms_norm_eps], dtype=work_np_dtype),
+            dtype=work_np_dtype)
+
+        if work_trt_dtype != trt.float32:
+            attention_mask = network.add_cast(attention_mask, work_trt_dtype).get_output(0)
+            cos_half_tensor = network.add_cast(cos_half_tensor, work_trt_dtype).get_output(0)
+            sin_half_tensor = network.add_cast(sin_half_tensor, work_trt_dtype).get_output(0)
+            eps_tensor = network.add_cast(eps_tensor, work_trt_dtype).get_output(0)
 
         # Embedding lookup with input_embed override for VL/audio
         gather = network.add_gather(embedding_table, token_id, 0)
         token_embed = gather.get_output(0)
+        if token_embed.dtype != work_trt_dtype:
+            token_embed = network.add_cast(token_embed, work_trt_dtype).get_output(0)
+        if input_embed_tensor.dtype != work_trt_dtype:
+            input_embed_tensor = network.add_cast(
+                input_embed_tensor, work_trt_dtype).get_output(0)
+        if use_input_embed_tensor.dtype != work_trt_dtype:
+            use_input_embed_tensor = network.add_cast(
+                use_input_embed_tensor, work_trt_dtype).get_output(0)
 
         # Conditional: (1 - flag) * token_embed + flag * input_embed
         flag_broadcast = network.add_shuffle(use_input_embed_tensor)
         flag_broadcast.reshape_dims = (-1, 1)
         one_const = graph_ops.add_constant(
-            network, (1, 1), np.array([1.0], dtype=np.float32))
+            network, (1, 1), np.array([1.0], dtype=work_np_dtype),
+            dtype=work_np_dtype)
+        if one_const.dtype != work_trt_dtype:
+            one_const = network.add_cast(one_const, work_trt_dtype).get_output(0)
         inv_flag = network.add_elementwise(
             one_const, flag_broadcast.get_output(0),
             trt.ElementWiseOperation.SUB)
@@ -670,6 +709,7 @@ class Qwen3OmniPlugin:
                 cos_half_tensor=cos_half_tensor,
                 sin_half_tensor=sin_half_tensor,
                 rotary_embedding_dim=head_dim,
+                dtype=work_np_dtype,
                 dynamic_kv_cache=True,
                 sequence_length=None,
             )
@@ -688,20 +728,22 @@ class Qwen3OmniPlugin:
                 network, post_attn, hidden,
                 weights[f"{prefix}.post_attn_norm"],
                 weights.get(f"{prefix}.post_attn_norm_beta"),
-                eps_tensor, "rmsnorm")
+                eps_tensor, "rmsnorm", dtype=work_np_dtype)
 
             # Check if this is an MoE or dense layer
             if f"{prefix}.router" in weights:
                 # MoE block
                 moe_out = _add_omni_moe_block(
                     network, norm2, weights, prefix,
-                    hidden, num_experts, moe_intermediate, top_k)
+                    hidden, num_experts, top_k,
+                    dtype=work_np_dtype)
             else:
                 # Dense SwiGLU MLP
                 moe_out = graph_blocks.add_swiglu_mlp(
                     network, norm2, weights=weights, prefix=prefix,
                     hidden_size=hidden,
-                    mlp_size=weights[f"{prefix}.w_gate"].shape[1])
+                    mlp_size=weights[f"{prefix}.w_gate"].shape[1],
+                    dtype=work_np_dtype)
 
             # Residual
             residual2 = network.add_elementwise(
@@ -721,7 +763,7 @@ class Qwen3OmniPlugin:
         if final_norm is not None and len(final_norm) > 0:
             hidden_state = graph_blocks.apply_norm(
                 network, hidden_state, hidden, final_norm, None,
-                eps_tensor, "rmsnorm")
+                eps_tensor, "rmsnorm", dtype=work_np_dtype)
 
         # Keep the output contract fixed at one row for both profiles. Only
         # the final prompt row can affect the first generated token.
@@ -744,9 +786,14 @@ class Qwen3OmniPlugin:
 
         # LM head
         logits = graph_ops.add_matmul_rhs_constant(
-            network, last_hidden, hidden, vocab, weights["w_out"])
-        b_out = np.zeros(vocab, dtype=np.float32)
-        logits = graph_ops.add_bias_sum(network, logits, vocab, b_out)
+            network, last_hidden, hidden, vocab, weights["w_out"],
+            dtype=work_np_dtype)
+        b_out = np.zeros(vocab, dtype=work_np_dtype)
+        logits = graph_ops.add_bias_sum(
+            network, logits, vocab, b_out, dtype=work_np_dtype)
+
+        if logits.dtype != trt.float32:
+            logits = network.add_cast(logits, trt.float32).get_output(0)
 
         logits.name = "logits"
         network.mark_output(logits)
@@ -923,7 +970,6 @@ class Qwen3OmniPlugin:
             "num_experts", 8)
         overrides["num_experts_per_tok"] = self._thinker_cfg.get(
             "num_experts_per_tok", 2)
-
         # Audio output config (flat keys matching C++ fast_path_config parser)
         overrides["audio_sample_rate"] = 24000
         overrides["omni_n_codebooks"] = self._talker_cfg.get(
@@ -963,30 +1009,46 @@ class Qwen3OmniPlugin:
 # MoE block for Omni (standard top-k softmax, same as Mixtral pattern)
 # ---------------------------------------------------------------------------
 
-def _add_swiglu_expert(
+def _add_packed_swiglu_experts(
     network: trt.INetworkDefinition,
     inp: trt.ITensor,
     hidden_size: int,
-    intermediate_size: int,
     w_gate: np.ndarray,
     w_up: np.ndarray,
     w_down: np.ndarray,
+    dtype: np.dtype = np.float32,
 ) -> trt.ITensor:
-    """Compute a single SwiGLU expert: down(silu(gate(x)) * up(x))."""
-    gate = graph_ops.add_matmul_rhs_constant(
-        network, inp, hidden_size, intermediate_size, w_gate)
-    up = graph_ops.add_matmul_rhs_constant(
-        network, inp, hidden_size, intermediate_size, w_up)
+    """Compute every expert with three batched matmuls for a dynamic token count."""
+    num_experts, _, intermediate_size = w_gate.shape
+    inp_4d = network.add_shuffle(inp)
+    inp_4d.reshape_dims = (-1, 1, 1, hidden_size)
 
-    sigmoid = network.add_activation(gate, trt.ActivationType.SIGMOID)
+    def packed_weight(values: np.ndarray) -> trt.ITensor:
+        tensor = graph_ops.add_constant(
+            network, (1, *values.shape), values.reshape(1, *values.shape), dtype=dtype)
+        if tensor.dtype != inp.dtype:
+            tensor = network.add_cast(tensor, inp.dtype).get_output(0)
+        return tensor
+
+    gate = network.add_matrix_multiply(
+        inp_4d.get_output(0), trt.MatrixOperation.NONE,
+        packed_weight(w_gate), trt.MatrixOperation.NONE)
+    up = network.add_matrix_multiply(
+        inp_4d.get_output(0), trt.MatrixOperation.NONE,
+        packed_weight(w_up), trt.MatrixOperation.NONE)
+
+    sigmoid = network.add_activation(gate.get_output(0), trt.ActivationType.SIGMOID)
     swish = network.add_elementwise(
-        gate, sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
+        gate.get_output(0), sigmoid.get_output(0), trt.ElementWiseOperation.PROD)
     gated = network.add_elementwise(
-        swish.get_output(0), up, trt.ElementWiseOperation.PROD)
+        swish.get_output(0), up.get_output(0), trt.ElementWiseOperation.PROD)
 
-    down = graph_ops.add_matmul_rhs_constant(
-        network, gated.get_output(0), intermediate_size, hidden_size, w_down)
-    return down
+    down = network.add_matrix_multiply(
+        gated.get_output(0), trt.MatrixOperation.NONE,
+        packed_weight(w_down), trt.MatrixOperation.NONE)
+    output = network.add_shuffle(down.get_output(0))
+    output.reshape_dims = (-1, num_experts, hidden_size)
+    return output.get_output(0)
 
 
 def _add_omni_moe_block(
@@ -996,14 +1058,14 @@ def _add_omni_moe_block(
     prefix: str,
     hidden_size: int,
     num_experts: int,
-    moe_intermediate: int,
     top_k: int = 2,
+    dtype: np.dtype = np.float32,
 ) -> trt.ITensor:
     """Add MoE block with standard top-k softmax routing (same as Mixtral)."""
     # Router logits
     router_logits = graph_ops.add_matmul_rhs_constant(
         network, inp, hidden_size, num_experts,
-        weights[f"{prefix}.router"])
+        weights[f"{prefix}.router"], dtype=dtype)
 
     # Softmax over router logits
     sm = network.add_softmax(router_logits)
@@ -1022,22 +1084,14 @@ def _add_omni_moe_block(
         top_values, sum_val.get_output(0),
         trt.ElementWiseOperation.DIV)
 
-    # Compute all expert outputs and stack as [Sq, E, H].
-    expert_outputs = []
-    for e in range(num_experts):
-        exp_out = _add_swiglu_expert(
-            network, inp, hidden_size, moe_intermediate,
-            weights[f"{prefix}.expert.{e}.w_gate"],
-            weights[f"{prefix}.expert.{e}.w_up"],
-            weights[f"{prefix}.expert.{e}.w_down"],
-        )
-        expert_row = network.add_shuffle(exp_out)
-        expert_row.reshape_dims = (-1, 1, hidden_size)
-        expert_outputs.append(expert_row.get_output(0))
-
-    stacked = network.add_concatenation(expert_outputs)
-    stacked.axis = 1
-    stacked_out = stacked.get_output(0)
+    # Compute all expert outputs as [Sq, E, H] with three packed matmuls.
+    stacked_out = _add_packed_swiglu_experts(
+        network, inp, hidden_size,
+        weights[f"{prefix}.experts.w_gate"],
+        weights[f"{prefix}.experts.w_up"],
+        weights[f"{prefix}.experts.w_down"],
+        dtype=dtype,
+    )
 
     # Build token-row indices [Sq, K] and pair them with the router's expert
     # indices. GatherND then selects K experts independently for every token.

--- a/python/tensorrt_model_connect/families/qwen3_omni/plugin.py
+++ b/python/tensorrt_model_connect/families/qwen3_omni/plugin.py
@@ -554,7 +554,6 @@ class Qwen3OmniPlugin:
         kv_attention_size = graph_blocks.infer_kv_attention_size(
             weights, num_kv_heads=num_kv_heads, head_dim=head_dim)
         attention_window = max_cache_length + 1
-
         logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
         builder = trt.Builder(logger)
         network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
@@ -562,16 +561,16 @@ class Qwen3OmniPlugin:
         trt_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)
 
         # Inputs
-        token_id = network.add_input("token_id", trt.int32, (1,))
-        position_id = network.add_input("position_id", trt.int32, (1,))
+        token_id = network.add_input("token_id", trt.int32, (-1,))
+        position_id = network.add_input("position_id", trt.int32, (-1,))
         attention_mask = network.add_input(
-            "attention_mask", trt.float32, (1, attention_window))
+            "attention_mask", trt.float32, (-1, -1))
 
         # VL embed_input (for vision/audio feature injection)
         input_embed_tensor = network.add_input(
-            "input_embed", trt.float32, (1, hidden))
+            "input_embed", trt.float32, (-1, hidden))
         use_input_embed_tensor = network.add_input(
-            "use_input_embed", trt.float32, (1,))
+            "use_input_embed", trt.float32, (-1, 1))
 
         # KV cache inputs
         cache_k_inputs = []
@@ -585,6 +584,25 @@ class Qwen3OmniPlugin:
                 trt.float32, (max_cache_length, kv_attention_size))
             cache_k_inputs.append(ck)
             cache_v_inputs.append(cv)
+
+        def _add_profile(opt_sq: int, max_sq: int, *, fixed: bool = False) -> None:
+            profile = builder.create_optimization_profile()
+            min_sq = opt_sq if fixed else 1
+            profile.set_shape("token_id", (min_sq,), (opt_sq,), (max_sq,))
+            profile.set_shape("position_id", (min_sq,), (opt_sq,), (max_sq,))
+            profile.set_shape(
+                "attention_mask",
+                (min_sq, max_cache_length + min_sq),
+                (opt_sq, max_cache_length + opt_sq),
+                (max_sq, max_cache_length + max_sq))
+            profile.set_shape(
+                "input_embed", (min_sq, hidden), (opt_sq, hidden), (max_sq, hidden))
+            profile.set_shape(
+                "use_input_embed", (min_sq, 1), (opt_sq, 1), (max_sq, 1))
+            trt_config.add_optimization_profile(profile)
+
+        _add_profile(min(64, max_cache_length), max_cache_length)
+        _add_profile(1, 1, fixed=True)
 
         # Shared constants
         embedding_table = graph_ops.add_constant(
@@ -610,7 +628,7 @@ class Qwen3OmniPlugin:
 
         # Conditional: (1 - flag) * token_embed + flag * input_embed
         flag_broadcast = network.add_shuffle(use_input_embed_tensor)
-        flag_broadcast.reshape_dims = (1, 1)
+        flag_broadcast.reshape_dims = (-1, 1)
         one_const = graph_ops.add_constant(
             network, (1, 1), np.array([1.0], dtype=np.float32))
         inv_flag = network.add_elementwise(
@@ -652,6 +670,8 @@ class Qwen3OmniPlugin:
                 cos_half_tensor=cos_half_tensor,
                 sin_half_tensor=sin_half_tensor,
                 rotary_embedding_dim=head_dim,
+                dynamic_kv_cache=True,
+                sequence_length=None,
             )
 
             attn_out = attn["attn_out"]
@@ -703,13 +723,28 @@ class Qwen3OmniPlugin:
                 network, hidden_state, hidden, final_norm, None,
                 eps_tensor, "rmsnorm")
 
-        hidden_out = network.add_identity(hidden_state).get_output(0)
+        # Keep the output contract fixed at one row for both profiles. Only
+        # the final prompt row can affect the first generated token.
+        hidden_shape = network.add_shape(hidden_state).get_output(0)
+        one_hidden = graph_ops.add_constant(
+            network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
+        last_start = network.add_elementwise(
+            hidden_shape, one_hidden, trt.ElementWiseOperation.SUB).get_output(0)
+        last_size = graph_ops.add_constant(
+            network, (2,), np.array([1, hidden], dtype=np.int64), dtype=np.int64)
+        last_slice = network.add_slice(
+            hidden_state, start=(0, 0), shape=(0, 0), stride=(1, 1))
+        last_slice.set_input(1, last_start)
+        last_slice.set_input(2, last_size)
+        last_hidden = last_slice.get_output(0)
+
+        hidden_out = network.add_identity(last_hidden).get_output(0)
         hidden_out.name = "hidden_state"
         network.mark_output(hidden_out)
 
         # LM head
         logits = graph_ops.add_matmul_rhs_constant(
-            network, hidden_state, hidden, vocab, weights["w_out"])
+            network, last_hidden, hidden, vocab, weights["w_out"])
         b_out = np.zeros(vocab, dtype=np.float32)
         logits = graph_ops.add_bias_sum(network, logits, vocab, b_out)
 
@@ -726,7 +761,7 @@ class Qwen3OmniPlugin:
             network.mark_output(pv)
 
         if verbose:
-            print(f"[trtmc build] Building Qwen3-Omni Thinker MoE engine "
+            print(f"[trtmc build] Building dual-profile Qwen3-Omni Thinker MoE engine "
                   f"({num_layers} layers, hidden={hidden}, "
                   f"attn={attention_size}, experts={num_experts}, "
                   f"top_k={top_k}, inter={moe_intermediate}, "
@@ -987,7 +1022,7 @@ def _add_omni_moe_block(
         top_values, sum_val.get_output(0),
         trt.ElementWiseOperation.DIV)
 
-    # Compute all expert outputs and stack
+    # Compute all expert outputs and stack as [Sq, E, H].
     expert_outputs = []
     for e in range(num_experts):
         exp_out = _add_swiglu_expert(
@@ -996,40 +1031,47 @@ def _add_omni_moe_block(
             weights[f"{prefix}.expert.{e}.w_up"],
             weights[f"{prefix}.expert.{e}.w_down"],
         )
-        expert_outputs.append(exp_out)
+        expert_row = network.add_shuffle(exp_out)
+        expert_row.reshape_dims = (-1, 1, hidden_size)
+        expert_outputs.append(expert_row.get_output(0))
 
     stacked = network.add_concatenation(expert_outputs)
-    stacked.axis = 0
+    stacked.axis = 1
     stacked_out = stacked.get_output(0)
 
-    # Gather and scale each selected expert, then sum
-    result = None
-    for k in range(top_k):
-        idx_slice = network.add_slice(
-            top_indices, start=(0, k), shape=(1, 1), stride=(1, 1))
-        idx_flat = network.add_shuffle(idx_slice.get_output(0))
-        idx_flat.reshape_dims = (1,)
+    # Build token-row indices [Sq, K] and pair them with the router's expert
+    # indices. GatherND then selects K experts independently for every token.
+    routing_shape = network.add_shape(top_indices).get_output(0)
+    fill_start = network.add_constant(
+        (), trt.Weights(np.array(0, dtype=np.int32))).get_output(0)
+    fill_delta = network.add_constant(
+        (2,), trt.Weights(np.array([1, 0], dtype=np.int32))).get_output(0)
+    row_indices = network.add_fill(
+        (1, top_k), trt.FillOperation.LINSPACE, trt.int32)
+    row_indices.set_input(0, routing_shape)
+    row_indices.set_input(1, fill_start)
+    row_indices.set_input(2, fill_delta)
 
-        w_slice = network.add_slice(
-            norm_weights.get_output(0),
-            start=(0, k), shape=(1, 1), stride=(1, 1))
+    row_3d = network.add_shuffle(row_indices.get_output(0))
+    row_3d.reshape_dims = (-1, top_k, 1)
+    expert_3d = network.add_shuffle(top_indices)
+    expert_3d.reshape_dims = (-1, top_k, 1)
+    gather_indices = network.add_concatenation(
+        [row_3d.get_output(0), expert_3d.get_output(0)])
+    gather_indices.axis = 2
 
-        expert_out = network.add_gather(
-            stacked_out, idx_flat.get_output(0), 0)
+    selected = network.add_gather(
+        stacked_out, gather_indices.get_output(0), 0)
+    selected.mode = trt.GatherMode.ND
 
-        scaled_expert = network.add_elementwise(
-            expert_out.get_output(0), w_slice.get_output(0),
-            trt.ElementWiseOperation.PROD)
-
-        if result is None:
-            result = scaled_expert.get_output(0)
-        else:
-            sum_layer = network.add_elementwise(
-                result, scaled_expert.get_output(0),
-                trt.ElementWiseOperation.SUM)
-            result = sum_layer.get_output(0)
-
-    return result
+    weights_3d = network.add_shuffle(norm_weights.get_output(0))
+    weights_3d.reshape_dims = (-1, top_k, 1)
+    weighted = network.add_elementwise(
+        selected.get_output(0), weights_3d.get_output(0),
+        trt.ElementWiseOperation.PROD)
+    summed = network.add_reduce(
+        weighted.get_output(0), trt.ReduceOperation.SUM, 1 << 1, keep_dims=False)
+    return summed.get_output(0)
 
 
 # ---------------------------------------------------------------------------

--- a/src/runtime/models/qwen3_omni/argmax_kernel.cu
+++ b/src/runtime/models/qwen3_omni/argmax_kernel.cu
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/qwen3_omni/argmax_kernel.h"
+
+#include <cfloat>
+#include <climits>
+#include <cuda_runtime.h>
+
+namespace trtmc {
+
+namespace {
+
+constexpr int32_t kBlockSize = 256;
+
+__global__ void argmax_kernel(const float* logits, int32_t vocab_size, int32_t* token_id) {
+    __shared__ float values[kBlockSize];
+    __shared__ int32_t indices[kBlockSize];
+
+    const int32_t thread = threadIdx.x;
+    float best_value = -FLT_MAX;
+    int32_t best_index = INT_MAX;
+    for (int32_t index = thread; index < vocab_size; index += kBlockSize) {
+        const float value = logits[index];
+        if (value > best_value || (value == best_value && index < best_index)) {
+            best_value = value;
+            best_index = index;
+        }
+    }
+    values[thread] = best_value;
+    indices[thread] = best_index;
+    __syncthreads();
+
+    for (int32_t stride = kBlockSize / 2; stride > 0; stride >>= 1) {
+        if (thread < stride) {
+            const float candidate_value = values[thread + stride];
+            const int32_t candidate_index = indices[thread + stride];
+            if (candidate_value > values[thread] ||
+                (candidate_value == values[thread] && candidate_index < indices[thread])) {
+                values[thread] = candidate_value;
+                indices[thread] = candidate_index;
+            }
+        }
+        __syncthreads();
+    }
+    if (thread == 0)
+        *token_id = indices[0];
+}
+
+} // namespace
+
+void qwen3_omni_gpu_argmax(const float* logits, int32_t vocab_size, int32_t* token_id,
+                           cudaStream_t stream) {
+    if (logits == nullptr || token_id == nullptr || vocab_size <= 0)
+        return;
+    argmax_kernel<<<1, kBlockSize, 0, stream>>>(logits, vocab_size, token_id);
+}
+
+} // namespace trtmc

--- a/src/runtime/models/qwen3_omni/argmax_kernel.h
+++ b/src/runtime/models/qwen3_omni/argmax_kernel.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cuda_runtime_api.h>
+
+namespace trtmc {
+
+void qwen3_omni_gpu_argmax(const float* logits, int32_t vocab_size, int32_t* token_id,
+                           cudaStream_t stream);
+
+} // namespace trtmc

--- a/src/runtime/models/qwen3_omni/omni_config.h
+++ b/src/runtime/models/qwen3_omni/omni_config.h
@@ -15,6 +15,7 @@ struct OmniConfig {
     int32_t sample_rate{24000};
 
     int32_t thinker_hidden_size{0};
+    int32_t thinker_vocab_size{0};
     int32_t thinker_num_layers{0};
     int32_t thinker_num_heads{0};
     int32_t thinker_eos_token_id{151645};

--- a/src/runtime/models/qwen3_omni/pipeline.cpp
+++ b/src/runtime/models/qwen3_omni/pipeline.cpp
@@ -5,6 +5,7 @@
 
 #include "runtime/models/qwen3_omni/pipeline.h"
 
+#include "runtime/models/qwen3_omni/argmax_kernel.h"
 #include "runtime/models/qwen3_omni/omni_audio_plan.h"
 #include "runtime/models/qwen3_omni/talker_runtime.h"
 #include "trtmc/tokenizer.h"
@@ -73,10 +74,12 @@ OmniPipeline::OmniPipeline(std::unique_ptr<TrtModule> thinker,
                            std::unique_ptr<Qwen3OmniInferenceState> thinker_state,
                            std::unique_ptr<TrtModule> code2wav, OmniConfig config,
                            cudaStream_t stream, std::shared_ptr<ITokenizer> tokenizer,
-                           std::string model_id_str)
-    : thinker_(std::move(thinker)), thinker_state_(std::move(thinker_state)),
-      code2wav_(std::move(code2wav)), config_(std::make_unique<OmniConfig>(std::move(config))),
-      stream_(stream), tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)) {
+                           std::string model_id_str, std::unique_ptr<TrtModule> thinker_prefill)
+    : thinker_(std::move(thinker)), thinker_prefill_(std::move(thinker_prefill)),
+      thinker_state_(std::move(thinker_state)), code2wav_(std::move(code2wav)),
+      config_(std::make_unique<OmniConfig>(std::move(config))), stream_(stream),
+      tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id_str)),
+      thinker_token_id_({1}, DType::kInt32, stream) {
     if (!thinker_ || !thinker_->ok())
         throw std::runtime_error("OmniPipeline: invalid thinker module");
     if (!thinker_state_ || !thinker_state_->ok())
@@ -88,7 +91,54 @@ OmniPipeline::OmniPipeline(std::unique_ptr<TrtModule> thinker,
 
 OmniPipeline::~OmniPipeline() = default;
 
-void OmniPipeline::run_thinker_step(int32_t token_id, std::vector<float>& logits) {
+namespace {
+
+int32_t host_argmax(const TensorMap& outputs, int32_t& d2h_count) {
+    auto it = outputs.find("logits");
+    if (it == outputs.end())
+        throw std::runtime_error("OmniPipeline thinker: no 'logits' output");
+    const auto& logits = it->second;
+    const auto count = static_cast<std::size_t>(logits.numel());
+    if (count == 0)
+        return 0;
+    ++d2h_count;
+    const auto* begin = static_cast<const float*>(logits.data);
+    return static_cast<int32_t>(std::distance(begin, std::max_element(begin, begin + count)));
+}
+
+bool gather_prefill_kv(TrtModule& prefill, int32_t num_layers, std::vector<const void*>& present_k,
+                       std::vector<const void*>& present_v) {
+    present_k.resize(static_cast<std::size_t>(num_layers));
+    present_v.resize(static_cast<std::size_t>(num_layers));
+    for (int32_t layer = 0; layer < num_layers; ++layer) {
+        const auto index = static_cast<std::size_t>(layer);
+        present_k[index] = prefill.device_ptr("present_k_" + std::to_string(layer));
+        present_v[index] = prefill.device_ptr("present_v_" + std::to_string(layer));
+        if (present_k[index] == nullptr || present_v[index] == nullptr)
+            return false;
+    }
+    return true;
+}
+
+Qwen3OmniKvCache* eligible_prefill_cache(TrtModule* prefill, Qwen3OmniInferenceState* state,
+                                         const OmniConfig& config, int32_t sequence_length) {
+    auto* cache = dynamic_cast<Qwen3OmniKvCache*>(state);
+    if (prefill == nullptr || cache == nullptr || sequence_length <= 0 ||
+        sequence_length > cache->max_length() || config.thinker_hidden_size <= 0 ||
+        config.thinker_vocab_size <= 0 || !prefill->has_input("input_embed"))
+        return nullptr;
+    return cache;
+}
+
+bool can_use_device_argmax(const TrtModule& module, const DeviceTensor& token_id,
+                           int32_t vocab_size) {
+    return module.device_ptr("logits") != nullptr &&
+           module.tensor_dtype("logits") == DType::kFloat32 && vocab_size > 0 && token_id.ok();
+}
+
+} // namespace
+
+int32_t OmniPipeline::run_thinker_step(int32_t token_id) {
     Tensor token_tensor;
     token_tensor.data = &token_id;
     token_tensor.shape = {1};
@@ -98,56 +148,111 @@ void OmniPipeline::run_thinker_step(int32_t token_id, std::vector<float>& logits
     inputs["token_id"] = token_tensor;
     thinker_state_->prepare_step(inputs);
 
-    TensorMap outputs = thinker_->forward(inputs);
+    ++thinker_stats_.decode_launches;
+    const bool gpu_argmax =
+        can_use_device_argmax(*thinker_, thinker_token_id_, config_->thinker_vocab_size);
+    if (!gpu_argmax) {
+        TensorMap outputs = thinker_->forward(inputs);
+        thinker_state_->advance();
+        return host_argmax(outputs, thinker_stats_.full_logits_d2h);
+    }
 
-    auto it = outputs.find("logits");
-    if (it == outputs.end())
-        throw std::runtime_error("OmniPipeline thinker: no 'logits' output");
-
-    const auto& lt = it->second;
-    auto n = lt.numel();
-    logits.resize(static_cast<std::size_t>(n));
-    std::memcpy(logits.data(), lt.data, n * sizeof(float));
-
+    thinker_->forward_async(inputs);
+    const auto* logits = static_cast<const float*>(thinker_->device_ptr("logits"));
+    qwen3_omni_gpu_argmax(logits, config_->thinker_vocab_size,
+                          static_cast<int32_t*>(thinker_token_id_.data()), stream_);
     thinker_state_->advance();
+    cudaMemcpyAsync(&thinker_token_host_, thinker_token_id_.data(), sizeof(thinker_token_host_),
+                    cudaMemcpyDeviceToHost, stream_);
+    thinker_->sync();
+    return thinker_token_host_;
 }
 
-static int32_t omni_argmax(const std::vector<float>& logits) {
-    if (logits.empty())
-        return 0;
-    return static_cast<int32_t>(
-        std::distance(logits.begin(), std::max_element(logits.begin(), logits.end())));
+bool OmniPipeline::run_thinker_prefill(const std::vector<int32_t>& input_ids, int32_t& next_token) {
+    const auto sequence_length = static_cast<int32_t>(input_ids.size());
+    auto* cache = eligible_prefill_cache(thinker_prefill_.get(), thinker_state_.get(), *config_,
+                                         sequence_length);
+    if (cache == nullptr)
+        return false;
+
+    std::vector<const void*> present_k;
+    std::vector<const void*> present_v;
+    if (!gather_prefill_kv(*thinker_prefill_, cache->num_layers(), present_k, present_v))
+        return false;
+
+    std::vector<float> input_embed(
+        static_cast<std::size_t>(sequence_length) * config_->thinker_hidden_size, 0.0F);
+    std::vector<float> use_input_embed(static_cast<std::size_t>(sequence_length), 0.0F);
+    TensorMap inputs;
+    inputs["token_id"] =
+        Tensor{const_cast<int32_t*>(input_ids.data()), {sequence_length}, DType::kInt32};
+    inputs["input_embed"] = Tensor{
+        input_embed.data(), {sequence_length, config_->thinker_hidden_size}, DType::kFloat32};
+    inputs["use_input_embed"] =
+        Tensor{use_input_embed.data(), {sequence_length, 1}, DType::kFloat32};
+    cache->bind_cache_inputs(*thinker_prefill_);
+    thinker_state_->prepare_step(inputs, sequence_length);
+
+    const bool gpu_argmax =
+        can_use_device_argmax(*thinker_prefill_, thinker_token_id_, config_->thinker_vocab_size);
+    ++thinker_stats_.prefill_launches;
+    if (gpu_argmax) {
+        thinker_prefill_->forward_async(inputs);
+        const auto* logits = static_cast<const float*>(thinker_prefill_->device_ptr("logits"));
+        qwen3_omni_gpu_argmax(logits, config_->thinker_vocab_size,
+                              static_cast<int32_t*>(thinker_token_id_.data()), stream_);
+        cache->write_prefill_kv(present_k, present_v, sequence_length);
+        cudaMemcpyAsync(&thinker_token_host_, thinker_token_id_.data(), sizeof(thinker_token_host_),
+                        cudaMemcpyDeviceToHost, stream_);
+        thinker_prefill_->sync();
+        next_token = thinker_token_host_;
+        return true;
+    }
+
+    TensorMap outputs = thinker_prefill_->forward(inputs);
+    cache->write_prefill_kv(present_k, present_v, sequence_length);
+    next_token = host_argmax(outputs, thinker_stats_.full_logits_d2h);
+    return true;
 }
 
 std::vector<int32_t> OmniPipeline::run_thinker(const std::vector<int32_t>& input_ids,
                                                int32_t max_tokens) {
+    thinker_stats_ = {};
+    thinker_stats_.prompt_tokens = static_cast<int32_t>(input_ids.size());
+    if (input_ids.empty() || max_tokens <= 0)
+        return {};
+
     thinker_state_->reset();
+    thinker_state_->set_prompt_length(static_cast<int32_t>(input_ids.size()));
     thinker_state_->bind_to(*thinker_);
 
-    std::vector<float> logits;
-
-    for (std::size_t i = 0; i + 1 < input_ids.size(); ++i)
-        run_thinker_step(input_ids[i], logits);
-
-    if (!input_ids.empty())
-        run_thinker_step(input_ids.back(), logits);
+    int32_t next_token = 0;
+    if (!run_thinker_prefill(input_ids, next_token)) {
+        for (int32_t token : input_ids)
+            next_token = run_thinker_step(token);
+    }
+    thinker_state_->mark_prefill_complete();
 
     std::vector<int32_t> output_ids;
     output_ids.reserve(static_cast<std::size_t>(max_tokens));
 
     for (int32_t step = 0; step < max_tokens; ++step) {
-        if (logits.empty())
-            break;
-        int32_t token = omni_argmax(logits);
+        const int32_t token = next_token;
         if (token == 0 || token == config_->thinker_eos_token_id)
             break;
         output_ids.push_back(token);
-        run_thinker_step(token, logits);
+        if (step + 1 < max_tokens)
+            next_token = run_thinker_step(token);
     }
 
     std::cerr << "[trtmc] Omni Thinker: generated " << output_ids.size() << " text tokens"
               << std::endl;
     return output_ids;
+}
+
+std::vector<int32_t> OmniPipeline::generate_thinker_ids(const std::vector<int32_t>& input_ids,
+                                                        int32_t max_tokens) {
+    return run_thinker(input_ids, max_tokens);
 }
 
 std::vector<float> OmniPipeline::run_code2wav(const std::vector<int32_t>& codec_tokens,

--- a/src/runtime/models/qwen3_omni/pipeline.h
+++ b/src/runtime/models/qwen3_omni/pipeline.h
@@ -13,6 +13,7 @@
 #include "runtime/models/qwen3_omni/kv_cache.h"
 #include "runtime/models/qwen3_omni/omni_config.h"
 #include "trtmc/pipeline.h"
+#include "trtmc/runtime/device_tensor.h"
 #include "trtmc/runtime/trt_module.h"
 #include "trtmc/tokenizer.h"
 
@@ -26,12 +27,20 @@ namespace trtmc {
 
 class Qwen3OmniTalkerRuntime;
 
+struct OmniThinkerRunStats {
+    int32_t prompt_tokens{0};
+    int32_t prefill_launches{0};
+    int32_t decode_launches{0};
+    int32_t full_logits_d2h{0};
+};
+
 class OmniPipeline final : public IPipeline {
   public:
     OmniPipeline(std::unique_ptr<TrtModule> thinker,
                  std::unique_ptr<Qwen3OmniInferenceState> thinker_state,
                  std::unique_ptr<TrtModule> code2wav, OmniConfig config, cudaStream_t stream,
-                 std::shared_ptr<ITokenizer> tokenizer = nullptr, std::string model_id_str = "");
+                 std::shared_ptr<ITokenizer> tokenizer = nullptr, std::string model_id_str = "",
+                 std::unique_ptr<TrtModule> thinker_prefill = nullptr);
 
     ~OmniPipeline() override;
 
@@ -40,14 +49,21 @@ class OmniPipeline final : public IPipeline {
     const char* model_id() const override { return model_id_.c_str(); }
     const char* pipeline_type() const override { return "OmniPipeline"; }
 
+    // Token-ID entry point and launch counters for deterministic runtime tests.
+    std::vector<int32_t> generate_thinker_ids(const std::vector<int32_t>& input_ids,
+                                              int32_t max_tokens);
+    const OmniThinkerRunStats& thinker_run_stats() const { return thinker_stats_; }
+
   private:
-    void run_thinker_step(int32_t token_id, std::vector<float>& logits);
+    int32_t run_thinker_step(int32_t token_id);
+    bool run_thinker_prefill(const std::vector<int32_t>& input_ids, int32_t& next_token);
     std::vector<int32_t> run_thinker(const std::vector<int32_t>& input_ids, int32_t max_tokens);
     std::vector<float> run_code2wav(const std::vector<int32_t>& codec_tokens, int32_t n_codebooks,
                                     int32_t n_frames, double& code2wav_and_transfer_ms,
                                     double& output_materialization_ms);
 
     std::unique_ptr<TrtModule> thinker_;
+    std::unique_ptr<TrtModule> thinker_prefill_;
     std::unique_ptr<Qwen3OmniInferenceState> thinker_state_;
     std::unique_ptr<TrtModule> code2wav_;
     std::unique_ptr<OmniConfig> config_;
@@ -55,6 +71,9 @@ class OmniPipeline final : public IPipeline {
     cudaStream_t stream_;
     std::shared_ptr<ITokenizer> tokenizer_;
     std::string model_id_;
+    DeviceTensor thinker_token_id_;
+    int32_t thinker_token_host_{0};
+    OmniThinkerRunStats thinker_stats_;
 };
 
 } // namespace trtmc

--- a/src/runtime/models/qwen3_omni/plugin.cpp
+++ b/src/runtime/models/qwen3_omni/plugin.cpp
@@ -27,15 +27,15 @@ class Qwen3OmniPlugin final : public IPipelinePlugin {
         const auto& json = ctx.config_json;
 
         // Thinker (MoE decoder) -- main engine plan
-        auto thinker_loaded = load_trt_module_from_plan(
+        auto thinker_modules = load_dual_profile_modules(
             ctx.backend, find_section(ctx.bundle, "engine_plan"), "omni thinker", opts);
-        cudaStream_t stream = thinker_loaded.module->stream();
+        cudaStream_t stream = thinker_modules.decode->stream();
         int32_t kv_dim = compute_kv_dim(ctx.config);
         // The cache allocation must follow the engine binding, not the bundle's
         // requested precision. Legacy Qwen3-Omni builders emitted FP32 cache
         // bindings even for a bundle labelled BF16; allocating BF16 here
         // truncated every present K/V row and corrupted subsequent tokens.
-        DType cache_dtype = thinker_loaded.module->tensor_dtype("cache_k_0");
+        DType cache_dtype = thinker_modules.decode->tensor_dtype("cache_k_0");
         std::unique_ptr<Qwen3OmniInferenceState> thinker_state = std::make_unique<Qwen3OmniKvCache>(
             ctx.config.num_layers, ctx.config.max_cache_length, kv_dim, stream, cache_dtype);
         if (!thinker_state->ok())
@@ -55,6 +55,7 @@ class Qwen3OmniPlugin final : public IPipelinePlugin {
         OmniConfig omni_cfg;
         omni_cfg.sample_rate = extract_json_int(json, "audio_sample_rate", 24000);
         omni_cfg.thinker_hidden_size = ctx.config.hidden_size;
+        omni_cfg.thinker_vocab_size = ctx.config.vocab_size;
         omni_cfg.thinker_num_layers = ctx.config.num_layers;
         omni_cfg.thinker_num_heads = ctx.config.num_heads;
         omni_cfg.num_experts = extract_json_int(json, "num_local_experts", 8);
@@ -82,8 +83,9 @@ class Qwen3OmniPlugin final : public IPipelinePlugin {
         auto tokenizer = create_tokenizer_from_bundle(ctx.bundle);
 
         return std::make_unique<OmniPipeline>(
-            std::move(thinker_loaded.module), std::move(thinker_state), std::move(code2wav_module),
-            std::move(omni_cfg), stream, std::move(tokenizer), ctx.bundle.info.model_id);
+            std::move(thinker_modules.decode), std::move(thinker_state), std::move(code2wav_module),
+            std::move(omni_cfg), stream, std::move(tokenizer), ctx.bundle.info.model_id,
+            std::move(thinker_modules.prefill));
     }
 };
 

--- a/tests/cpp/models/qwen3_omni/test_qwen3_omni_pipeline.cpp
+++ b/tests/cpp/models/qwen3_omni/test_qwen3_omni_pipeline.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace {
@@ -35,6 +36,71 @@ class OmniFixedTokenizer : public trtmc::ITokenizer {
     std::string decode(const std::vector<int32_t>&) const override { return ""; }
     int32_t id_for_token(std::string_view) const override { return 0; }
     std::string token_for_id(int32_t) const override { return ""; }
+};
+
+struct CountingOmniStats {
+    int32_t launches{0};
+    std::unordered_map<std::string, std::vector<int64_t>> shapes;
+};
+
+class CountingOmniModule final : public trtmc::ITrtModule {
+  public:
+    CountingOmniModule(std::shared_ptr<CountingOmniStats> stats, bool prefill, cudaStream_t stream)
+        : stats_(std::move(stats)), prefill_(prefill), stream_(stream),
+          device_logits_({1, 4}, trtmc::DType::kFloat32, stream) {
+        device_logits_.copy_from_host(host_logits_.data());
+    }
+
+    trtmc::TensorMap forward(const trtmc::TensorMap& inputs) override {
+        record(inputs);
+        return {{"logits", trtmc::Tensor{host_logits_.data(), {1, 4}, trtmc::DType::kFloat32}}};
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override { return {}; }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {}
+    void forward_async(const trtmc::TensorMap& inputs) override { record(inputs); }
+    void sync() override { cudaStreamSynchronize(stream_); }
+    cudaStream_t stream() const override { return stream_; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return prefill_ ? 0 : 1; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return {}; }
+    std::vector<trtmc::TensorInfo> output_info() const override { return {}; }
+    bool has_input(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" || name == "attention_mask" ||
+               name == "input_embed" || name == "use_input_embed";
+    }
+    bool has_output(const std::string& name) const override { return name == "logits"; }
+    trtmc::DType tensor_dtype(const std::string&) const override { return trtmc::DType::kFloat32; }
+    std::vector<int64_t> tensor_shape(const std::string&) const override { return {}; }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return prefill_ ? 2 : 1; }
+    void* device_ptr(const std::string& name) const override {
+        return name == "logits" ? const_cast<void*>(device_logits_.data()) : nullptr;
+    }
+    void bind_external(const std::string&, void*) override {}
+    int32_t input_rank(const std::string& name) const override {
+        return name == "token_id" || name == "position_id" ? 1 : 2;
+    }
+    bool input_is_dynamic(const std::string&) const override { return prefill_; }
+    bool ok() const override { return device_logits_.ok(); }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    void record(const trtmc::TensorMap& inputs) {
+        ++stats_->launches;
+        stats_->shapes.clear();
+        for (const auto& [name, tensor] : inputs)
+            stats_->shapes[name] = tensor.shape;
+    }
+
+    std::shared_ptr<CountingOmniStats> stats_;
+    bool prefill_{false};
+    cudaStream_t stream_{nullptr};
+    std::vector<float> host_logits_{0.1F, 0.9F, 0.9F, 0.3F};
+    mutable trtmc::DeviceTensor device_logits_;
 };
 
 void test_omni_pipeline_construction() {
@@ -110,12 +176,59 @@ void test_omni_validates_thinker() {
     check(threw, "omni: null thinker throws");
 }
 
+void test_omni_batched_prefill_and_device_argmax() {
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    auto decode_stats = std::make_shared<CountingOmniStats>();
+    auto prefill_stats = std::make_shared<CountingOmniStats>();
+    auto decoder = std::make_unique<CountingOmniModule>(decode_stats, false, stream);
+    auto prefill = std::make_unique<CountingOmniModule>(prefill_stats, true, stream);
+    if (!decoder->ok() || !prefill->ok()) {
+        std::cerr << "WARNING: Could not allocate Omni test buffers, skipping\n";
+        cudaStreamDestroy(stream);
+        return;
+    }
+
+    auto cache = std::make_unique<trtmc::Qwen3OmniKvCache>(0, 8, 0, stream);
+    trtmc::OmniConfig cfg;
+    cfg.thinker_hidden_size = 4;
+    cfg.thinker_vocab_size = 4;
+    cfg.thinker_eos_token_id = 99;
+
+    {
+        trtmc::OmniPipeline pipeline(std::move(decoder), std::move(cache), nullptr, cfg, stream,
+                                     nullptr, "test-prefill", std::move(prefill));
+        const auto output = pipeline.generate_thinker_ids({1, 2, 3}, 2);
+        const auto& stats = pipeline.thinker_run_stats();
+
+        check(output == std::vector<int32_t>({1, 1}),
+              "omni prefill: token output and lowest-index tie break preserved");
+        check(prefill_stats->launches == 1, "omni prefill: one prompt launch");
+        check(decode_stats->launches == 1, "omni prefill: decode only generated token");
+        check(prefill_stats->shapes["token_id"] == std::vector<int64_t>({3}),
+              "omni prefill: token shape");
+        check(prefill_stats->shapes["attention_mask"] == std::vector<int64_t>({3, 11}),
+              "omni prefill: causal mask shape");
+        check(prefill_stats->shapes["input_embed"] == std::vector<int64_t>({3, 4}),
+              "omni prefill: embedding shape");
+        check(prefill_stats->shapes["use_input_embed"] == std::vector<int64_t>({3, 1}),
+              "omni prefill: selector shape");
+        check(stats.prompt_tokens == 3 && stats.prefill_launches == 1 && stats.decode_launches == 1,
+              "omni prefill: deterministic launch counters");
+        check(stats.full_logits_d2h == 0, "omni prefill: no full-logits D2H");
+    }
+
+    cudaStreamDestroy(stream);
+}
+
 } // namespace
 
 int main() {
     test_omni_pipeline_construction();
     test_omni_generate_audio();
     test_omni_validates_thinker();
+    test_omni_batched_prefill_and_device_argmax();
     if (failures > 0) {
         std::cerr << failures << " omni pipeline test(s) FAILED\n";
     }

--- a/tests/e2e/models/qwen3_omni/test_qwen3_omni_audio_runtime.py
+++ b/tests/e2e/models/qwen3_omni/test_qwen3_omni_audio_runtime.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import io
+import importlib
 import struct
 
 import numpy as np
@@ -172,3 +173,57 @@ def test_bundle_config_persists_portable_talker_locator() -> None:
 
     assert overrides["omni_talker_model_id"] == "Qwen/Qwen3-Omni-30B-A3B-Instruct"
     assert overrides["omni_talker_model_revision"] == "abc123"
+
+
+def test_thinker_load_weights_preserves_bf16_storage(monkeypatch, tmp_path) -> None:
+    plugin_module = importlib.import_module(
+        "tensorrt_model_connect.families.qwen3_omni.plugin")
+    config = ModelConfig.create_tiny("qwen3_omni")
+
+    class FakeReader:
+        @staticmethod
+        def keys() -> list[str]:
+            return []
+
+    def has_tensor(_readers, key: str) -> bool:
+        return (
+            key == "model.thinker.embed_tokens.weight"
+            or key == "model.thinker.norm.weight"
+            or key == "lm_head.weight"
+            or key.startswith("model.thinker.layers.")
+        )
+
+    def load_tensor(_readers, key: str) -> np.ndarray:
+        if key == "model.thinker.embed_tokens.weight":
+            shape = (config.vocab_size, config.hidden_size)
+        elif key == "lm_head.weight":
+            shape = (config.vocab_size, config.hidden_size)
+        elif key.endswith(("input_layernorm.weight", "post_attention_layernorm.weight")):
+            shape = (config.hidden_size,)
+        elif key == "model.thinker.norm.weight":
+            shape = (config.hidden_size,)
+        elif key.endswith("mlp.gate.weight"):
+            shape = (8, config.hidden_size)
+        elif key.endswith(("gate_proj.weight", "up_proj.weight")):
+            shape = (config.intermediate_size, config.hidden_size)
+        elif key.endswith("down_proj.weight"):
+            shape = (config.hidden_size, config.intermediate_size)
+        else:
+            shape = (config.hidden_size, config.hidden_size)
+        return np.ones(shape, dtype=np.float32)
+
+    monkeypatch.setattr(plugin_module, "_open_safetensors", lambda _path: [FakeReader()])
+    monkeypatch.setattr(plugin_module, "_has_tensor", has_tensor)
+    monkeypatch.setattr(plugin_module, "_load_tensor", load_tensor)
+
+    weights = plugin_module.Qwen3OmniPlugin().load_weights(
+        str(tmp_path), config, precision="bf16")
+
+    assert weights["embedding"].dtype.name == "bfloat16"
+    assert weights["layer.0.w_q"].dtype.name == "bfloat16"
+    assert weights["layer.0.router"].dtype.name == "bfloat16"
+    assert weights["layer.0.experts.w_gate"].dtype.name == "bfloat16"
+    assert weights["layer.0.experts.w_gate"].shape == (8, 16, 32)
+    assert weights["layer.0.experts.w_down"].shape == (8, 32, 16)
+    assert weights["w_out"].dtype.name == "bfloat16"
+    assert weights["final_norm"].dtype == np.float32


### PR DESCRIPTION
## Background

Qwen3-Omni submitted every prompt token through its single-token Thinker decode path. A 61-token prompt plus 7 generated tokens therefore required 68 Thinker engine launches per request, and each launch downloaded the full vocabulary logits for host argmax.

The first CI run also exposed a fresh-build problem: the 48-layer Thinker graph emitted three separate projections for every one of its 128 experts, producing 18,432 expert MatMul layers. The full BF16 profile did not finish within the model-owned 5,400-second build budget. Its checkpoint mapper also staged BF16 weights through FP16, which could perturb very small values and make output quality tactic-sensitive.

This PR closes #501. The separate persistent-Talker optimization remains isolated in #509; the complete-task performance section below stacks that Draft PR only for measurement, as requested by the issue acceptance criteria.

## Exit Criteria

- Run a supported prompt with one Thinker prefill launch and keep decode launches proportional to generated tokens.
- Preserve prompt KV state, positions, causal masks, greedy token IDs, and audio quality.
- Transfer one selected token ID instead of full vocabulary logits when device selection is available.
- Build the unchanged full BF16 profile from a cold artifact within the model-owned timeout.
- Retain compatibility with existing single-profile bundles.

## Implementation

- Build one dynamic-sequence Thinker plan with a prompt profile and a fixed single-token decode profile. The prompt profile carries all token rows through attention and per-token MoE routing while returning only the final hidden/logit row.
- Execute prompt prefill once, copy the produced K/V rows directly into the existing device cache, and continue autoregressive decoding through the fixed profile.
- Select greedy tokens with a deterministic device argmax and copy only the selected `int32` token to the host. Equal logits retain the previous lowest-index behavior.
- Pack all 128 experts' gate, up, and down projections so each layer uses three broadcast batched MatMuls instead of 384 separate MatMuls. Existing per-token top-k routing and `GatherND` selection remain unchanged.
- Preserve checkpoint BF16 arrays until TensorRT's strongly typed graph performs its BF16 cast. TensorRT Python constants are promoted losslessly to FP32 first because `trt.Weights` cannot directly consume NumPy BF16 arrays.
- Fall back to the existing token-linear path for legacy single-profile plans and unsupported prompt shapes.
- Add deterministic runtime coverage for launch counts, input shapes, lowest-index tie handling, absence of full-logit downloads, packed expert weight layout, and BF16 storage.

## Performance And Accuracy

Measured on an NVIDIA GB300 with TensorRT 11.2 and CUDA 13.0. Both sides use the same model revision, prompt, bundle precision contract, batch size 1, one warmup, five timed requests, CUDA synchronization before and after every task, and the complete host-prompt-to-host-PCM boundary.

| Metric | #500 only | #500 + #501 | Change |
| --- | ---: | ---: | ---: |
| Complete task p50 | 7,739.50 ms | 4,980.18 ms | -35.7% (1.55x faster) |
| Thinker engine execution/request | 3,856.38 ms | 622.26 ms | -83.9% (6.20x faster) |
| Thinker launches/request | 68 | 8 (1 prefill + 7 decode) | -88.2% |

- Output quality in the original performance run: exact match. Both paths produced FNV-1a `8269ca2ac150cf6c`, 58,965 samples at 24 kHz, 2.456875 seconds, and RMS `0.0641396876255`.
- Engine artifacts: baseline bundle SHA256 `bffa5bb9c6538c5ec0de3caedf821a8f8914bb30100118f0739d5b08b7c8788c`; fixed bundle SHA256 `d6cb69a246604cb03d84123eb9f68ab5b093052b8eedadaa6e07529e047ab449`.
- A fresh full-profile build after packing completed the main Thinker engine in 326.4 seconds and the complete bundle in 483.4 seconds, versus the prior 5,400-second timeout.
- The rebuilt full-profile bundle produced `Hello from Qwen-Omni`, 58,965 samples at 24 kHz, 2.456875 seconds, RMS `0.06413991`, and reference waveform cosine `0.4693` against the unchanged `0.25` threshold.

## Validation

- `CI_BASE_REF=github/main python3 -m tools.ci pipeline source-quality`: passed; CCN maximum 10 and 156 architecture tests passed.
- `python3 tools/legal_headers.py --check`: passed with no findings.
- `python3 -m ruff check <changed Python files>`: passed.
- `python3 tools/model_ci.py validate`: passed for all 77 registered models.
- `PYTHONPATH=python python3 -m pytest tests/builder -q -p no:cacheprovider`: 645 passed, 89 skipped.
- `PYTHONPATH=python python3 -m pytest tests/e2e/models/qwen3_omni --ignore=tests/e2e/models/qwen3_omni/test_qwen3_omni_e2e.py -q`: 39 passed.
- `ctest --test-dir build -R '^test_qwen3_omni_pipeline$' --output-on-failure`: passed on the target GB300 for both the isolated change and the #500/#501 validation stack.
- A one-layer TensorRT parity probe compared a batched three-token prefill against three token-linear executions: logits max-absolute error `1.49e-08`, hidden-state error `8.94e-08`, K-cache error `2.38e-07`, V-cache error `1.49e-08`, with the same selected token.
- Fresh full-profile build with `--precision bf16 --max-cache-length 256`: passed in 483.4 seconds total; no cached engine artifact was reused.
- Model-owned `qwen3-omni-30b-a3b-instruct` L3 task evaluation: passed (`1 passed in 131.78s`) with unchanged duration, RMS, peak, fallback, and waveform-cosine gates.

## Notes For Future Readers

- No model quality thresholds, requested precision, or profile bounds changed.
- Review the packed expert graph and BF16 constant path first, then the dynamic profile construction, runtime prefill/cache handoff, and device argmax.
- This PR is based directly on `main`. Its performance measurement stacks #509 without including that commit in this branch.
