### PR TITLE
perf(sana-wm): enable TensorRT tactic search

### DIFF
--- a/python/tensorrt_model_connect/families/sana_wm/refiner_dit_builder.py
+++ b/python/tensorrt_model_connect/families/sana_wm/refiner_dit_builder.py
@@ -444,8 +444,6 @@ def build_sana_wm_refiner_dit_engine(
     builder = trt_module.Builder(logger)
     config = builder.create_builder_config()
     config.set_memory_pool_limit(trt_module.MemoryPoolType.WORKSPACE, 64 << 30)
-    if hasattr(config, "builder_optimization_level"):
-        config.builder_optimization_level = 0
 
     network = builder.create_network(
         1 << int(trt_module.NetworkDefinitionCreationFlag.STRONGLY_TYPED)

--- a/python/tensorrt_model_connect/families/sana_wm/refiner_text_connector_builder.py
+++ b/python/tensorrt_model_connect/families/sana_wm/refiner_text_connector_builder.py
@@ -220,8 +220,6 @@ def build_sana_wm_refiner_text_connector_engine(
     builder = trt_module.Builder(logger)
     config = builder.create_builder_config()
     config.set_memory_pool_limit(trt_module.MemoryPoolType.WORKSPACE, 16 << 30)
-    if hasattr(config, "builder_optimization_level"):
-        config.builder_optimization_level = 0
 
     network = builder.create_network(
         1 << int(trt_module.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
@@ -506,8 +504,6 @@ def _build_exact_sana_wm_refiner_text_connector_engine(
     builder = trt_module.Builder(logger)
     config = builder.create_builder_config()
     config.set_memory_pool_limit(trt_module.MemoryPoolType.WORKSPACE, 16 << 30)
-    if hasattr(config, "builder_optimization_level"):
-        config.builder_optimization_level = 0
     network = builder.create_network(
         1 << int(trt_module.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
     )

--- a/python/tensorrt_model_connect/families/sana_wm/stage1_dit_builder.py
+++ b/python/tensorrt_model_connect/families/sana_wm/stage1_dit_builder.py
@@ -9632,15 +9632,6 @@ def build_sana_wm_stage1_dit_engine(
     builder = trt.Builder(logger)
     builder_config = builder.create_builder_config()
     builder_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 64 << 30)
-    if hasattr(builder_config, "builder_optimization_level"):
-        builder_config.builder_optimization_level = 0
-    if hasattr(builder_config, "max_num_tactics"):
-        builder_config.max_num_tactics = 1
-    if hasattr(builder_config, "tiling_optimization_level") and hasattr(
-        trt,
-        "TilingOptimizationLevel",
-    ):
-        builder_config.tiling_optimization_level = trt.TilingOptimizationLevel.NONE
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
     shape = stage1_shape_from_config(raw_config, weights)
     dtype = _target_np_dtype(precision)

--- a/tests/builder/test_sana_wm_builder_performance_contract.py
+++ b/tests/builder/test_sana_wm_builder_performance_contract.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static performance contracts for the SANA-WM TensorRT builders."""
+
+from pathlib import Path
+
+import pytest
+
+
+FAMILY_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "python"
+    / "tensorrt_model_connect"
+    / "families"
+    / "sana_wm"
+)
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "stage1_dit_builder.py",
+        "refiner_dit_builder.py",
+        "refiner_text_connector_builder.py",
+    ],
+)
+def test_production_builders_do_not_suppress_tensorrt_search(relative_path: str) -> None:
+    source = (FAMILY_DIR / relative_path).read_text(encoding="utf-8")
+
+    forbidden_assignments = (
+        "builder_optimization_level = 0",
+        "max_num_tactics = 1",
+        "tiling_optimization_level = trt.TilingOptimizationLevel.NONE",
+    )
+    for assignment in forbidden_assignments:
+        assert assignment not in source


### PR DESCRIPTION
## Background

SANA-WM production builders forced TensorRT optimization level 0. The Stage-1 builder also limited tactic search to one candidate and disabled tiling optimization, even though Stage-1 accounts for most complete-task latency.

This PR closes #502.

## Exit Criteria

- Let normal production builds use TensorRT's representative optimization, tactic, and tiling search.
- Preserve the exact BF16 model, workload, output contract, and task-eval gates.
- Compare build cost, plan size, Stage-1 execution, complete-task latency, and output quality before and after the change.

## Implementation

- Remove the forced optimization-level-zero setting from the Stage-1, refiner denoiser, and refiner text-connector builders.
- Remove the Stage-1 one-tactic cap and disabled tiling override.
- Add a source contract test that prevents production builders from silently reintroducing restricted search defaults.

## Performance And Accuracy

Single-GPU GB300 measurements use the same model revision, BF16 precision contract, prompt, image, action sequence, 60 denoising steps, seed, synchronization boundary, one warmup, and five timed complete tasks.

| Metric | Restricted search | Normal TensorRT search | Change |
| --- | ---: | ---: | ---: |
| Complete-task p50 | 184,172.98 ms | 152,212.25 ms | -17.35% (1.21x faster) |
| Stage-1 execution/request | 169,386.26 ms | 137,179.03 ms | -19.01% (1.23x faster) |
| Bundle build time | 821.12 s | 820.15 s | -0.12% |
| Bundle size | 85.298 GB | 85.312 GB | +0.016% |
| Peak device memory | 191,660 MiB | 189,005 MiB | -1.39% (-2,655 MiB) |

Peak device memory was sampled every 200 ms over one complete warmup and one timed task for each bundle; latency statistics use the five timed tasks described above.

- Output quality: exact match. Both runs produced the same output hash, pixel count, dimensions, mean, and standard deviation; all samples were finite and nonconstant.
- Artifact identity: bundle SHA-256 changed from `57ef73c0478b5a8d6b982c7b399b1e1c779581938a3d36c07456a190443b5035` to `0ee809c43ce1f6075c5144ceda9e962a17ca2c7ea7d40ff3c379bbbfdbf3ec99`.
- Repository task evaluation: passed the full model-owned 321-frame, 60-step external-reference workflow.

## Validation

- `python3 tools/legal_headers.py --check`: passed with no findings.
- `ruff check --config ruff.toml <changed Python files>`: passed.
- `PYTHONPATH=python python3 -m pytest tests/builder/test_sana_wm_builder_performance_contract.py tests/e2e/models/sana_wm --ignore=tests/e2e/models/sana_wm/test_sana_wm_e2e.py tests/tools/test_model_plugin_encapsulation_static.py -q -p no:cacheprovider`: passed.
- Full optimized bundle build and aligned target-GPU benchmark: passed.
- Repository task evaluation: passed (`1 passed`).

## Notes For Future Readers

- This removes non-representative default restrictions; it does not add a new optimization policy or change model precision.
- If a fast-build mode is needed later, expose it explicitly instead of applying it to performance artifacts.
- Review the Stage-1 builder first, then the two refiner builders, and finally the source contract test.
