### PR TITLE
perf(elf): keep flow sampling on device

### DIFF
--- a/src/runtime/models/elf_flow/MODEL.toml
+++ b/src/runtime/models/elf_flow/MODEL.toml
@@ -7,5 +7,6 @@ runtime_plugins = ["plugin.cpp|register_elf_flow_plugin"]
 runtime_strategies = ["elf_flow"]
 runtime_tests = [
   "test_elf_flow_pipeline|test_elf_flow_pipeline.cpp|trtmc_model_elf_flow|_|_",
+  "test_elf_flow_sampling_kernels|test_elf_flow_sampling_kernels.cpp|trtmc_model_elf_flow|_|REQUIRES_TRT",
 ]
 task_strategy = "diffusion_text_generation"

--- a/src/runtime/models/elf_flow/pipeline.cpp
+++ b/src/runtime/models/elf_flow/pipeline.cpp
@@ -5,7 +5,10 @@
 
 #include "runtime/models/elf_flow/pipeline.h"
 
+#include "runtime/models/elf_flow/sampling_kernels.h"
+
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <cstring>
@@ -130,7 +133,76 @@ float resolve_nonnegative_float(float value, float fallback) {
     return fallback;
 }
 
+void check_cuda(cudaError_t error, const char* operation) {
+    if (error == cudaSuccess)
+        return;
+    throw std::runtime_error(std::string("ElfFlowPipeline: ") + operation +
+                             " failed: " + cudaGetErrorString(error));
+}
+
 } // namespace
+
+struct ElfFlowPipeline::DeviceSamplingWorkspace {
+    DeviceSamplingWorkspace(int32_t max_length, int32_t input_dim, int32_t text_dim,
+                            cudaStream_t stream_value)
+        : stream(stream_value), z({max_length, text_dim}, DType::kFloat32, stream),
+          self_condition({max_length, text_dim}, DType::kFloat32, stream),
+          z_eval({max_length, text_dim}, DType::kFloat32, stream),
+          condition({max_length, text_dim}, DType::kFloat32, stream),
+          condition_mask({max_length}, DType::kFloat32, stream),
+          model_latent({max_length, input_dim}, DType::kFloat32, stream),
+          timestep({1}, DType::kFloat32, stream), decoder_mode({1}, DType::kFloat32, stream),
+          self_cond_cfg_scale({1}, DType::kFloat32, stream),
+          conditional_denoised({max_length, text_dim}, DType::kFloat32, stream),
+          token_ids({max_length}, DType::kInt32, stream) {}
+
+    bool ok() const {
+        const std::array<const DeviceTensor*, 11> required = {
+            &z,
+            &self_condition,
+            &z_eval,
+            &condition,
+            &condition_mask,
+            &model_latent,
+            &timestep,
+            &decoder_mode,
+            &self_cond_cfg_scale,
+            &conditional_denoised,
+            &token_ids,
+        };
+        return std::all_of(required.begin(), required.end(),
+                           [](const DeviceTensor* tensor) { return tensor->ok(); });
+    }
+
+    void ensure_sde_noises(std::size_t numel) {
+        if (numel == sde_noise_numel)
+            return;
+        sde_noises = numel == 0
+                         ? DeviceTensor{}
+                         : DeviceTensor({static_cast<int64_t>(numel)}, DType::kFloat32, stream);
+        sde_noise_numel = numel;
+        if (numel > 0 && !sde_noises.ok())
+            throw std::runtime_error("ElfFlowPipeline: failed to allocate device SDE noise");
+    }
+
+    cudaStream_t stream{nullptr};
+    DeviceTensor z;
+    DeviceTensor self_condition;
+    DeviceTensor z_eval;
+    DeviceTensor condition;
+    DeviceTensor condition_mask;
+    DeviceTensor model_latent;
+    DeviceTensor timestep;
+    DeviceTensor decoder_mode;
+    DeviceTensor self_cond_cfg_scale;
+    DeviceTensor conditional_denoised;
+    DeviceTensor token_ids;
+    DeviceTensor sde_noises;
+    std::size_t sde_noise_numel{0};
+    float host_timestep{0.0F};
+    float host_decoder_mode{0.0F};
+    float host_self_cond_cfg_scale{1.0F};
+};
 
 ElfFlowPipeline::ElfFlowPipeline(std::unique_ptr<TrtModule> model, int32_t max_length,
                                  int32_t max_input_length, int32_t input_dim, int32_t text_dim,
@@ -151,6 +223,8 @@ ElfFlowPipeline::ElfFlowPipeline(std::unique_ptr<TrtModule> model, int32_t max_l
     configure_model_dimensions();
     configure_text_encoder();
 }
+
+ElfFlowPipeline::~ElfFlowPipeline() = default;
 
 void ElfFlowPipeline::configure_model_dimensions() {
     max_length_ = infer_static_dim(*model_, "latent", 0, max_length_);
@@ -697,6 +771,215 @@ void ElfFlowPipeline::run_sampling(SamplingWorkspace& workspace, const GenerateC
         run_final_step(workspace, cond, options, steps);
 }
 
+bool ElfFlowPipeline::supports_device_sampling() const {
+    if (!model_->has_input("latent") || !model_->has_input("timestep") ||
+        !model_->has_input("decoder_mode") || !model_->has_output("denoised") ||
+        !model_->has_output("decoder_logits")) {
+        return false;
+    }
+    if (model_->tensor_dtype("latent") != DType::kFloat32 ||
+        model_->tensor_dtype("denoised") != DType::kFloat32 ||
+        model_->tensor_dtype("decoder_logits") != DType::kFloat32) {
+        return false;
+    }
+    return model_->device_ptr("denoised") != nullptr &&
+           model_->device_ptr("decoder_logits") != nullptr;
+}
+
+ElfFlowPipeline::DeviceSamplingWorkspace&
+ElfFlowPipeline::prepare_device_sampling_workspace(const SamplingWorkspace& host_workspace,
+                                                   const ConditionState& cond,
+                                                   const std::vector<float>& sde_noises) {
+    if (!device_sampling_workspace_) {
+        device_sampling_workspace_ = std::make_unique<DeviceSamplingWorkspace>(
+            max_length_, input_dim_, text_dim_, model_->stream());
+    }
+    auto& workspace = *device_sampling_workspace_;
+    if (!workspace.ok())
+        throw std::runtime_error("ElfFlowPipeline: failed to allocate device sampling workspace");
+    workspace.ensure_sde_noises(sde_noises.size());
+
+    const bool copied = workspace.z.copy_from_host(host_workspace.z.data()) &&
+                        workspace.self_condition.copy_from_host(host_workspace.x_pred.data()) &&
+                        workspace.condition.copy_from_host(cond.latents.data()) &&
+                        workspace.condition_mask.copy_from_host(cond.mask.data());
+    if (!copied)
+        throw std::runtime_error("ElfFlowPipeline: failed to upload device sampling inputs");
+    if (!sde_noises.empty() && !workspace.sde_noises.copy_from_host(sde_noises.data()))
+        throw std::runtime_error("ElfFlowPipeline: failed to upload device SDE noise");
+    return workspace;
+}
+
+std::vector<float> ElfFlowPipeline::make_device_sde_noises(const GenerateConfig& cfg,
+                                                           const SamplingOptions& options,
+                                                           const std::vector<float>& steps) const {
+    if (options.sde_gamma <= 0.0F || steps.size() <= 2U)
+        return {};
+    if (!cfg.sde_noises.empty())
+        return cfg.sde_noises;
+
+    const std::size_t latent_numel =
+        static_cast<std::size_t>(max_length_) * static_cast<std::size_t>(text_dim_);
+    const std::size_t step_count = steps.size() - 2U;
+    std::vector<float> noises(step_count * latent_numel);
+    std::mt19937 rng(normalize_seed(options.seed) ^ 0x85EBCA6BU);
+    std::normal_distribution<float> normal(0.0F, denoiser_noise_scale_);
+    for (float& value : noises)
+        value = normal(rng);
+    return noises;
+}
+
+void ElfFlowPipeline::enqueue_device_forward(DeviceSamplingWorkspace& workspace, float timestep,
+                                             float self_cond_cfg_scale, bool decoder_mode,
+                                             bool zero_condition, bool zero_self_condition) {
+    elf_prepare_model_latent(static_cast<float*>(workspace.model_latent.data()),
+                             static_cast<const float*>(workspace.z_eval.data()),
+                             static_cast<const float*>(workspace.self_condition.data()),
+                             static_cast<const float*>(workspace.condition_mask.data()),
+                             max_length_, text_dim_, input_dim_, zero_condition,
+                             zero_self_condition, workspace.stream);
+    check_cuda(cudaGetLastError(), "prepare model latent kernel");
+
+    workspace.host_timestep = timestep;
+    workspace.host_decoder_mode = decoder_mode ? 1.0F : 0.0F;
+    workspace.host_self_cond_cfg_scale = self_cond_cfg_scale;
+    const bool copied =
+        workspace.timestep.copy_from_host(&workspace.host_timestep) &&
+        workspace.decoder_mode.copy_from_host(&workspace.host_decoder_mode) &&
+        workspace.self_cond_cfg_scale.copy_from_host(&workspace.host_self_cond_cfg_scale);
+    if (!copied)
+        throw std::runtime_error("ElfFlowPipeline: failed to upload engine scalar inputs");
+
+    DeviceTensorMap inputs;
+    inputs["latent"] = &workspace.model_latent;
+    inputs["timestep"] = &workspace.timestep;
+    inputs["decoder_mode"] = &workspace.decoder_mode;
+    if (model_->has_input("self_cond_cfg_scale"))
+        inputs["self_cond_cfg_scale"] = &workspace.self_cond_cfg_scale;
+    model_->forward_device_async(inputs);
+}
+
+void ElfFlowPipeline::run_device_denoise_step(DeviceSamplingWorkspace& workspace,
+                                              const SamplingOptions& options, float timestep,
+                                              float next_timestep) {
+    enqueue_device_forward(workspace, timestep, options.self_cond_cfg_scale, false, false, false);
+    const auto* denoised = static_cast<const float*>(model_->device_ptr("denoised"));
+    if (options.cfg_scale == 1.0F) {
+        elf_update_latent(static_cast<float*>(workspace.z.data()),
+                          static_cast<float*>(workspace.self_condition.data()),
+                          static_cast<const float*>(workspace.z_eval.data()), denoised,
+                          static_cast<const float*>(workspace.condition.data()),
+                          static_cast<const float*>(workspace.condition_mask.data()), timestep,
+                          next_timestep, t_eps_, max_length_, text_dim_, workspace.stream);
+        check_cuda(cudaGetLastError(), "update latent kernel");
+        return;
+    }
+
+    check_cuda(cudaMemcpyAsync(workspace.conditional_denoised.data(), denoised,
+                               workspace.conditional_denoised.nbytes(), cudaMemcpyDeviceToDevice,
+                               workspace.stream),
+               "preserve conditional denoiser output");
+    enqueue_device_forward(workspace, timestep, options.self_cond_cfg_scale, false, true, false);
+    const auto* unconditional = static_cast<const float*>(model_->device_ptr("denoised"));
+    elf_update_latent_cfg(static_cast<float*>(workspace.z.data()),
+                          static_cast<float*>(workspace.self_condition.data()),
+                          static_cast<const float*>(workspace.z_eval.data()),
+                          static_cast<const float*>(workspace.conditional_denoised.data()),
+                          unconditional, static_cast<const float*>(workspace.condition.data()),
+                          static_cast<const float*>(workspace.condition_mask.data()),
+                          options.cfg_scale, timestep, next_timestep, t_eps_, max_length_,
+                          text_dim_, workspace.stream);
+    check_cuda(cudaGetLastError(), "update CFG latent kernel");
+}
+
+void ElfFlowPipeline::run_device_sampling(DeviceSamplingWorkspace& workspace,
+                                          const SamplingOptions& options,
+                                          const std::vector<float>& steps) {
+    const std::size_t latent_numel =
+        static_cast<std::size_t>(max_length_) * static_cast<std::size_t>(text_dim_);
+    for (std::size_t i = 0; i + 2U < steps.size(); ++i) {
+        const float timestep = steps[i];
+        const float next_timestep = steps[i + 1U];
+        float evaluation_timestep = timestep;
+        if (options.sde_gamma > 0.0F) {
+            const float alpha =
+                std::clamp(1.0F - options.sde_gamma * (next_timestep - timestep), 0.0F, 1.0F);
+            evaluation_timestep = alpha * timestep;
+            const auto* noise = static_cast<const float*>(workspace.sde_noises.data()) +
+                                static_cast<std::ptrdiff_t>(i * latent_numel);
+            elf_prepare_sde_latent(static_cast<float*>(workspace.z_eval.data()),
+                                   static_cast<const float*>(workspace.z.data()), noise,
+                                   static_cast<const float*>(workspace.condition.data()),
+                                   static_cast<const float*>(workspace.condition_mask.data()),
+                                   alpha, max_length_, text_dim_, workspace.stream);
+            check_cuda(cudaGetLastError(), "prepare SDE latent kernel");
+        } else if (!workspace.z_eval.copy_from(workspace.z)) {
+            throw std::runtime_error("ElfFlowPipeline: failed to stage device latent");
+        }
+        run_device_denoise_step(workspace, options, evaluation_timestep, next_timestep);
+    }
+
+    if (steps.size() < 2U)
+        return;
+    if (!workspace.z_eval.copy_from(workspace.z))
+        throw std::runtime_error("ElfFlowPipeline: failed to stage final device latent");
+    run_device_denoise_step(workspace, options, steps[steps.size() - 2U], steps.back());
+}
+
+std::vector<int32_t> ElfFlowPipeline::decode_device_tokens(DeviceSamplingWorkspace& workspace,
+                                                           const SamplingOptions& options,
+                                                           int32_t eos_token_id,
+                                                           int32_t prefix_tokens_to_drop,
+                                                           int32_t max_output_tokens) {
+    if (!workspace.z_eval.copy_from(workspace.z))
+        throw std::runtime_error("ElfFlowPipeline: failed to stage decoder latent");
+    enqueue_device_forward(workspace, 1.0F, options.self_cond_cfg_scale, true, false, true);
+
+    const int32_t start = std::max(0, std::min(prefix_tokens_to_drop, max_length_));
+    const int32_t limit =
+        max_output_tokens > 0 ? std::min(max_length_, start + max_output_tokens) : max_length_;
+    const int32_t row_count = limit - start;
+    if (row_count <= 0)
+        return {};
+
+    const auto* logits = static_cast<const float*>(model_->device_ptr("decoder_logits"));
+    elf_argmax_rows(logits, vocab_size_, start, row_count,
+                    static_cast<int32_t*>(workspace.token_ids.data()), workspace.stream);
+    check_cuda(cudaGetLastError(), "decoder argmax kernel");
+
+    std::vector<int32_t> all_token_ids(static_cast<std::size_t>(row_count));
+    check_cuda(cudaMemcpyAsync(all_token_ids.data(), workspace.token_ids.data(),
+                               all_token_ids.size() * sizeof(int32_t), cudaMemcpyDeviceToHost,
+                               workspace.stream),
+               "download selected token IDs");
+    check_cuda(cudaStreamSynchronize(workspace.stream), "synchronize final decoder");
+
+    std::vector<int32_t> token_ids;
+    token_ids.reserve(all_token_ids.size());
+    for (int32_t token_id : all_token_ids) {
+        if (eos_token_id >= 0 && token_id == eos_token_id)
+            break;
+        token_ids.push_back(token_id);
+    }
+    return token_ids;
+}
+
+TextResult ElfFlowPipeline::make_device_text_result(DeviceSamplingWorkspace& workspace,
+                                                    const GenerateConfig& cfg,
+                                                    const SamplingOptions& options,
+                                                    bool has_condition, int32_t eos_token_id,
+                                                    int32_t cond_prefix_len, double sampling_ms) {
+    const auto decode_start = std::chrono::steady_clock::now();
+    TextResult result;
+    result.token_ids = decode_device_tokens(workspace, options, eos_token_id, cond_prefix_len,
+                                            resolve_max_output_tokens(cfg, has_condition));
+    result.text = tokenizer_->decode(result.token_ids);
+    const auto decode_end = std::chrono::steady_clock::now();
+    result.prefill_ms = sampling_ms;
+    result.decode_ms = std::chrono::duration<double, std::milli>(decode_end - decode_start).count();
+    return result;
+}
+
 TextResult ElfFlowPipeline::make_text_result(const SamplingWorkspace& workspace,
                                              const GenerateConfig& cfg,
                                              const SamplingOptions& options, bool has_condition,
@@ -724,6 +1007,18 @@ TextResult ElfFlowPipeline::generate(const std::string& prompt, const GenerateCo
     const auto options = resolve_sampling_options(cfg, has_condition);
     auto workspace = make_sampling_workspace(cfg, cond, options.seed);
     const auto steps = make_sampling_steps(cfg, options.num_steps, options.seed);
+    if (supports_device_sampling()) {
+        validate_sde_noises(cfg, steps);
+        const auto sde_noises = make_device_sde_noises(cfg, options, steps);
+        auto& device_workspace = prepare_device_sampling_workspace(workspace, cond, sde_noises);
+        run_device_sampling(device_workspace, options, steps);
+        check_cuda(cudaStreamSynchronize(device_workspace.stream), "synchronize flow sampling");
+        const auto sampling_end = std::chrono::steady_clock::now();
+        const double sampling_ms =
+            std::chrono::duration<double, std::milli>(sampling_end - t_start).count();
+        return make_device_text_result(device_workspace, cfg, options, has_condition, eos_token_id,
+                                       condition_prefix_tokens(cond.mask), sampling_ms);
+    }
     run_sampling(workspace, cfg, cond, options, steps);
     auto t_after_sampling = std::chrono::steady_clock::now();
     const double sampling_ms =

--- a/src/runtime/models/elf_flow/pipeline.h
+++ b/src/runtime/models/elf_flow/pipeline.h
@@ -28,6 +28,7 @@ class ElfFlowPipeline final : public IPipeline {
                     std::string model_id_str = "",
                     std::unique_ptr<TrtModule> text_encoder = nullptr, float latent_mean = 0.0F,
                     float latent_std = 1.0F, int32_t encoder_pad_token_id = 0);
+    ~ElfFlowPipeline() override;
 
     TextResult generate(const std::string& prompt, const GenerateConfig& cfg = {}) override;
     int32_t default_max_new_tokens() const override { return 0; }
@@ -75,6 +76,7 @@ class ElfFlowPipeline final : public IPipeline {
         std::vector<float> z;
         std::vector<float> x_pred;
     };
+    struct DeviceSamplingWorkspace;
 
     static const Tensor* select_output(const TensorMap& outputs, bool decoder_mode);
     static std::vector<float> copy_tensor_data(const Tensor& tensor);
@@ -130,6 +132,29 @@ class ElfFlowPipeline final : public IPipeline {
     void run_sampling(SamplingWorkspace& workspace, const GenerateConfig& cfg,
                       const ConditionState& cond, const SamplingOptions& options,
                       const std::vector<float>& steps);
+    bool supports_device_sampling() const;
+    DeviceSamplingWorkspace&
+    prepare_device_sampling_workspace(const SamplingWorkspace& host_workspace,
+                                      const ConditionState& cond,
+                                      const std::vector<float>& sde_noises);
+    std::vector<float> make_device_sde_noises(const GenerateConfig& cfg,
+                                              const SamplingOptions& options,
+                                              const std::vector<float>& steps) const;
+    void enqueue_device_forward(DeviceSamplingWorkspace& workspace, float timestep,
+                                float self_cond_cfg_scale, bool decoder_mode, bool zero_condition,
+                                bool zero_self_condition);
+    void run_device_denoise_step(DeviceSamplingWorkspace& workspace, const SamplingOptions& options,
+                                 float timestep, float next_timestep);
+    void run_device_sampling(DeviceSamplingWorkspace& workspace, const SamplingOptions& options,
+                             const std::vector<float>& steps);
+    std::vector<int32_t> decode_device_tokens(DeviceSamplingWorkspace& workspace,
+                                              const SamplingOptions& options, int32_t eos_token_id,
+                                              int32_t prefix_tokens_to_drop,
+                                              int32_t max_output_tokens);
+    TextResult make_device_text_result(DeviceSamplingWorkspace& workspace,
+                                       const GenerateConfig& cfg, const SamplingOptions& options,
+                                       bool has_condition, int32_t eos_token_id,
+                                       int32_t cond_prefix_len, double sampling_ms);
     TextResult make_text_result(const SamplingWorkspace& workspace, const GenerateConfig& cfg,
                                 const SamplingOptions& options, bool has_condition,
                                 int32_t eos_token_id, int32_t cond_prefix_len, double sampling_ms);
@@ -158,6 +183,7 @@ class ElfFlowPipeline final : public IPipeline {
     int32_t encoder_pad_token_id_{0};
     std::shared_ptr<ITokenizer> tokenizer_;
     std::string model_id_;
+    std::unique_ptr<DeviceSamplingWorkspace> device_sampling_workspace_;
 };
 
 } // namespace trtmc

--- a/src/runtime/models/elf_flow/sampling_kernels.cu
+++ b/src/runtime/models/elf_flow/sampling_kernels.cu
@@ -1,0 +1,215 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/elf_flow/sampling_kernels.h"
+
+#include <cfloat>
+#include <climits>
+#include <cuda_runtime.h>
+
+namespace trtmc {
+
+namespace {
+
+constexpr int32_t kBlockSize = 256;
+
+__device__ bool candidate_is_better(float lhs_value, int32_t lhs_index, float rhs_value,
+                                    int32_t rhs_index) {
+    return lhs_value > rhs_value || (lhs_value == rhs_value && lhs_index < rhs_index);
+}
+
+__device__ void find_row_candidate(const float* row, int32_t vocab_size, int32_t thread,
+                                   float& best_value, int32_t& best_index) {
+    best_value = -FLT_MAX;
+    best_index = INT_MAX;
+    for (int32_t index = thread; index < vocab_size; index += kBlockSize) {
+        const float value = row[index];
+        if (candidate_is_better(value, index, best_value, best_index)) {
+            best_value = value;
+            best_index = index;
+        }
+    }
+}
+
+__device__ void reduce_row_candidates(float* values, int32_t* indices, int32_t thread) {
+    for (int32_t stride = kBlockSize / 2; stride > 0; stride >>= 1) {
+        if (thread < stride &&
+            candidate_is_better(values[thread + stride], indices[thread + stride], values[thread],
+                                indices[thread])) {
+            values[thread] = values[thread + stride];
+            indices[thread] = indices[thread + stride];
+        }
+        __syncthreads();
+    }
+}
+
+__global__ void prepare_model_latent_kernel(float* model_latent, const float* z,
+                                            const float* self_condition,
+                                            const float* condition_mask, int32_t numel,
+                                            int32_t text_dim, int32_t input_dim,
+                                            bool zero_condition, bool zero_self_condition) {
+    const int32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index >= numel)
+        return;
+
+    const int32_t row = index / text_dim;
+    const int32_t column = index - row * text_dim;
+    const bool masked = zero_condition && condition_mask[row] > 0.0F;
+    const int32_t output_base = row * input_dim + column;
+    model_latent[output_base] = masked ? 0.0F : z[index];
+    if (input_dim == 2 * text_dim) {
+        const float value = zero_self_condition || masked ? 0.0F : self_condition[index];
+        model_latent[output_base + text_dim] = value;
+    }
+}
+
+__global__ void prepare_sde_latent_kernel(float* z_eval, const float* z, const float* noise,
+                                          const float* condition, const float* condition_mask,
+                                          float alpha, int32_t numel, int32_t text_dim) {
+    const int32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index >= numel)
+        return;
+
+    const int32_t row = index / text_dim;
+    if (condition_mask[row] > 0.0F) {
+        z_eval[index] = condition[index];
+        return;
+    }
+    z_eval[index] = alpha * z[index] + (1.0F - alpha) * noise[index];
+}
+
+__device__ float next_latent(float z_eval, float denoised, float timestep, float next_timestep,
+                             float timestep_epsilon) {
+    const float denominator = fmaxf(1.0F - timestep, timestep_epsilon);
+    const float velocity = (denoised - z_eval) / denominator;
+    return z_eval + (next_timestep - timestep) * velocity;
+}
+
+__global__ void update_latent_kernel(float* z, float* self_condition, const float* z_eval,
+                                     const float* denoised, const float* condition,
+                                     const float* condition_mask, float timestep,
+                                     float next_timestep, float timestep_epsilon, int32_t numel,
+                                     int32_t text_dim) {
+    const int32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index >= numel)
+        return;
+
+    const int32_t row = index / text_dim;
+    if (condition_mask[row] > 0.0F) {
+        z[index] = condition[index];
+        self_condition[index] = condition[index];
+        return;
+    }
+    const float x = denoised[index];
+    z[index] = next_latent(z_eval[index], x, timestep, next_timestep, timestep_epsilon);
+    self_condition[index] = x;
+}
+
+__global__ void update_latent_cfg_kernel(float* z, float* self_condition, const float* z_eval,
+                                         const float* conditional_denoised,
+                                         const float* unconditional_denoised,
+                                         const float* condition, const float* condition_mask,
+                                         float cfg_scale, float timestep, float next_timestep,
+                                         float timestep_epsilon, int32_t numel, int32_t text_dim) {
+    const int32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index >= numel)
+        return;
+
+    const int32_t row = index / text_dim;
+    if (condition_mask[row] > 0.0F) {
+        z[index] = condition[index];
+        self_condition[index] = condition[index];
+        return;
+    }
+    const float unconditional = unconditional_denoised[index];
+    const float x = unconditional + cfg_scale * (conditional_denoised[index] - unconditional);
+    z[index] = next_latent(z_eval[index], x, timestep, next_timestep, timestep_epsilon);
+    self_condition[index] = x;
+}
+
+__global__ void argmax_rows_kernel(const float* logits, int32_t vocab_size, int32_t start_row,
+                                   int32_t* token_ids) {
+    __shared__ float values[kBlockSize];
+    __shared__ int32_t indices[kBlockSize];
+
+    const int32_t thread = threadIdx.x;
+    const float* row = logits + static_cast<int64_t>(start_row + blockIdx.x) * vocab_size;
+    float best_value;
+    int32_t best_index;
+    find_row_candidate(row, vocab_size, thread, best_value, best_index);
+    values[thread] = best_value;
+    indices[thread] = best_index;
+    __syncthreads();
+    reduce_row_candidates(values, indices, thread);
+    if (thread == 0)
+        token_ids[blockIdx.x] = indices[0];
+}
+
+int32_t block_count(int32_t numel) {
+    return (numel + kBlockSize - 1) / kBlockSize;
+}
+
+} // namespace
+
+void elf_prepare_model_latent(float* model_latent, const float* z, const float* self_condition,
+                              const float* condition_mask, int32_t max_length, int32_t text_dim,
+                              int32_t input_dim, bool zero_condition, bool zero_self_condition,
+                              cudaStream_t stream) {
+    const int32_t numel = max_length * text_dim;
+    if (!model_latent || !z || !self_condition || !condition_mask || numel <= 0)
+        return;
+    prepare_model_latent_kernel<<<block_count(numel), kBlockSize, 0, stream>>>(
+        model_latent, z, self_condition, condition_mask, numel, text_dim, input_dim, zero_condition,
+        zero_self_condition);
+}
+
+void elf_prepare_sde_latent(float* z_eval, const float* z, const float* noise,
+                            const float* condition, const float* condition_mask, float alpha,
+                            int32_t max_length, int32_t text_dim, cudaStream_t stream) {
+    const int32_t numel = max_length * text_dim;
+    if (!z_eval || !z || !noise || !condition || !condition_mask || numel <= 0)
+        return;
+    prepare_sde_latent_kernel<<<block_count(numel), kBlockSize, 0, stream>>>(
+        z_eval, z, noise, condition, condition_mask, alpha, numel, text_dim);
+}
+
+void elf_update_latent(float* z, float* self_condition, const float* z_eval, const float* denoised,
+                       const float* condition, const float* condition_mask, float timestep,
+                       float next_timestep, float timestep_epsilon, int32_t max_length,
+                       int32_t text_dim, cudaStream_t stream) {
+    const int32_t numel = max_length * text_dim;
+    if (!z || !self_condition || !z_eval || !denoised || !condition || !condition_mask ||
+        numel <= 0) {
+        return;
+    }
+    update_latent_kernel<<<block_count(numel), kBlockSize, 0, stream>>>(
+        z, self_condition, z_eval, denoised, condition, condition_mask, timestep, next_timestep,
+        timestep_epsilon, numel, text_dim);
+}
+
+void elf_update_latent_cfg(float* z, float* self_condition, const float* z_eval,
+                           const float* conditional_denoised, const float* unconditional_denoised,
+                           const float* condition, const float* condition_mask, float cfg_scale,
+                           float timestep, float next_timestep, float timestep_epsilon,
+                           int32_t max_length, int32_t text_dim, cudaStream_t stream) {
+    const int32_t numel = max_length * text_dim;
+    if (!z || !self_condition || !z_eval || !conditional_denoised || !unconditional_denoised ||
+        !condition || !condition_mask || numel <= 0) {
+        return;
+    }
+    update_latent_cfg_kernel<<<block_count(numel), kBlockSize, 0, stream>>>(
+        z, self_condition, z_eval, conditional_denoised, unconditional_denoised, condition,
+        condition_mask, cfg_scale, timestep, next_timestep, timestep_epsilon, numel, text_dim);
+}
+
+void elf_argmax_rows(const float* logits, int32_t vocab_size, int32_t start_row, int32_t row_count,
+                     int32_t* token_ids, cudaStream_t stream) {
+    if (!logits || !token_ids || vocab_size <= 0 || row_count <= 0)
+        return;
+    argmax_rows_kernel<<<row_count, kBlockSize, 0, stream>>>(logits, vocab_size, start_row,
+                                                             token_ids);
+}
+
+} // namespace trtmc

--- a/src/runtime/models/elf_flow/sampling_kernels.h
+++ b/src/runtime/models/elf_flow/sampling_kernels.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cuda_runtime_api.h>
+
+namespace trtmc {
+
+void elf_prepare_model_latent(float* model_latent, const float* z, const float* self_condition,
+                              const float* condition_mask, int32_t max_length, int32_t text_dim,
+                              int32_t input_dim, bool zero_condition, bool zero_self_condition,
+                              cudaStream_t stream);
+
+void elf_prepare_sde_latent(float* z_eval, const float* z, const float* noise,
+                            const float* condition, const float* condition_mask, float alpha,
+                            int32_t max_length, int32_t text_dim, cudaStream_t stream);
+
+void elf_update_latent(float* z, float* self_condition, const float* z_eval, const float* denoised,
+                       const float* condition, const float* condition_mask, float timestep,
+                       float next_timestep, float timestep_epsilon, int32_t max_length,
+                       int32_t text_dim, cudaStream_t stream);
+
+void elf_update_latent_cfg(float* z, float* self_condition, const float* z_eval,
+                           const float* conditional_denoised, const float* unconditional_denoised,
+                           const float* condition, const float* condition_mask, float cfg_scale,
+                           float timestep, float next_timestep, float timestep_epsilon,
+                           int32_t max_length, int32_t text_dim, cudaStream_t stream);
+
+void elf_argmax_rows(const float* logits, int32_t vocab_size, int32_t start_row, int32_t row_count,
+                     int32_t* token_ids, cudaStream_t stream);
+
+} // namespace trtmc

--- a/tests/cpp/models/elf_flow/test_elf_flow_sampling_kernels.cpp
+++ b/tests/cpp/models/elf_flow/test_elf_flow_sampling_kernels.cpp
@@ -1,0 +1,144 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/elf_flow/sampling_kernels.h"
+#include "trtmc/runtime/device_tensor.h"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& name) {
+    if (condition)
+        return;
+    std::cerr << "FAIL: " << name << '\n';
+    ++g_failures;
+}
+
+void check_cuda(cudaError_t error, const std::string& operation) {
+    check(error == cudaSuccess, operation + ": " + cudaGetErrorString(error));
+}
+
+void check_close(const std::vector<float>& actual, const std::vector<float>& expected,
+                 const std::string& name) {
+    check(actual.size() == expected.size(), name + " size");
+    if (actual.size() != expected.size())
+        return;
+    for (std::size_t i = 0; i < actual.size(); ++i) {
+        if (std::fabs(actual[i] - expected[i]) <= 1e-6F)
+            continue;
+        check(false, name + " value " + std::to_string(i));
+    }
+}
+
+trtmc::DeviceTensor upload(const std::vector<float>& values, cudaStream_t stream) {
+    trtmc::DeviceTensor tensor({static_cast<int64_t>(values.size())}, trtmc::DType::kFloat32,
+                               stream);
+    check(tensor.ok(), "allocate float tensor");
+    check(tensor.copy_from_host(values.data()), "upload float tensor");
+    return tensor;
+}
+
+std::vector<float> download(const trtmc::DeviceTensor& tensor) {
+    std::vector<float> values(static_cast<std::size_t>(tensor.numel()));
+    check(tensor.copy_to_host(values.data()), "download float tensor");
+    return values;
+}
+
+void test_prepare_model_latent(cudaStream_t stream) {
+    auto z = upload({1.0F, 2.0F, 3.0F, 4.0F}, stream);
+    auto self_condition = upload({5.0F, 6.0F, 7.0F, 8.0F}, stream);
+    auto mask = upload({1.0F, 0.0F}, stream);
+    trtmc::DeviceTensor output({8}, trtmc::DType::kFloat32, stream);
+
+    trtmc::elf_prepare_model_latent(
+        static_cast<float*>(output.data()), static_cast<const float*>(z.data()),
+        static_cast<const float*>(self_condition.data()), static_cast<const float*>(mask.data()), 2,
+        2, 4, true, false, stream);
+    check_cuda(cudaStreamSynchronize(stream), "synchronize conditional input");
+    check_close(download(output), {0.0F, 0.0F, 0.0F, 0.0F, 3.0F, 4.0F, 7.0F, 8.0F},
+                "zero condition prefix");
+
+    trtmc::elf_prepare_model_latent(
+        static_cast<float*>(output.data()), static_cast<const float*>(z.data()),
+        static_cast<const float*>(self_condition.data()), static_cast<const float*>(mask.data()), 2,
+        2, 4, false, true, stream);
+    check_cuda(cudaStreamSynchronize(stream), "synchronize decoder input");
+    check_close(download(output), {1.0F, 2.0F, 0.0F, 0.0F, 3.0F, 4.0F, 0.0F, 0.0F},
+                "zero decoder self condition");
+}
+
+void test_sde_and_scheduler_updates(cudaStream_t stream) {
+    auto z = upload({1.0F, 2.0F, 3.0F, 4.0F}, stream);
+    auto noise = upload({5.0F, 6.0F, 7.0F, 8.0F}, stream);
+    auto condition = upload({9.0F, 8.0F, 0.0F, 0.0F}, stream);
+    auto mask = upload({1.0F, 0.0F}, stream);
+    trtmc::DeviceTensor z_eval({4}, trtmc::DType::kFloat32, stream);
+
+    trtmc::elf_prepare_sde_latent(
+        static_cast<float*>(z_eval.data()), static_cast<const float*>(z.data()),
+        static_cast<const float*>(noise.data()), static_cast<const float*>(condition.data()),
+        static_cast<const float*>(mask.data()), 0.5F, 2, 2, stream);
+    check_cuda(cudaStreamSynchronize(stream), "synchronize SDE latent");
+    check_close(download(z_eval), {9.0F, 8.0F, 5.0F, 6.0F}, "SDE latent");
+
+    auto denoised = upload({100.0F, 100.0F, 7.0F, 10.0F}, stream);
+    trtmc::DeviceTensor self_condition({4}, trtmc::DType::kFloat32, stream);
+    trtmc::elf_update_latent(
+        static_cast<float*>(z.data()), static_cast<float*>(self_condition.data()),
+        static_cast<const float*>(z_eval.data()), static_cast<const float*>(denoised.data()),
+        static_cast<const float*>(condition.data()), static_cast<const float*>(mask.data()), 0.0F,
+        0.5F, 0.05F, 2, 2, stream);
+    check_cuda(cudaStreamSynchronize(stream), "synchronize scheduler update");
+    check_close(download(z), {9.0F, 8.0F, 6.0F, 8.0F}, "scheduler latent");
+    check_close(download(self_condition), {9.0F, 8.0F, 7.0F, 10.0F}, "scheduler self condition");
+
+    auto conditional = upload({100.0F, 100.0F, 7.0F, 10.0F}, stream);
+    auto unconditional = upload({100.0F, 100.0F, 5.0F, 6.0F}, stream);
+    trtmc::elf_update_latent_cfg(
+        static_cast<float*>(z.data()), static_cast<float*>(self_condition.data()),
+        static_cast<const float*>(z_eval.data()), static_cast<const float*>(conditional.data()),
+        static_cast<const float*>(unconditional.data()),
+        static_cast<const float*>(condition.data()), static_cast<const float*>(mask.data()), 2.0F,
+        0.0F, 0.5F, 0.05F, 2, 2, stream);
+    check_cuda(cudaStreamSynchronize(stream), "synchronize CFG scheduler update");
+    check_close(download(z), {9.0F, 8.0F, 7.0F, 10.0F}, "CFG scheduler latent");
+    check_close(download(self_condition), {9.0F, 8.0F, 9.0F, 14.0F}, "CFG self condition");
+}
+
+void test_argmax_tie_break(cudaStream_t stream) {
+    auto logits = upload({0.0F, 5.0F, 5.0F, 1.0F, -1.0F, -2.0F, 3.0F, 0.0F}, stream);
+    trtmc::DeviceTensor token_ids({2}, trtmc::DType::kInt32, stream);
+    trtmc::elf_argmax_rows(static_cast<const float*>(logits.data()), 4, 0, 2,
+                           static_cast<int32_t*>(token_ids.data()), stream);
+    check_cuda(cudaStreamSynchronize(stream), "synchronize argmax");
+    std::vector<int32_t> actual(2);
+    check(token_ids.copy_to_host(actual.data()), "download argmax IDs");
+    check(actual == std::vector<int32_t>({1, 2}), "argmax preserves lowest-index tie break");
+}
+
+} // namespace
+
+int main() {
+    int32_t device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count <= 0) {
+        std::cout << "SKIP: CUDA device unavailable\n";
+        return 0;
+    }
+
+    cudaStream_t stream = nullptr;
+    check_cuda(cudaStreamCreate(&stream), "create stream");
+    test_prepare_model_latent(stream);
+    test_sde_and_scheduler_updates(stream);
+    test_argmax_tie_break(stream);
+    check_cuda(cudaStreamDestroy(stream), "destroy stream");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/e2e/models/elf_flow/test_elf_flow_family_plugin.py
+++ b/tests/e2e/models/elf_flow/test_elf_flow_family_plugin.py
@@ -630,6 +630,8 @@ def test_elf_trtmc_run_generates_text_from_diffusion_decode(tmp_path: Path) -> N
             str(trtmc_binary),
             "run",
             str(bundle_path),
+            "--prompt",
+            "",
             "--num-steps",
             "1",
             "--guidance-scale",


### PR DESCRIPTION
## Background

ELF flow sampling kept iterative latents and self-conditioning state on the host. Every ODE model call therefore synchronized, downloaded all engine outputs, copied them into CPU vectors, and uploaded the next state. That per-launch round trip erased much of the TensorRT engine advantage.

This PR closes #503.

## Exit Criteria

- Keep iterative latent, self-conditioning, CFG, scheduler, and final token selection state on GPU.
- Chain dependent ODE launches asynchronously on one stream.
- Copy only final token IDs to the host.
- Preserve replay tensors, precision selectors, token IDs, decoded text, and task-eval quality.

## Implementation

- Add a persistent device sampling workspace for latents, conditions, SDE noise, scalar inputs, denoiser outputs, and final token IDs.
- Run the ELF engine through device-input asynchronous execution without downloading intermediate outputs.
- Move conditional masking, SDE perturbation, CFG combination, scheduler updates, and deterministic row-wise argmax to CUDA kernels.
- Retain the host path as a compatibility fallback when a bundle does not expose the required device tensors.
- Add CUDA regression tests for condition masking, SDE/scheduler updates, and lowest-index argmax tie handling.

## Performance And Accuracy

Measurements use the same bundles, precision contracts, replay tensors, seeds, complete-task boundary, five warmups, and 50 timed requests before and after.

| Workload | Before p50 | After p50 | Speedup | Output |
| --- | ---: | ---: | ---: | --- |
| ELF-B-XSum, ODE64 CFG2 | 1,002.27 ms | 718.70 ms | 1.39x | Exact token/text hash |
| ELF-B-OWT, ODE32 | 323.48 ms | 237.55 ms | 1.36x | Exact token/text hash |

- XSum engine execution/request: 723.64 ms before, 715.75 ms after; non-engine time fell from 278.63 ms to 2.95 ms (-98.94%).
- OWT engine execution/request: 236.54 ms before, 236.66 ms after; non-engine time fell from 86.94 ms to 0.88 ms (-98.99%).
- Repository replay task evaluation: passed for both workloads (`2 passed`).

## Validation

- `python3 tools/legal_headers.py --check`: passed with no findings.
- `ruff check --config ruff.toml tests/e2e/models/elf_flow/test_elf_flow_family_plugin.py`: passed.
- `clang-format --dry-run --Werror <changed C++/CUDA files>`: passed.
- `python3 tools/check_cyclomatic_complexity.py --max-ccn 10 <changed C++/CUDA files>`: passed; maximum CCN 10.
- `PYTHONPATH=python python3 -m pytest tests/e2e/models/elf_flow --ignore=tests/e2e/models/elf_flow/test_elf_flow_e2e.py tests/tools/test_model_plugin_encapsulation_static.py -m 'not trt' -q -p no:cacheprovider`: passed.
- `ctest --test-dir build --output-on-failure -R elf_flow`: 2/2 passed on CUDA.
- Target-GPU XSum/OWT replay task evaluation: 2/2 passed.

## Notes For Future Readers

- The host sampling path remains intentionally available for incompatible legacy plans.
- Review the device workspace and sampling loop first, then the CUDA state-update kernels, and finally the parity tests.
