### PR TITLE
fix(package): include benchmark prompt assets

### DIFF
--- a/_pyproject_backend.py
+++ b/_pyproject_backend.py
@@ -91,8 +91,11 @@ def _append_benchmark_catalog_to_sdist(sdist_path: Path) -> None:
             raise RuntimeError(f"cannot read benchmark manifest {manifest}: {exc}") from exc
         references = [("fp8_scales", raw.get("fp8_scales"))]
         for index, testcase in enumerate(raw.get("testcases", [])):
-            if isinstance(testcase, dict) and "test_image" in testcase:
-                references.append((f"testcases[{index}].test_image", testcase["test_image"]))
+            if not isinstance(testcase, dict):
+                continue
+            for field in ("test_image", "prompt_file"):
+                if field in testcase:
+                    references.append((f"testcases[{index}].{field}", testcase[field]))
         for field, declared in references:
             if declared is None:
                 continue

--- a/conanfile.py
+++ b/conanfile.py
@@ -76,8 +76,11 @@ def _stage_benchmark_catalog(recipe: ConanFile, source_folder: str | Path, packa
             raise ConanException(f"cannot read benchmark manifest {manifest}: {exc}") from exc
         references = [("fp8_scales", raw.get("fp8_scales"))]
         for index, testcase in enumerate(raw.get("testcases", [])):
-            if isinstance(testcase, dict) and "test_image" in testcase:
-                references.append((f"testcases[{index}].test_image", testcase["test_image"]))
+            if not isinstance(testcase, dict):
+                continue
+            for field in ("test_image", "prompt_file"):
+                if field in testcase:
+                    references.append((f"testcases[{index}].{field}", testcase[field]))
         for field, declared in references:
             if declared is None:
                 continue

--- a/tests/tools/test_optimized_runtime_packaging.py
+++ b/tests/tools/test_optimized_runtime_packaging.py
@@ -121,13 +121,15 @@ def _package(recipe_module, source: Path, tmp_path: Path) -> Path:
     )
     (catalog_family / "manifests/example.json").write_text(
         '{"fp8_scales": "data/fp8-scales.json", '
-        '"testcases": [{"test_image": "data/test_img.jpeg"}]}\n',
+        '"testcases": [{"test_image": "data/test_img.jpeg", '
+        '"prompt_file": "data/prompt.txt"}]}\n',
         encoding="utf-8",
     )
     (catalog_family / "data").mkdir()
     (catalog_family / "data/Recording.wav").write_bytes(b"RIFF-test-audio")
     (catalog_family / "data/fp8-scales.json").write_text("{}\n", encoding="utf-8")
     (catalog_family / "data/test_img.jpeg").write_bytes(b"test-image")
+    (catalog_family / "data/prompt.txt").write_text("test prompt\n", encoding="utf-8")
     recipe = recipe_module.TensorRTModelConnectConan()
     recipe.source_folder = str(source)
     recipe.build_folder = str(build)
@@ -190,6 +192,7 @@ def test_package_stages_a_model_owned_adapter_as_inert_source(
     assert (catalog / "data/Recording.wav").is_file()
     assert (catalog / "data/fp8-scales.json").is_file()
     assert (catalog / "data/test_img.jpeg").is_file()
+    assert (catalog / "data/prompt.txt").is_file()
 
 
 def test_package_stages_the_complete_canonical_benchmark_catalog(
@@ -217,6 +220,7 @@ def test_package_stages_the_complete_canonical_benchmark_catalog(
     assert (installed / "flux/data/flux2-fp8-scales.json").is_file()
     assert (installed / "qwen_image/data/test_img.jpeg").is_file()
     assert (installed / "sana_wm/assets/demo_0.png").is_file()
+    assert (installed / "sana_wm/assets/demo_0.txt").is_file()
 
 
 def test_sdist_appends_only_the_minimal_benchmark_catalog(
@@ -232,13 +236,15 @@ def test_sdist_appends_only_the_minimal_benchmark_catalog(
     (family / "MODEL.toml").write_text('id = "example"\n', encoding="utf-8")
     (family / "manifests/example.json").write_text(
         '{"fp8_scales": "data/fp8-scales.json", '
-        '"testcases": [{"test_image": "data/test_img.jpeg"}]}\n',
+        '"testcases": [{"test_image": "data/test_img.jpeg", '
+        '"prompt_file": "data/prompt.txt"}]}\n',
         encoding="utf-8",
     )
     (family / "data").mkdir()
     (family / "data/Recording.wav").write_bytes(b"RIFF-test-audio")
     (family / "data/fp8-scales.json").write_text("{}\n", encoding="utf-8")
     (family / "data/test_img.jpeg").write_bytes(b"test-image")
+    (family / "data/prompt.txt").write_text("test prompt\n", encoding="utf-8")
     (family / "data/not-a-benchmark-input.bin").write_bytes(b"large fixture")
     archive = tmp_path / "example-0.1.0.tar.gz"
     with tarfile.open(archive, "w:gz") as destination:
@@ -255,6 +261,7 @@ def test_sdist_appends_only_the_minimal_benchmark_catalog(
     assert f"{prefix}/data/Recording.wav" in names
     assert f"{prefix}/data/fp8-scales.json" in names
     assert f"{prefix}/data/test_img.jpeg" in names
+    assert f"{prefix}/data/prompt.txt" in names
     assert f"{prefix}/data/not-a-benchmark-input.bin" not in names
 
 


### PR DESCRIPTION
## Background

Merged-main Nightly run 29965154103 built and installed the wheel, then failed Python package coverage because the packaged benchmark catalog omitted SANA-WM assets/demo_0.txt. The source catalog was complete, but installed-wheel catalog resolution marked SANA-WM invalid and blocked the entire model matrix.

## Exit Criteria

- Wheel catalog staging includes testcase prompt_file assets.
- Source-distribution catalog staging includes the same referenced prompt assets.
- The canonical packaged SANA-WM catalog contains assets/demo_0.txt.
- Unreferenced benchmark fixtures remain excluded.

## Implementation

- Extend the existing manifest asset loop in both Conan wheel staging and the PEP 517 sdist backend to include prompt_file beside test_image.
- Extend synthetic wheel and sdist tests with a prompt asset.
- Add a real-catalog assertion for SANA-WM demo_0.txt.

## Validation

- PYTHONPATH=python python -m pytest tests/tools/test_optimized_runtime_packaging.py tests/tools/test_trtmc_bench.py -q (66 passed)
- Staged installed-package catalog simulation with TRTMC_TEST_INSTALLED_WHEEL=1, covering the complete catalog, the previously filtered families, and SANA native-worker asset resolution (18 passed)
- CI_BASE_REF=github/main python3 -m tools.ci pipeline source-quality (157 architecture checks passed; lint and complexity passed)
- python tools/legal_headers.py --check (0 findings)
- python -m ruff check conanfile.py _pyproject_backend.py tests/tools/test_optimized_runtime_packaging.py
- git diff --check github/main...HEAD

## Notes

This is intentionally limited to the installed default benchmark catalog failure observed in Nightly. It does not weaken catalog readiness assertions or change runner scheduling, GPU capacity, cache warming, or model acceptance criteria.