### PR TITLE
docs(website): fix CI tutorial link

### DIFF
--- a/website/docs/wiki/Testing-and-Validation.md
+++ b/website/docs/wiki/Testing-and-Validation.md
@@ -840,7 +840,7 @@ pytest tests/builder/ -m trt -v
 ## CI orchestration
 
 The class-based CI control flow is documented in the
-[CI orchestration tutorial](../../../tools/ci/README.md). Start there to follow
+[CI orchestration tutorial](https://github.com/NVIDIA/TensorRT-Model-Connect/blob/main/tools/ci/README.md). Start there to follow
 the `run-ci` trigger through impact analysis, unit gates, isolated model proofs,
 GPU scheduling, and the combined HTML report.
 


### PR DESCRIPTION
## Background

The Docusaurus Pages build failed in runs
[29910005525](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29910005525)
and
[29924373301](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29924373301)
because the CI tutorial's relative link escaped the `website/docs` tree and
was interpreted as the nonexistent site route `/tools/ci/README.md`.

## Exit Criteria

- The production documentation build passes with strict broken-link checking.
- The testing guide still links readers to the CI orchestration tutorial.

## Implementation

- Replace the cross-tree relative path with an explicit GitHub source link.
- Keep `onBrokenLinks: 'throw'` unchanged.

## Validation

- `npm ci`: passed using the committed lockfile.
- `npm run build`: passed and generated the static Docusaurus site.
- `python3 tools/legal_headers.py --check`: passed with zero findings.

## Notes For Future Readers

- Repository files outside `website/docs` are not Docusaurus document routes;
  link to their GitHub source location instead of traversing out of the docs
  tree.
