### PR TITLE
fix(validation): require reference-backed comparisons

### DIFF
--- a/python/tensorrt_model_connect/families/internlm/python_profile_requirements/internlm.lock.txt
+++ b/python/tensorrt_model_connect/families/internlm/python_profile_requirements/internlm.lock.txt
@@ -1,4 +1,4 @@
 einops==0.8.1
-huggingface-hub==0.24.7
-tokenizers==0.19.1
-transformers==4.44.2
+huggingface-hub==0.26.5
+tokenizers==0.20.3
+transformers==4.46.3

--- a/python/tensorrt_model_connect/families/internlm/python_profile_verify.py
+++ b/python/tensorrt_model_connect/families/internlm/python_profile_verify.py
@@ -6,4 +6,5 @@ import transformers
 from transformers.cache_utils import DynamicCache
 
 assert hasattr(DynamicCache, "from_legacy_cache")
+assert hasattr(DynamicCache, "get_max_cache_shape")
 print(f"einops={einops.__version__} transformers={transformers.__version__}")

--- a/tests/e2e/models/internlm/test_internlm_manifest_profiles.py
+++ b/tests/e2e/models/internlm/test_internlm_manifest_profiles.py
@@ -12,6 +12,10 @@ from tests.e2e_harness.manifest_loader import load_manifest
 
 
 _MANIFEST_DIR = Path(__file__).with_name("manifests")
+_FAMILY_DIR = (
+    Path(__file__).resolve().parents[4]
+    / "python/tensorrt_model_connect/families/internlm"
+)
 
 
 def _write_manifest(tmp_path, data: dict) -> str:
@@ -70,3 +74,15 @@ def test_internlm_builds_reserve_an_exclusive_gpu() -> None:
             (_MANIFEST_DIR / manifest_name).read_text(encoding="utf-8"))
 
         assert manifest["e2e_parallel_resource"] == "exclusive_gpu"
+
+
+def test_reference_profile_supports_current_internlm_dynamic_cache_api() -> None:
+    lock = (
+        _FAMILY_DIR / "python_profile_requirements/internlm.lock.txt"
+    ).read_text(encoding="utf-8")
+    verify = (_FAMILY_DIR / "python_profile_verify.py").read_text(encoding="utf-8")
+
+    assert "huggingface-hub==0.26.5" in lock
+    assert "tokenizers==0.20.3" in lock
+    assert "transformers==4.46.3" in lock
+    assert 'hasattr(DynamicCache, "get_max_cache_shape")' in verify

--- a/tests/e2e/models/qwen/manifests/qwen3-0.6b-fp8.json
+++ b/tests/e2e/models/qwen/manifests/qwen3-0.6b-fp8.json
@@ -22,6 +22,11 @@
       "expected_answers": [
         "Paris"
       ],
+      "task_eval": {
+        "reference_backend": "hf_transformers",
+        "reference_family": "chat_qwen3_posttrained",
+        "user_contract": "chat_response"
+      },
       "max_new_tokens": 10,
       "notes": "FP8 quantization can perturb raw logit distributions while preserving decoded answer semantics. Require the model-owned expected answer plus the default logit and token agreement gates for output confidence."
     }

--- a/tests/e2e/models/qwen/manifests/qwen3-0.6b-topp.json
+++ b/tests/e2e/models/qwen/manifests/qwen3-0.6b-topp.json
@@ -21,6 +21,11 @@
       "top_p": 0.9,
       "top_k": 50,
       "seed": 42,
+      "task_eval": {
+        "reference_backend": "hf_transformers",
+        "reference_family": "chat_qwen3_posttrained",
+        "user_contract": "chat_response"
+      },
       "determinism_reruns": 1,
       "test_note": "Validates host-side top-p nucleus sampling on an fp16 Qwen3 bundle: with temperature=0.7/top_p=0.9/top_k=50/seed=42, the runtime CLI must forward sampling flags, produce non-empty output, and reproduce the same seeded output on rerun. Device placement is not asserted by this E2E contract; top-p filtering is implemented on CPU via HOST sampler logits."
     }

--- a/tests/e2e/models/qwen/test_qwen_manifest_contract.py
+++ b/tests/e2e/models/qwen/test_qwen_manifest_contract.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from tests.e2e_harness.manifest_loader import load_manifest
+from tools import task_eval
 
 
 @pytest.mark.parametrize(
@@ -26,3 +27,26 @@ def test_qwen3_fp8_manifest_declares_hf_text_generation_contract(
     assert case.task_strategy == "text_generation_causal"
     assert case.user_contract == "text-generation"
     assert not case.metadata.get("skip_reason")
+
+
+def test_fp8_and_topp_use_deterministic_mmlu_validation_contract() -> None:
+    manifest_dir = Path(__file__).with_name("manifests")
+    topp_e2e = load_manifest(manifest_dir / "qwen3-0.6b-topp.json")
+    models = {
+        name: task_eval.manifest_record(manifest_dir / f"{name}.json")
+        for name in ("qwen3-0.6b-fp8", "qwen3-0.6b-topp")
+    }
+    suite = task_eval.suite_by_id(
+        task_eval.load_suites(),
+        "mmlu_five_shot_mcq",
+    )
+
+    for model in models.values():
+        assert model["reference_backend"] == "hf_transformers"
+        assert model["reference_family"] == "chat_qwen3_posttrained"
+        assert model["user_contract"] == "chat_response"
+        assert task_eval.suite_match_reason(suite, model) == (True, "selected")
+    assert set(models) < set(suite["default_model_names"])
+    assert topp_e2e.reference_backend == "invariant_only"
+    assert topp_e2e.reference_family == "sampling_top_p"
+    assert topp_e2e.user_contract == "sampling"

--- a/tests/task_eval/validation_suites.yaml
+++ b/tests/task_eval/validation_suites.yaml
@@ -22,6 +22,8 @@ suites:
       - phi3-mini
       - phi-moe
       - qwen3-0.6b-fp16
+      - qwen3-0.6b-fp8
+      - qwen3-0.6b-topp
       - qwen3-4b-instruct-2507
       - qwen35-9b
       - qwen3-moe-30b-a3b

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -3512,6 +3512,7 @@ def test_run_hf_reference_subprocess_uses_hf_python(tmp_path: Path, monkeypatch)
     args = argparse.Namespace(
         hf_python="/opt/deepseek-hf/bin/python3",
         reference_cache_dir=str(tmp_path / "references"),
+        reference_cache_identity="org/model/reference-contract-v1",
         hf_dtype="auto",
         hf_device="cuda",
         hf_device_map="",
@@ -3543,6 +3544,9 @@ def test_run_hf_reference_subprocess_uses_hf_python(tmp_path: Path, monkeypatch)
     assert captured["cmd"][captured["cmd"].index("--cache-dir") + 1] == str(
         tmp_path / "references"
     )
+    assert captured["cmd"][
+        captured["cmd"].index("--reference-cache-identity") + 1
+    ] == "org/model/reference-contract-v1"
 
 
 def test_run_hf_reference_subprocess_passes_asr_family_metadata(

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -3854,6 +3854,24 @@ def test_run_diffusion_hf_reference_writes_image_artifact_predictions(
     assert predictions["responses"][0]["source"] == "hf"
 
 
+def test_captured_utf8_subprocess_replaces_invalid_native_output() -> None:
+    result = task_eval._run_captured_utf8_subprocess(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import os; "
+                "os.write(1, b'answer:\\x93A'); "
+                "os.write(2, b'warning:\\xff')"
+            ),
+        ]
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == "answer:\ufffdA"
+    assert result.stderr == "warning:\ufffd"
+
+
 def test_run_trtfb_dispatches_diffusion_prompt_workdir(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/tools/test_task_eval.py
+++ b/tests/tools/test_task_eval.py
@@ -950,6 +950,84 @@ def test_prompted_segmentation_uses_family_prompt_semantics(tmp_path: Path) -> N
     assert text["mean_backend_mask_iou"] == 1.0
 
 
+def test_prompted_segmentation_empty_prediction_is_a_comparison_failure(
+    tmp_path: Path,
+) -> None:
+    ground = np.array([[1, 1], [0, 0]], dtype=np.uint8)
+    ground_path = tmp_path / "ground.npy"
+    hf_path = tmp_path / "hf.npy"
+    np.save(ground_path, ground)
+    np.save(hf_path, ground[None, ...])
+    answers = {
+        "requests": [
+            {
+                "sample_id": "prompt",
+                "category_mask": str(ground_path),
+                "text_prompt": "object",
+            }
+        ]
+    }
+    hf = {
+        "responses": [
+            {
+                "sample_id": "prompt",
+                "masks_path": str(hf_path),
+                "mask_scores": [0.9],
+            }
+        ]
+    }
+    trtfb = {
+        "responses": [
+            {
+                "sample_id": "prompt",
+                "masks_path": "",
+                "mask_scores": [],
+                "num_masks": 0,
+                "empty_prediction": True,
+                "returncode": 1,
+            }
+        ]
+    }
+
+    summary = task_eval.compare_prompted_segmentation_prediction_sets(
+        hf,
+        trtfb,
+        answers,
+        gates={},
+        prompt_mode="text",
+        ground_truth_mask_field="category_mask",
+    )
+
+    assert summary["status"] == "failed"
+    assert summary["valid_count"] == 1
+    assert summary["mean_backend_mask_iou"] == 0.0
+    assert summary["cases"][0]["trtfb_empty_prediction"] is True
+
+
+def test_vision_response_preserves_prompted_segmentation_empty_prediction(
+    tmp_path: Path,
+) -> None:
+    response = task_eval._vision_response(
+        case=SimpleNamespace(name="prompt"),
+        source="trtfb",
+        output=SimpleNamespace(
+            data={"masks": [], "num_masks": 0},
+            metadata={
+                "returncode": 1,
+                "stderr": "Error: prompted segmentation produced no masks",
+            },
+            timing_s=0.1,
+        ),
+        dataset_kind="prompted_segmentation_json",
+        prompt_row={"image": "image.jpg", "text_prompt": "train"},
+        artifact_dir=tmp_path,
+    )
+
+    assert response["returncode"] == 1
+    assert response["num_masks"] == 0
+    assert response["empty_prediction"] is True
+
+
 @pytest.mark.parametrize(
     ("result", "expected"),
     [

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -106,7 +106,7 @@ def test_tts_transcriber_passes_local_files_only_once(monkeypatch) -> None:
     }
 
 
-def _prepare_work(path: Path) -> None:
+def _prepare_work(path: Path, *, model_manifest: str = "") -> None:
     path.mkdir(parents=True)
     (path / "answers.json").write_text(
         json.dumps({"requests": [{"sample_id": "one", "answer": "A"}]}),
@@ -116,18 +116,16 @@ def _prepare_work(path: Path) -> None:
         json.dumps({"sample_id": "one", "prompt": "question"}) + "\n",
         encoding="utf-8",
     )
-    (path / "manifest.json").write_text(
-        json.dumps(
-            {
-                "dataset_kind": "mmlu_json",
-                "files": {
-                    "answers": str(path / "answers.json"),
-                    "prompts": str(path / "prompts.jsonl"),
-                },
-            }
-        ),
-        encoding="utf-8",
-    )
+    manifest = {
+        "dataset_kind": "mmlu_json",
+        "files": {
+            "answers": str(path / "answers.json"),
+            "prompts": str(path / "prompts.jsonl"),
+        },
+    }
+    if model_manifest:
+        manifest["task_eval"] = {"model_manifest": model_manifest}
+    (path / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
 
 
 def _args(work_dir: Path, cache_dir: Path, *extra: str):
@@ -205,6 +203,71 @@ def test_reference_cache_reuses_same_settings_across_work_directories(
     entries = [path for path in cache_dir.iterdir() if not path.name.startswith(".")]
     assert len(entries) == 1
     assert stat.S_IMODE(entries[0].stat().st_mode) & 0o055 == 0o055
+
+
+def test_reference_cache_identity_shares_equivalent_trtmc_variants(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    _prepare_work(first, model_manifest="manifests/model-fp16.json")
+    _prepare_work(second, model_manifest="manifests/model-fp8.json")
+    calls = 0
+
+    def fake_reference(args) -> None:
+        nonlocal calls
+        calls += 1
+        Path(args.work_dir, "hf_predictions.json").write_text(
+            json.dumps(
+                {"responses": [{"sample_id": "one", "output_text": "A"}]}
+            ),
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(
+        trtmc_reference.task_eval,
+        "run_hf_reference",
+        fake_reference,
+    )
+
+    identity = "org/model/reference-contract-v1"
+    first_args = _args(
+        first,
+        cache_dir,
+        "--reference-cache-identity",
+        identity,
+    )
+    second_args = _args(
+        second,
+        cache_dir,
+        "--reference-cache-identity",
+        identity,
+    )
+
+    assert trtmc_reference.run_reference(first_args) == "generated"
+    assert trtmc_reference.run_reference(second_args) == "reused"
+    assert calls == 1
+    entries = [
+        path for path in cache_dir.iterdir() if not path.name.startswith(".")
+    ]
+    assert len(entries) == 1
+
+
+def test_reference_cache_keeps_variant_manifests_separate_without_identity(
+    tmp_path: Path,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    _prepare_work(first, model_manifest="manifests/model-fp16.json")
+    _prepare_work(second, model_manifest="manifests/model-fp8.json")
+
+    first_key, _ = trtmc_reference.reference_key(_args(first, cache_dir))
+    second_key, _ = trtmc_reference.reference_key(_args(second, cache_dir))
+
+    assert first_key != second_key
 
 
 def test_reference_cache_key_changes_with_inference_setting(

--- a/tests/tools/test_trtmc_reference.py
+++ b/tests/tools/test_trtmc_reference.py
@@ -255,6 +255,79 @@ def test_reference_cache_identity_shares_equivalent_trtmc_variants(
     assert len(entries) == 1
 
 
+def test_reference_cache_identity_ignores_native_runner_variant_metadata(
+    tmp_path: Path,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    _prepare_work(first, model_manifest="manifests/model-fp16.json")
+    _prepare_work(second, model_manifest="manifests/model-fp8.json")
+    for work_dir in (first, second):
+        manifest_path = work_dir / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["dataset_kind"] = "mmlu_five_shot_json"
+        manifest["generation"] = {"max_new_tokens": 1, "do_sample": False}
+        manifest["task_eval"].update(
+            {
+                "family": "qwen",
+                "model_max_new_tokens": 10,
+                "task_strategy": "text_generation_causal",
+            }
+        )
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    second_manifest_path = second / "manifest.json"
+    second_manifest = json.loads(second_manifest_path.read_text(encoding="utf-8"))
+    second_manifest["task_eval"].update(
+        {
+            "model_max_new_tokens": 20,
+            "reference_backend": "hf_transformers",
+            "reference_family": "chat_qwen3_posttrained",
+            "user_contract": "chat_response",
+        }
+    )
+    second_manifest_path.write_text(
+        json.dumps(second_manifest),
+        encoding="utf-8",
+    )
+    identity = "qwen3-0.6b-mmlu-five-shot-v1"
+
+    first_key, _ = trtmc_reference.reference_key(
+        _args(first, cache_dir, "--reference-cache-identity", identity)
+    )
+    second_key, _ = trtmc_reference.reference_key(
+        _args(second, cache_dir, "--reference-cache-identity", identity)
+    )
+
+    assert first_key == second_key
+
+
+def test_reference_cache_identity_keeps_effective_generation_separate(
+    tmp_path: Path,
+) -> None:
+    cache_dir = tmp_path / "cache"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    _prepare_work(first, model_manifest="manifests/model-fp16.json")
+    _prepare_work(second, model_manifest="manifests/model-fp8.json")
+    for work_dir, max_new_tokens in ((first, 1), (second, 2)):
+        manifest_path = work_dir / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["dataset_kind"] = "mmlu_five_shot_json"
+        manifest["generation"] = {"max_new_tokens": max_new_tokens}
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    identity = "org/model/reference-contract-v1"
+
+    first_key, _ = trtmc_reference.reference_key(
+        _args(first, cache_dir, "--reference-cache-identity", identity)
+    )
+    second_key, _ = trtmc_reference.reference_key(
+        _args(second, cache_dir, "--reference-cache-identity", identity)
+    )
+
+    assert first_key != second_key
+
+
 def test_reference_cache_keeps_variant_manifests_separate_without_identity(
     tmp_path: Path,
 ) -> None:

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -36,6 +36,13 @@ def test_model_workload_catalog_covers_every_ready_model():
     )
 
     assert len(catalog["models"]) == len(ready_models) == 105
+    assert sum(
+        "not_compared_reason" in spec for spec in catalog["models"].values()
+    ) == 10
+    assert all(
+        "e2e" not in spec.get("workloads", [])
+        for spec in catalog["models"].values()
+    )
 
 
 def test_validation_ready_models_exclude_l0_only_profiles():
@@ -62,8 +69,7 @@ def test_catalog_defines_sample_limit_for_every_dataset_workload():
     declared = {
         workload
         for spec in catalog["models"].values()
-        for workload in spec["workloads"]
-        if workload != "e2e"
+        for workload in spec.get("workloads", [])
     }
 
     assert configured == declared
@@ -80,8 +86,7 @@ def test_every_dataset_backed_validation_binding_has_native_reference_runner():
     bindings = [
         (model_name, workload)
         for model_name, spec in catalog["models"].items()
-        for workload in spec["workloads"]
-        if workload != "e2e"
+        for workload in spec.get("workloads", [])
     ]
     missing = []
     for model_name, workload in bindings:
@@ -115,6 +120,52 @@ def test_resolve_binding_defaults_and_rejects_undeclared_workload():
         trtmc_validate.resolve_binding(catalog, "model-a", "workload-c")
 
 
+def test_resolve_binding_keeps_unimplemented_model_visible_but_not_runnable():
+    catalog = {
+        "models": {
+            "model-a": {
+                "not_compared_reason": "Reference comparator is missing.",
+            }
+        }
+    }
+
+    binding = trtmc_validate.resolve_binding(catalog, "model-a")
+
+    assert binding == trtmc_validate.Binding(
+        "model-a",
+        None,
+        "Reference comparator is missing.",
+    )
+    assert not binding.runnable
+    with pytest.raises(
+        trtmc_validate.ValidationError,
+        match="has no reference-consistency workloads",
+    ):
+        trtmc_validate.resolve_binding(catalog, "model-a", "workload-a")
+
+
+def test_catalog_rejects_e2e_as_reference_consistency_workload(tmp_path):
+    catalog_path = tmp_path / "model_workloads.yaml"
+    catalog_path.write_text(
+        """
+version: 1
+sample_limits:
+  workload-a: 1
+models:
+  model-a:
+    default: e2e
+    workloads: [e2e]
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        trtmc_validate.ValidationError,
+        match="cannot use e2e",
+    ):
+        trtmc_validate.load_catalog(catalog_path)
+
+
 def test_resolve_sample_limit_uses_workload_policy_and_cli_override():
     catalog = {
         "sample_limits": {"workload-a": 50},
@@ -123,9 +174,8 @@ def test_resolve_sample_limit_uses_workload_policy_and_cli_override():
                 "default": "workload-a",
                 "workloads": ["workload-a"],
             },
-            "model-e2e": {
-                "default": "e2e",
-                "workloads": ["e2e"],
+            "model-not-compared": {
+                "not_compared_reason": "Reference comparator is missing.",
             },
         },
     }
@@ -157,7 +207,23 @@ def test_resolve_sample_limit_uses_workload_policy_and_cli_override():
     assert (
         trtmc_validate.resolve_sample_limit(
             catalog,
-            trtmc_validate.Binding("model-e2e", "e2e"),
+            trtmc_validate.Binding(
+                "model-not-compared",
+                None,
+                "Reference comparator is missing.",
+            ),
+            7,
+        )
+        == 0
+    )
+    assert (
+        trtmc_validate.resolve_sample_limit(
+            catalog,
+            trtmc_validate.Binding(
+                "model-not-compared",
+                None,
+                "Reference comparator is missing.",
+            ),
             None,
         )
         == 0
@@ -242,6 +308,67 @@ def test_all_supervisor_applies_model_failure_policy(
 
     assert returncode == 1
     assert attempted == expected_models
+
+
+def test_all_supervisor_records_not_compared_without_launching_worker(
+    tmp_path,
+    monkeypatch,
+):
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "--all",
+            "--output",
+            str(tmp_path / "results"),
+            "--engine-dir",
+            str(tmp_path / "engines"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+        ]
+    )
+    binding = trtmc_validate.Binding(
+        "model-a",
+        None,
+        "Reference comparator is missing.",
+    )
+
+    def unexpected_worker(*_args, **_kwargs):
+        raise AssertionError("not-compared models must not launch a worker")
+
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_run_supervised_binding",
+        unexpected_worker,
+    )
+    monkeypatch.setattr(trtmc_validate, "write_run_metadata", lambda output: output)
+    monkeypatch.setattr(
+        trtmc_validate,
+        "write_report",
+        lambda output: (
+            output / "report.json",
+            output / "report.html",
+            {},
+        ),
+    )
+    monkeypatch.setattr(trtmc_validate, "_print_result", lambda *args: None)
+
+    returncode = trtmc_validate._run_all_bindings(
+        [binding],
+        arguments=arguments,
+        catalog={"sample_limits": {}},
+    )
+
+    comparison = (
+        arguments.output
+        / "model-a"
+        / trtmc_validate.NOT_COMPARED_DIRECTORY
+        / "comparison.json"
+    )
+    result = json.loads(comparison.read_text(encoding="utf-8"))
+    assert returncode == 0
+    assert result["execution"]["status"] == "not_run"
+    assert result["comparison"]["status"] == "not_run"
+    assert result["validation"]["status"] == "not_compared"
+    assert result["not_compared_reason"] == "Reference comparator is missing."
 
 
 def test_supervised_binding_replaces_stale_result_with_worker_crash(tmp_path, monkeypatch):
@@ -358,9 +485,8 @@ def test_all_dry_run_emits_machine_readable_ci_cases(monkeypatch, capsys):
                 "default": "workload-a",
                 "workloads": ["workload-a"],
             },
-            "model-e2e": {
-                "default": "e2e",
-                "workloads": ["e2e"],
+            "model-not-compared": {
+                "not_compared_reason": "Reference comparator is missing.",
             },
         },
     }
@@ -370,7 +496,7 @@ def test_all_dry_run_emits_machine_readable_ci_cases(monkeypatch, capsys):
         lambda arguments: (
             catalog,
             {"workload-a": {}},
-            ("model-a", "model-e2e"),
+            ("model-a", "model-not-compared"),
             {},
         ),
     )
@@ -385,9 +511,11 @@ def test_all_dry_run_emits_machine_readable_ci_cases(monkeypatch, capsys):
             "sample_limit": 5,
         },
         {
-            "model": "model-e2e",
-            "workload": "e2e",
+            "model": "model-not-compared",
+            "workload": None,
             "sample_limit": 0,
+            "status": "not_compared",
+            "reason": "Reference comparator is missing.",
         },
     ]
 
@@ -421,7 +549,7 @@ def test_single_ci_case_writes_stable_result_and_exit_code(
     binding = trtmc_validate.Binding("model-a", "workload-a")
     catalog = {"sample_limits": {"workload-a": 5}}
 
-    def run_binding(binding, *, arguments, task_models, e2e_models, suites):
+    def run_binding(binding, *, arguments, task_models, suites):
         result = {
             "schema_version": "trtmc.validation-result/v2",
             "model": binding.model,
@@ -453,7 +581,6 @@ def test_single_ci_case_writes_stable_result_and_exit_code(
         )
         return result
 
-    monkeypatch.setattr(trtmc_validate, "_e2e_models", lambda models_dir: {})
     monkeypatch.setattr(trtmc_validate, "run_binding", run_binding)
 
     returncode = trtmc_validate._run_bindings(
@@ -509,7 +636,6 @@ def test_model_specific_reference_environment_keeps_common_validation_base() -> 
                 "reference_backend": "hf_transformers",
             }
         },
-        e2e_models={},
     )
 
     assert profiles == (
@@ -771,7 +897,7 @@ def test_traffic_light_counts_are_mutually_exclusive():
             result("passed", "agreement"),
             result("skipped", "not_run"),
             result("failed", "disagreement"),
-            result("failed", "not_run"),
+            result("not_compared", "not_run"),
         ]
     ) == {
         "green": 1,
@@ -779,6 +905,77 @@ def test_traffic_light_counts_are_mutually_exclusive():
         "red": 1,
         "white": 1,
     }
+
+
+def test_legacy_e2e_result_is_not_reported_as_reference_agreement(tmp_path):
+    case_dir = tmp_path / "model-a" / "e2e"
+    case_dir.mkdir(parents=True)
+    (case_dir / "comparison.json").write_text(
+        json.dumps(
+            {
+                "model": "model-a",
+                "workload": "e2e",
+                "executor": "e2e",
+                "status": "passed",
+                "returncode": 0,
+                "raw_results": [{"status": "pass"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _, html_path, report = trtmc_validate.write_report(tmp_path)
+
+    result = report["results"][0]
+    assert report["validation_status"] == "incomplete"
+    assert report["summary"]["agreements"] == 0
+    assert report["summary"]["not_compared"] == 1
+    assert result["execution"]["status"] == "not_run"
+    assert result["comparison"]["status"] == "not_run"
+    assert result["validation"]["status"] == "not_compared"
+    assert result["not_compared_reason"] == trtmc_validate.LEGACY_E2E_REASON
+    document = html_path.read_text(encoding="utf-8")
+    assert "🟢 0 &nbsp; 🟡 0 &nbsp;" in document
+    assert "🔴 0 &nbsp; ⚪ 1" in document
+    assert "E2E execution does not compare aligned reference" in document
+
+
+def test_not_compared_result_replaces_legacy_e2e_row_without_deleting_evidence(
+    tmp_path,
+):
+    legacy_dir = tmp_path / "model-a" / "e2e"
+    legacy_dir.mkdir(parents=True)
+    legacy_comparison = legacy_dir / "comparison.json"
+    legacy_comparison.write_text(
+        json.dumps(
+            {
+                "model": "model-a",
+                "workload": "e2e",
+                "executor": "e2e",
+                "status": "passed",
+                "raw_results": [{"status": "pass"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    trtmc_validate._write_not_compared_case(
+        trtmc_validate.Binding(
+            "model-a",
+            None,
+            "Reference comparator is missing.",
+        ),
+        tmp_path,
+    )
+
+    _, _, report = trtmc_validate.write_report(tmp_path)
+
+    assert legacy_comparison.is_file()
+    assert report["summary"]["cases"] == 1
+    assert report["summary"]["not_compared"] == 1
+    assert (
+        report["results"][0]["not_compared_reason"]
+        == "Reference comparator is missing."
+    )
 
 
 def test_write_report_records_total_duration(tmp_path, monkeypatch):
@@ -1570,7 +1767,6 @@ def test_run_binding_wires_reference_source_command_and_environment(
                 "execution_profiles": {},
             }
         },
-        e2e_models={},
         suites={"elf-workload": {}},
     )
 

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -43,6 +43,19 @@ def test_model_workload_catalog_covers_every_ready_model():
         "e2e" not in spec.get("workloads", [])
         for spec in catalog["models"].values()
     )
+    assert (
+        catalog["models"]["flux-2-dev"]["reference_cache_identity"]
+        == catalog["models"]["flux-2-dev-fp8"]["reference_cache_identity"]
+    )
+    qwen_identities = {
+        catalog["models"][name]["reference_cache_identity"]
+        for name in (
+            "qwen3-0.6b-fp16",
+            "qwen3-0.6b-fp8",
+            "qwen3-0.6b-topp",
+        )
+    }
+    assert len(qwen_identities) == 1
 
 
 def test_validation_ready_models_exclude_l0_only_profiles():
@@ -106,15 +119,24 @@ def test_resolve_binding_defaults_and_rejects_undeclared_workload():
             "model-a": {
                 "default": "workload-a",
                 "workloads": ["workload-a", "workload-b"],
+                "reference_cache_identity": "org/model/reference-contract-v1",
             }
         }
     }
 
     assert trtmc_validate.resolve_binding(catalog, "model-a") == (
-        trtmc_validate.Binding("model-a", "workload-a")
+        trtmc_validate.Binding(
+            "model-a",
+            "workload-a",
+            reference_cache_identity="org/model/reference-contract-v1",
+        )
     )
     assert trtmc_validate.resolve_binding(catalog, "model-a", "workload-b") == (
-        trtmc_validate.Binding("model-a", "workload-b")
+        trtmc_validate.Binding(
+            "model-a",
+            "workload-b",
+            reference_cache_identity="org/model/reference-contract-v1",
+        )
     )
     with pytest.raises(trtmc_validate.ValidationError, match="does not declare"):
         trtmc_validate.resolve_binding(catalog, "model-a", "workload-c")
@@ -164,6 +186,54 @@ models:
         match="cannot use e2e",
     ):
         trtmc_validate.load_catalog(catalog_path)
+
+
+def test_catalog_rejects_cache_identity_across_different_reference_contracts(
+    monkeypatch,
+) -> None:
+    catalog = {
+        "models": {
+            "model-a": {
+                "default": "workload-a",
+                "workloads": ["workload-a"],
+                "reference_cache_identity": "shared-reference",
+            },
+            "model-b": {
+                "default": "workload-a",
+                "workloads": ["workload-a"],
+                "reference_cache_identity": "shared-reference",
+            },
+        }
+    }
+    task_models = {
+        "model-a": {
+            "hf_id": "org/model-a",
+            "family": "family",
+            "reference_backend": "hf_transformers",
+            "reference_family": "causal",
+        },
+        "model-b": {
+            "hf_id": "org/model-b",
+            "family": "family",
+            "reference_backend": "hf_transformers",
+            "reference_family": "causal",
+        },
+    }
+    monkeypatch.setattr(
+        trtmc_validate.task_eval,
+        "suite_match_reason",
+        lambda _suite, _model: (True, ""),
+    )
+
+    with pytest.raises(
+        trtmc_validate.ValidationError,
+        match="spans different reference contracts",
+    ):
+        trtmc_validate.audit_workload_compatibility(
+            catalog,
+            suites={"workload-a": {}},
+            task_models=task_models,
+        )
 
 
 def test_resolve_sample_limit_uses_workload_policy_and_cli_override():
@@ -1686,7 +1756,11 @@ def test_comparison_command_uses_validation_entrypoint(tmp_path):
     )
 
     command = trtmc_validate._comparison_command(
-        trtmc_validate.Binding("model-a", "workload-a"),
+        trtmc_validate.Binding(
+            "model-a",
+            "workload-a",
+            reference_cache_identity="org/model/reference-contract-v1",
+        ),
         case_dir=tmp_path / "case",
         dataset=tmp_path / "dataset.json",
         arguments=arguments,
@@ -1707,6 +1781,9 @@ def test_comparison_command_uses_validation_entrypoint(tmp_path):
     assert command[command.index("--reference-cache-dir") + 1] == str(
         tmp_path / "references"
     )
+    assert command[
+        command.index("--reference-cache-identity") + 1
+    ] == "org/model/reference-contract-v1"
     assert "--replace-bundle-on-build" in command
     assert "--force-hf" in command
     assert "--require-prebuilt-bundles" in command

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -368,6 +368,11 @@ def test_all_supervisor_applies_model_failure_policy(
     monkeypatch.setattr(trtmc_validate, "write_run_metadata", lambda output: output)
     monkeypatch.setattr(
         trtmc_validate,
+        "finalize_run_metadata",
+        lambda output: output,
+    )
+    monkeypatch.setattr(
+        trtmc_validate,
         "write_report",
         lambda output: (
             output / "report.json",
@@ -499,6 +504,11 @@ def test_all_supervisor_records_not_compared_without_launching_worker(
         unexpected_worker,
     )
     monkeypatch.setattr(trtmc_validate, "write_run_metadata", lambda output: output)
+    monkeypatch.setattr(
+        trtmc_validate,
+        "finalize_run_metadata",
+        lambda output: output,
+    )
     monkeypatch.setattr(
         trtmc_validate,
         "write_report",
@@ -1192,6 +1202,29 @@ def test_write_report_records_total_duration(tmp_path, monkeypatch):
 
     assert report["summary"]["duration_seconds"] == 10_923.5
     assert "3h 02m 04s total duration" in html_path.read_text(encoding="utf-8")
+
+
+def test_write_report_preserves_finalized_duration(tmp_path, monkeypatch):
+    (tmp_path / "run.json").write_text(
+        json.dumps(
+            {
+                "started_at": "2026-07-25T01:02:03+00:00",
+                "finished_at": "2026-07-25T01:02:13+00:00",
+                "duration_seconds": 10.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_utc_now",
+        lambda: datetime(2026, 7, 25, 4, 4, 6, tzinfo=timezone.utc),
+    )
+
+    _, html_path, report = trtmc_validate.write_report(tmp_path)
+
+    assert report["summary"]["duration_seconds"] == 10.0
+    assert "0h 00m 10s total duration" in html_path.read_text(encoding="utf-8")
 
 
 def test_write_report_does_not_render_validation_wrapper(tmp_path):
@@ -1902,6 +1935,24 @@ def test_run_metadata_records_source_and_exact_command(monkeypatch, tmp_path):
     assert metadata["source_revision"] == "abc123"
     assert metadata["cuda_visible_devices"] == "1"
     assert metadata["command"] == "tools/trtmc_validate.py model-a"
+    assert metadata["finished_at"] is None
+    assert metadata["duration_seconds"] is None
+
+
+def test_finalize_run_metadata_records_completion(monkeypatch, tmp_path):
+    started_at = datetime(2026, 7, 25, 1, 2, 3, tzinfo=timezone.utc)
+    finished_at = datetime(2026, 7, 25, 4, 4, 6, 500000, tzinfo=timezone.utc)
+    (tmp_path / "run.json").write_text(
+        json.dumps({"started_at": started_at.isoformat()}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(trtmc_validate, "_utc_now", lambda: finished_at)
+
+    path = trtmc_validate.finalize_run_metadata(tmp_path)
+    metadata = json.loads(path.read_text(encoding="utf-8"))
+
+    assert metadata["finished_at"] == finished_at.isoformat()
+    assert metadata["duration_seconds"] == 10_923.5
 
 
 def test_comparison_command_uses_validation_entrypoint(tmp_path):

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -308,6 +308,8 @@ def test_all_defaults_to_continue_and_accepts_stop_policy():
 
     assert default.on_model_failure == "continue"
     assert stop.on_model_failure == "stop"
+    assert default.model_attempts == 2
+    assert default.model_retry_delay_seconds == 5.0
 
 
 @pytest.mark.parametrize(
@@ -354,10 +356,15 @@ def test_all_supervisor_applies_model_failure_policy(
         return {
             "model": binding.model,
             "workload": binding.workload,
+            "execution": {"status": "completed"},
             "validation": {"status": status},
         }
 
-    monkeypatch.setattr(trtmc_validate, "_run_supervised_binding", run_worker)
+    monkeypatch.setattr(
+        trtmc_validate,
+        "_run_supervised_binding_with_retries",
+        run_worker,
+    )
     monkeypatch.setattr(trtmc_validate, "write_run_metadata", lambda output: output)
     monkeypatch.setattr(
         trtmc_validate,
@@ -378,6 +385,88 @@ def test_all_supervisor_applies_model_failure_policy(
 
     assert returncode == 1
     assert attempted == expected_models
+
+
+def test_supervisor_retries_execution_error_but_not_disagreement(
+    tmp_path,
+    monkeypatch,
+):
+    arguments = trtmc_validate.build_parser().parse_args(
+        [
+            "--all",
+            "--model-retry-delay-seconds",
+            "0",
+            "--output",
+            str(tmp_path / "results"),
+            "--engine-dir",
+            str(tmp_path / "engines"),
+            "--reference-cache-dir",
+            str(tmp_path / "references"),
+        ]
+    )
+    binding = trtmc_validate.Binding("model-a", "workload-a")
+    attempts = []
+
+    def run_worker(binding, *, arguments, catalog, attempt):
+        attempts.append(attempt)
+        execution_status = "error" if attempt == 1 else "completed"
+        validation_status = "failed" if attempt == 1 else "passed"
+        result = {
+            "model": binding.model,
+            "workload": binding.workload,
+            "execution": {"status": execution_status, "exit_code": 1 if attempt == 1 else 0},
+            "validation": {"status": validation_status},
+            "raw_result": {
+                "status": validation_status,
+                "error_type": "WorkerProcessError" if attempt == 1 else "",
+            },
+            "worker_log": str(tmp_path / f"worker-{attempt}.log"),
+        }
+        case_dir = trtmc_validate._case_directory(arguments.output, binding)
+        case_dir.mkdir(parents=True, exist_ok=True)
+        (case_dir / "comparison.json").write_text(
+            json.dumps(result),
+            encoding="utf-8",
+        )
+        return result
+
+    monkeypatch.setattr(trtmc_validate, "_run_supervised_binding", run_worker)
+
+    result = trtmc_validate._run_supervised_binding_with_retries(
+        binding,
+        arguments=arguments,
+        catalog={"sample_limits": {"workload-a": 5}},
+    )
+
+    assert attempts == [1, 2]
+    assert result["execution"]["status"] == "completed"
+    assert result["execution"]["attempt_count"] == 2
+    assert result["execution"]["retry_count"] == 1
+
+    attempts.clear()
+
+    def disagree(binding, *, arguments, catalog, attempt):
+        attempts.append(attempt)
+        return {
+            "model": binding.model,
+            "workload": binding.workload,
+            "execution": {"status": "completed", "exit_code": 1},
+            "validation": {"status": "failed"},
+            "raw_result": {"status": "failed"},
+            "worker_log": str(tmp_path / "worker-disagreement.log"),
+        }
+
+    monkeypatch.setattr(trtmc_validate, "_run_supervised_binding", disagree)
+
+    disagreement = trtmc_validate._run_supervised_binding_with_retries(
+        binding,
+        arguments=arguments,
+        catalog={"sample_limits": {"workload-a": 5}},
+    )
+
+    assert attempts == [1]
+    assert disagreement["execution"]["status"] == "completed"
+    assert disagreement["execution"]["attempt_count"] == 1
 
 
 def test_all_supervisor_records_not_compared_without_launching_worker(
@@ -406,7 +495,7 @@ def test_all_supervisor_records_not_compared_without_launching_worker(
 
     monkeypatch.setattr(
         trtmc_validate,
-        "_run_supervised_binding",
+        "_run_supervised_binding_with_retries",
         unexpected_worker,
     )
     monkeypatch.setattr(trtmc_validate, "write_run_metadata", lambda output: output)

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -1420,6 +1420,47 @@ def test_cached_reference_command_is_relocated_to_current_work_dir(
     assert shlex.quote(str(work_dir / "hf_predictions.json")) in command
 
 
+def test_commands_from_logs_use_native_trtmc_jsonl(tmp_path: Path) -> None:
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    (work_dir / "prompts.jsonl").write_text(
+        "\n".join(
+            json.dumps({"sample_id": sample_id})
+            for sample_id in ("sample-1", "sample-2")
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (work_dir / "trtfb_run.log").write_text(
+        "$ python task_eval.py run-trtfb\n",
+        encoding="utf-8",
+    )
+    commands = (
+        {
+            "sample_id": "sample-1",
+            "command": ["trtmc", "segment-prompted", "model.trtfb", "--prompt", "cat"],
+        },
+        {
+            "sample_id": "sample-2",
+            "command": ["trtmc", "segment-prompted", "model.trtfb", "--prompt", "dog"],
+        },
+    )
+    (work_dir / "trtfb_native_commands.jsonl").write_text(
+        "".join(json.dumps(command) + "\n" for command in commands),
+        encoding="utf-8",
+    )
+
+    reproduction = trtmc_validate._commands_from_logs(work_dir)
+
+    assert reproduction["trtmc"] == [
+        "trtmc segment-prompted model.trtfb --prompt cat"
+    ]
+    assert reproduction["command_count"]["trtmc"] == 2
+    assert reproduction["command_logs"]["trtmc"] == [
+        "trtfb_native_commands.jsonl"
+    ]
+
+
 def test_failed_sample_uses_recorded_trtmc_command_and_copies_media(tmp_path):
     case_dir = tmp_path / "model-a" / "workload-a"
     work_dir = case_dir / "validation" / "workload-a" / "model-a"

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -1461,6 +1461,41 @@ def test_commands_from_logs_use_native_trtmc_jsonl(tmp_path: Path) -> None:
     ]
 
 
+def test_commands_from_logs_prefer_native_reference_jsonl(tmp_path: Path) -> None:
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    (work_dir / "prompts.jsonl").write_text(
+        json.dumps({"sample_id": "sample-1"}) + "\n",
+        encoding="utf-8",
+    )
+    (work_dir / "hf_run.log").write_text(
+        "$ python trtmc_reference.py run\n",
+        encoding="utf-8",
+    )
+    (work_dir / "hf_native_run.log").write_text(
+        "$ python plugin_reference.py\n",
+        encoding="utf-8",
+    )
+    (work_dir / "hf_native_commands.jsonl").write_text(
+        json.dumps(
+            {
+                "sample_id": "sample-1",
+                "command": ["python", "model_reference.py", "--prompt", "cat"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    reproduction = trtmc_validate._commands_from_logs(work_dir)
+
+    assert reproduction["hf"] == ["python model_reference.py --prompt cat"]
+    assert reproduction["command_count"]["hf"] == 1
+    assert reproduction["command_logs"]["hf"] == [
+        "hf_native_commands.jsonl"
+    ]
+
+
 def test_failed_sample_uses_recorded_trtmc_command_and_copies_media(tmp_path):
     case_dir = tmp_path / "model-a" / "workload-a"
     work_dir = case_dir / "validation" / "workload-a" / "model-a"

--- a/tests/tools/test_trtmc_validate.py
+++ b/tests/tools/test_trtmc_validate.py
@@ -38,7 +38,7 @@ def test_model_workload_catalog_covers_every_ready_model():
     assert len(catalog["models"]) == len(ready_models) == 105
     assert sum(
         "not_compared_reason" in spec for spec in catalog["models"].values()
-    ) == 10
+    ) == 8
     assert all(
         "e2e" not in spec.get("workloads", [])
         for spec in catalog["models"].values()
@@ -97,7 +97,7 @@ def test_every_dataset_backed_validation_binding_has_native_reference_runner():
             missing.append((model_name, workload, dataset_kind))
 
     assert not missing
-    assert len({model for model, _workload in bindings}) == 95
+    assert len({model for model, _workload in bindings}) == 97
 
 
 def test_resolve_binding_defaults_and_rejects_undeclared_workload():
@@ -905,6 +905,44 @@ def test_traffic_light_counts_are_mutually_exclusive():
         "red": 1,
         "white": 1,
     }
+
+
+def test_diffusion_report_flattens_nested_reference_metrics():
+    comparison = trtmc_validate._comparison_details(
+        {
+            "status": "passed",
+            "mode": "diffusion_image_clip_parity",
+            "overall_pass_rate": 1.0,
+            "passed_count": 5,
+            "valid_count": 5,
+            "skipped_count": 0,
+            "metrics": {
+                "trt_hf_image_clip_cosine": {
+                    "mean": 0.91,
+                    "min": 0.87,
+                    "max": 0.95,
+                    "count": 5,
+                },
+                "psnr": {
+                    "mean": 12.5,
+                    "min": 11.0,
+                    "max": 14.0,
+                    "count": 5,
+                },
+            },
+        },
+        {"status": "completed"},
+    )
+
+    assert comparison["primary_metric"] == {
+        "name": "overall_pass_rate",
+        "value": 1.0,
+    }
+    assert comparison["metrics"]["trt_hf_image_clip_cosine"] == 0.91
+    assert comparison["metrics"]["psnr"] == 12.5
+    assert "No metrics" not in trtmc_validate._render_metrics(
+        {"comparison": comparison}
+    )
 
 
 def test_legacy_e2e_result_is_not_reported_as_reference_agreement(tmp_path):

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -47,11 +47,13 @@ python tools/trtmc_validate.py gpt2-125m mmlu_continuation_parity \
   --output validation-artifacts
 ```
 
-The case result is always written to
+For configured consistency workloads, the case result is always written to
 `<output>/<model>/<workload>/comparison.json`; `report.json` and `report.html`
 are written at the output root. Exit status `0` means reference consistency
 passed, `1` means the case ran but validation failed, and `2` means CLI or
-setup validation failed before the case could run.
+setup validation failed before the case could run. Requesting a model that is
+explicitly marked not compared also writes
+`<output>/<model>/not-compared/comparison.json` and returns `2`.
 
 Dataset-backed workloads use the task-specific sample limits declared in
 `model_workloads.yaml`. Fast encoder and classification workloads use larger
@@ -80,13 +82,24 @@ directories therefore do not retain another copy of the bundle.
 
 At completion the command prints the exact reference and TRTMC reproduction
 commands, the per-model `comparison.json`, and the aggregate `report.html`.
-Dataset-backed comparison runs through `tools/trtmc_compare.py`; task-eval
+Comparison runs through `tools/trtmc_compare.py`; task-eval
 commands are not part of the validation result or its reproduction contract.
-Every non-`e2e` model/workload binding must resolve to an independent reference
+Every model/workload binding must resolve to an independent reference
 runner selected by the prepared dataset kind. A catalog-wide test rejects new
-bindings that would fall back to `task_eval.py`. Models whose validation
-contract is still only `e2e` continue to use the E2E path and are not presented
-as migrated task-eval workloads.
+bindings that would fall back to `task_eval.py` or E2E execution.
+
+Every agreement or disagreement therefore means that both backends consumed
+the aligned prepared inputs and produced outputs that were evaluated by the
+declared comparator. A model without that complete contract stays in the
+catalog with `not_compared_reason`. `--all` records it as a white **Not
+compared** row without launching E2E, creating a reference environment, or
+building an engine. Such rows make the aggregate report status `incomplete`;
+they are not agreements, disagreements, execution errors, or attempted model
+failures.
+
+`--all --dry-run` keeps these models visible with `workload: null`,
+`status: not_compared`, and the reason. CI matrix generation can select only
+entries that contain a workload.
 
 The HTML artifact is named **TRTMC Reference Consistency Report** because it
 covers task accuracy as well as token, embedding, and numerical agreement.
@@ -121,6 +134,9 @@ The report keeps three statuses separate:
 - `comparison`: whether TRTMC agrees or disagrees with the reference;
 - `validation`: the final pass, fail, or skipped result.
 
+An unimplemented consistency contract uses `execution: not_run`,
+`comparison: not_run`, and `validation: not_compared`.
+
 The HTML report renders each status as an independent colored signal and shows
 the primary agreement metric next to it.
 
@@ -132,6 +148,13 @@ the primary agreement metric next to it.
 3. Add a workload sample limit if the workload is new.
 4. Select one workload as the model default.
 
-Use `e2e` only when the model cannot use a dataset-backed workload yet. A model
-may list multiple workloads; callers select one by passing it after the model
-name.
+A model may list multiple workloads; callers select one by passing it after the
+model name. If the aligned reference/TRTMC comparison is not implemented yet,
+declare only:
+
+```yaml
+model-name:
+  not_compared_reason: Aligned reference workload and output comparator are not implemented.
+```
+
+Do not use `e2e` as a validation workload.

--- a/tests/validation/README.md
+++ b/tests/validation/README.md
@@ -73,7 +73,11 @@ The command creates a reference environment only when one does not already
 exist, then prints the environment it used. Reference inference runs through
 `tools/trtmc_reference.py`, outside the task-eval CLI. Its result is keyed by
 the input slice and inference settings and reused from the shared reference
-cache when the key already exists.
+cache when the key already exists. TRTMC variants may declare the same
+`reference_cache_identity` in `model_workloads.yaml` only when they use the
+same reference model, prepared inputs, and inference contract. The explicit
+identity lets those variants share one cached reference result without
+weakening cache isolation for other models.
 
 TRTMC bundles live in one shared validation engine directory. A required
 rebuild removes the existing bundle and writes the replacement at the same

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -34,10 +34,11 @@ sample_limits:
   wmt14_en_de_t5_translation_parity: 10
   xsum_elf_diffusion_text: 5
 
-# Model-first validation bindings. Workload names other than "e2e" refer to
-# dataset preparation and comparison contracts in
-# tests/task_eval/validation_suites.yaml. "e2e" reuses the model-owned E2E
-# cases when no compatible dataset-backed workload exists yet.
+# Model-first validation bindings. Workload names refer to aligned input,
+# reference inference, TRTMC inference, and output comparison contracts in
+# tests/task_eval/validation_suites.yaml. Models without that complete contract
+# remain visible as not compared; E2E execution is never treated as reference
+# consistency.
 models:
   albert-base:
     default: stsbenchmark_encoder_embedding_parity
@@ -157,8 +158,7 @@ models:
     default: vlm_mmmu_pro_vision_fixed_mcq
     workloads: [vlm_mmmu_pro_vision_fixed_mcq, vlm_mmmu_pro_vision_mcq]
   lance-3b-x2t-image:
-    default: e2e
-    workloads: [e2e]
+    not_compared_reason: Aligned reference workload and output comparator are not implemented.
   magpie-tts-357m:
     default: seedtts_en_tts_intelligibility
     workloads: [seedtts_en_tts_intelligibility]
@@ -196,8 +196,7 @@ models:
     default: mmlu_continuation_parity
     workloads: [mmlu_continuation_parity]
   nemotron-labs-diffusion-8b:
-    default: e2e
-    workloads: [e2e]
+    not_compared_reason: Aligned reference workload and output comparator are not implemented.
   nemotron-mini-4b:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
@@ -211,8 +210,7 @@ models:
     default: librispeech_clean_asr_streaming
     workloads: [librispeech_clean_asr_streaming]
   nllb-200-distilled-600m:
-    default: e2e
-    workloads: [e2e]
+    not_compared_reason: Aligned reference workload and output comparator are not implemented.
   olmo-1b:
     default: mmlu_continuation_parity
     workloads: [mmlu_continuation_parity]
@@ -235,8 +233,7 @@ models:
     default: etth1_time_series_parity
     workloads: [etth1_time_series_parity]
   personaplex-7b:
-    default: e2e
-    workloads: [e2e]
+    not_compared_reason: Aligned reference workload and output comparator are not implemented.
   phi-moe:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
@@ -244,8 +241,7 @@ models:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
   phi4-multimodal:
-    default: e2e
-    workloads: [e2e]
+    not_compared_reason: Aligned reference workload and output comparator are not implemented.
   pixart-sigma-1024:
     default: dpg_bench_diffusion_image
     workloads: [dpg_bench_diffusion_image]
@@ -268,11 +264,9 @@ models:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
   qwen3-0.6b-fp8:
-    default: e2e
-    workloads: [e2e]
+    not_compared_reason: Aligned reference workload and output comparator are not implemented.
   qwen3-0.6b-topp:
-    default: e2e
-    workloads: [e2e]
+    not_compared_reason: Aligned reference workload and output comparator are not implemented.
   qwen3-4b-instruct-2507:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
@@ -280,8 +274,7 @@ models:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
   qwen3-omni-30b-a3b-instruct:
-    default: e2e
-    workloads: [e2e]
+    not_compared_reason: Aligned reference workload and output comparator are not implemented.
   qwen3-vl-2b:
     default: vlm_mmmu_pro_vision_fixed_mcq
     workloads: [vlm_mmmu_pro_vision_fixed_mcq, vlm_mmmu_pro_vision_mcq]
@@ -331,11 +324,9 @@ models:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
   wan21-t2v-1.3b:
-    default: e2e
-    workloads: [e2e]
+    not_compared_reason: Aligned reference workload and output comparator are not implemented.
   wan22-ti2v-5b:
-    default: e2e
-    workloads: [e2e]
+    not_compared_reason: Aligned reference workload and output comparator are not implemented.
   whisper-large-v3-turbo:
     default: librispeech_clean_asr
     workloads: [librispeech_clean_asr]

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -264,9 +264,11 @@ models:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
   qwen3-0.6b-fp8:
-    not_compared_reason: Aligned reference workload and output comparator are not implemented.
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
   qwen3-0.6b-topp:
-    not_compared_reason: Aligned reference workload and output comparator are not implemented.
+    default: mmlu_five_shot_mcq
+    workloads: [mmlu_five_shot_mcq]
   qwen3-4b-instruct-2507:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]

--- a/tests/validation/model_workloads.yaml
+++ b/tests/validation/model_workloads.yaml
@@ -124,9 +124,11 @@ models:
   flux-2-dev:
     default: dpg_bench_diffusion_image
     workloads: [dpg_bench_diffusion_image]
+    reference_cache_identity: flux-2-dev-dpg-v1
   flux-2-dev-fp8:
     default: dpg_bench_diffusion_image
     workloads: [dpg_bench_diffusion_image]
+    reference_cache_identity: flux-2-dev-dpg-v1
   flux-schnell:
     default: dpg_bench_diffusion_image
     workloads: [dpg_bench_diffusion_image]
@@ -263,12 +265,15 @@ models:
   qwen3-0.6b-fp16:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
+    reference_cache_identity: qwen3-0.6b-mmlu-five-shot-v1
   qwen3-0.6b-fp8:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
+    reference_cache_identity: qwen3-0.6b-mmlu-five-shot-v1
   qwen3-0.6b-topp:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]
+    reference_cache_identity: qwen3-0.6b-mmlu-five-shot-v1
   qwen3-4b-instruct-2507:
     default: mmlu_five_shot_mcq
     workloads: [mmlu_five_shot_mcq]

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -3005,6 +3005,20 @@ def _parse_generated_token_ids(text: str) -> list[int] | None:
     return None
 
 
+def _run_captured_utf8_subprocess(
+    command: Sequence[str],
+    **kwargs: Any,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(command),
+        check=False,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        **kwargs,
+    )
+
+
 def _parse_transcribe_stdout(text: str) -> str:
     for line in str(text or "").splitlines():
         cleaned = re.sub(r"<\|[^|]+\|>", "", line).strip()
@@ -3200,11 +3214,8 @@ def run_vlm_trtfb(args: argparse.Namespace) -> None:
             )
             log_f.write(f"$ {' '.join(cmd)}\n")
             start = time.perf_counter()
-            proc = subprocess.run(
+            proc = _run_captured_utf8_subprocess(
                 cmd,
-                check=False,
-                text=True,
-                capture_output=True,
                 env=env,
             )
             wall_ms = (time.perf_counter() - start) * 1000.0
@@ -3286,11 +3297,8 @@ def run_asr_trtfb(args: argparse.Namespace) -> None:
             )
             log_f.write(f"$ {' '.join(cmd)}\n")
             start = time.perf_counter()
-            proc = subprocess.run(
+            proc = _run_captured_utf8_subprocess(
                 cmd,
-                check=False,
-                text=True,
-                capture_output=True,
                 env=env,
             )
             wall_ms = (time.perf_counter() - start) * 1000.0

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -431,10 +431,22 @@ def manifest_record(path: Path) -> dict[str, Any]:
             raw = {**raw, **canonical, "name": model_name}
     build_args = raw.get("build_args", {})
     task_eval_config = raw.get("task_eval", {})
+    if not isinstance(task_eval_config, dict):
+        task_eval_config = {}
     runtime_strategy = str(raw.get("runtime_strategy") or "")
     task_strategy = str(raw.get("task_strategy") or runtime_strategy)
-    reference_family = infer_reference_family(raw)
-    reference_backend = str(raw.get("reference_backend", "") or "")
+    # A model's E2E testcase may exercise a different contract from its
+    # dataset-backed validation workload (for example seeded top-p sampling
+    # versus deterministic MMLU). Keep the E2E fields intact and let the
+    # task-eval section declare validation-specific reference semantics.
+    reference_family = str(
+        task_eval_config.get("reference_family") or infer_reference_family(raw)
+    )
+    reference_backend = str(
+        task_eval_config.get("reference_backend")
+        or raw.get("reference_backend", "")
+        or ""
+    )
     if not reference_backend:
         try:
             with warnings.catch_warnings():
@@ -442,7 +454,10 @@ def manifest_record(path: Path) -> dict[str, Any]:
                 reference_backend = load_manifest(path).reference_backend
         except Exception:
             reference_backend = "hf_transformers"
-    user_contract = infer_user_contract(raw, reference_family)
+    user_contract = str(
+        task_eval_config.get("user_contract")
+        or infer_user_contract(raw, reference_family)
+    )
     distributed = raw.get("distributed_runtime", {})
     requires_multi_device = bool(distributed.get("enabled")) or (
         str(raw.get("ci_tier", "")) == "multi_device"
@@ -484,7 +499,7 @@ def manifest_record(path: Path) -> dict[str, Any]:
         "video_height": raw.get("video_height"),
         "video_width": raw.get("video_width"),
         "num_inference_steps": raw.get("num_inference_steps"),
-        "task_eval": task_eval_config if isinstance(task_eval_config, dict) else {},
+        "task_eval": task_eval_config,
         "runtime_config": raw.get("runtime_config", {})
         if isinstance(raw.get("runtime_config", {}), dict)
         else {},

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -8762,6 +8762,13 @@ def run_hf_reference_subprocess(
     )
     if reference_cache_dir:
         cmd.extend(["--cache-dir", reference_cache_dir])
+    reference_cache_identity = str(
+        getattr(args, "reference_cache_identity", "") or ""
+    )
+    if reference_cache_identity:
+        cmd.extend(
+            ["--reference-cache-identity", reference_cache_identity]
+        )
     if hf_args.device_map:
         cmd.extend(["--device-map", str(hf_args.device_map)])
     if hf_args.attn_impl:
@@ -10813,6 +10820,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--reference-cache-dir",
         default="",
         help="Shared setting-keyed cache managed by tools/trtmc_reference.py.",
+    )
+    p.add_argument(
+        "--reference-cache-identity",
+        default="",
+        help=(
+            "Explicit identity for TRTMC variants that share one reference "
+            "contract and may reuse the same cached reference result."
+        ),
     )
     p.add_argument("--force-build", action="store_true", help="Rebuild the .trtfb bundle.")
     p.add_argument(

--- a/tools/task_eval.py
+++ b/tools/task_eval.py
@@ -6916,14 +6916,20 @@ def _vision_response(
             masks_path = _persist_numpy_output(
                 masks, artifact_dir / case.name / f"{source}_masks.npy"
             )
-        if not masks_path or not Path(masks_path).is_file():
+        num_masks = int(data.get("num_masks", len(masks) if masks is not None else 0))
+        stderr = str(metadata.get("stderr", "") or "")
+        empty_prediction = num_masks == 0 and (
+            masks is not None or "produced no masks" in stderr.lower()
+        )
+        if (not masks_path or not Path(masks_path).is_file()) and not empty_prediction:
             raise RuntimeError(f"{source} prompted segmentation produced no masks")
         scores = data.get("mask_scores") or data.get("iou_scores") or data.get("scores") or []
         response.update(
             {
                 "masks_path": masks_path,
                 "mask_scores": [float(value) for value in scores],
-                "num_masks": int(data.get("num_masks", 0)),
+                "num_masks": num_masks,
+                "empty_prediction": empty_prediction,
                 "point_x": prompt_row.get("point_x"),
                 "point_y": prompt_row.get("point_y"),
                 "text_prompt": str(prompt_row.get("text_prompt", "")),
@@ -7021,7 +7027,7 @@ def run_vision_trtfb(args: argparse.Namespace) -> None:
                 prompt_row=prompt_row,
                 artifact_dir=artifacts_dir,
             )
-            if response["returncode"] != 0:
+            if response["returncode"] != 0 and not response.get("empty_prediction"):
                 raise RuntimeError(
                     f"TRT vision run failed for {case.name}: "
                     f"returncode={response['returncode']}"
@@ -9375,6 +9381,20 @@ def _selected_prompt_mask(masks: Any, scores: list[Any], prompt_mode: str) -> An
     return masks[min(index, masks.shape[0] - 1)]
 
 
+def _selected_prompt_prediction_mask(
+    row: dict[str, Any], prompt_mode: str, target_shape: tuple[int, ...]
+) -> Any:
+    import numpy as np
+
+    if bool(row.get("empty_prediction")) or int(row.get("num_masks", -1)) == 0:
+        return np.zeros(target_shape, dtype=bool)
+    return _selected_prompt_mask(
+        _mask_stack(str(row["masks_path"])),
+        list(row.get("mask_scores", [])),
+        prompt_mode,
+    )
+
+
 def _binary_mask_iou(left: Any, right: Any) -> float:
     import numpy as np
 
@@ -9410,17 +9430,17 @@ def compare_prompted_segmentation_prediction_sets(
         if hf_row is None or trtfb_row is None:
             cases.append({"sample_id": sample_id, "passed": False, "error": "missing prediction"})
             continue
-        hf_mask = _selected_prompt_mask(
-            _mask_stack(str(hf_row["masks_path"])),
-            list(hf_row.get("mask_scores", [])),
-            prompt_mode,
-        )
-        trtfb_mask = _selected_prompt_mask(
-            _mask_stack(str(trtfb_row["masks_path"])),
-            list(trtfb_row.get("mask_scores", [])),
-            prompt_mode,
-        )
         ground_truth = _load_segmentation_array(str(request[ground_truth_mask_field])) > 0
+        hf_mask = _selected_prompt_prediction_mask(
+            hf_row,
+            prompt_mode,
+            ground_truth.shape,
+        )
+        trtfb_mask = _selected_prompt_prediction_mask(
+            trtfb_row,
+            prompt_mode,
+            ground_truth.shape,
+        )
         backend_iou = _binary_mask_iou(hf_mask, trtfb_mask)
         hf_gt_iou = _binary_mask_iou(ground_truth, hf_mask)
         trtfb_gt_iou = _binary_mask_iou(ground_truth, trtfb_mask)
@@ -9433,6 +9453,8 @@ def compare_prompted_segmentation_prediction_sets(
                 "hf_ground_truth_iou": hf_gt_iou,
                 "trtfb_ground_truth_iou": trtfb_gt_iou,
                 "ground_truth_iou_drop_from_hf": hf_gt_iou - trtfb_gt_iou,
+                "hf_empty_prediction": bool(hf_row.get("empty_prediction")),
+                "trtfb_empty_prediction": bool(trtfb_row.get("empty_prediction")),
                 "hf_segmented_image_path": str(hf_row.get("segmented_image_path", "")),
                 "trtfb_segmented_image_path": str(
                     trtfb_row.get("segmented_image_path", "")

--- a/tools/trtmc_reference.py
+++ b/tools/trtmc_reference.py
@@ -104,11 +104,28 @@ def _input_files(work_dir: Path) -> Iterable[Path]:
         yield path
 
 
-def _hash_file(hasher: Any, path: Path, work_dir: Path) -> None:
+def _hash_file(
+    hasher: Any,
+    path: Path,
+    work_dir: Path,
+    *,
+    reference_cache_identity: str = "",
+) -> None:
     relative = path.relative_to(work_dir)
     hasher.update(str(relative).encode())
     if path.suffix.lower() in _TEXT_SUFFIXES and path.stat().st_size <= 32 * 1024 * 1024:
         content = path.read_text(encoding="utf-8", errors="replace")
+        if relative == Path("manifest.json"):
+            if reference_cache_identity:
+                manifest = json.loads(content)
+                task_config = manifest.get("task_eval", {})
+                if isinstance(task_config, dict) and "model_manifest" in task_config:
+                    task_config["model_manifest"] = "<REFERENCE_CACHE_IDENTITY>"
+                    content = json.dumps(
+                        manifest,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    )
         hasher.update(content.replace(str(work_dir), "<WORK_DIR>").encode())
         return
     with path.open("rb") as stream:
@@ -118,7 +135,7 @@ def _hash_file(hasher: Any, path: Path, work_dir: Path) -> None:
 
 def _settings(args: argparse.Namespace) -> dict[str, Any]:
     native_runner = _native_reference_runner(args)
-    return {
+    settings = {
         "implementation": CACHE_IMPLEMENTATION,
         "native_runner": _native_runner_identity(native_runner),
         "python": str(Path(sys.executable).resolve()),
@@ -142,6 +159,12 @@ def _settings(args: argparse.Namespace) -> dict[str, Any]:
         "min_p": args.min_p,
         "seed": args.seed,
     }
+    reference_cache_identity = str(
+        getattr(args, "reference_cache_identity", "") or ""
+    )
+    if reference_cache_identity:
+        settings["reference_cache_identity"] = reference_cache_identity
+    return settings
 
 
 def native_reference_runner_for_dataset_kind(dataset_kind: str) -> Path | None:
@@ -180,8 +203,16 @@ def reference_key(args: argparse.Namespace) -> tuple[str, dict[str, Any]]:
     settings = _settings(args)
     hasher = hashlib.sha256()
     hasher.update(json.dumps(settings, sort_keys=True, separators=(",", ":")).encode())
+    reference_cache_identity = str(
+        getattr(args, "reference_cache_identity", "") or ""
+    )
     for path in _input_files(work_dir):
-        _hash_file(hasher, path, work_dir)
+        _hash_file(
+            hasher,
+            path,
+            work_dir,
+            reference_cache_identity=reference_cache_identity,
+        )
     return hasher.hexdigest(), settings
 
 
@@ -488,6 +519,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--reference-family", default="")
     parser.add_argument("--work-dir", required=True)
     parser.add_argument("--cache-dir", default="")
+    parser.add_argument(
+        "--reference-cache-identity",
+        default="",
+        help=(
+            "Explicit identity shared by TRTMC variants with the same reference "
+            "contract. This replaces task_eval.model_manifest only in the cache key."
+        ),
+    )
     parser.add_argument("--predictions", default="hf_predictions.json")
     parser.add_argument("--raw-output", default="hf_raw.jsonl")
     parser.add_argument("--dtype", choices=("auto", "float16", "bfloat16"), default="auto")

--- a/tools/trtmc_reference.py
+++ b/tools/trtmc_reference.py
@@ -30,6 +30,7 @@ from tools import task_eval  # noqa: E402
 
 CACHE_SCHEMA = "trtmc.reference-cache/v1"
 CACHE_IMPLEMENTATION = 1
+REFERENCE_CACHE_IDENTITY_IMPLEMENTATION = 2
 _CACHE_METADATA = "reference.json"
 _WORK_METADATA = "hf_cache.json"
 _NATIVE_RUN_LOG = "hf_native_run.log"
@@ -71,6 +72,13 @@ _IGNORED_INPUT_NAMES = {
     "trtfb_run.log",
     "visual_review.html",
 }
+_NATIVE_RUNNER_VARIANT_TASK_KEYS = {
+    "family",
+    "model_max_new_tokens",
+    "reference_backend",
+    "reference_family",
+    "user_contract",
+}
 
 
 class ReferenceError(RuntimeError):
@@ -104,6 +112,24 @@ def _input_files(work_dir: Path) -> Iterable[Path]:
         yield path
 
 
+def _normalize_identity_manifest(content: str) -> str:
+    manifest = json.loads(content)
+    task_config = manifest.get("task_eval", {})
+    if not isinstance(task_config, dict):
+        return content
+    if "model_manifest" in task_config:
+        task_config["model_manifest"] = "<REFERENCE_CACHE_IDENTITY>"
+    dataset_kind = str(manifest.get("dataset_kind", "") or "")
+    if native_reference_runner_for_dataset_kind(dataset_kind) is not None:
+        for name in _NATIVE_RUNNER_VARIANT_TASK_KEYS:
+            task_config.pop(name, None)
+    return json.dumps(
+        manifest,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
 def _hash_file(
     hasher: Any,
     path: Path,
@@ -117,15 +143,7 @@ def _hash_file(
         content = path.read_text(encoding="utf-8", errors="replace")
         if relative == Path("manifest.json"):
             if reference_cache_identity:
-                manifest = json.loads(content)
-                task_config = manifest.get("task_eval", {})
-                if isinstance(task_config, dict) and "model_manifest" in task_config:
-                    task_config["model_manifest"] = "<REFERENCE_CACHE_IDENTITY>"
-                    content = json.dumps(
-                        manifest,
-                        sort_keys=True,
-                        separators=(",", ":"),
-                    )
+                content = _normalize_identity_manifest(content)
         hasher.update(content.replace(str(work_dir), "<WORK_DIR>").encode())
         return
     with path.open("rb") as stream:
@@ -164,6 +182,9 @@ def _settings(args: argparse.Namespace) -> dict[str, Any]:
     )
     if reference_cache_identity:
         settings["reference_cache_identity"] = reference_cache_identity
+        settings["reference_cache_identity_implementation"] = (
+            REFERENCE_CACHE_IDENTITY_IMPLEMENTATION
+        )
     return settings
 
 
@@ -524,7 +545,8 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help=(
             "Explicit identity shared by TRTMC variants with the same reference "
-            "contract. This replaces task_eval.model_manifest only in the cache key."
+            "contract. Native-runner cache keys normalize variant-only task metadata "
+            "while preserving prepared inputs and effective inference settings."
         ),
     )
     parser.add_argument("--predictions", default="hf_predictions.json")

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -745,9 +745,12 @@ def _command_log_kind(
     path: Path,
     *,
     has_native_reference: bool,
+    has_native_reference_commands: bool,
     has_native_trtmc: bool,
 ) -> str | None:
     if has_native_reference and path.name == "hf_run.log":
+        return None
+    if has_native_reference_commands and path.name == "hf_native_run.log":
         return None
     if has_native_trtmc and path.name == "trtfb_run.log":
         return None
@@ -798,6 +801,9 @@ def _collect_command_logs(
         path.name in {"hf_native_run.log", "hf_native_commands.jsonl"}
         for path in log_paths
     )
+    has_native_reference_commands = any(
+        path.name == "hf_native_commands.jsonl" for path in log_paths
+    )
     has_native_trtmc = any(
         path.name == "trtfb_native_commands.jsonl" for path in log_paths
     )
@@ -805,6 +811,7 @@ def _collect_command_logs(
         kind = _command_log_kind(
             path,
             has_native_reference=has_native_reference,
+            has_native_reference_commands=has_native_reference_commands,
             has_native_trtmc=has_native_trtmc,
         )
         if kind is None:

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -36,7 +36,6 @@ from tensorrt_model_connect.python_profiles import (  # noqa: E402
     profile_env_var,
     resolve_profile_python,
 )
-from tests.e2e_harness.manifest_loader import load_all_model_manifests  # noqa: E402
 from tools import task_eval, trtmc_disagreements  # noqa: E402
 
 
@@ -47,6 +46,10 @@ DEFAULT_OUTPUT = REPO_ROOT / "artifacts" / "trtmc-validate"
 DEFAULT_ENGINE_DIR = DEFAULT_OUTPUT / "engines"
 DEFAULT_REFERENCE_CACHE = DEFAULT_OUTPUT / "references"
 COMMON_REFERENCE_PROFILE = "reference_common"
+NOT_COMPARED_DIRECTORY = "not-compared"
+LEGACY_E2E_REASON = (
+    "E2E execution does not compare aligned reference and TRTMC outputs."
+)
 
 
 class ValidationError(RuntimeError):
@@ -56,7 +59,26 @@ class ValidationError(RuntimeError):
 @dataclass(frozen=True)
 class Binding:
     model: str
-    workload: str
+    workload: str | None
+    not_compared_reason: str = ""
+
+    @property
+    def runnable(self) -> bool:
+        return self.workload is not None
+
+
+def _required_workload(binding: Binding) -> str:
+    if binding.workload is None:
+        raise ValidationError(
+            f"model {binding.model} has no reference-consistency workload"
+        )
+    return binding.workload
+
+
+def _case_directory(output: Path, binding: Binding) -> Path:
+    return output / binding.model / (
+        binding.workload if binding.workload is not None else NOT_COMPARED_DIRECTORY
+    )
 
 
 @dataclass(frozen=True)
@@ -100,6 +122,17 @@ SANA_WM_SOURCE = ReferenceSource(
 def _validate_model_spec(path: Path, name: Any, spec: Any) -> None:
     if not isinstance(name, str) or not isinstance(spec, dict):
         raise ValidationError(f"{path}: invalid model binding {name!r}")
+    not_compared_reason = spec.get("not_compared_reason")
+    if not_compared_reason is not None:
+        if not isinstance(not_compared_reason, str) or not not_compared_reason.strip():
+            raise ValidationError(
+                f"{path}: {name}.not_compared_reason must be a non-empty string"
+            )
+        if "default" in spec or "workloads" in spec:
+            raise ValidationError(
+                f"{path}: {name} cannot declare workloads while marked not compared"
+            )
+        return
     workloads = spec.get("workloads")
     default = spec.get("default")
     valid_workloads = (
@@ -109,6 +142,11 @@ def _validate_model_spec(path: Path, name: Any, spec: Any) -> None:
     )
     if not valid_workloads:
         raise ValidationError(f"{path}: {name}.workloads must contain names")
+    if "e2e" in workloads:
+        raise ValidationError(
+            f"{path}: {name}.workloads cannot use e2e; reference consistency "
+            "requires aligned reference and TRTMC outputs"
+        )
     if default not in workloads:
         raise ValidationError(f"{path}: {name}.default must be one of {name}.workloads")
 
@@ -171,12 +209,12 @@ def audit_catalog(
             details.append(f"non-ready or unknown models: {', '.join(stale)}")
         raise ValidationError("; ".join(details))
 
-    known_workloads = set(suite_names) | {"e2e"}
+    known_workloads = set(suite_names)
     unknown = sorted(
         {
             workload
             for spec in models.values()
-            for workload in spec["workloads"]
+            for workload in spec.get("workloads", [])
             if workload not in known_workloads
         }
     )
@@ -186,8 +224,7 @@ def audit_catalog(
     declared_sampled = {
         workload
         for spec in models.values()
-        for workload in spec["workloads"]
-        if workload != "e2e"
+        for workload in spec.get("workloads", [])
     }
     configured_sampled = set(catalog["sample_limits"])
     missing_limits = sorted(declared_sampled - configured_sampled)
@@ -209,9 +246,7 @@ def audit_workload_compatibility(
 ) -> None:
     incompatible = []
     for model_name, spec in catalog["models"].items():
-        for workload in spec["workloads"]:
-            if workload == "e2e":
-                continue
+        for workload in spec.get("workloads", []):
             matched, reason = task_eval.suite_match_reason(
                 suites[workload],
                 task_models[model_name],
@@ -231,6 +266,18 @@ def resolve_binding(
     if model not in models:
         raise ValidationError(f"unknown or unsupported model: {model}")
     spec = models[model]
+    not_compared_reason = str(spec.get("not_compared_reason", "") or "")
+    if not_compared_reason:
+        if workload:
+            raise ValidationError(
+                f"model {model} has no reference-consistency workloads: "
+                f"{not_compared_reason}"
+            )
+        return Binding(
+            model=model,
+            workload=None,
+            not_compared_reason=not_compared_reason,
+        )
     selected = workload or spec["default"]
     if selected not in spec["workloads"]:
         available = ", ".join(spec["workloads"])
@@ -245,21 +292,18 @@ def resolve_sample_limit(
     binding: Binding,
     explicit_limit: int | None,
 ) -> int:
-    if explicit_limit is not None:
-        if explicit_limit < 0:
-            raise ValidationError("--limit must be zero or greater")
-        return explicit_limit
-    if binding.workload == "e2e":
+    if explicit_limit is not None and explicit_limit < 0:
+        raise ValidationError("--limit must be zero or greater")
+    if not binding.runnable:
         return 0
+    if explicit_limit is not None:
+        return explicit_limit
+    assert binding.workload is not None
     return int(catalog["sample_limits"][binding.workload])
 
 
 def _task_eval_models(models_root: Path) -> dict[str, dict[str, Any]]:
     return {str(model["name"]): model for model in task_eval.load_manifest_records(models_root)}
-
-
-def _e2e_models(models_root: Path) -> dict[str, Any]:
-    return {model.name: model for model in load_all_model_manifests(models_root)}
 
 
 def _declared_profile(
@@ -285,33 +329,23 @@ def _binding_profiles(
     binding: Binding,
     *,
     task_models: Mapping[str, dict[str, Any]],
-    e2e_models: Mapping[str, Any],
 ) -> tuple[str, ...]:
-    if binding.workload != "e2e":
-        model = task_models[binding.model]
-        profile = _declared_profile(
-            family=str(model.get("family", "") or ""),
-            runtime_strategy=str(model.get("runtime_strategy", "") or ""),
-            reference_backend=str(model.get("reference_backend", "") or ""),
-            execution_profiles=model.get("execution_profiles"),
+    if not binding.runnable:
+        raise ValidationError(
+            f"model {binding.model} has no reference-consistency workload"
         )
-        return (
-            (COMMON_REFERENCE_PROFILE,)
-            if profile == COMMON_REFERENCE_PROFILE
-            else (COMMON_REFERENCE_PROFILE, profile)
-        )
-
-    profiles = [COMMON_REFERENCE_PROFILE]
-    for case in e2e_models[binding.model].testcases:
-        profile = _declared_profile(
-            family=case.family,
-            runtime_strategy=case.runtime_strategy,
-            reference_backend=case.reference_backend,
-            execution_profiles=case.execution_profiles,
-        )
-        if profile not in profiles:
-            profiles.append(profile)
-    return tuple(profiles)
+    model = task_models[binding.model]
+    profile = _declared_profile(
+        family=str(model.get("family", "") or ""),
+        runtime_strategy=str(model.get("runtime_strategy", "") or ""),
+        reference_backend=str(model.get("reference_backend", "") or ""),
+        execution_profiles=model.get("execution_profiles"),
+    )
+    return (
+        (COMMON_REFERENCE_PROFILE,)
+        if profile == COMMON_REFERENCE_PROFILE
+        else (COMMON_REFERENCE_PROFILE, profile)
+    )
 
 
 def ensure_environments(
@@ -467,11 +501,12 @@ def _comparison_command(
     reference_sources: ReferenceSourceSelection | None = None,
 ) -> list[str]:
     work_root = case_dir / "validation"
+    workload = _required_workload(binding)
     command = [
         reference_python,
         str(REPO_ROOT / "tools" / "trtmc_compare.py"),
         "--suite",
-        binding.workload,
+        workload,
         "--dataset",
         str(dataset),
         "--model",
@@ -516,39 +551,6 @@ def _comparison_command(
                 str(reference_sources.elf_reference_repo),
             ]
         )
-    return command
-
-
-def _e2e_command(
-    binding: Binding,
-    *,
-    case_dir: Path,
-    arguments: argparse.Namespace,
-    reference_python: str,
-) -> list[str]:
-    command = [
-        reference_python,
-        "-m",
-        "pytest",
-        "tests/test_e2e.py",
-        "-q",
-        "--e2e-model",
-        binding.model,
-        "--e2e-artifacts-dir",
-        str(case_dir / "e2e"),
-        "--engine-dir",
-        str(arguments.engine_dir),
-        "--trtmc-binary",
-        str(arguments.trtmc_binary),
-        "--hf-python",
-        reference_python,
-    ]
-    if arguments.platform:
-        command.extend(["--e2e-platform", arguments.platform])
-    if arguments.force_build:
-        command.append("--rebuild-engines")
-    if arguments.model_plugin_dir:
-        command.extend(["--model-plugin-dir", str(arguments.model_plugin_dir)])
     return command
 
 
@@ -793,52 +795,6 @@ def _append_unique(commands: dict[str, list[str]], kind: str, command: str) -> N
         commands[kind].append(command)
 
 
-def _e2e_command_kind(command: Sequence[Any]) -> str:
-    executable = Path(str(command[0])).name
-    is_reference_python = "python" in executable and "-c" in command
-    return "hf" if is_reference_python else "trtmc"
-
-
-def _collect_e2e_result_commands(
-    commands: dict[str, list[str]],
-    result: Mapping[str, Any],
-) -> None:
-    for entry in result.get("commands", []):
-        command = entry.get("command", []) if isinstance(entry, dict) else []
-        if not isinstance(command, list) or not command:
-            continue
-        _append_unique(
-            commands,
-            _e2e_command_kind(command),
-            shlex.join(str(token) for token in command),
-        )
-    repro = result.get("repro_commands", {})
-    if isinstance(repro, dict):
-        _append_unique(
-            commands,
-            "trtmc",
-            str(repro.get("trt_inference", "") or ""),
-        )
-
-
-def _commands_from_e2e_results(results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
-    commands = {"hf": [], "trtmc": []}
-    for result in results:
-        _collect_e2e_result_commands(commands, result)
-    counts = {kind: len(values) for kind, values in commands.items()}
-    commands = {
-        kind: values[:MAX_REPRO_COMMANDS_PER_BACKEND]
-        for kind, values in commands.items()
-    }
-    return {
-        **commands,
-        "command_count": counts,
-        "commands_shown": {kind: len(values) for kind, values in commands.items()},
-        "command_logs": {"hf": [], "trtmc": []},
-        "representative": {"sample_id": "", "reason": "first_input"},
-    }
-
-
 _PRIMARY_COMPARISON_METRICS = (
     "sample_agreement_rate",
     "prediction_agreement_rate",
@@ -903,13 +859,6 @@ def _raw_comparison(result: Mapping[str, Any]) -> dict[str, Any]:
     raw_result = result.get("raw_result")
     if isinstance(raw_result, dict) and raw_result:
         return dict(raw_result)
-    raw_results = result.get("raw_results")
-    if isinstance(raw_results, list) and raw_results:
-        passed = all(
-            isinstance(item, dict) and item.get("status") in {"pass", "passed"}
-            for item in raw_results
-        )
-        return {"mode": "e2e", "status": "passed" if passed else "failed"}
     status = str(result.get("status", "") or "")
     return {"status": status} if status else {}
 
@@ -1068,6 +1017,25 @@ def _add_dataset_reproduction(
 
 def _normalize_result(result: Mapping[str, Any]) -> dict[str, Any]:
     normalized = dict(result)
+    if normalized.get("executor") == "e2e" or isinstance(
+        normalized.get("raw_results"),
+        list,
+    ):
+        normalized.update(
+            {
+                "workload": None,
+                "execution": {"status": "not_run", "exit_code": None},
+                "comparison": {
+                    "status": "not_run",
+                    "mode": "",
+                    "primary_metric": None,
+                    "metrics": {},
+                    "failures": [],
+                },
+                "validation": {"status": "not_compared"},
+                "not_compared_reason": LEGACY_E2E_REASON,
+            }
+        )
     raw_result = _raw_comparison(normalized)
     execution = normalized.get("execution")
     if not isinstance(execution, dict):
@@ -1092,6 +1060,42 @@ def _normalize_result(result: Mapping[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+def _not_compared_result(binding: Binding) -> dict[str, Any]:
+    return _normalize_result(
+        {
+            "schema_version": "trtmc.validation-result/v2",
+            "model": binding.model,
+            "workload": None,
+            "executor": "not_compared",
+            "execution": {"status": "not_run", "exit_code": None},
+            "comparison": {
+                "status": "not_run",
+                "mode": "",
+                "primary_metric": None,
+                "metrics": {},
+                "failures": [],
+            },
+            "validation": {"status": "not_compared"},
+            "not_compared_reason": binding.not_compared_reason,
+            "reference_environment": [],
+            "reproduce": {},
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+
+
+def _write_not_compared_case(binding: Binding, output: Path) -> tuple[dict[str, Any], Path]:
+    case_dir = _case_directory(output, binding)
+    case_dir.mkdir(parents=True, exist_ok=True)
+    result = _not_compared_result(binding)
+    comparison = case_dir / "comparison.json"
+    comparison.write_text(
+        json.dumps(result, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return result, comparison
+
+
 def _comparison_result(
     binding: Binding,
     *,
@@ -1101,7 +1105,8 @@ def _comparison_result(
     dataset_command: str,
     sample_limit: int = 0,
 ) -> dict[str, Any]:
-    summary_path = case_dir / "validation" / binding.workload / "eval_summary.json"
+    workload = _required_workload(binding)
+    summary_path = case_dir / "validation" / workload / "eval_summary.json"
     raw_result: dict[str, Any] = {}
     if summary_path.is_file():
         summary = json.loads(summary_path.read_text(encoding="utf-8"))
@@ -1123,7 +1128,7 @@ def _comparison_result(
     status = str(raw_result.get("status", "") or "")
     if status not in {"passed", "failed", "skipped"}:
         status = "passed" if returncode == 0 else "failed"
-    work_dir = case_dir / "validation" / binding.workload / binding.model
+    work_dir = case_dir / "validation" / workload / binding.model
     disagreements = trtmc_disagreements.build_disagreement_artifact(
         work_dir=work_dir,
         case_dir=case_dir,
@@ -1151,58 +1156,19 @@ def _comparison_result(
     })
 
 
-def _e2e_result(
-    binding: Binding,
-    *,
-    case_dir: Path,
-    returncode: int,
-    reference_environment: EnvironmentSelection,
-    dataset_command: str,
-) -> dict[str, Any]:
-    result_paths = sorted((case_dir / "e2e").glob("*/result.json"))
-    raw_results = [json.loads(path.read_text(encoding="utf-8")) for path in result_paths]
-    status = (
-        "passed"
-        if returncode == 0
-        and raw_results
-        and all(result.get("status") == "pass" for result in raw_results)
-        else "failed"
-    )
-    return _normalize_result({
-        "schema_version": "trtmc.validation-result/v2",
-        "model": binding.model,
-        "workload": binding.workload,
-        "executor": "e2e",
-        "status": status,
-        "returncode": returncode,
-        "reference_environment": [
-            {"name": name, "python": path} for name, path in reference_environment.names_and_paths
-        ],
-        "reproduce": _add_dataset_reproduction(
-            _commands_from_e2e_results(raw_results),
-            dataset_command,
-        ),
-        "raw_result_paths": [str(path) for path in result_paths],
-        "raw_results": raw_results,
-        "execution_log": str(case_dir / "execution.log"),
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    })
-
-
 def run_binding(
     binding: Binding,
     *,
     arguments: argparse.Namespace,
     task_models: Mapping[str, dict[str, Any]],
-    e2e_models: Mapping[str, Any],
     suites: Mapping[str, dict[str, Any]],
 ) -> dict[str, Any]:
-    case_dir = Path(arguments.output) / binding.model / binding.workload
+    workload = _required_workload(binding)
+    case_dir = _case_directory(Path(arguments.output), binding)
     case_dir.mkdir(parents=True, exist_ok=True)
     profiles = _binding_profiles(
         binding,
         task_models=task_models,
-        e2e_models=e2e_models,
     )
     environment = ensure_environments(profiles, str(arguments.hf_python))
     reference_sources = ensure_reference_sources(
@@ -1214,45 +1180,29 @@ def run_binding(
     process_env.update(reference_sources.environment)
     dataset_command = shlex.join([sys.executable, *sys.argv])
 
-    if binding.workload == "e2e":
-        command = _e2e_command(
-            binding,
-            case_dir=case_dir,
-            arguments=arguments,
-            reference_python=environment.base_python,
-        )
-        returncode = _run_subprocess(command, case_dir / "execution.log", process_env)
-        result = _e2e_result(
-            binding,
-            case_dir=case_dir,
-            returncode=returncode,
-            reference_environment=environment,
-            dataset_command=dataset_command,
-        )
-    else:
-        suite = suites[binding.workload]
-        dataset = (
-            Path(arguments.dataset)
-            if arguments.dataset
-            else _dataset_path(suite, arguments.dataset_root)
-        )
-        command = _comparison_command(
-            binding,
-            case_dir=case_dir,
-            dataset=dataset,
-            arguments=arguments,
-            reference_python=environment.base_python,
-            reference_sources=reference_sources,
-        )
-        returncode = _run_subprocess(command, case_dir / "execution.log", process_env)
-        result = _comparison_result(
-            binding,
-            case_dir=case_dir,
-            returncode=returncode,
-            reference_environment=environment,
-            dataset_command=dataset_command,
-            sample_limit=int(arguments.limit or 0),
-        )
+    suite = suites[workload]
+    dataset = (
+        Path(arguments.dataset)
+        if arguments.dataset
+        else _dataset_path(suite, arguments.dataset_root)
+    )
+    command = _comparison_command(
+        binding,
+        case_dir=case_dir,
+        dataset=dataset,
+        arguments=arguments,
+        reference_python=environment.base_python,
+        reference_sources=reference_sources,
+    )
+    returncode = _run_subprocess(command, case_dir / "execution.log", process_env)
+    result = _comparison_result(
+        binding,
+        case_dir=case_dir,
+        returncode=returncode,
+        reference_environment=environment,
+        dataset_command=dataset_command,
+        sample_limit=int(arguments.limit or 0),
+    )
 
     comparison = case_dir / "comparison.json"
     comparison.write_text(
@@ -1581,6 +1531,13 @@ def _render_reproduction(
     case_dir: Path,
     artifact_href: str,
 ) -> str:
+    not_compared_reason = str(result.get("not_compared_reason", "") or "")
+    if not_compared_reason:
+        return (
+            '<span class="unavailable">'
+            f"{html.escape(not_compared_reason)}"
+            "</span>"
+        )
     reference_commands = _result_commands(result, "hf")
     trtmc_commands = _result_commands(result, "trtmc")
     dataset_command, sample_limit, _ = _dataset_reproduction(result)
@@ -1631,10 +1588,15 @@ def _signal(status: str, labels: Mapping[str, str]) -> str:
 def _render_execution(result: Mapping[str, Any]) -> str:
     execution = result.get("execution", {})
     status = str(execution.get("status", "error")) if isinstance(execution, dict) else "error"
-    return _signal(status, {"completed": "Completed", "error": "Error"})
+    return _signal(
+        status,
+        {"completed": "Completed", "error": "Error", "not_run": "Not run"},
+    )
 
 
 def _render_reference(result: Mapping[str, Any]) -> str:
+    if result.get("not_compared_reason"):
+        return _signal("not_run", {"not_run": "Not configured"})
     status = _reference_result_status(result)
     display_status = {
         "reused": "cached",
@@ -1671,7 +1633,13 @@ def _render_comparison(result: Mapping[str, Any]) -> str:
         },
     )
     mode = str(comparison.get("mode", "") or "")
-    detail = f'<div class="detail">{html.escape(mode)}</div>' if mode else ""
+    not_compared_reason = str(result.get("not_compared_reason", "") or "")
+    detail_text = mode or not_compared_reason
+    detail = (
+        f'<div class="detail">{html.escape(detail_text)}</div>'
+        if detail_text
+        else ""
+    )
     return signal + detail
 
 
@@ -1694,6 +1662,8 @@ def _format_metric_value(name: str, value: Any) -> str:
 
 
 def _render_metrics(result: Mapping[str, Any]) -> str:
+    if result.get("not_compared_reason"):
+        return '<span class="unavailable">Not compared</span>'
     comparison = result.get("comparison", {})
     metrics = comparison.get("metrics", {}) if isinstance(comparison, dict) else {}
     if not isinstance(metrics, dict) or not metrics:
@@ -1728,16 +1698,21 @@ def _render_validation(result: Mapping[str, Any]) -> str:
     )
     return _signal(
         status,
-        {"passed": "Pass", "failed": "Fail", "skipped": "Skipped"},
+        {
+            "passed": "Pass",
+            "failed": "Fail",
+            "skipped": "Skipped",
+            "not_compared": "Not compared",
+        },
     )
 
 
 def _render_samples(result: Mapping[str, Any]) -> str:
+    if result.get("not_compared_reason"):
+        return "—"
     _command, sample_limit, _ = _dataset_reproduction(result)
     if sample_limit:
         return str(sample_limit)
-    if result.get("workload") == "e2e":
-        return "E2E"
     return "Full"
 
 
@@ -1757,12 +1732,32 @@ def _normalize_result_files(
     return results
 
 
+def _deduplicate_results(
+    result_paths: Sequence[Path],
+    results: Sequence[dict[str, Any]],
+) -> tuple[list[Path], list[dict[str, Any]]]:
+    selected: dict[tuple[str, str], tuple[Path, dict[str, Any]]] = {}
+    for path, result in zip(result_paths, results, strict=True):
+        key = (
+            str(result.get("model", "")),
+            str(result.get("workload") or ""),
+        )
+        current = selected.get(key)
+        if current is None or path.parent.name == NOT_COMPARED_DIRECTORY:
+            selected[key] = (path, result)
+    ordered = sorted(selected.values(), key=lambda item: str(item[0]))
+    return (
+        [path for path, _result in ordered],
+        [result for _path, result in ordered],
+    )
+
+
 def _report_counts(
     results: Sequence[Mapping[str, Any]],
 ) -> tuple[dict[str, int], dict[str, int], int]:
     validation_counts = {
         name: sum(result["validation"]["status"] == name for result in results)
-        for name in ("passed", "failed", "skipped")
+        for name in ("passed", "failed", "skipped", "not_compared")
     }
     comparison_counts = {
         name: sum(result["comparison"]["status"] == name for result in results)
@@ -1810,7 +1805,7 @@ def _report_rows(
         rows.append(
             "<tr>"
             f"<td>{html.escape(str(result.get('model', '')))}</td>"
-            f"<td>{html.escape(str(result.get('workload', '')))}</td>"
+            f"<td>{html.escape(str(result.get('workload') or '—'))}</td>"
             f"<td>{_render_samples(result)}</td>"
             f"<td>{_render_execution(result)}</td>"
             f"<td>{_render_reference(result)}</td>"
@@ -1881,7 +1876,7 @@ pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
 .signal-skipped .signal-light {{ background: #f9ab00; box-shadow: 0 0 0 3px #fef7e0; }}
 .signal-cached {{ color: #185abc; }}
 .signal-cached .signal-light {{ background: #1a73e8; box-shadow: 0 0 0 3px #e8f0fe; }}
-.signal-not_run {{ color: #5f6368; }}
+.signal-not_run, .signal-not_compared {{ color: #5f6368; }}
 .detail {{ color: #5f6368; font-size: 12px; margin-top: 4px; }}
 .metric {{ display: flex; justify-content: space-between; gap: 14px;
            font-variant-numeric: tabular-nums; font-size: 12px; }}
@@ -1898,6 +1893,7 @@ pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
 <div class="summary">{report["summary"]["cases"]} cases ·
 {comparison_counts["agreement"]} agreements ·
 {comparison_counts["disagreement"]} disagreements ·
+{comparison_counts["not_run"]} not compared ·
 {execution_errors} execution errors ·
 {report["summary"]["selected_samples"]} samples{duration_summary}<br>
 {html.escape(provenance)}</div>
@@ -1912,6 +1908,7 @@ pre {{ margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere;
 def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
     result_paths = sorted(output.glob("*/*/comparison.json"))
     results = _normalize_result_files(result_paths)
+    result_paths, results = _deduplicate_results(result_paths, results)
     validation_counts, comparison_counts, execution_errors = _report_counts(results)
     traffic_light_counts = _traffic_light_counts(results)
     sample_limits = [_dataset_reproduction(result)[1] for result in results]
@@ -1920,11 +1917,18 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
         "schema_version": "trtmc.validation-report/v2",
         "generated_at": generated_at.isoformat(),
         "validation_status": (
-            "passed" if results and validation_counts["failed"] == 0 else "failed"
+            "failed"
+            if not results or validation_counts["failed"]
+            else "incomplete"
+            if validation_counts["not_compared"]
+            else "passed"
         ),
         "summary": {
             "cases": len(results),
-            "execution_completed": len(results) - execution_errors,
+            "execution_completed": sum(
+                result["execution"]["status"] == "completed"
+                for result in results
+            ),
             "execution_errors": execution_errors,
             "agreements": comparison_counts["agreement"],
             "disagreements": comparison_counts["disagreement"],
@@ -1963,6 +1967,12 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
 
 
 def _print_result(result: Mapping[str, Any], comparison: Path, report: Path) -> None:
+    not_compared_reason = str(result.get("not_compared_reason", "") or "")
+    if not_compared_reason:
+        print()
+        print(f"Compare result: {comparison}")
+        print(f"Report:         {report}")
+        return
     reproduce = result.get("reproduce", {})
     hf_commands = reproduce.get("hf", []) if isinstance(reproduce, dict) else []
     trtmc_commands = reproduce.get("trtmc", []) if isinstance(reproduce, dict) else []
@@ -2030,7 +2040,6 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--backend-dir", type=Path)
     parser.add_argument("--model-plugin-dir", type=Path)
     parser.add_argument("--cuda-visible-devices", default="")
-    parser.add_argument("--platform", default="")
     parser.add_argument(
         "--limit",
         type=int,
@@ -2092,15 +2101,25 @@ def _print_bindings(
     print(
         json.dumps(
             [
-                {
-                    "model": binding.model,
-                    "workload": binding.workload,
-                    "sample_limit": resolve_sample_limit(
-                        catalog,
-                        binding,
-                        explicit_limit,
-                    ),
-                }
+                (
+                    {
+                        "model": binding.model,
+                        "workload": binding.workload,
+                        "sample_limit": resolve_sample_limit(
+                            catalog,
+                            binding,
+                            explicit_limit,
+                        ),
+                    }
+                    if binding.runnable
+                    else {
+                        "model": binding.model,
+                        "workload": None,
+                        "sample_limit": 0,
+                        "status": "not_compared",
+                        "reason": binding.not_compared_reason,
+                    }
+                )
                 for binding in bindings
             ],
             indent=2,
@@ -2118,11 +2137,12 @@ def _worker_command(
     binding: Binding,
     arguments: argparse.Namespace,
 ) -> list[str]:
+    workload = _required_workload(binding)
     command = [
         sys.executable,
         str(Path(__file__).resolve()),
         binding.model,
-        binding.workload,
+        workload,
         "--model-worker",
     ]
     for option, value in (
@@ -2142,7 +2162,6 @@ def _worker_command(
         ("--backend-dir", arguments.backend_dir),
         ("--model-plugin-dir", arguments.model_plugin_dir),
         ("--cuda-visible-devices", arguments.cuda_visible_devices),
-        ("--platform", arguments.platform),
     ):
         if value:
             command.extend([option, str(value)])
@@ -2212,7 +2231,7 @@ def _run_supervised_binding(
     arguments: argparse.Namespace,
     catalog: Mapping[str, Any],
 ) -> dict[str, Any]:
-    case_dir = arguments.output / binding.model / binding.workload
+    case_dir = _case_directory(arguments.output, binding)
     case_dir.mkdir(parents=True, exist_ok=True)
     comparison_path = case_dir / "comparison.json"
     comparison_path.unlink(missing_ok=True)
@@ -2267,13 +2286,24 @@ def _run_all_bindings(
     write_run_metadata(arguments.output)
     failed = False
     for binding in bindings:
+        if not binding.runnable:
+            print(
+                f"\nNot compared: {binding.model} / "
+                f"{binding.not_compared_reason}",
+                flush=True,
+            )
+            result, comparison = _write_not_compared_case(
+                binding,
+                arguments.output,
+            )
+            _, report_path, _ = write_report(arguments.output)
+            _print_result(result, comparison, report_path)
+            continue
         sample_limit = resolve_sample_limit(catalog, binding, arguments.limit)
         sample_note = (
             "full dataset"
-            if binding.workload != "e2e" and sample_limit == 0
+            if sample_limit == 0
             else f"{sample_limit} samples"
-            if binding.workload != "e2e"
-            else "e2e"
         )
         print(
             f"\nStarting worker: {binding.model} / {binding.workload} / {sample_note}",
@@ -2285,7 +2315,7 @@ def _run_all_bindings(
             catalog=catalog,
         )
         _, report_path, _ = write_report(arguments.output)
-        comparison = arguments.output / binding.model / binding.workload / "comparison.json"
+        comparison = _case_directory(arguments.output, binding) / "comparison.json"
         _print_result(result, comparison, report_path)
         model_failed = result["validation"]["status"] == "failed"
         failed = failed or model_failed
@@ -2306,12 +2336,27 @@ def _run_bindings(
     task_models: Mapping[str, dict[str, Any]],
     suites: Mapping[str, dict[str, Any]],
 ) -> int:
-    e2e_models = _e2e_models(arguments.models_dir)
     _prepare_run_directories(arguments)
     if not arguments.model_worker:
         write_run_metadata(arguments.output)
     failed = False
+    not_compared = False
     for binding in bindings:
+        if not binding.runnable:
+            print(
+                f"\nNot compared: {binding.model} / "
+                f"{binding.not_compared_reason}",
+                flush=True,
+            )
+            result, comparison = _write_not_compared_case(
+                binding,
+                arguments.output,
+            )
+            not_compared = True
+            if not arguments.model_worker:
+                _, report_path, _ = write_report(arguments.output)
+                _print_result(result, comparison, report_path)
+            continue
         binding_arguments = copy.copy(arguments)
         binding_arguments.limit = resolve_sample_limit(
             catalog,
@@ -2320,12 +2365,8 @@ def _run_bindings(
         )
         sample_note = (
             "full dataset"
-            if binding.workload != "e2e" and binding_arguments.limit == 0
-            else (
-                f"{binding_arguments.limit} samples"
-                if binding.workload != "e2e"
-                else "e2e"
-            )
+            if binding_arguments.limit == 0
+            else f"{binding_arguments.limit} samples"
         )
         print(
             f"\n{binding.model} / {binding.workload} / {sample_note}",
@@ -2335,28 +2376,30 @@ def _run_bindings(
             binding,
             arguments=binding_arguments,
             task_models=task_models,
-            e2e_models=e2e_models,
             suites=suites,
         )
         if not arguments.model_worker:
             _, report_path, _ = write_report(arguments.output)
-            comparison = arguments.output / binding.model / binding.workload / "comparison.json"
+            comparison = _case_directory(arguments.output, binding) / "comparison.json"
             _print_result(result, comparison, report_path)
         failed = failed or result["validation"]["status"] == "failed"
-    return 1 if failed else 0
+    if failed:
+        return 1
+    return 2 if not_compared and not arguments.all else 0
 
 
 def _main(arguments: argparse.Namespace) -> int:
     catalog, suites, ready, task_models = _load_validation_inputs(arguments)
     if arguments.list:
         for name, spec in catalog["models"].items():
+            not_compared_reason = str(spec.get("not_compared_reason", "") or "")
+            if not_compared_reason:
+                print(f"{name}: not compared ({not_compared_reason})")
+                continue
             workloads = []
             for workload in spec["workloads"]:
-                if workload == "e2e":
-                    workloads.append("e2e")
-                else:
-                    limit = catalog["sample_limits"][workload]
-                    workloads.append(f"{workload} ({limit} samples)")
+                limit = catalog["sample_limits"][workload]
+                workloads.append(f"{workload} ({limit} samples)")
             print(f"{name}: {', '.join(workloads)}")
         return 0
     bindings = _select_bindings(arguments, catalog, ready)

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -61,6 +61,7 @@ class Binding:
     model: str
     workload: str | None
     not_compared_reason: str = ""
+    reference_cache_identity: str = ""
 
     @property
     def runnable(self) -> bool:
@@ -149,6 +150,14 @@ def _validate_model_spec(path: Path, name: Any, spec: Any) -> None:
         )
     if default not in workloads:
         raise ValidationError(f"{path}: {name}.default must be one of {name}.workloads")
+    reference_cache_identity = spec.get("reference_cache_identity")
+    if reference_cache_identity is not None and (
+        not isinstance(reference_cache_identity, str)
+        or not reference_cache_identity.strip()
+    ):
+        raise ValidationError(
+            f"{path}: {name}.reference_cache_identity must be a non-empty string"
+        )
 
 
 def _validate_sample_limits(path: Path, raw: Mapping[str, Any]) -> None:
@@ -245,6 +254,7 @@ def audit_workload_compatibility(
     task_models: Mapping[str, dict[str, Any]],
 ) -> None:
     incompatible = []
+    reference_cache_contracts: dict[str, set[tuple[str, ...]]] = {}
     for model_name, spec in catalog["models"].items():
         for workload in spec.get("workloads", []):
             matched, reason = task_eval.suite_match_reason(
@@ -253,6 +263,29 @@ def audit_workload_compatibility(
             )
             if not matched:
                 incompatible.append(f"{model_name}/{workload}: {reason}")
+            reference_cache_identity = str(
+                spec.get("reference_cache_identity", "") or ""
+            )
+            if reference_cache_identity:
+                model = task_models[model_name]
+                contract = (
+                    str(model.get("hf_id", "") or ""),
+                    str(model.get("hf_revision", "") or ""),
+                    str(model.get("family", "") or ""),
+                    str(model.get("reference_backend", "") or ""),
+                    str(model.get("reference_family", "") or ""),
+                    workload,
+                )
+                reference_cache_contracts.setdefault(
+                    reference_cache_identity,
+                    set(),
+                ).add(contract)
+    for identity, contracts in sorted(reference_cache_contracts.items()):
+        if len(contracts) > 1:
+            incompatible.append(
+                f"reference cache identity {identity!r} spans "
+                "different reference contracts"
+            )
     if incompatible:
         raise ValidationError("incompatible model/workload bindings: " + "; ".join(incompatible))
 
@@ -284,7 +317,13 @@ def resolve_binding(
         raise ValidationError(
             f"model {model} does not declare workload {selected}; available: {available}"
         )
-    return Binding(model=model, workload=selected)
+    return Binding(
+        model=model,
+        workload=selected,
+        reference_cache_identity=str(
+            spec.get("reference_cache_identity", "") or ""
+        ),
+    )
 
 
 def resolve_sample_limit(
@@ -530,6 +569,13 @@ def _comparison_command(
     ]
     if arguments.limit:
         command.extend(["--limit", str(arguments.limit)])
+    if binding.reference_cache_identity:
+        command.extend(
+            [
+                "--reference-cache-identity",
+                binding.reference_cache_identity,
+            ]
+        )
     if arguments.force_hf:
         command.append("--force-hf")
     if arguments.force_build:

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -741,8 +741,15 @@ def _summarize_command_log(
     return count, selected or first
 
 
-def _command_log_kind(path: Path, *, has_native_reference: bool) -> str | None:
+def _command_log_kind(
+    path: Path,
+    *,
+    has_native_reference: bool,
+    has_native_trtmc: bool,
+) -> str | None:
     if has_native_reference and path.name == "hf_run.log":
+        return None
+    if has_native_trtmc and path.name == "trtfb_run.log":
         return None
     return "hf" if "hf" in path.name.lower() else "trtmc"
 
@@ -787,9 +794,19 @@ def _collect_command_logs(
     commands: dict[str, list[str]] = {"hf": [], "trtmc": []}
     counts = {"hf": 0, "trtmc": 0}
     logs: dict[str, list[str]] = {"hf": [], "trtmc": []}
-    has_native_reference = any(path.name == "hf_native_run.log" for path in log_paths)
+    has_native_reference = any(
+        path.name in {"hf_native_run.log", "hf_native_commands.jsonl"}
+        for path in log_paths
+    )
+    has_native_trtmc = any(
+        path.name == "trtfb_native_commands.jsonl" for path in log_paths
+    )
     for path in log_paths:
-        kind = _command_log_kind(path, has_native_reference=has_native_reference)
+        kind = _command_log_kind(
+            path,
+            has_native_reference=has_native_reference,
+            has_native_trtmc=has_native_trtmc,
+        )
         if kind is None:
             continue
         indexed_sample_ids = sample_ids if path.name == "trtfb_run.log" else ()
@@ -814,7 +831,12 @@ def _commands_from_logs(root: Path) -> dict[str, Any]:
     sample_ids = _prepared_sample_ids(root)
     disagreement_id = _first_disagreement_id(root)
     representative_id = disagreement_id or (sample_ids[0] if sample_ids else "")
-    log_paths = sorted(root.rglob("*.log"))
+    log_paths = sorted(
+        {
+            *root.rglob("*.log"),
+            *root.rglob("*_native_commands.jsonl"),
+        }
+    )
     commands, counts, logs = _collect_command_logs(
         root,
         log_paths=log_paths,

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -1329,8 +1329,23 @@ def write_run_metadata(output: Path) -> Path:
         "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES", ""),
         "command": shlex.join(sys.argv),
         "started_at": _utc_now().isoformat(),
+        "finished_at": None,
+        "duration_seconds": None,
     }
     path = output / "run.json"
+    path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    return path
+
+
+def finalize_run_metadata(output: Path) -> Path:
+    path = output / "run.json"
+    metadata = json.loads(path.read_text(encoding="utf-8"))
+    finished_at = _utc_now()
+    metadata["finished_at"] = finished_at.isoformat()
+    metadata["duration_seconds"] = _elapsed_seconds(
+        metadata.get("started_at"),
+        finished_at,
+    )
     path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
     return path
 
@@ -2039,10 +2054,12 @@ def write_report(output: Path) -> tuple[Path, Path, dict[str, Any]]:
     run_path = output / "run.json"
     if run_path.is_file():
         report["run"] = json.loads(run_path.read_text(encoding="utf-8"))
-        duration_seconds = _elapsed_seconds(
-            report["run"].get("started_at"),
-            generated_at,
-        )
+        duration_seconds = report["run"].get("duration_seconds")
+        if duration_seconds is None:
+            duration_seconds = _elapsed_seconds(
+                report["run"].get("started_at"),
+                generated_at,
+            )
         if duration_seconds is not None:
             report["summary"]["duration_seconds"] = duration_seconds
     json_path = output / "report.json"
@@ -2563,6 +2580,8 @@ def _run_all_bindings(
                 flush=True,
             )
             break
+    finalize_run_metadata(arguments.output)
+    write_report(arguments.output)
     if failed:
         return 1
     return 2 if not_compared and not arguments.all else 0

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -16,9 +16,11 @@ import os
 from pathlib import Path
 import platform
 import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from typing import Any, Iterable, Mapping, Sequence
 
 import yaml
@@ -1677,10 +1679,15 @@ def _signal(status: str, labels: Mapping[str, str]) -> str:
 def _render_execution(result: Mapping[str, Any]) -> str:
     execution = result.get("execution", {})
     status = str(execution.get("status", "error")) if isinstance(execution, dict) else "error"
-    return _signal(
+    rendered = _signal(
         status,
         {"completed": "Completed", "error": "Error", "not_run": "Not run"},
     )
+    attempts = int(execution.get("attempt_count", 1)) if isinstance(execution, dict) else 1
+    if attempts > 1:
+        outcome = "recovered" if status == "completed" else "failed"
+        rendered += f'<div class="detail">{outcome} after {attempts} attempts</div>'
+    return rendered
 
 
 def _render_reference(result: Mapping[str, Any]) -> str:
@@ -2088,6 +2095,20 @@ def _print_result(result: Mapping[str, Any], comparison: Path, report: Path) -> 
     print(f"Report:         {report}")
 
 
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def _nonnegative_float(value: str) -> float:
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be nonnegative")
+    return parsed
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Validate TRTMC against model reference implementations."
@@ -2099,7 +2120,19 @@ def build_parser() -> argparse.ArgumentParser:
         "--on-model-failure",
         choices=("continue", "stop"),
         default="continue",
-        help=("with --all, continue after a failed model or stop after recording it"),
+        help="continue after a failed model or stop after recording it",
+    )
+    parser.add_argument(
+        "--model-attempts",
+        type=_positive_int,
+        default=2,
+        help="maximum worker attempts for execution errors; comparisons are not retried",
+    )
+    parser.add_argument(
+        "--model-retry-delay-seconds",
+        type=_nonnegative_float,
+        default=5.0,
+        help="delay before retrying a model worker after an execution error",
     )
     parser.add_argument(
         "--model-worker",
@@ -2244,6 +2277,8 @@ def _worker_command(
         ("--trtmc-binary", arguments.trtmc_binary),
         ("--benchmark-binary", arguments.benchmark_binary),
         ("--hf-python", arguments.hf_python),
+        ("--model-attempts", arguments.model_attempts),
+        ("--model-retry-delay-seconds", arguments.model_retry_delay_seconds),
     ):
         command.extend([option, str(value)])
     for option, value in (
@@ -2319,12 +2354,15 @@ def _run_supervised_binding(
     *,
     arguments: argparse.Namespace,
     catalog: Mapping[str, Any],
+    attempt: int = 1,
 ) -> dict[str, Any]:
     case_dir = _case_directory(arguments.output, binding)
     case_dir.mkdir(parents=True, exist_ok=True)
     comparison_path = case_dir / "comparison.json"
     comparison_path.unlink(missing_ok=True)
-    worker_log = case_dir / "worker.log"
+    worker_log = case_dir / (
+        "worker.log" if attempt == 1 else f"worker.attempt-{attempt}.log"
+    )
     command = _worker_command(binding, arguments)
     launch_error = ""
     try:
@@ -2365,6 +2403,115 @@ def _run_supervised_binding(
     return result
 
 
+def _archive_failed_attempt(case_dir: Path, attempt: int) -> dict[str, str]:
+    archived = {}
+    for name in ("comparison.json", "execution.log", "disagreements.jsonl"):
+        source = case_dir / name
+        if not source.is_file():
+            continue
+        path = case_dir / f"{source.stem}.attempt-{attempt}{source.suffix}"
+        shutil.copy2(source, path)
+        archived[name] = str(path)
+    return archived
+
+
+def _attempt_record(
+    result: Mapping[str, Any],
+    *,
+    attempt: int,
+    archived: Mapping[str, str],
+) -> dict[str, Any]:
+    execution = result.get("execution", {})
+    validation = result.get("validation", {})
+    raw_result = result.get("raw_result", {})
+    execution_log = archived.get(
+        "execution.log",
+        str(result.get("execution_log", "") or ""),
+    )
+    return {
+        "attempt": attempt,
+        "execution_status": (
+            str(execution.get("status", "")) if isinstance(execution, Mapping) else ""
+        ),
+        "validation_status": (
+            str(validation.get("status", "")) if isinstance(validation, Mapping) else ""
+        ),
+        "worker_log": str(result.get("worker_log", "") or ""),
+        "execution_log": execution_log,
+        "comparison_result": archived.get("comparison.json", ""),
+        "error_type": (
+            str(raw_result.get("error_type", ""))
+            if isinstance(raw_result, Mapping)
+            else ""
+        ),
+        "error": (
+            str(raw_result.get("error", ""))
+            if isinstance(raw_result, Mapping)
+            else ""
+        ),
+    }
+
+
+def _run_supervised_binding_with_retries(
+    binding: Binding,
+    *,
+    arguments: argparse.Namespace,
+    catalog: Mapping[str, Any],
+) -> dict[str, Any]:
+    case_dir = _case_directory(arguments.output, binding)
+    attempts = []
+    result: dict[str, Any] = {}
+    for attempt in range(1, arguments.model_attempts + 1):
+        result = _run_supervised_binding(
+            binding,
+            arguments=arguments,
+            catalog=catalog,
+            attempt=attempt,
+        )
+        execution = result.get("execution", {})
+        execution_error = (
+            isinstance(execution, Mapping)
+            and execution.get("status") == "error"
+        )
+        archived = (
+            _archive_failed_attempt(case_dir, attempt)
+            if execution_error and attempt < arguments.model_attempts
+            else {}
+        )
+        attempts.append(
+            _attempt_record(
+                result,
+                attempt=attempt,
+                archived=archived,
+            )
+        )
+        if not execution_error or attempt == arguments.model_attempts:
+            break
+        print(
+            f"Retrying worker after execution error: {binding.model} "
+            f"(attempt {attempt + 1}/{arguments.model_attempts})",
+            flush=True,
+        )
+        if arguments.model_retry_delay_seconds:
+            time.sleep(arguments.model_retry_delay_seconds)
+    execution = dict(result.get("execution", {}))
+    execution.update(
+        {
+            "attempt_count": len(attempts),
+            "max_attempts": arguments.model_attempts,
+            "retry_count": max(0, len(attempts) - 1),
+            "attempts": attempts,
+        }
+    )
+    result["execution"] = execution
+    comparison_path = case_dir / "comparison.json"
+    comparison_path.write_text(
+        json.dumps(result, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return result
+
+
 def _run_all_bindings(
     bindings: Iterable[Binding],
     *,
@@ -2374,6 +2521,7 @@ def _run_all_bindings(
     _prepare_run_directories(arguments)
     write_run_metadata(arguments.output)
     failed = False
+    not_compared = False
     for binding in bindings:
         if not binding.runnable:
             print(
@@ -2385,6 +2533,7 @@ def _run_all_bindings(
                 binding,
                 arguments.output,
             )
+            not_compared = True
             _, report_path, _ = write_report(arguments.output)
             _print_result(result, comparison, report_path)
             continue
@@ -2398,7 +2547,7 @@ def _run_all_bindings(
             f"\nStarting worker: {binding.model} / {binding.workload} / {sample_note}",
             flush=True,
         )
-        result = _run_supervised_binding(
+        result = _run_supervised_binding_with_retries(
             binding,
             arguments=arguments,
             catalog=catalog,
@@ -2414,7 +2563,9 @@ def _run_all_bindings(
                 flush=True,
             )
             break
-    return 1 if failed else 0
+    if failed:
+        return 1
+    return 2 if not_compared and not arguments.all else 0
 
 
 def _run_bindings(
@@ -2499,7 +2650,7 @@ def _main(arguments: argparse.Namespace) -> int:
             explicit_limit=arguments.limit,
         )
         return 0
-    if arguments.all:
+    if not arguments.model_worker:
         return _run_all_bindings(
             bindings,
             arguments=arguments,

--- a/tools/trtmc_validate.py
+++ b/tools/trtmc_validate.py
@@ -809,6 +809,7 @@ _PRIMARY_COMPARISON_METRICS = (
 _PRIMARY_METRIC_BY_MODE = {
     "asr_transcript": "prediction_agreement_rate",
     "continuation": "token_prefix_agreement",
+    "diffusion_image_clip_parity": "overall_pass_rate",
     "diffusion_text_parity": "token_agreement_rate",
     "encoder_embedding_parity": "vector_pass_rate",
     "image_classification_parity": "top1_agreement",
@@ -819,6 +820,10 @@ _PRIMARY_METRIC_BY_MODE = {
 }
 _COMPARISON_METRICS = (
     *_PRIMARY_COMPARISON_METRICS,
+    "overall_pass_rate",
+    "passed_count",
+    "valid_count",
+    "skipped_count",
     "token_id_prefix_agreement",
     "normalized_transcript_exact_agreement_rate",
     "correctness_agreement_rate",
@@ -881,11 +886,20 @@ def _execution_details(
 
 
 def _comparison_metrics(raw_result: Mapping[str, Any]) -> dict[str, Any]:
-    return {
+    metrics = {
         name: raw_result[name]
         for name in _COMPARISON_METRICS
         if raw_result.get(name) is not None
     }
+    nested = raw_result.get("metrics", {})
+    if isinstance(nested, Mapping):
+        for name, summary in nested.items():
+            if not isinstance(summary, Mapping):
+                continue
+            mean = summary.get("mean")
+            if isinstance(mean, (int, float)) and not isinstance(mean, bool):
+                metrics[str(name)] = mean
+    return metrics
 
 
 def _primary_metric(


### PR DESCRIPTION
## Background

`trtmc-validate` could use a model-owned E2E case when no dataset-backed validation workload existed. The report then translated the E2E process result into Agreement or Disagreement even when no aligned reference/TRTMC output comparison had occurred.

Follow-up report validation exposed additional gaps. Qwen3 FP8 and top-p lacked dataset-backed comparison even though they can use the FP16 MMLU contract. Diffusion metrics were nested and rendered as `No metrics`. Equivalent TRTMC variants regenerated identical HF outputs because their manifest paths differed. The first cache-identity implementation normalized that path but still included build-only prepared-manifest metadata, so the three Qwen3 variants did not actually share a key. InternLM pinned Transformers 4.44.2 while current model remote code uses a DynamicCache API available in 4.46.

Full-run validation also found that an expected empty prompted-segmentation result stopped the entire model as an execution error. Vision runners recorded native per-sample commands, but the report ignored their JSONL command logs and could show a reference wrapper alongside the native command. A transient FLUX TensorRT deserialization OOM also showed that the supervisor treated a recoverable execution error as final even though the same native command succeeded immediately afterward. A later Qwen2.5-VL attempt exposed one non-UTF-8 byte in native process output; strict subprocess decoding incorrectly turned that sample into an execution error.

## Exit Criteria

- Agreement and Disagreement require aligned reference and TRTMC inference plus an output comparator.
- Models without that complete contract remain visible but are not counted as compared.
- Qwen3 FP16, FP8, and top-p use the same deterministic, reference-backed MMLU five-shot workload.
- DPG-Bench and image-edit rows expose reference-relative diffusion metrics.
- Equivalent TRTMC variants may explicitly share one HF reference cache entry; different prepared inputs or effective inference settings remain isolated.
- Existing E2E result files fail closed when a report is regenerated.
- Managed InternLM reference environments provide the DynamicCache API required by current model code.
- An empty prompted-segmentation prediction is compared as a sample result instead of aborting the model.
- Reports use recorded native reference and TRTMC commands without also showing orchestration wrappers.
- The model supervisor retries execution errors without rerunning deterministic Agreement or Disagreement outcomes.
- Full and single-model invocations use the same supervised worker path for CI isolation.
- Native VLM and ASR output is decoded loss-tolerantly so diagnostic bytes cannot abort validation.
- A completed run records an immutable finish timestamp and duration in both run metadata and the final report.

## Implementation

- Remove the E2E executor, command extraction, environment selection, and result-to-agreement fallback from `trtmc-validate`; reject `e2e` as a validation catalog workload.
- Mark 8 models without a reference-consistency workload with `not_compared_reason`. `--all` reports white Not compared rows and dry-run keeps them visible for CI matrix filtering.
- Add validation-specific reference semantics so Qwen3 FP8 and top-p use the FP16 MMLU five-shot contract without changing model-owned E2E contracts.
- Propagate an opt-in `reference_cache_identity` from the catalog to the standalone reference runner. Catalog auditing rejects identities spanning different HF ids, revisions, families, reference backends, reference families, or workloads.
- Under an explicit identity, native-runner cache keys normalize variant-only task metadata such as TRTMC manifest paths and build token limits. Prepared inputs, effective generation, native runner, reference model, and runtime settings remain in the key. An identity implementation marker prevents old partial-normalization entries from being reused.
- Share identities for `flux-2-dev`/`flux-2-dev-fp8` and the three `qwen3-0.6b` variants.
- Flatten aggregate diffusion scorecard means into report metrics and use `overall_pass_rate` as the primary DPG signal.
- Add `not_run`/`not_compared` report states and an aggregate `incomplete` status. Legacy E2E results normalize to Not compared.
- Pin the InternLM reference profile to Transformers 4.46.3 with compatible Hub/tokenizer versions and verify `DynamicCache.get_max_cache_shape` during environment creation.
- Preserve explicit empty prompted-segmentation outputs, compare them as all-zero masks, and continue the remaining samples. Other nonzero runner exits still fail execution.
- Collect `hf_native_commands.jsonl` and `trtfb_native_commands.jsonl` for report reproduction. Prefer native command logs over wrapper logs and keep only a bounded representative command in the report.
- Supervise both `--all` and explicitly selected models in isolated workers. Retry execution errors up to `--model-attempts` after a configurable delay, preserve failed-attempt logs and comparison files, and expose attempt metadata in report JSON and HTML. Completed comparisons, including Disagreement, are never retried.
- Decode captured native VLM and ASR stdout/stderr as UTF-8 with replacement for malformed bytes while preserving the complete text logs.
- Finalize `run.json` after the model loop and regenerate the report from that completed metadata so CI and report consumers see the same finish time and duration.

## Validation

- `PYTHONPATH=python:. python3 -m pytest -q tests/tools/test_trtmc_reference.py tests/tools/test_task_eval.py tests/tools/test_trtmc_validate.py tests/e2e/models/internlm/test_internlm_manifest_profiles.py`: 279 passed.
- `PYTHONPATH=python:. python3 -m pytest -qq tests/tools/test_model_plugin_encapsulation_static.py tests/builder`: passed.
- `CI_BASE_REF=b282324c73ef005f6aa8065bc22daccc683cf278 python3 -m tools.ci pipeline source-quality`: passed complexity, lint, and 157 architecture checks.
- `python3 tools/legal_headers.py --check`: passed with zero findings.
- `PYTHONPATH=python:. python3 tools/trtmc_validate.py --all --dry-run`: 105 catalog models, 97 runnable consistency workloads, 8 explicit not-compared models, and 1,946 selected samples.
- A native one-sample InternLM reference and TRTMC smoke with the pinned environment completed successfully.
- Qwen3 FP16, FP8, and top-p smokes used one cache key; FP8 and top-p reused the FP16 reference.
- A 20-sample SAM3 validation completed all samples, preserved two empty TRTMC predictions, and passed with mean backend mask IoU 0.9378. The generated report includes native HF and TRTMC reproduction commands.
- A 5-sample FLUX single-model invocation completed through the supervised path with one attempt, reused the reference cache, recorded zero execution errors, and reported its comparison Disagreement without retrying it.
- A full 105-model diagnostic run exercised the new retry path: Qwen2.5-VL preserved its first failed attempt and recovered on attempt two, leaving zero final execution errors. The malformed-byte cause was then fixed rather than accepted as a retry-only workaround.
- A post-fix Qwen2.5-VL 5-sample validation completed on the first attempt in 19.378 seconds with Agreement and zero execution errors.
- A clean single-GPU full campaign at source `79f0e2ea` used the exact `tools/trtmc_validate.py --all --on-model-failure continue` entrypoint and completed 105/105 models and 1,946 selected samples in 4,769.762 seconds: 71 Agreement, 26 Disagreement, 8 Not compared, zero final execution errors, and zero retries. All 97 compared rows had metrics and native HF/TRTMC reproduction commands; final run and report durations matched.
- GitHub premerge CI passed unit tests, all seven selected model jobs, the combined HTML report, and the required Premerge CI context.
- Regression tests reproduce the Qwen3 prepared-manifest differences and prove that equal effective contracts share a key while different generation settings remain separate.

## Notes For Future Readers

- A cache identity is an explicit assertion that variants have the same reference model, prepared inputs, and effective inference contract. Do not use it to mask a real setting difference.
- DPG-Bench runs each model native HF/diffusers reference on aligned prompts, seeds, and initial latents before comparing with TRTMC. Report flattening only exposes metrics produced by that comparator.
- The 8 not-compared models need aligned input, reference runner, TRTMC runner, comparator, and tolerance contracts before becoming runnable validation cases. E2E coverage must not return as a consistency fallback.
