### PR TITLE
fix(runtime): release CUDA graphs before NCCL

### DIFF
--- a/src/runtime/backend/trt_module_impl.cpp
+++ b/src/runtime/backend/trt_module_impl.cpp
@@ -183,6 +183,11 @@ void TrtModuleImpl::reset_execution_context() {
 
 TrtModuleImpl::~TrtModuleImpl() {
     flush_timing_events();
+    // CUDA Graphs may contain TensorRT collective launches that retain the
+    // distributed communicator. Destroy the captured graph before member
+    // teardown releases distributed_owner from keep_alive_.
+    if (cuda_graph_)
+        cuda_graph_->reset();
     free_buffers();
     delete ctx_;
 }

--- a/tests/cpp/test_cuda_graph.cpp
+++ b/tests/cpp/test_cuda_graph.cpp
@@ -325,6 +325,27 @@ static void test_module_enable_after_normal_run() {
     cudaStreamDestroy(stream);
 }
 
+static void test_module_cuda_graph_destruction() {
+    auto engine = build_identity_engine();
+    if (!engine)
+        return;
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+    {
+        auto module = make_module(engine.get(), stream);
+        module->enable_cuda_graph();
+
+        float input[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+        float output[4] = {0};
+        run_and_read(*module, input, output);
+        check(module->cuda_graph_active(), "graph_destruction: graph remains active");
+    }
+    check(cudaStreamSynchronize(stream) == cudaSuccess,
+          "graph_destruction: module releases graph before stream teardown");
+    cudaStreamDestroy(stream);
+}
+
 int main() {
     // CudaGraphExec unit tests
     test_default_state();
@@ -338,6 +359,7 @@ int main() {
     test_module_cuda_graph_correctness();
     test_module_cuda_graph_multiple_runs();
     test_module_enable_after_normal_run();
+    test_module_cuda_graph_destruction();
     if (failures > 0) {
         std::cerr << failures << " test(s) FAILED\n";
         return 1;

--- a/tests/cpp/test_cuda_graph.cpp
+++ b/tests/cpp/test_cuda_graph.cpp
@@ -325,27 +325,6 @@ static void test_module_enable_after_normal_run() {
     cudaStreamDestroy(stream);
 }
 
-static void test_module_cuda_graph_destruction() {
-    auto engine = build_identity_engine();
-    if (!engine)
-        return;
-
-    cudaStream_t stream;
-    cudaStreamCreate(&stream);
-    {
-        auto module = make_module(engine.get(), stream);
-        module->enable_cuda_graph();
-
-        float input[4] = {1.0f, 2.0f, 3.0f, 4.0f};
-        float output[4] = {0};
-        run_and_read(*module, input, output);
-        check(module->cuda_graph_active(), "graph_destruction: graph remains active");
-    }
-    check(cudaStreamSynchronize(stream) == cudaSuccess,
-          "graph_destruction: module releases graph before stream teardown");
-    cudaStreamDestroy(stream);
-}
-
 int main() {
     // CudaGraphExec unit tests
     test_default_state();
@@ -359,7 +338,6 @@ int main() {
     test_module_cuda_graph_correctness();
     test_module_cuda_graph_multiple_runs();
     test_module_enable_after_normal_run();
-    test_module_cuda_graph_destruction();
     if (failures > 0) {
         std::cerr << failures << " test(s) FAILED\n";
         return 1;


### PR DESCRIPTION
## Background

While validating the Canary TP4 fix in #539, inference produced the expected output but the processes did not exit. The hang occurred in `ncclCommDestroy` when CUDA Graphs were enabled; disabling CUDA Graphs or setting `TRTMC_NCCL_SKIP_DESTROY=1` allowed clean exit.

`TrtModuleImpl` released resources retained in `keep_alive_`, including the distributed communicator owner, before its `CudaGraphExec` member was destroyed. A captured TensorRT graph can retain NCCL collective resources, leaving communicator destruction waiting indefinitely.

## Exit Criteria

- Destroy captured CUDA Graph resources before releasing the NCCL communicator owner.
- Preserve CUDA Graph execution behavior.
- TP2 and TP4 processes exit normally without `TRTMC_NCCL_SKIP_DESTROY`.

## Implementation

- Explicitly reset `CudaGraphExec` in `TrtModuleImpl` teardown before buffers, the TensorRT context, and keep-alive resources are released.

## Validation

- `cmake --build build-multigpu --target trtmc_backend_trt test_cuda_graph -j4`: passed with TensorRT 11.1.
- `LD_LIBRARY_PATH=build-multigpu ./build-multigpu/test_cuda_graph`: all existing CUDA Graph tests passed.
- `clang-format --dry-run --Werror src/runtime/backend/trt_module_impl.cpp`: passed.
- `git diff --check`: passed.
- TP + CUDA Graph exit matrix on four A30 GPUs, without `TRTMC_NCCL_SKIP_DESTROY`: 6/6 exited with `rc=0`:
  - Pythia 70M TP4
  - Qwen3 0.6B FP16 TP4
  - Bloom 560M TP4
  - Mixtral Stories 15M TP2
  - DeepSeek-V2 Tiny TP2
  - Canary 1B v2 TP4
- `python -m pytest "tests/test_e2e.py::test_e2e[canary-1b-v2-tp4]" ...`: exact-transcript E2E passed in 59.87s without the NCCL skip-destroy workaround.

## Notes For Future Readers

- The existing `TRTMC_NCCL_SKIP_DESTROY` escape hatch remains available for unrelated external-runtime teardown failures.
- The shared GPU test `tests/cpp/test_cuda_graph.cpp` is intentionally unchanged because repository ownership policy requires model-coupled tests to select an isolated model proof.
- Review the destructor ordering in `TrtModuleImpl`.
