### PR TITLE
fix(perf): make audio benchmarks reproducible

### DIFF
--- a/benchmarks/performance/baselines/task_reference.py
+++ b/benchmarks/performance/baselines/task_reference.py
@@ -183,6 +183,13 @@ def _seed_all(torch_module: Any, seed: int) -> None:
         torch_module.cuda.manual_seed_all(seed)
 
 
+def _request_seed(request: Mapping[str, Any], fallback: Any = 42) -> int:
+    value = request.get("seed", fallback)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("reference request seed must be an integer")
+    return value
+
+
 def _load_kwargs(arguments: argparse.Namespace, torch_module: Any) -> dict[str, Any]:
     values: dict[str, Any] = {
         "trust_remote_code": arguments.trust_remote_code,
@@ -395,7 +402,10 @@ def _load_tts(
             local_files_only=arguments.local_files_only,
         )
         model = MagpieTTSModel.restore_from(restore_path=model_archive).eval().to(device)
-        seed = int(_runtime_config(arguments).get("audio_magpie.seed", 42))
+        seed = _request_seed(
+            request,
+            _runtime_config(arguments).get("audio_magpie.seed", 42),
+        )
 
         def invoke() -> Mapping[str, Any]:
             _seed_all(torch, seed)
@@ -414,9 +424,13 @@ def _load_tts(
             .to(device)
         )
         inputs = _to_device(processor(prompt, return_tensors="pt"), device)
+        seed = _request_seed(
+            request,
+            _runtime_config(arguments).get("audio_bark.seed", 42),
+        )
 
         def invoke() -> Mapping[str, Any]:
-            _seed_all(torch, 42)
+            _seed_all(torch, seed)
             with torch.inference_mode():
                 audio = model.generate(**inputs)
             return {
@@ -1798,9 +1812,10 @@ def _load_qwen3_omni(
     inputs = _qwen3_omni_chat_inputs(processor, conversation).to(model.device)
     thinker_tokens = int(request.get("max_new_tokens", 16))
     talker_tokens = int(options.get("talker_max_new_tokens", 32))
+    seed = _request_seed(request)
 
     def invoke() -> Mapping[str, Any]:
-        _seed_all(torch, 42)
+        _seed_all(torch, seed)
         with torch.inference_mode():
             text_ids, audio = model.generate(
                 **inputs,

--- a/benchmarks/performance/baselines/task_reference.py
+++ b/benchmarks/performance/baselines/task_reference.py
@@ -190,6 +190,15 @@ def _request_seed(request: Mapping[str, Any], fallback: Any = 42) -> int:
     return value
 
 
+def _bark_generation_options(request: Mapping[str, Any]) -> dict[str, int]:
+    max_new_tokens = request.get("max_new_tokens", 0)
+    if isinstance(max_new_tokens, bool) or not isinstance(max_new_tokens, int):
+        raise ValueError("Bark request max_new_tokens must be an integer")
+    if max_new_tokens <= 0:
+        return {}
+    return {"semantic_max_new_tokens": max_new_tokens}
+
+
 def _load_kwargs(arguments: argparse.Namespace, torch_module: Any) -> dict[str, Any]:
     values: dict[str, Any] = {
         "trust_remote_code": arguments.trust_remote_code,
@@ -428,11 +437,12 @@ def _load_tts(
             request,
             _runtime_config(arguments).get("audio_bark.seed", 42),
         )
+        generation_options = _bark_generation_options(request)
 
         def invoke() -> Mapping[str, Any]:
             _seed_all(torch, seed)
             with torch.inference_mode():
-                audio = model.generate(**inputs)
+                audio = model.generate(**inputs, **generation_options)
             return {
                 "audio_samples": int(audio.numel()),
                 "sample_rate": int(model.generation_config.sample_rate),

--- a/benchmarks/performance/baselines/task_reference.py
+++ b/benchmarks/performance/baselines/task_reference.py
@@ -199,6 +199,14 @@ def _bark_generation_options(request: Mapping[str, Any]) -> dict[str, int]:
     return {"semantic_max_new_tokens": max_new_tokens}
 
 
+def _apply_magpie_generation_options(model: Any, request: Mapping[str, Any]) -> None:
+    max_new_tokens = request.get("max_new_tokens", 0)
+    if isinstance(max_new_tokens, bool) or not isinstance(max_new_tokens, int):
+        raise ValueError("Magpie request max_new_tokens must be an integer")
+    if max_new_tokens > 0:
+        model.inference_parameters.max_decoder_steps = max_new_tokens
+
+
 def _load_kwargs(arguments: argparse.Namespace, torch_module: Any) -> dict[str, Any]:
     values: dict[str, Any] = {
         "trust_remote_code": arguments.trust_remote_code,
@@ -411,6 +419,7 @@ def _load_tts(
             local_files_only=arguments.local_files_only,
         )
         model = MagpieTTSModel.restore_from(restore_path=model_archive).eval().to(device)
+        _apply_magpie_generation_options(model, request)
         seed = _request_seed(
             request,
             _runtime_config(arguments).get("audio_magpie.seed", 42),

--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -41,7 +41,9 @@ entries:
       reference_backend: hf_transformers
       timing_scope: task-model-call-wall
       input_preparation_included: false
-      output_contract: audio-shape
+      output_contract: audio-duration
+      # Fixed-seed backends may stop at adjacent AR steps; keep workloads within 2%.
+      max_audio_duration_relative_difference: 0.02
   - id: bart.generate
     family: bart
     operation: generate

--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -34,6 +34,9 @@ entries:
     model: bark-small
     workload:
       testcase: bark-small
+      request:
+        # Stop before either backend's sampled EOS so both run exactly 128 semantic steps.
+        max_new_tokens: 128
     baseline:
       runner: task-reference
       adapter: hf-transformers-tts
@@ -41,9 +44,7 @@ entries:
       reference_backend: hf_transformers
       timing_scope: task-model-call-wall
       input_preparation_included: false
-      output_contract: audio-duration
-      # Fixed-seed backends may stop at adjacent AR steps; keep workloads within 2%.
-      max_audio_duration_relative_difference: 0.02
+      output_contract: audio-shape
   - id: bart.generate
     family: bart
     operation: generate

--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -413,6 +413,8 @@ entries:
     model: magpie-tts-357m
     workload:
       testcase: magpie-tts-357m
+      request:
+        max_new_tokens: 256
     baseline:
       runner: task-reference
       adapter: nemo-tts

--- a/include/trtmc/config/cli_support.h
+++ b/include/trtmc/config/cli_support.h
@@ -26,6 +26,7 @@
 
 #include <any>
 #include <iosfwd>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -96,6 +97,17 @@ ConfigBundle resolve_cli_config(const std::string& config_path,             // e
 std::string write_effective_config_next_to(const ConfigBundle& bundle,
                                            const std::string& artifact_path,
                                            const std::string& suffix = ".effective_config.json");
+
+// Best-effort variant for runtime paths where the artifact may be read-only.
+// Resolution remains authoritative even when the diagnostic sidecar cannot
+// be written; callers can surface ``error`` without changing behavior.
+struct EffectiveConfigWriteResult {
+    std::optional<std::string> path;
+    std::string error;
+};
+EffectiveConfigWriteResult
+try_write_effective_config_next_to(const ConfigBundle& bundle, const std::string& artifact_path,
+                                   const std::string& suffix = ".effective_config.json");
 
 // Low-level: serialize a bundle to JSON text. Stable field/namespace
 // ordering so two identical bundles produce byte-identical output.

--- a/python/tensorrt_model_connect/benchmark/task_adapters.py
+++ b/python/tensorrt_model_connect/benchmark/task_adapters.py
@@ -388,6 +388,7 @@ def _generate_audio_request(testcase: Mapping[str, Any], _model_root: Path) -> C
     runtime_config = testcase.get("runtime_config", {})
     if not isinstance(runtime_config, Mapping):
         raise BenchmarkError("generate_audio runtime_config must be an object")
+    config = _flatten_runtime_config(runtime_config)
     request = {
         "batch_size": 1,
         "prompt": _prompt(testcase, "generate_audio"),
@@ -398,7 +399,10 @@ def _generate_audio_request(testcase: Mapping[str, Any], _model_root: Path) -> C
         "prompt": _MODEL_TESTCASE,
         "max_new_tokens": _MODEL_TESTCASE if "max_new_tokens" in testcase else _TASK_DEFAULT,
     }
-    config = _flatten_runtime_config(runtime_config)
+    seed = _generate_audio_seed(testcase, config)
+    if seed is not None:
+        request["seed"] = seed
+        sources["seed"] = _MODEL_TESTCASE
     runtime = {"config": config} if config else {}
     runtime_sources = {"config": _MODEL_TESTCASE} if config else {}
     return _resolution(
@@ -408,6 +412,46 @@ def _generate_audio_request(testcase: Mapping[str, Any], _model_root: Path) -> C
         runtime=runtime,
         runtime_sources=runtime_sources,
     )
+
+
+def _generate_audio_seed(
+    testcase: Mapping[str, Any], runtime_config: Mapping[str, Any]
+) -> int | None:
+    inputs = testcase.get("inputs", {})
+    if not isinstance(inputs, Mapping):
+        raise BenchmarkError("generate_audio testcase inputs must be an object")
+    determinism = testcase.get("determinism", {})
+    if not isinstance(determinism, Mapping):
+        raise BenchmarkError("generate_audio testcase determinism must be an object")
+
+    declared: Any = None
+    found = False
+    for values in (inputs, testcase, determinism):
+        if "seed" in values:
+            declared = values["seed"]
+            found = True
+            break
+
+    if not found:
+        runtime_seeds = [
+            value for name, value in runtime_config.items() if name.endswith(".seed")
+        ]
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) for value in runtime_seeds
+        ):
+            raise BenchmarkError("generate_audio seed must be an integer")
+        distinct_runtime_seeds = set(runtime_seeds)
+        if len(distinct_runtime_seeds) > 1:
+            raise BenchmarkError("generate_audio runtime config has conflicting seed values")
+        if runtime_seeds:
+            declared = runtime_seeds[0]
+            found = True
+
+    if not found:
+        return None
+    if isinstance(declared, bool) or not isinstance(declared, int):
+        raise BenchmarkError("generate_audio seed must be an integer")
+    return declared
 
 
 def _flatten_runtime_config(value: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -1566,9 +1566,16 @@ int apply_cli_config(const CliArgs& args) {
     try {
         auto bundle = trtmc::config::resolve_cli_config(args.config_path, args.set_tokens);
         if (!args.bundle_path.empty()) {
-            std::string path =
-                trtmc::config::write_effective_config_next_to(bundle, args.bundle_path);
-            std::cerr << "[trtmc] Wrote effective config: " << path << '\n';
+            const auto sidecar =
+                trtmc::config::try_write_effective_config_next_to(bundle, args.bundle_path);
+            if (sidecar.path) {
+                std::cerr << "[trtmc] Wrote effective config: " << *sidecar.path << '\n';
+            } else {
+                std::cerr << "[trtmc.config] Failed to write effective config sidecar: "
+                          << sidecar.error
+                          << "\n          Command will continue with resolved "
+                             "runtime config.\n";
+            }
         }
     } catch (const std::exception& e) {
         std::cerr << "Error resolving config: " << e.what() << '\n';

--- a/src/runtime/config/cli_support.cpp
+++ b/src/runtime/config/cli_support.cpp
@@ -511,9 +511,10 @@ LayeredFileValues load_layered_file(const std::string& path) {
     if (ext_low == ".json")
         return parse_layered_json(body);
     if (ext_low == ".yaml" || ext_low == ".yml") {
-        throw std::invalid_argument("--config " + path +
-                                    ": YAML is not supported by the C++ loader; convert to JSON or "
-                                    "load via a wrapper (tensorrt_model_connect/cli.py accepts YAML).");
+        throw std::invalid_argument(
+            "--config " + path +
+            ": YAML is not supported by the C++ loader; convert to JSON or "
+            "load via a wrapper (tensorrt_model_connect/cli.py accepts YAML).");
     }
     throw std::invalid_argument("--config " + path + ": unsupported extension '" + ext +
                                 "' (expected .json)");
@@ -750,6 +751,17 @@ std::string write_effective_config_next_to(const ConfigBundle& bundle,
         throw std::invalid_argument("cannot write effective_config to: " + p.string());
     out << bundle_to_effective_json(bundle);
     return p.string();
+}
+
+EffectiveConfigWriteResult try_write_effective_config_next_to(const ConfigBundle& bundle,
+                                                              const std::string& artifact_path,
+                                                              const std::string& suffix) {
+    try {
+        return EffectiveConfigWriteResult{
+            write_effective_config_next_to(bundle, artifact_path, suffix), ""};
+    } catch (const std::exception& e) {
+        return EffectiveConfigWriteResult{std::nullopt, e.what()};
+    }
 }
 
 } // namespace trtmc::config

--- a/src/runtime/models/bark/bark_generation_plan.h
+++ b/src/runtime/models/bark/bark_generation_plan.h
@@ -41,6 +41,10 @@ struct BarkFinePlan {
     int32_t last_predicted_codebook{8};
 };
 
+inline int64_t resolve_bark_seed(int64_t session_seed, int32_t request_seed) {
+    return request_seed >= 0 ? static_cast<int64_t>(request_seed) : session_seed;
+}
+
 inline bool bark_fine_uses_sampling(const BarkConfig& cfg) {
     return !cfg.greedy && std::abs(cfg.fine_temperature - 1.0F) > 1e-6F;
 }

--- a/src/runtime/models/bark/pipeline.cpp
+++ b/src/runtime/models/bark/pipeline.cpp
@@ -92,8 +92,8 @@ void maybe_dump_tokens(const std::string& dump_path, const char* suffix,
     }
 }
 
-// Seed the sampler RNG from audio_bark.seed. A value of -1 (default)
-// means "leave the RNG at its constructed state." Replaces TRTMC_BARK_SEED.
+// Seed the sampler RNG from the request, falling back to audio_bark.seed.
+// A value of -1 (default) means "leave the RNG at its constructed state."
 void maybe_seed_bark_rng(std::mt19937& rng, std::int64_t seed) {
     if (seed < 0)
         return;
@@ -186,10 +186,9 @@ AudioResult BarkPipeline::generate_audio(const std::string& prompt, const Genera
 
     int32_t max_tokens = cfg.max_new_tokens > 0 ? cfg.max_new_tokens : 768;
 
-    // config_.greedy and config_.seed arrive pre-populated from the
-    // audio_bark.* namespace (see bark_plugin.cpp). No env-var reads
-    // anywhere in this file.
-    maybe_seed_bark_rng(rng_, config_.seed);
+    // A public request seed takes precedence over the session-level
+    // audio_bark.seed fallback populated by bark_plugin.cpp.
+    maybe_seed_bark_rng(rng_, resolve_bark_seed(config_.seed, cfg.seed));
 
     std::cerr << "[trtmc] Bark: starting pipeline with " << input_ids.size()
               << " text tokens, max_semantic=" << max_tokens << (config_.greedy ? " (greedy)" : "")

--- a/src/runtime/models/magpie/MODEL.toml
+++ b/src/runtime/models/magpie/MODEL.toml
@@ -12,6 +12,7 @@ runtime_tests = [
   "test_magpie_config_schema|test_magpie_config_schema.cpp|trtmc_model_magpie|_|_",
   "test_magpie_decode_policy|test_magpie_decode_policy.cpp|_|_|_",
   "test_magpie_decoder_plan|test_magpie_decoder_plan.cpp|_|_|_",
+  "test_magpie_generation_plan|test_magpie_generation_plan.cpp|_|_|_",
   "test_magpie_text_completion_policy|test_magpie_text_completion_policy.cpp|_|_|_",
   "test_magpie_codec_plan|test_magpie_codec_plan.cpp|_|_|_",
   "test_magpie_pipeline|test_magpie_pipeline.cpp|trtmc_model_magpie|_|REQUIRES_TRT",

--- a/src/runtime/models/magpie/magpie_generation_plan.h
+++ b/src/runtime/models/magpie/magpie_generation_plan.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace trtmc {
+
+inline int64_t resolve_magpie_seed(int64_t session_seed, int32_t request_seed) {
+    return request_seed >= 0 ? static_cast<int64_t>(request_seed) : session_seed;
+}
+
+} // namespace trtmc

--- a/src/runtime/models/magpie/pipeline.cpp
+++ b/src/runtime/models/magpie/pipeline.cpp
@@ -9,6 +9,7 @@
 #include "runtime/models/magpie/magpie_codec_plan.h"
 #include "runtime/models/magpie/magpie_decode_policy.h"
 #include "runtime/models/magpie/magpie_decoder_plan.h"
+#include "runtime/models/magpie/magpie_generation_plan.h"
 #include "runtime/models/magpie/magpie_text_completion_policy.h"
 #include "runtime/models/magpie/tensor_names.h"
 
@@ -1777,7 +1778,7 @@ int32_t MagpiePipeline::generate_audio_streaming(const std::vector<int32_t>& tex
     if (!audio_callback)
         return 0;
 
-    apply_env_overrides();
+    reset_rng_for_request();
     ensure_cfg_resources();
     text_length_ = static_cast<int32_t>(text_ids.size());
 
@@ -1980,13 +1981,14 @@ void MagpiePipeline::log_pipeline_profiling(int32_t num_frames, int32_t num_samp
 // generate_audio() helpers
 // ---------------------------------------------------------------------------
 
-void MagpiePipeline::apply_env_overrides() {
+void MagpiePipeline::reset_rng_for_request(int32_t request_seed) {
     // All values now arrive pre-populated from the audio_magpie.* namespace
     // (magpie_plugin does the ctx.runtime_config reads at construction).
     // Formerly this method read TRTMC_MAGPIE_{GREEDY,CFG_SCALE,TEMPERATURE,
     // FINISHED_LIMIT,SEED} directly — those env vars are deleted.
-    if (config_.seed >= 0)
-        rng_.seed(static_cast<std::mt19937::result_type>(config_.seed));
+    const int64_t seed = resolve_magpie_seed(config_.seed, request_seed);
+    if (seed >= 0)
+        rng_.seed(static_cast<std::mt19937::result_type>(seed));
 }
 
 void MagpiePipeline::ensure_cfg_resources() {
@@ -2047,7 +2049,7 @@ AudioResult MagpiePipeline::generate_audio(const std::string& prompt, const Gene
     AudioResult result;
     result.sample_rate = config_.sample_rate;
 
-    apply_env_overrides();
+    reset_rng_for_request(cfg.seed);
     ensure_cfg_resources();
 
     text_length_ = static_cast<int32_t>(input_ids.size());

--- a/src/runtime/models/magpie/pipeline.h
+++ b/src/runtime/models/magpie/pipeline.h
@@ -182,7 +182,7 @@ class MagpiePipeline final : public IPipeline {
     void init_cross_attn_resources();
     void init_cfg_logit_buffers();
 
-    void apply_env_overrides();
+    void reset_rng_for_request(int32_t request_seed = -1);
     void ensure_cfg_resources();
     void run_cfg_encoder(const std::vector<int32_t>& text_ids);
     void log_decoder_profiling(const DecoderLoopState& state, int32_t ctx_frames,

--- a/src/runtime/registry/pipeline_factory.cpp
+++ b/src/runtime/registry/pipeline_factory.cpp
@@ -263,11 +263,11 @@ detail::resolve_runtime_config(const std::string& config_text, const std::string
                                const std::vector<std::string>& set_tokens) {
     try {
         auto resolution = config::resolve_pipeline_config(config_text, config_path, set_tokens);
-        try {
-            config::write_effective_config_next_to(resolution.bundle, bundle_path);
-        } catch (const std::exception& e) {
-            std::cerr << "[trtmc.config] Failed to write effective config sidecar: " << e.what()
-                      << "\n          Resolved runtime config remains active.\n";
+        const auto sidecar =
+            config::try_write_effective_config_next_to(resolution.bundle, bundle_path);
+        if (!sidecar.path) {
+            std::cerr << "[trtmc.config] Failed to write effective config sidecar: "
+                      << sidecar.error << "\n          Resolved runtime config remains active.\n";
         }
         apply_platform_config(resolution.bundle);
         return std::move(resolution.bundle);

--- a/src/runtime/registry/pipeline_factory.cpp
+++ b/src/runtime/registry/pipeline_factory.cpp
@@ -11,6 +11,7 @@
 #include "runtime/core/trt_common.h"
 #include "runtime/providers/optimized_runtime_host.h"
 #include "runtime/registry/bundle_materialization.h"
+#include "runtime/registry/runtime_config_resolution.h"
 #include "trtmc/config/cli_support.h"
 #include "trtmc/config/config_bundle.h"
 #include "trtmc/config/schema_registry.h"
@@ -151,7 +152,7 @@ IPipelinePlugin* lookup_plugin_or_throw(const std::string& strategy,
 
 // Apply platform.* values to their process-wide sinks. Replaces the old
 // TRTMC_DATA_DIR and TRTMC_TRT_LOG_{STDERR,MIN_SEVERITY} env-var reads.
-// Called from try_resolve_runtime_config once a bundle has resolved.
+// Called once a bundle's layered runtime config has resolved.
 void apply_platform_config(const config::ConfigBundle& bundle) {
     try {
         const std::string source = bundle.get<std::string>("platform", "source_dir");
@@ -254,13 +255,20 @@ IBackend* load_backend_for_bundle(const BundleFile& bundle, const std::string& c
     return backend;
 }
 
+} // namespace
+
 std::optional<config::ConfigBundle>
-try_resolve_runtime_config(const std::string& config_text, const std::string& bundle_path,
-                           const std::string& config_path,
-                           const std::vector<std::string>& set_tokens) {
+detail::resolve_runtime_config(const std::string& config_text, const std::string& bundle_path,
+                               const std::string& config_path,
+                               const std::vector<std::string>& set_tokens) {
     try {
         auto resolution = config::resolve_pipeline_config(config_text, config_path, set_tokens);
-        config::write_effective_config_next_to(resolution.bundle, bundle_path);
+        try {
+            config::write_effective_config_next_to(resolution.bundle, bundle_path);
+        } catch (const std::exception& e) {
+            std::cerr << "[trtmc.config] Failed to write effective config sidecar: " << e.what()
+                      << "\n          Resolved runtime config remains active.\n";
+        }
         apply_platform_config(resolution.bundle);
         return std::move(resolution.bundle);
     } catch (const std::exception& e) {
@@ -269,8 +277,6 @@ try_resolve_runtime_config(const std::string& config_text, const std::string& bu
         return std::nullopt;
     }
 }
-
-} // namespace
 
 std::unique_ptr<IPipeline> PipelineFactory::from_bundle(const std::string& bundle_path,
                                                         const std::string& hf_python,
@@ -314,8 +320,8 @@ std::unique_ptr<IPipeline> PipelineFactory::from_bundle(const std::string& bundl
     // Best-effort: a malformed input prints to stderr and falls back to
     // schema defaults so plugin construction isn't blocked.
     std::optional<config::ConfigBundle> resolved =
-        try_resolve_runtime_config(config_text, bundle_path, /*config_path=*/"",
-                                   /*set_tokens=*/{});
+        detail::resolve_runtime_config(config_text, bundle_path, /*config_path=*/"",
+                                       /*set_tokens=*/{});
 
     PipelineContext ctx{bundle,
                         base_cfg,
@@ -358,7 +364,7 @@ std::unique_ptr<IPipeline> PipelineFactory::from_bundle(const std::string& bundl
     BaseConfig base_cfg = parse_base_config(config_text, bundle.info.max_cache_length);
     base_cfg.runtime_strategy = strategy;
 
-    std::optional<config::ConfigBundle> resolved = try_resolve_runtime_config(
+    std::optional<config::ConfigBundle> resolved = detail::resolve_runtime_config(
         config_text, bundle_path, options.config_path, options.set_tokens);
 
     PipelineContext ctx{bundle,
@@ -404,7 +410,7 @@ std::unique_ptr<PipelinePool> PipelineFactory::from_bundle_pool(const std::strin
 
     BaseConfig base_cfg = parse_base_config(config_text, bundle.info.max_cache_length);
     base_cfg.runtime_strategy = strategy;
-    std::optional<config::ConfigBundle> resolved = try_resolve_runtime_config(
+    std::optional<config::ConfigBundle> resolved = detail::resolve_runtime_config(
         config_text, bundle_path, options.config_path, options.set_tokens);
 
     PipelineContext ctx{bundle,

--- a/src/runtime/registry/runtime_config_resolution.h
+++ b/src/runtime/registry/runtime_config_resolution.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "trtmc/config/config_bundle.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace trtmc::detail {
+
+std::optional<config::ConfigBundle>
+resolve_runtime_config(const std::string& config_text, const std::string& bundle_path,
+                       const std::string& config_path, const std::vector<std::string>& set_tokens);
+
+} // namespace trtmc::detail

--- a/tests/cpp/models/bark/test_bark_generation_plan.cpp
+++ b/tests/cpp/models/bark/test_bark_generation_plan.cpp
@@ -125,6 +125,15 @@ void test_fine_sampling_policy_matches_hf() {
     check(!trtmc::bark_fine_uses_sampling(cfg), "bark global greedy disables fine sampling");
 }
 
+void test_request_seed_overrides_session_seed() {
+    check(trtmc::resolve_bark_seed(42, 0) == 0,
+          "bark request seed overrides configured session seed");
+    check(trtmc::resolve_bark_seed(42, -1) == 42,
+          "bark configured session seed remains the fallback");
+    check(trtmc::resolve_bark_seed(-1, -1) == -1,
+          "bark remains nondeterministic when neither seed is configured");
+}
+
 void test_fine_input_embeddings_use_hf_padding_code() {
     constexpr int32_t n_frames = 1;
     constexpr int32_t actual_frames = 1;
@@ -178,6 +187,7 @@ int main() {
     test_codec_plan_prefers_fine_codes_when_available();
     test_fine_plan_and_code_initialization();
     test_fine_sampling_policy_matches_hf();
+    test_request_seed_overrides_session_seed();
     test_fine_input_embeddings_use_hf_padding_code();
     test_codec_input_builder_transposes_codebooks();
 

--- a/tests/cpp/models/magpie/test_magpie_generation_plan.cpp
+++ b/tests/cpp/models/magpie/test_magpie_generation_plan.cpp
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// =============================================================================
+// ISO 26262 Traceability
+// =============================================================================
+// Trace ID:       UT-AUD-CPP-08
+// Architecture:   ARCH-FAC-001
+// Unit Design:    UD-AUD-01
+// Intent:         Magpie request generation settings override session defaults
+// Preconditions:  Session and request seed values
+// Postconditions: Request seed wins when present; session seed remains the fallback
+// =============================================================================
+
+#include "runtime/models/magpie/magpie_generation_plan.h"
+
+#include <iostream>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* name) {
+    if (!condition) {
+        std::cerr << "FAIL: " << name << '\n';
+        ++g_failures;
+    }
+}
+
+void test_request_seed_overrides_session_seed() {
+    check(trtmc::resolve_magpie_seed(42, 0) == 0,
+          "magpie request seed overrides configured session seed");
+    check(trtmc::resolve_magpie_seed(42, -1) == 42,
+          "magpie configured session seed remains the fallback");
+    check(trtmc::resolve_magpie_seed(-1, -1) == -1,
+          "magpie remains nondeterministic when neither seed is configured");
+}
+
+} // namespace
+
+int main() {
+    test_request_seed_overrides_session_seed();
+    if (g_failures != 0) {
+        std::cerr << g_failures << " magpie generation plan test(s) failed\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/cpp/test_config_cli_support.cpp
+++ b/tests/cpp/test_config_cli_support.cpp
@@ -354,6 +354,18 @@ void test_write_effective_config_next_to_places_file(std::string tmp_dir) {
           "write_effective: sibling filename");
 }
 
+void test_try_write_effective_config_reports_unwritable_sidecar() {
+    register_demo_schema();
+    auto bundle = trtmc::config::resolve_cli_config("", {"triattention.kv_budget=8192"});
+
+    const auto result =
+        trtmc::config::try_write_effective_config_next_to(bundle, "/dev/null/bundle.trtfb");
+
+    check(!result.path.has_value(), "try_write_effective: unwritable path is non-fatal");
+    check(result.error.find("cannot create directories") != std::string::npos,
+          "try_write_effective: write error remains observable");
+}
+
 void test_runtime_resolution_survives_unwritable_effective_config_sidecar() {
     register_demo_schema();
     auto resolved = trtmc::detail::resolve_runtime_config(
@@ -518,6 +530,7 @@ int main() {
     test_resolve_session_beats_platform();
 
     test_bundle_to_effective_json_contains_source();
+    test_try_write_effective_config_reports_unwritable_sidecar();
     test_runtime_resolution_survives_unwritable_effective_config_sidecar();
 
     test_extract_bundle_defaults_finds_block();

--- a/tests/cpp/test_config_cli_support.cpp
+++ b/tests/cpp/test_config_cli_support.cpp
@@ -19,6 +19,7 @@
 //                 profile parser accepts the scoped shape.
 // =============================================================================
 
+#include "runtime/registry/runtime_config_resolution.h"
 #include "test_helpers.h"
 #include "trtmc/config/cli_support.h"
 #include "trtmc/config/config_bundle.h"
@@ -316,7 +317,8 @@ void test_resolve_session_beats_platform() {
     LayerContribution platform;
     platform.layer = Layer::PlatformProfile;
     platform.values["triattention"]["kv_budget"] = std::any{std::int32_t{10240}};
-    auto bundle = trtmc::config::resolve_cli_config("", {"triattention.kv_budget=8192"}, {platform});
+    auto bundle =
+        trtmc::config::resolve_cli_config("", {"triattention.kv_budget=8192"}, {platform});
     check(bundle.get<std::int32_t>("triattention", "kv_budget") == 8192,
           "resolve: session beats platform");
     check(bundle.source_of("triattention", "kv_budget") == Layer::SessionRequest,
@@ -350,6 +352,19 @@ void test_write_effective_config_next_to_places_file(std::string tmp_dir) {
     check(fs::exists(written), "write_effective: file exists");
     check(fs::path(written).filename() == "bundle.effective_config.json",
           "write_effective: sibling filename");
+}
+
+void test_runtime_resolution_survives_unwritable_effective_config_sidecar() {
+    register_demo_schema();
+    auto resolved = trtmc::detail::resolve_runtime_config(
+        R"({"defaults":{"triattention":{"kv_budget":4096}}})", "/dev/null/bundle.trtfb", "",
+        {"triattention.kv_budget=8192"});
+
+    check(resolved.has_value(), "runtime resolution: unwritable sidecar retains config");
+    if (resolved) {
+        check(resolved->get<std::int32_t>("triattention", "kv_budget") == 8192,
+              "runtime resolution: session override remains active");
+    }
 }
 
 // ---- bundle defaults: block ------------------------------------------------
@@ -417,7 +432,7 @@ void test_resolve_pipeline_config_merges_bundle_and_session(std::string tmp_dir)
     std::ofstream(profile) << R"({"triattention": {"dump_scores_path": "/tmp/x"}})";
 
     auto res = trtmc::config::resolve_pipeline_config(header, profile.string(),
-                                                     {"triattention.kv_budget=8192"});
+                                                      {"triattention.kv_budget=8192"});
 
     // bundle_default + session contributions both land
     check(res.contributions.size() == 2, "resolve: two contributions");
@@ -503,6 +518,7 @@ int main() {
     test_resolve_session_beats_platform();
 
     test_bundle_to_effective_json_contains_source();
+    test_runtime_resolution_survives_unwritable_effective_config_sidecar();
 
     test_extract_bundle_defaults_finds_block();
     test_extract_bundle_defaults_absent_block();

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import runpy
 import subprocess
 import sys
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 import yaml
@@ -311,6 +311,10 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     assert (
         by_id["bark.generate_audio"]["workload"]["request"]["max_new_tokens"]
         == 128
+    )
+    assert (
+        by_id["magpie_tts.generate_audio"]["workload"]["request"]["max_new_tokens"]
+        == 256
     )
     for case_id in (
         "bark.generate_audio",
@@ -1350,6 +1354,16 @@ def test_bark_reference_maps_public_token_cap_to_semantic_stage() -> None:
         "semantic_max_new_tokens": 128
     }
     assert runner["_bark_generation_options"]({"max_new_tokens": 0}) == {}
+
+
+def test_magpie_reference_maps_public_token_cap_to_decoder_steps() -> None:
+    runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py"))
+    inference_parameters = SimpleNamespace(max_decoder_steps=750)
+    model = SimpleNamespace(inference_parameters=inference_parameters)
+
+    runner["_apply_magpie_generation_options"](model, {"max_new_tokens": 256})
+
+    assert inference_parameters.max_decoder_steps == 256
 
 
 def test_task_reference_runner_measures_loaded_public_operation(

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -308,14 +308,12 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     assert by_id["magpie_tts.generate_audio"]["baseline"]["adapter_options"] == {
         "speaker_encoder_revision": "e9124b5364a2c3e9b4f78da429a33cbca8f8c22b"
     }
-    assert by_id["bark.generate_audio"]["baseline"]["output_contract"] == "audio-duration"
     assert (
-        by_id["bark.generate_audio"]["baseline"][
-            "max_audio_duration_relative_difference"
-        ]
-        == 0.02
+        by_id["bark.generate_audio"]["workload"]["request"]["max_new_tokens"]
+        == 128
     )
     for case_id in (
+        "bark.generate_audio",
         "magpie_tts.generate_audio",
         "personaplex.speak",
         "qwen3_omni.generate_audio",
@@ -732,65 +730,6 @@ def test_audio_contract_rejects_different_generated_sample_counts() -> None:
 
     reference["output_summary"]["audio_samples"] = 58_965
     assert perf_matrix._output_contract(case, candidate, reference) == (True, "")
-
-
-def test_audio_duration_contract_allows_only_tightly_comparable_workloads() -> None:
-    case = {
-        "operation": "generate_audio",
-        "baseline": {
-            "output_contract": "audio-duration",
-            "max_audio_duration_relative_difference": 0.02,
-        },
-    }
-    candidate = {
-        "output_summary": {
-            "num_samples": 85_440,
-            "sample_rate": 24_000,
-        }
-    }
-    reference = {
-        "output_summary": {
-            "audio_samples": 86_400,
-            "sample_rate": 24_000,
-        }
-    }
-
-    assert perf_matrix._output_contract(case, candidate, reference) == (True, "")
-
-    candidate["output_summary"]["num_samples"] = 327_680
-    assert perf_matrix._output_contract(case, candidate, reference) == (
-        False,
-        "audio duration differs by more than the configured contract",
-    )
-
-    candidate["output_summary"]["num_samples"] = 85_440
-    candidate["output_summary"]["sample_rate"] = 22_050
-    assert perf_matrix._output_contract(case, candidate, reference) == (
-        False,
-        "audio sample rate differs",
-    )
-
-
-def test_audio_duration_contract_requires_an_explicit_bounded_limit() -> None:
-    case = next(
-        value
-        for value in perf_matrix._cases(perf_matrix._read_yaml(SUITE))
-        if value["id"] == "bark.generate_audio"
-    )
-
-    for invalid in (None, True, -0.01, 1.01):
-        drifted = {
-            **case,
-            "baseline": {
-                **case["baseline"],
-                "max_audio_duration_relative_difference": invalid,
-            },
-        }
-        with pytest.raises(
-            perf_matrix.PerfMatrixError,
-            match="audio-duration contract has an invalid relative-difference limit",
-        ):
-            perf_matrix._validate_baseline(drifted)
 
 
 def test_media_contract_compares_materialized_frame_geometry() -> None:
@@ -1402,6 +1341,15 @@ def test_task_reference_request_seed_is_explicit_and_strict() -> None:
     for invalid in (True, 0.5, "42"):
         with pytest.raises(ValueError, match="request seed must be an integer"):
             runner["_request_seed"]({"seed": invalid})
+
+
+def test_bark_reference_maps_public_token_cap_to_semantic_stage() -> None:
+    runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py"))
+
+    assert runner["_bark_generation_options"]({"max_new_tokens": 128}) == {
+        "semantic_max_new_tokens": 128
+    }
+    assert runner["_bark_generation_options"]({"max_new_tokens": 0}) == {}
 
 
 def test_task_reference_runner_measures_loaded_public_operation(

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -308,6 +308,19 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     assert by_id["magpie_tts.generate_audio"]["baseline"]["adapter_options"] == {
         "speaker_encoder_revision": "e9124b5364a2c3e9b4f78da429a33cbca8f8c22b"
     }
+    assert by_id["bark.generate_audio"]["baseline"]["output_contract"] == "audio-duration"
+    assert (
+        by_id["bark.generate_audio"]["baseline"][
+            "max_audio_duration_relative_difference"
+        ]
+        == 0.02
+    )
+    for case_id in (
+        "magpie_tts.generate_audio",
+        "personaplex.speak",
+        "qwen3_omni.generate_audio",
+    ):
+        assert by_id[case_id]["baseline"]["output_contract"] == "audio-shape"
     assert by_id["personaplex.speak"]["baseline"]["adapter_options"] == {
         "reference_commit": "3428dfd95309a7f3c84fd93259ded0f810d1ff91"
     }
@@ -719,6 +732,65 @@ def test_audio_contract_rejects_different_generated_sample_counts() -> None:
 
     reference["output_summary"]["audio_samples"] = 58_965
     assert perf_matrix._output_contract(case, candidate, reference) == (True, "")
+
+
+def test_audio_duration_contract_allows_only_tightly_comparable_workloads() -> None:
+    case = {
+        "operation": "generate_audio",
+        "baseline": {
+            "output_contract": "audio-duration",
+            "max_audio_duration_relative_difference": 0.02,
+        },
+    }
+    candidate = {
+        "output_summary": {
+            "num_samples": 85_440,
+            "sample_rate": 24_000,
+        }
+    }
+    reference = {
+        "output_summary": {
+            "audio_samples": 86_400,
+            "sample_rate": 24_000,
+        }
+    }
+
+    assert perf_matrix._output_contract(case, candidate, reference) == (True, "")
+
+    candidate["output_summary"]["num_samples"] = 327_680
+    assert perf_matrix._output_contract(case, candidate, reference) == (
+        False,
+        "audio duration differs by more than the configured contract",
+    )
+
+    candidate["output_summary"]["num_samples"] = 85_440
+    candidate["output_summary"]["sample_rate"] = 22_050
+    assert perf_matrix._output_contract(case, candidate, reference) == (
+        False,
+        "audio sample rate differs",
+    )
+
+
+def test_audio_duration_contract_requires_an_explicit_bounded_limit() -> None:
+    case = next(
+        value
+        for value in perf_matrix._cases(perf_matrix._read_yaml(SUITE))
+        if value["id"] == "bark.generate_audio"
+    )
+
+    for invalid in (None, True, -0.01, 1.01):
+        drifted = {
+            **case,
+            "baseline": {
+                **case["baseline"],
+                "max_audio_duration_relative_difference": invalid,
+            },
+        }
+        with pytest.raises(
+            perf_matrix.PerfMatrixError,
+            match="audio-duration contract has an invalid relative-difference limit",
+        ):
+            perf_matrix._validate_baseline(drifted)
 
 
 def test_media_contract_compares_materialized_frame_geometry() -> None:
@@ -1320,6 +1392,16 @@ def test_source_revision_can_be_injected_without_git(monkeypatch) -> None:
     monkeypatch.setenv("TRTMC_PERF_SOURCE_REVISION", "tested-commit")
 
     assert perf_matrix._git_commit() == "tested-commit"
+
+
+def test_task_reference_request_seed_is_explicit_and_strict() -> None:
+    runner = runpy.run_path(str(REPOSITORY / "benchmarks/performance/baselines/task_reference.py"))
+
+    assert runner["_request_seed"]({"seed": 0}) == 0
+    assert runner["_request_seed"]({}, 42) == 42
+    for invalid in (True, 0.5, "42"):
+        with pytest.raises(ValueError, match="request seed must be an integer"):
+            runner["_request_seed"]({"seed": invalid})
 
 
 def test_task_reference_runner_measures_loaded_public_operation(

--- a/tests/tools/test_trtmc_bench.py
+++ b/tests/tools/test_trtmc_bench.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import json
 from pathlib import Path
 import subprocess
@@ -758,11 +759,54 @@ def test_multimodal_and_speech_cases_preserve_required_runtime_inputs(tmp_path: 
         ManifestCatalog().resolve("magpie-tts-357m"),
         tmp_path / "magpie.trtfb",
     )
+    assert magpie.request["seed"] == 42
     assert magpie.runtime["config"] == {
         "audio_magpie.cfg_scale": 2.5,
         "audio_magpie.temperature": 0.6,
         "audio_magpie.seed": 42,
     }
+
+    bark = resolve_case(
+        ManifestCatalog().resolve("bark-small"),
+        tmp_path / "bark.trtfb",
+    )
+    assert bark.request["seed"] == 0
+    assert bark.sources["request.seed"] == "model testcase"
+
+    qwen3_omni = resolve_case(
+        ManifestCatalog().resolve("qwen3-omni-30b-a3b-instruct"),
+        tmp_path / "qwen3-omni.trtfb",
+    )
+    assert qwen3_omni.request["seed"] == 42
+    assert qwen3_omni.sources["request.seed"] == "model testcase"
+
+
+def test_seeded_ready_profiles_preserve_seed_in_public_request(tmp_path: Path) -> None:
+    def declares_seed(value: object) -> bool:
+        if not isinstance(value, Mapping):
+            return False
+        return any(
+            name in {"seed", "seeds"} or declares_seed(item)
+            for name, item in value.items()
+        )
+
+    missing: list[str] = []
+    for entry in ManifestCatalog().entries():
+        if entry.status != "ready" or entry.model is None:
+            continue
+        testcase = entry.model.testcases[0]
+        seed_contract = {
+            name: testcase[name]
+            for name in ("seed", "seeds", "inputs", "determinism", "runtime_config")
+            if name in testcase
+        }
+        if not declares_seed(seed_contract):
+            continue
+        case = resolve_case(entry.model, tmp_path / f"{entry.name}.trtfb")
+        if not {"seed", "seeds"} & set(case.request):
+            missing.append(entry.name)
+
+    assert missing == []
 
 
 def test_text_generation_preserves_sampling_contract(tmp_path: Path) -> None:

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -545,6 +545,7 @@ def _validate_baseline(case: Mapping[str, Any]) -> None:
         raise PerfMatrixError(f"case {case['id']} baseline experts implementation is invalid")
     output_contract = baseline.get("output_contract", "exact-token-ids")
     if output_contract not in {
+        "audio-duration",
         "audio-shape",
         "exact-token-ids",
         "exact-text",
@@ -556,6 +557,17 @@ def _validate_baseline(case: Mapping[str, Any]) -> None:
         "token-agreement",
     }:
         raise PerfMatrixError(f"case {case['id']} baseline output contract is invalid")
+    if output_contract == "audio-duration":
+        limit = baseline.get("max_audio_duration_relative_difference")
+        if (
+            isinstance(limit, bool)
+            or not isinstance(limit, (int, float))
+            or not 0.0 <= float(limit) <= 1.0
+        ):
+            raise PerfMatrixError(
+                f"case {case['id']} audio-duration contract has an invalid "
+                "relative-difference limit"
+            )
     if output_contract == "token-agreement":
         for name in ("min_positional_token_agreement", "max_normalized_edit_distance"):
             value = baseline.get(name)
@@ -1565,6 +1577,28 @@ def _output_contract(
         )
         matched = None not in left_shape and left_shape == right_shape
         return matched, "audio output shape differs" if not matched else ""
+    if contract == "audio-duration":
+        left_samples = left.get("num_samples", left.get("audio_samples"))
+        right_samples = right.get("num_samples", right.get("audio_samples"))
+        left_rate = left.get("sample_rate")
+        right_rate = right.get("sample_rate")
+        values = (left_samples, right_samples, left_rate, right_rate)
+        if any(
+            isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0
+            for value in values
+        ):
+            return False, "audio duration metadata is incomplete"
+        if left_rate != right_rate:
+            return False, "audio sample rate differs"
+        relative_difference = abs(float(left_samples) - float(right_samples)) / float(
+            right_samples
+        )
+        limit = float(case["baseline"]["max_audio_duration_relative_difference"])
+        matched = relative_difference <= limit
+        return (
+            matched,
+            "audio duration differs by more than the configured contract" if not matched else "",
+        )
     if contract == "media-shape":
         names = ("height", "width", "channels")
         media_type = right.get("media_type")

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -545,7 +545,6 @@ def _validate_baseline(case: Mapping[str, Any]) -> None:
         raise PerfMatrixError(f"case {case['id']} baseline experts implementation is invalid")
     output_contract = baseline.get("output_contract", "exact-token-ids")
     if output_contract not in {
-        "audio-duration",
         "audio-shape",
         "exact-token-ids",
         "exact-text",
@@ -557,17 +556,6 @@ def _validate_baseline(case: Mapping[str, Any]) -> None:
         "token-agreement",
     }:
         raise PerfMatrixError(f"case {case['id']} baseline output contract is invalid")
-    if output_contract == "audio-duration":
-        limit = baseline.get("max_audio_duration_relative_difference")
-        if (
-            isinstance(limit, bool)
-            or not isinstance(limit, (int, float))
-            or not 0.0 <= float(limit) <= 1.0
-        ):
-            raise PerfMatrixError(
-                f"case {case['id']} audio-duration contract has an invalid "
-                "relative-difference limit"
-            )
     if output_contract == "token-agreement":
         for name in ("min_positional_token_agreement", "max_normalized_edit_distance"):
             value = baseline.get(name)
@@ -1577,28 +1565,6 @@ def _output_contract(
         )
         matched = None not in left_shape and left_shape == right_shape
         return matched, "audio output shape differs" if not matched else ""
-    if contract == "audio-duration":
-        left_samples = left.get("num_samples", left.get("audio_samples"))
-        right_samples = right.get("num_samples", right.get("audio_samples"))
-        left_rate = left.get("sample_rate")
-        right_rate = right.get("sample_rate")
-        values = (left_samples, right_samples, left_rate, right_rate)
-        if any(
-            isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0
-            for value in values
-        ):
-            return False, "audio duration metadata is incomplete"
-        if left_rate != right_rate:
-            return False, "audio sample rate differs"
-        relative_difference = abs(float(left_samples) - float(right_samples)) / float(
-            right_samples
-        )
-        limit = float(case["baseline"]["max_audio_duration_relative_difference"])
-        matched = relative_difference <= limit
-        return (
-            matched,
-            "audio duration differs by more than the configured contract" if not matched else "",
-        )
     if contract == "media-shape":
         names = ("height", "width", "channels")
         media_type = right.get("media_type")


### PR DESCRIPTION
## Background

The Bark and Magpie release comparisons allowed stochastic end-of-sequence decisions to change the amount of audio generated by the candidate and reference. Bark also dropped the testcase seed before invoking TRTMC, while Magpie's NeMo reference ignored the public `max_new_tokens` workload cap.

The Magpie investigation exposed a separate runtime-config issue: failure to write the optional effective-config sidecar next to a read-only bundle discarded an otherwise valid resolved config and silently fell back to schema defaults.

## Exit Criteria

- Bark candidate and reference consume the same seed and fixed 128-token semantic workload.
- Magpie candidate and reference consume the same seed and fixed 256-frame decoder workload.
- The strict `audio-shape` contract verifies identical sample rate and sample count before latency comparison.
- A read-only bundle cannot disable successfully resolved session config merely because its optional sidecar is unwritable.
- Other ready profiles that declare an audio seed preserve it in the public benchmark request.

## Implementation

- Propagate audio seeds from testcase inputs, testcase fields, determinism metadata, or namespaced runtime config into the benchmark request.
- Make the Bark and Magpie runtimes honor request seeds ahead of session-level fallbacks.
- Set the Bark release workload to 128 semantic tokens and map it to Hugging Face Bark's `semantic_max_new_tokens`.
- Set the Magpie release workload to 256 frames and map it to NeMo's `inference_parameters.max_decoder_steps`.
- Keep resolved runtime config active when writing the diagnostic effective-config sidecar fails.
- Add catalog-wide seed coverage plus focused Python and C++ regression tests.

## Validation

- `python3 -m pytest -q tests/tools/test_perf_matrix.py tests/tools/test_trtmc_bench.py`: 137 passed.
- `python3 -m pytest -q tests/tools/test_model_plugin_encapsulation_static.py`: 157 passed.
- GB300 CTest for `test_config_cli_support` and `test_magpie_generation_plan`: 2 passed.
- Read-only bundle smoke, `trtmc inspect ... --set audio_magpie.seed=42`: returned success after reporting the unwritable sidecar and continued with resolved config.
- Ruff, clang-format dry-run, legal-header, family-coverage, and cyclomatic-complexity checks passed.
- GitHub Premerge CI passed at `a566f942`, including clean-container unit tests, direct Bark and Magpie model proofs, fallback model proofs, and the combined certification report.
- Earlier full tools suite on this branch: 2105 passed; one unrelated model-proof reflink test failed because the sandbox filesystem does not support `cp --reflink`.
- Final Bark GB300 release row at `f00524ee` was green:
  - 3 warmups and 10 measured iterations on each side.
  - Both sides used `seed=0`, `max_new_tokens=128`, and produced 61,440 samples at 24 kHz.
  - Candidate/reference p50 was 2,601.26/5,925.41 ms.
- Final Magpie GB300 release row at `a566f942` was green:
  - 3 warmups and 10 measured iterations on each side with workload digest `01ff452f55dd72f1f41e6ef5061979f698f1d13babe29252dcb6f16be7afed93`.
  - Both sides used `seed=42`, `max_new_tokens=256`, and produced 262,144 samples at 22.05 kHz.
  - Candidate/reference p50 was 1,769.86/11,023.97 ms; reference/candidate ratio was 6.229.
  - Candidate worker provenance matched the PR head.

## Notes For Future Readers

- Same numeric seed does not imply identical sampling sequences across C++ and Python frameworks.
- Fixed work caps before natural EOS make the compared work reproducible while retaining the strict output-shape guard.
- The effective-config sidecar is diagnostic output; failure to write it must not alter runtime behavior.
- Review the request path in this order: release workload, task adapter, benchmark worker `GenerateConfig`, model seed/cap resolution, then the reference loader.
