### PR TITLE
perf(canary): keep inference state in FP16

### DIFF
--- a/python/tensorrt_model_connect/families/canary/decoder_tp_builder.py
+++ b/python/tensorrt_model_connect/families/canary/decoder_tp_builder.py
@@ -397,10 +397,10 @@ def build_canary_tp_decoder_engine(
     for i in range(dec_layers):
         cross_k_inputs.append(network.add_input(
             graph_ops.layer_tensor_name("cross_k", i),
-            trt.float32, (-1, max_source_positions, hidden)))
+            work_trt_dtype, (-1, max_source_positions, hidden)))
         cross_v_inputs.append(network.add_input(
             graph_ops.layer_tensor_name("cross_v", i),
-            trt.float32, (-1, max_source_positions, hidden)))
+            work_trt_dtype, (-1, max_source_positions, hidden)))
 
     profile = builder.create_optimization_profile()
     profile.set_shape(

--- a/python/tensorrt_model_connect/families/canary/plugin.py
+++ b/python/tensorrt_model_connect/families/canary/plugin.py
@@ -901,6 +901,7 @@ class CanaryPlugin:
         else:
             raise ValueError(
                 f"Unsupported Canary precision {precision!r}; expected fp32 or fp16")
+        state_io_trt_dtype = work_trt_dtype
         encoder_layers = int(weights["_enc_layers"])
         decoder_io_component = encoder_layers + dl + 1
         use_fp32_decoder_io = (
@@ -928,10 +929,10 @@ class CanaryPlugin:
             "cross_attention_mask", trt.float32, (-1, 1, es))
         cki, cvi, xki, xvi = [], [], [], []
         for i in range(dl):
-            cki.append(net.add_input(graph_ops.layer_tensor_name("cache_k", i), trt.float32, (-1, max_cache_length, h)))
-            cvi.append(net.add_input(graph_ops.layer_tensor_name("cache_v", i), trt.float32, (-1, max_cache_length, h)))
-            xki.append(net.add_input(graph_ops.layer_tensor_name("cross_k", i), trt.float32, (-1, es, h)))
-            xvi.append(net.add_input(graph_ops.layer_tensor_name("cross_v", i), trt.float32, (-1, es, h)))
+            cki.append(net.add_input(graph_ops.layer_tensor_name("cache_k", i), state_io_trt_dtype, (-1, max_cache_length, h)))
+            cvi.append(net.add_input(graph_ops.layer_tensor_name("cache_v", i), state_io_trt_dtype, (-1, max_cache_length, h)))
+            xki.append(net.add_input(graph_ops.layer_tensor_name("cross_k", i), state_io_trt_dtype, (-1, es, h)))
+            xvi.append(net.add_input(graph_ops.layer_tensor_name("cross_v", i), state_io_trt_dtype, (-1, es, h)))
 
         profile = b.create_optimization_profile()
         batch_shapes = {
@@ -1051,10 +1052,10 @@ class CanaryPlugin:
         logits.name = "logits"
         net.mark_output(logits)
         for i in range(dl):
-            if pko[i].dtype != trt.float32:
-                pko[i] = net.add_cast(pko[i], trt.float32).get_output(0)
-            if pvo[i].dtype != trt.float32:
-                pvo[i] = net.add_cast(pvo[i], trt.float32).get_output(0)
+            if pko[i].dtype != state_io_trt_dtype:
+                pko[i] = net.add_cast(pko[i], state_io_trt_dtype).get_output(0)
+            if pvo[i].dtype != state_io_trt_dtype:
+                pvo[i] = net.add_cast(pvo[i], state_io_trt_dtype).get_output(0)
             pko[i].name = graph_ops.layer_tensor_name("present_k", i)
             pvo[i].name = graph_ops.layer_tensor_name("present_v", i)
             net.mark_output(pko[i])
@@ -1269,8 +1270,8 @@ def _build_encoder(
     output_layer = net.add_shuffle(hs)
     output_layer.reshape_dims = (-1, es, h)
     output = output_layer.get_output(0)
-    if output.dtype != trt.float32:
-        output = net.add_cast(output, trt.float32).get_output(0)
+    if output.dtype != work_trt_dtype:
+        output = net.add_cast(output, work_trt_dtype).get_output(0)
     output.name = "encoder_output"
     net.mark_output(output)
     if verbose:

--- a/src/runtime/models/canary/canary_cross_kv_plan.h
+++ b/src/runtime/models/canary/canary_cross_kv_plan.h
@@ -18,22 +18,23 @@ struct CanaryCrossKvPlan {
 };
 
 inline CanaryCrossKvPlan make_canary_cross_kv_plan(int32_t encoder_seq_length, int32_t hidden_size,
-                                                   int32_t actual_encoder_seq_length) {
+                                                   int32_t actual_encoder_seq_length,
+                                                   std::size_t element_size = sizeof(float)) {
     CanaryCrossKvPlan plan;
-    if (encoder_seq_length <= 0 || hidden_size <= 0) {
+    if (encoder_seq_length <= 0 || hidden_size <= 0 || element_size == 0) {
         return plan;
     }
 
     const std::size_t encoder_tokens = static_cast<std::size_t>(encoder_seq_length);
     const std::size_t hidden = static_cast<std::size_t>(hidden_size);
-    plan.buffer_bytes = encoder_tokens * hidden * sizeof(float);
+    plan.buffer_bytes = encoder_tokens * hidden * element_size;
 
     if (actual_encoder_seq_length <= 0 || actual_encoder_seq_length >= encoder_seq_length) {
         plan.valid_bytes = plan.buffer_bytes;
         return plan;
     }
 
-    plan.valid_bytes = static_cast<std::size_t>(actual_encoder_seq_length) * hidden * sizeof(float);
+    plan.valid_bytes = static_cast<std::size_t>(actual_encoder_seq_length) * hidden * element_size;
     plan.pad_bytes = plan.buffer_bytes - plan.valid_bytes;
     plan.zero_pad_encoder_output = plan.pad_bytes > 0;
     return plan;

--- a/src/runtime/models/canary/pipeline.cpp
+++ b/src/runtime/models/canary/pipeline.cpp
@@ -491,9 +491,16 @@ void zero_pad_canary_encoder_batch(uint8_t* encoder_output,
                                    const std::vector<int32_t>& actual_encoder_lengths,
                                    int32_t max_source_positions, int32_t hidden_size,
                                    std::size_t sample_bytes, cudaStream_t stream) {
+    if (max_source_positions <= 0 || hidden_size <= 0)
+        return;
+    const std::size_t sample_elements =
+        static_cast<std::size_t>(max_source_positions) * static_cast<std::size_t>(hidden_size);
+    if (sample_bytes == 0 || sample_bytes % sample_elements != 0)
+        throw std::invalid_argument("Canary encoder output has an invalid byte size");
+    const std::size_t element_size = sample_bytes / sample_elements;
     for (std::size_t sample = 0; sample < actual_encoder_lengths.size(); ++sample) {
         const auto plan = make_canary_cross_kv_plan(max_source_positions, hidden_size,
-                                                    actual_encoder_lengths[sample]);
+                                                    actual_encoder_lengths[sample], element_size);
         if (!plan.zero_pad_encoder_output || plan.pad_bytes == 0)
             continue;
         const auto status = cudaMemsetAsync(
@@ -717,8 +724,14 @@ CanaryPipeline::CanaryPipeline(
     // All decoder layers consume the same raw encoder output and perform their
     // own cross-attention projections, so one stable external buffer can back
     // every cross_k/cross_v input.
+    const DType encoder_output_dtype = encoder_->tensor_dtype("encoder_output");
+    const DType cross_input_dtype = decoder_->tensor_dtype("cross_k_0");
+    if (encoder_output_dtype != cross_input_dtype) {
+        throw std::runtime_error(
+            "CanaryPipeline: encoder output and decoder cross-attention dtypes differ");
+    }
     cross_kv_sample_bytes_ = static_cast<std::size_t>(canary_config_.max_source_positions) *
-                             static_cast<std::size_t>(hidden_size_) * sizeof(float);
+                             static_cast<std::size_t>(hidden_size_) * dtype_size(cross_input_dtype);
     const std::size_t cross_bytes =
         static_cast<std::size_t>(decoder_lane_capacity_) * cross_kv_sample_bytes_;
     cross_kv_ptr_ = allocate_canary_cross_kv_buffer(num_decoder_layers_, cross_bytes);

--- a/tests/cpp/models/canary/test_canary_host_plan.cpp
+++ b/tests/cpp/models/canary/test_canary_host_plan.cpp
@@ -189,6 +189,14 @@ void test_encoder_mask_and_cross_kv_plan() {
     check(partial_plan.pad_bytes == partial_plan.buffer_bytes - partial_plan.valid_bytes,
           "canary cross-kv plan computes padded byte span");
 
+    const auto fp16_plan = trtmc::make_canary_cross_kv_plan(1500, 4, 1000, 2);
+    check(fp16_plan.buffer_bytes == static_cast<std::size_t>(1500 * 4 * 2),
+          "canary cross-kv plan supports FP16 buffers");
+    check(fp16_plan.valid_bytes == static_cast<std::size_t>(1000 * 4 * 2),
+          "canary cross-kv plan computes the FP16 valid byte span");
+    check(fp16_plan.pad_bytes == static_cast<std::size_t>(500 * 4 * 2),
+          "canary cross-kv plan computes the FP16 padded byte span");
+
     const auto invalid_plan = trtmc::make_canary_cross_kv_plan(0, 4, 0);
     check(invalid_plan.buffer_bytes == 0 && !invalid_plan.zero_pad_encoder_output,
           "canary cross-kv plan returns empty plan for invalid shape");


### PR DESCRIPTION
## Background

Canary's FP16 engines cast encoder output, decoder KV cache, and cross-attention state to FP32 at engine boundaries, then cast those tensors back to FP16 for computation. The round trip adds conversion work and doubles state-buffer traffic without recovering information. L4 is the primary target for this optimization.

## Exit Criteria

- Keep Canary encoder and decoder state I/O in the selected engine precision while preserving FP32 normalization, masks, and logits.
- Make runtime cross-attention allocation and padding use the actual engine tensor width.
- Preserve exact token and transcript output on the available Canary audio probes.
- Improve L4 latency across greedy and beam-2 workloads without weakening validation.

## Implementation

- Export encoder output, decoder cache/present K/V, and decoder cross-attention K/V in the working TensorRT dtype. FP16 builds therefore keep state in FP16 instead of inserting FP32 boundary casts.
- Apply the same cross-attention I/O contract to tensor-parallel decoder builds.
- Derive cross-attention buffer and padding sizes from the engine dtype, and reject mismatched encoder/decoder boundary types.
- Add host-plan coverage for two-byte FP16 elements.

## Validation

- `ruff check --config ruff.toml python/tensorrt_model_connect/families/canary/plugin.py python/tensorrt_model_connect/families/canary/decoder_tp_builder.py`: passed.
- `clang-format --dry-run --Werror src/runtime/models/canary/canary_cross_kv_plan.h src/runtime/models/canary/pipeline.cpp tests/cpp/models/canary/test_canary_host_plan.cpp`: passed.
- `python -m pytest -q tests/e2e/models/canary/test_canary_family_plugin_weights.py tests/e2e/models/canary/test_canary_registry_contract.py tests/e2e/models/canary/test_canary_reference_paths.py`: 17 passed.
- `ctest --test-dir build-gb300-fp16io --output-on-failure -R 'test_canary_(host_plan|pipeline)'`: 2 passed.

L4, TensorRT 11.2, paired latency reduction:

| Beam | Batch 1 | Batch 4 | Batch 8 | Batch 16 |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 1.83% | 4.16% | 4.64% | 5.26% |
| 2 | 2.28% | 5.63% | 6.59% | 8.93% |

A reversed-order repeat confirmed the L4 result. Token IDs and transcript bytes matched in 32/32 L4 comparisons across eight audio probes, direct and mixed batch-8 execution, and beam sizes 1 and 2.

GB300, TensorRT 11.2.0.113, reverse-order pinned median latency:

| Beam | Batch | Baseline | FP16 state | Result |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 1 | 26.67 ms | 27.51 ms | 3.1% slower |
| 1 | 8 | 47.46 ms | 46.83 ms | 1.3% faster |
| 1 | 16 | 67.90 ms | 65.50 ms | 3.5% faster |
| 2 | 1 | 38.06 ms | 39.41 ms | 3.5% slower |
| 2 | 8 | 73.30 ms | 72.34 ms | 1.3% faster |
| 2 | 16 | 115.59 ms | 112.77 ms | 2.4% faster |

GB300 token IDs and transcripts matched for all eight probes at beam sizes 1 and 2. Tensor inspection confirmed FP16 encoder/state I/O and FP32 logits.

## Notes For Future Readers

- FP32 LayerNorm is intentional: FP16 LayerNorm caused incorrect output and TensorRT overflow warnings during exploration.
- The GB300 batch-1 regression is repeatable even though batches 8 and 16 improve. Treat this as an L4-first throughput optimization, not a universal low-latency win.
- Review the Python engine-boundary changes first, then the runtime dtype-aware allocation and padding changes.
