### PR TITLE
fix(perf): exclude qwen3 moe 30b profile

### DIFF
--- a/benchmarks/performance/README.md
+++ b/benchmarks/performance/README.md
@@ -12,8 +12,9 @@ frameworks run in separate Python processes and do not add dependencies to
 
 The suite contains one row for every release-relevant single-process model
 profile marked `ready` in the benchmark catalog. Profiles whose names contain an
-`l0` segment are shorter PR-smoke duplicates and are deliberately excluded. The
-suite currently has 105 model-profile comparisons across 76 families and 77
+`l0` segment are shorter PR-smoke duplicates and are deliberately excluded.
+Other temporary omissions must be named under `excluded_profiles` with a reason.
+The suite currently has 104 model-profile comparisons across 76 families and 77
 `(family, operation)` contracts because some families expose multiple profiles
 and `eagle_vlm` exposes both `embed` and `rerank`. Catalog profiles marked
 `distributed` require their own multi-process launch and are not silently
@@ -109,9 +110,19 @@ additional_profiles:
 The resolved row uses `qwen3-0.6b-fp8` as both its model profile and testcase,
 while retaining the reviewed Qwen timing, reference, and output contracts. A
 profile with different replay inputs or reference assets declares those
-overrides in the same block. The coverage check requires every non-L0 ready
-single-process catalog profile exactly once and rejects L0 entries in the suite
-as extras.
+overrides in the same block.
+
+A ready profile can be omitted only with an explicit reason:
+
+```yaml
+excluded_profiles:
+  - model: qwen3-moe-30b-a3b
+    reason: Excluded while its single-process TensorRT engine deserialization failure is unresolved.
+```
+
+The coverage check requires every non-L0 ready single-process catalog profile to
+appear exactly once or in `excluded_profiles`. It rejects L0 entries, unknown
+exclusions, and profiles that are both configured and excluded.
 
 Suite-level `defaults.measurement` avoids repeating warmup and iteration counts.
 The fully resolved workload and measurement values are recorded in `results.json`.

--- a/benchmarks/performance/release.yaml
+++ b/benchmarks/performance/release.yaml
@@ -17,6 +17,10 @@ defaults:
     input_preparation_included: true
     asset_loading_included: false
 
+excluded_profiles:
+  - model: qwen3-moe-30b-a3b
+    reason: Excluded while its single-process TensorRT engine deserialization failure is unresolved.
+
 entries:
   - id: albert.encode
     family: albert
@@ -708,9 +712,9 @@ entries:
   - id: qwen_moe.generate
     family: qwen_moe
     operation: generate
-    model: qwen3-moe-30b-a3b
+    model: qwen3-moe-tiny-random
     workload:
-      testcase: qwen3-moe-30b-a3b
+      testcase: qwen3-moe-tiny-random
     baseline:
       runner: hf-transformers
       mode: torch-compile
@@ -985,8 +989,6 @@ additional_profiles:
     inherit: qwen.generate
   - model: qwen3-4b-instruct-2507
     inherit: qwen.generate
-  - model: qwen3-moe-tiny-random
-    inherit: qwen_moe.generate
   - model: riva-translate-4b
     inherit: mistral.generate
   - model: roberta-base

--- a/tests/tools/test_perf_matrix.py
+++ b/tests/tools/test_perf_matrix.py
@@ -235,22 +235,29 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     raw_suite = yaml.safe_load(SUITE.read_text(encoding="utf-8"))
     raw_entries = raw_suite["entries"]
     raw_additional = raw_suite["additional_profiles"]
+    excluded_profiles = perf_matrix._excluded_profiles(suite)
     ready_profiles = {
         entry.name
         for entry in perf_matrix.ManifestCatalog().entries()
         if entry.status == "ready" and not perf_matrix._is_l0_profile(entry.name)
     }
 
-    perf_matrix._validate_coverage(cases)
+    perf_matrix._validate_coverage(cases, excluded_profiles)
 
-    assert len(cases) == 105
+    assert len(cases) == 104
     assert len(raw_entries) == 77
-    assert len(raw_additional) == 28
+    assert len(raw_additional) == 27
+    assert excluded_profiles == {
+        "qwen3-moe-30b-a3b": (
+            "Excluded while its single-process TensorRT engine deserialization "
+            "failure is unresolved."
+        )
+    }
     assert all(set(entry["workload"]) <= {"testcase", "request"} for entry in raw_entries)
     assert all(entry["workload"].get("testcase") for entry in raw_entries)
     assert all(entry.get("model") and entry.get("inherit") for entry in raw_additional)
     assert not any("priority" in entry for entry in raw_entries)
-    assert {case["model"] for case in cases} == ready_profiles
+    assert {case["model"] for case in cases} == ready_profiles - set(excluded_profiles)
     assert not any(perf_matrix._is_l0_profile(case["model"]) for case in cases)
     assert len({(case["family"], case["operation"]) for case in cases}) == 77
     assert len({case["family"] for case in cases}) == 76
@@ -260,7 +267,7 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     ]
     assert Counter(perf_matrix._candidate_timing_scope(case) for case in cases) == {
         "model_call_wall": 22,
-        "public_pipeline_call_wall": 83,
+        "public_pipeline_call_wall": 82,
     }
     assert {
         case["id"]
@@ -291,6 +298,7 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     )
     assert by_id["mixtral.generate"]["baseline"]["experts_implementation"] == "batched_mm"
     assert by_id["phi_moe.generate"]["baseline"]["experts_implementation"] == "batched_mm"
+    assert by_id["qwen_moe.generate"]["model"] == "qwen3-moe-tiny-random"
     assert by_id["qwen_moe.generate"]["baseline"]["experts_implementation"] == "batched_mm"
     assert by_id["phi_moe.generate"]["baseline"]["output_contract"] == "exact-text"
     assert by_id["opt.generate"]["workload"]["request"]["max_new_tokens"] == 10
@@ -338,6 +346,41 @@ def test_release_suite_covers_every_non_l0_ready_model_profile() -> None:
     assert diffusion_baseline["mode"] == "hf-eager"
     assert diffusion_baseline["model_class"] == "auto"
     assert diffusion_baseline["generation_method"] == "ar-generate"
+
+
+def test_release_suite_rejects_unknown_explicit_exclusion() -> None:
+    suite = perf_matrix._read_yaml(SUITE)
+    cases = perf_matrix._cases(suite)
+    exclusions = {
+        **perf_matrix._excluded_profiles(suite),
+        "unknown-profile": "Invalid test exclusion.",
+    }
+
+    with pytest.raises(
+        perf_matrix.PerfMatrixError,
+        match="invalid-exclusion=unknown-profile",
+    ):
+        perf_matrix._validate_coverage(cases, exclusions)
+
+
+def test_release_suite_rejects_a_configured_explicit_exclusion() -> None:
+    suite = perf_matrix._read_yaml(SUITE)
+    cases = perf_matrix._cases(suite)
+    qwen_moe = next(case for case in cases if case["id"] == "qwen_moe.generate")
+    cases.append(
+        {
+            **qwen_moe,
+            "id": "qwen_moe.generate@qwen3-moe-30b-a3b",
+            "model": "qwen3-moe-30b-a3b",
+            "workload": {"testcase": "qwen3-moe-30b-a3b"},
+        }
+    )
+
+    with pytest.raises(
+        perf_matrix.PerfMatrixError,
+        match="excluded-and-configured=qwen3-moe-30b-a3b",
+    ):
+        perf_matrix._validate_coverage(cases, perf_matrix._excluded_profiles(suite))
 
 
 def test_checked_in_gb300_environment_is_ci_runnable() -> None:
@@ -871,7 +914,7 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert not scratch_root.exists()
     results = json.loads((output / "results.json").read_text(encoding="utf-8"))
     rows = {row["id"]: row for row in results["cases"]}
-    assert len(rows) == 105
+    assert len(rows) == 104
     assert results["environment_config"]["name"] == "test-gb300"
     assert (
         results["environment_config"]["execution"]["minimum_gpu_free_fraction"]
@@ -887,7 +930,17 @@ def test_run_consolidates_results_and_records_replayable_commands(
     expected_catalog_coverage = {
         "total_profiles": len(catalog_entries),
         "ready_profiles": catalog_counts["ready"],
-        "release_profiles": catalog_counts["ready"] - excluded_l0_profiles,
+        "release_profiles": catalog_counts["ready"] - excluded_l0_profiles - 1,
+        "explicitly_excluded_profiles": 1,
+        "explicit_exclusions": [
+            {
+                "model": "qwen3-moe-30b-a3b",
+                "reason": (
+                    "Excluded while its single-process TensorRT engine "
+                    "deserialization failure is unresolved."
+                ),
+            }
+        ],
         "excluded_l0_profiles": excluded_l0_profiles,
         "distributed_profiles": catalog_counts["distributed"],
         "other_profiles": sum(
@@ -925,8 +978,9 @@ def test_run_consolidates_results_and_records_replayable_commands(
     assert ">gpt2<" in report
     assert "HF eager" in report
     assert "76 families" in report
-    assert "105 model-profile comparisons" in report
-    assert "105 single-process profiles" in report
+    assert "104 model-profile comparisons" in report
+    assert "104 single-process profiles" in report
+    assert "1 explicitly excluded profile" in report
     assert (
         f"{expected_catalog_coverage['excluded_l0_profiles']} duplicate L0 profiles are excluded"
     ) in report

--- a/tools/perf_matrix.py
+++ b/tools/perf_matrix.py
@@ -379,6 +379,34 @@ def _cases(suite: Mapping[str, Any]) -> list[dict[str, Any]]:
     return cases
 
 
+def _excluded_profiles(suite: Mapping[str, Any]) -> dict[str, str]:
+    configured = suite.get("excluded_profiles", [])
+    if not isinstance(configured, list):
+        raise PerfMatrixError("suite excluded_profiles must be a list")
+    exclusions: dict[str, str] = {}
+    for raw in configured:
+        if not isinstance(raw, Mapping):
+            raise PerfMatrixError("every excluded profile must be an object")
+        unsupported = sorted(set(raw) - {"model", "reason"})
+        if unsupported:
+            raise PerfMatrixError(
+                "excluded profile has unsupported fields: " + ", ".join(unsupported)
+            )
+        model = raw.get("model")
+        reason = raw.get("reason")
+        if not isinstance(model, str) or not model.strip():
+            raise PerfMatrixError("excluded profile model must be a non-empty string")
+        if not isinstance(reason, str) or not reason.strip():
+            raise PerfMatrixError(
+                f"excluded profile {model} reason must be a non-empty string"
+            )
+        model = model.strip()
+        if model in exclusions:
+            raise PerfMatrixError(f"duplicate excluded profile: {model}")
+        exclusions[model] = reason.strip()
+    return exclusions
+
+
 def _additional_profile_cases(
     base_cases: Sequence[Mapping[str, Any]],
     configured: Sequence[Any],
@@ -621,16 +649,27 @@ def _is_l0_profile(name: str) -> bool:
     return L0_PROFILE_PATTERN.search(name) is not None
 
 
-def _validate_coverage(cases: Sequence[Mapping[str, Any]]) -> None:
-    expected = {
+def _validate_coverage(
+    cases: Sequence[Mapping[str, Any]],
+    excluded_profiles: Iterable[str] = (),
+) -> None:
+    catalog_profiles = {
         entry.name: (entry.family, entry.operation)
         for entry in ManifestCatalog().entries()
         if entry.status == "ready" and not _is_l0_profile(entry.name)
     }
+    excluded = set(excluded_profiles)
+    invalid_exclusions = sorted(excluded - set(catalog_profiles))
+    expected = {
+        model: contract
+        for model, contract in catalog_profiles.items()
+        if model not in excluded
+    }
     actual_models = [str(case["model"]) for case in cases]
     actual = set(actual_models)
     missing = sorted(set(expected) - actual)
-    extra = sorted(actual - set(expected))
+    extra = sorted(actual - set(catalog_profiles))
+    excluded_in_cases = sorted(actual & excluded)
     duplicates = sorted(
         model for model, count in Counter(actual_models).items() if count > 1
     )
@@ -638,17 +677,31 @@ def _validate_coverage(cases: Sequence[Mapping[str, Any]]) -> None:
         (
             model,
             f"{case['family']}.{case['operation']}",
-            f"{expected[model][0]}.{expected[model][1]}",
+            f"{catalog_profiles[model][0]}.{catalog_profiles[model][1]}",
         )
         for case in cases
-        if (model := str(case["model"])) in expected
-        and (str(case["family"]), str(case["operation"])) != expected[model]
+        if (model := str(case["model"])) in catalog_profiles
+        and (str(case["family"]), str(case["operation"])) != catalog_profiles[model]
     )
-    if missing or extra or duplicates or mismatched:
-        details = _coverage_details(missing, extra, duplicates, mismatched)
+    if (
+        missing
+        or extra
+        or duplicates
+        or mismatched
+        or invalid_exclusions
+        or excluded_in_cases
+    ):
+        details = _coverage_details(
+            missing,
+            extra,
+            duplicates,
+            mismatched,
+            invalid_exclusions,
+            excluded_in_cases,
+        )
         raise PerfMatrixError(
             "suite profile coverage does not match the release-ready catalog "
-            "(L0 duplicates excluded): " + "; ".join(details)
+            "(configured and L0 exclusions applied): " + "; ".join(details)
         )
 
 
@@ -657,6 +710,8 @@ def _coverage_details(
     extra: Sequence[str],
     duplicates: Sequence[str],
     mismatched: Sequence[tuple[str, str, str]],
+    invalid_exclusions: Sequence[str],
+    excluded_in_cases: Sequence[str],
 ) -> list[str]:
     details = []
     if missing:
@@ -670,6 +725,10 @@ def _coverage_details(
             "family-operation="
             + ",".join(f"{model}:{actual}!={expected}" for model, actual, expected in mismatched)
         )
+    if invalid_exclusions:
+        details.append("invalid-exclusion=" + ",".join(invalid_exclusions))
+    if excluded_in_cases:
+        details.append("excluded-and-configured=" + ",".join(excluded_in_cases))
     return details
 
 
@@ -747,6 +806,7 @@ def _initial_results(
 ) -> dict[str, Any]:
     catalog_entries = ManifestCatalog().entries()
     catalog_counts = Counter(entry.status for entry in catalog_entries)
+    explicit_exclusions = _excluded_profiles(suite)
     excluded_l0_profiles = sum(
         entry.status == "ready" and _is_l0_profile(entry.name)
         for entry in catalog_entries
@@ -772,7 +832,16 @@ def _initial_results(
         "catalog_coverage": {
             "total_profiles": sum(catalog_counts.values()),
             "ready_profiles": catalog_counts["ready"],
-            "release_profiles": catalog_counts["ready"] - excluded_l0_profiles,
+            "release_profiles": (
+                catalog_counts["ready"]
+                - excluded_l0_profiles
+                - len(explicit_exclusions)
+            ),
+            "explicitly_excluded_profiles": len(explicit_exclusions),
+            "explicit_exclusions": [
+                {"model": model, "reason": reason}
+                for model, reason in explicit_exclusions.items()
+            ],
             "excluded_l0_profiles": excluded_l0_profiles,
             "distributed_profiles": catalog_counts["distributed"],
             "other_profiles": sum(
@@ -2278,8 +2347,15 @@ def _report_html(results: Mapping[str, Any]) -> str:
     ready_profiles = int(catalog.get("ready_profiles", len(rows)))
     release_profiles = int(catalog.get("release_profiles", len(rows)))
     excluded_l0_profiles = int(catalog.get("excluded_l0_profiles", 0))
+    explicitly_excluded_profiles = int(
+        catalog.get("explicitly_excluded_profiles", 0)
+    )
     distributed_profiles = int(catalog.get("distributed_profiles", 0))
     other_profiles = int(catalog.get("other_profiles", 0))
+    explicit_exclusion_label = (
+        f"{explicitly_excluded_profiles} explicitly excluded profile"
+        + ("s" if explicitly_excluded_profiles != 1 else "")
+    )
     bundle_preparation_summary = html.escape(_bundle_preparation_summary(rows))
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
@@ -2296,7 +2372,7 @@ th{{background:#e5e7eb}} tr:nth-child(even){{background:#f9fafb}} code{{font-siz
 </style></head><body>
 <h1>TRTMC performance matrix</h1>
 <p class="meta">Generated {generated}. {family_count} families across {len(rows)} model-profile comparisons.{repeated_note}</p>
-<p class="meta">Release matrix coverage: {release_profiles} single-process profiles. {excluded_l0_profiles} duplicate L0 profiles are excluded from the {ready_profiles} ready catalog profiles. {distributed_profiles} distributed profiles require a separate multi-process run and are outside this report. {other_profiles} other or unsupported profiles.</p>
+<p class="meta">Release matrix coverage: {release_profiles} single-process profiles. {explicit_exclusion_label} and {excluded_l0_profiles} duplicate L0 profiles are excluded from the {ready_profiles} ready catalog profiles. {distributed_profiles} distributed profiles require a separate multi-process run and are outside this report. {other_profiles} other or unsupported profiles.</p>
 <p class="meta">Timing contracts were validated before execution for {preflight_count} comparisons. A row is classified only when its recorded TRTMC and reference policies match that contract.</p>
 <p class="meta">Times are the p50 wall time from the recorded timed samples. Measured scope states the exact recorded boundary and the work included and excluded on each side.</p>
 <p class="meta">{bundle_preparation_summary}</p>
@@ -2482,7 +2558,7 @@ def _load_suite_request(
     suite_path = arguments.suite.resolve()
     suite = _read_yaml(suite_path)
     cases = _cases(suite)
-    _validate_coverage(cases)
+    _validate_coverage(cases, _excluded_profiles(suite))
     selected = _selected_cases(cases, arguments.entry)
     if not selected:
         raise PerfMatrixError("selection contains no entries")
@@ -2557,7 +2633,7 @@ def _resume(arguments: argparse.Namespace) -> int:
         raise PerfMatrixError("cannot resume because the repository revision changed")
     suite = _read_yaml(suite_path)
     cases = _cases(suite)
-    _validate_coverage(cases)
+    _validate_coverage(cases, _excluded_profiles(suite))
     selected_ids = results.get("selected_entry_ids")
     if not isinstance(selected_ids, list) or not all(
         isinstance(value, str) for value in selected_ids


### PR DESCRIPTION
## Background

The `qwen3-moe-30b-a3b` single-process release comparison does not produce usable timings because TensorRT engine deserialization fails. Future release matrices should omit that failed row without dropping `qwen_moe` coverage.

## Exit Criteria

- `qwen3-moe-30b-a3b` is not run or rendered in the release performance matrix.
- `qwen_moe` remains covered by `qwen3-moe-tiny-random`.
- Intentional ready-profile omissions are explicit, reasoned, and coverage-validated.

## Implementation

- Add suite-level `excluded_profiles` entries with required reasons.
- Reject unknown exclusions and profiles that are both configured and excluded.
- Use `qwen3-moe-tiny-random` as the base `qwen_moe.generate` comparison and record the excluded profile in result coverage metadata.
- Update report coverage text, documentation, and matrix count assertions for 104 comparisons.

## Validation

- `python3 -m pytest -q tests/tools/test_perf_matrix.py`: passed, 75 tests.
- `CI_BASE_REF=github/main python3 -m tools.ci pipeline source-quality`: passed, including 157 architecture-contract tests and the CCN 10 gate.
- `ruff check tools/perf_matrix.py tests/tools/test_perf_matrix.py`: passed.
- `python3 tools/legal_headers.py --check`: passed with no findings.
- `git diff --check`: passed.

## Notes For Future Readers

- Once the 30B engine deserialization issue is fixed, remove its exclusion and restore it as an additional `qwen_moe.generate` profile.
