### PR TITLE
fix(canary): preserve epsilon in FP32 builds

### DIFF
--- a/python/tensorrt_model_connect/families/canary/plugin.py
+++ b/python/tensorrt_model_connect/families/canary/plugin.py
@@ -1029,7 +1029,7 @@ class CanaryPlugin:
                 cross_k=layer_cross_k, cross_v=layer_cross_v,
                 attention_mask=layer_mask,
                 cross_attention_mask=layer_cross_mask,
-                eps=fp32_eps if layer_np_dtype == np.float32 else eps,
+                eps=_select_norm_eps(eps, fp32_eps, layer_np_dtype),
                 weights=weights, pfx=pfx,
                 hsz=h, nheads=dh, hdim=hd, ffn=df,
                 maxcache=max_cache_length, maxsrc=es, dtype=layer_np_dtype)
@@ -1148,6 +1148,13 @@ def network_add_elementwise_sum(net, a, b):
     return net.add_elementwise(a, b, trt.ElementWiseOperation.SUM).get_output(0)
 
 
+def _select_norm_eps(eps, fp32_eps, layer_np_dtype):
+    """Select the promoted epsilon only when one was actually created."""
+    if layer_np_dtype == np.float32 and fp32_eps is not None:
+        return fp32_eps
+    return eps
+
+
 def _build_encoder(
     config, weights, *, precision="fp32", verbose=False, fp32_layers=(),
 ):
@@ -1262,7 +1269,7 @@ def _build_encoder(
             dtype=layer_np_dtype)
         hs = _add_conformer_block(
             net, hs, weights, pfx, h, eh, hd, ef, k, es, rpe,
-            fp32_eps if layer_np_dtype == np.float32 else eps,
+            _select_norm_eps(eps, fp32_eps, layer_np_dtype),
             layer_mask,
             conv_norm_type=conv_norm_type, conv_context_size=conv_context_size,
             valid_mask=layer_valid_mask, dtype=layer_np_dtype)

--- a/tests/e2e/models/canary/test_canary_family_plugin_weights.py
+++ b/tests/e2e/models/canary/test_canary_family_plugin_weights.py
@@ -74,6 +74,27 @@ class TestCanaryPlugin:
             "fp32_layers": [3, 7],
         }
 
+    def test_norm_epsilon_falls_back_for_full_fp32_build(self):
+        plugin = importlib.import_module(
+            "tensorrt_model_connect.families.canary.plugin")
+        regular_eps = object()
+
+        selected = plugin._select_norm_eps(
+            regular_eps, None, np.float32)
+
+        assert selected is regular_eps
+
+    def test_norm_epsilon_uses_promoted_tensor_for_mixed_precision(self):
+        plugin = importlib.import_module(
+            "tensorrt_model_connect.families.canary.plugin")
+        regular_eps = object()
+        promoted_eps = object()
+
+        selected = plugin._select_norm_eps(
+            regular_eps, promoted_eps, np.float32)
+
+        assert selected is promoted_eps
+
     @staticmethod
     def _make_tp_weights(
         *,


### PR DESCRIPTION
## Background

This PR fixes the Canary TP4 encoder build failure reported in #537. Full FP32 builds created the regular epsilon tensor but not the optional mixed-precision promoted tensor, while normalization selected the missing tensor based only on the layer dtype.

## Exit Criteria

- Full FP32 Canary encoder and decoder normalization always receive a valid epsilon tensor.
- Mixed-precision layers continue to use the promoted FP32 epsilon when it exists.
- The `canary-1b-v2-tp4` release test builds and passes exact-transcript validation on four A30 GPUs.

## Implementation

- Select the promoted epsilon only when it was actually created; otherwise use the regular epsilon.
- Apply the same selection rule to the encoder and non-TP decoder paths.
- Add regression coverage for full-FP32 fallback and mixed-precision selection.

## Validation

- `PYTHONPATH=python python3 -m pytest -q tests/e2e/models/canary/test_canary_family_plugin_weights.py`: 16 passed, 1 skipped.
- `python3 -m ruff check python/tensorrt_model_connect/families/canary/plugin.py tests/e2e/models/canary/test_canary_family_plugin_weights.py`: passed.
- `python -m pytest "tests/test_e2e.py::test_e2e[canary-1b-v2-tp4]" ...`: passed on four A30 GPUs with TensorRT 11.1; 1 passed in 58.83s. The existing `TRTMC_NCCL_SKIP_DESTROY=1` workaround was used for an environment-specific NCCL 2.30 process-exit hang after successful inference.

## Notes For Future Readers

- Review `_select_norm_eps` first, then its encoder and decoder call sites.
- This change is specifically for issue #537 and does not change validation thresholds or transcript acceptance criteria.

Fixes #537
