### PR TITLE
ci: run builder units for model-owned changes

### DIFF
--- a/tests/builder/test_debug_runner.py
+++ b/tests/builder/test_debug_runner.py
@@ -29,7 +29,7 @@ class TestLoadEngineFromBundle:
     """Tests for load_engine_from_bundle() bundle parsing."""
 
     def test_roundtrip(self, tmp_path):
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_engine_from_bundle
+        from tensorrt_model_connect.families.qwen.debug_runner import load_engine_from_bundle
 
         header = {
             "model_id": "test-model",
@@ -49,7 +49,7 @@ class TestLoadEngineFromBundle:
         assert hdr["num_layers"] == 4
 
     def test_invalid_magic(self, tmp_path):
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_engine_from_bundle
+        from tensorrt_model_connect.families.qwen.debug_runner import load_engine_from_bundle
 
         path = tmp_path / "bad.trtfb"
         path.write_bytes(b"NOT_A_BUNDLE_xxxxxxxxxxxx")
@@ -58,7 +58,7 @@ class TestLoadEngineFromBundle:
             load_engine_from_bundle(str(path))
 
     def test_named_engine_section(self, tmp_path):
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_engine_from_bundle
+        from tensorrt_model_connect.families.qwen.debug_runner import load_engine_from_bundle
 
         header = {
             "model_id": "test-model",
@@ -88,7 +88,9 @@ class TestLoadVisionEngineFromBundle:
     """Tests for load_vision_engine_from_bundle()."""
 
     def test_with_vision_section(self, tmp_path):
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_vision_engine_from_bundle
+        from tensorrt_model_connect.families.qwen_vl.vl_debug_runner import (
+            load_vision_engine_from_bundle,
+        )
 
         header = {"num_layers": 2, "max_cache_length": 64}
         engine_data = b"TEXT_ENGINE"
@@ -104,7 +106,9 @@ class TestLoadVisionEngineFromBundle:
         assert hdr["num_layers"] == 2
 
     def test_without_vision_section(self, tmp_path):
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_vision_engine_from_bundle
+        from tensorrt_model_connect.families.qwen_vl.vl_debug_runner import (
+            load_vision_engine_from_bundle,
+        )
 
         header = {"num_layers": 2, "max_cache_length": 64}
         bundle = make_bundle_bytes(header, engine_plan=b"TEXT_ONLY")
@@ -125,7 +129,7 @@ class TestBundleSectionUtils:
     """Tests for section loading utilities."""
 
     def test_load_section_missing(self, tmp_path):
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_section_from_bundle
+        from tensorrt_model_connect.families.qwen.debug_runner import load_section_from_bundle
 
         header = {"num_layers": 1, "max_cache_length": 32}
         bundle = make_bundle_bytes(header, engine_plan=b"X")
@@ -137,7 +141,7 @@ class TestBundleSectionUtils:
         assert result is None
 
     def test_load_config_from_bundle(self, tmp_path):
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_config_from_bundle
+        from tensorrt_model_connect.families.qwen.debug_runner import load_config_from_bundle
 
         # Build a bundle with a config.json section
         config_data = json.dumps({"model_type": "example_decoder"}).encode("utf-8")

--- a/tests/builder/test_debug_runner_extended.py
+++ b/tests/builder/test_debug_runner_extended.py
@@ -30,7 +30,7 @@ class TestLoadConfigFromBundleExtended:
 
     def test_missing_config_section_returns_empty(self, tmp_path):
         """Bundle without a config.json section returns empty dict."""
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_config_from_bundle
+        from tensorrt_model_connect.families.qwen.debug_runner import load_config_from_bundle
 
         header = {"num_layers": 2, "max_cache_length": 64}
         bundle = make_bundle_bytes(header, engine_plan=b"FAKE")
@@ -43,7 +43,7 @@ class TestLoadConfigFromBundleExtended:
 
     def test_config_with_nested_values(self, tmp_path):
         """Config section with nested JSON is correctly round-tripped."""
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_config_from_bundle
+        from tensorrt_model_connect.families.qwen.debug_runner import load_config_from_bundle
 
         config_data = json.dumps({
             "model_type": "example_decoder",
@@ -79,7 +79,9 @@ class TestLoadPreprocessorConfigFromBundle:
 
     def test_present(self, tmp_path):
         """Extracts and parses preprocessor_config.json section."""
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_preprocessor_config_from_bundle
+        from tensorrt_model_connect.families.qwen_vl.vl_debug_runner import (
+            load_preprocessor_config_from_bundle,
+        )
 
         preproc_data = json.dumps({
             "temporal_patch_size": 2,
@@ -106,7 +108,9 @@ class TestLoadPreprocessorConfigFromBundle:
 
     def test_missing_returns_empty(self, tmp_path):
         """Bundle without preprocessor_config.json returns empty dict."""
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_preprocessor_config_from_bundle
+        from tensorrt_model_connect.families.qwen_vl.vl_debug_runner import (
+            load_preprocessor_config_from_bundle,
+        )
 
         header = {"num_layers": 1, "max_cache_length": 32}
         bundle = make_bundle_bytes(header, engine_plan=b"EP")
@@ -149,7 +153,7 @@ class TestMultiSectionBundle:
 
     def test_engine_plan_extracted(self, tmp_path):
         """load_engine_from_bundle extracts the correct engine_plan section."""
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_engine_from_bundle
+        from tensorrt_model_connect.families.qwen.debug_runner import load_engine_from_bundle
 
         path, engine_plan, _, _ = self._build_multi_section_bundle(tmp_path)
         plan, hdr = load_engine_from_bundle(path)
@@ -158,7 +162,7 @@ class TestMultiSectionBundle:
 
     def test_config_section_extracted(self, tmp_path):
         """load_config_from_bundle extracts config.json from multi-section bundle."""
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_config_from_bundle
+        from tensorrt_model_connect.families.qwen.debug_runner import load_config_from_bundle
 
         path, _, _, _ = self._build_multi_section_bundle(tmp_path)
         cfg = load_config_from_bundle(path)
@@ -166,7 +170,7 @@ class TestMultiSectionBundle:
 
     def test_arbitrary_section_extracted(self, tmp_path):
         """load_section_from_bundle can extract tokenizer.json from bundle."""
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_section_from_bundle
+        from tensorrt_model_connect.families.qwen.debug_runner import load_section_from_bundle
 
         path, _, _, tokenizer_data = self._build_multi_section_bundle(tmp_path)
         data = load_section_from_bundle(path, "tokenizer.json")
@@ -176,7 +180,7 @@ class TestMultiSectionBundle:
 
     def test_unknown_section_returns_none(self, tmp_path):
         """Requesting a non-existent section returns None (graceful)."""
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_section_from_bundle
+        from tensorrt_model_connect.families.qwen.debug_runner import load_section_from_bundle
 
         path, _, _, _ = self._build_multi_section_bundle(tmp_path)
         result = load_section_from_bundle(path, "totally_unknown_section")
@@ -191,7 +195,7 @@ class TestLoadSectionInvalidBundle:
     """load_section_from_bundle should raise on corrupted bundles."""
 
     def test_invalid_magic_raises(self, tmp_path):
-        from tests.e2e.models.qwen.e2e_plugins.runners.vl_debug_runner import load_section_from_bundle
+        from tensorrt_model_connect.families.qwen.debug_runner import load_section_from_bundle
 
         path = tmp_path / "bad.trtfb"
         path.write_bytes(b"GARBAGE_DATA_NOT_A_BUNDLE")

--- a/tests/builder/test_graph_ops_extended.py
+++ b/tests/builder/test_graph_ops_extended.py
@@ -3,11 +3,11 @@
 
 """Extended tests for graph_ops -- pure NumPy helpers (no GPU).
 
-Covers _yarn_correction_dim, compute_alibi_slopes (extended cases),
-make_bucketed_relative_position_bias, and make_yarn_rope_table.
+Covers _yarn_correction_dim, compute_alibi_slopes (extended cases), and
+make_yarn_rope_table.
 
 Trace: ARCH-GRP-001, UD-GRP-OPS-EXT
-Intent: Validate pure-NumPy graph op helpers (YaRN correction, bucketed relative-position bias, ALiBi slopes, RoPE tables)
+Intent: Validate pure-NumPy graph op helpers (YaRN correction, ALiBi slopes, RoPE tables)
 Preconditions: tensorrt_model_connect is importable; no GPU or TRT required
 Postconditions: Helper functions produce mathematically correct values matching hand-computed references
 """
@@ -20,13 +20,8 @@ from tests.builder.conftest import requires_trt
 
 try:
     from tests.builder.owned_graph_modules import load_graph_ops
-    graph_ops = load_graph_ops(
-        "_yarn_correction_dim",
-        "compute_alibi_slopes",
-        "make_bucketed_relative_position_bias",
-        "make_yarn_rope_table",
-        "make_rope_query_scale_table",
-    )
+
+    graph_ops = load_graph_ops()
 except (ImportError, ModuleNotFoundError):
     pytest.skip("tensorrt_model_connect requires tensorrt", allow_module_level=True)
 
@@ -162,143 +157,7 @@ class TestComputeAlibiSlopesExtended:
 
 
 # ===================================================================
-# 3. make_bucketed_relative_position_bias
-# ===================================================================
-
-class TestMakeBucketedRelativePositionBias:
-    """Tests for make_bucketed_relative_position_bias.
-
-    The return is [max_seq_len, max_seq_len] int32 bucket indices.  The
-    num_heads parameter is retained for call-site symmetry with attention
-    helpers but is not needed for bucket construction.
-    """
-
-    def test_output_shape(self):
-        """Verify output shape is [max_seq_len, max_seq_len]."""
-        result = graph_ops.make_bucketed_relative_position_bias(
-            num_heads=8, max_seq_len=16, num_buckets=32, max_distance=128
-        )
-        assert result.shape == (16, 16)
-        assert result.dtype == np.int32
-
-    def test_values_in_range(self):
-        """All bucket indices should be in [0, num_buckets)."""
-        num_buckets = 32
-        result = graph_ops.make_bucketed_relative_position_bias(
-            num_heads=8, max_seq_len=32, num_buckets=num_buckets, max_distance=128
-        )
-        assert np.all(result >= 0)
-        assert np.all(result < num_buckets)
-
-    def test_diagonals_constant(self):
-        """bias[i][j] depends only on j-i, so each diagonal should be constant."""
-        result = graph_ops.make_bucketed_relative_position_bias(
-            num_heads=8, max_seq_len=16, num_buckets=32, max_distance=128
-        )
-        seq_len = 16
-        for offset in range(-seq_len + 1, seq_len):
-            diag = np.diag(result, k=offset)
-            assert np.all(diag == diag[0]), (
-                f"Diagonal offset={offset} is not constant: {diag}"
-            )
-
-    def test_bidirectional_symmetry(self):
-        """Positive and negative relative positions should map to different bucket halves.
-
-        For bidirectional=True with num_buckets=32:
-        - Positive offsets (j > i, i.e. looking right): bucket indices in [16, 31]
-        - Negative offsets (j < i, i.e. looking left): bucket indices in [0, 15]
-        - Zero offset (diagonal): bucket index for n=0
-        """
-        num_buckets = 32
-        result = graph_ops.make_bucketed_relative_position_bias(
-            num_heads=8, max_seq_len=16, num_buckets=num_buckets, max_distance=128
-        )
-        half_buckets = num_buckets // 2
-
-        # Check upper triangle (j > i => relative_position > 0 => n < 0 =>
-        # offset by num_bkts//2 in bidirectional mode)
-        for i in range(16):
-            for j in range(i + 1, 16):
-                assert result[i, j] >= half_buckets, (
-                    f"result[{i}][{j}]={result[i, j]} should be >= {half_buckets}"
-                )
-
-        # Check lower triangle (j < i => relative_position < 0 => n > 0 =>
-        # no offset)
-        for i in range(1, 16):
-            for j in range(i):
-                assert result[i, j] < half_buckets, (
-                    f"result[{i}][{j}]={result[i, j]} should be < {half_buckets}"
-                )
-
-    def test_max_seq_len_1(self):
-        """max_seq_len=1 should return a single-element array."""
-        result = graph_ops.make_bucketed_relative_position_bias(
-            num_heads=8, max_seq_len=1, num_buckets=32, max_distance=128
-        )
-        assert result.shape == (1, 1)
-        # Relative position is 0; for bidirectional n=-0=0, n<0 is False,
-        # so no half-bucket offset. n=abs(0)=0, is_small=True, ret=0.
-        assert result[0, 0] == 0
-
-    def test_num_buckets_2_minimal(self):
-        """Minimal num_buckets=2 triggers division by zero in log scaling.
-
-        With bidirectional=True, num_bkts becomes 1, max_exact becomes 0,
-        causing log(max_dist/0) → ZeroDivisionError. This is a known edge
-        case that does not occur for supported bucket counts.
-        """
-        with pytest.raises((ZeroDivisionError, FloatingPointError)):
-            graph_ops.make_bucketed_relative_position_bias(
-                num_heads=4, max_seq_len=8, num_buckets=2, max_distance=128
-            )
-
-    def test_diagonal_is_zero_relative(self):
-        """The main diagonal (j==i) should have consistent bucket index.
-
-        At i==j, relative_position = 0. In bidirectional mode:
-        n = -0 = 0, n<0 is False => no offset. abs(0) = 0, is_small = True.
-        ret = 0.
-        """
-        result = graph_ops.make_bucketed_relative_position_bias(
-            num_heads=8, max_seq_len=16, num_buckets=32, max_distance=128
-        )
-        diag = np.diag(result)
-        np.testing.assert_array_equal(diag, 0)
-
-    @pytest.mark.parametrize("num_buckets", [8, 16, 32, 64])
-    def test_various_num_buckets(self, num_buckets):
-        """Values in range for different num_buckets settings."""
-        result = graph_ops.make_bucketed_relative_position_bias(
-            num_heads=4, max_seq_len=16, num_buckets=num_buckets, max_distance=128
-        )
-        assert np.all(result >= 0)
-        assert np.all(result < num_buckets)
-
-    def test_adjacent_positions_monotonic(self):
-        """For increasing distance, bucket indices should be non-decreasing.
-
-        Looking at a fixed row i, as j increases from i+1 onward (positive
-        offsets in upper half), the bucket should be non-decreasing.
-        Similarly for the lower half.
-        """
-        result = graph_ops.make_bucketed_relative_position_bias(
-            num_heads=8, max_seq_len=32, num_buckets=32, max_distance=128
-        )
-        # Upper triangle: row 0, columns 1..31
-        row = result[0, 1:]
-        diffs = np.diff(row)
-        assert np.all(diffs >= 0), "Bucket indices should be non-decreasing with distance"
-
-        # Lower triangle: column 0, rows 1..31
-        col = result[1:, 0]
-        diffs = np.diff(col)
-        assert np.all(diffs >= 0), "Bucket indices should be non-decreasing with distance"
-
-
-# ===================================================================
-# 4. make_yarn_rope_table
+# 3. make_yarn_rope_table
 # ===================================================================
 
 class TestMakeYarnRopeTable:
@@ -494,41 +353,7 @@ class TestMakeYarnRopeTable:
 
 
 # ===================================================================
-# 4b. make_rope_query_scale_table
-# ===================================================================
-
-class TestMakeRopeQueryScaleTable:
-    """Tests for the per-position RoPE query scale table."""
-
-    def test_values_match_hf_formula(self):
-        table = graph_ops.make_rope_query_scale_table(
-            max_cache_length=10,
-            beta=0.1,
-            original_max_position_embeddings=4,
-        )
-        positions = np.arange(10, dtype=np.float64)
-        expected = 1.0 + 0.1 * np.log1p(np.floor(positions / 4.0))
-        np.testing.assert_allclose(table[:, 0], expected.astype(np.float32), atol=1e-7)
-
-    def test_positions_before_original_window_are_unscaled(self):
-        table = graph_ops.make_rope_query_scale_table(
-            max_cache_length=4,
-            beta=0.1,
-            original_max_position_embeddings=4,
-        )
-        np.testing.assert_allclose(table, np.ones((4, 1), dtype=np.float32))
-
-    def test_zero_beta_disables_scaling(self):
-        table = graph_ops.make_rope_query_scale_table(
-            max_cache_length=8,
-            beta=0.0,
-            original_max_position_embeddings=4,
-        )
-        np.testing.assert_allclose(table, np.ones((8, 1), dtype=np.float32))
-
-
-# ===================================================================
-# 5. add_elu (TRT)
+# 4. add_elu (TRT)
 # ===================================================================
 
 @requires_trt

--- a/tests/builder/test_split_decoder_builder_contract.py
+++ b/tests/builder/test_split_decoder_builder_contract.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 
@@ -35,6 +36,22 @@ def _builder_contract_text(path: Path, *, local_module: str) -> str:
     return text
 
 
+def _selects_prefill_or_dual_profile(text: str) -> bool:
+    """Return whether a call chooses between the two supported profile modes."""
+    tree = ast.parse(text)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.keyword) or node.arg != "profile_mode":
+            continue
+        values = {
+            child.value
+            for child in ast.walk(node.value)
+            if isinstance(child, ast.Constant) and isinstance(child.value, str)
+        }
+        if {"prefill", "dual_profile"} <= values:
+            return True
+    return False
+
+
 def test_shared_builder_modules_are_removed() -> None:
     """Shared builder package must not retain concrete model builder logic."""
     violations = [
@@ -54,7 +71,7 @@ def test_family_standard_decoder_builders_honor_split_roles() -> None:
         if (
             "_decoder_engine_role" not in text
             or "_decoder_engine_layout_supported" not in text
-            or "profile_mode=(" not in text
+            or not _selects_prefill_or_dual_profile(text)
         ):
             missing.append(str(path.relative_to(ROOT)))
 

--- a/tests/tools/test_github_actions_ci.py
+++ b/tests/tools/test_github_actions_ci.py
@@ -16,6 +16,8 @@ import textwrap
 import time
 from pathlib import Path
 
+from tools.ci.quality import UnitTestRunner
+
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -1559,6 +1561,9 @@ def test_premerge_unit_stage_builds_no_model_plugins_or_native_wheel() -> None:
     assert '["trtmc", "trtmc_platform_cpp_tests"]' in script
     assert '"TRTMC_PREMERGE_UNIT_SCOPE", "all"' in stage
     assert "tests/builder/test_cli.py" in script
+    assert 'if scope == "builder"' in script
+    assert '["tests/builder/"]' in script
+    assert "if native_targets:" in stage
     assert '[build / "trtmc", "version"]' in stage
     assert '[build / "trtmc", "--help"]' in stage
     assert "--stop-on-failure" in stage
@@ -1585,6 +1590,41 @@ def test_premerge_unit_stage_builds_no_model_plugins_or_native_wheel() -> None:
         "test_tvm_ffi_module_loader REQUIRES_TRT REQUIRES_GPU",
     ):
         assert f"trtmc_add_test({gpu_test})" in cmake
+
+
+def test_builder_unit_scope_runs_python_without_native_build(tmp_path: Path) -> None:
+    class RecordingContext:
+        repository = tmp_path
+        env = {
+            "GITHUB_WORKSPACE": str(tmp_path),
+            "TRTMC_PREMERGE_UNIT_SCOPE": "builder",
+            "TRTMC_UNIT_BUILD_JOBS": "8",
+            "TRTMC_UNIT_TEST_JOBS": "8",
+        }
+
+        def __init__(self) -> None:
+            self.commands: list[list[object]] = []
+
+        def positive_integer(self, value: str, _name: str) -> int:
+            return int(value)
+
+        def run(self, command: list[object], **_kwargs: object) -> subprocess.CompletedProcess:
+            self.commands.append(command)
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    context = RecordingContext()
+    UnitTestRunner(context).premerge()
+
+    pytest_commands = [
+        command
+        for command in context.commands
+        if command[:3] == ["python", "-m", "pytest"]
+    ]
+    assert len(pytest_commands) == 1
+    assert "tests/builder/" in pytest_commands[0]
+    assert not [
+        command for command in context.commands if command[0] in {"cmake", "ctest"}
+    ]
 
 
 def test_premerge_unit_container_is_unprivileged_offline_and_cpu_only() -> None:

--- a/tests/tools/test_model_ci.py
+++ b/tests/tools/test_model_ci.py
@@ -399,8 +399,70 @@ def test_impact_selects_only_model_a(tmp_path: Path) -> None:
     assert result["direct_models"] == ["model_a"]
     assert result["fallback_models"] == []
     assert result["matrix"] == {"include": [{"model": "model_a", "selection_kind": "direct"}]}
-    assert result["run_unit_tests"] is False
-    assert result["unit_scope"] == "none"
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "builder"
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "python/tensorrt_model_connect/families/model_a/graph_ops.py",
+        "python/tensorrt_model_connect/families/model_a/graph_blocks.py",
+        "python/tensorrt_model_connect/families/model_a/model/model.py",
+        "python/tensorrt_model_connect/families/model_a/debug_runner.py",
+        "tests/e2e/models/model_a/model.l0.json",
+        "src/runtime/models/model_a/model_a.cpp",
+    ),
+)
+def test_model_owned_change_runs_builder_units(
+    tmp_path: Path,
+    path: str,
+) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(repo, path, "# graph implementation\n")
+    head = _commit(repo, "change family graph source")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "models"
+    assert result["affected_models"] == ["model_a"]
+    assert result["direct_models"] == ["model_a"]
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "builder"
+
+
+def test_model_owned_deletion_runs_builder_units(tmp_path: Path) -> None:
+    repo, _ = _make_repo(tmp_path)
+    path = "python/tensorrt_model_connect/families/model_a/graph_ops.py"
+    _write(repo, path, "# graph implementation\n")
+    base = _commit(repo, "add family graph source")
+    (repo / path).unlink()
+    head = _commit(repo, "delete family graph source")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "models"
+    assert result["affected_models"] == ["model_a"]
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "builder"
+
+
+def test_mixed_model_and_cli_change_runs_all_units(tmp_path: Path) -> None:
+    repo, base = _make_repo(tmp_path)
+    _write(
+        repo,
+        "python/tensorrt_model_connect/families/model_a/graph_ops.py",
+        "# graph implementation\n",
+    )
+    _write(repo, "src/runtime/config/cli_support.cpp", "// CLI implementation\n")
+    head = _commit(repo, "change graph and CLI sources")
+
+    result = _impact(repo, base, head)
+
+    assert result["mode"] == "models"
+    assert result["affected_models"] == ["model_a"]
+    assert result["run_unit_tests"] is True
+    assert result["unit_scope"] == "all"
 
 
 @pytest.mark.parametrize(

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -76,6 +76,11 @@ base and tested revisions. It emits:
 This is why a model-only change validates that model, while a CI-platform change
 selects a small representative set instead of all models.
 
+Every model-owned change also selects the `builder` unit scope. That scope runs
+the Python `tests/builder/` suite without a native build. CLI-only changes
+select `cli`; changes that need both scopes, or any broad source/tooling change,
+select `all`.
+
 ### 3. Reject cheap failures first
 
 Source Quality runs `python3 -m tools.ci pipeline source-quality` on a CPU runner

--- a/tools/ci/quality.py
+++ b/tools/ci/quality.py
@@ -235,58 +235,61 @@ class UnitTestRunner:
                 updates={"PYTHONPATH": python_path},
             )
 
-        if build.exists():
-            shutil.rmtree(build)
-        self.context.run(
-            [
-                "cmake",
-                "-S",
-                source,
-                "-B",
-                build,
-                "-G",
-                "Ninja",
-                "-DCMAKE_BUILD_TYPE=Release",
-                "-DTRTMC_BUILD_TESTS=ON",
-                "-DTRTMC_BUILD_BENCHMARKS=OFF",
-                "-DTRTMC_ENABLE_LIBTORCH_MULTINOMIAL=OFF",
-                "-DTRTMC_BUILD_DIFFUSION_KERNELS=OFF",
-                "-DFETCHCONTENT_FULLY_DISCONNECTED=ON",
-            ]
-        )
-        self.context.run(
-            [
-                "cmake",
-                "--build",
-                build,
-                "--parallel",
-                str(build_jobs),
-                "--target",
-                *native_targets,
-            ],
-            limit=self.context.env.get("BUILD_ALL_TIMEOUT", "15m"),
-        )
-        if scope == "cli":
-            self.context.run([build / "trtmc", "version"], limit="1m")
-            self.context.run([build / "trtmc", "--help"], limit="1m")
-        leaked = next(build.rglob("libtrtmc_model_*.so*"), None)
-        if leaked:
-            raise CiError(f"source-only unit build produced a model plugin: {leaked}")
-        self.context.run(
-            [
-                "ctest",
-                "--test-dir",
-                build,
-                "--output-on-failure",
-                "--stop-on-failure",
-                *ctest_selector,
-                "-j",
-                str(test_jobs),
-            ],
-            limit=self.context.env.get("CPP_UNIT_TIMEOUT", "20m"),
-        )
+        if native_targets:
+            if build.exists():
+                shutil.rmtree(build)
+            self.context.run(
+                [
+                    "cmake",
+                    "-S",
+                    source,
+                    "-B",
+                    build,
+                    "-G",
+                    "Ninja",
+                    "-DCMAKE_BUILD_TYPE=Release",
+                    "-DTRTMC_BUILD_TESTS=ON",
+                    "-DTRTMC_BUILD_BENCHMARKS=OFF",
+                    "-DTRTMC_ENABLE_LIBTORCH_MULTINOMIAL=OFF",
+                    "-DTRTMC_BUILD_DIFFUSION_KERNELS=OFF",
+                    "-DFETCHCONTENT_FULLY_DISCONNECTED=ON",
+                ]
+            )
+            self.context.run(
+                [
+                    "cmake",
+                    "--build",
+                    build,
+                    "--parallel",
+                    str(build_jobs),
+                    "--target",
+                    *native_targets,
+                ],
+                limit=self.context.env.get("BUILD_ALL_TIMEOUT", "15m"),
+            )
+            if scope == "cli":
+                self.context.run([build / "trtmc", "version"], limit="1m")
+                self.context.run([build / "trtmc", "--help"], limit="1m")
+            leaked = next(build.rglob("libtrtmc_model_*.so*"), None)
+            if leaked:
+                raise CiError(f"source-only unit build produced a model plugin: {leaked}")
+            self.context.run(
+                [
+                    "ctest",
+                    "--test-dir",
+                    build,
+                    "--output-on-failure",
+                    "--stop-on-failure",
+                    *ctest_selector,
+                    "-j",
+                    str(test_jobs),
+                ],
+                limit=self.context.env.get("CPP_UNIT_TIMEOUT", "20m"),
+            )
 
     def _premerge_scope(self, scope: str) -> tuple[list[str], list[str], list[str]]:
+        if scope == "builder":
+            return (["tests/builder/"], [], [])
         if scope == "cli":
             return (
                 [
@@ -312,7 +315,7 @@ class UnitTestRunner:
                 ["trtmc", "trtmc_platform_cpp_tests"],
                 ["-L", "platform"],
             )
-        raise CiError("TRTMC_PREMERGE_UNIT_SCOPE must be cli or all")
+        raise CiError("TRTMC_PREMERGE_UNIT_SCOPE must be builder, cli, or all")
 
     def cpp_targets(self) -> list[str]:
         if self.context.env.get("FULL_E2E", "false") == "true":

--- a/tools/model_ci.py
+++ b/tools/model_ci.py
@@ -603,6 +603,16 @@ def _is_legal_or_docs(path: str) -> bool:
     )
 
 
+def _merge_unit_scope(current: str, requested: str) -> str:
+    if current == requested or requested == "none":
+        return current
+    if current == "none":
+        return requested
+    if current == "all" or requested == "all":
+        return "all"
+    return "all"
+
+
 def _classify_path(path: str, catalog: OwnershipCatalog) -> tuple[str, str | None]:
     if path in MODEL_ROOT_PLATFORM_FILES:
         return "platform", None
@@ -947,14 +957,14 @@ def calculate_impact(
             if owner is not None:
                 item["model"] = owner
                 affected.add(owner)
+                unit_scope = _merge_unit_scope(unit_scope, "builder")
             elif kind == "unit_cli":
-                if unit_scope == "none":
-                    unit_scope = "cli"
+                unit_scope = _merge_unit_scope(unit_scope, "cli")
             elif kind == "unit_tests":
-                unit_scope = "all"
+                unit_scope = _merge_unit_scope(unit_scope, "all")
             elif kind in {"platform", "ci_tooling", "unknown"}:
                 broad_change = True
-                unit_scope = "all"
+                unit_scope = _merge_unit_scope(unit_scope, "all")
             classifications.append(item)
         serialized_changes.append(
             {


### PR DESCRIPTION
## Background

Current `main` cannot complete the source-only Unit stage because generic
builder tests still reference family code removed by recent cleanup PRs. The
first visible failure is the graph-op collection error introduced by #545;
after repairing that collection boundary, stale qwen bundle-reader imports and
a syntax-sensitive decoder contract also fail.

Those regressions passed premerge because model-owned diffs selected model
proofs but skipped the generic builder suite. This also accounts for the
source-unit and package-coverage failures reported in #518; the model-specific
nightly failure in that tracker is outside this PR.

## Exit criteria

- The current builder suite collects and passes without restoring deleted
  production helpers.
- Every model-owned change or deletion runs generic builder units.
- Builder-only coverage does not pay for a native CMake/C++ build.
- Mixed builder and CLI/shared changes continue to fail closed through the
  full Unit scope.

## Implementation

- Retarget bundle-reader tests to live qwen and qwen-vl family modules.
- Remove tests for two graph helpers that no family defines or calls.
- Resolve remaining graph helpers per symbol instead of requiring one family
  to implement every helper.
- Make the split-profile contract inspect Python syntax rather than formatting.
- Add a `builder` Unit scope that runs `tests/builder/` without native targets.
- Select that scope for every model-owned diff and promote incompatible scope
  combinations to `all`.

## Validation

- CI-equivalent Python builder selection: 675 passed, 1 skipped, 84 deselected.
- Affected CI/tool tests: 161 passed.
- Static model architecture contracts: 157 passed.
- Legal-header validation and Ruff passed.
- Replaying the historical #545 and #596 diffs now produces
  `run_unit_tests=true` and `unit_scope=builder`.

The local host filesystem does not support `cp --reflink=always`, so one
existing model-proof runner test cannot complete locally. It is not changed or
relaxed here; the GitHub Unit job remains the authoritative full-suite check.
