### PR TITLE
perf(wan2.2): accelerate Thor generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(GNUInstallDirs)
+find_package(Threads REQUIRED)
 
 option(TRTMC_ENABLE_TRT "Enable TensorRT backend DSO integration" ON)
 option(TRTMC_BUILD_BACKEND_TRT "Build standard TensorRT backend DSO" ON)
@@ -606,7 +607,7 @@ add_executable(trtmc
   src/cli/args.cpp
   src/cli/main.cpp
 )
-target_link_libraries(trtmc PRIVATE trtmc_core)
+target_link_libraries(trtmc PRIVATE trtmc_core Threads::Threads)
 target_include_directories(trtmc PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(trtmc SYSTEM PRIVATE ${PROJECT_SOURCE_DIR}/third_party/stb)
 set_target_properties(trtmc PROPERTIES

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/dit_builder.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/dit_builder.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import math
 import sys
 
 import numpy as np
@@ -29,6 +30,70 @@ trt = trt_compat.get_trt()
 def _numpy_state(model_dir: str) -> dict[str, np.ndarray]:
     state = convert_transformer_state_dict(load_native_transformer_state_dict(model_dir))
     return {name: tensor.detach().float().cpu().numpy() for name, tensor in state.items()}
+
+
+def _ffn_fp8_layer_names(profile: Wan22TI2VConfig) -> tuple[str, ...]:
+    return tuple(
+        name
+        for index in range(profile.num_layers)
+        for name in (
+            f"blocks.{index}.ffn.net.0.proj",
+            f"blocks.{index}.ffn.net.2",
+        )
+    )
+
+
+def _validated_ffn_fp8_scales(
+    weights: dict[str, np.ndarray],
+    profile: Wan22TI2VConfig,
+    scales: dict | None,
+) -> dict[str, dict[str, float]] | None:
+    """Validate a fail-closed FFN-only FP8 scale map.
+
+    Every FFN projection must be present and no non-FFN layer is accepted.
+    Weight scales may be omitted; in that case the checkpoint's exact
+    per-tensor absolute maximum is used.
+    """
+
+    if scales is None:
+        return None
+    if not isinstance(scales, dict):
+        raise TypeError("Wan2.2 FFN FP8 scales must be a dictionary")
+
+    expected = set(_ffn_fp8_layer_names(profile))
+    provided = set(scales)
+    missing = sorted(expected - provided)
+    unexpected = sorted(provided - expected)
+    if missing or unexpected:
+        raise ValueError(
+            "Wan2.2 FFN FP8 scales must cover exactly the two FFN projections "
+            f"in every block; missing={missing}, unexpected={unexpected}"
+        )
+
+    result: dict[str, dict[str, float]] = {}
+    for name in sorted(expected):
+        entry = scales[name]
+        if not isinstance(entry, dict):
+            raise TypeError(f"Wan2.2 FFN FP8 scale entry for {name} must be a dictionary")
+        input_scale = float(entry.get("input_scale", 0.0))
+        if not math.isfinite(input_scale) or input_scale <= 0.0:
+            raise ValueError(f"Wan2.2 FFN FP8 input_scale for {name} must be positive and finite")
+
+        weight = weights[f"{name}.weight"]
+        minimum_weight_scale = op.fp8_e4m3_weight_scale(weight)
+        weight_scale = float(entry.get("weight_scale", minimum_weight_scale))
+        if not math.isfinite(weight_scale) or weight_scale <= 0.0:
+            raise ValueError(f"Wan2.2 FFN FP8 weight_scale for {name} must be positive and finite")
+        if weight_scale < minimum_weight_scale * (1.0 - 1.0e-6):
+            raise ValueError(
+                f"Wan2.2 FFN FP8 weight_scale for {name} would overflow E4M3: "
+                f"provided={weight_scale}, minimum={minimum_weight_scale}"
+            )
+        result[name] = {
+            "input_scale": input_scale,
+            "weight_scale": weight_scale,
+        }
+    return result
 
 
 def _wan_rope(profile: Wan22TI2VConfig):
@@ -120,6 +185,7 @@ def build_dit_engine(
     model_dir: str,
     *,
     profile: Wan22TI2VConfig = WAN22_TI2V_5B,
+    ffn_fp8_scales: dict | None = None,
     verbose: bool = False,
 ) -> bytes:
     """Build a DiT plan for an explicitly qualified profile."""
@@ -127,6 +193,10 @@ def build_dit_engine(
     if profile not in SUPPORTED_GENERATION_PROFILES:
         raise ValueError("Wan2.2 DiT profile is not one of the qualified generation profiles")
     weights = _numpy_state(model_dir)
+    ffn_fp8_scales = _validated_ffn_fp8_scales(weights, profile, ffn_fp8_scales)
+    # TensorRT consumes raw pointers for explicit FP8 constants. Keep their
+    # NumPy owners alive until build_serialized_network() has returned.
+    fp8_weight_refs: list[np.ndarray] = []
     logger = trt.Logger(trt.Logger.VERBOSE if verbose else trt.Logger.WARNING)
     builder = trt.Builder(logger)
     network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.STRONGLY_TYPED))
@@ -227,23 +297,17 @@ def build_dit_engine(
             round_bf16=index == 0,
         )
         qkv_input = op.adaptive_norm(network, normalized, shift_sa, scale_sa)
-        q = op.linear(
+        q, k, v = op.fused_qkv_linear(
             network,
             qkv_input,
             weights[f"{prefix}.attn1.to_q.weight"],
             weights[f"{prefix}.attn1.to_q.bias"],
-        )
-        k = op.linear(
-            network,
-            qkv_input,
             weights[f"{prefix}.attn1.to_k.weight"],
             weights[f"{prefix}.attn1.to_k.bias"],
-        )
-        v = op.linear(
-            network,
-            qkv_input,
             weights[f"{prefix}.attn1.to_v.weight"],
             weights[f"{prefix}.attn1.to_v.bias"],
+            rows=profile.num_patches,
+            hidden_size=profile.dim,
         )
         q = op.rms_norm(
             network,
@@ -355,19 +419,43 @@ def build_dit_engine(
 
         normalized = op.layer_norm(network, hidden, profile.dim, profile.eps)
         ffn_input = op.adaptive_norm(network, normalized, shift_ff, scale_ff)
-        ffn = op.linear(
-            network,
-            ffn_input,
-            weights[f"{prefix}.ffn.net.0.proj.weight"],
-            weights[f"{prefix}.ffn.net.0.proj.bias"],
-        )
+        ffn_up_name = f"{prefix}.ffn.net.0.proj"
+        if ffn_fp8_scales is None:
+            ffn = op.linear(
+                network,
+                ffn_input,
+                weights[f"{ffn_up_name}.weight"],
+                weights[f"{ffn_up_name}.bias"],
+            )
+        else:
+            ffn = op.linear_fp8_e4m3(
+                network,
+                ffn_input,
+                weights[f"{ffn_up_name}.weight"],
+                weights[f"{ffn_up_name}.bias"],
+                input_scale=ffn_fp8_scales[ffn_up_name]["input_scale"],
+                weight_scale=ffn_fp8_scales[ffn_up_name]["weight_scale"],
+                weight_refs=fp8_weight_refs,
+            )
         ffn = op.gelu_tanh(network, ffn)
-        ffn = op.linear(
-            network,
-            ffn,
-            weights[f"{prefix}.ffn.net.2.weight"],
-            weights[f"{prefix}.ffn.net.2.bias"],
-        )
+        ffn_down_name = f"{prefix}.ffn.net.2"
+        if ffn_fp8_scales is None:
+            ffn = op.linear(
+                network,
+                ffn,
+                weights[f"{ffn_down_name}.weight"],
+                weights[f"{ffn_down_name}.bias"],
+            )
+        else:
+            ffn = op.linear_fp8_e4m3(
+                network,
+                ffn,
+                weights[f"{ffn_down_name}.weight"],
+                weights[f"{ffn_down_name}.bias"],
+                input_scale=ffn_fp8_scales[ffn_down_name]["input_scale"],
+                weight_scale=ffn_fp8_scales[ffn_down_name]["weight_scale"],
+                weight_refs=fp8_weight_refs,
+            )
         hidden = op.add_fp32_residual(network, hidden, ffn, gate_ff)
 
     final_table = weights["scale_shift_table"].reshape(1, 2 * profile.dim)
@@ -398,7 +486,8 @@ def build_dit_engine(
     print(
         f"[wan2.2-ti2v] building DiT: layers={profile.num_layers}, "
         f"patches={profile.num_patches}, "
-        f"latent={profile.latent_frames}x{profile.latent_height}x{profile.latent_width}",
+        f"latent={profile.latent_frames}x{profile.latent_height}x{profile.latent_width}, "
+        f"ffn_fp8={'enabled' if ffn_fp8_scales is not None else 'disabled'}",
         file=sys.stderr,
     )
     plan = builder.build_serialized_network(network, build_config)

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/dit_builder.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/dit_builder.py
@@ -43,6 +43,98 @@ def _ffn_fp8_layer_names(profile: Wan22TI2VConfig) -> tuple[str, ...]:
     )
 
 
+def _cross_qo_fp8_layer_names(profile: Wan22TI2VConfig) -> tuple[str, ...]:
+    """Return the exact qualified cross-attention FP8 projection set."""
+
+    return tuple(
+        name
+        for index in range(profile.num_layers)
+        for name in (
+            f"blocks.{index}.attn2.to_q",
+            f"blocks.{index}.attn2.to_out.0",
+        )
+    )
+
+
+def _validated_cross_qo_fp8_scales(
+    weights: dict[str, np.ndarray],
+    profile: Wan22TI2VConfig,
+    scales: dict | None,
+) -> dict[str, dict[str, float]] | None:
+    """Validate the complete, qualified cross-Q/O FP8 scale map."""
+
+    if scales is None:
+        return None
+    if not isinstance(scales, dict):
+        raise TypeError("Wan2.2 cross-Q/O FP8 scales must be a dictionary")
+
+    expected = set(_cross_qo_fp8_layer_names(profile))
+    provided = set(scales)
+    missing = sorted(expected - provided)
+    unexpected = sorted(provided - expected)
+    if missing or unexpected:
+        raise ValueError(
+            "Wan2.2 cross-Q/O FP8 scales must cover exactly the query and "
+            "output projections in every cross-attention block; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+
+    result: dict[str, dict[str, float]] = {}
+    for name in sorted(expected):
+        entry = scales[name]
+        if not isinstance(entry, dict):
+            raise TypeError(f"Wan2.2 cross-Q/O FP8 scale entry for {name} must be a dictionary")
+        input_scale = float(entry.get("input_scale", 0.0))
+        if not math.isfinite(input_scale) or input_scale <= 0.0:
+            raise ValueError(
+                f"Wan2.2 cross-Q/O FP8 input_scale for {name} must be positive and finite"
+            )
+
+        weight = weights[f"{name}.weight"]
+        minimum_weight_scale = op.fp8_e4m3_weight_scale(weight)
+        weight_scale = float(entry.get("weight_scale", minimum_weight_scale))
+        if not math.isfinite(weight_scale) or weight_scale <= 0.0:
+            raise ValueError(
+                f"Wan2.2 cross-Q/O FP8 weight_scale for {name} must be positive and finite"
+            )
+        if weight_scale < minimum_weight_scale * (1.0 - 1.0e-6):
+            raise ValueError(
+                f"Wan2.2 cross-Q/O FP8 weight_scale for {name} would overflow E4M3: "
+                f"provided={weight_scale}, minimum={minimum_weight_scale}"
+            )
+        result[name] = {
+            "input_scale": input_scale,
+            "weight_scale": weight_scale,
+        }
+    return result
+
+
+def _cross_qo_linear(
+    network,
+    tensor,
+    weights: dict[str, np.ndarray],
+    name: str,
+    scales: dict[str, dict[str, float]] | None,
+    weight_refs: list[np.ndarray],
+):
+    if scales is None:
+        return op.linear(
+            network,
+            tensor,
+            weights[f"{name}.weight"],
+            weights[f"{name}.bias"],
+        )
+    return op.linear_fp8_e4m3(
+        network,
+        tensor,
+        weights[f"{name}.weight"],
+        weights[f"{name}.bias"],
+        input_scale=scales[name]["input_scale"],
+        weight_scale=scales[name]["weight_scale"],
+        weight_refs=weight_refs,
+    )
+
+
 def _validated_ffn_fp8_scales(
     weights: dict[str, np.ndarray],
     profile: Wan22TI2VConfig,
@@ -186,14 +278,22 @@ def build_dit_engine(
     *,
     profile: Wan22TI2VConfig = WAN22_TI2V_5B,
     ffn_fp8_scales: dict | None = None,
+    cross_qo_fp8_scales: dict | None = None,
     verbose: bool = False,
 ) -> bytes:
     """Build a DiT plan for an explicitly qualified profile."""
 
     if profile not in SUPPORTED_GENERATION_PROFILES:
         raise ValueError("Wan2.2 DiT profile is not one of the qualified generation profiles")
+    if cross_qo_fp8_scales is not None and ffn_fp8_scales is None:
+        raise ValueError("Wan2.2 cross-Q/O FP8 requires the complete FFN FP8 scale map")
     weights = _numpy_state(model_dir)
     ffn_fp8_scales = _validated_ffn_fp8_scales(weights, profile, ffn_fp8_scales)
+    cross_qo_fp8_scales = _validated_cross_qo_fp8_scales(
+        weights,
+        profile,
+        cross_qo_fp8_scales,
+    )
     # TensorRT consumes raw pointers for explicit FP8 constants. Keep their
     # NumPy owners alive until build_serialized_network() has returned.
     fp8_weight_refs: list[np.ndarray] = []
@@ -367,11 +467,14 @@ def build_dit_engine(
             profile.dim,
             profile.eps,
         )
-        cq = op.linear(
+        cross_q_name = f"{prefix}.attn2.to_q"
+        cq = _cross_qo_linear(
             network,
             cross_input,
-            weights[f"{prefix}.attn2.to_q.weight"],
-            weights[f"{prefix}.attn2.to_q.bias"],
+            weights,
+            cross_q_name,
+            cross_qo_fp8_scales,
+            fp8_weight_refs,
         )
         ck = op.linear(
             network,
@@ -409,11 +512,14 @@ def build_dit_engine(
             heads=profile.num_heads,
             head_dim=profile.head_dim,
         )
-        cross = op.linear(
+        cross_out_name = f"{prefix}.attn2.to_out.0"
+        cross = _cross_qo_linear(
             network,
             cross,
-            weights[f"{prefix}.attn2.to_out.0.weight"],
-            weights[f"{prefix}.attn2.to_out.0.bias"],
+            weights,
+            cross_out_name,
+            cross_qo_fp8_scales,
+            fp8_weight_refs,
         )
         hidden = op.add_fp32_residual(network, hidden, cross)
 
@@ -487,7 +593,8 @@ def build_dit_engine(
         f"[wan2.2-ti2v] building DiT: layers={profile.num_layers}, "
         f"patches={profile.num_patches}, "
         f"latent={profile.latent_frames}x{profile.latent_height}x{profile.latent_width}, "
-        f"ffn_fp8={'enabled' if ffn_fp8_scales is not None else 'disabled'}",
+        f"ffn_fp8={'enabled' if ffn_fp8_scales is not None else 'disabled'}, "
+        f"cross_qo_fp8={'enabled' if cross_qo_fp8_scales is not None else 'disabled'}",
         file=sys.stderr,
     )
     plan = builder.build_serialized_network(network, build_config)

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_dit_builder.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_dit_builder.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from tensorrt_model_connect.families.wan2_2_ti2v import dit_builder as dit
@@ -15,3 +16,49 @@ from tensorrt_model_connect.families.wan2_2_ti2v import dit_builder as dit
 def test_dit_builder_rejects_unqualified_profiles_before_loading_weights() -> None:
     with pytest.raises(ValueError, match="not one of the qualified generation profiles"):
         dit.build_dit_engine("unused", profile=SimpleNamespace())
+
+
+def _fp8_fixture(num_layers: int = 2):
+    profile = SimpleNamespace(num_layers=num_layers)
+    weights = {}
+    scales = {}
+    for name in dit._ffn_fp8_layer_names(profile):
+        weights[f"{name}.weight"] = np.array(
+            [[-2.0, 0.5], [1.0, 0.25]],
+            dtype=np.float32,
+        )
+        scales[name] = {"input_scale": 8.0 / 448.0}
+    return profile, weights, scales
+
+
+def test_ffn_fp8_scales_require_all_and_only_ffn_projections() -> None:
+    profile, weights, scales = _fp8_fixture()
+    missing = dict(scales)
+    missing.pop(next(iter(missing)))
+    with pytest.raises(ValueError, match="missing="):
+        dit._validated_ffn_fp8_scales(weights, profile, missing)
+
+    unexpected = dict(scales)
+    unexpected["blocks.0.attn1.to_q"] = {"input_scale": 1.0}
+    with pytest.raises(ValueError, match="unexpected="):
+        dit._validated_ffn_fp8_scales(weights, profile, unexpected)
+
+
+def test_ffn_fp8_scales_derive_safe_checkpoint_weight_scales() -> None:
+    profile, weights, scales = _fp8_fixture()
+    result = dit._validated_ffn_fp8_scales(weights, profile, scales)
+
+    assert result is not None
+    for name, entry in result.items():
+        assert entry["input_scale"] == pytest.approx(8.0 / 448.0)
+        assert entry["weight_scale"] == pytest.approx(
+            np.max(np.abs(weights[f"{name}.weight"])) / 448.0
+        )
+
+
+def test_ffn_fp8_scales_reject_weight_overflow() -> None:
+    profile, weights, scales = _fp8_fixture()
+    first = next(iter(scales))
+    scales[first]["weight_scale"] = 1.0e-12
+    with pytest.raises(ValueError, match="would overflow E4M3"):
+        dit._validated_ffn_fp8_scales(weights, profile, scales)

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_dit_builder.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_dit_builder.py
@@ -31,6 +31,19 @@ def _fp8_fixture(num_layers: int = 2):
     return profile, weights, scales
 
 
+def _cross_qo_fp8_fixture(num_layers: int = 2):
+    profile = SimpleNamespace(num_layers=num_layers)
+    weights = {}
+    scales = {}
+    for name in dit._cross_qo_fp8_layer_names(profile):
+        weights[f"{name}.weight"] = np.array(
+            [[-2.0, 0.5], [1.0, 0.25]],
+            dtype=np.float32,
+        )
+        scales[name] = {"input_scale": 8.0 / 448.0}
+    return profile, weights, scales
+
+
 def test_ffn_fp8_scales_require_all_and_only_ffn_projections() -> None:
     profile, weights, scales = _fp8_fixture()
     missing = dict(scales)
@@ -62,3 +75,101 @@ def test_ffn_fp8_scales_reject_weight_overflow() -> None:
     scales[first]["weight_scale"] = 1.0e-12
     with pytest.raises(ValueError, match="would overflow E4M3"):
         dit._validated_ffn_fp8_scales(weights, profile, scales)
+
+
+def test_cross_qo_fp8_layer_names_are_exact() -> None:
+    profile = SimpleNamespace(num_layers=2)
+
+    assert dit._cross_qo_fp8_layer_names(profile) == (
+        "blocks.0.attn2.to_q",
+        "blocks.0.attn2.to_out.0",
+        "blocks.1.attn2.to_q",
+        "blocks.1.attn2.to_out.0",
+    )
+
+
+def test_cross_qo_fp8_scales_require_all_and_only_qualified_projections() -> None:
+    profile, weights, scales = _cross_qo_fp8_fixture()
+    missing = dict(scales)
+    missing.pop(next(iter(missing)))
+    with pytest.raises(ValueError, match="missing="):
+        dit._validated_cross_qo_fp8_scales(weights, profile, missing)
+
+    unexpected = dict(scales)
+    unexpected["blocks.0.attn1.to_out.0"] = {"input_scale": 1.0}
+    with pytest.raises(ValueError, match="unexpected="):
+        dit._validated_cross_qo_fp8_scales(weights, profile, unexpected)
+
+
+def test_cross_qo_fp8_scales_derive_safe_checkpoint_weight_scales() -> None:
+    profile, weights, scales = _cross_qo_fp8_fixture()
+    result = dit._validated_cross_qo_fp8_scales(weights, profile, scales)
+
+    assert result is not None
+    for name, entry in result.items():
+        assert entry["input_scale"] == pytest.approx(8.0 / 448.0)
+        assert entry["weight_scale"] == pytest.approx(
+            np.max(np.abs(weights[f"{name}.weight"])) / 448.0
+        )
+
+
+def test_cross_qo_fp8_scales_reject_invalid_values() -> None:
+    profile, weights, scales = _cross_qo_fp8_fixture()
+    first = next(iter(scales))
+
+    invalid_entry = dict(scales)
+    invalid_entry[first] = 0.125
+    with pytest.raises(TypeError, match="must be a dictionary"):
+        dit._validated_cross_qo_fp8_scales(weights, profile, invalid_entry)
+
+    invalid_input = {name: dict(entry) for name, entry in scales.items()}
+    invalid_input[first]["input_scale"] = float("inf")
+    with pytest.raises(ValueError, match="positive and finite"):
+        dit._validated_cross_qo_fp8_scales(weights, profile, invalid_input)
+
+    invalid_weight = {name: dict(entry) for name, entry in scales.items()}
+    invalid_weight[first]["weight_scale"] = 1.0e-12
+    with pytest.raises(ValueError, match="would overflow E4M3"):
+        dit._validated_cross_qo_fp8_scales(weights, profile, invalid_weight)
+
+
+def test_cross_qo_linear_is_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    name = "blocks.0.attn2.to_q"
+    network = object()
+    tensor = object()
+    weights = {
+        f"{name}.weight": np.ones((2, 2), dtype=np.float32),
+        f"{name}.bias": np.ones((2,), dtype=np.float32),
+    }
+    calls = []
+    monkeypatch.setattr(
+        dit.op,
+        "linear",
+        lambda *args, **kwargs: calls.append(("bf16", args, kwargs)) or "bf16-output",
+    )
+    monkeypatch.setattr(
+        dit.op,
+        "linear_fp8_e4m3",
+        lambda *args, **kwargs: calls.append(("fp8", args, kwargs)) or "fp8-output",
+    )
+
+    assert dit._cross_qo_linear(network, tensor, weights, name, None, []) == "bf16-output"
+    refs = []
+    scales = {name: {"input_scale": 0.125, "weight_scale": 0.25}}
+    assert dit._cross_qo_linear(network, tensor, weights, name, scales, refs) == "fp8-output"
+
+    assert [call[0] for call in calls] == ["bf16", "fp8"]
+    assert calls[1][2] == {
+        "input_scale": 0.125,
+        "weight_scale": 0.25,
+        "weight_refs": refs,
+    }
+
+
+def test_dit_builder_rejects_cross_qo_fp8_without_ffn_before_loading_weights() -> None:
+    with pytest.raises(ValueError, match="requires the complete FFN"):
+        dit.build_dit_engine(
+            "unused",
+            profile=dit.WAN22_TI2V_5B,
+            cross_qo_fp8_scales={},
+        )

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_family.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_family.py
@@ -300,6 +300,7 @@ def test_component_builder_emits_four_native_plans(
     assert components["tokenizer_json"] == tokenizer_payload
     assert denoiser_calls[0]["profile"] is WAN22_TI2V_5B
     assert denoiser_calls[0]["ffn_fp8_scales"] is None
+    assert denoiser_calls[0]["cross_qo_fp8_scales"] is None
 
     trt_builder.build_wan22_components(
         str(tmp_path),
@@ -313,16 +314,71 @@ def test_component_builder_emits_four_native_plans(
     )
     assert denoiser_calls[1]["profile"] is WAN22_TI2V_5B_L0
     assert denoiser_calls[1]["ffn_fp8_scales"] is None
+    assert denoiser_calls[1]["cross_qo_fp8_scales"] is None
 
-    explicit_scales = {"precomputed": {"input_scale": 0.125}}
+    ffn_scales = {
+        name: {"input_scale": 0.125}
+        for index in range(WAN22_TI2V_5B.num_layers)
+        for name in (
+            f"blocks.{index}.ffn.net.0.proj",
+            f"blocks.{index}.ffn.net.2",
+        )
+    }
     trt_builder.build_wan22_components(
         str(tmp_path),
         config=_runtime_config(),
         weights=weights,
-        fp8_scales=explicit_scales,
+        fp8_scales=ffn_scales,
     )
     assert denoiser_calls[2]["profile"] is WAN22_TI2V_5B
-    assert denoiser_calls[2]["ffn_fp8_scales"] is explicit_scales
+    assert denoiser_calls[2]["ffn_fp8_scales"] is ffn_scales
+    assert denoiser_calls[2]["cross_qo_fp8_scales"] is None
+
+    cross_qo_scales = {
+        name: {"input_scale": 0.25}
+        for index in range(WAN22_TI2V_5B.num_layers)
+        for name in (
+            f"blocks.{index}.attn2.to_q",
+            f"blocks.{index}.attn2.to_out.0",
+        )
+    }
+    combined_scales = {**ffn_scales, **cross_qo_scales}
+    trt_builder.build_wan22_components(
+        str(tmp_path),
+        config=_runtime_config(),
+        weights=weights,
+        fp8_scales=combined_scales,
+    )
+    assert denoiser_calls[3]["ffn_fp8_scales"] == ffn_scales
+    assert denoiser_calls[3]["cross_qo_fp8_scales"] == cross_qo_scales
+
+    with pytest.raises(ValueError, match="complete FFN\\+cross-Q/O"):
+        trt_builder.build_wan22_components(
+            str(tmp_path),
+            config=_runtime_config(),
+            weights=weights,
+            fp8_scales=cross_qo_scales,
+        )
+
+    incomplete_scales = dict(combined_scales)
+    incomplete_scales.pop("blocks.0.attn2.to_q")
+    with pytest.raises(ValueError, match="missing_cross_qo="):
+        trt_builder.build_wan22_components(
+            str(tmp_path),
+            config=_runtime_config(),
+            weights=weights,
+            fp8_scales=incomplete_scales,
+        )
+
+    unqualified_scales = dict(combined_scales)
+    unqualified_scales["blocks.0.attn1.to_out.0"] = {"input_scale": 0.25}
+    with pytest.raises(ValueError, match="unexpected="):
+        trt_builder.build_wan22_components(
+            str(tmp_path),
+            config=_runtime_config(),
+            weights=weights,
+            fp8_scales=unqualified_scales,
+        )
 
     with pytest.raises(ValueError, match="FP8 scales are qualified only"):
         trt_builder.build_wan22_components(
@@ -334,7 +390,7 @@ def test_component_builder_emits_four_native_plans(
                 num_inference_steps=15,
             ),
             weights=weights,
-            fp8_scales=explicit_scales,
+            fp8_scales=ffn_scales,
         )
 
 

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_family.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_family.py
@@ -271,10 +271,11 @@ def test_component_builder_emits_four_native_plans(
         "build_native_umt5_encoder_engine",
         lambda *_args, **_kwargs: b"text-plan",
     )
+    denoiser_calls = []
     monkeypatch.setattr(
         trt_builder,
         "build_dit_engine",
-        lambda *_args, **_kwargs: b"dit-plan",
+        lambda *_args, **kwargs: denoiser_calls.append(kwargs) or b"dit-plan",
     )
     monkeypatch.setattr(
         trt_builder,
@@ -297,6 +298,44 @@ def test_component_builder_emits_four_native_plans(
     assert components["vae_decoder"] == b"vae-recurrent"
     assert components["vae_decoder_first_frame"] == b"vae-first"
     assert components["tokenizer_json"] == tokenizer_payload
+    assert denoiser_calls[0]["profile"] is WAN22_TI2V_5B
+    assert denoiser_calls[0]["ffn_fp8_scales"] is None
+
+    trt_builder.build_wan22_components(
+        str(tmp_path),
+        config=_runtime_config(
+            video_width=672,
+            video_height=384,
+            video_num_frames=5,
+            num_inference_steps=15,
+        ),
+        weights=weights,
+    )
+    assert denoiser_calls[1]["profile"] is WAN22_TI2V_5B_L0
+    assert denoiser_calls[1]["ffn_fp8_scales"] is None
+
+    explicit_scales = {"precomputed": {"input_scale": 0.125}}
+    trt_builder.build_wan22_components(
+        str(tmp_path),
+        config=_runtime_config(),
+        weights=weights,
+        fp8_scales=explicit_scales,
+    )
+    assert denoiser_calls[2]["profile"] is WAN22_TI2V_5B
+    assert denoiser_calls[2]["ffn_fp8_scales"] is explicit_scales
+
+    with pytest.raises(ValueError, match="FP8 scales are qualified only"):
+        trt_builder.build_wan22_components(
+            str(tmp_path),
+            config=_runtime_config(
+                video_width=672,
+                video_height=384,
+                video_num_frames=5,
+                num_inference_steps=15,
+            ),
+            weights=weights,
+            fp8_scales=explicit_scales,
+        )
 
 
 def test_runtime_config_supports_only_qualified_profiles_and_seed_range() -> None:

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_trt_ops.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_trt_ops.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused contracts for Wan2.2-owned TensorRT graph operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+from tensorrt_model_connect.families.wan2_2_ti2v import trt_ops as op
+
+
+@dataclass
+class _Tensor:
+    shape: tuple[int, int]
+    dtype: str = "bfloat16"
+
+
+class _Layer:
+    def __init__(self, output: _Tensor) -> None:
+        self._output = output
+
+    def get_output(self, index: int) -> _Tensor:
+        assert index == 0
+        return self._output
+
+
+class _Network:
+    def __init__(self) -> None:
+        self.slices: list[tuple[tuple[int, int], tuple[int, int], tuple[int, int]]] = []
+
+    def add_slice(
+        self,
+        tensor: _Tensor,
+        start: tuple[int, int],
+        shape: tuple[int, int],
+        stride: tuple[int, int],
+    ) -> _Layer:
+        assert tensor.dtype == "bfloat16"
+        self.slices.append((start, shape, stride))
+        return _Layer(_Tensor(shape, dtype=tensor.dtype))
+
+
+def test_fused_qkv_linear_packs_qkv_in_order_and_preserves_bf16_slices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rows, hidden_size = 7, 4
+    x = _Tensor((rows, hidden_size))
+    weights = tuple(
+        np.full((hidden_size, hidden_size), fill_value, dtype=np.float32)
+        for fill_value in (1.0, 2.0, 3.0)
+    )
+    biases = tuple(
+        np.full((hidden_size,), fill_value, dtype=np.float32) for fill_value in (4.0, 5.0, 6.0)
+    )
+    calls = []
+
+    def _linear(network, actual_x, weight, bias):
+        calls.append((network, actual_x, weight, bias))
+        return _Tensor((rows, 3 * hidden_size))
+
+    monkeypatch.setattr(op, "linear", _linear)
+    network = _Network()
+
+    q, k, v = op.fused_qkv_linear(
+        network,
+        x,
+        weights[0],
+        biases[0],
+        weights[1],
+        biases[1],
+        weights[2],
+        biases[2],
+        rows=rows,
+        hidden_size=hidden_size,
+    )
+
+    assert len(calls) == 1
+    _, actual_x, packed_weight, packed_bias = calls[0]
+    assert actual_x is x
+    assert packed_weight.shape == (3 * hidden_size, hidden_size)
+    assert packed_bias.shape == (3 * hidden_size,)
+    for index in range(3):
+        np.testing.assert_array_equal(
+            packed_weight[index * hidden_size : (index + 1) * hidden_size],
+            weights[index],
+        )
+        np.testing.assert_array_equal(
+            packed_bias[index * hidden_size : (index + 1) * hidden_size],
+            biases[index],
+        )
+    reference_x = np.arange(2 * hidden_size, dtype=np.float32).reshape(2, hidden_size)
+    separate_qkv = np.concatenate(
+        [reference_x @ weight.T + bias for weight, bias in zip(weights, biases)],
+        axis=1,
+    )
+    packed_qkv = reference_x @ packed_weight.T + packed_bias
+    np.testing.assert_array_equal(packed_qkv, separate_qkv)
+    assert network.slices == [
+        ((0, 0), (rows, hidden_size), (1, 1)),
+        ((0, hidden_size), (rows, hidden_size), (1, 1)),
+        ((0, 2 * hidden_size), (rows, hidden_size), (1, 1)),
+    ]
+    assert (q.shape, k.shape, v.shape) == ((rows, hidden_size),) * 3
+    assert (q.dtype, k.dtype, v.dtype) == ("bfloat16",) * 3
+
+
+@pytest.mark.parametrize(("bad_weight", "bad_bias"), [(True, False), (False, True)])
+def test_fused_qkv_linear_rejects_shape_drift(bad_weight: bool, bad_bias: bool) -> None:
+    hidden_size = 4
+    weight_shape = (hidden_size, hidden_size - 1) if bad_weight else (hidden_size, hidden_size)
+    bias_shape = (hidden_size - 1,) if bad_bias else (hidden_size,)
+    weights = [np.zeros((hidden_size, hidden_size), dtype=np.float32) for _ in range(3)]
+    biases = [np.zeros((hidden_size,), dtype=np.float32) for _ in range(3)]
+    weights[1] = np.zeros(weight_shape, dtype=np.float32)
+    biases[2] = np.zeros(bias_shape, dtype=np.float32)
+
+    with pytest.raises(ValueError, match="Q/K/V (weights|biases) must all have shape"):
+        op.fused_qkv_linear(
+            _Network(),
+            _Tensor((2, hidden_size)),
+            weights[0],
+            biases[0],
+            weights[1],
+            biases[1],
+            weights[2],
+            biases[2],
+            rows=2,
+            hidden_size=hidden_size,
+        )

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/trt_builder.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/trt_builder.py
@@ -42,6 +42,54 @@ def load_vae_step_weights(*args, **kwargs):
     return implementation(*args, **kwargs)
 
 
+def _qualified_fp8_scale_names(profile) -> tuple[set[str], set[str]]:
+    ffn = {
+        name
+        for index in range(profile.num_layers)
+        for name in (
+            f"blocks.{index}.ffn.net.0.proj",
+            f"blocks.{index}.ffn.net.2",
+        )
+    }
+    cross_qo = {
+        name
+        for index in range(profile.num_layers)
+        for name in (
+            f"blocks.{index}.attn2.to_q",
+            f"blocks.{index}.attn2.to_out.0",
+        )
+    }
+    return ffn, cross_qo
+
+
+def _split_qualified_fp8_scales(
+    fp8_scales: dict | None,
+    profile,
+) -> tuple[dict | None, dict | None]:
+    if fp8_scales is None:
+        return None, None
+    if not isinstance(fp8_scales, dict):
+        raise TypeError("Wan2.2 FP8 scales must be a dictionary")
+
+    expected_ffn, expected_cross_qo = _qualified_fp8_scale_names(profile)
+    provided = set(fp8_scales)
+    if provided == expected_ffn:
+        return fp8_scales, None
+    if provided == expected_ffn | expected_cross_qo:
+        return (
+            {name: fp8_scales[name] for name in sorted(expected_ffn)},
+            {name: fp8_scales[name] for name in sorted(expected_cross_qo)},
+        )
+
+    raise ValueError(
+        "Wan2.2 FP8 scales must contain either the complete FFN map or the "
+        "complete FFN+cross-Q/O map; "
+        f"missing_ffn={sorted(expected_ffn - provided)}, "
+        f"missing_cross_qo={sorted(expected_cross_qo - provided)}, "
+        f"unexpected={sorted(provided - expected_ffn - expected_cross_qo)}"
+    )
+
+
 def build_wan22_components(
     model_dir: str,
     *,
@@ -59,9 +107,13 @@ def build_wan22_components(
     generation_profile = select_generation_profile(config.raw)
     if fp8_scales is not None and generation_profile != WAN22_TI2V_5B:
         raise ValueError(
-            "Wan2.2 FFN FP8 scales are qualified only for the official "
+            "Wan2.2 FP8 scales are qualified only for the official "
             "1280x704, 121-frame, 50-step profile"
         )
+    ffn_fp8_scales, cross_qo_fp8_scales = _split_qualified_fp8_scales(
+        fp8_scales,
+        generation_profile,
+    )
 
     text_encoder = build_native_umt5_encoder_engine(
         weights["_text_encoder_checkpoint"],
@@ -70,7 +122,8 @@ def build_wan22_components(
     denoiser = build_dit_engine(
         model_dir,
         profile=generation_profile,
-        ffn_fp8_scales=fp8_scales,
+        ffn_fp8_scales=ffn_fp8_scales,
+        cross_qo_fp8_scales=cross_qo_fp8_scales,
         verbose=verbose,
     )
 

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/trt_builder.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/trt_builder.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .model_config import select_generation_profile
+from .model_config import WAN22_TI2V_5B, select_generation_profile
 
 
 # Heavy TensorRT/NumPy/PyTorch conversion modules are loaded only when the
@@ -49,6 +49,7 @@ def build_wan22_components(
     weights: dict,
     precision: str = "bf16",
     verbose: bool = False,
+    fp8_scales: dict | None = None,
     **_kwargs,
 ) -> dict:
     """Build all four plans for one qualified checkpoint profile."""
@@ -56,6 +57,11 @@ def build_wan22_components(
     if precision.lower() not in {"bf16", "bfloat16"}:
         raise ValueError("Wan2.2-TI2V-5B requires BF16 DiT/T5 precision")
     generation_profile = select_generation_profile(config.raw)
+    if fp8_scales is not None and generation_profile != WAN22_TI2V_5B:
+        raise ValueError(
+            "Wan2.2 FFN FP8 scales are qualified only for the official "
+            "1280x704, 121-frame, 50-step profile"
+        )
 
     text_encoder = build_native_umt5_encoder_engine(
         weights["_text_encoder_checkpoint"],
@@ -64,6 +70,7 @@ def build_wan22_components(
     denoiser = build_dit_engine(
         model_dir,
         profile=generation_profile,
+        ffn_fp8_scales=fp8_scales,
         verbose=verbose,
     )
 

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/trt_ops.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/trt_ops.py
@@ -54,6 +54,151 @@ def linear(network, x, weight, bias=None, *, bf16=True):
     return bf16_barrier(network, y) if bf16 else y
 
 
+def fused_qkv_linear(
+    network,
+    x,
+    q_weight,
+    q_bias,
+    k_weight,
+    k_bias,
+    v_weight,
+    v_bias,
+    *,
+    rows: int,
+    hidden_size: int,
+):
+    """Run self-attention Q/K/V as one BF16 linear and return Q, K, V rows."""
+
+    weights = tuple(
+        np.asarray(weight, dtype=np.float32) for weight in (q_weight, k_weight, v_weight)
+    )
+    biases = tuple(np.asarray(bias, dtype=np.float32) for bias in (q_bias, k_bias, v_bias))
+    expected_weight_shape = (hidden_size, hidden_size)
+    expected_bias_shape = (hidden_size,)
+    if any(weight.shape != expected_weight_shape for weight in weights):
+        raise ValueError(
+            "Q/K/V weights must all have shape "
+            f"{expected_weight_shape}; got {[weight.shape for weight in weights]}"
+        )
+    if any(bias.shape != expected_bias_shape for bias in biases):
+        raise ValueError(
+            "Q/K/V biases must all have shape "
+            f"{expected_bias_shape}; got {[bias.shape for bias in biases]}"
+        )
+
+    packed = linear(
+        network,
+        x,
+        np.concatenate(weights, axis=0),
+        np.concatenate(biases, axis=0),
+    )
+    return tuple(
+        network.add_slice(
+            packed,
+            (0, index * hidden_size),
+            (rows, hidden_size),
+            (1, 1),
+        ).get_output(0)
+        for index in range(3)
+    )
+
+
+def fp8_e4m3_weight_scale(weight) -> float:
+    """Return the smallest finite per-tensor E4M3 scale for ``weight``."""
+
+    maximum = float(np.max(np.abs(np.asarray(weight, dtype=np.float32))))
+    if not math.isfinite(maximum) or maximum <= 0.0:
+        raise ValueError("FP8 weight must have a positive finite absolute maximum")
+    return maximum / 448.0
+
+
+def _fp8_e4m3_tn(weight, scale: float):
+    """Pre-quantize PyTorch ``[out, in]`` weights in TRT's FP8 TN layout."""
+
+    if not math.isfinite(scale) or scale <= 0.0:
+        raise ValueError("FP8 weight scale must be positive and finite")
+
+    minimum_scale = fp8_e4m3_weight_scale(weight)
+    if scale < minimum_scale * (1.0 - 1.0e-6):
+        raise ValueError(
+            f"FP8 weight scale would overflow E4M3: provided={scale}, minimum={minimum_scale}"
+        )
+
+    try:
+        import ml_dtypes
+    except ImportError as exc:
+        raise RuntimeError("Wan2.2 FFN FP8 builds require the ml_dtypes build dependency") from exc
+
+    # ``weight`` is already [out, in]. Keeping that storage and transposing
+    # operand B at the matmul is the TN form that TensorRT fuses on Blackwell.
+    scaled = np.ascontiguousarray(np.asarray(weight, dtype=np.float32) / scale)
+    scaled = np.clip(scaled, -448.0, 448.0)
+    return np.ascontiguousarray(scaled.astype(ml_dtypes.float8_e4m3fn))
+
+
+def linear_fp8_e4m3(
+    network,
+    x,
+    weight,
+    bias=None,
+    *,
+    input_scale: float,
+    weight_scale: float | None = None,
+    weight_refs: list[np.ndarray] | None = None,
+):
+    """FFN linear using native TensorRT E4M3 Q/DQ and an FP8 TN weight.
+
+    The output and bias boundary stay BF16, matching :func:`linear`. Only the
+    matmul operands are quantized. ``weight_refs`` keeps the NumPy-owned FP8
+    storage alive until TensorRT has finished serializing the network.
+    """
+
+    if not math.isfinite(input_scale) or input_scale <= 0.0:
+        raise ValueError("FP8 input scale must be positive and finite")
+    if weight_scale is None:
+        weight_scale = fp8_e4m3_weight_scale(weight)
+    fp8_weight = _fp8_e4m3_tn(weight, weight_scale)
+    if weight_refs is not None:
+        weight_refs.append(fp8_weight)
+
+    x = cast(network, x, trt.bfloat16)
+    input_scale_tensor = constant(network, np.asarray(input_scale, dtype=np.float32))
+    quantized_x = network.add_quantize(x, input_scale_tensor, trt.DataType.FP8)
+    dequantized_x = network.add_dequantize(
+        quantized_x.get_output(0),
+        input_scale_tensor,
+        trt.bfloat16,
+    )
+
+    out_features, in_features = np.asarray(weight).shape
+    fp8_weight_tensor = network.add_constant(
+        (out_features, in_features),
+        trt.Weights(
+            trt.DataType.FP8,
+            fp8_weight.ctypes.data,
+            fp8_weight.size,
+        ),
+    ).get_output(0)
+    weight_scale_tensor = constant(network, np.asarray(weight_scale, dtype=np.float32))
+    dequantized_weight = network.add_dequantize(
+        fp8_weight_tensor,
+        weight_scale_tensor,
+        trt.bfloat16,
+    )
+
+    y = network.add_matrix_multiply(
+        dequantized_x.get_output(0),
+        trt.MatrixOperation.NONE,
+        dequantized_weight.get_output(0),
+        trt.MatrixOperation.TRANSPOSE,
+    ).get_output(0)
+    if bias is not None:
+        bias_tensor = constant(network, np.asarray(bias, dtype=np.float32).reshape(1, -1))
+        bias_tensor = cast(network, bias_tensor, y.dtype)
+        y = network.add_elementwise(y, bias_tensor, trt.ElementWiseOperation.SUM).get_output(0)
+    return bf16_barrier(network, y)
+
+
 def layer_norm(network, x, hidden_size: int, eps: float, *, round_bf16: bool = False):
     x = cast(network, x, trt.float32)
     gamma = constant(network, np.ones((1, hidden_size), dtype=np.float32))

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -39,6 +39,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cctype>
 #include <cerrno>
 #include <chrono>
@@ -48,6 +49,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <iterator>
@@ -61,6 +63,7 @@
 #include <string>
 #include <sys/wait.h>
 #include <system_error>
+#include <thread>
 #include <unistd.h>
 #include <vector>
 
@@ -710,6 +713,18 @@ int cmd_generate_video(const CliArgs& args) {
         return EXIT_FAILURE;
     }
 
+    std::optional<std::size_t> png_worker_override;
+    if (const char* raw = std::getenv("TRTMC_PNG_WRITE_WORKERS"); raw != nullptr && *raw != '\0') {
+        errno = 0;
+        char* end = nullptr;
+        const auto parsed = std::strtoul(raw, &end, 10);
+        if (errno != 0 || end == raw || *end != '\0' || parsed < 1 || parsed > 8) {
+            std::cerr << "Error: TRTMC_PNG_WRITE_WORKERS must be an integer in [1, 8]\n";
+            return EXIT_FAILURE;
+        }
+        png_worker_override = static_cast<std::size_t>(parsed);
+    }
+
     const std::string out_dir =
         args.output_dir.empty() ? "/tmp/trtmc_generate_video" : args.output_dir;
 
@@ -744,27 +759,90 @@ int cmd_generate_video(const CliArgs& args) {
     const auto frame_pixels =
         static_cast<std::size_t>(result.height) * static_cast<std::size_t>(result.width) * 3;
 
+    const auto output_begin = std::chrono::steady_clock::now();
+    std::vector<std::string> frame_paths(static_cast<std::size_t>(result.num_frames));
     for (int32_t f = 0; f < result.num_frames; ++f) {
-        // Convert float32 HWC [0,1] to uint8 HWC [0,255].
-        std::vector<unsigned char> rgb(frame_pixels);
-        const float* src = result.pixels.data() + static_cast<std::size_t>(f) * frame_pixels;
-        for (std::size_t i = 0; i < frame_pixels; ++i) {
-            const float v = std::max(0.0F, std::min(1.0F, src[i]));
-            rgb[i] = static_cast<unsigned char>(v * 255.0F + 0.5F);
-        }
-
-        // Build filename: frame_0000.png
         std::ostringstream fname;
         fname << out_dir << "/frame_" << std::setw(4) << std::setfill('0') << f << ".png";
+        frame_paths[static_cast<std::size_t>(f)] = fname.str();
+    }
 
-        const int stride = result.width * 3;
-        if (!stbi_write_png(fname.str().c_str(), result.width, result.height, 3, rgb.data(),
-                            stride)) {
-            std::cerr << "Error: failed to write " << fname.str() << '\n';
+    std::size_t workers_used = 0;
+    if (result.num_frames > 0) {
+        const auto hardware_threads = std::max(1U, std::thread::hardware_concurrency());
+        const auto automatic_workers =
+            std::min<std::size_t>(8, static_cast<std::size_t>(hardware_threads));
+        const auto requested_workers = png_worker_override.value_or(automatic_workers);
+        const auto worker_count =
+            std::min<std::size_t>(static_cast<std::size_t>(result.num_frames), requested_workers);
+
+        // Allocate all fallible per-worker storage before any threads start.
+        std::vector<std::vector<unsigned char>> rgb_buffers;
+        rgb_buffers.reserve(worker_count);
+        for (std::size_t worker = 0; worker < worker_count; ++worker)
+            rgb_buffers.emplace_back(frame_pixels);
+
+        std::vector<unsigned char> frame_status(static_cast<std::size_t>(result.num_frames), 0);
+        std::atomic<int32_t> next_frame{0};
+        const auto encode_frames = [&](std::vector<unsigned char>& rgb) noexcept {
+            while (true) {
+                const int32_t f = next_frame.fetch_add(1, std::memory_order_relaxed);
+                if (f >= result.num_frames)
+                    return;
+
+                try {
+                    const float* src =
+                        result.pixels.data() + static_cast<std::size_t>(f) * frame_pixels;
+                    for (std::size_t i = 0; i < frame_pixels; ++i) {
+                        const float v = std::max(0.0F, std::min(1.0F, src[i]));
+                        rgb[i] = static_cast<unsigned char>(v * 255.0F + 0.5F);
+                    }
+
+                    const auto& path = frame_paths[static_cast<std::size_t>(f)];
+                    const int stride = result.width * 3;
+                    if (!stbi_write_png(path.c_str(), result.width, result.height, 3, rgb.data(),
+                                        stride))
+                        frame_status[static_cast<std::size_t>(f)] = 1;
+                } catch (...) {
+                    frame_status[static_cast<std::size_t>(f)] = 2;
+                }
+            }
+        };
+
+        // Keep the calling thread as a worker. If a background thread cannot
+        // be created, safely continue with the smaller pool already started.
+        std::vector<std::thread> workers;
+        workers.reserve(worker_count - 1);
+        for (std::size_t worker = 0; worker + 1 < worker_count; ++worker) {
+            try {
+                workers.emplace_back(encode_frames, std::ref(rgb_buffers[worker]));
+            } catch (...) {
+                break;
+            }
+        }
+        workers_used = workers.size() + 1;
+        encode_frames(rgb_buffers[workers.size()]);
+        for (auto& worker : workers)
+            worker.join();
+
+        for (std::size_t f = 0; f < frame_status.size(); ++f) {
+            if (frame_status[f] == 0)
+                continue;
+            std::cerr << "Error: failed to " << (frame_status[f] == 1 ? "write " : "encode ")
+                      << frame_paths[f] << '\n';
             return EXIT_FAILURE;
         }
-        std::cout << "Saved " << fname.str() << '\n';
     }
+
+    for (const auto& path : frame_paths) {
+        std::cout << "Saved " << path << '\n';
+    }
+    const auto output_end = std::chrono::steady_clock::now();
+    const auto output_ms =
+        std::chrono::duration<double, std::milli>(output_end - output_begin).count();
+    std::cerr << "[trtmc.video_output_timing] frames=" << result.num_frames
+              << " workers=" << workers_used << " output_ms=" << std::fixed << std::setprecision(3)
+              << output_ms << '\n';
 
     return EXIT_SUCCESS;
 }

--- a/src/runtime/models/wan2_2_ti2v/MODEL.toml
+++ b/src/runtime/models/wan2_2_ti2v/MODEL.toml
@@ -7,6 +7,7 @@ runtime_plugins = ["plugin.cpp|register_wan2_2_ti2v_plugin"]
 runtime_strategies = ["diffusion_wan2_2_ti2v"]
 runtime_tests = [
   "test_wan2_2_cuda_rng|test_wan2_2_cuda_rng.cpp|_|torch_cuda_normal.cu|REQUIRES_GPU",
+  "test_wan2_2_easycache|test_wan2_2_easycache.cpp|_|easycache.cpp|_",
   "test_wan2_2_prompt_cleaner|test_wan2_2_prompt_cleaner.cpp|_|prompt_cleaner.cpp|_",
   "test_wan2_2_options|test_wan2_2_options.cpp|nlohmann_json::nlohmann_json|options.cpp|_",
   "test_wan2_2_staged_pipeline|test_wan2_2_staged_pipeline.cpp|trtmc_model_wan2_2_ti2v|_|REQUIRES_TRT,REQUIRES_GPU",

--- a/src/runtime/models/wan2_2_ti2v/easycache.cpp
+++ b/src/runtime/models/wan2_2_ti2v/easycache.cpp
@@ -1,0 +1,434 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/wan2_2_ti2v/easycache.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace trtmc::wan2_2_ti2v {
+namespace {
+
+constexpr const char* kEnableEnvironment = "TRTMC_WAN22_EASYCACHE";
+constexpr const char* kThresholdEnvironment = "TRTMC_WAN22_EASYCACHE_THRESHOLD";
+constexpr const char* kFirstExactEnvironment = "TRTMC_WAN22_EASYCACHE_FIRST_EXACT_STEPS";
+constexpr const char* kLastExactEnvironment = "TRTMC_WAN22_EASYCACHE_LAST_EXACT_STEPS";
+constexpr const char* kMaxConsecutiveReuseEnvironment =
+    "TRTMC_WAN22_EASYCACHE_MAX_CONSECUTIVE_REUSE";
+constexpr const char* kLateCfgEnableEnvironment = "TRTMC_WAN22_EASYCACHE_LATE_CFG";
+constexpr double kMinimumNorm = 1.0e-8;
+constexpr double kMaximumTimestepExtrapolation = 2.0;
+
+std::string lowercase(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char character) {
+        return static_cast<char>(std::tolower(character));
+    });
+    return value;
+}
+
+bool parse_enabled(const char* name) {
+    const char* value = std::getenv(name);
+    if (value == nullptr || *value == '\0')
+        return false;
+    const auto normalized = lowercase(value);
+    constexpr std::array<std::string_view, 4> enabled = {"1", "true", "yes", "on"};
+    constexpr std::array<std::string_view, 4> disabled = {"0", "false", "no", "off"};
+    if (std::find(enabled.begin(), enabled.end(), normalized) != enabled.end())
+        return true;
+    if (std::find(disabled.begin(), disabled.end(), normalized) != disabled.end())
+        return false;
+    throw std::invalid_argument(std::string(name) +
+                                " must be one of 0/1, false/true, no/yes, or off/on");
+}
+
+double parse_positive_double(const char* name, double default_value) {
+    const char* value = std::getenv(name);
+    if (value == nullptr || *value == '\0')
+        return default_value;
+    char* end = nullptr;
+    errno = 0;
+    const double parsed = std::strtod(value, &end);
+    if (errno != 0 || end == value || *end != '\0' || !std::isfinite(parsed) || parsed <= 0.0)
+        throw std::invalid_argument(std::string(name) + " must be a finite positive number");
+    return parsed;
+}
+
+int32_t parse_nonnegative_int(const char* name, int32_t default_value) {
+    const char* value = std::getenv(name);
+    if (value == nullptr || *value == '\0')
+        return default_value;
+    char* end = nullptr;
+    errno = 0;
+    const long parsed = std::strtol(value, &end, 10);
+    if (errno != 0 || end == value || *end != '\0' || parsed < 0 ||
+        parsed > std::numeric_limits<int32_t>::max()) {
+        throw std::invalid_argument(std::string(name) + " must be a non-negative integer");
+    }
+    return static_cast<int32_t>(parsed);
+}
+
+bool exact_windows_are_valid(const EasyCacheConfig& config) noexcept {
+    return config.first_exact_steps >= 0 && config.last_exact_steps >= 0 &&
+           config.first_exact_steps <= config.total_steps &&
+           config.last_exact_steps <= config.total_steps - config.first_exact_steps;
+}
+
+void validate_config(const EasyCacheConfig& config) {
+    if (!config.enabled)
+        throw std::invalid_argument("EasyCacheController requires an enabled configuration");
+    if (!std::isfinite(config.threshold) || config.threshold <= 0.0)
+        throw std::invalid_argument("Wan2.2 EasyCache threshold must be finite and positive");
+    if (config.total_steps <= 0)
+        throw std::invalid_argument("Wan2.2 EasyCache total_steps must be positive");
+    if (!exact_windows_are_valid(config))
+        throw std::invalid_argument("Wan2.2 EasyCache exact-step windows must not overlap");
+    if (config.max_consecutive_reuse <= 0) {
+        throw std::invalid_argument(
+            "Wan2.2 EasyCache max_consecutive_reuse must be a positive integer");
+    }
+}
+
+bool is_qualified_late_cfg_profile(const EasyCacheConfig& config) noexcept {
+    return config.enabled && config.threshold == kQualifiedEasyCacheThreshold &&
+           config.first_exact_steps == kQualifiedEasyCacheFirstExactSteps &&
+           config.last_exact_steps == kQualifiedEasyCacheLastExactSteps &&
+           config.max_consecutive_reuse == kQualifiedEasyCacheMaxConsecutiveReuse &&
+           config.total_steps == kQualifiedEasyCacheTotalSteps;
+}
+
+} // namespace
+
+EasyCacheConfig easycache_config_from_environment(int32_t total_steps) {
+    EasyCacheConfig config;
+    config.total_steps = total_steps;
+    config.enabled = parse_enabled(kEnableEnvironment);
+    if (!config.enabled)
+        return config;
+
+    config.threshold = parse_positive_double(kThresholdEnvironment, config.threshold);
+    config.first_exact_steps =
+        parse_nonnegative_int(kFirstExactEnvironment, config.first_exact_steps);
+    config.last_exact_steps = parse_nonnegative_int(kLastExactEnvironment, config.last_exact_steps);
+    config.max_consecutive_reuse =
+        parse_nonnegative_int(kMaxConsecutiveReuseEnvironment, config.max_consecutive_reuse);
+    validate_config(config);
+    return config;
+}
+
+bool late_cfg_enabled_from_environment(const EasyCacheConfig& easycache) {
+    if (!parse_enabled(kLateCfgEnableEnvironment))
+        return false;
+    if (!is_qualified_late_cfg_profile(easycache)) {
+        throw std::invalid_argument(
+            "TRTMC_WAN22_EASYCACHE_LATE_CFG requires the qualified 50-step EasyCache profile "
+            "(threshold=0.08, first_exact_steps=7, last_exact_steps=2, "
+            "max_consecutive_reuse=4)");
+    }
+    return true;
+}
+
+EasyCacheController::EasyCacheController(EasyCacheConfig config) : config_(config) {
+    validate_config(config_);
+    stats_.total_steps = config_.total_steps;
+}
+
+bool EasyCacheController::decide(int32_t step, const std::vector<float>& raw_latents) {
+    validate_decision_input(step, raw_latents);
+    const bool compute = choose_compute(step, raw_latents);
+    finish_decision(compute, raw_latents);
+    return compute;
+}
+
+void EasyCacheController::validate_decision_input(int32_t step,
+                                                  const std::vector<float>& raw_latents) const {
+    if (step != stats_.compute_steps + stats_.reuse_steps || step < 0 ||
+        step >= config_.total_steps) {
+        throw std::invalid_argument("Wan2.2 EasyCache steps must be consecutive and in range");
+    }
+    if (raw_latents.empty())
+        throw std::invalid_argument("Wan2.2 EasyCache raw latent input must not be empty");
+    if (!previous_step_input_.empty() && previous_step_input_.size() != raw_latents.size())
+        throw std::invalid_argument("Wan2.2 EasyCache latent shape changed during generation");
+}
+
+bool EasyCacheController::choose_compute(int32_t step, const std::vector<float>& raw_latents) {
+    if (in_exact_window(step) || !has_reusable_state() ||
+        consecutive_reuse_ >= config_.max_consecutive_reuse) {
+        accumulator_ = 0.0;
+        return true;
+    }
+    const double input_change = mean_abs_delta(raw_latents, previous_step_input_);
+    const double output_norm = std::max(mean_abs(last_full_output_), kMinimumNorm);
+    accumulator_ += *change_factor_ * input_change / output_norm;
+    if (accumulator_ < config_.threshold)
+        return false;
+    accumulator_ = 0.0;
+    return true;
+}
+
+bool EasyCacheController::in_exact_window(int32_t step) const noexcept {
+    return step < config_.first_exact_steps ||
+           step >= config_.total_steps - config_.last_exact_steps;
+}
+
+bool EasyCacheController::has_reusable_state() const noexcept {
+    return !previous_step_input_.empty() && !conditional_residual_.empty() &&
+           !unconditional_residual_.empty() && change_factor_.has_value();
+}
+
+void EasyCacheController::finish_decision(bool compute, const std::vector<float>& raw_latents) {
+    previous_step_input_ = raw_latents;
+    last_decision_compute_ = compute;
+    if (compute) {
+        consecutive_reuse_ = 0;
+        ++stats_.compute_steps;
+        return;
+    }
+    ++consecutive_reuse_;
+    ++stats_.reuse_steps;
+}
+
+void EasyCacheController::update_conditional(const std::vector<float>& raw_latents,
+                                             const std::vector<float>& denoiser_output) {
+    if (!last_decision_compute_)
+        throw std::logic_error("Wan2.2 EasyCache cannot refresh after a reuse decision");
+    require_same_nonempty_size(raw_latents, denoiser_output, "conditional refresh");
+    if (!last_full_input_.empty()) {
+        const double input_change =
+            std::max(mean_abs_delta(raw_latents, last_full_input_), kMinimumNorm);
+        const double output_change = mean_abs_delta(denoiser_output, last_full_output_);
+        change_factor_ = output_change / input_change;
+    }
+    last_full_input_ = raw_latents;
+    last_full_output_ = denoiser_output;
+    conditional_residual_ = make_residual(denoiser_output, raw_latents);
+}
+
+void EasyCacheController::update_unconditional(const std::vector<float>& raw_latents,
+                                               const std::vector<float>& denoiser_output) {
+    if (!last_decision_compute_)
+        throw std::logic_error("Wan2.2 EasyCache cannot refresh after a reuse decision");
+    require_same_nonempty_size(raw_latents, denoiser_output, "unconditional refresh");
+    unconditional_residual_ = make_residual(denoiser_output, raw_latents);
+}
+
+std::vector<float>
+EasyCacheController::reuse_conditional(const std::vector<float>& raw_latents) const {
+    if (last_decision_compute_ || conditional_residual_.empty())
+        throw std::logic_error("Wan2.2 EasyCache conditional residual is not reusable");
+    return add_residual(raw_latents, conditional_residual_);
+}
+
+std::vector<float>
+EasyCacheController::reuse_unconditional(const std::vector<float>& raw_latents) const {
+    if (last_decision_compute_ || unconditional_residual_.empty())
+        throw std::logic_error("Wan2.2 EasyCache unconditional residual is not reusable");
+    return add_residual(raw_latents, unconditional_residual_);
+}
+
+double EasyCacheController::mean_abs(const std::vector<float>& values) {
+    if (values.empty())
+        throw std::invalid_argument("Wan2.2 EasyCache reduction requires a non-empty tensor");
+    double sum = 0.0;
+    for (const float value : values)
+        sum += std::abs(static_cast<double>(value));
+    return sum / static_cast<double>(values.size());
+}
+
+double EasyCacheController::mean_abs_delta(const std::vector<float>& left,
+                                           const std::vector<float>& right) {
+    require_same_nonempty_size(left, right, "mean absolute delta");
+    double sum = 0.0;
+    for (std::size_t index = 0; index < left.size(); ++index)
+        sum += std::abs(static_cast<double>(left[index]) - static_cast<double>(right[index]));
+    return sum / static_cast<double>(left.size());
+}
+
+std::vector<float> EasyCacheController::make_residual(const std::vector<float>& output,
+                                                      const std::vector<float>& input) {
+    require_same_nonempty_size(output, input, "residual update");
+    std::vector<float> residual(output.size());
+    for (std::size_t index = 0; index < output.size(); ++index)
+        residual[index] = output[index] - input[index];
+    return residual;
+}
+
+std::vector<float> EasyCacheController::add_residual(const std::vector<float>& input,
+                                                     const std::vector<float>& residual) {
+    require_same_nonempty_size(input, residual, "residual reuse");
+    std::vector<float> output(input.size());
+    for (std::size_t index = 0; index < input.size(); ++index)
+        output[index] = input[index] + residual[index];
+    return output;
+}
+
+void EasyCacheController::require_same_nonempty_size(const std::vector<float>& left,
+                                                     const std::vector<float>& right,
+                                                     const char* operation) {
+    if (left.empty() || left.size() != right.size()) {
+        throw std::invalid_argument(std::string("Wan2.2 EasyCache ") + operation +
+                                    " requires equal non-empty tensors");
+    }
+}
+
+LateCfgController::LateCfgController() {
+    stats_.total_steps = kQualifiedEasyCacheTotalSteps;
+}
+
+LateCfgAction LateCfgController::decide(int32_t step, int64_t timestep, bool easycache_compute) {
+    if (actual_pending_ || prediction_pending_)
+        throw std::logic_error("Wan2.2 late-CFG result was not consumed");
+    if (step != stats_.processed_steps || step < 0 || step >= stats_.total_steps)
+        throw std::invalid_argument("Wan2.2 late-CFG steps must be consecutive and in range");
+
+    ++stats_.processed_steps;
+    if (!easycache_compute) {
+        ++stats_.easycache_reuse_events;
+        return LateCfgAction::kEasyCacheReuse;
+    }
+
+    ++stats_.easycache_compute_events;
+    pending_timestep_ = timestep;
+    if (in_exact_window(step))
+        return request_actual();
+
+    const int32_t event = late_compute_event_++;
+    if (!has_predictable_history() || event % 2 == 0)
+        return request_actual();
+
+    prediction_pending_ = true;
+    return LateCfgAction::kPredictUnconditional;
+}
+
+bool LateCfgController::in_exact_window(int32_t step) const noexcept {
+    constexpr int32_t first_exact_steps = 20;
+    constexpr int32_t last_exact_steps = 2;
+    return step < first_exact_steps || step >= stats_.total_steps - last_exact_steps;
+}
+
+bool LateCfgController::has_predictable_history() const noexcept {
+    return actual_history_size_ == 2 && latest_actual_timestep_ != older_actual_timestep_;
+}
+
+LateCfgAction LateCfgController::request_actual() {
+    actual_pending_ = true;
+    return LateCfgAction::kActualUnconditional;
+}
+
+void LateCfgController::record_actual(const std::vector<float>& conditional,
+                                      const std::vector<float>& unconditional,
+                                      double guidance_scale) {
+    if (!actual_pending_ && !prediction_pending_)
+        throw std::logic_error("Wan2.2 late-CFG has no actual unconditional result to record");
+    require_same_nonempty_size(conditional, unconditional, "actual refresh");
+    if (!std::isfinite(guidance_scale))
+        throw std::invalid_argument("Wan2.2 late-CFG guidance scale must be finite");
+
+    const bool prediction_fallback = prediction_pending_;
+    const double residual_scale = guidance_scale - 1.0;
+    std::vector<float> residual(conditional.size());
+    for (std::size_t index = 0; index < conditional.size(); ++index) {
+        const double value = residual_scale * (static_cast<double>(conditional[index]) -
+                                               static_cast<double>(unconditional[index]));
+        if (!std::isfinite(value) ||
+            std::abs(value) > static_cast<double>(std::numeric_limits<float>::max())) {
+            throw std::invalid_argument("Wan2.2 late-CFG actual guidance residual is not finite");
+        }
+        residual[index] = static_cast<float>(value);
+    }
+
+    if (actual_history_size_ != 0) {
+        older_actual_residual_ = std::move(latest_actual_residual_);
+        older_actual_timestep_ = latest_actual_timestep_;
+    }
+    latest_actual_residual_ = std::move(residual);
+    latest_actual_timestep_ = pending_timestep_;
+    actual_history_size_ = std::min(actual_history_size_ + 1, 2);
+    ++stats_.actual_unconditional_calls;
+    if (prediction_fallback)
+        ++stats_.prediction_fallbacks;
+    actual_pending_ = false;
+    prediction_pending_ = false;
+}
+
+std::optional<double> LateCfgController::prediction_factor() const noexcept {
+    const double denominator =
+        static_cast<double>(latest_actual_timestep_ - older_actual_timestep_);
+    if (denominator == 0.0)
+        return std::nullopt;
+    const double factor =
+        static_cast<double>(pending_timestep_ - latest_actual_timestep_) / denominator;
+    if (!std::isfinite(factor) || std::abs(factor) > kMaximumTimestepExtrapolation)
+        return std::nullopt;
+    return factor;
+}
+
+std::optional<std::pair<float, float>>
+LateCfgController::synthesize(float conditional, float older_residual, float latest_residual,
+                              double factor, double residual_scale) noexcept {
+    const double predicted =
+        latest_residual + factor * (static_cast<double>(latest_residual) - older_residual);
+    const double guided = static_cast<double>(conditional) + predicted;
+    const double synthetic = residual_scale == 0.0
+                                 ? conditional
+                                 : static_cast<double>(conditional) - predicted / residual_scale;
+    if (!std::isfinite(predicted) || !std::isfinite(guided) || !std::isfinite(synthetic))
+        return std::nullopt;
+    const float guided_value = static_cast<float>(guided);
+    const float synthetic_value = static_cast<float>(synthetic);
+    if (!std::isfinite(guided_value) || !std::isfinite(synthetic_value))
+        return std::nullopt;
+    return std::pair<float, float>{guided_value, synthetic_value};
+}
+
+std::optional<LateCfgPrediction>
+LateCfgController::try_predict(const std::vector<float>& conditional, double guidance_scale) {
+    if (!prediction_pending_)
+        throw std::logic_error("Wan2.2 late-CFG prediction was not requested");
+    if (!std::isfinite(guidance_scale) || conditional.empty())
+        return std::nullopt;
+    if (conditional.size() != latest_actual_residual_.size() ||
+        conditional.size() != older_actual_residual_.size()) {
+        return std::nullopt;
+    }
+    const auto factor = prediction_factor();
+    if (!factor.has_value())
+        return std::nullopt;
+
+    LateCfgPrediction result;
+    result.guided.resize(conditional.size());
+    result.synthetic_unconditional.resize(conditional.size());
+    const double residual_scale = guidance_scale - 1.0;
+    for (std::size_t index = 0; index < conditional.size(); ++index) {
+        const auto values = synthesize(conditional[index], older_actual_residual_[index],
+                                       latest_actual_residual_[index], *factor, residual_scale);
+        if (!values.has_value())
+            return std::nullopt;
+        result.guided[index] = values->first;
+        result.synthetic_unconditional[index] = values->second;
+    }
+    prediction_pending_ = false;
+    ++stats_.predicted_unconditional_reuses;
+    return result;
+}
+
+void LateCfgController::require_same_nonempty_size(const std::vector<float>& left,
+                                                   const std::vector<float>& right,
+                                                   const char* operation) {
+    if (left.empty() || left.size() != right.size()) {
+        throw std::invalid_argument(std::string("Wan2.2 late-CFG ") + operation +
+                                    " requires equal non-empty tensors");
+    }
+}
+
+} // namespace trtmc::wan2_2_ti2v

--- a/src/runtime/models/wan2_2_ti2v/easycache.h
+++ b/src/runtime/models/wan2_2_ti2v/easycache.h
@@ -1,0 +1,141 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace trtmc::wan2_2_ti2v {
+
+constexpr double kQualifiedEasyCacheThreshold = 0.08;
+constexpr int32_t kQualifiedEasyCacheFirstExactSteps = 7;
+constexpr int32_t kQualifiedEasyCacheLastExactSteps = 2;
+constexpr int32_t kQualifiedEasyCacheMaxConsecutiveReuse = 4;
+constexpr int32_t kQualifiedEasyCacheTotalSteps = 50;
+
+struct EasyCacheConfig {
+    bool enabled{false};
+    double threshold{0.02};
+    int32_t first_exact_steps{7};
+    int32_t last_exact_steps{2};
+    int32_t max_consecutive_reuse{1};
+    int32_t total_steps{50};
+};
+
+struct EasyCacheStats {
+    int32_t total_steps{0};
+    int32_t compute_steps{0};
+    int32_t reuse_steps{0};
+};
+
+EasyCacheConfig easycache_config_from_environment(int32_t total_steps);
+bool late_cfg_enabled_from_environment(const EasyCacheConfig& easycache);
+
+class EasyCacheController {
+  public:
+    explicit EasyCacheController(EasyCacheConfig config);
+
+    bool decide(int32_t step, const std::vector<float>& raw_latents);
+    void update_conditional(const std::vector<float>& raw_latents,
+                            const std::vector<float>& denoiser_output);
+    void update_unconditional(const std::vector<float>& raw_latents,
+                              const std::vector<float>& denoiser_output);
+    std::vector<float> reuse_conditional(const std::vector<float>& raw_latents) const;
+    std::vector<float> reuse_unconditional(const std::vector<float>& raw_latents) const;
+
+    const EasyCacheConfig& config() const noexcept { return config_; }
+    const EasyCacheStats& stats() const noexcept { return stats_; }
+
+  private:
+    void validate_decision_input(int32_t step, const std::vector<float>& raw_latents) const;
+    bool choose_compute(int32_t step, const std::vector<float>& raw_latents);
+    bool in_exact_window(int32_t step) const noexcept;
+    bool has_reusable_state() const noexcept;
+    void finish_decision(bool compute, const std::vector<float>& raw_latents);
+
+    static double mean_abs(const std::vector<float>& values);
+    static double mean_abs_delta(const std::vector<float>& left, const std::vector<float>& right);
+    static std::vector<float> make_residual(const std::vector<float>& output,
+                                            const std::vector<float>& input);
+    static std::vector<float> add_residual(const std::vector<float>& input,
+                                           const std::vector<float>& residual);
+    static void require_same_nonempty_size(const std::vector<float>& left,
+                                           const std::vector<float>& right, const char* operation);
+
+    EasyCacheConfig config_;
+    EasyCacheStats stats_;
+    std::vector<float> previous_step_input_;
+    std::vector<float> last_full_input_;
+    std::vector<float> last_full_output_;
+    std::vector<float> conditional_residual_;
+    std::vector<float> unconditional_residual_;
+    std::optional<double> change_factor_;
+    double accumulator_{0.0};
+    int32_t consecutive_reuse_{0};
+    bool last_decision_compute_{true};
+};
+
+enum class LateCfgAction {
+    kEasyCacheReuse,
+    kActualUnconditional,
+    kPredictUnconditional,
+};
+
+struct LateCfgPrediction {
+    std::vector<float> guided;
+    std::vector<float> synthetic_unconditional;
+};
+
+struct LateCfgStats {
+    int32_t total_steps{0};
+    int32_t processed_steps{0};
+    int32_t easycache_compute_events{0};
+    int32_t easycache_reuse_events{0};
+    int32_t actual_unconditional_calls{0};
+    int32_t predicted_unconditional_reuses{0};
+    int32_t prediction_fallbacks{0};
+};
+
+class LateCfgController {
+  public:
+    LateCfgController();
+
+    LateCfgAction decide(int32_t step, int64_t timestep, bool easycache_compute);
+    void record_actual(const std::vector<float>& conditional,
+                       const std::vector<float>& unconditional, double guidance_scale);
+    std::optional<LateCfgPrediction> try_predict(const std::vector<float>& conditional,
+                                                 double guidance_scale);
+
+    const LateCfgStats& stats() const noexcept { return stats_; }
+
+  private:
+    bool in_exact_window(int32_t step) const noexcept;
+    bool has_predictable_history() const noexcept;
+    LateCfgAction request_actual();
+    std::optional<double> prediction_factor() const noexcept;
+    static std::optional<std::pair<float, float>> synthesize(float conditional,
+                                                             float older_residual,
+                                                             float latest_residual, double factor,
+                                                             double residual_scale) noexcept;
+    static void require_same_nonempty_size(const std::vector<float>& left,
+                                           const std::vector<float>& right, const char* operation);
+
+    LateCfgStats stats_;
+    std::vector<float> older_actual_residual_;
+    std::vector<float> latest_actual_residual_;
+    int64_t older_actual_timestep_{0};
+    int64_t latest_actual_timestep_{0};
+    int64_t pending_timestep_{0};
+    int32_t actual_history_size_{0};
+    int32_t late_compute_event_{0};
+    bool actual_pending_{false};
+    bool prediction_pending_{false};
+};
+
+} // namespace trtmc::wan2_2_ti2v

--- a/src/runtime/models/wan2_2_ti2v/pipeline.cpp
+++ b/src/runtime/models/wan2_2_ti2v/pipeline.cpp
@@ -5,6 +5,7 @@
 
 #include "runtime/models/wan2_2_ti2v/pipeline.h"
 
+#include "runtime/models/wan2_2_ti2v/easycache.h"
 #include "runtime/models/wan2_2_ti2v/prompt_cleaner.h"
 #include "runtime/models/wan2_2_ti2v/torch_cuda_normal.h"
 #include "runtime/models/wan2_2_ti2v/vae_cache_storage.h"
@@ -216,6 +217,97 @@ bool same_runtime_shape(const Wan22TI2VRuntimeShape& left, const Wan22TI2VRuntim
                     right.video_frames, right.video_height, right.video_width, right.latent_count);
 }
 
+template <typename DenoiserRunner>
+bool run_denoiser_step(int32_t step, int64_t timestep, const std::vector<float>& latents,
+                       const std::vector<float>& prompt_context,
+                       const std::vector<float>& negative_context, double guidance_scale,
+                       wan2_2_ti2v::EasyCacheController* easycache,
+                       wan2_2_ti2v::LateCfgController* late_cfg, DenoiserRunner&& run_denoiser,
+                       std::vector<float>& conditional, std::vector<float>& unconditional,
+                       std::vector<float>& guided) {
+    if (easycache == nullptr) {
+        conditional = run_denoiser(prompt_context);
+        unconditional = run_denoiser(negative_context);
+        return false;
+    }
+
+    const bool compute = easycache->decide(step, latents);
+    auto late_action = wan2_2_ti2v::LateCfgAction::kActualUnconditional;
+    if (late_cfg != nullptr)
+        late_action = late_cfg->decide(step, timestep, compute);
+    if (!compute) {
+        conditional = easycache->reuse_conditional(latents);
+        unconditional = easycache->reuse_unconditional(latents);
+        return false;
+    }
+
+    conditional = run_denoiser(prompt_context);
+    easycache->update_conditional(latents, conditional);
+    if (late_cfg != nullptr && late_action == wan2_2_ti2v::LateCfgAction::kPredictUnconditional) {
+        auto prediction = late_cfg->try_predict(conditional, guidance_scale);
+        if (prediction.has_value()) {
+            unconditional = std::move(prediction->synthetic_unconditional);
+            guided = std::move(prediction->guided);
+            easycache->update_unconditional(latents, unconditional);
+            return true;
+        }
+    }
+
+    unconditional = run_denoiser(negative_context);
+    if (late_cfg != nullptr)
+        late_cfg->record_actual(conditional, unconditional, guidance_scale);
+    easycache->update_unconditional(latents, unconditional);
+    return false;
+}
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize("fp-contract=off")
+#endif
+void apply_cfg(const std::vector<float>& conditional, const std::vector<float>& unconditional,
+               double guidance_scale, std::vector<float>& guided) {
+    if (conditional.size() != unconditional.size() || conditional.size() != guided.size())
+        throw std::invalid_argument("Wan2.2 CFG tensors have inconsistent shapes");
+    for (std::size_t index = 0; index < guided.size(); ++index) {
+        guided[index] =
+            unconditional[index] + guidance_scale * (conditional[index] - unconditional[index]);
+    }
+}
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
+
+void print_cache_summaries(const wan2_2_ti2v::EasyCacheController* easycache,
+                           const wan2_2_ti2v::LateCfgController* late_cfg) {
+    if (easycache == nullptr)
+        return;
+    const auto& easy_stats = easycache->stats();
+    const int32_t late_saved =
+        late_cfg == nullptr ? 0 : late_cfg->stats().predicted_unconditional_reuses;
+    std::cerr << "[wan2.2-ti2v.easycache.summary] total_steps=" << easy_stats.total_steps
+              << " compute_steps=" << easy_stats.compute_steps
+              << " reuse_steps=" << easy_stats.reuse_steps
+              << " denoiser_calls=" << (2 * easy_stats.compute_steps - late_saved)
+              << " saved_denoiser_calls=" << (2 * easy_stats.reuse_steps + late_saved) << '\n';
+    if (late_cfg == nullptr)
+        return;
+
+    const auto& late_stats = late_cfg->stats();
+    if (late_stats.processed_steps != late_stats.total_steps ||
+        late_stats.actual_unconditional_calls + late_stats.predicted_unconditional_reuses !=
+            late_stats.easycache_compute_events) {
+        throw std::runtime_error("Wan2.2 late-CFG call accounting is inconsistent");
+    }
+    std::cerr << "[wan2.2-ti2v.late_cfg.summary] total_steps=" << late_stats.total_steps
+              << " easycache_compute_events=" << late_stats.easycache_compute_events
+              << " easycache_reuse_events=" << late_stats.easycache_reuse_events
+              << " actual_unconditional_calls=" << late_stats.actual_unconditional_calls
+              << " predicted_unconditional_reuses=" << late_stats.predicted_unconditional_reuses
+              << " prediction_fallbacks=" << late_stats.prediction_fallbacks << " denoiser_calls="
+              << (late_stats.easycache_compute_events + late_stats.actual_unconditional_calls)
+              << '\n';
+}
+
 } // namespace
 
 Wan22TI2VRuntimeShape make_wan22_runtime_shape(const Wan22TI2VRequest& request) {
@@ -371,6 +463,75 @@ std::vector<float> Wan22TI2VPipeline::run_denoiser(const std::vector<float>& lat
                          "DiT output");
 }
 
+void Wan22TI2VPipeline::run_denoising(std::vector<float>& latents,
+                                      const std::vector<float>& prompt_context,
+                                      const std::vector<float>& negative_context,
+                                      const Wan22TI2VRequest& request,
+                                      const Wan22TI2VRuntimeShape& shape, double& denoiser_ms,
+                                      double& scheduler_ms) {
+    std::vector<float> guided(shape.latent_count);
+    std::vector<float> next(shape.latent_count);
+    denoiser_ms = 0.0;
+    scheduler_ms = 0.0;
+
+    wan2_2_ti2v::FlowUniPCCuda scheduler(stream_, request.num_inference_steps, request.flow_shift,
+                                         1000);
+    auto denoiser = load_module("denoiser_plan");
+    validate_denoiser_contract(*denoiser, shape);
+
+    const auto easycache_config =
+        wan2_2_ti2v::easycache_config_from_environment(request.num_inference_steps);
+    std::unique_ptr<wan2_2_ti2v::EasyCacheController> easycache;
+    if (easycache_config.enabled) {
+        easycache = std::make_unique<wan2_2_ti2v::EasyCacheController>(easycache_config);
+        std::cerr << "[wan2.2-ti2v.easycache] enabled=1 threshold=" << easycache_config.threshold
+                  << " first_exact_steps=" << easycache_config.first_exact_steps
+                  << " last_exact_steps=" << easycache_config.last_exact_steps
+                  << " max_consecutive_reuse=" << easycache_config.max_consecutive_reuse << '\n';
+    }
+
+    std::unique_ptr<wan2_2_ti2v::LateCfgController> late_cfg;
+    if (wan2_2_ti2v::late_cfg_enabled_from_environment(easycache_config)) {
+        late_cfg = std::make_unique<wan2_2_ti2v::LateCfgController>();
+        std::cerr << "[wan2.2-ti2v.late_cfg] enabled=1 refresh_interval=2"
+                  << " first_exact_steps=20 last_exact_steps=2"
+                  << " cadence=easycache_compute_events\n";
+    }
+
+    try {
+        for (int32_t step = 0; step < request.num_inference_steps; ++step) {
+            const int64_t timestep = scheduler.timesteps()[static_cast<std::size_t>(step)];
+            const auto time = wan2_2_ti2v::torch_cuda_timestep_features(timestep);
+            std::vector<float> conditional;
+            std::vector<float> unconditional;
+            const auto denoiser_begin = Clock::now();
+            const auto runner = [&](const std::vector<float>& context) {
+                return run_denoiser(latents, context, time, shape, *denoiser);
+            };
+            const bool guided_ready = run_denoiser_step(
+                step, timestep, latents, prompt_context, negative_context, request.guidance_scale,
+                easycache.get(), late_cfg.get(), runner, conditional, unconditional, guided);
+            const auto denoiser_end = Clock::now();
+            denoiser_ms += milliseconds(denoiser_begin, denoiser_end);
+
+            const auto scheduler_begin = Clock::now();
+            if (!guided_ready)
+                apply_cfg(conditional, unconditional, request.guidance_scale, guided);
+            scheduler.step(guided.data(), latents.data(), next.data(), shape.latent_count);
+            latents.swap(next);
+            const auto scheduler_end = Clock::now();
+            scheduler_ms += milliseconds(scheduler_begin, scheduler_end);
+            std::cerr << "[wan2.2-ti2v] step " << (step + 1) << '/' << request.num_inference_steps
+                      << '\n';
+        }
+        synchronize_stream("finishing DiT denoising");
+        print_cache_summaries(easycache.get(), late_cfg.get());
+    } catch (...) {
+        synchronize_stream_noexcept();
+        throw;
+    }
+}
+
 ImageResult Wan22TI2VPipeline::decode_video(const std::vector<float>& latents,
                                             const Wan22TI2VRuntimeShape& shape) {
     if (latents.size() != shape.latent_count)
@@ -466,9 +627,6 @@ ImageResult Wan22TI2VPipeline::decode_video(const std::vector<float>& latents,
     return result;
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC optimize("fp-contract=off")
-#endif
 ImageResult Wan22TI2VPipeline::generate_image(const std::string& prompt,
                                               const GenerateConfig& cfg) {
     std::lock_guard<std::mutex> generation_lock(generation_mutex_);
@@ -498,47 +656,12 @@ ImageResult Wan22TI2VPipeline::generate_image(const std::string& prompt,
     auto latents =
         wan2_2_ti2v::torch_cuda_normal(shape.latent_count, static_cast<uint64_t>(request.seed));
 
-    std::vector<float> guided(shape.latent_count);
-    std::vector<float> next(shape.latent_count);
+    // The scheduler, DiT, and their host workspaces are destroyed before VAE
+    // allocation, preserving the staged-memory contract on Thor.
     double denoiser_ms = 0.0;
     double scheduler_ms = 0.0;
-    {
-        // The official scheduler evaluates its tensor expressions on CUDA.
-        // Keeping UniPC state inside this stage both preserves those numeric
-        // semantics and releases its device workspaces before VAE allocation.
-        wan2_2_ti2v::FlowUniPCCuda scheduler(stream_, request.num_inference_steps,
-                                             request.flow_shift, 1000);
-        auto denoiser = load_module("denoiser_plan");
-        validate_denoiser_contract(*denoiser, shape);
-        try {
-            for (int32_t step = 0; step < request.num_inference_steps; ++step) {
-                const int64_t timestep = scheduler.timesteps()[static_cast<std::size_t>(step)];
-                const auto time = wan2_2_ti2v::torch_cuda_timestep_features(timestep);
-                const auto denoiser_begin = Clock::now();
-                auto conditional = run_denoiser(latents, prompt_context, time, shape, *denoiser);
-                auto unconditional =
-                    run_denoiser(latents, negative_context, time, shape, *denoiser);
-                const auto denoiser_end = Clock::now();
-                denoiser_ms += milliseconds(denoiser_begin, denoiser_end);
-
-                const auto scheduler_begin = Clock::now();
-                for (std::size_t index = 0; index < shape.latent_count; ++index)
-                    guided[index] =
-                        unconditional[index] +
-                        request.guidance_scale * (conditional[index] - unconditional[index]);
-                scheduler.step(guided.data(), latents.data(), next.data(), shape.latent_count);
-                latents.swap(next);
-                const auto scheduler_end = Clock::now();
-                scheduler_ms += milliseconds(scheduler_begin, scheduler_end);
-                std::cerr << "[wan2.2-ti2v] step " << (step + 1) << '/'
-                          << request.num_inference_steps << '\n';
-            }
-            synchronize_stream("finishing DiT denoising");
-        } catch (...) {
-            synchronize_stream_noexcept();
-            throw;
-        }
-    }
+    run_denoising(latents, prompt_context, negative_context, request, shape, denoiser_ms,
+                  scheduler_ms);
 
     // These host-side workspaces are no longer needed once DiT has been
     // destroyed. Release them before the recurrent VAE cache allocation.
@@ -546,10 +669,6 @@ ImageResult Wan22TI2VPipeline::generate_image(const std::string& prompt,
     prompt_context.shrink_to_fit();
     negative_context.clear();
     negative_context.shrink_to_fit();
-    guided.clear();
-    guided.shrink_to_fit();
-    next.clear();
-    next.shrink_to_fit();
 
     const auto vae_begin = Clock::now();
     auto result = decode_video(latents, shape);

--- a/src/runtime/models/wan2_2_ti2v/pipeline.cpp
+++ b/src/runtime/models/wan2_2_ti2v/pipeline.cpp
@@ -396,21 +396,20 @@ ImageResult Wan22TI2VPipeline::decode_video(const std::vector<float>& latents,
         cache_inputs.push_back(input_cache_bank.device_address(index));
         cache_outputs.push_back(output_cache_bank.device_address(index));
     }
-    const auto cache_bindings = make_wan22_vae_cache_bindings(cache_inputs, cache_outputs, shape);
-
     {
-        auto initializer = load_module("vae_decoder_first_frame_plan", cache_bindings);
+        auto initializer =
+            load_module("vae_decoder_first_frame_plan",
+                        make_wan22_vae_cache_bindings(cache_inputs, cache_outputs, shape));
         validate_vae_module_contract(*initializer, kVaeFirstFrameOutputFrames, shape,
                                      "first-frame");
         try {
             input_cache_bank.zero_async(stream_);
+            output_cache_bank.zero_async(stream_);
             synchronize_stream("initializing recurrent VAE caches");
             append_video_chunk(result, video_frame_offset,
                                run_vae_latent(latents, latent_frame, 0, kVaeFirstFrameOutputFrames,
                                               shape, *initializer),
                                kVaeFirstFrameOutputFrames, shape);
-            input_cache_bank.copy_from_async(output_cache_bank, stream_);
-            synchronize_stream("preserving first-frame VAE cache state");
         } catch (...) {
             synchronize_stream_noexcept();
             throw;
@@ -418,8 +417,13 @@ ImageResult Wan22TI2VPipeline::decode_video(const std::vector<float>& latents,
         std::cerr << "[wan2.2-ti2v] VAE latent 1/" << shape.latent_frames << '\n';
     }
 
+    // The initializer leaves the first recurrent state in cache_outputs. Use
+    // it directly as the next input, then alternate the two banks instead of
+    // copying the complete cache state after every latent.
+    std::swap(cache_inputs, cache_outputs);
     {
-        auto recurrent = load_module("vae_decoder_plan", cache_bindings);
+        auto recurrent = load_module(
+            "vae_decoder_plan", make_wan22_vae_cache_bindings(cache_inputs, cache_outputs, shape));
         validate_vae_module_contract(*recurrent, kVaeStepOutputFrames, shape, "step");
         try {
             for (int32_t latent_index = 1; latent_index < shape.latent_frames; ++latent_index) {
@@ -428,8 +432,20 @@ ImageResult Wan22TI2VPipeline::decode_video(const std::vector<float>& latents,
                                                   kVaeStepOutputFrames, shape, *recurrent),
                                    kVaeStepOutputFrames, shape);
                 if (latent_index + 1 < shape.latent_frames) {
-                    input_cache_bank.copy_from_async(output_cache_bank, stream_);
-                    synchronize_stream("carrying recurrent VAE cache state");
+                    std::swap(cache_inputs, cache_outputs);
+                    for (int32_t index = 0; index < kVaeCacheCount; ++index) {
+                        const auto offset = static_cast<std::size_t>(index);
+                        const auto input_name = "cache_" + std::to_string(index);
+                        const auto output_name = "cache_out_" + std::to_string(index);
+                        recurrent->bind_external(input_name, cache_inputs[offset]);
+                        recurrent->bind_external(output_name, cache_outputs[offset]);
+                        if (recurrent->device_ptr(input_name) != cache_inputs[offset] ||
+                            recurrent->device_ptr(output_name) != cache_outputs[offset]) {
+                            throw std::runtime_error(
+                                "Wan2.2 recurrent VAE cache rebinding failed at index " +
+                                std::to_string(index));
+                        }
+                    }
                 }
                 std::cerr << "[wan2.2-ti2v] VAE latent " << (latent_index + 1) << '/'
                           << shape.latent_frames << '\n';

--- a/src/runtime/models/wan2_2_ti2v/pipeline.cpp
+++ b/src/runtime/models/wan2_2_ti2v/pipeline.cpp
@@ -192,6 +192,23 @@ void append_video_chunk(ImageResult& result, int32_t& video_frame_offset,
     video_frame_offset += chunk_frames;
 }
 
+void swap_and_rebind_vae_cache_banks(ITrtModule& recurrent, std::vector<void*>& cache_inputs,
+                                     std::vector<void*>& cache_outputs) {
+    std::swap(cache_inputs, cache_outputs);
+    for (int32_t index = 0; index < kVaeCacheCount; ++index) {
+        const auto offset = static_cast<std::size_t>(index);
+        const auto input_name = "cache_" + std::to_string(index);
+        const auto output_name = "cache_out_" + std::to_string(index);
+        recurrent.bind_external(input_name, cache_inputs[offset]);
+        recurrent.bind_external(output_name, cache_outputs[offset]);
+        if (recurrent.device_ptr(input_name) != cache_inputs[offset] ||
+            recurrent.device_ptr(output_name) != cache_outputs[offset]) {
+            throw std::runtime_error("Wan2.2 recurrent VAE cache rebinding failed at index " +
+                                     std::to_string(index));
+        }
+    }
+}
+
 bool same_runtime_shape(const Wan22TI2VRuntimeShape& left, const Wan22TI2VRuntimeShape& right) {
     return std::tie(left.latent_frames, left.latent_height, left.latent_width, left.video_frames,
                     left.video_height, left.video_width, left.latent_count) ==
@@ -432,20 +449,7 @@ ImageResult Wan22TI2VPipeline::decode_video(const std::vector<float>& latents,
                                                   kVaeStepOutputFrames, shape, *recurrent),
                                    kVaeStepOutputFrames, shape);
                 if (latent_index + 1 < shape.latent_frames) {
-                    std::swap(cache_inputs, cache_outputs);
-                    for (int32_t index = 0; index < kVaeCacheCount; ++index) {
-                        const auto offset = static_cast<std::size_t>(index);
-                        const auto input_name = "cache_" + std::to_string(index);
-                        const auto output_name = "cache_out_" + std::to_string(index);
-                        recurrent->bind_external(input_name, cache_inputs[offset]);
-                        recurrent->bind_external(output_name, cache_outputs[offset]);
-                        if (recurrent->device_ptr(input_name) != cache_inputs[offset] ||
-                            recurrent->device_ptr(output_name) != cache_outputs[offset]) {
-                            throw std::runtime_error(
-                                "Wan2.2 recurrent VAE cache rebinding failed at index " +
-                                std::to_string(index));
-                        }
-                    }
+                    swap_and_rebind_vae_cache_banks(*recurrent, cache_inputs, cache_outputs);
                 }
                 std::cerr << "[wan2.2-ti2v] VAE latent " << (latent_index + 1) << '/'
                           << shape.latent_frames << '\n';

--- a/src/runtime/models/wan2_2_ti2v/pipeline.h
+++ b/src/runtime/models/wan2_2_ti2v/pipeline.h
@@ -58,6 +58,10 @@ class Wan22TI2VPipeline final : public IPipeline {
                                     const std::vector<float>& context,
                                     const std::vector<float>& time,
                                     const Wan22TI2VRuntimeShape& shape, ITrtModule& denoiser);
+    void run_denoising(std::vector<float>& latents, const std::vector<float>& prompt_context,
+                       const std::vector<float>& negative_context, const Wan22TI2VRequest& request,
+                       const Wan22TI2VRuntimeShape& shape, double& denoiser_ms,
+                       double& scheduler_ms);
     ImageResult decode_video(const std::vector<float>& latents, const Wan22TI2VRuntimeShape& shape);
     std::unique_ptr<ITrtModule>
     load_module(const std::string& section_name,

--- a/src/runtime/models/wan2_2_ti2v/vae_cache_storage.cpp
+++ b/src/runtime/models/wan2_2_ti2v/vae_cache_storage.cpp
@@ -54,8 +54,10 @@ VaeCacheLayout make_vae_cache_layout(const std::vector<std::size_t>& capacities)
     return layout;
 }
 
-VaeCacheMemoryKind select_vae_cache_memory_kind(bool integrated, bool can_map_host_memory) {
-    if (!integrated)
+VaeCacheMemoryKind select_vae_cache_memory_kind(bool integrated, bool can_map_host_memory,
+                                                int compute_capability_major,
+                                                int compute_capability_minor) {
+    if (!integrated || (compute_capability_major == 11 && compute_capability_minor == 0))
         return VaeCacheMemoryKind::kDevice;
     if (!can_map_host_memory) {
         throw std::runtime_error(
@@ -71,6 +73,14 @@ VaeCacheBank VaeCacheBank::allocate_for_current_device(const std::vector<std::si
     int integrated = 0;
     require_cuda_success(cudaDeviceGetAttribute(&integrated, cudaDevAttrIntegrated, device),
                          "integrated-device query");
+    int compute_capability_major = 0;
+    require_cuda_success(cudaDeviceGetAttribute(&compute_capability_major,
+                                                cudaDevAttrComputeCapabilityMajor, device),
+                         "compute-capability-major query");
+    int compute_capability_minor = 0;
+    require_cuda_success(cudaDeviceGetAttribute(&compute_capability_minor,
+                                                cudaDevAttrComputeCapabilityMinor, device),
+                         "compute-capability-minor query");
     int can_map_host_memory = 0;
     if (integrated != 0) {
         require_cuda_success(
@@ -79,7 +89,9 @@ VaeCacheBank VaeCacheBank::allocate_for_current_device(const std::vector<std::si
     }
 
     auto layout = make_vae_cache_layout(capacities);
-    const auto kind = select_vae_cache_memory_kind(integrated != 0, can_map_host_memory != 0);
+    const auto kind =
+        select_vae_cache_memory_kind(integrated != 0, can_map_host_memory != 0,
+                                     compute_capability_major, compute_capability_minor);
     return VaeCacheBank(std::move(layout), kind);
 }
 

--- a/src/runtime/models/wan2_2_ti2v/vae_cache_storage.h
+++ b/src/runtime/models/wan2_2_ti2v/vae_cache_storage.h
@@ -28,11 +28,13 @@ struct VaeCacheLayout {
 // Pure helpers are public inside this model-owned header so policy, overflow,
 // and alignment can be tested without depending on the current CUDA device.
 VaeCacheLayout make_vae_cache_layout(const std::vector<std::size_t>& capacities);
-VaeCacheMemoryKind select_vae_cache_memory_kind(bool integrated, bool can_map_host_memory);
+VaeCacheMemoryKind select_vae_cache_memory_kind(bool integrated, bool can_map_host_memory,
+                                                int compute_capability_major,
+                                                int compute_capability_minor);
 
-// One contiguous recurrent-cache bank. Discrete GPUs retain the historical
-// cudaMalloc behavior. Integrated GPUs use a mapped pinned system allocation
-// and expose only its CUDA device alias to TensorRT.
+// One contiguous recurrent-cache bank. Discrete GPUs and qualified SM 11.0
+// integrated GPUs use cudaMalloc. Other integrated GPUs use a mapped pinned
+// system allocation and expose only its CUDA device alias to TensorRT.
 class VaeCacheBank final {
   public:
     static VaeCacheBank allocate_for_current_device(const std::vector<std::size_t>& capacities);

--- a/src/utils/sha256.h
+++ b/src/utils/sha256.h
@@ -15,6 +15,17 @@
 #include <string>
 #include <string_view>
 
+#if defined(__aarch64__) && (defined(__GNUC__) || defined(__clang__))
+#include <arm_neon.h>
+#define TRTMC_INTERNAL_HAS_ARM_SHA2_INTRINSICS 1
+#if defined(__linux__)
+#include <sys/auxv.h>
+#if defined(__has_include) && __has_include(<asm/hwcap.h>)
+#include <asm/hwcap.h>
+#endif
+#endif
+#endif
+
 namespace trtmc::internal {
 
 class Sha256 {
@@ -24,16 +35,30 @@ class Sha256 {
     void update(const void* data, std::size_t size) {
         const auto* bytes = static_cast<const std::uint8_t*>(data);
         total_size_ += size;
-        while (size != 0) {
+
+        if (block_size_ != 0 && size != 0) {
             const std::size_t count = std::min(size, block_.size() - block_size_);
             std::memcpy(block_.data() + block_size_, bytes, count);
             block_size_ += count;
             bytes += count;
             size -= count;
             if (block_size_ == block_.size()) {
-                transform(block_.data());
+                transform_blocks(block_.data(), 1);
                 block_size_ = 0;
             }
+        }
+
+        const std::size_t full_blocks = size / block_.size();
+        if (full_blocks != 0) {
+            transform_blocks(bytes, full_blocks);
+            const std::size_t consumed = full_blocks * block_.size();
+            bytes += consumed;
+            size -= consumed;
+        }
+
+        if (size != 0) {
+            std::memcpy(block_.data(), bytes, size);
+            block_size_ = size;
         }
     }
 
@@ -94,7 +119,7 @@ class Sha256 {
         return rotate_right(value, 17) ^ rotate_right(value, 19) ^ (value >> 10);
     }
 
-    void transform(const std::uint8_t* block) {
+    void transform_scalar(const std::uint8_t* block) {
         std::array<std::uint32_t, 64> words{};
         for (std::size_t i = 0; i < 16; ++i) {
             const std::size_t offset = i * 4;
@@ -139,11 +164,77 @@ class Sha256 {
         state_[7] += h;
     }
 
+#if defined(TRTMC_INTERNAL_HAS_ARM_SHA2_INTRINSICS)
+    static bool arm_sha2_available() {
+#if defined(TRTMC_SHA256_FORCE_SCALAR)
+        return false;
+#elif defined(__ARM_FEATURE_SHA2)
+        return true;
+#elif defined(__linux__) && defined(AT_HWCAP) && defined(HWCAP_SHA2)
+        static const bool available = (getauxval(AT_HWCAP) & HWCAP_SHA2) != 0;
+        return available;
+#else
+        return false;
+#endif
+    }
+
+    __attribute__((target("+crypto"), noinline)) void transform_arm_sha2(const std::uint8_t* blocks,
+                                                                         std::size_t block_count) {
+        uint32x4_t state_abcd = vld1q_u32(state_.data());
+        uint32x4_t state_efgh = vld1q_u32(state_.data() + 4);
+
+        while (block_count-- != 0) {
+            const uint32x4_t saved_abcd = state_abcd;
+            const uint32x4_t saved_efgh = state_efgh;
+            uint32x4_t messages[4];
+            for (std::size_t i = 0; i < 4; ++i) {
+                const uint8x16_t input = vld1q_u8(blocks + i * 16);
+                messages[i] = vreinterpretq_u32_u8(vrev32q_u8(input));
+            }
+
+            for (std::size_t group = 0; group < 16; ++group) {
+                const std::size_t index = group & 3U;
+                const uint32x4_t rounds =
+                    vaddq_u32(messages[index], vld1q_u32(kRoundConstants.data() + group * 4));
+                const uint32x4_t previous_abcd = state_abcd;
+                state_abcd = vsha256hq_u32(state_abcd, state_efgh, rounds);
+                state_efgh = vsha256h2q_u32(state_efgh, previous_abcd, rounds);
+
+                if (group < 12) {
+                    messages[index] = vsha256su0q_u32(messages[index], messages[(index + 1) & 3U]);
+                    messages[index] = vsha256su1q_u32(messages[index], messages[(index + 2) & 3U],
+                                                      messages[(index + 3) & 3U]);
+                }
+            }
+
+            state_abcd = vaddq_u32(state_abcd, saved_abcd);
+            state_efgh = vaddq_u32(state_efgh, saved_efgh);
+            blocks += block_.size();
+        }
+
+        vst1q_u32(state_.data(), state_abcd);
+        vst1q_u32(state_.data() + 4, state_efgh);
+    }
+#endif
+
+    void transform_blocks(const std::uint8_t* blocks, std::size_t block_count) {
+#if defined(TRTMC_INTERNAL_HAS_ARM_SHA2_INTRINSICS)
+        if (arm_sha2_available()) {
+            transform_arm_sha2(blocks, block_count);
+            return;
+        }
+#endif
+        while (block_count-- != 0) {
+            transform_scalar(blocks);
+            blocks += block_.size();
+        }
+    }
+
     std::array<std::uint8_t, 32> finalize() {
         block_[block_size_++] = 0x80U;
         if (block_size_ > 56) {
             std::fill(block_.begin() + static_cast<std::ptrdiff_t>(block_size_), block_.end(), 0);
-            transform(block_.data());
+            transform_blocks(block_.data(), 1);
             block_size_ = 0;
         }
         std::fill(block_.begin() + static_cast<std::ptrdiff_t>(block_size_), block_.begin() + 56,
@@ -151,7 +242,7 @@ class Sha256 {
         const std::uint64_t bit_length = total_size_ * 8U;
         for (std::size_t i = 0; i < 8; ++i)
             block_[63 - i] = static_cast<std::uint8_t>(bit_length >> (8U * i));
-        transform(block_.data());
+        transform_blocks(block_.data(), 1);
 
         std::array<std::uint8_t, 32> output{};
         for (std::size_t i = 0; i < state_.size(); ++i) {
@@ -171,3 +262,7 @@ class Sha256 {
 };
 
 } // namespace trtmc::internal
+
+#if defined(TRTMC_INTERNAL_HAS_ARM_SHA2_INTRINSICS)
+#undef TRTMC_INTERNAL_HAS_ARM_SHA2_INTRINSICS
+#endif

--- a/tests/cpp/models/wan2_2_ti2v/test_wan2_2_easycache.cpp
+++ b/tests/cpp/models/wan2_2_ti2v/test_wan2_2_easycache.cpp
@@ -1,0 +1,306 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "runtime/models/wan2_2_ti2v/easycache.h"
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using trtmc::wan2_2_ti2v::EasyCacheConfig;
+using trtmc::wan2_2_ti2v::EasyCacheController;
+using trtmc::wan2_2_ti2v::LateCfgAction;
+using trtmc::wan2_2_ti2v::LateCfgController;
+
+int failures = 0;
+
+void check(bool condition, const char* label) {
+    if (!condition) {
+        std::cerr << "FAIL: " << label << '\n';
+        ++failures;
+    }
+}
+
+bool close(double left, double right, double tolerance = 1.0e-6) {
+    return std::abs(left - right) <= tolerance;
+}
+
+template <typename Callable>
+void check_throws(Callable&& callable, const char* label) {
+    try {
+        callable();
+        check(false, label);
+    } catch (const std::invalid_argument&) {
+    }
+}
+
+class ScopedEnvironment {
+  public:
+    explicit ScopedEnvironment(const char* name) : name_(name) {
+        if (const char* value = std::getenv(name))
+            original_ = value;
+    }
+
+    ~ScopedEnvironment() {
+        if (original_.has_value())
+            setenv(name_.c_str(), original_->c_str(), 1);
+        else
+            unsetenv(name_.c_str());
+    }
+
+    void set(const char* value) { setenv(name_.c_str(), value, 1); }
+    void unset() { unsetenv(name_.c_str()); }
+
+  private:
+    std::string name_;
+    std::optional<std::string> original_;
+};
+
+EasyCacheConfig qualified_config() {
+    EasyCacheConfig config;
+    config.enabled = true;
+    config.threshold = trtmc::wan2_2_ti2v::kQualifiedEasyCacheThreshold;
+    config.first_exact_steps = trtmc::wan2_2_ti2v::kQualifiedEasyCacheFirstExactSteps;
+    config.last_exact_steps = trtmc::wan2_2_ti2v::kQualifiedEasyCacheLastExactSteps;
+    config.max_consecutive_reuse = trtmc::wan2_2_ti2v::kQualifiedEasyCacheMaxConsecutiveReuse;
+    config.total_steps = trtmc::wan2_2_ti2v::kQualifiedEasyCacheTotalSteps;
+    return config;
+}
+
+void test_defaults_are_inert() {
+    ScopedEnvironment easycache("TRTMC_WAN22_EASYCACHE");
+    ScopedEnvironment threshold("TRTMC_WAN22_EASYCACHE_THRESHOLD");
+    ScopedEnvironment late_cfg("TRTMC_WAN22_EASYCACHE_LATE_CFG");
+    easycache.unset();
+    threshold.set("not-parsed-while-disabled");
+    late_cfg.unset();
+
+    const auto config = trtmc::wan2_2_ti2v::easycache_config_from_environment(50);
+    check(!config.enabled, "EasyCache is disabled by default");
+    check(!trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(config),
+          "late-CFG is disabled by default");
+}
+
+void test_qualified_profile_lock() {
+    ScopedEnvironment easycache("TRTMC_WAN22_EASYCACHE");
+    ScopedEnvironment threshold("TRTMC_WAN22_EASYCACHE_THRESHOLD");
+    ScopedEnvironment first("TRTMC_WAN22_EASYCACHE_FIRST_EXACT_STEPS");
+    ScopedEnvironment last("TRTMC_WAN22_EASYCACHE_LAST_EXACT_STEPS");
+    ScopedEnvironment maximum("TRTMC_WAN22_EASYCACHE_MAX_CONSECUTIVE_REUSE");
+    ScopedEnvironment late_cfg("TRTMC_WAN22_EASYCACHE_LATE_CFG");
+    easycache.set("true");
+    threshold.set("0.08");
+    first.set("7");
+    last.set("2");
+    maximum.set("4");
+    late_cfg.set("true");
+
+    const auto parsed = trtmc::wan2_2_ti2v::easycache_config_from_environment(50);
+    check(trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(parsed),
+          "late-CFG accepts the qualified EasyCache profile");
+
+    auto invalid = qualified_config();
+    invalid.enabled = false;
+    check_throws([&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(invalid); },
+                 "late-CFG rejects disabled EasyCache");
+    invalid = qualified_config();
+    invalid.threshold = 0.05;
+    check_throws([&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(invalid); },
+                 "late-CFG rejects an unqualified threshold");
+    invalid = qualified_config();
+    invalid.first_exact_steps = 8;
+    check_throws([&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(invalid); },
+                 "late-CFG rejects an unqualified prefix");
+    invalid = qualified_config();
+    invalid.last_exact_steps = 1;
+    check_throws([&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(invalid); },
+                 "late-CFG rejects an unqualified suffix");
+    invalid = qualified_config();
+    invalid.max_consecutive_reuse = 3;
+    check_throws([&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(invalid); },
+                 "late-CFG rejects an unqualified reuse cap");
+    invalid = qualified_config();
+    invalid.total_steps = 49;
+    check_throws([&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(invalid); },
+                 "late-CFG rejects an unqualified step count");
+}
+
+void test_easycache_exact_and_reuse_paths() {
+    EasyCacheConfig config;
+    config.enabled = true;
+    config.threshold = 1.0;
+    config.first_exact_steps = 1;
+    config.last_exact_steps = 1;
+    config.max_consecutive_reuse = 2;
+    config.total_steps = 6;
+    EasyCacheController controller(config);
+
+    check(controller.decide(0, {0.0F}), "EasyCache computes the exact prefix");
+    controller.update_conditional({0.0F}, {1.0F});
+    controller.update_unconditional({0.0F}, {-1.0F});
+    check(controller.decide(1, {1.0F}), "EasyCache initializes its change factor");
+    controller.update_conditional({1.0F}, {2.0F});
+    controller.update_unconditional({1.0F}, {0.0F});
+
+    check(!controller.decide(2, {1.01F}), "EasyCache reuses below threshold");
+    const auto conditional = controller.reuse_conditional({1.01F});
+    const auto unconditional = controller.reuse_unconditional({1.01F});
+    check(close(conditional[0], 2.01) && close(unconditional[0], 0.01),
+          "EasyCache keeps branch-local residuals");
+    check(!controller.decide(3, {1.02F}), "EasyCache permits the qualified reuse sequence");
+    check(controller.decide(4, {1.03F}), "EasyCache refreshes at the reuse cap");
+    controller.update_conditional({1.03F}, {2.03F});
+    controller.update_unconditional({1.03F}, {0.03F});
+    check(controller.decide(5, {1.04F}), "EasyCache computes the exact suffix");
+    controller.update_conditional({1.04F}, {2.04F});
+    controller.update_unconditional({1.04F}, {0.04F});
+
+    check(controller.stats().compute_steps == 4 && controller.stats().reuse_steps == 2,
+          "EasyCache reports compute and reuse accounting");
+}
+
+void record_simple_actual(LateCfgController& controller, int32_t step) {
+    const float conditional = static_cast<float>(step + 1);
+    controller.record_actual({conditional}, {conditional - 1.0F}, 5.0);
+}
+
+void test_late_cfg_exact_windows_cadence_and_prediction() {
+    LateCfgController controller;
+    for (int32_t step = 0; step < 50; ++step) {
+        const bool compute = step <= 21 || step == 47 || step >= 48;
+        const auto action = controller.decide(step, 1000 - 10 * step, compute);
+        if (!compute) {
+            check(action == LateCfgAction::kEasyCacheReuse,
+                  "late-CFG ignores EasyCache reuse events");
+            continue;
+        }
+        if (step == 21) {
+            check(action == LateCfgAction::kPredictUnconditional,
+                  "late-CFG predicts every second late compute event");
+            const auto prediction = controller.try_predict({30.0F, 12.0F}, 5.0);
+            check(prediction.has_value(), "late-CFG produces a bounded prediction");
+            check(close(prediction->guided[0], 46.0) && close(prediction->guided[1], 24.0) &&
+                      close(prediction->synthetic_unconditional[0], 26.0) &&
+                      close(prediction->synthetic_unconditional[1], 9.0),
+                  "late-CFG preserves guided and synthetic-unconditional algebra");
+            continue;
+        }
+
+        check(action == LateCfgAction::kActualUnconditional,
+              "late-CFG refreshes exact windows and cadence anchors");
+        if (step == 19)
+            controller.record_actual({10.0F, 4.0F}, {8.0F, 3.0F}, 5.0);
+        else if (step == 20)
+            controller.record_actual({20.0F, 8.0F}, {17.0F, 6.0F}, 5.0);
+        else
+            record_simple_actual(controller, step);
+    }
+
+    const auto& stats = controller.stats();
+    check(stats.processed_steps == 50 && stats.easycache_compute_events == 25 &&
+              stats.easycache_reuse_events == 25 && stats.actual_unconditional_calls == 24 &&
+              stats.predicted_unconditional_reuses == 1 && stats.prediction_fallbacks == 0,
+          "late-CFG reports exact interval-2 accounting");
+}
+
+void test_prediction_falls_back_to_actual() {
+    LateCfgController controller;
+    for (int32_t step = 0; step <= 22; ++step) {
+        const bool compute = step == 0 || step == 19 || step == 20 || step == 21;
+        int64_t timestep = 1000 - step;
+        if (step == 19)
+            timestep = 100;
+        if (step == 20)
+            timestep = 99;
+        if (step == 21)
+            timestep = 0;
+        const auto action = controller.decide(step, timestep, compute);
+        if (!compute) {
+            check(action == LateCfgAction::kEasyCacheReuse,
+                  "late-CFG continues after prediction fallback");
+            continue;
+        }
+        if (step == 21) {
+            check(action == LateCfgAction::kPredictUnconditional,
+                  "late-CFG requests its interval-2 prediction");
+            check(!controller.try_predict({4.0F}, 5.0).has_value(),
+                  "late-CFG rejects an unbounded timestep extrapolation");
+            controller.record_actual({4.0F}, {3.0F}, 5.0);
+        } else {
+            record_simple_actual(controller, step);
+        }
+    }
+    const auto& stats = controller.stats();
+    check(stats.actual_unconditional_calls == 4 && stats.predicted_unconditional_reuses == 0 &&
+              stats.prediction_fallbacks == 1,
+          "late-CFG accounts for an actual-unconditional fallback");
+}
+
+void test_synthetic_unconditional_updates_easycache() {
+    LateCfgController late_cfg;
+    std::optional<trtmc::wan2_2_ti2v::LateCfgPrediction> prediction;
+    for (int32_t step = 0; step <= 21; ++step) {
+        const bool compute = step == 0 || step == 19 || step == 20 || step == 21;
+        const auto action = late_cfg.decide(step, 1000 - 10 * step, compute);
+        if (!compute)
+            continue;
+        if (step == 19)
+            late_cfg.record_actual({1.0F}, {0.0F}, 5.0);
+        else if (step == 20)
+            late_cfg.record_actual({1.2F}, {0.1F}, 5.0);
+        else if (action == LateCfgAction::kPredictUnconditional)
+            prediction = late_cfg.try_predict({1.3F}, 5.0);
+        else
+            record_simple_actual(late_cfg, step);
+    }
+    check(prediction.has_value(), "late-CFG produces the stacked EasyCache prediction");
+    if (!prediction.has_value())
+        return;
+
+    EasyCacheConfig config;
+    config.enabled = true;
+    config.threshold = 0.01;
+    config.first_exact_steps = 2;
+    config.last_exact_steps = 0;
+    config.max_consecutive_reuse = 4;
+    config.total_steps = 4;
+    EasyCacheController easycache(config);
+
+    (void)easycache.decide(0, {0.0F});
+    easycache.update_conditional({0.0F}, {1.0F});
+    easycache.update_unconditional({0.0F}, {0.0F});
+    (void)easycache.decide(1, {0.1F});
+    easycache.update_conditional({0.1F}, {1.2F});
+    easycache.update_unconditional({0.1F}, {0.1F});
+    check(easycache.decide(2, {0.11F}), "EasyCache reaches a stacked compute event");
+    easycache.update_conditional({0.11F}, {1.3F});
+    easycache.update_unconditional({0.11F}, prediction->synthetic_unconditional);
+
+    check(!easycache.decide(3, {0.111F}), "EasyCache reuses after the stacked prediction");
+    const auto conditional = easycache.reuse_conditional({0.111F});
+    const auto unconditional = easycache.reuse_unconditional({0.111F});
+    const double guided = unconditional[0] + 5.0 * (conditional[0] - unconditional[0]);
+    const double predicted_residual = prediction->guided[0] - 1.3;
+    check(close(guided, conditional[0] + predicted_residual, 1.0e-5),
+          "synthetic unconditional preserves the predicted guidance residual");
+}
+
+} // namespace
+
+int main() {
+    test_defaults_are_inert();
+    test_qualified_profile_lock();
+    test_easycache_exact_and_reuse_paths();
+    test_late_cfg_exact_windows_cadence_and_prediction();
+    test_prediction_falls_back_to_actual();
+    test_synthetic_unconditional_updates_easycache();
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/cpp/models/wan2_2_ti2v/test_wan2_2_staged_pipeline.cpp
+++ b/tests/cpp/models/wan2_2_ti2v/test_wan2_2_staged_pipeline.cpp
@@ -282,15 +282,19 @@ bool test_vae_cache_layout_and_policy() {
             return false;
         }
     }
-    if (select_vae_cache_memory_kind(false, false) != VaeCacheMemoryKind::kDevice ||
-        select_vae_cache_memory_kind(false, true) != VaeCacheMemoryKind::kDevice ||
-        select_vae_cache_memory_kind(true, true) != VaeCacheMemoryKind::kMappedHost) {
+    if (select_vae_cache_memory_kind(false, false, 8, 7) != VaeCacheMemoryKind::kDevice ||
+        select_vae_cache_memory_kind(false, true, 11, 0) != VaeCacheMemoryKind::kDevice ||
+        select_vae_cache_memory_kind(true, false, 11, 0) != VaeCacheMemoryKind::kDevice ||
+        select_vae_cache_memory_kind(true, true, 11, 0) != VaeCacheMemoryKind::kDevice ||
+        select_vae_cache_memory_kind(true, true, 8, 7) != VaeCacheMemoryKind::kMappedHost ||
+        select_vae_cache_memory_kind(true, true, 10, 0) != VaeCacheMemoryKind::kMappedHost ||
+        select_vae_cache_memory_kind(true, true, 12, 0) != VaeCacheMemoryKind::kMappedHost) {
         std::cerr << "FAIL: VAE cache memory policy changed\n";
         return false;
     }
     try {
-        (void)select_vae_cache_memory_kind(true, false);
-        std::cerr << "FAIL: integrated GPU without host mapping did not fail closed\n";
+        (void)select_vae_cache_memory_kind(true, false, 8, 7);
+        std::cerr << "FAIL: unsupported integrated GPU without host mapping did not fail closed\n";
         return false;
     } catch (const std::runtime_error&) {
     }
@@ -316,10 +320,16 @@ bool test_vae_cache_small_cuda_round_trip() {
     int device = 0;
     int integrated = 0;
     int can_map_host_memory = 0;
+    int compute_capability_major = 0;
+    int compute_capability_minor = 0;
     if (cudaGetDevice(&device) != cudaSuccess ||
         cudaDeviceGetAttribute(&integrated, cudaDevAttrIntegrated, device) != cudaSuccess ||
         cudaDeviceGetAttribute(&can_map_host_memory, cudaDevAttrCanMapHostMemory, device) !=
-            cudaSuccess) {
+            cudaSuccess ||
+        cudaDeviceGetAttribute(&compute_capability_major, cudaDevAttrComputeCapabilityMajor,
+                               device) != cudaSuccess ||
+        cudaDeviceGetAttribute(&compute_capability_minor, cudaDevAttrComputeCapabilityMinor,
+                               device) != cudaSuccess) {
         std::cerr << "FAIL: could not query CUDA cache-allocation policy\n";
         return false;
     }
@@ -328,10 +338,10 @@ bool test_vae_cache_small_cuda_round_trip() {
         VaeCacheBank::allocate_for_current_device({sizeof(uint32_t) * 4, sizeof(uint32_t) * 8});
     auto outputs =
         VaeCacheBank::allocate_for_current_device({sizeof(uint32_t) * 4, sizeof(uint32_t) * 8});
-    const auto expected_kind =
-        integrated != 0 ? VaeCacheMemoryKind::kMappedHost : VaeCacheMemoryKind::kDevice;
-    if ((integrated != 0 && can_map_host_memory == 0) || inputs.memory_kind() != expected_kind ||
-        outputs.memory_kind() != expected_kind) {
+    const auto expected_kind = trtmc::wan2_2_ti2v::select_vae_cache_memory_kind(
+        integrated != 0, can_map_host_memory != 0, compute_capability_major,
+        compute_capability_minor);
+    if (inputs.memory_kind() != expected_kind || outputs.memory_kind() != expected_kind) {
         std::cerr << "FAIL: current-device VAE cache allocation selected the wrong memory kind\n";
         return false;
     }

--- a/tests/cpp/models/wan2_2_ti2v/test_wan2_2_staged_pipeline.cpp
+++ b/tests/cpp/models/wan2_2_ti2v/test_wan2_2_staged_pipeline.cpp
@@ -98,6 +98,26 @@ bool test_backend_prebinding_contract() {
             output[0] != 1.0F || output[3] != 4.0F) {
             throw std::runtime_error("prebound execution produced the wrong output");
         }
+
+        // Wan2.2 alternates its recurrent VAE cache banks in place. Exercise
+        // the same input/output address swap on a live TensorRT context.
+        module->bind_external("x", output_buffer);
+        module->bind_external("y", input_buffer);
+        if (module->device_ptr("x") != output_buffer || module->device_ptr("y") != input_buffer)
+            throw std::runtime_error("external addresses were not rebound");
+        float rebound_input[4] = {5.0F, 6.0F, 7.0F, 8.0F};
+        if (cudaMemcpy(output_buffer, rebound_input, sizeof(rebound_input),
+                       cudaMemcpyHostToDevice) != cudaSuccess) {
+            throw std::runtime_error("rebound input copy failed");
+        }
+        module->forward_async({{"x", {rebound_input, {4}, trtmc::DType::kFloat32}}});
+        module->sync();
+        float rebound_output[4] = {};
+        if (cudaMemcpy(rebound_output, input_buffer, sizeof(rebound_output),
+                       cudaMemcpyDeviceToHost) != cudaSuccess ||
+            rebound_output[0] != 5.0F || rebound_output[3] != 8.0F) {
+            throw std::runtime_error("rebound execution produced the wrong output");
+        }
     } catch (const std::exception& error) {
         std::cerr << "FAIL: TensorRT prebinding execution: " << error.what() << '\n';
         ok = false;

--- a/tests/cpp/test_bundle_format.cpp
+++ b/tests/cpp/test_bundle_format.cpp
@@ -337,14 +337,73 @@ static void test_sha256_known_vectors() {
           "SHA-256 empty vector");
     trtmc::internal::Sha256 abc;
     abc.update("abc");
+    abc.update(nullptr, 0);
     check(abc.hex_digest() == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
-          "SHA-256 abc vector");
+          "SHA-256 abc vector and zero-size null update");
     trtmc::internal::Sha256 multi_block_padding;
     multi_block_padding.update("abcdbcdecdefdefgefghfghighijhijk");
     multi_block_padding.update("ijkljklmklmnlmnomnopnopq");
     check(multi_block_padding.hex_digest() ==
               "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
           "SHA-256 incremental multi-block padding vector");
+}
+
+static void test_sha256_boundaries_and_chunking() {
+    struct ExpectedDigest {
+        std::size_t size;
+        const char* hex;
+    };
+    static constexpr ExpectedDigest expected[] = {
+        {0, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+        {1, "0bfe935e70c321c7ca3afc75ce0d0ca2f98b5422e008bb31c00c6d7f1f1c0ad6"},
+        {55, "13eb4480c03a102020e430341f50315f7ab0e2eab3a84c8c630e019c8baa68a0"},
+        {56, "95879a336f9ac08995bd30220a50c60710b5e5712314c357dae0375596e7cdc7"},
+        {63, "0fd92b28d7de02f75f5c140ffe00bc834a2911c50841b1d734868d30d17013be"},
+        {64, "8509136a1d80b20158213ca1508c046646abdf827af2fc1f4023e557cb59ef61"},
+        {65, "28ae167bf703e3582d77be270a09fd3b8c250a3125adc3b3b30ee4a883685ab1"},
+        {127, "aeb49743ff155ac07a69cfad222e391d8ba711cd8336b4c7b38058cb9bcb5604"},
+        {128, "2fe61ce346d4861e8f5ddfdc9da12797a78660ddadbf2ab83e630c9f956a5742"},
+        {129, "f71a9a7856fa2f3b7176c0fce89e44eeed1f69076ffffbe864f51b7180458b33"},
+        {1024, "e219ea8e440569c6815638fde3d38d2c9028a6de36c21bb96b313cd0dc4e9474"},
+        {65537, "76bc99ec74df99033f031e2b96c6b07b9bafbb06769a670b94a6b7e5eb6d551c"},
+    };
+
+    std::vector<std::uint8_t> input(expected[std::size(expected) - 1].size);
+    std::uint32_t random_state = 0x12345678U;
+    for (auto& byte : input) {
+        random_state = random_state * 1664525U + 1013904223U;
+        byte = static_cast<std::uint8_t>(random_state >> 24U);
+    }
+
+    static constexpr std::size_t chunk_sizes[] = {1, 3, 7, 31, 64, 65, 127, 1024};
+    for (const auto& vector : expected) {
+        trtmc::internal::Sha256 one_shot;
+        one_shot.update(input.data(), vector.size);
+        check(one_shot.hex_digest() == vector.hex, "SHA-256 deterministic boundary vector");
+
+        for (const std::size_t chunk_size : chunk_sizes) {
+            trtmc::internal::Sha256 chunked;
+            for (std::size_t offset = 0; offset < vector.size; offset += chunk_size) {
+                const std::size_t count = std::min(chunk_size, vector.size - offset);
+                chunked.update(input.data() + offset, count);
+            }
+            check(chunked.hex_digest() == vector.hex,
+                  "SHA-256 fixed-size incremental chunk parity");
+        }
+
+        trtmc::internal::Sha256 random_chunks;
+        std::size_t offset = 0;
+        std::uint32_t chunk_state = 0x9e3779b9U;
+        while (offset < vector.size) {
+            chunk_state = chunk_state * 1103515245U + 12345U;
+            const std::size_t requested = 1 + ((chunk_state >> 16U) & 511U);
+            const std::size_t count = std::min(requested, vector.size - offset);
+            random_chunks.update(input.data() + offset, count);
+            offset += count;
+        }
+        check(random_chunks.hex_digest() == vector.hex,
+              "SHA-256 pseudo-random incremental chunk parity");
+    }
 }
 
 int main() {
@@ -359,6 +418,7 @@ int main() {
     test_max_batch_size_parse_and_back_compat();
     test_copy_section_streams_in_bounded_chunks();
     test_sha256_known_vectors();
+    test_sha256_boundaries_and_chunking();
 
     if (failures > 0) {
         std::cerr << failures << " test(s) FAILED\n";


### PR DESCRIPTION
## Background

Wan2.2 TI2V-5B runs at its qualified BF16 behavior by default, but the official
1280x704, 121-frame, 50-step workload on Thor was dominated by 100 DiT calls,
followed by recurrent VAE cache allocation and serial PNG output.

This PR contains only the production mechanisms that produced measurable
end-to-end gains and passed full-video qualification. Calibration probes,
latent injection, profiling harnesses, persistent 12.9 GB cache retention,
async VAE experiments, and rejected FP4/FP8 variants are not included.

## Implementation

- Pack each self-attention Q, K, and V projection into one native TensorRT BF16
  matmul and slice the result in Q/K/V order.
- Extend the explicit static-scale TensorRT E4M3 path to qualified FFN and
  cross-attention Q/O projections. Mixed precision remains opt-in through
  caller-supplied scales and is rejected for the reduced L0 profile.
- Add a Wan-owned EasyCache controller and bounded interval-2 late-CFG reuse.
  Both are disabled by default. Late-CFG accepts only the qualified 50-step
  profile: threshold 0.08, 7 exact prefix steps, 2 exact suffix steps, and at
  most 4 consecutive cache reuses.
- Keep the existing two recurrent VAE cache banks externally rebound. Discrete
  GPUs and qualified integrated SM 11.0 devices use `cudaMalloc`; other
  integrated GPUs retain mapped-host allocation and fail closed when host
  mapping is unavailable.
- Encode PNG frames with a bounded worker pool of at most 8 threads.
- Dispatch SHA-256 full blocks to ARMv8 SHA2 intrinsics when Linux HWCAP reports
  support, while retaining the portable scalar implementation.

## Exact-head Thor qualification

Configuration:

- Prompt: `Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage`
- Seed 42, 50 steps, guidance 5.0
- 1280x704, 121 frames
- TensorRT 11.2.0.113, CUDA 13.4.46
- 19 computed steps, 31 EasyCache reuse steps, 35 total denoiser calls

Results:

| Metric | Exact baseline | Optimized exact source | Speedup |
| --- | ---: | ---: | ---: |
| End-to-end wall clock | 636.0 s | 241.0 s | 2.64x |
| Pipeline time | 618.095 s | 237.633 s | 2.60x |
| Denoiser calls | 100 | 35 | 2.86x fewer |

Optimized pipeline breakdown:

- Text encoder: 5.141 s
- Denoiser: 176.428 s
- Scheduler and CFG: 0.260 s
- VAE decoder: 54.330 s
- Parallel PNG output: 2.299 s

The run completed with 121/121 valid RGB frames. The SM110 VAE cache log
reported device allocation of 12,863,488,000 bytes; minimum system
`MemAvailable` remained 100,882,644 KiB.

The Thor source archive was checksum-pinned before building. Rebase onto
`github/main` changed only upstream CI files; a content comparison confirmed
that all CMake, CLI, builder, Wan runtime, and Wan test files used by the run
are identical at PR head `b88c1de73a3e226c6341774c45856003d2ec6b18`.

## Visual acceptance

All 121 optimized frames were reviewed directly in sequence and at full
resolution, including the numerically worst frames 79 and 80. The video keeps
the prompt semantics, two stable cats, boxing gear, coherent movement,
sharpness, and a clean ending. No progressive blur, frozen sequence, flicker
pattern, anatomy collapse, or image collapse was observed.

- Threshold 0.08 versus the accepted 0.06 control: mean cosine 0.97095, worst
  0.93521; direct visual verdict: pass.
- Exact production build versus the accepted 0.08 A/B: mean cosine 0.99481,
  worst 0.98920; direct visual verdict: pass.
- Changing only mapped-host VAE cache placement to device allocation at
  threshold 0.06 produced 121/121 byte-identical frames.

Cosine values are diagnostic telemetry, not the acceptance gate.

## Validation

- Wan2.2 Python family suite: 36 passed.
- Wan CPU tests (`easycache`, `prompt_cleaner`, `options`): 3/3 passed.
- Exact CLI and Wan model DSO built successfully for TensorRT/CUDA; Thor DSO
  contains two SM110 cubins.
- `ruff`, changed-file `clang-format`, and `git diff --check`: passed.
- Family E2E coverage: 78/78.
- Runtime cyclomatic complexity: maximum CCN 10.
- Full exact-source Thor generation: passed, 121 frames, 241 seconds.

Static FP8 accuracy remains scoped to the scale set supplied by the caller.
The qualified 0.08 visual evidence is specifically for the Thor official-shape
workload above and is not a blanket qualification of every geometry or GPU.
