### PR TITLE
perf(wan2.2): tune Thor VAE and cache profile

### DIFF
--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/graph_ops.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/graph_ops.py
@@ -56,6 +56,55 @@ def add_silu(network, tensor):
     return network.add_elementwise(tensor, sigmoid, trt.ElementWiseOperation.PROD).get_output(0)
 
 
+def _add_convolution(
+    network,
+    tensor,
+    weight,
+    bias,
+    *,
+    out_channels: int,
+    kernel_shape: tuple[int, ...],
+    convolution_dtype,
+):
+    """Add one FP32 or BF16 convolution."""
+
+    if convolution_dtype == trt.float32:
+        weights = trt.Weights(weight)
+        biases = trt.Weights() if bias is None else trt.Weights(bias)
+        return network.add_convolution_nd(
+            tensor,
+            num_output_maps=out_channels,
+            kernel_shape=kernel_shape,
+            kernel=weights,
+            bias=biases,
+        )
+    if convolution_dtype != trt.bfloat16:
+        raise ValueError(f"Unsupported Wan2.2 VAE convolution dtype: {convolution_dtype}")
+    typed_input = network.add_cast(tensor, trt.bfloat16).get_output(0)
+    weight_tensor = add_constant(network, tuple(weight.shape), weight)
+    typed_weight = network.add_cast(weight_tensor, trt.bfloat16).get_output(0)
+    convolution = network.add_convolution_nd(
+        typed_input,
+        num_output_maps=out_channels,
+        kernel_shape=kernel_shape,
+        kernel=trt.Weights(),
+        bias=trt.Weights(),
+    )
+    convolution.set_input(1, typed_weight)
+    if bias is not None:
+        bias_tensor = add_constant(network, (out_channels,), bias)
+        typed_bias = network.add_cast(bias_tensor, trt.bfloat16).get_output(0)
+        convolution.set_input(2, typed_bias)
+    return convolution
+
+
+def _convolution_output(network, convolution, convolution_dtype):
+    output = convolution.get_output(0)
+    if convolution_dtype == trt.float32:
+        return output
+    return network.add_cast(output, trt.float32).get_output(0)
+
+
 def add_conv3d_as_conv2d(
     network,
     tensor,
@@ -65,6 +114,7 @@ def add_conv3d_as_conv2d(
     kernel_size: tuple[int, int, int],
     stride: tuple[int, int, int] = (1, 1, 1),
     padding: tuple[int, int, int] = (0, 0, 0),
+    convolution_dtype=None,
 ):
     """Apply a temporal-kernel-one Conv3D as per-frame Conv2D."""
 
@@ -76,31 +126,32 @@ def add_conv3d_as_conv2d(
         raise ValueError(
             "Wan2.2 Conv3D-as-Conv2D requires temporal kernel/stride 1 and no temporal padding"
         )
+    if convolution_dtype is None:
+        convolution_dtype = trt.float32
 
     reshape_input = network.add_shuffle(tensor)
     reshape_input.first_transpose = trt.Permutation([0, 2, 1, 3, 4])
     reshape_input.reshape_dims = (batch * frames, input_channels, height, width)
-    weights = trt.Weights(
-        np.ascontiguousarray(
-            np.asarray(weight).reshape(out_channels, input_channels, kh, kw),
-            dtype=np.float32,
-        )
+    weights = np.ascontiguousarray(
+        np.asarray(weight).reshape(out_channels, input_channels, kh, kw),
+        dtype=np.float32,
     )
-    biases = (
-        trt.Weights() if bias is None else trt.Weights(np.ascontiguousarray(bias, dtype=np.float32))
-    )
-    convolution = network.add_convolution_nd(
+    biases = None if bias is None else np.ascontiguousarray(bias, dtype=np.float32)
+    convolution = _add_convolution(
+        network,
         reshape_input.get_output(0),
-        num_output_maps=out_channels,
+        weights,
+        biases,
+        out_channels=out_channels,
         kernel_shape=(kh, kw),
-        kernel=weights,
-        bias=biases,
+        convolution_dtype=convolution_dtype,
     )
     convolution.stride_nd = (sh, sw)
     convolution.padding_nd = (ph, pw)
+    convolution_output = _convolution_output(network, convolution, convolution_dtype)
     output_height = (height + 2 * ph - kh) // sh + 1
     output_width = (width + 2 * pw - kw) // sw + 1
-    reshape_output = network.add_shuffle(convolution.get_output(0))
+    reshape_output = network.add_shuffle(convolution_output)
     reshape_output.reshape_dims = (
         batch,
         frames,
@@ -122,6 +173,7 @@ def add_causal_conv3d(
     kernel_size: tuple[int, int, int],
     stride: tuple[int, int, int] = (1, 1, 1),
     padding_hw: tuple[int, int] = (0, 0),
+    convolution_dtype=None,
 ):
     """Apply a causal Conv3D and return its two-frame updated cache."""
 
@@ -130,6 +182,8 @@ def add_causal_conv3d(
     ph, pw = padding_hw
     if kt != 3:
         raise ValueError(f"Wan2.2 causal Conv3D requires temporal kernel 3, got {kt}")
+    if convolution_dtype is None:
+        convolution_dtype = trt.float32
 
     concatenation = network.add_concatenation([cache, tensor])
     concatenation.axis = 2
@@ -137,29 +191,26 @@ def add_causal_conv3d(
     if input_frames == 1:
         reshape_input = network.add_shuffle(temporal)
         reshape_input.reshape_dims = (batch, input_channels * kt, height, width)
-        weights = trt.Weights(
-            np.ascontiguousarray(
-                np.asarray(weight).reshape(out_channels, input_channels * kt, kh, kw),
-                dtype=np.float32,
-            )
+        weights = np.ascontiguousarray(
+            np.asarray(weight).reshape(out_channels, input_channels * kt, kh, kw),
+            dtype=np.float32,
         )
-        biases = (
-            trt.Weights()
-            if bias is None
-            else trt.Weights(np.ascontiguousarray(bias, dtype=np.float32))
-        )
-        convolution = network.add_convolution_nd(
+        biases = None if bias is None else np.ascontiguousarray(bias, dtype=np.float32)
+        convolution = _add_convolution(
+            network,
             reshape_input.get_output(0),
-            num_output_maps=out_channels,
+            weights,
+            biases,
+            out_channels=out_channels,
             kernel_shape=(kh, kw),
-            kernel=weights,
-            bias=biases,
+            convolution_dtype=convolution_dtype,
         )
         convolution.stride_nd = (stride[1], stride[2])
         convolution.padding_nd = (ph, pw)
+        convolution_output = _convolution_output(network, convolution, convolution_dtype)
         output_height = (height + 2 * ph - kh) // stride[1] + 1
         output_width = (width + 2 * pw - kw) // stride[2] + 1
-        reshape_output = network.add_shuffle(convolution.get_output(0))
+        reshape_output = network.add_shuffle(convolution_output)
         reshape_output.reshape_dims = (
             batch,
             out_channels,
@@ -169,27 +220,23 @@ def add_causal_conv3d(
         )
         output = reshape_output.get_output(0)
     else:
-        weights = trt.Weights(
-            np.ascontiguousarray(
-                np.asarray(weight).reshape(out_channels, input_channels, kt, kh, kw),
-                dtype=np.float32,
-            )
+        weights = np.ascontiguousarray(
+            np.asarray(weight).reshape(out_channels, input_channels, kt, kh, kw),
+            dtype=np.float32,
         )
-        biases = (
-            trt.Weights()
-            if bias is None
-            else trt.Weights(np.ascontiguousarray(bias, dtype=np.float32))
-        )
-        convolution = network.add_convolution_nd(
+        biases = None if bias is None else np.ascontiguousarray(bias, dtype=np.float32)
+        convolution = _add_convolution(
+            network,
             temporal,
-            num_output_maps=out_channels,
+            weights,
+            biases,
+            out_channels=out_channels,
             kernel_shape=(kt, kh, kw),
-            kernel=weights,
-            bias=biases,
+            convolution_dtype=convolution_dtype,
         )
         convolution.stride_nd = stride
         convolution.padding_nd = (0, ph, pw)
-        output = convolution.get_output(0)
+        output = _convolution_output(network, convolution, convolution_dtype)
 
     updated_cache = network.add_slice(
         temporal,
@@ -220,6 +267,7 @@ def add_spatial_upsample_with_conv(
     weight,
     bias,
     scale: int = 2,
+    convolution_dtype=None,
 ):
     upsampled = add_spatial_upsample(network, tensor, scale)
     return add_conv3d_as_conv2d(
@@ -230,6 +278,7 @@ def add_spatial_upsample_with_conv(
         out_channels=int(weight.shape[0]),
         kernel_size=(1, 3, 3),
         padding=(0, 1, 1),
+        convolution_dtype=convolution_dtype,
     )
 
 

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_vae_step_builder.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_vae_step_builder.py
@@ -5,11 +5,18 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+import numpy as np
 import pytest
 
+from tensorrt_model_connect.families.wan2_2_ti2v import graph_ops
+from tensorrt_model_connect.families.wan2_2_ti2v import vae_step_builder as vae_builder
 from tensorrt_model_connect.families.wan2_2_ti2v.vae_step_builder import (
     VAE_STEP_CACHE_SPECS,
     Wan22VaeStepProfile,
+    select_vae_convolution_precision,
 )
 
 
@@ -21,6 +28,148 @@ def test_vae_step_cache_contract_matches_source_order() -> None:
     assert VAE_STEP_CACHE_SPECS[18].logical_name == ("decoder.up_blocks.1.upsampler.time_conv")
     assert VAE_STEP_CACHE_SPECS[-1].logical_name == "decoder.conv_out"
     assert all(spec.shape(profile)[2] == 2 for spec in VAE_STEP_CACHE_SPECS)
+
+
+@pytest.mark.parametrize(
+    ("height", "width", "compute_capability", "integrated", "expected"),
+    [
+        (44, 80, (11, 0), True, "bf16"),
+        (44, 80, (11, 0), False, "fp32"),
+        (44, 80, (10, 3), False, "fp32"),
+        (24, 42, (11, 0), True, "fp32"),
+        (44, 79, (11, 0), True, "fp32"),
+    ],
+    ids=(
+        "thor-official-720p",
+        "discrete-sm110",
+        "gb300",
+        "l0",
+        "non-official-default",
+    ),
+)
+def test_vae_convolution_precision_is_scoped_to_thor_official_profile(
+    height: int,
+    width: int,
+    compute_capability: tuple[int, int],
+    integrated: bool,
+    expected: str,
+) -> None:
+    profile = Wan22VaeStepProfile(height, width)
+    assert (
+        select_vae_convolution_precision(
+            profile,
+            compute_capability,
+            integrated=integrated,
+        )
+        == expected
+    )
+
+
+def test_cuda_device_profile_uses_cuda_python(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = SimpleNamespace(
+        cudaError_t=SimpleNamespace(cudaSuccess=0),
+        cudaGetDevice=lambda: (0, 2),
+        cudaGetDeviceProperties=lambda device: (
+            0,
+            SimpleNamespace(major=11 if device == 2 else 0, minor=0, integrated=1),
+        ),
+    )
+    monkeypatch.setattr(vae_builder, "_cuda_runtime", lambda: runtime)
+    assert vae_builder._current_cuda_device_profile() == ((11, 0), True)
+
+
+def test_cuda_device_profile_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = SimpleNamespace(
+        cudaError_t=SimpleNamespace(cudaSuccess=0),
+        cudaGetDevice=lambda: (1, 0),
+    )
+    monkeypatch.setattr(vae_builder, "_cuda_runtime", lambda: runtime)
+    with pytest.raises(RuntimeError, match="cudaGetDevice failed"):
+        vae_builder._current_cuda_device_profile()
+
+
+@pytest.mark.parametrize(
+    ("convolution_dtype", "expected_input_casts", "expected_constants", "dynamic_weights"),
+    [
+        (graph_ops.trt.float32, (), 0, False),
+        (
+            graph_ops.trt.bfloat16,
+            (
+                graph_ops.trt.bfloat16,
+                graph_ops.trt.bfloat16,
+                graph_ops.trt.bfloat16,
+            ),
+            2,
+            True,
+        ),
+    ],
+    ids=("fp32-static-weights", "bf16-dynamic-weights"),
+)
+def test_vae_convolution_graph_contract(
+    convolution_dtype,
+    expected_input_casts: tuple[object, ...],
+    expected_constants: int,
+    dynamic_weights: bool,
+) -> None:
+    network = Mock()
+    tensor = SimpleNamespace(shape=(1, 2, 4, 4), dtype=graph_ops.trt.float32)
+    cast_outputs: list[SimpleNamespace] = []
+
+    def add_cast(actual_tensor, dtype):
+        output = SimpleNamespace(shape=tuple(actual_tensor.shape), dtype=dtype)
+        cast_outputs.append(output)
+        layer = Mock()
+        layer.get_output.return_value = output
+        return layer
+
+    def add_constant(shape, weights):
+        del weights
+        layer = Mock()
+        layer.get_output.return_value = SimpleNamespace(
+            shape=tuple(shape), dtype=graph_ops.trt.float32
+        )
+        return layer
+
+    network.add_cast.side_effect = add_cast
+    network.add_constant.side_effect = add_constant
+    convolution = Mock()
+    convolution_output = SimpleNamespace(shape=(1, 3, 4, 4), dtype=convolution_dtype)
+    convolution.get_output.return_value = convolution_output
+    network.add_convolution_nd.return_value = convolution
+
+    result = graph_ops._add_convolution(
+        network,
+        tensor,
+        np.ones((3, 2, 3, 3), dtype=np.float32),
+        np.zeros((3,), dtype=np.float32),
+        out_channels=3,
+        kernel_shape=(3, 3),
+        convolution_dtype=convolution_dtype,
+    )
+
+    assert result is convolution
+    assert tuple(item.args[1] for item in network.add_cast.call_args_list) == expected_input_casts
+    assert network.add_constant.call_count == expected_constants
+    if dynamic_weights:
+        assert convolution.set_input.call_args_list == [
+            call(1, cast_outputs[1]),
+            call(2, cast_outputs[2]),
+        ]
+    else:
+        convolution.set_input.assert_not_called()
+
+    network.add_cast.reset_mock()
+    output = graph_ops._convolution_output(network, convolution, convolution_dtype)
+    if convolution_dtype == graph_ops.trt.bfloat16:
+        network.add_cast.assert_called_once_with(convolution_output, graph_ops.trt.float32)
+        assert output.dtype == graph_ops.trt.float32
+    else:
+        network.add_cast.assert_not_called()
+        assert output is convolution_output
 
 
 @pytest.mark.parametrize(("height", "width"), [(0, 2), (2, 0), (-1, 2)])

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/vae_step_builder.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/vae_step_builder.py
@@ -59,6 +59,58 @@ class Wan22VaeStepProfile:
         )
 
 
+def _cuda_runtime():
+    try:
+        from cuda.bindings import runtime as cudart
+    except ImportError:
+        try:
+            from cuda import cudart
+        except ImportError as exc:
+            raise RuntimeError(
+                "Wan2.2 VAE build requires CUDA Python to query the active GPU"
+            ) from exc
+    return cudart
+
+
+def _current_cuda_device_profile() -> tuple[tuple[int, int], bool]:
+    cudart = _cuda_runtime()
+    success = getattr(getattr(cudart, "cudaError_t", None), "cudaSuccess", 0)
+    try:
+        status, device = cudart.cudaGetDevice()
+        if status not in (success, 0):
+            raise RuntimeError(f"cudaGetDevice failed with status {status}")
+        status, properties = cudart.cudaGetDeviceProperties(int(device))
+        if status not in (success, 0):
+            raise RuntimeError(f"cudaGetDeviceProperties failed with status {status}")
+        major = int(properties.major)
+        minor = int(properties.minor)
+        integrated = bool(getattr(properties, "integrated", False))
+    except RuntimeError:
+        raise
+    except Exception as exc:
+        raise RuntimeError(f"Wan2.2 VAE could not query the active CUDA device: {exc}") from exc
+    if major <= 0 or minor < 0:
+        raise RuntimeError(f"Wan2.2 VAE received invalid CUDA compute capability {major}.{minor}")
+    return (major, minor), integrated
+
+
+def select_vae_convolution_precision(
+    profile: Wan22VaeStepProfile,
+    compute_capability: tuple[int, int],
+    *,
+    integrated: bool,
+) -> str:
+    """Return the qualified convolution precision for one VAE profile and GPU."""
+
+    if (
+        (profile.latent_height, profile.latent_width) == (44, 80)
+        and compute_capability == (11, 0)
+        and integrated
+    ):
+        return "bf16"
+    return "fp32"
+
+
 @dataclass(frozen=True)
 class Wan22VaeCacheSpec:
     """One source-ordered causal feature-cache tensor."""
@@ -248,6 +300,13 @@ def build_vae_step_engine(
     network = builder.create_network(flags)
     config = builder.create_builder_config()
     config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, OFFICIAL_VAE_WORKSPACE_GIB << 30)
+    compute_capability, integrated = _current_cuda_device_profile()
+    convolution_precision = select_vae_convolution_precision(
+        profile,
+        compute_capability,
+        integrated=integrated,
+    )
+    convolution_dtype = trt.bfloat16 if convolution_precision == "bf16" else trt.float32
 
     latent = network.add_input("latent_frame", trt.float32, profile.latent_shape)
     cache_inputs = [
@@ -292,6 +351,7 @@ def build_vae_step_engine(
         bias=weights["post_quant_conv.bias"],
         out_channels=48,
         kernel_size=(1, 1, 1),
+        convolution_dtype=convolution_dtype,
     )
 
     current_scale = 1
@@ -305,6 +365,7 @@ def build_vae_step_engine(
         out_channels=1024,
         kernel_size=(3, 3, 3),
         padding_hw=(1, 1),
+        convolution_dtype=convolution_dtype,
     )
 
     def add_resnet(tensor, *, prefix: str, input_channels: int, output_channels: int):
@@ -326,6 +387,7 @@ def build_vae_step_engine(
             out_channels=output_channels,
             kernel_size=(3, 3, 3),
             padding_hw=(1, 1),
+            convolution_dtype=convolution_dtype,
         )
         norm2 = graph_ops.add_l2_channel_norm(
             network,
@@ -345,6 +407,7 @@ def build_vae_step_engine(
             out_channels=output_channels,
             kernel_size=(3, 3, 3),
             padding_hw=(1, 1),
+            convolution_dtype=convolution_dtype,
         )
         if input_channels == output_channels:
             shortcut = tensor
@@ -356,6 +419,7 @@ def build_vae_step_engine(
                 bias=weights[f"{prefix}.conv_shortcut.bias"],
                 out_channels=output_channels,
                 kernel_size=(1, 1, 1),
+                convolution_dtype=convolution_dtype,
             )
         return network.add_elementwise(conv2, shortcut, trt.ElementWiseOperation.SUM).get_output(0)
 
@@ -407,6 +471,7 @@ def build_vae_step_engine(
                     bias=weights[f"{prefix}.bias"],
                     out_channels=output_channels * 2,
                     kernel_size=(3, 1, 1),
+                    convolution_dtype=convolution_dtype,
                 )
                 x = graph_ops.add_temporal_pixel_shuffle(network, x, factor=2)
 
@@ -418,6 +483,7 @@ def build_vae_step_engine(
                 weight=weights[f"{prefix}.weight"],
                 bias=weights[f"{prefix}.bias"],
                 scale=2,
+                convolution_dtype=convolution_dtype,
             )
             current_scale *= 2
 
@@ -450,6 +516,7 @@ def build_vae_step_engine(
         out_channels=12,
         kernel_size=(3, 3, 3),
         padding_hw=(1, 1),
+        convolution_dtype=convolution_dtype,
     )
     x = _add_unpatchify(trt, network, x)
 
@@ -477,7 +544,8 @@ def build_vae_step_engine(
     kind = "initializer" if first_frame_only else "recurrent"
     print(
         f"[wan22-vae-step] building {kind}: video={expected_video_shape}, "
-        f"caches={len(VAE_STEP_CACHE_SPECS)}",
+        f"caches={len(VAE_STEP_CACHE_SPECS)}, convolutions={convolution_precision}, "
+        f"sm={compute_capability[0]}{compute_capability[1]}",
         file=sys.stderr,
     )
     plan = builder.build_serialized_network(network, config)

--- a/src/runtime/models/wan2_2_ti2v/easycache.cpp
+++ b/src/runtime/models/wan2_2_ti2v/easycache.cpp
@@ -5,6 +5,8 @@
 
 #include "runtime/models/wan2_2_ti2v/easycache.h"
 
+#include "runtime/models/wan2_2_ti2v/options.h"
+
 #include <algorithm>
 #include <array>
 #include <cctype>
@@ -98,7 +100,7 @@ void validate_config(const EasyCacheConfig& config) {
     }
 }
 
-bool is_qualified_late_cfg_profile(const EasyCacheConfig& config) noexcept {
+bool is_qualified_conservative_late_cfg_profile(const EasyCacheConfig& config) noexcept {
     return config.enabled && config.threshold == kQualifiedEasyCacheThreshold &&
            config.first_exact_steps == kQualifiedEasyCacheFirstExactSteps &&
            config.last_exact_steps == kQualifiedEasyCacheLastExactSteps &&
@@ -125,14 +127,34 @@ EasyCacheConfig easycache_config_from_environment(int32_t total_steps) {
     return config;
 }
 
-bool late_cfg_enabled_from_environment(const EasyCacheConfig& easycache) {
+bool is_thor_performance_easycache_config(const EasyCacheConfig& easycache) noexcept {
+    return easycache.enabled && easycache.threshold == kThorPerformanceEasyCacheThreshold &&
+           easycache.first_exact_steps == kThorPerformanceEasyCacheFirstExactSteps &&
+           easycache.last_exact_steps == kThorPerformanceEasyCacheLastExactSteps &&
+           easycache.max_consecutive_reuse == kThorPerformanceEasyCacheMaxConsecutiveReuse &&
+           easycache.total_steps == kThorPerformanceEasyCacheTotalSteps;
+}
+
+bool is_qualified_thor_performance_easycache_profile(
+    const EasyCacheConfig& easycache, const EasyCacheRuntimeProfile& runtime) noexcept {
+    return is_thor_performance_easycache_config(easycache) &&
+           runtime.video_height == trtmc::kWan22OfficialVideoHeight &&
+           runtime.video_width == trtmc::kWan22OfficialVideoWidth &&
+           runtime.video_frames == trtmc::kWan22OfficialVideoFrames &&
+           runtime.guidance_scale == trtmc::kWan22OfficialGuidanceScale && runtime.integrated_gpu &&
+           runtime.compute_capability_major == 11 && runtime.compute_capability_minor == 0;
+}
+
+bool late_cfg_enabled_from_environment(const EasyCacheConfig& easycache,
+                                       bool thor_performance_profile_qualified) {
     if (!parse_enabled(kLateCfgEnableEnvironment))
         return false;
-    if (!is_qualified_late_cfg_profile(easycache)) {
+    if (!is_qualified_conservative_late_cfg_profile(easycache) &&
+        !(thor_performance_profile_qualified && is_thor_performance_easycache_config(easycache))) {
         throw std::invalid_argument(
-            "TRTMC_WAN22_EASYCACHE_LATE_CFG requires the qualified 50-step EasyCache profile "
-            "(threshold=0.08, first_exact_steps=7, last_exact_steps=2, "
-            "max_consecutive_reuse=4)");
+            "TRTMC_WAN22_EASYCACHE_LATE_CFG requires either the conservative 50-step "
+            "EasyCache profile (threshold=0.08, first_exact_steps=7, last_exact_steps=2, "
+            "max_consecutive_reuse=4) or its runtime-qualified Thor performance profile");
     }
     return true;
 }

--- a/src/runtime/models/wan2_2_ti2v/easycache.h
+++ b/src/runtime/models/wan2_2_ti2v/easycache.h
@@ -18,6 +18,11 @@ constexpr int32_t kQualifiedEasyCacheFirstExactSteps = 7;
 constexpr int32_t kQualifiedEasyCacheLastExactSteps = 2;
 constexpr int32_t kQualifiedEasyCacheMaxConsecutiveReuse = 4;
 constexpr int32_t kQualifiedEasyCacheTotalSteps = 50;
+constexpr double kThorPerformanceEasyCacheThreshold = 1.0;
+constexpr int32_t kThorPerformanceEasyCacheFirstExactSteps = 7;
+constexpr int32_t kThorPerformanceEasyCacheLastExactSteps = 2;
+constexpr int32_t kThorPerformanceEasyCacheMaxConsecutiveReuse = 4;
+constexpr int32_t kThorPerformanceEasyCacheTotalSteps = 50;
 
 struct EasyCacheConfig {
     bool enabled{false};
@@ -34,8 +39,22 @@ struct EasyCacheStats {
     int32_t reuse_steps{0};
 };
 
+struct EasyCacheRuntimeProfile {
+    int32_t video_height{0};
+    int32_t video_width{0};
+    int32_t video_frames{0};
+    float guidance_scale{0.0F};
+    bool integrated_gpu{false};
+    int32_t compute_capability_major{0};
+    int32_t compute_capability_minor{0};
+};
+
 EasyCacheConfig easycache_config_from_environment(int32_t total_steps);
-bool late_cfg_enabled_from_environment(const EasyCacheConfig& easycache);
+bool is_thor_performance_easycache_config(const EasyCacheConfig& easycache) noexcept;
+bool is_qualified_thor_performance_easycache_profile(
+    const EasyCacheConfig& easycache, const EasyCacheRuntimeProfile& runtime) noexcept;
+bool late_cfg_enabled_from_environment(const EasyCacheConfig& easycache,
+                                       bool thor_performance_profile_qualified = false);
 
 class EasyCacheController {
   public:

--- a/src/runtime/models/wan2_2_ti2v/pipeline.cpp
+++ b/src/runtime/models/wan2_2_ti2v/pipeline.cpp
@@ -57,6 +57,39 @@ double milliseconds(Clock::time_point begin, Clock::time_point end) {
     return std::chrono::duration<double, std::milli>(end - begin).count();
 }
 
+void require_easycache_cuda_success(cudaError_t status, const char* operation) {
+    if (status != cudaSuccess) {
+        throw std::runtime_error(std::string("Wan2.2 EasyCache ") + operation +
+                                 " failed: " + cudaGetErrorString(status));
+    }
+}
+
+wan2_2_ti2v::EasyCacheRuntimeProfile
+current_easycache_runtime_profile(const Wan22TI2VRequest& request) {
+    wan2_2_ti2v::EasyCacheRuntimeProfile profile;
+    profile.video_height = request.video_height;
+    profile.video_width = request.video_width;
+    profile.video_frames = request.video_num_frames;
+    profile.guidance_scale = request.guidance_scale;
+
+    int device = 0;
+    require_easycache_cuda_success(cudaGetDevice(&device), "device query");
+    int integrated = 0;
+    require_easycache_cuda_success(
+        cudaDeviceGetAttribute(&integrated, cudaDevAttrIntegrated, device),
+        "integrated-device query");
+    require_easycache_cuda_success(cudaDeviceGetAttribute(&profile.compute_capability_major,
+                                                          cudaDevAttrComputeCapabilityMajor,
+                                                          device),
+                                   "compute-capability-major query");
+    require_easycache_cuda_success(cudaDeviceGetAttribute(&profile.compute_capability_minor,
+                                                          cudaDevAttrComputeCapabilityMinor,
+                                                          device),
+                                   "compute-capability-minor query");
+    profile.integrated_gpu = integrated != 0;
+    return profile;
+}
+
 std::vector<float> copy_as_float(const Tensor& tensor, std::size_t expected, const char* label) {
     if (tensor.data == nullptr || tensor.numel() != expected || tensor.dtype != DType::kFloat32)
         throw std::runtime_error(std::string("Wan2.2 ") + label + " has an invalid shape");
@@ -481,6 +514,18 @@ void Wan22TI2VPipeline::run_denoising(std::vector<float>& latents,
 
     const auto easycache_config =
         wan2_2_ti2v::easycache_config_from_environment(request.num_inference_steps);
+    bool thor_performance_profile_qualified = false;
+    if (wan2_2_ti2v::is_thor_performance_easycache_config(easycache_config)) {
+        const auto runtime_profile = current_easycache_runtime_profile(request);
+        thor_performance_profile_qualified =
+            wan2_2_ti2v::is_qualified_thor_performance_easycache_profile(easycache_config,
+                                                                         runtime_profile);
+        if (!thor_performance_profile_qualified) {
+            throw std::invalid_argument(
+                "Wan2.2 aggressive EasyCache is qualified only for the official "
+                "1280x704/121-frame/50-step/CFG5 profile on integrated SM 11.0 Thor");
+        }
+    }
     std::unique_ptr<wan2_2_ti2v::EasyCacheController> easycache;
     if (easycache_config.enabled) {
         easycache = std::make_unique<wan2_2_ti2v::EasyCacheController>(easycache_config);
@@ -491,7 +536,8 @@ void Wan22TI2VPipeline::run_denoising(std::vector<float>& latents,
     }
 
     std::unique_ptr<wan2_2_ti2v::LateCfgController> late_cfg;
-    if (wan2_2_ti2v::late_cfg_enabled_from_environment(easycache_config)) {
+    if (wan2_2_ti2v::late_cfg_enabled_from_environment(easycache_config,
+                                                       thor_performance_profile_qualified)) {
         late_cfg = std::make_unique<wan2_2_ti2v::LateCfgController>();
         std::cerr << "[wan2.2-ti2v.late_cfg] enabled=1 refresh_interval=2"
                   << " first_exact_steps=20 last_exact_steps=2"

--- a/tests/cpp/models/wan2_2_ti2v/test_wan2_2_easycache.cpp
+++ b/tests/cpp/models/wan2_2_ti2v/test_wan2_2_easycache.cpp
@@ -75,6 +75,29 @@ EasyCacheConfig qualified_config() {
     return config;
 }
 
+EasyCacheConfig thor_performance_config() {
+    EasyCacheConfig config;
+    config.enabled = true;
+    config.threshold = trtmc::wan2_2_ti2v::kThorPerformanceEasyCacheThreshold;
+    config.first_exact_steps = trtmc::wan2_2_ti2v::kThorPerformanceEasyCacheFirstExactSteps;
+    config.last_exact_steps = trtmc::wan2_2_ti2v::kThorPerformanceEasyCacheLastExactSteps;
+    config.max_consecutive_reuse = trtmc::wan2_2_ti2v::kThorPerformanceEasyCacheMaxConsecutiveReuse;
+    config.total_steps = trtmc::wan2_2_ti2v::kThorPerformanceEasyCacheTotalSteps;
+    return config;
+}
+
+trtmc::wan2_2_ti2v::EasyCacheRuntimeProfile qualified_thor_runtime() {
+    trtmc::wan2_2_ti2v::EasyCacheRuntimeProfile runtime;
+    runtime.video_height = 704;
+    runtime.video_width = 1280;
+    runtime.video_frames = 121;
+    runtime.guidance_scale = 5.0F;
+    runtime.integrated_gpu = true;
+    runtime.compute_capability_major = 11;
+    runtime.compute_capability_minor = 0;
+    return runtime;
+}
+
 void test_defaults_are_inert() {
     ScopedEnvironment easycache("TRTMC_WAN22_EASYCACHE");
     ScopedEnvironment threshold("TRTMC_WAN22_EASYCACHE_THRESHOLD");
@@ -131,6 +154,69 @@ void test_qualified_profile_lock() {
     invalid.total_steps = 49;
     check_throws([&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(invalid); },
                  "late-CFG rejects an unqualified step count");
+}
+
+void test_thor_performance_profile_scope() {
+    ScopedEnvironment late_cfg("TRTMC_WAN22_EASYCACHE_LATE_CFG");
+    late_cfg.set("true");
+    const auto config = thor_performance_config();
+    const auto runtime = qualified_thor_runtime();
+
+    check(trtmc::wan2_2_ti2v::is_thor_performance_easycache_config(config),
+          "Thor performance EasyCache config is exact");
+    check(trtmc::wan2_2_ti2v::is_qualified_thor_performance_easycache_profile(config, runtime),
+          "Thor performance profile accepts official integrated SM110");
+    check(trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(config, true),
+          "late-CFG accepts runtime-qualified Thor performance profile");
+    check_throws(
+        [&] { (void)trtmc::wan2_2_ti2v::late_cfg_enabled_from_environment(config, false); },
+        "late-CFG rejects an unqualified Thor performance profile");
+
+    auto invalid_runtime = runtime;
+    invalid_runtime.video_height = 384;
+    check(!trtmc::wan2_2_ti2v::is_qualified_thor_performance_easycache_profile(config,
+                                                                               invalid_runtime),
+          "Thor performance profile rejects L0 height");
+    invalid_runtime = runtime;
+    invalid_runtime.video_width = 672;
+    check(!trtmc::wan2_2_ti2v::is_qualified_thor_performance_easycache_profile(config,
+                                                                               invalid_runtime),
+          "Thor performance profile rejects L0 width");
+    invalid_runtime = runtime;
+    invalid_runtime.video_frames = 5;
+    check(!trtmc::wan2_2_ti2v::is_qualified_thor_performance_easycache_profile(config,
+                                                                               invalid_runtime),
+          "Thor performance profile rejects L0 frame count");
+    invalid_runtime = runtime;
+    invalid_runtime.guidance_scale = 4.0F;
+    check(!trtmc::wan2_2_ti2v::is_qualified_thor_performance_easycache_profile(config,
+                                                                               invalid_runtime),
+          "Thor performance profile rejects non-qualified CFG");
+    invalid_runtime = runtime;
+    invalid_runtime.integrated_gpu = false;
+    check(!trtmc::wan2_2_ti2v::is_qualified_thor_performance_easycache_profile(config,
+                                                                               invalid_runtime),
+          "Thor performance profile rejects discrete SM110");
+    invalid_runtime = runtime;
+    invalid_runtime.compute_capability_major = 10;
+    invalid_runtime.compute_capability_minor = 3;
+    check(!trtmc::wan2_2_ti2v::is_qualified_thor_performance_easycache_profile(config,
+                                                                               invalid_runtime),
+          "Thor performance profile rejects SM103");
+    invalid_runtime = runtime;
+    invalid_runtime.compute_capability_minor = 1;
+    check(!trtmc::wan2_2_ti2v::is_qualified_thor_performance_easycache_profile(config,
+                                                                               invalid_runtime),
+          "Thor performance profile rejects non-Thor SM111");
+
+    auto invalid_config = config;
+    invalid_config.max_consecutive_reuse = 5;
+    check(!trtmc::wan2_2_ti2v::is_thor_performance_easycache_config(invalid_config),
+          "Thor performance profile rejects config drift");
+    invalid_config = config;
+    invalid_config.total_steps = 49;
+    check(!trtmc::wan2_2_ti2v::is_thor_performance_easycache_config(invalid_config),
+          "Thor performance profile rejects non-qualified step count");
 }
 
 void test_easycache_exact_and_reuse_paths() {
@@ -298,6 +384,7 @@ void test_synthetic_unconditional_updates_easycache() {
 int main() {
     test_defaults_are_inert();
     test_qualified_profile_lock();
+    test_thor_performance_profile_scope();
     test_easycache_exact_and_reuse_paths();
     test_late_cfg_exact_windows_cadence_and_prediction();
     test_prediction_falls_back_to_actual();


### PR DESCRIPTION
## Background

#542 reduces full Wan2.2 TI2V generation latency on Jetson Thor. This follow-up
optimizes the remaining VAE and denoising cost while preserving the video
quality selected during Thor qualification.

The more aggressive max10 cache profile reached 164 seconds, but direct visual
review found a material quality regression. This PR therefore ships the
quality-preserving max4 profile, which reproduces the accepted 205-second
output exactly.

## Exit Criteria

- Complete the official `1280x704`, 121-frame, 50-step, CFG 5 workload on Thor
  in approximately 205 seconds.
- Reproduce all 121 frames from the visually accepted max4 run without pixel or
  temporal drift.
- Limit BF16 VAE and the performance cache profile to the qualified integrated
  SM110 Thor workload, with FP32 and conservative fallbacks elsewhere.
- Keep the change inside Wan2.2 builder, runtime, and test ownership.

## Implementation

- Build VAE convolution weights and bias inputs in BF16 only for the official
  `44x80` latent profile on integrated SM110; cast convolution outputs back to
  FP32 and preserve the original static FP32 path for every other profile.
- Add a runtime-qualified Thor EasyCache profile with threshold `1.0`, first
  exact steps `7`, last exact steps `2`, and maximum consecutive reuse `4`.
- Require the official `1280x704`, 121-frame, 50-step, CFG 5 workload on an
  integrated SM110 device before enabling the performance profile and Late-CFG.
- Add graph-contract, device-scope, fallback, and runtime-profile tests.

## Validation

- `docker run --rm -v <checkout>:/work:ro -w /work -e PYTHONPATH=/work/python trtmc-dev-gb300:manylinux_2_39-6902216b96e1 python -m pytest -q python/tensorrt_model_connect/families/wan2_2_ti2v/tests`:
  45 passed.
- `g++ -std=c++17 -O2 -Isrc src/runtime/models/wan2_2_ti2v/easycache.cpp tests/cpp/models/wan2_2_ti2v/test_wan2_2_easycache.cpp -o /tmp/test_wan22_easycache_max4 && /tmp/test_wan22_easycache_max4`:
  passed.
- `ruff check`, `ruff format --check`, `clang-format --dry-run --Werror`, and
  `git diff --check`: passed for all changed files.
- Full Thor generation:
  - Wall clock: 204 seconds; the prior accepted run was 205 seconds.
  - Output: 121 / 121 frames.
  - EasyCache: 17 compute steps / 33 reuse steps.
  - Denoiser: 31 calls, 154.576 seconds.
  - BF16 VAE: 36.534 seconds.
  - PNG output: 2.268 seconds.
  - Final model DSO SHA-256:
    `08a05a6c4aeae0411d8d706227bb00eaa590f250fa771866afb1b337f9cb2cd3`.
- Exact comparison against the accepted 205-second output:
  - 121 / 121 frames byte-identical.
  - Differing pixel values: `0`.
  - Global and minimum-frame cosine: `1.0`.
  - RMSE: `0`.
  - Temporal correlation and motion ratio: `1.0`.

## Notes For Future Readers

- #542 merged as `be11986b`. This PR's single follow-up commit was rebased onto
  that exact `main` commit; `git range-diff` confirmed that the patch remained
  unchanged across the rebase.
- Do not raise the qualified cache cap from `4` without a new full-video visual
  qualification. The measured max10 point was faster but did not meet the
  selected quality bar.
