### PR TITLE
perf(personaplex): keep generation state on device

### DIFF
--- a/src/runtime/models/personaplex/MODEL.toml
+++ b/src/runtime/models/personaplex/MODEL.toml
@@ -15,5 +15,6 @@ runtime_tests = [
   "test_personaplex_speech_temporal_embed_plan|test_personaplex_speech_temporal_embed_plan.cpp|_|_|_",
   "test_personaplex_speech_mimi_decode_plan|test_personaplex_speech_mimi_decode_plan.cpp|_|_|_",
   "test_personaplex_decode_runtime|test_personaplex_decode_runtime.cpp|_|decode_runtime.cpp|_",
+  "test_personaplex_sampling_kernels|test_personaplex_sampling_kernels.cpp|trtmc_model_personaplex|_|REQUIRES_TRT",
   "test_personaplex_speech_pipeline|test_personaplex_speech_pipeline.cpp|trtmc_model_personaplex|_|REQUIRES_TRT",
 ]

--- a/src/runtime/models/personaplex/kv_cache.cpp
+++ b/src/runtime/models/personaplex/kv_cache.cpp
@@ -354,7 +354,6 @@ void PersonaplexKvCache::reset() {
         cudaMemsetAsync(present_k_[li].data(), 0, present_k_[li].nbytes(), stream_);
         cudaMemsetAsync(present_v_[li].data(), 0, present_v_[li].nbytes(), stream_);
     }
-    cudaStreamSynchronize(stream_);
 }
 
 std::size_t PersonaplexKvCache::device_memory_bytes() const {

--- a/src/runtime/models/personaplex/pipeline.cpp
+++ b/src/runtime/models/personaplex/pipeline.cpp
@@ -6,6 +6,7 @@
 #include "runtime/models/personaplex/pipeline.h"
 
 #include "runtime/models/personaplex/decode_runtime.h"
+#include "runtime/models/personaplex/sampling_kernels.h"
 #include "runtime/models/personaplex/speech_decode_stop_policy.h"
 #include "runtime/models/personaplex/speech_delay_cache.h"
 #include "runtime/models/personaplex/speech_depth_plan.h"
@@ -146,6 +147,63 @@ std::shared_ptr<ISubprocessRunner> CreateDefaultSubprocessRunner() {
 
 // ─── SpeechPipeline (TrtModule-based) ───
 
+namespace {
+
+constexpr uint64_t kSpeechSamplingSeed = 0x5EEDC0DECAFE1234ULL;
+
+DeviceTensor upload_float_table(const std::vector<float>& values, cudaStream_t stream,
+                                const char* label) {
+    if (values.empty())
+        return {};
+    DeviceTensor tensor({static_cast<int64_t>(values.size())}, DType::kFloat32, stream);
+    if (!tensor.ok() || !tensor.copy_from_host(values.data()))
+        throw std::runtime_error(std::string("SpeechPipeline: failed to upload ") + label);
+    return tensor;
+}
+
+int32_t output_width(const TrtModule& module, const char* name) {
+    const auto shape = module.tensor_shape(name);
+    if (shape.empty() || shape.back() <= 0 || shape.back() > INT32_MAX)
+        throw std::runtime_error(std::string("SpeechPipeline: invalid output shape for ") + name);
+    return static_cast<int32_t>(shape.back());
+}
+
+bool speech_is_sampling_enabled(const SpeechConfig& config) {
+    return config.depth_temperature > 0.0F && config.depth_top_k > 0;
+}
+
+} // namespace
+
+struct SpeechDeviceWorkspace {
+    SpeechDeviceWorkspace(const SpeechConfig& config, cudaStream_t stream)
+        : depth_projection(upload_float_table(config.depth_projection, stream, "depth projection")),
+          depth_text_embedding(
+              upload_float_table(config.depth_text_embedding, stream, "depth text embedding")),
+          depth_audio_embeddings(
+              upload_float_table(config.depth_audio_embeddings, stream, "depth audio embeddings")),
+          depth_embed({std::max(config.depth_hidden_size, 1)}, DType::kFloat32, stream),
+          selected_tokens({static_cast<int64_t>(std::max(config.num_codebooks + 1, 1))},
+                          DType::kInt32, stream),
+          dummy_token(DeviceTensor::zeros({1}, DType::kInt32, stream)),
+          use_input_embed({1}, DType::kFloat32, stream), rng_state({2}, DType::kInt32, stream) {
+        constexpr float one = 1.0F;
+        if (!depth_embed.ok() || !selected_tokens.ok() || !dummy_token.ok() ||
+            !use_input_embed.ok() || !rng_state.ok() || !use_input_embed.copy_from_host(&one) ||
+            !rng_state.copy_from_host(&kSpeechSamplingSeed)) {
+            throw std::runtime_error("SpeechPipeline: failed to allocate device generation state");
+        }
+    }
+
+    DeviceTensor depth_projection;
+    DeviceTensor depth_text_embedding;
+    DeviceTensor depth_audio_embeddings;
+    DeviceTensor depth_embed;
+    DeviceTensor selected_tokens;
+    DeviceTensor dummy_token;
+    DeviceTensor use_input_embed;
+    DeviceTensor rng_state;
+};
+
 SpeechPipeline::SpeechPipeline(std::unique_ptr<TrtModule> mimi_encoder,
                                std::unique_ptr<TrtModule> temporal,
                                std::unique_ptr<PersonaplexInferenceState> temporal_state,
@@ -155,7 +213,7 @@ SpeechPipeline::SpeechPipeline(std::unique_ptr<TrtModule> mimi_encoder,
                                cudaStream_t stream,
                                std::shared_ptr<ISubprocessRunner> subprocess_runner,
                                std::string model_id_str)
-    : mimi_encoder_(std::move(mimi_encoder)), temporal_(std::move(temporal)),
+    : temporal_(std::move(temporal)), mimi_encoder_(std::move(mimi_encoder)),
       temporal_state_(std::move(temporal_state)), depth_engines_(std::move(depth_engines)),
       depth_state_(std::move(depth_state)), mimi_decoder_(std::move(mimi_decoder)), stream_(stream),
       config_(std::move(config)), subprocess_runner_(std::move(subprocess_runner)),
@@ -168,11 +226,18 @@ SpeechPipeline::SpeechPipeline(std::unique_ptr<TrtModule> mimi_encoder,
     if (!subprocess_runner_)
         subprocess_runner_ = CreateDefaultSubprocessRunner();
 
-    // Fixed deterministic seed for reproducible audio output.
-    // PersonaPlex depth sampling (temperature=0.8, top_k=250) is sensitive
-    // to the RNG sequence; a fixed seed ensures identical output across runs
-    // and between the old and new pipeline paths.
-    rng_state_ = 0x5EEDC0DECAFE1234ULL;
+    device_workspace_ = std::make_unique<SpeechDeviceWorkspace>(config_, stream_);
+    temporal_->bind_external("token_id", device_workspace_->dummy_token.data());
+    temporal_->bind_external("use_input_embed", device_workspace_->use_input_embed.data());
+    for (auto& engine : depth_engines_) {
+        if (!engine)
+            continue;
+        if (engine->stream() != stream_)
+            throw std::runtime_error("SpeechPipeline: generation modules must share one stream");
+        engine->bind_external("token_id", device_workspace_->dummy_token.data());
+        engine->bind_external("use_input_embed", device_workspace_->use_input_embed.data());
+        engine->bind_external("input_embed", device_workspace_->depth_embed.data());
+    }
 }
 
 SpeechPipeline::~SpeechPipeline() = default;
@@ -289,63 +354,47 @@ std::vector<int32_t> SpeechPipeline::run_mimi_encode(const float* samples, int32
 // Temporal step with PersonaplexKvCache: input_embed -> logits (+ hidden_state)
 // ---------------------------------------------------------------------------
 
-void SpeechPipeline::run_temporal_embed_step(const float* embed_ptr, int32_t embed_size,
-                                             std::vector<float>& logits,
-                                             std::vector<float>& hidden_out) {
+SpeechTemporalDeviceOutput SpeechPipeline::run_temporal_embed_step(const float* embed_ptr,
+                                                                   int32_t embed_size) {
     temporal_state_->bind_to(*temporal_);
 
-    float use_input_embed = 1.0F;
-    int32_t dummy_token = 0;
-
-    // Copy embed to mutable buffer (Tensor requires non-const pointer)
-    std::vector<float> embed_buf(embed_ptr, embed_ptr + embed_size);
-
-    Tensor token_tensor;
-    token_tensor.data = &dummy_token;
-    token_tensor.shape = {1};
-    token_tensor.dtype = DType::kInt32;
-
     Tensor embed_tensor;
-    embed_tensor.data = embed_buf.data();
+    embed_tensor.data = const_cast<float*>(embed_ptr);
     embed_tensor.shape = {static_cast<int64_t>(embed_size)};
     embed_tensor.dtype = DType::kFloat32;
 
-    Tensor use_embed_tensor;
-    use_embed_tensor.data = &use_input_embed;
-    use_embed_tensor.shape = {1};
-    use_embed_tensor.dtype = DType::kFloat32;
-
     TensorMap inputs;
-    inputs["token_id"] = token_tensor;
     inputs["input_embed"] = embed_tensor;
-    inputs["use_input_embed"] = use_embed_tensor;
     temporal_state_->prepare_step(inputs);
 
-    TensorMap outputs = temporal_->forward(inputs);
+    temporal_->forward_async(inputs);
+    const auto* logits = static_cast<const float*>(temporal_->device_ptr("logits"));
+    if (!logits || temporal_->tensor_dtype("logits") != DType::kFloat32)
+        throw std::runtime_error("SpeechPipeline temporal: FP32 device logits unavailable");
 
-    // Extract logits
-    auto logits_it = outputs.find("logits");
-    if (logits_it == outputs.end())
-        throw std::runtime_error("SpeechPipeline temporal: no 'logits' output");
-
-    const auto& lt = logits_it->second;
-    auto n = lt.numel();
-    logits.resize(static_cast<std::size_t>(n));
-    std::memcpy(logits.data(), lt.data, n * sizeof(float));
-
-    // Extract hidden_state if available
-    auto hidden_it = outputs.find("hidden_state");
-    if (hidden_it != outputs.end()) {
-        const auto& ht = hidden_it->second;
-        auto hn = ht.numel();
-        hidden_out.resize(static_cast<std::size_t>(hn));
-        std::memcpy(hidden_out.data(), ht.data, hn * sizeof(float));
-    } else {
-        // Fallback: use logits as hidden representation (truncated/padded to hidden_size)
-        hidden_out.clear();
+    const bool sampled = speech_is_sampling_enabled(config_);
+    if (!personaplex_select_token(logits, output_width(*temporal_, "logits"), sampled ? 0.7F : 0.0F,
+                                  sampled ? 25 : 0, output_width(*temporal_, "logits") - 1,
+                                  static_cast<uint64_t*>(device_workspace_->rng_state.data()),
+                                  static_cast<int32_t*>(device_workspace_->selected_tokens.data()),
+                                  stream_)) {
+        throw std::runtime_error(
+            "SpeechPipeline temporal: device sampling failed or is unsupported");
     }
 
     temporal_state_->advance();
+
+    SpeechTemporalDeviceOutput output;
+    if (temporal_->has_output("hidden_state")) {
+        output.hidden = temporal_->device_ptr("hidden_state");
+        output.hidden_dtype = temporal_->tensor_dtype("hidden_state");
+    } else {
+        output.hidden = logits;
+        output.hidden_dtype = DType::kFloat32;
+    }
+    if (!output.hidden)
+        throw std::runtime_error("SpeechPipeline temporal: device hidden state unavailable");
+    return output;
 }
 
 // ---------------------------------------------------------------------------
@@ -358,159 +407,85 @@ int32_t speech_clamp_token(int32_t token, int32_t vocab_size) {
     return clamp_speech_depth_token(token, vocab_size);
 }
 
-bool speech_is_sampling_enabled(const SpeechConfig& cfg) {
-    return cfg.depth_temperature > 0.0F && cfg.depth_top_k > 0;
-}
-
-int32_t speech_select_depth_token_greedy(const std::vector<float>& logits, const SpeechConfig&,
-                                         uint64_t&) {
-    return personaplex_select_argmax_token(logits);
-}
-
-int32_t speech_select_depth_token_sampled(const std::vector<float>& logits, const SpeechConfig& cfg,
-                                          uint64_t& rng_state) {
-    return personaplex_sample_token_topk(logits, cfg.depth_temperature, cfg.depth_top_k, rng_state);
-}
-
-using SpeechDepthTokenSelectFn = int32_t (*)(const std::vector<float>&, const SpeechConfig&,
-                                             uint64_t&);
-
-SpeechDepthTokenSelectFn speech_select_depth_token_dispatch(const SpeechConfig& cfg) {
-    return speech_is_sampling_enabled(cfg) ? speech_select_depth_token_sampled
-                                           : speech_select_depth_token_greedy;
-}
-
-int32_t speech_sample_temporal_text_token(const std::vector<float>& logits, int32_t text_pad_id,
-                                          const SpeechConfig& cfg, uint64_t& rng_state) {
-    if (logits.empty())
-        return text_pad_id;
-    if (speech_is_sampling_enabled(cfg)) {
-        constexpr float kTextTemp = 0.7F;
-        constexpr int32_t kTextTopK = 25;
-        return personaplex_sample_token_topk(logits, kTextTemp, kTextTopK, rng_state);
-    }
-    return personaplex_select_argmax_token(logits);
-}
-
-void speech_maybe_log_depth_debug(int32_t cb, int32_t depth_call_idx,
-                                  const std::vector<float>& logits, int32_t best) {
-    if (cb != 0 || depth_call_idx >= 12 || logits.empty())
-        return;
-    int32_t top1 = -1;
-    int32_t top2 = -1;
-    float v1 = -1.0e30F;
-    float v2 = -1.0e30F;
-    for (int32_t i = 0; i < static_cast<int32_t>(logits.size()); ++i) {
-        const float v = logits[static_cast<std::size_t>(i)];
-        if (v > v1) {
-            v2 = v1;
-            top2 = top1;
-            v1 = v;
-            top1 = i;
-        } else if (v > v2) {
-            v2 = v;
-            top2 = i;
-        }
-    }
-    std::cerr << "[speech] DepthDbg frame=" << depth_call_idx << " cb0 top1=" << top1
-              << " v1=" << v1 << " top2=" << top2 << " v2=" << v2 << " margin=" << (v1 - v2)
-              << " sampled=" << best << std::endl;
-}
-
 } // anonymous namespace
 
-std::vector<int32_t> SpeechPipeline::run_depth(const float* temporal_hidden, int32_t hidden_dim,
-                                               int32_t text_token,
-                                               const int32_t* forced_audio_tokens,
-                                               const uint8_t* forced_audio_provided) {
-    (void)hidden_dim;
-
-    const auto& cfg = config_;
-    const int32_t num_cb = cfg.num_codebooks;
-    const int32_t depth_hidden = cfg.depth_hidden_size;
-
+void SpeechPipeline::run_depth(const SpeechTemporalDeviceOutput& temporal_output,
+                               int32_t text_token, bool text_token_is_forced,
+                               const int32_t* forced_audio_tokens,
+                               const uint8_t* forced_audio_provided) {
     if (depth_engines_.empty())
-        return std::vector<int32_t>(static_cast<std::size_t>(num_cb), 0);
+        throw std::runtime_error("SpeechPipeline: no depth engine available");
 
-    // Reset shared depth cache for this frame
     depth_state_->reset();
-
-    std::vector<int32_t> codebook_tokens;
-    codebook_tokens.reserve(static_cast<std::size_t>(num_cb));
-    const int32_t depth_call_idx = depth_debug_call_count_++;
-
-    std::vector<float> logits;
-    const auto projection_view = make_depth_projection_view(cfg, temporal_hidden);
-
-    std::vector<float> depth_embed(static_cast<std::size_t>(depth_hidden), 0.0F);
-    const auto select_token = speech_select_depth_token_dispatch(cfg);
-
-    int32_t prev_token = 0;
-
-    for (int32_t cb = 0; cb < num_cb; ++cb) {
-        const auto cb_idx = static_cast<std::size_t>(cb);
-        auto* engine = (cb_idx < depth_engines_.size() && depth_engines_[cb_idx])
-                           ? depth_engines_[cb_idx].get()
-                           : depth_engines_[0].get();
-
-        build_depth_input_embedding(cfg, projection_view, cb, text_token, prev_token, depth_hidden,
-                                    depth_embed);
-
-        // Bind depth cache and run with input_embed
-        depth_state_->bind_to(*engine);
-
-        float use_input_embed = 1.0F;
-        int32_t dummy_token = 0;
-
-        Tensor token_tensor;
-        token_tensor.data = &dummy_token;
-        token_tensor.shape = {1};
-        token_tensor.dtype = DType::kInt32;
-
-        Tensor embed_tensor;
-        embed_tensor.data = depth_embed.data();
-        embed_tensor.shape = {static_cast<int64_t>(depth_hidden)};
-        embed_tensor.dtype = DType::kFloat32;
-
-        Tensor use_embed_tensor;
-        use_embed_tensor.data = &use_input_embed;
-        use_embed_tensor.shape = {1};
-        use_embed_tensor.dtype = DType::kFloat32;
-
-        TensorMap inputs;
-        inputs["token_id"] = token_tensor;
-        inputs["input_embed"] = embed_tensor;
-        inputs["use_input_embed"] = use_embed_tensor;
-        depth_state_->prepare_step(inputs);
-
-        TensorMap outputs = engine->forward(inputs);
-
-        auto logits_it = outputs.find("logits");
-        if (logits_it == outputs.end()) {
-            std::cerr << "[speech] Depth step cb=" << cb << " failed: no logits" << std::endl;
-            break;
-        }
-
-        const auto& lt = logits_it->second;
-        auto n = lt.numel();
-        logits.resize(static_cast<std::size_t>(n));
-        std::memcpy(logits.data(), lt.data, n * sizeof(float));
-
-        depth_state_->advance();
-
-        int32_t best = select_token(logits, cfg, rng_state_);
-        best = std::max(0, std::min(best, cfg.codebook_size - 1));
-        codebook_tokens.push_back(best);
-        prev_token =
-            resolve_depth_prev_token(cb, best, cfg, forced_audio_tokens, forced_audio_provided);
-        speech_maybe_log_depth_debug(cb, depth_call_idx, logits, best);
+    auto* selected_tokens = static_cast<int32_t*>(device_workspace_->selected_tokens.data());
+    for (int32_t codebook = 0; codebook < config_.num_codebooks; ++codebook) {
+        prepare_depth_input(temporal_output, codebook, text_token, text_token_is_forced,
+                            forced_audio_tokens, forced_audio_provided, selected_tokens);
+        enqueue_depth_step(depth_engine_for_codebook(codebook), codebook, selected_tokens);
     }
+}
 
-    // Pad if we stopped early
-    while (static_cast<int32_t>(codebook_tokens.size()) < num_cb)
-        codebook_tokens.push_back(0);
+TrtModule& SpeechPipeline::depth_engine_for_codebook(int32_t codebook) {
+    const auto index = static_cast<std::size_t>(codebook);
+    if (index < depth_engines_.size() && depth_engines_[index])
+        return *depth_engines_[index];
+    return *depth_engines_.front();
+}
 
-    return codebook_tokens;
+void SpeechPipeline::prepare_depth_input(const SpeechTemporalDeviceOutput& temporal_output,
+                                         int32_t codebook, int32_t text_token,
+                                         bool text_token_is_forced,
+                                         const int32_t* forced_audio_tokens,
+                                         const uint8_t* forced_audio_provided,
+                                         int32_t* selected_tokens) {
+    const int32_t previous_codebook = codebook - 1;
+    const bool previous_is_forced = previous_codebook >= 0 && forced_audio_tokens &&
+                                    forced_audio_provided &&
+                                    forced_audio_provided[previous_codebook] != 0;
+    const int32_t forced_previous = previous_is_forced ? forced_audio_tokens[previous_codebook] : 0;
+    personaplex_prepare_depth_embedding(
+        static_cast<float*>(device_workspace_->depth_embed.data()), temporal_output.hidden,
+        temporal_output.hidden_dtype,
+        static_cast<const float*>(device_workspace_->depth_projection.data()),
+        device_workspace_->depth_projection.numel(),
+        static_cast<const float*>(device_workspace_->depth_text_embedding.data()),
+        device_workspace_->depth_text_embedding.numel(),
+        static_cast<const float*>(device_workspace_->depth_audio_embeddings.data()),
+        device_workspace_->depth_audio_embeddings.numel(), selected_tokens, codebook, text_token,
+        text_token_is_forced, forced_previous, previous_is_forced, config_.depth_hidden_size,
+        config_.temporal_hidden_size, config_.depth_text_vocab, config_.audio_vocab_size,
+        config_.num_depformer_emb, stream_);
+    if (const auto error = cudaGetLastError(); error != cudaSuccess) {
+        throw std::runtime_error(std::string("SpeechPipeline depth embedding: ") +
+                                 cudaGetErrorString(error));
+    }
+}
+
+void SpeechPipeline::enqueue_depth_step(TrtModule& engine, int32_t codebook,
+                                        int32_t* selected_tokens) {
+    depth_state_->bind_to(engine);
+    TensorMap inputs;
+    depth_state_->prepare_step(inputs);
+    engine.forward_async(inputs);
+    const auto* logits = static_cast<const float*>(engine.device_ptr("logits"));
+    if (!logits || engine.tensor_dtype("logits") != DType::kFloat32)
+        throw std::runtime_error("SpeechPipeline depth: FP32 device logits unavailable");
+    depth_state_->advance();
+    if (!personaplex_select_token(logits, output_width(engine, "logits"), config_.depth_temperature,
+                                  config_.depth_top_k, config_.codebook_size - 1,
+                                  static_cast<uint64_t*>(device_workspace_->rng_state.data()),
+                                  selected_tokens + codebook + 1, stream_)) {
+        throw std::runtime_error("SpeechPipeline depth: device sampling failed or is unsupported");
+    }
+}
+
+void SpeechPipeline::download_selected_frame_tokens(std::vector<int32_t>& selected_tokens) {
+    selected_tokens.resize(static_cast<std::size_t>(config_.num_codebooks + 1));
+    const auto bytes = selected_tokens.size() * sizeof(int32_t);
+    auto error = cudaMemcpyAsync(selected_tokens.data(), device_workspace_->selected_tokens.data(),
+                                 bytes, cudaMemcpyDeviceToHost, stream_);
+    if (error != cudaSuccess || cudaStreamSynchronize(stream_) != cudaSuccess)
+        throw std::runtime_error("SpeechPipeline: failed to download selected frame tokens");
 }
 
 // ---------------------------------------------------------------------------
@@ -672,14 +647,14 @@ void SpeechPipeline::run_text_prompt() {
     if (!resolve_text_prompt_tokens(cfg, *subprocess_runner_, text_tokens))
         return;
 
-    std::vector<float> summed_embed(static_cast<std::size_t>(hidden));
-    std::vector<float> logits;
-    std::vector<float> hidden_out;
-
+    std::vector<float> prompt_embeddings(text_tokens.size() * static_cast<std::size_t>(hidden));
     for (std::size_t t = 0; t < text_tokens.size(); ++t) {
-        compute_text_prompt_frame_embed(cfg, text_tokens[t], hidden, summed_embed.data());
-        run_temporal_embed_step(summed_embed.data(), hidden, logits, hidden_out);
+        auto* embedding = prompt_embeddings.data() + t * static_cast<std::size_t>(hidden);
+        compute_text_prompt_frame_embed(cfg, text_tokens[t], hidden, embedding);
+        run_temporal_embed_step(embedding, hidden);
     }
+    if (cudaStreamSynchronize(stream_) != cudaSuccess)
+        throw std::runtime_error("SpeechPipeline: text prompt synchronization failed");
 
     std::cerr << "[speech] Text prompt injection complete (" << text_tokens.size()
               << " temporal steps)" << std::endl;
@@ -740,17 +715,12 @@ void speech_maybe_log_stop_decision(SpeechDecodeStopReason reason,
     }
 }
 
-void speech_maybe_log_interleaved_debug(int32_t offset, int32_t hidden,
-                                        const std::vector<float>& frame_hidden, int32_t text_input,
+void speech_maybe_log_interleaved_debug(int32_t offset, int32_t text_input,
                                         int32_t sampled_text_token,
                                         const std::vector<int32_t>& frame_codes) {
     if (offset <= 0 || offset > 5)
         return;
-    float l2 = 0.0F;
-    for (int32_t d = 0; d < hidden; ++d)
-        l2 += frame_hidden[static_cast<std::size_t>(d)] * frame_hidden[static_cast<std::size_t>(d)];
-    l2 = std::sqrt(l2);
-    std::cerr << "[speech] Offset " << offset << " hidden L2=" << l2 << " text_in=" << text_input
+    std::cerr << "[speech] Offset " << offset << " text_in=" << text_input
               << " text_out=" << sampled_text_token << " depth:";
     for (int32_t cb = 0; cb < std::min(4, static_cast<int32_t>(frame_codes.size())); ++cb)
         std::cerr << " " << frame_codes[static_cast<std::size_t>(cb)];
@@ -802,13 +772,12 @@ void SpeechPipeline::speak_run_generation_loop(const SpeechGenerationSettings& s
     speech_log_stop_configuration(config_, plan.extra_tail);
 
     std::vector<float> summed_embed(static_cast<std::size_t>(hidden));
-    std::vector<float> frame_hidden(static_cast<std::size_t>(hidden));
-    std::vector<float> logits;
-    std::vector<float> hidden_out;
     std::vector<int32_t> moshi_input(static_cast<std::size_t>(settings.stream_cb));
     std::vector<int32_t> user_input(static_cast<std::size_t>(settings.stream_cb));
     std::vector<int32_t> target_audio_tokens(static_cast<std::size_t>(settings.num_cb));
     std::vector<uint8_t> target_audio_provided(static_cast<std::size_t>(settings.num_cb));
+    std::vector<int32_t> selected_frame_tokens;
+    std::vector<int32_t> frame_codes(static_cast<std::size_t>(settings.num_cb));
 
     frames_collected = 0;
     for (int32_t offset = 0; offset < plan.total_iters && frames_collected < plan.output_frames;
@@ -832,28 +801,18 @@ void SpeechPipeline::speak_run_generation_loop(const SpeechGenerationSettings& s
                                          moshi_input.data(), user_input.data(), text_input,
                                          summed_embed.data());
 
-        run_temporal_embed_step(summed_embed.data(), settings.hidden, logits, hidden_out);
-
-        if (!hidden_out.empty()) {
-            frame_hidden.resize(static_cast<std::size_t>(settings.hidden));
-            const auto copy_sz =
-                std::min(hidden_out.size(), static_cast<std::size_t>(settings.hidden));
-            std::memcpy(frame_hidden.data(), hidden_out.data(), copy_sz * sizeof(float));
-        } else {
-            fill_hidden_from_logits(frame_hidden, logits, settings.hidden);
-        }
-
-        const int32_t sampled_text_token =
-            speech_sample_temporal_text_token(logits, settings.text_pad_id, config_, rng_state_);
+        const auto temporal_output = run_temporal_embed_step(summed_embed.data(), settings.hidden);
         const auto text_target_idx = delay_cache_index(delay_state, 0, target_pos);
         const bool text_provided = delay_state.provided[text_target_idx] != 0;
-        const int32_t next_text_token =
-            text_provided ? delay_state.cache[text_target_idx] : sampled_text_token;
+        const int32_t forced_text_token = delay_state.cache[text_target_idx];
 
         build_target_audio_arrays(delay_state, target_pos, settings.num_cb, settings.audio_bos,
                                   target_audio_tokens, target_audio_provided);
-        auto frame_codes = run_depth(frame_hidden.data(), settings.hidden, next_text_token,
-                                     target_audio_tokens.data(), target_audio_provided.data());
+        run_depth(temporal_output, forced_text_token, text_provided, target_audio_tokens.data(),
+                  target_audio_provided.data());
+        download_selected_frame_tokens(selected_frame_tokens);
+        const int32_t sampled_text_token = selected_frame_tokens[0];
+        std::copy_n(selected_frame_tokens.begin() + 1, settings.num_cb, frame_codes.begin());
 
         clear_provided_flags_at_pos(delay_state, model_input_pos);
         write_generated_tokens_to_delay_cache(delay_state, target_pos, sampled_text_token,
@@ -876,8 +835,7 @@ void SpeechPipeline::speak_run_generation_loop(const SpeechGenerationSettings& s
         const auto stop_decision = UpdateSpeechDecodeStopState(stop_state, stop_input);
         stop_state = stop_decision.state;
         speech_maybe_log_stop_decision(stop_decision.reason, stop_state, offset);
-        speech_maybe_log_interleaved_debug(offset, settings.hidden, frame_hidden, text_input,
-                                           sampled_text_token, frame_codes);
+        speech_maybe_log_interleaved_debug(offset, text_input, sampled_text_token, frame_codes);
         if (stop_decision.should_break)
             break;
     }
@@ -903,8 +861,6 @@ AudioResult SpeechPipeline::speak(const float* audio_in, int32_t num_samples,
                                   const GenerateConfig& cfg, int32_t input_sample_rate) {
     AudioResult result;
     result.sample_rate = config_.sample_rate;
-
-    depth_debug_call_count_ = 0;
 
     const int32_t max_output_frames = cfg.max_new_tokens > 0 ? cfg.max_new_tokens : 375;
 

--- a/src/runtime/models/personaplex/pipeline.h
+++ b/src/runtime/models/personaplex/pipeline.h
@@ -27,6 +27,12 @@
 namespace trtmc {
 
 class ISubprocessRunner;
+struct SpeechDeviceWorkspace;
+
+struct SpeechTemporalDeviceOutput {
+    const void* hidden{nullptr};
+    DType hidden_dtype{DType::kFloat32};
+};
 
 class SpeechPipeline final : public IPipeline {
   public:
@@ -50,12 +56,18 @@ class SpeechPipeline final : public IPipeline {
   private:
     std::vector<int32_t> run_mimi_encode(const float* samples, int32_t num_samples);
 
-    void run_temporal_embed_step(const float* embed_ptr, int32_t embed_size,
-                                 std::vector<float>& logits, std::vector<float>& hidden_out);
+    SpeechTemporalDeviceOutput run_temporal_embed_step(const float* embed_ptr, int32_t embed_size);
 
-    std::vector<int32_t> run_depth(const float* temporal_hidden, int32_t hidden_dim,
-                                   int32_t text_token, const int32_t* forced_audio_tokens = nullptr,
-                                   const uint8_t* forced_audio_provided = nullptr);
+    void run_depth(const SpeechTemporalDeviceOutput& temporal_output, int32_t text_token,
+                   bool text_token_is_forced, const int32_t* forced_audio_tokens = nullptr,
+                   const uint8_t* forced_audio_provided = nullptr);
+    TrtModule& depth_engine_for_codebook(int32_t codebook);
+    void prepare_depth_input(const SpeechTemporalDeviceOutput& temporal_output, int32_t codebook,
+                             int32_t text_token, bool text_token_is_forced,
+                             const int32_t* forced_audio_tokens,
+                             const uint8_t* forced_audio_provided, int32_t* selected_tokens);
+    void enqueue_depth_step(TrtModule& engine, int32_t codebook, int32_t* selected_tokens);
+    void download_selected_frame_tokens(std::vector<int32_t>& selected_tokens);
 
     std::vector<float> run_mimi_decode(const std::vector<int32_t>& codec_tokens,
                                        int32_t num_frames);
@@ -69,23 +81,21 @@ class SpeechPipeline final : public IPipeline {
                                    std::vector<int32_t>& output_codes, int32_t& frames_collected);
     void speak_postprocess_waveform(std::vector<float>& waveform, int32_t generated_frames) const;
 
-    std::unique_ptr<TrtModule> mimi_encoder_;
     std::unique_ptr<TrtModule> temporal_;
+    std::unique_ptr<TrtModule> mimi_encoder_;
     std::unique_ptr<PersonaplexInferenceState> temporal_state_;
     std::vector<std::unique_ptr<TrtModule>> depth_engines_;
     std::unique_ptr<PersonaplexInferenceState> depth_state_;
     std::unique_ptr<TrtModule> mimi_decoder_;
+    std::unique_ptr<SpeechDeviceWorkspace> device_workspace_;
 
     cudaStream_t stream_;
     SpeechConfig config_;
     std::shared_ptr<ISubprocessRunner> subprocess_runner_;
     std::string model_id_;
-    uint64_t rng_state_{0};
 
     int32_t last_encode_frames_{0};
     int32_t last_encode_codebooks_{0};
-
-    int32_t depth_debug_call_count_{0};
 };
 
 } // namespace trtmc

--- a/src/runtime/models/personaplex/plugin.cpp
+++ b/src/runtime/models/personaplex/plugin.cpp
@@ -84,6 +84,8 @@ class PersonaPlexPlugin final : public IPipelinePlugin {
                                       "speech temporal", temporal_opts);
 
         cudaStream_t stream = temporal_loaded.module->stream();
+        ModuleCreateOptions chained_opts = opts;
+        chained_opts.stream = stream;
 
         const int32_t temporal_kv_fallback =
             compute_kv_dim_kv_heads(ctx.config, ctx.config.hidden_size);
@@ -98,7 +100,7 @@ class PersonaPlexPlugin final : public IPipelinePlugin {
             throw std::runtime_error(
                 "SpeechPipeline: failed to create temporal PersonaplexKvCache");
 
-        auto depth_engines = load_depth_engines(ctx.backend, ctx.bundle, opts);
+        auto depth_engines = load_depth_engines(ctx.backend, ctx.bundle, chained_opts);
 
         const auto depth_cfg = make_depth_engine_config(ctx.config_json, ctx.config);
         int32_t depth_kv_dim = compute_kv_dim_kv_heads(depth_cfg, depth_cfg.hidden_size);
@@ -114,10 +116,10 @@ class PersonaPlexPlugin final : public IPipelinePlugin {
 
         auto mimi_encoder =
             extract_optional_module(ctx.backend, find_section(ctx.bundle, "mimi_encoder_plan"),
-                                    "speech mimi_encoder", opts);
+                                    "speech mimi_encoder", chained_opts);
         auto mimi_decoder =
             extract_optional_module(ctx.backend, find_section(ctx.bundle, "mimi_decoder_plan"),
-                                    "speech mimi_decoder", opts);
+                                    "speech mimi_decoder", chained_opts);
 
         return std::make_unique<SpeechPipeline>(
             std::move(mimi_encoder), std::move(temporal_loaded.module), std::move(temporal_state),

--- a/src/runtime/models/personaplex/sampling_kernels.cu
+++ b/src/runtime/models/personaplex/sampling_kernels.cu
@@ -1,0 +1,301 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/personaplex/sampling_kernels.h"
+
+#include <cfloat>
+#include <climits>
+#include <cmath>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+namespace trtmc {
+
+namespace {
+
+constexpr int32_t kArgmaxThreads = 256;
+constexpr int32_t kSampleThreads = 128;
+constexpr int32_t kMaxTopK = 4096;
+
+__device__ bool candidate_is_better(float lhs_value, int32_t lhs_index, float rhs_value,
+                                    int32_t rhs_index) {
+    return lhs_value > rhs_value || (lhs_value == rhs_value && lhs_index < rhs_index);
+}
+
+__device__ bool candidate_precedes_cutoff(float value, int32_t index, int32_t rank,
+                                          float cutoff_value, int32_t cutoff_index) {
+    if (rank == 0)
+        return false;
+    if (value > cutoff_value)
+        return true;
+    if (value < cutoff_value)
+        return false;
+    return index <= cutoff_index;
+}
+
+__device__ void find_thread_candidate(const float* logits, int32_t vocab_size, int32_t rank,
+                                      float cutoff_value, int32_t cutoff_index, int32_t thread,
+                                      float& best_value, int32_t& best_index) {
+    best_value = -FLT_MAX;
+    best_index = INT_MAX;
+    for (int32_t index = thread; index < vocab_size; index += kSampleThreads) {
+        const float value = logits[index];
+        if (candidate_precedes_cutoff(value, index, rank, cutoff_value, cutoff_index))
+            continue;
+        if (candidate_is_better(value, index, best_value, best_index)) {
+            best_value = value;
+            best_index = index;
+        }
+    }
+}
+
+__device__ void reduce_thread_candidates(float* values, int32_t* indices, int32_t thread) {
+    for (int32_t stride = kSampleThreads / 2; stride > 0; stride >>= 1) {
+        if (thread < stride &&
+            candidate_is_better(values[thread + stride], indices[thread + stride], values[thread],
+                                indices[thread])) {
+            values[thread] = values[thread + stride];
+            indices[thread] = indices[thread + stride];
+        }
+        __syncthreads();
+    }
+}
+
+__device__ float topk_probability_sum(const float* top_values, int32_t keep, float temperature) {
+    const float max_logit = top_values[0];
+    float sum = 0.0F;
+    for (int32_t slot = 0; slot < keep; ++slot)
+        sum += expf((top_values[slot] - max_logit) / temperature);
+    return sum;
+}
+
+__device__ float next_uniform(uint64_t* rng_state) {
+    uint64_t state = *rng_state;
+    state ^= state << 13;
+    state ^= state >> 7;
+    state ^= state << 17;
+    *rng_state = state;
+    return static_cast<float>(state & 0xFFFFFFFFULL) / 4294967296.0F;
+}
+
+__device__ int32_t sample_rank(const float* top_values, const int32_t* top_indices, int32_t keep,
+                               float temperature, float probability_sum, float draw) {
+    const float max_logit = top_values[0];
+    float cumulative = 0.0F;
+    for (int32_t slot = 0; slot < keep; ++slot) {
+        const float unnormalized = expf((top_values[slot] - max_logit) / temperature);
+        const float probability = probability_sum > 0.0F ? unnormalized / probability_sum
+                                                         : 1.0F / static_cast<float>(keep);
+        cumulative += probability;
+        if (draw < cumulative)
+            return top_indices[slot];
+    }
+    return top_indices[keep - 1];
+}
+
+__global__ void argmax_kernel(const float* logits, int32_t vocab_size, int32_t max_token_id,
+                              int32_t* token_id) {
+    __shared__ float values[kArgmaxThreads];
+    __shared__ int32_t indices[kArgmaxThreads];
+
+    const int32_t thread = threadIdx.x;
+    float best_value = -FLT_MAX;
+    int32_t best_index = INT_MAX;
+    for (int32_t index = thread; index < vocab_size; index += kArgmaxThreads) {
+        const float value = logits[index];
+        if (candidate_is_better(value, index, best_value, best_index)) {
+            best_value = value;
+            best_index = index;
+        }
+    }
+    values[thread] = best_value;
+    indices[thread] = best_index;
+    __syncthreads();
+
+    for (int32_t stride = kArgmaxThreads / 2; stride > 0; stride >>= 1) {
+        if (thread < stride &&
+            candidate_is_better(values[thread + stride], indices[thread + stride], values[thread],
+                                indices[thread])) {
+            values[thread] = values[thread + stride];
+            indices[thread] = indices[thread + stride];
+        }
+        __syncthreads();
+    }
+    if (thread == 0)
+        *token_id = min(indices[0], max_token_id);
+}
+
+__global__ void sample_topk_kernel(const float* logits, int32_t vocab_size, float temperature,
+                                   int32_t top_k, int32_t max_token_id, uint64_t* rng_state,
+                                   int32_t* token_id) {
+    __shared__ float reduction_values[kSampleThreads];
+    __shared__ int32_t reduction_indices[kSampleThreads];
+    __shared__ float top_values[kMaxTopK];
+    __shared__ int32_t top_indices[kMaxTopK];
+    const int32_t thread = threadIdx.x;
+    const int32_t keep = min(top_k, vocab_size);
+    for (int32_t rank = 0; rank < keep; ++rank) {
+        const float cutoff_value = rank > 0 ? top_values[rank - 1] : 0.0F;
+        const int32_t cutoff_index = rank > 0 ? top_indices[rank - 1] : 0;
+        float local_value;
+        int32_t local_index;
+        find_thread_candidate(logits, vocab_size, rank, cutoff_value, cutoff_index, thread,
+                              local_value, local_index);
+        reduction_values[thread] = local_value;
+        reduction_indices[thread] = local_index;
+        __syncthreads();
+        reduce_thread_candidates(reduction_values, reduction_indices, thread);
+        if (thread == 0) {
+            top_values[rank] = reduction_values[0];
+            top_indices[rank] = reduction_indices[0];
+        }
+        __syncthreads();
+    }
+
+    if (thread != 0)
+        return;
+    const float probability_sum = topk_probability_sum(top_values, keep, temperature);
+    *token_id = min(sample_rank(top_values, top_indices, keep, temperature, probability_sum,
+                                next_uniform(rng_state)),
+                    max_token_id);
+}
+
+template <typename HiddenT>
+__device__ float load_hidden(const HiddenT* hidden, int32_t index) {
+    return static_cast<float>(hidden[index]);
+}
+
+template <>
+__device__ float load_hidden<__half>(const __half* hidden, int32_t index) {
+    return __half2float(hidden[index]);
+}
+
+template <>
+__device__ float load_hidden<__nv_bfloat16>(const __nv_bfloat16* hidden, int32_t index) {
+    return __bfloat162float(hidden[index]);
+}
+
+__device__ float text_seed(const float* embedding, int64_t elements, const int32_t* selected_tokens,
+                           int32_t forced_token, bool token_is_forced, int32_t vocab_size,
+                           int32_t hidden_size, int32_t row) {
+    if (!embedding || vocab_size <= 0)
+        return 0.0F;
+    const int32_t selected = token_is_forced ? forced_token : selected_tokens[0];
+    const int32_t token = max(0, min(selected, vocab_size - 1));
+    const int64_t offset = static_cast<int64_t>(token) * hidden_size + row;
+    return offset < elements ? embedding[offset] : 0.0F;
+}
+
+__device__ float audio_seed(const float* embeddings, int64_t elements,
+                            const int32_t* selected_tokens, int32_t codebook, int32_t forced_token,
+                            bool token_is_forced, int32_t vocab_size, int32_t hidden_size,
+                            int32_t num_embeddings, int32_t row) {
+    if (!embeddings || vocab_size <= 0 || codebook <= 0 || codebook > num_embeddings)
+        return 0.0F;
+    const int32_t selected = token_is_forced ? forced_token : selected_tokens[codebook];
+    const int32_t token = max(0, min(selected, vocab_size - 1));
+    const int64_t table = static_cast<int64_t>(codebook - 1) * vocab_size * hidden_size;
+    const int64_t offset = table + static_cast<int64_t>(token) * hidden_size + row;
+    return offset < elements ? embeddings[offset] : 0.0F;
+}
+
+template <typename HiddenT>
+__device__ float projected_hidden(const HiddenT* temporal_hidden, const float* depth_projection,
+                                  int64_t projection_elements, int32_t codebook,
+                                  int32_t depth_hidden, int32_t temporal_hidden_dim, int32_t row) {
+    if (!depth_projection || !temporal_hidden || temporal_hidden_dim <= 0)
+        return 0.0F;
+    const int64_t matrix = static_cast<int64_t>(codebook) * depth_hidden * temporal_hidden_dim;
+    const int64_t row_offset = matrix + static_cast<int64_t>(row) * temporal_hidden_dim;
+    if (row_offset + temporal_hidden_dim > projection_elements)
+        return 0.0F;
+    float value = 0.0F;
+    for (int32_t column = 0; column < temporal_hidden_dim; ++column) {
+        value += depth_projection[row_offset + column] * load_hidden(temporal_hidden, column);
+    }
+    return value;
+}
+
+template <typename HiddenT>
+__global__ void prepare_depth_embedding_kernel(
+    float* output, const HiddenT* temporal_hidden, const float* depth_projection,
+    int64_t depth_projection_elements, const float* depth_text_embedding,
+    int64_t depth_text_embedding_elements, const float* depth_audio_embeddings,
+    int64_t depth_audio_embedding_elements, const int32_t* selected_tokens, int32_t codebook,
+    int32_t forced_text_token, bool text_token_is_forced, int32_t forced_previous_token,
+    bool previous_token_is_forced, int32_t depth_hidden, int32_t temporal_hidden_dim,
+    int32_t depth_text_vocab, int32_t audio_vocab_size, int32_t num_depformer_embeddings) {
+    const int32_t row = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row >= depth_hidden)
+        return;
+    const float seed =
+        codebook == 0
+            ? text_seed(depth_text_embedding, depth_text_embedding_elements, selected_tokens,
+                        forced_text_token, text_token_is_forced, depth_text_vocab, depth_hidden,
+                        row)
+            : audio_seed(depth_audio_embeddings, depth_audio_embedding_elements, selected_tokens,
+                         codebook, forced_previous_token, previous_token_is_forced,
+                         audio_vocab_size, depth_hidden, num_depformer_embeddings, row);
+    output[row] =
+        seed + projected_hidden(temporal_hidden, depth_projection, depth_projection_elements,
+                                codebook, depth_hidden, temporal_hidden_dim, row);
+}
+
+} // namespace
+
+bool personaplex_select_token(const float* logits, int32_t vocab_size, float temperature,
+                              int32_t top_k, int32_t max_token_id, uint64_t* rng_state,
+                              int32_t* token_id, cudaStream_t stream) {
+    if (!logits || !token_id || vocab_size <= 0)
+        return false;
+    max_token_id = max(0, min(max_token_id, vocab_size - 1));
+    if (temperature < 1.0e-6F || top_k <= 0 || !rng_state) {
+        argmax_kernel<<<1, kArgmaxThreads, 0, stream>>>(logits, vocab_size, max_token_id, token_id);
+        return cudaGetLastError() == cudaSuccess;
+    }
+    if (top_k > kMaxTopK)
+        return false;
+    sample_topk_kernel<<<1, kSampleThreads, 0, stream>>>(logits, vocab_size, temperature, top_k,
+                                                         max_token_id, rng_state, token_id);
+    return cudaGetLastError() == cudaSuccess;
+}
+
+void personaplex_prepare_depth_embedding(
+    float* output, const void* temporal_hidden, DType temporal_hidden_dtype,
+    const float* depth_projection, int64_t depth_projection_elements,
+    const float* depth_text_embedding, int64_t depth_text_embedding_elements,
+    const float* depth_audio_embeddings, int64_t depth_audio_embedding_elements,
+    const int32_t* selected_tokens, int32_t codebook, int32_t forced_text_token,
+    bool text_token_is_forced, int32_t forced_previous_token, bool previous_token_is_forced,
+    int32_t depth_hidden, int32_t temporal_hidden_dim, int32_t depth_text_vocab,
+    int32_t audio_vocab_size, int32_t num_depformer_embeddings, cudaStream_t stream) {
+    if (!output || !selected_tokens || depth_hidden <= 0)
+        return;
+    constexpr int32_t threads = 256;
+    const int32_t blocks = (depth_hidden + threads - 1) / threads;
+#define TRTMC_LAUNCH_DEPTH_EMBED(HIDDEN_TYPE)                                                      \
+    prepare_depth_embedding_kernel<<<blocks, threads, 0, stream>>>(                                \
+        output, static_cast<const HIDDEN_TYPE*>(temporal_hidden), depth_projection,                \
+        depth_projection_elements, depth_text_embedding, depth_text_embedding_elements,            \
+        depth_audio_embeddings, depth_audio_embedding_elements, selected_tokens, codebook,         \
+        forced_text_token, text_token_is_forced, forced_previous_token, previous_token_is_forced,  \
+        depth_hidden, temporal_hidden_dim, depth_text_vocab, audio_vocab_size,                     \
+        num_depformer_embeddings)
+    switch (temporal_hidden_dtype) {
+    case DType::kFloat16:
+        TRTMC_LAUNCH_DEPTH_EMBED(__half);
+        break;
+    case DType::kBFloat16:
+        TRTMC_LAUNCH_DEPTH_EMBED(__nv_bfloat16);
+        break;
+    case DType::kFloat32:
+    default:
+        TRTMC_LAUNCH_DEPTH_EMBED(float);
+        break;
+    }
+#undef TRTMC_LAUNCH_DEPTH_EMBED
+}
+
+} // namespace trtmc

--- a/src/runtime/models/personaplex/sampling_kernels.h
+++ b/src/runtime/models/personaplex/sampling_kernels.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/runtime/tensor.h"
+
+#include <cstdint>
+#include <cuda_runtime_api.h>
+
+namespace trtmc {
+
+bool personaplex_select_token(const float* logits, int32_t vocab_size, float temperature,
+                              int32_t top_k, int32_t max_token_id, uint64_t* rng_state,
+                              int32_t* token_id, cudaStream_t stream);
+
+void personaplex_prepare_depth_embedding(
+    float* output, const void* temporal_hidden, DType temporal_hidden_dtype,
+    const float* depth_projection, int64_t depth_projection_elements,
+    const float* depth_text_embedding, int64_t depth_text_embedding_elements,
+    const float* depth_audio_embeddings, int64_t depth_audio_embedding_elements,
+    const int32_t* selected_tokens, int32_t codebook, int32_t forced_text_token,
+    bool text_token_is_forced, int32_t forced_previous_token, bool previous_token_is_forced,
+    int32_t depth_hidden, int32_t temporal_hidden_dim, int32_t depth_text_vocab,
+    int32_t audio_vocab_size, int32_t num_depformer_embeddings, cudaStream_t stream);
+
+} // namespace trtmc

--- a/tests/builder/test_personaplex_runtime_performance_contract.py
+++ b/tests/builder/test_personaplex_runtime_performance_contract.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static performance contracts for the PersonaPlex generation runtime."""
+
+from pathlib import Path
+
+
+RUNTIME_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "runtime"
+    / "models"
+    / "personaplex"
+)
+
+
+def test_temporal_and_depth_generation_do_not_use_synchronous_host_forward() -> None:
+    source = (RUNTIME_DIR / "pipeline.cpp").read_text(encoding="utf-8")
+
+    assert "temporal_->forward_async(inputs)" in source
+    assert "engine.forward_async(inputs)" in source
+    assert "temporal_->forward(inputs)" not in source
+    assert "engine.forward(inputs)" not in source
+
+
+def test_depth_cache_reset_does_not_synchronize_the_generation_stream() -> None:
+    source = (RUNTIME_DIR / "kv_cache.cpp").read_text(encoding="utf-8")
+    reset_body = source.split("void PersonaplexKvCache::reset()", maxsplit=1)[1].split(
+        "std::size_t PersonaplexKvCache::device_memory_bytes()", maxsplit=1
+    )[0]
+
+    assert "cudaStreamSynchronize" not in reset_body
+
+
+def test_personaplex_modules_share_one_ordered_generation_stream() -> None:
+    source = (RUNTIME_DIR / "plugin.cpp").read_text(encoding="utf-8")
+
+    assert "chained_opts.stream = stream" in source
+    assert "load_depth_engines(ctx.backend, ctx.bundle, chained_opts)" in source

--- a/tests/cpp/models/personaplex/test_personaplex_sampling_kernels.cpp
+++ b/tests/cpp/models/personaplex/test_personaplex_sampling_kernels.cpp
@@ -1,0 +1,135 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/personaplex/decode_runtime.h"
+#include "runtime/models/personaplex/sampling_kernels.h"
+#include "trtmc/runtime/device_tensor.h"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& name) {
+    if (condition)
+        return;
+    std::cerr << "FAIL: " << name << '\n';
+    ++g_failures;
+}
+
+void check_cuda(cudaError_t error, const std::string& operation) {
+    check(error == cudaSuccess, operation + ": " + cudaGetErrorString(error));
+}
+
+template <typename T>
+trtmc::DeviceTensor upload(const std::vector<T>& values, trtmc::DType dtype, cudaStream_t stream) {
+    trtmc::DeviceTensor tensor({static_cast<int64_t>(values.size())}, dtype, stream);
+    check(tensor.ok(), "allocate upload tensor");
+    check(tensor.copy_from_host(values.data()), "upload tensor");
+    return tensor;
+}
+
+void check_close(const std::vector<float>& actual, const std::vector<float>& expected,
+                 const std::string& name) {
+    check(actual.size() == expected.size(), name + " size");
+    if (actual.size() != expected.size())
+        return;
+    for (std::size_t index = 0; index < actual.size(); ++index) {
+        check(std::fabs(actual[index] - expected[index]) <= 1.0e-5F,
+              name + " value " + std::to_string(index));
+    }
+}
+
+void test_argmax_and_topk_sampling(cudaStream_t stream) {
+    const std::vector<float> logits{0.25F, 1.5F, -2.0F, 4.0F, 3.0F, 0.5F, 2.5F, -1.0F};
+    auto device_logits = upload(logits, trtmc::DType::kFloat32, stream);
+    trtmc::DeviceTensor device_token({1}, trtmc::DType::kInt32, stream);
+    trtmc::DeviceTensor device_rng({2}, trtmc::DType::kInt32, stream);
+    const uint64_t initial_rng = 0x5EEDC0DECAFE1234ULL;
+    check(device_rng.copy_from_host(&initial_rng), "upload RNG state");
+
+    check(trtmc::personaplex_select_token(static_cast<const float*>(device_logits.data()),
+                                          static_cast<int32_t>(logits.size()), 0.0F, 0, 7,
+                                          static_cast<uint64_t*>(device_rng.data()),
+                                          static_cast<int32_t*>(device_token.data()), stream),
+          "launch argmax");
+    check_cuda(cudaStreamSynchronize(stream), "synchronize argmax");
+    int32_t actual = -1;
+    check(device_token.copy_to_host(&actual), "download argmax token");
+    check(actual == 3, "argmax selects maximum logit");
+
+    uint64_t host_rng = initial_rng;
+    for (int32_t iteration = 0; iteration < 4; ++iteration) {
+        const int32_t expected = trtmc::personaplex_sample_token_topk(logits, 0.8F, 4, host_rng);
+        check(trtmc::personaplex_select_token(static_cast<const float*>(device_logits.data()),
+                                              static_cast<int32_t>(logits.size()), 0.8F, 4, 7,
+                                              static_cast<uint64_t*>(device_rng.data()),
+                                              static_cast<int32_t*>(device_token.data()), stream),
+              "launch top-k sampling");
+        check_cuda(cudaStreamSynchronize(stream), "synchronize sampled token");
+        check(device_token.copy_to_host(&actual), "download sampled token");
+        check(actual == expected, "device top-k matches host selection");
+    }
+    uint64_t actual_rng = 0;
+    check(device_rng.copy_to_host(&actual_rng), "download RNG state");
+    check(actual_rng == host_rng, "device sampling advances the same RNG state");
+    check(!trtmc::personaplex_select_token(static_cast<const float*>(device_logits.data()),
+                                           static_cast<int32_t>(logits.size()), 0.8F, 4097, 7,
+                                           static_cast<uint64_t*>(device_rng.data()),
+                                           static_cast<int32_t*>(device_token.data()), stream),
+          "unsupported top-k fails closed");
+}
+
+void test_depth_embedding(cudaStream_t stream) {
+    auto hidden = upload<float>({1.0F, 2.0F}, trtmc::DType::kFloat32, stream);
+    auto projection = upload<float>({1.0F, 0.0F, 0.0F, 1.0F, 2.0F, 0.0F, 0.0F, 2.0F},
+                                    trtmc::DType::kFloat32, stream);
+    auto text_embedding =
+        upload<float>({10.0F, 11.0F, 20.0F, 21.0F}, trtmc::DType::kFloat32, stream);
+    auto audio_embedding =
+        upload<float>({30.0F, 31.0F, 40.0F, 41.0F, 50.0F, 51.0F}, trtmc::DType::kFloat32, stream);
+    auto selected = upload<int32_t>({1, 2, 0}, trtmc::DType::kInt32, stream);
+    trtmc::DeviceTensor output({2}, trtmc::DType::kFloat32, stream);
+
+    const auto run = [&](int32_t codebook, int32_t forced, bool provided) {
+        trtmc::personaplex_prepare_depth_embedding(
+            static_cast<float*>(output.data()), hidden.data(), trtmc::DType::kFloat32,
+            static_cast<const float*>(projection.data()), projection.numel(),
+            static_cast<const float*>(text_embedding.data()), text_embedding.numel(),
+            static_cast<const float*>(audio_embedding.data()), audio_embedding.numel(),
+            static_cast<const int32_t*>(selected.data()), codebook, 0, false, forced, provided, 2,
+            2, 2, 3, 1, stream);
+        check_cuda(cudaStreamSynchronize(stream), "synchronize depth embedding");
+        std::vector<float> values(2);
+        check(output.copy_to_host(values.data()), "download depth embedding");
+        return values;
+    };
+
+    check_close(run(0, 0, false), {21.0F, 23.0F}, "text-seeded depth embedding");
+    check_close(run(1, 0, false), {52.0F, 55.0F}, "sampled audio depth embedding");
+    check_close(run(1, 1, true), {42.0F, 45.0F}, "forced audio depth embedding");
+}
+
+} // namespace
+
+int main() {
+    int32_t device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count <= 0) {
+        std::cout << "SKIP: CUDA device unavailable\n";
+        return 0;
+    }
+
+    cudaStream_t stream = nullptr;
+    check_cuda(cudaStreamCreate(&stream), "create stream");
+    test_argmax_and_topk_sampling(stream);
+    test_depth_embedding(stream);
+    check_cuda(cudaStreamDestroy(stream), "destroy stream");
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Background

PersonaPlex performs one temporal and 16 autoregressively dependent depth calls per generated frame. The previous runtime synchronized and downloaded full logits after every call, leaving most complete-task latency outside TensorRT engine execution.

This PR closes #504.

## Exit Criteria

- Keep temporal/depth hidden state, cache state, embeddings, logits, RNG, and selected tokens device-resident through dependent engine calls.
- Use deterministic device-side greedy/top-k selection and same-stream asynchronous chaining.
- Reduce each generated frame from 17 full-logit synchronized round trips to the minimum host control transfer required by the current delay/stop policy.
- Preserve official token, PCM, deterministic-seed, and task-eval quality contracts.

## Implementation

- Make temporal, depth, and Mimi modules share the temporal module's ordered CUDA stream.
- Keep depth projection and embedding tables in a persistent device workspace and build each depth input embedding with a CUDA kernel.
- Execute temporal and depth engines asynchronously, select tokens on device, and download only the small selected-token frame needed by the host delay/stop controller.
- Remove the redundant synchronization from depth-cache reset; same-stream ordering preserves reset-before-use semantics.
- Add deterministic CUDA tests for greedy selection, top-k/RNG parity, forced embeddings, and unsupported sampling configurations, plus static contracts against synchronous generation calls.

## Performance And Accuracy

Measurements use the same FP16 bundle and FP32 selector, decoded PCM input, greedy policy, seed, complete-task boundary, five warmups, and 50 timed requests before and after.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Complete-task p50 | 3,544.36 ms | 1,197.47 ms | -66.21% (2.96x faster) |
| Engine execution/request | 697.69 ms | 541.04 ms | -22.45% (1.29x faster) |
| Median GPU utilization | 19% | 99% | +80 percentage points |
| Synchronized transfers/frame | 17 full-logit | 1 small token frame | 17x fewer |

GPU utilization is the median one-second SM sample from the first through the last nonzero sample, excluding pipeline load and trailing idle time.

- Non-engine time/request fell from 2,846.67 ms to 656.43 ms (-76.94%).
- Output audio quality: exact baseline/fixed hash, sample count, sample rate, duration, and RMS.
- Repository task evaluation: passed the model-owned audio and reference-token contract (`1 passed`).

## Validation

- `python3 tools/legal_headers.py --check`: passed with no findings.
- `ruff check --config ruff.toml tests/builder/test_personaplex_runtime_performance_contract.py`: passed.
- `clang-format --dry-run --Werror <changed C++/CUDA files>`: passed.
- `python3 tools/check_cyclomatic_complexity.py --max-ccn 10 <changed C++/CUDA files>`: passed; maximum CCN 9.
- `PYTHONPATH=python python3 -m pytest tests/e2e/models/personaplex --ignore=tests/e2e/models/personaplex/test_personaplex_e2e.py tests/builder/test_personaplex_runtime_performance_contract.py tests/tools/test_model_plugin_encapsulation_static.py -q -p no:cacheprovider`: 203 passed.
- `ctest --test-dir build --output-on-failure -R personaplex`: 10/10 passed on CUDA.
- Target-GPU `personaplex-7b-l0` task evaluation: passed (`1 passed`).

## Notes For Future Readers

- One tiny token-frame D2H remains because the existing host delay cache and early-stop policy control the generation loop. Full logits and hidden states no longer leave the GPU per engine call.
- Top-k values above the supported device limit fail closed instead of silently changing sampling semantics.
- Review stream ownership and workspace lifetime first, then the generation loop, then the sampling/embedding kernels and tests.
