### PR TITLE
feat(validation): add model-first reference consistency checks

### DIFF
--- a/python/tensorrt_model_connect/families/elf_flow/python_profile_reference_verify.py
+++ b/python/tensorrt_model_connect/families/elf_flow/python_profile_reference_verify.py
@@ -1,20 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Verify the official ELF PyTorch reference profile."""
+"""Verify the official PyTorch ELF reference environment."""
 
-from importlib.metadata import version
-
-import muon
-import numpy
+import huggingface_hub
+import tokenizers
 import transformers
-from transformers import T5EncoderModel
 
 
-assert version("huggingface-hub") == "0.24.7"
-assert version("muon-optimizer") == "0.1.0"
-assert numpy.__version__ == "1.26.4"
-assert version("tokenizers") == "0.19.1"
 assert transformers.__version__ == "4.44.2"
-assert hasattr(muon, "MuonWithAuxAdam")
-assert T5EncoderModel is not None
+assert tokenizers.__version__ == "0.19.1"
+assert huggingface_hub.__version__ == "0.24.7"

--- a/python/tensorrt_model_connect/families/elf_flow/python_profile_requirements/elf_flow_reference.lock.txt
+++ b/python/tensorrt_model_connect/families/elf_flow/python_profile_requirements/elf_flow_reference.lock.txt
@@ -1,5 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 huggingface-hub==0.24.7
-muon-optimizer==0.1.0
-numpy==1.26.4
 tokenizers==0.19.1
 transformers==4.44.2

--- a/python/tensorrt_model_connect/python_profile_requirements/reference_common.lock.txt
+++ b/python/tensorrt_model_connect/python_profile_requirements/reference_common.lock.txt
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+transformers==5.2.0

--- a/python/tensorrt_model_connect/python_profile_requirements/reference_common.lock.txt
+++ b/python/tensorrt_model_connect/python_profile_requirements/reference_common.lock.txt
@@ -2,3 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 transformers==5.2.0
+rouge-score==0.1.2
+sacrebleu==2.5.1

--- a/python/tensorrt_model_connect/python_profiles.py
+++ b/python/tensorrt_model_connect/python_profiles.py
@@ -15,7 +15,7 @@ import subprocess
 import tempfile
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 try:
     import tomllib
@@ -322,6 +322,8 @@ def _materialize_venv_profile(
     profile_name: str,
     spec: Mapping[str, Any],
     base_python: str,
+    *,
+    on_create: Callable[[str], None] | None = None,
 ) -> str:
     base_python = _absolute_python(base_python)
     if not base_python:
@@ -385,6 +387,9 @@ def _materialize_venv_profile(
         if ready_path.is_file() and python_path.is_file():
             return str(python_path.absolute())
 
+        if on_create is not None:
+            on_create(profile_name)
+
         tmp_dir = Path(tempfile.mkdtemp(prefix=f"{profile_name}-", dir=str(root)))
         tmp_python = tmp_dir / "bin" / "python"
         requirements_file = tmp_dir / "requirements.lock.txt"
@@ -447,7 +452,12 @@ def _materialize_venv_profile(
     return str(python_path.absolute())
 
 
-def resolve_profile_python(profile_name: str, base_python: str) -> str:
+def resolve_profile_python(
+    profile_name: str,
+    base_python: str,
+    *,
+    on_create: Callable[[str], None] | None = None,
+) -> str:
     """Resolve a symbolic profile name to a Python executable path."""
     name = _normalize_profile_name(profile_name)
     if name == DEFAULT_PROFILE:
@@ -472,7 +482,12 @@ def resolve_profile_python(profile_name: str, base_python: str) -> str:
         raise ValueError(
             f"Execution profile {name!r} declares unsupported kind {kind!r}"
         )
-    return _materialize_venv_profile(name, spec, base_python)
+    return _materialize_venv_profile(
+        name,
+        spec,
+        base_python,
+        on_create=on_create,
+    )
 
 
 def resolve_case_profile_names(case: Any) -> dict[str, str]:

--- a/python/tensorrt_model_connect/python_profiles.py
+++ b/python/tensorrt_model_connect/python_profiles.py
@@ -142,6 +142,12 @@ def _exact_pinned_requirements(requirements_text: str) -> dict[str, str]:
     return pinned
 
 
+def _pinned_version_matches(expected: str, actual: str) -> bool:
+    if actual == expected:
+        return True
+    return "+" not in expected and actual.partition("+")[0] == expected
+
+
 def _verify_exact_requirements(
     profile_name: str,
     profile_python: str,
@@ -151,10 +157,12 @@ def _verify_exact_requirements(
         return
     script = (
         "import importlib.metadata as m, json, sys; "
+        "from tensorrt_model_connect.python_profiles "
+        "import _pinned_version_matches as matches; "
         "expected=json.loads(sys.argv[1]); "
         "actual={name:m.version(name) for name in expected}; "
         "bad={name:(expected[name], actual[name]) for name in expected "
-        "if actual[name] != expected[name]}; "
+        "if not matches(expected[name], actual[name])}; "
         "assert not bad, f'exact profile pins do not match: {bad}'"
     )
     _run_profile_command(

--- a/python/tensorrt_model_connect/python_profiles.toml
+++ b/python/tensorrt_model_connect/python_profiles.toml
@@ -11,6 +11,9 @@ kind = "venv"
 requirements = "python_profile_requirements/reference_common.lock.txt"
 system_site_packages = true
 verification_script = """
+from importlib.metadata import version
 import transformers
 assert transformers.__version__ == "5.2.0", transformers.__version__
+assert version("rouge-score") == "0.1.2"
+assert version("sacrebleu") == "2.5.1"
 """

--- a/python/tensorrt_model_connect/python_profiles.toml
+++ b/python/tensorrt_model_connect/python_profiles.toml
@@ -5,3 +5,12 @@ version = 1
 
 [profiles.base]
 kind = "passthrough"
+
+[profiles.reference_common]
+kind = "venv"
+requirements = "python_profile_requirements/reference_common.lock.txt"
+system_site_packages = true
+verification_script = """
+import transformers
+assert transformers.__version__ == "5.2.0", transformers.__version__
+"""

--- a/tests/e2e/models/elf_flow/test_elf_flow_family_plugin.py
+++ b/tests/e2e/models/elf_flow/test_elf_flow_family_plugin.py
@@ -36,6 +36,45 @@ except (ImportError, ModuleNotFoundError):
 RNG = np.random.RandomState(7)
 
 
+def test_elf_reference_uses_upstream_compatible_python_profile() -> None:
+    from tensorrt_model_connect.python_profiles import normalize_execution_profiles
+
+    profiles = normalize_execution_profiles(
+        None,
+        family="elf_flow",
+        runtime_strategy="elf_flow",
+        reference_backend="hf_transformers",
+    )
+
+    assert profiles["build"] == "elf_flow"
+    assert profiles["reference"] == "elf_flow_reference"
+
+
+def test_elf_reference_profile_pins_upstream_transformers_version() -> None:
+    family_root = (
+        Path(__file__).resolve().parents[4]
+        / "python"
+        / "tensorrt_model_connect"
+        / "families"
+        / "elf_flow"
+    )
+    lock = (
+        family_root
+        / "python_profile_requirements"
+        / "elf_flow_reference.lock.txt"
+    ).read_text(encoding="utf-8")
+    verify = (family_root / "python_profile_reference_verify.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "transformers==4.44.2" in lock
+    assert "tokenizers==0.19.1" in lock
+    assert "huggingface-hub==0.24.7" in lock
+    assert 'transformers.__version__ == "4.44.2"' in verify
+    assert 'tokenizers.__version__ == "0.19.1"' in verify
+    assert 'huggingface_hub.__version__ == "0.24.7"' in verify
+
+
 def _rand(*shape: int) -> np.ndarray:
     return RNG.randn(*shape).astype(np.float32)
 

--- a/tests/e2e/models/elf_flow/test_elf_flow_python_profiles.py
+++ b/tests/e2e/models/elf_flow/test_elf_flow_python_profiles.py
@@ -21,19 +21,24 @@ def test_elf_profile_pins_official_optimizer_dependencies() -> None:
     assert "optax==0.2.5" in requirements
 
 
-def test_elf_reference_profile_pins_official_pytorch_branch_dependencies() -> None:
+def test_elf_reference_profile_pins_inference_only_dependencies() -> None:
     repository = Path(__file__).resolve().parents[4]
-    requirements = (
+    requirements_text = (
         repository
         / "python/tensorrt_model_connect/families/elf_flow/python_profile_requirements"
         / "elf_flow_reference.lock.txt"
     ).read_text(encoding="utf-8")
+    requirements = {
+        line
+        for line in requirements_text.splitlines()
+        if line and not line.startswith("#")
+    }
 
-    assert "huggingface-hub==0.24.7" in requirements
-    assert "muon-optimizer==0.1.0" in requirements
-    assert "numpy==1.26.4" in requirements
-    assert "tokenizers==0.19.1" in requirements
-    assert "transformers==4.44.2" in requirements
+    assert requirements == {
+        "huggingface-hub==0.24.7",
+        "tokenizers==0.19.1",
+        "transformers==4.44.2",
+    }
     assert default_execution_profiles(family="elf_flow") == {
         "build": "elf_flow",
         "runtime": "base",

--- a/tests/e2e/models/magpie_tts/test_magpie_nemo_reference.py
+++ b/tests/e2e/models/magpie_tts/test_magpie_nemo_reference.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 import subprocess
 
 from tests.e2e.models.magpie_tts.e2e_plugins.references.nemo_reference import (
@@ -14,6 +15,20 @@ from tests.e2e.models.magpie_tts.e2e_plugins.references.nemo_reference import (
     NemoReference,
 )
 from tests.e2e_harness.contracts import E2ECase, RunContext, StageSpec
+
+
+def test_reference_profile_matches_pinned_magpie_checkpoint() -> None:
+    family_root = Path(__file__).resolve().parents[4] / (
+        "python/tensorrt_model_connect/families/magpie_tts"
+    )
+    lock = (
+        family_root
+        / "python_profile_requirements/magpie_tts_reference.lock.txt"
+    ).read_text(encoding="utf-8")
+    verify = (family_root / "python_profile_verify.py").read_text(encoding="utf-8")
+
+    assert "nemo_toolkit==2.7.3" in lock
+    assert 'startswith("2.7.")' in verify
 
 
 def test_magpie_reference_maps_upstream_url_to_pre_warmed_file(monkeypatch, tmp_path) -> None:

--- a/tests/tools/test_e2e_python_profiles.py
+++ b/tests/tools/test_e2e_python_profiles.py
@@ -119,12 +119,26 @@ def test_resolve_profile_python_materializes_declared_venv(monkeypatch, tmp_path
         },
     )
 
-    python = shared_profiles.resolve_profile_python("custom", sys.executable)
+    created = []
+    python = shared_profiles.resolve_profile_python(
+        "custom",
+        sys.executable,
+        on_create=created.append,
+    )
     ready = Path(python).parent.parent / ".ready"
 
     assert Path(python).is_file()
     assert ready.is_file()
-    assert shared_profiles.resolve_profile_python("custom", sys.executable) == python
+    assert created == ["custom"]
+    assert (
+        shared_profiles.resolve_profile_python(
+            "custom",
+            sys.executable,
+            on_create=created.append,
+        )
+        == python
+    )
+    assert created == ["custom"]
 
 
 def test_family_profile_registry_is_fully_exact_pinned():
@@ -140,6 +154,7 @@ def test_family_profile_registry_is_fully_exact_pinned():
         "personaplex_reference",
         "phi4_multimodal",
         "sana_wm_reference",
+        "reference_common",
     }
     profiles = shared_profiles.load_python_profile_registry()["profiles"]
 

--- a/tests/tools/test_e2e_python_profiles.py
+++ b/tests/tools/test_e2e_python_profiles.py
@@ -177,6 +177,19 @@ def test_profile_lock_rejects_non_exact_or_duplicate_requirements():
         )
 
 
+def test_exact_profile_pin_accepts_only_local_builds_of_same_public_version():
+    assert shared_profiles._pinned_version_matches(
+        "3.1.0",
+        "3.1.0+c9040511b",
+    )
+    assert shared_profiles._pinned_version_matches("3.1.0", "3.1.0")
+    assert not shared_profiles._pinned_version_matches("3.1.0", "3.1.1")
+    assert not shared_profiles._pinned_version_matches(
+        "3.1.0+expected",
+        "3.1.0+different",
+    )
+
+
 def test_prebuilt_only_profile_fails_before_creating_a_runtime_cache(
     monkeypatch, tmp_path
 ):

--- a/tests/tools/test_ensure_ci_docker_image.py
+++ b/tests/tools/test_ensure_ci_docker_image.py
@@ -19,7 +19,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SCRIPT = REPO_ROOT / "tools" / "ci" / "docker_image.py"
 DEFAULT_PROFILES = (
     "chronos,deepseek_ocr,elf_flow,elf_flow_reference,internlm,lance_reference,magpie_tts_reference,"
-    "nemotron_h_reference,personaplex_reference,phi4_multimodal,sana_wm_reference"
+    "nemotron_h_reference,personaplex_reference,phi4_multimodal,reference_common,sana_wm_reference"
 )
 
 
@@ -105,7 +105,7 @@ fi
 
 if [ "${1:-}" = "run" ]; then
   capability="${FAKE_DOCKER_CAPABILITY:-available}"
-  profiles="${FAKE_DOCKER_PROFILES-chronos,deepseek_ocr,elf_flow,elf_flow_reference,internlm,lance_reference,magpie_tts_reference,nemotron_h_reference,personaplex_reference,phi4_multimodal,sana_wm_reference}"
+  profiles="${FAKE_DOCKER_PROFILES-chronos,deepseek_ocr,elf_flow,elf_flow_reference,internlm,lance_reference,magpie_tts_reference,nemotron_h_reference,personaplex_reference,phi4_multimodal,reference_common,sana_wm_reference}"
   if [ -f "$FAKE_DOCKER_REBUILT" ]; then
     capability="available"
     profiles="$FAKE_DOCKER_REBUILT_PROFILES"
@@ -278,8 +278,8 @@ def _resolved_image_for_repo(
     result, github_env, docker_log = _run_ensure_script(
         tmp_path,
         existing_images={},
-        profiles="demo",
-        rebuilt_profiles="demo",
+        profiles="demo,reference_common",
+        rebuilt_profiles="demo,reference_common",
         repo_root=repo_root,
     )
     assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -3162,6 +3162,75 @@ def test_build_bundle_command_omits_fp32_layers_when_absent(tmp_path: Path) -> N
     assert "--fp32-layers" not in cmd
 
 
+def test_ensure_bundle_replaces_existing_file_before_build(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    bundle = tmp_path / "shared" / "model.trtfb"
+    bundle.parent.mkdir()
+    bundle.write_bytes(b"old")
+
+    class Result:
+        returncode = 0
+
+    def fake_run(command, **_kwargs):
+        output = Path(command[command.index("-o") + 1])
+        assert not output.exists()
+        output.write_bytes(b"new")
+        return Result()
+
+    monkeypatch.setattr(task_eval.subprocess, "run", fake_run)
+
+    result, built = task_eval.ensure_bundle(
+        {
+            "name": "model",
+            "hf_id": "org/model",
+            "precision": "fp32",
+        },
+        bundle_path=bundle,
+        trtmc_binary="trtmc",
+        force_build=True,
+        replace_existing=True,
+    )
+
+    assert result == bundle
+    assert built is True
+    assert bundle.read_bytes() == b"new"
+
+
+def test_ensure_bundle_removes_partial_replacement_after_failed_build(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    bundle = tmp_path / "shared" / "model.trtfb"
+    bundle.parent.mkdir()
+    bundle.write_bytes(b"old")
+
+    class Result:
+        returncode = 1
+
+    def fake_run(command, **_kwargs):
+        Path(command[command.index("-o") + 1]).write_bytes(b"partial")
+        return Result()
+
+    monkeypatch.setattr(task_eval.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="Bundle build failed"):
+        task_eval.ensure_bundle(
+            {
+                "name": "model",
+                "hf_id": "org/model",
+                "precision": "fp32",
+            },
+            bundle_path=bundle,
+            trtmc_binary="trtmc",
+            force_build=True,
+            replace_existing=True,
+        )
+
+    assert not bundle.exists()
+
+
 def test_suite_build_cache_minimum_overrides_manifest_cache() -> None:
     suite = {"build": {"min_max_cache_length": 1024}}
     model = {"max_cache_length": 256}
@@ -3208,6 +3277,7 @@ def test_run_hf_reference_subprocess_uses_hf_python(tmp_path: Path, monkeypatch)
 
     args = argparse.Namespace(
         hf_python="/opt/deepseek-hf/bin/python3",
+        reference_cache_dir=str(tmp_path / "references"),
         hf_dtype="auto",
         hf_device="cuda",
         hf_device_map="",
@@ -3228,7 +3298,10 @@ def test_run_hf_reference_subprocess_uses_hf_python(tmp_path: Path, monkeypatch)
     task_eval.run_hf_reference_subprocess(args, model, work_dir)
 
     assert captured["cmd"][0] == "/opt/deepseek-hf/bin/python3"
-    assert captured["cmd"][1:3] == [str(Path(task_eval.__file__).resolve()), "run-hf"]
+    assert captured["cmd"][1:3] == [str(task_eval.REFERENCE_RUNNER), "run"]
+    assert captured["cmd"][captured["cmd"].index("--cache-dir") + 1] == str(
+        tmp_path / "references"
+    )
 
 
 def test_run_hf_reference_subprocess_passes_asr_family_metadata(
@@ -4328,7 +4401,7 @@ def test_run_deepseek_ocr_hf_reference_writes_predictions(tmp_path: Path) -> Non
     assert payload["responses"][0]["generated_token_ids"] == [1, 2]
 
 
-def test_eval_one_model_reuses_hf_builds_bundle_and_reruns_trtfb(
+def test_eval_one_model_reuses_cached_hf_builds_bundle_and_reruns_trtfb(
     tmp_path: Path, monkeypatch
 ) -> None:
     dataset = tmp_path / "mmlu.json"
@@ -4364,9 +4437,12 @@ def test_eval_one_model_reuses_hf_builds_bundle_and_reruns_trtfb(
     )
     calls: list[str] = []
 
-    def fake_run_hf(_args):
-        calls.append("hf")
-        raise AssertionError("HF should be reused")
+    def fake_run_hf(_args, _model, reference_work_dir):
+        calls.append("hf-cache")
+        (reference_work_dir / "hf_cache.json").write_text(
+            json.dumps({"status": "reused", "key": "abc123"}),
+            encoding="utf-8",
+        )
 
     monkeypatch.setattr(task_eval, "max_prompt_token_length", lambda **_kwargs: 405)
 
@@ -4392,7 +4468,7 @@ def test_eval_one_model_reuses_hf_builds_bundle_and_reruns_trtfb(
             encoding="utf-8",
         )
 
-    monkeypatch.setattr(task_eval, "run_hf_reference", fake_run_hf)
+    monkeypatch.setattr(task_eval, "run_hf_reference_subprocess", fake_run_hf)
     monkeypatch.setattr(task_eval, "ensure_bundle", fake_ensure_bundle)
     monkeypatch.setattr(task_eval, "run_trtfb", fake_run_trtfb)
 
@@ -4437,8 +4513,9 @@ def test_eval_one_model_reuses_hf_builds_bundle_and_reruns_trtfb(
 
     result = task_eval.eval_one_model(suite=suite, model=model, args=args)
 
-    assert calls == ["build", "trtfb-seed=123"]
+    assert calls == ["hf-cache", "build", "trtfb-seed=123"]
     assert result["hf_reused"] is True
+    assert result["hf_cache_key"] == "abc123"
     assert result["bundle_built"] is True
     assert result["trtfb_accuracy"] == 0.5
     assert (work_dir / "summary.json").is_file()

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -3654,6 +3654,61 @@ def test_dataset_benchmark_reproduction_is_direct_and_uses_single_input(
     assert "task_eval.py" not in " ".join(payload["command"])
 
 
+def test_dataset_benchmark_reproduction_preserves_per_sample_seed(
+    tmp_path: Path,
+) -> None:
+    command = [
+        "/workspace/build/trtmc_dataset_benchmark",
+        "/runs/engines/model.trtfb",
+        "/runs/work/prompts.jsonl",
+        "/runs/work/trtfb_raw.jsonl",
+        "--seed",
+        "42",
+    ]
+
+    task_eval._write_dataset_benchmark_reproduction(tmp_path, command)
+
+    payload = json.loads(
+        (tmp_path / "trtfb_repro.json").read_text(encoding="utf-8")
+    )
+    assert payload["base_seed"] == 42
+    assert payload["command"][payload["command"].index("--seed") + 1] == (
+        "{sample_seed}"
+    )
+
+
+def test_native_trtmc_command_recorder_extracts_nested_model_command(
+    tmp_path: Path,
+) -> None:
+    task_eval._reset_native_trtmc_commands(tmp_path)
+    output = SimpleNamespace(
+        metadata={
+            "cpp": {
+                "command": [
+                    "/workspace/build/trtmc",
+                    "run",
+                    "/runs/engines/model.trtfb",
+                    "--prompt",
+                    "hello",
+                ]
+            }
+        }
+    )
+
+    task_eval._record_output_native_command(
+        tmp_path,
+        "sample-7",
+        output,
+    )
+
+    row = json.loads(
+        (tmp_path / "trtfb_native_commands.jsonl").read_text(encoding="utf-8")
+    )
+    assert row["sample_id"] == "sample-7"
+    assert row["command"][0:2] == ["/workspace/build/trtmc", "run"]
+    assert "task_eval.py" not in " ".join(row["command"])
+
+
 def test_run_diffusion_trtfb_writes_image_artifact_predictions(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -3514,6 +3514,15 @@ def test_run_diffusion_trtfb_writes_image_artifact_predictions(
                     "frame_stats": {"mean": 0.5, "std": 0.2},
                     "prompt": case.inputs["prompt"],
                 },
+                metadata={
+                    "command": [
+                        "build/trtmc",
+                        "generate-video",
+                        str(tmp_path / "bundles" / "flux-schnell-l0.trtfb"),
+                        "--prompt",
+                        case.inputs["prompt"],
+                    ]
+                },
                 timing_s=0.5,
             )
 
@@ -3546,6 +3555,11 @@ def test_run_diffusion_trtfb_writes_image_artifact_predictions(
     assert seen == [("a red cube", "build/trtmc", "flux-schnell-l0.trtfb")]
     assert predictions["responses"][0]["source"] == "trtfb"
     assert predictions["responses"][0]["num_frames"] == 1
+    assert (work_dir / "trtfb_run.log").read_text(encoding="utf-8") == (
+        "$ build/trtmc generate-video "
+        f"{tmp_path / 'bundles' / 'flux-schnell-l0.trtfb'} "
+        "--prompt 'a red cube'\n"
+    )
 
 
 def test_compare_diffusion_image_predictions_aggregates_model_comparator_metrics(

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -1275,6 +1275,7 @@ def test_load_manifest_records_discovers_model_owned_manifests(tmp_path: Path) -
             {
                 "name": "example-decoder",
                 "hf_id": "example-org/example-decoder",
+                "hf_revision": "0123456789abcdef",
                 "bundle": "example-decoder.trtfb",
                 "family": "example_decoder",
                 "runtime_strategy": "example_decoder_decoder_kv_cache",
@@ -1293,6 +1294,7 @@ def test_load_manifest_records_discovers_model_owned_manifests(tmp_path: Path) -
 
     assert [record["name"] for record in records] == ["example-decoder"]
     assert records[0]["manifest"].endswith("example_decoder/manifests/example-decoder.json")
+    assert records[0]["hf_revision"] == "0123456789abcdef"
     assert records[0]["task_eval"] == {
         "vlm_fallback_prompt_template": "<image>{prompt}",
     }
@@ -2469,6 +2471,23 @@ def test_convert_trtfb_uses_generated_text_field(tmp_path: Path) -> None:
     assert payload["responses"][0]["source"] == "trtfb"
 
 
+def test_convert_trtfb_replaces_invalid_utf8_in_generated_text(
+    tmp_path: Path,
+) -> None:
+    raw = tmp_path / "trtfb_raw.jsonl"
+    raw.write_bytes(
+        b'{"sample_id":"sample-0","text":"bad \x88 text",'
+        b'"generated_token_ids":[7]}\n'
+    )
+    predictions = tmp_path / "predictions.json"
+
+    task_eval.convert_trtfb_jsonl_to_predictions(raw, predictions)
+
+    payload = json.loads(predictions.read_text(encoding="utf-8"))
+    assert payload["responses"][0]["output_text"] == "bad \ufffd text"
+    assert payload["responses"][0]["generated_token_ids"] == [7]
+
+
 def test_score_and_compare_mmlu_predictions(tmp_path: Path) -> None:
     dataset = tmp_path / "mmlu.json"
     _write_mmlu(dataset)
@@ -3125,6 +3144,27 @@ def test_build_bundle_command_uses_manifest_build_settings(tmp_path: Path) -> No
     assert "--verbose" in cmd
 
 
+def test_build_bundle_command_passes_manifest_hf_revision(tmp_path: Path) -> None:
+    model = {
+        "name": "case",
+        "hf_id": "org/model",
+        "hf_revision": "0123456789abcdef",
+        "max_cache_length": 256,
+        "precision": "fp32",
+    }
+
+    cmd = task_eval.build_bundle_command(
+        model,
+        trtmc_binary="build/trtmc",
+        bundle_path=tmp_path / "case.trtfb",
+    )
+
+    assert cmd[cmd.index("--model-revision") : cmd.index("--model-revision") + 2] == [
+        "--model-revision",
+        "0123456789abcdef",
+    ]
+
+
 def test_build_bundle_command_passes_manifest_fp32_layers(tmp_path: Path) -> None:
     """Reduced-precision selectors must reach the build, matching the E2E harness."""
     model = {
@@ -3369,12 +3409,19 @@ def test_run_hf_reference_subprocess_uses_hf_python(tmp_path: Path, monkeypatch)
         min_p=None,
         seed=None,
     )
-    model = {"hf_id": "org/model", "trust_remote_code": False}
+    model = {
+        "hf_id": "org/model",
+        "hf_revision": "0123456789abcdef",
+        "trust_remote_code": False,
+    }
 
     task_eval.run_hf_reference_subprocess(args, model, work_dir)
 
     assert captured["cmd"][0] == "/opt/deepseek-hf/bin/python3"
     assert captured["cmd"][1:3] == [str(task_eval.REFERENCE_RUNNER), "run"]
+    assert captured["cmd"][captured["cmd"].index("--model-revision") + 1] == (
+        "0123456789abcdef"
+    )
     assert captured["cmd"][captured["cmd"].index("--cache-dir") + 1] == str(
         tmp_path / "references"
     )
@@ -5563,6 +5610,46 @@ def test_diffusion_text_hf_parity_uses_token_agreement_only() -> None:
     assert result["shared_sampling_inputs_match_rate"] == 1.0
     assert "normalized_text_exact_match_rate" not in result
     assert "text_ned" not in result["samples"][0]
+
+
+def test_diffusion_text_shared_inputs_match_through_reference_cache_symlink(
+    tmp_path: Path,
+) -> None:
+    cached_dir = tmp_path / "cache" / "hf_shared_inputs" / "sample"
+    cached_dir.mkdir(parents=True)
+    cached_input = cached_dir / "initial_latents.f32"
+    cached_input.write_bytes(b"latents")
+    materialized_root = tmp_path / "work" / "hf_shared_inputs"
+    materialized_root.parent.mkdir()
+    materialized_root.symlink_to(cached_dir.parent, target_is_directory=True)
+    materialized_input = materialized_root / "sample" / "initial_latents.f32"
+
+    result = task_eval.compare_diffusion_text_prediction_sets(
+        {
+            "responses": [
+                {
+                    "sample_id": "sample",
+                    "generated_token_ids": [1],
+                    "shared_sampling_inputs": {
+                        "initial_latents": str(cached_input),
+                    },
+                }
+            ]
+        },
+        {
+            "responses": [
+                {
+                    "sample_id": "sample",
+                    "generated_token_ids": [1],
+                    "shared_sampling_inputs": {
+                        "initial_latents": str(materialized_input),
+                    },
+                }
+            ]
+        },
+    )
+
+    assert result["shared_sampling_inputs_match_rate"] == 1.0
 
 
 def test_diffusion_text_hf_parity_requires_token_ids() -> None:

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -4303,6 +4303,27 @@ def test_flux_task_eval_build_command_preserves_diffusion_shape(tmp_path: Path) 
     assert command[command.index("--num-inference-steps") + 1] == "20"
 
 
+def test_flux_fp8_build_command_resolves_model_owned_scales(tmp_path: Path) -> None:
+    model = next(
+        model
+        for model in task_eval.load_manifest_records()
+        if model["name"] == "flux-2-dev-fp8"
+    )
+
+    command = task_eval.build_bundle_command(
+        model,
+        trtmc_binary="build/trtmc",
+        bundle_path=tmp_path / "flux-2-dev-fp8.trtfb",
+    )
+
+    scales = Path(command[command.index("--fp8-scales") + 1])
+    assert scales == (
+        task_eval.REPO_ROOT
+        / "tests/e2e/models/flux/data/flux2-fp8-scales.json"
+    )
+    assert scales.is_file()
+
+
 def test_eval_one_model_diffusion_uses_clip_parity_summary(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -3231,6 +3231,40 @@ def test_ensure_bundle_removes_partial_replacement_after_failed_build(
     assert not bundle.exists()
 
 
+def test_ensure_bundle_replaces_dangling_shared_bundle_symlink(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    bundle = tmp_path / "shared" / "model.trtfb"
+    bundle.parent.mkdir()
+    bundle.symlink_to(tmp_path / "missing.trtfb")
+
+    class Result:
+        returncode = 0
+
+    def fake_run(command, **_kwargs):
+        output = Path(command[command.index("-o") + 1])
+        assert not output.is_symlink()
+        output.write_bytes(b"new")
+        return Result()
+
+    monkeypatch.setattr(task_eval.subprocess, "run", fake_run)
+
+    task_eval.ensure_bundle(
+        {
+            "name": "model",
+            "hf_id": "org/model",
+            "precision": "fp32",
+        },
+        bundle_path=bundle,
+        trtmc_binary="trtmc",
+        replace_existing=True,
+    )
+
+    assert not bundle.is_symlink()
+    assert bundle.read_bytes() == b"new"
+
+
 def test_suite_build_cache_minimum_overrides_manifest_cache() -> None:
     suite = {"build": {"min_max_cache_length": 1024}}
     model = {"max_cache_length": 256}

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -3630,6 +3630,30 @@ def test_run_trtfb_dispatches_diffusion_prompt_workdir(
     assert calls == ["diffusion"]
 
 
+def test_dataset_benchmark_reproduction_is_direct_and_uses_single_input(
+    tmp_path: Path,
+) -> None:
+    command = [
+        "/workspace/build/trtmc_dataset_benchmark",
+        "/runs/engines/model.trtfb",
+        "/runs/work/prompts.jsonl",
+        "/runs/work/trtfb_raw.jsonl",
+        "--max-new-tokens",
+        "8",
+    ]
+
+    task_eval._write_dataset_benchmark_reproduction(tmp_path, command)
+
+    payload = json.loads(
+        (tmp_path / "trtfb_repro.json").read_text(encoding="utf-8")
+    )
+    assert payload["backend"] == "trtmc_dataset_benchmark"
+    assert payload["command"][0] == "/workspace/build/trtmc_dataset_benchmark"
+    assert payload["command"][2] == "{input_jsonl}"
+    assert payload["command"][3] == "{trtmc_raw_jsonl}"
+    assert "task_eval.py" not in " ".join(payload["command"])
+
+
 def test_run_diffusion_trtfb_writes_image_artifact_predictions(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -3265,6 +3265,48 @@ def test_ensure_bundle_replaces_dangling_shared_bundle_symlink(
     assert bundle.read_bytes() == b"new"
 
 
+def test_ensure_bundle_replaces_incompatible_tensorrt_abi(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    bundle = tmp_path / "shared" / "model.trtfb"
+    bundle.parent.mkdir()
+    bundle.write_bytes(b"old")
+    commands: list[list[str]] = []
+
+    class Result:
+        returncode = 0
+        stdout = "TRT ABI:            11.0\nMax cache length:   256\n"
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        if command[1] == "inspect":
+            return Result()
+        output = Path(command[command.index("-o") + 1])
+        assert not output.exists()
+        output.write_bytes(b"new")
+        return Result()
+
+    monkeypatch.setattr(task_eval.subprocess, "run", fake_run)
+    monkeypatch.setattr(task_eval, "runtime_tensorrt_abi", lambda: "11.2")
+
+    _, built = task_eval.ensure_bundle(
+        {
+            "name": "model",
+            "hf_id": "org/model",
+            "precision": "fp32",
+        },
+        bundle_path=bundle,
+        trtmc_binary="trtmc",
+        max_cache_length=256,
+        replace_existing=True,
+    )
+
+    assert built is True
+    assert bundle.read_bytes() == b"new"
+    assert [command[1] for command in commands] == ["inspect", "build"]
+
+
 def test_suite_build_cache_minimum_overrides_manifest_cache() -> None:
     suite = {"build": {"min_max_cache_length": 1024}}
     model = {"max_cache_length": 256}

--- a/tests/tools/test_test_impact.py
+++ b/tests/tools/test_test_impact.py
@@ -1712,11 +1712,60 @@ class TestUnitTiers:
         assert match.unit_tiers == ["tools"]
         assert match.rebuild_cpp is False
 
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tools/reference/transformers_text.py",
+            "tools/reference/transformers_encoder.py",
+            "tools/reference/transformers_vlm.py",
+            "tools/reference/plugin_reference.py",
+            "tools/reference/speech.py",
+            "tools/reference/elf_prepared.py",
+            "tools/trtmc_compare.py",
+            "tools/trtmc_disagreements.py",
+            "tools/trtmc_reference.py",
+            "tools/trtmc_validate.py",
+        ],
+    )
+    def test_validation_tool_triggers_tools_tier(self, imap, path):
+        """Validation runner edits run tools-tier tests without E2E."""
+        match = test_impact.classify_file(path, imap)
+
+        assert match.rule == "validation_tool"
+        assert match.models == []
+        assert match.unit_tiers == ["tools"]
+        assert match.rebuild_cpp is False
+
     def test_task_eval_suite_config_triggers_tools_tier(self, imap):
         """task_eval suite config edits run tools-tier tests without E2E."""
         match = test_impact.classify_file("tests/task_eval/validation_suites.yaml", imap)
 
         assert match.rule == "task_eval_config"
+        assert match.models == []
+        assert match.unit_tiers == ["tools"]
+        assert match.rebuild_cpp is False
+
+    def test_validation_config_triggers_tools_tier(self, imap):
+        """Model-first validation catalog edits run tools-tier tests without E2E."""
+        match = test_impact.classify_file(
+            "tests/validation/model_workloads.yaml",
+            imap,
+        )
+
+        assert match.rule == "validation_config"
+        assert match.models == []
+        assert match.unit_tiers == ["tools"]
+        assert match.rebuild_cpp is False
+
+    def test_validation_reference_requirements_trigger_tools_tier(self, imap):
+        """The shared HF validation environment only affects tools-tier tests."""
+        match = test_impact.classify_file(
+            "python/tensorrt_model_connect/"
+            "python_profile_requirements/reference_common.lock.txt",
+            imap,
+        )
+
+        assert match.rule == "validation_reference_requirements"
         assert match.models == []
         assert match.unit_tiers == ["tools"]
         assert match.rebuild_cpp is False

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools import trtmc_reference
+
+
+def _prepare_work(path: Path) -> None:
+    path.mkdir(parents=True)
+    (path / "answers.json").write_text(
+        json.dumps({"requests": [{"sample_id": "one", "answer": "A"}]}),
+        encoding="utf-8",
+    )
+    (path / "prompts.jsonl").write_text(
+        json.dumps({"sample_id": "one", "prompt": "question"}) + "\n",
+        encoding="utf-8",
+    )
+    (path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "dataset_kind": "mmlu_json",
+                "files": {
+                    "answers": str(path / "answers.json"),
+                    "prompts": str(path / "prompts.jsonl"),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _args(work_dir: Path, cache_dir: Path, *extra: str):
+    return trtmc_reference.build_parser().parse_args(
+        [
+            "run",
+            "--model",
+            "org/model",
+            "--family",
+            "family",
+            "--reference-family",
+            "causal",
+            "--work-dir",
+            str(work_dir),
+            "--cache-dir",
+            str(cache_dir),
+            *extra,
+        ]
+    )
+
+
+def test_reference_cache_reuses_same_settings_across_work_directories(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    _prepare_work(first)
+    _prepare_work(second)
+    calls: list[Path] = []
+
+    def fake_reference(args) -> None:
+        work_dir = Path(args.work_dir)
+        calls.append(work_dir)
+        artifact = work_dir / "hf_artifacts" / "one.bin"
+        artifact.parent.mkdir()
+        artifact.write_bytes(b"reference")
+        (work_dir / "hf_predictions.json").write_text(
+            json.dumps(
+                {
+                    "responses": [
+                        {
+                            "sample_id": "one",
+                            "output_text": "A",
+                            "artifact": str(artifact),
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        (work_dir / "hf_raw.jsonl").write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        trtmc_reference.task_eval,
+        "run_hf_reference",
+        fake_reference,
+    )
+
+    assert trtmc_reference.run_reference(_args(first, cache_dir)) == "generated"
+    assert trtmc_reference.run_reference(_args(second, cache_dir)) == "reused"
+
+    assert calls == [first]
+    assert (first / "hf_predictions.json").is_symlink()
+    assert (second / "hf_predictions.json").is_symlink()
+    payload = json.loads(
+        (second / "hf_predictions.json").read_text(encoding="utf-8")
+    )
+    assert Path(payload["responses"][0]["artifact"]).read_bytes() == b"reference"
+    assert json.loads((second / "hf_cache.json").read_text(encoding="utf-8"))[
+        "status"
+    ] == "reused"
+    assert len([path for path in cache_dir.iterdir() if not path.name.startswith(".")]) == 1
+
+
+def test_reference_cache_key_changes_with_inference_setting(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    _prepare_work(first)
+    _prepare_work(second)
+    calls = 0
+
+    def fake_reference(args) -> None:
+        nonlocal calls
+        calls += 1
+        Path(args.work_dir, "hf_predictions.json").write_text(
+            json.dumps(
+                {"responses": [{"sample_id": "one", "output_text": "A"}]}
+            ),
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(
+        trtmc_reference.task_eval,
+        "run_hf_reference",
+        fake_reference,
+    )
+
+    trtmc_reference.run_reference(_args(first, cache_dir, "--seed", "1"))
+    trtmc_reference.run_reference(_args(second, cache_dir, "--seed", "2"))
+
+    assert calls == 2
+    assert len([path for path in cache_dir.iterdir() if not path.name.startswith(".")]) == 2
+
+
+def test_reference_cache_can_adopt_an_existing_result(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    work_dir = tmp_path / "existing"
+    _prepare_work(work_dir)
+    (work_dir / "hf_predictions.json").write_text(
+        json.dumps({"responses": [{"sample_id": "one", "output_text": "A"}]}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        trtmc_reference.task_eval,
+        "run_hf_reference",
+        lambda _args: (_ for _ in ()).throw(AssertionError("must not infer")),
+    )
+
+    status = trtmc_reference.run_reference(
+        _args(work_dir, cache_dir, "--adopt-existing")
+    )
+
+    assert status == "adopted"
+    assert (work_dir / "hf_predictions.json").is_symlink()

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -527,6 +527,49 @@ def test_plugin_reference_preserves_model_owned_subprocess_command() -> None:
     assert namespace["run_reference_subprocess"] is original
 
 
+def test_plugin_reference_preserves_direct_subprocess_command() -> None:
+    namespace: dict[str, object] = {}
+
+    def fake_subprocess_run(command, **_kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            command_was_run=list(command),
+        )
+
+    subprocess_module = SimpleNamespace(run=fake_subprocess_run)
+    namespace["subprocess"] = subprocess_module
+    exec(
+        "def run_stage(case, stage, context):\n"
+        "    completed = subprocess.run(\n"
+        "        [context.hf_python, '-c', case.script],\n"
+        "        capture_output=True,\n"
+        "    )\n"
+        "    return type('Output', (), {\n"
+        "        'metadata': {'returncode': completed.returncode},\n"
+        "        'command_was_run': completed.command_was_run,\n"
+        "    })()\n",
+        namespace,
+    )
+    reference = SimpleNamespace(run_stage=namespace["run_stage"])
+    case = SimpleNamespace(script="print('direct HF')")
+    context = SimpleNamespace(hf_python="/profiles/reference/bin/python")
+
+    output = plugin_reference._run_reference_stage(
+        reference,
+        case,
+        SimpleNamespace(name="end_to_end"),
+        context,
+    )
+
+    assert output.metadata["command"] == [
+        "/profiles/reference/bin/python",
+        "-c",
+        "print('direct HF')",
+    ]
+    assert output.command_was_run == output.metadata["command"]
+    assert subprocess_module.run is fake_subprocess_run
+
+
 def test_vlm_reference_metadata_is_direct_and_sample_selectable(
     tmp_path: Path,
 ) -> None:

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -8,7 +8,14 @@ from pathlib import Path
 import stat
 from types import SimpleNamespace
 
-from tools.reference import transformers_text
+from tools.reference import (
+    elf_prepared,
+    plugin_reference,
+    speech,
+    transformers_encoder,
+    transformers_text,
+    transformers_vlm,
+)
 from tools import trtmc_reference
 
 
@@ -182,6 +189,10 @@ def test_causal_reference_uses_native_transformers_entrypoint(
     _prepare_work(work_dir)
     arguments = _args(work_dir, cache_dir)
     arguments.reference_family = "causal_base_continuation"
+    manifest_path = work_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["dataset_kind"] = "mmlu_five_shot_json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
     captured = {}
 
     def fake_run(command, **kwargs):
@@ -260,3 +271,538 @@ def test_transformers_reference_metadata_is_direct_and_sample_selectable(
     assert command[command.index("--sample-id") + 1] == "{sample_id}"
     assert command[command.index("--prompts") + 1] == "{work_dir}/prompts.jsonl"
     assert "task_eval.py" not in " ".join(command)
+
+
+def test_encoder_reference_metadata_is_direct_and_sample_selectable(
+    tmp_path: Path,
+) -> None:
+    metadata = tmp_path / "reproduction.json"
+    arguments = transformers_encoder.build_parser().parse_args(
+        [
+            "--model",
+            "org/model",
+            "--reference-family",
+            "encoder_base_features",
+            "--prompts",
+            str(tmp_path / "prompts.jsonl"),
+            "--answers",
+            str(tmp_path / "answers.json"),
+            "--manifest",
+            str(tmp_path / "manifest.json"),
+            "--predictions",
+            str(tmp_path / "predictions.json"),
+            "--raw-output",
+            str(tmp_path / "raw.jsonl"),
+            "--repro-metadata",
+            str(metadata),
+            "--local-files-only",
+        ]
+    )
+
+    transformers_encoder._write_reproduction_metadata(arguments)
+
+    payload = json.loads(metadata.read_text(encoding="utf-8"))
+    command = payload["command"]
+    assert command[1].endswith("tools/reference/transformers_encoder.py")
+    assert command[command.index("--sample-id") + 1] == "{sample_id}"
+    assert command[command.index("--prompts") + 1] == "{work_dir}/prompts.jsonl"
+    assert "task_eval.py" not in " ".join(command)
+
+
+def test_native_reference_runner_uses_prepared_dataset_kind(tmp_path: Path) -> None:
+    work_dir = tmp_path / "work"
+    _prepare_work(work_dir)
+    arguments = _args(work_dir, tmp_path / "cache")
+    manifest_path = work_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    manifest["dataset_kind"] = "text_generation_json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    assert trtmc_reference._native_reference_runner(arguments).name == (
+        "transformers_text.py"
+    )
+
+    manifest["dataset_kind"] = "sts_pair_jsonl"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    assert trtmc_reference._native_reference_runner(arguments).name == (
+        "transformers_encoder.py"
+    )
+
+    manifest["dataset_kind"] = "diffusion_prompt_json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    assert trtmc_reference._native_reference_runner(arguments).name == (
+        "plugin_reference.py"
+    )
+
+    manifest["dataset_kind"] = "vlm_chat_json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    assert trtmc_reference._native_reference_runner(arguments).name == (
+        "transformers_vlm.py"
+    )
+
+    manifest["dataset_kind"] = "asr_chat_json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    assert trtmc_reference._native_reference_runner(arguments).name == "speech.py"
+
+    manifest["dataset_kind"] = "conditional_text_jsonl"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    assert trtmc_reference._native_reference_runner(arguments).name == (
+        "elf_prepared.py"
+    )
+
+
+def test_plugin_reference_metadata_uses_recorded_upstream_command(
+    tmp_path: Path,
+) -> None:
+    metadata = tmp_path / "reproduction.json"
+    arguments = plugin_reference.build_parser().parse_args(
+        [
+            "--model",
+            "org/model",
+            "--reference-family",
+            "diffusers_image_gen",
+            "--prompts",
+            str(tmp_path / "prompts.jsonl"),
+            "--answers",
+            str(tmp_path / "answers.json"),
+            "--manifest",
+            str(tmp_path / "manifest.json"),
+            "--predictions",
+            str(tmp_path / "predictions.json"),
+            "--raw-output",
+            str(tmp_path / "raw.jsonl"),
+            "--repro-metadata",
+            str(metadata),
+            "--local-files-only",
+        ]
+    )
+
+    plugin_reference._write_reproduction_metadata(arguments)
+
+    payload = json.loads(metadata.read_text(encoding="utf-8"))
+    assert payload["command_source"] == "hf_native_commands.jsonl"
+    assert "command" not in payload
+
+
+def test_plugin_reference_records_nested_upstream_command(tmp_path: Path) -> None:
+    command_path = tmp_path / "hf_native_commands.jsonl"
+    command_path.write_text("", encoding="utf-8")
+    output = SimpleNamespace(
+        metadata={
+            "backend": {
+                "command": [
+                    "/profiles/diffusers/bin/python",
+                    "/workspace/model/reference.py",
+                    "--prompt",
+                    "a red cube",
+                ]
+            }
+        }
+    )
+
+    plugin_reference._record_native_command(
+        command_path,
+        "sample-3",
+        output,
+    )
+
+    row = json.loads(command_path.read_text(encoding="utf-8"))
+    assert row["sample_id"] == "sample-3"
+    assert row["command"][1] == "/workspace/model/reference.py"
+    assert "plugin_reference.py" not in " ".join(row["command"])
+
+
+def test_vlm_reference_metadata_is_direct_and_sample_selectable(
+    tmp_path: Path,
+) -> None:
+    metadata = tmp_path / "reproduction.json"
+    arguments = transformers_vlm.build_parser().parse_args(
+        [
+            "--model",
+            "org/model",
+            "--reference-family",
+            "vl_instruct_qa",
+            "--prompts",
+            str(tmp_path / "prompts.jsonl"),
+            "--answers",
+            str(tmp_path / "answers.json"),
+            "--manifest",
+            str(tmp_path / "manifest.json"),
+            "--predictions",
+            str(tmp_path / "predictions.json"),
+            "--raw-output",
+            str(tmp_path / "raw.jsonl"),
+            "--repro-metadata",
+            str(metadata),
+            "--local-files-only",
+        ]
+    )
+
+    transformers_vlm._write_reproduction_metadata(arguments)
+
+    payload = json.loads(metadata.read_text(encoding="utf-8"))
+    command = payload["command"]
+    assert command[1].endswith("tools/reference/transformers_vlm.py")
+    assert command[command.index("--sample-id") + 1] == "{sample_id}"
+    assert command[command.index("--answers") + 1] == "{work_dir}/answers.json"
+    assert "task_eval.py" not in " ".join(command)
+
+
+def test_speech_reference_metadata_is_direct_and_sample_selectable(
+    tmp_path: Path,
+) -> None:
+    metadata = tmp_path / "reproduction.json"
+    arguments = speech.build_parser().parse_args(
+        [
+            "--model",
+            "openai/whisper-tiny",
+            "--family",
+            "whisper",
+            "--reference-family",
+            "asr_whisper",
+            "--prompts",
+            str(tmp_path / "prompts.jsonl"),
+            "--answers",
+            str(tmp_path / "answers.json"),
+            "--manifest",
+            str(tmp_path / "manifest.json"),
+            "--predictions",
+            str(tmp_path / "predictions.json"),
+            "--raw-output",
+            str(tmp_path / "raw.jsonl"),
+            "--repro-metadata",
+            str(metadata),
+            "--local-files-only",
+        ]
+    )
+
+    speech._write_reproduction_metadata(arguments)
+
+    payload = json.loads(metadata.read_text(encoding="utf-8"))
+    command = payload["command"]
+    assert command[1].endswith("tools/reference/speech.py")
+    assert command[command.index("--sample-id") + 1] == "{sample_id}"
+    assert command[command.index("--manifest") + 1] == "{work_dir}/manifest.json"
+    assert "task_eval.py" not in " ".join(command)
+
+
+def test_elf_metadata_points_to_official_reference_entrypoint(tmp_path: Path) -> None:
+    repo = tmp_path / "elf"
+    config = repo / "src/configs/model.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("{}\n", encoding="utf-8")
+    metadata = tmp_path / "reproduction.json"
+    arguments = elf_prepared.build_parser().parse_args(
+        [
+            "--model",
+            "org/elf",
+            "--elf-reference-repo",
+            str(repo),
+            "--prompts",
+            str(tmp_path / "prompts.jsonl"),
+            "--answers",
+            str(tmp_path / "answers.json"),
+            "--manifest",
+            str(tmp_path / "manifest.json"),
+            "--predictions",
+            str(tmp_path / "predictions.json"),
+            "--raw-output",
+            str(tmp_path / "raw.jsonl"),
+            "--repro-metadata",
+            str(metadata),
+        ]
+    )
+    manifest = {
+        "task_eval": {
+            "reference": {
+                "config": "src/configs/model.yaml",
+                "checkpoint": "org/elf",
+            }
+        },
+        "generation": {"generation_mode": "conditional"},
+    }
+
+    elf_prepared._write_reproduction_metadata(arguments, manifest)
+
+    payload = json.loads(metadata.read_text(encoding="utf-8"))
+    command = payload["command"]
+    assert command[1].endswith("tools/elf_hf_reference.py")
+    assert command[command.index("--dataset") + 1] == "{reference_input_jsonl}"
+    assert command[command.index("--seed") + 1] == "{reference_sample_seed}"
+    assert payload["base_seed"] == 42
+    assert "elf_prepared.py" not in " ".join(command)
+    assert "task_eval.py" not in " ".join(command)
+
+
+def test_speech_runner_dispatches_asr_without_task_eval(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    prompts = tmp_path / "prompts.jsonl"
+    answers = tmp_path / "answers.json"
+    manifest = tmp_path / "manifest.json"
+    predictions = tmp_path / "predictions.json"
+    raw_output = tmp_path / "raw.jsonl"
+    metadata = tmp_path / "reproduction.json"
+    prompts.write_text(
+        json.dumps({"sample_id": "asr-1", "audio": "/data/one.wav"}) + "\n",
+        encoding="utf-8",
+    )
+    answers.write_text(
+        json.dumps({"requests": [{"sample_id": "asr-1"}]}),
+        encoding="utf-8",
+    )
+    manifest.write_text(
+        json.dumps({"dataset_kind": "asr_chat_json", "generation": {}}),
+        encoding="utf-8",
+    )
+    calls = []
+
+    def fake_whisper(arguments, selected, generation):
+        calls.append((arguments.model, selected, generation))
+        return [
+            {
+                "sample_id": "asr-1",
+                "output_text": "hello",
+                "source": "hf",
+            }
+        ]
+
+    monkeypatch.setattr(speech, "_run_whisper_asr", fake_whisper)
+    arguments = speech.build_parser().parse_args(
+        [
+            "--model",
+            "openai/whisper-tiny",
+            "--family",
+            "whisper",
+            "--prompts",
+            str(prompts),
+            "--answers",
+            str(answers),
+            "--manifest",
+            str(manifest),
+            "--predictions",
+            str(predictions),
+            "--raw-output",
+            str(raw_output),
+            "--repro-metadata",
+            str(metadata),
+        ]
+    )
+
+    speech.run(arguments)
+
+    assert calls[0][0] == "openai/whisper-tiny"
+    assert calls[0][1][0]["sample_id"] == "asr-1"
+    assert json.loads(predictions.read_text(encoding="utf-8"))["responses"][0][
+        "output_text"
+    ] == "hello"
+    assert "task_eval.py" not in metadata.read_text(encoding="utf-8")
+
+
+def test_plugin_reference_records_actual_command_during_inference(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    prompts = tmp_path / "prompts.jsonl"
+    answers = tmp_path / "answers.json"
+    manifest = tmp_path / "manifest.json"
+    predictions = tmp_path / "hf_predictions.json"
+    raw_output = tmp_path / "hf_raw.jsonl"
+    metadata = tmp_path / "hf_native_repro.json"
+    prompts.write_text(
+        json.dumps(
+            {
+                "sample_id": "series-1",
+                "inputs": {"past_values": [1.0, 2.0]},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    answers.write_text(json.dumps({"requests": []}), encoding="utf-8")
+    manifest.write_text(
+        json.dumps(
+            {
+                "dataset_kind": "time_series_csv",
+                "task_eval": {"model_manifest": "unused.json"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    template = SimpleNamespace(
+        name="template",
+        inputs={},
+        stages=[SimpleNamespace(name="full_inference")],
+    )
+
+    class FakeReference:
+        def run_stage(self, case, stage, context):
+            assert case.name == "series-1"
+            assert stage.name == "full_inference"
+            assert context.artifacts_dir.endswith("hf_artifacts")
+            return SimpleNamespace(
+                data={
+                    "output_field": [3.0, 4.0],
+                    "output_shape": [1, 2],
+                },
+                metadata={
+                    "command": [
+                        "/profiles/timeseries/bin/python",
+                        "/workspace/model/reference.py",
+                        "--input",
+                        "series-1.csv",
+                    ],
+                    "returncode": 0,
+                },
+                timing_s=0.01,
+            )
+
+    monkeypatch.setattr(
+        plugin_reference,
+        "_load_reference_plugin",
+        lambda _manifest: (template, FakeReference()),
+    )
+    arguments = plugin_reference.build_parser().parse_args(
+        [
+            "--model",
+            "org/model",
+            "--prompts",
+            str(prompts),
+            "--answers",
+            str(answers),
+            "--manifest",
+            str(manifest),
+            "--predictions",
+            str(predictions),
+            "--raw-output",
+            str(raw_output),
+            "--repro-metadata",
+            str(metadata),
+        ]
+    )
+
+    plugin_reference.run(arguments)
+
+    response = json.loads(predictions.read_text(encoding="utf-8"))["responses"][0]
+    assert response["output_values"] == [3.0, 4.0]
+    command = json.loads(
+        (tmp_path / "hf_native_commands.jsonl").read_text(encoding="utf-8")
+    )["command"]
+    assert command[1] == "/workspace/model/reference.py"
+    assert "plugin_reference.py" not in " ".join(command)
+
+
+def test_elf_adapter_preserves_original_sample_seed_and_answer(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    reference_repo = tmp_path / "elf"
+    config = reference_repo / "src/configs/model.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("{}\n", encoding="utf-8")
+    prompts = tmp_path / "prompts.jsonl"
+    answers = tmp_path / "answers.json"
+    manifest = tmp_path / "manifest.json"
+    predictions = tmp_path / "hf_predictions.json"
+    raw_output = tmp_path / "hf_raw.jsonl"
+    metadata = tmp_path / "hf_native_repro.json"
+    prompts.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "sample_id": "elf-0",
+                        "source_text": "zero",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "sample_id": "elf-1",
+                        "source_text": "one",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    answers.write_text(
+        json.dumps(
+            {
+                "requests": [
+                    {"sample_id": "elf-0", "answer": "ZERO"},
+                    {"sample_id": "elf-1", "answer": "ONE"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifest.write_text(
+        json.dumps(
+            {
+                "dataset_kind": "conditional_text_jsonl",
+                "generation": {
+                    "generation_mode": "conditional",
+                    "sampling_method": "ode",
+                    "seed": 42,
+                },
+                "task_eval": {
+                    "reference": {
+                        "config": "src/configs/model.yaml",
+                        "checkpoint": "org/elf",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run(command, **_kwargs):
+        dataset = Path(command[command.index("--dataset") + 1])
+        row = json.loads(dataset.read_text(encoding="utf-8"))
+        assert row == {"id": "elf-1", "input": "one", "output": "ONE"}
+        assert command[command.index("--seed") + 1] == "43"
+        Path(command[command.index("--output") + 1]).write_text(
+            json.dumps(
+                {
+                    "responses": [
+                        {"sample_id": "elf-1", "output_text": "generated"}
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(elf_prepared.subprocess, "run", fake_run)
+    arguments = elf_prepared.build_parser().parse_args(
+        [
+            "--model",
+            "org/elf",
+            "--elf-reference-repo",
+            str(reference_repo),
+            "--prompts",
+            str(prompts),
+            "--answers",
+            str(answers),
+            "--manifest",
+            str(manifest),
+            "--predictions",
+            str(predictions),
+            "--raw-output",
+            str(raw_output),
+            "--repro-metadata",
+            str(metadata),
+            "--sample-id",
+            "elf-1",
+        ]
+    )
+
+    elf_prepared.run(arguments)
+
+    assert json.loads(predictions.read_text(encoding="utf-8"))["responses"][0][
+        "sample_id"
+    ] == "elf-1"
+    repro = json.loads(metadata.read_text(encoding="utf-8"))
+    assert repro["command"][1].endswith("tools/elf_hf_reference.py")

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import stat
+import sys
 from types import SimpleNamespace
 
 from tools.reference import (
@@ -17,6 +18,82 @@ from tools.reference import (
     transformers_vlm,
 )
 from tools import trtmc_reference
+
+
+def test_tts_transcriber_passes_local_files_only_once(monkeypatch) -> None:
+    load_calls: list[tuple[str, str, dict[str, object]]] = []
+    pipeline_call: dict[str, object] = {}
+    loaded_model = object()
+    loaded_processor = SimpleNamespace(
+        tokenizer=object(),
+        feature_extractor=SimpleNamespace(sampling_rate=16000),
+    )
+
+    class FakeTranscriber:
+        feature_extractor = SimpleNamespace(sampling_rate=16000)
+
+        def __call__(self, _waveforms, **_kwargs):
+            return [{"text": "hello"}]
+
+    class FakeModelLoader:
+        @staticmethod
+        def from_pretrained(model_id: str, **kwargs):
+            load_calls.append(("model", model_id, kwargs))
+            return loaded_model
+
+    class FakeProcessorLoader:
+        @staticmethod
+        def from_pretrained(model_id: str, **kwargs):
+            load_calls.append(("processor", model_id, kwargs))
+            return loaded_processor
+
+    def fake_pipeline(task: str, **kwargs):
+        assert task == "automatic-speech-recognition"
+        pipeline_call.update(kwargs)
+        return FakeTranscriber()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "torch",
+        SimpleNamespace(cuda=SimpleNamespace(is_available=lambda: False)),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(
+            AutoModelForSpeechSeq2Seq=FakeModelLoader,
+            AutoProcessor=FakeProcessorLoader,
+            pipeline=fake_pipeline,
+        ),
+    )
+    monkeypatch.setattr(
+        speech,
+        "_read_wav_float32",
+        lambda _path: ([0.0], 16000),
+    )
+    monkeypatch.setattr(
+        speech,
+        "_resample_audio",
+        lambda audio, _source_rate, _target_rate: audio,
+    )
+
+    result = speech._transcribe_tts(
+        SimpleNamespace(device="cuda", local_files_only=True),
+        [Path("sample.wav")],
+        "openai/whisper-tiny",
+    )
+
+    assert result == ["hello"]
+    assert load_calls == [
+        ("model", "openai/whisper-tiny", {"local_files_only": True}),
+        ("processor", "openai/whisper-tiny", {"local_files_only": True}),
+    ]
+    assert pipeline_call == {
+        "model": loaded_model,
+        "tokenizer": loaded_processor.tokenizer,
+        "feature_extractor": loaded_processor.feature_extractor,
+        "device": -1,
+    }
 
 
 def _prepare_work(path: Path) -> None:

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -97,6 +97,7 @@ def test_reference_cache_reuses_same_settings_across_work_directories(
     assert calls == [first]
     assert (first / "hf_predictions.json").is_symlink()
     assert (second / "hf_predictions.json").is_symlink()
+    assert not (second / "hf_predictions.json").readlink().is_absolute()
     payload = json.loads(
         (second / "hf_predictions.json").read_text(encoding="utf-8")
     )

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import stat
+from types import SimpleNamespace
 
+from tools.reference import transformers_text
 from tools import trtmc_reference
 
 
@@ -169,3 +171,92 @@ def test_reference_cache_can_adopt_an_existing_result(
 
     assert status == "adopted"
     assert (work_dir / "hf_predictions.json").is_symlink()
+
+
+def test_causal_reference_uses_native_transformers_entrypoint(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    work_dir = tmp_path / "native"
+    _prepare_work(work_dir)
+    arguments = _args(work_dir, cache_dir)
+    arguments.reference_family = "causal_base_continuation"
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        assert kwargs["stderr"] == trtmc_reference.subprocess.STDOUT
+        predictions = Path(command[command.index("--predictions") + 1])
+        raw_output = Path(command[command.index("--raw-output") + 1])
+        metadata = Path(command[command.index("--repro-metadata") + 1])
+        predictions.write_text(
+            json.dumps(
+                {"responses": [{"sample_id": "one", "output_text": "A"}]}
+            ),
+            encoding="utf-8",
+        )
+        raw_output.write_text("{}\n", encoding="utf-8")
+        metadata.write_text(
+            json.dumps(
+                {
+                    "command": [
+                        command[0],
+                        command[1],
+                        "--sample-id",
+                        "{sample_id}",
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(
+        trtmc_reference.task_eval,
+        "run_hf_reference",
+        lambda _args: (_ for _ in ()).throw(AssertionError("wrapper was used")),
+    )
+    monkeypatch.setattr(trtmc_reference.subprocess, "run", fake_run)
+
+    assert trtmc_reference.run_reference(arguments) == "generated"
+
+    command = captured["command"]
+    assert command[1].endswith("tools/reference/transformers_text.py")
+    assert "task_eval.py" not in " ".join(command)
+    assert (work_dir / "hf_native_run.log").is_symlink()
+    assert (work_dir / "hf_native_repro.json").is_symlink()
+
+
+def test_transformers_reference_metadata_is_direct_and_sample_selectable(
+    tmp_path: Path,
+) -> None:
+    metadata = tmp_path / "reproduction.json"
+    arguments = transformers_text.build_parser().parse_args(
+        [
+            "--model",
+            "org/model",
+            "--prompts",
+            str(tmp_path / "prompts.jsonl"),
+            "--answers",
+            str(tmp_path / "answers.json"),
+            "--manifest",
+            str(tmp_path / "manifest.json"),
+            "--predictions",
+            str(tmp_path / "predictions.json"),
+            "--raw-output",
+            str(tmp_path / "raw.jsonl"),
+            "--repro-metadata",
+            str(metadata),
+            "--local-files-only",
+        ]
+    )
+
+    transformers_text._write_reproduction_metadata(arguments)
+
+    payload = json.loads(metadata.read_text(encoding="utf-8"))
+    command = payload["command"]
+    assert command[1].endswith("tools/reference/transformers_text.py")
+    assert command[command.index("--sample-id") + 1] == "{sample_id}"
+    assert command[command.index("--prompts") + 1] == "{work_dir}/prompts.jsonl"
+    assert "task_eval.py" not in " ".join(command)

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -489,6 +489,44 @@ def test_plugin_reference_records_nested_upstream_command(tmp_path: Path) -> Non
     assert "plugin_reference.py" not in " ".join(row["command"])
 
 
+def test_plugin_reference_preserves_model_owned_subprocess_command() -> None:
+    namespace: dict[str, object] = {}
+
+    def fake_run_reference_subprocess(*, command, **_kwargs):
+        return SimpleNamespace(
+            metadata={"returncode": 0},
+            command_was_run=list(command),
+        )
+
+    namespace["run_reference_subprocess"] = fake_run_reference_subprocess
+    exec(
+        "def run_stage(case, stage, context):\n"
+        "    return run_reference_subprocess(\n"
+        "        command=[context.hf_python, '-c', case.script],\n"
+        "    )\n",
+        namespace,
+    )
+    original = namespace["run_reference_subprocess"]
+    reference = SimpleNamespace(run_stage=namespace["run_stage"])
+    case = SimpleNamespace(script="print('native HF')")
+    context = SimpleNamespace(hf_python="/profiles/reference/bin/python")
+
+    output = plugin_reference._run_reference_stage(
+        reference,
+        case,
+        SimpleNamespace(name="full_inference"),
+        context,
+    )
+
+    assert output.metadata["command"] == [
+        "/profiles/reference/bin/python",
+        "-c",
+        "print('native HF')",
+    ]
+    assert output.command_was_run == output.metadata["command"]
+    assert namespace["run_reference_subprocess"] is original
+
+
 def test_vlm_reference_metadata_is_direct_and_sample_selectable(
     tmp_path: Path,
 ) -> None:

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import stat
 
 from tools import trtmc_reference
 
@@ -105,7 +106,9 @@ def test_reference_cache_reuses_same_settings_across_work_directories(
     assert json.loads((second / "hf_cache.json").read_text(encoding="utf-8"))[
         "status"
     ] == "reused"
-    assert len([path for path in cache_dir.iterdir() if not path.name.startswith(".")]) == 1
+    entries = [path for path in cache_dir.iterdir() if not path.name.startswith(".")]
+    assert len(entries) == 1
+    assert stat.S_IMODE(entries[0].stat().st_mode) & 0o055 == 0o055
 
 
 def test_reference_cache_key_changes_with_inference_setting(

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 import stat
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 from tools.reference import (
     elf_prepared,
@@ -17,7 +17,17 @@ from tools.reference import (
     transformers_text,
     transformers_vlm,
 )
-from tools import trtmc_reference
+from tools import elf_hf_reference, trtmc_reference
+
+
+def test_elf_reference_uses_canonical_t5_cache_id() -> None:
+    assert elf_hf_reference._canonical_hf_model_id("t5-small") == "google-t5/t5-small"
+    assert elf_hf_reference._canonical_hf_model_id("org/custom") == "org/custom"
+
+
+def test_elf_reference_ignores_training_only_optimizer_state() -> None:
+    optimizer = elf_hf_reference._InferenceOptimizer()
+    assert optimizer.load_state_dict({"state": {"unused": True}}) is None
 
 
 def test_tts_transcriber_passes_local_files_only_once(monkeypatch) -> None:
@@ -231,6 +241,44 @@ def test_reference_cache_key_changes_with_inference_setting(
     assert len([path for path in cache_dir.iterdir() if not path.name.startswith(".")]) == 2
 
 
+def test_reference_cache_key_changes_with_model_revision(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    _prepare_work(first)
+    _prepare_work(second)
+    calls = 0
+
+    def fake_reference(args) -> None:
+        nonlocal calls
+        calls += 1
+        Path(args.work_dir, "hf_predictions.json").write_text(
+            json.dumps(
+                {"responses": [{"sample_id": "one", "output_text": "A"}]}
+            ),
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(
+        trtmc_reference.task_eval,
+        "run_hf_reference",
+        fake_reference,
+    )
+
+    trtmc_reference.run_reference(
+        _args(first, cache_dir, "--model-revision", "revision-one")
+    )
+    trtmc_reference.run_reference(
+        _args(second, cache_dir, "--model-revision", "revision-two")
+    )
+
+    assert calls == 2
+    assert len([path for path in cache_dir.iterdir() if not path.name.startswith(".")]) == 2
+
+
 def test_reference_cache_can_adopt_an_existing_result(
     tmp_path: Path,
     monkeypatch,
@@ -264,7 +312,12 @@ def test_causal_reference_uses_native_transformers_entrypoint(
     cache_dir = tmp_path / "cache"
     work_dir = tmp_path / "native"
     _prepare_work(work_dir)
-    arguments = _args(work_dir, cache_dir)
+    arguments = _args(
+        work_dir,
+        cache_dir,
+        "--model-revision",
+        "0123456789abcdef",
+    )
     arguments.reference_family = "causal_base_continuation"
     manifest_path = work_dir / "manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -311,6 +364,7 @@ def test_causal_reference_uses_native_transformers_entrypoint(
 
     command = captured["command"]
     assert command[1].endswith("tools/reference/transformers_text.py")
+    assert command[command.index("--model-revision") + 1] == "0123456789abcdef"
     assert "task_eval.py" not in " ".join(command)
     assert (work_dir / "hf_native_run.log").is_symlink()
     assert (work_dir / "hf_native_repro.json").is_symlink()
@@ -614,6 +668,8 @@ def test_speech_reference_metadata_is_direct_and_sample_selectable(
         [
             "--model",
             "openai/whisper-tiny",
+            "--model-revision",
+            "0123456789abcdef",
             "--family",
             "whisper",
             "--reference-family",
@@ -639,9 +695,100 @@ def test_speech_reference_metadata_is_direct_and_sample_selectable(
     payload = json.loads(metadata.read_text(encoding="utf-8"))
     command = payload["command"]
     assert command[1].endswith("tools/reference/speech.py")
+    assert command[command.index("--model-revision") + 1] == "0123456789abcdef"
     assert command[command.index("--sample-id") + 1] == "{sample_id}"
     assert command[command.index("--manifest") + 1] == "{work_dir}/manifest.json"
     assert "task_eval.py" not in " ".join(command)
+
+
+def test_magpie_reference_restores_exact_pinned_archive(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    archive = tmp_path / "magpie_tts_multilingual_357m.nemo"
+    archive.write_bytes(b"checkpoint")
+    speaker_checkpoint = tmp_path / "speaker.bin"
+    speaker_checkpoint.write_bytes(b"speaker")
+    download_calls: list[dict[str, object]] = []
+    opened_paths: list[object] = []
+    restore_kwargs: dict[str, object] = {}
+
+    def fake_hf_hub_download(**kwargs):
+        download_calls.append(kwargs)
+        if kwargs["repo_id"] == speech.MAGPIE_SPEAKER_ENCODER_REPO:
+            return str(speaker_checkpoint)
+        return str(archive)
+
+    def fake_fsspec_open(path, *_args, **_kwargs):
+        opened_paths.append(path)
+        return object()
+
+    class FakeModel:
+        @classmethod
+        def restore_from(cls, **kwargs):
+            import fsspec
+
+            fsspec.open(speech.MAGPIE_SPEAKER_ENCODER_URL)
+            restore_kwargs.update(kwargs)
+            return cls()
+
+        def eval(self):
+            return self
+
+        def to(self, device):
+            restore_kwargs["device"] = device
+            return self
+
+    huggingface_hub = ModuleType("huggingface_hub")
+    huggingface_hub.hf_hub_download = fake_hf_hub_download
+    fsspec = ModuleType("fsspec")
+    fsspec.open = fake_fsspec_open
+    nemo = ModuleType("nemo")
+    nemo.__path__ = []
+    collections = ModuleType("nemo.collections")
+    collections.__path__ = []
+    tts = ModuleType("nemo.collections.tts")
+    tts.__path__ = []
+    models = ModuleType("nemo.collections.tts.models")
+    models.MagpieTTSModel = FakeModel
+    monkeypatch.setitem(sys.modules, "huggingface_hub", huggingface_hub)
+    monkeypatch.setitem(sys.modules, "fsspec", fsspec)
+    monkeypatch.setitem(sys.modules, "nemo", nemo)
+    monkeypatch.setitem(sys.modules, "nemo.collections", collections)
+    monkeypatch.setitem(sys.modules, "nemo.collections.tts", tts)
+    monkeypatch.setitem(sys.modules, "nemo.collections.tts.models", models)
+
+    arguments = SimpleNamespace(
+        model="nvidia/magpie_tts_multilingual_357m",
+        model_revision="34d7e40da85cabc97f92198889b65cea27bc7fd1",
+        local_files_only=True,
+        device="cuda",
+    )
+    processor, model = speech._load_tts_runtime(
+        arguments,
+        SimpleNamespace(device=lambda name: f"device:{name}"),
+    )
+
+    assert processor is None
+    assert isinstance(model, FakeModel)
+    assert download_calls == [
+        {
+            "repo_id": speech.MAGPIE_SPEAKER_ENCODER_REPO,
+            "filename": speech.MAGPIE_SPEAKER_ENCODER_FILENAME,
+            "local_files_only": True,
+        },
+        {
+            "repo_id": "nvidia/magpie_tts_multilingual_357m",
+            "filename": "magpie_tts_multilingual_357m.nemo",
+            "local_files_only": True,
+            "revision": "34d7e40da85cabc97f92198889b65cea27bc7fd1",
+        },
+    ]
+    assert opened_paths == [str(speaker_checkpoint)]
+    assert restore_kwargs == {
+        "restore_path": str(archive),
+        "device": "device:cuda",
+    }
 
 
 def test_elf_metadata_points_to_official_reference_entrypoint(tmp_path: Path) -> None:
@@ -756,6 +903,94 @@ def test_speech_runner_dispatches_asr_without_task_eval(
         "output_text"
     ] == "hello"
     assert "task_eval.py" not in metadata.read_text(encoding="utf-8")
+
+
+def test_nemotron35_asr_restores_nemo_archive_and_uses_language_manifest(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    archive = tmp_path / "nemotron.nemo"
+    archive.write_bytes(b"archive")
+    transcribe_calls: list[tuple[str, int]] = []
+
+    class FakeCuda:
+        @staticmethod
+        def is_available() -> bool:
+            return False
+
+        @staticmethod
+        def empty_cache() -> None:
+            return None
+
+    fake_torch = SimpleNamespace(cuda=FakeCuda())
+
+    class FakeModel:
+        def transcribe(self, manifest_path, *, batch_size, verbose):
+            rows = [
+                json.loads(line)
+                for line in Path(manifest_path)
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            expected_audio = (
+                tmp_path
+                / "predictions"
+                / "hf_canary_audio"
+                / "asr-1.wav"
+            )
+            assert rows == [
+                {
+                    "audio_filepath": str(expected_audio),
+                    "duration": 0.5,
+                    "text": "",
+                    "lang": "en-US",
+                }
+            ]
+            transcribe_calls.append((manifest_path, batch_size))
+            assert verbose is False
+            return [SimpleNamespace(text="CONCORD RETURNED")]
+
+    monkeypatch.setattr(
+        speech,
+        "_load_nemotron35_model",
+        lambda _arguments, resolved_archive: (
+            fake_torch,
+            FakeModel(),
+        ),
+    )
+    monkeypatch.setattr(
+        speech,
+        "_resolve_nemotron35_archive",
+        lambda _arguments: archive,
+    )
+    monkeypatch.setattr(
+        speech,
+        "_audio_for_prompt",
+        lambda _prompt, _rate: ([0.0] * 8000, Path("source.wav")),
+    )
+
+    def write_fake_wav(path, _audio, _rate):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"wav")
+
+    monkeypatch.setattr(speech, "_write_wav_pcm16", write_fake_wav)
+    arguments = SimpleNamespace(
+        model="nvidia/nemotron-3.5-asr-streaming-0.6b",
+        device="cuda",
+        dtype="auto",
+        local_files_only=True,
+        predictions=tmp_path / "predictions" / "hf_predictions.json",
+    )
+
+    responses = speech._run_nemotron35_asr(
+        arguments,
+        [{"sample_id": "asr-1", "language": "en-US"}],
+        {"sample_rate": 16000},
+    )
+
+    assert len(transcribe_calls) == 1
+    assert responses[0]["output_text"] == "CONCORD RETURNED"
+    assert responses[0]["generated_token_ids"] is None
 
 
 def test_plugin_reference_records_actual_command_during_inference(

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -921,6 +921,27 @@ def test_compare_entrypoint_forwards_to_validation_backend(monkeypatch):
             "failed",
         ),
         (
+            {
+                "status": "failed",
+                "prediction_agreement_rate": 0.5,
+                "gate_failures": [
+                    {
+                        "gate": "min_prediction_agreement_rate",
+                        "actual": 0.5,
+                        "required": 0.98,
+                    }
+                ],
+                "error_type": "BenchmarkGateError",
+                "error": (
+                    "min_prediction_agreement_rate "
+                    "actual=0.5 required=0.98"
+                ),
+            },
+            "completed",
+            "disagreement",
+            "failed",
+        ),
+        (
             {"status": "failed", "error": "runner crashed"},
             "error",
             "not_run",

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 
 import argparse
 import json
+from pathlib import Path
 
 import pytest
 
 from tools import task_eval
 from tools import trtmc_compare
+from tools import trtmc_disagreements
+from tools import trtmc_reference
 from tools import trtmc_validate
 
 
@@ -30,6 +33,27 @@ def test_model_workload_catalog_covers_every_ready_model():
     )
 
     assert len(catalog["models"]) == len(trtmc_validate.ready_model_names())
+
+
+def test_every_dataset_backed_validation_binding_has_native_reference_runner():
+    catalog = trtmc_validate.load_catalog()
+    suites = {suite["id"]: suite for suite in task_eval.load_suites()}
+    bindings = [
+        (model_name, workload)
+        for model_name, spec in catalog["models"].items()
+        for workload in spec["workloads"]
+        if workload != "e2e"
+    ]
+    missing = []
+    for model_name, workload in bindings:
+        dataset_kind = str(suites[workload]["dataset"]["kind"])
+        if trtmc_reference.native_reference_runner_for_dataset_kind(
+            dataset_kind
+        ) is None:
+            missing.append((model_name, workload, dataset_kind))
+
+    assert not missing
+    assert len({model for model, _workload in bindings}) == 111
 
 
 def test_resolve_binding_defaults_and_rejects_undeclared_workload():
@@ -367,7 +391,11 @@ def test_report_adds_failed_sample_results_and_native_commands(tmp_path):
     case_dir = tmp_path / "model-a" / "workload-a"
     work_dir = case_dir / "validation" / "workload-a" / "model-a"
     work_dir.mkdir(parents=True)
-    prompt = {"sample_id": "sample-7", "prompt": "Complete this sentence"}
+    prompt = {
+        "sample_id": "sample-7",
+        "eval_index": 7,
+        "prompt": "Complete this sentence",
+    }
     (work_dir / "prompts.jsonl").write_text(
         json.dumps(prompt) + "\n",
         encoding="utf-8",
@@ -441,7 +469,10 @@ def test_report_adds_failed_sample_results_and_native_commands(tmp_path):
                     "{trtmc_raw_jsonl}",
                     "--max-new-tokens",
                     "8",
-                ]
+                    "--seed",
+                    "{sample_seed}",
+                ],
+                "base_seed": 42,
             }
         ),
         encoding="utf-8",
@@ -477,6 +508,7 @@ def test_report_adds_failed_sample_results_and_native_commands(tmp_path):
     assert records[0]["reproduce"]["trtmc"].startswith(
         "/workspace/build/trtmc_dataset_benchmark model.trtfb"
     )
+    assert records[0]["reproduce"]["trtmc"].endswith("--seed 49")
     assert (case_dir / records[0]["artifacts"]["trtmc_input"]).read_text(
         encoding="utf-8"
     ) == json.dumps(prompt, ensure_ascii=False) + "\n"
@@ -495,6 +527,147 @@ def test_report_adds_failed_sample_results_and_native_commands(tmp_path):
         "trtmc_validate.py",
     ):
         assert wrapper not in json.dumps(records)
+
+
+def test_failed_sample_uses_recorded_trtmc_command_and_copies_media(tmp_path):
+    case_dir = tmp_path / "model-a" / "workload-a"
+    work_dir = case_dir / "validation" / "workload-a" / "model-a"
+    frames = work_dir / "reference_frames"
+    frames.mkdir(parents=True)
+    input_image = work_dir / "input.png"
+    reference_image = frames / "000.png"
+    trtmc_audio = work_dir / "output.wav"
+    input_image.write_bytes(b"input-image")
+    reference_image.write_bytes(b"reference-image")
+    trtmc_audio.write_bytes(b"RIFFfake-wave")
+    prompt = {
+        "sample_id": "sample-9",
+        "prompt": "Describe",
+        "images": [str(input_image)],
+    }
+    (work_dir / "prompts.jsonl").write_text(
+        json.dumps(prompt) + "\n",
+        encoding="utf-8",
+    )
+    (work_dir / "answers.json").write_text(
+        json.dumps({"requests": [{"sample_id": "sample-9", "answer": "A"}]}),
+        encoding="utf-8",
+    )
+    (work_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "disagreements": [
+                    {"sample_id": "sample-9", "status": "failed"}
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (work_dir / "hf_predictions.json").write_text(
+        json.dumps(
+            {
+                "responses": [
+                    {
+                        "sample_id": "sample-9",
+                        "frames_dir": str(frames),
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (work_dir / "trtfb_predictions.json").write_text(
+        json.dumps(
+            {
+                "responses": [
+                    {
+                        "sample_id": "sample-9",
+                        "wav_path": str(trtmc_audio),
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    native_command = [
+        "/workspace/build/trtmc",
+        "run",
+        "/runs/engines/model.trtfb",
+        "--prompt",
+        "Describe",
+    ]
+    (work_dir / "trtfb_native_commands.jsonl").write_text(
+        json.dumps({"sample_id": "sample-9", "command": native_command}) + "\n",
+        encoding="utf-8",
+    )
+    reference_command = [
+        "/profiles/reference/bin/python",
+        "/workspace/model/reference.py",
+        "--input",
+        str(input_image),
+    ]
+    (work_dir / "hf_native_commands.jsonl").write_text(
+        json.dumps(
+            {"sample_id": "sample-9", "command": reference_command}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    metadata = trtmc_disagreements.build_disagreement_artifact(
+        work_dir=work_dir,
+        case_dir=case_dir,
+    )
+
+    record = json.loads(
+        (case_dir / metadata["path"]).read_text(encoding="utf-8")
+    )
+    assert record["reproduce"]["trtmc"] == (
+        "/workspace/build/trtmc run /runs/engines/model.trtfb "
+        "--prompt Describe"
+    )
+    assert record["reproduce"]["reference"].startswith(
+        "/profiles/reference/bin/python /workspace/model/reference.py"
+    )
+    media = record["artifacts"]["media"]
+    assert {item["kind"] for item in media} == {"image", "audio"}
+    assert all((case_dir / item["path"]).is_file() for item in media)
+    rendered = trtmc_validate._render_disagreement_record(
+        record,
+        asset_base=Path("model-a/workload-a"),
+    )
+    assert "<img " in rendered
+    assert "<audio " in rendered
+    assert "task_eval.py" not in rendered
+
+
+def test_failed_encoder_pair_expands_to_both_reproducible_samples():
+    rows = [
+        {
+            "pair_id": "sts-4",
+            "passed": False,
+            "cosine_abs_delta": 0.2,
+        }
+    ]
+    prompts = {
+        "sts-4-a": {
+            "sample_id": "sts-4-a",
+            "pair_id": "sts-4",
+            "pair_side": "sentence1",
+        },
+        "sts-4-b": {
+            "sample_id": "sts-4-b",
+            "pair_id": "sts-4",
+            "pair_side": "sentence2",
+        },
+    }
+
+    expanded = trtmc_disagreements._expand_pair_disagreements(rows, prompts)
+
+    assert [row["sample_id"] for row in expanded] == [
+        "sts-4-a",
+        "sts-4-b",
+    ]
 
 
 def test_report_bounds_inline_failed_samples_but_keeps_full_artifact(tmp_path):

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -20,10 +20,11 @@ def test_model_workload_catalog_covers_every_ready_model():
     catalog = trtmc_validate.load_catalog()
     suites = task_eval.load_suites()
     task_models = trtmc_validate._task_eval_models(trtmc_validate.DEFAULT_MODELS)
+    ready_models = trtmc_validate.ready_model_names()
 
     trtmc_validate.audit_catalog(
         catalog,
-        ready_models=trtmc_validate.ready_model_names(),
+        ready_models=ready_models,
         suite_names=(suite["id"] for suite in suites),
     )
     trtmc_validate.audit_workload_compatibility(
@@ -32,7 +33,25 @@ def test_model_workload_catalog_covers_every_ready_model():
         task_models=task_models,
     )
 
-    assert len(catalog["models"]) == len(trtmc_validate.ready_model_names())
+    assert len(catalog["models"]) == len(ready_models) == 105
+
+
+def test_validation_ready_models_exclude_l0_only_profiles():
+    records = task_eval.load_manifest_records(trtmc_validate.DEFAULT_MODELS)
+    eligible = {
+        str(record["name"])
+        for record in records
+        if not record["requires_multi_device"] and not record.get("skip")
+    }
+    l0_only = {
+        str(record["name"])
+        for record in records
+        if record.get("ci_tier") == "l0_only"
+    }
+    selected = set(trtmc_validate.ready_model_names())
+
+    assert l0_only
+    assert selected == eligible - l0_only
 
 
 def test_catalog_defines_sample_limit_for_every_dataset_workload():
@@ -71,7 +90,7 @@ def test_every_dataset_backed_validation_binding_has_native_reference_runner():
             missing.append((model_name, workload, dataset_kind))
 
     assert not missing
-    assert len({model for model, _workload in bindings}) == 111
+    assert len({model for model, _workload in bindings}) == 95
 
 
 def test_resolve_binding_defaults_and_rejects_undeclared_workload():

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -7,6 +7,7 @@ import argparse
 from datetime import datetime, timezone
 import json
 from pathlib import Path
+import shlex
 
 import pytest
 
@@ -498,6 +499,25 @@ def test_default_reference_backends_share_common_environment(reference_backend):
     )
 
 
+def test_model_specific_reference_environment_keeps_common_validation_base() -> None:
+    profiles = trtmc_validate._binding_profiles(
+        trtmc_validate.Binding("elf", "dataset"),
+        task_models={
+            "elf": {
+                "family": "elf_flow",
+                "runtime_strategy": "elf_flow",
+                "reference_backend": "hf_transformers",
+            }
+        },
+        e2e_models={},
+    )
+
+    assert profiles == (
+        trtmc_validate.COMMON_REFERENCE_PROFILE,
+        "elf_flow_reference",
+    )
+
+
 def test_ensure_environments_reports_create_only_when_resolver_creates(monkeypatch, capsys):
     calls = 0
 
@@ -527,6 +547,90 @@ def test_ensure_environments_reports_create_only_when_resolver_creates(monkeypat
     assert "Using reference environment: /profiles/reference_common/bin/python" in (warm_output)
     assert cold.base_python == "/profiles/reference_common/bin/python"
     assert warm.base_python == cold.base_python
+
+
+def test_reference_sources_create_once_then_reuse(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    source = trtmc_validate.ReferenceSource(
+        name="ELF",
+        repository="https://example.invalid/ELF.git",
+        revision="0123456789abcdef",
+        relative_checkout=Path("elf/reference/ELF-0123456789ab"),
+        entrypoint=Path("src/entrypoint.py"),
+    )
+    commands: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        commands.append(list(command))
+        if command[1] == "-C":
+            checkout = Path(command[2])
+            entrypoint = checkout / source.entrypoint
+            entrypoint.parent.mkdir(parents=True)
+            entrypoint.write_text("# reference\n", encoding="utf-8")
+        return argparse.Namespace(returncode=0)
+
+    monkeypatch.setattr(trtmc_validate.subprocess, "run", fake_run)
+
+    cold = trtmc_validate._ensure_reference_source(source, tmp_path)
+    cold_output = capsys.readouterr().out
+    command_count = len(commands)
+    warm = trtmc_validate._ensure_reference_source(source, tmp_path)
+    warm_output = capsys.readouterr().out
+
+    assert cold == warm == tmp_path / source.relative_checkout
+    assert command_count == 2
+    assert len(commands) == command_count
+    assert "Creating reference source: ELF" in cold_output
+    assert f"Using reference source: {cold}" in cold_output
+    assert "Creating reference source" not in warm_output
+    assert f"Using reference source: {warm}" in warm_output
+
+
+def test_elf_reference_source_is_pinned_to_upstream_pytorch_implementation() -> None:
+    assert trtmc_validate.ELF_SOURCE.revision == (
+        "b29d8833609e9ab7f67cd9da39435ac5cea04837"
+    )
+    assert trtmc_validate.ELF_SOURCE.relative_checkout == Path(
+        "elf/reference/ELF-b29d8833609e"
+    )
+
+
+def test_reference_sources_select_model_specific_inputs(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    prepared: list[str] = []
+
+    def prepare(source, cache_root):
+        prepared.append(source.name)
+        checkout = cache_root / source.relative_checkout
+        entrypoint = checkout / source.entrypoint
+        entrypoint.parent.mkdir(parents=True)
+        entrypoint.write_text("# reference\n", encoding="utf-8")
+        return checkout
+
+    monkeypatch.setattr(trtmc_validate, "_ensure_reference_source", prepare)
+
+    elf = trtmc_validate.ensure_reference_sources("elf_flow", tmp_path)
+    sana = trtmc_validate.ensure_reference_sources("sana_wm", tmp_path)
+    common = trtmc_validate.ensure_reference_sources("bert", tmp_path)
+
+    assert prepared == ["ELF", "SANA-WM"]
+    assert (
+        elf.elf_reference_repo
+        == tmp_path / trtmc_validate.ELF_SOURCE.relative_checkout
+    )
+    assert elf.environment["TRTMC_STORAGE_ROOT"] == str(tmp_path)
+    assert sana.environment["SANA_WM_SCRIPT"] == str(
+        tmp_path
+        / trtmc_validate.SANA_WM_SOURCE.relative_checkout
+        / trtmc_validate.SANA_WM_SOURCE.entrypoint
+    )
+    assert common.elf_reference_repo is None
+    assert common.environment == {"TRTMC_STORAGE_ROOT": str(tmp_path)}
 
 
 def test_print_result_only_exposes_raw_commands_and_result_locations(tmp_path, capsys):
@@ -961,6 +1065,32 @@ def test_report_adds_failed_sample_results_and_native_commands(tmp_path):
         assert wrapper not in json.dumps(records)
 
 
+def test_cached_reference_command_is_relocated_to_current_work_dir(
+    tmp_path: Path,
+) -> None:
+    work_dir = tmp_path / "current run"
+    work_dir.mkdir()
+    (work_dir / "prompts.jsonl").write_text(
+        json.dumps({"sample_id": "sample-1"}) + "\n",
+        encoding="utf-8",
+    )
+    old_work_dir = Path("/runs/results/old-run/model/workload")
+    (work_dir / "hf_native_run.log").write_text(
+        "$ python reference.py "
+        f"--prompts {shlex.quote(str(old_work_dir / 'prompts.jsonl'))} "
+        f"--answers {shlex.quote(str(old_work_dir / 'answers.json'))} "
+        f"--manifest {shlex.quote(str(old_work_dir / 'manifest.json'))} "
+        f"--output {shlex.quote(str(old_work_dir / 'hf_predictions.json'))}\n",
+        encoding="utf-8",
+    )
+
+    command = trtmc_validate._commands_from_logs(work_dir)["hf"][0]
+
+    assert str(old_work_dir) not in command
+    assert shlex.quote(str(work_dir / "prompts.jsonl")) in command
+    assert shlex.quote(str(work_dir / "hf_predictions.json")) in command
+
+
 def test_failed_sample_uses_recorded_trtmc_command_and_copies_media(tmp_path):
     case_dir = tmp_path / "model-a" / "workload-a"
     work_dir = case_dir / "validation" / "workload-a" / "model-a"
@@ -1305,7 +1435,7 @@ def test_comparison_command_uses_validation_entrypoint(tmp_path):
     )
 
     assert command[:2] == [
-        trtmc_validate.sys.executable,
+        "/profiles/python",
         str(trtmc_validate.REPO_ROOT / "tools" / "trtmc_compare.py"),
     ]
     assert "task_eval.py" not in " ".join(command)
@@ -1322,6 +1452,109 @@ def test_comparison_command_uses_validation_entrypoint(tmp_path):
     assert "--force-hf" in command
     assert "--require-prebuilt-bundles" in command
     assert "--local-files-only" in command
+
+
+def test_comparison_command_passes_elf_reference_checkout(tmp_path):
+    arguments = trtmc_validate.build_parser().parse_args([])
+    arguments.engine_dir = tmp_path / "engines"
+    arguments.reference_cache_dir = tmp_path / "references"
+    arguments.trtmc_binary = tmp_path / "trtmc"
+    arguments.benchmark_binary = tmp_path / "trtmc_dataset_benchmark"
+    arguments.limit = 1
+    reference_sources = trtmc_validate.ReferenceSourceSelection(
+        environment={},
+        elf_reference_repo=tmp_path / "sources" / "elf",
+    )
+
+    command = trtmc_validate._comparison_command(
+        trtmc_validate.Binding("elf-b", "elf-workload"),
+        case_dir=tmp_path / "case",
+        dataset=tmp_path / "dataset.json",
+        arguments=arguments,
+        reference_python="/profiles/python",
+        reference_sources=reference_sources,
+    )
+
+    assert command[command.index("--elf-reference-repo") + 1] == str(
+        reference_sources.elf_reference_repo
+    )
+
+
+def test_run_binding_wires_reference_source_command_and_environment(
+    tmp_path,
+    monkeypatch,
+):
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "elf-b",
+            "elf-workload",
+            "--output",
+            str(tmp_path / "results"),
+            "--dataset",
+            str(tmp_path / "dataset.json"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+        ]
+    )
+    selection = trtmc_validate.ReferenceSourceSelection(
+        environment={
+            "TRTMC_STORAGE_ROOT": str(tmp_path / "references"),
+            "EXTERNAL_REFERENCE_SENTINEL": "present",
+        },
+        elf_reference_repo=tmp_path / "references" / "elf",
+    )
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        trtmc_validate,
+        "ensure_environments",
+        lambda _profiles, _base: trtmc_validate.EnvironmentSelection(
+            base_python="/profiles/python",
+            names_and_paths=(),
+            overrides={},
+        ),
+    )
+    monkeypatch.setattr(
+        trtmc_validate,
+        "ensure_reference_sources",
+        lambda _family, _cache: selection,
+    )
+
+    def run(command, _log_path, environment):
+        captured["command"] = command
+        captured["environment"] = environment
+        return 0
+
+    monkeypatch.setattr(trtmc_validate, "_run_subprocess", run)
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_comparison_result",
+        lambda binding, **_kwargs: {
+            "model": binding.model,
+            "workload": binding.workload,
+        },
+    )
+
+    trtmc_validate.run_binding(
+        trtmc_validate.Binding("elf-b", "elf-workload"),
+        arguments=arguments,
+        task_models={
+            "elf-b": {
+                "family": "elf_flow",
+                "runtime_strategy": "elf_flow",
+                "reference_backend": "torch_reference",
+                "execution_profiles": {},
+            }
+        },
+        e2e_models={},
+        suites={"elf-workload": {}},
+    )
+
+    command = captured["command"]
+    assert command[command.index("--elf-reference-repo") + 1] == str(
+        selection.elf_reference_repo
+    )
+    assert captured["environment"]["EXTERNAL_REFERENCE_SENTINEL"] == "present"
 
 
 def test_compare_entrypoint_forwards_to_validation_backend(monkeypatch):

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -140,6 +140,325 @@ def test_resolve_sample_limit_uses_workload_policy_and_cli_override():
     )
 
 
+def test_all_defaults_to_continue_and_accepts_stop_policy():
+    parser = trtmc_validate.build_parser()
+
+    default = parser.parse_args(["--all"])
+    stop = parser.parse_args(["--all", "--on-model-failure", "stop"])
+
+    assert default.on_model_failure == "continue"
+    assert stop.on_model_failure == "stop"
+
+
+@pytest.mark.parametrize(
+    ("policy", "expected_models"),
+    [
+        ("continue", ["model-a", "model-b"]),
+        ("stop", ["model-a"]),
+    ],
+)
+def test_all_supervisor_applies_model_failure_policy(
+    tmp_path,
+    monkeypatch,
+    policy,
+    expected_models,
+):
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "--all",
+            "--on-model-failure",
+            policy,
+            "--output",
+            str(tmp_path / "results"),
+            "--engine-dir",
+            str(tmp_path / "engines"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+        ]
+    )
+    bindings = [
+        trtmc_validate.Binding("model-a", "workload-a"),
+        trtmc_validate.Binding("model-b", "workload-b"),
+    ]
+    catalog = {
+        "sample_limits": {
+            "workload-a": 5,
+            "workload-b": 10,
+        }
+    }
+    attempted = []
+
+    def run_worker(binding, *, arguments, catalog):
+        attempted.append(binding.model)
+        status = "failed" if binding.model == "model-a" else "passed"
+        return {
+            "model": binding.model,
+            "workload": binding.workload,
+            "validation": {"status": status},
+        }
+
+    monkeypatch.setattr(trtmc_validate, "_run_supervised_binding", run_worker)
+    monkeypatch.setattr(trtmc_validate, "write_run_metadata", lambda output: output)
+    monkeypatch.setattr(
+        trtmc_validate,
+        "write_report",
+        lambda output: (
+            output / "report.json",
+            output / "report.html",
+            {},
+        ),
+    )
+    monkeypatch.setattr(trtmc_validate, "_print_result", lambda *args: None)
+
+    returncode = trtmc_validate._run_all_bindings(
+        bindings,
+        arguments=arguments,
+        catalog=catalog,
+    )
+
+    assert returncode == 1
+    assert attempted == expected_models
+
+
+def test_supervised_binding_replaces_stale_result_with_worker_crash(tmp_path, monkeypatch):
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "--all",
+            "--output",
+            str(tmp_path / "results"),
+            "--engine-dir",
+            str(tmp_path / "engines"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+            "--local-files-only",
+        ]
+    )
+    binding = trtmc_validate.Binding("model-a", "workload-a")
+    catalog = {"sample_limits": {"workload-a": 5}}
+    case_dir = arguments.output / binding.model / binding.workload
+    case_dir.mkdir(parents=True)
+    comparison = case_dir / "comparison.json"
+    comparison.write_text(
+        json.dumps(
+            {
+                "model": binding.model,
+                "workload": binding.workload,
+                "status": "passed",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def crash(command, log_path, env):
+        log_path.write_text("worker crashed before comparison\n", encoding="utf-8")
+        return 2
+
+    monkeypatch.setattr(trtmc_validate, "_run_subprocess", crash)
+
+    result = trtmc_validate._run_supervised_binding(
+        binding,
+        arguments=arguments,
+        catalog=catalog,
+    )
+
+    assert result["execution"] == {"status": "error", "exit_code": 2}
+    assert result["comparison"]["status"] == "not_run"
+    assert result["validation"]["status"] == "failed"
+    assert result["raw_result"]["error_type"] == "WorkerProcessError"
+    assert result["reproduce"]["dataset"]["sample_limit"] == 5
+    assert "--model-worker" in result["reproduce"]["dataset"]["command"]
+    assert "--local-files-only" in result["reproduce"]["dataset"]["command"]
+    assert json.loads(comparison.read_text(encoding="utf-8")) == result
+
+
+def test_supervised_binding_accepts_fresh_worker_result(tmp_path, monkeypatch):
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "--all",
+            "--output",
+            str(tmp_path / "results"),
+            "--engine-dir",
+            str(tmp_path / "engines"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+        ]
+    )
+    binding = trtmc_validate.Binding("model-a", "workload-a")
+    catalog = {"sample_limits": {"workload-a": 5}}
+    comparison = (
+        arguments.output / binding.model / binding.workload / "comparison.json"
+    )
+
+    def pass_worker(command, log_path, env):
+        comparison.write_text(
+            json.dumps(
+                {
+                    "model": binding.model,
+                    "workload": binding.workload,
+                    "status": "passed",
+                    "returncode": 0,
+                    "raw_result": {"status": "passed"},
+                    "reproduce": {
+                        "dataset": {
+                            "command": "internal worker command",
+                            "sample_limit": 5,
+                            "prepared_input_count": 5,
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return 0
+
+    monkeypatch.setattr(trtmc_validate, "_run_subprocess", pass_worker)
+
+    result = trtmc_validate._run_supervised_binding(
+        binding,
+        arguments=arguments,
+        catalog=catalog,
+    )
+
+    assert result["execution"]["status"] == "completed"
+    assert result["comparison"]["status"] == "agreement"
+    assert result["validation"]["status"] == "passed"
+    assert result["worker_log"].endswith("/model-a/workload-a/worker.log")
+    assert "--model-worker" not in result["reproduce"]["dataset"]["command"]
+
+
+def test_all_dry_run_emits_machine_readable_ci_cases(monkeypatch, capsys):
+    catalog = {
+        "sample_limits": {"workload-a": 5},
+        "models": {
+            "model-a": {
+                "default": "workload-a",
+                "workloads": ["workload-a"],
+            },
+            "model-e2e": {
+                "default": "e2e",
+                "workloads": ["e2e"],
+            },
+        },
+    }
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_load_validation_inputs",
+        lambda arguments: (
+            catalog,
+            {"workload-a": {}},
+            ("model-a", "model-e2e"),
+            {},
+        ),
+    )
+
+    returncode = trtmc_validate.main(["--all", "--dry-run"])
+
+    assert returncode == 0
+    assert json.loads(capsys.readouterr().out) == [
+        {
+            "model": "model-a",
+            "workload": "workload-a",
+            "sample_limit": 5,
+        },
+        {
+            "model": "model-e2e",
+            "workload": "e2e",
+            "sample_limit": 0,
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("validation_status", "comparison_status", "expected_returncode"),
+    [
+        ("passed", "agreement", 0),
+        ("failed", "disagreement", 1),
+    ],
+)
+def test_single_ci_case_writes_stable_result_and_exit_code(
+    tmp_path,
+    monkeypatch,
+    validation_status,
+    comparison_status,
+    expected_returncode,
+):
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "model-a",
+            "workload-a",
+            "--output",
+            str(tmp_path / "results"),
+            "--engine-dir",
+            str(tmp_path / "engines"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+        ]
+    )
+    binding = trtmc_validate.Binding("model-a", "workload-a")
+    catalog = {"sample_limits": {"workload-a": 5}}
+
+    def run_binding(binding, *, arguments, task_models, e2e_models, suites):
+        result = {
+            "schema_version": "trtmc.validation-result/v2",
+            "model": binding.model,
+            "workload": binding.workload,
+            "execution": {"status": "completed", "exit_code": 0},
+            "comparison": {
+                "status": comparison_status,
+                "mode": "test",
+                "primary_metric": None,
+                "metrics": {},
+                "failures": [],
+            },
+            "validation": {"status": validation_status},
+            "reproduce": {
+                "dataset": {
+                    "command": "python tools/trtmc_validate.py model-a workload-a",
+                    "sample_limit": arguments.limit,
+                    "prepared_input_count": arguments.limit,
+                },
+                "hf": [],
+                "trtmc": [],
+            },
+        }
+        case_dir = arguments.output / binding.model / binding.workload
+        case_dir.mkdir(parents=True, exist_ok=True)
+        (case_dir / "comparison.json").write_text(
+            json.dumps(result),
+            encoding="utf-8",
+        )
+        return result
+
+    monkeypatch.setattr(trtmc_validate, "_e2e_models", lambda models_dir: {})
+    monkeypatch.setattr(trtmc_validate, "run_binding", run_binding)
+
+    returncode = trtmc_validate._run_bindings(
+        [binding],
+        arguments=arguments,
+        catalog=catalog,
+        task_models={},
+        suites={"workload-a": {}},
+    )
+
+    case_dir = arguments.output / "model-a" / "workload-a"
+    assert returncode == expected_returncode
+    assert (case_dir / "comparison.json").is_file()
+    assert (arguments.output / "report.json").is_file()
+    assert (arguments.output / "report.html").is_file()
+
+
+def test_single_ci_case_returns_exit_two_for_setup_error(monkeypatch):
+    def fail(arguments):
+        raise trtmc_validate.ValidationError("missing CI dataset")
+
+    monkeypatch.setattr(trtmc_validate, "_load_validation_inputs", fail)
+
+    with pytest.raises(SystemExit) as error:
+        trtmc_validate.main(["model-a", "workload-a"])
+
+    assert error.value.code == 2
+
+
 @pytest.mark.parametrize(
     "reference_backend",
     ["hf_transformers", "torch_reference", "diffusers_reference"],

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -967,3 +967,30 @@ def test_result_statuses_separate_execution_from_agreement(
     assert result["execution"]["status"] == execution
     assert result["comparison"]["status"] == comparison
     assert result["validation"]["status"] == validation
+
+
+@pytest.mark.parametrize("returncode", [0, 1])
+def test_comparison_result_marks_missing_summary_as_execution_error(
+    tmp_path,
+    returncode,
+):
+    result = trtmc_validate._comparison_result(
+        trtmc_validate.Binding("model-a", "workload-a"),
+        case_dir=tmp_path,
+        returncode=returncode,
+        reference_environment=trtmc_validate.EnvironmentSelection(
+            base_python="/profiles/python",
+            names_and_paths=(("reference_common", "/profiles/python"),),
+            overrides={},
+        ),
+        dataset_command="python tools/trtmc_validate.py model-a",
+    )
+
+    assert result["execution"] == {
+        "status": "error",
+        "exit_code": returncode,
+    }
+    assert result["comparison"]["status"] == "not_run"
+    assert result["validation"]["status"] == "failed"
+    assert result["raw_result"]["error_type"] == "ComparisonProcessError"
+    assert "without writing" in result["raw_result"]["error"]

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+from tools import task_eval
+from tools import trtmc_validate
+
+
+def test_model_workload_catalog_covers_every_ready_model():
+    catalog = trtmc_validate.load_catalog()
+    suites = task_eval.load_suites()
+    task_models = trtmc_validate._task_eval_models(trtmc_validate.DEFAULT_MODELS)
+
+    trtmc_validate.audit_catalog(
+        catalog,
+        ready_models=trtmc_validate.ready_model_names(),
+        suite_names=(suite["id"] for suite in suites),
+    )
+    trtmc_validate.audit_workload_compatibility(
+        catalog,
+        suites={suite["id"]: suite for suite in suites},
+        task_models=task_models,
+    )
+
+    assert len(catalog["models"]) == len(trtmc_validate.ready_model_names())
+
+
+def test_resolve_binding_defaults_and_rejects_undeclared_workload():
+    catalog = {
+        "models": {
+            "model-a": {
+                "default": "workload-a",
+                "workloads": ["workload-a", "workload-b"],
+            }
+        }
+    }
+
+    assert trtmc_validate.resolve_binding(catalog, "model-a") == (
+        trtmc_validate.Binding("model-a", "workload-a")
+    )
+    assert trtmc_validate.resolve_binding(catalog, "model-a", "workload-b") == (
+        trtmc_validate.Binding("model-a", "workload-b")
+    )
+    with pytest.raises(trtmc_validate.ValidationError, match="does not declare"):
+        trtmc_validate.resolve_binding(catalog, "model-a", "workload-c")
+
+
+@pytest.mark.parametrize(
+    "reference_backend",
+    ["hf_transformers", "torch_reference", "diffusers_reference"],
+)
+def test_default_reference_backends_share_common_environment(reference_backend):
+    assert (
+        trtmc_validate._declared_profile(
+            family="",
+            runtime_strategy="",
+            reference_backend=reference_backend,
+            execution_profiles=None,
+        )
+        == trtmc_validate.COMMON_REFERENCE_PROFILE
+    )
+
+
+def test_ensure_environments_reports_create_only_when_resolver_creates(monkeypatch, capsys):
+    calls = 0
+
+    def resolve(name, base_python, *, on_create):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            on_create(name)
+        return f"/profiles/{name}/bin/python"
+
+    monkeypatch.setattr(trtmc_validate, "resolve_profile_python", resolve)
+
+    cold = trtmc_validate.ensure_environments(
+        [trtmc_validate.COMMON_REFERENCE_PROFILE],
+        "/base/python",
+    )
+    cold_output = capsys.readouterr().out
+    warm = trtmc_validate.ensure_environments(
+        [trtmc_validate.COMMON_REFERENCE_PROFILE],
+        "/base/python",
+    )
+    warm_output = capsys.readouterr().out
+
+    assert "Creating reference environment: reference_common" in cold_output
+    assert "Using reference environment: /profiles/reference_common/bin/python" in (cold_output)
+    assert "Creating reference environment" not in warm_output
+    assert "Using reference environment: /profiles/reference_common/bin/python" in (warm_output)
+    assert cold.base_python == "/profiles/reference_common/bin/python"
+    assert warm.base_python == cold.base_python
+
+
+def test_print_result_only_exposes_raw_commands_and_result_locations(tmp_path, capsys):
+    comparison = tmp_path / "comparison.json"
+    report = tmp_path / "report.html"
+    trtmc_validate._print_result(
+        {
+            "reproduce": {
+                "hf": ["python hf_reference.py --model model-a"],
+                "trtmc": ["trtmc run --model model-a"],
+                "validation": "python tools/trtmc_validate.py model-a",
+            }
+        },
+        comparison,
+        report,
+    )
+
+    output = capsys.readouterr().out
+    assert output == (
+        "\n"
+        "Reproduce HF:\n"
+        "  python hf_reference.py --model model-a\n"
+        "\n"
+        "Reproduce TRTMC:\n"
+        "  trtmc run --model model-a\n"
+        "\n"
+        f"Compare result: {comparison}\n"
+        f"Report:         {report}\n"
+    )
+    assert "package" not in output.lower()
+    assert "token-agreement" not in output
+    assert "env action" not in output.lower()
+
+
+def test_print_result_does_not_mislabel_validation_wrapper_as_raw_command(tmp_path, capsys):
+    comparison = tmp_path / "comparison.json"
+    report = tmp_path / "report.html"
+    trtmc_validate._print_result(
+        {
+            "reproduce": {
+                "hf": [],
+                "trtmc": [],
+                "validation": "python tools/trtmc_validate.py model-a",
+            }
+        },
+        comparison,
+        report,
+    )
+
+    output = capsys.readouterr().out
+    assert output.count("unavailable; see comparison result") == 2
+    assert "python tools/trtmc_validate.py model-a" not in output
+
+
+def test_write_report_links_each_comparison(tmp_path):
+    case_dir = tmp_path / "model-a" / "workload-a"
+    case_dir.mkdir(parents=True)
+    comparison = case_dir / "comparison.json"
+    comparison.write_text(
+        json.dumps(
+            {
+                "model": "model-a",
+                "workload": "workload-a",
+                "status": "passed",
+                "reference_environment": [
+                    {"name": "reference_common", "python": "/profiles/python"}
+                ],
+                "reproduce": {
+                    "hf": ["python hf.py"],
+                    "trtmc": ["trtmc run"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    json_path, html_path, report = trtmc_validate.write_report(tmp_path)
+
+    assert report["summary"] == {
+        "cases": 1,
+        "passed": 1,
+        "failed": 0,
+        "skipped": 0,
+    }
+    assert json_path == tmp_path / "report.json"
+    assert html_path == tmp_path / "report.html"
+    assert "model-a/workload-a/comparison.json" in html_path.read_text(encoding="utf-8")
+
+
+def test_run_metadata_records_source_and_exact_command(monkeypatch, tmp_path):
+    monkeypatch.setenv("TRTMC_VALIDATION_SOURCE_REVISION", "abc123")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1")
+    monkeypatch.setattr(
+        trtmc_validate.sys,
+        "argv",
+        ["tools/trtmc_validate.py", "model-a"],
+    )
+
+    path = trtmc_validate.write_run_metadata(tmp_path)
+    metadata = json.loads(path.read_text(encoding="utf-8"))
+
+    assert metadata["source_revision"] == "abc123"
+    assert metadata["cuda_visible_devices"] == "1"
+    assert metadata["command"] == "tools/trtmc_validate.py model-a"
+
+
+def test_task_eval_command_is_directly_reproducible(tmp_path):
+    arguments = argparse.Namespace(
+        engine_dir=tmp_path / "engines",
+        trtmc_binary=tmp_path / "trtmc",
+        benchmark_binary=tmp_path / "trtmc_dataset_benchmark",
+        limit=2,
+        force_hf=True,
+        force_build=False,
+        no_build=True,
+        local_files_only=True,
+        backend_dir=None,
+        model_plugin_dir=None,
+        cuda_visible_devices="1",
+    )
+
+    command = trtmc_validate._task_eval_command(
+        trtmc_validate.Binding("model-a", "workload-a"),
+        case_dir=tmp_path / "case",
+        dataset=tmp_path / "dataset.json",
+        arguments=arguments,
+        reference_python="/profiles/python",
+    )
+
+    assert command[:3] == [
+        trtmc_validate.sys.executable,
+        str(trtmc_validate.REPO_ROOT / "tools" / "task_eval.py"),
+        "eval",
+    ]
+    assert command[command.index("--model") + 1] == "model-a"
+    assert command[command.index("--suite") + 1] == "workload-a"
+    assert command[command.index("--hf-python") + 1] == "/profiles/python"
+    assert "--force-hf" in command
+    assert "--require-prebuilt-bundles" in command
+    assert "--local-files-only" in command

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -275,6 +275,7 @@ def test_run_metadata_records_source_and_exact_command(monkeypatch, tmp_path):
 def test_task_eval_command_is_directly_reproducible(tmp_path):
     arguments = argparse.Namespace(
         engine_dir=tmp_path / "engines",
+        reference_cache_dir=tmp_path / "references",
         trtmc_binary=tmp_path / "trtmc",
         benchmark_binary=tmp_path / "trtmc_dataset_benchmark",
         limit=2,
@@ -303,6 +304,10 @@ def test_task_eval_command_is_directly_reproducible(tmp_path):
     assert command[command.index("--model") + 1] == "model-a"
     assert command[command.index("--suite") + 1] == "workload-a"
     assert command[command.index("--hf-python") + 1] == "/profiles/python"
+    assert command[command.index("--reference-cache-dir") + 1] == str(
+        tmp_path / "references"
+    )
+    assert "--replace-bundle-on-build" in command
     assert "--force-hf" in command
     assert "--require-prebuilt-bundles" in command
     assert "--local-files-only" in command

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -536,9 +536,13 @@ def test_failed_sample_uses_recorded_trtmc_command_and_copies_media(tmp_path):
     frames.mkdir(parents=True)
     input_image = work_dir / "input.png"
     reference_image = frames / "000.png"
+    reference_visualization = work_dir / "reference_visualization.png"
+    trtmc_visualization = work_dir / "trtmc_visualization.png"
     trtmc_audio = work_dir / "output.wav"
     input_image.write_bytes(b"input-image")
     reference_image.write_bytes(b"reference-image")
+    reference_visualization.write_bytes(b"reference-visualization")
+    trtmc_visualization.write_bytes(b"trtmc-visualization")
     trtmc_audio.write_bytes(b"RIFFfake-wave")
     prompt = {
         "sample_id": "sample-9",
@@ -576,6 +580,7 @@ def test_failed_sample_uses_recorded_trtmc_command_and_copies_media(tmp_path):
                     {
                         "sample_id": "sample-9",
                         "frames_dir": str(frames),
+                        "visualization_path": str(reference_visualization),
                     }
                 ]
             }
@@ -589,6 +594,7 @@ def test_failed_sample_uses_recorded_trtmc_command_and_copies_media(tmp_path):
                     {
                         "sample_id": "sample-9",
                         "wav_path": str(trtmc_audio),
+                        "visualization_path": str(trtmc_visualization),
                     }
                 ]
             }
@@ -637,6 +643,11 @@ def test_failed_sample_uses_recorded_trtmc_command_and_copies_media(tmp_path):
     )
     media = record["artifacts"]["media"]
     assert {item["kind"] for item in media} == {"image", "audio"}
+    assert len(media) == 5
+    assert {item["label"] for item in media} >= {
+        "Reference visualization_path",
+        "TRTMC visualization_path",
+    }
     assert all((case_dir / item["path"]).is_file() for item in media)
     rendered = trtmc_validate._render_disagreement_record(
         record,

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -48,6 +48,9 @@ def test_catalog_defines_sample_limit_for_every_dataset_workload():
     assert configured == declared
     assert min(catalog["sample_limits"].values()) >= 2
     assert max(catalog["sample_limits"].values()) == 100
+    assert catalog["sample_limits"]["mmlu_five_shot_mcq"] == 20
+    assert catalog["sample_limits"]["dpg_bench_diffusion_image"] == 5
+    assert catalog["sample_limits"]["gedit_bench_image_edit"] == 5
 
 
 def test_every_dataset_backed_validation_binding_has_native_reference_runner():

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -363,6 +363,50 @@ def test_report_bounds_large_sample_commands_and_selects_disagreement(tmp_path):
     assert (tmp_path / "report.json").stat().st_size < 20_000
 
 
+def test_report_does_not_treat_shared_task_failure_as_disagreement(tmp_path):
+    case_dir = tmp_path / "model-a" / "workload-a"
+    work_dir = case_dir / "validation" / "workload-a" / "model-a"
+    work_dir.mkdir(parents=True)
+    (work_dir / "prompts.jsonl").write_text(
+        json.dumps({"sample_id": "sample-0", "prompt": "hello"}) + "\n",
+        encoding="utf-8",
+    )
+    (work_dir / "trtfb_run.log").write_text(
+        "$ trtmc run model.trtfb --prompt hello\n",
+        encoding="utf-8",
+    )
+    (work_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "disagreements": [],
+                "hf": {"samples": [{"sample_id": "sample-0", "passed": False}]},
+                "trtfb": {
+                    "samples": [{"sample_id": "sample-0", "passed": False}]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (case_dir / "comparison.json").write_text(
+        json.dumps(
+            {
+                "model": "model-a",
+                "workload": "workload-a",
+                "status": "passed",
+                "raw_result": {"work_dir": str(work_dir)},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, _, report = trtmc_validate.write_report(tmp_path)
+
+    assert report["results"][0]["reproduce"]["representative"] == {
+        "sample_id": "sample-0",
+        "reason": "first_input",
+    }
+
+
 def test_run_metadata_records_source_and_exact_command(monkeypatch, tmp_path):
     monkeypatch.setenv("TRTMC_VALIDATION_SOURCE_REVISION", "abc123")
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1")

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -9,6 +9,7 @@ import json
 import pytest
 
 from tools import task_eval
+from tools import trtmc_compare
 from tools import trtmc_validate
 
 
@@ -176,14 +177,26 @@ def test_write_report_links_each_comparison(tmp_path):
 
     assert report["summary"] == {
         "cases": 1,
-        "passed": 1,
-        "failed": 0,
-        "skipped": 0,
+        "execution_completed": 1,
+        "execution_errors": 0,
+        "agreements": 1,
+        "disagreements": 0,
+        "not_compared": 0,
+        "validation_passed": 1,
+        "validation_failed": 0,
+        "validation_skipped": 0,
     }
+    assert report["validation_status"] == "passed"
+    assert report["results"][0]["execution"]["status"] == "completed"
+    assert report["results"][0]["comparison"]["status"] == "agreement"
+    assert report["results"][0]["validation"]["status"] == "passed"
+    assert "status" not in report["results"][0]
     assert json_path == tmp_path / "report.json"
     assert html_path == tmp_path / "report.html"
     document = html_path.read_text(encoding="utf-8")
     assert "model-a/workload-a/comparison.json" in document
+    assert "Agreement" in document
+    assert "Completed" in document
     assert "Vanilla reproduction" in document
     assert "Reference 1 · TRTMC 1" in document
     assert "$ python hf.py" in document
@@ -202,7 +215,7 @@ def test_write_report_does_not_render_validation_wrapper(tmp_path):
                 "reproduce": {
                     "hf": ["python hf.py --prompt '<hello>'"],
                     "trtmc": [],
-                    "validation": "python tools/trtmc_validate.py model-a",
+                    "validation": "python tools/task_eval.py eval --model model-a",
                 },
             }
         ),
@@ -214,7 +227,9 @@ def test_write_report_does_not_render_validation_wrapper(tmp_path):
     document = html_path.read_text(encoding="utf-8")
     assert "python hf.py --prompt &#x27;&lt;hello&gt;&#x27;" in document
     assert "Not reached; see comparison.json." in document
-    assert "python tools/trtmc_validate.py" not in document
+    assert "task_eval.py" not in document
+    migrated = json.loads((case_dir / "comparison.json").read_text(encoding="utf-8"))
+    assert set(migrated["reproduce"]) == {"hf", "trtmc"}
 
 
 def test_write_report_recovers_json_logged_runner_command(tmp_path):
@@ -272,7 +287,7 @@ def test_run_metadata_records_source_and_exact_command(monkeypatch, tmp_path):
     assert metadata["command"] == "tools/trtmc_validate.py model-a"
 
 
-def test_task_eval_command_is_directly_reproducible(tmp_path):
+def test_comparison_command_uses_validation_entrypoint(tmp_path):
     arguments = argparse.Namespace(
         engine_dir=tmp_path / "engines",
         reference_cache_dir=tmp_path / "references",
@@ -288,7 +303,7 @@ def test_task_eval_command_is_directly_reproducible(tmp_path):
         cuda_visible_devices="1",
     )
 
-    command = trtmc_validate._task_eval_command(
+    command = trtmc_validate._comparison_command(
         trtmc_validate.Binding("model-a", "workload-a"),
         case_dir=tmp_path / "case",
         dataset=tmp_path / "dataset.json",
@@ -296,11 +311,14 @@ def test_task_eval_command_is_directly_reproducible(tmp_path):
         reference_python="/profiles/python",
     )
 
-    assert command[:3] == [
+    assert command[:2] == [
         trtmc_validate.sys.executable,
-        str(trtmc_validate.REPO_ROOT / "tools" / "task_eval.py"),
-        "eval",
+        str(trtmc_validate.REPO_ROOT / "tools" / "trtmc_compare.py"),
     ]
+    assert "task_eval.py" not in " ".join(command)
+    assert command[command.index("--work-root") + 1] == str(
+        tmp_path / "case" / "validation"
+    )
     assert command[command.index("--model") + 1] == "model-a"
     assert command[command.index("--suite") + 1] == "workload-a"
     assert command[command.index("--hf-python") + 1] == "/profiles/python"
@@ -311,3 +329,59 @@ def test_task_eval_command_is_directly_reproducible(tmp_path):
     assert "--force-hf" in command
     assert "--require-prebuilt-bundles" in command
     assert "--local-files-only" in command
+
+
+def test_compare_entrypoint_forwards_to_validation_backend(monkeypatch):
+    captured = []
+
+    def run(arguments):
+        captured.extend(arguments)
+        return 7
+
+    monkeypatch.setattr(trtmc_compare.task_eval, "main", run)
+
+    assert trtmc_compare.main(["--suite", "suite-a"]) == 7
+    assert captured == ["eval", "--suite", "suite-a"]
+
+
+@pytest.mark.parametrize(
+    ("raw_result", "execution", "comparison", "validation"),
+    [
+        (
+            {"status": "passed", "prediction_agreement_rate": 1.0},
+            "completed",
+            "agreement",
+            "passed",
+        ),
+        (
+            {"status": "failed", "prediction_agreement_rate": 0.5},
+            "completed",
+            "disagreement",
+            "failed",
+        ),
+        (
+            {"status": "failed", "error": "runner crashed"},
+            "error",
+            "not_run",
+            "failed",
+        ),
+    ],
+)
+def test_result_statuses_separate_execution_from_agreement(
+    raw_result,
+    execution,
+    comparison,
+    validation,
+):
+    result = trtmc_validate._normalize_result(
+        {
+            "model": "model-a",
+            "workload": "workload-a",
+            "status": raw_result["status"],
+            "raw_result": raw_result,
+        }
+    )
+
+    assert result["execution"]["status"] == execution
+    assert result["comparison"]["status"] == comparison
+    assert result["validation"]["status"] == validation

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -35,6 +35,21 @@ def test_model_workload_catalog_covers_every_ready_model():
     assert len(catalog["models"]) == len(trtmc_validate.ready_model_names())
 
 
+def test_catalog_defines_sample_limit_for_every_dataset_workload():
+    catalog = trtmc_validate.load_catalog()
+    configured = set(catalog["sample_limits"])
+    declared = {
+        workload
+        for spec in catalog["models"].values()
+        for workload in spec["workloads"]
+        if workload != "e2e"
+    }
+
+    assert configured == declared
+    assert min(catalog["sample_limits"].values()) >= 2
+    assert max(catalog["sample_limits"].values()) == 100
+
+
 def test_every_dataset_backed_validation_binding_has_native_reference_runner():
     catalog = trtmc_validate.load_catalog()
     suites = {suite["id"]: suite for suite in task_eval.load_suites()}
@@ -74,6 +89,55 @@ def test_resolve_binding_defaults_and_rejects_undeclared_workload():
     )
     with pytest.raises(trtmc_validate.ValidationError, match="does not declare"):
         trtmc_validate.resolve_binding(catalog, "model-a", "workload-c")
+
+
+def test_resolve_sample_limit_uses_workload_policy_and_cli_override():
+    catalog = {
+        "sample_limits": {"workload-a": 50},
+        "models": {
+            "model-a": {
+                "default": "workload-a",
+                "workloads": ["workload-a"],
+            },
+            "model-e2e": {
+                "default": "e2e",
+                "workloads": ["e2e"],
+            },
+        },
+    }
+
+    assert (
+        trtmc_validate.resolve_sample_limit(
+            catalog,
+            trtmc_validate.Binding("model-a", "workload-a"),
+            None,
+        )
+        == 50
+    )
+    assert (
+        trtmc_validate.resolve_sample_limit(
+            catalog,
+            trtmc_validate.Binding("model-a", "workload-a"),
+            7,
+        )
+        == 7
+    )
+    assert (
+        trtmc_validate.resolve_sample_limit(
+            catalog,
+            trtmc_validate.Binding("model-a", "workload-a"),
+            0,
+        )
+        == 0
+    )
+    assert (
+        trtmc_validate.resolve_sample_limit(
+            catalog,
+            trtmc_validate.Binding("model-e2e", "e2e"),
+            None,
+        )
+        == 0
+    )
 
 
 @pytest.mark.parametrize(
@@ -131,6 +195,7 @@ def test_print_result_only_exposes_raw_commands_and_result_locations(tmp_path, c
             "reproduce": {
                 "dataset": {
                     "command": "python tools/trtmc_validate.py model-a --limit 1000",
+                    "sample_limit": 1000,
                     "prepared_input_count": 1000,
                 },
                 "hf": ["python hf_reference.py --model model-a"],
@@ -144,7 +209,7 @@ def test_print_result_only_exposes_raw_commands_and_result_locations(tmp_path, c
     output = capsys.readouterr().out
     assert output == (
         "\n"
-        "Reproduce full dataset:\n"
+        "Reproduce dataset run:\n"
         "  python tools/trtmc_validate.py model-a --limit 1000\n"
         "\n"
         "Reproduce representative HF:\n"
@@ -199,6 +264,7 @@ def test_write_report_links_each_comparison(tmp_path):
                     "trtmc": ["trtmc run"],
                     "dataset": {
                         "command": "python tools/trtmc_validate.py model-a",
+                        "sample_limit": 500,
                         "prepared_input_count": 1000,
                     },
                 },
@@ -219,6 +285,8 @@ def test_write_report_links_each_comparison(tmp_path):
         "validation_passed": 1,
         "validation_failed": 0,
         "validation_skipped": 0,
+        "selected_samples": 500,
+        "prepared_inputs": 1000,
     }
     assert report["validation_status"] == "passed"
     assert report["results"][0]["execution"]["status"] == "completed"
@@ -234,7 +302,11 @@ def test_write_report_links_each_comparison(tmp_path):
     assert "TRTMC Reference Consistency Report" in document
     assert "Vanilla reproduction" in document
     assert "Dataset · Reference 1/1 · TRTMC 1/1" in document
-    assert "Full dataset (1000 prepared inputs)" in document
+    assert "Dataset slice (500 selected samples; 1000 prepared inputs)" in document
+    assert "<th>Samples</th>" in document
+    assert "500 selected<br><span class=\"detail\">1000 prepared inputs</span>" in document
+    assert report["summary"]["selected_samples"] == 500
+    assert report["summary"]["prepared_inputs"] == 1000
     assert "$ python tools/trtmc_validate.py model-a" in document
     assert "$ python hf.py" in document
     assert "$ trtmc run" in document

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -182,7 +182,77 @@ def test_write_report_links_each_comparison(tmp_path):
     }
     assert json_path == tmp_path / "report.json"
     assert html_path == tmp_path / "report.html"
-    assert "model-a/workload-a/comparison.json" in html_path.read_text(encoding="utf-8")
+    document = html_path.read_text(encoding="utf-8")
+    assert "model-a/workload-a/comparison.json" in document
+    assert "Vanilla reproduction" in document
+    assert "Reference 1 · TRTMC 1" in document
+    assert "$ python hf.py" in document
+    assert "$ trtmc run" in document
+
+
+def test_write_report_does_not_render_validation_wrapper(tmp_path):
+    case_dir = tmp_path / "model-a" / "workload-a"
+    case_dir.mkdir(parents=True)
+    (case_dir / "comparison.json").write_text(
+        json.dumps(
+            {
+                "model": "model-a",
+                "workload": "workload-a",
+                "status": "failed",
+                "reproduce": {
+                    "hf": ["python hf.py --prompt '<hello>'"],
+                    "trtmc": [],
+                    "validation": "python tools/trtmc_validate.py model-a",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, html_path, _ = trtmc_validate.write_report(tmp_path)
+
+    document = html_path.read_text(encoding="utf-8")
+    assert "python hf.py --prompt &#x27;&lt;hello&gt;&#x27;" in document
+    assert "Not reached; see comparison.json." in document
+    assert "python tools/trtmc_validate.py" not in document
+
+
+def test_write_report_recovers_json_logged_runner_command(tmp_path):
+    case_dir = tmp_path / "model-a" / "workload-a"
+    work_dir = case_dir / "task-eval"
+    work_dir.mkdir(parents=True)
+    (work_dir / "trtfb_run.log").write_text(
+        json.dumps(
+            {
+                "sample_id": "sample-1",
+                "command": ["trtmc", "solve", "model.trtfb", "--field-input", "1,2"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (case_dir / "comparison.json").write_text(
+        json.dumps(
+            {
+                "model": "model-a",
+                "workload": "workload-a",
+                "status": "passed",
+                "raw_result": {"work_dir": str(work_dir)},
+                "reproduce": {"hf": ["python hf.py"], "trtmc": ["trtmc build"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, html_path, report = trtmc_validate.write_report(tmp_path)
+
+    assert report["results"][0]["reproduce"]["trtmc"] == [
+        "trtmc build",
+        "trtmc solve model.trtfb --field-input 1,2",
+    ]
+    assert "$ trtmc solve model.trtfb --field-input 1,2" in html_path.read_text(
+        encoding="utf-8"
+    )
 
 
 def test_run_metadata_records_source_and_exact_command(monkeypatch, tmp_path):

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -105,9 +105,12 @@ def test_print_result_only_exposes_raw_commands_and_result_locations(tmp_path, c
     trtmc_validate._print_result(
         {
             "reproduce": {
+                "dataset": {
+                    "command": "python tools/trtmc_validate.py model-a --limit 1000",
+                    "prepared_input_count": 1000,
+                },
                 "hf": ["python hf_reference.py --model model-a"],
                 "trtmc": ["trtmc run --model model-a"],
-                "validation": "python tools/trtmc_validate.py model-a",
             }
         },
         comparison,
@@ -117,10 +120,13 @@ def test_print_result_only_exposes_raw_commands_and_result_locations(tmp_path, c
     output = capsys.readouterr().out
     assert output == (
         "\n"
-        "Reproduce HF:\n"
+        "Reproduce full dataset:\n"
+        "  python tools/trtmc_validate.py model-a --limit 1000\n"
+        "\n"
+        "Reproduce representative HF:\n"
         "  python hf_reference.py --model model-a\n"
         "\n"
-        "Reproduce TRTMC:\n"
+        "Reproduce representative TRTMC:\n"
         "  trtmc run --model model-a\n"
         "\n"
         f"Compare result: {comparison}\n"
@@ -147,7 +153,7 @@ def test_print_result_does_not_mislabel_validation_wrapper_as_raw_command(tmp_pa
     )
 
     output = capsys.readouterr().out
-    assert output.count("unavailable; see comparison result") == 2
+    assert output.count("unavailable; see comparison result") == 3
     assert "python tools/trtmc_validate.py model-a" not in output
 
 
@@ -167,6 +173,10 @@ def test_write_report_links_each_comparison(tmp_path):
                 "reproduce": {
                     "hf": ["python hf.py"],
                     "trtmc": ["trtmc run"],
+                    "dataset": {
+                        "command": "python tools/trtmc_validate.py model-a",
+                        "prepared_input_count": 1000,
+                    },
                 },
             }
         ),
@@ -197,8 +207,11 @@ def test_write_report_links_each_comparison(tmp_path):
     assert "model-a/workload-a/comparison.json" in document
     assert "Agreement" in document
     assert "Completed" in document
+    assert "TRTMC Reference Consistency Report" in document
     assert "Vanilla reproduction" in document
-    assert "Reference 1 · TRTMC 1" in document
+    assert "Dataset · Reference 1/1 · TRTMC 1/1" in document
+    assert "Full dataset (1000 prepared inputs)" in document
+    assert "$ python tools/trtmc_validate.py model-a" in document
     assert "$ python hf.py" in document
     assert "$ trtmc run" in document
 
@@ -229,7 +242,16 @@ def test_write_report_does_not_render_validation_wrapper(tmp_path):
     assert "Not reached; see comparison.json." in document
     assert "task_eval.py" not in document
     migrated = json.loads((case_dir / "comparison.json").read_text(encoding="utf-8"))
-    assert set(migrated["reproduce"]) == {"hf", "trtmc"}
+    assert "validation" not in migrated["reproduce"]
+    assert set(migrated["reproduce"]) == {
+        "command_count",
+        "command_logs",
+        "commands_shown",
+        "dataset",
+        "hf",
+        "representative",
+        "trtmc",
+    }
 
 
 def test_write_report_recovers_json_logged_runner_command(tmp_path):
@@ -268,6 +290,77 @@ def test_write_report_recovers_json_logged_runner_command(tmp_path):
     assert "$ trtmc solve model.trtfb --field-input 1,2" in html_path.read_text(
         encoding="utf-8"
     )
+
+
+def test_report_bounds_large_sample_commands_and_selects_disagreement(tmp_path):
+    case_dir = tmp_path / "model-a" / "workload-a"
+    work_dir = case_dir / "validation" / "workload-a" / "model-a"
+    work_dir.mkdir(parents=True)
+    sample_count = 10_000
+    (work_dir / "prompts.jsonl").write_text(
+        "".join(
+            json.dumps({"sample_id": f"sample-{index}", "prompt": f"prompt-{index}"})
+            + "\n"
+            for index in range(sample_count)
+        ),
+        encoding="utf-8",
+    )
+    (work_dir / "trtfb_run.log").write_text(
+        "".join(
+            f"$ trtmc run model.trtfb --prompt prompt-{index}\n"
+            for index in range(sample_count)
+        ),
+        encoding="utf-8",
+    )
+    (work_dir / "summary.json").write_text(
+        json.dumps({"disagreements": [{"sample_id": "sample-9999"}]}),
+        encoding="utf-8",
+    )
+    (case_dir / "comparison.json").write_text(
+        json.dumps(
+            {
+                "model": "model-a",
+                "workload": "workload-a",
+                "status": "failed",
+                "raw_result": {
+                    "status": "failed",
+                    "work_dir": str(work_dir),
+                },
+                "reproduce": {
+                    "dataset": {
+                        "command": (
+                            "python tools/trtmc_validate.py model-a --limit 10000"
+                        ),
+                        "prepared_input_count": sample_count,
+                    },
+                    "hf": [],
+                    "trtmc": [],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, html_path, report = trtmc_validate.write_report(tmp_path)
+
+    reproduction = report["results"][0]["reproduce"]
+    assert reproduction["command_count"]["trtmc"] == sample_count
+    assert reproduction["commands_shown"]["trtmc"] == 1
+    assert reproduction["trtmc"] == [
+        "trtmc run model.trtfb --prompt prompt-9999"
+    ]
+    assert reproduction["representative"] == {
+        "sample_id": "sample-9999",
+        "reason": "first_disagreement",
+    }
+    assert reproduction["command_logs"]["trtmc"] == ["trtfb_run.log"]
+    assert "prompt-5000" not in json.dumps(report)
+    document = html_path.read_text(encoding="utf-8")
+    assert "Showing 1 of 10000 commands" in document
+    assert "prompt-9999" in document
+    assert "prompt-5000" not in document
+    assert (case_dir / "comparison.json").stat().st_size < 20_000
+    assert (tmp_path / "report.json").stat().st_size < 20_000
 
 
 def test_run_metadata_records_source_and_exact_command(monkeypatch, tmp_path):

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -556,9 +556,15 @@ def test_failed_sample_uses_recorded_trtmc_command_and_copies_media(tmp_path):
     (work_dir / "summary.json").write_text(
         json.dumps(
             {
-                "disagreements": [
-                    {"sample_id": "sample-9", "status": "failed"}
-                ]
+                "status": "failed",
+                "backend_mean_iou": 0.90,
+                "gates": {"min_backend_mean_iou": 0.95},
+                "cases": [
+                    {
+                        "sample_id": "sample-9",
+                        "backend_mean_iou": 0.90,
+                    }
+                ],
             }
         ),
         encoding="utf-8",
@@ -667,6 +673,37 @@ def test_failed_encoder_pair_expands_to_both_reproducible_samples():
     assert [row["sample_id"] for row in expanded] == [
         "sts-4-a",
         "sts-4-b",
+    ]
+
+
+def test_summary_gate_failure_selects_worst_sample_for_reproduction():
+    rows = trtmc_disagreements._summary_disagreements(
+        {
+            "status": "failed",
+            "backend_mean_iou": 0.92,
+            "gates": {"min_backend_mean_iou": 0.95},
+            "cases": [
+                {"sample_id": "sample-good", "backend_mean_iou": 0.97},
+                {"sample_id": "sample-worst", "backend_mean_iou": 0.90},
+            ],
+        }
+    )
+
+    assert rows == [
+        {
+            "sample_id": "sample-worst",
+            "backend_mean_iou": 0.90,
+            "status": "failed",
+            "reason": "summary_gate_failure",
+            "failed_gates": [
+                {
+                    "gate": "min_backend_mean_iou",
+                    "metric": "backend_mean_iou",
+                    "actual": 0.92,
+                    "threshold": 0.95,
+                }
+            ],
+        }
     ]
 
 

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -286,7 +286,6 @@ def test_write_report_links_each_comparison(tmp_path):
         "validation_failed": 0,
         "validation_skipped": 0,
         "selected_samples": 500,
-        "prepared_inputs": 1000,
     }
     assert report["validation_status"] == "passed"
     assert report["results"][0]["execution"]["status"] == "completed"
@@ -302,11 +301,11 @@ def test_write_report_links_each_comparison(tmp_path):
     assert "TRTMC Reference Consistency Report" in document
     assert "Vanilla reproduction" in document
     assert "Dataset · Reference 1/1 · TRTMC 1/1" in document
-    assert "Dataset slice (500 selected samples; 1000 prepared inputs)" in document
+    assert "Dataset slice (500 samples)" in document
     assert "<th>Samples</th>" in document
-    assert "500 selected<br><span class=\"detail\">1000 prepared inputs</span>" in document
+    assert "<td>500</td>" in document
     assert report["summary"]["selected_samples"] == 500
-    assert report["summary"]["prepared_inputs"] == 1000
+    assert "prepared inputs" not in document
     assert "$ python tools/trtmc_validate.py model-a" in document
     assert "$ python hf.py" in document
     assert "$ trtmc run" in document

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -363,6 +363,209 @@ def test_report_bounds_large_sample_commands_and_selects_disagreement(tmp_path):
     assert (tmp_path / "report.json").stat().st_size < 20_000
 
 
+def test_report_adds_failed_sample_results_and_native_commands(tmp_path):
+    case_dir = tmp_path / "model-a" / "workload-a"
+    work_dir = case_dir / "validation" / "workload-a" / "model-a"
+    work_dir.mkdir(parents=True)
+    prompt = {"sample_id": "sample-7", "prompt": "Complete this sentence"}
+    (work_dir / "prompts.jsonl").write_text(
+        json.dumps(prompt) + "\n",
+        encoding="utf-8",
+    )
+    (work_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "disagreements": [
+                    {
+                        "sample_id": "sample-7",
+                        "hf_prediction": "reference answer",
+                        "trtfb_prediction": "TRTMC answer",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (work_dir / "hf_predictions.json").write_text(
+        json.dumps(
+            {
+                "responses": [
+                    {
+                        "sample_id": "sample-7",
+                        "output_text": "reference answer",
+                        "generated_token_ids": [1, 2],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (work_dir / "trtfb_predictions.json").write_text(
+        json.dumps(
+            {
+                "responses": [
+                    {
+                        "sample_id": "sample-7",
+                        "output_text": "TRTMC answer",
+                        "generated_token_ids": [1, 3],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (work_dir / "hf_native_repro.json").write_text(
+        json.dumps(
+            {
+                "command": [
+                    "/profiles/reference/bin/python",
+                    "/workspace/trtmc/tools/reference/transformers_text.py",
+                    "--prompts",
+                    "{work_dir}/prompts.jsonl",
+                    "--sample-id",
+                    "{sample_id}",
+                    "--predictions",
+                    "{reference_predictions_json}",
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (work_dir / "trtfb_repro.json").write_text(
+        json.dumps(
+            {
+                "command": [
+                    "/workspace/build/trtmc_dataset_benchmark",
+                    "model.trtfb",
+                    "{input_jsonl}",
+                    "{trtmc_raw_jsonl}",
+                    "--max-new-tokens",
+                    "8",
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (case_dir / "comparison.json").write_text(
+        json.dumps(
+            {
+                "model": "model-a",
+                "workload": "workload-a",
+                "status": "failed",
+                "raw_result": {"status": "failed", "work_dir": str(work_dir)},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, html_path, report = trtmc_validate.write_report(tmp_path)
+
+    metadata = report["results"][0]["disagreements"]
+    assert metadata["count"] == 1
+    artifact = case_dir / metadata["path"]
+    records = [
+        json.loads(line)
+        for line in artifact.read_text(encoding="utf-8").splitlines()
+    ]
+    assert records[0]["input"] == prompt
+    assert records[0]["reference_result"]["output_text"] == "reference answer"
+    assert records[0]["trtmc_result"]["output_text"] == "TRTMC answer"
+    assert records[0]["reproduce"]["reference"].startswith(
+        "/profiles/reference/bin/python "
+        "/workspace/trtmc/tools/reference/transformers_text.py"
+    )
+    assert records[0]["reproduce"]["trtmc"].startswith(
+        "/workspace/build/trtmc_dataset_benchmark model.trtfb"
+    )
+    assert (case_dir / records[0]["artifacts"]["trtmc_input"]).read_text(
+        encoding="utf-8"
+    ) == json.dumps(prompt, ensure_ascii=False) + "\n"
+    rendered = html_path.read_text(encoding="utf-8")
+    assert "1 failed samples · results and vanilla commands" in rendered
+    assert "Reference result" in rendered
+    assert "TRTMC result" in rendered
+    assert "reference answer" in rendered
+    assert "TRTMC answer" in rendered
+    assert "Reference vanilla command" in rendered
+    assert "TRTMC vanilla command" in rendered
+    for wrapper in (
+        "task_eval.py",
+        "trtmc_compare.py",
+        "trtmc_reference.py",
+        "trtmc_validate.py",
+    ):
+        assert wrapper not in json.dumps(records)
+
+
+def test_report_bounds_inline_failed_samples_but_keeps_full_artifact(tmp_path):
+    case_dir = tmp_path / "model-a" / "workload-a"
+    work_dir = case_dir / "validation" / "workload-a" / "model-a"
+    work_dir.mkdir(parents=True)
+    sample_count = 25
+    prompts = [
+        {"sample_id": f"sample-{index}", "prompt": f"prompt-{index}"}
+        for index in range(sample_count)
+    ]
+    (work_dir / "prompts.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in prompts),
+        encoding="utf-8",
+    )
+    (work_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "disagreements": [
+                    {"sample_id": row["sample_id"], "reason": "token_mismatch"}
+                    for row in prompts
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    for name, prefix in (
+        ("hf_predictions.json", "reference"),
+        ("trtfb_predictions.json", "trtmc"),
+    ):
+        (work_dir / name).write_text(
+            json.dumps(
+                {
+                    "responses": [
+                        {
+                            "sample_id": row["sample_id"],
+                            "output_text": f"{prefix}-{index}",
+                        }
+                        for index, row in enumerate(prompts)
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+    (case_dir / "comparison.json").write_text(
+        json.dumps(
+            {
+                "model": "model-a",
+                "workload": "workload-a",
+                "status": "failed",
+                "raw_result": {"status": "failed", "work_dir": str(work_dir)},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, html_path, report = trtmc_validate.write_report(tmp_path)
+
+    metadata = report["results"][0]["disagreements"]
+    artifact = case_dir / metadata["path"]
+    assert metadata["count"] == sample_count
+    assert len(artifact.read_text(encoding="utf-8").splitlines()) == sample_count
+    rendered = html_path.read_text(encoding="utf-8")
+    assert "Showing 20 of 25" in rendered
+    assert "sample-19" in rendered
+    assert "sample-20" not in rendered
+    assert "View all in disagreements.jsonl" in rendered
+    assert (case_dir / "comparison.json").stat().st_size < 20_000
+    assert (tmp_path / "report.json").stat().st_size < 20_000
+
+
 def test_report_does_not_treat_shared_task_failure_as_disagreement(tmp_path):
     case_dir = tmp_path / "model-a" / "workload-a"
     work_dir = case_dir / "validation" / "workload-a" / "model-a"

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
 import json
 from pathlib import Path
 
@@ -650,6 +651,25 @@ def test_write_report_links_each_comparison(tmp_path):
     assert "$ python tools/trtmc_validate.py model-a" in document
     assert "$ python hf.py" in document
     assert "$ trtmc run" in document
+
+
+def test_write_report_records_total_duration(tmp_path, monkeypatch):
+    started_at = "2026-07-25T01:02:03+00:00"
+    finished_at = datetime(2026, 7, 25, 4, 4, 6, 500000, tzinfo=timezone.utc)
+    (tmp_path / "run.json").write_text(
+        json.dumps({"started_at": started_at}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_utc_now",
+        lambda: finished_at,
+    )
+
+    _, html_path, report = trtmc_validate.write_report(tmp_path)
+
+    assert report["summary"]["duration_seconds"] == 10_923.5
+    assert "3h 02m 04s total duration" in html_path.read_text(encoding="utf-8")
 
 
 def test_write_report_does_not_render_validation_wrapper(tmp_path):

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -39,6 +39,17 @@ directories therefore do not retain another copy of the bundle.
 
 At completion the command prints the exact reference and TRTMC reproduction
 commands, the per-model `comparison.json`, and the aggregate `report.html`.
+Dataset-backed comparison runs through `tools/trtmc_compare.py`; task-eval
+commands are not part of the validation result or its reproduction contract.
+
+The report keeps three statuses separate:
+
+- `execution`: whether the programs completed or errored;
+- `comparison`: whether TRTMC agrees or disagrees with the reference;
+- `validation`: the final pass, fail, or skipped result.
+
+The HTML report renders each status as an independent colored signal and shows
+the primary agreement metric next to it.
 
 ## Add or extend a model
 

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -26,6 +26,20 @@ Run every single-device model whose catalog status is `ready`:
 python tools/trtmc_validate.py --all
 ```
 
+Dataset-backed workloads use the task-specific sample limits declared in
+`model_workloads.yaml`. Fast encoder and classification workloads use larger
+slices, while generation-heavy image, video, and audio workloads use smaller
+slices. The selected limit is printed before execution and recorded next to the
+actual prepared-input count in `comparison.json` and `report.html`.
+
+Override the configured limit for one run, or request the complete dataset
+explicitly:
+
+```bash
+python tools/trtmc_validate.py gpt2-125m --limit 100
+python tools/trtmc_validate.py gpt2-125m --limit 0
+```
+
 The command creates a reference environment only when one does not already
 exist, then prints the environment it used. Reference inference runs through
 `tools/trtmc_reference.py`, outside the task-eval CLI. Its result is keyed by
@@ -49,7 +63,7 @@ as migrated task-eval workloads.
 
 The HTML artifact is named **TRTMC Reference Consistency Report** because it
 covers task accuracy as well as token, embedding, and numerical agreement.
-For large datasets it shows one full-dataset command and at most three
+For large datasets it shows one dataset-run command and at most three
 representative commands per backend. The first disagreement is preferred when
 one exists.
 
@@ -88,7 +102,8 @@ the primary agreement metric next to it.
 1. Reuse or add a dataset workload in
    `tests/task_eval/validation_suites.yaml`.
 2. Add that workload under the model in `model_workloads.yaml`.
-3. Select one workload as the model default.
+3. Add a workload sample limit if the workload is new.
+4. Select one workload as the model default.
 
 Use `e2e` only when the model cannot use a dataset-backed workload yet. A model
 may list multiple workloads; callers select one by passing it after the model

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -42,6 +42,13 @@ commands, the per-model `comparison.json`, and the aggregate `report.html`.
 Dataset-backed comparison runs through `tools/trtmc_compare.py`; task-eval
 commands are not part of the validation result or its reproduction contract.
 
+The HTML artifact is named **TRTMC Reference Consistency Report** because it
+covers task accuracy as well as token, embedding, and numerical agreement.
+For large datasets it shows one full-dataset command and at most three
+representative commands per backend. The first disagreement is preferred when
+one exists. Complete per-sample commands remain in the run logs and are not
+copied into `comparison.json`, `report.json`, or the HTML report.
+
 The report keeps three statuses separate:
 
 - `execution`: whether the programs completed or errored;

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -41,6 +41,11 @@ At completion the command prints the exact reference and TRTMC reproduction
 commands, the per-model `comparison.json`, and the aggregate `report.html`.
 Dataset-backed comparison runs through `tools/trtmc_compare.py`; task-eval
 commands are not part of the validation result or its reproduction contract.
+Every non-`e2e` model/workload binding must resolve to an independent reference
+runner selected by the prepared dataset kind. A catalog-wide test rejects new
+bindings that would fall back to `task_eval.py`. Models whose validation
+contract is still only `e2e` continue to use the E2E path and are not presented
+as migrated task-eval workloads.
 
 The HTML artifact is named **TRTMC Reference Consistency Report** because it
 covers task accuracy as well as token, embedding, and numerical agreement.
@@ -56,6 +61,18 @@ entrypoint and the TRTMC command invokes the model executable directly; neither
 command re-enters validation, comparison, or task-eval orchestration. The
 complete set is written to `disagreements.jsonl`, while `comparison.json` and
 `report.json` retain only bounded metadata.
+
+Model-owned reference and TRTMC plugins record the subprocess command they
+actually executed. These per-sample command logs stay in the model work
+directory; the HTML includes only commands for disagreement samples. This
+keeps a 1,000- or 10,000-sample report compact without reconstructing a command
+after the failure.
+
+For failed image, video, or audio samples, the report copies only the relevant
+input/output media into that sample's `repro` directory. Image and video-frame
+previews, playable video files up to the artifact size limit, and WAV/audio
+controls are rendered next to the two result records. Passing samples do not
+duplicate media.
 
 The report keeps three statuses separate:
 

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -26,6 +26,33 @@ Run every single-device model whose catalog status is `ready`:
 python tools/trtmc_validate.py --all
 ```
 
+The all-model command supervises one isolated worker process per model. By
+default it records a failed worker and continues with the remaining models.
+Stop after the first failed model when that is preferable:
+
+```bash
+python tools/trtmc_validate.py --all --on-model-failure stop
+```
+
+Both policies return a nonzero exit status when any attempted model fails.
+Process isolation also covers failures that happen before backend execution,
+such as reference-environment setup or uncaught model-specific Python errors.
+
+The same CLI is the CI case entry point. Generate a machine-readable matrix,
+then run one exact model/workload binding in each CI node:
+
+```bash
+python tools/trtmc_validate.py --all --dry-run
+python tools/trtmc_validate.py gpt2-125m mmlu_continuation_parity \
+  --output validation-artifacts
+```
+
+The case result is always written to
+`<output>/<model>/<workload>/comparison.json`; `report.json` and `report.html`
+are written at the output root. Exit status `0` means reference consistency
+passed, `1` means the case ran but validation failed, and `2` means CLI or
+setup validation failed before the case could run.
+
 Dataset-backed workloads use the task-specific sample limits declared in
 `model_workloads.yaml`. Fast encoder and classification workloads use larger
 slices, while generation-heavy image, video, and audio workloads use smaller

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -27,9 +27,18 @@ python tools/trtmc_validate.py --all
 ```
 
 The command creates a reference environment only when one does not already
-exist, then prints the environment it used. At completion it prints the exact
-HF and TRTMC reproduction commands, the per-model `comparison.json`, and the
-aggregate `report.html`.
+exist, then prints the environment it used. Reference inference runs through
+`tools/trtmc_reference.py`, outside the task-eval CLI. Its result is keyed by
+the prepared inputs and inference settings and reused from the shared reference
+cache when the key already exists.
+
+TRTMC bundles live in one shared validation engine directory. A required
+rebuild removes the existing bundle and writes the replacement at the same
+path; a failed replacement removes any partial bundle. Per-run result
+directories therefore do not retain another copy of the bundle.
+
+At completion the command prints the exact reference and TRTMC reproduction
+commands, the per-model `comparison.json`, and the aggregate `report.html`.
 
 ## Add or extend a model
 

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -29,8 +29,8 @@ python tools/trtmc_validate.py --all
 Dataset-backed workloads use the task-specific sample limits declared in
 `model_workloads.yaml`. Fast encoder and classification workloads use larger
 slices, while generation-heavy image, video, and audio workloads use smaller
-slices. The selected limit is printed before execution and recorded next to the
-actual prepared-input count in `comparison.json` and `report.html`.
+slices. The selected limit is printed before execution and shown in the
+`Samples` column of `report.html`.
 
 Override the configured limit for one run, or request the complete dataset
 explicitly:
@@ -43,7 +43,7 @@ python tools/trtmc_validate.py gpt2-125m --limit 0
 The command creates a reference environment only when one does not already
 exist, then prints the environment it used. Reference inference runs through
 `tools/trtmc_reference.py`, outside the task-eval CLI. Its result is keyed by
-the prepared inputs and inference settings and reused from the shared reference
+the input slice and inference settings and reused from the shared reference
 cache when the key already exists.
 
 TRTMC bundles live in one shared validation engine directory. A required
@@ -68,7 +68,7 @@ representative commands per backend. The first disagreement is preferred when
 one exists.
 
 When per-sample differences exist, the model row also shows up to 20 affected
-samples. Each sample contains the prepared input, both raw prediction records,
+samples. Each sample contains the exact input, both raw prediction records,
 the comparison evidence, and native single-sample commands when the backends
 provide them. The reference command invokes a standalone upstream-framework
 entrypoint and the TRTMC command invokes the model executable directly; neither

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -46,8 +46,16 @@ The HTML artifact is named **TRTMC Reference Consistency Report** because it
 covers task accuracy as well as token, embedding, and numerical agreement.
 For large datasets it shows one full-dataset command and at most three
 representative commands per backend. The first disagreement is preferred when
-one exists. Complete per-sample commands remain in the run logs and are not
-copied into `comparison.json`, `report.json`, or the HTML report.
+one exists.
+
+When per-sample differences exist, the model row also shows up to 20 affected
+samples. Each sample contains the prepared input, both raw prediction records,
+the comparison evidence, and native single-sample commands when the backends
+provide them. The reference command invokes a standalone upstream-framework
+entrypoint and the TRTMC command invokes the model executable directly; neither
+command re-enters validation, comparison, or task-eval orchestration. The
+complete set is written to `disagreements.jsonl`, while `comparison.json` and
+`report.json` retain only bounded metadata.
 
 The report keeps three statuses separate:
 

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -1,0 +1,43 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# TRTMC reference validation
+
+`trtmc-validate` is an internal Dev/QA workflow for checking that a TRTMC model
+still agrees with its original reference implementation.
+
+Run a model's default workload:
+
+```bash
+python tools/trtmc_validate.py gpt2-125m
+```
+
+Run a different workload declared for that model:
+
+```bash
+python tools/trtmc_validate.py internvl3-2b vlm_mmmu_pro_vision_mcq
+```
+
+Run every single-device model whose catalog status is `ready`:
+
+```bash
+python tools/trtmc_validate.py --all
+```
+
+The command creates a reference environment only when one does not already
+exist, then prints the environment it used. At completion it prints the exact
+HF and TRTMC reproduction commands, the per-model `comparison.json`, and the
+aggregate `report.html`.
+
+## Add or extend a model
+
+1. Reuse or add a dataset workload in
+   `tests/task_eval/validation_suites.yaml`.
+2. Add that workload under the model in `model_workloads.yaml`.
+3. Select one workload as the model default.
+
+Use `e2e` only when the model cannot use a dataset-backed workload yet. A model
+may list multiple workloads; callers select one by passing it after the model
+name.

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -1,0 +1,382 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 1
+
+# Model-first validation bindings. Workload names other than "e2e" refer to
+# dataset preparation and comparison contracts in
+# tests/task_eval/validation_suites.yaml. "e2e" reuses the model-owned E2E
+# cases when no compatible dataset-backed workload exists yet.
+models:
+  albert-base:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  all-minilm-l6-v2:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  all-mpnet-base-v2:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  bark-large:
+    default: seedtts_en_tts_intelligibility
+    workloads: [seedtts_en_tts_intelligibility]
+  bark-small:
+    default: seedtts_en_tts_intelligibility
+    workloads: [seedtts_en_tts_intelligibility]
+  bart-base:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  bert-base-uncased:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  bge-small-en-v1.5:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  bloom-560m:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  camembert-base:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  canary-1b-v2:
+    default: librispeech_clean_asr
+    workloads: [librispeech_clean_asr]
+  chronos-bolt-tiny-official:
+    default: etth1_time_series_parity
+    workloads: [etth1_time_series_parity]
+  codegen-350m:
+    default: humaneval_code_continuation_parity
+    workloads: [humaneval_code_continuation_parity]
+  convbert-base:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  deberta-base:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  deepseek-ocr:
+    default: ocrbench_v2_unified
+    workloads: [ocrbench_v2_unified]
+  deepseek-ocr-l0:
+    default: ocrbench_v2_unified
+    workloads: [ocrbench_v2_unified]
+  deepseek-v2-lite:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  deepseek-v2-tiny:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  distilbert-base-uncased:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  distilgpt2:
+    default: wikitext103_distilgpt2_continuation_parity
+    workloads: [wikitext103_distilgpt2_continuation_parity]
+  dpr-ctx-encoder:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  electra-base-discriminator:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  elf-b-de-en-l0:
+    default: wmt14_de_en_elf_diffusion_text
+    workloads: [wmt14_de_en_elf_diffusion_text]
+  elf-b-owt-l0:
+    default: openwebtext_elf_diffusion_text
+    workloads: [openwebtext_elf_diffusion_text]
+  elf-b-xsum-l0:
+    default: xsum_elf_diffusion_text
+    workloads: [xsum_elf_diffusion_text]
+  falcon-rw-1b:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  falcon3-1b:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  flux-2-dev:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]
+  flux-2-dev-fp8:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]
+  flux-2-dev-fp8-l0:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]
+  flux-2-dev-l0:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]
+  flux-schnell:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]
+  flux-schnell-l0:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]
+  flux-schnell-l0-batch2:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]
+  fnet-base:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  gemma-2-2b:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  glm-4-9b:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  glm-4-9b-l0:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  gpt-neo-125m:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  gpt-oss-20b:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  gpt-oss-20b-l0:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  gpt2-125m:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  granite-3.1-2b:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  internlm2-1.8b:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  internvl3-2b:
+    default: vlm_mmmu_pro_vision_fixed_mcq
+    workloads: [vlm_mmmu_pro_vision_fixed_mcq, vlm_mmmu_pro_vision_mcq]
+  internvl3-8b:
+    default: vlm_mmmu_pro_vision_fixed_mcq
+    workloads: [vlm_mmmu_pro_vision_fixed_mcq, vlm_mmmu_pro_vision_mcq]
+  lance-3b-x2t-image:
+    default: e2e
+    workloads: [e2e]
+  locateanything-3b:
+    default: e2e
+    workloads: [e2e]
+  ltx-video-l0:
+    default: vbench_t2v_diffusion_video
+    workloads: [vbench_t2v_diffusion_video]
+  magpie-tts-357m:
+    default: seedtts_en_tts_intelligibility
+    workloads: [seedtts_en_tts_intelligibility]
+  mamba-130m:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  marian-en-ru:
+    default: newstest2019_en_ru_marian_translation_parity
+    workloads: [newstest2019_en_ru_marian_translation_parity]
+  minitron-4b-depth:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  minitron-4b-width:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  minitron-4b-width-l0:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  mistral-7b:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  mistral-7b-l0:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  mixtral-stories-15m:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  modernbert-base:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  nemotron-3.5-asr-streaming-0.6b:
+    default: librispeech_clean_asr_streaming
+    workloads: [librispeech_clean_asr_streaming]
+  nemotron-embed-vl-1b-v2:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  nemotron-h-nano-9b:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  nemotron-hindi-4b:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  nemotron-labs-diffusion-8b:
+    default: e2e
+    workloads: [e2e]
+  nemotron-labs-diffusion-8b-l0:
+    default: e2e
+    workloads: [e2e]
+  nemotron-mini-4b:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  nemotron-nano-4b:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  nemotron-rerank-vl-1b-v2:
+    default: beir_scifact_reranking
+    workloads: [beir_scifact_reranking]
+  nemotron-speech-streaming-en-0.6b:
+    default: librispeech_clean_asr_streaming
+    workloads: [librispeech_clean_asr_streaming]
+  nllb-200-distilled-600m:
+    default: e2e
+    workloads: [e2e]
+  olmo-1b:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  olmo2-1b:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  opt-125m:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  paraphrase-multilingual-minilm-l12-v2:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  patchtsmixer-granite-official:
+    default: etth1_time_series_parity
+    workloads: [etth1_time_series_parity]
+  patchtst-etth1-regression-distribution:
+    default: etth1_time_series_parity
+    workloads: [etth1_time_series_parity]
+  patchtst-granite-official:
+    default: etth1_time_series_parity
+    workloads: [etth1_time_series_parity]
+  personaplex-7b:
+    default: e2e
+    workloads: [e2e]
+  personaplex-7b-l0:
+    default: e2e
+    workloads: [e2e]
+  phi-moe:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  phi-moe-l0:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  phi3-mini:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  phi4-multimodal:
+    default: e2e
+    workloads: [e2e]
+  pixart-sigma-1024:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]
+  pixart-sigma-1024-l0:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]
+  pythia-70m:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  qwen-image:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]
+  qwen-image-2512:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]
+  qwen-image-edit-2511:
+    default: gedit_bench_image_edit
+    workloads: [gedit_bench_image_edit]
+  qwen-image-l0:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]
+  qwen25vl-3b:
+    default: vlm_mmmu_pro_vision_fixed_mcq
+    workloads: [vlm_mmmu_pro_vision_fixed_mcq, vlm_mmmu_pro_vision_mcq]
+  qwen3-0.6b-fp16:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  qwen3-0.6b-fp8:
+    default: e2e
+    workloads: [e2e]
+  qwen3-0.6b-topp:
+    default: e2e
+    workloads: [e2e]
+  qwen3-4b-instruct-2507:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  qwen3-moe-30b-a3b:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  qwen3-moe-tiny-random:
+    default: e2e
+    workloads: [e2e]
+  qwen3-omni-30b-a3b-instruct:
+    default: e2e
+    workloads: [e2e]
+  qwen3-vl-2b:
+    default: vlm_mmmu_pro_vision_fixed_mcq
+    workloads: [vlm_mmmu_pro_vision_fixed_mcq, vlm_mmmu_pro_vision_mcq]
+  qwen35-9b:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  riva-translate-4b:
+    default: flores200_en_fr_riva_translation_parity
+    workloads: [flores200_en_fr_riva_translation_parity]
+  roberta-base:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  roberta-large:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  rwkv-169m:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  sam-vit-base:
+    default: coco2017_prompted_segmentation
+    workloads: [coco2017_prompted_segmentation]
+  sam3:
+    default: coco2017_prompted_segmentation
+    workloads: [coco2017_prompted_segmentation]
+  sana-wm-bidirectional:
+    default: sana_wm_benchmark_diffusion_video
+    workloads: [sana_wm_benchmark_diffusion_video]
+  segformer-b0-ade:
+    default: ade20k_semantic_segmentation
+    workloads: [ade20k_semantic_segmentation]
+  stablelm2-1.6b:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  starcoder2-3b:
+    default: humaneval_code_continuation_parity
+    workloads: [humaneval_code_continuation_parity]
+  t5-small:
+    default: wmt14_en_de_t5_translation_parity
+    workloads: [wmt14_en_de_t5_translation_parity]
+  timesfm-2.0-500m-official:
+    default: etth1_time_series_parity
+    workloads: [etth1_time_series_parity]
+  timm-vit-base-p16-224-augreg-in21k-ft-in1k:
+    default: imagenette_image_classification
+    workloads: [imagenette_image_classification]
+  tinyllama-1.1b:
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
+  wan21-t2v-1.3b:
+    default: e2e
+    workloads: [e2e]
+  wan21-t2v-1.3b-l0:
+    default: vbench_t2v_diffusion_video
+    workloads: [vbench_t2v_diffusion_video]
+  whisper-large-v3-turbo:
+    default: librispeech_clean_asr
+    workloads: [librispeech_clean_asr]
+  whisper-tiny-fp16:
+    default: librispeech_clean_asr
+    workloads: [librispeech_clean_asr]
+  xglm-564m:
+    default: mmlu_continuation_parity
+    workloads: [mmlu_continuation_parity]
+  xlm-roberta-base:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  xlnet-base:
+    default: stsbenchmark_encoder_embedding_parity
+    workloads: [stsbenchmark_encoder_embedding_parity]
+  z-image-turbo:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]
+  z-image-turbo-l0:
+    default: dpg_bench_diffusion_image
+    workloads: [dpg_bench_diffusion_image]

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -27,7 +27,6 @@ sample_limits:
   sana_wm_benchmark_diffusion_video: 2
   seedtts_en_tts_intelligibility: 3
   stsbenchmark_encoder_embedding_parity: 50
-  vbench_t2v_diffusion_video: 2
   vlm_mmmu_pro_vision_fixed_mcq: 5
   vlm_mmmu_pro_vision_mcq: 5
   wikitext103_distilgpt2_continuation_parity: 20
@@ -88,9 +87,6 @@ models:
   deepseek-ocr:
     default: ocrbench_v2_unified
     workloads: [ocrbench_v2_unified]
-  deepseek-ocr-l0:
-    default: ocrbench_v2_unified
-    workloads: [ocrbench_v2_unified]
   deepseek-v2-lite:
     default: mmlu_continuation_parity
     workloads: [mmlu_continuation_parity]
@@ -130,19 +126,7 @@ models:
   flux-2-dev-fp8:
     default: dpg_bench_diffusion_image
     workloads: [dpg_bench_diffusion_image]
-  flux-2-dev-fp8-l0:
-    default: dpg_bench_diffusion_image
-    workloads: [dpg_bench_diffusion_image]
-  flux-2-dev-l0:
-    default: dpg_bench_diffusion_image
-    workloads: [dpg_bench_diffusion_image]
   flux-schnell:
-    default: dpg_bench_diffusion_image
-    workloads: [dpg_bench_diffusion_image]
-  flux-schnell-l0:
-    default: dpg_bench_diffusion_image
-    workloads: [dpg_bench_diffusion_image]
-  flux-schnell-l0-batch2:
     default: dpg_bench_diffusion_image
     workloads: [dpg_bench_diffusion_image]
   fnet-base:
@@ -154,16 +138,10 @@ models:
   glm-4-9b:
     default: mmlu_continuation_parity
     workloads: [mmlu_continuation_parity]
-  glm-4-9b-l0:
-    default: mmlu_continuation_parity
-    workloads: [mmlu_continuation_parity]
   gpt-neo-125m:
     default: mmlu_continuation_parity
     workloads: [mmlu_continuation_parity]
   gpt-oss-20b:
-    default: mmlu_five_shot_mcq
-    workloads: [mmlu_five_shot_mcq]
-  gpt-oss-20b-l0:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
   gpt2-125m:
@@ -175,21 +153,12 @@ models:
   internlm2-1.8b:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
-  internvl3-2b:
-    default: vlm_mmmu_pro_vision_fixed_mcq
-    workloads: [vlm_mmmu_pro_vision_fixed_mcq, vlm_mmmu_pro_vision_mcq]
   internvl3-8b:
     default: vlm_mmmu_pro_vision_fixed_mcq
     workloads: [vlm_mmmu_pro_vision_fixed_mcq, vlm_mmmu_pro_vision_mcq]
   lance-3b-x2t-image:
     default: e2e
     workloads: [e2e]
-  locateanything-3b:
-    default: e2e
-    workloads: [e2e]
-  ltx-video-l0:
-    default: vbench_t2v_diffusion_video
-    workloads: [vbench_t2v_diffusion_video]
   magpie-tts-357m:
     default: seedtts_en_tts_intelligibility
     workloads: [seedtts_en_tts_intelligibility]
@@ -205,13 +174,7 @@ models:
   minitron-4b-width:
     default: mmlu_continuation_parity
     workloads: [mmlu_continuation_parity]
-  minitron-4b-width-l0:
-    default: mmlu_continuation_parity
-    workloads: [mmlu_continuation_parity]
   mistral-7b:
-    default: mmlu_five_shot_mcq
-    workloads: [mmlu_five_shot_mcq]
-  mistral-7b-l0:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
   mixtral-stories-15m:
@@ -233,9 +196,6 @@ models:
     default: mmlu_continuation_parity
     workloads: [mmlu_continuation_parity]
   nemotron-labs-diffusion-8b:
-    default: e2e
-    workloads: [e2e]
-  nemotron-labs-diffusion-8b-l0:
     default: e2e
     workloads: [e2e]
   nemotron-mini-4b:
@@ -277,13 +237,7 @@ models:
   personaplex-7b:
     default: e2e
     workloads: [e2e]
-  personaplex-7b-l0:
-    default: e2e
-    workloads: [e2e]
   phi-moe:
-    default: mmlu_five_shot_mcq
-    workloads: [mmlu_five_shot_mcq]
-  phi-moe-l0:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
   phi3-mini:
@@ -293,9 +247,6 @@ models:
     default: e2e
     workloads: [e2e]
   pixart-sigma-1024:
-    default: dpg_bench_diffusion_image
-    workloads: [dpg_bench_diffusion_image]
-  pixart-sigma-1024-l0:
     default: dpg_bench_diffusion_image
     workloads: [dpg_bench_diffusion_image]
   pythia-70m:
@@ -310,9 +261,6 @@ models:
   qwen-image-edit-2511:
     default: gedit_bench_image_edit
     workloads: [gedit_bench_image_edit]
-  qwen-image-l0:
-    default: dpg_bench_diffusion_image
-    workloads: [dpg_bench_diffusion_image]
   qwen25vl-3b:
     default: vlm_mmmu_pro_vision_fixed_mcq
     workloads: [vlm_mmmu_pro_vision_fixed_mcq, vlm_mmmu_pro_vision_mcq]
@@ -331,9 +279,6 @@ models:
   qwen3-moe-30b-a3b:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
-  qwen3-moe-tiny-random:
-    default: e2e
-    workloads: [e2e]
   qwen3-omni-30b-a3b-instruct:
     default: e2e
     workloads: [e2e]
@@ -388,13 +333,7 @@ models:
   wan21-t2v-1.3b:
     default: e2e
     workloads: [e2e]
-  wan21-t2v-1.3b-l0:
-    default: vbench_t2v_diffusion_video
-    workloads: [vbench_t2v_diffusion_video]
   wan22-ti2v-5b:
-    default: e2e
-    workloads: [e2e]
-  wan22-ti2v-5b-l0:
     default: e2e
     workloads: [e2e]
   whisper-large-v3-turbo:
@@ -413,8 +352,5 @@ models:
     default: stsbenchmark_encoder_embedding_parity
     workloads: [stsbenchmark_encoder_embedding_parity]
   z-image-turbo:
-    default: dpg_bench_diffusion_image
-    workloads: [dpg_bench_diffusion_image]
-  z-image-turbo-l0:
     default: dpg_bench_diffusion_image
     workloads: [dpg_bench_diffusion_image]

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -11,16 +11,16 @@ sample_limits:
   ade20k_semantic_segmentation: 50
   beir_scifact_reranking: 20
   coco2017_prompted_segmentation: 20
-  dpg_bench_diffusion_image: 2
+  dpg_bench_diffusion_image: 5
   etth1_time_series_parity: 10
   flores200_en_fr_riva_translation_parity: 10
-  gedit_bench_image_edit: 2
+  gedit_bench_image_edit: 5
   humaneval_code_continuation_parity: 10
   imagenette_image_classification: 100
   librispeech_clean_asr: 10
   librispeech_clean_asr_streaming: 5
   mmlu_continuation_parity: 10
-  mmlu_five_shot_mcq: 5
+  mmlu_five_shot_mcq: 20
   newstest2019_en_ru_marian_translation_parity: 10
   ocrbench_v2_unified: 5
   openwebtext_elf_diffusion_text: 5

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -3,6 +3,38 @@
 
 version: 1
 
+# Default dataset sample counts for Dev/QA reference-consistency runs. These
+# limits are workload-owned so every model using the same validation contract
+# sees the same deterministic slice. Pass --limit to override one run; use
+# --limit 0 explicitly for the full dataset.
+sample_limits:
+  ade20k_semantic_segmentation: 50
+  beir_scifact_reranking: 20
+  coco2017_prompted_segmentation: 20
+  dpg_bench_diffusion_image: 2
+  etth1_time_series_parity: 10
+  flores200_en_fr_riva_translation_parity: 10
+  gedit_bench_image_edit: 2
+  humaneval_code_continuation_parity: 10
+  imagenette_image_classification: 100
+  librispeech_clean_asr: 10
+  librispeech_clean_asr_streaming: 5
+  mmlu_continuation_parity: 10
+  mmlu_five_shot_mcq: 5
+  newstest2019_en_ru_marian_translation_parity: 10
+  ocrbench_v2_unified: 5
+  openwebtext_elf_diffusion_text: 5
+  sana_wm_benchmark_diffusion_video: 2
+  seedtts_en_tts_intelligibility: 3
+  stsbenchmark_encoder_embedding_parity: 50
+  vbench_t2v_diffusion_video: 2
+  vlm_mmmu_pro_vision_fixed_mcq: 5
+  vlm_mmmu_pro_vision_mcq: 5
+  wikitext103_distilgpt2_continuation_parity: 20
+  wmt14_de_en_elf_diffusion_text: 5
+  wmt14_en_de_t5_translation_parity: 10
+  xsum_elf_diffusion_text: 5
+
 # Model-first validation bindings. Workload names other than "e2e" refer to
 # dataset preparation and comparison contracts in
 # tests/task_eval/validation_suites.yaml. "e2e" reuses the model-owned E2E

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -359,6 +359,12 @@ models:
   wan21-t2v-1.3b-l0:
     default: vbench_t2v_diffusion_video
     workloads: [vbench_t2v_diffusion_video]
+  wan22-ti2v-5b:
+    default: e2e
+    workloads: [e2e]
+  wan22-ti2v-5b-l0:
+    default: e2e
+    workloads: [e2e]
   whisper-large-v3-turbo:
     default: librispeech_clean_asr
     workloads: [librispeech_clean_asr]

--- a/tools/elf_hf_reference.py
+++ b/tools/elf_hf_reference.py
@@ -81,6 +81,18 @@ def _validate_replay_arguments(args: argparse.Namespace) -> bool:
     return bool(args.initial_latents)
 
 
+def _canonical_hf_model_id(model_id: str) -> str:
+    """Resolve legacy aliases to the repository IDs used by TRTMC cache warming."""
+    return {"t5-small": "google-t5/t5-small"}.get(model_id, model_id)
+
+
+class _InferenceOptimizer:
+    """Accept checkpoint optimizer state without installing training-only packages."""
+
+    def load_state_dict(self, _state) -> None:
+        return None
+
+
 def main() -> int:
     args = _parse_args()
     replay_inputs = _validate_replay_arguments(args)
@@ -104,7 +116,7 @@ def main() -> int:
         shift_left,
     )
     from utils.sampling_utils import _ode_step, _forward_sample, restore_cond
-    from utils.train_utils import TrainState, get_optimizer
+    from utils.train_utils import TrainState
 
     if args.local_files_only:
         import os
@@ -124,8 +136,12 @@ def main() -> int:
         torch.backends.cuda.enable_flash_sdp(False)
         torch.backends.cuda.enable_mem_efficient_sdp(True)
         torch.backends.cuda.enable_math_sdp(True)
+    encoder_model_id = _canonical_hf_model_id(config.encoder_model_name)
+    tokenizer_model_id = _canonical_hf_model_id(
+        config.tokenizer_name or config.encoder_model_name
+    )
     tokenizer = __import__("transformers").AutoTokenizer.from_pretrained(
-        config.tokenizer_name or config.encoder_model_name,
+        tokenizer_model_id,
         local_files_only=args.local_files_only,
     )
     pad_token_id = get_pad_token_id(tokenizer, config.pad_token)
@@ -138,7 +154,7 @@ def main() -> int:
             raise ValueError("initial replay latents do not divide evenly by config.max_length")
         text_encoder_dim = replay_initial.numel() // int(config.max_length)
     elif args.generation_mode == "conditional":
-        encoder_config, encoder = get_encoder(config.encoder_model_name, torch.float32)
+        encoder_config, encoder = get_encoder(encoder_model_id, torch.float32)
         encoder = encoder.to(device).eval()
         for parameter in encoder.parameters():
             parameter.requires_grad_(False)
@@ -157,10 +173,9 @@ def main() -> int:
         num_model_mode_tokens=config.num_model_mode_tokens,
         bottleneck_dim=config.bottleneck_dim,
     ).to(device)
-    optimizer = get_optimizer(model, config, lr=1e-4)
     state = TrainState(
         model=model,
-        optimizer=optimizer,
+        optimizer=_InferenceOptimizer(),
         lr_scheduler=None,
         ema_params1=TrainState.init_ema(model),
         step=0,

--- a/tools/reference/elf_prepared.py
+++ b/tools/reference/elf_prepared.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prepare task datasets for direct execution by the official ELF reference."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any, Mapping, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ELF_REFERENCE = REPO_ROOT / "tools" / "elf_hf_reference.py"
+SCHEMA_VERSION = "trtmc.native-reference-reproduction/v1"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if not isinstance(row, dict):
+            raise ValueError(f"{path}:{line_number} must contain a JSON object")
+        rows.append(row)
+    return rows
+
+
+def _selected_rows(
+    prompts: Sequence[Mapping[str, Any]],
+    requests: Sequence[Mapping[str, Any]],
+    sample_id: str,
+) -> list[tuple[int, Mapping[str, Any], Mapping[str, Any]]]:
+    if len(prompts) != len(requests):
+        raise ValueError("ELF reference prompt/answer count mismatch")
+    selected = [
+        (index, prompt, request)
+        for index, (prompt, request) in enumerate(
+            zip(prompts, requests, strict=True)
+        )
+        if not sample_id or str(prompt.get("sample_id", "")) == sample_id
+    ]
+    if sample_id and not selected:
+        raise ValueError(f"sample_id {sample_id!r} is not present in the prepared prompts")
+    return selected
+
+
+def _write_dataset(
+    path: Path,
+    selected: Sequence[
+        tuple[int, Mapping[str, Any], Mapping[str, Any]]
+    ],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as output:
+        for _index, prompt, request in selected:
+            output.write(
+                json.dumps(
+                    {
+                        "id": str(prompt.get("sample_id", "")),
+                        "input": str(
+                            prompt.get("source_text", prompt.get("prompt", ""))
+                        ),
+                        "output": str(request.get("answer", "")),
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+
+
+def _generation(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
+    generation = manifest.get("generation", {})
+    return generation if isinstance(generation, Mapping) else {}
+
+
+def _reference(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
+    task_config = manifest.get("task_eval", {})
+    if not isinstance(task_config, Mapping):
+        return {}
+    reference = task_config.get("reference", {})
+    return reference if isinstance(reference, Mapping) else {}
+
+
+def _config_path(arguments: argparse.Namespace, reference: Mapping[str, Any]) -> Path:
+    value = str(reference.get("config", "") or "")
+    if not value:
+        raise ValueError("ELF reference requires task_eval.reference.config")
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return arguments.elf_reference_repo / path
+
+
+def _direct_command(
+    arguments: argparse.Namespace,
+    manifest: Mapping[str, Any],
+    dataset: str,
+    output: str,
+    artifacts: str,
+    seed: str,
+) -> list[str]:
+    reference = _reference(manifest)
+    generation = _generation(manifest)
+    command = [
+        sys.executable,
+        str(ELF_REFERENCE),
+        "--reference-repo",
+        str(arguments.elf_reference_repo),
+        "--config",
+        str(_config_path(arguments, reference)),
+        "--checkpoint",
+        str(reference.get("checkpoint", arguments.model) or arguments.model),
+        "--dataset",
+        dataset,
+        "--output",
+        output,
+        "--shared-inputs-dir",
+        artifacts,
+        "--generation-mode",
+        str(generation.get("generation_mode", "conditional")),
+        "--sampling-method",
+        str(generation.get("sampling_method", "ode")),
+        "--num-steps",
+        str(generation.get("num_sampling_steps", 64)),
+        "--cfg-scale",
+        str(generation.get("cfg_scale", 1.0)),
+        "--self-cond-cfg-scale",
+        str(generation.get("self_cond_cfg_scale", 1.0)),
+        "--sde-gamma",
+        str(generation.get("sde_gamma", 0.0)),
+        "--seed",
+        seed,
+    ]
+    if arguments.local_files_only:
+        command.append("--local-files-only")
+    return command
+
+
+def _write_reproduction_metadata(
+    arguments: argparse.Namespace,
+    manifest: Mapping[str, Any],
+) -> None:
+    if arguments.repro_metadata is None:
+        return
+    arguments.repro_metadata.write_text(
+        json.dumps(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "backend": "elf_official_pytorch",
+                "entrypoint": str(ELF_REFERENCE),
+                "entrypoint_sha256": hashlib.sha256(
+                    ELF_REFERENCE.read_bytes()
+                ).hexdigest(),
+                "input_format": "elf_reference_jsonl",
+                "base_seed": int(_generation(manifest).get("seed", 42)),
+                "command": _direct_command(
+                    arguments,
+                    manifest,
+                    "{reference_input_jsonl}",
+                    "{reference_predictions_json}",
+                    "{reference_artifacts_dir}",
+                    "{reference_sample_seed}",
+                ),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def run(arguments: argparse.Namespace) -> None:
+    manifest = _load_json(arguments.manifest)
+    answers = _load_json(arguments.answers)
+    requests = answers.get("requests", [])
+    if not isinstance(requests, list):
+        raise ValueError("answers.json requests must be a list")
+    selected = _selected_rows(
+        _load_jsonl(arguments.prompts),
+        requests,
+        arguments.sample_id,
+    )
+    dataset = arguments.predictions.parent / "hf_reference_dataset.jsonl"
+    artifacts = arguments.predictions.parent / "hf_shared_inputs"
+    _write_dataset(dataset, selected)
+    arguments.predictions.parent.mkdir(parents=True, exist_ok=True)
+    command = _direct_command(
+        arguments,
+        manifest,
+        str(dataset),
+        str(arguments.predictions),
+        str(artifacts),
+        str(
+            int(_generation(manifest).get("seed", 42))
+            + (selected[0][0] if len(selected) == 1 else 0)
+        ),
+    )
+    result = subprocess.run(
+        command,
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=arguments.elf_reference_repo,
+    )
+    (arguments.predictions.parent / "hf_reference_stdout.log").write_text(
+        result.stdout,
+        encoding="utf-8",
+    )
+    (arguments.predictions.parent / "hf_reference_stderr.log").write_text(
+        result.stderr,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ELF reference failed rc={result.returncode}; "
+            "see hf_reference_stderr.log"
+        )
+    payload = _load_json(arguments.predictions)
+    with arguments.raw_output.open("w", encoding="utf-8") as raw_file:
+        for row in payload.get("responses", []):
+            raw_file.write(json.dumps(row, ensure_ascii=False) + "\n")
+    _write_reproduction_metadata(arguments, manifest)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Prepare and run the official ELF PyTorch reference."
+    )
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--reference-family", default="")
+    parser.add_argument("--elf-reference-repo", type=Path, required=True)
+    parser.add_argument("--prompts", type=Path, required=True)
+    parser.add_argument("--answers", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--predictions", type=Path, required=True)
+    parser.add_argument("--raw-output", type=Path, required=True)
+    parser.add_argument("--repro-metadata", type=Path)
+    parser.add_argument("--sample-id", default="")
+    parser.add_argument("--dtype", default="auto")
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--device-map", default="")
+    parser.add_argument("--attn-impl", default="")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--local-files-only", action="store_true")
+    parser.add_argument("--do-sample", action="store_true")
+    parser.add_argument("--apply-chat-template", action="store_true")
+    parser.add_argument("--max-new-tokens", type=int)
+    parser.add_argument("--temperature", type=float)
+    parser.add_argument("--top-k", type=int)
+    parser.add_argument("--top-p", type=float)
+    parser.add_argument("--seed", type=int)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    run(build_parser().parse_args(argv))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/reference/plugin_reference.py
+++ b/tools/reference/plugin_reference.py
@@ -1,0 +1,722 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run model-owned reference plugins without task-eval orchestration."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+import shlex
+import sys
+from typing import Any, Mapping, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tests.e2e_harness.contracts import RunContext, StageSpec  # noqa: E402
+from tests.e2e_harness.manifest_loader import load_manifest  # noqa: E402
+from tests.e2e_harness.registry import (  # noqa: E402
+    activate_model_plugins,
+    get_reference,
+)
+
+
+SCHEMA_VERSION = "trtmc.native-reference-reproduction/v1"
+_VISION_DATASET_KINDS = {
+    "image_classification_json",
+    "prompted_segmentation_json",
+    "semantic_segmentation_json",
+}
+_DIFFUSION_SAMPLE_INPUT_FIELDS = frozenset(
+    {
+        "action",
+        "camera_intrinsics",
+        "camera_intrinsics_file",
+        "image",
+        "image_path",
+        "prompt_file",
+        "rotation_speed_deg",
+        "translation_speed",
+    }
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    with path.open(encoding="utf-8") as input_file:
+        for line_number, line in enumerate(input_file, start=1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if not isinstance(row, dict):
+                raise ValueError(f"{path}:{line_number} must contain a JSON object")
+            rows.append(row)
+    return rows
+
+
+def _selected_rows(
+    rows: Sequence[Mapping[str, Any]],
+    sample_id: str,
+) -> list[tuple[int, dict[str, Any]]]:
+    selected = [
+        (index, dict(row))
+        for index, row in enumerate(rows)
+        if not sample_id or str(row.get("sample_id", "")) == sample_id
+    ]
+    if sample_id and not selected:
+        raise ValueError(f"sample_id {sample_id!r} is not present in the prepared prompts")
+    return selected
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _entrypoint_sha256() -> str:
+    return _sha256_file(Path(__file__))
+
+
+def _write_reproduction_metadata(arguments: argparse.Namespace) -> None:
+    if arguments.repro_metadata is None:
+        return
+    arguments.repro_metadata.write_text(
+        json.dumps(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "backend": "model_reference_plugin",
+                "entrypoint": str(Path(__file__).resolve()),
+                "entrypoint_sha256": _entrypoint_sha256(),
+                "command_source": "hf_native_commands.jsonl",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _command_tokens(value: Any) -> list[str]:
+    if isinstance(value, (list, tuple)) and value and all(
+        isinstance(token, (str, int, float, Path)) for token in value
+    ):
+        return [str(token) for token in value]
+    if isinstance(value, str):
+        tokens = shlex.split(value)
+        if len(tokens) > 1:
+            return tokens
+    return []
+
+
+def _native_command_from_metadata(metadata: Any) -> list[str]:
+    if not isinstance(metadata, Mapping):
+        return []
+    command = _command_tokens(metadata.get("command"))
+    if command:
+        return command
+    for value in metadata.values():
+        nested = _native_command_from_metadata(value)
+        if nested:
+            return nested
+    return []
+
+
+def _record_native_command(path: Path, sample_id: str, output: Any) -> None:
+    metadata = getattr(output, "metadata", {})
+    command = _native_command_from_metadata(metadata)
+    if not command:
+        return
+    with path.open("a", encoding="utf-8") as command_file:
+        command_file.write(
+            json.dumps(
+                {"sample_id": sample_id, "command": command},
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+
+
+def _model_manifest_path(manifest: Mapping[str, Any]) -> Path:
+    task_config = manifest.get("task_eval", {})
+    task_config = task_config if isinstance(task_config, dict) else {}
+    manifest_ref = str(task_config.get("model_manifest", "") or "")
+    if not manifest_ref:
+        raise ValueError("reference plugin requires task_eval.model_manifest")
+    manifest_path = Path(manifest_ref)
+    return manifest_path if manifest_path.is_absolute() else REPO_ROOT / manifest_path
+
+
+def _load_reference_plugin(manifest: Mapping[str, Any]) -> tuple[Any, Any]:
+    case = load_manifest(_model_manifest_path(manifest))
+    activate_model_plugins(str(case.metadata.get("model_test_dir", "") or ""))
+    reference = get_reference(case.reference_backend)
+    if reference is None:
+        raise RuntimeError(
+            f"No reference plugin {case.reference_backend!r} for {case.family}"
+        )
+    return case, reference
+
+
+def _stage(case: Any, name: str) -> Any:
+    for stage in case.stages:
+        if stage.name == name:
+            return stage
+    return StageSpec(name=name, required=True)
+
+
+def _context(case: Any, artifacts_dir: Path) -> RunContext:
+    return RunContext(
+        case=case,
+        artifacts_dir=str(artifacts_dir),
+        hf_python=sys.executable,
+        reference_python=sys.executable,
+    )
+
+
+def _time_series_case(
+    template: Any,
+    prompt_row: Mapping[str, Any],
+    index: int,
+) -> Any:
+    case = copy.deepcopy(template)
+    case.name = str(prompt_row.get("sample_id", f"time_series_{index:06d}"))
+    inputs = prompt_row.get("inputs")
+    if not isinstance(inputs, dict) or not inputs:
+        raise ValueError(f"Time-series sample {case.name!r} has no numeric inputs")
+    case.inputs = copy.deepcopy(inputs)
+    return case
+
+
+def _time_series_values(data: Mapping[str, Any], sample_id: str) -> list[float]:
+    error = str(data.get("error", "") or "")
+    values = data.get("output_field", data.get("field"))
+    if error:
+        raise RuntimeError(f"HF time-series inference failed for {sample_id}: {error}")
+    if not isinstance(values, list) or not values:
+        raise RuntimeError(
+            f"HF time-series inference produced no output tensor for {sample_id}"
+        )
+    return [float(value) for value in values]
+
+
+def _time_series_shape(
+    data: Mapping[str, Any],
+    output_values: Sequence[float],
+) -> list[int]:
+    output_shape = data.get("output_shape")
+    if not isinstance(output_shape, list):
+        output_shape = [int(data.get("output_dim", len(output_values)))]
+    return [int(dim) for dim in output_shape]
+
+
+def _time_series_response(case: Any, output: Any) -> dict[str, Any]:
+    data = output.data if isinstance(output.data, dict) else {}
+    metadata = output.metadata if isinstance(output.metadata, dict) else {}
+    output_values = _time_series_values(data, case.name)
+    return {
+        "sample_id": case.name,
+        "source": "hf",
+        "output_values": output_values,
+        "output_shape": _time_series_shape(data, output_values),
+        "output_name": str(data.get("reference_output_name", "") or ""),
+        "returncode": int(metadata.get("returncode", 0) or 0),
+        "wall_ms": float(output.timing_s) * 1000.0,
+    }
+
+
+def _run_time_series(
+    template: Any,
+    reference: Any,
+    rows: Sequence[tuple[int, dict[str, Any]]],
+    artifacts_dir: Path,
+    command_path: Path,
+) -> list[dict[str, Any]]:
+    responses = []
+    for run_index, (source_index, prompt_row) in enumerate(rows):
+        case = _time_series_case(template, prompt_row, source_index)
+        output = reference.run_stage(
+            case,
+            _stage(case, "full_inference"),
+            _context(case, artifacts_dir),
+        )
+        _record_native_command(command_path, case.name, output)
+        responses.append(_time_series_response(case, output))
+        print(
+            f"[reference.plugin.time_series] sample={run_index + 1}/{len(rows)}",
+            file=sys.stderr,
+        )
+    return responses
+
+
+def _vision_case(
+    template: Any,
+    prompt_row: Mapping[str, Any],
+    task_config: Mapping[str, Any],
+    index: int,
+) -> Any:
+    case = copy.deepcopy(template)
+    case.name = str(prompt_row.get("sample_id", f"vision_{index:06d}"))
+    case.inputs["image"] = str(prompt_row["image"])
+    prompt_mode = str(task_config.get("prompt_mode", "") or "")
+    if prompt_mode == "point":
+        case.inputs["point_x"] = float(prompt_row["point_x"])
+        case.inputs["point_y"] = float(prompt_row["point_y"])
+        case.inputs["is_foreground"] = True
+    elif prompt_mode == "text":
+        text_prompt = str(prompt_row["text_prompt"])
+        case.inputs["prompt"] = text_prompt
+        case.inputs["text_prompt"] = text_prompt
+    return case
+
+
+def _persist_numpy_output(value: Any, path: Path) -> str:
+    import numpy as np
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.save(path, np.asarray(value))
+    return str(path)
+
+
+def _classification_fields(data: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "top_class": int(data["top_class"]),
+        "top_score": float(data.get("top_score", 0.0)),
+        "num_classes": int(data.get("num_classes", 0)),
+    }
+
+
+def _semantic_class_map_path(
+    data: Mapping[str, Any],
+    artifact_dir: Path,
+    sample_id: str,
+) -> str:
+    class_map_path = str(
+        data.get("class_map_path")
+        or data.get("segmentation_map_path")
+        or data.get("output_path")
+        or ""
+    )
+    if not class_map_path and data.get("class_map") is not None:
+        class_map_path = _persist_numpy_output(
+            data["class_map"],
+            artifact_dir / sample_id / "hf_class_map.npy",
+        )
+    if not class_map_path or not Path(class_map_path).is_file():
+        raise RuntimeError("HF semantic segmentation produced no class map")
+    return class_map_path
+
+
+def _semantic_raw_class_map(data: Mapping[str, Any]) -> str:
+    raw_class_map_path = str(data.get("raw_class_map_path") or "")
+    if raw_class_map_path and not Path(raw_class_map_path).is_file():
+        raise RuntimeError(
+            "HF semantic segmentation raw class map does not exist: "
+            f"{raw_class_map_path}"
+        )
+    return raw_class_map_path
+
+
+def _semantic_segmentation_fields(
+    data: Mapping[str, Any],
+    artifact_dir: Path,
+    sample_id: str,
+) -> dict[str, Any]:
+    fields = {
+        "class_map_path": _semantic_class_map_path(
+            data,
+            artifact_dir,
+            sample_id,
+        ),
+        "visualization_path": str(
+            data.get("viz_path") or data.get("output_path") or ""
+        ),
+    }
+    raw_class_map_path = _semantic_raw_class_map(data)
+    if raw_class_map_path:
+        fields["raw_class_map_path"] = raw_class_map_path
+    return fields
+
+
+def _prompted_masks_path(
+    data: Mapping[str, Any],
+    artifact_dir: Path,
+    sample_id: str,
+) -> str:
+    masks_path = str(data.get("masks_path", "") or "")
+    if not masks_path and data.get("masks") is not None:
+        masks_path = _persist_numpy_output(
+            data["masks"],
+            artifact_dir / sample_id / "hf_masks.npy",
+        )
+    if not masks_path or not Path(masks_path).is_file():
+        raise RuntimeError("HF prompted segmentation produced no masks")
+    return masks_path
+
+
+def _prompted_segmentation_fields(
+    data: Mapping[str, Any],
+    artifact_dir: Path,
+    prompt_row: Mapping[str, Any],
+    sample_id: str,
+) -> dict[str, Any]:
+    scores = (
+        data.get("mask_scores")
+        or data.get("iou_scores")
+        or data.get("scores")
+        or []
+    )
+    return {
+        "masks_path": _prompted_masks_path(data, artifact_dir, sample_id),
+        "mask_scores": [float(value) for value in scores],
+        "num_masks": int(data.get("num_masks", 0)),
+        "point_x": prompt_row.get("point_x"),
+        "point_y": prompt_row.get("point_y"),
+        "text_prompt": str(prompt_row.get("text_prompt", "")),
+        "segmented_image_path": str(data.get("segmented_image_path", "") or ""),
+    }
+
+
+def _vision_response(
+    case: Any,
+    output: Any,
+    dataset_kind: str,
+    prompt_row: Mapping[str, Any],
+    artifact_dir: Path,
+) -> dict[str, Any]:
+    data = output.data if isinstance(output.data, dict) else {}
+    metadata = output.metadata if isinstance(output.metadata, dict) else {}
+    response = {
+        "sample_id": case.name,
+        "source": "hf",
+        "returncode": int(data.get("returncode", metadata.get("returncode", 0))),
+        "image": str(prompt_row["image"]),
+        "wall_ms": float(output.timing_s) * 1000.0,
+    }
+    if dataset_kind == "image_classification_json":
+        response.update(_classification_fields(data))
+    elif dataset_kind == "semantic_segmentation_json":
+        response.update(
+            _semantic_segmentation_fields(data, artifact_dir, case.name)
+        )
+    elif dataset_kind == "prompted_segmentation_json":
+        response.update(
+            _prompted_segmentation_fields(
+                data,
+                artifact_dir,
+                prompt_row,
+                case.name,
+            )
+        )
+    else:
+        raise ValueError(f"Unsupported vision dataset kind {dataset_kind!r}")
+    return response
+
+
+def _run_vision(
+    template: Any,
+    reference: Any,
+    rows: Sequence[tuple[int, dict[str, Any]]],
+    artifacts_dir: Path,
+    manifest: Mapping[str, Any],
+    command_path: Path,
+) -> list[dict[str, Any]]:
+    task_config = manifest.get("task_eval", {})
+    task_config = task_config if isinstance(task_config, dict) else {}
+    dataset_kind = str(manifest.get("dataset_kind", "") or "")
+    responses = []
+    for run_index, (source_index, prompt_row) in enumerate(rows):
+        case = _vision_case(template, prompt_row, task_config, source_index)
+        output = reference.run_stage(
+            case,
+            _stage(case, "full_inference"),
+            _context(case, artifacts_dir),
+        )
+        _record_native_command(command_path, case.name, output)
+        responses.append(
+            _vision_response(
+                case,
+                output,
+                dataset_kind,
+                prompt_row,
+                artifacts_dir,
+            )
+        )
+        print(
+            f"[reference.plugin.vision] sample={run_index + 1}/{len(rows)}",
+            file=sys.stderr,
+        )
+    return responses
+
+
+def _reranking_case(
+    template: Any,
+    prompt_row: Mapping[str, Any],
+    index: int,
+) -> Any:
+    case = copy.deepcopy(template)
+    case.name = str(prompt_row.get("sample_id", f"reranking_{index:06d}"))
+    case.inputs["prompt"] = str(prompt_row["query"])
+    case.inputs["documents"] = [
+        str(document) for document in prompt_row["documents"]
+    ]
+    return case
+
+
+def _reranking_response(
+    case: Any,
+    output: Any,
+    prompt_row: Mapping[str, Any],
+) -> dict[str, Any]:
+    data = output.data if isinstance(output.data, dict) else {}
+    scores = data.get("scores")
+    documents = prompt_row["documents"]
+    if not isinstance(scores, list) or len(scores) != len(documents):
+        raise RuntimeError(
+            f"HF reranking produced "
+            f"{len(scores) if isinstance(scores, list) else 0} "
+            f"scores for {len(documents)} documents"
+        )
+    return {
+        "sample_id": case.name,
+        "source": "hf",
+        "query": str(prompt_row["query"]),
+        "documents": [str(document) for document in documents],
+        "scores": [float(score) for score in scores],
+        "wall_ms": float(output.timing_s) * 1000.0,
+    }
+
+
+def _run_reranking(
+    template: Any,
+    reference: Any,
+    rows: Sequence[tuple[int, dict[str, Any]]],
+    artifacts_dir: Path,
+    command_path: Path,
+) -> list[dict[str, Any]]:
+    responses = []
+    for run_index, (source_index, prompt_row) in enumerate(rows):
+        case = _reranking_case(template, prompt_row, source_index)
+        output = reference.run_stage(
+            case,
+            _stage(case, "full_inference"),
+            _context(case, artifacts_dir),
+        )
+        _record_native_command(command_path, case.name, output)
+        responses.append(_reranking_response(case, output, prompt_row))
+        print(
+            f"[reference.plugin.reranking] sample={run_index + 1}/{len(rows)}",
+            file=sys.stderr,
+        )
+    return responses
+
+
+def _diffusion_case(
+    template: Any,
+    prompt_row: Mapping[str, Any],
+    generation: Mapping[str, Any],
+    index: int,
+) -> Any:
+    case = copy.deepcopy(template)
+    case.name = str(prompt_row.get("sample_id", f"diffusion_{index:06d}"))
+    case.inputs.update(generation)
+    case.inputs["prompt"] = str(prompt_row["prompt"])
+    for field in _DIFFUSION_SAMPLE_INPUT_FIELDS:
+        if field in prompt_row:
+            case.inputs[field] = copy.deepcopy(prompt_row[field])
+    seed = int(generation.get("seed", case.determinism.get("seed", 42)))
+    case.inputs["seed"] = seed + index
+    return case
+
+
+def _diffusion_response(case: Any, output: Any, prompt: str) -> dict[str, Any]:
+    data = output.data if isinstance(output.data, dict) else {}
+    image_value = str(
+        case.inputs.get("image") or case.inputs.get("image_path") or ""
+    )
+    response = {
+        "sample_id": case.name,
+        "source": "hf",
+        "returncode": int(data.get("returncode", 1)),
+        "num_frames": int(data.get("num_frames", 0)),
+        "frames_dir": str(data.get("frames_dir", "")),
+        "frame_stats": data.get("frame_stats", {}),
+        "prompt": prompt,
+        "initial_latents_sha256": str(data.get("initial_latents_sha256", "")),
+        "wall_ms": float(output.timing_s) * 1000.0,
+        "seed": int(case.inputs.get("seed", case.determinism.get("seed", 42))),
+        "action": str(case.inputs.get("action", "")),
+        "condition_image": image_value,
+    }
+    image_path = Path(image_value) if image_value else None
+    if image_path is not None and image_path.is_file():
+        response["condition_image_sha256"] = _sha256_file(image_path)
+    if response["returncode"] != 0 or response["num_frames"] < 1:
+        raise RuntimeError(
+            f"HF diffusion reference failed for {case.name}: "
+            f"returncode={response['returncode']} frames={response['num_frames']}"
+        )
+    return response
+
+
+def _run_diffusion(
+    template: Any,
+    reference: Any,
+    rows: Sequence[tuple[int, dict[str, Any]]],
+    artifacts_dir: Path,
+    manifest: Mapping[str, Any],
+    command_path: Path,
+) -> list[dict[str, Any]]:
+    generation = manifest.get("generation", {})
+    generation = generation if isinstance(generation, dict) else {}
+    responses = []
+    for run_index, (source_index, prompt_row) in enumerate(rows):
+        case = _diffusion_case(template, prompt_row, generation, source_index)
+        output = reference.run_stage(
+            case,
+            _stage(case, "end_to_end"),
+            _context(case, artifacts_dir),
+        )
+        _record_native_command(command_path, case.name, output)
+        responses.append(
+            _diffusion_response(case, output, str(prompt_row["prompt"]))
+        )
+        print(
+            f"[reference.plugin.diffusion] sample={run_index + 1}/{len(rows)}",
+            file=sys.stderr,
+        )
+    return responses
+
+
+def _run_dataset_kind(
+    *,
+    manifest: Mapping[str, Any],
+    template: Any,
+    reference: Any,
+    rows: Sequence[tuple[int, dict[str, Any]]],
+    artifacts_dir: Path,
+    command_path: Path,
+) -> list[dict[str, Any]]:
+    dataset_kind = str(manifest.get("dataset_kind", "") or "")
+    if dataset_kind == "time_series_csv":
+        return _run_time_series(
+            template,
+            reference,
+            rows,
+            artifacts_dir,
+            command_path,
+        )
+    if dataset_kind in _VISION_DATASET_KINDS:
+        return _run_vision(
+            template,
+            reference,
+            rows,
+            artifacts_dir,
+            manifest,
+            command_path,
+        )
+    if dataset_kind == "reranking_json":
+        return _run_reranking(
+            template,
+            reference,
+            rows,
+            artifacts_dir,
+            command_path,
+        )
+    if dataset_kind == "diffusion_prompt_json":
+        return _run_diffusion(
+            template,
+            reference,
+            rows,
+            artifacts_dir,
+            manifest,
+            command_path,
+        )
+    raise ValueError(f"Unsupported reference plugin dataset kind {dataset_kind!r}")
+
+
+def run(arguments: argparse.Namespace) -> None:
+    manifest = _load_json(arguments.manifest)
+    rows = _selected_rows(
+        _load_jsonl(arguments.prompts),
+        arguments.sample_id,
+    )
+    template, reference = _load_reference_plugin(manifest)
+    artifacts_dir = arguments.predictions.parent / "hf_artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    command_path = arguments.predictions.parent / "hf_native_commands.jsonl"
+    command_path.write_text("", encoding="utf-8")
+    responses = _run_dataset_kind(
+        manifest=manifest,
+        template=template,
+        reference=reference,
+        rows=rows,
+        artifacts_dir=artifacts_dir,
+        command_path=command_path,
+    )
+    arguments.raw_output.parent.mkdir(parents=True, exist_ok=True)
+    with arguments.raw_output.open("w", encoding="utf-8") as raw_file:
+        for response in responses:
+            raw_file.write(json.dumps(response, ensure_ascii=False) + "\n")
+    arguments.predictions.write_text(
+        json.dumps({"responses": responses}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    _write_reproduction_metadata(arguments)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a model-owned reference plugin directly."
+    )
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--reference-family", default="")
+    parser.add_argument("--prompts", type=Path, required=True)
+    parser.add_argument("--answers", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--predictions", type=Path, required=True)
+    parser.add_argument("--raw-output", type=Path, required=True)
+    parser.add_argument("--repro-metadata", type=Path)
+    parser.add_argument("--sample-id", default="")
+    parser.add_argument(
+        "--dtype",
+        choices=("auto", "float16", "bfloat16"),
+        default="auto",
+    )
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--device-map", default="")
+    parser.add_argument("--attn-impl", default="")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--local-files-only", action="store_true")
+    parser.add_argument("--do-sample", action="store_true")
+    parser.add_argument("--apply-chat-template", action="store_true")
+    parser.add_argument("--max-new-tokens", type=int)
+    parser.add_argument("--temperature", type=float)
+    parser.add_argument("--top-k", type=int)
+    parser.add_argument("--top-p", type=float)
+    parser.add_argument("--seed", type=int)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    run(build_parser().parse_args(argv))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/reference/plugin_reference.py
+++ b/tools/reference/plugin_reference.py
@@ -162,12 +162,15 @@ def _run_reference_stage(
     run_stage = reference.run_stage
     function = getattr(run_stage, "__func__", run_stage)
     namespace = getattr(function, "__globals__", {})
-    original = namespace.get("run_reference_subprocess")
-    if not callable(original):
+    helper = namespace.get("run_reference_subprocess")
+    subprocess_module = namespace.get("subprocess")
+    direct_run = getattr(subprocess_module, "run", None)
+    if not callable(helper) and not callable(direct_run):
         return run_stage(case, stage, context)
+    captured_commands: list[list[str]] = []
 
     def run_and_record(*args: Any, **kwargs: Any) -> Any:
-        output = original(*args, **kwargs)
+        output = helper(*args, **kwargs)
         command = _command_tokens(kwargs.get("command"))
         metadata = getattr(output, "metadata", {})
         if command and not _native_command_from_metadata(metadata):
@@ -177,11 +180,31 @@ def _run_reference_stage(
             }
         return output
 
-    namespace["run_reference_subprocess"] = run_and_record
+    def capture_direct_run(*args: Any, **kwargs: Any) -> Any:
+        command_value = args[0] if args else kwargs.get("args")
+        command = _command_tokens(command_value)
+        if command:
+            captured_commands.append(command)
+        return direct_run(*args, **kwargs)
+
+    if callable(helper):
+        namespace["run_reference_subprocess"] = run_and_record
+    if callable(direct_run):
+        subprocess_module.run = capture_direct_run
     try:
-        return run_stage(case, stage, context)
+        output = run_stage(case, stage, context)
     finally:
-        namespace["run_reference_subprocess"] = original
+        if callable(helper):
+            namespace["run_reference_subprocess"] = helper
+        if callable(direct_run):
+            subprocess_module.run = direct_run
+    metadata = getattr(output, "metadata", {})
+    if captured_commands and not _native_command_from_metadata(metadata):
+        output.metadata = {
+            **(metadata if isinstance(metadata, dict) else {}),
+            "command": captured_commands[-1],
+        }
+    return output
 
 
 def _model_manifest_path(manifest: Mapping[str, Any]) -> Path:

--- a/tools/reference/plugin_reference.py
+++ b/tools/reference/plugin_reference.py
@@ -152,6 +152,38 @@ def _record_native_command(path: Path, sample_id: str, output: Any) -> None:
         )
 
 
+def _run_reference_stage(
+    reference: Any,
+    case: Any,
+    stage: Any,
+    context: RunContext,
+) -> Any:
+    """Run a model reference while preserving its direct subprocess command."""
+    run_stage = reference.run_stage
+    function = getattr(run_stage, "__func__", run_stage)
+    namespace = getattr(function, "__globals__", {})
+    original = namespace.get("run_reference_subprocess")
+    if not callable(original):
+        return run_stage(case, stage, context)
+
+    def run_and_record(*args: Any, **kwargs: Any) -> Any:
+        output = original(*args, **kwargs)
+        command = _command_tokens(kwargs.get("command"))
+        metadata = getattr(output, "metadata", {})
+        if command and not _native_command_from_metadata(metadata):
+            output.metadata = {
+                **(metadata if isinstance(metadata, dict) else {}),
+                "command": command,
+            }
+        return output
+
+    namespace["run_reference_subprocess"] = run_and_record
+    try:
+        return run_stage(case, stage, context)
+    finally:
+        namespace["run_reference_subprocess"] = original
+
+
 def _model_manifest_path(manifest: Mapping[str, Any]) -> Path:
     task_config = manifest.get("task_eval", {})
     task_config = task_config if isinstance(task_config, dict) else {}
@@ -250,7 +282,8 @@ def _run_time_series(
     responses = []
     for run_index, (source_index, prompt_row) in enumerate(rows):
         case = _time_series_case(template, prompt_row, source_index)
-        output = reference.run_stage(
+        output = _run_reference_stage(
+            reference,
             case,
             _stage(case, "full_inference"),
             _context(case, artifacts_dir),
@@ -442,7 +475,8 @@ def _run_vision(
     responses = []
     for run_index, (source_index, prompt_row) in enumerate(rows):
         case = _vision_case(template, prompt_row, task_config, source_index)
-        output = reference.run_stage(
+        output = _run_reference_stage(
+            reference,
             case,
             _stage(case, "full_inference"),
             _context(case, artifacts_dir),
@@ -512,7 +546,8 @@ def _run_reranking(
     responses = []
     for run_index, (source_index, prompt_row) in enumerate(rows):
         case = _reranking_case(template, prompt_row, source_index)
-        output = reference.run_stage(
+        output = _run_reference_stage(
+            reference,
             case,
             _stage(case, "full_inference"),
             _context(case, artifacts_dir),
@@ -587,7 +622,8 @@ def _run_diffusion(
     responses = []
     for run_index, (source_index, prompt_row) in enumerate(rows):
         case = _diffusion_case(template, prompt_row, generation, source_index)
-        output = reference.run_stage(
+        output = _run_reference_stage(
+            reference,
             case,
             _stage(case, "end_to_end"),
             _context(case, artifacts_dir),

--- a/tools/reference/speech.py
+++ b/tools/reference/speech.py
@@ -542,20 +542,31 @@ def _transcribe_tts(
     model_id: str,
 ) -> list[str]:
     import torch
-    from transformers import pipeline
+    from transformers import (
+        AutoModelForSpeechSeq2Seq,
+        AutoProcessor,
+        pipeline,
+    )
 
     device = (
         0
         if arguments.device.startswith("cuda") and torch.cuda.is_available()
         else -1
     )
+    model = AutoModelForSpeechSeq2Seq.from_pretrained(
+        model_id,
+        local_files_only=arguments.local_files_only,
+    )
+    processor = AutoProcessor.from_pretrained(
+        model_id,
+        local_files_only=arguments.local_files_only,
+    )
     transcriber = pipeline(
         "automatic-speech-recognition",
-        model=model_id,
+        model=model,
+        tokenizer=processor.tokenizer,
+        feature_extractor=processor.feature_extractor,
         device=device,
-        model_kwargs={"local_files_only": True}
-        if arguments.local_files_only
-        else {},
     )
     target_rate = int(transcriber.feature_extractor.sampling_rate)
     waveforms = []

--- a/tools/reference/speech.py
+++ b/tools/reference/speech.py
@@ -1,0 +1,763 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run ASR and TTS references directly through their upstream runtimes."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import math
+from pathlib import Path
+import random
+import re
+import struct
+import sys
+import time
+from typing import Any, Mapping, Sequence
+import wave
+
+
+SCHEMA_VERSION = "trtmc.native-reference-reproduction/v1"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if not isinstance(row, dict):
+            raise ValueError(f"{path}:{line_number} must contain a JSON object")
+        rows.append(row)
+    return rows
+
+
+def _selected_rows(
+    rows: Sequence[Mapping[str, Any]],
+    sample_id: str,
+) -> list[dict[str, Any]]:
+    selected = [
+        dict(row)
+        for row in rows
+        if not sample_id or str(row.get("sample_id", "")) == sample_id
+    ]
+    if sample_id and not selected:
+        raise ValueError(f"sample_id {sample_id!r} is not present in the prepared prompts")
+    return selected
+
+
+def _generation(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
+    value = manifest.get("generation", {})
+    return value if isinstance(value, Mapping) else {}
+
+
+def _scoring(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
+    value = manifest.get("scoring", {})
+    return value if isinstance(value, Mapping) else {}
+
+
+def _model_dtype(torch_module: Any, name: str) -> str | Any:
+    if name == "float16":
+        return torch_module.float16
+    if name == "bfloat16":
+        return torch_module.bfloat16
+    return "auto"
+
+
+def _safe_sample_filename(sample_id: str, suffix: str) -> str:
+    stem = re.sub(r"[^A-Za-z0-9_.-]+", "_", sample_id).strip("._")
+    return f"{stem or 'sample'}{suffix}"
+
+
+def _to_device(batch: Any, device: Any) -> Any:
+    if hasattr(batch, "to"):
+        return batch.to(device)
+    return {
+        key: value.to(device) if hasattr(value, "to") else value
+        for key, value in batch.items()
+    }
+
+
+def _read_wav_float32(path: str) -> tuple[Any, int]:
+    import numpy as np
+
+    with wave.open(path, "rb") as wav_file:
+        channels = wav_file.getnchannels()
+        sample_width = wav_file.getsampwidth()
+        sample_rate = wav_file.getframerate()
+        frames = wav_file.readframes(wav_file.getnframes())
+    dtype_scale = {
+        1: (np.uint8, 128.0),
+        2: ("<i2", 32768.0),
+        4: ("<i4", 2147483648.0),
+    }
+    if sample_width not in dtype_scale:
+        raise RuntimeError(f"Unsupported WAV sample width {sample_width} bytes for {path}")
+    dtype, scale = dtype_scale[sample_width]
+    audio = np.frombuffer(frames, dtype=dtype).astype(np.float32)
+    audio = (audio - 128.0) / scale if sample_width == 1 else audio / scale
+    if channels > 1:
+        audio = audio.reshape(-1, channels).mean(axis=1)
+    return audio, sample_rate
+
+
+def _resample_audio(audio: Any, source_rate: int, target_rate: int) -> Any:
+    if source_rate == target_rate or len(audio) == 0:
+        return audio
+    import numpy as np
+
+    target_length = max(1, int(len(audio) * target_rate / source_rate))
+    source_x = np.arange(len(audio), dtype=np.float32)
+    target_x = np.linspace(0, len(audio) - 1, target_length, dtype=np.float32)
+    return np.interp(target_x, source_x, audio).astype(np.float32)
+
+
+def _write_wav_pcm16(path: Path, audio: Any, sample_rate: int) -> None:
+    import numpy as np
+
+    samples = np.asarray(audio, dtype=np.float32)
+    if samples.ndim > 1:
+        samples = samples.mean(axis=1)
+    peak = float(np.max(np.abs(samples))) if samples.size else 0.0
+    if peak > 1.0:
+        samples = samples / peak
+    pcm = np.clip(samples * 32767.0, -32768, 32767).astype("<i2")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(pcm.tobytes())
+
+
+def _wav_metrics(path: Path) -> dict[str, Any]:
+    with wave.open(str(path), "rb") as wav_file:
+        sample_rate = wav_file.getframerate()
+        channels = wav_file.getnchannels()
+        frame_count = wav_file.getnframes()
+        sample_width = wav_file.getsampwidth()
+        frames = wav_file.readframes(frame_count)
+    rms = 0.0
+    if frames and sample_width == 2:
+        count = len(frames) // 2
+        samples = struct.unpack(f"<{count}h", frames)
+        rms = math.sqrt(
+            sum((float(value) / 32768.0) ** 2 for value in samples) / count
+        )
+    return {
+        "sample_rate": sample_rate,
+        "channels": channels,
+        "duration_s": frame_count / sample_rate if sample_rate else 0.0,
+        "rms": rms,
+    }
+
+
+def _write_predictions(
+    arguments: argparse.Namespace,
+    responses: Sequence[Mapping[str, Any]],
+) -> None:
+    arguments.predictions.parent.mkdir(parents=True, exist_ok=True)
+    arguments.predictions.write_text(
+        json.dumps({"responses": list(responses)}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    with arguments.raw_output.open("w", encoding="utf-8") as raw_file:
+        for row in responses:
+            raw_file.write(json.dumps(dict(row), ensure_ascii=False) + "\n")
+
+
+def _is_nemo_asr(arguments: argparse.Namespace) -> bool:
+    values = (
+        arguments.reference_family.lower(),
+        arguments.family.lower(),
+        arguments.model.lower(),
+    )
+    return (
+        values[0] in {"asr_canary", "asr_nemo"}
+        or values[1] in {"canary", "nemotron_speech_streaming"}
+        or "canary" in values[2]
+        or "nemotron-speech-streaming" in values[2]
+    )
+
+
+def _transcription_text(value: Any) -> str:
+    if isinstance(value, list):
+        value = value[0] if value else ""
+    if hasattr(value, "text"):
+        return str(value.text)
+    if isinstance(value, Mapping):
+        return str(value.get("text", ""))
+    return str(value)
+
+
+def _asr_row(
+    prompt: Mapping[str, Any],
+    output_text: str,
+    wall_ms: float,
+    token_ids: Sequence[int] | None = None,
+) -> dict[str, Any]:
+    tokens = None if token_ids is None else [int(value) for value in token_ids]
+    return {
+        "sample_id": str(prompt.get("sample_id", "")),
+        "output_text": output_text,
+        "generated_tokens": None if tokens is None else len(tokens),
+        "generated_token_ids": tokens,
+        "wall_ms": wall_ms,
+        "source": "hf",
+    }
+
+
+def _audio_for_prompt(
+    prompt: Mapping[str, Any],
+    target_rate: int,
+) -> tuple[Any, Path]:
+    audio_path = str(prompt.get("audio", ""))
+    if not audio_path:
+        raise ValueError(
+            f"ASR reference expects an audio path for {prompt.get('sample_id', '')}"
+        )
+    audio, source_rate = _read_wav_float32(audio_path)
+    return _resample_audio(audio, source_rate, target_rate), Path(audio_path)
+
+
+def _load_whisper_runtime(
+    arguments: argparse.Namespace,
+) -> tuple[Any, Any, Any, Any]:
+    import torch
+    from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, logging
+
+    logging.set_verbosity_error()
+    processor = AutoProcessor.from_pretrained(
+        arguments.model,
+        trust_remote_code=arguments.trust_remote_code,
+        local_files_only=arguments.local_files_only,
+    )
+    model_kwargs = {
+        "torch_dtype": _model_dtype(torch, arguments.dtype),
+        "trust_remote_code": arguments.trust_remote_code,
+        "local_files_only": arguments.local_files_only,
+    }
+    if arguments.device_map:
+        model_kwargs["device_map"] = arguments.device_map
+    if arguments.attn_impl:
+        model_kwargs["attn_implementation"] = arguments.attn_impl
+    model = AutoModelForSpeechSeq2Seq.from_pretrained(
+        arguments.model,
+        **model_kwargs,
+    ).eval()
+    device = model.device if arguments.device_map else torch.device(arguments.device)
+    if not arguments.device_map:
+        model.to(device)
+    return torch, processor, model, device
+
+
+def _whisper_inputs(
+    processor: Any,
+    audio: Any,
+    target_rate: int,
+    device: Any,
+    model_dtype: Any,
+) -> dict[str, Any]:
+    inputs = processor(audio, sampling_rate=target_rate, return_tensors="pt")
+    return {
+        key: (
+            value.to(device=device, dtype=model_dtype)
+            if hasattr(value, "is_floating_point") and value.is_floating_point()
+            else value.to(device)
+            if hasattr(value, "to")
+            else value
+        )
+        for key, value in inputs.items()
+    }
+
+
+def _seed_torch(torch: Any, seed: int) -> None:
+    if seed < 0:
+        return
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def _run_whisper_asr(
+    arguments: argparse.Namespace,
+    prompts: Sequence[Mapping[str, Any]],
+    generation: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    torch, processor, model, device = _load_whisper_runtime(arguments)
+    model_dtype = next(model.parameters()).dtype
+    target_rate = int(getattr(processor.feature_extractor, "sampling_rate", 16000))
+    max_new_tokens = arguments.max_new_tokens or int(
+        generation.get("max_new_tokens", 100)
+    )
+    seed = arguments.seed
+    if seed is None:
+        seed = int(generation.get("seed", -1))
+    responses = []
+    for prompt in prompts:
+        audio, _source = _audio_for_prompt(prompt, target_rate)
+        eval_index = int(prompt.get("eval_index", 0))
+        _seed_torch(torch, seed + eval_index if seed >= 0 else -1)
+        started = time.perf_counter()
+        with torch.inference_mode():
+            output_ids = model.generate(
+                **_whisper_inputs(
+                    processor,
+                    audio,
+                    target_rate,
+                    device,
+                    model_dtype,
+                ),
+                max_new_tokens=max_new_tokens,
+            )
+        responses.append(
+            _asr_row(
+                prompt,
+                processor.batch_decode(output_ids, skip_special_tokens=True)[0],
+                (time.perf_counter() - started) * 1000.0,
+                output_ids[0].tolist(),
+            )
+        )
+    del model
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return responses
+
+
+def _run_nemotron35_asr(
+    arguments: argparse.Namespace,
+    prompts: Sequence[Mapping[str, Any]],
+    generation: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    import torch
+    from transformers import AutoModel, AutoProcessor
+
+    device = torch.device(arguments.device)
+    common = {
+        "trust_remote_code": arguments.trust_remote_code,
+        "local_files_only": arguments.local_files_only,
+    }
+    processor = AutoProcessor.from_pretrained(arguments.model, **common)
+    model = AutoModel.from_pretrained(
+        arguments.model,
+        torch_dtype=_model_dtype(torch, arguments.dtype),
+        **common,
+    ).eval().to(device)
+    target_rate = int(generation.get("sample_rate", 16000) or 16000)
+    max_new_tokens = arguments.max_new_tokens or int(
+        generation.get("max_new_tokens", 256)
+    )
+    output_dir = arguments.predictions.parent / "hf_canary_audio"
+    responses = []
+    for prompt in prompts:
+        audio, _source = _audio_for_prompt(prompt, target_rate)
+        wav_path = output_dir / _safe_sample_filename(
+            str(prompt.get("sample_id", "")),
+            ".wav",
+        )
+        _write_wav_pcm16(wav_path, audio, target_rate)
+        inputs = processor(
+            audio,
+            sampling_rate=target_rate,
+            language=str(prompt.get("language") or generation.get("language", "en-US")),
+            return_tensors="pt",
+        )
+        started = time.perf_counter()
+        with torch.inference_mode():
+            generated = model.generate(
+                **_to_device(inputs, device),
+                max_new_tokens=max_new_tokens,
+            )
+        sequences = generated.sequences if hasattr(generated, "sequences") else generated
+        responses.append(
+            _asr_row(
+                prompt,
+                processor.batch_decode(sequences, skip_special_tokens=True)[0],
+                (time.perf_counter() - started) * 1000.0,
+                sequences[0].detach().cpu().tolist(),
+            )
+        )
+    del model
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return responses
+
+
+def _run_nemo_asr(
+    arguments: argparse.Namespace,
+    prompts: Sequence[Mapping[str, Any]],
+    generation: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    if "nemotron-3.5-asr-streaming" in arguments.model.lower():
+        return _run_nemotron35_asr(arguments, prompts, generation)
+    target_rate = int(generation.get("sample_rate", 16000) or 16000)
+    output_dir = arguments.predictions.parent / "hf_canary_audio"
+    try:
+        import nemo.collections.asr as nemo_asr
+    except ImportError:
+        return _run_pipeline_asr(
+            arguments,
+            prompts,
+            target_rate,
+            output_dir,
+        )
+    model = nemo_asr.models.ASRModel.from_pretrained(
+        arguments.model,
+        map_location=arguments.device,
+    )
+    if arguments.device != "cpu" and hasattr(model, "to"):
+        model = model.to(arguments.device)
+    model.eval()
+    responses = []
+    for prompt in prompts:
+        audio, _source = _audio_for_prompt(prompt, target_rate)
+        wav_path = output_dir / _safe_sample_filename(
+            str(prompt.get("sample_id", "")),
+            ".wav",
+        )
+        _write_wav_pcm16(wav_path, audio, target_rate)
+        started = time.perf_counter()
+        transcription = model.transcribe([str(wav_path)], batch_size=1)
+        responses.append(
+            _asr_row(
+                prompt,
+                _transcription_text(transcription),
+                (time.perf_counter() - started) * 1000.0,
+            )
+        )
+    del model
+    gc.collect()
+    return responses
+
+
+def _run_pipeline_asr(
+    arguments: argparse.Namespace,
+    prompts: Sequence[Mapping[str, Any]],
+    target_rate: int,
+    output_dir: Path,
+) -> list[dict[str, Any]]:
+    import torch
+    from transformers import pipeline
+
+    device = (
+        0
+        if arguments.device.startswith("cuda") and torch.cuda.is_available()
+        else -1
+    )
+    transcriber = pipeline(
+        "automatic-speech-recognition",
+        model=arguments.model,
+        torch_dtype=_model_dtype(torch, arguments.dtype),
+        device=device,
+        trust_remote_code=arguments.trust_remote_code,
+        model_kwargs={"local_files_only": True}
+        if arguments.local_files_only
+        else {},
+    )
+    responses = []
+    for prompt in prompts:
+        audio, _source = _audio_for_prompt(prompt, target_rate)
+        wav_path = output_dir / _safe_sample_filename(
+            str(prompt.get("sample_id", "")),
+            ".wav",
+        )
+        _write_wav_pcm16(wav_path, audio, target_rate)
+        started = time.perf_counter()
+        result = transcriber({"raw": audio, "sampling_rate": target_rate})
+        responses.append(
+            _asr_row(
+                prompt,
+                _transcription_text(result),
+                (time.perf_counter() - started) * 1000.0,
+            )
+        )
+    return responses
+
+
+def _load_tts_runtime(arguments: argparse.Namespace, torch: Any) -> tuple[Any, Any]:
+    if "magpie" in arguments.model.lower():
+        from nemo.collections.tts.models import MagpieTTSModel
+
+        model = MagpieTTSModel.from_pretrained(arguments.model)
+        return None, model.eval().to(torch.device(arguments.device))
+    from transformers import AutoProcessor, BarkModel, logging
+
+    logging.set_verbosity_error()
+    processor = AutoProcessor.from_pretrained(
+        arguments.model,
+        trust_remote_code=arguments.trust_remote_code,
+        local_files_only=arguments.local_files_only,
+    )
+    model = BarkModel.from_pretrained(
+        arguments.model,
+        trust_remote_code=arguments.trust_remote_code,
+        local_files_only=arguments.local_files_only,
+        torch_dtype=_model_dtype(torch, arguments.dtype),
+    )
+    return processor, model.eval().to(torch.device(arguments.device))
+
+
+def _generate_tts_audio(
+    model: Any,
+    processor: Any,
+    prompt: Mapping[str, Any],
+    device: Any,
+) -> tuple[Any, int]:
+    if processor is None:
+        audio_tensor, audio_length = model.do_tts(
+            transcript=str(prompt.get("prompt", "")),
+            language=str(prompt.get("language", "en") or "en"),
+            use_cfg=True,
+        )
+        audio = audio_tensor.detach().cpu().numpy().reshape(-1)
+        length = int(audio_length.item()) if audio_length.numel() else len(audio)
+        return audio[:length], 22050
+    inputs = _to_device(
+        processor(str(prompt.get("prompt", "")), return_tensors="pt"),
+        device,
+    )
+    audio = model.generate(**inputs).detach().cpu().numpy().reshape(-1)
+    return audio, int(model.generation_config.sample_rate)
+
+
+def _transcribe_tts(
+    arguments: argparse.Namespace,
+    wav_paths: Sequence[Path],
+    model_id: str,
+) -> list[str]:
+    import torch
+    from transformers import pipeline
+
+    device = (
+        0
+        if arguments.device.startswith("cuda") and torch.cuda.is_available()
+        else -1
+    )
+    transcriber = pipeline(
+        "automatic-speech-recognition",
+        model=model_id,
+        device=device,
+        model_kwargs={"local_files_only": True}
+        if arguments.local_files_only
+        else {},
+    )
+    target_rate = int(transcriber.feature_extractor.sampling_rate)
+    waveforms = []
+    for path in wav_paths:
+        audio, sample_rate = _read_wav_float32(str(path))
+        waveforms.append(_resample_audio(audio, sample_rate, target_rate))
+    outputs = transcriber(waveforms, batch_size=min(8, len(waveforms)))
+    if isinstance(outputs, Mapping):
+        outputs = [outputs]
+    return [_transcription_text(output).strip() for output in outputs]
+
+
+def _run_tts(
+    arguments: argparse.Namespace,
+    prompts: Sequence[Mapping[str, Any]],
+    manifest: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    import numpy as np
+    import torch
+
+    generation = _generation(manifest)
+    seed = arguments.seed
+    if seed is None:
+        seed = int(generation.get("seed", 42))
+    device = torch.device(arguments.device)
+    processor, model = _load_tts_runtime(arguments, torch)
+    output_dir = arguments.predictions.parent / "hf_audio"
+    responses = []
+    for prompt in prompts:
+        eval_index = int(prompt.get("eval_index", 0))
+        sample_seed = seed + eval_index
+        random.seed(sample_seed)
+        np.random.seed(sample_seed)
+        torch.manual_seed(sample_seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(sample_seed)
+        started = time.perf_counter()
+        with torch.inference_mode():
+            audio, sample_rate = _generate_tts_audio(
+                model,
+                processor,
+                prompt,
+                device,
+            )
+        wav_path = output_dir / _safe_sample_filename(
+            str(prompt.get("sample_id", "")),
+            ".wav",
+        )
+        _write_wav_pcm16(wav_path, audio, sample_rate)
+        metrics = _wav_metrics(wav_path)
+        responses.append(
+            {
+                "sample_id": str(prompt.get("sample_id", "")),
+                "output_text": "",
+                "wav_path": str(wav_path),
+                "wav_exists": True,
+                "rms": metrics["rms"],
+                "duration_s": metrics["duration_s"],
+                "sample_rate": metrics["sample_rate"],
+                "wall_ms": (time.perf_counter() - started) * 1000.0,
+                "source": "hf",
+            }
+        )
+    del model
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    scoring = _scoring(manifest)
+    transcripts = _transcribe_tts(
+        arguments,
+        [Path(row["wav_path"]) for row in responses],
+        str(scoring.get("asr_model", "openai/whisper-large-v3-turbo")),
+    )
+    for row, transcript in zip(responses, transcripts, strict=True):
+        row["output_text"] = transcript
+        row["asr_transcript"] = transcript
+    return responses
+
+
+def _reproduction_command(arguments: argparse.Namespace) -> list[str]:
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--model",
+        arguments.model,
+        "--family",
+        arguments.family,
+        "--reference-family",
+        arguments.reference_family,
+        "--prompts",
+        "{work_dir}/prompts.jsonl",
+        "--answers",
+        "{work_dir}/answers.json",
+        "--manifest",
+        "{work_dir}/manifest.json",
+        "--predictions",
+        "{reference_predictions_json}",
+        "--raw-output",
+        "{reference_raw_jsonl}",
+        "--dtype",
+        arguments.dtype,
+        "--device",
+        arguments.device,
+        "--sample-id",
+        "{sample_id}",
+    ]
+    for flag, value in (
+        ("--device-map", arguments.device_map),
+        ("--attn-impl", arguments.attn_impl),
+        ("--max-new-tokens", arguments.max_new_tokens),
+        ("--seed", arguments.seed),
+    ):
+        if value not in (None, ""):
+            command.extend([flag, str(value)])
+    for enabled, flag in (
+        (arguments.trust_remote_code, "--trust-remote-code"),
+        (arguments.local_files_only, "--local-files-only"),
+    ):
+        if enabled:
+            command.append(flag)
+    return command
+
+
+def _write_reproduction_metadata(arguments: argparse.Namespace) -> None:
+    if arguments.repro_metadata is None:
+        return
+    arguments.repro_metadata.write_text(
+        json.dumps(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "backend": "upstream_speech",
+                "entrypoint": str(Path(__file__).resolve()),
+                "entrypoint_sha256": hashlib.sha256(
+                    Path(__file__).read_bytes()
+                ).hexdigest(),
+                "command": _reproduction_command(arguments),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def run(arguments: argparse.Namespace) -> None:
+    manifest = _load_json(arguments.manifest)
+    prompts = _selected_rows(
+        _load_jsonl(arguments.prompts),
+        arguments.sample_id,
+    )
+    dataset_kind = str(manifest.get("dataset_kind", ""))
+    if dataset_kind == "seedtts_json":
+        responses = _run_tts(arguments, prompts, manifest)
+    elif dataset_kind == "asr_chat_json":
+        generation = _generation(manifest)
+        if _is_nemo_asr(arguments):
+            responses = _run_nemo_asr(arguments, prompts, generation)
+        else:
+            responses = _run_whisper_asr(arguments, prompts, generation)
+    else:
+        raise ValueError(f"unsupported speech dataset kind: {dataset_kind!r}")
+    _write_predictions(arguments, responses)
+    _write_reproduction_metadata(arguments)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run ASR or TTS directly through its upstream runtime."
+    )
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--family", default="")
+    parser.add_argument("--reference-family", default="")
+    parser.add_argument("--prompts", type=Path, required=True)
+    parser.add_argument("--answers", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--predictions", type=Path, required=True)
+    parser.add_argument("--raw-output", type=Path, required=True)
+    parser.add_argument("--repro-metadata", type=Path)
+    parser.add_argument("--sample-id", default="")
+    parser.add_argument(
+        "--dtype",
+        choices=("auto", "float16", "bfloat16"),
+        default="auto",
+    )
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--device-map", default="")
+    parser.add_argument("--attn-impl", default="")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--local-files-only", action="store_true")
+    parser.add_argument("--do-sample", action="store_true")
+    parser.add_argument("--apply-chat-template", action="store_true")
+    parser.add_argument("--max-new-tokens", type=int)
+    parser.add_argument("--temperature", type=float)
+    parser.add_argument("--top-k", type=int)
+    parser.add_argument("--top-p", type=float)
+    parser.add_argument("--seed", type=int)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    run(build_parser().parse_args(argv))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/reference/speech.py
+++ b/tools/reference/speech.py
@@ -22,6 +22,12 @@ import wave
 
 
 SCHEMA_VERSION = "trtmc.native-reference-reproduction/v1"
+MAGPIE_SPEAKER_ENCODER_REPO = "Edresson/Speaker_Encoder_H_ASP"
+MAGPIE_SPEAKER_ENCODER_FILENAME = "pytorch_model.bin"
+MAGPIE_SPEAKER_ENCODER_URL = (
+    "https://huggingface.co/Edresson/Speaker_Encoder_H_ASP/resolve/main/"
+    "pytorch_model.bin"
+)
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -241,11 +247,13 @@ def _load_whisper_runtime(
     from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, logging
 
     logging.set_verbosity_error()
-    processor = AutoProcessor.from_pretrained(
-        arguments.model,
-        trust_remote_code=arguments.trust_remote_code,
-        local_files_only=arguments.local_files_only,
-    )
+    processor_kwargs = {
+        "trust_remote_code": arguments.trust_remote_code,
+        "local_files_only": arguments.local_files_only,
+    }
+    if arguments.model_revision:
+        processor_kwargs["revision"] = arguments.model_revision
+    processor = AutoProcessor.from_pretrained(arguments.model, **processor_kwargs)
     model_kwargs = {
         "torch_dtype": _model_dtype(torch, arguments.dtype),
         "trust_remote_code": arguments.trust_remote_code,
@@ -255,6 +263,8 @@ def _load_whisper_runtime(
         model_kwargs["device_map"] = arguments.device_map
     if arguments.attn_impl:
         model_kwargs["attn_implementation"] = arguments.attn_impl
+    if arguments.model_revision:
+        model_kwargs["revision"] = arguments.model_revision
     model = AutoModelForSpeechSeq2Seq.from_pretrained(
         arguments.model,
         **model_kwargs,
@@ -344,52 +354,49 @@ def _run_nemotron35_asr(
     prompts: Sequence[Mapping[str, Any]],
     generation: Mapping[str, Any],
 ) -> list[dict[str, Any]]:
-    import torch
-    from transformers import AutoModel, AutoProcessor
-
-    device = torch.device(arguments.device)
-    common = {
-        "trust_remote_code": arguments.trust_remote_code,
-        "local_files_only": arguments.local_files_only,
-    }
-    processor = AutoProcessor.from_pretrained(arguments.model, **common)
-    model = AutoModel.from_pretrained(
-        arguments.model,
-        torch_dtype=_model_dtype(torch, arguments.dtype),
-        **common,
-    ).eval().to(device)
+    archive = _resolve_nemotron35_archive(arguments)
+    torch, model = _load_nemotron35_model(arguments, archive)
     target_rate = int(generation.get("sample_rate", 16000) or 16000)
-    max_new_tokens = arguments.max_new_tokens or int(
-        generation.get("max_new_tokens", 256)
-    )
     output_dir = arguments.predictions.parent / "hf_canary_audio"
     responses = []
     for prompt in prompts:
         audio, _source = _audio_for_prompt(prompt, target_rate)
-        wav_path = output_dir / _safe_sample_filename(
-            str(prompt.get("sample_id", "")),
-            ".wav",
-        )
+        sample_id = str(prompt.get("sample_id", ""))
+        wav_path = output_dir / _safe_sample_filename(sample_id, ".wav")
         _write_wav_pcm16(wav_path, audio, target_rate)
-        inputs = processor(
-            audio,
-            sampling_rate=target_rate,
-            language=str(prompt.get("language") or generation.get("language", "en-US")),
-            return_tensors="pt",
+        manifest_path = output_dir / _safe_sample_filename(
+            sample_id,
+            ".manifest.jsonl",
+        )
+        language = str(
+            prompt.get("language")
+            or generation.get("language")
+            or "auto"
+        )
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "audio_filepath": str(wav_path),
+                    "duration": len(audio) / target_rate,
+                    "text": "",
+                    "lang": language,
+                },
+                ensure_ascii=False,
+            )
+            + "\n",
+            encoding="utf-8",
         )
         started = time.perf_counter()
-        with torch.inference_mode():
-            generated = model.generate(
-                **_to_device(inputs, device),
-                max_new_tokens=max_new_tokens,
-            )
-        sequences = generated.sequences if hasattr(generated, "sequences") else generated
+        transcriptions = model.transcribe(
+            str(manifest_path),
+            batch_size=1,
+            verbose=False,
+        )
         responses.append(
             _asr_row(
                 prompt,
-                processor.batch_decode(sequences, skip_special_tokens=True)[0],
+                _transcription_text(transcriptions),
                 (time.perf_counter() - started) * 1000.0,
-                sequences[0].detach().cpu().tolist(),
             )
         )
     del model
@@ -397,6 +404,53 @@ def _run_nemotron35_asr(
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
     return responses
+
+
+def _resolve_nemotron35_archive(arguments: argparse.Namespace) -> Path:
+    model_path = Path(arguments.model)
+    if model_path.is_file() and model_path.suffix == ".nemo":
+        return model_path
+    if model_path.is_dir():
+        archives = sorted(model_path.glob("*.nemo"))
+    else:
+        from huggingface_hub import snapshot_download
+
+        snapshot = Path(
+            snapshot_download(
+                arguments.model,
+                allow_patterns=["*.nemo"],
+                local_files_only=arguments.local_files_only,
+                **(
+                    {"revision": arguments.model_revision}
+                    if arguments.model_revision
+                    else {}
+                ),
+            )
+        )
+        archives = sorted(snapshot.glob("*.nemo"))
+    if not archives:
+        raise FileNotFoundError(
+            f"Nemotron 3.5 ASR NeMo archive is missing for {arguments.model}"
+        )
+    return archives[0]
+
+
+def _load_nemotron35_model(
+    arguments: argparse.Namespace,
+    archive: Path,
+) -> tuple[Any, Any]:
+    import torch
+    from nemo.collections.asr.models import EncDecRNNTBPEModelWithPrompt
+
+    device = torch.device(arguments.device)
+    model = EncDecRNNTBPEModelWithPrompt.restore_from(
+        str(archive),
+        map_location=device,
+    )
+    model.eval()
+    if hasattr(model, "to"):
+        model.to(device)
+    return torch, model
 
 
 def _run_nemo_asr(
@@ -490,25 +544,68 @@ def _run_pipeline_asr(
     return responses
 
 
+def _resolve_magpie_archive(arguments: argparse.Namespace) -> Path:
+    model_path = Path(arguments.model)
+    if model_path.is_file() and model_path.suffix == ".nemo":
+        return model_path
+    if model_path.is_dir():
+        archives = sorted(model_path.glob("*.nemo"))
+        if not archives:
+            raise FileNotFoundError(
+                f"Magpie NeMo archive is missing under {arguments.model}"
+            )
+        return archives[0]
+
+    from huggingface_hub import hf_hub_download
+
+    download_kwargs = {
+        "repo_id": arguments.model,
+        "filename": "magpie_tts_multilingual_357m.nemo",
+        "local_files_only": arguments.local_files_only,
+    }
+    if arguments.model_revision:
+        download_kwargs["revision"] = arguments.model_revision
+    return Path(hf_hub_download(**download_kwargs))
+
+
 def _load_tts_runtime(arguments: argparse.Namespace, torch: Any) -> tuple[Any, Any]:
     if "magpie" in arguments.model.lower():
+        import fsspec
+        from huggingface_hub import hf_hub_download
         from nemo.collections.tts.models import MagpieTTSModel
 
-        model = MagpieTTSModel.from_pretrained(arguments.model)
+        speaker_checkpoint = hf_hub_download(
+            repo_id=MAGPIE_SPEAKER_ENCODER_REPO,
+            filename=MAGPIE_SPEAKER_ENCODER_FILENAME,
+            local_files_only=arguments.local_files_only,
+        )
+        original_fsspec_open = fsspec.open
+
+        def offline_fsspec_open(path: Any, *args: Any, **kwargs: Any) -> Any:
+            normalized = str(path).split("?", 1)[0]
+            if normalized == MAGPIE_SPEAKER_ENCODER_URL:
+                path = speaker_checkpoint
+            return original_fsspec_open(path, *args, **kwargs)
+
+        fsspec.open = offline_fsspec_open
+        model = MagpieTTSModel.restore_from(
+            restore_path=str(_resolve_magpie_archive(arguments))
+        )
         return None, model.eval().to(torch.device(arguments.device))
     from transformers import AutoProcessor, BarkModel, logging
 
     logging.set_verbosity_error()
-    processor = AutoProcessor.from_pretrained(
-        arguments.model,
-        trust_remote_code=arguments.trust_remote_code,
-        local_files_only=arguments.local_files_only,
-    )
+    load_kwargs = {
+        "trust_remote_code": arguments.trust_remote_code,
+        "local_files_only": arguments.local_files_only,
+    }
+    if arguments.model_revision:
+        load_kwargs["revision"] = arguments.model_revision
+    processor = AutoProcessor.from_pretrained(arguments.model, **load_kwargs)
     model = BarkModel.from_pretrained(
         arguments.model,
-        trust_remote_code=arguments.trust_remote_code,
-        local_files_only=arguments.local_files_only,
         torch_dtype=_model_dtype(torch, arguments.dtype),
+        **load_kwargs,
     )
     return processor, model.eval().to(torch.device(arguments.device))
 
@@ -674,6 +771,7 @@ def _reproduction_command(arguments: argparse.Namespace) -> list[str]:
         "{sample_id}",
     ]
     for flag, value in (
+        ("--model-revision", arguments.model_revision),
         ("--device-map", arguments.device_map),
         ("--attn-impl", arguments.attn_impl),
         ("--max-new-tokens", arguments.max_new_tokens),
@@ -736,6 +834,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="Run ASR or TTS directly through its upstream runtime."
     )
     parser.add_argument("--model", required=True)
+    parser.add_argument("--model-revision", default="")
     parser.add_argument("--family", default="")
     parser.add_argument("--reference-family", default="")
     parser.add_argument("--prompts", type=Path, required=True)

--- a/tools/reference/transformers_encoder.py
+++ b/tools/reference/transformers_encoder.py
@@ -100,6 +100,7 @@ def _reproduction_command(arguments: argparse.Namespace) -> list[str]:
         "{sample_id}",
     ]
     for flag, value in (
+        ("--model-revision", arguments.model_revision),
         ("--reference-family", arguments.reference_family),
         ("--device-map", arguments.device_map),
     ):
@@ -183,10 +184,15 @@ def _load_runtime(
         arguments.reference_family,
     )
     transformers_module.logging.set_verbosity_error()
+    tokenizer_kwargs = {
+        "trust_remote_code": arguments.trust_remote_code,
+        "local_files_only": arguments.local_files_only,
+    }
+    if arguments.model_revision:
+        tokenizer_kwargs["revision"] = arguments.model_revision
     tokenizer = tokenizer_class.from_pretrained(
         arguments.model,
-        trust_remote_code=arguments.trust_remote_code,
-        local_files_only=arguments.local_files_only,
+        **tokenizer_kwargs,
     )
     model_kwargs = {
         "torch_dtype": _model_dtype(torch_module, arguments.dtype),
@@ -195,6 +201,8 @@ def _load_runtime(
     }
     if arguments.device_map:
         model_kwargs["device_map"] = arguments.device_map
+    if arguments.model_revision:
+        model_kwargs["revision"] = arguments.model_revision
     model = model_class.from_pretrained(arguments.model, **model_kwargs).eval()
     if arguments.device_map:
         device = model.device
@@ -279,6 +287,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="Run an encoder model directly through Transformers."
     )
     parser.add_argument("--model", required=True)
+    parser.add_argument("--model-revision", default="")
     parser.add_argument("--reference-family", default="")
     parser.add_argument("--prompts", type=Path, required=True)
     parser.add_argument("--answers", type=Path, required=True)

--- a/tools/reference/transformers_encoder.py
+++ b/tools/reference/transformers_encoder.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run encoder and embedding references directly through Transformers."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import sys
+import time
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = "trtmc.native-reference-reproduction/v1"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    with path.open(encoding="utf-8") as input_file:
+        for line_number, line in enumerate(input_file, start=1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if not isinstance(row, dict):
+                raise ValueError(f"{path}:{line_number} must contain a JSON object")
+            rows.append(row)
+    return rows
+
+
+def _selected_rows(
+    rows: Sequence[Mapping[str, Any]],
+    sample_id: str,
+) -> list[dict[str, Any]]:
+    selected = [
+        dict(row)
+        for row in rows
+        if not sample_id or str(row.get("sample_id", "")) == sample_id
+    ]
+    if sample_id and not selected:
+        raise ValueError(f"sample_id {sample_id!r} is not present in the prepared prompts")
+    return selected
+
+
+def _model_dtype(torch_module: Any, name: str) -> str | Any:
+    if name == "float16":
+        return torch_module.float16
+    if name == "bfloat16":
+        return torch_module.bfloat16
+    return "auto"
+
+
+def _reference_classes(
+    transformers_module: Any,
+    reference_family: str,
+) -> tuple[Any, Any]:
+    if reference_family == "dpr_context_embed":
+        return (
+            transformers_module.DPRContextEncoder,
+            transformers_module.DPRContextEncoderTokenizerFast,
+        )
+    return transformers_module.AutoModel, transformers_module.AutoTokenizer
+
+
+def _entrypoint_sha256() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+def _reproduction_command(arguments: argparse.Namespace) -> list[str]:
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--model",
+        arguments.model,
+        "--prompts",
+        "{work_dir}/prompts.jsonl",
+        "--answers",
+        "{work_dir}/answers.json",
+        "--manifest",
+        "{work_dir}/manifest.json",
+        "--predictions",
+        "{reference_predictions_json}",
+        "--raw-output",
+        "{reference_raw_jsonl}",
+        "--dtype",
+        arguments.dtype,
+        "--device",
+        arguments.device,
+        "--sample-id",
+        "{sample_id}",
+    ]
+    for flag, value in (
+        ("--reference-family", arguments.reference_family),
+        ("--device-map", arguments.device_map),
+    ):
+        if value:
+            command.extend([flag, str(value)])
+    for enabled, flag in (
+        (arguments.trust_remote_code, "--trust-remote-code"),
+        (arguments.local_files_only, "--local-files-only"),
+    ):
+        if enabled:
+            command.append(flag)
+    return command
+
+
+def _write_reproduction_metadata(arguments: argparse.Namespace) -> None:
+    if arguments.repro_metadata is None:
+        return
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "backend": "transformers",
+        "entrypoint": str(Path(__file__).resolve()),
+        "entrypoint_sha256": _entrypoint_sha256(),
+        "command": _reproduction_command(arguments),
+    }
+    arguments.repro_metadata.write_text(
+        json.dumps(payload, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _runtime_dependencies() -> tuple[Any, Any]:
+    try:
+        import torch
+        import transformers
+    except Exception as exc:  # pragma: no cover - runtime dependency
+        raise RuntimeError(
+            "native encoder reference requires torch and transformers"
+        ) from exc
+    return torch, transformers
+
+
+def _last_hidden_state(outputs: Any) -> Any:
+    hidden = getattr(outputs, "last_hidden_state", None)
+    if hidden is not None:
+        return hidden
+    hidden_states = getattr(outputs, "hidden_states", None)
+    if hidden_states:
+        return hidden_states[-1]
+    if isinstance(outputs, (tuple, list)) and outputs:
+        return outputs[0]
+    return None
+
+
+def _result_vector(
+    torch_module: Any,
+    hidden: Any,
+    encoded: Mapping[str, Any],
+    vector_mode: str,
+) -> list[float]:
+    if vector_mode != "embedding":
+        return hidden[0, 0].float().cpu().numpy().tolist()
+    attention_mask = encoded.get("attention_mask")
+    if attention_mask is None:
+        attention_mask = torch_module.ones(
+            hidden.shape[:2],
+            device=hidden.device,
+        )
+    mask = attention_mask.unsqueeze(-1).to(hidden.dtype)
+    vector = (hidden * mask).sum(dim=1) / mask.sum(dim=1).clamp(min=1)
+    vector = torch_module.nn.functional.normalize(vector, p=2, dim=-1)[0]
+    return vector.float().cpu().numpy().tolist()
+
+
+def _load_runtime(
+    arguments: argparse.Namespace,
+    torch_module: Any,
+    transformers_module: Any,
+) -> tuple[Any, Any, Any]:
+    model_class, tokenizer_class = _reference_classes(
+        transformers_module,
+        arguments.reference_family,
+    )
+    transformers_module.logging.set_verbosity_error()
+    tokenizer = tokenizer_class.from_pretrained(
+        arguments.model,
+        trust_remote_code=arguments.trust_remote_code,
+        local_files_only=arguments.local_files_only,
+    )
+    model_kwargs = {
+        "torch_dtype": _model_dtype(torch_module, arguments.dtype),
+        "trust_remote_code": arguments.trust_remote_code,
+        "local_files_only": arguments.local_files_only,
+    }
+    if arguments.device_map:
+        model_kwargs["device_map"] = arguments.device_map
+    model = model_class.from_pretrained(arguments.model, **model_kwargs).eval()
+    if arguments.device_map:
+        device = model.device
+    else:
+        device = torch_module.device(arguments.device)
+        model.to(device)
+    return tokenizer, model, device
+
+
+def run(arguments: argparse.Namespace) -> None:
+    torch, transformers = _runtime_dependencies()
+    manifest = _load_json(arguments.manifest)
+    prompt_rows = _selected_rows(
+        _load_jsonl(arguments.prompts),
+        arguments.sample_id,
+    )
+    task_config = manifest.get("task_eval", {})
+    task_config = task_config if isinstance(task_config, dict) else {}
+    vector_mode = (
+        "embedding"
+        if task_config.get("task_strategy") == "embedding"
+        else "cls"
+    )
+    tokenizer, model, device = _load_runtime(
+        arguments,
+        torch,
+        transformers,
+    )
+    responses = []
+    arguments.raw_output.parent.mkdir(parents=True, exist_ok=True)
+    arguments.predictions.parent.mkdir(parents=True, exist_ok=True)
+    with arguments.raw_output.open("w", encoding="utf-8") as raw_file:
+        for index, prompt_row in enumerate(prompt_rows):
+            encoded = tokenizer(
+                str(prompt_row["prompt"]),
+                return_tensors="pt",
+                truncation=True,
+            )
+            encoded = {name: value.to(device) for name, value in encoded.items()}
+            start = time.perf_counter()
+            with torch.inference_mode():
+                outputs = model(**encoded, output_hidden_states=True)
+            wall_ms = (time.perf_counter() - start) * 1000.0
+            hidden = _last_hidden_state(outputs)
+            if hidden is None or hidden.ndim != 3:
+                raise RuntimeError(
+                    f"encoder output for {prompt_row['sample_id']} "
+                    "has no rank-3 hidden state"
+                )
+            row = {
+                "sample_id": str(prompt_row["sample_id"]),
+                "pair_id": str(prompt_row["pair_id"]),
+                "pair_side": str(prompt_row["pair_side"]),
+                "score": float(prompt_row["score"]),
+                "vector_mode": vector_mode,
+                "vector": _result_vector(
+                    torch,
+                    hidden,
+                    encoded,
+                    vector_mode,
+                ),
+                "wall_ms": wall_ms,
+                "source": "hf",
+            }
+            responses.append(row)
+            raw_file.write(json.dumps(row, ensure_ascii=False) + "\n")
+            raw_file.flush()
+            print(
+                f"[transformers.native_encoder] "
+                f"sample={index + 1}/{len(prompt_rows)}",
+                file=sys.stderr,
+            )
+    arguments.predictions.write_text(
+        json.dumps({"responses": responses}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    _write_reproduction_metadata(arguments)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run an encoder model directly through Transformers."
+    )
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--reference-family", default="")
+    parser.add_argument("--prompts", type=Path, required=True)
+    parser.add_argument("--answers", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--predictions", type=Path, required=True)
+    parser.add_argument("--raw-output", type=Path, required=True)
+    parser.add_argument("--repro-metadata", type=Path)
+    parser.add_argument("--sample-id", default="")
+    parser.add_argument(
+        "--dtype",
+        choices=("auto", "float16", "bfloat16"),
+        default="auto",
+    )
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--device-map", default="")
+    parser.add_argument("--attn-impl", default="")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--local-files-only", action="store_true")
+    parser.add_argument("--do-sample", action="store_true")
+    parser.add_argument("--apply-chat-template", action="store_true")
+    parser.add_argument("--max-new-tokens", type=int)
+    parser.add_argument("--temperature", type=float)
+    parser.add_argument("--top-k", type=int)
+    parser.add_argument("--top-p", type=float)
+    parser.add_argument("--seed", type=int)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    run(build_parser().parse_args(argv))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/reference/transformers_text.py
+++ b/tools/reference/transformers_text.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run text generation directly through the upstream Transformers API."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import sys
+import time
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = "trtmc.native-reference-reproduction/v1"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    with path.open(encoding="utf-8") as input_file:
+        for line_number, line in enumerate(input_file, start=1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if not isinstance(row, dict):
+                raise ValueError(f"{path}:{line_number} must contain a JSON object")
+            rows.append(row)
+    return rows
+
+
+def _generation_value(
+    arguments: argparse.Namespace,
+    generation: Mapping[str, Any],
+    name: str,
+    default: Any,
+) -> Any:
+    configured = getattr(arguments, name)
+    return generation.get(name, default) if configured is None else configured
+
+
+def _model_dtype(torch_module: Any, name: str) -> str | Any:
+    if name == "float16":
+        return torch_module.float16
+    if name == "bfloat16":
+        return torch_module.bfloat16
+    return "auto"
+
+
+def _load_model(
+    transformers_module: Any,
+    model_id: str,
+    *,
+    model_kwargs: dict[str, Any],
+    trust_remote_code: bool,
+    local_files_only: bool,
+) -> tuple[Any, bool]:
+    config = transformers_module.AutoConfig.from_pretrained(
+        model_id,
+        trust_remote_code=trust_remote_code,
+        local_files_only=local_files_only,
+    )
+    is_encoder_decoder = bool(getattr(config, "is_encoder_decoder", False))
+    model_class = (
+        transformers_module.AutoModelForSeq2SeqLM
+        if is_encoder_decoder
+        else transformers_module.AutoModelForCausalLM
+    )
+    return model_class.from_pretrained(model_id, **model_kwargs).eval(), is_encoder_decoder
+
+
+def _request_prompt(request: Mapping[str, Any]) -> str:
+    messages = request.get("messages")
+    if isinstance(messages, list):
+        for message in reversed(messages):
+            if (
+                isinstance(message, dict)
+                and message.get("role") == "user"
+                and isinstance(message.get("content"), str)
+            ):
+                return str(message["content"])
+    prompt = request.get("prompt")
+    if isinstance(prompt, str):
+        return prompt
+    return ""
+
+
+def _selected_indexes(
+    prompts: Sequence[Mapping[str, Any]],
+    sample_id: str,
+) -> list[int]:
+    if not sample_id:
+        return list(range(len(prompts)))
+    selected = [
+        index
+        for index, prompt in enumerate(prompts)
+        if str(prompt.get("sample_id", "")) == sample_id
+    ]
+    if not selected:
+        raise ValueError(f"sample_id {sample_id!r} is not present in the prepared prompts")
+    return selected
+
+
+def _entrypoint_sha256() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+def _reproduction_command(arguments: argparse.Namespace) -> list[str]:
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--model",
+        arguments.model,
+        "--prompts",
+        "{work_dir}/prompts.jsonl",
+        "--answers",
+        "{work_dir}/answers.json",
+        "--manifest",
+        "{work_dir}/manifest.json",
+        "--predictions",
+        "{reference_predictions_json}",
+        "--raw-output",
+        "{reference_raw_jsonl}",
+        "--dtype",
+        arguments.dtype,
+        "--device",
+        arguments.device,
+        "--sample-id",
+        "{sample_id}",
+    ]
+    for flag, value in (
+        ("--device-map", arguments.device_map),
+        ("--attn-impl", arguments.attn_impl),
+        ("--max-new-tokens", arguments.max_new_tokens),
+        ("--temperature", arguments.temperature),
+        ("--top-k", arguments.top_k),
+        ("--top-p", arguments.top_p),
+        ("--seed", arguments.seed),
+    ):
+        if value not in (None, ""):
+            command.extend([flag, str(value)])
+    for enabled, flag in (
+        (arguments.trust_remote_code, "--trust-remote-code"),
+        (arguments.local_files_only, "--local-files-only"),
+        (arguments.do_sample, "--do-sample"),
+        (arguments.apply_chat_template, "--apply-chat-template"),
+    ):
+        if enabled:
+            command.append(flag)
+    return command
+
+
+def _write_reproduction_metadata(arguments: argparse.Namespace) -> None:
+    if arguments.repro_metadata is None:
+        return
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "backend": "transformers",
+        "entrypoint": str(Path(__file__).resolve()),
+        "entrypoint_sha256": _entrypoint_sha256(),
+        "command": _reproduction_command(arguments),
+    }
+    arguments.repro_metadata.write_text(
+        json.dumps(payload, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _runtime_dependencies() -> tuple[Any, Any]:
+    try:
+        import torch
+        import transformers
+    except Exception as exc:  # pragma: no cover - runtime dependency
+        raise RuntimeError("native text reference requires torch and transformers") from exc
+    return torch, transformers
+
+
+def _generation_settings(
+    arguments: argparse.Namespace,
+    manifest: Mapping[str, Any],
+    answers: Mapping[str, Any],
+) -> dict[str, Any]:
+    generation = manifest.get("generation", {})
+    generation = generation if isinstance(generation, dict) else {}
+    task_config = manifest.get("task_eval", {})
+    task_config = task_config if isinstance(task_config, dict) else {}
+    settings = {
+        "max_new_tokens": int(
+            _generation_value(arguments, generation, "max_new_tokens", 1)
+        ),
+        "temperature": float(
+            _generation_value(arguments, generation, "temperature", 1.0)
+        ),
+        "top_k": int(_generation_value(arguments, generation, "top_k", 1)),
+        "top_p": float(_generation_value(arguments, generation, "top_p", 1.0)),
+        "seed": int(_generation_value(arguments, generation, "seed", -1)),
+        "do_sample": arguments.do_sample
+        or bool(generation.get("do_sample", False)),
+        "apply_chat_template": arguments.apply_chat_template
+        or bool(
+            generation.get(
+                "apply_chat_template",
+                answers.get("apply_chat_template", False),
+            )
+        ),
+        "generation_overrides": {},
+    }
+    if "hf_use_cache" in task_config:
+        settings["generation_overrides"]["use_cache"] = bool(
+            task_config["hf_use_cache"]
+        )
+    return settings
+
+
+def _load_runtime(
+    arguments: argparse.Namespace,
+    torch_module: Any,
+    transformers_module: Any,
+) -> tuple[Any, Any, Any, bool]:
+    transformers_module.logging.set_verbosity_error()
+    tokenizer = transformers_module.AutoTokenizer.from_pretrained(
+        arguments.model,
+        trust_remote_code=arguments.trust_remote_code,
+        local_files_only=arguments.local_files_only,
+    )
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    model_kwargs = {
+        "torch_dtype": _model_dtype(torch_module, arguments.dtype),
+        "trust_remote_code": arguments.trust_remote_code,
+        "local_files_only": arguments.local_files_only,
+    }
+    if arguments.device_map:
+        model_kwargs["device_map"] = arguments.device_map
+    if arguments.attn_impl:
+        model_kwargs["attn_implementation"] = arguments.attn_impl
+    model, is_encoder_decoder = _load_model(
+        transformers_module,
+        arguments.model,
+        model_kwargs=model_kwargs,
+        trust_remote_code=arguments.trust_remote_code,
+        local_files_only=arguments.local_files_only,
+    )
+    if arguments.device_map:
+        device = model.device
+    else:
+        device = torch_module.device(arguments.device)
+        model.to(device)
+    return tokenizer, model, device, is_encoder_decoder
+
+
+def _seed_runtime(torch_module: Any, seed: int, source_index: int) -> None:
+    if seed < 0:
+        return
+    torch_module.manual_seed(seed + source_index)
+    if torch_module.cuda.is_available():
+        torch_module.cuda.manual_seed_all(seed + source_index)
+
+
+def _generated_sequence(
+    output_ids: Any,
+    *,
+    input_length: int,
+    model: Any,
+    is_encoder_decoder: bool,
+) -> tuple[Any, bool]:
+    if not is_encoder_decoder:
+        return output_ids[0, input_length:], False
+    generated = output_ids[0]
+    decoder_start_token_id = getattr(
+        model.config,
+        "decoder_start_token_id",
+        None,
+    )
+    if (
+        decoder_start_token_id is not None
+        and generated.numel() > 0
+        and int(generated[0]) == int(decoder_start_token_id)
+    ):
+        generated = generated[1:]
+    return generated, True
+
+
+def _generate_sample(
+    *,
+    torch_module: Any,
+    tokenizer: Any,
+    model: Any,
+    device: Any,
+    is_encoder_decoder: bool,
+    request: Mapping[str, Any],
+    prompt_row: Mapping[str, Any],
+    source_index: int,
+    settings: Mapping[str, Any],
+) -> tuple[str, Any, float]:
+    prompt = str(prompt_row.get("prompt") or _request_prompt(request))
+    if settings["apply_chat_template"]:
+        prompt = tokenizer.apply_chat_template(
+            request["messages"],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+    encoded = tokenizer(prompt, return_tensors="pt")
+    encoded = {name: value.to(device) for name, value in encoded.items()}
+    _seed_runtime(torch_module, int(settings["seed"]), source_index)
+    start = time.perf_counter()
+    with torch_module.inference_mode():
+        output_ids = model.generate(
+            **encoded,
+            max_new_tokens=settings["max_new_tokens"],
+            do_sample=settings["do_sample"],
+            temperature=settings["temperature"],
+            top_k=settings["top_k"],
+            top_p=settings["top_p"],
+            num_beams=1,
+            pad_token_id=tokenizer.pad_token_id,
+            eos_token_id=tokenizer.eos_token_id,
+            **settings["generation_overrides"],
+        )
+    wall_ms = (time.perf_counter() - start) * 1000.0
+    generated, skip_special_tokens = _generated_sequence(
+        output_ids,
+        input_length=encoded["input_ids"].shape[1],
+        model=model,
+        is_encoder_decoder=is_encoder_decoder,
+    )
+    return (
+        tokenizer.decode(generated, skip_special_tokens=skip_special_tokens),
+        generated,
+        wall_ms,
+    )
+
+
+def run(arguments: argparse.Namespace) -> None:
+    torch, transformers = _runtime_dependencies()
+
+    manifest = _load_json(arguments.manifest)
+    answers = _load_json(arguments.answers)
+    prompt_rows = _load_jsonl(arguments.prompts)
+    requests = answers.get("requests", [])
+    if not isinstance(requests, list) or len(requests) != len(prompt_rows):
+        raise ValueError("answers and prepared prompts must contain the same number of samples")
+    selected = _selected_indexes(prompt_rows, arguments.sample_id)
+    settings = _generation_settings(arguments, manifest, answers)
+    tokenizer, model, device, is_encoder_decoder = _load_runtime(
+        arguments,
+        torch,
+        transformers,
+    )
+    responses = []
+    arguments.raw_output.parent.mkdir(parents=True, exist_ok=True)
+    arguments.predictions.parent.mkdir(parents=True, exist_ok=True)
+    with arguments.raw_output.open("w", encoding="utf-8") as raw_file:
+        for run_index, source_index in enumerate(selected):
+            prompt_row = prompt_rows[source_index]
+            request = requests[source_index]
+            if not isinstance(request, dict):
+                raise ValueError(f"request {source_index} must be a JSON object")
+            output_text, generated, wall_ms = _generate_sample(
+                torch_module=torch,
+                tokenizer=tokenizer,
+                model=model,
+                device=device,
+                is_encoder_decoder=is_encoder_decoder,
+                request=request,
+                prompt_row=prompt_row,
+                source_index=source_index,
+                settings=settings,
+            )
+            row = {
+                "sample_id": prompt_row.get("sample_id", f"sample_{source_index:06d}"),
+                "output_text": output_text,
+                "generated_tokens": int(generated.shape[0]),
+                "generated_token_ids": [
+                    int(token_id) for token_id in generated.tolist()
+                ],
+                "wall_ms": wall_ms,
+                "source": "hf",
+            }
+            responses.append(row)
+            raw_file.write(json.dumps(row, ensure_ascii=False) + "\n")
+            raw_file.flush()
+            print(
+                f"[transformers.native_reference] sample={run_index + 1}/{len(selected)}",
+                file=sys.stderr,
+            )
+    arguments.predictions.write_text(
+        json.dumps({"responses": responses}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    _write_reproduction_metadata(arguments)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a text model directly through Transformers."
+    )
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--prompts", type=Path, required=True)
+    parser.add_argument("--answers", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--predictions", type=Path, required=True)
+    parser.add_argument("--raw-output", type=Path, required=True)
+    parser.add_argument("--repro-metadata", type=Path)
+    parser.add_argument("--sample-id", default="")
+    parser.add_argument("--dtype", choices=("auto", "float16", "bfloat16"), default="auto")
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--device-map", default="")
+    parser.add_argument("--attn-impl", default="")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--local-files-only", action="store_true")
+    parser.add_argument("--do-sample", action="store_true")
+    parser.add_argument("--apply-chat-template", action="store_true")
+    parser.add_argument("--max-new-tokens", type=int)
+    parser.add_argument("--temperature", type=float)
+    parser.add_argument("--top-k", type=int)
+    parser.add_argument("--top-p", type=float)
+    parser.add_argument("--seed", type=int)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    run(build_parser().parse_args(argv))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/reference/transformers_text.py
+++ b/tools/reference/transformers_text.py
@@ -137,6 +137,8 @@ def _reproduction_command(arguments: argparse.Namespace) -> list[str]:
         "--sample-id",
         "{sample_id}",
     ]
+    if arguments.reference_family:
+        command.extend(["--reference-family", arguments.reference_family])
     for flag, value in (
         ("--device-map", arguments.device_map),
         ("--attn-impl", arguments.attn_impl),
@@ -405,6 +407,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="Run a text model directly through Transformers."
     )
     parser.add_argument("--model", required=True)
+    parser.add_argument("--reference-family", default="")
     parser.add_argument("--prompts", type=Path, required=True)
     parser.add_argument("--answers", type=Path, required=True)
     parser.add_argument("--manifest", type=Path, required=True)

--- a/tools/reference/transformers_text.py
+++ b/tools/reference/transformers_text.py
@@ -61,14 +61,17 @@ def _load_model(
     model_id: str,
     *,
     model_kwargs: dict[str, Any],
+    model_revision: str,
     trust_remote_code: bool,
     local_files_only: bool,
 ) -> tuple[Any, bool]:
-    config = transformers_module.AutoConfig.from_pretrained(
-        model_id,
-        trust_remote_code=trust_remote_code,
-        local_files_only=local_files_only,
-    )
+    config_kwargs = {
+        "trust_remote_code": trust_remote_code,
+        "local_files_only": local_files_only,
+    }
+    if model_revision:
+        config_kwargs["revision"] = model_revision
+    config = transformers_module.AutoConfig.from_pretrained(model_id, **config_kwargs)
     is_encoder_decoder = bool(getattr(config, "is_encoder_decoder", False))
     model_class = (
         transformers_module.AutoModelForSeq2SeqLM
@@ -140,6 +143,7 @@ def _reproduction_command(arguments: argparse.Namespace) -> list[str]:
     if arguments.reference_family:
         command.extend(["--reference-family", arguments.reference_family])
     for flag, value in (
+        ("--model-revision", arguments.model_revision),
         ("--device-map", arguments.device_map),
         ("--attn-impl", arguments.attn_impl),
         ("--max-new-tokens", arguments.max_new_tokens),
@@ -229,10 +233,15 @@ def _load_runtime(
     transformers_module: Any,
 ) -> tuple[Any, Any, Any, bool]:
     transformers_module.logging.set_verbosity_error()
+    tokenizer_kwargs = {
+        "trust_remote_code": arguments.trust_remote_code,
+        "local_files_only": arguments.local_files_only,
+    }
+    if arguments.model_revision:
+        tokenizer_kwargs["revision"] = arguments.model_revision
     tokenizer = transformers_module.AutoTokenizer.from_pretrained(
         arguments.model,
-        trust_remote_code=arguments.trust_remote_code,
-        local_files_only=arguments.local_files_only,
+        **tokenizer_kwargs,
     )
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token = tokenizer.eos_token
@@ -245,10 +254,13 @@ def _load_runtime(
         model_kwargs["device_map"] = arguments.device_map
     if arguments.attn_impl:
         model_kwargs["attn_implementation"] = arguments.attn_impl
+    if arguments.model_revision:
+        model_kwargs["revision"] = arguments.model_revision
     model, is_encoder_decoder = _load_model(
         transformers_module,
         arguments.model,
         model_kwargs=model_kwargs,
+        model_revision=arguments.model_revision,
         trust_remote_code=arguments.trust_remote_code,
         local_files_only=arguments.local_files_only,
     )
@@ -407,6 +419,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="Run a text model directly through Transformers."
     )
     parser.add_argument("--model", required=True)
+    parser.add_argument("--model-revision", default="")
     parser.add_argument("--reference-family", default="")
     parser.add_argument("--prompts", type=Path, required=True)
     parser.add_argument("--answers", type=Path, required=True)

--- a/tools/reference/transformers_vlm.py
+++ b/tools/reference/transformers_vlm.py
@@ -88,6 +88,7 @@ def _reproduction_command(arguments: argparse.Namespace) -> list[str]:
         "{sample_id}",
     ]
     for flag, value in (
+        ("--model-revision", arguments.model_revision),
         ("--reference-family", arguments.reference_family),
         ("--device-map", arguments.device_map),
         ("--attn-impl", arguments.attn_impl),
@@ -296,6 +297,11 @@ def _load_runtime(
         arguments.model,
         trust_remote_code=arguments.trust_remote_code,
         local_files_only=arguments.local_files_only,
+        **(
+            {"revision": arguments.model_revision}
+            if arguments.model_revision
+            else {}
+        ),
     )
     model_kwargs = {
         "torch_dtype": _model_dtype(torch_module, arguments.dtype),
@@ -306,6 +312,8 @@ def _load_runtime(
         model_kwargs["device_map"] = arguments.device_map
     if arguments.attn_impl:
         model_kwargs["attn_implementation"] = arguments.attn_impl
+    if arguments.model_revision:
+        model_kwargs["revision"] = arguments.model_revision
     model = _load_model(
         transformers_module,
         arguments.model,
@@ -527,6 +535,7 @@ def build_parser() -> argparse.ArgumentParser:
         description="Run a VLM directly through Transformers."
     )
     parser.add_argument("--model", required=True)
+    parser.add_argument("--model-revision", default="")
     parser.add_argument("--reference-family", default="")
     parser.add_argument("--prompts", type=Path, required=True)
     parser.add_argument("--answers", type=Path, required=True)

--- a/tools/reference/transformers_vlm.py
+++ b/tools/reference/transformers_vlm.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run vision-language references directly through Transformers."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import sys
+import time
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = "trtmc.native-reference-reproduction/v1"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    with path.open(encoding="utf-8") as input_file:
+        for line_number, line in enumerate(input_file, start=1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if not isinstance(row, dict):
+                raise ValueError(f"{path}:{line_number} must contain a JSON object")
+            rows.append(row)
+    return rows
+
+
+def _selected_indices(
+    rows: Sequence[Mapping[str, Any]],
+    sample_id: str,
+) -> list[int]:
+    selected = [
+        index
+        for index, row in enumerate(rows)
+        if not sample_id or str(row.get("sample_id", "")) == sample_id
+    ]
+    if sample_id and not selected:
+        raise ValueError(f"sample_id {sample_id!r} is not present in the prepared prompts")
+    return selected
+
+
+def _model_dtype(torch_module: Any, name: str) -> str | Any:
+    if name == "float16":
+        return torch_module.float16
+    if name == "bfloat16":
+        return torch_module.bfloat16
+    return "auto"
+
+
+def _entrypoint_sha256() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+
+
+def _reproduction_command(arguments: argparse.Namespace) -> list[str]:
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--model",
+        arguments.model,
+        "--prompts",
+        "{work_dir}/prompts.jsonl",
+        "--answers",
+        "{work_dir}/answers.json",
+        "--manifest",
+        "{work_dir}/manifest.json",
+        "--predictions",
+        "{reference_predictions_json}",
+        "--raw-output",
+        "{reference_raw_jsonl}",
+        "--dtype",
+        arguments.dtype,
+        "--device",
+        arguments.device,
+        "--sample-id",
+        "{sample_id}",
+    ]
+    for flag, value in (
+        ("--reference-family", arguments.reference_family),
+        ("--device-map", arguments.device_map),
+        ("--attn-impl", arguments.attn_impl),
+        ("--max-new-tokens", arguments.max_new_tokens),
+        ("--temperature", arguments.temperature),
+        ("--top-k", arguments.top_k),
+        ("--top-p", arguments.top_p),
+        ("--seed", arguments.seed),
+    ):
+        if value not in (None, ""):
+            command.extend([flag, str(value)])
+    for enabled, flag in (
+        (arguments.trust_remote_code, "--trust-remote-code"),
+        (arguments.local_files_only, "--local-files-only"),
+        (arguments.do_sample, "--do-sample"),
+    ):
+        if enabled:
+            command.append(flag)
+    return command
+
+
+def _write_reproduction_metadata(arguments: argparse.Namespace) -> None:
+    if arguments.repro_metadata is None:
+        return
+    arguments.repro_metadata.write_text(
+        json.dumps(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "backend": "transformers_vlm",
+                "entrypoint": str(Path(__file__).resolve()),
+                "entrypoint_sha256": _entrypoint_sha256(),
+                "command": _reproduction_command(arguments),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _runtime_dependencies() -> tuple[Any, Any, Any]:
+    try:
+        import torch
+        import transformers
+        from transformers import AutoProcessor
+    except Exception as exc:  # pragma: no cover - runtime dependency
+        raise RuntimeError(
+            "native VLM reference requires torch and transformers"
+        ) from exc
+    return torch, transformers, AutoProcessor
+
+
+def _model_classes(transformers_module: Any) -> list[Any]:
+    classes = [
+        getattr(transformers_module, name, None)
+        for name in (
+            "AutoModelForImageTextToText",
+            "AutoModelForVision2Seq",
+            "AutoModelForCausalLM",
+            "AutoModel",
+        )
+    ]
+    available = [model_class for model_class in classes if model_class is not None]
+    if not available:
+        raise RuntimeError(
+            "Transformers installation does not expose a VLM-capable AutoModel class"
+        )
+    return available
+
+
+def _load_model(
+    transformers_module: Any,
+    model_id: str,
+    model_kwargs: Mapping[str, Any],
+) -> Any:
+    errors = []
+    for model_class in _model_classes(transformers_module):
+        try:
+            return model_class.from_pretrained(
+                model_id,
+                **dict(model_kwargs),
+            ).eval()
+        except ValueError as exc:
+            errors.append(f"{model_class.__name__}: {exc}")
+    raise RuntimeError(
+        f"Could not load VLM reference model {model_id!r}: "
+        + " | ".join(errors)
+    )
+
+
+def _load_images(image_paths: Sequence[str]) -> list[Any]:
+    try:
+        from PIL import Image
+    except Exception as exc:  # pragma: no cover - runtime dependency
+        raise RuntimeError("native VLM reference requires Pillow") from exc
+    images = []
+    for image_path in image_paths:
+        with Image.open(image_path) as image:
+            images.append(image.convert("RGB"))
+    return images
+
+
+def _has_image_placeholder(text: str) -> bool:
+    return any(
+        marker in text
+        for marker in (
+            "<|image_pad|>",
+            "<|vision_start|>",
+            "<image>",
+            "<IMG_CONTEXT>",
+        )
+    )
+
+
+def _apply_chat_template(obj: Any, messages: Sequence[Any]) -> str:
+    if not hasattr(obj, "apply_chat_template"):
+        return ""
+    try:
+        return str(
+            obj.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+        )
+    except ValueError as exc:
+        if "chat_template" in str(exc):
+            return ""
+        raise
+
+
+def _chat_text(
+    processor: Any,
+    request: Mapping[str, Any],
+    fallback_prompt: str,
+    fallback_template: str,
+) -> str:
+    messages = request.get("messages")
+    messages = messages if isinstance(messages, list) else []
+    rendered = _apply_chat_template(processor, messages)
+    tokenizer = getattr(processor, "tokenizer", None)
+    if not rendered and tokenizer is not None:
+        rendered = _apply_chat_template(tokenizer, messages)
+    if rendered or _has_image_placeholder(fallback_prompt):
+        return rendered or fallback_prompt
+    return (
+        fallback_template.replace("{prompt}", fallback_prompt)
+        if fallback_template
+        else fallback_prompt
+    )
+
+
+def _to_device(batch: Any, device: Any) -> Any:
+    if hasattr(batch, "to"):
+        return batch.to(device)
+    return {
+        key: value.to(device) if hasattr(value, "to") else value
+        for key, value in batch.items()
+    }
+
+
+def _generation_settings(
+    arguments: argparse.Namespace,
+    manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    defaults = manifest.get("generation", {})
+    defaults = defaults if isinstance(defaults, dict) else {}
+    return {
+        "max_new_tokens": (
+            arguments.max_new_tokens
+            if arguments.max_new_tokens is not None
+            else int(defaults.get("max_new_tokens", 8))
+        ),
+        "temperature": (
+            arguments.temperature
+            if arguments.temperature is not None
+            else float(defaults.get("temperature", 1.0))
+        ),
+        "top_k": (
+            arguments.top_k
+            if arguments.top_k is not None
+            else int(defaults.get("top_k", 1))
+        ),
+        "top_p": (
+            arguments.top_p
+            if arguments.top_p is not None
+            else float(defaults.get("top_p", 1.0))
+        ),
+        "seed": (
+            arguments.seed
+            if arguments.seed is not None
+            else int(defaults.get("seed", -1))
+        ),
+        "do_sample": arguments.do_sample
+        or bool(defaults.get("do_sample", False)),
+    }
+
+
+def _load_runtime(
+    arguments: argparse.Namespace,
+    torch_module: Any,
+    transformers_module: Any,
+    processor_class: Any,
+) -> tuple[Any, Any, Any]:
+    transformers_module.logging.set_verbosity_error()
+    processor = processor_class.from_pretrained(
+        arguments.model,
+        trust_remote_code=arguments.trust_remote_code,
+        local_files_only=arguments.local_files_only,
+    )
+    model_kwargs = {
+        "torch_dtype": _model_dtype(torch_module, arguments.dtype),
+        "trust_remote_code": arguments.trust_remote_code,
+        "local_files_only": arguments.local_files_only,
+    }
+    if arguments.device_map:
+        model_kwargs["device_map"] = arguments.device_map
+    if arguments.attn_impl:
+        model_kwargs["attn_implementation"] = arguments.attn_impl
+    model = _load_model(
+        transformers_module,
+        arguments.model,
+        model_kwargs,
+    )
+    if arguments.device_map:
+        device = model.device
+    else:
+        device = torch_module.device(arguments.device)
+        model.to(device)
+    return processor, model, device
+
+
+def _is_deepseek_ocr(model_id: str, model: Any) -> bool:
+    return "deepseek-ocr" in model_id.lower() and hasattr(model, "infer")
+
+
+def _deepseek_prompt(prompt: str) -> str:
+    return prompt if "<image>" in prompt else f"<image>\n{prompt}"
+
+
+def _deepseek_response(
+    *,
+    model: Any,
+    processor: Any,
+    prompt_row: Mapping[str, Any],
+    output_root: Path,
+) -> dict[str, Any]:
+    images = [str(path) for path in prompt_row.get("images", [])]
+    if len(images) != 1:
+        raise ValueError("DeepSeek-OCR reference expects exactly one image")
+    sample_id = str(prompt_row.get("sample_id", "vlm"))
+    start = time.perf_counter()
+    output_text = model.infer(
+        processor,
+        prompt=_deepseek_prompt(str(prompt_row.get("prompt", ""))),
+        image_file=images[0],
+        output_path=str(output_root / sample_id),
+        save_results=False,
+        eval_mode=True,
+    )
+    wall_ms = (time.perf_counter() - start) * 1000.0
+    output_text = "" if output_text is None else str(output_text)
+    try:
+        token_ids = [
+            int(token_id)
+            for token_id in processor(
+                output_text,
+                add_special_tokens=False,
+            ).input_ids
+        ]
+    except Exception:
+        token_ids = []
+    return {
+        "sample_id": sample_id,
+        "output_text": output_text,
+        "generated_tokens": len(token_ids),
+        "generated_token_ids": token_ids,
+        "wall_ms": wall_ms,
+        "source": "hf",
+    }
+
+
+def _generate_kwargs(
+    processor: Any,
+    settings: Mapping[str, Any],
+) -> dict[str, Any]:
+    tokenizer = getattr(processor, "tokenizer", None)
+    pad_token_id = getattr(tokenizer, "pad_token_id", None)
+    eos_token_id = getattr(tokenizer, "eos_token_id", None)
+    if tokenizer is not None and pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
+        pad_token_id = tokenizer.pad_token_id
+    kwargs = {
+        "max_new_tokens": settings["max_new_tokens"],
+        "do_sample": settings["do_sample"],
+        "temperature": settings["temperature"],
+        "top_k": settings["top_k"],
+        "top_p": settings["top_p"],
+        "num_beams": 1,
+    }
+    if pad_token_id is not None:
+        kwargs["pad_token_id"] = pad_token_id
+    if eos_token_id is not None:
+        kwargs["eos_token_id"] = eos_token_id
+    return kwargs
+
+
+def _generated_text(processor: Any, generated: Any) -> str:
+    if hasattr(processor, "batch_decode"):
+        return processor.batch_decode(
+            generated.unsqueeze(0),
+            skip_special_tokens=False,
+        )[0]
+    tokenizer = getattr(processor, "tokenizer", None)
+    if tokenizer is not None:
+        return tokenizer.decode(generated, skip_special_tokens=False)
+    return str(generated.tolist())
+
+
+def _vlm_response(
+    *,
+    torch_module: Any,
+    processor: Any,
+    model: Any,
+    device: Any,
+    request: Mapping[str, Any],
+    prompt_row: Mapping[str, Any],
+    source_index: int,
+    settings: Mapping[str, Any],
+    fallback_template: str,
+) -> dict[str, Any]:
+    image_paths = [str(path) for path in prompt_row.get("images", [])]
+    if len(image_paths) != 1:
+        raise ValueError("VLM reference expects exactly one image")
+    prompt = _chat_text(
+        processor,
+        request,
+        str(prompt_row.get("prompt", "")),
+        fallback_template,
+    )
+    inputs = processor(
+        text=[prompt],
+        images=_load_images(image_paths),
+        padding=True,
+        return_tensors="pt",
+    )
+    inputs = _to_device(inputs, device)
+    seed = int(settings["seed"])
+    if seed >= 0:
+        torch_module.manual_seed(seed + source_index)
+        if torch_module.cuda.is_available():
+            torch_module.cuda.manual_seed_all(seed + source_index)
+    start = time.perf_counter()
+    with torch_module.inference_mode():
+        output_ids = model.generate(
+            **inputs,
+            **_generate_kwargs(processor, settings),
+        )
+    wall_ms = (time.perf_counter() - start) * 1000.0
+    generated = output_ids[0, int(inputs["input_ids"].shape[1]) :]
+    return {
+        "sample_id": prompt_row.get("sample_id", f"vlm_{source_index:06d}"),
+        "output_text": _generated_text(processor, generated),
+        "generated_tokens": int(generated.shape[0]),
+        "generated_token_ids": [
+            int(token_id) for token_id in generated.tolist()
+        ],
+        "wall_ms": wall_ms,
+        "source": "hf",
+    }
+
+
+def run(arguments: argparse.Namespace) -> None:
+    torch, transformers, processor_class = _runtime_dependencies()
+    manifest = _load_json(arguments.manifest)
+    answers = _load_json(arguments.answers)
+    prompt_rows = _load_jsonl(arguments.prompts)
+    requests = answers.get("requests", [])
+    if not isinstance(requests, list) or len(requests) != len(prompt_rows):
+        raise ValueError("answers and prepared prompts must contain the same samples")
+    selected = _selected_indices(prompt_rows, arguments.sample_id)
+    processor, model, device = _load_runtime(
+        arguments,
+        torch,
+        transformers,
+        processor_class,
+    )
+    settings = _generation_settings(arguments, manifest)
+    task_config = manifest.get("task_eval", {})
+    task_config = task_config if isinstance(task_config, dict) else {}
+    fallback_template = str(
+        task_config.get("vlm_fallback_prompt_template", "") or ""
+    )
+    responses = []
+    for run_index, source_index in enumerate(selected):
+        prompt_row = prompt_rows[source_index]
+        request = requests[source_index]
+        if not isinstance(request, dict):
+            raise ValueError(f"request {source_index} must be a JSON object")
+        if _is_deepseek_ocr(arguments.model, model):
+            response = _deepseek_response(
+                model=model,
+                processor=processor,
+                prompt_row=prompt_row,
+                output_root=arguments.predictions.parent
+                / "hf_deepseek_ocr_outputs",
+            )
+        else:
+            response = _vlm_response(
+                torch_module=torch,
+                processor=processor,
+                model=model,
+                device=device,
+                request=request,
+                prompt_row=prompt_row,
+                source_index=source_index,
+                settings=settings,
+                fallback_template=fallback_template,
+            )
+        responses.append(response)
+        print(
+            f"[transformers.native_vlm] sample={run_index + 1}/{len(selected)}",
+            file=sys.stderr,
+        )
+    arguments.raw_output.parent.mkdir(parents=True, exist_ok=True)
+    with arguments.raw_output.open("w", encoding="utf-8") as raw_file:
+        for response in responses:
+            raw_file.write(json.dumps(response, ensure_ascii=False) + "\n")
+    arguments.predictions.write_text(
+        json.dumps({"responses": responses}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    _write_reproduction_metadata(arguments)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a VLM directly through Transformers."
+    )
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--reference-family", default="")
+    parser.add_argument("--prompts", type=Path, required=True)
+    parser.add_argument("--answers", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--predictions", type=Path, required=True)
+    parser.add_argument("--raw-output", type=Path, required=True)
+    parser.add_argument("--repro-metadata", type=Path)
+    parser.add_argument("--sample-id", default="")
+    parser.add_argument(
+        "--dtype",
+        choices=("auto", "float16", "bfloat16"),
+        default="auto",
+    )
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--device-map", default="")
+    parser.add_argument("--attn-impl", default="")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--local-files-only", action="store_true")
+    parser.add_argument("--do-sample", action="store_true")
+    parser.add_argument("--apply-chat-template", action="store_true")
+    parser.add_argument("--max-new-tokens", type=int)
+    parser.add_argument("--temperature", type=float)
+    parser.add_argument("--top-k", type=int)
+    parser.add_argument("--top-p", type=float)
+    parser.add_argument("--seed", type=int)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    run(build_parser().parse_args(argv))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -8346,6 +8346,30 @@ def _manifest_tensor_parallel_size(build_args: dict[str, Any]) -> int | None:
     return None
 
 
+def _model_asset_path(model: dict[str, Any], value: str) -> Path:
+    asset = Path(value)
+    if asset.is_absolute():
+        return asset
+    manifest = Path(str(model.get("manifest", "") or ""))
+    if manifest:
+        if not manifest.is_absolute():
+            manifest = REPO_ROOT / manifest
+        model_dir = (
+            manifest.parent.parent
+            if manifest.parent.name == "manifests"
+            else manifest.parent
+        )
+        if asset.parts[:3] == ("tests", "e2e", "data"):
+            candidate = model_dir / "data" / asset.name
+        elif asset.parts and asset.parts[0] == "data":
+            candidate = model_dir / asset
+        else:
+            candidate = model_dir / "data" / asset
+        if candidate.is_file():
+            return candidate
+    return REPO_ROOT / "tests" / "e2e" / "data" / asset
+
+
 def build_bundle_command(
     model: dict[str, Any],
     *,
@@ -8404,7 +8428,7 @@ def build_bundle_command(
             cmd.extend([flag, str(value)])
     fp8_scales = model.get("fp8_scales")
     if fp8_scales:
-        scales_path = REPO_ROOT / "tests" / "e2e" / "data" / str(fp8_scales)
+        scales_path = _model_asset_path(model, str(fp8_scales))
         if scales_path.is_file():
             cmd.extend(["--fp8-scales", str(scales_path)])
     if extra_build_args:

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -29,7 +29,7 @@ import warnings
 from collections import Counter, defaultdict
 from itertools import product
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -8308,7 +8308,10 @@ def requested_build_max_cache_length(
     return max(model_cache, suite_cache, prompt_cache)
 
 
-def bundle_max_cache_length(bundle_path: Path, trtmc_binary: str) -> int | None:
+def bundle_inspection(
+    bundle_path: Path,
+    trtmc_binary: str,
+) -> dict[str, str]:
     try:
         proc = subprocess.run(
             [trtmc_binary, "inspect", str(bundle_path)],
@@ -8318,13 +8321,50 @@ def bundle_max_cache_length(bundle_path: Path, trtmc_binary: str) -> int | None:
             timeout=60,
         )
     except Exception:
-        return None
+        return {}
     if proc.returncode != 0:
+        return {}
+    values = {}
+    for label, value in re.findall(r"^([^:\n]+):\s+(.+?)\s*$", proc.stdout, re.MULTILINE):
+        values[label.strip()] = value.strip()
+    return values
+
+
+def bundle_max_cache_length(bundle_path: Path, trtmc_binary: str) -> int | None:
+    value = bundle_inspection(bundle_path, trtmc_binary).get("Max cache length")
+    try:
+        return int(value) if value is not None else None
+    except ValueError:
         return None
-    match = re.search(r"^Max cache length:\s+(\d+)\s*$", proc.stdout, re.MULTILINE)
-    if not match:
-        return None
-    return int(match.group(1))
+
+
+def runtime_tensorrt_abi() -> str:
+    try:
+        import tensorrt
+    except Exception:
+        return ""
+    parts = str(tensorrt.__version__).split(".")
+    return ".".join(parts[:2]) if len(parts) >= 2 else ""
+
+
+def _bundle_can_be_reused(
+    inspection: Mapping[str, str],
+    *,
+    max_cache_length: int | None,
+    allow_unknown: bool,
+) -> bool:
+    if not inspection:
+        return allow_unknown
+    raw_cache = inspection.get("Max cache length")
+    if max_cache_length is not None and raw_cache is not None:
+        try:
+            if int(raw_cache) < max_cache_length:
+                return False
+        except ValueError:
+            return False
+    bundle_abi = inspection.get("TRT ABI", "")
+    runtime_abi = runtime_tensorrt_abi()
+    return not bundle_abi or not runtime_abi or bundle_abi == runtime_abi
 
 
 def _remove_bundle_before_or_after_replacement(
@@ -8347,10 +8387,12 @@ def ensure_bundle(
     log_path: Path | None = None,
 ) -> tuple[Path, bool]:
     if bundle_path.is_file() and not force_build:
-        if max_cache_length is None:
-            return bundle_path, False
-        existing_cache = bundle_max_cache_length(bundle_path, trtmc_binary)
-        if existing_cache is None or existing_cache >= max_cache_length:
+        inspection = bundle_inspection(bundle_path, trtmc_binary)
+        if _bundle_can_be_reused(
+            inspection,
+            max_cache_length=max_cache_length,
+            allow_unknown=not replace_existing,
+        ):
             return bundle_path, False
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
     _remove_bundle_before_or_after_replacement(

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -52,6 +52,7 @@ from tests.e2e_harness.registry import (  # noqa: E402
 DEFAULT_SUITES = REPO_ROOT / "tests" / "task_eval" / "validation_suites.yaml"
 DEFAULT_MODELS_DIR = REPO_ROOT / "tests" / "e2e" / "models"
 DEFAULT_WAIVES = REPO_ROOT / "tests" / "e2e" / "waives.txt"
+REFERENCE_RUNNER = REPO_ROOT / "tools" / "trtmc_reference.py"
 ERROR_OUTPUT_TEXT = "TensorRT Edge LLM cannot handle this request. Fails."
 CHOICE_LETTERS = set("ABCDEFGHIJ")
 GPT_OSS_MMLU_SYSTEM_PROMPT = "You are a helpful assistant. Answer with only the option letter."
@@ -2964,6 +2965,17 @@ def predictions_file_valid(
             isinstance(row, dict) and _generated_token_ids(row) is not None for row in responses
         )
     return True
+
+
+def reference_cache_metadata(work_dir: Path) -> dict[str, Any]:
+    path = work_dir / "hf_cache.json"
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 def _parse_generated_token_ids(text: str) -> list[int] | None:
@@ -8322,6 +8334,7 @@ def ensure_bundle(
     trtmc_binary: str,
     max_cache_length: int | None = None,
     force_build: bool = False,
+    replace_existing: bool = False,
     extra_build_args: list[str] | None = None,
     log_path: Path | None = None,
 ) -> tuple[Path, bool]:
@@ -8332,6 +8345,8 @@ def ensure_bundle(
         if existing_cache is None or existing_cache >= max_cache_length:
             return bundle_path, False
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    if replace_existing and bundle_path.exists():
+        bundle_path.unlink()
     cmd = build_bundle_command(
         model,
         trtmc_binary=trtmc_binary,
@@ -8346,6 +8361,8 @@ def ensure_bundle(
         log_f.flush()
         proc = subprocess.run(cmd, check=False, text=True, stdout=log_f, stderr=subprocess.STDOUT)
     if proc.returncode != 0:
+        if replace_existing and bundle_path.exists():
+            bundle_path.unlink()
         raise RuntimeError(
             f"Bundle build failed for {model['name']} rc={proc.returncode}; see {log_path}"
         )
@@ -8479,8 +8496,8 @@ def run_hf_reference_subprocess(
     hf_python = model_reference_python(model, base_python)
     cmd = [
         hf_python,
-        str(Path(__file__).resolve()),
-        "run-hf",
+        str(REFERENCE_RUNNER),
+        "run",
         "--model",
         str(hf_args.model),
         "--family",
@@ -8498,6 +8515,11 @@ def run_hf_reference_subprocess(
         "--device",
         str(hf_args.device),
     ]
+    reference_cache_dir = str(
+        getattr(args, "reference_cache_dir", "") or ""
+    )
+    if reference_cache_dir:
+        cmd.extend(["--cache-dir", reference_cache_dir])
     if hf_args.device_map:
         cmd.extend(["--device-map", str(hf_args.device_map)])
     if hf_args.attn_impl:
@@ -8512,6 +8534,8 @@ def run_hf_reference_subprocess(
         cmd.append("--apply-chat-template")
     if hf_args.elf_reference_repo:
         cmd.extend(["--elf-reference-repo", str(hf_args.elf_reference_repo)])
+    if bool(getattr(args, "force_hf", False)):
+        cmd.append("--force")
     for flag, value in (
         ("--max-new-tokens", hf_args.max_new_tokens),
         ("--temperature", hf_args.temperature),
@@ -9419,20 +9443,14 @@ def eval_one_model(
         )
 
     answers_path = work_dir / "answers.json"
-    hf_predictions = work_dir / "hf_predictions.json"
-    prompts_changed = bool(
-        prompt_normalization and prompt_normalization.get("truncated_count", 0)
-    )
-    hf_reused = (
-        not no_hf_reference
-        and predictions_file_valid(hf_predictions, answers_path)
-        and not args.force_hf
-        and not prompts_changed
-    )
-    if not no_hf_reference and not hf_reused:
+    hf_reused = False
+    if not no_hf_reference:
         # Run HF in its own process so its GPU memory is fully reclaimed before
         # the TRT bundle build and TRTFB inference for this model.
         run_hf_reference_subprocess(args, model, work_dir)
+    hf_cache = reference_cache_metadata(work_dir)
+    if hf_cache.get("status") in {"reused", "adopted"}:
+        hf_reused = True
 
     if args.bundle:
         if len(args.model or []) != 1:
@@ -9491,6 +9509,9 @@ def eval_one_model(
         trtmc_binary=args.trtmc_binary,
         max_cache_length=max_cache_length,
         force_build=args.force_build,
+        replace_existing=bool(
+            getattr(args, "replace_bundle_on_build", False)
+        ),
         extra_build_args=args.extra_build_arg,
         log_path=work_dir / "build.log",
     )
@@ -9514,6 +9535,8 @@ def eval_one_model(
         if hf_reused
         else "ran",
         "hf_reused": hf_reused,
+        "hf_cache_status": str(hf_cache.get("status", "") or ""),
+        "hf_cache_key": str(hf_cache.get("key", "") or ""),
         "bundle_built": built,
         "model_plugin_dir": str(getattr(args, "model_plugin_dir", "") or ""),
     }
@@ -10429,24 +10452,6 @@ def build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--subject", default="")
     p.add_argument("--sample-seed", type=int)
 
-    p = sub.add_parser("run-hf")
-    p.add_argument("--model", required=True)
-    p.add_argument("--family", default="")
-    p.add_argument("--reference-family", default="")
-    p.add_argument("--work-dir", required=True)
-    p.add_argument("--predictions")
-    p.add_argument("--raw-output")
-    p.add_argument("--dtype", choices=["auto", "float16", "bfloat16"], default="auto")
-    p.add_argument("--device", default="cuda")
-    p.add_argument("--device-map", default="")
-    p.add_argument("--attn-impl", default="")
-    p.add_argument("--trust-remote-code", action="store_true")
-    p.add_argument("--local-files-only", action="store_true")
-    p.add_argument("--do-sample", action="store_true")
-    p.add_argument("--apply-chat-template", action="store_true")
-    p.add_argument("--elf-reference-repo", default="")
-    add_generation_args(p)
-
     p = sub.add_parser("run-trtfb")
     p.add_argument("--bundle", required=True)
     p.add_argument("--work-dir", required=True)
@@ -10559,7 +10564,17 @@ def build_arg_parser() -> argparse.ArgumentParser:
     p.add_argument("--subject", default="")
     p.add_argument("--sample-seed", type=int)
     p.add_argument("--force-hf", action="store_true", help="Regenerate HF reference outputs.")
+    p.add_argument(
+        "--reference-cache-dir",
+        default="",
+        help="Shared setting-keyed cache managed by tools/trtmc_reference.py.",
+    )
     p.add_argument("--force-build", action="store_true", help="Rebuild the .trtfb bundle.")
+    p.add_argument(
+        "--replace-bundle-on-build",
+        action="store_true",
+        help="Remove the existing bundle before rebuilding it at the same path.",
+    )
     p.add_argument(
         "--require-prebuilt-bundles",
         action="store_true",
@@ -11114,9 +11129,6 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_prepare_media(args)
     if args.cmd == "prepare-ci-dataset":
         return cmd_prepare_ci_dataset(args)
-    if args.cmd == "run-hf":
-        run_hf_reference(args)
-        return 0
     if args.cmd == "run-trtfb":
         run_trtfb(args)
         return 0

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -451,6 +451,7 @@ def manifest_record(path: Path) -> dict[str, Any]:
         "name": model_name,
         "manifest": str(path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path),
         "hf_id": raw.get("hf_id") or raw.get("model_id", ""),
+        "hf_revision": str(raw.get("hf_revision", "") or ""),
         "bundle": raw.get("bundle", f"{path.stem}.trtfb"),
         "family": raw.get("family", ""),
         "runtime_strategy": runtime_strategy,
@@ -2758,9 +2759,9 @@ def prepare_task_dataset(
     raise ValueError(f"Unsupported task-eval dataset kind {dataset_kind!r}")
 
 
-def load_jsonl(path: Path) -> list[dict[str, Any]]:
+def load_jsonl(path: Path, *, errors: str = "strict") -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
-    with path.open("r", encoding="utf-8") as f:
+    with path.open("r", encoding="utf-8", errors=errors) as f:
         for line in f:
             line = line.strip()
             if line:
@@ -2999,7 +3000,7 @@ def _parse_transcribe_stdout(text: str) -> str:
 
 def convert_trtfb_jsonl_to_predictions(raw_path: Path, predictions_path: Path) -> None:
     rows = []
-    for row in load_jsonl(raw_path):
+    for row in load_jsonl(raw_path, errors="replace"):
         rows.append(
             {
                 "sample_id": row.get("sample_id", ""),
@@ -4760,7 +4761,10 @@ def _first_token_divergence(reference: list[int], actual: list[int]) -> int:
 def _diffusion_text_shared_sampling_inputs(row: dict[str, Any]) -> dict[str, str]:
     explicit = row.get("shared_sampling_inputs", {})
     if isinstance(explicit, dict) and explicit:
-        return {str(key): str(value) for key, value in explicit.items()}
+        return {
+            str(key): str(Path(str(value)).resolve())
+            for key, value in explicit.items()
+        }
     shared_dir = str(row.get("shared_inputs_dir", "") or "")
     if not shared_dir:
         return {}
@@ -8383,11 +8387,16 @@ def build_bundle_command(
         trtmc_binary,
         "build",
         str(model["hf_id"]),
+    ]
+    hf_revision = str(model.get("hf_revision", "") or "")
+    if hf_revision:
+        cmd.extend(["--model-revision", hf_revision])
+    cmd.extend([
         "-o",
         str(bundle_path),
         "--max-cache-length",
         str(cache_length),
-    ]
+    ])
     build_args = model.get("build_args", {})
     method = _manifest_build_method(build_args)
     if method:
@@ -8616,6 +8625,7 @@ def _namespace_for_run_hf(
 ) -> argparse.Namespace:
     return argparse.Namespace(
         model=model["hf_id"],
+        model_revision=str(model.get("hf_revision", "") or ""),
         family=model.get("family", ""),
         reference_family=model.get("reference_family", ""),
         work_dir=str(work_dir),
@@ -8711,6 +8721,8 @@ def run_hf_reference_subprocess(
         "--device",
         str(hf_args.device),
     ]
+    if hf_args.model_revision:
+        cmd.extend(["--model-revision", str(hf_args.model_revision)])
     reference_cache_dir = str(
         getattr(args, "reference_cache_dir", "") or ""
     )

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -29,7 +29,7 @@ import warnings
 from collections import Counter, defaultdict
 from itertools import product
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -3024,15 +3024,84 @@ def _write_dataset_benchmark_reproduction(
     template = list(command)
     template[2] = "{input_jsonl}"
     template[3] = "{trtmc_raw_jsonl}"
+    base_seed = None
+    if "--seed" in template:
+        seed_index = template.index("--seed") + 1
+        base_seed = int(template[seed_index])
+        template[seed_index] = "{sample_seed}"
     payload = {
         "schema_version": "trtmc.native-trtmc-reproduction/v1",
         "backend": "trtmc_dataset_benchmark",
         "command": template,
     }
+    if base_seed is not None:
+        payload["base_seed"] = base_seed
     (work_dir / "trtfb_repro.json").write_text(
         json.dumps(payload, indent=2),
         encoding="utf-8",
     )
+
+
+_NATIVE_TRTMC_COMMANDS = "trtfb_native_commands.jsonl"
+
+
+def _reset_native_trtmc_commands(work_dir: Path) -> None:
+    (work_dir / _NATIVE_TRTMC_COMMANDS).write_text("", encoding="utf-8")
+
+
+def _append_native_trtmc_command(
+    work_dir: Path,
+    sample_id: str,
+    command: Sequence[Any],
+) -> None:
+    tokens = [str(token) for token in command]
+    if not tokens:
+        return
+    with (work_dir / _NATIVE_TRTMC_COMMANDS).open("a", encoding="utf-8") as output:
+        output.write(
+            json.dumps(
+                {"sample_id": sample_id, "command": tokens},
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+
+
+def _command_tokens(value: Any) -> list[str]:
+    if isinstance(value, (list, tuple)) and value and all(
+        isinstance(token, (str, int, float, Path)) for token in value
+    ):
+        return [str(token) for token in value]
+    if isinstance(value, str):
+        tokens = shlex.split(value)
+        if len(tokens) > 1:
+            return tokens
+    return []
+
+
+def _native_command_from_metadata(metadata: Any) -> list[str]:
+    if not isinstance(metadata, Mapping):
+        return []
+    command = _command_tokens(metadata.get("command"))
+    if command:
+        return command
+    for value in metadata.values():
+        nested = _native_command_from_metadata(value)
+        if nested:
+            return nested
+    return []
+
+
+def _record_output_native_command(
+    work_dir: Path,
+    sample_id: str,
+    output: Any,
+) -> None:
+    raw_metadata = getattr(output, "metadata", {})
+    metadata = raw_metadata if isinstance(raw_metadata, Mapping) else {}
+    command = _native_command_from_metadata(metadata)
+    if command:
+        _append_native_trtmc_command(work_dir, sample_id, command)
 
 
 def run_vlm_trtfb(args: argparse.Namespace) -> None:
@@ -3063,6 +3132,7 @@ def run_vlm_trtfb(args: argparse.Namespace) -> None:
 
     rows: list[dict[str, Any]] = []
     prompt_rows = load_jsonl(work_dir / "prompts.jsonl")
+    _reset_native_trtmc_commands(work_dir)
     with (
         raw_output.open("w", encoding="utf-8") as raw_f,
         log_path.open("w", encoding="utf-8") as log_f,
@@ -3107,6 +3177,11 @@ def run_vlm_trtfb(args: argparse.Namespace) -> None:
             if not bool(defaults.get("enable_thinking", True)):
                 cmd.append("--no-thinking")
 
+            _append_native_trtmc_command(
+                work_dir,
+                str(prompt_row.get("sample_id", f"vlm_{idx:06d}")),
+                cmd,
+            )
             log_f.write(f"$ {' '.join(cmd)}\n")
             start = time.perf_counter()
             proc = subprocess.run(
@@ -3166,6 +3241,7 @@ def run_asr_trtfb(args: argparse.Namespace) -> None:
 
     rows: list[dict[str, Any]] = []
     prompt_rows = load_jsonl(work_dir / "prompts.jsonl")
+    _reset_native_trtmc_commands(work_dir)
     with (
         raw_output.open("w", encoding="utf-8") as raw_f,
         log_path.open("w", encoding="utf-8") as log_f,
@@ -3187,6 +3263,11 @@ def run_asr_trtfb(args: argparse.Namespace) -> None:
                 cmd.extend(["--hf-python", args.hf_python])
             cmd.extend(_asr_runtime_flags(prompt_row, defaults))
 
+            _append_native_trtmc_command(
+                work_dir,
+                str(prompt_row.get("sample_id", f"asr_{idx:06d}")),
+                cmd,
+            )
             log_f.write(f"$ {' '.join(cmd)}\n")
             start = time.perf_counter()
             proc = subprocess.run(
@@ -6672,6 +6753,7 @@ def run_time_series_trtfb(args: argparse.Namespace) -> None:
     log_path = work_dir / (args.log or "trtfb_run.log")
     bundle_path = Path(args.bundle).resolve()
     responses: list[dict[str, Any]] = []
+    _reset_native_trtmc_commands(work_dir)
     with (
         raw_path.open("w", encoding="utf-8") as raw_file,
         log_path.open("w", encoding="utf-8") as log_file,
@@ -6689,6 +6771,7 @@ def run_time_series_trtfb(args: argparse.Namespace) -> None:
                 model_plugin_dir=str(getattr(args, "model_plugin_dir", "") or ""),
             )
             output = runner.run_stage(case, _time_series_full_inference_stage(case), context)
+            _record_output_native_command(work_dir, case.name, output)
             log_file.write(
                 json.dumps(
                     {
@@ -6893,6 +6976,7 @@ def run_vision_trtfb(args: argparse.Namespace) -> None:
     pred_path = work_dir / (args.predictions or "trtfb_predictions.json")
     bundle_path = Path(args.bundle).resolve()
     responses: list[dict[str, Any]] = []
+    _reset_native_trtmc_commands(work_dir)
     with raw_path.open("w", encoding="utf-8") as raw_file:
         for index, prompt_row in enumerate(prompt_rows):
             case = _vision_case_for_request(template, prompt_row, task_eval_config, index)
@@ -6909,6 +6993,7 @@ def run_vision_trtfb(args: argparse.Namespace) -> None:
             output = runner.run_stage(
                 case, _vision_full_inference_stage(case), context
             )
+            _record_output_native_command(work_dir, case.name, output)
             response = _vision_response(
                 case=case,
                 source="trtfb",
@@ -7067,6 +7152,7 @@ def run_reranking_trtfb(args: argparse.Namespace) -> None:
     metadata_path = work_dir / (args.log or "trtfb_run.log")
     bundle_path = Path(args.bundle).resolve()
     responses: list[dict[str, Any]] = []
+    _reset_native_trtmc_commands(work_dir)
     with (
         raw_path.open("w", encoding="utf-8") as raw_file,
         metadata_path.open("w", encoding="utf-8") as metadata_file,
@@ -7086,6 +7172,7 @@ def run_reranking_trtfb(args: argparse.Namespace) -> None:
             output = runner.run_stage(
                 case, _reranking_full_inference_stage(case), context
             )
+            _record_output_native_command(work_dir, case.name, output)
             response = _reranking_response(
                 case=case, source="trtfb", output=output, prompt_row=prompt_row
             )
@@ -7652,6 +7739,7 @@ def run_diffusion_trtfb(args: argparse.Namespace) -> None:
     log_path = work_dir / (getattr(args, "log", "") or "trtfb_run.log")
     bundle_path = Path(args.bundle).resolve()
     responses: list[dict[str, Any]] = []
+    _reset_native_trtmc_commands(work_dir)
     with (
         raw_path.open("w", encoding="utf-8") as raw_file,
         log_path.open("w", encoding="utf-8") as log_file,
@@ -7671,6 +7759,7 @@ def run_diffusion_trtfb(args: argparse.Namespace) -> None:
             output = runner.run_stage(
                 case, _diffusion_end_to_end_stage(case), context
             )
+            _record_output_native_command(work_dir, case.name, output)
             command = (
                 output.metadata.get("command")
                 if isinstance(output.metadata, dict)
@@ -7752,6 +7841,7 @@ def run_diffusion_text_trtfb(args: argparse.Namespace) -> None:
     bundle_path = Path(args.bundle).resolve()
     base_seed = int(generation.get("seed", 42))
     responses: list[dict[str, Any]] = []
+    _reset_native_trtmc_commands(work_dir)
     with raw_path.open("w", encoding="utf-8") as raw_file:
         for index, prompt_row in enumerate(prompt_rows):
             case = copy.deepcopy(template)
@@ -7804,6 +7894,7 @@ def run_diffusion_text_trtfb(args: argparse.Namespace) -> None:
                 model_plugin_dir=str(getattr(args, "model_plugin_dir", "") or ""),
             )
             output = runner.run_stage(case, StageSpec(name="decoded_text", required=True), context)
+            _record_output_native_command(work_dir, sample_id, output)
             generated_samples = output.data.get("generated_samples", [])
             generated = generated_samples[0] if generated_samples else {}
             output_text = str(
@@ -7973,6 +8064,7 @@ def run_tts_trtfb(args: argparse.Namespace) -> None:
     if args.cuda_visible_devices:
         env["CUDA_VISIBLE_DEVICES"] = args.cuda_visible_devices
     responses: list[dict[str, Any]] = []
+    _reset_native_trtmc_commands(work_dir)
     with (
         raw_output.open("w", encoding="utf-8") as raw_f,
         log_path.open("w", encoding="utf-8") as log_f,
@@ -8002,6 +8094,7 @@ def run_tts_trtfb(args: argparse.Namespace) -> None:
                 sample_set_tokens.append(f"audio_bark.seed={seed + idx}")
             for token in sample_set_tokens:
                 cmd.extend(["--set", token])
+            _append_native_trtmc_command(work_dir, sample_id, cmd)
             log_f.write(f"$ {' '.join(cmd)}\n")
             start = time.perf_counter()
             proc = subprocess.run(cmd, check=False, text=True, capture_output=True, env=env)
@@ -8065,6 +8158,7 @@ def run_encoder_embedding_trtfb(args: argparse.Namespace) -> None:
     pred_path = work_dir / (args.predictions or "trtfb_predictions.json")
     log_path = work_dir / (args.log or "trtfb_run.log")
     responses: list[dict[str, Any]] = []
+    _reset_native_trtmc_commands(work_dir)
     env = os.environ.copy()
     if args.cuda_visible_devices:
         env["CUDA_VISIBLE_DEVICES"] = args.cuda_visible_devices
@@ -8090,6 +8184,11 @@ def run_encoder_embedding_trtfb(args: argparse.Namespace) -> None:
                 cmd.extend(["--config", args.config])
             for token in args.set or []:
                 cmd.extend(["--set", token])
+            _append_native_trtmc_command(
+                work_dir,
+                str(prompt_row["sample_id"]),
+                cmd,
+            )
             start = time.perf_counter()
             proc = subprocess.run(cmd, check=False, text=True, capture_output=True, env=env)
             wall_ms = (time.perf_counter() - start) * 1000.0

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -16,6 +16,7 @@ import math
 import os
 import random
 import re
+import shlex
 import shutil
 import struct
 import traceback
@@ -8161,6 +8162,8 @@ def run_trtfb(args: argparse.Namespace) -> None:
         env["CUDA_VISIBLE_DEVICES"] = args.cuda_visible_devices
     log_path = work_dir / (args.log or "trtfb_run.log")
     with log_path.open("w", encoding="utf-8") as log_f:
+        log_f.write(f"$ {shlex.join(cmd)}\n")
+        log_f.flush()
         proc = subprocess.run(
             cmd, check=False, text=True, stdout=log_f, stderr=subprocess.STDOUT, env=env
         )
@@ -8323,6 +8326,8 @@ def ensure_bundle(
     log_path = log_path or bundle_path.with_suffix(".build.log")
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open("w", encoding="utf-8") as log_f:
+        log_f.write(f"$ {shlex.join(cmd)}\n")
+        log_f.flush()
         proc = subprocess.run(cmd, check=False, text=True, stdout=log_f, stderr=subprocess.STDOUT)
     if proc.returncode != 0:
         raise RuntimeError(
@@ -8506,6 +8511,8 @@ def run_hf_reference_subprocess(
     env.setdefault("TOKENIZERS_PARALLELISM", "false")
     env.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
     with log_path.open("w", encoding="utf-8") as log_f:
+        log_f.write(f"$ {shlex.join(cmd)}\n")
+        log_f.flush()
         proc = subprocess.run(
             cmd, check=False, text=True, stdout=log_f, stderr=subprocess.STDOUT, env=env
         )

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -3017,6 +3017,24 @@ def _trtmc_binary_from_args(args: argparse.Namespace) -> str:
     return str(getattr(args, "trtmc_binary", "") or "build/trtmc")
 
 
+def _write_dataset_benchmark_reproduction(
+    work_dir: Path,
+    command: list[str],
+) -> None:
+    template = list(command)
+    template[2] = "{input_jsonl}"
+    template[3] = "{trtmc_raw_jsonl}"
+    payload = {
+        "schema_version": "trtmc.native-trtmc-reproduction/v1",
+        "backend": "trtmc_dataset_benchmark",
+        "command": template,
+    }
+    (work_dir / "trtfb_repro.json").write_text(
+        json.dumps(payload, indent=2),
+        encoding="utf-8",
+    )
+
+
 def run_vlm_trtfb(args: argparse.Namespace) -> None:
     work_dir = Path(args.work_dir)
     defaults = generation_defaults(work_dir)
@@ -8185,6 +8203,7 @@ def run_trtfb(args: argparse.Namespace) -> None:
     if not bool(defaults.get("enable_thinking", True)):
         cmd.append("--no-thinking")
 
+    _write_dataset_benchmark_reproduction(work_dir, cmd)
     env = os.environ.copy()
     if args.cuda_visible_devices:
         env["CUDA_VISIBLE_DEVICES"] = args.cuda_visible_devices

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -8327,6 +8327,14 @@ def bundle_max_cache_length(bundle_path: Path, trtmc_binary: str) -> int | None:
     return int(match.group(1))
 
 
+def _remove_bundle_before_or_after_replacement(
+    bundle_path: Path,
+    replace_existing: bool,
+) -> None:
+    if replace_existing and (bundle_path.exists() or bundle_path.is_symlink()):
+        bundle_path.unlink()
+
+
 def ensure_bundle(
     model: dict[str, Any],
     *,
@@ -8345,8 +8353,10 @@ def ensure_bundle(
         if existing_cache is None or existing_cache >= max_cache_length:
             return bundle_path, False
     bundle_path.parent.mkdir(parents=True, exist_ok=True)
-    if replace_existing and bundle_path.exists():
-        bundle_path.unlink()
+    _remove_bundle_before_or_after_replacement(
+        bundle_path,
+        replace_existing,
+    )
     cmd = build_bundle_command(
         model,
         trtmc_binary=trtmc_binary,
@@ -8361,8 +8371,10 @@ def ensure_bundle(
         log_f.flush()
         proc = subprocess.run(cmd, check=False, text=True, stdout=log_f, stderr=subprocess.STDOUT)
     if proc.returncode != 0:
-        if replace_existing and bundle_path.exists():
-            bundle_path.unlink()
+        _remove_bundle_before_or_after_replacement(
+            bundle_path,
+            replace_existing,
+        )
         raise RuntimeError(
             f"Bundle build failed for {model['name']} rc={proc.returncode}; see {log_path}"
         )

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -7619,9 +7619,13 @@ def run_diffusion_trtfb(args: argparse.Namespace) -> None:
     artifacts_dir.mkdir(parents=True, exist_ok=True)
     raw_path = work_dir / (args.raw_output or "trtfb_raw.jsonl")
     pred_path = work_dir / (args.predictions or "trtfb_predictions.json")
+    log_path = work_dir / (getattr(args, "log", "") or "trtfb_run.log")
     bundle_path = Path(args.bundle).resolve()
     responses: list[dict[str, Any]] = []
-    with raw_path.open("w", encoding="utf-8") as raw_file:
+    with (
+        raw_path.open("w", encoding="utf-8") as raw_file,
+        log_path.open("w", encoding="utf-8") as log_file,
+    ):
         for index, prompt_row in enumerate(prompt_rows):
             case = _diffusion_case_for_prompt(template, prompt_row, generation, index)
             case.bundle = bundle_path.name
@@ -7637,6 +7641,18 @@ def run_diffusion_trtfb(args: argparse.Namespace) -> None:
             output = runner.run_stage(
                 case, _diffusion_end_to_end_stage(case), context
             )
+            command = (
+                output.metadata.get("command")
+                if isinstance(output.metadata, dict)
+                else None
+            )
+            if isinstance(command, list) and command:
+                log_file.write(
+                    f"$ {shlex.join(str(token) for token in command)}\n"
+                )
+            elif isinstance(command, str) and command:
+                log_file.write(f"$ {command}\n")
+            log_file.flush()
             response = _diffusion_response(case.name, "trtfb", output, case=case)
             response["prompt"] = str(prompt_row["prompt"])
             if response["returncode"] != 0 or response["num_frames"] < 1:

--- a/tools/test_impact.py
+++ b/tools/test_impact.py
@@ -1369,6 +1369,23 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
             covered_by=("TestSharedModules.test_python_profile_requirements_scope",),
         ),
         ClassificationRule(
+            priority=18,
+            name="validation_reference_requirements",
+            matcher=_path_equals(
+                "python/tensorrt_model_connect/"
+                "python_profile_requirements/reference_common.lock.txt"
+            ),
+            resolver=_match_result(
+                "validation_reference_requirements",
+                _no_models,
+                ["tools"],
+                False,
+            ),
+            covered_by=(
+                "TestUnitTiers.test_validation_reference_requirements_trigger_tools_tier",
+            ),
+        ),
+        ClassificationRule(
             priority=90,
             name="specialized_builder",
             matcher=_regex_rule(
@@ -1906,27 +1923,44 @@ def _classification_rules() -> Tuple[ClassificationRule, ...]:
         ),
         ClassificationRule(
             priority=487,
+            name="validation_tool",
+            matcher=_regex_rule(
+                r"tools/(?:reference/[^/]+\.py|"
+                r"trtmc_(?:compare|disagreements|reference|validate)\.py)$"
+            ),
+            resolver=_match_result("validation_tool", _no_models, ["tools"], False),
+            covered_by=("TestUnitTiers.test_validation_tool_triggers_tools_tier",),
+        ),
+        ClassificationRule(
+            priority=488,
             name="task_eval_config",
             matcher=_path_startswith("tests/task_eval/"),
             resolver=_match_result("task_eval_config", _no_models, ["tools"], False),
             covered_by=("TestUnitTiers.test_task_eval_suite_config_triggers_tools_tier",),
         ),
         ClassificationRule(
-            priority=488,
+            priority=489,
+            name="validation_config",
+            matcher=_path_equals("tests/validation/model_workloads.yaml"),
+            resolver=_match_result("validation_config", _no_models, ["tools"], False),
+            covered_by=("TestUnitTiers.test_validation_config_triggers_tools_tier",),
+        ),
+        ClassificationRule(
+            priority=490,
             name="test_impact_tool",
             matcher=_path_equals("tools/test_impact.py"),
             resolver=_match_result("test_impact_tool", _no_models, ["tools"], False),
             covered_by=("TestUnitTiers.test_test_impact_tool_triggers_tools_tier",),
         ),
         ClassificationRule(
-            priority=489,
+            priority=491,
             name="github_ci_config",
             matcher=_path_startswith(".github/"),
             resolver=_match_result("github_ci_config", _no_models, ["tools"], False),
             covered_by=("TestUnitTiers.test_github_ci_config_triggers_tools_tier",),
         ),
         ClassificationRule(
-            priority=490,
+            priority=492,
             name="no_impact",
             matcher=_no_impact_matcher,
             resolver=_no_impact_resolver,

--- a/tools/trtmc_compare.py
+++ b/tools/trtmc_compare.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run one TRTMC-to-reference comparison through the validation backend."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools import task_eval  # noqa: E402
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Expose comparison as a validation command instead of a task-eval command."""
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    return task_eval.main(["eval", *arguments])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/trtmc_disagreements.py
+++ b/tools/trtmc_disagreements.py
@@ -77,19 +77,136 @@ def _record_is_disagreement(record: Mapping[str, Any]) -> bool:
     }
 
 
-def _summary_disagreements(summary: Mapping[str, Any]) -> list[dict[str, Any]]:
-    explicit = summary.get("disagreements")
-    if isinstance(explicit, list):
-        return [item for item in explicit if isinstance(item, dict)]
+def _gate_metric(gate: str) -> tuple[str, str] | None:
+    if gate.startswith("min_"):
+        return gate.removeprefix("min_"), "min"
+    if gate.startswith("max_"):
+        return gate.removeprefix("max_"), "max"
+    return None
+
+
+def _numeric(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _failed_summary_gates(summary: Mapping[str, Any]) -> list[dict[str, Any]]:
+    if str(summary.get("status", "") or "").lower() not in {"fail", "failed"}:
+        return []
+    gates = summary.get("gates")
+    if not isinstance(gates, Mapping):
+        return []
+    failures = []
+    for gate, threshold in gates.items():
+        metric_and_direction = _gate_metric(str(gate))
+        if metric_and_direction is None:
+            continue
+        metric, direction = metric_and_direction
+        actual_number = _numeric(summary.get(metric))
+        threshold_number = _numeric(threshold)
+        if actual_number is None or threshold_number is None:
+            continue
+        failed = (
+            actual_number < threshold_number
+            if direction == "min"
+            else actual_number > threshold_number
+        )
+        if failed:
+            failures.append(
+                {
+                    "gate": str(gate),
+                    "metric": metric,
+                    "actual": summary.get(metric),
+                    "threshold": threshold,
+                    "direction": direction,
+                }
+            )
+    return failures
+
+
+def _summary_case_rows(summary: Mapping[str, Any]) -> list[dict[str, Any]]:
     for collection_name in ("samples", "cases", "pairs"):
         collection = summary.get(collection_name)
         if isinstance(collection, list):
-            return [
+            return [dict(item) for item in collection if isinstance(item, dict)]
+    return []
+
+
+def _worst_gate_case(
+    cases: Sequence[Mapping[str, Any]],
+    failure: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    metric = str(failure["metric"])
+    candidates = [
+        (case, _numeric(case.get(metric)))
+        for case in cases
+        if _numeric(case.get(metric)) is not None
+    ]
+    if not candidates:
+        return dict(cases[0]) if cases else None
+    selector = min if failure["direction"] == "min" else max
+    return dict(selector(candidates, key=lambda item: item[1])[0])
+
+
+def _summary_gate_disagreements(
+    summary: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    cases = _summary_case_rows(summary)
+    selected: dict[str, dict[str, Any]] = {}
+    for failure in _failed_summary_gates(summary):
+        case = _worst_gate_case(cases, failure)
+        if case is None:
+            continue
+        sample_id = _sample_id(case, f"sample-{len(selected)}")
+        public_failure = {
+            name: value
+            for name, value in failure.items()
+            if name != "direction"
+        }
+        if sample_id in selected:
+            selected[sample_id]["failed_gates"].append(public_failure)
+            continue
+        selected[sample_id] = {
+            **case,
+            "sample_id": sample_id,
+            "status": "failed",
+            "reason": "summary_gate_failure",
+            "failed_gates": [public_failure],
+        }
+    return list(selected.values())
+
+
+def _explicit_disagreements(summary: Mapping[str, Any]) -> list[dict[str, Any]]:
+    explicit = summary.get("disagreements")
+    if not isinstance(explicit, list):
+        return []
+    return [item for item in explicit if isinstance(item, dict)]
+
+
+def _recorded_disagreements(summary: Mapping[str, Any]) -> list[dict[str, Any]]:
+    for collection_name in ("samples", "cases", "pairs"):
+        collection = summary.get(collection_name)
+        if isinstance(collection, list):
+            disagreements = [
                 item
                 for item in collection
                 if isinstance(item, dict) and _record_is_disagreement(item)
             ]
+            if disagreements:
+                return disagreements
     return []
+
+
+def _summary_disagreements(summary: Mapping[str, Any]) -> list[dict[str, Any]]:
+    explicit = _explicit_disagreements(summary)
+    if explicit:
+        return explicit
+    recorded = _recorded_disagreements(summary)
+    if recorded:
+        return recorded
+    return _summary_gate_disagreements(summary)
 
 
 def _indexed_rows(rows: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:

--- a/tools/trtmc_disagreements.py
+++ b/tools/trtmc_disagreements.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build per-sample disagreement evidence for TRTMC validation reports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import shlex
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = "trtmc.validation-disagreement/v1"
+INLINE_DISAGREEMENT_LIMIT = 20
+_FORBIDDEN_REPRO_ENTRYPOINTS = (
+    "task_eval.py",
+    "trtmc_compare.py",
+    "trtmc_reference.py",
+    "trtmc_validate.py",
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    rows = []
+    with path.open(encoding="utf-8") as input_file:
+        for line in input_file:
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if isinstance(row, dict):
+                rows.append(row)
+    return rows
+
+
+def _sample_id(record: Mapping[str, Any], fallback: str = "") -> str:
+    for name in ("sample_id", "case_id", "id", "name"):
+        value = record.get(name)
+        if value is not None and str(value):
+            return str(value)
+    return fallback
+
+
+def _record_is_disagreement(record: Mapping[str, Any]) -> bool:
+    if record.get("diverged") is True:
+        return True
+    for name in (
+        "agreement_match",
+        "exact",
+        "exact_match",
+        "passed",
+        "top1_agreement",
+        "transcript_exact",
+    ):
+        if record.get(name) is False:
+            return True
+    return str(record.get("status", "") or "").lower() in {
+        "disagreement",
+        "failed",
+        "mismatch",
+    }
+
+
+def _summary_disagreements(summary: Mapping[str, Any]) -> list[dict[str, Any]]:
+    explicit = summary.get("disagreements")
+    if isinstance(explicit, list):
+        return [item for item in explicit if isinstance(item, dict)]
+    for collection_name in ("samples", "cases"):
+        collection = summary.get(collection_name)
+        if isinstance(collection, list):
+            return [
+                item
+                for item in collection
+                if isinstance(item, dict) and _record_is_disagreement(item)
+            ]
+    return []
+
+
+def _indexed_rows(rows: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {
+        _sample_id(row, f"sample-{index}"): dict(row)
+        for index, row in enumerate(rows)
+    }
+
+
+def _prediction_rows(path: Path) -> dict[str, dict[str, Any]]:
+    data = _load_json(path)
+    responses = data.get("responses", [])
+    return _indexed_rows(responses) if isinstance(responses, list) else {}
+
+
+def _safe_sample_name(sample_id: str) -> str:
+    value = re.sub(r"[^A-Za-z0-9_.-]+", "_", sample_id).strip("._")
+    return value or "sample"
+
+
+def _replace_placeholders(value: str, replacements: Mapping[str, str]) -> str:
+    result = value
+    for name, replacement in replacements.items():
+        result = result.replace(f"{{{name}}}", replacement)
+    return result
+
+
+def _command_from_template(
+    metadata: Mapping[str, Any],
+    replacements: Mapping[str, str],
+) -> str:
+    command = metadata.get("command", [])
+    if not isinstance(command, list) or not command:
+        return ""
+    tokens = [
+        _replace_placeholders(str(token), replacements)
+        for token in command
+    ]
+    rendered = shlex.join(tokens)
+    if any(name in rendered for name in _FORBIDDEN_REPRO_ENTRYPOINTS):
+        return ""
+    return rendered
+
+
+def _write_trtmc_input(path: Path, prompt: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(dict(prompt), ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _reproduction_commands(
+    *,
+    sample_id: str,
+    prompt: Mapping[str, Any],
+    work_dir: Path,
+    case_dir: Path,
+    reference_metadata: Mapping[str, Any],
+    trtmc_metadata: Mapping[str, Any],
+) -> tuple[dict[str, str], dict[str, str]]:
+    sample_dir = case_dir / "repro" / _safe_sample_name(sample_id)
+    input_path = sample_dir / "input.jsonl"
+    reference_predictions = sample_dir / "reference_predictions.json"
+    reference_raw = sample_dir / "reference_raw.jsonl"
+    trtmc_raw = sample_dir / "trtmc_raw.jsonl"
+    replacements = {
+        "sample_id": sample_id,
+        "work_dir": str(work_dir),
+        "input_jsonl": str(input_path),
+        "reference_predictions_json": str(reference_predictions),
+        "reference_raw_jsonl": str(reference_raw),
+        "trtmc_raw_jsonl": str(trtmc_raw),
+    }
+    reference_command = _command_from_template(reference_metadata, replacements)
+    trtmc_command = _command_from_template(trtmc_metadata, replacements)
+    artifacts = {}
+    if trtmc_command and prompt:
+        _write_trtmc_input(input_path, prompt)
+        artifacts["trtmc_input"] = str(input_path.relative_to(case_dir))
+    return (
+        {"reference": reference_command, "trtmc": trtmc_command},
+        artifacts,
+    )
+
+
+def _reason(record: Mapping[str, Any]) -> str:
+    configured = str(record.get("reason", "") or "")
+    if configured:
+        return configured
+    if record.get("diverged") is True or record.get("exact") is False:
+        return "output_divergence"
+    if record.get("top1_agreement") is False:
+        return "top1_mismatch"
+    if record.get("transcript_exact") is False:
+        return "transcript_mismatch"
+    return "comparison_threshold"
+
+
+def build_disagreement_artifact(
+    *,
+    work_dir: Path,
+    case_dir: Path,
+) -> dict[str, Any]:
+    summary = _load_json(work_dir / "summary.json")
+    comparison_rows = _summary_disagreements(summary)
+    prompts = _indexed_rows(_load_jsonl(work_dir / "prompts.jsonl"))
+    reference_rows = _prediction_rows(work_dir / "hf_predictions.json")
+    trtmc_rows = _prediction_rows(work_dir / "trtfb_predictions.json")
+    reference_metadata = _load_json(work_dir / "hf_native_repro.json")
+    trtmc_metadata = _load_json(work_dir / "trtfb_repro.json")
+    records = []
+    for index, comparison in enumerate(comparison_rows):
+        sample_id = _sample_id(comparison, f"sample-{index}")
+        prompt = prompts.get(sample_id, {})
+        commands, artifacts = _reproduction_commands(
+            sample_id=sample_id,
+            prompt=prompt,
+            work_dir=work_dir,
+            case_dir=case_dir,
+            reference_metadata=reference_metadata,
+            trtmc_metadata=trtmc_metadata,
+        )
+        records.append(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "sample_id": sample_id,
+                "reason": _reason(comparison),
+                "input": prompt,
+                "reference_result": reference_rows.get(sample_id, {}),
+                "trtmc_result": trtmc_rows.get(sample_id, {}),
+                "comparison": dict(comparison),
+                "reproduce": commands,
+                "artifacts": artifacts,
+            }
+        )
+
+    artifact_path = case_dir / "disagreements.jsonl"
+    with artifact_path.open("w", encoding="utf-8") as output:
+        for record in records:
+            output.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return {
+        "count": len(records),
+        "path": artifact_path.name,
+        "inline_limit": INLINE_DISAGREEMENT_LIMIT,
+        "reference_vanilla_available": bool(reference_metadata),
+        "trtmc_vanilla_available": bool(trtmc_metadata),
+    }
+
+
+def load_disagreement_preview(
+    path: Path,
+    *,
+    limit: int = INLINE_DISAGREEMENT_LIMIT,
+) -> list[dict[str, Any]]:
+    rows = []
+    if not path.is_file():
+        return rows
+    with path.open(encoding="utf-8") as input_file:
+        for line in input_file:
+            if len(rows) >= limit:
+                break
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if isinstance(row, dict):
+                rows.append(row)
+    return rows

--- a/tools/trtmc_disagreements.py
+++ b/tools/trtmc_disagreements.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 import re
 import shlex
+import shutil
 from typing import Any, Mapping, Sequence
 
 
@@ -21,6 +22,10 @@ _FORBIDDEN_REPRO_ENTRYPOINTS = (
     "trtmc_reference.py",
     "trtmc_validate.py",
 )
+_IMAGE_SUFFIXES = {".avif", ".bmp", ".gif", ".jpeg", ".jpg", ".png", ".webp"}
+_AUDIO_SUFFIXES = {".flac", ".mp3", ".ogg", ".wav"}
+_VIDEO_SUFFIXES = {".m4v", ".mkv", ".mov", ".mp4", ".webm"}
+_MEDIA_FILE_LIMIT = 128 * 1024 * 1024
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -76,7 +81,7 @@ def _summary_disagreements(summary: Mapping[str, Any]) -> list[dict[str, Any]]:
     explicit = summary.get("disagreements")
     if isinstance(explicit, list):
         return [item for item in explicit if isinstance(item, dict)]
-    for collection_name in ("samples", "cases"):
+    for collection_name in ("samples", "cases", "pairs"):
         collection = summary.get(collection_name)
         if isinstance(collection, list):
             return [
@@ -94,10 +99,50 @@ def _indexed_rows(rows: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, Any]
     }
 
 
+def _expand_pair_disagreements(
+    rows: Sequence[Mapping[str, Any]],
+    prompts: Mapping[str, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    expanded = []
+    for index, row in enumerate(rows):
+        sample_id = _sample_id(row, f"sample-{index}")
+        pair_id = str(row.get("pair_id", "") or "")
+        if sample_id in prompts or not pair_id:
+            expanded.append(dict(row))
+            continue
+        pair_samples = [
+            prompt_id
+            for prompt_id, prompt in prompts.items()
+            if str(prompt.get("pair_id", "") or "") == pair_id
+        ]
+        if not pair_samples:
+            expanded.append(dict(row))
+            continue
+        for prompt_id in pair_samples:
+            expanded.append({**dict(row), "sample_id": prompt_id})
+    return expanded
+
+
 def _prediction_rows(path: Path) -> dict[str, dict[str, Any]]:
     data = _load_json(path)
     responses = data.get("responses", [])
     return _indexed_rows(responses) if isinstance(responses, list) else {}
+
+
+def _answer_rows(path: Path) -> dict[str, dict[str, Any]]:
+    data = _load_json(path)
+    requests = data.get("requests", [])
+    return _indexed_rows(requests) if isinstance(requests, list) else {}
+
+
+def _native_trtmc_commands(path: Path) -> dict[str, list[str]]:
+    commands = {}
+    for row in _load_jsonl(path):
+        sample_id = _sample_id(row)
+        command = row.get("command")
+        if sample_id and isinstance(command, list) and command:
+            commands[sample_id] = [str(token) for token in command]
+    return commands
 
 
 def _safe_sample_name(sample_id: str) -> str:
@@ -137,6 +182,139 @@ def _write_trtmc_input(path: Path, prompt: Mapping[str, Any]) -> None:
     )
 
 
+def _media_kind(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix in _IMAGE_SUFFIXES:
+        return "image"
+    if suffix in _AUDIO_SUFFIXES:
+        return "audio"
+    if suffix in _VIDEO_SUFFIXES:
+        return "video"
+    return ""
+
+
+def _copy_media(
+    *,
+    source: Path,
+    media_dir: Path,
+    case_dir: Path,
+    label: str,
+    ordinal: int,
+) -> dict[str, str] | None:
+    kind = _media_kind(source)
+    if (
+        not kind
+        or not source.is_file()
+        or source.stat().st_size > _MEDIA_FILE_LIMIT
+    ):
+        return None
+    stem = _safe_sample_name(label).lower()
+    target = media_dir / f"{ordinal:02d}-{stem}{source.suffix.lower()}"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+    return {
+        "label": label,
+        "kind": kind,
+        "path": str(target.relative_to(case_dir)),
+    }
+
+
+def _frame_paths(root: Path) -> list[Path]:
+    images = sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix.lower() in _IMAGE_SUFFIXES
+    )
+    if len(images) <= 3:
+        return images
+    return [images[0], images[len(images) // 2], images[-1]]
+
+
+def _media_candidates(
+    label: str,
+    record: Mapping[str, Any],
+) -> list[tuple[str, Path]]:
+    direct_fields = (
+        "audio",
+        "condition_image",
+        "hf_image",
+        "image",
+        "output_video",
+        "segmented_image_path",
+        "trtfb_image",
+        "video",
+        "video_path",
+        "wav_path",
+    )
+    candidates = [
+        (f"{label} {field}", Path(value))
+        for field in direct_fields
+        if isinstance((value := record.get(field)), str) and value
+    ]
+    images = record.get("images", [])
+    if isinstance(images, list):
+        candidates.extend(
+            (f"{label} input image {index + 1}", Path(str(value)))
+            for index, value in enumerate(images)
+            if str(value)
+        )
+    candidates.extend(_frame_candidates(label, record.get("frames_dir")))
+    return candidates
+
+
+def _frame_candidates(label: str, value: Any) -> list[tuple[str, Path]]:
+    if not isinstance(value, str) or not Path(value).is_dir():
+        return []
+    root = Path(value)
+    images = [
+        (f"{label} frame {index + 1}", path)
+        for index, path in enumerate(_frame_paths(root))
+    ]
+    videos = [
+        (f"{label} video", path)
+        for path in sorted(root.rglob("*"))
+        if path.is_file() and path.suffix.lower() in _VIDEO_SUFFIXES
+    ]
+    return images + videos
+
+
+def _collect_media(
+    *,
+    sample_dir: Path,
+    case_dir: Path,
+    prompt: Mapping[str, Any],
+    reference_result: Mapping[str, Any],
+    trtmc_result: Mapping[str, Any],
+) -> list[dict[str, str]]:
+    media_dir = sample_dir / "media"
+    seen = set()
+    copied = []
+    sources = (
+        ("Input", prompt),
+        ("Reference", reference_result),
+        ("TRTMC", trtmc_result),
+    )
+    for label, record in sources:
+        for candidate_label, source in _media_candidates(label, record):
+            try:
+                resolved = source.resolve()
+            except OSError:
+                continue
+            if resolved in seen:
+                continue
+            item = _copy_media(
+                source=resolved,
+                media_dir=media_dir,
+                case_dir=case_dir,
+                label=candidate_label,
+                ordinal=len(copied) + 1,
+            )
+            if item is not None:
+                seen.add(resolved)
+                copied.append(item)
+    return copied
+
+
 def _reproduction_commands(
     *,
     sample_id: str,
@@ -145,11 +323,15 @@ def _reproduction_commands(
     case_dir: Path,
     reference_metadata: Mapping[str, Any],
     trtmc_metadata: Mapping[str, Any],
-) -> tuple[dict[str, str], dict[str, str]]:
+    native_reference_command: Sequence[str] = (),
+    native_trtmc_command: Sequence[str] = (),
+) -> tuple[dict[str, str], dict[str, Any]]:
     sample_dir = case_dir / "repro" / _safe_sample_name(sample_id)
     input_path = sample_dir / "input.jsonl"
     reference_predictions = sample_dir / "reference_predictions.json"
     reference_raw = sample_dir / "reference_raw.jsonl"
+    reference_input = sample_dir / "reference_input.jsonl"
+    reference_artifacts = sample_dir / "reference_artifacts"
     trtmc_raw = sample_dir / "trtmc_raw.jsonl"
     replacements = {
         "sample_id": sample_id,
@@ -157,11 +339,33 @@ def _reproduction_commands(
         "input_jsonl": str(input_path),
         "reference_predictions_json": str(reference_predictions),
         "reference_raw_jsonl": str(reference_raw),
+        "reference_input_jsonl": str(reference_input),
+        "reference_artifacts_dir": str(reference_artifacts),
         "trtmc_raw_jsonl": str(trtmc_raw),
+        "sample_seed": _sample_seed(trtmc_metadata, prompt),
+        "reference_sample_seed": _sample_seed(reference_metadata, prompt),
     }
-    reference_command = _command_from_template(reference_metadata, replacements)
-    trtmc_command = _command_from_template(trtmc_metadata, replacements)
+    reference_command = _resolved_command(
+        reference_metadata,
+        replacements,
+        native_reference_command,
+    )
+    trtmc_command = _resolved_command(
+        trtmc_metadata,
+        replacements,
+        native_trtmc_command,
+    )
     artifacts = {}
+    if _write_elf_reference_input(
+        reference_input,
+        sample_id=sample_id,
+        prompt=prompt,
+        enabled=bool(
+            reference_command
+            and reference_metadata.get("input_format") == "elf_reference_jsonl"
+        ),
+    ):
+        artifacts["reference_input"] = str(reference_input.relative_to(case_dir))
     if trtmc_command and prompt:
         _write_trtmc_input(input_path, prompt)
         artifacts["trtmc_input"] = str(input_path.relative_to(case_dir))
@@ -169,6 +373,58 @@ def _reproduction_commands(
         {"reference": reference_command, "trtmc": trtmc_command},
         artifacts,
     )
+
+
+def _sample_seed(
+    metadata: Mapping[str, Any],
+    prompt: Mapping[str, Any],
+) -> str:
+    value = metadata.get("base_seed")
+    if value is None:
+        return ""
+    index = prompt.get("seed_index", prompt.get("eval_index", 0))
+    return str(int(value) + int(index))
+
+
+def _resolved_command(
+    metadata: Mapping[str, Any],
+    replacements: Mapping[str, str],
+    native_command: Sequence[str],
+) -> str:
+    command = _command_from_template(metadata, replacements)
+    if command or not native_command:
+        return command
+    rendered = shlex.join(str(token) for token in native_command)
+    if any(name in rendered for name in _FORBIDDEN_REPRO_ENTRYPOINTS):
+        return ""
+    return rendered
+
+
+def _write_elf_reference_input(
+    path: Path,
+    *,
+    sample_id: str,
+    prompt: Mapping[str, Any],
+    enabled: bool,
+) -> bool:
+    if not enabled:
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "id": sample_id,
+                "input": str(
+                    prompt.get("source_text", prompt.get("prompt", ""))
+                ),
+                "output": str(prompt.get("answer", "")),
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return True
 
 
 def _reason(record: Mapping[str, Any]) -> str:
@@ -190,16 +446,29 @@ def build_disagreement_artifact(
     case_dir: Path,
 ) -> dict[str, Any]:
     summary = _load_json(work_dir / "summary.json")
-    comparison_rows = _summary_disagreements(summary)
     prompts = _indexed_rows(_load_jsonl(work_dir / "prompts.jsonl"))
+    comparison_rows = _expand_pair_disagreements(
+        _summary_disagreements(summary),
+        prompts,
+    )
+    answers = _answer_rows(work_dir / "answers.json")
     reference_rows = _prediction_rows(work_dir / "hf_predictions.json")
     trtmc_rows = _prediction_rows(work_dir / "trtfb_predictions.json")
     reference_metadata = _load_json(work_dir / "hf_native_repro.json")
+    native_reference_commands = _native_trtmc_commands(
+        work_dir / "hf_native_commands.jsonl"
+    )
     trtmc_metadata = _load_json(work_dir / "trtfb_repro.json")
+    native_trtmc_commands = _native_trtmc_commands(
+        work_dir / "trtfb_native_commands.jsonl"
+    )
     records = []
     for index, comparison in enumerate(comparison_rows):
         sample_id = _sample_id(comparison, f"sample-{index}")
-        prompt = prompts.get(sample_id, {})
+        prompt = {
+            **answers.get(sample_id, {}),
+            **prompts.get(sample_id, {}),
+        }
         commands, artifacts = _reproduction_commands(
             sample_id=sample_id,
             prompt=prompt,
@@ -207,7 +476,21 @@ def build_disagreement_artifact(
             case_dir=case_dir,
             reference_metadata=reference_metadata,
             trtmc_metadata=trtmc_metadata,
+            native_reference_command=native_reference_commands.get(
+                sample_id,
+                (),
+            ),
+            native_trtmc_command=native_trtmc_commands.get(sample_id, ()),
         )
+        media = _collect_media(
+            sample_dir=case_dir / "repro" / _safe_sample_name(sample_id),
+            case_dir=case_dir,
+            prompt=prompt,
+            reference_result=reference_rows.get(sample_id, {}),
+            trtmc_result=trtmc_rows.get(sample_id, {}),
+        )
+        if media:
+            artifacts["media"] = media
         records.append(
             {
                 "schema_version": SCHEMA_VERSION,
@@ -230,8 +513,12 @@ def build_disagreement_artifact(
         "count": len(records),
         "path": artifact_path.name,
         "inline_limit": INLINE_DISAGREEMENT_LIMIT,
-        "reference_vanilla_available": bool(reference_metadata),
-        "trtmc_vanilla_available": bool(trtmc_metadata),
+        "reference_vanilla_available": bool(
+            reference_metadata.get("command") or native_reference_commands
+        ),
+        "trtmc_vanilla_available": bool(
+            trtmc_metadata.get("command") or native_trtmc_commands
+        ),
     }
 
 

--- a/tools/trtmc_disagreements.py
+++ b/tools/trtmc_disagreements.py
@@ -361,6 +361,7 @@ def _media_candidates(
         "trtfb_image",
         "video",
         "video_path",
+        "visualization_path",
         "wav_path",
     )
     candidates = [

--- a/tools/trtmc_reference.py
+++ b/tools/trtmc_reference.py
@@ -35,8 +35,30 @@ _WORK_METADATA = "hf_cache.json"
 _NATIVE_RUN_LOG = "hf_native_run.log"
 _NATIVE_REPRO_METADATA = "hf_native_repro.json"
 _TEXT_SUFFIXES = {".json", ".jsonl", ".log", ".md", ".txt"}
-_NATIVE_TEXT_REFERENCE_FAMILIES = {"causal_base_continuation"}
+_NATIVE_TEXT_DATASET_KINDS = {"mmlu_five_shot_json", "text_generation_json"}
+_NATIVE_ENCODER_DATASET_KINDS = {"sts_pair_jsonl"}
+_NATIVE_PLUGIN_DATASET_KINDS = {
+    "diffusion_prompt_json",
+    "image_classification_json",
+    "prompted_segmentation_json",
+    "reranking_json",
+    "semantic_segmentation_json",
+    "time_series_csv",
+}
+_NATIVE_VLM_DATASET_KINDS = {"vlm_chat_json", "vlm_unified_json"}
+_NATIVE_ELF_DATASET_KINDS = {
+    "conditional_text_jsonl",
+    "unconditional_text_json",
+}
+_NATIVE_SPEECH_DATASET_KINDS = {"asr_chat_json", "seedtts_json"}
 _TRANSFORMERS_TEXT_RUNNER = REPO_ROOT / "tools" / "reference" / "transformers_text.py"
+_TRANSFORMERS_ENCODER_RUNNER = (
+    REPO_ROOT / "tools" / "reference" / "transformers_encoder.py"
+)
+_PLUGIN_REFERENCE_RUNNER = REPO_ROOT / "tools" / "reference" / "plugin_reference.py"
+_TRANSFORMERS_VLM_RUNNER = REPO_ROOT / "tools" / "reference" / "transformers_vlm.py"
+_ELF_PREPARED_RUNNER = REPO_ROOT / "tools" / "reference" / "elf_prepared.py"
+_SPEECH_REFERENCE_RUNNER = REPO_ROOT / "tools" / "reference" / "speech.py"
 _IGNORED_INPUT_NAMES = {
     "build.log",
     "eval_result.json",
@@ -121,10 +143,29 @@ def _settings(args: argparse.Namespace) -> dict[str, Any]:
     }
 
 
-def _native_reference_runner(args: argparse.Namespace) -> Path | None:
-    if str(args.reference_family or "") in _NATIVE_TEXT_REFERENCE_FAMILIES:
+def native_reference_runner_for_dataset_kind(dataset_kind: str) -> Path | None:
+    if dataset_kind in _NATIVE_TEXT_DATASET_KINDS:
         return _TRANSFORMERS_TEXT_RUNNER
+    if dataset_kind in _NATIVE_ENCODER_DATASET_KINDS:
+        return _TRANSFORMERS_ENCODER_RUNNER
+    if dataset_kind in _NATIVE_PLUGIN_DATASET_KINDS:
+        return _PLUGIN_REFERENCE_RUNNER
+    if dataset_kind in _NATIVE_VLM_DATASET_KINDS:
+        return _TRANSFORMERS_VLM_RUNNER
+    if dataset_kind in _NATIVE_ELF_DATASET_KINDS:
+        return _ELF_PREPARED_RUNNER
+    if dataset_kind in _NATIVE_SPEECH_DATASET_KINDS:
+        return _SPEECH_REFERENCE_RUNNER
     return None
+
+
+def _native_reference_runner(args: argparse.Namespace) -> Path | None:
+    manifest_path = Path(args.work_dir).resolve() / "manifest.json"
+    if not manifest_path.is_file():
+        return None
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    dataset_kind = str(manifest.get("dataset_kind", "") or "")
+    return native_reference_runner_for_dataset_kind(dataset_kind)
 
 
 def _native_runner_identity(path: Path | None) -> str:
@@ -315,6 +356,12 @@ def _native_reference_command(
         "--device",
         str(args.device),
     ]
+    if args.reference_family:
+        command.extend(["--reference-family", str(args.reference_family)])
+    if runner == _ELF_PREPARED_RUNNER and args.elf_reference_repo:
+        command.extend(["--elf-reference-repo", str(args.elf_reference_repo)])
+    if runner == _SPEECH_REFERENCE_RUNNER and args.family:
+        command.extend(["--family", str(args.family)])
     for flag, value in (
         ("--device-map", args.device_map),
         ("--attn-impl", args.attn_impl),

--- a/tools/trtmc_reference.py
+++ b/tools/trtmc_reference.py
@@ -12,6 +12,8 @@ import json
 import os
 from pathlib import Path
 import shutil
+import shlex
+import subprocess
 import sys
 import tempfile
 from typing import Any, Iterable, Mapping, Sequence
@@ -30,7 +32,11 @@ CACHE_SCHEMA = "trtmc.reference-cache/v1"
 CACHE_IMPLEMENTATION = 1
 _CACHE_METADATA = "reference.json"
 _WORK_METADATA = "hf_cache.json"
+_NATIVE_RUN_LOG = "hf_native_run.log"
+_NATIVE_REPRO_METADATA = "hf_native_repro.json"
 _TEXT_SUFFIXES = {".json", ".jsonl", ".log", ".md", ".txt"}
+_NATIVE_TEXT_REFERENCE_FAMILIES = {"causal_base_continuation"}
+_TRANSFORMERS_TEXT_RUNNER = REPO_ROOT / "tools" / "reference" / "transformers_text.py"
 _IGNORED_INPUT_NAMES = {
     "build.log",
     "eval_result.json",
@@ -89,8 +95,10 @@ def _hash_file(hasher: Any, path: Path, work_dir: Path) -> None:
 
 
 def _settings(args: argparse.Namespace) -> dict[str, Any]:
+    native_runner = _native_reference_runner(args)
     return {
         "implementation": CACHE_IMPLEMENTATION,
+        "native_runner": _native_runner_identity(native_runner),
         "python": str(Path(sys.executable).resolve()),
         "model": args.model,
         "family": args.family,
@@ -111,6 +119,18 @@ def _settings(args: argparse.Namespace) -> dict[str, Any]:
         "min_p": args.min_p,
         "seed": args.seed,
     }
+
+
+def _native_reference_runner(args: argparse.Namespace) -> Path | None:
+    if str(args.reference_family or "") in _NATIVE_TEXT_REFERENCE_FAMILIES:
+        return _TRANSFORMERS_TEXT_RUNNER
+    return None
+
+
+def _native_runner_identity(path: Path | None) -> str:
+    if path is None:
+        return ""
+    return f"{path.name}:{hashlib.sha256(path.read_bytes()).hexdigest()}"
 
 
 def reference_key(args: argparse.Namespace) -> tuple[str, dict[str, Any]]:
@@ -170,6 +190,8 @@ def _materialize(entry: Path, work_dir: Path) -> None:
 def _rewrite_cached_paths(root: Path, old: Path, new: Path) -> None:
     for path in root.rglob("*"):
         if not path.is_file() or path.suffix.lower() not in _TEXT_SUFFIXES:
+            continue
+        if path.name == _NATIVE_RUN_LOG:
             continue
         content = path.read_text(encoding="utf-8", errors="replace")
         updated = content.replace(str(old), str(new))
@@ -254,7 +276,7 @@ def _write_work_metadata(
 
 
 def _run_without_cache(args: argparse.Namespace, key: str) -> str:
-    task_eval.run_hf_reference(args)
+    _run_reference_inference(args)
     work_dir = Path(args.work_dir).resolve()
     if not task_eval.predictions_file_valid(
         work_dir / "hf_predictions.json",
@@ -264,6 +286,79 @@ def _run_without_cache(args: argparse.Namespace, key: str) -> str:
     _write_work_metadata(work_dir, key=key, status="generated", entry=None)
     print("Reference result: generated", flush=True)
     return "generated"
+
+
+def _native_reference_command(
+    args: argparse.Namespace,
+    runner: Path,
+) -> list[str]:
+    work_dir = Path(args.work_dir).resolve()
+    command = [
+        sys.executable,
+        str(runner),
+        "--model",
+        str(args.model),
+        "--prompts",
+        str(work_dir / "prompts.jsonl"),
+        "--answers",
+        str(work_dir / "answers.json"),
+        "--manifest",
+        str(work_dir / "manifest.json"),
+        "--predictions",
+        str(work_dir / args.predictions),
+        "--raw-output",
+        str(work_dir / args.raw_output),
+        "--repro-metadata",
+        str(work_dir / _NATIVE_REPRO_METADATA),
+        "--dtype",
+        str(args.dtype),
+        "--device",
+        str(args.device),
+    ]
+    for flag, value in (
+        ("--device-map", args.device_map),
+        ("--attn-impl", args.attn_impl),
+        ("--max-new-tokens", args.max_new_tokens),
+        ("--temperature", args.temperature),
+        ("--top-k", args.top_k),
+        ("--top-p", args.top_p),
+        ("--seed", args.seed),
+    ):
+        if value not in (None, ""):
+            command.extend([flag, str(value)])
+    for enabled, flag in (
+        (args.trust_remote_code, "--trust-remote-code"),
+        (args.local_files_only, "--local-files-only"),
+        (args.do_sample, "--do-sample"),
+        (args.apply_chat_template, "--apply-chat-template"),
+    ):
+        if enabled:
+            command.append(flag)
+    return command
+
+
+def _run_reference_inference(args: argparse.Namespace) -> None:
+    runner = _native_reference_runner(args)
+    if runner is None:
+        task_eval.run_hf_reference(args)
+        return
+    work_dir = Path(args.work_dir).resolve()
+    command = _native_reference_command(args, runner)
+    log_path = work_dir / _NATIVE_RUN_LOG
+    with log_path.open("w", encoding="utf-8") as log_file:
+        log_file.write(f"$ {shlex.join(command)}\n")
+        log_file.flush()
+        process = subprocess.run(
+            command,
+            check=False,
+            text=True,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+    if process.returncode != 0:
+        raise ReferenceError(
+            f"native reference failed with rc={process.returncode}; see {log_path}"
+        )
 
 
 def run_reference(args: argparse.Namespace) -> str:
@@ -293,7 +388,7 @@ def run_reference(args: argparse.Namespace) -> str:
     )
     if not adopt:
         _clear_reference_outputs(work_dir)
-        task_eval.run_hf_reference(args)
+        _run_reference_inference(args)
     if not task_eval.predictions_file_valid(
         work_dir / "hf_predictions.json",
         work_dir / "answers.json",

--- a/tools/trtmc_reference.py
+++ b/tools/trtmc_reference.py
@@ -123,6 +123,7 @@ def _settings(args: argparse.Namespace) -> dict[str, Any]:
         "native_runner": _native_runner_identity(native_runner),
         "python": str(Path(sys.executable).resolve()),
         "model": args.model,
+        "model_revision": args.model_revision,
         "family": args.family,
         "reference_family": args.reference_family,
         "dtype": args.dtype,
@@ -358,6 +359,14 @@ def _native_reference_command(
     ]
     if args.reference_family:
         command.extend(["--reference-family", str(args.reference_family)])
+    revision_runners = {
+        _TRANSFORMERS_TEXT_RUNNER,
+        _TRANSFORMERS_ENCODER_RUNNER,
+        _TRANSFORMERS_VLM_RUNNER,
+        _SPEECH_REFERENCE_RUNNER,
+    }
+    if runner in revision_runners and args.model_revision:
+        command.extend(["--model-revision", str(args.model_revision)])
     if runner == _ELF_PREPARED_RUNNER and args.elf_reference_repo:
         command.extend(["--elf-reference-repo", str(args.elf_reference_repo)])
     if runner == _SPEECH_REFERENCE_RUNNER and args.family:
@@ -474,6 +483,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run and cache a model reference.")
     parser.add_argument("command", choices=("run",))
     parser.add_argument("--model", required=True)
+    parser.add_argument("--model-revision", default="")
     parser.add_argument("--family", default="")
     parser.add_argument("--reference-family", default="")
     parser.add_argument("--work-dir", required=True)

--- a/tools/trtmc_reference.py
+++ b/tools/trtmc_reference.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 from pathlib import Path
 import shutil
 import sys
@@ -162,7 +163,8 @@ def _materialize(entry: Path, work_dir: Path) -> None:
         target = work_dir / source.name
         if target.exists() or target.is_symlink():
             _remove_path(target)
-        target.symlink_to(source, target_is_directory=source.is_dir())
+        relative_source = os.path.relpath(source, target.parent)
+        target.symlink_to(relative_source, target_is_directory=source.is_dir())
 
 
 def _rewrite_cached_paths(root: Path, old: Path, new: Path) -> None:

--- a/tools/trtmc_reference.py
+++ b/tools/trtmc_reference.py
@@ -191,6 +191,14 @@ def _restore_moved_outputs(moved: Iterable[tuple[Path, Path]]) -> None:
             shutil.move(str(source), str(destination))
 
 
+def _make_cache_readable(root: Path) -> None:
+    for path in [root, *root.rglob("*")]:
+        if path.is_symlink():
+            continue
+        mode = path.stat().st_mode
+        path.chmod(mode | (0o055 if path.is_dir() else 0o044))
+
+
 def _move_outputs_to_cache(
     *,
     work_dir: Path,
@@ -216,6 +224,7 @@ def _move_outputs_to_cache(
             json.dumps(dict(metadata), indent=2, ensure_ascii=False),
             encoding="utf-8",
         )
+        _make_cache_readable(stage)
         stage.rename(entry)
     except BaseException:
         _restore_moved_outputs(moved)

--- a/tools/trtmc_reference.py
+++ b/tools/trtmc_reference.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run and cache model reference inference independently from task evaluation."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+from typing import Any, Iterable, Mapping, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYTHON_ROOT = REPO_ROOT / "python"
+for import_root in (REPO_ROOT, PYTHON_ROOT):
+    if str(import_root) not in sys.path:
+        sys.path.insert(0, str(import_root))
+
+from tools import task_eval  # noqa: E402
+
+
+CACHE_SCHEMA = "trtmc.reference-cache/v1"
+CACHE_IMPLEMENTATION = 1
+_CACHE_METADATA = "reference.json"
+_WORK_METADATA = "hf_cache.json"
+_TEXT_SUFFIXES = {".json", ".jsonl", ".log", ".md", ".txt"}
+_IGNORED_INPUT_NAMES = {
+    "build.log",
+    "eval_result.json",
+    "hf_cache.json",
+    "hf_run.log",
+    "summary.json",
+    "summary.md",
+    "trtfb_predictions.json",
+    "trtfb_raw.jsonl",
+    "trtfb_run.log",
+    "visual_review.html",
+}
+
+
+class ReferenceError(RuntimeError):
+    """Reference inference or cache materialization failed."""
+
+
+def _is_reference_output(name: str) -> bool:
+    return (
+        (name.startswith("hf_") and name not in {"hf_run.log", _WORK_METADATA})
+        or name == "shared_initial_latents"
+    )
+
+
+def _is_non_input(name: str) -> bool:
+    return (
+        _is_reference_output(name)
+        or name.startswith("trtfb_")
+        or name in _IGNORED_INPUT_NAMES
+    )
+
+
+def _input_files(work_dir: Path) -> Iterable[Path]:
+    for path in sorted(work_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(work_dir)
+        if _is_non_input(relative.parts[0]):
+            continue
+        if relative.name in _IGNORED_INPUT_NAMES:
+            continue
+        yield path
+
+
+def _hash_file(hasher: Any, path: Path, work_dir: Path) -> None:
+    relative = path.relative_to(work_dir)
+    hasher.update(str(relative).encode())
+    if path.suffix.lower() in _TEXT_SUFFIXES and path.stat().st_size <= 32 * 1024 * 1024:
+        content = path.read_text(encoding="utf-8", errors="replace")
+        hasher.update(content.replace(str(work_dir), "<WORK_DIR>").encode())
+        return
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            hasher.update(chunk)
+
+
+def _settings(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "implementation": CACHE_IMPLEMENTATION,
+        "python": str(Path(sys.executable).resolve()),
+        "model": args.model,
+        "family": args.family,
+        "reference_family": args.reference_family,
+        "dtype": args.dtype,
+        "device": args.device,
+        "device_map": args.device_map,
+        "attn_impl": args.attn_impl,
+        "trust_remote_code": args.trust_remote_code,
+        "local_files_only": args.local_files_only,
+        "do_sample": args.do_sample,
+        "apply_chat_template": args.apply_chat_template,
+        "elf_reference_repo": args.elf_reference_repo,
+        "max_new_tokens": args.max_new_tokens,
+        "temperature": args.temperature,
+        "top_k": args.top_k,
+        "top_p": args.top_p,
+        "min_p": args.min_p,
+        "seed": args.seed,
+    }
+
+
+def reference_key(args: argparse.Namespace) -> tuple[str, dict[str, Any]]:
+    work_dir = Path(args.work_dir).resolve()
+    settings = _settings(args)
+    hasher = hashlib.sha256()
+    hasher.update(json.dumps(settings, sort_keys=True, separators=(",", ":")).encode())
+    for path in _input_files(work_dir):
+        _hash_file(hasher, path, work_dir)
+    return hasher.hexdigest(), settings
+
+
+def _cache_entry(cache_dir: Path, key: str) -> Path:
+    return cache_dir / key
+
+
+def _load_cache_metadata(entry: Path, key: str) -> dict[str, Any] | None:
+    path = entry / _CACHE_METADATA
+    if not path.is_file():
+        return None
+    try:
+        metadata = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if (
+        metadata.get("schema_version") != CACHE_SCHEMA
+        or metadata.get("key") != key
+        or not (entry / "files" / "hf_predictions.json").is_file()
+    ):
+        return None
+    return metadata
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def _clear_reference_outputs(work_dir: Path) -> None:
+    for path in work_dir.iterdir():
+        if _is_reference_output(path.name):
+            _remove_path(path)
+
+
+def _materialize(entry: Path, work_dir: Path) -> None:
+    files_dir = entry / "files"
+    for source in sorted(files_dir.iterdir()):
+        target = work_dir / source.name
+        if target.exists() or target.is_symlink():
+            _remove_path(target)
+        target.symlink_to(source, target_is_directory=source.is_dir())
+
+
+def _rewrite_cached_paths(root: Path, old: Path, new: Path) -> None:
+    for path in root.rglob("*"):
+        if not path.is_file() or path.suffix.lower() not in _TEXT_SUFFIXES:
+            continue
+        content = path.read_text(encoding="utf-8", errors="replace")
+        updated = content.replace(str(old), str(new))
+        if updated != content:
+            path.write_text(updated, encoding="utf-8")
+
+
+def _reference_outputs(work_dir: Path) -> list[Path]:
+    return [
+        path
+        for path in sorted(work_dir.iterdir())
+        if _is_reference_output(path.name)
+    ]
+
+
+def _restore_moved_outputs(moved: Iterable[tuple[Path, Path]]) -> None:
+    for source, destination in reversed(list(moved)):
+        if source.exists() or source.is_symlink():
+            shutil.move(str(source), str(destination))
+
+
+def _move_outputs_to_cache(
+    *,
+    work_dir: Path,
+    cache_dir: Path,
+    entry: Path,
+    metadata: Mapping[str, Any],
+) -> None:
+    outputs = _reference_outputs(work_dir)
+    if not any(path.name == "hf_predictions.json" for path in outputs):
+        raise ReferenceError("reference inference did not produce hf_predictions.json")
+
+    stage = Path(tempfile.mkdtemp(prefix=f".{entry.name}.", dir=cache_dir))
+    files_dir = stage / "files"
+    files_dir.mkdir()
+    moved: list[tuple[Path, Path]] = []
+    try:
+        for source in outputs:
+            destination = files_dir / source.name
+            shutil.move(str(source), str(destination))
+            moved.append((destination, source))
+        _rewrite_cached_paths(files_dir, work_dir, entry / "files")
+        (stage / _CACHE_METADATA).write_text(
+            json.dumps(dict(metadata), indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        stage.rename(entry)
+    except BaseException:
+        _restore_moved_outputs(moved)
+        if stage.exists():
+            shutil.rmtree(stage)
+        raise
+
+
+def _write_work_metadata(
+    work_dir: Path,
+    *,
+    key: str,
+    status: str,
+    entry: Path | None,
+) -> None:
+    payload = {
+        "schema_version": CACHE_SCHEMA,
+        "key": key,
+        "status": status,
+    }
+    if entry is not None:
+        payload["entry"] = str(entry)
+    (work_dir / _WORK_METADATA).write_text(
+        json.dumps(payload, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _run_without_cache(args: argparse.Namespace, key: str) -> str:
+    task_eval.run_hf_reference(args)
+    work_dir = Path(args.work_dir).resolve()
+    if not task_eval.predictions_file_valid(
+        work_dir / "hf_predictions.json",
+        work_dir / "answers.json",
+    ):
+        raise ReferenceError("reference inference produced invalid predictions")
+    _write_work_metadata(work_dir, key=key, status="generated", entry=None)
+    print("Reference result: generated", flush=True)
+    return "generated"
+
+
+def run_reference(args: argparse.Namespace) -> str:
+    work_dir = Path(args.work_dir).resolve()
+    work_dir.mkdir(parents=True, exist_ok=True)
+    key, settings = reference_key(args)
+    if not args.cache_dir:
+        return _run_without_cache(args, key)
+
+    cache_dir = Path(args.cache_dir).resolve()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    entry = _cache_entry(cache_dir, key)
+    cached = None if args.force else _load_cache_metadata(entry, key)
+    if cached is not None:
+        _clear_reference_outputs(work_dir)
+        _materialize(entry, work_dir)
+        _write_work_metadata(work_dir, key=key, status="reused", entry=entry)
+        print(f"Reference result: reused {key[:12]}", flush=True)
+        return "reused"
+
+    if entry.exists():
+        shutil.rmtree(entry)
+
+    adopt = args.adopt_existing and task_eval.predictions_file_valid(
+        work_dir / "hf_predictions.json",
+        work_dir / "answers.json",
+    )
+    if not adopt:
+        _clear_reference_outputs(work_dir)
+        task_eval.run_hf_reference(args)
+    if not task_eval.predictions_file_valid(
+        work_dir / "hf_predictions.json",
+        work_dir / "answers.json",
+    ):
+        raise ReferenceError("reference inference produced invalid predictions")
+
+    status = "adopted" if adopt else "generated"
+    metadata = {
+        "schema_version": CACHE_SCHEMA,
+        "key": key,
+        "settings": settings,
+        "status": status,
+    }
+    _move_outputs_to_cache(
+        work_dir=work_dir,
+        cache_dir=cache_dir,
+        entry=entry,
+        metadata=metadata,
+    )
+    _materialize(entry, work_dir)
+    _write_work_metadata(work_dir, key=key, status=status, entry=entry)
+    print(f"Reference result: {status} {key[:12]}", flush=True)
+    return status
+
+
+def add_generation_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--max-new-tokens", type=int)
+    parser.add_argument("--temperature", type=float)
+    parser.add_argument("--top-k", type=int)
+    parser.add_argument("--top-p", type=float)
+    parser.add_argument("--min-p", type=float)
+    parser.add_argument("--seed", type=int)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run and cache a model reference.")
+    parser.add_argument("command", choices=("run",))
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--family", default="")
+    parser.add_argument("--reference-family", default="")
+    parser.add_argument("--work-dir", required=True)
+    parser.add_argument("--cache-dir", default="")
+    parser.add_argument("--predictions", default="hf_predictions.json")
+    parser.add_argument("--raw-output", default="hf_raw.jsonl")
+    parser.add_argument("--dtype", choices=("auto", "float16", "bfloat16"), default="auto")
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--device-map", default="")
+    parser.add_argument("--attn-impl", default="")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--local-files-only", action="store_true")
+    parser.add_argument("--do-sample", action="store_true")
+    parser.add_argument("--apply-chat-template", action="store_true")
+    parser.add_argument("--elf-reference-repo", default="")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--adopt-existing", action="store_true")
+    add_generation_args(parser)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    run_reference(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -388,32 +388,179 @@ def _e2e_command(
     return command
 
 
-def _commands_from_logs(root: Path) -> dict[str, list[str]]:
-    commands = {"hf": [], "trtmc": []}
-    for path in sorted(root.rglob("*.log")):
-        kind = "hf" if "hf" in path.name.lower() else "trtmc"
-        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-            value = _command_from_log_line(line)
-            if value and value not in commands[kind]:
-                commands[kind].append(value)
-    return commands
+MAX_REPRO_COMMANDS_PER_BACKEND = 3
+_FAILED_SAMPLE_STATUSES = {"disagreement", "fail", "failed", "mismatch"}
+_FAILED_SAMPLE_FIELDS = (
+    "agreement_match",
+    "exact_match",
+    "passed",
+    "top1_agreement",
+    "transcript_exact",
+)
+_SAMPLE_ID_FIELDS = ("sample_id", "case_id", "id", "name")
 
 
-def _command_from_log_line(line: str) -> str:
+def _command_record_from_log_line(line: str) -> tuple[str, str]:
     if line.startswith("$ "):
-        return line[2:].strip()
+        return line[2:].strip(), ""
     try:
         data = json.loads(line)
     except json.JSONDecodeError:
+        return "", ""
+    if not isinstance(data, dict):
+        return "", ""
+    command = data.get("command")
+    sample_id = next(
+        (str(data[name]) for name in _SAMPLE_ID_FIELDS if data.get(name) is not None),
+        "",
+    )
+    if isinstance(command, list) and command:
+        return shlex.join(str(token) for token in command), sample_id
+    if isinstance(command, str):
+        return command.strip(), sample_id
+    return "", ""
+
+
+def _command_from_log_line(line: str) -> str:
+    return _command_record_from_log_line(line)[0]
+
+
+def _sample_id(record: Mapping[str, Any]) -> str:
+    return next(
+        (str(record[name]) for name in _SAMPLE_ID_FIELDS if record.get(name) is not None),
+        "",
+    )
+
+
+def _explicit_disagreement_id(data: Mapping[str, Any]) -> str:
+    disagreements = data.get("disagreements", [])
+    if not isinstance(disagreements, list):
+        return ""
+    for item in disagreements:
+        if isinstance(item, dict) and _sample_id(item):
+            return _sample_id(item)
+    return ""
+
+
+def _record_is_disagreement(record: Mapping[str, Any]) -> bool:
+    status = str(record.get("status", "") or "").lower()
+    if status in _FAILED_SAMPLE_STATUSES:
+        return True
+    return any(record.get(name) is False for name in _FAILED_SAMPLE_FIELDS)
+
+
+def _failed_sample_id(data: Any) -> str:
+    if isinstance(data, list):
+        for item in data:
+            failed = _failed_sample_id(item)
+            if failed:
+                return failed
         return ""
     if not isinstance(data, dict):
         return ""
-    command = data.get("command")
-    if isinstance(command, list) and command:
-        return shlex.join(str(token) for token in command)
-    if isinstance(command, str):
-        return command.strip()
+    if _record_is_disagreement(data) and _sample_id(data):
+        return _sample_id(data)
+    for value in data.values():
+        failed = _failed_sample_id(value)
+        if failed:
+            return failed
     return ""
+
+
+def _first_disagreement_id(work_dir: Path) -> str:
+    for name in ("summary.json", "eval_result.json"):
+        path = work_dir / name
+        if not path.is_file():
+            continue
+        data = json.loads(path.read_text(encoding="utf-8"))
+        explicit_id = _explicit_disagreement_id(data) if isinstance(data, dict) else ""
+        if explicit_id:
+            return explicit_id
+        failed = _failed_sample_id(data)
+        if failed:
+            return failed
+    return ""
+
+
+def _prepared_sample_ids(work_dir: Path) -> list[str]:
+    prompts = work_dir / "prompts.jsonl"
+    if not prompts.is_file():
+        return []
+    sample_ids = []
+    with prompts.open(encoding="utf-8") as prompt_file:
+        for index, line in enumerate(prompt_file):
+            record = json.loads(line)
+            if isinstance(record, dict):
+                sample_ids.append(_sample_id(record) or f"sample-{index}")
+    return sample_ids
+
+
+def _sample_ids_match(candidate: str, target: str) -> bool:
+    return bool(
+        candidate
+        and target
+        and (
+            candidate == target
+            or candidate.startswith(f"{target}:")
+            or target.startswith(f"{candidate}:")
+        )
+    )
+
+
+def _summarize_command_log(
+    path: Path,
+    *,
+    sample_ids: Sequence[str],
+    target_sample_id: str,
+) -> tuple[int, str]:
+    count = 0
+    first = ""
+    selected = ""
+    with path.open(encoding="utf-8", errors="replace") as log_file:
+        for line in log_file:
+            command, logged_sample_id = _command_record_from_log_line(line)
+            if not command:
+                continue
+            indexed_sample_id = sample_ids[count] if count < len(sample_ids) else ""
+            command_sample_id = logged_sample_id or indexed_sample_id
+            count += 1
+            first = first or command
+            if _sample_ids_match(command_sample_id, target_sample_id):
+                selected = command
+    return count, selected or first
+
+
+def _commands_from_logs(root: Path) -> dict[str, Any]:
+    sample_ids = _prepared_sample_ids(root)
+    disagreement_id = _first_disagreement_id(root)
+    representative_id = disagreement_id or (sample_ids[0] if sample_ids else "")
+    commands: dict[str, list[str]] = {"hf": [], "trtmc": []}
+    counts = {"hf": 0, "trtmc": 0}
+    logs: dict[str, list[str]] = {"hf": [], "trtmc": []}
+    for path in sorted(root.rglob("*.log")):
+        kind = "hf" if "hf" in path.name.lower() else "trtmc"
+        count, representative = _summarize_command_log(
+            path,
+            sample_ids=sample_ids if path.name == "trtfb_run.log" else (),
+            target_sample_id=representative_id,
+        )
+        counts[kind] += count
+        if count:
+            logs[kind].append(str(path.relative_to(root)))
+        _append_unique(commands, kind, representative)
+    for kind in commands:
+        commands[kind] = commands[kind][:MAX_REPRO_COMMANDS_PER_BACKEND]
+    return {
+        **commands,
+        "command_count": counts,
+        "commands_shown": {kind: len(values) for kind, values in commands.items()},
+        "command_logs": logs,
+        "representative": {
+            "sample_id": representative_id,
+            "reason": "first_disagreement" if disagreement_id else "first_input",
+        },
+        "prepared_input_count": len(sample_ids),
+    }
 
 
 def _append_unique(commands: dict[str, list[str]], kind: str, command: str) -> None:
@@ -449,11 +596,22 @@ def _collect_e2e_result_commands(
         )
 
 
-def _commands_from_e2e_results(results: Sequence[Mapping[str, Any]]) -> dict[str, list[str]]:
+def _commands_from_e2e_results(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     commands = {"hf": [], "trtmc": []}
     for result in results:
         _collect_e2e_result_commands(commands, result)
-    return commands
+    counts = {kind: len(values) for kind, values in commands.items()}
+    commands = {
+        kind: values[:MAX_REPRO_COMMANDS_PER_BACKEND]
+        for kind, values in commands.items()
+    }
+    return {
+        **commands,
+        "command_count": counts,
+        "commands_shown": {kind: len(values) for kind, values in commands.items()},
+        "command_logs": {"hf": [], "trtmc": []},
+        "representative": {"sample_id": "", "reason": "first_input"},
+    }
 
 
 _PRIMARY_COMPARISON_METRICS = (
@@ -599,6 +757,74 @@ def _validation_details(
     return {"status": status_by_comparison[str(comparison["status"])]}
 
 
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def _normalized_command_count(
+    reproduce: Mapping[str, Any],
+    kind: str,
+    commands: Sequence[str],
+) -> int:
+    counts = reproduce.get("command_count", {})
+    configured = counts.get(kind) if isinstance(counts, dict) else None
+    try:
+        return max(int(configured), len(commands))
+    except (TypeError, ValueError):
+        return len(commands)
+
+
+def _normalized_command_logs(reproduce: Mapping[str, Any], kind: str) -> list[str]:
+    logs = reproduce.get("command_logs", {})
+    return _string_list(logs.get(kind, [])) if isinstance(logs, dict) else []
+
+
+def _normalize_reproduction(value: Any) -> dict[str, Any]:
+    reproduce = value if isinstance(value, dict) else {}
+    all_commands = {
+        kind: _string_list(reproduce.get(kind, []))
+        for kind in ("hf", "trtmc")
+    }
+    commands = {
+        kind: values[:MAX_REPRO_COMMANDS_PER_BACKEND]
+        for kind, values in all_commands.items()
+    }
+    dataset = reproduce.get("dataset", {})
+    if not isinstance(dataset, dict):
+        dataset = {"command": str(dataset)} if str(dataset).strip() else {}
+    representative = reproduce.get("representative", {})
+    if not isinstance(representative, dict):
+        representative = {}
+    return {
+        "dataset": dataset,
+        **commands,
+        "command_count": {
+            kind: _normalized_command_count(reproduce, kind, all_commands[kind])
+            for kind in commands
+        },
+        "commands_shown": {kind: len(values) for kind, values in commands.items()},
+        "command_logs": {
+            kind: _normalized_command_logs(reproduce, kind) for kind in commands
+        },
+        "representative": representative,
+    }
+
+
+def _add_dataset_reproduction(
+    reproduce: Mapping[str, Any],
+    command: str,
+) -> dict[str, Any]:
+    result = dict(reproduce)
+    prepared_input_count = int(result.pop("prepared_input_count", 0) or 0)
+    result["dataset"] = {
+        "command": command,
+        "prepared_input_count": prepared_input_count,
+    }
+    return result
+
+
 def _normalize_result(result: Mapping[str, Any]) -> dict[str, Any]:
     normalized = dict(result)
     raw_result = _raw_comparison(normalized)
@@ -611,19 +837,13 @@ def _normalize_result(result: Mapping[str, Any]) -> dict[str, Any]:
     validation = normalized.get("validation")
     if not isinstance(validation, dict):
         validation = _validation_details(execution, comparison)
-    reproduce = normalized.get("reproduce", {})
-    if not isinstance(reproduce, dict):
-        reproduce = {}
     normalized.update(
         {
             "schema_version": "trtmc.validation-result/v2",
             "execution": execution,
             "comparison": comparison,
             "validation": validation,
-            "reproduce": {
-                "hf": list(reproduce.get("hf", [])),
-                "trtmc": list(reproduce.get("trtmc", [])),
-            },
+            "reproduce": _normalize_reproduction(normalized.get("reproduce")),
         }
     )
     normalized.pop("returncode", None)
@@ -637,6 +857,7 @@ def _comparison_result(
     case_dir: Path,
     returncode: int,
     reference_environment: EnvironmentSelection,
+    dataset_command: str,
 ) -> dict[str, Any]:
     summary_path = case_dir / "validation" / binding.workload / "eval_summary.json"
     raw_result: dict[str, Any] = {}
@@ -662,7 +883,10 @@ def _comparison_result(
         "reference_environment": [
             {"name": name, "python": path} for name, path in reference_environment.names_and_paths
         ],
-        "reproduce": _commands_from_logs(work_dir),
+        "reproduce": _add_dataset_reproduction(
+            _commands_from_logs(work_dir),
+            dataset_command,
+        ),
         "raw_result": raw_result,
         "raw_result_path": str(summary_path),
         "execution_log": str(case_dir / "execution.log"),
@@ -676,6 +900,7 @@ def _e2e_result(
     case_dir: Path,
     returncode: int,
     reference_environment: EnvironmentSelection,
+    dataset_command: str,
 ) -> dict[str, Any]:
     result_paths = sorted((case_dir / "e2e").glob("*/result.json"))
     raw_results = [json.loads(path.read_text(encoding="utf-8")) for path in result_paths]
@@ -696,7 +921,10 @@ def _e2e_result(
         "reference_environment": [
             {"name": name, "python": path} for name, path in reference_environment.names_and_paths
         ],
-        "reproduce": _commands_from_e2e_results(raw_results),
+        "reproduce": _add_dataset_reproduction(
+            _commands_from_e2e_results(raw_results),
+            dataset_command,
+        ),
         "raw_result_paths": [str(path) for path in result_paths],
         "raw_results": raw_results,
         "execution_log": str(case_dir / "execution.log"),
@@ -722,6 +950,7 @@ def run_binding(
     environment = ensure_environments(profiles, str(arguments.hf_python))
     process_env = _source_environment()
     process_env.update(environment.overrides)
+    dataset_command = shlex.join([sys.executable, *sys.argv])
 
     if binding.workload == "e2e":
         command = _e2e_command(
@@ -736,6 +965,7 @@ def run_binding(
             case_dir=case_dir,
             returncode=returncode,
             reference_environment=environment,
+            dataset_command=dataset_command,
         )
     else:
         suite = suites[binding.workload]
@@ -757,6 +987,7 @@ def run_binding(
             case_dir=case_dir,
             returncode=returncode,
             reference_environment=environment,
+            dataset_command=dataset_command,
         )
 
     comparison = case_dir / "comparison.json"
@@ -813,16 +1044,16 @@ def _merge_commands_from_result_logs(result: dict[str, Any]) -> None:
     if not root.is_dir():
         return
     discovered = _commands_from_logs(root)
-    reproduce = result.setdefault("reproduce", {})
+    reproduce = result.get("reproduce", {})
     if not isinstance(reproduce, dict):
-        return
+        reproduce = {}
     for kind in ("hf", "trtmc"):
-        commands = reproduce.setdefault(kind, [])
-        if not isinstance(commands, list):
-            continue
-        for command in discovered[kind]:
-            if command not in commands:
-                commands.append(command)
+        existing = _string_list(reproduce.get(kind, []))
+        extra = [command for command in existing if command not in discovered[kind]]
+        discovered[kind] = (extra + discovered[kind])[:MAX_REPRO_COMMANDS_PER_BACKEND]
+        discovered["command_count"][kind] += len(extra)
+    discovered["dataset"] = reproduce.get("dataset", {})
+    result["reproduce"] = _normalize_reproduction(discovered)
 
 
 def _result_commands(result: Mapping[str, Any], kind: str) -> list[str]:
@@ -835,27 +1066,97 @@ def _result_commands(result: Mapping[str, Any], kind: str) -> list[str]:
     return [str(command) for command in commands if str(command).strip()]
 
 
-def _render_command_group(label: str, commands: Sequence[str]) -> str:
+def _render_command_group(
+    label: str,
+    commands: Sequence[str],
+    *,
+    total: int | None = None,
+    logs: Sequence[str] = (),
+) -> str:
     if not commands:
         body = '<span class="unavailable">Not reached; see comparison.json.</span>'
     else:
         shell = "\n".join(f"$ {command}" for command in commands)
         body = f"<pre><code>{html.escape(shell)}</code></pre>"
+    command_total = len(commands) if total is None else total
+    if command_total > len(commands):
+        locations = ", ".join(logs) or "comparison.json"
+        body += (
+            f'<div class="detail">Showing {len(commands)} of {command_total} commands. '
+            f"Full command log: {html.escape(locations)}.</div>"
+        )
     return f"<h4>{html.escape(label)}</h4>{body}"
+
+
+def _reproduction_count(result: Mapping[str, Any], kind: str) -> int:
+    reproduce = result.get("reproduce", {})
+    counts = reproduce.get("command_count", {}) if isinstance(reproduce, dict) else {}
+    commands = _result_commands(result, kind)
+    try:
+        return max(int(counts.get(kind)), len(commands)) if isinstance(counts, dict) else len(commands)
+    except (TypeError, ValueError):
+        return len(commands)
+
+
+def _reproduction_logs(result: Mapping[str, Any], kind: str) -> list[str]:
+    reproduce = result.get("reproduce", {})
+    logs = reproduce.get("command_logs", {}) if isinstance(reproduce, dict) else {}
+    return _string_list(logs.get(kind, [])) if isinstance(logs, dict) else []
+
+
+def _dataset_reproduction(result: Mapping[str, Any]) -> tuple[str, int]:
+    reproduce = result.get("reproduce", {})
+    dataset = reproduce.get("dataset", {}) if isinstance(reproduce, dict) else {}
+    if not isinstance(dataset, dict):
+        return "", 0
+    command = str(dataset.get("command", "") or "")
+    try:
+        prepared = int(dataset.get("prepared_input_count", 0) or 0)
+    except (TypeError, ValueError):
+        prepared = 0
+    return command, prepared
+
+
+def _representative_note(result: Mapping[str, Any]) -> str:
+    reproduce = result.get("reproduce", {})
+    representative = (
+        reproduce.get("representative", {}) if isinstance(reproduce, dict) else {}
+    )
+    if not isinstance(representative, dict):
+        return ""
+    sample_id = str(representative.get("sample_id", "") or "")
+    if not sample_id:
+        return ""
+    reason = str(representative.get("reason", "") or "").replace("_", " ")
+    return (
+        '<div class="detail">Representative sample: '
+        f"{html.escape(sample_id)}"
+        f" ({html.escape(reason)}).</div>"
+    )
 
 
 def _render_reproduction(result: Mapping[str, Any]) -> str:
     reference_commands = _result_commands(result, "hf")
     trtmc_commands = _result_commands(result, "trtmc")
+    dataset_command, prepared_input_count = _dataset_reproduction(result)
+    reference_total = _reproduction_count(result, "hf")
+    trtmc_total = _reproduction_count(result, "trtmc")
+    dataset_label = (
+        f"Full dataset ({prepared_input_count} prepared inputs)"
+        if prepared_input_count
+        else "Full dataset"
+    )
     summary = (
-        f"Reference {len(reference_commands)} · "
-        f"TRTMC {len(trtmc_commands)}"
+        f"Dataset · Reference {len(reference_commands)}/{reference_total} · "
+        f"TRTMC {len(trtmc_commands)}/{trtmc_total}"
     )
     return (
         f"<details><summary>{summary}</summary>"
         '<div class="commands">'
-        f"{_render_command_group('Reference', reference_commands)}"
-        f"{_render_command_group('TRTMC', trtmc_commands)}"
+        f"{_render_command_group(dataset_label, [dataset_command] if dataset_command else [])}"
+        f"{_render_command_group('Reference sample', reference_commands, total=reference_total, logs=_reproduction_logs(result, 'hf'))}"
+        f"{_render_command_group('TRTMC sample', trtmc_commands, total=trtmc_total, logs=_reproduction_logs(result, 'trtmc'))}"
+        f"{_representative_note(result)}"
         "</div></details>"
     )
 
@@ -1051,10 +1352,11 @@ def _report_document(
     provenance = _report_provenance(report.get("run", {}))
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
-<title>TRTMC Validation Report</title>
+<title>TRTMC Reference Consistency Report</title>
 <style>
 body {{ font: 14px system-ui, sans-serif; margin: 32px; color: #202124; }}
 h1 {{ margin-bottom: 4px; }}
+.purpose {{ color: #5f6368; margin-bottom: 8px; }}
 .summary {{ color: #5f6368; margin-bottom: 24px; }}
 table {{ border-collapse: collapse; width: 100%; }}
 th, td {{ border: 1px solid #dadce0; padding: 8px 10px; text-align: left; }}
@@ -1088,7 +1390,8 @@ pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
 .metric.primary {{ font-size: 13px; }}
 .metric.primary span, .metric.primary strong {{ color: #202124; }}
 </style></head><body>
-<h1>TRTMC Validation Report</h1>
+<h1>TRTMC Reference Consistency Report</h1>
+<div class="purpose">Accuracy and output agreement against the model reference.</div>
 <div class="summary">{report["summary"]["cases"]} cases ·
 {comparison_counts["agreement"]} agreements ·
 {comparison_counts["disagreement"]} disagreements ·
@@ -1148,15 +1451,19 @@ def _print_result(result: Mapping[str, Any], comparison: Path, report: Path) -> 
     reproduce = result.get("reproduce", {})
     hf_commands = reproduce.get("hf", []) if isinstance(reproduce, dict) else []
     trtmc_commands = reproduce.get("trtmc", []) if isinstance(reproduce, dict) else []
+    dataset_command, _ = _dataset_reproduction(result)
     print()
-    print("Reproduce HF:")
+    print("Reproduce full dataset:")
+    print(f"  {dataset_command}" if dataset_command else "  unavailable; see comparison result")
+    print()
+    print("Reproduce representative HF:")
     if hf_commands:
         for command in hf_commands:
             print(f"  {command}")
     else:
         print("  unavailable; see comparison result")
     print()
-    print("Reproduce TRTMC:")
+    print("Reproduce representative TRTMC:")
     if trtmc_commands:
         for command in trtmc_commands:
             print(f"  {command}")

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -1396,26 +1396,14 @@ def _render_reproduction(
 ) -> str:
     reference_commands = _result_commands(result, "hf")
     trtmc_commands = _result_commands(result, "trtmc")
-    dataset_command, sample_limit, prepared_input_count = _dataset_reproduction(result)
+    dataset_command, sample_limit, _ = _dataset_reproduction(result)
     reference_total = _reproduction_count(result, "hf")
     trtmc_total = _reproduction_count(result, "trtmc")
-    input_label = "input" if prepared_input_count == 1 else "inputs"
     if sample_limit:
         sample_label = "sample" if sample_limit == 1 else "samples"
-        prepared_label = (
-            f"; {prepared_input_count} prepared {input_label}"
-            if prepared_input_count
-            else ""
-        )
-        dataset_label = (
-            f"Dataset slice ({sample_limit} selected {sample_label}{prepared_label})"
-        )
+        dataset_label = f"Dataset slice ({sample_limit} {sample_label})"
     else:
-        dataset_label = (
-            f"Full dataset ({prepared_input_count} prepared {input_label})"
-            if prepared_input_count
-            else "Full dataset"
-        )
+        dataset_label = "Full dataset"
     summary = (
         f"Dataset · Reference {len(reference_commands)}/{reference_total} · "
         f"TRTMC {len(trtmc_commands)}/{trtmc_total}"
@@ -1558,25 +1546,12 @@ def _render_validation(result: Mapping[str, Any]) -> str:
 
 
 def _render_samples(result: Mapping[str, Any]) -> str:
-    _command, sample_limit, prepared_input_count = _dataset_reproduction(result)
+    _command, sample_limit, _ = _dataset_reproduction(result)
     if sample_limit:
-        selected = f"{sample_limit} selected"
-        if prepared_input_count and prepared_input_count != sample_limit:
-            input_label = "input" if prepared_input_count == 1 else "inputs"
-            return (
-                f'{selected}<br><span class="detail">'
-                f"{prepared_input_count} prepared {input_label}</span>"
-            )
-        return selected
-    if prepared_input_count:
-        input_label = "input" if prepared_input_count == 1 else "inputs"
-        return (
-            f'Full<br><span class="detail">'
-            f"{prepared_input_count} prepared {input_label}</span>"
-        )
+        return str(sample_limit)
     if result.get("workload") == "e2e":
         return "E2E"
-    return '<span class="unavailable">Unavailable</span>'
+    return "Full"
 
 
 def _normalize_result_files(
@@ -1711,8 +1686,7 @@ pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
 {comparison_counts["agreement"]} agreements ·
 {comparison_counts["disagreement"]} disagreements ·
 {execution_errors} execution errors ·
-{report["summary"]["selected_samples"]} selected samples ·
-{report["summary"]["prepared_inputs"]} prepared inputs<br>
+{report["summary"]["selected_samples"]} samples<br>
 {html.escape(provenance)}</div>
 <table><thead><tr><th>Model</th><th>Workload</th><th>Samples</th><th>Execution</th>
 <th>Reference</th><th>Comparison</th><th>Agreement metrics</th>
@@ -1726,7 +1700,7 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
     result_paths = sorted(output.glob("*/*/comparison.json"))
     results = _normalize_result_files(result_paths)
     validation_counts, comparison_counts, execution_errors = _report_counts(results)
-    sampling = [_dataset_reproduction(result)[1:] for result in results]
+    sample_limits = [_dataset_reproduction(result)[1] for result in results]
     report = {
         "schema_version": "trtmc.validation-report/v2",
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -1743,8 +1717,7 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
             "validation_passed": validation_counts["passed"],
             "validation_failed": validation_counts["failed"],
             "validation_skipped": validation_counts["skipped"],
-            "selected_samples": sum(limit for limit, _prepared in sampling),
-            "prepared_inputs": sum(prepared for _limit, prepared in sampling),
+            "selected_samples": sum(sample_limits),
         },
         "results": results,
     }

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -18,6 +18,7 @@ import platform
 import shlex
 import subprocess
 import sys
+import tempfile
 from typing import Any, Iterable, Mapping, Sequence
 
 import yaml
@@ -63,6 +64,37 @@ class EnvironmentSelection:
     base_python: str
     names_and_paths: tuple[tuple[str, str], ...]
     overrides: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class ReferenceSource:
+    name: str
+    repository: str
+    revision: str
+    relative_checkout: Path
+    entrypoint: Path
+
+
+@dataclass(frozen=True)
+class ReferenceSourceSelection:
+    environment: Mapping[str, str]
+    elf_reference_repo: Path | None = None
+
+
+ELF_SOURCE = ReferenceSource(
+    name="ELF",
+    repository="https://github.com/lillian039/ELF.git",
+    revision="b29d8833609e9ab7f67cd9da39435ac5cea04837",
+    relative_checkout=Path("elf/reference/ELF-b29d8833609e"),
+    entrypoint=Path("src"),
+)
+SANA_WM_SOURCE = ReferenceSource(
+    name="SANA-WM",
+    repository="https://github.com/NVlabs/Sana.git",
+    revision="59629fdf790850797cb657bad014fce432bd713d",
+    relative_checkout=Path("sana_wm/reference/Sana-59629fdf7908"),
+    entrypoint=Path("inference_video_scripts/wm/inference_sana_wm.py"),
+)
 
 
 def _validate_model_spec(path: Path, name: Any, spec: Any) -> None:
@@ -257,16 +289,19 @@ def _binding_profiles(
 ) -> tuple[str, ...]:
     if binding.workload != "e2e":
         model = task_models[binding.model]
+        profile = _declared_profile(
+            family=str(model.get("family", "") or ""),
+            runtime_strategy=str(model.get("runtime_strategy", "") or ""),
+            reference_backend=str(model.get("reference_backend", "") or ""),
+            execution_profiles=model.get("execution_profiles"),
+        )
         return (
-            _declared_profile(
-                family=str(model.get("family", "") or ""),
-                runtime_strategy=str(model.get("runtime_strategy", "") or ""),
-                reference_backend=str(model.get("reference_backend", "") or ""),
-                execution_profiles=model.get("execution_profiles"),
-            ),
+            (COMMON_REFERENCE_PROFILE,)
+            if profile == COMMON_REFERENCE_PROFILE
+            else (COMMON_REFERENCE_PROFILE, profile)
         )
 
-    profiles = []
+    profiles = [COMMON_REFERENCE_PROFILE]
     for case in e2e_models[binding.model].testcases:
         profile = _declared_profile(
             family=case.family,
@@ -307,6 +342,79 @@ def ensure_environments(
         names_and_paths=tuple(names_and_paths),
         overrides=overrides,
     )
+
+
+def _ensure_reference_source(source: ReferenceSource, cache_root: Path) -> Path:
+    checkout = cache_root / source.relative_checkout
+    entrypoint = checkout / source.entrypoint
+    if entrypoint.exists():
+        print(f"Using reference source: {checkout}", flush=True)
+        return checkout
+    if checkout.exists():
+        raise ValidationError(f"Incomplete cached {source.name} reference: {checkout}")
+
+    checkout.parent.mkdir(parents=True, exist_ok=True)
+    print(f"Creating reference source: {source.name}", flush=True)
+    try:
+        with tempfile.TemporaryDirectory(
+            prefix=f".{checkout.name}-",
+            dir=checkout.parent,
+        ) as temporary:
+            staged = Path(temporary) / "checkout"
+            subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    "--filter=blob:none",
+                    "--no-checkout",
+                    source.repository,
+                    str(staged),
+                ],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(staged),
+                    "checkout",
+                    "--detach",
+                    source.revision,
+                ],
+                check=True,
+            )
+            if not (staged / source.entrypoint).exists():
+                raise ValidationError(
+                    f"Pinned {source.name} checkout is missing "
+                    f"{source.entrypoint}"
+                )
+            staged.rename(checkout)
+    except subprocess.CalledProcessError as exc:
+        raise ValidationError(
+            f"Could not prepare pinned {source.name} reference "
+            f"{source.revision}: git exited with code {exc.returncode}"
+        ) from exc
+    print(f"Using reference source: {checkout}", flush=True)
+    return checkout
+
+
+def ensure_reference_sources(
+    family: str,
+    cache_root: Path,
+) -> ReferenceSourceSelection:
+    environment = {"TRTMC_STORAGE_ROOT": str(cache_root)}
+    if family == "elf_flow":
+        checkout = _ensure_reference_source(ELF_SOURCE, cache_root)
+        return ReferenceSourceSelection(
+            environment=environment,
+            elf_reference_repo=checkout,
+        )
+    if family == "sana_wm":
+        checkout = _ensure_reference_source(SANA_WM_SOURCE, cache_root)
+        environment["SANA_WM_SCRIPT"] = str(
+            checkout / SANA_WM_SOURCE.entrypoint
+        )
+    return ReferenceSourceSelection(environment=environment)
 
 
 def _dataset_path(suite: Mapping[str, Any], dataset_root: Path | None) -> Path:
@@ -356,10 +464,11 @@ def _comparison_command(
     dataset: Path,
     arguments: argparse.Namespace,
     reference_python: str,
+    reference_sources: ReferenceSourceSelection | None = None,
 ) -> list[str]:
     work_root = case_dir / "validation"
     command = [
-        sys.executable,
+        reference_python,
         str(REPO_ROOT / "tools" / "trtmc_compare.py"),
         "--suite",
         binding.workload,
@@ -400,6 +509,13 @@ def _comparison_command(
         command.extend(["--model-plugin-dir", str(arguments.model_plugin_dir)])
     if arguments.cuda_visible_devices:
         command.extend(["--cuda-visible-devices", arguments.cuda_visible_devices])
+    if reference_sources and reference_sources.elf_reference_repo:
+        command.extend(
+            [
+                "--elf-reference-repo",
+                str(reference_sources.elf_reference_repo),
+            ]
+        )
     return command
 
 
@@ -411,7 +527,7 @@ def _e2e_command(
     reference_python: str,
 ) -> list[str]:
     command = [
-        sys.executable,
+        reference_python,
         "-m",
         "pytest",
         "tests/test_e2e.py",
@@ -583,6 +699,36 @@ def _command_log_kind(path: Path, *, has_native_reference: bool) -> str | None:
     return "hf" if "hf" in path.name.lower() else "trtmc"
 
 
+def _relocate_cached_reference_command(command: str, work_dir: Path) -> str:
+    """Point a cached native reference command at the current materialized run."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return command
+    original_work_dir = None
+    for flag in ("--manifest", "--prompts", "--answers"):
+        if flag in tokens:
+            index = tokens.index(flag)
+            if index + 1 < len(tokens):
+                candidate = Path(tokens[index + 1])
+                if candidate.is_absolute():
+                    original_work_dir = candidate.parent
+                    break
+    if original_work_dir is None:
+        return command
+    original_prefix = str(original_work_dir)
+    current_prefix = str(work_dir.resolve())
+    relocated = [
+        (
+            current_prefix + token[len(original_prefix) :]
+            if token == original_prefix or token.startswith(original_prefix + os.sep)
+            else token
+        )
+        for token in tokens
+    ]
+    return shlex.join(relocated)
+
+
 def _collect_command_logs(
     root: Path,
     *,
@@ -604,6 +750,11 @@ def _collect_command_logs(
             sample_ids=indexed_sample_ids,
             target_sample_id=representative_id,
         )
+        if path.name == "hf_native_run.log":
+            representative = _relocate_cached_reference_command(
+                representative,
+                root,
+            )
         counts[kind] += count
         if count:
             logs[kind].append(str(path.relative_to(root)))
@@ -1054,8 +1205,13 @@ def run_binding(
         e2e_models=e2e_models,
     )
     environment = ensure_environments(profiles, str(arguments.hf_python))
+    reference_sources = ensure_reference_sources(
+        str(task_models[binding.model].get("family", "") or ""),
+        Path(arguments.reference_cache_dir),
+    )
     process_env = _source_environment()
     process_env.update(environment.overrides)
+    process_env.update(reference_sources.environment)
     dataset_command = shlex.join([sys.executable, *sys.argv])
 
     if binding.workload == "e2e":
@@ -1086,6 +1242,7 @@ def run_binding(
             dataset=dataset,
             arguments=arguments,
             reference_python=environment.base_python,
+            reference_sources=reference_sources,
         )
         returncode = _run_subprocess(command, case_dir / "execution.log", process_env)
         result = _comparison_result(

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -691,6 +691,15 @@ _COMPARISON_METRICS = (
 _EXECUTION_ERROR_FIELDS = ("error", "exception", "traceback", "failure_class")
 
 
+def _is_comparison_gate_failure(raw_result: Mapping[str, Any]) -> bool:
+    failures = raw_result.get("gate_failures")
+    return (
+        raw_result.get("error_type") == "BenchmarkGateError"
+        and isinstance(failures, list)
+        and bool(failures)
+    )
+
+
 def _raw_comparison(result: Mapping[str, Any]) -> dict[str, Any]:
     raw_result = result.get("raw_result")
     if isinstance(raw_result, dict) and raw_result:
@@ -710,7 +719,12 @@ def _execution_details(
     result: Mapping[str, Any],
     raw_result: Mapping[str, Any],
 ) -> dict[str, Any]:
-    has_error = any(raw_result.get(name) for name in _EXECUTION_ERROR_FIELDS)
+    comparison_gate_failure = _is_comparison_gate_failure(raw_result)
+    has_error = any(
+        raw_result.get(name)
+        for name in _EXECUTION_ERROR_FIELDS
+        if name != "error" or not comparison_gate_failure
+    )
     completed = bool(raw_result) and not has_error
     return {
         "status": "completed" if completed else "error",

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -389,12 +389,27 @@ def _commands_from_logs(root: Path) -> dict[str, list[str]]:
     for path in sorted(root.rglob("*.log")):
         kind = "hf" if "hf" in path.name.lower() else "trtmc"
         for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-            if not line.startswith("$ "):
-                continue
-            value = line[2:].strip()
+            value = _command_from_log_line(line)
             if value and value not in commands[kind]:
                 commands[kind].append(value)
     return commands
+
+
+def _command_from_log_line(line: str) -> str:
+    if line.startswith("$ "):
+        return line[2:].strip()
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    command = data.get("command")
+    if isinstance(command, list) and command:
+        return shlex.join(str(token) for token in command)
+    if isinstance(command, str):
+        return command.strip()
+    return ""
 
 
 def _append_unique(commands: dict[str, list[str]], kind: str, command: str) -> None:
@@ -618,9 +633,67 @@ def _report_provenance(run: Mapping[str, Any]) -> str:
     return " · ".join(f"{name}={value}" for name, value in fields if value)
 
 
+def _merge_commands_from_result_logs(result: dict[str, Any]) -> None:
+    raw_result = result.get("raw_result", {})
+    work_dir = raw_result.get("work_dir") if isinstance(raw_result, dict) else None
+    if not work_dir:
+        return
+    root = Path(str(work_dir))
+    if not root.is_dir():
+        return
+    discovered = _commands_from_logs(root)
+    reproduce = result.setdefault("reproduce", {})
+    if not isinstance(reproduce, dict):
+        return
+    for kind in ("hf", "trtmc"):
+        commands = reproduce.setdefault(kind, [])
+        if not isinstance(commands, list):
+            continue
+        for command in discovered[kind]:
+            if command not in commands:
+                commands.append(command)
+
+
+def _result_commands(result: Mapping[str, Any], kind: str) -> list[str]:
+    reproduce = result.get("reproduce", {})
+    if not isinstance(reproduce, dict):
+        return []
+    commands = reproduce.get(kind, [])
+    if not isinstance(commands, list):
+        return []
+    return [str(command) for command in commands if str(command).strip()]
+
+
+def _render_command_group(label: str, commands: Sequence[str]) -> str:
+    if not commands:
+        body = '<span class="unavailable">Not reached; see comparison.json.</span>'
+    else:
+        shell = "\n".join(f"$ {command}" for command in commands)
+        body = f"<pre><code>{html.escape(shell)}</code></pre>"
+    return f"<h4>{html.escape(label)}</h4>{body}"
+
+
+def _render_reproduction(result: Mapping[str, Any]) -> str:
+    reference_commands = _result_commands(result, "hf")
+    trtmc_commands = _result_commands(result, "trtmc")
+    summary = (
+        f"Reference {len(reference_commands)} · "
+        f"TRTMC {len(trtmc_commands)}"
+    )
+    return (
+        f"<details><summary>{summary}</summary>"
+        '<div class="commands">'
+        f"{_render_command_group('Reference', reference_commands)}"
+        f"{_render_command_group('TRTMC', trtmc_commands)}"
+        "</div></details>"
+    )
+
+
 def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
     result_paths = sorted(output.glob("*/*/comparison.json"))
     results = [json.loads(path.read_text(encoding="utf-8")) for path in result_paths]
+    for result in results:
+        _merge_commands_from_result_logs(result)
     counts = {
         name: sum(result.get("status") == name for result in results)
         for name in ("passed", "failed", "skipped")
@@ -654,6 +727,7 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
             f"<td>{html.escape(str(result.get('workload', '')))}</td>"
             f'<td class="{html.escape(status)}">{html.escape(status)}</td>'
             f"<td>{html.escape(environments)}</td>"
+            f"<td>{_render_reproduction(result)}</td>"
             f'<td><a href="{html.escape(str(relative))}">comparison.json</a></td>'
             "</tr>"
         )
@@ -668,6 +742,13 @@ h1 {{ margin-bottom: 4px; }}
 table {{ border-collapse: collapse; width: 100%; }}
 th, td {{ border: 1px solid #dadce0; padding: 8px 10px; text-align: left; }}
 th {{ background: #f8f9fa; }}
+details {{ min-width: 210px; }}
+summary {{ cursor: pointer; color: #185abc; }}
+.commands {{ min-width: min(760px, 70vw); padding: 4px 0; }}
+.commands h4 {{ margin: 12px 0 4px; }}
+pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
+       background: #f8f9fa; border: 1px solid #dadce0; border-radius: 4px; }}
+.unavailable {{ color: #5f6368; }}
 .passed {{ color: #137333; font-weight: 600; }}
 .failed {{ color: #b3261e; font-weight: 600; }}
 .skipped {{ color: #8a4f00; font-weight: 600; }}
@@ -677,7 +758,7 @@ th {{ background: #f8f9fa; }}
 {counts["passed"]} passed · {counts["failed"]} failed · {counts["skipped"]} skipped<br>
 {html.escape(provenance)}</div>
 <table><thead><tr><th>Model</th><th>Workload</th><th>Status</th>
-<th>Reference environment</th><th>Result</th></tr></thead>
+<th>Reference environment</th><th>Vanilla reproduction</th><th>Result</th></tr></thead>
 <tbody>{"".join(rows)}</tbody></table>
 </body></html>
 """

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -1,0 +1,847 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run model-first TRTMC reference validation for Dev and QA."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import html
+import json
+import os
+from pathlib import Path
+import platform
+import shlex
+import subprocess
+import sys
+from typing import Any, Iterable, Mapping, Sequence
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYTHON_ROOT = REPO_ROOT / "python"
+for import_root in (REPO_ROOT, PYTHON_ROOT):
+    if str(import_root) not in sys.path:
+        sys.path.insert(0, str(import_root))
+
+from tensorrt_model_connect.python_profiles import (  # noqa: E402
+    DEFAULT_PROFILE,
+    normalize_execution_profiles,
+    profile_env_var,
+    resolve_profile_python,
+)
+from tests.e2e_harness.manifest_loader import load_all_model_manifests  # noqa: E402
+from tools import task_eval  # noqa: E402
+
+
+DEFAULT_CATALOG = REPO_ROOT / "tests" / "validation" / "model_workloads.yaml"
+DEFAULT_SUITES = REPO_ROOT / "tests" / "task_eval" / "validation_suites.yaml"
+DEFAULT_MODELS = REPO_ROOT / "tests" / "e2e" / "models"
+DEFAULT_OUTPUT = REPO_ROOT / "artifacts" / "trtmc-validate"
+COMMON_REFERENCE_PROFILE = "reference_common"
+
+
+class ValidationError(RuntimeError):
+    """The requested validation cannot be resolved or executed."""
+
+
+@dataclass(frozen=True)
+class Binding:
+    model: str
+    workload: str
+
+
+@dataclass(frozen=True)
+class EnvironmentSelection:
+    base_python: str
+    names_and_paths: tuple[tuple[str, str], ...]
+    overrides: Mapping[str, str]
+
+
+def _validate_model_spec(path: Path, name: Any, spec: Any) -> None:
+    if not isinstance(name, str) or not isinstance(spec, dict):
+        raise ValidationError(f"{path}: invalid model binding {name!r}")
+    workloads = spec.get("workloads")
+    default = spec.get("default")
+    valid_workloads = (
+        isinstance(workloads, list)
+        and bool(workloads)
+        and all(isinstance(item, str) and item for item in workloads)
+    )
+    if not valid_workloads:
+        raise ValidationError(f"{path}: {name}.workloads must contain names")
+    if default not in workloads:
+        raise ValidationError(f"{path}: {name}.default must be one of {name}.workloads")
+
+
+def load_catalog(path: Path = DEFAULT_CATALOG) -> dict[str, Any]:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict) or raw.get("version") != 1:
+        raise ValidationError(f"{path}: expected version: 1")
+    models = raw.get("models")
+    if not isinstance(models, dict) or not models:
+        raise ValidationError(f"{path}: models must be a non-empty mapping")
+    for name, spec in models.items():
+        _validate_model_spec(path, name, spec)
+    return raw
+
+
+def ready_model_names(models_root: Path = DEFAULT_MODELS) -> tuple[str, ...]:
+    models = task_eval.load_manifest_records(models_root)
+    return tuple(
+        sorted(
+            str(model["name"])
+            for model in models
+            if not model["requires_multi_device"] and not model.get("skip")
+        )
+    )
+
+
+def audit_catalog(
+    catalog: Mapping[str, Any],
+    *,
+    ready_models: Iterable[str],
+    suite_names: Iterable[str],
+) -> None:
+    models = catalog["models"]
+    ready = set(ready_models)
+    configured = set(models)
+    missing = sorted(ready - configured)
+    stale = sorted(configured - ready)
+    if missing or stale:
+        details = []
+        if missing:
+            details.append(f"missing ready models: {', '.join(missing)}")
+        if stale:
+            details.append(f"non-ready or unknown models: {', '.join(stale)}")
+        raise ValidationError("; ".join(details))
+
+    known_workloads = set(suite_names) | {"e2e"}
+    unknown = sorted(
+        {
+            workload
+            for spec in models.values()
+            for workload in spec["workloads"]
+            if workload not in known_workloads
+        }
+    )
+    if unknown:
+        raise ValidationError(f"unknown workloads: {', '.join(unknown)}")
+
+
+def audit_workload_compatibility(
+    catalog: Mapping[str, Any],
+    *,
+    suites: Mapping[str, dict[str, Any]],
+    task_models: Mapping[str, dict[str, Any]],
+) -> None:
+    incompatible = []
+    for model_name, spec in catalog["models"].items():
+        for workload in spec["workloads"]:
+            if workload == "e2e":
+                continue
+            matched, reason = task_eval.suite_match_reason(
+                suites[workload],
+                task_models[model_name],
+            )
+            if not matched:
+                incompatible.append(f"{model_name}/{workload}: {reason}")
+    if incompatible:
+        raise ValidationError("incompatible model/workload bindings: " + "; ".join(incompatible))
+
+
+def resolve_binding(
+    catalog: Mapping[str, Any],
+    model: str,
+    workload: str | None = None,
+) -> Binding:
+    models = catalog["models"]
+    if model not in models:
+        raise ValidationError(f"unknown or unsupported model: {model}")
+    spec = models[model]
+    selected = workload or spec["default"]
+    if selected not in spec["workloads"]:
+        available = ", ".join(spec["workloads"])
+        raise ValidationError(
+            f"model {model} does not declare workload {selected}; available: {available}"
+        )
+    return Binding(model=model, workload=selected)
+
+
+def _task_eval_models(models_root: Path) -> dict[str, dict[str, Any]]:
+    return {str(model["name"]): model for model in task_eval.load_manifest_records(models_root)}
+
+
+def _e2e_models(models_root: Path) -> dict[str, Any]:
+    return {model.name: model for model in load_all_model_manifests(models_root)}
+
+
+def _declared_profile(
+    *,
+    family: str,
+    runtime_strategy: str,
+    reference_backend: str,
+    execution_profiles: Mapping[str, str] | None,
+) -> str:
+    profiles = normalize_execution_profiles(
+        execution_profiles,
+        family=family,
+        runtime_strategy=runtime_strategy,
+        reference_backend=reference_backend,
+    )
+    profile = profiles["reference"]
+    if profile == DEFAULT_PROFILE:
+        return COMMON_REFERENCE_PROFILE
+    return profile
+
+
+def _binding_profiles(
+    binding: Binding,
+    *,
+    task_models: Mapping[str, dict[str, Any]],
+    e2e_models: Mapping[str, Any],
+) -> tuple[str, ...]:
+    if binding.workload != "e2e":
+        model = task_models[binding.model]
+        return (
+            _declared_profile(
+                family=str(model.get("family", "") or ""),
+                runtime_strategy=str(model.get("runtime_strategy", "") or ""),
+                reference_backend=str(model.get("reference_backend", "") or ""),
+                execution_profiles=model.get("execution_profiles"),
+            ),
+        )
+
+    profiles = []
+    for case in e2e_models[binding.model].testcases:
+        profile = _declared_profile(
+            family=case.family,
+            runtime_strategy=case.runtime_strategy,
+            reference_backend=case.reference_backend,
+            execution_profiles=case.execution_profiles,
+        )
+        if profile not in profiles:
+            profiles.append(profile)
+    return tuple(profiles)
+
+
+def ensure_environments(
+    profile_names: Iterable[str],
+    base_python: str,
+) -> EnvironmentSelection:
+    names_and_paths = []
+    overrides = {}
+    selected_base = base_python
+
+    def announce_create(name: str) -> None:
+        print(f"Creating reference environment: {name}", flush=True)
+
+    for name in profile_names:
+        path = resolve_profile_python(
+            name,
+            base_python,
+            on_create=announce_create,
+        )
+        print(f"Using reference environment: {path}", flush=True)
+        names_and_paths.append((name, path))
+        if name == COMMON_REFERENCE_PROFILE:
+            selected_base = path
+        elif name != DEFAULT_PROFILE:
+            overrides[profile_env_var(name)] = path
+    return EnvironmentSelection(
+        base_python=selected_base,
+        names_and_paths=tuple(names_and_paths),
+        overrides=overrides,
+    )
+
+
+def _dataset_path(suite: Mapping[str, Any], dataset_root: Path | None) -> Path:
+    raw = str(suite.get("dataset", {}).get("default_path", "") or "")
+    if not raw:
+        raise ValidationError(f"workload {suite.get('id')} has no default dataset path")
+    path = Path(raw)
+    if dataset_root is None:
+        return path
+    try:
+        relative = path.relative_to("/mnt/data")
+    except ValueError:
+        relative = Path(path.name)
+    return dataset_root / relative
+
+
+def _run_subprocess(command: Sequence[str], log_path: Path, env: Mapping[str, str]) -> int:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w", encoding="utf-8") as output:
+        output.write(f"$ {shlex.join(command)}\n")
+        output.flush()
+        completed = subprocess.run(
+            list(command),
+            check=False,
+            text=True,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            env=dict(env),
+        )
+    return completed.returncode
+
+
+def _source_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    existing = environment.get("PYTHONPATH", "")
+    roots = [str(PYTHON_ROOT), str(REPO_ROOT)]
+    if existing:
+        roots.append(existing)
+    environment["PYTHONPATH"] = os.pathsep.join(roots)
+    return environment
+
+
+def _task_eval_command(
+    binding: Binding,
+    *,
+    case_dir: Path,
+    dataset: Path,
+    arguments: argparse.Namespace,
+    reference_python: str,
+) -> list[str]:
+    work_root = case_dir / "task-eval"
+    command = [
+        sys.executable,
+        str(REPO_ROOT / "tools" / "task_eval.py"),
+        "eval",
+        "--suite",
+        binding.workload,
+        "--dataset",
+        str(dataset),
+        "--model",
+        binding.model,
+        "--work-root",
+        str(work_root),
+        "--engine-dir",
+        str(arguments.engine_dir),
+        "--trtmc-binary",
+        str(arguments.trtmc_binary),
+        "--benchmark-binary",
+        str(arguments.benchmark_binary),
+        "--hf-python",
+        reference_python,
+        "--single-device-only",
+        "--include-waived",
+        "--fail-fast",
+    ]
+    if arguments.limit:
+        command.extend(["--limit", str(arguments.limit)])
+    if arguments.force_hf:
+        command.append("--force-hf")
+    if arguments.force_build:
+        command.append("--force-build")
+    if arguments.no_build:
+        command.append("--require-prebuilt-bundles")
+    if arguments.local_files_only:
+        command.append("--local-files-only")
+    if arguments.backend_dir:
+        command.extend(["--backend-dir", str(arguments.backend_dir)])
+    if arguments.model_plugin_dir:
+        command.extend(["--model-plugin-dir", str(arguments.model_plugin_dir)])
+    if arguments.cuda_visible_devices:
+        command.extend(["--cuda-visible-devices", arguments.cuda_visible_devices])
+    return command
+
+
+def _e2e_command(
+    binding: Binding,
+    *,
+    case_dir: Path,
+    arguments: argparse.Namespace,
+    reference_python: str,
+) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "tests/test_e2e.py",
+        "-q",
+        "--e2e-model",
+        binding.model,
+        "--e2e-artifacts-dir",
+        str(case_dir / "e2e"),
+        "--engine-dir",
+        str(arguments.engine_dir),
+        "--trtmc-binary",
+        str(arguments.trtmc_binary),
+        "--hf-python",
+        reference_python,
+    ]
+    if arguments.platform:
+        command.extend(["--e2e-platform", arguments.platform])
+    if arguments.force_build:
+        command.append("--rebuild-engines")
+    if arguments.model_plugin_dir:
+        command.extend(["--model-plugin-dir", str(arguments.model_plugin_dir)])
+    return command
+
+
+def _commands_from_logs(root: Path) -> dict[str, list[str]]:
+    commands = {"hf": [], "trtmc": []}
+    for path in sorted(root.rglob("*.log")):
+        kind = "hf" if "hf" in path.name.lower() else "trtmc"
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if not line.startswith("$ "):
+                continue
+            value = line[2:].strip()
+            if value and value not in commands[kind]:
+                commands[kind].append(value)
+    return commands
+
+
+def _append_unique(commands: dict[str, list[str]], kind: str, command: str) -> None:
+    if command and command not in commands[kind]:
+        commands[kind].append(command)
+
+
+def _e2e_command_kind(command: Sequence[Any]) -> str:
+    executable = Path(str(command[0])).name
+    is_reference_python = "python" in executable and "-c" in command
+    return "hf" if is_reference_python else "trtmc"
+
+
+def _collect_e2e_result_commands(
+    commands: dict[str, list[str]],
+    result: Mapping[str, Any],
+) -> None:
+    for entry in result.get("commands", []):
+        command = entry.get("command", []) if isinstance(entry, dict) else []
+        if not isinstance(command, list) or not command:
+            continue
+        _append_unique(
+            commands,
+            _e2e_command_kind(command),
+            shlex.join(str(token) for token in command),
+        )
+    repro = result.get("repro_commands", {})
+    if isinstance(repro, dict):
+        _append_unique(
+            commands,
+            "trtmc",
+            str(repro.get("trt_inference", "") or ""),
+        )
+
+
+def _commands_from_e2e_results(results: Sequence[Mapping[str, Any]]) -> dict[str, list[str]]:
+    commands = {"hf": [], "trtmc": []}
+    for result in results:
+        _collect_e2e_result_commands(commands, result)
+    return commands
+
+
+def _task_eval_result(
+    binding: Binding,
+    *,
+    case_dir: Path,
+    returncode: int,
+    reference_environment: EnvironmentSelection,
+    command: Sequence[str],
+) -> dict[str, Any]:
+    summary_path = case_dir / "task-eval" / binding.workload / "eval_summary.json"
+    raw_result: dict[str, Any] = {}
+    if summary_path.is_file():
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        for candidate in summary.get("results", []):
+            if candidate.get("model") == binding.model:
+                raw_result = candidate
+                break
+        if not raw_result and summary.get("results"):
+            raw_result = summary["results"][0]
+    status = str(raw_result.get("status", "") or "")
+    if status not in {"passed", "failed", "skipped"}:
+        status = "passed" if returncode == 0 else "failed"
+    work_dir = case_dir / "task-eval" / binding.workload / binding.model
+    return {
+        "schema_version": "trtmc.validation-result/v1",
+        "model": binding.model,
+        "workload": binding.workload,
+        "executor": "task_eval",
+        "status": status,
+        "reference_environment": [
+            {"name": name, "python": path} for name, path in reference_environment.names_and_paths
+        ],
+        "reproduce": {
+            **_commands_from_logs(work_dir),
+            "validation": shlex.join(command),
+        },
+        "raw_result": raw_result,
+        "raw_result_path": str(summary_path),
+        "execution_log": str(case_dir / "execution.log"),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _e2e_result(
+    binding: Binding,
+    *,
+    case_dir: Path,
+    returncode: int,
+    reference_environment: EnvironmentSelection,
+    command: Sequence[str],
+) -> dict[str, Any]:
+    result_paths = sorted((case_dir / "e2e").glob("*/result.json"))
+    raw_results = [json.loads(path.read_text(encoding="utf-8")) for path in result_paths]
+    status = (
+        "passed"
+        if returncode == 0
+        and raw_results
+        and all(result.get("status") == "pass" for result in raw_results)
+        else "failed"
+    )
+    return {
+        "schema_version": "trtmc.validation-result/v1",
+        "model": binding.model,
+        "workload": binding.workload,
+        "executor": "e2e",
+        "status": status,
+        "reference_environment": [
+            {"name": name, "python": path} for name, path in reference_environment.names_and_paths
+        ],
+        "reproduce": {
+            **_commands_from_e2e_results(raw_results),
+            "validation": shlex.join(command),
+        },
+        "raw_result_paths": [str(path) for path in result_paths],
+        "raw_results": raw_results,
+        "execution_log": str(case_dir / "execution.log"),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def run_binding(
+    binding: Binding,
+    *,
+    arguments: argparse.Namespace,
+    task_models: Mapping[str, dict[str, Any]],
+    e2e_models: Mapping[str, Any],
+    suites: Mapping[str, dict[str, Any]],
+) -> dict[str, Any]:
+    case_dir = Path(arguments.output) / binding.model / binding.workload
+    case_dir.mkdir(parents=True, exist_ok=True)
+    profiles = _binding_profiles(
+        binding,
+        task_models=task_models,
+        e2e_models=e2e_models,
+    )
+    environment = ensure_environments(profiles, str(arguments.hf_python))
+    process_env = _source_environment()
+    process_env.update(environment.overrides)
+
+    if binding.workload == "e2e":
+        command = _e2e_command(
+            binding,
+            case_dir=case_dir,
+            arguments=arguments,
+            reference_python=environment.base_python,
+        )
+        returncode = _run_subprocess(command, case_dir / "execution.log", process_env)
+        result = _e2e_result(
+            binding,
+            case_dir=case_dir,
+            returncode=returncode,
+            reference_environment=environment,
+            command=command,
+        )
+    else:
+        suite = suites[binding.workload]
+        dataset = (
+            Path(arguments.dataset)
+            if arguments.dataset
+            else _dataset_path(suite, arguments.dataset_root)
+        )
+        command = _task_eval_command(
+            binding,
+            case_dir=case_dir,
+            dataset=dataset,
+            arguments=arguments,
+            reference_python=environment.base_python,
+        )
+        returncode = _run_subprocess(command, case_dir / "execution.log", process_env)
+        result = _task_eval_result(
+            binding,
+            case_dir=case_dir,
+            returncode=returncode,
+            reference_environment=environment,
+            command=command,
+        )
+
+    comparison = case_dir / "comparison.json"
+    comparison.write_text(
+        json.dumps(result, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return result
+
+
+def _source_revision() -> str:
+    configured = os.environ.get("TRTMC_VALIDATION_SOURCE_REVISION", "").strip()
+    if configured:
+        return configured
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def write_run_metadata(output: Path) -> Path:
+    metadata = {
+        "schema_version": "trtmc.validation-run/v1",
+        "source_revision": _source_revision(),
+        "hostname": platform.node(),
+        "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES", ""),
+        "command": shlex.join(sys.argv),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+    }
+    path = output / "run.json"
+    path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    return path
+
+
+def _report_provenance(run: Mapping[str, Any]) -> str:
+    fields = (
+        ("source", run.get("source_revision")),
+        ("host", run.get("hostname")),
+        ("CUDA_VISIBLE_DEVICES", run.get("cuda_visible_devices")),
+    )
+    return " · ".join(f"{name}={value}" for name, value in fields if value)
+
+
+def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
+    result_paths = sorted(output.glob("*/*/comparison.json"))
+    results = [json.loads(path.read_text(encoding="utf-8")) for path in result_paths]
+    counts = {
+        name: sum(result.get("status") == name for result in results)
+        for name in ("passed", "failed", "skipped")
+    }
+    report = {
+        "schema_version": "trtmc.validation-report/v1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "status": "passed" if results and counts["failed"] == 0 else "failed",
+        "summary": {"cases": len(results), **counts},
+        "results": results,
+    }
+    run_path = output / "run.json"
+    if run_path.is_file():
+        report["run"] = json.loads(run_path.read_text(encoding="utf-8"))
+    json_path = output / "report.json"
+    html_path = output / "report.html"
+    json_path.write_text(
+        json.dumps(report, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    rows = []
+    for result, path in zip(results, result_paths, strict=True):
+        relative = path.relative_to(output)
+        environments = ", ".join(
+            str(item.get("name", "")) for item in result.get("reference_environment", [])
+        )
+        status = str(result.get("status", "failed"))
+        rows.append(
+            "<tr>"
+            f"<td>{html.escape(str(result.get('model', '')))}</td>"
+            f"<td>{html.escape(str(result.get('workload', '')))}</td>"
+            f'<td class="{html.escape(status)}">{html.escape(status)}</td>'
+            f"<td>{html.escape(environments)}</td>"
+            f'<td><a href="{html.escape(str(relative))}">comparison.json</a></td>'
+            "</tr>"
+        )
+    provenance = _report_provenance(report.get("run", {}))
+    document = f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<title>TRTMC Validation Report</title>
+<style>
+body {{ font: 14px system-ui, sans-serif; margin: 32px; color: #202124; }}
+h1 {{ margin-bottom: 4px; }}
+.summary {{ color: #5f6368; margin-bottom: 24px; }}
+table {{ border-collapse: collapse; width: 100%; }}
+th, td {{ border: 1px solid #dadce0; padding: 8px 10px; text-align: left; }}
+th {{ background: #f8f9fa; }}
+.passed {{ color: #137333; font-weight: 600; }}
+.failed {{ color: #b3261e; font-weight: 600; }}
+.skipped {{ color: #8a4f00; font-weight: 600; }}
+</style></head><body>
+<h1>TRTMC Validation Report</h1>
+<div class="summary">{report["summary"]["cases"]} cases ·
+{counts["passed"]} passed · {counts["failed"]} failed · {counts["skipped"]} skipped<br>
+{html.escape(provenance)}</div>
+<table><thead><tr><th>Model</th><th>Workload</th><th>Status</th>
+<th>Reference environment</th><th>Result</th></tr></thead>
+<tbody>{"".join(rows)}</tbody></table>
+</body></html>
+"""
+    html_path.write_text(document, encoding="utf-8")
+    return json_path, html_path, report
+
+
+def _print_result(result: Mapping[str, Any], comparison: Path, report: Path) -> None:
+    reproduce = result.get("reproduce", {})
+    hf_commands = reproduce.get("hf", []) if isinstance(reproduce, dict) else []
+    trtmc_commands = reproduce.get("trtmc", []) if isinstance(reproduce, dict) else []
+    print()
+    print("Reproduce HF:")
+    if hf_commands:
+        for command in hf_commands:
+            print(f"  {command}")
+    else:
+        print("  unavailable; see comparison result")
+    print()
+    print("Reproduce TRTMC:")
+    if trtmc_commands:
+        for command in trtmc_commands:
+            print(f"  {command}")
+    else:
+        print("  unavailable; see comparison result")
+    print()
+    print(f"Compare result: {comparison}")
+    print(f"Report:         {report}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate TRTMC against model reference implementations."
+    )
+    parser.add_argument("model", nargs="?")
+    parser.add_argument("workload", nargs="?")
+    parser.add_argument("--all", action="store_true", help="run every ready model")
+    parser.add_argument("--list", action="store_true", help="list model-first workloads")
+    parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    parser.add_argument("--suites", type=Path, default=DEFAULT_SUITES)
+    parser.add_argument("--models-dir", type=Path, default=DEFAULT_MODELS)
+    parser.add_argument("-o", "--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--dataset-root", type=Path)
+    parser.add_argument("--dataset", type=Path)
+    parser.add_argument("--engine-dir", type=Path, default=DEFAULT_OUTPUT / "engines")
+    parser.add_argument("--trtmc-binary", type=Path, default=REPO_ROOT / "build" / "trtmc")
+    parser.add_argument(
+        "--benchmark-binary",
+        type=Path,
+        default=REPO_ROOT / "build" / "trtmc_dataset_benchmark",
+    )
+    parser.add_argument("--hf-python", type=Path, default=Path(sys.executable))
+    parser.add_argument("--backend-dir", type=Path)
+    parser.add_argument("--model-plugin-dir", type=Path)
+    parser.add_argument("--cuda-visible-devices", default="")
+    parser.add_argument("--platform", default="")
+    parser.add_argument("--limit", type=int, default=0)
+    parser.add_argument("--force-hf", action="store_true")
+    parser.add_argument("--force-build", action="store_true")
+    parser.add_argument("--no-build", action="store_true")
+    parser.add_argument("--local-files-only", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def _load_validation_inputs(
+    arguments: argparse.Namespace,
+) -> tuple[
+    dict[str, Any],
+    dict[str, dict[str, Any]],
+    tuple[str, ...],
+    dict[str, dict[str, Any]],
+]:
+    catalog = load_catalog(arguments.catalog)
+    suites_list = task_eval.load_suites(arguments.suites)
+    suites = {suite["id"]: suite for suite in suites_list}
+    ready = ready_model_names(arguments.models_dir)
+    task_models = _task_eval_models(arguments.models_dir)
+    audit_catalog(catalog, ready_models=ready, suite_names=suites)
+    audit_workload_compatibility(
+        catalog,
+        suites=suites,
+        task_models=task_models,
+    )
+    return catalog, suites, ready, task_models
+
+
+def _select_bindings(
+    arguments: argparse.Namespace,
+    catalog: Mapping[str, Any],
+    ready_models: Iterable[str],
+) -> list[Binding]:
+    if arguments.all:
+        if arguments.model or arguments.workload or arguments.dataset:
+            raise ValidationError("--all cannot be combined with MODEL, WORKLOAD, or --dataset")
+        return [resolve_binding(catalog, model) for model in ready_models]
+    if not arguments.model:
+        raise ValidationError("provide MODEL [WORKLOAD], --all, or --list")
+    return [resolve_binding(catalog, arguments.model, arguments.workload)]
+
+
+def _print_bindings(bindings: Iterable[Binding]) -> None:
+    print(
+        json.dumps(
+            [{"model": binding.model, "workload": binding.workload} for binding in bindings],
+            indent=2,
+        )
+    )
+
+
+def _run_bindings(
+    bindings: Iterable[Binding],
+    *,
+    arguments: argparse.Namespace,
+    task_models: Mapping[str, dict[str, Any]],
+    suites: Mapping[str, dict[str, Any]],
+) -> int:
+    e2e_models = _e2e_models(arguments.models_dir)
+    arguments.output.mkdir(parents=True, exist_ok=True)
+    arguments.engine_dir.mkdir(parents=True, exist_ok=True)
+    write_run_metadata(arguments.output)
+    failed = False
+    for binding in bindings:
+        print(f"\n{binding.model} / {binding.workload}", flush=True)
+        result = run_binding(
+            binding,
+            arguments=arguments,
+            task_models=task_models,
+            e2e_models=e2e_models,
+            suites=suites,
+        )
+        _, report_path, _ = write_report(arguments.output)
+        comparison = arguments.output / binding.model / binding.workload / "comparison.json"
+        _print_result(result, comparison, report_path)
+        failed = failed or result.get("status") == "failed"
+    return 1 if failed else 0
+
+
+def _main(arguments: argparse.Namespace) -> int:
+    catalog, suites, ready, task_models = _load_validation_inputs(arguments)
+    if arguments.list:
+        for name, spec in catalog["models"].items():
+            print(f"{name}: {', '.join(spec['workloads'])}")
+        return 0
+    bindings = _select_bindings(arguments, catalog, ready)
+    if arguments.dry_run:
+        _print_bindings(bindings)
+        return 0
+    return _run_bindings(
+        bindings,
+        arguments=arguments,
+        task_models=task_models,
+        suites=suites,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    try:
+        return _main(parser.parse_args(argv))
+    except (OSError, ValueError, ValidationError) as exc:
+        parser.error(str(exc))
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -113,7 +113,9 @@ def ready_model_names(models_root: Path = DEFAULT_MODELS) -> tuple[str, ...]:
         sorted(
             str(model["name"])
             for model in models
-            if not model["requires_multi_device"] and not model.get("skip")
+            if not model["requires_multi_device"]
+            and not model.get("skip")
+            and model.get("ci_tier") != "l0_only"
         )
     )
 

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -42,6 +42,8 @@ DEFAULT_CATALOG = REPO_ROOT / "tests" / "validation" / "model_workloads.yaml"
 DEFAULT_SUITES = REPO_ROOT / "tests" / "task_eval" / "validation_suites.yaml"
 DEFAULT_MODELS = REPO_ROOT / "tests" / "e2e" / "models"
 DEFAULT_OUTPUT = REPO_ROOT / "artifacts" / "trtmc-validate"
+DEFAULT_ENGINE_DIR = DEFAULT_OUTPUT / "engines"
+DEFAULT_REFERENCE_CACHE = DEFAULT_OUTPUT / "references"
 COMMON_REFERENCE_PROFILE = "reference_common"
 
 
@@ -328,6 +330,9 @@ def _task_eval_command(
         str(arguments.benchmark_binary),
         "--hf-python",
         reference_python,
+        "--reference-cache-dir",
+        str(arguments.reference_cache_dir),
+        "--replace-bundle-on-build",
         "--single-device-only",
         "--include-waived",
         "--fail-fast",
@@ -689,6 +694,17 @@ def _render_reproduction(result: Mapping[str, Any]) -> str:
     )
 
 
+def _reference_result_status(result: Mapping[str, Any]) -> str:
+    raw_result = result.get("raw_result", {})
+    if not isinstance(raw_result, dict):
+        return ""
+    return str(
+        raw_result.get("hf_cache_status")
+        or raw_result.get("hf_reference_status")
+        or ""
+    )
+
+
 def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
     result_paths = sorted(output.glob("*/*/comparison.json"))
     results = [json.loads(path.read_text(encoding="utf-8")) for path in result_paths]
@@ -727,6 +743,7 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
             f"<td>{html.escape(str(result.get('workload', '')))}</td>"
             f'<td class="{html.escape(status)}">{html.escape(status)}</td>'
             f"<td>{html.escape(environments)}</td>"
+            f"<td>{html.escape(_reference_result_status(result))}</td>"
             f"<td>{_render_reproduction(result)}</td>"
             f'<td><a href="{html.escape(str(relative))}">comparison.json</a></td>'
             "</tr>"
@@ -758,7 +775,8 @@ pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
 {counts["passed"]} passed · {counts["failed"]} failed · {counts["skipped"]} skipped<br>
 {html.escape(provenance)}</div>
 <table><thead><tr><th>Model</th><th>Workload</th><th>Status</th>
-<th>Reference environment</th><th>Vanilla reproduction</th><th>Result</th></tr></thead>
+<th>Reference environment</th><th>Reference result</th>
+<th>Vanilla reproduction</th><th>Result</th></tr></thead>
 <tbody>{"".join(rows)}</tbody></table>
 </body></html>
 """
@@ -803,7 +821,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("-o", "--output", type=Path, default=DEFAULT_OUTPUT)
     parser.add_argument("--dataset-root", type=Path)
     parser.add_argument("--dataset", type=Path)
-    parser.add_argument("--engine-dir", type=Path, default=DEFAULT_OUTPUT / "engines")
+    parser.add_argument("--engine-dir", type=Path, default=DEFAULT_ENGINE_DIR)
+    parser.add_argument(
+        "--reference-cache-dir",
+        type=Path,
+        default=DEFAULT_REFERENCE_CACHE,
+    )
     parser.add_argument("--trtmc-binary", type=Path, default=REPO_ROOT / "build" / "trtmc")
     parser.add_argument(
         "--benchmark-binary",
@@ -879,6 +902,7 @@ def _run_bindings(
     e2e_models = _e2e_models(arguments.models_dir)
     arguments.output.mkdir(parents=True, exist_ok=True)
     arguments.engine_dir.mkdir(parents=True, exist_ok=True)
+    arguments.reference_cache_dir.mkdir(parents=True, exist_ok=True)
     write_run_metadata(arguments.output)
     failed = False
     for binding in bindings:

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -909,6 +909,15 @@ def _comparison_result(
                 break
         if not raw_result and summary.get("results"):
             raw_result = summary["results"][0]
+    if not raw_result:
+        raw_result = {
+            "status": "failed",
+            "error_type": "ComparisonProcessError",
+            "error": (
+                f"comparison exited with code {returncode} without writing "
+                f"a model result to {summary_path}"
+            ),
+        }
     status = str(raw_result.get("status", "") or "")
     if status not in {"passed", "failed", "skipped"}:
         status = "passed" if returncode == 0 else "failed"

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -1119,6 +1119,10 @@ def _source_revision() -> str:
     return result.stdout.strip() if result.returncode == 0 else ""
 
 
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
 def write_run_metadata(output: Path) -> Path:
     metadata = {
         "schema_version": "trtmc.validation-run/v1",
@@ -1126,7 +1130,7 @@ def write_run_metadata(output: Path) -> Path:
         "hostname": platform.node(),
         "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES", ""),
         "command": shlex.join(sys.argv),
-        "started_at": datetime.now(timezone.utc).isoformat(),
+        "started_at": _utc_now().isoformat(),
     }
     path = output / "run.json"
     path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
@@ -1140,6 +1144,30 @@ def _report_provenance(run: Mapping[str, Any]) -> str:
         ("CUDA_VISIBLE_DEVICES", run.get("cuda_visible_devices")),
     )
     return " · ".join(f"{name}={value}" for name, value in fields if value)
+
+
+def _elapsed_seconds(
+    started_at: Any,
+    finished_at: datetime,
+) -> float | None:
+    if not isinstance(started_at, str) or not started_at:
+        return None
+    try:
+        started = datetime.fromisoformat(started_at)
+    except ValueError:
+        return None
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=timezone.utc)
+    return round(max(0.0, (finished_at - started).total_seconds()), 3)
+
+
+def _format_duration(seconds: Any) -> str:
+    if not isinstance(seconds, (int, float)) or isinstance(seconds, bool):
+        return ""
+    total_seconds = max(0, round(seconds))
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{hours}h {minutes:02d}m {seconds:02d}s"
 
 
 def _merge_commands_from_result_logs(result: dict[str, Any]) -> None:
@@ -1629,6 +1657,8 @@ def _report_document(
     execution_errors: int,
 ) -> str:
     provenance = _report_provenance(report.get("run", {}))
+    duration = _format_duration(report["summary"].get("duration_seconds"))
+    duration_summary = f" · {html.escape(duration)} total duration" if duration else ""
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
 <title>TRTMC Reference Consistency Report</title>
@@ -1688,7 +1718,7 @@ pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
 {comparison_counts["agreement"]} agreements ·
 {comparison_counts["disagreement"]} disagreements ·
 {execution_errors} execution errors ·
-{report["summary"]["selected_samples"]} samples<br>
+{report["summary"]["selected_samples"]} samples{duration_summary}<br>
 {html.escape(provenance)}</div>
 <table><thead><tr><th>Model</th><th>Workload</th><th>Samples</th><th>Execution</th>
 <th>Reference</th><th>Comparison</th><th>Agreement metrics</th>
@@ -1703,9 +1733,10 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
     results = _normalize_result_files(result_paths)
     validation_counts, comparison_counts, execution_errors = _report_counts(results)
     sample_limits = [_dataset_reproduction(result)[1] for result in results]
+    generated_at = _utc_now()
     report = {
         "schema_version": "trtmc.validation-report/v2",
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": generated_at.isoformat(),
         "validation_status": (
             "passed" if results and validation_counts["failed"] == 0 else "failed"
         ),
@@ -1726,6 +1757,12 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
     run_path = output / "run.json"
     if run_path.is_file():
         report["run"] = json.loads(run_path.read_text(encoding="utf-8"))
+        duration_seconds = _elapsed_seconds(
+            report["run"].get("started_at"),
+            generated_at,
+        )
+        if duration_seconds is not None:
+            report["summary"]["duration_seconds"] = duration_seconds
     json_path = output / "report.json"
     html_path = output / "report.html"
     json_path.write_text(

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -473,9 +473,8 @@ def _first_disagreement_id(work_dir: Path) -> str:
         if not path.is_file():
             continue
         data = json.loads(path.read_text(encoding="utf-8"))
-        explicit_id = _explicit_disagreement_id(data) if isinstance(data, dict) else ""
-        if explicit_id:
-            return explicit_id
+        if isinstance(data, dict) and isinstance(data.get("disagreements"), list):
+            return _explicit_disagreement_id(data)
         failed = _failed_sample_id(data)
         if failed:
             return failed
@@ -1141,8 +1140,9 @@ def _render_reproduction(result: Mapping[str, Any]) -> str:
     dataset_command, prepared_input_count = _dataset_reproduction(result)
     reference_total = _reproduction_count(result, "hf")
     trtmc_total = _reproduction_count(result, "trtmc")
+    input_label = "input" if prepared_input_count == 1 else "inputs"
     dataset_label = (
-        f"Full dataset ({prepared_input_count} prepared inputs)"
+        f"Full dataset ({prepared_input_count} prepared {input_label})"
         if prepared_input_count
         else "Full dataset"
     )

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import html
@@ -80,6 +81,19 @@ def _validate_model_spec(path: Path, name: Any, spec: Any) -> None:
         raise ValidationError(f"{path}: {name}.default must be one of {name}.workloads")
 
 
+def _validate_sample_limits(path: Path, raw: Mapping[str, Any]) -> None:
+    sample_limits = raw.get("sample_limits")
+    if not isinstance(sample_limits, dict) or not sample_limits:
+        raise ValidationError(f"{path}: sample_limits must be a non-empty mapping")
+    for workload, limit in sample_limits.items():
+        if not isinstance(workload, str) or not workload:
+            raise ValidationError(f"{path}: invalid sample-limit workload {workload!r}")
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+            raise ValidationError(
+                f"{path}: sample_limits.{workload} must be a positive integer"
+            )
+
+
 def load_catalog(path: Path = DEFAULT_CATALOG) -> dict[str, Any]:
     raw = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(raw, dict) or raw.get("version") != 1:
@@ -87,6 +101,7 @@ def load_catalog(path: Path = DEFAULT_CATALOG) -> dict[str, Any]:
     models = raw.get("models")
     if not isinstance(models, dict) or not models:
         raise ValidationError(f"{path}: models must be a non-empty mapping")
+    _validate_sample_limits(path, raw)
     for name, spec in models.items():
         _validate_model_spec(path, name, spec)
     return raw
@@ -134,6 +149,23 @@ def audit_catalog(
     if unknown:
         raise ValidationError(f"unknown workloads: {', '.join(unknown)}")
 
+    declared_sampled = {
+        workload
+        for spec in models.values()
+        for workload in spec["workloads"]
+        if workload != "e2e"
+    }
+    configured_sampled = set(catalog["sample_limits"])
+    missing_limits = sorted(declared_sampled - configured_sampled)
+    stale_limits = sorted(configured_sampled - declared_sampled)
+    if missing_limits or stale_limits:
+        details = []
+        if missing_limits:
+            details.append(f"missing sample limits: {', '.join(missing_limits)}")
+        if stale_limits:
+            details.append(f"unused sample limits: {', '.join(stale_limits)}")
+        raise ValidationError("; ".join(details))
+
 
 def audit_workload_compatibility(
     catalog: Mapping[str, Any],
@@ -172,6 +204,20 @@ def resolve_binding(
             f"model {model} does not declare workload {selected}; available: {available}"
         )
     return Binding(model=model, workload=selected)
+
+
+def resolve_sample_limit(
+    catalog: Mapping[str, Any],
+    binding: Binding,
+    explicit_limit: int | None,
+) -> int:
+    if explicit_limit is not None:
+        if explicit_limit < 0:
+            raise ValidationError("--limit must be zero or greater")
+        return explicit_limit
+    if binding.workload == "e2e":
+        return 0
+    return int(catalog["sample_limits"][binding.workload])
 
 
 def _task_eval_models(models_root: Path) -> dict[str, dict[str, Any]]:
@@ -855,11 +901,13 @@ def _normalize_reproduction(value: Any) -> dict[str, Any]:
 def _add_dataset_reproduction(
     reproduce: Mapping[str, Any],
     command: str,
+    sample_limit: int = 0,
 ) -> dict[str, Any]:
     result = dict(reproduce)
     prepared_input_count = int(result.pop("prepared_input_count", 0) or 0)
     result["dataset"] = {
         "command": command,
+        "sample_limit": sample_limit,
         "prepared_input_count": prepared_input_count,
     }
     return result
@@ -898,6 +946,7 @@ def _comparison_result(
     returncode: int,
     reference_environment: EnvironmentSelection,
     dataset_command: str,
+    sample_limit: int = 0,
 ) -> dict[str, Any]:
     summary_path = case_dir / "validation" / binding.workload / "eval_summary.json"
     raw_result: dict[str, Any] = {}
@@ -939,6 +988,7 @@ def _comparison_result(
         "reproduce": _add_dataset_reproduction(
             _commands_from_logs(work_dir),
             dataset_command,
+            sample_limit,
         ),
         "raw_result": raw_result,
         "raw_result_path": str(summary_path),
@@ -1042,6 +1092,7 @@ def run_binding(
             returncode=returncode,
             reference_environment=environment,
             dataset_command=dataset_command,
+            sample_limit=int(arguments.limit or 0),
         )
 
     comparison = case_dir / "comparison.json"
@@ -1172,17 +1223,19 @@ def _reproduction_logs(result: Mapping[str, Any], kind: str) -> list[str]:
     return _string_list(logs.get(kind, [])) if isinstance(logs, dict) else []
 
 
-def _dataset_reproduction(result: Mapping[str, Any]) -> tuple[str, int]:
+def _dataset_reproduction(result: Mapping[str, Any]) -> tuple[str, int, int]:
     reproduce = result.get("reproduce", {})
     dataset = reproduce.get("dataset", {}) if isinstance(reproduce, dict) else {}
     if not isinstance(dataset, dict):
-        return "", 0
+        return "", 0, 0
     command = str(dataset.get("command", "") or "")
     try:
+        sample_limit = int(dataset.get("sample_limit", 0) or 0)
         prepared = int(dataset.get("prepared_input_count", 0) or 0)
     except (TypeError, ValueError):
+        sample_limit = 0
         prepared = 0
-    return command, prepared
+    return command, sample_limit, prepared
 
 
 def _representative_note(result: Mapping[str, Any]) -> str:
@@ -1343,15 +1396,26 @@ def _render_reproduction(
 ) -> str:
     reference_commands = _result_commands(result, "hf")
     trtmc_commands = _result_commands(result, "trtmc")
-    dataset_command, prepared_input_count = _dataset_reproduction(result)
+    dataset_command, sample_limit, prepared_input_count = _dataset_reproduction(result)
     reference_total = _reproduction_count(result, "hf")
     trtmc_total = _reproduction_count(result, "trtmc")
     input_label = "input" if prepared_input_count == 1 else "inputs"
-    dataset_label = (
-        f"Full dataset ({prepared_input_count} prepared {input_label})"
-        if prepared_input_count
-        else "Full dataset"
-    )
+    if sample_limit:
+        sample_label = "sample" if sample_limit == 1 else "samples"
+        prepared_label = (
+            f"; {prepared_input_count} prepared {input_label}"
+            if prepared_input_count
+            else ""
+        )
+        dataset_label = (
+            f"Dataset slice ({sample_limit} selected {sample_label}{prepared_label})"
+        )
+    else:
+        dataset_label = (
+            f"Full dataset ({prepared_input_count} prepared {input_label})"
+            if prepared_input_count
+            else "Full dataset"
+        )
     summary = (
         f"Dataset · Reference {len(reference_commands)}/{reference_total} · "
         f"TRTMC {len(trtmc_commands)}/{trtmc_total}"
@@ -1493,6 +1557,28 @@ def _render_validation(result: Mapping[str, Any]) -> str:
     )
 
 
+def _render_samples(result: Mapping[str, Any]) -> str:
+    _command, sample_limit, prepared_input_count = _dataset_reproduction(result)
+    if sample_limit:
+        selected = f"{sample_limit} selected"
+        if prepared_input_count and prepared_input_count != sample_limit:
+            input_label = "input" if prepared_input_count == 1 else "inputs"
+            return (
+                f'{selected}<br><span class="detail">'
+                f"{prepared_input_count} prepared {input_label}</span>"
+            )
+        return selected
+    if prepared_input_count:
+        input_label = "input" if prepared_input_count == 1 else "inputs"
+        return (
+            f'Full<br><span class="detail">'
+            f"{prepared_input_count} prepared {input_label}</span>"
+        )
+    if result.get("workload") == "e2e":
+        return "E2E"
+    return '<span class="unavailable">Unavailable</span>'
+
+
 def _normalize_result_files(
     result_paths: Sequence[Path],
 ) -> list[dict[str, Any]]:
@@ -1545,6 +1631,7 @@ def _report_rows(
             "<tr>"
             f"<td>{html.escape(str(result.get('model', '')))}</td>"
             f"<td>{html.escape(str(result.get('workload', '')))}</td>"
+            f"<td>{_render_samples(result)}</td>"
             f"<td>{_render_execution(result)}</td>"
             f"<td>{_render_reference(result)}</td>"
             f"<td>{_render_comparison(result)}</td>"
@@ -1623,9 +1710,11 @@ pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
 <div class="summary">{report["summary"]["cases"]} cases ·
 {comparison_counts["agreement"]} agreements ·
 {comparison_counts["disagreement"]} disagreements ·
-{execution_errors} execution errors<br>
+{execution_errors} execution errors ·
+{report["summary"]["selected_samples"]} selected samples ·
+{report["summary"]["prepared_inputs"]} prepared inputs<br>
 {html.escape(provenance)}</div>
-<table><thead><tr><th>Model</th><th>Workload</th><th>Execution</th>
+<table><thead><tr><th>Model</th><th>Workload</th><th>Samples</th><th>Execution</th>
 <th>Reference</th><th>Comparison</th><th>Agreement metrics</th>
 <th>Validation</th><th>Vanilla reproduction</th><th>Result</th></tr></thead>
 <tbody>{rows}</tbody></table>
@@ -1637,6 +1726,7 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
     result_paths = sorted(output.glob("*/*/comparison.json"))
     results = _normalize_result_files(result_paths)
     validation_counts, comparison_counts, execution_errors = _report_counts(results)
+    sampling = [_dataset_reproduction(result)[1:] for result in results]
     report = {
         "schema_version": "trtmc.validation-report/v2",
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -1653,6 +1743,8 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
             "validation_passed": validation_counts["passed"],
             "validation_failed": validation_counts["failed"],
             "validation_skipped": validation_counts["skipped"],
+            "selected_samples": sum(limit for limit, _prepared in sampling),
+            "prepared_inputs": sum(prepared for _limit, prepared in sampling),
         },
         "results": results,
     }
@@ -1679,9 +1771,9 @@ def _print_result(result: Mapping[str, Any], comparison: Path, report: Path) -> 
     reproduce = result.get("reproduce", {})
     hf_commands = reproduce.get("hf", []) if isinstance(reproduce, dict) else []
     trtmc_commands = reproduce.get("trtmc", []) if isinstance(reproduce, dict) else []
-    dataset_command, _ = _dataset_reproduction(result)
+    dataset_command, _, _ = _dataset_reproduction(result)
     print()
-    print("Reproduce full dataset:")
+    print("Reproduce dataset run:")
     print(f"  {dataset_command}" if dataset_command else "  unavailable; see comparison result")
     print()
     print("Reproduce representative HF:")
@@ -1733,7 +1825,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--model-plugin-dir", type=Path)
     parser.add_argument("--cuda-visible-devices", default="")
     parser.add_argument("--platform", default="")
-    parser.add_argument("--limit", type=int, default=0)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help=(
+            "override the workload sample limit; use 0 for the complete dataset"
+        ),
+    )
     parser.add_argument("--force-hf", action="store_true")
     parser.add_argument("--force-build", action="store_true")
     parser.add_argument("--no-build", action="store_true")
@@ -1778,10 +1877,26 @@ def _select_bindings(
     return [resolve_binding(catalog, arguments.model, arguments.workload)]
 
 
-def _print_bindings(bindings: Iterable[Binding]) -> None:
+def _print_bindings(
+    bindings: Iterable[Binding],
+    *,
+    catalog: Mapping[str, Any],
+    explicit_limit: int | None,
+) -> None:
     print(
         json.dumps(
-            [{"model": binding.model, "workload": binding.workload} for binding in bindings],
+            [
+                {
+                    "model": binding.model,
+                    "workload": binding.workload,
+                    "sample_limit": resolve_sample_limit(
+                        catalog,
+                        binding,
+                        explicit_limit,
+                    ),
+                }
+                for binding in bindings
+            ],
             indent=2,
         )
     )
@@ -1791,6 +1906,7 @@ def _run_bindings(
     bindings: Iterable[Binding],
     *,
     arguments: argparse.Namespace,
+    catalog: Mapping[str, Any],
     task_models: Mapping[str, dict[str, Any]],
     suites: Mapping[str, dict[str, Any]],
 ) -> int:
@@ -1801,10 +1917,28 @@ def _run_bindings(
     write_run_metadata(arguments.output)
     failed = False
     for binding in bindings:
-        print(f"\n{binding.model} / {binding.workload}", flush=True)
+        binding_arguments = copy.copy(arguments)
+        binding_arguments.limit = resolve_sample_limit(
+            catalog,
+            binding,
+            arguments.limit,
+        )
+        sample_note = (
+            "full dataset"
+            if binding.workload != "e2e" and binding_arguments.limit == 0
+            else (
+                f"{binding_arguments.limit} samples"
+                if binding.workload != "e2e"
+                else "e2e"
+            )
+        )
+        print(
+            f"\n{binding.model} / {binding.workload} / {sample_note}",
+            flush=True,
+        )
         result = run_binding(
             binding,
-            arguments=arguments,
+            arguments=binding_arguments,
             task_models=task_models,
             e2e_models=e2e_models,
             suites=suites,
@@ -1820,15 +1954,27 @@ def _main(arguments: argparse.Namespace) -> int:
     catalog, suites, ready, task_models = _load_validation_inputs(arguments)
     if arguments.list:
         for name, spec in catalog["models"].items():
-            print(f"{name}: {', '.join(spec['workloads'])}")
+            workloads = []
+            for workload in spec["workloads"]:
+                if workload == "e2e":
+                    workloads.append("e2e")
+                else:
+                    limit = catalog["sample_limits"][workload]
+                    workloads.append(f"{workload} ({limit} samples)")
+            print(f"{name}: {', '.join(workloads)}")
         return 0
     bindings = _select_bindings(arguments, catalog, ready)
     if arguments.dry_run:
-        _print_bindings(bindings)
+        _print_bindings(
+            bindings,
+            catalog=catalog,
+            explicit_limit=arguments.limit,
+        )
         return 0
     return _run_bindings(
         bindings,
         arguments=arguments,
+        catalog=catalog,
         task_models=task_models,
         suites=suites,
     )

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -301,7 +301,7 @@ def _source_environment() -> dict[str, str]:
     return environment
 
 
-def _task_eval_command(
+def _comparison_command(
     binding: Binding,
     *,
     case_dir: Path,
@@ -309,11 +309,10 @@ def _task_eval_command(
     arguments: argparse.Namespace,
     reference_python: str,
 ) -> list[str]:
-    work_root = case_dir / "task-eval"
+    work_root = case_dir / "validation"
     command = [
         sys.executable,
-        str(REPO_ROOT / "tools" / "task_eval.py"),
-        "eval",
+        str(REPO_ROOT / "tools" / "trtmc_compare.py"),
         "--suite",
         binding.workload,
         "--dataset",
@@ -457,15 +456,189 @@ def _commands_from_e2e_results(results: Sequence[Mapping[str, Any]]) -> dict[str
     return commands
 
 
-def _task_eval_result(
+_PRIMARY_COMPARISON_METRICS = (
+    "sample_agreement_rate",
+    "prediction_agreement_rate",
+    "vector_pass_rate",
+    "top1_agreement",
+    "backend_pixel_agreement",
+    "mean_pairwise_ordering_agreement",
+    "token_prefix_agreement",
+    "token_agreement_rate",
+    "exact_match_rate",
+)
+_PRIMARY_METRIC_BY_MODE = {
+    "asr_transcript": "prediction_agreement_rate",
+    "continuation": "token_prefix_agreement",
+    "diffusion_text_parity": "token_agreement_rate",
+    "encoder_embedding_parity": "vector_pass_rate",
+    "image_classification_parity": "top1_agreement",
+    "ocrbench_v2": "prediction_agreement_rate",
+    "reranking_parity": "mean_pairwise_ordering_agreement",
+    "semantic_segmentation_parity": "backend_pixel_agreement",
+    "time_series_parity": "sample_agreement_rate",
+}
+_COMPARISON_METRICS = (
+    *_PRIMARY_COMPARISON_METRICS,
+    "token_id_prefix_agreement",
+    "normalized_transcript_exact_agreement_rate",
+    "correctness_agreement_rate",
+    "divergence_rate",
+    "divergent_count",
+    "hf_accuracy",
+    "trtfb_accuracy",
+    "accuracy_delta_trtfb_minus_hf",
+    "accuracy_drop_from_hf",
+    "hf_top1_accuracy",
+    "trtfb_top1_accuracy",
+    "top1_accuracy_drop_from_hf",
+    "hf_mean_iou",
+    "trtfb_mean_iou",
+    "backend_mean_iou",
+    "mean_iou_drop_from_hf",
+    "mean_vector_cosine",
+    "min_vector_cosine",
+    "mean_pair_cosine_abs_delta",
+    "max_pair_cosine_abs_delta",
+    "mean_relative_l2",
+    "max_relative_l2",
+    "max_absolute_error",
+)
+_EXECUTION_ERROR_FIELDS = ("error", "exception", "traceback", "failure_class")
+
+
+def _raw_comparison(result: Mapping[str, Any]) -> dict[str, Any]:
+    raw_result = result.get("raw_result")
+    if isinstance(raw_result, dict) and raw_result:
+        return dict(raw_result)
+    raw_results = result.get("raw_results")
+    if isinstance(raw_results, list) and raw_results:
+        passed = all(
+            isinstance(item, dict) and item.get("status") in {"pass", "passed"}
+            for item in raw_results
+        )
+        return {"mode": "e2e", "status": "passed" if passed else "failed"}
+    status = str(result.get("status", "") or "")
+    return {"status": status} if status else {}
+
+
+def _execution_details(
+    result: Mapping[str, Any],
+    raw_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    has_error = any(raw_result.get(name) for name in _EXECUTION_ERROR_FIELDS)
+    completed = bool(raw_result) and not has_error
+    return {
+        "status": "completed" if completed else "error",
+        "exit_code": result.get("returncode"),
+    }
+
+
+def _comparison_metrics(raw_result: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        name: raw_result[name]
+        for name in _COMPARISON_METRICS
+        if raw_result.get(name) is not None
+    }
+
+
+def _primary_metric(
+    mode: str,
+    metrics: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    preferred = _PRIMARY_METRIC_BY_MODE.get(mode)
+    if preferred in metrics:
+        return {"name": preferred, "value": metrics[preferred]}
+    for name in _PRIMARY_COMPARISON_METRICS:
+        if name in metrics:
+            return {"name": name, "value": metrics[name]}
+    return None
+
+
+def _comparison_details(
+    raw_result: Mapping[str, Any],
+    execution: Mapping[str, Any],
+) -> dict[str, Any]:
+    raw_status = str(raw_result.get("status", "") or "")
+    status_by_raw = {
+        "pass": "agreement",
+        "passed": "agreement",
+        "fail": "disagreement",
+        "failed": "disagreement",
+        "skip": "not_run",
+        "skipped": "not_run",
+    }
+    status = (
+        status_by_raw.get(raw_status, "not_run")
+        if execution.get("status") == "completed"
+        else "not_run"
+    )
+    metrics = _comparison_metrics(raw_result)
+    failures = raw_result.get("gate_failures", [])
+    mode = str(raw_result.get("mode", "") or "")
+    return {
+        "status": status,
+        "mode": mode,
+        "primary_metric": _primary_metric(mode, metrics),
+        "metrics": metrics,
+        "failures": failures if isinstance(failures, list) else [],
+    }
+
+
+def _validation_details(
+    execution: Mapping[str, Any],
+    comparison: Mapping[str, Any],
+) -> dict[str, str]:
+    if execution.get("status") != "completed":
+        return {"status": "failed"}
+    status_by_comparison = {
+        "agreement": "passed",
+        "disagreement": "failed",
+        "not_run": "skipped",
+    }
+    return {"status": status_by_comparison[str(comparison["status"])]}
+
+
+def _normalize_result(result: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = dict(result)
+    raw_result = _raw_comparison(normalized)
+    execution = normalized.get("execution")
+    if not isinstance(execution, dict):
+        execution = _execution_details(normalized, raw_result)
+    comparison = normalized.get("comparison")
+    if not isinstance(comparison, dict):
+        comparison = _comparison_details(raw_result, execution)
+    validation = normalized.get("validation")
+    if not isinstance(validation, dict):
+        validation = _validation_details(execution, comparison)
+    reproduce = normalized.get("reproduce", {})
+    if not isinstance(reproduce, dict):
+        reproduce = {}
+    normalized.update(
+        {
+            "schema_version": "trtmc.validation-result/v2",
+            "execution": execution,
+            "comparison": comparison,
+            "validation": validation,
+            "reproduce": {
+                "hf": list(reproduce.get("hf", [])),
+                "trtmc": list(reproduce.get("trtmc", [])),
+            },
+        }
+    )
+    normalized.pop("returncode", None)
+    normalized.pop("status", None)
+    return normalized
+
+
+def _comparison_result(
     binding: Binding,
     *,
     case_dir: Path,
     returncode: int,
     reference_environment: EnvironmentSelection,
-    command: Sequence[str],
 ) -> dict[str, Any]:
-    summary_path = case_dir / "task-eval" / binding.workload / "eval_summary.json"
+    summary_path = case_dir / "validation" / binding.workload / "eval_summary.json"
     raw_result: dict[str, Any] = {}
     if summary_path.is_file():
         summary = json.loads(summary_path.read_text(encoding="utf-8"))
@@ -478,25 +651,23 @@ def _task_eval_result(
     status = str(raw_result.get("status", "") or "")
     if status not in {"passed", "failed", "skipped"}:
         status = "passed" if returncode == 0 else "failed"
-    work_dir = case_dir / "task-eval" / binding.workload / binding.model
-    return {
-        "schema_version": "trtmc.validation-result/v1",
+    work_dir = case_dir / "validation" / binding.workload / binding.model
+    return _normalize_result({
+        "schema_version": "trtmc.validation-result/v2",
         "model": binding.model,
         "workload": binding.workload,
-        "executor": "task_eval",
+        "executor": "trtmc_compare",
         "status": status,
+        "returncode": returncode,
         "reference_environment": [
             {"name": name, "python": path} for name, path in reference_environment.names_and_paths
         ],
-        "reproduce": {
-            **_commands_from_logs(work_dir),
-            "validation": shlex.join(command),
-        },
+        "reproduce": _commands_from_logs(work_dir),
         "raw_result": raw_result,
         "raw_result_path": str(summary_path),
         "execution_log": str(case_dir / "execution.log"),
         "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
+    })
 
 
 def _e2e_result(
@@ -505,7 +676,6 @@ def _e2e_result(
     case_dir: Path,
     returncode: int,
     reference_environment: EnvironmentSelection,
-    command: Sequence[str],
 ) -> dict[str, Any]:
     result_paths = sorted((case_dir / "e2e").glob("*/result.json"))
     raw_results = [json.loads(path.read_text(encoding="utf-8")) for path in result_paths]
@@ -516,24 +686,22 @@ def _e2e_result(
         and all(result.get("status") == "pass" for result in raw_results)
         else "failed"
     )
-    return {
-        "schema_version": "trtmc.validation-result/v1",
+    return _normalize_result({
+        "schema_version": "trtmc.validation-result/v2",
         "model": binding.model,
         "workload": binding.workload,
         "executor": "e2e",
         "status": status,
+        "returncode": returncode,
         "reference_environment": [
             {"name": name, "python": path} for name, path in reference_environment.names_and_paths
         ],
-        "reproduce": {
-            **_commands_from_e2e_results(raw_results),
-            "validation": shlex.join(command),
-        },
+        "reproduce": _commands_from_e2e_results(raw_results),
         "raw_result_paths": [str(path) for path in result_paths],
         "raw_results": raw_results,
         "execution_log": str(case_dir / "execution.log"),
         "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
+    })
 
 
 def run_binding(
@@ -568,7 +736,6 @@ def run_binding(
             case_dir=case_dir,
             returncode=returncode,
             reference_environment=environment,
-            command=command,
         )
     else:
         suite = suites[binding.workload]
@@ -577,7 +744,7 @@ def run_binding(
             if arguments.dataset
             else _dataset_path(suite, arguments.dataset_root)
         )
-        command = _task_eval_command(
+        command = _comparison_command(
             binding,
             case_dir=case_dir,
             dataset=dataset,
@@ -585,12 +752,11 @@ def run_binding(
             reference_python=environment.base_python,
         )
         returncode = _run_subprocess(command, case_dir / "execution.log", process_env)
-        result = _task_eval_result(
+        result = _comparison_result(
             binding,
             case_dir=case_dir,
             returncode=returncode,
             reference_environment=environment,
-            command=command,
         )
 
     comparison = case_dir / "comparison.json"
@@ -705,51 +871,185 @@ def _reference_result_status(result: Mapping[str, Any]) -> str:
     )
 
 
-def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
-    result_paths = sorted(output.glob("*/*/comparison.json"))
-    results = [json.loads(path.read_text(encoding="utf-8")) for path in result_paths]
-    for result in results:
+def _signal(status: str, labels: Mapping[str, str]) -> str:
+    label = labels.get(status, status.replace("_", " ").title())
+    safe_status = status if status.replace("_", "").isalnum() else "unknown"
+    return (
+        f'<span class="signal signal-{safe_status}">'
+        '<span class="signal-light"></span>'
+        f"{html.escape(label)}</span>"
+    )
+
+
+def _render_execution(result: Mapping[str, Any]) -> str:
+    execution = result.get("execution", {})
+    status = str(execution.get("status", "error")) if isinstance(execution, dict) else "error"
+    return _signal(status, {"completed": "Completed", "error": "Error"})
+
+
+def _render_reference(result: Mapping[str, Any]) -> str:
+    status = _reference_result_status(result)
+    display_status = {
+        "reused": "cached",
+        "adopted": "cached",
+        "generated": "completed",
+        "ran": "completed",
+    }.get(status, "not_run")
+    label = {
+        "reused": "Reused",
+        "adopted": "Adopted",
+        "generated": "Generated",
+        "ran": "Generated",
+    }.get(status, "Not recorded")
+    environments = ", ".join(
+        str(item.get("name", ""))
+        for item in result.get("reference_environment", [])
+        if isinstance(item, dict)
+    )
+    detail = f'<div class="detail">{html.escape(environments)}</div>' if environments else ""
+    return _signal(display_status, {display_status: label}) + detail
+
+
+def _render_comparison(result: Mapping[str, Any]) -> str:
+    comparison = result.get("comparison", {})
+    if not isinstance(comparison, dict):
+        return _signal("not_run", {"not_run": "Not compared"})
+    status = str(comparison.get("status", "not_run"))
+    signal = _signal(
+        status,
+        {
+            "agreement": "Agreement",
+            "disagreement": "Disagreement",
+            "not_run": "Not compared",
+        },
+    )
+    mode = str(comparison.get("mode", "") or "")
+    detail = f'<div class="detail">{html.escape(mode)}</div>' if mode else ""
+    return signal + detail
+
+
+def _format_metric_value(name: str, value: Any) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, int):
+        return str(value)
+    if not isinstance(value, float):
+        return str(value)
+    is_ratio = any(
+        token in name
+        for token in ("accuracy", "agreement", "pass_rate", "exact_match", "divergence_rate")
+    )
+    if is_ratio:
+        return f"{value * 100:.2f}%"
+    if value and abs(value) < 0.001:
+        return f"{value:.3e}"
+    return f"{value:.6f}"
+
+
+def _render_metrics(result: Mapping[str, Any]) -> str:
+    comparison = result.get("comparison", {})
+    metrics = comparison.get("metrics", {}) if isinstance(comparison, dict) else {}
+    if not isinstance(metrics, dict) or not metrics:
+        return '<span class="unavailable">No metrics</span>'
+    primary = comparison.get("primary_metric")
+    primary_name = primary.get("name") if isinstance(primary, dict) else None
+    ordered = ([primary_name] if primary_name in metrics else []) + [
+        name for name in metrics if name != primary_name
+    ]
+    visible = ordered[:5]
+    rows = [
+        (
+            f'<div class="metric{" primary" if name == primary_name else ""}">'
+            f"<span>{html.escape(str(name))}</span>"
+            f"<strong>{html.escape(_format_metric_value(str(name), metrics[name]))}</strong>"
+            "</div>"
+        )
+        for name in visible
+    ]
+    remaining = len(ordered) - len(visible)
+    if remaining:
+        rows.append(f'<div class="detail">+{remaining} more in comparison.json</div>')
+    return "".join(rows)
+
+
+def _render_validation(result: Mapping[str, Any]) -> str:
+    validation = result.get("validation", {})
+    status = (
+        str(validation.get("status", "failed"))
+        if isinstance(validation, dict)
+        else "failed"
+    )
+    return _signal(
+        status,
+        {"passed": "Pass", "failed": "Fail", "skipped": "Skipped"},
+    )
+
+
+def _normalize_result_files(
+    result_paths: Sequence[Path],
+) -> list[dict[str, Any]]:
+    results = []
+    for path in result_paths:
+        result = _normalize_result(json.loads(path.read_text(encoding="utf-8")))
         _merge_commands_from_result_logs(result)
-    counts = {
-        name: sum(result.get("status") == name for result in results)
+        path.write_text(
+            json.dumps(result, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        results.append(result)
+    return results
+
+
+def _report_counts(
+    results: Sequence[Mapping[str, Any]],
+) -> tuple[dict[str, int], dict[str, int], int]:
+    validation_counts = {
+        name: sum(result["validation"]["status"] == name for result in results)
         for name in ("passed", "failed", "skipped")
     }
-    report = {
-        "schema_version": "trtmc.validation-report/v1",
-        "generated_at": datetime.now(timezone.utc).isoformat(),
-        "status": "passed" if results and counts["failed"] == 0 else "failed",
-        "summary": {"cases": len(results), **counts},
-        "results": results,
+    comparison_counts = {
+        name: sum(result["comparison"]["status"] == name for result in results)
+        for name in ("agreement", "disagreement", "not_run")
     }
-    run_path = output / "run.json"
-    if run_path.is_file():
-        report["run"] = json.loads(run_path.read_text(encoding="utf-8"))
-    json_path = output / "report.json"
-    html_path = output / "report.html"
-    json_path.write_text(
-        json.dumps(report, indent=2, ensure_ascii=False),
-        encoding="utf-8",
+    execution_errors = sum(
+        result["execution"]["status"] == "error" for result in results
     )
+    return validation_counts, comparison_counts, execution_errors
+
+
+def _report_rows(
+    output: Path,
+    results: Sequence[Mapping[str, Any]],
+    result_paths: Sequence[Path],
+) -> str:
     rows = []
     for result, path in zip(results, result_paths, strict=True):
         relative = path.relative_to(output)
-        environments = ", ".join(
-            str(item.get("name", "")) for item in result.get("reference_environment", [])
-        )
-        status = str(result.get("status", "failed"))
         rows.append(
             "<tr>"
             f"<td>{html.escape(str(result.get('model', '')))}</td>"
             f"<td>{html.escape(str(result.get('workload', '')))}</td>"
-            f'<td class="{html.escape(status)}">{html.escape(status)}</td>'
-            f"<td>{html.escape(environments)}</td>"
-            f"<td>{html.escape(_reference_result_status(result))}</td>"
+            f"<td>{_render_execution(result)}</td>"
+            f"<td>{_render_reference(result)}</td>"
+            f"<td>{_render_comparison(result)}</td>"
+            f"<td>{_render_metrics(result)}</td>"
+            f"<td>{_render_validation(result)}</td>"
             f"<td>{_render_reproduction(result)}</td>"
             f'<td><a href="{html.escape(str(relative))}">comparison.json</a></td>'
             "</tr>"
         )
+    return "".join(rows)
+
+
+def _report_document(
+    report: Mapping[str, Any],
+    *,
+    rows: str,
+    comparison_counts: Mapping[str, int],
+    execution_errors: int,
+) -> str:
     provenance = _report_provenance(report.get("run", {}))
-    document = f"""<!doctype html>
+    return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
 <title>TRTMC Validation Report</title>
 <style>
@@ -766,20 +1066,80 @@ summary {{ cursor: pointer; color: #185abc; }}
 pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
        background: #f8f9fa; border: 1px solid #dadce0; border-radius: 4px; }}
 .unavailable {{ color: #5f6368; }}
-.passed {{ color: #137333; font-weight: 600; }}
-.failed {{ color: #b3261e; font-weight: 600; }}
-.skipped {{ color: #8a4f00; font-weight: 600; }}
+.signal {{ display: inline-flex; align-items: center; gap: 7px; font-weight: 650;
+           white-space: nowrap; }}
+.signal-light {{ width: 10px; height: 10px; border-radius: 50%;
+                 background: #80868b; box-shadow: 0 0 0 3px #eef0f1; }}
+.signal-completed, .signal-agreement, .signal-passed {{ color: #137333; }}
+.signal-completed .signal-light, .signal-agreement .signal-light,
+.signal-passed .signal-light {{ background: #1e8e3e; box-shadow: 0 0 0 3px #e6f4ea; }}
+.signal-error, .signal-disagreement, .signal-failed {{ color: #b3261e; }}
+.signal-error .signal-light, .signal-disagreement .signal-light,
+.signal-failed .signal-light {{ background: #d93025; box-shadow: 0 0 0 3px #fce8e6; }}
+.signal-skipped {{ color: #8a4f00; }}
+.signal-skipped .signal-light {{ background: #f9ab00; box-shadow: 0 0 0 3px #fef7e0; }}
+.signal-cached {{ color: #185abc; }}
+.signal-cached .signal-light {{ background: #1a73e8; box-shadow: 0 0 0 3px #e8f0fe; }}
+.signal-not_run {{ color: #5f6368; }}
+.detail {{ color: #5f6368; font-size: 12px; margin-top: 4px; }}
+.metric {{ display: flex; justify-content: space-between; gap: 14px;
+           font-variant-numeric: tabular-nums; font-size: 12px; }}
+.metric span {{ color: #5f6368; }}
+.metric.primary {{ font-size: 13px; }}
+.metric.primary span, .metric.primary strong {{ color: #202124; }}
 </style></head><body>
 <h1>TRTMC Validation Report</h1>
 <div class="summary">{report["summary"]["cases"]} cases ·
-{counts["passed"]} passed · {counts["failed"]} failed · {counts["skipped"]} skipped<br>
+{comparison_counts["agreement"]} agreements ·
+{comparison_counts["disagreement"]} disagreements ·
+{execution_errors} execution errors<br>
 {html.escape(provenance)}</div>
-<table><thead><tr><th>Model</th><th>Workload</th><th>Status</th>
-<th>Reference environment</th><th>Reference result</th>
-<th>Vanilla reproduction</th><th>Result</th></tr></thead>
-<tbody>{"".join(rows)}</tbody></table>
+<table><thead><tr><th>Model</th><th>Workload</th><th>Execution</th>
+<th>Reference</th><th>Comparison</th><th>Agreement metrics</th>
+<th>Validation</th><th>Vanilla reproduction</th><th>Result</th></tr></thead>
+<tbody>{rows}</tbody></table>
 </body></html>
 """
+
+
+def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
+    result_paths = sorted(output.glob("*/*/comparison.json"))
+    results = _normalize_result_files(result_paths)
+    validation_counts, comparison_counts, execution_errors = _report_counts(results)
+    report = {
+        "schema_version": "trtmc.validation-report/v2",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "validation_status": (
+            "passed" if results and validation_counts["failed"] == 0 else "failed"
+        ),
+        "summary": {
+            "cases": len(results),
+            "execution_completed": len(results) - execution_errors,
+            "execution_errors": execution_errors,
+            "agreements": comparison_counts["agreement"],
+            "disagreements": comparison_counts["disagreement"],
+            "not_compared": comparison_counts["not_run"],
+            "validation_passed": validation_counts["passed"],
+            "validation_failed": validation_counts["failed"],
+            "validation_skipped": validation_counts["skipped"],
+        },
+        "results": results,
+    }
+    run_path = output / "run.json"
+    if run_path.is_file():
+        report["run"] = json.loads(run_path.read_text(encoding="utf-8"))
+    json_path = output / "report.json"
+    html_path = output / "report.html"
+    json_path.write_text(
+        json.dumps(report, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    document = _report_document(
+        report,
+        rows=_report_rows(output, results, result_paths),
+        comparison_counts=comparison_counts,
+        execution_errors=execution_errors,
+    )
     html_path.write_text(document, encoding="utf-8")
     return json_path, html_path, report
 
@@ -917,7 +1277,7 @@ def _run_bindings(
         _, report_path, _ = write_report(arguments.output)
         comparison = arguments.output / binding.model / binding.workload / "comparison.json"
         _print_result(result, comparison, report_path)
-        failed = failed or result.get("status") == "failed"
+        failed = failed or result["validation"]["status"] == "failed"
     return 1 if failed else 0
 
 

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -529,28 +529,51 @@ def _summarize_command_log(
     return count, selected or first
 
 
-def _commands_from_logs(root: Path) -> dict[str, Any]:
-    sample_ids = _prepared_sample_ids(root)
-    disagreement_id = _first_disagreement_id(root)
-    representative_id = disagreement_id or (sample_ids[0] if sample_ids else "")
+def _command_log_kind(path: Path, *, has_native_reference: bool) -> str | None:
+    if has_native_reference and path.name == "hf_run.log":
+        return None
+    return "hf" if "hf" in path.name.lower() else "trtmc"
+
+
+def _collect_command_logs(
+    root: Path,
+    *,
+    log_paths: Sequence[Path],
+    sample_ids: Sequence[str],
+    representative_id: str,
+) -> tuple[dict[str, list[str]], dict[str, int], dict[str, list[str]]]:
     commands: dict[str, list[str]] = {"hf": [], "trtmc": []}
     counts = {"hf": 0, "trtmc": 0}
     logs: dict[str, list[str]] = {"hf": [], "trtmc": []}
-    log_paths = sorted(root.rglob("*.log"))
     has_native_reference = any(path.name == "hf_native_run.log" for path in log_paths)
     for path in log_paths:
-        if has_native_reference and path.name == "hf_run.log":
+        kind = _command_log_kind(path, has_native_reference=has_native_reference)
+        if kind is None:
             continue
-        kind = "hf" if "hf" in path.name.lower() else "trtmc"
+        indexed_sample_ids = sample_ids if path.name == "trtfb_run.log" else ()
         count, representative = _summarize_command_log(
             path,
-            sample_ids=sample_ids if path.name == "trtfb_run.log" else (),
+            sample_ids=indexed_sample_ids,
             target_sample_id=representative_id,
         )
         counts[kind] += count
         if count:
             logs[kind].append(str(path.relative_to(root)))
         _append_unique(commands, kind, representative)
+    return commands, counts, logs
+
+
+def _commands_from_logs(root: Path) -> dict[str, Any]:
+    sample_ids = _prepared_sample_ids(root)
+    disagreement_id = _first_disagreement_id(root)
+    representative_id = disagreement_id or (sample_ids[0] if sample_ids else "")
+    log_paths = sorted(root.rglob("*.log"))
+    commands, counts, logs = _collect_command_logs(
+        root,
+        log_paths=log_paths,
+        sample_ids=sample_ids,
+        representative_id=representative_id,
+    )
     for kind in commands:
         commands[kind] = commands[kind][:MAX_REPRO_COMMANDS_PER_BACKEND]
     return {
@@ -1175,7 +1198,50 @@ def _render_vanilla_command(label: str, command: str) -> str:
     return f"<h5>{html.escape(label)}</h5>{body}"
 
 
-def _render_disagreement_record(record: Mapping[str, Any]) -> str:
+def _render_failure_media(
+    record: Mapping[str, Any],
+    *,
+    asset_base: Path,
+) -> str:
+    artifacts = record.get("artifacts", {})
+    media = artifacts.get("media", []) if isinstance(artifacts, dict) else []
+    if not isinstance(media, list):
+        return ""
+    rendered = []
+    for item in media:
+        if not isinstance(item, dict):
+            continue
+        label = html.escape(str(item.get("label", "artifact")))
+        relative_path = str(item.get("path", "") or "")
+        if not relative_path:
+            continue
+        href = html.escape(str(asset_base / relative_path))
+        body = _failure_media_tag(str(item.get("kind", "")), href, label)
+        if not body:
+            continue
+        rendered.append(
+            f'<figure><figcaption>{label}</figcaption>{body}</figure>'
+        )
+    if not rendered:
+        return ""
+    return '<h5>Failure media</h5><div class="failure-media">' + "".join(rendered) + "</div>"
+
+
+def _failure_media_tag(kind: str, href: str, label: str) -> str:
+    if kind == "image":
+        return f'<a href="{href}"><img src="{href}" alt="{label}" loading="lazy"></a>'
+    if kind == "audio":
+        return f'<audio controls preload="metadata" src="{href}"></audio>'
+    if kind == "video":
+        return f'<video controls preload="metadata" src="{href}"></video>'
+    return ""
+
+
+def _render_disagreement_record(
+    record: Mapping[str, Any],
+    *,
+    asset_base: Path,
+) -> str:
     sample_id = str(record.get("sample_id", "") or "unknown sample")
     reason = str(record.get("reason", "") or "comparison mismatch").replace("_", " ")
     reproduce = record.get("reproduce", {})
@@ -1189,6 +1255,7 @@ def _render_disagreement_record(record: Mapping[str, Any]) -> str:
         f"<section><h5>TRTMC result</h5>{_json_preview(record.get('trtmc_result', {}))}</section>"
         f"<section><h5>Comparison</h5>{_json_preview(record.get('comparison', {}))}</section>"
         "</div>"
+        f"{_render_failure_media(record, asset_base=asset_base)}"
         f"{_render_vanilla_command('Reference vanilla command', str(reproduce.get('reference', '') or ''))}"
         f"{_render_vanilla_command('TRTMC vanilla command', str(reproduce.get('trtmc', '') or ''))}"
         "</details>"
@@ -1227,7 +1294,11 @@ def _render_disagreements(
         and comparison.get("status") == "disagreement"
     )
     noun = "failed samples" if failed else "sample differences"
-    records = "".join(_render_disagreement_record(record) for record in preview)
+    asset_base = Path(artifact_href).parent
+    records = "".join(
+        _render_disagreement_record(record, asset_base=asset_base)
+        for record in preview
+    )
     more = ""
     if count > len(preview):
         more = (
@@ -1493,6 +1564,12 @@ summary {{ cursor: pointer; color: #185abc; }}
 .difference-grid {{ display: grid; grid-template-columns: repeat(2, minmax(260px, 1fr));
                     gap: 10px; }}
 .difference-grid pre {{ max-height: 260px; overflow: auto; }}
+.failure-media {{ display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-start; }}
+.failure-media figure {{ margin: 0; max-width: 360px; }}
+.failure-media figcaption {{ color: #5f6368; margin-bottom: 4px; }}
+.failure-media img, .failure-media video {{ display: block; max-width: 360px;
+                                           max-height: 280px; }}
+.failure-media audio {{ width: min(360px, 70vw); }}
 pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
        background: #f8f9fa; border: 1px solid #dadce0; border-radius: 4px; }}
 .unavailable {{ color: #5f6368; }}

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -35,7 +35,7 @@ from tensorrt_model_connect.python_profiles import (  # noqa: E402
     resolve_profile_python,
 )
 from tests.e2e_harness.manifest_loader import load_all_model_manifests  # noqa: E402
-from tools import task_eval  # noqa: E402
+from tools import task_eval, trtmc_disagreements  # noqa: E402
 
 
 DEFAULT_CATALOG = REPO_ROOT / "tests" / "validation" / "model_workloads.yaml"
@@ -536,7 +536,11 @@ def _commands_from_logs(root: Path) -> dict[str, Any]:
     commands: dict[str, list[str]] = {"hf": [], "trtmc": []}
     counts = {"hf": 0, "trtmc": 0}
     logs: dict[str, list[str]] = {"hf": [], "trtmc": []}
-    for path in sorted(root.rglob("*.log")):
+    log_paths = sorted(root.rglob("*.log"))
+    has_native_reference = any(path.name == "hf_native_run.log" for path in log_paths)
+    for path in log_paths:
+        if has_native_reference and path.name == "hf_run.log":
+            continue
         kind = "hf" if "hf" in path.name.lower() else "trtmc"
         count, representative = _summarize_command_log(
             path,
@@ -872,6 +876,10 @@ def _comparison_result(
     if status not in {"passed", "failed", "skipped"}:
         status = "passed" if returncode == 0 else "failed"
     work_dir = case_dir / "validation" / binding.workload / binding.model
+    disagreements = trtmc_disagreements.build_disagreement_artifact(
+        work_dir=work_dir,
+        case_dir=case_dir,
+    )
     return _normalize_result({
         "schema_version": "trtmc.validation-result/v2",
         "model": binding.model,
@@ -888,6 +896,7 @@ def _comparison_result(
         ),
         "raw_result": raw_result,
         "raw_result_path": str(summary_path),
+        "disagreements": disagreements,
         "execution_log": str(case_dir / "execution.log"),
         "timestamp": datetime.now(timezone.utc).isoformat(),
     })
@@ -1055,6 +1064,20 @@ def _merge_commands_from_result_logs(result: dict[str, Any]) -> None:
     result["reproduce"] = _normalize_reproduction(discovered)
 
 
+def _refresh_disagreement_artifact(
+    result: dict[str, Any],
+    case_dir: Path,
+) -> None:
+    raw_result = result.get("raw_result", {})
+    work_dir = raw_result.get("work_dir") if isinstance(raw_result, dict) else None
+    if not work_dir or not Path(str(work_dir)).is_dir():
+        return
+    result["disagreements"] = trtmc_disagreements.build_disagreement_artifact(
+        work_dir=Path(str(work_dir)),
+        case_dir=case_dir,
+    )
+
+
 def _result_commands(result: Mapping[str, Any], kind: str) -> list[str]:
     reproduce = result.get("reproduce", {})
     if not isinstance(reproduce, dict):
@@ -1134,7 +1157,96 @@ def _representative_note(result: Mapping[str, Any]) -> str:
     )
 
 
-def _render_reproduction(result: Mapping[str, Any]) -> str:
+def _json_preview(value: Any, *, max_characters: int = 2000) -> str:
+    rendered = json.dumps(value, indent=2, ensure_ascii=False)
+    if len(rendered) > max_characters:
+        rendered = rendered[:max_characters] + "\n... see disagreements.jsonl"
+    return f"<pre><code>{html.escape(rendered)}</code></pre>"
+
+
+def _render_vanilla_command(label: str, command: str) -> str:
+    if command:
+        body = f"<pre><code>{html.escape('$ ' + command)}</code></pre>"
+    else:
+        body = (
+            '<span class="unavailable">Native single-sample command unavailable '
+            "for this backend.</span>"
+        )
+    return f"<h5>{html.escape(label)}</h5>{body}"
+
+
+def _render_disagreement_record(record: Mapping[str, Any]) -> str:
+    sample_id = str(record.get("sample_id", "") or "unknown sample")
+    reason = str(record.get("reason", "") or "comparison mismatch").replace("_", " ")
+    reproduce = record.get("reproduce", {})
+    reproduce = reproduce if isinstance(reproduce, dict) else {}
+    return (
+        '<details class="sample-difference">'
+        f"<summary>{html.escape(sample_id)} · {html.escape(reason)}</summary>"
+        '<div class="difference-grid">'
+        f"<section><h5>Input</h5>{_json_preview(record.get('input', {}))}</section>"
+        f"<section><h5>Reference result</h5>{_json_preview(record.get('reference_result', {}))}</section>"
+        f"<section><h5>TRTMC result</h5>{_json_preview(record.get('trtmc_result', {}))}</section>"
+        f"<section><h5>Comparison</h5>{_json_preview(record.get('comparison', {}))}</section>"
+        "</div>"
+        f"{_render_vanilla_command('Reference vanilla command', str(reproduce.get('reference', '') or ''))}"
+        f"{_render_vanilla_command('TRTMC vanilla command', str(reproduce.get('trtmc', '') or ''))}"
+        "</details>"
+    )
+
+
+def _render_disagreements(
+    result: Mapping[str, Any],
+    *,
+    case_dir: Path,
+    artifact_href: str,
+) -> str:
+    metadata = result.get("disagreements", {})
+    if not isinstance(metadata, dict):
+        return ""
+    try:
+        count = int(metadata.get("count", 0) or 0)
+        limit = int(
+            metadata.get(
+                "inline_limit",
+                trtmc_disagreements.INLINE_DISAGREEMENT_LIMIT,
+            )
+        )
+    except (TypeError, ValueError):
+        return ""
+    if count <= 0:
+        return ""
+    artifact_name = str(metadata.get("path", "disagreements.jsonl"))
+    preview = trtmc_disagreements.load_disagreement_preview(
+        case_dir / artifact_name,
+        limit=limit,
+    )
+    comparison = result.get("comparison", {})
+    failed = (
+        isinstance(comparison, dict)
+        and comparison.get("status") == "disagreement"
+    )
+    noun = "failed samples" if failed else "sample differences"
+    records = "".join(_render_disagreement_record(record) for record in preview)
+    more = ""
+    if count > len(preview):
+        more = (
+            f'<div class="detail">Showing {len(preview)} of {count}. '
+            f'<a href="{html.escape(artifact_href)}">View all in disagreements.jsonl</a>.</div>'
+        )
+    return (
+        f'<details class="failure-details"><summary>{count} {noun} · '
+        "results and vanilla commands</summary>"
+        f"{records}{more}</details>"
+    )
+
+
+def _render_reproduction(
+    result: Mapping[str, Any],
+    *,
+    case_dir: Path,
+    artifact_href: str,
+) -> str:
     reference_commands = _result_commands(result, "hf")
     trtmc_commands = _result_commands(result, "trtmc")
     dataset_command, prepared_input_count = _dataset_reproduction(result)
@@ -1151,6 +1263,7 @@ def _render_reproduction(result: Mapping[str, Any]) -> str:
         f"TRTMC {len(trtmc_commands)}/{trtmc_total}"
     )
     return (
+        f"{_render_disagreements(result, case_dir=case_dir, artifact_href=artifact_href)}"
         f"<details><summary>{summary}</summary>"
         '<div class="commands">'
         f"{_render_command_group(dataset_label, [dataset_command] if dataset_command else [])}"
@@ -1293,6 +1406,7 @@ def _normalize_result_files(
     for path in result_paths:
         result = _normalize_result(json.loads(path.read_text(encoding="utf-8")))
         _merge_commands_from_result_logs(result)
+        _refresh_disagreement_artifact(result, path.parent)
         path.write_text(
             json.dumps(result, indent=2, ensure_ascii=False),
             encoding="utf-8",
@@ -1326,6 +1440,13 @@ def _report_rows(
     rows = []
     for result, path in zip(results, result_paths, strict=True):
         relative = path.relative_to(output)
+        metadata = result.get("disagreements", {})
+        artifact_name = (
+            str(metadata.get("path", "disagreements.jsonl"))
+            if isinstance(metadata, dict)
+            else "disagreements.jsonl"
+        )
+        artifact_relative = relative.parent / artifact_name
         rows.append(
             "<tr>"
             f"<td>{html.escape(str(result.get('model', '')))}</td>"
@@ -1335,7 +1456,7 @@ def _report_rows(
             f"<td>{_render_comparison(result)}</td>"
             f"<td>{_render_metrics(result)}</td>"
             f"<td>{_render_validation(result)}</td>"
-            f"<td>{_render_reproduction(result)}</td>"
+            f"<td>{_render_reproduction(result, case_dir=path.parent, artifact_href=str(artifact_relative))}</td>"
             f'<td><a href="{html.escape(str(relative))}">comparison.json</a></td>'
             "</tr>"
         )
@@ -1365,6 +1486,13 @@ details {{ min-width: 210px; }}
 summary {{ cursor: pointer; color: #185abc; }}
 .commands {{ min-width: min(760px, 70vw); padding: 4px 0; }}
 .commands h4 {{ margin: 12px 0 4px; }}
+.failure-details {{ min-width: min(900px, 75vw); margin-bottom: 10px; }}
+.sample-difference {{ margin: 8px 0; padding: 8px; border: 1px solid #dadce0;
+                      border-radius: 4px; }}
+.sample-difference h5 {{ margin: 10px 0 4px; }}
+.difference-grid {{ display: grid; grid-template-columns: repeat(2, minmax(260px, 1fr));
+                    gap: 10px; }}
+.difference-grid pre {{ max-height: 260px; overflow: auto; }}
 pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
        background: #f8f9fa; border: 1px solid #dadce0; border-radius: 4px; }}
 .unavailable {{ color: #5f6368; }}

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -1774,6 +1774,17 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("model", nargs="?")
     parser.add_argument("workload", nargs="?")
     parser.add_argument("--all", action="store_true", help="run every ready model")
+    parser.add_argument(
+        "--on-model-failure",
+        choices=("continue", "stop"),
+        default="continue",
+        help=("with --all, continue after a failed model or stop after recording it"),
+    )
+    parser.add_argument(
+        "--model-worker",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     parser.add_argument("--list", action="store_true", help="list model-first workloads")
     parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
     parser.add_argument("--suites", type=Path, default=DEFAULT_SUITES)
@@ -1875,6 +1886,196 @@ def _print_bindings(
     )
 
 
+def _prepare_run_directories(arguments: argparse.Namespace) -> None:
+    arguments.output.mkdir(parents=True, exist_ok=True)
+    arguments.engine_dir.mkdir(parents=True, exist_ok=True)
+    arguments.reference_cache_dir.mkdir(parents=True, exist_ok=True)
+
+
+def _worker_command(
+    binding: Binding,
+    arguments: argparse.Namespace,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        binding.model,
+        binding.workload,
+        "--model-worker",
+    ]
+    for option, value in (
+        ("--catalog", arguments.catalog),
+        ("--suites", arguments.suites),
+        ("--models-dir", arguments.models_dir),
+        ("--output", arguments.output),
+        ("--engine-dir", arguments.engine_dir),
+        ("--reference-cache-dir", arguments.reference_cache_dir),
+        ("--trtmc-binary", arguments.trtmc_binary),
+        ("--benchmark-binary", arguments.benchmark_binary),
+        ("--hf-python", arguments.hf_python),
+    ):
+        command.extend([option, str(value)])
+    for option, value in (
+        ("--dataset-root", arguments.dataset_root),
+        ("--backend-dir", arguments.backend_dir),
+        ("--model-plugin-dir", arguments.model_plugin_dir),
+        ("--cuda-visible-devices", arguments.cuda_visible_devices),
+        ("--platform", arguments.platform),
+    ):
+        if value:
+            command.extend([option, str(value)])
+    if arguments.limit is not None:
+        command.extend(["--limit", str(arguments.limit)])
+    for option, enabled in (
+        ("--force-hf", arguments.force_hf),
+        ("--force-build", arguments.force_build),
+        ("--no-build", arguments.no_build),
+        ("--local-files-only", arguments.local_files_only),
+    ):
+        if enabled:
+            command.append(option)
+    return command
+
+
+def _worker_error_result(
+    binding: Binding,
+    *,
+    command: Sequence[str],
+    returncode: int,
+    worker_log: Path,
+    sample_limit: int,
+    error: str,
+) -> dict[str, Any]:
+    return _normalize_result(
+        {
+            "schema_version": "trtmc.validation-result/v2",
+            "model": binding.model,
+            "workload": binding.workload,
+            "executor": "model_worker",
+            "status": "failed",
+            "returncode": returncode,
+            "reference_environment": [],
+            "reproduce": {
+                "dataset": {
+                    "command": shlex.join(command),
+                    "sample_limit": sample_limit,
+                    "prepared_input_count": 0,
+                },
+                "hf": [],
+                "trtmc": [],
+            },
+            "raw_result": {
+                "status": "failed",
+                "error_type": "WorkerProcessError",
+                "error": error,
+            },
+            "raw_result_path": "",
+            "disagreements": {
+                "count": 0,
+                "path": "disagreements.jsonl",
+                "inline_limit": trtmc_disagreements.INLINE_DISAGREEMENT_LIMIT,
+                "reference_vanilla_available": False,
+                "trtmc_vanilla_available": False,
+            },
+            "execution_log": str(worker_log),
+            "worker_log": str(worker_log),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+
+
+def _run_supervised_binding(
+    binding: Binding,
+    *,
+    arguments: argparse.Namespace,
+    catalog: Mapping[str, Any],
+) -> dict[str, Any]:
+    case_dir = arguments.output / binding.model / binding.workload
+    case_dir.mkdir(parents=True, exist_ok=True)
+    comparison_path = case_dir / "comparison.json"
+    comparison_path.unlink(missing_ok=True)
+    worker_log = case_dir / "worker.log"
+    command = _worker_command(binding, arguments)
+    launch_error = ""
+    try:
+        returncode = _run_subprocess(command, worker_log, _source_environment())
+    except OSError as exc:
+        returncode = 127
+        launch_error = f"could not start model worker: {exc}"
+    try:
+        if launch_error:
+            raise ValidationError(launch_error)
+        if not comparison_path.is_file():
+            raise ValidationError(
+                f"worker exited with code {returncode} without writing comparison.json"
+            )
+        loaded = json.loads(comparison_path.read_text(encoding="utf-8"))
+        result = _normalize_result(loaded)
+        if result.get("model") != binding.model or result.get("workload") != binding.workload:
+            raise ValidationError("worker wrote comparison.json for a different binding")
+    except (OSError, ValueError, ValidationError) as exc:
+        result = _worker_error_result(
+            binding,
+            command=command,
+            returncode=returncode,
+            worker_log=worker_log,
+            sample_limit=resolve_sample_limit(catalog, binding, arguments.limit),
+            error=str(exc),
+        )
+        (case_dir / "disagreements.jsonl").write_text("", encoding="utf-8")
+    else:
+        result["worker_log"] = str(worker_log)
+        dataset = result.get("reproduce", {}).get("dataset", {})
+        if isinstance(dataset, dict):
+            dataset["command"] = shlex.join(token for token in command if token != "--model-worker")
+    comparison_path.write_text(
+        json.dumps(result, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return result
+
+
+def _run_all_bindings(
+    bindings: Iterable[Binding],
+    *,
+    arguments: argparse.Namespace,
+    catalog: Mapping[str, Any],
+) -> int:
+    _prepare_run_directories(arguments)
+    write_run_metadata(arguments.output)
+    failed = False
+    for binding in bindings:
+        sample_limit = resolve_sample_limit(catalog, binding, arguments.limit)
+        sample_note = (
+            "full dataset"
+            if binding.workload != "e2e" and sample_limit == 0
+            else f"{sample_limit} samples"
+            if binding.workload != "e2e"
+            else "e2e"
+        )
+        print(
+            f"\nStarting worker: {binding.model} / {binding.workload} / {sample_note}",
+            flush=True,
+        )
+        result = _run_supervised_binding(
+            binding,
+            arguments=arguments,
+            catalog=catalog,
+        )
+        _, report_path, _ = write_report(arguments.output)
+        comparison = arguments.output / binding.model / binding.workload / "comparison.json"
+        _print_result(result, comparison, report_path)
+        model_failed = result["validation"]["status"] == "failed"
+        failed = failed or model_failed
+        if model_failed and arguments.on_model_failure == "stop":
+            print(
+                f"Stopping after failed model: {binding.model}",
+                flush=True,
+            )
+            break
+    return 1 if failed else 0
+
+
 def _run_bindings(
     bindings: Iterable[Binding],
     *,
@@ -1884,10 +2085,9 @@ def _run_bindings(
     suites: Mapping[str, dict[str, Any]],
 ) -> int:
     e2e_models = _e2e_models(arguments.models_dir)
-    arguments.output.mkdir(parents=True, exist_ok=True)
-    arguments.engine_dir.mkdir(parents=True, exist_ok=True)
-    arguments.reference_cache_dir.mkdir(parents=True, exist_ok=True)
-    write_run_metadata(arguments.output)
+    _prepare_run_directories(arguments)
+    if not arguments.model_worker:
+        write_run_metadata(arguments.output)
     failed = False
     for binding in bindings:
         binding_arguments = copy.copy(arguments)
@@ -1916,9 +2116,10 @@ def _run_bindings(
             e2e_models=e2e_models,
             suites=suites,
         )
-        _, report_path, _ = write_report(arguments.output)
-        comparison = arguments.output / binding.model / binding.workload / "comparison.json"
-        _print_result(result, comparison, report_path)
+        if not arguments.model_worker:
+            _, report_path, _ = write_report(arguments.output)
+            comparison = arguments.output / binding.model / binding.workload / "comparison.json"
+            _print_result(result, comparison, report_path)
         failed = failed or result["validation"]["status"] == "failed"
     return 1 if failed else 0
 
@@ -1944,6 +2145,12 @@ def _main(arguments: argparse.Namespace) -> int:
             explicit_limit=arguments.limit,
         )
         return 0
+    if arguments.all:
+        return _run_all_bindings(
+            bindings,
+            arguments=arguments,
+            catalog=catalog,
+        )
     return _run_bindings(
         bindings,
         arguments=arguments,


### PR DESCRIPTION
## Background

The existing task-eval workflow coupled reference inference, TRTMC execution,
scoring, and environment dependencies. Dev and QA need a model-first workflow
that can reuse reference results and TensorRT engines while still preserving
enough native evidence to diagnose an accuracy regression without rerunning an
entire dataset.

## Exit Criteria

- Cover every dataset-backed, single-device task-eval model profile with an
  explicit validation workload.
- Run HF references outside task-eval with reusable, automatically provisioned
  Python environments and content-addressed result caching.
- Report execution health separately from reference consistency.
- Preserve bounded, per-failure native HF/TRTMC commands, exact outputs, and
  image, video, or audio evidence where applicable.
- Replace a rebuilt shared engine in place instead of accumulating campaign
  copies.
- Use task-appropriate default sample counts so inexpensive workloads get
  broader coverage without making diffusion, video, or long-context validation
  impractical.
- Use one entry point for full campaigns, selected models, and exact
  model/workload cases that CI can schedule independently.
- Isolate model-specific failures so a broken environment or uncaught backend
  error can be reported without terminating the remaining campaign.

## Implementation

- Add `trtmc-validate`, a model-first Dev/QA entry point backed by an explicit
  model-to-workload catalog.
- Exclude profiles declared as `ci_tier: l0_only` from the default validation
  catalog and `--all` matrix. Their model manifests remain available to the
  model-owned L0 CI workflows.
- Run `--all` as a supervisor with one child process per model. The default
  policy records a failed model and continues; `--on-model-failure stop`
  records the failure, writes the report, and stops the campaign.
- Make `--all --dry-run` emit a machine-readable CI matrix. The same CLI runs
  one exact matrix case, writes a stable
  `<output>/<model>/<workload>/comparison.json`, and returns a documented
  consistency-sensitive exit status.
- Remove a stale case result before launching its worker. A worker that exits
  before producing a fresh result becomes a reportable execution error rather
  than reusing an earlier pass.
- Add independent native reference runners for text, encoders, VLM, speech,
  vision, diffusion, reranking, time series, ELF, and SANA-WM workloads.
- Reuse content-addressed HF references and model-declared Python profiles;
  uncommon dependency stacks remain isolated while common models share one
  environment.
- Provision pinned external reference sources on first use. ELF uses the
  official PyTorch implementation at `b29d8833609e`; SANA uses
  `59629fdf7908`.
- Add compatible isolated reference profiles for ELF, InternLM, Magpie/NeMo,
  and the shared reference stack. Restore Nemotron 3.5 ASR directly from its
  `.nemo` snapshot.
- Treat the model revision as part of reference identity: pass it from the
  manifest through the cache key, native runner, upstream loader, and vanilla
  reproduction command.
- Keep Magpie on the checkpoint-compatible NeMo 2.7.3 profile and restore its
  exact pinned `.nemo` archive. This prevents the reference from silently
  loading a newer, architecture-incompatible Hub checkpoint.
- Keep InternLM on its upstream-compatible Transformers 4.44.2 and tokenizers
  0.19.1 profile; newer tokenizers reject the model's remote BPE merge format.
- Tolerate invalid UTF-8 in backend output without weakening dataset parsing,
  and materialize cached native reproduction commands into the current run.
- Add workload-owned sample defaults from 2 to 100 selected dataset samples.
  Image generation/editing and expensive multi-input workloads use 5, video
  uses 2, TTS uses 3, ordinary generation and speech use 10, MMLU five-shot,
  reranking, and selected text tasks use 20, encoders use 50, and image
  classification uses 100.
- Resolve the workload default when `--limit` is omitted. An explicit
  `--limit N` overrides the default, while `--limit 0` requests the full
  dataset.
- Report only the selected dataset sample count, without exposing internal
  input expansion details.
- Add a reference-consistency report with separate Execution, Reference,
  Comparison, and Validation signals.
- Record total wall-clock duration in `report.json` and render it in the
  script-generated HTML report.
- Generate per-sample difference evidence with exact inputs, both backend
  results, direct commands, and copied media. Dataset-slice reproduction
  remains one bounded command regardless of dataset size.
- Keep E2E-only models explicit in the catalog and enforce catalog, runner, and
  sample-policy coverage in unit tests.
- Classify processes that exit before producing a comparison summary as
  execution errors with Comparison Not Run, rather than false accuracy
  disagreements.

## Validation

- `tests/tools/test_task_eval.py`: 181 passed.
- `tests/tools/test_trtmc_validate.py`: 47 passed.
- Focused task-eval, reference-cache, CI image, Magpie, and InternLM profile
  contract tests: 230 passed.
- Combined tests covering the changed validation/reference paths: 278 passed,
  2 deselected. The deselected local tests require a usable CUDA runtime.
- Source-quality pipeline passed changed-file Ruff, complexity, and model
  architecture checks; 157 architecture contract tests passed.
- Legal-header audit passed with 0 findings.
- `python3 tools/trtmc_validate.py --all --dry-run` emits 105 unique non-L0,
  single-device model cases.
- The final GB300-2 campaign ran the committed entry point directly, without an
  agent wrapper:

  ```text
  python tools/trtmc_validate.py --all --on-model-failure continue --output <output>
  ```

- Source revision: `c8291be0390705ca1cdcccdff83e251e7d7e1767`.
- Final matrix: 105 cases and 1,906 selected samples in 11,712.508 seconds
  (3h 15m 12.508s).
- Execution: 104 completed and 1 error. The only execution error is
  `facebook/sam3`: Hugging Face returned a gated-repository 403 because the
  account's access request was rejected.
- Reference consistency: 69 agreements and 35 disagreements. Disagreements
  remain failed validation signals; passing criteria were not changed.
- The CLI generated `report.html`, `report.json`, and every case
  `comparison.json` directly. The aggregate report was not post-processed.
- Dataset-backed disagreement artifacts contain bounded sample evidence,
  backend results, and available native reference/TRTMC commands. E2E-only
  workloads retain their native pytest artifacts and logs instead of inventing
  a separate reference command.

## Notes For Future Readers

- Start review with `tests/validation/README.md` and
  `tests/validation/model_workloads.yaml`, then review
  `tools/trtmc_validate.py`, the native reference runners, and
  `tools/trtmc_disagreements.py`.
- A green Execution signal means the comparison pipeline completed. It does not
  imply agreement; reference consistency is a separate signal.
- Execution errors intentionally produce Comparison Not Run. The report keeps
  their logs and error classification instead of presenting them as accuracy
  regressions.
