### PR TITLE
feat(dev): manage GPU workspaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,24 @@
   test.
 - Never change the test passing criteria for the purpose of passing CI. If you believe the test is faulty, escalate to a human
 
+## Managed GPU Host Workspaces
+
+- On a shared GPU host, use `scripts/manage_gpu_workspace.sh` and the canonical
+  layout documented in `website/docs/operations/managed-gpu-workspaces.md`.
+- Use one stable workspace ID for one deployed worktree, one run directory, one
+  state manifest, and one Docker container. Never reuse a container for a
+  different worktree, even when the image and branch are similar.
+- Put durable outputs under the matching `runs/<workspace-id>/` tree. Only the
+  Hugging Face cache and read-only datasets are shared across workspaces. Do
+  not write new artifacts into a legacy shared engine directory or an ad hoc
+  home, repository, or temporary directory.
+- Keep hostnames, addresses, credentials, and host-specific roots in the
+  machine-local host config, never in tracked repository files.
+- Before proposing cleanup, run the manager's read-only `audit` command and
+  match every candidate to its workspace/container state. Agents must not
+  remove containers, workspaces, run directories, caches, images, or Docker
+  build cache without explicit user approval for the exact targets.
+
 ## Repo Skills
 
 - Codex skills packaged for this repo are registered through

--- a/scripts/autopilot/autorun.py
+++ b/scripts/autopilot/autorun.py
@@ -32,7 +32,11 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 # Config — edit these to match your setup
 # ---------------------------------------------------------------------------
-WORKSPACE_ROOT = "/workspace/users/yifeif/workspaces"
+HOST_ROOT = os.environ.get("TRTMC_HOST_ROOT", "")
+WORKSPACE_ROOT = os.environ.get(
+    "TRTMC_WORKSPACE_ROOT",
+    str(Path(HOST_ROOT) / "workspaces") if HOST_ROOT else "",
+)
 DISCOVER_CONTAINER = "trtmc-dev-gb300-agent-1"
 DEFAULT_AGENT_BIN = "codex"
 DEFAULT_AGENT_ARGS = [
@@ -148,14 +152,14 @@ WORKER_PROMPT = textwrap.dedent("""\
       "
       ```
     - Read existing family plugins for reference at:
-      /workspace/users/yifeif/workspaces/{agent_id}/tensorrt-model-connect/python/tensorrt_model_connect/families/
+      {workspace}/python/tensorrt_model_connect/families/
     - Read the selected family's model/model.py for graph operations and blocks.
     - Read the HF model's modeling code to understand the EXACT computation.
     - If the model uses a novel attention mechanism (disentangled, sliding
       window, linear, etc.), you MUST implement it correctly in the plugin's
       build_engine() — do not approximate or skip it.
     - Edit the plugin on the HOST at:
-      /workspace/users/yifeif/workspaces/{agent_id}/tensorrt-model-connect/python/tensorrt_model_connect/families/{family_name}/
+      {workspace}/python/tensorrt_model_connect/families/{family_name}/
       Keep plugin.py and config.py at the root; put weight loading in weights/
       and graph/build/runtime implementation in model/.
 
@@ -166,7 +170,7 @@ WORKER_PROMPT = textwrap.dedent("""\
 
     How to add a C++ runtime plugin:
     1. Read an existing plugin for reference. Key files at:
-       /workspace/users/yifeif/workspaces/{agent_id}/tensorrt-model-connect/src/runtime/plugins/
+       {workspace}/src/runtime/plugins/
        - decoder_plugin.cpp (decoder-only text gen)
        - a specialized encoder-decoder plugin
        - encoder_plugin.cpp (encoder-only)
@@ -185,7 +189,7 @@ WORKER_PROMPT = textwrap.dedent("""\
 
     ### Done
     When ALL THREE validation gates pass, create the E2E manifest at (HOST path):
-    /workspace/users/yifeif/workspaces/{agent_id}/tensorrt-model-connect/tests/e2e/models/{family_name}/manifests/{family_name}.json
+    {workspace}/tests/e2e/models/{family_name}/manifests/{family_name}.json
     Also list it in tests/e2e/models/{family_name}/MODEL.toml.
     The manifest must NOT have a "skip" field.
 
@@ -194,7 +198,7 @@ WORKER_PROMPT = textwrap.dedent("""\
     docker exec trtmc-dev-gb300-{agent_id} /opt/venv/bin/python -m pytest \
         tests/e2e/models/{family_name}/test_{family_name}_e2e.py -v \
         --e2e-model {family_name} \
-        --engine-dir /workspace/users/yifeif/tensorrt-model-connect/engines \
+        --engine-dir /work/engines \
         --trtmc-binary ./build/trtmc --hf-python /opt/venv/bin/python \
         --rebuild-engines
     ```
@@ -206,7 +210,7 @@ WORKER_PROMPT = textwrap.dedent("""\
     ### Submit
     After validation passes, prepare a focused commit and GitHub PR:
     ```
-    cd /workspace/users/yifeif/workspaces/{agent_id}/tensorrt-model-connect
+    cd {workspace}
     git fetch github main
     git switch -C autopilot/{family_name} github/main
     git status --short
@@ -237,8 +241,8 @@ WORKER_PROMPT = textwrap.dedent("""\
       "
       ```
       The container's /workspace/tensorrt-model-connect/ maps to the host workspace.
-      Do NOT try to write directly to /workspace/users/yifeif/workspaces/{agent_id}/
-      — that path is read-only from the sandbox. Always write via docker exec.
+      Do not write to any other host workspace. Always write through this
+      worktree's matching container.
     - **Decoupling**: Create NEW files for your plugin — do NOT modify existing
       plugins (decoder, encoder, or modality-specific plugins, etc.).
       Each family gets its own isolated Python plugin and (if needed) its own
@@ -349,7 +353,9 @@ _OPTIMIZE_SECTION = """\
 """
 
 
-def build_prompt(task: dict, agent_id: str, *, optimize: bool = False) -> str:
+def build_prompt(
+    task: dict, agent_id: str, workspace: str, *, optimize: bool = False
+) -> str:
     """Fill in the worker prompt template."""
     trust_rc = task.get("trust_remote_code", False)
     optimize_section = ""
@@ -363,6 +369,7 @@ def build_prompt(task: dict, agent_id: str, *, optimize: bool = False) -> str:
         hf_id=task["hf_id"],
         family_name=task["family_name"],
         agent_id=agent_id,
+        workspace=workspace,
         trust_remote_code_line=(
             "- trust_remote_code: yes" if trust_rc else ""),
         trust_flag="--trust-remote-code" if trust_rc else "",
@@ -418,9 +425,13 @@ def launch_batch(
 ) -> dict[str, subprocess.Popen]:
     """Launch the configured agent CLI for each (agent_id, task) pair."""
     procs = {}
+    if not WORKSPACE_ROOT:
+        raise RuntimeError(
+            "Set TRTMC_HOST_ROOT or TRTMC_WORKSPACE_ROOT before launching autopilot agents"
+        )
     for agent_id, task in batch:
-        workspace = f"{WORKSPACE_ROOT}/{agent_id}/tensorrt-model-connect"
-        prompt = build_prompt(task, agent_id, optimize=optimize)
+        workspace = str(Path(WORKSPACE_ROOT) / agent_id / "repo")
+        prompt = build_prompt(task, agent_id, workspace, optimize=optimize)
         family = task["family_name"]
 
         if dry_run:

--- a/scripts/autopilot/dispatch.py
+++ b/scripts/autopilot/dispatch.py
@@ -38,7 +38,11 @@ from pathlib import Path
 # Configuration
 # ---------------------------------------------------------------------------
 
-WORKSPACE_ROOT = "/workspace/users/yifeif/workspaces"
+HOST_ROOT = os.environ.get("TRTMC_HOST_ROOT", "")
+WORKSPACE_ROOT = os.environ.get(
+    "TRTMC_WORKSPACE_ROOT",
+    str(Path(HOST_ROOT) / "workspaces") if HOST_ROOT else "",
+)
 DEFAULT_AGENTS = ["agent-1", "agent-2", "agent-3", "agent-4"]
 DEFAULT_AGENT_BIN = "codex"
 DEFAULT_AGENT_ARGS = [
@@ -137,7 +141,7 @@ WORKER_PROMPT = textwrap.dedent("""\
 
     ## Step 5: Commit, push, and open a PR
     ```
-    cd /workspace/users/yifeif/workspaces/{agent_id}/tensorrt-model-connect
+    cd {workspace}
     git fetch github main
     git switch -C autopilot/{family_name} github/main
     git add python/tensorrt_model_connect/families/{family_name}.py
@@ -154,7 +158,7 @@ WORKER_PROMPT = textwrap.dedent("""\
     At the end, write a JSON status file to the WORKSPACE (not container /tmp):
     ```
     echo '{{"family": "{family_name}", "status": "PASS", "branch": "autopilot/{family_name}"}}' \\
-        > /workspace/users/yifeif/workspaces/{agent_id}/tensorrt-model-connect/.autopilot_status.json
+        > {workspace}/.autopilot_status.json
     ```
     If all retries failed, write status "FAIL" with the last error message instead.
     Write this file on the HOST filesystem, not via docker exec.
@@ -186,7 +190,9 @@ _OPTIMIZE_SECTION = """\
 """
 
 
-def build_prompt(task: dict, agent_id: str, *, optimize: bool = False) -> str:
+def build_prompt(
+    task: dict, agent_id: str, workspace: str, *, optimize: bool = False
+) -> str:
     """Fill in the worker prompt template for a specific task."""
     trust_rc = task.get("trust_remote_code", False)
     optimize_section = ""
@@ -198,6 +204,7 @@ def build_prompt(task: dict, agent_id: str, *, optimize: bool = False) -> str:
         hf_id=task["hf_id"],
         family_name=task["family_name"],
         agent_id=agent_id,
+        workspace=workspace,
         trust_remote_code_line=(
             "- trust_remote_code: yes" if trust_rc else ""),
         trust_flag="--trust-remote-code" if trust_rc else "",
@@ -248,8 +255,12 @@ def launch_agent(
     optimize: bool = False,
 ) -> subprocess.Popen | None:
     """Launch an agent CLI session for one task in one agent workspace."""
-    workspace = f"{WORKSPACE_ROOT}/{agent_id}/tensorrt-model-connect"
-    prompt = build_prompt(task, agent_id, optimize=optimize)
+    if not WORKSPACE_ROOT:
+        raise RuntimeError(
+            "Set TRTMC_HOST_ROOT or TRTMC_WORKSPACE_ROOT before launching autopilot agents"
+        )
+    workspace = str(Path(WORKSPACE_ROOT) / agent_id / "repo")
+    prompt = build_prompt(task, agent_id, workspace, optimize=optimize)
 
     if dry_run:
         print(f"\n{'='*60}")
@@ -296,7 +307,7 @@ def wait_for_batch(
                 # Check status file (written to workspace by agent)
                 status_file = (
                     f"{WORKSPACE_ROOT}/{agent_id}/"
-                    f"tensorrt-model-connect/.autopilot_status.json"
+                    f"repo/.autopilot_status.json"
                 )
                 status = {"family": family, "status": "UNKNOWN"}
                 if os.path.exists(status_file):
@@ -455,7 +466,13 @@ def main():
 
     # Verify agent workspaces exist
     for aid in agent_ids:
-        ws = Path(f"{WORKSPACE_ROOT}/{aid}/tensorrt-model-connect")
+        if not WORKSPACE_ROOT:
+            print(
+                "ERROR: Set TRTMC_HOST_ROOT or TRTMC_WORKSPACE_ROOT before dispatch.",
+                file=sys.stderr,
+            )
+            return
+        ws = Path(WORKSPACE_ROOT) / aid / "repo"
         if not ws.is_dir() and args.mode != "dry-run":
             print(f"WARNING: Workspace {ws} does not exist.", file=sys.stderr)
             print(f"  Bootstrap it: ./scripts/bootstrap_workspace.sh "

--- a/scripts/autopilot/optimize_supervisor.sh
+++ b/scripts/autopilot/optimize_supervisor.sh
@@ -19,7 +19,13 @@ AGENT_ID="${4:-agent-3}"
 SAFE_NAME="$(echo "$MODEL_ID" | tr '/' '_' | tr '.' '_')"
 PROGRESS_FILE="/tmp/optimize_progress_${SAFE_NAME}.json"
 CONTAINER="trtmc-dev-gb300-${AGENT_ID}"
-REPO_DIR="/workspace/users/yifeif/workspaces/${AGENT_ID}/tensorrt-model-connect"
+HOST_CONFIG="${TRTMC_HOST_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/trtmc/host.env}"
+if [ -f "$HOST_CONFIG" ]; then
+    # shellcheck source=/dev/null
+    source "$HOST_CONFIG"
+fi
+: "${TRTMC_HOST_ROOT:?Set TRTMC_HOST_ROOT before running the optimize supervisor}"
+REPO_DIR="${TRTMC_WORKSPACE_ROOT:-${TRTMC_HOST_ROOT%/}/workspaces}/${AGENT_ID}/repo"
 AGENT_BIN="${TRTMC_AGENT_BIN:-codex}"
 read -r -a AGENT_ARGS <<< "${TRTMC_AGENT_ARGS:-exec -s danger-full-access -a never -C {workspace} {prompt}}"
 

--- a/scripts/autopilot/run.sh
+++ b/scripts/autopilot/run.sh
@@ -19,6 +19,16 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+HOST_CONFIG="${TRTMC_HOST_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/trtmc/host.env}"
+
+if [ -f "$HOST_CONFIG" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$HOST_CONFIG"
+    set +a
+fi
+
+: "${TRTMC_HOST_ROOT:?Set TRTMC_HOST_ROOT or create $HOST_CONFIG}"
 
 # Defaults
 MIN_DOWNLOADS=10000

--- a/scripts/bootstrap_workspace.sh
+++ b/scripts/bootstrap_workspace.sh
@@ -2,167 +2,121 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Bootstrap an isolated workspace: clone repo + start a uniquely-named container.
-#
-# Each workspace gets:
-#   - Its own repo clone at /workspace/users/yifeif/workspaces/<id>/tensorrt-model-connect
-#   - Its own Docker container named trtmc-dev-gb300-<id>
-#   - Shared HF cache and engine storage (read-mostly, safe to share)
-#   - Isolated build artifacts and git state
-#
-# Usage:
-#   ./scripts/bootstrap_workspace.sh                    # auto-generate ID
-#   ./scripts/bootstrap_workspace.sh --id my-feature    # custom ID
-#   ./scripts/bootstrap_workspace.sh --branch feat/foo  # checkout a branch
-#   ./scripts/bootstrap_workspace.sh --id agent-1 --branch feat/foo --detach
-#
-# The script prints the container name and repo path for use by agent teams.
+# Create a canonical host checkout and start its one-to-one dev container.
+# Existing checkouts and containers are reused but never removed by this script.
 
 set -euo pipefail
 
-# --- Defaults ----------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MANAGER="$SCRIPT_DIR/manage_gpu_workspace.sh"
+HOST_CONFIG="${TRTMC_HOST_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/trtmc/host.env}"
 
-WORKSPACE_ROOT="/workspace/users/yifeif/workspaces"
+if [ -f "$HOST_CONFIG" ]; then
+    # shellcheck source=/dev/null
+    source "$HOST_CONFIG"
+fi
+
 GIT_REMOTE="${TRTMC_GIT_REMOTE:-https://github.com/NVIDIA/TensorRT-Model-Connect.git}"
-DOCKER_IMAGE="trtmc-dev-gb300:latest"
-STORAGE_ROOT="/workspace/users/yifeif/tensorrt-model-connect"
-HF_CACHE="/mnt/storage/tensorrt-model-connect/model-weights"
-
+DOCKER_IMAGE="${TRTMC_DOCKER_IMAGE:-trtmc-dev-gb300:latest}"
 WORKSPACE_ID=""
 BRANCH="main"
 DETACH=false
 BUILD=true
 
-# --- Parse args --------------------------------------------------------------
+usage() {
+    cat <<EOF
+Usage: $0 --id ID [--branch BRANCH] [--detach] [--no-build] [--image IMAGE]
 
-while [ $# -gt 0 ]; do
+Options:
+  --id ID          Stable identifier shared by the worktree, run directory,
+                   state manifest, and container
+  --branch BRANCH  Branch to clone when the canonical checkout is absent
+                   (default: main)
+  --detach         Return after the container is ready instead of opening a shell
+  --no-build       Skip editable install and C++ build
+  --image IMAGE    Container image (default: $DOCKER_IMAGE)
+
+The checkout is created at:
+  TRTMC_HOST_ROOT/workspaces/ID/repo
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
     case "$1" in
-        --id)          WORKSPACE_ID="$2"; shift 2 ;;
-        --branch)      BRANCH="$2"; shift 2 ;;
-        --detach)      DETACH=true; shift ;;
-        --no-build)    BUILD=false; shift ;;
-        --image)       DOCKER_IMAGE="$2"; shift 2 ;;
-        -h|--help)
-            echo "Usage: $0 [--id NAME] [--branch BRANCH] [--detach] [--no-build] [--image IMAGE]"
-            echo ""
-            echo "Options:"
-            echo "  --id NAME       Workspace identifier (default: auto-generated UUID)"
-            echo "  --branch BRANCH Git branch to checkout (default: main)"
-            echo "  --detach        Run container in background (default: interactive)"
-            echo "  --no-build      Skip C++ build step"
-            echo "  --image IMAGE   Docker image to use (default: trtmc-dev-gb300:latest)"
-            exit 0
-            ;;
-        *)
-            echo "ERROR: Unknown argument: $1" >&2
-            exit 1
-            ;;
+        --id) WORKSPACE_ID="$2"; shift 2 ;;
+        --branch) BRANCH="$2"; shift 2 ;;
+        --detach) DETACH=true; shift ;;
+        --no-build) BUILD=false; shift ;;
+        --image) DOCKER_IMAGE="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "ERROR: Unknown argument: $1" >&2; usage >&2; exit 1 ;;
     esac
 done
 
-# Auto-generate ID if not provided
-if [ -z "$WORKSPACE_ID" ]; then
-    WORKSPACE_ID="ws-$(head -c 4 /dev/urandom | xxd -p)"
-fi
-
-REPO_DIR="${WORKSPACE_ROOT}/${WORKSPACE_ID}/tensorrt-model-connect"
-CONTAINER_NAME="trtmc-dev-gb300-${WORKSPACE_ID}"
-ENGINE_DIR="${STORAGE_ROOT}/engines"
-
-# --- Validate ----------------------------------------------------------------
-
-if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
-    echo "ERROR: Container ${CONTAINER_NAME} already exists." >&2
-    echo "  Stop it:   docker rm -f ${CONTAINER_NAME}" >&2
-    echo "  Or pick a different --id" >&2
+[ -n "$WORKSPACE_ID" ] || {
+    echo "ERROR: --id is required so the remote workspace has a stable owner." >&2
     exit 1
-fi
+}
+[[ "$WORKSPACE_ID" =~ ^[a-z0-9][a-z0-9._-]*$ ]] || {
+    echo "ERROR: workspace ID must match [a-z0-9][a-z0-9._-]*" >&2
+    exit 1
+}
+[ "${#WORKSPACE_ID}" -le 48 ] || {
+    echo "ERROR: workspace ID must be at most 48 characters" >&2
+    exit 1
+}
 
-# --- Clone -------------------------------------------------------------------
+: "${TRTMC_HOST_ROOT:?Set TRTMC_HOST_ROOT or create $HOST_CONFIG}"
+HOST_ROOT="${TRTMC_HOST_ROOT%/}"
+REPO_DIR="$HOST_ROOT/workspaces/$WORKSPACE_ID/repo"
+CONTAINER_PREFIX="${TRTMC_CONTAINER_PREFIX:-trtmc-dev-gb300}"
+CONTAINER_NAME="$CONTAINER_PREFIX-$WORKSPACE_ID"
 
-echo "=== Workspace: ${WORKSPACE_ID} ==="
-echo "  Repo:      ${REPO_DIR}"
-echo "  Container: ${CONTAINER_NAME}"
-echo "  Branch:    ${BRANCH}"
-echo ""
+echo "=== Workspace: $WORKSPACE_ID ==="
+echo "  Repo:      $REPO_DIR"
+echo "  Container: $CONTAINER_NAME"
+echo "  Branch:    $BRANCH"
 
-if [ -d "${REPO_DIR}/.git" ]; then
-    echo "Repo already exists, fetching latest..."
-    git -C "$REPO_DIR" fetch origin
-    git -C "$REPO_DIR" checkout "$BRANCH" 2>/dev/null \
-        || git -C "$REPO_DIR" checkout -b "$BRANCH" "origin/${BRANCH}"
+if [ -e "$REPO_DIR" ]; then
+    [ -d "$REPO_DIR" ] || {
+        echo "ERROR: canonical repo path exists but is not a directory: $REPO_DIR" >&2
+        exit 1
+    }
+    echo "Using the existing deployed checkout; no fetch or checkout was performed."
 else
-    echo "Cloning repo..."
     mkdir -p "$(dirname "$REPO_DIR")"
-    git clone "$GIT_REMOTE" "$REPO_DIR"
-    if [ "$BRANCH" != "main" ]; then
-        git -C "$REPO_DIR" checkout -b "$BRANCH"
-    fi
+    git clone --branch "$BRANCH" --single-branch "$GIT_REMOTE" "$REPO_DIR"
 fi
 
-# --- Write workspace ID so agents can self-discover -------------------------
+TRTMC_DOCKER_IMAGE="$DOCKER_IMAGE" "$MANAGER" start "$WORKSPACE_ID"
 
-echo "$WORKSPACE_ID" > "${REPO_DIR}/.workspace_id"
-
-# --- Create shared dirs -----------------------------------------------------
-
-mkdir -p "$ENGINE_DIR" 2>/dev/null || true
-mkdir -p "$HF_CACHE" 2>/dev/null || true
-
-# --- Start container ---------------------------------------------------------
-
-echo ""
-echo "Starting container ${CONTAINER_NAME}..."
-
-DOCKER_ARGS=(
-    --gpus all
-    -v "${REPO_DIR}":/workspace/tensorrt-model-connect
-    -v "${STORAGE_ROOT}:${STORAGE_ROOT}"
-    -v "${HF_CACHE}":/root/.cache/huggingface/hub
-    -w /workspace/tensorrt-model-connect
-    --name "$CONTAINER_NAME"
-    "$DOCKER_IMAGE"
-)
-
-if [ "$DETACH" = true ]; then
-    docker run -d "${DOCKER_ARGS[@]}" sleep infinity
-    echo "Container started in background."
-
-    # Build inside detached container
-    if [ "$BUILD" = true ]; then
-        echo ""
-        echo "Installing tensorrt_model_connect and building C++ runtime..."
-        docker exec "$CONTAINER_NAME" pip install --no-deps -e . -C py-only=true
-        docker exec "$CONTAINER_NAME" bash -c '
-            cmake -S . -B build -G Ninja \
-                -DTRTMC_TRT_INCLUDE_DIR=$TRT_INC_DIR \
-                -DTRTMC_TRT_LIBRARY=$TRT_LIB_DIR/libnvinfer.so \
-                -DTRTMC_CUDA_INCLUDE_DIR=/usr/local/cuda/include \
-                -DTRTMC_CUDART_LIBRARY=/usr/local/cuda/lib64/libcudart.so &&
-            cmake --build build -j'
-        echo "Build complete."
-    fi
-else
-    echo "(Interactive mode — run build commands manually inside the container)"
-    docker run --rm -it "${DOCKER_ARGS[@]}" bash
+if [ "$BUILD" = true ]; then
+    echo "Installing tensorrt_model_connect and building the C++ runtime..."
+    "$MANAGER" exec "$WORKSPACE_ID" -- \
+        /opt/venv/bin/python3 -m pip install --no-deps -e . -C py-only=true
+    "$MANAGER" exec "$WORKSPACE_ID" -- bash -lc '
+        cmake -S . -B build -G Ninja \
+            -DTRTMC_TRT_INCLUDE_DIR=$TRT_INC_DIR \
+            -DTRTMC_TRT_LIBRARY=$TRT_LIB_DIR/libnvinfer.so \
+            -DTRTMC_CUDA_INCLUDE_DIR=/usr/local/cuda/include \
+            -DTRTMC_CUDART_LIBRARY=/usr/local/cuda/lib64/libcudart.so &&
+        cmake --build build -j'
 fi
 
-# --- Summary -----------------------------------------------------------------
-
-echo ""
+echo
 echo "=== Workspace ready ==="
-echo "  ID:        ${WORKSPACE_ID}"
-echo "  Repo:      ${REPO_DIR}"
-echo "  Container: ${CONTAINER_NAME}"
-echo "  Branch:    ${BRANCH}"
-echo ""
-echo "To use:"
-echo "  docker exec -it ${CONTAINER_NAME} bash"
-echo ""
-echo "To run tests:"
-echo "  docker exec ${CONTAINER_NAME} ctest --test-dir build --output-on-failure"
-echo "  docker exec ${CONTAINER_NAME} python -m pytest tests/builder/ -v -n auto"
-echo ""
-echo "To tear down:"
-echo "  docker rm -f ${CONTAINER_NAME}"
-echo "  rm -rf ${REPO_DIR%/*}"
+echo "  Source:    $REPO_DIR"
+echo "  Artifacts: $HOST_ROOT/runs/$WORKSPACE_ID"
+echo "  State:     $HOST_ROOT/state/$WORKSPACE_ID/workspace.env"
+echo "  Container: $CONTAINER_NAME"
+echo
+echo "Inspect without changing anything:"
+echo "  $MANAGER inspect $WORKSPACE_ID"
+echo "  $MANAGER audit"
+echo
+echo "Stop without deleting:"
+echo "  $MANAGER stop $WORKSPACE_ID"
+
+if [ "$DETACH" = false ]; then
+    "$MANAGER" shell "$WORKSPACE_ID"
+fi

--- a/scripts/docker_run_gb300.sh
+++ b/scripts/docker_run_gb300.sh
@@ -6,7 +6,30 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# Persistent storage paths (host) — adjust these to your local environment
+HOST_CONFIG="${TRTMC_HOST_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/trtmc/host.env}"
+if [ -f "$HOST_CONFIG" ]; then
+  # shellcheck source=/dev/null
+  source "$HOST_CONFIG"
+fi
+
+# Shared GPU hosts must use the stable one-worktree/one-container mapping.
+if [ -n "${TRTMC_HOST_ROOT:-}" ]; then
+  WORKSPACE_ID="${TRTMC_WORKSPACE_ID:-}"
+  if [ -z "$WORKSPACE_ID" ] && [ -f .workspace_id ]; then
+    WORKSPACE_ID="$(<.workspace_id)"
+  fi
+  if [ -z "$WORKSPACE_ID" ] && [ "$(basename "$PWD")" = repo ]; then
+    WORKSPACE_ID="$(basename "$(dirname "$PWD")")"
+  fi
+  [ -n "$WORKSPACE_ID" ] || {
+    echo "ERROR: Set TRTMC_WORKSPACE_ID or run from a canonical workspaces/ID/repo checkout." >&2
+    exit 1
+  }
+  ./scripts/manage_gpu_workspace.sh start "$WORKSPACE_ID"
+  exec ./scripts/manage_gpu_workspace.sh shell "$WORKSPACE_ID"
+fi
+
+# Unmanaged local developer fallback. Shared GPU hosts never take this path.
 STORAGE_ROOT="${TRTMC_STORAGE_ROOT:-$HOME/trtmc-storage}"
 HF_CACHE="${TRTMC_HF_CACHE:-$HOME/.cache/huggingface/hub}"
 ENGINE_DIR="${STORAGE_ROOT}/engines"

--- a/scripts/manage_gpu_workspace.sh
+++ b/scripts/manage_gpu_workspace.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Manage the one-worktree/one-container layout used on shared GPU hosts.
+#
+# This script deliberately has no delete command. Removing a container, source
+# checkout, run directory, or cache requires a separate, explicitly reviewed
+# operation.
+
+set -euo pipefail
+
+PROGRAM="$(basename "$0")"
+CONTAINER_WORKDIR="/workspace/tensorrt-model-connect"
+CONTAINER_RUN_ROOT="/work"
+CONTAINER_HF_HOME="/cache/huggingface"
+CONTAINER_DATA_ROOT="/mnt/data"
+MANAGED_LABEL="com.nvidia.trtmc.managed"
+WORKSPACE_LABEL="com.nvidia.trtmc.workspace-id"
+
+usage() {
+    cat <<EOF
+Usage:
+  $PROGRAM start ID
+  $PROGRAM stop ID
+  $PROGRAM shell ID
+  $PROGRAM exec ID -- COMMAND [ARG ...]
+  $PROGRAM inspect ID
+  $PROGRAM status
+  $PROGRAM audit
+
+Required host configuration:
+  TRTMC_HOST_ROOT             Canonical storage root shared by all workspaces
+
+Optional host configuration:
+  TRTMC_HOST_CONFIG           Shell config file (default: ~/.config/trtmc/host.env)
+  TRTMC_DOCKER_IMAGE          Image (default: trtmc-dev-gb300:latest)
+  TRTMC_CONTAINER_PREFIX      Name prefix (default: trtmc-dev-gb300)
+  TRTMC_GPU_REQUEST           docker --gpus value (default: all)
+  TRTMC_RESTART_POLICY        Docker restart policy (default: unless-stopped)
+
+Canonical layout below TRTMC_HOST_ROOT:
+  workspaces/ID/repo          Deployed source for exactly one worktree
+  runs/ID/engines             Worktree-owned engine bundles
+  runs/ID/results             Worktree-owned test and benchmark results
+  runs/ID/logs                Worktree-owned logs
+  runs/ID/tmp                 Worktree-owned temporary files
+  state/ID/workspace.env      Generated ownership/lifecycle metadata
+  huggingface/                Shared Hugging Face cache
+  data/                       Shared datasets, mounted read-only
+EOF
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+load_host_config() {
+    local config="${TRTMC_HOST_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/trtmc/host.env}"
+    local override_container_prefix="${TRTMC_CONTAINER_PREFIX:-}"
+    local override_docker_image="${TRTMC_DOCKER_IMAGE:-}"
+    local override_gpu_request="${TRTMC_GPU_REQUEST:-}"
+    local override_host_root="${TRTMC_HOST_ROOT:-}"
+    local override_restart_policy="${TRTMC_RESTART_POLICY:-}"
+    if [ -f "$config" ]; then
+        # The config is host-owned and may set any TRTMC_* value used below.
+        # shellcheck source=/dev/null
+        source "$config"
+    fi
+
+    [ -z "$override_container_prefix" ] || TRTMC_CONTAINER_PREFIX="$override_container_prefix"
+    [ -z "$override_docker_image" ] || TRTMC_DOCKER_IMAGE="$override_docker_image"
+    [ -z "$override_gpu_request" ] || TRTMC_GPU_REQUEST="$override_gpu_request"
+    [ -z "$override_host_root" ] || TRTMC_HOST_ROOT="$override_host_root"
+    [ -z "$override_restart_policy" ] || TRTMC_RESTART_POLICY="$override_restart_policy"
+
+    : "${TRTMC_HOST_ROOT:?Set TRTMC_HOST_ROOT or create the host config file}"
+    case "$TRTMC_HOST_ROOT" in
+        /*) ;;
+        *) die "TRTMC_HOST_ROOT must be an absolute path" ;;
+    esac
+    [ "$TRTMC_HOST_ROOT" != "/" ] || die "TRTMC_HOST_ROOT cannot be /"
+
+    HOST_ROOT="${TRTMC_HOST_ROOT%/}"
+    DOCKER_IMAGE="${TRTMC_DOCKER_IMAGE:-trtmc-dev-gb300:latest}"
+    CONTAINER_PREFIX="${TRTMC_CONTAINER_PREFIX:-trtmc-dev-gb300}"
+    GPU_REQUEST="${TRTMC_GPU_REQUEST:-all}"
+    RESTART_POLICY="${TRTMC_RESTART_POLICY:-unless-stopped}"
+}
+
+validate_id() {
+    local workspace_id="$1"
+    [ "${#workspace_id}" -le 48 ] || die "workspace ID must be at most 48 characters"
+    [[ "$workspace_id" =~ ^[a-z0-9][a-z0-9._-]*$ ]] \
+        || die "workspace ID must match [a-z0-9][a-z0-9._-]*"
+}
+
+set_workspace_paths() {
+    WORKSPACE_ID="$1"
+    validate_id "$WORKSPACE_ID"
+    WORKSPACE_ROOT="$HOST_ROOT/workspaces/$WORKSPACE_ID"
+    REPO_DIR="$WORKSPACE_ROOT/repo"
+    RUN_ROOT="$HOST_ROOT/runs/$WORKSPACE_ID"
+    STATE_ROOT="$HOST_ROOT/state/$WORKSPACE_ID"
+    HF_HOME_HOST="$HOST_ROOT/huggingface"
+    DATA_ROOT_HOST="$HOST_ROOT/data"
+    CONTAINER_NAME="$CONTAINER_PREFIX-$WORKSPACE_ID"
+}
+
+container_exists() {
+    docker container inspect "$CONTAINER_NAME" >/dev/null 2>&1
+}
+
+assert_managed_container() {
+    local managed workspace
+    managed="$(docker inspect --format "{{index .Config.Labels \"$MANAGED_LABEL\"}}" "$CONTAINER_NAME")"
+    workspace="$(docker inspect --format "{{index .Config.Labels \"$WORKSPACE_LABEL\"}}" "$CONTAINER_NAME")"
+    [ "$managed" = "true" ] \
+        || die "container $CONTAINER_NAME exists but is not managed by $PROGRAM"
+    [ "$workspace" = "$WORKSPACE_ID" ] \
+        || die "container $CONTAINER_NAME belongs to workspace $workspace"
+}
+
+write_state() {
+    local git_branch git_sha state_tmp
+    git_branch="$(git -C "$REPO_DIR" branch --show-current 2>/dev/null || true)"
+    git_sha="$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || true)"
+    [ -n "$git_branch" ] || git_branch="unknown"
+    [ -n "$git_sha" ] || git_sha="unknown"
+    state_tmp="$STATE_ROOT/workspace.env.tmp"
+
+    mkdir -p "$STATE_ROOT"
+    {
+        printf 'TRTMC_WORKSPACE_ID=%q\n' "$WORKSPACE_ID"
+        printf 'TRTMC_CONTAINER_NAME=%q\n' "$CONTAINER_NAME"
+        printf 'TRTMC_REPO_DIR=%q\n' "$REPO_DIR"
+        printf 'TRTMC_RUN_ROOT=%q\n' "$RUN_ROOT"
+        printf 'TRTMC_GIT_BRANCH=%q\n' "$git_branch"
+        printf 'TRTMC_GIT_SHA=%q\n' "$git_sha"
+        printf 'TRTMC_DOCKER_IMAGE=%q\n' "$DOCKER_IMAGE"
+        printf 'TRTMC_OWNER=%q\n' "${USER:-unknown}"
+        printf 'TRTMC_UPDATED_AT=%q\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } > "$state_tmp"
+    mv "$state_tmp" "$STATE_ROOT/workspace.env"
+}
+
+start_workspace() {
+    local git_sha
+    [ -d "$REPO_DIR" ] \
+        || die "deployed repo is missing: $REPO_DIR"
+
+    if container_exists; then
+        assert_managed_container
+        write_state
+        if [ "$(docker inspect --format '{{.State.Running}}' "$CONTAINER_NAME")" = "true" ]; then
+            echo "$CONTAINER_NAME is already running"
+        else
+            docker start "$CONTAINER_NAME" >/dev/null
+            echo "Started existing container $CONTAINER_NAME"
+        fi
+        return
+    fi
+
+    mkdir -p \
+        "$RUN_ROOT/engines" \
+        "$RUN_ROOT/results" \
+        "$RUN_ROOT/logs" \
+        "$RUN_ROOT/tmp" \
+        "$HF_HOME_HOST/hub" \
+        "$HF_HOME_HOST/modules" \
+        "$DATA_ROOT_HOST"
+
+    write_state
+    git_sha="$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || echo unknown)"
+
+    docker run -d \
+        --name "$CONTAINER_NAME" \
+        --restart "$RESTART_POLICY" \
+        --gpus "$GPU_REQUEST" \
+        --ipc host \
+        --label "$MANAGED_LABEL=true" \
+        --label "$WORKSPACE_LABEL=$WORKSPACE_ID" \
+        --label "com.nvidia.trtmc.owner=${USER:-unknown}" \
+        --label "com.nvidia.trtmc.git-sha=$git_sha" \
+        --label "com.nvidia.trtmc.repo-dir=$REPO_DIR" \
+        --label "com.nvidia.trtmc.run-root=$RUN_ROOT" \
+        -v "$REPO_DIR:$CONTAINER_WORKDIR" \
+        -v "$RUN_ROOT:$CONTAINER_RUN_ROOT" \
+        -v "$HF_HOME_HOST:$CONTAINER_HF_HOME" \
+        -v "$DATA_ROOT_HOST:$CONTAINER_DATA_ROOT:ro" \
+        -e "TRTMC_WORKSPACE_ID=$WORKSPACE_ID" \
+        -e "TRTMC_STORAGE_ROOT=$CONTAINER_RUN_ROOT" \
+        -e "ENGINE_DIR=$CONTAINER_RUN_ROOT/engines" \
+        -e "RESULT_DIR=$CONTAINER_RUN_ROOT/results" \
+        -e "TMPDIR=$CONTAINER_RUN_ROOT/tmp" \
+        -e "HF_HOME=$CONTAINER_HF_HOME" \
+        -e "HF_HUB_CACHE=$CONTAINER_HF_HOME/hub" \
+        -e "HUGGINGFACE_HUB_CACHE=$CONTAINER_HF_HOME/hub" \
+        -e "HF_MODULES_CACHE=$CONTAINER_HF_HOME/modules" \
+        -w "$CONTAINER_WORKDIR" \
+        "$DOCKER_IMAGE" sleep infinity >/dev/null
+
+    echo "Started $CONTAINER_NAME"
+    echo "  repo: $REPO_DIR"
+    echo "  run:  $RUN_ROOT"
+}
+
+stop_workspace() {
+    container_exists || die "container does not exist: $CONTAINER_NAME"
+    assert_managed_container
+    docker stop "$CONTAINER_NAME" >/dev/null
+    echo "Stopped $CONTAINER_NAME (container and files were retained)"
+}
+
+shell_workspace() {
+    container_exists || die "container does not exist: $CONTAINER_NAME"
+    assert_managed_container
+    docker exec -it "$CONTAINER_NAME" bash
+}
+
+exec_workspace() {
+    shift 2
+    [ "${1:-}" = "--" ] || die "exec requires -- before the command"
+    shift
+    [ "$#" -gt 0 ] || die "exec requires a command"
+    container_exists || die "container does not exist: $CONTAINER_NAME"
+    assert_managed_container
+    docker exec "$CONTAINER_NAME" "$@"
+}
+
+inspect_workspace() {
+    echo "workspace_id=$WORKSPACE_ID"
+    echo "repo_dir=$REPO_DIR"
+    echo "run_root=$RUN_ROOT"
+    if [ -d "$WORKSPACE_ROOT" ]; then
+        du -sh "$WORKSPACE_ROOT" "$RUN_ROOT" 2>/dev/null || true
+    fi
+    if container_exists; then
+        assert_managed_container
+        docker inspect --format \
+            'container={{.Name}} status={{.State.Status}} image={{.Config.Image}} created={{.Created}}' \
+            "$CONTAINER_NAME"
+    else
+        echo "container=missing"
+    fi
+}
+
+status_workspaces() {
+    docker ps -a --size \
+        --filter "label=$MANAGED_LABEL=true" \
+        --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Size}}'
+}
+
+audit_host() {
+    echo "Filesystem usage"
+    df -hT "$HOST_ROOT" "$(docker info --format '{{.DockerRootDir}}')"
+    echo
+    echo "Managed directory usage"
+    for path in workspaces runs state huggingface data; do
+        if [ -e "$HOST_ROOT/$path" ]; then
+            du -sh "$HOST_ROOT/$path"
+        else
+            echo "missing  $HOST_ROOT/$path"
+        fi
+    done
+    echo
+    echo "Managed containers"
+    status_workspaces
+    echo
+    echo "Docker usage (reclaimable is advisory; this command does not delete it)"
+    docker system df
+    echo
+    echo "Workspace state"
+    find "$HOST_ROOT/state" -mindepth 2 -maxdepth 2 -name workspace.env -print 2>/dev/null \
+        | sort || true
+}
+
+main() {
+    case "${1:-}" in
+        -h|--help|help|"")
+            usage
+            return
+            ;;
+    esac
+
+    load_host_config
+    case "$1" in
+        start|stop|shell|exec|inspect)
+            [ "$#" -ge 2 ] || die "$1 requires a workspace ID"
+            set_workspace_paths "$2"
+            ;;
+    esac
+
+    case "$1" in
+        start) start_workspace ;;
+        stop) stop_workspace ;;
+        shell) shell_workspace ;;
+        exec) exec_workspace "$@" ;;
+        inspect) inspect_workspace ;;
+        status) status_workspaces ;;
+        audit) audit_host ;;
+        *) die "unknown command: $1" ;;
+    esac
+}
+
+main "$@"

--- a/scripts/validate_family.sh
+++ b/scripts/validate_family.sh
@@ -272,7 +272,7 @@ while IFS= read -r -d '' manifest; do
 done < <(find "${PROJECT_DIR}/tests/e2e/models" -maxdepth 3 -type f -name "*.json" -print0 | sort -z)
 
 if [[ -n "$E2E_MODEL" ]] && [[ -x "$BINARY" ]]; then
-    ENGINE_DIR="${ENGINE_DIR:-/workspace/users/yifeif/tensorrt-model-connect/engines}"
+    ENGINE_DIR="${ENGINE_DIR:-/work/engines}"
     E2E_NODE="${PROJECT_DIR}/tests/e2e/models/${E2E_FAMILY}/test_${E2E_FAMILY}_e2e.py::test_model_e2e[${E2E_MODEL}]"
     E2E_ARGS=(
         "$E2E_NODE"

--- a/tests/tools/test_managed_gpu_workspace.py
+++ b/tests/tools/test_managed_gpu_workspace.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANAGER = REPO_ROOT / "scripts" / "manage_gpu_workspace.sh"
+BOOTSTRAP = REPO_ROOT / "scripts" / "bootstrap_workspace.sh"
+
+
+def test_workspace_shell_scripts_parse() -> None:
+    subprocess.run(
+        ["bash", "-n", str(MANAGER), str(BOOTSTRAP)],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_bootstrap_help_does_not_require_host_configuration() -> None:
+    env = {**os.environ, "TRTMC_HOST_CONFIG": "/dev/null"}
+    env.pop("TRTMC_HOST_ROOT", None)
+    result = subprocess.run(
+        [str(BOOTSTRAP), "--help"],
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert "--id ID" in result.stdout
+
+
+def test_manager_starts_with_canonical_mounts_and_state(tmp_path: Path) -> None:
+    host_root = tmp_path / "host"
+    repo = host_root / "workspaces" / "fix-runtime" / "repo"
+    repo.mkdir(parents=True)
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker_log = tmp_path / "docker.log"
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [ \"$1\" = container ] && [ \"$2\" = inspect ]; then
+    exit 1
+fi
+if [ \"$1\" = run ]; then
+    printf '%s\\n' \"$@\" > \"$FAKE_DOCKER_LOG\"
+    exit 0
+fi
+exit 1
+""",
+        encoding="utf-8",
+    )
+    fake_docker.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "FAKE_DOCKER_LOG": str(docker_log),
+        "TRTMC_HOST_CONFIG": "/dev/null",
+        "TRTMC_HOST_ROOT": str(host_root),
+        "TRTMC_DOCKER_IMAGE": "test-image:latest",
+    }
+    result = subprocess.run(
+        [str(MANAGER), "start", "fix-runtime"],
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "Started trtmc-dev-gb300-fix-runtime" in result.stdout
+    for path in ("engines", "results", "logs", "tmp"):
+        assert (host_root / "runs" / "fix-runtime" / path).is_dir()
+    assert (host_root / "huggingface" / "hub").is_dir()
+    assert (host_root / "data").is_dir()
+
+    state = (host_root / "state" / "fix-runtime" / "workspace.env").read_text()
+    assert "TRTMC_WORKSPACE_ID=fix-runtime" in state
+    assert "TRTMC_DOCKER_IMAGE=test-image:latest" in state
+
+    docker_args = docker_log.read_text(encoding="utf-8").splitlines()
+    assert "trtmc-dev-gb300-fix-runtime" in docker_args
+    assert f"{repo}:/workspace/tensorrt-model-connect" in docker_args
+    assert f"{host_root}/runs/fix-runtime:/work" in docker_args
+    assert f"{host_root}/huggingface:/cache/huggingface" in docker_args
+    assert f"{host_root}/data:/mnt/data:ro" in docker_args
+    assert "ENGINE_DIR=/work/engines" in docker_args
+    assert "HF_HUB_CACHE=/cache/huggingface/hub" in docker_args
+
+
+def test_manager_has_no_delete_operation() -> None:
+    text = MANAGER.read_text(encoding="utf-8")
+    assert "docker rm" not in text
+    assert "rm -rf" not in text
+    assert "system prune" not in text
+    assert "image prune" not in text
+    assert "builder prune" not in text

--- a/website/docs/operations/managed-gpu-workspaces.md
+++ b/website/docs/operations/managed-gpu-workspaces.md
@@ -1,0 +1,126 @@
+---
+sidebar_position: 6
+title: Managed GPU host workspaces
+---
+
+# Managed GPU host workspaces
+
+Shared GPU hosts use a one-worktree/one-container layout. The same workspace ID
+connects the deployed source, generated artifacts, lifecycle metadata, and
+Docker container, so owners and cleanup candidates can be resolved without
+guessing from directory or container names.
+
+## Host configuration
+
+Create `~/.config/trtmc/host.env` on each managed host. Hostnames, credentials,
+storage mount details, and GPU topology belong in this untracked file.
+
+```bash
+TRTMC_HOST_ROOT=/srv/trtmc
+TRTMC_DOCKER_IMAGE=trtmc-dev-gb300:latest
+TRTMC_CONTAINER_PREFIX=trtmc-dev-gb300
+TRTMC_GPU_REQUEST=all
+TRTMC_RESTART_POLICY=unless-stopped
+```
+
+Use the same `TRTMC_HOST_ROOT`, image policy, and container prefix on equivalent
+hosts. `TRTMC_GPU_REQUEST` may differ when their physical GPU topology differs.
+
+## Canonical layout
+
+For a workspace ID such as `fix-runtime-reset`, the host tree is:
+
+```text
+$TRTMC_HOST_ROOT/
+├── workspaces/fix-runtime-reset/repo/
+├── runs/fix-runtime-reset/
+│   ├── engines/
+│   ├── results/
+│   ├── logs/
+│   └── tmp/
+├── state/fix-runtime-reset/workspace.env
+├── huggingface/
+└── data/
+```
+
+The ownership rules are:
+
+- `workspaces/<id>/repo` contains exactly one deployed worktree.
+- `runs/<id>` is writable only for that worktree's generated artifacts.
+- `state/<id>/workspace.env` records the worktree/container mapping.
+- `huggingface` is the shared, reproducible download cache.
+- `data` is shared and mounted read-only in containers.
+- Existing legacy shared artifact directories remain legacy inputs. New work
+  must not add files to them.
+
+Inside every managed container, those paths are stable:
+
+| Host content | Container path | Access |
+| --- | --- | --- |
+| Deployed worktree | `/workspace/tensorrt-model-connect` | Read/write |
+| Workspace run directory | `/work` | Read/write |
+| Hugging Face cache | `/cache/huggingface` | Read/write, shared |
+| Datasets | `/mnt/data` | Read-only, shared |
+
+`ENGINE_DIR`, `RESULT_DIR`, `TMPDIR`, `HF_HOME`, and the Hugging Face hub/module
+cache variables are set to these managed paths by the container launcher.
+
+## Create or start a workspace
+
+Choose a stable, lowercase ID derived from the local worktree or task. Reuse the
+same ID on equivalent hosts.
+
+For a pushed branch, bootstrap the canonical checkout and container together:
+
+```bash
+./scripts/bootstrap_workspace.sh \
+  --id fix-runtime-reset \
+  --branch fix/runtime-reset \
+  --detach
+```
+
+For source deployed by another mechanism, place it at
+`$TRTMC_HOST_ROOT/workspaces/<id>/repo` and start only its container:
+
+```bash
+./scripts/manage_gpu_workspace.sh start fix-runtime-reset
+```
+
+The manager will reuse a stopped container only when its management labels and
+workspace ID match. It refuses to adopt an unrelated container with the same
+name.
+
+## Work with the matching container
+
+```bash
+./scripts/manage_gpu_workspace.sh inspect fix-runtime-reset
+./scripts/manage_gpu_workspace.sh shell fix-runtime-reset
+./scripts/manage_gpu_workspace.sh exec fix-runtime-reset -- \
+  ctest --test-dir build --output-on-failure
+./scripts/manage_gpu_workspace.sh stop fix-runtime-reset
+```
+
+Stopping retains the container, source, run artifacts, caches, and state
+manifest. The manager intentionally provides no delete command.
+
+## Audit and cleanup handoff
+
+Run the read-only audit before discussing cleanup:
+
+```bash
+./scripts/manage_gpu_workspace.sh audit
+docker system df -v
+```
+
+A cleanup proposal must name exact targets and classify them:
+
+1. Retain: running workspaces, open work, reusable shared caches, and evidence
+   still needed for an active issue or pull request.
+2. Review: stopped workspaces, completed run artifacts, duplicated experiment
+   bundles, and caches whose future reuse is unclear.
+3. Reclaimable after approval: abandoned workspaces, explicitly archived run
+   artifacts, stopped containers, unreferenced images, and build cache.
+
+Docker's `RECLAIMABLE` value is advisory. It is not proof that another user no
+longer needs an image, stopped container, or cache. Deletion remains a separate
+human-approved operation.

--- a/website/docs/operations/model-e2e-task-prompt.md
+++ b/website/docs/operations/model-e2e-task-prompt.md
@@ -57,10 +57,10 @@ You are working in tensorrt-model-connect. Add one model end-to-end so it is
   D) Single-model E2E validation (mandatory)
   Run:
   - python -m pytest tests/test_e2e.py::test_e2e[<MODEL_NAME>] -v \
-    --engine-dir /workspace/users/yifeif/tensorrt-model-connect/engines \
+    --engine-dir /work/engines \
     --trtmc-binary ./build/trtmc \
     --hf-python /opt/venv/bin/python \
-    --e2e-artifacts-dir /workspace/users/yifeif/tensorrt-model-connect/test-result
+    --e2e-artifacts-dir /work/results
 
   Then inspect artifacts/result.json and verify output quality:
   - text: continuation makes sense
@@ -84,7 +84,7 @@ You are working in tensorrt-model-connect. Add one model end-to-end so it is
   - python -m pytest tests/builder/test_graph_ops.py tests/builder/
   test_graph_ops_extended.py tests/builder/test_graph_blocks.py -v -n auto
   - python -m pytest tests/test_e2e.py::test_e2e[qwen3-0.6b] -v \
-    --engine-dir /workspace/users/yifeif/tensorrt-model-connect/engines \
+    --engine-dir /work/engines \
     --trtmc-binary ./build/trtmc \
     --hf-python /opt/venv/bin/python \
     --rebuild-engines

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -114,6 +114,7 @@ const sidebars = {
         'operations/ai-agent-system',
         'operations/ai-local-pipeline',
         'operations/ai-staging',
+        'operations/managed-gpu-workspaces',
         'operations/model-e2e-task-prompt'
       ]
     },


### PR DESCRIPTION
## Background

Shared GPU-host workflows used hard-coded or ad hoc workspace, engine, cache,
and container paths. That made it possible to reuse one container across
different worktrees and made storage ownership difficult to audit.

## Exit Criteria

- One stable workspace ID maps one deployed checkout, run directory, state
  manifest, and Docker container.
- New engines, results, logs, and temporary files are isolated per worktree;
  only the Hugging Face cache and read-only datasets are shared.
- Host-specific configuration remains untracked, and the management tool has
  no delete operation.

## Implementation

- Add `manage_gpu_workspace.sh` with start, stop, shell, exec, inspect, status,
  and read-only audit commands. Managed containers carry ownership labels and
  stable mounts for source, run storage, model cache, and datasets.
- Route bootstrap, local GB300 startup, autopilot, optimization, and validation
  output through the canonical workspace/run layout.
- Document the lifecycle and cleanup handoff, and make the policy mandatory for
  agents through `AGENTS.md`.

## Validation

- `pytest tests/tools/test_managed_gpu_workspace.py tests/tools/test_model_owned_validation_scripts.py -q -p no:cacheprovider`: 6 passed.
- `pytest tests/tools/test_model_plugin_encapsulation_static.py -q -p no:cacheprovider -k shared_autopilot_prompt_has_no_single_family_examples`: 1 passed.
- `python tools/legal_headers.py --check`: no findings.
- `ruff check --no-cache scripts/autopilot/autorun.py scripts/autopilot/dispatch.py tests/tools/test_managed_gpu_workspace.py`: passed.
- `bash -n` on all changed shell scripts and `git diff --check`: passed.

## Notes For Future Readers

- Review the manager and its focused test first, then the bootstrap/autopilot
  routing changes, and finally the operations documentation.
- Existing shared engine directories remain legacy inputs. New work writes to
  the workspace-owned `/work` mount.
- Cleanup stays separate and requires explicit review of exact targets; this
  tooling intentionally cannot remove containers, files, images, or caches.
