### PR TITLE
ci: label nightly failure issues

### DIFF
--- a/tests/tools/test_nightly_issue_tracker.py
+++ b/tests/tools/test_nightly_issue_tracker.py
@@ -20,6 +20,9 @@ from tools.nightly_issue_tracker import (
     EXPECTED_API_URL,
     EXPECTED_SERVER_URL,
     FAILURE_TITLE,
+    NIGHTLY_FAILURE_LABEL,
+    NIGHTLY_FAILURE_LABEL_COLOR,
+    NIGHTLY_FAILURE_LABEL_DESCRIPTION,
     RECOVERY_TITLE,
     TRACKER_MARKER,
     GitHubApi,
@@ -76,6 +79,12 @@ class FakeApi:
         self.calls.append(("list_run_artifacts", run_id))
         return self.artifacts
 
+    def ensure_label(self, *, name: str, color: str, description: str) -> None:
+        self.calls.append(("ensure_label", name, color, description))
+
+    def add_issue_labels(self, issue_number: int, labels: list[str]) -> None:
+        self.calls.append(("add_issue_labels", issue_number, list(labels)))
+
     def create_issue(self, payload: dict[str, object]) -> dict[str, object]:
         self.calls.append(("create_issue", payload))
         return {
@@ -95,7 +104,12 @@ class FakeApi:
 
     @property
     def mutations(self) -> list[tuple[object, ...]]:
-        return [call for call in self.calls if call[0] in {"create_issue", "update_issue"}]
+        return [
+            call
+            for call in self.calls
+            if call[0]
+            in {"ensure_label", "add_issue_labels", "create_issue", "update_issue"}
+        ]
 
 
 def _run(**overrides: str) -> NightlyRun:
@@ -103,12 +117,21 @@ def _run(**overrides: str) -> NightlyRun:
 
 
 def _tracker_issue(
-    *, number: int = 55, body: str = TRACKER_MARKER, state: str = "open"
+    *,
+    number: int = 55,
+    body: str = TRACKER_MARKER,
+    state: str = "open",
+    labels: list[dict[str, str] | str] | None = None,
 ) -> dict[str, object]:
     return {
         "number": number,
         "state": state,
         "body": body,
+        "labels": (
+            labels
+            if labels is not None
+            else [{"name": "bug"}, {"name": NIGHTLY_FAILURE_LABEL}]
+        ),
         "html_url": (f"https://github.com/NVIDIA/TensorRT-Model-Connect/issues/{number}"),
     }
 
@@ -156,7 +179,7 @@ def test_default_mode_plans_a_failure_without_mutating() -> None:
     assert parse_args(["--apply"]).apply is True
 
 
-def test_first_failure_creates_one_bug_with_current_attempt_evidence() -> None:
+def test_first_failure_creates_labeled_bug_with_current_attempt_evidence() -> None:
     run = _run()
     api = FakeApi(
         issues=[
@@ -204,11 +227,16 @@ def test_first_failure_creates_one_bug_with_current_attempt_evidence() -> None:
 
     assert result.action == "created"
     assert ("list_run_jobs", 777, 2) in api.calls
-    assert len(api.mutations) == 1
-    operation, payload = api.mutations[0]
+    assert api.mutations[0] == (
+        "ensure_label",
+        NIGHTLY_FAILURE_LABEL,
+        NIGHTLY_FAILURE_LABEL_COLOR,
+        NIGHTLY_FAILURE_LABEL_DESCRIPTION,
+    )
+    operation, payload = api.mutations[1]
     assert operation == "create_issue"
     assert payload["title"] == FAILURE_TITLE
-    assert payload["labels"] == ["bug"]
+    assert payload["labels"] == ["bug", NIGHTLY_FAILURE_LABEL]
     body = str(payload["body"])
     assert TRACKER_MARKER in body
     assert run.run_marker in body
@@ -225,17 +253,29 @@ def test_first_failure_creates_one_bug_with_current_attempt_evidence() -> None:
 
 def test_later_failure_updates_the_open_tracker_and_same_attempt_is_idempotent() -> None:
     run = _run(GITHUB_RUN_ID="778", GITHUB_RUN_ATTEMPT="1")
-    tracker = _tracker_issue(body=f"{TRACKER_MARKER}\n<!-- old run -->")
+    tracker = _tracker_issue(
+        body=f"{TRACKER_MARKER}\n<!-- old run -->",
+        labels=[{"name": "bug"}, {"name": "human-triage"}],
+    )
     api = FakeApi(issues=[tracker])
 
     result = reconcile(run, api, apply=True)
 
     assert result.action == "updated"
-    assert len(api.mutations) == 1
-    operation, issue_number, payload = api.mutations[0]
+    assert api.mutations[:2] == [
+        (
+            "ensure_label",
+            NIGHTLY_FAILURE_LABEL,
+            NIGHTLY_FAILURE_LABEL_COLOR,
+            NIGHTLY_FAILURE_LABEL_DESCRIPTION,
+        ),
+        ("add_issue_labels", 55, [NIGHTLY_FAILURE_LABEL]),
+    ]
+    operation, issue_number, payload = api.mutations[2]
     assert operation == "update_issue"
     assert issue_number == 55
     assert payload["state"] == "open"
+    assert "labels" not in payload
     assert run.run_marker in str(payload["body"])
 
     reconciled = _tracker_issue(body=str(payload["body"]))
@@ -246,18 +286,73 @@ def test_later_failure_updates_the_open_tracker_and_same_attempt_is_idempotent()
     assert second_api.mutations == []
 
 
+def test_same_attempt_backfills_missing_label_without_rewriting_issue() -> None:
+    run = _run(GITHUB_RUN_ID="778", GITHUB_RUN_ATTEMPT="1")
+    tracker = _tracker_issue(
+        body=f"{TRACKER_MARKER}\n{run.run_marker}",
+        labels=[{"name": "bug"}, {"name": "human-triage"}],
+    )
+    api = FakeApi(issues=[tracker])
+
+    result = reconcile(run, api, apply=True)
+
+    assert result.action == "labeled"
+    assert api.mutations == [
+        (
+            "ensure_label",
+            NIGHTLY_FAILURE_LABEL,
+            NIGHTLY_FAILURE_LABEL_COLOR,
+            NIGHTLY_FAILURE_LABEL_DESCRIPTION,
+        ),
+        ("add_issue_labels", 55, [NIGHTLY_FAILURE_LABEL]),
+    ]
+    assert not any(call[0] == "update_issue" for call in api.calls)
+
+
+def test_same_attempt_dry_run_plans_label_without_mutating() -> None:
+    run = _run(GITHUB_RUN_ID="778", GITHUB_RUN_ATTEMPT="1")
+    tracker = _tracker_issue(
+        body=f"{TRACKER_MARKER}\n{run.run_marker}",
+        labels=[{"name": "bug"}],
+    )
+    api = FakeApi(issues=[tracker])
+
+    result = reconcile(run, api, apply=False)
+
+    assert result.action == "would-label"
+    assert api.calls == [("list_open_issues",)]
+    assert api.mutations == []
+
+
 def test_success_closes_one_open_tracker_without_erasing_failure_evidence() -> None:
     run = _run(
         NIGHTLY_REQUIRED_RESULT="success",
         NIGHTLY_RELEASE_RESULT="success",
     )
-    api = FakeApi(issues=[_tracker_issue(body=f"{TRACKER_MARKER}\nlast failure evidence")])
+    api = FakeApi(
+        issues=[
+            _tracker_issue(
+                body=f"{TRACKER_MARKER}\nlast failure evidence",
+                labels=[{"name": "bug"}, {"name": "human-triage"}],
+            )
+        ]
+    )
 
     result = reconcile(run, api, apply=True)
 
     assert result.action == "closed"
-    operation, issue_number, payload = api.mutations[0]
+    assert api.mutations[:2] == [
+        (
+            "ensure_label",
+            NIGHTLY_FAILURE_LABEL,
+            NIGHTLY_FAILURE_LABEL_COLOR,
+            NIGHTLY_FAILURE_LABEL_DESCRIPTION,
+        ),
+        ("add_issue_labels", 55, [NIGHTLY_FAILURE_LABEL]),
+    ]
+    operation, issue_number, payload = api.mutations[2]
     assert operation == "update_issue" and issue_number == 55
+    assert "labels" not in payload
     assert payload["title"] == RECOVERY_TITLE
     assert payload["state"] == "closed"
     assert payload["state_reason"] == "completed"
@@ -296,6 +391,208 @@ def test_rest_client_refuses_mutation_without_explicit_apply() -> None:
 
     with pytest.raises(TrackerError, match="without --apply"):
         api.create_issue({"title": "must not be sent"})
+    with pytest.raises(TrackerError, match="without --apply"):
+        api.add_issue_labels(55, [NIGHTLY_FAILURE_LABEL])
+
+    class MissingLabelApi(GitHubApi):
+        def _request(
+            self,
+            method: str,
+            path: str,
+            payload: dict[str, object] | None = None,
+            *,
+            allow_not_found: bool = False,
+        ) -> object:
+            return None
+
+    missing = MissingLabelApi(
+        api_url=EXPECTED_API_URL,
+        repository=EXPECTED_REPOSITORY,
+        token="not-a-real-token",
+        allow_mutations=False,
+    )
+    with pytest.raises(TrackerError, match="without --apply"):
+        missing.ensure_label(
+            name=NIGHTLY_FAILURE_LABEL,
+            color=NIGHTLY_FAILURE_LABEL_COLOR,
+            description=NIGHTLY_FAILURE_LABEL_DESCRIPTION,
+        )
+
+
+def test_rest_client_creates_missing_repository_label() -> None:
+    class RecordingApi(GitHubApi):
+        def __init__(self) -> None:
+            super().__init__(
+                api_url=EXPECTED_API_URL,
+                repository=EXPECTED_REPOSITORY,
+                token="not-a-real-token",
+                allow_mutations=True,
+            )
+            self.requests: list[tuple[object, ...]] = []
+
+        def _request(
+            self,
+            method: str,
+            path: str,
+            payload: dict[str, object] | None = None,
+            *,
+            allow_not_found: bool = False,
+        ) -> object:
+            self.requests.append((method, path, payload, allow_not_found))
+            if method == "GET":
+                return None
+            return {"name": NIGHTLY_FAILURE_LABEL}
+
+    api = RecordingApi()
+
+    api.ensure_label(
+        name=NIGHTLY_FAILURE_LABEL,
+        color=NIGHTLY_FAILURE_LABEL_COLOR,
+        description=NIGHTLY_FAILURE_LABEL_DESCRIPTION,
+    )
+
+    assert api.requests == [
+        (
+            "GET",
+            "/repos/NVIDIA/TensorRT-Model-Connect/labels/Nightly%20Failure",
+            None,
+            True,
+        ),
+        (
+            "POST",
+            "/repos/NVIDIA/TensorRT-Model-Connect/labels",
+            {
+                "name": NIGHTLY_FAILURE_LABEL,
+                "color": NIGHTLY_FAILURE_LABEL_COLOR,
+                "description": NIGHTLY_FAILURE_LABEL_DESCRIPTION,
+            },
+            False,
+        ),
+    ]
+
+
+def test_rest_client_reuses_existing_repository_label() -> None:
+    class RecordingApi(GitHubApi):
+        def __init__(self) -> None:
+            super().__init__(
+                api_url=EXPECTED_API_URL,
+                repository=EXPECTED_REPOSITORY,
+                token="not-a-real-token",
+                allow_mutations=True,
+            )
+            self.requests: list[tuple[object, ...]] = []
+
+        def _request(
+            self,
+            method: str,
+            path: str,
+            payload: dict[str, object] | None = None,
+            *,
+            allow_not_found: bool = False,
+        ) -> object:
+            self.requests.append((method, path, payload, allow_not_found))
+            return {"name": "NIGHTLY FAILURE"}
+
+    api = RecordingApi()
+
+    api.ensure_label(
+        name=NIGHTLY_FAILURE_LABEL,
+        color=NIGHTLY_FAILURE_LABEL_COLOR,
+        description=NIGHTLY_FAILURE_LABEL_DESCRIPTION,
+    )
+
+    assert api.requests == [
+        (
+            "GET",
+            "/repos/NVIDIA/TensorRT-Model-Connect/labels/Nightly%20Failure",
+            None,
+            True,
+        )
+    ]
+
+
+def test_rest_client_adds_label_without_replacing_existing_labels() -> None:
+    class RecordingApi(GitHubApi):
+        def __init__(self) -> None:
+            super().__init__(
+                api_url=EXPECTED_API_URL,
+                repository=EXPECTED_REPOSITORY,
+                token="not-a-real-token",
+                allow_mutations=True,
+            )
+            self.request: tuple[object, ...] | None = None
+
+        def _request(
+            self,
+            method: str,
+            path: str,
+            payload: dict[str, object] | None = None,
+            *,
+            allow_not_found: bool = False,
+        ) -> object:
+            self.request = (method, path, payload, allow_not_found)
+            return [
+                {"name": "bug"},
+                {"name": "human-triage"},
+                {"name": NIGHTLY_FAILURE_LABEL},
+            ]
+
+    api = RecordingApi()
+
+    api.add_issue_labels(55, [NIGHTLY_FAILURE_LABEL])
+
+    assert api.request == (
+        "POST",
+        "/repos/NVIDIA/TensorRT-Model-Connect/issues/55/labels",
+        {"labels": [NIGHTLY_FAILURE_LABEL]},
+        False,
+    )
+
+
+def test_rest_client_rejects_an_incomplete_add_labels_response() -> None:
+    class DroppingApi(GitHubApi):
+        def _request(
+            self,
+            method: str,
+            path: str,
+            payload: dict[str, object] | None = None,
+            *,
+            allow_not_found: bool = False,
+        ) -> object:
+            return [{"name": "bug"}]
+
+    api = DroppingApi(
+        api_url=EXPECTED_API_URL,
+        repository=EXPECTED_REPOSITORY,
+        token="not-a-real-token",
+        allow_mutations=True,
+    )
+
+    with pytest.raises(TrackerError, match="did not apply issue labels"):
+        api.add_issue_labels(55, [NIGHTLY_FAILURE_LABEL])
+
+
+def test_create_repairs_any_labels_dropped_by_github() -> None:
+    class DroppingApi(FakeApi):
+        def create_issue(self, payload: dict[str, object]) -> dict[str, object]:
+            self.calls.append(("create_issue", payload))
+            return {
+                "number": 101,
+                "state": "open",
+                "labels": [],
+                "html_url": "https://github.com/NVIDIA/TensorRT-Model-Connect/issues/101",
+            }
+
+    api = DroppingApi()
+
+    result = reconcile(_run(), api, apply=True)
+
+    assert result.action == "created"
+    assert api.mutations[-1] == (
+        "add_issue_labels",
+        101,
+        ["bug", NIGHTLY_FAILURE_LABEL],
+    )
 
 
 def test_rest_client_refuses_to_send_token_to_another_host_or_repository() -> None:

--- a/tools/nightly_issue_tracker.py
+++ b/tools/nightly_issue_tracker.py
@@ -13,6 +13,7 @@ import sys
 from dataclasses import dataclass
 from typing import Mapping, Protocol, Sequence
 from urllib.error import HTTPError, URLError
+from urllib.parse import quote
 from urllib.request import Request, urlopen
 
 
@@ -26,6 +27,10 @@ EXPECTED_API_URL = "https://api.github.com"
 TRACKER_MARKER = "<!-- trtmc-nightly-failure-tracker:v1 -->"
 FAILURE_TITLE = "[Nightly] Scheduled validation needs attention"
 RECOVERY_TITLE = "[Nightly] Scheduled validation recovered"
+NIGHTLY_FAILURE_LABEL = "Nightly Failure"
+NIGHTLY_FAILURE_LABEL_COLOR = "B60205"
+NIGHTLY_FAILURE_LABEL_DESCRIPTION = "Automated failure in the scheduled Nightly workflow"
+REQUIRED_ISSUE_LABELS = ("bug", NIGHTLY_FAILURE_LABEL)
 FAILURE_CONCLUSIONS = {
     "action_required",
     "cancelled",
@@ -147,6 +152,10 @@ class TrackerApi(Protocol):
 
     def list_run_artifacts(self, run_id: int) -> list[dict[str, object]]: ...
 
+    def ensure_label(self, *, name: str, color: str, description: str) -> None: ...
+
+    def add_issue_labels(self, issue_number: int, labels: Sequence[str]) -> None: ...
+
     def create_issue(self, payload: dict[str, object]) -> dict[str, object]: ...
 
     def update_issue(self, issue_number: int, payload: dict[str, object]) -> dict[str, object]: ...
@@ -179,6 +188,8 @@ class GitHubApi:
         method: str,
         path: str,
         payload: dict[str, object] | None = None,
+        *,
+        allow_not_found: bool = False,
     ) -> object:
         data = None if payload is None else json.dumps(payload).encode("utf-8")
         headers = {
@@ -199,6 +210,8 @@ class GitHubApi:
             with urlopen(request, timeout=30) as response:  # noqa: S310
                 body = response.read()
         except HTTPError as error:
+            if allow_not_found and error.code == 404:
+                return None
             details = error.read(2_000).decode("utf-8", errors="replace")
             raise TrackerError(
                 f"GitHub API {method} {path} returned {error.code}: {details}"
@@ -256,8 +269,41 @@ class GitHubApi:
             raise TrackerError("GitHub issue mutation was attempted without --apply")
         response = self._request(method, path, payload)
         if not isinstance(response, dict):
-            raise TrackerError(f"GitHub API {method} {path} returned no issue object")
+            raise TrackerError(f"GitHub API {method} {path} returned no resource object")
         return response
+
+    def ensure_label(self, *, name: str, color: str, description: str) -> None:
+        encoded_name = quote(name, safe="")
+        path = f"/repos/{self.repository}/labels/{encoded_name}"
+        existing = self._request("GET", path, allow_not_found=True)
+        if existing is not None:
+            if not isinstance(existing, dict) or str(existing.get("name") or "").casefold() != (
+                name.casefold()
+            ):
+                raise TrackerError(f"GitHub API GET {path} returned an invalid label object")
+            return
+        created = self._mutate(
+            "POST",
+            f"/repos/{self.repository}/labels",
+            {"name": name, "color": color, "description": description},
+        )
+        if str(created.get("name") or "").casefold() != name.casefold():
+            raise TrackerError("GitHub API created an unexpected repository label")
+
+    def add_issue_labels(self, issue_number: int, labels: Sequence[str]) -> None:
+        if not self.allow_mutations:
+            raise TrackerError("GitHub issue mutation was attempted without --apply")
+        response = self._request(
+            "POST",
+            f"/repos/{self.repository}/issues/{issue_number}/labels",
+            {"labels": list(labels)},
+        )
+        if not isinstance(response, list) or not all(isinstance(item, dict) for item in response):
+            raise TrackerError("GitHub API returned an invalid issue label list")
+        names = {str(item.get("name") or "").casefold() for item in response}
+        missing = [label for label in labels if label.casefold() not in names]
+        if missing:
+            raise TrackerError(f"GitHub API did not apply issue labels: {', '.join(missing)}")
 
     def create_issue(self, payload: dict[str, object]) -> dict[str, object]:
         return self._mutate("POST", f"/repos/{self.repository}/issues", payload)
@@ -304,6 +350,41 @@ def _issue_number(issue: Mapping[str, object]) -> int:
 def _issue_url(issue: Mapping[str, object]) -> str | None:
     value = issue.get("html_url")
     return value if isinstance(value, str) and value.startswith("https://") else None
+
+
+def _issue_has_label(issue: Mapping[str, object], label_name: str) -> bool:
+    raw_labels = issue.get("labels")
+    if not isinstance(raw_labels, list):
+        return False
+    for label in raw_labels:
+        if isinstance(label, str):
+            name = label
+        elif isinstance(label, Mapping):
+            name = str(label.get("name") or "")
+        else:
+            continue
+        if name.casefold() == label_name.casefold():
+            return True
+    return False
+
+
+def _missing_issue_labels(
+    issue: Mapping[str, object], required_labels: Sequence[str]
+) -> list[str]:
+    return [label for label in required_labels if not _issue_has_label(issue, label)]
+
+
+def _ensure_nightly_failure_label(api: TrackerApi) -> None:
+    api.ensure_label(
+        name=NIGHTLY_FAILURE_LABEL,
+        color=NIGHTLY_FAILURE_LABEL_COLOR,
+        description=NIGHTLY_FAILURE_LABEL_DESCRIPTION,
+    )
+
+
+def _add_nightly_failure_label(api: TrackerApi, tracker: Mapping[str, object]) -> None:
+    _ensure_nightly_failure_label(api)
+    api.add_issue_labels(_issue_number(tracker), [NIGHTLY_FAILURE_LABEL])
 
 
 def _find_tracker(issues: Sequence[Mapping[str, object]]) -> Mapping[str, object] | None:
@@ -463,23 +544,41 @@ def reconcile(run: NightlyRun, api: TrackerApi, *, apply: bool) -> ReconcileResu
         }
         if not apply:
             return _result("would-close", tracker)
+        if not _issue_has_label(tracker, NIGHTLY_FAILURE_LABEL):
+            _add_nightly_failure_label(api, tracker)
         return _result("closed", api.update_issue(_issue_number(tracker), payload))
 
     if tracker is not None and run.run_marker in str(tracker.get("body") or ""):
+        if not _issue_has_label(tracker, NIGHTLY_FAILURE_LABEL):
+            if not apply:
+                return _result("would-label", tracker)
+            _add_nightly_failure_label(api, tracker)
+            return _result("labeled", tracker)
         return _result("already-reconciled", tracker)
 
     jobs = api.list_run_jobs(run.run_id, run.run_attempt)
     artifacts = api.list_run_artifacts(run.run_id)
     body = render_failure_body(run, jobs, artifacts)
     if tracker is None:
-        payload = {"title": FAILURE_TITLE, "body": body, "labels": ["bug"]}
+        payload = {
+            "title": FAILURE_TITLE,
+            "body": body,
+            "labels": list(REQUIRED_ISSUE_LABELS),
+        }
         if not apply:
             return _result("would-create")
-        return _result("created", api.create_issue(payload))
+        _ensure_nightly_failure_label(api)
+        created = api.create_issue(payload)
+        missing_labels = _missing_issue_labels(created, REQUIRED_ISSUE_LABELS)
+        if missing_labels:
+            api.add_issue_labels(_issue_number(created), missing_labels)
+        return _result("created", created)
 
     payload = {"title": FAILURE_TITLE, "body": body, "state": "open"}
     if not apply:
         return _result("would-update", tracker)
+    if not _issue_has_label(tracker, NIGHTLY_FAILURE_LABEL):
+        _add_nightly_failure_label(api, tracker)
     return _result("updated", api.update_issue(_issue_number(tracker), payload))
 
 


### PR DESCRIPTION
## Background

Nightly failure issues currently carry only the generic `bug` label, so scheduled failures cannot be filtered reliably from other defects.

## Exit criteria

- New automated Nightly failure issues carry both `bug` and `Nightly Failure`.
- Existing open Nightly trackers are backfilled additively, preserving human-applied labels.
- Dry runs and non-production workflow contexts cannot mutate repository labels or issues.

## Implementation

- Ensure the dedicated red `Nightly Failure` repository label exists before a production issue mutation.
- Add missing labels through the additive issue-label endpoint rather than replacing the issue's full label set.
- Validate GitHub responses and repair labels if issue creation omits either required label.
- Cover creation, repeated attempts, later failures, recovery, legacy trackers, mutation guards, and malformed API responses.

## Validation

- `env -u GITHUB_TOKEN -u GH_TOKEN PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/tools/test_nightly_issue_tracker.py -q -p no:cacheprovider` — 24 passed
- `ruff check --config ruff.toml tools/nightly_issue_tracker.py tests/tools/test_nightly_issue_tracker.py` — passed
- `python3 tools/test_impact.py --validate` — passed (200 models, 12 core, 77 families)
- `python3 tools/legal_headers.py --check` — passed (0 findings)
- CI-image tools suite with `--network none`, a read-only source mount, and no GitHub credentials — 343 passed
- `git diff --check` — passed

## Safety

The repository label is created lazily only when a real scheduled-main Nightly failure needs an issue mutation. Local and container tests had no network access or GitHub token, so they could not create labels or pollute the current issue list.
