### PR TITLE
ci(gpu): expand proof pool across nodes

### DIFF
--- a/.github/workflows/model-proof.yml
+++ b/.github/workflows/model-proof.yml
@@ -43,7 +43,7 @@ jobs:
       TRTMC_HF_HUB_CACHE: ${{ vars.TRTMC_HF_HUB_CACHE || format('{0}/hub', vars.TRTMC_HF_HOME || '/workspace/users/yifeif/tensorrt-model-connect/hf-cache') }}
       TRTMC_MODEL_REFERENCE_CACHE_ROOT: ${{ vars.TRTMC_MODEL_REFERENCE_CACHE_ROOT || '/workspace/users/yifeif/tensorrt-model-connect' }}
       TRTMC_MODEL_PROOF_BUILD_JOBS: ${{ vars.TRTMC_MODEL_PROOF_BUILD_JOBS || '2' }}
-      TRTMC_MODEL_PROOF_GPU_IDS: ${{ vars.TRTMC_MODEL_PROOF_GPU_IDS || '0,1,2,3' }}
+      # GPU IDs come from the node-local runner service environment.
       TRTMC_MODEL_PROOF_SLOTS_PER_GPU: ${{ vars.TRTMC_MODEL_PROOF_SLOTS_PER_GPU || '4' }}
       TRTMC_MODEL_PROOF_GPU_LOCK_DIR: ${{ vars.TRTMC_MODEL_PROOF_GPU_LOCK_DIR || '/tmp/trtmc-model-proof-gpu-locks' }}
       TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS: ${{ vars.TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS || (inputs.suite == 'nightly' && '5400' || '3600') }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -272,7 +272,7 @@ jobs:
           fi
 
   cache-warm:
-    name: 3 / HF cache / Active single-GPU nightly cases
+    name: 3 / HF cache / ${{ matrix.node_label }}
     needs:
       - legal
       - inventory
@@ -281,7 +281,13 @@ jobs:
         needs.legal.result == 'success' &&
         needs.inventory.result == 'success'
       }}
-    runs-on: ${{ fromJSON(vars.TRTMC_MODEL_RUNNER_LABELS || vars.TRTMC_RUNNER_LABELS || '["self-hosted"]') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node_label:
+          - trtmc-node-gb300-nvl-019-compute01
+          - trtmc-node-gb300-nvl-019-compute02
+    runs-on: ${{ matrix.node_label }}
     timeout-minutes: 240
     permissions:
       contents: read
@@ -484,7 +490,6 @@ jobs:
       # A failed model invalidates the nightly, but every sibling proof still
       # runs so one nightly captures the complete failure set.
       fail-fast: false
-      max-parallel: 16
       matrix: ${{ fromJSON(needs.inventory.outputs.matrix) }}
     permissions:
       contents: read

--- a/.github/workflows/trtmc-ci.yml
+++ b/.github/workflows/trtmc-ci.yml
@@ -342,7 +342,6 @@ jobs:
       }}
     strategy:
       fail-fast: true
-      max-parallel: 16
       matrix: ${{ fromJSON(needs.impact.outputs.matrix) }}
     permissions:
       contents: read

--- a/reports/gb300-ci-28-slot-implementation-plan.md
+++ b/reports/gb300-ci-28-slot-implementation-plan.md
@@ -1,0 +1,101 @@
+# GB300 CI: 28-slot KISS rollout
+
+## Outcome
+
+Use one generic GitHub Actions label, `trtmc-gb300-proof`, for all model-proof
+work. After rollout the pool contains:
+
+- `gb300-nvl-019-compute01`: GPUs `0,1,2,3`, four shared slots per GPU,
+  16 runner listeners.
+- `gb300-nvl-019-compute02`: GPUs `1,2,3`, four shared slots per GPU,
+  12 runner listeners.
+
+Normal Pre-Merge and Nightly model jobs do not select a host. GitHub assigns
+each matrix job to any idle runner carrying the generic label. The existing
+host-local GPU lease then selects one of that host's shared GPU slots.
+
+## Minimal repository change
+
+1. Stop overriding GPU IDs in `model-proof.yml`. That value comes from each
+   runner service environment.
+2. Remove the fixed 16-job Pre-Merge and Nightly model matrix limits so the
+   matrix can use every available generic runner when it has enough jobs.
+3. Turn the existing Nightly cache-warm job into a two-row static matrix, one
+   node label per host. The existing strict cache warmer runs once on each
+   host before Nightly model proofs begin.
+
+No new scheduler, GitHub App, runner-discovery service, cache-copy process, or
+permanent capacity-canary framework is required.
+
+## Runner configuration
+
+Only the usable GPU list differs between the two nodes, so that is the only
+runner-local value this patch needs to consume:
+
+```text
+# compute01
+TRTMC_MODEL_PROOF_GPU_IDS=0,1,2,3
+
+# compute02
+TRTMC_MODEL_PROOF_GPU_IDS=1,2,3
+```
+
+The existing workflow continues to use four slots per GPU and the same lock
+and Hugging Face cache path strings on both hosts. Those paths resolve on each
+host's local filesystem; the two hosts do not share one cache.
+
+Runner labels have two purposes:
+
+- `trtmc-gb300-proof`: generic production scheduling.
+- `trtmc-node-<hostname>`: route the one-per-node Nightly cache warm.
+
+## Safe rollout
+
+1. Keep the 16 compute01 proof runners online with only their node label while
+   the pull request is under review.
+2. Verify all four compute01 GPUs with a disposable, network-disabled CUDA
+   probe and verify all 16 listener services are active and enabled.
+3. Run the pull request's exact-head CI on the existing production pool.
+4. Merge through the GitHub ruleset only after the required checks pass.
+5. Run Nightly from merged `main`; require both node-specific cache-warm matrix
+   rows to pass.
+6. Add `trtmc-gb300-proof` to the exact 16 compute01 runner registrations with
+   the GitHub runner-label API. Adding a label does not require `sudo` or a
+   runner restart.
+7. Assert the production label resolves to exactly 28 online runners:
+   16 on compute01 and 12 on compute02.
+
+If admission fails, remove only `trtmc-gb300-proof` from the 16 compute01
+runners. Their services and node labels remain intact, so the rollback is
+immediate and reversible.
+
+## Acceptance tests
+
+After merge, use short-lived test-only pull requests. Do not merge their test
+workflow into `main`.
+
+1. Capacity test: start 29 tiny jobs on `trtmc-gb300-proof`. The first 28 hold
+   one real `GpuLease`; GitHub must report 16 jobs on compute01, 12 on
+   compute02, and the 29th queued until a slot is released.
+2. Ordinary Pre-Merge test: run a small model-owned change and confirm it can
+   land on compute01 without any host-specific workflow selector.
+3. Nightly test: dispatch merged `main`, confirm one successful cache-warm job
+   on each node, then confirm model proofs consume the generic 28-runner pool.
+
+Close the test pull requests after collecting run IDs, runner names, node
+distribution, GPU/slot receipts, and final conclusions.
+
+## Adding another GPU node
+
+Expansion is intentionally semi-automatic and declarative:
+
+1. Install and start the desired number of runner listeners on the new host.
+2. Give them the generic production label and one shared node label.
+3. Configure that host's usable GPU IDs in its runner service environment and
+   use the shared four-slots-per-GPU, lock-path, and cache-path contract.
+4. Add one row for the node label to the Nightly cache-warm matrix in a normal
+   pull request.
+5. Repeat the temporary `N+1` capacity test.
+
+Normal Pre-Merge and Nightly model scheduling needs no further host-specific
+code. The only per-node repository data is the cache-warm matrix row.

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -648,7 +648,7 @@ def test_premerge_ci_exposes_the_model_owned_dependency_graph() -> None:
     assert "name: 4 / Model / ${{ matrix.model }} [${{ matrix.selection_kind }}]" in model_proof
     assert "fail-fast: true" in model_proof
     assert "continue-on-error" not in model_proof
-    assert "max-parallel: 16" in model_proof
+    assert "max-parallel:" not in model_proof
     assert "matrix: ${{ fromJSON(needs.impact.outputs.matrix) }}" in model_proof
     assert "model: ${{ matrix.model }}" in model_proof
     assert "models: ${{ needs.impact.outputs.affected_models }}" not in model_proof
@@ -941,7 +941,7 @@ def test_nightly_exposes_the_staged_all_model_dependency_graph() -> None:
     assert "needs.cache-warm.result == 'success'" in model_proof
     assert "needs.package.result == 'success'" in model_proof
     assert "fail-fast: false" in model_proof
-    assert "max-parallel: 16" in model_proof
+    assert "max-parallel:" not in model_proof
     assert "matrix: ${{ fromJSON(needs.inventory.outputs.matrix) }}" in model_proof
     assert "uses: ./.github/workflows/model-proof.yml" in model_proof
     assert "model: ${{ matrix.model }}" in model_proof
@@ -1003,12 +1003,23 @@ def test_nightly_self_hosted_stages_use_the_configured_proof_runner_pool() -> No
 
     for start, end in (
         ("unit-tests", "cache-warm"),
-        ("cache-warm", "package"),
         ("package", "model-proof"),
         ("diffusion-vlm", "report"),
     ):
         block = text.split(f"\n  {start}:", maxsplit=1)[1].split(f"\n  {end}:", maxsplit=1)[0]
         assert selector in block
+
+
+def test_nightly_warms_the_shared_cache_once_on_each_gpu_node() -> None:
+    text = (REPO_ROOT / ".github" / "workflows" / "nightly.yml").read_text()
+    cache = text.split("\n  cache-warm:", maxsplit=1)[1].split("\n  package:", maxsplit=1)[0]
+
+    assert "name: 3 / HF cache / ${{ matrix.node_label }}" in cache
+    assert "fail-fast: false" in cache
+    assert "runs-on: ${{ matrix.node_label }}" in cache
+    assert cache.count("- trtmc-node-") == 2
+    for node in ("gb300-nvl-019-compute01", "gb300-nvl-019-compute02"):
+        assert f"trtmc-node-{node}" in cache
 
 
 def test_nightly_strictly_warms_all_active_non_multi_device_cases() -> None:

--- a/tests/tools/test_model_proof_runner.py
+++ b/tests/tools/test_model_proof_runner.py
@@ -3685,9 +3685,9 @@ def test_gpu_mapping_exists_only_on_the_hermetic_proof_container() -> None:
     assert '"resource_class": self.resource_class' in allocator
     assert '"gpu_resource_class": self.resource_class' in allocator
     assert '"gpu_lease_evidence": "gpu-lease.json"' in inner
-    assert (
-        "TRTMC_MODEL_PROOF_GPU_IDS: ${{ vars.TRTMC_MODEL_PROOF_GPU_IDS || '0,1,2,3' }}" in workflow
-    )
+    assert "vars.TRTMC_MODEL_PROOF_GPU_IDS" not in workflow
+    assert "\n      TRTMC_MODEL_PROOF_GPU_IDS:" not in workflow
+    assert "TRTMC_MODEL_PROOF_SLOTS_PER_GPU" in workflow
     assert (
         "TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS: "
         "${{ vars.TRTMC_MODEL_PROOF_GPU_LEASE_TIMEOUT_SECONDS || "


### PR DESCRIPTION
## Background

The generic GB300 proof pool currently overrides every host with GPU IDs `1,2,3` and caps both model matrices at 16 jobs. That prevents compute01 from contributing GPU 0 and prevents CI from filling the planned 28 shared slots. Nightly also warms the shared Hugging Face cache on only one randomly selected node.

## Exit Criteria

- One generic proof label can safely span compute01 GPUs `0,1,2,3` and compute02 GPUs `1,2,3`.
- Pre-Merge and Nightly can use every available runner when their matrix is large enough.
- The existing strict Nightly cache warm runs once on each declared node before model proofs.

## Implementation

- Let model proofs inherit `TRTMC_MODEL_PROOF_GPU_IDS` from each runner service instead of the repository variable.
- Remove the fixed `max-parallel: 16` limits; GitHub runner availability now determines concurrency.
- Route the existing cache-warm job through a two-row node-label matrix.
- Add a concise rollout, rollback, validation, and future-node plan.

## Validation

- `python3 -m pytest -q tests/tools/test_github_actions_ci.py`: 87 passed.
- `python3 -m pytest -q tests/tools/test_model_proof_runner.py -k gpu_mapping_exists_only_on_the_hermetic_proof_container`: 1 passed.
- `python3 -m pytest -q tests/tools/test_model_proof_runner.py -m "not model_proof_allocator"`: 102 passed.
- `PYTHONPATH=python python3 -m pytest -q tests/tools/test_warm_hf_cache_static.py`: 36 passed.
- `CI_BASE_REF=github/main python3 -m tools.ci pipeline source-quality`: passed, including 157 tests.
- Disposable network-disabled CUDA probes completed successfully on compute01 GPUs 0 through 3; all 16 compute01 proof services are active and enabled.

## Notes For Future Readers

Review the three workflow edits first; no scheduler or allocator code is added. During exact-head validation, compute01 proof-00 through proof-11 temporarily expose 12 old-workflow-compatible slots for GPUs `1,2,3`; proof-12 through proof-15 remain node-only, so GPU 0 is not advertised to old workflow refs. Full 16-slot admission happens only after this change is merged. Future same-shape nodes need runner registration plus one declarative cache-warm matrix row.