### PR TITLE
fix(validation): reserve continuation cache headroom

### DIFF
--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -3356,6 +3356,124 @@ def test_suite_build_cache_minimum_overrides_manifest_cache() -> None:
     assert task_eval.requested_build_max_cache_length(suite, model, 512) == 512
 
 
+def test_continuation_reserves_generation_cache_headroom() -> None:
+    assert (
+        task_eval.generation_cache_headroom(
+            scorer="continuation",
+            task_eval_config={},
+            generation={"max_new_tokens": 64},
+            max_new_tokens=None,
+        )
+        == 64
+    )
+    assert (
+        task_eval.generation_cache_headroom(
+            scorer="continuation",
+            task_eval_config={},
+            generation={"max_new_tokens": 64},
+            max_new_tokens=8,
+        )
+        == 8
+    )
+
+
+def test_non_continuation_only_reserves_explicit_generation_headroom() -> None:
+    generation = {"max_new_tokens": 8}
+
+    assert (
+        task_eval.generation_cache_headroom(
+            scorer="mcq",
+            task_eval_config={},
+            generation=generation,
+            max_new_tokens=None,
+        )
+        == 0
+    )
+    assert (
+        task_eval.generation_cache_headroom(
+            scorer="mcq",
+            task_eval_config={"build_generation_headroom": True},
+            generation=generation,
+            max_new_tokens=None,
+        )
+        == 8
+    )
+
+
+def test_eval_continuation_builds_for_prompt_and_generated_tokens(
+    tmp_path: Path, monkeypatch
+) -> None:
+    dataset = tmp_path / "mmlu.json"
+    _write_mmlu(dataset)
+    suite = task_eval.suite_by_id(
+        task_eval.load_suites(), "mmlu_continuation_parity"
+    )
+    model = {
+        "name": "decoder-small",
+        "hf_id": "example-org/decoder-small",
+        "bundle": "decoder-small.trtfb",
+        "max_cache_length": 256,
+        "precision": "fp32",
+        "trust_remote_code": False,
+        "build_args": {},
+        "quantization": {},
+    }
+    responses = [
+        {
+            "sample_id": "mmlu_000000",
+            "output_text": " A",
+            "generated_token_ids": [1],
+        },
+        {
+            "sample_id": "mmlu_000001",
+            "output_text": " B",
+            "generated_token_ids": [2],
+        },
+    ]
+
+    def fake_run_hf(_args, _model, work_dir):
+        task_eval.write_predictions(work_dir / "hf_predictions.json", responses)
+
+    def fake_ensure_bundle(*_args, **kwargs):
+        assert kwargs["max_cache_length"] == 445
+        bundle = kwargs["bundle_path"]
+        bundle.parent.mkdir(parents=True, exist_ok=True)
+        bundle.write_bytes(b"bundle")
+        return bundle, True
+
+    def fake_run_trtfb(args):
+        task_eval.write_predictions(
+            Path(args.work_dir) / "trtfb_predictions.json", responses
+        )
+
+    monkeypatch.setattr(task_eval, "max_prompt_token_length", lambda **_kwargs: 381)
+    monkeypatch.setattr(
+        task_eval, "run_hf_reference_subprocess", fake_run_hf
+    )
+    monkeypatch.setattr(task_eval, "ensure_bundle", fake_ensure_bundle)
+    monkeypatch.setattr(task_eval, "run_trtfb", fake_run_trtfb)
+    args = task_eval.build_arg_parser().parse_args(
+        [
+            "eval",
+            "--dataset",
+            str(dataset),
+            "--work-root",
+            str(tmp_path / "work"),
+            "--engine-dir",
+            str(tmp_path / "engines"),
+            "--model",
+            model["name"],
+            "--local-files-only",
+        ]
+    )
+
+    result = task_eval.eval_one_model(suite=suite, model=model, args=args)
+
+    assert result["build_max_cache_length"] == 445
+    assert result["generation_cache_headroom"] == 64
+    assert result["status"] == "passed"
+
+
 def test_prompt_length_validation_rejects_over_cache(tmp_path: Path, monkeypatch) -> None:
     work_dir = tmp_path / "work"
     work_dir.mkdir()

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -745,6 +745,8 @@ def test_write_report_links_each_comparison(tmp_path):
     assert "Agreement" in document
     assert "Completed" in document
     assert "TRTMC Reference Consistency Report" in document
+    assert "🟢 1 &nbsp; 🟡 0 &nbsp;" in document
+    assert "🔴 0 &nbsp; ⚪ 0" in document
     assert "Vanilla reproduction" in document
     assert "Dataset · Reference 1/1 · TRTMC 1/1" in document
     assert "Dataset slice (500 samples)" in document
@@ -755,6 +757,28 @@ def test_write_report_links_each_comparison(tmp_path):
     assert "$ python tools/trtmc_validate.py model-a" in document
     assert "$ python hf.py" in document
     assert "$ trtmc run" in document
+
+
+def test_traffic_light_counts_are_mutually_exclusive():
+    def result(validation, comparison):
+        return {
+            "validation": {"status": validation},
+            "comparison": {"status": comparison},
+        }
+
+    assert trtmc_validate._traffic_light_counts(
+        [
+            result("passed", "agreement"),
+            result("skipped", "not_run"),
+            result("failed", "disagreement"),
+            result("failed", "not_run"),
+        ]
+    ) == {
+        "green": 1,
+        "yellow": 1,
+        "red": 1,
+        "white": 1,
+    }
 
 
 def test_write_report_records_total_duration(tmp_path, monkeypatch):

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -8459,6 +8459,25 @@ def requested_build_max_cache_length(
     return max(model_cache, suite_cache, prompt_cache)
 
 
+def generation_cache_headroom(
+    *,
+    scorer: str,
+    task_eval_config: dict[str, Any],
+    generation: dict[str, Any],
+    max_new_tokens: int | None,
+) -> int:
+    reserve_headroom = scorer == "continuation" or bool(
+        task_eval_config.get("build_generation_headroom", False)
+    )
+    if not reserve_headroom:
+        return 0
+    return int(
+        max_new_tokens
+        if max_new_tokens is not None
+        else generation.get("max_new_tokens", 0)
+    )
+
+
 def bundle_inspection(
     bundle_path: Path,
     trtmc_binary: str,
@@ -9688,13 +9707,12 @@ def eval_one_model(
             trust_remote_code=args.trust_remote_code or bool(model.get("trust_remote_code", False)),
         )
     generation = generation_defaults(work_dir)
-    generation_headroom = 0
-    if bool(task_eval_config.get("build_generation_headroom", False)):
-        generation_headroom = int(
-            args.max_new_tokens
-            if args.max_new_tokens is not None
-            else generation.get("max_new_tokens", 0)
-        )
+    generation_headroom = generation_cache_headroom(
+        scorer=scorer,
+        task_eval_config=task_eval_config,
+        generation=generation,
+        max_new_tokens=args.max_new_tokens,
+    )
     required_prompt_cache = (
         int(max_prompt_len or 0) + generation_headroom if max_prompt_len is not None else None
     )
@@ -9704,10 +9722,13 @@ def eval_one_model(
         args.build_max_cache_length,
         prompt_max_tokens=required_prompt_cache,
     )
-    if max_prompt_len is not None and max_prompt_len > max_cache_length:
+    if required_prompt_cache is not None and required_prompt_cache > max_cache_length:
         raise RuntimeError(
-            f"Dataset prompt length exceeds bundle cache for {model['name']}: "
-            f"max_prompt_tokens={max_prompt_len}, build_max_cache_length={max_cache_length}. "
+            f"Dataset prompt and generation exceed bundle cache for {model['name']}: "
+            f"max_prompt_tokens={max_prompt_len}, "
+            f"generation_cache_headroom={generation_headroom}, "
+            f"required_cache_length={required_prompt_cache}, "
+            f"build_max_cache_length={max_cache_length}. "
             "Use a smaller dataset slice/subject or set --build-max-cache-length high enough "
             "for this model and TensorRT target."
         )
@@ -9736,6 +9757,7 @@ def eval_one_model(
         "bundle": str(bundle_path),
         "build_max_cache_length": max_cache_length,
         "max_prompt_tokens": max_prompt_len,
+        "generation_cache_headroom": generation_headroom,
         "reference_backend": reference_backend,
         "hf_reference_status": reference_mode
         if no_hf_reference

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -1774,6 +1774,24 @@ def _report_counts(
     return validation_counts, comparison_counts, execution_errors
 
 
+def _traffic_light_counts(
+    results: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    counts = {"green": 0, "yellow": 0, "red": 0, "white": 0}
+    for result in results:
+        validation_status = str(result["validation"]["status"])
+        comparison_status = str(result["comparison"]["status"])
+        if validation_status == "skipped":
+            counts["yellow"] += 1
+        elif comparison_status == "agreement":
+            counts["green"] += 1
+        elif comparison_status == "disagreement":
+            counts["red"] += 1
+        else:
+            counts["white"] += 1
+    return counts
+
+
 def _report_rows(
     output: Path,
     results: Sequence[Mapping[str, Any]],
@@ -1812,6 +1830,7 @@ def _report_document(
     rows: str,
     comparison_counts: Mapping[str, int],
     execution_errors: int,
+    traffic_light_counts: Mapping[str, int],
 ) -> str:
     provenance = _report_provenance(report.get("run", {}))
     duration = _format_duration(report["summary"].get("duration_seconds"))
@@ -1823,6 +1842,7 @@ def _report_document(
 body {{ font: 14px system-ui, sans-serif; margin: 32px; color: #202124; }}
 h1 {{ margin-bottom: 4px; }}
 .purpose {{ color: #5f6368; margin-bottom: 8px; }}
+.traffic-summary {{ font-size: 20px; font-weight: 650; margin: 14px 0 8px; }}
 .summary {{ color: #5f6368; margin-bottom: 24px; }}
 table {{ border-collapse: collapse; width: 100%; }}
 th, td {{ border: 1px solid #dadce0; padding: 8px 10px; text-align: left; }}
@@ -1871,6 +1891,10 @@ pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
 </style></head><body>
 <h1>TRTMC Reference Consistency Report</h1>
 <div class="purpose">Accuracy and output agreement against the model reference.</div>
+<div class="traffic-summary" title="Agreement · Skipped · Disagreement · Not compared">
+🟢 {traffic_light_counts["green"]} &nbsp; 🟡 {traffic_light_counts["yellow"]} &nbsp;
+🔴 {traffic_light_counts["red"]} &nbsp; ⚪ {traffic_light_counts["white"]}
+</div>
 <div class="summary">{report["summary"]["cases"]} cases ·
 {comparison_counts["agreement"]} agreements ·
 {comparison_counts["disagreement"]} disagreements ·
@@ -1889,6 +1913,7 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
     result_paths = sorted(output.glob("*/*/comparison.json"))
     results = _normalize_result_files(result_paths)
     validation_counts, comparison_counts, execution_errors = _report_counts(results)
+    traffic_light_counts = _traffic_light_counts(results)
     sample_limits = [_dataset_reproduction(result)[1] for result in results]
     generated_at = _utc_now()
     report = {
@@ -1931,6 +1956,7 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
         rows=_report_rows(output, results, result_paths),
         comparison_counts=comparison_counts,
         execution_errors=execution_errors,
+        traffic_light_counts=traffic_light_counts,
     )
     html_path.write_text(document, encoding="utf-8")
     return json_path, html_path, report


### PR DESCRIPTION
## Background

A 22-model continuation validation run completed every MMLU case but reported
20 HF/TRTMC disagreements. The generated bundles were sized to the longest
prompt while the 64 generated tokens were omitted, so attention-based models
could exhaust their KV cache and repeat tokens during comparison.

The aggregate report also lacked the compact traffic-light summary used by the
performance report.

## Exit Criteria

- Continuation validation reserves cache space for both the prompt and requested
  generated tokens without relaxing the agreement gate.
- Existing undersized bundles are detected by the current bundle inspection and
  rebuilt at the required cache length.
- Generated HTML reports show mutually exclusive green, yellow, red, and white
  case counts.

## Implementation

- Treat `max_new_tokens` as required build cache headroom for every continuation
  scorer while preserving the existing explicit opt-in for other scorers.
- Fail clearly when an explicit cache override cannot fit the prompt and
  generation headroom, and record the reserved headroom in raw results.
- Classify report rows as agreement, skipped, disagreement, or not compared and
  render the four counts above the detailed summary.
- Add focused unit and integration coverage for cache sizing and report
  classification.

## Validation

- `PYTHONPATH=python:. python3 -m pytest -q tests/tools/test_task_eval.py tests/tools/test_trtmc_validate.py`:
  233 passed.
- `python3 tools/legal_headers.py --check`: passed with no findings.
- `ruff check --config ruff.toml tools/task_eval.py tools/trtmc_validate.py tests/tools/test_task_eval.py tests/tools/test_trtmc_validate.py`:
  passed.
- `PYTHONPATH=python:. python3 -m pytest -q tests/tools`: 2,205 passed; one
  unrelated model-proof cache test could not use `cp --reflink=always` on the
  local temporary filesystem (`Operation not supported`).
- Representative GB300 GPT-2 MMLU continuation smoke, 10 samples: passed with a
  cache length of 445 (381 prompt + 64 generation), 100% token-prefix agreement,
  10/10 exact matches, and a generated `🟢 1 🟡 0 🔴 0 ⚪ 0` report summary.

## Notes For Future Readers

- The 0.98 token-prefix agreement requirement is unchanged. The previous
  disagreement was caused by insufficient runtime capacity, not a validation
  threshold.
- Review cache sizing first, then report classification and their focused tests.
