### PR TITLE
feat(openpi): add native TensorRT policy runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ set(TRTMC_MODEL_PROOF_MODEL "" CACHE STRING
   "Require the source tree to contain exactly this runtime model (CI isolation proof mode).")
 set(TRTMC_TRT_BACKEND_ABI "" CACHE STRING
   "TensorRT ABI suffix for the standard backend DSO, e.g. 10_15. Empty means auto-detect from headers.")
+file(GLOB _trtmc_model_option_files
+  "${PROJECT_SOURCE_DIR}/src/runtime/models/*/model_options.cmake")
+foreach(_trtmc_model_option_file IN LISTS _trtmc_model_option_files)
+  include("${_trtmc_model_option_file}")
+endforeach()
 
 # CUDA is required by the core runtime. TensorRT is optional at core build time:
 # concrete TRT runtimes live in backend DSOs.
@@ -459,6 +464,7 @@ foreach(_trtmc_model IN LISTS TRTMC_RUNTIME_MODEL_IDS)
   install(TARGETS trtmc_model_${_trtmc_model}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/trtmc/models/${_trtmc_model}
   )
+  include("${PROJECT_SOURCE_DIR}/src/runtime/models/${_trtmc_model}/model.cmake" OPTIONAL)
 endforeach()
 
 # Build the TVM-FFI TensorRT plugin as a standalone shared library.
@@ -624,6 +630,7 @@ if(TRTMC_BUILD_BENCHMARKS)
 
   add_executable(trtmc_benchmark_worker examples/trtmc_benchmark_worker.cpp)
   target_link_libraries(trtmc_benchmark_worker PRIVATE trtmc_core)
+  target_include_directories(trtmc_benchmark_worker PRIVATE ${PROJECT_SOURCE_DIR}/src)
   target_include_directories(trtmc_benchmark_worker SYSTEM PRIVATE
     ${_trtmc_nlohmann_json_include}
   )

--- a/conanfile.py
+++ b/conanfile.py
@@ -217,6 +217,8 @@ class TensorRTModelConnectConan(ConanFile):
             keep_path=False,
         )
         for destination in (package_bin, wheel_data_scripts):
+            copy(self, "trtmc-*", src=self.build_folder, dst=str(destination), keep_path=False)
+        for destination in (package_bin, wheel_data_scripts):
             copy(
                 self,
                 "libtrtmc_core.so*",
@@ -305,7 +307,9 @@ class TensorRTModelConnectConan(ConanFile):
             raise ConanException("TRTMC TensorRT backend DSO was not staged into the wheel package")
         if not model_plugins:
             raise ConanException("TRTMC model plugin DSOs were not staged into the wheel package")
-
-        for executable in (native, installed_script, benchmark_worker, benchmark_script):
+        executables = [native, installed_script, benchmark_worker, benchmark_script]
+        executables.extend(sorted(package_bin.glob("trtmc-*")))
+        executables.extend(sorted(wheel_data_scripts.glob("trtmc-*")))
+        for executable in executables:
             mode = executable.stat().st_mode
             executable.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)

--- a/examples/trtmc_benchmark_worker.cpp
+++ b/examples/trtmc_benchmark_worker.cpp
@@ -6,6 +6,11 @@
 #include "trtmc/pipeline.h"
 #include "trtmc/trtmc_io.hpp"
 
+#if __has_include("runtime/models/openpi/benchmark_worker_adapter.h")
+#include "runtime/models/openpi/benchmark_worker_adapter.h"
+using trtmc::openpi::benchmark::run_predict_actions;
+#endif
+
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -788,6 +793,9 @@ Json execute(const Json& request) {
         {"encode", run_encode},
         {"embed", run_embed},
         {"solve", run_solve},
+#if __has_include("runtime/models/openpi/benchmark_worker_adapter.h")
+        {"predict_actions", run_predict_actions},
+#endif
         {"transcribe", run_transcribe},
     };
     const auto runner = runners.find(operation);

--- a/python/tensorrt_model_connect/benchmark/operations.py
+++ b/python/tensorrt_model_connect/benchmark/operations.py
@@ -162,6 +162,14 @@ _OPERATIONS = (
         ),
     ),
     OperationSpec(
+        name="predict_actions",
+        rate_metrics=(
+            RateMetric("action_chunks", "action_chunks_per_s"),
+            RateMetric("action_steps", "action_steps_per_s"),
+        ),
+        stage_timings=("preprocess_ms", "prefill_ms", "denoise_ms", "postprocess_ms"),
+    ),
+    OperationSpec(
         name="transcribe",
         rate_metrics=(
             RateMetric(

--- a/python/tensorrt_model_connect/benchmark/task_adapters.py
+++ b/python/tensorrt_model_connect/benchmark/task_adapters.py
@@ -581,6 +581,32 @@ def _solve_request(testcase: Mapping[str, Any], _model_root: Path) -> CaseResolu
     return _resolution(request, sources, testcase=testcase)
 
 
+def _robot_action_request(testcase: Mapping[str, Any], _model_root: Path) -> CaseResolution:
+    determinism = testcase.get("determinism", {})
+    if not isinstance(determinism, Mapping):
+        raise BenchmarkError("robot_action_generation determinism must be an object")
+    prompt = testcase.get("prompt", testcase.get("test_prompt", "pick up the object"))
+    if not isinstance(prompt, str) or not prompt:
+        raise BenchmarkError("robot_action_generation prompt must be non-empty")
+    return _resolution(
+        {
+            "batch_size": 1,
+            "prompt": prompt,
+            "seed": int(determinism.get("seed", 0)),
+        },
+        {
+            "batch_size": _TASK_DEFAULT,
+            "prompt": (
+                _MODEL_TESTCASE
+                if "prompt" in testcase or "test_prompt" in testcase
+                else _TASK_DEFAULT
+            ),
+            "seed": _MODEL_TESTCASE if "seed" in determinism else _TASK_DEFAULT,
+        },
+        testcase=testcase,
+    )
+
+
 def _transcribe_request(testcase: Mapping[str, Any], model_root: Path) -> CaseResolution:
     streaming = testcase.get("streaming", {})
     if not isinstance(streaming, Mapping):
@@ -696,6 +722,12 @@ _TASK_ADAPTERS = (
         "solve",
         MeasurementSpec(warmup=50, iterations=500),
         _solve_request,
+    ),
+    TaskAdapter(
+        "robot_action_generation",
+        "predict_actions",
+        MeasurementSpec(warmup=5, iterations=50),
+        _robot_action_request,
     ),
     TaskAdapter(
         "speech_to_text",

--- a/python/tensorrt_model_connect/families/openpi/MODEL.toml
+++ b/python/tensorrt_model_connect/families/openpi/MODEL.toml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id = "openpi"
+plugin = "openpi"
+module = "plugin"
+config_adapter = "model_config.py|config_from_dir"
+hf_allow_patterns = [
+  "openpi_config.json",
+  "openpi_conversion_manifest.json",
+  "tokenizer.model",
+  "preprocessor_config.json",
+  "assets/paligemma_tokenizer.trtmcbpe",
+  "assets/droid/norm_stats.json",
+  "trtmc_openpi/**",
+]
+hf_required_files = [
+  "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|config.json",
+  "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|model.safetensors",
+  "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|openpi_config.json",
+  "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|openpi_conversion_manifest.json",
+  "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|tokenizer.model",
+  "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|preprocessor_config.json",
+  "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|assets/paligemma_tokenizer.trtmcbpe",
+  "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|assets/droid/norm_stats.json",
+  "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|trtmc_openpi/reference/reference-set.json",
+  "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|trtmc_openpi/request/request.json",
+  "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|trtmc_openpi/performance/pytorch-eager.json",
+]
+aliases = [
+  "openpi",
+  "openpi_pi05_flow",
+  "pi05_droid",
+]
+prefixes = [
+  "openpi",
+  "pi05",
+]

--- a/python/tensorrt_model_connect/families/openpi/__init__.py
+++ b/python/tensorrt_model_connect/families/openpi/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenPI π0.5 vision-language-action family."""
+
+from .plugin import plugin
+
+__all__ = ["plugin"]

--- a/python/tensorrt_model_connect/families/openpi/action_expert_builder.py
+++ b/python/tensorrt_model_connect/families/openpi/action_expert_builder.py
@@ -1,0 +1,703 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct TensorRT builder for the OpenPI π0.5 action expert.
+
+The engine consumes the compact prefix K/V cache produced by the OpenPI
+prefill engine and executes one Euler flow step.  Keeping the Euler update in
+the plan lets the C++ runtime alternate two device buffers without copying the
+action trajectory through host memory between denoising steps.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from collections.abc import Mapping
+
+import numpy as np
+
+from .model_config import OpenPIProfile
+
+
+_DROID_TIME_CONDITION_WEIGHT_SHA256 = {
+    "projections.time_mlp_in.weight": (
+        "85ecc978190f79949312a4a752f478f4b62c78dcd21b3f1dba29524ef832c193"
+    ),
+    "projections.time_mlp_in.bias": (
+        "11d898afc211d8bb47dd2839a15d4bdebb0ee61d73f618d05ed65a8fc9b10701"
+    ),
+    "projections.time_mlp_out.weight": (
+        "9296cdb4f07c09c1c76176b45082666af029bad61753b998c1f95dfa30005512"
+    ),
+    "projections.time_mlp_out.bias": (
+        "f0827b9c8a0913d42ff07eb7dc90af1e0b326232b3943a6f0b25fbe67295c935"
+    ),
+}
+
+_DROID_ADAPTIVE_MODULATION_WEIGHT_SHA256 = {
+    "action.layer.6.pre_ffw_norm.dense.weight": (
+        "232cce0d38e54b88025a944b28a9f79bdf19f567788cc26eda48b51f9e59d9e7"
+    ),
+    "action.layer.6.pre_ffw_norm.dense.bias": (
+        "02d543a1031d35b756d68d9a37fd14c0dbc547ec69c61ec659ce572cbc60521d"
+    ),
+    "action.layer.11.pre_attention_norm.dense.weight": (
+        "eb241f79e1a1cdd4e23efcafd294c5546ac8a40d0cb1abfa41d201cc97809708"
+    ),
+    "action.layer.11.pre_attention_norm.dense.bias": (
+        "f727a3fdbbfb2be46d4413b04d72dee62b7a8b34efb14a878f5a57fadb5e1d83"
+    ),
+    "action.layer.12.pre_ffw_norm.dense.weight": (
+        "e54d6f1684b717677e546f1f25a8fa0683cffd2b6b774db01d46c3362dba5005"
+    ),
+    "action.layer.12.pre_ffw_norm.dense.bias": (
+        "458bbf1cf284ae151861f84421d803845480093934dc0c213504ac1a95a8011a"
+    ),
+    "action.layer.14.pre_ffw_norm.dense.weight": (
+        "55bb753eaa9d89f6337eb2286cdb579b339d4b007514534bedec6d22503f6cfd"
+    ),
+    "action.layer.14.pre_ffw_norm.dense.bias": (
+        "746b2d2509799c4b895aab029305c5a17f22cdb8b21c13e8ff9166dfccefaab3"
+    ),
+}
+
+
+def _weight(
+    weights: Mapping[str, object],
+    name: str,
+    shape: tuple[int, ...],
+) -> np.ndarray:
+    """Return one mapped weight after enforcing its production shape."""
+    if name not in weights:
+        raise ValueError(f"OpenPI action engine is missing weight {name!r}")
+    value = np.asarray(weights[name])
+    if tuple(value.shape) != shape:
+        raise ValueError(
+            f"OpenPI action weight {name!r} has shape {tuple(value.shape)}, expected {shape}"
+        )
+    if value.dtype.kind != "f" and value.dtype.name != "bfloat16":
+        raise ValueError(f"OpenPI action weight {name!r} must be floating point")
+    return np.ascontiguousarray(value)
+
+
+def required_action_weight_shapes(profile: OpenPIProfile) -> dict[str, tuple[int, ...]]:
+    """Return the complete action-plan weight inventory."""
+    cfg = profile.action_expert
+    shapes: dict[str, tuple[int, ...]] = {
+        "projections.action_in.weight": (profile.action_dim, cfg.width),
+        "projections.action_in.bias": (cfg.width,),
+        "projections.time_mlp_in.weight": (cfg.width, cfg.width),
+        "projections.time_mlp_in.bias": (cfg.width,),
+        "projections.time_mlp_out.weight": (cfg.width, cfg.width),
+        "projections.time_mlp_out.bias": (cfg.width,),
+        "projections.action_out.weight": (cfg.width, profile.action_dim),
+        "projections.action_out.bias": (profile.action_dim,),
+        "action.final_norm.dense.weight": (cfg.width, 3 * cfg.width),
+        "action.final_norm.dense.bias": (3 * cfg.width,),
+    }
+    for layer in range(cfg.depth):
+        prefix = f"action.layer.{layer}"
+        shapes.update(
+            {
+                f"{prefix}.pre_attention_norm.dense.weight": (
+                    cfg.width,
+                    3 * cfg.width,
+                ),
+                f"{prefix}.pre_attention_norm.dense.bias": (3 * cfg.width,),
+                f"{prefix}.attention.q.weight": (
+                    cfg.width,
+                    cfg.attention_width,
+                ),
+                f"{prefix}.attention.k.weight": (cfg.width, cfg.kv_width),
+                f"{prefix}.attention.v.weight": (cfg.width, cfg.kv_width),
+                f"{prefix}.attention.o.weight": (
+                    cfg.attention_width,
+                    cfg.width,
+                ),
+                f"{prefix}.pre_ffw_norm.dense.weight": (
+                    cfg.width,
+                    3 * cfg.width,
+                ),
+                f"{prefix}.pre_ffw_norm.dense.bias": (3 * cfg.width,),
+                f"{prefix}.mlp.gate.weight": (cfg.width, cfg.mlp_dim),
+                f"{prefix}.mlp.up.weight": (cfg.width, cfg.mlp_dim),
+                f"{prefix}.mlp.down.weight": (cfg.mlp_dim, cfg.width),
+            }
+        )
+    return shapes
+
+
+def _validate_action_weights(
+    weights: Mapping[str, object], profile: OpenPIProfile
+) -> dict[str, np.ndarray]:
+    return {
+        name: _weight(weights, name, shape)
+        for name, shape in required_action_weight_shapes(profile).items()
+    }
+
+
+def _uses_exact_droid_final_norm(profile: OpenPIProfile, *, precision: str) -> bool:
+    """Return whether the audited fusion.144 contract applies exactly."""
+    return (
+        profile.name == "pi05_droid"
+        and precision == "bf16"
+        and profile.action_horizon == 15
+        and profile.action_expert.width == 1024
+        and np.float32(profile.rms_norm_epsilon) == np.float32(1.0e-6)
+    )
+
+
+def _uses_exact_droid_pre_attention_norm(
+    profile: OpenPIProfile,
+    *,
+    precision: str,
+    layer: int,
+) -> bool:
+    """Return whether the audited fixed-shape pre-attention norm applies."""
+    cfg = profile.action_expert
+    return (
+        0 <= layer < cfg.depth
+        and profile.name == "pi05_droid"
+        and precision == "bf16"
+        and profile.action_horizon == 15
+        and cfg.depth == 18
+        and cfg.width == 1024
+        and np.float32(profile.rms_norm_epsilon) == np.float32(1.0e-6)
+    )
+
+
+def _uses_exact_droid_action_contract(
+    profile: OpenPIProfile,
+    *,
+    precision: str,
+) -> bool:
+    """Return whether the fully qualified fixed-shape DROID contract applies."""
+    cfg = profile.action_expert
+    prefix = profile.prefix
+    return (
+        profile.name == "pi05_droid"
+        and precision == "bf16"
+        and profile.prefix_length == 968
+        and profile.action_horizon == 15
+        and profile.action_dim == 32
+        and profile.denoise_steps == 10
+        and cfg.depth == 18
+        and cfg.width == 1024
+        and cfg.mlp_dim == 4096
+        and cfg.num_heads == 8
+        and cfg.num_kv_heads == 1
+        and cfg.head_dim == 256
+        and prefix.depth == 18
+        and prefix.width == 2048
+        and prefix.num_heads == 8
+        and prefix.num_kv_heads == 1
+        and prefix.head_dim == 256
+        and np.float32(profile.rms_norm_epsilon) == np.float32(1.0e-6)
+    )
+
+
+def _uses_exact_droid_action_mlp_closure(
+    profile: OpenPIProfile,
+    *,
+    precision: str,
+    layer: int,
+) -> bool:
+    """Return whether the qualified exact DROID MLP closure applies."""
+    return 0 <= layer < profile.action_expert.depth and _uses_exact_droid_action_contract(
+        profile, precision=precision
+    )
+
+
+def _uses_exact_droid_action_output_projection(
+    profile: OpenPIProfile,
+    *,
+    precision: str,
+) -> bool:
+    """Return whether the audited padded action-output GEMM applies."""
+    return _uses_exact_droid_action_contract(profile, precision=precision)
+
+
+def _uses_exact_droid_time_condition_corrections(
+    profile: OpenPIProfile,
+    *,
+    precision: str,
+) -> bool:
+    """Return whether the pinned DROID BF16 condition corrections apply."""
+    return _uses_exact_droid_action_contract(profile, precision=precision)
+
+
+def _uses_exact_droid_adaptive_modulation_corrections(
+    profile: OpenPIProfile,
+    *,
+    precision: str,
+) -> bool:
+    """Return whether the pinned DROID modulation corrections apply."""
+    return _uses_exact_droid_time_condition_corrections(profile, precision=precision)
+
+
+def _require_exact_droid_time_condition_weights(
+    weights: Mapping[str, object],
+) -> None:
+    """Fail unless the correction seam sees the audited BF16 checkpoint."""
+    mismatches = []
+    for name, expected in _DROID_TIME_CONDITION_WEIGHT_SHA256.items():
+        value = weights.get(name)
+        if value is None:
+            mismatches.append(f"{name}=missing")
+            continue
+        payload = np.ascontiguousarray(value, dtype=np.float32).tobytes()
+        actual = hashlib.sha256(payload).hexdigest()
+        if actual != expected:
+            mismatches.append(f"{name}={actual}")
+    if mismatches:
+        raise ValueError(
+            "OpenPI DROID time-condition corrections require the audited "
+            "BF16-rounded checkpoint weights: " + ", ".join(mismatches)
+        )
+
+
+def _require_exact_droid_adaptive_modulation_weights(
+    weights: Mapping[str, object],
+) -> None:
+    """Fail unless sparse modulation corrections see their audited weights."""
+    mismatches = []
+    for name, expected in _DROID_ADAPTIVE_MODULATION_WEIGHT_SHA256.items():
+        value = weights.get(name)
+        if value is None:
+            mismatches.append(f"{name}=missing")
+            continue
+        payload = np.ascontiguousarray(value, dtype=np.float32).tobytes()
+        actual = hashlib.sha256(payload).hexdigest()
+        if actual != expected:
+            mismatches.append(f"{name}={actual}")
+    if mismatches:
+        raise ValueError(
+            "OpenPI DROID adaptive-modulation corrections require the audited "
+            "BF16-rounded checkpoint weights: " + ", ".join(mismatches)
+        )
+
+
+def _uses_action_attention_context(
+    profile: OpenPIProfile,
+    *,
+    precision: str,
+    layer: int,
+) -> bool:
+    """Return whether the qualified exact DROID attention topology applies."""
+    cfg = profile.action_expert
+    return (
+        0 <= layer < cfg.depth
+        and profile.name == "pi05_droid"
+        and precision == "bf16"
+        and profile.prefix_length == 968
+        and profile.action_horizon == 15
+        and cfg.depth > 1
+        and cfg.width == 1024
+        and cfg.num_heads == 8
+        and cfg.num_kv_heads == 1
+        and cfg.head_dim == 256
+    )
+
+
+def _combined_attention_mask(network, prefix_mask, profile: OpenPIProfile, *, graph_ops, trt):
+    """Build bool ``[1,1,H,P+H]`` suffix-to-prefix/full-suffix mask."""
+    horizon = profile.action_horizon
+    prefix_length = profile.prefix_length
+    prefix_shuffle = network.add_shuffle(prefix_mask)
+    prefix_shuffle.reshape_dims = (1, 1, 1, prefix_length)
+    query_rows = graph_ops.constant(
+        network,
+        np.ones((1, 1, horizon, 1), dtype=np.bool_),
+        dtype=trt.bool,
+    )
+    prefix_part = network.add_elementwise(
+        prefix_shuffle.get_output(0),
+        query_rows,
+        trt.ElementWiseOperation.AND,
+    ).get_output(0)
+    suffix_part = graph_ops.constant(
+        network,
+        np.ones((1, 1, horizon, horizon), dtype=np.bool_),
+        dtype=trt.bool,
+    )
+    combined = network.add_concatenation([prefix_part, suffix_part])
+    combined.axis = 3
+    return combined.get_output(0)
+
+
+def build_action_expert_engine(
+    profile: OpenPIProfile,
+    weights: Mapping[str, object],
+    *,
+    precision: str = "bf16",
+    verbose: bool = False,
+) -> bytes:
+    """Build the one-step π0.5 action expert with TensorRT primitives only."""
+    # Keep TensorRT lazy so profile/config inspection works in host-only build
+    # environments.
+    from . import graph_ops
+
+    trt = graph_ops.trt
+    mapped = _validate_action_weights(weights, profile)
+    cfg = profile.action_expert
+    horizon = profile.action_horizon
+    prefix_length = profile.prefix_length
+    _, work_dtype = graph_ops.precision_types(precision)
+    builder, network, builder_config = graph_ops.create_builder_context(
+        verbose=verbose,
+        workspace_bytes=8 << 30,
+    )
+
+    noisy_actions = network.add_input(
+        "noisy_actions", trt.float32, (1, horizon, profile.action_dim)
+    )
+    timestep = network.add_input("timestep", trt.float32, (1,))
+    step_size = network.add_input("step_size", trt.float32, (1,))
+    prefix_mask = network.add_input("prefix_mask", trt.bool, (1, prefix_length))
+    suffix_position_ids = network.add_input("suffix_position_ids", trt.int32, (1, horizon))
+
+    prefix_cache: list[tuple[object, object]] = []
+    for layer in range(cfg.depth):
+        prefix_k = network.add_input(
+            f"prefix_k_{layer}",
+            work_dtype,
+            (1, prefix_length, cfg.num_kv_heads, cfg.head_dim),
+        )
+        prefix_v = network.add_input(
+            f"prefix_v_{layer}",
+            work_dtype,
+            (1, prefix_length, cfg.num_kv_heads, cfg.head_dim),
+        )
+        prefix_k_shuffle = network.add_shuffle(prefix_k)
+        prefix_k_shuffle.first_transpose = (0, 2, 1, 3)
+        prefix_v_shuffle = network.add_shuffle(prefix_v)
+        prefix_v_shuffle.first_transpose = (0, 2, 1, 3)
+        prefix_cache.append((prefix_k_shuffle.get_output(0), prefix_v_shuffle.get_output(0)))
+
+    # NNX projections outside PaliGemma run at the FP32 boundary. The expert
+    # module casts action tokens to its configured embedding dtype on entry.
+    hidden = graph_ops.linear(
+        network,
+        noisy_actions,
+        mapped["projections.action_in.weight"],
+        mapped["projections.action_in.bias"],
+        dtype=trt.float32,
+    )
+    hidden = graph_ops.cast(network, hidden, work_dtype)
+
+    condition = graph_ops.add_sinusoidal_embedding(network, timestep, cfg.width)
+    condition = graph_ops.linear(
+        network,
+        condition,
+        mapped["projections.time_mlp_in.weight"],
+        mapped["projections.time_mlp_in.bias"],
+        dtype=trt.float32,
+    )
+    condition = graph_ops._xla_fp32_silu(network, condition)
+    condition = graph_ops.linear(
+        network,
+        condition,
+        mapped["projections.time_mlp_out.weight"],
+        mapped["projections.time_mlp_out.bias"],
+        dtype=trt.float32,
+    )
+    condition = graph_ops._xla_fp32_silu(network, condition)
+    if _uses_exact_droid_time_condition_corrections(profile, precision=precision):
+        _require_exact_droid_time_condition_weights(mapped)
+        condition = graph_ops.correct_droid_time_condition_bf16_boundaries(
+            network,
+            condition,
+            timestep,
+        )
+    use_droid_modulation_corrections = _uses_exact_droid_adaptive_modulation_corrections(
+        profile,
+        precision=precision,
+    )
+    if use_droid_modulation_corrections:
+        _require_exact_droid_adaptive_modulation_weights(mapped)
+    attention_mask = _combined_attention_mask(
+        network, prefix_mask, profile, graph_ops=graph_ops, trt=trt
+    )
+
+    for layer in range(cfg.depth):
+        layer_prefix = f"action.layer.{layer}"
+        if _uses_exact_droid_pre_attention_norm(
+            profile,
+            precision=precision,
+            layer=layer,
+        ):
+            normed, gate = graph_ops.pre_attention_adaptive_rms_norm(
+                network,
+                hidden,
+                condition,
+                mapped[f"{layer_prefix}.pre_attention_norm.dense.weight"],
+                mapped[f"{layer_prefix}.pre_attention_norm.dense.bias"],
+                epsilon=profile.rms_norm_epsilon,
+                layer_name=f"openpi_pre_attention_rms_norm_layer_{layer}",
+                droid_timestep=timestep if use_droid_modulation_corrections else None,
+                droid_layer=layer if use_droid_modulation_corrections else None,
+            )
+        else:
+            normed, gate = graph_ops.adaptive_rms_norm(
+                network,
+                hidden,
+                condition,
+                mapped[f"{layer_prefix}.pre_attention_norm.dense.weight"],
+                mapped[f"{layer_prefix}.pre_attention_norm.dense.bias"],
+                epsilon=profile.rms_norm_epsilon,
+            )
+        q_weight = np.ascontiguousarray(
+            mapped[f"{layer_prefix}.attention.q.weight"]
+            .reshape(cfg.width, cfg.num_heads, cfg.head_dim)
+            .transpose(1, 0, 2)
+        )
+        kv_weights = [
+            np.ascontiguousarray(
+                mapped[f"{layer_prefix}.attention.{kind}.weight"]
+                .reshape(cfg.width, cfg.num_kv_heads, cfg.head_dim)
+                .transpose(1, 0, 2)
+            )
+            for kind in ("k", "v")
+        ]
+        q_tokens = network.add_einsum(
+            [normed, graph_ops.constant(network, q_weight, dtype=work_dtype)],
+            "btd,ndh->btnh",
+        ).get_output(0)
+        kv_tokens = [
+            network.add_einsum(
+                [normed, graph_ops.constant(network, weight, dtype=work_dtype)],
+                "btd,kdh->btkh",
+            ).get_output(0)
+            for weight in kv_weights
+        ]
+        q_shuffle = network.add_shuffle(q_tokens)
+        q_shuffle.first_transpose = (0, 2, 1, 3)
+        k_shuffle = network.add_shuffle(kv_tokens[0])
+        k_shuffle.first_transpose = (0, 2, 1, 3)
+        v_shuffle = network.add_shuffle(kv_tokens[1])
+        v_shuffle.first_transpose = (0, 2, 1, 3)
+        q = q_shuffle.get_output(0)
+        suffix_k = k_shuffle.get_output(0)
+        suffix_v = v_shuffle.get_output(0)
+        q, suffix_k = graph_ops.apply_action_rope_qk(
+            network,
+            q,
+            suffix_k,
+            suffix_position_ids,
+            max_positions=prefix_length + horizon,
+            head_dim=cfg.head_dim,
+        )
+        cached_k, cached_v = prefix_cache[layer]
+        k_concat = network.add_concatenation([cached_k, suffix_k])
+        k_concat.axis = 2
+        v_concat = network.add_concatenation([cached_v, suffix_v])
+        v_concat.axis = 2
+        if _uses_action_attention_context(
+            profile,
+            precision=precision,
+            layer=layer,
+        ):
+            attended = graph_ops.action_attention_context(
+                network,
+                q,
+                k_concat.get_output(0),
+                v_concat.get_output(0),
+                attention_mask,
+                layer_name=f"openpi_action_attention_context_layer_{layer}",
+            )
+        else:
+            attended = graph_ops.attention_from_rotated(
+                network,
+                q,
+                k_concat.get_output(0),
+                v_concat.get_output(0),
+                attention_mask,
+                num_query_heads=cfg.num_heads,
+                num_kv_heads=cfg.num_kv_heads,
+                head_dim=cfg.head_dim,
+                fp32_logits=True,
+            )
+        attended_heads = network.add_shuffle(attended)
+        attended_heads.reshape_dims = (
+            1,
+            horizon,
+            cfg.num_heads,
+            cfg.head_dim,
+        )
+        o_weight = np.ascontiguousarray(
+            mapped[f"{layer_prefix}.attention.o.weight"].reshape(
+                cfg.num_heads, cfg.head_dim, cfg.width
+            )
+        )
+        attended = network.add_einsum(
+            [
+                attended_heads.get_output(0),
+                graph_ops.constant(network, o_weight, dtype=work_dtype),
+            ],
+            "btnh,nhd->btd",
+        ).get_output(0)
+        attention_residual = hidden
+        attention_update = attended
+        attention_gate = gate
+        hidden = graph_ops.gated_residual(
+            network,
+            attention_residual,
+            attention_update,
+            attention_gate,
+            rounding_output_name=f"rounding_attention_update_{layer}",
+        )
+
+        normed, gate = graph_ops.post_attention_adaptive_rms_norm(
+            network,
+            attention_residual,
+            attention_update,
+            attention_gate,
+            condition,
+            mapped[f"{layer_prefix}.pre_ffw_norm.dense.weight"],
+            mapped[f"{layer_prefix}.pre_ffw_norm.dense.bias"],
+            epsilon=profile.rms_norm_epsilon,
+            droid_timestep=timestep if use_droid_modulation_corrections else None,
+            droid_layer=layer if use_droid_modulation_corrections else None,
+        )
+        if _uses_exact_droid_action_mlp_closure(
+            profile,
+            precision=precision,
+            layer=layer,
+        ):
+            hidden = graph_ops.action_layer0_mlp_closure(
+                network,
+                hidden,
+                normed,
+                gate,
+                mapped[f"{layer_prefix}.mlp.gate.weight"],
+                mapped[f"{layer_prefix}.mlp.up.weight"],
+                mapped[f"{layer_prefix}.mlp.down.weight"],
+                layer_name=f"openpi_action_mlp_closure_layer_{layer}",
+            )
+        else:
+            gate_projection = network.add_einsum(
+                [
+                    normed,
+                    graph_ops.constant(
+                        network,
+                        mapped[f"{layer_prefix}.mlp.gate.weight"],
+                        dtype=work_dtype,
+                    ),
+                ],
+                "btd,df->btf",
+            ).get_output(0)
+            gated = graph_ops.gelu_tanh(
+                network,
+                gate_projection,
+                rounding_output_name=f"rounding_mlp_gelu_cubic_{layer}",
+            )
+            up = network.add_einsum(
+                [
+                    normed,
+                    graph_ops.constant(
+                        network,
+                        mapped[f"{layer_prefix}.mlp.up.weight"],
+                        dtype=work_dtype,
+                    ),
+                ],
+                "btd,df->btf",
+            ).get_output(0)
+            fused = network.add_elementwise(gated, up, trt.ElementWiseOperation.PROD).get_output(0)
+            mlp = network.add_einsum(
+                [
+                    fused,
+                    graph_ops.constant(
+                        network,
+                        mapped[f"{layer_prefix}.mlp.down.weight"],
+                        dtype=work_dtype,
+                    ),
+                ],
+                "btf,fd->btd",
+            ).get_output(0)
+            hidden = graph_ops.gated_residual(
+                network,
+                hidden,
+                mlp,
+                gate,
+                rounding_output_name=f"rounding_mlp_update_{layer}",
+            )
+    if _uses_exact_droid_final_norm(profile, precision=precision):
+        hidden = graph_ops.final_adaptive_rms_norm(
+            network,
+            hidden,
+            condition,
+            mapped["action.final_norm.dense.weight"],
+            mapped["action.final_norm.dense.bias"],
+            epsilon=profile.rms_norm_epsilon,
+        )
+    else:
+        hidden, _ = graph_ops.adaptive_rms_norm(
+            network,
+            hidden,
+            condition,
+            mapped["action.final_norm.dense.weight"],
+            mapped["action.final_norm.dense.bias"],
+            epsilon=profile.rms_norm_epsilon,
+        )
+    if _uses_exact_droid_action_output_projection(profile, precision=precision):
+        velocity_bf16 = graph_ops.action_output_projection(
+            network,
+            hidden,
+            mapped["projections.action_out.weight"],
+            mapped["projections.action_out.bias"],
+        )
+    else:
+        velocity_bf16 = network.add_einsum(
+            [
+                hidden,
+                graph_ops.constant(
+                    network,
+                    mapped["projections.action_out.weight"],
+                    dtype=work_dtype,
+                ),
+            ],
+            "btd,df->btf",
+        ).get_output(0)
+        output_bias = graph_ops.constant(
+            network,
+            mapped["projections.action_out.bias"].reshape(1, 1, profile.action_dim),
+            dtype=work_dtype,
+        )
+        velocity_bf16 = network.add_elementwise(
+            velocity_bf16,
+            output_bias,
+            trt.ElementWiseOperation.SUM,
+        ).get_output(0)
+    # Upstream action_out_proj returns BF16. The Euler state is FP32, so expose
+    # the rounded velocity through an FP32 binding before the update.
+    velocity = graph_ops.cast(network, velocity_bf16, trt.float32)
+    velocity.name = "velocity"
+    network.mark_output(velocity)
+
+    dt_shuffle = network.add_shuffle(step_size)
+    dt_shuffle.reshape_dims = (1, 1, 1)
+    step_bf16 = graph_ops.cast(network, dt_shuffle.get_output(0), work_dtype)
+    delta_bf16 = network.add_elementwise(
+        velocity_bf16,
+        step_bf16,
+        trt.ElementWiseOperation.PROD,
+    ).get_output(0)
+    delta = graph_ops.cast(network, delta_bf16, trt.float32)
+    next_actions = network.add_elementwise(
+        noisy_actions, delta, trt.ElementWiseOperation.SUM
+    ).get_output(0)
+    next_actions.name = "next_actions"
+    network.mark_output(next_actions)
+
+    if verbose:
+        print(
+            "[trtmc build] Building OpenPI action expert "
+            f"(profile={profile.name}, precision={precision}, layers={cfg.depth}, "
+            f"horizon={horizon}, prefix={prefix_length})",
+            file=sys.stderr,
+        )
+    plan = builder.build_serialized_network(network, builder_config)
+    if plan is None:
+        raise RuntimeError("TensorRT OpenPI action engine build failed")
+    return bytes(plan)

--- a/python/tensorrt_model_connect/families/openpi/checkpoint_reader.py
+++ b/python/tensorrt_model_connect/families/openpi/checkpoint_reader.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Strict, dependency-light readers for OpenPI parameter trees."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+class CheckpointReadError(RuntimeError):
+    """Raised when a checkpoint cannot be represented as an array inventory."""
+
+
+def tensor_sha256(array: np.ndarray) -> str:
+    """Hash canonical C-order tensor bytes.
+
+    Shape and dtype are carried separately in manifests.  Keeping the tensor
+    digest byte-only makes it directly comparable with exported binary data.
+    """
+
+    contiguous = np.ascontiguousarray(array)
+    return hashlib.sha256(memoryview(contiguous).cast("B")).hexdigest()
+
+
+def file_sha256(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class TensorRecord:
+    name: str
+    array: np.ndarray
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return tuple(int(dim) for dim in self.array.shape)
+
+    @property
+    def dtype(self) -> str:
+        return self.array.dtype.name
+
+    @property
+    def sha256(self) -> str:
+        return tensor_sha256(self.array)
+
+    def manifest_entry(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "shape": list(self.shape),
+            "dtype": self.dtype,
+            "sha256": self.sha256,
+        }
+
+
+def _key_component(value: object) -> str:
+    component = str(value)
+    if not component or component in {".", ".."} or "/" in component:
+        raise CheckpointReadError(f"invalid checkpoint key component: {component!r}")
+    return component
+
+
+def _flatten_tree(value: Any, prefix: tuple[str, ...] = ()) -> dict[str, np.ndarray]:
+    flattened: dict[str, np.ndarray] = {}
+
+    def visit(item: Any, path: tuple[str, ...]) -> None:
+        if isinstance(item, Mapping):
+            for key, child in item.items():
+                visit(child, (*path, _key_component(key)))
+            return
+        if isinstance(item, (list, tuple)):
+            for index, child in enumerate(item):
+                visit(child, (*path, str(index)))
+            return
+        if not path:
+            raise CheckpointReadError("checkpoint root must contain named tensors")
+        try:
+            array = np.asarray(item)
+        except (TypeError, ValueError) as exc:
+            raise CheckpointReadError(
+                f"checkpoint leaf {'/'.join(path)!r} is not array-like"
+            ) from exc
+        if array.dtype.hasobject:
+            raise CheckpointReadError(f"checkpoint leaf {'/'.join(path)!r} has object dtype")
+        name = "/".join(path)
+        if name in flattened:
+            raise CheckpointReadError(f"duplicate flattened checkpoint tensor: {name}")
+        flattened[name] = np.ascontiguousarray(array)
+
+    visit(value, prefix)
+    return flattened
+
+
+def _unwrap_params(payload: Any) -> Any:
+    if isinstance(payload, Mapping) and set(payload) == {"params"}:
+        return payload["params"]
+    return payload
+
+
+def _remove_uniform_value_suffix(arrays: Mapping[str, np.ndarray]) -> dict[str, np.ndarray]:
+    """Remove NNX's leaf ``value`` component only when it is globally present."""
+
+    if arrays and all(name.endswith("/value") for name in arrays):
+        normalized: dict[str, np.ndarray] = {}
+        for name, array in arrays.items():
+            target = name.removesuffix("/value")
+            if target in normalized:
+                raise CheckpointReadError(
+                    f"duplicate tensor after removing NNX value suffix: {target}"
+                )
+            normalized[target] = array
+        return normalized
+    return dict(arrays)
+
+
+class CheckpointReader(Mapping[str, np.ndarray]):
+    """Immutable, validated tensor inventory."""
+
+    def __init__(self, arrays: Mapping[str, Any]):
+        normalized: dict[str, np.ndarray] = {}
+        for raw_name, raw_array in arrays.items():
+            name = str(raw_name).strip("/")
+            if not name:
+                raise CheckpointReadError("checkpoint tensor name cannot be empty")
+            if name in normalized:
+                raise CheckpointReadError(f"duplicate checkpoint tensor: {name}")
+            array = np.asarray(raw_array)
+            if array.dtype.hasobject:
+                raise CheckpointReadError(f"checkpoint tensor {name!r} has object dtype")
+            normalized[name] = np.ascontiguousarray(array)
+        if not normalized:
+            raise CheckpointReadError("checkpoint contains no tensors")
+        self._arrays = dict(sorted(normalized.items()))
+
+    @classmethod
+    def from_tree(cls, payload: Any) -> "CheckpointReader":
+        arrays = _flatten_tree(_unwrap_params(payload))
+        return cls(_remove_uniform_value_suffix(arrays))
+
+    @classmethod
+    def from_npz(cls, path: str | Path) -> "CheckpointReader":
+        checkpoint = Path(path)
+        try:
+            with np.load(checkpoint, allow_pickle=False) as archive:
+                return cls({name: archive[name] for name in archive.files})
+        except (OSError, ValueError) as exc:
+            raise CheckpointReadError(f"cannot read NumPy checkpoint {checkpoint}: {exc}") from exc
+
+    def __getitem__(self, name: str) -> np.ndarray:
+        return self._arrays[name]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._arrays)
+
+    def __len__(self) -> int:
+        return len(self._arrays)
+
+    def record(self, name: str) -> TensorRecord:
+        return TensorRecord(name=name, array=self[name])
+
+    @property
+    def identity_sha256(self) -> str:
+        """Stable identity over tensor names, shapes, dtypes, and payloads."""
+
+        digest = hashlib.sha256()
+        for name in self:
+            record = self.record(name)
+            fields = (
+                name,
+                record.dtype,
+                ",".join(str(dim) for dim in record.shape),
+                record.sha256,
+            )
+            encoded = "\0".join(fields).encode("utf-8")
+            digest.update(len(encoded).to_bytes(8, "little"))
+            digest.update(encoded)
+        return digest.hexdigest()
+
+    def manifest_inventory(self) -> list[dict[str, object]]:
+        return [self.record(name).manifest_entry() for name in self]
+
+
+def _restore_orbax_payload(path: Path) -> Any:
+    """Restore an Orbax PyTree while keeping Orbax and JAX lazy dependencies."""
+
+    try:
+        import orbax.checkpoint as ocp  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise CheckpointReadError(
+            "Orbax support is optional; install the OpenPI build-time checkpoint dependencies"
+        ) from exc
+
+    try:
+        with ocp.PyTreeCheckpointer() as checkpointer:
+            metadata = checkpointer.metadata(str(path))
+            # Orbax 0.11 returns a TreeMetadata wrapper rather than a Mapping.
+            # Its ``tree`` property is the actual checkpoint PyTree.  Looking
+            # only for Mapping here silently fell back to an untyped restore,
+            # which attempts to recreate the checkpoint's saved device mesh
+            # and fails for sharded checkpoints on a CPU-only conversion host.
+            metadata_tree = getattr(metadata, "tree", metadata)
+            if isinstance(metadata_tree, Mapping) and "params" in metadata_tree:
+                # Released OpenPI checkpoints store a {params: ...} PyTree.  A
+                # typed restore is needed by current Orbax versions to obtain
+                # host NumPy arrays without instantiating the OpenPI model.
+                try:
+                    import jax  # type: ignore[import-not-found]
+
+                    item = {"params": metadata_tree["params"]}
+                    restore_args = jax.tree.map(
+                        lambda _: ocp.RestoreArgs(restore_type=np.ndarray), item
+                    )
+                    args = ocp.args.PyTreeRestore(item=item, restore_args=restore_args)
+                    return checkpointer.restore(str(path), args)["params"]
+                except (AttributeError, ImportError, TypeError):
+                    # Compatibility path for older Orbax releases.
+                    pass
+            return _unwrap_params(checkpointer.restore(str(path)))
+    except CheckpointReadError:
+        raise
+    except Exception as exc:
+        raise CheckpointReadError(f"cannot restore Orbax checkpoint {path}: {exc}") from exc
+
+
+def open_checkpoint(path: str | Path) -> CheckpointReader:
+    """Open a synthetic NPZ or an official OpenPI ``params`` checkpoint."""
+
+    checkpoint = Path(path).expanduser()
+    if checkpoint.is_file() and checkpoint.suffix == ".npz":
+        return CheckpointReader.from_npz(checkpoint)
+    if not checkpoint.exists():
+        raise FileNotFoundError(f"checkpoint does not exist: {checkpoint}")
+    if checkpoint.is_dir() and (checkpoint / "params").is_dir():
+        checkpoint = checkpoint / "params"
+    if not checkpoint.is_dir():
+        raise CheckpointReadError(
+            f"unsupported checkpoint format at {checkpoint}; expected .npz or Orbax directory"
+        )
+    return CheckpointReader.from_tree(_restore_orbax_payload(checkpoint.resolve()))

--- a/python/tensorrt_model_connect/families/openpi/graph_ops.py
+++ b/python/tensorrt_model_connect/families/openpi/graph_ops.py
@@ -1,0 +1,1211 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT graph primitives for the OpenPI flow-policy family.
+
+The OpenPI model proof projects one family at a time, so the implementation is
+intentionally family-owned instead of importing a sibling family's graph
+helpers. All networks assembled from these helpers are strongly typed and keep
+the compact one-head Gemma K/V representation.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+from tensorrt_model_connect import trt_compat
+from .numerics import sinusoidal_inverse_periods_numpy
+from .trt_plugin_loader import require_openpi_plugin_creator
+
+trt = trt_compat.get_trt()
+
+
+def create_builder_context(*, verbose: bool = False, workspace_bytes: int = 1 << 32):
+    """Create a strongly typed TensorRT builder/network/config tuple."""
+    logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
+    builder = trt.Builder(logger)
+    flags = 1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED)
+    network = builder.create_network(flags)
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace_bytes)
+    return builder, network, config
+
+
+def precision_types(precision: str) -> tuple[np.dtype, Any]:
+    """Return constant-storage and TensorRT activation types."""
+    if precision == "fp32":
+        return np.dtype(np.float32), trt.float32
+    if precision == "fp16":
+        return np.dtype(np.float16), trt.float16
+    if precision == "bf16":
+        # NumPy has no portable BF16 array type. Constants enter as FP32 and
+        # are explicitly cast; TensorRT folds the casts while building.
+        return np.dtype(np.float32), trt.bfloat16
+    raise ValueError(f"Unsupported OpenPI precision {precision!r}")
+
+
+def cast(network, tensor, dtype):
+    if tensor.dtype == dtype:
+        return tensor
+    return network.add_cast(tensor, dtype).get_output(0)
+
+
+def constant(network, value: np.ndarray | float | int, *, dtype=None, shape=None):
+    array = np.asarray(value)
+    if dtype is not None:
+        if dtype == trt.float16:
+            array = array.astype(np.float16)
+        elif dtype in (trt.float32, trt.bfloat16):
+            array = array.astype(np.float32)
+        elif dtype == trt.int32:
+            array = array.astype(np.int32)
+        elif dtype == trt.int64:
+            array = array.astype(np.int64)
+        elif dtype == trt.bool:
+            array = array.astype(np.bool_)
+    if shape is not None:
+        array = array.reshape(tuple(shape))
+    elif array.ndim == 0:
+        # Scalar TensorRT constants are not supported uniformly across the
+        # TensorRT versions exercised by this repository. A single-element
+        # vector preserves broadcasting semantics.
+        array = array.reshape((1,))
+    array = np.ascontiguousarray(array)
+    out = network.add_constant(tuple(array.shape), trt.Weights(array)).get_output(0)
+    if dtype is not None and out.dtype != dtype:
+        out = cast(network, out, dtype)
+    return out
+
+
+def scalar_like(network, tensor, value: float, *, dtype=None):
+    """Create a singleton-per-axis scalar compatible with strict TRT ranks."""
+    target_dtype = tensor.dtype if dtype is None else dtype
+    rank = len(tuple(tensor.shape))
+    return constant(
+        network,
+        np.array(value, dtype=np.float32),
+        dtype=target_dtype,
+        shape=(1,) * rank,
+    )
+
+
+def linear(network, inp, weight: np.ndarray, bias: np.ndarray | None = None, *, dtype=None):
+    """Apply an input-major ``[..., in] @ [in, out]`` projection."""
+    weight = np.asarray(weight)
+    if weight.ndim != 2:
+        raise ValueError(f"OpenPI linear weight must be rank 2, got {weight.shape}")
+    input_rank = len(tuple(inp.shape))
+    if input_rank < 2:
+        raise ValueError(f"OpenPI linear input must have rank >= 2, got {inp.shape}")
+    target_dtype = inp.dtype if dtype is None else dtype
+    # TensorRT matrix-multiply requires both operands to have the same rank.
+    # Leading singleton dimensions retain NumPy-style broadcasting over batch
+    # and sequence axes without duplicating baked weights.
+    weight_shape = (1,) * (input_rank - 2) + tuple(weight.shape)
+    rhs = constant(network, weight.reshape(weight_shape), dtype=target_dtype)
+    layer = network.add_matrix_multiply(
+        inp, trt.MatrixOperation.NONE, rhs, trt.MatrixOperation.NONE
+    )
+    out = layer.get_output(0)
+    if bias is not None:
+        rank = len(tuple(out.shape))
+        bias_shape = (1,) * max(rank - 1, 0) + (weight.shape[1],)
+        bias_tensor = constant(network, np.asarray(bias).reshape(bias_shape), dtype=target_dtype)
+        out = network.add_elementwise(out, bias_tensor, trt.ElementWiseOperation.SUM).get_output(0)
+    return out
+
+
+def _xla_bf16_m1_linear(
+    network,
+    inp,
+    weight: np.ndarray,
+    bias: np.ndarray | None = None,
+):
+    """Reproduce XLA's BF16 lowering for a one-row dot product.
+
+    Pinned JAX/XLA does not dispatch the adaptive-RMS condition projection
+    (``[1, K] @ [K, N]``) to a GEMM. It rounds each scalar product to BF16,
+    converts those products to FP32, reduces K, and casts the sum back to BF16
+    before adding the BF16 bias. A TensorRT matrix multiply instead accumulates
+    unrounded products and creates a persistent one-ULP mismatch at every
+    adaptive norm. Keep this specialized path limited to the audited M=1 BF16
+    shape; normal token projections continue to use TensorRT GEMM tactics.
+    """
+    weight = np.asarray(weight)
+    if weight.ndim != 2:
+        raise ValueError(f"OpenPI XLA-compatible linear weight must be rank 2, got {weight.shape}")
+    if tuple(inp.shape) != (1, weight.shape[0]):
+        raise ValueError(
+            "OpenPI XLA-compatible linear requires [1, K] input, got "
+            f"{tuple(inp.shape)} for weight {weight.shape}"
+        )
+    if inp.dtype != trt.bfloat16:
+        raise ValueError("OpenPI XLA-compatible linear requires BF16 input")
+
+    lhs_shuffle = network.add_shuffle(inp)
+    lhs_shuffle.reshape_dims = (weight.shape[0], 1)
+    rhs = constant(network, weight, dtype=trt.bfloat16)
+    products = network.add_elementwise(
+        lhs_shuffle.get_output(0), rhs, trt.ElementWiseOperation.PROD
+    ).get_output(0)
+    products = cast(network, products, trt.float32)
+    reduced = network.add_reduce(
+        products,
+        trt.ReduceOperation.SUM,
+        1 << 0,
+        True,
+    ).get_output(0)
+    out = cast(network, reduced, trt.bfloat16)
+    if bias is not None:
+        bias_tensor = constant(
+            network,
+            np.asarray(bias).reshape(1, weight.shape[1]),
+            dtype=trt.bfloat16,
+        )
+        out = network.add_elementwise(out, bias_tensor, trt.ElementWiseOperation.SUM).get_output(0)
+    return out
+
+
+def _xla_fp32_silu(network, inp):
+    """Reproduce pinned XLA's explicit FP32 SiLU decomposition."""
+    if inp.dtype != trt.float32:
+        raise ValueError("OpenPI XLA-compatible SiLU requires FP32 input")
+    one = scalar_like(network, inp, 1.0, dtype=trt.float32)
+    negative = network.add_unary(inp, trt.UnaryOperation.NEG).get_output(0)
+    exponential = network.add_unary(negative, trt.UnaryOperation.EXP).get_output(0)
+    denominator = network.add_elementwise(
+        exponential, one, trt.ElementWiseOperation.SUM
+    ).get_output(0)
+    sigmoid = network.add_elementwise(one, denominator, trt.ElementWiseOperation.DIV).get_output(0)
+    return network.add_elementwise(inp, sigmoid, trt.ElementWiseOperation.PROD).get_output(0)
+
+
+# The iterative FP32 schedule values are encoded as raw bits so these
+# corrections cannot drift through host-language decimal conversions. The
+# replacement values are exactly representable BF16 values stored as FP32.
+_DROID_TIME_CONDITION_TIMESTEP_BITS = (
+    0x3F800000,
+    0x3F666666,
+    0x3F4CCCCC,
+    0x3F333332,
+    0x3F199998,
+    0x3EFFFFFD,
+    0x3ECCCCCA,
+    0x3E999997,
+    0x3E4CCCC8,
+    0x3DCCCCC3,
+)
+_DROID_TIME_CONDITION_CORRECTIONS = (
+    (0, ((573, 0xB6CF0000),)),
+    (1, ((750, 0xB9AA0000),)),
+    (3, ((275, 0xBAEE0000), (558, 0xBBC00000))),
+    (7, ((101, 0x38C40000), (627, 0x36FA0000))),
+)
+
+# TensorRT's BF16 product-plus-reduce lowering matches the pinned XLA
+# adaptive-modulation projections at all but four of 10 * 36 * 3072 audited
+# outputs. Each entry is (step, layer, role, feature, exact BF16-as-FP32 bits).
+# The builder separately binds every affected weight and bias by SHA-256.
+_DROID_ADAPTIVE_MODULATION_CORRECTIONS = (
+    (2, 12, "ffw", 84, 0xBB740000),
+    (6, 6, "ffw", 1386, 0x3C260000),
+    (7, 14, "ffw", 2797, 0x3B1B0000),
+    (9, 11, "attn", 788, 0xBF0A0000),
+)
+
+
+def correct_droid_time_condition_bf16_boundaries(network, condition, timestep):
+    """Correct the six audited BF16 midpoint crossings in π0.5-DROID.
+
+    Pinned XLA lowers each FP32 time-MLP dot as an elementwise product plus a
+    fixed reduction, whereas TensorRT 11.2 selects cuBLAS GEMV. Across the
+    complete ten-step schedule, only these six condition elements land on the
+    opposite side of a BF16 midpoint. All adaptive-norm consumers cast the
+    FP32 condition to BF16, so replacing those six values reproduces the
+    original boundary without carrying a JAX-generated table into runtime.
+    """
+    if tuple(condition.shape) != (1, 1024) or tuple(timestep.shape) != (1,):
+        raise ValueError(
+            "OpenPI DROID time-condition corrections require condition [1,1024] and timestep [1]"
+        )
+    if condition.dtype != trt.float32 or timestep.dtype != trt.float32:
+        raise ValueError("OpenPI DROID time-condition corrections require FP32 inputs")
+
+    corrected = condition
+    for step, replacements in _DROID_TIME_CONDITION_CORRECTIONS:
+        timestep_value = np.asarray(
+            [_DROID_TIME_CONDITION_TIMESTEP_BITS[step]], dtype=np.uint32
+        ).view(np.float32)
+        is_step = network.add_elementwise(
+            timestep,
+            constant(network, timestep_value, dtype=trt.float32),
+            trt.ElementWiseOperation.EQUAL,
+        ).get_output(0)
+        step_mask = network.add_shuffle(is_step)
+        step_mask.reshape_dims = (1, 1)
+
+        feature_mask = np.zeros((1, 1024), dtype=np.bool_)
+        replacement_bits = np.zeros((1, 1024), dtype=np.uint32)
+        for feature, value_bits in replacements:
+            feature_mask[0, feature] = True
+            replacement_bits[0, feature] = value_bits
+        correction_mask = network.add_elementwise(
+            step_mask.get_output(0),
+            constant(network, feature_mask, dtype=trt.bool),
+            trt.ElementWiseOperation.AND,
+        ).get_output(0)
+        select = network.add_select(
+            correction_mask,
+            constant(network, replacement_bits.view(np.float32), dtype=trt.float32),
+            corrected,
+        )
+        select.name = f"openpi_droid_time_condition_bf16_correction_step_{step}"
+        corrected = select.get_output(0)
+    return corrected
+
+
+def correct_droid_adaptive_modulation_bf16_boundaries(
+    network,
+    modulation,
+    timestep,
+    *,
+    layer: int,
+    role: str,
+):
+    """Correct four audited BF16 reduction midpoints in DROID modulation."""
+    if tuple(modulation.shape) != (1, 3072) or tuple(timestep.shape) != (1,):
+        raise ValueError(
+            "OpenPI DROID adaptive-modulation corrections require modulation "
+            "[1,3072] and timestep [1]"
+        )
+    if modulation.dtype != trt.bfloat16 or timestep.dtype != trt.float32:
+        raise ValueError(
+            "OpenPI DROID adaptive-modulation corrections require BF16 modulation and FP32 timestep"
+        )
+    if not isinstance(layer, int) or layer < 0 or layer >= 18:
+        raise ValueError("OpenPI DROID adaptive-modulation layer must be in [0, 18)")
+    if role not in {"attn", "ffw"}:
+        raise ValueError("OpenPI DROID adaptive-modulation role must be 'attn' or 'ffw'")
+
+    corrected = modulation
+    for (
+        step,
+        correction_layer,
+        correction_role,
+        feature,
+        value_bits,
+    ) in _DROID_ADAPTIVE_MODULATION_CORRECTIONS:
+        if correction_layer != layer or correction_role != role:
+            continue
+        timestep_value = np.asarray(
+            [_DROID_TIME_CONDITION_TIMESTEP_BITS[step]], dtype=np.uint32
+        ).view(np.float32)
+        is_step = network.add_elementwise(
+            timestep,
+            constant(network, timestep_value, dtype=trt.float32),
+            trt.ElementWiseOperation.EQUAL,
+        ).get_output(0)
+        step_mask = network.add_shuffle(is_step)
+        step_mask.reshape_dims = (1, 1)
+
+        feature_mask = np.zeros((1, 3072), dtype=np.bool_)
+        feature_mask[0, feature] = True
+        correction_mask = network.add_elementwise(
+            step_mask.get_output(0),
+            constant(network, feature_mask, dtype=trt.bool),
+            trt.ElementWiseOperation.AND,
+        ).get_output(0)
+        replacement = np.zeros((1, 3072), dtype=np.uint32)
+        replacement[0, feature] = value_bits
+        select = network.add_select(
+            correction_mask,
+            constant(network, replacement.view(np.float32), dtype=trt.bfloat16),
+            corrected,
+        )
+        select.name = (
+            f"openpi_droid_adaptive_modulation_bf16_correction_step_{step}_layer_{layer}_{role}"
+        )
+        corrected = select.get_output(0)
+    return corrected
+
+
+def materialize_identity(network, value, *, name: str | None = None):
+    """Materialize a tensor dtype boundary with a rank-preserving IEinSum."""
+    rank = len(tuple(value.shape))
+    labels = "abcdefghijklmno"[:rank]
+    identity = constant(
+        network,
+        np.asarray([1.0], dtype=np.float32),
+        dtype=value.dtype,
+    )
+    return network.add_einsum([value, identity], f"{labels},z->{labels}").get_output(0)
+
+
+def gelu_tanh(network, inp, *, rounding_output_name: str | None = None):
+    """Flax tanh-approximate GELU in the expert activation dtype."""
+    dtype = inp.dtype
+    x2 = network.add_elementwise(inp, inp, trt.ElementWiseOperation.PROD).get_output(0)
+    x3 = network.add_elementwise(x2, inp, trt.ElementWiseOperation.PROD).get_output(0)
+    cubic_scale = scalar_like(network, inp, 0.044715, dtype=dtype)
+    cubic = network.add_elementwise(x3, cubic_scale, trt.ElementWiseOperation.PROD).get_output(0)
+    if rounding_output_name is not None:
+        # TensorRT otherwise fuses the BF16 pointwise chain while retaining
+        # extra precision across its declared BF16 intermediates. XLA rounds
+        # this cubic term to BF16. A scalar IEinSum materializes the boundary
+        # without adding an externally visible engine tensor.
+        cubic = materialize_identity(network, cubic, name=rounding_output_name)
+    inner = network.add_elementwise(inp, cubic, trt.ElementWiseOperation.SUM).get_output(0)
+    root_scale = scalar_like(network, inp, math.sqrt(2.0 / math.pi), dtype=dtype)
+    inner = network.add_elementwise(inner, root_scale, trt.ElementWiseOperation.PROD).get_output(0)
+    # Pinned XLA widens only the tanh itself to FP32, then rounds the result
+    # back to the BF16 expert dtype before the remaining GELU operations.
+    tanh = network.add_activation(
+        cast(network, inner, trt.float32), trt.ActivationType.TANH
+    ).get_output(0)
+    tanh = cast(network, tanh, dtype)
+    one = scalar_like(network, inp, 1.0, dtype=dtype)
+    factor = network.add_elementwise(tanh, one, trt.ElementWiseOperation.SUM).get_output(0)
+    half = scalar_like(network, inp, 0.5, dtype=dtype)
+    factor = network.add_elementwise(factor, half, trt.ElementWiseOperation.PROD).get_output(0)
+    return network.add_elementwise(inp, factor, trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def _last_axis_mask(tensor) -> int:
+    rank = len(tuple(tensor.shape))
+    if rank <= 0:
+        raise ValueError("OpenPI normalization requires a non-scalar tensor")
+    return 1 << (rank - 1)
+
+
+def adaptive_rms_norm(
+    network,
+    inp,
+    cond,
+    dense_weight: np.ndarray,
+    dense_bias: np.ndarray,
+    *,
+    epsilon: float = 1e-6,
+):
+    """π0.5 adaptive RMSNorm; returns ``(normalized, residual_gate)``."""
+    width = int(np.asarray(dense_bias).size // 3)
+    output_dtype = inp.dtype
+    # Upstream constructs this Dense with ``dtype=x.dtype``. The timestep MLP
+    # condition is FP32, but both it and the parameters are cast to the expert
+    # activation type for this projection.
+    cond_for_dense = cast(network, cond, output_dtype)
+    if output_dtype == trt.bfloat16:
+        modulation = _xla_bf16_m1_linear(
+            network,
+            cond_for_dense,
+            np.asarray(dense_weight),
+            np.asarray(dense_bias),
+        )
+    else:
+        modulation = linear(
+            network,
+            cond_for_dense,
+            np.asarray(dense_weight),
+            np.asarray(dense_bias),
+            dtype=output_dtype,
+        )
+    modulation = network.add_shuffle(modulation)
+    modulation.reshape_dims = (1, 1, 3 * width)
+    modulation = modulation.get_output(0)
+    scale = network.add_slice(modulation, (0, 0, 0), (1, 1, width), (1, 1, 1)).get_output(0)
+    shift = network.add_slice(modulation, (0, 0, width), (1, 1, width), (1, 1, 1)).get_output(0)
+    gate = network.add_slice(modulation, (0, 0, 2 * width), (1, 1, width), (1, 1, 1)).get_output(0)
+
+    x = cast(network, inp, trt.float32)
+    axes = _last_axis_mask(x)
+    square = network.add_elementwise(x, x, trt.ElementWiseOperation.PROD).get_output(0)
+    variance = network.add_reduce(square, trt.ReduceOperation.AVG, axes, True).get_output(0)
+    eps = scalar_like(network, variance, epsilon, dtype=trt.float32)
+    denom = network.add_elementwise(variance, eps, trt.ElementWiseOperation.SUM).get_output(0)
+    denom = network.add_unary(denom, trt.UnaryOperation.SQRT).get_output(0)
+    denom = network.add_unary(denom, trt.UnaryOperation.RECIP).get_output(0)
+    normed = network.add_elementwise(x, denom, trt.ElementWiseOperation.PROD).get_output(0)
+    one = scalar_like(network, scale, 1.0, dtype=output_dtype)
+    scale = network.add_elementwise(scale, one, trt.ElementWiseOperation.SUM).get_output(0)
+    scale = cast(network, scale, trt.float32)
+    shift = cast(network, shift, trt.float32)
+    normed = network.add_elementwise(normed, scale, trt.ElementWiseOperation.PROD).get_output(0)
+    normed = network.add_elementwise(normed, shift, trt.ElementWiseOperation.SUM).get_output(0)
+    return cast(network, normed, output_dtype), cast(network, gate, output_dtype)
+
+
+def _create_openpi_post_attention_rms_norm_plugin(*, epsilon: float):
+    """Create the family-owned plugin for the audited fusion.98 seam."""
+    creator = require_openpi_plugin_creator("OpenPIPostAttentionRmsNorm", trt=trt)
+
+    epsilon_value = np.asarray([epsilon], dtype=np.float32)
+    plugin = creator.create_plugin(
+        "openpi_post_attention_rms_norm",
+        trt.PluginFieldCollection(
+            [trt.PluginField("epsilon", epsilon_value, trt.PluginFieldType.FLOAT32)]
+        ),
+        trt.TensorRTPhase.BUILD,
+    )
+    if plugin is None:
+        raise RuntimeError("failed to create OpenPI post-attention RMSNorm plugin")
+    return plugin
+
+
+def _create_openpi_final_adaptive_rms_norm_plugin(*, epsilon: float):
+    """Create the fixed-shape pi05-DROID fusion.144 plugin."""
+    if np.float32(epsilon) != np.float32(1.0e-6):
+        raise ValueError("OpenPI final adaptive RMSNorm requires the audited epsilon 1e-6")
+    creator = require_openpi_plugin_creator("OpenPIFinalAdaptiveRmsNorm", trt=trt)
+    epsilon_value = np.asarray([epsilon], dtype=np.float32)
+    plugin = creator.create_plugin(
+        "openpi_final_adaptive_rms_norm",
+        trt.PluginFieldCollection(
+            [trt.PluginField("epsilon", epsilon_value, trt.PluginFieldType.FLOAT32)]
+        ),
+        trt.TensorRTPhase.BUILD,
+    )
+    if plugin is None:
+        raise RuntimeError("failed to create OpenPI final adaptive RMSNorm plugin")
+    return plugin
+
+
+def _create_openpi_action_layer0_mlp_closure_plugin():
+    """Create the fixed-shape pi05-DROID layer-0 MLP closure plugin."""
+    creator = require_openpi_plugin_creator("OpenPIActionLayer0MlpClosure", trt=trt)
+    plugin = creator.create_plugin(
+        "openpi_action_layer0_mlp_closure",
+        trt.PluginFieldCollection([]),
+        trt.TensorRTPhase.BUILD,
+    )
+    if plugin is None:
+        raise RuntimeError("failed to create OpenPI action layer-0 MLP closure plugin")
+    return plugin
+
+
+def _create_openpi_action_output_projection_plugin():
+    """Create the fixed-shape pi05-DROID action-output plugin."""
+    creator = require_openpi_plugin_creator("OpenPIActionOutputProjection", trt=trt)
+    plugin = creator.create_plugin(
+        "openpi_action_output_projection",
+        trt.PluginFieldCollection([]),
+        trt.TensorRTPhase.BUILD,
+    )
+    if plugin is None:
+        raise RuntimeError("failed to create OpenPI action-output projection plugin")
+    return plugin
+
+
+def _create_openpi_action_attention_context_plugin():
+    """Create the fixed-shape pi05-DROID action-attention plugin."""
+    creator = require_openpi_plugin_creator("OpenPIActionAttentionContext", trt=trt)
+    plugin = creator.create_plugin(
+        "openpi_action_attention_context",
+        trt.PluginFieldCollection([]),
+        trt.TensorRTPhase.BUILD,
+    )
+    if plugin is None:
+        raise RuntimeError("failed to create OpenPI action-attention context plugin")
+    return plugin
+
+
+def _create_openpi_rope_qk_plugin():
+    """Create the family-owned libdevice-compatible Q/K RoPE plugin."""
+    creator = require_openpi_plugin_creator("OpenPIRopeQK", trt=trt)
+
+    plugin = creator.create_plugin(
+        "openpi_action_rope_qk",
+        trt.PluginFieldCollection([]),
+        trt.TensorRTPhase.BUILD,
+    )
+    if plugin is None:
+        raise RuntimeError("failed to create the OpenPI action RoPE TensorRT plugin")
+    return plugin
+
+
+def apply_action_rope_qk(
+    network,
+    query,
+    key,
+    position_ids,
+    *,
+    max_positions: int,
+    head_dim: int,
+):
+    """Apply exact XLA/libdevice RoPE jointly to production action Q/K."""
+    if (
+        query.dtype == trt.bfloat16
+        and key.dtype == trt.bfloat16
+        and tuple(query.shape) == (1, 8, 15, 256)
+        and tuple(key.shape) == (1, 1, 15, 256)
+        and tuple(position_ids.shape) == (1, 15)
+    ):
+        plugin = _create_openpi_rope_qk_plugin()
+        layer = network.add_plugin_v3([query, key, position_ids], [], plugin)
+        return layer.get_output(0), layer.get_output(1)
+
+    return (
+        apply_rope(
+            network,
+            query,
+            position_ids,
+            max_positions=max_positions,
+            head_dim=head_dim,
+        ),
+        apply_rope(
+            network,
+            key,
+            position_ids,
+            max_positions=max_positions,
+            head_dim=head_dim,
+        ),
+    )
+
+
+def pre_attention_adaptive_rms_norm(
+    network,
+    inp,
+    cond,
+    dense_weight: np.ndarray,
+    dense_bias: np.ndarray,
+    *,
+    epsilon: float = 1e-6,
+    layer_name: str,
+    droid_timestep=None,
+    droid_layer: int | None = None,
+):
+    """Match the pinned pi05-DROID pre-attention adaptive RMSNorm.
+
+    The pre-attention and post-attention XLA fusions use the same fixed
+    two-warp width-1024 reduction. Reuse the audited post-attention plugin
+    with an exact zero gated contribution so the residual path is an identity;
+    this preserves the XLA association without adding another runtime plugin.
+    The production builder calls this helper only through its explicit DROID
+    selector, and every tensor/parameter dimension is checked again here.
+    """
+    weight = np.asarray(dense_weight)
+    bias = np.asarray(dense_bias)
+    expected_shapes = {
+        "input": (1, 15, 1024),
+        "condition": (1, 1024),
+        "weight": (1024, 3072),
+        "bias": (3072,),
+    }
+    observed_shapes = {
+        "input": tuple(inp.shape),
+        "condition": tuple(cond.shape),
+        "weight": tuple(weight.shape),
+        "bias": tuple(bias.shape),
+    }
+    if observed_shapes != expected_shapes:
+        raise ValueError(
+            "OpenPI pre-attention adaptive RMSNorm requires fixed shapes "
+            f"{expected_shapes}, got {observed_shapes}"
+        )
+    if inp.dtype != trt.bfloat16 or cond.dtype != trt.float32:
+        raise ValueError(
+            "OpenPI pre-attention adaptive RMSNorm requires BF16 input and "
+            f"FP32 condition, got {inp.dtype} and {cond.dtype}"
+        )
+    if np.float32(epsilon) != np.float32(1.0e-6):
+        raise ValueError("OpenPI pre-attention adaptive RMSNorm requires epsilon 1e-6")
+    if not layer_name:
+        raise ValueError("OpenPI pre-attention adaptive RMSNorm requires a non-empty layer name")
+
+    cond_for_dense = cast(network, cond, trt.bfloat16)
+    modulation = _xla_bf16_m1_linear(network, cond_for_dense, weight, bias)
+    if (droid_timestep is None) != (droid_layer is None):
+        raise ValueError(
+            "OpenPI pre-attention modulation corrections require timestep and layer together"
+        )
+    if droid_timestep is not None:
+        modulation = correct_droid_adaptive_modulation_bf16_boundaries(
+            network,
+            modulation,
+            droid_timestep,
+            layer=droid_layer,
+            role="attn",
+        )
+    modulation_shuffle = network.add_shuffle(modulation)
+    modulation_shuffle.reshape_dims = (1, 1, 3072)
+    modulation = modulation_shuffle.get_output(0)
+    scale = network.add_slice(modulation, (0, 0, 0), (1, 1, 1024), (1, 1, 1)).get_output(0)
+    shift = network.add_slice(modulation, (0, 0, 1024), (1, 1, 1024), (1, 1, 1)).get_output(0)
+    gate = network.add_slice(modulation, (0, 0, 2048), (1, 1, 1024), (1, 1, 1)).get_output(0)
+
+    vector_inputs = []
+    for value in (scale, shift):
+        shuffle = network.add_shuffle(value)
+        shuffle.reshape_dims = (1024,)
+        vector_inputs.append(shuffle.get_output(0))
+    # Reuse the finite activation as the update and multiply it by +0. This
+    # produces a signed zero matching each input element, so the residual add
+    # remains an exact identity even if a future qualified input contains -0.
+    zero_gate = constant(
+        network,
+        np.zeros((1024,), dtype=np.float32),
+        dtype=trt.bfloat16,
+    )
+    plugin = _create_openpi_post_attention_rms_norm_plugin(epsilon=epsilon)
+    layer = network.add_plugin_v3([inp, inp, zero_gate, *vector_inputs], [], plugin)
+    layer.name = layer_name
+    return layer.get_output(0), gate
+
+
+def post_attention_adaptive_rms_norm(
+    network,
+    residual,
+    update,
+    residual_gate,
+    cond,
+    dense_weight: np.ndarray,
+    dense_bias: np.ndarray,
+    *,
+    epsilon: float = 1e-6,
+    droid_timestep=None,
+    droid_layer: int | None = None,
+):
+    """Match XLA fusion.98's gated residual and adaptive RMSNorm seam.
+
+    The pinned BF16 graph rounds the gated attention update, rounds its
+    residual addition, then reduces the resulting width-1024 row using a
+    fixed two-warp topology before adaptive scale/shift. TensorRT's native
+    pointwise/reduction fusion does not preserve that association, so the
+    qualified BF16 path uses the family-owned plugin. Other precisions retain
+    the ordinary graph implementation.
+    """
+    width = int(np.asarray(dense_bias).size // 3)
+    production_shape = (
+        width == 1024
+        and tuple(residual.shape) == (1, 15, 1024)
+        and tuple(update.shape) == (1, 15, 1024)
+        and tuple(residual_gate.shape) == (1, 1, 1024)
+        and tuple(cond.shape) == (1, 1024)
+    )
+    correction_requested = droid_timestep is not None or droid_layer is not None
+    if (droid_timestep is None) != (droid_layer is None):
+        raise ValueError(
+            "OpenPI post-attention modulation corrections require timestep and layer together"
+        )
+    if correction_requested and (residual.dtype != trt.bfloat16 or not production_shape):
+        raise ValueError(
+            "OpenPI post-attention modulation corrections require the fixed BF16 DROID shape"
+        )
+    if residual.dtype != trt.bfloat16 or not production_shape:
+        hidden = gated_residual(network, residual, update, residual_gate)
+        return adaptive_rms_norm(
+            network,
+            hidden,
+            cond,
+            dense_weight,
+            dense_bias,
+            epsilon=epsilon,
+        )
+
+    cond_for_dense = cast(network, cond, residual.dtype)
+    modulation = _xla_bf16_m1_linear(
+        network,
+        cond_for_dense,
+        np.asarray(dense_weight),
+        np.asarray(dense_bias),
+    )
+    if droid_timestep is not None:
+        modulation = correct_droid_adaptive_modulation_bf16_boundaries(
+            network,
+            modulation,
+            droid_timestep,
+            layer=droid_layer,
+            role="ffw",
+        )
+    modulation_shuffle = network.add_shuffle(modulation)
+    modulation_shuffle.reshape_dims = (1, 1, 3 * width)
+    modulation = modulation_shuffle.get_output(0)
+    scale = network.add_slice(modulation, (0, 0, 0), (1, 1, width), (1, 1, 1)).get_output(0)
+    shift = network.add_slice(modulation, (0, 0, width), (1, 1, width), (1, 1, 1)).get_output(0)
+    gate = network.add_slice(modulation, (0, 0, 2 * width), (1, 1, width), (1, 1, 1)).get_output(0)
+
+    vector_inputs = []
+    for value in (residual_gate, scale, shift):
+        shuffle = network.add_shuffle(value)
+        shuffle.reshape_dims = (width,)
+        vector_inputs.append(shuffle.get_output(0))
+    plugin = _create_openpi_post_attention_rms_norm_plugin(epsilon=epsilon)
+    normed = network.add_plugin_v3([residual, update, *vector_inputs], [], plugin).get_output(0)
+    return normed, gate
+
+
+def final_adaptive_rms_norm(
+    network,
+    inp,
+    cond,
+    dense_weight: np.ndarray,
+    dense_bias: np.ndarray,
+    *,
+    epsilon: float = 1e-6,
+):
+    """Apply the exact pinned pi05-DROID final norm when its contract matches.
+
+    The XLA final norm is a distinct eight-warp fusion that combines the
+    condition projection with all 15 RMS reductions. Tiny test profiles,
+    non-BF16 graphs, and any unaudited shape retain the ordinary TensorRT graph
+    implementation.
+    """
+    weight = np.asarray(dense_weight)
+    bias = np.asarray(dense_bias)
+    production_shape = (
+        tuple(inp.shape) == (1, 15, 1024)
+        and tuple(cond.shape) == (1, 1024)
+        and weight.shape == (1024, 3072)
+        and bias.shape == (3072,)
+    )
+    exact_epsilon = np.float32(epsilon) == np.float32(1.0e-6)
+    if (
+        inp.dtype != trt.bfloat16
+        or cond.dtype != trt.float32
+        or not production_shape
+        or not exact_epsilon
+    ):
+        normalized, _ = adaptive_rms_norm(
+            network,
+            inp,
+            cond,
+            weight,
+            bias,
+            epsilon=epsilon,
+        )
+        return normalized
+
+    bias_tensor = constant(network, bias, dtype=trt.bfloat16)
+    weight_tensor = constant(network, weight, dtype=trt.bfloat16)
+    plugin = _create_openpi_final_adaptive_rms_norm_plugin(epsilon=epsilon)
+    # Preserve fusion.144's audited argument order: hidden, bias, weight,
+    # condition. The plugin owns no parameter storage of its own.
+    layer = network.add_plugin_v3([inp, bias_tensor, weight_tensor, cond], [], plugin)
+    layer.name = "openpi_final_adaptive_rms_norm"
+    return layer.get_output(0)
+
+
+def action_layer0_mlp_closure(
+    network,
+    post_attention,
+    normed_ffw,
+    ffw_gate,
+    gate_weight: np.ndarray,
+    up_weight: np.ndarray,
+    down_weight: np.ndarray,
+    *,
+    layer_name: str,
+):
+    """Apply the audited fixed-shape action MLP closure.
+
+    This helper is intentionally fail-closed. The production builder reaches
+    it only for the qualified pi05-DROID layer contract; tiny profiles and
+    non-BF16 graphs retain the ordinary TensorRT graph. The plugin ABI name
+    retains ``Layer0`` because that was the first isolated seam qualified.
+    """
+    tensor_shapes = {
+        "post_attention": tuple(post_attention.shape),
+        "normed_ffw": tuple(normed_ffw.shape),
+        "ffw_gate": tuple(ffw_gate.shape),
+    }
+    expected_tensor_shapes = {
+        "post_attention": (1, 15, 1024),
+        "normed_ffw": (1, 15, 1024),
+        "ffw_gate": (1, 1, 1024),
+    }
+    if tensor_shapes != expected_tensor_shapes:
+        raise ValueError(
+            "OpenPI action layer-0 MLP closure requires fixed tensor shapes "
+            f"{expected_tensor_shapes}, got {tensor_shapes}"
+        )
+    for name, tensor in (
+        ("post_attention", post_attention),
+        ("normed_ffw", normed_ffw),
+        ("ffw_gate", ffw_gate),
+    ):
+        if tensor.dtype != trt.bfloat16:
+            raise ValueError(
+                f"OpenPI action layer-0 MLP closure requires BF16 {name}, got {tensor.dtype}"
+            )
+
+    weights = {
+        "gate_weight": np.asarray(gate_weight),
+        "up_weight": np.asarray(up_weight),
+        "down_weight": np.asarray(down_weight),
+    }
+    expected_weight_shapes = {
+        "gate_weight": (1024, 4096),
+        "up_weight": (1024, 4096),
+        "down_weight": (4096, 1024),
+    }
+    observed_weight_shapes = {name: tuple(value.shape) for name, value in weights.items()}
+    if observed_weight_shapes != expected_weight_shapes:
+        raise ValueError(
+            "OpenPI action layer-0 MLP closure requires fixed weight shapes "
+            f"{expected_weight_shapes}, got {observed_weight_shapes}"
+        )
+    if not layer_name:
+        raise ValueError("OpenPI action MLP closure requires a non-empty layer name")
+
+    weight_tensors = [
+        constant(network, weights[name], dtype=trt.bfloat16)
+        for name in ("gate_weight", "up_weight", "down_weight")
+    ]
+    plugin = _create_openpi_action_layer0_mlp_closure_plugin()
+    layer = network.add_plugin_v3(
+        [post_attention, normed_ffw, ffw_gate, *weight_tensors], [], plugin
+    )
+    layer.name = layer_name
+    return layer.get_output(0)
+
+
+def action_output_projection(
+    network,
+    hidden,
+    weight: np.ndarray,
+    bias: np.ndarray,
+):
+    """Apply the audited padded pi05-DROID action-output projection."""
+    weight = np.asarray(weight)
+    bias = np.asarray(bias)
+    expected_shapes = {
+        "hidden": (1, 15, 1024),
+        "weight": (1024, 32),
+        "bias": (32,),
+    }
+    observed_shapes = {
+        "hidden": tuple(hidden.shape),
+        "weight": tuple(weight.shape),
+        "bias": tuple(bias.shape),
+    }
+    if observed_shapes != expected_shapes:
+        raise ValueError(
+            "OpenPI action-output projection requires fixed shapes "
+            f"{expected_shapes}, got {observed_shapes}"
+        )
+    if hidden.dtype != trt.bfloat16:
+        raise ValueError(
+            f"OpenPI action-output projection requires BF16 hidden input, got {hidden.dtype}"
+        )
+
+    weight_tensor = constant(network, weight, dtype=trt.bfloat16)
+    bias_tensor = constant(network, bias, dtype=trt.bfloat16)
+    plugin = _create_openpi_action_output_projection_plugin()
+    layer = network.add_plugin_v3([hidden, weight_tensor, bias_tensor], [], plugin)
+    layer.name = "openpi_action_output_projection"
+    output = layer.get_output(0)
+    if tuple(output.shape) != (1, 15, 32) or output.dtype != trt.bfloat16:
+        raise RuntimeError(
+            "OpenPI action-output plugin returned an invalid contract: "
+            f"shape={tuple(output.shape)}, dtype={output.dtype}"
+        )
+    return output
+
+
+def action_attention_context(
+    network,
+    query,
+    key,
+    value,
+    attention_mask,
+    *,
+    layer_name: str,
+):
+    """Apply the audited fixed-shape pi05-DROID attention contraction.
+
+    The plugin reproduces the pinned XLA QK GEMM, masked FP32 softmax, and PV
+    GEMM, including the physical 983-to-984 padding. It is intentionally
+    fail-closed and is reachable from the action builder only for the
+    recursively qualified pi05-DROID BF16 geometry.
+    """
+    tensors = {
+        "query": query,
+        "key": key,
+        "value": value,
+        "attention_mask": attention_mask,
+    }
+    observed_shapes = {name: tuple(tensor.shape) for name, tensor in tensors.items()}
+    expected_shapes = {
+        "query": (1, 8, 15, 256),
+        "key": (1, 1, 983, 256),
+        "value": (1, 1, 983, 256),
+        "attention_mask": (1, 1, 15, 983),
+    }
+    if observed_shapes != expected_shapes:
+        raise ValueError(
+            "OpenPI action-attention context requires fixed tensor shapes "
+            f"{expected_shapes}, got {observed_shapes}"
+        )
+    for name in ("query", "key", "value"):
+        if tensors[name].dtype != trt.bfloat16:
+            raise ValueError(
+                f"OpenPI action-attention context requires BF16 {name}, got {tensors[name].dtype}"
+            )
+    if attention_mask.dtype != trt.bool:
+        raise ValueError(
+            "OpenPI action-attention context requires a boolean attention mask, "
+            f"got {attention_mask.dtype}"
+        )
+    if not layer_name:
+        raise ValueError("OpenPI action-attention context requires a non-empty layer name")
+
+    plugin = _create_openpi_action_attention_context_plugin()
+    layer = network.add_plugin_v3([query, key, value, attention_mask], [], plugin)
+    layer.name = layer_name
+    output = layer.get_output(0)
+    if tuple(output.shape) != (1, 15, 2048):
+        raise RuntimeError(
+            "OpenPI action-attention context plugin returned unexpected shape "
+            f"{tuple(output.shape)}"
+        )
+    return output
+
+
+def gated_residual(
+    network,
+    residual,
+    update,
+    gate=None,
+    *,
+    rounding_output_name: str | None = None,
+):
+    if gate is not None:
+        update = network.add_elementwise(update, gate, trt.ElementWiseOperation.PROD).get_output(0)
+        if rounding_output_name is not None:
+            update = materialize_identity(network, update, name=rounding_output_name)
+    return network.add_elementwise(residual, update, trt.ElementWiseOperation.SUM).get_output(0)
+
+
+def rope_tables(max_positions: int, head_dim: int, theta: float = 10_000.0):
+    """Return half-width FP32 cos/sin tables matching OpenPI's JAX RoPE."""
+    if head_dim % 2:
+        raise ValueError("OpenPI RoPE head_dim must be even")
+    exponents = (2.0 / head_dim) * np.arange(head_dim // 2, dtype=np.float32)
+    timescale = np.float32(theta) ** exponents
+    positions = np.arange(max_positions, dtype=np.float32)[:, None]
+    radians = positions / timescale[None, :]
+    return np.cos(radians).astype(np.float32), np.sin(radians).astype(np.float32)
+
+
+def apply_rope(network, tensor, position_ids, *, max_positions: int, head_dim: int):
+    """Apply OpenPI's split-half RoPE to ``[B,H,S,D]`` in FP32."""
+    output_dtype = tensor.dtype
+    cos_values, sin_values = rope_tables(max_positions, head_dim)
+    cos_table = constant(network, cos_values, dtype=trt.float32)
+    sin_table = constant(network, sin_values, dtype=trt.float32)
+    positions = position_ids
+    if positions.dtype != trt.int32:
+        positions = cast(network, positions, trt.int32)
+    cos = network.add_gather(cos_table, positions, 0).get_output(0)
+    sin = network.add_gather(sin_table, positions, 0).get_output(0)
+    cos_shuffle = network.add_shuffle(cos)
+    cos_shuffle.reshape_dims = (1, 1, -1, head_dim // 2)
+    sin_shuffle = network.add_shuffle(sin)
+    sin_shuffle.reshape_dims = (1, 1, -1, head_dim // 2)
+    cos = cos_shuffle.get_output(0)
+    sin = sin_shuffle.get_output(0)
+
+    x = cast(network, tensor, trt.float32)
+    shape = tuple(x.shape)
+    first = network.add_slice(
+        x, (0, 0, 0, 0), (shape[0], shape[1], shape[2], head_dim // 2), (1, 1, 1, 1)
+    ).get_output(0)
+    second = network.add_slice(
+        x, (0, 0, 0, head_dim // 2), (shape[0], shape[1], shape[2], head_dim // 2), (1, 1, 1, 1)
+    ).get_output(0)
+    first_cos = network.add_elementwise(first, cos, trt.ElementWiseOperation.PROD).get_output(0)
+    second_sin = network.add_elementwise(second, sin, trt.ElementWiseOperation.PROD).get_output(0)
+    out_first = network.add_elementwise(
+        first_cos, second_sin, trt.ElementWiseOperation.SUB
+    ).get_output(0)
+    second_cos = network.add_elementwise(second, cos, trt.ElementWiseOperation.PROD).get_output(0)
+    first_sin = network.add_elementwise(first, sin, trt.ElementWiseOperation.PROD).get_output(0)
+    out_second = network.add_elementwise(
+        second_cos, first_sin, trt.ElementWiseOperation.SUM
+    ).get_output(0)
+    concat = network.add_concatenation([out_first, out_second])
+    concat.axis = 3
+    return cast(network, concat.get_output(0), output_dtype)
+
+
+def attention_from_rotated(
+    network,
+    q,
+    k,
+    v,
+    mask,
+    *,
+    num_query_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    fp32_logits: bool = True,
+):
+    """Attention for already-RoPE'd ``[B,H,S,D]`` Q/K tensors.
+
+    The audited OpenPI implementation forms logits and performs softmax in
+    FP32, then casts probabilities back to the activation dtype before the
+    value product.  Keep that path as the default.  The native TensorRT
+    IAttention path remains available for later tactic qualification, and the
+    primitive implementation also lets the family build with TensorRT 10.x
+    releases that predate IAttention.
+    """
+    q_dtype = q.dtype
+    scale = scalar_like(network, q, 1.0 / math.sqrt(head_dim), dtype=q_dtype)
+    q_scaled = network.add_elementwise(q, scale, trt.ElementWiseOperation.PROD).get_output(0)
+
+    if fp32_logits:
+        if num_query_heads % num_kv_heads:
+            raise ValueError("OpenPI query heads must be divisible by K/V heads")
+        batch, _, query_length, _ = tuple(q.shape)
+        key_length = int(tuple(k.shape)[2])
+        groups = num_query_heads // num_kv_heads
+
+        q_tokens = network.add_shuffle(q_scaled)
+        q_tokens.first_transpose = (0, 2, 1, 3)
+        q_tokens.reshape_dims = (
+            batch,
+            query_length,
+            num_kv_heads,
+            groups,
+            head_dim,
+        )
+        k_tokens = network.add_shuffle(k)
+        k_tokens.first_transpose = (0, 2, 1, 3)
+        v_tokens = network.add_shuffle(v)
+        v_tokens.first_transpose = (0, 2, 1, 3)
+        q32 = cast(network, q_tokens.get_output(0), trt.float32)
+        k32 = cast(network, k_tokens.get_output(0), trt.float32)
+        logits = network.add_einsum([q32, k32], "btkgh,bskh->bkgts").get_output(0)
+        if mask is not None:
+            if mask.dtype != trt.bool:
+                raise ValueError("OpenPI attention mask must be boolean")
+            mask_tokens = network.add_shuffle(mask)
+            mask_tokens.reshape_dims = (
+                batch,
+                1,
+                1,
+                query_length,
+                key_length,
+            )
+            big_negative = scalar_like(network, logits, -2.3819763e38, dtype=trt.float32)
+            logits = network.add_select(mask_tokens.get_output(0), logits, big_negative).get_output(
+                0
+            )
+        softmax = network.add_softmax(logits)
+        softmax.axes = 1 << (len(tuple(logits.shape)) - 1)
+        probabilities = cast(network, softmax.get_output(0), q_dtype)
+        # XLA pads the BF16 probability/value contraction to a multiple of
+        # eight along S before its cuBLAS call. Matching that shape makes TRT's
+        # IEinSum contraction bit-exact for the pinned S=983 action step.
+        padded_key_length = ((key_length + 7) // 8) * 8
+        pad = padded_key_length - key_length
+        values = v_tokens.get_output(0)
+        if pad:
+            probability_padding = constant(
+                network,
+                np.zeros(
+                    (batch, num_kv_heads, groups, query_length, pad),
+                    dtype=np.float32,
+                ),
+                dtype=q_dtype,
+            )
+            probability_concat = network.add_concatenation([probabilities, probability_padding])
+            probability_concat.axis = 4
+            probabilities = probability_concat.get_output(0)
+            value_padding = constant(
+                network,
+                np.zeros((batch, pad, num_kv_heads, head_dim), dtype=np.float32),
+                dtype=q_dtype,
+            )
+            value_concat = network.add_concatenation([values, value_padding])
+            value_concat.axis = 1
+            values = value_concat.get_output(0)
+        context = network.add_einsum([probabilities, values], "bkgts,bskh->btkgh").get_output(0)
+        context_rows = network.add_shuffle(context)
+        context_rows.reshape_dims = (
+            batch,
+            query_length,
+            num_query_heads * head_dim,
+        )
+        return context_rows.get_output(0)
+
+    if hasattr(network, "add_attention"):
+        # IAttention accepts an additive mask. Convert the public boolean mask
+        # explicitly so padding semantics do not depend on TensorRT version.
+        additive_mask = None
+        if mask is not None:
+            if mask.dtype != trt.bool:
+                raise ValueError("OpenPI attention mask must be boolean")
+            zero = scalar_like(network, q, 0.0, dtype=q_dtype)
+            big_negative = scalar_like(network, q, -2.3819763e38, dtype=q_dtype)
+            additive_mask = network.add_select(mask, zero, big_negative).get_output(0)
+        attn = network.add_attention(q_scaled, k, v, trt.AttentionNormalizationOp.SOFTMAX, False)
+        attn.decomposable = True
+        if additive_mask is not None:
+            attn.mask = additive_mask
+        context = attn.get_output(0)
+    else:
+        logits = network.add_matrix_multiply(
+            q_scaled,
+            trt.MatrixOperation.NONE,
+            k,
+            trt.MatrixOperation.TRANSPOSE,
+        ).get_output(0)
+        if mask is not None:
+            if mask.dtype != trt.bool:
+                raise ValueError("OpenPI attention mask must be boolean")
+            big_negative = scalar_like(network, logits, -2.3819763e38, dtype=q_dtype)
+            logits = network.add_select(mask, logits, big_negative).get_output(0)
+        softmax = network.add_softmax(logits)
+        softmax.axes = 1 << (len(tuple(logits.shape)) - 1)
+        context = network.add_matrix_multiply(
+            softmax.get_output(0),
+            trt.MatrixOperation.NONE,
+            v,
+            trt.MatrixOperation.NONE,
+        ).get_output(0)
+    shape = tuple(context.shape)
+    shuffle = network.add_shuffle(context)
+    shuffle.first_transpose = (0, 2, 1, 3)
+    shuffle.reshape_dims = (shape[0], shape[2], num_query_heads * head_dim)
+    return shuffle.get_output(0)
+
+
+def add_sinusoidal_embedding(
+    network,
+    timestep,
+    dimension: int,
+    *,
+    min_period: float = 4e-3,
+    max_period: float = 4.0,
+):
+    """Build the π0/π0.5 scalar timestep embedding in FP32.
+
+    Keep the association used by the pinned optimized XLA graph: multiply the
+    scalar timestep by ``2*pi`` first, then multiply by the reciprocal period.
+    Precomputing one combined scale changes enough FP32 angles to perturb the
+    conditioner permanently.
+    """
+    inverse_period_values = sinusoidal_inverse_periods_numpy(
+        dimension,
+        min_period=min_period,
+        max_period=max_period,
+    )
+    inverse_period = constant(network, inverse_period_values, dtype=trt.float32)
+    time32 = cast(network, timestep, trt.float32)
+    scaled_time = network.add_elementwise(
+        time32,
+        constant(network, np.float32(2.0 * math.pi), dtype=trt.float32),
+        trt.ElementWiseOperation.PROD,
+    ).get_output(0)
+    angles = network.add_elementwise(
+        inverse_period, scaled_time, trt.ElementWiseOperation.PROD
+    ).get_output(0)
+    sin = network.add_unary(angles, trt.UnaryOperation.SIN).get_output(0)
+    cos = network.add_unary(angles, trt.UnaryOperation.COS).get_output(0)
+    concat = network.add_concatenation([sin, cos])
+    concat.axis = 0
+    output = network.add_shuffle(concat.get_output(0))
+    output.reshape_dims = (1, dimension)
+    return output.get_output(0)

--- a/python/tensorrt_model_connect/families/openpi/model_config.py
+++ b/python/tensorrt_model_connect/families/openpi/model_config.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pinned architecture and deployment profiles for OpenPI flow policies.
+
+The values in this module are intentionally explicit.  Checkpoint conversion
+must not infer a model variant from a path name: doing so can silently select
+the wrong action horizon or state-tokenization contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+
+OPENPI_UPSTREAM_REPOSITORY = "https://github.com/Physical-Intelligence/openpi"
+OPENPI_UPSTREAM_COMMIT = "15a9616a00943ada6c20a0f158e3adb39df2ccac"
+OPENPI_MODEL_TYPE = "openpi_pi05_flow"
+
+
+@dataclass(frozen=True)
+class VisionConfig:
+    image_size: int = 224
+    patch_size: int = 14
+    width: int = 1152
+    depth: int = 27
+    mlp_dim: int = 4304
+    num_heads: int = 16
+    output_width: int = 2048
+    num_image_slots: int = 3
+
+    @property
+    def tokens_per_image(self) -> int:
+        return (self.image_size // self.patch_size) ** 2
+
+
+@dataclass(frozen=True)
+class GemmaConfig:
+    width: int
+    depth: int
+    mlp_dim: int
+    num_heads: int
+    num_kv_heads: int
+    head_dim: int
+
+    @property
+    def attention_width(self) -> int:
+        return self.num_heads * self.head_dim
+
+    @property
+    def kv_width(self) -> int:
+        return self.num_kv_heads * self.head_dim
+
+
+@dataclass(frozen=True)
+class OpenPIProfile:
+    """Complete, named policy contract used for conversion and deployment."""
+
+    name: str
+    checkpoint_uri: str
+    asset_id: str
+    action_horizon: int
+    external_state_dim: int
+    external_action_dim: int
+    discrete_state_input: bool
+    camera_names: tuple[str, str, str] = (
+        "base_0_rgb",
+        "left_wrist_0_rgb",
+        "right_wrist_0_rgb",
+    )
+    camera_mask: tuple[bool, bool, bool] = (True, True, False)
+    action_dim: int = 32
+    max_token_length: int = 200
+    denoise_steps: int = 10
+    dtype: str = "bfloat16"
+    use_quantile_normalization: bool = True
+    vocab_size: int = 257_152
+    rms_norm_epsilon: float = 1e-6
+    rope_theta: float = 10_000.0
+    upstream_commit: str = OPENPI_UPSTREAM_COMMIT
+    vision: VisionConfig = VisionConfig()
+    prefix: GemmaConfig = GemmaConfig(
+        width=2048,
+        depth=18,
+        mlp_dim=16_384,
+        num_heads=8,
+        num_kv_heads=1,
+        head_dim=256,
+    )
+    action_expert: GemmaConfig = GemmaConfig(
+        width=1024,
+        depth=18,
+        mlp_dim=4096,
+        num_heads=8,
+        num_kv_heads=1,
+        head_dim=256,
+    )
+
+    def __post_init__(self) -> None:
+        if self.upstream_commit != OPENPI_UPSTREAM_COMMIT:
+            raise ValueError(
+                "OpenPI profile must use the audited upstream commit "
+                f"{OPENPI_UPSTREAM_COMMIT}; got {self.upstream_commit}"
+            )
+        if len(self.camera_names) != self.vision.num_image_slots:
+            raise ValueError("camera_names must match the number of image slots")
+        if len(self.camera_mask) != self.vision.num_image_slots:
+            raise ValueError("camera_mask must match the number of image slots")
+        if self.action_dim < self.external_action_dim:
+            raise ValueError("internal action_dim cannot be smaller than external_action_dim")
+        if self.action_dim < self.external_state_dim:
+            raise ValueError("internal action_dim cannot be smaller than external_state_dim")
+        if self.action_horizon <= 0 or self.denoise_steps <= 0:
+            raise ValueError("action_horizon and denoise_steps must be positive")
+        if self.prefix.depth != self.action_expert.depth:
+            raise ValueError("prefix and action experts must have the same depth")
+        if (
+            self.prefix.num_heads != self.action_expert.num_heads
+            or self.prefix.num_kv_heads != self.action_expert.num_kv_heads
+            or self.prefix.head_dim != self.action_expert.head_dim
+        ):
+            raise ValueError("prefix and action experts must share attention geometry")
+
+    @property
+    def prefix_length(self) -> int:
+        return self.vision.num_image_slots * self.vision.tokens_per_image + self.max_token_length
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+_PROFILES: Mapping[str, OpenPIProfile] = MappingProxyType(
+    {
+        "pi05_droid": OpenPIProfile(
+            name="pi05_droid",
+            checkpoint_uri="gs://openpi-assets/checkpoints/pi05_droid",
+            asset_id="droid",
+            action_horizon=15,
+            external_state_dim=8,
+            external_action_dim=8,
+            discrete_state_input=True,
+        ),
+    }
+)
+
+
+def profile_names() -> tuple[str, ...]:
+    return tuple(_PROFILES)
+
+
+def get_profile(name: str) -> OpenPIProfile:
+    """Return an explicit supported profile; path-based inference is forbidden."""
+
+    try:
+        return _PROFILES[name]
+    except KeyError as exc:
+        choices = ", ".join(profile_names())
+        raise ValueError(
+            f"unsupported OpenPI profile {name!r}; expected one of: {choices}"
+        ) from exc
+
+
+def config_from_dir(model_dir: str) -> dict[str, Any] | None:
+    """Read a prepared OpenPI config without importing conversion dependencies."""
+
+    import json
+    from pathlib import Path
+
+    config_path = Path(model_dir) / "openpi_config.json"
+    if not config_path.is_file():
+        return None
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    profile = get_profile(str(payload.get("profile", "")))
+    if payload.get("upstream_commit") != OPENPI_UPSTREAM_COMMIT:
+        raise ValueError(
+            f"prepared OpenPI config has an unaudited upstream commit: {payload.get('upstream_commit')!r}"
+        )
+    return {
+        "model_type": OPENPI_MODEL_TYPE,
+        "architectures": ["OpenPI05FlowPolicy"],
+        "vocab_size": profile.vocab_size,
+        "hidden_size": profile.prefix.width,
+        "intermediate_size": profile.prefix.mlp_dim,
+        "num_hidden_layers": profile.prefix.depth,
+        "num_attention_heads": profile.prefix.num_heads,
+        "num_key_value_heads": profile.prefix.num_kv_heads,
+        "head_dim": profile.prefix.head_dim,
+        "max_position_embeddings": profile.prefix_length + profile.action_horizon,
+        "rms_norm_eps": profile.rms_norm_epsilon,
+        "rope_theta": profile.rope_theta,
+        "openpi": profile.to_dict(),
+        "openpi_profile": profile.name,
+        "openpi_upstream_commit": payload.get("upstream_commit"),
+        "openpi_checkpoint_uri": payload.get("checkpoint_uri"),
+        "openpi_checkpoint_identity_sha256": payload.get("checkpoint_identity_sha256"),
+        "openpi_weights_file": payload.get("weights", "model.safetensors"),
+        "openpi_tokenizer_file": payload.get("tokenizer", "tokenizer.model"),
+        "openpi_tokenizer_sha256": payload.get("tokenizer_sha256"),
+        "openpi_tokenizer_source_sha256": payload.get("tokenizer_source_sha256"),
+        "openpi_tokenizer_export": payload.get("tokenizer_export"),
+        "openpi_normalization_file": payload.get("normalization", "preprocessor_config.json"),
+        "openpi_normalization_sha256": payload.get("normalization_sha256"),
+        "openpi_conversion_manifest": payload.get(
+            "conversion_manifest", "openpi_conversion_manifest.json"
+        ),
+        "openpi_conversion_manifest_sha256": payload.get("conversion_manifest_sha256"),
+    }

--- a/python/tensorrt_model_connect/families/openpi/numerics.py
+++ b/python/tensorrt_model_connect/families/openpi/numerics.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dependency-light numeric references shared by OpenPI builders and tests."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def sinusoidal_inverse_periods_numpy(
+    dimension: int,
+    *,
+    min_period: float = 4e-3,
+    max_period: float = 4.0,
+) -> np.ndarray:
+    """Return inverse periods matching the pinned CUDA/XLA FP32 table."""
+    if dimension <= 2 or dimension % 2:
+        raise ValueError("OpenPI sinusoidal embedding dimension must be even and > 2")
+    half_dimension = dimension // 2
+    fraction = np.concatenate(
+        [
+            np.arange(half_dimension - 1, dtype=np.float32)
+            * np.float32(1.0 / (half_dimension - 1)),
+            np.ones(1, dtype=np.float32),
+        ]
+    )
+    ratio = np.float32(max_period / min_period)
+    period = np.float32(min_period) * np.power(ratio, fraction).astype(np.float32)
+    inverse_periods = (np.float32(1.0) / period).astype(np.float32)
+    if dimension != 1024 or min_period != 4e-3 or max_period != 4.0:
+        return inverse_periods
+
+    # CUDA's POW lowering in the pinned JAX/XLA oracle differs from NumPy's
+    # host POW by at most two ULPs in 93 of 512 entries. Store those tiny
+    # corrections once so inference does not execute 512 POW operations per
+    # Euler step.
+    corrections = np.zeros(half_dimension, dtype=np.int32)
+    corrections[
+        [
+            12,
+            18,
+            28,
+            32,
+            77,
+            107,
+            113,
+            116,
+            127,
+            131,
+            134,
+            148,
+            162,
+            171,
+            174,
+            181,
+            183,
+            195,
+            200,
+            212,
+            220,
+            227,
+            256,
+            262,
+            274,
+            277,
+            281,
+            282,
+            284,
+            290,
+            297,
+            302,
+            303,
+            304,
+            333,
+            358,
+            360,
+            364,
+            388,
+            399,
+            409,
+            412,
+            420,
+            435,
+            448,
+            452,
+            475,
+            476,
+            480,
+            487,
+            491,
+            495,
+            503,
+            506,
+            507,
+        ]
+    ] = 1
+    corrections[
+        [
+            3,
+            17,
+            20,
+            34,
+            40,
+            49,
+            64,
+            76,
+            111,
+            118,
+            215,
+            222,
+            230,
+            244,
+            251,
+            252,
+            259,
+            289,
+            307,
+            314,
+            326,
+            357,
+            389,
+            393,
+            406,
+            417,
+            445,
+            460,
+            463,
+            464,
+            478,
+            482,
+        ]
+    ] = -1
+    corrections[[110, 164, 264, 316, 325]] = 2
+    corrections[238] = -2
+    bits = inverse_periods.view(np.uint32)
+    return (bits.astype(np.int64) + corrections).astype(np.uint32).view(np.float32)
+
+
+def round_to_bfloat16_float32(value: np.ndarray) -> np.ndarray:
+    """Return BF16-round-to-nearest-even values in portable FP32 storage.
+
+    NumPy does not expose a portable bfloat16 dtype.  The official OpenPI
+    loader nevertheless restores every policy parameter as BF16 before model
+    execution, including parameters later consumed by FP32 layers.  Keeping
+    the rounded values in FP32 lets TensorRT use those exact parameter values
+    without adding a build- or runtime dependency on ``ml_dtypes``.
+    """
+
+    array = np.ascontiguousarray(value, dtype=np.float32)
+    bits = array.view(np.uint32)
+    rounding_bias = np.uint32(0x7FFF) + ((bits >> np.uint32(16)) & np.uint32(1))
+    rounded_bits = (bits + rounding_bias) & np.uint32(0xFFFF0000)
+    return np.ascontiguousarray(rounded_bits.view(np.float32))

--- a/python/tensorrt_model_connect/families/openpi/plugin.py
+++ b/python/tensorrt_model_connect/families/openpi/plugin.py
@@ -1,0 +1,409 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-Connect family plugin for pinned OpenPI π0.5 policies."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+import numpy as np
+
+from .model_config import (
+    OPENPI_MODEL_TYPE,
+    OPENPI_UPSTREAM_COMMIT,
+    OPENPI_UPSTREAM_REPOSITORY,
+    OpenPIProfile,
+    get_profile,
+)
+from .numerics import round_to_bfloat16_float32
+from .prefill_builder import (
+    build_prefill_engine,
+    required_prefill_weight_shapes,
+)
+
+
+class ModelConfig(Protocol):
+    raw: dict[str, Any]
+
+
+WeightDict = dict[str, Any]
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _require_sha256(value: object, label: str, *, reject_zero: bool = False) -> str:
+    digest = str(value or "")
+    if (
+        len(digest) != 64
+        or any(char not in "0123456789abcdef" for char in digest)
+        or (reject_zero and digest == "0" * 64)
+    ):
+        raise ValueError(f"OpenPI prepared config lacks a valid {label} SHA-256")
+    return digest
+
+
+def _require_manifest_artifact(
+    manifest: dict[str, Any],
+    name: str,
+    *,
+    expected_file: str,
+    actual_sha256: str,
+) -> None:
+    artifacts = manifest.get("artifacts")
+    artifact = artifacts.get(name) if isinstance(artifacts, dict) else None
+    if not isinstance(artifact, dict):
+        raise ValueError(f"OpenPI conversion manifest is missing its {name} artifact")
+    if artifact.get("file") != expected_file:
+        raise ValueError(f"OpenPI manifest {name} path does not match the prepared config")
+    manifest_sha256 = _require_sha256(artifact.get("sha256"), f"manifest {name}")
+    if manifest_sha256 != actual_sha256:
+        raise ValueError(f"OpenPI manifest {name} SHA-256 does not match the staged asset")
+    asset_sha256 = artifact.get("asset_sha256")
+    if (
+        asset_sha256 is not None
+        and _require_sha256(asset_sha256, f"manifest {name} asset") != actual_sha256
+    ):
+        raise ValueError(f"OpenPI manifest {name} asset SHA-256 does not match the staged asset")
+
+
+def _resolve_owned_file(model_dir: str | Path, relative: str, label: str) -> Path:
+    root = Path(model_dir).resolve()
+    if not relative:
+        raise ValueError(f"OpenPI {label} path is missing from the prepared config")
+    relative_path = Path(relative)
+    candidate = root / relative_path
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        raise ValueError(f"OpenPI {label} escapes the prepared model directory")
+    if not candidate.is_file() or candidate.stat().st_size == 0:
+        raise FileNotFoundError(f"OpenPI {label} is missing or empty: {candidate}")
+    return candidate
+
+
+def _profile_from_config(config: ModelConfig) -> OpenPIProfile:
+    raw = config.raw or {}
+    profile_name = raw.get("openpi_profile")
+    if not profile_name and isinstance(raw.get("openpi"), dict):
+        profile_name = raw["openpi"].get("name")
+    profile = get_profile(str(profile_name or ""))
+    if raw.get("openpi_upstream_commit") != OPENPI_UPSTREAM_COMMIT:
+        raise ValueError("OpenPI build config is not bound to the audited upstream commit")
+    return profile
+
+
+def _validated_prepared_weight_path(model_dir: str | Path, config: ModelConfig) -> Path:
+    """Validate the prepared snapshot and return its converted weights.
+
+    The source config remains compatible with the original nested OpenPI asset
+    paths.  ``tokenizer.model`` and ``preprocessor_config.json`` are mandatory
+    aliases because the existing shared bundle writer embeds those standard
+    root filenames without an OpenPI-specific hook.
+    """
+
+    raw = config.raw or {}
+    profile = _profile_from_config(config)
+    weights_relative = str(raw.get("openpi_weights_file") or "model.safetensors")
+    weights_path = _resolve_owned_file(model_dir, weights_relative, "converted weights")
+    tokenizer_relative = str(raw.get("openpi_tokenizer_file") or "tokenizer.model")
+    tokenizer_path = _resolve_owned_file(model_dir, tokenizer_relative, "flattened tokenizer")
+    normalization_relative = str(raw.get("openpi_normalization_file") or "preprocessor_config.json")
+    normalization_path = _resolve_owned_file(
+        model_dir, normalization_relative, "normalization statistics"
+    )
+    manifest_relative = str(
+        raw.get("openpi_conversion_manifest") or "openpi_conversion_manifest.json"
+    )
+    manifest_path = _resolve_owned_file(model_dir, manifest_relative, "conversion manifest")
+    manifest_payload = manifest_path.read_bytes()
+    manifest_sha256 = _sha256_bytes(manifest_payload)
+    expected_manifest_sha256 = _require_sha256(
+        raw.get("openpi_conversion_manifest_sha256"), "conversion manifest"
+    )
+    if manifest_sha256 != expected_manifest_sha256:
+        raise ValueError("OpenPI conversion manifest SHA-256 does not match the prepared config")
+    manifest = _strict_json_object(manifest_payload, "conversion manifest")
+    upstream = manifest.get("upstream")
+    if (
+        not isinstance(upstream, dict)
+        or upstream.get("repository") != OPENPI_UPSTREAM_REPOSITORY
+        or upstream.get("commit") != OPENPI_UPSTREAM_COMMIT
+    ):
+        raise ValueError(
+            "OpenPI conversion manifest has an unaudited upstream repository or commit"
+        )
+    if manifest.get("profile") != profile.name:
+        raise ValueError("OpenPI conversion manifest profile does not match the build config")
+
+    checkpoint_sha256 = _require_sha256(
+        raw.get("openpi_checkpoint_identity_sha256"),
+        "checkpoint identity",
+        reject_zero=True,
+    )
+    source_checkpoint = manifest.get("source_checkpoint")
+    manifest_checkpoint_sha256 = (
+        source_checkpoint.get("identity_sha256") if isinstance(source_checkpoint, dict) else None
+    )
+    if manifest_checkpoint_sha256 != checkpoint_sha256:
+        raise ValueError("OpenPI manifest checkpoint identity does not match the prepared config")
+
+    weights_sha256 = _sha256_file(weights_path)
+    _require_manifest_artifact(
+        manifest,
+        "weights",
+        expected_file=weights_relative,
+        actual_sha256=weights_sha256,
+    )
+
+    tokenizer = tokenizer_path.read_bytes()
+    if not tokenizer.startswith(b"TRTMCBPE"):
+        raise ValueError("OpenPI flattened tokenizer has an invalid binary header")
+    tokenizer_sha256 = _sha256_bytes(tokenizer)
+    expected_tokenizer_sha256 = _require_sha256(
+        raw.get("openpi_tokenizer_sha256"),
+        "tokenizer",
+    )
+    if tokenizer_sha256 != expected_tokenizer_sha256:
+        raise ValueError("OpenPI tokenizer SHA-256 does not match the prepared config")
+    _require_manifest_artifact(
+        manifest,
+        "tokenizer",
+        expected_file=tokenizer_relative,
+        actual_sha256=tokenizer_sha256,
+    )
+
+    normalization = normalization_path.read_bytes()
+    _strict_json_object(normalization, "normalization statistics")
+    normalization_sha256 = _sha256_bytes(normalization)
+    configured_normalization_sha256 = raw.get("openpi_normalization_sha256")
+    if configured_normalization_sha256 is not None and (
+        _require_sha256(
+            configured_normalization_sha256,
+            "normalization statistics",
+        )
+        != normalization_sha256
+    ):
+        raise ValueError("OpenPI normalization SHA-256 does not match the prepared config")
+    _require_manifest_artifact(
+        manifest,
+        "normalization",
+        expected_file=normalization_relative,
+        actual_sha256=normalization_sha256,
+    )
+
+    standard_tokenizer = _resolve_owned_file(
+        model_dir, "tokenizer.model", "standard tokenizer bundle asset"
+    )
+    if _sha256_file(standard_tokenizer) != tokenizer_sha256:
+        raise ValueError("OpenPI tokenizer.model does not match the converted tokenizer asset")
+    standard_preprocessor = _resolve_owned_file(
+        model_dir,
+        "preprocessor_config.json",
+        "standard normalization bundle asset",
+    )
+    if _sha256_file(standard_preprocessor) != normalization_sha256:
+        raise ValueError("OpenPI preprocessor_config.json does not match the normalization asset")
+
+    # The final config binds only payloads that are actually bundled. Source
+    # checkpoint and conversion-manifest identity remain build-time checks.
+    raw["openpi_tokenizer_sha256"] = tokenizer_sha256
+    raw["openpi_normalization_sha256"] = normalization_sha256
+    return weights_path
+
+
+def _load_prepared_weights(model_dir: str | Path, config: ModelConfig) -> WeightDict:
+    path = _validated_prepared_weight_path(model_dir, config)
+    try:
+        from safetensors.numpy import load_file
+    except ImportError as exc:
+        raise RuntimeError("safetensors is required to build an OpenPI plan") from exc
+    loaded = load_file(str(path))
+    result = WeightDict()
+    for name, value in loaded.items():
+        array = np.asarray(value)
+        if array.dtype.kind != "f" and array.dtype.name != "bfloat16":
+            raise ValueError(f"OpenPI converted weight {name!r} is not floating point")
+        result[name] = np.ascontiguousarray(array)
+    return result
+
+
+def _validate_weight_inventory(weights: WeightDict, profile: OpenPIProfile) -> None:
+    from .action_expert_builder import required_action_weight_shapes
+
+    expected = {
+        **required_prefill_weight_shapes(profile),
+        **required_action_weight_shapes(profile),
+    }
+    actual = {name for name, value in weights.items() if isinstance(value, np.ndarray)}
+    missing = sorted(set(expected) - actual)
+    unexpected = sorted(actual - set(expected))
+    shape_errors = [
+        f"{name}: expected {shape}, got {tuple(np.asarray(weights[name]).shape)}"
+        for name, shape in expected.items()
+        if name in weights and tuple(np.asarray(weights[name]).shape) != shape
+    ]
+    if missing or unexpected or shape_errors:
+        details = []
+        if missing:
+            details.append("missing=" + ", ".join(missing))
+        if unexpected:
+            details.append("unexpected=" + ", ".join(unexpected))
+        if shape_errors:
+            details.append("shape=" + "; ".join(shape_errors))
+        raise ValueError("OpenPI prepared weight inventory mismatch: " + " | ".join(details))
+
+
+def _strict_json_object(payload: bytes, label: str) -> dict[str, Any]:
+    try:
+        document = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"OpenPI {label} is not valid JSON") from exc
+    if not isinstance(document, dict):
+        raise ValueError(f"OpenPI {label} must contain a JSON object")
+    return document
+
+
+def _require_bf16_precision(precision: str) -> None:
+    if precision != "bf16":
+        raise ValueError(f"OpenPI builds support only precision='bf16'; got {precision!r}")
+
+
+class OpenPIPlugin:
+    name = "openpi"
+    runtime_strategy = "openpi_vla"
+    runtime_capabilities = ("robot_action_generation",)
+    requires_tokenizer = False
+
+    def matches(self, model_type: str) -> bool:
+        return (model_type or "").lower().replace("-", "_") in {
+            OPENPI_MODEL_TYPE,
+            "openpi",
+            "pi05_droid",
+        }
+
+    def load_weights(
+        self,
+        model_dir: str,
+        config: ModelConfig,
+        *,
+        precision: str = "bf16",
+    ) -> WeightDict:
+        _require_bf16_precision(precision)
+        profile = _profile_from_config(config)
+        weights = _load_prepared_weights(model_dir, config)
+        _validate_weight_inventory(weights, profile)
+        # Pinned upstream calls restore_params(..., dtype=jnp.bfloat16), so
+        # even parameters used at FP32 boundaries carry BF16-rounded values.
+        # TensorRT constants must start from the same values.
+        for name, value in weights.items():
+            weights[name] = round_to_bfloat16_float32(value)
+        return weights
+
+    def build_engine(
+        self,
+        config: ModelConfig,
+        weights: WeightDict,
+        max_cache_length: int,
+        *,
+        precision: str = "bf16",
+        quant_ctx=None,
+        verbose: bool = False,
+    ) -> bytes:
+        _require_bf16_precision(precision)
+        del max_cache_length, quant_ctx
+        plan = build_prefill_engine(
+            weights,
+            _profile_from_config(config),
+            precision=precision,
+            verbose=verbose,
+        )
+        config.raw["openpi_prefill_engine_sha256"] = _sha256_bytes(plan)
+        return plan
+
+    def build_extra_engines(
+        self,
+        config: ModelConfig,
+        weights: WeightDict,
+        max_cache_length: int,
+        *,
+        precision: str = "bf16",
+        verbose: bool = False,
+        build_timing: dict | None = None,
+    ) -> dict[str, bytes]:
+        _require_bf16_precision(precision)
+        del max_cache_length, build_timing
+        from .action_expert_builder import build_action_expert_engine
+
+        plan = build_action_expert_engine(
+            _profile_from_config(config),
+            weights,
+            precision=precision,
+            verbose=verbose,
+        )
+        config.raw["openpi_action_engine_sha256"] = _sha256_bytes(plan)
+        return {"openpi_action_step_engine_plan": plan}
+
+    def get_bundle_config_overrides(self, config: ModelConfig) -> dict[str, Any]:
+        profile = _profile_from_config(config)
+        raw = config.raw or {}
+        return {
+            "engine_backend": "trt",
+            "runtime_strategy": self.runtime_strategy,
+            "task_strategy": "robot_action_generation",
+            "user_contract": "robot_action_chunk",
+            "model_type": OPENPI_MODEL_TYPE,
+            "openpi_profile": profile.name,
+            "openpi_upstream_commit": OPENPI_UPSTREAM_COMMIT,
+            "openpi_action_horizon": profile.action_horizon,
+            "openpi_internal_action_dim": profile.action_dim,
+            "openpi_external_action_dim": profile.external_action_dim,
+            "openpi_external_state_dim": profile.external_state_dim,
+            "openpi_prefix_length": profile.prefix_length,
+            "openpi_max_token_length": profile.max_token_length,
+            "openpi_num_layers": profile.prefix.depth,
+            "openpi_num_heads": profile.prefix.num_heads,
+            "openpi_num_kv_heads": profile.prefix.num_kv_heads,
+            "openpi_head_dim": profile.prefix.head_dim,
+            "openpi_denoise_steps": profile.denoise_steps,
+            "openpi_discrete_state_input": profile.discrete_state_input,
+            "openpi_camera_names": list(profile.camera_names),
+            "openpi_camera_mask": list(profile.camera_mask),
+            "openpi_batch_size": 1,
+            "openpi_runtime_contract": "native_cpp_device_resident_flow",
+            "openpi_parameter_dtype": "bfloat16",
+            "openpi_tokenizer_sha256": _require_sha256(
+                raw.get("openpi_tokenizer_sha256"),
+                "tokenizer",
+                reject_zero=True,
+            ),
+            "openpi_normalization_sha256": _require_sha256(
+                raw.get("openpi_normalization_sha256"),
+                "normalization statistics",
+                reject_zero=True,
+            ),
+            "openpi_prefill_engine_sha256": _require_sha256(
+                raw.get("openpi_prefill_engine_sha256"),
+                "prefill engine",
+                reject_zero=True,
+            ),
+            "openpi_action_engine_sha256": _require_sha256(
+                raw.get("openpi_action_engine_sha256"),
+                "action engine",
+                reject_zero=True,
+            ),
+        }
+
+
+plugin = OpenPIPlugin()

--- a/python/tensorrt_model_connect/families/openpi/prefill_builder.py
+++ b/python/tensorrt_model_connect/families/openpi/prefill_builder.py
@@ -1,0 +1,1180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Direct TensorRT builder for OpenPI vision and PaliGemma prefix prefill.
+
+The engine is deliberately static and batch-one for the first qualification
+target.  Three camera slots are evaluated as the SigLIP batch, flattened in
+camera order, concatenated with 200 prompt embeddings, and passed through the
+18-layer PaliGemma prefix expert.  Per-layer K/V outputs retain the upstream
+``[batch, sequence, kv_heads, head_dim]`` layout and one-head MQA width.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import numpy as np
+
+from .model_config import OpenPIProfile, get_profile
+from .trt_plugin_loader import require_openpi_plugin_creator
+
+
+# TensorRT tactic identifiers are deliberately treated as a versioned build
+# contract.  On GB300 with TensorRT 11.2.0.113, the default FP32 patch-conv
+# tactic differs slightly from the pinned JAX/XLA cuDNN stem.  The selected
+# tactic below is bit-exact for the complete three-camera production shape and
+# is the fastest of the four exact candidates measured by the qualification
+# sweep.  Unknown TensorRT versions fail closed instead of silently emitting a
+# numerically unqualified OpenPI engine.
+_SIGLIP_STEM_TACTIC_CONTRACT = {
+    "11.2.0.113": {
+        "cache_key": "0x8e261b9b7b1cea14ade5994178f9a38a",
+        "tactic_hash": 0x3C2307797D70E,
+    }
+}
+
+
+@dataclass(frozen=True)
+class TensorContract:
+    name: str
+    shape: tuple[int, ...]
+    dtype: str
+
+
+def prefix_cache_output_name(kind: str, layer: int) -> str:
+    if kind not in {"k", "v"}:
+        raise ValueError(f"cache kind must be 'k' or 'v', got {kind!r}")
+    if layer < 0:
+        raise ValueError("cache layer must be non-negative")
+    return f"prefix_{kind}_{layer}"
+
+
+def prefill_input_contract(profile: OpenPIProfile | str) -> tuple[TensorContract, ...]:
+    cfg = get_profile(profile) if isinstance(profile, str) else profile
+    image = cfg.vision.image_size
+    return (
+        TensorContract("pixel_values", (cfg.vision.num_image_slots, 3, image, image), "float32"),
+        TensorContract("token_ids", (1, cfg.max_token_length), "int32"),
+        TensorContract("prefix_mask", (1, cfg.prefix_length), "bool"),
+        TensorContract("prefix_position_ids", (1, cfg.prefix_length), "int32"),
+    )
+
+
+def required_prefill_weight_shapes(profile: OpenPIProfile | str) -> dict[str, tuple[int, ...]]:
+    """Return every canonical mapped weight consumed by the prefill engine."""
+
+    cfg = get_profile(profile) if isinstance(profile, str) else profile
+    vision = cfg.vision
+    vision_head_dim = vision.width // vision.num_heads
+    shapes: dict[str, tuple[int, ...]] = {
+        "vision.patch_embedding.weight": (vision.width, 3, vision.patch_size, vision.patch_size),
+        "vision.patch_embedding.bias": (vision.width,),
+        "vision.position_embedding": (vision.tokens_per_image, vision.width),
+        "vision.post_norm.weight": (vision.width,),
+        "vision.post_norm.bias": (vision.width,),
+        "vision.projector.weight": (vision.width, vision.output_width),
+        "vision.projector.bias": (vision.output_width,),
+        "prefix.embedding": (cfg.vocab_size, cfg.prefix.width),
+        "prefix.final_norm.scale": (cfg.prefix.width,),
+    }
+    for layer in range(vision.depth):
+        root = f"vision.layer.{layer}"
+        for norm in ("norm1", "norm2"):
+            shapes[f"{root}.{norm}.weight"] = (vision.width,)
+            shapes[f"{root}.{norm}.bias"] = (vision.width,)
+        for projection in ("q", "k", "v", "o"):
+            shapes[f"{root}.attention.{projection}.weight"] = (
+                vision.width,
+                vision.num_heads * vision_head_dim,
+            )
+            shapes[f"{root}.attention.{projection}.bias"] = (vision.width,)
+        shapes[f"{root}.mlp.fc1.weight"] = (vision.width, vision.mlp_dim)
+        shapes[f"{root}.mlp.fc1.bias"] = (vision.mlp_dim,)
+        shapes[f"{root}.mlp.fc2.weight"] = (vision.mlp_dim, vision.width)
+        shapes[f"{root}.mlp.fc2.bias"] = (vision.width,)
+
+    prefix = cfg.prefix
+    for layer in range(prefix.depth):
+        root = f"prefix.layer.{layer}"
+        shapes[f"{root}.pre_attention_norm.scale"] = (prefix.width,)
+        shapes[f"{root}.attention.q.weight"] = (prefix.width, prefix.attention_width)
+        shapes[f"{root}.attention.k.weight"] = (prefix.width, prefix.kv_width)
+        shapes[f"{root}.attention.v.weight"] = (prefix.width, prefix.kv_width)
+        shapes[f"{root}.attention.o.weight"] = (prefix.attention_width, prefix.width)
+        shapes[f"{root}.pre_ffw_norm.scale"] = (prefix.width,)
+        shapes[f"{root}.mlp.gate.weight"] = (prefix.width, prefix.mlp_dim)
+        shapes[f"{root}.mlp.up.weight"] = (prefix.width, prefix.mlp_dim)
+        shapes[f"{root}.mlp.down.weight"] = (prefix.mlp_dim, prefix.width)
+    return shapes
+
+
+def validate_prefill_weights(
+    weights: Mapping[str, np.ndarray], profile: OpenPIProfile | str
+) -> None:
+    expected = required_prefill_weight_shapes(profile)
+    missing = sorted(set(expected) - set(weights))
+    shape_errors: list[str] = []
+    dtype_errors: list[str] = []
+    for name, shape in expected.items():
+        if name not in weights:
+            continue
+        value = np.asarray(weights[name])
+        if tuple(value.shape) != shape:
+            shape_errors.append(f"{name}: expected {shape}, got {tuple(value.shape)}")
+        if value.dtype.kind != "f" and value.dtype.name != "bfloat16":
+            dtype_errors.append(f"{name}: expected floating point, got {value.dtype.name}")
+    if missing or shape_errors or dtype_errors:
+        details: list[str] = []
+        if missing:
+            details.append("missing=" + ", ".join(missing))
+        if shape_errors:
+            details.append("shape=" + "; ".join(shape_errors))
+        if dtype_errors:
+            details.append("dtype=" + "; ".join(dtype_errors))
+        raise ValueError("invalid OpenPI prefill weights: " + " | ".join(details))
+
+
+def _shuffle(network, tensor, *, reshape: tuple[int, ...], transpose=None):
+    layer = network.add_shuffle(tensor)
+    if transpose is not None:
+        layer.first_transpose = transpose
+    layer.reshape_dims = reshape
+    return layer.get_output(0)
+
+
+def _rows_to_heads(network, rows, *, heads: int, head_dim: int):
+    batch, sequence, _ = tuple(rows.shape)
+    layer = network.add_shuffle(rows)
+    layer.reshape_dims = (batch, sequence, heads, head_dim)
+    layer.second_transpose = (0, 2, 1, 3)
+    return layer.get_output(0)
+
+
+def _qkv_slice_to_heads(network, tensor, *, batch: int, sequence: int, heads: int, head_dim: int):
+    layer = network.add_shuffle(tensor)
+    layer.reshape_dims = (batch, sequence, heads, head_dim)
+    layer.second_transpose = (0, 2, 1, 3)
+    return layer.get_output(0)
+
+
+def _heads_to_rows(network, heads_tensor):
+    batch, heads, sequence, head_dim = tuple(heads_tensor.shape)
+    layer = network.add_shuffle(heads_tensor)
+    layer.first_transpose = (0, 2, 1, 3)
+    layer.reshape_dims = (batch, sequence, heads * head_dim)
+    return layer.get_output(0)
+
+
+def _heads_to_cache(network, heads_tensor):
+    batch, heads, sequence, head_dim = tuple(heads_tensor.shape)
+    return _shuffle(
+        network,
+        heads_tensor,
+        reshape=(batch, sequence, heads, head_dim),
+        transpose=(0, 2, 1, 3),
+    )
+
+
+def _ranked_constant(network, tensor, value: float, *, dtype, ops):
+    rank = len(tuple(tensor.shape))
+    return ops.constant(
+        network,
+        np.array(value, dtype=np.float32),
+        dtype=dtype,
+        shape=(1,) * rank,
+    )
+
+
+def _install_siglip_stem_timing_cache(
+    builder_config,
+    weights,
+    profile,
+    *,
+    workspace_bytes: int,
+    verbose: bool,
+    ops,
+    trt,
+) -> None:
+    """Seed the production builder with the parity-qualified stem tactic."""
+
+    vision = profile.vision
+    production_shape = (
+        vision.num_image_slots == 3
+        and vision.image_size == 224
+        and vision.patch_size == 14
+        and vision.width == 1152
+        and vision.tokens_per_image == 256
+    )
+    if not production_shape:
+        # Tiny structural tests and future non-production profiles do not use
+        # the GB300 tactic key, whose operation shape is intentionally exact.
+        return
+    version = str(getattr(trt, "__version__", ""))
+    contract = _SIGLIP_STEM_TACTIC_CONTRACT.get(version)
+    if contract is None:
+        raise RuntimeError(
+            "OpenPI SigLIP parity has no validated stem tactic for TensorRT "
+            f"{version or '<unknown>'}; expected one of "
+            f"{sorted(_SIGLIP_STEM_TACTIC_CONTRACT)}"
+        )
+
+    calibration_builder, calibration_network, calibration_config = ops.create_builder_context(
+        verbose=verbose, workspace_bytes=workspace_bytes
+    )
+    calibration_config.clear_flag(trt.BuilderFlag.TF32)
+    calibration_config.set_flag(trt.BuilderFlag.EDITABLE_TIMING_CACHE)
+    calibration_cache = calibration_config.create_timing_cache(b"")
+    if not calibration_config.set_timing_cache(calibration_cache, False):
+        raise RuntimeError("failed to attach OpenPI stem calibration timing cache")
+    image = calibration_network.add_input(
+        "pixel_values",
+        trt.float32,
+        (vision.num_image_slots, 3, vision.image_size, vision.image_size),
+    )
+    convolution = calibration_network.add_convolution_nd(
+        image,
+        vision.width,
+        (vision.patch_size, vision.patch_size),
+        trt.Weights(
+            np.ascontiguousarray(weights["vision.patch_embedding.weight"], dtype=np.float32)
+        ),
+        trt.Weights(np.ascontiguousarray(weights["vision.patch_embedding.bias"], dtype=np.float32)),
+    )
+    convolution.stride_nd = (vision.patch_size, vision.patch_size)
+    output = _shuffle(
+        calibration_network,
+        convolution.get_output(0),
+        reshape=(vision.num_image_slots, vision.tokens_per_image, vision.width),
+        transpose=(0, 2, 3, 1),
+    )
+    output.name = "stem"
+    calibration_network.mark_output(output)
+    calibration_plan = calibration_builder.build_serialized_network(
+        calibration_network, calibration_config
+    )
+    if calibration_plan is None:
+        raise RuntimeError("TensorRT OpenPI stem tactic calibration build failed")
+    populated_cache = calibration_config.get_timing_cache()
+    keys = {str(key) for key in populated_cache.queryKeys()}
+    key_text = str(contract["cache_key"])
+    if key_text not in keys:
+        raise RuntimeError(
+            "TensorRT OpenPI stem timing-cache key drifted: "
+            f"expected {key_text}, observed {sorted(keys)}"
+        )
+
+    production_cache = builder_config.create_timing_cache(bytes(populated_cache.serialize()))
+    key = trt.TimingCacheKey.parse(key_text)
+    tactic_hash = int(contract["tactic_hash"])
+    if not production_cache.update(key, trt.TimingCacheValue(tactic_hash, 0.0)):
+        raise RuntimeError(f"failed to select OpenPI stem tactic {tactic_hash:#x} for {key_text}")
+    builder_config.set_flag(trt.BuilderFlag.EDITABLE_TIMING_CACHE)
+    if not builder_config.set_timing_cache(production_cache, False):
+        raise RuntimeError("failed to attach parity-qualified OpenPI timing cache")
+
+
+def _openpi_plugin_creator(name: str, *, trt):
+    """Find an OpenPI creator through the deterministic build-time loader."""
+
+    return require_openpi_plugin_creator(name, trt=trt)
+
+
+def _create_openpi_rms_norm_plugin(*, epsilon: float, trt):
+    """Create the family-owned TensorRT plugin used by production Gemma."""
+
+    creator = _openpi_plugin_creator("OpenPIRmsNorm", trt=trt)
+    epsilon_value = np.asarray([epsilon], dtype=np.float32)
+    fields = trt.PluginFieldCollection(
+        [trt.PluginField("epsilon", epsilon_value, trt.PluginFieldType.FLOAT32)]
+    )
+    plugin = creator.create_plugin("openpi_gemma_rms_norm", fields, trt.TensorRTPhase.BUILD)
+    if plugin is None:
+        raise RuntimeError("failed to create the OpenPI RMSNorm TensorRT plugin")
+    return plugin
+
+
+def _create_openpi_siglip_layer_norm_plugin(*, epsilon: float, trt):
+    """Create the fixed-shape SigLIP LayerNorm production plugin."""
+
+    if epsilon != 1.0e-6:
+        raise ValueError("OpenPI SigLIP LayerNorm plugin requires epsilon=1e-6")
+    creator = _openpi_plugin_creator("OpenPISiglipLayerNorm", trt=trt)
+    epsilon_value = np.asarray([epsilon], dtype=np.float32)
+    fields = trt.PluginFieldCollection(
+        [trt.PluginField("epsilon", epsilon_value, trt.PluginFieldType.FLOAT32)]
+    )
+    plugin = creator.create_plugin(
+        "openpi_siglip_layer_norm",
+        fields,
+        trt.TensorRTPhase.BUILD,
+    )
+    if plugin is None:
+        raise RuntimeError("failed to create the OpenPI SigLIP LayerNorm TensorRT plugin")
+    return plugin
+
+
+def _apply_siglip_layer_norm_plugin(
+    network,
+    tensor,
+    weight,
+    bias,
+    *,
+    epsilon: float,
+    name: str,
+    ops,
+    trt,
+):
+    """Apply the exact fixed-shape BF16 SigLIP LayerNorm production seam."""
+
+    if epsilon != 1.0e-6:
+        raise ValueError("OpenPI SigLIP LayerNorm plugin requires epsilon=1e-6")
+    if tensor.dtype != trt.bfloat16 or tuple(tensor.shape) != (1, 256, 1152):
+        raise ValueError("OpenPI SigLIP LayerNorm plugin requires BF16 activation [1,256,1152]")
+    gamma_value = np.asarray(weight, dtype=np.float32)
+    beta_value = np.asarray(bias, dtype=np.float32)
+    if gamma_value.shape != (1152,) or beta_value.shape != (1152,):
+        raise ValueError("OpenPI SigLIP LayerNorm plugin requires gamma/beta [1152]")
+    if not name:
+        raise ValueError("OpenPI SigLIP LayerNorm plugin requires a deterministic layer name")
+    gamma = ops.constant(network, gamma_value, dtype=trt.bfloat16)
+    beta = ops.constant(network, beta_value, dtype=trt.bfloat16)
+    layer = network.add_plugin_v3(
+        [tensor, gamma, beta],
+        [],
+        _create_openpi_siglip_layer_norm_plugin(epsilon=epsilon, trt=trt),
+    )
+    layer.name = name
+    return layer.get_output(0)
+
+
+def _create_openpi_siglip_attention_residual_plugin(*, trt):
+    """Create the fixed-shape exact SigLIP attention-residual plugin."""
+
+    creator = _openpi_plugin_creator("OpenPISiglipAttentionResidual", trt=trt)
+    plugin = creator.create_plugin(
+        "openpi_siglip_attention_residual",
+        trt.PluginFieldCollection([]),
+        trt.TensorRTPhase.BUILD,
+    )
+    if plugin is None:
+        raise RuntimeError("failed to create the OpenPI SigLIP attention-residual TensorRT plugin")
+    return plugin
+
+
+def _apply_siglip_attention_residual_plugin(
+    network,
+    hidden,
+    norm_weight,
+    norm_bias,
+    qkv_weight,
+    qkv_bias,
+    output_weight,
+    output_bias,
+    *,
+    name: str,
+    ops,
+    trt,
+):
+    """Apply the pinned BF16 SigLIP attention and its first residual add."""
+
+    if hidden.dtype != trt.bfloat16 or tuple(hidden.shape) != (1, 256, 1152):
+        raise ValueError(
+            "OpenPI SigLIP attention-residual plugin requires BF16 hidden [1,256,1152]"
+        )
+    arrays = (
+        np.asarray(norm_weight, dtype=np.float32),
+        np.asarray(norm_bias, dtype=np.float32),
+        np.asarray(qkv_weight, dtype=np.float32),
+        np.asarray(qkv_bias, dtype=np.float32),
+        np.asarray(output_weight, dtype=np.float32),
+        np.asarray(output_bias, dtype=np.float32),
+    )
+    expected_shapes = (
+        (1152,),
+        (1152,),
+        (1152, 3456),
+        (3456,),
+        (1152, 1152),
+        (1152,),
+    )
+    if tuple(value.shape for value in arrays) != expected_shapes:
+        raise ValueError(
+            "OpenPI SigLIP attention-residual plugin requires norm [1152], "
+            "QKV weight/bias [1152,3456]/[3456], and output weight/bias "
+            "[1152,1152]/[1152]"
+        )
+    if not name:
+        raise ValueError(
+            "OpenPI SigLIP attention-residual plugin requires a deterministic layer name"
+        )
+    constants = [ops.constant(network, value, dtype=trt.bfloat16) for value in arrays]
+    layer = network.add_plugin_v3(
+        [hidden, *constants],
+        [],
+        _create_openpi_siglip_attention_residual_plugin(trt=trt),
+    )
+    layer.name = name
+    return layer.get_output(0)
+
+
+def _uses_siglip_attention_residual_plugin(hidden, cfg, *, trt) -> bool:
+    """Gate the production plugin to its audited fixed geometry."""
+
+    return (
+        hidden.dtype == trt.bfloat16
+        and tuple(hidden.shape) == (1, 256, 1152)
+        and cfg.tokens_per_image == 256
+        and cfg.width == 1152
+        and cfg.num_heads == 16
+        and cfg.width // cfg.num_heads == 72
+    )
+
+
+def _create_openpi_rope_plugin(*, trt):
+    creator = _openpi_plugin_creator("OpenPIRopeQK", trt=trt)
+    plugin = creator.create_plugin(
+        "openpi_gemma_rope_qk",
+        trt.PluginFieldCollection([]),
+        trt.TensorRTPhase.BUILD,
+    )
+    if plugin is None:
+        raise RuntimeError("failed to create the OpenPI RoPE TensorRT plugin")
+    return plugin
+
+
+def _create_openpi_prefix_qk_plugin(*, trt):
+    creator = _openpi_plugin_creator("OpenPIPrefixQK", trt=trt)
+    plugin = creator.create_plugin(
+        "openpi_gemma_prefix_qk",
+        trt.PluginFieldCollection([]),
+        trt.TensorRTPhase.BUILD,
+    )
+    if plugin is None:
+        raise RuntimeError("failed to create the OpenPI prefix-QK TensorRT plugin")
+    return plugin
+
+
+def _create_openpi_prefix_softmax_plugin(*, trt):
+    creator = _openpi_plugin_creator("OpenPIPrefixSoftmax", trt=trt)
+    plugin = creator.create_plugin(
+        "openpi_gemma_prefix_softmax",
+        trt.PluginFieldCollection([]),
+        trt.TensorRTPhase.BUILD,
+    )
+    if plugin is None:
+        raise RuntimeError("failed to create the OpenPI prefix-softmax TensorRT plugin")
+    return plugin
+
+
+def _apply_prefix_qk(network, query, key, *, trt):
+    """Issue XLA's flattened BF16-to-FP32 cuBLAS prefix contraction."""
+
+    if (
+        query.dtype == trt.bfloat16
+        and key.dtype == trt.bfloat16
+        and tuple(query.shape) == (1, 8, 968, 256)
+        and tuple(key.shape) == (1, 1, 968, 256)
+    ):
+        plugin = _create_openpi_prefix_qk_plugin(trt=trt)
+        raw_logits = network.add_plugin_v3([query, key], [], plugin).get_output(0)
+        # The plugin exposes cuBLAS column-major [H*S,S] bytes as row-major
+        # [S,S,H]. This shuffle is XLA's post-GEMM logical transpose.
+        return _shuffle(
+            network,
+            raw_logits,
+            reshape=(1, 8, 968, 968),
+            transpose=(0, 3, 2, 1),
+        )
+    return None
+
+
+def _apply_prefix_softmax(network, logits, attention_mask, *, trt):
+    """Issue XLA's exact family-owned prefix softmax."""
+
+    if (
+        logits.dtype == trt.float32
+        and attention_mask is not None
+        and attention_mask.dtype == trt.bool
+        and tuple(logits.shape) == (1, 8, 968, 968)
+        and tuple(attention_mask.shape) == (1, 1, 968, 968)
+    ):
+        plugin = _create_openpi_prefix_softmax_plugin(trt=trt)
+        return network.add_plugin_v3([logits, attention_mask], [], plugin).get_output(0)
+    return None
+
+
+def _apply_prefix_rope_qk(network, query, key, position_ids, *, profile, ops, trt):
+    if (
+        query.dtype == trt.bfloat16
+        and key.dtype == trt.bfloat16
+        and tuple(query.shape) == (1, 8, 968, 256)
+        and tuple(key.shape) == (1, 1, 968, 256)
+        and tuple(position_ids.shape) == (1, 968)
+    ):
+        plugin = _create_openpi_rope_plugin(trt=trt)
+        layer = network.add_plugin_v3([query, key, position_ids], [], plugin)
+        return layer.get_output(0), layer.get_output(1)
+
+    max_positions = profile.prefix_length + profile.action_horizon
+    query = ops.apply_rope(
+        network,
+        query,
+        position_ids,
+        max_positions=max_positions,
+        head_dim=profile.prefix.head_dim,
+    )
+    key = ops.apply_rope(
+        network,
+        key,
+        position_ids,
+        max_positions=max_positions,
+        head_dim=profile.prefix.head_dim,
+    )
+    return query, key
+
+
+def _rms_norm_fp32(network, tensor, scale, *, epsilon: float, ops, trt):
+    scale_value = np.asarray(scale, dtype=np.float32)
+    if (
+        tensor.dtype == trt.bfloat16
+        and len(tuple(tensor.shape)) >= 2
+        and tuple(tensor.shape)[-1] == 2048
+        and scale_value.shape == (2048,)
+    ):
+        scale_tensor = ops.constant(
+            network,
+            scale_value,
+            dtype=trt.bfloat16,
+            shape=(2048,),
+        )
+        plugin = _create_openpi_rms_norm_plugin(epsilon=epsilon, trt=trt)
+        return network.add_plugin_v3([tensor, scale_tensor], [], plugin).get_output(0)
+
+    output_dtype = tensor.dtype
+    x = ops.cast(network, tensor, trt.float32)
+    axes = 1 << (len(tuple(x.shape)) - 1)
+    square = network.add_elementwise(x, x, trt.ElementWiseOperation.PROD).get_output(0)
+    variance = network.add_reduce(square, trt.ReduceOperation.AVG, axes, True).get_output(0)
+    epsilon_tensor = _ranked_constant(network, variance, epsilon, dtype=trt.float32, ops=ops)
+    denominator = network.add_elementwise(
+        variance, epsilon_tensor, trt.ElementWiseOperation.SUM
+    ).get_output(0)
+    denominator = network.add_unary(denominator, trt.UnaryOperation.SQRT).get_output(0)
+    denominator = network.add_unary(denominator, trt.UnaryOperation.RECIP).get_output(0)
+    normalized = network.add_elementwise(x, denominator, trt.ElementWiseOperation.PROD).get_output(
+        0
+    )
+    gamma_shape = (1,) * (len(tuple(x.shape)) - 1) + (scale_value.size,)
+    gamma = ops.constant(network, scale_value, dtype=output_dtype, shape=gamma_shape)
+    one = _ranked_constant(network, gamma, 1.0, dtype=output_dtype, ops=ops)
+    gamma = network.add_elementwise(gamma, one, trt.ElementWiseOperation.SUM).get_output(0)
+    gamma = ops.cast(network, gamma, trt.float32)
+    normalized = network.add_elementwise(
+        normalized, gamma, trt.ElementWiseOperation.PROD
+    ).get_output(0)
+    return ops.cast(network, normalized, output_dtype)
+
+
+def _gelu_tanh(network, tensor, *, ops, trt):
+    """JAX's tanh GELU evaluated in the input activation dtype."""
+
+    if tensor.dtype == trt.bfloat16:
+        # TensorRT fuses the nominally BF16 pointwise chain and retains FP32
+        # intermediates across operations. Pinned XLA rounds after every BF16
+        # operation. Express those boundaries as observable FP32 -> BF16 ->
+        # FP32 casts so TensorRT cannot legally reassociate them. This makes
+        # the complete SigLIP FC1 -> GELU -> FC2 subgraph bit-exact while
+        # retaining direct TensorRT layers and a BF16 public activation type.
+        def rounded(value):
+            return ops.cast(
+                network,
+                ops.cast(network, value, trt.bfloat16),
+                trt.float32,
+            )
+
+        def constant_like(value, scalar: float):
+            bf16_value = _ranked_constant(
+                network,
+                value,
+                scalar,
+                dtype=trt.bfloat16,
+                ops=ops,
+            )
+            return ops.cast(network, bf16_value, trt.float32)
+
+        x = ops.cast(network, tensor, trt.float32)
+        x2 = rounded(network.add_elementwise(x, x, trt.ElementWiseOperation.PROD).get_output(0))
+        x3 = rounded(network.add_elementwise(x2, x, trt.ElementWiseOperation.PROD).get_output(0))
+        cubic = rounded(
+            network.add_elementwise(
+                x3,
+                constant_like(x3, 0.044715),
+                trt.ElementWiseOperation.PROD,
+            ).get_output(0)
+        )
+        inner = rounded(
+            network.add_elementwise(x, cubic, trt.ElementWiseOperation.SUM).get_output(0)
+        )
+        inner = rounded(
+            network.add_elementwise(
+                inner,
+                constant_like(inner, math.sqrt(2.0 / math.pi)),
+                trt.ElementWiseOperation.PROD,
+            ).get_output(0)
+        )
+        tanh = rounded(network.add_activation(inner, trt.ActivationType.TANH).get_output(0))
+        factor = rounded(
+            network.add_elementwise(
+                tanh,
+                constant_like(tanh, 1.0),
+                trt.ElementWiseOperation.SUM,
+            ).get_output(0)
+        )
+        factor = rounded(
+            network.add_elementwise(
+                factor,
+                constant_like(factor, 0.5),
+                trt.ElementWiseOperation.PROD,
+            ).get_output(0)
+        )
+        output = rounded(
+            network.add_elementwise(x, factor, trt.ElementWiseOperation.PROD).get_output(0)
+        )
+        return ops.cast(network, output, trt.bfloat16)
+
+    x = tensor
+    dtype = tensor.dtype
+    x2 = network.add_elementwise(x, x, trt.ElementWiseOperation.PROD).get_output(0)
+    x3 = network.add_elementwise(x2, x, trt.ElementWiseOperation.PROD).get_output(0)
+    cubic_scale = _ranked_constant(network, x3, 0.044715, dtype=dtype, ops=ops)
+    cubic = network.add_elementwise(x3, cubic_scale, trt.ElementWiseOperation.PROD).get_output(0)
+    inner = network.add_elementwise(x, cubic, trt.ElementWiseOperation.SUM).get_output(0)
+    root_scale = _ranked_constant(network, inner, math.sqrt(2.0 / math.pi), dtype=dtype, ops=ops)
+    inner = network.add_elementwise(inner, root_scale, trt.ElementWiseOperation.PROD).get_output(0)
+    tanh = network.add_activation(inner, trt.ActivationType.TANH).get_output(0)
+    one = _ranked_constant(network, tanh, 1.0, dtype=dtype, ops=ops)
+    factor = network.add_elementwise(tanh, one, trt.ElementWiseOperation.SUM).get_output(0)
+    half = _ranked_constant(network, factor, 0.5, dtype=dtype, ops=ops)
+    factor = network.add_elementwise(factor, half, trt.ElementWiseOperation.PROD).get_output(0)
+    return network.add_elementwise(x, factor, trt.ElementWiseOperation.PROD).get_output(0)
+
+
+def _softmax_attention(
+    network,
+    q,
+    k,
+    v,
+    mask,
+    *,
+    head_dim: int,
+    fp32_logits: bool,
+    scale_with_division: bool,
+    use_einsum: bool = False,
+    ops,
+    trt,
+):
+    """Attention with the exact dtype and query scaling used upstream."""
+
+    q_dtype = q.dtype
+    use_siglip_bf16_scaling = use_einsum and q_dtype == trt.bfloat16 and not fp32_logits
+    if scale_with_division and use_siglip_bf16_scaling:
+        # Pinned XLA strength-reduces BF16 division by sqrt(head_dim) to a
+        # rounded reciprocal multiply. A TensorRT elementwise layer is folded
+        # into QK and retains extra precision. A scalar native einsum is the
+        # smallest direct-TRT contraction that preserves the BF16 boundary.
+        scale = ops.constant(
+            network,
+            np.asarray([1.0 / math.sqrt(head_dim)], dtype=np.float32),
+            dtype=q_dtype,
+        )
+        q = network.add_einsum([q, scale], "bhqd,z->bhqd").get_output(0)
+    elif scale_with_division:
+        scale = _ranked_constant(network, q, math.sqrt(head_dim), dtype=q_dtype, ops=ops)
+        q = network.add_elementwise(q, scale, trt.ElementWiseOperation.DIV).get_output(0)
+    else:
+        scale = _ranked_constant(network, q, 1.0 / math.sqrt(head_dim), dtype=q_dtype, ops=ops)
+        q = network.add_elementwise(q, scale, trt.ElementWiseOperation.PROD).get_output(0)
+    logits = _apply_prefix_qk(network, q, k, trt=trt) if fp32_logits else None
+    if logits is None:
+        query = ops.cast(network, q, trt.float32) if fp32_logits else q
+        key = ops.cast(network, k, trt.float32) if fp32_logits else k
+        if use_einsum:
+            logits = network.add_einsum([query, key], "bhqd,bhkd->bhqk").get_output(0)
+        else:
+            logits = network.add_matrix_multiply(
+                query, trt.MatrixOperation.NONE, key, trt.MatrixOperation.TRANSPOSE
+            ).get_output(0)
+    prefix_probabilities = (
+        _apply_prefix_softmax(network, logits, mask, trt=trt) if fp32_logits else None
+    )
+    if mask is not None and prefix_probabilities is None:
+        negative = _ranked_constant(network, logits, -2.3819763e38, dtype=logits.dtype, ops=ops)
+        logits = network.add_select(mask, logits, negative).get_output(0)
+    softmax_axes = 1 << (len(tuple(logits.shape)) - 1)
+    if prefix_probabilities is not None:
+        probabilities = prefix_probabilities
+    else:
+        # TensorRT's native BF16 softmax is bit-exact with the pinned XLA
+        # result in the complete SigLIP attention graph. The Gemma prefix
+        # shape above instead needs its family-owned exact reduction plugin.
+        softmax = network.add_softmax(logits)
+        softmax.axes = softmax_axes
+        probabilities = ops.cast(network, softmax.get_output(0), q_dtype)
+    if use_einsum:
+        context = network.add_einsum([probabilities, v], "bhqk,bhkd->bhqd").get_output(0)
+    else:
+        context = network.add_matrix_multiply(
+            probabilities,
+            trt.MatrixOperation.NONE,
+            v,
+            trt.MatrixOperation.NONE,
+        ).get_output(0)
+    return _heads_to_rows(network, context)
+
+
+def _prefix_attention_mask(network, prefix_mask, *, sequence: int, trt):
+    query_mask = _shuffle(network, prefix_mask, reshape=(1, 1, sequence, 1))
+    key_mask = _shuffle(network, prefix_mask, reshape=(1, 1, 1, sequence))
+    return network.add_elementwise(query_mask, key_mask, trt.ElementWiseOperation.AND).get_output(0)
+
+
+def _einsum_linear_3d(network, tensor, weight, bias, *, ops):
+    """Apply Flax/JAX ``bsi,io->bso`` with TensorRT's native einsum layer."""
+    weight_value = np.asarray(weight)
+    if len(tuple(tensor.shape)) != 3 or weight_value.ndim != 2:
+        raise ValueError("OpenPI SigLIP einsum linear requires rank-3 input and rank-2 weight")
+    rhs = ops.constant(network, weight_value, dtype=tensor.dtype)
+    output = network.add_einsum([tensor, rhs], "bsi,io->bso").get_output(0)
+    if bias is not None:
+        bias_value = ops.constant(
+            network,
+            np.asarray(bias).reshape(1, 1, weight_value.shape[1]),
+            dtype=tensor.dtype,
+        )
+        output = network.add_elementwise(
+            output, bias_value, ops.trt.ElementWiseOperation.SUM
+        ).get_output(0)
+    return output
+
+
+def _vision_transformer_camera(
+    network,
+    hidden,
+    weights,
+    cfg,
+    *,
+    camera_index,
+    activation_dtype,
+    ops,
+    trt,
+):
+    """Run one SigLIP camera exactly as the pinned OpenPI image loop does."""
+
+    if not isinstance(camera_index, int) or not 0 <= camera_index < cfg.num_image_slots:
+        raise ValueError(f"invalid OpenPI SigLIP camera index {camera_index!r}")
+    head_dim = cfg.width // cfg.num_heads
+    for layer in range(cfg.depth):
+        root = f"vision.layer.{layer}"
+        # XLA folds the three Flax DenseGeneral projections into one
+        # [tokens,width] @ [width,3*width] BF16 GEMM. Keep each camera at
+        # M=tokens: upstream calls PaliGemma.img independently for every image,
+        # and flattening the three cameras to M=3*tokens selects a different
+        # reduction tactic with measurable BF16 drift.
+        qkv_weight = np.concatenate(
+            [np.asarray(weights[f"{root}.attention.{name}.weight"]) for name in ("q", "k", "v")],
+            axis=1,
+        )
+        qkv_bias = np.concatenate(
+            [np.asarray(weights[f"{root}.attention.{name}.bias"]) for name in ("q", "k", "v")],
+            axis=0,
+        )
+        if _uses_siglip_attention_residual_plugin(hidden, cfg, trt=trt):
+            hidden = _apply_siglip_attention_residual_plugin(
+                network,
+                hidden,
+                weights[f"{root}.norm1.weight"],
+                weights[f"{root}.norm1.bias"],
+                qkv_weight,
+                qkv_bias,
+                weights[f"{root}.attention.o.weight"],
+                weights[f"{root}.attention.o.bias"],
+                name=(f"openpi/siglip/camera_{camera_index}/layer_{layer:02d}/attention_residual"),
+                ops=ops,
+                trt=trt,
+            )
+        else:
+            normed = _apply_siglip_layer_norm_plugin(
+                network,
+                hidden,
+                weights[f"{root}.norm1.weight"],
+                weights[f"{root}.norm1.bias"],
+                epsilon=1e-6,
+                name=f"openpi/siglip/camera_{camera_index}/layer_{layer:02d}/norm1",
+                ops=ops,
+                trt=trt,
+            )
+            qkv_rhs = ops.constant(
+                network,
+                qkv_weight.reshape(cfg.width, 3, cfg.num_heads, head_dim),
+                dtype=activation_dtype,
+            )
+            qkv = network.add_einsum([normed, qkv_rhs], "bsi,iqhd->bsqhd").get_output(0)
+            qkv_bias_value = ops.constant(
+                network,
+                qkv_bias.reshape(1, 1, 3, cfg.num_heads, head_dim),
+                dtype=activation_dtype,
+            )
+            qkv = network.add_elementwise(
+                qkv, qkv_bias_value, trt.ElementWiseOperation.SUM
+            ).get_output(0)
+            projections = []
+            for projection in range(3):
+                value = network.add_slice(
+                    qkv,
+                    (0, 0, projection, 0, 0),
+                    (1, cfg.tokens_per_image, 1, cfg.num_heads, head_dim),
+                    (1, 1, 1, 1, 1),
+                ).get_output(0)
+                projections.append(
+                    _qkv_slice_to_heads(
+                        network,
+                        value,
+                        batch=1,
+                        sequence=cfg.tokens_per_image,
+                        heads=cfg.num_heads,
+                        head_dim=head_dim,
+                    )
+                )
+            attended = _softmax_attention(
+                network,
+                *projections,
+                None,
+                head_dim=head_dim,
+                fp32_logits=False,
+                scale_with_division=True,
+                use_einsum=True,
+                ops=ops,
+                trt=trt,
+            )
+            attended = _einsum_linear_3d(
+                network,
+                attended,
+                weights[f"{root}.attention.o.weight"],
+                weights[f"{root}.attention.o.bias"],
+                ops=ops,
+            )
+            hidden = ops.gated_residual(network, hidden, attended)
+
+        normed = _apply_siglip_layer_norm_plugin(
+            network,
+            hidden,
+            weights[f"{root}.norm2.weight"],
+            weights[f"{root}.norm2.bias"],
+            epsilon=1e-6,
+            name=f"openpi/siglip/camera_{camera_index}/layer_{layer:02d}/norm2",
+            ops=ops,
+            trt=trt,
+        )
+        mlp = _einsum_linear_3d(
+            network,
+            normed,
+            weights[f"{root}.mlp.fc1.weight"],
+            weights[f"{root}.mlp.fc1.bias"],
+            ops=ops,
+        )
+        mlp = _gelu_tanh(network, mlp, ops=ops, trt=trt)
+        mlp = _einsum_linear_3d(
+            network,
+            mlp,
+            weights[f"{root}.mlp.fc2.weight"],
+            weights[f"{root}.mlp.fc2.bias"],
+            ops=ops,
+        )
+        hidden = ops.gated_residual(network, hidden, mlp)
+
+    hidden = _apply_siglip_layer_norm_plugin(
+        network,
+        hidden,
+        weights["vision.post_norm.weight"],
+        weights["vision.post_norm.bias"],
+        epsilon=1e-6,
+        name=f"openpi/siglip/camera_{camera_index}/post_norm",
+        ops=ops,
+        trt=trt,
+    )
+    return _einsum_linear_3d(
+        network,
+        hidden,
+        weights["vision.projector.weight"],
+        weights["vision.projector.bias"],
+        ops=ops,
+    )
+
+
+def _vision_encoder(
+    network,
+    pixel_values,
+    weights,
+    profile,
+    *,
+    activation_dtype,
+    ops,
+    trt,
+):
+    cfg = profile.vision
+    patch_weight = np.ascontiguousarray(weights["vision.patch_embedding.weight"], dtype=np.float32)
+    patch_bias = np.ascontiguousarray(weights["vision.patch_embedding.bias"], dtype=np.float32)
+    conv = network.add_convolution_nd(
+        pixel_values,
+        cfg.width,
+        (cfg.patch_size, cfg.patch_size),
+        trt.Weights(patch_weight),
+        trt.Weights(patch_bias),
+    )
+    conv.stride_nd = (cfg.patch_size, cfg.patch_size)
+    hidden = _shuffle(
+        network,
+        conv.get_output(0),
+        reshape=(cfg.num_image_slots, cfg.tokens_per_image, cfg.width),
+        transpose=(0, 2, 3, 1),
+    )
+    position = ops.constant(
+        network,
+        np.asarray(weights["vision.position_embedding"], dtype=np.float32).reshape(
+            1, cfg.tokens_per_image, cfg.width
+        ),
+        dtype=trt.float32,
+    )
+    hidden = network.add_elementwise(hidden, position, trt.ElementWiseOperation.SUM).get_output(0)
+    hidden = ops.cast(network, hidden, activation_dtype)
+
+    camera_outputs = []
+    for camera in range(cfg.num_image_slots):
+        camera_hidden = network.add_slice(
+            hidden,
+            (camera, 0, 0),
+            (1, cfg.tokens_per_image, cfg.width),
+            (1, 1, 1),
+        ).get_output(0)
+        camera_outputs.append(
+            _vision_transformer_camera(
+                network,
+                camera_hidden,
+                weights,
+                cfg,
+                camera_index=camera,
+                activation_dtype=activation_dtype,
+                ops=ops,
+                trt=trt,
+            )
+        )
+
+    concatenation = network.add_concatenation(camera_outputs)
+    concatenation.axis = 0
+    return _shuffle(
+        network,
+        concatenation.get_output(0),
+        reshape=(1, cfg.num_image_slots * cfg.tokens_per_image, cfg.output_width),
+    )
+
+
+def _prompt_embeddings(network, token_ids, weights, profile, *, activation_dtype, ops, trt):
+    cfg = profile.prefix
+    embedding = ops.constant(
+        network,
+        np.asarray(weights["prefix.embedding"], dtype=np.float32),
+        dtype=activation_dtype,
+    )
+    hidden = network.add_gather(embedding, token_ids, 0).get_output(0)
+    scale = _ranked_constant(network, hidden, math.sqrt(cfg.width), dtype=activation_dtype, ops=ops)
+    hidden = network.add_elementwise(hidden, scale, trt.ElementWiseOperation.PROD).get_output(0)
+    return hidden
+
+
+def _prefix_expert(
+    network,
+    hidden,
+    prefix_mask,
+    position_ids,
+    weights,
+    profile,
+    *,
+    ops,
+    trt,
+):
+    cfg = profile.prefix
+    attention_mask = _prefix_attention_mask(
+        network, prefix_mask, sequence=profile.prefix_length, trt=trt
+    )
+    caches = []
+    for layer in range(cfg.depth):
+        root = f"prefix.layer.{layer}"
+        normed = _rms_norm_fp32(
+            network,
+            hidden,
+            weights[f"{root}.pre_attention_norm.scale"],
+            epsilon=profile.rms_norm_epsilon,
+            ops=ops,
+            trt=trt,
+        )
+        q = ops.linear(network, normed, weights[f"{root}.attention.q.weight"])
+        k = ops.linear(network, normed, weights[f"{root}.attention.k.weight"])
+        v = ops.linear(network, normed, weights[f"{root}.attention.v.weight"])
+        q = _rows_to_heads(network, q, heads=cfg.num_heads, head_dim=cfg.head_dim)
+        k = _rows_to_heads(network, k, heads=cfg.num_kv_heads, head_dim=cfg.head_dim)
+        v = _rows_to_heads(network, v, heads=cfg.num_kv_heads, head_dim=cfg.head_dim)
+        q, k = _apply_prefix_rope_qk(
+            network,
+            q,
+            k,
+            position_ids,
+            profile=profile,
+            ops=ops,
+            trt=trt,
+        )
+        cache_k = _heads_to_cache(network, k)
+        cache_v = _heads_to_cache(network, v)
+        caches.append((cache_k, cache_v))
+
+        attended = _softmax_attention(
+            network,
+            q,
+            k,
+            v,
+            attention_mask,
+            head_dim=cfg.head_dim,
+            fp32_logits=True,
+            scale_with_division=False,
+            ops=ops,
+            trt=trt,
+        )
+        attended = ops.linear(network, attended, weights[f"{root}.attention.o.weight"])
+        hidden = ops.gated_residual(network, hidden, attended)
+
+        normed = _rms_norm_fp32(
+            network,
+            hidden,
+            weights[f"{root}.pre_ffw_norm.scale"],
+            epsilon=profile.rms_norm_epsilon,
+            ops=ops,
+            trt=trt,
+        )
+        gate = ops.linear(network, normed, weights[f"{root}.mlp.gate.weight"])
+        gate = _gelu_tanh(network, gate, ops=ops, trt=trt)
+        up = ops.linear(network, normed, weights[f"{root}.mlp.up.weight"])
+        mlp = network.add_elementwise(gate, up, trt.ElementWiseOperation.PROD).get_output(0)
+        mlp = ops.linear(network, mlp, weights[f"{root}.mlp.down.weight"])
+        hidden = ops.gated_residual(network, hidden, mlp)
+
+    _ = _rms_norm_fp32(
+        network,
+        hidden,
+        weights["prefix.final_norm.scale"],
+        epsilon=profile.rms_norm_epsilon,
+        ops=ops,
+        trt=trt,
+    )
+    return caches
+
+
+def build_prefill_engine(
+    weights: Mapping[str, np.ndarray],
+    profile: OpenPIProfile | str,
+    *,
+    precision: str = "bf16",
+    workspace_bytes: int = 1 << 32,
+    verbose: bool = False,
+) -> bytes:
+    """Build the fixed-shape OpenPI prefill plan with direct TensorRT APIs."""
+
+    cfg = get_profile(profile) if isinstance(profile, str) else profile
+    validate_prefill_weights(weights, cfg)
+
+    # Kept lazy so config inspection and reference tests do not require a
+    # TensorRT installation on the host.
+    from . import graph_ops as ops
+
+    trt = ops.trt
+    _constant_dtype, activation_dtype = ops.precision_types(precision)
+    builder, network, builder_config = ops.create_builder_context(
+        verbose=verbose, workspace_bytes=workspace_bytes
+    )
+    # Flax promotes the BF16 SigLIP patch kernel to FP32, and pinned XLA/cuDNN
+    # evaluates that convolution with IEEE FP32 products. TensorRT's default
+    # TF32 mode changes enough stem values to cross BF16 rounding boundaries,
+    # so disable TF32 for this parity-qualified prefill plan.
+    builder_config.clear_flag(trt.BuilderFlag.TF32)
+    _install_siglip_stem_timing_cache(
+        builder_config,
+        weights,
+        cfg,
+        workspace_bytes=workspace_bytes,
+        verbose=verbose,
+        ops=ops,
+        trt=trt,
+    )
+    contracts = prefill_input_contract(cfg)
+    pixel_values = network.add_input(contracts[0].name, trt.float32, contracts[0].shape)
+    token_ids = network.add_input(contracts[1].name, trt.int32, contracts[1].shape)
+    prefix_mask = network.add_input(contracts[2].name, trt.bool, contracts[2].shape)
+    position_ids = network.add_input(contracts[3].name, trt.int32, contracts[3].shape)
+
+    vision_tokens = _vision_encoder(
+        network,
+        pixel_values,
+        weights,
+        cfg,
+        activation_dtype=activation_dtype,
+        ops=ops,
+        trt=trt,
+    )
+    # This output is always present so a runtime can bind a persistent device
+    # buffer without rebuilding or switching plans for qualification. Normal
+    # inference never copies it to the host. Adding it changes the serialized
+    # engine contract, so existing production prefill plans must be rebuilt.
+    vision_output = _shuffle(
+        network,
+        vision_tokens,
+        reshape=(
+            1,
+            cfg.vision.num_image_slots,
+            cfg.vision.tokens_per_image,
+            cfg.vision.output_width,
+        ),
+    )
+    vision_output.name = "vision_tokens"
+    network.mark_output(vision_output)
+    prompt_tokens = _prompt_embeddings(
+        network,
+        token_ids,
+        weights,
+        cfg,
+        activation_dtype=activation_dtype,
+        ops=ops,
+        trt=trt,
+    )
+    concat = network.add_concatenation([vision_tokens, prompt_tokens])
+    concat.axis = 1
+    prefix_hidden = concat.get_output(0)
+    caches = _prefix_expert(
+        network,
+        prefix_hidden,
+        prefix_mask,
+        position_ids,
+        weights,
+        cfg,
+        ops=ops,
+        trt=trt,
+    )
+    for layer, (cache_k, cache_v) in enumerate(caches):
+        for kind, cache in (("k", cache_k), ("v", cache_v)):
+            cache.name = prefix_cache_output_name(kind, layer)
+            network.mark_output(cache)
+
+    plan = builder.build_serialized_network(network, builder_config)
+    if plan is None:
+        raise RuntimeError("TensorRT OpenPI prefill engine build failed")
+    return bytes(plan)

--- a/python/tensorrt_model_connect/families/openpi/prepare_model_dir.py
+++ b/python/tensorrt_model_connect/families/openpi/prepare_model_dir.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Convert a pinned OpenPI checkpoint into a reproducible TRTMC build directory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from .checkpoint_reader import file_sha256, open_checkpoint
+from .model_config import (
+    OPENPI_MODEL_TYPE,
+    OPENPI_UPSTREAM_COMMIT,
+    get_profile,
+    profile_names,
+)
+from .tokenizer_export import export_paligemma_bpe_model
+from .weight_mapper import MappingRule, map_weights
+
+
+_MARKER_NAME = ".trtmc-openpi-model-dir"
+_MARKER_CONTENT = "trtmc.openpi.prepared.v1\n"
+
+
+def _validate_regular_file(path: str | Path, description: str) -> Path:
+    resolved = Path(path).expanduser().resolve()
+    if not resolved.is_file():
+        raise FileNotFoundError(f"{description} does not exist or is not a file: {resolved}")
+    if resolved.stat().st_size == 0:
+        raise ValueError(f"{description} is empty: {resolved}")
+    return resolved
+
+
+def _load_and_validate_norm_stats(path: Path, *, state_dim: int, action_dim: int) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"normalization statistics are not valid JSON: {path}") from exc
+    stats = payload.get("norm_stats") if isinstance(payload, dict) else None
+    if not isinstance(stats, dict):
+        raise ValueError("normalization statistics must contain a norm_stats object")
+    for field, minimum_dim in (("state", state_dim), ("actions", action_dim)):
+        entry = stats.get(field)
+        if not isinstance(entry, dict):
+            raise ValueError(f"normalization statistics are missing {field!r}")
+        q01 = entry.get("q01")
+        q99 = entry.get("q99")
+        if not isinstance(q01, list) or not isinstance(q99, list):
+            raise ValueError(f"quantile normalization requires q01/q99 arrays for {field!r}")
+        if len(q01) < minimum_dim or len(q99) < minimum_dim:
+            raise ValueError(
+                f"normalization field {field!r} has fewer than {minimum_dim} dimensions"
+            )
+        for index, (low, high) in enumerate(zip(q01, q99, strict=True)):
+            if not isinstance(low, (int, float)) or not isinstance(high, (int, float)):
+                raise ValueError(f"normalization field {field!r}[{index}] is not numeric")
+            if index < minimum_dim and high <= low:
+                raise ValueError(f"normalization field {field!r}[{index}] has q99 <= q01")
+            if index >= minimum_dim and high < low:
+                raise ValueError(f"normalization field {field!r}[{index}] has q99 < q01")
+    return payload
+
+
+def _save_weights(path: Path, weights: dict[str, Any]) -> None:
+    try:
+        from safetensors.numpy import save_file
+    except ImportError as exc:
+        raise RuntimeError("safetensors is required to write converted OpenPI weights") from exc
+    save_file(weights, str(path))
+
+
+def _safe_replace_output(staging: Path, output: Path, *, force: bool) -> None:
+    if output.exists():
+        if output.is_dir() and not any(output.iterdir()):
+            output.rmdir()
+        elif force:
+            marker = output / _MARKER_NAME
+            if not marker.is_file() or marker.read_text(encoding="utf-8") != _MARKER_CONTENT:
+                raise FileExistsError(
+                    f"refusing to replace unowned output directory despite --force: {output}"
+                )
+            shutil.rmtree(output)
+        else:
+            raise FileExistsError(f"output directory already exists and is not empty: {output}")
+    os.replace(staging, output)
+
+
+def prepare_model_dir(
+    args: argparse.Namespace,
+    *,
+    rules: Sequence[MappingRule] | None = None,
+) -> dict[str, Any]:
+    """Prepare one profile and return its machine-readable provenance summary.
+
+    ``rules`` is an internal test seam for tiny synthetic checkpoints.  CLI
+    callers always use the complete audited mapping returned by the family.
+    """
+
+    profile = get_profile(str(args.profile))
+    checkpoint = Path(args.checkpoint).expanduser().resolve()
+    tokenizer = _validate_regular_file(args.tokenizer, "PaliGemma tokenizer")
+    norm_stats = _validate_regular_file(args.norm_stats, "normalization statistics")
+    _load_and_validate_norm_stats(
+        norm_stats,
+        state_dim=profile.external_state_dim,
+        action_dim=profile.external_action_dim,
+    )
+
+    output = Path(args.output).expanduser().resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    force = bool(getattr(args, "force", False))
+    if output.exists():
+        if not output.is_dir():
+            raise FileExistsError(f"output exists and is not a directory: {output}")
+        if any(output.iterdir()) and not force:
+            raise FileExistsError(f"output directory already exists and is not empty: {output}")
+
+    reader = open_checkpoint(checkpoint)
+    mapped = map_weights(reader, profile, rules=rules)
+
+    staging = Path(tempfile.mkdtemp(prefix=f".{output.name}.staging-", dir=output.parent))
+    try:
+        weights_path = staging / "model.safetensors"
+        _save_weights(weights_path, mapped.weights)
+
+        tokenizer_target = staging / "tokenizer.model"
+        tokenizer_metadata = export_paligemma_bpe_model(tokenizer, tokenizer_target)
+        norm_target = staging / "preprocessor_config.json"
+        shutil.copyfile(norm_stats, norm_target)
+
+        manifest = dict(mapped.manifest)
+        manifest["artifacts"] = {
+            "weights": {
+                "file": weights_path.name,
+                "sha256": file_sha256(weights_path),
+            },
+            "tokenizer": {
+                "file": tokenizer_target.relative_to(staging).as_posix(),
+                "format": "TRTMCBPE",
+                "sha256": tokenizer_metadata.asset_sha256,
+                **tokenizer_metadata.to_dict(),
+            },
+            "normalization": {
+                "file": norm_target.relative_to(staging).as_posix(),
+                "source_sha256": file_sha256(norm_stats),
+                "sha256": file_sha256(norm_target),
+            },
+        }
+        manifest_path = staging / "openpi_conversion_manifest.json"
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        manifest_sha256 = file_sha256(manifest_path)
+
+        config = {
+            "model_type": OPENPI_MODEL_TYPE,
+            "profile": profile.name,
+            "upstream_commit": OPENPI_UPSTREAM_COMMIT,
+            "checkpoint_uri": profile.checkpoint_uri,
+            "checkpoint_identity_sha256": reader.identity_sha256,
+            "conversion_manifest": manifest_path.name,
+            "conversion_manifest_sha256": manifest_sha256,
+            "weights": weights_path.name,
+            "tokenizer": tokenizer_target.relative_to(staging).as_posix(),
+            "tokenizer_format": "TRTMCBPE",
+            "tokenizer_sha256": tokenizer_metadata.asset_sha256,
+            "tokenizer_source_sha256": tokenizer_metadata.source_sha256,
+            "tokenizer_export": tokenizer_metadata.to_dict(),
+            "normalization": norm_target.relative_to(staging).as_posix(),
+            "normalization_sha256": file_sha256(norm_target),
+            "policy": profile.to_dict(),
+        }
+        config_path = staging / "openpi_config.json"
+        config_path.write_text(
+            json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        (staging / _MARKER_NAME).write_text(_MARKER_CONTENT, encoding="utf-8")
+
+        _safe_replace_output(staging, output, force=force)
+    except Exception:
+        if staging.exists():
+            shutil.rmtree(staging)
+        raise
+
+    return {
+        "output_dir": str(output),
+        "profile": profile.name,
+        "upstream_commit": OPENPI_UPSTREAM_COMMIT,
+        "checkpoint_identity_sha256": reader.identity_sha256,
+        "source_tensor_count": len(mapped.manifest["source_tensors"]),
+        "destination_tensor_count": len(mapped.weights),
+        "conversion_manifest": str(output / "openpi_conversion_manifest.json"),
+        "conversion_manifest_sha256": manifest_sha256,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True, choices=profile_names())
+    parser.add_argument(
+        "--checkpoint",
+        required=True,
+        help="local official checkpoint directory, its params directory, or a synthetic .npz",
+    )
+    parser.add_argument("--tokenizer", required=True, help="local PaliGemma tokenizer model")
+    parser.add_argument("--norm-stats", required=True, help="profile norm_stats.json")
+    parser.add_argument("--output", required=True, help="TRTMC model directory to create")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="replace an existing directory created by this tool",
+    )
+    result = prepare_model_dir(parser.parse_args())
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/tensorrt_model_connect/families/openpi/tests/test_action_expert_builder.py
+++ b/python/tensorrt_model_connect/families/openpi/tests/test_action_expert_builder.py
@@ -1,0 +1,1153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tensorrt_model_connect.families.openpi import action_expert_builder
+from tensorrt_model_connect.families.openpi.action_expert_builder import (
+    _require_exact_droid_adaptive_modulation_weights,
+    _require_exact_droid_time_condition_weights,
+    _uses_action_attention_context,
+    _uses_exact_droid_action_output_projection,
+    _uses_exact_droid_action_mlp_closure,
+    _uses_exact_droid_adaptive_modulation_corrections,
+    _uses_exact_droid_time_condition_corrections,
+    _uses_exact_droid_pre_attention_norm,
+    _uses_exact_droid_final_norm,
+    _validate_action_weights,
+    build_action_expert_engine,
+    required_action_weight_shapes,
+)
+from tensorrt_model_connect.families.openpi.model_config import GemmaConfig, get_profile
+
+
+def _tiny_action_profile():
+    return replace(
+        get_profile("pi05_droid"),
+        action_horizon=3,
+        action_dim=4,
+        external_state_dim=4,
+        external_action_dim=4,
+        action_expert=GemmaConfig(
+            width=8,
+            depth=2,
+            mlp_dim=12,
+            num_heads=2,
+            num_kv_heads=1,
+            head_dim=4,
+        ),
+        prefix=GemmaConfig(
+            width=16,
+            depth=2,
+            mlp_dim=24,
+            num_heads=2,
+            num_kv_heads=1,
+            head_dim=4,
+        ),
+    )
+
+
+def _tiny_action_weights(profile) -> dict[str, np.ndarray]:
+    return {
+        name: np.full(shape, (index + 1) / 1000.0, dtype=np.float32)
+        for index, (name, shape) in enumerate(required_action_weight_shapes(profile).items())
+    }
+
+
+def test_action_weight_inventory_is_exhaustive_and_compact() -> None:
+    profile = _tiny_action_profile()
+    shapes = required_action_weight_shapes(profile)
+
+    assert len(shapes) == 10 + 11 * profile.action_expert.depth
+    assert shapes["action.layer.0.attention.q.weight"] == (8, 8)
+    assert shapes["action.layer.0.attention.k.weight"] == (8, 4)
+    assert shapes["action.layer.0.attention.v.weight"] == (8, 4)
+    assert shapes["action.layer.0.pre_attention_norm.dense.weight"] == (8, 24)
+
+    mapped = {name: np.zeros(shape, dtype=np.float16) for name, shape in shapes.items()}
+    assert set(_validate_action_weights(mapped, profile)) == set(shapes)
+
+
+def test_production_action_builder_exposes_no_trace_plan_switch() -> None:
+    parameters = inspect.signature(build_action_expert_engine).parameters
+    assert "debug_outputs" not in parameters
+    assert "_diagnostic_layer0_mlp_closure" not in parameters
+    assert "_diagnostic_layer1_attention_context" not in parameters
+
+
+def test_action_mlp_closure_selector_is_explicit_and_fail_closed() -> None:
+    droid = get_profile("pi05_droid")
+    assert _uses_exact_droid_action_mlp_closure(
+        droid,
+        precision="bf16",
+        layer=0,
+    )
+    assert _uses_exact_droid_action_mlp_closure(
+        droid,
+        precision="bf16",
+        layer=1,
+    )
+    assert _uses_exact_droid_action_mlp_closure(
+        droid,
+        precision="bf16",
+        layer=17,
+    )
+    assert not _uses_exact_droid_action_mlp_closure(
+        droid,
+        precision="bf16",
+        layer=18,
+    )
+    assert not _uses_exact_droid_action_mlp_closure(
+        droid,
+        precision="fp32",
+        layer=0,
+    )
+    assert not _uses_exact_droid_action_mlp_closure(
+        replace(droid, name="unqualified"),
+        precision="bf16",
+        layer=0,
+    )
+    assert not _uses_exact_droid_action_mlp_closure(
+        replace(droid, action_horizon=10), precision="bf16", layer=0
+    )
+    assert not _uses_exact_droid_action_mlp_closure(
+        replace(droid, action_expert=replace(droid.action_expert, width=512)),
+        precision="bf16",
+        layer=0,
+    )
+    assert not _uses_exact_droid_action_mlp_closure(
+        replace(droid, action_expert=replace(droid.action_expert, mlp_dim=2048)),
+        precision="bf16",
+        layer=0,
+    )
+    assert not _uses_exact_droid_action_mlp_closure(
+        replace(droid, rms_norm_epsilon=1.0e-5), precision="bf16", layer=0
+    )
+
+
+def test_pre_attention_norm_selector_is_explicit_and_fail_closed() -> None:
+    droid = get_profile("pi05_droid")
+    assert _uses_exact_droid_pre_attention_norm(droid, precision="bf16", layer=0)
+    assert _uses_exact_droid_pre_attention_norm(droid, precision="bf16", layer=17)
+    assert not _uses_exact_droid_pre_attention_norm(droid, precision="bf16", layer=-1)
+    assert not _uses_exact_droid_pre_attention_norm(droid, precision="bf16", layer=18)
+    assert not _uses_exact_droid_pre_attention_norm(droid, precision="fp32", layer=0)
+    assert not _uses_exact_droid_pre_attention_norm(
+        replace(droid, name="unqualified"), precision="bf16", layer=0
+    )
+    assert not _uses_exact_droid_pre_attention_norm(
+        replace(droid, action_horizon=10), precision="bf16", layer=0
+    )
+    assert not _uses_exact_droid_pre_attention_norm(
+        replace(
+            droid,
+            prefix=replace(droid.prefix, depth=17),
+            action_expert=replace(droid.action_expert, depth=17),
+        ),
+        precision="bf16",
+        layer=0,
+    )
+    assert not _uses_exact_droid_pre_attention_norm(
+        replace(
+            droid,
+            action_expert=replace(droid.action_expert, width=512),
+        ),
+        precision="bf16",
+        layer=0,
+    )
+    assert not _uses_exact_droid_pre_attention_norm(
+        replace(droid, rms_norm_epsilon=1.0e-5), precision="bf16", layer=0
+    )
+
+
+def test_action_output_projection_selector_is_explicit_and_fail_closed() -> None:
+    droid = get_profile("pi05_droid")
+    assert _uses_exact_droid_action_output_projection(droid, precision="bf16")
+    assert not _uses_exact_droid_action_output_projection(droid, precision="fp32")
+    assert not _uses_exact_droid_action_output_projection(
+        replace(droid, name="unqualified"), precision="bf16"
+    )
+    assert not _uses_exact_droid_action_output_projection(
+        replace(droid, action_horizon=10), precision="bf16"
+    )
+    assert not _uses_exact_droid_action_output_projection(
+        replace(droid, action_dim=16), precision="bf16"
+    )
+    assert not _uses_exact_droid_action_output_projection(
+        replace(droid, denoise_steps=5), precision="bf16"
+    )
+    assert not _uses_exact_droid_action_output_projection(
+        replace(droid, action_expert=replace(droid.action_expert, width=512)),
+        precision="bf16",
+    )
+    assert not _uses_exact_droid_action_output_projection(
+        replace(
+            droid,
+            prefix=replace(droid.prefix, depth=17),
+            action_expert=replace(droid.action_expert, depth=17),
+        ),
+        precision="bf16",
+    )
+    assert not _uses_exact_droid_action_output_projection(
+        replace(droid, action_expert=replace(droid.action_expert, mlp_dim=2048)),
+        precision="bf16",
+    )
+    assert not _uses_exact_droid_action_output_projection(
+        replace(droid, prefix=replace(droid.prefix, width=1024)),
+        precision="bf16",
+    )
+    assert not _uses_exact_droid_action_output_projection(
+        replace(droid, rms_norm_epsilon=1.0e-5), precision="bf16"
+    )
+
+
+def test_time_condition_correction_selector_is_explicit_and_fail_closed() -> None:
+    droid = get_profile("pi05_droid")
+    assert _uses_exact_droid_time_condition_corrections(droid, precision="bf16")
+    assert not _uses_exact_droid_time_condition_corrections(droid, precision="fp32")
+    assert not _uses_exact_droid_time_condition_corrections(
+        replace(droid, name="unqualified"), precision="bf16"
+    )
+    assert not _uses_exact_droid_time_condition_corrections(
+        replace(droid, denoise_steps=5), precision="bf16"
+    )
+    assert not _uses_exact_droid_time_condition_corrections(
+        replace(droid, action_expert=replace(droid.action_expert, width=512)),
+        precision="bf16",
+    )
+
+
+def test_adaptive_modulation_correction_selector_is_explicit_and_fail_closed() -> None:
+    droid = get_profile("pi05_droid")
+    assert _uses_exact_droid_adaptive_modulation_corrections(droid, precision="bf16")
+    assert not _uses_exact_droid_adaptive_modulation_corrections(droid, precision="fp32")
+    assert not _uses_exact_droid_adaptive_modulation_corrections(
+        replace(droid, name="unqualified"), precision="bf16"
+    )
+    assert not _uses_exact_droid_adaptive_modulation_corrections(
+        replace(droid, denoise_steps=5), precision="bf16"
+    )
+
+
+def test_time_condition_corrections_are_exact_and_fail_closed() -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.families.openpi import graph_ops
+
+    assert graph_ops._DROID_TIME_CONDITION_TIMESTEP_BITS == (
+        0x3F800000,
+        0x3F666666,
+        0x3F4CCCCC,
+        0x3F333332,
+        0x3F199998,
+        0x3EFFFFFD,
+        0x3ECCCCCA,
+        0x3E999997,
+        0x3E4CCCC8,
+        0x3DCCCCC3,
+    )
+    assert graph_ops._DROID_TIME_CONDITION_CORRECTIONS == (
+        (0, ((573, 0xB6CF0000),)),
+        (1, ((750, 0xB9AA0000),)),
+        (3, ((275, 0xBAEE0000), (558, 0xBBC00000))),
+        (7, ((101, 0x38C40000), (627, 0x36FA0000))),
+    )
+    with pytest.raises(ValueError, match="require condition"):
+        graph_ops.correct_droid_time_condition_bf16_boundaries(
+            None,
+            _FakeTensor((1, 512), graph_ops.trt.float32),
+            _FakeTensor((1,), graph_ops.trt.float32),
+        )
+    with pytest.raises(ValueError, match="require FP32"):
+        graph_ops.correct_droid_time_condition_bf16_boundaries(
+            None,
+            _FakeTensor((1, 1024), graph_ops.trt.bfloat16),
+            _FakeTensor((1,), graph_ops.trt.float32),
+        )
+
+
+def test_time_condition_corrections_require_the_audited_checkpoint(
+    monkeypatch,
+) -> None:
+    names = tuple(action_expert_builder._DROID_TIME_CONDITION_WEIGHT_SHA256)
+    weights = {
+        name: np.asarray([index + 0.25], dtype=np.float32) for index, name in enumerate(names)
+    }
+    expected = {
+        name: hashlib.sha256(value.tobytes()).hexdigest() for name, value in weights.items()
+    }
+    monkeypatch.setattr(
+        action_expert_builder,
+        "_DROID_TIME_CONDITION_WEIGHT_SHA256",
+        expected,
+    )
+    _require_exact_droid_time_condition_weights(weights)
+
+    weights[names[0]] = weights[names[0]] + np.float32(1.0)
+    with pytest.raises(ValueError, match="require the audited BF16-rounded checkpoint"):
+        _require_exact_droid_time_condition_weights(weights)
+
+
+def test_adaptive_modulation_corrections_are_exact_and_fail_closed() -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.families.openpi import graph_ops
+
+    assert graph_ops._DROID_ADAPTIVE_MODULATION_CORRECTIONS == (
+        (2, 12, "ffw", 84, 0xBB740000),
+        (6, 6, "ffw", 1386, 0x3C260000),
+        (7, 14, "ffw", 2797, 0x3B1B0000),
+        (9, 11, "attn", 788, 0xBF0A0000),
+    )
+    with pytest.raises(ValueError, match="require modulation"):
+        graph_ops.correct_droid_adaptive_modulation_bf16_boundaries(
+            None,
+            _FakeTensor((1, 1024), graph_ops.trt.bfloat16),
+            _FakeTensor((1,), graph_ops.trt.float32),
+            layer=6,
+            role="ffw",
+        )
+    with pytest.raises(ValueError, match="require BF16 modulation"):
+        graph_ops.correct_droid_adaptive_modulation_bf16_boundaries(
+            None,
+            _FakeTensor((1, 3072), graph_ops.trt.float32),
+            _FakeTensor((1,), graph_ops.trt.float32),
+            layer=6,
+            role="ffw",
+        )
+    with pytest.raises(ValueError, match="layer must be"):
+        graph_ops.correct_droid_adaptive_modulation_bf16_boundaries(
+            None,
+            _FakeTensor((1, 3072), graph_ops.trt.bfloat16),
+            _FakeTensor((1,), graph_ops.trt.float32),
+            layer=18,
+            role="ffw",
+        )
+    with pytest.raises(ValueError, match="role must be"):
+        graph_ops.correct_droid_adaptive_modulation_bf16_boundaries(
+            None,
+            _FakeTensor((1, 3072), graph_ops.trt.bfloat16),
+            _FakeTensor((1,), graph_ops.trt.float32),
+            layer=6,
+            role="invalid",
+        )
+
+
+def test_adaptive_modulation_corrections_require_the_audited_checkpoint(
+    monkeypatch,
+) -> None:
+    names = tuple(action_expert_builder._DROID_ADAPTIVE_MODULATION_WEIGHT_SHA256)
+    weights = {
+        name: np.asarray([index + 0.25], dtype=np.float32) for index, name in enumerate(names)
+    }
+    expected = {
+        name: hashlib.sha256(value.tobytes()).hexdigest() for name, value in weights.items()
+    }
+    monkeypatch.setattr(
+        action_expert_builder,
+        "_DROID_ADAPTIVE_MODULATION_WEIGHT_SHA256",
+        expected,
+    )
+    _require_exact_droid_adaptive_modulation_weights(weights)
+
+    weights[names[0]] = weights[names[0]] + np.float32(1.0)
+    with pytest.raises(ValueError, match="require the audited BF16-rounded checkpoint"):
+        _require_exact_droid_adaptive_modulation_weights(weights)
+
+
+def test_adaptive_modulation_hash_inventory_matches_the_correction_table() -> None:
+    graph_ops_path = Path(action_expert_builder.__file__).with_name("graph_ops.py")
+    module = ast.parse(graph_ops_path.read_text(encoding="utf-8"))
+    correction_node = next(
+        node.value
+        for node in module.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "_DROID_ADAPTIVE_MODULATION_CORRECTIONS"
+            for target in node.targets
+        )
+    )
+    corrections = ast.literal_eval(correction_node)
+    norm_for_role = {"attn": "pre_attention_norm", "ffw": "pre_ffw_norm"}
+    expected_weights = {
+        f"action.layer.{layer}.{norm_for_role[role]}.dense.{parameter}"
+        for _, layer, role, _, _ in corrections
+        for parameter in ("weight", "bias")
+    }
+
+    assert set(action_expert_builder._DROID_ADAPTIVE_MODULATION_WEIGHT_SHA256) == (expected_weights)
+
+
+def test_action_attention_context_selector_is_explicit_and_fail_closed() -> None:
+    droid = get_profile("pi05_droid")
+    assert _uses_action_attention_context(
+        droid,
+        precision="bf16",
+        layer=0,
+    )
+    assert _uses_action_attention_context(
+        droid,
+        precision="bf16",
+        layer=1,
+    )
+    assert _uses_action_attention_context(
+        droid,
+        precision="bf16",
+        layer=17,
+    )
+    assert not _uses_action_attention_context(
+        droid,
+        precision="bf16",
+        layer=18,
+    )
+    assert not _uses_action_attention_context(
+        droid,
+        precision="fp32",
+        layer=1,
+    )
+    assert not _uses_action_attention_context(
+        replace(droid, name="unqualified"),
+        precision="bf16",
+        layer=1,
+    )
+    assert not _uses_action_attention_context(
+        replace(droid, max_token_length=droid.max_token_length - 1),
+        precision="bf16",
+        layer=1,
+    )
+    assert not _uses_action_attention_context(
+        replace(
+            droid,
+            prefix=replace(droid.prefix, depth=1),
+            action_expert=replace(droid.action_expert, depth=1),
+        ),
+        precision="bf16",
+        layer=1,
+    )
+
+
+class _FakeTensor:
+    def __init__(self, shape, dtype):
+        self.shape = tuple(shape)
+        self.dtype = dtype
+
+
+class _FakePluginLayer:
+    def __init__(self, output):
+        self._output = output
+        self.name = ""
+
+    def get_output(self, index):
+        assert index == 0
+        return self._output
+
+
+class _FakeShuffleLayer:
+    def __init__(self, tensor):
+        self._tensor = tensor
+        self._reshape_dims = tensor.shape
+
+    @property
+    def reshape_dims(self):
+        return self._reshape_dims
+
+    @reshape_dims.setter
+    def reshape_dims(self, value):
+        self._reshape_dims = tuple(value)
+
+    def get_output(self, index):
+        assert index == 0
+        return _FakeTensor(self._reshape_dims, self._tensor.dtype)
+
+
+class _FakePluginNetwork:
+    def __init__(self, *, output_shape=None):
+        self.plugin_layers = []
+        self.output_shape = output_shape
+
+    def add_plugin_v3(self, inputs, shape_inputs, plugin):
+        assert shape_inputs == []
+        output_shape = inputs[0].shape if self.output_shape is None else self.output_shape
+        layer = _FakePluginLayer(_FakeTensor(output_shape, inputs[0].dtype))
+        self.plugin_layers.append((layer, tuple(inputs), plugin))
+        return layer
+
+    def add_shuffle(self, tensor):
+        return _FakeShuffleLayer(tensor)
+
+    def add_slice(self, tensor, start, shape, stride):
+        assert len(start) == len(shape) == len(stride)
+        return _FakePluginLayer(_FakeTensor(shape, tensor.dtype))
+
+
+class _FakeValueTensor(_FakeTensor):
+    def __init__(self, value, dtype):
+        self.value = np.asarray(value)
+        super().__init__(self.value.shape, dtype)
+
+
+class _FakeValueShuffleLayer:
+    def __init__(self, tensor):
+        self._tensor = tensor
+        self.reshape_dims = tensor.shape
+
+    def get_output(self, index):
+        assert index == 0
+        return _FakeValueTensor(
+            self._tensor.value.reshape(self.reshape_dims),
+            self._tensor.dtype,
+        )
+
+
+class _FakeCorrectionNetwork:
+    def __init__(self, trt):
+        self._trt = trt
+        self.select_layers = []
+
+    def add_elementwise(self, lhs, rhs, operation):
+        if operation == self._trt.ElementWiseOperation.EQUAL:
+            value = np.equal(lhs.value, rhs.value)
+        elif operation == self._trt.ElementWiseOperation.AND:
+            value = np.logical_and(lhs.value, rhs.value)
+        else:
+            raise AssertionError(f"unexpected elementwise operation {operation}")
+        return _FakePluginLayer(_FakeValueTensor(value, self._trt.bool))
+
+    def add_shuffle(self, tensor):
+        return _FakeValueShuffleLayer(tensor)
+
+    def add_select(self, condition, then_input, else_input):
+        output = _FakeValueTensor(
+            np.where(condition.value, then_input.value, else_input.value),
+            else_input.dtype,
+        )
+        layer = _FakePluginLayer(output)
+        self.select_layers.append(layer)
+        return layer
+
+
+def _broadcast_weight(shape):
+    return np.broadcast_to(np.asarray(0.0, dtype=np.float32), shape)
+
+
+@pytest.mark.parametrize(
+    "step, layer, role, feature, value_bits",
+    (
+        (2, 12, "ffw", 84, 0xBB740000),
+        (6, 6, "ffw", 1386, 0x3C260000),
+        (7, 14, "ffw", 2797, 0x3B1B0000),
+        (9, 11, "attn", 788, 0xBF0A0000),
+    ),
+)
+def test_adaptive_modulation_corrections_replace_the_exact_boundary(
+    monkeypatch,
+    step,
+    layer,
+    role,
+    feature,
+    value_bits,
+) -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.families.openpi import graph_ops
+
+    monkeypatch.setattr(
+        graph_ops,
+        "constant",
+        lambda _network, value, *, dtype=None, shape=None: _FakeValueTensor(
+            np.asarray(value).reshape(shape) if shape is not None else np.asarray(value),
+            dtype,
+        ),
+    )
+    network = _FakeCorrectionNetwork(graph_ops.trt)
+    source = np.ones((1, 3072), dtype=np.float32)
+    timestep = np.asarray(
+        [graph_ops._DROID_TIME_CONDITION_TIMESTEP_BITS[step]], dtype=np.uint32
+    ).view(np.float32)
+
+    corrected = graph_ops.correct_droid_adaptive_modulation_bf16_boundaries(
+        network,
+        _FakeValueTensor(source, graph_ops.trt.bfloat16),
+        _FakeValueTensor(timestep, graph_ops.trt.float32),
+        layer=layer,
+        role=role,
+    )
+
+    expected = source.copy()
+    expected[0, feature] = np.asarray([value_bits], dtype=np.uint32).view(np.float32)[0]
+    np.testing.assert_array_equal(corrected.value.view(np.uint32), expected.view(np.uint32))
+    assert [item.name for item in network.select_layers] == [
+        f"openpi_droid_adaptive_modulation_bf16_correction_step_{step}_layer_{layer}_{role}"
+    ]
+
+
+def test_adaptive_modulation_correction_is_noop_for_the_wrong_timestep(
+    monkeypatch,
+) -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.families.openpi import graph_ops
+
+    monkeypatch.setattr(
+        graph_ops,
+        "constant",
+        lambda _network, value, *, dtype=None, shape=None: _FakeValueTensor(
+            np.asarray(value).reshape(shape) if shape is not None else np.asarray(value),
+            dtype,
+        ),
+    )
+    source = np.full((1, 3072), 0.5, dtype=np.float32)
+    wrong_timestep = np.asarray(
+        [graph_ops._DROID_TIME_CONDITION_TIMESTEP_BITS[5]], dtype=np.uint32
+    ).view(np.float32)
+
+    corrected = graph_ops.correct_droid_adaptive_modulation_bf16_boundaries(
+        _FakeCorrectionNetwork(graph_ops.trt),
+        _FakeValueTensor(source, graph_ops.trt.bfloat16),
+        _FakeValueTensor(wrong_timestep, graph_ops.trt.float32),
+        layer=6,
+        role="ffw",
+    )
+
+    np.testing.assert_array_equal(corrected.value.view(np.uint32), source.view(np.uint32))
+
+
+def test_post_attention_correction_request_cannot_use_the_generic_fallback() -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.families.openpi import graph_ops
+
+    residual = _FakeTensor((1, 3, 8), graph_ops.trt.bfloat16)
+    update = _FakeTensor((1, 3, 8), graph_ops.trt.bfloat16)
+    gate = _FakeTensor((1, 1, 8), graph_ops.trt.bfloat16)
+    condition = _FakeTensor((1, 8), graph_ops.trt.float32)
+    timestep = _FakeTensor((1,), graph_ops.trt.float32)
+    weight = _broadcast_weight((8, 24))
+    bias = _broadcast_weight((24,))
+
+    with pytest.raises(ValueError, match="require timestep and layer together"):
+        graph_ops.post_attention_adaptive_rms_norm(
+            None,
+            residual,
+            update,
+            gate,
+            condition,
+            weight,
+            bias,
+            droid_timestep=timestep,
+        )
+    with pytest.raises(ValueError, match="require the fixed BF16 DROID shape"):
+        graph_ops.post_attention_adaptive_rms_norm(
+            None,
+            residual,
+            update,
+            gate,
+            condition,
+            weight,
+            bias,
+            droid_timestep=timestep,
+            droid_layer=6,
+        )
+
+
+def test_pre_attention_norm_helper_reuses_exact_plugin_fail_closed(
+    monkeypatch,
+) -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.families.openpi import graph_ops
+
+    plugin = object()
+    constants = []
+    network = _FakePluginNetwork()
+    monkeypatch.setattr(
+        graph_ops,
+        "_create_openpi_post_attention_rms_norm_plugin",
+        lambda *, epsilon: plugin,
+    )
+    monkeypatch.setattr(
+        graph_ops,
+        "cast",
+        lambda _network, tensor, dtype: (
+            tensor if tensor.dtype == dtype else _FakeTensor(tensor.shape, dtype)
+        ),
+    )
+    monkeypatch.setattr(
+        graph_ops,
+        "_xla_bf16_m1_linear",
+        lambda _network, inp, weight, bias: _FakeTensor((1, np.asarray(bias).size), inp.dtype),
+    )
+
+    def fake_constant(_network, value, *, dtype=None, shape=None):
+        array = np.asarray(value)
+        observed_shape = tuple(array.shape) if shape is None else tuple(shape)
+        constants.append((array, observed_shape, dtype))
+        return _FakeTensor(observed_shape, dtype)
+
+    monkeypatch.setattr(graph_ops, "constant", fake_constant)
+    hidden = _FakeTensor((1, 15, 1024), graph_ops.trt.bfloat16)
+    condition = _FakeTensor((1, 1024), graph_ops.trt.float32)
+    output, gate = graph_ops.pre_attention_adaptive_rms_norm(
+        network,
+        hidden,
+        condition,
+        _broadcast_weight((1024, 3072)),
+        _broadcast_weight((3072,)),
+        layer_name="openpi_pre_attention_rms_norm_layer_0",
+    )
+
+    assert output.shape == hidden.shape
+    assert gate.shape == (1, 1, 1024)
+    assert len(network.plugin_layers) == 1
+    layer, inputs, observed_plugin = network.plugin_layers[0]
+    assert layer.name == "openpi_pre_attention_rms_norm_layer_0"
+    assert observed_plugin is plugin
+    assert inputs[0] is hidden and inputs[1] is hidden
+    assert [tensor.shape for tensor in inputs] == [
+        (1, 15, 1024),
+        (1, 15, 1024),
+        (1024,),
+        (1024,),
+        (1024,),
+    ]
+    assert all(tensor.dtype == graph_ops.trt.bfloat16 for tensor in inputs)
+    assert len(constants) == 1
+    assert constants[0][1:] == ((1024,), graph_ops.trt.bfloat16)
+    assert not np.any(constants[0][0])
+
+    with pytest.raises(ValueError, match="requires fixed shapes"):
+        graph_ops.pre_attention_adaptive_rms_norm(
+            network,
+            _FakeTensor((1, 10, 1024), graph_ops.trt.bfloat16),
+            condition,
+            _broadcast_weight((1024, 3072)),
+            _broadcast_weight((3072,)),
+            layer_name="wrong_horizon",
+        )
+    with pytest.raises(ValueError, match="requires fixed shapes"):
+        graph_ops.pre_attention_adaptive_rms_norm(
+            network,
+            hidden,
+            condition,
+            _broadcast_weight((1024, 2048)),
+            _broadcast_weight((3072,)),
+            layer_name="wrong_weight",
+        )
+
+
+def test_action_layer0_mlp_closure_helper_has_fixed_order_and_name(
+    monkeypatch,
+) -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.families.openpi import graph_ops
+
+    plugin = object()
+    network = _FakePluginNetwork()
+    monkeypatch.setattr(
+        graph_ops,
+        "_create_openpi_action_layer0_mlp_closure_plugin",
+        lambda: plugin,
+    )
+    monkeypatch.setattr(
+        graph_ops,
+        "constant",
+        lambda _network, value, *, dtype=None, shape=None: _FakeTensor(
+            np.asarray(value).shape if shape is None else shape,
+            dtype,
+        ),
+    )
+    post_attention = _FakeTensor((1, 15, 1024), graph_ops.trt.bfloat16)
+    normed_ffw = _FakeTensor((1, 15, 1024), graph_ops.trt.bfloat16)
+    ffw_gate = _FakeTensor((1, 1, 1024), graph_ops.trt.bfloat16)
+
+    output = graph_ops.action_layer0_mlp_closure(
+        network,
+        post_attention,
+        normed_ffw,
+        ffw_gate,
+        _broadcast_weight((1024, 4096)),
+        _broadcast_weight((1024, 4096)),
+        _broadcast_weight((4096, 1024)),
+        layer_name="openpi_action_mlp_closure_layer_17",
+    )
+
+    assert output.shape == (1, 15, 1024)
+    assert len(network.plugin_layers) == 1
+    layer, inputs, observed_plugin = network.plugin_layers[0]
+    assert layer.name == "openpi_action_mlp_closure_layer_17"
+    assert observed_plugin is plugin
+    assert [tensor.shape for tensor in inputs] == [
+        (1, 15, 1024),
+        (1, 15, 1024),
+        (1, 1, 1024),
+        (1024, 4096),
+        (1024, 4096),
+        (4096, 1024),
+    ]
+    assert all(tensor.dtype == graph_ops.trt.bfloat16 for tensor in inputs)
+
+
+def test_action_layer0_mlp_closure_helper_rejects_unqualified_shape() -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.families.openpi import graph_ops
+
+    network = _FakePluginNetwork()
+    with pytest.raises(ValueError, match="requires fixed tensor shapes"):
+        graph_ops.action_layer0_mlp_closure(
+            network,
+            _FakeTensor((1, 10, 1024), graph_ops.trt.bfloat16),
+            _FakeTensor((1, 10, 1024), graph_ops.trt.bfloat16),
+            _FakeTensor((1, 1, 1024), graph_ops.trt.bfloat16),
+            _broadcast_weight((1024, 4096)),
+            _broadcast_weight((1024, 4096)),
+            _broadcast_weight((4096, 1024)),
+            layer_name="openpi_action_mlp_closure_layer_0",
+        )
+
+
+def test_action_output_projection_helper_has_fixed_order_and_name(monkeypatch) -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.families.openpi import graph_ops
+
+    plugin = object()
+    network = _FakePluginNetwork(output_shape=(1, 15, 32))
+    monkeypatch.setattr(
+        graph_ops,
+        "_create_openpi_action_output_projection_plugin",
+        lambda: plugin,
+    )
+    monkeypatch.setattr(
+        graph_ops,
+        "constant",
+        lambda _network, value, *, dtype=None, shape=None: _FakeTensor(
+            np.asarray(value).shape if shape is None else shape,
+            dtype,
+        ),
+    )
+    hidden = _FakeTensor((1, 15, 1024), graph_ops.trt.bfloat16)
+
+    output = graph_ops.action_output_projection(
+        network,
+        hidden,
+        _broadcast_weight((1024, 32)),
+        _broadcast_weight((32,)),
+    )
+
+    assert output.shape == (1, 15, 32)
+    assert output.dtype == graph_ops.trt.bfloat16
+    assert len(network.plugin_layers) == 1
+    layer, inputs, observed_plugin = network.plugin_layers[0]
+    assert layer.name == "openpi_action_output_projection"
+    assert observed_plugin is plugin
+    assert [tensor.shape for tensor in inputs] == [
+        (1, 15, 1024),
+        (1024, 32),
+        (32,),
+    ]
+    assert all(tensor.dtype == graph_ops.trt.bfloat16 for tensor in inputs)
+
+
+def test_action_output_projection_helper_rejects_unqualified_contract() -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.families.openpi import graph_ops
+
+    network = _FakePluginNetwork(output_shape=(1, 15, 32))
+    with pytest.raises(ValueError, match="requires fixed shapes"):
+        graph_ops.action_output_projection(
+            network,
+            _FakeTensor((1, 10, 1024), graph_ops.trt.bfloat16),
+            _broadcast_weight((1024, 32)),
+            _broadcast_weight((32,)),
+        )
+    with pytest.raises(ValueError, match="requires BF16"):
+        graph_ops.action_output_projection(
+            network,
+            _FakeTensor((1, 15, 1024), graph_ops.trt.float32),
+            _broadcast_weight((1024, 32)),
+            _broadcast_weight((32,)),
+        )
+
+
+def test_action_attention_context_helper_has_fixed_order_and_name(monkeypatch) -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.families.openpi import graph_ops
+
+    plugin = object()
+    network = _FakePluginNetwork(output_shape=(1, 15, 2048))
+    monkeypatch.setattr(
+        graph_ops,
+        "_create_openpi_action_attention_context_plugin",
+        lambda: plugin,
+    )
+    tensors = [
+        _FakeTensor((1, 8, 15, 256), graph_ops.trt.bfloat16),
+        _FakeTensor((1, 1, 983, 256), graph_ops.trt.bfloat16),
+        _FakeTensor((1, 1, 983, 256), graph_ops.trt.bfloat16),
+        _FakeTensor((1, 1, 15, 983), graph_ops.trt.bool),
+    ]
+
+    output = graph_ops.action_attention_context(
+        network,
+        *tensors,
+        layer_name="openpi_action_attention_context_layer_1",
+    )
+
+    assert output.shape == (1, 15, 2048)
+    assert len(network.plugin_layers) == 1
+    layer, inputs, observed_plugin = network.plugin_layers[0]
+    assert layer.name == "openpi_action_attention_context_layer_1"
+    assert observed_plugin is plugin
+    assert list(inputs) == tensors
+
+
+def test_action_attention_context_helper_rejects_unqualified_contract() -> None:
+    pytest.importorskip("tensorrt")
+    from tensorrt_model_connect.families.openpi import graph_ops
+
+    network = _FakePluginNetwork(output_shape=(1, 15, 2048))
+    with pytest.raises(ValueError, match="requires fixed tensor shapes"):
+        graph_ops.action_attention_context(
+            network,
+            _FakeTensor((1, 8, 14, 256), graph_ops.trt.bfloat16),
+            _FakeTensor((1, 1, 983, 256), graph_ops.trt.bfloat16),
+            _FakeTensor((1, 1, 983, 256), graph_ops.trt.bfloat16),
+            _FakeTensor((1, 1, 15, 983), graph_ops.trt.bool),
+            layer_name="openpi_action_attention_context_layer_1",
+        )
+    with pytest.raises(ValueError, match="requires a boolean attention mask"):
+        graph_ops.action_attention_context(
+            network,
+            _FakeTensor((1, 8, 15, 256), graph_ops.trt.bfloat16),
+            _FakeTensor((1, 1, 983, 256), graph_ops.trt.bfloat16),
+            _FakeTensor((1, 1, 983, 256), graph_ops.trt.bfloat16),
+            _FakeTensor((1, 1, 15, 983), graph_ops.trt.bfloat16),
+            layer_name="openpi_action_attention_context_layer_1",
+        )
+
+
+def test_action_attention_context_plugin_is_exact_and_fail_closed() -> None:
+    repository = Path(__file__).resolve().parents[5]
+    source = (
+        repository / "src/runtime/models/openpi/trt_plugins/action_attention_context_plugin.cu"
+    ).read_text(encoding="utf-8")
+    cmake = (repository / "src/runtime/models/openpi/model.cmake").read_text(encoding="utf-8")
+    compact = " ".join(source.split())
+
+    assert 'kName = "OpenPIActionAttentionContext"' in source
+    assert 'kVersion = "1"' in source
+    assert "nb_inputs != 4" in source
+    assert "has_query_shape(inputs[0])" in source
+    assert "has_key_value_shape(inputs[1])" in source
+    assert "has_key_value_shape(inputs[2])" in source
+    assert "has_mask_shape(inputs[3])" in source
+    assert "has_supported_dimensions(minimum, outputs[0].min)" in compact
+    assert "has_supported_dimensions(maximum, outputs[0].max)" in compact
+    assert "kPluginWorkspaceBytes == 2281344" in source
+    assert "kQkCublasWorkspaceBytes = 565248" in source
+    assert "kPvCublasWorkspaceBytes = 739968" in source
+    assert "logit_row0 = query * kQueryHeads + first_head" in source
+    assert "probability_row0 = first_head * kQueryRows + query" in source
+    assert "source_column = head * kQueryRows + token" in source
+    assert source.count("CUBLAS_GEMM_DEFAULT);") == 2
+    assert "CUBLAS_COMPUTE_32F" in source
+    assert "cublasSetMathMode(plugin->cublas_handle_, CUBLAS_DEFAULT_MATH)" in compact
+    assert "every thread has consumed both broadcast maxima" in source
+    assert "bits += 0x00007FFFU + ((bits >> 16U) & 1U)" in source
+    assert 'asm("div.full.f32' in source
+    assert "<<<kSoftmaxBlocks, kSoftmaxThreads, 0, stream>>>" in compact
+    assert "plugin_registrar_openpi_action_attention_context" in source
+    assert '"${CMAKE_CURRENT_LIST_DIR}/trt_plugins/action_attention_context_plugin.cu"' in cmake
+
+
+def test_action_layer0_mlp_closure_plugin_is_exact_and_fail_closed() -> None:
+    repository = Path(__file__).resolve().parents[5]
+    source = (
+        repository / "src/runtime/models/openpi/trt_plugins/action_layer0_mlp_closure_plugin.cu"
+    ).read_text(encoding="utf-8")
+    cmake = (repository / "src/runtime/models/openpi/model.cmake").read_text(encoding="utf-8")
+    compact = " ".join(source.split())
+
+    assert 'kName = "OpenPIActionLayer0MlpClosure"' in source
+    assert 'kVersion = "1"' in source
+    assert "nb_inputs != 6" in source
+    assert "has_activation_shape(input[0])" in source
+    assert "has_activation_shape(input[1])" in source
+    assert "has_gate_shape(input[2])" in source
+    assert "has_matrix_shape(input[3], kWidth, kMlpWidth)" in source
+    assert "has_matrix_shape(input[4], kWidth, kMlpWidth)" in source
+    assert "has_matrix_shape(input[5], kMlpWidth, kWidth)" in source
+    assert "has_supported_dimensions(minimum, output[0].min)" in compact
+    assert "has_supported_dimensions(maximum, output[0].max)" in compact
+    assert "kCombinedCublasWorkspaceBytes = 16809984" in source
+    assert "kDownCublasWorkspaceBytes = 8519680" in source
+    assert source.count("CUBLAS_GEMM_DEFAULT);") == 2
+    assert "CUBLAS_COMPUTE_32F" in source
+    assert "cublasSetMathMode(plugin->cublas_handle_, CUBLAS_DEFAULT_MATH)" in compact
+    assert "__fadd_rn(bf16_to_float(lhs), bf16_to_float(rhs))" in compact
+    assert "__fmul_rn(bf16_to_float(lhs), bf16_to_float(rhs))" in compact
+    assert "bits += 0x00007FFFU + ((bits >> 16U) & 1U)" in source
+    assert 'asm("add.rn.bf16' not in source
+    assert 'asm("mul.rn.bf16' not in source
+    assert 'asm("div.full.f32' in source
+    for coefficient in (
+        "0x40FFF644U",
+        "0x39D1B717U",
+        "0xA59F25C0U",
+        "0x3BA059DCU",
+        "0x3BA059DDU",
+        "0x3D37U",
+        "0x3F4CU",
+    ):
+        assert coefficient in source
+    assert "cudaMemcpy2DAsync" in source
+    assert "plugin_registrar_openpi_action_layer0_mlp_closure" in source
+    assert ('"${CMAKE_CURRENT_LIST_DIR}/trt_plugins/action_layer0_mlp_closure_plugin.cu"') in cmake
+
+
+def test_action_output_projection_plugin_is_exact_and_fail_closed() -> None:
+    repository = Path(__file__).resolve().parents[5]
+    source = (
+        repository / "src/runtime/models/openpi/trt_plugins/action_output_projection_plugin.cu"
+    ).read_text(encoding="utf-8")
+    cmake = (repository / "src/runtime/models/openpi/model.cmake").read_text(encoding="utf-8")
+    builder_source = inspect.getsource(build_action_expert_engine)
+    compact = " ".join(source.split())
+
+    assert 'kName = "OpenPIActionOutputProjection"' in source
+    assert 'kVersion = "1"' in source
+    assert "nb_inputs != 3" in source
+    assert "has_hidden_shape(inputs[0])" in source
+    assert "has_weight_shape(inputs[1])" in source
+    assert "has_bias_shape(inputs[2])" in source
+    assert "inputs[0].nbDims != 3" in source
+    assert "inputs[1].nbDims != 2" in source
+    assert "inputs[2].nbDims != 1" in source
+    assert "inputs[0].d[0] == nullptr" in source
+    assert "inputs[0].d[1] == nullptr" in source
+    assert "has_supported_dimensions(minimum, outputs[0].min)" in compact
+    assert "has_supported_dimensions(maximum, outputs[0].max)" in compact
+    assert "kCublasWorkspaceBytes = 98304" in source
+    assert "kPaddedInputOffset == 0x0080" in source
+    assert "kPaddedOutputOffset == 0x8080" in source
+    assert "kCublasWorkspaceOffset == 0x8480" in source
+    assert "kWorkspacePayloadBytes == 0x20480" in source
+    assert "kPluginWorkspaceBytes == 0x2057F" in source
+    assert "kPaddedInputOffset % 256 == 128" in source
+    assert "workspace_address + kWorkspaceAlignmentSlack" in compact
+    assert "cublasSetWorkspace(handle, workspace, kCublasWorkspaceBytes)" in compact
+    assert "CUBLAS_OP_N, CUBLAS_OP_N, kOutputWidth, kPaddedRows" in compact
+    assert "weight, CUDA_R_16BF, kOutputWidth, padded_hidden" in compact
+    assert "CUDA_R_16BF, kWidth, &beta, padded_output, CUDA_R_16BF" in compact
+    assert "kOutputWidth, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT" in compact
+    assert "cublasSetMathMode(plugin->cublas_handle_, CUBLAS_DEFAULT_MATH)" in compact
+    assert "cublasSetPointerMode(plugin->cublas_handle_, CUBLAS_POINTER_MODE_HOST)" in compact
+    assert "cudaMemcpyAsync" in source
+    assert "cudaMemsetAsync" in source
+    assert 'asm("add.rn.bf16' in source
+    assert source.index("cublasGemmEx") < source.rindex("openpi_action_output_bias_kernel<<<")
+    assert "plugin_registrar_openpi_action_output_projection" in source
+    assert '"${CMAKE_CURRENT_LIST_DIR}/trt_plugins/action_output_projection_plugin.cu"' in cmake
+    assert "velocity_bf16 = graph_ops.action_output_projection(" in builder_source
+
+
+def test_exact_final_norm_is_owned_only_by_the_pinned_droid_shape() -> None:
+    droid = get_profile("pi05_droid")
+    assert _uses_exact_droid_final_norm(droid, precision="bf16")
+    assert not _uses_exact_droid_final_norm(droid, precision="fp32")
+    assert not _uses_exact_droid_final_norm(replace(droid, name="unqualified"), precision="bf16")
+    assert not _uses_exact_droid_final_norm(replace(droid, action_horizon=10), precision="bf16")
+    assert not _uses_exact_droid_final_norm(
+        replace(
+            droid,
+            action_expert=replace(droid.action_expert, width=512),
+        ),
+        precision="bf16",
+    )
+
+
+def test_final_adaptive_norm_plugin_is_fixed_shape_and_fail_closed() -> None:
+    source = (
+        Path(__file__).resolve().parents[5]
+        / "src/runtime/models/openpi/trt_plugins/rms_norm_plugin.cu"
+    ).read_text(encoding="utf-8")
+    compact = " ".join(source.split())
+
+    assert 'kName = "OpenPIFinalAdaptiveRmsNorm"' in source
+    assert 'kVersion = "1"' in source
+    assert "hidden.d[1] == kFinalAdaptiveRows" in source
+    assert "hidden.d[2] == kActionWidth" in source
+    assert "bias.d[0] == kFinalAdaptiveProjectionWidth" in source
+    assert "weight.d[0] == kActionWidth" in source
+    assert "weight.d[1] == kFinalAdaptiveProjectionWidth" in source
+    assert "condition.d[1] == kActionWidth" in source
+    assert "input[0].min, input[1].min" in compact
+    assert "input[0].max, input[1].max" in compact
+    assert "epsilon != kFinalAdaptiveEpsilon" in source
+    assert "<<<kFinalAdaptiveBlocks, kFinalAdaptiveThreads, 0, stream>>>" in compact
+    assert "plugin_registrar_openpi_final_adaptive_rms_norm" in source
+
+
+def test_action_weight_validation_rejects_missing_and_wrong_shape() -> None:
+    profile = _tiny_action_profile()
+    shapes = required_action_weight_shapes(profile)
+    mapped = {name: np.zeros(shape, dtype=np.float32) for name, shape in shapes.items()}
+    mapped.pop("projections.action_in.bias")
+    with pytest.raises(ValueError, match="missing weight"):
+        _validate_action_weights(mapped, profile)
+
+    mapped["projections.action_in.bias"] = np.zeros((8,), dtype=np.float32)
+    mapped["action.layer.1.attention.k.weight"] = np.zeros((8, 8), dtype=np.float32)
+    with pytest.raises(ValueError, match=r"expected \(8, 4\)"):
+        _validate_action_weights(mapped, profile)
+
+
+@pytest.mark.trt
+def test_tiny_action_expert_serializes_with_compact_prefill_cache() -> None:
+    trt = pytest.importorskip("tensorrt")
+    profile = _tiny_action_profile()
+    plan = build_action_expert_engine(
+        profile,
+        _tiny_action_weights(profile),
+        precision="bf16",
+    )
+    assert len(plan) > 0
+
+    runtime = trt.Runtime(trt.Logger(trt.Logger.ERROR))
+    engine = runtime.deserialize_cuda_engine(plan)
+    assert engine is not None
+    io = {
+        engine.get_tensor_name(index): (
+            tuple(engine.get_tensor_shape(engine.get_tensor_name(index))),
+            engine.get_tensor_dtype(engine.get_tensor_name(index)),
+            engine.get_tensor_mode(engine.get_tensor_name(index)),
+        )
+        for index in range(engine.num_io_tensors)
+    }
+    assert set(io) == {
+        "noisy_actions",
+        "timestep",
+        "step_size",
+        "prefix_mask",
+        "suffix_position_ids",
+        "prefix_k_0",
+        "prefix_v_0",
+        "prefix_k_1",
+        "prefix_v_1",
+        "velocity",
+        "next_actions",
+    }
+    for name in ("prefix_k_0", "prefix_v_0", "prefix_k_1", "prefix_v_1"):
+        assert io[name] == (
+            (1, profile.prefix_length, 1, 4),
+            trt.bfloat16,
+            trt.TensorIOMode.INPUT,
+        )
+    for name in ("velocity", "next_actions"):
+        assert io[name] == (
+            (1, profile.action_horizon, profile.action_dim),
+            trt.float32,
+            trt.TensorIOMode.OUTPUT,
+        )

--- a/python/tensorrt_model_connect/families/openpi/tests/test_checkpoint_conversion.py
+++ b/python/tensorrt_model_connect/families/openpi/tests/test_checkpoint_conversion.py
@@ -1,0 +1,384 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import types
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families.openpi.checkpoint_reader import (
+    CheckpointReadError,
+    CheckpointReader,
+    _restore_orbax_payload,
+    file_sha256,
+    open_checkpoint,
+)
+from tensorrt_model_connect.families.openpi.model_config import (
+    GemmaConfig,
+    VisionConfig,
+    config_from_dir,
+    get_profile,
+)
+from tensorrt_model_connect.families.openpi.plugin import (
+    _validated_prepared_weight_path,
+)
+from tensorrt_model_connect.families.openpi.prepare_model_dir import prepare_model_dir
+from tensorrt_model_connect.families.openpi.tokenizer_export import TokenizerExportMetadata
+from tensorrt_model_connect.families.openpi.weight_mapper import (
+    DestinationTensor,
+    MappingRule,
+    WeightMappingError,
+    map_weights,
+    openpi_mapping_rules,
+)
+
+
+def _identity_rule(source: str, destination: str, shape: tuple[int, ...]) -> MappingRule:
+    return MappingRule(
+        source=source,
+        expected_shape=shape,
+        transform=lambda array: [DestinationTensor(destination, array.copy(), "identity")],
+    )
+
+
+def _tiny_profile():
+    return replace(
+        get_profile("pi05_droid"),
+        action_dim=3,
+        external_state_dim=2,
+        external_action_dim=2,
+        max_token_length=5,
+        vocab_size=11,
+        vision=VisionConfig(
+            image_size=4,
+            patch_size=2,
+            width=4,
+            depth=2,
+            mlp_dim=6,
+            num_heads=2,
+            output_width=8,
+            num_image_slots=3,
+        ),
+        prefix=GemmaConfig(
+            width=8,
+            depth=2,
+            mlp_dim=10,
+            num_heads=2,
+            num_kv_heads=1,
+            head_dim=4,
+        ),
+        action_expert=GemmaConfig(
+            width=4,
+            depth=2,
+            mlp_dim=7,
+            num_heads=2,
+            num_kv_heads=1,
+            head_dim=4,
+        ),
+    )
+
+
+def test_reader_flattens_params_and_uniform_nnx_value_suffix() -> None:
+    reader = CheckpointReader.from_tree(
+        {
+            "params": {
+                "PaliGemma": {
+                    "a": {"value": np.arange(4, dtype=np.float32).reshape(2, 2)},
+                    "b": {"value": np.ones(3, dtype=np.float16)},
+                }
+            }
+        }
+    )
+    assert tuple(reader) == ("PaliGemma/a", "PaliGemma/b")
+    assert reader.record("PaliGemma/a").shape == (2, 2)
+    assert len(reader.identity_sha256) == 64
+    assert reader.identity_sha256 == reader.identity_sha256
+
+
+def test_reader_rejects_non_array_leaf_and_object_dtype() -> None:
+    with pytest.raises(CheckpointReadError, match="object dtype"):
+        CheckpointReader({"bad": np.array([object()], dtype=object)})
+
+
+def test_npz_reader_is_dependency_free(tmp_path) -> None:
+    path = tmp_path / "checkpoint.npz"
+    np.savez(path, a=np.arange(3, dtype=np.float32), b=np.ones((2, 2), dtype=np.float16))
+    reader = open_checkpoint(path)
+    assert tuple(reader) == ("a", "b")
+    assert reader["a"].tolist() == [0.0, 1.0, 2.0]
+
+
+def test_orbax_tree_metadata_restore_forces_host_numpy(monkeypatch, tmp_path) -> None:
+    class FakeTreeMetadata:
+        tree = {"params": {"sharded": object()}}
+
+    class FakeRestoreArgs:
+        def __init__(self, *, restore_type):
+            self.restore_type = restore_type
+
+    class FakePyTreeRestore:
+        def __init__(self, *, item, restore_args):
+            self.item = item
+            self.restore_args = restore_args
+
+    class FakeTree:
+        @staticmethod
+        def map(function, tree):
+            if isinstance(tree, dict):
+                return {key: FakeTree.map(function, value) for key, value in tree.items()}
+            return function(tree)
+
+    class FakeCheckpointer:
+        restore_call = None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def metadata(self, path):
+            assert path == str(tmp_path)
+            return FakeTreeMetadata()
+
+        def restore(self, path, args=None):
+            assert path == str(tmp_path)
+            FakeCheckpointer.restore_call = args
+            return {"params": {"sharded": np.arange(3, dtype=np.float32)}}
+
+    fake_checkpoint = types.SimpleNamespace(
+        PyTreeCheckpointer=FakeCheckpointer,
+        RestoreArgs=FakeRestoreArgs,
+        args=types.SimpleNamespace(PyTreeRestore=FakePyTreeRestore),
+    )
+    monkeypatch.setitem(sys.modules, "orbax", types.SimpleNamespace(checkpoint=fake_checkpoint))
+    monkeypatch.setitem(sys.modules, "orbax.checkpoint", fake_checkpoint)
+    monkeypatch.setitem(sys.modules, "jax", types.SimpleNamespace(tree=FakeTree))
+
+    payload = _restore_orbax_payload(tmp_path)
+
+    np.testing.assert_array_equal(payload["sharded"], np.arange(3, dtype=np.float32))
+    call = FakeCheckpointer.restore_call
+    assert call.item == FakeTreeMetadata.tree
+    assert call.restore_args["params"]["sharded"].restore_type is np.ndarray
+
+
+def test_full_tiny_mapping_is_exhaustive_and_uses_compact_kv() -> None:
+    profile = _tiny_profile()
+    rules = openpi_mapping_rules(profile)
+    arrays = {}
+    for index, rule in enumerate(rules):
+        count = int(np.prod(rule.expected_shape))
+        arrays[rule.source] = (
+            np.arange(count, dtype=np.float32).reshape(rule.expected_shape) + index
+        )
+    reader = CheckpointReader(arrays)
+    result = map_weights(reader, profile, rules=rules)
+
+    assert result.manifest["source_checkpoint"]["tensor_count"] == len(rules)
+    assert result.manifest["destination_weights"]["tensor_count"] == len(result.weights)
+    assert len(result.manifest["source_checkpoint"]["identity_sha256"]) == 64
+    assert result.weights["prefix.layer.0.attention.k.weight"].shape == (8, 4)
+    assert result.weights["action.layer.0.attention.k.weight"].shape == (4, 4)
+    assert result.weights["action.layer.0.attention.q.weight"].shape == (4, 8)
+    assert result.weights["action.layer.0.pre_attention_norm.dense.weight"].shape == (4, 12)
+
+    source_patch = arrays["PaliGemma/img/embedding/kernel"]
+    np.testing.assert_array_equal(
+        result.weights["vision.patch_embedding.weight"],
+        source_patch.transpose(3, 2, 0, 1),
+    )
+    destination_names = [entry["name"] for entry in result.manifest["destination_tensors"]]
+    assert destination_names == sorted(destination_names)
+    assert set(destination_names) == set(result.weights)
+
+
+@pytest.mark.parametrize(
+    ("arrays", "rules", "message"),
+    [
+        (
+            {"a": np.ones(2, dtype=np.float32)},
+            (_identity_rule("missing", "x", (2,)),),
+            "missing=missing.*unexpected=a",
+        ),
+        (
+            {"a": np.ones(2, dtype=np.float32), "extra": np.ones(1, dtype=np.float32)},
+            (_identity_rule("a", "x", (2,)),),
+            "unexpected=extra",
+        ),
+        (
+            {"a": np.ones(2, dtype=np.float32)},
+            (_identity_rule("a", "x", (2,)), _identity_rule("a", "y", (2,))),
+            "duplicate source mapping rules",
+        ),
+        (
+            {"a": np.ones(3, dtype=np.float32)},
+            (_identity_rule("a", "x", (2,)),),
+            "expected \\(2,\\), got \\(3,\\)",
+        ),
+        (
+            {"a": np.ones(2, dtype=np.int32)},
+            (_identity_rule("a", "x", (2,)),),
+            "expected floating point",
+        ),
+    ],
+)
+def test_mapping_rejects_missing_unexpected_duplicate_shape_and_dtype(
+    arrays, rules, message
+) -> None:
+    with pytest.raises(WeightMappingError, match=message):
+        map_weights(CheckpointReader(arrays), get_profile("pi05_droid"), rules=rules)
+
+
+def test_mapping_rejects_duplicate_destinations() -> None:
+    rules = (
+        _identity_rule("a", "same", (1,)),
+        _identity_rule("b", "same", (1,)),
+    )
+    with pytest.raises(WeightMappingError, match="duplicate destination mapping"):
+        map_weights(
+            CheckpointReader(
+                {"a": np.ones(1, dtype=np.float32), "b": np.ones(1, dtype=np.float32)}
+            ),
+            get_profile("pi05_droid"),
+            rules=rules,
+        )
+
+
+def test_prepare_model_dir_writes_hash_bound_artifacts(tmp_path, monkeypatch) -> None:
+    checkpoint = tmp_path / "checkpoint.npz"
+    np.savez(checkpoint, synthetic=np.arange(6, dtype=np.float32).reshape(2, 3))
+    tokenizer = tmp_path / "tokenizer.model"
+    tokenizer.write_bytes(b"synthetic-tokenizer")
+
+    def fake_tokenizer_export(source_model, output_asset, *, overwrite=False):
+        assert Path(source_model) == tokenizer.resolve()
+        assert not overwrite
+        output_path = Path(output_asset)
+        output_path.write_bytes(b"TRTMCBPE\x01synthetic-native-asset")
+        return TokenizerExportMetadata(
+            schema_version=1,
+            source_model_type="BPE",
+            source_sha256=file_sha256(tokenizer),
+            asset_sha256=file_sha256(output_path),
+            asset_size=output_path.stat().st_size,
+            piece_count=260,
+            piece_type_counts={
+                "normal": 0,
+                "unknown": 1,
+                "control": 3,
+                "user_defined": 0,
+                "unused": 0,
+                "byte": 256,
+            },
+            normalization_name="identity",
+            normalization_rule_count=0,
+            add_dummy_prefix=False,
+            remove_extra_whitespaces=False,
+            escape_whitespaces=True,
+            byte_fallback=True,
+            treat_whitespace_as_suffix=False,
+            unknown_id=3,
+            bos_id=2,
+            eos_id=1,
+            pad_id=0,
+        )
+
+    monkeypatch.setattr(
+        "tensorrt_model_connect.families.openpi.prepare_model_dir.export_paligemma_bpe_model",
+        fake_tokenizer_export,
+    )
+    norm_stats = tmp_path / "norm_stats.json"
+    norm_stats.write_text(
+        json.dumps(
+            {
+                "norm_stats": {
+                    "state": {"mean": [0] * 8, "std": [1] * 8, "q01": [-1] * 8, "q99": [1] * 8},
+                    "actions": {"mean": [0] * 8, "std": [1] * 8, "q01": [-1] * 8, "q99": [1] * 8},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "prepared"
+    args = argparse.Namespace(
+        profile="pi05_droid",
+        checkpoint=str(checkpoint),
+        tokenizer=str(tokenizer),
+        norm_stats=str(norm_stats),
+        output=str(output),
+        force=False,
+    )
+    result = prepare_model_dir(
+        args,
+        rules=(_identity_rule("synthetic", "prefix.synthetic", (2, 3)),),
+    )
+
+    config = json.loads((output / "openpi_config.json").read_text(encoding="utf-8"))
+    manifest_path = output / "openpi_conversion_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert result["profile"] == "pi05_droid"
+    assert result["source_tensor_count"] == 1
+    assert result["destination_tensor_count"] == 1
+    assert config["conversion_manifest_sha256"] == file_sha256(manifest_path)
+    assert manifest["artifacts"]["tokenizer"]["source_sha256"] == file_sha256(tokenizer)
+    tokenizer_asset = output / "tokenizer.model"
+    assert tokenizer_asset.is_file()
+    normalization_asset = output / "preprocessor_config.json"
+    assert normalization_asset.is_file()
+    assert not (output / "assets").exists()
+    assert config["tokenizer"] == "tokenizer.model"
+    assert config["tokenizer_format"] == "TRTMCBPE"
+    assert config["tokenizer_sha256"] == file_sha256(tokenizer_asset)
+    assert config["normalization"] == "preprocessor_config.json"
+    assert config["normalization_sha256"] == file_sha256(normalization_asset)
+    assert config["tokenizer_export"]["source_model_type"] == "BPE"
+    assert manifest["artifacts"]["tokenizer"]["format"] == "TRTMCBPE"
+    assert manifest["artifacts"]["tokenizer"]["asset_sha256"] == file_sha256(tokenizer_asset)
+    assert manifest["artifacts"]["normalization"]["source_sha256"] == file_sha256(norm_stats)
+    assert manifest["artifacts"]["weights"]["sha256"] == file_sha256(output / "model.safetensors")
+    family_config = config_from_dir(str(output))
+    assert family_config is not None
+    bundle_config = ModelConfig.from_json(json.dumps(family_config))
+    assert _validated_prepared_weight_path(output, bundle_config) == output / "model.safetensors"
+    assert (output / ".trtmc-openpi-model-dir").is_file()
+
+
+def test_prepare_model_dir_refuses_invalid_quantiles(tmp_path) -> None:
+    checkpoint = tmp_path / "checkpoint.npz"
+    np.savez(checkpoint, synthetic=np.ones(1, dtype=np.float32))
+    tokenizer = tmp_path / "tokenizer.model"
+    tokenizer.write_bytes(b"x")
+    norm_stats = tmp_path / "norm_stats.json"
+    norm_stats.write_text(
+        json.dumps(
+            {
+                "norm_stats": {
+                    "state": {"q01": [1] * 8, "q99": [0] * 8},
+                    "actions": {"q01": [-1] * 8, "q99": [1] * 8},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    args = argparse.Namespace(
+        profile="pi05_droid",
+        checkpoint=str(checkpoint),
+        tokenizer=str(tokenizer),
+        norm_stats=str(norm_stats),
+        output=str(tmp_path / "prepared"),
+        force=False,
+    )
+    with pytest.raises(ValueError, match="q99 <= q01"):
+        prepare_model_dir(
+            args,
+            rules=(_identity_rule("synthetic", "prefix.synthetic", (1,)),),
+        )

--- a/python/tensorrt_model_connect/families/openpi/tests/test_model_config.py
+++ b/python/tensorrt_model_connect/families/openpi/tests/test_model_config.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tensorrt_model_connect.families.openpi.model_config import (
+    OPENPI_MODEL_TYPE,
+    OPENPI_UPSTREAM_COMMIT,
+    config_from_dir,
+    get_profile,
+    profile_names,
+)
+
+
+def test_profiles_are_explicit_and_pinned() -> None:
+    assert profile_names() == ("pi05_droid",)
+
+    droid = get_profile("pi05_droid")
+    assert droid.upstream_commit == OPENPI_UPSTREAM_COMMIT
+    assert droid.action_horizon == 15
+    assert droid.external_state_dim == 8
+    assert droid.external_action_dim == 8
+    assert droid.discrete_state_input is True
+    assert droid.prefix_length == 968
+    assert droid.prefix.kv_width == 256
+    assert droid.action_expert.kv_width == 256
+
+
+def test_profile_selection_never_infers_from_path() -> None:
+    with pytest.raises(ValueError, match="unsupported OpenPI profile"):
+        get_profile("/tmp/checkpoints/pi05_droid")
+
+
+def test_prepared_config_is_commit_bound(tmp_path) -> None:
+    config_path = tmp_path / "openpi_config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "profile": "pi05_droid",
+                "upstream_commit": OPENPI_UPSTREAM_COMMIT,
+                "conversion_manifest": "openpi_conversion_manifest.json",
+                "tokenizer": "assets/paligemma_tokenizer.trtmcbpe",
+                "tokenizer_sha256": "1" * 64,
+                "tokenizer_source_sha256": "2" * 64,
+                "tokenizer_export": {"schema_version": 1, "source_model_type": "BPE"},
+                "normalization": "assets/droid/norm_stats.json",
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = config_from_dir(str(tmp_path))
+    assert config is not None
+    assert config["model_type"] == OPENPI_MODEL_TYPE
+    assert config["head_dim"] == 256
+    assert config["openpi"]["action_horizon"] == 15
+    assert config["openpi_tokenizer_file"] == "assets/paligemma_tokenizer.trtmcbpe"
+    assert config["openpi_tokenizer_sha256"] == "1" * 64
+    assert config["openpi_normalization_file"] == "assets/droid/norm_stats.json"
+    assert config["openpi_tokenizer_source_sha256"] == "2" * 64
+    assert config["openpi_tokenizer_export"]["source_model_type"] == "BPE"
+
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    payload["upstream_commit"] = "0" * 40
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="unaudited upstream commit"):
+        config_from_dir(str(tmp_path))

--- a/python/tensorrt_model_connect/families/openpi/tests/test_numerics.py
+++ b/python/tensorrt_model_connect/families/openpi/tests/test_numerics.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+
+from tensorrt_model_connect.families.openpi.numerics import (
+    round_to_bfloat16_float32,
+    sinusoidal_inverse_periods_numpy,
+)
+
+
+def test_bfloat16_rounding_is_ties_to_even_and_portably_stored_as_float32() -> None:
+    source_bits = np.array([0x3F800000, 0x3F808000, 0x3F818000, 0xBF818000], dtype=np.uint32)
+    rounded = round_to_bfloat16_float32(source_bits.view(np.float32))
+
+    assert rounded.dtype == np.float32
+    assert rounded.view(np.uint32).tolist() == [
+        0x3F800000,
+        0x3F800000,
+        0x3F820000,
+        0xBF820000,
+    ]
+    np.testing.assert_array_equal(round_to_bfloat16_float32(rounded), rounded)
+
+
+def test_canonical_timestep_inverse_periods_match_pinned_xla_table() -> None:
+    inverse_periods = sinusoidal_inverse_periods_numpy(1024)
+
+    assert inverse_periods.shape == (512,)
+    assert inverse_periods.dtype == np.float32
+    assert hashlib.sha256(inverse_periods.astype("<f4").tobytes()).hexdigest() == (
+        "1761ced44acfa477ba656be02ea923a0ab201cef26e43cafe63de22272890f03"
+    )

--- a/python/tensorrt_model_connect/families/openpi/tests/test_plugin_integration.py
+++ b/python/tensorrt_model_connect/families/openpi/tests/test_plugin_integration.py
@@ -1,0 +1,513 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tensorrt_model_connect.checkpoint_mapper import WeightDict
+from tensorrt_model_connect.config import ModelConfig
+from tensorrt_model_connect.families import find_plugin
+from tensorrt_model_connect.families.openpi.model_config import (
+    OPENPI_MODEL_TYPE,
+    OPENPI_UPSTREAM_COMMIT,
+    get_profile,
+)
+
+
+action_builder = importlib.import_module(
+    "tensorrt_model_connect.families.openpi.action_expert_builder"
+)
+plugin_module = importlib.import_module("tensorrt_model_connect.families.openpi.plugin")
+
+
+_CHECKPOINT_SHA256 = "a" * 64
+_MANIFEST_SHA256 = "b" * 64
+_TOKENIZER_SHA256 = "c" * 64
+_NORMALIZATION_SHA256 = "d" * 64
+_PREFILL_PLAN_SHA256 = "e" * 64
+_ACTION_PLAN_SHA256 = "f" * 64
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _config(profile: str = "pi05_droid", **updates) -> ModelConfig:
+    raw = {
+        "openpi_profile": profile,
+        "openpi_upstream_commit": OPENPI_UPSTREAM_COMMIT,
+        "openpi_checkpoint_identity_sha256": _CHECKPOINT_SHA256,
+        "openpi_conversion_manifest_sha256": _MANIFEST_SHA256,
+        "openpi_tokenizer_sha256": _TOKENIZER_SHA256,
+        "openpi_normalization_sha256": _NORMALIZATION_SHA256,
+        "openpi_prefill_engine_sha256": _PREFILL_PLAN_SHA256,
+        "openpi_action_engine_sha256": _ACTION_PLAN_SHA256,
+    }
+    raw.update(updates)
+    return ModelConfig(model_type=OPENPI_MODEL_TYPE, raw=raw)
+
+
+def _write(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def _render_json(payload: object) -> bytes:
+    return (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode()
+
+
+def _bundle_fixture(tmp_path: Path, profile_name: str = "pi05_droid"):
+    model_dir = tmp_path / "prepared"
+    weights_relative = "model.safetensors"
+    tokenizer_relative = "assets/paligemma_tokenizer.trtmcbpe"
+    normalization_relative = f"assets/{get_profile(profile_name).asset_id}/norm_stats.json"
+    manifest_relative = "openpi_conversion_manifest.json"
+    tokenizer = b"TRTMCBPE\x01\x00native-paligemma-bpe"
+    weights = b"synthetic-safetensors-for-integrity-tests"
+    normalization = _render_json(
+        {
+            "norm_stats": {
+                "actions": {"q01": [-1.0], "q99": [1.0]},
+                "state": {"q01": [-1.0], "q99": [1.0]},
+            }
+        }
+    )
+    _write(model_dir / weights_relative, weights)
+    _write(model_dir / tokenizer_relative, tokenizer)
+    _write(model_dir / normalization_relative, normalization)
+    # The pinned legacy prepared snapshot keeps nested source paths.  Standard
+    # aliases let the unchanged shared bundle writer embed the exact same bytes.
+    _write(model_dir / "tokenizer.model", tokenizer)
+    _write(model_dir / "preprocessor_config.json", normalization)
+    manifest = {
+        "schema_version": 1,
+        "format": "trtmc.openpi.weight-conversion",
+        "profile": profile_name,
+        "upstream": {
+            "repository": "https://github.com/Physical-Intelligence/openpi",
+            "commit": OPENPI_UPSTREAM_COMMIT,
+        },
+        "source_checkpoint": {"identity_sha256": _CHECKPOINT_SHA256},
+        "artifacts": {
+            "weights": {
+                "file": weights_relative,
+                "sha256": _sha256(weights),
+            },
+            "tokenizer": {
+                "file": tokenizer_relative,
+                "sha256": _sha256(tokenizer),
+                "asset_sha256": _sha256(tokenizer),
+            },
+            "normalization": {
+                "file": normalization_relative,
+                "sha256": _sha256(normalization),
+            },
+        },
+    }
+    manifest_path = model_dir / manifest_relative
+    manifest_payload = _render_json(manifest)
+    _write(manifest_path, manifest_payload)
+    config = _config(
+        profile_name,
+        openpi_weights_file=weights_relative,
+        openpi_tokenizer_file=tokenizer_relative,
+        openpi_tokenizer_sha256=_sha256(tokenizer),
+        openpi_normalization_file=normalization_relative,
+        openpi_normalization_sha256=_sha256(normalization),
+        openpi_conversion_manifest=manifest_relative,
+        openpi_conversion_manifest_sha256=_sha256(manifest_payload),
+    )
+    return {
+        "model_dir": model_dir,
+        "config": config,
+        "weights": weights,
+        "weights_path": model_dir / weights_relative,
+        "tokenizer": tokenizer,
+        "tokenizer_path": model_dir / tokenizer_relative,
+        "normalization": normalization,
+        "normalization_path": model_dir / normalization_relative,
+        "manifest": manifest,
+        "manifest_path": manifest_path,
+        "manifest_payload": manifest_payload,
+    }
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        "openpi",
+        "OPENPI",
+        "openpi_pi05_flow",
+        "OpenPI-PI05-Flow",
+        "pi05_droid",
+        "PI05-DROID",
+    ],
+)
+def test_plugin_matches_every_owned_alias(model_type: str) -> None:
+    assert plugin_module.plugin.matches(model_type)
+
+
+@pytest.mark.parametrize("model_type", ["", "pi0", "qwen", "openpi_pi0_flow"])
+def test_plugin_rejects_foreign_model_types(model_type: str) -> None:
+    assert not plugin_module.plugin.matches(model_type)
+
+
+def test_profile_binding_requires_an_explicit_profile_and_pinned_commit() -> None:
+    nested = _config()
+    nested.raw.pop("openpi_profile")
+    nested.raw["openpi"] = {"name": "pi05_droid"}
+    assert plugin_module.plugin.get_bundle_config_overrides(nested)["openpi_profile"] == (
+        "pi05_droid"
+    )
+
+    with pytest.raises(ValueError, match="unsupported OpenPI profile"):
+        plugin_module.plugin.get_bundle_config_overrides(
+            ModelConfig(
+                model_type=OPENPI_MODEL_TYPE,
+                raw={"openpi_upstream_commit": OPENPI_UPSTREAM_COMMIT},
+            )
+        )
+    with pytest.raises(ValueError, match="audited upstream commit"):
+        plugin_module.plugin.get_bundle_config_overrides(_config(openpi_upstream_commit="0" * 40))
+
+
+@pytest.mark.parametrize(
+    ("profile_name", "action_horizon", "external_action_dim", "discrete_state_input"),
+    [
+        ("pi05_droid", 15, 8, True),
+    ],
+)
+def test_bundle_config_overrides_are_the_complete_native_runtime_contract(
+    profile_name: str,
+    action_horizon: int,
+    external_action_dim: int,
+    discrete_state_input: bool,
+) -> None:
+    profile = get_profile(profile_name)
+    assert plugin_module.plugin.get_bundle_config_overrides(_config(profile_name)) == {
+        "engine_backend": "trt",
+        "runtime_strategy": "openpi_vla",
+        "task_strategy": "robot_action_generation",
+        "user_contract": "robot_action_chunk",
+        "model_type": OPENPI_MODEL_TYPE,
+        "openpi_profile": profile_name,
+        "openpi_upstream_commit": OPENPI_UPSTREAM_COMMIT,
+        "openpi_action_horizon": action_horizon,
+        "openpi_internal_action_dim": 32,
+        "openpi_external_action_dim": external_action_dim,
+        "openpi_external_state_dim": 8,
+        "openpi_prefix_length": 968,
+        "openpi_max_token_length": 200,
+        "openpi_num_layers": 18,
+        "openpi_num_heads": 8,
+        "openpi_num_kv_heads": 1,
+        "openpi_head_dim": 256,
+        "openpi_denoise_steps": 10,
+        "openpi_discrete_state_input": discrete_state_input,
+        "openpi_camera_names": list(profile.camera_names),
+        "openpi_camera_mask": list(profile.camera_mask),
+        "openpi_batch_size": 1,
+        "openpi_runtime_contract": "native_cpp_device_resident_flow",
+        "openpi_parameter_dtype": "bfloat16",
+        "openpi_tokenizer_sha256": _TOKENIZER_SHA256,
+        "openpi_normalization_sha256": _NORMALIZATION_SHA256,
+        "openpi_prefill_engine_sha256": _PREFILL_PLAN_SHA256,
+        "openpi_action_engine_sha256": _ACTION_PLAN_SHA256,
+    }
+
+
+def test_weight_inventory_accepts_only_the_exact_names_and_shapes(monkeypatch) -> None:
+    monkeypatch.setattr(
+        plugin_module,
+        "required_prefill_weight_shapes",
+        lambda _profile: {"prefix.weight": (2, 3)},
+    )
+    monkeypatch.setattr(
+        action_builder,
+        "required_action_weight_shapes",
+        lambda _profile: {"action.weight": (3,)},
+    )
+    profile = get_profile("pi05_droid")
+    valid = WeightDict(
+        {
+            "prefix.weight": np.zeros((2, 3), dtype=np.float32),
+            "action.weight": np.zeros(3, dtype=np.float16),
+        }
+    )
+    plugin_module._validate_weight_inventory(valid, profile)
+
+    with pytest.raises(ValueError, match=r"missing=action\.weight"):
+        plugin_module._validate_weight_inventory(
+            WeightDict({"prefix.weight": valid["prefix.weight"]}), profile
+        )
+    with pytest.raises(ValueError, match=r"unexpected=rogue\.weight"):
+        plugin_module._validate_weight_inventory(
+            WeightDict({**valid, "rogue.weight": np.zeros(1, dtype=np.float32)}),
+            profile,
+        )
+    with pytest.raises(ValueError, match=r"prefix\.weight: expected \(2, 3\), got \(3, 2\)"):
+        plugin_module._validate_weight_inventory(
+            WeightDict(
+                {
+                    "prefix.weight": np.zeros((3, 2), dtype=np.float32),
+                    "action.weight": valid["action.weight"],
+                }
+            ),
+            profile,
+        )
+
+
+def test_extra_engine_uses_the_exact_runtime_section_name(monkeypatch) -> None:
+    calls = []
+
+    def fake_build(profile, weights, *, precision, verbose):
+        calls.append((profile, weights, precision, verbose))
+        return b"ACTION-PLAN"
+
+    monkeypatch.setattr(action_builder, "build_action_expert_engine", fake_build)
+    weights = WeightDict({"sentinel": np.zeros(1, dtype=np.float32)})
+    config = _config("pi05_droid")
+    sections = plugin_module.plugin.build_extra_engines(
+        config,
+        weights,
+        1234,
+        precision="bf16",
+        verbose=True,
+        build_timing={},
+    )
+
+    assert sections == {"openpi_action_step_engine_plan": b"ACTION-PLAN"}
+    assert calls == [(get_profile("pi05_droid"), weights, "bf16", True)]
+    assert config.raw["openpi_action_engine_sha256"] == _sha256(b"ACTION-PLAN")
+
+
+def test_prefill_engine_hash_is_bound_into_the_runtime_config(monkeypatch) -> None:
+    monkeypatch.setattr(
+        plugin_module,
+        "build_prefill_engine",
+        lambda *_args, **_kwargs: b"PREFILL-PLAN",
+    )
+    config = _config("pi05_droid")
+
+    assert (
+        plugin_module.plugin.build_engine(
+            config,
+            WeightDict(),
+            1234,
+            precision="bf16",
+        )
+        == b"PREFILL-PLAN"
+    )
+    assert config.raw["openpi_prefill_engine_sha256"] == _sha256(b"PREFILL-PLAN")
+
+
+@pytest.mark.parametrize("precision", ["fp16", "fp32"])
+def test_plugin_rejects_unqualified_precision_before_load_or_build(
+    monkeypatch, precision: str
+) -> None:
+    def unexpected_call(*_args, **_kwargs):
+        raise AssertionError("OpenPI reached an implementation behind the precision gate")
+
+    monkeypatch.setattr(plugin_module, "_load_prepared_weights", unexpected_call)
+    monkeypatch.setattr(plugin_module, "build_prefill_engine", unexpected_call)
+    monkeypatch.setattr(action_builder, "build_action_expert_engine", unexpected_call)
+    config = _config("pi05_droid")
+    weights = WeightDict()
+    message = r"only precision='bf16'"
+
+    with pytest.raises(ValueError, match=message):
+        plugin_module.plugin.load_weights("unused", config, precision=precision)
+    with pytest.raises(ValueError, match=message):
+        plugin_module.plugin.build_engine(config, weights, 0, precision=precision)
+    with pytest.raises(ValueError, match=message):
+        plugin_module.plugin.build_extra_engines(config, weights, 0, precision=precision)
+
+
+def test_prepared_weights_are_sha256_bound_to_the_conversion_manifest(tmp_path) -> None:
+    fixture = _bundle_fixture(tmp_path)
+
+    assert (
+        plugin_module._validated_prepared_weight_path(fixture["model_dir"], fixture["config"])
+        == fixture["weights_path"]
+    )
+
+    fixture["weights_path"].write_bytes(b"tampered-but-still-structurally-valid-safetensors")
+    with pytest.raises(ValueError, match="manifest weights SHA-256"):
+        plugin_module._validated_prepared_weight_path(fixture["model_dir"], fixture["config"])
+
+
+def test_prepared_asset_validation_accepts_standard_aliases_for_legacy_paths(
+    tmp_path,
+) -> None:
+    fixture = _bundle_fixture(tmp_path)
+    assert (
+        plugin_module._validated_prepared_weight_path(fixture["model_dir"], fixture["config"])
+        == fixture["weights_path"]
+    )
+    assert fixture["config"].raw["openpi_tokenizer_sha256"] == _sha256(fixture["tokenizer"])
+    assert fixture["config"].raw["openpi_normalization_sha256"] == _sha256(fixture["normalization"])
+
+
+@pytest.mark.parametrize(
+    ("standard_name", "message"),
+    [
+        ("tokenizer.model", "does not match the converted tokenizer"),
+        ("preprocessor_config.json", "does not match the normalization"),
+    ],
+)
+def test_prepared_asset_validation_rejects_mismatched_standard_aliases(
+    tmp_path, standard_name: str, message: str
+) -> None:
+    fixture = _bundle_fixture(tmp_path)
+    (fixture["model_dir"] / standard_name).write_bytes(b"tampered-alias")
+    with pytest.raises(ValueError, match=message):
+        plugin_module._validated_prepared_weight_path(fixture["model_dir"], fixture["config"])
+
+
+@pytest.mark.parametrize(
+    ("config_key", "label"),
+    [
+        ("openpi_tokenizer_file", "flattened tokenizer"),
+        ("openpi_normalization_file", "normalization statistics"),
+        ("openpi_conversion_manifest", "conversion manifest"),
+    ],
+)
+def test_prepared_asset_validation_rejects_paths_outside_the_prepared_directory(
+    tmp_path, config_key: str, label: str
+) -> None:
+    fixture = _bundle_fixture(tmp_path)
+    outside = tmp_path / "outside.bin"
+    outside.write_bytes(b"outside")
+    fixture["config"].raw[config_key] = "../outside.bin"
+
+    with pytest.raises(ValueError, match=rf"{label} escapes"):
+        plugin_module._validated_prepared_weight_path(fixture["model_dir"], fixture["config"])
+
+
+def test_prepared_asset_validation_rejects_tampered_payload_semantics(tmp_path) -> None:
+    fixture = _bundle_fixture(tmp_path)
+    fixture["tokenizer_path"].write_bytes(b"NOT-BPE")
+    with pytest.raises(ValueError, match="invalid binary header"):
+        plugin_module._validated_prepared_weight_path(fixture["model_dir"], fixture["config"])
+
+    fixture = _bundle_fixture(tmp_path / "norm")
+    fixture["normalization_path"].write_bytes(b"[]\n")
+    with pytest.raises(ValueError, match="must contain a JSON object"):
+        plugin_module._validated_prepared_weight_path(fixture["model_dir"], fixture["config"])
+
+    fixture = _bundle_fixture(tmp_path / "manifest")
+    fixture["manifest"]["upstream"]["commit"] = "0" * 40
+    tampered_manifest = _render_json(fixture["manifest"])
+    fixture["manifest_path"].write_bytes(tampered_manifest)
+    fixture["config"].raw["openpi_conversion_manifest_sha256"] = _sha256(tampered_manifest)
+    with pytest.raises(ValueError, match="unaudited upstream repository or commit"):
+        plugin_module._validated_prepared_weight_path(fixture["model_dir"], fixture["config"])
+
+
+@pytest.mark.parametrize(
+    "checkpoint_sha256",
+    ["", "0" * 64, "A" * 64, "g" * 64, "a" * 63],
+)
+def test_prepared_asset_validation_rejects_invalid_checkpoint_hashes(
+    tmp_path, checkpoint_sha256: str
+) -> None:
+    fixture = _bundle_fixture(tmp_path)
+    fixture["config"].raw["openpi_checkpoint_identity_sha256"] = checkpoint_sha256
+    with pytest.raises(ValueError, match="checkpoint identity SHA-256"):
+        plugin_module._validated_prepared_weight_path(fixture["model_dir"], fixture["config"])
+
+
+@pytest.mark.parametrize(
+    ("tamper", "message"),
+    [
+        ("config_tokenizer", "tokenizer SHA-256"),
+        ("config_manifest", "conversion manifest SHA-256"),
+        ("manifest_tokenizer", "manifest tokenizer SHA-256"),
+        ("manifest_normalization", "manifest normalization SHA-256"),
+        ("manifest_checkpoint", "manifest checkpoint identity"),
+    ],
+)
+def test_prepared_asset_validation_rejects_every_hash_binding_mismatch(
+    tmp_path, tamper: str, message: str
+) -> None:
+    fixture = _bundle_fixture(tmp_path)
+    if tamper == "config_tokenizer":
+        fixture["config"].raw["openpi_tokenizer_sha256"] = "f" * 64
+    elif tamper == "config_manifest":
+        fixture["config"].raw["openpi_conversion_manifest_sha256"] = "f" * 64
+    elif tamper == "manifest_tokenizer":
+        fixture["manifest"]["artifacts"]["tokenizer"]["sha256"] = "f" * 64
+    elif tamper == "manifest_normalization":
+        fixture["manifest"]["artifacts"]["normalization"]["sha256"] = "f" * 64
+    elif tamper == "manifest_checkpoint":
+        fixture["manifest"]["source_checkpoint"]["identity_sha256"] = "f" * 64
+    else:  # pragma: no cover - exhaustive parameter guard
+        raise AssertionError(tamper)
+
+    if tamper.startswith("manifest_"):
+        manifest_payload = _render_json(fixture["manifest"])
+        fixture["manifest_path"].write_bytes(manifest_payload)
+        fixture["config"].raw["openpi_conversion_manifest_sha256"] = _sha256(manifest_payload)
+
+    with pytest.raises(ValueError, match=message):
+        plugin_module._validated_prepared_weight_path(fixture["model_dir"], fixture["config"])
+
+
+def test_repository_family_index_drives_openpi_plugin_discovery() -> None:
+    import tensorrt_model_connect.families as families
+
+    metadata = next(meta for meta in families._load_family_metadata() if meta.id == "openpi")
+    assert metadata.import_module == "openpi"
+    assert metadata.aliases == {
+        "openpi",
+        "openpi_pi05_flow",
+        "pi05_droid",
+    }
+    assert metadata.prefixes == {"openpi", "pi05"}
+    assert metadata.config_adapter == "model_config.py|config_from_dir"
+    assert set(metadata.hf_allow_patterns) == {
+        "openpi_config.json",
+        "openpi_conversion_manifest.json",
+        "tokenizer.model",
+        "preprocessor_config.json",
+        "assets/paligemma_tokenizer.trtmcbpe",
+        "assets/droid/norm_stats.json",
+        "trtmc_openpi/**",
+    }
+    assert {
+        "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|trtmc_openpi/reference/reference-set.json",
+        "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|trtmc_openpi/request/request.json",
+        "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID|"
+        "trtmc_openpi/performance/pytorch-eager.json",
+    }.issubset(metadata.hf_required_files)
+    for alias in metadata.aliases:
+        assert find_plugin(alias) is plugin_module.plugin
+
+
+def test_repository_e2e_manifests_validate_as_openpi_cases(monkeypatch) -> None:
+    from tests.e2e_harness import manifest_loader
+
+    # Runtime-strategy registration is validated by the runtime model manifest
+    # suite. This test isolates the Python family and its DROID E2E manifest.
+    monkeypatch.setattr(
+        manifest_loader,
+        "_known_runtime_strategies",
+        lambda: frozenset({"openpi_vla"}),
+    )
+    repository_root = Path(__file__).resolve().parents[5]
+    cases = manifest_loader.load_all_manifests(
+        repository_root / "tests" / "e2e" / "models" / "openpi"
+    )
+
+    assert [case.name for case in cases] == ["pi05-droid"]
+    assert {case.family for case in cases} == {"openpi"}
+    assert {case.runtime_strategy for case in cases} == {"openpi_vla"}
+    assert {case.task_strategy for case in cases} == {"robot_action_generation"}
+    assert {case.metadata["precision"] for case in cases} == {"bf16"}

--- a/python/tensorrt_model_connect/families/openpi/tests/test_prefill_builder.py
+++ b/python/tensorrt_model_connect/families/openpi/tests/test_prefill_builder.py
@@ -1,0 +1,855 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import inspect
+import sys
+import types
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import tensorrt_model_connect.families.openpi as openpi_package
+from tensorrt_model_connect.families.openpi import prefill_builder as prefill_builder_module
+from tensorrt_model_connect.families.openpi.model_config import (
+    GemmaConfig,
+    VisionConfig,
+    get_profile,
+)
+from tensorrt_model_connect.families.openpi.prefill_builder import (
+    _gelu_tanh,
+    build_prefill_engine,
+    prefill_input_contract,
+    prefix_cache_output_name,
+    required_prefill_weight_shapes,
+    validate_prefill_weights,
+)
+
+
+def _tiny_profile():
+    return replace(
+        get_profile("pi05_droid"),
+        action_dim=3,
+        external_state_dim=2,
+        external_action_dim=2,
+        max_token_length=5,
+        vocab_size=11,
+        vision=VisionConfig(
+            image_size=4,
+            patch_size=2,
+            width=4,
+            depth=2,
+            mlp_dim=6,
+            num_heads=2,
+            output_width=8,
+            num_image_slots=3,
+        ),
+        prefix=GemmaConfig(
+            width=8,
+            depth=2,
+            mlp_dim=10,
+            num_heads=2,
+            num_kv_heads=1,
+            head_dim=4,
+        ),
+        action_expert=GemmaConfig(
+            width=4,
+            depth=2,
+            mlp_dim=7,
+            num_heads=2,
+            num_kv_heads=1,
+            head_dim=4,
+        ),
+    )
+
+
+def _tiny_weights(profile) -> dict[str, np.ndarray]:
+    return {
+        name: np.full(shape, (index + 1) / 1000.0, dtype=np.float32)
+        for index, (name, shape) in enumerate(required_prefill_weight_shapes(profile).items())
+    }
+
+
+def test_production_io_contract_is_fixed_batch_one_and_compact() -> None:
+    inputs = prefill_input_contract("pi05_droid")
+    assert [(item.name, item.shape, item.dtype) for item in inputs] == [
+        ("pixel_values", (3, 3, 224, 224), "float32"),
+        ("token_ids", (1, 200), "int32"),
+        ("prefix_mask", (1, 968), "bool"),
+        ("prefix_position_ids", (1, 968), "int32"),
+    ]
+
+
+def test_production_prefill_builder_exposes_no_trace_plan_switches() -> None:
+    parameters = inspect.signature(build_prefill_engine).parameters
+    assert "debug_outputs" not in parameters
+    assert "debug_prefix_layer" not in parameters
+    assert "emit_prefix_hidden" not in parameters
+
+
+def test_required_production_weights_use_canonical_compact_names() -> None:
+    shapes = required_prefill_weight_shapes("pi05_droid")
+    assert len(shapes) == 603
+    assert shapes["vision.patch_embedding.weight"] == (1152, 3, 14, 14)
+    assert shapes["prefix.layer.0.attention.q.weight"] == (2048, 2048)
+    assert shapes["prefix.layer.0.attention.k.weight"] == (2048, 256)
+    assert shapes["prefix.layer.17.attention.v.weight"] == (2048, 256)
+    assert shapes["prefix.layer.17.attention.o.weight"] == (2048, 2048)
+    assert all(not name.startswith("action.") for name in shapes)
+
+
+def test_weight_validation_reports_missing_shape_and_dtype() -> None:
+    profile = _tiny_profile()
+    weights = _tiny_weights(profile)
+    validate_prefill_weights(weights, profile)
+
+    missing = dict(weights)
+    del missing["prefix.embedding"]
+    with pytest.raises(ValueError, match="missing=prefix.embedding"):
+        validate_prefill_weights(missing, profile)
+
+    wrong_shape = dict(weights)
+    wrong_shape["prefix.embedding"] = np.zeros((10, 8), dtype=np.float32)
+    with pytest.raises(ValueError, match="expected \\(11, 8\\), got \\(10, 8\\)"):
+        validate_prefill_weights(wrong_shape, profile)
+
+    wrong_dtype = dict(weights)
+    wrong_dtype["prefix.embedding"] = np.zeros((11, 8), dtype=np.int32)
+    with pytest.raises(ValueError, match="expected floating point"):
+        validate_prefill_weights(wrong_dtype, profile)
+
+
+class _FakeTensor:
+    def __init__(self, shape, dtype):
+        self.shape = tuple(int(dim) for dim in shape)
+        self.dtype = dtype
+        self.name = ""
+
+
+class _FakeLayer:
+    def __init__(self, output):
+        self.output = output
+        self.name = ""
+
+    def get_output(self, index):
+        assert index == 0
+        return self.output
+
+
+class _FakeShuffle:
+    def __init__(self, tensor):
+        self.tensor = tensor
+        self.first_transpose = None
+        self.second_transpose = None
+        self.reshape_dims = None
+
+    def get_output(self, index):
+        assert index == 0
+        shape = self.tensor.shape
+        if self.first_transpose is not None:
+            shape = tuple(shape[index] for index in self.first_transpose)
+        if self.reshape_dims is not None:
+            reshape = list(self.reshape_dims)
+            if -1 in reshape:
+                known = int(np.prod([dim for dim in reshape if dim != -1]))
+                reshape[reshape.index(-1)] = int(np.prod(shape)) // known
+            shape = tuple(reshape)
+        if self.second_transpose is not None:
+            shape = tuple(shape[index] for index in self.second_transpose)
+        return _FakeTensor(shape, self.tensor.dtype)
+
+
+class _FakeConvolution:
+    def __init__(self, tensor, out_channels, kernel):
+        self.tensor = tensor
+        self.out_channels = out_channels
+        self.kernel = kernel
+        self._stride = (1, 1)
+
+    @property
+    def stride_nd(self):
+        return self._stride
+
+    @stride_nd.setter
+    def stride_nd(self, value):
+        self._stride = tuple(value)
+
+    def get_output(self, index):
+        assert index == 0
+        batch, _channels, height, width = self.tensor.shape
+        out_h = (height - self.kernel[0]) // self._stride[0] + 1
+        out_w = (width - self.kernel[1]) // self._stride[1] + 1
+        return _FakeTensor((batch, self.out_channels, out_h, out_w), self.tensor.dtype)
+
+
+class _FakeConcatenation:
+    def __init__(self, tensors):
+        self.tensors = tensors
+        self.axis = 0
+
+    def get_output(self, index):
+        assert index == 0
+        shape = list(self.tensors[0].shape)
+        shape[self.axis] = sum(tensor.shape[self.axis] for tensor in self.tensors)
+        return _FakeTensor(shape, self.tensors[0].dtype)
+
+
+def _broadcast_shape(*shapes):
+    return tuple(np.broadcast_shapes(*shapes))
+
+
+class _FakeNetwork:
+    def __init__(self, trt):
+        self.trt = trt
+        self.inputs = []
+        self.outputs = []
+        self.softmax_input_dtypes = []
+        self.einsum_equations = []
+        self.plugin_layers = []
+        self.events = []
+
+    def add_input(self, name, dtype, shape):
+        tensor = _FakeTensor(shape, dtype)
+        tensor.name = name
+        self.inputs.append(tensor)
+        return tensor
+
+    def add_convolution_nd(self, tensor, out_channels, kernel, weight, bias):
+        del weight, bias
+        return _FakeConvolution(tensor, out_channels, kernel)
+
+    def add_shuffle(self, tensor):
+        return _FakeShuffle(tensor)
+
+    def add_elementwise(self, left, right, operation):
+        del operation
+        return _FakeLayer(_FakeTensor(_broadcast_shape(left.shape, right.shape), left.dtype))
+
+    def add_reduce(self, tensor, operation, axes, keep_dims):
+        del operation
+        shape = list(tensor.shape)
+        for axis in range(len(shape)):
+            if axes & (1 << axis):
+                shape[axis] = 1 if keep_dims else 0
+        if not keep_dims:
+            shape = [dim for dim in shape if dim != 0]
+        return _FakeLayer(_FakeTensor(shape, tensor.dtype))
+
+    def add_unary(self, tensor, operation):
+        del operation
+        return _FakeLayer(_FakeTensor(tensor.shape, tensor.dtype))
+
+    def add_activation(self, tensor, activation):
+        del activation
+        return _FakeLayer(_FakeTensor(tensor.shape, tensor.dtype))
+
+    def add_matrix_multiply(self, left, left_op, right, right_op):
+        left_shape = left.shape
+        right_shape = right.shape
+        if left_op == self.trt.MatrixOperation.TRANSPOSE:
+            left_shape = (*left_shape[:-2], left_shape[-1], left_shape[-2])
+        if right_op == self.trt.MatrixOperation.TRANSPOSE:
+            right_shape = (*right_shape[:-2], right_shape[-1], right_shape[-2])
+        assert left_shape[-1] == right_shape[-2]
+        batch = _broadcast_shape(left_shape[:-2], right_shape[:-2])
+        return _FakeLayer(_FakeTensor((*batch, left_shape[-2], right_shape[-1]), left.dtype))
+
+    def add_einsum(self, tensors, equation):
+        self.einsum_equations.append(equation)
+        self.events.append(("einsum", equation))
+        left, right = tensors
+        if equation == "bsi,iqhd->bsqhd":
+            shape = (left.shape[0], left.shape[1], *right.shape[1:])
+        elif equation == "bsi,io->bso":
+            shape = (left.shape[0], left.shape[1], right.shape[1])
+        elif equation == "bhqd,bhkd->bhqk":
+            shape = (left.shape[0], left.shape[1], left.shape[2], right.shape[2])
+        elif equation == "bhqk,bhkd->bhqd":
+            shape = (left.shape[0], left.shape[1], left.shape[2], right.shape[3])
+        elif ",z->" in equation and equation.split(",z->", 1)[0] == equation.split(",z->", 1)[1]:
+            assert right.shape == (1,)
+            shape = left.shape
+        elif ",ij->" in equation:
+            lhs, output = equation.split(",ij->", 1)
+            assert lhs.endswith("i")
+            assert output.endswith("j")
+            assert left.shape[-1] == right.shape[0]
+            shape = (*left.shape[:-1], right.shape[1])
+        else:  # pragma: no cover - catches unexpected builder drift.
+            raise AssertionError(f"unsupported fake einsum equation {equation!r}")
+        return _FakeLayer(_FakeTensor(shape, left.dtype))
+
+    def add_select(self, condition, then_tensor, else_tensor):
+        shape = _broadcast_shape(condition.shape, then_tensor.shape, else_tensor.shape)
+        return _FakeLayer(_FakeTensor(shape, then_tensor.dtype))
+
+    def add_softmax(self, tensor):
+        self.softmax_input_dtypes.append(tensor.dtype)
+        self.events.append(("softmax",))
+        layer = _FakeLayer(_FakeTensor(tensor.shape, tensor.dtype))
+        layer.axes = 0
+        return layer
+
+    def add_gather(self, data, indices, axis):
+        shape = (*data.shape[:axis], *indices.shape, *data.shape[axis + 1 :])
+        return _FakeLayer(_FakeTensor(shape, data.dtype))
+
+    def add_slice(self, tensor, start, shape, stride):
+        del start, stride
+        return _FakeLayer(_FakeTensor(shape, tensor.dtype))
+
+    def add_concatenation(self, tensors):
+        return _FakeConcatenation(tensors)
+
+    def add_plugin_v3(self, inputs, shape_inputs, plugin):
+        assert not shape_inputs
+        layer = _FakeLayer(_FakeTensor(inputs[0].shape, inputs[0].dtype))
+        self.plugin_layers.append((layer, tuple(inputs), plugin))
+        self.events.append(("plugin", plugin))
+        return layer
+
+    def mark_output(self, tensor):
+        self.outputs.append(tensor)
+
+
+class _FakeBuilder:
+    def build_serialized_network(self, network, config):
+        del network, config
+        return b"fake-prefill-plan"
+
+
+class _FakeBuilderConfig:
+    def __init__(self):
+        self.cleared_flags = []
+
+    def clear_flag(self, flag):
+        self.cleared_flags.append(flag)
+
+
+def _fake_graph_ops_module():
+    trt = types.SimpleNamespace(
+        float32="float32",
+        float16="float16",
+        bfloat16="bfloat16",
+        int32="int32",
+        bool="bool",
+        Weights=lambda value: value,
+        MatrixOperation=types.SimpleNamespace(NONE="none", TRANSPOSE="transpose"),
+        ElementWiseOperation=types.SimpleNamespace(
+            PROD="prod",
+            SUM="sum",
+            AND="and",
+            SUB="sub",
+            MAX="max",
+            DIV="div",
+            POW="pow",
+        ),
+        ReduceOperation=types.SimpleNamespace(AVG="avg", SUM="sum", MAX="max"),
+        UnaryOperation=types.SimpleNamespace(SQRT="sqrt", RECIP="recip", EXP="exp"),
+        ActivationType=types.SimpleNamespace(TANH="tanh"),
+        BuilderFlag=types.SimpleNamespace(TF32="tf32"),
+    )
+    module = types.ModuleType("tensorrt_model_connect.families.openpi.graph_ops")
+    module.trt = trt
+    module.cast_transitions = []
+    module.linear_weight_shapes = []
+
+    def create_builder_context(**kwargs):
+        module.builder_context_kwargs = kwargs
+        module.last_network = _FakeNetwork(trt)
+        module.last_builder_config = _FakeBuilderConfig()
+        return _FakeBuilder(), module.last_network, module.last_builder_config
+
+    def precision_types(precision):
+        return np.dtype(np.float32), {
+            "bf16": trt.bfloat16,
+            "fp16": trt.float16,
+            "fp32": trt.float32,
+        }[precision]
+
+    def constant(network, value, *, dtype=None, shape=None):
+        del network
+        array = np.asarray(value)
+        result_shape = tuple(shape) if shape is not None else (array.shape or (1,))
+        return _FakeTensor(result_shape, dtype or trt.float32)
+
+    def cast(network, tensor, dtype):
+        del network
+        if tensor.dtype != dtype:
+            module.cast_transitions.append((tensor.dtype, dtype))
+        return tensor if tensor.dtype == dtype else _FakeTensor(tensor.shape, dtype)
+
+    def linear(network, tensor, weight, bias=None, *, dtype=None):
+        del network, bias
+        weight_shape = np.asarray(weight).shape
+        module.linear_weight_shapes.append(weight_shape)
+        return _FakeTensor((*tensor.shape[:-1], weight_shape[1]), dtype or tensor.dtype)
+
+    def same_shape(network, tensor, *args, **kwargs):
+        del network, args, kwargs
+        return _FakeTensor(tensor.shape, tensor.dtype)
+
+    def gated_residual(network, residual, update, gate=None):
+        del network, update, gate
+        return _FakeTensor(residual.shape, residual.dtype)
+
+    module.create_builder_context = create_builder_context
+    module.precision_types = precision_types
+    module.constant = constant
+    module.cast = cast
+    module.linear = linear
+    module.gelu_tanh = same_shape
+    module.apply_rope = same_shape
+    module.gated_residual = gated_residual
+    return module
+
+
+def test_siglip_layer_norm_plugin_is_fail_closed_and_names_layer(monkeypatch) -> None:
+    fake_ops = _fake_graph_ops_module()
+    network = _FakeNetwork(fake_ops.trt)
+    plugin = object()
+    monkeypatch.setattr(
+        prefill_builder_module,
+        "_create_openpi_siglip_layer_norm_plugin",
+        lambda *, epsilon, trt: plugin,
+    )
+    activation = _FakeTensor((1, 256, 1152), fake_ops.trt.bfloat16)
+    gamma = np.ones((1152,), dtype=np.float32)
+    beta = np.zeros((1152,), dtype=np.float32)
+    name = "openpi/siglip/camera_2/layer_26/norm2"
+
+    output = prefill_builder_module._apply_siglip_layer_norm_plugin(
+        network,
+        activation,
+        gamma,
+        beta,
+        epsilon=1.0e-6,
+        name=name,
+        ops=fake_ops,
+        trt=fake_ops.trt,
+    )
+
+    assert output.shape == (1, 256, 1152)
+    assert output.dtype == fake_ops.trt.bfloat16
+    assert len(network.plugin_layers) == 1
+    layer, inputs, observed_plugin = network.plugin_layers[0]
+    assert layer.name == name
+    assert observed_plugin is plugin
+    assert [(item.shape, item.dtype) for item in inputs] == [
+        ((1, 256, 1152), fake_ops.trt.bfloat16),
+        ((1152,), fake_ops.trt.bfloat16),
+        ((1152,), fake_ops.trt.bfloat16),
+    ]
+
+    with pytest.raises(ValueError, match="epsilon=1e-6"):
+        prefill_builder_module._apply_siglip_layer_norm_plugin(
+            network,
+            activation,
+            gamma,
+            beta,
+            epsilon=1.0e-5,
+            name=name,
+            ops=fake_ops,
+            trt=fake_ops.trt,
+        )
+    with pytest.raises(ValueError, match=r"BF16 activation \[1,256,1152\]"):
+        prefill_builder_module._apply_siglip_layer_norm_plugin(
+            network,
+            _FakeTensor((1, 256, 1152), fake_ops.trt.float16),
+            gamma,
+            beta,
+            epsilon=1.0e-6,
+            name=name,
+            ops=fake_ops,
+            trt=fake_ops.trt,
+        )
+    with pytest.raises(ValueError, match=r"BF16 activation \[1,256,1152\]"):
+        prefill_builder_module._apply_siglip_layer_norm_plugin(
+            network,
+            _FakeTensor((1, 255, 1152), fake_ops.trt.bfloat16),
+            gamma,
+            beta,
+            epsilon=1.0e-6,
+            name=name,
+            ops=fake_ops,
+            trt=fake_ops.trt,
+        )
+    with pytest.raises(ValueError, match=r"gamma/beta \[1152\]"):
+        prefill_builder_module._apply_siglip_layer_norm_plugin(
+            network,
+            activation,
+            gamma.reshape(1, 1152),
+            beta,
+            epsilon=1.0e-6,
+            name=name,
+            ops=fake_ops,
+            trt=fake_ops.trt,
+        )
+    with pytest.raises(ValueError, match="deterministic layer name"):
+        prefill_builder_module._apply_siglip_layer_norm_plugin(
+            network,
+            activation,
+            gamma,
+            beta,
+            epsilon=1.0e-6,
+            name="",
+            ops=fake_ops,
+            trt=fake_ops.trt,
+        )
+    assert len(network.plugin_layers) == 1
+
+
+def test_siglip_attention_residual_plugin_is_fixed_shape_and_names_layer(
+    monkeypatch,
+) -> None:
+    fake_ops = _fake_graph_ops_module()
+    network = _FakeNetwork(fake_ops.trt)
+    plugin = object()
+    monkeypatch.setattr(
+        prefill_builder_module,
+        "_create_openpi_siglip_attention_residual_plugin",
+        lambda *, trt: plugin,
+    )
+    hidden = _FakeTensor((1, 256, 1152), fake_ops.trt.bfloat16)
+    arrays = (
+        np.broadcast_to(np.float32(1.0), (1152,)),
+        np.broadcast_to(np.float32(0.0), (1152,)),
+        np.broadcast_to(np.float32(0.0), (1152, 3456)),
+        np.broadcast_to(np.float32(0.0), (3456,)),
+        np.broadcast_to(np.float32(0.0), (1152, 1152)),
+        np.broadcast_to(np.float32(0.0), (1152,)),
+    )
+    name = "openpi/siglip/camera_0/layer_00/attention_residual"
+
+    output = prefill_builder_module._apply_siglip_attention_residual_plugin(
+        network,
+        hidden,
+        *arrays,
+        name=name,
+        ops=fake_ops,
+        trt=fake_ops.trt,
+    )
+
+    assert output.shape == hidden.shape
+    assert output.dtype == fake_ops.trt.bfloat16
+    assert len(network.plugin_layers) == 1
+    layer, inputs, observed_plugin = network.plugin_layers[0]
+    assert layer.name == name
+    assert observed_plugin is plugin
+    assert [(item.shape, item.dtype) for item in inputs] == [
+        ((1, 256, 1152), fake_ops.trt.bfloat16),
+        ((1152,), fake_ops.trt.bfloat16),
+        ((1152,), fake_ops.trt.bfloat16),
+        ((1152, 3456), fake_ops.trt.bfloat16),
+        ((3456,), fake_ops.trt.bfloat16),
+        ((1152, 1152), fake_ops.trt.bfloat16),
+        ((1152,), fake_ops.trt.bfloat16),
+    ]
+
+    with pytest.raises(ValueError, match=r"BF16 hidden \[1,256,1152\]"):
+        prefill_builder_module._apply_siglip_attention_residual_plugin(
+            network,
+            _FakeTensor((1, 255, 1152), fake_ops.trt.bfloat16),
+            *arrays,
+            name=name,
+            ops=fake_ops,
+            trt=fake_ops.trt,
+        )
+    with pytest.raises(ValueError, match=r"QKV weight/bias"):
+        prefill_builder_module._apply_siglip_attention_residual_plugin(
+            network,
+            hidden,
+            *arrays[:2],
+            np.zeros((1152, 3455), dtype=np.float32),
+            *arrays[3:],
+            name=name,
+            ops=fake_ops,
+            trt=fake_ops.trt,
+        )
+    with pytest.raises(ValueError, match="deterministic layer name"):
+        prefill_builder_module._apply_siglip_attention_residual_plugin(
+            network,
+            hidden,
+            *arrays,
+            name="",
+            ops=fake_ops,
+            trt=fake_ops.trt,
+        )
+    assert len(network.plugin_layers) == 1
+
+
+def test_siglip_attention_residual_plugin_source_is_exact_and_fail_closed() -> None:
+    root = Path(__file__).resolve().parents[5]
+    source = (
+        root / "src/runtime/models/openpi/trt_plugins/siglip_attention_residual_plugin.cu"
+    ).read_text(encoding="utf-8")
+    cmake = (root / "src/runtime/models/openpi/model.cmake").read_text(encoding="utf-8")
+
+    assert 'kName = "OpenPISiglipAttentionResidual"' in source
+    assert 'kVersion = "1"' in source
+    assert "nb_inputs != 7" in source
+    assert "has_supported_dynamic_shape(input, nb_inputs, output, nb_outputs)" in source
+    assert "kQkvCublasWorkspaceBytes = 8552448" in source
+    assert "kQkCublasWorkspaceBytes = 1179648" in source
+    assert "kPvCublasWorkspaceBytes = 2686976" in source
+    assert "kOutputCublasWorkspaceBytes = 3244032" in source
+    assert "ex2.approx.f32" in source
+    assert "div.full.f32" in source
+    assert "CUBLAS_COMPUTE_32F" in source
+    assert "CUBLAS_GEMM_DEFAULT" in source
+    assert "cublasSetMathMode(plugin->cublas_handle_, CUBLAS_DEFAULT_MATH)" in source
+    assert source.count("configure_cublas(") == 5
+    assert source.count("cublasSetStream(handle, stream)") == 1
+    assert "fields != nullptr && fields->nbFields != 0" in source
+    assert '"${CMAKE_CURRENT_LIST_DIR}/trt_plugins/siglip_attention_residual_plugin.cu"' in cmake
+
+
+def test_siglip_attention_residual_selection_accepts_depth1_and_full_geometry() -> None:
+    fake_ops = _fake_graph_ops_module()
+    hidden = _FakeTensor((1, 256, 1152), fake_ops.trt.bfloat16)
+    full = get_profile("pi05_droid").vision
+    depth1 = replace(full, depth=1)
+
+    assert prefill_builder_module._uses_siglip_attention_residual_plugin(
+        hidden, full, trt=fake_ops.trt
+    )
+    assert prefill_builder_module._uses_siglip_attention_residual_plugin(
+        hidden, depth1, trt=fake_ops.trt
+    )
+    assert not prefill_builder_module._uses_siglip_attention_residual_plugin(
+        _FakeTensor(hidden.shape, fake_ops.trt.float16), full, trt=fake_ops.trt
+    )
+    assert not prefill_builder_module._uses_siglip_attention_residual_plugin(
+        _FakeTensor((1, 255, 1152), fake_ops.trt.bfloat16), full, trt=fake_ops.trt
+    )
+    assert not prefill_builder_module._uses_siglip_attention_residual_plugin(
+        hidden, _tiny_profile().vision, trt=fake_ops.trt
+    )
+
+
+def test_siglip_fallback_scalar_einsum_scaling_precedes_qk() -> None:
+    fake_ops = _fake_graph_ops_module()
+    network = _FakeNetwork(fake_ops.trt)
+    q = _FakeTensor((1, 16, 256, 72), fake_ops.trt.bfloat16)
+
+    output = prefill_builder_module._softmax_attention(
+        network,
+        q,
+        _FakeTensor(q.shape, q.dtype),
+        _FakeTensor(q.shape, q.dtype),
+        None,
+        head_dim=72,
+        fp32_logits=False,
+        scale_with_division=True,
+        use_einsum=True,
+        ops=fake_ops,
+        trt=fake_ops.trt,
+    )
+
+    assert network.events == [
+        ("einsum", "bhqd,z->bhqd"),
+        ("einsum", "bhqd,bhkd->bhqk"),
+        ("softmax",),
+        ("einsum", "bhqk,bhkd->bhqd"),
+    ]
+    assert output.shape == (1, 256, 1152)
+    assert output.dtype == fake_ops.trt.bfloat16
+
+
+def test_siglip_layer_norm_plugin_topology_covers_every_camera_block_and_postnorm(
+    monkeypatch,
+) -> None:
+    profile = _tiny_profile()
+    weights = _tiny_weights(profile)
+    fake_ops = _fake_graph_ops_module()
+    network = _FakeNetwork(fake_ops.trt)
+    observed: list[tuple[str, float]] = []
+
+    def record_plugin(
+        network,
+        tensor,
+        weight,
+        bias,
+        *,
+        epsilon,
+        name,
+        ops,
+        trt,
+    ):
+        del network, weight, bias, ops, trt
+        observed.append((name, epsilon))
+        return _FakeTensor(tensor.shape, tensor.dtype)
+
+    monkeypatch.setattr(
+        prefill_builder_module,
+        "_apply_siglip_layer_norm_plugin",
+        record_plugin,
+    )
+    output = prefill_builder_module._vision_encoder(
+        network,
+        _FakeTensor((3, 3, 4, 4), fake_ops.trt.float32),
+        weights,
+        profile,
+        activation_dtype=fake_ops.trt.bfloat16,
+        ops=fake_ops,
+        trt=fake_ops.trt,
+    )
+
+    expected_names = []
+    for camera in range(profile.vision.num_image_slots):
+        for layer in range(profile.vision.depth):
+            expected_names.extend(
+                [
+                    f"openpi/siglip/camera_{camera}/layer_{layer:02d}/norm1",
+                    f"openpi/siglip/camera_{camera}/layer_{layer:02d}/norm2",
+                ]
+            )
+        expected_names.append(f"openpi/siglip/camera_{camera}/post_norm")
+    assert [name for name, _epsilon in observed] == expected_names
+    assert all(epsilon == 1.0e-6 for _name, epsilon in observed)
+    assert len(set(expected_names)) == len(expected_names)
+    assert output.shape == (1, 12, 8)
+    assert output.dtype == fake_ops.trt.bfloat16
+
+
+def test_siglip_attention_residual_topology_replaces_norm1_through_first_residual(
+    monkeypatch,
+) -> None:
+    profile = _tiny_profile()
+    weights = _tiny_weights(profile)
+    fake_ops = _fake_graph_ops_module()
+    network = _FakeNetwork(fake_ops.trt)
+    attention_names: list[str] = []
+    norm_names: list[str] = []
+
+    monkeypatch.setattr(
+        prefill_builder_module,
+        "_uses_siglip_attention_residual_plugin",
+        lambda hidden, cfg, *, trt: True,
+    )
+
+    def record_attention(network, hidden, *args, name, ops, trt):
+        del network, args, ops, trt
+        attention_names.append(name)
+        return _FakeTensor(hidden.shape, hidden.dtype)
+
+    def record_norm(network, tensor, weight, bias, *, name, **kwargs):
+        del network, weight, bias, kwargs
+        norm_names.append(name)
+        return _FakeTensor(tensor.shape, tensor.dtype)
+
+    monkeypatch.setattr(
+        prefill_builder_module,
+        "_apply_siglip_attention_residual_plugin",
+        record_attention,
+    )
+    monkeypatch.setattr(
+        prefill_builder_module,
+        "_apply_siglip_layer_norm_plugin",
+        record_norm,
+    )
+    output = prefill_builder_module._vision_encoder(
+        network,
+        _FakeTensor((3, 3, 4, 4), fake_ops.trt.float32),
+        weights,
+        profile,
+        activation_dtype=fake_ops.trt.bfloat16,
+        ops=fake_ops,
+        trt=fake_ops.trt,
+    )
+
+    expected_attention_names = [
+        f"openpi/siglip/camera_{camera}/layer_{layer:02d}/attention_residual"
+        for camera in range(profile.vision.num_image_slots)
+        for layer in range(profile.vision.depth)
+    ]
+    expected_norm_names = []
+    for camera in range(profile.vision.num_image_slots):
+        expected_norm_names.extend(
+            f"openpi/siglip/camera_{camera}/layer_{layer:02d}/norm2"
+            for layer in range(profile.vision.depth)
+        )
+        expected_norm_names.append(f"openpi/siglip/camera_{camera}/post_norm")
+
+    assert attention_names == expected_attention_names
+    assert norm_names == expected_norm_names
+    assert output.shape == (1, 12, 8)
+    assert output.dtype == fake_ops.trt.bfloat16
+
+
+def test_tiny_graph_build_has_exact_io_compact_cache_and_upstream_softmax_dtypes(
+    monkeypatch,
+) -> None:
+    profile = _tiny_profile()
+    weights = _tiny_weights(profile)
+    fake_ops = _fake_graph_ops_module()
+    monkeypatch.setitem(
+        sys.modules,
+        "tensorrt_model_connect.families.openpi.graph_ops",
+        fake_ops,
+    )
+    # ``from . import graph_ops`` may reuse the package attribute after an
+    # earlier real TensorRT test imported the module. Replace both import
+    # caches so this structural test remains order-independent.
+    monkeypatch.setattr(openpi_package, "graph_ops", fake_ops, raising=False)
+    monkeypatch.setattr(
+        prefill_builder_module,
+        "_apply_siglip_layer_norm_plugin",
+        lambda network, tensor, weight, bias, **kwargs: _FakeTensor(tensor.shape, tensor.dtype),
+    )
+
+    plan = build_prefill_engine(weights, profile, precision="bf16", workspace_bytes=1234)
+    assert plan == b"fake-prefill-plan"
+    assert fake_ops.builder_context_kwargs == {"verbose": False, "workspace_bytes": 1234}
+    assert fake_ops.last_builder_config.cleared_flags == ["tf32"]
+    network = fake_ops.last_network
+    assert network.plugin_layers == []
+    assert [(tensor.name, tensor.shape, tensor.dtype) for tensor in network.inputs] == [
+        ("pixel_values", (3, 3, 4, 4), "float32"),
+        ("token_ids", (1, 5), "int32"),
+        ("prefix_mask", (1, 17), "bool"),
+        ("prefix_position_ids", (1, 17), "int32"),
+    ]
+    assert [(tensor.name, tensor.shape, tensor.dtype) for tensor in network.outputs] == [
+        ("vision_tokens", (1, 3, 4, 8), "bfloat16"),
+        *[
+            (prefix_cache_output_name(kind, layer), (1, 17, 1, 4), "bfloat16")
+            for layer in range(2)
+            for kind in ("k", "v")
+        ],
+    ]
+    # Each per-camera SigLIP layer uses TensorRT's native BF16 softmax. The
+    # tiny shape does not activate the fixed production materialization
+    # plugin. Gemma retains one FP32-logit softmax per prefix layer.
+    assert network.softmax_input_dtypes == ["bfloat16"] * 6 + ["float32"] * 2
+    # The three camera encoders remain separate M=tokens graphs, matching the
+    # upstream per-image loop and preserving its contraction tactics.
+    assert network.einsum_equations.count("bsi,iqhd->bsqhd") == 6
+    assert network.einsum_equations.count("bsi,io->bso") == 21
+    assert network.einsum_equations.count("bhqd,bhkd->bhqk") == 6
+    assert network.einsum_equations.count("bhqk,bhkd->bhqd") == 6
+    assert network.einsum_equations.count("bhqd,z->bhqd") == 6
+    assert network.einsum_equations.count("bhqk,z->bhqk") == 0
+
+
+def test_bf16_gelu_preserves_every_jax_rounding_boundary() -> None:
+    fake_ops = _fake_graph_ops_module()
+    network = _FakeNetwork(fake_ops.trt)
+    tensor = _FakeTensor((1, 4, 6), fake_ops.trt.bfloat16)
+
+    output = _gelu_tanh(
+        network,
+        tensor,
+        ops=fake_ops,
+        trt=fake_ops.trt,
+    )
+
+    assert output.shape == tensor.shape
+    assert output.dtype == fake_ops.trt.bfloat16
+    # Nine JAX BF16 pointwise results plus the final return are explicitly
+    # quantized from FP32. This prevents TensorRT from carrying extended
+    # precision through its fused GELU kernel.
+    assert fake_ops.cast_transitions.count((fake_ops.trt.float32, fake_ops.trt.bfloat16)) == 10

--- a/python/tensorrt_model_connect/families/openpi/tests/test_prepare_norm_validation.py
+++ b/python/tensorrt_model_connect/families/openpi/tests/test_prepare_norm_validation.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tensorrt_model_connect.families.openpi.prepare_model_dir import (
+    _load_and_validate_norm_stats,
+)
+
+
+def _official_style_droid_stats() -> dict:
+    active_low = [-1.0] * 8
+    active_high = [1.0] * 8
+    padded = [0.0] * 24
+    return {
+        "norm_stats": {
+            "state": {
+                "q01": active_low + padded,
+                "q99": active_high + padded,
+            },
+            "actions": {
+                "q01": active_low + padded,
+                "q99": active_high + padded,
+            },
+        }
+    }
+
+
+def test_official_droid_zero_span_padding_is_accepted(tmp_path) -> None:
+    stats = _official_style_droid_stats()
+    path = tmp_path / "norm_stats.json"
+    path.write_text(json.dumps(stats), encoding="utf-8")
+
+    assert _load_and_validate_norm_stats(path, state_dim=8, action_dim=8) == stats
+
+
+def test_decreasing_quantiles_in_unused_padding_are_rejected(tmp_path) -> None:
+    stats = _official_style_droid_stats()
+    stats["norm_stats"]["state"]["q99"][31] = -1.0
+    path = tmp_path / "norm_stats.json"
+    path.write_text(json.dumps(stats), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"state.*\[31\].*q99 < q01"):
+        _load_and_validate_norm_stats(path, state_dim=8, action_dim=8)

--- a/python/tensorrt_model_connect/families/openpi/tests/test_tokenizer_export.py
+++ b/python/tensorrt_model_connect/families/openpi/tests/test_tokenizer_export.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import builtins
+import hashlib
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+from tensorrt_model_connect.families.openpi import tokenizer_export
+
+
+def _add_piece(model, text: str, score: float, piece_type: int) -> None:
+    piece = model.pieces.add()
+    piece.piece = text
+    piece.score = score
+    piece.type = piece_type
+
+
+def _synthetic_bpe_model():
+    try:
+        pb = tokenizer_export._load_sentencepiece_proto_module()
+    except tokenizer_export.TokenizerExportDependencyError as exc:
+        pytest.skip(str(exc))
+    model = pb.ModelProto()
+    trainer = model.trainer_spec
+    trainer.model_type = pb.TrainerSpec.BPE
+    trainer.byte_fallback = True
+    trainer.treat_whitespace_as_suffix = False
+    trainer.unk_id = 3
+    trainer.bos_id = 2
+    trainer.eos_id = 1
+    trainer.pad_id = 0
+
+    normalizer = model.normalizer_spec
+    normalizer.name = "identity"
+    normalizer.add_dummy_prefix = False
+    normalizer.remove_extra_whitespaces = False
+    normalizer.escape_whitespaces = True
+
+    piece_type = pb.ModelProto.SentencePiece
+    _add_piece(model, "<pad>", 0.0, piece_type.CONTROL)
+    _add_piece(model, "<eos>", 0.0, piece_type.CONTROL)
+    _add_piece(model, "<bos>", 0.0, piece_type.CONTROL)
+    _add_piece(model, "<unk>", 0.0, piece_type.UNKNOWN)
+    _add_piece(model, "<robot>", 0.0, piece_type.USER_DEFINED)
+    for value in range(256):
+        _add_piece(model, f"<0x{value:02X}>", 0.0, piece_type.BYTE)
+    _add_piece(model, "h", -2.0, piece_type.NORMAL)
+    _add_piece(model, "i", -3.0, piece_type.NORMAL)
+    _add_piece(model, "hi", 7.5, piece_type.NORMAL)
+    return model
+
+
+def _serialize(model) -> bytes:
+    return model.SerializeToString(deterministic=True)
+
+
+def test_synthetic_sentencepiece_bpe_round_trips_exact_v1_layout() -> None:
+    model_bytes = _serialize(_synthetic_bpe_model())
+    asset_bytes, metadata = tokenizer_export.convert_paligemma_tokenizer_model(model_bytes)
+    parsed = tokenizer_export.parse_trtmcbpe_asset(asset_bytes)
+
+    assert asset_bytes.startswith(b"TRTMCBPE")
+    expected_flags = (1 << 2) | (1 << 3)
+    expected_piece_count = 4 + 1 + 256 + 3
+    assert asset_bytes[8:40] == struct.pack(
+        "<IIiiiiII",
+        1,
+        expected_flags,
+        3,
+        2,
+        1,
+        0,
+        expected_piece_count,
+        0,
+    )
+    assert parsed.version == 1
+    assert not parsed.add_dummy_prefix
+    assert not parsed.remove_extra_whitespaces
+    assert parsed.escape_whitespaces
+    assert parsed.byte_fallback
+    assert not parsed.treat_whitespace_as_suffix
+    assert (parsed.pad_id, parsed.eos_id, parsed.bos_id, parsed.unknown_id) == (0, 1, 2, 3)
+    assert len(parsed.pieces) == expected_piece_count
+    assert parsed.pieces[0] == tokenizer_export.FlatBpePiece("<pad>", 0.0, 3)
+    assert parsed.pieces[4] == tokenizer_export.FlatBpePiece("<robot>", 0.0, 4)
+    assert parsed.pieces[5].text == "<0x00>"
+    assert parsed.pieces[260].text == "<0xFF>"
+    assert parsed.pieces[-1] == tokenizer_export.FlatBpePiece("hi", 7.5, 1)
+    assert parsed.normalization_rules == ()
+
+    assert metadata.source_model_type == "BPE"
+    assert metadata.source_sha256 == hashlib.sha256(model_bytes).hexdigest()
+    assert metadata.asset_sha256 == hashlib.sha256(asset_bytes).hexdigest()
+    assert metadata.asset_size == len(asset_bytes)
+    assert metadata.piece_count == expected_piece_count
+    assert metadata.piece_type_counts == {
+        "normal": 3,
+        "unknown": 1,
+        "control": 3,
+        "user_defined": 1,
+        "unused": 0,
+        "byte": 256,
+    }
+    assert metadata.normalization_name == "identity"
+    assert metadata.normalization_rule_count == 0
+
+    repeated_bytes, repeated_metadata = tokenizer_export.convert_paligemma_tokenizer_model(
+        model_bytes
+    )
+    assert repeated_bytes == asset_bytes
+    assert repeated_metadata == metadata
+
+
+def test_file_export_and_cli_produce_hash_bound_metadata(tmp_path, capsys) -> None:
+    model_path = tmp_path / "paligemma_tokenizer.model"
+    model_path.write_bytes(_serialize(_synthetic_bpe_model()))
+    asset_path = tmp_path / "assets" / "paligemma_tokenizer.trtmcbpe"
+
+    metadata = tokenizer_export.export_paligemma_bpe_model(model_path, asset_path)
+    assert asset_path.is_file()
+    assert metadata.asset_sha256 == hashlib.sha256(asset_path.read_bytes()).hexdigest()
+    with pytest.raises(FileExistsError, match="refusing to overwrite"):
+        tokenizer_export.export_paligemma_bpe_model(model_path, asset_path)
+
+    metadata_path = tmp_path / "tokenizer_export.json"
+    assert (
+        tokenizer_export.main(
+            [
+                "--input",
+                str(model_path),
+                "--output",
+                str(asset_path),
+                "--metadata-output",
+                str(metadata_path),
+                "--force",
+            ]
+        )
+        == 0
+    )
+    stdout_payload = json.loads(capsys.readouterr().out)
+    file_payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert stdout_payload == file_payload
+    assert stdout_payload["asset_sha256"] == metadata.asset_sha256
+    assert stdout_payload["source_model_type"] == "BPE"
+    assert Path(stdout_payload["output"]) == asset_path.resolve()
+
+
+def test_non_bpe_model_is_rejected() -> None:
+    model = _synthetic_bpe_model()
+    pb = tokenizer_export._load_sentencepiece_proto_module()
+    model.trainer_spec.model_type = pb.TrainerSpec.UNIGRAM
+    with pytest.raises(tokenizer_export.TokenizerExportError, match="not BPE"):
+        tokenizer_export.convert_paligemma_tokenizer_model(_serialize(model))
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda model: setattr(model.normalizer_spec, "name", "nmt_nfkc"), "identity normalizer"),
+        (
+            lambda model: setattr(model.normalizer_spec, "precompiled_charsmap", b"rules"),
+            "precompiled_charsmap",
+        ),
+        (
+            lambda model: setattr(model.normalizer_spec, "normalization_rule_tsv", "rules.tsv"),
+            "normalization_rule_tsv",
+        ),
+        (
+            lambda model: setattr(model.denormalizer_spec, "name", "identity"),
+            "denormalizer_spec",
+        ),
+    ],
+)
+def test_unsupported_normalizer_semantics_are_never_dropped(mutation, message) -> None:
+    model = _synthetic_bpe_model()
+    mutation(model)
+    with pytest.raises(tokenizer_export.TokenizerExportError, match=message):
+        tokenizer_export.convert_paligemma_tokenizer_model(_serialize(model))
+
+
+def test_incomplete_byte_fallback_table_is_rejected() -> None:
+    model = _synthetic_bpe_model()
+    del model.pieces[5]
+    with pytest.raises(tokenizer_export.TokenizerExportError, match="byte fallback table"):
+        tokenizer_export.convert_paligemma_tokenizer_model(_serialize(model))
+
+
+def test_corrupt_source_and_flat_assets_are_rejected() -> None:
+    model = _synthetic_bpe_model()
+    with pytest.raises(tokenizer_export.TokenizerExportError, match="valid ModelProto"):
+        tokenizer_export.convert_paligemma_tokenizer_model(b"\xff\xff\xff")
+
+    asset, _ = tokenizer_export.convert_paligemma_tokenizer_model(_serialize(model))
+    with pytest.raises(tokenizer_export.TokenizerExportError, match="magic"):
+        tokenizer_export.parse_trtmcbpe_asset(b"X" + asset[1:])
+    with pytest.raises(tokenizer_export.TokenizerExportError, match="truncated"):
+        tokenizer_export.parse_trtmcbpe_asset(asset[:-1])
+    with pytest.raises(tokenizer_export.TokenizerExportError, match="trailing"):
+        tokenizer_export.parse_trtmcbpe_asset(asset + b"x")
+    excessive_count = bytearray(asset)
+    struct.pack_into("<I", excessive_count, 32, 1_000_001)
+    with pytest.raises(tokenizer_export.TokenizerExportError, match="record count"):
+        tokenizer_export.parse_trtmcbpe_asset(bytes(excessive_count))
+
+
+def test_missing_build_dependencies_have_actionable_error(monkeypatch) -> None:
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "sentencepiece" or name.startswith("sentencepiece."):
+            raise ModuleNotFoundError("blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    with pytest.raises(
+        tokenizer_export.TokenizerExportDependencyError,
+        match="install both 'sentencepiece' and 'protobuf'",
+    ):
+        tokenizer_export._load_sentencepiece_proto_module()

--- a/python/tensorrt_model_connect/families/openpi/tests/test_trt_plugin_loader.py
+++ b/python/tensorrt_model_connect/families/openpi/tests/test_trt_plugin_loader.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tensorrt_model_connect.families.openpi import trt_plugin_loader
+
+
+class _Registry:
+    def __init__(self, creator=None):
+        self.creator = creator
+
+    def get_creator(self, name: str, version: str, namespace: str):
+        assert name == "OpenPIRopeQK"
+        assert version == "1"
+        assert namespace == ""
+        return self.creator
+
+
+class _Trt:
+    def __init__(self, registry: _Registry):
+        self.registry = registry
+
+    def get_plugin_registry(self) -> _Registry:
+        return self.registry
+
+
+def test_preloaded_openpi_creator_never_touches_the_filesystem(monkeypatch) -> None:
+    expected = object()
+    trt = _Trt(_Registry(expected))
+    monkeypatch.setattr(
+        trt_plugin_loader,
+        "_plugin_library_path",
+        lambda: pytest.fail("preloaded creator must not resolve a DSO path"),
+    )
+
+    assert trt_plugin_loader.require_openpi_plugin_creator("OpenPIRopeQK", trt=trt) is expected
+
+
+def test_openpi_plugin_path_honors_explicit_library(monkeypatch, tmp_path: Path) -> None:
+    configured = tmp_path / "custom-openpi.so"
+    monkeypatch.setenv("TRTMC_OPENPI_TRT_PLUGIN", str(configured))
+    monkeypatch.setenv("TRTMC_MODEL_PLUGIN_DIR", str(tmp_path / "ignored"))
+
+    assert trt_plugin_loader._plugin_library_path() == configured
+
+
+def test_openpi_plugin_path_honors_model_plugin_directory(monkeypatch, tmp_path: Path) -> None:
+    configured = tmp_path / "plugins" / "openpi" / "libtrtmc_model_openpi.so"
+    configured.parent.mkdir(parents=True)
+    configured.write_bytes(b"test")
+    monkeypatch.delenv("TRTMC_OPENPI_TRT_PLUGIN", raising=False)
+    monkeypatch.setenv("TRTMC_MODEL_PLUGIN_DIR", str(tmp_path / "plugins"))
+
+    assert trt_plugin_loader._plugin_library_path() == configured
+
+
+def test_openpi_plugin_path_uses_installed_wheel_dso(monkeypatch, tmp_path: Path) -> None:
+    module = tmp_path / "tensorrt_model_connect/families/openpi/trt_plugin_loader.py"
+    module.parent.mkdir(parents=True)
+    module.write_text("", encoding="utf-8")
+    installed = tmp_path / "tensorrt_model_connect/bin/libtrtmc_model_openpi.so"
+    installed.parent.mkdir(parents=True)
+    installed.write_bytes(b"test")
+    monkeypatch.delenv("TRTMC_OPENPI_TRT_PLUGIN", raising=False)
+    monkeypatch.delenv("TRTMC_MODEL_PLUGIN_DIR", raising=False)
+    monkeypatch.setattr(trt_plugin_loader, "__file__", str(module))
+
+    assert trt_plugin_loader._plugin_library_path() == installed
+
+
+def test_openpi_creator_loads_only_the_exact_build_relative_dso(
+    monkeypatch, tmp_path: Path
+) -> None:
+    plugin_path = tmp_path / "libtrtmc_model_openpi.so"
+    plugin_path.write_bytes(b"test")
+    expected = object()
+    registry = _Registry()
+    calls: list[tuple[str, int]] = []
+
+    def fake_cdll(path: str, *, mode: int):
+        calls.append((path, mode))
+        registry.creator = expected
+        return object()
+
+    monkeypatch.setattr(trt_plugin_loader, "_plugin_library_path", lambda: plugin_path)
+    monkeypatch.setattr(trt_plugin_loader.ctypes, "CDLL", fake_cdll)
+    monkeypatch.setattr(trt_plugin_loader, "_openpi_plugin_handle", None)
+
+    actual = trt_plugin_loader.require_openpi_plugin_creator("OpenPIRopeQK", trt=_Trt(registry))
+
+    assert actual is expected
+    assert calls == [(str(plugin_path), trt_plugin_loader.ctypes.RTLD_GLOBAL)]
+
+
+def test_openpi_creator_rejects_a_missing_or_symlinked_dso(monkeypatch, tmp_path: Path) -> None:
+    missing = tmp_path / "missing.so"
+    monkeypatch.setattr(trt_plugin_loader, "_plugin_library_path", lambda: missing)
+    with pytest.raises(RuntimeError, match="regular model DSO"):
+        trt_plugin_loader.require_openpi_plugin_creator("OpenPIRopeQK", trt=_Trt(_Registry()))
+
+    target = tmp_path / "target.so"
+    target.write_bytes(b"test")
+    symlink = tmp_path / "plugin.so"
+    symlink.symlink_to(target)
+    monkeypatch.setattr(trt_plugin_loader, "_plugin_library_path", lambda: symlink)
+    with pytest.raises(RuntimeError, match="regular model DSO"):
+        trt_plugin_loader.require_openpi_plugin_creator("OpenPIRopeQK", trt=_Trt(_Registry()))

--- a/python/tensorrt_model_connect/families/openpi/tokenizer_export.py
+++ b/python/tensorrt_model_connect/families/openpi/tokenizer_export.py
@@ -1,0 +1,609 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export the PaliGemma SentencePiece BPE model for the native OpenPI runtime.
+
+The source file is a build-time-only SentencePiece protobuf.  The resulting
+``TRTMCBPE`` asset contains only the data consumed by the dependency-free C++
+runtime in ``src/runtime/models/openpi/paligemma_bpe.{h,cpp}``.
+
+PaliGemma uses SentencePiece's score-ordered BPE model with byte fallback.  It
+does not use the SentencePiece Unigram model.  The pinned public tokenizer has
+an identity normalizer with no precompiled character map.  Version 1 refuses
+non-identity normalizers because silently dropping their rules would change
+token IDs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import struct
+import tempfile
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+ASSET_MAGIC = b"TRTMCBPE"
+ASSET_VERSION = 1
+
+_FLAG_DUMMY_PREFIX = 1 << 0
+_FLAG_REMOVE_EXTRA_WHITESPACES = 1 << 1
+_FLAG_ESCAPE_WHITESPACES = 1 << 2
+_FLAG_BYTE_FALLBACK = 1 << 3
+_FLAG_WHITESPACE_AS_SUFFIX = 1 << 4
+_KNOWN_FLAGS = (
+    _FLAG_DUMMY_PREFIX
+    | _FLAG_REMOVE_EXTRA_WHITESPACES
+    | _FLAG_ESCAPE_WHITESPACES
+    | _FLAG_BYTE_FALLBACK
+    | _FLAG_WHITESPACE_AS_SUFFIX
+)
+
+_HEADER = struct.Struct("<IIiiiiII")
+_PIECE_HEADER = struct.Struct("<BfI")
+_RULE_HEADER = struct.Struct("<II")
+_MAX_RECORDS = 1_000_000
+
+_NORMAL = 1
+_UNKNOWN = 2
+_CONTROL = 3
+_USER_DEFINED = 4
+_UNUSED = 5
+_BYTE = 6
+_VALID_PIECE_TYPES = frozenset({_NORMAL, _UNKNOWN, _CONTROL, _USER_DEFINED, _UNUSED, _BYTE})
+
+
+class TokenizerExportError(ValueError):
+    """Raised when an input tokenizer cannot be represented exactly."""
+
+
+class TokenizerExportDependencyError(RuntimeError):
+    """Raised when build-time protobuf support is unavailable."""
+
+
+@dataclass(frozen=True)
+class FlatBpePiece:
+    """One vocabulary entry in source ID order."""
+
+    text: str
+    score: float
+    piece_type: int
+
+
+@dataclass(frozen=True)
+class FlatBpeAsset:
+    """Parsed ``TRTMCBPE`` v1 data used for build-time verification."""
+
+    version: int
+    add_dummy_prefix: bool
+    remove_extra_whitespaces: bool
+    escape_whitespaces: bool
+    byte_fallback: bool
+    treat_whitespace_as_suffix: bool
+    unknown_id: int
+    bos_id: int
+    eos_id: int
+    pad_id: int
+    pieces: tuple[FlatBpePiece, ...]
+    normalization_rules: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True)
+class TokenizerExportMetadata:
+    """Hash-bound provenance returned to ``prepare_model_dir`` callers."""
+
+    schema_version: int
+    source_model_type: str
+    source_sha256: str
+    asset_sha256: str
+    asset_size: int
+    piece_count: int
+    piece_type_counts: dict[str, int]
+    normalization_name: str
+    normalization_rule_count: int
+    add_dummy_prefix: bool
+    remove_extra_whitespaces: bool
+    escape_whitespaces: bool
+    byte_fallback: bool
+    treat_whitespace_as_suffix: bool
+    unknown_id: int
+    bos_id: int
+    eos_id: int
+    pad_id: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-ready copy for the conversion manifest."""
+
+        return asdict(self)
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _load_sentencepiece_proto_module():
+    """Load the build-only protobuf bindings without adding a runtime import."""
+
+    try:
+        from sentencepiece import sentencepiece_model_pb2
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise TokenizerExportDependencyError(
+            "OpenPI tokenizer export requires build-time SentencePiece protobuf bindings; "
+            "install both 'sentencepiece' and 'protobuf' in the builder environment"
+        ) from exc
+    return sentencepiece_model_pb2
+
+
+def _special_piece(
+    pieces: Sequence[FlatBpePiece],
+    token_id: int,
+    *,
+    expected_type: int,
+    name: str,
+    required: bool,
+) -> None:
+    if token_id < 0:
+        if required:
+            raise TokenizerExportError(f"PaliGemma tokenizer is missing its {name}")
+        return
+    if token_id >= len(pieces) or pieces[token_id].piece_type != expected_type:
+        raise TokenizerExportError(
+            f"PaliGemma tokenizer {name} {token_id} does not reference the required piece type"
+        )
+
+
+def _validate_piece_inventory(
+    pieces: Sequence[FlatBpePiece],
+    *,
+    unknown_id: int,
+    bos_id: int,
+    eos_id: int,
+    pad_id: int,
+    byte_fallback: bool,
+) -> None:
+    if not pieces:
+        raise TokenizerExportError("PaliGemma tokenizer contains no pieces")
+    if len(pieces) > _MAX_RECORDS:
+        raise TokenizerExportError(
+            f"PaliGemma tokenizer exceeds the TRTMCBPE v1 limit of {_MAX_RECORDS} pieces"
+        )
+
+    seen: set[str] = set()
+    unknown_count = 0
+    byte_pieces: set[str] = set()
+    for token_id, piece in enumerate(pieces):
+        if not piece.text:
+            raise TokenizerExportError(f"PaliGemma tokenizer piece {token_id} is empty")
+        if piece.text in seen:
+            raise TokenizerExportError(
+                f"PaliGemma tokenizer piece {token_id} duplicates {piece.text!r}"
+            )
+        seen.add(piece.text)
+        if not math.isfinite(piece.score):
+            raise TokenizerExportError(
+                f"PaliGemma tokenizer piece {token_id} has a non-finite score"
+            )
+        if piece.piece_type not in _VALID_PIECE_TYPES:
+            raise TokenizerExportError(
+                f"PaliGemma tokenizer piece {token_id} has unsupported type {piece.piece_type}"
+            )
+        encoded = piece.text.encode("utf-8")
+        if len(encoded) > 0xFFFFFFFF:
+            raise TokenizerExportError(
+                f"PaliGemma tokenizer piece {token_id} exceeds the TRTMCBPE string limit"
+            )
+        if piece.piece_type == _UNKNOWN:
+            unknown_count += 1
+        elif piece.piece_type == _BYTE:
+            byte_pieces.add(piece.text)
+
+    if unknown_count != 1:
+        raise TokenizerExportError(
+            f"PaliGemma tokenizer must have exactly one unknown piece, found {unknown_count}"
+        )
+    _special_piece(
+        pieces,
+        unknown_id,
+        expected_type=_UNKNOWN,
+        name="unknown id",
+        required=True,
+    )
+    _special_piece(
+        pieces,
+        bos_id,
+        expected_type=_CONTROL,
+        name="BOS id",
+        required=True,
+    )
+    _special_piece(
+        pieces,
+        eos_id,
+        expected_type=_CONTROL,
+        name="EOS id",
+        required=False,
+    )
+    _special_piece(
+        pieces,
+        pad_id,
+        expected_type=_CONTROL,
+        name="padding id",
+        required=False,
+    )
+    enabled_special_ids = [
+        token_id for token_id in (unknown_id, bos_id, eos_id, pad_id) if token_id >= 0
+    ]
+    if len(enabled_special_ids) != len(set(enabled_special_ids)):
+        raise TokenizerExportError("PaliGemma tokenizer special token ids are not distinct")
+
+    if byte_fallback:
+        expected_bytes = {f"<0x{value:02X}>" for value in range(256)}
+        missing = sorted(expected_bytes - byte_pieces)
+        unexpected = sorted(byte_pieces - expected_bytes)
+        if missing or unexpected or len(byte_pieces) != 256:
+            raise TokenizerExportError(
+                "PaliGemma byte fallback table is not exact: "
+                f"missing={missing[:4]}, unexpected={unexpected[:4]}"
+            )
+    elif byte_pieces:
+        raise TokenizerExportError(
+            "PaliGemma tokenizer contains byte pieces while byte_fallback is disabled"
+        )
+
+
+def _flags(
+    *,
+    add_dummy_prefix: bool,
+    remove_extra_whitespaces: bool,
+    escape_whitespaces: bool,
+    byte_fallback: bool,
+    treat_whitespace_as_suffix: bool,
+) -> int:
+    return (
+        (_FLAG_DUMMY_PREFIX if add_dummy_prefix else 0)
+        | (_FLAG_REMOVE_EXTRA_WHITESPACES if remove_extra_whitespaces else 0)
+        | (_FLAG_ESCAPE_WHITESPACES if escape_whitespaces else 0)
+        | (_FLAG_BYTE_FALLBACK if byte_fallback else 0)
+        | (_FLAG_WHITESPACE_AS_SUFFIX if treat_whitespace_as_suffix else 0)
+    )
+
+
+def _serialize_asset(
+    pieces: Sequence[FlatBpePiece],
+    *,
+    flags: int,
+    unknown_id: int,
+    bos_id: int,
+    eos_id: int,
+    pad_id: int,
+    normalization_rules: Sequence[tuple[str, str]] = (),
+) -> bytes:
+    if flags & ~_KNOWN_FLAGS:
+        raise TokenizerExportError(f"TRTMCBPE flags contain unknown bits: {flags:#x}")
+    if len(normalization_rules) > _MAX_RECORDS:
+        raise TokenizerExportError(
+            f"TRTMCBPE v1 exceeds its limit of {_MAX_RECORDS} normalization rules"
+        )
+
+    output = bytearray(ASSET_MAGIC)
+    output.extend(
+        _HEADER.pack(
+            ASSET_VERSION,
+            flags,
+            unknown_id,
+            bos_id,
+            eos_id,
+            pad_id,
+            len(pieces),
+            len(normalization_rules),
+        )
+    )
+    for piece in pieces:
+        encoded = piece.text.encode("utf-8")
+        output.extend(_PIECE_HEADER.pack(piece.piece_type, piece.score, len(encoded)))
+        output.extend(encoded)
+    for source, replacement in normalization_rules:
+        source_bytes = source.encode("utf-8")
+        replacement_bytes = replacement.encode("utf-8")
+        if not source_bytes:
+            raise TokenizerExportError("TRTMCBPE normalization rule source cannot be empty")
+        if len(source_bytes) > 0xFFFFFFFF or len(replacement_bytes) > 0xFFFFFFFF:
+            raise TokenizerExportError("TRTMCBPE normalization rule exceeds uint32 string size")
+        output.extend(_RULE_HEADER.pack(len(source_bytes), len(replacement_bytes)))
+        output.extend(source_bytes)
+        output.extend(replacement_bytes)
+    return bytes(output)
+
+
+class _AssetReader:
+    def __init__(self, data: bytes) -> None:
+        self._data = memoryview(data)
+        self._offset = 0
+
+    def read(self, size: int) -> bytes:
+        if size < 0 or self._offset + size > len(self._data):
+            raise TokenizerExportError("truncated TRTMCBPE asset")
+        value = bytes(self._data[self._offset : self._offset + size])
+        self._offset += size
+        return value
+
+    def unpack(self, layout: struct.Struct) -> tuple[Any, ...]:
+        return layout.unpack(self.read(layout.size))
+
+    @property
+    def at_end(self) -> bool:
+        return self._offset == len(self._data)
+
+
+def parse_trtmcbpe_asset(data: bytes) -> FlatBpeAsset:
+    """Parse and validate bytes using the C++ runtime's exact v1 layout."""
+
+    reader = _AssetReader(data)
+    if reader.read(len(ASSET_MAGIC)) != ASSET_MAGIC:
+        raise TokenizerExportError("invalid TRTMCBPE asset magic")
+    (
+        version,
+        flags,
+        unknown_id,
+        bos_id,
+        eos_id,
+        pad_id,
+        piece_count,
+        rule_count,
+    ) = reader.unpack(_HEADER)
+    if version != ASSET_VERSION:
+        raise TokenizerExportError(f"unsupported TRTMCBPE asset version {version}")
+    if flags & ~_KNOWN_FLAGS:
+        raise TokenizerExportError(f"TRTMCBPE asset contains unknown flags {flags:#x}")
+    if piece_count > _MAX_RECORDS or rule_count > _MAX_RECORDS:
+        raise TokenizerExportError("TRTMCBPE asset record count exceeds its limit")
+
+    pieces: list[FlatBpePiece] = []
+    for token_id in range(piece_count):
+        piece_type, score, byte_length = reader.unpack(_PIECE_HEADER)
+        try:
+            text = reader.read(byte_length).decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise TokenizerExportError(f"TRTMCBPE piece {token_id} is not valid UTF-8") from exc
+        pieces.append(FlatBpePiece(text=text, score=score, piece_type=piece_type))
+
+    rules: list[tuple[str, str]] = []
+    for rule_index in range(rule_count):
+        source_length, replacement_length = reader.unpack(_RULE_HEADER)
+        try:
+            source = reader.read(source_length).decode("utf-8")
+            replacement = reader.read(replacement_length).decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise TokenizerExportError(
+                f"TRTMCBPE normalization rule {rule_index} is not valid UTF-8"
+            ) from exc
+        rules.append((source, replacement))
+    if not reader.at_end:
+        raise TokenizerExportError("TRTMCBPE asset contains trailing bytes")
+
+    byte_fallback = bool(flags & _FLAG_BYTE_FALLBACK)
+    _validate_piece_inventory(
+        pieces,
+        unknown_id=unknown_id,
+        bos_id=bos_id,
+        eos_id=eos_id,
+        pad_id=pad_id,
+        byte_fallback=byte_fallback,
+    )
+    if any(not source for source, _ in rules):
+        raise TokenizerExportError("TRTMCBPE asset contains an empty normalization source")
+    if len({source for source, _ in rules}) != len(rules):
+        raise TokenizerExportError("TRTMCBPE asset contains duplicate normalization sources")
+
+    return FlatBpeAsset(
+        version=version,
+        add_dummy_prefix=bool(flags & _FLAG_DUMMY_PREFIX),
+        remove_extra_whitespaces=bool(flags & _FLAG_REMOVE_EXTRA_WHITESPACES),
+        escape_whitespaces=bool(flags & _FLAG_ESCAPE_WHITESPACES),
+        byte_fallback=byte_fallback,
+        treat_whitespace_as_suffix=bool(flags & _FLAG_WHITESPACE_AS_SUFFIX),
+        unknown_id=unknown_id,
+        bos_id=bos_id,
+        eos_id=eos_id,
+        pad_id=pad_id,
+        pieces=tuple(pieces),
+        normalization_rules=tuple(rules),
+    )
+
+
+def convert_paligemma_tokenizer_model(
+    model_bytes: bytes,
+) -> tuple[bytes, TokenizerExportMetadata]:
+    """Convert one raw SentencePiece BPE protobuf to ``TRTMCBPE`` v1 bytes."""
+
+    if not model_bytes:
+        raise TokenizerExportError("PaliGemma SentencePiece model is empty")
+    sentencepiece_model_pb2 = _load_sentencepiece_proto_module()
+    model = sentencepiece_model_pb2.ModelProto()
+    try:
+        model.ParseFromString(model_bytes)
+    except Exception as exc:
+        raise TokenizerExportError("PaliGemma tokenizer is not a valid ModelProto") from exc
+
+    trainer = model.trainer_spec
+    bpe_model_type = int(sentencepiece_model_pb2.TrainerSpec.BPE)
+    if int(trainer.model_type) != bpe_model_type:
+        raise TokenizerExportError(
+            "OpenPI requires the PaliGemma SentencePiece BPE model; "
+            f"source model_type={int(trainer.model_type)} is not BPE ({bpe_model_type})"
+        )
+
+    normalizer = model.normalizer_spec
+    if normalizer.name != "identity":
+        raise TokenizerExportError(
+            "TRTMCBPE v1 only supports the pinned PaliGemma identity normalizer; "
+            f"source normalizer is {normalizer.name!r}"
+        )
+    if normalizer.precompiled_charsmap:
+        raise TokenizerExportError(
+            "TRTMCBPE v1 cannot safely flatten a non-empty precompiled_charsmap; "
+            "refusing to drop tokenizer normalization semantics"
+        )
+    if normalizer.normalization_rule_tsv:
+        raise TokenizerExportError("TRTMCBPE v1 does not accept an external normalization_rule_tsv")
+    if model.HasField("denormalizer_spec"):
+        raise TokenizerExportError(
+            "TRTMCBPE v1 does not represent a SentencePiece denormalizer_spec"
+        )
+
+    pieces = tuple(
+        FlatBpePiece(
+            text=piece.piece,
+            score=float(piece.score),
+            piece_type=int(piece.type),
+        )
+        for piece in model.pieces
+    )
+    unknown_id = int(trainer.unk_id)
+    bos_id = int(trainer.bos_id)
+    eos_id = int(trainer.eos_id)
+    pad_id = int(trainer.pad_id)
+    byte_fallback = bool(trainer.byte_fallback)
+    _validate_piece_inventory(
+        pieces,
+        unknown_id=unknown_id,
+        bos_id=bos_id,
+        eos_id=eos_id,
+        pad_id=pad_id,
+        byte_fallback=byte_fallback,
+    )
+
+    add_dummy_prefix = bool(normalizer.add_dummy_prefix)
+    remove_extra_whitespaces = bool(normalizer.remove_extra_whitespaces)
+    escape_whitespaces = bool(normalizer.escape_whitespaces)
+    treat_whitespace_as_suffix = bool(trainer.treat_whitespace_as_suffix)
+    flags = _flags(
+        add_dummy_prefix=add_dummy_prefix,
+        remove_extra_whitespaces=remove_extra_whitespaces,
+        escape_whitespaces=escape_whitespaces,
+        byte_fallback=byte_fallback,
+        treat_whitespace_as_suffix=treat_whitespace_as_suffix,
+    )
+    # The pinned tokenizer's normalizer is identity and has no rules.  Keep the
+    # v1 rule count explicit so a future non-identity model cannot be mistaken
+    # for an exact conversion.
+    normalization_rules: tuple[tuple[str, str], ...] = ()
+    asset_bytes = _serialize_asset(
+        pieces,
+        flags=flags,
+        unknown_id=unknown_id,
+        bos_id=bos_id,
+        eos_id=eos_id,
+        pad_id=pad_id,
+        normalization_rules=normalization_rules,
+    )
+
+    parsed = parse_trtmcbpe_asset(asset_bytes)
+    if parsed.pieces != pieces:
+        raise TokenizerExportError("TRTMCBPE serializer failed its piece round-trip check")
+
+    type_names = {
+        _NORMAL: "normal",
+        _UNKNOWN: "unknown",
+        _CONTROL: "control",
+        _USER_DEFINED: "user_defined",
+        _UNUSED: "unused",
+        _BYTE: "byte",
+    }
+    counts = Counter(piece.piece_type for piece in pieces)
+    metadata = TokenizerExportMetadata(
+        schema_version=ASSET_VERSION,
+        source_model_type="BPE",
+        source_sha256=_sha256(model_bytes),
+        asset_sha256=_sha256(asset_bytes),
+        asset_size=len(asset_bytes),
+        piece_count=len(pieces),
+        piece_type_counts={type_names[kind]: counts.get(kind, 0) for kind in sorted(type_names)},
+        normalization_name=normalizer.name,
+        normalization_rule_count=0,
+        add_dummy_prefix=add_dummy_prefix,
+        remove_extra_whitespaces=remove_extra_whitespaces,
+        escape_whitespaces=escape_whitespaces,
+        byte_fallback=byte_fallback,
+        treat_whitespace_as_suffix=treat_whitespace_as_suffix,
+        unknown_id=unknown_id,
+        bos_id=bos_id,
+        eos_id=eos_id,
+        pad_id=pad_id,
+    )
+    return asset_bytes, metadata
+
+
+def _atomic_write(path: Path, data: bytes, *, overwrite: bool) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"refusing to overwrite existing tokenizer asset: {path}")
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def export_paligemma_bpe_model(
+    source_model: str | Path,
+    output_asset: str | Path,
+    *,
+    overwrite: bool = False,
+) -> TokenizerExportMetadata:
+    """Convert ``source_model`` and atomically write one native tokenizer asset.
+
+    ``prepare_model_dir`` can call this helper with its raw tokenizer path and a
+    staging destination such as ``tokenizer.model``.  The
+    returned metadata is ready to embed under the manifest's tokenizer entry.
+    """
+
+    source = Path(source_model).expanduser().resolve()
+    if not source.is_file():
+        raise FileNotFoundError(f"PaliGemma SentencePiece model does not exist: {source}")
+    model_bytes = source.read_bytes()
+    asset_bytes, metadata = convert_paligemma_tokenizer_model(model_bytes)
+    output = Path(output_asset).expanduser().resolve()
+    _atomic_write(output, asset_bytes, overwrite=overwrite)
+    return metadata
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="raw PaliGemma SentencePiece .model")
+    parser.add_argument("--output", required=True, help="TRTMCBPE v1 asset to create")
+    parser.add_argument(
+        "--metadata-output",
+        help="optional JSON file for hash-bound exporter metadata",
+    )
+    parser.add_argument("--force", action="store_true", help="replace an existing output asset")
+    args = parser.parse_args(argv)
+
+    metadata = export_paligemma_bpe_model(args.input, args.output, overwrite=args.force)
+    payload = {
+        "input": str(Path(args.input).expanduser().resolve()),
+        "output": str(Path(args.output).expanduser().resolve()),
+        **metadata.to_dict(),
+    }
+    rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.metadata_output:
+        metadata_path = Path(args.metadata_output).expanduser().resolve()
+        _atomic_write(metadata_path, rendered.encode("utf-8"), overwrite=args.force)
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/tensorrt_model_connect/families/openpi/trt_plugin_loader.py
+++ b/python/tensorrt_model_connect/families/openpi/trt_plugin_loader.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail-closed build-time loading for the OpenPI model DSO."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+from pathlib import Path
+
+
+_OPENPI_PLUGIN_LIBRARY = "libtrtmc_model_openpi.so"
+_openpi_plugin_handle = None
+
+
+def _plugin_library_path() -> Path:
+    configured_library = os.environ.get("TRTMC_OPENPI_TRT_PLUGIN")
+    if configured_library:
+        return Path(configured_library).expanduser().absolute()
+
+    configured_plugin_dir = os.environ.get("TRTMC_MODEL_PLUGIN_DIR")
+    if configured_plugin_dir:
+        plugin_dir = Path(configured_plugin_dir).expanduser().absolute()
+        candidates = (
+            plugin_dir / "openpi" / _OPENPI_PLUGIN_LIBRARY,
+            plugin_dir / _OPENPI_PLUGIN_LIBRARY,
+        )
+        return next((candidate for candidate in candidates if candidate.exists()), candidates[0])
+
+    installed_library = Path(__file__).resolve().parents[2] / "bin" / _OPENPI_PLUGIN_LIBRARY
+    if installed_library.is_file():
+        return installed_library
+
+    return (
+        Path(__file__).resolve().parents[4] / "build" / "models" / "openpi" / _OPENPI_PLUGIN_LIBRARY
+    )
+
+
+def require_openpi_plugin_creator(name: str, *, trt):
+    """Return one registered creator after loading the selected OpenPI DSO."""
+
+    global _openpi_plugin_handle
+
+    registry = trt.get_plugin_registry()
+    creator = registry.get_creator(name, "1", "")
+    if creator is not None:
+        return creator
+
+    plugin_path = _plugin_library_path()
+    if plugin_path.is_symlink() or not plugin_path.is_file():
+        raise RuntimeError(
+            f"OpenPI TensorRT engine construction requires the regular model DSO at {plugin_path}"
+        )
+    try:
+        _openpi_plugin_handle = ctypes.CDLL(str(plugin_path), mode=ctypes.RTLD_GLOBAL)
+    except OSError as error:
+        raise RuntimeError(
+            f"failed to load the required OpenPI model DSO {plugin_path}: {error}"
+        ) from error
+
+    creator = registry.get_creator(name, "1", "")
+    if creator is None:
+        raise RuntimeError(f"OpenPI model DSO {plugin_path} does not register creator {name!r} v1")
+    return creator

--- a/python/tensorrt_model_connect/families/openpi/weight_mapper.py
+++ b/python/tensorrt_model_connect/families/openpi/weight_mapper.py
@@ -1,0 +1,593 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exhaustive OpenPI Orbax-to-TensorRT weight mapping.
+
+Destination matrices use input-major layout (``[in, out]``), matching the
+TensorRT matrix-multiply builders.  Prefix and action K/V matrices remain
+compact MQA tensors rather than being expanded to the query-head count.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from .checkpoint_reader import CheckpointReader, tensor_sha256
+from .model_config import (
+    OPENPI_UPSTREAM_COMMIT,
+    OPENPI_UPSTREAM_REPOSITORY,
+    OpenPIProfile,
+)
+
+
+CONVERSION_MANIFEST_SCHEMA_VERSION = 1
+
+
+class WeightMappingError(RuntimeError):
+    """Raised when mapping is incomplete, ambiguous, or shape-incompatible."""
+
+
+@dataclass(frozen=True)
+class DestinationTensor:
+    name: str
+    array: np.ndarray
+    transform: str
+
+
+Transform = Callable[[np.ndarray], Iterable[DestinationTensor]]
+
+
+@dataclass(frozen=True)
+class MappingRule:
+    source: str
+    expected_shape: tuple[int, ...]
+    transform: Transform
+
+
+@dataclass(frozen=True)
+class MappingResult:
+    weights: dict[str, np.ndarray]
+    manifest: dict[str, Any]
+
+
+def _single(
+    destination: str,
+    *,
+    transform_name: str = "identity",
+    operation: Callable[[np.ndarray], np.ndarray] | None = None,
+) -> Transform:
+    def apply(array: np.ndarray) -> tuple[DestinationTensor, ...]:
+        output = array if operation is None else operation(array)
+        return (
+            DestinationTensor(
+                name=destination,
+                array=np.ascontiguousarray(output),
+                transform=transform_name,
+            ),
+        )
+
+    return apply
+
+
+def _scanned(
+    depth: int,
+    destination: str,
+    *,
+    transform_name: str = "slice-axis-0",
+    operation: Callable[[np.ndarray], np.ndarray] | None = None,
+) -> Transform:
+    def apply(array: np.ndarray) -> list[DestinationTensor]:
+        outputs: list[DestinationTensor] = []
+        for layer in range(depth):
+            value = array[layer]
+            if operation is not None:
+                value = operation(value)
+            outputs.append(
+                DestinationTensor(
+                    name=destination.format(layer=layer),
+                    array=np.ascontiguousarray(value),
+                    transform=f"{transform_name}[{layer}]",
+                )
+            )
+        return outputs
+
+    return apply
+
+
+def _scanned_pair(
+    depth: int,
+    first_destination: str,
+    second_destination: str,
+    *,
+    labels: tuple[str, str],
+) -> Transform:
+    def apply(array: np.ndarray) -> list[DestinationTensor]:
+        outputs: list[DestinationTensor] = []
+        for layer in range(depth):
+            for index, (destination, label) in enumerate(
+                zip((first_destination, second_destination), labels, strict=True)
+            ):
+                outputs.append(
+                    DestinationTensor(
+                        name=destination.format(layer=layer),
+                        array=np.ascontiguousarray(array[layer, index]),
+                        transform=f"slice-axis-0[{layer}]-axis-1[{index}:{label}]",
+                    )
+                )
+        return outputs
+
+    return apply
+
+
+def _gemma_q(width: int, attention_width: int) -> Callable[[np.ndarray], np.ndarray]:
+    return lambda value: value.transpose(1, 0, 2).reshape(width, attention_width)
+
+
+def _gemma_kv(which: int, width: int, kv_width: int) -> Callable[[np.ndarray], np.ndarray]:
+    return lambda value: value[which].transpose(1, 0, 2).reshape(width, kv_width)
+
+
+def _gemma_o(attention_width: int, width: int) -> Callable[[np.ndarray], np.ndarray]:
+    return lambda value: value.reshape(attention_width, width)
+
+
+def _vision_projection(width: int) -> Callable[[np.ndarray], np.ndarray]:
+    return lambda value: value.reshape(width, width)
+
+
+def _rules_for_gemma_expert(
+    *,
+    source_suffix: str,
+    destination_prefix: str,
+    profile: OpenPIProfile,
+    adaptive_norm: bool,
+) -> list[MappingRule]:
+    cfg = profile.action_expert if destination_prefix == "action" else profile.prefix
+    depth = cfg.depth
+    suffix = source_suffix
+    rules = [
+        MappingRule(
+            f"PaliGemma/llm/layers/attn/q_einsum{suffix}/w",
+            (depth, cfg.num_heads, cfg.width, cfg.head_dim),
+            _scanned(
+                depth,
+                f"{destination_prefix}.layer.{{layer}}.attention.q.weight",
+                transform_name="slice-and-q-head-flatten",
+                operation=_gemma_q(cfg.width, cfg.attention_width),
+            ),
+        ),
+        MappingRule(
+            f"PaliGemma/llm/layers/attn/kv_einsum{suffix}/w",
+            (depth, 2, cfg.num_kv_heads, cfg.width, cfg.head_dim),
+            lambda array: [
+                DestinationTensor(
+                    name=f"{destination_prefix}.layer.{layer}.attention.{kind}.weight",
+                    array=np.ascontiguousarray(
+                        _gemma_kv(which, cfg.width, cfg.kv_width)(array[layer])
+                    ),
+                    transform=f"slice-axis-0[{layer}]-{kind}-compact-kv",
+                )
+                for layer in range(depth)
+                for which, kind in ((0, "k"), (1, "v"))
+            ],
+        ),
+        MappingRule(
+            f"PaliGemma/llm/layers/attn/attn_vec_einsum{suffix}/w",
+            (depth, cfg.num_heads, cfg.head_dim, cfg.width),
+            _scanned(
+                depth,
+                f"{destination_prefix}.layer.{{layer}}.attention.o.weight",
+                transform_name="slice-and-output-head-flatten",
+                operation=_gemma_o(cfg.attention_width, cfg.width),
+            ),
+        ),
+        MappingRule(
+            f"PaliGemma/llm/layers/mlp{suffix}/gating_einsum",
+            (depth, 2, cfg.width, cfg.mlp_dim),
+            _scanned_pair(
+                depth,
+                f"{destination_prefix}.layer.{{layer}}.mlp.gate.weight",
+                f"{destination_prefix}.layer.{{layer}}.mlp.up.weight",
+                labels=("gate", "up"),
+            ),
+        ),
+        MappingRule(
+            f"PaliGemma/llm/layers/mlp{suffix}/linear",
+            (depth, cfg.mlp_dim, cfg.width),
+            _scanned(depth, f"{destination_prefix}.layer.{{layer}}.mlp.down.weight"),
+        ),
+    ]
+    if adaptive_norm:
+        for source_name, destination_name in (
+            ("pre_attention_norm", "pre_attention_norm"),
+            ("pre_ffw_norm", "pre_ffw_norm"),
+        ):
+            rules.extend(
+                [
+                    MappingRule(
+                        f"PaliGemma/llm/layers/{source_name}{suffix}/Dense_0/kernel",
+                        (depth, cfg.width, 3 * cfg.width),
+                        _scanned(
+                            depth,
+                            f"{destination_prefix}.layer.{{layer}}.{destination_name}.dense.weight",
+                        ),
+                    ),
+                    MappingRule(
+                        f"PaliGemma/llm/layers/{source_name}{suffix}/Dense_0/bias",
+                        (depth, 3 * cfg.width),
+                        _scanned(
+                            depth,
+                            f"{destination_prefix}.layer.{{layer}}.{destination_name}.dense.bias",
+                        ),
+                    ),
+                ]
+            )
+        rules.extend(
+            [
+                MappingRule(
+                    f"PaliGemma/llm/final_norm{suffix}/Dense_0/kernel",
+                    (cfg.width, 3 * cfg.width),
+                    _single(f"{destination_prefix}.final_norm.dense.weight"),
+                ),
+                MappingRule(
+                    f"PaliGemma/llm/final_norm{suffix}/Dense_0/bias",
+                    (3 * cfg.width,),
+                    _single(f"{destination_prefix}.final_norm.dense.bias"),
+                ),
+            ]
+        )
+    else:
+        rules.extend(
+            [
+                MappingRule(
+                    f"PaliGemma/llm/layers/pre_attention_norm{suffix}/scale",
+                    (depth, cfg.width),
+                    _scanned(
+                        depth,
+                        f"{destination_prefix}.layer.{{layer}}.pre_attention_norm.scale",
+                    ),
+                ),
+                MappingRule(
+                    f"PaliGemma/llm/layers/pre_ffw_norm{suffix}/scale",
+                    (depth, cfg.width),
+                    _scanned(
+                        depth,
+                        f"{destination_prefix}.layer.{{layer}}.pre_ffw_norm.scale",
+                    ),
+                ),
+                MappingRule(
+                    f"PaliGemma/llm/final_norm{suffix}/scale",
+                    (cfg.width,),
+                    _single(f"{destination_prefix}.final_norm.scale"),
+                ),
+            ]
+        )
+    return rules
+
+
+def openpi_mapping_rules(profile: OpenPIProfile) -> tuple[MappingRule, ...]:
+    """Return the complete source inventory for audited π0.5 checkpoints."""
+
+    vision = profile.vision
+    rules: list[MappingRule] = [
+        MappingRule(
+            "PaliGemma/img/embedding/kernel",
+            (vision.patch_size, vision.patch_size, 3, vision.width),
+            _single(
+                "vision.patch_embedding.weight",
+                transform_name="hwio-to-oihw",
+                operation=lambda value: value.transpose(3, 2, 0, 1),
+            ),
+        ),
+        MappingRule(
+            "PaliGemma/img/embedding/bias",
+            (vision.width,),
+            _single("vision.patch_embedding.bias"),
+        ),
+        MappingRule(
+            "PaliGemma/img/pos_embedding",
+            (1, vision.tokens_per_image, vision.width),
+            _single(
+                "vision.position_embedding",
+                transform_name="squeeze-batch-axis",
+                operation=lambda value: value[0],
+            ),
+        ),
+    ]
+
+    for upstream, destination in (
+        ("LayerNorm_0/scale", "norm1.weight"),
+        ("LayerNorm_0/bias", "norm1.bias"),
+        ("LayerNorm_1/scale", "norm2.weight"),
+        ("LayerNorm_1/bias", "norm2.bias"),
+    ):
+        rules.append(
+            MappingRule(
+                f"PaliGemma/img/Transformer/encoderblock/{upstream}",
+                (vision.depth, vision.width),
+                _scanned(vision.depth, f"vision.layer.{{layer}}.{destination}"),
+            )
+        )
+
+    for upstream, destination, shape in (
+        ("Dense_0/kernel", "fc1.weight", (vision.depth, vision.width, vision.mlp_dim)),
+        ("Dense_0/bias", "fc1.bias", (vision.depth, vision.mlp_dim)),
+        ("Dense_1/kernel", "fc2.weight", (vision.depth, vision.mlp_dim, vision.width)),
+        ("Dense_1/bias", "fc2.bias", (vision.depth, vision.width)),
+    ):
+        rules.append(
+            MappingRule(
+                f"PaliGemma/img/Transformer/encoderblock/MlpBlock_0/{upstream}",
+                shape,
+                _scanned(vision.depth, f"vision.layer.{{layer}}.mlp.{destination}"),
+            )
+        )
+
+    vision_head_dim = vision.width // vision.num_heads
+    for kind in ("query", "key", "value"):
+        short = {"query": "q", "key": "k", "value": "v"}[kind]
+        rules.extend(
+            [
+                MappingRule(
+                    f"PaliGemma/img/Transformer/encoderblock/"
+                    f"MultiHeadDotProductAttention_0/{kind}/kernel",
+                    (vision.depth, vision.width, vision.num_heads, vision_head_dim),
+                    _scanned(
+                        vision.depth,
+                        f"vision.layer.{{layer}}.attention.{short}.weight",
+                        transform_name="slice-and-head-flatten",
+                        operation=_vision_projection(vision.width),
+                    ),
+                ),
+                MappingRule(
+                    f"PaliGemma/img/Transformer/encoderblock/"
+                    f"MultiHeadDotProductAttention_0/{kind}/bias",
+                    (vision.depth, vision.num_heads, vision_head_dim),
+                    _scanned(
+                        vision.depth,
+                        f"vision.layer.{{layer}}.attention.{short}.bias",
+                        transform_name="slice-and-head-flatten",
+                        operation=lambda value, width=vision.width: value.reshape(width),
+                    ),
+                ),
+            ]
+        )
+    rules.extend(
+        [
+            MappingRule(
+                "PaliGemma/img/Transformer/encoderblock/MultiHeadDotProductAttention_0/out/kernel",
+                (vision.depth, vision.num_heads, vision_head_dim, vision.width),
+                _scanned(
+                    vision.depth,
+                    "vision.layer.{layer}.attention.o.weight",
+                    transform_name="slice-and-head-flatten",
+                    operation=_vision_projection(vision.width),
+                ),
+            ),
+            MappingRule(
+                "PaliGemma/img/Transformer/encoderblock/MultiHeadDotProductAttention_0/out/bias",
+                (vision.depth, vision.width),
+                _scanned(vision.depth, "vision.layer.{layer}.attention.o.bias"),
+            ),
+            MappingRule(
+                "PaliGemma/img/Transformer/encoder_norm/scale",
+                (vision.width,),
+                _single("vision.post_norm.weight"),
+            ),
+            MappingRule(
+                "PaliGemma/img/Transformer/encoder_norm/bias",
+                (vision.width,),
+                _single("vision.post_norm.bias"),
+            ),
+            MappingRule(
+                "PaliGemma/img/head/kernel",
+                (vision.width, vision.output_width),
+                _single("vision.projector.weight"),
+            ),
+            MappingRule(
+                "PaliGemma/img/head/bias",
+                (vision.output_width,),
+                _single("vision.projector.bias"),
+            ),
+            MappingRule(
+                "PaliGemma/llm/embedder/input_embedding",
+                (profile.vocab_size, profile.prefix.width),
+                _single("prefix.embedding"),
+            ),
+        ]
+    )
+    rules.extend(
+        _rules_for_gemma_expert(
+            source_suffix="",
+            destination_prefix="prefix",
+            profile=profile,
+            adaptive_norm=False,
+        )
+    )
+    rules.extend(
+        _rules_for_gemma_expert(
+            source_suffix="_1",
+            destination_prefix="action",
+            profile=profile,
+            adaptive_norm=True,
+        )
+    )
+
+    action = profile.action_expert
+    for name, shape in (
+        ("action_in", (profile.action_dim, action.width)),
+        ("time_mlp_in", (action.width, action.width)),
+        ("time_mlp_out", (action.width, action.width)),
+        ("action_out", (action.width, profile.action_dim)),
+    ):
+        rules.extend(
+            [
+                MappingRule(
+                    f"{name}_proj/kernel"
+                    if name in {"action_in", "action_out"}
+                    else f"{name}/kernel",
+                    shape,
+                    _single(f"projections.{name}.weight"),
+                ),
+                MappingRule(
+                    f"{name}_proj/bias" if name in {"action_in", "action_out"} else f"{name}/bias",
+                    (shape[1],),
+                    _single(f"projections.{name}.bias"),
+                ),
+            ]
+        )
+    return tuple(rules)
+
+
+def _dtype_is_float(dtype: np.dtype[Any]) -> bool:
+    return dtype.kind == "f" or dtype.name == "bfloat16"
+
+
+def _inventory_sha256(entries: Sequence[dict[str, Any]]) -> str:
+    digest = hashlib.sha256()
+    for entry in entries:
+        encoded = (
+            f"{entry['name']}\0{entry['dtype']}\0{','.join(map(str, entry['shape']))}"
+            f"\0{entry['sha256']}"
+        ).encode("utf-8")
+        digest.update(len(encoded).to_bytes(8, "little"))
+        digest.update(encoded)
+    return digest.hexdigest()
+
+
+def map_weights(
+    reader: CheckpointReader,
+    profile: OpenPIProfile,
+    *,
+    rules: Sequence[MappingRule] | None = None,
+) -> MappingResult:
+    """Map a checkpoint and reject any non-exhaustive conversion."""
+
+    selected_rules = tuple(rules if rules is not None else openpi_mapping_rules(profile))
+    if not selected_rules:
+        raise WeightMappingError("weight mapping contains no rules")
+
+    rule_sources: set[str] = set()
+    duplicate_rules: list[str] = []
+    for rule in selected_rules:
+        if rule.source in rule_sources:
+            duplicate_rules.append(rule.source)
+        rule_sources.add(rule.source)
+    if duplicate_rules:
+        raise WeightMappingError(
+            "duplicate source mapping rules: " + ", ".join(sorted(set(duplicate_rules)))
+        )
+
+    resolved: list[tuple[MappingRule, str]] = []
+    missing: list[str] = []
+    ambiguous: list[str] = []
+    consumed: set[str] = set()
+    for rule in selected_rules:
+        candidates = [name for name in (rule.source, f"{rule.source}/value") if name in reader]
+        if not candidates:
+            missing.append(rule.source)
+            continue
+        if len(candidates) != 1:
+            ambiguous.append(f"{rule.source}: {candidates}")
+            continue
+        actual = candidates[0]
+        if actual in consumed:
+            ambiguous.append(f"{actual}: consumed by multiple rules")
+            continue
+        consumed.add(actual)
+        resolved.append((rule, actual))
+
+    unexpected = sorted(set(reader) - consumed)
+    if missing or ambiguous or unexpected:
+        details: list[str] = []
+        if missing:
+            details.append("missing=" + ", ".join(sorted(missing)))
+        if ambiguous:
+            details.append("ambiguous=" + "; ".join(sorted(ambiguous)))
+        if unexpected:
+            details.append("unexpected=" + ", ".join(unexpected))
+        raise WeightMappingError("checkpoint mapping is not exhaustive: " + " | ".join(details))
+
+    shape_errors: list[str] = []
+    dtype_errors: list[str] = []
+    for rule, actual in resolved:
+        array = reader[actual]
+        shape = tuple(int(dim) for dim in array.shape)
+        if shape != rule.expected_shape:
+            shape_errors.append(f"{actual}: expected {rule.expected_shape}, got {shape}")
+        if not _dtype_is_float(array.dtype):
+            dtype_errors.append(f"{actual}: expected floating point, got {array.dtype.name}")
+    if shape_errors or dtype_errors:
+        raise WeightMappingError(
+            "checkpoint tensor contract mismatch: " + " | ".join(shape_errors + dtype_errors)
+        )
+
+    weights: dict[str, np.ndarray] = {}
+    destination_entries: list[dict[str, Any]] = []
+    mapping_entries: list[dict[str, Any]] = []
+    for rule, actual in resolved:
+        source_record = reader.record(actual)
+        destinations: list[dict[str, Any]] = []
+        for mapped in rule.transform(source_record.array):
+            if not mapped.name:
+                raise WeightMappingError(f"mapping for {actual} emitted an empty destination name")
+            if mapped.name in weights:
+                raise WeightMappingError(f"duplicate destination mapping: {mapped.name}")
+            array = np.ascontiguousarray(mapped.array)
+            if not _dtype_is_float(array.dtype):
+                raise WeightMappingError(
+                    f"mapping for {actual} emitted non-floating destination {mapped.name}: {array.dtype}"
+                )
+            weights[mapped.name] = array
+            destination = {
+                "name": mapped.name,
+                "shape": list(array.shape),
+                "dtype": array.dtype.name,
+                "sha256": tensor_sha256(array),
+                "source": actual,
+                "transform": mapped.transform,
+            }
+            destination_entries.append(destination)
+            destinations.append(destination)
+        if not destinations:
+            raise WeightMappingError(f"mapping for {actual} emitted no destination tensors")
+        mapping_entries.append(
+            {
+                "expected_source": rule.source,
+                "expected_shape": list(rule.expected_shape),
+                "source": source_record.manifest_entry(),
+                "destinations": destinations,
+            }
+        )
+
+    destination_entries.sort(key=lambda item: item["name"])
+    mapping_entries.sort(key=lambda item: item["expected_source"])
+    source_entries = reader.manifest_inventory()
+    manifest: dict[str, Any] = {
+        "schema_version": CONVERSION_MANIFEST_SCHEMA_VERSION,
+        "format": "trtmc.openpi.weight-conversion",
+        "profile": profile.name,
+        "policy": profile.to_dict(),
+        "upstream": {
+            "repository": OPENPI_UPSTREAM_REPOSITORY,
+            "commit": OPENPI_UPSTREAM_COMMIT,
+            "checkpoint_uri": profile.checkpoint_uri,
+        },
+        "source_checkpoint": {
+            "tensor_count": len(source_entries),
+            "identity_sha256": reader.identity_sha256,
+        },
+        "destination_weights": {
+            "tensor_count": len(destination_entries),
+            "identity_sha256": _inventory_sha256(destination_entries),
+        },
+        "source_tensors": source_entries,
+        "destination_tensors": destination_entries,
+        "mappings": mapping_entries,
+    }
+    return MappingResult(weights=weights, manifest=manifest)

--- a/scripts/generate_e2e_report.py
+++ b/scripts/generate_e2e_report.py
@@ -99,6 +99,7 @@ _TASK_STRATEGY_TO_MODALITY = {
     "embedding": "numeric",
     "reranking": "reranking",
     "neural_operator": "neural_operator",
+    "robot_action_generation": "neural_operator",
     "omni_multimodal": "omni",
     # Kept explicit for forward-compatible manifests.  Unknown strategies
     # still receive the structured TRT/reference fallback renderer.
@@ -3630,7 +3631,7 @@ def validate_evidence(
             if external_reference:
                 require(bool(_first_stage_value(result, "ref", ("scores",))),
                         "missing reference reranking scores")
-        elif strategy == "neural_operator":
+        elif strategy in {"neural_operator", "robot_action_generation"}:
             trt_field = _first_stage_value(
                 result, "trt", ("output_field", "field", "prediction", "forecast",
                                 "output_field_preview"))

--- a/src/runtime/models/openpi/MODEL.toml
+++ b/src/runtime/models/openpi/MODEL.toml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id = "openpi"
+runtime_library = "libtrtmc_model_openpi.so"
+runtime_plugins = ["plugin.cpp|register_openpi_plugin"]
+runtime_strategies = ["openpi_vla"]
+task_strategy = "robot_action_generation"
+runtime_tests = [
+  "test_openpi_action_request_json|test_openpi_action_request_json.cpp|nlohmann_json::nlohmann_json|tool/action_request_json.cpp|_",
+  "test_openpi_data_plane|test_openpi_data_plane.cpp|_|openpi_data_plane.cpp|_",
+  "test_paligemma_bpe|test_paligemma_bpe.cpp|_|openpi_data_plane.cpp,paligemma_bpe.cpp|_",
+  "test_openpi_pipeline|test_openpi_pipeline.cpp|trtmc_model_openpi|_|_",
+  "test_openpi_qualification_diagnostics|test_openpi_qualification_diagnostics.cpp|nlohmann_json::nlohmann_json|tool/qualification_diagnostics.cpp|_",
+]

--- a/src/runtime/models/openpi/api.h
+++ b/src/runtime/models/openpi/api.h
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace trtmc::openpi {
+
+struct RobotImage {
+    std::string name;
+    std::vector<float> pixels; // RGB HWC float32 in [0, 1].
+    int32_t height{0};
+    int32_t width{0};
+    int32_t channels{3};
+    bool valid{true};
+};
+
+struct ActionRequest {
+    std::string prompt;
+    std::vector<RobotImage> cameras;
+    std::vector<float> state;
+    std::vector<float> initial_noise;
+    int32_t seed{-1};
+    int32_t denoise_steps{-1};
+};
+
+struct PolicyTimings {
+    double preprocess_ms{0.0};
+    double prefill_ms{0.0};
+    double denoise_ms{0.0};
+    double postprocess_ms{0.0};
+};
+
+struct ActionResult {
+    std::vector<float> actions; // Row-major [horizon, action_dim].
+    int32_t horizon{0};
+    int32_t action_dim{0};
+    PolicyTimings timings;
+};
+
+class IOpenPIActionPipeline {
+  public:
+    virtual ~IOpenPIActionPipeline() = default;
+    virtual ActionResult predict_actions(const ActionRequest& request) = 0;
+};
+
+enum class DiagnosticTensorType : uint8_t {
+    kBool,
+    kInt32,
+    kBFloat16,
+    kFloat32,
+};
+
+enum class DiagnosticStage : uint8_t {
+    kPreprocess,
+    kVision,
+    kPrefix,
+    kFlow,
+    kPostprocess,
+};
+
+enum class DiagnosticRole : uint8_t {
+    kInput,
+    kIntermediate,
+    kOutput,
+};
+
+struct DiagnosticTensor {
+    std::string name;
+    DiagnosticStage stage{DiagnosticStage::kPreprocess};
+    DiagnosticRole role{DiagnosticRole::kIntermediate};
+    DiagnosticTensorType dtype{DiagnosticTensorType::kFloat32};
+    std::vector<int64_t> shape;
+    std::vector<uint8_t> bytes;
+};
+
+struct ActionDiagnosticResult {
+    ActionResult result;
+    std::vector<DiagnosticTensor> tensors;
+};
+
+// OpenPI qualification capture is model-owned and absent from production
+// robot-policy APIs.
+class IOpenPIDiagnosticPipeline {
+  public:
+    virtual ~IOpenPIDiagnosticPipeline() = default;
+    virtual ActionDiagnosticResult
+    predict_actions_with_diagnostics(const ActionRequest& request) = 0;
+};
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/benchmark_worker_adapter.h
+++ b/src/runtime/models/openpi/benchmark_worker_adapter.h
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "runtime/models/openpi/api.h"
+#include "trtmc/pipeline.h"
+
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace trtmc::openpi::benchmark {
+
+inline nlohmann::json run_predict_actions(IPipeline& pipeline, const nlohmann::json& request,
+                                          int warmup, int iterations) {
+    constexpr std::size_t kPixelsPerCamera = 224U * 224U * 3U;
+    constexpr std::array<const char*, 3> kCameraNames = {"base_0_rgb", "left_wrist_0_rgb",
+                                                         "right_wrist_0_rgb"};
+    constexpr std::array<bool, 3> kCameraValidity = {true, true, false};
+
+    ActionRequest input;
+    input.prompt = request.at("prompt").get<std::string>();
+    input.seed = request.at("seed").get<int32_t>();
+    input.denoise_steps = 10;
+    input.state.assign(8U, 0.0F);
+    input.initial_noise.assign(15U * 32U, 0.0F);
+    for (std::size_t index = 0; index < kCameraNames.size(); ++index) {
+        RobotImage camera;
+        camera.name = kCameraNames[index];
+        camera.height = 224;
+        camera.width = 224;
+        camera.channels = 3;
+        camera.valid = kCameraValidity[index];
+        camera.pixels.assign(kPixelsPerCamera, camera.valid ? 0.5F : 0.0F);
+        input.cameras.push_back(std::move(camera));
+    }
+
+    auto* action_pipeline = dynamic_cast<IOpenPIActionPipeline*>(&pipeline);
+    if (action_pipeline == nullptr) {
+        throw std::runtime_error(std::string(pipeline.pipeline_type()) +
+                                 " does not support predict_actions");
+    }
+    ActionResult last;
+    for (int index = 0; index < warmup; ++index) {
+        last = action_pipeline->predict_actions(input);
+    }
+    nlohmann::json observations = nlohmann::json::array();
+    using Clock = std::chrono::steady_clock;
+    for (int index = 0; index < iterations; ++index) {
+        const auto start = Clock::now();
+        last = action_pipeline->predict_actions(input);
+        const double wall_ms =
+            std::chrono::duration<double, std::milli>(Clock::now() - start).count();
+        observations.push_back({
+            {"iteration", index},
+            {"runtime_e2e_wall_ms", wall_ms},
+            {"action_chunks", 1},
+            {"action_steps", last.horizon},
+            {"preprocess_ms", last.timings.preprocess_ms},
+            {"prefill_ms", last.timings.prefill_ms},
+            {"denoise_ms", last.timings.denoise_ms},
+            {"postprocess_ms", last.timings.postprocess_ms},
+        });
+    }
+    return {
+        {"observations", std::move(observations)},
+        {"output_summary",
+         {
+             {"horizon", last.horizon},
+             {"action_dim", last.action_dim},
+             {"element_count", last.actions.size()},
+         }},
+    };
+}
+
+} // namespace trtmc::openpi::benchmark

--- a/src/runtime/models/openpi/config.cpp
+++ b/src/runtime/models/openpi/config.cpp
@@ -1,0 +1,338 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/openpi/config.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace trtmc::openpi {
+namespace {
+
+using Json = nlohmann::json;
+
+Json parse_object(std::string_view text, const char* label) {
+    Json document;
+    std::vector<std::unordered_set<std::string>> object_keys;
+    try {
+        const Json::parser_callback_t reject_duplicate_keys =
+            [&object_keys](int, Json::parse_event_t event, Json& parsed) {
+                if (event == Json::parse_event_t::object_start) {
+                    object_keys.emplace_back();
+                } else if (event == Json::parse_event_t::key) {
+                    if (object_keys.empty() ||
+                        !object_keys.back().emplace(parsed.get<std::string>()).second) {
+                        throw std::invalid_argument("duplicate JSON object key");
+                    }
+                } else if (event == Json::parse_event_t::object_end) {
+                    if (object_keys.empty()) {
+                        throw std::invalid_argument("invalid JSON object nesting");
+                    }
+                    object_keys.pop_back();
+                }
+                return true;
+            };
+        document = Json::parse(text.begin(), text.end(), reject_duplicate_keys);
+    } catch (const std::exception& error) {
+        throw std::invalid_argument(std::string("OpenPI ") + label +
+                                    " is not valid JSON: " + error.what());
+    }
+    if (!document.is_object()) {
+        throw std::invalid_argument(std::string("OpenPI ") + label + " must contain a JSON object");
+    }
+    return document;
+}
+
+const Json& require_field(const Json& object, const char* key, const char* label) {
+    const auto iterator = object.find(key);
+    if (iterator == object.end()) {
+        throw std::invalid_argument(std::string("OpenPI ") + label + " is missing '" + key + "'");
+    }
+    return *iterator;
+}
+
+std::string require_string(const Json& object, const char* key, const char* label) {
+    const auto& value = require_field(object, key, label);
+    if (!value.is_string()) {
+        throw std::invalid_argument(std::string("OpenPI ") + label + " field '" + key +
+                                    "' must be a string");
+    }
+    return value.get<std::string>();
+}
+
+int32_t require_int32(const Json& object, const char* key, const char* label) {
+    const auto& value = require_field(object, key, label);
+    if (!value.is_number_integer()) {
+        throw std::invalid_argument(std::string("OpenPI ") + label + " field '" + key +
+                                    "' must be an integer");
+    }
+    const auto parsed = value.get<int64_t>();
+    if (parsed < std::numeric_limits<int32_t>::min() ||
+        parsed > std::numeric_limits<int32_t>::max()) {
+        throw std::invalid_argument(std::string("OpenPI ") + label + " field '" + key +
+                                    "' is outside int32 range");
+    }
+    return static_cast<int32_t>(parsed);
+}
+
+bool require_bool(const Json& object, const char* key, const char* label) {
+    const auto& value = require_field(object, key, label);
+    if (!value.is_boolean()) {
+        throw std::invalid_argument(std::string("OpenPI ") + label + " field '" + key +
+                                    "' must be a boolean");
+    }
+    return value.get<bool>();
+}
+
+void require_string_value(const Json& object, const char* key, std::string_view expected,
+                          const char* label) {
+    const auto actual = require_string(object, key, label);
+    if (actual != expected) {
+        throw std::invalid_argument(std::string("OpenPI ") + label + " field '" + key +
+                                    "' mismatch: expected '" + std::string(expected) + "', got '" +
+                                    actual + "'");
+    }
+}
+
+void require_int_value(const Json& object, const char* key, int32_t expected, const char* label) {
+    const int32_t actual = require_int32(object, key, label);
+    if (actual != expected) {
+        throw std::invalid_argument(std::string("OpenPI ") + label + " field '" + key +
+                                    "' mismatch: expected " + std::to_string(expected) + ", got " +
+                                    std::to_string(actual));
+    }
+}
+
+bool is_lower_sha256(std::string_view digest) {
+    return digest.size() == 64 && std::all_of(digest.begin(), digest.end(), [](char character) {
+               return (character >= '0' && character <= '9') ||
+                      (character >= 'a' && character <= 'f');
+           });
+}
+
+void require_digest(const std::string& digest, const char* field, bool nonzero = false) {
+    if (!is_lower_sha256(digest) ||
+        (nonzero &&
+         std::all_of(digest.begin(), digest.end(), [](char value) { return value == '0'; }))) {
+        throw std::invalid_argument(std::string("OpenPI config.json field '") + field +
+                                    "' must be a valid lowercase SHA-256 digest");
+    }
+}
+
+std::vector<float> require_float_array(const Json& object, const char* key, const char* label) {
+    const auto& value = require_field(object, key, label);
+    if (!value.is_array() || value.empty()) {
+        throw std::invalid_argument(std::string("OpenPI ") + label + " field '" + key +
+                                    "' must be a non-empty array");
+    }
+    std::vector<float> result;
+    result.reserve(value.size());
+    for (const auto& element : value) {
+        if (!element.is_number()) {
+            throw std::invalid_argument(std::string("OpenPI ") + label + " field '" + key +
+                                        "' must contain only numbers");
+        }
+        const double parsed = element.get<double>();
+        if (!std::isfinite(parsed) || parsed < -std::numeric_limits<float>::max() ||
+            parsed > std::numeric_limits<float>::max()) {
+            throw std::invalid_argument(std::string("OpenPI ") + label + " field '" + key +
+                                        "' contains a non-finite or out-of-range value");
+        }
+        result.push_back(static_cast<float>(parsed));
+    }
+    return result;
+}
+
+void require_quantile_dimensions(const QuantileStats& quantiles, const char* field,
+                                 int32_t minimum_dimension) {
+    const auto dimension = quantiles.q01.size();
+    if (dimension != quantiles.q99.size() ||
+        dimension < static_cast<std::size_t>(minimum_dimension) ||
+        dimension > kModelActionDimension) {
+        throw std::invalid_argument(std::string("OpenPI normalization field '") + field +
+                                    "' has an invalid quantile dimension");
+    }
+}
+
+void require_quantile_order(float q01, float q99, std::size_t index, std::size_t external_dimension,
+                            const char* field) {
+    const bool externally_used = index < external_dimension;
+    const bool valid = externally_used ? q99 > q01 : q99 >= q01;
+    if (valid) {
+        return;
+    }
+    throw std::invalid_argument(std::string("OpenPI normalization field '") + field +
+                                (externally_used ? "' has q99 <= q01 at externally used dimension "
+                                                 : "' has q99 < q01 at padded dimension ") +
+                                std::to_string(index));
+}
+
+QuantileStats parse_quantiles(const Json& norm_stats, const char* field,
+                              int32_t minimum_dimension) {
+    const auto& entry = require_field(norm_stats, field, "normalization statistics");
+    if (!entry.is_object()) {
+        throw std::invalid_argument(std::string("OpenPI normalization field '") + field +
+                                    "' must be an object");
+    }
+    QuantileStats result;
+    result.q01 = require_float_array(entry, "q01", field);
+    result.q99 = require_float_array(entry, "q99", field);
+    require_quantile_dimensions(result, field, minimum_dimension);
+    for (std::size_t index = 0; index < result.q01.size(); ++index) {
+        require_quantile_order(result.q01[index], result.q99[index], index,
+                               static_cast<std::size_t>(minimum_dimension), field);
+    }
+    return result;
+}
+
+struct ProfileContract {
+    int32_t action_horizon;
+    int32_t external_action_dim;
+    int32_t external_state_dim;
+    bool discrete_state_input;
+};
+
+ProfileContract contract_for_profile(std::string_view profile) {
+    if (profile == "pi05_droid") {
+        return ProfileContract{15, 8, 8, true};
+    }
+    throw std::invalid_argument("Unsupported OpenPI profile '" + std::string(profile) +
+                                "'; expected pi05_droid");
+}
+
+OpenPIConfig parse_config_fields(const Json& root) {
+    OpenPIConfig config;
+    config.profile = require_string(root, "openpi_profile", "config.json");
+    config.precision = require_string(root, "precision", "config.json");
+    config.parameter_dtype = require_string(root, "openpi_parameter_dtype", "config.json");
+    config.tokenizer_sha256 = require_string(root, "openpi_tokenizer_sha256", "config.json");
+    config.normalization_sha256 =
+        require_string(root, "openpi_normalization_sha256", "config.json");
+    config.prefill_engine_sha256 =
+        require_string(root, "openpi_prefill_engine_sha256", "config.json");
+    config.action_engine_sha256 =
+        require_string(root, "openpi_action_engine_sha256", "config.json");
+    config.action_horizon = require_int32(root, "openpi_action_horizon", "config.json");
+    config.internal_action_dim = require_int32(root, "openpi_internal_action_dim", "config.json");
+    config.external_action_dim = require_int32(root, "openpi_external_action_dim", "config.json");
+    config.external_state_dim = require_int32(root, "openpi_external_state_dim", "config.json");
+    config.prefix_length = require_int32(root, "openpi_prefix_length", "config.json");
+    config.max_token_length = require_int32(root, "openpi_max_token_length", "config.json");
+    config.num_layers = require_int32(root, "openpi_num_layers", "config.json");
+    config.num_heads = require_int32(root, "openpi_num_heads", "config.json");
+    config.num_kv_heads = require_int32(root, "openpi_num_kv_heads", "config.json");
+    config.head_dim = require_int32(root, "openpi_head_dim", "config.json");
+    config.denoise_steps = require_int32(root, "openpi_denoise_steps", "config.json");
+    config.batch_size = require_int32(root, "openpi_batch_size", "config.json");
+    config.discrete_state_input = require_bool(root, "openpi_discrete_state_input", "config.json");
+    return config;
+}
+
+void require_config_dimensions(const Json& root, const ProfileContract& expected) {
+    require_int_value(root, "openpi_action_horizon", expected.action_horizon, "config.json");
+    require_int_value(root, "openpi_internal_action_dim",
+                      static_cast<int32_t>(kModelActionDimension), "config.json");
+    require_int_value(root, "openpi_external_action_dim", expected.external_action_dim,
+                      "config.json");
+    require_int_value(root, "openpi_external_state_dim", expected.external_state_dim,
+                      "config.json");
+    require_int_value(root, "openpi_prefix_length", kPrefixLength, "config.json");
+    require_int_value(root, "openpi_max_token_length", kMaximumPromptTokens, "config.json");
+    require_int_value(root, "openpi_num_layers", kTransformerLayers, "config.json");
+    require_int_value(root, "openpi_num_heads", 8, "config.json");
+    require_int_value(root, "openpi_num_kv_heads", kKvHeads, "config.json");
+    require_int_value(root, "openpi_head_dim", kHeadDimension, "config.json");
+    require_int_value(root, "openpi_denoise_steps", 10, "config.json");
+    require_int_value(root, "openpi_batch_size", 1, "config.json");
+}
+
+void require_config_scalar_contract(const OpenPIConfig& config, const ProfileContract& expected) {
+    if (config.discrete_state_input != expected.discrete_state_input) {
+        throw std::invalid_argument("OpenPI config discrete-state setting does not match profile");
+    }
+    if (config.precision != "bf16" && config.precision != "bfloat16") {
+        throw std::invalid_argument("OpenPI config precision must be bf16 or bfloat16");
+    }
+    if (config.parameter_dtype != "bfloat16") {
+        throw std::invalid_argument("OpenPI parameter dtype must be bfloat16");
+    }
+    require_digest(config.tokenizer_sha256, "openpi_tokenizer_sha256");
+    require_digest(config.normalization_sha256, "openpi_normalization_sha256");
+    require_digest(config.prefill_engine_sha256, "openpi_prefill_engine_sha256");
+    require_digest(config.action_engine_sha256, "openpi_action_engine_sha256");
+}
+
+void require_camera_array_shapes(const Json& names, const Json& masks, std::size_t count) {
+    if (!names.is_array() || names.size() != count || !masks.is_array() || masks.size() != count) {
+        throw std::invalid_argument(
+            "OpenPI config must declare exactly three camera names and masks");
+    }
+}
+
+void parse_camera_entry(OpenPIConfig& config, const Json& names, const Json& masks,
+                        std::size_t index) {
+    if (!names[index].is_string() || !masks[index].is_boolean()) {
+        throw std::invalid_argument("OpenPI config camera names/masks have invalid types");
+    }
+    config.camera_names[index] = names[index].get<std::string>();
+    config.camera_mask[index] = masks[index].get<bool>();
+    if (config.camera_names[index] != kCameraNames[index]) {
+        throw std::invalid_argument(
+            "OpenPI config camera ordering does not match the audited contract");
+    }
+}
+
+void parse_camera_contract(OpenPIConfig& config, const Json& root) {
+    const auto& names = require_field(root, "openpi_camera_names", "config.json");
+    const auto& masks = require_field(root, "openpi_camera_mask", "config.json");
+    require_camera_array_shapes(names, masks, config.camera_names.size());
+    for (std::size_t index = 0; index < config.camera_names.size(); ++index) {
+        parse_camera_entry(config, names, masks, index);
+    }
+    if (config.camera_mask != std::array<bool, 3>{true, true, false}) {
+        throw std::invalid_argument("OpenPI config camera mask must be [true, true, false]");
+    }
+}
+
+} // namespace
+
+OpenPIConfig parse_openpi_config(std::string_view config_json) {
+    const Json root = parse_object(config_json, "config.json");
+    require_string_value(root, "runtime_strategy", "openpi_vla", "config.json");
+    require_string_value(root, "task_strategy", "robot_action_generation", "config.json");
+    require_string_value(root, "user_contract", "robot_action_chunk", "config.json");
+    require_string_value(root, "model_type", "openpi_pi05_flow", "config.json");
+    require_string_value(root, "openpi_upstream_commit", kAuditedUpstreamCommit, "config.json");
+    require_string_value(root, "openpi_runtime_contract", "native_cpp_device_resident_flow",
+                         "config.json");
+
+    OpenPIConfig config = parse_config_fields(root);
+    const auto expected = contract_for_profile(config.profile);
+    require_config_dimensions(root, expected);
+    require_config_scalar_contract(config, expected);
+    parse_camera_contract(config, root);
+    return config;
+}
+
+OpenPINormalization parse_openpi_normalization(std::string_view normalization_json,
+                                               const OpenPIConfig& config) {
+    const Json root = parse_object(normalization_json, "normalization statistics");
+    const auto& stats = require_field(root, "norm_stats", "normalization statistics");
+    if (!stats.is_object()) {
+        throw std::invalid_argument("OpenPI normalization statistics require a norm_stats object");
+    }
+    OpenPINormalization normalization;
+    normalization.state = parse_quantiles(stats, "state", config.external_state_dim);
+    normalization.actions = parse_quantiles(stats, "actions", config.external_action_dim);
+    return normalization;
+}
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/config.h
+++ b/src/runtime/models/openpi/config.h
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "runtime/models/openpi/openpi_data_plane.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace trtmc::openpi {
+
+inline constexpr std::string_view kAuditedUpstreamCommit =
+    "15a9616a00943ada6c20a0f158e3adb39df2ccac";
+inline constexpr int32_t kPrefixLength = 968;
+inline constexpr int32_t kMaximumPromptTokens = 200;
+inline constexpr int32_t kTransformerLayers = 18;
+inline constexpr int32_t kKvHeads = 1;
+inline constexpr int32_t kHeadDimension = 256;
+inline constexpr std::array<std::string_view, 5> kRequiredIntegritySectionNames = {
+    "config.json",
+    "engine_plan",
+    "openpi_action_step_engine_plan",
+    "tokenizer.model",
+    "preprocessor_config.json",
+};
+
+struct OpenPIConfig {
+    std::string profile;
+    std::string precision;
+    std::string parameter_dtype;
+    std::string tokenizer_sha256;
+    std::string normalization_sha256;
+    std::string prefill_engine_sha256;
+    std::string action_engine_sha256;
+    int32_t action_horizon{0};
+    int32_t internal_action_dim{0};
+    int32_t external_action_dim{0};
+    int32_t external_state_dim{0};
+    int32_t prefix_length{0};
+    int32_t max_token_length{0};
+    int32_t num_layers{0};
+    int32_t num_heads{0};
+    int32_t num_kv_heads{0};
+    int32_t head_dim{0};
+    int32_t denoise_steps{0};
+    int32_t batch_size{0};
+    bool discrete_state_input{false};
+    std::array<std::string, 3> camera_names;
+    std::array<bool, 3> camera_mask{};
+};
+
+struct OpenPINormalization {
+    QuantileStats state;
+    QuantileStats actions;
+};
+
+// Parse and validate the complete model-owned runtime contract. Only the two
+// explicitly audited profiles are accepted; path- or shape-based inference is
+// deliberately forbidden.
+OpenPIConfig parse_openpi_config(std::string_view config_json);
+
+// Parse profile normalization statistics and require finite q01/q99 values.
+// Externally visible dimensions require a positive span; padded model-only
+// dimensions may have the equal zero-span statistics emitted by OpenPI.
+OpenPINormalization parse_openpi_normalization(std::string_view normalization_json,
+                                               const OpenPIConfig& config);
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/model.cmake
+++ b/src/runtime/models/openpi/model.cmake
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Keep the action surface model-owned. The shared `trtmc` CLI and public
+# IPipeline interface do not need OpenPI request or diagnostic concepts.
+option(TRTMC_OPENPI_REQUIRE_QUALIFIED_RUNTIME
+  "Fail unless the qualified OpenPI GB300 TensorRT runtime can be built" OFF)
+if(TRTMC_MODEL_PROOF_MODEL STREQUAL "openpi")
+  set(TRTMC_OPENPI_REQUIRE_QUALIFIED_RUNTIME ON CACHE BOOL
+    "Fail unless the qualified OpenPI GB300 TensorRT runtime can be built" FORCE)
+endif()
+
+add_executable(trtmc_openpi_runner
+  "${CMAKE_CURRENT_LIST_DIR}/tool/action_request_json.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/tool/main.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/tool/qualification_diagnostics.cpp"
+)
+target_link_libraries(trtmc_openpi_runner PRIVATE trtmc_core)
+target_include_directories(trtmc_openpi_runner PRIVATE
+  "${PROJECT_SOURCE_DIR}/include"
+  "${PROJECT_SOURCE_DIR}/src"
+)
+target_include_directories(trtmc_openpi_runner SYSTEM PRIVATE
+  "${_trtmc_nlohmann_json_include}"
+)
+target_compile_options(trtmc_openpi_runner PRIVATE -Wall -Wextra -Wpedantic)
+set_target_properties(trtmc_openpi_runner PROPERTIES
+  OUTPUT_NAME trtmc-openpi
+  BUILD_RPATH "\$ORIGIN"
+  BUILD_RPATH_USE_ORIGIN TRUE
+  INSTALL_RPATH "\$ORIGIN"
+)
+add_dependencies(trtmc_model_${_trtmc_model} trtmc_openpi_runner)
+install(TARGETS trtmc_openpi_runner
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# OpenPI's custom TensorRT plugins are qualified only on the Linux/aarch64
+# GB300 stack. Do not compile them on another platform: a successful build
+# there would imply support that has not been established.
+set(_trtmc_openpi_platform_eligible TRUE)
+set(_trtmc_openpi_platform_reason "")
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(_trtmc_openpi_platform_eligible FALSE)
+  set(_trtmc_openpi_platform_reason
+    "requires Linux; detected '${CMAKE_SYSTEM_NAME}'")
+elseif(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  set(_trtmc_openpi_platform_eligible FALSE)
+  set(_trtmc_openpi_platform_reason
+    "requires aarch64; detected '${CMAKE_SYSTEM_PROCESSOR}'")
+elseif(NOT CMAKE_CUDA_COMPILER)
+  set(_trtmc_openpi_platform_eligible FALSE)
+  set(_trtmc_openpi_platform_reason "requires a CUDA compiler with sm103 support")
+elseif(NOT _trtmc_can_build_trt_backend)
+  set(_trtmc_openpi_platform_eligible FALSE)
+  set(_trtmc_openpi_platform_reason "requires TensorRT headers and libraries")
+else()
+  _trtmc_header_define_value(_trtmc_openpi_trt_major NV_TENSORRT_MAJOR)
+  _trtmc_header_define_value(_trtmc_openpi_trt_minor NV_TENSORRT_MINOR)
+  _trtmc_header_define_value(_trtmc_openpi_trt_patch NV_TENSORRT_PATCH)
+  _trtmc_header_define_value(_trtmc_openpi_trt_build NV_TENSORRT_BUILD)
+  set(_trtmc_openpi_trt_version
+    "${_trtmc_openpi_trt_major}.${_trtmc_openpi_trt_minor}."
+    "${_trtmc_openpi_trt_patch}.${_trtmc_openpi_trt_build}")
+  string(JOIN "" _trtmc_openpi_trt_version ${_trtmc_openpi_trt_version})
+  if(NOT _trtmc_openpi_trt_version STREQUAL "11.2.0.113")
+    set(_trtmc_openpi_platform_eligible FALSE)
+    set(_trtmc_openpi_platform_reason
+      "requires TensorRT 11.2.0.113; detected '${_trtmc_openpi_trt_version}'")
+  endif()
+endif()
+
+if(TRTMC_OPENPI_REQUIRE_QUALIFIED_RUNTIME AND NOT _trtmc_openpi_platform_eligible)
+  message(FATAL_ERROR
+    "OpenPI native runtime is qualified only for NVIDIA GB300 (sm103) on "
+    "Linux/aarch64 with TensorRT 11.2.0.113: ${_trtmc_openpi_platform_reason}")
+endif()
+
+if(_trtmc_openpi_platform_eligible)
+  set(TRTMC_OPENPI_CUDA_ARCHITECTURES "103" CACHE STRING
+    "CUDA architecture for the qualified OpenPI GB300 runtime")
+  if(NOT "${TRTMC_OPENPI_CUDA_ARCHITECTURES}" STREQUAL "103")
+    message(FATAL_ERROR
+      "OpenPI is qualified only for GB300 sm103; "
+      "TRTMC_OPENPI_CUDA_ARCHITECTURES must be exactly '103'")
+  endif()
+  target_sources(trtmc_model_${_trtmc_model} PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/trt_plugins/action_attention_context_plugin.cu"
+    "${CMAKE_CURRENT_LIST_DIR}/trt_plugins/action_layer0_mlp_closure_plugin.cu"
+    "${CMAKE_CURRENT_LIST_DIR}/trt_plugins/action_output_projection_plugin.cu"
+    "${CMAKE_CURRENT_LIST_DIR}/trt_plugins/rms_norm_plugin.cu"
+    "${CMAKE_CURRENT_LIST_DIR}/trt_plugins/siglip_attention_residual_plugin.cu"
+    "${CMAKE_CURRENT_LIST_DIR}/trt_plugins/siglip_layer_norm_plugin.cu"
+  )
+  target_include_directories(trtmc_model_${_trtmc_model} SYSTEM PRIVATE
+    ${TRTMC_TRT_INCLUDE_DIR}
+  )
+  target_compile_definitions(trtmc_model_${_trtmc_model} PRIVATE
+    TRTMC_OPENPI_RMS_NORM_PLUGIN=1
+  )
+  target_link_libraries(trtmc_model_${_trtmc_model} PRIVATE
+    ${TRTMC_TRT_LIBRARY}
+    ${TRTMC_CUBLAS_LIBRARY}
+  )
+  set_target_properties(trtmc_model_${_trtmc_model} PROPERTIES
+    CUDA_ARCHITECTURES "${TRTMC_OPENPI_CUDA_ARCHITECTURES}"
+    BUILD_RPATH "\$ORIGIN;\$ORIGIN/../.."
+    INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../.."
+  )
+  message(STATUS "OpenPI TensorRT plugins: libtrtmc_model_openpi.so")
+else()
+  message(STATUS
+    "OpenPI TensorRT plugin disabled on this unqualified platform: "
+    "${_trtmc_openpi_platform_reason}")
+endif()

--- a/src/runtime/models/openpi/model_options.cmake
+++ b/src/runtime/models/openpi/model_options.cmake
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if(TRTMC_MODEL_PROOF_MODEL STREQUAL "openpi")
+  # OpenPI's qualified runtime contains only Model Connect C++, CUDA, and TensorRT.
+  set(TRTMC_ENABLE_LIBTORCH_MULTINOMIAL OFF CACHE BOOL
+    "Disable libtorch in the OpenPI native runtime" FORCE)
+  set(TRTMC_ENABLE_TVM_FFI OFF CACHE BOOL
+    "Disable TVM-FFI in the OpenPI native runtime" FORCE)
+endif()

--- a/src/runtime/models/openpi/openpi_data_plane.cpp
+++ b/src/runtime/models/openpi/openpi_data_plane.cpp
@@ -1,0 +1,663 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/openpi/openpi_data_plane.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace trtmc::openpi {
+namespace {
+
+constexpr float kTransformEpsilon = 1.0e-6F;
+// Pinned OpenPI JAX/XLA lowers `uint8 / 255 * 2 - 1` to this reciprocal
+// scale (bits 0x3c008080), one ULP below the correctly rounded 2/255 value.
+// Keeping the lowered constant explicit avoids compiler-dependent reassociation
+// at the native preprocessing boundary.
+constexpr float kUint8ToOpenPiScale = 0x1.0101p-7F;
+
+std::size_t checked_element_count(int32_t height, int32_t width, int32_t channels) {
+    if (height <= 0 || width <= 0 || channels <= 0) {
+        throw std::invalid_argument("OpenPI image dimensions and channel count must be positive");
+    }
+    const auto h = static_cast<std::size_t>(height);
+    const auto w = static_cast<std::size_t>(width);
+    const auto c = static_cast<std::size_t>(channels);
+    if (h > std::numeric_limits<std::size_t>::max() / w ||
+        h * w > std::numeric_limits<std::size_t>::max() / c) {
+        throw std::overflow_error("OpenPI image element count overflow");
+    }
+    return h * w * c;
+}
+
+std::size_t checked_flow_count(int32_t batch_size, int32_t action_horizon,
+                               int32_t action_dimension) {
+    if (batch_size <= 0 || action_horizon <= 0 || action_dimension <= 0) {
+        throw std::invalid_argument("OpenPI flow dimensions must be positive");
+    }
+    const auto batch = static_cast<std::size_t>(batch_size);
+    const auto horizon = static_cast<std::size_t>(action_horizon);
+    const auto dimension = static_cast<std::size_t>(action_dimension);
+    if (batch > std::numeric_limits<std::size_t>::max() / horizon ||
+        batch * horizon > std::numeric_limits<std::size_t>::max() / dimension) {
+        throw std::overflow_error("OpenPI flow element count overflow");
+    }
+    return batch * horizon * dimension;
+}
+
+void validate_quantile_stats(const QuantileStats& stats) {
+    if (stats.q01.empty() || stats.q01.size() != stats.q99.size()) {
+        throw std::invalid_argument("OpenPI q01/q99 statistics must have equal non-zero size");
+    }
+    for (std::size_t i = 0; i < stats.q01.size(); ++i) {
+        if (!std::isfinite(stats.q01[i]) || !std::isfinite(stats.q99[i])) {
+            throw std::invalid_argument("OpenPI quantile statistics must be finite");
+        }
+    }
+}
+
+struct Utf8Codepoint {
+    char32_t value{0};
+    std::size_t offset{0};
+    std::size_t length{0};
+};
+
+struct Utf8Prefix {
+    std::size_t length{0};
+    char32_t value{0};
+    char32_t minimum{0};
+};
+
+Utf8Prefix decode_utf8_prefix(uint8_t first) {
+    if (first <= 0x7FU) {
+        return Utf8Prefix{1, first, 0};
+    }
+
+    if ((first & 0xE0U) == 0xC0U) {
+        return Utf8Prefix{2, first & 0x1FU, 0x80};
+    }
+    if ((first & 0xF0U) == 0xE0U) {
+        return Utf8Prefix{3, first & 0x0FU, 0x800};
+    }
+    if ((first & 0xF8U) == 0xF0U) {
+        return Utf8Prefix{4, first & 0x07U, 0x10000};
+    }
+    throw std::invalid_argument("OpenPI prompt contains invalid UTF-8");
+}
+
+char32_t decode_utf8_continuations(std::string_view text, std::size_t offset,
+                                   const Utf8Prefix& prefix) {
+    char32_t value = prefix.value;
+    for (std::size_t i = 1; i < prefix.length; ++i) {
+        const auto byte = static_cast<uint8_t>(text[offset + i]);
+        if ((byte & 0xC0U) != 0x80U) {
+            throw std::invalid_argument("OpenPI prompt contains invalid UTF-8 continuation byte");
+        }
+        value = static_cast<char32_t>((value << 6U) | (byte & 0x3FU));
+    }
+    return value;
+}
+
+bool is_invalid_utf8_scalar(char32_t value, char32_t minimum) {
+    if (value < minimum || value > 0x10FFFFU) {
+        return true;
+    }
+    return value >= 0xD800U && value <= 0xDFFFU;
+}
+
+Utf8Codepoint decode_utf8(std::string_view text, std::size_t offset) {
+    if (offset >= text.size()) {
+        throw std::invalid_argument("OpenPI prompt UTF-8 offset is out of range");
+    }
+
+    const Utf8Prefix prefix = decode_utf8_prefix(static_cast<uint8_t>(text[offset]));
+    if (offset + prefix.length > text.size()) {
+        throw std::invalid_argument("OpenPI prompt contains truncated UTF-8");
+    }
+    const char32_t value = decode_utf8_continuations(text, offset, prefix);
+    if (is_invalid_utf8_scalar(value, prefix.minimum)) {
+        throw std::invalid_argument("OpenPI prompt contains a non-canonical UTF-8 codepoint");
+    }
+    return Utf8Codepoint{value, offset, prefix.length};
+}
+
+struct CodepointRange {
+    char32_t first;
+    char32_t last;
+};
+
+bool is_python_whitespace(char32_t value) {
+    // CPython's Unicode whitespace set (Py_UNICODE_ISSPACE), used by str.strip().
+    constexpr std::array<CodepointRange, 10> kWhitespaceRanges = {
+        CodepointRange{0x0009U, 0x000DU}, CodepointRange{0x001CU, 0x0020U},
+        CodepointRange{0x0085U, 0x0085U}, CodepointRange{0x00A0U, 0x00A0U},
+        CodepointRange{0x1680U, 0x1680U}, CodepointRange{0x2000U, 0x200AU},
+        CodepointRange{0x2028U, 0x2029U}, CodepointRange{0x202FU, 0x202FU},
+        CodepointRange{0x205FU, 0x205FU}, CodepointRange{0x3000U, 0x3000U},
+    };
+    for (const auto& range : kWhitespaceRanges) {
+        if (value >= range.first && value <= range.last) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void validate_uint8_camera(const CameraFrameView& camera) {
+    if (camera.uint8_data == nullptr || camera.float_data != nullptr) {
+        throw std::invalid_argument("OpenPI uint8 camera must provide only uint8 pixel data");
+    }
+    if (camera.valid) {
+        return;
+    }
+    if (std::any_of(camera.uint8_data, camera.uint8_data + camera.element_count,
+                    [](uint8_t value) { return value != 0U; })) {
+        throw std::invalid_argument("OpenPI masked uint8 camera slot must be black (zero)");
+    }
+}
+
+void validate_float_camera_pixel(float value, bool valid) {
+    if (!std::isfinite(value) || value < -1.0F || value > 1.0F) {
+        throw std::invalid_argument("OpenPI float camera pixels must be finite and in [-1, 1]");
+    }
+    if (!valid && value != -1.0F) {
+        throw std::invalid_argument("OpenPI masked float camera slot must be black (-1)");
+    }
+}
+
+void validate_float_camera(const CameraFrameView& camera) {
+    if (camera.float_data == nullptr || camera.uint8_data != nullptr) {
+        throw std::invalid_argument("OpenPI float camera must provide only float32 pixel data");
+    }
+    for (std::size_t i = 0; i < camera.element_count; ++i) {
+        validate_float_camera_pixel(camera.float_data[i], camera.valid);
+    }
+}
+
+std::vector<Utf8Codepoint> decode_prompt(std::string_view prompt) {
+    std::vector<Utf8Codepoint> result;
+    for (std::size_t offset = 0; offset < prompt.size();) {
+        auto codepoint = decode_utf8(prompt, offset);
+        offset += codepoint.length;
+        result.push_back(codepoint);
+    }
+    return result;
+}
+
+std::size_t camera_index(std::string_view name) {
+    for (std::size_t i = 0; i < kCameraNames.size(); ++i) {
+        if (name == kCameraNames[i]) {
+            return i;
+        }
+    }
+    throw std::invalid_argument("Unknown OpenPI camera slot: " + std::string(name));
+}
+
+void validate_camera(const CameraFrameView& camera) {
+    const auto expected_count = checked_element_count(camera.height, camera.width, camera.channels);
+    if (camera.channels != 3) {
+        throw std::invalid_argument("OpenPI camera slots must contain HWC RGB pixels");
+    }
+    if (camera.element_count != expected_count) {
+        throw std::invalid_argument("OpenPI camera pixel count does not match its geometry");
+    }
+
+    if (camera.pixel_type == CameraPixelType::kUint8) {
+        validate_uint8_camera(camera);
+        return;
+    }
+
+    if (camera.pixel_type != CameraPixelType::kFloat32) {
+        throw std::invalid_argument("OpenPI float camera must provide only float32 pixel data");
+    }
+    validate_float_camera(camera);
+}
+
+struct AxisWeight {
+    int32_t source_index{0};
+    float weight{0.0F};
+};
+
+using AxisWeights = std::vector<std::vector<AxisWeight>>;
+
+AxisWeights make_identity_axis_weights(int32_t size) {
+    AxisWeights result(static_cast<std::size_t>(size));
+    for (int32_t i = 0; i < size; ++i) {
+        result[static_cast<std::size_t>(i)].push_back({i, 1.0F});
+    }
+    return result;
+}
+
+bool jax_sample_has_no_support(float total, float sample, int32_t input_size) {
+    constexpr float minimum_total = 1000.0F * std::numeric_limits<float>::epsilon();
+    return std::fabs(total) <= minimum_total || sample < -0.5F ||
+           sample > static_cast<float>(input_size) - 0.5F;
+}
+
+std::vector<AxisWeight> make_jax_sample_weights(int32_t input_size, float sample,
+                                                float kernel_scale) {
+    std::vector<AxisWeight> weights;
+    float total = 0.0F;
+    for (int32_t input = 0; input < input_size; ++input) {
+        const float distance = std::fabs(sample - static_cast<float>(input)) / kernel_scale;
+        const float weight = std::max(0.0F, 1.0F - std::fabs(distance));
+        if (weight != 0.0F) {
+            weights.push_back({input, weight});
+            total += weight;
+        }
+    }
+    if (jax_sample_has_no_support(total, sample, input_size)) {
+        return {};
+    }
+    for (auto& weight : weights) {
+        weight.weight /= total;
+    }
+    return weights;
+}
+
+AxisWeights make_jax_linear_weights(int32_t input_size, int32_t output_size) {
+    if (input_size <= 0 || output_size < 0) {
+        throw std::invalid_argument("OpenPI resize axis dimensions are invalid");
+    }
+    AxisWeights result(static_cast<std::size_t>(output_size));
+    if (output_size == 0) {
+        return result;
+    }
+    if (input_size == output_size) {
+        return make_identity_axis_weights(output_size);
+    }
+
+    // This follows jax._src.image.scale.compute_weight_mat in JAX 0.5.3.
+    const float scale = static_cast<float>(output_size) / static_cast<float>(input_size);
+    const float inverse_scale = 1.0F / scale;
+    const float kernel_scale = std::max(inverse_scale, 1.0F);
+
+    for (int32_t output = 0; output < output_size; ++output) {
+        const float sample = (static_cast<float>(output) + 0.5F) * inverse_scale - 0.5F;
+        result[static_cast<std::size_t>(output)] =
+            make_jax_sample_weights(input_size, sample, kernel_scale);
+    }
+    return result;
+}
+
+std::vector<float> resize_jax_horizontal(const float* pixels, int32_t source_height,
+                                         int32_t source_width, int32_t channels,
+                                         int32_t target_width,
+                                         const AxisWeights& horizontal_weights) {
+    const auto temporary_count = checked_element_count(source_height, target_width, channels);
+    std::vector<float> temporary(temporary_count, 0.0F);
+    for (int32_t y = 0; y < source_height; ++y) {
+        for (int32_t x = 0; x < target_width; ++x) {
+            for (int32_t channel = 0; channel < channels; ++channel) {
+                float value = 0.0F;
+                for (const auto& weight : horizontal_weights[static_cast<std::size_t>(x)]) {
+                    const auto source_index =
+                        (static_cast<std::size_t>(y) * source_width + weight.source_index) *
+                            static_cast<std::size_t>(channels) +
+                        static_cast<std::size_t>(channel);
+                    value += pixels[source_index] * weight.weight;
+                }
+                const auto destination_index = (static_cast<std::size_t>(y) * target_width + x) *
+                                                   static_cast<std::size_t>(channels) +
+                                               static_cast<std::size_t>(channel);
+                temporary[destination_index] = value;
+            }
+        }
+    }
+    return temporary;
+}
+
+std::vector<float> resize_jax_vertical(const std::vector<float>& temporary, int32_t target_height,
+                                       int32_t target_width, int32_t channels,
+                                       const AxisWeights& vertical_weights) {
+    const auto output_count = checked_element_count(target_height, target_width, channels);
+    std::vector<float> output(output_count, 0.0F);
+    for (int32_t y = 0; y < target_height; ++y) {
+        for (int32_t x = 0; x < target_width; ++x) {
+            for (int32_t channel = 0; channel < channels; ++channel) {
+                float value = 0.0F;
+                for (const auto& weight : vertical_weights[static_cast<std::size_t>(y)]) {
+                    const auto source_index =
+                        (static_cast<std::size_t>(weight.source_index) * target_width + x) *
+                            static_cast<std::size_t>(channels) +
+                        static_cast<std::size_t>(channel);
+                    value += temporary[source_index] * weight.weight;
+                }
+                const auto destination_index = (static_cast<std::size_t>(y) * target_width + x) *
+                                                   static_cast<std::size_t>(channels) +
+                                               static_cast<std::size_t>(channel);
+                output[destination_index] = value;
+            }
+        }
+    }
+    return output;
+}
+
+std::vector<float> resize_jax_linear(const float* pixels, int32_t source_height,
+                                     int32_t source_width, int32_t channels, int32_t target_height,
+                                     int32_t target_width) {
+    if (target_height == 0 || target_width == 0) {
+        return {};
+    }
+    const auto horizontal_weights = make_jax_linear_weights(source_width, target_width);
+    const auto vertical_weights = make_jax_linear_weights(source_height, target_height);
+    const auto temporary = resize_jax_horizontal(pixels, source_height, source_width, channels,
+                                                 target_width, horizontal_weights);
+    return resize_jax_vertical(temporary, target_height, target_width, channels, vertical_weights);
+}
+
+float round_to_nearest_even(float value) {
+    const float lower = std::floor(value);
+    const float fraction = value - lower;
+    if (fraction < 0.5F) {
+        return lower;
+    }
+    if (fraction > 0.5F) {
+        return lower + 1.0F;
+    }
+    const auto integer = static_cast<int64_t>(lower);
+    return integer % 2 == 0 ? lower : lower + 1.0F;
+}
+
+template <typename T>
+void copy_resized_into_padded(const std::vector<T>& resized, int32_t resized_height,
+                              int32_t resized_width, int32_t channels,
+                              const ResizeWithPadGeometry& geometry, std::vector<T>& padded) {
+    for (int32_t y = 0; y < resized_height; ++y) {
+        for (int32_t x = 0; x < resized_width; ++x) {
+            for (int32_t channel = 0; channel < channels; ++channel) {
+                const auto source_index = (static_cast<std::size_t>(y) * resized_width + x) *
+                                              static_cast<std::size_t>(channels) +
+                                          static_cast<std::size_t>(channel);
+                const auto destination_index =
+                    (static_cast<std::size_t>(y + geometry.pad_top) * geometry.target_width + x +
+                     geometry.pad_left) *
+                        static_cast<std::size_t>(channels) +
+                    static_cast<std::size_t>(channel);
+                padded[destination_index] = resized[source_index];
+            }
+        }
+    }
+}
+
+} // namespace
+
+std::vector<float> quantile_normalize(const std::vector<float>& values, std::size_t last_dimension,
+                                      const QuantileStats& stats) {
+    validate_quantile_stats(stats);
+    if (last_dimension == 0 || values.size() % last_dimension != 0) {
+        throw std::invalid_argument("OpenPI quantile input has an invalid last dimension");
+    }
+    if (stats.q01.size() < last_dimension) {
+        throw std::invalid_argument("OpenPI input statistics do not cover the last dimension");
+    }
+
+    std::vector<float> output(values.size());
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        const std::size_t dimension = i % last_dimension;
+        output[i] = (values[i] - stats.q01[dimension]) /
+                        (stats.q99[dimension] - stats.q01[dimension] + kTransformEpsilon) * 2.0F -
+                    1.0F;
+    }
+    return output;
+}
+
+std::vector<float> quantile_unnormalize(const std::vector<float>& values,
+                                        std::size_t last_dimension, const QuantileStats& stats) {
+    validate_quantile_stats(stats);
+    if (last_dimension == 0 || values.size() % last_dimension != 0) {
+        throw std::invalid_argument("OpenPI quantile output has an invalid last dimension");
+    }
+    if (stats.q01.size() > last_dimension) {
+        throw std::invalid_argument("OpenPI output statistics exceed the last dimension");
+    }
+
+    std::vector<float> output(values);
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        const std::size_t dimension = i % last_dimension;
+        if (dimension < stats.q01.size()) {
+            output[i] = (values[i] + 1.0F) / 2.0F *
+                            (stats.q99[dimension] - stats.q01[dimension] + kTransformEpsilon) +
+                        stats.q01[dimension];
+        }
+    }
+    return output;
+}
+
+int32_t discretize_state_value(float value) {
+    std::array<double, 256> boundaries{};
+    for (std::size_t i = 0; i < boundaries.size(); ++i) {
+        boundaries[i] = -1.0 + static_cast<double>(i) / 128.0;
+    }
+    const auto iterator =
+        std::upper_bound(boundaries.begin(), boundaries.end(), static_cast<double>(value));
+    return static_cast<int32_t>(std::distance(boundaries.begin(), iterator)) - 1;
+}
+
+std::vector<int32_t> discretize_state(const std::vector<float>& state) {
+    std::vector<int32_t> output;
+    output.reserve(state.size());
+    std::transform(state.begin(), state.end(), std::back_inserter(output),
+                   [](float value) { return discretize_state_value(value); });
+    return output;
+}
+
+std::string clean_prompt(std::string_view prompt) {
+    const auto codepoints = decode_prompt(prompt);
+    std::size_t first = 0;
+    while (first < codepoints.size() && is_python_whitespace(codepoints[first].value)) {
+        ++first;
+    }
+    std::size_t last = codepoints.size();
+    while (last > first && is_python_whitespace(codepoints[last - 1].value)) {
+        --last;
+    }
+    if (first == last) {
+        return {};
+    }
+
+    const std::size_t begin_offset = codepoints[first].offset;
+    const std::size_t end_offset = codepoints[last - 1].offset + codepoints[last - 1].length;
+    std::string output(prompt.substr(begin_offset, end_offset - begin_offset));
+    std::replace(output.begin(), output.end(), '_', ' ');
+    std::replace(output.begin(), output.end(), '\n', ' ');
+    return output;
+}
+
+std::string format_pi05_prompt(std::string_view prompt, const std::vector<float>& state) {
+    const auto bins = discretize_state(state);
+    std::string output = "Task: " + clean_prompt(prompt) + ", State: ";
+    for (std::size_t i = 0; i < bins.size(); ++i) {
+        if (i != 0) {
+            output.push_back(' ');
+        }
+        output.append(std::to_string(bins[i]));
+    }
+    output.append(";\nAction: ");
+    return output;
+}
+
+OrderedCameraSlots validate_and_order_camera_slots(const std::vector<CameraFrameView>& cameras) {
+    if (cameras.size() != kCameraNames.size()) {
+        throw std::invalid_argument("OpenPI requires exactly three named camera slots");
+    }
+
+    OrderedCameraSlots ordered{};
+    std::array<bool, 3> found{};
+    for (const auto& camera : cameras) {
+        const std::size_t index = camera_index(camera.name);
+        if (found[index]) {
+            throw std::invalid_argument("Duplicate OpenPI camera slot: " +
+                                        std::string(camera.name));
+        }
+        validate_camera(camera);
+        ordered[index] = camera;
+        found[index] = true;
+    }
+    if (std::find(found.begin(), found.end(), false) != found.end()) {
+        throw std::invalid_argument("OpenPI camera set is incomplete");
+    }
+    return ordered;
+}
+
+void validate_pi05_two_camera_masks(const OrderedCameraSlots& cameras) {
+    for (std::size_t i = 0; i < cameras.size(); ++i) {
+        if (cameras[i].name != kCameraNames[i]) {
+            throw std::invalid_argument("OpenPI camera slots are not in canonical order");
+        }
+    }
+    if (!cameras[0].valid || !cameras[1].valid || cameras[2].valid) {
+        throw std::invalid_argument(
+            "OpenPI pi0.5 two-camera profile requires masks [true, true, false]");
+    }
+}
+
+ResizeWithPadGeometry compute_resize_with_pad_geometry(int32_t source_height, int32_t source_width,
+                                                       int32_t target_height,
+                                                       int32_t target_width) {
+    if (source_height <= 0 || source_width <= 0 || target_height <= 0 || target_width <= 0) {
+        throw std::invalid_argument("OpenPI resize dimensions must be positive");
+    }
+    const double ratio =
+        std::max(static_cast<double>(source_width) / static_cast<double>(target_width),
+                 static_cast<double>(source_height) / static_cast<double>(target_height));
+    const int32_t resized_height = static_cast<int32_t>(static_cast<double>(source_height) / ratio);
+    const int32_t resized_width = static_cast<int32_t>(static_cast<double>(source_width) / ratio);
+    if (resized_height < 0 || resized_height > target_height || resized_width < 0 ||
+        resized_width > target_width) {
+        throw std::runtime_error("OpenPI resize geometry is inconsistent");
+    }
+
+    ResizeWithPadGeometry geometry;
+    geometry.source_height = source_height;
+    geometry.source_width = source_width;
+    geometry.target_height = target_height;
+    geometry.target_width = target_width;
+    geometry.resized_height = resized_height;
+    geometry.resized_width = resized_width;
+    geometry.pad_top = (target_height - resized_height) / 2;
+    geometry.pad_bottom = target_height - resized_height - geometry.pad_top;
+    geometry.pad_left = (target_width - resized_width) / 2;
+    geometry.pad_right = target_width - resized_width - geometry.pad_left;
+    return geometry;
+}
+
+std::vector<uint8_t> resize_with_pad_uint8(const uint8_t* pixels, int32_t source_height,
+                                           int32_t source_width, int32_t channels,
+                                           int32_t target_height, int32_t target_width) {
+    const auto source_count = checked_element_count(source_height, source_width, channels);
+    if (pixels == nullptr) {
+        throw std::invalid_argument("OpenPI uint8 resize source must not be null");
+    }
+    const auto geometry =
+        compute_resize_with_pad_geometry(source_height, source_width, target_height, target_width);
+    const auto target_count = checked_element_count(target_height, target_width, channels);
+    std::vector<uint8_t> padded(target_count, 0U);
+    if (geometry.resized_height == 0 || geometry.resized_width == 0) {
+        return padded;
+    }
+
+    std::vector<float> input(source_count);
+    std::transform(pixels, pixels + source_count, input.begin(),
+                   [](uint8_t value) { return static_cast<float>(value); });
+    const auto resized_float =
+        resize_jax_linear(input.data(), source_height, source_width, channels,
+                          geometry.resized_height, geometry.resized_width);
+    std::vector<uint8_t> resized(resized_float.size());
+    std::transform(resized_float.begin(), resized_float.end(), resized.begin(), [](float value) {
+        const float clipped = std::max(0.0F, std::min(255.0F, value));
+        return static_cast<uint8_t>(round_to_nearest_even(clipped));
+    });
+    copy_resized_into_padded(resized, geometry.resized_height, geometry.resized_width, channels,
+                             geometry, padded);
+    return padded;
+}
+
+std::vector<float> resize_with_pad_float(const float* pixels, int32_t source_height,
+                                         int32_t source_width, int32_t channels,
+                                         int32_t target_height, int32_t target_width) {
+    const auto source_count = checked_element_count(source_height, source_width, channels);
+    if (pixels == nullptr) {
+        throw std::invalid_argument("OpenPI float resize source must not be null");
+    }
+    for (std::size_t i = 0; i < source_count; ++i) {
+        if (!std::isfinite(pixels[i]) || pixels[i] < -1.0F || pixels[i] > 1.0F) {
+            throw std::invalid_argument("OpenPI float resize pixels must be finite and in [-1, 1]");
+        }
+    }
+    const auto geometry =
+        compute_resize_with_pad_geometry(source_height, source_width, target_height, target_width);
+    const auto target_count = checked_element_count(target_height, target_width, channels);
+    std::vector<float> padded(target_count, -1.0F);
+    if (geometry.resized_height == 0 || geometry.resized_width == 0) {
+        return padded;
+    }
+
+    auto resized = resize_jax_linear(pixels, source_height, source_width, channels,
+                                     geometry.resized_height, geometry.resized_width);
+    std::transform(resized.begin(), resized.end(), resized.begin(),
+                   [](float value) { return std::max(-1.0F, std::min(1.0F, value)); });
+    copy_resized_into_padded(resized, geometry.resized_height, geometry.resized_width, channels,
+                             geometry, padded);
+    return padded;
+}
+
+std::vector<float> uint8_to_openpi_float(const std::vector<uint8_t>& pixels) {
+    std::vector<float> result(pixels.size());
+    std::transform(pixels.begin(), pixels.end(), result.begin(), [](uint8_t value) {
+        return static_cast<float>(value) * kUint8ToOpenPiScale - 1.0F;
+    });
+    return result;
+}
+
+EulerSchedule make_euler_schedule(int32_t num_steps) {
+    if (num_steps <= 0) {
+        throw std::invalid_argument("OpenPI Euler step count must be positive");
+    }
+    EulerSchedule schedule;
+    schedule.dt = -1.0F / static_cast<float>(num_steps);
+    schedule.timesteps.reserve(static_cast<std::size_t>(num_steps));
+    float time = 1.0F;
+    while (time >= -schedule.dt / 2.0F) {
+        schedule.timesteps.push_back(time);
+        if (schedule.timesteps.size() > static_cast<std::size_t>(num_steps) + 1U) {
+            throw std::runtime_error("OpenPI Euler schedule failed to converge");
+        }
+        time += schedule.dt;
+    }
+    if (schedule.timesteps.size() != static_cast<std::size_t>(num_steps)) {
+        throw std::runtime_error("OpenPI Euler schedule produced an unexpected step count");
+    }
+    return schedule;
+}
+
+std::vector<float> make_fixed_noise(const std::vector<float>& noise, int32_t batch_size,
+                                    int32_t action_horizon, int32_t action_dimension) {
+    if (noise.size() != checked_flow_count(batch_size, action_horizon, action_dimension)) {
+        throw std::invalid_argument("OpenPI fixed noise size does not match [B, H, D]");
+    }
+    if (std::any_of(noise.begin(), noise.end(),
+                    [](float value) { return !std::isfinite(value); })) {
+        throw std::invalid_argument("OpenPI fixed noise must contain finite values");
+    }
+    return noise;
+}
+
+void euler_step_in_place(std::vector<float>& sample, const std::vector<float>& velocity, float dt) {
+    if (sample.size() != velocity.size()) {
+        throw std::invalid_argument("OpenPI Euler sample and velocity sizes do not match");
+    }
+    if (!std::isfinite(dt)) {
+        throw std::invalid_argument("OpenPI Euler dt must be finite");
+    }
+    for (std::size_t i = 0; i < sample.size(); ++i) {
+        sample[i] = sample[i] + dt * velocity[i];
+    }
+}
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/openpi_data_plane.h
+++ b/src/runtime/models/openpi/openpi_data_plane.h
@@ -1,0 +1,137 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace trtmc::openpi {
+
+inline constexpr std::size_t kModelActionDimension = 32;
+inline constexpr int32_t kImageHeight = 224;
+inline constexpr int32_t kImageWidth = 224;
+inline constexpr std::array<std::string_view, 3> kCameraNames = {
+    "base_0_rgb",
+    "left_wrist_0_rgb",
+    "right_wrist_0_rgb",
+};
+
+struct QuantileStats {
+    std::vector<float> q01;
+    std::vector<float> q99;
+};
+
+// Matches OpenPI transforms.Normalize(use_quantiles=True). Quantile statistics
+// are broadcast over every leading dimension and sliced to last_dimension.
+std::vector<float> quantile_normalize(const std::vector<float>& values, std::size_t last_dimension,
+                                      const QuantileStats& stats);
+
+// Matches OpenPI transforms.Unnormalize(use_quantiles=True). When the stored
+// statistics cover fewer dimensions than the model's 32-D action tensor, the
+// uncalibrated tail is preserved verbatim.
+std::vector<float> quantile_unnormalize(const std::vector<float>& values,
+                                        std::size_t last_dimension, const QuantileStats& stats);
+
+// Matches np.digitize(x, np.linspace(-1, 1, 257)[:-1]) - 1 exactly at bin
+// boundaries. Values outside the nominal range are intentionally not clipped:
+// OpenPI maps values below -1 to -1 and values at or above the last boundary to
+// 255. NaN follows NumPy and maps to 255.
+int32_t discretize_state_value(float value);
+std::vector<int32_t> discretize_state(const std::vector<float>& state);
+
+// Matches prompt.strip().replace("_", " ").replace("\n", " ") from the
+// upstream PaligemmaTokenizer. Invalid UTF-8 is rejected instead of being
+// accepted differently by different C++ standard libraries.
+std::string clean_prompt(std::string_view prompt);
+
+// Formats the released pi0.5 discrete-state language input:
+//   Task: <clean prompt>, State: <space-separated bin ids>;\nAction:
+std::string format_pi05_prompt(std::string_view prompt, const std::vector<float>& state);
+
+enum class CameraPixelType : uint8_t {
+    kUint8,
+    kFloat32,
+};
+
+// Non-owning HWC RGB view. Float pixels use OpenPI's normalized [-1, 1]
+// convention. Even masked camera slots carry a correctly shaped black image,
+// as they do in the upstream DROID adapter.
+struct CameraFrameView {
+    std::string_view name;
+    int32_t height{0};
+    int32_t width{0};
+    int32_t channels{0};
+    bool valid{false};
+    CameraPixelType pixel_type{CameraPixelType::kUint8};
+    const uint8_t* uint8_data{nullptr};
+    const float* float_data{nullptr};
+    std::size_t element_count{0};
+};
+
+using OrderedCameraSlots = std::array<CameraFrameView, 3>;
+
+// Validates names, geometry, pointers, ranges, duplicates, and masked-camera
+// black pixels, then returns the canonical OpenPI camera order.
+OrderedCameraSlots validate_and_order_camera_slots(const std::vector<CameraFrameView>& cameras);
+
+// The released pi0.5 DROID checkpoint uses two real views followed by one
+// black, masked right-wrist slot.
+void validate_pi05_two_camera_masks(const OrderedCameraSlots& cameras);
+
+struct ResizeWithPadGeometry {
+    int32_t source_height{0};
+    int32_t source_width{0};
+    int32_t target_height{0};
+    int32_t target_width{0};
+    int32_t resized_height{0};
+    int32_t resized_width{0};
+    int32_t pad_top{0};
+    int32_t pad_bottom{0};
+    int32_t pad_left{0};
+    int32_t pad_right{0};
+};
+
+ResizeWithPadGeometry compute_resize_with_pad_geometry(int32_t source_height, int32_t source_width,
+                                                       int32_t target_height, int32_t target_width);
+
+// Dependency-free implementation of OpenPI's JAX resize_with_pad path:
+// half-pixel centers, LINEAR triangle kernel, antialiasing while downsampling,
+// round-to-nearest-even for uint8, and centered black padding.
+std::vector<uint8_t> resize_with_pad_uint8(const uint8_t* pixels, int32_t source_height,
+                                           int32_t source_width, int32_t channels,
+                                           int32_t target_height, int32_t target_width);
+
+// Float input and output use OpenPI's [-1, 1] convention. Padding is -1 and
+// resized values are clipped to [-1, 1], matching the upstream JAX helper.
+std::vector<float> resize_with_pad_float(const float* pixels, int32_t source_height,
+                                         int32_t source_width, int32_t channels,
+                                         int32_t target_height, int32_t target_width);
+
+// Matches the exact float32 values produced by the pinned JAX/XLA lowering,
+// including its reciprocal approximation rather than ideal real arithmetic.
+std::vector<float> uint8_to_openpi_float(const std::vector<uint8_t>& pixels);
+
+struct EulerSchedule {
+    float dt{0.0F};
+    std::vector<float> timesteps;
+};
+
+// Uses iterative float32 time updates and OpenPI's robust `time >= -dt / 2`
+// stop condition rather than reconstructing timesteps in higher precision.
+EulerSchedule make_euler_schedule(int32_t num_steps);
+
+// Validates and copies caller-provided noise for reproducible parity runs.
+std::vector<float> make_fixed_noise(const std::vector<float>& noise, int32_t batch_size,
+                                    int32_t action_horizon, int32_t action_dimension);
+
+// Performs x_t <- x_t + dt * v_t in float32 and rejects mismatched buffers.
+void euler_step_in_place(std::vector<float>& sample, const std::vector<float>& velocity, float dt);
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/paligemma_bpe.cpp
+++ b/src/runtime/models/openpi/paligemma_bpe.cpp
@@ -1,0 +1,777 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/openpi/paligemma_bpe.h"
+
+#include "runtime/models/openpi/openpi_data_plane.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <queue>
+#include <stdexcept>
+#include <unordered_set>
+#include <utility>
+
+namespace trtmc::openpi {
+namespace {
+
+constexpr std::string_view kAssetMagic{"TRTMCBPE"};
+constexpr uint32_t kFlagDummyPrefix = 1U << 0U;
+constexpr uint32_t kFlagRemoveExtraWhitespaces = 1U << 1U;
+constexpr uint32_t kFlagEscapeWhitespaces = 1U << 2U;
+constexpr uint32_t kFlagByteFallback = 1U << 3U;
+constexpr uint32_t kFlagWhitespaceAsSuffix = 1U << 4U;
+constexpr uint32_t kKnownFlags = kFlagDummyPrefix | kFlagRemoveExtraWhitespaces |
+                                 kFlagEscapeWhitespaces | kFlagByteFallback |
+                                 kFlagWhitespaceAsSuffix;
+constexpr std::size_t kMaximumRecords = 1'000'000;
+constexpr std::string_view kSpaceSymbol{"\xE2\x96\x81"};
+constexpr std::string_view kReplacementCharacter{"\xEF\xBF\xBD"};
+
+class AssetReader {
+  public:
+    explicit AssetReader(std::string_view bytes) : bytes_(bytes) {}
+
+    uint8_t read_u8() {
+        require(1);
+        return static_cast<uint8_t>(bytes_[offset_++]);
+    }
+
+    uint32_t read_u32() {
+        require(4);
+        uint32_t value = 0;
+        for (uint32_t i = 0; i < 4; ++i) {
+            value |= static_cast<uint32_t>(static_cast<uint8_t>(bytes_[offset_ + i])) << (8U * i);
+        }
+        offset_ += 4;
+        return value;
+    }
+
+    int32_t read_i32() { return static_cast<int32_t>(read_u32()); }
+
+    float read_float() {
+        const uint32_t bits = read_u32();
+        float value = 0.0F;
+        static_assert(sizeof(value) == sizeof(bits));
+        std::memcpy(&value, &bits, sizeof(value));
+        return value;
+    }
+
+    std::string read_string() {
+        const auto size = static_cast<std::size_t>(read_u32());
+        require(size);
+        std::string value(bytes_.substr(offset_, size));
+        offset_ += size;
+        return value;
+    }
+
+    std::string read_raw(std::size_t size) {
+        require(size);
+        std::string value(bytes_.substr(offset_, size));
+        offset_ += size;
+        return value;
+    }
+
+    bool at_end() const noexcept { return offset_ == bytes_.size(); }
+
+  private:
+    void require(std::size_t size) const {
+        if (size > bytes_.size() - std::min(offset_, bytes_.size())) {
+            throw std::invalid_argument("Truncated OpenPI PaliGemma BPE asset");
+        }
+    }
+
+    std::string_view bytes_;
+    std::size_t offset_{0};
+};
+
+void append_u8(std::vector<uint8_t>& output, uint8_t value) {
+    output.push_back(value);
+}
+
+void append_u32(std::vector<uint8_t>& output, uint32_t value) {
+    for (uint32_t i = 0; i < 4; ++i) {
+        output.push_back(static_cast<uint8_t>((value >> (8U * i)) & 0xFFU));
+    }
+}
+
+void append_i32(std::vector<uint8_t>& output, int32_t value) {
+    append_u32(output, static_cast<uint32_t>(value));
+}
+
+void append_float(std::vector<uint8_t>& output, float value) {
+    uint32_t bits = 0;
+    static_assert(sizeof(value) == sizeof(bits));
+    std::memcpy(&bits, &value, sizeof(value));
+    append_u32(output, bits);
+}
+
+void append_string(std::vector<uint8_t>& output, std::string_view value) {
+    if (value.size() > std::numeric_limits<uint32_t>::max()) {
+        throw std::overflow_error("OpenPI BPE asset string is too large");
+    }
+    append_u32(output, static_cast<uint32_t>(value.size()));
+    output.insert(output.end(), value.begin(), value.end());
+}
+
+bool is_valid_piece_type(SentencePieceType type) {
+    switch (type) {
+    case SentencePieceType::kNormal:
+    case SentencePieceType::kUnknown:
+    case SentencePieceType::kControl:
+    case SentencePieceType::kUserDefined:
+    case SentencePieceType::kUnused:
+    case SentencePieceType::kByte:
+        return true;
+    }
+    return false;
+}
+
+int hex_nibble(char value) {
+    if (value >= '0' && value <= '9') {
+        return value - '0';
+    }
+    if (value >= 'A' && value <= 'F') {
+        return value - 'A' + 10;
+    }
+    return -1;
+}
+
+bool has_byte_piece_shape(std::string_view piece) {
+    return piece.size() == 6 && piece[0] == '<' && piece[1] == '0' && piece[2] == 'x' &&
+           piece[5] == '>';
+}
+
+int byte_from_piece(std::string_view piece) {
+    if (!has_byte_piece_shape(piece)) {
+        return -1;
+    }
+    const int high = hex_nibble(piece[3]);
+    const int low = hex_nibble(piece[4]);
+    return high < 0 || low < 0 ? -1 : high * 16 + low;
+}
+
+void validate_special_id(const PaligemmaBpeAsset& asset, int32_t id, SentencePieceType type,
+                         std::string_view name, bool required) {
+    if (id < 0) {
+        if (required) {
+            throw std::invalid_argument("OpenPI BPE asset is missing " + std::string(name));
+        }
+        return;
+    }
+    if (static_cast<std::size_t>(id) >= asset.pieces.size() || asset.pieces[id].type != type) {
+        throw std::invalid_argument("OpenPI BPE asset has an invalid " + std::string(name));
+    }
+}
+
+void validate_piece(const BpePiece& piece, std::unordered_set<std::string>& piece_names,
+                    std::array<bool, 256>& byte_found, int32_t& unknown_count) {
+    if (piece.text.empty() || !std::isfinite(piece.score) || !is_valid_piece_type(piece.type)) {
+        throw std::invalid_argument("OpenPI BPE asset contains an invalid piece");
+    }
+    if (!piece_names.insert(piece.text).second) {
+        throw std::invalid_argument("OpenPI BPE asset contains a duplicate piece");
+    }
+    if (piece.type == SentencePieceType::kUnknown) {
+        ++unknown_count;
+    }
+    if (piece.type != SentencePieceType::kByte) {
+        return;
+    }
+    const int value = byte_from_piece(piece.text);
+    if (value < 0 || byte_found[static_cast<std::size_t>(value)]) {
+        throw std::invalid_argument("OpenPI BPE asset contains an invalid byte piece");
+    }
+    byte_found[static_cast<std::size_t>(value)] = true;
+}
+
+void validate_normalization_rules(const std::vector<NormalizationRule>& rules) {
+    std::unordered_set<std::string> rule_sources;
+    for (const auto& rule : rules) {
+        if (rule.source.empty() || !rule_sources.insert(rule.source).second) {
+            throw std::invalid_argument("OpenPI BPE asset contains an invalid normalization rule");
+        }
+    }
+}
+
+void validate_asset(const PaligemmaBpeAsset& asset) {
+    if (asset.version != PaligemmaBpeAsset::kCurrentVersion) {
+        throw std::invalid_argument("Unsupported OpenPI PaliGemma BPE asset version");
+    }
+    if (asset.pieces.empty() || asset.pieces.size() > kMaximumRecords ||
+        asset.normalization_rules.size() > kMaximumRecords) {
+        throw std::invalid_argument("OpenPI BPE asset record count is invalid");
+    }
+
+    std::unordered_set<std::string> piece_names;
+    std::array<bool, 256> byte_found{};
+    int32_t unknown_count = 0;
+    for (const auto& piece : asset.pieces) {
+        validate_piece(piece, piece_names, byte_found, unknown_count);
+    }
+    if (unknown_count != 1) {
+        throw std::invalid_argument("OpenPI BPE asset must contain exactly one unknown piece");
+    }
+    validate_special_id(asset, asset.unknown_id, SentencePieceType::kUnknown, "unknown id", true);
+    validate_special_id(asset, asset.bos_id, SentencePieceType::kControl, "BOS id", true);
+    validate_special_id(asset, asset.eos_id, SentencePieceType::kControl, "EOS id", false);
+    validate_special_id(asset, asset.pad_id, SentencePieceType::kControl, "padding id", false);
+    if (asset.byte_fallback &&
+        std::find(byte_found.begin(), byte_found.end(), false) != byte_found.end()) {
+        throw std::invalid_argument(
+            "OpenPI BPE byte fallback requires exactly one piece for every byte");
+    }
+    validate_normalization_rules(asset.normalization_rules);
+}
+
+struct Utf8Prefix {
+    std::size_t length{0};
+    char32_t value{0};
+    char32_t minimum{0};
+};
+
+Utf8Prefix decode_utf8_prefix(uint8_t first) {
+    if ((first & 0xE0U) == 0xC0U) {
+        return {2, static_cast<char32_t>(first & 0x1FU), 0x80};
+    }
+    if ((first & 0xF0U) == 0xE0U) {
+        return {3, static_cast<char32_t>(first & 0x0FU), 0x800};
+    }
+    if ((first & 0xF8U) == 0xF0U) {
+        return {4, static_cast<char32_t>(first & 0x07U), 0x10000};
+    }
+    return {};
+}
+
+bool valid_unicode_scalar(char32_t value, char32_t minimum) {
+    return value >= minimum && value <= 0x10FFFFU && !(value >= 0xD800U && value <= 0xDFFFU);
+}
+
+std::size_t valid_utf8_character_length(std::string_view text) {
+    if (text.empty()) {
+        return 0;
+    }
+    const auto first = static_cast<uint8_t>(text[0]);
+    if (first <= 0x7FU) {
+        return 1;
+    }
+    Utf8Prefix prefix = decode_utf8_prefix(first);
+    if (prefix.length == 0 || prefix.length > text.size()) {
+        return 0;
+    }
+    for (std::size_t i = 1; i < prefix.length; ++i) {
+        const auto byte = static_cast<uint8_t>(text[i]);
+        if ((byte & 0xC0U) != 0x80U) {
+            return 0;
+        }
+        prefix.value = static_cast<char32_t>((prefix.value << 6U) | (byte & 0x3FU));
+    }
+    return valid_unicode_scalar(prefix.value, prefix.minimum) ? prefix.length : 0;
+}
+
+bool starts_with(std::string_view text, std::string_view prefix) {
+    return text.size() >= prefix.size() && text.substr(0, prefix.size()) == prefix;
+}
+
+bool ends_with(std::string_view text, std::string_view suffix) {
+    return text.size() >= suffix.size() && text.substr(text.size() - suffix.size()) == suffix;
+}
+
+template <typename PrefixLookup>
+std::size_t skip_leading_normalized_spaces(std::string_view text, bool remove_extra_whitespaces,
+                                           PrefixLookup&& lookup) {
+    if (!remove_extra_whitespaces) {
+        return 0;
+    }
+    std::size_t consumed = 0;
+    while (consumed < text.size()) {
+        const auto prefix = lookup(text.substr(consumed));
+        if (prefix.first != " ") {
+            break;
+        }
+        consumed += prefix.second;
+    }
+    return consumed;
+}
+
+void append_normalized_whitespace(std::string& normalized, bool escape_whitespaces) {
+    normalized.append(escape_whitespaces ? kSpaceSymbol : std::string_view(" "));
+}
+
+void append_normalized_piece(std::string& normalized, std::string piece, bool escape_whitespaces,
+                             bool remove_extra_whitespaces, bool& previous_was_space) {
+    if (previous_was_space) {
+        while (!piece.empty() && piece.front() == ' ') {
+            piece.erase(piece.begin());
+        }
+    }
+    if (piece.empty()) {
+        return;
+    }
+    for (char value : piece) {
+        if (escape_whitespaces && value == ' ') {
+            normalized.append(kSpaceSymbol);
+        } else {
+            normalized.push_back(value);
+        }
+    }
+    previous_was_space = remove_extra_whitespaces && piece.back() == ' ';
+}
+
+template <typename PrefixLookup>
+void append_normalized_text(std::string_view text, std::size_t consumed, PrefixLookup&& lookup,
+                            const PaligemmaBpeAsset& asset, std::string& normalized) {
+    bool previous_was_space = asset.remove_extra_whitespaces;
+    while (consumed < text.size()) {
+        auto prefix = lookup(text.substr(consumed));
+        append_normalized_piece(normalized, std::move(prefix.first), asset.escape_whitespaces,
+                                asset.remove_extra_whitespaces, previous_was_space);
+        consumed += prefix.second;
+    }
+}
+
+void trim_trailing_normalized_spaces(std::string& normalized, bool remove_extra_whitespaces,
+                                     bool escape_whitespaces) {
+    if (!remove_extra_whitespaces) {
+        return;
+    }
+    const std::string_view space = escape_whitespaces ? kSpaceSymbol : std::string_view(" ");
+    while (ends_with(normalized, space)) {
+        normalized.resize(normalized.size() - space.size());
+    }
+}
+
+struct EncodingSymbol {
+    int32_t previous{-1};
+    int32_t next{-1};
+    std::size_t begin{0};
+    std::size_t size{0};
+    bool frozen{false};
+    bool alive{true};
+};
+
+struct EncodingPiece {
+    bool found{false};
+    int32_t id{-1};
+    float score{0.0F};
+    SentencePieceType type{SentencePieceType::kNormal};
+};
+
+struct MergeCandidate {
+    int32_t left{-1};
+    int32_t right{-1};
+    float score{0.0F};
+    std::size_t size{0};
+};
+
+struct MergeCandidatePriority {
+    bool operator()(const MergeCandidate& lhs, const MergeCandidate& rhs) const {
+        return lhs.score < rhs.score || (lhs.score == rhs.score && lhs.left > rhs.left);
+    }
+};
+
+using MergeQueue =
+    std::priority_queue<MergeCandidate, std::vector<MergeCandidate>, MergeCandidatePriority>;
+using ReverseUnusedMerges = std::unordered_map<std::string, std::pair<std::string, std::string>>;
+
+std::string_view encoding_symbol_text(std::string_view text,
+                                      const std::vector<EncodingSymbol>& symbols, int32_t index) {
+    const auto& symbol = symbols[static_cast<std::size_t>(index)];
+    return std::string_view(text.data() + symbol.begin, symbol.size);
+}
+
+template <typename UserDefinedPrefixLength>
+std::pair<std::size_t, bool>
+initial_symbol_length(std::string_view remaining,
+                      UserDefinedPrefixLength&& user_defined_prefix_length) {
+    const std::size_t user_defined_length = user_defined_prefix_length(remaining);
+    if (user_defined_length != 0) {
+        return {user_defined_length, true};
+    }
+    const std::size_t character_length = valid_utf8_character_length(remaining);
+    return {character_length == 0 ? 1 : character_length, false};
+}
+
+template <typename UserDefinedPrefixLength>
+std::vector<EncodingSymbol>
+make_initial_symbols(std::string_view text, UserDefinedPrefixLength&& user_defined_prefix_length) {
+    std::vector<EncodingSymbol> symbols;
+    for (std::size_t offset = 0; offset < text.size();) {
+        const std::string_view remaining(text.data() + offset, text.size() - offset);
+        const auto [length, frozen] = initial_symbol_length(remaining, user_defined_prefix_length);
+        const int32_t index = static_cast<int32_t>(symbols.size());
+        symbols.push_back({index == 0 ? -1 : index - 1, -1, offset, length, frozen, true});
+        if (index > 0) {
+            symbols[static_cast<std::size_t>(index - 1)].next = index;
+        }
+        offset += length;
+    }
+    return symbols;
+}
+
+bool merge_pair_is_current(const std::vector<EncodingSymbol>& symbols, int32_t left,
+                           int32_t right) {
+    if (left < 0 || right < 0) {
+        return false;
+    }
+    const auto& left_symbol = symbols[static_cast<std::size_t>(left)];
+    const auto& right_symbol = symbols[static_cast<std::size_t>(right)];
+    return left_symbol.alive && right_symbol.alive && !left_symbol.frozen && !right_symbol.frozen &&
+           left_symbol.next == right && left_symbol.begin + left_symbol.size == right_symbol.begin;
+}
+
+template <typename PieceLookup>
+void add_merge_candidate(std::string_view text, const std::vector<EncodingSymbol>& symbols,
+                         int32_t left, int32_t right, PieceLookup&& lookup_piece,
+                         MergeQueue& candidates, ReverseUnusedMerges& reverse_unused_merges) {
+    if (!merge_pair_is_current(symbols, left, right)) {
+        return;
+    }
+    const auto& left_symbol = symbols[static_cast<std::size_t>(left)];
+    const auto& right_symbol = symbols[static_cast<std::size_t>(right)];
+    const std::string merged(text.data() + left_symbol.begin, left_symbol.size + right_symbol.size);
+    const EncodingPiece piece = lookup_piece(merged);
+    if (!piece.found) {
+        return;
+    }
+    candidates.push({left, right, piece.score, merged.size()});
+    if (piece.type != SentencePieceType::kUnused) {
+        return;
+    }
+    reverse_unused_merges[merged] = {std::string(encoding_symbol_text(text, symbols, left)),
+                                     std::string(encoding_symbol_text(text, symbols, right))};
+}
+
+bool merge_candidate_is_current(const std::vector<EncodingSymbol>& symbols,
+                                const MergeCandidate& candidate) {
+    const auto& left = symbols[static_cast<std::size_t>(candidate.left)];
+    const auto& right = symbols[static_cast<std::size_t>(candidate.right)];
+    return left.alive && right.alive && left.next == candidate.right &&
+           left.size + right.size == candidate.size;
+}
+
+void apply_merge_candidate(std::vector<EncodingSymbol>& symbols, const MergeCandidate& candidate) {
+    auto& left = symbols[static_cast<std::size_t>(candidate.left)];
+    auto& right = symbols[static_cast<std::size_t>(candidate.right)];
+    left.size += right.size;
+    left.next = right.next;
+    if (right.next >= 0) {
+        symbols[static_cast<std::size_t>(right.next)].previous = candidate.left;
+    }
+    right.alive = false;
+    right.size = 0;
+}
+
+template <typename PieceLookup>
+ReverseUnusedMerges merge_encoding_symbols(std::string_view text,
+                                           std::vector<EncodingSymbol>& symbols,
+                                           PieceLookup&& lookup_piece) {
+    MergeQueue candidates;
+    ReverseUnusedMerges reverse_unused_merges;
+    for (std::size_t i = 1; i < symbols.size(); ++i) {
+        add_merge_candidate(text, symbols, static_cast<int32_t>(i - 1), static_cast<int32_t>(i),
+                            lookup_piece, candidates, reverse_unused_merges);
+    }
+    while (!candidates.empty()) {
+        const MergeCandidate candidate = candidates.top();
+        candidates.pop();
+        if (!merge_candidate_is_current(symbols, candidate)) {
+            continue;
+        }
+        apply_merge_candidate(symbols, candidate);
+        const auto& merged = symbols[static_cast<std::size_t>(candidate.left)];
+        add_merge_candidate(text, symbols, merged.previous, candidate.left, lookup_piece,
+                            candidates, reverse_unused_merges);
+        add_merge_candidate(text, symbols, candidate.left, merged.next, lookup_piece, candidates,
+                            reverse_unused_merges);
+    }
+    return reverse_unused_merges;
+}
+
+void emit_byte_fallback(std::string_view piece, const std::array<int32_t, 256>& byte_ids,
+                        std::vector<int32_t>& ids) {
+    for (const unsigned char byte : piece) {
+        const int32_t byte_id = byte_ids[byte];
+        if (byte_id < 0) {
+            throw std::runtime_error("OpenPI BPE byte fallback table is incomplete");
+        }
+        ids.push_back(byte_id);
+    }
+}
+
+template <typename PieceLookup>
+void emit_piece(std::string_view piece, const PaligemmaBpeAsset& asset,
+                const std::array<int32_t, 256>& byte_ids,
+                const ReverseUnusedMerges& reverse_unused_merges, PieceLookup&& lookup_piece,
+                std::vector<int32_t>& ids) {
+    const EncodingPiece found = lookup_piece(piece);
+    const int32_t id = found.found ? found.id : asset.unknown_id;
+    const auto type = asset.pieces[static_cast<std::size_t>(id)].type;
+    if (type == SentencePieceType::kUnused) {
+        const auto reverse = reverse_unused_merges.find(std::string(piece));
+        if (reverse != reverse_unused_merges.end()) {
+            emit_piece(reverse->second.first, asset, byte_ids, reverse_unused_merges, lookup_piece,
+                       ids);
+            emit_piece(reverse->second.second, asset, byte_ids, reverse_unused_merges, lookup_piece,
+                       ids);
+            return;
+        }
+    }
+    if (type == SentencePieceType::kUnknown && asset.byte_fallback) {
+        emit_byte_fallback(piece, byte_ids, ids);
+        return;
+    }
+    ids.push_back(id);
+}
+
+template <typename PieceLookup>
+std::vector<int32_t>
+emit_encoding(std::string_view text, const std::vector<EncodingSymbol>& symbols,
+              const PaligemmaBpeAsset& asset, const std::array<int32_t, 256>& byte_ids,
+              const ReverseUnusedMerges& reverse_unused_merges, PieceLookup&& lookup_piece,
+              bool add_bos) {
+    std::vector<int32_t> ids;
+    if (add_bos) {
+        ids.push_back(asset.bos_id);
+    }
+    for (int32_t index = symbols.empty() ? -1 : 0; index >= 0;
+         index = symbols[static_cast<std::size_t>(index)].next) {
+        emit_piece(encoding_symbol_text(text, symbols, index), asset, byte_ids,
+                   reverse_unused_merges, lookup_piece, ids);
+    }
+    return ids;
+}
+
+} // namespace
+
+PaligemmaBpeAsset parse_paligemma_bpe_asset(std::string_view bytes) {
+    AssetReader reader(bytes);
+    if (reader.read_raw(kAssetMagic.size()) != kAssetMagic) {
+        throw std::invalid_argument("OpenPI PaliGemma BPE asset has invalid magic");
+    }
+
+    PaligemmaBpeAsset asset;
+    asset.version = reader.read_u32();
+    const uint32_t flags = reader.read_u32();
+    if ((flags & ~kKnownFlags) != 0U) {
+        throw std::invalid_argument("OpenPI PaliGemma BPE asset has unknown flags");
+    }
+    asset.add_dummy_prefix = (flags & kFlagDummyPrefix) != 0U;
+    asset.remove_extra_whitespaces = (flags & kFlagRemoveExtraWhitespaces) != 0U;
+    asset.escape_whitespaces = (flags & kFlagEscapeWhitespaces) != 0U;
+    asset.byte_fallback = (flags & kFlagByteFallback) != 0U;
+    asset.treat_whitespace_as_suffix = (flags & kFlagWhitespaceAsSuffix) != 0U;
+    asset.unknown_id = reader.read_i32();
+    asset.bos_id = reader.read_i32();
+    asset.eos_id = reader.read_i32();
+    asset.pad_id = reader.read_i32();
+    const auto piece_count = static_cast<std::size_t>(reader.read_u32());
+    const auto rule_count = static_cast<std::size_t>(reader.read_u32());
+    if (piece_count > kMaximumRecords || rule_count > kMaximumRecords) {
+        throw std::invalid_argument("OpenPI BPE asset record count exceeds its limit");
+    }
+
+    asset.pieces.reserve(piece_count);
+    for (std::size_t i = 0; i < piece_count; ++i) {
+        BpePiece piece;
+        piece.type = static_cast<SentencePieceType>(reader.read_u8());
+        piece.score = reader.read_float();
+        piece.text = reader.read_string();
+        asset.pieces.push_back(std::move(piece));
+    }
+    asset.normalization_rules.reserve(rule_count);
+    for (std::size_t i = 0; i < rule_count; ++i) {
+        NormalizationRule rule;
+        rule.source = reader.read_string();
+        rule.replacement = reader.read_string();
+        asset.normalization_rules.push_back(std::move(rule));
+    }
+    if (!reader.at_end()) {
+        throw std::invalid_argument("OpenPI PaliGemma BPE asset contains trailing bytes");
+    }
+    validate_asset(asset);
+    return asset;
+}
+
+std::vector<uint8_t> serialize_paligemma_bpe_asset(const PaligemmaBpeAsset& asset) {
+    validate_asset(asset);
+    if (asset.pieces.size() > std::numeric_limits<uint32_t>::max() ||
+        asset.normalization_rules.size() > std::numeric_limits<uint32_t>::max()) {
+        throw std::overflow_error("OpenPI BPE asset has too many records");
+    }
+    std::vector<uint8_t> output;
+    output.insert(output.end(), kAssetMagic.begin(), kAssetMagic.end());
+    append_u32(output, asset.version);
+    uint32_t flags = 0;
+    flags |= asset.add_dummy_prefix ? kFlagDummyPrefix : 0U;
+    flags |= asset.remove_extra_whitespaces ? kFlagRemoveExtraWhitespaces : 0U;
+    flags |= asset.escape_whitespaces ? kFlagEscapeWhitespaces : 0U;
+    flags |= asset.byte_fallback ? kFlagByteFallback : 0U;
+    flags |= asset.treat_whitespace_as_suffix ? kFlagWhitespaceAsSuffix : 0U;
+    append_u32(output, flags);
+    append_i32(output, asset.unknown_id);
+    append_i32(output, asset.bos_id);
+    append_i32(output, asset.eos_id);
+    append_i32(output, asset.pad_id);
+    append_u32(output, static_cast<uint32_t>(asset.pieces.size()));
+    append_u32(output, static_cast<uint32_t>(asset.normalization_rules.size()));
+    for (const auto& piece : asset.pieces) {
+        append_u8(output, static_cast<uint8_t>(piece.type));
+        append_float(output, piece.score);
+        append_string(output, piece.text);
+    }
+    for (const auto& rule : asset.normalization_rules) {
+        append_string(output, rule.source);
+        append_string(output, rule.replacement);
+    }
+    return output;
+}
+
+PaligemmaBpeTokenizer::PaligemmaBpeTokenizer(PaligemmaBpeAsset asset) : asset_(std::move(asset)) {
+    validate_asset(asset_);
+    byte_ids_.fill(-1);
+    for (std::size_t i = 0; i < asset_.pieces.size(); ++i) {
+        const auto& piece = asset_.pieces[i];
+        if (piece.type == SentencePieceType::kNormal ||
+            piece.type == SentencePieceType::kUserDefined ||
+            piece.type == SentencePieceType::kUnused) {
+            merge_pieces_.emplace(piece.text,
+                                  PieceIndex{static_cast<int32_t>(i), piece.score, piece.type});
+        }
+        if (piece.type == SentencePieceType::kUserDefined) {
+            const auto first = static_cast<unsigned char>(piece.text.front());
+            user_defined_pieces_by_first_byte_[first].push_back(piece.text);
+        }
+        if (piece.type == SentencePieceType::kByte) {
+            byte_ids_[static_cast<std::size_t>(byte_from_piece(piece.text))] =
+                static_cast<int32_t>(i);
+        }
+    }
+    for (auto& pieces : user_defined_pieces_by_first_byte_) {
+        std::sort(pieces.begin(), pieces.end(), [](const std::string& lhs, const std::string& rhs) {
+            return lhs.size() > rhs.size();
+        });
+    }
+    normalization_rules_ = asset_.normalization_rules;
+    std::stable_sort(normalization_rules_.begin(), normalization_rules_.end(),
+                     [](const NormalizationRule& lhs, const NormalizationRule& rhs) {
+                         return lhs.source.size() > rhs.source.size();
+                     });
+}
+
+std::size_t PaligemmaBpeTokenizer::user_defined_prefix_length(std::string_view text) const {
+    if (text.empty()) {
+        return 0;
+    }
+    const auto first = static_cast<unsigned char>(text.front());
+    for (const auto& piece : user_defined_pieces_by_first_byte_[first]) {
+        if (starts_with(text, piece)) {
+            return piece.size();
+        }
+    }
+    return 0;
+}
+
+std::pair<std::string, std::size_t>
+PaligemmaBpeTokenizer::normalized_prefix(std::string_view text) const {
+    if (text.empty()) {
+        return {};
+    }
+    const std::size_t user_defined_length = user_defined_prefix_length(text);
+    if (user_defined_length != 0) {
+        return {std::string(text.substr(0, user_defined_length)), user_defined_length};
+    }
+    for (const auto& rule : normalization_rules_) {
+        if (starts_with(text, rule.source)) {
+            return {rule.replacement, rule.source.size()};
+        }
+    }
+    const std::size_t character_length = valid_utf8_character_length(text);
+    if (character_length == 0) {
+        return {std::string(kReplacementCharacter), 1};
+    }
+    return {std::string(text.substr(0, character_length)), character_length};
+}
+
+std::string PaligemmaBpeTokenizer::normalize(std::string_view text) const {
+    if (text.empty()) {
+        return {};
+    }
+
+    const auto lookup_prefix = [this](std::string_view remaining) {
+        return normalized_prefix(remaining);
+    };
+    const std::size_t consumed =
+        skip_leading_normalized_spaces(text, asset_.remove_extra_whitespaces, lookup_prefix);
+    if (consumed == text.size()) {
+        return {};
+    }
+
+    std::string normalized;
+    if (!asset_.treat_whitespace_as_suffix && asset_.add_dummy_prefix) {
+        append_normalized_whitespace(normalized, asset_.escape_whitespaces);
+    }
+
+    append_normalized_text(text, consumed, lookup_prefix, asset_, normalized);
+    trim_trailing_normalized_spaces(normalized, asset_.remove_extra_whitespaces,
+                                    asset_.escape_whitespaces);
+    if (asset_.treat_whitespace_as_suffix && asset_.add_dummy_prefix) {
+        append_normalized_whitespace(normalized, asset_.escape_whitespaces);
+    }
+    return normalized;
+}
+
+std::vector<int32_t> PaligemmaBpeTokenizer::encode(std::string_view text, bool add_bos) const {
+    const std::string normalized_text = normalize(text);
+    auto symbols = make_initial_symbols(normalized_text, [this](std::string_view remaining) {
+        return user_defined_prefix_length(remaining);
+    });
+    const auto lookup_piece = [this](std::string_view piece) {
+        const auto found = merge_pieces_.find(std::string(piece));
+        if (found == merge_pieces_.end()) {
+            return EncodingPiece{};
+        }
+        return EncodingPiece{true, found->second.id, found->second.score, found->second.type};
+    };
+    const ReverseUnusedMerges reverse_unused_merges =
+        merge_encoding_symbols(normalized_text, symbols, lookup_piece);
+    return emit_encoding(normalized_text, symbols, asset_, byte_ids_, reverse_unused_merges,
+                         lookup_piece, add_bos);
+}
+
+TokenizedPrompt PaligemmaBpeTokenizer::pad_or_truncate(std::vector<int32_t> ids,
+                                                       std::size_t max_length) const {
+    if (max_length == 0) {
+        throw std::invalid_argument("OpenPI prompt maximum length must be positive");
+    }
+    TokenizedPrompt result;
+    result.truncated = ids.size() > max_length;
+    if (ids.size() > max_length) {
+        ids.resize(max_length);
+    }
+    result.token_mask.assign(ids.size(), 1U);
+    ids.resize(max_length, 0);
+    result.token_mask.resize(max_length, 0U);
+    result.token_ids = std::move(ids);
+    return result;
+}
+
+TokenizedPrompt PaligemmaBpeTokenizer::tokenize_pi05(std::string_view prompt,
+                                                     const std::vector<float>& state,
+                                                     std::size_t max_length) const {
+    return pad_or_truncate(encode(format_pi05_prompt(prompt, state), true), max_length);
+}
+
+TokenizedPrompt PaligemmaBpeTokenizer::tokenize_pi0(std::string_view prompt,
+                                                    std::size_t max_length) const {
+    auto ids = encode(clean_prompt(prompt), true);
+    auto newline_ids = encode("\n", false);
+    ids.insert(ids.end(), newline_ids.begin(), newline_ids.end());
+    return pad_or_truncate(std::move(ids), max_length);
+}
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/paligemma_bpe.h
+++ b/src/runtime/models/openpi/paligemma_bpe.h
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace trtmc::openpi {
+
+// PaliGemma uses the SentencePiece BPE model, not SentencePiece's Unigram
+// model. The build-time converter flattens protobuf-only data into this runtime
+// representation so inference does not link protobuf or SentencePiece.
+enum class SentencePieceType : uint8_t {
+    kNormal = 1,
+    kUnknown = 2,
+    kControl = 3,
+    kUserDefined = 4,
+    kUnused = 5,
+    kByte = 6,
+};
+
+struct BpePiece {
+    std::string text;
+    float score{0.0F};
+    SentencePieceType type{SentencePieceType::kNormal};
+};
+
+struct NormalizationRule {
+    std::string source;
+    std::string replacement;
+};
+
+struct PaligemmaBpeAsset {
+    static constexpr uint32_t kCurrentVersion = 1;
+
+    uint32_t version{kCurrentVersion};
+    bool add_dummy_prefix{true};
+    bool remove_extra_whitespaces{true};
+    bool escape_whitespaces{true};
+    bool byte_fallback{true};
+    bool treat_whitespace_as_suffix{false};
+    int32_t unknown_id{-1};
+    int32_t bos_id{-1};
+    int32_t eos_id{-1};
+    int32_t pad_id{-1};
+    std::vector<BpePiece> pieces;
+    // Leftmost-longest rules expanded from NormalizerSpec.precompiled_charsmap.
+    std::vector<NormalizationRule> normalization_rules;
+};
+
+// Binary layout (little endian):
+//   8 bytes magic "TRTMCBPE", u32 version, u32 flags,
+//   i32 unk/bos/eos/pad, u32 piece_count, u32 normalization_rule_count,
+//   piece records: u8 type, f32 score, u32 byte_length, raw UTF-8 bytes,
+//   rule records: u32 source_length, u32 replacement_length, raw bytes.
+// Flags are, in order, dummy-prefix, remove-extra-space, escape-space,
+// byte-fallback, and whitespace-as-suffix. This deliberately is not a
+// SentencePiece protobuf parser.
+PaligemmaBpeAsset parse_paligemma_bpe_asset(std::string_view bytes);
+std::vector<uint8_t> serialize_paligemma_bpe_asset(const PaligemmaBpeAsset& asset);
+
+struct TokenizedPrompt {
+    std::vector<int32_t> token_ids;
+    std::vector<uint8_t> token_mask;
+    bool truncated{false};
+};
+
+class PaligemmaBpeTokenizer {
+  public:
+    explicit PaligemmaBpeTokenizer(PaligemmaBpeAsset asset);
+
+    std::string normalize(std::string_view text) const;
+    std::vector<int32_t> encode(std::string_view text, bool add_bos) const;
+
+    // Mirrors OpenPI PaligemmaTokenizer for pi0.5, including discrete state
+    // formatting and hard-coded zero padding (`False` appended to a Python int
+    // list becomes token id zero upstream).
+    TokenizedPrompt tokenize_pi05(std::string_view prompt, const std::vector<float>& state,
+                                  std::size_t max_length) const;
+
+    // Mirrors the pi0 prompt path, which encodes the cleaned prompt with BOS
+    // and then encodes "\n" in a separate SentencePiece call.
+    TokenizedPrompt tokenize_pi0(std::string_view prompt, std::size_t max_length) const;
+
+  private:
+    struct PieceIndex {
+        int32_t id{-1};
+        float score{0.0F};
+        SentencePieceType type{SentencePieceType::kNormal};
+    };
+
+    TokenizedPrompt pad_or_truncate(std::vector<int32_t> ids, std::size_t max_length) const;
+    std::size_t user_defined_prefix_length(std::string_view text) const;
+    std::pair<std::string, std::size_t> normalized_prefix(std::string_view text) const;
+
+    PaligemmaBpeAsset asset_;
+    std::unordered_map<std::string, PieceIndex> merge_pieces_;
+    // SentencePiece user-defined symbols are matched leftmost-longest. Bucket
+    // them by their first byte so ordinary prompt characters do not scan the
+    // full (1,397-entry in the released PaliGemma asset) symbol table.
+    std::array<std::vector<std::string>, 256> user_defined_pieces_by_first_byte_;
+    std::vector<NormalizationRule> normalization_rules_;
+    std::array<int32_t, 256> byte_ids_{};
+};
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/pipeline.cpp
+++ b/src/runtime/models/openpi/pipeline.cpp
@@ -1,0 +1,901 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/openpi/pipeline.h"
+
+#include "trtmc/runtime/device_tensor.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <cuda_runtime_api.h>
+#include <limits>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace trtmc::openpi {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+double elapsed_ms(Clock::time_point begin, Clock::time_point end) {
+    return std::chrono::duration<double, std::milli>(end - begin).count();
+}
+
+void require_cuda(cudaError_t status, const char* operation) {
+    if (status != cudaSuccess) {
+        throw std::runtime_error(std::string("OpenPI ") + operation +
+                                 " failed: " + cudaGetErrorString(status));
+    }
+}
+
+class CudaEvent final {
+  public:
+    CudaEvent() { require_cuda(cudaEventCreate(&event_), "CUDA event creation"); }
+    ~CudaEvent() {
+        if (event_ != nullptr) {
+            cudaEventDestroy(event_);
+        }
+    }
+
+    CudaEvent(const CudaEvent&) = delete;
+    CudaEvent& operator=(const CudaEvent&) = delete;
+
+    void record(cudaStream_t stream) const {
+        require_cuda(cudaEventRecord(event_, stream), "CUDA event recording");
+    }
+
+    static double elapsed(const CudaEvent& begin, const CudaEvent& end) {
+        float milliseconds = 0.0F;
+        require_cuda(cudaEventElapsedTime(&milliseconds, begin.event_, end.event_),
+                     "CUDA event timing");
+        return static_cast<double>(milliseconds);
+    }
+
+  private:
+    cudaEvent_t event_{nullptr};
+};
+
+class PrefixKvCache {
+  public:
+    PrefixKvCache(int32_t num_layers, int32_t prefix_length, int32_t num_kv_heads, int32_t head_dim,
+                  DType dtype, cudaStream_t stream) {
+        if (num_layers <= 0 || prefix_length <= 0 || num_kv_heads <= 0 || head_dim <= 0) {
+            throw std::invalid_argument("OpenPI prefix KV cache dimensions must be positive");
+        }
+
+        keys_.reserve(static_cast<std::size_t>(num_layers));
+        values_.reserve(static_cast<std::size_t>(num_layers));
+        const std::vector<int64_t> shape{1, prefix_length, num_kv_heads, head_dim};
+        for (int32_t layer = 0; layer < num_layers; ++layer) {
+            keys_.emplace_back(shape, dtype, stream);
+            values_.emplace_back(shape, dtype, stream);
+        }
+    }
+
+    void bind_to(ITrtModule& module) {
+        for (std::size_t layer = 0; layer < keys_.size(); ++layer) {
+            module.bind_external("prefix_k_" + std::to_string(layer), keys_[layer].data());
+            module.bind_external("prefix_v_" + std::to_string(layer), values_[layer].data());
+        }
+    }
+
+    bool ok() const {
+        const auto valid = [](const DeviceTensor& tensor) { return tensor.ok(); };
+        return std::all_of(keys_.begin(), keys_.end(), valid) &&
+               std::all_of(values_.begin(), values_.end(), valid);
+    }
+
+    const DeviceTensor& key(int32_t layer) const {
+        return keys_.at(static_cast<std::size_t>(layer));
+    }
+
+    const DeviceTensor& value(int32_t layer) const {
+        return values_.at(static_cast<std::size_t>(layer));
+    }
+
+  private:
+    std::vector<DeviceTensor> keys_;
+    std::vector<DeviceTensor> values_;
+};
+
+std::size_t checked_image_elements(const RobotImage& image) {
+    if (image.height <= 0 || image.width <= 0 || image.channels != 3) {
+        throw std::invalid_argument("OpenPI cameras must be non-empty HWC RGB images");
+    }
+    const auto height = static_cast<std::size_t>(image.height);
+    const auto width = static_cast<std::size_t>(image.width);
+    if (height > std::numeric_limits<std::size_t>::max() / width ||
+        height * width > std::numeric_limits<std::size_t>::max() / 3U) {
+        throw std::overflow_error("OpenPI camera element count overflow");
+    }
+    return height * width * 3U;
+}
+
+std::vector<uint8_t> robot_pixels_to_uint8(const RobotImage& image) {
+    const std::size_t expected = checked_image_elements(image);
+    if (image.pixels.size() != expected) {
+        throw std::invalid_argument("OpenPI camera pixel count does not match its geometry");
+    }
+    std::vector<uint8_t> result;
+    result.reserve(expected);
+    for (float value : image.pixels) {
+        if (!std::isfinite(value) || value < 0.0F || value > 1.0F) {
+            throw std::invalid_argument("OpenPI public camera pixels must be finite and in [0, 1]");
+        }
+        // The pinned DROID policy adapter uses
+        // `(255 * image).astype(np.uint8)` for floating inputs.
+        result.push_back(static_cast<uint8_t>(value * 255.0F));
+    }
+    return result;
+}
+
+std::vector<float> make_deterministic_noise(const OpenPIConfig& config, int32_t seed) {
+    const std::size_t count = static_cast<std::size_t>(config.action_horizon) *
+                              static_cast<std::size_t>(config.internal_action_dim);
+    std::mt19937 generator(static_cast<uint32_t>(seed >= 0 ? seed : 0));
+    std::normal_distribution<float> distribution(0.0F, 1.0F);
+    std::vector<float> noise(count);
+    std::generate(noise.begin(), noise.end(), [&] { return distribution(generator); });
+    return noise;
+}
+
+void require_shape(const ITrtModule& module, const std::string& name, bool input,
+                   const std::vector<int64_t>& expected) {
+    const bool present = input ? module.has_input(name) : module.has_output(name);
+    if (!present) {
+        throw std::runtime_error("OpenPI engine is missing " +
+                                 std::string(input ? "input '" : "output '") + name + "'");
+    }
+    const auto actual = module.tensor_shape(name);
+    if (actual != expected) {
+        throw std::runtime_error("OpenPI engine tensor '" + name + "' has an invalid shape");
+    }
+}
+
+void require_dtype(const ITrtModule& module, const std::string& name, DType expected) {
+    if (module.tensor_dtype(name) != expected) {
+        throw std::runtime_error("OpenPI engine tensor '" + name + "' has an invalid data type");
+    }
+}
+
+DType cache_dtype_for_precision(const OpenPIConfig& config) {
+    if (config.precision == "bf16" || config.precision == "bfloat16") {
+        return DType::kBFloat16;
+    }
+    if (config.precision == "fp16") {
+        return DType::kFloat16;
+    }
+    return DType::kFloat32;
+}
+
+void require_device_tensor(const DeviceTensor& tensor, const char* name) {
+    if (!tensor.ok()) {
+        throw std::runtime_error(std::string("OpenPI failed to allocate device tensor '") + name +
+                                 "'");
+    }
+}
+
+std::string cache_name(char kind, int32_t layer) {
+    return std::string("prefix_") + kind + "_" + std::to_string(layer);
+}
+
+std::size_t diagnostic_type_size(DiagnosticTensorType dtype) {
+    switch (dtype) {
+    case DiagnosticTensorType::kBool:
+        return 1U;
+    case DiagnosticTensorType::kInt32:
+    case DiagnosticTensorType::kFloat32:
+        return 4U;
+    case DiagnosticTensorType::kBFloat16:
+        return 2U;
+    }
+    throw std::invalid_argument("OpenPI diagnostic tensor has an unknown data type");
+}
+
+std::size_t diagnostic_byte_count(const std::vector<int64_t>& shape, DiagnosticTensorType dtype) {
+    if (shape.empty()) {
+        throw std::invalid_argument("OpenPI diagnostic tensor shape must not be empty");
+    }
+    std::size_t elements = 1U;
+    for (int64_t dimension : shape) {
+        if (dimension <= 0 || elements > std::numeric_limits<std::size_t>::max() /
+                                             static_cast<std::size_t>(dimension)) {
+            throw std::overflow_error("OpenPI diagnostic tensor shape is invalid");
+        }
+        elements *= static_cast<std::size_t>(dimension);
+    }
+    const std::size_t width = diagnostic_type_size(dtype);
+    if (elements > std::numeric_limits<std::size_t>::max() / width) {
+        throw std::overflow_error("OpenPI diagnostic tensor byte count overflow");
+    }
+    return elements * width;
+}
+
+void require_little_endian_diagnostics() {
+    constexpr uint16_t marker = 1U;
+    if (*reinterpret_cast<const uint8_t*>(&marker) != 1U) {
+        throw std::runtime_error("OpenPI qualification diagnostics require a little-endian host");
+    }
+}
+
+DiagnosticTensor make_diagnostic_tensor(std::string name, DiagnosticStage stage,
+                                        DiagnosticRole role, DiagnosticTensorType dtype,
+                                        std::vector<int64_t> shape, const void* data,
+                                        std::size_t byte_count) {
+    const std::size_t expected = diagnostic_byte_count(shape, dtype);
+    if (data == nullptr || byte_count != expected) {
+        throw std::runtime_error("OpenPI diagnostic tensor '" + name +
+                                 "' has an invalid payload size");
+    }
+    DiagnosticTensor tensor;
+    tensor.name = std::move(name);
+    tensor.stage = stage;
+    tensor.role = role;
+    tensor.dtype = dtype;
+    tensor.shape = std::move(shape);
+    tensor.bytes.resize(byte_count);
+    std::memcpy(tensor.bytes.data(), data, byte_count);
+    return tensor;
+}
+
+template <typename Value>
+DiagnosticTensor make_vector_diagnostic(std::string name, DiagnosticStage stage,
+                                        DiagnosticRole role, DiagnosticTensorType dtype,
+                                        std::vector<int64_t> shape,
+                                        const std::vector<Value>& values) {
+    return make_diagnostic_tensor(std::move(name), stage, role, dtype, std::move(shape),
+                                  values.data(), values.size() * sizeof(Value));
+}
+
+DiagnosticTensor copy_device_diagnostic(std::string name, DiagnosticStage stage,
+                                        DiagnosticRole role, DiagnosticTensorType dtype,
+                                        std::vector<int64_t> shape, const DeviceTensor& source) {
+    const std::size_t expected = diagnostic_byte_count(shape, dtype);
+    if (source.nbytes() != expected) {
+        throw std::runtime_error("OpenPI device diagnostic tensor '" + name +
+                                 "' has an invalid payload size");
+    }
+    DiagnosticTensor tensor;
+    tensor.name = std::move(name);
+    tensor.stage = stage;
+    tensor.role = role;
+    tensor.dtype = dtype;
+    tensor.shape = std::move(shape);
+    tensor.bytes.resize(expected);
+    if (!source.copy_to_host(tensor.bytes.data())) {
+        throw std::runtime_error("OpenPI device diagnostic copy failed for '" + tensor.name + "'");
+    }
+    return tensor;
+}
+
+void validate_action_request(const OpenPIConfig& config, const ActionRequest& request) {
+    if (request.denoise_steps > 0 && request.denoise_steps != config.denoise_steps) {
+        throw std::invalid_argument(
+            "OpenPI runtime only accepts the bundle-qualified denoise step count");
+    }
+    if (request.state.size() != static_cast<std::size_t>(config.external_state_dim)) {
+        throw std::invalid_argument(
+            "OpenPI request state dimension does not match the selected profile");
+    }
+    if (std::any_of(request.state.begin(), request.state.end(),
+                    [](float value) { return !std::isfinite(value); })) {
+        throw std::invalid_argument("OpenPI request state must contain only finite values");
+    }
+    if (clean_prompt(request.prompt).empty()) {
+        throw std::invalid_argument("OpenPI request prompt must contain non-whitespace text");
+    }
+    if (request.cameras.size() != kCameraNames.size()) {
+        throw std::invalid_argument("OpenPI requires exactly three named camera slots");
+    }
+}
+
+std::vector<CameraFrameView> make_camera_views(const ActionRequest& request,
+                                               std::vector<std::vector<uint8_t>>& camera_storage) {
+    camera_storage.reserve(request.cameras.size());
+    std::vector<CameraFrameView> camera_views;
+    camera_views.reserve(request.cameras.size());
+    for (const auto& camera : request.cameras) {
+        camera_storage.push_back(robot_pixels_to_uint8(camera));
+        const auto& bytes = camera_storage.back();
+        CameraFrameView view;
+        view.name = camera.name;
+        view.height = camera.height;
+        view.width = camera.width;
+        view.channels = camera.channels;
+        view.valid = camera.valid;
+        view.pixel_type = CameraPixelType::kUint8;
+        view.uint8_data = bytes.data();
+        view.element_count = bytes.size();
+        camera_views.push_back(view);
+    }
+    return camera_views;
+}
+
+std::vector<uint8_t> resize_camera_pixels(const CameraFrameView& camera,
+                                          std::size_t pixels_per_camera) {
+    if (camera.height == kImageHeight && camera.width == kImageWidth) {
+        return {camera.uint8_data, camera.uint8_data + pixels_per_camera};
+    }
+    return resize_with_pad_uint8(camera.uint8_data, camera.height, camera.width, camera.channels,
+                                 kImageHeight, kImageWidth);
+}
+
+void copy_hwc_to_nchw(const std::vector<float>& normalized, std::size_t camera_index,
+                      std::vector<float>& pixel_values) {
+    for (int32_t channel = 0; channel < 3; ++channel) {
+        for (int32_t row = 0; row < kImageHeight; ++row) {
+            for (int32_t column = 0; column < kImageWidth; ++column) {
+                const std::size_t source = (static_cast<std::size_t>(row) * kImageWidth +
+                                            static_cast<std::size_t>(column)) *
+                                               3U +
+                                           static_cast<std::size_t>(channel);
+                const std::size_t destination =
+                    ((camera_index * 3U + static_cast<std::size_t>(channel)) * kImageHeight +
+                     static_cast<std::size_t>(row)) *
+                        kImageWidth +
+                    static_cast<std::size_t>(column);
+                pixel_values[destination] = normalized[source];
+            }
+        }
+    }
+}
+
+std::vector<uint8_t> prepare_camera_inputs(const OrderedCameraSlots& ordered,
+                                           bool retain_diagnostics, PreparedOpenPIInputs& result) {
+    constexpr std::size_t pixels_per_camera =
+        static_cast<std::size_t>(kImageHeight) * static_cast<std::size_t>(kImageWidth) * 3U;
+    result.pixel_values.resize(kCameraNames.size() * pixels_per_camera);
+    if (retain_diagnostics) {
+        result.preprocessed_images.resize(kCameraNames.size() * pixels_per_camera);
+        result.image_mask.reserve(kCameraNames.size());
+    }
+
+    std::vector<uint8_t> image_mask;
+    image_mask.reserve(kCameraNames.size());
+    for (std::size_t camera_index = 0; camera_index < ordered.size(); ++camera_index) {
+        const auto& camera = ordered[camera_index];
+        image_mask.push_back(camera.valid ? 1U : 0U);
+        // Upstream preprocess_observation() bypasses resize_with_pad when the
+        // camera is already at the policy resolution. Besides matching that
+        // control flow exactly, retaining the bytes avoids three separable
+        // antialiased resizes on the common 224x224 request path.
+        const auto resized = resize_camera_pixels(camera, pixels_per_camera);
+        const auto normalized = uint8_to_openpi_float(resized);
+        if (retain_diagnostics) {
+            std::copy(normalized.begin(), normalized.end(),
+                      result.preprocessed_images.begin() +
+                          static_cast<std::ptrdiff_t>(camera_index * pixels_per_camera));
+        }
+        copy_hwc_to_nchw(normalized, camera_index, result.pixel_values);
+    }
+    return image_mask;
+}
+
+void retain_state_diagnostics(const std::vector<float>& normalized_state, bool retain_diagnostics,
+                              PreparedOpenPIInputs& result) {
+    if (!retain_diagnostics) {
+        return;
+    }
+    result.normalized_state.assign(kModelActionDimension, 0.0F);
+    if (normalized_state.size() > result.normalized_state.size()) {
+        throw std::runtime_error("OpenPI normalized state exceeds the model width");
+    }
+    std::copy(normalized_state.begin(), normalized_state.end(), result.normalized_state.begin());
+}
+
+TokenizedPrompt tokenize_prompt(const OpenPIConfig& config, const PaligemmaBpeTokenizer& tokenizer,
+                                const ActionRequest& request,
+                                const std::vector<float>& normalized_state) {
+    if (config.discrete_state_input) {
+        return tokenizer.tokenize_pi05(request.prompt, normalized_state,
+                                       static_cast<std::size_t>(config.max_token_length));
+    }
+    return tokenizer.tokenize_pi0(request.prompt,
+                                  static_cast<std::size_t>(config.max_token_length));
+}
+
+void prepare_prefix_inputs(const OpenPIConfig& config, TokenizedPrompt&& tokenized,
+                           const std::vector<uint8_t>& image_mask, bool retain_diagnostics,
+                           PreparedOpenPIInputs& result) {
+    result.token_ids = std::move(tokenized.token_ids);
+    if (retain_diagnostics) {
+        result.token_mask = tokenized.token_mask;
+        result.image_mask = image_mask;
+    }
+
+    result.prefix_mask.reserve(static_cast<std::size_t>(config.prefix_length));
+    constexpr int32_t tokens_per_image = (kImageHeight / 14) * (kImageWidth / 14);
+    for (uint8_t valid : image_mask) {
+        result.prefix_mask.insert(result.prefix_mask.end(), tokens_per_image, valid);
+    }
+    result.prefix_mask.insert(result.prefix_mask.end(), tokenized.token_mask.begin(),
+                              tokenized.token_mask.end());
+    if (result.prefix_mask.size() != static_cast<std::size_t>(config.prefix_length)) {
+        throw std::runtime_error("OpenPI prepared prefix mask has an invalid length");
+    }
+
+    result.prefix_positions.resize(result.prefix_mask.size());
+    int32_t valid_prefix_tokens = 0;
+    for (std::size_t index = 0; index < result.prefix_mask.size(); ++index) {
+        if (result.prefix_mask[index] != 0U) {
+            ++valid_prefix_tokens;
+        }
+        result.prefix_positions[index] = valid_prefix_tokens - 1;
+    }
+    result.suffix_positions.resize(static_cast<std::size_t>(config.action_horizon));
+    for (int32_t index = 0; index < config.action_horizon; ++index) {
+        result.suffix_positions[static_cast<std::size_t>(index)] = valid_prefix_tokens + index;
+    }
+}
+
+void prepare_noise_inputs(const OpenPIConfig& config, const ActionRequest& request,
+                          PreparedOpenPIInputs& result) {
+    result.schedule = make_euler_schedule(config.denoise_steps);
+    result.initial_noise =
+        request.initial_noise.empty()
+            ? make_deterministic_noise(config, request.seed)
+            : make_fixed_noise(request.initial_noise, config.batch_size, config.action_horizon,
+                               config.internal_action_dim);
+}
+
+void require_diagnostic_precision(const OpenPIConfig& config) {
+    if (config.precision != "bf16" && config.precision != "bfloat16") {
+        throw std::runtime_error(
+            "OpenPI qualification diagnostics require the BF16-qualified engine plans");
+    }
+}
+
+void append_preprocess_diagnostics(const PreparedOpenPIInputs& inputs, const OpenPIConfig& config,
+                                   const std::vector<int64_t>& action_shape,
+                                   std::vector<DiagnosticTensor>& tensors) {
+    tensors.push_back(make_vector_diagnostic("initial_noise", DiagnosticStage::kPreprocess,
+                                             DiagnosticRole::kInput, DiagnosticTensorType::kFloat32,
+                                             action_shape, inputs.initial_noise));
+    tensors.push_back(make_vector_diagnostic(
+        "token_ids", DiagnosticStage::kPreprocess, DiagnosticRole::kIntermediate,
+        DiagnosticTensorType::kInt32, {1, config.max_token_length}, inputs.token_ids));
+    tensors.push_back(make_vector_diagnostic(
+        "token_mask", DiagnosticStage::kPreprocess, DiagnosticRole::kIntermediate,
+        DiagnosticTensorType::kBool, {1, config.max_token_length}, inputs.token_mask));
+    tensors.push_back(
+        make_vector_diagnostic("preprocessed_images", DiagnosticStage::kPreprocess,
+                               DiagnosticRole::kIntermediate, DiagnosticTensorType::kFloat32,
+                               {1, 3, kImageHeight, kImageWidth, 3}, inputs.preprocessed_images));
+    tensors.push_back(make_vector_diagnostic(
+        "image_mask", DiagnosticStage::kPreprocess, DiagnosticRole::kIntermediate,
+        DiagnosticTensorType::kBool, {1, 3}, inputs.image_mask));
+    tensors.push_back(make_vector_diagnostic(
+        "normalized_state", DiagnosticStage::kPreprocess, DiagnosticRole::kIntermediate,
+        DiagnosticTensorType::kFloat32, {1, static_cast<int64_t>(kModelActionDimension)},
+        inputs.normalized_state));
+}
+
+DiagnosticTensor copy_prefix_cache_diagnostic(const PrefixKvCache& prefix_cache,
+                                              const OpenPIConfig& config) {
+    const std::vector<int64_t> combined_cache_shape{
+        config.num_layers, 2, 1, config.prefix_length, config.num_kv_heads, config.head_dim};
+    std::vector<uint8_t> combined_cache(
+        diagnostic_byte_count(combined_cache_shape, DiagnosticTensorType::kBFloat16));
+    std::size_t cache_offset = 0U;
+    for (int32_t layer = 0; layer < config.num_layers; ++layer) {
+        for (const DeviceTensor* cache : {&prefix_cache.key(layer), &prefix_cache.value(layer)}) {
+            if (cache_offset + cache->nbytes() > combined_cache.size() ||
+                !cache->copy_to_host(combined_cache.data() + cache_offset)) {
+                throw std::runtime_error("OpenPI prefix KV diagnostic copy failed");
+            }
+            cache_offset += cache->nbytes();
+        }
+    }
+    if (cache_offset != combined_cache.size()) {
+        throw std::runtime_error("OpenPI prefix KV diagnostic byte count mismatch");
+    }
+    return make_vector_diagnostic("prefix_kv_cache", DiagnosticStage::kPrefix,
+                                  DiagnosticRole::kIntermediate, DiagnosticTensorType::kBFloat16,
+                                  combined_cache_shape, combined_cache);
+}
+
+std::string indexed_diagnostic_name(const char* prefix, int32_t index) {
+    return std::string(prefix) + (index < 10 ? "0" : "") + std::to_string(index);
+}
+
+void execute_diagnostic_steps(ITrtModule& action_step, const OpenPIConfig& config,
+                              DeviceTensor& actions_a, DeviceTensor& actions_b,
+                              DeviceTensor& velocity, DeviceTensor& timesteps,
+                              const std::vector<int64_t>& action_shape,
+                              std::vector<float>& flow_state,
+                              std::vector<DiagnosticTensor>& tensors) {
+    DeviceTensor* current = &actions_a;
+    DeviceTensor* next = &actions_b;
+    auto* timestep_base = static_cast<uint8_t*>(timesteps.data());
+    for (int32_t step = 0; step < config.denoise_steps; ++step) {
+        action_step.bind_external("noisy_actions", current->data(), action_shape);
+        action_step.bind_external("next_actions", next->data(), action_shape);
+        action_step.bind_external(
+            "timestep", timestep_base + static_cast<std::size_t>(step) * sizeof(float), {1});
+        action_step.forward_device_async({});
+
+        std::vector<float> velocity_values(velocity.numel());
+        if (!velocity.copy_to_host(velocity_values.data())) {
+            throw std::runtime_error("OpenPI velocity diagnostic copy failed");
+        }
+        tensors.push_back(
+            make_vector_diagnostic(indexed_diagnostic_name("velocity_", step),
+                                   DiagnosticStage::kFlow, DiagnosticRole::kIntermediate,
+                                   DiagnosticTensorType::kFloat32, action_shape, velocity_values));
+
+        flow_state.resize(static_cast<std::size_t>(next->numel()));
+        if (!next->copy_to_host(flow_state.data())) {
+            throw std::runtime_error("OpenPI flow-state diagnostic copy failed");
+        }
+        tensors.push_back(
+            make_vector_diagnostic(indexed_diagnostic_name("flow_state_", step + 1),
+                                   DiagnosticStage::kFlow, DiagnosticRole::kIntermediate,
+                                   DiagnosticTensorType::kFloat32, action_shape, flow_state));
+        std::swap(current, next);
+    }
+}
+
+ActionResult make_diagnostic_action_result(const OpenPIConfig& config,
+                                           const OpenPINormalization& normalization,
+                                           const std::vector<float>& flow_state) {
+    const auto physical_internal = quantile_unnormalize(
+        flow_state, static_cast<std::size_t>(config.internal_action_dim), normalization.actions);
+    ActionResult result;
+    result.horizon = config.action_horizon;
+    result.action_dim = config.external_action_dim;
+    result.actions.resize(static_cast<std::size_t>(result.horizon) *
+                          static_cast<std::size_t>(result.action_dim));
+    for (int32_t row = 0; row < result.horizon; ++row) {
+        const auto source = static_cast<std::size_t>(row) * config.internal_action_dim;
+        const auto destination = static_cast<std::size_t>(row) * result.action_dim;
+        std::copy_n(physical_internal.begin() + static_cast<std::ptrdiff_t>(source),
+                    result.action_dim,
+                    result.actions.begin() + static_cast<std::ptrdiff_t>(destination));
+    }
+    return result;
+}
+
+} // namespace
+
+PreparedOpenPIInputs prepare_openpi_inputs(const OpenPIConfig& config,
+                                           const OpenPINormalization& normalization,
+                                           const PaligemmaBpeTokenizer& tokenizer,
+                                           const ActionRequest& request, bool retain_diagnostics) {
+    validate_action_request(config, request);
+    std::vector<std::vector<uint8_t>> camera_storage;
+    const auto camera_views = make_camera_views(request, camera_storage);
+    const auto ordered = validate_and_order_camera_slots(camera_views);
+    validate_pi05_two_camera_masks(ordered);
+
+    PreparedOpenPIInputs result;
+    const auto image_mask = prepare_camera_inputs(ordered, retain_diagnostics, result);
+    const auto normalized_state = quantile_normalize(
+        request.state, static_cast<std::size_t>(config.external_state_dim), normalization.state);
+    retain_state_diagnostics(normalized_state, retain_diagnostics, result);
+    prepare_prefix_inputs(config, tokenize_prompt(config, tokenizer, request, normalized_state),
+                          image_mask, retain_diagnostics, result);
+    prepare_noise_inputs(config, request, result);
+    return result;
+}
+
+void validate_openpi_engine_contracts(const ITrtModule& prefill, const ITrtModule& action_step,
+                                      const OpenPIConfig& config) {
+    if (!prefill.ok() || !action_step.ok()) {
+        throw std::runtime_error("OpenPI requires two valid TensorRT modules");
+    }
+    if (prefill.stream() != action_step.stream()) {
+        throw std::runtime_error("OpenPI prefill and action modules must share one CUDA stream");
+    }
+    if (prefill.input_info().size() != 4U ||
+        prefill.output_info().size() != static_cast<std::size_t>(1 + 2 * config.num_layers)) {
+        throw std::runtime_error("OpenPI prefill engine has unexpected inputs or outputs");
+    }
+    if (action_step.input_info().size() != static_cast<std::size_t>(5 + 2 * config.num_layers) ||
+        action_step.output_info().size() != 2U) {
+        throw std::runtime_error("OpenPI action engine has unexpected inputs or outputs");
+    }
+
+    require_shape(prefill, "pixel_values", true, {3, 3, 224, 224});
+    require_dtype(prefill, "pixel_values", DType::kFloat32);
+    require_shape(prefill, "token_ids", true, {1, config.max_token_length});
+    require_dtype(prefill, "token_ids", DType::kInt32);
+    require_shape(prefill, "prefix_mask", true, {1, config.prefix_length});
+    // ITrtModule's public DType predates TensorRT bool. Bool tensors are bound
+    // as one-byte external storage and validated by name/shape here.
+    require_shape(prefill, "prefix_position_ids", true, {1, config.prefix_length});
+    require_dtype(prefill, "prefix_position_ids", DType::kInt32);
+
+    require_shape(prefill, "vision_tokens", false, {1, 3, 256, 2048});
+    require_dtype(prefill, "vision_tokens", cache_dtype_for_precision(config));
+
+    const std::vector<int64_t> action_shape{1, config.action_horizon, config.internal_action_dim};
+    require_shape(action_step, "noisy_actions", true, action_shape);
+    require_dtype(action_step, "noisy_actions", DType::kFloat32);
+    require_shape(action_step, "timestep", true, {1});
+    require_dtype(action_step, "timestep", DType::kFloat32);
+    require_shape(action_step, "step_size", true, {1});
+    require_dtype(action_step, "step_size", DType::kFloat32);
+    require_shape(action_step, "prefix_mask", true, {1, config.prefix_length});
+    require_shape(action_step, "suffix_position_ids", true, {1, config.action_horizon});
+    require_dtype(action_step, "suffix_position_ids", DType::kInt32);
+    require_shape(action_step, "velocity", false, action_shape);
+    require_dtype(action_step, "velocity", DType::kFloat32);
+    require_shape(action_step, "next_actions", false, action_shape);
+    require_dtype(action_step, "next_actions", DType::kFloat32);
+
+    const DType cache_dtype = cache_dtype_for_precision(config);
+    const std::vector<int64_t> cache_shape{1, config.prefix_length, config.num_kv_heads,
+                                           config.head_dim};
+    for (int32_t layer = 0; layer < config.num_layers; ++layer) {
+        for (char kind : {'k', 'v'}) {
+            const auto name = cache_name(kind, layer);
+            require_shape(prefill, name, false, cache_shape);
+            require_dtype(prefill, name, cache_dtype);
+            require_shape(action_step, name, true, cache_shape);
+            require_dtype(action_step, name, cache_dtype);
+        }
+    }
+}
+
+struct OpenPIPipeline::DeviceWorkspace {
+    DeviceWorkspace(const OpenPIConfig& config, DType cache_dtype, cudaStream_t stream)
+        : pixel_values({3, 3, 224, 224}, DType::kFloat32, stream),
+          token_ids({1, config.max_token_length}, DType::kInt32, stream),
+          prefix_mask({1, config.prefix_length}, DType::kInt8, stream),
+          prefix_positions({1, config.prefix_length}, DType::kInt32, stream),
+          suffix_positions({1, config.action_horizon}, DType::kInt32, stream),
+          vision_tokens({1, 3, 256, 2048}, cache_dtype, stream),
+          timesteps({config.denoise_steps}, DType::kFloat32, stream),
+          step_size({1}, DType::kFloat32, stream),
+          actions_a({1, config.action_horizon, config.internal_action_dim}, DType::kFloat32,
+                    stream),
+          actions_b({1, config.action_horizon, config.internal_action_dim}, DType::kFloat32,
+                    stream),
+          velocity({1, config.action_horizon, config.internal_action_dim}, DType::kFloat32, stream),
+          prefix_cache(config.num_layers, config.prefix_length, config.num_kv_heads,
+                       config.head_dim, cache_dtype, stream) {}
+
+    DeviceTensor pixel_values;
+    DeviceTensor token_ids;
+    DeviceTensor prefix_mask;
+    DeviceTensor prefix_positions;
+    DeviceTensor suffix_positions;
+    DeviceTensor vision_tokens;
+    DeviceTensor timesteps;
+    DeviceTensor step_size;
+    DeviceTensor actions_a;
+    DeviceTensor actions_b;
+    DeviceTensor velocity;
+    PrefixKvCache prefix_cache;
+};
+
+OpenPIPipeline::OpenPIPipeline(std::unique_ptr<ITrtModule> prefill,
+                               std::unique_ptr<ITrtModule> action_step, OpenPIConfig config,
+                               OpenPINormalization normalization, PaligemmaBpeTokenizer tokenizer,
+                               std::string model_id)
+    : prefill_(std::move(prefill)), action_step_(std::move(action_step)),
+      config_(std::move(config)), normalization_(std::move(normalization)),
+      tokenizer_(std::move(tokenizer)), model_id_(std::move(model_id)) {
+    if (!prefill_ || !action_step_) {
+        throw std::runtime_error("OpenPIPipeline requires both TensorRT engine plans");
+    }
+    validate_openpi_engine_contracts(*prefill_, *action_step_, config_);
+}
+
+OpenPIPipeline::~OpenPIPipeline() {
+    if (action_step_) {
+        action_step_->sync();
+    }
+    action_step_.reset();
+    prefill_.reset();
+    workspace_.reset();
+}
+
+void OpenPIPipeline::ensure_workspace() {
+    if (workspace_) {
+        return;
+    }
+    workspace_ = std::make_unique<DeviceWorkspace>(config_, cache_dtype_for_precision(config_),
+                                                   prefill_->stream());
+    require_device_tensor(workspace_->pixel_values, "pixel_values");
+    require_device_tensor(workspace_->token_ids, "token_ids");
+    require_device_tensor(workspace_->prefix_mask, "prefix_mask");
+    require_device_tensor(workspace_->prefix_positions, "prefix_position_ids");
+    require_device_tensor(workspace_->suffix_positions, "suffix_position_ids");
+    require_device_tensor(workspace_->vision_tokens, "vision_tokens");
+    require_device_tensor(workspace_->timesteps, "timestep_schedule");
+    require_device_tensor(workspace_->step_size, "step_size");
+    require_device_tensor(workspace_->actions_a, "actions_a");
+    require_device_tensor(workspace_->actions_b, "actions_b");
+    require_device_tensor(workspace_->velocity, "velocity");
+    if (!workspace_->prefix_cache.ok()) {
+        throw std::runtime_error("OpenPI failed to allocate the device prefix KV cache");
+    }
+
+    prefill_->bind_external("pixel_values", workspace_->pixel_values.data());
+    prefill_->bind_external("token_ids", workspace_->token_ids.data());
+    prefill_->bind_external("prefix_mask", workspace_->prefix_mask.data());
+    prefill_->bind_external("prefix_position_ids", workspace_->prefix_positions.data());
+    prefill_->bind_external("vision_tokens", workspace_->vision_tokens.data());
+    action_step_->bind_external("prefix_mask", workspace_->prefix_mask.data());
+    action_step_->bind_external("suffix_position_ids", workspace_->suffix_positions.data());
+    action_step_->bind_external("step_size", workspace_->step_size.data());
+    action_step_->bind_external("velocity", workspace_->velocity.data());
+    workspace_->prefix_cache.bind_to(*prefill_);
+    workspace_->prefix_cache.bind_to(*action_step_);
+}
+
+void OpenPIPipeline::upload_request(const PreparedOpenPIInputs& inputs) {
+    if (!workspace_->pixel_values.copy_from_host(inputs.pixel_values.data()) ||
+        !workspace_->token_ids.copy_from_host(inputs.token_ids.data()) ||
+        !workspace_->prefix_mask.copy_from_host(inputs.prefix_mask.data()) ||
+        !workspace_->prefix_positions.copy_from_host(inputs.prefix_positions.data()) ||
+        !workspace_->suffix_positions.copy_from_host(inputs.suffix_positions.data()) ||
+        !workspace_->timesteps.copy_from_host(inputs.schedule.timesteps.data()) ||
+        !workspace_->step_size.copy_from_host(&inputs.schedule.dt) ||
+        !workspace_->actions_a.copy_from_host(inputs.initial_noise.data())) {
+        throw std::runtime_error("OpenPI failed to upload request tensors to the GPU");
+    }
+}
+
+std::vector<float> OpenPIPipeline::execute_device_resident_flow(const PreparedOpenPIInputs& inputs,
+                                                                double& prefill_ms,
+                                                                double& denoise_ms) {
+    ensure_workspace();
+    const cudaStream_t stream = prefill_->stream();
+    CudaEvent prefill_begin;
+    CudaEvent prefill_end;
+    CudaEvent denoise_begin;
+    CudaEvent denoise_end;
+
+    prefill_begin.record(stream);
+    upload_request(inputs);
+    prefill_->forward_device_async({});
+    prefill_end.record(stream);
+
+    denoise_begin.record(stream);
+    DeviceTensor* current = &workspace_->actions_a;
+    DeviceTensor* next = &workspace_->actions_b;
+    auto* timestep_base = static_cast<uint8_t*>(workspace_->timesteps.data());
+    const std::vector<int64_t> action_shape{1, config_.action_horizon, config_.internal_action_dim};
+    for (int32_t step = 0; step < config_.denoise_steps; ++step) {
+        action_step_->bind_external("noisy_actions", current->data(), action_shape);
+        action_step_->bind_external("next_actions", next->data(), action_shape);
+        action_step_->bind_external(
+            "timestep", timestep_base + static_cast<std::size_t>(step) * sizeof(float), {1});
+        action_step_->forward_device_async({});
+        std::swap(current, next);
+    }
+    denoise_end.record(stream);
+
+    // This is the sole host synchronization point in inference. No cache,
+    // velocity, or intermediate flow state is copied to the host.
+    require_cuda(cudaStreamSynchronize(stream), "device-resident flow synchronization");
+    std::vector<float> model_actions(current->numel());
+    if (!current->copy_to_host(model_actions.data())) {
+        throw std::runtime_error("OpenPI final device-to-host action copy failed");
+    }
+    prefill_ms = CudaEvent::elapsed(prefill_begin, prefill_end);
+    denoise_ms = CudaEvent::elapsed(denoise_begin, denoise_end);
+    return model_actions;
+}
+
+ActionDiagnosticResult OpenPIPipeline::execute_diagnostic_flow(const PreparedOpenPIInputs& inputs,
+                                                               double preprocess_ms) {
+    require_little_endian_diagnostics();
+    require_diagnostic_precision(config_);
+
+    ActionDiagnosticResult capture;
+    auto& tensors = capture.tensors;
+    const std::vector<int64_t> action_shape{1, config_.action_horizon, config_.internal_action_dim};
+    tensors.reserve(31U);
+    append_preprocess_diagnostics(inputs, config_, action_shape, tensors);
+
+    ensure_workspace();
+    const cudaStream_t stream = prefill_->stream();
+    CudaEvent prefill_begin;
+    CudaEvent prefill_end;
+    CudaEvent denoise_begin;
+    CudaEvent denoise_end;
+
+    prefill_begin.record(stream);
+    upload_request(inputs);
+    prefill_->forward_device_async({});
+    prefill_end.record(stream);
+    require_cuda(cudaStreamSynchronize(stream), "diagnostic prefill synchronization");
+
+    tensors.push_back(copy_device_diagnostic(
+        "vision_tokens", DiagnosticStage::kVision, DiagnosticRole::kIntermediate,
+        DiagnosticTensorType::kBFloat16, {1, 3, 256, 2048}, workspace_->vision_tokens));
+    tensors.push_back(copy_prefix_cache_diagnostic(workspace_->prefix_cache, config_));
+
+    std::vector<float> flow_state = inputs.initial_noise;
+    tensors.push_back(make_vector_diagnostic(
+        "flow_state_00", DiagnosticStage::kFlow, DiagnosticRole::kIntermediate,
+        DiagnosticTensorType::kFloat32, action_shape, flow_state));
+
+    denoise_begin.record(stream);
+    execute_diagnostic_steps(*action_step_, config_, workspace_->actions_a, workspace_->actions_b,
+                             workspace_->velocity, workspace_->timesteps, action_shape, flow_state,
+                             tensors);
+    denoise_end.record(stream);
+    require_cuda(cudaStreamSynchronize(stream), "diagnostic flow synchronization");
+
+    tensors.push_back(make_vector_diagnostic(
+        "normalized_actions", DiagnosticStage::kPostprocess, DiagnosticRole::kOutput,
+        DiagnosticTensorType::kFloat32, action_shape, flow_state));
+
+    const auto postprocess_begin = Clock::now();
+    capture.result = make_diagnostic_action_result(config_, normalization_, flow_state);
+    const auto postprocess_end = Clock::now();
+    ActionResult& result = capture.result;
+    result.timings.preprocess_ms = preprocess_ms;
+    result.timings.prefill_ms = CudaEvent::elapsed(prefill_begin, prefill_end);
+    result.timings.denoise_ms = CudaEvent::elapsed(denoise_begin, denoise_end);
+    result.timings.postprocess_ms = elapsed_ms(postprocess_begin, postprocess_end);
+
+    tensors.push_back(make_vector_diagnostic(
+        "physical_actions", DiagnosticStage::kPostprocess, DiagnosticRole::kOutput,
+        DiagnosticTensorType::kFloat32, {1, config_.action_horizon, config_.external_action_dim},
+        result.actions));
+    if (tensors.size() != 31U) {
+        throw std::runtime_error("OpenPI diagnostic capture emitted an incomplete tensor set");
+    }
+    return capture;
+}
+
+ActionResult OpenPIPipeline::predict_actions(const ActionRequest& request) {
+    const auto preprocess_begin = Clock::now();
+    const auto prepared = prepare_openpi_inputs(config_, normalization_, tokenizer_, request);
+    const auto preprocess_end = Clock::now();
+
+    double prefill_ms = 0.0;
+    double denoise_ms = 0.0;
+    auto model_actions = execute_device_resident_flow(prepared, prefill_ms, denoise_ms);
+
+    const auto postprocess_begin = Clock::now();
+    model_actions =
+        quantile_unnormalize(model_actions, static_cast<std::size_t>(config_.internal_action_dim),
+                             normalization_.actions);
+    ActionResult result;
+    result.horizon = config_.action_horizon;
+    result.action_dim = config_.external_action_dim;
+    result.actions.resize(static_cast<std::size_t>(result.horizon) *
+                          static_cast<std::size_t>(result.action_dim));
+    for (int32_t row = 0; row < result.horizon; ++row) {
+        const auto source = static_cast<std::size_t>(row) * config_.internal_action_dim;
+        const auto destination = static_cast<std::size_t>(row) * result.action_dim;
+        std::copy_n(model_actions.begin() + static_cast<std::ptrdiff_t>(source), result.action_dim,
+                    result.actions.begin() + static_cast<std::ptrdiff_t>(destination));
+    }
+    const auto postprocess_end = Clock::now();
+    result.timings.preprocess_ms = elapsed_ms(preprocess_begin, preprocess_end);
+    result.timings.prefill_ms = prefill_ms;
+    result.timings.denoise_ms = denoise_ms;
+    result.timings.postprocess_ms = elapsed_ms(postprocess_begin, postprocess_end);
+    return result;
+}
+
+ActionDiagnosticResult
+OpenPIPipeline::predict_actions_with_diagnostics(const ActionRequest& request) {
+    if (request.initial_noise.empty()) {
+        throw std::invalid_argument(
+            "OpenPI qualification diagnostics require caller-supplied initial_noise");
+    }
+    const auto preprocess_begin = Clock::now();
+    const auto prepared = prepare_openpi_inputs(config_, normalization_, tokenizer_, request, true);
+    const auto preprocess_end = Clock::now();
+    return execute_diagnostic_flow(prepared, elapsed_ms(preprocess_begin, preprocess_end));
+}
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/pipeline.h
+++ b/src/runtime/models/openpi/pipeline.h
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "runtime/models/openpi/api.h"
+#include "runtime/models/openpi/config.h"
+#include "runtime/models/openpi/paligemma_bpe.h"
+#include "trtmc/pipeline.h"
+#include "trtmc/runtime/trt_module.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace trtmc::openpi {
+
+struct PreparedOpenPIInputs {
+    std::vector<float> pixel_values;        // [3, 3, 224, 224], NCHW
+    std::vector<float> preprocessed_images; // [1, 3, 224, 224, 3], NHWC
+    std::vector<int32_t> token_ids;         // [1, 200]
+    std::vector<uint8_t> token_mask;        // [1, 200], bool storage
+    std::vector<uint8_t> image_mask;        // [1, 3], bool storage
+    std::vector<float> normalized_state;    // [1, 32]
+    std::vector<uint8_t> prefix_mask;       // [1, 968], TensorRT bool storage
+    std::vector<int32_t> prefix_positions;  // [1, 968]
+    std::vector<int32_t> suffix_positions;  // [1, H]
+    std::vector<float> initial_noise;       // [1, H, 32]
+    EulerSchedule schedule;
+};
+
+// CPU-only request preparation seam used by the runtime and model-owned tests.
+PreparedOpenPIInputs prepare_openpi_inputs(const OpenPIConfig& config,
+                                           const OpenPINormalization& normalization,
+                                           const PaligemmaBpeTokenizer& tokenizer,
+                                           const ActionRequest& request,
+                                           bool retain_diagnostics = false);
+
+// Validate both fixed-shape plans before any GPU workspace is allocated.
+void validate_openpi_engine_contracts(const ITrtModule& prefill, const ITrtModule& action_step,
+                                      const OpenPIConfig& config);
+
+class OpenPIPipeline final : public IPipeline,
+                             public IOpenPIActionPipeline,
+                             public IOpenPIDiagnosticPipeline {
+  public:
+    OpenPIPipeline(std::unique_ptr<ITrtModule> prefill, std::unique_ptr<ITrtModule> action_step,
+                   OpenPIConfig config, OpenPINormalization normalization,
+                   PaligemmaBpeTokenizer tokenizer, std::string model_id);
+    ~OpenPIPipeline() override;
+
+    OpenPIPipeline(const OpenPIPipeline&) = delete;
+    OpenPIPipeline& operator=(const OpenPIPipeline&) = delete;
+
+    ActionResult predict_actions(const ActionRequest& request) override;
+    ActionDiagnosticResult predict_actions_with_diagnostics(const ActionRequest& request) override;
+
+    const char* model_id() const override { return model_id_.c_str(); }
+    const char* pipeline_type() const override { return "OpenPIPipeline"; }
+
+  private:
+    struct DeviceWorkspace;
+
+    void ensure_workspace();
+    void upload_request(const PreparedOpenPIInputs& inputs);
+    std::vector<float> execute_device_resident_flow(const PreparedOpenPIInputs& inputs,
+                                                    double& prefill_ms, double& denoise_ms);
+    ActionDiagnosticResult execute_diagnostic_flow(const PreparedOpenPIInputs& inputs,
+                                                   double preprocess_ms);
+
+    // The action module borrows the prefill module's stream. Destruction is
+    // therefore explicit in ~OpenPIPipeline: action first, prefill second.
+    std::unique_ptr<ITrtModule> prefill_;
+    std::unique_ptr<ITrtModule> action_step_;
+    OpenPIConfig config_;
+    OpenPINormalization normalization_;
+    PaligemmaBpeTokenizer tokenizer_;
+    std::string model_id_;
+    std::unique_ptr<DeviceWorkspace> workspace_;
+};
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/plugin.cpp
+++ b/src/runtime/models/openpi/plugin.cpp
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bundle/bundle_view.h"
+#include "runtime/models/openpi/config.h"
+#include "runtime/models/openpi/paligemma_bpe.h"
+#include "runtime/models/openpi/pipeline.h"
+#include "runtime/models/openpi/plugin_helpers.h"
+#include "trtmc/runtime/pipeline_registry.h"
+
+#ifndef TRTMC_OPENPI_RMS_NORM_PLUGIN
+#define TRTMC_OPENPI_RMS_NORM_PLUGIN 0
+#endif
+
+#if TRTMC_OPENPI_RMS_NORM_PLUGIN
+extern "C" void trtmc_openpi_rms_norm_plugin_force_link();
+#endif
+
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+namespace trtmc {
+
+class OpenPIPlugin final : public IPipelinePlugin {
+  public:
+    std::unique_ptr<IPipeline> create(const PipelineContext& ctx) override {
+#if TRTMC_OPENPI_RMS_NORM_PLUGIN
+        // Keep the plugin translation unit linked and its static creator
+        // registration observable before either plan is deserialized.
+        trtmc_openpi_rms_norm_plugin_force_link();
+#endif
+        auto verified = openpi::verify_openpi_bundle_integrity(ctx.bundle);
+        if (verified.config_json != ctx.config_json) {
+            throw std::runtime_error(
+                "OpenPI verified config.json differs from the factory configuration");
+        }
+        auto tokenizer_asset = openpi::parse_paligemma_bpe_asset(verified.tokenizer_bytes);
+
+        ModuleCreateOptions prefill_options;
+        prefill_options.runtime_cache_path = ctx.runtime_cache_path.c_str();
+        // Per-engine graph capture cannot represent alternating action buffers
+        // or per-step timestep addresses. The complete ten-step loop remains
+        // asynchronous and device-resident on one stream.
+        prefill_options.cuda_graphs = false;
+        auto prefill = openpi::load_openpi_module(ctx.backend, verified.prefill_plan, "engine_plan",
+                                                  "openpi_prefill", prefill_options);
+
+        ModuleCreateOptions action_options = prefill_options;
+        action_options.stream = prefill->stream();
+        auto action = openpi::load_openpi_module(ctx.backend, verified.action_plan,
+                                                 "openpi_action_step_engine_plan",
+                                                 "openpi_action_step", action_options);
+
+        return std::make_unique<openpi::OpenPIPipeline>(
+            std::move(prefill), std::move(action), std::move(verified.config),
+            std::move(verified.normalization),
+            openpi::PaligemmaBpeTokenizer(std::move(tokenizer_asset)), ctx.bundle.info.model_id);
+    }
+};
+
+REGISTER_PIPELINE_PLUGIN_WITH_MANIFEST(register_openpi_plugin, OpenPIPlugin, "openpi_vla");
+
+} // namespace trtmc

--- a/src/runtime/models/openpi/plugin_helpers.cpp
+++ b/src/runtime/models/openpi/plugin_helpers.cpp
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/openpi/plugin_helpers.h"
+
+#include "bundle/bundle_view.h"
+#include "utils/sha256.h"
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+
+namespace trtmc::openpi {
+namespace {
+
+const std::vector<char>* require_unique_section(const BundleFile& bundle, const char* name) {
+    const std::vector<char>* result = nullptr;
+    for (const auto& section : bundle.sections) {
+        if (section.name != name) {
+            continue;
+        }
+        if (result != nullptr) {
+            throw std::runtime_error(std::string("OpenPI bundle contains duplicate section '") +
+                                     name + "'");
+        }
+        result = &section.data;
+    }
+    if (result == nullptr || result->empty()) {
+        throw std::runtime_error(std::string("OpenPI bundle is missing required section '") + name +
+                                 "'");
+    }
+    return result;
+}
+
+std::string_view section_text(const std::vector<char>& section) {
+    return std::string_view(section.data(), section.size());
+}
+
+std::string sha256(std::string_view bytes) {
+    internal::Sha256 hash;
+    hash.update(bytes);
+    return hash.hex_digest();
+}
+
+void require_matching_digest(std::string_view section_name, std::string_view bytes,
+                             const std::string& expected) {
+    if (sha256(bytes) != expected) {
+        throw std::runtime_error("OpenPI bundle section '" + std::string(section_name) +
+                                 "' does not match config.json SHA-256");
+    }
+}
+
+} // namespace
+
+VerifiedOpenPIBundle verify_openpi_bundle_integrity(const BundleFile& bundle) {
+    std::unordered_set<std::string_view> section_names;
+    for (const auto& section : bundle.sections) {
+        if (!section_names.emplace(section.name).second) {
+            throw std::runtime_error("OpenPI bundle contains duplicate section '" + section.name +
+                                     "'");
+        }
+    }
+    std::unordered_set<std::string_view> expected_section_names;
+    for (const auto name : kRequiredIntegritySectionNames) {
+        expected_section_names.emplace(name);
+    }
+    if (section_names != expected_section_names) {
+        throw std::runtime_error("OpenPI bundle contains missing or unexpected physical sections");
+    }
+
+    const auto* config_section = require_unique_section(bundle, "config.json");
+    const auto* prefill_plan = require_unique_section(bundle, "engine_plan");
+    const auto* action_plan = require_unique_section(bundle, "openpi_action_step_engine_plan");
+    const auto* tokenizer_section = require_unique_section(bundle, "tokenizer.model");
+    const auto* normalization_section = require_unique_section(bundle, "preprocessor_config.json");
+
+    VerifiedOpenPIBundle verified;
+    verified.config_json = section_text(*config_section);
+    verified.tokenizer_bytes = section_text(*tokenizer_section);
+    verified.normalization_bytes = section_text(*normalization_section);
+    verified.prefill_plan = prefill_plan;
+    verified.action_plan = action_plan;
+    verified.config = parse_openpi_config(verified.config_json);
+    verified.normalization =
+        parse_openpi_normalization(verified.normalization_bytes, verified.config);
+
+    require_matching_digest("engine_plan", section_text(*prefill_plan),
+                            verified.config.prefill_engine_sha256);
+    require_matching_digest("openpi_action_step_engine_plan", section_text(*action_plan),
+                            verified.config.action_engine_sha256);
+    require_matching_digest("tokenizer.model", verified.tokenizer_bytes,
+                            verified.config.tokenizer_sha256);
+    require_matching_digest("preprocessor_config.json", verified.normalization_bytes,
+                            verified.config.normalization_sha256);
+    return verified;
+}
+
+std::unique_ptr<ITrtModule> load_openpi_module(IBackend* backend, const std::vector<char>* plan,
+                                               const char* section_name, const char* timing_label,
+                                               const ModuleCreateOptions& options) {
+    if (backend == nullptr) {
+        throw std::runtime_error("OpenPI cannot load without a TensorRT backend");
+    }
+    const char* backend_name = backend->name();
+    if (backend_name == nullptr) {
+        throw std::runtime_error("OpenPI requires TensorRT backend 'trt'; backend name is null");
+    }
+    if (std::string_view(backend_name) != "trt") {
+        throw std::runtime_error(std::string("OpenPI requires TensorRT backend 'trt'; got '") +
+                                 backend_name + "'");
+    }
+    if (plan == nullptr || plan->empty()) {
+        throw std::runtime_error(std::string("OpenPI bundle is missing required section '") +
+                                 section_name + "'");
+    }
+    auto module = backend->create_module(plan->data(), plan->size(), options);
+    if (!module || !module->ok()) {
+        throw std::runtime_error(std::string("OpenPI failed to deserialize '") + section_name +
+                                 "'");
+    }
+    module->set_timing_label(timing_label);
+    return module;
+}
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/plugin_helpers.h
+++ b/src/runtime/models/openpi/plugin_helpers.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "bundle/bundle_format.h"
+#include "runtime/models/openpi/config.h"
+#include "trtmc/runtime/trt_backend.h"
+#include "trtmc/runtime/trt_module.h"
+
+#include <memory>
+#include <string_view>
+#include <vector>
+
+namespace trtmc::openpi {
+
+struct VerifiedOpenPIBundle {
+    OpenPIConfig config;
+    OpenPINormalization normalization;
+    std::string_view config_json;
+    std::string_view tokenizer_bytes;
+    std::string_view normalization_bytes;
+    const std::vector<char>* prefill_plan{nullptr};
+    const std::vector<char>* action_plan{nullptr};
+};
+
+// Validate the complete OpenPI bundle integrity contract before either plan is
+// handed to TensorRT. Missing, duplicate, empty, or hash-mismatched sections
+// fail closed.
+VerifiedOpenPIBundle verify_openpi_bundle_integrity(const BundleFile& bundle);
+
+// Deserialize one required OpenPI TensorRT plan.
+std::unique_ptr<ITrtModule> load_openpi_module(IBackend* backend, const std::vector<char>* plan,
+                                               const char* section_name, const char* timing_label,
+                                               const ModuleCreateOptions& options);
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/tool/action_request_json.cpp
+++ b/src/runtime/models/openpi/tool/action_request_json.cpp
@@ -1,0 +1,237 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/openpi/tool/action_request_json.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+namespace trtmc::openpi::tool {
+namespace {
+
+using Json = nlohmann::json;
+
+constexpr std::array<const char*, 3> kCameraNames = {
+    "base_0_rgb",
+    "left_wrist_0_rgb",
+    "right_wrist_0_rgb",
+};
+
+Json parse_strict_document(std::string_view text) {
+    std::vector<std::unordered_set<std::string>> object_keys;
+    Json::parser_callback_t reject_duplicate_keys = [&](int, Json::parse_event_t event,
+                                                        Json& value) {
+        if (event == Json::parse_event_t::object_start) {
+            object_keys.emplace_back();
+        } else if (event == Json::parse_event_t::key) {
+            if (object_keys.empty() ||
+                !object_keys.back().insert(value.get<std::string>()).second) {
+                throw std::invalid_argument("duplicate JSON object key");
+            }
+        } else if (event == Json::parse_event_t::object_end) {
+            if (!object_keys.empty())
+                object_keys.pop_back();
+        }
+        return true;
+    };
+
+    try {
+        return Json::parse(text.begin(), text.end(), reject_duplicate_keys);
+    } catch (const std::exception& error) {
+        throw std::invalid_argument(std::string("action request is not valid strict JSON: ") +
+                                    error.what());
+    }
+}
+
+void require_exact_keys(const Json& object, std::initializer_list<const char*> required,
+                        std::initializer_list<const char*> optional, const std::string& context) {
+    if (!object.is_object())
+        throw std::invalid_argument(context + " must be a JSON object");
+
+    std::unordered_set<std::string> accepted;
+    for (const char* key : required) {
+        accepted.emplace(key);
+        if (!object.contains(key))
+            throw std::invalid_argument(context + " is missing '" + key + "'");
+    }
+    for (const char* key : optional)
+        accepted.emplace(key);
+
+    for (const auto& [key, unused] : object.items()) {
+        (void)unused;
+        if (accepted.find(key) == accepted.end())
+            throw std::invalid_argument(context + " has unexpected field '" + key + "'");
+    }
+}
+
+const Json& require_field(const Json& object, const char* key, std::string_view context) {
+    const auto iterator = object.find(key);
+    if (iterator == object.end())
+        throw std::invalid_argument(std::string(context) + " is missing '" + key + "'");
+    return *iterator;
+}
+
+std::string require_nonempty_string(const Json& object, const char* key,
+                                    const std::string& context) {
+    const auto& value = require_field(object, key, context);
+    if (!value.is_string() || value.get_ref<const std::string&>().empty())
+        throw std::invalid_argument(context + " field '" + key + "' must be a non-empty string");
+    return value.get<std::string>();
+}
+
+bool require_bool(const Json& object, const char* key, const std::string& context) {
+    const auto& value = require_field(object, key, context);
+    if (!value.is_boolean())
+        throw std::invalid_argument(context + " field '" + key + "' must be a boolean");
+    return value.get<bool>();
+}
+
+int32_t require_nonnegative_int32(const Json& object, const char* key, const std::string& context,
+                                  bool strictly_positive) {
+    const auto& value = require_field(object, key, context);
+    if (!value.is_number_integer() && !value.is_number_unsigned())
+        throw std::invalid_argument(context + " field '" + key + "' must be an integer");
+
+    std::uint64_t parsed = 0;
+    if (value.is_number_unsigned()) {
+        parsed = value.get<std::uint64_t>();
+    } else {
+        const auto signed_value = value.get<std::int64_t>();
+        if (signed_value < 0)
+            throw std::invalid_argument(context + " field '" + key + "' must be non-negative");
+        parsed = static_cast<std::uint64_t>(signed_value);
+    }
+    if (parsed > static_cast<std::uint64_t>(std::numeric_limits<int32_t>::max()) ||
+        (strictly_positive && parsed == 0U)) {
+        throw std::invalid_argument(
+            context + " field '" + key +
+            (strictly_positive ? "' must be a positive int32" : "' is outside int32 range"));
+    }
+    return static_cast<int32_t>(parsed);
+}
+
+std::vector<float> require_finite_float_array(const Json& object, const char* key,
+                                              const std::string& context) {
+    const auto& value = require_field(object, key, context);
+    if (!value.is_array() || value.empty())
+        throw std::invalid_argument(context + " field '" + key +
+                                    "' must be a non-empty numeric array");
+
+    constexpr std::size_t kMaximumElements = 1U << 20U;
+    if (value.size() > kMaximumElements)
+        throw std::invalid_argument(context + " field '" + key + "' is unreasonably large");
+
+    std::vector<float> result;
+    result.reserve(value.size());
+    for (const auto& element : value) {
+        if (!element.is_number())
+            throw std::invalid_argument(context + " field '" + key + "' must contain only numbers");
+        const double parsed = element.get<double>();
+        if (!std::isfinite(parsed) ||
+            std::fabs(parsed) > static_cast<double>(std::numeric_limits<float>::max())) {
+            throw std::invalid_argument(context + " field '" + key +
+                                        "' contains a non-finite or out-of-range value");
+        }
+        result.push_back(static_cast<float>(parsed));
+    }
+    return result;
+}
+
+void validate_timing(double value, const char* name) {
+    if (!std::isfinite(value) || value < 0.0)
+        throw std::invalid_argument(std::string("action result timing '") + name +
+                                    "' must be finite and non-negative");
+}
+
+} // namespace
+
+ActionRequestFile parse_action_request_json(std::string_view text) {
+    const Json root = parse_strict_document(text);
+    require_exact_keys(root, {"prompt", "cameras", "state"},
+                       {"initial_noise", "seed", "denoise_steps"}, "action request");
+
+    ActionRequestFile result;
+    result.prompt = require_nonempty_string(root, "prompt", "action request");
+    result.state = require_finite_float_array(root, "state", "action request");
+
+    if (root.contains("initial_noise"))
+        result.initial_noise = require_finite_float_array(root, "initial_noise", "action request");
+    if (root.contains("seed"))
+        result.seed = require_nonnegative_int32(root, "seed", "action request", false);
+    if (root.contains("denoise_steps"))
+        result.denoise_steps =
+            require_nonnegative_int32(root, "denoise_steps", "action request", true);
+
+    const auto& cameras = require_field(root, "cameras", "action request");
+    require_exact_keys(cameras, {kCameraNames[0], kCameraNames[1], kCameraNames[2]}, {},
+                       "action request cameras");
+    for (std::size_t index = 0; index < kCameraNames.size(); ++index) {
+        const char* name = kCameraNames[index];
+        const auto& camera = require_field(cameras, name, "action request cameras");
+        const std::string context = std::string("action request camera '") + name + "'";
+        require_exact_keys(camera, {"path", "valid"}, {}, context);
+        result.cameras[index] = ActionCameraFile{
+            name,
+            require_nonempty_string(camera, "path", context),
+            require_bool(camera, "valid", context),
+        };
+    }
+
+    return result;
+}
+
+ActionRequestFile read_action_request_json(const std::string& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input)
+        throw std::runtime_error("failed to open action request JSON: " + path);
+    const std::string text{std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+    if (!input.good() && !input.eof())
+        throw std::runtime_error("failed to read action request JSON: " + path);
+    return parse_action_request_json(text);
+}
+
+std::string serialize_action_result_json(const ActionResult& result) {
+    if (result.horizon <= 0 || result.action_dim <= 0)
+        throw std::invalid_argument("action result horizon and action_dim must be positive");
+    const auto horizon = static_cast<std::size_t>(result.horizon);
+    const auto action_dim = static_cast<std::size_t>(result.action_dim);
+    if (horizon > std::numeric_limits<std::size_t>::max() / action_dim ||
+        result.actions.size() != horizon * action_dim) {
+        throw std::invalid_argument("action result data size does not match horizon * action_dim");
+    }
+    if (std::any_of(result.actions.begin(), result.actions.end(),
+                    [](float value) { return !std::isfinite(value); })) {
+        throw std::invalid_argument("action result contains a non-finite action value");
+    }
+    validate_timing(result.timings.preprocess_ms, "preprocess_ms");
+    validate_timing(result.timings.prefill_ms, "prefill_ms");
+    validate_timing(result.timings.denoise_ms, "denoise_ms");
+    validate_timing(result.timings.postprocess_ms, "postprocess_ms");
+
+    Json output = {
+        {"actions", result.actions},
+        {"horizon", result.horizon},
+        {"action_dim", result.action_dim},
+        {"timings",
+         {
+             {"preprocess_ms", result.timings.preprocess_ms},
+             {"prefill_ms", result.timings.prefill_ms},
+             {"denoise_ms", result.timings.denoise_ms},
+             {"postprocess_ms", result.timings.postprocess_ms},
+         }},
+    };
+    return output.dump();
+}
+
+} // namespace trtmc::openpi::tool

--- a/src/runtime/models/openpi/tool/action_request_json.h
+++ b/src/runtime/models/openpi/tool/action_request_json.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "runtime/models/openpi/api.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace trtmc::openpi::tool {
+
+struct ActionCameraFile {
+    std::string name;
+    std::string path;
+    bool valid{true};
+};
+
+struct ActionRequestFile {
+    std::string prompt;
+    std::array<ActionCameraFile, 3> cameras;
+    std::vector<float> state;
+    std::vector<float> initial_noise;
+    int32_t seed{-1};
+    int32_t denoise_steps{-1};
+};
+
+// Parse the OpenPI runner's `--request-json` schema. The parser rejects
+// duplicate, unknown, missing, mistyped, non-finite, and out-of-range values.
+ActionRequestFile parse_action_request_json(std::string_view text);
+ActionRequestFile read_action_request_json(const std::string& path);
+
+// Serialize the public action result schema after validating the typed result's
+// shape and numeric values. Actions use row-major [horizon, action_dim] order.
+std::string serialize_action_result_json(const ActionResult& result);
+
+} // namespace trtmc::openpi::tool

--- a/src/runtime/models/openpi/tool/main.cpp
+++ b/src/runtime/models/openpi/tool/main.cpp
@@ -1,0 +1,244 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/openpi/api.h"
+#include "runtime/models/openpi/tool/action_request_json.h"
+#include "runtime/models/openpi/tool/qualification_diagnostics.h"
+#include "trtmc/pipeline.h"
+#include "trtmc/trtmc_io.hpp"
+
+#include <algorithm>
+#include <charconv>
+#include <chrono>
+#include <cstddef>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+namespace {
+
+struct RunnerArgs {
+    std::string bundle_path;
+    std::string request_json;
+    std::string output_json;
+    std::string qualification_diagnostics;
+    int benchmark{0};
+    int warmup{1};
+};
+
+void print_usage(std::ostream& output) {
+    output << "Usage: trtmc-openpi <bundle.trtfb> --request-json PATH [--output-json PATH]\n"
+              "                    [--benchmark N] [--warmup N]\n"
+              "                    [--qualification-diagnostics DIR]\n";
+}
+
+int parse_nonnegative_integer(std::string_view text, std::string_view option,
+                              bool strictly_positive) {
+    int value = 0;
+    const auto [end, error] = std::from_chars(text.data(), text.data() + text.size(), value);
+    if (error != std::errc{} || end != text.data() + text.size() || value < 0 ||
+        (strictly_positive && value == 0)) {
+        throw std::invalid_argument(std::string(option) + (strictly_positive
+                                                               ? " expects an integer > 0"
+                                                               : " expects an integer >= 0"));
+    }
+    return value;
+}
+
+std::string require_option_value(int argc, char** argv, int& index, std::string_view option) {
+    if (index + 1 >= argc)
+        throw std::invalid_argument(std::string(option) + " requires a value");
+    return argv[++index];
+}
+
+void parse_option(RunnerArgs& result, int argc, char** argv, int& index, std::string_view option) {
+    const auto value = require_option_value(argc, argv, index, option);
+    if (option == "--request-json") {
+        result.request_json = value;
+    } else if (option == "--output-json") {
+        result.output_json = value;
+    } else if (option == "--qualification-diagnostics") {
+        result.qualification_diagnostics = value;
+    } else if (option == "--benchmark") {
+        result.benchmark = parse_nonnegative_integer(value, option, true);
+    } else {
+        result.warmup = parse_nonnegative_integer(value, option, false);
+    }
+}
+
+bool is_value_option(std::string_view argument) {
+    return argument == "--request-json" || argument == "--output-json" ||
+           argument == "--qualification-diagnostics" || argument == "--benchmark" ||
+           argument == "--warmup";
+}
+
+void parse_argument(RunnerArgs& result, int argc, char** argv, int& index) {
+    const std::string_view argument(argv[index]);
+    if (argument == "--help" || argument == "-h") {
+        print_usage(std::cout);
+        std::exit(EXIT_SUCCESS);
+    }
+    if (is_value_option(argument)) {
+        parse_option(result, argc, argv, index, argument);
+        return;
+    }
+    if (!argument.empty() && argument.front() == '-')
+        throw std::invalid_argument("unknown option: " + std::string(argument));
+    if (result.bundle_path.empty()) {
+        result.bundle_path = argument;
+        return;
+    }
+    throw std::invalid_argument("unexpected positional argument: " + std::string(argument));
+}
+
+void validate_args(const RunnerArgs& result) {
+    if (result.bundle_path.empty() || result.request_json.empty())
+        throw std::invalid_argument("OpenPI runner requires bundle + --request-json");
+    if (!result.qualification_diagnostics.empty() && result.benchmark > 0) {
+        throw std::invalid_argument(
+            "--qualification-diagnostics cannot be combined with --benchmark");
+    }
+}
+
+RunnerArgs parse_args(int argc, char** argv) {
+    if (argc < 2)
+        throw std::invalid_argument("missing OpenPI bundle path");
+
+    RunnerArgs result;
+    for (int index = 1; index < argc; ++index)
+        parse_argument(result, argc, argv, index);
+    validate_args(result);
+    return result;
+}
+
+trtmc::openpi::ActionRequest load_action_request(const RunnerArgs& args) {
+    const auto document = trtmc::openpi::tool::read_action_request_json(args.request_json);
+    const std::filesystem::path request_dir =
+        std::filesystem::path(args.request_json).parent_path();
+
+    trtmc::openpi::ActionRequest request;
+    request.prompt = document.prompt;
+    request.state = document.state;
+    request.initial_noise = document.initial_noise;
+    request.seed = document.seed;
+    request.denoise_steps = document.denoise_steps;
+    request.cameras.reserve(document.cameras.size());
+    for (const auto& camera_file : document.cameras) {
+        std::filesystem::path image_path(camera_file.path);
+        if (image_path.is_relative() && !request_dir.empty())
+            image_path = request_dir / image_path;
+        auto image = trtmc::io::read_image(image_path.string());
+        if (image.empty())
+            throw std::runtime_error("failed to load OpenPI camera image: " + image_path.string());
+
+        trtmc::openpi::RobotImage camera;
+        camera.name = camera_file.name;
+        camera.pixels = std::move(image.pixels);
+        camera.height = image.height;
+        camera.width = image.width;
+        camera.channels = 3;
+        camera.valid = camera_file.valid;
+        if (!camera.valid)
+            std::fill(camera.pixels.begin(), camera.pixels.end(), 0.0F);
+        request.cameras.push_back(std::move(camera));
+    }
+    return request;
+}
+
+double nearest_rank_percentile(std::vector<double> values, std::size_t percentile) {
+    if (values.empty() || percentile == 0U || percentile > 100U)
+        throw std::invalid_argument("invalid benchmark percentile request");
+    std::sort(values.begin(), values.end());
+    const std::size_t rank = (percentile * values.size() + 99U) / 100U;
+    return values[rank - 1U];
+}
+
+void write_result(const RunnerArgs& args, const trtmc::openpi::ActionResult& result) {
+    const std::string output = trtmc::openpi::tool::serialize_action_result_json(result);
+    if (args.output_json.empty()) {
+        std::cout << output << '\n';
+        return;
+    }
+
+    const std::filesystem::path output_path(args.output_json);
+    const auto parent = output_path.parent_path();
+    if (!parent.empty())
+        std::filesystem::create_directories(parent);
+    std::ofstream stream(output_path, std::ios::out | std::ios::trunc);
+    if (!stream)
+        throw std::runtime_error("failed to open action result JSON: " + args.output_json);
+    stream << output << '\n';
+    if (!stream)
+        throw std::runtime_error("failed to write action result JSON: " + args.output_json);
+    std::cerr << "Actions saved: " << args.output_json << '\n';
+}
+
+int run(const RunnerArgs& args) {
+    const auto request = load_action_request(args);
+    auto pipeline = trtmc::load(args.bundle_path);
+    if (!pipeline)
+        throw std::runtime_error("failed to load OpenPI bundle");
+
+    auto* action_pipeline = dynamic_cast<trtmc::openpi::IOpenPIActionPipeline*>(pipeline.get());
+    if (action_pipeline == nullptr)
+        throw std::runtime_error("bundle does not implement OpenPI action inference");
+
+    trtmc::openpi::ActionResult result;
+    if (!args.qualification_diagnostics.empty()) {
+        auto* diagnostic_pipeline =
+            dynamic_cast<trtmc::openpi::IOpenPIDiagnosticPipeline*>(pipeline.get());
+        if (diagnostic_pipeline == nullptr)
+            throw std::runtime_error("bundle does not implement OpenPI qualification capture");
+        auto diagnostics = diagnostic_pipeline->predict_actions_with_diagnostics(request);
+        result = diagnostics.result;
+        const auto manifest = trtmc::openpi::tool::write_qualification_diagnostics(
+            diagnostics, args.qualification_diagnostics, pipeline->model_id());
+        std::cerr << "Qualification diagnostics saved: " << manifest.string() << '\n';
+    } else if (args.benchmark > 0) {
+        for (int iteration = 0; iteration < args.warmup; ++iteration)
+            result = action_pipeline->predict_actions(request);
+
+        std::vector<double> wall_times_ms;
+        wall_times_ms.reserve(static_cast<std::size_t>(args.benchmark));
+        for (int iteration = 0; iteration < args.benchmark; ++iteration) {
+            const auto begin = std::chrono::steady_clock::now();
+            result = action_pipeline->predict_actions(request);
+            const auto end = std::chrono::steady_clock::now();
+            wall_times_ms.push_back(std::chrono::duration<double, std::milli>(end - begin).count());
+        }
+        const double mean = std::accumulate(wall_times_ms.begin(), wall_times_ms.end(), 0.0) /
+                            static_cast<double>(wall_times_ms.size());
+        std::cerr << std::fixed << std::setprecision(6)
+                  << "[trtmc.openpi.benchmark] action_ms=" << mean
+                  << " p50_ms=" << nearest_rank_percentile(wall_times_ms, 50U)
+                  << " p95_ms=" << nearest_rank_percentile(wall_times_ms, 95U)
+                  << " iterations=" << args.benchmark << " warmup=" << args.warmup << '\n';
+    } else {
+        result = action_pipeline->predict_actions(request);
+    }
+
+    write_result(args, result);
+    return EXIT_SUCCESS;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        return run(parse_args(argc, argv));
+    } catch (const std::exception& error) {
+        std::cerr << "Error: " << error.what() << '\n';
+        print_usage(std::cerr);
+        return EXIT_FAILURE;
+    }
+}

--- a/src/runtime/models/openpi/tool/qualification_diagnostics.cpp
+++ b/src/runtime/models/openpi/tool/qualification_diagnostics.cpp
@@ -1,0 +1,231 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/openpi/tool/qualification_diagnostics.h"
+
+#include "utils/sha256.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+
+namespace trtmc::openpi::tool {
+namespace {
+
+using Json = nlohmann::json;
+
+std::string_view dtype_name(DiagnosticTensorType dtype) {
+    switch (dtype) {
+    case DiagnosticTensorType::kBool:
+        return "bool";
+    case DiagnosticTensorType::kInt32:
+        return "int32";
+    case DiagnosticTensorType::kBFloat16:
+        return "bfloat16";
+    case DiagnosticTensorType::kFloat32:
+        return "float32";
+    }
+    throw std::invalid_argument("qualification diagnostic has an unknown dtype");
+}
+
+std::size_t dtype_width(DiagnosticTensorType dtype) {
+    switch (dtype) {
+    case DiagnosticTensorType::kBool:
+        return 1U;
+    case DiagnosticTensorType::kBFloat16:
+        return 2U;
+    case DiagnosticTensorType::kInt32:
+    case DiagnosticTensorType::kFloat32:
+        return 4U;
+    }
+    throw std::invalid_argument("qualification diagnostic has an unknown dtype");
+}
+
+std::string_view stage_name(DiagnosticStage stage) {
+    switch (stage) {
+    case DiagnosticStage::kPreprocess:
+        return "preprocess";
+    case DiagnosticStage::kVision:
+        return "vision";
+    case DiagnosticStage::kPrefix:
+        return "prefix";
+    case DiagnosticStage::kFlow:
+        return "flow";
+    case DiagnosticStage::kPostprocess:
+        return "postprocess";
+    }
+    throw std::invalid_argument("qualification diagnostic has an unknown stage");
+}
+
+std::string_view role_name(DiagnosticRole role) {
+    switch (role) {
+    case DiagnosticRole::kInput:
+        return "input";
+    case DiagnosticRole::kIntermediate:
+        return "intermediate";
+    case DiagnosticRole::kOutput:
+        return "output";
+    }
+    throw std::invalid_argument("qualification diagnostic has an unknown role");
+}
+
+std::size_t expected_bytes(const DiagnosticTensor& tensor) {
+    if (tensor.shape.empty())
+        throw std::invalid_argument("qualification diagnostic tensor shape must not be empty");
+    std::size_t elements = 1U;
+    for (int64_t dimension : tensor.shape) {
+        if (dimension <= 0 || elements > std::numeric_limits<std::size_t>::max() /
+                                             static_cast<std::size_t>(dimension)) {
+            throw std::invalid_argument("qualification diagnostic tensor shape is invalid");
+        }
+        elements *= static_cast<std::size_t>(dimension);
+    }
+    const std::size_t width = dtype_width(tensor.dtype);
+    if (elements > std::numeric_limits<std::size_t>::max() / width)
+        throw std::overflow_error("qualification diagnostic tensor size overflow");
+    return elements * width;
+}
+
+bool safe_tensor_name(std::string_view name) {
+    const auto accepted = [](const char character) {
+        const bool lowercase = character >= 'a' && character <= 'z';
+        const bool uppercase = character >= 'A' && character <= 'Z';
+        const bool digit = character >= '0' && character <= '9';
+        return lowercase || uppercase || digit || character == '_' || character == '.' ||
+               character == '-';
+    };
+    return !name.empty() && std::all_of(name.begin(), name.end(), accepted);
+}
+
+std::string sha256_bytes(const std::vector<uint8_t>& bytes) {
+    internal::Sha256 digest;
+    digest.update(bytes.data(), bytes.size());
+    return digest.hex_digest();
+}
+
+void write_bytes(const std::filesystem::path& path, const std::vector<uint8_t>& bytes) {
+    std::ofstream output(path, std::ios::binary | std::ios::out | std::ios::trunc);
+    if (!output)
+        throw std::runtime_error("failed to create qualification tensor: " + path.string());
+    output.write(reinterpret_cast<const char*>(bytes.data()),
+                 static_cast<std::streamsize>(bytes.size()));
+    if (!output)
+        throw std::runtime_error("failed to write qualification tensor: " + path.string());
+}
+
+void validate_diagnostic_output(const ActionDiagnosticResult& diagnostics,
+                                const std::filesystem::path& output_directory) {
+    constexpr uint16_t endian_marker = 1U;
+    if (*reinterpret_cast<const uint8_t*>(&endian_marker) != 1U)
+        throw std::runtime_error("qualification diagnostics require a little-endian host");
+    if (diagnostics.tensors.empty())
+        throw std::invalid_argument("qualification diagnostics contain no tensors");
+    if (output_directory.empty())
+        throw std::invalid_argument("qualification diagnostics directory must not be empty");
+    if (std::filesystem::exists(output_directory)) {
+        throw std::invalid_argument("qualification diagnostics directory already exists: " +
+                                    output_directory.string());
+    }
+}
+
+std::filesystem::path make_staging_directory(const std::filesystem::path& output_directory) {
+    const auto parent = output_directory.parent_path().empty() ? std::filesystem::current_path()
+                                                               : output_directory.parent_path();
+    std::filesystem::create_directories(parent);
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto staging =
+        parent / ("." + output_directory.filename().string() + ".tmp-" + std::to_string(nonce));
+    if (std::filesystem::exists(staging))
+        throw std::runtime_error("qualification diagnostics staging directory already exists");
+    return staging;
+}
+
+void validate_tensor_name(const DiagnosticTensor& tensor, std::unordered_set<std::string>& names) {
+    if (!safe_tensor_name(tensor.name) || !names.insert(tensor.name).second) {
+        throw std::invalid_argument("qualification diagnostic tensor name is unsafe or "
+                                    "duplicated: " +
+                                    tensor.name);
+    }
+}
+
+Json tensor_descriptor(const DiagnosticTensor& tensor,
+                       const std::filesystem::path& tensor_directory,
+                       std::unordered_set<std::string>& names) {
+    validate_tensor_name(tensor, names);
+    const std::size_t byte_count = expected_bytes(tensor);
+    if (tensor.bytes.size() != byte_count) {
+        throw std::invalid_argument("qualification diagnostic tensor byte count mismatch: " +
+                                    tensor.name);
+    }
+    const auto payload = tensor_directory / (tensor.name + ".bin");
+    write_bytes(payload, tensor.bytes);
+    return {
+        {"path", "tensors/" + tensor.name + ".bin"},
+        {"stage", stage_name(tensor.stage)},
+        {"role", role_name(tensor.role)},
+        {"dtype", dtype_name(tensor.dtype)},
+        {"shape", tensor.shape},
+        {"byte_length", byte_count},
+        {"sha256", sha256_bytes(tensor.bytes)},
+    };
+}
+
+Json write_tensor_payloads(const ActionDiagnosticResult& diagnostics,
+                           const std::filesystem::path& staging) {
+    const auto tensor_directory = staging / "tensors";
+    std::filesystem::create_directories(tensor_directory);
+    Json descriptors = Json::object();
+    std::unordered_set<std::string> names;
+    for (const auto& tensor : diagnostics.tensors)
+        descriptors[tensor.name] = tensor_descriptor(tensor, tensor_directory, names);
+    return descriptors;
+}
+
+void write_manifest(const std::filesystem::path& staging, std::string_view model_id,
+                    Json tensor_descriptors) {
+    const Json manifest = {
+        {"schema_version", 1},
+        {"artifact_type", "trtmc_action_qualification_diagnostics"},
+        {"runtime_contract", "native_cpp_tensorrt"},
+        {"model_id", std::string(model_id)},
+        {"tensors", std::move(tensor_descriptors)},
+    };
+    const auto manifest_path = staging / "manifest.json";
+    std::ofstream output(manifest_path, std::ios::out | std::ios::trunc);
+    if (!output)
+        throw std::runtime_error("failed to create qualification diagnostics manifest");
+    output << manifest.dump(2) << '\n';
+    if (!output)
+        throw std::runtime_error("failed to write qualification diagnostics manifest");
+}
+
+} // namespace
+
+std::filesystem::path write_qualification_diagnostics(const ActionDiagnosticResult& diagnostics,
+                                                      const std::filesystem::path& output_directory,
+                                                      std::string_view model_id) {
+    validate_diagnostic_output(diagnostics, output_directory);
+    const auto staging = make_staging_directory(output_directory);
+
+    try {
+        write_manifest(staging, model_id, write_tensor_payloads(diagnostics, staging));
+        std::filesystem::rename(staging, output_directory);
+        return output_directory / "manifest.json";
+    } catch (...) {
+        std::error_code cleanup_error;
+        std::filesystem::remove_all(staging, cleanup_error);
+        throw;
+    }
+}
+
+} // namespace trtmc::openpi::tool

--- a/src/runtime/models/openpi/tool/qualification_diagnostics.h
+++ b/src/runtime/models/openpi/tool/qualification_diagnostics.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "runtime/models/openpi/api.h"
+
+#include <filesystem>
+#include <string_view>
+
+namespace trtmc::openpi::tool {
+
+// Atomically write qualification-only tensor payloads beneath a new
+// directory. The returned manifest uses the same tensor descriptor fields as
+// the OpenPI reference artifacts consumed by the model-owned E2E harness.
+std::filesystem::path write_qualification_diagnostics(const ActionDiagnosticResult& diagnostics,
+                                                      const std::filesystem::path& output_directory,
+                                                      std::string_view model_id);
+
+} // namespace trtmc::openpi::tool

--- a/src/runtime/models/openpi/trt_plugins/action_attention_context_plugin.cu
+++ b/src/runtime/models/openpi/trt_plugins/action_attention_context_plugin.cu
@@ -1,0 +1,619 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <NvInferRuntime.h>
+#include <cstddef>
+#include <cstdint>
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <new>
+#include <string>
+
+namespace trtmc::openpi {
+
+int32_t launch_openpi_action_attention_context(const std::uint16_t* query, const std::uint16_t* key,
+                                               const std::uint16_t* value,
+                                               const std::uint8_t* attention_mask,
+                                               std::uint16_t* output, void* workspace,
+                                               void* cublas_handle, cudaStream_t stream) noexcept;
+
+namespace {
+
+constexpr int32_t kBatch = 1;
+constexpr int32_t kQueryHeads = 8;
+constexpr int32_t kKeyHeads = 1;
+constexpr int32_t kQueryRows = 15;
+constexpr int32_t kKeyRows = 983;
+constexpr int32_t kPaddedKeyRows = 984;
+constexpr int32_t kHeadDimension = 256;
+constexpr int32_t kOutputWidth = kQueryHeads * kHeadDimension;
+constexpr int32_t kFlattenedQueries = kQueryHeads * kQueryRows;
+
+constexpr std::size_t kPackedQueryElements =
+    static_cast<std::size_t>(kFlattenedQueries) * kHeadDimension;
+constexpr std::size_t kPackedKeyElements =
+    static_cast<std::size_t>(kPaddedKeyRows) * kHeadDimension;
+constexpr std::size_t kLogitElements = static_cast<std::size_t>(kPaddedKeyRows) * kFlattenedQueries;
+constexpr std::size_t kProbabilityElements =
+    static_cast<std::size_t>(kFlattenedQueries) * kPaddedKeyRows;
+constexpr std::size_t kContextElements =
+    static_cast<std::size_t>(kHeadDimension) * kFlattenedQueries;
+
+constexpr std::size_t kPackedQueryBytes = kPackedQueryElements * sizeof(std::uint16_t);
+constexpr std::size_t kPackedKeyBytes = kPackedKeyElements * sizeof(std::uint16_t);
+constexpr std::size_t kLogitBytes = kLogitElements * sizeof(float);
+
+// Exact scratch allocations attached to custom-call.65 and custom-call.66 in
+// the pinned JAX 0.5.3 / XLA action executable.
+constexpr std::size_t kQkCublasWorkspaceBytes = 565248;
+constexpr std::size_t kPvCublasWorkspaceBytes = 739968;
+
+// Phase liveness keeps the workspace compact without aliasing a live tensor:
+// softmax probabilities overwrite dead padded K after QK, and raw PV context
+// overwrites dead FP32 logits after softmax.
+constexpr std::size_t kPackedQueryOffset = 0;
+constexpr std::size_t kPackedKeyOffset = kPackedQueryOffset + kPackedQueryBytes;
+constexpr std::size_t kPackedValueOffset = kPackedKeyOffset + kPackedKeyBytes;
+constexpr std::size_t kLogitOffset = kPackedValueOffset + kPackedKeyBytes;
+constexpr std::size_t kCublasWorkspaceOffset = kLogitOffset + kLogitBytes;
+constexpr std::size_t kPluginWorkspaceBytes = kCublasWorkspaceOffset + kPvCublasWorkspaceBytes;
+static_assert(kQkCublasWorkspaceBytes <= kPvCublasWorkspaceBytes);
+static_assert(kProbabilityElements * sizeof(std::uint16_t) <= kPackedKeyBytes);
+static_assert(kContextElements * sizeof(std::uint16_t) <= kLogitBytes);
+static_assert(kPluginWorkspaceBytes == 2281344);
+
+constexpr int32_t kPointwiseThreads = 256;
+constexpr int32_t kSoftmaxThreads = 128;
+constexpr int32_t kSoftmaxBlocks = kQueryHeads * kQueryRows / 2;
+constexpr int32_t kSoftmaxTiles = 8;
+
+__device__ __forceinline__ float bf16_to_float(std::uint16_t value) {
+    return __uint_as_float(static_cast<std::uint32_t>(value) << 16U);
+}
+
+__device__ __forceinline__ std::uint16_t float_to_bf16_rn(float value) {
+    std::uint32_t bits = __float_as_uint(value);
+    if ((bits & 0x7FFFFFFFU) > 0x7F800000U) {
+        return static_cast<std::uint16_t>((bits >> 16U) | 0x0040U);
+    }
+    bits += 0x00007FFFU + ((bits >> 16U) & 1U);
+    return static_cast<std::uint16_t>(bits >> 16U);
+}
+
+__device__ __forceinline__ std::uint16_t bf16_multiply_rn(std::uint16_t lhs, std::uint16_t rhs) {
+    return float_to_bf16_rn(__fmul_rn(bf16_to_float(lhs), bf16_to_float(rhs)));
+}
+
+__device__ __forceinline__ float full_divide(float numerator, float denominator) {
+    float result;
+    asm("div.full.f32 %0, %1, %2;" : "=f"(result) : "f"(numerator), "f"(denominator));
+    return result;
+}
+
+// Exact libdevice exp lowering emitted inside action fusion.86.
+__device__ __forceinline__ float openpi_action_expf(float value) {
+    const float scaled =
+        __fmaf_rn(value, __uint_as_float(0x3BBB989DU), __uint_as_float(0x3F000000U));
+    float saturated;
+    asm("cvt.sat.f32.f32 %0, %1;" : "=f"(saturated) : "f"(scaled));
+    const float exponent =
+        __fmaf_rd(saturated, __uint_as_float(0x437C0000U), __uint_as_float(0x4B400001U));
+    const float rounded = __fadd_rn(exponent, __uint_as_float(0xCB40007FU));
+    float reduced = __fmaf_rn(value, __uint_as_float(0x3FB8AA3BU), -rounded);
+    reduced = __fmaf_rn(value, __uint_as_float(0x32A57060U), reduced);
+    const float power_of_two = __uint_as_float(__float_as_uint(exponent) << 23U);
+    float exponential;
+    asm("ex2.approx.ftz.f32 %0, %1;" : "=f"(exponential) : "f"(reduced));
+    return __fmul_rn(exponential, power_of_two);
+}
+
+// Pack XLA's physical operands in one pass. Q is converted from TensorRT's
+// [head,token,dimension] layout to [token,head,dimension] and multiplied at
+// the BF16 boundary by 1/sqrt(256) == 0.0625. K/V receive XLA's zero row 983.
+__global__ void openpi_action_attention_pack_kernel(const std::uint16_t* __restrict__ query,
+                                                    const std::uint16_t* __restrict__ key,
+                                                    const std::uint16_t* __restrict__ value,
+                                                    std::uint16_t* __restrict__ packed_query,
+                                                    std::uint16_t* __restrict__ padded_key,
+                                                    std::uint16_t* __restrict__ padded_value) {
+    const std::size_t index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index < kPackedQueryElements) {
+        const int32_t flattened = static_cast<int32_t>(index / kHeadDimension);
+        const int32_t dimension = static_cast<int32_t>(index % kHeadDimension);
+        const int32_t token = flattened / kQueryHeads;
+        const int32_t head = flattened % kQueryHeads;
+        const std::size_t source =
+            (static_cast<std::size_t>(head) * kQueryRows + token) * kHeadDimension + dimension;
+        packed_query[index] = bf16_multiply_rn(query[source], 0x3D80U);
+    }
+    if (index < kPackedKeyElements) {
+        if (index < static_cast<std::size_t>(kKeyRows) * kHeadDimension) {
+            padded_key[index] = key[index];
+            padded_value[index] = value[index];
+        } else {
+            padded_key[index] = 0;
+            padded_value[index] = 0;
+        }
+    }
+}
+
+__device__ __forceinline__ float warp_xor_max(float value) {
+#pragma unroll
+    for (int32_t offset = 16; offset > 0; offset >>= 1) {
+        value = fmaxf(value, __shfl_xor_sync(0xFFFFFFFFU, value, offset, 32));
+    }
+    return value;
+}
+
+__device__ __forceinline__ float warp_xor_sum(float value) {
+#pragma unroll
+    for (int32_t offset = 16; offset > 0; offset >>= 1) {
+        value = __fadd_rn(value, __shfl_xor_sync(0xFFFFFFFFU, value, offset, 32));
+    }
+    return value;
+}
+
+// fusion.86 launches 60 four-warp CTAs. A CTA owns one query and two adjacent
+// heads; each thread consumes eight keys separated by 128. Both the serial
+// per-thread association and the warp/cross-warp XOR trees mirror the pinned
+// PTX. Probabilities are written as padded [head*query,984] BF16 rows.
+__global__ void
+openpi_action_attention_softmax_kernel(const float* __restrict__ logits,
+                                       const std::uint8_t* __restrict__ attention_mask,
+                                       std::uint16_t* __restrict__ probabilities) {
+    __shared__ float partials[8];
+
+    const int32_t thread = threadIdx.x;
+    const int32_t lane = thread & 31;
+    const int32_t warp = thread >> 5;
+    const int32_t query = blockIdx.x % kQueryRows;
+    const int32_t first_head = (blockIdx.x / kQueryRows) * 2;
+    const int32_t logit_row0 = query * kQueryHeads + first_head;
+    const int32_t logit_row1 = logit_row0 + 1;
+    const int32_t probability_row0 = first_head * kQueryRows + query;
+    const int32_t probability_row1 = probability_row0 + kQueryRows;
+    constexpr float kNegative = -2.38197633e38F;
+    constexpr float kNegativeInfinity = -__builtin_inff();
+
+    float values0[kSoftmaxTiles];
+    float values1[kSoftmaxTiles];
+    bool valid[kSoftmaxTiles];
+#pragma unroll
+    for (int32_t tile = 0; tile < kSoftmaxTiles; ++tile) {
+        const int32_t key = thread + tile * kSoftmaxThreads;
+        valid[tile] = key < kKeyRows;
+        if (valid[tile]) {
+            const bool keep = attention_mask[query * kKeyRows + key];
+            const std::size_t logit_base = static_cast<std::size_t>(key) * kFlattenedQueries;
+            values0[tile] = keep ? logits[logit_base + logit_row0] : kNegative;
+            values1[tile] = keep ? logits[logit_base + logit_row1] : kNegative;
+        } else {
+            values0[tile] = kNegativeInfinity;
+            values1[tile] = kNegativeInfinity;
+        }
+    }
+
+    float maximum0 = values0[0];
+    float maximum1 = values1[0];
+#pragma unroll
+    for (int32_t tile = 1; tile < kSoftmaxTiles; ++tile) {
+        if (valid[tile]) {
+            maximum0 = fmaxf(maximum0, values0[tile]);
+            maximum1 = fmaxf(maximum1, values1[tile]);
+        }
+    }
+    maximum0 = warp_xor_max(maximum0);
+    maximum1 = warp_xor_max(maximum1);
+    if (lane == 0) {
+        partials[warp] = maximum0;
+        partials[warp + 4] = maximum1;
+    }
+    __syncthreads();
+
+    float group_maximum = thread < 8 ? partials[thread] : kNegativeInfinity;
+    group_maximum = fmaxf(group_maximum, __shfl_xor_sync(0xFFFFFFFFU, group_maximum, 2, 32));
+    group_maximum = fmaxf(group_maximum, __shfl_xor_sync(0xFFFFFFFFU, group_maximum, 1, 32));
+    if (thread == 0 || thread == 4) {
+        partials[thread] = group_maximum;
+    }
+    __syncthreads();
+    maximum0 = partials[0];
+    maximum1 = partials[4];
+    // Do not let warp leaders reuse partials for the sum reduction until
+    // every thread has consumed both broadcast maxima.
+    __syncthreads();
+
+    float exponentials0[kSoftmaxTiles];
+    float exponentials1[kSoftmaxTiles];
+#pragma unroll
+    for (int32_t tile = 0; tile < kSoftmaxTiles; ++tile) {
+        if (valid[tile]) {
+            exponentials0[tile] = openpi_action_expf(__fsub_rn(values0[tile], maximum0));
+            exponentials1[tile] = openpi_action_expf(__fsub_rn(values1[tile], maximum1));
+        } else {
+            exponentials0[tile] = 0.0F;
+            exponentials1[tile] = 0.0F;
+        }
+    }
+
+    float sum0 = exponentials0[0];
+    float sum1 = exponentials1[0];
+#pragma unroll
+    for (int32_t tile = 1; tile < kSoftmaxTiles; ++tile) {
+        sum0 = __fadd_rn(sum0, exponentials0[tile]);
+        sum1 = __fadd_rn(sum1, exponentials1[tile]);
+    }
+    sum0 = warp_xor_sum(sum0);
+    sum1 = warp_xor_sum(sum1);
+    if (lane == 0) {
+        partials[warp] = sum0;
+        partials[warp + 4] = sum1;
+    }
+    __syncthreads();
+
+    float group_sum = thread < 8 ? partials[thread] : 0.0F;
+    group_sum = __fadd_rn(group_sum, __shfl_xor_sync(0xFFFFFFFFU, group_sum, 2, 32));
+    group_sum = __fadd_rn(group_sum, __shfl_xor_sync(0xFFFFFFFFU, group_sum, 1, 32));
+    if (thread == 0 || thread == 4) {
+        partials[thread] = group_sum;
+    }
+    __syncthreads();
+    sum0 = partials[0];
+    sum1 = partials[4];
+
+#pragma unroll
+    for (int32_t tile = 0; tile < kSoftmaxTiles; ++tile) {
+        const int32_t key = thread + tile * kSoftmaxThreads;
+        if (key < kPaddedKeyRows) {
+            const std::uint16_t probability0 =
+                key < kKeyRows ? float_to_bf16_rn(full_divide(exponentials0[tile], sum0)) : 0;
+            const std::uint16_t probability1 =
+                key < kKeyRows ? float_to_bf16_rn(full_divide(exponentials1[tile], sum1)) : 0;
+            probabilities[static_cast<std::size_t>(probability_row0) * kPaddedKeyRows + key] =
+                probability0;
+            probabilities[static_cast<std::size_t>(probability_row1) * kPaddedKeyRows + key] =
+                probability1;
+        }
+    }
+}
+
+__global__ void
+openpi_action_attention_context_to_rows_kernel(const std::uint16_t* __restrict__ raw_context,
+                                               std::uint16_t* __restrict__ output) {
+    const std::size_t index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index >= kPackedQueryElements) {
+        return;
+    }
+    const int32_t flattened = static_cast<int32_t>(index / kHeadDimension);
+    const int32_t dimension = static_cast<int32_t>(index % kHeadDimension);
+    const int32_t token = flattened / kQueryHeads;
+    const int32_t head = flattened % kQueryHeads;
+    const int32_t source_column = head * kQueryRows + token;
+    output[index] =
+        raw_context[static_cast<std::size_t>(dimension) * kFlattenedQueries + source_column];
+}
+
+bool is_bf16_linear(nvinfer1::PluginTensorDesc const& descriptor) {
+    return descriptor.type == nvinfer1::DataType::kBF16 &&
+           descriptor.format == nvinfer1::TensorFormat::kLINEAR;
+}
+
+bool is_bool_linear(nvinfer1::PluginTensorDesc const& descriptor) {
+    return descriptor.type == nvinfer1::DataType::kBOOL &&
+           descriptor.format == nvinfer1::TensorFormat::kLINEAR;
+}
+
+bool has_query_shape(nvinfer1::Dims const& dims) {
+    return dims.nbDims == 4 && dims.d[0] == kBatch && dims.d[1] == kQueryHeads &&
+           dims.d[2] == kQueryRows && dims.d[3] == kHeadDimension;
+}
+
+bool has_key_value_shape(nvinfer1::Dims const& dims) {
+    return dims.nbDims == 4 && dims.d[0] == kBatch && dims.d[1] == kKeyHeads &&
+           dims.d[2] == kKeyRows && dims.d[3] == kHeadDimension;
+}
+
+bool has_mask_shape(nvinfer1::Dims const& dims) {
+    return dims.nbDims == 4 && dims.d[0] == kBatch && dims.d[1] == 1 && dims.d[2] == kQueryRows &&
+           dims.d[3] == kKeyRows;
+}
+
+bool has_output_shape(nvinfer1::Dims const& dims) {
+    return dims.nbDims == 3 && dims.d[0] == kBatch && dims.d[1] == kQueryRows &&
+           dims.d[2] == kOutputWidth;
+}
+
+bool has_supported_dimensions(nvinfer1::Dims const* inputs, nvinfer1::Dims const& output) {
+    return has_query_shape(inputs[0]) && has_key_value_shape(inputs[1]) &&
+           has_key_value_shape(inputs[2]) && has_mask_shape(inputs[3]) && has_output_shape(output);
+}
+
+bool has_supported_shape(nvinfer1::PluginTensorDesc const* inputs, int32_t nb_inputs,
+                         nvinfer1::PluginTensorDesc const* outputs, int32_t nb_outputs) {
+    if (inputs == nullptr || outputs == nullptr || nb_inputs != 4 || nb_outputs != 1 ||
+        !is_bf16_linear(inputs[0]) || !is_bf16_linear(inputs[1]) || !is_bf16_linear(inputs[2]) ||
+        !is_bool_linear(inputs[3]) || !is_bf16_linear(outputs[0])) {
+        return false;
+    }
+    nvinfer1::Dims input_dims[4] = {inputs[0].dims, inputs[1].dims, inputs[2].dims, inputs[3].dims};
+    return has_supported_dimensions(input_dims, outputs[0].dims);
+}
+
+bool has_supported_dynamic_shape(nvinfer1::DynamicPluginTensorDesc const* inputs, int32_t nb_inputs,
+                                 nvinfer1::DynamicPluginTensorDesc const* outputs,
+                                 int32_t nb_outputs) {
+    if (inputs == nullptr || outputs == nullptr || nb_inputs != 4 || nb_outputs != 1) {
+        return false;
+    }
+    nvinfer1::PluginTensorDesc input_desc[4] = {inputs[0].desc, inputs[1].desc, inputs[2].desc,
+                                                inputs[3].desc};
+    const nvinfer1::PluginTensorDesc output_desc[1] = {outputs[0].desc};
+    nvinfer1::Dims minimum[4] = {inputs[0].min, inputs[1].min, inputs[2].min, inputs[3].min};
+    nvinfer1::Dims maximum[4] = {inputs[0].max, inputs[1].max, inputs[2].max, inputs[3].max};
+    return has_supported_shape(input_desc, 4, output_desc, 1) &&
+           has_supported_dimensions(minimum, outputs[0].min) &&
+           has_supported_dimensions(maximum, outputs[0].max);
+}
+
+int32_t configure_cublas(cublasHandle_t handle, cudaStream_t stream, void* workspace,
+                         std::size_t workspace_bytes) noexcept {
+    cublasStatus_t status = cublasSetStream(handle, stream);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+    status = cublasSetWorkspace(handle, workspace, workspace_bytes);
+    return status == CUBLAS_STATUS_SUCCESS ? 0 : 1;
+}
+
+class OpenPIActionAttentionContextPlugin final : public nvinfer1::IPluginV3,
+                                                 public nvinfer1::IPluginV3OneCore,
+                                                 public nvinfer1::IPluginV3OneBuild,
+                                                 public nvinfer1::IPluginV3OneRuntime {
+  public:
+    static constexpr const char* kName = "OpenPIActionAttentionContext";
+    static constexpr const char* kVersion = "1";
+
+    OpenPIActionAttentionContextPlugin() { serialization_fields_.nbFields = 0; }
+
+    ~OpenPIActionAttentionContextPlugin() override {
+        if (cublas_handle_ != nullptr) {
+            static_cast<void>(cublasDestroy(cublas_handle_));
+            cublas_handle_ = nullptr;
+        }
+    }
+
+    nvinfer1::IPluginCapability*
+    getCapabilityInterface(nvinfer1::PluginCapabilityType type) noexcept override {
+        switch (type) {
+        case nvinfer1::PluginCapabilityType::kCORE:
+            return static_cast<nvinfer1::IPluginV3OneCore*>(this);
+        case nvinfer1::PluginCapabilityType::kBUILD:
+            return static_cast<nvinfer1::IPluginV3OneBuild*>(this);
+        case nvinfer1::PluginCapabilityType::kRUNTIME:
+            return static_cast<nvinfer1::IPluginV3OneRuntime*>(this);
+        }
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV3* clone() noexcept override {
+        auto* plugin = new (std::nothrow) OpenPIActionAttentionContextPlugin();
+        if (plugin != nullptr) {
+            plugin->namespace_ = namespace_;
+        }
+        return plugin;
+    }
+
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override { return kName; }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override { return kVersion; }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override {
+        return namespace_.c_str();
+    }
+
+    int32_t configurePlugin(nvinfer1::DynamicPluginTensorDesc const* inputs, int32_t nb_inputs,
+                            nvinfer1::DynamicPluginTensorDesc const* outputs,
+                            int32_t nb_outputs) noexcept override {
+        return has_supported_dynamic_shape(inputs, nb_inputs, outputs, nb_outputs) ? 0 : 1;
+    }
+
+    int32_t getOutputDataTypes(nvinfer1::DataType* output_types, int32_t nb_outputs,
+                               nvinfer1::DataType const* input_types,
+                               int32_t nb_inputs) const noexcept override {
+        if (output_types == nullptr || input_types == nullptr || nb_outputs != 1 ||
+            nb_inputs != 4 || input_types[0] != nvinfer1::DataType::kBF16 ||
+            input_types[1] != nvinfer1::DataType::kBF16 ||
+            input_types[2] != nvinfer1::DataType::kBF16 ||
+            input_types[3] != nvinfer1::DataType::kBOOL) {
+            return 1;
+        }
+        output_types[0] = nvinfer1::DataType::kBF16;
+        return 0;
+    }
+
+    int32_t getOutputShapes(nvinfer1::DimsExprs const* inputs, int32_t nb_inputs,
+                            nvinfer1::DimsExprs const*, int32_t nb_shape_inputs,
+                            nvinfer1::DimsExprs* outputs, int32_t nb_outputs,
+                            nvinfer1::IExprBuilder& expression_builder) noexcept override {
+        if (inputs == nullptr || outputs == nullptr || nb_inputs != 4 || nb_shape_inputs != 0 ||
+            nb_outputs != 1) {
+            return 1;
+        }
+        outputs[0].nbDims = 3;
+        outputs[0].d[0] = inputs[0].d[0];
+        outputs[0].d[1] = inputs[0].d[2];
+        outputs[0].d[2] = expression_builder.constant(kOutputWidth);
+        return 0;
+    }
+
+    bool supportsFormatCombination(int32_t position,
+                                   nvinfer1::DynamicPluginTensorDesc const* descriptors,
+                                   int32_t nb_inputs, int32_t nb_outputs) noexcept override {
+        if (descriptors == nullptr || nb_inputs != 4 || nb_outputs != 1 || position < 0 ||
+            position >= 5) {
+            return false;
+        }
+        return position == 3 ? is_bool_linear(descriptors[position].desc)
+                             : is_bf16_linear(descriptors[position].desc);
+    }
+
+    int32_t getNbOutputs() const noexcept override { return 1; }
+
+    std::size_t getWorkspaceSize(nvinfer1::DynamicPluginTensorDesc const*, int32_t,
+                                 nvinfer1::DynamicPluginTensorDesc const*,
+                                 int32_t) const noexcept override {
+        return kPluginWorkspaceBytes;
+    }
+
+    int32_t onShapeChange(nvinfer1::PluginTensorDesc const* inputs, int32_t nb_inputs,
+                          nvinfer1::PluginTensorDesc const* outputs,
+                          int32_t nb_outputs) noexcept override {
+        return has_supported_shape(inputs, nb_inputs, outputs, nb_outputs) ? 0 : 1;
+    }
+
+    int32_t enqueue(nvinfer1::PluginTensorDesc const* input_desc,
+                    nvinfer1::PluginTensorDesc const* output_desc, void const* const* inputs,
+                    void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
+        if (!has_supported_shape(input_desc, 4, output_desc, 1) || inputs == nullptr ||
+            outputs == nullptr || workspace == nullptr || cublas_handle_ == nullptr ||
+            outputs[0] == nullptr) {
+            return 1;
+        }
+        for (int32_t index = 0; index < 4; ++index) {
+            if (inputs[index] == nullptr) {
+                return 1;
+            }
+        }
+        return launch_openpi_action_attention_context(
+            static_cast<const std::uint16_t*>(inputs[0]),
+            static_cast<const std::uint16_t*>(inputs[1]),
+            static_cast<const std::uint16_t*>(inputs[2]),
+            static_cast<const std::uint8_t*>(inputs[3]), static_cast<std::uint16_t*>(outputs[0]),
+            workspace, static_cast<void*>(cublas_handle_), stream);
+    }
+
+    nvinfer1::IPluginV3* attachToContext(nvinfer1::IPluginResourceContext*) noexcept override {
+        auto* plugin = new (std::nothrow) OpenPIActionAttentionContextPlugin();
+        if (plugin == nullptr) {
+            return nullptr;
+        }
+        plugin->namespace_ = namespace_;
+        cublasStatus_t status = cublasCreate(&plugin->cublas_handle_);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+            delete plugin;
+            return nullptr;
+        }
+        status = cublasSetMathMode(plugin->cublas_handle_, CUBLAS_DEFAULT_MATH);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+            delete plugin;
+            return nullptr;
+        }
+        return plugin;
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldsToSerialize() noexcept override {
+        return &serialization_fields_;
+    }
+
+  private:
+    std::string namespace_;
+    nvinfer1::PluginFieldCollection serialization_fields_{};
+    cublasHandle_t cublas_handle_{nullptr};
+};
+
+class OpenPIActionAttentionContextCreator final : public nvinfer1::IPluginCreatorV3One {
+  public:
+    OpenPIActionAttentionContextCreator() { fields_.nbFields = 0; }
+
+    nvinfer1::IPluginV3* createPlugin(nvinfer1::AsciiChar const*,
+                                      nvinfer1::PluginFieldCollection const* fields,
+                                      nvinfer1::TensorRTPhase) noexcept override {
+        if (fields != nullptr && fields->nbFields != 0) {
+            return nullptr;
+        }
+        return new (std::nothrow) OpenPIActionAttentionContextPlugin();
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldNames() noexcept override { return &fields_; }
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override {
+        return OpenPIActionAttentionContextPlugin::kName;
+    }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override {
+        return OpenPIActionAttentionContextPlugin::kVersion;
+    }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override { return ""; }
+
+  private:
+    nvinfer1::PluginFieldCollection fields_{};
+};
+
+static nvinfer1::PluginRegistrar<OpenPIActionAttentionContextCreator>
+    plugin_registrar_openpi_action_attention_context{};
+
+} // namespace
+
+int32_t launch_openpi_action_attention_context(const std::uint16_t* query, const std::uint16_t* key,
+                                               const std::uint16_t* value,
+                                               const std::uint8_t* attention_mask,
+                                               std::uint16_t* output, void* workspace,
+                                               void* cublas_handle, cudaStream_t stream) noexcept {
+    if (query == nullptr || key == nullptr || value == nullptr || attention_mask == nullptr ||
+        output == nullptr || workspace == nullptr || cublas_handle == nullptr) {
+        return 1;
+    }
+
+    auto* workspace_bytes = static_cast<std::byte*>(workspace);
+    auto* packed_query = reinterpret_cast<std::uint16_t*>(workspace_bytes + kPackedQueryOffset);
+    auto* padded_key = reinterpret_cast<std::uint16_t*>(workspace_bytes + kPackedKeyOffset);
+    auto* padded_value = reinterpret_cast<std::uint16_t*>(workspace_bytes + kPackedValueOffset);
+    auto* logits = reinterpret_cast<float*>(workspace_bytes + kLogitOffset);
+    void* cublas_workspace = workspace_bytes + kCublasWorkspaceOffset;
+
+    constexpr std::size_t kPackElements = kPackedKeyElements;
+    constexpr int32_t kPackBlocks =
+        static_cast<int32_t>((kPackElements + kPointwiseThreads - 1) / kPointwiseThreads);
+    openpi_action_attention_pack_kernel<<<kPackBlocks, kPointwiseThreads, 0, stream>>>(
+        query, key, value, packed_query, padded_key, padded_value);
+    if (cudaPeekAtLastError() != cudaSuccess) {
+        return 1;
+    }
+
+    auto handle = reinterpret_cast<cublasHandle_t>(cublas_handle);
+    if (configure_cublas(handle, stream, cublas_workspace, kQkCublasWorkspaceBytes) != 0) {
+        return 1;
+    }
+    const float alpha = 1.0F;
+    const float beta = 0.0F;
+    cublasStatus_t status = cublasGemmEx(
+        handle, CUBLAS_OP_T, CUBLAS_OP_N, kFlattenedQueries, kPaddedKeyRows, kHeadDimension, &alpha,
+        packed_query, CUDA_R_16BF, kHeadDimension, padded_key, CUDA_R_16BF, kHeadDimension, &beta,
+        logits, CUDA_R_32F, kFlattenedQueries, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+
+    auto* probabilities = reinterpret_cast<std::uint16_t*>(workspace_bytes + kPackedKeyOffset);
+    openpi_action_attention_softmax_kernel<<<kSoftmaxBlocks, kSoftmaxThreads, 0, stream>>>(
+        logits, attention_mask, probabilities);
+    if (cudaPeekAtLastError() != cudaSuccess ||
+        configure_cublas(handle, stream, cublas_workspace, kPvCublasWorkspaceBytes) != 0) {
+        return 1;
+    }
+
+    auto* raw_context = reinterpret_cast<std::uint16_t*>(workspace_bytes + kLogitOffset);
+    status = cublasGemmEx(handle, CUBLAS_OP_T, CUBLAS_OP_T, kFlattenedQueries, kHeadDimension,
+                          kPaddedKeyRows, &alpha, probabilities, CUDA_R_16BF, kPaddedKeyRows,
+                          padded_value, CUDA_R_16BF, kHeadDimension, &beta, raw_context,
+                          CUDA_R_16BF, kFlattenedQueries, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+
+    constexpr int32_t kContextBlocks =
+        static_cast<int32_t>((kContextElements + kPointwiseThreads - 1) / kPointwiseThreads);
+    openpi_action_attention_context_to_rows_kernel<<<kContextBlocks, kPointwiseThreads, 0,
+                                                     stream>>>(raw_context, output);
+    return cudaPeekAtLastError() == cudaSuccess ? 0 : 1;
+}
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/trt_plugins/action_layer0_mlp_closure_plugin.cu
+++ b/src/runtime/models/openpi/trt_plugins/action_layer0_mlp_closure_plugin.cu
@@ -1,0 +1,485 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <NvInferRuntime.h>
+#include <cstddef>
+#include <cstdint>
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <new>
+#include <string>
+
+namespace trtmc::openpi {
+
+int32_t launch_openpi_action_layer0_mlp_closure(
+    const std::uint16_t* post_attention, const std::uint16_t* normed_ffw,
+    const std::uint16_t* ffw_gate, const std::uint16_t* gate_weight, const std::uint16_t* up_weight,
+    const std::uint16_t* down_weight, std::uint16_t* post_mlp, void* workspace, void* cublas_handle,
+    cudaStream_t stream) noexcept;
+
+namespace {
+
+constexpr int32_t kBatch = 1;
+constexpr int32_t kRows = 15;
+constexpr int32_t kPaddedRows = 16;
+constexpr int32_t kWidth = 1024;
+constexpr int32_t kMlpWidth = 4096;
+constexpr int32_t kCombinedWidth = 2 * kMlpWidth;
+
+constexpr std::size_t kPaddedActivationElements = static_cast<std::size_t>(kPaddedRows) * kWidth;
+constexpr std::size_t kPaddedActivationBytes = kPaddedActivationElements * sizeof(std::uint16_t);
+constexpr std::size_t kCombinedWeightElements = static_cast<std::size_t>(kWidth) * kCombinedWidth;
+constexpr std::size_t kCombinedWeightBytes = kCombinedWeightElements * sizeof(std::uint16_t);
+constexpr std::size_t kCombinedOutputElements =
+    static_cast<std::size_t>(kPaddedRows) * kCombinedWidth;
+constexpr std::size_t kCombinedOutputBytes = kCombinedOutputElements * sizeof(std::uint16_t);
+constexpr std::size_t kFusedOutputElements = static_cast<std::size_t>(kPaddedRows) * kMlpWidth;
+constexpr std::size_t kFusedOutputBytes = kFusedOutputElements * sizeof(std::uint16_t);
+
+// Exact scratch sizes attached to custom-call.68 and custom-call.69 in the
+// pinned JAX 0.5.3 / XLA action executable. They are deliberately not rounded
+// to a generic workspace bucket.
+constexpr std::size_t kCombinedCublasWorkspaceBytes = 16809984;
+constexpr std::size_t kDownCublasWorkspaceBytes = 8519680;
+
+// The packed gate/up matrix is dead after the first GEMM, so its prefix can be
+// reused by the fused GELU product and down-projection output. The large cuBLAS
+// scratch region remains disjoint for the lifetime of enqueue.
+constexpr std::size_t kCombinedWeightOffset = 0;
+constexpr std::size_t kPaddedNormedOffset = kCombinedWeightOffset + kCombinedWeightBytes;
+constexpr std::size_t kCombinedOutputOffset = kPaddedNormedOffset + kPaddedActivationBytes;
+constexpr std::size_t kCublasWorkspaceOffset = kCombinedOutputOffset + kCombinedOutputBytes;
+constexpr std::size_t kPluginWorkspaceBytes =
+    kCublasWorkspaceOffset + kCombinedCublasWorkspaceBytes;
+constexpr std::size_t kFusedOutputOffset = kCombinedWeightOffset;
+constexpr std::size_t kDownOutputOffset = kFusedOutputOffset + kFusedOutputBytes;
+static_assert(kDownCublasWorkspaceBytes <= kCombinedCublasWorkspaceBytes);
+static_assert(kDownOutputOffset + kPaddedActivationBytes <= kCombinedWeightBytes);
+
+constexpr int32_t kPointwiseThreads = 128;
+constexpr int32_t kGeluBlocks = kPaddedRows * kMlpWidth / kPointwiseThreads;
+constexpr int32_t kResidualBlocks = kRows * kWidth / kPointwiseThreads;
+
+__device__ __forceinline__ float bf16_to_float(std::uint16_t value) {
+    return __uint_as_float(static_cast<std::uint32_t>(value) << 16U);
+}
+
+__device__ __forceinline__ std::uint16_t float_to_bf16_rn(float value) {
+    std::uint32_t bits = __float_as_uint(value);
+    if ((bits & 0x7FFFFFFFU) > 0x7F800000U) {
+        return static_cast<std::uint16_t>((bits >> 16U) | 0x0040U);
+    }
+    bits += 0x00007FFFU + ((bits >> 16U) & 1U);
+    return static_cast<std::uint16_t>(bits >> 16U);
+}
+
+__device__ __forceinline__ std::uint16_t bf16_add_rn(std::uint16_t lhs, std::uint16_t rhs) {
+    return float_to_bf16_rn(__fadd_rn(bf16_to_float(lhs), bf16_to_float(rhs)));
+}
+
+__device__ __forceinline__ std::uint16_t bf16_multiply_rn(std::uint16_t lhs, std::uint16_t rhs) {
+    return float_to_bf16_rn(__fmul_rn(bf16_to_float(lhs), bf16_to_float(rhs)));
+}
+
+__device__ __forceinline__ float full_divide(float numerator, float denominator) {
+    float result;
+    asm("div.full.f32 %0, %1, %2;" : "=f"(result) : "f"(numerator), "f"(denominator));
+    return result;
+}
+
+// Exact libdevice tanh lowering emitted inside XLA's loop_pad_fusion. The
+// clamp, tiny-input branch, coefficient bit patterns, FMA association, and
+// full-precision divide are copied from the qualified PTX rather than using a
+// toolkit-version-dependent tanhf implementation.
+__device__ __forceinline__ float xla_tanh(float value) {
+    const float upper = __uint_as_float(0x40FFF644U);
+    const float lower = __uint_as_float(0xC0FFF644U);
+    const float upper_limited = value >= upper ? upper : value;
+    const float clamped = upper_limited <= lower ? lower : upper_limited;
+    const bool tiny = fabsf(value) < __uint_as_float(0x39D1B717U);
+    const float square = __fmul_rn(clamped, clamped);
+
+    float numerator_polynomial =
+        __fmaf_rn(square, __uint_as_float(0xA59F25C0U), __uint_as_float(0x2A61337EU));
+    numerator_polynomial = __fmaf_rn(square, numerator_polynomial, __uint_as_float(0xAEBD37FFU));
+    numerator_polynomial = __fmaf_rn(square, numerator_polynomial, __uint_as_float(0x335C0041U));
+    numerator_polynomial = __fmaf_rn(square, numerator_polynomial, __uint_as_float(0x3779434AU));
+    numerator_polynomial = __fmaf_rn(square, numerator_polynomial, __uint_as_float(0x3A270DEDU));
+    numerator_polynomial = __fmaf_rn(square, numerator_polynomial, __uint_as_float(0x3BA059DCU));
+    const float numerator = __fmul_rn(clamped, numerator_polynomial);
+
+    float denominator =
+        __fmaf_rn(square, __uint_as_float(0x35A0D3D8U), __uint_as_float(0x38F895D6U));
+    denominator = __fmaf_rn(square, denominator, __uint_as_float(0x3B14AA05U));
+    denominator = __fmaf_rn(square, denominator, __uint_as_float(0x3BA059DDU));
+    const float ratio = full_divide(numerator, denominator);
+    return tiny ? clamped : ratio;
+}
+
+// XLA launches one 128-thread CTA per 128-feature tile over the padded
+// [16,4096] result. Row 15 is the exact zero pad consumed by the down GEMM.
+__global__ void openpi_action_layer0_gelu_gated_kernel(const std::uint16_t* __restrict__ combined,
+                                                       std::uint16_t* __restrict__ fused) {
+    const int32_t row = static_cast<int32_t>(blockIdx.x) >> 5;
+    const int32_t feature =
+        ((static_cast<int32_t>(blockIdx.x) << 7) & 3968) | static_cast<int32_t>(threadIdx.x);
+    const int32_t output_index = row * kMlpWidth + feature;
+    if (row == kRows) {
+        fused[output_index] = 0;
+        return;
+    }
+
+    const int32_t combined_index = row * kCombinedWidth + feature;
+    const std::uint16_t gate = combined[combined_index];
+    const std::uint16_t squared = bf16_multiply_rn(gate, gate);
+    const std::uint16_t cubed = bf16_multiply_rn(gate, squared);
+    const std::uint16_t cubic = bf16_multiply_rn(cubed, 0x3D37U);
+    const std::uint16_t inner = bf16_add_rn(gate, cubic);
+    const std::uint16_t scaled = bf16_multiply_rn(inner, 0x3F4CU);
+    const std::uint16_t tanh = float_to_bf16_rn(xla_tanh(bf16_to_float(scaled)));
+    const std::uint16_t shifted = bf16_add_rn(tanh, 0x3F80U);
+    const std::uint16_t halved = bf16_multiply_rn(shifted, 0x3F00U);
+    const std::uint16_t activated = bf16_multiply_rn(gate, halved);
+    const std::uint16_t up = combined[combined_index + kMlpWidth];
+    fused[output_index] = bf16_multiply_rn(activated, up);
+}
+
+__global__ void openpi_action_layer0_mlp_residual_kernel(
+    const std::uint16_t* __restrict__ post_attention, const std::uint16_t* __restrict__ down,
+    const std::uint16_t* __restrict__ ffw_gate, std::uint16_t* __restrict__ post_mlp) {
+    const int32_t index = static_cast<int32_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int32_t feature = index & (kWidth - 1);
+    const std::uint16_t gated = bf16_multiply_rn(down[index], ffw_gate[feature]);
+    post_mlp[index] = bf16_add_rn(post_attention[index], gated);
+}
+
+bool is_bf16_linear(nvinfer1::PluginTensorDesc const& descriptor) {
+    return descriptor.type == nvinfer1::DataType::kBF16 &&
+           descriptor.format == nvinfer1::TensorFormat::kLINEAR;
+}
+
+bool has_activation_shape(nvinfer1::Dims const& dims) {
+    return dims.nbDims == 3 && dims.d[0] == kBatch && dims.d[1] == kRows && dims.d[2] == kWidth;
+}
+
+bool has_gate_shape(nvinfer1::Dims const& dims) {
+    return dims.nbDims == 3 && dims.d[0] == kBatch && dims.d[1] == 1 && dims.d[2] == kWidth;
+}
+
+bool has_matrix_shape(nvinfer1::Dims const& dims, int32_t rows, int32_t columns) {
+    return dims.nbDims == 2 && dims.d[0] == rows && dims.d[1] == columns;
+}
+
+bool has_supported_dimensions(nvinfer1::Dims const* input, nvinfer1::Dims const& output) {
+    return has_activation_shape(input[0]) && has_activation_shape(input[1]) &&
+           has_gate_shape(input[2]) && has_matrix_shape(input[3], kWidth, kMlpWidth) &&
+           has_matrix_shape(input[4], kWidth, kMlpWidth) &&
+           has_matrix_shape(input[5], kMlpWidth, kWidth) && has_activation_shape(output);
+}
+
+bool has_supported_shape(nvinfer1::PluginTensorDesc const* input, int32_t nb_inputs,
+                         nvinfer1::PluginTensorDesc const* output, int32_t nb_outputs) {
+    if (input == nullptr || output == nullptr || nb_inputs != 6 || nb_outputs != 1) {
+        return false;
+    }
+    nvinfer1::Dims input_dims[6];
+    for (int32_t index = 0; index < 6; ++index) {
+        if (!is_bf16_linear(input[index])) {
+            return false;
+        }
+        input_dims[index] = input[index].dims;
+    }
+    return is_bf16_linear(output[0]) && has_supported_dimensions(input_dims, output[0].dims);
+}
+
+bool has_supported_dynamic_shape(nvinfer1::DynamicPluginTensorDesc const* input, int32_t nb_inputs,
+                                 nvinfer1::DynamicPluginTensorDesc const* output,
+                                 int32_t nb_outputs) {
+    if (input == nullptr || output == nullptr || nb_inputs != 6 || nb_outputs != 1) {
+        return false;
+    }
+    nvinfer1::PluginTensorDesc input_desc[6];
+    nvinfer1::Dims minimum[6];
+    nvinfer1::Dims maximum[6];
+    for (int32_t index = 0; index < 6; ++index) {
+        input_desc[index] = input[index].desc;
+        minimum[index] = input[index].min;
+        maximum[index] = input[index].max;
+    }
+    const nvinfer1::PluginTensorDesc output_desc[1] = {output[0].desc};
+    return has_supported_shape(input_desc, 6, output_desc, 1) &&
+           has_supported_dimensions(minimum, output[0].min) &&
+           has_supported_dimensions(maximum, output[0].max);
+}
+
+class OpenPIActionLayer0MlpClosurePlugin final : public nvinfer1::IPluginV3,
+                                                 public nvinfer1::IPluginV3OneCore,
+                                                 public nvinfer1::IPluginV3OneBuild,
+                                                 public nvinfer1::IPluginV3OneRuntime {
+  public:
+    static constexpr const char* kName = "OpenPIActionLayer0MlpClosure";
+    static constexpr const char* kVersion = "1";
+
+    OpenPIActionLayer0MlpClosurePlugin() { serialization_fields_.nbFields = 0; }
+
+    ~OpenPIActionLayer0MlpClosurePlugin() override {
+        if (cublas_handle_ != nullptr) {
+            static_cast<void>(cublasDestroy(cublas_handle_));
+            cublas_handle_ = nullptr;
+        }
+    }
+
+    nvinfer1::IPluginCapability*
+    getCapabilityInterface(nvinfer1::PluginCapabilityType type) noexcept override {
+        switch (type) {
+        case nvinfer1::PluginCapabilityType::kCORE:
+            return static_cast<nvinfer1::IPluginV3OneCore*>(this);
+        case nvinfer1::PluginCapabilityType::kBUILD:
+            return static_cast<nvinfer1::IPluginV3OneBuild*>(this);
+        case nvinfer1::PluginCapabilityType::kRUNTIME:
+            return static_cast<nvinfer1::IPluginV3OneRuntime*>(this);
+        }
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV3* clone() noexcept override {
+        auto* plugin = new (std::nothrow) OpenPIActionLayer0MlpClosurePlugin();
+        if (plugin != nullptr) {
+            plugin->namespace_ = namespace_;
+        }
+        return plugin;
+    }
+
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override { return kName; }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override { return kVersion; }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override {
+        return namespace_.c_str();
+    }
+
+    int32_t configurePlugin(nvinfer1::DynamicPluginTensorDesc const* input, int32_t nb_inputs,
+                            nvinfer1::DynamicPluginTensorDesc const* output,
+                            int32_t nb_outputs) noexcept override {
+        return has_supported_dynamic_shape(input, nb_inputs, output, nb_outputs) ? 0 : 1;
+    }
+
+    int32_t getOutputDataTypes(nvinfer1::DataType* output_types, int32_t nb_outputs,
+                               nvinfer1::DataType const* input_types,
+                               int32_t nb_inputs) const noexcept override {
+        if (output_types == nullptr || input_types == nullptr || nb_outputs != 1 ||
+            nb_inputs != 6) {
+            return 1;
+        }
+        for (int32_t index = 0; index < 6; ++index) {
+            if (input_types[index] != nvinfer1::DataType::kBF16) {
+                return 1;
+            }
+        }
+        output_types[0] = nvinfer1::DataType::kBF16;
+        return 0;
+    }
+
+    int32_t getOutputShapes(nvinfer1::DimsExprs const* inputs, int32_t nb_inputs,
+                            nvinfer1::DimsExprs const*, int32_t nb_shape_inputs,
+                            nvinfer1::DimsExprs* outputs, int32_t nb_outputs,
+                            nvinfer1::IExprBuilder&) noexcept override {
+        if (inputs == nullptr || outputs == nullptr || nb_inputs != 6 || nb_shape_inputs != 0 ||
+            nb_outputs != 1) {
+            return 1;
+        }
+        outputs[0] = inputs[0];
+        return 0;
+    }
+
+    bool supportsFormatCombination(int32_t position,
+                                   nvinfer1::DynamicPluginTensorDesc const* descriptors,
+                                   int32_t nb_inputs, int32_t nb_outputs) noexcept override {
+        if (descriptors == nullptr || nb_inputs != 6 || nb_outputs != 1 || position < 0 ||
+            position >= 7) {
+            return false;
+        }
+        return is_bf16_linear(descriptors[position].desc);
+    }
+
+    int32_t getNbOutputs() const noexcept override { return 1; }
+
+    std::size_t getWorkspaceSize(nvinfer1::DynamicPluginTensorDesc const*, int32_t,
+                                 nvinfer1::DynamicPluginTensorDesc const*,
+                                 int32_t) const noexcept override {
+        return kPluginWorkspaceBytes;
+    }
+
+    int32_t onShapeChange(nvinfer1::PluginTensorDesc const* input, int32_t nb_inputs,
+                          nvinfer1::PluginTensorDesc const* output,
+                          int32_t nb_outputs) noexcept override {
+        return has_supported_shape(input, nb_inputs, output, nb_outputs) ? 0 : 1;
+    }
+
+    int32_t enqueue(nvinfer1::PluginTensorDesc const* input_desc,
+                    nvinfer1::PluginTensorDesc const* output_desc, void const* const* inputs,
+                    void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
+        if (!has_supported_shape(input_desc, 6, output_desc, 1) || inputs == nullptr ||
+            outputs == nullptr || workspace == nullptr || cublas_handle_ == nullptr ||
+            outputs[0] == nullptr) {
+            return 1;
+        }
+        for (int32_t index = 0; index < 6; ++index) {
+            if (inputs[index] == nullptr) {
+                return 1;
+            }
+        }
+        return launch_openpi_action_layer0_mlp_closure(
+            static_cast<const std::uint16_t*>(inputs[0]),
+            static_cast<const std::uint16_t*>(inputs[1]),
+            static_cast<const std::uint16_t*>(inputs[2]),
+            static_cast<const std::uint16_t*>(inputs[3]),
+            static_cast<const std::uint16_t*>(inputs[4]),
+            static_cast<const std::uint16_t*>(inputs[5]), static_cast<std::uint16_t*>(outputs[0]),
+            workspace, static_cast<void*>(cublas_handle_), stream);
+    }
+
+    nvinfer1::IPluginV3* attachToContext(nvinfer1::IPluginResourceContext*) noexcept override {
+        auto* plugin = new (std::nothrow) OpenPIActionLayer0MlpClosurePlugin();
+        if (plugin == nullptr) {
+            return nullptr;
+        }
+        plugin->namespace_ = namespace_;
+        cublasStatus_t status = cublasCreate(&plugin->cublas_handle_);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+            delete plugin;
+            return nullptr;
+        }
+        status = cublasSetMathMode(plugin->cublas_handle_, CUBLAS_DEFAULT_MATH);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+            delete plugin;
+            return nullptr;
+        }
+        return plugin;
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldsToSerialize() noexcept override {
+        return &serialization_fields_;
+    }
+
+  private:
+    std::string namespace_;
+    nvinfer1::PluginFieldCollection serialization_fields_{};
+    cublasHandle_t cublas_handle_{nullptr};
+};
+
+class OpenPIActionLayer0MlpClosureCreator final : public nvinfer1::IPluginCreatorV3One {
+  public:
+    OpenPIActionLayer0MlpClosureCreator() { fields_.nbFields = 0; }
+
+    nvinfer1::IPluginV3* createPlugin(nvinfer1::AsciiChar const*,
+                                      nvinfer1::PluginFieldCollection const* fields,
+                                      nvinfer1::TensorRTPhase) noexcept override {
+        if (fields != nullptr && fields->nbFields != 0) {
+            return nullptr;
+        }
+        return new (std::nothrow) OpenPIActionLayer0MlpClosurePlugin();
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldNames() noexcept override { return &fields_; }
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override {
+        return OpenPIActionLayer0MlpClosurePlugin::kName;
+    }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override {
+        return OpenPIActionLayer0MlpClosurePlugin::kVersion;
+    }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override { return ""; }
+
+  private:
+    nvinfer1::PluginFieldCollection fields_{};
+};
+
+static nvinfer1::PluginRegistrar<OpenPIActionLayer0MlpClosureCreator>
+    plugin_registrar_openpi_action_layer0_mlp_closure{};
+
+int32_t configure_cublas(cublasHandle_t handle, cudaStream_t stream, void* workspace,
+                         std::size_t workspace_bytes) noexcept {
+    cublasStatus_t status = cublasSetStream(handle, stream);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+    status = cublasSetWorkspace(handle, workspace, workspace_bytes);
+    return status == CUBLAS_STATUS_SUCCESS ? 0 : 1;
+}
+
+} // namespace
+
+int32_t launch_openpi_action_layer0_mlp_closure(
+    const std::uint16_t* post_attention, const std::uint16_t* normed_ffw,
+    const std::uint16_t* ffw_gate, const std::uint16_t* gate_weight, const std::uint16_t* up_weight,
+    const std::uint16_t* down_weight, std::uint16_t* post_mlp, void* workspace, void* cublas_handle,
+    cudaStream_t stream) noexcept {
+    if (post_attention == nullptr || normed_ffw == nullptr || ffw_gate == nullptr ||
+        gate_weight == nullptr || up_weight == nullptr || down_weight == nullptr ||
+        post_mlp == nullptr || workspace == nullptr || cublas_handle == nullptr) {
+        return 1;
+    }
+
+    auto* workspace_bytes = static_cast<std::byte*>(workspace);
+    auto* combined_weight =
+        reinterpret_cast<std::uint16_t*>(workspace_bytes + kCombinedWeightOffset);
+    auto* padded_normed = reinterpret_cast<std::uint16_t*>(workspace_bytes + kPaddedNormedOffset);
+    auto* combined_output =
+        reinterpret_cast<std::uint16_t*>(workspace_bytes + kCombinedOutputOffset);
+    void* cublas_workspace = workspace_bytes + kCublasWorkspaceOffset;
+
+    constexpr std::size_t kWeightRowBytes =
+        static_cast<std::size_t>(kMlpWidth) * sizeof(std::uint16_t);
+    constexpr std::size_t kCombinedWeightRowBytes =
+        static_cast<std::size_t>(kCombinedWidth) * sizeof(std::uint16_t);
+    if (cudaMemcpy2DAsync(combined_weight, kCombinedWeightRowBytes, gate_weight, kWeightRowBytes,
+                          kWeightRowBytes, kWidth, cudaMemcpyDeviceToDevice,
+                          stream) != cudaSuccess ||
+        cudaMemcpy2DAsync(combined_weight + kMlpWidth, kCombinedWeightRowBytes, up_weight,
+                          kWeightRowBytes, kWeightRowBytes, kWidth, cudaMemcpyDeviceToDevice,
+                          stream) != cudaSuccess ||
+        cudaMemcpyAsync(padded_normed, normed_ffw,
+                        static_cast<std::size_t>(kRows) * kWidth * sizeof(std::uint16_t),
+                        cudaMemcpyDeviceToDevice, stream) != cudaSuccess ||
+        cudaMemsetAsync(padded_normed + static_cast<std::size_t>(kRows) * kWidth, 0,
+                        static_cast<std::size_t>(kWidth) * sizeof(std::uint16_t),
+                        stream) != cudaSuccess) {
+        return 1;
+    }
+
+    auto handle = reinterpret_cast<cublasHandle_t>(cublas_handle);
+    if (configure_cublas(handle, stream, cublas_workspace, kCombinedCublasWorkspaceBytes) != 0) {
+        return 1;
+    }
+    const float alpha = 1.0F;
+    const float beta = 0.0F;
+    cublasStatus_t status = cublasGemmEx(
+        handle, CUBLAS_OP_N, CUBLAS_OP_N, kCombinedWidth, kPaddedRows, kWidth, &alpha,
+        combined_weight, CUDA_R_16BF, kCombinedWidth, padded_normed, CUDA_R_16BF, kWidth, &beta,
+        combined_output, CUDA_R_16BF, kCombinedWidth, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+
+    auto* fused = reinterpret_cast<std::uint16_t*>(workspace_bytes + kFusedOutputOffset);
+    openpi_action_layer0_gelu_gated_kernel<<<kGeluBlocks, kPointwiseThreads, 0, stream>>>(
+        combined_output, fused);
+    if (cudaPeekAtLastError() != cudaSuccess ||
+        configure_cublas(handle, stream, cublas_workspace, kDownCublasWorkspaceBytes) != 0) {
+        return 1;
+    }
+
+    auto* down = reinterpret_cast<std::uint16_t*>(workspace_bytes + kDownOutputOffset);
+    status = cublasGemmEx(handle, CUBLAS_OP_N, CUBLAS_OP_N, kWidth, kPaddedRows, kMlpWidth, &alpha,
+                          down_weight, CUDA_R_16BF, kWidth, fused, CUDA_R_16BF, kMlpWidth, &beta,
+                          down, CUDA_R_16BF, kWidth, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+
+    openpi_action_layer0_mlp_residual_kernel<<<kResidualBlocks, kPointwiseThreads, 0, stream>>>(
+        post_attention, down, ffw_gate, post_mlp);
+    return cudaPeekAtLastError() == cudaSuccess ? 0 : 1;
+}
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/trt_plugins/action_output_projection_plugin.cu
+++ b/src/runtime/models/openpi/trt_plugins/action_output_projection_plugin.cu
@@ -1,0 +1,379 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <NvInferRuntime.h>
+#include <cstddef>
+#include <cstdint>
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <new>
+#include <string>
+
+namespace trtmc::openpi {
+
+int32_t launch_openpi_action_output_projection(const std::uint16_t* hidden,
+                                               const std::uint16_t* weight,
+                                               const std::uint16_t* bias, std::uint16_t* velocity,
+                                               void* workspace, void* cublas_handle,
+                                               cudaStream_t stream) noexcept;
+
+namespace {
+
+constexpr int32_t kBatch = 1;
+constexpr int32_t kRows = 15;
+constexpr int32_t kPaddedRows = 16;
+constexpr int32_t kWidth = 1024;
+constexpr int32_t kOutputWidth = 32;
+constexpr std::size_t kPaddedInputElements = static_cast<std::size_t>(kPaddedRows) * kWidth;
+constexpr std::size_t kPaddedInputBytes = kPaddedInputElements * sizeof(std::uint16_t);
+constexpr std::size_t kPaddedOutputElements = static_cast<std::size_t>(kPaddedRows) * kOutputWidth;
+constexpr std::size_t kPaddedOutputBytes = kPaddedOutputElements * sizeof(std::uint16_t);
+// Exact scratch allocation attached to custom-call.73 in the pinned
+// JAX 0.5.3 / XLA action executable.
+constexpr std::size_t kCublasWorkspaceBytes = 98304;
+constexpr std::size_t kWorkspaceAlignment = 256;
+constexpr std::size_t kWorkspaceAlignmentSlack = kWorkspaceAlignment - 1;
+// The pinned XLA buffer assignment places all three cuBLAS pointers at +0x80
+// modulo 256. CUBLAS_GEMM_DEFAULT is alignment-sensitive, so preserve that
+// physical address geometry rather than merely keeping the regions disjoint.
+// TensorRT supplies an opaque workspace pointer, so reserve enough slack to
+// align its base explicitly instead of depending on an undocumented alignment.
+constexpr std::size_t kPaddedInputOffset = 0x80;
+constexpr std::size_t kPaddedOutputOffset = kPaddedInputOffset + kPaddedInputBytes;
+constexpr std::size_t kCublasWorkspaceOffset = kPaddedOutputOffset + kPaddedOutputBytes;
+constexpr std::size_t kWorkspacePayloadBytes = kCublasWorkspaceOffset + kCublasWorkspaceBytes;
+constexpr std::size_t kPluginWorkspaceBytes = kWorkspaceAlignmentSlack + kWorkspacePayloadBytes;
+static_assert(kPaddedInputOffset == 0x0080);
+static_assert(kPaddedOutputOffset == 0x8080);
+static_assert(kCublasWorkspaceOffset == 0x8480);
+static_assert(kWorkspacePayloadBytes == 0x20480);
+static_assert(kPluginWorkspaceBytes == 0x2057F);
+static_assert((kWorkspaceAlignment & (kWorkspaceAlignment - 1)) == 0);
+static_assert(kPaddedInputOffset % 256 == 128);
+static_assert(kPaddedOutputOffset % 256 == 128);
+static_assert(kCublasWorkspaceOffset % 256 == 128);
+constexpr int32_t kPointwiseThreads = 128;
+constexpr int32_t kOutputElements = kRows * kOutputWidth;
+constexpr int32_t kPointwiseBlocks = (kOutputElements + kPointwiseThreads - 1) / kPointwiseThreads;
+
+__device__ __forceinline__ std::uint16_t bf16_add_rn(std::uint16_t lhs, std::uint16_t rhs) {
+    // Match the pinned sm_103a XLA PTX directly on the qualified platform.
+    std::uint16_t result;
+    asm("add.rn.bf16 %0, %1, %2;" : "=h"(result) : "h"(lhs), "h"(rhs));
+    return result;
+}
+
+__global__ void openpi_action_output_bias_kernel(const std::uint16_t* __restrict__ projected,
+                                                 const std::uint16_t* __restrict__ bias,
+                                                 std::uint16_t* __restrict__ velocity) {
+    const int32_t index = static_cast<int32_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index < kOutputElements) {
+        velocity[index] = bf16_add_rn(projected[index], bias[index % kOutputWidth]);
+    }
+}
+
+bool is_bf16_linear(nvinfer1::PluginTensorDesc const& descriptor) {
+    return descriptor.type == nvinfer1::DataType::kBF16 &&
+           descriptor.format == nvinfer1::TensorFormat::kLINEAR;
+}
+
+bool has_hidden_shape(nvinfer1::Dims const& dims) {
+    return dims.nbDims == 3 && dims.d[0] == kBatch && dims.d[1] == kRows && dims.d[2] == kWidth;
+}
+
+bool has_weight_shape(nvinfer1::Dims const& dims) {
+    return dims.nbDims == 2 && dims.d[0] == kWidth && dims.d[1] == kOutputWidth;
+}
+
+bool has_bias_shape(nvinfer1::Dims const& dims) {
+    return dims.nbDims == 1 && dims.d[0] == kOutputWidth;
+}
+
+bool has_output_shape(nvinfer1::Dims const& dims) {
+    return dims.nbDims == 3 && dims.d[0] == kBatch && dims.d[1] == kRows &&
+           dims.d[2] == kOutputWidth;
+}
+
+bool has_supported_dimensions(nvinfer1::Dims const* inputs, nvinfer1::Dims const& output) {
+    return has_hidden_shape(inputs[0]) && has_weight_shape(inputs[1]) &&
+           has_bias_shape(inputs[2]) && has_output_shape(output);
+}
+
+bool has_supported_shape(nvinfer1::PluginTensorDesc const* inputs, int32_t nb_inputs,
+                         nvinfer1::PluginTensorDesc const* outputs, int32_t nb_outputs) {
+    if (inputs == nullptr || outputs == nullptr || nb_inputs != 3 || nb_outputs != 1) {
+        return false;
+    }
+    nvinfer1::Dims input_dims[3];
+    for (int32_t index = 0; index < 3; ++index) {
+        if (!is_bf16_linear(inputs[index])) {
+            return false;
+        }
+        input_dims[index] = inputs[index].dims;
+    }
+    return is_bf16_linear(outputs[0]) && has_supported_dimensions(input_dims, outputs[0].dims);
+}
+
+bool has_supported_dynamic_shape(nvinfer1::DynamicPluginTensorDesc const* inputs, int32_t nb_inputs,
+                                 nvinfer1::DynamicPluginTensorDesc const* outputs,
+                                 int32_t nb_outputs) {
+    if (inputs == nullptr || outputs == nullptr || nb_inputs != 3 || nb_outputs != 1) {
+        return false;
+    }
+    const nvinfer1::PluginTensorDesc input_desc[3] = {inputs[0].desc, inputs[1].desc,
+                                                      inputs[2].desc};
+    const nvinfer1::PluginTensorDesc output_desc[1] = {outputs[0].desc};
+    const nvinfer1::Dims minimum[3] = {inputs[0].min, inputs[1].min, inputs[2].min};
+    const nvinfer1::Dims maximum[3] = {inputs[0].max, inputs[1].max, inputs[2].max};
+    return has_supported_shape(input_desc, 3, output_desc, 1) &&
+           has_supported_dimensions(minimum, outputs[0].min) &&
+           has_supported_dimensions(maximum, outputs[0].max);
+}
+
+int32_t configure_cublas(cublasHandle_t handle, cudaStream_t stream, void* workspace) noexcept {
+    cublasStatus_t status = cublasSetStream(handle, stream);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+    status = cublasSetWorkspace(handle, workspace, kCublasWorkspaceBytes);
+    return status == CUBLAS_STATUS_SUCCESS ? 0 : 1;
+}
+
+class OpenPIActionOutputProjectionPlugin final : public nvinfer1::IPluginV3,
+                                                 public nvinfer1::IPluginV3OneCore,
+                                                 public nvinfer1::IPluginV3OneBuild,
+                                                 public nvinfer1::IPluginV3OneRuntime {
+  public:
+    static constexpr const char* kName = "OpenPIActionOutputProjection";
+    static constexpr const char* kVersion = "1";
+
+    OpenPIActionOutputProjectionPlugin() { serialization_fields_.nbFields = 0; }
+
+    ~OpenPIActionOutputProjectionPlugin() override {
+        if (cublas_handle_ != nullptr) {
+            static_cast<void>(cublasDestroy(cublas_handle_));
+            cublas_handle_ = nullptr;
+        }
+    }
+
+    nvinfer1::IPluginCapability*
+    getCapabilityInterface(nvinfer1::PluginCapabilityType type) noexcept override {
+        switch (type) {
+        case nvinfer1::PluginCapabilityType::kCORE:
+            return static_cast<nvinfer1::IPluginV3OneCore*>(this);
+        case nvinfer1::PluginCapabilityType::kBUILD:
+            return static_cast<nvinfer1::IPluginV3OneBuild*>(this);
+        case nvinfer1::PluginCapabilityType::kRUNTIME:
+            return static_cast<nvinfer1::IPluginV3OneRuntime*>(this);
+        }
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV3* clone() noexcept override {
+        auto* plugin = new (std::nothrow) OpenPIActionOutputProjectionPlugin();
+        if (plugin != nullptr) {
+            plugin->namespace_ = namespace_;
+        }
+        return plugin;
+    }
+
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override { return kName; }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override { return kVersion; }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override {
+        return namespace_.c_str();
+    }
+
+    int32_t configurePlugin(nvinfer1::DynamicPluginTensorDesc const* inputs, int32_t nb_inputs,
+                            nvinfer1::DynamicPluginTensorDesc const* outputs,
+                            int32_t nb_outputs) noexcept override {
+        return has_supported_dynamic_shape(inputs, nb_inputs, outputs, nb_outputs) ? 0 : 1;
+    }
+
+    int32_t getOutputDataTypes(nvinfer1::DataType* output_types, int32_t nb_outputs,
+                               nvinfer1::DataType const* input_types,
+                               int32_t nb_inputs) const noexcept override {
+        if (output_types == nullptr || input_types == nullptr || nb_outputs != 1 ||
+            nb_inputs != 3) {
+            return 1;
+        }
+        for (int32_t index = 0; index < 3; ++index) {
+            if (input_types[index] != nvinfer1::DataType::kBF16) {
+                return 1;
+            }
+        }
+        output_types[0] = nvinfer1::DataType::kBF16;
+        return 0;
+    }
+
+    int32_t getOutputShapes(nvinfer1::DimsExprs const* inputs, int32_t nb_inputs,
+                            nvinfer1::DimsExprs const*, int32_t nb_shape_inputs,
+                            nvinfer1::DimsExprs* outputs, int32_t nb_outputs,
+                            nvinfer1::IExprBuilder& expression_builder) noexcept override {
+        if (inputs == nullptr || outputs == nullptr || nb_inputs != 3 || nb_shape_inputs != 0 ||
+            nb_outputs != 1 || inputs[0].nbDims != 3 || inputs[1].nbDims != 2 ||
+            inputs[2].nbDims != 1 || inputs[0].d[0] == nullptr || inputs[0].d[1] == nullptr) {
+            return 1;
+        }
+        outputs[0].nbDims = 3;
+        outputs[0].d[0] = inputs[0].d[0];
+        outputs[0].d[1] = inputs[0].d[1];
+        outputs[0].d[2] = expression_builder.constant(kOutputWidth);
+        return 0;
+    }
+
+    bool supportsFormatCombination(int32_t position,
+                                   nvinfer1::DynamicPluginTensorDesc const* descriptors,
+                                   int32_t nb_inputs, int32_t nb_outputs) noexcept override {
+        return descriptors != nullptr && nb_inputs == 3 && nb_outputs == 1 && position >= 0 &&
+               position < 4 && is_bf16_linear(descriptors[position].desc);
+    }
+
+    int32_t getNbOutputs() const noexcept override { return 1; }
+
+    std::size_t getWorkspaceSize(nvinfer1::DynamicPluginTensorDesc const*, int32_t,
+                                 nvinfer1::DynamicPluginTensorDesc const*,
+                                 int32_t) const noexcept override {
+        return kPluginWorkspaceBytes;
+    }
+
+    int32_t onShapeChange(nvinfer1::PluginTensorDesc const* inputs, int32_t nb_inputs,
+                          nvinfer1::PluginTensorDesc const* outputs,
+                          int32_t nb_outputs) noexcept override {
+        return has_supported_shape(inputs, nb_inputs, outputs, nb_outputs) ? 0 : 1;
+    }
+
+    int32_t enqueue(nvinfer1::PluginTensorDesc const* input_desc,
+                    nvinfer1::PluginTensorDesc const* output_desc, void const* const* inputs,
+                    void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
+        if (!has_supported_shape(input_desc, 3, output_desc, 1) || inputs == nullptr ||
+            outputs == nullptr || workspace == nullptr || cublas_handle_ == nullptr ||
+            outputs[0] == nullptr) {
+            return 1;
+        }
+        for (int32_t index = 0; index < 3; ++index) {
+            if (inputs[index] == nullptr) {
+                return 1;
+            }
+        }
+        return launch_openpi_action_output_projection(
+            static_cast<const std::uint16_t*>(inputs[0]),
+            static_cast<const std::uint16_t*>(inputs[1]),
+            static_cast<const std::uint16_t*>(inputs[2]), static_cast<std::uint16_t*>(outputs[0]),
+            workspace, static_cast<void*>(cublas_handle_), stream);
+    }
+
+    nvinfer1::IPluginV3* attachToContext(nvinfer1::IPluginResourceContext*) noexcept override {
+        auto* plugin = new (std::nothrow) OpenPIActionOutputProjectionPlugin();
+        if (plugin == nullptr) {
+            return nullptr;
+        }
+        plugin->namespace_ = namespace_;
+        cublasStatus_t status = cublasCreate(&plugin->cublas_handle_);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+            delete plugin;
+            return nullptr;
+        }
+        status = cublasSetMathMode(plugin->cublas_handle_, CUBLAS_DEFAULT_MATH);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+            delete plugin;
+            return nullptr;
+        }
+        status = cublasSetPointerMode(plugin->cublas_handle_, CUBLAS_POINTER_MODE_HOST);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+            delete plugin;
+            return nullptr;
+        }
+        return plugin;
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldsToSerialize() noexcept override {
+        return &serialization_fields_;
+    }
+
+  private:
+    std::string namespace_;
+    nvinfer1::PluginFieldCollection serialization_fields_{};
+    cublasHandle_t cublas_handle_{nullptr};
+};
+
+class OpenPIActionOutputProjectionCreator final : public nvinfer1::IPluginCreatorV3One {
+  public:
+    OpenPIActionOutputProjectionCreator() { fields_.nbFields = 0; }
+
+    nvinfer1::IPluginV3* createPlugin(nvinfer1::AsciiChar const*,
+                                      nvinfer1::PluginFieldCollection const* fields,
+                                      nvinfer1::TensorRTPhase) noexcept override {
+        if (fields != nullptr && fields->nbFields != 0) {
+            return nullptr;
+        }
+        return new (std::nothrow) OpenPIActionOutputProjectionPlugin();
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldNames() noexcept override { return &fields_; }
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override {
+        return OpenPIActionOutputProjectionPlugin::kName;
+    }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override {
+        return OpenPIActionOutputProjectionPlugin::kVersion;
+    }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override { return ""; }
+
+  private:
+    nvinfer1::PluginFieldCollection fields_{};
+};
+
+static nvinfer1::PluginRegistrar<OpenPIActionOutputProjectionCreator>
+    plugin_registrar_openpi_action_output_projection{};
+
+} // namespace
+
+int32_t launch_openpi_action_output_projection(const std::uint16_t* hidden,
+                                               const std::uint16_t* weight,
+                                               const std::uint16_t* bias, std::uint16_t* velocity,
+                                               void* workspace, void* cublas_handle,
+                                               cudaStream_t stream) noexcept {
+    if (hidden == nullptr || weight == nullptr || bias == nullptr || velocity == nullptr ||
+        workspace == nullptr || cublas_handle == nullptr) {
+        return 1;
+    }
+
+    const auto workspace_address = reinterpret_cast<std::uintptr_t>(workspace);
+    const auto aligned_workspace_address = (workspace_address + kWorkspaceAlignmentSlack) &
+                                           ~static_cast<std::uintptr_t>(kWorkspaceAlignmentSlack);
+    auto* workspace_bytes = reinterpret_cast<std::byte*>(aligned_workspace_address);
+    auto* padded_hidden = reinterpret_cast<std::uint16_t*>(workspace_bytes + kPaddedInputOffset);
+    auto* padded_output = reinterpret_cast<std::uint16_t*>(workspace_bytes + kPaddedOutputOffset);
+    void* cublas_workspace = workspace_bytes + kCublasWorkspaceOffset;
+
+    constexpr std::size_t kInputBytes =
+        static_cast<std::size_t>(kRows) * kWidth * sizeof(std::uint16_t);
+    constexpr std::size_t kPaddingBytes = static_cast<std::size_t>(kWidth) * sizeof(std::uint16_t);
+    if (cudaMemcpyAsync(padded_hidden, hidden, kInputBytes, cudaMemcpyDeviceToDevice, stream) !=
+            cudaSuccess ||
+        cudaMemsetAsync(padded_hidden + static_cast<std::size_t>(kRows) * kWidth, 0, kPaddingBytes,
+                        stream) != cudaSuccess) {
+        return 1;
+    }
+
+    auto handle = reinterpret_cast<cublasHandle_t>(cublas_handle);
+    if (configure_cublas(handle, stream, cublas_workspace) != 0) {
+        return 1;
+    }
+    const float alpha = 1.0F;
+    const float beta = 0.0F;
+    const cublasStatus_t status = cublasGemmEx(
+        handle, CUBLAS_OP_N, CUBLAS_OP_N, kOutputWidth, kPaddedRows, kWidth, &alpha, weight,
+        CUDA_R_16BF, kOutputWidth, padded_hidden, CUDA_R_16BF, kWidth, &beta, padded_output,
+        CUDA_R_16BF, kOutputWidth, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+
+    openpi_action_output_bias_kernel<<<kPointwiseBlocks, kPointwiseThreads, 0, stream>>>(
+        padded_output, bias, velocity);
+    return cudaPeekAtLastError() == cudaSuccess ? 0 : 1;
+}
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/trt_plugins/rms_norm_plugin.cu
+++ b/src/runtime/models/openpi/trt_plugins/rms_norm_plugin.cu
@@ -1,0 +1,1894 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <NvInferRuntime.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <limits>
+#include <new>
+#include <string>
+
+namespace trtmc::openpi {
+
+int32_t launch_openpi_rms_norm(const std::uint16_t* input, const std::uint16_t* scale,
+                               std::uint16_t* output, int32_t rows, float epsilon,
+                               cudaStream_t stream) noexcept;
+int32_t launch_openpi_rope_qk(const std::uint16_t* query, const std::uint16_t* key,
+                              const std::int32_t* positions, std::uint16_t* query_output,
+                              std::uint16_t* key_output, int32_t sequence, void* workspace,
+                              cudaStream_t stream) noexcept;
+int32_t launch_openpi_prefix_qk(const std::uint16_t* query, const std::uint16_t* key, float* logits,
+                                void* workspace, void* cublas_handle, cudaStream_t stream) noexcept;
+int32_t launch_openpi_prefix_softmax(const float* logits, const std::uint8_t* attention_mask,
+                                     std::uint16_t* probabilities, cudaStream_t stream) noexcept;
+int32_t launch_openpi_final_adaptive_rms_norm(const std::uint16_t* hidden,
+                                              const std::uint16_t* bias,
+                                              const std::uint16_t* weight, const float* condition,
+                                              std::uint16_t* output, float epsilon,
+                                              cudaStream_t stream) noexcept;
+int32_t launch_openpi_post_attention_rms_norm(
+    const std::uint16_t* residual, const std::uint16_t* update, const std::uint16_t* residual_gate,
+    const std::uint16_t* scale, const std::uint16_t* shift, std::uint16_t* output, int32_t rows,
+    float epsilon, cudaStream_t stream) noexcept;
+
+namespace {
+
+constexpr int32_t kWidth = 2048;
+constexpr int32_t kThreads = 256;
+constexpr int32_t kRowsPerBlock = 4;
+constexpr int32_t kElementsPerThread = 8;
+constexpr float kReciprocalWidth = 1.0F / static_cast<float>(kWidth);
+constexpr int32_t kRopeSequence = 968;
+constexpr int32_t kActionSequence = 15;
+constexpr int32_t kRopeHeadDim = 256;
+constexpr int32_t kRopeHalf = kRopeHeadDim / 2;
+constexpr int32_t kRopeQueryHeads = 8;
+constexpr int32_t kRopeKeyHeads = 1;
+constexpr std::size_t kRopeTableElements = kRopeSequence * kRopeHalf;
+constexpr std::size_t kRopeWorkspaceBytes = (kRopeHalf + 2 * kRopeTableElements) * sizeof(float);
+constexpr int32_t kPrefixQKRows = kRopeQueryHeads * kRopeSequence;
+constexpr std::size_t kPrefixQKQueryElements =
+    static_cast<std::size_t>(kPrefixQKRows) * kRopeHeadDim;
+constexpr std::size_t kPrefixQKQueryWorkspaceBytes = kPrefixQKQueryElements * sizeof(std::uint16_t);
+// This is the exact scratch allocation handed to cublasGemmEx by the pinned
+// JAX 0.5.3 / XLA executable on the qualification GPU.
+constexpr std::size_t kPrefixQKCublasWorkspaceBytes = 4460544;
+constexpr std::size_t kPrefixQKWorkspaceBytes =
+    kPrefixQKQueryWorkspaceBytes + kPrefixQKCublasWorkspaceBytes;
+constexpr int32_t kPrefixSoftmaxThreads = 64;
+constexpr int32_t kPrefixSoftmaxTiles = 16;
+constexpr int32_t kPrefixSoftmaxRows = kRopeQueryHeads * kRopeSequence;
+constexpr int32_t kActionWidth = 1024;
+constexpr int32_t kActionThreads = 64;
+constexpr int32_t kActionElementsPerThread = 16;
+constexpr float kActionReciprocalWidth = 1.0F / static_cast<float>(kActionWidth);
+constexpr int32_t kFinalAdaptiveRows = 15;
+constexpr int32_t kFinalAdaptivePaddedRows = 16;
+constexpr int32_t kFinalAdaptiveProjectionWidth = 3 * kActionWidth;
+constexpr int32_t kFinalAdaptiveColumnsPerBlock = 16;
+constexpr int32_t kFinalAdaptiveBlocks = kActionWidth / kFinalAdaptiveColumnsPerBlock;
+constexpr int32_t kFinalAdaptiveThreads = 256;
+constexpr int32_t kFinalAdaptiveWarpCount = kFinalAdaptiveThreads / 32;
+constexpr int32_t kFinalAdaptiveRmsWarpsPerRow = 4;
+constexpr int32_t kFinalAdaptiveConditionTiles = 8;
+constexpr float kFinalAdaptiveEpsilon = 1.0e-6F;
+
+__device__ __forceinline__ float bf16_to_float(std::uint16_t value) {
+    return __uint_as_float(static_cast<std::uint32_t>(value) << 16U);
+}
+
+__device__ __forceinline__ std::uint16_t float_to_bf16_rn(float value) {
+    std::uint32_t bits = __float_as_uint(value);
+    // Round-to-nearest-even, matching cvt.rn.bf16.f32. Preserve a quiet NaN
+    // payload if a non-finite value ever reaches this family-owned primitive.
+    if ((bits & 0x7FFFFFFFU) > 0x7F800000U) {
+        return static_cast<std::uint16_t>((bits >> 16U) | 0x0040U);
+    }
+    bits += 0x00007FFFU + ((bits >> 16U) & 1U);
+    return static_cast<std::uint16_t>(bits >> 16U);
+}
+
+__device__ __forceinline__ std::uint16_t bf16_multiply_rn(std::uint16_t lhs, std::uint16_t rhs) {
+    return float_to_bf16_rn(__fmul_rn(bf16_to_float(lhs), bf16_to_float(rhs)));
+}
+
+__device__ __forceinline__ std::uint16_t bf16_add_rn(std::uint16_t lhs, std::uint16_t rhs) {
+    return float_to_bf16_rn(__fadd_rn(bf16_to_float(lhs), bf16_to_float(rhs)));
+}
+
+__device__ __forceinline__ float approximate_rsqrt(float value) {
+    float result;
+    asm("rsqrt.approx.f32 %0, %1;" : "=f"(result) : "f"(value));
+    return result;
+}
+
+__device__ __forceinline__ float warp_reduce_sum(float value) {
+#pragma unroll
+    for (int32_t mask = 16; mask > 0; mask >>= 1) {
+        value += __shfl_xor_sync(0xFFFFFFFFU, value, mask, 32);
+    }
+    return value;
+}
+
+// This is the exact reduction mapping decoded from the pinned JAX/XLA 0.5.3
+// GPU kernel. One 256-thread block handles four rows. Every warp owns 256
+// contiguous dimensions, every lane accumulates eight contiguous squares,
+// the 32 lane totals use a butterfly reduction, and the eight warp totals use
+// a second butterfly reduction. XLA then applies CUDA rsqrtf before the two
+// separately rounded FP32 products and final BF16 conversion.
+__global__ void openpi_rms_norm_kernel(const std::uint16_t* __restrict__ input,
+                                       const std::uint16_t* __restrict__ scale,
+                                       std::uint16_t* __restrict__ output, int32_t rows,
+                                       float epsilon) {
+    __shared__ float partials[kRowsPerBlock * 8];
+
+    const int32_t lane = threadIdx.x & 31;
+    const int32_t warp = threadIdx.x >> 5;
+    const int32_t dimension = threadIdx.x * kElementsPerThread;
+    const int32_t first_row = blockIdx.x * kRowsPerBlock;
+    float values[kRowsPerBlock][kElementsPerThread];
+    float local_sums[kRowsPerBlock]{};
+
+#pragma unroll
+    for (int32_t row_offset = 0; row_offset < kRowsPerBlock; ++row_offset) {
+        const int32_t row = first_row + row_offset;
+        const int64_t base = static_cast<int64_t>(row) * kWidth + dimension;
+#pragma unroll
+        for (int32_t item = 0; item < kElementsPerThread; ++item) {
+            const float value = row < rows ? bf16_to_float(input[base + item]) : 0.0F;
+            values[row_offset][item] = value;
+            local_sums[row_offset] += value * value;
+        }
+        const float warp_sum = warp_reduce_sum(local_sums[row_offset]);
+        if (lane == 0) {
+            partials[row_offset * 8 + warp] = warp_sum;
+        }
+    }
+    __syncthreads();
+
+    if (threadIdx.x < kRowsPerBlock * 8) {
+        float total = partials[threadIdx.x];
+#pragma unroll
+        for (int32_t mask = 4; mask > 0; mask >>= 1) {
+            total += __shfl_xor_sync(0xFFFFFFFFU, total, mask, 32);
+        }
+        if ((threadIdx.x & 7) == 0) {
+            partials[threadIdx.x] = total;
+        }
+    }
+    __syncthreads();
+
+    float gamma[kElementsPerThread];
+#pragma unroll
+    for (int32_t item = 0; item < kElementsPerThread; ++item) {
+        // XLA emits fma.rn.bf16(scale, 1, 1). BF16 operands are exactly
+        // representable in FP32, so FP32 add followed by explicit BF16 RNE is
+        // the same operation and avoids a native-BF16 architecture baseline.
+        const float scale_value = bf16_to_float(scale[dimension + item]);
+        gamma[item] = bf16_to_float(float_to_bf16_rn(scale_value + 1.0F));
+    }
+
+#pragma unroll
+    for (int32_t row_offset = 0; row_offset < kRowsPerBlock; ++row_offset) {
+        const int32_t row = first_row + row_offset;
+        if (row >= rows) {
+            continue;
+        }
+        const float reciprocal = rsqrtf(partials[row_offset * 8] * kReciprocalWidth + epsilon);
+        const int64_t base = static_cast<int64_t>(row) * kWidth + dimension;
+#pragma unroll
+        for (int32_t item = 0; item < kElementsPerThread; ++item) {
+            const float normalized = values[row_offset][item] * reciprocal;
+            output[base + item] = float_to_bf16_rn(normalized * gamma[item]);
+        }
+    }
+}
+
+__global__ void openpi_rope_period_kernel(float* periods) {
+    const int32_t dimension = threadIdx.x;
+    if (dimension < kRopeHalf) {
+        periods[dimension] = powf(10000.0F, static_cast<float>(dimension) * (2.0F / kRopeHeadDim));
+    }
+}
+
+__device__ __forceinline__ float full_divide(float numerator, float denominator) {
+    float result;
+    asm("div.full.f32 %0, %1, %2;" : "=f"(result) : "f"(numerator), "f"(denominator));
+    return result;
+}
+
+// XLA lowers each position to one 128-thread block. Its CUDA libdevice sine
+// and cosine implementations are bit-identical to separate sinf/cosf calls,
+// provided the preceding division uses PTX div.full.f32 rather than nvcc's
+// usual div.rn.f32 lowering.
+__global__ void openpi_rope_table_kernel(const int32_t* __restrict__ positions,
+                                         const float* __restrict__ periods,
+                                         float* __restrict__ cosine, float* __restrict__ sine) {
+    const int32_t position_index = blockIdx.x;
+    const int32_t dimension = threadIdx.x;
+    const int32_t table_index = position_index * kRopeHalf + dimension;
+    const float radians =
+        full_divide(static_cast<float>(positions[position_index]), periods[dimension]);
+    cosine[table_index] = cosf(radians);
+    sine[table_index] = sinf(radians);
+}
+
+__global__ void openpi_rope_apply_kernel(const std::uint16_t* __restrict__ input,
+                                         const float* __restrict__ cosine,
+                                         const float* __restrict__ sine,
+                                         std::uint16_t* __restrict__ output, int32_t heads,
+                                         int32_t sequence) {
+    const int64_t pair_index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int64_t pair_count = static_cast<int64_t>(heads) * sequence * kRopeHalf;
+    if (pair_index >= pair_count) {
+        return;
+    }
+    const int32_t dimension = pair_index % kRopeHalf;
+    const int64_t token_head = pair_index / kRopeHalf;
+    const int32_t token = token_head % sequence;
+    const int64_t base = token_head * kRopeHeadDim + dimension;
+    const int32_t table_index = token * kRopeHalf + dimension;
+    const float first = bf16_to_float(input[base]);
+    const float second = bf16_to_float(input[base + kRopeHalf]);
+    const float cos_value = cosine[table_index];
+    const float sin_value = sine[table_index];
+    const float out_first = __fsub_rn(__fmul_rn(first, cos_value), __fmul_rn(second, sin_value));
+    const float out_second = __fadd_rn(__fmul_rn(second, cos_value), __fmul_rn(first, sin_value));
+    output[base] = float_to_bf16_rn(out_first);
+    output[base + kRopeHalf] = float_to_bf16_rn(out_second);
+}
+
+// TensorRT attention tensors are head-major [B,H,S,D], whereas untouched XLA
+// presents one sequence-major [B,S,H,D] matrix to a single m=H*S cuBLAS GEMM.
+// Preserve that physical row order: splitting into eight m=S GEMMs selects a
+// different reduction kernel and changes FP32 logits despite identical BF16
+// operands.
+__global__ void openpi_prefix_q_bhsd_to_bshd_kernel(const std::uint16_t* __restrict__ input,
+                                                    std::uint16_t* __restrict__ output) {
+    const int64_t input_index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (input_index >= static_cast<int64_t>(kPrefixQKQueryElements)) {
+        return;
+    }
+    const int32_t dimension = input_index % kRopeHeadDim;
+    const int64_t head_token = input_index / kRopeHeadDim;
+    const int32_t token = head_token % kRopeSequence;
+    const int32_t head = head_token / kRopeSequence;
+    const int64_t output_index =
+        (static_cast<int64_t>(token) * kRopeQueryHeads + head) * kRopeHeadDim + dimension;
+    output[output_index] = input[input_index];
+}
+
+// XLA's prefix softmax uses its own exp2 polynomial lowering rather than
+// CUDA's __expf implementation. Keep every rounding mode explicit: a change
+// in any one of these operations is observable in the BF16 probability cache.
+__device__ __forceinline__ float openpi_prefix_expf(float value) {
+    const float scaled =
+        __fmaf_rn(value, __uint_as_float(0x3BBB989DU), __uint_as_float(0x3F000000U));
+    float saturated;
+    asm("cvt.sat.f32.f32 %0, %1;" : "=f"(saturated) : "f"(scaled));
+    const float exponent =
+        __fmaf_rd(saturated, __uint_as_float(0x437C0000U), __uint_as_float(0x4B400001U));
+    const float rounded = __fadd_rn(exponent, __uint_as_float(0xCB40007FU));
+    float reduced = __fmaf_rn(value, __uint_as_float(0x3FB8AA3BU), -rounded);
+    reduced = __fmaf_rn(value, __uint_as_float(0x32A57060U), reduced);
+    const float power_of_two = __uint_as_float(__float_as_uint(exponent) << 23U);
+    float exponential;
+    asm("ex2.approx.ftz.f32 %0, %1;" : "=f"(exponential) : "f"(reduced));
+    return __fmul_rn(exponential, power_of_two);
+}
+
+// Exact reduction topology decoded from the pinned JAX 0.5.3 / XLA prefix
+// program. One 64-thread block owns one head/query row. Each thread processes
+// 16 keys separated by 64, then reductions proceed first across eight-lane
+// logical groups and finally across the eight group totals. This is deliberately
+// family- and shape-specific so unsupported attention shapes fail closed.
+__global__ void openpi_prefix_softmax_kernel(const float* __restrict__ logits,
+                                             const std::uint8_t* __restrict__ attention_mask,
+                                             std::uint16_t* __restrict__ probabilities) {
+    const int32_t row = blockIdx.x;
+    const int32_t thread = threadIdx.x;
+    const int32_t query = row % kRopeSequence;
+    constexpr float negative = -2.3819763e38F;
+    const int64_t logits_base = static_cast<int64_t>(row) * kRopeSequence;
+    const int64_t mask_base = static_cast<int64_t>(query) * kRopeSequence;
+
+    float maximum = __uint_as_float(0xFF800000U);
+#pragma unroll
+    for (int32_t key_tile = 0; key_tile < kPrefixSoftmaxTiles; ++key_tile) {
+        const int32_t key = thread + kPrefixSoftmaxThreads * key_tile;
+        if (key < kRopeSequence) {
+            const float value =
+                attention_mask[mask_base + key] ? logits[logits_base + key] : negative;
+            maximum = fmaxf(maximum, value);
+        }
+    }
+#pragma unroll
+    for (int32_t offset = 4; offset > 0; offset >>= 1) {
+        maximum = fmaxf(maximum, __shfl_xor_sync(0xFFFFFFFFU, maximum, offset, 8));
+    }
+
+    __shared__ float partial[8];
+    if ((thread & 7) == 0) {
+        partial[thread >> 3] = maximum;
+    }
+    __syncthreads();
+    if (thread < 8) {
+        maximum = partial[thread];
+#pragma unroll
+        for (int32_t offset = 4; offset > 0; offset >>= 1) {
+            maximum = fmaxf(maximum, __shfl_xor_sync(0x000000FFU, maximum, offset, 8));
+        }
+    }
+    __syncthreads();
+    if (thread == 0) {
+        partial[0] = maximum;
+    }
+    __syncthreads();
+    maximum = partial[0];
+    // All threads must consume the broadcast maximum before group leaders
+    // reuse the same shared array for the exponential-sum reduction.
+    __syncthreads();
+
+    float exponentials[kPrefixSoftmaxTiles]{};
+    float sum = 0.0F;
+#pragma unroll
+    for (int32_t key_tile = 0; key_tile < kPrefixSoftmaxTiles; ++key_tile) {
+        const int32_t key = thread + kPrefixSoftmaxThreads * key_tile;
+        if (key < kRopeSequence) {
+            const float value =
+                attention_mask[mask_base + key] ? logits[logits_base + key] : negative;
+            exponentials[key_tile] = openpi_prefix_expf(__fsub_rn(value, maximum));
+            sum = __fadd_rn(sum, exponentials[key_tile]);
+        }
+    }
+#pragma unroll
+    for (int32_t offset = 4; offset > 0; offset >>= 1) {
+        sum = __fadd_rn(sum, __shfl_xor_sync(0xFFFFFFFFU, sum, offset, 8));
+    }
+    if ((thread & 7) == 0) {
+        partial[thread >> 3] = sum;
+    }
+    __syncthreads();
+    if (thread < 8) {
+        sum = partial[thread];
+#pragma unroll
+        for (int32_t offset = 4; offset > 0; offset >>= 1) {
+            sum = __fadd_rn(sum, __shfl_xor_sync(0x000000FFU, sum, offset, 8));
+        }
+    }
+    __syncthreads();
+    if (thread == 0) {
+        partial[0] = sum;
+    }
+    __syncthreads();
+    sum = partial[0];
+
+#pragma unroll
+    for (int32_t key_tile = 0; key_tile < kPrefixSoftmaxTiles; ++key_tile) {
+        const int32_t key = thread + kPrefixSoftmaxThreads * key_tile;
+        if (key < kRopeSequence) {
+            probabilities[logits_base + key] =
+                float_to_bf16_rn(full_divide(exponentials[key_tile], sum));
+        }
+    }
+}
+
+// Exact final adaptive RMSNorm lowering from the pinned pi05-DROID XLA
+// fusion.144. Unlike the per-layer fusion.100 primitive above, one eight-warp
+// block owns a 16-channel output tile and jointly reproduces the condition
+// projection, all 15 RMS reductions, and the final modulation. Row 15 is the
+// zero-padded row present in XLA's [16,1024] tile and is deliberately not
+// stored.
+__global__ void openpi_final_adaptive_rms_norm_kernel(const std::uint16_t* __restrict__ hidden,
+                                                      const std::uint16_t* __restrict__ bias,
+                                                      const std::uint16_t* __restrict__ weight,
+                                                      const float* __restrict__ condition,
+                                                      std::uint16_t* __restrict__ output,
+                                                      float epsilon) {
+    __shared__ std::uint16_t condition_bf16[kActionWidth];
+    __shared__ float rms_partials[kFinalAdaptivePaddedRows][kFinalAdaptiveRmsWarpsPerRow];
+    __shared__ float reciprocals[kFinalAdaptivePaddedRows];
+    __shared__ float projection_partials[kFinalAdaptiveColumnsPerBlock][kFinalAdaptiveWarpCount];
+    __shared__ std::uint16_t modulation[2][kFinalAdaptiveColumnsPerBlock];
+
+    const int32_t thread = threadIdx.x;
+    const int32_t lane = thread & 31;
+    const int32_t warp = thread >> 5;
+    const int32_t column_base = static_cast<int32_t>(blockIdx.x) * kFinalAdaptiveColumnsPerBlock;
+
+    // fusion.144 materializes condition.astype(bfloat16) in 256 four-value
+    // vector lanes before either of the two [1024,16] reductions.
+    const int32_t condition_base = thread * 4;
+#pragma unroll
+    for (int32_t item = 0; item < 4; ++item) {
+        const int32_t index = condition_base + item;
+        condition_bf16[index] = float_to_bf16_rn(condition[index]);
+    }
+    __syncthreads();
+
+    // Each row parity uses 128 threads. A thread owns eight contiguous
+    // dimensions for every row of that parity; four warp totals are then
+    // reduced with the exact XOR(2), XOR(1) tree emitted by Triton.
+    const int32_t row_parity = thread >> 7;
+    const int32_t first_dimension = (thread & 127) * 8;
+#pragma unroll
+    for (int32_t row_pair = 0; row_pair < 8; ++row_pair) {
+        const int32_t row = row_pair * 2 + row_parity;
+        float local_sum = 0.0F;
+        if (row < kFinalAdaptiveRows) {
+            const int64_t row_base = static_cast<int64_t>(row) * kActionWidth + first_dimension;
+            float value = bf16_to_float(hidden[row_base]);
+            local_sum = __fmul_rn(value, value);
+#pragma unroll
+            for (int32_t item = 1; item < 8; ++item) {
+                value = bf16_to_float(hidden[row_base + item]);
+                local_sum = __fadd_rn(local_sum, __fmul_rn(value, value));
+            }
+        }
+#pragma unroll
+        for (int32_t offset = 16; offset > 0; offset >>= 1) {
+            local_sum = __fadd_rn(local_sum, __shfl_xor_sync(0xFFFFFFFFU, local_sum, offset, 32));
+        }
+        if (lane == 0) {
+            rms_partials[row][warp & 3] = local_sum;
+        }
+    }
+    __syncthreads();
+
+    if (thread < kFinalAdaptivePaddedRows * kFinalAdaptiveRmsWarpsPerRow) {
+        const int32_t row = thread / kFinalAdaptiveRmsWarpsPerRow;
+        const int32_t partial = thread & 3;
+        float total = rms_partials[row][partial];
+        total = __fadd_rn(total, __shfl_xor_sync(0xFFFFFFFFU, total, 2, 32));
+        total = __fadd_rn(total, __shfl_xor_sync(0xFFFFFFFFU, total, 1, 32));
+        if (partial == 0) {
+            const float mean = __fmul_rn(total, kActionReciprocalWidth);
+            reciprocals[row] = approximate_rsqrt(__fadd_rn(mean, epsilon));
+        }
+    }
+    __syncthreads();
+
+    // Thread parity selects one eight-column half of this block's output
+    // tile. Each thread reduces K={k0,k0+128,...,k0+896} serially. The
+    // physical warp combines the 16 lanes of each parity using XOR
+    // 16/8/4/2; shared memory then combines all eight warp totals using XOR
+    // 4/2/1. This is the reduction order in fusion.144, not a generic GEMM.
+    const int32_t column_half = thread & 1;
+    const int32_t k0 = ((thread >> 1) & 63) + ((thread >> 7) * 64);
+#pragma unroll
+    for (int32_t slice = 0; slice < 2; ++slice) {
+        const int32_t slice_offset = slice * kActionWidth;
+#pragma unroll
+        for (int32_t item = 0; item < 8; ++item) {
+            const int32_t relative_column = column_half * 8 + item;
+            const int32_t output_column = column_base + relative_column;
+            std::uint16_t product =
+                bf16_multiply_rn(condition_bf16[k0],
+                                 weight[static_cast<int64_t>(k0) * kFinalAdaptiveProjectionWidth +
+                                        slice_offset + output_column]);
+            float local_sum = bf16_to_float(product);
+#pragma unroll
+            for (int32_t tile = 1; tile < kFinalAdaptiveConditionTiles; ++tile) {
+                const int32_t reduction_index =
+                    k0 + tile * (kActionWidth / kFinalAdaptiveConditionTiles);
+                product = bf16_multiply_rn(
+                    condition_bf16[reduction_index],
+                    weight[static_cast<int64_t>(reduction_index) * kFinalAdaptiveProjectionWidth +
+                           slice_offset + output_column]);
+                local_sum = __fadd_rn(local_sum, bf16_to_float(product));
+            }
+#pragma unroll
+            for (int32_t offset = 16; offset >= 2; offset >>= 1) {
+                local_sum =
+                    __fadd_rn(local_sum, __shfl_xor_sync(0xFFFFFFFFU, local_sum, offset, 32));
+            }
+            if (lane < 2) {
+                projection_partials[relative_column][warp] = local_sum;
+            }
+        }
+        __syncthreads();
+
+        if (thread < kFinalAdaptiveColumnsPerBlock * kFinalAdaptiveWarpCount) {
+            const int32_t relative_column = thread / kFinalAdaptiveWarpCount;
+            const int32_t partial = thread & (kFinalAdaptiveWarpCount - 1);
+            float total = projection_partials[relative_column][partial];
+            total = __fadd_rn(total, __shfl_xor_sync(0xFFFFFFFFU, total, 4, 32));
+            total = __fadd_rn(total, __shfl_xor_sync(0xFFFFFFFFU, total, 2, 32));
+            total = __fadd_rn(total, __shfl_xor_sync(0xFFFFFFFFU, total, 1, 32));
+            if (partial == 0) {
+                const int32_t parameter_column = slice_offset + column_base + relative_column;
+                std::uint16_t value = bf16_add_rn(float_to_bf16_rn(total), bias[parameter_column]);
+                if (slice == 0) {
+                    value = bf16_add_rn(value, 0x3F80U);
+                }
+                modulation[slice][relative_column] = value;
+            }
+        }
+        __syncthreads();
+    }
+
+    const int32_t row = thread >> 4;
+    const int32_t relative_column = thread & 15;
+    if (row < kFinalAdaptiveRows) {
+        const int64_t index =
+            static_cast<int64_t>(row) * kActionWidth + column_base + relative_column;
+        const float normalized = __fmul_rn(bf16_to_float(hidden[index]), reciprocals[row]);
+        const float scaled = __fmul_rn(normalized, bf16_to_float(modulation[0][relative_column]));
+        const float shifted = __fadd_rn(scaled, bf16_to_float(modulation[1][relative_column]));
+        output[index] = float_to_bf16_rn(shifted);
+    }
+}
+
+// Exact arithmetic seam from production fusion.98. The two BF16 roundings in
+// the residual path are intentional: XLA emits one native-BF16 FMA for the
+// gated update and a second native-BF16 FMA for the residual addition before
+// widening the result for the RMS reduction.
+__global__ void openpi_post_attention_rms_norm_kernel(
+    const std::uint16_t* __restrict__ residual, const std::uint16_t* __restrict__ update,
+    const std::uint16_t* __restrict__ residual_gate, const std::uint16_t* __restrict__ scale,
+    const std::uint16_t* __restrict__ shift, std::uint16_t* __restrict__ output, int32_t rows,
+    float epsilon) {
+    __shared__ float partials[2];
+
+    const int32_t row = blockIdx.x;
+    if (row >= rows) {
+        return;
+    }
+    const int32_t lane = threadIdx.x & 31;
+    const int32_t warp = threadIdx.x >> 5;
+    const int32_t first_dimension = lane * 8 + warp * 256;
+    const int64_t row_base = static_cast<int64_t>(row) * kActionWidth;
+    float values[kActionElementsPerThread];
+
+#pragma unroll
+    for (int32_t item = 0; item < 8; ++item) {
+        const int32_t dimensions[2] = {first_dimension + item, first_dimension + 512 + item};
+#pragma unroll
+        for (int32_t region = 0; region < 2; ++region) {
+            const int32_t dimension = dimensions[region];
+            const float gated = bf16_to_float(
+                float_to_bf16_rn(__fmul_rn(bf16_to_float(update[row_base + dimension]),
+                                           bf16_to_float(residual_gate[dimension]))));
+            values[item + region * 8] = bf16_to_float(
+                float_to_bf16_rn(__fadd_rn(bf16_to_float(residual[row_base + dimension]), gated)));
+        }
+    }
+
+    float local_sum = __fmul_rn(values[0], values[0]);
+#pragma unroll
+    for (int32_t item = 1; item < kActionElementsPerThread; ++item) {
+        local_sum = __fadd_rn(local_sum, __fmul_rn(values[item], values[item]));
+    }
+    const float warp_sum = warp_reduce_sum(local_sum);
+    if (lane == 0) {
+        partials[warp] = warp_sum;
+    }
+    __syncthreads();
+
+    float two_warp_value = 0.0F;
+    if (threadIdx.x < 2) {
+        two_warp_value = partials[threadIdx.x];
+    }
+    two_warp_value += __shfl_xor_sync(0xFFFFFFFFU, two_warp_value, 1, 32);
+    if (threadIdx.x == 0) {
+        partials[0] = two_warp_value;
+    }
+    __syncthreads();
+
+    const float reciprocal =
+        rsqrtf(__fadd_rn(__fmul_rn(partials[0], kActionReciprocalWidth), epsilon));
+#pragma unroll
+    for (int32_t item = 0; item < 8; ++item) {
+        const int32_t dimensions[2] = {first_dimension + item, first_dimension + 512 + item};
+#pragma unroll
+        for (int32_t region = 0; region < 2; ++region) {
+            const int32_t dimension = dimensions[region];
+            const float gamma =
+                bf16_to_float(float_to_bf16_rn(__fadd_rn(bf16_to_float(scale[dimension]), 1.0F)));
+            const float normalized = __fmul_rn(values[item + region * 8], reciprocal);
+            const float modulated =
+                __fadd_rn(__fmul_rn(normalized, gamma), bf16_to_float(shift[dimension]));
+            output[row_base + dimension] = float_to_bf16_rn(modulated);
+        }
+    }
+}
+
+bool is_bf16_linear(nvinfer1::PluginTensorDesc const& descriptor) {
+    return descriptor.type == nvinfer1::DataType::kBF16 &&
+           descriptor.format == nvinfer1::TensorFormat::kLINEAR;
+}
+
+bool is_float_linear(nvinfer1::PluginTensorDesc const& descriptor) {
+    return descriptor.type == nvinfer1::DataType::kFLOAT &&
+           descriptor.format == nvinfer1::TensorFormat::kLINEAR;
+}
+
+bool is_bool_linear(nvinfer1::PluginTensorDesc const& descriptor) {
+    return descriptor.type == nvinfer1::DataType::kBOOL &&
+           descriptor.format == nvinfer1::TensorFormat::kLINEAR;
+}
+
+bool has_supported_shape(nvinfer1::Dims const& input, nvinfer1::Dims const& scale) {
+    if (input.nbDims < 2 || scale.nbDims != 1 || input.d[input.nbDims - 1] != kWidth ||
+        scale.d[0] != kWidth) {
+        return false;
+    }
+    int64_t rows = 1;
+    for (int32_t axis = 0; axis + 1 < input.nbDims; ++axis) {
+        if (input.d[axis] <= 0) {
+            return false;
+        }
+        rows *= input.d[axis];
+    }
+    return rows > 0 && rows <= std::numeric_limits<int32_t>::max();
+}
+
+bool is_int32_linear(nvinfer1::PluginTensorDesc const& descriptor) {
+    return descriptor.type == nvinfer1::DataType::kINT32 &&
+           descriptor.format == nvinfer1::TensorFormat::kLINEAR;
+}
+
+bool has_rope_shape(nvinfer1::Dims const& query, nvinfer1::Dims const& key,
+                    nvinfer1::Dims const& positions) {
+    if (query.nbDims != 4 || key.nbDims != 4 || positions.nbDims != 2 ||
+        (query.d[2] != kRopeSequence && query.d[2] != kActionSequence)) {
+        return false;
+    }
+    const int32_t sequence = query.d[2];
+    return query.nbDims == 4 && key.nbDims == 4 && positions.nbDims == 2 && query.d[0] == 1 &&
+           query.d[1] == kRopeQueryHeads && query.d[2] == sequence && query.d[3] == kRopeHeadDim &&
+           key.d[0] == 1 && key.d[1] == kRopeKeyHeads && key.d[2] == sequence &&
+           key.d[3] == kRopeHeadDim && positions.d[0] == 1 && positions.d[1] == sequence;
+}
+
+bool has_prefix_qk_shape(nvinfer1::Dims const& query, nvinfer1::Dims const& key) {
+    return query.nbDims == 4 && key.nbDims == 4 && query.d[0] == 1 &&
+           query.d[1] == kRopeQueryHeads && query.d[2] == kRopeSequence &&
+           query.d[3] == kRopeHeadDim && key.d[0] == 1 && key.d[1] == kRopeKeyHeads &&
+           key.d[2] == kRopeSequence && key.d[3] == kRopeHeadDim;
+}
+
+bool has_prefix_softmax_shape(nvinfer1::Dims const& logits, nvinfer1::Dims const& attention_mask) {
+    return logits.nbDims == 4 && attention_mask.nbDims == 4 && logits.d[0] == 1 &&
+           logits.d[1] == kRopeQueryHeads && logits.d[2] == kRopeSequence &&
+           logits.d[3] == kRopeSequence && attention_mask.d[0] == 1 && attention_mask.d[1] == 1 &&
+           attention_mask.d[2] == kRopeSequence && attention_mask.d[3] == kRopeSequence;
+}
+
+bool has_supported_adaptive_shape(nvinfer1::Dims const& input, nvinfer1::Dims const& scale,
+                                  nvinfer1::Dims const& shift) {
+    if (input.nbDims < 2 || scale.nbDims != 1 || shift.nbDims != 1 ||
+        input.d[input.nbDims - 1] != kActionWidth || scale.d[0] != kActionWidth ||
+        shift.d[0] != kActionWidth) {
+        return false;
+    }
+    int64_t rows = 1;
+    for (int32_t axis = 0; axis + 1 < input.nbDims; ++axis) {
+        if (input.d[axis] <= 0) {
+            return false;
+        }
+        rows *= input.d[axis];
+    }
+    return rows > 0 && rows <= std::numeric_limits<int32_t>::max();
+}
+
+bool has_final_adaptive_shape(nvinfer1::Dims const& hidden, nvinfer1::Dims const& bias,
+                              nvinfer1::Dims const& weight, nvinfer1::Dims const& condition) {
+    return hidden.nbDims == 3 && hidden.d[0] == 1 && hidden.d[1] == kFinalAdaptiveRows &&
+           hidden.d[2] == kActionWidth && bias.nbDims == 1 &&
+           bias.d[0] == kFinalAdaptiveProjectionWidth && weight.nbDims == 2 &&
+           weight.d[0] == kActionWidth && weight.d[1] == kFinalAdaptiveProjectionWidth &&
+           condition.nbDims == 2 && condition.d[0] == 1 && condition.d[1] == kActionWidth;
+}
+
+bool has_final_adaptive_output_shape(nvinfer1::Dims const& output) {
+    return output.nbDims == 3 && output.d[0] == 1 && output.d[1] == kFinalAdaptiveRows &&
+           output.d[2] == kActionWidth;
+}
+
+bool has_supported_post_attention_shape(nvinfer1::Dims const& residual,
+                                        nvinfer1::Dims const& update,
+                                        nvinfer1::Dims const& residual_gate,
+                                        nvinfer1::Dims const& scale, nvinfer1::Dims const& shift) {
+    if (!has_supported_adaptive_shape(residual, scale, shift) || update.nbDims != residual.nbDims ||
+        residual_gate.nbDims != 1 || residual_gate.d[0] != kActionWidth) {
+        return false;
+    }
+    for (int32_t axis = 0; axis < residual.nbDims; ++axis) {
+        if (update.d[axis] != residual.d[axis]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+class OpenPIRmsNormPlugin final : public nvinfer1::IPluginV3,
+                                  public nvinfer1::IPluginV3OneCore,
+                                  public nvinfer1::IPluginV3OneBuild,
+                                  public nvinfer1::IPluginV3OneRuntime {
+  public:
+    static constexpr const char* kName = "OpenPIRmsNorm";
+    static constexpr const char* kVersion = "1";
+
+    explicit OpenPIRmsNormPlugin(float epsilon = 1.0e-6F) : epsilon_(epsilon) {
+        reset_serialization_fields();
+    }
+
+    nvinfer1::IPluginCapability*
+    getCapabilityInterface(nvinfer1::PluginCapabilityType type) noexcept override {
+        switch (type) {
+        case nvinfer1::PluginCapabilityType::kCORE:
+            return static_cast<nvinfer1::IPluginV3OneCore*>(this);
+        case nvinfer1::PluginCapabilityType::kBUILD:
+            return static_cast<nvinfer1::IPluginV3OneBuild*>(this);
+        case nvinfer1::PluginCapabilityType::kRUNTIME:
+            return static_cast<nvinfer1::IPluginV3OneRuntime*>(this);
+        }
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV3* clone() noexcept override {
+        auto* plugin = new (std::nothrow) OpenPIRmsNormPlugin(epsilon_);
+        if (plugin != nullptr) {
+            plugin->namespace_ = namespace_;
+        }
+        return plugin;
+    }
+
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override { return kName; }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override { return kVersion; }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override {
+        return namespace_.c_str();
+    }
+
+    int32_t configurePlugin(nvinfer1::DynamicPluginTensorDesc const* input, int32_t nb_inputs,
+                            nvinfer1::DynamicPluginTensorDesc const* output,
+                            int32_t nb_outputs) noexcept override {
+        if (input == nullptr || output == nullptr || nb_inputs != 2 || nb_outputs != 1 ||
+            !is_bf16_linear(input[0].desc) || !is_bf16_linear(input[1].desc) ||
+            !is_bf16_linear(output[0].desc)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t getOutputDataTypes(nvinfer1::DataType* output_types, int32_t nb_outputs,
+                               nvinfer1::DataType const* input_types,
+                               int32_t nb_inputs) const noexcept override {
+        if (output_types == nullptr || input_types == nullptr || nb_outputs != 1 ||
+            nb_inputs != 2 || input_types[0] != nvinfer1::DataType::kBF16 ||
+            input_types[1] != nvinfer1::DataType::kBF16) {
+            return 1;
+        }
+        output_types[0] = nvinfer1::DataType::kBF16;
+        return 0;
+    }
+
+    int32_t getOutputShapes(nvinfer1::DimsExprs const* inputs, int32_t nb_inputs,
+                            nvinfer1::DimsExprs const*, int32_t nb_shape_inputs,
+                            nvinfer1::DimsExprs* outputs, int32_t nb_outputs,
+                            nvinfer1::IExprBuilder&) noexcept override {
+        if (inputs == nullptr || outputs == nullptr || nb_inputs != 2 || nb_shape_inputs != 0 ||
+            nb_outputs != 1) {
+            return 1;
+        }
+        outputs[0] = inputs[0];
+        return 0;
+    }
+
+    bool supportsFormatCombination(int32_t position,
+                                   nvinfer1::DynamicPluginTensorDesc const* descriptors,
+                                   int32_t nb_inputs, int32_t nb_outputs) noexcept override {
+        return descriptors != nullptr && nb_inputs == 2 && nb_outputs == 1 && position >= 0 &&
+               position < 3 && is_bf16_linear(descriptors[position].desc);
+    }
+
+    int32_t getNbOutputs() const noexcept override { return 1; }
+
+    int32_t onShapeChange(nvinfer1::PluginTensorDesc const* input, int32_t nb_inputs,
+                          nvinfer1::PluginTensorDesc const* output,
+                          int32_t nb_outputs) noexcept override {
+        if (input == nullptr || output == nullptr || nb_inputs != 2 || nb_outputs != 1 ||
+            !has_supported_shape(input[0].dims, input[1].dims) ||
+            output[0].dims.nbDims != input[0].dims.nbDims) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t enqueue(nvinfer1::PluginTensorDesc const* input_desc, nvinfer1::PluginTensorDesc const*,
+                    void const* const* inputs, void* const* outputs, void*,
+                    cudaStream_t stream) noexcept override {
+        if (input_desc == nullptr || inputs == nullptr || outputs == nullptr) {
+            return 1;
+        }
+        int64_t rows = 1;
+        for (int32_t axis = 0; axis + 1 < input_desc[0].dims.nbDims; ++axis) {
+            rows *= input_desc[0].dims.d[axis];
+        }
+        return launch_openpi_rms_norm(static_cast<const std::uint16_t*>(inputs[0]),
+                                      static_cast<const std::uint16_t*>(inputs[1]),
+                                      static_cast<std::uint16_t*>(outputs[0]),
+                                      static_cast<int32_t>(rows), epsilon_, stream);
+    }
+
+    nvinfer1::IPluginV3* attachToContext(nvinfer1::IPluginResourceContext*) noexcept override {
+        return clone();
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldsToSerialize() noexcept override {
+        reset_serialization_fields();
+        return &serialization_fields_;
+    }
+
+  private:
+    void reset_serialization_fields() noexcept {
+        serialization_field_ = {"epsilon", &epsilon_, nvinfer1::PluginFieldType::kFLOAT32, 1};
+        serialization_fields_.nbFields = 1;
+        serialization_fields_.fields = &serialization_field_;
+    }
+
+    float epsilon_{1.0e-6F};
+    std::string namespace_;
+    nvinfer1::PluginField serialization_field_{};
+    nvinfer1::PluginFieldCollection serialization_fields_{};
+};
+
+class OpenPIRmsNormCreator final : public nvinfer1::IPluginCreatorV3One {
+  public:
+    OpenPIRmsNormCreator() {
+        field_ = {"epsilon", nullptr, nvinfer1::PluginFieldType::kFLOAT32, 1};
+        fields_.nbFields = 1;
+        fields_.fields = &field_;
+    }
+
+    nvinfer1::IPluginV3* createPlugin(nvinfer1::AsciiChar const*,
+                                      nvinfer1::PluginFieldCollection const* fields,
+                                      nvinfer1::TensorRTPhase) noexcept override {
+        float epsilon = 1.0e-6F;
+        if (fields != nullptr) {
+            for (int32_t index = 0; index < fields->nbFields; ++index) {
+                const auto& field = fields->fields[index];
+                if (field.name != nullptr && std::strcmp(field.name, "epsilon") == 0 &&
+                    field.type == nvinfer1::PluginFieldType::kFLOAT32 && field.data != nullptr &&
+                    field.length == 1) {
+                    epsilon = *static_cast<const float*>(field.data);
+                }
+            }
+        }
+        if (!(epsilon > 0.0F)) {
+            return nullptr;
+        }
+        return new (std::nothrow) OpenPIRmsNormPlugin(epsilon);
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldNames() noexcept override { return &fields_; }
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override {
+        return OpenPIRmsNormPlugin::kName;
+    }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override {
+        return OpenPIRmsNormPlugin::kVersion;
+    }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override { return ""; }
+
+  private:
+    nvinfer1::PluginField field_{};
+    nvinfer1::PluginFieldCollection fields_{};
+};
+
+class OpenPIRopePlugin final : public nvinfer1::IPluginV3,
+                               public nvinfer1::IPluginV3OneCore,
+                               public nvinfer1::IPluginV3OneBuild,
+                               public nvinfer1::IPluginV3OneRuntime {
+  public:
+    static constexpr const char* kName = "OpenPIRopeQK";
+    static constexpr const char* kVersion = "1";
+
+    OpenPIRopePlugin() { serialization_fields_.nbFields = 0; }
+
+    nvinfer1::IPluginCapability*
+    getCapabilityInterface(nvinfer1::PluginCapabilityType type) noexcept override {
+        switch (type) {
+        case nvinfer1::PluginCapabilityType::kCORE:
+            return static_cast<nvinfer1::IPluginV3OneCore*>(this);
+        case nvinfer1::PluginCapabilityType::kBUILD:
+            return static_cast<nvinfer1::IPluginV3OneBuild*>(this);
+        case nvinfer1::PluginCapabilityType::kRUNTIME:
+            return static_cast<nvinfer1::IPluginV3OneRuntime*>(this);
+        }
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV3* clone() noexcept override {
+        auto* plugin = new (std::nothrow) OpenPIRopePlugin();
+        if (plugin != nullptr) {
+            plugin->namespace_ = namespace_;
+        }
+        return plugin;
+    }
+
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override { return kName; }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override { return kVersion; }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override {
+        return namespace_.c_str();
+    }
+
+    int32_t configurePlugin(nvinfer1::DynamicPluginTensorDesc const* input, int32_t nb_inputs,
+                            nvinfer1::DynamicPluginTensorDesc const* output,
+                            int32_t nb_outputs) noexcept override {
+        if (input == nullptr || output == nullptr || nb_inputs != 3 || nb_outputs != 2 ||
+            !is_bf16_linear(input[0].desc) || !is_bf16_linear(input[1].desc) ||
+            !is_int32_linear(input[2].desc) || !is_bf16_linear(output[0].desc) ||
+            !is_bf16_linear(output[1].desc)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t getOutputDataTypes(nvinfer1::DataType* output_types, int32_t nb_outputs,
+                               nvinfer1::DataType const* input_types,
+                               int32_t nb_inputs) const noexcept override {
+        if (output_types == nullptr || input_types == nullptr || nb_outputs != 2 ||
+            nb_inputs != 3 || input_types[0] != nvinfer1::DataType::kBF16 ||
+            input_types[1] != nvinfer1::DataType::kBF16 ||
+            input_types[2] != nvinfer1::DataType::kINT32) {
+            return 1;
+        }
+        output_types[0] = nvinfer1::DataType::kBF16;
+        output_types[1] = nvinfer1::DataType::kBF16;
+        return 0;
+    }
+
+    int32_t getOutputShapes(nvinfer1::DimsExprs const* inputs, int32_t nb_inputs,
+                            nvinfer1::DimsExprs const*, int32_t nb_shape_inputs,
+                            nvinfer1::DimsExprs* outputs, int32_t nb_outputs,
+                            nvinfer1::IExprBuilder&) noexcept override {
+        if (inputs == nullptr || outputs == nullptr || nb_inputs != 3 || nb_shape_inputs != 0 ||
+            nb_outputs != 2) {
+            return 1;
+        }
+        outputs[0] = inputs[0];
+        outputs[1] = inputs[1];
+        return 0;
+    }
+
+    bool supportsFormatCombination(int32_t position,
+                                   nvinfer1::DynamicPluginTensorDesc const* descriptors,
+                                   int32_t nb_inputs, int32_t nb_outputs) noexcept override {
+        if (descriptors == nullptr || nb_inputs != 3 || nb_outputs != 2 || position < 0 ||
+            position >= 5) {
+            return false;
+        }
+        return position == 2 ? is_int32_linear(descriptors[position].desc)
+                             : is_bf16_linear(descriptors[position].desc);
+    }
+
+    int32_t getNbOutputs() const noexcept override { return 2; }
+
+    std::size_t getWorkspaceSize(nvinfer1::DynamicPluginTensorDesc const*, int32_t,
+                                 nvinfer1::DynamicPluginTensorDesc const*,
+                                 int32_t) const noexcept override {
+        return kRopeWorkspaceBytes;
+    }
+
+    int32_t onShapeChange(nvinfer1::PluginTensorDesc const* input, int32_t nb_inputs,
+                          nvinfer1::PluginTensorDesc const* output,
+                          int32_t nb_outputs) noexcept override {
+        if (input == nullptr || output == nullptr || nb_inputs != 3 || nb_outputs != 2 ||
+            !has_rope_shape(input[0].dims, input[1].dims, input[2].dims) ||
+            output[0].dims.nbDims != 4 || output[1].dims.nbDims != 4) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t enqueue(nvinfer1::PluginTensorDesc const* input_desc, nvinfer1::PluginTensorDesc const*,
+                    void const* const* inputs, void* const* outputs, void* workspace,
+                    cudaStream_t stream) noexcept override {
+        if (input_desc == nullptr || inputs == nullptr || outputs == nullptr ||
+            workspace == nullptr) {
+            return 1;
+        }
+        return launch_openpi_rope_qk(
+            static_cast<const std::uint16_t*>(inputs[0]),
+            static_cast<const std::uint16_t*>(inputs[1]),
+            static_cast<const std::int32_t*>(inputs[2]), static_cast<std::uint16_t*>(outputs[0]),
+            static_cast<std::uint16_t*>(outputs[1]), input_desc[0].dims.d[2], workspace, stream);
+    }
+
+    nvinfer1::IPluginV3* attachToContext(nvinfer1::IPluginResourceContext*) noexcept override {
+        return clone();
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldsToSerialize() noexcept override {
+        return &serialization_fields_;
+    }
+
+  private:
+    std::string namespace_;
+    nvinfer1::PluginFieldCollection serialization_fields_{};
+};
+
+class OpenPIRopeCreator final : public nvinfer1::IPluginCreatorV3One {
+  public:
+    OpenPIRopeCreator() { fields_.nbFields = 0; }
+
+    nvinfer1::IPluginV3* createPlugin(nvinfer1::AsciiChar const*,
+                                      nvinfer1::PluginFieldCollection const*,
+                                      nvinfer1::TensorRTPhase) noexcept override {
+        return new (std::nothrow) OpenPIRopePlugin();
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldNames() noexcept override { return &fields_; }
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override {
+        return OpenPIRopePlugin::kName;
+    }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override {
+        return OpenPIRopePlugin::kVersion;
+    }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override { return ""; }
+
+  private:
+    nvinfer1::PluginFieldCollection fields_{};
+};
+
+class OpenPIPrefixQKPlugin final : public nvinfer1::IPluginV3,
+                                   public nvinfer1::IPluginV3OneCore,
+                                   public nvinfer1::IPluginV3OneBuild,
+                                   public nvinfer1::IPluginV3OneRuntime {
+  public:
+    static constexpr const char* kName = "OpenPIPrefixQK";
+    static constexpr const char* kVersion = "1";
+
+    OpenPIPrefixQKPlugin() { serialization_fields_.nbFields = 0; }
+
+    ~OpenPIPrefixQKPlugin() override {
+        if (cublas_handle_ != nullptr) {
+            const cublasStatus_t status = cublasDestroy(cublas_handle_);
+            // Destructors cannot report an error through TensorRT. Still
+            // evaluate the return value so no cuBLAS call is unchecked.
+            if (status != CUBLAS_STATUS_SUCCESS) {
+                cublas_handle_ = nullptr;
+                return;
+            }
+            cublas_handle_ = nullptr;
+        }
+    }
+
+    nvinfer1::IPluginCapability*
+    getCapabilityInterface(nvinfer1::PluginCapabilityType type) noexcept override {
+        switch (type) {
+        case nvinfer1::PluginCapabilityType::kCORE:
+            return static_cast<nvinfer1::IPluginV3OneCore*>(this);
+        case nvinfer1::PluginCapabilityType::kBUILD:
+            return static_cast<nvinfer1::IPluginV3OneBuild*>(this);
+        case nvinfer1::PluginCapabilityType::kRUNTIME:
+            return static_cast<nvinfer1::IPluginV3OneRuntime*>(this);
+        }
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV3* clone() noexcept override {
+        auto* plugin = new (std::nothrow) OpenPIPrefixQKPlugin();
+        if (plugin != nullptr) {
+            plugin->namespace_ = namespace_;
+        }
+        return plugin;
+    }
+
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override { return kName; }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override { return kVersion; }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override {
+        return namespace_.c_str();
+    }
+
+    int32_t configurePlugin(nvinfer1::DynamicPluginTensorDesc const* input, int32_t nb_inputs,
+                            nvinfer1::DynamicPluginTensorDesc const* output,
+                            int32_t nb_outputs) noexcept override {
+        if (input == nullptr || output == nullptr || nb_inputs != 2 || nb_outputs != 1 ||
+            !is_bf16_linear(input[0].desc) || !is_bf16_linear(input[1].desc) ||
+            !is_float_linear(output[0].desc)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t getOutputDataTypes(nvinfer1::DataType* output_types, int32_t nb_outputs,
+                               nvinfer1::DataType const* input_types,
+                               int32_t nb_inputs) const noexcept override {
+        if (output_types == nullptr || input_types == nullptr || nb_outputs != 1 ||
+            nb_inputs != 2 || input_types[0] != nvinfer1::DataType::kBF16 ||
+            input_types[1] != nvinfer1::DataType::kBF16) {
+            return 1;
+        }
+        output_types[0] = nvinfer1::DataType::kFLOAT;
+        return 0;
+    }
+
+    int32_t getOutputShapes(nvinfer1::DimsExprs const* inputs, int32_t nb_inputs,
+                            nvinfer1::DimsExprs const*, int32_t nb_shape_inputs,
+                            nvinfer1::DimsExprs* outputs, int32_t nb_outputs,
+                            nvinfer1::IExprBuilder&) noexcept override {
+        if (inputs == nullptr || outputs == nullptr || nb_inputs != 2 || nb_shape_inputs != 0 ||
+            nb_outputs != 1) {
+            return 1;
+        }
+        // Raw cublasGemmEx C is column-major [H*S,S]. TensorRT views the same
+        // bytes row-major as [S,S,H], after which one shuffle transposes it to
+        // the public [H,S,S] attention layout without another arithmetic seam.
+        outputs[0].nbDims = 4;
+        outputs[0].d[0] = inputs[0].d[0];
+        outputs[0].d[1] = inputs[0].d[2];
+        outputs[0].d[2] = inputs[0].d[2];
+        outputs[0].d[3] = inputs[0].d[1];
+        return 0;
+    }
+
+    bool supportsFormatCombination(int32_t position,
+                                   nvinfer1::DynamicPluginTensorDesc const* descriptors,
+                                   int32_t nb_inputs, int32_t nb_outputs) noexcept override {
+        if (descriptors == nullptr || nb_inputs != 2 || nb_outputs != 1 || position < 0 ||
+            position >= 3) {
+            return false;
+        }
+        return position < 2 ? is_bf16_linear(descriptors[position].desc)
+                            : is_float_linear(descriptors[position].desc);
+    }
+
+    int32_t getNbOutputs() const noexcept override { return 1; }
+
+    std::size_t getWorkspaceSize(nvinfer1::DynamicPluginTensorDesc const*, int32_t,
+                                 nvinfer1::DynamicPluginTensorDesc const*,
+                                 int32_t) const noexcept override {
+        return kPrefixQKWorkspaceBytes;
+    }
+
+    int32_t onShapeChange(nvinfer1::PluginTensorDesc const* input, int32_t nb_inputs,
+                          nvinfer1::PluginTensorDesc const* output,
+                          int32_t nb_outputs) noexcept override {
+        if (input == nullptr || output == nullptr || nb_inputs != 2 || nb_outputs != 1 ||
+            !has_prefix_qk_shape(input[0].dims, input[1].dims) || output[0].dims.nbDims != 4 ||
+            output[0].dims.d[0] != 1 || output[0].dims.d[1] != kRopeSequence ||
+            output[0].dims.d[2] != kRopeSequence || output[0].dims.d[3] != kRopeQueryHeads) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t enqueue(nvinfer1::PluginTensorDesc const*, nvinfer1::PluginTensorDesc const*,
+                    void const* const* inputs, void* const* outputs, void* workspace,
+                    cudaStream_t stream) noexcept override {
+        if (inputs == nullptr || outputs == nullptr || workspace == nullptr ||
+            cublas_handle_ == nullptr) {
+            return 1;
+        }
+        return launch_openpi_prefix_qk(static_cast<const std::uint16_t*>(inputs[0]),
+                                       static_cast<const std::uint16_t*>(inputs[1]),
+                                       static_cast<float*>(outputs[0]), workspace,
+                                       static_cast<void*>(cublas_handle_), stream);
+    }
+
+    nvinfer1::IPluginV3* attachToContext(nvinfer1::IPluginResourceContext*) noexcept override {
+        auto* plugin = new (std::nothrow) OpenPIPrefixQKPlugin();
+        if (plugin == nullptr) {
+            return nullptr;
+        }
+        plugin->namespace_ = namespace_;
+        cublasStatus_t status = cublasCreate(&plugin->cublas_handle_);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+            delete plugin;
+            return nullptr;
+        }
+        status = cublasSetMathMode(plugin->cublas_handle_, CUBLAS_DEFAULT_MATH);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+            delete plugin;
+            return nullptr;
+        }
+        return plugin;
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldsToSerialize() noexcept override {
+        return &serialization_fields_;
+    }
+
+  private:
+    std::string namespace_;
+    nvinfer1::PluginFieldCollection serialization_fields_{};
+    cublasHandle_t cublas_handle_{nullptr};
+};
+
+class OpenPIPrefixQKCreator final : public nvinfer1::IPluginCreatorV3One {
+  public:
+    OpenPIPrefixQKCreator() { fields_.nbFields = 0; }
+
+    nvinfer1::IPluginV3* createPlugin(nvinfer1::AsciiChar const*,
+                                      nvinfer1::PluginFieldCollection const*,
+                                      nvinfer1::TensorRTPhase) noexcept override {
+        return new (std::nothrow) OpenPIPrefixQKPlugin();
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldNames() noexcept override { return &fields_; }
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override {
+        return OpenPIPrefixQKPlugin::kName;
+    }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override {
+        return OpenPIPrefixQKPlugin::kVersion;
+    }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override { return ""; }
+
+  private:
+    nvinfer1::PluginFieldCollection fields_{};
+};
+
+class OpenPIPrefixSoftmaxPlugin final : public nvinfer1::IPluginV3,
+                                        public nvinfer1::IPluginV3OneCore,
+                                        public nvinfer1::IPluginV3OneBuild,
+                                        public nvinfer1::IPluginV3OneRuntime {
+  public:
+    static constexpr const char* kName = "OpenPIPrefixSoftmax";
+    static constexpr const char* kVersion = "1";
+
+    OpenPIPrefixSoftmaxPlugin() { serialization_fields_.nbFields = 0; }
+
+    nvinfer1::IPluginCapability*
+    getCapabilityInterface(nvinfer1::PluginCapabilityType type) noexcept override {
+        switch (type) {
+        case nvinfer1::PluginCapabilityType::kCORE:
+            return static_cast<nvinfer1::IPluginV3OneCore*>(this);
+        case nvinfer1::PluginCapabilityType::kBUILD:
+            return static_cast<nvinfer1::IPluginV3OneBuild*>(this);
+        case nvinfer1::PluginCapabilityType::kRUNTIME:
+            return static_cast<nvinfer1::IPluginV3OneRuntime*>(this);
+        }
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV3* clone() noexcept override {
+        auto* plugin = new (std::nothrow) OpenPIPrefixSoftmaxPlugin();
+        if (plugin != nullptr) {
+            plugin->namespace_ = namespace_;
+        }
+        return plugin;
+    }
+
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override { return kName; }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override { return kVersion; }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override {
+        return namespace_.c_str();
+    }
+
+    int32_t configurePlugin(nvinfer1::DynamicPluginTensorDesc const* input, int32_t nb_inputs,
+                            nvinfer1::DynamicPluginTensorDesc const* output,
+                            int32_t nb_outputs) noexcept override {
+        if (input == nullptr || output == nullptr || nb_inputs != 2 || nb_outputs != 1 ||
+            !is_float_linear(input[0].desc) || !is_bool_linear(input[1].desc) ||
+            !is_bf16_linear(output[0].desc)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t getOutputDataTypes(nvinfer1::DataType* output_types, int32_t nb_outputs,
+                               nvinfer1::DataType const* input_types,
+                               int32_t nb_inputs) const noexcept override {
+        if (output_types == nullptr || input_types == nullptr || nb_outputs != 1 ||
+            nb_inputs != 2 || input_types[0] != nvinfer1::DataType::kFLOAT ||
+            input_types[1] != nvinfer1::DataType::kBOOL) {
+            return 1;
+        }
+        output_types[0] = nvinfer1::DataType::kBF16;
+        return 0;
+    }
+
+    int32_t getOutputShapes(nvinfer1::DimsExprs const* inputs, int32_t nb_inputs,
+                            nvinfer1::DimsExprs const*, int32_t nb_shape_inputs,
+                            nvinfer1::DimsExprs* outputs, int32_t nb_outputs,
+                            nvinfer1::IExprBuilder&) noexcept override {
+        if (inputs == nullptr || outputs == nullptr || nb_inputs != 2 || nb_shape_inputs != 0 ||
+            nb_outputs != 1) {
+            return 1;
+        }
+        outputs[0] = inputs[0];
+        return 0;
+    }
+
+    bool supportsFormatCombination(int32_t position,
+                                   nvinfer1::DynamicPluginTensorDesc const* descriptors,
+                                   int32_t nb_inputs, int32_t nb_outputs) noexcept override {
+        if (descriptors == nullptr || nb_inputs != 2 || nb_outputs != 1 || position < 0 ||
+            position >= 3) {
+            return false;
+        }
+        if (position == 0) {
+            return is_float_linear(descriptors[position].desc);
+        }
+        if (position == 1) {
+            return is_bool_linear(descriptors[position].desc);
+        }
+        return is_bf16_linear(descriptors[position].desc);
+    }
+
+    int32_t getNbOutputs() const noexcept override { return 1; }
+
+    std::size_t getWorkspaceSize(nvinfer1::DynamicPluginTensorDesc const*, int32_t,
+                                 nvinfer1::DynamicPluginTensorDesc const*,
+                                 int32_t) const noexcept override {
+        return 0;
+    }
+
+    int32_t onShapeChange(nvinfer1::PluginTensorDesc const* input, int32_t nb_inputs,
+                          nvinfer1::PluginTensorDesc const* output,
+                          int32_t nb_outputs) noexcept override {
+        if (input == nullptr || output == nullptr || nb_inputs != 2 || nb_outputs != 1 ||
+            !has_prefix_softmax_shape(input[0].dims, input[1].dims) || output[0].dims.nbDims != 4 ||
+            output[0].dims.d[0] != 1 || output[0].dims.d[1] != kRopeQueryHeads ||
+            output[0].dims.d[2] != kRopeSequence || output[0].dims.d[3] != kRopeSequence) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t enqueue(nvinfer1::PluginTensorDesc const*, nvinfer1::PluginTensorDesc const*,
+                    void const* const* inputs, void* const* outputs, void*,
+                    cudaStream_t stream) noexcept override {
+        if (inputs == nullptr || outputs == nullptr) {
+            return 1;
+        }
+        return launch_openpi_prefix_softmax(static_cast<const float*>(inputs[0]),
+                                            static_cast<const std::uint8_t*>(inputs[1]),
+                                            static_cast<std::uint16_t*>(outputs[0]), stream);
+    }
+
+    nvinfer1::IPluginV3* attachToContext(nvinfer1::IPluginResourceContext*) noexcept override {
+        return clone();
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldsToSerialize() noexcept override {
+        return &serialization_fields_;
+    }
+
+  private:
+    std::string namespace_;
+    nvinfer1::PluginFieldCollection serialization_fields_{};
+};
+
+class OpenPIPrefixSoftmaxCreator final : public nvinfer1::IPluginCreatorV3One {
+  public:
+    OpenPIPrefixSoftmaxCreator() { fields_.nbFields = 0; }
+
+    nvinfer1::IPluginV3* createPlugin(nvinfer1::AsciiChar const*,
+                                      nvinfer1::PluginFieldCollection const*,
+                                      nvinfer1::TensorRTPhase) noexcept override {
+        return new (std::nothrow) OpenPIPrefixSoftmaxPlugin();
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldNames() noexcept override { return &fields_; }
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override {
+        return OpenPIPrefixSoftmaxPlugin::kName;
+    }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override {
+        return OpenPIPrefixSoftmaxPlugin::kVersion;
+    }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override { return ""; }
+
+  private:
+    nvinfer1::PluginFieldCollection fields_{};
+};
+
+class OpenPIFinalAdaptiveRmsNormPlugin final : public nvinfer1::IPluginV3,
+                                               public nvinfer1::IPluginV3OneCore,
+                                               public nvinfer1::IPluginV3OneBuild,
+                                               public nvinfer1::IPluginV3OneRuntime {
+  public:
+    static constexpr const char* kName = "OpenPIFinalAdaptiveRmsNorm";
+    static constexpr const char* kVersion = "1";
+
+    explicit OpenPIFinalAdaptiveRmsNormPlugin(float epsilon = kFinalAdaptiveEpsilon)
+        : epsilon_(epsilon) {
+        reset_serialization_fields();
+    }
+
+    nvinfer1::IPluginCapability*
+    getCapabilityInterface(nvinfer1::PluginCapabilityType type) noexcept override {
+        switch (type) {
+        case nvinfer1::PluginCapabilityType::kCORE:
+            return static_cast<nvinfer1::IPluginV3OneCore*>(this);
+        case nvinfer1::PluginCapabilityType::kBUILD:
+            return static_cast<nvinfer1::IPluginV3OneBuild*>(this);
+        case nvinfer1::PluginCapabilityType::kRUNTIME:
+            return static_cast<nvinfer1::IPluginV3OneRuntime*>(this);
+        }
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV3* clone() noexcept override {
+        auto* plugin = new (std::nothrow) OpenPIFinalAdaptiveRmsNormPlugin(epsilon_);
+        if (plugin != nullptr) {
+            plugin->namespace_ = namespace_;
+        }
+        return plugin;
+    }
+
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override { return kName; }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override { return kVersion; }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override {
+        return namespace_.c_str();
+    }
+
+    int32_t configurePlugin(nvinfer1::DynamicPluginTensorDesc const* input, int32_t nb_inputs,
+                            nvinfer1::DynamicPluginTensorDesc const* output,
+                            int32_t nb_outputs) noexcept override {
+        if (input == nullptr || output == nullptr || nb_inputs != 4 || nb_outputs != 1 ||
+            !is_bf16_linear(input[0].desc) || !is_bf16_linear(input[1].desc) ||
+            !is_bf16_linear(input[2].desc) || !is_float_linear(input[3].desc) ||
+            !is_bf16_linear(output[0].desc) ||
+            !has_final_adaptive_shape(input[0].desc.dims, input[1].desc.dims, input[2].desc.dims,
+                                      input[3].desc.dims) ||
+            !has_final_adaptive_shape(input[0].min, input[1].min, input[2].min, input[3].min) ||
+            !has_final_adaptive_shape(input[0].max, input[1].max, input[2].max, input[3].max) ||
+            !has_final_adaptive_output_shape(output[0].desc.dims) ||
+            !has_final_adaptive_output_shape(output[0].min) ||
+            !has_final_adaptive_output_shape(output[0].max)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t getOutputDataTypes(nvinfer1::DataType* output_types, int32_t nb_outputs,
+                               nvinfer1::DataType const* input_types,
+                               int32_t nb_inputs) const noexcept override {
+        if (output_types == nullptr || input_types == nullptr || nb_outputs != 1 ||
+            nb_inputs != 4 || input_types[0] != nvinfer1::DataType::kBF16 ||
+            input_types[1] != nvinfer1::DataType::kBF16 ||
+            input_types[2] != nvinfer1::DataType::kBF16 ||
+            input_types[3] != nvinfer1::DataType::kFLOAT) {
+            return 1;
+        }
+        output_types[0] = nvinfer1::DataType::kBF16;
+        return 0;
+    }
+
+    int32_t getOutputShapes(nvinfer1::DimsExprs const* inputs, int32_t nb_inputs,
+                            nvinfer1::DimsExprs const*, int32_t nb_shape_inputs,
+                            nvinfer1::DimsExprs* outputs, int32_t nb_outputs,
+                            nvinfer1::IExprBuilder&) noexcept override {
+        if (inputs == nullptr || outputs == nullptr || nb_inputs != 4 || nb_shape_inputs != 0 ||
+            nb_outputs != 1) {
+            return 1;
+        }
+        outputs[0] = inputs[0];
+        return 0;
+    }
+
+    bool supportsFormatCombination(int32_t position,
+                                   nvinfer1::DynamicPluginTensorDesc const* descriptors,
+                                   int32_t nb_inputs, int32_t nb_outputs) noexcept override {
+        if (descriptors == nullptr || nb_inputs != 4 || nb_outputs != 1 || position < 0 ||
+            position >= 5) {
+            return false;
+        }
+        return position == 3 ? is_float_linear(descriptors[position].desc)
+                             : is_bf16_linear(descriptors[position].desc);
+    }
+
+    int32_t getNbOutputs() const noexcept override { return 1; }
+
+    std::size_t getWorkspaceSize(nvinfer1::DynamicPluginTensorDesc const*, int32_t,
+                                 nvinfer1::DynamicPluginTensorDesc const*,
+                                 int32_t) const noexcept override {
+        return 0;
+    }
+
+    int32_t onShapeChange(nvinfer1::PluginTensorDesc const* input, int32_t nb_inputs,
+                          nvinfer1::PluginTensorDesc const* output,
+                          int32_t nb_outputs) noexcept override {
+        if (input == nullptr || output == nullptr || nb_inputs != 4 || nb_outputs != 1 ||
+            !is_bf16_linear(input[0]) || !is_bf16_linear(input[1]) || !is_bf16_linear(input[2]) ||
+            !is_float_linear(input[3]) || !is_bf16_linear(output[0]) ||
+            !has_final_adaptive_shape(input[0].dims, input[1].dims, input[2].dims, input[3].dims) ||
+            !has_final_adaptive_output_shape(output[0].dims)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t enqueue(nvinfer1::PluginTensorDesc const* input_desc,
+                    nvinfer1::PluginTensorDesc const* output_desc, void const* const* inputs,
+                    void* const* outputs, void*, cudaStream_t stream) noexcept override {
+        if (input_desc == nullptr || output_desc == nullptr || inputs == nullptr ||
+            outputs == nullptr || !is_bf16_linear(input_desc[0]) ||
+            !is_bf16_linear(input_desc[1]) || !is_bf16_linear(input_desc[2]) ||
+            !is_float_linear(input_desc[3]) || !is_bf16_linear(output_desc[0]) ||
+            !has_final_adaptive_shape(input_desc[0].dims, input_desc[1].dims, input_desc[2].dims,
+                                      input_desc[3].dims) ||
+            !has_final_adaptive_output_shape(output_desc[0].dims)) {
+            return 1;
+        }
+        return launch_openpi_final_adaptive_rms_norm(
+            static_cast<const std::uint16_t*>(inputs[0]),
+            static_cast<const std::uint16_t*>(inputs[1]),
+            static_cast<const std::uint16_t*>(inputs[2]), static_cast<const float*>(inputs[3]),
+            static_cast<std::uint16_t*>(outputs[0]), epsilon_, stream);
+    }
+
+    nvinfer1::IPluginV3* attachToContext(nvinfer1::IPluginResourceContext*) noexcept override {
+        return clone();
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldsToSerialize() noexcept override {
+        reset_serialization_fields();
+        return &serialization_fields_;
+    }
+
+  private:
+    void reset_serialization_fields() noexcept {
+        serialization_field_ = {"epsilon", &epsilon_, nvinfer1::PluginFieldType::kFLOAT32, 1};
+        serialization_fields_.nbFields = 1;
+        serialization_fields_.fields = &serialization_field_;
+    }
+
+    float epsilon_{kFinalAdaptiveEpsilon};
+    std::string namespace_;
+    nvinfer1::PluginField serialization_field_{};
+    nvinfer1::PluginFieldCollection serialization_fields_{};
+};
+
+class OpenPIFinalAdaptiveRmsNormCreator final : public nvinfer1::IPluginCreatorV3One {
+  public:
+    OpenPIFinalAdaptiveRmsNormCreator() {
+        field_ = {"epsilon", nullptr, nvinfer1::PluginFieldType::kFLOAT32, 1};
+        fields_.nbFields = 1;
+        fields_.fields = &field_;
+    }
+
+    nvinfer1::IPluginV3* createPlugin(nvinfer1::AsciiChar const*,
+                                      nvinfer1::PluginFieldCollection const* fields,
+                                      nvinfer1::TensorRTPhase) noexcept override {
+        if (fields == nullptr || fields->fields == nullptr || fields->nbFields != 1) {
+            return nullptr;
+        }
+        const auto& field = fields->fields[0];
+        if (field.name == nullptr || std::strcmp(field.name, "epsilon") != 0 ||
+            field.type != nvinfer1::PluginFieldType::kFLOAT32 || field.data == nullptr ||
+            field.length != 1) {
+            return nullptr;
+        }
+        const float epsilon = *static_cast<const float*>(field.data);
+        if (epsilon != kFinalAdaptiveEpsilon) {
+            return nullptr;
+        }
+        return new (std::nothrow) OpenPIFinalAdaptiveRmsNormPlugin(epsilon);
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldNames() noexcept override { return &fields_; }
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override {
+        return OpenPIFinalAdaptiveRmsNormPlugin::kName;
+    }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override {
+        return OpenPIFinalAdaptiveRmsNormPlugin::kVersion;
+    }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override { return ""; }
+
+  private:
+    nvinfer1::PluginField field_{};
+    nvinfer1::PluginFieldCollection fields_{};
+};
+
+class OpenPIPostAttentionRmsNormPlugin final : public nvinfer1::IPluginV3,
+                                               public nvinfer1::IPluginV3OneCore,
+                                               public nvinfer1::IPluginV3OneBuild,
+                                               public nvinfer1::IPluginV3OneRuntime {
+  public:
+    static constexpr const char* kName = "OpenPIPostAttentionRmsNorm";
+    static constexpr const char* kVersion = "1";
+
+    explicit OpenPIPostAttentionRmsNormPlugin(float epsilon = 1.0e-6F) : epsilon_(epsilon) {
+        reset_serialization_fields();
+    }
+
+    nvinfer1::IPluginCapability*
+    getCapabilityInterface(nvinfer1::PluginCapabilityType type) noexcept override {
+        switch (type) {
+        case nvinfer1::PluginCapabilityType::kCORE:
+            return static_cast<nvinfer1::IPluginV3OneCore*>(this);
+        case nvinfer1::PluginCapabilityType::kBUILD:
+            return static_cast<nvinfer1::IPluginV3OneBuild*>(this);
+        case nvinfer1::PluginCapabilityType::kRUNTIME:
+            return static_cast<nvinfer1::IPluginV3OneRuntime*>(this);
+        }
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV3* clone() noexcept override {
+        auto* plugin = new (std::nothrow) OpenPIPostAttentionRmsNormPlugin(epsilon_);
+        if (plugin != nullptr) {
+            plugin->namespace_ = namespace_;
+        }
+        return plugin;
+    }
+
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override { return kName; }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override { return kVersion; }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override {
+        return namespace_.c_str();
+    }
+
+    int32_t configurePlugin(nvinfer1::DynamicPluginTensorDesc const* input, int32_t nb_inputs,
+                            nvinfer1::DynamicPluginTensorDesc const* output,
+                            int32_t nb_outputs) noexcept override {
+        if (input == nullptr || output == nullptr || nb_inputs != 5 || nb_outputs != 1 ||
+            !is_bf16_linear(input[0].desc) || !is_bf16_linear(input[1].desc) ||
+            !is_bf16_linear(input[2].desc) || !is_bf16_linear(input[3].desc) ||
+            !is_bf16_linear(input[4].desc) || !is_bf16_linear(output[0].desc)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t getOutputDataTypes(nvinfer1::DataType* output_types, int32_t nb_outputs,
+                               nvinfer1::DataType const* input_types,
+                               int32_t nb_inputs) const noexcept override {
+        if (output_types == nullptr || input_types == nullptr || nb_outputs != 1 ||
+            nb_inputs != 5) {
+            return 1;
+        }
+        for (int32_t index = 0; index < nb_inputs; ++index) {
+            if (input_types[index] != nvinfer1::DataType::kBF16) {
+                return 1;
+            }
+        }
+        output_types[0] = nvinfer1::DataType::kBF16;
+        return 0;
+    }
+
+    int32_t getOutputShapes(nvinfer1::DimsExprs const* inputs, int32_t nb_inputs,
+                            nvinfer1::DimsExprs const*, int32_t nb_shape_inputs,
+                            nvinfer1::DimsExprs* outputs, int32_t nb_outputs,
+                            nvinfer1::IExprBuilder&) noexcept override {
+        if (inputs == nullptr || outputs == nullptr || nb_inputs != 5 || nb_shape_inputs != 0 ||
+            nb_outputs != 1) {
+            return 1;
+        }
+        outputs[0] = inputs[0];
+        return 0;
+    }
+
+    bool supportsFormatCombination(int32_t position,
+                                   nvinfer1::DynamicPluginTensorDesc const* descriptors,
+                                   int32_t nb_inputs, int32_t nb_outputs) noexcept override {
+        return descriptors != nullptr && nb_inputs == 5 && nb_outputs == 1 && position >= 0 &&
+               position < 6 && is_bf16_linear(descriptors[position].desc);
+    }
+
+    int32_t getNbOutputs() const noexcept override { return 1; }
+
+    int32_t onShapeChange(nvinfer1::PluginTensorDesc const* input, int32_t nb_inputs,
+                          nvinfer1::PluginTensorDesc const* output,
+                          int32_t nb_outputs) noexcept override {
+        if (input == nullptr || output == nullptr || nb_inputs != 5 || nb_outputs != 1 ||
+            !has_supported_post_attention_shape(input[0].dims, input[1].dims, input[2].dims,
+                                                input[3].dims, input[4].dims) ||
+            output[0].dims.nbDims != input[0].dims.nbDims) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t enqueue(nvinfer1::PluginTensorDesc const* input_desc, nvinfer1::PluginTensorDesc const*,
+                    void const* const* inputs, void* const* outputs, void*,
+                    cudaStream_t stream) noexcept override {
+        if (input_desc == nullptr || inputs == nullptr || outputs == nullptr) {
+            return 1;
+        }
+        int64_t rows = 1;
+        for (int32_t axis = 0; axis + 1 < input_desc[0].dims.nbDims; ++axis) {
+            rows *= input_desc[0].dims.d[axis];
+        }
+        return launch_openpi_post_attention_rms_norm(static_cast<const std::uint16_t*>(inputs[0]),
+                                                     static_cast<const std::uint16_t*>(inputs[1]),
+                                                     static_cast<const std::uint16_t*>(inputs[2]),
+                                                     static_cast<const std::uint16_t*>(inputs[3]),
+                                                     static_cast<const std::uint16_t*>(inputs[4]),
+                                                     static_cast<std::uint16_t*>(outputs[0]),
+                                                     static_cast<int32_t>(rows), epsilon_, stream);
+    }
+
+    nvinfer1::IPluginV3* attachToContext(nvinfer1::IPluginResourceContext*) noexcept override {
+        return clone();
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldsToSerialize() noexcept override {
+        reset_serialization_fields();
+        return &serialization_fields_;
+    }
+
+  private:
+    void reset_serialization_fields() noexcept {
+        serialization_field_ = {"epsilon", &epsilon_, nvinfer1::PluginFieldType::kFLOAT32, 1};
+        serialization_fields_.nbFields = 1;
+        serialization_fields_.fields = &serialization_field_;
+    }
+
+    float epsilon_{1.0e-6F};
+    std::string namespace_;
+    nvinfer1::PluginField serialization_field_{};
+    nvinfer1::PluginFieldCollection serialization_fields_{};
+};
+
+class OpenPIPostAttentionRmsNormCreator final : public nvinfer1::IPluginCreatorV3One {
+  public:
+    OpenPIPostAttentionRmsNormCreator() {
+        field_ = {"epsilon", nullptr, nvinfer1::PluginFieldType::kFLOAT32, 1};
+        fields_.nbFields = 1;
+        fields_.fields = &field_;
+    }
+
+    nvinfer1::IPluginV3* createPlugin(nvinfer1::AsciiChar const*,
+                                      nvinfer1::PluginFieldCollection const* fields,
+                                      nvinfer1::TensorRTPhase) noexcept override {
+        float epsilon = 1.0e-6F;
+        if (fields != nullptr) {
+            for (int32_t index = 0; index < fields->nbFields; ++index) {
+                const auto& field = fields->fields[index];
+                if (field.name != nullptr && std::strcmp(field.name, "epsilon") == 0 &&
+                    field.type == nvinfer1::PluginFieldType::kFLOAT32 && field.data != nullptr &&
+                    field.length == 1) {
+                    epsilon = *static_cast<const float*>(field.data);
+                }
+            }
+        }
+        if (!(epsilon > 0.0F)) {
+            return nullptr;
+        }
+        return new (std::nothrow) OpenPIPostAttentionRmsNormPlugin(epsilon);
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldNames() noexcept override { return &fields_; }
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override {
+        return OpenPIPostAttentionRmsNormPlugin::kName;
+    }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override {
+        return OpenPIPostAttentionRmsNormPlugin::kVersion;
+    }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override { return ""; }
+
+  private:
+    nvinfer1::PluginField field_{};
+    nvinfer1::PluginFieldCollection fields_{};
+};
+
+} // namespace
+
+int32_t launch_openpi_rms_norm(const std::uint16_t* input, const std::uint16_t* scale,
+                               std::uint16_t* output, int32_t rows, float epsilon,
+                               cudaStream_t stream) noexcept {
+    if (input == nullptr || scale == nullptr || output == nullptr || rows <= 0 ||
+        !(epsilon > 0.0F)) {
+        return 1;
+    }
+    const int32_t blocks = (rows + kRowsPerBlock - 1) / kRowsPerBlock;
+    openpi_rms_norm_kernel<<<blocks, kThreads, 0, stream>>>(input, scale, output, rows, epsilon);
+    return cudaPeekAtLastError() == cudaSuccess ? 0 : 1;
+}
+
+int32_t launch_openpi_rope_qk(const std::uint16_t* query, const std::uint16_t* key,
+                              const std::int32_t* positions, std::uint16_t* query_output,
+                              std::uint16_t* key_output, int32_t sequence, void* workspace,
+                              cudaStream_t stream) noexcept {
+    if (query == nullptr || key == nullptr || positions == nullptr || query_output == nullptr ||
+        key_output == nullptr || workspace == nullptr ||
+        (sequence != kRopeSequence && sequence != kActionSequence)) {
+        return 1;
+    }
+    auto* periods = static_cast<float*>(workspace);
+    auto* cosine = periods + kRopeHalf;
+    auto* sine = cosine + kRopeTableElements;
+    openpi_rope_period_kernel<<<1, kRopeHalf, 0, stream>>>(periods);
+    openpi_rope_table_kernel<<<sequence, kRopeHalf, 0, stream>>>(positions, periods, cosine, sine);
+    constexpr int32_t threads = 256;
+    const int32_t query_pairs = kRopeQueryHeads * sequence * kRopeHalf;
+    const int32_t key_pairs = kRopeKeyHeads * sequence * kRopeHalf;
+    openpi_rope_apply_kernel<<<(query_pairs + threads - 1) / threads, threads, 0, stream>>>(
+        query, cosine, sine, query_output, kRopeQueryHeads, sequence);
+    openpi_rope_apply_kernel<<<(key_pairs + threads - 1) / threads, threads, 0, stream>>>(
+        key, cosine, sine, key_output, kRopeKeyHeads, sequence);
+    return cudaPeekAtLastError() == cudaSuccess ? 0 : 1;
+}
+
+int32_t launch_openpi_prefix_qk(const std::uint16_t* query, const std::uint16_t* key, float* logits,
+                                void* workspace, void* cublas_handle,
+                                cudaStream_t stream) noexcept {
+    if (query == nullptr || key == nullptr || logits == nullptr || workspace == nullptr ||
+        cublas_handle == nullptr) {
+        return 1;
+    }
+
+    auto* query_sequence_major = static_cast<std::uint16_t*>(workspace);
+    auto* cublas_workspace =
+        static_cast<void*>(static_cast<std::byte*>(workspace) + kPrefixQKQueryWorkspaceBytes);
+    constexpr int32_t threads = 256;
+    constexpr int32_t blocks =
+        static_cast<int32_t>((kPrefixQKQueryElements + threads - 1) / threads);
+    openpi_prefix_q_bhsd_to_bshd_kernel<<<blocks, threads, 0, stream>>>(query,
+                                                                        query_sequence_major);
+    if (cudaPeekAtLastError() != cudaSuccess) {
+        return 1;
+    }
+
+    auto handle = reinterpret_cast<cublasHandle_t>(cublas_handle);
+    cublasStatus_t status = cublasSetStream(handle, stream);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+    status = cublasSetWorkspace(handle, cublas_workspace, kPrefixQKCublasWorkspaceBytes);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+
+    const float alpha = 1.0F;
+    const float beta = 0.0F;
+    status = cublasGemmEx(handle, CUBLAS_OP_T, CUBLAS_OP_N, kPrefixQKRows, kRopeSequence,
+                          kRopeHeadDim, &alpha, query_sequence_major, CUDA_R_16BF, kRopeHeadDim,
+                          key, CUDA_R_16BF, kRopeHeadDim, &beta, logits, CUDA_R_32F, kPrefixQKRows,
+                          CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+    return status == CUBLAS_STATUS_SUCCESS ? 0 : 1;
+}
+
+int32_t launch_openpi_prefix_softmax(const float* logits, const std::uint8_t* attention_mask,
+                                     std::uint16_t* probabilities, cudaStream_t stream) noexcept {
+    if (logits == nullptr || attention_mask == nullptr || probabilities == nullptr) {
+        return 1;
+    }
+    openpi_prefix_softmax_kernel<<<kPrefixSoftmaxRows, kPrefixSoftmaxThreads, 0, stream>>>(
+        logits, attention_mask, probabilities);
+    return cudaPeekAtLastError() == cudaSuccess ? 0 : 1;
+}
+
+int32_t launch_openpi_final_adaptive_rms_norm(const std::uint16_t* hidden,
+                                              const std::uint16_t* bias,
+                                              const std::uint16_t* weight, const float* condition,
+                                              std::uint16_t* output, float epsilon,
+                                              cudaStream_t stream) noexcept {
+    if (hidden == nullptr || bias == nullptr || weight == nullptr || condition == nullptr ||
+        output == nullptr || epsilon != kFinalAdaptiveEpsilon) {
+        return 1;
+    }
+    openpi_final_adaptive_rms_norm_kernel<<<kFinalAdaptiveBlocks, kFinalAdaptiveThreads, 0,
+                                            stream>>>(hidden, bias, weight, condition, output,
+                                                      epsilon);
+    return cudaPeekAtLastError() == cudaSuccess ? 0 : 1;
+}
+
+int32_t launch_openpi_post_attention_rms_norm(
+    const std::uint16_t* residual, const std::uint16_t* update, const std::uint16_t* residual_gate,
+    const std::uint16_t* scale, const std::uint16_t* shift, std::uint16_t* output, int32_t rows,
+    float epsilon, cudaStream_t stream) noexcept {
+    if (residual == nullptr || update == nullptr || residual_gate == nullptr || scale == nullptr ||
+        shift == nullptr || output == nullptr || rows <= 0 || !(epsilon > 0.0F)) {
+        return 1;
+    }
+    openpi_post_attention_rms_norm_kernel<<<rows, kActionThreads, 0, stream>>>(
+        residual, update, residual_gate, scale, shift, output, rows, epsilon);
+    return cudaPeekAtLastError() == cudaSuccess ? 0 : 1;
+}
+
+} // namespace trtmc::openpi
+
+static nvinfer1::PluginRegistrar<trtmc::openpi::OpenPIRmsNormCreator>
+    plugin_registrar_openpi_rms_norm{};
+static nvinfer1::PluginRegistrar<trtmc::openpi::OpenPIRopeCreator> plugin_registrar_openpi_rope{};
+static nvinfer1::PluginRegistrar<trtmc::openpi::OpenPIPrefixQKCreator>
+    plugin_registrar_openpi_prefix_qk{};
+static nvinfer1::PluginRegistrar<trtmc::openpi::OpenPIPrefixSoftmaxCreator>
+    plugin_registrar_openpi_prefix_softmax{};
+static nvinfer1::PluginRegistrar<trtmc::openpi::OpenPIFinalAdaptiveRmsNormCreator>
+    plugin_registrar_openpi_final_adaptive_rms_norm{};
+static nvinfer1::PluginRegistrar<trtmc::openpi::OpenPIPostAttentionRmsNormCreator>
+    plugin_registrar_openpi_post_attention_rms_norm{};
+
+extern "C" void trtmc_openpi_rms_norm_plugin_force_link() {}

--- a/src/runtime/models/openpi/trt_plugins/siglip_attention_residual_plugin.cu
+++ b/src/runtime/models/openpi/trt_plugins/siglip_attention_residual_plugin.cu
@@ -1,0 +1,680 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <NvInferRuntime.h>
+#include <cstddef>
+#include <cstdint>
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <new>
+#include <string>
+
+namespace trtmc::openpi {
+
+int32_t launch_openpi_siglip_attention_residual(
+    const std::uint16_t* hidden, const std::uint16_t* norm_gamma, const std::uint16_t* norm_beta,
+    const std::uint16_t* qkv_weight, const std::uint16_t* qkv_bias,
+    const std::uint16_t* output_weight, const std::uint16_t* output_bias, std::uint16_t* output,
+    void* workspace, void* cublas_handle, cudaStream_t stream) noexcept;
+
+namespace {
+
+constexpr int32_t kBatch = 1;
+constexpr int32_t kRows = 256;
+constexpr int32_t kWidth = 1152;
+constexpr int32_t kHeads = 16;
+constexpr int32_t kHeadDimension = 72;
+constexpr int32_t kQkvProjections = 3;
+constexpr int32_t kQkvWidth = kQkvProjections * kWidth;
+
+constexpr std::size_t kActivationElements = static_cast<std::size_t>(kRows) * kWidth;
+constexpr std::size_t kActivationBytes = kActivationElements * sizeof(std::uint16_t);
+constexpr std::size_t kQkvElements = static_cast<std::size_t>(kRows) * kQkvWidth;
+constexpr std::size_t kQkvBytes = kQkvElements * sizeof(std::uint16_t);
+constexpr std::size_t kAttentionElements = static_cast<std::size_t>(kHeads) * kRows * kRows;
+constexpr std::size_t kAttentionBytes = kAttentionElements * sizeof(std::uint16_t);
+
+// Exact scratch sizes attached to the corresponding __cublas$gemm thunks in
+// the pinned JAX 0.5.3 / XLA executable.
+constexpr std::size_t kQkvCublasWorkspaceBytes = 8552448;
+constexpr std::size_t kQkCublasWorkspaceBytes = 1179648;
+constexpr std::size_t kPvCublasWorkspaceBytes = 2686976;
+constexpr std::size_t kOutputCublasWorkspaceBytes = 3244032;
+
+// Keep the two QKV representations disjoint while the exact XLA bias,
+// transpose, and query-scale boundary is materialized. Once packed Q/K/V are
+// ready, the norm and raw-QKV regions are reused for logits and context.
+constexpr std::size_t kNormOffset = 0;
+constexpr std::size_t kRawQkvOffset = kNormOffset + kActivationBytes;
+constexpr std::size_t kPackedQkvOffset = kRawQkvOffset + kQkvBytes;
+constexpr std::size_t kCublasWorkspaceOffset = kPackedQkvOffset + kQkvBytes;
+constexpr std::size_t kPluginWorkspaceBytes = kCublasWorkspaceOffset + kQkvCublasWorkspaceBytes;
+static_assert(kAttentionBytes <= kRawQkvOffset + kQkvBytes,
+              "reused logits region must fit before packed QKV");
+static_assert(kQkCublasWorkspaceBytes <= kQkvCublasWorkspaceBytes);
+static_assert(kPvCublasWorkspaceBytes + kActivationBytes <= kQkvCublasWorkspaceBytes);
+static_assert(kOutputCublasWorkspaceBytes <= kQkvCublasWorkspaceBytes);
+
+constexpr int32_t kLayerNormThreads = 96;
+constexpr int32_t kLayerNormWarps = 3;
+constexpr int32_t kLayerNormSegments = 3;
+constexpr int32_t kLayerNormItemsPerSegment = 4;
+constexpr int32_t kLayerNormSegmentWidth = 384;
+constexpr int32_t kSoftmaxThreads = 128;
+constexpr int32_t kSoftmaxRowsPerBlock = 8;
+constexpr int32_t kSoftmaxBlocks = kHeads * kRows / kSoftmaxRowsPerBlock;
+
+__device__ __forceinline__ float bf16_to_float(std::uint16_t value) {
+    return __uint_as_float(static_cast<std::uint32_t>(value) << 16U);
+}
+
+__device__ __forceinline__ std::uint16_t float_to_bf16_rn(float value) {
+    std::uint32_t bits = __float_as_uint(value);
+    if ((bits & 0x7FFFFFFFU) > 0x7F800000U) {
+        return static_cast<std::uint16_t>((bits >> 16U) | 0x0040U);
+    }
+    bits += 0x00007FFFU + ((bits >> 16U) & 1U);
+    return static_cast<std::uint16_t>(bits >> 16U);
+}
+
+__device__ __forceinline__ std::uint16_t bf16_add_rn(std::uint16_t lhs, std::uint16_t rhs) {
+    return float_to_bf16_rn(__fadd_rn(bf16_to_float(lhs), bf16_to_float(rhs)));
+}
+
+__device__ __forceinline__ std::uint16_t bf16_multiply_rn(std::uint16_t lhs, std::uint16_t rhs) {
+    return float_to_bf16_rn(__fmul_rn(bf16_to_float(lhs), bf16_to_float(rhs)));
+}
+
+__device__ __forceinline__ float approximate_rsqrt(float value) {
+    float result;
+    asm("rsqrt.approx.f32 %0, %1;" : "=f"(result) : "f"(value));
+    return result;
+}
+
+__device__ __forceinline__ float approximate_exp2(float value) {
+    float result;
+    asm("ex2.approx.f32 %0, %1;" : "=f"(result) : "f"(value));
+    return result;
+}
+
+__device__ __forceinline__ float full_divide(float numerator, float denominator) {
+    float result;
+    asm("div.full.f32 %0, %1, %2;" : "=f"(result) : "f"(numerator), "f"(denominator));
+    return result;
+}
+
+__device__ __forceinline__ float warp_reduce_down_sum(float value) {
+#pragma unroll
+    for (int32_t offset = 16; offset > 0; offset >>= 1) {
+        value = __fadd_rn(value, __shfl_down_sync(0xFFFFFFFFU, value, offset));
+    }
+    return value;
+}
+
+__device__ __forceinline__ float warp_reduce_xor_sum(float value) {
+#pragma unroll
+    for (int32_t offset = 16; offset > 0; offset >>= 1) {
+        value = __fadd_rn(value, __shfl_xor_sync(0xFFFFFFFFU, value, offset));
+    }
+    return value;
+}
+
+__device__ __forceinline__ float warp_reduce_xor_max(float value) {
+#pragma unroll
+    for (int32_t offset = 16; offset > 0; offset >>= 1) {
+        value = fmaxf(value, __shfl_xor_sync(0xFFFFFFFFU, value, offset));
+    }
+    return value;
+}
+
+// Exact copy of the pinned SigLIP LayerNorm lowering. Every block owns one
+// row; 96 lanes consume four adjacent elements from each of three 384-wide
+// segments. The three warp totals combine as (warp0 + warp2) + warp1.
+__global__ void openpi_siglip_attention_layer_norm_kernel(const std::uint16_t* __restrict__ input,
+                                                          const std::uint16_t* __restrict__ gamma,
+                                                          const std::uint16_t* __restrict__ beta,
+                                                          std::uint16_t* __restrict__ output) {
+    __shared__ float sum_partials[kLayerNormWarps];
+    __shared__ float square_partials[kLayerNormWarps];
+    __shared__ float mean;
+    __shared__ float reciprocal;
+
+    const int32_t row = blockIdx.x;
+    const int32_t thread = threadIdx.x;
+    const int32_t lane = thread & 31;
+    const int32_t warp = thread >> 5;
+    const int64_t row_base = static_cast<int64_t>(row) * kWidth;
+    const int32_t lane_base = thread * kLayerNormItemsPerSegment;
+    float values[kLayerNormSegments][kLayerNormItemsPerSegment];
+    float local_sum = 0.0F;
+    float local_square = 0.0F;
+    bool first = true;
+
+#pragma unroll
+    for (int32_t segment = 0; segment < kLayerNormSegments; ++segment) {
+#pragma unroll
+        for (int32_t item = 0; item < kLayerNormItemsPerSegment; ++item) {
+            const int32_t dimension = segment * kLayerNormSegmentWidth + lane_base + item;
+            const float value = bf16_to_float(input[row_base + dimension]);
+            values[segment][item] = value;
+            const float square = __fmul_rn(value, value);
+            if (first) {
+                local_sum = value;
+                local_square = square;
+                first = false;
+            } else {
+                local_sum = __fadd_rn(local_sum, value);
+                local_square = __fadd_rn(local_square, square);
+            }
+        }
+    }
+
+    const float warp_sum = warp_reduce_down_sum(local_sum);
+    const float warp_square = warp_reduce_down_sum(local_square);
+    if (lane == 0) {
+        sum_partials[warp] = warp_sum;
+        square_partials[warp] = warp_square;
+    }
+    __syncthreads();
+
+    if (thread == 0) {
+        const float sum = __fadd_rn(__fadd_rn(sum_partials[0], sum_partials[2]), sum_partials[1]);
+        const float square_sum =
+            __fadd_rn(__fadd_rn(square_partials[0], square_partials[2]), square_partials[1]);
+        const float reciprocal_width = __uint_as_float(0x3A638E39U);
+        const float row_mean = __fmul_rn(sum, reciprocal_width);
+        const float row_mean_square = __fmul_rn(square_sum, reciprocal_width);
+        const float mean_squared = __fmul_rn(row_mean, row_mean);
+        const float variance = __fsub_rn(row_mean_square, mean_squared);
+        const float denominator = __fadd_rn(fmaxf(variance, 0.0F), __uint_as_float(0x358637BDU));
+        mean = row_mean;
+        reciprocal = approximate_rsqrt(denominator);
+    }
+    __syncthreads();
+
+#pragma unroll
+    for (int32_t segment = 0; segment < kLayerNormSegments; ++segment) {
+#pragma unroll
+        for (int32_t item = 0; item < kLayerNormItemsPerSegment; ++item) {
+            const int32_t dimension = segment * kLayerNormSegmentWidth + lane_base + item;
+            const float centered = __fsub_rn(values[segment][item], mean);
+            const float scaled_reciprocal = __fmul_rn(reciprocal, bf16_to_float(gamma[dimension]));
+            const float normalized = __fmul_rn(centered, scaled_reciprocal);
+            const float shifted = __fadd_rn(normalized, bf16_to_float(beta[dimension]));
+            output[row_base + dimension] = float_to_bf16_rn(shifted);
+        }
+    }
+}
+
+// QKV is emitted row-major by cuBLAS. This kernel applies the separately
+// rounded BF16 bias, applies XLA's BF16 reciprocal-sqrt scale to Q, and packs
+// every projection as contiguous [head, query, dimension] storage for the
+// exact batched QK/PV cuBLAS calls.
+__global__ void openpi_siglip_pack_qkv_kernel(const std::uint16_t* __restrict__ raw_qkv,
+                                              const std::uint16_t* __restrict__ bias,
+                                              std::uint16_t* __restrict__ packed_qkv) {
+    const std::size_t index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index >= kQkvElements) {
+        return;
+    }
+    const std::size_t projection = index / kActivationElements;
+    const std::size_t projection_index = index % kActivationElements;
+    const std::size_t row = projection_index / kWidth;
+    const std::size_t feature = projection_index % kWidth;
+    const std::size_t head = feature / kHeadDimension;
+    const std::size_t dimension = feature % kHeadDimension;
+    const std::size_t source = row * kQkvWidth + projection * kWidth + feature;
+    const std::size_t destination =
+        projection * kActivationElements + (head * kRows + row) * kHeadDimension + dimension;
+    std::uint16_t value = bf16_add_rn(raw_qkv[source], bias[projection * kWidth + feature]);
+    if (projection == 0) {
+        // BF16 1/sqrt(72), exactly as constant_90_2 in the pinned HLO.
+        value = bf16_multiply_rn(value, 0x3DF1U);
+    }
+    packed_qkv[destination] = value;
+}
+
+// fusion.257: one 128-thread CTA owns eight rows of the [16,256,256]
+// logits tensor. Every warp owns two rows and every lane owns eight adjacent
+// columns. Max and sum reductions use XOR butterflies, matching the Triton
+// lowering exactly, including BF16 max/subtract/exp boundaries.
+// This kernel intentionally supports logits == probabilities; do not mark
+// either pointer restrict, because the production path normalizes in place.
+__global__ void openpi_siglip_softmax_kernel(const std::uint16_t* logits,
+                                             std::uint16_t* probabilities) {
+    const int32_t warp = threadIdx.x >> 5;
+    const int32_t lane = threadIdx.x & 31;
+    const int32_t first_row = blockIdx.x * kSoftmaxRowsPerBlock + warp;
+
+#pragma unroll
+    for (int32_t row_group = 0; row_group < 2; ++row_group) {
+        const int32_t row = first_row + row_group * 4;
+        const int64_t row_base = static_cast<int64_t>(row) * kRows;
+        const int32_t column_base = lane * 8;
+        std::uint16_t input_values[8];
+        float local_max;
+
+#pragma unroll
+        for (int32_t item = 0; item < 8; ++item) {
+            input_values[item] = logits[row_base + column_base + item];
+            const float value = bf16_to_float(input_values[item]);
+            local_max = item == 0 ? value : fmaxf(local_max, value);
+        }
+        const std::uint16_t maximum = float_to_bf16_rn(warp_reduce_xor_max(local_max));
+
+        std::uint16_t exponential_bf16[8];
+        float local_sum = 0.0F;
+#pragma unroll
+        for (int32_t item = 0; item < 8; ++item) {
+            const std::uint16_t difference = float_to_bf16_rn(
+                __fsub_rn(bf16_to_float(input_values[item]), bf16_to_float(maximum)));
+            const float exponent =
+                __fmul_rn(bf16_to_float(difference), __uint_as_float(0x3FB8AA3BU));
+            exponential_bf16[item] = float_to_bf16_rn(approximate_exp2(exponent));
+            const float value = bf16_to_float(exponential_bf16[item]);
+            local_sum = item == 0 ? value : __fadd_rn(local_sum, value);
+        }
+        const float denominator = warp_reduce_xor_sum(local_sum);
+
+#pragma unroll
+        for (int32_t item = 0; item < 8; ++item) {
+            const float probability =
+                full_divide(bf16_to_float(exponential_bf16[item]), denominator);
+            probabilities[row_base + column_base + item] = float_to_bf16_rn(probability);
+        }
+    }
+}
+
+__global__ void openpi_siglip_context_to_rows_kernel(const std::uint16_t* __restrict__ head_major,
+                                                     std::uint16_t* __restrict__ row_major) {
+    const std::size_t index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index >= kActivationElements) {
+        return;
+    }
+    const std::size_t row = index / kWidth;
+    const std::size_t feature = index % kWidth;
+    const std::size_t head = feature / kHeadDimension;
+    const std::size_t dimension = feature % kHeadDimension;
+    row_major[index] = head_major[(head * kRows + row) * kHeadDimension + dimension];
+}
+
+__global__ void openpi_siglip_output_residual_kernel(const std::uint16_t* __restrict__ hidden,
+                                                     const std::uint16_t* __restrict__ attended,
+                                                     const std::uint16_t* __restrict__ bias,
+                                                     std::uint16_t* __restrict__ output) {
+    const std::size_t index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index >= kActivationElements) {
+        return;
+    }
+    const std::uint16_t shifted = bf16_add_rn(attended[index], bias[index % kWidth]);
+    output[index] = bf16_add_rn(hidden[index], shifted);
+}
+
+bool is_bf16_linear(nvinfer1::PluginTensorDesc const& descriptor) {
+    return descriptor.type == nvinfer1::DataType::kBF16 &&
+           descriptor.format == nvinfer1::TensorFormat::kLINEAR;
+}
+
+bool has_activation_shape(nvinfer1::Dims const& dims) {
+    return dims.nbDims == 3 && dims.d[0] == kBatch && dims.d[1] == kRows && dims.d[2] == kWidth;
+}
+
+bool has_vector_shape(nvinfer1::Dims const& dims, int32_t width) {
+    return dims.nbDims == 1 && dims.d[0] == width;
+}
+
+bool has_matrix_shape(nvinfer1::Dims const& dims, int32_t rows, int32_t columns) {
+    return dims.nbDims == 2 && dims.d[0] == rows && dims.d[1] == columns;
+}
+
+bool has_supported_dimensions(nvinfer1::Dims const* input, nvinfer1::Dims const& output) {
+    return has_activation_shape(input[0]) && has_vector_shape(input[1], kWidth) &&
+           has_vector_shape(input[2], kWidth) && has_matrix_shape(input[3], kWidth, kQkvWidth) &&
+           has_vector_shape(input[4], kQkvWidth) && has_matrix_shape(input[5], kWidth, kWidth) &&
+           has_vector_shape(input[6], kWidth) && has_activation_shape(output);
+}
+
+bool has_supported_shape(nvinfer1::PluginTensorDesc const* input, int32_t nb_inputs,
+                         nvinfer1::PluginTensorDesc const* output, int32_t nb_outputs) {
+    if (input == nullptr || output == nullptr || nb_inputs != 7 || nb_outputs != 1) {
+        return false;
+    }
+    nvinfer1::Dims input_dims[7];
+    for (int32_t index = 0; index < 7; ++index) {
+        if (!is_bf16_linear(input[index])) {
+            return false;
+        }
+        input_dims[index] = input[index].dims;
+    }
+    return is_bf16_linear(output[0]) && has_supported_dimensions(input_dims, output[0].dims);
+}
+
+bool has_supported_dynamic_shape(nvinfer1::DynamicPluginTensorDesc const* input, int32_t nb_inputs,
+                                 nvinfer1::DynamicPluginTensorDesc const* output,
+                                 int32_t nb_outputs) {
+    if (input == nullptr || output == nullptr || nb_inputs != 7 || nb_outputs != 1) {
+        return false;
+    }
+    nvinfer1::PluginTensorDesc input_desc[7];
+    nvinfer1::Dims minimum[7];
+    nvinfer1::Dims maximum[7];
+    for (int32_t index = 0; index < 7; ++index) {
+        input_desc[index] = input[index].desc;
+        minimum[index] = input[index].min;
+        maximum[index] = input[index].max;
+    }
+    const nvinfer1::PluginTensorDesc output_desc[1] = {output[0].desc};
+    return has_supported_shape(input_desc, 7, output_desc, 1) &&
+           has_supported_dimensions(minimum, output[0].min) &&
+           has_supported_dimensions(maximum, output[0].max);
+}
+
+class OpenPISiglipAttentionResidualPlugin final : public nvinfer1::IPluginV3,
+                                                  public nvinfer1::IPluginV3OneCore,
+                                                  public nvinfer1::IPluginV3OneBuild,
+                                                  public nvinfer1::IPluginV3OneRuntime {
+  public:
+    static constexpr const char* kName = "OpenPISiglipAttentionResidual";
+    static constexpr const char* kVersion = "1";
+
+    OpenPISiglipAttentionResidualPlugin() { serialization_fields_.nbFields = 0; }
+
+    ~OpenPISiglipAttentionResidualPlugin() override {
+        if (cublas_handle_ != nullptr) {
+            static_cast<void>(cublasDestroy(cublas_handle_));
+            cublas_handle_ = nullptr;
+        }
+    }
+
+    nvinfer1::IPluginCapability*
+    getCapabilityInterface(nvinfer1::PluginCapabilityType type) noexcept override {
+        switch (type) {
+        case nvinfer1::PluginCapabilityType::kCORE:
+            return static_cast<nvinfer1::IPluginV3OneCore*>(this);
+        case nvinfer1::PluginCapabilityType::kBUILD:
+            return static_cast<nvinfer1::IPluginV3OneBuild*>(this);
+        case nvinfer1::PluginCapabilityType::kRUNTIME:
+            return static_cast<nvinfer1::IPluginV3OneRuntime*>(this);
+        }
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV3* clone() noexcept override {
+        auto* plugin = new (std::nothrow) OpenPISiglipAttentionResidualPlugin();
+        if (plugin != nullptr) {
+            plugin->namespace_ = namespace_;
+        }
+        return plugin;
+    }
+
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override { return kName; }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override { return kVersion; }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override {
+        return namespace_.c_str();
+    }
+
+    int32_t configurePlugin(nvinfer1::DynamicPluginTensorDesc const* input, int32_t nb_inputs,
+                            nvinfer1::DynamicPluginTensorDesc const* output,
+                            int32_t nb_outputs) noexcept override {
+        return has_supported_dynamic_shape(input, nb_inputs, output, nb_outputs) ? 0 : 1;
+    }
+
+    int32_t getOutputDataTypes(nvinfer1::DataType* output_types, int32_t nb_outputs,
+                               nvinfer1::DataType const* input_types,
+                               int32_t nb_inputs) const noexcept override {
+        if (output_types == nullptr || input_types == nullptr || nb_outputs != 1 ||
+            nb_inputs != 7) {
+            return 1;
+        }
+        for (int32_t index = 0; index < 7; ++index) {
+            if (input_types[index] != nvinfer1::DataType::kBF16) {
+                return 1;
+            }
+        }
+        output_types[0] = nvinfer1::DataType::kBF16;
+        return 0;
+    }
+
+    int32_t getOutputShapes(nvinfer1::DimsExprs const* inputs, int32_t nb_inputs,
+                            nvinfer1::DimsExprs const*, int32_t nb_shape_inputs,
+                            nvinfer1::DimsExprs* outputs, int32_t nb_outputs,
+                            nvinfer1::IExprBuilder&) noexcept override {
+        if (inputs == nullptr || outputs == nullptr || nb_inputs != 7 || nb_shape_inputs != 0 ||
+            nb_outputs != 1) {
+            return 1;
+        }
+        outputs[0] = inputs[0];
+        return 0;
+    }
+
+    bool supportsFormatCombination(int32_t position,
+                                   nvinfer1::DynamicPluginTensorDesc const* descriptors,
+                                   int32_t nb_inputs, int32_t nb_outputs) noexcept override {
+        if (descriptors == nullptr || nb_inputs != 7 || nb_outputs != 1 || position < 0 ||
+            position >= 8) {
+            return false;
+        }
+        return is_bf16_linear(descriptors[position].desc);
+    }
+
+    int32_t getNbOutputs() const noexcept override { return 1; }
+
+    std::size_t getWorkspaceSize(nvinfer1::DynamicPluginTensorDesc const*, int32_t,
+                                 nvinfer1::DynamicPluginTensorDesc const*,
+                                 int32_t) const noexcept override {
+        return kPluginWorkspaceBytes;
+    }
+
+    int32_t onShapeChange(nvinfer1::PluginTensorDesc const* input, int32_t nb_inputs,
+                          nvinfer1::PluginTensorDesc const* output,
+                          int32_t nb_outputs) noexcept override {
+        return has_supported_shape(input, nb_inputs, output, nb_outputs) ? 0 : 1;
+    }
+
+    int32_t enqueue(nvinfer1::PluginTensorDesc const* input_desc,
+                    nvinfer1::PluginTensorDesc const* output_desc, void const* const* inputs,
+                    void* const* outputs, void* workspace, cudaStream_t stream) noexcept override {
+        if (!has_supported_shape(input_desc, 7, output_desc, 1) || inputs == nullptr ||
+            outputs == nullptr || workspace == nullptr || cublas_handle_ == nullptr ||
+            outputs[0] == nullptr) {
+            return 1;
+        }
+        for (int32_t index = 0; index < 7; ++index) {
+            if (inputs[index] == nullptr) {
+                return 1;
+            }
+        }
+        return launch_openpi_siglip_attention_residual(
+            static_cast<const std::uint16_t*>(inputs[0]),
+            static_cast<const std::uint16_t*>(inputs[1]),
+            static_cast<const std::uint16_t*>(inputs[2]),
+            static_cast<const std::uint16_t*>(inputs[3]),
+            static_cast<const std::uint16_t*>(inputs[4]),
+            static_cast<const std::uint16_t*>(inputs[5]),
+            static_cast<const std::uint16_t*>(inputs[6]), static_cast<std::uint16_t*>(outputs[0]),
+            workspace, static_cast<void*>(cublas_handle_), stream);
+    }
+
+    nvinfer1::IPluginV3* attachToContext(nvinfer1::IPluginResourceContext*) noexcept override {
+        auto* plugin = new (std::nothrow) OpenPISiglipAttentionResidualPlugin();
+        if (plugin == nullptr) {
+            return nullptr;
+        }
+        plugin->namespace_ = namespace_;
+        cublasStatus_t status = cublasCreate(&plugin->cublas_handle_);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+            delete plugin;
+            return nullptr;
+        }
+        status = cublasSetMathMode(plugin->cublas_handle_, CUBLAS_DEFAULT_MATH);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+            delete plugin;
+            return nullptr;
+        }
+        return plugin;
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldsToSerialize() noexcept override {
+        return &serialization_fields_;
+    }
+
+  private:
+    std::string namespace_;
+    nvinfer1::PluginFieldCollection serialization_fields_{};
+    cublasHandle_t cublas_handle_{nullptr};
+};
+
+class OpenPISiglipAttentionResidualCreator final : public nvinfer1::IPluginCreatorV3One {
+  public:
+    OpenPISiglipAttentionResidualCreator() { fields_.nbFields = 0; }
+
+    nvinfer1::IPluginV3* createPlugin(nvinfer1::AsciiChar const*,
+                                      nvinfer1::PluginFieldCollection const* fields,
+                                      nvinfer1::TensorRTPhase) noexcept override {
+        if (fields != nullptr && fields->nbFields != 0) {
+            return nullptr;
+        }
+        return new (std::nothrow) OpenPISiglipAttentionResidualPlugin();
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldNames() noexcept override { return &fields_; }
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override {
+        return OpenPISiglipAttentionResidualPlugin::kName;
+    }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override {
+        return OpenPISiglipAttentionResidualPlugin::kVersion;
+    }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override { return ""; }
+
+  private:
+    nvinfer1::PluginFieldCollection fields_{};
+};
+
+static nvinfer1::PluginRegistrar<OpenPISiglipAttentionResidualCreator>
+    plugin_registrar_openpi_siglip_attention_residual{};
+
+int32_t configure_cublas(cublasHandle_t handle, cudaStream_t stream, void* workspace,
+                         std::size_t workspace_bytes) noexcept {
+    cublasStatus_t status = cublasSetStream(handle, stream);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+    status = cublasSetWorkspace(handle, workspace, workspace_bytes);
+    return status == CUBLAS_STATUS_SUCCESS ? 0 : 1;
+}
+
+} // namespace
+
+int32_t launch_openpi_siglip_attention_residual(
+    const std::uint16_t* hidden, const std::uint16_t* norm_gamma, const std::uint16_t* norm_beta,
+    const std::uint16_t* qkv_weight, const std::uint16_t* qkv_bias,
+    const std::uint16_t* output_weight, const std::uint16_t* output_bias, std::uint16_t* output,
+    void* workspace, void* cublas_handle, cudaStream_t stream) noexcept {
+    if (hidden == nullptr || norm_gamma == nullptr || norm_beta == nullptr ||
+        qkv_weight == nullptr || qkv_bias == nullptr || output_weight == nullptr ||
+        output_bias == nullptr || output == nullptr || workspace == nullptr ||
+        cublas_handle == nullptr) {
+        return 1;
+    }
+
+    auto* workspace_bytes = static_cast<std::byte*>(workspace);
+    auto* normalized = reinterpret_cast<std::uint16_t*>(workspace_bytes + kNormOffset);
+    auto* raw_qkv = reinterpret_cast<std::uint16_t*>(workspace_bytes + kRawQkvOffset);
+    auto* packed_qkv = reinterpret_cast<std::uint16_t*>(workspace_bytes + kPackedQkvOffset);
+    void* cublas_workspace = workspace_bytes + kCublasWorkspaceOffset;
+    auto handle = reinterpret_cast<cublasHandle_t>(cublas_handle);
+
+    openpi_siglip_attention_layer_norm_kernel<<<kRows, kLayerNormThreads, 0, stream>>>(
+        hidden, norm_gamma, norm_beta, normalized);
+    if (cudaPeekAtLastError() != cudaSuccess ||
+        configure_cublas(handle, stream, cublas_workspace, kQkvCublasWorkspaceBytes) != 0) {
+        return 1;
+    }
+
+    const float alpha = 1.0F;
+    const float beta = 0.0F;
+    cublasStatus_t status =
+        cublasGemmEx(handle, CUBLAS_OP_N, CUBLAS_OP_N, kQkvWidth, kRows, kWidth, &alpha, qkv_weight,
+                     CUDA_R_16BF, kQkvWidth, normalized, CUDA_R_16BF, kWidth, &beta, raw_qkv,
+                     CUDA_R_16BF, kQkvWidth, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+
+    constexpr int32_t kPointwiseThreads = 256;
+    constexpr int32_t kQkvBlocks =
+        static_cast<int32_t>((kQkvElements + kPointwiseThreads - 1) / kPointwiseThreads);
+    openpi_siglip_pack_qkv_kernel<<<kQkvBlocks, kPointwiseThreads, 0, stream>>>(raw_qkv, qkv_bias,
+                                                                                packed_qkv);
+    if (cudaPeekAtLastError() != cudaSuccess) {
+        return 1;
+    }
+
+    auto* query = packed_qkv;
+    auto* key = query + kActivationElements;
+    auto* value = key + kActivationElements;
+    // The norm + raw-QKV prefix is large enough for [16,256,256] logits and
+    // is dead before this contraction starts.
+    auto* logits = reinterpret_cast<std::uint16_t*>(workspace_bytes + kNormOffset);
+    if (configure_cublas(handle, stream, cublas_workspace, kQkCublasWorkspaceBytes) != 0) {
+        return 1;
+    }
+    constexpr long long kHeadOperandStride = static_cast<long long>(kRows) * kHeadDimension;
+    constexpr long long kAttentionStride = static_cast<long long>(kRows) * kRows;
+    status = cublasGemmStridedBatchedEx(
+        handle, CUBLAS_OP_T, CUBLAS_OP_N, kRows, kRows, kHeadDimension, &alpha, key, CUDA_R_16BF,
+        kHeadDimension, kHeadOperandStride, query, CUDA_R_16BF, kHeadDimension, kHeadOperandStride,
+        &beta, logits, CUDA_R_16BF, kRows, kAttentionStride, kHeads, CUBLAS_COMPUTE_32F,
+        CUBLAS_GEMM_DEFAULT);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+
+    openpi_siglip_softmax_kernel<<<kSoftmaxBlocks, kSoftmaxThreads, 0, stream>>>(logits, logits);
+    if (cudaPeekAtLastError() != cudaSuccess ||
+        configure_cublas(handle, stream, cublas_workspace, kPvCublasWorkspaceBytes) != 0) {
+        return 1;
+    }
+
+    // PV writes contiguous [head,query,dimension] immediately after its exact
+    // cuBLAS scratch allocation. This keeps the output disjoint from both the
+    // in-place probability tensor and packed V.
+    auto* context_head_major = reinterpret_cast<std::uint16_t*>(
+        static_cast<std::byte*>(cublas_workspace) + kPvCublasWorkspaceBytes);
+    status = cublasGemmStridedBatchedEx(
+        handle, CUBLAS_OP_N, CUBLAS_OP_N, kHeadDimension, kRows, kRows, &alpha, value, CUDA_R_16BF,
+        kHeadDimension, kHeadOperandStride, logits, CUDA_R_16BF, kRows, kAttentionStride, &beta,
+        context_head_major, CUDA_R_16BF, kHeadDimension, kHeadOperandStride, kHeads,
+        CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+
+    auto* context_rows = reinterpret_cast<std::uint16_t*>(workspace_bytes + kNormOffset);
+    constexpr int32_t kActivationBlocks =
+        static_cast<int32_t>((kActivationElements + kPointwiseThreads - 1) / kPointwiseThreads);
+    openpi_siglip_context_to_rows_kernel<<<kActivationBlocks, kPointwiseThreads, 0, stream>>>(
+        context_head_major, context_rows);
+    if (cudaPeekAtLastError() != cudaSuccess ||
+        configure_cublas(handle, stream, cublas_workspace, kOutputCublasWorkspaceBytes) != 0) {
+        return 1;
+    }
+
+    // Reuse the dead raw-QKV region for the row-major output.
+    auto* attended = reinterpret_cast<std::uint16_t*>(workspace_bytes + kRawQkvOffset);
+    status =
+        cublasGemmEx(handle, CUBLAS_OP_N, CUBLAS_OP_N, kWidth, kRows, kWidth, &alpha, output_weight,
+                     CUDA_R_16BF, kWidth, context_rows, CUDA_R_16BF, kWidth, &beta, attended,
+                     CUDA_R_16BF, kWidth, CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+    if (status != CUBLAS_STATUS_SUCCESS) {
+        return 1;
+    }
+
+    openpi_siglip_output_residual_kernel<<<kActivationBlocks, kPointwiseThreads, 0, stream>>>(
+        hidden, attended, output_bias, output);
+    return cudaPeekAtLastError() == cudaSuccess ? 0 : 1;
+}
+
+} // namespace trtmc::openpi

--- a/src/runtime/models/openpi/trt_plugins/siglip_layer_norm_plugin.cu
+++ b/src/runtime/models/openpi/trt_plugins/siglip_layer_norm_plugin.cu
@@ -1,0 +1,366 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <NvInferRuntime.h>
+#include <cstddef>
+#include <cstdint>
+#include <cuda_runtime.h>
+#include <new>
+#include <string>
+
+namespace trtmc::openpi {
+namespace {
+
+constexpr int32_t kBatch = 1;
+constexpr int32_t kRows = 256;
+constexpr int32_t kWidth = 1152;
+constexpr int32_t kThreads = 96;
+constexpr int32_t kWarps = 3;
+constexpr int32_t kSegments = 3;
+constexpr int32_t kItemsPerSegment = 4;
+constexpr int32_t kSegmentWidth = 384;
+constexpr float kEpsilon = 1.0e-6F;
+
+__device__ __forceinline__ float bf16_to_float(std::uint16_t value) {
+    return __uint_as_float(static_cast<std::uint32_t>(value) << 16U);
+}
+
+__device__ __forceinline__ std::uint16_t float_to_bf16_rn(float value) {
+    std::uint32_t bits = __float_as_uint(value);
+    if ((bits & 0x7FFFFFFFU) > 0x7F800000U) {
+        return static_cast<std::uint16_t>((bits >> 16U) | 0x0040U);
+    }
+    bits += 0x00007FFFU + ((bits >> 16U) & 1U);
+    return static_cast<std::uint16_t>(bits >> 16U);
+}
+
+__device__ __forceinline__ float xla_warp_reduce_down(float value) {
+#pragma unroll
+    for (int32_t offset = 16; offset > 0; offset >>= 1) {
+        value = __fadd_rn(__shfl_down_sync(0xFFFFFFFFU, value, offset), value);
+    }
+    return value;
+}
+
+__device__ __forceinline__ float xla_rsqrt(float value) {
+    float result;
+    asm("rsqrt.approx.f32 %0, %1;" : "=f"(result) : "f"(value));
+    return result;
+}
+
+// This fixed-shape kernel mirrors the pinned XLA input-reduction and convert
+// kernels. Each of 96 lanes owns four adjacent values in each of three
+// 384-wide segments. The three warp totals are combined as (warp0 + warp2) +
+// warp1, then every association-sensitive FP32 operation uses an explicit RN
+// intrinsic before the final BF16 round-to-nearest-even conversion.
+__global__ void openpi_siglip_layer_norm_kernel(const std::uint16_t* __restrict__ input,
+                                                const std::uint16_t* __restrict__ gamma,
+                                                const std::uint16_t* __restrict__ beta,
+                                                std::uint16_t* __restrict__ output) {
+    __shared__ float sum_partials[kWarps];
+    __shared__ float square_partials[kWarps];
+    __shared__ float mean;
+    __shared__ float reciprocal;
+
+    const int32_t row = blockIdx.x;
+    const int32_t thread = threadIdx.x;
+    const int32_t lane = thread & 31;
+    const int32_t warp = thread >> 5;
+    const int64_t row_base = static_cast<int64_t>(row) * kWidth;
+    const int32_t lane_base = thread * kItemsPerSegment;
+    float values[kSegments][kItemsPerSegment];
+    float local_sum = 0.0F;
+    float local_square = 0.0F;
+    bool first = true;
+
+#pragma unroll
+    for (int32_t segment = 0; segment < kSegments; ++segment) {
+#pragma unroll
+        for (int32_t item = 0; item < kItemsPerSegment; ++item) {
+            const int32_t dimension = segment * kSegmentWidth + lane_base + item;
+            const float value = bf16_to_float(input[row_base + dimension]);
+            values[segment][item] = value;
+            const float square = __fmul_rn(value, value);
+            if (first) {
+                local_sum = value;
+                local_square = square;
+                first = false;
+            } else {
+                local_sum = __fadd_rn(local_sum, value);
+                local_square = __fadd_rn(local_square, square);
+            }
+        }
+    }
+
+    const float warp_sum = xla_warp_reduce_down(local_sum);
+    const float warp_square = xla_warp_reduce_down(local_square);
+    if (lane == 0) {
+        sum_partials[warp] = warp_sum;
+        square_partials[warp] = warp_square;
+    }
+    __syncthreads();
+
+    if (thread == 0) {
+        const float sum = __fadd_rn(__fadd_rn(sum_partials[0], sum_partials[2]), sum_partials[1]);
+        const float square_sum =
+            __fadd_rn(__fadd_rn(square_partials[0], square_partials[2]), square_partials[1]);
+        const float reciprocal_width = __uint_as_float(0x3A638E39U);
+        const float row_mean = __fmul_rn(sum, reciprocal_width);
+        const float row_mean_square = __fmul_rn(square_sum, reciprocal_width);
+        const float mean_squared = __fmul_rn(row_mean, row_mean);
+        const float variance = __fsub_rn(row_mean_square, mean_squared);
+        const float clamped_variance = fmaxf(variance, 0.0F);
+        const float denominator = __fadd_rn(clamped_variance, __uint_as_float(0x358637BDU));
+        mean = row_mean;
+        reciprocal = xla_rsqrt(denominator);
+    }
+    __syncthreads();
+
+#pragma unroll
+    for (int32_t segment = 0; segment < kSegments; ++segment) {
+#pragma unroll
+        for (int32_t item = 0; item < kItemsPerSegment; ++item) {
+            const int32_t dimension = segment * kSegmentWidth + lane_base + item;
+            const float centered = __fsub_rn(values[segment][item], mean);
+            const float scaled_reciprocal = __fmul_rn(reciprocal, bf16_to_float(gamma[dimension]));
+            const float normalized = __fmul_rn(centered, scaled_reciprocal);
+            const float shifted = __fadd_rn(normalized, bf16_to_float(beta[dimension]));
+            output[row_base + dimension] = float_to_bf16_rn(shifted);
+        }
+    }
+}
+
+int32_t launch_openpi_siglip_layer_norm(const std::uint16_t* input, const std::uint16_t* gamma,
+                                        const std::uint16_t* beta, std::uint16_t* output,
+                                        cudaStream_t stream) noexcept {
+    openpi_siglip_layer_norm_kernel<<<kRows, kThreads, 0, stream>>>(input, gamma, beta, output);
+    return cudaGetLastError() == cudaSuccess ? 0 : 1;
+}
+
+bool is_bf16_linear(nvinfer1::PluginTensorDesc const& descriptor) {
+    return descriptor.type == nvinfer1::DataType::kBF16 &&
+           descriptor.format == nvinfer1::TensorFormat::kLINEAR;
+}
+
+bool has_activation_shape(nvinfer1::Dims const& dims) {
+    return dims.nbDims == 3 && dims.d[0] == kBatch && dims.d[1] == kRows && dims.d[2] == kWidth;
+}
+
+bool has_parameter_shape(nvinfer1::Dims const& dims) {
+    return dims.nbDims == 1 && dims.d[0] == kWidth;
+}
+
+bool has_supported_shape(nvinfer1::PluginTensorDesc const& activation,
+                         nvinfer1::PluginTensorDesc const& gamma,
+                         nvinfer1::PluginTensorDesc const& beta,
+                         nvinfer1::PluginTensorDesc const& output) {
+    return is_bf16_linear(activation) && is_bf16_linear(gamma) && is_bf16_linear(beta) &&
+           is_bf16_linear(output) && has_activation_shape(activation.dims) &&
+           has_parameter_shape(gamma.dims) && has_parameter_shape(beta.dims) &&
+           has_activation_shape(output.dims);
+}
+
+bool has_supported_shape(nvinfer1::PluginTensorDesc const* input, int32_t nb_inputs,
+                         nvinfer1::PluginTensorDesc const* output, int32_t nb_outputs) {
+    return input != nullptr && output != nullptr && nb_inputs == 3 && nb_outputs == 1 &&
+           has_supported_shape(input[0], input[1], input[2], output[0]);
+}
+
+bool has_supported_dynamic_shape(nvinfer1::DynamicPluginTensorDesc const* input, int32_t nb_inputs,
+                                 nvinfer1::DynamicPluginTensorDesc const* output,
+                                 int32_t nb_outputs) {
+    if (input == nullptr || output == nullptr || nb_inputs != 3 || nb_outputs != 1) {
+        return false;
+    }
+    return has_supported_shape(input[0].desc, input[1].desc, input[2].desc, output[0].desc) &&
+           has_activation_shape(input[0].min) && has_parameter_shape(input[1].min) &&
+           has_parameter_shape(input[2].min) && has_activation_shape(output[0].min) &&
+           has_activation_shape(input[0].max) && has_parameter_shape(input[1].max) &&
+           has_parameter_shape(input[2].max) && has_activation_shape(output[0].max);
+}
+
+class OpenPISiglipLayerNormPlugin final : public nvinfer1::IPluginV3,
+                                          public nvinfer1::IPluginV3OneCore,
+                                          public nvinfer1::IPluginV3OneBuild,
+                                          public nvinfer1::IPluginV3OneRuntime {
+  public:
+    static constexpr const char* kName = "OpenPISiglipLayerNorm";
+    static constexpr const char* kVersion = "1";
+
+    explicit OpenPISiglipLayerNormPlugin(float epsilon = kEpsilon) : epsilon_(epsilon) {
+        update_serialization_fields();
+    }
+
+    nvinfer1::IPluginCapability*
+    getCapabilityInterface(nvinfer1::PluginCapabilityType type) noexcept override {
+        switch (type) {
+        case nvinfer1::PluginCapabilityType::kCORE:
+            return static_cast<nvinfer1::IPluginV3OneCore*>(this);
+        case nvinfer1::PluginCapabilityType::kBUILD:
+            return static_cast<nvinfer1::IPluginV3OneBuild*>(this);
+        case nvinfer1::PluginCapabilityType::kRUNTIME:
+            return static_cast<nvinfer1::IPluginV3OneRuntime*>(this);
+        }
+        return nullptr;
+    }
+
+    nvinfer1::IPluginV3* clone() noexcept override {
+        auto* plugin = new (std::nothrow) OpenPISiglipLayerNormPlugin(epsilon_);
+        if (plugin != nullptr) {
+            plugin->namespace_ = namespace_;
+        }
+        return plugin;
+    }
+
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override { return kName; }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override { return kVersion; }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override {
+        return namespace_.c_str();
+    }
+
+    int32_t configurePlugin(nvinfer1::DynamicPluginTensorDesc const* input, int32_t nb_inputs,
+                            nvinfer1::DynamicPluginTensorDesc const* output,
+                            int32_t nb_outputs) noexcept override {
+        if (epsilon_ != kEpsilon ||
+            !has_supported_dynamic_shape(input, nb_inputs, output, nb_outputs)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t getOutputDataTypes(nvinfer1::DataType* output_types, int32_t nb_outputs,
+                               nvinfer1::DataType const* input_types,
+                               int32_t nb_inputs) const noexcept override {
+        if (output_types == nullptr || input_types == nullptr || nb_outputs != 1 ||
+            nb_inputs != 3 || input_types[0] != nvinfer1::DataType::kBF16 ||
+            input_types[1] != nvinfer1::DataType::kBF16 ||
+            input_types[2] != nvinfer1::DataType::kBF16) {
+            return 1;
+        }
+        output_types[0] = nvinfer1::DataType::kBF16;
+        return 0;
+    }
+
+    int32_t getOutputShapes(nvinfer1::DimsExprs const* inputs, int32_t nb_inputs,
+                            nvinfer1::DimsExprs const*, int32_t nb_shape_inputs,
+                            nvinfer1::DimsExprs* outputs, int32_t nb_outputs,
+                            nvinfer1::IExprBuilder&) noexcept override {
+        if (inputs == nullptr || outputs == nullptr || nb_inputs != 3 || nb_shape_inputs != 0 ||
+            nb_outputs != 1) {
+            return 1;
+        }
+        outputs[0] = inputs[0];
+        return 0;
+    }
+
+    bool supportsFormatCombination(int32_t position,
+                                   nvinfer1::DynamicPluginTensorDesc const* descriptors,
+                                   int32_t nb_inputs, int32_t nb_outputs) noexcept override {
+        if (descriptors == nullptr || nb_inputs != 3 || nb_outputs != 1 || position < 0 ||
+            position >= 4) {
+            return false;
+        }
+        return is_bf16_linear(descriptors[position].desc);
+    }
+
+    int32_t getNbOutputs() const noexcept override { return 1; }
+
+    std::size_t getWorkspaceSize(nvinfer1::DynamicPluginTensorDesc const*, int32_t,
+                                 nvinfer1::DynamicPluginTensorDesc const*,
+                                 int32_t) const noexcept override {
+        return 0;
+    }
+
+    int32_t onShapeChange(nvinfer1::PluginTensorDesc const* input, int32_t nb_inputs,
+                          nvinfer1::PluginTensorDesc const* output,
+                          int32_t nb_outputs) noexcept override {
+        if (epsilon_ != kEpsilon || !has_supported_shape(input, nb_inputs, output, nb_outputs)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    int32_t enqueue(nvinfer1::PluginTensorDesc const* input_desc,
+                    nvinfer1::PluginTensorDesc const* output_desc, void const* const* inputs,
+                    void* const* outputs, void*, cudaStream_t stream) noexcept override {
+        if (epsilon_ != kEpsilon || !has_supported_shape(input_desc, 3, output_desc, 1) ||
+            inputs == nullptr || outputs == nullptr || inputs[0] == nullptr ||
+            inputs[1] == nullptr || inputs[2] == nullptr || outputs[0] == nullptr) {
+            return 1;
+        }
+        return launch_openpi_siglip_layer_norm(static_cast<const std::uint16_t*>(inputs[0]),
+                                               static_cast<const std::uint16_t*>(inputs[1]),
+                                               static_cast<const std::uint16_t*>(inputs[2]),
+                                               static_cast<std::uint16_t*>(outputs[0]), stream);
+    }
+
+    nvinfer1::IPluginV3* attachToContext(nvinfer1::IPluginResourceContext*) noexcept override {
+        return clone();
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldsToSerialize() noexcept override {
+        update_serialization_fields();
+        return &serialization_fields_;
+    }
+
+  private:
+    void update_serialization_fields() noexcept {
+        serialization_field_ = {"epsilon", &epsilon_, nvinfer1::PluginFieldType::kFLOAT32, 1};
+        serialization_fields_.nbFields = 1;
+        serialization_fields_.fields = &serialization_field_;
+    }
+
+    float epsilon_{kEpsilon};
+    std::string namespace_;
+    nvinfer1::PluginField serialization_field_{};
+    nvinfer1::PluginFieldCollection serialization_fields_{};
+};
+
+class OpenPISiglipLayerNormCreator final : public nvinfer1::IPluginCreatorV3One {
+  public:
+    OpenPISiglipLayerNormCreator() {
+        field_ = {"epsilon", nullptr, nvinfer1::PluginFieldType::kFLOAT32, 1};
+        fields_.nbFields = 1;
+        fields_.fields = &field_;
+    }
+
+    nvinfer1::IPluginV3* createPlugin(nvinfer1::AsciiChar const*,
+                                      nvinfer1::PluginFieldCollection const* fields,
+                                      nvinfer1::TensorRTPhase) noexcept override {
+        if (fields == nullptr || fields->fields == nullptr || fields->nbFields != 1) {
+            return nullptr;
+        }
+        const auto& field = fields->fields[0];
+        if (field.name == nullptr || std::string(field.name) != "epsilon" ||
+            field.type != nvinfer1::PluginFieldType::kFLOAT32 || field.data == nullptr ||
+            field.length != 1) {
+            return nullptr;
+        }
+        const float epsilon = *static_cast<const float*>(field.data);
+        if (epsilon != kEpsilon) {
+            return nullptr;
+        }
+        return new (std::nothrow) OpenPISiglipLayerNormPlugin(epsilon);
+    }
+
+    nvinfer1::PluginFieldCollection const* getFieldNames() noexcept override { return &fields_; }
+    nvinfer1::AsciiChar const* getPluginName() const noexcept override {
+        return OpenPISiglipLayerNormPlugin::kName;
+    }
+    nvinfer1::AsciiChar const* getPluginVersion() const noexcept override {
+        return OpenPISiglipLayerNormPlugin::kVersion;
+    }
+    nvinfer1::AsciiChar const* getPluginNamespace() const noexcept override { return ""; }
+
+  private:
+    nvinfer1::PluginField field_{};
+    nvinfer1::PluginFieldCollection fields_{};
+};
+
+static nvinfer1::PluginRegistrar<OpenPISiglipLayerNormCreator>
+    plugin_registrar_openpi_siglip_layer_norm{};
+
+} // namespace
+} // namespace trtmc::openpi

--- a/tests/cpp/models/openpi/test_openpi_action_request_json.cpp
+++ b/tests/cpp/models/openpi/test_openpi_action_request_json.cpp
@@ -1,0 +1,214 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// =============================================================================
+// ISO 26262 Traceability
+// =============================================================================
+// Trace ID:       UT-CLI-CPP-02
+// Architecture:   ARCH-FAC-001
+// Unit Design:    UD-CABI-01
+// Intent:         Strict native action-request JSON parsing and result encoding
+// Preconditions:  None
+// Postconditions: Malformed policy requests fail closed and valid typed results
+//                 serialize with a stable machine-readable schema
+// =============================================================================
+
+#include "runtime/models/openpi/tool/action_request_json.h"
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+template <typename Function>
+void check_throws(Function&& function, const char* needle, const char* name) {
+    try {
+        function();
+        check(false, name);
+    } catch (const std::exception& error) {
+        check(std::string(error.what()).find(needle) != std::string::npos, name);
+    }
+}
+
+const char* kValidRequest = R"json(
+{
+  "prompt": "pick up the red block",
+  "cameras": {
+    "base_0_rgb": {"path": "base.png", "valid": true},
+    "left_wrist_0_rgb": {"path": "left.png", "valid": true},
+    "right_wrist_0_rgb": {"path": "right.png", "valid": false}
+  },
+  "state": [0, 1.5, -2, 3, 4, 5, 6, 7],
+  "initial_noise": [0.25, -0.5],
+  "seed": 7,
+  "denoise_steps": 10
+}
+)json";
+
+void test_valid_request() {
+    const auto request = trtmc::openpi::tool::parse_action_request_json(kValidRequest);
+    check(request.prompt == "pick up the red block", "valid prompt");
+    check(request.cameras[0].name == "base_0_rgb" && request.cameras[0].path == "base.png" &&
+              request.cameras[0].valid,
+          "base camera");
+    check(request.cameras[1].name == "left_wrist_0_rgb" && request.cameras[1].path == "left.png" &&
+              request.cameras[1].valid,
+          "left camera");
+    check(request.cameras[2].name == "right_wrist_0_rgb" &&
+              request.cameras[2].path == "right.png" && !request.cameras[2].valid,
+          "right camera mask");
+    check(request.state.size() == 8U && request.state[1] == 1.5F, "state array");
+    check(request.initial_noise.size() == 2U && request.initial_noise[1] == -0.5F,
+          "initial noise array");
+    check(request.seed == 7, "seed");
+    check(request.denoise_steps == 10, "denoise steps");
+}
+
+void test_optional_fields() {
+    const auto request = trtmc::openpi::tool::parse_action_request_json(R"json({
+      "prompt": "move",
+      "cameras": {
+        "base_0_rgb": {"path": "a.png", "valid": true},
+        "left_wrist_0_rgb": {"path": "b.png", "valid": true},
+        "right_wrist_0_rgb": {"path": "c.png", "valid": false}
+      },
+      "state": [0]
+    })json");
+    check(request.initial_noise.empty(), "optional initial noise absent");
+    check(request.seed == -1, "optional seed absent");
+    check(request.denoise_steps == -1, "optional denoise steps absent");
+}
+
+void test_strict_keys_and_types() {
+    check_throws(
+        [] {
+            trtmc::openpi::tool::parse_action_request_json(
+                R"json({"prompt":"a","prompt":"b","cameras":{},"state":[0]})json");
+        },
+        "duplicate JSON object key", "duplicate root key rejected");
+    check_throws(
+        [] {
+            trtmc::openpi::tool::parse_action_request_json(R"json({
+              "prompt":"a",
+              "cameras":{
+                "base_0_rgb":{"path":"a","path":"b","valid":true},
+                "left_wrist_0_rgb":{"path":"b","valid":true},
+                "right_wrist_0_rgb":{"path":"c","valid":false}},
+              "state":[0]})json");
+        },
+        "duplicate JSON object key", "duplicate camera key rejected");
+    check_throws(
+        [] {
+            trtmc::openpi::tool::parse_action_request_json(R"json({
+              "prompt":"a","cameras":{
+                "base_0_rgb":{"path":"a","valid":true},
+                "left_wrist_0_rgb":{"path":"b","valid":true},
+                "right_wrist_0_rgb":{"path":"c","valid":false}},
+              "state":[0],"unknown":1})json");
+        },
+        "unexpected field 'unknown'", "unknown root field rejected");
+    check_throws(
+        [] {
+            trtmc::openpi::tool::parse_action_request_json(R"json({
+              "prompt":"a","cameras":{
+                "base_0_rgb":{"path":"a","valid":1},
+                "left_wrist_0_rgb":{"path":"b","valid":true},
+                "right_wrist_0_rgb":{"path":"c","valid":false}},
+              "state":[0]})json");
+        },
+        "must be a boolean", "integer camera mask rejected");
+    check_throws(
+        [] {
+            trtmc::openpi::tool::parse_action_request_json(R"json({
+              "prompt":"a","cameras":{
+                "base_0_rgb":{"path":"a","valid":true},
+                "left_wrist_0_rgb":{"path":"b","valid":true},
+                "right_wrist_0_rgb":{"path":"c","valid":false}},
+              "state":[0],"seed":-1})json");
+        },
+        "must be non-negative", "negative seed rejected");
+    check_throws(
+        [] {
+            trtmc::openpi::tool::parse_action_request_json(R"json({
+              "prompt":"a","cameras":{
+                "base_0_rgb":{"path":"a","valid":true},
+                "left_wrist_0_rgb":{"path":"b","valid":true},
+                "right_wrist_0_rgb":{"path":"c","valid":false}},
+              "state":[0],"denoise_steps":0})json");
+        },
+        "positive int32", "zero denoise steps rejected");
+    check_throws(
+        [] {
+            trtmc::openpi::tool::parse_action_request_json(R"json({
+              "prompt":"a","cameras":{
+                "base_0_rgb":{"path":"a","valid":true},
+                "left_wrist_0_rgb":{"path":"b","valid":true},
+                "right_wrist_0_rgb":{"path":"c","valid":false}},
+              "state":[1e40]})json");
+        },
+        "out-of-range", "out-of-range float rejected");
+}
+
+void test_result_serialization() {
+    trtmc::openpi::ActionResult result;
+    result.actions = {0.25F, -0.5F, 1.0F, 2.0F};
+    result.horizon = 2;
+    result.action_dim = 2;
+    result.timings.preprocess_ms = 0.1;
+    result.timings.prefill_ms = 1.2;
+    result.timings.denoise_ms = 3.4;
+    result.timings.postprocess_ms = 0.2;
+
+    const auto document =
+        nlohmann::json::parse(trtmc::openpi::tool::serialize_action_result_json(result));
+    check(document.size() == 4U, "result exact root field count");
+    check(document.at("horizon") == 2, "result horizon");
+    check(document.at("action_dim") == 2, "result action dim");
+    check(document.at("actions").size() == 4U && document.at("actions")[1] == -0.5F,
+          "result actions");
+    check(document.at("timings").size() == 4U && document.at("timings").at("denoise_ms") == 3.4,
+          "result timings");
+
+    result.actions.pop_back();
+    check_throws([&] { trtmc::openpi::tool::serialize_action_result_json(result); },
+                 "does not match horizon", "result shape rejected");
+    result.actions = {0.25F, -0.5F, 1.0F, std::numeric_limits<float>::infinity()};
+    check_throws([&] { trtmc::openpi::tool::serialize_action_result_json(result); },
+                 "non-finite action", "non-finite result rejected");
+    result.actions.back() = 2.0F;
+    result.timings.prefill_ms = -1.0;
+    check_throws([&] { trtmc::openpi::tool::serialize_action_result_json(result); },
+                 "must be finite and non-negative", "negative timing rejected");
+}
+
+} // namespace
+
+int main() {
+    test_valid_request();
+    test_optional_fields();
+    test_strict_keys_and_types();
+    test_result_serialization();
+
+    if (failures != 0) {
+        std::cerr << failures << " action request JSON tests failed\n";
+        return EXIT_FAILURE;
+    }
+    std::cout << "All action request JSON tests passed\n";
+    return EXIT_SUCCESS;
+}

--- a/tests/cpp/models/openpi/test_openpi_data_plane.cpp
+++ b/tests/cpp/models/openpi/test_openpi_data_plane.cpp
@@ -1,0 +1,259 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/openpi/openpi_data_plane.h"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++g_failures;
+    }
+}
+
+void check_close(float actual, float expected, float tolerance, const char* name) {
+    if (std::fabs(actual - expected) > tolerance) {
+        std::cerr << "FAIL: " << name << " actual=" << actual << " expected=" << expected << '\n';
+        ++g_failures;
+    }
+}
+
+template <typename Function>
+void check_throws(Function&& function, const char* name) {
+    bool threw = false;
+    try {
+        function();
+    } catch (const std::exception&) {
+        threw = true;
+    }
+    check(threw, name);
+}
+
+void test_quantile_normalization_matches_openpi_broadcast_and_tail_rules() {
+    const trtmc::openpi::QuantileStats input_stats{{0.0F, -10.0F}, {10.0F, 10.0F}};
+    const std::vector<float> values{0.0F, -10.0F, 5.0F, 0.0F, 10.0F, 10.0F};
+    const auto normalized = trtmc::openpi::quantile_normalize(values, 2, input_stats);
+    check(normalized.size() == values.size(), "quantile normalization preserves shape");
+    check_close(normalized[0], -1.0F, 1e-7F, "quantile normalization q01 maps to -1");
+    check_close(normalized[2], -1.1920929e-7F, 2e-7F,
+                "quantile normalization midpoint includes upstream epsilon");
+    check_close(normalized[5], 0.99999988F, 2e-7F,
+                "quantile normalization q99 includes upstream epsilon");
+
+    const trtmc::openpi::QuantileStats output_stats{{0.0F, -10.0F}, {10.0F, 10.0F}};
+    const std::vector<float> model_actions{-1.0F, 0.0F, 123.0F, 1.0F, 1.0F, -7.0F};
+    const auto actions = trtmc::openpi::quantile_unnormalize(model_actions, 3, output_stats);
+    check_close(actions[0], 0.0F, 1e-7F, "quantile unnormalize -1 maps to q01");
+    check_close(actions[1], 9.536743e-7F, 1e-8F,
+                "quantile unnormalize midpoint includes float32 epsilon");
+    check_close(actions[2], 123.0F, 0.0F, "quantile unnormalize preserves padded tail");
+    check_close(actions[5], -7.0F, 0.0F, "quantile unnormalize preserves every padded row tail");
+
+    check_throws([&] { (void)trtmc::openpi::quantile_normalize(values, 3, input_stats); },
+                 "quantile normalize rejects undersized stats");
+    check_throws([&] { (void)trtmc::openpi::quantile_unnormalize(values, 1, output_stats); },
+                 "quantile unnormalize rejects oversized stats");
+}
+
+void test_state_binning_and_prompt_format_match_pi05() {
+    check(trtmc::openpi::discretize_state_value(-2.0F) == -1,
+          "state values below range remain bin -1");
+    check(trtmc::openpi::discretize_state_value(-1.0F) == 0, "state -1 maps to bin zero");
+    check(trtmc::openpi::discretize_state_value(-0.9921875F) == 1,
+          "state exact second boundary maps to bin one");
+    check(trtmc::openpi::discretize_state_value(0.0F) == 128, "state zero maps to bin 128");
+    check(trtmc::openpi::discretize_state_value(0.9921875F) == 255,
+          "state last boundary maps to bin 255");
+    check(trtmc::openpi::discretize_state_value(std::numeric_limits<float>::infinity()) == 255,
+          "state positive infinity follows numpy digitize");
+    check(trtmc::openpi::discretize_state_value(std::numeric_limits<float>::quiet_NaN()) == 255,
+          "state NaN follows numpy digitize");
+
+    const std::string padded_prompt =
+        std::string("\xC2\xA0") + "pick_up\nblock" + std::string("\xE3\x80\x80");
+    check(trtmc::openpi::clean_prompt(padded_prompt) == "pick up block",
+          "prompt cleaning matches unicode strip and replacements");
+    check(trtmc::openpi::clean_prompt("  keep\rreturn  ") == "keep\rreturn",
+          "prompt cleaning only replaces newline, not carriage return");
+    check(trtmc::openpi::format_pi05_prompt(padded_prompt, {-1.0F, 0.0F, 1.0F}) ==
+              "Task: pick up block, State: 0 128 255;\nAction: ",
+          "pi05 prompt formatting is exact");
+    check_throws(
+        [] {
+            const std::string invalid("\xC0\xAF", 2);
+            (void)trtmc::openpi::clean_prompt(invalid);
+        },
+        "prompt cleaning rejects non-canonical UTF-8");
+}
+
+void test_camera_slot_validation_and_order() {
+    const std::vector<uint8_t> base{1, 2, 3};
+    const std::vector<uint8_t> wrist{4, 5, 6};
+    const std::vector<uint8_t> black{0, 0, 0};
+    auto camera = [](std::string_view name, const std::vector<uint8_t>& data, bool valid) {
+        trtmc::openpi::CameraFrameView view;
+        view.name = name;
+        view.height = 1;
+        view.width = 1;
+        view.channels = 3;
+        view.valid = valid;
+        view.pixel_type = trtmc::openpi::CameraPixelType::kUint8;
+        view.uint8_data = data.data();
+        view.element_count = data.size();
+        return view;
+    };
+    const auto ordered = trtmc::openpi::validate_and_order_camera_slots(
+        {camera("right_wrist_0_rgb", black, false), camera("base_0_rgb", base, true),
+         camera("left_wrist_0_rgb", wrist, true)});
+    check(ordered[0].name == "base_0_rgb" && ordered[1].name == "left_wrist_0_rgb" &&
+              ordered[2].name == "right_wrist_0_rgb",
+          "camera slots are returned in canonical order");
+    trtmc::openpi::validate_pi05_two_camera_masks(ordered);
+
+    check_throws(
+        [&] {
+            (void)trtmc::openpi::validate_and_order_camera_slots(
+                {camera("base_0_rgb", base, true), camera("base_0_rgb", base, true),
+                 camera("right_wrist_0_rgb", black, false)});
+        },
+        "camera validation rejects duplicates");
+    const std::vector<uint8_t> non_black{0, 1, 0};
+    check_throws(
+        [&] {
+            (void)trtmc::openpi::validate_and_order_camera_slots(
+                {camera("base_0_rgb", base, true), camera("left_wrist_0_rgb", wrist, true),
+                 camera("right_wrist_0_rgb", non_black, false)});
+        },
+        "camera validation rejects non-black masked slot");
+}
+
+void test_resize_with_pad_matches_jax_linear_geometry_and_values() {
+    const auto geometry = trtmc::openpi::compute_resize_with_pad_geometry(256, 320, 60, 80);
+    check(geometry.resized_height == 60 && geometry.resized_width == 75,
+          "resize geometry preserves aspect ratio with truncation");
+    check(geometry.pad_left == 2 && geometry.pad_right == 3 && geometry.pad_top == 0 &&
+              geometry.pad_bottom == 0,
+          "resize geometry puts odd extra padding on right/bottom");
+
+    // JAX LINEAR uses a widened triangular kernel when downsampling. For each
+    // identical row [0, 0, 255, 255], a 4 -> 2 resize yields [36, 219] after
+    // weight normalization and ties-to-even uint8 rounding, not [0, 255].
+    const std::vector<uint8_t> downsample_source{0, 0, 255, 255, 0, 0, 255, 255};
+    const auto downsampled =
+        trtmc::openpi::resize_with_pad_uint8(downsample_source.data(), 2, 4, 1, 1, 2);
+    check(downsampled == std::vector<uint8_t>({36, 219}),
+          "uint8 resize matches JAX antialiased triangle kernel");
+
+    const std::vector<float> upsample_source{0.0F, 1.0F, 1.0F, 0.0F};
+    const auto upsampled =
+        trtmc::openpi::resize_with_pad_float(upsample_source.data(), 2, 2, 1, 3, 3);
+    check(upsampled.size() == 9, "float resize produces target geometry");
+    check_close(upsampled[4], 0.5F, 1e-6F, "float resize uses half-pixel bilinear interpolation");
+
+    const std::vector<float> wide_source{0.0F, 0.25F, 0.5F, 1.0F, 1.0F, 0.5F, 0.25F, 0.0F};
+    const auto padded = trtmc::openpi::resize_with_pad_float(wide_source.data(), 2, 4, 1, 4, 4);
+    check(padded.size() == 16, "float resize-with-pad target size");
+    check_close(padded[0], -1.0F, 0.0F, "float resize top padding is normalized black");
+    check_close(padded[4], 0.0F, 0.0F, "float resize preserves identity row");
+    check_close(padded[15], -1.0F, 0.0F, "float resize bottom padding is normalized black");
+
+    const auto normalized = trtmc::openpi::uint8_to_openpi_float({0, 64, 127, 128, 249, 255});
+    const std::vector<float> expected_normalized{
+        -0x1.0p+0F, -0x1.fdfe00p-2F, -0x1.0102p-8F, 0x1.01p-8F, 0x1.e7e7e4p-1F, 0x1.fffffcp-1F,
+    };
+    check(normalized == expected_normalized,
+          "uint8 normalization is bit-exact with pinned JAX/XLA lowering");
+}
+
+void test_resize_matches_pinned_jax_0_5_3_goldens() {
+    std::vector<uint8_t> uint8_source(45);
+    for (std::size_t i = 0; i < uint8_source.size(); ++i) {
+        uint8_source[i] = static_cast<uint8_t>(i * 5U);
+    }
+    // Generated directly with jax==0.5.3, ResizeMethod.LINEAR (default
+    // antialias=True), followed by jnp.round/clip/uint8 and jnp.pad.
+    const std::vector<uint8_t> expected_uint8{
+        0,   0,   0,   0,   0,  0,  0,  0,  0,   0,   0,   0,   32,  37,  42,  49,
+        54,  59,  67,  72,  77, 84, 89, 94, 126, 131, 136, 143, 148, 153, 161, 166,
+        171, 178, 183, 188, 0,  0,  0,  0,  0,   0,   0,   0,   0,   0,   0,   0,
+    };
+    const auto actual_uint8 =
+        trtmc::openpi::resize_with_pad_uint8(uint8_source.data(), 3, 5, 3, 4, 4);
+    check(actual_uint8 == expected_uint8, "uint8 resize is exact against pinned JAX golden");
+
+    const std::vector<float> float_source{
+        -1.0F,         -0.931034505F, -0.862068951F,  -0.793103456F, -0.724137902F, -0.655172408F,
+        -0.586206913F, -0.517241359F, -0.448275864F,  -0.37931034F,  -0.310344815F, -0.241379306F,
+        -0.172413796F, -0.103448279F, -0.0344827585F, 0.0344827585F, 0.103448279F,  0.172413796F,
+        0.241379306F,  0.310344815F,  0.37931034F,    0.448275864F,  0.517241359F,  0.586206913F,
+        0.655172408F,  0.724137902F,  0.793103456F,   0.862068951F,  0.931034505F,  1.0F,
+    };
+    const std::vector<float> expected_float{
+        -1.0F,         -1.0F,         -1.0F,         -1.0F,         -1.0F,         -1.0F,
+        -1.0F,         -1.0F,         -0.706896544F, -0.637930989F, -0.545976996F, -0.477011472F,
+        -0.385057449F, -0.316091925F, -0.224137917F, -0.155172408F, 0.155172408F,  0.224137932F,
+        0.316091925F,  0.385057449F,  0.477011502F,  0.545976996F,  0.637931049F,  0.706896544F,
+        -1.0F,         -1.0F,         -1.0F,         -1.0F,         -1.0F,         -1.0F,
+        -1.0F,         -1.0F,
+    };
+    const auto actual_float =
+        trtmc::openpi::resize_with_pad_float(float_source.data(), 3, 5, 2, 4, 4);
+    check(actual_float.size() == expected_float.size(),
+          "float JAX golden has matching element count");
+    for (std::size_t i = 0; i < actual_float.size() && i < expected_float.size(); ++i) {
+        check_close(actual_float[i], expected_float[i], 2e-7F,
+                    "float resize matches pinned JAX golden");
+    }
+}
+
+void test_fixed_noise_and_euler_helpers_are_reproducible() {
+    const auto schedule = trtmc::openpi::make_euler_schedule(10);
+    check(schedule.timesteps.size() == 10, "Euler schedule has ten denoising steps");
+    check_close(schedule.dt, -0.1F, 0.0F, "Euler schedule dt matches OpenPI");
+    check_close(schedule.timesteps.front(), 1.0F, 0.0F, "Euler schedule starts at noise time");
+    check_close(schedule.timesteps.back(), 0.099999927F, 1e-7F,
+                "Euler schedule retains iterative float32 drift");
+
+    const std::vector<float> source_noise{0.25F, -0.5F, 1.0F, -1.0F};
+    auto sample = trtmc::openpi::make_fixed_noise(source_noise, 1, 2, 2);
+    check(sample == source_noise, "fixed noise helper preserves every supplied bit");
+    trtmc::openpi::euler_step_in_place(sample, {0.5F, -1.0F, 2.0F, 4.0F}, schedule.dt);
+    check_close(sample[0], 0.2F, 1e-7F, "Euler update first component");
+    check_close(sample[1], -0.4F, 1e-7F, "Euler update second component");
+    check_close(sample[2], 0.8F, 1e-7F, "Euler update third component");
+    check_close(sample[3], -1.4F, 1e-7F, "Euler update fourth component");
+    check_throws([&] { (void)trtmc::openpi::make_fixed_noise(source_noise, 1, 3, 2); },
+                 "fixed noise rejects incorrect shape");
+    check_throws([&] { trtmc::openpi::euler_step_in_place(sample, {1.0F}, -0.1F); },
+                 "Euler update rejects mismatched velocity");
+}
+
+} // namespace
+
+int main() {
+    test_quantile_normalization_matches_openpi_broadcast_and_tail_rules();
+    test_state_binning_and_prompt_format_match_pi05();
+    test_camera_slot_validation_and_order();
+    test_resize_with_pad_matches_jax_linear_geometry_and_values();
+    test_resize_matches_pinned_jax_0_5_3_goldens();
+    test_fixed_noise_and_euler_helpers_are_reproducible();
+
+    if (g_failures != 0) {
+        std::cerr << g_failures << " OpenPI data-plane test(s) failed\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/cpp/models/openpi/test_openpi_pipeline.cpp
+++ b/tests/cpp/models/openpi/test_openpi_pipeline.cpp
@@ -1,0 +1,562 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/openpi/config.h"
+#include "runtime/models/openpi/paligemma_bpe.h"
+#include "runtime/models/openpi/pipeline.h"
+#include "runtime/models/openpi/plugin_helpers.h"
+#include "utils/sha256.h"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++g_failures;
+    }
+}
+
+void check_close(float actual, float expected, float tolerance, const char* name) {
+    if (std::fabs(actual - expected) > tolerance) {
+        std::cerr << "FAIL: " << name << " actual=" << actual << " expected=" << expected << '\n';
+        ++g_failures;
+    }
+}
+
+template <typename Function>
+void check_throws(Function&& function, const char* name) {
+    bool threw = false;
+    try {
+        function();
+    } catch (const std::exception&) {
+        threw = true;
+    }
+    check(threw, name);
+}
+
+std::string sha256(std::string_view bytes) {
+    trtmc::internal::Sha256 hash;
+    hash.update(bytes);
+    return hash.hex_digest();
+}
+
+std::string droid_config_json(std::string tokenizer_sha256 = std::string(64, '3'),
+                              std::string normalization_sha256 = std::string(64, '4'),
+                              std::string prefill_sha256 = std::string(64, '5'),
+                              std::string action_sha256 = std::string(64, '6')) {
+    std::string result = R"json({
+      "runtime_strategy": "openpi_vla",
+      "task_strategy": "robot_action_generation",
+      "user_contract": "robot_action_chunk",
+      "model_type": "openpi_pi05_flow",
+      "precision": "bf16",
+      "openpi_profile": "pi05_droid",
+      "openpi_upstream_commit": "15a9616a00943ada6c20a0f158e3adb39df2ccac",
+      "openpi_action_horizon": 15,
+      "openpi_internal_action_dim": 32,
+      "openpi_external_action_dim": 8,
+      "openpi_external_state_dim": 8,
+      "openpi_prefix_length": 968,
+      "openpi_max_token_length": 200,
+      "openpi_num_layers": 18,
+      "openpi_num_heads": 8,
+      "openpi_num_kv_heads": 1,
+      "openpi_head_dim": 256,
+      "openpi_denoise_steps": 10,
+      "openpi_discrete_state_input": true,
+      "openpi_camera_names": ["base_0_rgb", "left_wrist_0_rgb", "right_wrist_0_rgb"],
+      "openpi_camera_mask": [true, true, false],
+      "openpi_batch_size": 1,
+      "openpi_runtime_contract": "native_cpp_device_resident_flow",
+      "openpi_parameter_dtype": "bfloat16",
+      "openpi_tokenizer_sha256": ")json";
+    result += tokenizer_sha256;
+    result += R"json(",
+      "openpi_normalization_sha256": ")json";
+    result += normalization_sha256;
+    result += R"json(",
+      "openpi_prefill_engine_sha256": ")json";
+    result += prefill_sha256;
+    result += R"json(",
+      "openpi_action_engine_sha256": ")json";
+    result += action_sha256;
+    result += R"json("
+    })json";
+    return result;
+}
+
+std::string normalization_json() {
+    return R"json({
+      "norm_stats": {
+        "state": {
+          "q01": [-1,-1,-1,-1,-1,-1,-1,-1],
+          "q99": [1,1,1,1,1,1,1,1]
+        },
+        "actions": {
+          "q01": [-1,-1,-1,-1,-1,-1,-1,-1],
+          "q99": [1,1,1,1,1,1,1,1]
+        }
+      }
+    })json";
+}
+
+std::string padded_normalization_json() {
+    return R"json({
+      "norm_stats": {
+        "state": {
+          "q01": [-1,-1,-1,-1,-1,-1,-1,-1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+          "q99": [1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+        },
+        "actions": {
+          "q01": [-1,-1,-1,-1,-1,-1,-1,-1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+          "q99": [1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+        }
+      }
+    })json";
+}
+
+trtmc::openpi::PaligemmaBpeAsset make_tokenizer_asset() {
+    using trtmc::openpi::BpePiece;
+    using trtmc::openpi::SentencePieceType;
+    trtmc::openpi::PaligemmaBpeAsset asset;
+    asset.byte_fallback = false;
+    asset.add_dummy_prefix = false;
+    asset.remove_extra_whitespaces = false;
+    asset.unknown_id = 1;
+    asset.bos_id = 2;
+    asset.eos_id = 3;
+    asset.pad_id = 0;
+    asset.pieces = {
+        BpePiece{"<pad>", 0.0F, SentencePieceType::kControl},
+        BpePiece{"<unk>", 0.0F, SentencePieceType::kUnknown},
+        BpePiece{"<s>", 0.0F, SentencePieceType::kControl},
+        BpePiece{"</s>", 0.0F, SentencePieceType::kControl},
+    };
+    return asset;
+}
+
+class FakeModule final : public trtmc::ITrtModule {
+  public:
+    void add_input(std::string name, std::vector<int64_t> shape, trtmc::DType dtype) {
+        tensors_[name] = trtmc::TensorInfo{name, std::move(shape), dtype, true};
+    }
+
+    void add_output(std::string name, std::vector<int64_t> shape, trtmc::DType dtype) {
+        tensors_[name] = trtmc::TensorInfo{name, std::move(shape), dtype, false};
+    }
+
+    trtmc::TensorMap forward(const trtmc::TensorMap&) override {
+        throw std::runtime_error("FakeModule::forward must not run");
+    }
+    trtmc::DeviceTensorMap forward_device(const trtmc::DeviceTensorMap&) override {
+        throw std::runtime_error("FakeModule::forward_device must not run");
+    }
+    void forward_device_async(const trtmc::DeviceTensorMap&) override {
+        throw std::runtime_error("FakeModule::forward_device_async must not run");
+    }
+    void forward_async(const trtmc::TensorMap&) override {
+        throw std::runtime_error("FakeModule::forward_async must not run");
+    }
+    void sync() override {}
+    cudaStream_t stream() const override { return nullptr; }
+    void enable_cuda_graph() override {}
+    bool cuda_graph_active() const override { return false; }
+    int32_t profile_idx() const override { return 0; }
+    std::vector<trtmc::TensorInfo> input_info() const override { return tensor_info(true); }
+    std::vector<trtmc::TensorInfo> output_info() const override { return tensor_info(false); }
+    bool has_input(const std::string& name) const override { return has(name, true); }
+    bool has_output(const std::string& name) const override { return has(name, false); }
+    trtmc::DType tensor_dtype(const std::string& name) const override {
+        return tensors_.at(name).dtype;
+    }
+    std::vector<int64_t> tensor_shape(const std::string& name) const override {
+        return tensors_.at(name).shape;
+    }
+    std::vector<int64_t> input_profile_shape(const std::string&, int32_t,
+                                             trtmc::ProfileShapeSelector) const override {
+        return {};
+    }
+    int32_t optimization_profile_count() const override { return 1; }
+    void* device_ptr(const std::string&) const override { return nullptr; }
+    void bind_external(const std::string&, void*) override {}
+    bool ok() const override { return true; }
+    void keep_alive(std::shared_ptr<void>) override {}
+
+  private:
+    bool has(const std::string& name, bool input) const {
+        const auto iterator = tensors_.find(name);
+        return iterator != tensors_.end() && iterator->second.is_input == input;
+    }
+
+    std::vector<trtmc::TensorInfo> tensor_info(bool input) const {
+        std::vector<trtmc::TensorInfo> result;
+        for (const auto& [unused, info] : tensors_) {
+            (void)unused;
+            if (info.is_input == input) {
+                result.push_back(info);
+            }
+        }
+        return result;
+    }
+
+    std::unordered_map<std::string, trtmc::TensorInfo> tensors_;
+};
+
+class FakeBackend final : public trtmc::IBackend {
+  public:
+    explicit FakeBackend(const char* backend_name) : backend_name_(backend_name) {}
+
+    std::unique_ptr<trtmc::ITrtModule> create_module(const void*, size_t,
+                                                     const trtmc::ModuleCreateOptions&) override {
+        ++create_module_calls;
+        return std::make_unique<FakeModule>();
+    }
+
+    trtmc::BackendDualProfileModules
+    create_dual_profile_modules(const void*, size_t, const trtmc::ModuleCreateOptions&) override {
+        return {};
+    }
+
+    trtmc::BackendProfileModules create_profile_modules(const void*, size_t,
+                                                        const trtmc::ModuleCreateOptions&,
+                                                        const std::vector<int32_t>&) override {
+        return {};
+    }
+
+    trtmc::BackendContextModules
+    create_context_modules(const void*, size_t,
+                           const std::vector<trtmc::ModuleCreateOptions>&) override {
+        return {};
+    }
+
+    const char* name() const override { return backend_name_; }
+
+    int create_module_calls{0};
+
+  private:
+    const char* backend_name_;
+};
+
+std::pair<std::unique_ptr<FakeModule>, std::unique_ptr<FakeModule>>
+make_fake_modules(const trtmc::openpi::OpenPIConfig& config) {
+    auto prefill = std::make_unique<FakeModule>();
+    prefill->add_input("pixel_values", {3, 3, 224, 224}, trtmc::DType::kFloat32);
+    prefill->add_input("token_ids", {1, 200}, trtmc::DType::kInt32);
+    prefill->add_input("prefix_mask", {1, 968}, trtmc::DType::kFloat32);
+    prefill->add_input("prefix_position_ids", {1, 968}, trtmc::DType::kInt32);
+    prefill->add_output("vision_tokens", {1, 3, 256, 2048}, trtmc::DType::kBFloat16);
+
+    auto action = std::make_unique<FakeModule>();
+    const std::vector<int64_t> action_shape{1, config.action_horizon, 32};
+    action->add_input("noisy_actions", action_shape, trtmc::DType::kFloat32);
+    action->add_input("timestep", {1}, trtmc::DType::kFloat32);
+    action->add_input("step_size", {1}, trtmc::DType::kFloat32);
+    action->add_input("prefix_mask", {1, 968}, trtmc::DType::kFloat32);
+    action->add_input("suffix_position_ids", {1, config.action_horizon}, trtmc::DType::kInt32);
+    action->add_output("velocity", action_shape, trtmc::DType::kFloat32);
+    action->add_output("next_actions", action_shape, trtmc::DType::kFloat32);
+
+    const std::vector<int64_t> cache_shape{1, 968, 1, 256};
+    for (int32_t layer = 0; layer < config.num_layers; ++layer) {
+        for (char kind : {'k', 'v'}) {
+            const std::string name = std::string("prefix_") + kind + "_" + std::to_string(layer);
+            prefill->add_output(name, cache_shape, trtmc::DType::kBFloat16);
+            action->add_input(name, cache_shape, trtmc::DType::kBFloat16);
+        }
+    }
+    return {std::move(prefill), std::move(action)};
+}
+
+void test_strict_config_and_normalization() {
+    const auto config = trtmc::openpi::parse_openpi_config(droid_config_json());
+    check(config.profile == "pi05_droid" && config.action_horizon == 15 &&
+              config.tokenizer_sha256 == std::string(64, '3') &&
+              config.normalization_sha256 == std::string(64, '4') &&
+              config.prefill_engine_sha256 == std::string(64, '5') &&
+              config.action_engine_sha256 == std::string(64, '6'),
+          "OpenPI config selects explicit DROID profile");
+    const auto normalization =
+        trtmc::openpi::parse_openpi_normalization(normalization_json(), config);
+    check(normalization.state.q01.size() == 8 && normalization.actions.q99.size() == 8,
+          "OpenPI normalization parses profile quantiles");
+    const auto padded_normalization =
+        trtmc::openpi::parse_openpi_normalization(padded_normalization_json(), config);
+    check(padded_normalization.state.q01.size() == 32 &&
+              padded_normalization.actions.q99.size() == 32 &&
+              padded_normalization.actions.q01[31] == padded_normalization.actions.q99[31],
+          "OpenPI normalization accepts official zero-span padded dimensions");
+
+    auto mismatched = droid_config_json();
+    const auto position = mismatched.find("\"openpi_action_horizon\": 15");
+    mismatched.replace(position, std::string("\"openpi_action_horizon\": 15").size(),
+                       "\"openpi_action_horizon\": 10");
+    check_throws([&] { (void)trtmc::openpi::parse_openpi_config(mismatched); },
+                 "OpenPI config rejects profile/shape mismatch");
+    auto duplicate_key_config = droid_config_json();
+    const auto profile_position = duplicate_key_config.find("\"openpi_profile\"");
+    duplicate_key_config.insert(profile_position, "\"openpi_profile\": \"pi05_droid\",\n      ");
+    check_throws([&] { (void)trtmc::openpi::parse_openpi_config(duplicate_key_config); },
+                 "OpenPI config rejects duplicate JSON keys");
+
+    check_throws(
+        [&] { (void)trtmc::openpi::parse_openpi_config(droid_config_json(std::string(64, 'A'))); },
+        "OpenPI config rejects an uppercase payload digest");
+    check_throws(
+        [&] {
+            (void)trtmc::openpi::parse_openpi_config(
+                droid_config_json(std::string(64, '3'), std::string(63, '4')));
+        },
+        "OpenPI config rejects a truncated payload digest");
+
+    auto bfloat16 = droid_config_json();
+    const auto bf16_position = bfloat16.find("\"precision\": \"bf16\"");
+    bfloat16.replace(bf16_position, std::string("\"precision\": \"bf16\"").size(),
+                     "\"precision\": \"bfloat16\"");
+    check(trtmc::openpi::parse_openpi_config(bfloat16).precision == "bfloat16",
+          "OpenPI config accepts the bfloat16 precision alias");
+
+    for (const std::string_view rejected_precision : {"fp16", "fp32"}) {
+        auto rejected = droid_config_json();
+        const auto precision_position = rejected.find("\"precision\": \"bf16\"");
+        rejected.replace(precision_position, std::string("\"precision\": \"bf16\"").size(),
+                         "\"precision\": \"" + std::string(rejected_precision) + "\"");
+        const auto parameter_dtype_position =
+            rejected.find("\"openpi_parameter_dtype\": \"bfloat16\"");
+        rejected.replace(parameter_dtype_position,
+                         std::string("\"openpi_parameter_dtype\": \"bfloat16\"").size(),
+                         "\"openpi_parameter_dtype\": \"" + std::string(rejected_precision) + "\"");
+        check_throws([&] { (void)trtmc::openpi::parse_openpi_config(rejected); },
+                     "OpenPI config rejects an unqualified network precision");
+    }
+
+    auto mismatched_parameter_dtype = droid_config_json();
+    const auto dtype_position =
+        mismatched_parameter_dtype.find("\"openpi_parameter_dtype\": \"bfloat16\"");
+    mismatched_parameter_dtype.replace(
+        dtype_position, std::string("\"openpi_parameter_dtype\": \"bfloat16\"").size(),
+        "\"openpi_parameter_dtype\": \"bf16\"");
+    check_throws([&] { (void)trtmc::openpi::parse_openpi_config(mismatched_parameter_dtype); },
+                 "OpenPI config rejects a non-bfloat16 parameter dtype");
+}
+
+void test_bundle_integrity_rejects_missing_duplicate_and_tampered_sections() {
+    const auto tokenizer_vector =
+        trtmc::openpi::serialize_paligemma_bpe_asset(make_tokenizer_asset());
+    const std::string tokenizer(reinterpret_cast<const char*>(tokenizer_vector.data()),
+                                tokenizer_vector.size());
+    const std::string prefill_plan = "prefill-plan";
+    const std::string action_plan = "action-plan";
+    const std::string normalization = normalization_json();
+    const std::array<std::string, 5> storage = {
+        droid_config_json(sha256(tokenizer), sha256(normalization), sha256(prefill_plan),
+                          sha256(action_plan)),
+        prefill_plan,
+        action_plan,
+        tokenizer,
+        normalization,
+    };
+    trtmc::BundleFile bundle;
+    for (std::size_t index = 0; index < storage.size(); ++index) {
+        bundle.sections.push_back(
+            {std::string(trtmc::openpi::kRequiredIntegritySectionNames[index]),
+             std::vector<char>(storage[index].begin(), storage[index].end())});
+    }
+
+    const auto verified = trtmc::openpi::verify_openpi_bundle_integrity(bundle);
+    check(verified.prefill_plan != nullptr && verified.action_plan != nullptr &&
+              verified.tokenizer_bytes == tokenizer &&
+              verified.normalization_bytes == normalization,
+          "OpenPI bundle integrity verifies every required section before engine loading");
+
+    auto duplicate = bundle;
+    duplicate.sections.push_back(bundle.sections[1]);
+    check_throws([&] { (void)trtmc::openpi::verify_openpi_bundle_integrity(duplicate); },
+                 "OpenPI bundle integrity rejects duplicate physical sections");
+
+    auto unexpected = bundle;
+    unexpected.sections.push_back({"openpi_provenance.json", {'x'}});
+    check_throws([&] { (void)trtmc::openpi::verify_openpi_bundle_integrity(unexpected); },
+                 "OpenPI bundle integrity rejects the removed provenance section");
+
+    auto missing = bundle;
+    missing.sections.erase(missing.sections.begin() + 2);
+    check_throws([&] { (void)trtmc::openpi::verify_openpi_bundle_integrity(missing); },
+                 "OpenPI bundle integrity rejects missing action plan");
+
+    auto empty = bundle;
+    empty.sections[4].data.clear();
+    check_throws([&] { (void)trtmc::openpi::verify_openpi_bundle_integrity(empty); },
+                 "OpenPI bundle integrity rejects an empty required section");
+
+    for (std::size_t index = 1; index < storage.size(); ++index) {
+        auto tampered = bundle;
+        tampered.sections[index].data.push_back('x');
+        check_throws([&] { (void)trtmc::openpi::verify_openpi_bundle_integrity(tampered); },
+                     "OpenPI bundle integrity rejects tampered payload bytes");
+    }
+}
+
+void test_module_loader_rejects_non_trt_backends_before_deserialization() {
+    const std::vector<char> plan{'p', 'l', 'a', 'n'};
+    const trtmc::ModuleCreateOptions options{};
+
+    FakeBackend null_name(nullptr);
+    check_throws(
+        [&] {
+            (void)trtmc::openpi::load_openpi_module(&null_name, &plan, "engine_plan", "openpi-test",
+                                                    options);
+        },
+        "OpenPI module loader rejects a null backend name");
+    check(null_name.create_module_calls == 0,
+          "OpenPI null-name rejection happens before deserialization");
+
+    FakeBackend wrong_name("trt_rtx");
+    check_throws(
+        [&] {
+            (void)trtmc::openpi::load_openpi_module(&wrong_name, &plan, "engine_plan",
+                                                    "openpi-test", options);
+        },
+        "OpenPI module loader rejects a non-trt backend");
+    check(wrong_name.create_module_calls == 0,
+          "OpenPI wrong-backend rejection happens before deserialization");
+
+    FakeBackend trt_backend("trt");
+    auto module = trtmc::openpi::load_openpi_module(&trt_backend, &plan, "engine_plan",
+                                                    "openpi-test", options);
+    check(module != nullptr && trt_backend.create_module_calls == 1,
+          "OpenPI module loader accepts exactly the standard trt backend");
+}
+
+trtmc::openpi::ActionRequest make_request(const trtmc::openpi::OpenPIConfig& config) {
+    constexpr std::size_t image_elements = 224U * 224U * 3U;
+    trtmc::openpi::RobotImage base{
+        "base_0_rgb", std::vector<float>(image_elements, 0.5F), 224, 224, 3, true};
+    trtmc::openpi::RobotImage left{
+        "left_wrist_0_rgb", std::vector<float>(image_elements, 1.0F), 224, 224, 3, true};
+    trtmc::openpi::RobotImage right{
+        "right_wrist_0_rgb", std::vector<float>(image_elements, 0.0F), 224, 224, 3, false};
+    trtmc::openpi::ActionRequest request;
+    request.prompt = "pick_up block";
+    request.cameras = {std::move(right), std::move(base), std::move(left)};
+    request.state.assign(static_cast<std::size_t>(config.external_state_dim), 0.0F);
+    request.initial_noise.assign(static_cast<std::size_t>(config.action_horizon) * 32U, 0.25F);
+    return request;
+}
+
+void test_cpu_request_preparation() {
+    const auto config = trtmc::openpi::parse_openpi_config(droid_config_json());
+    const auto normalization =
+        trtmc::openpi::parse_openpi_normalization(normalization_json(), config);
+    trtmc::openpi::PaligemmaBpeTokenizer tokenizer(make_tokenizer_asset());
+    const auto prepared = trtmc::openpi::prepare_openpi_inputs(config, normalization, tokenizer,
+                                                               make_request(config), true);
+    check(prepared.pixel_values.size() == 3U * 3U * 224U * 224U,
+          "OpenPI request preparation emits fixed NCHW pixels");
+    check(prepared.preprocessed_images.size() == 3U * 224U * 224U * 3U &&
+              prepared.preprocessed_images[0] == prepared.pixel_values[0],
+          "OpenPI request preparation retains qualification NHWC pixels");
+    check_close(prepared.pixel_values[0], -0.0039215684F, 1e-7F,
+                "OpenPI float public pixels follow upstream uint8 conversion");
+    check_close(prepared.pixel_values[3U * 224U * 224U], 0x1.fffffcp-1F, 0.0F,
+                "OpenPI canonical camera order places left wrist second");
+    check_close(prepared.pixel_values[6U * 224U * 224U], -1.0F, 0.0F,
+                "OpenPI masked right wrist is normalized black");
+    check(prepared.token_ids.size() == 200U && prepared.prefix_mask.size() == 968U,
+          "OpenPI request preparation emits fixed token/prefix shapes");
+    check(prepared.token_mask.size() == 200U &&
+              prepared.image_mask == std::vector<uint8_t>({1U, 1U, 0U}) &&
+              prepared.normalized_state.size() == 32U,
+          "OpenPI request preparation retains exact masks and padded normalized state");
+    check(prepared.prefix_mask[0] == 1U && prepared.prefix_mask[511] == 1U &&
+              prepared.prefix_mask[512] == 0U && prepared.prefix_mask[767] == 0U,
+          "OpenPI request preparation expands camera validity over image tokens");
+    check(prepared.prefix_positions[511] == 511 && prepared.prefix_positions[767] == 511,
+          "OpenPI prefix positions use cumsum(valid)-1");
+    check(prepared.suffix_positions.front() >= 512 && prepared.schedule.timesteps.size() == 10U,
+          "OpenPI suffix positions and ten-step schedule are prepared");
+    check(prepared.initial_noise.front() == 0.25F && prepared.initial_noise.back() == 0.25F,
+          "OpenPI caller-provided parity noise is preserved");
+
+    const auto production_prepared = trtmc::openpi::prepare_openpi_inputs(
+        config, normalization, tokenizer, make_request(config));
+    check(production_prepared.preprocessed_images.empty() &&
+              production_prepared.token_mask.empty() && production_prepared.image_mask.empty() &&
+              production_prepared.normalized_state.empty(),
+          "OpenPI production preparation does not retain diagnostic-only host tensors");
+
+    auto invalid = make_request(config);
+    invalid.denoise_steps = 9;
+    check_throws(
+        [&] {
+            (void)trtmc::openpi::prepare_openpi_inputs(config, normalization, tokenizer, invalid);
+        },
+        "OpenPI request rejects a non-qualified denoise step override");
+}
+
+void test_fake_module_contract_and_pipeline_construction() {
+    const auto config = trtmc::openpi::parse_openpi_config(droid_config_json());
+    auto modules = make_fake_modules(config);
+    trtmc::openpi::validate_openpi_engine_contracts(*modules.first, *modules.second, config);
+    const auto normalization =
+        trtmc::openpi::parse_openpi_normalization(normalization_json(), config);
+    trtmc::openpi::OpenPIPipeline pipeline(
+        std::move(modules.first), std::move(modules.second), config, normalization,
+        trtmc::openpi::PaligemmaBpeTokenizer(make_tokenizer_asset()), "openpi-test");
+    check(std::string(pipeline.pipeline_type()) == "OpenPIPipeline" &&
+              std::string(pipeline.model_id()) == "openpi-test",
+          "OpenPI pipeline constructs with CPU fake modules after contract validation");
+
+    auto bad_modules = make_fake_modules(config);
+    bad_modules.second->add_output("next_actions", {1, 14, 32}, trtmc::DType::kFloat32);
+    check_throws(
+        [&] {
+            trtmc::openpi::validate_openpi_engine_contracts(*bad_modules.first, *bad_modules.second,
+                                                            config);
+        },
+        "OpenPI engine validation rejects action shape mismatch");
+
+    auto stale_prefill_modules = make_fake_modules(config);
+    stale_prefill_modules.first->add_output("vision_tokens", {1, 768, 2048},
+                                            trtmc::DType::kBFloat16);
+    check_throws(
+        [&] {
+            trtmc::openpi::validate_openpi_engine_contracts(*stale_prefill_modules.first,
+                                                            *stale_prefill_modules.second, config);
+        },
+        "OpenPI engine validation requires rebuilt vision diagnostic output");
+
+    auto request_without_noise = make_request(config);
+    request_without_noise.initial_noise.clear();
+    check_throws([&] { (void)pipeline.predict_actions_with_diagnostics(request_without_noise); },
+                 "OpenPI diagnostics fail closed without external replay noise");
+}
+
+} // namespace
+
+int main() {
+    test_strict_config_and_normalization();
+    test_bundle_integrity_rejects_missing_duplicate_and_tampered_sections();
+    test_module_loader_rejects_non_trt_backends_before_deserialization();
+    test_cpu_request_preparation();
+    test_fake_module_contract_and_pipeline_construction();
+    if (g_failures != 0) {
+        std::cerr << g_failures << " OpenPI pipeline test(s) failed\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/cpp/models/openpi/test_openpi_qualification_diagnostics.cpp
+++ b/tests/cpp/models/openpi/test_openpi_qualification_diagnostics.cpp
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/openpi/tool/qualification_diagnostics.h"
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++failures;
+    }
+}
+
+template <typename Function>
+void check_throws(Function&& function, const char* name) {
+    bool threw = false;
+    try {
+        function();
+    } catch (const std::exception&) {
+        threw = true;
+    }
+    check(threw, name);
+}
+
+void test_atomic_manifest_and_payload() {
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto root = std::filesystem::temp_directory_path() /
+                      ("trtmc_qualification_diagnostics_test_" + std::to_string(nonce));
+
+    trtmc::openpi::ActionDiagnosticResult capture;
+    trtmc::openpi::DiagnosticTensor tensor;
+    tensor.name = "normalized_actions";
+    tensor.stage = trtmc::openpi::DiagnosticStage::kPostprocess;
+    tensor.role = trtmc::openpi::DiagnosticRole::kOutput;
+    tensor.dtype = trtmc::openpi::DiagnosticTensorType::kFloat32;
+    tensor.shape = {1, 1, 1};
+    tensor.bytes.resize(sizeof(float));
+    const float value = 1.5F;
+    std::memcpy(tensor.bytes.data(), &value, sizeof(value));
+    capture.tensors.push_back(tensor);
+
+    const auto manifest =
+        trtmc::openpi::tool::write_qualification_diagnostics(capture, root, "openpi-test");
+    check(manifest == root / "manifest.json" && std::filesystem::is_regular_file(manifest),
+          "qualification manifest is atomically published");
+    std::ifstream manifest_stream(manifest);
+    const auto document = nlohmann::json::parse(manifest_stream);
+    const auto& descriptor = document.at("tensors").at("normalized_actions");
+    check(document.at("artifact_type") == "trtmc_action_qualification_diagnostics" &&
+              descriptor.at("path") == "tensors/normalized_actions.bin" &&
+              descriptor.at("stage") == "postprocess" && descriptor.at("role") == "output" &&
+              descriptor.at("dtype") == "float32" && descriptor.at("shape") == tensor.shape &&
+              descriptor.at("byte_length") == sizeof(float) &&
+              descriptor.at("sha256").get<std::string>().size() == 64U,
+          "qualification manifest uses reference-compatible descriptors");
+    std::ifstream payload(root / "tensors" / "normalized_actions.bin", std::ios::binary);
+    const std::vector<uint8_t> bytes{std::istreambuf_iterator<char>(payload),
+                                     std::istreambuf_iterator<char>()};
+    check(bytes == tensor.bytes, "qualification payload preserves raw little-endian bytes");
+    check_throws(
+        [&] {
+            (void)trtmc::openpi::tool::write_qualification_diagnostics(capture, root,
+                                                                       "openpi-test");
+        },
+        "qualification writer rejects an existing target");
+
+    std::filesystem::remove_all(root);
+}
+
+void test_invalid_payload_fails_closed() {
+    trtmc::openpi::ActionDiagnosticResult capture;
+    capture.tensors.push_back(
+        trtmc::openpi::DiagnosticTensor{"bad/name",
+                                        trtmc::openpi::DiagnosticStage::kFlow,
+                                        trtmc::openpi::DiagnosticRole::kIntermediate,
+                                        trtmc::openpi::DiagnosticTensorType::kFloat32,
+                                        {1},
+                                        std::vector<uint8_t>(sizeof(float))});
+    check_throws(
+        [&] {
+            (void)trtmc::openpi::tool::write_qualification_diagnostics(
+                capture, std::filesystem::temp_directory_path() / "trtmc_never_publish_bad_name",
+                "openpi-test");
+        },
+        "qualification writer rejects unsafe tensor names");
+}
+
+} // namespace
+
+int main() {
+    test_atomic_manifest_and_payload();
+    test_invalid_payload_fails_closed();
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cerr << "All qualification diagnostics tests passed.\n";
+    return 0;
+}

--- a/tests/cpp/models/openpi/test_paligemma_bpe.cpp
+++ b/tests/cpp/models/openpi/test_paligemma_bpe.cpp
@@ -1,0 +1,280 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/openpi/paligemma_bpe.h"
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++g_failures;
+    }
+}
+
+template <typename Function>
+void check_throws(Function&& function, const char* name) {
+    bool threw = false;
+    try {
+        function();
+    } catch (const std::exception&) {
+        threw = true;
+    }
+    check(threw, name);
+}
+
+std::string byte_piece(int value) {
+    char piece[7]{};
+    std::snprintf(piece, sizeof(piece), "<0x%02X>", value);
+    return piece;
+}
+
+struct SyntheticAsset {
+    trtmc::openpi::PaligemmaBpeAsset asset;
+    int32_t space{-1};
+    int32_t a{-1};
+    int32_t b{-1};
+    int32_t c{-1};
+    int32_t aa{-1};
+    int32_t hello{-1};
+    int32_t space_hello{-1};
+    int32_t space_world{-1};
+    int32_t abc{-1};
+    int32_t robot{-1};
+    int32_t capital_a{-1};
+};
+
+SyntheticAsset make_synthetic_asset() {
+    using trtmc::openpi::BpePiece;
+    using trtmc::openpi::SentencePieceType;
+
+    SyntheticAsset result;
+    auto& asset = result.asset;
+    asset.unknown_id = 1;
+    asset.bos_id = 2;
+    asset.eos_id = 3;
+    asset.pad_id = 0;
+    asset.pieces = {
+        BpePiece{"<pad>", 0.0F, SentencePieceType::kControl},
+        BpePiece{"<unk>", 0.0F, SentencePieceType::kUnknown},
+        BpePiece{"<s>", 0.0F, SentencePieceType::kControl},
+        BpePiece{"</s>", 0.0F, SentencePieceType::kControl},
+    };
+    for (int value = 0; value < 256; ++value) {
+        asset.pieces.push_back(BpePiece{byte_piece(value), 0.0F, SentencePieceType::kByte});
+    }
+    auto add = [&](std::string text, float score,
+                   SentencePieceType type = SentencePieceType::kNormal) {
+        const auto id = static_cast<int32_t>(asset.pieces.size());
+        asset.pieces.push_back(BpePiece{std::move(text), score, type});
+        return id;
+    };
+
+    result.space = add("\xE2\x96\x81", 0.0F);
+    result.a = add("a", 0.0F);
+    result.b = add("b", 0.0F);
+    result.c = add("c", 0.0F);
+    (void)add("h", 0.0F);
+    (void)add("e", 0.0F);
+    (void)add("l", 0.0F);
+    (void)add("o", 0.0F);
+    (void)add("w", 0.0F);
+    (void)add("r", 0.0F);
+    (void)add("d", 0.0F);
+    (void)add("he", 1.0F);
+    (void)add("ll", 3.0F);
+    (void)add("llo", 4.0F);
+    result.hello = add("hello", 10.0F);
+    result.space_hello = add("\xE2\x96\x81hello", 11.0F);
+    (void)add("wo", 1.0F);
+    (void)add("wor", 2.0F);
+    (void)add("worl", 3.0F);
+    (void)add("world", 4.0F);
+    result.space_world = add("\xE2\x96\x81world", 5.0F);
+    result.aa = add("aa", 1.0F);
+    (void)add("ab", 5.0F, SentencePieceType::kUnused);
+    result.abc = add("abc", 6.0F);
+    result.robot = add("<robot>", 100.0F, SentencePieceType::kUserDefined);
+    result.capital_a = add("A", 0.0F);
+    asset.normalization_rules = {
+        {"\xEF\xBC\xA1", "A"}, // full-width A
+        {"\t", " "},
+        {"\n", " "},
+    };
+    return result;
+}
+
+void test_flat_asset_round_trip_and_validation() {
+    const auto synthetic = make_synthetic_asset();
+    const auto bytes = trtmc::openpi::serialize_paligemma_bpe_asset(synthetic.asset);
+    const auto parsed = trtmc::openpi::parse_paligemma_bpe_asset(
+        std::string_view(reinterpret_cast<const char*>(bytes.data()), bytes.size()));
+    check(parsed.version == 1, "flat BPE parser preserves version");
+    check(parsed.pieces.size() == synthetic.asset.pieces.size(),
+          "flat BPE parser preserves every piece");
+    check(parsed.normalization_rules.size() == synthetic.asset.normalization_rules.size(),
+          "flat BPE parser preserves normalization rules");
+    check(parsed.byte_fallback && parsed.add_dummy_prefix && parsed.escape_whitespaces,
+          "flat BPE parser preserves SentencePiece flags");
+
+    auto corrupted = bytes;
+    corrupted[0] = 'X';
+    check_throws(
+        [&] {
+            (void)trtmc::openpi::parse_paligemma_bpe_asset(std::string_view(
+                reinterpret_cast<const char*>(corrupted.data()), corrupted.size()));
+        },
+        "flat BPE parser rejects bad magic");
+
+    auto incomplete_bytes = synthetic.asset;
+    incomplete_bytes.pieces.erase(incomplete_bytes.pieces.begin() + 4);
+    check_throws([&] { (void)trtmc::openpi::serialize_paligemma_bpe_asset(incomplete_bytes); },
+                 "flat BPE validation rejects incomplete byte fallback table");
+}
+
+void test_sentencepiece_normalization_and_score_ordered_bpe() {
+    const auto synthetic = make_synthetic_asset();
+    trtmc::openpi::PaligemmaBpeTokenizer tokenizer(synthetic.asset);
+
+    check(tokenizer.normalize("  hello   world ") == "\xE2\x96\x81hello\xE2\x96\x81world",
+          "SentencePiece normalization collapses spaces and adds dummy prefix");
+    check(tokenizer.normalize("\t\xEF\xBC\xA1 ") == "\xE2\x96\x81"
+                                                    "A",
+          "SentencePiece normalization uses flattened longest-prefix rules");
+
+    const auto hello_world = tokenizer.encode("hello world", true);
+    check(hello_world == std::vector<int32_t>({synthetic.asset.bos_id, synthetic.space_hello,
+                                               synthetic.space_world}),
+          "SentencePiece BPE performs highest-score merges");
+
+    const auto tied = tokenizer.encode("aaa", false);
+    check(tied == std::vector<int32_t>({synthetic.space, synthetic.aa, synthetic.a}),
+          "SentencePiece BPE resolves equal-score merges from the left");
+}
+
+void test_unused_resegmentation_user_symbols_and_byte_fallback() {
+    const auto synthetic = make_synthetic_asset();
+    trtmc::openpi::PaligemmaBpeTokenizer tokenizer(synthetic.asset);
+
+    const auto unused_only = tokenizer.encode("ab", false);
+    check(unused_only == std::vector<int32_t>({synthetic.space, synthetic.a, synthetic.b}),
+          "unused merged piece is recursively resegmented");
+    const auto useful_unused = tokenizer.encode("abc", false);
+    check(useful_unused == std::vector<int32_t>({synthetic.space, synthetic.abc}),
+          "unused merge can participate in a later normal merge");
+
+    const auto user_defined = tokenizer.encode("<robot>", false);
+    check(user_defined == std::vector<int32_t>({synthetic.space, synthetic.robot}),
+          "user-defined symbol is frozen as one piece");
+
+    const auto unknown = tokenizer.encode("\xF0\x9F\xA4\x96", false); // robot emoji
+    check(unknown ==
+              std::vector<int32_t>({synthetic.space, 4 + 0xF0, 4 + 0x9F, 4 + 0xA4, 4 + 0x96}),
+          "unknown Unicode is decomposed into SentencePiece byte fallback ids");
+}
+
+void test_openpi_fixed_length_prompt_contract() {
+    const auto synthetic = make_synthetic_asset();
+    trtmc::openpi::PaligemmaBpeTokenizer tokenizer(synthetic.asset);
+
+    const auto pi0 = tokenizer.tokenize_pi0(" hello_", 5);
+    check(pi0.token_ids[0] == synthetic.asset.bos_id && pi0.token_ids[1] == synthetic.space_hello,
+          "pi0 tokenizer cleans prompt and inserts BOS");
+    check(pi0.token_ids[2] == 0 && pi0.token_ids[4] == 0,
+          "OpenPI prompt padding uses integer zero");
+    check(pi0.token_mask == std::vector<uint8_t>({1, 1, 0, 0, 0}),
+          "OpenPI prompt mask tracks only real tokens");
+    check(!pi0.truncated, "short OpenPI prompt is not marked truncated");
+
+    const auto truncated = tokenizer.tokenize_pi0("hello world", 2);
+    check(truncated.truncated && truncated.token_ids.size() == 2 &&
+              truncated.token_mask == std::vector<uint8_t>({1, 1}),
+          "OpenPI prompt truncation matches max length");
+
+    const auto pi05 = tokenizer.tokenize_pi05("A", {-1.0F, 0.0F, 1.0F}, 200);
+    check(pi05.token_ids.size() == 200 && pi05.token_mask.size() == 200,
+          "pi05 tokenization emits fixed 200-token contract");
+    check(pi05.token_ids.front() == synthetic.asset.bos_id,
+          "pi05 tokenization inserts BOS before formatted task/state text");
+    check_throws([&] { (void)tokenizer.tokenize_pi0("hello", 0); },
+                 "OpenPI tokenizer rejects zero maximum length");
+}
+
+void test_official_paligemma_asset(std::string_view path) {
+    std::ifstream input(std::string(path), std::ios::binary);
+    if (!input) {
+        std::cerr << "FAIL: cannot open official PaliGemma flat asset: " << path << '\n';
+        ++g_failures;
+        return;
+    }
+    const std::string bytes((std::istreambuf_iterator<char>(input)),
+                            std::istreambuf_iterator<char>());
+    auto asset = trtmc::openpi::parse_paligemma_bpe_asset(bytes);
+    check(asset.pieces.size() == 257152, "official PaliGemma vocabulary size");
+    check(asset.unknown_id == 3 && asset.bos_id == 2 && asset.eos_id == 1 && asset.pad_id == 0,
+          "official PaliGemma special token ids");
+    check(!asset.add_dummy_prefix && !asset.remove_extra_whitespaces && asset.escape_whitespaces &&
+              asset.byte_fallback,
+          "official PaliGemma identity-normalizer flags");
+
+    trtmc::openpi::PaligemmaBpeTokenizer tokenizer(std::move(asset));
+    check(tokenizer.encode("hello world", true) == std::vector<int32_t>({2, 17534, 2134}),
+          "native BPE matches official SentencePiece hello-world ids");
+    check(tokenizer.encode("\xF0\x9F\xA4\x96", true) == std::vector<int32_t>({2, 243349}),
+          "native BPE matches official SentencePiece Unicode ids");
+
+    const auto pi0 = tokenizer.tokenize_pi0(" hello_", 48);
+    check(std::vector<int32_t>(pi0.token_ids.begin(), pi0.token_ids.begin() + 4) ==
+              std::vector<int32_t>({2, 17534, 235248, 108}),
+          "native pi0 prompt path matches official SentencePiece ids");
+    check(std::vector<uint8_t>(pi0.token_mask.begin(), pi0.token_mask.begin() + 5) ==
+              std::vector<uint8_t>({1, 1, 1, 1, 0}),
+          "native pi0 prompt padding mask matches OpenPI");
+
+    const auto pi05 = tokenizer.tokenize_pi05("pick_up\nblock", {-1.0F, 0.0F, 1.0F}, 200);
+    const std::vector<int32_t> expected_pi05{
+        2,      7071,   235292, 4788,   908,    3963,   235269, 3040,
+        235292, 235248, 235276, 235248, 235274, 235284, 235321, 235248,
+        235284, 235308, 235308, 235289, 108,    4022,   235292, 235248,
+    };
+    check(std::vector<int32_t>(pi05.token_ids.begin(),
+                               pi05.token_ids.begin() + expected_pi05.size()) == expected_pi05,
+          "native pi05 formatted prompt matches official SentencePiece ids");
+    check(pi05.token_mask[expected_pi05.size() - 1] == 1U &&
+              pi05.token_mask[expected_pi05.size()] == 0U,
+          "native pi05 prompt mask begins padding after official token sequence");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    test_flat_asset_round_trip_and_validation();
+    test_sentencepiece_normalization_and_score_ordered_bpe();
+    test_unused_resegmentation_user_symbols_and_byte_fallback();
+    test_openpi_fixed_length_prompt_contract();
+    if (argc == 2) {
+        test_official_paligemma_asset(argv[1]);
+    } else if (argc > 2) {
+        std::cerr << "FAIL: expected zero arguments or one official flat BPE asset path\n";
+        ++g_failures;
+    }
+
+    if (g_failures != 0) {
+        std::cerr << g_failures << " OpenPI PaliGemma BPE test(s) failed\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/e2e/models/openpi/MODEL.toml
+++ b/tests/e2e/models/openpi/MODEL.toml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+id = "openpi"
+plugin = "openpi"
+test_manifests = [
+  "manifests/pi05-droid.json",
+]
+
+[e2e_defaults.robot_action_generation]
+reference_backend = "upstream_replay"
+oracle_level = "L1_external_reference"
+stages = [
+  { name = "preprocess", required = true, artifact_type = "token_ids", comparison_mode = "token_exact" },
+  { name = "vision", required = true, artifact_type = "embedding", comparison_mode = "numeric_tensor" },
+  { name = "prefix", required = true, artifact_type = "embedding", comparison_mode = "numeric_tensor" },
+  { name = "flow", required = true, artifact_type = "embedding", comparison_mode = "numeric_tensor" },
+  { name = "actions", required = true, artifact_type = "embedding", comparison_mode = "numeric_tensor" },
+]

--- a/tests/e2e/models/openpi/__init__.py
+++ b/tests/e2e/models/openpi/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenPI-owned qualification contracts and pinned-reference E2E plugins."""

--- a/tests/e2e/models/openpi/contracts/pi05_droid.json
+++ b/tests/e2e/models/openpi/contracts/pi05_droid.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "profile_name": "pi05_droid",
+  "variant": "pi05_flow",
+  "upstream": {
+    "repository": "https://github.com/Physical-Intelligence/openpi.git",
+    "commit": "15a9616a00943ada6c20a0f158e3adb39df2ccac",
+    "checkpoint_uri": "gs://openpi-assets/checkpoints/pi05_droid",
+    "checkpoint_digest_policy": "required_in_reference_artifact"
+  },
+  "precision": {
+    "network": "bfloat16",
+    "sensitive_accumulation": "float32"
+  },
+  "images": {
+    "order": ["base_0_rgb", "left_wrist_0_rgb", "right_wrist_0_rgb"],
+    "validity": [true, true, false],
+    "shape_hwc": [224, 224, 3],
+    "tokens_per_image": 256,
+    "embedding_width": 2048
+  },
+  "prompt": {
+    "max_tokens": 200,
+    "discrete_state_input": true,
+    "vocab_size": 257152
+  },
+  "state": {
+    "external_dim": 8,
+    "internal_dim": 32,
+    "normalization": "quantile_q01_q99"
+  },
+  "actions": {
+    "horizon": 15,
+    "external_dim": 8,
+    "internal_dim": 32,
+    "normalization": "quantile_q01_q99"
+  },
+  "prefix": {
+    "max_physical_tokens": 968,
+    "layers": 18,
+    "query_heads": 8,
+    "kv_heads": 1,
+    "head_dim": 256
+  },
+  "flow": {
+    "steps": 10,
+    "initial_t": 1.0,
+    "dt": -0.1,
+    "external_noise_required_for_parity": true,
+    "timestep_injection": "adaptive_rms_norm"
+  },
+  "runtime": {
+    "language": "c++",
+    "engine_api": "tensorrt",
+    "onnx_allowed": false,
+    "python_allowed": false,
+    "additional_frameworks_allowed": false
+  }
+}

--- a/tests/e2e/models/openpi/e2e_plugins/__init__.py
+++ b/tests/e2e/models/openpi/e2e_plugins/__init__.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenPI-owned unified E2E plugins."""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path, PurePosixPath
+
+from huggingface_hub import snapshot_download
+
+OPENPI_SNAPSHOT_REPO_ID = "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID"
+OPENPI_SNAPSHOT_REVISION = "59205df7225305b0a6680dd8fe9a064cfec774d7"
+OPENPI_SNAPSHOT_ALLOW_PATTERNS = (
+    "openpi_config.json",
+    "preprocessor_config.json",
+    "trtmc_openpi/**",
+)
+
+
+@functools.lru_cache(maxsize=1)
+def openpi_snapshot_root() -> Path:
+    """Return the immutable, already-cached OpenPI qualification snapshot."""
+
+    root = (
+        Path(
+            snapshot_download(
+                repo_id=OPENPI_SNAPSHOT_REPO_ID,
+                revision=OPENPI_SNAPSHOT_REVISION,
+                allow_patterns=list(OPENPI_SNAPSHOT_ALLOW_PATTERNS),
+                local_files_only=True,
+            )
+        )
+        .expanduser()
+        .resolve(strict=True)
+    )
+    if not root.is_dir():
+        raise FileNotFoundError(f"OpenPI Hugging Face snapshot is not a directory: {root}")
+    return root
+
+
+def openpi_snapshot_path(*parts: str) -> Path:
+    """Resolve a fixed path below the pinned OpenPI snapshot."""
+
+    relative = PurePosixPath(*parts)
+    if (
+        relative.is_absolute()
+        or not relative.parts
+        or any(part in {"", ".", ".."} for part in relative.parts)
+    ):
+        raise ValueError(f"Invalid OpenPI snapshot-relative path: {relative}")
+    return openpi_snapshot_root().joinpath(*relative.parts)
+
+
+def openpi_proof_path(*parts: str) -> Path:
+    """Resolve an OpenPI-only proof asset inside the pinned snapshot."""
+
+    return openpi_snapshot_path("trtmc_openpi", *parts)
+
+
+def resolve_model_asset(value: str, model_test_dir: str) -> Path:
+    """Resolve a model-local path without searching unrelated workspaces."""
+
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    if model_test_dir:
+        return Path(model_test_dir) / path
+    return Path(__file__).resolve().parents[1] / path

--- a/tests/e2e/models/openpi/e2e_plugins/comparator.py
+++ b/tests/e2e/models/openpi/e2e_plugins/comparator.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenPI model-owned E2E comparator plugin."""
+
+from .comparators.robot_action import plugin as comparator  # noqa: F401

--- a/tests/e2e/models/openpi/e2e_plugins/comparators/__init__.py
+++ b/tests/e2e/models/openpi/e2e_plugins/comparators/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenPI action and stage comparators."""

--- a/tests/e2e/models/openpi/e2e_plugins/comparators/robot_action.py
+++ b/tests/e2e/models/openpi/e2e_plugins/comparators/robot_action.py
@@ -1,0 +1,453 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Numerical OpenPI comparator for action chunks and diagnostic stages."""
+
+from __future__ import annotations
+
+import math
+import struct
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .. import performance
+from ..contracts import (
+    CompareResult,
+    MetricResult,
+    StageOutput,
+    StageSpec,
+    StageStatus,
+    ThresholdProfile,
+)
+
+
+def _flatten(value: Any) -> Iterable[float]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            yield from _flatten(item)
+        return
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError(f"tensor value must be numeric, got {type(value).__name__}")
+    yield float(value)
+
+
+def _binary_values(descriptor: Mapping[str, Any]) -> Iterable[float]:
+    path = Path(str(descriptor["path"]))
+    payload = path.read_bytes()
+    dtype = str(descriptor["dtype"])
+    if dtype == "bool":
+        return (float(value != 0) for value in payload)
+    if dtype == "uint8":
+        return (float(value) for value in payload)
+    if dtype == "int32":
+        return (float(item[0]) for item in struct.iter_unpack("<i", payload))
+    if dtype == "int64":
+        return (float(item[0]) for item in struct.iter_unpack("<q", payload))
+    if dtype == "float16":
+        return (float(item[0]) for item in struct.iter_unpack("<e", payload))
+    if dtype == "float32":
+        return (float(item[0]) for item in struct.iter_unpack("<f", payload))
+    if dtype == "bfloat16":
+        return (
+            float(struct.unpack("<f", struct.pack("<I", item[0] << 16))[0])
+            for item in struct.iter_unpack("<H", payload)
+        )
+    raise ValueError(f"unsupported tensor dtype {dtype!r}")
+
+
+def _tensor_values(data: Mapping[str, Any], name: str) -> Iterable[float]:
+    if name in data:
+        return _flatten(data[name])
+    tensors = data.get("tensors")
+    if isinstance(tensors, Mapping) and name in tensors:
+        return _flatten(tensors[name])
+    files = data.get("tensor_files")
+    if isinstance(files, Mapping) and isinstance(files.get(name), Mapping):
+        return _binary_values(files[name])
+    raise ValueError(f"stage output is missing tensor {name!r}")
+
+
+def _numeric_error_metrics(actual: Iterable[float], expected: Iterable[float]) -> dict[str, float]:
+    count = 0
+    dot = 0.0
+    actual_sq = 0.0
+    expected_sq = 0.0
+    squared_error = 0.0
+    absolute_error_sum = 0.0
+    max_abs = 0.0
+    nonfinite = 0
+    actual_iter = iter(actual)
+    expected_iter = iter(expected)
+    sentinel = object()
+    while True:
+        lhs = next(actual_iter, sentinel)
+        rhs = next(expected_iter, sentinel)
+        if lhs is sentinel or rhs is sentinel:
+            if lhs is not sentinel or rhs is not sentinel:
+                raise ValueError("tensor element counts differ")
+            break
+        lhs_value, rhs_value = float(lhs), float(rhs)
+        count += 1
+        if not math.isfinite(lhs_value) or not math.isfinite(rhs_value):
+            nonfinite += 1
+            continue
+        error = abs(lhs_value - rhs_value)
+        dot += lhs_value * rhs_value
+        actual_sq += lhs_value * lhs_value
+        expected_sq += rhs_value * rhs_value
+        squared_error += error * error
+        absolute_error_sum += error
+        max_abs = max(max_abs, error)
+    if count == 0:
+        raise ValueError("cannot compare empty tensors")
+    denominator = math.sqrt(actual_sq * expected_sq)
+    cosine = dot / denominator if denominator > 0.0 else float(max_abs == 0.0)
+    return {
+        "count": float(count),
+        "cosine": cosine,
+        "rmse": math.sqrt(squared_error / count),
+        "mae": absolute_error_sum / count,
+        "max_abs": max_abs,
+        "nonfinite": float(nonfinite),
+    }
+
+
+def _percentile(values: Sequence[float], probability: float) -> float:
+    if not values:
+        raise ValueError("cannot compute a percentile of an empty tensor")
+    ordered = sorted(values)
+    index = max(0, math.ceil(probability * len(ordered)) - 1)
+    return float(ordered[index])
+
+
+def _metric(value: float, threshold: float, operator: str) -> MetricResult:
+    passed = value >= threshold if operator == ">=" else value <= threshold
+    return MetricResult(value=value, threshold=threshold, operator=operator, passed=passed)
+
+
+def _error(stage: str, message: str) -> CompareResult:
+    return CompareResult(
+        stage_name=stage,
+        status=StageStatus.ERROR.value,
+        metrics={},
+        message=message,
+    )
+
+
+def _performance_metrics(
+    trt: StageOutput,
+    threshold: ThresholdProfile,
+) -> dict[str, MetricResult]:
+    native, baseline = performance.validate_receipt(trt.metadata.get("performance"))
+    native_latency = native["latency_ms"]
+    baseline_latency = baseline["latency_ms"]
+    native_p50 = float(native_latency["p50_ms"])
+    native_p95 = float(native_latency["p95_ms"])
+    compile_invocations = int(baseline["torch_compile_guard_invocation_count"])
+    return {
+        "native_latency_p50_ms": _metric(
+            native_p50,
+            float(threshold.metrics["native_latency_p50_ms_max"]),
+            "<=",
+        ),
+        "native_latency_p95_ms": _metric(
+            native_p95,
+            float(threshold.metrics["native_latency_p95_ms_max"]),
+            "<=",
+        ),
+        "torch_eager_latency_p50_ms": MetricResult(
+            value=float(baseline_latency["p50_ms"]),
+            threshold=None,
+            operator="info",
+            passed=True,
+        ),
+        "torch_eager_latency_p95_ms": MetricResult(
+            value=float(baseline_latency["p95_ms"]),
+            threshold=None,
+            operator="info",
+            passed=True,
+        ),
+        "torch_eager_speedup_p50": _metric(
+            float(baseline_latency["p50_ms"]) / native_p50,
+            float(threshold.metrics["torch_eager_speedup_p50_min"]),
+            ">=",
+        ),
+        "torch_eager_speedup_p95": _metric(
+            float(baseline_latency["p95_ms"]) / native_p95,
+            float(threshold.metrics["torch_eager_speedup_p95_min"]),
+            ">=",
+        ),
+        "torch_compile_invocation_count": MetricResult(
+            value=float(compile_invocations),
+            threshold=0.0,
+            operator="==",
+            passed=compile_invocations == 0,
+        ),
+    }
+
+
+class RobotActionGenerationComparator:
+    """Gate OpenPI parity using the published action and stage tolerances."""
+
+    @property
+    def task_strategy(self) -> str:
+        return "robot_action_generation"
+
+    def compare(
+        self,
+        trt: StageOutput,
+        ref: StageOutput,
+        threshold: ThresholdProfile,
+        stage: StageSpec,
+    ) -> CompareResult:
+        if int(trt.data.get("returncode", 0)) != 0:
+            return _error(stage.name, str(trt.data.get("error") or trt.data.get("stderr")))
+        try:
+            if stage.name in {"actions", "act", "end_to_end"}:
+                return self._compare_actions(trt, ref, threshold, stage)
+            if stage.name == "preprocess":
+                return self._compare_preprocess(trt, ref, threshold, stage)
+            if stage.name in {"vision", "prefix", "flow"}:
+                return self._compare_numeric_stage(trt, ref, threshold, stage)
+        except (KeyError, OSError, TypeError, ValueError) as error:
+            return _error(stage.name, f"OpenPI comparison input error: {error}")
+        return _error(stage.name, f"Unsupported OpenPI comparison stage {stage.name!r}")
+
+    @staticmethod
+    def _compare_actions(
+        trt: StageOutput,
+        ref: StageOutput,
+        threshold: ThresholdProfile,
+        stage: StageSpec,
+    ) -> CompareResult:
+        actual_rows = trt.data.get("actions")
+        expected_rows = ref.data.get("physical_actions", ref.data.get("actions"))
+        if not isinstance(actual_rows, list) or not isinstance(expected_rows, list):
+            raise ValueError("action outputs must be arrays")
+        horizon = int(ref.data["horizon"])
+        action_dim = int(ref.data["action_dim"])
+        expected_count = horizon * action_dim
+        actual = list(_flatten(actual_rows))
+        expected = list(_flatten(expected_rows))
+        shape_exact = (
+            int(trt.data.get("horizon", -1)) == horizon
+            and int(trt.data.get("action_dim", -1)) == action_dim
+            and len(actual) == expected_count
+            and len(expected) == expected_count
+        )
+        metrics: dict[str, MetricResult] = {
+            "action_shape_exact": MetricResult(
+                value=float(shape_exact), threshold=1.0, operator="==", passed=shape_exact
+            )
+        }
+        if not shape_exact:
+            return CompareResult(
+                stage_name=stage.name,
+                status=StageStatus.FAILED.value,
+                metrics=metrics,
+                composite_rule="shape exact AND physical action gates",
+                message="OpenPI action shape differs from the pinned reference",
+            )
+        metrics.update(_performance_metrics(trt, threshold))
+
+        base = _numeric_error_metrics(actual, expected)
+        metrics.update(
+            {
+                "physical_action_cosine": MetricResult(
+                    value=base["cosine"], threshold=None, operator="info", passed=True
+                ),
+                "physical_action_mae": MetricResult(
+                    value=base["mae"], threshold=None, operator="info", passed=True
+                ),
+                "physical_action_max_abs": MetricResult(
+                    value=base["max_abs"], threshold=None, operator="info", passed=True
+                ),
+                "physical_action_nan_or_inf_count": _metric(base["nonfinite"], 0.0, "<="),
+            }
+        )
+
+        spans_value = ref.data.get("action_spans", trt.data.get("action_spans"))
+        if not isinstance(spans_value, list) or len(spans_value) < action_dim:
+            return _error(
+                stage.name,
+                "OpenPI physical action parity requires q99-q01 action_spans",
+            )
+        spans = [float(value) for value in spans_value[:action_dim]]
+        if any(not math.isfinite(span) or span <= 0.0 for span in spans):
+            raise ValueError("action_spans must be finite and positive")
+        span_errors = [
+            abs(lhs - rhs) / spans[index % action_dim]
+            for index, (lhs, rhs) in enumerate(zip(actual, expected, strict=True))
+        ]
+        span_limit = float(threshold.metrics.get("physical_action_p99_span_fraction_max", 0.01))
+        metrics["physical_action_p99_span_fraction"] = _metric(
+            _percentile(span_errors, 0.99), span_limit, "<="
+        )
+
+        indices_value = ref.data.get("decision_indices", [action_dim - 1])
+        if not isinstance(indices_value, list):
+            raise ValueError("decision_indices must be an array")
+        decision_indices = [int(value) for value in indices_value]
+        if any(index < 0 or index >= action_dim for index in decision_indices):
+            raise ValueError("decision index is outside the action dimension")
+        decision_changes = sum(
+            (actual[row * action_dim + index] >= 0.0) != (expected[row * action_dim + index] >= 0.0)
+            for row in range(horizon)
+            for index in decision_indices
+        )
+        metrics["sign_or_gripper_decision_changes"] = _metric(float(decision_changes), 0.0, "<=")
+
+        try:
+            normalized_lhs = list(_tensor_values(trt.data, "normalized_actions"))
+            normalized_rhs = list(_tensor_values(ref.data, "normalized_actions"))
+        except (KeyError, OSError, ValueError) as error:
+            return _error(
+                stage.name,
+                f"OpenPI normalized action parity evidence is required: {error}",
+            )
+        normalized = _numeric_error_metrics(normalized_lhs, normalized_rhs)
+        absolute_errors = [
+            abs(lhs - rhs) for lhs, rhs in zip(normalized_lhs, normalized_rhs, strict=True)
+        ]
+        metrics.update(
+            {
+                "normalized_action_cosine": _metric(
+                    normalized["cosine"],
+                    float(threshold.metrics.get("normalized_action_cosine_min", 0.9995)),
+                    ">=",
+                ),
+                "normalized_action_mae": _metric(
+                    normalized["mae"],
+                    float(threshold.metrics.get("normalized_action_mae_max", 0.003)),
+                    "<=",
+                ),
+                "normalized_action_p99_abs": _metric(
+                    _percentile(absolute_errors, 0.99),
+                    float(threshold.metrics.get("normalized_action_p99_abs_max", 0.01)),
+                    "<=",
+                ),
+                "normalized_action_max_abs": _metric(
+                    normalized["max_abs"],
+                    float(threshold.metrics.get("normalized_action_max_abs_max", 0.02)),
+                    "<=",
+                ),
+                "normalized_action_nan_or_inf_count": _metric(normalized["nonfinite"], 0.0, "<="),
+            }
+        )
+
+        passed = all(metric.passed for metric in metrics.values())
+        return CompareResult(
+            stage_name=stage.name,
+            status=StageStatus.PASSED.value if passed else StageStatus.FAILED.value,
+            metrics=metrics,
+            composite_rule=(
+                "shape exact AND finite AND physical parity gates AND declared native p50/p95 "
+                "and Torch Eager speedup thresholds AND zero torch.compile invocations"
+            ),
+            message=f"OpenPI action parity and performance {'passed' if passed else 'failed'}",
+        )
+
+    @staticmethod
+    def _compare_numeric_stage(
+        trt: StageOutput,
+        ref: StageOutput,
+        threshold: ThresholdProfile,
+        stage: StageSpec,
+    ) -> CompareResult:
+        names = {
+            "vision": ("vision_tokens",),
+            "prefix": ("prefix_kv_cache",),
+            "flow": tuple(
+                [f"velocity_{step:02d}" for step in range(10)]
+                + [f"flow_state_{step:02d}" for step in range(11)]
+            ),
+        }[stage.name]
+        per_tensor = [
+            _numeric_error_metrics(_tensor_values(trt.data, name), _tensor_values(ref.data, name))
+            for name in names
+        ]
+        cosine = min(item["cosine"] for item in per_tensor)
+        rmse = max(item["rmse"] for item in per_tensor)
+        max_abs = max(item["max_abs"] for item in per_tensor)
+        nonfinite = sum(item["nonfinite"] for item in per_tensor)
+        metrics = {
+            "stage_cosine_min": _metric(
+                cosine,
+                float(threshold.metrics.get("stage_velocity_cosine_min", 0.9995)),
+                ">=",
+            ),
+            "stage_rmse_max": _metric(
+                rmse,
+                float(threshold.metrics.get("stage_velocity_rmse_max", 0.005)),
+                "<=",
+            ),
+            "stage_max_abs": _metric(
+                max_abs,
+                float(threshold.metrics.get("stage_velocity_max_abs_max", 0.05)),
+                "<=",
+            ),
+            "stage_nan_or_inf_count": _metric(nonfinite, 0.0, "<="),
+        }
+        passed = all(metric.passed for metric in metrics.values())
+        return CompareResult(
+            stage_name=stage.name,
+            status=StageStatus.PASSED.value if passed else StageStatus.FAILED.value,
+            metrics=metrics,
+            composite_rule="all stage tensors meet cosine, RMSE, max-absolute, and finite gates",
+            message=f"OpenPI {stage.name} parity {'passed' if passed else 'failed'}",
+        )
+
+    @staticmethod
+    def _compare_preprocess(
+        trt: StageOutput,
+        ref: StageOutput,
+        threshold: ThresholdProfile,
+        stage: StageSpec,
+    ) -> CompareResult:
+        token_actual = list(_tensor_values(trt.data, "token_ids"))
+        token_expected = list(_tensor_values(ref.data, "token_ids"))
+        token_mismatches = sum(
+            lhs != rhs for lhs, rhs in zip(token_actual, token_expected, strict=True)
+        )
+        mask_mismatches = 0
+        for name in ("token_mask", "image_mask", "initial_noise"):
+            lhs = list(_tensor_values(trt.data, name))
+            rhs = list(_tensor_values(ref.data, name))
+            mask_mismatches += sum(a != b for a, b in zip(lhs, rhs, strict=True))
+        image = _numeric_error_metrics(
+            _tensor_values(trt.data, "preprocessed_images"),
+            _tensor_values(ref.data, "preprocessed_images"),
+        )
+        state = _numeric_error_metrics(
+            _tensor_values(trt.data, "normalized_state"),
+            _tensor_values(ref.data, "normalized_state"),
+        )
+        metrics = {
+            "token_mismatch_count": _metric(float(token_mismatches), 0.0, "<="),
+            "mask_or_noise_mismatch_count": _metric(float(mask_mismatches), 0.0, "<="),
+            "image_uint8_max_lsb": _metric(
+                image["max_abs"] * 127.5,
+                float(threshold.metrics.get("image_uint8_max_lsb", 1.0)),
+                "<=",
+            ),
+            "normalization_max_abs": _metric(
+                state["max_abs"],
+                float(threshold.metrics.get("normalization_max_abs", 1e-6)),
+                "<=",
+            ),
+            "preprocess_nan_or_inf_count": _metric(
+                image["nonfinite"] + state["nonfinite"], 0.0, "<="
+            ),
+        }
+        passed = all(metric.passed for metric in metrics.values())
+        return CompareResult(
+            stage_name=stage.name,
+            status=StageStatus.PASSED.value if passed else StageStatus.FAILED.value,
+            metrics=metrics,
+            composite_rule="exact tokens/masks/noise AND image/normalization tolerance gates",
+            message=f"OpenPI preprocessing parity {'passed' if passed else 'failed'}",
+        )
+
+
+plugin = RobotActionGenerationComparator()

--- a/tests/e2e/models/openpi/e2e_plugins/contracts.py
+++ b/tests/e2e/models/openpi/e2e_plugins/contracts.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable E2E protocol aliases for the OpenPI model package."""
+
+from tests.e2e_harness.contracts import *  # noqa: F401,F403

--- a/tests/e2e/models/openpi/e2e_plugins/performance.py
+++ b/tests/e2e/models/openpi/e2e_plugins/performance.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Strict, model-owned OpenPI performance evidence validation."""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Any, Mapping, Sequence
+
+from tests.e2e.models.openpi import qualification
+
+from . import openpi_proof_path
+
+TORCH_EAGER_SHA256 = "3cd217412ddbe931e179038f39c74ffc4b7b35675132eb739370dc42dc53a8d8"
+BENCHMARK_ITERATIONS = 1000
+BENCHMARK_WARMUPS = 100
+_PROFILE = "pi05_droid"
+_UPSTREAM_COMMIT = "15a9616a00943ada6c20a0f158e3adb39df2ccac"
+_EXPECTED_WORKLOAD = {
+    "action_horizon": 15,
+    "batch_size": 1,
+    "camera_slots": 3,
+    "capture_manifest_sha256": "837695cfb46e9d550edd8c4d1126f2f052a256ceb597808cdde9032d3633a78b",
+    "case_id": "droid_iris_20231204154425_f000005",
+    "case_identity_sha256": "0800003c9dd4ba0d3cc63219bf73df361c1524c33e7a3533637236b522c8a866",
+    "fixed_external_noise": True,
+    "flow_steps": 10,
+    "input_payload_sha256": {
+        "base_0_rgb": "b2d1abbcc6987fd01440e590e741a908cbe2730f4e5e3a547d4ebcc4cd71962c",
+        "initial_noise": "99a09944483723ee6221367ee8276ab8810f1cef7b95fc9306bcb673bc593e69",
+        "left_wrist_0_rgb": "b137782b5e544c666fcb63721ccd198db717323c7ca891b251d92700b4efc196",
+        "state": "1232e74cfa6c1f4da00392c35619d80e0cdec678392e08ad7e57755e626c035b",
+    },
+    "internal_action_dim": 32,
+}
+_BASELINE_FIELDS = {
+    "artifact_type",
+    "backend",
+    "determinism",
+    "first_request_ms",
+    "hardware",
+    "iterations",
+    "latency_samples_ms",
+    "profile_name",
+    "provenance",
+    "schema_version",
+    "warmups",
+    "workload",
+}
+_DECIMAL = r"(?:0|[1-9][0-9]*)\.[0-9]{6}"
+_BENCHMARK_PREFIX = "[trtmc.openpi.benchmark]"
+_BENCHMARK_LINE = re.compile(
+    rf"^\[trtmc\.openpi\.benchmark\] action_ms=(?P<mean>{_DECIMAL}) "
+    rf"p50_ms=(?P<p50>{_DECIMAL}) p95_ms=(?P<p95>{_DECIMAL}) "
+    r"iterations=(?P<iterations>[1-9][0-9]*) warmup=(?P<warmups>0|[1-9][0-9]*)$"
+)
+
+
+def _positive_finite(value: Any, label: str) -> float:
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(float(value))
+        or float(value) <= 0.0
+    ):
+        raise ValueError(f"{label} must be finite and positive")
+    return float(value)
+
+
+def _nearest_rank(values: Sequence[float], probability: float) -> float:
+    if not values:
+        raise ValueError("OpenPI performance samples cannot be empty")
+    ordered = sorted(values)
+    return ordered[math.ceil(probability * len(ordered)) - 1]
+
+
+def _latency_summary(samples: Sequence[Any], expected_count: int) -> dict[str, float]:
+    if len(samples) != expected_count:
+        raise ValueError(
+            f"OpenPI performance sample count mismatch: expected {expected_count}, found {len(samples)}"
+        )
+    values = [
+        _positive_finite(value, f"OpenPI performance sample {index}")
+        for index, value in enumerate(samples)
+    ]
+    return {
+        "mean_ms": sum(values) / len(values),
+        "p50_ms": _nearest_rank(values, 0.50),
+        "p95_ms": _nearest_rank(values, 0.95),
+    }
+
+
+def validate_torch_eager_document(document: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and summarize the immutable Torch Eager qualification receipt."""
+
+    if set(document) != _BASELINE_FIELDS:
+        raise ValueError("Torch Eager baseline fields do not match the OpenPI contract")
+    expected_identity = {
+        "schema_version": 1,
+        "artifact_type": "openpi_baseline_performance_measurement",
+        "backend": "pytorch_eager",
+        "profile_name": _PROFILE,
+        "iterations": BENCHMARK_ITERATIONS,
+        "warmups": BENCHMARK_WARMUPS,
+    }
+    for field, expected in expected_identity.items():
+        if document.get(field) != expected or type(document.get(field)) is not type(expected):
+            raise ValueError(f"Torch Eager baseline {field} is stale or mismatched")
+    _positive_finite(document.get("first_request_ms"), "Torch Eager first request latency")
+
+    hardware = document.get("hardware")
+    if not isinstance(hardware, Mapping) or (
+        hardware.get("gpu_name"),
+        hardware.get("tensorrt_version"),
+    ) != ("NVIDIA GB300", "11.2.0.113"):
+        raise ValueError("Torch Eager baseline hardware does not match the qualified platform")
+    if document.get("workload") != _EXPECTED_WORKLOAD:
+        raise ValueError("Torch Eager baseline workload is stale or mismatched")
+
+    provenance = document.get("provenance")
+    if not isinstance(provenance, Mapping) or (
+        provenance.get("upstream_repository"),
+        provenance.get("upstream_commit"),
+    ) != ("https://github.com/Physical-Intelligence/openpi.git", _UPSTREAM_COMMIT):
+        raise ValueError("Torch Eager baseline upstream provenance is stale or mismatched")
+    environment = provenance.get("environment")
+    if (
+        not isinstance(environment, Mapping)
+        or environment.get("effective_compile_mode") is not None
+    ):
+        raise ValueError("Torch Eager baseline must have effective_compile_mode=null")
+    if environment.get("forbidden_compiler_environment_names") != []:
+        raise ValueError("Torch Eager baseline has forbidden compiler environment settings")
+    guard = environment.get("torch_compile_guard")
+    expected_guard = {
+        "enforcement": "raise_on_invocation",
+        "invocation_count": 0,
+        "scope": "policy_construction_and_measurement",
+    }
+    if (
+        guard != expected_guard
+        or not isinstance(guard, Mapping)
+        or type(guard.get("invocation_count")) is not int
+    ):
+        raise ValueError("Torch Eager baseline torch.compile guard is invalid")
+
+    samples = document.get("latency_samples_ms")
+    if not isinstance(samples, list):
+        raise ValueError("Torch Eager baseline latency_samples_ms must be an array")
+    latency = _latency_summary(samples, BENCHMARK_ITERATIONS)
+    return {
+        "artifact_sha256": TORCH_EAGER_SHA256,
+        "backend": "pytorch_eager",
+        "profile_name": _PROFILE,
+        "iterations": BENCHMARK_ITERATIONS,
+        "warmups": BENCHMARK_WARMUPS,
+        "latency_ms": latency,
+        "effective_compile_mode": None,
+        "torch_compile_guard_invocation_count": 0,
+        "upstream_commit": _UPSTREAM_COMMIT,
+        "hardware": {
+            "gpu_name": hardware["gpu_name"],
+            "tensorrt_version": hardware["tensorrt_version"],
+        },
+        "workload": dict(_EXPECTED_WORKLOAD),
+    }
+
+
+def load_torch_eager_baseline() -> dict[str, Any]:
+    """Load the Torch Eager receipt from the pinned offline snapshot."""
+
+    path = openpi_proof_path("performance", "pytorch-eager.json")
+    if not path.is_file():
+        raise ValueError("Pinned OpenPI Torch Eager baseline is unavailable")
+    digest = qualification.sha256_file(path)
+    if digest != TORCH_EAGER_SHA256:
+        raise ValueError(
+            "Pinned OpenPI Torch Eager baseline SHA-256 mismatch: "
+            f"expected {TORCH_EAGER_SHA256}, found {digest}"
+        )
+    return validate_torch_eager_document(qualification.strict_json_load(path))
+
+
+def validate_case(case: Any, baseline: Mapping[str, Any]) -> None:
+    """Reject a case whose declared workload differs from the pinned receipt."""
+
+    inputs = case.inputs
+    expected_inputs = {
+        "profile": baseline["profile_name"],
+        "reference_case_id": baseline["workload"]["case_id"],
+        "action_horizon": baseline["workload"]["action_horizon"],
+        "internal_action_dim": baseline["workload"]["internal_action_dim"],
+        "flow_steps": baseline["workload"]["flow_steps"],
+        "fixed_external_noise": baseline["workload"]["fixed_external_noise"],
+    }
+    for field, expected in expected_inputs.items():
+        if (
+            field not in inputs
+            or inputs[field] != expected
+            or type(inputs[field]) is not type(expected)
+        ):
+            raise ValueError(f"OpenPI performance case {field} differs from the pinned workload")
+
+    expected_declaration = {
+        "native_backend": "tensorrt_cpp",
+        "baseline_backend": "pytorch_eager",
+        "baseline_artifact": "performance/pytorch-eager.json",
+        "baseline_sha256": TORCH_EAGER_SHA256,
+        "iterations": BENCHMARK_ITERATIONS,
+        "warmups": BENCHMARK_WARMUPS,
+    }
+    declared = case.metadata.get("performance_qualification")
+    if (
+        declared != expected_declaration
+        or not isinstance(declared, Mapping)
+        or any(
+            type(declared[key]) is not type(value) for key, value in expected_declaration.items()
+        )
+    ):
+        raise ValueError("OpenPI performance qualification declaration is stale or mismatched")
+
+
+def parse_native_benchmark(stderr: str) -> dict[str, Any]:
+    """Parse the single anchored benchmark receipt emitted by ``trtmc-openpi``."""
+
+    prefix_lines = [line for line in stderr.splitlines() if _BENCHMARK_PREFIX in line]
+    if len(prefix_lines) != 1:
+        raise ValueError("trtmc-openpi must emit exactly one valid benchmark receipt line")
+    match = _BENCHMARK_LINE.fullmatch(prefix_lines[0])
+    if match is None:
+        raise ValueError("trtmc-openpi benchmark receipt line is malformed")
+    iterations = int(match.group("iterations"))
+    warmups = int(match.group("warmups"))
+    if (iterations, warmups) != (BENCHMARK_ITERATIONS, BENCHMARK_WARMUPS):
+        raise ValueError("trtmc-openpi benchmark counts do not match the qualification contract")
+    latency = {
+        "mean_ms": _positive_finite(float(match.group("mean")), "native mean latency"),
+        "p50_ms": _positive_finite(float(match.group("p50")), "native p50 latency"),
+        "p95_ms": _positive_finite(float(match.group("p95")), "native p95 latency"),
+    }
+    if latency["p50_ms"] > latency["p95_ms"]:
+        raise ValueError("trtmc-openpi benchmark p50 latency exceeds p95 latency")
+    return {
+        "backend": "tensorrt_cpp",
+        "runtime": "trtmc-openpi",
+        "runtime_contract": "native_cpp_tensorrt",
+        "iterations": iterations,
+        "warmups": warmups,
+        "latency_ms": latency,
+    }
+
+
+def build_receipt(stderr: str, case: Any) -> dict[str, Any]:
+    baseline = load_torch_eager_baseline()
+    validate_case(case, baseline)
+    return {
+        "schema_version": 1,
+        "artifact_type": "openpi_performance_receipt",
+        "native": parse_native_benchmark(stderr),
+        "torch_eager": baseline,
+        "native_stderr": stderr,
+    }
+
+
+def validate_receipt(receipt: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Revalidate persisted evidence before applying performance gates."""
+
+    if not isinstance(receipt, Mapping) or set(receipt) != {
+        "schema_version",
+        "artifact_type",
+        "native",
+        "torch_eager",
+        "native_stderr",
+    }:
+        raise ValueError("OpenPI performance receipt fields do not match the contract")
+    if (
+        receipt["schema_version"] != 1
+        or receipt["artifact_type"] != "openpi_performance_receipt"
+        or not isinstance(receipt["native_stderr"], str)
+    ):
+        raise ValueError("OpenPI performance receipt identity is invalid")
+    native = parse_native_benchmark(receipt["native_stderr"])
+    baseline = load_torch_eager_baseline()
+    if receipt["native"] != native:
+        raise ValueError("OpenPI native benchmark summary differs from its stderr receipt")
+    if receipt["torch_eager"] != baseline:
+        raise ValueError("OpenPI Torch Eager summary differs from its pinned artifact")
+    return native, baseline

--- a/tests/e2e/models/openpi/e2e_plugins/reference.py
+++ b/tests/e2e/models/openpi/e2e_plugins/reference.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenPI pinned-upstream reference plugin."""
+
+from .references.upstream_replay import plugin as reference  # noqa: F401

--- a/tests/e2e/models/openpi/e2e_plugins/references/__init__.py
+++ b/tests/e2e/models/openpi/e2e_plugins/references/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenPI pinned-reference backends."""

--- a/tests/e2e/models/openpi/e2e_plugins/references/upstream_replay.py
+++ b/tests/e2e/models/openpi/e2e_plugins/references/upstream_replay.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pinned, content-addressed OpenPI upstream replay backend."""
+
+from __future__ import annotations
+
+import functools
+import json
+import os
+import struct
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping
+
+from tests.e2e.models.openpi import qualification
+
+from .. import openpi_proof_path, openpi_snapshot_path, resolve_model_asset
+from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
+
+_STAGE_TENSORS = {
+    "preprocess": (
+        "initial_noise",
+        "token_ids",
+        "token_mask",
+        "preprocessed_images",
+        "image_mask",
+        "normalized_state",
+    ),
+    "vision": ("vision_tokens",),
+    "prefix": ("prefix_kv_cache",),
+    "actions": ("normalized_actions", "physical_actions"),
+    "act": ("normalized_actions", "physical_actions"),
+    "end_to_end": ("normalized_actions", "physical_actions"),
+}
+
+
+def _replay_path(case: E2ECase) -> Path:
+    value = str(
+        case.inputs.get("upstream_replay_artifact")
+        or case.metadata.get("upstream_replay_artifact")
+        or os.environ.get("TRTMC_OPENPI_REFERENCE_ARTIFACT", "")
+    )
+    if value:
+        return resolve_model_asset(value, str(case.metadata.get("model_test_dir", "")))
+
+    return openpi_proof_path("reference", "reference-set.json")
+
+
+@functools.lru_cache(maxsize=8)
+def _load_validated_document(path_text: str) -> dict[str, Any]:
+    path = Path(path_text)
+    document = qualification.strict_json_load(path)
+    artifact_type = document.get("artifact_type")
+    if artifact_type == "openpi_pinned_reference_set":
+        return qualification.validate_reference_set(path, minimum_cases=512)
+    raise ValueError(
+        "OpenPI E2E requires a validated 512-case openpi_pinned_reference_set; "
+        f"got {artifact_type!r}"
+    )
+
+
+@functools.lru_cache(maxsize=32)
+def _load_validated_case(path_text: str) -> dict[str, Any]:
+    return qualification.validate_reference_artifact(Path(path_text))
+
+
+def _resolve_case_artifact(case: E2ECase) -> tuple[Path, dict[str, Any]]:
+    source = _replay_path(case)
+    if not source.is_file():
+        raise FileNotFoundError(f"OpenPI reference set is missing: {source}")
+    document = _load_validated_document(str(source))
+    requested_id = str(
+        case.inputs.get("reference_case_id")
+        or case.metadata.get("reference_case_id")
+        or os.environ.get("TRTMC_OPENPI_REFERENCE_CASE_ID", "")
+    )
+    entries = document["cases"]
+    if not requested_id and len(entries) == 1:
+        requested_id = str(entries[0]["id"])
+    if not requested_id and any(entry["id"] == case.name for entry in entries):
+        requested_id = case.name
+    if not requested_id:
+        raise ValueError(
+            "A multi-case OpenPI reference set requires inputs.reference_case_id or "
+            "TRTMC_OPENPI_REFERENCE_CASE_ID"
+        )
+    matches = [entry for entry in entries if entry["id"] == requested_id]
+    if len(matches) != 1:
+        raise ValueError(f"OpenPI reference case {requested_id!r} is not present exactly once")
+    relative = PurePosixPath(str(matches[0]["path"]))
+    artifact_path = source.parent.joinpath(*relative.parts)
+    if not artifact_path.is_file():
+        raise FileNotFoundError(f"OpenPI reference case is missing: {artifact_path}")
+    return artifact_path, _load_validated_case(str(artifact_path))
+
+
+def _iter_tensor_values(path: Path, dtype: str) -> Iterable[float | int | bool]:
+    payload = path.read_bytes()
+    if dtype == "bool":
+        return (value != 0 for value in payload)
+    if dtype == "uint8":
+        return iter(payload)
+    if dtype == "int32":
+        return (item[0] for item in struct.iter_unpack("<i", payload))
+    if dtype == "int64":
+        return (item[0] for item in struct.iter_unpack("<q", payload))
+    if dtype == "float16":
+        return (float(item[0]) for item in struct.iter_unpack("<e", payload))
+    if dtype == "float32":
+        return (float(item[0]) for item in struct.iter_unpack("<f", payload))
+    if dtype == "bfloat16":
+        return (
+            float(struct.unpack("<f", struct.pack("<I", item[0] << 16))[0])
+            for item in struct.iter_unpack("<H", payload)
+        )
+    raise ValueError(f"Unsupported OpenPI replay tensor dtype {dtype!r}")
+
+
+def _tensor_file_descriptor(artifact_path: Path, descriptor: Mapping[str, Any]) -> dict[str, Any]:
+    relative = PurePosixPath(str(descriptor["path"]))
+    return {
+        "path": str(artifact_path.parent.joinpath(*relative.parts)),
+        "dtype": str(descriptor["dtype"]),
+        "shape": list(descriptor["shape"]),
+        "sha256": str(descriptor["sha256"]),
+    }
+
+
+def _reshape_actions(values: list[float], shape: list[int]) -> list[list[float]]:
+    if len(shape) != 3 or shape[0] != 1:
+        raise ValueError(f"OpenPI action tensor must have shape [1,H,D], got {shape}")
+    horizon, action_dim = shape[1], shape[2]
+    if len(values) != horizon * action_dim:
+        raise ValueError("OpenPI action tensor payload length does not match its shape")
+    return [values[row * action_dim : (row + 1) * action_dim] for row in range(horizon)]
+
+
+def _snapshot_normalization_path(case: E2ECase) -> Path:
+    profile = str(case.inputs.get("profile") or case.metadata.get("profile") or "")
+    config_path = openpi_snapshot_path("openpi_config.json")
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    if profile and config.get("profile") != profile:
+        raise ValueError(
+            f"OpenPI snapshot profile {config.get('profile')!r} does not match {profile!r}"
+        )
+    normalization = openpi_snapshot_path("preprocessor_config.json")
+    if not normalization.is_file():
+        raise FileNotFoundError(f"OpenPI snapshot normalization asset is missing: {normalization}")
+    return normalization
+
+
+def _load_action_spans(case: E2ECase, action_dim: int) -> list[float] | None:
+    direct = case.inputs.get("action_spans") or case.metadata.get("action_spans")
+    if direct is not None:
+        spans = [float(value) for value in direct]
+    else:
+        stats_value = str(
+            case.inputs.get("normalization_stats")
+            or case.metadata.get("normalization_stats")
+            or os.environ.get("TRTMC_OPENPI_NORM_STATS", "")
+        )
+        if stats_value:
+            stats_path = resolve_model_asset(
+                stats_value, str(case.metadata.get("model_test_dir", ""))
+            )
+        else:
+            stats_path = _snapshot_normalization_path(case)
+        payload = json.loads(stats_path.read_text(encoding="utf-8"))
+        root = payload.get("norm_stats", payload)
+        actions = root.get("actions") if isinstance(root, dict) else None
+        if not isinstance(actions, dict):
+            raise ValueError("OpenPI normalization stats do not contain actions")
+        q01, q99 = actions.get("q01"), actions.get("q99")
+        if not isinstance(q01, list) or not isinstance(q99, list):
+            raise ValueError("OpenPI action normalization must contain q01/q99 arrays")
+        spans = [float(high) - float(low) for low, high in zip(q01, q99, strict=True)]
+    if len(spans) < action_dim or any(span <= 0.0 for span in spans[:action_dim]):
+        raise ValueError("OpenPI action spans must be positive and cover every output dimension")
+    return spans[:action_dim]
+
+
+class UpstreamReplayReference:
+    """Read tensors captured from the audited OpenPI commit and checkpoint."""
+
+    @property
+    def backend_name(self) -> str:
+        return "upstream_replay"
+
+    def run_stage(self, case: E2ECase, stage: StageSpec, ctx: RunContext) -> StageOutput:
+        del ctx
+        artifact_path, artifact = _resolve_case_artifact(case)
+        expected_profile = str(case.inputs.get("profile", ""))
+        if expected_profile and artifact["profile_name"] != expected_profile:
+            raise ValueError(
+                f"OpenPI reference profile {artifact['profile_name']!r} does not match "
+                f"case profile {expected_profile!r}"
+            )
+        tensor_names = _STAGE_TENSORS.get(stage.name)
+        if stage.name == "flow":
+            tensor_names = tuple(
+                [f"velocity_{step:02d}" for step in range(10)]
+                + [f"flow_state_{step:02d}" for step in range(11)]
+            )
+        if tensor_names is None:
+            raise ValueError(f"Unsupported OpenPI replay stage {stage.name!r}")
+
+        descriptors = {
+            name: _tensor_file_descriptor(artifact_path, artifact["tensors"][name])
+            for name in tensor_names
+        }
+        data: dict[str, Any] = {
+            "tensor_files": descriptors,
+            "profile_name": artifact["profile_name"],
+            "reference_case_id": artifact["case"]["id"],
+        }
+        if stage.name in {"actions", "act", "end_to_end"}:
+            for key in ("normalized_actions", "physical_actions"):
+                descriptor = descriptors[key]
+                values = [
+                    float(value)
+                    for value in _iter_tensor_values(
+                        Path(descriptor["path"]), str(descriptor["dtype"])
+                    )
+                ]
+                data[key] = _reshape_actions(values, list(descriptor["shape"]))
+            data["actions"] = data["physical_actions"]
+            data["output_field"] = data["physical_actions"]
+            data["horizon"] = len(data["physical_actions"])
+            data["action_dim"] = len(data["physical_actions"][0])
+            spans = _load_action_spans(case, int(data["action_dim"]))
+            if spans is not None:
+                data["action_spans"] = spans
+
+        return StageOutput(
+            stage_name=stage.name,
+            data=data,
+            metadata={
+                "source": "upstream_replay",
+                "artifact_path": str(artifact_path),
+                "upstream_commit": qualification.UPSTREAM_COMMIT,
+                "checkpoint_sha256": artifact["upstream"]["checkpoint"]["sha256"],
+            },
+        )
+
+
+plugin = UpstreamReplayReference()

--- a/tests/e2e/models/openpi/e2e_plugins/runner.py
+++ b/tests/e2e/models/openpi/e2e_plugins/runner.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenPI model-owned E2E runner plugin."""
+
+from .runners.robot_action import plugin as runner  # noqa: F401

--- a/tests/e2e/models/openpi/e2e_plugins/runners/__init__.py
+++ b/tests/e2e/models/openpi/e2e_plugins/runners/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenPI E2E strategy runners."""

--- a/tests/e2e/models/openpi/e2e_plugins/runners/robot_action.py
+++ b/tests/e2e/models/openpi/e2e_plugins/runners/robot_action.py
@@ -1,0 +1,463 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native model-owned OpenPI action runner."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from ... import qualification
+from .. import openpi_proof_path, performance, resolve_model_asset
+from ..contracts import E2ECase, RunContext, StageOutput, StageSpec
+
+_ACTION_STAGES = frozenset({"actions", "act", "end_to_end"})
+_OUTPUT_KEYS = frozenset({"actions", "horizon", "action_dim", "timings"})
+_STAGE_TENSORS = {
+    "preprocess": (
+        "initial_noise",
+        "token_ids",
+        "token_mask",
+        "preprocessed_images",
+        "image_mask",
+        "normalized_state",
+    ),
+    "vision": ("vision_tokens",),
+    "prefix": ("prefix_kv_cache",),
+    "flow": tuple(
+        [f"velocity_{step:02d}" for step in range(10)]
+        + [f"flow_state_{step:02d}" for step in range(11)]
+    ),
+}
+
+
+def _resolve_bundle_path(case: E2ECase, ctx: RunContext) -> Path:
+    bundle = Path(case.bundle)
+    return bundle if bundle.is_absolute() else Path(ctx.engine_dir) / bundle
+
+
+def _resolve_request_path(case: E2ECase) -> Path:
+    value = str(case.inputs.get("request_json") or os.environ.get("TRTMC_OPENPI_REQUEST_JSON", ""))
+    if value:
+        return resolve_model_asset(value, str(case.metadata.get("model_test_dir", "")))
+
+    snapshot_request = openpi_proof_path("request", "request.json")
+    if not snapshot_request.is_file():
+        raise FileNotFoundError(f"Pinned OpenPI request is missing: {snapshot_request}")
+    return snapshot_request
+
+
+def _diagnostic_cache_key(
+    case: E2ECase, ctx: RunContext, profile_name: str
+) -> tuple[str, str, str, str]:
+    return (
+        str(_resolve_bundle_path(case, ctx)),
+        str(_resolve_request_path(case)),
+        str(ctx.binary_path),
+        profile_name,
+    )
+
+
+def build_openpi_act_command(
+    case: E2ECase,
+    ctx: RunContext,
+    *,
+    output_json: str | Path,
+    qualification_diagnostics: str | Path | None = None,
+    benchmark: bool = False,
+) -> list[str]:
+    """Build the pure-native action command used by the E2E harness."""
+
+    if not ctx.binary_path:
+        raise ValueError("OpenPI E2E requires a trtmc binary path")
+    shared_binary = Path(ctx.binary_path)
+    binary = (
+        shared_binary
+        if shared_binary.name == "trtmc-openpi"
+        else shared_binary.with_name("trtmc-openpi")
+    )
+    command = [
+        str(binary),
+        str(_resolve_bundle_path(case, ctx)),
+        "--request-json",
+        str(_resolve_request_path(case)),
+        "--output-json",
+        str(output_json),
+    ]
+    if qualification_diagnostics is not None:
+        command.extend(["--qualification-diagnostics", str(qualification_diagnostics)])
+    if benchmark:
+        command.extend(
+            [
+                "--benchmark",
+                str(performance.BENCHMARK_ITERATIONS),
+                "--warmup",
+                str(performance.BENCHMARK_WARMUPS),
+            ]
+        )
+    return command
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON value {value!r}")
+
+
+def _load_action_output(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"), parse_constant=_reject_nonfinite_json
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"Unable to read OpenPI action output {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise ValueError("OpenPI action output must be a JSON object")
+    unexpected = sorted(set(payload) - _OUTPUT_KEYS)
+    if unexpected:
+        raise ValueError(f"OpenPI action output contains unexpected fields: {unexpected}")
+    missing = sorted({"actions", "horizon", "action_dim", "timings"} - set(payload))
+    if missing:
+        raise ValueError(f"OpenPI action output is missing fields: {missing}")
+    horizon = payload["horizon"]
+    action_dim = payload["action_dim"]
+    if (
+        not isinstance(horizon, int)
+        or isinstance(horizon, bool)
+        or horizon <= 0
+        or not isinstance(action_dim, int)
+        or isinstance(action_dim, bool)
+        or action_dim <= 0
+    ):
+        raise ValueError("OpenPI action output horizon and action_dim must be positive integers")
+    actions = payload["actions"]
+    if not isinstance(actions, list):
+        raise ValueError("OpenPI action output actions must be an array")
+    if actions and isinstance(actions[0], list):
+        if len(actions) != horizon or any(
+            not isinstance(row, list) or len(row) != action_dim for row in actions
+        ):
+            raise ValueError("OpenPI nested action output does not match horizon x action_dim")
+        values = [value for row in actions for value in row]
+    else:
+        values = actions
+        if len(values) != horizon * action_dim:
+            raise ValueError("OpenPI flat action output does not match horizon x action_dim")
+    if any(
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(float(value))
+        for value in values
+    ):
+        raise ValueError("OpenPI action output contains a non-finite or non-numeric value")
+    if not isinstance(payload["timings"], dict):
+        raise ValueError("OpenPI action output timings must be an object")
+    return payload
+
+
+def _load_native_diagnostic_manifest(
+    manifest_path: Path, profile_name: str
+) -> dict[str, dict[str, Any]]:
+    """Validate a native capture against the same tensor contract as the oracle."""
+
+    manifest = qualification.strict_json_load(manifest_path)
+    required_top = {
+        "schema_version",
+        "artifact_type",
+        "runtime_contract",
+        "model_id",
+        "tensors",
+    }
+    if set(manifest) != required_top:
+        raise ValueError("OpenPI native diagnostic manifest fields do not match the contract")
+    if (
+        manifest["schema_version"] != 1
+        or manifest["artifact_type"] != "trtmc_action_qualification_diagnostics"
+        or manifest["runtime_contract"] != "native_cpp_tensorrt"
+    ):
+        raise ValueError("OpenPI native diagnostic manifest identity is invalid")
+    tensors = manifest["tensors"]
+    if not isinstance(tensors, dict):
+        raise ValueError("OpenPI native diagnostic tensors must be an object")
+    expected = qualification._expected_tensor_contract(qualification.load_contract(profile_name))
+    if set(tensors) != set(expected):
+        raise ValueError(
+            "OpenPI native diagnostic tensor set mismatch: "
+            f"missing={sorted(set(expected) - set(tensors))}, "
+            f"unexpected={sorted(set(tensors) - set(expected))}"
+        )
+
+    root = manifest_path.parent.resolve(strict=True)
+    descriptors: dict[str, dict[str, Any]] = {}
+    for name, contract in expected.items():
+        descriptor = tensors[name]
+        required_descriptor = {
+            "path",
+            "stage",
+            "role",
+            "dtype",
+            "shape",
+            "byte_length",
+            "sha256",
+        }
+        if not isinstance(descriptor, dict) or set(descriptor) != required_descriptor:
+            raise ValueError(f"OpenPI native diagnostic descriptor {name!r} is malformed")
+        for field in ("stage", "role", "dtype", "shape"):
+            if descriptor[field] != contract[field]:
+                raise ValueError(
+                    f"OpenPI native diagnostic {name!r}.{field} differs from the contract"
+                )
+        relative = PurePosixPath(str(descriptor["path"]))
+        if relative.is_absolute() or ".." in relative.parts or relative.parts[:1] != ("tensors",):
+            raise ValueError(f"OpenPI native diagnostic {name!r} has an unsafe path")
+        payload = root.joinpath(*relative.parts).resolve(strict=True)
+        if root not in payload.parents or not payload.is_file():
+            raise ValueError(f"OpenPI native diagnostic {name!r} escapes its capture directory")
+        expected_bytes = qualification._tensor_byte_length(
+            str(contract["dtype"]), contract["shape"]
+        )
+        if descriptor["byte_length"] != expected_bytes or payload.stat().st_size != expected_bytes:
+            raise ValueError(f"OpenPI native diagnostic {name!r} has an invalid byte count")
+        if qualification.sha256_file(payload) != descriptor["sha256"]:
+            raise ValueError(f"OpenPI native diagnostic {name!r} SHA-256 mismatch")
+        descriptors[name] = {
+            "path": str(payload),
+            "stage": descriptor["stage"],
+            "role": descriptor["role"],
+            "dtype": descriptor["dtype"],
+            "shape": descriptor["shape"],
+            "byte_length": descriptor["byte_length"],
+            "sha256": descriptor["sha256"],
+        }
+    return descriptors
+
+
+class RobotActionGenerationRunner:
+    """Execute OpenPI through the C++/TensorRT-only ``act`` runtime path."""
+
+    @property
+    def strategy_name(self) -> str:
+        return "robot_action_generation"
+
+    def __init__(self) -> None:
+        self._diagnostic_cache: dict[
+            tuple[str, str, str, str],
+            tuple[dict[str, Any], dict[str, dict[str, Any]], dict[str, Any]],
+        ] = {}
+        self._diagnostic_lock = threading.Lock()
+        self._benchmark_cache: dict[tuple[int, str, str, str, str, str], dict[str, Any]] = {}
+        self._benchmark_contexts: dict[int, RunContext] = {}
+        self._benchmark_lock = threading.Lock()
+
+    def run_stage(self, case: E2ECase, stage: StageSpec, ctx: RunContext) -> StageOutput:
+        if stage.name not in _ACTION_STAGES:
+            if stage.name not in _STAGE_TENSORS:
+                return StageOutput(
+                    stage_name=stage.name,
+                    data={"error": f"Unsupported OpenPI stage {stage.name!r}", "returncode": -1},
+                    metadata={"status": "unsupported_stage"},
+                )
+            return self._run_diagnostic_stage(case, stage, ctx)
+
+        if ctx.artifacts_dir:
+            output_path = Path(ctx.artifacts_dir) / case.name / "openpi_actions.json"
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            return self._run_actions(case, stage, ctx, output_path)
+
+        with tempfile.TemporaryDirectory(prefix="trtmc_openpi_e2e_") as temporary_dir:
+            return self._run_actions(case, stage, ctx, Path(temporary_dir) / "openpi_actions.json")
+
+    def _run_diagnostic_stage(
+        self, case: E2ECase, stage: StageSpec, ctx: RunContext
+    ) -> StageOutput:
+        profile_name = str(case.inputs.get("profile", ""))
+        if not profile_name:
+            raise ValueError("OpenPI diagnostic stage requires inputs.profile")
+        cache_key = _diagnostic_cache_key(case, ctx, profile_name)
+        with self._diagnostic_lock:
+            cached = self._diagnostic_cache.get(cache_key)
+            if cached is None:
+                parent_root = Path(ctx.artifacts_dir) / case.name if ctx.artifacts_dir else None
+                if parent_root is not None:
+                    parent_root.mkdir(parents=True, exist_ok=True)
+                capture_parent = Path(
+                    tempfile.mkdtemp(prefix="openpi_qualification_", dir=parent_root)
+                )
+                diagnostics_dir = capture_parent / "capture"
+                output_path = capture_parent / "openpi_actions.json"
+                command = build_openpi_act_command(
+                    case,
+                    ctx,
+                    output_json=output_path,
+                    qualification_diagnostics=diagnostics_dir,
+                )
+                environment = os.environ.copy()
+                if ctx.ld_library_path:
+                    environment["LD_LIBRARY_PATH"] = ctx.ld_library_path
+                timeout_s = int(case.metadata.get("runtime_timeout_s", 1800))
+                started = time.monotonic()
+                result = subprocess.run(
+                    command,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    env=environment,
+                    timeout=timeout_s,
+                )
+                elapsed = time.monotonic() - started
+                if result.returncode != 0:
+                    return StageOutput(
+                        stage_name=stage.name,
+                        data={
+                            "returncode": result.returncode,
+                            "stdout": result.stdout,
+                            "stderr": result.stderr,
+                        },
+                        timing_s=elapsed,
+                        metadata={"command": command, "returncode": result.returncode},
+                    )
+                action_payload = _load_action_output(output_path)
+                descriptors = _load_native_diagnostic_manifest(
+                    diagnostics_dir / "manifest.json", profile_name
+                )
+                metadata = {
+                    "command": command,
+                    "returncode": result.returncode,
+                    "diagnostic_manifest": str(diagnostics_dir / "manifest.json"),
+                    "runtime_contract": "native_cpp_tensorrt",
+                    "timing_s": elapsed,
+                }
+                cached = (action_payload, descriptors, metadata)
+                self._diagnostic_cache[cache_key] = cached
+
+        _action_payload, descriptors, metadata = cached
+        selected = {name: descriptors[name] for name in _STAGE_TENSORS[stage.name]}
+        return StageOutput(
+            stage_name=stage.name,
+            data={
+                "tensor_files": selected,
+                "returncode": 0,
+                "profile_name": profile_name,
+            },
+            timing_s=float(metadata["timing_s"]),
+            metadata=dict(metadata),
+        )
+
+    def _run_actions(
+        self,
+        case: E2ECase,
+        stage: StageSpec,
+        ctx: RunContext,
+        output_path: Path,
+    ) -> StageOutput:
+        context_identity = id(ctx)
+        benchmark_key = (
+            context_identity,
+            case.name,
+            str(_resolve_bundle_path(case, ctx)),
+            str(_resolve_request_path(case)),
+            str(ctx.binary_path),
+            str(case.inputs.get("profile", "")),
+        )
+        with self._benchmark_lock:
+            # Keep each context alive so Python cannot recycle its identity
+            # while this runner retains the corresponding benchmark receipt.
+            self._benchmark_contexts[context_identity] = ctx
+            receipt = self._benchmark_cache.get(benchmark_key)
+            if receipt is None:
+                command = build_openpi_act_command(
+                    case,
+                    ctx,
+                    output_json=output_path,
+                    benchmark=True,
+                )
+                output = self._invoke_actions(case, stage, ctx, output_path, command)
+                if int(output.data.get("returncode", 0)) != 0:
+                    return output
+                receipt = performance.build_receipt(str(output.metadata["runtime_stderr"]), case)
+                self._benchmark_cache[benchmark_key] = receipt
+                output.metadata["performance"] = receipt
+                self._attach_normalized_actions(output, case, ctx)
+                return output
+
+        command = build_openpi_act_command(case, ctx, output_json=output_path)
+        output = self._invoke_actions(case, stage, ctx, output_path, command)
+        if int(output.data.get("returncode", 0)) == 0:
+            output.metadata["performance"] = receipt
+            self._attach_normalized_actions(output, case, ctx)
+        return output
+
+    def _attach_normalized_actions(
+        self, output: StageOutput, case: E2ECase, ctx: RunContext
+    ) -> None:
+        profile_name = str(case.inputs.get("profile", ""))
+        if not profile_name:
+            return
+        with self._diagnostic_lock:
+            cached = self._diagnostic_cache.get(_diagnostic_cache_key(case, ctx, profile_name))
+        if cached is not None:
+            output.data["tensor_files"] = {"normalized_actions": cached[1]["normalized_actions"]}
+
+    @staticmethod
+    def _invoke_actions(
+        case: E2ECase,
+        stage: StageSpec,
+        ctx: RunContext,
+        output_path: Path,
+        command: list[str],
+    ) -> StageOutput:
+        environment = os.environ.copy()
+        if ctx.ld_library_path:
+            environment["LD_LIBRARY_PATH"] = ctx.ld_library_path
+        timeout_s = int(case.metadata.get("runtime_timeout_s", 1800))
+        started = time.monotonic()
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=environment,
+            timeout=timeout_s,
+        )
+        elapsed = time.monotonic() - started
+        if result.returncode != 0:
+            return StageOutput(
+                stage_name=stage.name,
+                data={
+                    "returncode": result.returncode,
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                },
+                timing_s=elapsed,
+                metadata={"command": command, "returncode": result.returncode},
+            )
+        payload = _load_action_output(output_path)
+        runtime_timings = payload.pop("timings")
+        payload["output_field"] = payload["actions"]
+        payload["returncode"] = result.returncode
+        metadata = {
+            "command": command,
+            "returncode": result.returncode,
+            "output_json": str(output_path),
+            "runtime_contract": "native_cpp_tensorrt",
+            "runtime_timings": runtime_timings,
+            "runtime_stdout": result.stdout,
+            "runtime_stderr": result.stderr,
+        }
+        return StageOutput(
+            stage_name=stage.name,
+            data=payload,
+            timing_s=elapsed,
+            metadata=metadata,
+        )
+
+
+plugin = RobotActionGenerationRunner()

--- a/tests/e2e/models/openpi/e2e_plugins/runtime_dependencies.py
+++ b/tests/e2e/models/openpi/e2e_plugins/runtime_dependencies.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail-closed dependency proof for the native OpenPI runtime."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from tests.e2e.models.openpi import qualification
+
+
+class OpenPIRuntimeDependencyError(RuntimeError):
+    """Raised when OpenPI's runtime dependency contract is not satisfied."""
+
+
+_ARTIFACTS = (
+    ("runner", "trtmc-openpi"),
+    ("core", "libtrtmc_core.so"),
+    ("tensorrt_backend", "libtrtmc_backend_trt.so"),
+    ("openpi_model", "libtrtmc_model_openpi.so"),
+)
+_NEEDED = re.compile(r"\(NEEDED\).*Shared library: \[([^\]]+)\]")
+_FORBIDDEN = re.compile(
+    r"(?:onnx|onnxruntime|python|torch|c10|tvm|jax|tensorflow|opencv|"
+    r"protobuf|sentencepiece)",
+    re.IGNORECASE,
+)
+_ALLOWED = tuple(
+    re.compile(pattern)
+    for pattern in (
+        r"linux-vdso\.so\.1",
+        r"ld-linux(?:-[A-Za-z0-9_-]+)?\.so(?:\.[A-Za-z0-9_+.-]+)*",
+        r"lib(?:c|m|dl|pthread|rt|stdc\+\+|gcc_s|atomic|util)\.so"
+        r"(?:\.[A-Za-z0-9_+.-]+)*",
+        r"lib(?:cuda|cudart|cublas|cublasLt|nvrtc|nvrtc-builtins|nvJitLink)\.so"
+        r"(?:\.[A-Za-z0-9_+.-]+)*",
+        r"libnvinfer(?:_[A-Za-z0-9_]+)?\.so(?:\.[A-Za-z0-9_+.-]+)*",
+        r"libtrtmc_(?:core|backend_trt(?:_[0-9_]+)?|model_openpi)\.so"
+        r"(?:\.[A-Za-z0-9_+.-]+)*",
+    )
+)
+
+
+def _run_tool(command: Sequence[str], *, ld_library_path: str) -> str:
+    environment = os.environ.copy()
+    environment["LD_LIBRARY_PATH"] = ld_library_path
+    completed = subprocess.run(
+        list(command),
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "no diagnostic"
+        raise OpenPIRuntimeDependencyError(f"{command[0]} failed for {command[-1]}: {detail}")
+    return completed.stdout
+
+
+def _readelf_dependencies(output: str, *, artifact: str) -> tuple[str, ...]:
+    dependencies = tuple(
+        match.group(1)
+        for line in output.splitlines()
+        if (match := _NEEDED.search(line)) is not None
+    )
+    if not dependencies:
+        raise OpenPIRuntimeDependencyError(f"{artifact}: readelf reported no direct dependencies")
+    return tuple(sorted(set(dependencies)))
+
+
+def _ldd_dependencies(output: str, *, artifact: str) -> tuple[str, ...]:
+    if "not found" in output.lower():
+        raise OpenPIRuntimeDependencyError(f"{artifact}: ldd reported an unresolved dependency")
+    dependencies: set[str] = set()
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        token = line.split("=>", 1)[0].strip() if "=>" in line else line.split()[0]
+        name = Path(token).name
+        if name:
+            dependencies.add(name)
+    if not dependencies:
+        raise OpenPIRuntimeDependencyError(f"{artifact}: ldd reported no dependencies")
+    return tuple(sorted(dependencies))
+
+
+def _validate(dependencies: Sequence[str], *, artifact: str, source: str) -> None:
+    forbidden = sorted(name for name in dependencies if _FORBIDDEN.search(name))
+    if forbidden:
+        raise OpenPIRuntimeDependencyError(
+            f"{artifact}: forbidden {source} dependencies: {forbidden}"
+        )
+    unknown = sorted(
+        name for name in dependencies if not any(pattern.fullmatch(name) for pattern in _ALLOWED)
+    )
+    if unknown:
+        raise OpenPIRuntimeDependencyError(f"{artifact}: unknown {source} dependencies: {unknown}")
+
+
+def audit_openpi_runtime_dependencies(
+    *,
+    runner: str | Path,
+    core: str | Path,
+    tensorrt_backend: str | Path,
+    openpi_model: str | Path,
+    ld_library_path: str | os.PathLike[str] | Sequence[str | os.PathLike[str]],
+) -> dict[str, Any]:
+    """Prove that the exact OpenPI runtime closure is TensorRT/C++ only."""
+
+    if isinstance(ld_library_path, (str, os.PathLike)):
+        library_path = os.fspath(ld_library_path)
+    else:
+        library_path = os.pathsep.join(os.fspath(path) for path in ld_library_path)
+    if not library_path:
+        raise OpenPIRuntimeDependencyError("LD_LIBRARY_PATH must be explicit and non-empty")
+
+    paths = (Path(runner), Path(core), Path(tensorrt_backend), Path(openpi_model))
+    evidence: list[dict[str, Any]] = []
+    for (role, expected_name), path in zip(_ARTIFACTS, paths, strict=True):
+        if path.name != expected_name:
+            raise OpenPIRuntimeDependencyError(
+                f"{role}: expected artifact {expected_name!r}, got {path.name!r}"
+            )
+        if not path.is_file():
+            raise OpenPIRuntimeDependencyError(f"{role}: artifact is not a file: {path}")
+
+        direct = _readelf_dependencies(
+            _run_tool(("readelf", "-d", str(path)), ld_library_path=library_path),
+            artifact=expected_name,
+        )
+        closure = _ldd_dependencies(
+            _run_tool(("ldd", str(path)), ld_library_path=library_path),
+            artifact=expected_name,
+        )
+        _validate(direct, artifact=expected_name, source="direct")
+        _validate(closure, artifact=expected_name, source="transitive")
+        if role == "openpi_model":
+            if not any(
+                re.fullmatch(r"libnvinfer(?:_[A-Za-z0-9_]+)?\.so(?:\..+)*", name) for name in direct
+            ):
+                raise OpenPIRuntimeDependencyError(
+                    "libtrtmc_model_openpi.so must directly depend on libnvinfer"
+                )
+            if not any(re.fullmatch(r"libcublas\.so(?:\..+)*", name) for name in direct):
+                raise OpenPIRuntimeDependencyError(
+                    "libtrtmc_model_openpi.so must directly depend on libcublas"
+                )
+        evidence.append(
+            {
+                "role": role,
+                "name": expected_name,
+                "sha256": qualification.sha256_file(path),
+                "direct_dependencies": list(direct),
+                "dependencies": list(closure),
+            }
+        )
+
+    return {
+        "schema_version": 1,
+        "runtime_contract": "native_cpp_tensorrt_only",
+        "artifacts": evidence,
+    }

--- a/tests/e2e/models/openpi/manifests/pi05-droid.json
+++ b/tests/e2e/models/openpi/manifests/pi05-droid.json
@@ -1,0 +1,72 @@
+{
+  "name": "pi05-droid",
+  "hf_id": "NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID",
+  "hf_revision": "59205df7225305b0a6680dd8fe9a064cfec774d7",
+  "bundle": "pi05-droid.trtfb",
+  "family": "openpi",
+  "runtime_strategy": "openpi_vla",
+  "task_strategy": "robot_action_generation",
+  "precision": "bf16",
+  "build_timeout_s": 14400,
+  "e2e_parallel_resource": "exclusive_gpu",
+  "testcases": [
+    {
+      "name": "pi05-droid",
+      "trace_id": "IT-E2E-OPENPI-PI05-DROID-01",
+      "reference_backend": "upstream_replay",
+      "oracle_level": "L1_external_reference",
+      "reference_family": "openpi_flow_policy",
+      "user_contract": "robot_action_chunk",
+      "preflight_requirements": [
+        {"kind": "binary_exists", "args": {}, "gating": true},
+        {"kind": "gpu_count_min", "args": {"count": 1}, "gating": true}
+      ],
+      "inputs": {
+        "profile": "pi05_droid",
+        "reference_case_id": "droid_iris_20231204154425_f000005",
+        "contract": "contracts/pi05_droid.json",
+        "camera_order": ["base_0_rgb", "left_wrist_0_rgb", "right_wrist_0_rgb"],
+        "camera_validity": [true, true, false],
+        "image_shape_hwc": [224, 224, 3],
+        "state_dim": 8,
+        "internal_action_dim": 32,
+        "output_action_dim": 8,
+        "action_horizon": 15,
+        "max_prompt_tokens": 200,
+        "flow_steps": 10,
+        "flow_dt": -0.1,
+        "fixed_external_noise": true
+      },
+      "stages": [
+        {"name": "preprocess", "required": true, "artifact_type": "token_ids", "comparison_mode": "token_exact"},
+        {"name": "vision", "required": true, "artifact_type": "embedding", "comparison_mode": "numeric_tensor"},
+        {"name": "prefix", "required": true, "artifact_type": "embedding", "comparison_mode": "numeric_tensor"},
+        {"name": "flow", "required": true, "artifact_type": "embedding", "comparison_mode": "numeric_tensor"},
+        {"name": "actions", "required": true, "artifact_type": "embedding", "comparison_mode": "numeric_tensor"}
+      ],
+      "determinism": {"seed": 42, "reruns": 100},
+      "metadata": {
+        "upstream_repository": "https://github.com/Physical-Intelligence/openpi.git",
+        "upstream_commit": "15a9616a00943ada6c20a0f158e3adb39df2ccac",
+        "checkpoint_digest_required": true,
+        "qualified_platform": {
+          "gpu": "NVIDIA GB300",
+          "compute_capability": "sm103",
+          "os": "Linux",
+          "cpu_architecture": "aarch64",
+          "tensorrt": "11.2.0.113"
+        },
+        "runtime_dependency_contract": "TensorRT, CUDA, Model-Connect C++, and standard system libraries only",
+        "performance_qualification": {
+          "native_backend": "tensorrt_cpp",
+          "baseline_backend": "pytorch_eager",
+          "baseline_artifact": "performance/pytorch-eager.json",
+          "baseline_sha256": "3cd217412ddbe931e179038f39c74ffc4b7b35675132eb739370dc42dc53a8d8",
+          "iterations": 1000,
+          "warmups": 100
+        },
+        "onnx_prohibited": true
+      }
+    }
+  ]
+}

--- a/tests/e2e/models/openpi/qualification.py
+++ b/tests/e2e/models/openpi/qualification.py
@@ -1,0 +1,804 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate the pinned contracts and replay artifacts used by OpenPI E2E tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+UPSTREAM_REPOSITORY = "https://github.com/Physical-Intelligence/openpi.git"
+UPSTREAM_COMMIT = "15a9616a00943ada6c20a0f158e3adb39df2ccac"
+SCHEMA_VERSION = 1
+
+_ROOT = Path(__file__).resolve().parent
+_CONTRACTS = {
+    "pi05_droid": _ROOT / "contracts" / "pi05_droid.json",
+}
+_THRESHOLDS = {
+    "pi05_droid": _ROOT / "thresholds" / "pi05-droid.json",
+}
+_DTYPE_BYTES = {
+    "bool": 1,
+    "uint8": 1,
+    "int32": 4,
+    "int64": 8,
+    "bfloat16": 2,
+    "float16": 2,
+    "float32": 4,
+}
+
+
+class OpenPIQualificationError(ValueError):
+    """Raised when a contract or replay artifact is invalid."""
+
+
+class _DuplicateKeyError(ValueError):
+    pass
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateKeyError(key)
+        result[key] = value
+    return result
+
+
+def strict_json_load(path: str | Path) -> dict[str, Any]:
+    """Load a JSON object while rejecting duplicate keys and non-finite numbers."""
+
+    source = Path(path)
+
+    def reject_constant(value: str) -> None:
+        raise OpenPIQualificationError(f"{source}: non-finite JSON number {value!r}")
+
+    try:
+        value = json.loads(
+            source.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=reject_constant,
+        )
+    except _DuplicateKeyError as error:
+        raise OpenPIQualificationError(
+            f"{source}: duplicate JSON object key {str(error)!r}"
+        ) from error
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise OpenPIQualificationError(f"Unable to read strict JSON {source}: {error}") from error
+    if not isinstance(value, dict):
+        raise OpenPIQualificationError(f"{source}: top-level JSON value must be an object")
+    return value
+
+
+def sha256_file(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _object(value: Any, *, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise OpenPIQualificationError(f"{label} must be an object")
+    return value
+
+
+def _require_exact_keys(
+    value: Mapping[str, Any],
+    required: set[str],
+    *,
+    optional: set[str] = frozenset(),
+    label: str,
+) -> None:
+    missing = sorted(required - set(value))
+    if missing:
+        raise OpenPIQualificationError(f"{label} is missing required fields: {missing}")
+    unexpected = sorted(set(value) - required - optional)
+    if unexpected:
+        raise OpenPIQualificationError(f"{label} contains unexpected fields: {unexpected}")
+
+
+def _require_int(value: Any, *, label: str, minimum: int | None = None) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise OpenPIQualificationError(f"{label} must be an integer")
+    if minimum is not None and value < minimum:
+        raise OpenPIQualificationError(f"{label} must be >= {minimum}, got {value}")
+    return value
+
+
+def _require_sha256(value: Any, *, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or value == "0" * 64
+        or any(char not in "0123456789abcdef" for char in value)
+    ):
+        raise OpenPIQualificationError(f"{label} must be a non-zero lowercase SHA-256")
+    return value
+
+
+def _safe_relative_path(value: Any, *, label: str, prefix: str | None = None) -> PurePosixPath:
+    if not isinstance(value, str) or not value:
+        raise OpenPIQualificationError(f"{label} must be a non-empty string")
+    relative = PurePosixPath(value)
+    if (
+        relative.is_absolute()
+        or ".." in relative.parts
+        or relative.as_posix() != value
+        or (prefix is not None and relative.parts[:1] != (prefix,))
+    ):
+        suffix = f" under {prefix}/" if prefix else ""
+        raise OpenPIQualificationError(f"{label} must be a canonical relative path{suffix}")
+    return relative
+
+
+def _hf_cache_blob_root(root: Path) -> Path | None:
+    """Return the sibling blob store for a canonical HF snapshot path."""
+
+    for snapshots_dir in root.parents:
+        if snapshots_dir.name != "snapshots":
+            continue
+        relative = root.relative_to(snapshots_dir)
+        revision = relative.parts[0] if relative.parts else ""
+        if (
+            len(revision) == 40
+            and all(char in "0123456789abcdef" for char in revision)
+            and snapshots_dir.parent.name.startswith("models--")
+        ):
+            blobs = snapshots_dir.parent / "blobs"
+            return blobs.resolve(strict=True) if blobs.is_dir() else None
+    return None
+
+
+def _resolve_relative_file(root: Path, relative: PurePosixPath, *, label: str) -> Path:
+    """Resolve a local file or a standard HF snapshot symlink without traversal."""
+
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved = root.joinpath(*relative.parts).resolve(strict=True)
+    except OSError as error:
+        raise OpenPIQualificationError(f"{label} is missing") from error
+    if not resolved.is_file():
+        raise OpenPIQualificationError(f"{label} is not a file")
+    if resolved_root in resolved.parents:
+        return resolved
+    blob_root = _hf_cache_blob_root(resolved_root)
+    if blob_root is not None and blob_root in resolved.parents:
+        return resolved
+    raise OpenPIQualificationError(f"{label} escapes its artifact directory")
+
+
+def load_contract(profile_name: str) -> dict[str, Any]:
+    try:
+        path = _CONTRACTS[profile_name]
+    except KeyError as error:
+        raise OpenPIQualificationError(f"Unsupported OpenPI profile {profile_name!r}") from error
+    contract = strict_json_load(path)
+    validate_contract(contract)
+    return contract
+
+
+def load_thresholds(profile_name: str) -> dict[str, Any]:
+    try:
+        path = _THRESHOLDS[profile_name]
+    except KeyError as error:
+        raise OpenPIQualificationError(f"Unsupported OpenPI profile {profile_name!r}") from error
+    document = strict_json_load(path)
+    _require_exact_keys(document, {"threshold_overrides"}, label="OpenPI thresholds")
+    overrides = _object(document["threshold_overrides"], label="threshold_overrides")
+    for name, value in overrides.items():
+        if (
+            not isinstance(name, str)
+            or not isinstance(value, (int, float))
+            or isinstance(value, bool)
+        ):
+            raise OpenPIQualificationError(
+                "threshold_overrides must contain numeric values keyed by strings"
+            )
+    return dict(overrides)
+
+
+def validate_contract(contract: Mapping[str, Any]) -> None:
+    _require_exact_keys(
+        contract,
+        {
+            "schema_version",
+            "profile_name",
+            "variant",
+            "upstream",
+            "precision",
+            "images",
+            "prompt",
+            "state",
+            "actions",
+            "prefix",
+            "flow",
+            "runtime",
+        },
+        label="OpenPI contract",
+    )
+    profile = contract["profile_name"]
+    if profile not in _CONTRACTS:
+        raise OpenPIQualificationError(f"Unknown contract profile {profile!r}")
+    if contract["schema_version"] != SCHEMA_VERSION or contract["variant"] != "pi05_flow":
+        raise OpenPIQualificationError("OpenPI contract must declare schema v1 and pi05_flow")
+
+    upstream = _object(contract["upstream"], label="OpenPI contract upstream")
+    _require_exact_keys(
+        upstream,
+        {"repository", "commit", "checkpoint_uri", "checkpoint_digest_policy"},
+        label="OpenPI contract upstream",
+    )
+    expected_checkpoint = f"gs://openpi-assets/checkpoints/{profile}"
+    if upstream != {
+        "repository": UPSTREAM_REPOSITORY,
+        "commit": UPSTREAM_COMMIT,
+        "checkpoint_uri": expected_checkpoint,
+        "checkpoint_digest_policy": "required_in_reference_artifact",
+    }:
+        raise OpenPIQualificationError("OpenPI contract does not use the pinned upstream")
+
+    precision = _object(contract["precision"], label="OpenPI contract precision")
+    if precision != {"network": "bfloat16", "sensitive_accumulation": "float32"}:
+        raise OpenPIQualificationError("OpenPI precision contract was weakened")
+
+    images = _object(contract["images"], label="OpenPI contract images")
+    if images != {
+        "order": ["base_0_rgb", "left_wrist_0_rgb", "right_wrist_0_rgb"],
+        "validity": [True, True, False],
+        "shape_hwc": [224, 224, 3],
+        "tokens_per_image": 256,
+        "embedding_width": 2048,
+    }:
+        raise OpenPIQualificationError("OpenPI image contract does not match upstream")
+
+    expected_actions = {"horizon": 15, "external_dim": 8}
+    actions = _object(contract["actions"], label="OpenPI contract actions")
+    if actions != {
+        **expected_actions,
+        "internal_dim": 32,
+        "normalization": "quantile_q01_q99",
+    }:
+        raise OpenPIQualificationError(f"{profile} action contract does not match upstream")
+
+    state = _object(contract["state"], label="OpenPI contract state")
+    if state != {
+        "external_dim": 8,
+        "internal_dim": 32,
+        "normalization": "quantile_q01_q99",
+    }:
+        raise OpenPIQualificationError("OpenPI state contract does not match upstream")
+
+    prompt = _object(contract["prompt"], label="OpenPI contract prompt")
+    if prompt != {
+        "max_tokens": 200,
+        "discrete_state_input": True,
+        "vocab_size": 257152,
+    }:
+        raise OpenPIQualificationError("OpenPI prompt contract does not match upstream")
+
+    prefix = _object(contract["prefix"], label="OpenPI contract prefix")
+    if prefix != {
+        "max_physical_tokens": 968,
+        "layers": 18,
+        "query_heads": 8,
+        "kv_heads": 1,
+        "head_dim": 256,
+    }:
+        raise OpenPIQualificationError("OpenPI prefix contract does not match upstream")
+
+    flow = _object(contract["flow"], label="OpenPI contract flow")
+    if flow != {
+        "steps": 10,
+        "initial_t": 1.0,
+        "dt": -0.1,
+        "external_noise_required_for_parity": True,
+        "timestep_injection": "adaptive_rms_norm",
+    }:
+        raise OpenPIQualificationError("OpenPI flow contract does not match upstream")
+
+    runtime = _object(contract["runtime"], label="OpenPI contract runtime")
+    if runtime != {
+        "language": "c++",
+        "engine_api": "tensorrt",
+        "onnx_allowed": False,
+        "python_allowed": False,
+        "additional_frameworks_allowed": False,
+    }:
+        raise OpenPIQualificationError("OpenPI runtime purity contract was weakened")
+
+
+def _expected_tensor_contract(contract: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    horizon = int(_object(contract["actions"], label="actions")["horizon"])
+    external_dim = int(_object(contract["actions"], label="actions")["external_dim"])
+    prefix = _object(contract["prefix"], label="prefix")
+    flow_shape = [1, horizon, 32]
+    expected: dict[str, dict[str, Any]] = {
+        "initial_noise": {
+            "stage": "preprocess",
+            "role": "input",
+            "dtype": "float32",
+            "shape": flow_shape,
+        },
+        "token_ids": {
+            "stage": "preprocess",
+            "role": "intermediate",
+            "dtype": "int32",
+            "shape": [1, 200],
+        },
+        "token_mask": {
+            "stage": "preprocess",
+            "role": "intermediate",
+            "dtype": "bool",
+            "shape": [1, 200],
+        },
+        "preprocessed_images": {
+            "stage": "preprocess",
+            "role": "intermediate",
+            "dtype": "float32",
+            "shape": [1, 3, 224, 224, 3],
+        },
+        "image_mask": {
+            "stage": "preprocess",
+            "role": "intermediate",
+            "dtype": "bool",
+            "shape": [1, 3],
+        },
+        "normalized_state": {
+            "stage": "preprocess",
+            "role": "intermediate",
+            "dtype": "float32",
+            "shape": [1, 32],
+        },
+        "vision_tokens": {
+            "stage": "vision",
+            "role": "intermediate",
+            "dtype": "bfloat16",
+            "shape": [1, 3, 256, 2048],
+        },
+        "prefix_kv_cache": {
+            "stage": "prefix",
+            "role": "intermediate",
+            "dtype": "bfloat16",
+            "shape": [
+                int(prefix["layers"]),
+                2,
+                1,
+                int(prefix["max_physical_tokens"]),
+                int(prefix["kv_heads"]),
+                int(prefix["head_dim"]),
+            ],
+        },
+        "normalized_actions": {
+            "stage": "postprocess",
+            "role": "output",
+            "dtype": "float32",
+            "shape": flow_shape,
+        },
+        "physical_actions": {
+            "stage": "postprocess",
+            "role": "output",
+            "dtype": "float32",
+            "shape": [1, horizon, external_dim],
+        },
+    }
+    for step in range(11):
+        expected[f"flow_state_{step:02d}"] = {
+            "stage": "flow",
+            "role": "intermediate",
+            "dtype": "float32",
+            "shape": flow_shape,
+        }
+    for step in range(10):
+        expected[f"velocity_{step:02d}"] = {
+            "stage": "flow",
+            "role": "intermediate",
+            "dtype": "float32",
+            "shape": flow_shape,
+        }
+    return expected
+
+
+def _tensor_byte_length(dtype: str, shape: Sequence[int]) -> int:
+    try:
+        width = _DTYPE_BYTES[dtype]
+    except KeyError as error:
+        raise OpenPIQualificationError(f"Unsupported tensor dtype {dtype!r}") from error
+    elements = 1
+    for index, dimension in enumerate(shape):
+        elements *= _require_int(dimension, label=f"shape[{index}]", minimum=1)
+    return elements * width
+
+
+def _validate_tensor_descriptor(
+    name: str,
+    descriptor: Mapping[str, Any],
+    *,
+    artifact_root: Path,
+    verify_payloads: bool,
+) -> None:
+    _require_exact_keys(
+        descriptor,
+        {"path", "stage", "role", "dtype", "shape", "byte_length", "sha256"},
+        label=f"tensor {name!r}",
+    )
+    relative = _safe_relative_path(
+        descriptor["path"], label=f"tensor {name!r}.path", prefix="tensors"
+    )
+    shape = descriptor["shape"]
+    if not isinstance(shape, list) or not shape:
+        raise OpenPIQualificationError(f"tensor {name!r}.shape must be a non-empty array")
+    expected_bytes = _tensor_byte_length(str(descriptor["dtype"]), shape)
+    byte_length = _require_int(
+        descriptor["byte_length"], label=f"tensor {name!r}.byte_length", minimum=1
+    )
+    if byte_length != expected_bytes:
+        raise OpenPIQualificationError(
+            f"tensor {name!r} byte length {byte_length} does not match dtype/shape {expected_bytes}"
+        )
+    expected_sha = _require_sha256(descriptor["sha256"], label=f"tensor {name!r}.sha256")
+    if not verify_payloads:
+        return
+
+    payload = _resolve_relative_file(
+        artifact_root,
+        relative,
+        label=f"tensor {name!r} payload",
+    )
+    if payload.stat().st_size != byte_length:
+        raise OpenPIQualificationError(
+            f"tensor {name!r} payload size does not match its descriptor"
+        )
+    if sha256_file(payload) != expected_sha:
+        raise OpenPIQualificationError(f"tensor {name!r} payload SHA-256 mismatch")
+
+
+def validate_reference_artifact(
+    artifact_path: str | Path,
+    *,
+    verify_payloads: bool = True,
+) -> dict[str, Any]:
+    path = Path(artifact_path)
+    artifact = strict_json_load(path)
+    _require_exact_keys(
+        artifact,
+        {
+            "schema_version",
+            "artifact_type",
+            "profile_name",
+            "contract_sha256",
+            "upstream",
+            "case",
+            "fixed_external_noise",
+            "tensors",
+        },
+        optional={"exporter"},
+        label="OpenPI reference artifact",
+    )
+    if (
+        artifact["schema_version"] != SCHEMA_VERSION
+        or artifact["artifact_type"] != "openpi_pinned_reference"
+    ):
+        raise OpenPIQualificationError("Not an OpenPI pinned reference artifact v1")
+
+    profile = str(artifact["profile_name"])
+    contract = load_contract(profile)
+    contract_path = _CONTRACTS[profile]
+    if artifact["contract_sha256"] != sha256_file(contract_path):
+        raise OpenPIQualificationError(
+            "Reference artifact is not bound to the current profile contract"
+        )
+
+    upstream = _object(artifact["upstream"], label="reference upstream")
+    _require_exact_keys(
+        upstream,
+        {"repository", "commit", "checkpoint", "tokenizer", "normalization"},
+        label="reference upstream",
+    )
+    if upstream["repository"] != UPSTREAM_REPOSITORY or upstream["commit"] != UPSTREAM_COMMIT:
+        raise OpenPIQualificationError("Reference artifact does not use the pinned OpenPI source")
+    for asset_name in ("checkpoint", "tokenizer", "normalization"):
+        asset = _object(upstream[asset_name], label=f"upstream.{asset_name}")
+        _require_exact_keys(asset, {"uri", "sha256"}, label=f"upstream.{asset_name}")
+        if not isinstance(asset["uri"], str) or not asset["uri"]:
+            raise OpenPIQualificationError(f"upstream.{asset_name}.uri must be non-empty")
+        _require_sha256(asset["sha256"], label=f"upstream.{asset_name}.sha256")
+    checkpoint = _object(upstream["checkpoint"], label="upstream.checkpoint")
+    if (
+        checkpoint["uri"]
+        != _object(contract["upstream"], label="contract upstream")["checkpoint_uri"]
+    ):
+        raise OpenPIQualificationError(
+            "Reference checkpoint URI does not match the profile contract"
+        )
+
+    case = _object(artifact["case"], label="reference case")
+    _require_exact_keys(case, {"id", "prompt"}, optional={"description"}, label="reference case")
+    if not isinstance(case["id"], str) or not case["id"]:
+        raise OpenPIQualificationError("Reference case id must be non-empty")
+    if not isinstance(case["prompt"], str):
+        raise OpenPIQualificationError("Reference prompt must be a string")
+
+    if artifact["fixed_external_noise"] != {
+        "tensor": "initial_noise",
+        "provided_by_caller": True,
+        "rng_backend": "external",
+    }:
+        raise OpenPIQualificationError("Reference artifact must use caller-supplied initial_noise")
+
+    tensors = _object(artifact["tensors"], label="reference tensors")
+    expected_tensors = _expected_tensor_contract(contract)
+    missing = sorted(set(expected_tensors) - set(tensors))
+    if missing:
+        raise OpenPIQualificationError(
+            f"Reference artifact is missing stagewise tensors: {missing}"
+        )
+    paths: set[str] = set()
+    for name, descriptor_value in tensors.items():
+        if not isinstance(name, str) or not name:
+            raise OpenPIQualificationError("Reference tensor names must be non-empty strings")
+        descriptor = _object(descriptor_value, label=f"tensor {name!r}")
+        _validate_tensor_descriptor(
+            name,
+            descriptor,
+            artifact_root=path.parent,
+            verify_payloads=verify_payloads,
+        )
+        descriptor_path = str(descriptor["path"])
+        if descriptor_path in paths:
+            raise OpenPIQualificationError(f"Reference tensor path {descriptor_path!r} is reused")
+        paths.add(descriptor_path)
+        expected = expected_tensors.get(name)
+        if expected is not None:
+            for field in ("stage", "role", "dtype", "shape"):
+                if descriptor[field] != expected[field]:
+                    raise OpenPIQualificationError(
+                        f"tensor {name!r}.{field}={descriptor[field]!r}; "
+                        f"expected {expected[field]!r}"
+                    )
+    return artifact
+
+
+def materialize_reference_artifact(
+    capture_spec_path: str | Path,
+    output_dir: str | Path,
+) -> Path:
+    """Copy a complete upstream capture into a hashed replay artifact."""
+
+    spec_path = Path(capture_spec_path)
+    spec = strict_json_load(spec_path)
+    _require_exact_keys(
+        spec,
+        {"schema_version", "artifact_type", "profile_name", "upstream", "case", "tensors"},
+        optional={"exporter"},
+        label="OpenPI capture specification",
+    )
+    if spec["schema_version"] != SCHEMA_VERSION or (
+        spec["artifact_type"] != "openpi_reference_capture_spec"
+    ):
+        raise OpenPIQualificationError("Capture specification must declare OpenPI schema v1")
+    profile = str(spec["profile_name"])
+    contract = load_contract(profile)
+    expected = _expected_tensor_contract(contract)
+    tensors = _object(spec["tensors"], label="capture tensors")
+    missing = sorted(set(expected) - set(tensors))
+    if missing:
+        raise OpenPIQualificationError(f"Capture is missing stagewise tensors: {missing}")
+
+    destination = Path(output_dir)
+    if destination.exists() and (not destination.is_dir() or any(destination.iterdir())):
+        raise OpenPIQualificationError(f"Reference output directory is not empty: {destination}")
+    tensor_dir = destination / "tensors"
+    tensor_dir.mkdir(parents=True, exist_ok=True)
+
+    output_tensors: dict[str, Any] = {}
+    safe_name_chars = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-")
+    for name in sorted(tensors):
+        if not isinstance(name, str) or not name or not set(name) <= safe_name_chars:
+            raise OpenPIQualificationError(f"Capture tensor name is unsafe: {name!r}")
+        capture = _object(tensors[name], label=f"capture tensor {name!r}")
+        _require_exact_keys(
+            capture,
+            {"source", "stage", "role", "dtype", "shape"},
+            label=f"capture tensor {name!r}",
+        )
+        source_text = capture["source"]
+        if not isinstance(source_text, str) or not source_text:
+            raise OpenPIQualificationError(f"Capture tensor {name!r}.source must be non-empty")
+        source = Path(source_text)
+        if not source.is_absolute():
+            source = spec_path.parent / source
+        if not source.is_file():
+            raise OpenPIQualificationError(f"Capture tensor {name!r} is missing: {source}")
+        shape = capture["shape"]
+        if not isinstance(shape, list) or not shape:
+            raise OpenPIQualificationError(
+                f"Capture tensor {name!r}.shape must be a non-empty array"
+            )
+        expected_bytes = _tensor_byte_length(str(capture["dtype"]), shape)
+        if source.stat().st_size != expected_bytes:
+            raise OpenPIQualificationError(
+                f"Capture tensor {name!r} has {source.stat().st_size} bytes; "
+                f"expected {expected_bytes}"
+            )
+        target = tensor_dir / f"{name}.bin"
+        shutil.copyfile(source, target)
+        output_tensors[name] = {
+            "path": f"tensors/{name}.bin",
+            "stage": capture["stage"],
+            "role": capture["role"],
+            "dtype": capture["dtype"],
+            "shape": shape,
+            "byte_length": expected_bytes,
+            "sha256": sha256_file(target),
+        }
+
+    artifact: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_type": "openpi_pinned_reference",
+        "profile_name": profile,
+        "contract_sha256": sha256_file(_CONTRACTS[profile]),
+        "upstream": spec["upstream"],
+        "case": spec["case"],
+        "fixed_external_noise": {
+            "tensor": "initial_noise",
+            "provided_by_caller": True,
+            "rng_backend": "external",
+        },
+        "tensors": output_tensors,
+    }
+    if "exporter" in spec:
+        artifact["exporter"] = spec["exporter"]
+    artifact_path = destination / "artifact.json"
+    artifact_path.write_text(
+        json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    try:
+        validate_reference_artifact(artifact_path)
+    except Exception:
+        artifact_path.unlink(missing_ok=True)
+        raise
+    return artifact_path
+
+
+def materialize_reference_set(
+    artifact_paths: Sequence[str | Path],
+    output_path: str | Path,
+) -> Path:
+    """Create a content-addressed index over independently replayable cases."""
+
+    target = Path(output_path)
+    if target.exists():
+        raise OpenPIQualificationError(f"Reference-set output already exists: {target}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    root = target.parent.resolve(strict=True)
+    entries: list[dict[str, Any]] = []
+    profile: str | None = None
+    seen_ids: set[str] = set()
+    for artifact_value in artifact_paths:
+        artifact_path = Path(artifact_value).resolve(strict=True)
+        if root not in artifact_path.parents:
+            raise OpenPIQualificationError(
+                f"Reference case must be stored beneath the set directory: {artifact_path}"
+            )
+        artifact = validate_reference_artifact(artifact_path)
+        artifact_profile = str(artifact["profile_name"])
+        if profile is None:
+            profile = artifact_profile
+        elif profile != artifact_profile:
+            raise OpenPIQualificationError("A reference set cannot mix OpenPI profiles")
+        case_id = str(_object(artifact["case"], label="reference case")["id"])
+        if case_id in seen_ids:
+            raise OpenPIQualificationError(f"Duplicate reference case id {case_id!r}")
+        seen_ids.add(case_id)
+        entries.append(
+            {
+                "id": case_id,
+                "path": artifact_path.relative_to(root).as_posix(),
+                "sha256": sha256_file(artifact_path),
+            }
+        )
+    if profile is None:
+        raise OpenPIQualificationError("Reference set requires at least one case artifact")
+    entries.sort(key=lambda item: item["id"])
+    document = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_type": "openpi_pinned_reference_set",
+        "profile_name": profile,
+        "contract_sha256": sha256_file(_CONTRACTS[profile]),
+        "case_count": len(entries),
+        "cases": entries,
+    }
+    target.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    try:
+        validate_reference_set(target)
+    except Exception:
+        target.unlink(missing_ok=True)
+        raise
+    return target
+
+
+def validate_reference_set(
+    set_path: str | Path,
+    *,
+    verify_payloads: bool = True,
+    minimum_cases: int = 1,
+) -> dict[str, Any]:
+    path = Path(set_path)
+    document = strict_json_load(path)
+    _require_exact_keys(
+        document,
+        {
+            "schema_version",
+            "artifact_type",
+            "profile_name",
+            "contract_sha256",
+            "case_count",
+            "cases",
+        },
+        label="OpenPI reference set",
+    )
+    if document["schema_version"] != SCHEMA_VERSION or (
+        document["artifact_type"] != "openpi_pinned_reference_set"
+    ):
+        raise OpenPIQualificationError("Not an OpenPI pinned reference set v1")
+    profile = str(document["profile_name"])
+    load_contract(profile)
+    if document["contract_sha256"] != sha256_file(_CONTRACTS[profile]):
+        raise OpenPIQualificationError("Reference set is not bound to the current profile contract")
+    cases = document["cases"]
+    if not isinstance(cases, list):
+        raise OpenPIQualificationError("Reference set cases must be an array")
+    case_count = _require_int(document["case_count"], label="reference set case_count", minimum=1)
+    required_count = _require_int(minimum_cases, label="minimum_cases", minimum=1)
+    if case_count != len(cases):
+        raise OpenPIQualificationError("Reference set case_count does not match its case array")
+    if case_count < required_count:
+        raise OpenPIQualificationError(
+            f"Reference set contains {case_count} cases; qualification requires {required_count}"
+        )
+
+    root = path.parent.resolve(strict=True)
+    seen_ids: set[str] = set()
+    seen_paths: set[str] = set()
+    for index, entry_value in enumerate(cases):
+        entry = _object(entry_value, label=f"reference set cases[{index}]")
+        _require_exact_keys(entry, {"id", "path", "sha256"}, label=f"reference set cases[{index}]")
+        case_id = entry["id"]
+        if not isinstance(case_id, str) or not case_id or case_id in seen_ids:
+            raise OpenPIQualificationError(f"Invalid or duplicate reference case id {case_id!r}")
+        relative = _safe_relative_path(entry["path"], label=f"reference set cases[{index}].path")
+        relative_text = relative.as_posix()
+        if relative_text in seen_paths:
+            raise OpenPIQualificationError(
+                f"Unsafe or duplicate reference case path {relative_text!r}"
+            )
+        logical_artifact_path = root.joinpath(*relative.parts)
+        artifact_path = _resolve_relative_file(
+            root,
+            relative,
+            label=f"Reference case artifact {relative_text}",
+        )
+        expected_sha = _require_sha256(
+            entry["sha256"], label=f"reference set cases[{index}].sha256"
+        )
+        if sha256_file(artifact_path) != expected_sha:
+            raise OpenPIQualificationError(f"Reference case SHA-256 mismatch: {relative_text}")
+        artifact = validate_reference_artifact(
+            logical_artifact_path,
+            verify_payloads=verify_payloads,
+        )
+        artifact_case = _object(artifact["case"], label="reference case")
+        if artifact["profile_name"] != profile or artifact_case["id"] != case_id:
+            raise OpenPIQualificationError(f"Reference case metadata mismatch: {relative_text}")
+        seen_ids.add(case_id)
+        seen_paths.add(relative_text)
+    return document

--- a/tests/e2e/models/openpi/runner.py
+++ b/tests/e2e/models/openpi/runner.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-owned E2E entrypoint helpers for OpenPI."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+from tests.e2e_harness.model_runner import (
+    model_names_for_dir,
+    run_model_e2e as run_model_manifest_e2e,
+)
+
+from tests.e2e.models.openpi.e2e_plugins.runtime_dependencies import (
+    audit_openpi_runtime_dependencies,
+)
+
+_MODEL_DIR = Path(__file__).resolve().parent
+_PROJECT_DIR = _MODEL_DIR.parents[3]
+
+
+def _resolve_binary(config) -> str:
+    value = config.getoption("--trtmc-binary", default=None)
+    if value:
+        return str(Path(value).absolute())
+    default = _PROJECT_DIR / "build" / "trtmc"
+    return str(default) if default.is_file() else ""
+
+
+def _resolve_hf_python(config) -> str:
+    value = config.getoption("--hf-python", default=None)
+    if value:
+        return str(Path(value).absolute())
+    venv = _PROJECT_DIR / ".venv" / "bin" / "python"
+    return str(venv) if venv.is_file() else sys.executable
+
+
+def _resolve_engine_dir(config) -> str:
+    value = config.getoption("--engine-dir", default=None)
+    directory = Path(value) if value else Path("/mnt/storage/tensorrt-model-connect/engines")
+    directory.mkdir(parents=True, exist_ok=True)
+    return str(directory)
+
+
+def _resolve_model_plugin_dir(config) -> str:
+    value = config.getoption("--model-plugin-dir", default=None)
+    return str(Path(value).absolute()) if value else ""
+
+
+def _resolve_artifacts_dir(config) -> str:
+    value = config.getoption("--e2e-artifacts-dir", default=None)
+    return str(Path(value)) if value else str(Path("/tmp/e2e_artifacts") / _MODEL_DIR.name)
+
+
+@contextmanager
+def _model_plugin_dir_env(path: str):
+    previous = os.environ.get("TRTMC_MODEL_PLUGIN_DIR")
+    if path:
+        os.environ["TRTMC_MODEL_PLUGIN_DIR"] = path
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("TRTMC_MODEL_PLUGIN_DIR", None)
+        else:
+            os.environ["TRTMC_MODEL_PLUGIN_DIR"] = previous
+
+
+def _resolve_ld_library_path() -> str:
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import importlib.util; s=importlib.util.find_spec('tensorrt_libs'); "
+                "print(s.submodule_search_locations[0] if s else '')",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        trt_lib_dir = result.stdout.strip()
+    except Exception:
+        trt_lib_dir = ""
+    parts = [
+        os.environ.get("TRTMC_NCCL_LIB_DIR", ""),
+        trt_lib_dir,
+        "/usr/local/cuda/lib64",
+        os.environ.get("LD_LIBRARY_PATH", ""),
+    ]
+    return ":".join(part for part in parts if part)
+
+
+def _load_waives(platform: str = "") -> dict[str, tuple[str, str]]:
+    del platform
+    return {}
+
+
+def _is_multi_device_case(case) -> bool:
+    return str((case.metadata or {}).get("ci_tier", "")) == "multi_device"
+
+
+def _case_matches_e2e_model(case, filters: set[str]) -> bool:
+    if not filters:
+        return True
+    metadata = case.metadata or {}
+    fields = {
+        case.name,
+        case.family,
+        case.runtime_strategy,
+        case.task_strategy,
+        Path(case.hf_id).name if case.hf_id else "",
+        str(metadata.get("family", "")),
+        str(metadata.get("runtime_strategy", "")),
+    }
+    return bool(filters & {field for field in fields if field})
+
+
+def model_case_names(config=None) -> list[str]:
+    return model_names_for_dir(
+        config=config,
+        model_dir=_MODEL_DIR,
+        case_matches_model=_case_matches_e2e_model,
+        is_multi_device_case=_is_multi_device_case,
+    )
+
+
+def run_model_e2e(case_name: str, request) -> None:
+    run_model_manifest_e2e(
+        model_name=case_name,
+        request=request,
+        model_dir=_MODEL_DIR,
+        load_waives=_load_waives,
+        case_matches_model=_case_matches_e2e_model,
+        is_multi_device_case=_is_multi_device_case,
+        resolve_hf_python=_resolve_hf_python,
+        resolve_artifacts_dir=_resolve_artifacts_dir,
+        resolve_binary=_resolve_binary,
+        resolve_ld_library_path=_resolve_ld_library_path,
+        resolve_engine_dir=_resolve_engine_dir,
+        resolve_model_plugin_dir=_resolve_model_plugin_dir,
+        model_plugin_dir_env=_model_plugin_dir_env,
+    )
+
+    build_dir = Path(_resolve_binary(request.config)).parent
+    plugin_root_value = _resolve_model_plugin_dir(request.config)
+    plugin_root = Path(plugin_root_value) if plugin_root_value else None
+    model_library = (
+        plugin_root / "openpi" / "libtrtmc_model_openpi.so"
+        if plugin_root is not None
+        else build_dir / "models" / "openpi" / "libtrtmc_model_openpi.so"
+    )
+    library_path = ":".join(
+        part
+        for part in (
+            str(build_dir),
+            str(model_library.parent),
+            _resolve_ld_library_path(),
+        )
+        if part
+    )
+    evidence = audit_openpi_runtime_dependencies(
+        runner=build_dir / "trtmc-openpi",
+        core=build_dir / "libtrtmc_core.so",
+        tensorrt_backend=build_dir / "libtrtmc_backend_trt.so",
+        openpi_model=model_library,
+        ld_library_path=library_path,
+    )
+    evidence_path = Path(_resolve_artifacts_dir(request.config)) / case_name
+    evidence_path.mkdir(parents=True, exist_ok=True)
+    (evidence_path / "runtime-dependencies.json").write_text(
+        json.dumps(evidence, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )

--- a/tests/e2e/models/openpi/test_openpi_benchmark.py
+++ b/tests/e2e/models/openpi/test_openpi_benchmark.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-owned coverage for the generic OpenPI benchmark seam."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tensorrt_model_connect.benchmark.catalog import ManifestCatalog, resolve_case
+from tensorrt_model_connect.benchmark.metrics import reduce_metrics
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+ADAPTER_SOURCE = REPOSITORY_ROOT / "src/runtime/models/openpi/benchmark_worker_adapter.h"
+WORKER_SOURCE = REPOSITORY_ROOT / "examples/trtmc_benchmark_worker.cpp"
+
+
+def test_openpi_manifest_resolves_to_a_deterministic_benchmark_request(
+    tmp_path: Path,
+) -> None:
+    bundle = tmp_path / "pi05-droid.trtfb"
+    bundle.write_bytes(b"bundle")
+    case = resolve_case(ManifestCatalog().resolve("pi05-droid"), bundle)
+
+    assert case.operation == "predict_actions"
+    assert case.request == {
+        "batch_size": 1,
+        "prompt": "pick up the object",
+        "seed": 42,
+    }
+    assert case.sources["request.prompt"] == "operation default"
+    assert case.sources["request.seed"] == "model testcase"
+
+
+def test_openpi_benchmark_adapter_owns_constant_synthetic_inputs() -> None:
+    adapter = ADAPTER_SOURCE.read_text(encoding="utf-8")
+    worker = WORKER_SOURCE.read_text(encoding="utf-8")
+
+    assert "input.state.assign(8U, 0.0F);" in adapter
+    assert "input.initial_noise.assign(15U * 32U, 0.0F);" in adapter
+    assert "camera.pixels.assign(kPixelsPerCamera, camera.valid ? 0.5F : 0.0F);" in adapter
+    assert "dynamic_cast<IOpenPIActionPipeline*>(&pipeline)" in adapter
+    assert "ActionRequest input;" not in worker
+    assert '{"predict_actions", run_predict_actions}' in worker
+
+
+def test_openpi_benchmark_metrics_report_policy_rate_and_stages() -> None:
+    metrics = reduce_metrics(
+        "predict_actions",
+        [
+            {
+                "runtime_e2e_wall_ms": 20.0,
+                "action_chunks": 1,
+                "action_steps": 15,
+                "preprocess_ms": 1.0,
+                "prefill_ms": 2.0,
+                "denoise_ms": 15.0,
+                "postprocess_ms": 1.0,
+            }
+        ],
+    )
+
+    assert metrics["action_chunks_per_s"] == pytest.approx(50.0)
+    assert metrics["action_steps_per_s"] == pytest.approx(750.0)
+    assert metrics["reported_stages_ms"]["denoise_ms"]["p50"] == 15.0

--- a/tests/e2e/models/openpi/test_openpi_contracts.py
+++ b/tests/e2e/models/openpi/test_openpi_contracts.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structural tests for the immutable OpenPI model-owned contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.models.openpi.qualification import (
+    UPSTREAM_COMMIT,
+    load_contract,
+    load_thresholds,
+)
+from tests.e2e_harness.manifest_loader import load_model_manifest
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+@pytest.mark.parametrize(
+    ("profile", "horizon", "output_dim", "discrete_state"),
+    [
+        ("pi05_droid", 15, 8, True),
+    ],
+)
+def test_openpi_profile_contract_matches_pinned_upstream(
+    profile: str,
+    horizon: int,
+    output_dim: int,
+    discrete_state: bool,
+) -> None:
+    contract = load_contract(profile)
+
+    assert contract["upstream"]["commit"] == UPSTREAM_COMMIT
+    assert contract["images"]["order"] == [
+        "base_0_rgb",
+        "left_wrist_0_rgb",
+        "right_wrist_0_rgb",
+    ]
+    assert contract["images"]["validity"] == [True, True, False]
+    assert contract["prompt"]["discrete_state_input"] is discrete_state
+    assert contract["actions"] == {
+        "horizon": horizon,
+        "external_dim": output_dim,
+        "internal_dim": 32,
+        "normalization": "quantile_q01_q99",
+    }
+    assert contract["prefix"]["max_physical_tokens"] == 968
+    assert contract["prefix"]["kv_heads"] == 1
+    assert contract["prefix"]["head_dim"] == 256
+    assert contract["flow"]["steps"] == 10
+    assert contract["flow"]["external_noise_required_for_parity"] is True
+    assert contract["runtime"]["onnx_allowed"] is False
+    assert contract["runtime"]["python_allowed"] is False
+    assert contract["runtime"]["additional_frameworks_allowed"] is False
+
+
+@pytest.mark.parametrize(
+    ("manifest_name", "profile", "horizon", "output_dim"),
+    [
+        ("pi05-droid.json", "pi05_droid", 15, 8),
+    ],
+)
+def test_openpi_e2e_manifest_preserves_action_contract(
+    manifest_name: str,
+    profile: str,
+    horizon: int,
+    output_dim: int,
+) -> None:
+    model = load_model_manifest(ROOT / "manifests" / manifest_name)
+    assert len(model.testcases) == 1
+    case = model.testcases[0]
+
+    assert case.family == "openpi"
+    assert case.runtime_strategy == "openpi_vla"
+    assert case.task_strategy == "robot_action_generation"
+    assert case.user_contract == "robot_action_chunk"
+    assert case.reference_backend == "upstream_replay"
+    assert case.oracle_level == "L1_external_reference"
+    assert case.inputs["profile"] == profile
+    assert case.inputs["action_horizon"] == horizon
+    assert case.inputs["output_action_dim"] == output_dim
+    assert case.inputs["internal_action_dim"] == 32
+    assert case.inputs["fixed_external_noise"] is True
+    assert case.determinism == {"seed": 42, "reruns": 100}
+    assert [stage.name for stage in case.stages] == [
+        "preprocess",
+        "vision",
+        "prefix",
+        "flow",
+        "actions",
+    ]
+    assert all(stage.required for stage in case.stages)
+
+
+@pytest.mark.parametrize("profile", ["pi05_droid"])
+def test_openpi_thresholds_cannot_weaken_high_accuracy_gates(profile: str) -> None:
+    thresholds = load_thresholds(profile)
+
+    assert thresholds["normalized_action_cosine_min"] >= 0.9995
+    assert thresholds["normalized_action_mae_max"] <= 0.003
+    assert thresholds["normalized_action_p99_abs_max"] <= 0.01
+    assert thresholds["normalized_action_max_abs_max"] <= 0.02
+    assert thresholds["native_latency_p50_ms_max"] <= 50.0
+    assert thresholds["native_latency_p95_ms_max"] <= 60.0
+    assert thresholds["torch_eager_speedup_p50_min"] >= 5.0
+    assert thresholds["torch_eager_speedup_p95_min"] >= 5.0

--- a/tests/e2e/models/openpi/test_openpi_e2e.py
+++ b/tests/e2e/models/openpi/test_openpi_e2e.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-owned E2E entrypoint for the OpenPI family."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_RUNNER_PATH = Path(__file__).with_name("runner.py")
+_SPEC = importlib.util.spec_from_file_location("openpi_e2e_runner", _RUNNER_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_runner = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_runner)
+
+
+def pytest_generate_tests(metafunc):
+    if "case_name" in metafunc.fixturenames:
+        case_names = _runner.model_case_names(metafunc.config)
+        if not case_names:
+            pytest.skip("No OpenPI manifests selected", allow_module_level=True)
+        metafunc.parametrize("case_name", case_names)
+
+
+def test_model_e2e(case_name: str, request) -> None:
+    _runner.run_model_e2e(case_name, request)

--- a/tests/e2e/models/openpi/test_openpi_html_report.py
+++ b/tests/e2e/models/openpi/test_openpi_html_report.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenPI ownership tests for its HTML trajectory visualization."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def _report_module():
+    scripts = str(Path(__file__).resolve().parents[4] / "scripts")
+    if scripts not in sys.path:
+        sys.path.insert(0, scripts)
+    return importlib.import_module("generate_e2e_report")
+
+
+def test_openpi_actions_render_as_a_tensor_rt_reference_svg() -> None:
+    report = _report_module()
+    result = {
+        "case_name": "pi05-droid",
+        "status": "pass",
+        "oracle_level": "L1_external_reference",
+        "case_config": {
+            "family": "openpi",
+            "task_strategy": "robot_action_generation",
+            "reference_backend": "upstream_replay",
+            "inputs": {"horizon": 2},
+        },
+        "stages": {},
+        "stage_outputs": {
+            "trt_actions": {"data": {"output_field": [[0.1, -0.2], [0.3, -0.4]]}},
+            "ref_actions": {"data": {"output_field": [[0.11, -0.19], [0.31, -0.39]]}},
+        },
+        "repro_commands": {},
+        "timing": {},
+    }
+
+    rendered = report.render_model_section(result, project_dir=None)
+
+    assert report.classify_modality(result) == "neural_operator"
+    assert "Output Series Comparison" in rendered
+    assert 'aria-label="TRT and reference numeric output plot"' in rendered
+    assert "TRT / Base" in rendered
+    assert "Reference" in rendered
+    assert report.validate_evidence([result], project_dir=None) == []
+
+    result["stage_outputs"]["trt_actions"]["data"].pop("output_field")
+    issues = report.validate_evidence([result], project_dir=None)
+    assert len(issues) == 1
+    assert "missing numeric TRT/base field output" in issues[0]

--- a/tests/e2e/models/openpi/test_openpi_performance.py
+++ b/tests/e2e/models/openpi/test_openpi_performance.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused contracts for OpenPI's model-owned performance receipt."""
+
+from __future__ import annotations
+
+import copy
+import json
+import tomllib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tests.e2e.models.openpi import e2e_plugins
+from tests.e2e.models.openpi.e2e_plugins import performance
+
+
+def _baseline_document() -> dict:
+    return {
+        "schema_version": 1,
+        "artifact_type": "openpi_baseline_performance_measurement",
+        "backend": "pytorch_eager",
+        "profile_name": "pi05_droid",
+        "iterations": 1000,
+        "warmups": 100,
+        "latency_samples_ms": list(range(1, 1001)),
+        "first_request_ms": 1.0,
+        "determinism": {},
+        "hardware": {
+            "gpu_name": "NVIDIA GB300",
+            "tensorrt_version": "11.2.0.113",
+        },
+        "workload": copy.deepcopy(performance._EXPECTED_WORKLOAD),
+        "provenance": {
+            "upstream_repository": "https://github.com/Physical-Intelligence/openpi.git",
+            "upstream_commit": "15a9616a00943ada6c20a0f158e3adb39df2ccac",
+            "environment": {
+                "effective_compile_mode": None,
+                "forbidden_compiler_environment_names": [],
+                "torch_compile_guard": {
+                    "enforcement": "raise_on_invocation",
+                    "invocation_count": 0,
+                    "scope": "policy_construction_and_measurement",
+                },
+            },
+        },
+    }
+
+
+def _case() -> SimpleNamespace:
+    return SimpleNamespace(
+        inputs={
+            "profile": "pi05_droid",
+            "reference_case_id": "droid_iris_20231204154425_f000005",
+            "action_horizon": 15,
+            "internal_action_dim": 32,
+            "flow_steps": 10,
+            "fixed_external_noise": True,
+        },
+        metadata={
+            "performance_qualification": {
+                "native_backend": "tensorrt_cpp",
+                "baseline_backend": "pytorch_eager",
+                "baseline_artifact": "performance/pytorch-eager.json",
+                "baseline_sha256": performance.TORCH_EAGER_SHA256,
+                "iterations": 1000,
+                "warmups": 100,
+            }
+        },
+    )
+
+
+def _stderr(*, mean: float = 40.0, p50: float = 40.0, p95: float = 50.0) -> str:
+    return (
+        "TensorRT runtime detail\n"
+        "[trtmc.openpi.benchmark] "
+        f"action_ms={mean:.6f} p50_ms={p50:.6f} p95_ms={p95:.6f} "
+        "iterations=1000 warmup=100\n"
+    )
+
+
+def test_torch_eager_validator_recomputes_nearest_rank_summary() -> None:
+    summary = performance.validate_torch_eager_document(_baseline_document())
+
+    assert summary["backend"] == "pytorch_eager"
+    assert summary["latency_ms"] == {
+        "mean_ms": 500.5,
+        "p50_ms": 500.0,
+        "p95_ms": 950.0,
+    }
+    assert summary["effective_compile_mode"] is None
+    assert summary["torch_compile_guard_invocation_count"] == 0
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("effective_compile_mode", "max-autotune"),
+        ("forbidden_compiler_environment_names", ["TORCH_COMPILE"]),
+        (
+            "torch_compile_guard",
+            {
+                "enforcement": "log_only",
+                "invocation_count": 0,
+                "scope": "policy_construction_and_measurement",
+            },
+        ),
+        (
+            "torch_compile_guard",
+            {
+                "enforcement": "raise_on_invocation",
+                "invocation_count": 1,
+                "scope": "policy_construction_and_measurement",
+            },
+        ),
+    ],
+)
+def test_torch_eager_validator_rejects_compiler_provenance(field: str, value: object) -> None:
+    document = _baseline_document()
+    document["provenance"]["environment"][field] = value
+
+    with pytest.raises(ValueError, match="Torch Eager baseline"):
+        performance.validate_torch_eager_document(document)
+
+
+def test_torch_eager_validator_rejects_stale_workload_and_nonfinite_samples() -> None:
+    stale = _baseline_document()
+    stale["workload"]["case_id"] = "other-case"
+    with pytest.raises(ValueError, match="workload is stale or mismatched"):
+        performance.validate_torch_eager_document(stale)
+
+    malformed = _baseline_document()
+    malformed["latency_samples_ms"][4] = float("nan")
+    with pytest.raises(ValueError, match="finite and positive"):
+        performance.validate_torch_eager_document(malformed)
+
+
+def test_case_validator_requires_every_pinned_workload_field() -> None:
+    baseline = performance.validate_torch_eager_document(_baseline_document())
+    performance.validate_case(_case(), baseline)
+
+    for field in (
+        "profile",
+        "reference_case_id",
+        "action_horizon",
+        "internal_action_dim",
+        "flow_steps",
+        "fixed_external_noise",
+    ):
+        case = _case()
+        del case.inputs[field]
+        with pytest.raises(ValueError, match=rf"{field} differs"):
+            performance.validate_case(case, baseline)
+
+    case = _case()
+    case.metadata.clear()
+    with pytest.raises(ValueError, match="qualification declaration"):
+        performance.validate_case(case, baseline)
+
+
+def test_baseline_loader_rejects_an_unpinned_artifact(monkeypatch, tmp_path: Path) -> None:
+    artifact = tmp_path / "performance" / "pytorch-eager.json"
+    artifact.parent.mkdir()
+    artifact.write_text(json.dumps(_baseline_document()), encoding="utf-8")
+    monkeypatch.setattr(
+        performance,
+        "openpi_proof_path",
+        lambda *parts: tmp_path.joinpath(*parts),
+    )
+
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        performance.load_torch_eager_baseline()
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        _stderr() + _stderr(),
+        _stderr() + "[trtmc.openpi.benchmark] malformed\n",
+        _stderr().replace("iterations=1000", "iterations=999"),
+        _stderr().replace("p95_ms=50.000000", "p95_ms=nan"),
+        _stderr().replace(" warmup=100", "  warmup=100"),
+        _stderr() + " " + _stderr().splitlines()[1] + "\n",
+        _stderr(p50=51.0, p95=50.0),
+    ],
+)
+def test_native_benchmark_parser_rejects_duplicate_malformed_or_stale_lines(
+    stderr: str,
+) -> None:
+    with pytest.raises(ValueError, match="benchmark"):
+        performance.parse_native_benchmark(stderr)
+
+
+def test_native_benchmark_parser_records_backend_and_exact_counts() -> None:
+    summary = performance.parse_native_benchmark(_stderr())
+
+    assert summary == {
+        "backend": "tensorrt_cpp",
+        "runtime": "trtmc-openpi",
+        "runtime_contract": "native_cpp_tensorrt",
+        "iterations": 1000,
+        "warmups": 100,
+        "latency_ms": {
+            "mean_ms": 40.0,
+            "p50_ms": 40.0,
+            "p95_ms": 50.0,
+        },
+    }
+
+
+def test_persisted_receipt_is_revalidated_against_stderr_and_baseline(monkeypatch) -> None:
+    baseline = performance.validate_torch_eager_document(_baseline_document())
+    monkeypatch.setattr(performance, "load_torch_eager_baseline", lambda: baseline)
+    receipt = performance.build_receipt(_stderr(), _case())
+
+    native, loaded_baseline = performance.validate_receipt(receipt)
+    assert native["latency_ms"]["p50_ms"] == 40.0
+    assert loaded_baseline == baseline
+
+    receipt["native"]["latency_ms"]["p50_ms"] = 41.0
+    with pytest.raises(ValueError, match="differs from its stderr"):
+        performance.validate_receipt(receipt)
+
+
+def test_manifest_uses_one_pinned_hf_snapshot_for_all_proof_inputs() -> None:
+    model_config = tomllib.loads(Path(__file__).with_name("MODEL.toml").read_text(encoding="utf-8"))
+    manifest = json.loads(
+        (Path(__file__).with_name("manifests") / "pi05-droid.json").read_text(encoding="utf-8")
+    )
+
+    assert "model_artifact_cache" not in model_config
+    assert manifest["hf_id"] == e2e_plugins.OPENPI_SNAPSHOT_REPO_ID
+    assert manifest["hf_revision"] == e2e_plugins.OPENPI_SNAPSHOT_REVISION
+    declaration = manifest["testcases"][0]["metadata"]["performance_qualification"]
+    assert declaration["baseline_artifact"] == "performance/pytorch-eager.json"
+    assert declaration["baseline_sha256"] == performance.TORCH_EAGER_SHA256

--- a/tests/e2e/models/openpi/test_openpi_platform_contract.py
+++ b/tests/e2e/models/openpi/test_openpi_platform_contract.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail-closed checks for the qualified OpenPI deployment platform."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODEL_CMAKE = REPO_ROOT / "src" / "runtime" / "models" / "openpi" / "model.cmake"
+MODEL_OPTIONS = MODEL_CMAKE.with_name("model_options.cmake")
+
+
+def test_native_runtime_build_fails_closed_outside_qualified_platform() -> None:
+    cmake = MODEL_CMAKE.read_text(encoding="utf-8")
+
+    assert 'CMAKE_SYSTEM_NAME STREQUAL "Linux"' in cmake
+    assert 'CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64"' in cmake
+    assert "NV_TENSORRT_MAJOR" in cmake
+    assert "NV_TENSORRT_MINOR" in cmake
+    assert "NV_TENSORRT_PATCH" in cmake
+    assert "NV_TENSORRT_BUILD" in cmake
+    assert 'STREQUAL "11.2.0.113"' in cmake
+    assert "TRTMC_OPENPI_REQUIRE_QUALIFIED_RUNTIME AND NOT" in cmake
+    assert "FATAL_ERROR" in cmake
+
+
+def test_openpi_plugin_targets_only_qualified_gb300_architecture() -> None:
+    cmake = MODEL_CMAKE.read_text(encoding="utf-8")
+
+    assert 'TRTMC_OPENPI_CUDA_ARCHITECTURES "103"' in cmake
+    assert "must be exactly '103'" in cmake
+    assert "80-real" not in cmake
+
+
+def test_model_proof_disables_non_native_core_dependencies() -> None:
+    root_cmake = (REPO_ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+    options = MODEL_OPTIONS.read_text(encoding="utf-8")
+
+    assert '"${PROJECT_SOURCE_DIR}/src/runtime/models/*/model_options.cmake"' in root_cmake
+    assert 'if(TRTMC_MODEL_PROOF_MODEL STREQUAL "openpi")' in options
+    assert "set(TRTMC_ENABLE_LIBTORCH_MULTINOMIAL OFF CACHE BOOL" in options
+    assert "set(TRTMC_ENABLE_TVM_FFI OFF CACHE BOOL" in options

--- a/tests/e2e/models/openpi/test_openpi_plugin_governance.py
+++ b/tests/e2e/models/openpi/test_openpi_plugin_governance.py
@@ -1,0 +1,727 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused governance tests for the OpenPI E2E plugins."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import struct
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+
+from tests.e2e.models.openpi import e2e_plugins
+from tests.e2e.models.openpi.e2e_plugins import performance
+from tests.e2e.models.openpi.e2e_plugins.comparators.robot_action import (
+    RobotActionGenerationComparator,
+)
+from tests.e2e.models.openpi.e2e_plugins.references import upstream_replay
+from tests.e2e.models.openpi.e2e_plugins.runners import robot_action
+from tests.e2e_harness.contracts import (
+    E2ECase,
+    RunContext,
+    StageOutput,
+    StageSpec,
+    ThresholdProfile,
+)
+from tests.e2e_harness.registry import (
+    activate_model_plugins,
+    get_comparator,
+    get_reference,
+    get_runner,
+    reset,
+)
+
+
+def _case(tmp_path: Path) -> E2ECase:
+    request = tmp_path / "request.json"
+    request.write_text(
+        json.dumps(
+            {
+                "prompt": "pick up the block",
+                "cameras": {
+                    "base_0_rgb": {"path": "base.ppm", "valid": True},
+                    "left_wrist_0_rgb": {"path": "wrist.ppm", "valid": True},
+                    "right_wrist_0_rgb": {"path": "missing.ppm", "valid": False},
+                },
+                "state": [0.0, 0.1],
+                "initial_noise": [0.0, 0.0, 0.0, 0.0],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return E2ECase(
+        name="openpi-unit",
+        hf_id=e2e_plugins.OPENPI_SNAPSHOT_REPO_ID,
+        family="openpi",
+        runtime_strategy="openpi_vla",
+        task_strategy="robot_action_generation",
+        reference_backend="upstream_replay",
+        bundle="pi05-droid.trtfb",
+        inputs={
+            "request_json": str(request),
+            "profile": "pi05_droid",
+            "reference_case_id": "droid_iris_20231204154425_f000005",
+            "action_horizon": 15,
+            "internal_action_dim": 32,
+            "flow_steps": 10,
+            "fixed_external_noise": True,
+            "action_spans": [2.0, 4.0],
+        },
+        metadata={
+            "performance_qualification": {
+                "native_backend": "tensorrt_cpp",
+                "baseline_backend": "pytorch_eager",
+                "baseline_artifact": "performance/pytorch-eager.json",
+                "baseline_sha256": performance.TORCH_EAGER_SHA256,
+                "iterations": 1000,
+                "warmups": 100,
+            }
+        },
+    )
+
+
+def _context(case: E2ECase, tmp_path: Path) -> RunContext:
+    return RunContext(
+        case=case,
+        binary_path="/opt/trtmc/bin/trtmc",
+        engine_dir=str(tmp_path / "engines"),
+        artifacts_dir=str(tmp_path / "artifacts"),
+    )
+
+
+def _threshold() -> ThresholdProfile:
+    return ThresholdProfile(
+        task_strategy="robot_action_generation",
+        metrics={
+            "normalized_action_cosine_min": 0.9995,
+            "normalized_action_mae_max": 0.003,
+            "normalized_action_p99_abs_max": 0.01,
+            "normalized_action_max_abs_max": 0.02,
+            "physical_action_p99_span_fraction_max": 0.01,
+            "stage_velocity_cosine_min": 0.9995,
+            "stage_velocity_rmse_max": 0.005,
+            "stage_velocity_max_abs_max": 0.05,
+            "image_uint8_max_lsb": 1.0,
+            "normalization_max_abs": 1e-6,
+            "native_latency_p50_ms_max": 50.0,
+            "native_latency_p95_ms_max": 60.0,
+            "torch_eager_speedup_p50_min": 5.0,
+            "torch_eager_speedup_p95_min": 5.0,
+        },
+    )
+
+
+def _baseline_summary() -> dict:
+    return {
+        "artifact_sha256": performance.TORCH_EAGER_SHA256,
+        "backend": "pytorch_eager",
+        "profile_name": "pi05_droid",
+        "iterations": 1000,
+        "warmups": 100,
+        "latency_ms": {
+            "mean_ms": 385.0395223489992,
+            "p50_ms": 384.67197,
+            "p95_ms": 430.593005,
+        },
+        "effective_compile_mode": None,
+        "torch_compile_guard_invocation_count": 0,
+        "upstream_commit": "15a9616a00943ada6c20a0f158e3adb39df2ccac",
+        "hardware": {
+            "gpu_name": "NVIDIA GB300",
+            "tensorrt_version": "11.2.0.113",
+        },
+        "workload": dict(performance._EXPECTED_WORKLOAD),
+    }
+
+
+def _performance_receipt(
+    *,
+    mean_ms: float = 40.0,
+    p50_ms: float = 40.0,
+    p95_ms: float = 50.0,
+) -> dict:
+    stderr = (
+        "[trtmc.openpi.benchmark] "
+        f"action_ms={mean_ms:.6f} p50_ms={p50_ms:.6f} p95_ms={p95_ms:.6f} "
+        "iterations=1000 warmup=100\n"
+    )
+    return {
+        "schema_version": 1,
+        "artifact_type": "openpi_performance_receipt",
+        "native": performance.parse_native_benchmark(stderr),
+        "torch_eager": _baseline_summary(),
+        "native_stderr": stderr,
+    }
+
+
+def test_runner_invokes_native_act_and_parses_action_tensor(monkeypatch, tmp_path: Path) -> None:
+    case = _case(tmp_path)
+    context = _context(case, tmp_path)
+    invocation = 0
+    commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        nonlocal invocation
+        invocation += 1
+        commands.append(command)
+        assert kwargs["env"].get("PYTHONPATH") is None or isinstance(
+            kwargs["env"]["PYTHONPATH"], str
+        )
+        output_path = Path(command[command.index("--output-json") + 1])
+        output_path.write_text(
+            json.dumps(
+                {
+                    "actions": [[0.1, -0.2], [0.3, 0.4]],
+                    "horizon": 2,
+                    "action_dim": 2,
+                    "timings": {
+                        "preprocess_ms": 1.0,
+                        "prefill_ms": 2.0,
+                        "denoise_ms": 3.0 + invocation,
+                        "postprocess_ms": 0.5,
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(
+            returncode=0,
+            stdout=f"runtime log {invocation}",
+            stderr=(
+                f"runtime warning {invocation}\n"
+                "[trtmc.openpi.benchmark] action_ms=40.000000 p50_ms=40.000000 "
+                "p95_ms=50.000000 iterations=1000 warmup=100\n"
+                if "--benchmark" in command
+                else f"runtime warning {invocation}"
+            ),
+        )
+
+    monkeypatch.setattr(robot_action.subprocess, "run", fake_run)
+    monkeypatch.setattr(performance, "load_torch_eager_baseline", _baseline_summary)
+    runner = robot_action.RobotActionGenerationRunner()
+    output = runner.run_stage(case, StageSpec(name="actions"), context)
+    rerun = runner.run_stage(case, StageSpec(name="actions"), context)
+
+    command = output.metadata["command"]
+    assert command[:2] == [
+        "/opt/trtmc/bin/trtmc-openpi",
+        str(tmp_path / "engines" / "pi05-droid.trtfb"),
+    ]
+    assert command[2:4] == ["--request-json", str(tmp_path / "request.json")]
+    assert "--hf-python" not in command
+    assert output.data["actions"] == [[0.1, -0.2], [0.3, 0.4]]
+    assert output.data["horizon"] == 2
+    assert output.data["action_dim"] == 2
+    assert output.data["returncode"] == 0
+    assert "timings" not in output.data
+    assert "benchmark" not in output.data
+    assert "stdout" not in output.data
+    assert "stderr" not in output.data
+    assert output.data == rerun.data
+    assert invocation == 2
+    assert sum("--benchmark" in command for command in commands) == 1
+    assert output.metadata["command"][-4:] == ["--benchmark", "1000", "--warmup", "100"]
+    assert "--benchmark" not in rerun.metadata["command"]
+    assert output.metadata["runtime_timings"] != rerun.metadata["runtime_timings"]
+    assert output.metadata["performance"] == rerun.metadata["performance"]
+    assert output.metadata["runtime_stdout"] != rerun.metadata["runtime_stdout"]
+    assert output.metadata["runtime_stderr"] != rerun.metadata["runtime_stderr"]
+    assert output.metadata["runtime_contract"] == "native_cpp_tensorrt"
+
+    same_path_context = _context(case, tmp_path)
+    runner.run_stage(case, StageSpec(name="actions"), same_path_context)
+    other_context = _context(case, tmp_path)
+    other_context.artifacts_dir = str(tmp_path / "other-artifacts")
+    runner.run_stage(case, StageSpec(name="actions"), other_context)
+    renamed_case = deepcopy(case)
+    renamed_case.name = "openpi-other-run"
+    runner.run_stage(renamed_case, StageSpec(name="actions"), context)
+    assert invocation == 5
+    assert sum("--benchmark" in command for command in commands) == 4
+
+
+def test_runner_preserves_failed_process_diagnostics(monkeypatch, tmp_path: Path) -> None:
+    case = _case(tmp_path)
+    context = _context(case, tmp_path)
+    monkeypatch.setattr(
+        robot_action.subprocess,
+        "run",
+        lambda command, **kwargs: SimpleNamespace(
+            returncode=7,
+            stdout="partial output",
+            stderr="runtime failure",
+        ),
+    )
+
+    output = robot_action.RobotActionGenerationRunner().run_stage(
+        case, StageSpec(name="actions"), context
+    )
+
+    assert output.data == {
+        "returncode": 7,
+        "stdout": "partial output",
+        "stderr": "runtime failure",
+    }
+    assert output.metadata["returncode"] == 7
+
+
+def test_pinned_snapshot_resolver_is_offline_and_rejects_unsafe_paths(
+    monkeypatch, tmp_path: Path
+) -> None:
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    calls: list[dict[str, object]] = []
+
+    def fake_snapshot_download(**kwargs: object) -> str:
+        calls.append(kwargs)
+        return str(snapshot)
+
+    monkeypatch.setattr(e2e_plugins, "snapshot_download", fake_snapshot_download)
+    e2e_plugins.openpi_snapshot_root.cache_clear()
+
+    assert e2e_plugins.openpi_snapshot_path("request", "request.json") == (
+        snapshot / "request" / "request.json"
+    )
+    assert e2e_plugins.openpi_proof_path("request", "request.json") == (
+        snapshot / "trtmc_openpi" / "request" / "request.json"
+    )
+    assert e2e_plugins.openpi_snapshot_root() == snapshot
+    assert calls == [
+        {
+            "repo_id": e2e_plugins.OPENPI_SNAPSHOT_REPO_ID,
+            "revision": e2e_plugins.OPENPI_SNAPSHOT_REVISION,
+            "allow_patterns": list(e2e_plugins.OPENPI_SNAPSHOT_ALLOW_PATTERNS),
+            "local_files_only": True,
+        }
+    ]
+    for unsafe in ("../request.json", "/request.json"):
+        try:
+            e2e_plugins.openpi_snapshot_path(unsafe)
+        except ValueError as error:
+            assert "snapshot-relative" in str(error)
+        else:
+            raise AssertionError(f"unsafe snapshot path {unsafe!r} was accepted")
+    e2e_plugins.openpi_snapshot_root.cache_clear()
+
+
+def test_runner_request_falls_back_to_pinned_snapshot(monkeypatch, tmp_path: Path) -> None:
+    case = _case(tmp_path)
+    case.inputs.pop("request_json")
+    snapshot = tmp_path / "snapshot"
+    request = snapshot / "request" / "request.json"
+    request.parent.mkdir(parents=True)
+    request.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        robot_action,
+        "openpi_proof_path",
+        lambda *parts: snapshot.joinpath(*parts),
+    )
+
+    assert robot_action._resolve_request_path(case) == request
+
+    explicit = tmp_path / "explicit-request.json"
+    explicit.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("TRTMC_OPENPI_REQUEST_JSON", str(explicit))
+    assert robot_action._resolve_request_path(case) == explicit
+
+
+def test_runner_uses_one_native_capture_for_stagewise_outputs(monkeypatch, tmp_path: Path) -> None:
+    case = _case(tmp_path)
+    context = _context(case, tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        del kwargs
+        calls.append(command)
+        output_path = Path(command[command.index("--output-json") + 1])
+        output_path.write_text(
+            json.dumps(
+                {
+                    "actions": [[0.1, -0.2], [0.3, 0.4]],
+                    "horizon": 2,
+                    "action_dim": 2,
+                    "timings": {
+                        "preprocess_ms": 1.0,
+                        "prefill_ms": 2.0,
+                        "denoise_ms": 3.0,
+                        "postprocess_ms": 0.5,
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    descriptors = {
+        name: {
+            "path": str(tmp_path / f"{name}.bin"),
+            "dtype": "float32",
+            "shape": [1],
+            "byte_length": 4,
+            "sha256": "a" * 64,
+        }
+        for names in robot_action._STAGE_TENSORS.values()
+        for name in names
+    }
+    descriptors["normalized_actions"] = {
+        "path": str(tmp_path / "normalized_actions.bin"),
+        "dtype": "float32",
+        "shape": [1, 2, 2],
+        "byte_length": 16,
+        "sha256": "a" * 64,
+    }
+    monkeypatch.setattr(robot_action.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        robot_action, "_load_native_diagnostic_manifest", lambda path, profile: descriptors
+    )
+    runner = robot_action.RobotActionGenerationRunner()
+    preprocess = runner.run_stage(case, StageSpec(name="preprocess"), context)
+    vision = runner.run_stage(case, StageSpec(name="vision"), context)
+    action_output = StageOutput(stage_name="actions", data={})
+    runner._attach_normalized_actions(action_output, case, context)
+
+    assert len(calls) == 1
+    assert "--qualification-diagnostics" in calls[0]
+    assert set(preprocess.data["tensor_files"]) == set(robot_action._STAGE_TENSORS["preprocess"])
+    assert set(vision.data["tensor_files"]) == {"vision_tokens"}
+    assert set(action_output.data["tensor_files"]) == {"normalized_actions"}
+    assert preprocess.metadata["runtime_contract"] == "native_cpp_tensorrt"
+
+
+def test_native_capture_manifest_is_hash_and_contract_checked(monkeypatch, tmp_path: Path) -> None:
+    tensor_dir = tmp_path / "tensors"
+    tensor_dir.mkdir()
+    payload = tensor_dir / "token_ids.bin"
+    payload.write_bytes(struct.pack("<i", 7))
+    digest = hashlib.sha256(payload.read_bytes()).hexdigest()
+    contract = {
+        "token_ids": {
+            "stage": "preprocess",
+            "role": "intermediate",
+            "dtype": "int32",
+            "shape": [1],
+        }
+    }
+    manifest = {
+        "schema_version": 1,
+        "artifact_type": "trtmc_action_qualification_diagnostics",
+        "runtime_contract": "native_cpp_tensorrt",
+        "model_id": "openpi-test",
+        "tensors": {
+            "token_ids": {
+                "path": "tensors/token_ids.bin",
+                **contract["token_ids"],
+                "byte_length": 4,
+                "sha256": digest,
+            }
+        },
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.setattr(robot_action.qualification, "load_contract", lambda profile: {})
+    monkeypatch.setattr(
+        robot_action.qualification, "_expected_tensor_contract", lambda loaded: contract
+    )
+    descriptors = robot_action._load_native_diagnostic_manifest(manifest_path, "pi05_droid")
+    assert descriptors["token_ids"]["path"] == str(payload.resolve())
+
+    payload.write_bytes(struct.pack("<i", 8))
+    try:
+        robot_action._load_native_diagnostic_manifest(manifest_path, "pi05_droid")
+    except ValueError as error:
+        assert "SHA-256 mismatch" in str(error)
+    else:
+        raise AssertionError("modified native capture was accepted")
+
+
+def test_action_comparator_enforces_span_normalized_and_decision_gates(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(performance, "load_torch_eager_baseline", _baseline_summary)
+    comparator = RobotActionGenerationComparator()
+    reference = StageOutput(
+        stage_name="actions",
+        data={
+            "physical_actions": [[0.10, -0.20], [0.30, 0.40]],
+            "normalized_actions": [[0.10, -0.20], [0.30, 0.40]],
+            "horizon": 2,
+            "action_dim": 2,
+            "action_spans": [2.0, 4.0],
+            "decision_indices": [1],
+        },
+    )
+    close = StageOutput(
+        stage_name="actions",
+        data={
+            "actions": [[0.101, -0.199], [0.299, 0.401]],
+            "normalized_actions": [[0.101, -0.199], [0.299, 0.401]],
+            "horizon": 2,
+            "action_dim": 2,
+            "returncode": 0,
+        },
+        metadata={"performance": _performance_receipt()},
+    )
+    passed = comparator.compare(close, reference, _threshold(), StageSpec(name="actions"))
+    assert passed.status == "passed"
+    assert passed.metrics["physical_action_p99_span_fraction"].passed
+    assert passed.metrics["normalized_action_cosine"].passed
+    performance_metrics = {
+        "native_latency_p50_ms",
+        "native_latency_p95_ms",
+        "torch_eager_latency_p50_ms",
+        "torch_eager_latency_p95_ms",
+        "torch_eager_speedup_p50",
+        "torch_eager_speedup_p95",
+        "torch_compile_invocation_count",
+    }
+    assert performance_metrics <= set(passed.metrics)
+    assert passed.metrics["torch_eager_latency_p50_ms"].threshold is None
+    assert passed.metrics["torch_eager_latency_p95_ms"].threshold is None
+    for metric_name in (
+        "physical_action_cosine",
+        "physical_action_mae",
+        "physical_action_max_abs",
+    ):
+        assert passed.metrics[metric_name].threshold is None
+        assert passed.metrics[metric_name].operator == "info"
+
+    drifted = StageOutput(
+        stage_name="actions",
+        data={
+            "actions": [[0.20, 0.20], [0.30, 0.40]],
+            "normalized_actions": [[0.20, 0.20], [0.30, 0.40]],
+            "horizon": 2,
+            "action_dim": 2,
+            "returncode": 0,
+        },
+        metadata={"performance": _performance_receipt()},
+    )
+    failed = comparator.compare(drifted, reference, _threshold(), StageSpec(name="actions"))
+    assert failed.status == "failed"
+    assert not failed.metrics["physical_action_p99_span_fraction"].passed
+    assert not failed.metrics["sign_or_gripper_decision_changes"].passed
+
+    missing_normalized = deepcopy(close)
+    missing_normalized.data.pop("normalized_actions")
+    missing_result = comparator.compare(
+        missing_normalized, reference, _threshold(), StageSpec(name="actions")
+    )
+    assert missing_result.status == "error"
+    assert "normalized action parity evidence is required" in missing_result.message
+
+
+def test_action_comparator_enforces_all_performance_gates(monkeypatch) -> None:
+    baseline = _baseline_summary()
+    monkeypatch.setattr(performance, "load_torch_eager_baseline", lambda: baseline)
+    reference = StageOutput(
+        stage_name="actions",
+        data={
+            "physical_actions": [[0.1, -0.2], [0.3, 0.4]],
+            "normalized_actions": [[0.1, -0.2], [0.3, 0.4]],
+            "horizon": 2,
+            "action_dim": 2,
+            "action_spans": [2.0, 4.0],
+        },
+    )
+    actual = StageOutput(
+        stage_name="actions",
+        data={
+            "actions": [[0.1, -0.2], [0.3, 0.4]],
+            "normalized_actions": [[0.1, -0.2], [0.3, 0.4]],
+            "horizon": 2,
+            "action_dim": 2,
+            "returncode": 0,
+        },
+        metadata={"performance": _performance_receipt(p50_ms=80.0, p95_ms=90.0)},
+    )
+
+    result = RobotActionGenerationComparator().compare(
+        actual, reference, _threshold(), StageSpec(name="actions")
+    )
+    assert result.status == "failed"
+    for name in (
+        "native_latency_p50_ms",
+        "native_latency_p95_ms",
+        "torch_eager_speedup_p50",
+        "torch_eager_speedup_p95",
+    ):
+        assert not result.metrics[name].passed
+
+    compile_baseline = _baseline_summary()
+    compile_baseline["torch_compile_guard_invocation_count"] = 1
+    monkeypatch.setattr(performance, "load_torch_eager_baseline", lambda: compile_baseline)
+    actual.metadata["performance"]["torch_eager"] = compile_baseline
+    compile_result = RobotActionGenerationComparator().compare(
+        actual, reference, _threshold(), StageSpec(name="actions")
+    )
+    assert compile_result.status == "failed"
+    assert not compile_result.metrics["torch_compile_invocation_count"].passed
+
+    missing_threshold = _threshold()
+    missing_threshold.metrics.pop("torch_eager_speedup_p95_min")
+    missing_result = RobotActionGenerationComparator().compare(
+        actual, reference, missing_threshold, StageSpec(name="actions")
+    )
+    assert missing_result.status == "error"
+
+
+def test_preprocess_comparator_requires_exact_tokens_masks_and_noise() -> None:
+    comparator = RobotActionGenerationComparator()
+    reference = StageOutput(
+        stage_name="preprocess",
+        data={
+            "token_ids": [2, 10, 1, 0],
+            "token_mask": [1, 1, 1, 0],
+            "image_mask": [1, 1, 0],
+            "initial_noise": [0.25, -0.5],
+            "preprocessed_images": [-1.0, 0.0, 1.0],
+            "normalized_state": [0.1, -0.2],
+        },
+    )
+    actual = StageOutput(stage_name="preprocess", data=dict(reference.data))
+    passed = comparator.compare(actual, reference, _threshold(), StageSpec(name="preprocess"))
+    assert passed.status == "passed"
+
+    actual.data["token_ids"] = [2, 11, 1, 0]
+    failed = comparator.compare(actual, reference, _threshold(), StageSpec(name="preprocess"))
+    assert failed.status == "failed"
+    assert failed.metrics["token_mismatch_count"].value == 1.0
+
+
+def test_upstream_reference_requires_a_validated_512_case_set(monkeypatch, tmp_path: Path) -> None:
+    index = tmp_path / "reference-set.json"
+    index.write_text(json.dumps({"artifact_type": "openpi_pinned_reference_set"}), encoding="utf-8")
+    observed: dict[str, int] = {}
+
+    def fake_validate(path, *, verify_payloads=True, minimum_cases=1):
+        del path, verify_payloads
+        observed["minimum_cases"] = minimum_cases
+        return {"artifact_type": "openpi_pinned_reference_set", "cases": []}
+
+    upstream_replay._load_validated_document.cache_clear()
+    monkeypatch.setattr(upstream_replay.qualification, "validate_reference_set", fake_validate)
+    upstream_replay._load_validated_document(str(index))
+    assert observed["minimum_cases"] == 512
+
+
+def test_upstream_reference_and_norm_stats_fall_back_to_pinned_snapshot(
+    monkeypatch, tmp_path: Path
+) -> None:
+    case = _case(tmp_path)
+    case.inputs.pop("action_spans")
+    snapshot = tmp_path / "snapshot"
+    reference = snapshot / "reference" / "reference-set.json"
+    reference.parent.mkdir(parents=True)
+    reference.write_text("{}", encoding="utf-8")
+    normalization = snapshot / "preprocessor_config.json"
+    normalization.write_text(
+        json.dumps(
+            {
+                "norm_stats": {
+                    "actions": {
+                        "q01": [-1.0, -2.0],
+                        "q99": [1.0, 2.0],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (snapshot / "openpi_config.json").write_text(
+        json.dumps(
+            {
+                "profile": "pi05_droid",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        upstream_replay,
+        "openpi_snapshot_path",
+        lambda *parts: snapshot.joinpath(*parts),
+    )
+    monkeypatch.setattr(
+        upstream_replay,
+        "openpi_proof_path",
+        lambda *parts: snapshot.joinpath(*parts),
+    )
+
+    assert upstream_replay._replay_path(case) == reference
+    assert upstream_replay._load_action_spans(case, 2) == [2.0, 4.0]
+
+    explicit_reference = tmp_path / "explicit-reference.json"
+    explicit_reference.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("TRTMC_OPENPI_REFERENCE_ARTIFACT", str(explicit_reference))
+    assert upstream_replay._replay_path(case) == explicit_reference
+
+
+def test_upstream_reference_decodes_pinned_action_payload(monkeypatch, tmp_path: Path) -> None:
+    normalized_path = tmp_path / "normalized.bin"
+    physical_path = tmp_path / "physical.bin"
+    normalized_path.write_bytes(struct.pack("<4f", 0.1, -0.2, 0.3, 0.4))
+    physical_path.write_bytes(struct.pack("<4f", 1.0, -2.0, 3.0, 4.0))
+    artifact = {
+        "profile_name": "pi05_droid",
+        "case": {"id": "case-0001"},
+        "upstream": {"checkpoint": {"sha256": "a" * 64}},
+        "tensors": {
+            "normalized_actions": {
+                "path": normalized_path.name,
+                "dtype": "float32",
+                "shape": [1, 2, 2],
+                "sha256": "b" * 64,
+            },
+            "physical_actions": {
+                "path": physical_path.name,
+                "dtype": "float32",
+                "shape": [1, 2, 2],
+                "sha256": "c" * 64,
+            },
+        },
+    }
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        upstream_replay,
+        "_resolve_case_artifact",
+        lambda case: (artifact_path, artifact),
+    )
+    case = _case(tmp_path)
+    output = upstream_replay.UpstreamReplayReference().run_stage(
+        case, StageSpec(name="actions"), _context(case, tmp_path)
+    )
+    assert output.data["physical_actions"] == [[1.0, -2.0], [3.0, 4.0]]
+    assert output.data["action_spans"] == [2.0, 4.0]
+    assert output.metadata["upstream_commit"] == ("15a9616a00943ada6c20a0f158e3adb39df2ccac")
+
+
+def test_model_plugin_activation_resolves_all_openpi_protocols() -> None:
+    model_dir = Path(__file__).resolve().parent
+    try:
+        activate_model_plugins(model_dir)
+        assert type(get_runner("robot_action_generation")).__module__.startswith(
+            "tests.e2e.models.openpi.e2e_plugins"
+        )
+        assert type(get_reference("upstream_replay")).__module__.startswith(
+            "tests.e2e.models.openpi.e2e_plugins"
+        )
+        assert type(get_comparator("robot_action_generation")).__module__.startswith(
+            "tests.e2e.models.openpi.e2e_plugins"
+        )
+    finally:
+        reset()
+
+
+def test_runtime_strategy_matrix_declares_native_action_governance() -> None:
+    matrix_path = Path(__file__).resolve().parents[3] / "runtime_strategy_matrix.yaml"
+    matrix = json.loads(matrix_path.read_text(encoding="utf-8"))
+    entry = matrix["runtime_strategies"]["openpi_vla"]
+    assert entry["task_strategy"] == "robot_action_generation"
+    assert entry["cli_commands"] == ["trtmc-openpi"]
+    assert entry["performance_mode"] == "multi_stage"
+    assert entry["diff_framework_check_classes"] == []
+    assert "No diff_framework check currently registers" in entry["diff_framework_exemption"]
+    assert "openpi_vla" in matrix["new_runtime_guard_strategies"]

--- a/tests/e2e/models/openpi/test_openpi_reference_artifact.py
+++ b/tests/e2e/models/openpi/test_openpi_reference_artifact.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the fixed-noise, stagewise OpenPI reference artifact."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from tests.e2e.models.openpi import qualification
+
+
+def _asset(uri: str, digit: str) -> dict[str, str]:
+    return {"uri": uri, "sha256": digit * 64}
+
+
+def _capture_spec(tmp_path: Path, profile: str = "pi05_droid") -> Path:
+    contract = qualification.load_contract(profile)
+    tensors = {}
+    sources = tmp_path / "capture"
+    sources.mkdir()
+    for index, (name, expected) in enumerate(
+        qualification._expected_tensor_contract(contract).items(), start=1
+    ):
+        byte_length = qualification._tensor_byte_length(expected["dtype"], expected["shape"])
+        source = sources / f"{name}.bin"
+        with source.open("wb") as handle:
+            handle.seek(byte_length - 1)
+            handle.write(bytes([index % 251 + 1]))
+        tensors[name] = {"source": str(source), **expected}
+
+    spec = {
+        "schema_version": 1,
+        "artifact_type": "openpi_reference_capture_spec",
+        "profile_name": profile,
+        "upstream": {
+            "repository": qualification.UPSTREAM_REPOSITORY,
+            "commit": qualification.UPSTREAM_COMMIT,
+            "checkpoint": _asset(contract["upstream"]["checkpoint_uri"], "a"),
+            "tokenizer": _asset("openpi://paligemma_tokenizer.model", "b"),
+            "normalization": _asset(f"openpi://{profile}/norm_stats.json", "c"),
+        },
+        "case": {"id": "synthetic-qualification-case", "prompt": "pick up the block"},
+        "exporter": {"name": "openpi-jax-capture", "version": "pinned-test"},
+        "tensors": tensors,
+    }
+    path = tmp_path / "capture-spec.json"
+    path.write_text(json.dumps(spec), encoding="utf-8")
+    return path
+
+
+def test_reference_paths_accept_only_standard_hf_snapshot_symlinks(tmp_path: Path) -> None:
+    repo_cache = tmp_path / "models--NVIDIA--openpi"
+    blobs = repo_cache / "blobs"
+    snapshot = repo_cache / "snapshots" / ("a" * 40)
+    logical_root = snapshot / "trtmc_openpi" / "reference"
+    blobs.mkdir(parents=True)
+    logical_root.mkdir(parents=True)
+    blob = blobs / ("b" * 64)
+    blob.write_bytes(b"reference")
+    logical = logical_root / "reference.bin"
+    logical.symlink_to(os.path.relpath(blob, logical.parent))
+
+    assert (
+        qualification._resolve_relative_file(
+            logical_root,
+            PurePosixPath("reference.bin"),
+            label="reference",
+        )
+        == blob.resolve()
+    )
+
+    outside = tmp_path / "outside.bin"
+    outside.write_bytes(b"outside")
+    escaped = logical_root / "escaped.bin"
+    escaped.symlink_to(outside)
+    with pytest.raises(qualification.OpenPIQualificationError, match="escapes"):
+        qualification._resolve_relative_file(
+            logical_root,
+            PurePosixPath("escaped.bin"),
+            label="reference",
+        )
+
+
+def test_reference_generator_materializes_and_hashes_every_stage(tmp_path: Path) -> None:
+    artifact_path = qualification.materialize_reference_artifact(
+        _capture_spec(tmp_path), tmp_path / "artifact"
+    )
+    artifact = qualification.validate_reference_artifact(artifact_path)
+
+    assert artifact["fixed_external_noise"] == {
+        "tensor": "initial_noise",
+        "provided_by_caller": True,
+        "rng_backend": "external",
+    }
+    assert {f"velocity_{step:02d}" for step in range(10)} <= set(artifact["tensors"])
+    assert {f"flow_state_{step:02d}" for step in range(11)} <= set(artifact["tensors"])
+    assert artifact["tensors"]["normalized_actions"]["shape"] == [1, 15, 32]
+    assert artifact["tensors"]["physical_actions"]["shape"] == [1, 15, 8]
+
+
+def test_reference_validator_rejects_generated_noise_claim(tmp_path: Path) -> None:
+    artifact_path = qualification.materialize_reference_artifact(
+        _capture_spec(tmp_path), tmp_path / "artifact"
+    )
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    artifact["fixed_external_noise"]["provided_by_caller"] = False
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    with pytest.raises(qualification.OpenPIQualificationError, match="caller-supplied"):
+        qualification.validate_reference_artifact(artifact_path)
+
+
+def test_reference_validator_rejects_missing_intermediate_flow_step(tmp_path: Path) -> None:
+    artifact_path = qualification.materialize_reference_artifact(
+        _capture_spec(tmp_path), tmp_path / "artifact"
+    )
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    del artifact["tensors"]["velocity_06"]
+    artifact_path.write_text(json.dumps(artifact), encoding="utf-8")
+
+    with pytest.raises(qualification.OpenPIQualificationError, match="missing stagewise tensors"):
+        qualification.validate_reference_artifact(artifact_path, verify_payloads=False)
+
+
+def test_reference_validator_rejects_payload_hash_mismatch(tmp_path: Path) -> None:
+    artifact_path = qualification.materialize_reference_artifact(
+        _capture_spec(tmp_path), tmp_path / "artifact"
+    )
+    noise_path = artifact_path.parent / "tensors" / "initial_noise.bin"
+    with noise_path.open("r+b") as handle:
+        handle.seek(0)
+        handle.write(b"X")
+
+    with pytest.raises(qualification.OpenPIQualificationError, match="SHA-256 mismatch"):
+        qualification.validate_reference_artifact(artifact_path)
+
+
+def test_reference_generator_rejects_incomplete_capture_before_publishing(tmp_path: Path) -> None:
+    spec_path = _capture_spec(tmp_path)
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    del spec["tensors"]["initial_noise"]
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+
+    with pytest.raises(qualification.OpenPIQualificationError, match="missing stagewise tensors"):
+        qualification.materialize_reference_artifact(spec_path, tmp_path / "artifact")
+
+
+def test_reference_set_binds_independent_case_artifacts(tmp_path: Path) -> None:
+    corpus = tmp_path / "corpus"
+    artifact_path = qualification.materialize_reference_artifact(
+        _capture_spec(tmp_path), corpus / "case-0000"
+    )
+    index_path = qualification.materialize_reference_set(
+        [artifact_path], corpus / "reference-set.json"
+    )
+
+    reference_set = qualification.validate_reference_set(index_path)
+    assert reference_set["profile_name"] == "pi05_droid"
+    assert reference_set["case_count"] == 1
+    assert reference_set["cases"][0]["id"] == "synthetic-qualification-case"
+    with pytest.raises(qualification.OpenPIQualificationError, match="requires 512"):
+        qualification.validate_reference_set(index_path, minimum_cases=512)
+
+
+def test_reference_set_rejects_duplicate_case_identity(tmp_path: Path) -> None:
+    corpus = tmp_path / "corpus"
+    artifact_path = qualification.materialize_reference_artifact(
+        _capture_spec(tmp_path), corpus / "case-0000"
+    )
+
+    with pytest.raises(qualification.OpenPIQualificationError, match="Duplicate reference case id"):
+        qualification.materialize_reference_set(
+            [artifact_path, artifact_path], corpus / "reference-set.json"
+        )

--- a/tests/e2e/models/openpi/test_openpi_runtime_dependencies.py
+++ b/tests/e2e/models/openpi/test_openpi_runtime_dependencies.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for OpenPI's model-owned runtime dependency proof."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from .e2e_plugins import runtime_dependencies as audit
+
+
+_NAMES = (
+    "trtmc-openpi",
+    "libtrtmc_core.so",
+    "libtrtmc_backend_trt.so",
+    "libtrtmc_model_openpi.so",
+)
+_DIRECT = {
+    "trtmc-openpi": ("libtrtmc_core.so", "libstdc++.so.6", "libc.so.6"),
+    "libtrtmc_core.so": (
+        "libcudart.so.13",
+        "libcublas.so.13",
+        "libdl.so.2",
+        "libstdc++.so.6",
+    ),
+    "libtrtmc_backend_trt.so": (
+        "libtrtmc_core.so",
+        "libnvinfer.so.11",
+        "libcudart.so.13",
+    ),
+    "libtrtmc_model_openpi.so": (
+        "libtrtmc_core.so",
+        "libnvinfer.so.11",
+        "libcublas.so.13",
+        "libcudart.so.13",
+    ),
+}
+
+
+def _artifacts(tmp_path: Path) -> dict[str, Path]:
+    paths = [tmp_path / name for name in _NAMES]
+    for index, path in enumerate(paths):
+        path.write_bytes(f"artifact-{index}".encode())
+    return dict(zip(("runner", "core", "tensorrt_backend", "openpi_model"), paths, strict=True))
+
+
+def _fake_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    injected_dependency: str | None = None,
+    model_direct: tuple[str, ...] | None = None,
+) -> list[dict[str, object]]:
+    calls: list[dict[str, object]] = []
+
+    def run(command: list[str], **kwargs: object) -> SimpleNamespace:
+        calls.append({"command": command, **kwargs})
+        name = Path(command[-1]).name
+        dependencies = (
+            model_direct
+            if name == "libtrtmc_model_openpi.so" and model_direct is not None
+            else _DIRECT[name]
+        )
+        if command[0] == "readelf":
+            output = "\n".join(
+                f" 0x0000000000000001 (NEEDED) Shared library: [{dependency}]"
+                for dependency in dependencies
+            )
+        else:
+            closure = list(dependencies) + ["linux-vdso.so.1", "libgcc_s.so.1"]
+            if injected_dependency is not None and name == "libtrtmc_model_openpi.so":
+                closure.append(injected_dependency)
+            output = "\n".join(
+                f"{dependency} => /runtime/{dependency} (0x0000000000010000)"
+                for dependency in closure
+            )
+        return SimpleNamespace(returncode=0, stdout=output, stderr="")
+
+    monkeypatch.setattr(audit.subprocess, "run", run)
+    return calls
+
+
+def test_runtime_dependency_proof_returns_small_serializable_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifacts = _artifacts(tmp_path)
+    calls = _fake_subprocess(monkeypatch)
+    library_dirs = (tmp_path, tmp_path / "models" / "openpi")
+
+    result = audit.audit_openpi_runtime_dependencies(**artifacts, ld_library_path=library_dirs)
+
+    json.dumps(result)
+    assert result["runtime_contract"] == "native_cpp_tensorrt_only"
+    assert [entry["name"] for entry in result["artifacts"]] == list(_NAMES)
+    for entry, path in zip(result["artifacts"], artifacts.values(), strict=True):
+        assert entry["sha256"] == hashlib.sha256(path.read_bytes()).hexdigest()
+        assert entry["direct_dependencies"]
+        assert entry["dependencies"]
+    assert len(calls) == 8
+    expected_library_path = ":".join(str(path) for path in library_dirs)
+    assert all(call["env"]["LD_LIBRARY_PATH"] == expected_library_path for call in calls)
+
+
+@pytest.mark.parametrize(
+    "dependency",
+    (
+        "libnvonnxparser.so.11",
+        "libonnxruntime.so.1",
+        "libpython3.12.so.1.0",
+        "libtorch.so",
+        "libtvm_ffi.so",
+        "libjax_runtime.so",
+        "libtensorflow.so.2",
+        "libopencv_core.so.4",
+        "libprotobuf.so.32",
+        "libsentencepiece.so.0",
+    ),
+)
+def test_runtime_dependency_proof_rejects_forbidden_frameworks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, dependency: str
+) -> None:
+    artifacts = _artifacts(tmp_path)
+    _fake_subprocess(monkeypatch, injected_dependency=dependency)
+
+    with pytest.raises(audit.OpenPIRuntimeDependencyError, match="forbidden transitive"):
+        audit.audit_openpi_runtime_dependencies(**artifacts, ld_library_path=tmp_path)
+
+
+def test_runtime_dependency_proof_rejects_unknown_library(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifacts = _artifacts(tmp_path)
+    _fake_subprocess(monkeypatch, injected_dependency="libmystery.so.1")
+
+    with pytest.raises(audit.OpenPIRuntimeDependencyError, match="unknown transitive"):
+        audit.audit_openpi_runtime_dependencies(**artifacts, ld_library_path=tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("model_direct", "message"),
+    (
+        (
+            ("libtrtmc_core.so", "libcublas.so.13", "libcudart.so.13"),
+            "directly depend on libnvinfer",
+        ),
+        (
+            ("libtrtmc_core.so", "libnvinfer.so.11", "libcudart.so.13"),
+            "directly depend on libcublas",
+        ),
+    ),
+)
+def test_runtime_dependency_proof_requires_direct_model_links(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    model_direct: tuple[str, ...],
+    message: str,
+) -> None:
+    artifacts = _artifacts(tmp_path)
+    _fake_subprocess(monkeypatch, model_direct=model_direct)
+
+    with pytest.raises(audit.OpenPIRuntimeDependencyError, match=message):
+        audit.audit_openpi_runtime_dependencies(**artifacts, ld_library_path=tmp_path)

--- a/tests/e2e/models/openpi/thresholds/pi05-droid.json
+++ b/tests/e2e/models/openpi/thresholds/pi05-droid.json
@@ -1,0 +1,18 @@
+{
+  "threshold_overrides": {
+    "image_uint8_max_lsb": 1,
+    "normalization_max_abs": 1e-6,
+    "stage_velocity_cosine_min": 0.9995,
+    "stage_velocity_rmse_max": 0.005,
+    "stage_velocity_max_abs_max": 0.05,
+    "normalized_action_cosine_min": 0.9995,
+    "normalized_action_mae_max": 0.003,
+    "normalized_action_p99_abs_max": 0.01,
+    "normalized_action_max_abs_max": 0.02,
+    "physical_action_p99_span_fraction_max": 0.01,
+    "native_latency_p50_ms_max": 50.0,
+    "native_latency_p95_ms_max": 60.0,
+    "torch_eager_speedup_p50_min": 5.0,
+    "torch_eager_speedup_p95_min": 5.0
+  }
+}

--- a/tests/runtime_strategy_matrix.yaml
+++ b/tests/runtime_strategy_matrix.yaml
@@ -63,7 +63,8 @@
     "patchtsmixer_trt",
     "timesfm_trt",
     "chronos_bolt_trt",
-    "diffusion_wan2_2_ti2v"
+    "diffusion_wan2_2_ti2v",
+    "openpi_vla"
   ],
   "runtime_strategies": {
     "qwen_decoder_kv_cache": {
@@ -1100,6 +1101,17 @@
       "diff_framework_check_classes": [],
       "diff_framework_exemption": "No diff_framework check currently registers runtime_strategies=['torchtrt_diffusion'].",
       "performance_mode": "diffusion"
+    },
+    "openpi_vla": {
+      "task_strategy": "robot_action_generation",
+      "cli_commands": [
+        "trtmc-openpi"
+      ],
+      "runner_class": "robot_action.RobotActionGenerationRunner",
+      "comparator_class": "robot_action.RobotActionGenerationComparator",
+      "diff_framework_check_classes": [],
+      "diff_framework_exemption": "No diff_framework check currently registers runtime_strategies=['openpi_vla']; pinned 512-case stagewise and action parity is enforced by the OpenPI model-owned E2E plugins and qualification artifacts.",
+      "performance_mode": "multi_stage"
     }
   }
 }

--- a/tests/tools/test_family_specialization.py
+++ b/tests/tools/test_family_specialization.py
@@ -318,4 +318,4 @@ def test_repository_registers_all_current_families() -> None:
 
     families = specialization.family_dirs(repo_root, ())
 
-    assert len(families) == 78
+    assert len(families) == 79

--- a/tests/tools/test_optimized_runtime_packaging.py
+++ b/tests/tools/test_optimized_runtime_packaging.py
@@ -96,6 +96,7 @@ def _load_conan_recipe(monkeypatch: pytest.MonkeyPatch):
 def _fake_native_build(build: Path) -> None:
     for relative in (
         "trtmc",
+        "trtmc-example",
         "trtmc_benchmark_worker",
         "libtrtmc_core.so",
         "libtrtmc_backend_trt.so",
@@ -183,9 +184,13 @@ def test_package_stages_a_model_owned_adapter_as_inert_source(
     assert (sdk / "runtime" / "providers" / "optimized_runtime_factory.h").is_file()
     assert (sdk / "trtmc" / "pipeline.h").is_file()
     assert (module / "bin" / "trtmc").is_file()
+    assert (module / "bin" / "trtmc-example").is_file()
     assert (module / "bin" / "trtmc_benchmark_worker").is_file()
     benchmark_script = module.parent / "tensorrt_model_connect-0.1.0.data/scripts/trtmc-bench"
     assert benchmark_script.read_bytes().startswith(b"#!python\n")
+    model_script = module.parent / "tensorrt_model_connect-0.1.0.data/scripts/trtmc-example"
+    assert model_script.is_file()
+    assert model_script.stat().st_mode & 0o111
     catalog = module / "benchmark" / "_catalog" / "example"
     assert (catalog / "MODEL.toml").is_file()
     assert (catalog / "manifests" / "example.json").is_file()

--- a/tests/tools/test_trtmc_bench.py
+++ b/tests/tools/test_trtmc_bench.py
@@ -148,6 +148,7 @@ def test_catalog_reuses_existing_model_manifests_for_different_tasks(tmp_path: P
         "flux-schnell-l0": ("generate_image", 1, 5),
         "chronos-bolt-tiny-official": ("solve", 50, 500),
         "nemotron-embed-vl-1b-v2": ("embed", 50, 500),
+        "pi05-droid": ("predict_actions", 5, 50),
         "whisper-tiny-fp16": ("transcribe", 1, 10),
     }
     for model_name, expected in expectations.items():
@@ -172,6 +173,7 @@ def test_operation_registry_declares_supported_task_semantics() -> None:
         "encode",
         "embed",
         "solve",
+        "predict_actions",
         "transcribe",
     }
     assert {name: adapter.operation for name, adapter in adapters.items()} == {
@@ -190,6 +192,7 @@ def test_operation_registry_declares_supported_task_semantics() -> None:
         "encoder_only_nlp": "encode",
         "embedding": "embed",
         "neural_operator": "solve",
+        "robot_action_generation": "predict_actions",
         "speech_to_text": "transcribe",
     }
     assert operations["generate_image"].supports_batch is True

--- a/tools/legal_header_exceptions.toml
+++ b/tools/legal_header_exceptions.toml
@@ -28,8 +28,8 @@ sha256 = "dfedfff91c3de652969fc0a5919ada367c2f3709f435c6c0275044b2c39d9f2e"
 path = "tests/runtime_strategy_matrix.yaml"
 reason = "JSON-formatted test data is consumed by strict JSON parsers; comments would change parse behavior."
 license = "Apache-2.0"
-source = "https://github.com/NVIDIA/TensorRT-Model-Connect/blob/7b1ac26bb2193296274acfc67c03ad04dac149a8/tests/runtime_strategy_matrix.yaml"
-sha256 = "eba2d7c5a5e32b9ae07fcc0ad5b04538d35c85bd8a0d017ee9e2fb9d863c6224"
+source = "https://github.com/NVIDIA/TensorRT-Model-Connect/blob/9a1063879fe63592fe19f5c99e8a20666d51f020/tests/runtime_strategy_matrix.yaml"
+sha256 = "404477acb4499a663d22d9d1224f1e81d2cd7c7b479ff8bdd088bfe3519d2a21"
 
 [[exceptions]]
 path = "tests/e2e/models/bark/data/timing_cache/bark-small-gb300-trt11.2-cuda13.3-fp16.cache"


### PR DESCRIPTION
## Background

Add a focused Model Connect implementation of Physical Intelligence OpenPI pi0.5 for the DROID policy. The builder constructs TensorRT networks directly from the pinned prepared checkpoint, and deployment uses only TensorRT, CUDA, and Model Connect C++.

Unmodified Torch Eager is the sole performance baseline. ONNX, Torch Max-AutoTune, `torch.compile`, Python in the deployed runtime, and third-party inference runtimes are out of scope.

## Exit Criteria

- Build the pinned pi0.5 DROID policy directly with the TensorRT API, without ONNX.
- Match pinned upstream preprocess, vision, prefix, flow, and physical-action evidence at the declared thresholds.
- Meet native p50/p95 and speedup gates against the pinned Torch Eager receipt.
- Prove the deployed ELF closure contains no Python, Torch, JAX, TVM, ONNX, or other third-party inference runtime.
- Render TRT/C++ and reference action trajectories as an inline SVG in the HTML report and fail closed when numeric evidence is missing.
- Keep model-specific implementation and tests OpenPI-owned, with only the smallest repository integration seams.

## Minimality Boundary

The KISS diff is one commit directly on current `main`: 94 paths, `+23,909/-7`.

- 83 OpenPI-owned paths: `+23,822/-0`, under the OpenPI builder, runtime, and test ownership roots.
- 11 shared paths: `+87/-7`, limited to CMake/package discovery, OpenPI benchmark dispatch, a small HTML modality mapping, and existing governance tests/data.
- Compared with the pre-KISS snapshot, this removes 26 paths and 4,377 added lines while restoring unrelated shared-service machinery to `main`.
- The final pass removed another 534 lines of dead builder helpers, test-only numeric references, duplicated E2E utilities, and a redundant model README/self-sync test.
- No CI or workflow files are changed. Six unrelated untracked report files are excluded from this PR.

Removing any remaining shared seam would break build discovery, wheel packaging, the repository benchmark catalog invariant, numeric HTML visualization, or runtime-strategy governance. The shared benchmark worker has an eight-line conditional OpenPI adapter include/registration diff; replacing it with a generic registry would add a larger shared abstraction.

## Implementation

- Add OpenPI-owned checkpoint validation and conversion, tokenizer flattening, weight mapping, PaliGemma prefill construction, and action-expert TensorRT construction.
- Add a native C++ request/data plane, tokenizer, preprocessing, prefix state, flow denoising, action de-normalization, and dedicated `trtmc-openpi` runner.
- Compile all six OpenPI TensorRT CUDA plugins directly into `libtrtmc_model_openpi.so`; there is no ONNX path or companion model DSO.
- Qualify the native runtime only for Linux/aarch64 NVIDIA GB300 (`sm_103`) with TensorRT 11.2.0.113.
- Add model-owned pinned-reference comparison, Torch Eager performance gates, determinism checks, runtime dependency auditing, benchmark coverage, and HTML visualization coverage.

## Exact-Head Local Validation

Head: `cd552d58afd77958c659a8617cddd0d43b16034e`.

- OpenPI builder/E2E contract plus shared-seam Python suites: `466 passed`.
- Fresh exact-head Release build: 62 C++/CUDA steps passed with libtorch and TVM-FFI disabled.
- Fresh exact-head OpenPI native C++ build/tests: 73 build steps and `5/5` tests passed.
- Bundle: 6,644,898,498 bytes, SHA-256 `bd23eb1090ed0a9c75e9609555ede80b6c63affbd43db20eda62244631613f04`.
- Build timing: 706.15 s main TensorRT engine, 24.87 s action engine, 750.09 s total.
- Standalone action-step engine: pinned 512-case reference set passed `512/512` with zero mismatches.
- Full five-stage E2E: passed in 4,731.07 s against the pinned external reference.
- Physical actions: cosine `0.9999999999999932`, MAE `2.79e-8`, max absolute error `8.94e-8`, and zero sign/gripper decision changes.
- Native benchmark: p50 `38.259452 ms`, p95 `38.805541 ms`.
- Pinned Torch Eager baseline: p50 `384.671970 ms`, p95 `430.593005 ms`; native speedups `10.05x` and `11.10x`; `torch.compile` invocation count `0`.
- Determinism: 100/100 matched records for all five stages; the action stage is 100 fresh native C++ runtime invocations.
- Runtime dependency audit: `native_cpp_tensorrt_only`; the four audited ELF artifacts have no Python, Torch/JAX, ONNX/ORT, TVM, or other third-party inference runtime dependency.
- HTML: strict-evidence generation passed and produced a default-visible inline SVG with TRT/Base in red and Reference in blue. The curves visually overlap because the action outputs are nearly identical. Missing numeric action evidence remains a hard report failure.
- Ruff check/format and `git diff --check` pass.

## GitHub CI

Exact-head run: https://github.com/NVIDIA/TensorRT-Model-Connect/actions/runs/30131143853

- Legal compliance: passed.
- Source quality: passed.
- Ownership and impact: passed.
- Unit C++ and Python: passed.
- OpenPI isolated model proof: failed before build/inference at the unchanged offline HF cache-readiness gate.

The required snapshot for `NVIDIA/TensorRT-Model-Connect-OpenPI-Pi05-DROID` at pinned revision `59205df7225305b0a6680dd8fe9a064cfec774d7` is absent or not visible to the CI Hugging Face token. Both existing nightly cache-warm nodes reproduced the same 404 after successfully warming the other 114 assets. This PR does not weaken the gate or modify CI.

To unblock the required green run, an NVIDIA Hugging Face owner must publish/authorize the fixed prepared model asset, provide its real immutable commit SHA, and make it readable by CI. The pin must then be updated and exact-head proof rerun. The PR remains Draft until that external asset prerequisite and all required checks are green.

## Notes For Reviewers

- Review in this order: `families/openpi`, `runtime/models/openpi`, `tests/**/openpi`, then the 11 small shared seams.
- The generic benchmark uses deterministic synthetic inputs for catalog compliance; pinned DROID parity and performance are enforced by the OpenPI-owned E2E qualification path.
- Additional OpenPI policies, LIBERO, other hardware, and framework-based deployment paths remain outside this PR.
