### PR TITLE
fix(tokenizer): repair incomplete WordPiece assets

### DIFF
--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -690,13 +690,55 @@ def _detect_tokenizer_special_frame(model_dir: Path) -> tuple[list[int], list[in
     return None
 
 
+def _wordpiece_tokenizer_needs_rebuild(model_dir: Path) -> bool:
+    """Return whether a cached WordPiece tokenizer is smaller than the model.
+
+    Some Hugging Face repositories, including ConvBERT, publish ``vocab.txt``
+    without ``tokenizer.json``.  A tokenizer generated before ``vocab.txt`` is
+    available can contain only the special tokens and then remain in the shared
+    snapshot cache.  Rebuild only when all inputs prove that this happened.
+    """
+    tokenizer_path = model_dir / "tokenizer.json"
+    vocab_path = model_dir / "vocab.txt"
+    config_path = model_dir / "config.json"
+    if not (tokenizer_path.exists() and vocab_path.exists() and config_path.exists()):
+        return False
+
+    try:
+        tokenizer = json.loads(tokenizer_path.read_text(encoding="utf-8"))
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        model = tokenizer.get("model", {})
+        vocab = model.get("vocab", {})
+        expected_vocab_size = int(config.get("vocab_size", 0))
+        if model.get("type") != "WordPiece":
+            return False
+        if not isinstance(vocab, dict) or not vocab or expected_vocab_size <= 0:
+            return False
+        tokenizer_id_space = max(int(token_id) for token_id in vocab.values()) + 1
+        source_id_space = len(vocab_path.read_text(encoding="utf-8").splitlines())
+        return (
+            tokenizer_id_space < expected_vocab_size
+            and source_id_space >= expected_vocab_size
+        )
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return False
+
+
 def _ensure_tokenizer_json(model_dir: Path, *, plugin=None) -> None:
     """If the model directory lacks tokenizer.json, generate it from the
     slow tokenizer using HF transformers. This ensures the C++ runtime can
     always load the tokenizer natively.
     """
-    if (model_dir / "tokenizer.json").exists():
+    tokenizer_path = model_dir / "tokenizer.json"
+    rebuild_wordpiece = _wordpiece_tokenizer_needs_rebuild(model_dir)
+    if tokenizer_path.exists() and not rebuild_wordpiece:
         return
+    if rebuild_wordpiece:
+        print(
+            "[trtmc build] Rebuilding undersized WordPiece tokenizer.json "
+            "from vocab.txt",
+            file=sys.stderr,
+        )
 
     slow_tokenizer_error: str | None = None
 
@@ -705,7 +747,7 @@ def _ensure_tokenizer_json(model_dir: Path, *, plugin=None) -> None:
         from transformers import AutoTokenizer
         tok = AutoTokenizer.from_pretrained(str(model_dir), use_fast=False)
         tok.save_pretrained(str(model_dir))
-        if (model_dir / "tokenizer.json").exists():
+        if tokenizer_path.exists():
             print("[trtmc build] Generated tokenizer.json from slow tokenizer",
                   file=sys.stderr)
             return
@@ -1167,7 +1209,18 @@ def build_bundle(
             print(f"[trtmc build]   {ename}: {len(eplan) / (1024 * 1024):.1f} MB",
                   file=sys.stderr)
 
-    # 5. Detect tokenizer special-tokens behavior from HF config
+    # 5. Ensure tokenizer.json before detecting its special-token frame.  A
+    # repaired tokenizer may use different special-token IDs than a stale one.
+    requires_tokenizer = bool(getattr(plugin, "requires_tokenizer", True))
+    if requires_tokenizer:
+        tokenizer_json_t0 = time.monotonic()
+        _ensure_tokenizer_json(model_dir_path, plugin=plugin)
+        _add_build_timing(
+            build_timing, "tokenizer_json_ensure_s",
+            time.monotonic() - tokenizer_json_t0)
+        _write_build_timing(build_timing)
+
+    # 5b. Detect tokenizer special-tokens behavior from HF config
     tokenizer_t0 = time.monotonic()
     tokenizer_special_frame = _detect_tokenizer_special_frame(model_dir_path)
     if tokenizer_special_frame is None:
@@ -1233,18 +1286,6 @@ def build_bundle(
         sections.append(
             BundleSection(triattention_cfg.stats_section, triattention_section)
         )
-
-    # If model lacks tokenizer.json (fast format), generate it from the
-    # slow tokenizer so the C++ runtime can always load via AutoTokenizer.
-    # Non-text families opt out explicitly through their plugin metadata.
-    requires_tokenizer = bool(getattr(plugin, "requires_tokenizer", True))
-    if requires_tokenizer:
-        tokenizer_json_t0 = time.monotonic()
-        _ensure_tokenizer_json(model_dir_path, plugin=plugin)
-        _add_build_timing(
-            build_timing, "tokenizer_json_ensure_s",
-            time.monotonic() - tokenizer_json_t0)
-        _write_build_timing(build_timing)
 
     def make_runtime_config_json(source: bytes | None) -> bytes:
         cfg_dict = json.loads(source) if source is not None else dict(config.raw)

--- a/python/tensorrt_model_connect/hf_snapshot.py
+++ b/python/tensorrt_model_connect/hf_snapshot.py
@@ -27,6 +27,7 @@ GENERIC_HF_ALLOW_PATTERNS: tuple[str, ...] = (
     "tokenizer.json",
     "tokenizer_config.json",
     "chat_template.jinja",
+    "vocab.txt",
     "vocab.json",
     "merges.txt",
     "special_tokens_map.json",

--- a/scripts/warm_hf_cache.py
+++ b/scripts/warm_hf_cache.py
@@ -72,6 +72,7 @@ _HF_ALLOW_PATTERNS = [
     "tokenizer.json",
     "tokenizer_config.json",
     "chat_template.jinja",
+    "vocab.txt",
     "vocab.json",
     "merges.txt",
     "normalizer.json",

--- a/tests/builder/test_engine_builder_utils.py
+++ b/tests/builder/test_engine_builder_utils.py
@@ -329,6 +329,9 @@ class TestHfAllowPatterns:
     def test_contains_tokenizer(self):
         assert "tokenizer.json" in _HF_ALLOW_PATTERNS
 
+    def test_contains_wordpiece_vocab(self):
+        assert "vocab.txt" in _HF_ALLOW_PATTERNS
+
     def test_contains_processor_config(self):
         assert "processor_config.json" in _HF_ALLOW_PATTERNS
 
@@ -364,6 +367,63 @@ class TestEnsureTokenizerJson:
         # Should not raise or modify
         _ensure_tokenizer_json(tmp_path)
         assert (tmp_path / "tokenizer.json").read_text() == "{}"
+
+    def test_rebuilds_undersized_wordpiece_from_complete_vocab(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        (tmp_path / "config.json").write_text(json.dumps({"vocab_size": 6}))
+        (tmp_path / "vocab.txt").write_text(
+            "[PAD]\n[UNK]\n[CLS]\n[SEP]\n[MASK]\nhello\n"
+        )
+        (tmp_path / "tokenizer.json").write_text(json.dumps({
+            "model": {
+                "type": "WordPiece",
+                "vocab": {
+                    "[PAD]": 0,
+                    "[UNK]": 1,
+                    "[CLS]": 2,
+                    "[SEP]": 3,
+                    "[MASK]": 4,
+                },
+            },
+        }))
+
+        class FakeTokenizer:
+            @staticmethod
+            def save_pretrained(path):
+                (Path(path) / "tokenizer.json").write_text(json.dumps({
+                    "model": {
+                        "type": "WordPiece",
+                        "vocab": {
+                            "[PAD]": 0,
+                            "[UNK]": 1,
+                            "[CLS]": 2,
+                            "[SEP]": 3,
+                            "[MASK]": 4,
+                            "hello": 5,
+                        },
+                    },
+                }))
+
+        class FakeAutoTokenizer:
+            @staticmethod
+            def from_pretrained(path, use_fast=False):
+                assert Path(path) == tmp_path
+                assert use_fast is False
+                return FakeTokenizer()
+
+        monkeypatch.setitem(
+            sys.modules,
+            "transformers",
+            types.SimpleNamespace(AutoTokenizer=FakeAutoTokenizer),
+        )
+
+        _ensure_tokenizer_json(tmp_path)
+
+        tokenizer = json.loads((tmp_path / "tokenizer.json").read_text())
+        assert tokenizer["model"]["vocab"]["hello"] == 5
 
     def test_missing_fast_tokenizer_delegates_to_family_plugin(
         self,


### PR DESCRIPTION
## Background

The ConvBERT TP2 representation-parity test in #536 failed with cosine 0.9102 because the release bundle contained a five-token WordPiece tokenizer. The upstream checkpoint publishes `vocab.txt` but no `tokenizer.json`; the shared snapshot allowlist omitted that source vocabulary, and a generated incomplete tokenizer could then persist in the cache.

Fixes #536

## Exit Criteria

- Fresh snapshots download the WordPiece source vocabulary required to generate `tokenizer.json`.
- Existing undersized cached WordPiece tokenizers are repaired before special-token IDs are recorded.
- `convbert-base-tp2` passes its existing representation-parity threshold without changing test criteria.

## Implementation

- Add `vocab.txt` to the generic Hugging Face snapshot allowlist.
- Detect a cached WordPiece tokenizer whose token ID space is smaller than `config.json` while a complete source vocabulary is available, then regenerate it with the slow tokenizer.
- Ensure tokenizer generation or repair runs before special-token frame detection so the bundle records the repaired `[CLS]` and `[SEP]` IDs.
- Add regression coverage for both the download contract and stale-cache repair.

## Validation

- `python3 -m pytest -q tests/builder/test_engine_builder_utils.py tests/builder/test_engine_builder_extended.py`: 38 passed, 1 skipped.
- `python3 -m ruff check python/tensorrt_model_connect/engine_builder.py python/tensorrt_model_connect/hf_snapshot.py tests/builder/test_engine_builder_utils.py`: all checks passed.
- `pytest tests/test_e2e.py::test_e2e[convbert-base-tp2] --multi-device-only --rebuild-engines ...` on 4x A30 with TensorRT 11.1.0.106: 1 passed in 63.57s; cosine improved from 0.9102 to 0.9730 against the unchanged 0.95 threshold.
- Inspected the rebuilt bundle: tokenizer ID space 30522, model vocab size 30522, special-token prefix `[101]`, suffix `[102]`.

## Notes For Future Readers

- The upstream `vocab.txt` contains duplicate token strings, so the serialized vocabulary has 29,514 dictionary entries but occupies the correct ID space through 30,522. The repair check intentionally compares the maximum token ID plus one rather than dictionary length.