### PR TITLE
fix(ci): make FP8 asset test catalog-relative

### DIFF
--- a/tests/tools/test_trtmc_bench.py
+++ b/tests/tools/test_trtmc_bench.py
@@ -533,7 +533,34 @@ def test_image_edit_profile_resolves_built_in_condition_image(tmp_path: Path) ->
     assert Path(case.worker_request()["request"]["image_path"]).is_file()
 
 
-def test_auto_build_requires_and_passes_manifest_fp8_scales(tmp_path: Path) -> None:
+@pytest.mark.parametrize("catalog_layout", ["source", "installed"])
+def test_auto_build_requires_and_passes_manifest_fp8_scales(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    catalog_layout: str,
+) -> None:
+    if catalog_layout == "installed":
+        package = tmp_path / "site-packages/tensorrt_model_connect/benchmark"
+        family = package / "_catalog/flux"
+        manifest = family / "manifests/flux-2-dev-fp8.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_bytes(
+            (
+                REPOSITORY_ROOT
+                / "tests/e2e/models/flux/manifests/flux-2-dev-fp8.json"
+            ).read_bytes()
+        )
+        scales = family / "data/flux2-fp8-scales.json"
+        scales.parent.mkdir()
+        scales.write_bytes(
+            (
+                REPOSITORY_ROOT
+                / "tests/e2e/models/flux/data/flux2-fp8-scales.json"
+            ).read_bytes()
+        )
+        monkeypatch.delenv("TRTMC_BENCH_MANIFEST_ROOT", raising=False)
+        monkeypatch.setattr(benchmark_catalog, "__file__", str(package / "catalog.py"))
+
     catalog = ManifestCatalog()
     model = catalog.resolve("flux-2-dev-fp8")
     case = resolve_case(model, tmp_path / "pending.trtfb")
@@ -541,7 +568,7 @@ def test_auto_build_requires_and_passes_manifest_fp8_scales(tmp_path: Path) -> N
 
     assert model.build_settings["fp8_scales"] == "data/flux2-fp8-scales.json"
     expected_scales = (
-        REPOSITORY_ROOT / "tests/e2e/models/flux/data/flux2-fp8-scales.json"
+        model.manifest_path.parent.parent / str(model.build_settings["fp8_scales"])
     ).resolve()
     assert expected_scales.is_file()
     command = list(plan.command)


### PR DESCRIPTION
## Background

Scheduled Nightly run 29913059891 built and installed the wheel successfully, then failed one Python package-coverage test because the test required the Flux2 FP8 scale file to live under the source checkout. The installed benchmark catalog correctly resolved the same asset from package data instead. Issue #518 tracks the Nightly failure streak.

## Exit Criteria

- Validate the Flux2 FP8 build argument in both source and installed catalog layouts.
- Preserve file-existence and exact command-argument checks without depending on a checkout location.
- Confirm no other benchmark tool test has the same source-versus-package path coupling.

## Implementation

- Resolve the expected FP8 scale path relative to the manifest selected by ManifestCatalog.
- Parameterize the regression test across source and simulated installed-wheel catalog layouts.

## Validation

- python3 -m pytest -q tests/tools/test_trtmc_bench.py::test_auto_build_requires_and_passes_manifest_fp8_scales: passed, 2 tests.
- PYTHONPATH=python python3 -m pytest -q tests/tools/test_trtmc_bench.py: passed, 61 tests.
- CI_BASE_REF=github/main python3 -m tools.ci pipeline source-quality: passed, including 156 architecture-contract tests.
- PYTHONPATH=python python3 -m pytest -q tests/tools: 1832 passed; one unrelated existing model-proof runner test failed because the local filesystem does not support reflink. The failure reproduces independently and touches no changed file.
- Repository-wide path-coupling scan found no second test comparing a runtime catalog asset against a checkout-root path.

## Notes For Future Readers

- Catalog assets must be resolved from the selected manifest root because source checkouts and installed wheels intentionally use different physical locations.
- Refs #518; the automated Nightly tracker should close only after a fully successful scheduled run.
