### PR TITLE
ci: add nightly failure issue tracker

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1349,3 +1349,39 @@ jobs:
               > /dev/null
             echo "Published release asset: $name"
           done
+
+  nightly-issue:
+    name: 9 / Nightly failure issue
+    needs:
+      - required
+      - release
+    # This is the workflow's only issue-mutation path. Manual runs and forks
+    # stay useful for validation without touching the production issue list.
+    if: >-
+      ${{
+        always() &&
+        github.event_name == 'schedule' &&
+        github.ref == 'refs/heads/main' &&
+        github.repository == 'NVIDIA/TensorRT-Model-Connect'
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+
+    steps:
+      - name: Check out the scheduled Nightly snapshot
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Reconcile the scheduled Nightly failure issue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          NIGHTLY_REQUIRED_RESULT: ${{ needs.required.result }}
+          NIGHTLY_RELEASE_RESULT: ${{ needs.release.result }}
+        run: python3 tools/nightly_issue_tracker.py --apply

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -1125,17 +1125,35 @@ def test_nightly_all_gpu_gate_uses_the_model_proof_machine_lock() -> None:
     )
 
 
-def test_nightly_grants_write_permission_only_after_the_final_gate() -> None:
+def test_nightly_grants_mutation_permissions_only_after_the_final_gate() -> None:
     text = (REPO_ROOT / ".github" / "workflows" / "nightly.yml").read_text()
-    before_release, release = text.split("\n  release:", maxsplit=1)
+    before_release, after_release = text.split("\n  release:", maxsplit=1)
+    release, issue_tracker = after_release.split("\n  nightly-issue:", maxsplit=1)
     assert "permissions: {}" in before_release
     assert "contents: write" not in before_release
+    assert "issues: write" not in before_release
     assert text.count("contents: write") == 1
+    assert text.count("issues: write") == 1
     assert "contents: write" in release
+    assert "issues: write" not in release
     assert "needs.required.result == 'success'" in release
     assert "github.event_name == 'schedule' || github.ref == 'refs/heads/main'" in release
     assert "target_commitish" in release
     assert 'os.environ["TESTED_SHA"]' in release
+    assert "issues: write" in issue_tracker
+    assert "actions: read" in issue_tracker
+    assert "contents: read" in issue_tracker
+    assert "- required" in issue_tracker
+    assert "- release" in issue_tracker
+    assert "always()" in issue_tracker
+    assert "github.event_name == 'schedule'" in issue_tracker
+    assert "github.ref == 'refs/heads/main'" in issue_tracker
+    assert "github.repository == 'NVIDIA/TensorRT-Model-Connect'" in issue_tracker
+    assert "NIGHTLY_REQUIRED_RESULT: ${{ needs.required.result }}" in issue_tracker
+    assert "NIGHTLY_RELEASE_RESULT: ${{ needs.release.result }}" in issue_tracker
+    assert "python3 tools/nightly_issue_tracker.py --apply" in issue_tracker
+    assert text.count("python3 tools/nightly_issue_tracker.py --apply") == 1
+    assert "persist-credentials: false" in issue_tracker
     assert "secrets: inherit" not in text
 
 
@@ -1232,6 +1250,7 @@ def test_nightly_graph_stage_numbers_are_unambiguous() -> None:
     assert "name: 6 / Combined HTML report" in text
     assert "name: 7 / Nightly CI" in text
     assert "name: 8 / Publish nightly wheels" in text
+    assert "name: 9 / Nightly failure issue" in text
 
 
 def test_github_workflows_write_e2e_markdown_summary() -> None:

--- a/tests/tools/test_nightly_issue_tracker.py
+++ b/tests/tools/test_nightly_issue_tracker.py
@@ -1,0 +1,371 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the scheduled Nightly failure issue state machine."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from tools.nightly_issue_tracker import (
+    EXPECTED_REF,
+    EXPECTED_REPOSITORY,
+    EXPECTED_WORKFLOW_REF,
+    EXPECTED_API_URL,
+    EXPECTED_SERVER_URL,
+    FAILURE_TITLE,
+    RECOVERY_TITLE,
+    TRACKER_MARKER,
+    GitHubApi,
+    NightlyRun,
+    TrackerError,
+    parse_args,
+    reconcile,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "tools" / "nightly_issue_tracker.py"
+BASE_ENV = {
+    "GITHUB_ACTIONS": "true",
+    "GITHUB_API_URL": EXPECTED_API_URL,
+    "GITHUB_EVENT_NAME": "schedule",
+    "GITHUB_REF": EXPECTED_REF,
+    "GITHUB_REPOSITORY": EXPECTED_REPOSITORY,
+    "GITHUB_RUN_ATTEMPT": "2",
+    "GITHUB_RUN_ID": "777",
+    "GITHUB_SERVER_URL": EXPECTED_SERVER_URL,
+    "GITHUB_SHA": "a" * 40,
+    "GITHUB_WORKFLOW": "TensorRT-Model-Connect Nightly CI",
+    "GITHUB_WORKFLOW_REF": EXPECTED_WORKFLOW_REF,
+    "NIGHTLY_RELEASE_RESULT": "skipped",
+    "NIGHTLY_REQUIRED_RESULT": "failure",
+}
+
+
+class FakeApi:
+    """In-memory API that records every read and write operation."""
+
+    def __init__(
+        self,
+        *,
+        issues: list[dict[str, object]] | None = None,
+        jobs: list[dict[str, object]] | None = None,
+        artifacts: list[dict[str, object]] | None = None,
+    ) -> None:
+        self.issues = list(issues or [])
+        self.jobs = list(jobs or [])
+        self.artifacts = list(artifacts or [])
+        self.calls: list[tuple[object, ...]] = []
+
+    def list_open_issues(self) -> list[dict[str, object]]:
+        self.calls.append(("list_open_issues",))
+        return self.issues
+
+    def list_run_jobs(self, run_id: int, run_attempt: int) -> list[dict[str, object]]:
+        self.calls.append(("list_run_jobs", run_id, run_attempt))
+        return self.jobs
+
+    def list_run_artifacts(self, run_id: int) -> list[dict[str, object]]:
+        self.calls.append(("list_run_artifacts", run_id))
+        return self.artifacts
+
+    def create_issue(self, payload: dict[str, object]) -> dict[str, object]:
+        self.calls.append(("create_issue", payload))
+        return {
+            **payload,
+            "number": 101,
+            "state": "open",
+            "html_url": "https://github.com/NVIDIA/TensorRT-Model-Connect/issues/101",
+        }
+
+    def update_issue(self, issue_number: int, payload: dict[str, object]) -> dict[str, object]:
+        self.calls.append(("update_issue", issue_number, payload))
+        return {
+            **payload,
+            "number": issue_number,
+            "html_url": (f"https://github.com/NVIDIA/TensorRT-Model-Connect/issues/{issue_number}"),
+        }
+
+    @property
+    def mutations(self) -> list[tuple[object, ...]]:
+        return [call for call in self.calls if call[0] in {"create_issue", "update_issue"}]
+
+
+def _run(**overrides: str) -> NightlyRun:
+    return NightlyRun.from_environ({**BASE_ENV, **overrides})
+
+
+def _tracker_issue(
+    *, number: int = 55, body: str = TRACKER_MARKER, state: str = "open"
+) -> dict[str, object]:
+    return {
+        "number": number,
+        "state": state,
+        "body": body,
+        "html_url": (f"https://github.com/NVIDIA/TensorRT-Model-Connect/issues/{number}"),
+    }
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    (
+        ("github_actions", "false"),
+        ("repository", "someone/TensorRT-Model-Connect"),
+        ("event_name", "workflow_dispatch"),
+        ("ref", "refs/heads/feature"),
+        (
+            "workflow_ref",
+            "NVIDIA/TensorRT-Model-Connect/.github/workflows/other.yml@refs/heads/main",
+        ),
+        ("server_url", "https://github.example.com"),
+        ("api_url", "https://api.github.example.com"),
+    ),
+)
+def test_non_production_contexts_never_call_github(field: str, value: str) -> None:
+    api = FakeApi()
+    result = reconcile(replace(_run(), **{field: value}), api, apply=True)
+
+    assert result.action == "disabled-non-production-context"
+    assert api.calls == []
+
+
+def test_default_mode_plans_a_failure_without_mutating() -> None:
+    api = FakeApi(
+        jobs=[
+            {
+                "name": "4 / Model / qwen",
+                "conclusion": "failure",
+                "html_url": "https://github.com/NVIDIA/TensorRT-Model-Connect/"
+                "actions/runs/777/job/9",
+            }
+        ]
+    )
+
+    result = reconcile(_run(), api, apply=False)
+
+    assert result.action == "would-create"
+    assert api.mutations == []
+    assert parse_args([]).apply is False
+    assert parse_args(["--apply"]).apply is True
+
+
+def test_first_failure_creates_one_bug_with_current_attempt_evidence() -> None:
+    run = _run()
+    api = FakeApi(
+        issues=[
+            {
+                "number": 4,
+                "state": "open",
+                "body": TRACKER_MARKER,
+                "pull_request": {"url": "https://api.github.com/pulls/4"},
+            }
+        ],
+        jobs=[
+            {
+                "name": "4 / Model / qwen",
+                "conclusion": "failure",
+                "html_url": f"{run.run_url}/job/9",
+                "steps": [{"name": "Build + reference test", "conclusion": "failure"}],
+            },
+            {
+                "name": "4 / Model / llama",
+                "conclusion": "success",
+                "html_url": f"{run.run_url}/job/10",
+            },
+            {
+                "name": "7 / Nightly CI",
+                "conclusion": "cancelled",
+                "html_url": f"{run.run_url}/job/11",
+            },
+        ],
+        artifacts=[
+            {
+                "id": 700,
+                "name": "trtmc-nightly-html-report-777-1",
+            },
+            {
+                "id": 701,
+                "name": "trtmc-nightly-html-report-777-2",
+                "expired": False,
+                "size_in_bytes": 12345,
+                "digest": "sha256:abc123",
+            },
+        ],
+    )
+
+    result = reconcile(run, api, apply=True)
+
+    assert result.action == "created"
+    assert ("list_run_jobs", 777, 2) in api.calls
+    assert len(api.mutations) == 1
+    operation, payload = api.mutations[0]
+    assert operation == "create_issue"
+    assert payload["title"] == FAILURE_TITLE
+    assert payload["labels"] == ["bug"]
+    body = str(payload["body"])
+    assert TRACKER_MARKER in body
+    assert run.run_marker in body
+    assert run.run_url in body and run.sha in body
+    assert "4 / Model / qwen" in body
+    assert "Build + reference test" in body
+    assert "7 / Nightly CI" in body
+    assert "4 / Model / llama" not in body
+    assert "trtmc-nightly-html-report-777-2" in body
+    assert "sha256:abc123" in body
+    assert "`12345` bytes" in body
+    assert "trtmc-nightly-html-report-777-1" not in body
+
+
+def test_later_failure_updates_the_open_tracker_and_same_attempt_is_idempotent() -> None:
+    run = _run(GITHUB_RUN_ID="778", GITHUB_RUN_ATTEMPT="1")
+    tracker = _tracker_issue(body=f"{TRACKER_MARKER}\n<!-- old run -->")
+    api = FakeApi(issues=[tracker])
+
+    result = reconcile(run, api, apply=True)
+
+    assert result.action == "updated"
+    assert len(api.mutations) == 1
+    operation, issue_number, payload = api.mutations[0]
+    assert operation == "update_issue"
+    assert issue_number == 55
+    assert payload["state"] == "open"
+    assert run.run_marker in str(payload["body"])
+
+    reconciled = _tracker_issue(body=str(payload["body"]))
+    second_api = FakeApi(issues=[reconciled])
+    second = reconcile(run, second_api, apply=True)
+    assert second.action == "already-reconciled"
+    assert second_api.calls == [("list_open_issues",)]
+    assert second_api.mutations == []
+
+
+def test_success_closes_one_open_tracker_without_erasing_failure_evidence() -> None:
+    run = _run(
+        NIGHTLY_REQUIRED_RESULT="success",
+        NIGHTLY_RELEASE_RESULT="success",
+    )
+    api = FakeApi(issues=[_tracker_issue(body=f"{TRACKER_MARKER}\nlast failure evidence")])
+
+    result = reconcile(run, api, apply=True)
+
+    assert result.action == "closed"
+    operation, issue_number, payload = api.mutations[0]
+    assert operation == "update_issue" and issue_number == 55
+    assert payload["title"] == RECOVERY_TITLE
+    assert payload["state"] == "closed"
+    assert payload["state_reason"] == "completed"
+    assert run.run_marker in str(payload["body"])
+    assert "last failure evidence" in str(payload["body"])
+
+
+def test_success_without_an_open_tracker_is_a_noop() -> None:
+    run = _run(
+        NIGHTLY_REQUIRED_RESULT="success",
+        NIGHTLY_RELEASE_RESULT="success",
+    )
+
+    empty_api = FakeApi()
+    empty = reconcile(run, empty_api, apply=True)
+    assert empty.action == "no-open-tracker"
+    assert empty_api.mutations == []
+
+
+def test_multiple_open_trackers_fail_without_an_additional_mutation() -> None:
+    api = FakeApi(issues=[_tracker_issue(number=4), _tracker_issue(number=5)])
+
+    with pytest.raises(TrackerError, match="multiple open Nightly tracker issues"):
+        reconcile(_run(), api, apply=True)
+
+    assert api.mutations == []
+
+
+def test_rest_client_refuses_mutation_without_explicit_apply() -> None:
+    api = GitHubApi(
+        api_url="https://api.github.com",
+        repository=EXPECTED_REPOSITORY,
+        token="not-a-real-token",
+        allow_mutations=False,
+    )
+
+    with pytest.raises(TrackerError, match="without --apply"):
+        api.create_issue({"title": "must not be sent"})
+
+
+def test_rest_client_refuses_to_send_token_to_another_host_or_repository() -> None:
+    with pytest.raises(TrackerError, match="non-GitHub API URL"):
+        GitHubApi(
+            api_url="https://api.github.example.com",
+            repository=EXPECTED_REPOSITORY,
+            token="not-a-real-token",
+            allow_mutations=True,
+        )
+    with pytest.raises(TrackerError, match="outside the official repository"):
+        GitHubApi(
+            api_url=EXPECTED_API_URL,
+            repository="someone/TensorRT-Model-Connect",
+            token="not-a-real-token",
+            allow_mutations=True,
+        )
+
+
+def test_rest_client_reads_jobs_from_only_the_current_attempt() -> None:
+    class RecordingApi(GitHubApi):
+        def __init__(self) -> None:
+            super().__init__(
+                api_url=EXPECTED_API_URL,
+                repository=EXPECTED_REPOSITORY,
+                token="not-a-real-token",
+                allow_mutations=False,
+            )
+            self.paths: list[str] = []
+
+        def _request(
+            self,
+            method: str,
+            path: str,
+            payload: dict[str, object] | None = None,
+        ) -> object:
+            assert method == "GET" and payload is None
+            self.paths.append(path)
+            return {"jobs": []}
+
+    api = RecordingApi()
+
+    assert api.list_run_jobs(777, 2) == []
+    assert api.paths == [
+        "/repos/NVIDIA/TensorRT-Model-Connect/actions/runs/777/attempts/2/jobs?per_page=100&page=1"
+    ]
+
+
+def test_cli_manual_branch_guard_exits_before_token_or_network() -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            **BASE_ENV,
+            "GITHUB_EVENT_NAME": "workflow_dispatch",
+            "GITHUB_REF": "refs/heads/agent/nightly-issue-automation",
+            "GITHUB_WORKFLOW_REF": (
+                "NVIDIA/TensorRT-Model-Connect/.github/workflows/nightly.yml@"
+                "refs/heads/agent/nightly-issue-automation"
+            ),
+        }
+    )
+    env.pop("GITHUB_TOKEN", None)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--apply"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert '"action": "disabled-non-production-context"' in result.stdout

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1801,6 +1801,15 @@ class TestUnitTiers:
         assert match.unit_tiers == ["tools"]
         assert match.rebuild_cpp is False
 
+    def test_nightly_issue_tracker_tool(self, imap):
+        """Nightly issue tracking runs its tooling contracts, not model E2E."""
+        match = test_impact.classify_file("tools/nightly_issue_tracker.py", imap)
+
+        assert match.rule == "nightly_issue_tracker_tool"
+        assert match.models == []
+        assert match.unit_tiers == ["tools"]
+        assert match.rebuild_cpp is False
+
     def test_source_implies_unit_tier(self, imap):
         """C++ source change implies 'cpp' unit tier alongside E2E."""
         match = test_impact.classify_file("src/runtime/trt/trt_common.cpp", imap)
@@ -3479,6 +3488,22 @@ class TestCoverageMapIntegration:
         assert result.tools_tests == [
             "tests/tools/test_github_actions_ci.py",
             "tests/tools/test_select_latest_attempt_artifact.py",
+        ]
+        assert result.fallback_tiers == []
+
+    @pytest.mark.parametrize("coverage_map", [None, {}])
+    def test_nightly_issue_tracker_selects_focused_tools_tests(self, imap, coverage_map):
+        result = test_impact.analyze_impact(
+            ["tools/nightly_issue_tracker.py"],
+            imap,
+            coverage_map=coverage_map,
+        )
+
+        assert result.e2e_models == []
+        assert result.unit_tiers == ["tools"]
+        assert result.tools_tests == [
+            "tests/tools/test_github_actions_ci.py",
+            "tests/tools/test_nightly_issue_tracker.py",
         ]
         assert result.fallback_tiers == []
 

--- a/tools/nightly_issue_tracker.py
+++ b/tools/nightly_issue_tracker.py
@@ -1,0 +1,522 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Create one GitHub issue per scheduled Nightly failure streak."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from typing import Mapping, Protocol, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+EXPECTED_REPOSITORY = "NVIDIA/TensorRT-Model-Connect"
+EXPECTED_REF = "refs/heads/main"
+EXPECTED_WORKFLOW_REF = (
+    "NVIDIA/TensorRT-Model-Connect/.github/workflows/nightly.yml@refs/heads/main"
+)
+EXPECTED_SERVER_URL = "https://github.com"
+EXPECTED_API_URL = "https://api.github.com"
+TRACKER_MARKER = "<!-- trtmc-nightly-failure-tracker:v1 -->"
+FAILURE_TITLE = "[Nightly] Scheduled validation needs attention"
+RECOVERY_TITLE = "[Nightly] Scheduled validation recovered"
+FAILURE_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "failure",
+    "stale",
+    "startup_failure",
+    "timed_out",
+}
+_REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+_SHA_PATTERN = re.compile(r"[0-9a-fA-F]{40}")
+
+
+class TrackerError(RuntimeError):
+    """Raised when tracker inputs or GitHub responses are unsafe or ambiguous."""
+
+
+@dataclass(frozen=True)
+class NightlyRun:
+    """Immutable GitHub Actions context used for issue reconciliation."""
+
+    repository: str
+    run_id: int
+    run_attempt: int
+    sha: str
+    ref: str
+    event_name: str
+    workflow_name: str
+    workflow_ref: str
+    github_actions: str
+    server_url: str
+    api_url: str
+    required_result: str
+    release_result: str
+
+    @classmethod
+    def from_environ(cls, environ: Mapping[str, str]) -> NightlyRun:
+        """Build and validate a run context from GitHub's default variables."""
+
+        def required(name: str) -> str:
+            value = environ.get(name, "").strip()
+            if not value:
+                raise TrackerError(f"required environment variable {name} is empty")
+            if any(character in value for character in "\r\n"):
+                raise TrackerError(f"environment variable {name} contains a newline")
+            return value
+
+        repository = required("GITHUB_REPOSITORY")
+        if _REPOSITORY_PATTERN.fullmatch(repository) is None:
+            raise TrackerError(f"invalid GITHUB_REPOSITORY: {repository!r}")
+        sha = required("GITHUB_SHA")
+        if _SHA_PATTERN.fullmatch(sha) is None:
+            raise TrackerError("GITHUB_SHA must be a 40-character hexadecimal commit")
+        try:
+            run_id = int(required("GITHUB_RUN_ID"))
+            run_attempt = int(required("GITHUB_RUN_ATTEMPT"))
+        except ValueError as error:
+            raise TrackerError("GitHub run ID and attempt must be integers") from error
+        if run_id < 1 or run_attempt < 1:
+            raise TrackerError("GitHub run ID and attempt must be positive")
+        server_url = required("GITHUB_SERVER_URL").rstrip("/")
+        api_url = required("GITHUB_API_URL").rstrip("/")
+        if not server_url.startswith("https://") or not api_url.startswith("https://"):
+            raise TrackerError("GitHub server and API URLs must use HTTPS")
+        return cls(
+            repository=repository,
+            run_id=run_id,
+            run_attempt=run_attempt,
+            sha=sha.lower(),
+            ref=required("GITHUB_REF"),
+            event_name=required("GITHUB_EVENT_NAME"),
+            workflow_name=required("GITHUB_WORKFLOW"),
+            workflow_ref=required("GITHUB_WORKFLOW_REF"),
+            github_actions=required("GITHUB_ACTIONS").lower(),
+            server_url=server_url,
+            api_url=api_url,
+            required_result=required("NIGHTLY_REQUIRED_RESULT").lower(),
+            release_result=required("NIGHTLY_RELEASE_RESULT").lower(),
+        )
+
+    @property
+    def issue_writes_allowed(self) -> bool:
+        """Return true only for the official scheduled workflow on main."""
+
+        return (
+            self.github_actions == "true"
+            and self.repository == EXPECTED_REPOSITORY
+            and self.event_name == "schedule"
+            and self.ref == EXPECTED_REF
+            and self.workflow_ref == EXPECTED_WORKFLOW_REF
+            and self.server_url == EXPECTED_SERVER_URL
+            and self.api_url == EXPECTED_API_URL
+        )
+
+    @property
+    def successful(self) -> bool:
+        """Return true only when validation and publication both succeeded."""
+
+        return self.required_result == "success" and self.release_result == "success"
+
+    @property
+    def run_url(self) -> str:
+        return f"{self.server_url}/{self.repository}/actions/runs/{self.run_id}"
+
+    @property
+    def commit_url(self) -> str:
+        return f"{self.server_url}/{self.repository}/commit/{self.sha}"
+
+    @property
+    def run_marker(self) -> str:
+        return f"<!-- trtmc-nightly-run:{self.run_id}:{self.run_attempt} -->"
+
+
+class TrackerApi(Protocol):
+    """Small GitHub API boundary used by the reconciler and in-memory tests."""
+
+    def list_open_issues(self) -> list[dict[str, object]]: ...
+
+    def list_run_jobs(self, run_id: int, run_attempt: int) -> list[dict[str, object]]: ...
+
+    def list_run_artifacts(self, run_id: int) -> list[dict[str, object]]: ...
+
+    def create_issue(self, payload: dict[str, object]) -> dict[str, object]: ...
+
+    def update_issue(self, issue_number: int, payload: dict[str, object]) -> dict[str, object]: ...
+
+
+class GitHubApi:
+    """Minimal versioned REST client with mutation disabled unless requested."""
+
+    def __init__(
+        self,
+        *,
+        api_url: str,
+        repository: str,
+        token: str,
+        allow_mutations: bool,
+    ) -> None:
+        if not token or any(character in token for character in "\r\n"):
+            raise TrackerError("GITHUB_TOKEN must be a non-empty single-line token")
+        if api_url.rstrip("/") != EXPECTED_API_URL:
+            raise TrackerError("refusing to send GITHUB_TOKEN to a non-GitHub API URL")
+        if repository != EXPECTED_REPOSITORY:
+            raise TrackerError("refusing to mutate issues outside the official repository")
+        self.api_url = api_url.rstrip("/")
+        self.repository = repository
+        self.token = token
+        self.allow_mutations = allow_mutations
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, object] | None = None,
+    ) -> object:
+        data = None if payload is None else json.dumps(payload).encode("utf-8")
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self.token}",
+            "User-Agent": "trtmc-nightly-issue-tracker",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if data is not None:
+            headers["Content-Type"] = "application/json"
+        request = Request(
+            f"{self.api_url}{path}",
+            data=data,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urlopen(request, timeout=30) as response:  # noqa: S310
+                body = response.read()
+        except HTTPError as error:
+            details = error.read(2_000).decode("utf-8", errors="replace")
+            raise TrackerError(
+                f"GitHub API {method} {path} returned {error.code}: {details}"
+            ) from error
+        except URLError as error:
+            raise TrackerError(f"GitHub API {method} {path} failed: {error.reason}") from error
+        if not body:
+            return None
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError as error:
+            raise TrackerError(f"GitHub API {method} {path} returned invalid JSON") from error
+
+    def _paginate(self, path: str, *, field: str | None = None) -> list[dict[str, object]]:
+        items: list[dict[str, object]] = []
+        page = 1
+        while True:
+            separator = "&" if "?" in path else "?"
+            response = self._request("GET", f"{path}{separator}per_page=100&page={page}")
+            page_items: object
+            if field is None:
+                page_items = response
+            elif isinstance(response, dict):
+                page_items = response.get(field)
+            else:
+                page_items = None
+            if not isinstance(page_items, list) or not all(
+                isinstance(item, dict) for item in page_items
+            ):
+                raise TrackerError(f"GitHub API pagination payload is invalid for {path}")
+            items.extend(page_items)
+            if len(page_items) < 100:
+                return items
+            page += 1
+
+    def list_open_issues(self) -> list[dict[str, object]]:
+        return self._paginate(
+            f"/repos/{self.repository}/issues?state=open&sort=created&direction=desc"
+        )
+
+    def list_run_jobs(self, run_id: int, run_attempt: int) -> list[dict[str, object]]:
+        return self._paginate(
+            f"/repos/{self.repository}/actions/runs/{run_id}/attempts/{run_attempt}/jobs",
+            field="jobs",
+        )
+
+    def list_run_artifacts(self, run_id: int) -> list[dict[str, object]]:
+        return self._paginate(
+            f"/repos/{self.repository}/actions/runs/{run_id}/artifacts",
+            field="artifacts",
+        )
+
+    def _mutate(self, method: str, path: str, payload: dict[str, object]) -> dict[str, object]:
+        if not self.allow_mutations:
+            raise TrackerError("GitHub issue mutation was attempted without --apply")
+        response = self._request(method, path, payload)
+        if not isinstance(response, dict):
+            raise TrackerError(f"GitHub API {method} {path} returned no issue object")
+        return response
+
+    def create_issue(self, payload: dict[str, object]) -> dict[str, object]:
+        return self._mutate("POST", f"/repos/{self.repository}/issues", payload)
+
+    def update_issue(self, issue_number: int, payload: dict[str, object]) -> dict[str, object]:
+        return self._mutate("PATCH", f"/repos/{self.repository}/issues/{issue_number}", payload)
+
+
+@dataclass(frozen=True)
+class ReconcileResult:
+    """Machine-readable description of the performed or planned action."""
+
+    action: str
+    issue_number: int | None = None
+    issue_url: str | None = None
+
+    def as_json(self) -> str:
+        return json.dumps(
+            {
+                "action": self.action,
+                "issue_number": self.issue_number,
+                "issue_url": self.issue_url,
+            },
+            sort_keys=True,
+        )
+
+
+def _single_line(value: object, *, fallback: str) -> str:
+    text = " ".join(str(value or "").split())
+    return text[:300] if text else fallback
+
+
+def _code(value: object) -> str:
+    return _single_line(value, fallback="unknown").replace("`", "'")
+
+
+def _issue_number(issue: Mapping[str, object]) -> int:
+    number = issue.get("number")
+    if not isinstance(number, int) or number < 1:
+        raise TrackerError("GitHub issue response has no positive issue number")
+    return number
+
+
+def _issue_url(issue: Mapping[str, object]) -> str | None:
+    value = issue.get("html_url")
+    return value if isinstance(value, str) and value.startswith("https://") else None
+
+
+def _find_tracker(issues: Sequence[Mapping[str, object]]) -> Mapping[str, object] | None:
+    matches = [
+        issue
+        for issue in issues
+        if issue.get("state") == "open"
+        and "pull_request" not in issue
+        and TRACKER_MARKER in str(issue.get("body") or "")
+    ]
+    if len(matches) > 1:
+        numbers = ", ".join(str(_issue_number(issue)) for issue in matches)
+        raise TrackerError(f"multiple open Nightly tracker issues are ambiguous: {numbers}")
+    return matches[0] if matches else None
+
+
+def _failing_job_lines(run: NightlyRun, jobs: Sequence[Mapping[str, object]]) -> list[str]:
+    failures: list[tuple[str, str, str, str]] = []
+    for job in jobs:
+        conclusion = str(job.get("conclusion") or "").lower()
+        if conclusion not in FAILURE_CONCLUSIONS:
+            continue
+        name = _single_line(job.get("name"), fallback="Unnamed job")
+        url = str(job.get("html_url") or "")
+        if not url.startswith(f"{run.run_url}/job/"):
+            url = run.run_url
+        raw_steps = job.get("steps")
+        failed_steps = []
+        if isinstance(raw_steps, list):
+            failed_steps = [
+                _single_line(step.get("name"), fallback="Unnamed step")
+                for step in raw_steps
+                if isinstance(step, dict)
+                and str(step.get("conclusion") or "").lower() in FAILURE_CONCLUSIONS
+            ]
+        step_text = ", ".join(failed_steps[:5])
+        failures.append((name, conclusion, url, step_text))
+    return [
+        f"- [{name}]({url}) — `{conclusion}`"
+        + (f"; failing step: `{_code(step_text)}`" if step_text else "")
+        for name, conclusion, url, step_text in sorted(failures)
+    ] or [f"- No terminal failed job was returned; inspect the [full run]({run.run_url})."]
+
+
+def _artifact_lines(run: NightlyRun, artifacts: Sequence[Mapping[str, object]]) -> list[str]:
+    expected_name = f"trtmc-nightly-html-report-{run.run_id}-{run.run_attempt}"
+    reports: list[tuple[str, str, str, str, str]] = []
+    for artifact in artifacts:
+        name = str(artifact.get("name") or "")
+        artifact_id = artifact.get("id")
+        if name != expected_name or not isinstance(artifact_id, int):
+            continue
+        expired = str(bool(artifact.get("expired"))).lower()
+        size = artifact.get("size_in_bytes")
+        size_text = str(size) if isinstance(size, int) and size >= 0 else "unknown"
+        digest = _single_line(artifact.get("digest"), fallback="unavailable")
+        reports.append(
+            (
+                _single_line(name, fallback="Nightly report"),
+                str(artifact_id),
+                expired,
+                size_text,
+                digest,
+            )
+        )
+    return [
+        f"- `{name}` (artifact `{artifact_id}`, `{size}` bytes, digest `{_code(digest)}`, "
+        f"expired `{expired}`; [open run artifacts]({run.run_url}#artifacts))"
+        for name, artifact_id, expired, size, digest in sorted(reports)
+    ] or [f"- No combined report artifact is available; inspect the [run]({run.run_url})."]
+
+
+def render_failure_body(
+    run: NightlyRun,
+    jobs: Sequence[Mapping[str, object]],
+    artifacts: Sequence[Mapping[str, object]],
+) -> str:
+    """Render the latest failure evidence for the single open tracker."""
+
+    job_lines = "\n".join(_failing_job_lines(run, jobs))
+    artifact_lines = "\n".join(_artifact_lines(run, artifacts))
+    return f"""{TRACKER_MARKER}
+{run.run_marker}
+
+## Scheduled Nightly failure
+
+**Action required:** investigate the scheduled TensorRT-Model-Connect Nightly and
+fix the failing validation or publication stage.
+
+- Workflow: `{_code(run.workflow_name)}`
+- Run: [{run.run_id} attempt {run.run_attempt}]({run.run_url})
+- Commit: [`{run.sha}`]({run.commit_url})
+- Required validation gate: `{_code(run.required_result)}`
+- Nightly wheel publication: `{_code(run.release_result)}`
+
+### Failing jobs
+
+{job_lines}
+
+### Diagnostic report
+
+{artifact_lines}
+
+This issue is maintained automatically. Later failures in the same streak update this
+body; the next fully successful scheduled Nightly closes the issue.
+"""
+
+
+def render_recovery_body(run: NightlyRun, previous_body: str) -> str:
+    """Render recovery evidence before atomically closing the tracker."""
+
+    return f"""{previous_body.rstrip()}
+
+---
+
+{run.run_marker}
+
+## Scheduled Nightly recovered
+
+The scheduled TensorRT-Model-Connect Nightly is green again.
+
+- Workflow: `{_code(run.workflow_name)}`
+- Recovery run: [{run.run_id} attempt {run.run_attempt}]({run.run_url})
+- Commit: [`{run.sha}`]({run.commit_url})
+- Required validation gate: `{_code(run.required_result)}`
+- Nightly wheel publication: `{_code(run.release_result)}`
+
+This tracker was closed automatically after both validation and publication succeeded.
+"""
+
+
+def _result(action: str, issue: Mapping[str, object] | None = None) -> ReconcileResult:
+    if issue is None:
+        return ReconcileResult(action=action)
+    return ReconcileResult(
+        action=action,
+        issue_number=_issue_number(issue),
+        issue_url=_issue_url(issue),
+    )
+
+
+def reconcile(run: NightlyRun, api: TrackerApi, *, apply: bool) -> ReconcileResult:
+    """Create, update, close, or plan the one issue for this failure streak."""
+
+    if not run.issue_writes_allowed:
+        return _result("disabled-non-production-context")
+
+    tracker = _find_tracker(api.list_open_issues())
+    if run.successful:
+        if tracker is None:
+            return _result("no-open-tracker")
+        payload: dict[str, object] = {
+            "title": RECOVERY_TITLE,
+            "body": render_recovery_body(run, str(tracker.get("body") or "")),
+            "state": "closed",
+            "state_reason": "completed",
+        }
+        if not apply:
+            return _result("would-close", tracker)
+        return _result("closed", api.update_issue(_issue_number(tracker), payload))
+
+    if tracker is not None and run.run_marker in str(tracker.get("body") or ""):
+        return _result("already-reconciled", tracker)
+
+    jobs = api.list_run_jobs(run.run_id, run.run_attempt)
+    artifacts = api.list_run_artifacts(run.run_id)
+    body = render_failure_body(run, jobs, artifacts)
+    if tracker is None:
+        payload = {"title": FAILURE_TITLE, "body": body, "labels": ["bug"]}
+        if not apply:
+            return _result("would-create")
+        return _result("created", api.create_issue(payload))
+
+    payload = {"title": FAILURE_TITLE, "body": body, "state": "open"}
+    if not apply:
+        return _result("would-update", tracker)
+    return _result("updated", api.update_issue(_issue_number(tracker), payload))
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Reconcile the scheduled main-branch Nightly failure issue."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="allow issue creation/update/closure after all production guards pass",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        run = NightlyRun.from_environ(os.environ)
+        if not run.issue_writes_allowed:
+            print(_result("disabled-non-production-context").as_json())
+            return 0
+        token = os.environ.get("GITHUB_TOKEN", "")
+        api = GitHubApi(
+            api_url=run.api_url,
+            repository=run.repository,
+            token=token,
+            allow_mutations=args.apply,
+        )
+        result = reconcile(run, api, apply=args.apply)
+    except TrackerError as error:
+        prefix = "::error::" if os.environ.get("GITHUB_ACTIONS") == "true" else "error: "
+        print(f"{prefix}{error}", file=sys.stderr)
+        return 1
+    print(result.as_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1840,6 +1840,15 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             covered_by=("TestE2EDataFiles.test_data_file_maps_to_manifest_users",),
         ),
         ClassificationRule(
+            priority=483,
+            name="nightly_issue_tracker_tool",
+            matcher=_path_equals("tools/nightly_issue_tracker.py"),
+            resolver=_match_result(
+                "nightly_issue_tracker_tool", _no_models, ["tools"], False,
+            ),
+            covered_by=("TestUnitTiers.test_nightly_issue_tracker_tool",),
+        ),
+        ClassificationRule(
             priority=484,
             name="nightly_artifact_selector_tool",
             matcher=_path_equals("tools/select_latest_attempt_artifact.py"),
@@ -1953,6 +1962,10 @@ def _direct_python_test_targets(changed_files: List[str]) -> tuple[List[str], Li
 
 
 _EXPLICIT_TOOLS_TEST_TARGETS = {
+    "tools/nightly_issue_tracker.py": (
+        "tests/tools/test_github_actions_ci.py",
+        "tests/tools/test_nightly_issue_tracker.py",
+    ),
     "tools/select_latest_attempt_artifact.py": (
         "tests/tools/test_github_actions_ci.py",
         "tests/tools/test_select_latest_attempt_artifact.py",


### PR DESCRIPTION
## Background

The scheduled Nightly already fails closed and publishes a complete diagnostic report, but a failed run does not create a durable work item. Someone must notice the Actions failure and manually open an issue before triage can begin.

## Exit Criteria

- A failed scheduled Nightly on the official `main` branch creates or updates one open tracker issue with the failing run, commit, jobs, steps, and report artifact.
- Repeated failures update the same issue instead of adding one issue per day.
- A scheduled run closes the tracker only after both the required Nightly gate and wheel publication succeed.
- Local tests, pull-request CI, forks, and manually dispatched Nightly runs cannot create, update, or close repository issues.

## Implementation

- Add `9 / Nightly failure issue` after the required and release jobs. It is the only job with `issues: write`, and its workflow condition requires the official repository, a scheduled event, and `refs/heads/main`.
- Add a standard-library REST reconciler that defaults to dry-run. Production mutation additionally requires explicit `--apply`, `GITHUB_ACTIONS=true`, the exact official workflow ref, exact GitHub server/API URLs, and the official repository.
- Use a versioned marker to find the one open tracker, an attempt marker for idempotency, the existing `bug` label for new issues, current-attempt jobs, and the exact combined-report artifact. Multiple open tracker markers fail closed rather than creating another issue.
- Preserve the last failure evidence when a green scheduled run records recovery and closes the issue.
- Classify tracker changes as tools-only unit impact and select the tracker plus workflow contract tests explicitly, so future edits cannot fall through the generic `no_impact` rule.

## Validation

- `env -u GITHUB_TOKEN -u GH_TOKEN PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/tools/test_nightly_issue_tracker.py tests/tools/test_github_actions_ci.py -q -p no:cacheprovider`: 103 passed; all API behavior used in-memory fakes.
- `env -u GITHUB_TOKEN -u GH_TOKEN PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/tools/test_model_ci.py -q -p no:cacheprovider`: 61 passed.
- Exact CI image, network disabled, read-only source, and no GitHub credentials: `tests/tools/test_test_impact.py`, `tests/tools/test_nightly_issue_tracker.py`, and `tests/tools/test_github_actions_ci.py`: 336 passed.
- `python3 tools/test_impact.py --validate`: passed for 200 models, 12 core models, and 77 families.
- `ruff check --config ruff.toml` on all five changed Python files: passed.
- `python3 tools/legal_headers.py --check`: 0 findings.
- Parsed `.github/workflows/nightly.yml` with PyYAML and verified the `nightly-issue` job exists: passed.
- `git diff github/main...HEAD --check`: passed.
- No test received a GitHub token, and no issue was created, updated, closed, or commented on during validation.

## Notes For Future Readers

- Review `.github/workflows/nightly.yml` first, then `tools/nightly_issue_tracker.py`, then the state-machine tests.
- Because this is a stage in the same workflow, it cannot report a workflow file that fails to parse or a run that is forcibly cancelled before the stage starts. Covering those cases would require a separate default-branch `workflow_run` watcher.
- The tracker body is automation-owned. If multiple open issues contain the tracker marker, the job fails visibly and requires a human to choose the canonical issue; it will not create another duplicate.
