### PR TITLE
ci(nightly): run all validation stages

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,7 @@ jobs:
   inventory:
     name: 2 / All-model inventory
     needs: legal
-    if: ${{ needs.legal.result == 'success' }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -59,22 +59,24 @@ jobs:
       mode: ${{ steps.inventory.outputs.mode }}
 
     steps:
-      - name: Check out certified nightly snapshot
+      - name: Check out exact nightly snapshot
+        id: checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.legal.outputs.tested_sha }}
+          ref: ${{ needs.legal.outputs.tested_sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Validate ownership manifests
         env:
-          TESTED_SHA: ${{ needs.legal.outputs.tested_sha }}
+          TESTED_SHA: ${{ needs.legal.outputs.tested_sha || github.sha }}
         run: python3 tools/model_ci.py validate --revision "$TESTED_SHA"
 
       - name: Select every ownership model
         id: inventory
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         env:
-          TESTED_SHA: ${{ needs.legal.outputs.tested_sha }}
+          TESTED_SHA: ${{ needs.legal.outputs.tested_sha || github.sha }}
         run: |
           set -euo pipefail
           python3 tools/model_ci.py all \
@@ -82,8 +84,9 @@ jobs:
             --github-output "$GITHUB_OUTPUT"
 
       - name: Verify and summarize full inventory
+        if: ${{ !cancelled() && steps.inventory.outcome == 'success' }}
         env:
-          TESTED_SHA: ${{ needs.legal.outputs.tested_sha }}
+          TESTED_SHA: ${{ needs.legal.outputs.tested_sha || github.sha }}
           HAS_MODELS: ${{ steps.inventory.outputs.has_models }}
           EXPECTED_COUNT: ${{ steps.inventory.outputs.expected_count }}
           EXPECTED_CASES_BY_MODEL: ${{ steps.inventory.outputs.expected_cases_by_model }}
@@ -139,11 +142,7 @@ jobs:
     needs:
       - legal
       - inventory
-    if: >-
-      ${{
-        needs.legal.result == 'success' &&
-        needs.inventory.result == 'success'
-      }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -160,16 +159,16 @@ jobs:
       HF_MODULES_CACHE: ""
 
     steps:
-      - name: Check out certified nightly snapshot
+      - name: Check out exact nightly snapshot
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.legal.outputs.tested_sha }}
+          ref: ${{ needs.legal.outputs.tested_sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Resolve source-quality comparison base
         env:
-          TESTED_SHA: ${{ needs.legal.outputs.tested_sha }}
+          TESTED_SHA: ${{ needs.legal.outputs.tested_sha || github.sha }}
         run: |
           set -euo pipefail
           tested_sha="$(git rev-parse "${TESTED_SHA}^{commit}")"
@@ -202,18 +201,14 @@ jobs:
     needs:
       - legal
       - inventory
-    if: >-
-      ${{
-        needs.legal.result == 'success' &&
-        needs.inventory.result == 'success'
-      }}
+    if: ${{ !cancelled() }}
     runs-on: ${{ fromJSON(vars.TRTMC_MODEL_RUNNER_LABELS || vars.TRTMC_RUNNER_LABELS || '["self-hosted"]') }}
     timeout-minutes: 180
     permissions:
       contents: read
       packages: read
     env:
-      CI_BASE_REF: ${{ needs.legal.outputs.tested_sha }}
+      CI_BASE_REF: ${{ needs.legal.outputs.tested_sha || github.sha }}
       TRTMC_CI_CONTAINER_NAME: trtmc-nightly-unit-${{ github.run_id }}-${{ github.run_attempt }}
       TRTMC_CI_WORKSPACE: ${{ github.workspace }}/nightly-unit-${{ github.run_id }}-${{ github.run_attempt }}
       TRTMC_CI_HARDENED: "true"
@@ -222,10 +217,10 @@ jobs:
       TRTMC_PREMERGE_UNIT_SCOPE: all
 
     steps:
-      - name: Check out certified nightly snapshot
+      - name: Check out exact nightly snapshot
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.legal.outputs.tested_sha }}
+          ref: ${{ needs.legal.outputs.tested_sha || github.sha }}
           path: nightly-unit-${{ github.run_id }}-${{ github.run_attempt }}
           fetch-depth: 0
           persist-credentials: false
@@ -276,11 +271,7 @@ jobs:
     needs:
       - legal
       - inventory
-    if: >-
-      ${{
-        needs.legal.result == 'success' &&
-        needs.inventory.result == 'success'
-      }}
+    if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
       matrix:
@@ -304,10 +295,10 @@ jobs:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HF_TOKEN }}
 
     steps:
-      - name: Check out certified nightly snapshot
+      - name: Check out exact nightly snapshot
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.legal.outputs.tested_sha }}
+          ref: ${{ needs.legal.outputs.tested_sha || github.sha }}
           path: nightly-cache-${{ github.run_id }}-${{ github.run_attempt }}
           fetch-depth: 1
           persist-credentials: false
@@ -363,11 +354,7 @@ jobs:
     needs:
       - legal
       - inventory
-    if: >-
-      ${{
-        needs.legal.result == 'success' &&
-        needs.inventory.result == 'success'
-      }}
+    if: ${{ !cancelled() }}
     runs-on: ${{ fromJSON(vars.TRTMC_MODEL_RUNNER_LABELS || vars.TRTMC_RUNNER_LABELS || '["self-hosted"]') }}
     timeout-minutes: 330
     permissions:
@@ -388,10 +375,10 @@ jobs:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HF_TOKEN }}
 
     steps:
-      - name: Check out certified nightly snapshot
+      - name: Check out exact nightly snapshot
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.legal.outputs.tested_sha }}
+          ref: ${{ needs.legal.outputs.tested_sha || github.sha }}
           path: nightly-package-${{ github.run_id }}-${{ github.run_attempt }}
           fetch-depth: 1
           persist-credentials: false
@@ -477,13 +464,7 @@ jobs:
       - package
     if: >-
       ${{
-        always() &&
-        needs.legal.result == 'success' &&
-        needs.inventory.result == 'success' &&
-        needs.source-quality.result == 'success' &&
-        needs.unit-tests.result == 'success' &&
-        needs.cache-warm.result == 'success' &&
-        needs.package.result == 'success' &&
+        !cancelled() &&
         needs.inventory.outputs.has_models == 'true'
       }}
     strategy:
@@ -497,7 +478,7 @@ jobs:
     uses: ./.github/workflows/model-proof.yml
     with:
       model: ${{ matrix.model }}
-      revision: ${{ needs.legal.outputs.tested_sha }}
+      revision: ${{ needs.legal.outputs.tested_sha || github.sha }}
       suite: nightly
 
   diffusion-vlm:
@@ -508,10 +489,8 @@ jobs:
       - model-proof
     if: >-
       ${{
-        always() &&
-        needs.legal.result == 'success' &&
-        needs.inventory.result == 'success' &&
-        needs.model-proof.result == 'success'
+        !cancelled() &&
+        needs.inventory.outputs.has_models == 'true'
       }}
     runs-on: ${{ fromJSON(vars.TRTMC_MODEL_RUNNER_LABELS || vars.TRTMC_RUNNER_LABELS || '["self-hosted"]') }}
     timeout-minutes: 420
@@ -531,10 +510,10 @@ jobs:
       HUGGING_FACE_HUB_TOKEN: ${{ secrets.HF_TOKEN }}
 
     steps:
-      - name: Check out certified nightly snapshot
+      - name: Check out exact nightly snapshot
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.legal.outputs.tested_sha }}
+          ref: ${{ needs.legal.outputs.tested_sha || github.sha }}
           path: nightly-vlm-${{ github.run_id }}-${{ github.run_attempt }}
           fetch-depth: 1
           persist-credentials: false
@@ -544,7 +523,7 @@ jobs:
       - name: Download isolated nightly model proof artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: model-proof-*-${{ needs.legal.outputs.tested_sha }}-*
+          pattern: model-proof-*-${{ needs.legal.outputs.tested_sha || github.sha }}-*
           path: ${{ env.TRTMC_CI_WORKSPACE }}/model-proof-parts
           merge-multiple: false
 
@@ -646,7 +625,7 @@ jobs:
             python - \
               "$TRTMC_CI_WORKSPACE/e2e_artifacts/artifacts" \
               "$TRTMC_CI_WORKSPACE/e2e_artifacts/diffusion_vlm_assessment.json" \
-              "${{ needs.legal.outputs.tested_sha }}" \
+              "${{ needs.legal.outputs.tested_sha || github.sha }}" \
               "${{ github.run_id }}" \
               "${{ github.run_attempt }}" <<'PY'
           import json
@@ -761,7 +740,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: trtmc-nightly-vlm-${{ github.run_id }}-${{ needs.legal.outputs.tested_sha }}-${{ github.run_attempt }}
+          name: trtmc-nightly-vlm-${{ github.run_id }}-${{ needs.legal.outputs.tested_sha || github.sha }}-${{ github.run_attempt }}
           if-no-files-found: error
           retention-days: 14
           path: ${{ env.TRTMC_CI_WORKSPACE }}/e2e_artifacts/diffusion_vlm_assessment.json
@@ -929,7 +908,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          pattern: model-proof-*-${{ needs.legal.outputs.tested_sha }}-*
+          pattern: model-proof-*-${{ needs.legal.outputs.tested_sha || github.sha }}-*
           path: ${{ runner.temp }}/nightly-model-parts-${{ github.run_id }}-${{ github.run_attempt }}
           merge-multiple: false
 
@@ -939,7 +918,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          pattern: trtmc-nightly-vlm-${{ github.run_id }}-${{ needs.legal.outputs.tested_sha }}-*
+          pattern: trtmc-nightly-vlm-${{ github.run_id }}-${{ needs.legal.outputs.tested_sha || github.sha }}-*
           path: ${{ runner.temp }}/nightly-vlm-parts-${{ github.run_id }}-${{ github.run_attempt }}
           merge-multiple: false
 
@@ -950,7 +929,7 @@ jobs:
         run: |
           python3 tools/select_latest_attempt_artifact.py \
             --parts-dir "${{ runner.temp }}/nightly-vlm-parts-${{ github.run_id }}-${{ github.run_attempt }}" \
-            --artifact-prefix "trtmc-nightly-vlm-${{ github.run_id }}-${{ needs.legal.outputs.tested_sha }}-" \
+            --artifact-prefix "trtmc-nightly-vlm-${{ github.run_id }}-${{ needs.legal.outputs.tested_sha || github.sha }}-" \
             --max-attempt "${{ github.run_attempt }}" \
             --required-glob diffusion_vlm_assessment.json \
             --github-output "$GITHUB_OUTPUT"
@@ -1230,7 +1209,7 @@ jobs:
     steps:
       - name: Verify every nightly gate
         env:
-          TESTED_SHA: ${{ needs.legal.outputs.tested_sha }}
+          TESTED_SHA: ${{ needs.legal.outputs.tested_sha || github.sha }}
           LEGAL_RESULT: ${{ needs.legal.result }}
           INVENTORY_RESULT: ${{ needs.inventory.result }}
           SOURCE_QUALITY_RESULT: ${{ needs.source-quality.result }}

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -892,12 +892,25 @@ def test_reusable_legal_outputs_the_immutable_checked_out_sha() -> None:
     assert 'echo "tested_sha=$tested_sha" >> "$GITHUB_OUTPUT"' in text
 
 
-def test_nightly_reuses_the_legal_certified_sha_for_all_downstream_work() -> None:
+def test_nightly_reuses_the_resolved_sha_with_a_trigger_sha_fallback() -> None:
     text = (REPO_ROOT / ".github" / "workflows" / "nightly.yml").read_text()
-    assert text.count("ref: ${{ needs.legal.outputs.tested_sha }}") >= 5
-    assert "revision: ${{ needs.legal.outputs.tested_sha }}" in text
-    assert "pattern: model-proof-*-${{ needs.legal.outputs.tested_sha }}-*" in text
-    assert "TESTED_SHA: ${{ needs.legal.outputs.tested_sha }}" in text
+    validation, promotion = text.split("\n  release:", maxsplit=1)
+    release = promotion.split("\n  nightly-issue:", maxsplit=1)[0]
+    revision = "${{ needs.legal.outputs.tested_sha || github.sha }}"
+
+    sha_consumers = [
+        line
+        for line in validation.splitlines()
+        if "needs.legal.outputs.tested_sha" in line
+    ]
+    assert sha_consumers
+    assert all("|| github.sha" in line for line in sha_consumers)
+    assert f"revision: {revision}" in validation
+    assert f"pattern: model-proof-*-{revision}-*" in validation
+    assert f"TESTED_SHA: {revision}" in validation
+    assert "needs.required.result == 'success'" in release
+    assert "ref: ${{ needs.legal.outputs.tested_sha }}" in release
+    assert "|| github.sha" not in release
 
 
 def test_workflow_dispatch_lint_uses_resolved_ci_base_ref() -> None:
@@ -920,7 +933,7 @@ def test_manual_branch_nightly_lints_the_complete_main_diff() -> None:
     assert 'base_sha="$(git rev-parse "${tested_sha}^"' in comparison
 
 
-def test_nightly_exposes_the_staged_all_model_dependency_graph() -> None:
+def test_nightly_runs_every_runnable_stage_after_an_upstream_failure() -> None:
     text = (REPO_ROOT / ".github" / "workflows" / "nightly.yml").read_text()
     inventory = text.split("\n  inventory:", maxsplit=1)[1].split(
         "\n  source-quality:", maxsplit=1
@@ -931,15 +944,26 @@ def test_nightly_exposes_the_staged_all_model_dependency_graph() -> None:
     unit_tests = text.split("\n  unit-tests:", maxsplit=1)[1].split("\n  cache-warm:", maxsplit=1)[
         0
     ]
-    model_proof = text.split("\n  model-proof:", maxsplit=1)[1].split("\n  report:", maxsplit=1)[0]
+    cache_warm = text.split("\n  cache-warm:", maxsplit=1)[1].split("\n  package:", maxsplit=1)[0]
+    package = text.split("\n  package:", maxsplit=1)[1].split("\n  model-proof:", maxsplit=1)[0]
+    model_proof = text.split("\n  model-proof:", maxsplit=1)[1].split(
+        "\n  diffusion-vlm:", maxsplit=1
+    )[0]
+    diffusion_vlm = text.split("\n  diffusion-vlm:", maxsplit=1)[1].split(
+        "\n  report:", maxsplit=1
+    )[0]
     report = text.split("\n  report:", maxsplit=1)[1].split("\n  required:", maxsplit=1)[0]
     required = text.split("\n  required:", maxsplit=1)[1].split("\n  release:", maxsplit=1)[0]
 
     assert "needs: legal" in inventory
+    assert "if: ${{ !cancelled() }}" in inventory
+    assert "ref: ${{ needs.legal.outputs.tested_sha || github.sha }}" in inventory
     assert 'python3 tools/model_ci.py validate --revision "$TESTED_SHA"' in inventory
     assert "python3 tools/model_ci.py all" in inventory
     assert '--revision "$TESTED_SHA"' in inventory
     assert '--github-output "$GITHUB_OUTPUT"' in inventory
+    assert "!cancelled() && steps.checkout.outcome == 'success'" in inventory
+    assert "!cancelled() && steps.inventory.outcome == 'success'" in inventory
     for output in (
         "has_models",
         "matrix",
@@ -965,6 +989,11 @@ def test_nightly_exposes_the_staged_all_model_dependency_graph() -> None:
     assert "python3 -m tools.ci stage premerge-unit" in unit_tests
     assert "TRTMC_PREMERGE_UNIT_SCOPE: all" in unit_tests
     assert 'TRTMC_CI_HARDENED: "true"' in unit_tests
+    for independent_stage in (source_quality, unit_tests, cache_warm, package):
+        assert "!cancelled()" in independent_stage
+        assert "needs.legal.result == 'success'" not in independent_stage
+        assert "needs.inventory.result == 'success'" not in independent_stage
+        assert "needs.legal.outputs.tested_sha || github.sha" in independent_stage
 
     for dependency in (
         "legal",
@@ -975,20 +1004,34 @@ def test_nightly_exposes_the_staged_all_model_dependency_graph() -> None:
         "package",
     ):
         assert f"- {dependency}" in model_proof
-    assert "always()" in model_proof
-    assert "needs.legal.result == 'success'" in model_proof
-    assert "needs.inventory.result == 'success'" in model_proof
-    assert "needs.unit-tests.result == 'success'" in model_proof
-    assert "needs.source-quality.result == 'success'" in model_proof
-    assert "needs.cache-warm.result == 'success'" in model_proof
-    assert "needs.package.result == 'success'" in model_proof
+    assert "!cancelled()" in model_proof
+    assert "needs.legal.result == 'success'" not in model_proof
+    assert "needs.inventory.outputs.has_models == 'true'" in model_proof
+    for upstream in (
+        "inventory",
+        "source-quality",
+        "unit-tests",
+        "cache-warm",
+        "package",
+    ):
+        assert f"needs.{upstream}.result == 'success'" not in model_proof
     assert "fail-fast: false" in model_proof
     assert "max-parallel:" not in model_proof
     assert "matrix: ${{ fromJSON(needs.inventory.outputs.matrix) }}" in model_proof
     assert "uses: ./.github/workflows/model-proof.yml" in model_proof
     assert "model: ${{ matrix.model }}" in model_proof
-    assert "revision: ${{ needs.legal.outputs.tested_sha }}" in model_proof
+    assert "revision: ${{ needs.legal.outputs.tested_sha || github.sha }}" in model_proof
     assert "suite: nightly" in model_proof
+
+    assert "- legal" in diffusion_vlm
+    assert "- inventory" in diffusion_vlm
+    assert "- model-proof" in diffusion_vlm
+    assert "!cancelled()" in diffusion_vlm
+    assert "needs.legal.result == 'success'" not in diffusion_vlm
+    assert "needs.inventory.outputs.has_models == 'true'" in diffusion_vlm
+    assert "needs.inventory.result == 'success'" not in diffusion_vlm
+    assert "needs.model-proof.result == 'success'" not in diffusion_vlm
+    assert "needs.legal.outputs.tested_sha || github.sha" in diffusion_vlm
 
     assert "if: ${{ always() }}" in report
     for dependency in (
@@ -1034,6 +1077,13 @@ def test_nightly_source_quality_does_not_use_self_hosted_shared_storage() -> Non
     ):
         assert f'{variable}: ""' in source_quality
     assert "/workspace/" not in source_quality
+
+
+def test_nightly_has_no_fail_fast_validation_matrix_or_cache_warm() -> None:
+    text = (REPO_ROOT / ".github" / "workflows" / "nightly.yml").read_text()
+
+    assert "fail-fast: true" not in text
+    assert "--fail-fast" not in text
 
 
 def test_nightly_self_hosted_stages_use_the_configured_proof_runner_pool() -> None:
@@ -1091,7 +1141,7 @@ def test_nightly_report_requires_exact_all_model_results_and_evidence() -> None:
         "EXPECTED_CASES_BY_MODEL: ${{ needs.inventory.outputs.expected_cases_by_model }}" in report
     )
     assert "REVISION: ${{ needs.legal.outputs.tested_sha || github.sha }}" in report
-    assert "pattern: model-proof-*-${{ needs.legal.outputs.tested_sha }}-*" in report
+    assert "pattern: model-proof-*-${{ needs.legal.outputs.tested_sha || github.sha }}-*" in report
     assert "merge-multiple: false" in report
     assert "scripts/generate_model_proof_report.py" in report
     assert '--expected-cases-by-model "$EXPECTED_CASES_BY_MODEL"' in report
@@ -1129,7 +1179,7 @@ def test_nightly_preserves_diffusion_vlm_gate_and_injects_it_into_the_html() -> 
     vlm = text.split("\n  diffusion-vlm:", maxsplit=1)[1].split("\n  report:", maxsplit=1)[0]
     report = text.split("\n  report:", maxsplit=1)[1].split("\n  required:", maxsplit=1)[0]
     assert "needs:" in vlm and "- model-proof" in vlm
-    assert "always()" in vlm
+    assert "!cancelled()" in vlm
     assert "tools/count_diffusion_frame_pairs.py" in vlm
     assert "--require-complete" in vlm
     assert "No complete TRT/reference diffusion frame pairs were produced" in vlm
@@ -1140,17 +1190,17 @@ def test_nightly_preserves_diffusion_vlm_gate_and_injects_it_into_the_html() -> 
     assert 'assessment["source_revision"] = source_revision' in vlm
     assert 'assessment["workflow_run_id"] = workflow_run_id' in vlm
     assert 'assessment["workflow_run_attempt"] = workflow_run_attempt' in vlm
-    assert "needs.model-proof.result == 'success'" in vlm
+    assert "needs.model-proof.result == 'success'" not in vlm
     assert "does not exactly cover current frame pairs" in vlm
     assert "Upload diffusion semantic assessment" in vlm
     assert (
         "trtmc-nightly-vlm-${{ github.run_id }}-"
-        "${{ needs.legal.outputs.tested_sha }}-${{ github.run_attempt }}" in vlm
+        "${{ needs.legal.outputs.tested_sha || github.sha }}-${{ github.run_attempt }}" in vlm
     )
     assert "Download diffusion semantic assessment" in report
     assert (
         "pattern: trtmc-nightly-vlm-${{ github.run_id }}-"
-        "${{ needs.legal.outputs.tested_sha }}-*" in report
+        "${{ needs.legal.outputs.tested_sha || github.sha }}-*" in report
     )
     assert "merge-multiple: false" in report
     assert "Select latest diffusion semantic assessment attempt" in report

--- a/tests/tools/test_nightly_issue_tracker.py
+++ b/tests/tools/test_nightly_issue_tracker.py
@@ -666,3 +666,23 @@ def test_cli_manual_branch_guard_exits_before_token_or_network() -> None:
 
     assert result.returncode == 0, result.stderr
     assert '"action": "disabled-non-production-context"' in result.stdout
+
+
+def test_cli_official_scheduled_run_fails_loudly_without_token() -> None:
+    env = os.environ.copy()
+    env.update(BASE_ENV)
+    env.pop("GITHUB_TOKEN", None)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--apply"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert (
+        "::error::GITHUB_TOKEN must be a non-empty single-line token"
+        in result.stderr
+    )

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -135,8 +135,13 @@ The container half, `ModelProofInnerPipeline`, then runs linearly:
 
 Failure at any step produces a fallback status and HTML artifact before the job
 fails. The L0 premerge matrix uses fail-fast so the first failing model cancels
-its peers. The nightly matrix and cache warm continue through every model and
-asset so a single run captures the complete failure set.
+its peers. The nightly matrix and cache warm attempt every independent model
+and asset. Nightly job dependencies also wait for upstream work to finish
+without requiring it to succeed, so an earlier validation failure, including a
+legal-check failure, does not suppress later runnable stages. Hard-dependent
+phases may remain not-run when their required input could not be produced.
+The combined report and scheduled failure-issue reconciliation are still
+attempted, while publication remains gated on complete success.
 
 ### 5. Compose one report
 


### PR DESCRIPTION
## Background

Scheduled Nightly run [29913059891](https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/29913059891) failed in `Coverage and wheel package`. Although both Nightly matrices already used `fail-fast: false`, job-level success predicates skipped all 77 model proofs and the diffusion assessment. The final report and issue tracker ran, but the issue could only report the coverage failure and the downstream skips.

## Exit Criteria

- An upstream Legal, inventory-validation, source-quality, unit, cache, or package failure does not suppress independent Nightly validation.
- Every model matrix sibling runs after ordinary failures, and diffusion assessment is attempted after model failures.
- The combined report, final gate, and official scheduled failure-issue reconciliation still run and report the complete available evidence.
- Failed validation remains red and cannot publish Nightly wheels.

## Implementation

- Replace upstream-success predicates with `!cancelled()` so ordinary failures do not cascade while explicit cancellation still stops expensive work.
- Keep every existing dependency edge so cache/unit/package work finishes and releases runner capacity before the full model wave.
- Reuse the legal workflow's immutable SHA when available and fall back to the immutable trigger SHA after a legal failure. Promotion still requires the legal-certified SHA and a successful final gate.
- Let inventory selection continue after manifest validation fails so a valid matrix can still drive diagnostics. A checkout or selection failure that cannot produce a matrix remains the necessary hard-data exception.
- Add workflow contracts that forbid Nightly fail-fast, enforce the SHA fallback boundary, preserve success-only release, and verify the scheduled issue path fails loudly if its token is unavailable.

## Validation

- `python3 -m pytest tests/tools/test_github_actions_ci.py tests/tools/test_nightly_issue_tracker.py -q`: 114 passed.
- `ruff check tests/tools/test_github_actions_ci.py tests/tools/test_nightly_issue_tracker.py`: passed.
- `git diff --check`: passed.
- YAML safe-load check: passed and discovered all 12 Nightly jobs.
- Broader `tests/tools` attempt: 1,678 passed; 18 unrelated `test_cpu_profile.py` tests require the CUDA Python module missing from this host environment.

## Notes For Future Readers

- Review `.github/workflows/nightly.yml` first, then the contract updates in `tests/tools/test_github_actions_ci.py`.
- Publication is intentionally not exhaustive: `release` remains gated on complete Nightly success.
- Dynamic model dispatch cannot run if inventory checkout/selection produces no matrix. Explicit cancellation, GitHub platform outages, and issue API outages also remain external boundaries.
- Manual `workflow_dispatch` runs never mutate the production Nightly failure issue.
