### PR TITLE
test(ci): verify generic GB300 premerge scheduling

### DIFF
--- a/tests/e2e/models/patchtsmixer/GB300_POOL_ACCEPTANCE.md
+++ b/tests/e2e/models/patchtsmixer/GB300_POOL_ACCEPTANCE.md
@@ -1,0 +1,10 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Temporary GB300 pool acceptance marker
+
+This inert model-owned file exists only to exercise ordinary Pre-Merge
+scheduling on the generic `trtmc-gb300-proof` runner pool. The test pull
+request that contains it must be closed without merging.


### PR DESCRIPTION
## Background

This is a temporary acceptance PR for the merged 28-slot GB300 CI rollout. It verifies that an ordinary model-owned Pre-Merge job uses the generic runner pool and can be assigned to compute01 without a host-specific workflow selector.

## Exit Criteria

- Ownership and impact selects only `patchtsmixer`.
- The normal Pre-Merge workflow completes successfully.
- The model proof runs on a `gb300-nvl-019-compute01-proof-*` runner through the generic label.
- This PR is closed without merging after evidence is collected.

## Implementation

- Add one inert Markdown marker below the existing patchtsmixer model owner.
- Do not alter runtime behavior, test thresholds, or passing criteria.

## Validation

- `python3 tools/model_ci.py validate --revision HEAD`: passed; 77-model inventory is valid.
- `python3 tools/model_ci.py impact --base 9fc36dc74179f42e46cb12ce3fe0bbdb87661fb0 --head HEAD --platform-change-policy fallback --fallback-model deepseek_v2 --fallback-model patchtsmixer --fallback-model segformer --fallback-model whisper --fallback-model ltx_video`: passed; mode is `models`, direct model is only `patchtsmixer`, matrix size is one.
- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_model_ci.py tests/tools/test_github_actions_ci.py -q`: 150 passed.
- `python3 tools/legal_headers.py --check`: 0 findings.
- `git diff --check github/main...HEAD`: passed.

## Notes For Future Readers

Do not merge this PR. Do not apply `run-ci` while Nightly or the temporary capacity canary is using the GPU pool.