### PR TITLE
fix(runtime): release bundle file cache after reads

### DIFF
--- a/src/bundle/bundle_format.cpp
+++ b/src/bundle/bundle_format.cpp
@@ -12,9 +12,15 @@
 #include <cstring>
 #include <fstream>
 #include <limits>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <vector>
+
+#if defined(__linux__)
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 namespace trtmc {
 
@@ -212,7 +218,8 @@ std::uint64_t checked_section_file_offset(const BundleSectionInfo& section,
     return data_start + section.offset;
 }
 
-std::ifstream open_bundle_section(const std::string& path, const BundleSectionInfo& section) {
+std::ifstream open_bundle_section(const std::string& path, const BundleSectionInfo& section,
+                                  std::uint64_t& file_offset_out) {
     std::ifstream in(path, std::ios::binary | std::ios::ate);
     if (!in)
         throw std::runtime_error("Failed to open bundle file: " + path);
@@ -226,12 +233,70 @@ std::ifstream open_bundle_section(const std::string& path, const BundleSectionIn
     const std::uint64_t data_start = read_bundle_data_start(in, path, file_size);
     const std::uint64_t file_offset =
         checked_section_file_offset(section, data_start, file_size, path);
+    file_offset_out = file_offset;
     in.seekg(static_cast<std::streamoff>(file_offset));
     if (!in) {
         throw std::runtime_error("Failed to seek to bundle section '" + section.name +
                                  "' in: " + path);
     }
     return in;
+}
+
+#if defined(__linux__)
+struct FileCacheRange {
+    off_t offset;
+    off_t size;
+};
+
+std::optional<FileCacheRange> aligned_file_cache_range(std::uint64_t file_offset,
+                                                       std::uint64_t size) noexcept {
+    const long raw_page_size = sysconf(_SC_PAGESIZE);
+    if (size == 0 || raw_page_size <= 0 ||
+        file_offset > std::numeric_limits<std::uint64_t>::max() - size) {
+        return std::nullopt;
+    }
+
+    const auto page_size = static_cast<std::uint64_t>(raw_page_size);
+    const std::uint64_t aligned_offset = file_offset - (file_offset % page_size);
+    std::uint64_t aligned_end = file_offset + size;
+    const std::uint64_t end_remainder = aligned_end % page_size;
+    if (end_remainder != 0) {
+        const std::uint64_t padding = page_size - end_remainder;
+        if (aligned_end > std::numeric_limits<std::uint64_t>::max() - padding)
+            return std::nullopt;
+        aligned_end += padding;
+    }
+
+    const std::uint64_t aligned_size = aligned_end - aligned_offset;
+    const auto max_advice_value = static_cast<std::uint64_t>(std::numeric_limits<off_t>::max());
+    if (aligned_offset > max_advice_value || aligned_size > max_advice_value)
+        return std::nullopt;
+    return FileCacheRange{static_cast<off_t>(aligned_offset), static_cast<off_t>(aligned_size)};
+}
+#endif
+
+void release_bundle_section_cache(const std::string& path, std::uint64_t file_offset,
+                                  std::uint64_t size) noexcept {
+#if defined(__linux__)
+    const auto range = aligned_file_cache_range(file_offset, size);
+    if (!range)
+        return;
+
+    const int descriptor = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+    if (descriptor < 0)
+        return;
+
+    // Bundle data has already been copied into an owned buffer (or output
+    // stream), so retaining a second copy in the Linux page cache only raises
+    // peak memory. This is especially costly when GPU framebuffer is exposed
+    // as an OS-managed NUMA node.
+    (void)posix_fadvise(descriptor, range->offset, range->size, POSIX_FADV_DONTNEED);
+    close(descriptor);
+#else
+    (void)path;
+    (void)file_offset;
+    (void)size;
+#endif
 }
 
 } // namespace
@@ -285,10 +350,11 @@ BundleFile ReadBundleFile(const std::string& path) {
         if (!in) {
             throw std::runtime_error("Failed to read bundle section '" + name + "' from: " + path);
         }
-
         bundle.sections.push_back(std::move(section));
     }
 
+    in.close();
+    release_bundle_section_cache(path, 0, file_size);
     return bundle;
 }
 
@@ -320,7 +386,8 @@ BundleInfo ReadBundleHeader(const std::string& path) {
 }
 
 std::vector<char> ReadBundleSection(const std::string& path, const BundleSectionInfo& section) {
-    std::ifstream in = open_bundle_section(path, section);
+    std::uint64_t file_offset = 0;
+    std::ifstream in = open_bundle_section(path, section, file_offset);
     std::vector<char> data(static_cast<std::size_t>(section.size));
     if (!data.empty()) {
         in.read(data.data(), static_cast<std::streamsize>(data.size()));
@@ -329,12 +396,15 @@ std::vector<char> ReadBundleSection(const std::string& path, const BundleSection
         throw std::runtime_error("Failed to read bundle section '" + section.name +
                                  "' from: " + path);
     }
+    in.close();
+    release_bundle_section_cache(path, file_offset, section.size);
     return data;
 }
 
 void CopyBundleSection(const std::string& path, const BundleSectionInfo& section,
                        std::ostream& output) {
-    std::ifstream in = open_bundle_section(path, section);
+    std::uint64_t file_offset = 0;
+    std::ifstream in = open_bundle_section(path, section, file_offset);
     std::array<char, 1024 * 1024> buffer{};
     std::uint64_t remaining = section.size;
     while (remaining != 0) {
@@ -352,6 +422,8 @@ void CopyBundleSection(const std::string& path, const BundleSectionInfo& section
         }
         remaining -= static_cast<std::uint64_t>(chunk_size);
     }
+    in.close();
+    release_bundle_section_cache(path, file_offset, section.size);
 }
 
 bool HasBundleMagic(const std::string& path) {

--- a/tests/cpp/test_bundle_format.cpp
+++ b/tests/cpp/test_bundle_format.cpp
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <chrono>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -41,7 +42,15 @@
 #include <stdlib.h>
 #include <streambuf>
 #include <string>
+#include <thread>
 #include <vector>
+
+#if defined(__linux__)
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
 
 static int failures = 0;
 
@@ -331,6 +340,103 @@ static void test_copy_section_streams_in_bounded_chunks() {
     trtmc_test::remove_all_safe(tmp);
 }
 
+#if defined(__linux__)
+static std::filesystem::path make_cache_test_temp_dir() {
+    const auto pattern_path = std::filesystem::current_path() / "trtfb_cache_test_XXXXXX";
+    const std::string pattern = pattern_path.string();
+    std::vector<char> mutable_pattern(pattern.begin(), pattern.end());
+    mutable_pattern.push_back('\0');
+    char* dir = mkdtemp(mutable_pattern.data());
+    if (dir == nullptr) {
+        throw std::runtime_error(std::string("mkdtemp failed: ") + std::strerror(errno));
+    }
+    return std::filesystem::path(dir);
+}
+
+static double resident_fraction(const std::string& path, std::uint64_t offset, std::uint64_t size) {
+    const int descriptor = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+    if (descriptor < 0)
+        throw std::runtime_error("open failed while checking bundle residency");
+
+    struct stat metadata{};
+    if (fstat(descriptor, &metadata) != 0 || metadata.st_size <= 0) {
+        close(descriptor);
+        throw std::runtime_error("fstat failed while checking bundle residency");
+    }
+
+    const auto file_size = static_cast<std::size_t>(metadata.st_size);
+    void* mapping = mmap(nullptr, file_size, PROT_NONE, MAP_SHARED, descriptor, 0);
+    if (mapping == MAP_FAILED) {
+        close(descriptor);
+        throw std::runtime_error("mmap failed while checking bundle residency");
+    }
+
+    const auto page_size = static_cast<std::uint64_t>(sysconf(_SC_PAGESIZE));
+    std::vector<unsigned char> residency((file_size + page_size - 1) / page_size);
+    if (mincore(mapping, file_size, residency.data()) != 0) {
+        munmap(mapping, file_size);
+        close(descriptor);
+        throw std::runtime_error("mincore failed while checking bundle residency");
+    }
+
+    munmap(mapping, file_size);
+    close(descriptor);
+
+    const std::uint64_t first_page = (offset + page_size - 1) / page_size;
+    const std::uint64_t end_page = (offset + size) / page_size;
+    if (first_page >= end_page)
+        throw std::runtime_error("bundle residency range has no complete pages");
+
+    std::size_t resident_pages = 0;
+    for (std::uint64_t page = first_page; page < end_page; ++page)
+        resident_pages += residency[page] & 1U;
+    return static_cast<double>(resident_pages) / static_cast<double>(end_page - first_page);
+}
+
+static bool cache_residency_drops_below(const std::string& path, std::uint64_t offset,
+                                        std::uint64_t size, double threshold) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    do {
+        if (resident_fraction(path, offset, size) < threshold)
+            return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    } while (std::chrono::steady_clock::now() < deadline);
+    return false;
+}
+
+static void test_read_bundle_file_drops_payload_cache() {
+    // Use the CTest build volume instead of the container overlay filesystem:
+    // overlayfs may accept POSIX_FADV_DONTNEED without exposing eviction through
+    // mincore, while production bundles live on a regular mounted filesystem.
+    const auto tmp = make_cache_test_temp_dir();
+    const auto path = (tmp / "cache-drop.trtfb").string();
+    std::vector<char> payload(8 * 1024 * 1024, 'C');
+    const std::string header =
+        "{\"model_id\":\"cache-drop\",\"sections\":{\"engine_plan\":{\"offset\":0,\"size\":" +
+        std::to_string(payload.size()) + "}}}";
+    write_bundle_with_sections(path, header, {payload});
+
+    // DONTNEED discards clean pages. Make the freshly written fixture match a
+    // stable model bundle before checking the runtime's cache release.
+    const int descriptor = open(path.c_str(), O_RDWR | O_CLOEXEC);
+    check(descriptor >= 0 && fsync(descriptor) == 0, "cache-drop fixture synced");
+    if (descriptor >= 0)
+        close(descriptor);
+
+    const std::uint64_t payload_offset = trtmc::kBundleHeaderOffset + header.size();
+    check(resident_fraction(path, payload_offset, payload.size()) > 0.9,
+          "cache-drop fixture starts resident");
+
+    const auto loaded = trtmc::ReadBundleFile(path);
+    check(loaded.sections.size() == 1 && loaded.sections.front().data == payload,
+          "cache-drop read preserves section data");
+    check(cache_residency_drops_below(path, payload_offset, payload.size(), 0.1),
+          "bundle payload cache dropped after read");
+
+    trtmc_test::remove_all_safe(tmp);
+}
+#endif
+
 static void test_sha256_known_vectors() {
     trtmc::internal::Sha256 empty;
     check(empty.hex_digest() == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -417,6 +523,9 @@ int main() {
     test_truncated_bundle_throws();
     test_max_batch_size_parse_and_back_compat();
     test_copy_section_streams_in_bounded_chunks();
+#if defined(__linux__)
+    test_read_bundle_file_drops_payload_cache();
+#endif
     test_sha256_known_vectors();
     test_sha256_boundaries_and_chunking();
 


### PR DESCRIPTION
## Background

Large `.trtfb` reads leave a second copy of the serialized engine in the Linux page cache after the data has already been copied into runtime-owned buffers. On systems where GPU framebuffer is exposed as an OS-managed NUMA node, those cached file pages reduce the memory available for TensorRT deserialization even when no compute process remains.

## Exit Criteria

- Release clean bundle payload pages after their contents have been copied or streamed.
- Preserve the loaded section data and existing bundle behavior.
- Cover the cache-release behavior with a Linux regression test.

## Implementation

- Close bundle input streams before issuing cache advice.
- Align advice ranges to the runtime page size and use `POSIX_FADV_DONTNEED` on Linux.
- Release the complete file after eager bundle reads and the exact payload range after section or streaming reads.
- Keep the behavior a no-op on non-Linux platforms.
- Add a `mincore` regression test that verifies section bytes remain valid while their file-backed pages are no longer resident.

## Validation

- `g++ -std=c++17 -O2 ... test_bundle_format.cpp ... && /tmp/test_bundle_format_page_cache_final`: passed.
- `ctest --test-dir build --output-on-failure -R "^(test_bundle_format|test_bundle_materialization|test_bundle_e2e|test_bundle_view|test_optimized_runtime_host)$"`: 5/5 passed on GB300.
- `pytest -q tests/tools/test_model_plugin_encapsulation_static.py tests/tools/test_test_impact.py`: 395 passed.
- `python3 tools/legal_headers.py --check`: passed with no findings.
- `python3 tools/check_cyclomatic_complexity.py src/bundle/bundle_format.cpp --max-ccn 10 --top 20 --fail-on-missing-lizard`: passed, maximum CCN 10.
- `clang-format --dry-run --Werror src/bundle/bundle_format.cpp tests/cpp/test_bundle_format.cpp`: passed.
- Qwen3-Omni GB300 stress validation started with only 62,305 MiB free framebuffer memory, completed TensorRT deserialization and audio generation, produced 58,965 samples, and released 96,598 MiB of deliberately populated bundle file cache.

## Notes For Future Readers

- Review `src/bundle/bundle_format.cpp` first, then the residency assertion in `tests/cpp/test_bundle_format.cpp`.
- Stream closure and page-size alignment are intentional: both are required for reliable reclamation on systems with 64 KiB pages.
