### PR TITLE
feat(wan2.2): package reproducible FP8 scales

### DIFF
--- a/python/tensorrt_model_connect/build_cli.py
+++ b/python/tensorrt_model_connect/build_cli.py
@@ -163,7 +163,7 @@ def _cmd_build(args: argparse.Namespace) -> int:
     from .engine_builder import _build_native_impl as build
     from .quantization import canonicalize_quant_format
 
-    # FP8 quantization: --fp8-scales (pre-computed) or --fp8 (auto-calibrate)
+    # FP8 quantization: explicit scales or family-provided/live calibration.
     fp8_scales = None
     fp8_auto = getattr(args, 'fp8', False)
     if getattr(args, 'fp8_scales', None):
@@ -173,9 +173,9 @@ def _cmd_build(args: argparse.Namespace) -> int:
         print(f"[trtmc build] Loaded FP8 scales from {args.fp8_scales} "
               f"({len(fp8_scales)} layers)", file=sys.stderr)
     elif fp8_auto:
-        # Sentinel: engine_builder will call plugin.fp8_calibrate()
+        # Sentinel: engine_builder resolves packaged scales before calibration.
         fp8_scales = "auto"
-        print("[trtmc build] FP8 auto-calibration enabled", file=sys.stderr)
+        print("[trtmc build] FP8 scale resolution enabled", file=sys.stderr)
 
     save_fp8_scales = getattr(args, 'save_fp8_scales', None)
     quantize = canonicalize_quant_format(getattr(args, "quantize", None))
@@ -675,7 +675,7 @@ def main() -> None:
     build_p.add_argument("--verbose", action="store_true",
                          help="Verbose TRT builder output")
     build_p.add_argument("--fp8", action="store_true",
-                         help="Enable FP8 quantization (auto-calibrate via ModelOpt)")
+                         help="Enable FP8 with family-provided scales or auto-calibration")
     build_p.add_argument("--fp8-scales", default=None,
                          help="Path to pre-computed FP8 scales JSON (skips calibration)")
     build_p.add_argument("--save-fp8-scales", default=None,

--- a/python/tensorrt_model_connect/engine_builder.py
+++ b/python/tensorrt_model_connect/engine_builder.py
@@ -1493,7 +1493,28 @@ def _build_diffusion_bundle(
     if "_transformer_config" in weights:
         config.raw["_transformer_config"] = weights["_transformer_config"]
 
-    # Auto-calibrate FP8 if requested
+    # Prefer a family-provided scale asset before running live calibration.
+    if fp8_scales == "auto":
+        precomputed_fn = getattr(plugin, "fp8_precomputed_scales", None)
+        if callable(precomputed_fn):
+            print(
+                f"[trtmc build] Resolving packaged FP8 scales for {plugin.name} ...",
+                file=sys.stderr,
+            )
+            precomputed_scales = precomputed_fn(str(model_dir_path), config)
+            if precomputed_scales is not None:
+                if not isinstance(precomputed_scales, dict) or not precomputed_scales:
+                    raise ValueError(
+                        f"Plugin {plugin.name}.fp8_precomputed_scales() must "
+                        "return a non-empty dictionary or None"
+                    )
+                fp8_scales = precomputed_scales
+                print(
+                    f"[trtmc build] Loaded {len(fp8_scales)} precomputed FP8 layer scales",
+                    file=sys.stderr,
+                )
+
+    # Auto-calibrate FP8 when the family has no matching packaged asset.
     if fp8_scales == "auto":
         calibrate_fn = getattr(plugin, 'fp8_calibrate', None)
         if calibrate_fn is None:
@@ -1678,6 +1699,7 @@ def _build_diffusion_bundle(
         created_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         runtime_strategy=getattr(plugin, "runtime_strategy", "diffusion"),
         precision=precision,
+        quantization="fp8" if fp8_scales else "none",
         max_cache_length=max_cache_length,
         tokenizer_add_special_tokens=tokenizer_add_special_tokens,
         max_batch_size=mbs_envelope,

--- a/python/tensorrt_model_connect/families/base.py
+++ b/python/tensorrt_model_connect/families/base.py
@@ -204,6 +204,18 @@ class FamilyPlugin(Protocol):
     # Optional: FP8 quantization support
     # ------------------------------------------------------------------
 
+    def fp8_precomputed_scales(
+        self, model_dir: str, config: ModelConfig,
+    ) -> dict[str, dict[str, float]] | None:
+        """Return family-provided precomputed FP8 scales when available.
+
+        This hook is consulted before live calibration for ``--fp8`` builds.
+        Plugins should validate the checkpoint contents, generation profile,
+        and target hardware before returning a packaged scale map. Return None
+        to fall through to ``fp8_calibrate()``.
+        """
+        return None
+
     def fp8_calibrate(
         self, model_dir: str, config: ModelConfig,
     ) -> dict[str, dict[str, float]] | None:

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/data/wan22-ti2v-5b-921dbaf3-fp8-scales.json
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/data/wan22-ti2v-5b-921dbaf3-fp8-scales.json
@@ -1,0 +1,482 @@
+{
+  "blocks.0.ffn.net.0.proj": {
+    "input_scale": 0.014808872767857143,
+    "weight_scale": 0.000905532855540514
+  },
+  "blocks.0.ffn.net.2": {
+    "input_scale": 0.026088169642857147,
+    "weight_scale": 0.00048498915774481636
+  },
+  "blocks.1.ffn.net.0.proj": {
+    "input_scale": 0.02547433035714286,
+    "weight_scale": 0.0005013058627290386
+  },
+  "blocks.1.ffn.net.2": {
+    "input_scale": 0.02977120535714286,
+    "weight_scale": 0.0007491121733827251
+  },
+  "blocks.10.ffn.net.0.proj": {
+    "input_scale": 0.014425223214285715,
+    "weight_scale": 0.0005806685824479375
+  },
+  "blocks.10.ffn.net.2": {
+    "input_scale": 0.03621651785714286,
+    "weight_scale": 0.0006435511500707694
+  },
+  "blocks.11.ffn.net.0.proj": {
+    "input_scale": 0.014041573660714287,
+    "weight_scale": 0.0006864397520465511
+  },
+  "blocks.11.ffn.net.2": {
+    "input_scale": 0.045731026785714286,
+    "weight_scale": 0.0008375391896281924
+  },
+  "blocks.12.ffn.net.0.proj": {
+    "input_scale": 0.01381138392857143,
+    "weight_scale": 0.000556625725169267
+  },
+  "blocks.12.ffn.net.2": {
+    "input_scale": 0.03959263392857143,
+    "weight_scale": 0.0011219375633767673
+  },
+  "blocks.13.ffn.net.0.proj": {
+    "input_scale": 0.016420200892857142,
+    "weight_scale": 0.0006939338387123176
+  },
+  "blocks.13.ffn.net.2": {
+    "input_scale": 0.04880022321428572,
+    "weight_scale": 0.000553297544164317
+  },
+  "blocks.14.ffn.net.0.proj": {
+    "input_scale": 0.015576171875000001,
+    "weight_scale": 0.0007342960951583726
+  },
+  "blocks.14.ffn.net.2": {
+    "input_scale": 0.026548549107142858,
+    "weight_scale": 0.000749947370163032
+  },
+  "blocks.15.ffn.net.0.proj": {
+    "input_scale": 0.014501953125,
+    "weight_scale": 0.0008518152338053499
+  },
+  "blocks.15.ffn.net.2": {
+    "input_scale": 0.03606305803571429,
+    "weight_scale": 0.0006696188024112157
+  },
+  "blocks.16.ffn.net.0.proj": {
+    "input_scale": 0.015652901785714286,
+    "weight_scale": 0.0007603982064340796
+  },
+  "blocks.16.ffn.net.2": {
+    "input_scale": 0.021637834821428576,
+    "weight_scale": 0.0009853745411549295
+  },
+  "blocks.17.ffn.net.0.proj": {
+    "input_scale": 0.017724609375000002,
+    "weight_scale": 0.0007222492380865983
+  },
+  "blocks.17.ffn.net.2": {
+    "input_scale": 0.07059151785714286,
+    "weight_scale": 0.0009017693810164928
+  },
+  "blocks.18.ffn.net.0.proj": {
+    "input_scale": 0.016573660714285714,
+    "weight_scale": 0.0008616499336702484
+  },
+  "blocks.18.ffn.net.2": {
+    "input_scale": 0.021484375,
+    "weight_scale": 0.0005614100290196282
+  },
+  "blocks.19.ffn.net.0.proj": {
+    "input_scale": 0.01595982142857143,
+    "weight_scale": 0.0007552069478801318
+  },
+  "blocks.19.ffn.net.2": {
+    "input_scale": 0.028083147321428574,
+    "weight_scale": 0.0007474365245018687
+  },
+  "blocks.2.ffn.net.0.proj": {
+    "input_scale": 0.019335937500000004,
+    "weight_scale": 0.0006335658420409475
+  },
+  "blocks.2.ffn.net.2": {
+    "input_scale": 0.03514229910714286,
+    "weight_scale": 0.0008587621019354888
+  },
+  "blocks.20.ffn.net.0.proj": {
+    "input_scale": 0.011586216517857144,
+    "weight_scale": 0.000538648571819067
+  },
+  "blocks.20.ffn.net.2": {
+    "input_scale": 0.13995535714285715,
+    "weight_scale": 0.0009669398090669087
+  },
+  "blocks.21.ffn.net.0.proj": {
+    "input_scale": 0.011509486607142858,
+    "weight_scale": 0.0006026569088654858
+  },
+  "blocks.21.ffn.net.2": {
+    "input_scale": 0.05279017857142858,
+    "weight_scale": 0.0015829008604798997
+  },
+  "blocks.22.ffn.net.0.proj": {
+    "input_scale": 0.012276785714285714,
+    "weight_scale": 0.0007671515590378217
+  },
+  "blocks.22.ffn.net.2": {
+    "input_scale": 0.018491908482142858,
+    "weight_scale": 0.0017683031037449837
+  },
+  "blocks.23.ffn.net.0.proj": {
+    "input_scale": 0.011356026785714287,
+    "weight_scale": 0.0010059988791389124
+  },
+  "blocks.23.ffn.net.2": {
+    "input_scale": 0.03590959821428572,
+    "weight_scale": 0.0005599239042827062
+  },
+  "blocks.24.ffn.net.0.proj": {
+    "input_scale": 0.009974888392857142,
+    "weight_scale": 0.0009644627571105957
+  },
+  "blocks.24.ffn.net.2": {
+    "input_scale": 0.02839006696428572,
+    "weight_scale": 0.0006117802113294601
+  },
+  "blocks.25.ffn.net.0.proj": {
+    "input_scale": 0.011125837053571428,
+    "weight_scale": 0.0006089008945439543
+  },
+  "blocks.25.ffn.net.2": {
+    "input_scale": 0.018952287946428576,
+    "weight_scale": 0.00043816368893853256
+  },
+  "blocks.26.ffn.net.0.proj": {
+    "input_scale": 0.01166294642857143,
+    "weight_scale": 0.000890301274401801
+  },
+  "blocks.26.ffn.net.2": {
+    "input_scale": 0.04204799107142858,
+    "weight_scale": 0.0005452000602547612
+  },
+  "blocks.27.ffn.net.0.proj": {
+    "input_scale": 0.01273716517857143,
+    "weight_scale": 0.0007857695621039186
+  },
+  "blocks.27.ffn.net.2": {
+    "input_scale": 0.026088169642857147,
+    "weight_scale": 0.0004683848736541612
+  },
+  "blocks.28.ffn.net.0.proj": {
+    "input_scale": 0.014962332589285716,
+    "weight_scale": 0.0005134376032011849
+  },
+  "blocks.28.ffn.net.2": {
+    "input_scale": 0.03775111607142857,
+    "weight_scale": 0.0005817245026784283
+  },
+  "blocks.29.ffn.net.0.proj": {
+    "input_scale": 0.026855468750000003,
+    "weight_scale": 0.0010290478489228658
+  },
+  "blocks.29.ffn.net.2": {
+    "input_scale": 0.019796316964285715,
+    "weight_scale": 0.0008507317065128259
+  },
+  "blocks.3.ffn.net.0.proj": {
+    "input_scale": 0.01757114955357143,
+    "weight_scale": 0.0008110290925417628
+  },
+  "blocks.3.ffn.net.2": {
+    "input_scale": 0.04665178571428572,
+    "weight_scale": 0.0005105038373065847
+  },
+  "blocks.4.ffn.net.0.proj": {
+    "input_scale": 0.01595982142857143,
+    "weight_scale": 0.0007509609152163778
+  },
+  "blocks.4.ffn.net.2": {
+    "input_scale": 0.03989955357142857,
+    "weight_scale": 0.0004668039535837514
+  },
+  "blocks.5.ffn.net.0.proj": {
+    "input_scale": 0.01166294642857143,
+    "weight_scale": 0.0007536321479294981
+  },
+  "blocks.5.ffn.net.2": {
+    "input_scale": 0.03468191964285715,
+    "weight_scale": 0.0006897200032004289
+  },
+  "blocks.6.ffn.net.0.proj": {
+    "input_scale": 0.01396484375,
+    "weight_scale": 0.0006185496625091348
+  },
+  "blocks.6.ffn.net.2": {
+    "input_scale": 0.04204799107142858,
+    "weight_scale": 0.0005690549899424825
+  },
+  "blocks.7.ffn.net.0.proj": {
+    "input_scale": 0.013274274553571429,
+    "weight_scale": 0.0005742985356066908
+  },
+  "blocks.7.ffn.net.2": {
+    "input_scale": 0.05371093750000001,
+    "weight_scale": 0.0005371396962021079
+  },
+  "blocks.8.ffn.net.0.proj": {
+    "input_scale": 0.014425223214285715,
+    "weight_scale": 0.0006359715147742204
+  },
+  "blocks.8.ffn.net.2": {
+    "input_scale": 0.07028459821428572,
+    "weight_scale": 0.0005891206009047372
+  },
+  "blocks.9.ffn.net.0.proj": {
+    "input_scale": 0.014655412946428572,
+    "weight_scale": 0.0007201996631920338
+  },
+  "blocks.9.ffn.net.2": {
+    "input_scale": 0.03099888392857143,
+    "weight_scale": 0.0007091164588928223
+  },
+  "blocks.0.attn2.to_out.0": {
+    "input_scale": 0.0030116489955357146,
+    "weight_scale": 0.0014420489647558757
+  },
+  "blocks.0.attn2.to_q": {
+    "input_scale": 0.10189732142857144,
+    "weight_scale": 0.0006170465078737054
+  },
+  "blocks.1.attn2.to_out.0": {
+    "input_scale": 0.0023978097098214285,
+    "weight_scale": 0.0005232050150100674
+  },
+  "blocks.1.attn2.to_q": {
+    "input_scale": 0.09821428571428571,
+    "weight_scale": 0.0004240336628364665
+  },
+  "blocks.10.attn2.to_out.0": {
+    "input_scale": 0.005409458705357144,
+    "weight_scale": 0.0010769704489835671
+  },
+  "blocks.10.attn2.to_q": {
+    "input_scale": 0.06138392857142858,
+    "weight_scale": 0.00043865948516343323
+  },
+  "blocks.11.attn2.to_out.0": {
+    "input_scale": 0.005447823660714286,
+    "weight_scale": 0.0012347031650798662
+  },
+  "blocks.11.attn2.to_q": {
+    "input_scale": 0.06169084821428572,
+    "weight_scale": 0.00035632697732320854
+  },
+  "blocks.12.attn2.to_out.0": {
+    "input_scale": 0.0070207868303571435,
+    "weight_scale": 0.004064231046608516
+  },
+  "blocks.12.attn2.to_q": {
+    "input_scale": 0.07765066964285715,
+    "weight_scale": 0.0004304671726588692
+  },
+  "blocks.13.attn2.to_out.0": {
+    "input_scale": 0.005255998883928572,
+    "weight_scale": 0.003377301352364676
+  },
+  "blocks.13.attn2.to_q": {
+    "input_scale": 0.10987723214285715,
+    "weight_scale": 0.00039569680978144916
+  },
+  "blocks.14.attn2.to_out.0": {
+    "input_scale": 0.004143415178571429,
+    "weight_scale": 0.0014940911371793067
+  },
+  "blocks.14.attn2.to_q": {
+    "input_scale": 0.0666015625,
+    "weight_scale": 0.00036051523472581593
+  },
+  "blocks.15.attn2.to_out.0": {
+    "input_scale": 0.004642159598214286,
+    "weight_scale": 0.0034263309623513904
+  },
+  "blocks.15.attn2.to_q": {
+    "input_scale": 0.10680803571428572,
+    "weight_scale": 0.0003741495976490634
+  },
+  "blocks.16.attn2.to_out.0": {
+    "input_scale": 0.0045654296875,
+    "weight_scale": 0.0015051116102508136
+  },
+  "blocks.16.attn2.to_q": {
+    "input_scale": 0.07672991071428571,
+    "weight_scale": 0.00041502537871045727
+  },
+  "blocks.17.attn2.to_out.0": {
+    "input_scale": 0.0033185686383928573,
+    "weight_scale": 0.004064632313592094
+  },
+  "blocks.17.attn2.to_q": {
+    "input_scale": 0.11785714285714287,
+    "weight_scale": 0.00035572441161743233
+  },
+  "blocks.18.attn2.to_out.0": {
+    "input_scale": 0.003970772879464286,
+    "weight_scale": 0.002622304218155997
+  },
+  "blocks.18.attn2.to_q": {
+    "input_scale": 0.12215401785714286,
+    "weight_scale": 0.0003478117287158966
+  },
+  "blocks.19.attn2.to_out.0": {
+    "input_scale": 0.0032418387276785714,
+    "weight_scale": 0.002165785325425012
+  },
+  "blocks.19.attn2.to_q": {
+    "input_scale": 0.08839285714285715,
+    "weight_scale": 0.00030735697198127
+  },
+  "blocks.2.attn2.to_out.0": {
+    "input_scale": 0.004814801897321429,
+    "weight_scale": 0.00074632020135011
+  },
+  "blocks.2.attn2.to_q": {
+    "input_scale": 0.0908482142857143,
+    "weight_scale": 0.0003972911675061498
+  },
+  "blocks.20.attn2.to_out.0": {
+    "input_scale": 0.00281982421875,
+    "weight_scale": 0.0026612518621342523
+  },
+  "blocks.20.attn2.to_q": {
+    "input_scale": 0.11356026785714288,
+    "weight_scale": 0.0003318736396197762
+  },
+  "blocks.21.attn2.to_out.0": {
+    "input_scale": 0.0032610212053571434,
+    "weight_scale": 0.0027094350329467227
+  },
+  "blocks.21.attn2.to_q": {
+    "input_scale": 0.11417410714285715,
+    "weight_scale": 0.000313300739175507
+  },
+  "blocks.22.attn2.to_out.0": {
+    "input_scale": 0.002589634486607143,
+    "weight_scale": 0.0029862520417996813
+  },
+  "blocks.22.attn2.to_q": {
+    "input_scale": 0.12583705357142858,
+    "weight_scale": 0.00038650894670614174
+  },
+  "blocks.23.attn2.to_out.0": {
+    "input_scale": 0.0031267438616071432,
+    "weight_scale": 0.0038953380925314768
+  },
+  "blocks.23.attn2.to_q": {
+    "input_scale": 0.12583705357142858,
+    "weight_scale": 0.00035629178663449626
+  },
+  "blocks.24.attn2.to_out.0": {
+    "input_scale": 0.002858189174107143,
+    "weight_scale": 0.0033872260579041074
+  },
+  "blocks.24.attn2.to_q": {
+    "input_scale": 0.12890625000000003,
+    "weight_scale": 0.0003398429003677198
+  },
+  "blocks.25.attn2.to_out.0": {
+    "input_scale": 0.003433663504464286,
+    "weight_scale": 0.002470872497984341
+  },
+  "blocks.25.attn2.to_q": {
+    "input_scale": 0.12767857142857145,
+    "weight_scale": 0.0002861537504941225
+  },
+  "blocks.26.attn2.to_out.0": {
+    "input_scale": 0.003740583147321429,
+    "weight_scale": 0.0020183751891766277
+  },
+  "blocks.26.attn2.to_q": {
+    "input_scale": 0.12338169642857144,
+    "weight_scale": 0.000306043607581939
+  },
+  "blocks.27.attn2.to_out.0": {
+    "input_scale": 0.002762276785714286,
+    "weight_scale": 0.0022919225905622754
+  },
+  "blocks.27.attn2.to_q": {
+    "input_scale": 0.11417410714285715,
+    "weight_scale": 0.00031824120586471897
+  },
+  "blocks.28.attn2.to_out.0": {
+    "input_scale": 0.0045270647321428575,
+    "weight_scale": 0.0009442482675824847
+  },
+  "blocks.28.attn2.to_q": {
+    "input_scale": 0.11969866071428573,
+    "weight_scale": 0.00028893248444156986
+  },
+  "blocks.29.attn2.to_out.0": {
+    "input_scale": 0.004987444196428571,
+    "weight_scale": 0.0009351204415517193
+  },
+  "blocks.29.attn2.to_q": {
+    "input_scale": 0.10189732142857144,
+    "weight_scale": 0.00027856658146317514
+  },
+  "blocks.3.attn2.to_out.0": {
+    "input_scale": 0.003433663504464286,
+    "weight_scale": 0.0009840412198432855
+  },
+  "blocks.3.attn2.to_q": {
+    "input_scale": 0.08962053571428573,
+    "weight_scale": 0.0004091928380408457
+  },
+  "blocks.4.attn2.to_out.0": {
+    "input_scale": 0.004680524553571429,
+    "weight_scale": 0.002457295943583761
+  },
+  "blocks.4.attn2.to_q": {
+    "input_scale": 0.09821428571428571,
+    "weight_scale": 0.00035647472499736717
+  },
+  "blocks.5.attn2.to_out.0": {
+    "input_scale": 0.004469517299107143,
+    "weight_scale": 0.0009308561150516782
+  },
+  "blocks.5.attn2.to_q": {
+    "input_scale": 0.08716517857142858,
+    "weight_scale": 0.0003695639648607799
+  },
+  "blocks.6.attn2.to_out.0": {
+    "input_scale": 0.004949079241071429,
+    "weight_scale": 0.002448208097900663
+  },
+  "blocks.6.attn2.to_q": {
+    "input_scale": 0.09698660714285715,
+    "weight_scale": 0.0003641283671770777
+  },
+  "blocks.7.attn2.to_out.0": {
+    "input_scale": 0.004949079241071429,
+    "weight_scale": 0.0007512438377099377
+  },
+  "blocks.7.attn2.to_q": {
+    "input_scale": 0.07212611607142858,
+    "weight_scale": 0.00043967386175479205
+  },
+  "blocks.8.attn2.to_out.0": {
+    "input_scale": 0.005946568080357143,
+    "weight_scale": 0.0011146049946546555
+  },
+  "blocks.8.attn2.to_q": {
+    "input_scale": 0.06629464285714286,
+    "weight_scale": 0.00044996790321809906
+  },
+  "blocks.9.attn2.to_out.0": {
+    "input_scale": 0.005486188616071429,
+    "weight_scale": 0.0033992837582315716
+  },
+  "blocks.9.attn2.to_q": {
+    "input_scale": 0.09268973214285715,
+    "weight_scale": 0.00041607903715755256
+  }
+}

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/fp8_profile.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/fp8_profile.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Packaged FP8 scale profile for native Wan2.2 TI2V-5B.
+
+The activation scales were measured over the full 50-step conditional and
+unconditional denoising trajectory at 1280x704/121 frames, CFG 5, flow shift
+5, and seed 42. Activation amax uses a 10 percent margin before E4M3
+normalization; weight scales use per-tensor max-absolute E4M3 normalization.
+This fixed map was collected with PyTorch on GB300; it was not produced by
+ModelOpt or runtime calibration. The accepted visual receipt is the Jetson Thor
+cat-prompt/seed-42 run with TensorRT 11.2.0.113 and CUDA 13.4.46. Other prompts
+and software versions are outside that single-trajectory receipt.
+
+The data is checkpoint/profile calibration, not a serialized TensorRT plan.
+Each target still builds its own TensorRT engines.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import sys
+from pathlib import Path
+
+from .model_config import WAN22_TI2V_5B, select_generation_profile
+
+
+PACKAGED_HF_MODEL_ID = "Wan-AI/Wan2.2-TI2V-5B"
+PACKAGED_HF_REVISION = "921dbaf3f1674a56f47e83fb80a34bac8a8f203e"
+PACKAGED_FP8_SCALE_FILENAME = "wan22-ti2v-5b-921dbaf3-fp8-scales.json"
+PACKAGED_FP8_SCALE_SHA256 = (
+    "a6c0b5b5a450312e804f978bee7be4c45a3c766d0f10297d9c823542328d0b0a"
+)
+PACKAGED_FP8_SCALE_PATH = Path(__file__).with_name("data") / PACKAGED_FP8_SCALE_FILENAME
+
+# Exact platforms on which Model Connect may consume this packaged map.
+PACKAGED_FP8_TARGETS = {
+    ((10, 3), False): "GB300 calibration host",
+    ((11, 0), True): "Jetson Thor visual-validation target",
+}
+
+# Content identities at the pinned Hugging Face revision. Hashing is a one-time
+# build check and prevents a same-shape or locally modified checkpoint from
+# silently consuming activation scales measured on different weights.
+PACKAGED_CHECKPOINT_FILES = {
+    "config.json": (
+        "d1fea36899d00c2501b836c13ad65af56e2f9529ba622e50886d3f5c3e6c02bc",
+        251,
+    ),
+    "diffusion_pytorch_model.safetensors.index.json": (
+        "bfa2337f1163e195d24151a72298daf34a620543898109be47e414c8daa5b3fe",
+        72_865,
+    ),
+    "diffusion_pytorch_model-00001-of-00003.safetensors": (
+        "720b06c4ade5e87c1246bba8ac95b664c638749cd9b102cf84d823bb44c026a1",
+        9_825_014_472,
+    ),
+    "diffusion_pytorch_model-00002-of-00003.safetensors": (
+        "09ec5ef720d8396f6cfa51fbdcbdb2327e37722afd6e89fd38f1e7e5e782c283",
+        9_995_661_736,
+    ),
+    "diffusion_pytorch_model-00003-of-00003.safetensors": (
+        "6306f7894c345de9093ad588771c2abfaeb668a81f7a6d9a918bd26ba3568e49",
+        178_558_176,
+    ),
+    "Wan2.2_VAE.pth": (
+        "20eb789667fa5e60e7516bf509512f6cb61f01b0aa0695eadaea930c13892b36",
+        2_818_839_170,
+    ),
+    "models_t5_umt5-xxl-enc-bf16.pth": (
+        "7cace0da2b446bbbbc57d031ab6cf163a3d59b366da94e5afe36745b746fd81d",
+        11_361_920_418,
+    ),
+    "google/umt5-xxl/tokenizer.json": (
+        "6e197b4d3dbd71da14b4eb255f4fa91c9c1f2068b20a2de2472967ca3d22602b",
+        16_837_417,
+    ),
+}
+
+
+def _current_device_profile() -> tuple[tuple[int, int], bool]:
+    # Reuse the family-owned CUDA query used by the VAE precision selector.
+    from .vae_step_builder import _current_cuda_device_profile
+
+    return _current_cuda_device_profile()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as checkpoint_file:
+        for chunk in iter(lambda: checkpoint_file.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_checkpoint_contents(model_dir: str) -> None:
+    root = Path(model_dir)
+    for relative_path, (expected_sha256, expected_size) in PACKAGED_CHECKPOINT_FILES.items():
+        checkpoint = root / relative_path
+        if not checkpoint.is_file():
+            raise ValueError(
+                "Wan2.2 packaged FP8 scales require the exact checkpoint files "
+                f"from {PACKAGED_HF_MODEL_ID}@{PACKAGED_HF_REVISION}; missing "
+                f"{checkpoint}"
+            )
+        actual_size = checkpoint.stat().st_size
+        if actual_size != expected_size:
+            raise ValueError(
+                "Wan2.2 checkpoint content does not match the packaged FP8 scale "
+                f"provenance for {relative_path}: expected {expected_size} bytes, "
+                f"found {actual_size}"
+            )
+        actual_sha256 = _sha256_file(checkpoint)
+        if actual_sha256 != expected_sha256:
+            raise ValueError(
+                "Wan2.2 checkpoint content does not match the packaged FP8 scale "
+                f"provenance for {relative_path}: expected SHA256 {expected_sha256}, "
+                f"found {actual_sha256}"
+            )
+
+
+def _validate_packaged_request(model_dir: str, config) -> str:
+    profile = select_generation_profile(config.raw)
+    if profile != WAN22_TI2V_5B:
+        raise ValueError(
+            "Wan2.2 packaged FP8 scales require the official "
+            "1280x704, 121-frame, 50-step profile; omit --fp8 for the "
+            "reduced BF16 profile"
+        )
+
+    compute_capability, integrated = _current_device_profile()
+    target = PACKAGED_FP8_TARGETS.get((compute_capability, integrated))
+    if target is None:
+        enabled = "GB300 SM 10.3 or integrated Jetson Thor SM 11.0"
+        raise ValueError(
+            "Wan2.2 packaged FP8 scales are enabled only on "
+            f"{enabled}; found SM {compute_capability[0]}.{compute_capability[1]} "
+            f"(integrated={int(integrated)}). Omit --fp8 to build the portable "
+            "BF16 path"
+        )
+    print(
+        "[trtmc build] Verifying pinned Wan2.2 checkpoint contents for FP8 ...",
+        file=sys.stderr,
+    )
+    _validate_checkpoint_contents(model_dir)
+    return target
+
+
+def _load_scale_asset() -> dict[str, dict[str, float]]:
+    try:
+        payload = PACKAGED_FP8_SCALE_PATH.read_bytes()
+    except OSError as exc:
+        raise RuntimeError(
+            "The installed Wan2.2 FP8 scale asset is missing: "
+            f"{PACKAGED_FP8_SCALE_PATH}"
+        ) from exc
+
+    digest = hashlib.sha256(payload).hexdigest()
+    if digest != PACKAGED_FP8_SCALE_SHA256:
+        raise RuntimeError(
+            "The installed Wan2.2 FP8 scale asset failed its SHA256 "
+            f"check: expected {PACKAGED_FP8_SCALE_SHA256}, found {digest}"
+        )
+    try:
+        scales = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("The Wan2.2 FP8 scale asset is not valid JSON") from exc
+    if not isinstance(scales, dict):
+        raise RuntimeError("The Wan2.2 FP8 scale asset must contain a JSON object")
+
+    expected = {
+        name
+        for index in range(WAN22_TI2V_5B.num_layers)
+        for name in (
+            f"blocks.{index}.ffn.net.0.proj",
+            f"blocks.{index}.ffn.net.2",
+            f"blocks.{index}.attn2.to_q",
+            f"blocks.{index}.attn2.to_out.0",
+        )
+    }
+    provided = set(scales)
+    if provided != expected:
+        raise RuntimeError(
+            "The Wan2.2 FP8 scale asset has an unexpected layer map: "
+            f"missing={sorted(expected - provided)}, "
+            f"unexpected={sorted(provided - expected)}"
+        )
+    for name, entry in scales.items():
+        if not isinstance(entry, dict) or set(entry) != {"input_scale", "weight_scale"}:
+            raise RuntimeError(
+                f"Wan2.2 FP8 scale entry {name!r} must contain only "
+                "input_scale and weight_scale"
+            )
+        for field, value in entry.items():
+            if not isinstance(value, (int, float)) or not math.isfinite(value) or value <= 0:
+                raise RuntimeError(
+                    f"Wan2.2 FP8 scale {name}.{field} must be finite and positive"
+                )
+    return scales
+
+
+def load_packaged_fp8_scales(model_dir: str, config) -> dict[str, dict[str, float]]:
+    """Validate the request and load the immutable packaged scale map."""
+
+    target = _validate_packaged_request(model_dir, config)
+    scales = _load_scale_asset()
+    print(
+        "[trtmc build] Wan2.2 packaged FP8 profile: "
+        f"checkpoint={PACKAGED_HF_REVISION[:8]} target={target} "
+        f"asset_sha256={PACKAGED_FP8_SCALE_SHA256}",
+        file=sys.stderr,
+    )
+    return scales

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/plugin.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/plugin.py
@@ -82,6 +82,13 @@ class Wan22TI2VPlugin:
         del config, weights, _max_cache_length, precision, verbose, kwargs
         raise NotImplementedError("Wan2.2 TI2V uses build_components(), not build_engine()")
 
+    def fp8_precomputed_scales(self, model_dir: str, config) -> dict:
+        """Load the packaged scale profile after fail-closed qualification."""
+
+        from .fp8_profile import load_packaged_fp8_scales
+
+        return load_packaged_fp8_scales(model_dir, config)
+
     def build_components(
         self,
         model_dir: str,

--- a/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_family.py
+++ b/python/tensorrt_model_connect/families/wan2_2_ti2v/tests/test_family.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import math
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -22,6 +24,7 @@ from tensorrt_model_connect.families.wan2_2_ti2v.model_config import (
     select_generation_profile,
     validate_native_config,
 )
+from tensorrt_model_connect.families.wan2_2_ti2v import fp8_profile
 from tensorrt_model_connect.families.wan2_2_ti2v.plugin import (
     WAN22_EAGER_BUNDLE_SECTIONS,
     WAN22_LAZY_BUNDLE_SECTIONS,
@@ -72,6 +75,34 @@ def _write_checkpoint(root: Path) -> Path:
     return tokenizer
 
 
+_TEST_CHECKPOINT_PAYLOAD = b"wan22-test-checkpoint"
+
+
+def _packaged_snapshot(root: Path) -> Path:
+    snapshot = (
+        root
+        / "models--Wan-AI--Wan2.2-TI2V-5B"
+        / "snapshots"
+        / fp8_profile.PACKAGED_HF_REVISION
+    )
+    snapshot.mkdir(parents=True)
+    (snapshot / "test-checkpoint.bin").write_bytes(_TEST_CHECKPOINT_PAYLOAD)
+    return snapshot
+
+
+def _use_test_checkpoint_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        fp8_profile,
+        "PACKAGED_CHECKPOINT_FILES",
+        {
+            "test-checkpoint.bin": (
+                hashlib.sha256(_TEST_CHECKPOINT_PAYLOAD).hexdigest(),
+                len(_TEST_CHECKPOINT_PAYLOAD),
+            )
+        },
+    )
+
+
 def test_hf_snapshot_required_files_are_family_owned() -> None:
     manifest_path = Path(__file__).resolve().parents[1] / "MODEL.toml"
     with manifest_path.open("rb") as manifest_file:
@@ -93,6 +124,120 @@ def test_hf_snapshot_required_files_are_family_owned() -> None:
         "models_t5_umt5-xxl-enc-bf16.pth",
         "google/umt5-xxl/tokenizer.json",
     }
+
+
+def test_packaged_fp8_asset_is_complete_and_immutable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    payload = fp8_profile.PACKAGED_FP8_SCALE_PATH.read_bytes()
+    assert len(payload) == 14_001
+    assert hashlib.sha256(payload).hexdigest() == fp8_profile.PACKAGED_FP8_SCALE_SHA256
+
+    _use_test_checkpoint_identity(monkeypatch)
+    snapshot = _packaged_snapshot(tmp_path)
+    monkeypatch.setattr(
+        fp8_profile,
+        "_current_device_profile",
+        lambda: ((10, 3), False),
+    )
+    scales = Wan22TI2VPlugin().fp8_precomputed_scales(
+        str(snapshot),
+        _runtime_config(),
+    )
+    assert len(scales) == 120
+    assert set(scales) == {
+        name
+        for index in range(WAN22_TI2V_5B.num_layers)
+        for name in (
+            f"blocks.{index}.ffn.net.0.proj",
+            f"blocks.{index}.ffn.net.2",
+            f"blocks.{index}.attn2.to_q",
+            f"blocks.{index}.attn2.to_out.0",
+        )
+    }
+    assert all(
+        set(entry) == {"input_scale", "weight_scale"}
+        and all(math.isfinite(value) and value > 0 for value in entry.values())
+        for entry in scales.values()
+    )
+
+    monkeypatch.setattr(
+        fp8_profile,
+        "_current_device_profile",
+        lambda: ((11, 0), True),
+    )
+    assert (
+        Wan22TI2VPlugin().fp8_precomputed_scales(str(snapshot), _runtime_config())
+        == scales
+    )
+    local_checkpoint = tmp_path / "local-checkpoint"
+    local_checkpoint.mkdir()
+    (local_checkpoint / "test-checkpoint.bin").write_bytes(_TEST_CHECKPOINT_PAYLOAD)
+    assert (
+        Wan22TI2VPlugin().fp8_precomputed_scales(
+            str(local_checkpoint),
+            _runtime_config(),
+        )
+        == scales
+    )
+
+
+def test_packaged_fp8_request_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _use_test_checkpoint_identity(monkeypatch)
+    snapshot = _packaged_snapshot(tmp_path)
+    monkeypatch.setattr(
+        fp8_profile,
+        "_current_device_profile",
+        lambda: ((10, 3), False),
+    )
+
+    with pytest.raises(ValueError, match="exact checkpoint files"):
+        Wan22TI2VPlugin().fp8_precomputed_scales(str(tmp_path), _runtime_config())
+    with pytest.raises(ValueError, match="official"):
+        Wan22TI2VPlugin().fp8_precomputed_scales(
+            str(snapshot),
+            _runtime_config(
+                video_width=672,
+                video_height=384,
+                video_num_frames=5,
+                num_inference_steps=15,
+            ),
+        )
+
+    monkeypatch.setattr(
+        fp8_profile,
+        "_current_device_profile",
+        lambda: ((11, 0), False),
+    )
+    with pytest.raises(ValueError, match="portable BF16"):
+        Wan22TI2VPlugin().fp8_precomputed_scales(str(snapshot), _runtime_config())
+
+
+def test_packaged_fp8_checkpoint_corruption_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _use_test_checkpoint_identity(monkeypatch)
+    snapshot = _packaged_snapshot(tmp_path)
+    (snapshot / "test-checkpoint.bin").write_bytes(b"x" * len(_TEST_CHECKPOINT_PAYLOAD))
+    monkeypatch.setattr(
+        fp8_profile,
+        "_current_device_profile",
+        lambda: ((11, 0), True),
+    )
+    with pytest.raises(ValueError, match="content does not match"):
+        Wan22TI2VPlugin().fp8_precomputed_scales(str(snapshot), _runtime_config())
+
+
+def test_packaged_fp8_asset_corruption_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    corrupt = tmp_path / fp8_profile.PACKAGED_FP8_SCALE_FILENAME
+    corrupt.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(fp8_profile, "PACKAGED_FP8_SCALE_PATH", corrupt)
+    with pytest.raises(RuntimeError, match="SHA256"):
+        fp8_profile._load_scale_asset()
 
 
 def test_qualified_generation_profiles_are_exact() -> None:
@@ -228,6 +373,7 @@ def test_public_builder_routes_wan_to_component_bundle(
     monkeypatch.setattr(engine_builder.trt_compat, "resolved_summary", lambda: "TensorRT test")
     monkeypatch.setattr(engine_builder, "_get_trt_version", lambda: "11.2.0")
     monkeypatch.setattr(engine_builder, "_get_gpu_name", lambda: "NVIDIA GB300")
+    monkeypatch.setattr(engine_builder.build_bundle, "_fp8_scales", None, raising=False)
     captured = {}
     monkeypatch.setattr(
         engine_builder,
@@ -250,6 +396,43 @@ def test_public_builder_routes_wan_to_component_bundle(
         *WAN22_MODEL_OWNED_BUNDLE_SECTIONS,
         "config.json",
     ]
+
+    packaged_scales = {
+        name: {"input_scale": 0.125, "weight_scale": 0.25}
+        for index in range(WAN22_TI2V_5B.num_layers)
+        for name in (
+            f"blocks.{index}.ffn.net.0.proj",
+            f"blocks.{index}.ffn.net.2",
+            f"blocks.{index}.attn2.to_q",
+            f"blocks.{index}.attn2.to_out.0",
+        )
+    }
+    scale_calls = []
+    monkeypatch.setattr(
+        plugin,
+        "fp8_precomputed_scales",
+        lambda model_dir, config: (
+            scale_calls.append((model_dir, config)) or packaged_scales
+        ),
+    )
+    monkeypatch.setattr(engine_builder.build_bundle, "_fp8_scales", "auto")
+    engine_builder.build_bundle(
+        str(tmp_path),
+        output_path,
+    )
+
+    assert len(scale_calls) == 1
+    assert len(calls) == 2
+    assert calls[1][1]["fp8_scales"] is packaged_scales
+    assert captured["info"].quantization == "fp8"
+    config_payload = json.loads(
+        next(
+            section.data
+            for section in captured["sections"]
+            if section.name == "config.json"
+        )
+    )
+    assert config_payload["quantization"] == {"format": "fp8"}
 
 
 def test_component_builder_emits_four_native_plans(

--- a/tools/ci/package.py
+++ b/tools/ci/package.py
@@ -134,6 +134,14 @@ class WheelArchiveValidator:
                 if "/benchmark/_catalog/" in name
                 and name.endswith("/data/flux2-fp8-scales.json")
             ]
+            wan22_packaged_fp8_assets = [
+                name
+                for name in names
+                if name.endswith(
+                    "/families/wan2_2_ti2v/data/"
+                    "wan22-ti2v-5b-921dbaf3-fp8-scales.json"
+                )
+            ]
             benchmark_image_assets = [
                 name
                 for name in names
@@ -159,6 +167,10 @@ class WheelArchiveValidator:
             (bool(benchmark_manifests), "packaged benchmark manifests are missing"),
             (bool(benchmark_audio_assets), "packaged benchmark audio assets are missing"),
             (bool(benchmark_fp8_assets), "packaged benchmark FP8 scale assets are missing"),
+            (
+                len(wan22_packaged_fp8_assets) == 1,
+                "packaged Wan2.2 FP8 scale asset is missing",
+            ),
             (bool(benchmark_image_assets), "packaged benchmark image assets are missing"),
             (bool(package_cores), "packaged core DSO is missing"),
             (bool(script_cores), "core DSO beside native trtmc script is missing"),

--- a/website/docs/api/cli-reference.md
+++ b/website/docs/api/cli-reference.md
@@ -38,7 +38,7 @@ python -m tensorrt_model_connect build <hf-repo-or-local-dir> -o <output.trtfb>
 | `--quantize fp8|int8|int8_sq|int4|int4_awq|nvfp4|w4a8` | Quantization format. |
 | `--quant-scales PATH` | Load precomputed quantization scales. |
 | `--quant-calibration-samples N` | PTQ calibration sample count. |
-| `--fp8` | Enable legacy FP8 auto-calibration path. |
+| `--fp8` | Enable FP8 using family-provided scales when available, otherwise auto-calibrate. |
 | `--fp8-scales PATH` | Load precomputed FP8 scales. |
 | `--save-fp8-scales PATH` | Save calibrated FP8 scales. |
 | `--rtx` | Build for TensorRT-RTX backend. |

--- a/website/docs/features/quantization.md
+++ b/website/docs/features/quantization.md
@@ -16,7 +16,7 @@ Supported `--quantize` values are:
 fp8, int8, int8_sq, int4, int4_awq, nvfp4, w4a8
 ```
 
-The builder also exposes legacy FP8-specific flags:
+The builder also exposes FP8-specific flags:
 
 ```bash
 --fp8
@@ -31,9 +31,12 @@ Family plugins can override:
 - `quant_exclude_patterns()`
 - `calibration_data()`
 - `quant_adapter()`
+- `fp8_precomputed_scales()`
 - `fp8_calibrate()`
 
-These hooks keep quantization policy close to the model architecture that needs it.
+For `--fp8`, a family-provided precomputed scale profile is preferred before
+live calibration. These hooks keep quantization policy and qualification close
+to the model architecture that needs it.
 
 ## Validation expectation
 

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -135,6 +135,52 @@ minimal command does not repeat them. The runtime accepts `--num-steps 50
 other values are rejected rather than silently running an unqualified shape.
 CI additionally owns a fixed reduced L0 profile for fast smoke coverage.
 
+### Qualified Thor FP8 performance profile
+
+The accepted Thor performance build uses a packaged, immutable FP8 scale map,
+so customers do not download or generate a separate quantization JSON. Pin the
+qualified checkpoint revision and add `--fp8`:
+
+```bash
+$TRTMC build Wan-AI/Wan2.2-TI2V-5B \
+  --model-revision 921dbaf3f1674a56f47e83fb80a34bac8a8f203e \
+  --fp8 \
+  -o /tmp/wan22-ti2v-5b-fp8.trtfb
+
+TRTMC_WAN22_EASYCACHE=1 \
+TRTMC_WAN22_EASYCACHE_THRESHOLD=1.0 \
+TRTMC_WAN22_EASYCACHE_FIRST_EXACT_STEPS=7 \
+TRTMC_WAN22_EASYCACHE_LAST_EXACT_STEPS=2 \
+TRTMC_WAN22_EASYCACHE_MAX_CONSECUTIVE_REUSE=4 \
+TRTMC_WAN22_EASYCACHE_LATE_CFG=1 \
+TRTMC_PNG_WRITE_WORKERS=8 \
+$TRTMC generate-video /tmp/wan22-ti2v-5b-fp8.trtfb \
+  --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage" \
+  --output /tmp/wan22-fp8-frames \
+  --num-steps 50 \
+  --guidance-scale 5 \
+  --height 704 \
+  --width 1280 \
+  --seed 42
+```
+
+The JSON is a fixed offline PyTorch-collected map, not ModelOpt output or
+runtime auto-calibration. It covers the full 50-step conditional and
+unconditional trajectory for the prompt and seed above: activation scales are
+`amax * 1.10 / 448`, and weight scales are `maxabs / 448`. The exact checkpoint
+files and scale asset are SHA256-checked before the optimized build.
+
+The packaged scale asset is selected only for the pinned checkpoint, the
+official 1280x704/121-frame/50-step profile, and the GB300 calibration platform
+or integrated SM 11.0 Thor target. Omitting `--fp8` keeps the existing BF16
+build on other platforms. TensorRT plans remain target-specific and must be
+rebuilt on each machine; the scale JSON itself is checkpoint/profile data and
+does not make Wan2.2 Thor-only. The aggressive EasyCache settings above are
+additionally runtime-gated to the official profile on integrated SM 11.0 Thor.
+The accepted visual receipt is this prompt/seed on Thor with TensorRT
+11.2.0.113 and CUDA 13.4.46; other prompts and software versions are not claimed
+by that single run.
+
 ## What To Read Next
 
 - [Build and Run](build-and-run.md) covers common tasks for text, vision-language, audio, diffusion, segmentation, and time-series bundles.


### PR DESCRIPTION
## Background

The merged Wan2.2 Thor performance path still required users to obtain an
external FP8 scale JSON. That made the accepted configuration impossible to
reproduce from a clean Model Connect checkout and installed package alone.

## Exit Criteria

- `trtmc build ... --fp8` resolves the packaged Wan2.2 scale map without a
  separate user-managed JSON.
- The optimized path fails closed for a different checkpoint, generation
  profile, scale asset, or unsupported GPU.
- The existing BF16 build and standard Nightly manifest remain portable and
  unchanged.
- Source and binary packages carry the exact scale asset.
- The customer-facing Thor recipe documents the evidence and portability
  boundaries.

## Implementation

- Add a family-owned precomputed-FP8 hook before the existing live-calibration
  fallback.
- Package the 120-entry Wan2.2 scale map with immutable SHA256 verification.
- Verify the pinned Hugging Face checkpoint by content hash and size before
  using checkpoint-specific scales.
- Enable the packaged profile only for the official 1280x704, 121-frame,
  50-step configuration on GB300 SM 10.3 or integrated Jetson Thor SM 11.0.
- Record FP8 in bundle metadata and validate that the wheel contains exactly
  one Wan2.2 scale asset.
- Document a copy-paste Thor build and generation recipe.

## Validation

- Wan2.2 and builder-focused host tests: `64 passed, 1 skipped`
- Focused tests in the TensorRT development image: `98 passed, 1 skipped`
- Complete builder suite in the TensorRT development image:
  `675 passed, 89 skipped`
- Ruff and `git diff --check`: passed
- Docusaurus production build: passed
- Real pinned checkpoint verification: all 8 identities matched and 120 scale
  entries loaded
- Source distribution inspection: profile module and exact scale asset present

The local native build completed compilation, including the Wan2.2 DSO, but
this host could not finish wheel assembly because its package environment does
not stage the TensorRT backend DSO. GitHub package CI remains the authoritative
wheel assembly check.

## Notes

The scale map was collected offline with PyTorch on GB300, not ModelOpt or
runtime calibration. Activation scales use `amax * 1.10 / 448`; weight scales
use `maxabs / 448`.

The accepted visual receipt is the documented prompt and seed on Jetson Thor
with TensorRT 11.2.0.113 and CUDA 13.4.46. It does not claim qualification for
other prompts or software versions.

This does not make Wan2.2 Thor-only. Omitting `--fp8` preserves the existing
cross-platform BF16 path. The scale JSON is checkpoint/profile data, while
TensorRT plans are still rebuilt for each target platform.
