### PR TITLE
fix(ci): preserve nightly HF cache ownership

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -334,7 +334,9 @@ jobs:
         timeout-minutes: 120
         run: |
           set -euo pipefail
+          # Keep bind-mounted Hugging Face cache metadata owned by the host runner.
           docker exec \
+            --user "$(id -u):$(id -g)" \
             -w "$TRTMC_CI_WORKSPACE" \
             "$TRTMC_CI_CONTAINER_NAME" \
             env -u HF_HUB_OFFLINE python -u scripts/warm_hf_cache.py \

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -1118,7 +1118,12 @@ def test_nightly_warms_the_shared_cache_once_on_each_gpu_node() -> None:
 def test_nightly_strictly_warms_all_active_non_multi_device_cases() -> None:
     text = (REPO_ROOT / ".github" / "workflows" / "nightly.yml").read_text()
     cache = text.split("\n  cache-warm:", maxsplit=1)[1].split("\n  package:", maxsplit=1)[0]
+    model_warm = cache.split(
+        "- name: Strictly warm every active single-GPU nightly model", maxsplit=1
+    )[1].split("- name: Strictly warm declared Nightly model references", maxsplit=1)[0]
     assert "Strictly warm every active single-GPU nightly model" in cache
+    assert '--user "$(id -u):$(id -g)"' in model_warm
+    assert model_warm.index("--user") < model_warm.index('"$TRTMC_CI_CONTAINER_NAME"')
     for argument in (
         "python -u scripts/warm_hf_cache.py",
         "--exclude-ci-tier multi_device",


### PR DESCRIPTION
## Background

The full Nightly run after #535 exposed that the cache-warm container runs as
root. Hugging Face tree metadata written through the shared bind mount can
therefore become root-owned, while later model-proof workers intentionally read
the cache as the host runner UID/GID.

## Exit Criteria

- The Nightly model-cache warmer writes shared cache metadata as the host runner
  UID/GID on every configured GPU node.
- Regression coverage verifies that the Docker `--user` option remains before
  the container name.
- Other trusted CI container stages retain their existing user behavior.

## Implementation

- Run only the all-model Hugging Face cache-warm `docker exec` with
  `$(id -u):$(id -g)`.
- Extend the existing Nightly workflow contract test to enforce both the user
  mapping and correct Docker option placement.

## Validation

- `PYTHONPATH=python:. python3 -m pytest tests/tools/test_github_actions_ci.py tests/tools/test_schedule_e2e.py tests/tools/test_model_proof_runner.py -q`:
  passed, 273 tests.
- `python3 -m ruff check tools/ci tests/tools/test_github_actions_ci.py`: passed.
- `python3 tools/legal_headers.py --check`: passed with zero findings.
- `python3 -c "from pathlib import Path; import yaml; data=yaml.safe_load(Path('.github/workflows/nightly.yml').read_text()); assert 'cache-warm' in data['jobs']"`:
  passed.
- A network-disabled ephemeral container using the CI image and
  `--user 45558:30` created bind-mounted metadata as host owner `45558:30`, mode
  `0644`.

## Notes For Future Readers

- The one-time ownership repair fixes existing files; this change prevents
  later Nightly warmers from recreating the mismatch.
- Keep this override scoped to cache warming. Changing the default user for
  every trusted CI container could affect unrelated stages that still rely on
  root.
- This PR is intentionally draft until GitHub CI validates the real runner and
  workflow boundary.
