### PR TITLE
fix(ci): support shared image locks

### DIFF
--- a/.github/workflows/model-proof.yml
+++ b/.github/workflows/model-proof.yml
@@ -38,7 +38,6 @@ jobs:
 
     env:
       TRTMC_CI_IMAGE: ${{ vars.TRTMC_MANYLINUX_CI_IMAGE || 'trtmc-dev-gb300:manylinux_2_39' }}
-      TRTMC_CI_IMAGE_LOCK_FILE: ${{ vars.TRTMC_CI_IMAGE_LOCK_FILE || '/tmp/trtmc-ci-docker-image.lock' }}
       TRTMC_HF_CACHE: ${{ vars.TRTMC_HF_HOME || '/workspace/users/yifeif/tensorrt-model-connect/hf-cache' }}
       TRTMC_HF_HUB_CACHE: ${{ vars.TRTMC_HF_HUB_CACHE || format('{0}/hub', vars.TRTMC_HF_HOME || '/workspace/users/yifeif/tensorrt-model-connect/hf-cache') }}
       TRTMC_MODEL_REFERENCE_CACHE_ROOT: ${{ vars.TRTMC_MODEL_REFERENCE_CACHE_ROOT || '/workspace/users/yifeif/tensorrt-model-connect' }}

--- a/reports/gb300-ci-28-slot-implementation-plan.md
+++ b/reports/gb300-ci-28-slot-implementation-plan.md
@@ -49,6 +49,19 @@ Runner labels have two purposes:
 - `trtmc-gb300-proof`: generic production scheduling.
 - `trtmc-node-<hostname>`: route the one-per-node Nightly cache warm.
 
+Compute01 has runner services under both `gh-runner-mc` and `yifeif` sharing
+one Docker daemon. Its persistent tmpfiles configuration therefore keeps the
+daemon-wide image state writable by their shared `docker` group:
+
+```text
+d /tmp/trtmc-ci-image-verifications 2775 gh-runner-mc docker -
+f /tmp/trtmc-ci-docker-image.lock 0664 gh-runner-mc docker -
+```
+
+Apply the same shared-group invariant when a future node mixes service users.
+Do not use a per-user image lock: all runners on one host must serialize image
+verification and rebuilds against that host's single Docker daemon.
+
 ## Safe rollout
 
 1. Keep the 16 compute01 proof runners online with only their node label while

--- a/tests/tools/test_ensure_ci_docker_image.py
+++ b/tests/tools/test_ensure_ci_docker_image.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from tools.ci.docker_image import WorkflowImageLock
+
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SCRIPT = REPO_ROOT / "tools" / "ci" / "docker_image.py"
@@ -19,6 +21,57 @@ DEFAULT_PROFILES = (
     "chronos,deepseek_ocr,elf_flow,internlm,magpie_tts_reference,"
     "nemotron_h_reference,phi4_multimodal"
 )
+
+
+def _record_lock_open_modes(monkeypatch, lock_path: Path, *, lose_create_race=False) -> list[str]:
+    modes: list[str] = []
+    path_open = Path.open
+
+    def traced_open(path: Path, mode: str = "r", *args, **kwargs):
+        if path == lock_path:
+            modes.append(mode)
+            if mode == "x+" and lose_create_race:
+                path_open(path, mode, *args, **kwargs).close()
+                raise FileExistsError(lock_path)
+        return path_open(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", traced_open)
+    return modes
+
+
+def test_workflow_image_lock_opens_existing_file_without_create(
+    tmp_path: Path, monkeypatch
+) -> None:
+    lock_path = tmp_path / "ci-image.lock"
+    lock_path.touch()
+    modes = _record_lock_open_modes(monkeypatch, lock_path)
+
+    with WorkflowImageLock(lock_path, timeout=1):
+        pass
+
+    assert modes == ["r+"]
+
+
+def test_workflow_image_lock_creates_missing_file(tmp_path: Path, monkeypatch) -> None:
+    lock_path = tmp_path / "ci-image.lock"
+    modes = _record_lock_open_modes(monkeypatch, lock_path)
+
+    with WorkflowImageLock(lock_path, timeout=1):
+        assert lock_path.is_file()
+
+    assert modes == ["r+", "x+"]
+
+
+def test_workflow_image_lock_retries_when_another_runner_creates_file(
+    tmp_path: Path, monkeypatch
+) -> None:
+    lock_path = tmp_path / "ci-image.lock"
+    modes = _record_lock_open_modes(monkeypatch, lock_path, lose_create_race=True)
+
+    with WorkflowImageLock(lock_path, timeout=1):
+        pass
+
+    assert modes == ["r+", "x+", "r+"]
 
 
 def _write_fake_docker(tmp_path: Path, existing_images: dict[str, str]) -> tuple[Path, Path]:

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -1542,10 +1542,9 @@ def test_model_proof_runs_one_isolated_model_with_unique_complete_evidence() -> 
     assert "TRTMC_CI_IMAGE:" in proof
     assert "vars.TRTMC_MANYLINUX_CI_IMAGE" in proof
     assert "trtmc-dev-gb300:manylinux_2_39" in proof
-    assert (
-        "TRTMC_CI_IMAGE_LOCK_FILE: ${{ vars.TRTMC_CI_IMAGE_LOCK_FILE || "
-        "'/tmp/trtmc-ci-docker-image.lock' }}"
-    ) in proof
+    assert "TRTMC_CI_IMAGE_LOCK_FILE:" not in proof
+    image_manager = _ci_source("docker_image.py")
+    assert 'env.get("TRTMC_CI_IMAGE_LOCK_FILE", "/tmp/trtmc-ci-docker-image.lock")' in image_manager
     assert "Ensure CI Docker image" in proof
     assert "python3 -m tools.ci image ensure" in proof
     assert proof.count("actions/checkout@v4") == 1

--- a/tools/ci/docker_image.py
+++ b/tools/ci/docker_image.py
@@ -73,9 +73,24 @@ class WorkflowImageLock:
         self.timeout = timeout
         self.handle = None
 
+    def _open(self):
+        """Open a shared lock without O_CREAT when it already exists.
+
+        Hardened Linux rejects O_CREAT for another user's file directly under
+        a sticky directory such as /tmp, even when a shared group can write it.
+        """
+        try:
+            return self.path.open("r+", encoding="utf-8")
+        except FileNotFoundError:
+            try:
+                return self.path.open("x+", encoding="utf-8")
+            except FileExistsError:
+                # Another runner created the lock between the two opens.
+                return self.path.open("r+", encoding="utf-8")
+
     def __enter__(self) -> "WorkflowImageLock":
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.handle = self.path.open("a+", encoding="utf-8")
+        self.handle = self._open()
         deadline = time.monotonic() + self.timeout
         while True:
             try:


### PR DESCRIPTION
## Background

Compute01 now has `gh-runner-mc` and `yifeif` runner services sharing one
Docker daemon. The host-wide image lock is precreated as `0664
gh-runner-mc:docker`, but `fs.protected_regular=2` rejects Python's `a+` open
because it includes `O_CREAT` for another user's file directly under sticky
`/tmp`. This caused PR #528 and manual Nightly jobs on Compute01 to fail before
their CI stages started.

## Exit Criteria

- Mixed-user runners open the preprovisioned host-wide image lock without
  `O_CREAT`.
- Single-user or unprovisioned hosts still create the lock atomically when it
  is missing.
- Concurrent creators converge on one shared lock, and runners sharing a
  Docker daemon keep one serialization boundary.

## Implementation

- Open an existing lock with `r+`; fall back to exclusive `x+` creation only
  when it is absent, then handle a lost creation race by reopening it.
- Remove the model-proof repository-variable override so Unit, Nightly, and
  model proofs all use the same host-wide lock path.
- Add focused tests for the existing, missing, and concurrent-creation paths.
- Record the shared-group tmpfiles invariant in the 28-slot rollout plan.

## Validation

- `python -m pytest tests/tools/test_ensure_ci_docker_image.py tests/tools/test_github_actions_ci.py -q`:
  100 passed.
- `CI_BASE_REF=github/main python3 -m tools.ci pipeline source-quality`: passed.
- `python tools/legal_headers.py --check`: 0 findings.
- `python tools/test_impact.py --validate`: passed with existing warnings only.
- Independent review found no blocking issues.

## Notes For Future Readers

- Mixed-user nodes must precreate the verification directory and lock with a
  shared group; fallback creation intentionally preserves single-user behavior
  and does not replace host provisioning.
- Do not split the lock per user: every runner on a host operates on the same
  Docker daemon.
- The now-unused `TRTMC_CI_IMAGE_LOCK_FILE` repository variable can be removed
  after this change reaches `main`.
- A merged-main Nightly on both node-specific cache-warm rows remains the
  end-to-end acceptance test.
